### PR TITLE
i18n: Refresh translations for new message strings

### DIFF
--- a/po/ar.po
+++ b/po/ar.po
@@ -1846,3 +1846,81 @@ msgstr "[{y}]عم / [{n}]التالي / إ[{r}]ادة تعيين: "
 #: src/git_stage_batch/utils/git.py:227
 msgid "Not inside a git repository."
 msgstr "ليس داخل مستودع git."
+
+#: src/git_stage_batch/batch/semantic_selection.py:109 src/git_stage_batch/batch/semantic_selection.py:199 src/git_stage_batch/batch/semantic_selection.py:213 src/git_stage_batch/batch/semantic_selection.py:216 src/git_stage_batch/batch/semantic_selection.py:222
+msgid "Selected lines do not form an unambiguous replacement."
+msgstr "الأسطر المحددة لا تشكل استبدالاً غير ملتبس."
+
+#: src/git_stage_batch/batch/semantic_selection.py:232
+msgid "Select the whole replacement row or broaden the selection."
+msgstr "حدد صف الاستبدال كاملاً أو وسّع التحديد."
+
+#: src/git_stage_batch/batch/semantic_selection.py:372
+msgid "Selected semantic change cannot be merged into the current index state."
+msgstr "لا يمكن دمج التغيير الدلالي المحدد في حالة الفهرس الحالية."
+
+#: src/git_stage_batch/cli/argument_parser.py:134
+msgid "Undo the most recent undoable session operation"
+msgstr "تراجع عن أحدث عملية جلسة قابلة للتراجع"
+
+#: src/git_stage_batch/cli/argument_parser.py:139
+msgid "Overwrite changes made after the undo checkpoint"
+msgstr "اكتب فوق التغييرات التي أُجريت بعد نقطة تحقق التراجع"
+
+#: src/git_stage_batch/cli/argument_parser.py:147
+msgid "Redo the most recently undone session operation"
+msgstr "أعد أحدث عملية جلسة تم التراجع عنها"
+
+#: src/git_stage_batch/cli/argument_parser.py:152
+msgid "Overwrite changes made after the undo"
+msgstr "اكتب فوق التغييرات التي أُجريت بعد التراجع"
+
+#: src/git_stage_batch/cli/argument_parser.py:337
+msgid "Path to the file to block (defaults to selected hunk's file)"
+msgstr "مسار الملف المراد حظره (الافتراضي هو ملف المقطع المحدد)"
+
+#: src/git_stage_batch/commands/redo.py:19
+#, python-brace-format
+msgid "✓ Redid: {operation}"
+msgstr "✓ أُعيد: {operation}"
+
+#: src/git_stage_batch/commands/undo.py:19
+#, python-brace-format
+msgid "✓ Undid: {operation}"
+msgstr "✓ تم التراجع: {operation}"
+
+#: src/git_stage_batch/data/undo.py:318
+#, python-brace-format
+msgid "Undo checkpoint is missing {path}"
+msgstr "تفتقد نقطة تحقق التراجع {path}"
+
+#: src/git_stage_batch/data/undo.py:389
+msgid "batch refs"
+msgstr "مراجع الدُفعات"
+
+#: src/git_stage_batch/data/undo.py:539
+msgid "Nothing to undo."
+msgstr "لا يوجد ما يمكن التراجع عنه."
+
+#: src/git_stage_batch/data/undo.py:546 src/git_stage_batch/data/undo.py:614
+#, python-brace-format
+msgid "{preview}, and {count} more"
+msgstr "{preview}، و{count} إضافية"
+
+#: src/git_stage_batch/data/undo.py:548
+#, python-brace-format
+msgid "Cannot undo because current state has changed since the checkpoint: {items}.\nRun 'git-stage-batch undo --force' to overwrite those changes."
+msgstr "لا يمكن التراجع لأن الحالة الحالية تغيرت منذ نقطة التحقق: {items}.\nشغّل 'git-stage-batch undo --force' للكتابة فوق تلك التغييرات."
+
+#: src/git_stage_batch/data/undo.py:616
+#, python-brace-format
+msgid "Cannot redo because current state has changed since the undo: {items}.\nRun 'git-stage-batch redo --force' to overwrite those changes."
+msgstr "لا يمكن الإعادة لأن الحالة الحالية تغيرت منذ التراجع: {items}.\nشغّل 'git-stage-batch redo --force' للكتابة فوق تلك التغييرات."
+
+#: src/git_stage_batch/tui/interactive.py:1083
+msgid "  u, undo      - Undo the most recent operation"
+msgstr "  u, undo      - تراجع عن أحدث عملية"
+
+#: src/git_stage_batch/tui/interactive.py:1084
+msgid "  U, redo      - Redo the most recently undone operation"
+msgstr "  U, redo      - أعد أحدث عملية تم التراجع عنها"

--- a/po/cs.po
+++ b/po/cs.po
@@ -1838,3 +1838,81 @@ msgstr "[{y}]no / [{n}]ásledující / [{r}]eset: "
 #: src/git_stage_batch/utils/git.py:227
 msgid "Not inside a git repository."
 msgstr "Nejste uvnitř git repozitáře."
+
+#: src/git_stage_batch/batch/semantic_selection.py:109 src/git_stage_batch/batch/semantic_selection.py:199 src/git_stage_batch/batch/semantic_selection.py:213 src/git_stage_batch/batch/semantic_selection.py:216 src/git_stage_batch/batch/semantic_selection.py:222
+msgid "Selected lines do not form an unambiguous replacement."
+msgstr "Vybrané řádky netvoří jednoznačnou náhradu."
+
+#: src/git_stage_batch/batch/semantic_selection.py:232
+msgid "Select the whole replacement row or broaden the selection."
+msgstr "Vyberte celý řádek náhrady nebo výběr rozšiřte."
+
+#: src/git_stage_batch/batch/semantic_selection.py:372
+msgid "Selected semantic change cannot be merged into the current index state."
+msgstr "Vybranou sémantickou změnu nelze sloučit do aktuálního stavu indexu."
+
+#: src/git_stage_batch/cli/argument_parser.py:134
+msgid "Undo the most recent undoable session operation"
+msgstr "Vrátit zpět poslední vratnou operaci relace"
+
+#: src/git_stage_batch/cli/argument_parser.py:139
+msgid "Overwrite changes made after the undo checkpoint"
+msgstr "Přepsat změny provedené po kontrolním bodu pro vrácení zpět"
+
+#: src/git_stage_batch/cli/argument_parser.py:147
+msgid "Redo the most recently undone session operation"
+msgstr "Znovu provést naposledy vrácenou operaci relace"
+
+#: src/git_stage_batch/cli/argument_parser.py:152
+msgid "Overwrite changes made after the undo"
+msgstr "Přepsat změny provedené po vrácení zpět"
+
+#: src/git_stage_batch/cli/argument_parser.py:337
+msgid "Path to the file to block (defaults to selected hunk's file)"
+msgstr "Cesta k souboru, který se má blokovat (výchozí je soubor vybraného hunku)"
+
+#: src/git_stage_batch/commands/redo.py:19
+#, python-brace-format
+msgid "✓ Redid: {operation}"
+msgstr "✓ Znovu provedeno: {operation}"
+
+#: src/git_stage_batch/commands/undo.py:19
+#, python-brace-format
+msgid "✓ Undid: {operation}"
+msgstr "✓ Vráceno zpět: {operation}"
+
+#: src/git_stage_batch/data/undo.py:318
+#, python-brace-format
+msgid "Undo checkpoint is missing {path}"
+msgstr "V kontrolním bodu pro vrácení zpět chybí {path}"
+
+#: src/git_stage_batch/data/undo.py:389
+msgid "batch refs"
+msgstr "reference dávek"
+
+#: src/git_stage_batch/data/undo.py:539
+msgid "Nothing to undo."
+msgstr "Není co vrátit zpět."
+
+#: src/git_stage_batch/data/undo.py:546 src/git_stage_batch/data/undo.py:614
+#, python-brace-format
+msgid "{preview}, and {count} more"
+msgstr "{preview} a ještě {count}"
+
+#: src/git_stage_batch/data/undo.py:548
+#, python-brace-format
+msgid "Cannot undo because current state has changed since the checkpoint: {items}.\nRun 'git-stage-batch undo --force' to overwrite those changes."
+msgstr "Nelze vrátit zpět, protože aktuální stav se od kontrolního bodu změnil: {items}.\nSpusťte 'git-stage-batch undo --force' pro přepsání těchto změn."
+
+#: src/git_stage_batch/data/undo.py:616
+#, python-brace-format
+msgid "Cannot redo because current state has changed since the undo: {items}.\nRun 'git-stage-batch redo --force' to overwrite those changes."
+msgstr "Nelze znovu provést, protože aktuální stav se od vrácení zpět změnil: {items}.\nSpusťte 'git-stage-batch redo --force' pro přepsání těchto změn."
+
+#: src/git_stage_batch/tui/interactive.py:1083
+msgid "  u, undo      - Undo the most recent operation"
+msgstr "  u, undo      - Vrátit zpět nejnovější operaci"
+
+#: src/git_stage_batch/tui/interactive.py:1084
+msgid "  U, redo      - Redo the most recently undone operation"
+msgstr "  U, redo      - Znovu provést naposledy vrácenou operaci"

--- a/po/de.po
+++ b/po/de.po
@@ -1847,3 +1847,81 @@ msgstr "[{y}]a / [{n}]ächstes / [{r}]urücksetzen: "
 #: src/git_stage_batch/utils/git.py:227
 msgid "Not inside a git repository."
 msgstr "Nicht innerhalb eines Git-Repositorys."
+
+#: src/git_stage_batch/batch/semantic_selection.py:109 src/git_stage_batch/batch/semantic_selection.py:199 src/git_stage_batch/batch/semantic_selection.py:213 src/git_stage_batch/batch/semantic_selection.py:216 src/git_stage_batch/batch/semantic_selection.py:222
+msgid "Selected lines do not form an unambiguous replacement."
+msgstr "Die ausgewählten Zeilen bilden keinen eindeutigen Ersatz."
+
+#: src/git_stage_batch/batch/semantic_selection.py:232
+msgid "Select the whole replacement row or broaden the selection."
+msgstr "Wählen Sie die gesamte Ersatzzeile aus oder erweitern Sie die Auswahl."
+
+#: src/git_stage_batch/batch/semantic_selection.py:372
+msgid "Selected semantic change cannot be merged into the current index state."
+msgstr "Die ausgewählte semantische Änderung kann nicht in den aktuellen Indexzustand zusammengeführt werden."
+
+#: src/git_stage_batch/cli/argument_parser.py:134
+msgid "Undo the most recent undoable session operation"
+msgstr "Die letzte rückgängig machbare Sitzungsoperation rückgängig machen"
+
+#: src/git_stage_batch/cli/argument_parser.py:139
+msgid "Overwrite changes made after the undo checkpoint"
+msgstr "Änderungen überschreiben, die nach dem Rückgängig-Prüfpunkt vorgenommen wurden"
+
+#: src/git_stage_batch/cli/argument_parser.py:147
+msgid "Redo the most recently undone session operation"
+msgstr "Die zuletzt rückgängig gemachte Sitzungsoperation wiederherstellen"
+
+#: src/git_stage_batch/cli/argument_parser.py:152
+msgid "Overwrite changes made after the undo"
+msgstr "Änderungen überschreiben, die nach dem Rückgängigmachen vorgenommen wurden"
+
+#: src/git_stage_batch/cli/argument_parser.py:337
+msgid "Path to the file to block (defaults to selected hunk's file)"
+msgstr "Pfad zur zu blockierenden Datei (standardmäßig die Datei des ausgewählten Hunks)"
+
+#: src/git_stage_batch/commands/redo.py:19
+#, python-brace-format
+msgid "✓ Redid: {operation}"
+msgstr "✓ Wiederhergestellt: {operation}"
+
+#: src/git_stage_batch/commands/undo.py:19
+#, python-brace-format
+msgid "✓ Undid: {operation}"
+msgstr "✓ Rückgängig gemacht: {operation}"
+
+#: src/git_stage_batch/data/undo.py:318
+#, python-brace-format
+msgid "Undo checkpoint is missing {path}"
+msgstr "Dem Rückgängig-Prüfpunkt fehlt {path}"
+
+#: src/git_stage_batch/data/undo.py:389
+msgid "batch refs"
+msgstr "Batch-Refs"
+
+#: src/git_stage_batch/data/undo.py:539
+msgid "Nothing to undo."
+msgstr "Nichts rückgängig zu machen."
+
+#: src/git_stage_batch/data/undo.py:546 src/git_stage_batch/data/undo.py:614
+#, python-brace-format
+msgid "{preview}, and {count} more"
+msgstr "{preview}, und {count} weitere"
+
+#: src/git_stage_batch/data/undo.py:548
+#, python-brace-format
+msgid "Cannot undo because current state has changed since the checkpoint: {items}.\nRun 'git-stage-batch undo --force' to overwrite those changes."
+msgstr "Rückgängig machen nicht möglich, da sich der aktuelle Zustand seit dem Prüfpunkt geändert hat: {items}.\nFühren Sie 'git-stage-batch undo --force' aus, um diese Änderungen zu überschreiben."
+
+#: src/git_stage_batch/data/undo.py:616
+#, python-brace-format
+msgid "Cannot redo because current state has changed since the undo: {items}.\nRun 'git-stage-batch redo --force' to overwrite those changes."
+msgstr "Wiederherstellen nicht möglich, da sich der aktuelle Zustand seit dem Rückgängigmachen geändert hat: {items}.\nFühren Sie 'git-stage-batch redo --force' aus, um diese Änderungen zu überschreiben."
+
+#: src/git_stage_batch/tui/interactive.py:1083
+msgid "  u, undo      - Undo the most recent operation"
+msgstr "  u, undo      - Die letzte Operation rückgängig machen"
+
+#: src/git_stage_batch/tui/interactive.py:1084
+msgid "  U, redo      - Redo the most recently undone operation"
+msgstr "  U, redo      - Die zuletzt rückgängig gemachte Operation wiederherstellen"

--- a/po/es.po
+++ b/po/es.po
@@ -1838,3 +1838,81 @@ msgstr "[{y}]sí / [{n}]siguiente / [{r}]establecer: "
 #: src/git_stage_batch/utils/git.py:227
 msgid "Not inside a git repository."
 msgstr "No está dentro de un repositorio git."
+
+#: src/git_stage_batch/batch/semantic_selection.py:109 src/git_stage_batch/batch/semantic_selection.py:199 src/git_stage_batch/batch/semantic_selection.py:213 src/git_stage_batch/batch/semantic_selection.py:216 src/git_stage_batch/batch/semantic_selection.py:222
+msgid "Selected lines do not form an unambiguous replacement."
+msgstr "Las líneas seleccionadas no forman un reemplazo inequívoco."
+
+#: src/git_stage_batch/batch/semantic_selection.py:232
+msgid "Select the whole replacement row or broaden the selection."
+msgstr "Seleccione toda la fila de reemplazo o amplíe la selección."
+
+#: src/git_stage_batch/batch/semantic_selection.py:372
+msgid "Selected semantic change cannot be merged into the current index state."
+msgstr "El cambio semántico seleccionado no se puede fusionar con el estado actual del índice."
+
+#: src/git_stage_batch/cli/argument_parser.py:134
+msgid "Undo the most recent undoable session operation"
+msgstr "Deshacer la operación deshacible más reciente de la sesión"
+
+#: src/git_stage_batch/cli/argument_parser.py:139
+msgid "Overwrite changes made after the undo checkpoint"
+msgstr "Sobrescribir los cambios realizados después del punto de control de deshacer"
+
+#: src/git_stage_batch/cli/argument_parser.py:147
+msgid "Redo the most recently undone session operation"
+msgstr "Rehacer la operación deshecha más recientemente de la sesión"
+
+#: src/git_stage_batch/cli/argument_parser.py:152
+msgid "Overwrite changes made after the undo"
+msgstr "Sobrescribir los cambios realizados después de deshacer"
+
+#: src/git_stage_batch/cli/argument_parser.py:337
+msgid "Path to the file to block (defaults to selected hunk's file)"
+msgstr "Ruta del archivo que se bloqueará (por defecto, el archivo del fragmento seleccionado)"
+
+#: src/git_stage_batch/commands/redo.py:19
+#, python-brace-format
+msgid "✓ Redid: {operation}"
+msgstr "✓ Rehecho: {operation}"
+
+#: src/git_stage_batch/commands/undo.py:19
+#, python-brace-format
+msgid "✓ Undid: {operation}"
+msgstr "✓ Deshecho: {operation}"
+
+#: src/git_stage_batch/data/undo.py:318
+#, python-brace-format
+msgid "Undo checkpoint is missing {path}"
+msgstr "Al punto de control de deshacer le falta {path}"
+
+#: src/git_stage_batch/data/undo.py:389
+msgid "batch refs"
+msgstr "referencias de lotes"
+
+#: src/git_stage_batch/data/undo.py:539
+msgid "Nothing to undo."
+msgstr "No hay nada que deshacer."
+
+#: src/git_stage_batch/data/undo.py:546 src/git_stage_batch/data/undo.py:614
+#, python-brace-format
+msgid "{preview}, and {count} more"
+msgstr "{preview}, y {count} más"
+
+#: src/git_stage_batch/data/undo.py:548
+#, python-brace-format
+msgid "Cannot undo because current state has changed since the checkpoint: {items}.\nRun 'git-stage-batch undo --force' to overwrite those changes."
+msgstr "No se puede deshacer porque el estado actual ha cambiado desde el punto de control: {items}.\nEjecute 'git-stage-batch undo --force' para sobrescribir esos cambios."
+
+#: src/git_stage_batch/data/undo.py:616
+#, python-brace-format
+msgid "Cannot redo because current state has changed since the undo: {items}.\nRun 'git-stage-batch redo --force' to overwrite those changes."
+msgstr "No se puede rehacer porque el estado actual ha cambiado desde el deshacer: {items}.\nEjecute 'git-stage-batch redo --force' para sobrescribir esos cambios."
+
+#: src/git_stage_batch/tui/interactive.py:1083
+msgid "  u, undo      - Undo the most recent operation"
+msgstr "  u, undo      - Deshacer la operación más reciente"
+
+#: src/git_stage_batch/tui/interactive.py:1084
+msgid "  U, redo      - Redo the most recently undone operation"
+msgstr "  U, redo      - Rehacer la operación deshecha más recientemente"

--- a/po/fr.po
+++ b/po/fr.po
@@ -1845,3 +1845,81 @@ msgstr "[{y}] oui / [{n}] suivant / [{r}] réinitialiser : "
 #: src/git_stage_batch/utils/git.py:227
 msgid "Not inside a git repository."
 msgstr "Pas dans un dépôt git."
+
+#: src/git_stage_batch/batch/semantic_selection.py:109 src/git_stage_batch/batch/semantic_selection.py:199 src/git_stage_batch/batch/semantic_selection.py:213 src/git_stage_batch/batch/semantic_selection.py:216 src/git_stage_batch/batch/semantic_selection.py:222
+msgid "Selected lines do not form an unambiguous replacement."
+msgstr "Les lignes sélectionnées ne forment pas un remplacement non ambigu."
+
+#: src/git_stage_batch/batch/semantic_selection.py:232
+msgid "Select the whole replacement row or broaden the selection."
+msgstr "Sélectionnez toute la ligne de remplacement ou élargissez la sélection."
+
+#: src/git_stage_batch/batch/semantic_selection.py:372
+msgid "Selected semantic change cannot be merged into the current index state."
+msgstr "Le changement sémantique sélectionné ne peut pas être fusionné dans l'état actuel de l'index."
+
+#: src/git_stage_batch/cli/argument_parser.py:134
+msgid "Undo the most recent undoable session operation"
+msgstr "Annuler la dernière opération annulable de la session"
+
+#: src/git_stage_batch/cli/argument_parser.py:139
+msgid "Overwrite changes made after the undo checkpoint"
+msgstr "Écraser les changements effectués après le point de contrôle d'annulation"
+
+#: src/git_stage_batch/cli/argument_parser.py:147
+msgid "Redo the most recently undone session operation"
+msgstr "Rétablir la dernière opération annulée de la session"
+
+#: src/git_stage_batch/cli/argument_parser.py:152
+msgid "Overwrite changes made after the undo"
+msgstr "Écraser les changements effectués après l'annulation"
+
+#: src/git_stage_batch/cli/argument_parser.py:337
+msgid "Path to the file to block (defaults to selected hunk's file)"
+msgstr "Chemin du fichier à bloquer (par défaut, le fichier du fragment sélectionné)"
+
+#: src/git_stage_batch/commands/redo.py:19
+#, python-brace-format
+msgid "✓ Redid: {operation}"
+msgstr "✓ Rétabli : {operation}"
+
+#: src/git_stage_batch/commands/undo.py:19
+#, python-brace-format
+msgid "✓ Undid: {operation}"
+msgstr "✓ Annulé : {operation}"
+
+#: src/git_stage_batch/data/undo.py:318
+#, python-brace-format
+msgid "Undo checkpoint is missing {path}"
+msgstr "Le point de contrôle d'annulation ne contient pas {path}"
+
+#: src/git_stage_batch/data/undo.py:389
+msgid "batch refs"
+msgstr "références de lots"
+
+#: src/git_stage_batch/data/undo.py:539
+msgid "Nothing to undo."
+msgstr "Rien à annuler."
+
+#: src/git_stage_batch/data/undo.py:546 src/git_stage_batch/data/undo.py:614
+#, python-brace-format
+msgid "{preview}, and {count} more"
+msgstr "{preview}, et {count} de plus"
+
+#: src/git_stage_batch/data/undo.py:548
+#, python-brace-format
+msgid "Cannot undo because current state has changed since the checkpoint: {items}.\nRun 'git-stage-batch undo --force' to overwrite those changes."
+msgstr "Impossible d'annuler car l'état actuel a changé depuis le point de contrôle : {items}.\nExécutez 'git-stage-batch undo --force' pour écraser ces changements."
+
+#: src/git_stage_batch/data/undo.py:616
+#, python-brace-format
+msgid "Cannot redo because current state has changed since the undo: {items}.\nRun 'git-stage-batch redo --force' to overwrite those changes."
+msgstr "Impossible de rétablir car l'état actuel a changé depuis l'annulation : {items}.\nExécutez 'git-stage-batch redo --force' pour écraser ces changements."
+
+#: src/git_stage_batch/tui/interactive.py:1083
+msgid "  u, undo      - Undo the most recent operation"
+msgstr "  u, undo      - Annuler l'opération la plus récente"
+
+#: src/git_stage_batch/tui/interactive.py:1084
+msgid "  U, redo      - Redo the most recently undone operation"
+msgstr "  U, redo      - Rétablir l'opération annulée la plus récemment"

--- a/po/ja.po
+++ b/po/ja.po
@@ -1825,3 +1825,81 @@ msgstr "[{y}]はい / [{n}]次 / [{r}]リセット: "
 #: src/git_stage_batch/utils/git.py:227
 msgid "Not inside a git repository."
 msgstr "Gitリポジトリ内ではありません。"
+
+#: src/git_stage_batch/batch/semantic_selection.py:109 src/git_stage_batch/batch/semantic_selection.py:199 src/git_stage_batch/batch/semantic_selection.py:213 src/git_stage_batch/batch/semantic_selection.py:216 src/git_stage_batch/batch/semantic_selection.py:222
+msgid "Selected lines do not form an unambiguous replacement."
+msgstr "選択した行は明確な置換を形成していません。"
+
+#: src/git_stage_batch/batch/semantic_selection.py:232
+msgid "Select the whole replacement row or broaden the selection."
+msgstr "置換行全体を選択するか、選択範囲を広げてください。"
+
+#: src/git_stage_batch/batch/semantic_selection.py:372
+msgid "Selected semantic change cannot be merged into the current index state."
+msgstr "選択した意味的変更を現在のインデックス状態にマージできません。"
+
+#: src/git_stage_batch/cli/argument_parser.py:134
+msgid "Undo the most recent undoable session operation"
+msgstr "取り消し可能な最新のセッション操作を取り消す"
+
+#: src/git_stage_batch/cli/argument_parser.py:139
+msgid "Overwrite changes made after the undo checkpoint"
+msgstr "取り消しチェックポイント後に行われた変更を上書きする"
+
+#: src/git_stage_batch/cli/argument_parser.py:147
+msgid "Redo the most recently undone session operation"
+msgstr "直近で取り消したセッション操作をやり直す"
+
+#: src/git_stage_batch/cli/argument_parser.py:152
+msgid "Overwrite changes made after the undo"
+msgstr "取り消し後に行われた変更を上書きする"
+
+#: src/git_stage_batch/cli/argument_parser.py:337
+msgid "Path to the file to block (defaults to selected hunk's file)"
+msgstr "ブロックするファイルへのパス (既定では選択中のハンクのファイル)"
+
+#: src/git_stage_batch/commands/redo.py:19
+#, python-brace-format
+msgid "✓ Redid: {operation}"
+msgstr "✓ やり直しました: {operation}"
+
+#: src/git_stage_batch/commands/undo.py:19
+#, python-brace-format
+msgid "✓ Undid: {operation}"
+msgstr "✓ 取り消しました: {operation}"
+
+#: src/git_stage_batch/data/undo.py:318
+#, python-brace-format
+msgid "Undo checkpoint is missing {path}"
+msgstr "取り消しチェックポイントに {path} がありません"
+
+#: src/git_stage_batch/data/undo.py:389
+msgid "batch refs"
+msgstr "バッチ参照"
+
+#: src/git_stage_batch/data/undo.py:539
+msgid "Nothing to undo."
+msgstr "取り消すものはありません。"
+
+#: src/git_stage_batch/data/undo.py:546 src/git_stage_batch/data/undo.py:614
+#, python-brace-format
+msgid "{preview}, and {count} more"
+msgstr "{preview}、さらに {count} 件"
+
+#: src/git_stage_batch/data/undo.py:548
+#, python-brace-format
+msgid "Cannot undo because current state has changed since the checkpoint: {items}.\nRun 'git-stage-batch undo --force' to overwrite those changes."
+msgstr "チェックポイント以降に現在の状態が変更されたため取り消せません: {items}。\nこれらの変更を上書きするには 'git-stage-batch undo --force' を実行してください。"
+
+#: src/git_stage_batch/data/undo.py:616
+#, python-brace-format
+msgid "Cannot redo because current state has changed since the undo: {items}.\nRun 'git-stage-batch redo --force' to overwrite those changes."
+msgstr "取り消し以降に現在の状態が変更されたためやり直せません: {items}。\nこれらの変更を上書きするには 'git-stage-batch redo --force' を実行してください。"
+
+#: src/git_stage_batch/tui/interactive.py:1083
+msgid "  u, undo      - Undo the most recent operation"
+msgstr "  u, undo      - 最新の操作を取り消す"
+
+#: src/git_stage_batch/tui/interactive.py:1084
+msgid "  U, redo      - Redo the most recently undone operation"
+msgstr "  U, redo      - 直近で取り消した操作をやり直す"

--- a/po/ko.po
+++ b/po/ko.po
@@ -1821,3 +1821,81 @@ msgstr "[{y}]예 / [{n}]다음 / [{r}]재설정: "
 #: src/git_stage_batch/utils/git.py:227
 msgid "Not inside a git repository."
 msgstr "git 저장소 내부가 아닙니다."
+
+#: src/git_stage_batch/batch/semantic_selection.py:109 src/git_stage_batch/batch/semantic_selection.py:199 src/git_stage_batch/batch/semantic_selection.py:213 src/git_stage_batch/batch/semantic_selection.py:216 src/git_stage_batch/batch/semantic_selection.py:222
+msgid "Selected lines do not form an unambiguous replacement."
+msgstr "선택한 줄은 명확한 교체를 이루지 않습니다."
+
+#: src/git_stage_batch/batch/semantic_selection.py:232
+msgid "Select the whole replacement row or broaden the selection."
+msgstr "전체 교체 행을 선택하거나 선택 범위를 넓히십시오."
+
+#: src/git_stage_batch/batch/semantic_selection.py:372
+msgid "Selected semantic change cannot be merged into the current index state."
+msgstr "선택한 의미적 변경을 현재 인덱스 상태에 병합할 수 없습니다."
+
+#: src/git_stage_batch/cli/argument_parser.py:134
+msgid "Undo the most recent undoable session operation"
+msgstr "가장 최근의 되돌릴 수 있는 세션 작업 실행 취소"
+
+#: src/git_stage_batch/cli/argument_parser.py:139
+msgid "Overwrite changes made after the undo checkpoint"
+msgstr "실행 취소 체크포인트 이후의 변경 사항 덮어쓰기"
+
+#: src/git_stage_batch/cli/argument_parser.py:147
+msgid "Redo the most recently undone session operation"
+msgstr "가장 최근에 실행 취소한 세션 작업 다시 실행"
+
+#: src/git_stage_batch/cli/argument_parser.py:152
+msgid "Overwrite changes made after the undo"
+msgstr "실행 취소 이후의 변경 사항 덮어쓰기"
+
+#: src/git_stage_batch/cli/argument_parser.py:337
+msgid "Path to the file to block (defaults to selected hunk's file)"
+msgstr "차단할 파일 경로(기본값은 선택한 헝크의 파일)"
+
+#: src/git_stage_batch/commands/redo.py:19
+#, python-brace-format
+msgid "✓ Redid: {operation}"
+msgstr "✓ 다시 실행함: {operation}"
+
+#: src/git_stage_batch/commands/undo.py:19
+#, python-brace-format
+msgid "✓ Undid: {operation}"
+msgstr "✓ 실행 취소함: {operation}"
+
+#: src/git_stage_batch/data/undo.py:318
+#, python-brace-format
+msgid "Undo checkpoint is missing {path}"
+msgstr "실행 취소 체크포인트에 {path}이(가) 없습니다"
+
+#: src/git_stage_batch/data/undo.py:389
+msgid "batch refs"
+msgstr "배치 참조"
+
+#: src/git_stage_batch/data/undo.py:539
+msgid "Nothing to undo."
+msgstr "실행 취소할 항목이 없습니다."
+
+#: src/git_stage_batch/data/undo.py:546 src/git_stage_batch/data/undo.py:614
+#, python-brace-format
+msgid "{preview}, and {count} more"
+msgstr "{preview}, 그리고 {count}개 더"
+
+#: src/git_stage_batch/data/undo.py:548
+#, python-brace-format
+msgid "Cannot undo because current state has changed since the checkpoint: {items}.\nRun 'git-stage-batch undo --force' to overwrite those changes."
+msgstr "체크포인트 이후 현재 상태가 변경되어 실행 취소할 수 없습니다: {items}.\n해당 변경 사항을 덮어쓰려면 'git-stage-batch undo --force'를 실행하십시오."
+
+#: src/git_stage_batch/data/undo.py:616
+#, python-brace-format
+msgid "Cannot redo because current state has changed since the undo: {items}.\nRun 'git-stage-batch redo --force' to overwrite those changes."
+msgstr "실행 취소 이후 현재 상태가 변경되어 다시 실행할 수 없습니다: {items}.\n해당 변경 사항을 덮어쓰려면 'git-stage-batch redo --force'를 실행하십시오."
+
+#: src/git_stage_batch/tui/interactive.py:1083
+msgid "  u, undo      - Undo the most recent operation"
+msgstr "  u, undo      - 가장 최근 작업 실행 취소"
+
+#: src/git_stage_batch/tui/interactive.py:1084
+msgid "  U, redo      - Redo the most recently undone operation"
+msgstr "  U, redo      - 가장 최근에 실행 취소한 작업 다시 실행"

--- a/po/nl.po
+++ b/po/nl.po
@@ -1838,3 +1838,81 @@ msgstr "[{y}]a / [{n}]volgende / [{r}]eset: "
 #: src/git_stage_batch/utils/git.py:227
 msgid "Not inside a git repository."
 msgstr "Niet binnen een git-repository."
+
+#: src/git_stage_batch/batch/semantic_selection.py:109 src/git_stage_batch/batch/semantic_selection.py:199 src/git_stage_batch/batch/semantic_selection.py:213 src/git_stage_batch/batch/semantic_selection.py:216 src/git_stage_batch/batch/semantic_selection.py:222
+msgid "Selected lines do not form an unambiguous replacement."
+msgstr "De geselecteerde regels vormen geen eenduidige vervanging."
+
+#: src/git_stage_batch/batch/semantic_selection.py:232
+msgid "Select the whole replacement row or broaden the selection."
+msgstr "Selecteer de hele vervangingsrij of maak de selectie breder."
+
+#: src/git_stage_batch/batch/semantic_selection.py:372
+msgid "Selected semantic change cannot be merged into the current index state."
+msgstr "De geselecteerde semantische wijziging kan niet worden samengevoegd met de huidige indexstatus."
+
+#: src/git_stage_batch/cli/argument_parser.py:134
+msgid "Undo the most recent undoable session operation"
+msgstr "De meest recente ongedaan te maken sessiebewerking ongedaan maken"
+
+#: src/git_stage_batch/cli/argument_parser.py:139
+msgid "Overwrite changes made after the undo checkpoint"
+msgstr "Wijzigingen overschrijven die na het undo-controlepunt zijn gemaakt"
+
+#: src/git_stage_batch/cli/argument_parser.py:147
+msgid "Redo the most recently undone session operation"
+msgstr "De meest recent ongedaan gemaakte sessiebewerking opnieuw uitvoeren"
+
+#: src/git_stage_batch/cli/argument_parser.py:152
+msgid "Overwrite changes made after the undo"
+msgstr "Wijzigingen overschrijven die na het ongedaan maken zijn gemaakt"
+
+#: src/git_stage_batch/cli/argument_parser.py:337
+msgid "Path to the file to block (defaults to selected hunk's file)"
+msgstr "Pad naar het te blokkeren bestand (standaard het bestand van de geselecteerde hunk)"
+
+#: src/git_stage_batch/commands/redo.py:19
+#, python-brace-format
+msgid "✓ Redid: {operation}"
+msgstr "✓ Opnieuw uitgevoerd: {operation}"
+
+#: src/git_stage_batch/commands/undo.py:19
+#, python-brace-format
+msgid "✓ Undid: {operation}"
+msgstr "✓ Ongedaan gemaakt: {operation}"
+
+#: src/git_stage_batch/data/undo.py:318
+#, python-brace-format
+msgid "Undo checkpoint is missing {path}"
+msgstr "Undo-controlepunt mist {path}"
+
+#: src/git_stage_batch/data/undo.py:389
+msgid "batch refs"
+msgstr "batchverwijzingen"
+
+#: src/git_stage_batch/data/undo.py:539
+msgid "Nothing to undo."
+msgstr "Niets om ongedaan te maken."
+
+#: src/git_stage_batch/data/undo.py:546 src/git_stage_batch/data/undo.py:614
+#, python-brace-format
+msgid "{preview}, and {count} more"
+msgstr "{preview}, en nog {count}"
+
+#: src/git_stage_batch/data/undo.py:548
+#, python-brace-format
+msgid "Cannot undo because current state has changed since the checkpoint: {items}.\nRun 'git-stage-batch undo --force' to overwrite those changes."
+msgstr "Kan niet ongedaan maken omdat de huidige status sinds het controlepunt is gewijzigd: {items}.\nVoer 'git-stage-batch undo --force' uit om die wijzigingen te overschrijven."
+
+#: src/git_stage_batch/data/undo.py:616
+#, python-brace-format
+msgid "Cannot redo because current state has changed since the undo: {items}.\nRun 'git-stage-batch redo --force' to overwrite those changes."
+msgstr "Kan niet opnieuw uitvoeren omdat de huidige status sinds het ongedaan maken is gewijzigd: {items}.\nVoer 'git-stage-batch redo --force' uit om die wijzigingen te overschrijven."
+
+#: src/git_stage_batch/tui/interactive.py:1083
+msgid "  u, undo      - Undo the most recent operation"
+msgstr "  u, undo      - De meest recente bewerking ongedaan maken"
+
+#: src/git_stage_batch/tui/interactive.py:1084
+msgid "  U, redo      - Redo the most recently undone operation"
+msgstr "  U, redo      - De meest recent ongedaan gemaakte bewerking opnieuw uitvoeren"

--- a/po/pl.po
+++ b/po/pl.po
@@ -1844,3 +1844,81 @@ msgstr "[{y}] tak / [{n}] następny / [{r}] resetuj: "
 #: src/git_stage_batch/utils/git.py:227
 msgid "Not inside a git repository."
 msgstr "Nie jesteś wewnątrz repozytorium git."
+
+#: src/git_stage_batch/batch/semantic_selection.py:109 src/git_stage_batch/batch/semantic_selection.py:199 src/git_stage_batch/batch/semantic_selection.py:213 src/git_stage_batch/batch/semantic_selection.py:216 src/git_stage_batch/batch/semantic_selection.py:222
+msgid "Selected lines do not form an unambiguous replacement."
+msgstr "Wybrane wiersze nie tworzą jednoznacznego zastąpienia."
+
+#: src/git_stage_batch/batch/semantic_selection.py:232
+msgid "Select the whole replacement row or broaden the selection."
+msgstr "Wybierz cały wiersz zastąpienia albo rozszerz wybór."
+
+#: src/git_stage_batch/batch/semantic_selection.py:372
+msgid "Selected semantic change cannot be merged into the current index state."
+msgstr "Wybranej zmiany semantycznej nie można scalić z bieżącym stanem indeksu."
+
+#: src/git_stage_batch/cli/argument_parser.py:134
+msgid "Undo the most recent undoable session operation"
+msgstr "Cofnij najnowszą odwracalną operację sesji"
+
+#: src/git_stage_batch/cli/argument_parser.py:139
+msgid "Overwrite changes made after the undo checkpoint"
+msgstr "Nadpisz zmiany wykonane po punkcie kontrolnym cofania"
+
+#: src/git_stage_batch/cli/argument_parser.py:147
+msgid "Redo the most recently undone session operation"
+msgstr "Ponów ostatnio cofniętą operację sesji"
+
+#: src/git_stage_batch/cli/argument_parser.py:152
+msgid "Overwrite changes made after the undo"
+msgstr "Nadpisz zmiany wykonane po cofnięciu"
+
+#: src/git_stage_batch/cli/argument_parser.py:337
+msgid "Path to the file to block (defaults to selected hunk's file)"
+msgstr "Ścieżka do pliku do zablokowania (domyślnie plik wybranego hunka)"
+
+#: src/git_stage_batch/commands/redo.py:19
+#, python-brace-format
+msgid "✓ Redid: {operation}"
+msgstr "✓ Ponowiono: {operation}"
+
+#: src/git_stage_batch/commands/undo.py:19
+#, python-brace-format
+msgid "✓ Undid: {operation}"
+msgstr "✓ Cofnięto: {operation}"
+
+#: src/git_stage_batch/data/undo.py:318
+#, python-brace-format
+msgid "Undo checkpoint is missing {path}"
+msgstr "W punkcie kontrolnym cofania brakuje {path}"
+
+#: src/git_stage_batch/data/undo.py:389
+msgid "batch refs"
+msgstr "referencje partii"
+
+#: src/git_stage_batch/data/undo.py:539
+msgid "Nothing to undo."
+msgstr "Nie ma nic do cofnięcia."
+
+#: src/git_stage_batch/data/undo.py:546 src/git_stage_batch/data/undo.py:614
+#, python-brace-format
+msgid "{preview}, and {count} more"
+msgstr "{preview} i jeszcze {count}"
+
+#: src/git_stage_batch/data/undo.py:548
+#, python-brace-format
+msgid "Cannot undo because current state has changed since the checkpoint: {items}.\nRun 'git-stage-batch undo --force' to overwrite those changes."
+msgstr "Nie można cofnąć, ponieważ bieżący stan zmienił się od punktu kontrolnego: {items}.\nUruchom 'git-stage-batch undo --force', aby nadpisać te zmiany."
+
+#: src/git_stage_batch/data/undo.py:616
+#, python-brace-format
+msgid "Cannot redo because current state has changed since the undo: {items}.\nRun 'git-stage-batch redo --force' to overwrite those changes."
+msgstr "Nie można ponowić, ponieważ bieżący stan zmienił się od cofnięcia: {items}.\nUruchom 'git-stage-batch redo --force', aby nadpisać te zmiany."
+
+#: src/git_stage_batch/tui/interactive.py:1083
+msgid "  u, undo      - Undo the most recent operation"
+msgstr "  u, undo      - Cofnij najnowszą operację"
+
+#: src/git_stage_batch/tui/interactive.py:1084
+msgid "  U, redo      - Redo the most recently undone operation"
+msgstr "  U, redo      - Ponów ostatnio cofniętą operację"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1839,3 +1839,81 @@ msgstr "[{y}]im / [{n}]ext / [{r}]esetar: "
 #: src/git_stage_batch/utils/git.py:227
 msgid "Not inside a git repository."
 msgstr "Não está dentro de um repositório git."
+
+#: src/git_stage_batch/batch/semantic_selection.py:109 src/git_stage_batch/batch/semantic_selection.py:199 src/git_stage_batch/batch/semantic_selection.py:213 src/git_stage_batch/batch/semantic_selection.py:216 src/git_stage_batch/batch/semantic_selection.py:222
+msgid "Selected lines do not form an unambiguous replacement."
+msgstr "As linhas selecionadas não formam uma substituição inequívoca."
+
+#: src/git_stage_batch/batch/semantic_selection.py:232
+msgid "Select the whole replacement row or broaden the selection."
+msgstr "Selecione toda a linha de substituição ou amplie a seleção."
+
+#: src/git_stage_batch/batch/semantic_selection.py:372
+msgid "Selected semantic change cannot be merged into the current index state."
+msgstr "A alteração semântica selecionada não pode ser mesclada ao estado atual do índice."
+
+#: src/git_stage_batch/cli/argument_parser.py:134
+msgid "Undo the most recent undoable session operation"
+msgstr "Desfazer a operação de sessão desfeita mais recente"
+
+#: src/git_stage_batch/cli/argument_parser.py:139
+msgid "Overwrite changes made after the undo checkpoint"
+msgstr "Sobrescrever alterações feitas após o ponto de verificação de desfazer"
+
+#: src/git_stage_batch/cli/argument_parser.py:147
+msgid "Redo the most recently undone session operation"
+msgstr "Refazer a operação de sessão desfeita mais recentemente"
+
+#: src/git_stage_batch/cli/argument_parser.py:152
+msgid "Overwrite changes made after the undo"
+msgstr "Sobrescrever alterações feitas após desfazer"
+
+#: src/git_stage_batch/cli/argument_parser.py:337
+msgid "Path to the file to block (defaults to selected hunk's file)"
+msgstr "Caminho para o arquivo a bloquear (por padrão, o arquivo do hunk selecionado)"
+
+#: src/git_stage_batch/commands/redo.py:19
+#, python-brace-format
+msgid "✓ Redid: {operation}"
+msgstr "✓ Refeito: {operation}"
+
+#: src/git_stage_batch/commands/undo.py:19
+#, python-brace-format
+msgid "✓ Undid: {operation}"
+msgstr "✓ Desfeito: {operation}"
+
+#: src/git_stage_batch/data/undo.py:318
+#, python-brace-format
+msgid "Undo checkpoint is missing {path}"
+msgstr "O ponto de verificação de desfazer está sem {path}"
+
+#: src/git_stage_batch/data/undo.py:389
+msgid "batch refs"
+msgstr "referências de lotes"
+
+#: src/git_stage_batch/data/undo.py:539
+msgid "Nothing to undo."
+msgstr "Nada para desfazer."
+
+#: src/git_stage_batch/data/undo.py:546 src/git_stage_batch/data/undo.py:614
+#, python-brace-format
+msgid "{preview}, and {count} more"
+msgstr "{preview}, e mais {count}"
+
+#: src/git_stage_batch/data/undo.py:548
+#, python-brace-format
+msgid "Cannot undo because current state has changed since the checkpoint: {items}.\nRun 'git-stage-batch undo --force' to overwrite those changes."
+msgstr "Não é possível desfazer porque o estado atual mudou desde o ponto de verificação: {items}.\nExecute 'git-stage-batch undo --force' para sobrescrever essas alterações."
+
+#: src/git_stage_batch/data/undo.py:616
+#, python-brace-format
+msgid "Cannot redo because current state has changed since the undo: {items}.\nRun 'git-stage-batch redo --force' to overwrite those changes."
+msgstr "Não é possível refazer porque o estado atual mudou desde o desfazer: {items}.\nExecute 'git-stage-batch redo --force' para sobrescrever essas alterações."
+
+#: src/git_stage_batch/tui/interactive.py:1083
+msgid "  u, undo      - Undo the most recent operation"
+msgstr "  u, undo      - Desfazer a operação mais recente"
+
+#: src/git_stage_batch/tui/interactive.py:1084
+msgid "  U, redo      - Redo the most recently undone operation"
+msgstr "  U, redo      - Refazer a operação desfeita mais recentemente"

--- a/po/ru.po
+++ b/po/ru.po
@@ -1844,3 +1844,81 @@ msgstr "[{y}] да / [{n}] следующий / [{r}] сброс: "
 #: src/git_stage_batch/utils/git.py:227
 msgid "Not inside a git repository."
 msgstr "Не внутри git-репозитория."
+
+#: src/git_stage_batch/batch/semantic_selection.py:109 src/git_stage_batch/batch/semantic_selection.py:199 src/git_stage_batch/batch/semantic_selection.py:213 src/git_stage_batch/batch/semantic_selection.py:216 src/git_stage_batch/batch/semantic_selection.py:222
+msgid "Selected lines do not form an unambiguous replacement."
+msgstr "Выбранные строки не образуют однозначную замену."
+
+#: src/git_stage_batch/batch/semantic_selection.py:232
+msgid "Select the whole replacement row or broaden the selection."
+msgstr "Выберите всю строку замены или расширьте выбор."
+
+#: src/git_stage_batch/batch/semantic_selection.py:372
+msgid "Selected semantic change cannot be merged into the current index state."
+msgstr "Выбранное семантическое изменение нельзя объединить с текущим состоянием индекса."
+
+#: src/git_stage_batch/cli/argument_parser.py:134
+msgid "Undo the most recent undoable session operation"
+msgstr "Отменить последнюю отменяемую операцию сеанса"
+
+#: src/git_stage_batch/cli/argument_parser.py:139
+msgid "Overwrite changes made after the undo checkpoint"
+msgstr "Перезаписать изменения, сделанные после контрольной точки отмены"
+
+#: src/git_stage_batch/cli/argument_parser.py:147
+msgid "Redo the most recently undone session operation"
+msgstr "Повторить последнюю отменённую операцию сеанса"
+
+#: src/git_stage_batch/cli/argument_parser.py:152
+msgid "Overwrite changes made after the undo"
+msgstr "Перезаписать изменения, сделанные после отмены"
+
+#: src/git_stage_batch/cli/argument_parser.py:337
+msgid "Path to the file to block (defaults to selected hunk's file)"
+msgstr "Путь к файлу для блокировки (по умолчанию файл выбранного фрагмента)"
+
+#: src/git_stage_batch/commands/redo.py:19
+#, python-brace-format
+msgid "✓ Redid: {operation}"
+msgstr "✓ Повторено: {operation}"
+
+#: src/git_stage_batch/commands/undo.py:19
+#, python-brace-format
+msgid "✓ Undid: {operation}"
+msgstr "✓ Отменено: {operation}"
+
+#: src/git_stage_batch/data/undo.py:318
+#, python-brace-format
+msgid "Undo checkpoint is missing {path}"
+msgstr "В контрольной точке отмены отсутствует {path}"
+
+#: src/git_stage_batch/data/undo.py:389
+msgid "batch refs"
+msgstr "ссылки пакетов"
+
+#: src/git_stage_batch/data/undo.py:539
+msgid "Nothing to undo."
+msgstr "Нечего отменять."
+
+#: src/git_stage_batch/data/undo.py:546 src/git_stage_batch/data/undo.py:614
+#, python-brace-format
+msgid "{preview}, and {count} more"
+msgstr "{preview} и ещё {count}"
+
+#: src/git_stage_batch/data/undo.py:548
+#, python-brace-format
+msgid "Cannot undo because current state has changed since the checkpoint: {items}.\nRun 'git-stage-batch undo --force' to overwrite those changes."
+msgstr "Невозможно отменить, потому что текущее состояние изменилось после контрольной точки: {items}.\nЗапустите 'git-stage-batch undo --force', чтобы перезаписать эти изменения."
+
+#: src/git_stage_batch/data/undo.py:616
+#, python-brace-format
+msgid "Cannot redo because current state has changed since the undo: {items}.\nRun 'git-stage-batch redo --force' to overwrite those changes."
+msgstr "Невозможно повторить, потому что текущее состояние изменилось после отмены: {items}.\nЗапустите 'git-stage-batch redo --force', чтобы перезаписать эти изменения."
+
+#: src/git_stage_batch/tui/interactive.py:1083
+msgid "  u, undo      - Undo the most recent operation"
+msgstr "  u, undo      - Отменить последнюю операцию"
+
+#: src/git_stage_batch/tui/interactive.py:1084
+msgid "  U, redo      - Redo the most recently undone operation"
+msgstr "  U, redo      - Повторить последнюю отменённую операцию"

--- a/po/tr.po
+++ b/po/tr.po
@@ -1839,3 +1839,81 @@ msgstr "[{y}]vet / [{n}]onraki / [{r}]ıfırla: "
 #: src/git_stage_batch/utils/git.py:227
 msgid "Not inside a git repository."
 msgstr "Bir git deposu içinde değil."
+
+#: src/git_stage_batch/batch/semantic_selection.py:109 src/git_stage_batch/batch/semantic_selection.py:199 src/git_stage_batch/batch/semantic_selection.py:213 src/git_stage_batch/batch/semantic_selection.py:216 src/git_stage_batch/batch/semantic_selection.py:222
+msgid "Selected lines do not form an unambiguous replacement."
+msgstr "Seçilen satırlar belirsiz olmayan bir değiştirme oluşturmuyor."
+
+#: src/git_stage_batch/batch/semantic_selection.py:232
+msgid "Select the whole replacement row or broaden the selection."
+msgstr "Tüm değiştirme satırını seçin veya seçimi genişletin."
+
+#: src/git_stage_batch/batch/semantic_selection.py:372
+msgid "Selected semantic change cannot be merged into the current index state."
+msgstr "Seçilen anlamsal değişiklik geçerli indeks durumuyla birleştirilemiyor."
+
+#: src/git_stage_batch/cli/argument_parser.py:134
+msgid "Undo the most recent undoable session operation"
+msgstr "En son geri alınabilir oturum işlemini geri al"
+
+#: src/git_stage_batch/cli/argument_parser.py:139
+msgid "Overwrite changes made after the undo checkpoint"
+msgstr "Geri alma denetim noktasından sonra yapılan değişikliklerin üzerine yaz"
+
+#: src/git_stage_batch/cli/argument_parser.py:147
+msgid "Redo the most recently undone session operation"
+msgstr "En son geri alınan oturum işlemini yinele"
+
+#: src/git_stage_batch/cli/argument_parser.py:152
+msgid "Overwrite changes made after the undo"
+msgstr "Geri almadan sonra yapılan değişikliklerin üzerine yaz"
+
+#: src/git_stage_batch/cli/argument_parser.py:337
+msgid "Path to the file to block (defaults to selected hunk's file)"
+msgstr "Engellenecek dosyanın yolu (varsayılan olarak seçili hunk'ın dosyası)"
+
+#: src/git_stage_batch/commands/redo.py:19
+#, python-brace-format
+msgid "✓ Redid: {operation}"
+msgstr "✓ Yinelendi: {operation}"
+
+#: src/git_stage_batch/commands/undo.py:19
+#, python-brace-format
+msgid "✓ Undid: {operation}"
+msgstr "✓ Geri alındı: {operation}"
+
+#: src/git_stage_batch/data/undo.py:318
+#, python-brace-format
+msgid "Undo checkpoint is missing {path}"
+msgstr "Geri alma denetim noktasında {path} eksik"
+
+#: src/git_stage_batch/data/undo.py:389
+msgid "batch refs"
+msgstr "yığın başvuruları"
+
+#: src/git_stage_batch/data/undo.py:539
+msgid "Nothing to undo."
+msgstr "Geri alınacak bir şey yok."
+
+#: src/git_stage_batch/data/undo.py:546 src/git_stage_batch/data/undo.py:614
+#, python-brace-format
+msgid "{preview}, and {count} more"
+msgstr "{preview} ve {count} tane daha"
+
+#: src/git_stage_batch/data/undo.py:548
+#, python-brace-format
+msgid "Cannot undo because current state has changed since the checkpoint: {items}.\nRun 'git-stage-batch undo --force' to overwrite those changes."
+msgstr "Geçerli durum denetim noktasından beri değiştiği için geri alınamıyor: {items}.\nBu değişikliklerin üzerine yazmak için 'git-stage-batch undo --force' çalıştırın."
+
+#: src/git_stage_batch/data/undo.py:616
+#, python-brace-format
+msgid "Cannot redo because current state has changed since the undo: {items}.\nRun 'git-stage-batch redo --force' to overwrite those changes."
+msgstr "Geçerli durum geri almadan beri değiştiği için yinelenemiyor: {items}.\nBu değişikliklerin üzerine yazmak için 'git-stage-batch redo --force' çalıştırın."
+
+#: src/git_stage_batch/tui/interactive.py:1083
+msgid "  u, undo      - Undo the most recent operation"
+msgstr "  u, undo      - En son işlemi geri al"
+
+#: src/git_stage_batch/tui/interactive.py:1084
+msgid "  U, redo      - Redo the most recently undone operation"
+msgstr "  U, redo      - En son geri alınan işlemi yinele"

--- a/po/uk.po
+++ b/po/uk.po
@@ -1842,3 +1842,81 @@ msgstr "[{y}]так / [{n}]аступний / [{r}]кинути: "
 #: src/git_stage_batch/utils/git.py:227
 msgid "Not inside a git repository."
 msgstr "Не всередині git-репозиторія."
+
+#: src/git_stage_batch/batch/semantic_selection.py:109 src/git_stage_batch/batch/semantic_selection.py:199 src/git_stage_batch/batch/semantic_selection.py:213 src/git_stage_batch/batch/semantic_selection.py:216 src/git_stage_batch/batch/semantic_selection.py:222
+msgid "Selected lines do not form an unambiguous replacement."
+msgstr "Вибрані рядки не утворюють однозначної заміни."
+
+#: src/git_stage_batch/batch/semantic_selection.py:232
+msgid "Select the whole replacement row or broaden the selection."
+msgstr "Виберіть увесь рядок заміни або розширте вибір."
+
+#: src/git_stage_batch/batch/semantic_selection.py:372
+msgid "Selected semantic change cannot be merged into the current index state."
+msgstr "Вибрану семантичну зміну не можна об’єднати з поточним станом індексу."
+
+#: src/git_stage_batch/cli/argument_parser.py:134
+msgid "Undo the most recent undoable session operation"
+msgstr "Скасувати останню операцію сеансу, яку можна скасувати"
+
+#: src/git_stage_batch/cli/argument_parser.py:139
+msgid "Overwrite changes made after the undo checkpoint"
+msgstr "Перезаписати зміни, зроблені після контрольної точки скасування"
+
+#: src/git_stage_batch/cli/argument_parser.py:147
+msgid "Redo the most recently undone session operation"
+msgstr "Повторити останню скасовану операцію сеансу"
+
+#: src/git_stage_batch/cli/argument_parser.py:152
+msgid "Overwrite changes made after the undo"
+msgstr "Перезаписати зміни, зроблені після скасування"
+
+#: src/git_stage_batch/cli/argument_parser.py:337
+msgid "Path to the file to block (defaults to selected hunk's file)"
+msgstr "Шлях до файлу для блокування (типово файл вибраного фрагмента)"
+
+#: src/git_stage_batch/commands/redo.py:19
+#, python-brace-format
+msgid "✓ Redid: {operation}"
+msgstr "✓ Повторено: {operation}"
+
+#: src/git_stage_batch/commands/undo.py:19
+#, python-brace-format
+msgid "✓ Undid: {operation}"
+msgstr "✓ Скасовано: {operation}"
+
+#: src/git_stage_batch/data/undo.py:318
+#, python-brace-format
+msgid "Undo checkpoint is missing {path}"
+msgstr "У контрольній точці скасування бракує {path}"
+
+#: src/git_stage_batch/data/undo.py:389
+msgid "batch refs"
+msgstr "посилання пакетів"
+
+#: src/git_stage_batch/data/undo.py:539
+msgid "Nothing to undo."
+msgstr "Немає чого скасовувати."
+
+#: src/git_stage_batch/data/undo.py:546 src/git_stage_batch/data/undo.py:614
+#, python-brace-format
+msgid "{preview}, and {count} more"
+msgstr "{preview} і ще {count}"
+
+#: src/git_stage_batch/data/undo.py:548
+#, python-brace-format
+msgid "Cannot undo because current state has changed since the checkpoint: {items}.\nRun 'git-stage-batch undo --force' to overwrite those changes."
+msgstr "Неможливо скасувати, бо поточний стан змінився після контрольної точки: {items}.\nЗапустіть 'git-stage-batch undo --force', щоб перезаписати ці зміни."
+
+#: src/git_stage_batch/data/undo.py:616
+#, python-brace-format
+msgid "Cannot redo because current state has changed since the undo: {items}.\nRun 'git-stage-batch redo --force' to overwrite those changes."
+msgstr "Неможливо повторити, бо поточний стан змінився після скасування: {items}.\nЗапустіть 'git-stage-batch redo --force', щоб перезаписати ці зміни."
+
+#: src/git_stage_batch/tui/interactive.py:1083
+msgid "  u, undo      - Undo the most recent operation"
+msgstr "  u, undo      - Скасувати останню операцію"
+
+#: src/git_stage_batch/tui/interactive.py:1084
+msgid "  U, redo      - Redo the most recently undone operation"
+msgstr "  U, redo      - Повторити останню скасовану операцію"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1816,3 +1816,81 @@ msgstr "[{y}]是 / [{n}]下一个 / [{r}]重置："
 #: src/git_stage_batch/utils/git.py:227
 msgid "Not inside a git repository."
 msgstr "不在 Git 仓库中。"
+
+#: src/git_stage_batch/batch/semantic_selection.py:109 src/git_stage_batch/batch/semantic_selection.py:199 src/git_stage_batch/batch/semantic_selection.py:213 src/git_stage_batch/batch/semantic_selection.py:216 src/git_stage_batch/batch/semantic_selection.py:222
+msgid "Selected lines do not form an unambiguous replacement."
+msgstr "所选行没有形成明确的替换。"
+
+#: src/git_stage_batch/batch/semantic_selection.py:232
+msgid "Select the whole replacement row or broaden the selection."
+msgstr "请选择整个替换行，或扩大选择范围。"
+
+#: src/git_stage_batch/batch/semantic_selection.py:372
+msgid "Selected semantic change cannot be merged into the current index state."
+msgstr "无法将所选语义更改合并到当前索引状态。"
+
+#: src/git_stage_batch/cli/argument_parser.py:134
+msgid "Undo the most recent undoable session operation"
+msgstr "撤销最近一次可撤销的会话操作"
+
+#: src/git_stage_batch/cli/argument_parser.py:139
+msgid "Overwrite changes made after the undo checkpoint"
+msgstr "覆盖撤销检查点之后所做的更改"
+
+#: src/git_stage_batch/cli/argument_parser.py:147
+msgid "Redo the most recently undone session operation"
+msgstr "重做最近撤销的会话操作"
+
+#: src/git_stage_batch/cli/argument_parser.py:152
+msgid "Overwrite changes made after the undo"
+msgstr "覆盖撤销之后所做的更改"
+
+#: src/git_stage_batch/cli/argument_parser.py:337
+msgid "Path to the file to block (defaults to selected hunk's file)"
+msgstr "要阻止的文件路径（默认使用所选 hunk 的文件）"
+
+#: src/git_stage_batch/commands/redo.py:19
+#, python-brace-format
+msgid "✓ Redid: {operation}"
+msgstr "✓ 已重做：{operation}"
+
+#: src/git_stage_batch/commands/undo.py:19
+#, python-brace-format
+msgid "✓ Undid: {operation}"
+msgstr "✓ 已撤销：{operation}"
+
+#: src/git_stage_batch/data/undo.py:318
+#, python-brace-format
+msgid "Undo checkpoint is missing {path}"
+msgstr "撤销检查点缺少 {path}"
+
+#: src/git_stage_batch/data/undo.py:389
+msgid "batch refs"
+msgstr "批次引用"
+
+#: src/git_stage_batch/data/undo.py:539
+msgid "Nothing to undo."
+msgstr "没有可撤销的内容。"
+
+#: src/git_stage_batch/data/undo.py:546 src/git_stage_batch/data/undo.py:614
+#, python-brace-format
+msgid "{preview}, and {count} more"
+msgstr "{preview}，以及另外 {count} 项"
+
+#: src/git_stage_batch/data/undo.py:548
+#, python-brace-format
+msgid "Cannot undo because current state has changed since the checkpoint: {items}.\nRun 'git-stage-batch undo --force' to overwrite those changes."
+msgstr "无法撤销，因为当前状态自检查点以来已更改：{items}。\n运行 'git-stage-batch undo --force' 可覆盖这些更改。"
+
+#: src/git_stage_batch/data/undo.py:616
+#, python-brace-format
+msgid "Cannot redo because current state has changed since the undo: {items}.\nRun 'git-stage-batch redo --force' to overwrite those changes."
+msgstr "无法重做，因为当前状态自撤销以来已更改：{items}。\n运行 'git-stage-batch redo --force' 可覆盖这些更改。"
+
+#: src/git_stage_batch/tui/interactive.py:1083
+msgid "  u, undo      - Undo the most recent operation"
+msgstr "  u, undo      - 撤销最近的操作"
+
+#: src/git_stage_batch/tui/interactive.py:1084
+msgid "  U, redo      - Redo the most recently undone operation"
+msgstr "  U, redo      - 重做最近撤销的操作"


### PR DESCRIPTION
The program has gettext infrastructure and 14 locale translation files   
covering the original command message set, but those translations do not
yet include strings for semantic selection, undo/redo, and file blocking 
features.                                                                
                                                                         
Without translated strings for those features, non-English users see     
untranslated English text when using the newer parts of the interface.   
That creates an inconsistent experience across languages for 14 locales: 
Spanish, French, German, Brazilian Portuguese, Japanese, Simplified      
Chinese, Russian, Korean, Turkish, Polish, Dutch, Czech, Ukrainian, and  
Arabic.                                                                  
                                                                         
This series of commits refreshes each locale's .po file with translated  
entries for the new message strings, preserving existing translations and
gettext placeholders. Each locale is updated in its own commit.