### PR TITLE
Add --files argument for multi-file pattern operations

### DIFF
--- a/completions/git-stage-batch
+++ b/completions/git-stage-batch
@@ -10,6 +10,40 @@ __git_stage_batch_list_batches()
     } | sort -u
 }
 
+__git_stage_batch_find_from_batch()
+{
+    local i
+    for ((i=1; i < ${#words[@]}; i++)); do
+        if [[ "${words[i]}" == "--from" && $((i + 1)) -lt ${#words[@]} ]]; then
+            printf '%s\n' "${words[i + 1]}"
+            return
+        fi
+    done
+}
+
+__git_stage_batch_complete_files()
+{
+    local from_batch
+    from_batch="$(__git_stage_batch_find_from_batch)"
+
+    if [[ -n "$from_batch" ]]; then
+        git-stage-batch __complete-files --from "$from_batch" "$cur" 2>/dev/null
+    else
+        git-stage-batch __complete-files "$cur" 2>/dev/null
+    fi
+}
+
+__git_stage_batch_set_nospace_for_dirs()
+{
+    local reply
+    for reply in "${COMPREPLY[@]}"; do
+        if [[ "$reply" == */ ]]; then
+            compopt -o nospace 2>/dev/null
+            return
+        fi
+    done
+}
+
 _git_stage_batch()
 {
     local cur prev words cword
@@ -41,12 +75,17 @@ _git_stage_batch()
                     COMPREPLY=($(compgen -W "$(__git_stage_batch_list_batches)" -- "$cur"))
                     return
                     ;;
+                --file|--files)
+                    mapfile -t COMPREPLY < <(__git_stage_batch_complete_files)
+                    __git_stage_batch_set_nospace_for_dirs
+                    return
+                    ;;
                 --line)
                     # Line IDs - no completion
                     return
                     ;;
             esac
-            COMPREPLY=($(compgen -W "--porcelain --from --line" -- "$cur"))
+            COMPREPLY=($(compgen -W "--porcelain --from --file --files --line" -- "$cur"))
             ;;
         include)
             case "$prev" in
@@ -58,17 +97,23 @@ _git_stage_batch()
                     COMPREPLY=($(compgen -W "$(__git_stage_batch_list_batches)" -- "$cur"))
                     return
                     ;;
+                --file|--files)
+                    mapfile -t COMPREPLY < <(__git_stage_batch_complete_files)
+                    __git_stage_batch_set_nospace_for_dirs
+                    return
+                    ;;
                 --line)
                     # Line IDs - no completion
                     return
                     ;;
             esac
-            COMPREPLY=($(compgen -W "--file --from --to --line" -- "$cur"))
+            COMPREPLY=($(compgen -W "--file --files --from --to --line" -- "$cur"))
             ;;
         skip)
             case "$prev" in
-                --file)
-                    _filedir
+                --file|--files)
+                    mapfile -t COMPREPLY < <(__git_stage_batch_complete_files)
+                    __git_stage_batch_set_nospace_for_dirs
                     return
                     ;;
                 --line)
@@ -76,7 +121,7 @@ _git_stage_batch()
                     return
                     ;;
             esac
-            COMPREPLY=($(compgen -W "--file --line" -- "$cur"))
+            COMPREPLY=($(compgen -W "--file --files --line" -- "$cur"))
             ;;
         discard)
             case "$prev" in
@@ -88,12 +133,17 @@ _git_stage_batch()
                     COMPREPLY=($(compgen -W "$(__git_stage_batch_list_batches)" -- "$cur"))
                     return
                     ;;
+                --file|--files)
+                    mapfile -t COMPREPLY < <(__git_stage_batch_complete_files)
+                    __git_stage_batch_set_nospace_for_dirs
+                    return
+                    ;;
                 --line)
                     # Line IDs - no completion
                     return
                     ;;
             esac
-            COMPREPLY=($(compgen -W "--file --from --to --line" -- "$cur"))
+            COMPREPLY=($(compgen -W "--file --files --from --to --line" -- "$cur"))
             ;;
         apply)
             case "$prev" in
@@ -101,12 +151,17 @@ _git_stage_batch()
                     COMPREPLY=($(compgen -W "$(__git_stage_batch_list_batches)" -- "$cur"))
                     return
                     ;;
+                --file|--files)
+                    mapfile -t COMPREPLY < <(__git_stage_batch_complete_files)
+                    __git_stage_batch_set_nospace_for_dirs
+                    return
+                    ;;
                 --line)
                     # Line IDs - no completion
                     return
                     ;;
             esac
-            COMPREPLY=($(compgen -W "--from --line --file" -- "$cur"))
+            COMPREPLY=($(compgen -W "--from --line --file --files" -- "$cur"))
             ;;
         reset)
             case "$prev" in
@@ -114,12 +169,17 @@ _git_stage_batch()
                     COMPREPLY=($(compgen -W "$(__git_stage_batch_list_batches)" -- "$cur"))
                     return
                     ;;
+                --file|--files)
+                    mapfile -t COMPREPLY < <(__git_stage_batch_complete_files)
+                    __git_stage_batch_set_nospace_for_dirs
+                    return
+                    ;;
                 --line)
                     # Line IDs - no completion
                     return
                     ;;
             esac
-            COMPREPLY=($(compgen -W "--from --to --line --file" -- "$cur"))
+            COMPREPLY=($(compgen -W "--from --to --line --file --files" -- "$cur"))
             ;;
         status)
             COMPREPLY=($(compgen -W "--porcelain" -- "$cur"))

--- a/docs/batches.md
+++ b/docs/batches.md
@@ -155,6 +155,13 @@ Displays the diff representing all changes accumulated in the batch, showing wha
 
 Filter the display to show only specific line IDs from the batch.
 
+**Pattern-based filtering:**
+```bash
+❯ git-stage-batch show --from batch-name --files "src/**/*.py" "!src/vendor/**"
+```
+
+When `--files` resolves to multiple files, only the final displayed file remains selected for later `--line` operations.
+
 ---
 
 ## `include --from BATCH`
@@ -188,6 +195,11 @@ Stage changes from the batch for the selected hunk's file only. Use this during 
 ```
 
 Stage changes from the batch for `src/config.py` only, without needing a selected hunk. Useful for applying specific files from multi-file batches outside of an active staging session.
+
+**Pattern-based staging:**
+```bash
+❯ git-stage-batch include --from batch-name --files "src/**/*.py" "!src/vendor/**"
+```
 
 **Example - Selective file application:**
 ```bash
@@ -252,6 +264,11 @@ Remove batch changes from the working tree for the selected hunk's file only. Us
 
 Remove batch changes for `src/experimental.py` only, without needing a selected hunk. Useful for discarding specific files from multi-file batches.
 
+**Pattern-based discarding:**
+```bash
+❯ git-stage-batch discard --from batch-name --files "src/**/*.py" "!src/vendor/**"
+```
+
 !!! warning "Destructive Operation"
     This permanently removes changes from your working tree.
 
@@ -312,6 +329,11 @@ Apply batch changes to the working tree for the selected hunk's file only. Use t
 ```
 
 Apply batch changes for `src/debug.py` only to the working tree, without needing a selected hunk. Useful for testing specific files from multi-file batches.
+
+**Pattern-based application:**
+```bash
+❯ git-stage-batch apply --from batch-name --files "src/**/*.py" "!src/vendor/**"
+```
 
 !!! warning "Merge-Based Application"
     `apply --from BATCH` uses the same structural merge as `include --from BATCH`,
@@ -374,6 +396,11 @@ Clears all files from the batch.
 ```
 
 Removes only `src/debug.py` from the batch. If `--file` is used without a path, the selected hunk's file is used.
+
+**Reset files by pattern:**
+```bash
+❯ git-stage-batch reset --from batch-name --files "src/**/*.py" "!src/vendor/**"
+```
 
 **Reset selected lines from a file:**
 ```

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -23,7 +23,7 @@ Resets state if a session is already in progress.
 
 ---
 
-### `show [--file [PATH]]`
+### `show [--file [PATH] | --files PATTERN...]`
 
 Display the cached "selected" hunk or an entire file's changes.
 
@@ -42,13 +42,24 @@ Display the cached "selected" hunk or an entire file's changes.
 ❯ git-stage-batch show --file src/config.py
 ```
 
-When `--file` is used, displays all changes from the entire file (all hunks merged into a unified view), rather than just the selected hunk. This is useful for reviewing all changes in a file before staging or discarding them.
+**Show all changes from files matched by Git-style patterns:**
+```bash
+❯ git-stage-batch show --files "src/**/*.py" "!src/vendor/**"
+```
+
+When `--file` or `--files` is used, `show` displays all changes from the resolved file or files (all hunks merged into a unified view), rather than just the selected hunk. This is useful for reviewing all changes in a file before staging or discarding them.
 
 **Options:**
 - `--file [PATH]`: Display entire file instead of single hunk
   - Without PATH: uses selected hunk's file
   - With PATH: displays specified file
+- `--files PATTERN...`: Resolve one or more Git-style patterns to files
+  - Patterns follow Git's ignore matcher semantics, including `*`, `**`, `?`, character classes, and ordered `!` exclusions
+  - Resolution is performed against the current changed-file set
+  - `--file` and `--files` are mutually exclusive
 - `--porcelain`: Exit silently with status code only (no output)
+
+When `--files` resolves to multiple files, `show` displays each file in order. Only the final displayed file remains selected for later `--line` operations, so earlier files are shown without selectable gutter IDs.
 
 **Exit codes:**
 - `0` if hunk/file has changes
@@ -282,6 +293,7 @@ Stages all hunks from the specified file and advances to the next file. When a p
 **Use cases:**
 - `--file` (no path): Stage all hunks from the file of the selected hunk
 - `--file PATH`: Stage all hunks from the specified file, even if it's not the selected file
+- `--files PATTERN...`: Stage all hunks from files matched by Git-style patterns
 
 **Example workflow:**
 ```bash
@@ -294,6 +306,11 @@ Stages all hunks from the specified file and advances to the next file. When a p
 
 # Continue with selected file
 ❯ git-stage-batch include
+```
+
+**Pattern-based staging:**
+```bash
+❯ git-stage-batch include --files "src/**/*.py" "!src/vendor/**"
 ```
 
 ---
@@ -313,6 +330,11 @@ Skip all hunks from a file.
 ```
 
 All hunks from the file are marked as skipped and can be revisited with `again`.
+
+**Skip files by pattern:**
+```bash
+❯ git-stage-batch skip --files "docs/**/*.md" "scripts/*.sh"
+```
 
 ---
 
@@ -335,6 +357,7 @@ Removes all changes from the specified file. When a path is provided, you can di
 **Use cases:**
 - `--file` (no path): Discard the entire file of the selected hunk
 - `--file PATH`: Discard the specified file, even if it's not the selected file
+- `--files PATTERN...`: Discard all matched files as complete units
 
 !!! warning "Destructive Operation"
     This permanently removes the entire file from your working tree.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -111,6 +111,20 @@ auth.py :: @@ -10,5 +10,5 @@
 
 ---
 
+## Pattern-Based: Skip a Set of Files
+
+Use Git-style patterns to operate on a group of files without repeating `--file`:
+
+```bash
+❯ git-stage-batch skip --files "docs/**/*.md" "!docs/release-notes.md"
+✓ Skipped 2 hunks from docs/usage.md
+✓ Skipped 1 hunk from docs/tutorial.md
+```
+
+Patterns use Git's matcher semantics, so ordered exclusions work the same way they do in `.gitignore`.
+
+---
+
 ## Block Build Artifacts
 
 Permanently exclude generated files:

--- a/docs/git-stage-batch.1.in
+++ b/docs/git-stage-batch.1.in
@@ -86,6 +86,15 @@ Number of context lines in diff output (default: 3).
 Reprint the cached "selected" hunk.
 .RS
 .TP
+.B \-\-file \fR[\fIPATH\fR]
+Show all changes from one file. Without PATH, uses the selected hunk's file.
+.TP
+.B \-\-files \fIPATTERN\fR...
+Show all changes from files matched by Git-style patterns.
+Patterns use Git's ignore matcher semantics, including ordered \fB!\fR exclusions.
+When multiple files are shown, only the final displayed file remains selected
+for later \fB\-\-line\fR operations.
+.TP
 .B \-\-porcelain
 Exit silently with status code only (0 if hunk exists, 1 if no hunk).
 Useful for scripts checking hunk availability without output.
@@ -165,16 +174,25 @@ Overwrite changes made after the undo.
 Stage all hunks from the selected file.
 Advances to the next file after staging all hunks.
 .TP
+.B include \-\-files \fIPATTERN\fR...
+Stage all hunks from files matched by Git-style patterns.
+.TP
 .B skip \-\-file \fR[\fIPATH\fR]
 Skip all hunks from a file.
 If PATH is omitted, uses the selected hunk's file.
 All hunks from the file are marked as skipped and can be revisited with
 .BR again .
 .TP
+.B skip \-\-files \fIPATTERN\fR...
+Skip all hunks from files matched by Git-style patterns.
+.TP
 .B discard \-\-file
 Discard the entire selected file from the working tree.
 .B WARNING:
 This permanently removes the entire file from your working tree.
+.TP
+.B discard \-\-files \fIPATTERN\fR...
+Discard all matched files from the working tree as complete units.
 .SS Line-Level Operations
 .TP
 .B include \-\-line \fILINE_IDS\fR
@@ -270,32 +288,37 @@ Add or update the description for a batch.
 .PP
 The following commands accept \fB\-\-from\fR flags to work with batches:
 .TP
-.B show \-\-from \fIBATCH\fR [\fB\-\-line\fR \fILINE_IDS\fR]
+.B show \-\-from \fIBATCH\fR [\fB\-\-line\fR \fILINE_IDS\fR | \fB\-\-file\fR [\fIPATH\fR] | \fB\-\-files\fR \fIPATTERN\fR...]
 Show the accumulated changes stored in a batch.
 Use \fB\-\-line\fR to filter display to specific line IDs.
+Use \fB\-\-file\fR or \fB\-\-files\fR to limit display to specific batch files.
 .TP
-.B include \-\-from \fIBATCH\fR [\fB\-\-line\fR \fILINE_IDS\fR | \fB\-\-file\fR]
+.B include \-\-from \fIBATCH\fR [\fB\-\-line\fR \fILINE_IDS\fR | \fB\-\-file\fR [\fIPATH\fR] | \fB\-\-files\fR \fIPATTERN\fR...]
 Stage the changes from a batch to the index. Fails if the batch's changes
 cannot be applied cleanly to the selected state.
 Use \fB\-\-line\fR to stage only specific lines from the batch.
-Use \fB\-\-file\fR to apply all hunks from the batch that affect the selected file.
+Use \fB\-\-file\fR to apply one file from the batch.
+Use \fB\-\-files\fR to apply all batch files matched by Git-style patterns.
 .TP
-.B discard \-\-from \fIBATCH\fR [\fB\-\-line\fR \fILINE_IDS\fR | \fB\-\-file\fR]
+.B discard \-\-from \fIBATCH\fR [\fB\-\-line\fR \fILINE_IDS\fR | \fB\-\-file\fR [\fIPATH\fR] | \fB\-\-files\fR \fIPATTERN\fR...]
 Remove batch changes from the working tree. Fails if the batch's changes
 cannot be reversed cleanly. Does not delete the batch.
 Use \fB\-\-line\fR to discard only specific lines from the batch.
-Use \fB\-\-file\fR to reverse all hunks from the batch that affect the selected file.
+Use \fB\-\-file\fR to reverse one file from the batch.
+Use \fB\-\-files\fR to reverse all batch files matched by Git-style patterns.
 .TP
-.B apply \-\-from \fIBATCH\fR [\fB\-\-line\fR \fILINE_IDS\fR | \fB\-\-file\fR]
+.B apply \-\-from \fIBATCH\fR [\fB\-\-line\fR \fILINE_IDS\fR | \fB\-\-file\fR [\fIPATH\fR] | \fB\-\-files\fR \fIPATTERN\fR...]
 Apply batch changes to the working tree without staging them.
 This adds the batch's changes to your working tree while keeping the index clean.
 Fails if the batch's changes cannot be applied cleanly.
 Use \fB\-\-line\fR to apply only specific lines from the batch.
-Use \fB\-\-file\fR to apply all hunks from the batch that affect the selected file.
+Use \fB\-\-file\fR to apply one file from the batch.
+Use \fB\-\-files\fR to apply all batch files matched by Git-style patterns.
 .TP
-.B reset \-\-from \fIBATCH\fR [\fB\-\-to\fR \fIDEST_BATCH\fR] [\fB\-\-line\fR \fILINE_IDS\fR | \fB\-\-file\fR [\fIPATH\fR]]
+.B reset \-\-from \fIBATCH\fR [\fB\-\-to\fR \fIDEST_BATCH\fR] [\fB\-\-line\fR \fILINE_IDS\fR | \fB\-\-file\fR [\fIPATH\fR] | \fB\-\-files\fR \fIPATTERN\fR...]
 Remove claims from a batch without changing the working tree.
 Use \fB\-\-file\fR with a path to reset only that file from the batch.
+Use \fB\-\-files\fR to reset all matched batch files.
 Use \fB\-\-line\fR with \fB\-\-file\fR to reset specific line claims from a file.
 Use \fB\-\-to\fR to move the reset claims into another batch before removing
 them from the source batch.
@@ -336,18 +359,20 @@ git-stage-batch sift \-\-from feature-cleanups \-\-to feature-cleanups
 .PP
 The following commands accept \fB\-\-to\fR flags to save changes to batches:
 .TP
-.B include \-\-to \fIBATCH\fR [\fB\-\-line\fR \fILINE_IDS\fR | \fB\-\-file\fR]
+.B include \-\-to \fIBATCH\fR [\fB\-\-line\fR \fILINE_IDS\fR | \fB\-\-file\fR [\fIPATH\fR] | \fB\-\-files\fR \fIPATTERN\fR...]
 Save the selected hunk to a batch instead of just skipping it.
 Auto-creates the batch if it doesn't exist.
 Use \fB\-\-line\fR to save only specific lines to the batch.
-Use \fB\-\-file\fR to save the entire selected file to the batch.
+Use \fB\-\-file\fR to save one file to the batch.
+Use \fB\-\-files\fR to save all matched files to the batch.
 .TP
-.B discard \-\-to \fIBATCH\fR [\fB\-\-line\fR \fILINE_IDS\fR | \fB\-\-file\fR]
+.B discard \-\-to \fIBATCH\fR [\fB\-\-line\fR \fILINE_IDS\fR | \fB\-\-file\fR [\fIPATH\fR] | \fB\-\-files\fR \fIPATTERN\fR...]
 Save the selected hunk to a batch, then discard it from the working tree.
 Auto-creates the batch if it doesn't exist.
 Useful for saving changes before removing them, allowing later recovery.
 Use \fB\-\-line\fR to save and discard only specific lines.
-Use \fB\-\-file\fR to save and discard the entire selected file.
+Use \fB\-\-file\fR to save and discard one file.
+Use \fB\-\-files\fR to save and discard all matched files.
 .SH AUTHOR
 Written by Ray Strode.
 .SH REPORTING BUGS

--- a/src/git_stage_batch/batch/selection.py
+++ b/src/git_stage_batch/batch/selection.py
@@ -14,6 +14,7 @@ from .ownership import (
 from ..core.line_selection import parse_line_selection
 from ..exceptions import exit_with_error
 from ..i18n import _
+from ..utils.file_patterns import resolve_gitignore_style_patterns
 
 if TYPE_CHECKING:
     from ..exceptions import AtomicUnitError
@@ -24,6 +25,7 @@ def resolve_batch_file_scope(
     batch_name: str,
     all_files: dict[str, dict],
     file: Optional[str] = None,
+    patterns: Optional[list[str]] = None,
 ) -> dict[str, dict]:
     """Resolve which files from a batch to operate on.
 
@@ -34,6 +36,7 @@ def resolve_batch_file_scope(
             - None: operate on all files in batch
             - "": use currently selected hunk's file
             - path: specific file path
+        patterns: Optional gitignore-style file patterns to resolve against batch files
 
     Returns:
         Dictionary of file paths to file metadata for selected files
@@ -57,6 +60,16 @@ def resolve_batch_file_scope(
 
         target_file = get_batch_file_for_line_operation(batch_name, file_to_use)
         return {target_file: all_files[target_file]}
+    if patterns is not None:
+        resolved_files = resolve_gitignore_style_patterns(all_files.keys(), patterns)
+        if not resolved_files:
+            exit_with_error(
+                _("No files in batch '{name}' matched: {patterns}").format(
+                    name=batch_name,
+                    patterns=", ".join(patterns),
+                )
+            )
+        return {file_path: all_files[file_path] for file_path in resolved_files}
     else:
         # All files in batch (default)
         return all_files

--- a/src/git_stage_batch/cli/argument_parser.py
+++ b/src/git_stage_batch/cli/argument_parser.py
@@ -5,11 +5,15 @@ from __future__ import annotations
 import argparse
 import subprocess
 import sys
+from collections.abc import Callable
 
 from .. import __version__
+from ..batch.validation import batch_exists
 from .. import commands
+from ..batch.query import read_batch_metadata
 from ..exceptions import CommandError
 from ..i18n import _
+from ..utils.file_patterns import list_changed_files, resolve_gitignore_style_patterns
 
 
 class GitHelpArgumentParser(argparse.ArgumentParser):
@@ -30,6 +34,98 @@ class GitHelpArgumentParser(argparse.ArgumentParser):
 
         # Fall back to standard argparse help
         super().print_help(file)
+
+
+def _add_file_argument(parser: argparse.ArgumentParser, help_text: str) -> None:
+    """Add a single-file argument that supports omitted values."""
+    parser.add_argument(
+        "--file",
+        nargs="?",
+        const="",
+        default=None,
+        metavar="PATH",
+        help=help_text,
+    )
+    parser.add_argument(
+        "--files",
+        dest="file_patterns",
+        nargs="+",
+        default=None,
+        metavar="PATTERN",
+        help=_("Resolve one or more gitignore-style PATTERNs to files."),
+    )
+
+
+def _validate_file_inputs(
+    file_arg: str | None,
+    file_patterns: list[str] | None,
+) -> None:
+    """Validate cross-argument rules for file-scoped operations."""
+    if file_arg is not None and file_patterns is not None:
+        raise CommandError(_("Cannot use --file together with --files."))
+
+
+def _run_for_each_file(
+    file_arg: str | list[str] | None,
+    callback: Callable[[str | None], None],
+    *,
+    line_ids: str | None = None,
+) -> None:
+    """Run a callback once per resolved file argument."""
+    if isinstance(file_arg, list) and line_ids is not None:
+        raise CommandError(_("Cannot use --lines with multiple files."))
+    if isinstance(file_arg, list):
+        for file in file_arg:
+            callback(file)
+        return
+    callback(file_arg)
+
+
+def _resolve_live_file_scope(
+    file_arg: str | None,
+    file_patterns: list[str] | None,
+) -> str | list[str] | None:
+    """Resolve single-file or pattern-based live file scope."""
+    _validate_file_inputs(file_arg, file_patterns)
+    if file_patterns is None:
+        return file_arg
+
+    resolved_files = resolve_gitignore_style_patterns(list_changed_files(), file_patterns)
+    if not resolved_files:
+        raise CommandError(
+            _("No changed files matched: {patterns}").format(
+                patterns=", ".join(file_patterns),
+            )
+        )
+    if len(resolved_files) == 1:
+        return resolved_files[0]
+    return resolved_files
+
+
+def _resolve_batch_file_scope(
+    batch_name: str,
+    file_arg: str | None,
+    file_patterns: list[str] | None,
+) -> str | list[str] | None:
+    """Resolve single-file or pattern-based batch file scope."""
+    _validate_file_inputs(file_arg, file_patterns)
+    if file_patterns is None:
+        return file_arg
+    if not batch_exists(batch_name):
+        raise CommandError(_("Batch '{name}' does not exist").format(name=batch_name))
+
+    metadata = read_batch_metadata(batch_name)
+    resolved_files = resolve_gitignore_style_patterns(metadata.get("files", {}).keys(), file_patterns)
+    if not resolved_files:
+        raise CommandError(
+            _("No files in batch '{name}' matched: {patterns}").format(
+                name=batch_name,
+                patterns=", ".join(file_patterns),
+            )
+        )
+    if len(resolved_files) == 1:
+        return resolved_files[0]
+    return resolved_files
 
 
 def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Namespace | None:
@@ -172,26 +268,57 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
         metavar="IDS",
         help=_("Show only specific line IDs (e.g., '1,3,5-7')"),
     )
-    parser_show.add_argument(
-        "--file",
-        nargs="?",
-        const="",
-        default=None,
-        metavar="PATH",
-        help=_("Operate on entire file (live working tree state). "
-               "If PATH omitted, uses selected hunk's file. "
-               "With --line, operates on line IDs from entire file."),
+    _add_file_argument(
+        parser_show,
+        _("Operate on entire file (live working tree state). "
+          "If PATH omitted, uses selected hunk's file. "
+          "With --line, operates on line IDs from entire file."),
     )
     parser_show.add_argument(
         "--porcelain",
         action="store_true",
         help=_("Output JSON for scripting instead of human-readable text"),
     )
-    parser_show.set_defaults(func=lambda args: (
-        commands.command_show_from_batch(args.from_batch, args.line_ids, args.file) if args.from_batch
-        else commands.command_show(file=args.file, porcelain=args.porcelain) if args.line_ids or args.file is not None
-        else commands.command_show(porcelain=args.porcelain)
-    ))
+    def dispatch_show(args: argparse.Namespace) -> None:
+        resolved_file_scope = (
+            _resolve_batch_file_scope(args.from_batch, args.file, args.file_patterns)
+            if args.from_batch
+            else _resolve_live_file_scope(args.file, args.file_patterns)
+        )
+        if args.from_batch:
+            if isinstance(resolved_file_scope, list):
+                if args.line_ids:
+                    raise CommandError(_("Cannot use --lines with multiple files."))
+                last_index = len(resolved_file_scope) - 1
+                for index, file in enumerate(resolved_file_scope):
+                    commands.command_show_from_batch(
+                        args.from_batch,
+                        args.line_ids,
+                        file,
+                        selectable=(index == last_index),
+                    )
+            else:
+                commands.command_show_from_batch(args.from_batch, args.line_ids, resolved_file_scope)
+            return
+        if args.line_ids or resolved_file_scope is not None:
+            if isinstance(resolved_file_scope, list) and args.porcelain:
+                raise CommandError(_("Cannot use --porcelain with multiple files."))
+            if isinstance(resolved_file_scope, list):
+                if args.line_ids:
+                    raise CommandError(_("Cannot use --lines with multiple files."))
+                last_index = len(resolved_file_scope) - 1
+                for index, file in enumerate(resolved_file_scope):
+                    commands.command_show(
+                        file=file,
+                        porcelain=args.porcelain,
+                        selectable=(index == last_index),
+                    )
+            else:
+                commands.command_show(file=resolved_file_scope, porcelain=args.porcelain)
+            return
+        commands.command_show(porcelain=args.porcelain)
+
+    parser_show.set_defaults(func=dispatch_show)
 
     # status - Show selected session status
     parser_status = subparsers.add_parser(
@@ -219,16 +346,12 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
         metavar="IDS",
         help=_("Stage only specific line IDs (e.g., '1,3,5-7')"),
     )
-    parser_include.add_argument(
-        "--file",
-        nargs="?",
-        const="",
-        default=None,
-        metavar="PATH",
-        help=_("Operate on entire file (live working tree state). "
-               "If PATH omitted, uses selected hunk's file. "
-               "Without --line, stages entire file. "
-               "With --line, operates on line IDs from entire file."),
+    _add_file_argument(
+        parser_include,
+        _("Operate on entire file (live working tree state). "
+          "If PATH omitted, uses selected hunk's file. "
+          "Without --line, stages entire file. "
+          "With --line, operates on line IDs from entire file."),
     )
     parser_include.add_argument(
         "--from",
@@ -250,29 +373,48 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
     )
 
     def dispatch_include(args: argparse.Namespace) -> None:
+        resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
+        resolved_batch_scope = (
+            _resolve_batch_file_scope(args.from_batch, args.file, args.file_patterns)
+            if args.from_batch else None
+        )
         if args.as_text is not None:
             if args.line_ids and args.from_batch and not args.to_batch:
+                if isinstance(resolved_batch_scope, list):
+                    raise CommandError(_("Cannot use --lines with multiple files."))
                 commands.command_include_from_batch(
                     args.from_batch,
                     args.line_ids,
-                    args.file,
+                    file=resolved_batch_scope,
                     replacement_text=args.as_text,
                 )
                 return
             if args.line_ids and not args.from_batch and not args.to_batch:
-                commands.command_include_line_as(args.line_ids, args.as_text, file=args.file)
+                if isinstance(resolved_live_scope, list):
+                    raise CommandError(_("Cannot use --lines with multiple files."))
+                commands.command_include_line_as(args.line_ids, args.as_text, file=resolved_live_scope)
                 return
             raise CommandError(
                 _("`include --as` requires `--line` and does not support `--to`.")
             )
         if args.from_batch:
-            commands.command_include_from_batch(args.from_batch, args.line_ids, args.file)
+            _run_for_each_file(
+                resolved_batch_scope,
+                lambda file: commands.command_include_from_batch(args.from_batch, args.line_ids, file),
+                line_ids=args.line_ids,
+            )
         elif args.to_batch:
-            commands.command_include_to_batch(args.to_batch, args.line_ids, args.file)
+            _run_for_each_file(
+                resolved_live_scope,
+                lambda file: commands.command_include_to_batch(args.to_batch, args.line_ids, file),
+                line_ids=args.line_ids,
+            )
         elif args.line_ids:
-            commands.command_include_line(args.line_ids, file=args.file)
-        elif args.file is not None:
-            commands.command_include_file(args.file)
+            if isinstance(resolved_live_scope, list):
+                raise CommandError(_("Cannot use --lines with multiple files."))
+            commands.command_include_line(args.line_ids, file=resolved_live_scope)
+        elif resolved_live_scope is not None:
+            _run_for_each_file(resolved_live_scope, commands.command_include_file)
         else:
             commands.command_include()
 
@@ -291,21 +433,25 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
         metavar="IDS",
         help=_("Skip only specific line IDs (e.g., '1,3,5-7')"),
     )
-    parser_skip.add_argument(
-        "--file",
-        nargs="?",
-        const="",
-        default=None,
-        metavar="PATH",
-        help=_("Operate on entire file (live working tree state). "
-               "If PATH omitted, uses selected hunk's file. "
-               "Without --line, skips all hunks from the file."),
+    _add_file_argument(
+        parser_skip,
+        _("Operate on entire file (live working tree state). "
+          "If PATH omitted, uses selected hunk's file. "
+          "Without --line, skips all hunks from the file."),
     )
-    parser_skip.set_defaults(func=lambda args: (
-        commands.command_skip_line(args.line_ids) if args.line_ids
-        else commands.command_skip_file(args.file) if args.file is not None
-        else commands.command_skip()
-    ))
+
+    def dispatch_skip(args: argparse.Namespace) -> None:
+        resolved_file_scope = _resolve_live_file_scope(args.file, args.file_patterns)
+        if args.line_ids:
+            if isinstance(resolved_file_scope, list):
+                raise CommandError(_("Cannot use --lines with multiple files."))
+            commands.command_skip_line(args.line_ids)
+        elif resolved_file_scope is not None:
+            _run_for_each_file(resolved_file_scope, commands.command_skip_file)
+        else:
+            commands.command_skip()
+
+    parser_skip.set_defaults(func=dispatch_skip)
 
     # discard - Remove the selected hunk from working tree
     parser_discard = subparsers.add_parser(
@@ -320,16 +466,12 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
         metavar="IDS",
         help=_("Discard only specific line IDs (e.g., '1,3,5-7')"),
     )
-    parser_discard.add_argument(
-        "--file",
-        nargs="?",
-        const="",
-        default=None,
-        metavar="PATH",
-        help=_("Operate on entire file (live working tree state). "
-               "If PATH omitted, uses selected hunk's file. "
-               "Without --line, discards entire file. "
-               "With --line, operates on line IDs from entire file."),
+    _add_file_argument(
+        parser_discard,
+        _("Operate on entire file (live working tree state). "
+          "If PATH omitted, uses selected hunk's file. "
+          "Without --line, discards entire file. "
+          "With --line, operates on line IDs from entire file."),
     )
     parser_discard.add_argument(
         "--from",
@@ -351,26 +493,43 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
     )
 
     def dispatch_discard(args: argparse.Namespace) -> None:
+        resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
+        resolved_batch_scope = (
+            _resolve_batch_file_scope(args.from_batch, args.file, args.file_patterns)
+            if args.from_batch else None
+        )
         if args.as_text is not None:
             if args.to_batch and args.line_ids and not args.from_batch:
+                if isinstance(resolved_live_scope, list):
+                    raise CommandError(_("Cannot use --lines with multiple files."))
                 commands.command_discard_line_as_to_batch(
                     args.to_batch,
                     args.line_ids,
                     args.as_text,
-                    file=args.file,
+                    file=resolved_live_scope,
                 )
                 return
             raise CommandError(
                 _("`discard --as` requires `--to` and `--line`.")
             )
         if args.from_batch:
-            commands.command_discard_from_batch(args.from_batch, args.line_ids, args.file)
+            _run_for_each_file(
+                resolved_batch_scope,
+                lambda file: commands.command_discard_from_batch(args.from_batch, args.line_ids, file),
+                line_ids=args.line_ids,
+            )
         elif args.to_batch:
-            commands.command_discard_to_batch(args.to_batch, args.line_ids, args.file)
+            _run_for_each_file(
+                resolved_live_scope,
+                lambda file: commands.command_discard_to_batch(args.to_batch, args.line_ids, file),
+                line_ids=args.line_ids,
+            )
         elif args.line_ids:
-            commands.command_discard_line(args.line_ids, file=args.file)
-        elif args.file is not None:
-            commands.command_discard_file(args.file)
+            if isinstance(resolved_live_scope, list):
+                raise CommandError(_("Cannot use --lines with multiple files."))
+            commands.command_discard_line(args.line_ids, file=resolved_live_scope)
+        elif resolved_live_scope is not None:
+            _run_for_each_file(resolved_live_scope, commands.command_discard_file)
         else:
             commands.command_discard()
 
@@ -527,17 +686,26 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
         metavar="IDS",
         help=_("Apply only specific line IDs (e.g., '1,3,5-7')"),
     )
-    parser_apply.add_argument(
-        "--file",
-        nargs="?",
-        const="",
-        default=None,
-        metavar="PATH",
-        help=_("Operate on entire file from batch. "
-               "If PATH omitted, uses first file in batch (sorted order). "
-               "With --line, operates on line IDs from entire file."),
+    _add_file_argument(
+        parser_apply,
+        _("Operate on entire file from batch. "
+          "If PATH omitted, uses first file in batch (sorted order). "
+          "With --line, operates on line IDs from entire file."),
     )
-    parser_apply.set_defaults(func=lambda args: commands.command_apply_from_batch(args.from_batch, line_ids=args.line_ids if hasattr(args, 'line_ids') else None, file=args.file if hasattr(args, 'file') else None))
+
+    def dispatch_apply(args: argparse.Namespace) -> None:
+        resolved_file_scope = _resolve_batch_file_scope(args.from_batch, args.file, args.file_patterns)
+        _run_for_each_file(
+            resolved_file_scope,
+            lambda file: commands.command_apply_from_batch(
+                args.from_batch,
+                line_ids=args.line_ids if hasattr(args, "line_ids") else None,
+                file=file,
+            ),
+            line_ids=args.line_ids if hasattr(args, "line_ids") else None,
+        )
+
+    parser_apply.set_defaults(func=dispatch_apply)
 
     # reset - Remove claims from batch
     parser_reset = subparsers.add_parser(
@@ -564,17 +732,28 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
         metavar="IDS",
         help=_("Reset only specific line IDs (e.g., '1,3,5-7')"),
     )
-    parser_reset.add_argument(
-        "--file",
-        nargs="?",
-        const="",
-        default=None,
-        metavar="PATH",
-        help=_("Operate on entire file from batch. "
-               "If PATH omitted, uses selected hunk's file. "
-               "With --line, operates on line IDs from entire file."),
+    _add_file_argument(
+        parser_reset,
+        _("Operate on entire file from batch. "
+          "If PATH omitted, uses selected hunk's file. "
+          "With --line, operates on line IDs from entire file."),
     )
-    parser_reset.set_defaults(func=lambda args: commands.command_reset_from_batch(args.from_batch, args.line_ids, args.file, args.to_batch))
+
+    def dispatch_reset(args: argparse.Namespace) -> None:
+        resolved_file_scope = _resolve_batch_file_scope(args.from_batch, args.file, args.file_patterns)
+        _run_for_each_file(
+            resolved_file_scope,
+            lambda file: commands.command_reset_from_batch(
+                args.from_batch,
+                args.line_ids,
+                file,
+                None,
+                args.to_batch,
+            ),
+            line_ids=args.line_ids,
+        )
+
+    parser_reset.set_defaults(func=dispatch_reset)
 
     # sift - Reconcile batch against current tip
     parser_sift = subparsers.add_parser(

--- a/src/git_stage_batch/cli/argument_parser.py
+++ b/src/git_stage_batch/cli/argument_parser.py
@@ -14,6 +14,7 @@ from ..batch.query import read_batch_metadata
 from ..exceptions import CommandError
 from ..i18n import _
 from ..utils.file_patterns import list_changed_files, resolve_gitignore_style_patterns
+from .completion import command_complete_files
 
 
 class GitHelpArgumentParser(argparse.ArgumentParser):
@@ -775,6 +776,24 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
         help=_("Destination batch (may equal source for in-place sift)"),
     )
     parser_sift.set_defaults(func=lambda args: commands.command_sift_batch(args.from_batch, args.to_batch))
+
+    parser_complete_files = subparsers.add_parser(
+        "__complete-files",
+        help=argparse.SUPPRESS,
+    )
+    parser_complete_files.add_argument(
+        "current_token",
+        nargs="?",
+        default="",
+    )
+    parser_complete_files.add_argument(
+        "--from",
+        dest="from_batch",
+        default=None,
+    )
+    parser_complete_files.set_defaults(
+        func=lambda args: command_complete_files(args.current_token, from_batch=args.from_batch)
+    )
 
     # Parse arguments, return None on failure
     try:

--- a/src/git_stage_batch/cli/completion.py
+++ b/src/git_stage_batch/cli/completion.py
@@ -1,0 +1,112 @@
+"""Shell completion helpers."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import PurePosixPath
+
+from ..batch.query import list_batch_files
+from ..exceptions import CommandError
+from ..utils.file_patterns import list_changed_files
+
+
+_WILDMATCH_META = frozenset({"*", "?", "["})
+
+
+def _extract_completion_prefix(token: str) -> tuple[str, str]:
+    """Split a token into its negation prefix and literal completion prefix."""
+    negation = "!" if token.startswith("!") else ""
+    pattern = token[1:] if negation else token
+
+    if not pattern:
+        return negation, ""
+
+    escaped = False
+    in_class = False
+    literal_chars: list[str] = []
+    saw_meta = False
+
+    for char in pattern:
+        if escaped:
+            literal_chars.append(char)
+            escaped = False
+            continue
+        if char == "\\":
+            escaped = True
+            continue
+        if in_class:
+            if char == "]":
+                in_class = False
+            saw_meta = True
+            continue
+        if char == "[":
+            in_class = True
+            saw_meta = True
+            break
+        if char in {"*", "?"}:
+            saw_meta = True
+            break
+        literal_chars.append(char)
+
+    literal_prefix = "".join(literal_chars)
+    if saw_meta:
+        slash_index = literal_prefix.rfind("/")
+        if slash_index != -1:
+            literal_prefix = literal_prefix[:slash_index + 1]
+        else:
+            literal_prefix = ""
+
+    return negation, literal_prefix
+
+
+def _build_completion_candidates(paths: list[str]) -> list[str]:
+    """Build file and directory completion candidates from repo-relative files."""
+    candidates = set(paths)
+    for path in paths:
+        current = PurePosixPath(path).parent
+        while str(current) not in (".", ""):
+            candidates.add(f"{current.as_posix()}/")
+            current = current.parent
+    return sorted(candidates)
+
+
+def _filter_completion_candidates(candidates: list[str], token: str) -> list[str]:
+    """Filter candidates based on the partially typed token."""
+    negation, literal_prefix = _extract_completion_prefix(token)
+    pattern = token[1:] if negation else token
+
+    if "/" in pattern:
+        filtered = [candidate for candidate in candidates if candidate.startswith(literal_prefix)]
+    elif literal_prefix:
+        filtered = [
+            candidate for candidate in candidates
+            if candidate.startswith(literal_prefix) or PurePosixPath(candidate.rstrip("/")).name.startswith(literal_prefix)
+        ]
+    else:
+        filtered = candidates
+
+    return [negation + candidate for candidate in filtered]
+
+
+def list_file_completion_candidates(
+    current_token: str,
+    *,
+    from_batch: str | None = None,
+) -> list[str]:
+    """List repo-aware completion candidates for --file/--files."""
+    try:
+        paths = list_batch_files(from_batch) if from_batch is not None else list_changed_files()
+    except (CommandError, subprocess.CalledProcessError):
+        return []
+
+    if not paths:
+        return []
+
+    candidates = _build_completion_candidates(paths)
+    return _filter_completion_candidates(candidates, current_token)
+
+
+def command_complete_files(current_token: str, *, from_batch: str | None = None) -> None:
+    """Print completion candidates for --file/--files, one per line."""
+    for candidate in list_file_completion_candidates(current_token, from_batch=from_batch):
+        print(candidate)

--- a/src/git_stage_batch/cli/pager.py
+++ b/src/git_stage_batch/cli/pager.py
@@ -25,6 +25,7 @@ _PAGEABLE_COMMANDS = {
     "start",
     "status",
     "unblock-file",
+    "__complete-files",
 }
 
 

--- a/src/git_stage_batch/commands/apply_from.py
+++ b/src/git_stage_batch/commands/apply_from.py
@@ -75,7 +75,12 @@ def _apply_binary_file_from_batch(batch_name: str, file_path: str, file_meta: di
             pass
 
 
-def command_apply_from_batch(batch_name: str, line_ids: Optional[str] = None, file: Optional[str] = None) -> None:
+def command_apply_from_batch(
+    batch_name: str,
+    line_ids: Optional[str] = None,
+    file: Optional[str] = None,
+    patterns: Optional[list[str]] = None,
+) -> None:
     """Apply batch changes to working tree using structural merge.
 
     Args:
@@ -83,6 +88,7 @@ def command_apply_from_batch(batch_name: str, line_ids: Optional[str] = None, fi
         line_ids: Optional line IDs to apply (requires single-file context)
         file: Optional file path to select from batch.
               If None, applies all files in batch.
+        patterns: Optional gitignore-style file patterns to filter batch files.
     """
     require_git_repository()
 
@@ -102,7 +108,7 @@ def command_apply_from_batch(batch_name: str, line_ids: Optional[str] = None, fi
         exit_with_error(_("Batch '{name}' is empty").format(name=batch_name))
 
     # Determine which files to operate on
-    files = resolve_batch_file_scope(batch_name, all_files, file)
+    files = resolve_batch_file_scope(batch_name, all_files, file, patterns)
 
     # Parse line selection and enforce single-file context
     selected_ids = require_single_file_context_for_line_selection(

--- a/src/git_stage_batch/commands/discard_from.py
+++ b/src/git_stage_batch/commands/discard_from.py
@@ -60,7 +60,12 @@ def _discard_binary_file_from_batch(file_path: str, baseline_commit: str) -> Non
             pass
 
 
-def command_discard_from_batch(batch_name: str, line_ids: Optional[str] = None, file: Optional[str] = None) -> None:
+def command_discard_from_batch(
+    batch_name: str,
+    line_ids: Optional[str] = None,
+    file: Optional[str] = None,
+    patterns: Optional[list[str]] = None,
+) -> None:
     """Remove batch changes from working tree using structural merge.
 
     Args:
@@ -68,6 +73,7 @@ def command_discard_from_batch(batch_name: str, line_ids: Optional[str] = None, 
         line_ids: Optional line IDs to discard (requires single-file context)
         file: Optional file path to select from batch.
               If None, discards all files in batch.
+        patterns: Optional gitignore-style file patterns to filter batch files.
     """
     require_git_repository()
 
@@ -87,7 +93,7 @@ def command_discard_from_batch(batch_name: str, line_ids: Optional[str] = None, 
         exit_with_error(_("Batch '{name}' is empty").format(name=batch_name))
 
     # Determine which files to operate on
-    files = resolve_batch_file_scope(batch_name, all_files, file)
+    files = resolve_batch_file_scope(batch_name, all_files, file, patterns)
 
     # Parse line selection and enforce single-file context
     selected_ids = require_single_file_context_for_line_selection(

--- a/src/git_stage_batch/commands/include_from.py
+++ b/src/git_stage_batch/commands/include_from.py
@@ -81,6 +81,7 @@ def command_include_from_batch(
     batch_name: str,
     line_ids: Optional[str] = None,
     file: Optional[str] = None,
+    patterns: Optional[list[str]] = None,
     replacement_text: Optional[str] = None,
 ) -> None:
     """Stage batch changes to index using structural merge.
@@ -90,6 +91,7 @@ def command_include_from_batch(
         line_ids: Optional line IDs to include (requires single-file context)
         file: Optional file path to select from batch.
               If None, includes all files in batch.
+        patterns: Optional gitignore-style file patterns to filter batch files.
         replacement_text: Optional replacement text for selected batch lines.
     """
     require_git_repository()
@@ -113,7 +115,7 @@ def command_include_from_batch(
         exit_with_error(_("Batch '{name}' is empty").format(name=batch_name))
 
     # Determine which files to operate on
-    files = resolve_batch_file_scope(batch_name, all_files, file)
+    files = resolve_batch_file_scope(batch_name, all_files, file, patterns)
 
     # Parse line selection and enforce single-file context
     selected_ids = require_single_file_context_for_line_selection(

--- a/src/git_stage_batch/commands/reset.py
+++ b/src/git_stage_batch/commands/reset.py
@@ -41,6 +41,7 @@ def command_reset_from_batch(
     batch_name: str,
     line_ids: str | None = None,
     file: str | None = None,
+    patterns: list[str] | None = None,
     to_batch: str | None = None,
 ) -> None:
     """Remove claims from a batch, making changes visible again if not claimed elsewhere.
@@ -50,6 +51,7 @@ def command_reset_from_batch(
         line_ids: Optional line ID specification (e.g., "1,3,5-7")
         file: Optional file path to reset from batch.
               If None and line_ids is None, resets all claims in the batch.
+        patterns: Optional gitignore-style file patterns to filter batch files.
         to_batch: Optional destination batch to receive the reset claims.
     """
     require_git_repository()
@@ -72,9 +74,11 @@ def command_reset_from_batch(
         operation_parts.extend(["--file", file])
     with undo_checkpoint(" ".join(operation_parts)):
         if to_batch is not None:
-            _move_claims_between_batches(batch_name, to_batch, file, line_ids)
+            _move_claims_between_batches(batch_name, to_batch, file, patterns, line_ids)
         elif file is not None:
             _reset_file_claims_from_batch(batch_name, file, line_ids)
+        elif patterns is not None:
+            _reset_pattern_claims_from_batch(batch_name, patterns, line_ids)
         elif line_ids is not None:
             _reset_line_claims_from_batch(batch_name, line_ids)
         else:
@@ -120,11 +124,12 @@ def _move_claims_between_batches(
     source_batch: str,
     dest_batch: str,
     file: str | None,
+    patterns: list[str] | None,
     line_id_specification: str | None,
 ) -> None:
     """Move selected claims from one batch to another."""
     source_metadata = read_batch_metadata(source_batch)
-    files = resolve_batch_file_scope(source_batch, source_metadata.get("files", {}), file)
+    files = resolve_batch_file_scope(source_batch, source_metadata.get("files", {}), file, patterns)
     _ensure_destination_batch(source_batch, dest_batch, source_metadata)
 
     if line_id_specification is not None:
@@ -199,6 +204,30 @@ def _reset_file_claims_from_batch(
     if line_id_specification is None:
         file_path = list(files.keys())[0]
         remove_file_from_batch(batch_name, file_path)
+        return
+
+    selected_ids = require_single_file_context_for_line_selection(
+        batch_name, files, line_id_specification, "reset"
+    )
+    if selected_ids is None:
+        return
+
+    file_path = list(files.keys())[0]
+    _reset_line_claims_for_file(batch_name, file_path, selected_ids)
+
+
+def _reset_pattern_claims_from_batch(
+    batch_name: str,
+    patterns: list[str],
+    line_id_specification: str | None = None,
+) -> None:
+    """Remove claims for files selected by gitignore-style patterns."""
+    metadata = read_batch_metadata(batch_name)
+    files = resolve_batch_file_scope(batch_name, metadata.get("files", {}), None, patterns)
+
+    if line_id_specification is None:
+        for file_path in files:
+            remove_file_from_batch(batch_name, file_path)
         return
 
     selected_ids = require_single_file_context_for_line_selection(

--- a/src/git_stage_batch/commands/show.py
+++ b/src/git_stage_batch/commands/show.py
@@ -10,7 +10,12 @@ from ..core.diff_parser import build_line_changes_from_patch_bytes, parse_unifie
 from ..core.diff_parser import write_snapshots_for_selected_file_path
 from ..core.hashing import compute_stable_hunk_hash
 from ..core.models import BinaryFileChange
-from ..data.hunk_tracking import apply_line_level_batch_filter_to_cached_hunk, cache_file_as_single_hunk, get_selected_change_file_path
+from ..data.hunk_tracking import (
+    apply_line_level_batch_filter_to_cached_hunk,
+    cache_file_as_single_hunk,
+    get_selected_change_file_path,
+    render_file_as_single_hunk,
+)
 from ..data.line_state import convert_line_changes_to_serializable_dict, load_line_changes_from_state
 from ..data.session import require_session_started
 from ..exceptions import exit_with_error
@@ -28,7 +33,7 @@ from ..utils.paths import (
 )
 
 
-def command_show(file: str | None = None, *, porcelain: bool = False) -> None:
+def command_show(file: str | None = None, *, porcelain: bool = False, selectable: bool = True) -> None:
     """Show the first unprocessed hunk or entire file.
 
     Args:
@@ -36,6 +41,8 @@ def command_show(file: str | None = None, *, porcelain: bool = False) -> None:
               If empty string, uses selected hunk's file.
               If None, shows selected hunk (normal behavior).
         porcelain: If True, produce no output and exit with code 0 if hunk found, 1 if none
+        selectable: If True, cache the file and show selectable gutter IDs.
+                    If False, only preview the file and hide gutter IDs.
     """
     require_git_repository()
     require_session_started()
@@ -52,8 +59,12 @@ def command_show(file: str | None = None, *, porcelain: bool = False) -> None:
         else:
             target_file = file
 
-        # Cache and display entire file
-        file_lines = cache_file_as_single_hunk(target_file)
+        # Cache and display entire file when it's the active selection.
+        file_lines = (
+            cache_file_as_single_hunk(target_file)
+            if selectable else
+            render_file_as_single_hunk(target_file)
+        )
         if file_lines is None:
             if porcelain:
                 sys.exit(1)
@@ -62,7 +73,7 @@ def command_show(file: str | None = None, *, porcelain: bool = False) -> None:
             return
 
         if not porcelain:
-            print_line_level_changes(file_lines)
+            print_line_level_changes(file_lines, gutter_to_selection_id=None if selectable else {})
         return
 
     # Hunk-scoped operation (selected behavior)

--- a/src/git_stage_batch/commands/show_from.py
+++ b/src/git_stage_batch/commands/show_from.py
@@ -11,7 +11,12 @@ from ..batch.selection import (
     require_single_file_context_for_line_selection,
 )
 from ..batch.validation import batch_exists
-from ..data.hunk_tracking import cache_batch_as_single_hunk, cache_batch_files_generator, cache_rendered_batch_file_display
+from ..data.hunk_tracking import (
+    cache_batch_as_single_hunk,
+    cache_batch_files_generator,
+    cache_rendered_batch_file_display,
+    render_batch_file_display,
+)
 from ..output import print_line_level_changes
 from ..exceptions import exit_with_error, BatchMetadataError
 from ..i18n import _
@@ -19,7 +24,13 @@ from ..core.models import LineLevelChange
 from ..utils.git import require_git_repository
 
 
-def command_show_from_batch(batch_name: str, line_ids: Optional[str] = None, file: Optional[str] = None) -> None:
+def command_show_from_batch(
+    batch_name: str,
+    line_ids: Optional[str] = None,
+    file: Optional[str] = None,
+    patterns: Optional[list[str]] = None,
+    selectable: bool = True,
+) -> None:
     """Show changes from a batch.
 
     Args:
@@ -27,6 +38,8 @@ def command_show_from_batch(batch_name: str, line_ids: Optional[str] = None, fil
         line_ids: Optional line IDs to filter (requires single-file context)
         file: Optional file path to show from batch.
               If None, shows all files in batch.
+        patterns: Optional gitignore-style file patterns to filter batch files.
+        selectable: If True, cache the displayed file for later line operations.
     """
     require_git_repository()
 
@@ -43,7 +56,7 @@ def command_show_from_batch(batch_name: str, line_ids: Optional[str] = None, fil
     all_files = metadata.get("files", {})
 
     # Resolve file scope (for consistent --file handling across commands)
-    files = resolve_batch_file_scope(batch_name, all_files, file)
+    files = resolve_batch_file_scope(batch_name, all_files, file, patterns)
 
     # Parse line selection and enforce single-file context
     selected_ids = require_single_file_context_for_line_selection(
@@ -60,7 +73,11 @@ def command_show_from_batch(batch_name: str, line_ids: Optional[str] = None, fil
         file_path = list(files.keys())[0]
 
         # Cache that file from batch
-        rendered = cache_batch_as_single_hunk(batch_name, file_path=file_path, metadata=metadata)
+        rendered = (
+            cache_batch_as_single_hunk(batch_name, file_path=file_path, metadata=metadata)
+            if selectable else
+            render_batch_file_display(batch_name, file_path, metadata=metadata)
+        )
         if rendered is None:
             print(_("No changes for file '{file}' in batch '{name}'.").format(file=file_path, name=batch_name), file=sys.stderr)
             return
@@ -85,7 +102,10 @@ def command_show_from_batch(batch_name: str, line_ids: Optional[str] = None, fil
                 )
                 print_line_level_changes(filtered_line_changes, gutter_to_selection_id=rendered.gutter_to_selection_id)
         else:
-            print_line_level_changes(rendered.line_changes, gutter_to_selection_id=rendered.gutter_to_selection_id)
+            print_line_level_changes(
+                rendered.line_changes,
+                gutter_to_selection_id=rendered.gutter_to_selection_id if selectable else {},
+            )
 
         return
 

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -559,12 +559,7 @@ def cache_file_as_single_hunk(file_path: str) -> Optional[LineLevelChange]:
         LineLevelChange with all file changes, or None if no changes
     """
     try:
-        combined_line_changes = _build_combined_file_line_changes(
-            file_path,
-            parse_unified_diff_streaming(
-                stream_git_command(["diff", f"-U{get_context_lines()}", "--no-color", "HEAD", "--", file_path])
-            ),
-        )
+        combined_line_changes = render_file_as_single_hunk(file_path)
         if combined_line_changes is None:
             return None
 
@@ -599,6 +594,16 @@ def cache_file_as_single_hunk(file_path: str) -> Optional[LineLevelChange]:
     except subprocess.CalledProcessError:
         # Git diff failed (e.g., no changes in file)
         return None
+
+
+def render_file_as_single_hunk(file_path: str) -> Optional[LineLevelChange]:
+    """Render all changes for a file as a single hunk without caching state."""
+    return _build_combined_file_line_changes(
+        file_path,
+        parse_unified_diff_streaming(
+            stream_git_command(["diff", f"-U{get_context_lines()}", "--no-color", "HEAD", "--", file_path])
+        ),
+    )
 
 
 def build_file_hunk_from_content(file_path: str, file_content: bytes) -> Optional[LineLevelChange]:

--- a/src/git_stage_batch/utils/file_patterns.py
+++ b/src/git_stage_batch/utils/file_patterns.py
@@ -1,0 +1,97 @@
+"""Resolve gitignore-style file patterns against candidate paths."""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+from collections.abc import Iterable
+from pathlib import Path
+
+from .git import run_git_command
+from .file_io import write_text_file_contents
+
+
+def _normalize_path(path: str) -> str:
+    """Normalize repository-relative paths to POSIX separators."""
+    normalized = path.replace("\\", "/")
+    if normalized.startswith("./"):
+        normalized = normalized[2:]
+    return normalized
+
+
+def _validate_patterns(patterns: Iterable[str]) -> list[str]:
+    """Normalize and validate gitignore-style patterns."""
+    normalized_patterns = [_normalize_path(pattern) for pattern in patterns]
+    for pattern in normalized_patterns:
+        if not pattern:
+            raise ValueError("Pattern cannot be empty")
+    return normalized_patterns
+
+
+def _materialize_candidates(root: Path, candidates: list[str]) -> None:
+    """Create candidate paths in a temporary repository for Git-backed matching."""
+    for candidate in candidates:
+        candidate_path = root / candidate
+        if candidate.endswith("/"):
+            candidate_path.mkdir(parents=True, exist_ok=True)
+            continue
+        candidate_path.parent.mkdir(parents=True, exist_ok=True)
+        candidate_path.touch(exist_ok=True)
+
+
+def resolve_gitignore_style_patterns(
+    candidates: Iterable[str],
+    patterns: Iterable[str],
+) -> list[str]:
+    """Resolve gitignore-style patterns to matching candidate paths.
+
+    This delegates matching to Git itself using `git check-ignore`, which gives
+    parity with Git's wildmatch implementation, including escaping, negation,
+    character classes, and directory semantics.
+    """
+    normalized_candidates = [_normalize_path(candidate) for candidate in candidates]
+    normalized_patterns = _validate_patterns(patterns)
+    if not normalized_candidates:
+        return []
+
+    with tempfile.TemporaryDirectory(prefix="git-stage-batch-patterns-") as temp_dir:
+        temp_root = Path(temp_dir)
+        subprocess.run(
+            ["git", "init", "-q"],
+            check=True,
+            cwd=temp_root,
+            capture_output=True,
+        )
+        write_text_file_contents(temp_root / ".gitignore", "".join(f"{pattern}\n" for pattern in normalized_patterns))
+        _materialize_candidates(temp_root, normalized_candidates)
+
+        payload = b"".join(candidate.encode("utf-8") + b"\0" for candidate in normalized_candidates)
+        result = subprocess.run(
+            ["git", "check-ignore", "--no-index", "--stdin", "-z", "-v", "-n"],
+            check=True,
+            cwd=temp_root,
+            input=payload,
+            capture_output=True,
+        )
+
+    fields = result.stdout.split(b"\0")
+    resolved_status: dict[str, bool] = {}
+    for index in range(0, len(fields) - 1, 4):
+        _source, _line_number, pattern, candidate = fields[index:index + 4]
+        if not candidate:
+            continue
+        candidate_text = candidate.decode("utf-8")
+        pattern_text = pattern.decode("utf-8")
+        resolved_status[candidate_text] = bool(pattern_text) and not pattern_text.startswith("!")
+
+    return [candidate for candidate in normalized_candidates if resolved_status.get(candidate, False)]
+
+
+def list_changed_files() -> list[str]:
+    """List repository-relative files currently present in the working-tree diff."""
+    result = run_git_command(["diff", "--name-only", "-z"], text_output=False)
+    return [
+        _normalize_path(path.decode("utf-8"))
+        for path in result.stdout.split(b"\0")
+        if path
+    ]

--- a/tests/cli/test_argument_parser.py
+++ b/tests/cli/test_argument_parser.py
@@ -1,6 +1,6 @@
 """Tests for CLI argument parsing."""
 
-from unittest.mock import Mock
+from unittest.mock import Mock, call
 
 import pytest
 
@@ -175,6 +175,22 @@ def test_parse_command_line_include_with_file_and_line_dispatches_file_scope(mon
     assert args is not None
     args.func(args)
     mock_command.assert_called_once_with("2-3", file="path.txt")
+
+
+def test_parse_command_line_include_with_files_dispatches_per_file(monkeypatch):
+    """Include should dispatch once per file resolved from --files."""
+    mock_command = Mock()
+    monkeypatch.setattr(argument_parser.commands, "command_include_file", mock_command)
+    monkeypatch.setattr(argument_parser, "list_changed_files", lambda: ["foo.py", "dir/bar.py", "baz.txt"])
+
+    args = parse_command_line(["include", "--files", "*.py"], quiet=True)
+
+    assert args is not None
+    assert args.file_patterns == ["*.py"]
+    args.func(args)
+    assert mock_command.call_args_list == [call("foo.py"), call("dir/bar.py")]
+
+
 def test_parse_command_line_include_from_with_as():
     """Test parsing include --from with replacement text."""
     args = parse_command_line(
@@ -230,6 +246,94 @@ def test_parse_command_line_skip_with_line():
     assert args.line_ids == "1,3,5-7"
     assert hasattr(args, "func")
     assert callable(args.func)
+
+
+def test_parse_command_line_skip_with_files():
+    """Skip should parse --files patterns."""
+    args = parse_command_line(["skip", "--files", "*.py", "docs/*.md"], quiet=True)
+    assert args is not None
+    assert args.file_patterns == ["*.py", "docs/*.md"]
+
+
+def test_parse_command_line_skip_files_dispatches_per_file(monkeypatch):
+    """Skip should dispatch once per file resolved from --files."""
+    mock_command = Mock()
+    monkeypatch.setattr(argument_parser.commands, "command_skip_file", mock_command)
+    monkeypatch.setattr(argument_parser, "list_changed_files", lambda: ["foo.py", "bar.py", "notes.txt"])
+
+    args = parse_command_line(["skip", "--files", "*.py"], quiet=True)
+
+    assert args is not None
+    args.func(args)
+    assert mock_command.call_args_list == [call("foo.py"), call("bar.py")]
+
+
+def test_parse_command_line_skip_rejects_lines_with_multiple_files(monkeypatch):
+    """Skip should reject --line/--lines when --files resolves to multiple files."""
+    monkeypatch.setattr(argument_parser, "list_changed_files", lambda: ["foo.py", "bar.py"])
+    args = parse_command_line(["skip", "--files", "*.py", "--lines", "1"], quiet=True)
+    assert args is not None
+
+    with pytest.raises(argument_parser.CommandError, match="Cannot use --lines with multiple files"):
+        args.func(args)
+
+
+def test_parse_command_line_skip_rejects_mixed_file_and_files():
+    """Skip should reject mixing --file and --files."""
+    args = parse_command_line(["skip", "--file", "foo.py", "--files", "*.py"], quiet=True)
+    assert args is not None
+
+    with pytest.raises(argument_parser.CommandError, match="Cannot use --file together with --files"):
+        args.func(args)
+
+
+def test_parse_command_line_discard_with_files_dispatches_per_file(monkeypatch):
+    """Discard should dispatch once per file resolved from --files."""
+    mock_command = Mock()
+    monkeypatch.setattr(argument_parser.commands, "command_discard_file", mock_command)
+    monkeypatch.setattr(argument_parser, "list_changed_files", lambda: ["foo.py", "bar.py", "notes.txt"])
+
+    args = parse_command_line(["discard", "--files", "*.py"], quiet=True)
+
+    assert args is not None
+    args.func(args)
+    assert mock_command.call_args_list == [call("foo.py"), call("bar.py")]
+
+
+def test_parse_command_line_apply_with_files_dispatches_per_file(monkeypatch):
+    """Apply should dispatch once per file resolved from --files."""
+    mock_command = Mock()
+    monkeypatch.setattr(argument_parser.commands, "command_apply_from_batch", mock_command)
+    monkeypatch.setattr(argument_parser, "batch_exists", lambda name: True)
+    monkeypatch.setattr(argument_parser, "read_batch_metadata", lambda name: {"files": {"foo.py": {}, "bar.py": {}, "notes.txt": {}}})
+
+    args = parse_command_line(
+        ["apply", "--from", "batch", "--files", "*.py"],
+        quiet=True,
+    )
+
+    assert args is not None
+    args.func(args)
+    assert mock_command.call_args_list == [
+        call("batch", line_ids=None, file="foo.py"),
+        call("batch", line_ids=None, file="bar.py"),
+    ]
+
+
+def test_parse_command_line_show_with_files_only_last_result_is_selectable(monkeypatch):
+    """Show should hide gutters for earlier files resolved from --files."""
+    mock_command = Mock()
+    monkeypatch.setattr(argument_parser.commands, "command_show", mock_command)
+    monkeypatch.setattr(argument_parser, "list_changed_files", lambda: ["foo.py", "bar.py", "notes.txt"])
+
+    args = parse_command_line(["show", "--files", "*.py"], quiet=True)
+
+    assert args is not None
+    args.func(args)
+    assert mock_command.call_args_list == [
+        call(file="foo.py", porcelain=False, selectable=False),
+        call(file="bar.py", porcelain=False, selectable=True),
+    ]
 
 
 def test_parse_command_line_discard():

--- a/tests/cli/test_completion.py
+++ b/tests/cli/test_completion.py
@@ -1,0 +1,54 @@
+"""Tests for CLI completion helpers."""
+
+from git_stage_batch.cli.completion import list_file_completion_candidates
+
+
+def test_list_file_completion_candidates_uses_changed_files(monkeypatch):
+    """Live completion should use changed files and expose directories."""
+    monkeypatch.setattr(
+        "git_stage_batch.cli.completion.list_changed_files",
+        lambda: ["src/auth.py", "src/config/settings.py", "docs/guide.md"],
+    )
+
+    candidates = list_file_completion_candidates("s")
+
+    assert "src/" in candidates
+    assert "src/auth.py" in candidates
+    assert "src/config/" in candidates
+
+
+def test_list_file_completion_candidates_uses_batch_files(monkeypatch):
+    """Batch completion should resolve against batch contents."""
+    monkeypatch.setattr(
+        "git_stage_batch.cli.completion.list_batch_files",
+        lambda _name: ["src/auth.py", "tests/test_auth.py"],
+    )
+
+    candidates = list_file_completion_candidates("src/a", from_batch="feature")
+
+    assert candidates == ["src/auth.py"]
+
+
+def test_list_file_completion_candidates_preserves_negation(monkeypatch):
+    """Negated file-pattern completion should preserve the leading !."""
+    monkeypatch.setattr(
+        "git_stage_batch.cli.completion.list_changed_files",
+        lambda: ["dir/keep.py", "dir/exception.py"],
+    )
+
+    candidates = list_file_completion_candidates("!dir/e")
+
+    assert candidates == ["!dir/exception.py"]
+
+
+def test_list_file_completion_candidates_treats_wildmatch_as_directory_prefix(monkeypatch):
+    """Wildcard-bearing tokens should complete from their literal directory prefix."""
+    monkeypatch.setattr(
+        "git_stage_batch.cli.completion.list_changed_files",
+        lambda: ["src/auth.py", "src/core/models.py", "tests/test_auth.py"],
+    )
+
+    candidates = list_file_completion_candidates("src/**/")
+
+    assert "src/auth.py" in candidates
+    assert "src/core/" in candidates

--- a/tests/commands/test_show.py
+++ b/tests/commands/test_show.py
@@ -17,6 +17,7 @@ import pytest
 
 from git_stage_batch.commands.show import command_show
 from git_stage_batch.commands.start import command_start
+from git_stage_batch.data.line_state import load_line_changes_from_state
 
 
 @pytest.fixture
@@ -236,3 +237,32 @@ class TestCommandShow:
             command_show(porcelain=True)
 
         assert exc_info.value.code == 1
+
+    def test_show_file_preview_hides_gutter_ids_without_replacing_selection(self, temp_git_repo, capsys):
+        """Non-selectable file previews should hide gutter IDs and preserve cached selection."""
+        file1 = temp_git_repo / "file1.txt"
+        file2 = temp_git_repo / "file2.txt"
+        file1.write_text("one\n")
+        file2.write_text("two\n")
+        subprocess.run(["git", "add", "file1.txt", "file2.txt"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add files"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        file1.write_text("one changed\n")
+        file2.write_text("two changed\n")
+
+        command_start()
+        capsys.readouterr()
+
+        command_show(file="file1.txt", selectable=False)
+        preview = capsys.readouterr()
+        assert "file1.txt" in preview.out
+        assert "[#1]" not in preview.out
+
+        command_show(file="file2.txt")
+        selected = capsys.readouterr()
+        assert "file2.txt" in selected.out
+        assert "[#1]" in selected.out
+
+        cached = load_line_changes_from_state()
+        assert cached is not None
+        assert cached.path == "file2.txt"

--- a/tests/utils/test_file_patterns.py
+++ b/tests/utils/test_file_patterns.py
@@ -1,0 +1,93 @@
+"""Tests for gitignore-style file pattern resolution."""
+
+from git_stage_batch.utils.file_patterns import resolve_gitignore_style_patterns
+
+
+def test_resolve_gitignore_style_patterns_matches_basename_anywhere():
+    """Basename-only patterns should match in any directory."""
+    resolved = resolve_gitignore_style_patterns(
+        ["foo.py", "src/bar.py", "docs/readme.md"],
+        ["*.py"],
+    )
+
+    assert resolved == ["foo.py", "src/bar.py"]
+
+
+def test_resolve_gitignore_style_patterns_matches_root_anchored_pattern():
+    """Leading / should anchor the pattern at the repository root."""
+    resolved = resolve_gitignore_style_patterns(
+        ["src/main.py", "nested/src/main.py"],
+        ["/src/*.py"],
+    )
+
+    assert resolved == ["src/main.py"]
+
+
+def test_resolve_gitignore_style_patterns_matches_directory_pattern():
+    """Trailing / should match files within directories of that name."""
+    resolved = resolve_gitignore_style_patterns(
+        ["build/output.o", "nested/build/cache.txt", "src/build.py"],
+        ["build/"],
+    )
+
+    assert resolved == ["build/output.o", "nested/build/cache.txt"]
+
+
+def test_resolve_gitignore_style_patterns_supports_ordered_exclusion():
+    """Later negated patterns should remove earlier matches."""
+    resolved = resolve_gitignore_style_patterns(
+        ["dir/keep.py", "dir/exception.py", "other.py"],
+        ["dir/*", "!dir/exception.py"],
+    )
+
+    assert resolved == ["dir/keep.py"]
+
+
+def test_resolve_gitignore_style_patterns_supports_character_classes():
+    """Character classes should behave like shell-style wildcards."""
+    resolved = resolve_gitignore_style_patterns(
+        ["file1.py", "file2.py", "filea.py", "fileb.py"],
+        ["file[1a].py"],
+    )
+
+    assert resolved == ["file1.py", "filea.py"]
+
+
+def test_resolve_gitignore_style_patterns_supports_negated_character_classes():
+    """Negated character classes should exclude listed characters."""
+    resolved = resolve_gitignore_style_patterns(
+        ["file1.py", "file2.py", "filea.py"],
+        ["file[!a].py"],
+    )
+
+    assert resolved == ["file1.py", "file2.py"]
+
+
+def test_resolve_gitignore_style_patterns_supports_reinclusion_after_exclusion():
+    """Later positive patterns should be able to re-include candidates."""
+    resolved = resolve_gitignore_style_patterns(
+        ["dir/a.py", "dir/exception.py", "dir/z.py"],
+        ["dir/*", "!dir/*.py", "dir/exception.py"],
+    )
+
+    assert resolved == ["dir/exception.py"]
+
+
+def test_resolve_gitignore_style_patterns_supports_escaped_comment_marker():
+    """Escaped # should be treated as a literal character."""
+    resolved = resolve_gitignore_style_patterns(
+        ["#literal", "other"],
+        [r"\#literal"],
+    )
+
+    assert resolved == ["#literal"]
+
+
+def test_resolve_gitignore_style_patterns_supports_escaped_negation_marker():
+    """Escaped ! should be treated as a literal character, not an exclusion."""
+    resolved = resolve_gitignore_style_patterns(
+        ["!literal", "other"],
+        [r"\!literal"],
+    )
+
+    assert resolved == ["!literal"]


### PR DESCRIPTION
## Summary

- Add gitignore-style file pattern resolution using Git's wildmatch via `git check-ignore`, supporting basename patterns, root-anchored paths, directory matching, negation, character classes, and escapes
- Add `--files` argument to show, include, skip, discard, apply, and reset commands, enabling pattern-based multi-file operations in a single invocation (e.g., `--files '*.py'` or `--files 'src/'`)
- Multi-file show renders earlier files as non-selectable previews (hidden gutter IDs) so only the last file becomes the active selection

## Details

The series introduces a `file_patterns` utility module that delegates matching to Git's own wildmatch implementation, then threads pattern support through the batch selection resolver, command functions, and CLI argument parser. A `render_file_as_single_hunk` helper is extracted from the caching path to support preview-only display without side effects.

**10 commits:**
1. `utils: Add gitignore-style file pattern resolution`
2. `tests: Cover gitignore-style file pattern resolution`
3. `data: Extract non-caching file render from cache helper`
4. `show: Add preview mode for non-selectable file display`
5. `batch: Accept file patterns in batch scope resolution`
6. `show: Support multi-file batch display with preview`
7. `tests: Cover non-selectable file preview in show`
8. `commands: Accept file patterns in batch operations`
9. `cli: Add --files argument for multi-file operations`
10. `tests: Cover --files multi-file dispatch`

## Test plan

- [x] All 1331 tests pass
- [ ] Verify `--files '*.py'` selects only Python files in show/include/skip/discard/apply/reset
- [ ] Verify `--files` and `--file` are mutually exclusive
- [ ] Verify `--lines` is rejected with multi-file `--files` results
- [ ] Verify multi-file show hides gutter IDs for all but the last file