### PR TITLE
Materialize man page for editable installs

### DIFF
--- a/src/git_stage_batch/cli/argument_parser.py
+++ b/src/git_stage_batch/cli/argument_parser.py
@@ -6,7 +6,9 @@ import argparse
 import os
 import subprocess
 import sys
+import tempfile
 from collections.abc import Callable
+from contextlib import nullcontext
 from importlib import resources
 from pathlib import Path
 
@@ -78,6 +80,27 @@ def _try_git_help_with_environment(env: dict[str, str] | None = None) -> bool:
     return result.returncode == 0
 
 
+def _with_real_manpath_root(manpage_path: Path):
+    """Yield a manpath root that contains man1/git-stage-batch.1."""
+    if manpage_path.parent.name == "man1":
+        return nullcontext(manpage_path.parent.parent)
+
+    class _TemporaryManRoot:
+        def __enter__(self):
+            self._temp_dir = tempfile.TemporaryDirectory(prefix="git-stage-batch-help-")
+            temp_root = Path(self._temp_dir.name)
+            temp_manpage = temp_root / "man1" / "git-stage-batch.1"
+            temp_manpage.parent.mkdir(parents=True, exist_ok=True)
+            temp_manpage.write_bytes(manpage_path.read_bytes())
+            return temp_root
+
+        def __exit__(self, exc_type, exc, tb):
+            self._temp_dir.cleanup()
+            return False
+
+    return _TemporaryManRoot()
+
+
 def _show_git_stage_batch_help() -> bool:
     """Show git-stage-batch help from packaged or system man pages."""
     try:
@@ -91,13 +114,14 @@ def _show_git_stage_batch_help() -> bool:
         try:
             with resources.as_file(packaged_manpage) as packaged_manpage_path:
                 if packaged_manpage_path.exists():
-                    env = os.environ.copy()
-                    env["MANPATH"] = _build_manpath_with_packaged_page(
-                        packaged_manpage_path.parent.parent,
-                        env,
-                    )
-                    if _try_git_help_with_environment(env):
-                        return True
+                    with _with_real_manpath_root(packaged_manpage_path) as man_root:
+                        env = os.environ.copy()
+                        env["MANPATH"] = _build_manpath_with_packaged_page(
+                            Path(man_root),
+                            env,
+                        )
+                        if _try_git_help_with_environment(env):
+                            return True
         except FileNotFoundError:
             pass
 

--- a/tests/cli/test_argument_parser.py
+++ b/tests/cli/test_argument_parser.py
@@ -101,6 +101,48 @@ def test_show_git_stage_batch_help_uses_packaged_page_first(monkeypatch, tmp_pat
     assert calls[0][1]["MANPATH"] == f"{manpage.parent.parent}{os.pathsep}/usr/share/man"
 
 
+def test_show_git_stage_batch_help_materializes_editable_manpage(monkeypatch, tmp_path):
+    """Editable installs should copy the man page into a real man1 tree."""
+    editable_manpage = tmp_path / "build" / "cp313" / "git-stage-batch.1"
+    editable_manpage.parent.mkdir(parents=True)
+    editable_manpage.write_text("test", encoding="utf-8")
+
+    class _EditableRoot:
+        def joinpath(self, *segments):
+            assert segments == ("assets", "man", "man1", "git-stage-batch.1")
+            return editable_manpage
+
+    monkeypatch.setattr(argument_parser.resources, "files", lambda _package: _EditableRoot())
+
+    class _AsFile:
+        def __init__(self, path):
+            self.path = path
+
+        def __enter__(self):
+            return self.path
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(argument_parser.resources, "as_file", lambda path: _AsFile(path))
+    monkeypatch.setattr(argument_parser, "_resolve_default_manpath", lambda: "/usr/share/man")
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs.get("env")))
+        manpath_root = kwargs["env"]["MANPATH"].split(os.pathsep, 1)[0]
+        staged_manpage = argument_parser.Path(manpath_root) / "man1" / "git-stage-batch.1"
+        assert staged_manpage.exists()
+        assert staged_manpage.read_text(encoding="utf-8") == "test"
+        return Mock(returncode=0)
+
+    monkeypatch.setattr(argument_parser.subprocess, "run", fake_run)
+
+    assert argument_parser._show_git_stage_batch_help() is True
+    assert calls[0][1]["MANPATH"].endswith(f"{os.pathsep}/usr/share/man")
+
+
 def test_parse_command_line_version():
     """Test parsing --version flag."""
     # --version causes argparse to exit, which is expected


### PR DESCRIPTION
## Summary
- Adds `_with_real_manpath_root()` context manager that creates a temporary `man1/` directory tree when the packaged man page resolves outside the expected hierarchy (e.g. editable installs where it lands under `build/cp313/`)
- Wires the context manager into `_show_git_stage_batch_help()` so `git help` finds the page regardless of install layout
- Adds a test simulating an editable install scenario, verifying the temporary tree is created correctly

## Test plan
- [x] Existing tests pass
- [x] New test covers editable install man page materialization
- [x] Standard (non-editable) install path unchanged