### PR TITLE
cli: Add Git-style pager support for non-interactive output

### DIFF
--- a/src/git_stage_batch/cli/main.py
+++ b/src/git_stage_batch/cli/main.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import os
 import sys
+from contextlib import nullcontext
 
 from ..exceptions import CommandError
 from .argument_parser import parse_command_line
 from .dispatch import dispatch_args
+from .pager import pager_output, should_page_output
 
 
 def main() -> None:
@@ -17,7 +19,9 @@ def main() -> None:
         if args is not None:
             if args.working_directory is not None:
                 os.chdir(args.working_directory)
-            dispatch_args(args)
+            pager_context = pager_output() if should_page_output(args) else nullcontext()
+            with pager_context:
+                dispatch_args(args)
         else:
             # Parsing failed
             sys.exit(2)

--- a/src/git_stage_batch/cli/pager.py
+++ b/src/git_stage_batch/cli/pager.py
@@ -1,0 +1,158 @@
+"""Pager support for non-interactive CLI commands."""
+
+from __future__ import annotations
+
+import argparse
+import io
+import os
+import sys
+from contextlib import contextmanager
+from typing import Iterator
+
+from ..utils.command import start_command
+from ..utils.git import run_git_command
+
+
+_PAGEABLE_COMMANDS = {
+    None,
+    "again",
+    "block-file",
+    "discard",
+    "include",
+    "list",
+    "show",
+    "skip",
+    "start",
+    "status",
+    "unblock-file",
+}
+
+
+def should_page_output(args: argparse.Namespace) -> bool:
+    """Return whether the selected CLI command should write through a pager."""
+    if not sys.stdout.isatty():
+        return False
+
+    if getattr(args, "interactive_flag", False):
+        return False
+
+    command = getattr(args, "command", None)
+    if command == "interactive":
+        return False
+
+    if getattr(args, "porcelain", False):
+        return False
+
+    return command in _PAGEABLE_COMMANDS
+
+
+def _resolve_git_pager() -> str | None:
+    """Resolve the pager command using Git's own precedence rules."""
+    result = run_git_command(["var", "GIT_PAGER"], check=False)
+    if result.returncode != 0:
+        return None
+
+    pager = result.stdout.strip()
+    if pager == "cat":
+        return None
+    return pager or None
+
+
+class _PagerStdout(io.TextIOBase):
+    """Text stream proxy that preserves tty detection while writing to a pager."""
+
+    def __init__(self, stream: io.TextIOBase, original_stdout: io.TextIOBase) -> None:
+        self._stream = stream
+        self._original_stdout = original_stdout
+        self._broken_pipe = False
+
+    def write(self, text: str) -> int:
+        if self._broken_pipe:
+            return len(text)
+
+        try:
+            written = self._stream.write(text)
+            return len(text) if written is None else written
+        except BrokenPipeError:
+            self._broken_pipe = True
+            return len(text)
+
+    def flush(self) -> None:
+        if self._broken_pipe:
+            return
+
+        try:
+            self._stream.flush()
+        except BrokenPipeError:
+            self._broken_pipe = True
+
+    def writable(self) -> bool:
+        return True
+
+    def close(self) -> None:
+        if self._stream.closed:
+            return
+
+        try:
+            self._stream.close()
+        except BrokenPipeError:
+            self._broken_pipe = True
+
+    def isatty(self) -> bool:
+        return self._original_stdout.isatty()
+
+    @property
+    def encoding(self) -> str | None:
+        return getattr(self._original_stdout, "encoding", None)
+
+    @property
+    def errors(self) -> str | None:
+        return getattr(self._original_stdout, "errors", None)
+
+    def fileno(self) -> int:
+        return self._original_stdout.fileno()
+
+
+@contextmanager
+def pager_output() -> Iterator[None]:
+    """Route stdout through the configured Git pager when one is available."""
+    pager = _resolve_git_pager()
+    if pager is None:
+        yield
+        return
+
+    read_fd, write_fd = os.pipe()
+    original_stdout = sys.stdout
+    pager_process = None
+
+    try:
+        pager_process = start_command(
+            ["sh", "-c", pager],
+            stdin_fd=read_fd,
+            capture_stdout=False,
+            capture_stderr=False,
+        )
+    except OSError:
+        os.close(read_fd)
+        os.close(write_fd)
+        yield
+        return
+
+    writer = io.TextIOWrapper(
+        os.fdopen(write_fd, "wb", closefd=True),
+        encoding=getattr(original_stdout, "encoding", None) or "utf-8",
+        errors=getattr(original_stdout, "errors", None) or "strict",
+        write_through=True,
+    )
+    proxy = _PagerStdout(writer, original_stdout)
+    sys.stdout = proxy
+    try:
+        yield
+    finally:
+        try:
+            proxy.flush()
+        finally:
+            sys.stdout = original_stdout
+            proxy.close()
+            if pager_process is not None:
+                pager_process.wait()

--- a/src/git_stage_batch/utils/command.py
+++ b/src/git_stage_batch/utils/command.py
@@ -442,16 +442,21 @@ def start_command(
     arguments: list[str],
     *,
     stdin: bool = False,
+    stdin_fd: int | None = None,
     extra_fds: list[CapturedFd] | None = None,
     cwd: str | None = None,
     env: dict[str, str] | None = None,
+    capture_stdout: bool = True,
+    capture_stderr: bool = True,
 ) -> StreamingProcess:
     """Start a subprocess with streaming I/O using fork/exec.
 
-    Stdout and stderr are always captured.
+    Stdout and stderr are captured by default.
     """
     if extra_fds is None:
         extra_fds = []
+    if stdin and stdin_fd is not None:
+        raise ValueError("stdin and stdin_fd are mutually exclusive")
 
     child_fds_seen = {1, 2}
     for captured in extra_fds:
@@ -467,8 +472,15 @@ def start_command(
     else:
         stdin_read_fd, stdin_write_fd = None, None
 
-    stdout_read_fd, stdout_write_fd = os.pipe()
-    stderr_read_fd, stderr_write_fd = os.pipe()
+    if capture_stdout:
+        stdout_read_fd, stdout_write_fd = os.pipe()
+    else:
+        stdout_read_fd, stdout_write_fd = None, None
+
+    if capture_stderr:
+        stderr_read_fd, stderr_write_fd = os.pipe()
+    else:
+        stderr_read_fd, stderr_write_fd = None, None
 
     # Create pipes for extra fds
     extra_pipes: dict[int, tuple[int, int]] = {}
@@ -484,10 +496,12 @@ def start_command(
         if stdin:
             os.close(stdin_read_fd)
             os.close(stdin_write_fd)
-        os.close(stdout_read_fd)
-        os.close(stdout_write_fd)
-        os.close(stderr_read_fd)
-        os.close(stderr_write_fd)
+        if capture_stdout:
+            os.close(stdout_read_fd)
+            os.close(stdout_write_fd)
+        if capture_stderr:
+            os.close(stderr_read_fd)
+            os.close(stderr_write_fd)
         for read_fd, write_fd in extra_pipes.values():
             os.close(read_fd)
             os.close(write_fd)
@@ -499,8 +513,10 @@ def start_command(
             # Close parent-side fds
             if stdin:
                 os.close(stdin_write_fd)
-            os.close(stdout_read_fd)
-            os.close(stderr_read_fd)
+            if capture_stdout:
+                os.close(stdout_read_fd)
+            if capture_stderr:
+                os.close(stderr_read_fd)
             for read_fd, _ in extra_pipes.values():
                 os.close(read_fd)
 
@@ -508,14 +524,19 @@ def start_command(
             if stdin:
                 os.dup2(stdin_read_fd, 0)
                 os.close(stdin_read_fd)
+            elif stdin_fd is not None:
+                os.dup2(stdin_fd, 0)
+                os.close(stdin_fd)
 
             # Set up stdout (fd 1)
-            os.dup2(stdout_write_fd, 1)
-            os.close(stdout_write_fd)
+            if capture_stdout:
+                os.dup2(stdout_write_fd, 1)
+                os.close(stdout_write_fd)
 
             # Set up stderr (fd 2)
-            os.dup2(stderr_write_fd, 2)
-            os.close(stderr_write_fd)
+            if capture_stderr:
+                os.dup2(stderr_write_fd, 2)
+                os.close(stderr_write_fd)
 
             # Set up extra fds
             for child_fd, (_, write_fd) in extra_pipes.items():
@@ -539,15 +560,21 @@ def start_command(
     # Close child-side fds
     if stdin:
         os.close(stdin_read_fd)
-    os.close(stdout_write_fd)
-    os.close(stderr_write_fd)
+    elif stdin_fd is not None:
+        os.close(stdin_fd)
+    if capture_stdout:
+        os.close(stdout_write_fd)
+    if capture_stderr:
+        os.close(stderr_write_fd)
     for _, write_fd in extra_pipes.values():
         os.close(write_fd)
 
     # Build fd maps
     output_fds: dict[int, int] = {}
-    output_fds[stdout_read_fd] = 1
-    output_fds[stderr_read_fd] = 2
+    if capture_stdout and stdout_read_fd is not None:
+        output_fds[stdout_read_fd] = 1
+    if capture_stderr and stderr_read_fd is not None:
+        output_fds[stderr_read_fd] = 2
 
     for child_fd, (read_fd, _) in extra_pipes.items():
         output_fds[read_fd] = child_fd
@@ -573,9 +600,12 @@ def stream_command(
     arguments: list[str],
     stdin_chunks: Iterable[bytes] | None = None,
     *,
+    stdin_fd: int | None = None,
     extra_fds: list[CapturedFd] | None = None,
     cwd: str | None = None,
     env: dict[str, str] | None = None,
+    capture_stdout: bool = True,
+    capture_stderr: bool = True,
 ) -> Iterator[CommandEvent]:
     """One-shot convenience wrapper for streaming a command.
 
@@ -590,9 +620,12 @@ def stream_command(
     proc = start_command(
         arguments,
         stdin=stdin_chunks is not None,
+        stdin_fd=stdin_fd,
         extra_fds=extra_fds,
         cwd=cwd,
         env=env,
+        capture_stdout=capture_stdout,
+        capture_stderr=capture_stderr,
     )
 
     try:

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -1,22 +1,26 @@
 """Tests for CLI entry point."""
 
 import sys
+from argparse import Namespace
+from importlib import import_module
 from unittest.mock import patch
 
 import pytest
 
-from git_stage_batch.cli.main import main
+main_module = import_module("git_stage_batch.cli.main")
 
 
 def test_main_callable():
     """Test that main is callable."""
-    assert main is not None
-    assert callable(main)
+    assert main_module.main is not None
+    assert callable(main_module.main)
 
 
 def test_main_with_no_args():
     """Test main with no arguments exits with error."""
     with patch.object(sys, 'argv', ['git-stage-batch']):
-        with pytest.raises(SystemExit) as exc_info:
-            main()
-        assert exc_info.value.code == 1
+        with patch.object(main_module, "dispatch_args", side_effect=main_module.CommandError("boom", exit_code=1)):
+            with patch.object(main_module, "parse_command_line", return_value=Namespace(working_directory=None)):
+                with pytest.raises(SystemExit) as exc_info:
+                    main_module.main()
+                assert exc_info.value.code == 1

--- a/tests/cli/test_pager.py
+++ b/tests/cli/test_pager.py
@@ -1,0 +1,100 @@
+"""Tests for CLI pager activation."""
+
+from __future__ import annotations
+
+import argparse
+from contextlib import contextmanager
+from importlib import import_module
+
+main_module = import_module("git_stage_batch.cli.main")
+from git_stage_batch.cli import pager as pager_module
+from git_stage_batch.cli.pager import should_page_output
+
+
+def _make_args(**overrides) -> argparse.Namespace:
+    defaults = {
+        "command": None,
+        "interactive_flag": False,
+        "porcelain": False,
+        "working_directory": None,
+    }
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+def test_should_page_show_when_stdout_is_tty(monkeypatch):
+    """Show output should page when attached to a tty."""
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+
+    assert should_page_output(_make_args(command="show")) is True
+
+
+def test_should_page_include_when_stdout_is_tty(monkeypatch):
+    """Include should page because it advances and prints the next hunk."""
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+
+    assert should_page_output(_make_args(command="include")) is True
+
+
+def test_should_not_page_porcelain_output(monkeypatch):
+    """Machine-readable output should bypass the pager."""
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+
+    assert should_page_output(_make_args(command="status", porcelain=True)) is False
+
+
+def test_should_not_page_interactive_mode(monkeypatch):
+    """Interactive mode manages its own terminal output."""
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+
+    assert should_page_output(_make_args(command="interactive")) is False
+    assert should_page_output(_make_args(command=None, interactive_flag=True)) is False
+
+
+def test_resolve_git_pager_treats_cat_as_disabled(monkeypatch):
+    """Git's sentinel pager value should bypass pager startup."""
+    monkeypatch.setattr(
+        pager_module,
+        "run_git_command",
+        lambda _args, check=False: argparse.Namespace(returncode=0, stdout="cat\n"),
+    )
+
+    assert pager_module._resolve_git_pager() is None
+
+
+def test_main_wraps_dispatch_with_pager(monkeypatch):
+    """Main should activate the pager for pageable commands."""
+    events: list[str] = []
+    args = _make_args(command="show")
+
+    monkeypatch.setattr(main_module, "parse_command_line", lambda _argv, quiet=False: args)
+    monkeypatch.setattr(main_module, "should_page_output", lambda _args: True)
+
+    @contextmanager
+    def fake_pager_output():
+        events.append("enter")
+        try:
+            yield
+        finally:
+            events.append("exit")
+
+    monkeypatch.setattr(main_module, "pager_output", fake_pager_output)
+    monkeypatch.setattr(main_module, "dispatch_args", lambda _args: events.append("dispatch"))
+
+    main_module.main()
+
+    assert events == ["enter", "dispatch", "exit"]
+
+
+def test_main_skips_pager_when_command_is_not_pageable(monkeypatch):
+    """Main should dispatch directly when paging is disabled."""
+    events: list[str] = []
+    args = _make_args(command="annotate")
+
+    monkeypatch.setattr(main_module, "parse_command_line", lambda _argv, quiet=False: args)
+    monkeypatch.setattr(main_module, "should_page_output", lambda _args: False)
+    monkeypatch.setattr(main_module, "dispatch_args", lambda _args: events.append("dispatch"))
+
+    main_module.main()
+
+    assert events == ["dispatch"]

--- a/tests/utils/test_stream_process.py
+++ b/tests/utils/test_stream_process.py
@@ -1,5 +1,6 @@
 """Tests for POSIX subprocess streaming."""
 
+import os
 import time
 
 import sys
@@ -102,6 +103,25 @@ class TestStdinHandling:
         stdin_closed_events = [e for e in events if isinstance(e, StdinClosedEvent)]
         assert len(stdin_closed_events) == 0
 
+    def test_external_stdin_fd_round_trip(self):
+        """Test providing an externally-owned stdin pipe to the child."""
+        read_fd, write_fd = os.pipe()
+        try:
+            proc = start_command(["cat"], stdin_fd=read_fd)
+            os.write(write_fd, b"hello\nworld\n")
+            os.close(write_fd)
+            write_fd = None
+
+            events = list(proc.stream())
+        finally:
+            if write_fd is not None:
+                os.close(write_fd)
+
+        output_events = [e for e in events if isinstance(e, OutputEvent) and e.fd == 1]
+        output_data = b"".join(e.data for e in output_events)
+
+        assert output_data == b"hello\nworld\n"
+
 
 
 
@@ -190,6 +210,16 @@ class TestExtraFdCapture:
                 ["printf", "hello"],
                 extra_fds=[CapturedFd(2)]
             )
+
+    def test_stdin_and_stdin_fd_are_mutually_exclusive(self):
+        """Test that stdin pipe modes cannot be combined."""
+        read_fd, write_fd = os.pipe()
+        try:
+            with pytest.raises(ValueError, match="mutually exclusive"):
+                start_command(["cat"], stdin=True, stdin_fd=read_fd)
+        finally:
+            os.close(read_fd)
+            os.close(write_fd)
 
 
 class TestEventOrdering:

--- a/tests/utils/test_stream_process.py
+++ b/tests/utils/test_stream_process.py
@@ -341,6 +341,21 @@ class TestEdgeCases:
         assert len(exit_events) == 1
         assert exit_events[0].exit_code == 0
 
+    def test_no_captured_output_fds_exits_cleanly(self):
+        """Test commands can run without capturing stdout, stderr, or extra fds."""
+        events = list(stream_command(
+            ["printf", "hello"],
+            capture_stdout=False,
+            capture_stderr=False,
+        ))
+
+        output_events = [e for e in events if isinstance(e, OutputEvent)]
+        exit_events = [e for e in events if isinstance(e, ExitEvent)]
+
+        assert output_events == []
+        assert len(exit_events) == 1
+        assert exit_events[0].exit_code == 0
+
     def test_events_can_only_be_called_once(self):
         """Test that events() can only be called once on a StreamingProcess."""
         proc = start_command(["printf", "hello"])


### PR DESCRIPTION
## Summary

The CLI displays selected hunks directly on stdout for
non-interactive commands such as show, include, discard, and skip.

Users reviewing large selected hunks receive the full output in one
terminal dump, making it harder to inspect when commands advance to
another large hunk.

This series addresses that by routing pageable CLI stdout through a
Git-style pager subprocess, resolved via `git var GIT_PAGER` to
respect the full Git precedence chain. Interactive and porcelain
output continue to bypass the pager.

- Add optional stdout/stderr capture and caller-owned stdin fd
  support to the subprocess streaming layer
- Resolve the pager through `git var GIT_PAGER` and treat the `cat`
  sentinel as pager disablement
- Wrap non-interactive CLI dispatch in a pager context manager that
  preserves tty detection for downstream color/formatting decisions
- Handle `BrokenPipeError` throughout the pager proxy for early pager
  exit

## Test plan

- [x] Subprocess streaming: external stdin fd round-trip, mutual
  exclusion of stdin modes, no-capture-fd path
- [x] Pager decision logic: pageable commands, porcelain bypass,
  interactive bypass, tty check
- [x] Pager resolution: `cat` sentinel treated as disabled
- [x] Main entry point: pager context activation and bypass paths