### PR TITLE
cli: Show the selected hunk by default

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -79,12 +79,12 @@ Stage the cached hunk (entire hunk) to the index; advance to next.
 ❯ git-stage-batch include
 ```
 
-Or use the bare command when session is active:
+---
+
+When a session is active, the bare command shows the selected hunk:
 ```
 ❯ git-stage-batch
 ```
-
----
 
 ### `skip`
 

--- a/docs/git-stage-batch.1.in
+++ b/docs/git-stage-batch.1.in
@@ -93,15 +93,16 @@ Useful for scripts checking hunk availability without output.
 .TP
 .B include
 Stage the cached hunk (entire hunk) to the index; advance to next.
-When a session is active, running
-.B git-stage-batch
-with no command defaults to
-.BR include .
 .TP
 .B skip
 Mark the cached hunk as skipped; advance to next.
 Skipped hunks can be revisited with
 .BR again .
+.TP
+.B git-stage-batch
+When a session is active, running
+.B git-stage-batch
+with no command shows the selected hunk.
 .TP
 .B discard
 Reverse-apply the cached hunk to the working tree; advance to next.

--- a/src/git_stage_batch/cli/dispatch.py
+++ b/src/git_stage_batch/cli/dispatch.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import argparse
 
+from ..commands import command_show
 from ..exceptions import exit_with_error
 from ..i18n import _
+from ..utils.paths import get_abort_head_file_path
 
 
 def dispatch_args(args: argparse.Namespace) -> None:
@@ -19,10 +21,13 @@ def dispatch_args(args: argparse.Namespace) -> None:
         from ..commands import command_interactive
         command_interactive()
     elif args.command is None:
-        # No command provided - show helpful message
-        exit_with_error(
-            _("No batch staging session in progress.") + "\n" +
-            _("Run 'git-stage-batch start' to begin.")
-        )
+        if get_abort_head_file_path().exists():
+            command_show()
+        else:
+            # No command provided - show helpful message
+            exit_with_error(
+                _("No batch staging session in progress.") + "\n" +
+                _("Run 'git-stage-batch start' to begin.")
+            )
     else:
         args.func(args)

--- a/tests/cli/test_dispatch.py
+++ b/tests/cli/test_dispatch.py
@@ -4,22 +4,29 @@ import argparse
 
 import pytest
 
-from git_stage_batch.cli.dispatch import dispatch_args
+import git_stage_batch.cli.dispatch as dispatch
 from git_stage_batch.exceptions import CommandError
 
 
-def test_dispatch_args_no_command():
+def test_dispatch_args_no_command(monkeypatch):
     """Test dispatch with no command raises CommandError."""
     args = argparse.Namespace(command=None)
+
+    class _FakePath:
+        def exists(self) -> bool:
+            return False
+
+    monkeypatch.setattr(dispatch, "get_abort_head_file_path", lambda: _FakePath())
+
     with pytest.raises(CommandError) as exc_info:
-        dispatch_args(args)
+        dispatch.dispatch_args(args)
     assert "No batch staging session in progress" in exc_info.value.message
 
 
 def test_dispatch_args_callable():
     """Test that dispatch_args is callable."""
-    assert dispatch_args is not None
-    assert callable(dispatch_args)
+    assert dispatch.dispatch_args is not None
+    assert callable(dispatch.dispatch_args)
 
 
 def test_dispatch_args_with_command():
@@ -30,5 +37,22 @@ def test_dispatch_args_with_command():
         executed.append(True)
 
     args = argparse.Namespace(command="test", func=mock_command)
-    dispatch_args(args)
+    dispatch.dispatch_args(args)
     assert executed == [True]
+
+
+def test_dispatch_args_no_command_shows_selected_hunk_when_session_active(monkeypatch):
+    """Test dispatch with no command falls back to show during an active session."""
+    args = argparse.Namespace(command=None)
+    called = []
+
+    monkeypatch.setattr(dispatch, "command_show", lambda: called.append(True))
+
+    class _FakePath:
+        def exists(self) -> bool:
+            return True
+
+    monkeypatch.setattr(dispatch, "get_abort_head_file_path", lambda: _FakePath())
+
+    dispatch.dispatch_args(args)
+    assert called == [True]

--- a/tests/functional/test_basic_workflow.py
+++ b/tests/functional/test_basic_workflow.py
@@ -146,6 +146,16 @@ class TestDiscardWorkflow:
 class TestShowCommand:
     """Test show command."""
 
+    def test_bare_command_displays_selected_hunk_when_session_active(self, repo_with_changes):
+        """Test bare git-stage-batch behaves like show during an active session."""
+        git_stage_batch("start")
+
+        expected = git_stage_batch("show")
+        result = git_stage_batch()
+
+        assert result.returncode == 0
+        assert result.stdout == expected.stdout
+
     def test_show_displays_selected_hunk(self, repo_with_changes):
         """Test show displays selected hunk with line IDs."""
         git_stage_batch("start")


### PR DESCRIPTION
## Summary

- Invoking `git-stage-batch` with no subcommand now shows the selected hunk by default
- Tests cover the bare-command show dispatch
- Man page updated to describe the bare-command show behavior
- Website updated with bare-command show documentation