### PR TITLE
Add semantic line-selection for replacement hunks when staging to index

### DIFF
--- a/BATCHES.md
+++ b/BATCHES.md
@@ -900,6 +900,89 @@ def select_ownership_units_by_display_ids(units, selected_ids):
 * `apply --from BATCH --line IDs`: Apply subset of batch (future: could enforce atomicity)
 * `discard --from BATCH --line IDs`: Remove subset of batch from working tree
 
+### Ephemeral Semantic Selection for Index Staging
+
+`include --line IDs` also uses batch semantics opportunistically, but without
+creating a persisted named batch.
+
+This path starts from a live selected diff hunk rather than stored batch
+metadata:
+
+1. Read the selected hunk and requested display IDs.
+2. Try to derive temporary `BatchOwnership` in an in-memory source coordinate
+   system built from the selected hunk's base/index snapshot and source
+   snapshot.
+3. Represent selected changes as normal presence constraints (`claimed_lines`)
+   and absence constraints (`deletions`).
+4. Merge those constraints into the **current index content** with the same
+   `merge_batch()` engine used by persisted batches.
+5. Write the merged result back to the index.
+
+The temporary ownership object is only an internal vehicle for semantic
+interpretation. It is not written to `refs/batches/*`, does not appear in
+`list`, and does not update batch metadata.
+
+**Example:**
+
+```
+Selected hunk:
+[#1] - a
+[#2] - b
+[#3] + A
+[#4] + B
+
+User selects: include --line 1,3
+```
+
+For a simple same-cardinality one-to-one replacement run, the live hunk is
+interpreted as semantic rows:
+
+```
+row 1: a -> A
+row 2: b -> B
+```
+
+Selecting `1,3` builds temporary ownership equivalent to:
+
+```python
+BatchOwnership(
+    claimed_lines=["1"],  # "A" in the temporary source
+    deletions=[DeletionClaim(anchor_line=None, content_lines=[b"a\n"])]
+)
+```
+
+Merging this temporary ownership into index content produces:
+
+```
+A
+b
+```
+
+rather than the raw patch-line slice:
+
+```
+b
+A
+```
+
+**Fallback Policy:**
+
+This semantic path is best-effort. If the selected live hunk cannot be
+interpreted safely as temporary ownership, `include --line` falls back to the
+legacy raw line-level staging behavior instead of failing. This keeps the
+command's core contract intact: selecting lines from the working tree to stage
+should remain available even when semantic pairing is unclear.
+
+This means replacement pairing is permissive for simple same-cardinality
+replacement blocks, but still declines suspicious reorder-like shapes. A block
+like `-a -b +B +A` has the same normalized keys on both sides in a different
+order, so it may be a reorder rather than row-wise edits; the semantic path
+declines and the legacy staging path handles the selection.
+
+This fallback policy differs from persisted batch line selection, where partial
+selection of stored atomic ownership units may be rejected to protect batch
+metadata integrity.
+
 ---
 
 ## Stale Batch Source Detection and Repair

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -387,6 +387,20 @@ Stage only specific lines from the selected hunk.
 ❯ git-stage-batch include --line 1,3,5-7
 ```
 
+For simple replacement regions, selecting the matching deleted and added
+lines stages the semantic replacement row. For example, in a hunk like:
+
+```
+[#1] - a
+[#2] - b
+[#3] + A
+[#4] + B
+```
+
+`include --line 1,3` stages `a` -> `A` while leaving `b` unchanged.
+If git-stage-batch cannot determine a clear semantic replacement, it falls
+back to the regular line-level staging behavior.
+
 **Line ID syntax:**
 - Single: `1`
 - Multiple: `1,3,5`

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -66,6 +66,33 @@ config.py :: @@ -1,5 +1,7 @@
 
 ---
 
+## Line-Level: Stage One Replacement Row
+
+You changed two adjacent lines, but only one belongs in this commit:
+
+```
+❯ git-stage-batch start
+names.txt :: @@ -1,2 +1,2 @@
+[#1] - a
+[#2] - b
+[#3] + A
+[#4] + B
+
+# Stage only the first replacement row
+❯ git-stage-batch include --line 1,3
+
+❯ git diff --cached
+-a
++A
+ b
+```
+
+For clear one-to-one replacement rows, line selection stages the semantic
+replacement. If the row structure is not clear, git-stage-batch uses regular
+line-level staging.
+
+---
+
 ## File-Level: Stage Entire File
 
 You have multiple hunks in one file that all belong together:

--- a/docs/git-stage-batch.1.in
+++ b/docs/git-stage-batch.1.in
@@ -179,6 +179,9 @@ This permanently removes the entire file from your working tree.
 Stage only specific lines from the selected hunk.
 Lines are displayed with IDs in brackets (e.g., [#1], [#2]).
 LINE_IDS syntax: single (1), multiple (1,3,5), range (5-7), or combined (1,3,5-7).
+For clear one-to-one replacement regions, selecting the matching deleted and
+added lines stages that semantic replacement row; if no clear semantic row can
+be determined, regular line-level staging is used.
 After processing, the hunk is recalculated to show remaining changes.
 .TP
 .B skip \-\-line \fILINE_IDS\fR

--- a/src/git_stage_batch/batch/semantic_selection.py
+++ b/src/git_stage_batch/batch/semantic_selection.py
@@ -1,0 +1,414 @@
+"""Semantic line-selection helpers for partial staging."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .merge import merge_batch
+from .ownership import BatchOwnership, DeletionClaim
+from ..core.line_selection import format_line_ids
+from ..core.models import LineEntry, LineLevelChange
+from ..exceptions import MergeError
+from ..i18n import _
+
+
+class SemanticSelectionError(Exception):
+    """Raised when a selected hunk cannot be staged semantically."""
+
+
+class SemanticSelectionAmbiguousError(SemanticSelectionError):
+    """Raised when selected lines do not have an unambiguous semantic shape."""
+
+
+class SemanticSelectionAtomicError(SemanticSelectionError):
+    """Raised when selection splits an atomic replacement row."""
+
+
+class SemanticSelectionUnsupportedError(SemanticSelectionError):
+    """Raised when legacy raw line staging should handle the selection."""
+
+
+@dataclass
+class SemanticSelectionRow:
+    """A semantic row derived from a live diff hunk."""
+
+    old_display_ids: set[int]
+    new_display_ids: set[int]
+    deletion_claims: list[DeletionClaim]
+    claimed_source_lines: set[int]
+    is_atomic: bool
+
+
+@dataclass
+class TemporarySelectionRealization:
+    """In-memory semantic realization for selected hunk lines."""
+
+    ownership: BatchOwnership
+    hunk_base_content: bytes
+    source_content: bytes
+    realized_content: bytes
+    selected_rows: list[SemanticSelectionRow]
+    pairing_mode: str
+
+
+@dataclass
+class SemanticSelectionAttempt:
+    """Result of opportunistic semantic partial staging."""
+
+    used_semantic_staging: bool
+    realized_content: bytes | None = None
+    reason: str | None = None
+    realization: TemporarySelectionRealization | None = None
+
+
+def _split_content_lines(content: bytes) -> list[bytes]:
+    return content.splitlines(keepends=True)
+
+
+def _line_content_from_snapshot(
+    snapshot_lines: list[bytes],
+    line_number: int | None,
+    fallback: LineEntry,
+) -> bytes:
+    if line_number is not None and 1 <= line_number <= len(snapshot_lines):
+        return snapshot_lines[line_number - 1]
+    return fallback.text_bytes + b"\n"
+
+
+def _append_deletion_claim(
+    deletion_claims: list[DeletionClaim],
+    *,
+    anchor_line: int | None,
+    line: LineEntry,
+    line_content: bytes,
+) -> DeletionClaim:
+    if deletion_claims and deletion_claims[-1].anchor_line == anchor_line:
+        deletion_claims[-1].content_lines.append(line_content)
+        return deletion_claims[-1]
+
+    claim = DeletionClaim(anchor_line=anchor_line, content_lines=[line_content])
+    deletion_claims.append(claim)
+    return claim
+
+
+def _is_supported_replacement_run(run: list[LineEntry]) -> bool:
+    seen_addition = False
+    for line in run:
+        if line.kind == "+":
+            seen_addition = True
+        elif line.kind == "-" and seen_addition:
+            return False
+    return True
+
+
+def _ensure_unambiguous_replacement(deletions: list[LineEntry], additions: list[LineEntry]) -> None:
+    old_texts = [line.text_bytes for line in deletions]
+    new_texts = [line.text_bytes for line in additions]
+    if len(set(old_texts)) != len(old_texts) or len(set(new_texts)) != len(new_texts):
+        raise SemanticSelectionAmbiguousError(
+            _("Selected lines do not form an unambiguous replacement.")
+        )
+
+
+def _replacement_pair_key(line: LineEntry) -> bytes:
+    return line.text_bytes.strip().lower()
+
+
+def _replacement_rows_look_reordered(deletions: list[LineEntry], additions: list[LineEntry]) -> bool:
+    """Return True for same-content replacement blocks whose order changed.
+
+    Simple same-cardinality replacement blocks pair positionally by default.
+    Normalized keys are only a suspicion check: when both sides contain the same
+    unique keys but in a different order, this looks like a reorder rather than
+    row-wise edits, so semantic staging should decline and let legacy staging
+    handle the selection.
+    """
+    old_keys = [_replacement_pair_key(line) for line in deletions]
+    new_keys = [_replacement_pair_key(line) for line in additions]
+    if any(not key for key in old_keys + new_keys):
+        return False
+    if len(set(old_keys)) != len(old_keys) or len(set(new_keys)) != len(new_keys):
+        return False
+    return set(old_keys) == set(new_keys) and old_keys != new_keys
+
+
+def _build_claimed_ranges(claimed_source_lines: set[int]) -> list[str]:
+    if not claimed_source_lines:
+        return []
+    return [format_line_ids(sorted(claimed_source_lines))]
+
+
+def _build_temporary_ownership_for_selected_hunk(
+    *,
+    line_changes: LineLevelChange,
+    selected_display_ids: set[int],
+    selected_hunk_base_content: bytes,
+    selected_hunk_source_content: bytes,
+    current_index_content: bytes,
+) -> TemporarySelectionRealization:
+    """Build and merge temporary ownership for semantic partial staging.
+
+    The temporary source is the selected semantic result over the selected
+    hunk's base/index snapshot. That gives the batch merge engine enough
+    unchanged context to apply a selected replacement row into the current index
+    without treating the full worktree rewrite as the source.
+    """
+    if not selected_display_ids:
+        raise SemanticSelectionAmbiguousError(_("No lines selected."))
+
+    known_ids = {line.id for line in line_changes.lines if line.id is not None}
+    unknown_ids = selected_display_ids - known_ids
+    if unknown_ids:
+        first_unknown = min(unknown_ids)
+        raise SemanticSelectionAmbiguousError(
+            _("Line ID {id} not found in selected hunk.").format(id=first_unknown)
+        )
+
+    hunk_base_lines = _split_content_lines(selected_hunk_base_content)
+    hunk_source_lines = _split_content_lines(selected_hunk_source_content)
+    source_lines: list[bytes] = []
+    claimed_source_lines: set[int] = set()
+    deletion_claims: list[DeletionClaim] = []
+    selected_rows: list[SemanticSelectionRow] = []
+    pairing_modes: set[str] = set()
+
+    old_pointer = max(line_changes.header.old_start - 1, 0)
+    for index in range(0, min(old_pointer, len(hunk_base_lines))):
+        source_lines.append(hunk_base_lines[index])
+
+    def previous_source_line() -> int | None:
+        return len(source_lines) if source_lines else None
+
+    def copy_remaining_baseline_until(new_pointer: int) -> None:
+        nonlocal old_pointer
+        while old_pointer < min(new_pointer, len(hunk_base_lines)):
+            source_lines.append(hunk_base_lines[old_pointer])
+            old_pointer += 1
+
+    def flush_run(run: list[LineEntry]) -> None:
+        nonlocal old_pointer
+        if not run:
+            return
+
+        deletions = [line for line in run if line.kind == "-"]
+        additions = [line for line in run if line.kind == "+"]
+
+        if deletions and additions:
+            if not _is_supported_replacement_run(run):
+                raise SemanticSelectionAmbiguousError(
+                    _("Selected lines do not form an unambiguous replacement.")
+                )
+
+            if len(deletions) != len(additions):
+                selected_deletions = {
+                    line.id for line in deletions
+                    if line.id is not None and line.id in selected_display_ids
+                }
+                selected_additions = {
+                    line.id for line in additions
+                    if line.id is not None and line.id in selected_display_ids
+                }
+                if selected_deletions and selected_additions:
+                    raise SemanticSelectionAmbiguousError(
+                        _("Selected lines do not form an unambiguous replacement.")
+                    )
+                raise SemanticSelectionUnsupportedError(
+                    _("Selected lines do not form an unambiguous replacement.")
+                )
+
+            _ensure_unambiguous_replacement(deletions, additions)
+            if _replacement_rows_look_reordered(deletions, additions):
+                raise SemanticSelectionUnsupportedError(
+                    _("Selected lines do not form an unambiguous replacement.")
+                )
+            pairing_modes.add("replacement")
+
+            for old_line, new_line in zip(deletions, additions):
+                old_selected = old_line.id in selected_display_ids
+                new_selected = new_line.id in selected_display_ids
+
+                if old_selected != new_selected:
+                    raise SemanticSelectionAtomicError(
+                        _("Select the whole replacement row or broaden the selection.")
+                    )
+
+                if old_selected and new_selected:
+                    anchor = previous_source_line()
+                    claim = _append_deletion_claim(
+                        deletion_claims,
+                        anchor_line=anchor,
+                        line=old_line,
+                        line_content=_line_content_from_snapshot(
+                            hunk_base_lines,
+                            old_line.old_line_number,
+                            old_line,
+                        ),
+                    )
+                    source_lines.append(
+                        _line_content_from_snapshot(
+                            hunk_source_lines,
+                            new_line.new_line_number,
+                            new_line,
+                        )
+                    )
+                    source_line = len(source_lines)
+                    claimed_source_lines.add(source_line)
+                    selected_rows.append(
+                        SemanticSelectionRow(
+                            old_display_ids={old_line.id} if old_line.id is not None else set(),
+                            new_display_ids={new_line.id} if new_line.id is not None else set(),
+                            deletion_claims=[claim],
+                            claimed_source_lines={source_line},
+                            is_atomic=True,
+                        )
+                    )
+                else:
+                    source_lines.append(
+                        _line_content_from_snapshot(
+                            hunk_base_lines,
+                            old_line.old_line_number,
+                            old_line,
+                        )
+                    )
+                old_pointer += 1
+            return
+
+        if additions:
+            pairing_modes.add("addition")
+            for line in additions:
+                if line.id in selected_display_ids:
+                    source_lines.append(
+                        _line_content_from_snapshot(
+                            hunk_source_lines,
+                            line.new_line_number,
+                            line,
+                        )
+                    )
+                    source_line = len(source_lines)
+                    claimed_source_lines.add(source_line)
+                    selected_rows.append(
+                        SemanticSelectionRow(
+                            old_display_ids=set(),
+                            new_display_ids={line.id} if line.id is not None else set(),
+                            deletion_claims=[],
+                            claimed_source_lines={source_line},
+                            is_atomic=False,
+                        )
+                    )
+            return
+
+        if deletions:
+            pairing_modes.add("deletion")
+            for line in deletions:
+                if line.id in selected_display_ids:
+                    anchor = previous_source_line()
+                    claim = _append_deletion_claim(
+                        deletion_claims,
+                        anchor_line=anchor,
+                        line=line,
+                        line_content=_line_content_from_snapshot(
+                            hunk_base_lines,
+                            line.old_line_number,
+                            line,
+                        ),
+                    )
+                    selected_rows.append(
+                        SemanticSelectionRow(
+                            old_display_ids={line.id} if line.id is not None else set(),
+                            new_display_ids=set(),
+                            deletion_claims=[claim],
+                            claimed_source_lines=set(),
+                            is_atomic=False,
+                        )
+                    )
+                else:
+                    source_lines.append(
+                        _line_content_from_snapshot(
+                            hunk_base_lines,
+                            line.old_line_number,
+                            line,
+                        )
+                    )
+                old_pointer += 1
+
+    run: list[LineEntry] = []
+    for line in line_changes.lines:
+        if line.kind == " ":
+            flush_run(run)
+            run = []
+            copy_remaining_baseline_until(max(old_pointer, (line.old_line_number or 1) - 1))
+            if old_pointer < len(hunk_base_lines):
+                source_lines.append(hunk_base_lines[old_pointer])
+                old_pointer += 1
+            else:
+                source_lines.append(
+                    _line_content_from_snapshot(
+                        hunk_source_lines,
+                        line.new_line_number,
+                        line,
+                    )
+                )
+        else:
+            run.append(line)
+    flush_run(run)
+
+    while old_pointer < len(hunk_base_lines):
+        source_lines.append(hunk_base_lines[old_pointer])
+        old_pointer += 1
+
+    ownership = BatchOwnership(
+        claimed_lines=_build_claimed_ranges(claimed_source_lines),
+        deletions=deletion_claims,
+    )
+    if ownership.is_empty():
+        raise SemanticSelectionAmbiguousError(_("No selected semantic changes to stage."))
+
+    source_content = b"".join(source_lines)
+
+    try:
+        realized_content = merge_batch(source_content, ownership, current_index_content)
+    except MergeError as e:
+        raise SemanticSelectionAmbiguousError(
+            _("Selected semantic change cannot be merged into the current index state.")
+        ) from e
+
+    pairing_mode = "+".join(sorted(pairing_modes)) if pairing_modes else "unknown"
+    return TemporarySelectionRealization(
+        ownership=ownership,
+        hunk_base_content=selected_hunk_base_content,
+        source_content=source_content,
+        realized_content=realized_content,
+        selected_rows=selected_rows,
+        pairing_mode=pairing_mode,
+    )
+
+
+def try_build_semantic_selection_for_selected_hunk(
+    *,
+    line_changes: LineLevelChange,
+    selected_display_ids: set[int],
+    selected_hunk_base_content: bytes,
+    selected_hunk_source_content: bytes,
+    current_index_content: bytes,
+) -> SemanticSelectionAttempt:
+    """Try semantic partial staging and return a best-effort attempt result."""
+    try:
+        realization = _build_temporary_ownership_for_selected_hunk(
+            line_changes=line_changes,
+            selected_display_ids=selected_display_ids,
+            selected_hunk_base_content=selected_hunk_base_content,
+            selected_hunk_source_content=selected_hunk_source_content,
+            current_index_content=current_index_content,
+        )
+    except SemanticSelectionAtomicError:
+        return SemanticSelectionAttempt(False, reason="atomic_row_split")
+    except SemanticSelectionAmbiguousError:
+        return SemanticSelectionAttempt(False, reason="ambiguous_replacement")
+    except SemanticSelectionUnsupportedError:
+        return SemanticSelectionAttempt(False, reason="unsupported_shape")
+
+    return SemanticSelectionAttempt(
+        True,
+        realized_content=realization.realized_content,
+        realization=realization,
+    )

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -8,6 +8,7 @@ from ..batch import add_file_to_batch, create_batch
 from ..batch.display import annotate_with_batch_source
 from ..batch.ownership import BatchOwnership
 from ..batch.query import read_batch_metadata
+from ..batch.semantic_selection import try_build_semantic_selection_for_selected_hunk
 from ..batch.source_refresh import prepare_batch_ownership_update_for_selection
 from ..batch.validation import batch_exists
 from ..core.diff_parser import (
@@ -50,6 +51,7 @@ from ..utils.paths import (
     get_selected_hunk_patch_file_path,
     get_index_snapshot_file_path,
     get_processed_include_ids_file_path,
+    get_working_tree_snapshot_file_path,
 )
 
 
@@ -251,10 +253,49 @@ def command_include_line(line_id_specification: str) -> None:
 
     line_changes = load_line_changes_from_state()
 
-    # Get base content from index snapshot (captured when hunk was loaded)
-    base_bytes = read_file_bytes(get_index_snapshot_file_path())
+    # Get the selected hunk's base/source snapshots captured when the hunk was loaded.
+    hunk_base_content = read_file_bytes(get_index_snapshot_file_path())
+    hunk_source_content = read_file_bytes(get_working_tree_snapshot_file_path())
     with undo_checkpoint(f"include --line {line_id_specification}"):
-        target_index_content = build_target_index_content_bytes_with_selected_lines(line_changes, combined_include_ids, base_bytes)
+        index_result = run_git_command(
+            ["show", f":{line_changes.path}"],
+            check=False,
+            text_output=False,
+        )
+        current_index_content = index_result.stdout if index_result.returncode == 0 else b""
+
+        semantic_attempt = try_build_semantic_selection_for_selected_hunk(
+            line_changes=line_changes,
+            selected_display_ids=combined_include_ids,
+            selected_hunk_base_content=hunk_base_content,
+            selected_hunk_source_content=hunk_source_content,
+            current_index_content=current_index_content,
+        )
+        if semantic_attempt.used_semantic_staging:
+            log_journal(
+                "include_line_semantic_staging_used",
+                file_path=line_changes.path,
+                selected_ids=sorted(combined_include_ids),
+                pairing_mode=semantic_attempt.realization.pairing_mode if semantic_attempt.realization else None,
+            )
+            target_index_content = semantic_attempt.realized_content or b""
+        else:
+            # Semantic partial staging is a best-effort enhancement over legacy line
+            # staging. If semantic interpretation is ambiguous or unsupported, fall
+            # back to the legacy raw staging path instead of failing. Staging
+            # working-tree changes into the index should remain permissive.
+            log_journal(
+                "include_line_semantic_staging_declined",
+                file_path=line_changes.path,
+                selected_ids=sorted(combined_include_ids),
+                reason=semantic_attempt.reason,
+            )
+            target_index_content = build_target_index_content_bytes_with_selected_lines(
+                line_changes,
+                combined_include_ids,
+                hunk_base_content,
+            )
+
         update_index_with_blob_content(line_changes.path, target_index_content)
 
         # Update processed include IDs

--- a/src/git_stage_batch/staging/operations.py
+++ b/src/git_stage_batch/staging/operations.py
@@ -60,7 +60,8 @@ def build_target_index_content_with_selected_lines(
         push_output(base_lines[base_pointer])
         base_pointer += 1
 
-    return "\n".join(output_lines) + ("\n" if (base_text.endswith("\n") or output_lines) else "")
+    trailing_newline = base_text.endswith("\n") or (not base_text and bool(output_lines))
+    return "\n".join(output_lines) + ("\n" if trailing_newline else "")
 
 
 def build_target_index_content_bytes_with_selected_lines(
@@ -101,7 +102,7 @@ def build_target_index_content_bytes_with_selected_lines(
         push_output(base_lines[base_pointer])
         base_pointer += 1
 
-    trailing_newline = base_content.endswith(b"\n") or bool(output_lines)
+    trailing_newline = base_content.endswith(b"\n") or (not base_content and bool(output_lines))
     return b"\n".join(output_lines) + (b"\n" if trailing_newline else b"")
 
 

--- a/tests/functional/test_semantic_partial_staging.py
+++ b/tests/functional/test_semantic_partial_staging.py
@@ -1,0 +1,193 @@
+"""Functional tests for semantic line-level staging."""
+
+import subprocess
+
+from .conftest import git_stage_batch
+
+
+def _commit_file(repo, path: str, content: str) -> None:
+    file_path = repo / path
+    file_path.write_text(content)
+    subprocess.run(["git", "add", path], check=True, cwd=repo, capture_output=True)
+    subprocess.run(["git", "commit", "-m", f"Add {path}"], check=True, cwd=repo, capture_output=True)
+
+
+def _commit_file_bytes(repo, path: str, content: bytes) -> None:
+    file_path = repo / path
+    file_path.write_bytes(content)
+    subprocess.run(["git", "add", path], check=True, cwd=repo, capture_output=True)
+    subprocess.run(["git", "commit", "-m", f"Add {path}"], check=True, cwd=repo, capture_output=True)
+
+
+def _index_content(repo, path: str) -> str:
+    result = subprocess.run(
+        ["git", "show", f":{path}"],
+        check=True,
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def _index_bytes(repo, path: str) -> bytes:
+    result = subprocess.run(
+        ["git", "show", f":{path}"],
+        check=True,
+        cwd=repo,
+        capture_output=True,
+    )
+    return result.stdout
+
+
+def test_semantic_partial_staging_first_replace_row(functional_repo):
+    _commit_file(functional_repo, "file.txt", "a\nb\n")
+    (functional_repo / "file.txt").write_text("A\nB\n")
+
+    git_stage_batch("start")
+    git_stage_batch("include", "--line", "1,3")
+
+    assert _index_content(functional_repo, "file.txt") == "A\nb\n"
+
+
+def test_semantic_partial_staging_second_replace_row(functional_repo):
+    _commit_file(functional_repo, "file.txt", "a\nb\n")
+    (functional_repo / "file.txt").write_text("A\nB\n")
+
+    git_stage_batch("start")
+    git_stage_batch("include", "--line", "2,4")
+
+    assert _index_content(functional_repo, "file.txt") == "a\nB\n"
+
+
+def test_semantic_partial_staging_same_cardinality_replacement_by_position(functional_repo):
+    _commit_file(functional_repo, "file.txt", "red\nblue\n")
+    (functional_repo / "file.txt").write_text("circle\nsquare\n")
+
+    git_stage_batch("start")
+    git_stage_batch("include", "--line", "1,3")
+
+    assert _index_content(functional_repo, "file.txt") == "circle\nblue\n"
+
+
+def test_semantic_partial_staging_full_replace_selection(functional_repo):
+    _commit_file(functional_repo, "file.txt", "a\nb\n")
+    (functional_repo / "file.txt").write_text("A\nB\n")
+
+    git_stage_batch("start")
+    git_stage_batch("include", "--line", "1-4")
+
+    assert _index_content(functional_repo, "file.txt") == "A\nB\n"
+
+
+def test_semantic_partial_staging_pure_addition(functional_repo):
+    _commit_file(functional_repo, "file.txt", "base\n")
+    (functional_repo / "file.txt").write_text("base\nfoo\nbar\n")
+
+    git_stage_batch("start")
+    git_stage_batch("include", "--line", "1")
+
+    assert _index_content(functional_repo, "file.txt") == "base\nfoo\n"
+
+
+def test_semantic_partial_staging_pure_deletion(functional_repo):
+    _commit_file(functional_repo, "file.txt", "a\nb\nc\n")
+    (functional_repo / "file.txt").write_text("a\nc\n")
+
+    git_stage_batch("start")
+    git_stage_batch("include", "--line", "1")
+
+    assert _index_content(functional_repo, "file.txt") == "a\nc\n"
+
+
+def test_semantic_partial_staging_falls_back_for_partial_replace_row(functional_repo):
+    _commit_file(functional_repo, "file.txt", "a\nb\n")
+    (functional_repo / "file.txt").write_text("A\nB\n")
+
+    git_stage_batch("start")
+    result = git_stage_batch("include", "--line", "1")
+
+    assert result.returncode == 0
+    assert _index_content(functional_repo, "file.txt") == "b\n"
+
+
+def test_semantic_partial_staging_falls_back_for_ambiguous_replace_rows(functional_repo):
+    _commit_file(functional_repo, "file.txt", "same\nsame\n")
+    (functional_repo / "file.txt").write_text("A\nB\n")
+
+    git_stage_batch("start")
+    result = git_stage_batch("include", "--line", "1,3")
+
+    assert result.returncode == 0
+    assert _index_content(functional_repo, "file.txt") == "same\nA\n"
+
+
+def test_semantic_partial_staging_falls_back_for_reorder_like_replacement(functional_repo):
+    _commit_file(functional_repo, "file.txt", "a\nb\n")
+    (functional_repo / "file.txt").write_text("B\nA\n")
+
+    git_stage_batch("start")
+    result = git_stage_batch("include", "--line", "1,3")
+
+    assert result.returncode == 0
+    assert _index_content(functional_repo, "file.txt") == "b\nB\n"
+
+
+def test_semantic_partial_staging_replacement_preserves_missing_trailing_newline(functional_repo):
+    _commit_file_bytes(functional_repo, "file.txt", b"a\nb")
+    (functional_repo / "file.txt").write_bytes(b"A\nB")
+
+    git_stage_batch("start")
+    git_stage_batch("include", "--line", "1,3")
+
+    assert _index_bytes(functional_repo, "file.txt") == b"A\nb"
+
+
+def test_semantic_partial_staging_addition_preserves_missing_trailing_newline(functional_repo):
+    _commit_file_bytes(functional_repo, "file.txt", b"base\n")
+    (functional_repo / "file.txt").write_bytes(b"base\nfoo")
+
+    git_stage_batch("start")
+    git_stage_batch("include", "--line", "1")
+
+    assert _index_bytes(functional_repo, "file.txt") == b"base\nfoo"
+
+
+def test_semantic_partial_staging_fallback_preserves_missing_trailing_newline(functional_repo):
+    _commit_file_bytes(functional_repo, "file.txt", b"a\nb")
+    (functional_repo / "file.txt").write_bytes(b"A\nB")
+
+    git_stage_batch("start")
+    git_stage_batch("include", "--line", "1")
+
+    assert _index_bytes(functional_repo, "file.txt") == b"b"
+
+
+def test_semantic_partial_staging_preserves_unrelated_index_state(functional_repo):
+    _commit_file(functional_repo, "file.txt", "x\na\nb\ny\n")
+
+    file_path = functional_repo / "file.txt"
+    file_path.write_text("X\na\nb\ny\n")
+    subprocess.run(["git", "add", "file.txt"], check=True, cwd=functional_repo, capture_output=True)
+
+    file_path.write_text("X\nA\nB\ny\n")
+
+    git_stage_batch("start")
+    git_stage_batch("include", "--line", "1,3")
+
+    assert _index_content(functional_repo, "file.txt") == "X\nA\nb\ny\n"
+
+
+def test_semantic_partial_staging_fallback_preserves_unrelated_index_state(functional_repo):
+    _commit_file(functional_repo, "file.txt", "x\na\nb\ny\n")
+
+    file_path = functional_repo / "file.txt"
+    file_path.write_text("X\na\nb\ny\n")
+    subprocess.run(["git", "add", "file.txt"], check=True, cwd=functional_repo, capture_output=True)
+
+    file_path.write_text("X\nA\nB\ny\n")
+
+    git_stage_batch("start")
+    git_stage_batch("include", "--line", "1")
+
+    assert _index_content(functional_repo, "file.txt") == "X\nb\ny\n"


### PR DESCRIPTION
The include --line command stages selected display lines by extracting raw patch content and       
applying it to the index snapshot. The batch system has a semantic ownership model that understands
 replacement rows, pure additions, and pure deletions when operating on persisted batches, but that
 model is not available for ephemeral line-level staging.

When a hunk contains a clear one-to-one replacement region (e.g., a -> A and b -> B), the raw line 
approach treats deleted and added lines independently. Selecting lines 1,3 from such a hunk should
stage only the first replacement row, but raw extraction drops the unselected old line instead of  
preserving it, producing suboptimal index content.

This branch adds a semantic_selection module to the batch package that derives temporary in-memory 
BatchOwnership from a live diff hunk, interprets clear replacement runs as atomic rows, and merges
the result into the current index using the existing merge_batch engine. The include --line command
 attempts semantic selection first and falls back to the legacy raw path when the hunk shape is
ambiguous or when all lines are selected. The temporary ownership is never persisted to refs and
does not appear in batch listings.
