### PR TITLE
Store batch state in Git refs and add undo/redo

### DIFF
--- a/STORAGE.md
+++ b/STORAGE.md
@@ -1,0 +1,1294 @@
+# Git Stage Batch: Storage Reference
+
+## Table of Contents
+
+1. [Introduction](#introduction)
+2. [Mental Model](#mental-model)
+3. [Storage Principles](#storage-principles)
+4. [Top-Level Storage Areas](#top-level-storage-areas)
+5. [Authority and Precedence](#authority-and-precedence)
+6. [Authoritative Batch Content](#authoritative-batch-content)
+7. [File-Backed Batch Metadata](#file-backed-batch-metadata)
+8. [Git-Backed Batch State](#git-backed-batch-state)
+9. [Batch Source Snapshots](#batch-source-snapshots)
+10. [Session Scratch State](#session-scratch-state)
+11. [Abort and Recovery State](#abort-and-recovery-state)
+12. [Selected Change Cache](#selected-change-cache)
+13. [Progress and Navigation State](#progress-and-navigation-state)
+14. [Batch Ref Snapshots](#batch-ref-snapshots)
+15. [Object Reachability](#object-reachability)
+16. [Undo Checkpoints](#undo-checkpoints)
+17. [Future Direction](#future-direction)
+18. [Migration Invariants](#migration-invariants)
+
+---
+
+## Introduction
+
+This document describes where git-stage-batch stores persistent batch data,
+session state, snapshots, undo checkpoints, and Git-backed batch storage.
+
+`BATCHES.md` explains the semantic model for batches: baseline commits, batch
+source commits, realized content, ownership constraints, and structural merge.
+This document is narrower. It answers:
+
+* Which files and refs exist
+* Which storage locations are authoritative
+* Which storage locations are caches or mirrors
+* Which objects preserve source snapshots
+* Which state belongs to an active session
+* How undo checkpoints are stored and restored
+
+The selected implementation is intentionally hybrid. Git objects store durable
+content, batch state, undo checkpoints, and durable snapshots. Local files under
+`.git/git-stage-batch` store active session scratch state and compatibility
+caches.
+
+---
+
+## Mental Model
+
+git-stage-batch storage falls into four categories:
+
+* **Batch content refs**: durable user-facing truth for realized batch content.
+* **Batch state refs**: durable metadata needed to reconstruct, merge, validate, and restore batches.
+* **Session state**: ephemeral workflow machinery for an active session.
+* **Compatibility storage**: legacy paths kept only for migration and older repositories.
+
+For any path or ref, maintainers should ask:
+
+1. Is it durable content, durable state, ephemeral session state, or compatibility-only?
+2. If multiple locations mention the same batch, which one is authoritative?
+
+The answers are stable:
+
+* `refs/git-stage-batch/batches/<batch>` is authoritative for content.
+* `refs/git-stage-batch/state/<batch>` is authoritative for batch state.
+* `.git/git-stage-batch/session/` is authoritative for active session state.
+* Legacy refs and metadata files are migration inputs, not co-equal authorities.
+
+---
+
+## Storage Principles
+
+### Git Objects Store Durable Content
+
+Realized batch content is a normal Git commit. Batch source snapshots are Git
+commits in the selected storage model, and are also stored as tree entries in
+the Git-backed state refs.
+
+Durable file bytes should live as blobs in trees, not embedded in JSON.
+
+### Session Files Store Active Workflow State
+
+The current selected hunk, blocklists, processed line IDs, progress counters,
+and stale-cache snapshots are session-local scratch state. They are not project
+history. They live under:
+
+```text
+.git/git-stage-batch/session/
+```
+
+These files can be checkpointed for undo, but they do not need to be live Git
+refs in order for the interface to work.
+
+### Names Are Semantic, Versions Are Commits
+
+The storage model avoids numbered directories for source snapshots or undo
+frames. When the same logical path changes over time, the parent chain of the
+containing commit records the history.
+
+For example, the Git-backed state ref stores the current source snapshot
+for `src/main.py` at:
+
+```text
+sources/src/main.py
+```
+
+If that source changes, the next state commit updates the same path. The old
+source remains in the previous state commit.
+
+### Compatibility Must Not Be Confused With Authority
+
+The authoritative batch storage is:
+
+```text
+refs/git-stage-batch/batches/<batch>
+refs/git-stage-batch/state/<batch>
+```
+
+The legacy ref and metadata file are compatibility inputs:
+
+```text
+refs/batches/<batch>
+.git/git-stage-batch/batches/<batch>/metadata.json
+```
+
+Legacy-only batches are read as a migration fallback. Once a batch is written
+through the Git-backed storage path, the legacy ref and file-backed metadata for
+that batch are removed.
+
+### Ref Names Name Live Roots
+
+The formal git-stage-batch ref namespace is:
+
+```text
+refs/git-stage-batch/
+  batches/<batch>
+  state/<batch>
+  session/undo-stack
+  session/redo-stack
+```
+
+These refs are moving roots for live storage. Versioned data lives in the commit
+history reachable from those roots, or inside their trees. For example, undo
+checkpoints are parent commits reachable from `session/undo-stack`, not
+separate numbered refs.
+
+---
+
+## Top-Level Storage Areas
+
+git-stage-batch currently uses four broad storage areas.
+
+### Authoritative Git Refs
+
+```text
+refs/git-stage-batch/batches/<batch>
+```
+
+These refs store realized batch content. They are the selected content refs used
+by batch display, apply, reset, sift, and diff operations.
+
+### Git-Stage-Batch Git Refs
+
+```text
+refs/git-stage-batch/batches/<batch>
+refs/git-stage-batch/state/<batch>
+refs/git-stage-batch/session/undo-stack
+refs/git-stage-batch/session/redo-stack
+```
+
+The batch refs store authoritative content and metadata. They are written when
+batches are created, updated, deleted, or restored, and command reads prefer
+them.
+
+The session refs store the undo and redo stacks for the current active session.
+They are not mirrors; they are the selected checkpoint storage.
+
+### Repository-Local State Directory
+
+```text
+.git/git-stage-batch/
+```
+
+This directory stores active sessions, abort state, file-backed metadata, the
+debug journal, and permanent batch metadata.
+
+### Git Object Database
+
+Normal Git objects store:
+
+* Batch commits
+* Batch source commits
+* Batch state commits
+* Source blobs inside state trees
+* Undo checkpoint commits
+* Worktree before-image blobs inside undo checkpoint trees
+* Stash commits used by abort recovery
+
+---
+
+## Authority and Precedence
+
+When multiple storage locations mention the same batch, precedence is defined by
+design, not inferred heuristically.
+
+### Durable batch content
+
+Authoritative:
+
+`refs/git-stage-batch/batches/<batch>`
+
+Compatibility-only:
+
+`refs/batches/<batch>`
+
+### Durable batch state
+
+Authoritative:
+
+`refs/git-stage-batch/state/<batch>`
+
+Compatibility-only:
+
+`.git/git-stage-batch/batches/<batch>/metadata.json`
+
+### Session state
+
+Authoritative during an active session:
+
+`.git/git-stage-batch/session/`
+
+### Undo checkpoints
+
+Checkpoints are durable recovery units. Files captured inside them do not become
+semantic truth.
+
+---
+
+## Authoritative Batch Content
+
+### Authoritative Location
+
+```text
+refs/git-stage-batch/batches/<batch>
+```
+
+### Meaning
+
+This ref points at the realized batch commit. The commit tree contains the file
+content that the batch represents relative to its baseline.
+
+This is a content-only tree. It does not contain metadata, ownership, source
+snapshots, or session state.
+
+### Creation
+
+`create_batch()` creates an initial batch commit from the baseline tree:
+
+```text
+Batch Commit
+  tree: baseline tree
+  parent: baseline commit
+  ref: refs/git-stage-batch/batches/<batch>
+```
+
+If there is no baseline, an empty tree is used.
+
+### Updates
+
+`add_file_to_batch()` and related storage helpers update the batch tree by using
+a temporary index:
+
+1. Read the current batch commit tree into a temporary index.
+2. Add, update, or remove one file entry.
+3. Write a new tree.
+4. Create a new batch commit.
+5. Move `refs/git-stage-batch/batches/<batch>` to the new commit.
+6. Delete the legacy compatibility ref `refs/batches/<batch>`.
+
+Batch commits use parents to preserve object reachability:
+
+```text
+parent 1: baseline commit
+parent 2..n: batch source commits
+```
+
+### Inspection
+
+The content ref is intentionally readable with normal Git commands:
+
+```bash
+git show refs/git-stage-batch/batches/foo:path/to/file
+git diff <baseline> refs/git-stage-batch/batches/foo
+git ls-tree -r refs/git-stage-batch/batches/foo
+```
+
+`refs/batches/<batch>` is read only as a migration input. Batch writes delete it
+after publishing the Git-backed refs.
+
+---
+
+## File-Backed Batch Metadata
+
+### Location
+
+```text
+.git/git-stage-batch/batches/<batch>/metadata.json
+```
+
+### Meaning
+
+This file is a legacy metadata format read as a migration input when no
+Git-backed state ref exists. It records:
+
+* Batch note
+* Creation timestamp
+* Baseline commit
+* Per-file ownership
+* Per-file source snapshot commit
+* Per-file mode
+* Binary file markers when needed
+
+Example:
+
+```json
+{
+  "note": "Test note",
+  "created_at": "2026-04-17T12:00:00+00:00",
+  "baseline": "abc123...",
+  "files": {
+    "src/main.py": {
+      "batch_source_commit": "def456...",
+      "claimed_lines": ["10-12"],
+      "deletions": [],
+      "mode": "100644"
+    }
+  }
+}
+```
+
+### Role
+
+The corresponding state metadata is not just descriptive. It is the declarative
+model used to reconstruct and validate a batch:
+
+* `baseline` defines the baseline side of the batch.
+* `batch_source_commit` defines the coordinate space for ownership.
+* `claimed_lines` define source lines that must be present.
+* `deletions` define anchored absence constraints.
+* `mode` defines the file mode for realized content.
+
+### Limitations
+
+The compatibility metadata is mutable filesystem state rather than a Git tree.
+It is easy to inspect, but should not be treated as authoritative when the
+Git-backed state ref exists.
+
+It is not the right place to:
+
+* Store the canonical batch model
+* Restore atomically with content refs
+* Rewind with a ref-based undo model
+* Keep long-lived source snapshots obviously reachable from refs
+
+The Git-backed state ref addresses these limitations. New writes remove this
+file after importing its contents.
+
+---
+
+## Git-Backed Batch State
+
+### Locations
+
+```text
+refs/git-stage-batch/batches/<batch>
+refs/git-stage-batch/state/<batch>
+```
+
+### Status
+
+These refs are authoritative for new reads. They are written by
+`batch.state_refs.sync_batch_state_refs()`. The legacy `refs/batches/<batch>`
+and `metadata.json` paths are fallback inputs for older state; writes remove
+them after the Git-backed refs are published.
+
+The content ref answers what the batch contains; the state ref answers how the
+batch is reconstructed and validated.
+
+### Content Ref
+
+```text
+refs/git-stage-batch/batches/<batch>
+```
+
+This ref points at the realized batch content commit. Older versions used:
+
+```text
+refs/batches/<batch>
+```
+
+Command reads prefer the Git-backed content ref and fall back to the legacy ref
+only for older state. Command writes delete the legacy ref for the updated
+batch.
+
+### State Ref
+
+```text
+refs/git-stage-batch/state/<batch>
+```
+
+This ref points at a commit whose tree has this shape:
+
+```text
+batch.json
+sources/
+  <repo-relative paths>
+```
+
+Example:
+
+```text
+batch.json
+sources/src/main.py
+sources/README.md
+```
+
+### `batch.json`
+
+`batch.json` stores the authoritative batch metadata and explicit content-ref
+information:
+
+```json
+{
+  "batch": "foo",
+  "note": "Test note",
+  "created_at": "2026-04-17T12:00:00+00:00",
+  "baseline_commit": "abc123...",
+  "content_ref": "refs/git-stage-batch/batches/foo",
+  "content_commit": "def456...",
+  "files": {
+    "src/main.py": {
+      "batch_source_commit": "987654...",
+      "source_path": "sources/src/main.py",
+      "claimed_lines": ["10-12"],
+      "deletions": [],
+      "mode": "100644"
+    }
+  }
+}
+```
+
+The state keeps `batch_source_commit` for compatibility with the current model
+and adds `source_path` for the tree-backed source snapshot.
+
+### Source Entries
+
+Each `sources/<path>` entry stores the source bytes for that repository path.
+These bytes are read from the existing `batch_source_commit`.
+
+For example:
+
+```bash
+git show refs/git-stage-batch/state/foo:sources/src/main.py
+```
+
+prints the source snapshot that ownership for `src/main.py` is expressed
+against.
+
+### State History
+
+Every sync creates a new state commit. If a file's source snapshot changes, the
+same semantic path under `sources/` changes in a new commit. The previous source
+snapshot remains available in the parent state commit.
+
+This keeps path names meaningful and puts versioning in Git history rather than
+in numbered directories.
+
+### Consistency Invariant
+
+The state can be validated by checking:
+
+```text
+refs/git-stage-batch/batches/<batch> == batch.json.content_commit
+```
+
+Command reads should reject inconsistent state rather than silently using
+mismatched content and metadata.
+
+---
+
+## Batch Source Snapshots
+
+### Selected Storage
+
+The selected implementation stores batch source snapshots as Git commits. Each
+per-file source commit has:
+
+* The session baseline as its parent
+* A tree based on the baseline tree
+* One path replaced by the file's source bytes
+
+The source commit SHA is stored in:
+
+```text
+.git/git-stage-batch/batches/<batch>/metadata.json
+```
+
+under:
+
+```json
+"batch_source_commit": "..."
+```
+
+### Source Content Selection
+
+Source bytes come from the file state at session start:
+
+* For tracked files, the abort stash is used when available.
+* If the file is unchanged from the baseline, the baseline commit is used.
+* For untracked or intent-to-add files, the lazy abort snapshot is used.
+* For new files that did not exist at session start, the current working tree
+  content is used when the source is first created.
+
+### Lazy Creation
+
+Batch source commits are created lazily. A source exists only after a file is
+first added to a batch.
+
+The session cache:
+
+```text
+.git/git-stage-batch/session/batch-sources.json
+```
+
+maps repository paths to source commit SHAs for the active session.
+
+### Source Advancement
+
+If existing ownership uses stale source coordinates, source-refresh logic can
+advance the source. The selected model creates a new source commit, remaps the
+existing ownership, and updates the session source cache.
+
+### State Ref Source Entries
+
+The Git-backed state ref stores source commit contents under:
+
+```text
+refs/git-stage-batch/state/<batch>:sources/<path>
+```
+
+These source bytes are normal Git blobs reachable from the authoritative state
+ref.
+
+---
+
+## Session Scratch State
+
+### Root
+
+Active session state lives under:
+
+```text
+.git/git-stage-batch/session/
+```
+
+The layout is grouped by purpose:
+
+```text
+session/
+  abort/
+  config/
+  fixup/
+  processed/
+  progress/
+  selected/
+  batch-sources.json
+  start-head.txt
+  start-index-tree.txt
+  start-batch-refs.json
+```
+
+### Lifecycle
+
+Session state is created by `git-stage-batch start` and cleared by:
+
+* `git-stage-batch stop`
+* `git-stage-batch abort`
+
+Iteration-specific parts are cleared by:
+
+* `git-stage-batch again`
+
+Permanent batch metadata under:
+
+```text
+.git/git-stage-batch/batches/
+```
+
+is not cleared by `again`, `stop`, or `abort` except when abort restores batch
+refs and metadata to their session-start state.
+
+### Scratch vs Durable State
+
+Session files are scratch state. They are allowed to be direct files because:
+
+* They are small.
+* They change frequently.
+* They represent UI and traversal state.
+* They can be regenerated or cleared in many cases.
+
+Undo support can checkpoint these files without making the live state itself a
+Git ref.
+
+---
+
+## Abort and Recovery State
+
+### Location
+
+```text
+.git/git-stage-batch/session/abort/
+```
+
+### Files
+
+```text
+head.txt
+stash.txt
+untracked-paths.txt
+untracked/
+auto-added-files.txt
+intent-to-add-files.txt
+batch-refs.json
+```
+
+### `head.txt`
+
+Stores the selected `HEAD` commit at session start. Abort uses this as the
+reset target:
+
+```bash
+git reset --hard <head>
+```
+
+### `stash.txt`
+
+Stores the commit SHA returned by:
+
+```bash
+git stash create
+```
+
+The stash commit captures tracked worktree and index changes at session start.
+Abort applies it with `--index` to restore both staged and unstaged tracked
+state.
+
+### `untracked-paths.txt` and `untracked/`
+
+Untracked and intent-to-add file bytes are snapshotted lazily under:
+
+```text
+session/abort/untracked/<repo-relative-path>
+```
+
+`untracked-paths.txt` records which paths have snapshots.
+
+This exists because `git stash create` does not include untracked files, and
+intent-to-add files need special care around `git reset --hard`.
+
+### `auto-added-files.txt`
+
+Records files that git-stage-batch added to the index with `git add -N` so they
+can appear in diffs.
+
+Abort resets those paths before restoring the original state.
+
+### `intent-to-add-files.txt`
+
+Records files that had intent-to-add status at session start. Abort restores
+that status after resetting and applying the stash.
+
+### `batch-refs.json`
+
+Stores a session-start snapshot of batch refs and file-backed metadata.
+
+Abort uses it to:
+
+* Delete batches created during the session
+* Restore batches deleted during the session
+* Revert batches modified during the session
+* Restore file-backed metadata
+* Resync the Git-backed state refs
+
+---
+
+## Selected Change Cache
+
+### Location
+
+```text
+.git/git-stage-batch/session/selected/
+```
+
+### Files
+
+```text
+hunk.hash.txt
+hunk.patch
+hunk.lines.json
+binary-file.json
+index.snapshot
+working-tree.snapshot
+```
+
+### `hunk.patch`
+
+Stores the currently selected text hunk as patch bytes.
+
+Commands such as `include`, `discard`, and `show` use this cache to operate on
+the selected hunk.
+
+### `hunk.hash.txt`
+
+Stores the stable hash of the selected hunk. The hash is used for progress
+tracking and blocking already processed hunks.
+
+### `hunk.lines.json`
+
+Stores the parsed line-level representation of the selected hunk. Line-level
+commands use this file to map user-visible line IDs to actual source and target
+lines.
+
+### `binary-file.json`
+
+Stores selected binary-file metadata when the selected change is binary rather
+than a text hunk.
+
+### `index.snapshot`
+
+Stores the file's index bytes when the hunk is selected.
+
+### `working-tree.snapshot`
+
+Stores the file's working tree bytes when the hunk is selected.
+
+### Staleness Detection
+
+Before line-level operations, the selected snapshots are compared against the
+current index and working tree. If either changed, the cached hunk is stale and
+the operation is rejected.
+
+Batch hunks and file-scoped live operations do not use these staleness
+snapshots in the same way, because they are rendered from batch state or live
+working tree state rather than from the cached selected hunk.
+
+---
+
+## Progress and Navigation State
+
+### Location
+
+```text
+.git/git-stage-batch/session/progress/
+```
+
+### Files
+
+```text
+blocked-hunks.txt
+included-hunks.txt
+discarded-hunks.txt
+skipped-hunks.jsonl
+batched-hunks.txt
+blocked-files.txt
+```
+
+### `blocked-hunks.txt`
+
+Stores hunk hashes that should be skipped by forward traversal. This is the
+core forward-progress mechanism.
+
+When the next hunk is fetched, hunks whose hash appears here are ignored.
+
+### `included-hunks.txt`
+
+Stores hashes of hunks that have been staged into the Git index during the
+current iteration.
+
+### `discarded-hunks.txt`
+
+Stores hashes of hunks that have been removed from the working tree during the
+current iteration.
+
+### `skipped-hunks.jsonl`
+
+Stores one JSON object per skipped hunk. This records enough metadata to report
+skipped hunk progress and locations.
+
+JSON Lines is used because skipped hunk records are append-oriented and each
+record has structure.
+
+### `batched-hunks.txt`
+
+Reserved for hunk-level batch progress.
+
+### `blocked-files.txt`
+
+Stores repository paths that should be excluded from traversal.
+
+---
+
+## Processed Line State
+
+### Location
+
+```text
+.git/git-stage-batch/session/processed/
+```
+
+### Files
+
+```text
+included-lines.json
+skipped-lines.json
+batched-lines.json
+```
+
+These files track line IDs that have already been handled within the selected
+hunk or file-scoped operation.
+
+The filenames use `.json` because they are structured line-id sets, even though
+the selected serialization is still compatible with the existing line-id helper
+format.
+
+---
+
+## Config and Auxiliary Session State
+
+### Location
+
+```text
+.git/git-stage-batch/session/config/
+```
+
+### Files
+
+```text
+context-lines.txt
+iteration-count.txt
+```
+
+`context-lines.txt` stores the selected unified diff context line count.
+
+`iteration-count.txt` stores the current pass number. `again` increments it.
+
+### Start State
+
+```text
+.git/git-stage-batch/session/start-head.txt
+.git/git-stage-batch/session/start-index-tree.txt
+.git/git-stage-batch/session/start-batch-refs.json
+```
+
+Interactive mode uses start state to decide whether quitting should prompt to
+keep or undo staged changes.
+
+### Suggest-Fixup State
+
+```text
+.git/git-stage-batch/session/fixup/state.json
+```
+
+Stores the current iterative state for `suggest-fixup`.
+
+### Journal
+
+```text
+.git/git-stage-batch/journal.jsonl
+```
+
+The journal is a debug log. It is session-level, but it remains outside
+`session/` so it can be preserved across `again` and cleared with the full
+session.
+
+---
+
+## Batch Ref Snapshots
+
+### Location
+
+```text
+.git/git-stage-batch/session/abort/batch-refs.json
+```
+
+### Meaning
+
+This file stores the batch state at session start. Its selected format is:
+
+```json
+{
+  "batch-name": {
+    "commit_sha": "...",
+    "metadata": {}
+  }
+}
+```
+
+The snapshot includes complete file-backed metadata so abort can recreate
+deleted batches and roll back modified batches.
+
+### Restore Behavior
+
+Abort compares the snapshot with current batch refs:
+
+* Current batch not in snapshot: delete it.
+* Snapshot batch missing from current refs: recreate it.
+* Batch exists with different commit: reset its ref.
+* Metadata differs or was deleted: rewrite metadata from the snapshot.
+
+When the snapshot includes an exact Git-backed state ref commit, abort restores
+the content, state, and compatibility refs together through `update_git_refs()`.
+Older snapshots without a saved state ref are restored by resyncing the
+Git-backed state from the restored content ref and metadata.
+
+---
+
+## Object Reachability
+
+### Selected Batch Source Commits
+
+Batch source commits are made reachable by using them as parents of batch
+commits. The file-backed metadata also stores their SHAs, but metadata alone is
+not a Git reachability root.
+
+### Git-Backed Source Entries
+
+The Git-backed state refs make source snapshot bytes reachable from:
+
+```text
+refs/git-stage-batch/state/<batch>
+```
+
+The source bytes are ordinary blobs under the `sources/` tree.
+
+### Stash Commits
+
+Abort stash commits are stored by SHA in `stash.txt`. They are not refs. They
+remain available while the object is not garbage-collected. Because sessions are
+short-lived, this is acceptable for the selected model, but a more durable
+future model could store abort data in a Git-backed session ref.
+
+### Local File Snapshots
+
+Abort untracked snapshots are currently filesystem copies under:
+
+```text
+.git/git-stage-batch/session/abort/untracked/
+```
+
+These are not Git objects yet. They are candidates for a future Git-backed
+session state ref.
+
+---
+
+## Undo Checkpoints
+
+### Location
+
+```text
+refs/git-stage-batch/session/undo-stack
+```
+
+This ref points at the newest undo checkpoint for the active session. Each
+checkpoint commit has the previous checkpoint as its parent, so the undo stack
+is ordinary Git history rather than numbered frame directories.
+
+`git-stage-batch stop` and `git-stage-batch abort` delete this ref when they
+clear session state.
+
+### Checkpoint Tree
+
+Each checkpoint stores a before-image of the state needed to undo one operation:
+
+```text
+manifest.json
+session/
+batches/
+worktree/
+  <repo-relative paths>
+```
+
+### `manifest.json`
+
+`manifest.json` records the non-file state needed to restore the checkpoint:
+
+```json
+{
+  "operation": "include --line 1",
+  "head": "abc123...",
+  "index_tree": "def456...",
+  "refs": {
+    "refs/batches/foo": "111111...",
+    "refs/git-stage-batch/batches/foo": "111111...",
+    "refs/git-stage-batch/state/foo": "222222..."
+  },
+  "after": {
+    "index_tree": "999999...",
+    "refs": {
+      "refs/batches/foo": "333333...",
+      "refs/git-stage-batch/batches/foo": "333333...",
+      "refs/git-stage-batch/state/foo": "444444..."
+    },
+    "worktree_paths": [
+      {
+        "path": "src/main.py",
+        "exists": true,
+        "mode": "100644",
+        "blob": "555555..."
+      }
+    ]
+  },
+  "worktree_paths": [
+    {
+      "path": "src/main.py",
+      "exists": true,
+      "mode": "100644"
+    }
+  ]
+}
+```
+
+The `operation` string is user-facing output for `git-stage-batch undo`.
+`index_tree` is restored with `git read-tree`. The top-level `refs` map is the
+complete set of batch-related refs that undo restores.
+
+The `after` object is recorded after the mutating command completes. Undo uses
+it for conflict detection: if the current index tree, batch refs, or tracked
+worktree path bytes differ from `after`, undo refuses by default.
+
+### Session and Metadata Before-Images
+
+Undo snapshots these filesystem trees:
+
+```text
+.git/git-stage-batch/session/
+.git/git-stage-batch/batches/
+```
+
+They are stored in the checkpoint as:
+
+```text
+session/
+batches/
+```
+
+Restoring a checkpoint replaces the live session and file-backed batch metadata
+trees with these before-images.
+
+### Ref Before-Images
+
+Undo restores all refs under:
+
+```text
+refs/batches/
+refs/git-stage-batch/batches/
+refs/git-stage-batch/state/
+```
+
+Refs created after the checkpoint are deleted. Refs present in the checkpoint
+are moved back to the saved object IDs. Undo applies those ref updates through
+one `update_git_refs()` transaction so the batch-related refs are restored
+together.
+
+### Index and Worktree Before-Images
+
+Undo restores two separate views of repository state:
+
+1. The index tree saved in `manifest.json`.
+2. Worktree file bytes saved under `worktree/`.
+
+Because Git trees do not encode intent-to-add entries, undo reapplies
+intent-to-add for paths listed in the restored
+`session/abort/auto-added-files.txt` after restoring the saved index tree and
+worktree bytes.
+
+The worktree snapshot covers paths reported by:
+
+```bash
+git diff --name-only HEAD
+git diff --cached --name-only
+git ls-files --others --exclude-standard
+```
+
+For each path, the manifest records whether it existed and its executable mode.
+If a file did not exist at checkpoint time, undo removes it. If it did exist,
+undo writes the saved blob and restores the executable bit.
+
+### Restore Order
+
+`git-stage-batch undo` restores state in this order:
+
+1. Restore `.git/git-stage-batch/session/`.
+2. Restore `.git/git-stage-batch/batches/`.
+3. Restore batch refs and Git-backed state refs.
+4. Restore the Git index from `index_tree`.
+5. Restore worktree before-images.
+6. Move `refs/git-stage-batch/session/undo-stack` to the parent checkpoint, or
+   delete it when the stack is empty.
+
+The checkpoint is created immediately before mutating commands such as
+`include`, `skip`, `discard`, batch transfers, `reset`, `new`, `drop`, and
+`annotate`.
+
+### Conflict Detection
+
+Undo is guarded by default. It compares the current state to the checkpoint's
+recorded `after` state before restoring anything:
+
+* If the index tree changed, undo refuses.
+* If batch refs changed, undo refuses.
+* If a tracked worktree path changed, undo refuses.
+
+The user can bypass this guard with:
+
+```bash
+git-stage-batch undo --force
+```
+
+Forced undo restores the checkpoint before-images and overwrites those later
+changes.
+
+### Limitations
+
+Undo is intentionally session-scoped. It requires an active session and only
+tracks state that git-stage-batch knows how to restore.
+
+Undo does not attempt to merge arbitrary user edits made after the checkpoint.
+It either refuses or, with `--force`, writes the saved before-images for the
+affected paths.
+
+Undo checkpoint commits are reachable only from:
+
+```text
+refs/git-stage-batch/session/undo-stack
+```
+
+When that ref is deleted by stop or abort, the checkpoint commits become normal
+unreferenced objects and may eventually be garbage-collected.
+
+---
+
+## Redo Stack
+
+### Location
+
+```text
+refs/git-stage-batch/session/redo-stack
+```
+
+This ref points at the newest redo node for the active session. Each redo node
+commit has the previous redo node as its parent, so the redo stack is ordinary
+Git history analogous to the undo stack.
+
+`git-stage-batch stop` and `git-stage-batch abort` delete this ref when they
+clear session state. Any new undoable operation also clears the redo stack,
+because redo history becomes invalid once the user performs a new operation
+after undo.
+
+### Redo Node Tree
+
+Each redo node stores the target state to restore when redoing:
+
+```text
+manifest.json
+session/
+batches/
+worktree/
+  <repo-relative paths>
+```
+
+### `manifest.json`
+
+Redo node `manifest.json` records the state needed to restore and validate:
+
+```json
+{
+  "operation": "include --line 1",
+  "undo_checkpoint": "<sha of original undo checkpoint>",
+  "head": "<HEAD sha>",
+  "index_tree": "<target index tree>",
+  "refs": {
+    "refs/git-stage-batch/batches/foo": "...",
+    "refs/git-stage-batch/state/foo": "..."
+  },
+  "worktree_paths": [
+    {
+      "path": "src/main.py",
+      "exists": true,
+      "mode": "100644"
+    }
+  ],
+  "after_undo": {
+    "index_tree": "<state immediately after undo>",
+    "refs": {},
+    "worktree_paths": [
+      {
+        "path": "src/main.py",
+        "exists": true,
+        "mode": "100644",
+        "blob": "..."
+      }
+    ]
+  }
+}
+```
+
+The top-level `index_tree`, `refs`, `session/`, `batches/`, and `worktree/` are
+the state to restore when running redo.
+
+The `after_undo` object is the conflict-detection baseline. It records the state
+immediately after undo completed. If current state differs from `after_undo`,
+redo refuses unless `--force`.
+
+### Lifecycle
+
+Redo nodes are created during `undo_last_checkpoint()`. Each undo pushes a redo
+node whose target is the pre-undo state and whose `after_undo` is a snapshot of
+the post-undo state.
+
+`redo_last_checkpoint()` restores the target state from a redo node, pushes the
+original undo checkpoint back onto the undo stack, and pops the redo stack.
+
+### Redo Stack Invalidation
+
+The redo stack is cleared when:
+
+* A new undoable operation creates a checkpoint (any call to
+  `_create_undo_checkpoint()`).
+* `git-stage-batch stop` or `git-stage-batch abort` clears session state.
+
+This matches the standard editor undo/redo model: performing a new operation
+after undo discards the redo history.
+
+---
+
+## Future Direction
+
+The selected batch storage is:
+
+```text
+refs/git-stage-batch/batches/<batch>
+refs/git-stage-batch/state/<batch>
+```
+
+In this model:
+
+* `refs/git-stage-batch/batches/<batch>` stores realized content.
+* `refs/git-stage-batch/state/<batch>` stores `batch.json` and `sources/`.
+* File-backed batch metadata is a migration input.
+* Batch reads validate `batch.json.content_commit` against the content ref.
+* Batch updates move content and state refs together through `update_git_refs()`,
+  which uses `git update-ref --stdin`.
+* Undo restores ref values and session checkpoints instead of copying batch
+  metadata files.
+
+Abort recovery could also move further into Git-backed session state:
+
+```text
+refs/git-stage-batch/session/state
+  abort.json
+  untracked/
+```
+
+That would make untracked abort snapshots Git blobs rather than filesystem
+copies. The selected branch does not implement that yet.
+
+The remaining compatibility paths are import-only: they keep older state
+readable, and new writes remove them for the batches they migrate.
+
+---
+
+## Migration Invariants
+
+The compatibility layer should preserve these rules:
+
+* Migration is idempotent.
+* Once Git-backed refs exist, they win.
+* Stale compatibility metadata must not override authoritative refs.
+* Partial migration must not leave the repository in a more ambiguous state.
+* Compatibility code should remain removable without redesigning storage.
+
+Compatibility paths are transitional and intended to be removed before the
+1.0.0 release.

--- a/completions/git-stage-batch
+++ b/completions/git-stage-batch
@@ -15,7 +15,7 @@ _git_stage_batch()
     local cur prev words cword
     _init_completion || return
 
-    local commands="start show include skip discard status again stop abort block-file unblock-file suggest-fixup new list drop annotate apply reset undo"
+    local commands="start show include skip discard status again stop abort block-file unblock-file suggest-fixup new list drop annotate apply reset undo redo"
 
     # Handle subcommands
     if [[ $cword -eq 1 ]]; then
@@ -120,7 +120,7 @@ _git_stage_batch()
         status)
             COMPREPLY=($(compgen -W "--porcelain" -- "$cur"))
             ;;
-        undo)
+        undo|redo)
             COMPREPLY=($(compgen -W "--force" -- "$cur"))
             ;;
         block-file|unblock-file)

--- a/completions/git-stage-batch
+++ b/completions/git-stage-batch
@@ -2,7 +2,12 @@
 
 __git_stage_batch_list_batches()
 {
-    git for-each-ref --format='%(refname:short)' refs/batches/ 2>/dev/null | sed 's|^batches/||'
+    {
+        git for-each-ref --format='%(refname)' refs/git-stage-batch/batches/ 2>/dev/null |
+            sed 's|^refs/git-stage-batch/batches/||'
+        git for-each-ref --format='%(refname)' refs/batches/ 2>/dev/null |
+            sed 's|^refs/batches/||'
+    } | sort -u
 }
 
 _git_stage_batch()

--- a/completions/git-stage-batch
+++ b/completions/git-stage-batch
@@ -15,7 +15,7 @@ _git_stage_batch()
     local cur prev words cword
     _init_completion || return
 
-    local commands="start show include skip discard status again stop abort block-file unblock-file suggest-fixup new list drop annotate apply reset"
+    local commands="start show include skip discard status again stop abort block-file unblock-file suggest-fixup new list drop annotate apply reset undo"
 
     # Handle subcommands
     if [[ $cword -eq 1 ]]; then
@@ -119,6 +119,9 @@ _git_stage_batch()
             ;;
         status)
             COMPREPLY=($(compgen -W "--porcelain" -- "$cur"))
+            ;;
+        undo)
+            COMPREPLY=($(compgen -W "--force" -- "$cur"))
             ;;
         block-file|unblock-file)
             _filedir

--- a/docs/batches.md
+++ b/docs/batches.md
@@ -4,7 +4,7 @@
     Batches are an advanced feature for complex workflows. Most users will not need them.
     The core commands (start, include, skip, discard) handle the majority of use cases.
 
-Batches are named collections of accumulated changes that can be staged or discarded later as a unit. They persist across sessions and are stored as git commits under `refs/batches/<name>`.
+Batches are named collections of accumulated changes that can be staged or discarded later as a unit. They persist across sessions and are stored as git commits under `refs/git-stage-batch/batches/<name>`.
 
 Each batch captures not just the changes themselves, but also the working tree state at the time changes were saved (the **batch source**). This allows batch operations to intelligently merge or discard changes even when your code has evolved since the batch was created.
 
@@ -30,8 +30,10 @@ When you save content to a batch (via `include --to` or `discard --to`), the too
 3. **Deletion claims**: Which sequences were deleted by the batch (if any)
 
 This information is stored in:
-- A Git commit under `refs/batches/<name>` containing the realized batch content
-- Metadata tracking the batch source commit and ownership structure
+- A Git commit under `refs/git-stage-batch/batches/<name>` containing the realized batch content
+- A state commit under `refs/git-stage-batch/state/<name>` tracking the batch source commit and ownership structure
+
+Legacy batches under `refs/batches/<name>` are read as migration inputs. Once a batch is written by the current version, the legacy ref and file-backed metadata for that batch are removed.
 
 ### Application Model (include/apply --from)
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -234,6 +234,33 @@ Refuses by default if the current state has changed since the checkpoint.
 
 ---
 
+### `redo`
+
+Redo the most recently undone session operation.
+
+```
+❯ git-stage-batch redo
+```
+
+**Options:**
+- `--force`: Overwrite changes made after the undo
+
+Refuses by default if the current state has changed since the undo.
+
+Multiple undo/redo works in editor order:
+
+```bash
+# do A, do B, do C
+❯ git-stage-batch undo      # removes C, redo stack: C
+❯ git-stage-batch undo      # removes B, redo stack: B, C
+❯ git-stage-batch redo      # reapplies B, redo stack: C
+❯ git-stage-batch redo      # reapplies C, redo stack empty
+```
+
+A new undoable operation after undo clears the redo stack.
+
+---
+
 ## File-Level Operations
 
 ### `include --file [PATH]`

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -218,6 +218,22 @@ This:
 
 ---
 
+### `undo`
+
+Undo the most recent undoable session operation, restoring the repository
+to its state before that operation.
+
+```
+❯ git-stage-batch undo
+```
+
+**Options:**
+- `--force`: Overwrite changes made after the undo checkpoint
+
+Refuses by default if the current state has changed since the checkpoint.
+
+---
+
 ## File-Level Operations
 
 ### `include --file [PATH]`

--- a/docs/git-stage-batch.1.in
+++ b/docs/git-stage-batch.1.in
@@ -135,7 +135,7 @@ restores batch state (drops created batches, restores dropped/mutated batches),
 and removes session state.
 .B WARNING:
 This will undo any commits made during the session.
-.SS Undo
+.SS Undo and Redo
 .TP
 .B undo \fR[\fB\-\-force\fR]
 Undo the most recent undoable session operation. Restores the repository
@@ -146,6 +146,17 @@ checkpoint.
 .TP
 .B \-\-force
 Overwrite changes made after the undo checkpoint.
+.RE
+.TP
+.B redo \fR[\fB\-\-force\fR]
+Redo the most recently undone session operation. Restores the state that
+was in effect before the undo. Multiple undo/redo cycles work in standard
+editor order. A new undoable operation after undo clears the redo stack.
+Refuses by default if the current state has changed since the undo.
+.RS
+.TP
+.B \-\-force
+Overwrite changes made after the undo.
 .RE
 .SS File-Level Operations
 .TP

--- a/docs/git-stage-batch.1.in
+++ b/docs/git-stage-batch.1.in
@@ -135,6 +135,18 @@ restores batch state (drops created batches, restores dropped/mutated batches),
 and removes session state.
 .B WARNING:
 This will undo any commits made during the session.
+.SS Undo
+.TP
+.B undo \fR[\fB\-\-force\fR]
+Undo the most recent undoable session operation. Restores the repository
+state to the point before that operation (index, worktree, session files,
+batch refs). Refuses by default if the current state has changed since the
+checkpoint.
+.RS
+.TP
+.B \-\-force
+Overwrite changes made after the undo checkpoint.
+.RE
 .SS File-Level Operations
 .TP
 .B include \-\-file

--- a/docs/git-stage-batch.1.in
+++ b/docs/git-stage-batch.1.in
@@ -223,8 +223,10 @@ Defer changes without losing them while you work on other commits
 Group changes by type (e.g., debugging, refactoring) for separate handling
 .RE
 .PP
-Batches are stored as git commits under refs/batches/<name> and persist
-across sessions until explicitly dropped.
+Batches are stored as git commits under refs/git-stage-batch/batches/<name>
+and persist across sessions until explicitly dropped. Legacy batches under
+refs/batches/<name> are read as migration inputs and removed after the batch
+is written in the Git-backed namespace.
 .TP
 .B new \fIBATCH_NAME\fR [\fB\-\-note\fR \fINOTE\fR]
 Create a new named batch for accumulating changes.

--- a/src/git_stage_batch/batch/metadata_validation.py
+++ b/src/git_stage_batch/batch/metadata_validation.py
@@ -6,12 +6,12 @@ metadata early and produce clear error messages.
 
 from __future__ import annotations
 
-import json
 from typing import Any
 
+from .query import read_batch_metadata
+from .state_refs import get_batch_state_ref_name, get_legacy_batch_ref_name
 from ..exceptions import BatchMetadataError
 from ..i18n import _
-from ..utils.file_io import read_text_file_contents
 from ..utils.git import run_git_command
 from ..utils.paths import (
     get_batch_metadata_file_path,
@@ -44,7 +44,7 @@ def validate_state_directory_exists() -> None:
 
 
 def validate_batch_metadata_file_exists(batch_name: str) -> None:
-    """Verify that metadata file exists for a batch.
+    """Verify that compatibility metadata exists when only legacy refs exist.
 
     Args:
         batch_name: Name of the batch
@@ -52,9 +52,15 @@ def validate_batch_metadata_file_exists(batch_name: str) -> None:
     Raises:
         BatchMetadataError: If metadata file is missing for an existing batch
     """
-    # First check if batch ref exists
+    state_result = run_git_command(
+        ["show-ref", "--verify", "--quiet", get_batch_state_ref_name(batch_name)],
+        check=False
+    )
+    if state_result.returncode == 0:
+        return
+
     result = run_git_command(
-        ["show-ref", "--verify", "--quiet", f"refs/batches/{batch_name}"],
+        ["show-ref", "--verify", "--quiet", get_legacy_batch_ref_name(batch_name)],
         check=False
     )
     batch_ref_exists = result.returncode == 0
@@ -66,7 +72,7 @@ def validate_batch_metadata_file_exists(batch_name: str) -> None:
     if batch_ref_exists and not metadata_exists:
         raise BatchMetadataError(
             _("Batch metadata is missing or corrupted for '{name}'.\n"
-              "The batch ref exists (refs/batches/{name}) but metadata file is missing.\n"
+              "The legacy batch ref exists (refs/batches/{name}) but metadata file is missing.\n"
               "Expected metadata file: {file}\n"
               "The batch may not be recoverable automatically.").format(
                 name=batch_name,
@@ -192,28 +198,19 @@ def load_and_validate_batch_metadata(batch_name: str) -> dict[str, Any]:
     Raises:
         BatchMetadataError: If metadata is missing, corrupted, or structurally invalid
     """
-    # Check if batch ref exists first
-    result = run_git_command(
-        ["show-ref", "--verify", "--quiet", f"refs/batches/{batch_name}"],
+    state_result = run_git_command(
+        ["show-ref", "--verify", "--quiet", get_batch_state_ref_name(batch_name)],
         check=False
     )
-    batch_ref_exists = result.returncode == 0
+    state_ref_exists = state_result.returncode == 0
 
-    # Only validate metadata file if batch ref exists
-    if batch_ref_exists:
-        # Ensure metadata file exists for this batch
-        validate_batch_metadata_file_exists(batch_name)
+    legacy_result = run_git_command(
+        ["show-ref", "--verify", "--quiet", get_legacy_batch_ref_name(batch_name)],
+        check=False
+    )
+    batch_ref_exists = state_ref_exists or legacy_result.returncode == 0
 
-    # Load metadata
-    metadata_path = get_batch_metadata_file_path(batch_name)
-    if not metadata_path.exists():
-        # If batch ref exists but metadata doesn't, that's corruption
-        if batch_ref_exists:
-            # State directory check is done above if ref exists
-            pass  # Error already raised by validate_batch_metadata_file_exists
-
-        # Return minimal valid structure for non-existent batches
-        # (batch_exists should be checked before calling this)
+    if not batch_ref_exists:
         return {
             "note": "",
             "created_at": "",
@@ -221,25 +218,17 @@ def load_and_validate_batch_metadata(batch_name: str) -> dict[str, Any]:
             "files": {}
         }
 
+    if batch_ref_exists and not state_ref_exists:
+        # Ensure metadata file exists for this batch
+        validate_batch_metadata_file_exists(batch_name)
+
     try:
-        metadata = json.loads(read_text_file_contents(metadata_path))
-    except json.JSONDecodeError as e:
-        raise BatchMetadataError(
-            _("Batch metadata for '{name}' is corrupted (invalid JSON).\n"
-              "Metadata file: {file}\n"
-              "Error: {error}").format(
-                name=batch_name,
-                file=str(metadata_path),
-                error=str(e)
-            )
-        )
+        metadata = read_batch_metadata(batch_name)
     except Exception as e:
         raise BatchMetadataError(
             _("Failed to read batch metadata for '{name}'.\n"
-              "Metadata file: {file}\n"
               "Error: {error}").format(
                 name=batch_name,
-                file=str(metadata_path),
                 error=str(e)
             )
         )

--- a/src/git_stage_batch/batch/operations.py
+++ b/src/git_stage_batch/batch/operations.py
@@ -6,10 +6,11 @@ import json
 import shutil
 from datetime import datetime, timezone
 
+from .query import read_batch_metadata
 from .validation import batch_exists, validate_batch_name
 from ..exceptions import exit_with_error
 from ..i18n import _
-from ..utils.file_io import read_text_file_contents, write_text_file_contents
+from ..utils.file_io import write_text_file_contents
 from ..utils.git import run_git_command
 from ..utils.paths import get_batch_directory_path, get_batch_metadata_file_path
 
@@ -65,7 +66,8 @@ def create_batch(name: str, note: str = "", baseline_commit: str | None = None) 
 
     commit_sha = commit_result.stdout.strip()
 
-    run_git_command(["update-ref", f"refs/batches/{name}", commit_sha])
+    from .state_refs import sync_batch_state_refs
+    sync_batch_state_refs(name, content_commit=commit_sha)
 
 
 def delete_batch(name: str) -> None:
@@ -75,8 +77,8 @@ def delete_batch(name: str) -> None:
     if not batch_exists(name):
         exit_with_error(_("Batch '{name}' does not exist").format(name=name))
 
-    # Delete git ref
-    run_git_command(["update-ref", "-d", f"refs/batches/{name}"])
+    from .state_refs import delete_batch_state_refs
+    delete_batch_state_refs(name)
 
     # Delete metadata directory
     metadata_dir = get_batch_directory_path(name)
@@ -91,15 +93,12 @@ def update_batch_note(name: str, note: str) -> None:
     if not batch_exists(name):
         exit_with_error(_("Batch '{name}' does not exist").format(name=name))
 
-    # Read existing metadata
     metadata_path = get_batch_metadata_file_path(name)
-    metadata = {}
-    if metadata_path.exists():
-        try:
-            metadata = json.loads(read_text_file_contents(metadata_path))
-        except (json.JSONDecodeError, KeyError):
-            pass
+    metadata = read_batch_metadata(name)
 
     # Update note
     metadata["note"] = note
     write_text_file_contents(metadata_path, json.dumps(metadata, indent=2))
+
+    from .state_refs import sync_batch_state_refs
+    sync_batch_state_refs(name)

--- a/src/git_stage_batch/batch/query.py
+++ b/src/git_stage_batch/batch/query.py
@@ -5,6 +5,12 @@ from __future__ import annotations
 import json
 from typing import Optional
 
+from .ref_names import BATCH_CONTENT_REF_PREFIX, LEGACY_BATCH_REF_PREFIX
+from .state_refs import (
+    get_authoritative_batch_commit_sha,
+    get_legacy_batch_ref_name,
+    read_batch_state_metadata,
+)
 from .validation import validate_batch_name
 from ..utils.file_io import read_text_file_contents
 from ..utils.git import run_git_command
@@ -30,6 +36,10 @@ def read_batch_metadata(name: str) -> dict:
     }
     """
     validate_batch_name(name)
+
+    state_metadata = read_batch_state_metadata(name)
+    if state_metadata is not None:
+        return state_metadata
 
     metadata_path = get_batch_metadata_file_path(name)
     if not metadata_path.exists():
@@ -58,11 +68,15 @@ def read_batch_metadata(name: str) -> dict:
 
 
 def get_batch_commit_sha(name: str) -> Optional[str]:
-    """Get the commit SHA for a batch from its git ref."""
+    """Get the commit SHA for a batch from its authoritative git ref."""
     validate_batch_name(name)
 
+    commit_sha = get_authoritative_batch_commit_sha(name)
+    if commit_sha:
+        return commit_sha
+
     result = run_git_command(
-        ["rev-parse", "--verify", f"refs/batches/{name}"],
+        ["rev-parse", "--verify", get_legacy_batch_ref_name(name)],
         check=False
     )
     if result.returncode != 0:
@@ -72,18 +86,15 @@ def get_batch_commit_sha(name: str) -> Optional[str]:
 
 
 def list_batch_names() -> list[str]:
-    """List all batch names by querying refs/batches/* refs."""
-    result = run_git_command(["for-each-ref", "--format=%(refname)", "refs/batches/"], check=False)
-    if result.returncode != 0:
-        return []
-
-    batch_names = []
-    for line in result.stdout.strip().splitlines():
-        if not line:
+    """List all batch names by querying authoritative refs and legacy imports."""
+    batch_names: set[str] = set()
+    for prefix in (BATCH_CONTENT_REF_PREFIX, LEGACY_BATCH_REF_PREFIX):
+        result = run_git_command(["for-each-ref", "--format=%(refname)", prefix], check=False)
+        if result.returncode != 0:
             continue
-        if line.startswith("refs/batches/"):
-            batch_name = line[len("refs/batches/"):]
-            batch_names.append(batch_name)
+        for line in result.stdout.strip().splitlines():
+            if line.startswith(prefix):
+                batch_names.add(line[len(prefix):])
 
     return sorted(batch_names)
 

--- a/src/git_stage_batch/batch/ref_names.py
+++ b/src/git_stage_batch/batch/ref_names.py
@@ -1,0 +1,6 @@
+"""Git ref namespace constants for batch storage."""
+
+GIT_STAGE_BATCH_REF_NAMESPACE = "refs/git-stage-batch"
+BATCH_CONTENT_REF_PREFIX = f"{GIT_STAGE_BATCH_REF_NAMESPACE}/batches/"
+BATCH_STATE_REF_PREFIX = f"{GIT_STAGE_BATCH_REF_NAMESPACE}/state/"
+LEGACY_BATCH_REF_PREFIX = "refs/batches/"

--- a/src/git_stage_batch/batch/state_refs.py
+++ b/src/git_stage_batch/batch/state_refs.py
@@ -1,0 +1,222 @@
+"""Git-backed authoritative batch state refs."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from typing import Any
+
+from .ref_names import BATCH_CONTENT_REF_PREFIX, BATCH_STATE_REF_PREFIX, LEGACY_BATCH_REF_PREFIX
+from .validation import validate_batch_name
+from ..utils.file_io import read_text_file_contents
+from ..utils.git import create_git_blob, run_git_command, update_git_refs
+from ..utils.paths import get_batch_metadata_file_path
+
+
+def get_batch_content_ref_name(batch_name: str) -> str:
+    """Return the authoritative content ref for a batch."""
+    validate_batch_name(batch_name)
+    return f"{BATCH_CONTENT_REF_PREFIX}{batch_name}"
+
+
+def get_batch_state_ref_name(batch_name: str) -> str:
+    """Return the authoritative state ref for a batch."""
+    validate_batch_name(batch_name)
+    return f"{BATCH_STATE_REF_PREFIX}{batch_name}"
+
+
+def get_legacy_batch_ref_name(batch_name: str) -> str:
+    """Return the compatibility content ref for a batch."""
+    validate_batch_name(batch_name)
+    return f"{LEGACY_BATCH_REF_PREFIX}{batch_name}"
+
+
+def delete_batch_state_refs(batch_name: str) -> None:
+    """Delete authoritative batch state/content refs for a batch."""
+    validate_batch_name(batch_name)
+    update_git_refs(deletes=[
+        get_batch_content_ref_name(batch_name),
+        get_batch_state_ref_name(batch_name),
+        get_legacy_batch_ref_name(batch_name),
+    ])
+
+
+def remove_file_backed_batch_metadata(batch_name: str) -> None:
+    """Remove legacy file-backed metadata for a migrated batch."""
+    metadata_dir = get_batch_metadata_file_path(batch_name).parent
+    if metadata_dir.exists():
+        shutil.rmtree(metadata_dir, ignore_errors=True)
+
+
+def _legacy_batch_commit_sha(batch_name: str) -> str | None:
+    result = run_git_command(
+        ["rev-parse", "--verify", get_legacy_batch_ref_name(batch_name)],
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def read_file_backed_batch_metadata(batch_name: str) -> dict[str, Any]:
+    metadata_path = get_batch_metadata_file_path(batch_name)
+    if not metadata_path.exists():
+        return {
+            "note": "",
+            "created_at": "",
+            "baseline": None,
+            "files": {},
+        }
+
+    metadata = json.loads(read_text_file_contents(metadata_path))
+    return {
+        "note": metadata.get("note", ""),
+        "created_at": metadata.get("created_at", ""),
+        "baseline": metadata.get("baseline", None),
+        "files": metadata.get("files", {}),
+    }
+
+
+def read_batch_state_metadata(batch_name: str) -> dict[str, Any] | None:
+    """Read normalized batch metadata from the authoritative state ref."""
+    validate_batch_name(batch_name)
+    result = run_git_command(
+        ["show", f"{get_batch_state_ref_name(batch_name)}:batch.json"],
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+
+    state_metadata = json.loads(result.stdout)
+    return {
+        "note": state_metadata.get("note", ""),
+        "created_at": state_metadata.get("created_at", ""),
+        "baseline": state_metadata.get("baseline_commit", state_metadata.get("baseline")),
+        "files": state_metadata.get("files", {}),
+    }
+
+
+def get_authoritative_batch_commit_sha(batch_name: str) -> str | None:
+    """Get the batch content commit from the authoritative content ref."""
+    validate_batch_name(batch_name)
+    result = run_git_command(
+        ["rev-parse", "--verify", get_batch_content_ref_name(batch_name)],
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def sync_batch_state_refs(batch_name: str, *, content_commit: str | None = None) -> None:
+    """Publish batch metadata and source snapshots into authoritative Git refs."""
+    validate_batch_name(batch_name)
+
+    content_commit = content_commit or get_authoritative_batch_commit_sha(batch_name) or _legacy_batch_commit_sha(batch_name)
+    if not content_commit:
+        delete_batch_state_refs(batch_name)
+        return
+
+    metadata = read_file_backed_batch_metadata(batch_name)
+    state_metadata = {
+        "batch": batch_name,
+        "note": metadata.get("note", ""),
+        "created_at": metadata.get("created_at", ""),
+        "baseline_commit": metadata.get("baseline"),
+        "content_ref": get_batch_content_ref_name(batch_name),
+        "content_commit": content_commit,
+        "files": {},
+    }
+
+    temp_index = tempfile.NamedTemporaryFile(delete=False, suffix=".index")
+    temp_index_path = temp_index.name
+    temp_index.close()
+    os.unlink(temp_index_path)
+
+    env = os.environ.copy()
+    env["GIT_INDEX_FILE"] = temp_index_path
+
+    try:
+        for file_path, file_meta in metadata.get("files", {}).items():
+            state_file_meta = dict(file_meta)
+
+            source_commit = file_meta.get("batch_source_commit")
+            if source_commit:
+                source_result = run_git_command(
+                    ["show", f"{source_commit}:{file_path}"],
+                    check=False,
+                    text_output=False,
+                )
+                if source_result.returncode == 0:
+                    source_blob = create_git_blob([source_result.stdout])
+                    source_path = f"sources/{file_path}"
+                    subprocess.run(
+                        [
+                            "git",
+                            "update-index",
+                            "--add",
+                            "--cacheinfo",
+                            f"{file_meta.get('mode', '100644')},{source_blob},{source_path}",
+                        ],
+                        env=env,
+                        capture_output=True,
+                        check=True,
+                    )
+                    state_file_meta["source_path"] = source_path
+
+            state_metadata["files"][file_path] = state_file_meta
+
+        state_json = json.dumps(state_metadata, indent=2).encode("utf-8")
+        state_blob = create_git_blob([state_json])
+        subprocess.run(
+            [
+                "git",
+                "update-index",
+                "--add",
+                "--cacheinfo",
+                f"100644,{state_blob},batch.json",
+            ],
+            env=env,
+            capture_output=True,
+            check=True,
+        )
+
+        tree_result = subprocess.run(
+            ["git", "write-tree"],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        tree_sha = tree_result.stdout.strip()
+
+        existing_state = run_git_command(
+            ["rev-parse", "--verify", get_batch_state_ref_name(batch_name)],
+            check=False,
+        )
+        parent_args: list[str] = []
+        if existing_state.returncode == 0 and existing_state.stdout.strip():
+            parent_args = ["-p", existing_state.stdout.strip()]
+
+        commit_result = subprocess.run(
+            ["git", "commit-tree", tree_sha, *parent_args, "-m", f"Batch state: {batch_name}"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        state_commit = commit_result.stdout.strip()
+
+        update_git_refs(
+            updates=[
+                (get_batch_content_ref_name(batch_name), content_commit),
+                (get_batch_state_ref_name(batch_name), state_commit),
+            ],
+            deletes=[get_legacy_batch_ref_name(batch_name)],
+        )
+        remove_file_backed_batch_metadata(batch_name)
+    finally:
+        if os.path.exists(temp_index_path):
+            os.unlink(temp_index_path)

--- a/src/git_stage_batch/batch/storage.py
+++ b/src/git_stage_batch/batch/storage.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Optional
 from .metadata_validation import get_validated_baseline_commit
 from .operations import create_batch
 from .query import get_batch_baseline_commit, get_batch_commit_sha, read_batch_metadata
+from .state_refs import read_file_backed_batch_metadata
 from .validation import batch_exists, validate_batch_name
 from ..core.models import BinaryFileChange
 from ..data.batch_sources import (
@@ -427,7 +428,7 @@ def _remove_file_from_batch_commit(batch_name: str, file_path: str) -> None:
 
         # Collect parent commits: baseline + batch sources
         baseline = get_batch_baseline_commit(batch_name)
-        metadata = read_batch_metadata(batch_name)
+        metadata = read_file_backed_batch_metadata(batch_name)
 
         parents = []
         if baseline:
@@ -463,8 +464,8 @@ def _remove_file_from_batch_commit(batch_name: str, file_path: str) -> None:
 
         commit_sha = commit_result.stdout.strip()
 
-        # Update batch ref
-        run_git_command(["update-ref", f"refs/batches/{batch_name}", commit_sha])
+        from .state_refs import sync_batch_state_refs
+        sync_batch_state_refs(batch_name, content_commit=commit_sha)
 
     finally:
         if temp_index_path.exists():
@@ -518,7 +519,7 @@ def _update_batch_commit(batch_name: str, file_path: str, blob_sha: str, file_mo
 
         # Collect parent commits: baseline + batch sources
         baseline = get_batch_baseline_commit(batch_name)
-        metadata = read_batch_metadata(batch_name)
+        metadata = read_file_backed_batch_metadata(batch_name)
 
         parents = []
         if baseline:
@@ -554,8 +555,8 @@ def _update_batch_commit(batch_name: str, file_path: str, blob_sha: str, file_mo
 
         commit_sha = commit_result.stdout.strip()
 
-        # Update batch ref
-        run_git_command(["update-ref", f"refs/batches/{batch_name}", commit_sha])
+        from .state_refs import sync_batch_state_refs
+        sync_batch_state_refs(batch_name, content_commit=commit_sha)
 
     finally:
         if temp_index_path.exists():

--- a/src/git_stage_batch/batch/validation.py
+++ b/src/git_stage_batch/batch/validation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from .ref_names import BATCH_CONTENT_REF_PREFIX, LEGACY_BATCH_REF_PREFIX
 from ..exceptions import exit_with_error
 from ..i18n import _
 from ..utils.git import run_git_command
@@ -24,9 +25,16 @@ def validate_batch_name(name: str) -> None:
 
 
 def batch_exists(batch_name: str) -> bool:
-    """Check if a batch exists by checking for its git ref."""
+    """Check if a batch exists by checking its authoritative git ref."""
     result = run_git_command(
-        ["show-ref", "--verify", "--quiet", f"refs/batches/{batch_name}"],
+        ["show-ref", "--verify", "--quiet", f"{BATCH_CONTENT_REF_PREFIX}{batch_name}"],
+        check=False
+    )
+    if result.returncode == 0:
+        return True
+
+    result = run_git_command(
+        ["show-ref", "--verify", "--quiet", f"{LEGACY_BATCH_REF_PREFIX}{batch_name}"],
         check=False
     )
     return result.returncode == 0

--- a/src/git_stage_batch/cli/argument_parser.py
+++ b/src/git_stage_batch/cli/argument_parser.py
@@ -127,6 +127,19 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
     )
     parser_again.set_defaults(func=lambda _: commands.command_again())
 
+    # undo - Undo the most recent undoable session operation
+    parser_undo = subparsers.add_parser(
+        "undo",
+        aliases=["u", "back"],
+        help=_("Undo the most recent undoable session operation"),
+    )
+    parser_undo.add_argument(
+        "--force",
+        action="store_true",
+        help=_("Overwrite changes made after the undo checkpoint"),
+    )
+    parser_undo.set_defaults(func=lambda args: commands.command_undo(force=args.force))
+
     # show - Show the selected hunk
     parser_show = subparsers.add_parser(
         "show",

--- a/src/git_stage_batch/cli/argument_parser.py
+++ b/src/git_stage_batch/cli/argument_parser.py
@@ -140,6 +140,19 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
     )
     parser_undo.set_defaults(func=lambda args: commands.command_undo(force=args.force))
 
+    # redo - Redo the most recently undone session operation
+    parser_redo = subparsers.add_parser(
+        "redo",
+        aliases=["forward"],
+        help=_("Redo the most recently undone session operation"),
+    )
+    parser_redo.add_argument(
+        "--force",
+        action="store_true",
+        help=_("Overwrite changes made after the undo"),
+    )
+    parser_redo.set_defaults(func=lambda args: commands.command_redo(force=args.force))
+
     # show - Show the selected hunk
     parser_show = subparsers.add_parser(
         "show",

--- a/src/git_stage_batch/commands/__init__.py
+++ b/src/git_stage_batch/commands/__init__.py
@@ -25,6 +25,7 @@ from .status import command_status
 from .stop import command_stop
 from .suggest_fixup import command_suggest_fixup, command_suggest_fixup_line
 from .unblock_file import command_unblock_file
+from .undo import command_undo
 
 __all__ = [
     "command_abort",
@@ -59,4 +60,5 @@ __all__ = [
     "command_suggest_fixup",
     "command_suggest_fixup_line",
     "command_unblock_file",
+    "command_undo",
 ]

--- a/src/git_stage_batch/commands/__init__.py
+++ b/src/git_stage_batch/commands/__init__.py
@@ -25,6 +25,7 @@ from .status import command_status
 from .stop import command_stop
 from .suggest_fixup import command_suggest_fixup, command_suggest_fixup_line
 from .unblock_file import command_unblock_file
+from .redo import command_redo
 from .undo import command_undo
 
 __all__ = [
@@ -60,5 +61,6 @@ __all__ = [
     "command_suggest_fixup",
     "command_suggest_fixup_line",
     "command_unblock_file",
+    "command_redo",
     "command_undo",
 ]

--- a/src/git_stage_batch/commands/abort.py
+++ b/src/git_stage_batch/commands/abort.py
@@ -19,7 +19,7 @@ from ..utils.paths import (
     get_abort_snapshots_directory_path,
     get_abort_stash_file_path,
     get_auto_added_files_file_path,
-    get_state_directory_path,  # Still used for intent-to-add-files path construction
+    get_abort_state_directory_path,
 )
 
 
@@ -84,7 +84,7 @@ def command_abort() -> None:
                 print(_("Restored: {}").format(file_path), file=sys.stderr)
 
     # Restore intent-to-add status for files that had it before session
-    intent_to_add_path = get_state_directory_path() / "intent-to-add-files"
+    intent_to_add_path = get_abort_state_directory_path() / "intent-to-add-files.txt"
     if intent_to_add_path.exists():
         intent_to_add_files = read_file_paths_file(intent_to_add_path)
         for file_path in intent_to_add_files:

--- a/src/git_stage_batch/commands/annotate.py
+++ b/src/git_stage_batch/commands/annotate.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from ..batch import update_batch_note
 import sys
+from ..data.undo import undo_checkpoint
 from ..i18n import _
 from ..utils.git import require_git_repository
 
@@ -11,5 +12,6 @@ from ..utils.git import require_git_repository
 def command_annotate_batch(batch_name: str, note: str) -> None:
     """Add or update batch description."""
     require_git_repository()
-    update_batch_note(batch_name, note)
+    with undo_checkpoint(f"annotate {batch_name}"):
+        update_batch_note(batch_name, note)
     print(_("✓ Updated note for batch '{name}'").format(name=batch_name), file=sys.stderr)

--- a/src/git_stage_batch/commands/apply_from.py
+++ b/src/git_stage_batch/commands/apply_from.py
@@ -17,6 +17,7 @@ from ..batch.selection import (
 from ..batch.validation import batch_exists
 from ..data.hunk_tracking import render_batch_file_display
 from ..data.session import snapshot_file_if_untracked
+from ..data.undo import undo_checkpoint
 from ..exceptions import exit_with_error, MergeError, CommandError, AtomicUnitError, BatchMetadataError
 from ..i18n import _
 from ..utils.git import get_git_repository_root_path, require_git_repository, run_git_command
@@ -129,79 +130,84 @@ def command_apply_from_batch(batch_name: str, line_ids: Optional[str] = None, fi
                     selection_ids_to_apply.add(rendered.gutter_to_selection_id[gutter_id])
                 else:
                     exit_with_error(_("Line ID {id} not found or not individually mergeable").format(id=gutter_id))
+    operation_parts = ["apply", "--from", batch_name]
+    if line_ids is not None:
+        operation_parts.extend(["--line", line_ids])
+    if file is not None:
+        operation_parts.extend(["--file", file])
+    with undo_checkpoint(" ".join(operation_parts)):
+        # Apply all files in batch
+        repo_root = get_git_repository_root_path()
+        failed_files = []
 
-    # Apply all files in batch
-    repo_root = get_git_repository_root_path()
-    failed_files = []
-
-    for file_path, file_meta in files.items():
-        try:
-            # Snapshot file before modifying
-            snapshot_file_if_untracked(file_path)
-
-            # Binary files are atomic units - handle separately without ownership/merge logic
-            if file_meta.get("file_type") == "binary":
-                _apply_binary_file_from_batch(batch_name, file_path, file_meta)
-                continue
-
-            # Get batch source commit content (as bytes)
-            batch_source_commit = file_meta["batch_source_commit"]
-            batch_source_result = run_git_command(
-                ["show", f"{batch_source_commit}:{file_path}"],
-                check=False,
-                text_output=False
-            )
-            if batch_source_result.returncode != 0:
-                failed_files.append(file_path)
-                continue
-            batch_source_content = batch_source_result.stdout
-
-            # Get selected working tree content (as bytes)
-            full_path = repo_root / file_path
-            if full_path.exists():
-                working_content = full_path.read_bytes()
-            else:
-                working_content = b""
-
-            # Get ownership from metadata, filtered by selected selection IDs if specified
+        for file_path, file_meta in files.items():
             try:
-                ownership = select_batch_ownership_for_display_ids(
-                    file_meta, batch_source_content, selection_ids_to_apply
+                # Snapshot file before modifying
+                snapshot_file_if_untracked(file_path)
+
+                # Binary files are atomic units - handle separately without ownership/merge logic
+                if file_meta.get("file_type") == "binary":
+                    _apply_binary_file_from_batch(batch_name, file_path, file_meta)
+                    continue
+
+                # Get batch source commit content (as bytes)
+                batch_source_commit = file_meta["batch_source_commit"]
+                batch_source_result = run_git_command(
+                    ["show", f"{batch_source_commit}:{file_path}"],
+                    check=False,
+                    text_output=False
                 )
-            except AtomicUnitError as e:
-                # Translate selection IDs to gutter IDs and exit with user-friendly error
-                if rendered:
-                    translate_atomic_unit_error_to_gutter_ids(e, rendered, "apply", batch_name)
-                # No rendered context - show original error
-                exit_with_error(_("Failed to apply batch '{name}': {error}").format(
-                    name=batch_name,
-                    error=str(e)
-                ))
+                if batch_source_result.returncode != 0:
+                    failed_files.append(file_path)
+                    continue
+                batch_source_content = batch_source_result.stdout
 
-            # If nothing selected for this file, skip it
-            if ownership.is_empty():
-                continue
+                # Get selected working tree content (as bytes)
+                full_path = repo_root / file_path
+                if full_path.exists():
+                    working_content = full_path.read_bytes()
+                else:
+                    working_content = b""
 
-            # Perform structural merge
-            merged_content = merge_batch(
-                batch_source_content,
-                ownership,
-                working_content
-            )
+                # Get ownership from metadata, filtered by selected selection IDs if specified
+                try:
+                    ownership = select_batch_ownership_for_display_ids(
+                        file_meta, batch_source_content, selection_ids_to_apply
+                    )
+                except AtomicUnitError as e:
+                    # Translate selection IDs to gutter IDs and exit with user-friendly error
+                    if rendered:
+                        translate_atomic_unit_error_to_gutter_ids(e, rendered, "apply", batch_name)
+                    # No rendered context - show original error
+                    exit_with_error(_("Failed to apply batch '{name}': {error}").format(
+                        name=batch_name,
+                        error=str(e)
+                    ))
 
-            # Write merged content to working tree (bytes)
-            full_path.parent.mkdir(parents=True, exist_ok=True)
-            full_path.write_bytes(merged_content)
+                # If nothing selected for this file, skip it
+                if ownership.is_empty():
+                    continue
 
-        except MergeError:
-            # Merge conflict - batch created from different file version
-            failed_files.append(file_path)
-        except CommandError:
-            # Re-raise user errors (e.g., partial atomic selection)
-            raise
-        except Exception as e:
-            print(_("Error applying {file}: {error}").format(file=file_path, error=str(e)), file=sys.stderr)
-            failed_files.append(file_path)
+                # Perform structural merge
+                merged_content = merge_batch(
+                    batch_source_content,
+                    ownership,
+                    working_content
+                )
+
+                # Write merged content to working tree (bytes)
+                full_path.parent.mkdir(parents=True, exist_ok=True)
+                full_path.write_bytes(merged_content)
+
+            except MergeError:
+                # Merge conflict - batch created from different file version
+                failed_files.append(file_path)
+            except CommandError:
+                # Re-raise user errors (e.g., partial atomic selection)
+                raise
+            except Exception as e:
+                print(_("Error applying {file}: {error}").format(file=file_path, error=str(e)), file=sys.stderr)
+                failed_files.append(file_path)
 
     if failed_files:
         if len(failed_files) == 1:

--- a/src/git_stage_batch/commands/block_file.py
+++ b/src/git_stage_batch/commands/block_file.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import sys
+from contextlib import nullcontext
 
 from ..data.hunk_tracking import advance_to_and_show_next_change
+from ..data.undo import undo_checkpoint
 from ..exceptions import NoMoreHunks, exit_with_error
 from ..i18n import _
 from ..utils.file_io import append_file_path_to_file, remove_file_path_from_file
@@ -44,21 +46,27 @@ def command_block_file(file_path_arg: str = "") -> None:
 
     # Resolve to repo-relative path
     file_path = resolve_file_path_to_repo_relative(file_path_arg)
+    session_active = get_abort_head_file_path().exists()
+    checkpoint = (
+        undo_checkpoint(f"block-file {file_path}", worktree_paths=[".gitignore"])
+        if session_active else nullcontext()
+    )
 
-    # Add to .gitignore
-    add_file_to_gitignore(file_path)
+    with checkpoint:
+        # Add to .gitignore
+        add_file_to_gitignore(file_path)
 
-    # Remove from index if session is active and the file is a new intent-to-add entry
-    if get_abort_head_file_path().exists() and _is_new_intent_to_add_file(file_path):
-        run_git_command(["rm", "--cached", "--quiet", "--ignore-unmatch", "--", file_path], check=False)
-        remove_file_path_from_file(get_auto_added_files_file_path(), file_path)
+        # Remove from index if session is active and the file is a new intent-to-add entry
+        if session_active and _is_new_intent_to_add_file(file_path):
+            run_git_command(["rm", "--cached", "--quiet", "--ignore-unmatch", "--", file_path], check=False)
+            remove_file_path_from_file(get_auto_added_files_file_path(), file_path)
 
-    # Add to blocked-files state
-    append_file_path_to_file(get_blocked_files_file_path(), file_path)
+        # Add to blocked-files state
+        append_file_path_to_file(get_blocked_files_file_path(), file_path)
 
     print(_("Blocked file: {}").format(file_path), file=sys.stderr)
 
-    if get_abort_head_file_path().exists():
+    if session_active:
         try:
             advance_to_and_show_next_change()
         except NoMoreHunks:

--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -30,6 +30,7 @@ from ..data.hunk_tracking import (
 )
 from ..data.line_state import load_line_changes_from_state
 from ..data.session import require_session_started, snapshot_file_if_untracked
+from ..data.undo import undo_checkpoint
 from ..exceptions import exit_with_error, NoMoreHunks
 from ..i18n import _, ngettext
 from ..staging.operations import build_target_working_tree_content_bytes_with_discarded_lines
@@ -62,41 +63,99 @@ def command_discard(*, quiet: bool = False) -> None:
         if not quiet:
             print(_("No more hunks to process."), file=sys.stderr)
         return
+    with undo_checkpoint("discard"):
+        # Read cached hash
+        patch_hash = read_text_file_contents(get_selected_hunk_hash_file_path()).strip()
 
-    # Read cached hash
-    patch_hash = read_text_file_contents(get_selected_hunk_hash_file_path()).strip()
+        # Handle based on item type
+        if isinstance(item, BinaryFileChange):
+            # Binary file - restore from HEAD or delete
+            file_path = item.new_path if item.new_path != "/dev/null" else item.old_path
 
-    # Handle based on item type
-    if isinstance(item, BinaryFileChange):
-        # Binary file - restore from HEAD or delete
-        file_path = item.new_path if item.new_path != "/dev/null" else item.old_path
+            # Snapshot file if untracked before discarding
+            if file_path != "/dev/null":
+                snapshot_file_if_untracked(file_path)
+
+            log_journal("command_discard_binary_file", file_path=file_path, change_type=item.change_type)
+
+            if item.is_new_file():
+                # New file: delete from working tree
+                absolute_path = get_git_repository_root_path() / file_path
+                if absolute_path.exists():
+                    absolute_path.unlink()
+                    log_journal("command_discard_binary_deleted", file_path=file_path)
+            elif item.is_deleted_file():
+                # Deleted file: restore from HEAD
+                result = run_git_command(["checkout", "HEAD", "--", file_path], check=False)
+                if result.returncode != 0:
+                    print(_("Failed to restore binary file: {}").format(result.stderr), file=sys.stderr)
+                    return
+                log_journal("command_discard_binary_restored", file_path=file_path)
+            else:
+                # Modified file: restore from HEAD
+                result = run_git_command(["checkout", "HEAD", "--", file_path], check=False)
+                if result.returncode != 0:
+                    print(_("Failed to restore binary file: {}").format(result.stderr), file=sys.stderr)
+                    return
+                log_journal("command_discard_binary_restored", file_path=file_path)
+
+            # Add hash to blocklist
+            blocklist_path = get_block_list_file_path()
+            append_lines_to_file(blocklist_path, [patch_hash])
+
+            # Record for progress tracking
+            record_hunk_discarded(patch_hash)
+
+            if not quiet:
+                change_desc = "added" if item.is_new_file() else ("deleted" if item.is_deleted_file() else "modified")
+                print(_("✓ Binary file {desc} discarded: {file}").format(desc=change_desc, file=file_path), file=sys.stderr)
+
+            if quiet:
+                advance_to_next_change()
+            else:
+                advance_to_and_show_next_change()
+            return
+
+        # Text hunk - use git apply -R
+        patch_bytes = read_file_bytes(get_selected_hunk_patch_file_path())
+
+        # Extract filename for user feedback and snapshotting
+        line_changes = build_line_changes_from_patch_bytes(patch_bytes)
+        filename = line_changes.path
 
         # Snapshot file if untracked before discarding
-        if file_path != "/dev/null":
-            snapshot_file_if_untracked(file_path)
+        if filename != "/dev/null":
+            snapshot_file_if_untracked(filename)
 
-        log_journal("command_discard_binary_file", file_path=file_path, change_type=item.change_type)
+        # Apply the hunk in reverse to discard from working tree using streaming
+        log_journal("command_discard_before_git_apply", filename=filename, patch_hash=patch_hash)
+        stderr_chunks = []
+        exit_code = 0
 
-        if item.is_new_file():
-            # New file: delete from working tree
-            absolute_path = get_git_repository_root_path() / file_path
+        for event in stream_command(["git", "apply", "--reverse"], [patch_bytes]):
+            if isinstance(event, ExitEvent):
+                exit_code = event.exit_code
+            elif isinstance(event, OutputEvent):
+                if event.fd == 2:  # stderr
+                    stderr_chunks.append(event.data)
+
+        stderr_text = b"".join(stderr_chunks).decode('utf-8', errors='replace') if stderr_chunks else ""
+        log_journal("command_discard_after_git_apply", exit_code=exit_code, stderr_len=len(stderr_text), filename=filename)
+
+        if exit_code != 0:
+            log_journal("command_discard_git_apply_failed", exit_code=exit_code, stderr=stderr_text, filename=filename)
+            print(_("Failed to discard hunk: {}").format(stderr_text), file=sys.stderr)
+            return
+
+        # After reverse-applying a new file, delete it if it became empty
+        # (git apply -R on new files empties them but doesn't delete them)
+        is_new_file = b"--- /dev/null" in patch_bytes
+        if is_new_file:
+            absolute_path = get_git_repository_root_path() / filename
             if absolute_path.exists():
-                absolute_path.unlink()
-                log_journal("command_discard_binary_deleted", file_path=file_path)
-        elif item.is_deleted_file():
-            # Deleted file: restore from HEAD
-            result = run_git_command(["checkout", "HEAD", "--", file_path], check=False)
-            if result.returncode != 0:
-                print(_("Failed to restore binary file: {}").format(result.stderr), file=sys.stderr)
-                return
-            log_journal("command_discard_binary_restored", file_path=file_path)
-        else:
-            # Modified file: restore from HEAD
-            result = run_git_command(["checkout", "HEAD", "--", file_path], check=False)
-            if result.returncode != 0:
-                print(_("Failed to restore binary file: {}").format(result.stderr), file=sys.stderr)
-                return
-            log_journal("command_discard_binary_restored", file_path=file_path)
+                content = read_text_file_contents(absolute_path)
+                if not content.strip():  # File is empty
+                    absolute_path.unlink()
 
         # Add hash to blocklist
         blocklist_path = get_block_list_file_path()
@@ -105,73 +164,15 @@ def command_discard(*, quiet: bool = False) -> None:
         # Record for progress tracking
         record_hunk_discarded(patch_hash)
 
+        log_journal("command_discard_success", filename=filename, patch_hash=patch_hash)
+
         if not quiet:
-            change_desc = "added" if item.is_new_file() else ("deleted" if item.is_deleted_file() else "modified")
-            print(_("✓ Binary file {desc} discarded: {file}").format(desc=change_desc, file=file_path), file=sys.stderr)
+            print(_("✓ Hunk discarded from {file}").format(file=filename), file=sys.stderr)
 
         if quiet:
             advance_to_next_change()
         else:
             advance_to_and_show_next_change()
-        return
-
-    # Text hunk - use git apply -R
-    patch_bytes = read_file_bytes(get_selected_hunk_patch_file_path())
-
-    # Extract filename for user feedback and snapshotting
-    line_changes = build_line_changes_from_patch_bytes(patch_bytes)
-    filename = line_changes.path
-
-    # Snapshot file if untracked before discarding
-    if filename != "/dev/null":
-        snapshot_file_if_untracked(filename)
-
-    # Apply the hunk in reverse to discard from working tree using streaming
-    log_journal("command_discard_before_git_apply", filename=filename, patch_hash=patch_hash)
-    stderr_chunks = []
-    exit_code = 0
-
-    for event in stream_command(["git", "apply", "--reverse"], [patch_bytes]):
-        if isinstance(event, ExitEvent):
-            exit_code = event.exit_code
-        elif isinstance(event, OutputEvent):
-            if event.fd == 2:  # stderr
-                stderr_chunks.append(event.data)
-
-    stderr_text = b"".join(stderr_chunks).decode('utf-8', errors='replace') if stderr_chunks else ""
-    log_journal("command_discard_after_git_apply", exit_code=exit_code, stderr_len=len(stderr_text), filename=filename)
-
-    if exit_code != 0:
-        log_journal("command_discard_git_apply_failed", exit_code=exit_code, stderr=stderr_text, filename=filename)
-        print(_("Failed to discard hunk: {}").format(stderr_text), file=sys.stderr)
-        return
-
-    # After reverse-applying a new file, delete it if it became empty
-    # (git apply -R on new files empties them but doesn't delete them)
-    is_new_file = b"--- /dev/null" in patch_bytes
-    if is_new_file:
-        absolute_path = get_git_repository_root_path() / filename
-        if absolute_path.exists():
-            content = read_text_file_contents(absolute_path)
-            if not content.strip():  # File is empty
-                absolute_path.unlink()
-
-    # Add hash to blocklist
-    blocklist_path = get_block_list_file_path()
-    append_lines_to_file(blocklist_path, [patch_hash])
-
-    # Record for progress tracking
-    record_hunk_discarded(patch_hash)
-
-    log_journal("command_discard_success", filename=filename, patch_hash=patch_hash)
-
-    if not quiet:
-        print(_("✓ Hunk discarded from {file}").format(file=filename), file=sys.stderr)
-
-    if quiet:
-        advance_to_next_change()
-    else:
-        advance_to_and_show_next_change()
 
 
 def command_discard_file(file: str) -> None:
@@ -202,48 +203,48 @@ def command_discard_file(file: str) -> None:
     else:
         # Explicit path provided
         target_file = file
+    with undo_checkpoint(f"discard --file {file}".rstrip()):
+        # Load blocklist
+        blocklist_path = get_block_list_file_path()
+        blocklist_text = read_text_file_contents(blocklist_path)
+        blocked_hashes = set(blocklist_text.splitlines())
 
-    # Load blocklist
-    blocklist_path = get_block_list_file_path()
-    blocklist_text = read_text_file_contents(blocklist_path)
-    blocked_hashes = set(blocklist_text.splitlines())
+        # Snapshot the file if it's untracked (for abort functionality)
+        snapshot_file_if_untracked(target_file)
 
-    # Snapshot the file if it's untracked (for abort functionality)
-    snapshot_file_if_untracked(target_file)
+        # Stream through hunks and collect hashes from target file BEFORE removing it
+        # (git rm -f will stage the deletion, making hunks disappear from git diff)
+        hashes_to_block = []
+        for patch in parse_unified_diff_streaming(stream_git_command(["diff", f"-U{get_context_lines()}", "--no-color"])):
+            if patch.new_path != target_file:
+                continue
 
-    # Stream through hunks and collect hashes from target file BEFORE removing it
-    # (git rm -f will stage the deletion, making hunks disappear from git diff)
-    hashes_to_block = []
-    for patch in parse_unified_diff_streaming(stream_git_command(["diff", f"-U{get_context_lines()}", "--no-color"])):
-        if patch.new_path != target_file:
-            continue
+            patch_bytes = patch.to_patch_bytes()
+            patch_hash = compute_stable_hunk_hash(patch_bytes)
 
-        patch_bytes = patch.to_patch_bytes()
-        patch_hash = compute_stable_hunk_hash(patch_bytes)
+            if patch_hash not in blocked_hashes:
+                hashes_to_block.append(patch_hash)
 
-        if patch_hash not in blocked_hashes:
-            hashes_to_block.append(patch_hash)
+        # Remove the file from working tree
+        try:
+            subprocess.run(
+                ["git", "rm", "-f", target_file],
+                check=True,
+                capture_output=True,
+            )
+        except subprocess.CalledProcessError as e:
+            print(_("Failed to discard file: {}").format(e.stderr.decode("utf-8", errors="replace")), file=sys.stderr)
+            return
 
-    # Remove the file from working tree
-    try:
-        subprocess.run(
-            ["git", "rm", "-f", target_file],
-            check=True,
-            capture_output=True,
-        )
-    except subprocess.CalledProcessError as e:
-        print(_("Failed to discard file: {}").format(e.stderr.decode("utf-8", errors="replace")), file=sys.stderr)
-        return
+        # Mark all collected hashes as processed
+        for patch_hash in hashes_to_block:
+            append_lines_to_file(blocklist_path, [patch_hash])
+            # Record for progress tracking
+            record_hunk_discarded(patch_hash)
 
-    # Mark all collected hashes as processed
-    for patch_hash in hashes_to_block:
-        append_lines_to_file(blocklist_path, [patch_hash])
-        # Record for progress tracking
-        record_hunk_discarded(patch_hash)
+        print(_("✓ File discarded: {}").format(target_file), file=sys.stderr)
 
-    print(_("✓ File discarded: {}").format(target_file), file=sys.stderr)
-
-    advance_to_and_show_next_change()
+        advance_to_and_show_next_change()
 
 
 def command_discard_line(line_id_specification: str) -> None:
@@ -266,16 +267,16 @@ def command_discard_line(line_id_specification: str) -> None:
         working_bytes = working_file_path.read_bytes()
     else:
         exit_with_error(_("File not found in working tree: {file}").format(file=line_changes.path))
+    with undo_checkpoint(f"discard --line {line_id_specification}"):
+        # Build new working tree content with selected lines discarded
+        target_working_content = build_target_working_tree_content_bytes_with_discarded_lines(
+            line_changes, set(requested_ids), working_bytes)
 
-    # Build new working tree content with selected lines discarded
-    target_working_content = build_target_working_tree_content_bytes_with_discarded_lines(
-        line_changes, set(requested_ids), working_bytes)
+        # Write back to working tree
+        working_file_path.write_bytes(target_working_content)
 
-    # Write back to working tree
-    working_file_path.write_bytes(target_working_content)
-
-    # After modifying working tree, recalculate hunk for the SAME file
-    recalculate_selected_hunk_for_file(line_changes.path)
+        # After modifying working tree, recalculate hunk for the SAME file
+        recalculate_selected_hunk_for_file(line_changes.path)
 
     print(_("✓ Discarded line(s): {lines}").format(lines=line_id_specification), file=sys.stderr)
 
@@ -293,32 +294,37 @@ def command_discard_to_batch(batch_name: str, line_ids: str | None = None, file:
     """
     require_git_repository()
     ensure_state_directory_exists()
-
+    operation_parts = ["discard", "--to", batch_name]
+    if line_ids is not None:
+        operation_parts.extend(["--line", line_ids])
     if file is not None:
-        # File-scoped operation
+        operation_parts.extend(["--file", file])
+    with undo_checkpoint(" ".join(operation_parts)):
+        if file is not None:
+            # File-scoped operation
 
-        # Determine target file
-        if file == "":
-            # --file with no arg: use selected hunk's file
-            target_file = get_selected_change_file_path()
-            if target_file is None:
-                exit_with_error(_("No selected hunk. Run 'show' first or specify file path."))
-        else:
-            target_file = file
+            # Determine target file
+            if file == "":
+                # --file with no arg: use selected hunk's file
+                target_file = get_selected_change_file_path()
+                if target_file is None:
+                    exit_with_error(_("No selected hunk. Run 'show' first or specify file path."))
+            else:
+                target_file = file
 
-        if line_ids is None:
-            # --file without --line: discard entire file
-            _command_discard_file_to_batch(batch_name, target_file, quiet=quiet)
+            if line_ids is None:
+                # --file without --line: discard entire file
+                _command_discard_file_to_batch(batch_name, target_file, quiet=quiet)
+            else:
+                # --file with --line: discard specific lines from file
+                _command_discard_file_lines_to_batch(batch_name, target_file, line_ids, quiet=quiet)
         else:
-            # --file with --line: discard specific lines from file
-            _command_discard_file_lines_to_batch(batch_name, target_file, line_ids, quiet=quiet)
-    else:
-        # Hunk-scoped operation (selected behavior)
-        if line_ids is not None:
-            _command_discard_lines_to_batch(batch_name, line_ids, quiet=quiet)
-        else:
-            # Discard entire selected hunk
-            _command_discard_hunk_to_batch(batch_name, file_only=False, quiet=quiet)
+            # Hunk-scoped operation (selected behavior)
+            if line_ids is not None:
+                _command_discard_lines_to_batch(batch_name, line_ids, quiet=quiet)
+            else:
+                # Discard entire selected hunk
+                _command_discard_hunk_to_batch(batch_name, file_only=False, quiet=quiet)
 
 
 def _command_discard_file_to_batch(batch_name: str, file_path: str, *, quiet: bool = False) -> None:

--- a/src/git_stage_batch/commands/discard_from.py
+++ b/src/git_stage_batch/commands/discard_from.py
@@ -15,6 +15,7 @@ from ..batch.selection import (
 from ..batch.validation import batch_exists
 from ..data.hunk_tracking import render_batch_file_display
 from ..data.session import snapshot_file_if_untracked
+from ..data.undo import undo_checkpoint
 from ..exceptions import exit_with_error, MergeError, BatchMetadataError
 from ..i18n import _
 from ..utils.git import get_git_repository_root_path, require_git_repository, run_git_command
@@ -119,75 +120,80 @@ def command_discard_from_batch(batch_name: str, line_ids: Optional[str] = None, 
         baseline_commit = get_validated_baseline_commit(batch_name)
     except BatchMetadataError as e:
         exit_with_error(str(e))
+    operation_parts = ["discard", "--from", batch_name]
+    if line_ids is not None:
+        operation_parts.extend(["--line", line_ids])
+    if file is not None:
+        operation_parts.extend(["--file", file])
+    with undo_checkpoint(" ".join(operation_parts)):
+        # Discard all files in batch
+        repo_root = get_git_repository_root_path()
+        failed_files = []
 
-    # Discard all files in batch
-    repo_root = get_git_repository_root_path()
-    failed_files = []
+        for file_path, file_meta in files.items():
+            try:
+                # Snapshot file before modifying
+                snapshot_file_if_untracked(file_path)
 
-    for file_path, file_meta in files.items():
-        try:
-            # Snapshot file before modifying
-            snapshot_file_if_untracked(file_path)
+                # Binary files are atomic units - handle separately without ownership/merge logic
+                if file_meta.get("file_type") == "binary":
+                    _discard_binary_file_from_batch(file_path, baseline_commit)
+                    continue
 
-            # Binary files are atomic units - handle separately without ownership/merge logic
-            if file_meta.get("file_type") == "binary":
-                _discard_binary_file_from_batch(file_path, baseline_commit)
-                continue
+                # Get batch source commit content (as bytes)
+                batch_source_commit = file_meta["batch_source_commit"]
+                batch_source_result = run_git_command(
+                    ["show", f"{batch_source_commit}:{file_path}"],
+                    check=False,
+                    text_output=False
+                )
+                if batch_source_result.returncode != 0:
+                    failed_files.append(file_path)
+                    continue
+                batch_source_content = batch_source_result.stdout
 
-            # Get batch source commit content (as bytes)
-            batch_source_commit = file_meta["batch_source_commit"]
-            batch_source_result = run_git_command(
-                ["show", f"{batch_source_commit}:{file_path}"],
-                check=False,
-                text_output=False
-            )
-            if batch_source_result.returncode != 0:
+                # Get baseline content (as bytes)
+                baseline_result = run_git_command(
+                    ["show", f"{baseline_commit}:{file_path}"],
+                    check=False,
+                    text_output=False
+                )
+                baseline_content = baseline_result.stdout if baseline_result.returncode == 0 else b""
+
+                # Get selected working tree content (as bytes)
+                full_path = repo_root / file_path
+                if full_path.exists():
+                    working_content = full_path.read_bytes()
+                else:
+                    working_content = b""
+
+                # Get ownership from metadata, filtered by selected selection IDs if specified
+                ownership = select_batch_ownership_for_display_ids(
+                    file_meta, batch_source_content, selection_ids_to_discard
+                )
+
+                # If nothing selected for this file, skip it
+                if ownership.is_empty():
+                    continue
+
+                # Perform structural discard (inverse of merge)
+                discarded_content = discard_batch(
+                    batch_source_content,
+                    ownership,
+                    working_content,
+                    baseline_content
+                )
+
+                # Write to working tree (bytes)
+                full_path.parent.mkdir(parents=True, exist_ok=True)
+                full_path.write_bytes(discarded_content)
+
+            except MergeError as e:
+                print(_("Error discarding {file}: {error}").format(file=file_path, error=str(e)), file=sys.stderr)
                 failed_files.append(file_path)
-                continue
-            batch_source_content = batch_source_result.stdout
-
-            # Get baseline content (as bytes)
-            baseline_result = run_git_command(
-                ["show", f"{baseline_commit}:{file_path}"],
-                check=False,
-                text_output=False
-            )
-            baseline_content = baseline_result.stdout if baseline_result.returncode == 0 else b""
-
-            # Get selected working tree content (as bytes)
-            full_path = repo_root / file_path
-            if full_path.exists():
-                working_content = full_path.read_bytes()
-            else:
-                working_content = b""
-
-            # Get ownership from metadata, filtered by selected selection IDs if specified
-            ownership = select_batch_ownership_for_display_ids(
-                file_meta, batch_source_content, selection_ids_to_discard
-            )
-
-            # If nothing selected for this file, skip it
-            if ownership.is_empty():
-                continue
-
-            # Perform structural discard (inverse of merge)
-            discarded_content = discard_batch(
-                batch_source_content,
-                ownership,
-                working_content,
-                baseline_content
-            )
-
-            # Write to working tree (bytes)
-            full_path.parent.mkdir(parents=True, exist_ok=True)
-            full_path.write_bytes(discarded_content)
-
-        except MergeError as e:
-            print(_("Error discarding {file}: {error}").format(file=file_path, error=str(e)), file=sys.stderr)
-            failed_files.append(file_path)
-        except Exception as e:
-            print(_("Error discarding {file}: {error}").format(file=file_path, error=str(e)), file=sys.stderr)
-            failed_files.append(file_path)
+            except Exception as e:
+                print(_("Error discarding {file}: {error}").format(file=file_path, error=str(e)), file=sys.stderr)
+                failed_files.append(file_path)
 
     if failed_files:
         exit_with_error(

--- a/src/git_stage_batch/commands/drop.py
+++ b/src/git_stage_batch/commands/drop.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from ..batch import delete_batch
 import sys
+from ..data.undo import undo_checkpoint
 from ..i18n import _
 from ..utils.git import require_git_repository
 
@@ -11,5 +12,6 @@ from ..utils.git import require_git_repository
 def command_drop_batch(batch_name: str) -> None:
     """Delete a batch."""
     require_git_repository()
-    delete_batch(batch_name)
+    with undo_checkpoint(f"drop {batch_name}"):
+        delete_batch(batch_name)
     print(_("✓ Deleted batch '{name}'").format(name=batch_name), file=sys.stderr)

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -21,7 +21,9 @@ from ..core.models import BinaryFileChange
 from ..data.hunk_tracking import (
     advance_to_and_show_next_change,
     advance_to_next_change,
+    apply_line_level_batch_filter_to_cached_hunk,
     cache_file_as_single_hunk,
+    clear_selected_change_state_files,
     fetch_next_change,
     get_selected_change_file_path,
     recalculate_selected_hunk_for_file,
@@ -31,10 +33,10 @@ from ..data.hunk_tracking import (
 )
 from ..data.line_state import load_line_changes_from_state
 from ..data.session import require_session_started, snapshot_file_if_untracked
+from ..data.undo import undo_checkpoint
 from ..exceptions import NoMoreHunks, exit_with_error
 from ..i18n import _, ngettext
 from ..output import print_line_level_changes
-from ..output.hunk import print_line_level_changes as print_line_level_changes_from_hunk
 from ..staging.operations import build_target_index_content_bytes_with_selected_lines, update_index_with_blob_content
 from ..utils.command import ExitEvent, OutputEvent, stream_command
 from ..utils.file_io import append_lines_to_file, read_file_bytes, read_text_file_contents
@@ -67,19 +69,58 @@ def command_include(*, quiet: bool = False) -> None:
         if not quiet:
             print(_("No more hunks to process."), file=sys.stderr)
         return
+    with undo_checkpoint("include"):
+        # Read cached hash
+        patch_hash = read_text_file_contents(get_selected_hunk_hash_file_path()).strip()
 
-    # Read cached hash
-    patch_hash = read_text_file_contents(get_selected_hunk_hash_file_path()).strip()
+        # Handle based on item type
+        if isinstance(item, BinaryFileChange):
+            # Binary file - use git add
+            file_path = item.new_path if item.new_path != "/dev/null" else item.old_path
 
-    # Handle based on item type
-    if isinstance(item, BinaryFileChange):
-        # Binary file - use git add
-        file_path = item.new_path if item.new_path != "/dev/null" else item.old_path
+            # Stage the binary file using git add
+            result = run_git_command(["add", "--", file_path], check=False)
+            if result.returncode != 0:
+                print(_("Failed to stage binary file: {}").format(result.stderr), file=sys.stderr)
+                return
 
-        # Stage the binary file using git add
-        result = run_git_command(["add", "--", file_path], check=False)
-        if result.returncode != 0:
-            print(_("Failed to stage binary file: {}").format(result.stderr), file=sys.stderr)
+            # Add hash to blocklist
+            blocklist_path = get_block_list_file_path()
+            append_lines_to_file(blocklist_path, [patch_hash])
+
+            # Record for progress tracking
+            record_hunk_included(patch_hash)
+
+            if not quiet:
+                change_desc = "added" if item.is_new_file() else ("deleted" if item.is_deleted_file() else "modified")
+                print(_("✓ Binary file {desc}: {file}").format(desc=change_desc, file=file_path), file=sys.stderr)
+
+            if quiet:
+                advance_to_next_change()
+            else:
+                advance_to_and_show_next_change()
+            return
+
+        # Text hunk - use git apply (item is LineLevelChange here)
+        patch_bytes = read_file_bytes(get_selected_hunk_patch_file_path())
+
+        # Extract filename for user feedback (we already have LineLevelChange in item)
+        filename = item.path
+
+        # Apply the hunk to the index using streaming
+        stderr_chunks = []
+        exit_code = 0
+
+        for event in stream_command(["git", "apply", "--cached"], [patch_bytes]):
+            if isinstance(event, ExitEvent):
+                exit_code = event.exit_code
+            elif isinstance(event, OutputEvent):
+                if event.fd == 2:  # stderr
+                    stderr_chunks.append(event.data)
+
+        if exit_code != 0:
+            stderr_text = b"".join(stderr_chunks).decode('utf-8', errors='replace')
+            print(_("Failed to apply hunk: {}").format(stderr_text), file=sys.stderr)
             return
 
         # Add hash to blocklist
@@ -90,51 +131,12 @@ def command_include(*, quiet: bool = False) -> None:
         record_hunk_included(patch_hash)
 
         if not quiet:
-            change_desc = "added" if item.is_new_file() else ("deleted" if item.is_deleted_file() else "modified")
-            print(_("✓ Binary file {desc}: {file}").format(desc=change_desc, file=file_path), file=sys.stderr)
+            print(_("✓ Hunk staged from {file}").format(file=filename), file=sys.stderr)
 
         if quiet:
             advance_to_next_change()
         else:
             advance_to_and_show_next_change()
-        return
-
-    # Text hunk - use git apply (item is LineLevelChange here)
-    patch_bytes = read_file_bytes(get_selected_hunk_patch_file_path())
-
-    # Extract filename for user feedback (we already have LineLevelChange in item)
-    filename = item.path
-
-    # Apply the hunk to the index using streaming
-    stderr_chunks = []
-    exit_code = 0
-
-    for event in stream_command(["git", "apply", "--cached"], [patch_bytes]):
-        if isinstance(event, ExitEvent):
-            exit_code = event.exit_code
-        elif isinstance(event, OutputEvent):
-            if event.fd == 2:  # stderr
-                stderr_chunks.append(event.data)
-
-    if exit_code != 0:
-        stderr_text = b"".join(stderr_chunks).decode('utf-8', errors='replace')
-        print(_("Failed to apply hunk: {}").format(stderr_text), file=sys.stderr)
-        return
-
-    # Add hash to blocklist
-    blocklist_path = get_block_list_file_path()
-    append_lines_to_file(blocklist_path, [patch_hash])
-
-    # Record for progress tracking
-    record_hunk_included(patch_hash)
-
-    if not quiet:
-        print(_("✓ Hunk staged from {file}").format(file=filename), file=sys.stderr)
-
-    if quiet:
-        advance_to_next_change()
-    else:
-        advance_to_and_show_next_change()
 
 
 def command_include_file(file: str) -> None:
@@ -172,49 +174,49 @@ def command_include_file(file: str) -> None:
     else:
         # Explicit path provided
         target_file = file
+    with undo_checkpoint(f"include --file {file}".rstrip()):
+        # Load blocklist
+        blocklist_path = get_block_list_file_path()
+        blocklist_text = read_text_file_contents(blocklist_path)
+        blocked_hashes = set(blocklist_text.splitlines())
 
-    # Load blocklist
-    blocklist_path = get_block_list_file_path()
-    blocklist_text = read_text_file_contents(blocklist_path)
-    blocked_hashes = set(blocklist_text.splitlines())
+        # Stream through hunks and stage all from target file
+        hunks_staged = 0
+        for patch in parse_unified_diff_streaming(stream_git_command(["diff", "--no-color"])):
+            if patch.new_path != target_file:
+                continue
 
-    # Stream through hunks and stage all from target file
-    hunks_staged = 0
-    for patch in parse_unified_diff_streaming(stream_git_command(["diff", "--no-color"])):
-        if patch.new_path != target_file:
-            continue
+            patch_bytes = patch.to_patch_bytes()
+            patch_hash = compute_stable_hunk_hash(patch_bytes)
 
-        patch_bytes = patch.to_patch_bytes()
-        patch_hash = compute_stable_hunk_hash(patch_bytes)
+            # Skip if already blocked
+            if patch_hash in blocked_hashes:
+                continue
 
-        # Skip if already blocked
-        if patch_hash in blocked_hashes:
-            continue
+            # Apply the hunk to the index using streaming
+            stderr_chunks = []
+            exit_code = 0
 
-        # Apply the hunk to the index using streaming
-        stderr_chunks = []
-        exit_code = 0
+            for event in stream_command(["git", "apply", "--cached"], [patch_bytes]):
+                if isinstance(event, ExitEvent):
+                    exit_code = event.exit_code
+                elif isinstance(event, OutputEvent):
+                    if event.fd == 2:  # stderr
+                        stderr_chunks.append(event.data)
 
-        for event in stream_command(["git", "apply", "--cached"], [patch_bytes]):
-            if isinstance(event, ExitEvent):
-                exit_code = event.exit_code
-            elif isinstance(event, OutputEvent):
-                if event.fd == 2:  # stderr
-                    stderr_chunks.append(event.data)
+            if exit_code == 0:
+                # Add to blocklist so we don't try to stage it again
+                append_lines_to_file(blocklist_path, [patch_hash])
+                blocked_hashes.add(patch_hash)
 
-        if exit_code == 0:
-            # Add to blocklist so we don't try to stage it again
-            append_lines_to_file(blocklist_path, [patch_hash])
-            blocked_hashes.add(patch_hash)
+                # Record for progress tracking
+                record_hunk_included(patch_hash)
 
-            # Record for progress tracking
-            record_hunk_included(patch_hash)
-
-            hunks_staged += 1
-        else:
-            stderr_text = b"".join(stderr_chunks).decode('utf-8', errors='replace')
-            print(_("Failed to apply hunk: {error}").format(error=stderr_text), file=sys.stderr)
-            break
+                hunks_staged += 1
+            else:
+                stderr_text = b"".join(stderr_chunks).decode('utf-8', errors='replace')
+                print(_("Failed to apply hunk: {error}").format(error=stderr_text), file=sys.stderr)
+                break
 
     if hunks_staged == 0:
         print(_("No hunks staged from {file}").format(file=target_file), file=sys.stderr)
@@ -251,15 +253,15 @@ def command_include_line(line_id_specification: str) -> None:
 
     # Get base content from index snapshot (captured when hunk was loaded)
     base_bytes = read_file_bytes(get_index_snapshot_file_path())
+    with undo_checkpoint(f"include --line {line_id_specification}"):
+        target_index_content = build_target_index_content_bytes_with_selected_lines(line_changes, combined_include_ids, base_bytes)
+        update_index_with_blob_content(line_changes.path, target_index_content)
 
-    target_index_content = build_target_index_content_bytes_with_selected_lines(line_changes, combined_include_ids, base_bytes)
-    update_index_with_blob_content(line_changes.path, target_index_content)
+        # Update processed include IDs
+        write_line_ids_file(get_processed_include_ids_file_path(), combined_include_ids)
 
-    # Update processed include IDs
-    write_line_ids_file(get_processed_include_ids_file_path(), combined_include_ids)
-
-    # After modifying index, recalculate hunk for the SAME file
-    recalculate_selected_hunk_for_file(line_changes.path)
+        # After modifying index, recalculate hunk for the SAME file
+        recalculate_selected_hunk_for_file(line_changes.path)
 
     print(_("✓ Included line(s): {lines}").format(lines=line_id_specification), file=sys.stderr)
 
@@ -277,32 +279,37 @@ def command_include_to_batch(batch_name: str, line_ids: str | None = None, file:
     """
     require_git_repository()
     ensure_state_directory_exists()
-
+    operation_parts = ["include", "--to", batch_name]
+    if line_ids is not None:
+        operation_parts.extend(["--line", line_ids])
     if file is not None:
-        # File-scoped operation
+        operation_parts.extend(["--file", file])
+    with undo_checkpoint(" ".join(operation_parts)):
+        if file is not None:
+            # File-scoped operation
 
-        # Determine target file
-        if file == "":
-            # --file with no arg: use selected hunk's file
-            target_file = get_selected_change_file_path()
-            if target_file is None:
-                exit_with_error(_("No selected hunk. Run 'show' first or specify file path."))
-        else:
-            target_file = file
+            # Determine target file
+            if file == "":
+                # --file with no arg: use selected hunk's file
+                target_file = get_selected_change_file_path()
+                if target_file is None:
+                    exit_with_error(_("No selected hunk. Run 'show' first or specify file path."))
+            else:
+                target_file = file
 
-        if line_ids is None:
-            # --file without --line: include entire file
-            _command_include_file_to_batch(batch_name, target_file, quiet=quiet)
+            if line_ids is None:
+                # --file without --line: include entire file
+                _command_include_file_to_batch(batch_name, target_file, quiet=quiet)
+            else:
+                # --file with --line: include specific lines from file
+                _command_include_file_lines_to_batch(batch_name, target_file, line_ids, quiet=quiet)
         else:
-            # --file with --line: include specific lines from file
-            _command_include_file_lines_to_batch(batch_name, target_file, line_ids, quiet=quiet)
-    else:
-        # Hunk-scoped operation (selected behavior)
-        if line_ids is not None:
-            _command_include_lines_to_batch(batch_name, line_ids, quiet=quiet)
-        else:
-            # Include entire selected hunk
-            _command_include_hunk_to_batch(batch_name, file_only=False, quiet=quiet)
+            # Hunk-scoped operation (selected behavior)
+            if line_ids is not None:
+                _command_include_lines_to_batch(batch_name, line_ids, quiet=quiet)
+            else:
+                # Include entire selected hunk
+                _command_include_hunk_to_batch(batch_name, file_only=False, quiet=quiet)
 
 
 def _command_include_file_to_batch(batch_name: str, file_path: str, *, quiet: bool = False) -> None:

--- a/src/git_stage_batch/commands/include_from.py
+++ b/src/git_stage_batch/commands/include_from.py
@@ -15,6 +15,7 @@ from ..batch.selection import (
 )
 from ..batch.validation import batch_exists
 from ..data.hunk_tracking import render_batch_file_display
+from ..data.undo import undo_checkpoint
 from ..exceptions import exit_with_error, MergeError, CommandError, AtomicUnitError, BatchMetadataError
 from ..i18n import _
 from ..staging.operations import update_index_with_blob_content
@@ -73,73 +74,78 @@ def command_include_from_batch(batch_name: str, line_ids: Optional[str] = None, 
                     selection_ids_to_include.add(rendered.gutter_to_selection_id[gutter_id])
                 else:
                     exit_with_error(_("Line ID {id} not found or not individually mergeable").format(id=gutter_id))
+    operation_parts = ["include", "--from", batch_name]
+    if line_ids is not None:
+        operation_parts.extend(["--line", line_ids])
+    if file is not None:
+        operation_parts.extend(["--file", file])
+    with undo_checkpoint(" ".join(operation_parts)):
+        # Apply all files in batch
+        failed_files = []
 
-    # Apply all files in batch
-    failed_files = []
-
-    for file_path, file_meta in files.items():
-        try:
-            # Get batch source commit content (as bytes)
-            batch_source_commit = file_meta["batch_source_commit"]
-            batch_source_result = run_git_command(
-                ["show", f"{batch_source_commit}:{file_path}"],
-                check=False,
-                text_output=False
-            )
-            if batch_source_result.returncode != 0:
-                failed_files.append(file_path)
-                continue
-            batch_source_content = batch_source_result.stdout
-
-            # Get selected index content (as bytes)
-            index_result = run_git_command(
-                ["show", f":{file_path}"],
-                check=False,
-                text_output=False
-            )
-            if index_result.returncode == 0:
-                index_content = index_result.stdout
-            else:
-                index_content = b""
-
-            # Get ownership from metadata, filtered by selected selection IDs if specified
+        for file_path, file_meta in files.items():
             try:
-                ownership = select_batch_ownership_for_display_ids(
-                    file_meta, batch_source_content, selection_ids_to_include
+                # Get batch source commit content (as bytes)
+                batch_source_commit = file_meta["batch_source_commit"]
+                batch_source_result = run_git_command(
+                    ["show", f"{batch_source_commit}:{file_path}"],
+                    check=False,
+                    text_output=False
                 )
-            except AtomicUnitError as e:
-                # Translate selection IDs to gutter IDs and exit with user-friendly error
-                if rendered:
-                    translate_atomic_unit_error_to_gutter_ids(e, rendered, "include from", batch_name)
-                # No rendered context - show original error
-                exit_with_error(_("Failed to include from batch '{name}': {error}").format(
-                    name=batch_name,
-                    error=str(e)
-                ))
+                if batch_source_result.returncode != 0:
+                    failed_files.append(file_path)
+                    continue
+                batch_source_content = batch_source_result.stdout
 
-            # If nothing selected for this file, skip it
-            if ownership.is_empty():
-                continue
+                # Get selected index content (as bytes)
+                index_result = run_git_command(
+                    ["show", f":{file_path}"],
+                    check=False,
+                    text_output=False
+                )
+                if index_result.returncode == 0:
+                    index_content = index_result.stdout
+                else:
+                    index_content = b""
 
-            # Perform structural merge
-            merged_content = merge_batch(
-                batch_source_content,
-                ownership,
-                index_content
-            )
+                # Get ownership from metadata, filtered by selected selection IDs if specified
+                try:
+                    ownership = select_batch_ownership_for_display_ids(
+                        file_meta, batch_source_content, selection_ids_to_include
+                    )
+                except AtomicUnitError as e:
+                    # Translate selection IDs to gutter IDs and exit with user-friendly error
+                    if rendered:
+                        translate_atomic_unit_error_to_gutter_ids(e, rendered, "include from", batch_name)
+                    # No rendered context - show original error
+                    exit_with_error(_("Failed to include from batch '{name}': {error}").format(
+                        name=batch_name,
+                        error=str(e)
+                    ))
 
-            # Update index with merged content
-            update_index_with_blob_content(file_path, merged_content)
+                # If nothing selected for this file, skip it
+                if ownership.is_empty():
+                    continue
 
-        except MergeError:
-            # Merge conflict - batch created from different file version
-            failed_files.append(file_path)
-        except CommandError:
-            # Re-raise user errors (e.g., partial atomic selection)
-            raise
-        except Exception as e:
-            print(_("Error staging {file}: {error}").format(file=file_path, error=str(e)), file=sys.stderr)
-            failed_files.append(file_path)
+                # Perform structural merge
+                merged_content = merge_batch(
+                    batch_source_content,
+                    ownership,
+                    index_content
+                )
+
+                # Update index with merged content
+                update_index_with_blob_content(file_path, merged_content)
+
+            except MergeError:
+                # Merge conflict - batch created from different file version
+                failed_files.append(file_path)
+            except CommandError:
+                # Re-raise user errors (e.g., partial atomic selection)
+                raise
+            except Exception as e:
+                print(_("Error staging {file}: {error}").format(file=file_path, error=str(e)), file=sys.stderr)
+                failed_files.append(file_path)
 
     if failed_files:
         if len(failed_files) == 1:

--- a/src/git_stage_batch/commands/new.py
+++ b/src/git_stage_batch/commands/new.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from ..batch import create_batch
 import sys
+from ..data.undo import undo_checkpoint
 from ..i18n import _
 from ..utils.git import require_git_repository
 
@@ -11,5 +12,6 @@ from ..utils.git import require_git_repository
 def command_new_batch(batch_name: str, note: str = "") -> None:
     """Create a new batch."""
     require_git_repository()
-    create_batch(batch_name, note)
+    with undo_checkpoint(f"new {batch_name}"):
+        create_batch(batch_name, note)
     print(_("✓ Created batch '{name}'").format(name=batch_name), file=sys.stderr)

--- a/src/git_stage_batch/commands/redo.py
+++ b/src/git_stage_batch/commands/redo.py
@@ -1,0 +1,19 @@
+"""Redo command implementation."""
+
+from __future__ import annotations
+
+import sys
+
+from ..data.session import require_session_started
+from ..data.undo import redo_last_checkpoint
+from ..i18n import _
+from ..utils.git import require_git_repository
+
+
+def command_redo(*, force: bool = False) -> None:
+    """Redo the most recently undone session operation."""
+    require_git_repository()
+    require_session_started()
+
+    operation = redo_last_checkpoint(force=force)
+    print(_("✓ Redid: {operation}").format(operation=operation), file=sys.stderr)

--- a/src/git_stage_batch/commands/reset.py
+++ b/src/git_stage_batch/commands/reset.py
@@ -24,6 +24,7 @@ from ..batch.storage import (
     copy_file_from_batch_to_batch,
     remove_file_from_batch,
 )
+from ..batch.state_refs import sync_batch_state_refs
 from ..batch.validation import batch_exists, validate_batch_name
 from ..exceptions import MergeError, exit_with_error
 from ..i18n import _
@@ -333,3 +334,4 @@ def _reset_all_claims_from_batch(batch_name: str) -> None:
     metadata["files"] = {}
     metadata_path = get_batch_metadata_file_path(batch_name)
     write_text_file_contents(metadata_path, json.dumps(metadata, indent=2))
+    sync_batch_state_refs(batch_name)

--- a/src/git_stage_batch/commands/reset.py
+++ b/src/git_stage_batch/commands/reset.py
@@ -28,6 +28,7 @@ from ..batch.state_refs import sync_batch_state_refs
 from ..batch.validation import batch_exists, validate_batch_name
 from ..exceptions import MergeError, exit_with_error
 from ..i18n import _
+from ..data.undo import undo_checkpoint
 from ..utils.file_io import write_text_file_contents
 from ..utils.git import require_git_repository, run_git_command
 from ..utils.paths import (
@@ -62,13 +63,22 @@ def command_reset_from_batch(
         validate_batch_name(to_batch)
         if to_batch == batch_name:
             exit_with_error(_("--to must name a different batch"))
-        _move_claims_between_batches(batch_name, to_batch, file, line_ids)
-    elif file is not None:
-        _reset_file_claims_from_batch(batch_name, file, line_ids)
-    elif line_ids is not None:
-        _reset_line_claims_from_batch(batch_name, line_ids)
-    else:
-        _reset_all_claims_from_batch(batch_name)
+    operation_parts = ["reset", "--from", batch_name]
+    if to_batch is not None:
+        operation_parts.extend(["--to", to_batch])
+    if line_ids is not None:
+        operation_parts.extend(["--line", line_ids])
+    if file is not None:
+        operation_parts.extend(["--file", file])
+    with undo_checkpoint(" ".join(operation_parts)):
+        if to_batch is not None:
+            _move_claims_between_batches(batch_name, to_batch, file, line_ids)
+        elif file is not None:
+            _reset_file_claims_from_batch(batch_name, file, line_ids)
+        elif line_ids is not None:
+            _reset_line_claims_from_batch(batch_name, line_ids)
+        else:
+            _reset_all_claims_from_batch(batch_name)
 
     if to_batch is not None and line_ids:
         print(_("✓ Moved line(s) {lines} from batch '{source}' to '{dest}'").format(

--- a/src/git_stage_batch/commands/sift.py
+++ b/src/git_stage_batch/commands/sift.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 
 import json
 import os
-import shutil
 import subprocess
 import sys
 import tempfile
@@ -35,13 +34,18 @@ from ..batch.metadata_validation import read_validated_batch_metadata
 from ..batch.operations import create_batch, delete_batch
 from ..batch.ownership import BatchOwnership, DeletionClaim
 from ..batch.query import get_batch_baseline_commit, read_batch_metadata
+from ..batch.state_refs import (
+    delete_batch_state_refs,
+    get_batch_content_ref_name,
+    sync_batch_state_refs,
+)
 from ..batch.storage import add_binary_file_to_batch, _build_realized_content, _update_batch_commit
 from ..batch.validation import batch_exists, validate_batch_name
 from ..core.line_selection import format_line_ids
 from ..core.models import BinaryFileChange
 from ..exceptions import BatchMetadataError, exit_with_error
 from ..i18n import _
-from ..utils.file_io import read_text_file_contents, write_text_file_contents
+from ..utils.file_io import write_text_file_contents
 from ..utils.git import (
     create_git_blob,
     get_git_repository_root_path,
@@ -49,9 +53,7 @@ from ..utils.git import (
     run_git_command,
 )
 from ..utils.paths import (
-    get_batch_directory_path,
     get_batch_metadata_file_path,
-    get_batches_directory_path,
 )
 
 
@@ -60,9 +62,9 @@ def _set_batch_baseline(
     baseline_commit: str,
 ) -> None:
     """Update a batch's baseline commit in metadata."""
-    metadata_path = get_batch_metadata_file_path(batch_name)
-    metadata = json.loads(read_text_file_contents(metadata_path))
+    metadata = read_batch_metadata(batch_name)
     metadata["baseline"] = baseline_commit
+    metadata_path = get_batch_metadata_file_path(batch_name)
     write_text_file_contents(metadata_path, json.dumps(metadata, indent=2))
 
 
@@ -362,36 +364,15 @@ def _perform_atomic_in_place_sift(
                     file_mode=file_meta.get("mode", "100644"),
                 )
 
-        source_dir = get_batch_directory_path(batch_name)
-        temp_dir = get_batch_directory_path(temp_batch_name)
-        batches_dir = get_batches_directory_path()
-        backup_dir = batches_dir / f"{batch_name}-sift-backup"
+        temp_commit = run_git_command(["rev-parse", get_batch_content_ref_name(temp_batch_name)], check=False)
+        if temp_commit.returncode == 0:
+            commit_sha = temp_commit.stdout.strip()
+            temp_metadata = read_batch_metadata(temp_batch_name)
+            metadata_path = get_batch_metadata_file_path(batch_name)
+            write_text_file_contents(metadata_path, json.dumps(temp_metadata, indent=2))
+            sync_batch_state_refs(batch_name, content_commit=commit_sha)
 
-        if backup_dir.exists():
-            shutil.rmtree(backup_dir)
-
-        shutil.move(str(source_dir), str(backup_dir))
-
-        try:
-            shutil.move(str(temp_dir), str(source_dir))
-            shutil.rmtree(backup_dir)
-
-            temp_commit = run_git_command(
-                ["rev-parse", f"refs/batches/{temp_batch_name}"],
-                check=False,
-            )
-            if temp_commit.returncode == 0:
-                run_git_command(
-                    ["update-ref", f"refs/batches/{batch_name}", temp_commit.stdout.strip()]
-                )
-
-            run_git_command(["update-ref", "-d", f"refs/batches/{temp_batch_name}"], check=False)
-        except Exception:
-            if backup_dir.exists():
-                if source_dir.exists():
-                    shutil.rmtree(source_dir)
-                shutil.move(str(backup_dir), str(source_dir))
-            raise
+        delete_batch_state_refs(temp_batch_name)
 
     except Exception:
         if batch_exists(temp_batch_name):

--- a/src/git_stage_batch/commands/skip.py
+++ b/src/git_stage_batch/commands/skip.py
@@ -10,6 +10,7 @@ from ..core.line_selection import parse_line_selection, read_line_ids_file, writ
 from ..core.models import BinaryFileChange
 from ..data.hunk_tracking import advance_to_and_show_next_change, advance_to_next_change, fetch_next_change, record_hunk_skipped, require_selected_hunk
 from ..data.session import require_session_started
+from ..data.undo import undo_checkpoint
 from ..exceptions import NoMoreHunks
 from ..i18n import _, ngettext
 from ..utils.file_io import append_lines_to_file, read_text_file_contents
@@ -39,48 +40,48 @@ def command_skip(*, quiet: bool = False) -> None:
         if not quiet:
             print(_("No more hunks to process."), file=sys.stderr)
         return
+    with undo_checkpoint("skip"):
+        # Read cached hash
+        patch_hash = read_text_file_contents(get_selected_hunk_hash_file_path()).strip()
 
-    # Read cached hash
-    patch_hash = read_text_file_contents(get_selected_hunk_hash_file_path()).strip()
+        # Handle based on item type
+        if isinstance(item, BinaryFileChange):
+            # Binary file - just add to blocklist
+            file_path = item.new_path if item.new_path != "/dev/null" else item.old_path
 
-    # Handle based on item type
-    if isinstance(item, BinaryFileChange):
-        # Binary file - just add to blocklist
-        file_path = item.new_path if item.new_path != "/dev/null" else item.old_path
+            # Add hash to blocklist (without staging)
+            blocklist_path = get_block_list_file_path()
+            append_lines_to_file(blocklist_path, [patch_hash])
+
+            # Binary files don't have line-level tracking, so skip record_hunk_skipped
+
+            if not quiet:
+                change_desc = "added" if item.is_new_file() else ("deleted" if item.is_deleted_file() else "modified")
+                print(_("✓ Binary file {desc} skipped: {file}").format(desc=change_desc, file=file_path), file=sys.stderr)
+
+            if quiet:
+                advance_to_next_change()
+            else:
+                advance_to_and_show_next_change()
+            return
+
+        # Text hunk - item is LineLevelChange here
+        filename = item.path
 
         # Add hash to blocklist (without staging)
         blocklist_path = get_block_list_file_path()
         append_lines_to_file(blocklist_path, [patch_hash])
 
-        # Binary files don't have line-level tracking, so skip record_hunk_skipped
+        # Record for progress tracking
+        record_hunk_skipped(item, patch_hash)
 
         if not quiet:
-            change_desc = "added" if item.is_new_file() else ("deleted" if item.is_deleted_file() else "modified")
-            print(_("✓ Binary file {desc} skipped: {file}").format(desc=change_desc, file=file_path), file=sys.stderr)
+            print(_("✓ Hunk skipped from {file}").format(file=filename), file=sys.stderr)
 
         if quiet:
             advance_to_next_change()
         else:
             advance_to_and_show_next_change()
-        return
-
-    # Text hunk - item is LineLevelChange here
-    filename = item.path
-
-    # Add hash to blocklist (without staging)
-    blocklist_path = get_block_list_file_path()
-    append_lines_to_file(blocklist_path, [patch_hash])
-
-    # Record for progress tracking
-    record_hunk_skipped(item, patch_hash)
-
-    if not quiet:
-        print(_("✓ Hunk skipped from {file}").format(file=filename), file=sys.stderr)
-
-    if quiet:
-        advance_to_next_change()
-    else:
-        advance_to_and_show_next_change()
 
 
 def command_skip_file() -> None:
@@ -106,33 +107,33 @@ def command_skip_file() -> None:
     if target_file is None:
         print(_("No changes to process."), file=sys.stderr)
         return
+    with undo_checkpoint("skip --file"):
+        # Stream through hunks and skip all from target file
+        hunks_skipped = 0
+        for patch in parse_unified_diff_streaming(stream_git_command(["diff", f"-U{get_context_lines()}", "--no-color"])):
+            if patch.new_path != target_file:
+                continue
 
-    # Stream through hunks and skip all from target file
-    hunks_skipped = 0
-    for patch in parse_unified_diff_streaming(stream_git_command(["diff", f"-U{get_context_lines()}", "--no-color"])):
-        if patch.new_path != target_file:
-            continue
+            patch_bytes = patch.to_patch_bytes()
+            patch_hash = compute_stable_hunk_hash(patch_bytes)
 
-        patch_bytes = patch.to_patch_bytes()
-        patch_hash = compute_stable_hunk_hash(patch_bytes)
+            # Skip if already blocked
+            if patch_hash in blocked_hashes:
+                continue
 
-        # Skip if already blocked
-        if patch_hash in blocked_hashes:
-            continue
+            # Add to blocklist without staging
+            append_lines_to_file(blocklist_path, [patch_hash])
+            blocked_hashes.add(patch_hash)
+            hunks_skipped += 1
 
-        # Add to blocklist without staging
-        append_lines_to_file(blocklist_path, [patch_hash])
-        blocked_hashes.add(patch_hash)
-        hunks_skipped += 1
+        msg = ngettext(
+            "✓ Skipped {count} hunk from {file}",
+            "✓ Skipped {count} hunks from {file}",
+            hunks_skipped
+        ).format(count=hunks_skipped, file=target_file)
+        print(msg, file=sys.stderr)
 
-    msg = ngettext(
-        "✓ Skipped {count} hunk from {file}",
-        "✓ Skipped {count} hunks from {file}",
-        hunks_skipped
-    ).format(count=hunks_skipped, file=target_file)
-    print(msg, file=sys.stderr)
-
-    advance_to_and_show_next_change()
+        advance_to_and_show_next_change()
 
 
 def command_skip_line(line_id_specification: str) -> None:
@@ -149,8 +150,8 @@ def command_skip_line(line_id_specification: str) -> None:
     requested_ids = parse_line_selection(line_id_specification)
     already_skipped_ids = set(read_line_ids_file(get_processed_skip_ids_file_path()))
     combined_skip_ids = already_skipped_ids | set(requested_ids)
-
-    # Update processed skip IDs
-    write_line_ids_file(get_processed_skip_ids_file_path(), combined_skip_ids)
+    with undo_checkpoint(f"skip --line {line_id_specification}"):
+        # Update processed skip IDs
+        write_line_ids_file(get_processed_skip_ids_file_path(), combined_skip_ids)
 
     print(_("✓ Skipped line(s): {lines}").format(lines=line_id_specification), file=sys.stderr)

--- a/src/git_stage_batch/commands/unblock_file.py
+++ b/src/git_stage_batch/commands/unblock_file.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import sys
+from contextlib import nullcontext
 
 from ..data.hunk_tracking import advance_to_and_show_next_change
+from ..data.undo import undo_checkpoint
 from ..exceptions import NoMoreHunks, exit_with_error
 from ..i18n import _
 from ..utils.file_io import append_file_path_to_file, remove_file_path_from_file
@@ -34,25 +36,31 @@ def command_unblock_file(file_path_arg: str) -> None:
 
     # Resolve to repo-relative path
     file_path = resolve_file_path_to_repo_relative(file_path_arg)
+    session_active = get_abort_head_file_path().exists()
+    checkpoint = (
+        undo_checkpoint(f"unblock-file {file_path}", worktree_paths=[".gitignore"])
+        if session_active else nullcontext()
+    )
 
-    # Remove from .gitignore
-    removed_from_gitignore = remove_file_from_gitignore(file_path)
+    with checkpoint:
+        # Remove from .gitignore
+        removed_from_gitignore = remove_file_from_gitignore(file_path)
 
-    # Remove from blocked-files state
-    remove_file_path_from_file(get_blocked_files_file_path(), file_path)
+        # Remove from blocked-files state
+        remove_file_path_from_file(get_blocked_files_file_path(), file_path)
 
-    # Re-add new untracked files as intent-to-add if session is active
-    if get_abort_head_file_path().exists() and _is_absent_from_head(file_path) and _is_absent_from_index(file_path):
-        result = run_git_command(["add", "-N", "--", file_path], check=False)
-        if result.returncode == 0:
-            append_file_path_to_file(get_auto_added_files_file_path(), file_path)
+        # Re-add new untracked files as intent-to-add if session is active
+        if session_active and _is_absent_from_head(file_path) and _is_absent_from_index(file_path):
+            result = run_git_command(["add", "-N", "--", file_path], check=False)
+            if result.returncode == 0:
+                append_file_path_to_file(get_auto_added_files_file_path(), file_path)
 
     if removed_from_gitignore:
         print(f"Unblocked file: {file_path}", file=sys.stderr)
     else:
         print(f"Removed from blocked list: {file_path} (was not in .gitignore)", file=sys.stderr)
 
-    if get_abort_head_file_path().exists():
+    if session_active:
         try:
             advance_to_and_show_next_change()
         except NoMoreHunks:

--- a/src/git_stage_batch/commands/undo.py
+++ b/src/git_stage_batch/commands/undo.py
@@ -1,0 +1,19 @@
+"""Undo command implementation."""
+
+from __future__ import annotations
+
+import sys
+
+from ..data.session import require_session_started
+from ..data.undo import undo_last_checkpoint
+from ..i18n import _
+from ..utils.git import require_git_repository
+
+
+def command_undo(*, force: bool = False) -> None:
+    """Undo the most recent undoable session operation."""
+    require_git_repository()
+    require_session_started()
+
+    operation = undo_last_checkpoint(force=force)
+    print(_("✓ Undid: {operation}").format(operation=operation), file=sys.stderr)

--- a/src/git_stage_batch/core/diff_parser.py
+++ b/src/git_stage_batch/core/diff_parser.py
@@ -9,6 +9,7 @@ from typing import Iterable, Iterator, Optional, Union
 from .models import BinaryFileChange, LineLevelChange, HunkHeader, LineEntry, SingleHunkPatch
 from ..exceptions import exit_with_error
 from ..i18n import _
+from ..utils.file_io import write_file_bytes
 from ..utils.git import get_git_repository_root_path, run_git_command, stream_git_command
 from ..utils.journal import log_journal
 from ..utils.paths import get_index_snapshot_file_path, get_working_tree_snapshot_file_path
@@ -282,8 +283,8 @@ def write_snapshots_for_selected_file_path(file_path: str) -> None:
                 index_version = head_version
 
     # Write snapshots as bytes
-    get_index_snapshot_file_path().write_bytes(index_version)
-    get_working_tree_snapshot_file_path().write_bytes(working_tree_version)
+    write_file_bytes(get_index_snapshot_file_path(), index_version)
+    write_file_bytes(get_working_tree_snapshot_file_path(), working_tree_version)
 
     log_journal(
         "write_snapshots_for_selected_file",

--- a/src/git_stage_batch/data/batch_refs.py
+++ b/src/git_stage_batch/data/batch_refs.py
@@ -6,13 +6,51 @@ import json
 import shutil
 from typing import Any
 
+from ..batch.ref_names import BATCH_CONTENT_REF_PREFIX, LEGACY_BATCH_REF_PREFIX
+from ..batch.query import read_batch_metadata
+from ..batch.state_refs import (
+    delete_batch_state_refs,
+    get_batch_content_ref_name,
+    get_batch_state_ref_name,
+    remove_file_backed_batch_metadata,
+    sync_batch_state_refs,
+)
 from ..utils.file_io import read_text_file_contents, write_text_file_contents
-from ..utils.git import run_git_command
+from ..utils.git import run_git_command, update_git_refs
 from ..utils.paths import (
     get_batch_directory_path,
     get_batch_metadata_file_path,
     get_batch_refs_snapshot_file_path,
 )
+
+
+def _list_batch_content_refs() -> dict[str, str]:
+    refs: dict[str, str] = {}
+    prefixes = (
+        (BATCH_CONTENT_REF_PREFIX, len(BATCH_CONTENT_REF_PREFIX)),
+        (LEGACY_BATCH_REF_PREFIX, len(LEGACY_BATCH_REF_PREFIX)),
+    )
+    for prefix, prefix_len in prefixes:
+        result = run_git_command(["for-each-ref", "--format=%(objectname) %(refname)", prefix], check=False)
+        if result.returncode != 0:
+            continue
+        for line in result.stdout.strip().splitlines():
+            if not line:
+                continue
+            commit_sha, ref = line.split(None, 1)
+            if ref.startswith(prefix):
+                refs.setdefault(ref[prefix_len:], commit_sha)
+    return refs
+
+
+def _get_batch_state_ref_commit(batch_name: str) -> str | None:
+    result = run_git_command(
+        ["rev-parse", "--verify", get_batch_state_ref_name(batch_name)],
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
 
 
 def snapshot_batch_refs() -> None:
@@ -23,35 +61,13 @@ def snapshot_batch_refs() -> None:
 
     This includes complete metadata so dropped batches can be fully restored.
     """
-    # Get all batch refs
-    result = run_git_command(["for-each-ref", "--format=%(objectname) %(refname)", "refs/batches/"], check=False)
-    if result.returncode != 0:
-        # No batches exist, save empty snapshot
-        snapshot_data: dict[str, Any] = {}
-        write_text_file_contents(get_batch_refs_snapshot_file_path(), json.dumps(snapshot_data))
-        return
-
     snapshot_data = {}
-    for line in result.stdout.strip().splitlines():
-        if not line:
-            continue
-        commit_sha, ref = line.split(None, 1)
-        if not ref.startswith("refs/batches/"):
-            continue
-
-        batch_name = ref[len("refs/batches/"):]
-
-        # Read complete metadata if it exists
-        metadata_path = get_batch_metadata_file_path(batch_name)
-        full_metadata = {}
-        if metadata_path.exists():
-            try:
-                full_metadata = json.loads(read_text_file_contents(metadata_path))
-            except (json.JSONDecodeError, KeyError):
-                pass
+    for batch_name, commit_sha in _list_batch_content_refs().items():
+        full_metadata = read_batch_metadata(batch_name)
 
         snapshot_data[batch_name] = {
             "commit_sha": commit_sha,
+            "state_commit_sha": _get_batch_state_ref_commit(batch_name),
             "metadata": full_metadata
         }
 
@@ -77,22 +93,12 @@ def restore_batch_refs() -> None:
         return
 
     # Get selected batch refs
-    selected_batches: dict[str, str] = {}
-    result = run_git_command(["for-each-ref", "--format=%(objectname) %(refname)", "refs/batches/"], check=False)
-    if result.returncode == 0:
-        for line in result.stdout.strip().splitlines():
-            if not line:
-                continue
-            commit_sha, ref = line.split(None, 1)
-            if ref.startswith("refs/batches/"):
-                batch_name = ref[len("refs/batches/"):]
-                selected_batches[batch_name] = commit_sha
+    selected_batches = _list_batch_content_refs()
 
     # Drop batches created during session (in selected but not in snapshot)
     for batch_name in selected_batches:
         if batch_name not in snapshot_data:
-            # Delete ref
-            run_git_command(["update-ref", "-d", f"refs/batches/{batch_name}"], check=False)
+            delete_batch_state_refs(batch_name)
             # Delete metadata directory
             metadata_dir = get_batch_directory_path(batch_name)
             if metadata_dir.exists():
@@ -101,11 +107,21 @@ def restore_batch_refs() -> None:
     # Restore/revert batches from snapshot
     for batch_name, batch_state in snapshot_data.items():
         commit_sha = batch_state["commit_sha"]
+        state_commit_sha = batch_state.get("state_commit_sha")
         full_metadata = batch_state.get("metadata", {})
-
-        # Restore or revert ref
-        run_git_command(["update-ref", f"refs/batches/{batch_name}", commit_sha])
 
         # Restore complete metadata
         metadata_path = get_batch_metadata_file_path(batch_name)
         write_text_file_contents(metadata_path, json.dumps(full_metadata, indent=2))
+
+        if state_commit_sha:
+            update_git_refs(
+                updates=[
+                    (get_batch_content_ref_name(batch_name), commit_sha),
+                    (get_batch_state_ref_name(batch_name), state_commit_sha),
+                ],
+                deletes=[f"{LEGACY_BATCH_REF_PREFIX}{batch_name}"],
+            )
+            remove_file_backed_batch_metadata(batch_name)
+        else:
+            sync_batch_state_refs(batch_name, content_commit=commit_sha)

--- a/src/git_stage_batch/data/session.py
+++ b/src/git_stage_batch/data/session.py
@@ -31,39 +31,14 @@ PERMANENT_DIRS = frozenset({"batches", "batch-sources"})
 
 # Iteration-specific state (cleared by again, stop, abort)
 ITERATION_STATE_FILES = [
-    "selected-hunk-hash",
-    "selected-hunk-patch",
-    "selected-lines.json",
-    "selected-binary-file.json",
-    "index-snapshot",
-    "working-tree-snapshot",
-    "blocklist",
-    "discarded-hunks",
-    "included-hunks",
-    "skipped-hunks.jsonl",
-    "batched-hunks",
-    "blocked-files",
-    "processed.skip",
-    "processed.include",
-    "processed.batch",
+    "session/selected",
+    "session/progress",
+    "session/processed",
 ]
 
 # Session-level state (cleared by stop and abort, preserved by again)
 SESSION_STATE_FILES = [
-    "abort-head",
-    "abort-stash",
-    "snapshot-list",
-    "snapshots",  # directory
-    "auto-added-files",
-    "intent-to-add-files",
-    "iteration-count",
-    "start-head",
-    "start-index-tree",
-    "start-batch-refs.json",
-    "context-lines",
-    "suggest-fixup-state.json",
-    "session-batch-sources.json",
-    "batch-refs-snapshot.json",
+    "session",
     "journal.jsonl",
 ]
 
@@ -109,7 +84,7 @@ def _snapshot_intent_to_add_files() -> tuple[list[str], list[str]]:
 
     # Save list of intent-to-add files for abort restoration
     if all_intent_to_add_files:
-        intent_to_add_file = get_state_directory_path() / "intent-to-add-files"
+        intent_to_add_file = get_state_directory_path() / "session" / "abort" / "intent-to-add-files.txt"
         write_file_paths_file(intent_to_add_file, all_intent_to_add_files)
 
     return (all_intent_to_add_files, new_intent_to_add_files)

--- a/src/git_stage_batch/data/session.py
+++ b/src/git_stage_batch/data/session.py
@@ -240,6 +240,9 @@ def clear_session_state() -> None:
     """
     state_dir = get_state_directory_path()
 
+    from .undo import clear_undo_history
+    clear_undo_history()
+
     # Clear session state files
     for filename in SESSION_STATE_FILES:
         file_path = state_dir / filename

--- a/src/git_stage_batch/data/undo.py
+++ b/src/git_stage_batch/data/undo.py
@@ -1,0 +1,441 @@
+"""Undo checkpoint storage and restoration."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import stat
+import subprocess
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Iterator
+
+from ..batch.ref_names import BATCH_CONTENT_REF_PREFIX, BATCH_STATE_REF_PREFIX, LEGACY_BATCH_REF_PREFIX
+from ..exceptions import CommandError
+from ..i18n import _
+from ..utils.file_io import read_file_paths_file
+from ..utils.git import create_git_blob, get_git_repository_root_path, run_git_command, update_git_refs
+from ..utils.paths import (
+    get_auto_added_files_file_path,
+    get_batches_directory_path,
+    get_session_directory_path,
+    get_state_directory_path,
+)
+
+
+SESSION_UNDO_STACK_REF = "refs/git-stage-batch/session/undo-stack"
+REF_PREFIXES = (
+    LEGACY_BATCH_REF_PREFIX,
+    BATCH_CONTENT_REF_PREFIX,
+    BATCH_STATE_REF_PREFIX,
+)
+_PENDING_CHECKPOINT: str | None = None
+
+
+def _list_refs() -> dict[str, str]:
+    """List refs whose values are restored by undo."""
+    refs: dict[str, str] = {}
+    for prefix in REF_PREFIXES:
+        result = run_git_command(["for-each-ref", "--format=%(objectname) %(refname)", prefix], check=False)
+        if result.returncode != 0:
+            continue
+        for line in result.stdout.splitlines():
+            if not line.strip():
+                continue
+            object_name, ref_name = line.split(None, 1)
+            refs[ref_name] = object_name
+    return refs
+
+
+def _changed_worktree_paths() -> list[str]:
+    """Return repository-relative paths whose worktree bytes may need undo."""
+    paths: set[str] = set()
+    commands = [
+        ["diff", "--name-only", "HEAD"],
+        ["diff", "--cached", "--name-only"],
+        ["ls-files", "--others", "--exclude-standard"],
+    ]
+    for args in commands:
+        result = run_git_command(args, check=False)
+        if result.returncode == 0:
+            paths.update(line for line in result.stdout.splitlines() if line)
+    return sorted(paths)
+
+
+def _snapshot_worktree_paths(paths: list[str]) -> list[dict[str, Any]]:
+    repo_root = get_git_repository_root_path()
+    worktree_paths = []
+    for file_path in sorted(set(paths)):
+        full_path = repo_root / file_path
+        if full_path.exists() and full_path.is_file():
+            worktree_paths.append({
+                "path": file_path,
+                "exists": True,
+                "mode": _file_mode_for_path(full_path),
+                "blob": create_git_blob([full_path.read_bytes()]),
+            })
+        else:
+            worktree_paths.append({
+                "path": file_path,
+                "exists": False,
+                "mode": "100644",
+                "blob": None,
+            })
+    return worktree_paths
+
+
+def _snapshot_current_state(paths: list[str]) -> dict[str, Any]:
+    index_result = run_git_command(["write-tree"], check=False)
+    return {
+        "index_tree": index_result.stdout.strip() if index_result.returncode == 0 else None,
+        "refs": _list_refs(),
+        "worktree_paths": _snapshot_worktree_paths(paths),
+    }
+
+
+def _run_update_index(env: dict[str, str], mode: str, blob_sha: str, path: str) -> None:
+    subprocess.run(
+        ["git", "update-index", "--add", "--cacheinfo", mode, blob_sha, path],
+        env=env,
+        capture_output=True,
+        check=True,
+    )
+
+
+def _add_blob_to_index(env: dict[str, str], path: str, data: bytes, mode: str = "100644") -> None:
+    blob_sha = create_git_blob([data])
+    _run_update_index(env, mode, blob_sha, path)
+
+
+def _file_mode_for_path(path: Path) -> str:
+    try:
+        return "100755" if path.stat().st_mode & stat.S_IXUSR else "100644"
+    except OSError:
+        return "100644"
+
+
+def _restore_file_mode(path: Path, mode: str) -> None:
+    current_mode = path.stat().st_mode
+    if mode == "100755":
+        path.chmod(current_mode | stat.S_IXUSR)
+    else:
+        path.chmod(current_mode & ~stat.S_IXUSR & ~stat.S_IXGRP & ~stat.S_IXOTH)
+
+
+def _add_directory_to_index(env: dict[str, str], *, source_dir: Path, tree_prefix: str) -> None:
+    if not source_dir.exists():
+        return
+    for file_path in sorted(path for path in source_dir.rglob("*") if path.is_file()):
+        relative_path = file_path.relative_to(source_dir).as_posix()
+        tree_path = f"{tree_prefix}/{relative_path}"
+        _add_blob_to_index(env, tree_path, file_path.read_bytes(), _file_mode_for_path(file_path))
+
+
+def _current_undo_commit() -> str | None:
+    result = run_git_command(["rev-parse", "--verify", SESSION_UNDO_STACK_REF], check=False)
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def _create_undo_checkpoint(operation: str, *, worktree_paths: list[str] | None = None) -> str | None:
+    """Create a before-image checkpoint for an undoable operation."""
+    session_dir = get_state_directory_path() / "session"
+    if not session_dir.exists():
+        return None
+
+    global _PENDING_CHECKPOINT
+
+    tracked_worktree_paths = sorted(set(_changed_worktree_paths()) | set(worktree_paths or []))
+    before = _snapshot_current_state(tracked_worktree_paths)
+
+    manifest = {
+        "operation": operation,
+        "head": run_git_command(["rev-parse", "HEAD"], check=False).stdout.strip(),
+        "index_tree": before["index_tree"],
+        "refs": before["refs"],
+        "worktree_paths": [
+            {key: value for key, value in entry.items() if key != "blob"}
+            for entry in before["worktree_paths"]
+        ],
+        "tracked_worktree_paths": tracked_worktree_paths,
+    }
+
+    temp_index = tempfile.NamedTemporaryFile(delete=False, suffix=".index")
+    temp_index_path = temp_index.name
+    temp_index.close()
+    os.unlink(temp_index_path)
+
+    env = os.environ.copy()
+    env["GIT_INDEX_FILE"] = temp_index_path
+
+    try:
+        _add_blob_to_index(env, "manifest.json", json.dumps(manifest, indent=2, sort_keys=True).encode("utf-8"))
+        _add_directory_to_index(env, source_dir=session_dir, tree_prefix="session")
+        _add_directory_to_index(env, source_dir=get_batches_directory_path(), tree_prefix="batches")
+
+        repo_root = get_git_repository_root_path()
+        for entry in before["worktree_paths"]:
+            if not entry["exists"]:
+                continue
+            full_path = repo_root / entry["path"]
+            if full_path.exists() and full_path.is_file():
+                _add_blob_to_index(
+                    env,
+                    f"worktree/{entry['path']}",
+                    full_path.read_bytes(),
+                    entry["mode"],
+                )
+
+        tree_result = subprocess.run(
+            ["git", "write-tree"],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        tree_sha = tree_result.stdout.strip()
+
+        parent = _current_undo_commit()
+        parent_args = ["-p", parent] if parent else []
+        commit_result = subprocess.run(
+            ["git", "commit-tree", tree_sha, *parent_args, "-m", f"Undo checkpoint: {operation}"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        checkpoint_commit = commit_result.stdout.strip()
+        run_git_command(["update-ref", SESSION_UNDO_STACK_REF, checkpoint_commit])
+        _PENDING_CHECKPOINT = checkpoint_commit
+        return checkpoint_commit
+    finally:
+        if os.path.exists(temp_index_path):
+            os.unlink(temp_index_path)
+
+
+@contextmanager
+def undo_checkpoint(operation: str, *, worktree_paths: list[str] | None = None) -> Iterator[None]:
+    """Bracket an undoable operation with before and after snapshots."""
+    checkpoint = _create_undo_checkpoint(operation, worktree_paths=worktree_paths)
+    try:
+        yield
+    finally:
+        if checkpoint is not None:
+            finalize_pending_checkpoint()
+
+
+def finalize_pending_checkpoint() -> None:
+    """Record the post-operation state for conflict detection."""
+    global _PENDING_CHECKPOINT
+    checkpoint = _PENDING_CHECKPOINT
+    if checkpoint is None:
+        return
+    _PENDING_CHECKPOINT = None
+
+    current = _current_undo_commit()
+    if current != checkpoint:
+        return
+
+    try:
+        manifest = _read_json_from_commit(checkpoint, "manifest.json")
+    except CommandError:
+        return
+
+    paths = sorted(set(manifest.get("tracked_worktree_paths", [])) | set(_changed_worktree_paths()))
+    manifest["after"] = _snapshot_current_state(paths)
+    manifest["after"]["worktree_paths"] = manifest["after"]["worktree_paths"]
+
+    temp_index = tempfile.NamedTemporaryFile(delete=False, suffix=".index")
+    temp_index_path = temp_index.name
+    temp_index.close()
+    os.unlink(temp_index_path)
+
+    env = os.environ.copy()
+    env["GIT_INDEX_FILE"] = temp_index_path
+    try:
+        subprocess.run(["git", "read-tree", checkpoint], env=env, capture_output=True, check=True)
+        _add_blob_to_index(env, "manifest.json", json.dumps(manifest, indent=2, sort_keys=True).encode("utf-8"))
+        tree_result = subprocess.run(
+            ["git", "write-tree"],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        tree_sha = tree_result.stdout.strip()
+        parent = _checkpoint_parent(checkpoint)
+        parent_args = ["-p", parent] if parent else []
+        commit_result = subprocess.run(
+            ["git", "commit-tree", tree_sha, *parent_args, "-m", f"Undo checkpoint: {manifest.get('operation', 'operation')}"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        run_git_command(["update-ref", SESSION_UNDO_STACK_REF, commit_result.stdout.strip()])
+    finally:
+        if os.path.exists(temp_index_path):
+            os.unlink(temp_index_path)
+
+
+def _cat_blob(blob_sha: str) -> bytes:
+    result = run_git_command(["cat-file", "-p", blob_sha], check=True, text_output=False)
+    return result.stdout
+
+
+def _tree_entries(commit: str, prefix: str) -> list[tuple[str, str, str]]:
+    result = run_git_command(["ls-tree", "-r", "-z", commit, prefix], check=False, text_output=False)
+    if result.returncode != 0 or not result.stdout:
+        return []
+
+    entries = []
+    for record in result.stdout.rstrip(b"\0").split(b"\0"):
+        if not record:
+            continue
+        meta, path_bytes = record.split(b"\t", 1)
+        mode, object_type, object_sha = meta.decode("ascii").split()
+        if object_type != "blob":
+            continue
+        entries.append((mode, object_sha, path_bytes.decode("utf-8", errors="surrogateescape")))
+    return entries
+
+
+def _read_json_from_commit(commit: str, path: str) -> dict[str, Any]:
+    entries = _tree_entries(commit, path)
+    if not entries:
+        raise CommandError(_("Undo checkpoint is missing {path}").format(path=path))
+    _mode, blob_sha, _entry_path = entries[0]
+    return json.loads(_cat_blob(blob_sha).decode("utf-8"))
+
+
+def _restore_tree_prefix(commit: str, *, prefix: str, target_dir: Path) -> None:
+    if target_dir.exists():
+        shutil.rmtree(target_dir)
+    entries = _tree_entries(commit, prefix)
+    if not entries:
+        return
+    target_dir.mkdir(parents=True, exist_ok=True)
+    for mode, blob_sha, tree_path in entries:
+        relative_path = Path(tree_path).relative_to(prefix)
+        target_path = target_dir / relative_path
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        target_path.write_bytes(_cat_blob(blob_sha))
+        _restore_file_mode(target_path, mode)
+
+
+def _restore_refs(saved_refs: dict[str, str]) -> None:
+    current_refs = _list_refs()
+    update_git_refs(
+        updates=sorted(saved_refs.items()),
+        deletes=sorted(ref_name for ref_name in current_refs if ref_name not in saved_refs),
+    )
+
+
+def _restore_worktree(commit: str, manifest: dict[str, Any]) -> None:
+    repo_root = get_git_repository_root_path()
+    worktree_blobs = {
+        Path(tree_path).relative_to("worktree").as_posix(): (mode, blob_sha)
+        for mode, blob_sha, tree_path in _tree_entries(commit, "worktree")
+    }
+
+    for entry in manifest.get("worktree_paths", []):
+        file_path = entry["path"]
+        target_path = repo_root / file_path
+        if not entry.get("exists", False):
+            target_path.unlink(missing_ok=True)
+            continue
+
+        blob_info = worktree_blobs.get(file_path)
+        if blob_info is None:
+            continue
+        mode, blob_sha = blob_info
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        target_path.write_bytes(_cat_blob(blob_sha))
+        _restore_file_mode(target_path, mode)
+
+
+def _restore_intent_to_add_entries() -> None:
+    repo_root = get_git_repository_root_path()
+    for file_path in read_file_paths_file(get_auto_added_files_file_path()):
+        full_path = repo_root / file_path
+        if full_path.exists():
+            run_git_command(["add", "-N", "--", file_path], check=False)
+
+
+def _worktree_state_by_path(entries: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    return {entry["path"]: entry for entry in entries}
+
+
+def _detect_conflicts(manifest: dict[str, Any]) -> list[str]:
+    after = manifest.get("after")
+    if not isinstance(after, dict):
+        return []
+
+    conflicts: list[str] = []
+    current = _snapshot_current_state([entry["path"] for entry in after.get("worktree_paths", [])])
+
+    if current.get("index_tree") != after.get("index_tree"):
+        conflicts.append(_("index"))
+
+    if current.get("refs") != after.get("refs"):
+        conflicts.append(_("batch refs"))
+
+    expected_worktree = _worktree_state_by_path(after.get("worktree_paths", []))
+    current_worktree = _worktree_state_by_path(current.get("worktree_paths", []))
+    for path, expected in sorted(expected_worktree.items()):
+        actual = current_worktree.get(path)
+        if actual != expected:
+            conflicts.append(path)
+
+    return conflicts
+
+
+def _checkpoint_parent(commit: str) -> str | None:
+    result = run_git_command(["rev-parse", "--verify", f"{commit}^"], check=False)
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def undo_last_checkpoint(*, force: bool = False) -> str:
+    """Restore the latest undo checkpoint and pop it from the undo stack."""
+    finalize_pending_checkpoint()
+    checkpoint = _current_undo_commit()
+    if checkpoint is None:
+        raise CommandError(_("Nothing to undo."))
+
+    manifest = _read_json_from_commit(checkpoint, "manifest.json")
+    conflicts = _detect_conflicts(manifest)
+    if conflicts and not force:
+        preview = ", ".join(conflicts[:5])
+        if len(conflicts) > 5:
+            preview = _("{preview}, and {count} more").format(preview=preview, count=len(conflicts) - 5)
+        raise CommandError(
+            _("Cannot undo because current state has changed since the checkpoint: {items}.\n"
+              "Run 'git-stage-batch undo --force' to overwrite those changes.").format(items=preview)
+        )
+
+    _restore_tree_prefix(checkpoint, prefix="session", target_dir=get_session_directory_path())
+    _restore_tree_prefix(checkpoint, prefix="batches", target_dir=get_batches_directory_path())
+    _restore_refs(manifest.get("refs", {}))
+
+    index_tree = manifest.get("index_tree")
+    if index_tree:
+        run_git_command(["read-tree", index_tree])
+
+    _restore_worktree(checkpoint, manifest)
+    _restore_intent_to_add_entries()
+
+    parent = _checkpoint_parent(checkpoint)
+    if parent:
+        run_git_command(["update-ref", SESSION_UNDO_STACK_REF, parent])
+    else:
+        run_git_command(["update-ref", "-d", SESSION_UNDO_STACK_REF], check=False)
+
+    return str(manifest.get("operation", "operation"))
+
+
+def clear_undo_history() -> None:
+    """Clear all undo checkpoints for the current session."""
+    run_git_command(["update-ref", "-d", SESSION_UNDO_STACK_REF], check=False)

--- a/src/git_stage_batch/data/undo.py
+++ b/src/git_stage_batch/data/undo.py
@@ -26,6 +26,7 @@ from ..utils.paths import (
 
 
 SESSION_UNDO_STACK_REF = "refs/git-stage-batch/session/undo-stack"
+SESSION_REDO_STACK_REF = "refs/git-stage-batch/session/redo-stack"
 REF_PREFIXES = (
     LEGACY_BATCH_REF_PREFIX,
     BATCH_CONTENT_REF_PREFIX,
@@ -133,11 +134,19 @@ def _add_directory_to_index(env: dict[str, str], *, source_dir: Path, tree_prefi
         _add_blob_to_index(env, tree_path, file_path.read_bytes(), _file_mode_for_path(file_path))
 
 
-def _current_undo_commit() -> str | None:
-    result = run_git_command(["rev-parse", "--verify", SESSION_UNDO_STACK_REF], check=False)
+def _current_stack_commit(ref_name: str) -> str | None:
+    result = run_git_command(["rev-parse", "--verify", ref_name], check=False)
     if result.returncode != 0:
         return None
     return result.stdout.strip()
+
+
+def _current_undo_commit() -> str | None:
+    return _current_stack_commit(SESSION_UNDO_STACK_REF)
+
+
+def _current_redo_commit() -> str | None:
+    return _current_stack_commit(SESSION_REDO_STACK_REF)
 
 
 def _create_undo_checkpoint(operation: str, *, worktree_paths: list[str] | None = None) -> str | None:
@@ -145,6 +154,8 @@ def _create_undo_checkpoint(operation: str, *, worktree_paths: list[str] | None 
     session_dir = get_state_directory_path() / "session"
     if not session_dir.exists():
         return None
+
+    _clear_redo_history()
 
     global _PENDING_CHECKPOINT
 
@@ -367,21 +378,17 @@ def _worktree_state_by_path(entries: list[dict[str, Any]]) -> dict[str, dict[str
     return {entry["path"]: entry for entry in entries}
 
 
-def _detect_conflicts(manifest: dict[str, Any]) -> list[str]:
-    after = manifest.get("after")
-    if not isinstance(after, dict):
-        return []
-
+def _detect_conflicts_against_state(expected_state: dict[str, Any]) -> list[str]:
     conflicts: list[str] = []
-    current = _snapshot_current_state([entry["path"] for entry in after.get("worktree_paths", [])])
+    current = _snapshot_current_state([entry["path"] for entry in expected_state.get("worktree_paths", [])])
 
-    if current.get("index_tree") != after.get("index_tree"):
+    if current.get("index_tree") != expected_state.get("index_tree"):
         conflicts.append(_("index"))
 
-    if current.get("refs") != after.get("refs"):
+    if current.get("refs") != expected_state.get("refs"):
         conflicts.append(_("batch refs"))
 
-    expected_worktree = _worktree_state_by_path(after.get("worktree_paths", []))
+    expected_worktree = _worktree_state_by_path(expected_state.get("worktree_paths", []))
     current_worktree = _worktree_state_by_path(current.get("worktree_paths", []))
     for path, expected in sorted(expected_worktree.items()):
         actual = current_worktree.get(path)
@@ -391,11 +398,137 @@ def _detect_conflicts(manifest: dict[str, Any]) -> list[str]:
     return conflicts
 
 
+def _detect_conflicts(manifest: dict[str, Any]) -> list[str]:
+    after = manifest.get("after")
+    if not isinstance(after, dict):
+        return []
+    return _detect_conflicts_against_state(after)
+
+
+def _detect_redo_conflicts(manifest: dict[str, Any]) -> list[str]:
+    after_undo = manifest.get("after_undo")
+    if not isinstance(after_undo, dict):
+        return []
+    return _detect_conflicts_against_state(after_undo)
+
+
 def _checkpoint_parent(commit: str) -> str | None:
     result = run_git_command(["rev-parse", "--verify", f"{commit}^"], check=False)
     if result.returncode != 0:
         return None
     return result.stdout.strip()
+
+
+def _redo_relevant_paths(manifest: dict[str, Any]) -> list[str]:
+    paths: set[str] = set()
+    paths.update(manifest.get("tracked_worktree_paths", []))
+    for entry in manifest.get("worktree_paths", []):
+        paths.add(entry["path"])
+    after = manifest.get("after")
+    if isinstance(after, dict):
+        for entry in after.get("worktree_paths", []):
+            paths.add(entry["path"])
+    paths.update(_changed_worktree_paths())
+    return sorted(paths)
+
+
+def _write_snapshot_commit(
+    *,
+    ref_name: str,
+    message: str,
+    manifest: dict[str, Any],
+    session_dir: Path,
+    batches_dir: Path,
+    worktree_entries: list[dict[str, Any]],
+    parent: str | None,
+) -> str:
+    temp_index = tempfile.NamedTemporaryFile(delete=False, suffix=".index")
+    temp_index_path = temp_index.name
+    temp_index.close()
+    os.unlink(temp_index_path)
+
+    env = os.environ.copy()
+    env["GIT_INDEX_FILE"] = temp_index_path
+
+    try:
+        _add_blob_to_index(env, "manifest.json", json.dumps(manifest, indent=2, sort_keys=True).encode("utf-8"))
+        _add_directory_to_index(env, source_dir=session_dir, tree_prefix="session")
+        _add_directory_to_index(env, source_dir=batches_dir, tree_prefix="batches")
+
+        repo_root = get_git_repository_root_path()
+        for entry in worktree_entries:
+            if not entry.get("exists", False):
+                continue
+            blob_sha = entry.get("blob")
+            if blob_sha:
+                _run_update_index(env, entry.get("mode", "100644"), blob_sha, f"worktree/{entry['path']}")
+            else:
+                full_path = repo_root / entry["path"]
+                if full_path.exists() and full_path.is_file():
+                    _add_blob_to_index(
+                        env,
+                        f"worktree/{entry['path']}",
+                        full_path.read_bytes(),
+                        entry.get("mode", "100644"),
+                    )
+
+        tree_result = subprocess.run(
+            ["git", "write-tree"],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        tree_sha = tree_result.stdout.strip()
+
+        parent_args = ["-p", parent] if parent else []
+        commit_result = subprocess.run(
+            ["git", "commit-tree", tree_sha, *parent_args, "-m", message],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        commit_sha = commit_result.stdout.strip()
+        run_git_command(["update-ref", ref_name, commit_sha])
+        return commit_sha
+    finally:
+        if os.path.exists(temp_index_path):
+            os.unlink(temp_index_path)
+
+
+def _push_redo_node(
+    *,
+    operation: str,
+    undo_checkpoint: str,
+    target: dict[str, Any],
+    target_session_dir: Path,
+    target_batches_dir: Path,
+    after_undo: dict[str, Any],
+    worktree_entries: list[dict[str, Any]],
+) -> str:
+    manifest = {
+        "operation": operation,
+        "undo_checkpoint": undo_checkpoint,
+        "head": target.get("head", run_git_command(["rev-parse", "HEAD"], check=False).stdout.strip()),
+        "index_tree": target.get("index_tree"),
+        "refs": target.get("refs", {}),
+        "worktree_paths": [
+            {key: value for key, value in entry.items() if key != "blob"}
+            for entry in worktree_entries
+        ],
+        "after_undo": after_undo,
+    }
+
+    parent = _current_redo_commit()
+    return _write_snapshot_commit(
+        ref_name=SESSION_REDO_STACK_REF,
+        message=f"Redo node: {operation}",
+        manifest=manifest,
+        session_dir=target_session_dir,
+        batches_dir=target_batches_dir,
+        worktree_entries=worktree_entries,
+        parent=parent,
+    )
 
 
 def undo_last_checkpoint(*, force: bool = False) -> str:
@@ -416,16 +549,46 @@ def undo_last_checkpoint(*, force: bool = False) -> str:
               "Run 'git-stage-batch undo --force' to overwrite those changes.").format(items=preview)
         )
 
-    _restore_tree_prefix(checkpoint, prefix="session", target_dir=get_session_directory_path())
-    _restore_tree_prefix(checkpoint, prefix="batches", target_dir=get_batches_directory_path())
-    _restore_refs(manifest.get("refs", {}))
+    operation = str(manifest.get("operation", "operation"))
+    redo_paths = _redo_relevant_paths(manifest)
+    redo_target = _snapshot_current_state(redo_paths)
+    redo_worktree_entries = _snapshot_worktree_paths(redo_paths)
 
-    index_tree = manifest.get("index_tree")
-    if index_tree:
-        run_git_command(["read-tree", index_tree])
+    redo_session_dir = tempfile.mkdtemp(dir="/var/tmp", prefix="gsb-redo-session-")
+    redo_batches_dir = tempfile.mkdtemp(dir="/var/tmp", prefix="gsb-redo-batches-")
+    try:
+        live_session_dir = get_session_directory_path()
+        live_batches_dir = get_batches_directory_path()
+        if live_session_dir.exists():
+            shutil.copytree(live_session_dir, redo_session_dir, dirs_exist_ok=True)
+        if live_batches_dir.exists():
+            shutil.copytree(live_batches_dir, redo_batches_dir, dirs_exist_ok=True)
 
-    _restore_worktree(checkpoint, manifest)
-    _restore_intent_to_add_entries()
+        _restore_tree_prefix(checkpoint, prefix="session", target_dir=live_session_dir)
+        _restore_tree_prefix(checkpoint, prefix="batches", target_dir=live_batches_dir)
+        _restore_refs(manifest.get("refs", {}))
+
+        index_tree = manifest.get("index_tree")
+        if index_tree:
+            run_git_command(["read-tree", index_tree])
+
+        _restore_worktree(checkpoint, manifest)
+        _restore_intent_to_add_entries()
+
+        after_undo = _snapshot_current_state(redo_paths)
+
+        _push_redo_node(
+            operation=operation,
+            undo_checkpoint=checkpoint,
+            target=redo_target,
+            target_session_dir=Path(redo_session_dir),
+            target_batches_dir=Path(redo_batches_dir),
+            after_undo=after_undo,
+            worktree_entries=redo_worktree_entries,
+        )
+    finally:
+        shutil.rmtree(redo_session_dir, ignore_errors=True)
+        shutil.rmtree(redo_batches_dir, ignore_errors=True)
 
     parent = _checkpoint_parent(checkpoint)
     if parent:
@@ -433,9 +596,56 @@ def undo_last_checkpoint(*, force: bool = False) -> str:
     else:
         run_git_command(["update-ref", "-d", SESSION_UNDO_STACK_REF], check=False)
 
+    return operation
+
+
+def redo_last_checkpoint(*, force: bool = False) -> str:
+    """Reapply the most recently undone operation from the redo stack."""
+    finalize_pending_checkpoint()
+    redo_node = _current_redo_commit()
+    if redo_node is None:
+        raise CommandError(_("Nothing to redo."))
+
+    manifest = _read_json_from_commit(redo_node, "manifest.json")
+    conflicts = _detect_redo_conflicts(manifest)
+    if conflicts and not force:
+        preview = ", ".join(conflicts[:5])
+        if len(conflicts) > 5:
+            preview = _("{preview}, and {count} more").format(preview=preview, count=len(conflicts) - 5)
+        raise CommandError(
+            _("Cannot redo because current state has changed since the undo: {items}.\n"
+              "Run 'git-stage-batch redo --force' to overwrite those changes.").format(items=preview)
+        )
+
+    _restore_tree_prefix(redo_node, prefix="session", target_dir=get_session_directory_path())
+    _restore_tree_prefix(redo_node, prefix="batches", target_dir=get_batches_directory_path())
+    _restore_refs(manifest.get("refs", {}))
+
+    index_tree = manifest.get("index_tree")
+    if index_tree:
+        run_git_command(["read-tree", index_tree])
+
+    _restore_worktree(redo_node, manifest)
+    _restore_intent_to_add_entries()
+
+    undo_checkpoint = manifest.get("undo_checkpoint")
+    if undo_checkpoint:
+        run_git_command(["update-ref", SESSION_UNDO_STACK_REF, undo_checkpoint])
+
+    parent = _checkpoint_parent(redo_node)
+    if parent:
+        run_git_command(["update-ref", SESSION_REDO_STACK_REF, parent])
+    else:
+        run_git_command(["update-ref", "-d", SESSION_REDO_STACK_REF], check=False)
+
     return str(manifest.get("operation", "operation"))
 
 
+def _clear_redo_history() -> None:
+    run_git_command(["update-ref", "-d", SESSION_REDO_STACK_REF], check=False)
+
+
 def clear_undo_history() -> None:
-    """Clear all undo checkpoints for the current session."""
+    """Clear all undo and redo checkpoints for the current session."""
     run_git_command(["update-ref", "-d", SESSION_UNDO_STACK_REF], check=False)
+    _clear_redo_history()

--- a/src/git_stage_batch/tui/interactive.py
+++ b/src/git_stage_batch/tui/interactive.py
@@ -57,7 +57,7 @@ def _handle_include(flow_state: FlowState) -> None:
             raise ValueError(f"Unknown target role: {flow_state.target.role}")
     elif flow_state.source.role is LocationRole.BATCH:
         # Include from batch
-        if not flow_state.target.role is LocationRole.STAGING_AREA:
+        if flow_state.target.role is not LocationRole.STAGING_AREA:
             print(_("Batch-to-batch transfers not yet supported. Target must be staging."), file=sys.stderr)
             raise BypassRefresh()
         from ..commands.include_from import command_include_from_batch
@@ -101,7 +101,7 @@ def _handle_discard(flow_state: FlowState) -> None:
             raise ValueError(f"Unknown target role: {flow_state.target.role}")
     elif flow_state.source.role is LocationRole.BATCH:
         # Discard from batch
-        if not flow_state.target.role is LocationRole.STAGING_AREA:
+        if flow_state.target.role is not LocationRole.STAGING_AREA:
             print(_("Batch-to-batch transfers not yet supported. Target must be staging."), file=sys.stderr)
             raise BypassRefresh()
         from ..commands.discard_from import command_discard_from_batch
@@ -122,6 +122,12 @@ def _handle_again(flow_state: FlowState) -> None:
     auto_add_untracked_files()
 
     fetch_next_change()
+
+
+def _handle_undo(flow_state: FlowState) -> None:
+    """Handle undo action."""
+    from ..commands.undo import command_undo
+    command_undo()
 
 
 def _handle_line_selection(flow_state: FlowState) -> None:
@@ -528,6 +534,7 @@ ACTION_HANDLERS = {
     "f": ActionHandler(needs_hunk=True, handler=_handle_file_selection),
     "x": ActionHandler(needs_hunk=True, handler=_handle_fixup),
     "a": ActionHandler(needs_hunk=False, handler=_handle_again),
+    "u": ActionHandler(needs_hunk=False, handler=_handle_undo),
     "b": ActionHandler(needs_hunk=False, handler=_handle_batch),
     "?": ActionHandler(needs_hunk=False, handler=_handle_help),
     "q": ActionHandler(needs_hunk=False, handler=_handle_quit),
@@ -759,7 +766,7 @@ def handle_file_selection(flow_state: FlowState) -> None:
             else:
                 raise ValueError(f"Unknown target role: {flow_state.target.role}")
         elif flow_state.source.role is LocationRole.BATCH:
-            if not flow_state.target.role is LocationRole.STAGING_AREA:
+            if flow_state.target.role is not LocationRole.STAGING_AREA:
                 print(_("Batch-to-batch transfers not yet supported."), file=sys.stderr)
                 return
             from ..commands.include_from import command_include_from_batch
@@ -791,7 +798,7 @@ def handle_file_selection(flow_state: FlowState) -> None:
             else:
                 raise ValueError(f"Unknown target role: {flow_state.target.role}")
         elif flow_state.source.role is LocationRole.BATCH:
-            if not flow_state.target.role is LocationRole.STAGING_AREA:
+            if flow_state.target.role is not LocationRole.STAGING_AREA:
                 print(_("Batch-to-batch transfers not yet supported."), file=sys.stderr)
                 return
             from ..commands.discard_from import command_discard_from_batch
@@ -892,7 +899,7 @@ def handle_line_selection(flow_state: FlowState) -> None:
                 else:
                     raise ValueError(f"Unknown target role: {flow_state.target.role}")
             elif flow_state.source.role is LocationRole.BATCH:
-                if not flow_state.target.role is LocationRole.STAGING_AREA:
+                if flow_state.target.role is not LocationRole.STAGING_AREA:
                     print(_("Batch-to-batch transfers not yet supported."), file=sys.stderr)
                     return
                 from ..commands.include_from import command_include_from_batch
@@ -922,7 +929,7 @@ def handle_line_selection(flow_state: FlowState) -> None:
                 else:
                     raise ValueError(f"Unknown target role: {flow_state.target.role}")
             elif flow_state.source.role is LocationRole.BATCH:
-                if not flow_state.target.role is LocationRole.STAGING_AREA:
+                if flow_state.target.role is not LocationRole.STAGING_AREA:
                     print(_("Batch-to-batch transfers not yet supported."), file=sys.stderr)
                     return
                 from ..commands.discard_from import command_discard_from_batch
@@ -1066,6 +1073,7 @@ def print_help() -> None:
     print()
     print(_("More options:"))
     print(_("  a, again     - Clear state and start fresh pass through skipped hunks"))
+    print(_("  u, undo      - Undo the most recent operation"))
     print(_("  l, lines     - Select specific lines from this hunk"))
     print(_("  f, file      - Include or skip all hunks in this file"))
     print(_("  x, fixup     - Suggest which commit to fixup (iterative)"))

--- a/src/git_stage_batch/tui/interactive.py
+++ b/src/git_stage_batch/tui/interactive.py
@@ -130,6 +130,12 @@ def _handle_undo(flow_state: FlowState) -> None:
     command_undo()
 
 
+def _handle_redo(flow_state: FlowState) -> None:
+    """Handle redo action."""
+    from ..commands.redo import command_redo
+    command_redo()
+
+
 def _handle_line_selection(flow_state: FlowState) -> None:
     """Handle line selection submenu."""
     handle_line_selection(flow_state)
@@ -535,6 +541,7 @@ ACTION_HANDLERS = {
     "x": ActionHandler(needs_hunk=True, handler=_handle_fixup),
     "a": ActionHandler(needs_hunk=False, handler=_handle_again),
     "u": ActionHandler(needs_hunk=False, handler=_handle_undo),
+    "U": ActionHandler(needs_hunk=False, handler=_handle_redo),
     "b": ActionHandler(needs_hunk=False, handler=_handle_batch),
     "?": ActionHandler(needs_hunk=False, handler=_handle_help),
     "q": ActionHandler(needs_hunk=False, handler=_handle_quit),
@@ -1074,6 +1081,7 @@ def print_help() -> None:
     print(_("More options:"))
     print(_("  a, again     - Clear state and start fresh pass through skipped hunks"))
     print(_("  u, undo      - Undo the most recent operation"))
+    print(_("  U, redo      - Redo the most recently undone operation"))
     print(_("  l, lines     - Select specific lines from this hunk"))
     print(_("  f, file      - Include or skip all hunks in this file"))
     print(_("  x, fixup     - Suggest which commit to fixup (iterative)"))

--- a/src/git_stage_batch/tui/prompts.py
+++ b/src/git_stage_batch/tui/prompts.py
@@ -96,6 +96,7 @@ def prompt_action(use_color: bool = True, show_question: bool = True, has_hunk: 
         # More options
         more_options = [
             ("again", "a", ""),
+            ("undo", "u", ""),
             ("batch", "b", ""),
             ("fixup", "x", ""),
             ("cmd", "!", ""),
@@ -119,6 +120,7 @@ def prompt_action(use_color: bool = True, show_question: bool = True, has_hunk: 
 
         # More options - limited set
         more_options = [
+            ("undo", "u", ""),
             ("batch", "b", ""),
             ("cmd", "!", ""),
         ]
@@ -201,6 +203,7 @@ def prompt_action(use_color: bool = True, show_question: bool = True, has_hunk: 
         "discard": "d",
         "quit": "q",
         "again": "a",
+        "undo": "u",
         "lines": "l",
         "file": "f",
         "batch": "b",

--- a/src/git_stage_batch/tui/prompts.py
+++ b/src/git_stage_batch/tui/prompts.py
@@ -97,6 +97,7 @@ def prompt_action(use_color: bool = True, show_question: bool = True, has_hunk: 
         more_options = [
             ("again", "a", ""),
             ("undo", "u", ""),
+            ("redo", "U", ""),
             ("batch", "b", ""),
             ("fixup", "x", ""),
             ("cmd", "!", ""),
@@ -121,6 +122,7 @@ def prompt_action(use_color: bool = True, show_question: bool = True, has_hunk: 
         # More options - limited set
         more_options = [
             ("undo", "u", ""),
+            ("redo", "U", ""),
             ("batch", "b", ""),
             ("cmd", "!", ""),
         ]
@@ -204,6 +206,7 @@ def prompt_action(use_color: bool = True, show_question: bool = True, has_hunk: 
         "quit": "q",
         "again": "a",
         "undo": "u",
+        "redo": "U",
         "lines": "l",
         "file": "f",
         "batch": "b",

--- a/src/git_stage_batch/utils/git.py
+++ b/src/git_stage_batch/utils/git.py
@@ -69,6 +69,34 @@ def stream_git_command(
         )
 
 
+def _git_ref_exists(ref_name: str) -> bool:
+    result = run_git_command(["rev-parse", "--verify", ref_name], check=False)
+    return result.returncode == 0
+
+
+def update_git_refs(
+    *,
+    updates: Iterable[tuple[str, str]] = (),
+    deletes: Iterable[str] = (),
+    ignore_missing_deletes: bool = True,
+) -> None:
+    """Update one or more Git refs in a single update-ref transaction."""
+    update_commands = list(updates)
+    delete_commands = list(deletes)
+    if ignore_missing_deletes:
+        delete_commands = [ref_name for ref_name in delete_commands if _git_ref_exists(ref_name)]
+    if not update_commands and not delete_commands:
+        return
+
+    commands = ["start"]
+    commands.extend(f"update {ref_name} {object_name}" for ref_name, object_name in update_commands)
+    commands.extend(f"delete {ref_name}" for ref_name in delete_commands)
+    commands.extend(["prepare", "commit"])
+    payload = ("\n".join(commands) + "\n").encode("utf-8")
+    for _chunk in stream_git_command(["update-ref", "--stdin"], [payload]):
+        pass
+
+
 def run_git_command(
     arguments: list[str],
     check: bool = True,

--- a/src/git_stage_batch/utils/paths.py
+++ b/src/git_stage_batch/utils/paths.py
@@ -22,13 +22,62 @@ def ensure_state_directory_exists() -> None:
     get_state_directory_path().mkdir(parents=True, exist_ok=True)
 
 
+def get_session_directory_path() -> Path:
+    """Get the directory containing active session scratch state."""
+    path = get_state_directory_path() / "session"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def get_selected_state_directory_path() -> Path:
+    """Get the directory containing the selected change cache."""
+    path = get_session_directory_path() / "selected"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def get_progress_state_directory_path() -> Path:
+    """Get the directory containing hunk progress state."""
+    path = get_session_directory_path() / "progress"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def get_processed_state_directory_path() -> Path:
+    """Get the directory containing processed line-id state."""
+    path = get_session_directory_path() / "processed"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def get_config_state_directory_path() -> Path:
+    """Get the directory containing session configuration state."""
+    path = get_session_directory_path() / "config"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def get_abort_state_directory_path() -> Path:
+    """Get the directory containing abort/recovery state."""
+    path = get_session_directory_path() / "abort"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def get_fixup_state_directory_path() -> Path:
+    """Get the directory containing suggest-fixup state."""
+    path = get_session_directory_path() / "fixup"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
 def get_processed_include_ids_file_path() -> Path:
     """Get the path to the processed include IDs file.
 
     Returns:
         Path to processed include IDs file
     """
-    return get_state_directory_path() / "processed.include"
+    return get_processed_state_directory_path() / "included-lines.json"
 
 
 def get_processed_skip_ids_file_path() -> Path:
@@ -37,7 +86,7 @@ def get_processed_skip_ids_file_path() -> Path:
     Returns:
         Path to processed skip IDs file
     """
-    return get_state_directory_path() / "processed.skip"
+    return get_processed_state_directory_path() / "skipped-lines.json"
 
 
 def get_processed_batch_ids_file_path() -> Path:
@@ -46,7 +95,7 @@ def get_processed_batch_ids_file_path() -> Path:
     Returns:
         Path to processed batch IDs file
     """
-    return get_state_directory_path() / "processed.batch"
+    return get_processed_state_directory_path() / "batched-lines.json"
 
 
 def get_line_changes_json_file_path() -> Path:
@@ -55,7 +104,7 @@ def get_line_changes_json_file_path() -> Path:
     Returns:
         Path to selected lines JSON file
     """
-    return get_state_directory_path() / "selected-lines.json"
+    return get_selected_state_directory_path() / "hunk.lines.json"
 
 
 def get_index_snapshot_file_path() -> Path:
@@ -64,7 +113,7 @@ def get_index_snapshot_file_path() -> Path:
     Returns:
         Path to index snapshot file
     """
-    return get_state_directory_path() / "index-snapshot"
+    return get_selected_state_directory_path() / "index.snapshot"
 
 
 def get_working_tree_snapshot_file_path() -> Path:
@@ -73,7 +122,7 @@ def get_working_tree_snapshot_file_path() -> Path:
     Returns:
         Path to working tree snapshot file
     """
-    return get_state_directory_path() / "working-tree-snapshot"
+    return get_selected_state_directory_path() / "working-tree.snapshot"
 
 
 def get_block_list_file_path() -> Path:
@@ -82,7 +131,7 @@ def get_block_list_file_path() -> Path:
     Returns:
         Path to blocklist file
     """
-    return get_state_directory_path() / "blocklist"
+    return get_progress_state_directory_path() / "blocked-hunks.txt"
 
 
 def get_selected_hunk_patch_file_path() -> Path:
@@ -91,7 +140,7 @@ def get_selected_hunk_patch_file_path() -> Path:
     Returns:
         Path to selected hunk patch file
     """
-    return get_state_directory_path() / "selected-hunk-patch"
+    return get_selected_state_directory_path() / "hunk.patch"
 
 
 def get_selected_hunk_hash_file_path() -> Path:
@@ -100,7 +149,7 @@ def get_selected_hunk_hash_file_path() -> Path:
     Returns:
         Path to selected hunk hash file
     """
-    return get_state_directory_path() / "selected-hunk-hash"
+    return get_selected_state_directory_path() / "hunk.hash.txt"
 
 
 def get_selected_binary_file_json_path() -> Path:
@@ -112,7 +161,7 @@ def get_selected_binary_file_json_path() -> Path:
     Returns:
         Path to selected binary file JSON file
     """
-    return get_state_directory_path() / "selected-binary-file.json"
+    return get_selected_state_directory_path() / "binary-file.json"
 
 
 def get_abort_head_file_path() -> Path:
@@ -121,7 +170,7 @@ def get_abort_head_file_path() -> Path:
     Returns:
         Path to abort HEAD file
     """
-    return get_state_directory_path() / "abort-head"
+    return get_abort_state_directory_path() / "head.txt"
 
 
 def get_abort_stash_file_path() -> Path:
@@ -130,7 +179,7 @@ def get_abort_stash_file_path() -> Path:
     Returns:
         Path to abort stash file
     """
-    return get_state_directory_path() / "abort-stash"
+    return get_abort_state_directory_path() / "stash.txt"
 
 
 def get_abort_snapshots_directory_path() -> Path:
@@ -139,7 +188,7 @@ def get_abort_snapshots_directory_path() -> Path:
     Returns:
         Path to snapshots directory
     """
-    return get_state_directory_path() / "snapshots"
+    return get_abort_state_directory_path() / "untracked"
 
 
 def get_abort_snapshot_list_file_path() -> Path:
@@ -148,7 +197,7 @@ def get_abort_snapshot_list_file_path() -> Path:
     Returns:
         Path to snapshot list file
     """
-    return get_state_directory_path() / "snapshot-list"
+    return get_abort_state_directory_path() / "untracked-paths.txt"
 
 
 def get_session_batch_sources_file_path() -> Path:
@@ -157,7 +206,7 @@ def get_session_batch_sources_file_path() -> Path:
     Returns:
         Path to session-batch-sources.json file
     """
-    return get_state_directory_path() / "session-batch-sources.json"
+    return get_session_directory_path() / "batch-sources.json"
 
 
 def get_auto_added_files_file_path() -> Path:
@@ -166,7 +215,7 @@ def get_auto_added_files_file_path() -> Path:
     Returns:
         Path to auto-added files list file
     """
-    return get_state_directory_path() / "auto-added-files"
+    return get_abort_state_directory_path() / "auto-added-files.txt"
 
 
 def get_blocked_files_file_path() -> Path:
@@ -175,7 +224,7 @@ def get_blocked_files_file_path() -> Path:
     Returns:
         Path to blocked files list file
     """
-    return get_state_directory_path() / "blocked-files"
+    return get_progress_state_directory_path() / "blocked-files.txt"
 
 
 def get_iteration_count_file_path() -> Path:
@@ -184,7 +233,7 @@ def get_iteration_count_file_path() -> Path:
     Returns:
         Path to iteration count file
     """
-    return get_state_directory_path() / "iteration-count"
+    return get_config_state_directory_path() / "iteration-count.txt"
 
 
 def get_start_head_file_path() -> Path:
@@ -193,7 +242,7 @@ def get_start_head_file_path() -> Path:
     Returns:
         Path to start HEAD file
     """
-    return get_state_directory_path() / "start-head"
+    return get_session_directory_path() / "start-head.txt"
 
 
 def get_start_index_tree_file_path() -> Path:
@@ -202,7 +251,7 @@ def get_start_index_tree_file_path() -> Path:
     Returns:
         Path to start index tree file
     """
-    return get_state_directory_path() / "start-index-tree"
+    return get_session_directory_path() / "start-index-tree.txt"
 
 
 def get_start_batch_refs_file_path() -> Path:
@@ -211,7 +260,7 @@ def get_start_batch_refs_file_path() -> Path:
     Returns:
         Path to start batch refs file (JSON format: {batch_name: commit_sha})
     """
-    return get_state_directory_path() / "start-batch-refs.json"
+    return get_session_directory_path() / "start-batch-refs.json"
 
 
 def get_context_lines_file_path() -> Path:
@@ -220,7 +269,7 @@ def get_context_lines_file_path() -> Path:
     Returns:
         Path to context lines file
     """
-    return get_state_directory_path() / "context-lines"
+    return get_config_state_directory_path() / "context-lines.txt"
 
 
 def get_context_lines() -> int:
@@ -244,7 +293,7 @@ def get_suggest_fixup_state_file_path() -> Path:
     Returns:
         Path to suggest-fixup state JSON file
     """
-    return get_state_directory_path() / "suggest-fixup-state.json"
+    return get_fixup_state_directory_path() / "state.json"
 
 
 def get_included_hunks_file_path() -> Path:
@@ -253,7 +302,7 @@ def get_included_hunks_file_path() -> Path:
     Returns:
         Path to included hunks file
     """
-    return get_state_directory_path() / "included-hunks"
+    return get_progress_state_directory_path() / "included-hunks.txt"
 
 
 def get_skipped_hunks_jsonl_file_path() -> Path:
@@ -262,7 +311,7 @@ def get_skipped_hunks_jsonl_file_path() -> Path:
     Returns:
         Path to skipped hunks JSONL file
     """
-    return get_state_directory_path() / "skipped-hunks.jsonl"
+    return get_progress_state_directory_path() / "skipped-hunks.jsonl"
 
 
 def get_discarded_hunks_file_path() -> Path:
@@ -271,7 +320,7 @@ def get_discarded_hunks_file_path() -> Path:
     Returns:
         Path to discarded hunks file
     """
-    return get_state_directory_path() / "discarded-hunks"
+    return get_progress_state_directory_path() / "discarded-hunks.txt"
 
 
 def get_batched_hunks_file_path() -> Path:
@@ -280,7 +329,7 @@ def get_batched_hunks_file_path() -> Path:
     Returns:
         Path to batched hunks file
     """
-    return get_state_directory_path() / "batched-hunks"
+    return get_progress_state_directory_path() / "batched-hunks.txt"
 
 
 def get_batches_directory_path() -> Path:
@@ -346,4 +395,4 @@ def get_batch_refs_snapshot_file_path() -> Path:
     Returns:
         Path to batch refs snapshot JSON file
     """
-    return get_state_directory_path() / "batch-refs-snapshot.json"
+    return get_abort_state_directory_path() / "batch-refs.json"

--- a/tests/batch/test_batch_operations.py
+++ b/tests/batch/test_batch_operations.py
@@ -7,8 +7,8 @@ import pytest
 
 from git_stage_batch.batch.operations import create_batch, delete_batch, update_batch_note
 from git_stage_batch.batch.query import read_batch_metadata
+from git_stage_batch.batch.state_refs import get_batch_content_ref_name, get_batch_state_ref_name
 from git_stage_batch.exceptions import CommandError
-from git_stage_batch.utils.file_io import read_text_file_contents
 from git_stage_batch.utils.git import run_git_command
 from git_stage_batch.utils.paths import get_batch_metadata_file_path
 
@@ -29,16 +29,14 @@ def temp_git_repo(tmp_path, monkeypatch):
     return tmp_path
 
 
-def test_create_batch_creates_metadata(temp_git_repo):
-    """Test that create_batch creates metadata file."""
+def test_create_batch_creates_state_metadata(temp_git_repo):
+    """Test that create_batch creates Git-backed metadata."""
     create_batch("test-batch", "Test note")
 
-    metadata_path = get_batch_metadata_file_path("test-batch")
-    assert metadata_path.exists()
-
-    metadata = json.loads(read_text_file_contents(metadata_path))
+    metadata = read_batch_metadata("test-batch")
     assert metadata["note"] == "Test note"
     assert "created_at" in metadata
+    assert not get_batch_metadata_file_path("test-batch").exists()
 
 
 def test_create_batch_creates_ref(temp_git_repo):
@@ -46,7 +44,7 @@ def test_create_batch_creates_ref(temp_git_repo):
     create_batch("test-batch", "Test note")
 
     # Verify ref exists
-    result = run_git_command(["show-ref", "--verify", "refs/batches/test-batch"], check=False)
+    result = run_git_command(["show-ref", "--verify", get_batch_content_ref_name("test-batch")], check=False)
     assert result.returncode == 0
 
 
@@ -72,14 +70,15 @@ def test_delete_batch_removes_ref(temp_git_repo):
     create_batch("test-batch", "Test")
 
     # Verify ref exists
-    result = run_git_command(["show-ref", "--verify", "refs/batches/test-batch"], check=False)
+    result = run_git_command(["show-ref", "--verify", get_batch_content_ref_name("test-batch")], check=False)
     assert result.returncode == 0
 
     delete_batch("test-batch")
 
     # Verify ref is gone
-    result = run_git_command(["show-ref", "--verify", "refs/batches/test-batch"], check=False)
-    assert result.returncode != 0
+    for refname in (get_batch_content_ref_name("test-batch"), get_batch_state_ref_name("test-batch")):
+        result = run_git_command(["show-ref", "--verify", refname], check=False)
+        assert result.returncode != 0
 
 
 def test_delete_batch_removes_metadata(temp_git_repo):
@@ -87,7 +86,8 @@ def test_delete_batch_removes_metadata(temp_git_repo):
     create_batch("test-batch", "Test")
 
     metadata_path = get_batch_metadata_file_path("test-batch")
-    assert metadata_path.exists()
+    metadata_path.parent.mkdir(parents=True, exist_ok=True)
+    metadata_path.write_text(json.dumps({"note": "legacy"}))
 
     delete_batch("test-batch")
 

--- a/tests/batch/test_metadata_validation.py
+++ b/tests/batch/test_metadata_validation.py
@@ -17,6 +17,7 @@ from git_stage_batch.batch.metadata_validation import (
     validate_state_directory_exists,
 )
 from git_stage_batch.batch.operations import create_batch
+from git_stage_batch.batch.query import read_batch_metadata
 from git_stage_batch.data.session import initialize_abort_state
 from git_stage_batch.exceptions import BatchMetadataError
 from git_stage_batch.utils.file_io import write_text_file_contents
@@ -26,6 +27,48 @@ from git_stage_batch.utils.paths import (
     get_batch_metadata_file_path,
     get_state_directory_path,
 )
+
+
+def _write_state_batch_json(batch_name: str, content: str) -> None:
+    blob = subprocess.run(
+        ["git", "hash-object", "-w", "--stdin"],
+        input=content,
+        text=True,
+        check=True,
+        capture_output=True,
+    ).stdout.strip()
+    tree = subprocess.run(
+        ["git", "mktree"],
+        input=f"100644 blob {blob}\tbatch.json\n",
+        text=True,
+        check=True,
+        capture_output=True,
+    ).stdout.strip()
+    commit = subprocess.run(
+        ["git", "commit-tree", tree, "-m", f"Test batch state: {batch_name}"],
+        text=True,
+        check=True,
+        capture_output=True,
+    ).stdout.strip()
+    subprocess.run(["git", "update-ref", f"refs/git-stage-batch/state/{batch_name}", commit], check=True)
+
+
+def _write_state_metadata(batch_name: str, metadata: dict) -> None:
+    state_metadata = {
+        "batch": batch_name,
+        "note": metadata.get("note", ""),
+        "created_at": metadata.get("created_at", ""),
+        "baseline_commit": metadata.get("baseline"),
+        "content_ref": f"refs/git-stage-batch/batches/{batch_name}",
+        "content_commit": subprocess.run(
+            ["git", "rev-parse", f"refs/git-stage-batch/batches/{batch_name}"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip(),
+        "files": metadata.get("files", {}),
+    }
+    _write_state_batch_json(batch_name, json.dumps(state_metadata))
 
 
 @pytest.fixture
@@ -99,13 +142,9 @@ def test_load_and_validate_without_batch_ref(temp_git_repo):
 
 
 def test_validate_batch_metadata_file_missing_for_existing_ref(temp_git_repo):
-    """Metadata file validation fails when ref exists but metadata missing."""
-    # Create a batch normally
-    create_batch("test-batch", "Test note")
-
-    # Delete metadata file but keep ref
+    """Metadata file validation fails for legacy refs without state refs."""
+    run_git_command(["update-ref", "refs/batches/test-batch", "HEAD"])
     metadata_path = get_batch_metadata_file_path("test-batch")
-    metadata_path.unlink()
 
     with pytest.raises(BatchMetadataError) as exc_info:
         validate_batch_metadata_file_exists("test-batch")
@@ -318,19 +357,16 @@ def test_load_and_validate_batch_metadata_success(temp_git_repo):
 
 
 def test_load_and_validate_batch_metadata_malformed_json(temp_git_repo):
-    """Loading batch metadata fails with clear error for malformed JSON."""
+    """Loading batch metadata fails for malformed authoritative state JSON."""
     create_batch("test-batch", "Test note")
 
-    # Write malformed JSON
-    metadata_path = get_batch_metadata_file_path("test-batch")
-    write_text_file_contents(metadata_path, "{ invalid json")
+    _write_state_batch_json("test-batch", "{ invalid json")
 
     with pytest.raises(BatchMetadataError) as exc_info:
         load_and_validate_batch_metadata("test-batch")
 
     error_msg = str(exc_info.value)
-    assert "corrupted (invalid JSON)" in error_msg
-    assert str(metadata_path) in error_msg
+    assert "failed to read batch metadata" in error_msg.lower()
 
 
 def test_load_and_validate_batch_metadata_missing_file(temp_git_repo):
@@ -357,11 +393,9 @@ def test_get_validated_baseline_commit_missing(temp_git_repo):
     """Getting validated baseline commit fails when baseline is missing."""
     create_batch("test-batch", "Test note")
 
-    # Corrupt metadata by removing baseline
-    metadata_path = get_batch_metadata_file_path("test-batch")
-    metadata = json.loads(metadata_path.read_text())
+    metadata = read_batch_metadata("test-batch")
     metadata["baseline"] = None
-    write_text_file_contents(metadata_path, json.dumps(metadata))
+    _write_state_metadata("test-batch", metadata)
 
     with pytest.raises(BatchMetadataError) as exc_info:
         get_validated_baseline_commit("test-batch")
@@ -385,15 +419,13 @@ def test_read_validated_batch_metadata_corrupted(temp_git_repo):
     """Reading validated batch metadata fails for corrupted metadata."""
     create_batch("test-batch", "Test note")
 
-    # Corrupt metadata
-    metadata_path = get_batch_metadata_file_path("test-batch")
-    write_text_file_contents(metadata_path, "corrupted")
+    _write_state_batch_json("test-batch", "corrupted")
 
     with pytest.raises(BatchMetadataError) as exc_info:
         read_validated_batch_metadata("test-batch")
 
     error_msg = str(exc_info.value)
-    assert "corrupted" in error_msg.lower()
+    assert "failed to read batch metadata" in error_msg.lower()
 
 
 def test_require_batch_metadata_sane_success(temp_git_repo):
@@ -405,12 +437,8 @@ def test_require_batch_metadata_sane_success(temp_git_repo):
 
 
 def test_require_batch_metadata_sane_corrupted(temp_git_repo):
-    """Requiring sane metadata fails for corrupted batch."""
-    create_batch("test-batch", "Test note")
-
-    # Delete metadata file but keep ref
-    metadata_path = get_batch_metadata_file_path("test-batch")
-    metadata_path.unlink()
+    """Requiring sane metadata fails for legacy ref missing metadata."""
+    run_git_command(["update-ref", "refs/batches/test-batch", "HEAD"])
 
     with pytest.raises(BatchMetadataError) as exc_info:
         require_batch_metadata_sane("test-batch")

--- a/tests/batch/test_query.py
+++ b/tests/batch/test_query.py
@@ -60,17 +60,18 @@ def test_read_batch_metadata_nonexistent(temp_git_repo):
     assert metadata["created_at"] == ""
 
 
-def test_read_batch_metadata_corrupted_file(temp_git_repo):
-    """Test reading corrupted metadata file returns empty."""
+def test_read_batch_metadata_ignores_corrupted_compat_file(temp_git_repo):
+    """Test authoritative state ref wins over corrupted compatibility metadata."""
     create_batch("test-batch", "Original")
 
     # Corrupt the metadata file
     metadata_path = get_batch_metadata_file_path("test-batch")
+    metadata_path.parent.mkdir(parents=True, exist_ok=True)
     metadata_path.write_text("invalid json{")
 
     metadata = read_batch_metadata("test-batch")
-    assert metadata["note"] == ""
-    assert metadata["created_at"] == ""
+    assert metadata["note"] == "Original"
+    assert metadata["created_at"] != ""
 
 
 def test_get_batch_commit_sha_existing(temp_git_repo):

--- a/tests/batch/test_state_refs.py
+++ b/tests/batch/test_state_refs.py
@@ -1,0 +1,101 @@
+"""Tests for experimental Git-backed batch state refs."""
+
+import json
+import subprocess
+
+import pytest
+
+from git_stage_batch.batch.operations import create_batch, delete_batch, update_batch_note
+from git_stage_batch.batch.ownership import BatchOwnership
+from git_stage_batch.batch.state_refs import get_batch_content_ref_name, get_batch_state_ref_name
+from git_stage_batch.batch.storage import add_file_to_batch
+from git_stage_batch.data.session import initialize_abort_state
+from git_stage_batch.utils.paths import ensure_state_directory_exists
+
+
+@pytest.fixture
+def temp_git_repo(tmp_path, monkeypatch):
+    """Create a temporary git repository for state ref tests."""
+    monkeypatch.chdir(tmp_path)
+    subprocess.run(["git", "init"], check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], check=True)
+
+    (tmp_path / "README").write_text("initial\n")
+    subprocess.run(["git", "add", "README"], check=True)
+    subprocess.run(["git", "commit", "-m", "Initial commit"], check=True, capture_output=True)
+
+    (tmp_path / "file.txt").write_text("line1\nline2\nline3\n")
+    ensure_state_directory_exists()
+    initialize_abort_state()
+
+    return tmp_path
+
+
+def _git_show(refspec: str) -> str:
+    return subprocess.run(
+        ["git", "show", refspec],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+
+
+def _git_rev_parse(refname: str) -> str:
+    return subprocess.run(
+        ["git", "rev-parse", "--verify", refname],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def test_state_ref_contains_batch_json_and_source_snapshot(temp_git_repo):
+    """State ref mirrors metadata and stores source bytes as tree entries."""
+    create_batch("test-batch", "Test note")
+    add_file_to_batch("test-batch", "file.txt", BatchOwnership(claimed_lines=["1-2"], deletions=[]))
+
+    content_ref = get_batch_content_ref_name("test-batch")
+    state_ref = get_batch_state_ref_name("test-batch")
+    content_commit = _git_rev_parse(content_ref)
+
+    batch_json = json.loads(_git_show(f"{state_ref}:batch.json"))
+    assert batch_json["batch"] == "test-batch"
+    assert batch_json["note"] == "Test note"
+    assert batch_json["content_ref"] == content_ref
+    assert batch_json["content_commit"] == content_commit
+    assert batch_json["files"]["file.txt"]["source_path"] == "sources/file.txt"
+
+    source_content = _git_show(f"{state_ref}:sources/file.txt")
+    assert source_content == "line1\nline2\nline3\n"
+
+
+def test_state_ref_updates_note_history(temp_git_repo):
+    """State ref advances when metadata-only fields change."""
+    create_batch("test-batch", "Before")
+    first_state = _git_rev_parse(get_batch_state_ref_name("test-batch"))
+
+    update_batch_note("test-batch", "After")
+    state_ref = get_batch_state_ref_name("test-batch")
+    second_state = _git_rev_parse(state_ref)
+
+    assert second_state != first_state
+    batch_json = json.loads(_git_show(f"{state_ref}:batch.json"))
+    assert batch_json["note"] == "After"
+
+
+def test_delete_batch_removes_experimental_refs(temp_git_repo):
+    """Deleting a batch removes its mirrored content and state refs."""
+    create_batch("test-batch", "Test")
+    assert _git_rev_parse(get_batch_content_ref_name("test-batch"))
+    assert _git_rev_parse(get_batch_state_ref_name("test-batch"))
+
+    delete_batch("test-batch")
+
+    for refname in (get_batch_content_ref_name("test-batch"), get_batch_state_ref_name("test-batch")):
+        result = subprocess.run(
+            ["git", "rev-parse", "--verify", refname],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0

--- a/tests/cli/test_argument_parser.py
+++ b/tests/cli/test_argument_parser.py
@@ -376,6 +376,34 @@ def test_parse_command_line_undo_force():
     assert callable(args.func)
 
 
+def test_parse_command_line_redo():
+    """Test parsing redo command."""
+    args = parse_command_line(["redo"], quiet=True)
+    assert args is not None
+    assert args.command == "redo"
+    assert args.force is False
+    assert hasattr(args, "func")
+    assert callable(args.func)
+
+
+def test_parse_command_line_redo_force():
+    """Test parsing redo --force command."""
+    args = parse_command_line(["redo", "--force"], quiet=True)
+    assert args is not None
+    assert args.force is True
+    assert hasattr(args, "func")
+    assert callable(args.func)
+
+
+def test_parse_command_line_redo_forward_alias():
+    """Test parsing redo command alias 'forward'."""
+    args = parse_command_line(["forward"], quiet=True)
+    assert args is not None
+    assert args.command == "forward"
+    assert hasattr(args, "func")
+    assert callable(args.func)
+
+
 def test_parse_command_line_show_with_from():
     """Test parsing show command with --from flag."""
     args = parse_command_line(["show", "--from", "my-batch"], quiet=True)

--- a/tests/cli/test_argument_parser.py
+++ b/tests/cli/test_argument_parser.py
@@ -357,6 +357,25 @@ def test_parse_command_line_annotate():
     assert callable(args.func)
 
 
+def test_parse_command_line_undo():
+    """Test parsing undo command."""
+    args = parse_command_line(["undo"], quiet=True)
+    assert args is not None
+    assert args.command == "undo"
+    assert args.force is False
+    assert hasattr(args, "func")
+    assert callable(args.func)
+
+
+def test_parse_command_line_undo_force():
+    """Test parsing undo --force command."""
+    args = parse_command_line(["undo", "--force"], quiet=True)
+    assert args is not None
+    assert args.force is True
+    assert hasattr(args, "func")
+    assert callable(args.func)
+
+
 def test_parse_command_line_show_with_from():
     """Test parsing show command with --from flag."""
     args = parse_command_line(["show", "--from", "my-batch"], quiet=True)

--- a/tests/commands/test_again.py
+++ b/tests/commands/test_again.py
@@ -19,9 +19,11 @@ from git_stage_batch.utils.paths import (
     get_abort_snapshot_list_file_path,
     get_abort_snapshots_directory_path,
     get_abort_stash_file_path,
+    get_block_list_file_path,
     get_batch_claimed_hunks_file_path,
     get_batch_directory_path,
     get_batches_directory_path,
+    get_session_batch_sources_file_path,
     get_state_directory_path,
 )
 
@@ -57,13 +59,13 @@ class TestCommandAgain:
         state_dir = get_state_directory_path()
 
         # Create iteration-specific files
-        blocklist = state_dir / "blocklist"
+        blocklist = get_block_list_file_path()
         blocklist.write_text("test")
 
         # Create permanent files
         journal = state_dir / "journal.jsonl"
         journal.write_text("test")
-        abort_head = state_dir / "abort-head"
+        abort_head = get_abort_head_file_path()
         abort_head.write_text("test")
 
         assert blocklist.exists()
@@ -112,7 +114,7 @@ class TestCommandAgain:
 
         # Add claimed lines to metadata (JSON format)
         metadata_path = batch_dir / "metadata.json"
-        metadata = json.loads(read_text_file_contents(metadata_path))
+        metadata = {"note": "Test batch", "created_at": "", "baseline": None}
         metadata["files"] = {
             "README.md": {
                 "batch_source_commit": "dummy",
@@ -253,7 +255,7 @@ class TestCommandAgain:
 
         # Create iteration-specific file to verify it was cleared
         state_dir = get_state_directory_path()
-        blocklist = state_dir / "blocklist"
+        blocklist = get_block_list_file_path()
         blocklist.write_text("test")
 
         # Run again (no batches exist)
@@ -296,8 +298,7 @@ class TestCommandAgain:
         fetch_next_change()
         command_discard_to_batch("test-batch", quiet=True)
 
-        state_dir = get_state_directory_path()
-        batch_sources_file = state_dir / "session-batch-sources.json"
+        batch_sources_file = get_session_batch_sources_file_path()
 
         assert batch_sources_file.exists(), "session-batch-sources.json should exist"
         content_before = read_text_file_contents(batch_sources_file)

--- a/tests/commands/test_annotate.py
+++ b/tests/commands/test_annotate.py
@@ -1,15 +1,13 @@
 """Tests for annotate batch command."""
 
-import json
 import subprocess
 
 import pytest
 
+from git_stage_batch.batch.query import read_batch_metadata
 from git_stage_batch.commands.annotate import command_annotate_batch
 from git_stage_batch.commands.new import command_new_batch
 from git_stage_batch.exceptions import CommandError
-from git_stage_batch.utils.file_io import read_text_file_contents
-from git_stage_batch.utils.paths import get_batch_metadata_file_path
 
 
 @pytest.fixture
@@ -36,36 +34,25 @@ class TestCommandAnnotateBatch:
 
     def test_annotate_batch_adds_note(self, temp_git_repo, capsys):
         """Test adding a note to a batch."""
-        # Create a batch without a note
         command_new_batch("test-batch")
 
-        # Add a note
         command_annotate_batch("test-batch", "This is a note")
 
-        # Verify note is stored
-        metadata_path = get_batch_metadata_file_path("test-batch")
-        assert metadata_path.exists()
-        metadata = json.loads(read_text_file_contents(metadata_path))
+        metadata = read_batch_metadata("test-batch")
         assert metadata["note"] == "This is a note"
 
-        # Verify success message
         captured = capsys.readouterr()
         assert "Updated note for batch 'test-batch'" in captured.err
 
     def test_annotate_batch_updates_note(self, temp_git_repo, capsys):
         """Test updating an existing note."""
-        # Create a batch with a note
         command_new_batch("test-batch", note="Original note")
 
-        # Update the note
         command_annotate_batch("test-batch", "Updated note")
 
-        # Verify note is updated
-        metadata_path = get_batch_metadata_file_path("test-batch")
-        metadata = json.loads(read_text_file_contents(metadata_path))
+        metadata = read_batch_metadata("test-batch")
         assert metadata["note"] == "Updated note"
 
-        # Verify success message
         captured = capsys.readouterr()
         assert "Updated note for batch 'test-batch'" in captured.err
 
@@ -76,7 +63,6 @@ class TestCommandAnnotateBatch:
 
     def test_annotate_batch_outside_repo_raises_error(self, tmp_path, monkeypatch):
         """Test annotating a batch outside a repo raises an error."""
-        # Change to a non-repo directory
         non_repo = tmp_path / "not_a_repo"
         non_repo.mkdir()
         monkeypatch.chdir(non_repo)
@@ -88,10 +74,7 @@ class TestCommandAnnotateBatch:
         """Test annotating a batch with an empty note."""
         command_new_batch("test-batch", note="Original note")
 
-        # Update with empty note
         command_annotate_batch("test-batch", "")
 
-        # Verify note is cleared
-        metadata_path = get_batch_metadata_file_path("test-batch")
-        metadata = json.loads(read_text_file_contents(metadata_path))
+        metadata = read_batch_metadata("test-batch")
         assert metadata["note"] == ""

--- a/tests/commands/test_drop.py
+++ b/tests/commands/test_drop.py
@@ -4,6 +4,7 @@ import subprocess
 
 import pytest
 
+from git_stage_batch.batch.state_refs import get_batch_content_ref_name
 from git_stage_batch.commands.drop import command_drop_batch
 from git_stage_batch.commands.new import command_new_batch
 from git_stage_batch.exceptions import CommandError
@@ -38,7 +39,7 @@ class TestCommandDropBatch:
 
         # Verify batch exists
         result = subprocess.run(
-            ["git", "show-ref", "refs/batches/test-batch"],
+            ["git", "show-ref", get_batch_content_ref_name("test-batch")],
             capture_output=True,
         )
         assert result.returncode == 0
@@ -48,7 +49,7 @@ class TestCommandDropBatch:
 
         # Verify batch ref is gone
         result = subprocess.run(
-            ["git", "show-ref", "refs/batches/test-batch"],
+            ["git", "show-ref", get_batch_content_ref_name("test-batch")],
             capture_output=True,
         )
         assert result.returncode != 0
@@ -84,20 +85,20 @@ class TestCommandDropBatch:
 
         # Verify batch-b is gone
         result = subprocess.run(
-            ["git", "show-ref", "refs/batches/batch-b"],
+            ["git", "show-ref", get_batch_content_ref_name("batch-b")],
             capture_output=True,
         )
         assert result.returncode != 0
 
         # Verify other batches still exist
         result = subprocess.run(
-            ["git", "show-ref", "refs/batches/batch-a"],
+            ["git", "show-ref", get_batch_content_ref_name("batch-a")],
             capture_output=True,
         )
         assert result.returncode == 0
 
         result = subprocess.run(
-            ["git", "show-ref", "refs/batches/batch-c"],
+            ["git", "show-ref", get_batch_content_ref_name("batch-c")],
             capture_output=True,
         )
         assert result.returncode == 0

--- a/tests/commands/test_file_scoped_operations.py
+++ b/tests/commands/test_file_scoped_operations.py
@@ -11,6 +11,7 @@ from git_stage_batch.commands.show_from import command_show_from_batch
 from git_stage_batch.data.line_state import load_line_changes_from_state
 from git_stage_batch.core.hashing import compute_stable_hunk_hash
 from git_stage_batch.utils.paths import (
+    get_line_changes_json_file_path,
     get_selected_hunk_hash_file_path,
     get_selected_hunk_patch_file_path,
 )
@@ -433,13 +434,9 @@ class TestErrorHandling:
         command_include_to_batch("batch", file="alpha.txt")
 
         # Remove the cached hunk state
-        state_dir = multi_file_repo / ".git" / "git-stage-batch"
-        if (state_dir / "selected-lines.json").exists():
-            (state_dir / "selected-lines.json").unlink()
-        if (state_dir / "selected-hunk-patch").exists():
-            (state_dir / "selected-hunk-patch").unlink()
-        if (state_dir / "selected-hunk-hash").exists():
-            (state_dir / "selected-hunk-hash").unlink()
+        get_line_changes_json_file_path().unlink(missing_ok=True)
+        get_selected_hunk_patch_file_path().unlink(missing_ok=True)
+        get_selected_hunk_hash_file_path().unlink(missing_ok=True)
 
         # No selected hunk cached
         with pytest.raises(CommandError, match="No selected hunk"):

--- a/tests/commands/test_new.py
+++ b/tests/commands/test_new.py
@@ -1,6 +1,7 @@
 """Tests for new batch command."""
 
 from git_stage_batch.batch import read_batch_metadata
+from git_stage_batch.batch.state_refs import get_batch_content_ref_name
 
 import subprocess
 
@@ -36,9 +37,9 @@ class TestCommandNewBatch:
         """Test creating a new batch."""
         command_new_batch("test-batch")
 
-        # Verify batch ref exists
+        # Verify authoritative batch ref exists
         result = subprocess.run(
-            ["git", "show-ref", "refs/batches/test-batch"],
+            ["git", "show-ref", get_batch_content_ref_name("test-batch")],
             capture_output=True,
             text=True,
         )
@@ -52,9 +53,9 @@ class TestCommandNewBatch:
         """Test creating a batch with a note."""
         command_new_batch("test-batch", note="Test description")
 
-        # Verify batch ref exists
+        # Verify authoritative batch ref exists
         result = subprocess.run(
-            ["git", "show-ref", "refs/batches/test-batch"],
+            ["git", "show-ref", get_batch_content_ref_name("test-batch")],
             capture_output=True,
             text=True,
         )

--- a/tests/commands/test_reset.py
+++ b/tests/commands/test_reset.py
@@ -1,28 +1,21 @@
 """Tests for reset command."""
 
-import json
-from git_stage_batch.core.line_selection import parse_line_selection
-from git_stage_batch.exceptions import NoMoreHunks
-from git_stage_batch.commands.again import command_again
-from git_stage_batch.batch.ownership import BatchOwnership, DeletionClaim
-from git_stage_batch.batch.storage import add_file_to_batch, read_file_from_batch
-from git_stage_batch.commands.new import command_new_batch
-from git_stage_batch.batch.ownership import BatchOwnership
-from git_stage_batch.data.batch_sources import create_batch_source_commit, save_session_batch_sources
-
 import subprocess
 
 import pytest
 
+from git_stage_batch.batch.ownership import BatchOwnership, DeletionClaim
+from git_stage_batch.batch.query import read_batch_metadata
+from git_stage_batch.batch.storage import add_file_to_batch, read_file_from_batch
+from git_stage_batch.commands.again import command_again
 from git_stage_batch.commands.include import command_include_to_batch
+from git_stage_batch.commands.new import command_new_batch
 from git_stage_batch.commands.reset import command_reset_from_batch
 from git_stage_batch.commands.start import command_start
+from git_stage_batch.core.line_selection import parse_line_selection
+from git_stage_batch.data.batch_sources import create_batch_source_commit, save_session_batch_sources
 from git_stage_batch.data.hunk_tracking import fetch_next_change
-from git_stage_batch.exceptions import CommandError
-from git_stage_batch.utils.file_io import read_text_file_contents
-from git_stage_batch.utils.paths import (
-    get_batch_metadata_file_path,
-)
+from git_stage_batch.exceptions import CommandError, NoMoreHunks
 
 
 @pytest.fixture
@@ -78,9 +71,7 @@ class TestResetFromBatch:
         command_include_to_batch("mybatch", quiet=True)
 
         # Verify batch has claims in metadata
-        metadata_path = get_batch_metadata_file_path("mybatch")
-        assert metadata_path.exists()
-        metadata = json.loads(read_text_file_contents(metadata_path))
+        metadata = read_batch_metadata("mybatch")
         assert "test.py" in metadata["files"]
         assert len(metadata["files"]["test.py"]["claimed_lines"]) > 0
 
@@ -88,7 +79,7 @@ class TestResetFromBatch:
         command_reset_from_batch("mybatch")
 
         # Verify batch metadata files section is cleared
-        metadata_after = json.loads(read_text_file_contents(metadata_path))
+        metadata_after = read_batch_metadata("mybatch")
         assert metadata_after["files"] == {}
 
     def test_reset_line_claims(self, temp_git_repo):
@@ -108,10 +99,8 @@ class TestResetFromBatch:
         fetch_next_change()
         command_include_to_batch("mybatch", line_ids="4,5,6", quiet=True)
 
-        # Verify line claims exist in metadata JSON
-        metadata_path = get_batch_metadata_file_path("mybatch")
-        assert metadata_path.exists()
-        metadata = json.loads(read_text_file_contents(metadata_path))
+        # Verify line claims exist in metadata
+        metadata = read_batch_metadata("mybatch")
         batch_ownership = metadata["files"]["test.py"]
         batch_line_ids = set()
         for range_str in batch_ownership.get("claimed_lines", []):
@@ -122,7 +111,7 @@ class TestResetFromBatch:
         command_reset_from_batch("mybatch", line_ids="2")
 
         # Verify line 2 is removed from batch claims
-        metadata_after = json.loads(read_text_file_contents(metadata_path))
+        metadata_after = read_batch_metadata("mybatch")
         batch_ownership_after = metadata_after["files"]["test.py"]
         batch_line_ids_after = set()
         for range_str in batch_ownership_after.get("claimed_lines", []):
@@ -150,19 +139,17 @@ class TestResetFromBatch:
         command_include_to_batch("batch-b", quiet=True)
 
         # Verify both batches have the file
-        metadata_a_path = get_batch_metadata_file_path("batch-a")
-        metadata_a = json.loads(read_text_file_contents(metadata_a_path))
+        metadata_a = read_batch_metadata("batch-a")
         assert "test.py" in metadata_a["files"]
 
-        metadata_b_path = get_batch_metadata_file_path("batch-b")
-        metadata_b = json.loads(read_text_file_contents(metadata_b_path))
+        metadata_b = read_batch_metadata("batch-b")
         assert "test.py" in metadata_b["files"]
 
         # Reset batch-a
         command_reset_from_batch("batch-a")
 
         # Verify batch-a no longer claims the file
-        metadata_a_after = json.loads(read_text_file_contents(metadata_a_path))
+        metadata_a_after = read_batch_metadata("batch-a")
         assert "test.py" not in metadata_a_after["files"]
 
         # Verify hunk is STILL filtered (because batch-b still claims it)
@@ -207,7 +194,7 @@ class TestResetFromBatch:
 
         command_reset_from_batch("mybatch", file="file1.txt")
 
-        metadata_after = json.loads(read_text_file_contents(get_batch_metadata_file_path("mybatch")))
+        metadata_after = read_batch_metadata("mybatch")
         assert "file1.txt" not in metadata_after["files"]
         assert "file2.txt" in metadata_after["files"]
         assert read_file_from_batch("mybatch", "file1.txt") is None
@@ -232,7 +219,7 @@ class TestResetFromBatch:
             "100644",
         )
 
-        metadata_before = json.loads(read_text_file_contents(get_batch_metadata_file_path("mybatch")))
+        metadata_before = read_batch_metadata("mybatch")
         original_source = metadata_before["files"]["test.py"]["batch_source_commit"]
 
         wrong_source = create_batch_source_commit(
@@ -243,7 +230,7 @@ class TestResetFromBatch:
 
         command_reset_from_batch("mybatch", line_ids="1", file="test.py")
 
-        metadata_after = json.loads(read_text_file_contents(get_batch_metadata_file_path("mybatch")))
+        metadata_after = read_batch_metadata("mybatch")
         file_meta = metadata_after["files"]["test.py"]
         assert file_meta["batch_source_commit"] == original_source
 
@@ -271,14 +258,14 @@ class TestResetFromBatch:
             "100644",
         )
 
-        source_before = json.loads(read_text_file_contents(get_batch_metadata_file_path("source")))
+        source_before = read_batch_metadata("source")
         original_source = source_before["files"]["test.py"]["batch_source_commit"]
         source_baseline = source_before["baseline"]
 
         command_reset_from_batch("source", line_ids="1", file="test.py", to_batch="dest")
 
-        source_after = json.loads(read_text_file_contents(get_batch_metadata_file_path("source")))
-        dest_after = json.loads(read_text_file_contents(get_batch_metadata_file_path("dest")))
+        source_after = read_batch_metadata("source")
+        dest_after = read_batch_metadata("dest")
 
         assert dest_after["baseline"] == source_baseline
         assert dest_after["files"]["test.py"]["batch_source_commit"] == original_source
@@ -321,8 +308,8 @@ class TestResetFromBatch:
 
         command_reset_from_batch("source", file="file1.txt", to_batch="dest")
 
-        source_after = json.loads(read_text_file_contents(get_batch_metadata_file_path("source")))
-        dest_after = json.loads(read_text_file_contents(get_batch_metadata_file_path("dest")))
+        source_after = read_batch_metadata("source")
+        dest_after = read_batch_metadata("dest")
 
         assert "file1.txt" not in source_after["files"]
         assert "file2.txt" in source_after["files"]
@@ -395,7 +382,7 @@ class TestResetFromBatch:
         add_file_to_batch("mybatch", "test.py", ownership, "100644")
 
         # Verify initial ownership has both claimed line and deletion
-        metadata = json.loads(read_text_file_contents(get_batch_metadata_file_path("mybatch")))
+        metadata = read_batch_metadata("mybatch")
         file_ownership = BatchOwnership.from_metadata_dict(metadata["files"]["test.py"])
         assert "1" in ",".join(file_ownership.claimed_lines)
         assert len(file_ownership.deletions) == 1
@@ -406,7 +393,7 @@ class TestResetFromBatch:
         command_reset_from_batch("mybatch", line_ids="1,2")
 
         # Verify file is removed from batch (no ownership remains)
-        metadata_after = json.loads(read_text_file_contents(get_batch_metadata_file_path("mybatch")))
+        metadata_after = read_batch_metadata("mybatch")
         assert "test.py" not in metadata_after.get("files", {}), \
             "Expected file to be removed from batch when all ownership is reset"
 
@@ -480,7 +467,7 @@ class TestResetFromBatch:
         command_reset_from_batch("mybatch", line_ids="2")
 
         # Verify line 3 is removed but lines 1, 5 and deletion remain
-        metadata_after = json.loads(read_text_file_contents(get_batch_metadata_file_path("mybatch")))
+        metadata_after = read_batch_metadata("mybatch")
         file_ownership = BatchOwnership.from_metadata_dict(metadata_after["files"]["test.py"])
         claimed_ids = set()
         for range_str in file_ownership.claimed_lines:
@@ -526,7 +513,7 @@ class TestResetFromBatch:
         command_reset_from_batch("mybatch", line_ids="1,2")
 
         # Verify line 1 AND its deletion are removed, but line 2 remains
-        metadata_after = json.loads(read_text_file_contents(get_batch_metadata_file_path("mybatch")))
+        metadata_after = read_batch_metadata("mybatch")
         file_ownership = BatchOwnership.from_metadata_dict(metadata_after["files"]["test.py"])
         claimed_ids = set()
         for range_str in file_ownership.claimed_lines:
@@ -572,7 +559,7 @@ class TestResetFromBatch:
         command_reset_from_batch("mybatch", line_ids="2")
 
         # Verify only source line 2 is removed, lines 1 and 3 remain
-        metadata_after = json.loads(read_text_file_contents(get_batch_metadata_file_path("mybatch")))
+        metadata_after = read_batch_metadata("mybatch")
         file_ownership = BatchOwnership.from_metadata_dict(metadata_after["files"]["test.py"])
         claimed_ids = set()
         for range_str in file_ownership.claimed_lines:

--- a/tests/commands/test_sift.py
+++ b/tests/commands/test_sift.py
@@ -7,6 +7,7 @@ import pytest
 
 from git_stage_batch.batch.validation import batch_exists
 from git_stage_batch.batch.ownership import BatchOwnership
+from git_stage_batch.batch.state_refs import get_batch_content_ref_name
 from git_stage_batch.commands.new import command_new_batch
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.commands.apply_from import command_apply_from_batch
@@ -531,7 +532,7 @@ class TestSiftBinaryFiles:
 
     def _batch_file_bytes(self, batch_name: str, file_path: str) -> bytes | None:
         commit = subprocess.run(
-            ["git", "rev-parse", f"refs/batches/{batch_name}"],
+            ["git", "rev-parse", get_batch_content_ref_name(batch_name)],
             capture_output=True,
             text=True,
         )
@@ -693,7 +694,7 @@ class TestSiftPersistenceModel:
 
         # Read the batch commit to verify it contains realized target, not working tree
         result = subprocess.run(
-            ["git", "rev-parse", "refs/batches/sifted-batch"],
+            ["git", "rev-parse", get_batch_content_ref_name("sifted-batch")],
             cwd=temp_git_repo,
             capture_output=True,
             text=True
@@ -736,7 +737,7 @@ class TestSiftPersistenceModel:
 
         # Verify batch commit exists and can be read with git
         result = subprocess.run(
-            ["git", "rev-parse", "refs/batches/sifted-batch"],
+            ["git", "rev-parse", get_batch_content_ref_name("sifted-batch")],
             cwd=temp_git_repo,
             capture_output=True,
             text=True

--- a/tests/data/test_batch_refs.py
+++ b/tests/data/test_batch_refs.py
@@ -8,6 +8,7 @@ import subprocess
 import pytest
 
 from git_stage_batch.data.batch_refs import restore_batch_refs, snapshot_batch_refs
+from git_stage_batch.batch.state_refs import get_batch_content_ref_name
 from git_stage_batch.utils.file_io import read_text_file_contents
 from git_stage_batch.utils.git import run_git_command
 from git_stage_batch.utils.paths import (
@@ -133,14 +134,13 @@ class TestRestoreBatchRefs:
         # Restore
         restore_batch_refs()
 
-        # Verify batch was restored
-        result = run_git_command(["show-ref", f"refs/batches/{batch_name}"], check=False)
+        # Verify batch was restored into authoritative storage
+        result = run_git_command(["show-ref", get_batch_content_ref_name(batch_name)], check=False)
         assert result.returncode == 0
 
-        # Verify metadata was restored
-        assert metadata_path.exists()
-        restored_metadata = json.loads(read_text_file_contents(metadata_path))
-        assert restored_metadata["note"] == "Test note"
+        # Verify metadata was migrated and legacy storage was removed
+        assert not metadata_path.exists()
+        assert not metadata_path.parent.exists()
 
     def test_restore_reverts_modified_batches(self, temp_git_repo):
         """Test that modified batch refs are reverted."""
@@ -170,6 +170,8 @@ class TestRestoreBatchRefs:
         # Restore
         restore_batch_refs()
 
-        # Verify batch was reverted to original commit
-        result = run_git_command(["rev-parse", f"refs/batches/{batch_name}"])
+        # Verify batch was reverted to original commit in authoritative storage
+        result = run_git_command(["rev-parse", get_batch_content_ref_name(batch_name)])
         assert result.stdout.strip() == original_sha
+        result = run_git_command(["show-ref", f"refs/batches/{batch_name}"], check=False)
+        assert result.returncode != 0

--- a/tests/data/test_batch_refs.py
+++ b/tests/data/test_batch_refs.py
@@ -8,6 +8,7 @@ import subprocess
 import pytest
 
 from git_stage_batch.data.batch_refs import restore_batch_refs, snapshot_batch_refs
+from git_stage_batch.batch.operations import create_batch, update_batch_note
 from git_stage_batch.batch.state_refs import get_batch_content_ref_name
 from git_stage_batch.utils.file_io import read_text_file_contents
 from git_stage_batch.utils.git import run_git_command
@@ -175,3 +176,31 @@ class TestRestoreBatchRefs:
         assert result.stdout.strip() == original_sha
         result = run_git_command(["show-ref", f"refs/batches/{batch_name}"], check=False)
         assert result.returncode != 0
+
+    def test_restore_reverts_git_backed_state_ref_exactly(self, temp_git_repo):
+        """Test restore moves authoritative state ref back to its snapshot SHA."""
+        batch_name = "test-batch"
+        create_batch(batch_name, "before")
+        original_content_sha = run_git_command(
+            ["rev-parse", f"refs/git-stage-batch/batches/{batch_name}"]
+        ).stdout.strip()
+        original_state_sha = run_git_command(
+            ["rev-parse", f"refs/git-stage-batch/state/{batch_name}"]
+        ).stdout.strip()
+
+        snapshot_batch_refs()
+        update_batch_note(batch_name, "after")
+        assert run_git_command(
+            ["rev-parse", f"refs/git-stage-batch/state/{batch_name}"]
+        ).stdout.strip() != original_state_sha
+
+        restore_batch_refs()
+
+        restored_content_sha = run_git_command(
+            ["rev-parse", f"refs/git-stage-batch/batches/{batch_name}"]
+        ).stdout.strip()
+        restored_state_sha = run_git_command(
+            ["rev-parse", f"refs/git-stage-batch/state/{batch_name}"]
+        ).stdout.strip()
+        assert restored_content_sha == original_content_sha
+        assert restored_state_sha == original_state_sha

--- a/tests/functional/test_batch_source_timing.py
+++ b/tests/functional/test_batch_source_timing.py
@@ -1,9 +1,8 @@
 """Test that batch source commits capture content at session start, not at first discard."""
 
-import json
-from pathlib import Path
-
 import subprocess
+
+from git_stage_batch.batch.query import read_batch_metadata
 
 from .conftest import git_stage_batch
 
@@ -48,13 +47,7 @@ def my_function():
     assert not new_file.exists(), "File should be removed from working tree"
 
     # Now verify the batch source commit contains the ORIGINAL content
-    # Read the batch metadata to get batch source commit
-
-    state_dir = Path(".git/git-stage-batch")
-    metadata_file = state_dir / "batches" / "test-batch" / "metadata.json"
-    assert metadata_file.exists(), "Batch metadata should exist"
-
-    metadata = json.loads(metadata_file.read_text())
+    metadata = read_batch_metadata("test-batch")
     assert "files" in metadata, "Metadata should have files key"
     assert "test_module.py" in metadata["files"], "File should be in metadata"
 

--- a/tests/functional/test_metadata_corruption_handling.py
+++ b/tests/functional/test_metadata_corruption_handling.py
@@ -10,12 +10,53 @@ import subprocess
 import pytest
 
 from git_stage_batch.batch.operations import create_batch
+from git_stage_batch.batch.query import read_batch_metadata
 from git_stage_batch.commands.show_from import command_show_from_batch
 from git_stage_batch.exceptions import CommandError
-from git_stage_batch.utils.paths import (
-    get_batch_metadata_file_path,
-    get_state_directory_path,
-)
+from git_stage_batch.utils.paths import get_state_directory_path
+
+
+def _write_state_batch_json(batch_name: str, content: str) -> None:
+    """Replace authoritative batch.json for a batch state ref."""
+    blob = subprocess.run(
+        ["git", "hash-object", "-w", "--stdin"],
+        input=content,
+        text=True,
+        check=True,
+        capture_output=True,
+    ).stdout.strip()
+    tree = subprocess.run(
+        ["git", "mktree"],
+        input=f"100644 blob {blob}\tbatch.json\n",
+        text=True,
+        check=True,
+        capture_output=True,
+    ).stdout.strip()
+    commit = subprocess.run(
+        ["git", "commit-tree", tree, "-m", f"Corrupt batch state: {batch_name}"],
+        text=True,
+        check=True,
+        capture_output=True,
+    ).stdout.strip()
+    subprocess.run(["git", "update-ref", f"refs/git-stage-batch/state/{batch_name}", commit], check=True)
+
+
+def _write_state_metadata(batch_name: str, metadata: dict) -> None:
+    state_metadata = {
+        "batch": batch_name,
+        "note": metadata.get("note", ""),
+        "created_at": metadata.get("created_at", ""),
+        "baseline_commit": metadata.get("baseline"),
+        "content_ref": f"refs/git-stage-batch/batches/{batch_name}",
+        "content_commit": subprocess.run(
+            ["git", "rev-parse", f"refs/git-stage-batch/batches/{batch_name}"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip(),
+        "files": metadata.get("files", {}),
+    }
+    _write_state_batch_json(batch_name, json.dumps(state_metadata))
 
 
 def test_missing_metadata_directory_clear_error(functional_repo):
@@ -37,42 +78,28 @@ def test_missing_metadata_directory_clear_error(functional_repo):
 
 
 def test_missing_metadata_file_clear_error(functional_repo):
-    """Test that missing metadata file for existing batch produces clear error."""
-    # Create a batch
+    """Test missing compatibility metadata does not break authoritative state."""
     create_batch("test-batch", "Test")
 
-    # Create refs/batches/test-batch ref to simulate batch existing
+    # Create stale legacy state alongside authoritative state.
     subprocess.run(["git", "update-ref", "refs/batches/test-batch", "HEAD"], check=True)
 
-    # Delete metadata file but keep ref
-    metadata_path = get_batch_metadata_file_path("test-batch")
-    metadata_path.unlink()
-
-    # Try to show batch - should get clear error about missing metadata
-    with pytest.raises(CommandError) as exc_info:
-        command_show_from_batch("test-batch")
-
-    error_msg = str(exc_info.value.message)
-    assert "metadata is missing or corrupted" in error_msg.lower()
-    assert "test-batch" in error_msg
+    command_show_from_batch("test-batch")
 
 
-def test_corrupted_metadata_json_clear_error(functional_repo):
-    """Test that corrupted JSON in metadata produces clear error."""
+def test_corrupted_state_json_clear_error(functional_repo):
+    """Test that corrupted JSON in authoritative state produces clear error."""
     # Create a batch
     create_batch("test-batch", "Test")
 
-    # Corrupt metadata
-    metadata_path = get_batch_metadata_file_path("test-batch")
-    metadata_path.write_text("{ corrupted json syntax")
+    _write_state_batch_json("test-batch", "{ corrupted json syntax")
 
     # Try to show batch - should get clear error about corrupted metadata
     with pytest.raises(CommandError) as exc_info:
         command_show_from_batch("test-batch")
 
     error_msg = str(exc_info.value.message)
-    assert "corrupted" in error_msg.lower()
-    assert "invalid json" in error_msg.lower()
+    assert "failed to read batch metadata" in error_msg.lower()
 
 
 def test_missing_baseline_clear_error(functional_repo):
@@ -80,14 +107,9 @@ def test_missing_baseline_clear_error(functional_repo):
     # Create a batch
     create_batch("test-batch", "Test")
 
-    # Create refs/batches/test-batch ref to simulate batch existing
-    subprocess.run(["git", "update-ref", "refs/batches/test-batch", "HEAD"], check=True)
-
-    # Remove baseline from metadata
-    metadata_path = get_batch_metadata_file_path("test-batch")
-    metadata = json.loads(metadata_path.read_text())
+    metadata = read_batch_metadata("test-batch")
     metadata["baseline"] = None
-    metadata_path.write_text(json.dumps(metadata))
+    _write_state_metadata("test-batch", metadata)
 
     # Try to show batch - should get clear error about missing baseline
     with pytest.raises(CommandError) as exc_info:
@@ -104,12 +126,7 @@ def test_missing_batch_source_commit_clear_error(functional_repo):
     # Create a batch with valid baseline
     create_batch("test-batch", "Test")
 
-    # Create refs/batches/test-batch ref to simulate batch existing
-    subprocess.run(["git", "update-ref", "refs/batches/test-batch", "HEAD"], check=True)
-
-    # Add a file entry to metadata without batch_source_commit
-    metadata_path = get_batch_metadata_file_path("test-batch")
-    metadata = json.loads(metadata_path.read_text())
+    metadata = read_batch_metadata("test-batch")
     metadata["files"] = {
         "test.txt": {
             "claimed_lines": ["1-3"],
@@ -117,7 +134,7 @@ def test_missing_batch_source_commit_clear_error(functional_repo):
             # Missing batch_source_commit
         }
     }
-    metadata_path.write_text(json.dumps(metadata))
+    _write_state_metadata("test-batch", metadata)
 
     # Try to show batch - should get clear error about missing batch_source_commit
     with pytest.raises(CommandError) as exc_info:
@@ -132,11 +149,9 @@ def test_invalid_baseline_commit_clear_error(functional_repo):
     # Create a batch
     create_batch("test-batch", "Test")
 
-    # Set invalid baseline commit
-    metadata_path = get_batch_metadata_file_path("test-batch")
-    metadata = json.loads(metadata_path.read_text())
+    metadata = read_batch_metadata("test-batch")
     metadata["baseline"] = "0000000000000000000000000000000000000000"
-    metadata_path.write_text(json.dumps(metadata))
+    _write_state_metadata("test-batch", metadata)
 
     # Try to show batch - should get clear error about invalid baseline
     with pytest.raises(CommandError) as exc_info:

--- a/tests/functional/test_redo.py
+++ b/tests/functional/test_redo.py
@@ -1,0 +1,225 @@
+"""Functional tests for redo support."""
+
+import subprocess
+
+from .conftest import git_stage_batch, get_staged_diff
+
+
+def _git(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["git", *args], check=True, capture_output=True, text=True)
+
+
+def _commit_file(path, content: str) -> None:
+    path.write_text(content)
+    _git("add", str(path))
+    _git("commit", "-m", f"Add {path.name}")
+
+
+def test_redo_after_undo_include_line_restores_index(functional_repo):
+    """Redoing an undone include --line restores the staged diff."""
+    test_file = functional_repo / "notes.txt"
+    _commit_file(test_file, "one\n")
+    test_file.write_text("one\ntwo\n")
+
+    git_stage_batch("start")
+    git_stage_batch("include", "--line", "1")
+    assert "+two" in get_staged_diff("notes.txt")
+
+    git_stage_batch("undo")
+    assert get_staged_diff("notes.txt") == ""
+
+    result = git_stage_batch("redo")
+    assert result.returncode == 0
+    assert "Redid: include --line 1" in result.stderr
+    assert "+two" in get_staged_diff("notes.txt")
+
+
+def test_redo_after_undo_discard_line_restores_worktree(functional_repo):
+    """Redoing an undone discard --line re-discards the line."""
+    test_file = functional_repo / "notes.txt"
+    _commit_file(test_file, "one\n")
+    original = "one\ntwo\n"
+    test_file.write_text(original)
+
+    git_stage_batch("start")
+    git_stage_batch("discard", "--line", "1")
+    assert test_file.read_text() == "one\n"
+
+    git_stage_batch("undo")
+    assert test_file.read_text() == original
+
+    git_stage_batch("redo")
+    assert test_file.read_text() == "one\n"
+
+
+def test_multiple_undo_redo_order(functional_repo):
+    """Multiple undo/redo cycles work in editor order."""
+    file_a = functional_repo / "a.txt"
+    file_b = functional_repo / "b.txt"
+    _commit_file(file_a, "a-base\n")
+    _commit_file(file_b, "b-base\n")
+    file_a.write_text("a-base\na-new\n")
+    file_b.write_text("b-base\nb-new\n")
+
+    git_stage_batch("start")
+
+    git_stage_batch("include", "--line", "1")
+
+    git_stage_batch("include", "--line", "1")
+
+    git_stage_batch("undo")
+    git_stage_batch("undo")
+
+    staged = get_staged_diff()
+    assert "+a-new" not in staged
+    assert "+b-new" not in staged
+
+    result = git_stage_batch("redo")
+    assert result.returncode == 0
+
+    result = git_stage_batch("redo")
+    assert result.returncode == 0
+
+    staged = get_staged_diff()
+    assert "+a-new" in staged
+    assert "+b-new" in staged
+
+
+def test_new_operation_after_undo_clears_redo(functional_repo):
+    """A new undoable operation after undo clears the redo stack."""
+    test_file = functional_repo / "notes.txt"
+    _commit_file(test_file, "one\n")
+    test_file.write_text("one\ntwo\nthree\n")
+
+    git_stage_batch("start")
+    git_stage_batch("include", "--line", "1")
+    git_stage_batch("undo")
+
+    git_stage_batch("skip")
+
+    result = git_stage_batch("redo", check=False)
+    assert result.returncode != 0
+    assert "Nothing to redo" in result.stderr
+
+
+def test_redo_refuses_when_state_changed_after_undo(functional_repo):
+    """Redo refuses if the user modified state after the undo."""
+    test_file = functional_repo / "notes.txt"
+    _commit_file(test_file, "one\n")
+    test_file.write_text("one\ntwo\n")
+
+    git_stage_batch("start")
+    git_stage_batch("include", "--line", "1")
+    git_stage_batch("undo")
+
+    test_file.write_text("one\ntwo\nthree\n")
+
+    result = git_stage_batch("redo", check=False)
+    assert result.returncode != 0
+    assert "current state has changed since the undo" in result.stderr
+    assert "--force" in result.stderr
+
+
+def test_redo_force_overwrites_later_changes(functional_repo):
+    """Redo --force overwrites changes made after the undo."""
+    test_file = functional_repo / "notes.txt"
+    _commit_file(test_file, "one\n")
+    test_file.write_text("one\ntwo\n")
+
+    git_stage_batch("start")
+    git_stage_batch("include", "--line", "1")
+    git_stage_batch("undo")
+
+    test_file.write_text("one\ntwo\nthree\n")
+
+    result = git_stage_batch("redo", "--force")
+    assert result.returncode == 0
+    assert "+two" in get_staged_diff("notes.txt")
+
+
+def test_redo_with_empty_stack_fails(repo_with_changes):
+    """Redo reports an error when no redo node exists."""
+    git_stage_batch("start")
+
+    result = git_stage_batch("redo", check=False)
+
+    assert result.returncode != 0
+    assert "Nothing to redo" in result.stderr
+
+
+def test_redo_include_to_batch_restores_batch_refs(functional_repo):
+    """Redoing an undone include-to-batch restores batch content and state refs."""
+    test_file = functional_repo / "notes.txt"
+    _commit_file(test_file, "one\n")
+    test_file.write_text("one\ntwo\n")
+
+    git_stage_batch("new", "redo-batch")
+    git_stage_batch("start")
+    git_stage_batch("include", "--to", "redo-batch", "--line", "1")
+
+    batch_content = git_stage_batch("show", "--from", "redo-batch").stdout
+    assert batch_content
+    content_ref = _git("rev-parse", "refs/git-stage-batch/batches/redo-batch").stdout.strip()
+    state_ref = _git("rev-parse", "refs/git-stage-batch/state/redo-batch").stdout.strip()
+
+    git_stage_batch("undo")
+    assert git_stage_batch("show", "--from", "redo-batch").stdout == ""
+
+    git_stage_batch("redo")
+    assert git_stage_batch("show", "--from", "redo-batch").stdout == batch_content
+    assert _git("rev-parse", "refs/git-stage-batch/batches/redo-batch").stdout.strip() == content_ref
+    assert _git("rev-parse", "refs/git-stage-batch/state/redo-batch").stdout.strip() == state_ref
+
+
+def test_redo_block_file_restores_blocked_state(functional_repo):
+    """Redoing an undone block-file re-blocks the file."""
+    test_file = functional_repo / "generated.log"
+    test_file.write_text("generated\n")
+
+    git_stage_batch("start")
+    git_stage_batch("block-file", "generated.log")
+
+    assert not _git("ls-files", "--", "generated.log").stdout.strip()
+    assert "generated.log" in (functional_repo / ".gitignore").read_text()
+
+    git_stage_batch("undo")
+
+    assert _git("ls-files", "--", "generated.log").stdout.strip() == "generated.log"
+    assert not (functional_repo / ".gitignore").exists()
+
+    git_stage_batch("redo")
+
+    assert not _git("ls-files", "--", "generated.log").stdout.strip()
+    assert "generated.log" in (functional_repo / ".gitignore").read_text()
+
+
+def test_redo_unblock_file_restores_unblocked_state(functional_repo):
+    """Redoing an undone unblock-file re-unblocks the file."""
+    test_file = functional_repo / "generated.log"
+    test_file.write_text("generated\n")
+
+    git_stage_batch("start")
+    git_stage_batch("block-file", "generated.log")
+    git_stage_batch("unblock-file", "generated.log")
+
+    assert _git("ls-files", "--", "generated.log").stdout.strip() == "generated.log"
+    assert "generated.log" not in (functional_repo / ".gitignore").read_text()
+
+    git_stage_batch("undo")
+
+    assert not _git("ls-files", "--", "generated.log").stdout.strip()
+    assert "generated.log" in (functional_repo / ".gitignore").read_text()
+
+    git_stage_batch("redo")
+
+    assert _git("ls-files", "--", "generated.log").stdout.strip() == "generated.log"
+    assert "generated.log" not in (functional_repo / ".gitignore").read_text()
+
+
+def test_redo_forward_alias_works(repo_with_changes):
+    """The 'forward' alias works for redo."""
+    git_stage_batch("start")
+
+    result = git_stage_batch("forward", check=False)
+    assert result.returncode != 0
+    assert "Nothing to redo" in result.stderr

--- a/tests/functional/test_stash_with_intent_to_add.py
+++ b/tests/functional/test_stash_with_intent_to_add.py
@@ -1,9 +1,9 @@
 """Test that stash creation works even with intent-to-add files in index."""
 
-from pathlib import Path
-import json
-
 import subprocess
+
+from git_stage_batch.batch.query import read_batch_metadata
+from git_stage_batch.utils.paths import get_abort_snapshot_list_file_path, get_abort_stash_file_path
 
 from .conftest import git_stage_batch
 
@@ -37,10 +37,10 @@ def test_stash_created_despite_intent_to_add_files(repo_with_changes):
     git_stage_batch("start")
 
     # Verify stash was created by checking if abort-stash file exists
-    stash_file = Path(".git/git-stage-batch/abort-stash")
+    stash_file = get_abort_stash_file_path()
 
     if not stash_file.exists():
-        snapshot_list = Path(".git/git-stage-batch/abort-snapshot-list")
+        snapshot_list = get_abort_snapshot_list_file_path()
         if snapshot_list.exists():
             snapshots = snapshot_list.read_text().strip().split('\n')
             print(f"Snapshots created: {snapshots}")
@@ -110,10 +110,7 @@ def test_batch_source_from_stashed_tracked_file(repo_with_changes):
     git_stage_batch("discard", "--file", "--to", "test-batch")
 
     # Check batch source commit has the modified content (from stash)
-
-    metadata_file = Path(".git/git-stage-batch/batches/test-batch/metadata.json")
-    metadata = json.loads(metadata_file.read_text())
-
+    metadata = read_batch_metadata("test-batch")
     batch_source_sha = metadata["files"]["module.py"]["batch_source_commit"]
 
     # Read batch source content

--- a/tests/functional/test_undo.py
+++ b/tests/functional/test_undo.py
@@ -15,6 +15,108 @@ def _commit_file(path, content: str) -> None:
     _git("commit", "-m", f"Add {path.name}")
 
 
+def test_undo_skip_restores_selected_hunk(repo_with_changes):
+    """Undoing skip makes the skipped hunk selected again."""
+    git_stage_batch("start")
+    first_show = git_stage_batch("show").stdout
+
+    git_stage_batch("skip")
+    after_skip = git_stage_batch("show", check=False)
+    if after_skip.returncode == 0:
+        assert after_skip.stdout != first_show
+
+    result = git_stage_batch("undo")
+    assert result.returncode == 0
+    assert "Undid: skip" in result.stderr
+    assert git_stage_batch("show").stdout == first_show
+
+
+def test_undo_include_line_restores_index(functional_repo):
+    """Undoing line include restores the pre-operation index."""
+    test_file = functional_repo / "notes.txt"
+    _commit_file(test_file, "one\n")
+    test_file.write_text("one\ntwo\n")
+
+    git_stage_batch("start")
+    git_stage_batch("include", "--line", "1")
+    assert "+two" in get_staged_diff("notes.txt")
+
+    git_stage_batch("undo")
+    assert get_staged_diff("notes.txt") == ""
+
+
+def test_undo_discard_line_restores_worktree(functional_repo):
+    """Undoing line discard restores the pre-operation working tree bytes."""
+    test_file = functional_repo / "notes.txt"
+    _commit_file(test_file, "one\n")
+    original = "one\ntwo\n"
+    test_file.write_text(original)
+
+    git_stage_batch("start")
+    git_stage_batch("discard", "--line", "1")
+    assert test_file.read_text() == "one\n"
+
+    git_stage_batch("undo")
+    assert test_file.read_text() == original
+
+
+def test_undo_refuses_when_worktree_changed_after_checkpoint(functional_repo):
+    """Undo refuses to overwrite later worktree edits by default."""
+    test_file = functional_repo / "notes.txt"
+    _commit_file(test_file, "one\n")
+    test_file.write_text("one\ntwo\n")
+
+    git_stage_batch("start")
+    git_stage_batch("include", "--line", "1")
+    test_file.write_text("one\ntwo\nthree\n")
+
+    result = git_stage_batch("undo", check=False)
+
+    assert result.returncode != 0
+    assert "current state has changed since the checkpoint" in result.stderr
+    assert "--force" in result.stderr
+    assert test_file.read_text() == "one\ntwo\nthree\n"
+    assert "+two" in get_staged_diff("notes.txt")
+
+
+def test_undo_force_overwrites_later_worktree_edits(functional_repo):
+    """Undo --force restores checkpoint state even after later edits."""
+    test_file = functional_repo / "notes.txt"
+    _commit_file(test_file, "one\n")
+    original = "one\ntwo\n"
+    test_file.write_text(original)
+
+    git_stage_batch("start")
+    git_stage_batch("include", "--line", "1")
+    test_file.write_text("one\ntwo\nthree\n")
+
+    result = git_stage_batch("undo", "--force")
+
+    assert result.returncode == 0
+    assert test_file.read_text() == original
+    assert get_staged_diff("notes.txt") == ""
+
+
+def test_undo_include_to_batch_restores_batch_refs(functional_repo):
+    """Undoing include-to-batch restores batch content and state refs."""
+    test_file = functional_repo / "notes.txt"
+    _commit_file(test_file, "one\n")
+    test_file.write_text("one\ntwo\n")
+
+    git_stage_batch("new", "undo-batch")
+    git_stage_batch("start")
+    git_stage_batch("include", "--to", "undo-batch", "--line", "1")
+
+    assert git_stage_batch("show", "--from", "undo-batch").stdout
+    content_ref = _git("rev-parse", "refs/git-stage-batch/batches/undo-batch").stdout.strip()
+    state_ref = _git("rev-parse", "refs/git-stage-batch/state/undo-batch").stdout.strip()
+
+    git_stage_batch("undo")
+
+    assert git_stage_batch("show", "--from", "undo-batch").stdout == ""
+    assert _git("rev-parse", "refs/git-stage-batch/batches/undo-batch").stdout.strip() != content_ref
+    assert _git("rev-parse", "refs/git-stage-batch/state/undo-batch").stdout.strip() != state_ref
+
 def test_undo_with_empty_stack_fails(repo_with_changes):
     """Undo reports an error when no checkpoint exists."""
     git_stage_batch("start")

--- a/tests/functional/test_undo.py
+++ b/tests/functional/test_undo.py
@@ -117,6 +117,55 @@ def test_undo_include_to_batch_restores_batch_refs(functional_repo):
     assert _git("rev-parse", "refs/git-stage-batch/batches/undo-batch").stdout.strip() != content_ref
     assert _git("rev-parse", "refs/git-stage-batch/state/undo-batch").stdout.strip() != state_ref
 
+
+def test_undo_block_file_restores_gitignore_session_and_index(functional_repo):
+    """Undoing block-file during a session restores .gitignore, session state, and index."""
+    test_file = functional_repo / "generated.log"
+    test_file.write_text("generated\n")
+
+    git_stage_batch("start")
+    git_stage_batch("block-file", "generated.log")
+
+    assert not _git("ls-files", "--", "generated.log").stdout.strip()
+    assert "generated.log" in (functional_repo / ".gitignore").read_text()
+
+    git_stage_batch("undo")
+
+    assert _git("ls-files", "--", "generated.log").stdout.strip() == "generated.log"
+    assert not (functional_repo / ".gitignore").exists()
+
+
+def test_block_file_outside_session_does_not_create_undo_checkpoint(functional_repo):
+    """block-file is undoable only inside an active session."""
+    test_file = functional_repo / "generated.log"
+    test_file.write_text("generated\n")
+
+    git_stage_batch("block-file", "generated.log")
+    result = git_stage_batch("undo", check=False)
+
+    assert result.returncode != 0
+    assert "No session in progress" in result.stderr
+    assert "generated.log" in (functional_repo / ".gitignore").read_text()
+
+
+def test_undo_unblock_file_restores_blocked_state(functional_repo):
+    """Undoing unblock-file during a session re-blocks the file."""
+    test_file = functional_repo / "generated.log"
+    test_file.write_text("generated\n")
+
+    git_stage_batch("start")
+    git_stage_batch("block-file", "generated.log")
+    git_stage_batch("unblock-file", "generated.log")
+
+    assert _git("ls-files", "--", "generated.log").stdout.strip() == "generated.log"
+    assert "generated.log" not in (functional_repo / ".gitignore").read_text()
+
+    git_stage_batch("undo")
+
+    assert not _git("ls-files", "--", "generated.log").stdout.strip()
+    assert "generated.log" in (functional_repo / ".gitignore").read_text()
+
+
 def test_undo_with_empty_stack_fails(repo_with_changes):
     """Undo reports an error when no checkpoint exists."""
     git_stage_batch("start")

--- a/tests/functional/test_undo.py
+++ b/tests/functional/test_undo.py
@@ -1,0 +1,25 @@
+"""Functional tests for undo support."""
+
+import subprocess
+
+from .conftest import git_stage_batch, get_staged_diff
+
+
+def _git(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["git", *args], check=True, capture_output=True, text=True)
+
+
+def _commit_file(path, content: str) -> None:
+    path.write_text(content)
+    _git("add", str(path))
+    _git("commit", "-m", f"Add {path.name}")
+
+
+def test_undo_with_empty_stack_fails(repo_with_changes):
+    """Undo reports an error when no checkpoint exists."""
+    git_stage_batch("start")
+
+    result = git_stage_batch("undo", check=False)
+
+    assert result.returncode != 0
+    assert "Nothing to undo" in result.stderr

--- a/tests/tui/test_interactive.py
+++ b/tests/tui/test_interactive.py
@@ -56,6 +56,7 @@ class TestPrintHelp:
         assert "i, include" in captured.out
         assert "s, skip" in captured.out
         assert "d, discard" in captured.out
+        assert "u, undo" in captured.out
         assert "q, quit" in captured.out
         assert "?, help" in captured.out
 

--- a/tests/tui/test_prompts.py
+++ b/tests/tui/test_prompts.py
@@ -50,10 +50,16 @@ class TestPromptAction:
         with patch("builtins.input", return_value="quit"):
             assert prompt_action(use_color=False) == "q"
 
+        with patch("builtins.input", return_value="undo"):
+            assert prompt_action(use_color=False) == "u"
+
     def test_prompt_action_secondary_options(self):
         """Test selecting secondary options."""
         with patch("builtins.input", return_value="a"):
             assert prompt_action(use_color=False) == "a"
+
+        with patch("builtins.input", return_value="u"):
+            assert prompt_action(use_color=False) == "u"
 
         with patch("builtins.input", return_value="l"):
             assert prompt_action(use_color=False) == "l"
@@ -111,6 +117,17 @@ class TestPromptAction:
         assert result == "i"
         assert "from" in output.lower() or "<" in output
         assert "to" in output.lower() or ">" in output
+
+    def test_prompt_action_without_hunk_shows_undo(self):
+        """Test undo appears even when no hunk is selected."""
+        with patch("builtins.input", return_value="u"):
+            with patch("sys.stdout", new=StringIO()) as fake_out:
+                with patch("sys.stdout.isatty", return_value=False):
+                    result = prompt_action(use_color=False, has_hunk=False)
+                    output = fake_out.getvalue()
+
+        assert result == "u"
+        assert "[u]ndo" in output
 
     def test_prompt_action_from_normalized(self):
         """Test that 'from' normalizes to '<'."""

--- a/tests/utils/test_paths.py
+++ b/tests/utils/test_paths.py
@@ -95,35 +95,35 @@ class TestLineLevelOperationPaths:
 
         include_ids_path = get_processed_include_ids_file_path()
         state_dir = get_state_directory_path()
-        assert include_ids_path == state_dir / "processed.include"
+        assert include_ids_path == state_dir / "session" / "processed" / "included-lines.json"
 
     def test_get_processed_skip_ids_file_path(self, temp_git_repo):
         """Test getting the processed skip IDs file path."""
 
         skip_ids_path = get_processed_skip_ids_file_path()
         state_dir = get_state_directory_path()
-        assert skip_ids_path == state_dir / "processed.skip"
+        assert skip_ids_path == state_dir / "session" / "processed" / "skipped-lines.json"
 
     def test_get_line_changes_json_file_path(self, temp_git_repo):
         """Test getting the selected lines JSON file path."""
 
         line_changes_path = get_line_changes_json_file_path()
         state_dir = get_state_directory_path()
-        assert line_changes_path == state_dir / "selected-lines.json"
+        assert line_changes_path == state_dir / "session" / "selected" / "hunk.lines.json"
 
     def test_get_index_snapshot_file_path(self, temp_git_repo):
         """Test getting the index snapshot file path."""
 
         index_snapshot_path = get_index_snapshot_file_path()
         state_dir = get_state_directory_path()
-        assert index_snapshot_path == state_dir / "index-snapshot"
+        assert index_snapshot_path == state_dir / "session" / "selected" / "index.snapshot"
 
     def test_get_working_tree_snapshot_file_path(self, temp_git_repo):
         """Test getting the working tree snapshot file path."""
 
         working_tree_path = get_working_tree_snapshot_file_path()
         state_dir = get_state_directory_path()
-        assert working_tree_path == state_dir / "working-tree-snapshot"
+        assert working_tree_path == state_dir / "session" / "selected" / "working-tree.snapshot"
 
 
 class TestGetContextLines:
@@ -137,14 +137,14 @@ class TestGetContextLines:
     def test_get_context_lines_reads_file(self, temp_git_repo):
         """Test that get_context_lines reads value from file."""
         ensure_state_directory_exists()
-        context_file = get_state_directory_path() / "context-lines"
+        context_file = get_context_lines_file_path()
         context_file.write_text("5\n")
         assert get_context_lines() == 5
 
     def test_get_context_lines_invalid_content(self, temp_git_repo):
         """Test that get_context_lines returns 3 for invalid content."""
         ensure_state_directory_exists()
-        context_file = get_state_directory_path() / "context-lines"
+        context_file = get_context_lines_file_path()
         context_file.write_text("not-a-number\n")
         assert get_context_lines() == 3
 
@@ -155,7 +155,7 @@ class TestGetContextLinesFilePath:
     def test_get_context_lines_file_path(self, temp_git_repo):
         """Test getting the context lines file path."""
         context_file = get_context_lines_file_path()
-        assert context_file == temp_git_repo / ".git" / "git-stage-batch" / "context-lines"
+        assert context_file == temp_git_repo / ".git" / "git-stage-batch" / "session" / "config" / "context-lines.txt"
 
 
 class TestAbortStatePaths:
@@ -166,28 +166,28 @@ class TestAbortStatePaths:
 
         abort_head_path = get_abort_head_file_path()
         state_dir = get_state_directory_path()
-        assert abort_head_path == state_dir / "abort-head"
+        assert abort_head_path == state_dir / "session" / "abort" / "head.txt"
 
     def test_get_abort_stash_file_path(self, temp_git_repo):
         """Test getting the abort stash file path."""
 
         abort_stash_path = get_abort_stash_file_path()
         state_dir = get_state_directory_path()
-        assert abort_stash_path == state_dir / "abort-stash"
+        assert abort_stash_path == state_dir / "session" / "abort" / "stash.txt"
 
     def test_get_abort_snapshots_directory_path(self, temp_git_repo):
         """Test getting the abort snapshots directory path."""
 
         snapshots_dir = get_abort_snapshots_directory_path()
         state_dir = get_state_directory_path()
-        assert snapshots_dir == state_dir / "snapshots"
+        assert snapshots_dir == state_dir / "session" / "abort" / "untracked"
 
     def test_get_abort_snapshot_list_file_path(self, temp_git_repo):
         """Test getting the abort snapshot list file path."""
 
         snapshot_list_path = get_abort_snapshot_list_file_path()
         state_dir = get_state_directory_path()
-        assert snapshot_list_path == state_dir / "snapshot-list"
+        assert snapshot_list_path == state_dir / "session" / "abort" / "untracked-paths.txt"
 
 
 class TestAutoAddedFilesPath:
@@ -198,7 +198,7 @@ class TestAutoAddedFilesPath:
 
         auto_added_path = get_auto_added_files_file_path()
         state_dir = get_state_directory_path()
-        assert auto_added_path == state_dir / "auto-added-files"
+        assert auto_added_path == state_dir / "session" / "abort" / "auto-added-files.txt"
 
 
 class TestBlockedFilesPath:
@@ -209,7 +209,7 @@ class TestBlockedFilesPath:
 
         blocked_files_path = get_blocked_files_file_path()
         state_dir = get_state_directory_path()
-        assert blocked_files_path == state_dir / "blocked-files"
+        assert blocked_files_path == state_dir / "session" / "progress" / "blocked-files.txt"
 
 
 class TestSessionTrackingPaths:
@@ -220,28 +220,28 @@ class TestSessionTrackingPaths:
 
         iteration_count_path = get_iteration_count_file_path()
         state_dir = get_state_directory_path()
-        assert iteration_count_path == state_dir / "iteration-count"
+        assert iteration_count_path == state_dir / "session" / "config" / "iteration-count.txt"
 
     def test_get_start_head_file_path(self, temp_git_repo):
         """Test getting the start HEAD file path."""
 
         start_head_path = get_start_head_file_path()
         state_dir = get_state_directory_path()
-        assert start_head_path == state_dir / "start-head"
+        assert start_head_path == state_dir / "session" / "start-head.txt"
 
     def test_get_start_index_tree_file_path(self, temp_git_repo):
         """Test getting the start index tree file path."""
 
         start_index_tree_path = get_start_index_tree_file_path()
         state_dir = get_state_directory_path()
-        assert start_index_tree_path == state_dir / "start-index-tree"
+        assert start_index_tree_path == state_dir / "session" / "start-index-tree.txt"
 
     def test_get_suggest_fixup_state_file_path(self, temp_git_repo):
         """Test getting the suggest-fixup state file path."""
 
         suggest_fixup_path = get_suggest_fixup_state_file_path()
         state_dir = get_state_directory_path()
-        assert suggest_fixup_path == state_dir / "suggest-fixup-state.json"
+        assert suggest_fixup_path == state_dir / "session" / "fixup" / "state.json"
 
 
 class TestBatchMetadataPaths:
@@ -269,7 +269,7 @@ class TestBatchMetadataPaths:
         """Test getting the batch refs snapshot file path."""
 
         snapshot_file = get_batch_refs_snapshot_file_path()
-        assert snapshot_file == temp_git_repo / ".git" / "git-stage-batch" / "batch-refs-snapshot.json"
+        assert snapshot_file == temp_git_repo / ".git" / "git-stage-batch" / "session" / "abort" / "batch-refs.json"
 
     def test_get_batch_claimed_hunks_file_path(self, temp_git_repo):
         """Test getting a batch's claimed hunks file path."""
@@ -287,16 +287,16 @@ class TestBatchMetadataPaths:
         """Test getting the processed batch IDs file path."""
 
         batch_ids_file = get_processed_batch_ids_file_path()
-        assert batch_ids_file == temp_git_repo / ".git" / "git-stage-batch" / "processed.batch"
+        assert batch_ids_file == temp_git_repo / ".git" / "git-stage-batch" / "session" / "processed" / "batched-lines.json"
 
     def test_get_batched_hunks_file_path(self, temp_git_repo):
         """Test getting the batched hunks file path."""
 
         batched_hunks_file = get_batched_hunks_file_path()
-        assert batched_hunks_file == temp_git_repo / ".git" / "git-stage-batch" / "batched-hunks"
+        assert batched_hunks_file == temp_git_repo / ".git" / "git-stage-batch" / "session" / "progress" / "batched-hunks.txt"
 
     def test_get_start_batch_refs_file_path(self, temp_git_repo):
         """Test getting the start batch refs file path."""
 
         start_batch_refs_file = get_start_batch_refs_file_path()
-        assert start_batch_refs_file == temp_git_repo / ".git" / "git-stage-batch" / "start-batch-refs.json"
+        assert start_batch_refs_file == temp_git_repo / ".git" / "git-stage-batch" / "session" / "start-batch-refs.json"


### PR DESCRIPTION
The program stores batch content in refs/batches/<name> git refs and batch metadata in file-backed 
metadata.json files under .git/git-stage-batch/batches/. Session scratch state lives as a flat     
collection of files directly in .git/git-stage-batch/. Once an operation is performed during a     
session, there is no way to reverse it without aborting the entire session.

Batch state is split across two storage locations with no consistency guarantee. A ref can exist   
without a metadata file, or vice versa, after an interrupted write. The flat file layout in the
state directory also makes it hard to distinguish categories of state. Users who make an incorrect 
include or discard decision during a session must either abort and restart or accept the mistake,
since there is no per-operation undo.

This branch addresses those gaps in three stages. First, it makes                                  
refs/git-stage-batch/batches/<batch> and refs/git-stage-batch/state/<batch> the authoritative refs,
 using git update-ref --stdin with the start/prepare/commit protocol for atomic multi-ref updates, 
and reorganizes session state into structured subdirectories. Second, it adds a session-scoped undo
 command backed by a Git ref checkpoint stack at refs/git-stage-batch/session/undo-stack, with
conflict detection so undo refuses by default when the working state has diverged from the
checkpoint. Third, it adds a redo counterpart at refs/git-stage-batch/session/redo-stack that
restores undone state, following standard editor-style undo/redo ordering where new operations
invalidate the redo stack. Both undo and redo are available from the CLI and from interactive mode.
