### PR TITLE
Add replacement support for line workflows

### DIFF
--- a/BATCHES.md
+++ b/BATCHES.md
@@ -260,6 +260,12 @@ This decomposition is intentional:
 * it avoids introducing a special-case operation type
 * it keeps all behavior expressible in terms of constraints
 
+At the UI level, the program now exposes explicit replacement entry points such
+as `include --line --as`, `include --file --line --as`, and
+`include --from BATCH --line --as`. Those commands do not introduce a new
+storage primitive. They synthesize new claimed content while continuing to
+express the result in terms of presence and absence constraints.
+
 ### Ownership Model
 
 ```python
@@ -695,11 +701,16 @@ Both `merge_batch()` and `discard_batch()` correctly handle deletion-only owners
 * **Merge**: Suppresses forbidden sequences at their anchored positions
 * **Discard**: Re-inserts deleted sequences at their original boundaries
 
-However, the **current UI behavior** excludes deletions from line-level selection because:
+However, the **current UI behavior** is more specific than "deletions are never
+selectable." Different commands interpret batch display lines differently:
 
-* Line-level selection (`--line 5`) focuses on content to include, not suppressions to apply
-* For replacement changes, the deletion is contextual metadata for the claimed line
-* For pure removals, users select the entire hunk/file scope, not individual deletion display lines
+* Plain line-level inclusion from a batch still treats claimed lines as the
+  primary selectable content.
+* Replacement-oriented inclusion (`include --from BATCH --line ... --as`) can
+  consume a visible replacement span that includes both deletion and claimed
+  display lines.
+* Pure removal selections are still handled conservatively and are not exposed
+  as an arbitrary deletion-editing interface.
 
 This is a **product choice**, not an architectural limitation. The underlying merge/discard implementation fully supports deletion-only selections. The UI could be extended to distinguish "select this deletion claim" from "select this claimed content line" if desired.
 
@@ -733,6 +744,13 @@ They represent:
 * not how changes appear in the working tree
 
 This is distinct from attribution units, which operate in working tree space.
+
+One batch-facing replacement path now uses that model in a slightly different
+way. `include --from BATCH --line IDS --as TEXT` still starts from batch
+display, but it requires one contiguous visible selection range and rewrites a
+temporary batch-source view for that span before merging to the index. It does
+not add a new persisted batch primitive; it realizes edited content through the
+existing ownership and merge machinery.
 
 ### The Problem: Coupled Changes
 

--- a/src/git_stage_batch/batch/attribution.py
+++ b/src/git_stage_batch/batch/attribution.py
@@ -17,6 +17,7 @@ from ..batch.match import match_lines
 from ..batch.query import list_batch_names, read_batch_metadata
 from ..core.line_selection import parse_line_selection
 from ..core.models import LineLevelChange
+from ..data.consumed_selections import read_consumed_file_metadata
 from ..utils.git import (
     read_git_blob_as_bytes,
     read_git_object_as_lines,
@@ -308,6 +309,14 @@ def build_file_attribution(file_path: str) -> FileAttribution:
         metadata = read_batch_metadata(batch_name)
         if file_path in metadata.get("files", {}):
             all_batch_metadata[batch_name] = metadata
+
+    consumed_file_metadata = read_consumed_file_metadata(file_path)
+    if consumed_file_metadata is not None:
+        all_batch_metadata["__consumed__"] = {
+            "files": {
+                file_path: consumed_file_metadata,
+            }
+        }
 
     comparison = compare_baseline_to_working_tree(file_path)
     all_units_map: dict[str, AttributionUnit] = {}

--- a/src/git_stage_batch/batch/display.py
+++ b/src/git_stage_batch/batch/display.py
@@ -298,29 +298,33 @@ def annotate_with_batch_source(
     Use as annotator parameter to build_line_changes_from_patch_text when
     you need batch source mapping for saving changes to a batch.
     """
-    batch_source_commit = get_batch_source_for_file(path_value)
-    if not batch_source_commit:
-        # No batch source yet - working tree will become batch source
-        return _fill_source_from_working_tree(line_changes)
-
     repo_root = get_git_repository_root_path()
     file_full_path = repo_root / path_value
     if not file_full_path.exists():
-        # File doesn't exist - can't compute mapping
         return _fill_source_from_working_tree(line_changes)
 
     working_content = read_text_file_contents(file_full_path)
-    working_lines = working_content.splitlines(keepends=True)
+    return annotate_with_batch_source_content(path_value, line_changes, working_content)
+
+
+def annotate_with_batch_source_content(
+    path_value: str,
+    line_changes: LineLevelChange,
+    working_content: str,
+) -> LineLevelChange:
+    """Annotate LineLevelChange with batch source lines for arbitrary content."""
+    batch_source_commit = get_batch_source_for_file(path_value)
+    if not batch_source_commit:
+        return _fill_source_from_working_tree(line_changes)
 
     batch_source_result = run_git_command(
         ["show", f"{batch_source_commit}:{path_value}"],
         check=False,
     )
     if batch_source_result.returncode != 0:
-        # Use working tree as source when batch source unavailable
         return _fill_source_from_working_tree(line_changes)
 
     source_lines = batch_source_result.stdout.splitlines(keepends=True)
+    working_lines = working_content.splitlines(keepends=True)
     mapping = match_lines(source_lines, working_lines)
-
     return _apply_batch_source_mapping(line_changes, mapping)

--- a/src/git_stage_batch/batch/replacement.py
+++ b/src/git_stage_batch/batch/replacement.py
@@ -1,0 +1,119 @@
+"""Helpers for expressing replacement text in batch source space."""
+
+from __future__ import annotations
+
+from ..core.line_selection import format_line_ids, parse_line_selection
+from .ownership import BatchOwnership, DeletionClaim
+
+
+def _format_claimed_lines(line_numbers: list[int]) -> list[str]:
+    """Format claimed line numbers as normalized range strings."""
+    if not line_numbers:
+        return []
+    return [format_line_ids(line_numbers)]
+
+
+def build_replacement_batch_view(
+    batch_source_content: bytes,
+    ownership: BatchOwnership,
+    replacement_text: str,
+) -> tuple[bytes, BatchOwnership]:
+    """Build a temporary batch-source snapshot and ownership for replacement text."""
+    source_lines = batch_source_content.splitlines(keepends=True)
+    claimed_source_lines = sorted({
+        line_num
+        for line_range in ownership.claimed_lines
+        for line_num in parse_line_selection(line_range)
+    }) if ownership.claimed_lines else []
+    replacement_bytes = replacement_text.encode("utf-8", errors="surrogateescape")
+    replacement_lines = [line + b"\n" for line in replacement_bytes.splitlines()]
+
+    if claimed_source_lines:
+        expected_claimed = list(range(claimed_source_lines[0], claimed_source_lines[-1] + 1))
+        if claimed_source_lines != expected_claimed:
+            raise ValueError("Replacement selection must resolve to one contiguous batch-source line range.")
+
+        start_line = claimed_source_lines[0]
+        end_line = claimed_source_lines[-1]
+        removed_count = end_line - start_line + 1
+        added_count = len(replacement_lines)
+
+        new_source_lines = (
+            source_lines[:start_line - 1]
+            + replacement_lines
+            + source_lines[end_line:]
+        )
+
+        new_claimed_lines = list(range(start_line, start_line + added_count))
+        new_deletions = []
+        for deletion in ownership.deletions:
+            anchor = deletion.anchor_line
+            if anchor is None:
+                new_anchor = None
+            elif anchor < start_line:
+                new_anchor = anchor
+            elif anchor > end_line:
+                new_anchor = anchor - removed_count + added_count
+            elif added_count > 0:
+                new_anchor = start_line + added_count - 1
+            elif start_line > 1:
+                new_anchor = start_line - 1
+            else:
+                new_anchor = None
+
+            new_deletions.append(DeletionClaim(
+                anchor_line=new_anchor,
+                content_lines=deletion.content_lines,
+            ))
+
+        return (
+            b"".join(new_source_lines),
+            BatchOwnership(
+                claimed_lines=_format_claimed_lines(new_claimed_lines),
+                deletions=new_deletions,
+            ),
+        )
+
+    distinct_anchors = {deletion.anchor_line for deletion in ownership.deletions}
+    if len(distinct_anchors) > 1:
+        raise ValueError("Replacement selection must resolve to one contiguous batch-source region.")
+
+    anchor_line = next(iter(distinct_anchors), None)
+    insert_at = 0 if anchor_line is None else anchor_line
+    added_count = len(replacement_lines)
+
+    new_source_lines = (
+        source_lines[:insert_at]
+        + replacement_lines
+        + source_lines[insert_at:]
+    )
+    if added_count == 0:
+        new_claimed_lines: list[int] = []
+    elif anchor_line is None:
+        new_claimed_lines = list(range(1, added_count + 1))
+    else:
+        new_claimed_lines = list(range(anchor_line + 1, anchor_line + added_count + 1))
+
+    new_deletions = []
+    for deletion in ownership.deletions:
+        if deletion.anchor_line is None:
+            new_anchor = None
+        elif anchor_line is None:
+            new_anchor = deletion.anchor_line + added_count
+        elif deletion.anchor_line <= anchor_line:
+            new_anchor = deletion.anchor_line
+        else:
+            new_anchor = deletion.anchor_line + added_count
+
+        new_deletions.append(DeletionClaim(
+            anchor_line=new_anchor,
+            content_lines=deletion.content_lines,
+        ))
+
+    return (
+        b"".join(new_source_lines),
+        BatchOwnership(
+            claimed_lines=_format_claimed_lines(new_claimed_lines),
+            deletions=new_deletions,
+        ),
+    )

--- a/src/git_stage_batch/cli/argument_parser.py
+++ b/src/git_stage_batch/cli/argument_parser.py
@@ -8,6 +8,7 @@ import sys
 
 from .. import __version__
 from .. import commands
+from ..exceptions import CommandError
 from ..i18n import _
 
 
@@ -337,15 +338,6 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
         metavar="BATCH",
         help=_("Discard changes to batch"),
     )
-<<<<<<< HEAD
-    parser_discard.set_defaults(func=lambda args: (
-        commands.command_discard_from_batch(args.from_batch, args.line_ids, args.file) if args.from_batch
-        else commands.command_discard_to_batch(args.to_batch, args.line_ids, args.file) if args.to_batch
-        else commands.command_discard_line(args.line_ids) if args.line_ids
-        else commands.command_discard_file(args.file) if args.file is not None
-        else commands.command_discard()
-    ))
-=======
     parser_discard.add_argument(
         "--as",
         dest="as_text",
@@ -355,15 +347,16 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
 
     def dispatch_discard(args: argparse.Namespace) -> None:
         if args.as_text is not None:
-            if args.to_batch and args.line_ids and args.file is None and not args.from_batch:
+            if args.to_batch and args.line_ids and not args.from_batch:
                 commands.command_discard_line_as_to_batch(
                     args.to_batch,
                     args.line_ids,
                     args.as_text,
+                    file=args.file,
                 )
                 return
             raise CommandError(
-                _("`discard --as` requires `--to`, `--line`, and selected-hunk scope.")
+                _("`discard --as` requires `--to` and `--line`.")
             )
         if args.from_batch:
             commands.command_discard_from_batch(args.from_batch, args.line_ids, args.file)
@@ -377,7 +370,6 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
             commands.command_discard()
 
     parser_discard.set_defaults(func=dispatch_discard)
->>>>>>> 23ab95ce (commands: Fix file-scoped live line workflows)
 
     # abort - Restore repository to pre-session state
     parser_abort = subparsers.add_parser(

--- a/src/git_stage_batch/commands/__init__.py
+++ b/src/git_stage_batch/commands/__init__.py
@@ -10,7 +10,7 @@ from .block_file import command_block_file
 from .discard import command_discard, command_discard_file, command_discard_line, command_discard_to_batch
 from .discard_from import command_discard_from_batch
 from .drop import command_drop_batch
-from .include import command_include, command_include_file, command_include_line, command_include_to_batch
+from .include import command_include, command_include_file, command_include_line, command_include_line_as, command_include_to_batch
 from .include_from import command_include_from_batch
 from .interactive import command_interactive
 from .list import command_list_batches
@@ -43,6 +43,7 @@ __all__ = [
     "command_include",
     "command_include_file",
     "command_include_line",
+    "command_include_line_as",
     "command_include_from_batch",
     "command_include_to_batch",
     "command_interactive",

--- a/src/git_stage_batch/commands/__init__.py
+++ b/src/git_stage_batch/commands/__init__.py
@@ -7,7 +7,7 @@ from .again import command_again
 from .annotate import command_annotate_batch
 from .apply_from import command_apply_from_batch
 from .block_file import command_block_file
-from .discard import command_discard, command_discard_file, command_discard_line, command_discard_to_batch
+from .discard import command_discard, command_discard_file, command_discard_line, command_discard_line_as_to_batch, command_discard_to_batch
 from .discard_from import command_discard_from_batch
 from .drop import command_drop_batch
 from .include import command_include, command_include_file, command_include_line, command_include_line_as, command_include_to_batch
@@ -37,6 +37,7 @@ __all__ = [
     "command_discard",
     "command_discard_file",
     "command_discard_line",
+    "command_discard_line_as_to_batch",
     "command_discard_to_batch",
     "command_discard_from_batch",
     "command_drop_batch",

--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -6,7 +6,7 @@ import subprocess
 import sys
 
 from ..batch import add_file_to_batch, create_batch
-from ..batch.display import annotate_with_batch_source
+from ..batch.display import annotate_with_batch_source, annotate_with_batch_source_content
 from ..batch.ownership import BatchOwnership
 from ..batch.query import read_batch_metadata
 from ..batch.source_refresh import prepare_batch_ownership_update_for_selection
@@ -21,6 +21,7 @@ from ..core.models import BinaryFileChange
 from ..data.hunk_tracking import (
     advance_to_and_show_next_change,
     advance_to_next_change,
+    build_file_hunk_from_content,
     cache_file_as_single_hunk,
     fetch_next_change,
     get_selected_change_file_path,
@@ -29,11 +30,13 @@ from ..data.hunk_tracking import (
     require_selected_hunk,
 )
 from ..data.line_state import load_line_changes_from_state
+from ..data.batch_sources import create_batch_source_commit, load_session_batch_sources, save_session_batch_sources
 from ..data.session import require_session_started, snapshot_file_if_untracked
 from ..data.undo import undo_checkpoint
 from ..exceptions import exit_with_error, NoMoreHunks
 from ..i18n import _, ngettext
 from ..staging.operations import build_target_working_tree_content_bytes_with_discarded_lines
+from ..staging.operations import build_target_working_tree_content_bytes_with_replaced_lines
 from ..utils.command import ExitEvent, OutputEvent, stream_command
 from ..utils.file_io import append_lines_to_file, read_file_bytes, read_text_file_contents
 from ..utils.git import get_git_repository_root_path, require_git_repository, run_git_command, stream_git_command
@@ -44,6 +47,11 @@ from ..utils.paths import (
     get_context_lines,
     get_selected_hunk_hash_file_path,
     get_selected_hunk_patch_file_path,
+)
+from .include import (
+    _expand_replacement_selection_ids,
+    _restore_selected_change_state,
+    _snapshot_selected_change_state,
 )
 
 
@@ -344,6 +352,222 @@ def command_discard_to_batch(batch_name: str, line_ids: str | None = None, file:
             else:
                 # Discard entire selected hunk
                 _command_discard_hunk_to_batch(batch_name, file_only=False, quiet=quiet)
+
+
+def command_discard_line_as_to_batch(
+    batch_name: str,
+    line_id_specification: str,
+    replacement_text: str,
+    file: str | None = None,
+    *,
+    quiet: bool = False,
+) -> None:
+    """Save replacement text to batch, then discard the original selection locally."""
+    require_git_repository()
+    require_session_started()
+    ensure_state_directory_exists()
+
+    operation_parts = [
+        "discard",
+        "--to", batch_name,
+        "--line", line_id_specification,
+        "--as", replacement_text,
+    ]
+    if file is not None:
+        operation_parts.extend(["--file", file])
+    with undo_checkpoint(" ".join(operation_parts)):
+        saved_selected_state = _snapshot_selected_change_state()
+        preserve_selected_state = file is not None
+
+        try:
+            if file is None:
+                require_selected_hunk()
+            else:
+                if file == "":
+                    target_file = get_selected_change_file_path()
+                    if target_file is None:
+                        exit_with_error(_("No selected hunk. Run 'show' first or specify file path."))
+                else:
+                    target_file = file
+
+                cached_lines = cache_file_as_single_hunk(target_file)
+                if cached_lines is None:
+                    exit_with_error(_("No changes in file '{file}'.").format(file=target_file))
+
+            _command_discard_lines_to_batch_as(
+                batch_name,
+                line_id_specification,
+                replacement_text,
+                quiet=quiet,
+            )
+
+            if preserve_selected_state:
+                _restore_selected_change_state(saved_selected_state)
+        except Exception:
+            _restore_selected_change_state(saved_selected_state)
+            raise
+
+
+def _command_discard_lines_to_batch_as(
+    batch_name: str,
+    line_id_specification: str,
+    replacement_text: str,
+    *,
+    quiet: bool = False,
+) -> None:
+    """Persist replacement text to batch and discard original selected lines."""
+    if not batch_exists(batch_name):
+        create_batch(batch_name, "Auto-created")
+
+    requested_ids = set(parse_line_selection(line_id_specification))
+    line_changes = load_line_changes_from_state()
+    effective_ids = _expand_replacement_selection_ids(line_changes, requested_ids)
+    selected_lines = [line for line in line_changes.lines if line.id in effective_ids]
+    if not selected_lines:
+        exit_with_error(_("No matching lines found for selection: {ids}").format(ids=line_id_specification))
+
+    working_file_path = get_git_repository_root_path() / line_changes.path
+    if not working_file_path.exists():
+        exit_with_error(_("File not found in working tree: {file}").format(file=line_changes.path))
+    working_bytes = working_file_path.read_bytes()
+
+    try:
+        rewritten_working_content = build_target_working_tree_content_bytes_with_replaced_lines(
+            line_changes,
+            effective_ids,
+            replacement_text,
+            working_bytes,
+        )
+    except ValueError as e:
+        exit_with_error(str(e))
+
+    try:
+        rewritten_cached_lines = build_file_hunk_from_content(line_changes.path, rewritten_working_content)
+        if rewritten_cached_lines is None:
+            exit_with_error(_("No changes in file '{file}'.").format(file=line_changes.path))
+        rewritten_line_changes = annotate_with_batch_source_content(
+            line_changes.path,
+            rewritten_cached_lines,
+            rewritten_working_content.decode("utf-8", errors="replace"),
+        )
+        rewritten_selected_lines = _select_rewritten_replacement_lines(
+            selected_lines,
+            rewritten_line_changes,
+        )
+
+        metadata = read_batch_metadata(batch_name)
+        existing_ownership = None
+        current_batch_source = None
+        if line_changes.path in metadata.get("files", {}):
+            file_metadata = metadata["files"][line_changes.path]
+            existing_ownership = BatchOwnership.from_metadata_dict(file_metadata)
+            current_batch_source = file_metadata.get("batch_source_commit")
+
+        try:
+            update = prepare_batch_ownership_update_for_selection(
+                batch_name=batch_name,
+                file_path=line_changes.path,
+                current_batch_source_commit=current_batch_source,
+                existing_ownership=existing_ownership,
+                selected_lines=rewritten_selected_lines,
+            )
+            ownership = update.ownership_after
+        except ValueError as e:
+            exit_with_error(
+                _("Cannot discard lines to batch: batch source is stale and remapping failed.\n"
+                  "File: {file}\n"
+                  "Batch: {batch}\n"
+                  "Error: {error}").format(file=line_changes.path, batch=batch_name, error=str(e))
+            )
+
+        ls_result = run_git_command(["ls-files", "-s", "--", line_changes.path], check=False)
+        file_mode = "100644"
+        if ls_result.returncode == 0 and ls_result.stdout.strip():
+            parts = ls_result.stdout.strip().split()
+            if parts:
+                file_mode = parts[0]
+
+        batch_source_commit = current_batch_source
+        if batch_source_commit is None:
+            batch_source_commit = create_batch_source_commit(
+                line_changes.path,
+                file_content_override=rewritten_working_content,
+            )
+            batch_sources = load_session_batch_sources()
+            batch_sources[line_changes.path] = batch_source_commit
+            save_session_batch_sources(batch_sources)
+
+        snapshot_file_if_untracked(line_changes.path)
+        add_file_to_batch(
+            batch_name,
+            line_changes.path,
+            ownership,
+            file_mode,
+            batch_source_commit=batch_source_commit,
+        )
+
+        rewritten_selected_ids = {
+            line.id for line in rewritten_selected_lines if line.id is not None
+        }
+        target_working_content = build_target_working_tree_content_bytes_with_discarded_lines(
+            rewritten_line_changes,
+            rewritten_selected_ids,
+            rewritten_working_content,
+        )
+
+    except Exception:
+        working_file_path.write_bytes(working_bytes)
+        raise
+
+    working_file_path.write_bytes(target_working_content)
+
+    if not quiet:
+        print(
+            _("✓ Discarded line(s) as replacement to batch '{name}': {lines}").format(
+                name=batch_name,
+                lines=line_id_specification,
+            ),
+            file=sys.stderr,
+        )
+
+    recalculate_selected_hunk_for_file(line_changes.path)
+
+
+def _select_rewritten_replacement_lines(
+    original_selected_lines: list,
+    rewritten_line_changes,
+) -> list:
+    """Find the contiguous rewritten changed run that overlaps the original selection."""
+    original_old_lines = {
+        line.old_line_number
+        for line in original_selected_lines
+        if line.old_line_number is not None
+    }
+    original_new_lines = {
+        line.new_line_number
+        for line in original_selected_lines
+        if line.new_line_number is not None
+    }
+
+    runs: list[list] = []
+    current_run: list = []
+    for line in rewritten_line_changes.lines:
+        if line.kind == " ":
+            if current_run:
+                runs.append(current_run)
+                current_run = []
+            continue
+        current_run.append(line)
+    if current_run:
+        runs.append(current_run)
+
+    for run in runs:
+        run_old_lines = {line.old_line_number for line in run if line.old_line_number is not None}
+        run_new_lines = {line.new_line_number for line in run if line.new_line_number is not None}
+        if run_old_lines & original_old_lines or run_new_lines & original_new_lines:
+            return run
+
+    exit_with_error(_("Replacement selection could not be located after rewriting the file."))
 
 
 def _command_discard_file_to_batch(batch_name: str, file_path: str, *, quiet: bool = False) -> None:

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -6,7 +6,7 @@ import sys
 
 from ..batch import add_file_to_batch, create_batch
 from ..batch.display import annotate_with_batch_source
-from ..batch.ownership import BatchOwnership
+from ..batch.ownership import BatchOwnership, translate_lines_to_batch_ownership
 from ..batch.query import read_batch_metadata
 from ..batch.semantic_selection import try_build_semantic_selection_for_selected_hunk
 from ..batch.source_refresh import prepare_batch_ownership_update_for_selection
@@ -32,23 +32,30 @@ from ..data.hunk_tracking import (
     record_hunk_skipped,
     require_selected_hunk,
 )
+from ..data.consumed_selections import record_consumed_selection
 from ..data.line_state import load_line_changes_from_state
 from ..data.session import require_session_started, snapshot_file_if_untracked
 from ..data.undo import undo_checkpoint
 from ..exceptions import NoMoreHunks, exit_with_error
 from ..i18n import _, ngettext
 from ..output import print_line_level_changes
-from ..staging.operations import build_target_index_content_bytes_with_selected_lines, update_index_with_blob_content
+from ..staging.operations import (
+    build_target_index_content_bytes_with_replaced_lines,
+    build_target_index_content_bytes_with_selected_lines,
+    update_index_with_blob_content,
+)
 from ..utils.command import ExitEvent, OutputEvent, stream_command
 from ..utils.file_io import append_lines_to_file, read_file_bytes, read_text_file_contents
-from ..utils.git import require_git_repository, run_git_command, stream_git_command
+from ..utils.git import get_git_repository_root_path, require_git_repository, run_git_command, stream_git_command
 from ..utils.journal import log_journal
 from ..utils.paths import (
     ensure_state_directory_exists,
     get_block_list_file_path,
     get_context_lines,
+    get_line_changes_json_file_path,
     get_selected_hunk_hash_file_path,
     get_selected_hunk_patch_file_path,
+    get_selected_binary_file_json_path,
     get_index_snapshot_file_path,
     get_processed_include_ids_file_path,
     get_working_tree_snapshot_file_path,
@@ -333,6 +340,198 @@ def command_include_line(line_id_specification: str, file: str | None = None) ->
             recalculate_selected_hunk_for_file(line_changes.path)
 
     print(_("✓ Included line(s): {lines}").format(lines=line_id_specification), file=sys.stderr)
+
+
+def _expand_replacement_selection_ids(line_changes, requested_ids: set[int]) -> set[int]:
+    """Expand a selection to the smallest adjacent mixed replacement run."""
+    selected_indices = [
+        index for index, line in enumerate(line_changes.lines)
+        if line.id in requested_ids
+    ]
+    if not selected_indices:
+        return requested_ids
+
+    run_start = min(selected_indices)
+    run_end = max(selected_indices)
+
+    run_entries = line_changes.lines[run_start:run_end + 1]
+    run_kinds = {line.kind for line in run_entries if line.kind in ("+", "-")}
+
+    if run_kinds != {"+", "-"}:
+        selected_kind = next(iter(run_kinds), None)
+        opposite_kind = "-" if selected_kind == "+" else "+"
+
+        left_index = run_start - 1
+        while left_index >= 0 and line_changes.lines[left_index].kind == selected_kind:
+            left_index -= 1
+        if left_index >= 0 and line_changes.lines[left_index].kind == opposite_kind:
+            run_start = left_index
+
+        right_index = run_end + 1
+        while right_index < len(line_changes.lines) and line_changes.lines[right_index].kind == selected_kind:
+            right_index += 1
+        if right_index < len(line_changes.lines) and line_changes.lines[right_index].kind == opposite_kind:
+            run_end = right_index
+
+        run_entries = line_changes.lines[run_start:run_end + 1]
+        run_kinds = {line.kind for line in run_entries if line.kind in ("+", "-")}
+        if run_kinds != {"+", "-"}:
+            return requested_ids
+
+    return {
+        line.id
+        for line in run_entries
+        if line.id is not None
+    }
+
+
+def _apply_include_line_replacement(
+    line_changes,
+    *,
+    line_id_specification: str,
+    replacement_text: str,
+    hunk_base_content: bytes,
+    hunk_source_content: bytes,
+) -> None:
+    """Stage replacement text for selected lines and record session masking."""
+    requested_ids = set(parse_line_selection(line_id_specification))
+    effective_ids = _expand_replacement_selection_ids(line_changes, requested_ids)
+
+    selected_lines = [line for line in line_changes.lines if line.id in effective_ids]
+    if not selected_lines:
+        exit_with_error(_("No matching lines found for selection: {ids}").format(ids=line_id_specification))
+
+    ownership = translate_lines_to_batch_ownership(selected_lines)
+
+    try:
+        target_index_content = build_target_index_content_bytes_with_replaced_lines(
+            line_changes,
+            effective_ids,
+            replacement_text,
+            hunk_base_content,
+        )
+    except ValueError as error:
+        exit_with_error(str(error))
+
+    update_index_with_blob_content(line_changes.path, target_index_content)
+    record_consumed_selection(
+        line_changes.path,
+        source_content=hunk_source_content,
+        ownership=ownership,
+        replacement_mask={
+            "deleted_lines": replacement_text.splitlines(),
+            "added_lines": [line.text for line in selected_lines if line.kind == "+"],
+        },
+    )
+
+
+def _snapshot_selected_change_state() -> dict[str, bytes | None]:
+    """Capture the current selected change cache so explicit file ops can restore it."""
+    paths = {
+        "patch": get_selected_hunk_patch_file_path(),
+        "hash": get_selected_hunk_hash_file_path(),
+        "line_state": get_line_changes_json_file_path(),
+        "binary": get_selected_binary_file_json_path(),
+        "index_snapshot": get_index_snapshot_file_path(),
+        "working_snapshot": get_working_tree_snapshot_file_path(),
+        "processed_include_ids": get_processed_include_ids_file_path(),
+    }
+    return {
+        name: (read_file_bytes(path) if path.exists() else None)
+        for name, path in paths.items()
+    }
+
+
+def _restore_selected_change_state(snapshot: dict[str, bytes | None]) -> None:
+    """Restore a previously captured selected change cache."""
+    paths = {
+        "patch": get_selected_hunk_patch_file_path(),
+        "hash": get_selected_hunk_hash_file_path(),
+        "line_state": get_line_changes_json_file_path(),
+        "binary": get_selected_binary_file_json_path(),
+        "index_snapshot": get_index_snapshot_file_path(),
+        "working_snapshot": get_working_tree_snapshot_file_path(),
+        "processed_include_ids": get_processed_include_ids_file_path(),
+    }
+    for name, path in paths.items():
+        data = snapshot.get(name)
+        if data is None:
+            path.unlink(missing_ok=True)
+        else:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(data)
+
+
+def command_include_line_as(line_id_specification: str, replacement_text: str, file: str | None = None) -> None:
+    """Stage a replacement for one contiguous selected line range and mask it."""
+    require_git_repository()
+    require_session_started()
+    ensure_state_directory_exists()
+
+    operation_parts = ["include", "--line", line_id_specification, "--as", replacement_text]
+    if file is not None:
+        operation_parts.extend(["--file", file])
+
+    with undo_checkpoint(" ".join(operation_parts)):
+        if file is None:
+            require_selected_hunk()
+            line_changes = load_line_changes_from_state()
+            hunk_base_content = read_file_bytes(get_index_snapshot_file_path())
+            hunk_source_content = read_file_bytes(get_working_tree_snapshot_file_path())
+
+            _apply_include_line_replacement(
+                line_changes,
+                line_id_specification=line_id_specification,
+                replacement_text=replacement_text,
+                hunk_base_content=hunk_base_content,
+                hunk_source_content=hunk_source_content,
+            )
+
+            write_line_ids_file(get_processed_include_ids_file_path(), set())
+            recalculate_selected_hunk_for_file(line_changes.path)
+        else:
+            if file == "":
+                target_file = get_selected_change_file_path()
+                if target_file is None:
+                    exit_with_error(_("No selected hunk. Run 'show' first or specify file path."))
+                preserve_selected_state = False
+            else:
+                target_file = file
+                preserve_selected_state = True
+
+            saved_selected_state = _snapshot_selected_change_state() if preserve_selected_state else None
+
+            cached_lines = cache_file_as_single_hunk(target_file)
+            if cached_lines is None:
+                exit_with_error(_("No changes in file '{file}'.").format(file=target_file))
+
+            annotated_changes = annotate_with_batch_source(target_file, cached_lines)
+            hunk_base_result = run_git_command(
+                ["show", f":{target_file}"],
+                check=False,
+                text_output=False,
+            )
+            hunk_base_content = hunk_base_result.stdout if hunk_base_result.returncode == 0 else b""
+            hunk_source_content = read_file_bytes(get_git_repository_root_path() / target_file)
+
+            _apply_include_line_replacement(
+                annotated_changes,
+                line_id_specification=line_id_specification,
+                replacement_text=replacement_text,
+                hunk_base_content=hunk_base_content,
+                hunk_source_content=hunk_source_content,
+            )
+
+            if preserve_selected_state:
+                _restore_selected_change_state(saved_selected_state)
+            else:
+                write_line_ids_file(get_processed_include_ids_file_path(), set())
+                recalculate_selected_hunk_for_file(target_file)
+
+    print(
+        _("✓ Included line(s) as replacement: {lines}").format(lines=line_id_specification),
+        file=sys.stderr,
+    )
 
 
 def command_include_to_batch(batch_name: str, line_ids: str | None = None, file: str | None = None, *, quiet: bool = False) -> None:

--- a/src/git_stage_batch/commands/include_from.py
+++ b/src/git_stage_batch/commands/include_from.py
@@ -5,8 +5,14 @@ from __future__ import annotations
 import sys
 from typing import Optional
 
+from ..batch.display import build_display_lines_from_batch_source
 from ..batch.merge import merge_batch
 from ..batch.metadata_validation import read_validated_batch_metadata
+from ..batch.replacement import build_replacement_batch_view
+from ..batch.ownership import (
+    BatchOwnership,
+    DeletionClaim,
+)
 from ..batch.selection import (
     resolve_batch_file_scope,
     require_single_file_context_for_line_selection,
@@ -18,11 +24,65 @@ from ..data.hunk_tracking import render_batch_file_display
 from ..data.undo import undo_checkpoint
 from ..exceptions import exit_with_error, MergeError, CommandError, AtomicUnitError, BatchMetadataError
 from ..i18n import _
+from ..core.line_selection import format_line_ids
 from ..staging.operations import update_index_with_blob_content
 from ..utils.git import require_git_repository, run_git_command
 
 
-def command_include_from_batch(batch_name: str, line_ids: Optional[str] = None, file: Optional[str] = None) -> None:
+def _require_contiguous_display_selection(selected_ids: set[int]) -> None:
+    """Require one contiguous selected display range for replacement text."""
+    if not selected_ids:
+        return
+
+    selected_range = list(range(min(selected_ids), max(selected_ids) + 1))
+    if sorted(selected_ids) != selected_range:
+        exit_with_error(_("Replacement selection must be one contiguous line range."))
+
+
+def _select_batch_replacement_ownership(
+    file_meta: dict,
+    batch_source_content: bytes,
+    selected_display_ids: set[int],
+) -> BatchOwnership:
+    """Select exactly the visible batch lines chosen for replacement text."""
+    ownership = BatchOwnership.from_metadata_dict(file_meta)
+    display_lines = build_display_lines_from_batch_source(
+        batch_source_content.decode("utf-8", errors="replace"),
+        ownership,
+    )
+    deletion_by_index = {
+        index: deletion
+        for index, deletion in enumerate(ownership.deletions)
+    }
+    selected_claimed_lines: list[int] = []
+    selected_deletions: list[DeletionClaim] = []
+    seen_deletion_indexes: set[int] = set()
+
+    for display_line in display_lines:
+        display_id = display_line.get("id")
+        if display_id not in selected_display_ids:
+            continue
+
+        if display_line["type"] == "claimed":
+            selected_claimed_lines.append(display_line["source_line"])
+        elif display_line["type"] == "deletion":
+            deletion_index = display_line["deletion_index"]
+            if deletion_index not in seen_deletion_indexes:
+                selected_deletions.append(deletion_by_index[deletion_index])
+                seen_deletion_indexes.add(deletion_index)
+
+    return BatchOwnership(
+        claimed_lines=[format_line_ids(selected_claimed_lines)] if selected_claimed_lines else [],
+        deletions=selected_deletions,
+    )
+
+
+def command_include_from_batch(
+    batch_name: str,
+    line_ids: Optional[str] = None,
+    file: Optional[str] = None,
+    replacement_text: Optional[str] = None,
+) -> None:
     """Stage batch changes to index using structural merge.
 
     Args:
@@ -30,6 +90,7 @@ def command_include_from_batch(batch_name: str, line_ids: Optional[str] = None, 
         line_ids: Optional line IDs to include (requires single-file context)
         file: Optional file path to select from batch.
               If None, includes all files in batch.
+        replacement_text: Optional replacement text for selected batch lines.
     """
     require_git_repository()
 
@@ -58,11 +119,15 @@ def command_include_from_batch(batch_name: str, line_ids: Optional[str] = None, 
     selected_ids = require_single_file_context_for_line_selection(
         batch_name, files, line_ids, "include"
     )
+    if replacement_text is not None and not selected_ids:
+        exit_with_error(_("`include --from --as` requires `--line`."))
 
     # Translate gutter IDs to selection IDs if line selection is active
     selection_ids_to_include = selected_ids
     rendered = None  # Store for error translation
     if selected_ids:
+        if replacement_text is not None:
+            _require_contiguous_display_selection(selected_ids)
         # Use pure render helper to get gutter ID mapping (no side effects)
         file_path_for_render = list(files.keys())[0]  # Single file context enforced above
         rendered = render_batch_file_display(batch_name, file_path_for_render)
@@ -79,6 +144,8 @@ def command_include_from_batch(batch_name: str, line_ids: Optional[str] = None, 
         operation_parts.extend(["--line", line_ids])
     if file is not None:
         operation_parts.extend(["--file", file])
+    if replacement_text is not None:
+        operation_parts.extend(["--as", replacement_text])
     with undo_checkpoint(" ".join(operation_parts)):
         # Apply all files in batch
         failed_files = []
@@ -110,9 +177,16 @@ def command_include_from_batch(batch_name: str, line_ids: Optional[str] = None, 
 
                 # Get ownership from metadata, filtered by selected selection IDs if specified
                 try:
-                    ownership = select_batch_ownership_for_display_ids(
-                        file_meta, batch_source_content, selection_ids_to_include
-                    )
+                    if replacement_text is not None and selection_ids_to_include is not None:
+                        ownership = _select_batch_replacement_ownership(
+                            file_meta,
+                            batch_source_content,
+                            selection_ids_to_include,
+                        )
+                    else:
+                        ownership = select_batch_ownership_for_display_ids(
+                            file_meta, batch_source_content, selection_ids_to_include
+                        )
                 except AtomicUnitError as e:
                     # Translate selection IDs to gutter IDs and exit with user-friendly error
                     if rendered:
@@ -126,6 +200,16 @@ def command_include_from_batch(batch_name: str, line_ids: Optional[str] = None, 
                 # If nothing selected for this file, skip it
                 if ownership.is_empty():
                     continue
+
+                if replacement_text is not None:
+                    try:
+                        batch_source_content, ownership = build_replacement_batch_view(
+                            batch_source_content,
+                            ownership,
+                            replacement_text,
+                        )
+                    except ValueError as e:
+                        exit_with_error(str(e))
 
                 # Perform structural merge
                 merged_content = merge_batch(
@@ -179,7 +263,12 @@ def command_include_from_batch(batch_name: str, line_ids: Optional[str] = None, 
                 )
             )
 
-    if line_ids:
+    if replacement_text is not None and line_ids:
+        print(
+            _("✓ Staged selected lines as replacement from batch '{name}'").format(name=batch_name),
+            file=sys.stderr,
+        )
+    elif line_ids:
         print(_("✓ Staged selected lines from batch '{name}'").format(name=batch_name), file=sys.stderr)
     elif file is not None:
         print(_("✓ Staged changes for {file} from batch '{name}'").format(file=list(files.keys())[0], name=batch_name), file=sys.stderr)

--- a/src/git_stage_batch/data/consumed_selections.py
+++ b/src/git_stage_batch/data/consumed_selections.py
@@ -1,0 +1,75 @@
+"""Session-persistent consumed-selection ownership for hidden masking."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from ..batch.ownership import BatchOwnership, merge_batch_ownership
+from .batch_sources import create_batch_source_commit
+from ..utils.file_io import read_text_file_contents, write_text_file_contents
+from ..utils.paths import get_session_consumed_selections_file_path
+
+
+def load_consumed_selections_metadata() -> dict[str, Any]:
+    """Load hidden consumed-selection metadata."""
+    path = get_session_consumed_selections_file_path()
+    if not path.exists():
+        return {"files": {}}
+
+    try:
+        data = json.loads(read_text_file_contents(path))
+    except json.JSONDecodeError:
+        return {"files": {}}
+
+    files = data.get("files", {})
+    if not isinstance(files, dict):
+        return {"files": {}}
+    return {"files": files}
+
+
+def read_consumed_file_metadata(file_path: str) -> dict[str, Any] | None:
+    """Return hidden consumed-selection metadata for one file."""
+    metadata = load_consumed_selections_metadata()
+    file_metadata = metadata.get("files", {}).get(file_path)
+    return file_metadata if isinstance(file_metadata, dict) else None
+
+
+def record_consumed_selection(
+    file_path: str,
+    *,
+    source_content: bytes,
+    ownership: BatchOwnership,
+    replacement_mask: dict[str, list[str]] | None = None,
+) -> None:
+    """Persist consumed selection ownership for masking across `again`."""
+    metadata = load_consumed_selections_metadata()
+    files = metadata.setdefault("files", {})
+    existing_file_metadata = read_consumed_file_metadata(file_path)
+
+    if existing_file_metadata is not None:
+        existing_ownership = BatchOwnership.from_metadata_dict(existing_file_metadata)
+        merged_ownership = merge_batch_ownership(existing_ownership, ownership)
+        batch_source_commit = existing_file_metadata["batch_source_commit"]
+    else:
+        merged_ownership = ownership
+        batch_source_commit = create_batch_source_commit(
+            file_path,
+            file_content_override=source_content,
+        )
+
+    files[file_path] = {
+        "batch_source_commit": batch_source_commit,
+        **merged_ownership.to_metadata_dict(),
+    }
+    existing_replacement_masks = existing_file_metadata.get("replacement_masks", []) if existing_file_metadata else []
+    if replacement_mask is not None:
+        replacement_masks = existing_replacement_masks[:]
+        replacement_masks.append(replacement_mask)
+        files[file_path]["replacement_masks"] = replacement_masks
+    elif existing_replacement_masks:
+        files[file_path]["replacement_masks"] = existing_replacement_masks
+    write_text_file_contents(
+        get_session_consumed_selections_file_path(),
+        json.dumps(metadata, ensure_ascii=False, indent=2),
+    )

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import json
+import tempfile
 import subprocess
 import sys
+from dataclasses import replace
 from typing import Generator, Optional, Union
 
 from ..batch.attribution import build_file_attribution, filter_owned_diff_fragments
@@ -29,6 +31,7 @@ from ..core.line_selection import write_line_ids_file
 from ..exceptions import CommandError, MergeError, NoMoreHunks, exit_with_error
 from ..i18n import _
 from ..output import print_line_level_changes, print_binary_file_change
+from .consumed_selections import read_consumed_file_metadata
 from ..utils.file_io import (
     read_file_bytes,
     read_file_paths_file,
@@ -137,6 +140,10 @@ def apply_line_level_batch_filter_to_cached_hunk() -> bool:
     if should_skip:
         return True
 
+    filtered_line_changes = _filter_consumed_replacement_masks(filtered_line_changes)
+    if filtered_line_changes is None:
+        return True
+
     # Update cached hunk with filtered version
     write_text_file_contents(
         get_line_changes_json_file_path(),
@@ -145,6 +152,68 @@ def apply_line_level_batch_filter_to_cached_hunk() -> bool:
     )
 
     return False
+
+
+def _filter_consumed_replacement_masks(
+    line_changes: LineLevelChange,
+) -> LineLevelChange | None:
+    """Hide synthetic replacement runs created by `include --line --as`."""
+    file_metadata = read_consumed_file_metadata(line_changes.path)
+    replacement_masks = file_metadata.get("replacement_masks", []) if file_metadata else []
+    if not replacement_masks:
+        return line_changes
+
+    normalized_masks: set[tuple[tuple[str, str], ...]] = set()
+    for mask in replacement_masks:
+        deleted_signature = tuple(("-", text) for text in mask.get("deleted_lines", []))
+        added_signature = tuple(("+", text) for text in mask.get("added_lines", []))
+        full_signature = deleted_signature + added_signature
+        if full_signature:
+            normalized_masks.add(full_signature)
+        if deleted_signature:
+            normalized_masks.add(deleted_signature)
+        if added_signature:
+            normalized_masks.add(added_signature)
+
+    filtered_lines = []
+    changed_run: list[LineEntry] = []
+
+    def flush_changed_run() -> None:
+        nonlocal changed_run
+        if not changed_run:
+            return
+        run_signature = tuple((line.kind, line.text) for line in changed_run if line.kind in ("+", "-"))
+        if run_signature not in normalized_masks:
+            filtered_lines.extend(changed_run)
+        changed_run = []
+
+    for line_entry in line_changes.lines:
+        if line_entry.kind in ("+", "-"):
+            changed_run.append(line_entry)
+            continue
+        flush_changed_run()
+        filtered_lines.append(line_entry)
+
+    flush_changed_run()
+
+    new_id = 1
+    renumbered_lines = []
+    for line_entry in filtered_lines:
+        renumbered_lines.append(
+            replace(line_entry, id=new_id if line_entry.kind != " " else None)
+        )
+        if line_entry.kind != " ":
+            new_id += 1
+
+    has_changes_after_filter = any(line.kind in ("+", "-") for line in renumbered_lines)
+    if not has_changes_after_filter:
+        return None
+
+    return LineLevelChange(
+        path=line_changes.path,
+        header=line_changes.header,
+        lines=renumbered_lines,
+    )
 
 
 def render_batch_file_display(
@@ -489,82 +558,26 @@ def cache_file_as_single_hunk(file_path: str) -> Optional[LineLevelChange]:
     Returns:
         LineLevelChange with all file changes, or None if no changes
     """
-    # Get diff for entire file from selected working tree
-    # Using git diff HEAD -- file_path to get live state
     try:
-        all_line_entries = []
-        line_id_counter = 1
-        min_old_start = None
-        max_old_end = None
-        min_new_start = None
-        max_new_end = None
-
-        for single_hunk in parse_unified_diff_streaming(
-            stream_git_command(["diff", f"-U{get_context_lines()}", "--no-color", "HEAD", "--", file_path])
-        ):
-            # Build LineLevelChange from this hunk
-            patch_bytes = single_hunk.to_patch_bytes()
-            line_changes = build_line_changes_from_patch_bytes(patch_bytes)
-
-            # Track bounds for combined header
-            if min_old_start is None:
-                min_old_start = line_changes.header.old_start
-                min_new_start = line_changes.header.new_start
-
-            max_old_end = line_changes.header.old_start + line_changes.header.old_len
-            max_new_end = line_changes.header.new_start + line_changes.header.new_len
-
-            # Renumber line IDs to be continuous across all hunks
-            for line_entry in line_changes.lines:
-                if line_entry.kind != " ":
-                    # Changed line: assign new continuous ID
-                    new_entry = LineEntry(
-                        id=line_id_counter,
-                        kind=line_entry.kind,
-                        old_line_number=line_entry.old_line_number,
-                        new_line_number=line_entry.new_line_number,
-                        text_bytes=line_entry.text_bytes,
-                        text=line_entry.text,
-                        source_line=line_entry.source_line
-                    )
-                    line_id_counter += 1
-                else:
-                    # Context line: keep None
-                    new_entry = LineEntry(
-                        id=None,
-                        kind=line_entry.kind,
-                        old_line_number=line_entry.old_line_number,
-                        new_line_number=line_entry.new_line_number,
-                        text_bytes=line_entry.text_bytes,
-                        text=line_entry.text,
-                        source_line=line_entry.source_line
-                    )
-                all_line_entries.append(new_entry)
-
-        if not all_line_entries:
+        combined_line_changes = _build_combined_file_line_changes(
+            file_path,
+            parse_unified_diff_streaming(
+                stream_git_command(["diff", f"-U{get_context_lines()}", "--no-color", "HEAD", "--", file_path])
+            ),
+        )
+        if combined_line_changes is None:
             return None
-
-        # Create combined header spanning all hunks
-        combined_header = HunkHeader(
-            old_start=min_old_start,
-            old_len=max_old_end - min_old_start,
-            new_start=min_new_start,
-            new_len=max_new_end - min_new_start
-        )
-
-        combined_line_changes = LineLevelChange(
-            path=file_path,
-            header=combined_header,
-            lines=all_line_entries
-        )
 
         # Synthesize patch bytes for caching (used for hashing/identity)
         patch_lines = [
             f"--- a/{file_path}\n".encode("utf-8"),
             f"+++ b/{file_path}\n".encode("utf-8"),
-            f"@@ -{combined_header.old_start},{combined_header.old_len} +{combined_header.new_start},{combined_header.new_len} @@\n".encode("utf-8"),
+            (
+                f"@@ -{combined_line_changes.header.old_start},{combined_line_changes.header.old_len} "
+                f"+{combined_line_changes.header.new_start},{combined_line_changes.header.new_len} @@\n"
+            ).encode("utf-8"),
         ]
-        for entry in all_line_entries:
+        for entry in combined_line_changes.lines:
             patch_lines.append(entry.kind.encode("utf-8") + entry.text_bytes + b"\n")
         patch_bytes = b"".join(patch_lines)
 
@@ -586,6 +599,125 @@ def cache_file_as_single_hunk(file_path: str) -> Optional[LineLevelChange]:
     except subprocess.CalledProcessError:
         # Git diff failed (e.g., no changes in file)
         return None
+
+
+def build_file_hunk_from_content(file_path: str, file_content: bytes) -> Optional[LineLevelChange]:
+    """Build a file-scoped line view for hypothetical file content without writing it."""
+    head_result = run_git_command(["show", f"HEAD:{file_path}"], check=False, text_output=False)
+    head_content = head_result.stdout if head_result.returncode == 0 else b""
+
+    with tempfile.NamedTemporaryFile(delete=False) as old_tmp:
+        old_tmp.write(head_content)
+        old_path = old_tmp.name
+    with tempfile.NamedTemporaryFile(delete=False) as new_tmp:
+        new_tmp.write(file_content)
+        new_path = new_tmp.name
+
+    try:
+        diff_result = subprocess.run(
+            [
+                "git",
+                "diff",
+                "--no-index",
+                f"-U{get_context_lines()}",
+                "--no-color",
+                old_path,
+                new_path,
+            ],
+            check=False,
+            capture_output=True,
+        )
+        if diff_result.returncode not in (0, 1):
+            raise subprocess.CalledProcessError(
+                diff_result.returncode,
+                diff_result.args,
+                output=diff_result.stdout,
+                stderr=diff_result.stderr,
+            )
+
+        patch_bytes = diff_result.stdout.replace(
+            f"a{old_path}".encode("utf-8"),
+            f"a/{file_path}".encode("utf-8"),
+        ).replace(
+            f"b{new_path}".encode("utf-8"),
+            f"b/{file_path}".encode("utf-8"),
+        )
+
+        return _build_combined_file_line_changes(
+            file_path,
+            parse_unified_diff_streaming(patch_bytes.splitlines(keepends=True)),
+        )
+    finally:
+        try:
+            import os
+            os.unlink(old_path)
+            os.unlink(new_path)
+        except OSError:
+            pass
+
+
+def _build_combined_file_line_changes(
+    file_path: str,
+    patches,
+) -> Optional[LineLevelChange]:
+    """Combine file diff hunks into one file-scoped LineLevelChange."""
+    all_line_entries = []
+    line_id_counter = 1
+    min_old_start = None
+    max_old_end = None
+    min_new_start = None
+    max_new_end = None
+
+    for single_hunk in patches:
+        patch_bytes = single_hunk.to_patch_bytes()
+        line_changes = build_line_changes_from_patch_bytes(patch_bytes)
+
+        if min_old_start is None:
+            min_old_start = line_changes.header.old_start
+            min_new_start = line_changes.header.new_start
+
+        max_old_end = line_changes.header.old_start + line_changes.header.old_len
+        max_new_end = line_changes.header.new_start + line_changes.header.new_len
+
+        for line_entry in line_changes.lines:
+            if line_entry.kind != " ":
+                new_entry = LineEntry(
+                    id=line_id_counter,
+                    kind=line_entry.kind,
+                    old_line_number=line_entry.old_line_number,
+                    new_line_number=line_entry.new_line_number,
+                    text_bytes=line_entry.text_bytes,
+                    text=line_entry.text,
+                    source_line=line_entry.source_line,
+                )
+                line_id_counter += 1
+            else:
+                new_entry = LineEntry(
+                    id=None,
+                    kind=line_entry.kind,
+                    old_line_number=line_entry.old_line_number,
+                    new_line_number=line_entry.new_line_number,
+                    text_bytes=line_entry.text_bytes,
+                    text=line_entry.text,
+                    source_line=line_entry.source_line,
+                )
+            all_line_entries.append(new_entry)
+
+    if not all_line_entries:
+        return None
+
+    combined_header = HunkHeader(
+        old_start=min_old_start,
+        old_len=max_old_end - min_old_start,
+        new_start=min_new_start,
+        new_len=max_new_end - min_new_start,
+    )
+
+    return LineLevelChange(
+        path=file_path,
+        header=combined_header,
+        lines=all_line_entries,
+    )
 
 
 def fetch_next_change() -> Union[LineLevelChange, BinaryFileChange]:

--- a/src/git_stage_batch/staging/operations.py
+++ b/src/git_stage_batch/staging/operations.py
@@ -106,6 +106,79 @@ def build_target_index_content_bytes_with_selected_lines(
     return b"\n".join(output_lines) + (b"\n" if trailing_newline else b"")
 
 
+def build_target_index_content_bytes_with_replaced_lines(
+    line_changes: LineLevelChange,
+    replace_ids: set[int],
+    replacement_text: str,
+    base_content: bytes,
+) -> bytes:
+    """Build target index content by replacing one contiguous changed region."""
+    if not replace_ids:
+        return base_content
+
+    changed_ids = sorted(line_changes.changed_line_ids())
+    selected_ids = sorted(replace_ids)
+    if any(line_id not in changed_ids for line_id in selected_ids):
+        raise ValueError("Replacement selection contains line IDs outside the current hunk")
+
+    expected_range = list(range(selected_ids[0], selected_ids[-1] + 1))
+    if selected_ids != expected_range:
+        raise ValueError("Replacement selection must be one contiguous line range")
+
+    base_lines = base_content.splitlines()
+    replacement_bytes = replacement_text.encode("utf-8", errors="surrogateescape")
+    replacement_lines = replacement_bytes.splitlines()
+    output_lines: list[bytes] = []
+
+    base_pointer = line_changes.header.old_start - 1
+    base_line_count = len(base_lines)
+    inserted_replacement = False
+
+    def push_output(line: bytes) -> None:
+        output_lines.append(line)
+
+    def push_replacement_once() -> None:
+        nonlocal inserted_replacement
+        if inserted_replacement:
+            return
+        output_lines.extend(replacement_lines)
+        inserted_replacement = True
+
+    for index in range(0, min(base_pointer, base_line_count)):
+        push_output(base_lines[index])
+
+    for line_entry in line_changes.lines:
+        is_selected = line_entry.id in replace_ids if line_entry.id is not None else False
+
+        if is_selected:
+            push_replacement_once()
+            if line_entry.kind in (" ", "-") and base_pointer < base_line_count:
+                base_pointer += 1
+            continue
+
+        if line_entry.kind == " ":
+            if base_pointer < base_line_count:
+                push_output(base_lines[base_pointer])
+                base_pointer += 1
+        elif line_entry.kind == "-":
+            if base_pointer < base_line_count:
+                push_output(base_lines[base_pointer])
+                base_pointer += 1
+        elif line_entry.kind == "+":
+            continue
+
+    while 0 <= base_pointer < base_line_count:
+        push_output(base_lines[base_pointer])
+        base_pointer += 1
+
+    trailing_newline = (
+        replacement_text.endswith("\n")
+        or base_content.endswith(b"\n")
+        or (not base_content and bool(output_lines))
+    )
+    return b"\n".join(output_lines) + (b"\n" if trailing_newline else b"")
+
+
 def build_target_working_tree_content_with_discarded_lines(
     line_changes: LineLevelChange,
     discard_ids: set[int],
@@ -210,6 +283,79 @@ def build_target_working_tree_content_bytes_with_discarded_lines(
         working_pointer += 1
 
     trailing_newline = working_content.endswith(b"\n") or bool(output_lines)
+    return b"\n".join(output_lines) + (b"\n" if trailing_newline else b"")
+
+
+def build_target_working_tree_content_bytes_with_replaced_lines(
+    line_changes: LineLevelChange,
+    replace_ids: set[int],
+    replacement_text: str,
+    working_content: bytes,
+) -> bytes:
+    """Build working tree content by replacing one contiguous changed region."""
+    if not replace_ids:
+        return working_content
+
+    changed_ids = sorted(line_changes.changed_line_ids())
+    selected_ids = sorted(replace_ids)
+    if any(line_id not in changed_ids for line_id in selected_ids):
+        raise ValueError("Replacement selection contains line IDs outside the current hunk")
+
+    expected_range = list(range(selected_ids[0], selected_ids[-1] + 1))
+    if selected_ids != expected_range:
+        raise ValueError("Replacement selection must be one contiguous line range")
+
+    working_lines = working_content.splitlines()
+    output_lines: list[bytes] = []
+
+    working_pointer = line_changes.header.new_start - 1
+    working_line_count = len(working_lines)
+    replacement_bytes = replacement_text.encode("utf-8", errors="surrogateescape")
+    replacement_lines = replacement_bytes.splitlines()
+    inserted_replacement = False
+
+    def push_output(line: bytes) -> None:
+        output_lines.append(line)
+
+    def push_replacement_once() -> None:
+        nonlocal inserted_replacement
+        if inserted_replacement:
+            return
+        output_lines.extend(replacement_lines)
+        inserted_replacement = True
+
+    for index in range(0, min(working_pointer, working_line_count)):
+        push_output(working_lines[index])
+
+    for line_entry in line_changes.lines:
+        is_selected = line_entry.id in replace_ids if line_entry.id is not None else False
+
+        if is_selected:
+            push_replacement_once()
+            if line_entry.kind in (" ", "+") and working_pointer < working_line_count:
+                working_pointer += 1
+            continue
+
+        if line_entry.kind == " ":
+            if working_pointer < working_line_count:
+                push_output(working_lines[working_pointer])
+                working_pointer += 1
+        elif line_entry.kind == "-":
+            continue
+        elif line_entry.kind == "+":
+            if working_pointer < working_line_count:
+                push_output(working_lines[working_pointer])
+                working_pointer += 1
+
+    while 0 <= working_pointer < working_line_count:
+        push_output(working_lines[working_pointer])
+        working_pointer += 1
+
+    trailing_newline = (
+        replacement_text.endswith("\n")
+        or working_content.endswith(b"\n")
+        or bool(output_lines)
+    )
     return b"\n".join(output_lines) + (b"\n" if trailing_newline else b"")
 
 

--- a/src/git_stage_batch/utils/paths.py
+++ b/src/git_stage_batch/utils/paths.py
@@ -209,6 +209,15 @@ def get_session_batch_sources_file_path() -> Path:
     return get_session_directory_path() / "batch-sources.json"
 
 
+def get_session_consumed_selections_file_path() -> Path:
+    """Get the path to the hidden consumed-selection ownership cache.
+
+    Returns:
+        Path to session-consumed-selections.json file
+    """
+    return get_session_directory_path() / "consumed-selections.json"
+
+
 def get_auto_added_files_file_path() -> Path:
     """Get the path to the auto-added files list file.
 

--- a/tests/cli/test_argument_parser.py
+++ b/tests/cli/test_argument_parser.py
@@ -175,8 +175,6 @@ def test_parse_command_line_include_with_file_and_line_dispatches_file_scope(mon
     assert args is not None
     args.func(args)
     mock_command.assert_called_once_with("2-3", file="path.txt")
-
-
 def test_parse_command_line_include_from_with_as():
     """Test parsing include --from with replacement text."""
     args = parse_command_line(
@@ -242,6 +240,21 @@ def test_parse_command_line_discard_to_with_as():
     )
     assert args is not None
     assert args.to_batch == "batch"
+    assert args.line_ids == "2-3"
+    assert args.as_text == "replacement"
+    assert hasattr(args, "func")
+    assert callable(args.func)
+
+
+def test_parse_command_line_discard_to_with_file_and_as():
+    """Test parsing discard --to --file with replacement text."""
+    args = parse_command_line(
+        ["discard", "--to", "batch", "--file", "path.txt", "--line", "2-3", "--as", "replacement"],
+        quiet=True,
+    )
+    assert args is not None
+    assert args.to_batch == "batch"
+    assert args.file == "path.txt"
     assert args.line_ids == "2-3"
     assert args.as_text == "replacement"
     assert hasattr(args, "func")

--- a/tests/commands/test_discard.py
+++ b/tests/commands/test_discard.py
@@ -1,5 +1,7 @@
 """Tests for discard command."""
 
+from unittest.mock import patch
+
 from git_stage_batch.utils.paths import get_abort_snapshots_directory_path
 from git_stage_batch.batch import list_batch_files, read_file_from_batch
 from git_stage_batch.commands.discard import command_discard_to_batch
@@ -11,7 +13,7 @@ import subprocess
 
 import pytest
 
-from git_stage_batch.commands.discard import command_discard, command_discard_line
+from git_stage_batch.commands.discard import command_discard, command_discard_line, command_discard_line_as_to_batch
 from git_stage_batch.commands.include import command_include
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.exceptions import CommandError
@@ -423,3 +425,40 @@ class TestCommandDiscardToBatch:
         command_apply_from_batch("test")
 
         assert file_path.read_text() == "A\nB\n"
+
+    def test_discard_line_as_to_batch_stores_replacement_and_discards_original(self, temp_git_repo):
+        """Discard --to --as should batch edited text but remove the local change."""
+        readme = temp_git_repo / "README.md"
+        readme.write_text("# Test\nprint('debug')\n")
+
+        command_start()
+        fetch_next_change()
+
+        command_discard_line_as_to_batch(
+            "feature-batch",
+            "1",
+            'log("log worthy message that was debug print() before");',
+        )
+
+        assert readme.read_text() == "# Test\n"
+
+        command_apply_from_batch("feature-batch")
+        assert readme.read_text() == '# Test\nlog("log worthy message that was debug print() before");\n'
+
+    def test_discard_line_as_to_batch_restores_working_tree_on_batch_error(self, temp_git_repo):
+        """Batch persistence errors should not leave the rewritten file behind."""
+        readme = temp_git_repo / "README.md"
+        readme.write_text("# Test\nprint('debug')\n")
+
+        command_start()
+        fetch_next_change()
+
+        with patch("git_stage_batch.commands.discard.add_file_to_batch", side_effect=RuntimeError("boom")):
+            with pytest.raises(RuntimeError, match="boom"):
+                command_discard_line_as_to_batch(
+                    "feature-batch",
+                    "1",
+                    'log("log worthy message that was debug print() before");',
+                )
+
+        assert readme.read_text() == "# Test\nprint('debug')\n"

--- a/tests/commands/test_file_scoped_operations.py
+++ b/tests/commands/test_file_scoped_operations.py
@@ -672,6 +672,27 @@ class TestExplicitFilePath:
         result = run_git_command(["diff", "gamma.txt"])
         assert "gamma2-modified" in result.stdout
 
+    def test_include_file_line_as_with_explicit_path(self, multi_file_repo):
+        """Include --file PATH --line IDS --as should preserve selected position."""
+        command_start()
+
+        line_changes_before = load_line_changes_from_state()
+        assert line_changes_before.path == "alpha.txt"
+
+        command_include_line_as("2", "beta2-edited", file="beta.txt")
+
+        line_changes_after = load_line_changes_from_state()
+        assert line_changes_after.path == "alpha.txt"
+        assert line_changes_after.lines == line_changes_before.lines
+
+        staged_content = run_git_command(["show", ":beta.txt"]).stdout
+        assert staged_content == "beta1\nbeta2-edited\nbeta3\n"
+
+        working_diff = run_git_command(["diff", "beta.txt"]).stdout
+        assert "beta4-new" in working_diff
+        assert "beta2-modified" in working_diff
+        assert "beta2-edited" in working_diff
+
     def test_discard_file_with_explicit_path(self, multi_file_repo):
         """Discard --file PATH should discard all hunks from specified file."""
 
@@ -703,6 +724,34 @@ class TestExplicitFilePath:
         # Verify beta.txt is untouched
         beta_content = (multi_file_repo / "beta.txt").read_text()
         assert "beta2-modified" in beta_content
+
+    def test_discard_file_line_as_to_batch_with_explicit_path(self, multi_file_repo):
+        """Discard --to BATCH --file PATH --line --as should preserve selected position."""
+        command_start()
+
+        line_changes_before = load_line_changes_from_state()
+        assert line_changes_before.path == "alpha.txt"
+
+        from git_stage_batch.commands.discard import command_discard_line_as_to_batch
+
+        command_discard_line_as_to_batch(
+            "feature-batch",
+            "2",
+            "beta2-edited",
+            file="beta.txt",
+        )
+
+        line_changes_after = load_line_changes_from_state()
+        assert line_changes_after.path == "alpha.txt"
+        assert line_changes_after.lines == line_changes_before.lines
+
+        beta_content = (multi_file_repo / "beta.txt").read_text()
+        assert beta_content == "beta1\nbeta2\nbeta3\nbeta4-new\n"
+
+        command_apply_from_batch("feature-batch")
+
+        applied_content = (multi_file_repo / "beta.txt").read_text()
+        assert applied_content == "beta1\nbeta2-edited\nbeta3\nbeta4-new\n"
 
     def test_include_file_explicit_path_multiple_hunks(self, tmp_path, monkeypatch):
         """Include --file PATH should stage all hunks from multi-hunk file."""

--- a/tests/commands/test_include.py
+++ b/tests/commands/test_include.py
@@ -4,10 +4,12 @@ import subprocess
 
 import pytest
 
-from git_stage_batch.commands.include import command_include, command_include_line
+from git_stage_batch.commands.include import command_include, command_include_line, command_include_line_as
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.data.hunk_tracking import fetch_next_change
-from git_stage_batch.exceptions import CommandError
+from git_stage_batch.data.line_state import load_line_changes_from_state
+from git_stage_batch.exceptions import CommandError, NoMoreHunks
+from git_stage_batch.commands.again import command_again
 
 
 @pytest.fixture
@@ -281,3 +283,78 @@ class TestCommandIncludeLine:
         )
         assert "remove" not in result.stdout
         assert result.stdout == "keep1\nkeep2\n"
+
+    def test_include_line_as_replaces_staged_content_and_masks_hunk(self, temp_git_repo):
+        """Test include --line --as stages replacement text and hides the line."""
+        test_file = temp_git_repo / "test.txt"
+        test_file.write_text("old value\n")
+        subprocess.run(["git", "add", "test.txt"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add file"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        test_file.write_text("working value\n")
+
+        command_start()
+        fetch_next_change()
+        command_include_line_as("1", "staged value")
+
+        result = subprocess.run(
+            ["git", "show", ":test.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+            text=True,
+        )
+        assert result.stdout == "staged value\n"
+
+        command_again()
+        with pytest.raises(NoMoreHunks):
+            fetch_next_change()
+
+    def test_include_line_as_replaces_selected_range(self, temp_git_repo):
+        """Test include --line --as replaces a contiguous selected range."""
+        test_file = temp_git_repo / "test.txt"
+        test_file.write_text("header\n")
+        subprocess.run(["git", "add", "test.txt"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add file"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        test_file.write_text("header\nline1\nline2\nline3\n")
+
+        command_start()
+        fetch_next_change()
+        command_include_line_as("1-2", "replacement1\nreplacement2")
+
+        result = subprocess.run(
+            ["git", "show", ":test.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+            text=True,
+        )
+        assert result.stdout == "header\nreplacement1\nreplacement2\n"
+
+    def test_include_line_as_selected_file_recalculates_remaining_lines(self, temp_git_repo):
+        """Test include --file --line --as on the selected file recalculates that file."""
+        test_file = temp_git_repo / "test.txt"
+        test_file.write_text("keep\nold value\n")
+        subprocess.run(["git", "add", "test.txt"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add file"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        test_file.write_text("keep\nworking value\nextra line\n")
+
+        command_start()
+        fetch_next_change()
+        command_include_line_as("2", "staged value", file="")
+
+        result = subprocess.run(
+            ["git", "show", ":test.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+            text=True,
+        )
+        assert result.stdout == "keep\nstaged value\n"
+
+        line_changes = load_line_changes_from_state()
+        assert line_changes is not None
+        changed_lines = [line for line in line_changes.lines if line.kind != " "]
+        assert any("extra line" in line.text for line in changed_lines)

--- a/tests/commands/test_include_from.py
+++ b/tests/commands/test_include_from.py
@@ -11,6 +11,7 @@ import pytest
 
 from git_stage_batch.batch import create_batch
 from git_stage_batch.commands.include_from import command_include_from_batch
+from git_stage_batch.data.hunk_tracking import render_batch_file_display
 from git_stage_batch.data.session import initialize_abort_state
 from git_stage_batch.exceptions import CommandError
 from git_stage_batch.utils.git import run_git_command
@@ -141,3 +142,65 @@ class TestCommandIncludeFromBatch:
         # Try to use --file without cached hunk (no fetch_next_change call after command_start)
         with pytest.raises(CommandError):
             command_include_from_batch("test-batch", file="")
+
+    def test_include_from_batch_as_replaces_presence_only_selection(self, temp_git_repo):
+        """Test include --from --line --as replaces claimed batch content before staging."""
+        test_file = temp_git_repo / "test.txt"
+        test_file.write_text("keep\n")
+        subprocess.run(["git", "add", "test.txt"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add file"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        test_file.write_text("keep\nbatch value\n")
+        command_start()
+        command_include_to_batch("test-batch", quiet=True)
+
+        test_file.write_text("keep\n")
+        run_git_command(["reset", "HEAD", "test.txt"], check=False)
+
+        rendered = render_batch_file_display("test-batch", "test.txt")
+        batch_value_gutter = next(
+            rendered.selection_id_to_gutter[line.id]
+            for line in rendered.line_changes.lines
+            if line.id is not None and line.text == "batch value"
+        )
+
+        command_include_from_batch(
+            "test-batch",
+            line_ids=str(batch_value_gutter),
+            file="test.txt",
+            replacement_text="edited value",
+        )
+
+        result = run_git_command(["show", ":test.txt"])
+        assert result.stdout == "keep\nedited value\n"
+
+    def test_include_from_batch_as_replaces_atomic_replacement_unit(self, temp_git_repo):
+        """Test include --from --line --as preserves batch deletion semantics."""
+        test_file = temp_git_repo / "test.txt"
+        test_file.write_text("keep\nold value\n")
+        subprocess.run(["git", "add", "test.txt"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add file"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        test_file.write_text("keep\nbatch value\n")
+        command_start()
+        command_include_to_batch("test-batch", quiet=True)
+
+        test_file.write_text("keep\nold value\n")
+        run_git_command(["reset", "HEAD", "test.txt"], check=False)
+
+        rendered = render_batch_file_display("test-batch", "test.txt")
+        replacement_gutters = sorted(
+            rendered.selection_id_to_gutter[line.id]
+            for line in rendered.line_changes.lines
+            if line.id is not None and line.text in {"old value", "batch value"}
+        )
+
+        command_include_from_batch(
+            "test-batch",
+            line_ids=f"{replacement_gutters[0]}-{replacement_gutters[-1]}",
+            file="test.txt",
+            replacement_text="edited value",
+        )
+
+        result = run_git_command(["show", ":test.txt"])
+        assert result.stdout == "keep\nedited value\n"

--- a/tests/functional/test_semantic_partial_staging.py
+++ b/tests/functional/test_semantic_partial_staging.py
@@ -191,3 +191,14 @@ def test_semantic_partial_staging_fallback_preserves_unrelated_index_state(funct
     git_stage_batch("include", "--line", "1")
 
     assert _index_content(functional_repo, "file.txt") == "X\nb\ny\n"
+
+
+def test_semantic_partial_staging_falls_back_for_replacement_plus_trailing_insertion(functional_repo):
+    _commit_file(functional_repo, "file.txt", "keep\nold value\n")
+    (functional_repo / "file.txt").write_text("keep\nworking value\nextra line\n")
+
+    git_stage_batch("start")
+    result = git_stage_batch("include", "--line", "1,2")
+
+    assert result.returncode == 0
+    assert _index_content(functional_repo, "file.txt") == "keep\nworking value\n"

--- a/tests/staging/test_operations.py
+++ b/tests/staging/test_operations.py
@@ -6,6 +6,7 @@ import pytest
 
 from git_stage_batch.core.models import LineLevelChange, HunkHeader, LineEntry
 from git_stage_batch.staging.operations import (
+    build_target_index_content_bytes_with_replaced_lines,
     build_target_index_content_with_selected_lines,
     build_target_working_tree_content_with_discarded_lines,
     update_index_with_blob_content,
@@ -213,6 +214,27 @@ class TestBuildTargetIndexContent:
 
         # No changes should be applied
         assert result == "line1\nline2\n"
+
+    def test_replace_selection_does_not_consume_trailing_additions(self):
+        """Replacement staging should not absorb adjacent pure insertions."""
+        header = HunkHeader(1, 2, 1, 4)
+        lines = [
+            LineEntry(None, " ", 1, 1, text_bytes=b"keep", text="keep"),
+            LineEntry(1, "-", 2, None, text_bytes=b"old value", text="old value"),
+            LineEntry(2, "+", None, 2, text_bytes=b"working value", text="working value"),
+            LineEntry(3, "+", None, 3, text_bytes=b"extra line", text="extra line"),
+        ]
+        line_changes = LineLevelChange(path="test.txt", header=header, lines=lines)
+        base_content = b"keep\nold value\n"
+
+        result = build_target_index_content_bytes_with_replaced_lines(
+            line_changes,
+            {1, 2},
+            "staged value",
+            base_content,
+        )
+
+        assert result == b"keep\nstaged value\n"
 
 
 class TestBuildTargetWorkingTreeContent:


### PR DESCRIPTION
The program stages and batches selected diff lines, and line-based
commands operate on the exact text currently shown in live or batch
displays. Include and discard already support line selection, file-scoped
selection, and batch-origin selection, and the batch model continues to
express replacements through claimed lines and deletion constraints.

But users can not replace a selected line range with different text
during those workflows. That leaves line-based editing support
incomplete, especially for people who expect parity with `git add -e`.

This PR addresses that by introducing replacement-oriented primitives
and then using them in the line workflows that already exist. It adds
`include --line/--lines --as`, extends that to file-scoped and
batch-origin include flows, and adds
`discard --line/--lines --as --to` with explicit file support.

Closes: https://github.com/halfline/git-stage-batch/issues/5