### PR TITLE
Fix file-scoped live line workflows

### DIFF
--- a/src/git_stage_batch/cli/argument_parser.py
+++ b/src/git_stage_batch/cli/argument_parser.py
@@ -241,13 +241,41 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
         metavar="BATCH",
         help=_("Include changes to batch"),
     )
-    parser_include.set_defaults(func=lambda args: (
-        commands.command_include_from_batch(args.from_batch, args.line_ids, args.file) if args.from_batch
-        else commands.command_include_to_batch(args.to_batch, args.line_ids, args.file) if args.to_batch
-        else commands.command_include_line(args.line_ids) if args.line_ids
-        else commands.command_include_file(args.file) if args.file is not None
-        else commands.command_include()
-    ))
+    parser_include.add_argument(
+        "--as",
+        dest="as_text",
+        metavar="TEXT",
+        help=_("Replace selected lines with TEXT before staging them"),
+    )
+
+    def dispatch_include(args: argparse.Namespace) -> None:
+        if args.as_text is not None:
+            if args.line_ids and args.from_batch and not args.to_batch:
+                commands.command_include_from_batch(
+                    args.from_batch,
+                    args.line_ids,
+                    args.file,
+                    replacement_text=args.as_text,
+                )
+                return
+            if args.line_ids and not args.from_batch and not args.to_batch:
+                commands.command_include_line_as(args.line_ids, args.as_text, file=args.file)
+                return
+            raise CommandError(
+                _("`include --as` requires `--line` and does not support `--to`.")
+            )
+        if args.from_batch:
+            commands.command_include_from_batch(args.from_batch, args.line_ids, args.file)
+        elif args.to_batch:
+            commands.command_include_to_batch(args.to_batch, args.line_ids, args.file)
+        elif args.line_ids:
+            commands.command_include_line(args.line_ids, file=args.file)
+        elif args.file is not None:
+            commands.command_include_file(args.file)
+        else:
+            commands.command_include()
+
+    parser_include.set_defaults(func=dispatch_include)
 
     # skip - Skip the selected hunk without staging
     parser_skip = subparsers.add_parser(
@@ -309,6 +337,7 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
         metavar="BATCH",
         help=_("Discard changes to batch"),
     )
+<<<<<<< HEAD
     parser_discard.set_defaults(func=lambda args: (
         commands.command_discard_from_batch(args.from_batch, args.line_ids, args.file) if args.from_batch
         else commands.command_discard_to_batch(args.to_batch, args.line_ids, args.file) if args.to_batch
@@ -316,6 +345,39 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
         else commands.command_discard_file(args.file) if args.file is not None
         else commands.command_discard()
     ))
+=======
+    parser_discard.add_argument(
+        "--as",
+        dest="as_text",
+        metavar="TEXT",
+        help=_("Replace selected lines with TEXT before saving them to batch"),
+    )
+
+    def dispatch_discard(args: argparse.Namespace) -> None:
+        if args.as_text is not None:
+            if args.to_batch and args.line_ids and args.file is None and not args.from_batch:
+                commands.command_discard_line_as_to_batch(
+                    args.to_batch,
+                    args.line_ids,
+                    args.as_text,
+                )
+                return
+            raise CommandError(
+                _("`discard --as` requires `--to`, `--line`, and selected-hunk scope.")
+            )
+        if args.from_batch:
+            commands.command_discard_from_batch(args.from_batch, args.line_ids, args.file)
+        elif args.to_batch:
+            commands.command_discard_to_batch(args.to_batch, args.line_ids, args.file)
+        elif args.line_ids:
+            commands.command_discard_line(args.line_ids, file=args.file)
+        elif args.file is not None:
+            commands.command_discard_file(args.file)
+        else:
+            commands.command_discard()
+
+    parser_discard.set_defaults(func=dispatch_discard)
+>>>>>>> 23ab95ce (commands: Fix file-scoped live line workflows)
 
     # abort - Restore repository to pre-session state
     parser_abort = subparsers.add_parser(

--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -247,27 +247,46 @@ def command_discard_file(file: str) -> None:
         advance_to_and_show_next_change()
 
 
-def command_discard_line(line_id_specification: str) -> None:
+def command_discard_line(line_id_specification: str, file: str | None = None) -> None:
     """Discard only the specified lines from the working tree.
 
     Args:
         line_id_specification: Line ID specification (e.g., "1,3,5-7")
+        file: Optional file path for file-scoped operation.
+              If empty string, uses selected hunk's file.
+              If None, uses selected hunk (cached state).
     """
     require_git_repository()
     require_session_started()
     ensure_state_directory_exists()
-    require_selected_hunk()
+    operation_parts = ["discard", "--line", line_id_specification]
+    if file is not None:
+        operation_parts.extend(["--file", file])
+    with undo_checkpoint(" ".join(operation_parts)):
+        if file is None:
+            require_selected_hunk()
+            line_changes = load_line_changes_from_state()
+        else:
+            if file == "":
+                target_file = get_selected_change_file_path()
+                if target_file is None:
+                    exit_with_error(_("No selected hunk. Run 'show' first or specify file path."))
+            else:
+                target_file = file
 
-    requested_ids = parse_line_selection(line_id_specification)
-    line_changes = load_line_changes_from_state()
+            line_changes = cache_file_as_single_hunk(target_file)
+            if line_changes is None:
+                exit_with_error(_("No changes in file '{file}'.").format(file=target_file))
 
-    # Get selected working tree content
-    working_file_path = get_git_repository_root_path() / line_changes.path
-    if working_file_path.exists():
-        working_bytes = working_file_path.read_bytes()
-    else:
-        exit_with_error(_("File not found in working tree: {file}").format(file=line_changes.path))
-    with undo_checkpoint(f"discard --line {line_id_specification}"):
+        requested_ids = parse_line_selection(line_id_specification)
+
+        # Get selected working tree content
+        working_file_path = get_git_repository_root_path() / line_changes.path
+        if working_file_path.exists():
+            working_bytes = working_file_path.read_bytes()
+        else:
+            exit_with_error(_("File not found in working tree: {file}").format(file=line_changes.path))
+
         # Build new working tree content with selected lines discarded
         target_working_content = build_target_working_tree_content_bytes_with_discarded_lines(
             line_changes, set(requested_ids), working_bytes)

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -236,27 +236,53 @@ def command_include_file(file: str) -> None:
     advance_to_and_show_next_change()
 
 
-def command_include_line(line_id_specification: str) -> None:
+def command_include_line(line_id_specification: str, file: str | None = None) -> None:
     """Stage only the specified lines to the index.
 
     Args:
         line_id_specification: Line ID specification (e.g., "1,3,5-7")
+        file: Optional file path for file-scoped operation.
+              If empty string, uses selected hunk's file.
+              If None, uses selected hunk (cached state).
     """
     require_git_repository()
     require_session_started()
     ensure_state_directory_exists()
-    require_selected_hunk()
 
-    requested_ids = parse_line_selection(line_id_specification)
-    already_included_ids = set(read_line_ids_file(get_processed_include_ids_file_path()))
-    combined_include_ids = already_included_ids | set(requested_ids)
+    operation_parts = ["include", "--line", line_id_specification]
+    if file is not None:
+        operation_parts.extend(["--file", file])
 
-    line_changes = load_line_changes_from_state()
+    with undo_checkpoint(" ".join(operation_parts)):
+        preserve_selected_state = False
+        saved_selected_state = None
 
-    # Get the selected hunk's base/source snapshots captured when the hunk was loaded.
-    hunk_base_content = read_file_bytes(get_index_snapshot_file_path())
-    hunk_source_content = read_file_bytes(get_working_tree_snapshot_file_path())
-    with undo_checkpoint(f"include --line {line_id_specification}"):
+        if file is None:
+            require_selected_hunk()
+            line_changes = load_line_changes_from_state()
+        else:
+            if file == "":
+                target_file = get_selected_change_file_path()
+                if target_file is None:
+                    exit_with_error(_("No selected hunk. Run 'show' first or specify file path."))
+            else:
+                target_file = file
+                preserve_selected_state = True
+                saved_selected_state = _snapshot_selected_change_state()
+
+            line_changes = cache_file_as_single_hunk(target_file)
+            if line_changes is None:
+                exit_with_error(_("No changes in file '{file}'.").format(file=target_file))
+            line_changes = annotate_with_batch_source(target_file, line_changes)
+
+        requested_ids = parse_line_selection(line_id_specification)
+        already_included_ids = set(read_line_ids_file(get_processed_include_ids_file_path()))
+        combined_include_ids = already_included_ids | set(requested_ids)
+
+        # Get the selected hunk's base/source snapshots captured when the hunk was loaded.
+        hunk_base_content = read_file_bytes(get_index_snapshot_file_path())
+        hunk_source_content = read_file_bytes(get_working_tree_snapshot_file_path())
+
         index_result = run_git_command(
             ["show", f":{line_changes.path}"],
             check=False,
@@ -298,11 +324,13 @@ def command_include_line(line_id_specification: str) -> None:
 
         update_index_with_blob_content(line_changes.path, target_index_content)
 
-        # Update processed include IDs
-        write_line_ids_file(get_processed_include_ids_file_path(), combined_include_ids)
-
-        # After modifying index, recalculate hunk for the SAME file
-        recalculate_selected_hunk_for_file(line_changes.path)
+        if preserve_selected_state:
+            _restore_selected_change_state(saved_selected_state)
+        else:
+            # Update processed include IDs only when the selected display remains
+            # current for incremental line inclusion.
+            write_line_ids_file(get_processed_include_ids_file_path(), combined_include_ids)
+            recalculate_selected_hunk_for_file(line_changes.path)
 
     print(_("✓ Included line(s): {lines}").format(lines=line_id_specification), file=sys.stderr)
 

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -577,9 +577,9 @@ def cache_file_as_single_hunk(file_path: str) -> Optional[LineLevelChange]:
                                 json.dumps(convert_line_changes_to_serializable_dict(combined_line_changes),
                                           ensure_ascii=False, indent=0))
 
-        # No snapshots for file-scoped hunks (they use live state)
-        get_index_snapshot_file_path().unlink(missing_ok=True)
-        get_working_tree_snapshot_file_path().unlink(missing_ok=True)
+        # Cache live snapshots so later line-level operations can reuse the
+        # file-scoped selection the same way they reuse ordinary selected hunks.
+        write_snapshots_for_selected_file_path(file_path)
 
         return combined_line_changes
 

--- a/tests/cli/test_argument_parser.py
+++ b/tests/cli/test_argument_parser.py
@@ -1,7 +1,10 @@
 """Tests for CLI argument parsing."""
 
+from unittest.mock import Mock
+
 import pytest
 
+from git_stage_batch.cli import argument_parser
 from git_stage_batch.cli.argument_parser import parse_command_line
 
 
@@ -135,6 +138,57 @@ def test_parse_command_line_include_with_line():
     assert callable(args.func)
 
 
+def test_parse_command_line_include_with_as():
+    """Test parsing include command with --as replacement text."""
+    args = parse_command_line(["include", "--line", "2-3", "--as", "replacement"], quiet=True)
+    assert args is not None
+    assert args.line_ids == "2-3"
+    assert args.as_text == "replacement"
+    assert hasattr(args, "func")
+    assert callable(args.func)
+
+
+def test_parse_command_line_include_with_file_and_as():
+    """Test parsing include command with --file, --line, and --as."""
+    args = parse_command_line(
+        ["include", "--file", "path.txt", "--line", "2-3", "--as", "replacement"],
+        quiet=True,
+    )
+    assert args is not None
+    assert args.file == "path.txt"
+    assert args.line_ids == "2-3"
+    assert args.as_text == "replacement"
+    assert hasattr(args, "func")
+    assert callable(args.func)
+
+
+def test_parse_command_line_include_with_file_and_line_dispatches_file_scope(monkeypatch):
+    """Include --file --line should dispatch to file-scoped line staging."""
+    mock_command = Mock()
+    monkeypatch.setattr(argument_parser.commands, "command_include_line", mock_command)
+
+    args = parse_command_line(
+        ["include", "--file", "path.txt", "--line", "2-3"],
+        quiet=True,
+    )
+
+    assert args is not None
+    args.func(args)
+    mock_command.assert_called_once_with("2-3", file="path.txt")
+
+
+def test_parse_command_line_include_from_with_as():
+    """Test parsing include --from with replacement text."""
+    args = parse_command_line(
+        ["include", "--from", "batch", "--line", "2-3", "--as", "replacement"],
+        quiet=True,
+    )
+    assert args is not None
+    assert args.from_batch == "batch"
+    assert args.line_ids == "2-3"
+    assert args.as_text == "replacement"
+    assert hasattr(args, "func")
+    assert callable(args.func)
 def test_parse_command_line_skip():
     """Test parsing skip command."""
     args = parse_command_line(["skip"], quiet=True)
@@ -180,6 +234,33 @@ def test_parse_command_line_discard():
     assert callable(args.func)
 
 
+def test_parse_command_line_discard_to_with_as():
+    """Test parsing discard --to with replacement text."""
+    args = parse_command_line(
+        ["discard", "--to", "batch", "--line", "2-3", "--as", "replacement"],
+        quiet=True,
+    )
+    assert args is not None
+    assert args.to_batch == "batch"
+    assert args.line_ids == "2-3"
+    assert args.as_text == "replacement"
+    assert hasattr(args, "func")
+    assert callable(args.func)
+
+
+def test_parse_command_line_discard_with_file_and_line_dispatches_file_scope(monkeypatch):
+    """Discard --file --line should dispatch to file-scoped line discard."""
+    mock_command = Mock()
+    monkeypatch.setattr(argument_parser.commands, "command_discard_line", mock_command)
+
+    args = parse_command_line(
+        ["discard", "--file", "path.txt", "--line", "2-3"],
+        quiet=True,
+    )
+
+    assert args is not None
+    args.func(args)
+    mock_command.assert_called_once_with("2-3", file="path.txt")
 def test_parse_command_line_discard_alias():
     """Test parsing discard command alias 'd'."""
     args = parse_command_line(["d"], quiet=True)

--- a/tests/commands/test_file_scoped_operations.py
+++ b/tests/commands/test_file_scoped_operations.py
@@ -23,8 +23,13 @@ import pytest
 
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.commands.show import command_show
-from git_stage_batch.commands.include import command_include_to_batch, command_include_file
-from git_stage_batch.commands.discard import command_discard_to_batch, command_discard_file
+from git_stage_batch.commands.include import (
+    command_include_to_batch,
+    command_include_file,
+    command_include_line,
+    command_include_line_as,
+)
+from git_stage_batch.commands.discard import command_discard_to_batch, command_discard_file, command_discard_line
 from git_stage_batch.commands.include_from import command_include_from_batch
 from git_stage_batch.commands.discard_from import command_discard_from_batch
 from git_stage_batch.commands.apply_from import command_apply_from_batch
@@ -117,6 +122,25 @@ class TestShowFileFlag:
 
         captured = capsys.readouterr()
         assert "No changes" in captured.err
+
+    def test_show_file_selection_can_feed_include_line(self, multi_file_repo):
+        """Show --file should cache a usable selection for later include --line."""
+        command_start()
+        command_show(file="beta.txt")
+
+        command_include_line("3")
+
+        result = run_git_command(["show", ":beta.txt"])
+        assert result.stdout == "beta1\nbeta2\nbeta3\nbeta4-new\n"
+
+    def test_show_file_selection_can_feed_discard_line(self, multi_file_repo):
+        """Show --file should cache a usable selection for later discard --line."""
+        command_start()
+        command_show(file="beta.txt")
+
+        command_discard_line("3")
+
+        assert (multi_file_repo / "beta.txt").read_text() == "beta1\nbeta2-modified\nbeta3\n"
 
 
 class TestIncludeToBatchWithFile:


### PR DESCRIPTION
The program provides file-scoped live commands such as
show --file, include --file --line, and discard --file
--line. Those commands are meant to let users inspect a
whole file and then act on the resulting line IDs.

Users cannot rely on that workflow today. The CLI routes
plain include --file --line and discard --file --line to
the selected-hunk handlers, and show --file caches a
selection that later line commands immediately reject as
stale.

This commit addresses that by routing live line commands
through file-aware handlers and by caching snapshots for
file-scoped displays. That lets show --file feed later
line operations and makes the documented file-scoped
line commands reachable from the CLI.
