### PR TITLE
cli: Lock shared session state during command dispatch

### DIFF
--- a/src/git_stage_batch/cli/main.py
+++ b/src/git_stage_batch/cli/main.py
@@ -7,6 +7,7 @@ import sys
 from contextlib import nullcontext
 
 from ..exceptions import CommandError
+from ..utils.session_lock import acquire_session_lock
 from .argument_parser import parse_command_line
 from .dispatch import dispatch_args
 from .pager import pager_output, should_page_output
@@ -21,7 +22,8 @@ def main() -> None:
                 os.chdir(args.working_directory)
             pager_context = pager_output() if should_page_output(args) else nullcontext()
             with pager_context:
-                dispatch_args(args)
+                with acquire_session_lock():
+                    dispatch_args(args)
         else:
             # Parsing failed
             sys.exit(2)

--- a/src/git_stage_batch/core/line_selection.py
+++ b/src/git_stage_batch/core/line_selection.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Iterable
-
 from ..utils.file_io import read_text_file_contents, write_text_file_contents
 
 

--- a/src/git_stage_batch/utils/paths.py
+++ b/src/git_stage_batch/utils/paths.py
@@ -17,6 +17,15 @@ def get_state_directory_path() -> Path:
     return get_git_repository_root_path() / ".git" / "git-stage-batch"
 
 
+def get_session_lock_file_path() -> Path:
+    """Get the path to the session lock file.
+
+    Returns:
+        Path to session lock file
+    """
+    return get_state_directory_path() / "session.lock"
+
+
 def ensure_state_directory_exists() -> None:
     """Create the state directory if it doesn't exist."""
     get_state_directory_path().mkdir(parents=True, exist_ok=True)

--- a/src/git_stage_batch/utils/session_lock.py
+++ b/src/git_stage_batch/utils/session_lock.py
@@ -1,0 +1,49 @@
+"""Repository-scoped advisory lock for git-stage-batch session state."""
+
+from __future__ import annotations
+
+import fcntl
+from contextlib import contextmanager
+from pathlib import Path
+
+from .paths import ensure_state_directory_exists, get_session_lock_file_path
+
+_LOCK_DEPTH = 0
+_LOCK_HANDLE = None
+
+
+@contextmanager
+def acquire_session_lock():
+    """Hold an advisory lock covering the shared session-state directory.
+
+    The lock is process-reentrant so nested dispatches in interactive mode do
+    not deadlock. Because it uses `flock`, the kernel releases the lock
+    automatically if the process exits or crashes.
+    """
+    global _LOCK_DEPTH, _LOCK_HANDLE
+
+    if _LOCK_DEPTH > 0:
+        _LOCK_DEPTH += 1
+        try:
+            yield
+        finally:
+            _LOCK_DEPTH -= 1
+        return
+
+    ensure_state_directory_exists()
+    lock_path = get_session_lock_file_path()
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_handle = Path(lock_path).open("a+", encoding="utf-8")
+
+    try:
+        fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX)
+        _LOCK_HANDLE = lock_handle
+        _LOCK_DEPTH = 1
+        yield
+    finally:
+        _LOCK_DEPTH = 0
+        _LOCK_HANDLE = None
+        try:
+            fcntl.flock(lock_handle.fileno(), fcntl.LOCK_UN)
+        finally:
+            lock_handle.close()

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -2,6 +2,7 @@
 
 import sys
 from argparse import Namespace
+from contextlib import contextmanager
 from importlib import import_module
 from unittest.mock import patch
 
@@ -24,3 +25,30 @@ def test_main_with_no_args():
                 with pytest.raises(SystemExit) as exc_info:
                     main_module.main()
                 assert exc_info.value.code == 1
+
+
+def test_main_acquires_session_lock_before_dispatch():
+    """Test main runs dispatch inside the session lock."""
+    events = []
+
+    @contextmanager
+    def fake_lock():
+        events.append("lock-enter")
+        try:
+            yield
+        finally:
+            events.append("lock-exit")
+
+    def fake_dispatch(args):
+        events.append("dispatch")
+
+    args = Namespace(working_directory=None)
+
+    with patch.object(sys, "argv", ["git-stage-batch", "status"]):
+        with patch.object(main_module, "parse_command_line", return_value=args):
+            with patch.object(main_module, "should_page_output", return_value=False):
+                with patch.object(main_module, "acquire_session_lock", fake_lock):
+                    with patch.object(main_module, "dispatch_args", side_effect=fake_dispatch):
+                        main_module.main()
+
+    assert events == ["lock-enter", "dispatch", "lock-exit"]

--- a/tests/utils/test_paths.py
+++ b/tests/utils/test_paths.py
@@ -2,6 +2,7 @@
 
 from git_stage_batch.utils.paths import get_processed_include_ids_file_path
 from git_stage_batch.utils.paths import get_processed_skip_ids_file_path
+from git_stage_batch.utils.paths import get_session_lock_file_path
 from git_stage_batch.utils.paths import get_line_changes_json_file_path
 from git_stage_batch.utils.paths import get_index_snapshot_file_path
 from git_stage_batch.utils.paths import get_working_tree_snapshot_file_path
@@ -124,6 +125,13 @@ class TestLineLevelOperationPaths:
         working_tree_path = get_working_tree_snapshot_file_path()
         state_dir = get_state_directory_path()
         assert working_tree_path == state_dir / "session" / "selected" / "working-tree.snapshot"
+
+    def test_get_session_lock_file_path(self, temp_git_repo):
+        """Test getting the session lock file path."""
+
+        lock_path = get_session_lock_file_path()
+        state_dir = get_state_directory_path()
+        assert lock_path == state_dir / "session.lock"
 
 
 class TestGetContextLines:


### PR DESCRIPTION
The CLI dispatches commands against shared session state without any
coordination between concurrent invocations.

When multiple commands touch the same repository state at the same
time, they can observe or record session data in inconsistent order.
That makes later batch operations harder to reason about and can leave
session state out of sync with the command sequence users actually ran.

This PR addresses that by locking shared session state for the duration
of command dispatch and by adding coverage for the resulting dispatch
ordering.