### PR TITLE
Ship man page in wheel and use it for --help

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -34,6 +34,13 @@ manpage = configure_file(
   output: 'git-stage-batch.1',
   configuration: {'VERSION': meson.project_version()},
 )
+if get_option('python_wheel')
+  install_data(
+    manpage,
+    install_dir: package_dir / 'assets' / 'man' / 'man1',
+    install_tag: 'python-runtime',
+  )
+endif
 if not get_option('python_wheel')
   install_man(manpage)
 endif

--- a/meson.build
+++ b/meson.build
@@ -6,6 +6,7 @@ project('git-stage-batch',
 
 python = import('python').find_installation('python3', pure: true)
 i18n = import('i18n')
+package_dir = python.get_install_dir() / 'git_stage_batch'
 
 # Generate POTFILES.in by scanning for translatable strings
 run_command(

--- a/src/git_stage_batch/cli/argument_parser.py
+++ b/src/git_stage_batch/cli/argument_parser.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import argparse
+import os
 import subprocess
 import sys
 from collections.abc import Callable
+from importlib import resources
+from pathlib import Path
 
 from .. import __version__
 from ..batch.validation import batch_exists
@@ -22,19 +25,83 @@ class GitHelpArgumentParser(argparse.ArgumentParser):
 
     def print_help(self, file=None):
         """Try to use git help, fall back to argparse help."""
-        try:
-            result = subprocess.run(
-                ["git", "help", "stage-batch"],
-                check=False,
-                stderr=subprocess.DEVNULL,
-            )
-            if result.returncode == 0:
-                return
-        except (FileNotFoundError, OSError):
-            pass
+        if _show_git_stage_batch_help():
+            return
 
         # Fall back to standard argparse help
         super().print_help(file)
+
+
+def _resolve_default_manpath() -> str | None:
+    """Return the default manpath as if MANPATH were unset."""
+    env = os.environ.copy()
+    env.pop("MANPATH", None)
+    try:
+        result = subprocess.run(
+            ["manpath", "-q"],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            env=env,
+        )
+    except (FileNotFoundError, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def _build_manpath_with_packaged_page(man_root: Path, env: dict[str, str]) -> str:
+    """Build a MANPATH preferring the packaged man page when available."""
+    if env.get("MANPATH"):
+        return f"{man_root}{os.pathsep}{env['MANPATH']}"
+
+    default_manpath = _resolve_default_manpath()
+    if default_manpath:
+        return f"{man_root}{os.pathsep}{default_manpath}"
+
+    return f"{man_root}{os.pathsep}{os.pathsep}"
+
+
+def _try_git_help_with_environment(env: dict[str, str] | None = None) -> bool:
+    """Run git help for git-stage-batch."""
+    try:
+        result = subprocess.run(
+            ["git", "help", "stage-batch"],
+            check=False,
+            stderr=subprocess.DEVNULL,
+            env=env,
+        )
+    except (FileNotFoundError, OSError):
+        return False
+    return result.returncode == 0
+
+
+def _show_git_stage_batch_help() -> bool:
+    """Show git-stage-batch help from packaged or system man pages."""
+    try:
+        packaged_manpage = resources.files("git_stage_batch").joinpath(
+            "assets", "man", "man1", "git-stage-batch.1"
+        )
+    except (ModuleNotFoundError, FileNotFoundError):
+        packaged_manpage = None
+
+    if packaged_manpage is not None:
+        try:
+            with resources.as_file(packaged_manpage) as packaged_manpage_path:
+                if packaged_manpage_path.exists():
+                    env = os.environ.copy()
+                    env["MANPATH"] = _build_manpath_with_packaged_page(
+                        packaged_manpage_path.parent.parent,
+                        env,
+                    )
+                    if _try_git_help_with_environment(env):
+                        return True
+        except FileNotFoundError:
+            pass
+
+    return _try_git_help_with_environment()
 
 
 def _add_file_argument(parser: argparse.ArgumentParser, help_text: str) -> None:
@@ -802,3 +869,7 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
         if not quiet:
             parser.print_usage(sys.stderr)
         return None
+    except SystemExit as e:
+        if quiet and e.code != 0:
+            return None
+        raise

--- a/src/git_stage_batch/meson.build
+++ b/src/git_stage_batch/meson.build
@@ -1,5 +1,3 @@
-package_dir = python.get_install_dir() / 'git_stage_batch'
-
 configure_file(
   input: '_version.py.in',
   output: '_version.py',

--- a/tests/cli/test_argument_parser.py
+++ b/tests/cli/test_argument_parser.py
@@ -1,11 +1,104 @@
 """Tests for CLI argument parsing."""
 
+import os
 from unittest.mock import Mock, call
 
 import pytest
 
 from git_stage_batch.cli import argument_parser
 from git_stage_batch.cli.argument_parser import parse_command_line
+
+
+def test_build_manpath_with_existing_environment(monkeypatch):
+    """Existing MANPATH should be preserved after the packaged root."""
+    monkeypatch.setattr(argument_parser, "_resolve_default_manpath", lambda: "/ignored")
+
+    result = argument_parser._build_manpath_with_packaged_page(
+        argument_parser.Path("/tmp/pkg-man"),
+        {"MANPATH": "/custom/man"},
+    )
+
+    assert result == f"/tmp/pkg-man{os.pathsep}/custom/man"
+
+
+def test_build_manpath_uses_computed_default(monkeypatch):
+    """Unset MANPATH should use the computed default search path."""
+    monkeypatch.setattr(argument_parser, "_resolve_default_manpath", lambda: "/usr/share/man:/usr/local/share/man")
+
+    result = argument_parser._build_manpath_with_packaged_page(
+        argument_parser.Path("/tmp/pkg-man"),
+        {},
+    )
+
+    assert result == f"/tmp/pkg-man{os.pathsep}/usr/share/man:/usr/local/share/man"
+
+
+def test_build_manpath_falls_back_to_double_colon(monkeypatch):
+    """Unset MANPATH should preserve default lookup semantics as a fallback."""
+    monkeypatch.setattr(argument_parser, "_resolve_default_manpath", lambda: None)
+
+    result = argument_parser._build_manpath_with_packaged_page(
+        argument_parser.Path("/tmp/pkg-man"),
+        {},
+    )
+
+    assert result == f"/tmp/pkg-man{os.pathsep}{os.pathsep}"
+
+
+def test_resolve_default_manpath_unsets_manpath(monkeypatch):
+    """Default manpath discovery should ignore the current MANPATH override."""
+    captured_env = {}
+
+    def fake_run(*_args, **kwargs):
+        nonlocal captured_env
+        captured_env = kwargs["env"]
+        return Mock(returncode=0, stdout="/usr/share/man\n")
+
+    monkeypatch.setattr(argument_parser.subprocess, "run", fake_run)
+    monkeypatch.setenv("MANPATH", "/custom/man")
+
+    result = argument_parser._resolve_default_manpath()
+
+    assert result == "/usr/share/man"
+    assert "MANPATH" not in captured_env
+
+
+def test_show_git_stage_batch_help_uses_packaged_page_first(monkeypatch, tmp_path):
+    """Packaged man pages should be added to MANPATH before invoking git help."""
+    manpage = tmp_path / "assets" / "man" / "man1" / "git-stage-batch.1"
+    manpage.parent.mkdir(parents=True)
+    manpage.write_text("test", encoding="utf-8")
+
+    monkeypatch.setattr(
+        argument_parser.resources,
+        "files",
+        lambda _package: tmp_path,
+    )
+
+    class _AsFile:
+        def __init__(self, path):
+            self.path = path
+
+        def __enter__(self):
+            return self.path
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(argument_parser.resources, "as_file", lambda path: _AsFile(path))
+    monkeypatch.setattr(argument_parser, "_resolve_default_manpath", lambda: "/usr/share/man")
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs.get("env")))
+        return Mock(returncode=0)
+
+    monkeypatch.setattr(argument_parser.subprocess, "run", fake_run)
+
+    assert argument_parser._show_git_stage_batch_help() is True
+    assert calls[0][0] == ["git", "help", "stage-batch"]
+    assert calls[0][1]["MANPATH"] == f"{manpage.parent.parent}{os.pathsep}/usr/share/man"
 
 
 def test_parse_command_line_version():

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -65,6 +65,16 @@ class TestWheelContents:
         for expected in expected_files:
             assert any(expected in f for f in files), f"Missing {expected}"
 
+    def test_wheel_contains_packaged_man_page(self, build_wheel):
+        """Test that wheel contains the packaged man page fallback."""
+        with zipfile.ZipFile(build_wheel, 'r') as whl:
+            files = whl.namelist()
+
+        assert any(
+            'git_stage_batch/assets/man/man1/git-stage-batch.1' in f
+            for f in files
+        ), "Missing packaged man page asset"
+
     def test_wheel_contains_entry_point_script(self, build_wheel):
         """Test that wheel contains the executable entry point."""
         with zipfile.ZipFile(build_wheel, 'r') as whl:


### PR DESCRIPTION
## Summary
- Hoists `package_dir` to the top-level `meson.build` so it's accessible for asset installation
- Installs the generated man page into the wheel at `git_stage_batch/assets/man/man1/`
- Adds runtime logic to locate the packaged man page via `importlib.resources`, prepend it to `MANPATH`, and pass that to `git help` before falling back to argparse output
- Adds tests for MANPATH construction, default manpath resolution, help display pipeline, and wheel packaging

## Test plan
- [ ] `uv run meson test -C builddir` passes all tests
- [ ] Install via `pipx` and verify `git stage-batch --help` shows the full man page
- [ ] Verify system package install still finds the man page through the normal path