### PR TITLE
staging: Support file-scoped replacement workflows

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -482,6 +482,67 @@ Line-level discard allows surgical removal of debug code, experimental changes, 
 
 ---
 
+### Replacement text with `--as`
+
+`include --line ... --as TEXT` stages replacement text for the selected line
+region instead of staging the working-tree text directly.
+`include --file PATH --as TEXT` stages `TEXT` as the full index content for
+that file while leaving the working tree unchanged.
+`discard --file PATH --as TEXT` replaces the working-tree content for that
+file-scoped path with `TEXT` without staging it.
+`discard --to BATCH --line ... --as TEXT` saves replacement text to the batch
+and removes the original selected lines from the working tree.
+
+For line-scoped replacement workflows, `--as` now trims exact unchanged edge
+anchor lines by default when the provided text includes surrounding preserved
+context from the selected file span. Pass `--no-anchor` to keep those edge
+anchors literally.
+
+If the replacement text should come from a file or another command exactly,
+use `--as-stdin` instead of shell command substitution. For example:
+
+```bash
+❯ git-stage-batch include --file path.txt --as-stdin < replacement.txt
+❯ some-command | git-stage-batch include --line 1-3 --as-stdin
+❯ git-stage-batch discard --file path.txt --as-stdin < replacement.txt
+❯ some-command | git-stage-batch discard --to batch --line 1-3 --as-stdin
+❯ git-stage-batch include --line 1-3 --as 'keep1\nstaged\nkeep4' --no-anchor
+```
+
+Unlike `--as "$(cat replacement.txt)"`, `--as-stdin` preserves trailing
+newlines exactly.
+
+These replacement workflows require one contiguous selected line-ID span.
+Selections such as `1-4` or `2,3,4` are accepted because they resolve to one
+continuous gutter-ID range. Selections such as `1-2,5-6` are rejected because
+they pick multiple disjoint ranges.
+
+In ordinary hunk views, that usually means replacing one displayed changed
+region. File-scoped views are more nuanced: they can concatenate multiple real
+hunks into one display and insert omitted gap markers between them. In that
+mode, one contiguous gutter-ID span may cross those omitted gaps and replace
+the full underlying file span from the first selected changed line to the last
+selected changed line.
+
+For example, if a file-scoped view shows three changed regions with IDs
+`1-2`, `3-4`, and `5-6`, then this is allowed:
+
+```bash
+❯ git-stage-batch include --line 1-6 --as '...'
+```
+
+But this still requires separate commands because the selected IDs are not one
+contiguous span:
+
+```bash
+❯ git-stage-batch include --line 1-2 --as '...'
+❯ git-stage-batch include --line 5-6 --as '...'
+```
+
+The same rule applies to `discard --to BATCH --line ... --as TEXT`.
+
+---
+
 ## Fixup Suggestions
 
 ### `suggest-fixup`

--- a/docs/git-stage-batch.1.in
+++ b/docs/git-stage-batch.1.in
@@ -213,6 +213,37 @@ Remove specific lines from the working tree.
 .B WARNING:
 This permanently removes the specified lines from your working tree.
 Allows surgical removal of debug code or unwanted modifications.
+.TP
+.B include \-\-line \fILINE_IDS\fR \-\-as \fITEXT\fR
+Stage replacement text for the selected changed region.
+When TEXT includes exact unchanged edge anchors from the preserved file
+context, those anchors are stripped by default.
+Replacement selections must form one contiguous displayed line-ID range.
+File-scoped views may span omitted gap markers when the selected IDs remain
+contiguous, but disjoint ranges still require separate commands.
+.TP
+.B include \-\-line \fILINE_IDS\fR \-\-as \fITEXT\fR \-\-no\-anchor
+Do not strip unchanged edge anchor lines from replacement text.
+.TP
+.B include \-\-file \fIPATH\fR \-\-as \fITEXT\fR
+Stage TEXT as the full index content for the selected file-scoped path while
+leaving the working tree unchanged.
+.TP
+.B discard \-\-file \fIPATH\fR \-\-as \fITEXT\fR
+Replace the working-tree content for the selected file-scoped path with TEXT
+without staging it.
+.TP
+.B discard \-\-to \fIBATCH\fR \-\-line \fILINE_IDS\fR \-\-as \fITEXT\fR
+Save replacement text to a batch and discard the original selected lines
+from the working tree.
+When TEXT includes exact unchanged edge anchors from the preserved file
+context, those anchors are stripped by default.
+Replacement selections must form one contiguous displayed line-ID range.
+File-scoped views may span omitted gap markers when the selected IDs remain
+contiguous, but disjoint ranges still require separate commands.
+.TP
+.B discard \-\-to \fIBATCH\fR \-\-line \fILINE_IDS\fR \-\-as \fITEXT\fR \-\-no\-anchor
+Do not strip unchanged edge anchor lines from replacement text.
 .SS Permanent File Exclusion
 .TP
 .B block-file \fR[\fIPATH\fR]

--- a/docs/index.md
+++ b/docs/index.md
@@ -179,6 +179,25 @@ Similar to `git add -p` but **more granular and flexible**:
 ❯ git-stage-batch include --line 1,3,5-7  # or: il 1,3,5-7
 ❯ git-stage-batch skip --line 2,4         # or: sl 2,4
 
+# Replacement text must use one contiguous displayed line-ID span
+❯ git-stage-batch include --line 1-2 --as 'replacement'
+
+# Exact unchanged edge anchors are stripped by default for line-scoped --as
+❯ git-stage-batch include --line 1-2 --as 'keep1\nreplacement\nkeep4'
+
+# Keep those anchors literally with --no-anchor
+❯ git-stage-batch include --line 1-2 --as 'keep1\nreplacement\nkeep4' --no-anchor
+
+# Or stage full replacement text for one file-scoped path
+❯ git-stage-batch include --file path.txt --as 'full staged file text'
+
+# Or replace one file-scoped working-tree path without staging it
+❯ git-stage-batch discard --file path.txt --as 'full working tree text'
+
+# Or preserve exact stdin text, including trailing newlines
+❯ git-stage-batch include --file path.txt --as-stdin < replacement.txt
+❯ git-stage-batch discard --file path.txt --as-stdin < replacement.txt
+
 # Check status
 ❯ git-stage-batch status  # or: st
 
@@ -190,6 +209,7 @@ Similar to `git add -p` but **more granular and flexible**:
 ```
 
 See [batch operations](batches.md) for advanced patch-series organization.
+See [commands reference](commands.md) for the `--as` contiguous-range rules.
 
 ## Example Workflow
 

--- a/src/git_stage_batch/batch/comparison.py
+++ b/src/git_stage_batch/batch/comparison.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from enum import Enum, auto
 
 from ..batch.match import match_lines
+from ..core.models import LineLevelChange
 
 
 class SemanticChangeKind(Enum):
@@ -243,3 +244,46 @@ def derive_semantic_change_runs(
 
     # Return in logical order: replacements, then deletions, then presences
     return replacements + deletions + presences
+
+
+def derive_display_id_run_sets(
+    line_changes: LineLevelChange,
+    *,
+    source_content: bytes,
+    target_content: bytes,
+) -> list[set[int]]:
+    """Map semantic change runs onto display IDs in one rendered selection."""
+    semantic_runs = derive_semantic_change_runs(
+        source_content.splitlines(keepends=True),
+        target_content.splitlines(keepends=True),
+    )
+
+    run_sets: list[set[int]] = []
+    for run in semantic_runs:
+        display_ids = {
+            line.id
+            for line in line_changes.lines
+            if line.id is not None and (
+                (
+                    run.kind == SemanticChangeKind.REPLACEMENT
+                    and (
+                        (line.kind == "-" and line.old_line_number in (run.source_run or []))
+                        or (line.kind == "+" and line.new_line_number in (run.target_run or []))
+                    )
+                )
+                or (
+                    run.kind == SemanticChangeKind.DELETION
+                    and line.kind == "-"
+                    and line.old_line_number in (run.source_run or [])
+                )
+                or (
+                    run.kind == SemanticChangeKind.PRESENCE
+                    and line.kind == "+"
+                    and line.new_line_number in (run.target_run or [])
+                )
+            )
+        }
+        if display_ids:
+            run_sets.append(display_ids)
+
+    return run_sets

--- a/src/git_stage_batch/batch/semantic_selection.py
+++ b/src/git_stage_batch/batch/semantic_selection.py
@@ -277,6 +277,9 @@ def _build_temporary_ownership_for_selected_hunk(
             pairing_modes.add("addition")
             for line in additions:
                 if line.id in selected_display_ids:
+                    anchor = previous_source_line()
+                    if anchor is not None:
+                        claimed_source_lines.add(anchor)
                     source_lines.append(
                         _line_content_from_snapshot(
                             hunk_source_lines,
@@ -334,8 +337,14 @@ def _build_temporary_ownership_for_selected_hunk(
     run: list[LineEntry] = []
     for line in line_changes.lines:
         if line.kind == " ":
+            is_gap_line = (
+                line.old_line_number is None
+                and line.new_line_number is None
+            )
             flush_run(run)
             run = []
+            if is_gap_line:
+                continue
             copy_remaining_baseline_until(max(old_pointer, (line.old_line_number or 1) - 1))
             if old_pointer < len(hunk_base_lines):
                 source_lines.append(hunk_base_lines[old_pointer])

--- a/src/git_stage_batch/batch/source_refresh.py
+++ b/src/git_stage_batch/batch/source_refresh.py
@@ -198,8 +198,9 @@ def _refresh_selected_lines_against_new_source(selected_lines: list) -> list:
             if source_line is not None:
                 last_source_line = source_line
         elif line.kind == '-':
-            # Deletion: use last known source line (anchor point)
             source_line = last_source_line
+            if source_line is None and line.old_line_number is not None and line.old_line_number > 1:
+                source_line = line.old_line_number - 1
         else:
             source_line = None
 
@@ -241,6 +242,10 @@ def _refresh_selected_lines_against_source_content(
                 last_source_line = source_line
         elif line.kind == '-':
             source_line = last_source_line
+            if source_line is None and line.old_line_number is not None and line.old_line_number > 1:
+                source_line = mapping.get_source_line_from_target_line(
+                    line.old_line_number - 1
+                )
         else:
             source_line = None
 

--- a/src/git_stage_batch/cli/argument_parser.py
+++ b/src/git_stage_batch/cli/argument_parser.py
@@ -16,8 +16,9 @@ from .. import __version__
 from ..batch.validation import batch_exists
 from .. import commands
 from ..batch.query import read_batch_metadata
+from ..data.hunk_tracking import advance_to_next_change, show_selected_change
 from ..exceptions import CommandError
-from ..i18n import _
+from ..i18n import _, ngettext
 from ..utils.file_patterns import list_changed_files, resolve_gitignore_style_patterns
 from .completion import command_complete_files
 
@@ -173,6 +174,88 @@ def _run_for_each_file(
     callback(file_arg)
 
 
+def _include_each_resolved_file(files: list[str]) -> None:
+    """Stage a multi-file live scope and report one aggregate summary."""
+    total_hunks = 0
+    staged_files: list[str] = []
+
+    for file_path in files:
+        staged_hunks = commands.command_include_file(
+            file_path,
+            quiet=True,
+            advance=False,
+        )
+        if staged_hunks > 0:
+            total_hunks += staged_hunks
+            staged_files.append(file_path)
+
+    if total_hunks == 0:
+        print(_("No hunks staged from matched files."), file=sys.stderr)
+        return
+
+    advance_to_next_change()
+
+    if len(staged_files) == 1:
+        file_summary = staged_files[0]
+    else:
+        file_summary = ngettext(
+            "{count} file",
+            "{count} files",
+            len(staged_files),
+        ).format(count=len(staged_files))
+
+    print(
+        ngettext(
+            "✓ Staged {count} hunk from {files}",
+            "✓ Staged {count} hunks from {files}",
+            total_hunks,
+        ).format(count=total_hunks, files=file_summary),
+        file=sys.stderr,
+    )
+    show_selected_change()
+
+
+def _skip_each_resolved_file(files: list[str]) -> None:
+    """Skip a multi-file live scope and report one aggregate summary."""
+    total_hunks = 0
+    skipped_files: list[str] = []
+
+    for file_path in files:
+        skipped_hunks = commands.command_skip_file(
+            file_path,
+            quiet=True,
+            advance=False,
+        )
+        if skipped_hunks > 0:
+            total_hunks += skipped_hunks
+            skipped_files.append(file_path)
+
+    if total_hunks == 0:
+        print(_("No hunks skipped from matched files."), file=sys.stderr)
+        return
+
+    advance_to_next_change()
+
+    if len(skipped_files) == 1:
+        file_summary = skipped_files[0]
+    else:
+        file_summary = ngettext(
+            "{count} file",
+            "{count} files",
+            len(skipped_files),
+        ).format(count=len(skipped_files))
+
+    print(
+        ngettext(
+            "✓ Skipped {count} hunk from {files}",
+            "✓ Skipped {count} hunks from {files}",
+            total_hunks,
+        ).format(count=total_hunks, files=file_summary),
+        file=sys.stderr,
+    )
+    show_selected_change()
+
+
 def _resolve_live_file_scope(
     file_arg: str | None,
     file_patterns: list[str] | None,
@@ -218,6 +301,15 @@ def _resolve_batch_file_scope(
     if len(resolved_files) == 1:
         return resolved_files[0]
     return resolved_files
+
+
+def _resolve_replacement_text(args: argparse.Namespace) -> str | None:
+    """Return replacement text from `--as` or exact stdin content."""
+    if getattr(args, "as_text", None) is not None and getattr(args, "as_stdin", False):
+        raise CommandError(_("Cannot use `--as` and `--as-stdin` together."))
+    if getattr(args, "as_stdin", False):
+        return sys.stdin.buffer.read().decode("utf-8", errors="surrogateescape")
+    return getattr(args, "as_text", None)
 
 
 def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Namespace | None:
@@ -461,34 +553,68 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
         "--as",
         dest="as_text",
         metavar="TEXT",
-        help=_("Replace selected lines with TEXT before staging them"),
+        help=_("Replace selected lines, or full file with --file, using TEXT before staging"),
+    )
+    parser_include.add_argument(
+        "--as-stdin",
+        dest="as_stdin",
+        action="store_true",
+        help=_("Read replacement text from standard input exactly, preserving trailing newlines"),
+    )
+    parser_include.add_argument(
+        "--no-anchor",
+        dest="no_anchor",
+        action="store_true",
+        help=_("Do not strip unchanged edge anchor lines from replacement text used with --as"),
     )
 
     def dispatch_include(args: argparse.Namespace) -> None:
+        replacement_text = _resolve_replacement_text(args)
         resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
         resolved_batch_scope = (
             _resolve_batch_file_scope(args.from_batch, args.file, args.file_patterns)
             if args.from_batch else None
         )
-        if args.as_text is not None:
+        if replacement_text is not None:
             if args.line_ids and args.from_batch and not args.to_batch:
+                if args.no_anchor:
+                    raise CommandError(_("`--no-anchor` only applies to live `include --line --as` operations."))
                 if isinstance(resolved_batch_scope, list):
                     raise CommandError(_("Cannot use --lines with multiple files."))
                 commands.command_include_from_batch(
                     args.from_batch,
                     args.line_ids,
                     file=resolved_batch_scope,
-                    replacement_text=args.as_text,
+                    replacement_text=replacement_text,
                 )
                 return
             if args.line_ids and not args.from_batch and not args.to_batch:
                 if isinstance(resolved_live_scope, list):
                     raise CommandError(_("Cannot use --lines with multiple files."))
-                commands.command_include_line_as(args.line_ids, args.as_text, file=resolved_live_scope)
+                commands.command_include_line_as(
+                    args.line_ids,
+                    replacement_text,
+                    file=resolved_live_scope,
+                    no_anchor=args.no_anchor,
+                )
+                return
+            if (
+                args.line_ids is None
+                and args.from_batch is None
+                and args.to_batch is None
+                and resolved_live_scope is not None
+            ):
+                if args.no_anchor:
+                    raise CommandError(_("`--no-anchor` requires `include --line --as`."))
+                if isinstance(resolved_live_scope, list):
+                    raise CommandError(_("Cannot use --as with multiple files."))
+                commands.command_include_file_as(replacement_text, file=resolved_live_scope)
                 return
             raise CommandError(
-                _("`include --as` requires `--line` and does not support `--to`.")
+                _("`include --as` requires `--file` or `--line` and does not support `--to`.")
             )
+        if args.no_anchor:
+            raise CommandError(_("`--no-anchor` requires `include --line --as`."))
         if args.from_batch:
             _run_for_each_file(
                 resolved_batch_scope,
@@ -506,7 +632,10 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
                 raise CommandError(_("Cannot use --lines with multiple files."))
             commands.command_include_line(args.line_ids, file=resolved_live_scope)
         elif resolved_live_scope is not None:
-            _run_for_each_file(resolved_live_scope, commands.command_include_file)
+            if isinstance(resolved_live_scope, list):
+                _include_each_resolved_file(resolved_live_scope)
+            else:
+                commands.command_include_file(resolved_live_scope)
         else:
             commands.command_include()
 
@@ -539,7 +668,10 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
                 raise CommandError(_("Cannot use --lines with multiple files."))
             commands.command_skip_line(args.line_ids)
         elif resolved_file_scope is not None:
-            _run_for_each_file(resolved_file_scope, commands.command_skip_file)
+            if isinstance(resolved_file_scope, list):
+                _skip_each_resolved_file(resolved_file_scope)
+            else:
+                commands.command_skip_file(resolved_file_scope)
         else:
             commands.command_skip()
 
@@ -581,29 +713,57 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
         "--as",
         dest="as_text",
         metavar="TEXT",
-        help=_("Replace selected lines with TEXT before saving them to batch"),
+        help=_("Replace selected lines, or full file with --file, using TEXT"),
+    )
+    parser_discard.add_argument(
+        "--as-stdin",
+        dest="as_stdin",
+        action="store_true",
+        help=_("Read replacement text from standard input exactly, preserving trailing newlines"),
+    )
+    parser_discard.add_argument(
+        "--no-anchor",
+        dest="no_anchor",
+        action="store_true",
+        help=_("Do not strip unchanged edge anchor lines from replacement text used with --as"),
     )
 
     def dispatch_discard(args: argparse.Namespace) -> None:
+        replacement_text = _resolve_replacement_text(args)
         resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
         resolved_batch_scope = (
             _resolve_batch_file_scope(args.from_batch, args.file, args.file_patterns)
             if args.from_batch else None
         )
-        if args.as_text is not None:
+        if replacement_text is not None:
             if args.to_batch and args.line_ids and not args.from_batch:
                 if isinstance(resolved_live_scope, list):
                     raise CommandError(_("Cannot use --lines with multiple files."))
                 commands.command_discard_line_as_to_batch(
                     args.to_batch,
                     args.line_ids,
-                    args.as_text,
+                    replacement_text,
                     file=resolved_live_scope,
+                    no_anchor=args.no_anchor,
                 )
                 return
+            if (
+                args.to_batch is None
+                and args.from_batch is None
+                and args.line_ids is None
+                and resolved_live_scope is not None
+            ):
+                if args.no_anchor:
+                    raise CommandError(_("`--no-anchor` requires `discard --to --line --as`."))
+                if isinstance(resolved_live_scope, list):
+                    raise CommandError(_("Cannot use --as with multiple files."))
+                commands.command_discard_file_as(replacement_text, file=resolved_live_scope)
+                return
             raise CommandError(
-                _("`discard --as` requires `--to` and `--line`.")
+                _("`discard --as` requires `--file`, or `--to` with `--line`.")
             )
+        if args.no_anchor:
+            raise CommandError(_("`--no-anchor` requires `discard --to --line --as`."))
         if args.from_batch:
             _run_for_each_file(
                 resolved_batch_scope,

--- a/src/git_stage_batch/commands/__init__.py
+++ b/src/git_stage_batch/commands/__init__.py
@@ -7,7 +7,7 @@ from .again import command_again
 from .annotate import command_annotate_batch
 from .apply_from import command_apply_from_batch
 from .block_file import command_block_file
-from .discard import command_discard, command_discard_file, command_discard_line, command_discard_line_as_to_batch, command_discard_to_batch
+from .discard import command_discard, command_discard_file, command_discard_file_as, command_discard_line, command_discard_line_as_to_batch, command_discard_to_batch
 from .discard_from import command_discard_from_batch
 from .drop import command_drop_batch
 from .include import command_include, command_include_file, command_include_line, command_include_line_as, command_include_to_batch
@@ -36,6 +36,7 @@ __all__ = [
     "command_block_file",
     "command_discard",
     "command_discard_file",
+    "command_discard_file_as",
     "command_discard_line",
     "command_discard_line_as_to_batch",
     "command_discard_to_batch",

--- a/src/git_stage_batch/commands/__init__.py
+++ b/src/git_stage_batch/commands/__init__.py
@@ -10,7 +10,7 @@ from .block_file import command_block_file
 from .discard import command_discard, command_discard_file, command_discard_file_as, command_discard_line, command_discard_line_as_to_batch, command_discard_to_batch
 from .discard_from import command_discard_from_batch
 from .drop import command_drop_batch
-from .include import command_include, command_include_file, command_include_line, command_include_line_as, command_include_to_batch
+from .include import command_include, command_include_file, command_include_file_as, command_include_line, command_include_line_as, command_include_to_batch
 from .include_from import command_include_from_batch
 from .interactive import command_interactive
 from .list import command_list_batches

--- a/src/git_stage_batch/commands/__init__.py
+++ b/src/git_stage_batch/commands/__init__.py
@@ -44,6 +44,7 @@ __all__ = [
     "command_drop_batch",
     "command_include",
     "command_include_file",
+    "command_include_file_as",
     "command_include_line",
     "command_include_line_as",
     "command_include_from_batch",

--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -26,12 +26,16 @@ from ..core.hashing import compute_stable_hunk_hash
 from ..core.line_selection import parse_line_selection
 from ..core.models import BinaryFileChange
 from ..data.hunk_tracking import (
+    SelectedChangeKind,
     advance_to_and_show_next_change,
     advance_to_next_change,
     build_file_hunk_from_content,
     cache_file_as_single_hunk,
+    cache_unstaged_file_as_single_hunk,
     fetch_next_change,
     get_selected_change_file_path,
+    load_selected_change,
+    read_selected_change_kind,
     recalculate_selected_hunk_for_file,
     record_hunk_discarded,
     require_selected_hunk,
@@ -40,7 +44,7 @@ from ..data.line_state import load_line_changes_from_state
 from ..data.batch_sources import create_batch_source_commit, load_session_batch_sources, save_session_batch_sources
 from ..data.session import require_session_started, snapshot_file_if_untracked
 from ..data.undo import undo_checkpoint
-from ..exceptions import exit_with_error, NoMoreHunks
+from ..exceptions import CommandError, exit_with_error, NoMoreHunks
 from ..i18n import _, ngettext
 from ..staging.operations import build_target_working_tree_content_bytes_with_discarded_lines
 from ..staging.operations import build_target_working_tree_content_bytes_with_replaced_lines
@@ -76,6 +80,8 @@ def _load_explicit_file_selection(file_path: str):
     if line_changes is None:
         exit_with_error(_("No changes in file '{file}'.").format(file=file_path))
     return line_changes
+
+
 def command_discard(*, quiet: bool = False) -> None:
     """Discard the selected hunk or binary file from the working tree."""
 
@@ -216,6 +222,40 @@ def command_discard(*, quiet: bool = False) -> None:
             advance_to_and_show_next_change()
 
 
+def _command_discard_selected_file(*, quiet: bool = False) -> None:
+    """Discard all changes from the currently selected file-scoped view."""
+    target_file = get_selected_change_file_path()
+    if target_file is None:
+        if not quiet:
+            print(_("No selected hunk. Run 'show' first or specify file path."), file=sys.stderr)
+        return
+
+    with undo_checkpoint("discard"):
+        snapshot_file_if_untracked(target_file)
+
+        head_result = run_git_command(
+            ["show", f"HEAD:{target_file}"],
+            check=False,
+            text_output=False,
+        )
+        if head_result.returncode == 0:
+            result = run_git_command(["checkout", "HEAD", "--", target_file], check=False)
+            if result.returncode != 0:
+                if not quiet:
+                    print(_("Failed to discard file: {}").format(result.stderr), file=sys.stderr)
+                return
+        else:
+            absolute_path = get_git_repository_root_path() / target_file
+            if absolute_path.exists():
+                absolute_path.unlink()
+
+        if quiet:
+            advance_to_next_change()
+        else:
+            print(_("✓ File discarded: {}").format(target_file), file=sys.stderr)
+            advance_to_and_show_next_change()
+
+
 def command_discard_file(file: str) -> None:
     """Discard the entire specified file from the working tree.
 
@@ -231,16 +271,14 @@ def command_discard_file(file: str) -> None:
 
     # Determine target file
     if file == "":
-        # --file with no arg: use selected hunk's file
-        try:
-            fetch_next_change()
-        except NoMoreHunks:
-            print(_("No more hunks to process."), file=sys.stderr)
+        target_file = get_selected_change_file_path()
+        if target_file is None:
+            diff_result = run_git_command(["diff", "--quiet"], check=False)
+            if diff_result.returncode == 0:
+                print(_("No more hunks to process."), file=sys.stderr)
+            else:
+                print(_("No selected hunk. Run 'show' first or specify file path."), file=sys.stderr)
             return
-
-        # Get the target file from currently cached hunk
-        line_changes = load_line_changes_from_state()
-        target_file = line_changes.path
     else:
         # Explicit path provided
         target_file = file
@@ -324,6 +362,8 @@ def command_discard_file_as(replacement_text: str, file: str | None = None) -> N
             recalculate_selected_hunk_for_file(line_changes.path)
 
     print(_("✓ Discarded file as replacement: {file}").format(file=target_file), file=sys.stderr)
+
+
 def command_discard_line(line_id_specification: str, file: str | None = None) -> None:
     """Discard only the specified lines from the working tree.
 
@@ -351,9 +391,7 @@ def command_discard_line(line_id_specification: str, file: str | None = None) ->
             else:
                 target_file = file
 
-            line_changes = cache_file_as_single_hunk(target_file)
-            if line_changes is None:
-                exit_with_error(_("No changes in file '{file}'.").format(file=target_file))
+            line_changes = _load_explicit_file_selection(target_file)
 
         requested_ids = parse_line_selection(line_id_specification)
 
@@ -429,6 +467,7 @@ def command_discard_line_as_to_batch(
     replacement_text: str,
     file: str | None = None,
     *,
+    no_anchor: bool = False,
     quiet: bool = False,
 ) -> None:
     """Save replacement text to batch, then discard the original selection locally."""
@@ -442,6 +481,8 @@ def command_discard_line_as_to_batch(
         "--line", line_id_specification,
         "--as", replacement_text,
     ]
+    if no_anchor:
+        operation_parts.append("--no-anchor")
     if file is not None:
         operation_parts.extend(["--file", file])
     with undo_checkpoint(" ".join(operation_parts)):
@@ -459,14 +500,13 @@ def command_discard_line_as_to_batch(
                 else:
                     target_file = file
 
-                cached_lines = cache_file_as_single_hunk(target_file)
-                if cached_lines is None:
-                    exit_with_error(_("No changes in file '{file}'.").format(file=target_file))
+                cached_lines = _load_explicit_file_selection(target_file)
 
             _command_discard_lines_to_batch_as(
                 batch_name,
                 line_id_specification,
                 replacement_text,
+                no_anchor=no_anchor,
                 quiet=quiet,
             )
 
@@ -482,15 +522,17 @@ def _command_discard_lines_to_batch_as(
     line_id_specification: str,
     replacement_text: str,
     *,
+    no_anchor: bool = False,
     quiet: bool = False,
 ) -> None:
     """Persist replacement text to batch and discard original selected lines."""
+    line_changes = load_line_changes_from_state()
+    requested_ids = set(parse_line_selection(line_id_specification))
+    effective_ids = _expand_replacement_selection_ids(line_changes, requested_ids)
+
     if not batch_exists(batch_name):
         create_batch(batch_name, "Auto-created")
 
-    requested_ids = set(parse_line_selection(line_id_specification))
-    line_changes = load_line_changes_from_state()
-    effective_ids = _expand_replacement_selection_ids(line_changes, requested_ids)
     selected_lines = [line for line in line_changes.lines if line.id in effective_ids]
     if not selected_lines:
         exit_with_error(_("No matching lines found for selection: {ids}").format(ids=line_id_specification))
@@ -506,6 +548,7 @@ def _command_discard_lines_to_batch_as(
             effective_ids,
             replacement_text,
             working_bytes,
+            trim_unchanged_edge_anchors=not no_anchor,
         )
     except ValueError as e:
         exit_with_error(str(e))
@@ -833,14 +876,10 @@ def _command_discard_file_to_batch(batch_name: str, file_path: str, *, quiet: bo
 def _command_discard_file_lines_to_batch(batch_name: str, file_path: str, line_id_specification: str, *, quiet: bool = False) -> None:
     """Discard specific lines from a file to batch (file-scoped with line IDs)."""
 
-    # Cache entire file as a single hunk
-    cached_lines = cache_file_as_single_hunk(file_path)
-    if cached_lines is None:
-        exit_with_error(_("No changes in file '{file}'.").format(file=file_path))
+    cached_lines = _load_explicit_file_selection(file_path)
 
     # Annotate with batch source line numbers
     line_changes = annotate_with_batch_source(file_path, cached_lines)
-
     # Auto-create batch if it doesn't exist
     if not batch_exists(batch_name):
         create_batch(batch_name, "Auto-created")

--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -64,13 +64,25 @@ def command_discard(*, quiet: bool = False) -> None:
     require_session_started()
     ensure_state_directory_exists()
 
-    # Find and cache the next item
-    try:
-        item = fetch_next_change()
-    except NoMoreHunks:
-        if not quiet:
-            print(_("No more hunks to process."), file=sys.stderr)
+    if read_selected_change_kind() == SelectedChangeKind.FILE:
+        _command_discard_selected_file(quiet=quiet)
         return
+
+    try:
+        item = load_selected_change()
+    except CommandError as error:
+        if error.message == _("Cached hunk is stale (file was changed). Run 'start' or 'again' to continue."):
+            item = None
+        else:
+            raise
+
+    if item is None:
+        try:
+            item = fetch_next_change()
+        except NoMoreHunks:
+            if not quiet:
+                print(_("No more hunks to process."), file=sys.stderr)
+            return
     with undo_checkpoint("discard"):
         # Read cached hash
         patch_hash = read_text_file_contents(get_selected_hunk_hash_file_path()).strip()

--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -55,6 +55,20 @@ from .include import (
 )
 
 
+def _load_explicit_file_selection(file_path: str):
+    """Return the active file-scoped view for an explicit discard target."""
+    reuse_selected_file_view = (
+        read_selected_change_kind() == SelectedChangeKind.FILE
+        and get_selected_change_file_path() == file_path
+    )
+    if reuse_selected_file_view:
+        line_changes = load_line_changes_from_state()
+    else:
+        line_changes = cache_unstaged_file_as_single_hunk(file_path)
+
+    if line_changes is None:
+        exit_with_error(_("No changes in file '{file}'.").format(file=file_path))
+    return line_changes
 def command_discard(*, quiet: bool = False) -> None:
     """Discard the selected hunk or binary file from the working tree."""
 
@@ -267,6 +281,42 @@ def command_discard_file(file: str) -> None:
         advance_to_and_show_next_change()
 
 
+def command_discard_file_as(replacement_text: str, file: str | None = None) -> None:
+    """Replace one live file-scoped working-tree file with explicit text."""
+    require_git_repository()
+    require_session_started()
+    ensure_state_directory_exists()
+
+    operation_parts = ["discard", "--as", replacement_text]
+    if file is not None:
+        operation_parts.extend(["--file", file])
+
+    with undo_checkpoint(" ".join(operation_parts)):
+        preserve_selected_state = False
+        saved_selected_state = None
+
+        if file is None or file == "":
+            target_file = get_selected_change_file_path()
+            if target_file is None:
+                exit_with_error(_("No selected hunk. Run 'show' first or specify file path."))
+        else:
+            target_file = file
+            preserve_selected_state = True
+            saved_selected_state = _snapshot_selected_change_state()
+
+        line_changes = _load_explicit_file_selection(target_file)
+        snapshot_file_if_untracked(target_file)
+
+        absolute_path = get_git_repository_root_path() / target_file
+        absolute_path.parent.mkdir(parents=True, exist_ok=True)
+        absolute_path.write_text(replacement_text, encoding="utf-8", errors="surrogateescape")
+
+        if preserve_selected_state:
+            _restore_selected_change_state(saved_selected_state)
+        else:
+            recalculate_selected_hunk_for_file(line_changes.path)
+
+    print(_("✓ Discarded file as replacement: {file}").format(file=target_file), file=sys.stderr)
 def command_discard_line(line_id_specification: str, file: str | None = None) -> None:
     """Discard only the specified lines from the working tree.
 

--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -7,9 +7,16 @@ import sys
 
 from ..batch import add_file_to_batch, create_batch
 from ..batch.display import annotate_with_batch_source, annotate_with_batch_source_content
-from ..batch.ownership import BatchOwnership
+from ..batch.ownership import (
+    BatchOwnership,
+    _advance_source_content_preserving_existing_presence,
+    _remap_batch_ownership_with_source_line_map,
+    merge_batch_ownership,
+    translate_lines_to_batch_ownership,
+)
 from ..batch.query import read_batch_metadata
 from ..batch.source_refresh import prepare_batch_ownership_update_for_selection
+from ..batch.source_refresh import _refresh_selected_lines_against_source_content
 from ..batch.validation import batch_exists
 from ..core.diff_parser import (
     build_line_changes_from_patch_bytes,
@@ -520,20 +527,59 @@ def _command_discard_lines_to_batch_as(
         metadata = read_batch_metadata(batch_name)
         existing_ownership = None
         current_batch_source = None
+        batch_source_commit = None
         if line_changes.path in metadata.get("files", {}):
             file_metadata = metadata["files"][line_changes.path]
             existing_ownership = BatchOwnership.from_metadata_dict(file_metadata)
             current_batch_source = file_metadata.get("batch_source_commit")
 
         try:
-            update = prepare_batch_ownership_update_for_selection(
-                batch_name=batch_name,
-                file_path=line_changes.path,
-                current_batch_source_commit=current_batch_source,
-                existing_ownership=existing_ownership,
-                selected_lines=rewritten_selected_lines,
-            )
-            ownership = update.ownership_after
+            if existing_ownership is None:
+                update = prepare_batch_ownership_update_for_selection(
+                    batch_name=batch_name,
+                    file_path=line_changes.path,
+                    current_batch_source_commit=current_batch_source,
+                    existing_ownership=existing_ownership,
+                    selected_lines=rewritten_selected_lines,
+                )
+                ownership = update.ownership_after
+                batch_source_commit = update.batch_source_commit
+            else:
+                old_source_result = run_git_command(
+                    ["show", f"{current_batch_source}:{line_changes.path}"],
+                    text_output=False,
+                    check=False,
+                )
+                if old_source_result.returncode != 0:
+                    exit_with_error(
+                        _("Cannot discard lines to batch: failed to read batch source for '{file}'.").format(
+                            file=line_changes.path
+                        )
+                    )
+
+                new_source_content, source_line_map = _advance_source_content_preserving_existing_presence(
+                    old_source_content=old_source_result.stdout,
+                    working_content=rewritten_working_content,
+                    ownership=existing_ownership,
+                )
+                remapped_existing_ownership = _remap_batch_ownership_with_source_line_map(
+                    ownership=existing_ownership,
+                    source_line_map=source_line_map,
+                )
+                refreshed_selected_lines = _refresh_selected_lines_against_source_content(
+                    rewritten_selected_lines,
+                    source_content=new_source_content,
+                    working_content=rewritten_working_content,
+                )
+                new_ownership = translate_lines_to_batch_ownership(refreshed_selected_lines)
+                ownership = merge_batch_ownership(remapped_existing_ownership, new_ownership)
+                batch_source_commit = create_batch_source_commit(
+                    line_changes.path,
+                    file_content_override=new_source_content,
+                )
+                batch_sources = load_session_batch_sources()
+                batch_sources[line_changes.path] = batch_source_commit
+                save_session_batch_sources(batch_sources)
         except ValueError as e:
             exit_with_error(
                 _("Cannot discard lines to batch: batch source is stale and remapping failed.\n"
@@ -549,7 +595,6 @@ def _command_discard_lines_to_batch_as(
             if parts:
                 file_mode = parts[0]
 
-        batch_source_commit = current_batch_source
         if batch_source_commit is None:
             batch_source_commit = create_batch_source_commit(
                 line_changes.path,
@@ -599,7 +644,7 @@ def _select_rewritten_replacement_lines(
     original_selected_lines: list,
     rewritten_line_changes,
 ) -> list:
-    """Find the contiguous rewritten changed run that overlaps the original selection."""
+    """Find the rewritten changed span that overlaps the original selection."""
     original_old_lines = {
         line.old_line_number
         for line in original_selected_lines
@@ -611,23 +656,22 @@ def _select_rewritten_replacement_lines(
         if line.new_line_number is not None
     }
 
-    runs: list[list] = []
-    current_run: list = []
-    for line in rewritten_line_changes.lines:
-        if line.kind == " ":
-            if current_run:
-                runs.append(current_run)
-                current_run = []
-            continue
-        current_run.append(line)
-    if current_run:
-        runs.append(current_run)
-
-    for run in runs:
-        run_old_lines = {line.old_line_number for line in run if line.old_line_number is not None}
-        run_new_lines = {line.new_line_number for line in run if line.new_line_number is not None}
-        if run_old_lines & original_old_lines or run_new_lines & original_new_lines:
-            return run
+    matching_indices = [
+        index
+        for index, line in enumerate(rewritten_line_changes.lines)
+        if line.kind != " " and (
+            line.old_line_number in original_old_lines
+            or line.new_line_number in original_new_lines
+        )
+    ]
+    if matching_indices:
+        start_index = min(matching_indices)
+        end_index = max(matching_indices)
+        return [
+            line
+            for line in rewritten_line_changes.lines[start_index:end_index + 1]
+            if line.kind != " "
+        ]
 
     exit_with_error(_("Replacement selection could not be located after rewriting the file."))
 

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -682,14 +682,20 @@ def _command_include_file_to_batch(batch_name: str, file_path: str, *, quiet: bo
 def _command_include_file_lines_to_batch(batch_name: str, file_path: str, line_id_specification: str, *, quiet: bool = False) -> None:
     """Include specific lines from a file to batch (file-scoped with line IDs)."""
 
-    # Cache entire file as a single hunk
-    cached_lines = cache_file_as_single_hunk(file_path)
+    reuse_selected_file_view = (
+        read_selected_change_kind() == SelectedChangeKind.FILE
+        and get_selected_change_file_path() == file_path
+    )
+    if reuse_selected_file_view:
+        cached_lines = load_line_changes_from_state()
+    else:
+        cached_lines = cache_unstaged_file_as_single_hunk(file_path)
+
     if cached_lines is None:
         exit_with_error(_("No changes in file '{file}'.").format(file=file_path))
 
     # Annotate with batch source line numbers
     line_changes = annotate_with_batch_source(file_path, cached_lines)
-
     # Auto-create batch if it doesn't exist
     if not batch_exists(batch_name):
         create_batch(batch_name, "Auto-created")

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -5,21 +5,31 @@ from __future__ import annotations
 import sys
 
 from ..batch import add_file_to_batch, create_batch
+from ..batch.comparison import (
+    SemanticChangeKind,
+    derive_display_id_run_sets,
+    derive_semantic_change_runs,
+)
 from ..batch.display import annotate_with_batch_source
-from ..batch.ownership import BatchOwnership, translate_lines_to_batch_ownership
+from ..batch.ownership import BatchOwnership
 from ..batch.query import read_batch_metadata
 from ..batch.semantic_selection import try_build_semantic_selection_for_selected_hunk
 from ..batch.source_refresh import prepare_batch_ownership_update_for_selection
 from ..batch.validation import batch_exists
 from ..core.diff_parser import (
     build_line_changes_from_patch_bytes,
-    get_first_matching_file_from_diff,
     parse_unified_diff_streaming,
 )
 from ..core.hashing import compute_stable_hunk_hash
-from ..core.line_selection import parse_line_selection, read_line_ids_file, write_line_ids_file
+from ..core.line_selection import (
+    format_line_ids,
+    parse_line_selection,
+    read_line_ids_file,
+    write_line_ids_file,
+)
 from ..core.models import BinaryFileChange
 from ..data.hunk_tracking import (
+    SelectedChangeKind,
     advance_to_and_show_next_change,
     advance_to_next_change,
     apply_line_level_batch_filter_to_cached_hunk,
@@ -28,6 +38,8 @@ from ..data.hunk_tracking import (
     clear_selected_change_state_files,
     fetch_next_change,
     get_selected_change_file_path,
+    load_selected_change,
+    read_selected_change_kind,
     recalculate_selected_hunk_for_file,
     record_hunk_included,
     record_hunk_skipped,
@@ -54,6 +66,7 @@ from ..utils.paths import (
     get_block_list_file_path,
     get_context_lines,
     get_line_changes_json_file_path,
+    get_selected_change_kind_file_path,
     get_selected_hunk_hash_file_path,
     get_selected_hunk_patch_file_path,
     get_selected_binary_file_json_path,
@@ -72,13 +85,18 @@ def command_include(*, quiet: bool = False) -> None:
     require_session_started()
     ensure_state_directory_exists()
 
-    # Find and cache the next item
-    try:
-        item = fetch_next_change()
-    except NoMoreHunks:
-        if not quiet:
-            print(_("No more hunks to process."), file=sys.stderr)
-        return
+    if read_selected_change_kind() == SelectedChangeKind.FILE:
+        command_include_file("")
+        return 0
+
+    item = load_selected_change()
+    if item is None:
+        try:
+            item = fetch_next_change()
+        except NoMoreHunks:
+            if not quiet:
+                print(_("No more hunks to process."), file=sys.stderr)
+            return 0
     with undo_checkpoint("include"):
         # Read cached hash
         patch_hash = read_text_file_contents(get_selected_hunk_hash_file_path()).strip()
@@ -93,10 +111,6 @@ def command_include(*, quiet: bool = False) -> None:
             if result.returncode != 0:
                 print(_("Failed to stage binary file: {}").format(result.stderr), file=sys.stderr)
                 return
-
-            # Add hash to blocklist
-            blocklist_path = get_block_list_file_path()
-            append_lines_to_file(blocklist_path, [patch_hash])
 
             # Record for progress tracking
             record_hunk_included(patch_hash)
@@ -133,10 +147,6 @@ def command_include(*, quiet: bool = False) -> None:
             print(_("Failed to apply hunk: {}").format(stderr_text), file=sys.stderr)
             return
 
-        # Add hash to blocklist
-        blocklist_path = get_block_list_file_path()
-        append_lines_to_file(blocklist_path, [patch_hash])
-
         # Record for progress tracking
         record_hunk_included(patch_hash)
 
@@ -149,13 +159,23 @@ def command_include(*, quiet: bool = False) -> None:
             advance_to_and_show_next_change()
 
 
-def command_include_file(file: str) -> None:
+def command_include_file(
+    file: str,
+    *,
+    quiet: bool = False,
+    advance: bool = True,
+) -> int:
     """Include (stage) all hunks from the specified file.
 
     Args:
         file: File path for file-scoped operation.
               If empty string, uses selected hunk's file.
               If explicit path, uses that file.
+        quiet: Suppress per-file status output while preserving selection state.
+        advance: When quiet, advance the selection after staging this file.
+
+    Returns:
+        Number of hunks staged from the requested file.
     """
     require_git_repository()
     require_session_started()
@@ -163,34 +183,24 @@ def command_include_file(file: str) -> None:
 
     # Determine target file
     if file == "":
-        # --file with no arg: use selected hunk's file by finding first unblocked hunk
-        # Load blocklist
-        blocklist_path = get_block_list_file_path()
-        blocklist_text = read_text_file_contents(blocklist_path)
-        blocked_hashes = set(blocklist_text.splitlines())
-
-        # Find first non-blocked hunk to get the target file
-        def is_unblocked(patch_bytes: bytes) -> bool:
-            return compute_stable_hunk_hash(patch_bytes) not in blocked_hashes
-
-        target_file = get_first_matching_file_from_diff(
-            context_lines=get_context_lines(),
-            predicate=is_unblocked
-        )
-
+        target_file = get_selected_change_file_path()
         if target_file is None:
-            print(_("No changes to stage."), file=sys.stderr)
-            return
+            diff_result = run_git_command(["diff", "--quiet"], check=False)
+            if diff_result.returncode == 0:
+                print(_("No changes to stage."), file=sys.stderr)
+            else:
+                print(_("No selected hunk. Run 'show' first or specify file path."), file=sys.stderr)
+            return 0
     else:
         # Explicit path provided
         target_file = file
     with undo_checkpoint(f"include --file {file}".rstrip()):
-        # Load blocklist
-        blocklist_path = get_block_list_file_path()
-        blocklist_text = read_text_file_contents(blocklist_path)
-        blocked_hashes = set(blocklist_text.splitlines())
-
-        # Stream through hunks and stage all from target file
+        # Stream through the remaining unstaged hunks for this file.
+        #
+        # Included hunks do not need blocklist entries because staging removes
+        # them from `git diff` naturally. Keeping them in the processed blocklist
+        # makes later manual unstaging look like stale skipped work, which breaks
+        # follow-up `show --files` / `include --files` passes in the same session.
         hunks_staged = 0
         for patch in parse_unified_diff_streaming(stream_git_command(["diff", "--no-color"])):
             if patch.new_path != target_file:
@@ -198,10 +208,6 @@ def command_include_file(file: str) -> None:
 
             patch_bytes = patch.to_patch_bytes()
             patch_hash = compute_stable_hunk_hash(patch_bytes)
-
-            # Skip if already blocked
-            if patch_hash in blocked_hashes:
-                continue
 
             # Apply the hunk to the index using streaming
             stderr_chunks = []
@@ -215,10 +221,6 @@ def command_include_file(file: str) -> None:
                         stderr_chunks.append(event.data)
 
             if exit_code == 0:
-                # Add to blocklist so we don't try to stage it again
-                append_lines_to_file(blocklist_path, [patch_hash])
-                blocked_hashes.add(patch_hash)
-
                 # Record for progress tracking
                 record_hunk_included(patch_hash)
 
@@ -229,8 +231,14 @@ def command_include_file(file: str) -> None:
                 break
 
     if hunks_staged == 0:
-        print(_("No hunks staged from {file}").format(file=target_file), file=sys.stderr)
-        return
+        if not quiet:
+            print(_("No hunks staged from {file}").format(file=target_file), file=sys.stderr)
+        return 0
+
+    if quiet and advance:
+        advance_to_next_change()
+    if quiet:
+        return hunks_staged
 
     # Print summary message
     msg = ngettext(
@@ -242,6 +250,7 @@ def command_include_file(file: str) -> None:
 
     # Advance to next file's hunk
     advance_to_and_show_next_change()
+    return hunks_staged
 
 
 def command_include_file_as(replacement_text: str, file: str | None = None) -> None:
@@ -290,6 +299,8 @@ def command_include_file_as(replacement_text: str, file: str | None = None) -> N
             recalculate_selected_hunk_for_file(target_file)
 
     print(_("✓ Included file as replacement: {file}").format(file=target_file), file=sys.stderr)
+
+
 def command_include_line(line_id_specification: str, file: str | None = None) -> None:
     """Stage only the specified lines to the index.
 
@@ -321,16 +332,27 @@ def command_include_line(line_id_specification: str, file: str | None = None) ->
                     exit_with_error(_("No selected hunk. Run 'show' first or specify file path."))
             else:
                 target_file = file
-                preserve_selected_state = True
-                saved_selected_state = _snapshot_selected_change_state()
+            reuse_selected_file_view = (
+                read_selected_change_kind() == SelectedChangeKind.FILE
+                and get_selected_change_file_path() == target_file
+            )
+            if reuse_selected_file_view:
+                line_changes = load_line_changes_from_state()
+            else:
+                if file != "":
+                    preserve_selected_state = True
+                    saved_selected_state = _snapshot_selected_change_state()
 
-            line_changes = cache_file_as_single_hunk(target_file)
-            if line_changes is None:
-                exit_with_error(_("No changes in file '{file}'.").format(file=target_file))
-            line_changes = annotate_with_batch_source(target_file, line_changes)
+                line_changes = cache_unstaged_file_as_single_hunk(target_file)
+                if line_changes is None:
+                    exit_with_error(_("No changes in file '{file}'.").format(file=target_file))
+                line_changes = annotate_with_batch_source(target_file, line_changes)
 
         requested_ids = parse_line_selection(line_id_specification)
-        already_included_ids = set(read_line_ids_file(get_processed_include_ids_file_path()))
+        if preserve_selected_state:
+            already_included_ids = set()
+        else:
+            already_included_ids = set(read_line_ids_file(get_processed_include_ids_file_path()))
         combined_include_ids = already_included_ids | set(requested_ids)
 
         # Get the selected hunk's base/source snapshots captured when the hunk was loaded.
@@ -343,6 +365,24 @@ def command_include_line(line_id_specification: str, file: str | None = None) ->
             text_output=False,
         )
         current_index_content = index_result.stdout if index_result.returncode == 0 else b""
+
+        if read_selected_change_kind() == SelectedChangeKind.FILE:
+            partial_replacement_error = _build_partial_replacement_selection_error(
+                line_changes,
+                combined_include_ids,
+                hunk_base_content=hunk_base_content,
+                hunk_source_content=hunk_source_content,
+            )
+            if partial_replacement_error is not None:
+                exit_with_error(partial_replacement_error)
+            partial_structural_run_error = _build_partial_structural_run_selection_error(
+                line_changes,
+                combined_include_ids,
+                hunk_base_content=hunk_base_content,
+                hunk_source_content=hunk_source_content,
+            )
+            if partial_structural_run_error is not None:
+                exit_with_error(partial_structural_run_error)
 
         semantic_attempt = try_build_semantic_selection_for_selected_hunk(
             line_changes=line_changes,
@@ -387,6 +427,112 @@ def command_include_line(line_id_specification: str, file: str | None = None) ->
             recalculate_selected_hunk_for_file(line_changes.path)
 
     print(_("✓ Included line(s): {lines}").format(lines=line_id_specification), file=sys.stderr)
+
+
+def _derive_replacement_unit_display_ids(
+    line_changes,
+    *,
+    hunk_base_content: bytes,
+    hunk_source_content: bytes,
+) -> list[set[int]]:
+    """Map semantic replacement runs onto display IDs in the current selection."""
+    replacement_units: list[set[int]] = []
+    semantic_runs = derive_semantic_change_runs(
+        hunk_base_content.splitlines(keepends=True),
+        hunk_source_content.splitlines(keepends=True),
+    )
+
+    for run in semantic_runs:
+        if run.kind != SemanticChangeKind.REPLACEMENT:
+            continue
+
+        source_run = set(run.source_run or [])
+        target_run = set(run.target_run or [])
+        display_ids = {
+            line.id
+            for line in line_changes.lines
+            if line.id is not None and (
+                (line.kind == "-" and line.old_line_number in source_run)
+                or (line.kind == "+" and line.new_line_number in target_run)
+            )
+        }
+        if display_ids:
+            replacement_units.append(display_ids)
+
+    return replacement_units
+
+
+def _build_partial_replacement_selection_error(
+    line_changes,
+    selected_ids: set[int],
+    *,
+    hunk_base_content: bytes,
+    hunk_source_content: bytes,
+) -> str | None:
+    """Reject contiguous interval selections that tear a replacement unit."""
+    if len(selected_ids) <= 1:
+        return None
+
+    sorted_ids = sorted(selected_ids)
+    is_contiguous_interval = sorted_ids == list(range(sorted_ids[0], sorted_ids[-1] + 1))
+    if not is_contiguous_interval:
+        return None
+
+    replacement_units = _derive_replacement_unit_display_ids(
+        line_changes,
+        hunk_base_content=hunk_base_content,
+        hunk_source_content=hunk_source_content,
+    )
+    for replacement_unit in replacement_units:
+        selected_in_unit = selected_ids & replacement_unit
+        if selected_in_unit and selected_in_unit != replacement_unit:
+            return _(
+                "Contiguous line selections cannot split one replacement. "
+                "Select --lines {lines} instead, pick "
+                "individual lines one at a time, or use --as."
+            ).format(lines=format_line_ids(sorted(replacement_unit)))
+
+    return None
+
+
+def _build_partial_structural_run_selection_error(
+    line_changes,
+    selected_ids: set[int],
+    *,
+    hunk_base_content: bytes,
+    hunk_source_content: bytes,
+) -> str | None:
+    """Reject contiguous file-scoped selections that only partly include later runs."""
+    if len(selected_ids) <= 1:
+        return None
+
+    sorted_ids = sorted(selected_ids)
+    is_contiguous_interval = sorted_ids == list(range(sorted_ids[0], sorted_ids[-1] + 1))
+    if not is_contiguous_interval:
+        return None
+
+    run_sets = derive_display_id_run_sets(
+        line_changes,
+        source_content=hunk_base_content,
+        target_content=hunk_source_content,
+    )
+    intersected_runs = [run_set for run_set in run_sets if selected_ids & run_set]
+    if len(intersected_runs) <= 1:
+        return None
+
+    partially_selected_runs = [
+        run_set
+        for run_set in intersected_runs
+        if (selected_ids & run_set) != run_set
+    ]
+    if not partially_selected_runs:
+        return None
+
+    return _(
+        "Contiguous file-scoped selections cannot span multiple structural change runs "
+        "while selecting only part of one run. Select one run at a time, fully include "
+        "each spanned run, or use --as."
+    )
 
 
 def _expand_replacement_selection_ids(line_changes, requested_ids: set[int]) -> set[int]:

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -24,6 +24,7 @@ from ..data.hunk_tracking import (
     advance_to_next_change,
     apply_line_level_batch_filter_to_cached_hunk,
     cache_file_as_single_hunk,
+    cache_unstaged_file_as_single_hunk,
     clear_selected_change_state_files,
     fetch_next_change,
     get_selected_change_file_path,
@@ -243,6 +244,52 @@ def command_include_file(file: str) -> None:
     advance_to_and_show_next_change()
 
 
+def command_include_file_as(replacement_text: str, file: str | None = None) -> None:
+    """Stage full-file replacement text for a live file-scoped selection."""
+    require_git_repository()
+    require_session_started()
+    ensure_state_directory_exists()
+
+    operation_parts = ["include", "--as", replacement_text]
+    if file is not None:
+        operation_parts.extend(["--file", file])
+
+    with undo_checkpoint(" ".join(operation_parts)):
+        preserve_selected_state = False
+        saved_selected_state = None
+
+        if file is None or file == "":
+            target_file = get_selected_change_file_path()
+            if target_file is None:
+                exit_with_error(_("No selected hunk. Run 'show' first or specify file path."))
+        else:
+            target_file = file
+            preserve_selected_state = True
+            saved_selected_state = _snapshot_selected_change_state()
+
+        if preserve_selected_state:
+            line_changes = cache_unstaged_file_as_single_hunk(target_file)
+            if line_changes is None:
+                exit_with_error(_("No changes in file '{file}'.").format(file=target_file))
+        else:
+            line_changes = load_line_changes_from_state()
+            if line_changes is None or line_changes.path != target_file:
+                line_changes = cache_unstaged_file_as_single_hunk(target_file)
+                if line_changes is None:
+                    exit_with_error(_("No changes in file '{file}'.").format(file=target_file))
+
+        update_index_with_blob_content(
+            target_file,
+            replacement_text.encode("utf-8", errors="surrogateescape"),
+        )
+
+        if preserve_selected_state:
+            _restore_selected_change_state(saved_selected_state)
+        else:
+            write_line_ids_file(get_processed_include_ids_file_path(), set())
+            recalculate_selected_hunk_for_file(target_file)
+
+    print(_("✓ Included file as replacement: {file}").format(file=target_file), file=sys.stderr)
 def command_include_line(line_id_specification: str, file: str | None = None) -> None:
     """Stage only the specified lines to the index.
 

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -392,6 +392,7 @@ def _apply_include_line_replacement(
     replacement_text: str,
     hunk_base_content: bytes,
     hunk_source_content: bytes,
+    trim_unchanged_edge_anchors: bool,
 ) -> None:
     """Stage replacement text for selected lines and record session masking."""
     requested_ids = set(parse_line_selection(line_id_specification))
@@ -401,14 +402,13 @@ def _apply_include_line_replacement(
     if not selected_lines:
         exit_with_error(_("No matching lines found for selection: {ids}").format(ids=line_id_specification))
 
-    ownership = translate_lines_to_batch_ownership(selected_lines)
-
     try:
         target_index_content = build_target_index_content_bytes_with_replaced_lines(
             line_changes,
             effective_ids,
             replacement_text,
             hunk_base_content,
+            trim_unchanged_edge_anchors=trim_unchanged_edge_anchors,
         )
     except ValueError as error:
         exit_with_error(str(error))
@@ -417,7 +417,7 @@ def _apply_include_line_replacement(
     record_consumed_selection(
         line_changes.path,
         source_content=hunk_source_content,
-        ownership=ownership,
+        selected_lines=selected_lines,
         replacement_mask={
             "deleted_lines": replacement_text.splitlines(),
             "added_lines": [line.text for line in selected_lines if line.kind == "+"],
@@ -430,6 +430,7 @@ def _snapshot_selected_change_state() -> dict[str, bytes | None]:
     paths = {
         "patch": get_selected_hunk_patch_file_path(),
         "hash": get_selected_hunk_hash_file_path(),
+        "kind": get_selected_change_kind_file_path(),
         "line_state": get_line_changes_json_file_path(),
         "binary": get_selected_binary_file_json_path(),
         "index_snapshot": get_index_snapshot_file_path(),
@@ -447,6 +448,7 @@ def _restore_selected_change_state(snapshot: dict[str, bytes | None]) -> None:
     paths = {
         "patch": get_selected_hunk_patch_file_path(),
         "hash": get_selected_hunk_hash_file_path(),
+        "kind": get_selected_change_kind_file_path(),
         "line_state": get_line_changes_json_file_path(),
         "binary": get_selected_binary_file_json_path(),
         "index_snapshot": get_index_snapshot_file_path(),
@@ -462,17 +464,28 @@ def _restore_selected_change_state(snapshot: dict[str, bytes | None]) -> None:
             path.write_bytes(data)
 
 
-def command_include_line_as(line_id_specification: str, replacement_text: str, file: str | None = None) -> None:
-    """Stage a replacement for one contiguous selected line range and mask it."""
+def command_include_line_as(
+    line_id_specification: str,
+    replacement_text: str,
+    file: str | None = None,
+    *,
+    no_anchor: bool = False,
+) -> None:
+    """Stage a replacement for one contiguous selected line span and mask it."""
     require_git_repository()
     require_session_started()
     ensure_state_directory_exists()
 
     operation_parts = ["include", "--line", line_id_specification, "--as", replacement_text]
+    if no_anchor:
+        operation_parts.append("--no-anchor")
     if file is not None:
         operation_parts.extend(["--file", file])
 
     with undo_checkpoint(" ".join(operation_parts)):
+        preserve_selected_state = False
+        saved_selected_state = None
+
         if file is None:
             require_selected_hunk()
             line_changes = load_line_changes_from_state()
@@ -485,6 +498,7 @@ def command_include_line_as(line_id_specification: str, replacement_text: str, f
                 replacement_text=replacement_text,
                 hunk_base_content=hunk_base_content,
                 hunk_source_content=hunk_source_content,
+                trim_unchanged_edge_anchors=not no_anchor,
             )
 
             write_line_ids_file(get_processed_include_ids_file_path(), set())
@@ -497,15 +511,25 @@ def command_include_line_as(line_id_specification: str, replacement_text: str, f
                 preserve_selected_state = False
             else:
                 target_file = file
-                preserve_selected_state = True
+            reuse_selected_file_view = (
+                read_selected_change_kind() == SelectedChangeKind.FILE
+                and get_selected_change_file_path() == target_file
+            )
+            if reuse_selected_file_view:
+                cached_lines = load_line_changes_from_state()
+                if cached_lines is None:
+                    exit_with_error(_("No changes in file '{file}'.").format(file=target_file))
+                annotated_changes = annotate_with_batch_source(target_file, cached_lines)
+            else:
+                if file != "":
+                    preserve_selected_state = True
+                saved_selected_state = _snapshot_selected_change_state() if preserve_selected_state else None
 
-            saved_selected_state = _snapshot_selected_change_state() if preserve_selected_state else None
+                cached_lines = cache_unstaged_file_as_single_hunk(target_file)
+                if cached_lines is None:
+                    exit_with_error(_("No changes in file '{file}'.").format(file=target_file))
 
-            cached_lines = cache_file_as_single_hunk(target_file)
-            if cached_lines is None:
-                exit_with_error(_("No changes in file '{file}'.").format(file=target_file))
-
-            annotated_changes = annotate_with_batch_source(target_file, cached_lines)
+                annotated_changes = annotate_with_batch_source(target_file, cached_lines)
             hunk_base_result = run_git_command(
                 ["show", f":{target_file}"],
                 check=False,
@@ -520,6 +544,7 @@ def command_include_line_as(line_id_specification: str, replacement_text: str, f
                 replacement_text=replacement_text,
                 hunk_base_content=hunk_base_content,
                 hunk_source_content=hunk_source_content,
+                trim_unchanged_edge_anchors=not no_anchor,
             )
 
             if preserve_selected_state:

--- a/src/git_stage_batch/commands/show.py
+++ b/src/git_stage_batch/commands/show.py
@@ -11,10 +11,12 @@ from ..core.diff_parser import write_snapshots_for_selected_file_path
 from ..core.hashing import compute_stable_hunk_hash
 from ..core.models import BinaryFileChange
 from ..data.hunk_tracking import (
+    SelectedChangeKind,
     apply_line_level_batch_filter_to_cached_hunk,
     cache_file_as_single_hunk,
     get_selected_change_file_path,
     render_file_as_single_hunk,
+    write_selected_change_kind,
 )
 from ..data.line_state import convert_line_changes_to_serializable_dict, load_line_changes_from_state
 from ..data.session import require_session_started
@@ -94,6 +96,7 @@ def command_show(file: str | None = None, *, porcelain: bool = False, selectable
             # Cache selected hunk bytes exactly; display text is derived from parsed lines.
             write_file_bytes(get_selected_hunk_patch_file_path(), patch_bytes)
             write_text_file_contents(get_selected_hunk_hash_file_path(), patch_hash)
+            write_selected_change_kind(SelectedChangeKind.HUNK)
 
             # Parse and cache line_changes for batch filtering
             line_changes = build_line_changes_from_patch_bytes(patch_bytes, annotator=annotate_with_batch_source)

--- a/src/git_stage_batch/commands/skip.py
+++ b/src/git_stage_batch/commands/skip.py
@@ -2,24 +2,33 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
+import json
 import sys
 
-from ..core.diff_parser import get_first_matching_file_from_diff, parse_unified_diff_streaming
+from ..core.diff_parser import build_line_changes_from_patch_bytes, parse_unified_diff_streaming
 from ..core.hashing import compute_stable_hunk_hash
-from ..core.line_selection import parse_line_selection, read_line_ids_file, write_line_ids_file
+from ..core.line_selection import (
+    parse_line_selection,
+    read_line_ids_file,
+    write_line_ids_file,
+)
 from ..core.models import BinaryFileChange
-from ..data.hunk_tracking import advance_to_and_show_next_change, advance_to_next_change, fetch_next_change, record_hunk_skipped, require_selected_hunk
+from ..data.hunk_tracking import SelectedChangeKind, advance_to_and_show_next_change, advance_to_next_change, fetch_next_change, get_selected_change_file_path, load_selected_change, read_selected_change_kind, record_hunk_skipped, require_selected_hunk
+from ..data.line_state import convert_line_changes_to_serializable_dict, load_line_changes_from_state
 from ..data.session import require_session_started
 from ..data.undo import undo_checkpoint
 from ..exceptions import NoMoreHunks
 from ..i18n import _, ngettext
-from ..utils.file_io import append_lines_to_file, read_text_file_contents
+from ..output import print_line_level_changes
+from ..utils.file_io import append_lines_to_file, read_text_file_contents, write_text_file_contents
 from ..utils.git import require_git_repository, stream_git_command
 from ..utils.journal import log_journal
 from ..utils.paths import (
     ensure_state_directory_exists,
     get_block_list_file_path,
     get_context_lines,
+    get_line_changes_json_file_path,
     get_selected_hunk_hash_file_path,
     get_processed_skip_ids_file_path,
 )
@@ -33,13 +42,18 @@ def command_skip(*, quiet: bool = False) -> None:
     require_session_started()
     ensure_state_directory_exists()
 
-    # Find and cache the next item
-    try:
-        item = fetch_next_change()
-    except NoMoreHunks:
-        if not quiet:
-            print(_("No more hunks to process."), file=sys.stderr)
+    if read_selected_change_kind() == SelectedChangeKind.FILE:
+        command_skip_file("")
         return
+
+    item = load_selected_change()
+    if item is None:
+        try:
+            item = fetch_next_change()
+        except NoMoreHunks:
+            if not quiet:
+                print(_("No more hunks to process."), file=sys.stderr)
+            return
     with undo_checkpoint("skip"):
         # Read cached hash
         patch_hash = read_text_file_contents(get_selected_hunk_hash_file_path()).strip()
@@ -84,13 +98,24 @@ def command_skip(*, quiet: bool = False) -> None:
             advance_to_and_show_next_change()
 
 
-def command_skip_file(file: str = "") -> None:
+def command_skip_file(
+    file: str = "",
+    *,
+    quiet: bool = False,
+    advance: bool = True,
+) -> int:
     """Skip all remaining hunks from the specified file.
 
     Args:
         file: File path for file-scoped operation.
               If empty string, uses selected hunk's file.
               If explicit path, uses that file.
+
+        quiet: Suppress per-file status output while preserving selection state.
+        advance: When quiet, advance the selection after skipping this file.
+
+    Returns:
+        Number of hunks skipped from the requested file.
     """
     require_git_repository()
     require_session_started()
@@ -98,28 +123,16 @@ def command_skip_file(file: str = "") -> None:
 
     # Determine target file
     if file == "":
-        # --file with no arg: use selected hunk's file by finding first unblocked hunk
-        blocklist_path = get_block_list_file_path()
-        blocklist_text = read_text_file_contents(blocklist_path)
-        blocked_hashes = set(blocklist_text.splitlines())
-
-        def is_unblocked(patch_bytes: bytes) -> bool:
-            return compute_stable_hunk_hash(patch_bytes) not in blocked_hashes
-
-        target_file = get_first_matching_file_from_diff(
-            context_lines=get_context_lines(),
-            predicate=is_unblocked
-        )
-
+        target_file = get_selected_change_file_path()
         if target_file is None:
-            print(_("No changes to process."), file=sys.stderr)
-            return
+            if not quiet:
+                print(_("No selected hunk. Run 'show' first or specify file path."), file=sys.stderr)
+            return 0
     else:
         target_file = file
 
     with undo_checkpoint(f"skip --file {file}".rstrip()):
-        # Load blocklist
-        # Stream through hunks and skip all from target file
+        # Stream through hunks and skip all from target file.
         blocklist_path = get_block_list_file_path()
         blocklist_text = read_text_file_contents(blocklist_path)
         blocked_hashes = set(blocklist_text.splitlines())
@@ -139,7 +152,16 @@ def command_skip_file(file: str = "") -> None:
             # Add to blocklist without staging
             append_lines_to_file(blocklist_path, [patch_hash])
             blocked_hashes.add(patch_hash)
+            record_hunk_skipped(
+                build_line_changes_from_patch_bytes(patch_bytes),
+                patch_hash,
+            )
             hunks_skipped += 1
+
+        if quiet and advance:
+            advance_to_next_change()
+        if quiet:
+            return hunks_skipped
 
         msg = ngettext(
             "✓ Skipped {count} hunk from {file}",
@@ -149,6 +171,7 @@ def command_skip_file(file: str = "") -> None:
         print(msg, file=sys.stderr)
 
         advance_to_and_show_next_change()
+        return hunks_skipped
 
 
 def command_skip_line(line_id_specification: str) -> None:
@@ -162,6 +185,10 @@ def command_skip_line(line_id_specification: str) -> None:
     ensure_state_directory_exists()
     require_selected_hunk()
 
+    line_changes = load_line_changes_from_state()
+    if line_changes is None:
+        raise NoMoreHunks()
+
     requested_ids = parse_line_selection(line_id_specification)
     already_skipped_ids = set(read_line_ids_file(get_processed_skip_ids_file_path()))
     combined_skip_ids = already_skipped_ids | set(requested_ids)
@@ -169,4 +196,41 @@ def command_skip_line(line_id_specification: str) -> None:
         # Update processed skip IDs
         write_line_ids_file(get_processed_skip_ids_file_path(), combined_skip_ids)
 
+        visible_changed_ids = [
+            changed_id
+            for changed_id in line_changes.changed_line_ids()
+            if changed_id not in combined_skip_ids
+        ]
+
+        if not visible_changed_ids:
+            if read_selected_change_kind() == SelectedChangeKind.FILE:
+                print(_("✓ Skipped line(s): {lines}").format(lines=line_id_specification), file=sys.stderr)
+                command_skip_file("")
+                return
+
+            patch_hash = read_text_file_contents(get_selected_hunk_hash_file_path()).strip()
+            blocklist_path = get_block_list_file_path()
+            append_lines_to_file(blocklist_path, [patch_hash])
+            record_hunk_skipped(line_changes, patch_hash)
+            print(_("✓ Skipped line(s): {lines}").format(lines=line_id_specification), file=sys.stderr)
+            advance_to_and_show_next_change()
+            return
+
+        filtered_lines = [
+            replace(line_entry, id=None)
+            if line_entry.id in combined_skip_ids
+            else line_entry
+            for line_entry in line_changes.lines
+        ]
+        filtered_line_changes = replace(line_changes, lines=filtered_lines)
+        write_text_file_contents(
+            get_line_changes_json_file_path(),
+            json.dumps(
+                convert_line_changes_to_serializable_dict(filtered_line_changes),
+                ensure_ascii=False,
+                indent=0,
+            ),
+        )
+
     print(_("✓ Skipped line(s): {lines}").format(lines=line_id_specification), file=sys.stderr)
+    print_line_level_changes(filtered_line_changes)

--- a/src/git_stage_batch/data/consumed_selections.py
+++ b/src/git_stage_batch/data/consumed_selections.py
@@ -5,7 +5,17 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from ..batch.ownership import BatchOwnership, merge_batch_ownership
+from ..batch.ownership import (
+    BatchOwnership,
+    advance_batch_source_for_file,
+    detect_stale_batch_source_for_selection,
+    merge_batch_ownership,
+    translate_lines_to_batch_ownership,
+)
+from ..batch.source_refresh import (
+    _refresh_selected_lines_against_new_source,
+    _refresh_selected_lines_against_source_content,
+)
 from .batch_sources import create_batch_source_commit
 from ..utils.file_io import read_text_file_contents, write_text_file_contents
 from ..utils.paths import get_session_consumed_selections_file_path
@@ -39,7 +49,7 @@ def record_consumed_selection(
     file_path: str,
     *,
     source_content: bytes,
-    ownership: BatchOwnership,
+    selected_lines: list,
     replacement_mask: dict[str, list[str]] | None = None,
 ) -> None:
     """Persist consumed selection ownership for masking across `again`."""
@@ -49,10 +59,30 @@ def record_consumed_selection(
 
     if existing_file_metadata is not None:
         existing_ownership = BatchOwnership.from_metadata_dict(existing_file_metadata)
-        merged_ownership = merge_batch_ownership(existing_ownership, ownership)
         batch_source_commit = existing_file_metadata["batch_source_commit"]
+        if detect_stale_batch_source_for_selection(selected_lines):
+            (
+                batch_source_commit,
+                existing_ownership,
+                refreshed_source_content,
+                working_content,
+            ) = advance_batch_source_for_file(
+                batch_name="consumed-selections",
+                file_path=file_path,
+                old_batch_source_commit=batch_source_commit,
+                existing_ownership=existing_ownership,
+            )
+            selected_lines = _refresh_selected_lines_against_source_content(
+                selected_lines,
+                source_content=refreshed_source_content,
+                working_content=working_content,
+            )
+        new_ownership = translate_lines_to_batch_ownership(selected_lines)
+        merged_ownership = merge_batch_ownership(existing_ownership, new_ownership)
     else:
-        merged_ownership = ownership
+        if detect_stale_batch_source_for_selection(selected_lines):
+            selected_lines = _refresh_selected_lines_against_new_source(selected_lines)
+        merged_ownership = translate_lines_to_batch_ownership(selected_lines)
         batch_source_commit = create_batch_source_commit(
             file_path,
             file_content_override=source_content,

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -7,6 +7,7 @@ import tempfile
 import subprocess
 import sys
 from dataclasses import replace
+from enum import Enum
 from typing import Generator, Optional, Union
 
 from ..batch.attribution import build_file_attribution, filter_owned_diff_fragments
@@ -44,6 +45,7 @@ from ..utils.paths import (
     get_block_list_file_path,
     get_blocked_files_file_path,
     get_context_lines,
+    get_selected_change_kind_file_path,
     get_selected_binary_file_json_path,
     get_selected_hunk_hash_file_path,
     get_selected_hunk_patch_file_path,
@@ -52,21 +54,33 @@ from ..utils.paths import (
     get_included_hunks_file_path,
     get_index_snapshot_file_path,
     get_processed_include_ids_file_path,
+    get_processed_skip_ids_file_path,
     get_skipped_hunks_jsonl_file_path,
     get_working_tree_snapshot_file_path,
 )
 from .line_state import convert_line_changes_to_serializable_dict, load_line_changes_from_state
 
 
+class SelectedChangeKind(str, Enum):
+    """Kinds of selected changes cached in session state."""
+
+    HUNK = "hunk"
+    FILE = "file"
+    BINARY = "binary"
+    BATCH_FILE = "batch-file"
+
+
 def clear_selected_change_state_files() -> None:
     """Clear all cached selected hunk state files."""
     get_selected_hunk_patch_file_path().unlink(missing_ok=True)
     get_selected_hunk_hash_file_path().unlink(missing_ok=True)
+    get_selected_change_kind_file_path().unlink(missing_ok=True)
     get_line_changes_json_file_path().unlink(missing_ok=True)
     get_selected_binary_file_json_path().unlink(missing_ok=True)
     get_index_snapshot_file_path().unlink(missing_ok=True)
     get_working_tree_snapshot_file_path().unlink(missing_ok=True)
     get_processed_include_ids_file_path().unlink(missing_ok=True)
+    get_processed_skip_ids_file_path().unlink(missing_ok=True)
     # processed_batch_ids is global state (union of all batches), not per-hunk state
 
 
@@ -89,6 +103,47 @@ def load_selected_binary_file() -> Optional[BinaryFileChange]:
         )
     except (json.JSONDecodeError, KeyError):
         return None
+
+
+def write_selected_change_kind(kind: SelectedChangeKind) -> None:
+    """Persist the kind of selected change cached in session state."""
+    write_text_file_contents(get_selected_change_kind_file_path(), kind)
+
+
+def read_selected_change_kind() -> Optional[SelectedChangeKind]:
+    """Return the kind of selected change cached in session state."""
+    path = get_selected_change_kind_file_path()
+    if not path.exists():
+        return None
+
+    raw_kind = read_text_file_contents(path).strip()
+    if not raw_kind:
+        return None
+
+    try:
+        return SelectedChangeKind(raw_kind)
+    except ValueError:
+        return None
+
+
+def load_selected_change() -> Optional[Union[LineLevelChange, BinaryFileChange]]:
+    """Load the currently cached selected change, if any."""
+    binary_file = load_selected_binary_file()
+    if binary_file is not None:
+        return binary_file
+
+    patch_path = get_selected_hunk_patch_file_path()
+    if not patch_path.exists():
+        return None
+
+    require_selected_hunk()
+
+    line_changes = load_line_changes_from_state()
+    if line_changes is not None:
+        return line_changes
+
+    patch_bytes = read_file_bytes(patch_path)
+    return build_line_changes_from_patch_bytes(patch_bytes)
 
 
 def get_selected_change_file_path() -> Optional[str]:
@@ -475,6 +530,7 @@ def cache_rendered_batch_file_display(
     # Cache the hunk bytes exactly; display strings are derived elsewhere.
     write_file_bytes(get_selected_hunk_patch_file_path(), patch_bytes)
     write_text_file_contents(get_selected_hunk_hash_file_path(), patch_hash)
+    write_selected_change_kind(SelectedChangeKind.BATCH_FILE)
 
     # Save LineLevelChange for line-level operations
     write_text_file_contents(get_line_changes_json_file_path(),
@@ -560,40 +616,48 @@ def cache_file_as_single_hunk(file_path: str) -> Optional[LineLevelChange]:
     """
     try:
         combined_line_changes = render_file_as_single_hunk(file_path)
-        if combined_line_changes is None:
-            return None
-
-        # Synthesize patch bytes for caching (used for hashing/identity)
-        patch_lines = [
-            f"--- a/{file_path}\n".encode("utf-8"),
-            f"+++ b/{file_path}\n".encode("utf-8"),
-            (
-                f"@@ -{combined_line_changes.header.old_start},{combined_line_changes.header.old_len} "
-                f"+{combined_line_changes.header.new_start},{combined_line_changes.header.new_len} @@\n"
-            ).encode("utf-8"),
-        ]
-        for entry in combined_line_changes.lines:
-            patch_lines.append(entry.kind.encode("utf-8") + entry.text_bytes + b"\n")
-        patch_bytes = b"".join(patch_lines)
-
-        patch_hash = compute_stable_hunk_hash(patch_bytes)
-
-        # Cache the combined hunk
-        write_file_bytes(get_selected_hunk_patch_file_path(), patch_bytes)
-        write_text_file_contents(get_selected_hunk_hash_file_path(), patch_hash)
-        write_text_file_contents(get_line_changes_json_file_path(),
-                                json.dumps(convert_line_changes_to_serializable_dict(combined_line_changes),
-                                          ensure_ascii=False, indent=0))
-
-        # Cache live snapshots so later line-level operations can reuse the
-        # file-scoped selection the same way they reuse ordinary selected hunks.
-        write_snapshots_for_selected_file_path(file_path)
-
-        return combined_line_changes
-
+        return _cache_combined_file_line_changes(file_path, combined_line_changes)
     except subprocess.CalledProcessError:
         # Git diff failed (e.g., no changes in file)
         return None
+
+
+def _cache_combined_file_line_changes(
+    file_path: str,
+    combined_line_changes: Optional[LineLevelChange],
+) -> Optional[LineLevelChange]:
+    """Persist a combined file-scoped view as the current selection."""
+    if combined_line_changes is None:
+        return None
+
+    # Synthesize patch bytes for caching (used for hashing/identity)
+    patch_lines = [
+        f"--- a/{file_path}\n".encode("utf-8"),
+        f"+++ b/{file_path}\n".encode("utf-8"),
+        (
+            f"@@ -{combined_line_changes.header.old_start},{combined_line_changes.header.old_len} "
+            f"+{combined_line_changes.header.new_start},{combined_line_changes.header.new_len} @@\n"
+        ).encode("utf-8"),
+    ]
+    for entry in combined_line_changes.lines:
+        patch_lines.append(entry.kind.encode("utf-8") + entry.text_bytes + b"\n")
+    patch_bytes = b"".join(patch_lines)
+
+    patch_hash = compute_stable_hunk_hash(patch_bytes)
+
+    # Cache the combined hunk
+    write_file_bytes(get_selected_hunk_patch_file_path(), patch_bytes)
+    write_text_file_contents(get_selected_hunk_hash_file_path(), patch_hash)
+    write_selected_change_kind(SelectedChangeKind.FILE)
+    write_text_file_contents(get_line_changes_json_file_path(),
+                            json.dumps(convert_line_changes_to_serializable_dict(combined_line_changes),
+                                      ensure_ascii=False, indent=0))
+
+    # Cache live snapshots so later line-level operations can reuse the
+    # file-scoped selection the same way they reuse ordinary selected hunks.
+    write_snapshots_for_selected_file_path(file_path)
+
+    return combined_line_changes
 
 
 def render_file_as_single_hunk(file_path: str) -> Optional[LineLevelChange]:
@@ -764,6 +828,7 @@ def fetch_next_change() -> Union[LineLevelChange, BinaryFileChange]:
                 write_text_file_contents(get_selected_binary_file_json_path(),
                                        json.dumps(binary_data, ensure_ascii=False, indent=0))
                 write_text_file_contents(get_selected_hunk_hash_file_path(), binary_hash)
+                write_selected_change_kind(SelectedChangeKind.BINARY)
 
                 # Return the BinaryFileChange object directly
                 return item
@@ -781,6 +846,7 @@ def fetch_next_change() -> Union[LineLevelChange, BinaryFileChange]:
 
             write_file_bytes(get_selected_hunk_patch_file_path(), patch_bytes)
             write_text_file_contents(get_selected_hunk_hash_file_path(), hunk_hash)
+            write_selected_change_kind(SelectedChangeKind.HUNK)
 
             write_text_file_contents(get_line_changes_json_file_path(),
                                      json.dumps(convert_line_changes_to_serializable_dict(line_changes),

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -30,7 +30,7 @@ from ..core.diff_parser import (
 )
 from ..core.line_selection import write_line_ids_file
 from ..exceptions import CommandError, MergeError, NoMoreHunks, exit_with_error
-from ..i18n import _
+from ..i18n import _, ngettext
 from ..output import print_line_level_changes, print_binary_file_change
 from .consumed_selections import read_consumed_file_metadata
 from ..utils.file_io import (
@@ -736,10 +736,34 @@ def _build_combined_file_line_changes(
     max_old_end = None
     min_new_start = None
     max_new_end = None
+    previous_old_end = None
+    previous_new_end = None
 
     for single_hunk in patches:
         patch_bytes = single_hunk.to_patch_bytes()
         line_changes = build_line_changes_from_patch_bytes(patch_bytes)
+
+        if previous_old_end is not None and previous_new_end is not None:
+            omitted_old_lines = line_changes.header.old_start - previous_old_end
+            omitted_new_lines = line_changes.header.new_start - previous_new_end
+            omitted_line_count = max(omitted_old_lines, omitted_new_lines)
+            if omitted_line_count > 0:
+                gap_text = ngettext(
+                    "... {count} more line ...",
+                    "... {count} more lines ...",
+                    omitted_line_count,
+                ).format(count=omitted_line_count)
+                all_line_entries.append(
+                    LineEntry(
+                        id=None,
+                        kind=" ",
+                        old_line_number=None,
+                        new_line_number=None,
+                        text_bytes=gap_text.encode("utf-8"),
+                        text=gap_text,
+                        source_line=None,
+                    )
+                )
 
         if min_old_start is None:
             min_old_start = line_changes.header.old_start
@@ -747,6 +771,8 @@ def _build_combined_file_line_changes(
 
         max_old_end = line_changes.header.old_start + line_changes.header.old_len
         max_new_end = line_changes.header.new_start + line_changes.header.new_len
+        previous_old_end = max_old_end
+        previous_new_end = max_new_end
 
         for line_entry in line_changes.lines:
             if line_entry.kind != " ":

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -622,6 +622,16 @@ def cache_file_as_single_hunk(file_path: str) -> Optional[LineLevelChange]:
         return None
 
 
+def cache_unstaged_file_as_single_hunk(file_path: str) -> Optional[LineLevelChange]:
+    """Cache the remaining unstaged changes for a file as a single hunk."""
+    try:
+        combined_line_changes = render_unstaged_file_as_single_hunk(file_path)
+        return _cache_combined_file_line_changes(file_path, combined_line_changes)
+    except subprocess.CalledProcessError:
+        # Git diff failed (e.g., no changes in file)
+        return None
+
+
 def _cache_combined_file_line_changes(
     file_path: str,
     combined_line_changes: Optional[LineLevelChange],
@@ -666,6 +676,16 @@ def render_file_as_single_hunk(file_path: str) -> Optional[LineLevelChange]:
         file_path,
         parse_unified_diff_streaming(
             stream_git_command(["diff", f"-U{get_context_lines()}", "--no-color", "HEAD", "--", file_path])
+        ),
+    )
+
+
+def render_unstaged_file_as_single_hunk(file_path: str) -> Optional[LineLevelChange]:
+    """Render the remaining unstaged changes for a file as a single hunk."""
+    return _build_combined_file_line_changes(
+        file_path,
+        parse_unified_diff_streaming(
+            stream_git_command(["diff", f"-U{get_context_lines()}", "--no-color", "--", file_path])
         ),
     )
 
@@ -1020,8 +1040,22 @@ def recalculate_selected_hunk_for_file(file_path: str) -> None:
     Args:
         file_path: Repository-relative path to recalculate hunk for
     """
+    selected_kind = read_selected_change_kind()
+
     # Clear processed IDs since old line numbers don't apply to fresh hunk
     write_line_ids_file(get_processed_include_ids_file_path(), set())
+    write_line_ids_file(get_processed_skip_ids_file_path(), set())
+
+    if selected_kind == SelectedChangeKind.FILE:
+        line_changes = cache_unstaged_file_as_single_hunk(file_path)
+        if line_changes is None:
+            clear_selected_change_state_files()
+            from ..commands.show import command_show
+            command_show()
+            return
+
+        print_line_level_changes(line_changes)
+        return
 
     # Load blocklist
     blocklist_content = read_text_file_contents(get_block_list_file_path())
@@ -1041,6 +1075,7 @@ def recalculate_selected_hunk_for_file(file_path: str) -> None:
 
             write_file_bytes(get_selected_hunk_patch_file_path(), patch_bytes)
             write_text_file_contents(get_selected_hunk_hash_file_path(), hunk_hash)
+            write_selected_change_kind(SelectedChangeKind.HUNK)
 
             line_changes = build_line_changes_from_patch_bytes(patch_bytes, annotator=annotate_with_batch_source)
             write_text_file_contents(get_line_changes_json_file_path(),

--- a/src/git_stage_batch/staging/operations.py
+++ b/src/git_stage_batch/staging/operations.py
@@ -171,8 +171,37 @@ def build_target_index_content_bytes_with_replaced_lines(
     replace_ids: set[int],
     replacement_text: str,
     base_content: bytes,
+    *,
+    trim_unchanged_edge_anchors: bool = True,
 ) -> bytes:
-    """Build target index content by replacing one contiguous changed region."""
+    """Build target index content by replacing one contiguous selected span.
+
+    Unlike ordinary single-hunk views, file-scoped displays can concatenate
+    multiple real hunks and insert synthetic gap markers between them. This
+    implementation therefore replaces the underlying file span from the first
+    selected changed line to the last selected changed line, even when the
+    displayed selection crosses omitted gap markers.
+    """
+    def longest_prefix_context_match(
+        candidate_lines: list[bytes],
+        context_lines: list[bytes],
+    ) -> int:
+        max_count = min(len(candidate_lines), len(context_lines))
+        for count in range(max_count, 0, -1):
+            if candidate_lines[:count] == context_lines[-count:]:
+                return count
+        return 0
+
+    def longest_suffix_context_match(
+        candidate_lines: list[bytes],
+        context_lines: list[bytes],
+    ) -> int:
+        max_count = min(len(candidate_lines), len(context_lines))
+        for count in range(max_count, 0, -1):
+            if candidate_lines[-count:] == context_lines[:count]:
+                return count
+        return 0
+
     if not replace_ids:
         return base_content
 
@@ -188,48 +217,76 @@ def build_target_index_content_bytes_with_replaced_lines(
     base_lines = base_content.splitlines()
     replacement_bytes = replacement_text.encode("utf-8", errors="surrogateescape")
     replacement_lines = replacement_bytes.splitlines()
-    output_lines: list[bytes] = []
-
-    base_pointer = line_changes.header.old_start - 1
     base_line_count = len(base_lines)
-    inserted_replacement = False
+    selected_indices = [
+        index
+        for index, line in enumerate(line_changes.lines)
+        if line.id in replace_ids
+    ]
+    span_start_index = min(selected_indices)
+    span_end_index = max(selected_indices)
 
-    def push_output(line: bytes) -> None:
-        output_lines.append(line)
+    def find_next_old_line_number(start_index: int) -> int | None:
+        for line_entry in line_changes.lines[start_index:]:
+            if line_entry.old_line_number is not None:
+                return line_entry.old_line_number
+        return None
 
-    def push_replacement_once() -> None:
-        nonlocal inserted_replacement
-        if inserted_replacement:
-            return
-        output_lines.extend(replacement_lines)
-        inserted_replacement = True
+    first_selected_line = line_changes.lines[span_start_index]
+    if first_selected_line.old_line_number is not None:
+        replace_start = max(first_selected_line.old_line_number - 1, 0)
+    else:
+        next_old_line_number = find_next_old_line_number(span_start_index + 1)
+        replace_start = (
+            max(next_old_line_number - 1, 0)
+            if next_old_line_number is not None
+            else base_line_count
+        )
 
-    for index in range(0, min(base_pointer, base_line_count)):
-        push_output(base_lines[index])
+    replace_end = base_line_count
+    for line_entry in reversed(line_changes.lines[span_start_index:span_end_index + 1]):
+        if line_entry.old_line_number is not None:
+            replace_end = line_entry.old_line_number
+            break
+    else:
+        next_old_line_number = find_next_old_line_number(span_end_index + 1)
+        replace_end = (
+            max(next_old_line_number - 1, 0)
+            if next_old_line_number is not None
+            else base_line_count
+        )
 
-    for line_entry in line_changes.lines:
-        is_selected = line_entry.id in replace_ids if line_entry.id is not None else False
+    if trim_unchanged_edge_anchors:
+        before_context = base_lines[:replace_start]
+        after_context = base_lines[replace_end:]
 
-        if is_selected:
-            push_replacement_once()
-            if line_entry.kind in (" ", "-") and base_pointer < base_line_count:
-                base_pointer += 1
-            continue
+        prefix_trim = longest_prefix_context_match(replacement_lines, before_context)
+        if prefix_trim:
+            replacement_lines = replacement_lines[prefix_trim:]
 
-        if line_entry.kind == " ":
-            if base_pointer < base_line_count:
-                push_output(base_lines[base_pointer])
-                base_pointer += 1
-        elif line_entry.kind == "-":
-            if base_pointer < base_line_count:
-                push_output(base_lines[base_pointer])
-                base_pointer += 1
-        elif line_entry.kind == "+":
-            continue
+        suffix_trim = longest_suffix_context_match(replacement_lines, after_context)
+        if suffix_trim:
+            replacement_lines = replacement_lines[:-suffix_trim]
 
-    while 0 <= base_pointer < base_line_count:
-        push_output(base_lines[base_pointer])
-        base_pointer += 1
+        if longest_prefix_context_match(replacement_lines, before_context) >= 2:
+            raise ValueError(
+                "Replacement text still includes unchanged anchor lines before the selected span. "
+                "Provide replacement text only for the selected span, use --file --as for a full-file replacement, "
+                "or pass --no-anchor to keep the anchor text."
+            )
+
+        if longest_suffix_context_match(replacement_lines, after_context) >= 2:
+            raise ValueError(
+                "Replacement text still includes unchanged anchor lines after the selected span. "
+                "Provide replacement text only for the selected span, use --file --as for a full-file replacement, "
+                "or pass --no-anchor to keep the anchor text."
+            )
+
+    output_lines = (
+        base_lines[:replace_start]
+        + replacement_lines
+        + base_lines[replace_end:]
+    )
 
     trailing_newline = (
         replacement_text.endswith("\n")
@@ -260,43 +317,46 @@ def build_target_working_tree_content_with_discarded_lines(
     def push_output(line: str) -> None:
         output_lines.append(line)
 
+    def copy_unchanged_lines_before(new_line_number: int | None) -> None:
+        nonlocal working_pointer
+        if new_line_number is None:
+            return
+        target_index = max(new_line_number - 1, 0)
+        while working_pointer < min(target_index, working_line_count):
+            push_output(working_lines[working_pointer])
+            working_pointer += 1
+
     # Copy lines before the hunk
     for index in range(0, min(working_pointer, working_line_count)):
         push_output(working_lines[index])
 
     # Process hunk lines
     for line_entry in line_changes.lines:
+        is_gap_line = (
+            line_entry.kind == " "
+            and line_entry.old_line_number is None
+            and line_entry.new_line_number is None
+        )
+        if is_gap_line:
+            continue
+
         if line_entry.kind == " ":
-            # Context line: always include
+            copy_unchanged_lines_before(line_entry.new_line_number)
             if working_pointer < working_line_count:
                 push_output(working_lines[working_pointer])
                 working_pointer += 1
         elif line_entry.kind == "-":
-            # Deletion: reinsert if discarding
             if line_entry.id in discard_ids:
-                push_output(line_entry.text)   # reinsert deleted line
-            else:
-                # keep deletion as-is (no output, no pointer advance)
-                pass
+                push_output(line_entry.text)
         elif line_entry.kind == "+":
-            # Addition: remove if discarding
+            copy_unchanged_lines_before(line_entry.new_line_number)
             if working_pointer < working_line_count:
                 if line_entry.id in discard_ids:
-                    working_pointer += 1       # drop inserted line
+                    working_pointer += 1
                 else:
                     push_output(working_lines[working_pointer])
                     working_pointer += 1
-            else:
-                # addition beyond EOF
-                if line_entry.id in discard_ids:
-                    # nothing to drop
-                    pass
-                else:
-                    # addition kept would already be in file if beyond EOF was materialized;
-                    # nothing to emit here
-                    pass
 
-    # Copy remaining lines after the hunk
     while 0 <= working_pointer < working_line_count:
         push_output(working_lines[working_pointer])
         working_pointer += 1
@@ -319,11 +379,29 @@ def build_target_working_tree_content_bytes_with_discarded_lines(
     def push_output(line: bytes) -> None:
         output_lines.append(line)
 
+    def copy_unchanged_lines_before(new_line_number: int | None) -> None:
+        nonlocal working_pointer
+        if new_line_number is None:
+            return
+        target_index = max(new_line_number - 1, 0)
+        while working_pointer < min(target_index, working_line_count):
+            push_output(working_lines[working_pointer])
+            working_pointer += 1
+
     for index in range(0, min(working_pointer, working_line_count)):
         push_output(working_lines[index])
 
     for line_entry in line_changes.lines:
+        is_gap_line = (
+            line_entry.kind == " "
+            and line_entry.old_line_number is None
+            and line_entry.new_line_number is None
+        )
+        if is_gap_line:
+            continue
+
         if line_entry.kind == " ":
+            copy_unchanged_lines_before(line_entry.new_line_number)
             if working_pointer < working_line_count:
                 push_output(working_lines[working_pointer])
                 working_pointer += 1
@@ -331,6 +409,7 @@ def build_target_working_tree_content_bytes_with_discarded_lines(
             if line_entry.id in discard_ids:
                 push_output(line_entry.text_bytes)
         elif line_entry.kind == "+":
+            copy_unchanged_lines_before(line_entry.new_line_number)
             if working_pointer < working_line_count:
                 if line_entry.id in discard_ids:
                     working_pointer += 1
@@ -351,8 +430,30 @@ def build_target_working_tree_content_bytes_with_replaced_lines(
     replace_ids: set[int],
     replacement_text: str,
     working_content: bytes,
+    *,
+    trim_unchanged_edge_anchors: bool = True,
 ) -> bytes:
-    """Build working tree content by replacing one contiguous changed region."""
+    """Build working tree content by replacing one contiguous selected span."""
+    def longest_prefix_context_match(
+        candidate_lines: list[bytes],
+        context_lines: list[bytes],
+    ) -> int:
+        max_count = min(len(candidate_lines), len(context_lines))
+        for count in range(max_count, 0, -1):
+            if candidate_lines[:count] == context_lines[-count:]:
+                return count
+        return 0
+
+    def longest_suffix_context_match(
+        candidate_lines: list[bytes],
+        context_lines: list[bytes],
+    ) -> int:
+        max_count = min(len(candidate_lines), len(context_lines))
+        for count in range(max_count, 0, -1):
+            if candidate_lines[-count:] == context_lines[:count]:
+                return count
+        return 0
+
     if not replace_ids:
         return working_content
 
@@ -366,50 +467,78 @@ def build_target_working_tree_content_bytes_with_replaced_lines(
         raise ValueError("Replacement selection must be one contiguous line range")
 
     working_lines = working_content.splitlines()
-    output_lines: list[bytes] = []
-
-    working_pointer = line_changes.header.new_start - 1
     working_line_count = len(working_lines)
     replacement_bytes = replacement_text.encode("utf-8", errors="surrogateescape")
     replacement_lines = replacement_bytes.splitlines()
-    inserted_replacement = False
+    selected_indices = [
+        index
+        for index, line in enumerate(line_changes.lines)
+        if line.id in replace_ids
+    ]
+    span_start_index = min(selected_indices)
+    span_end_index = max(selected_indices)
 
-    def push_output(line: bytes) -> None:
-        output_lines.append(line)
+    def find_next_new_line_number(start_index: int) -> int | None:
+        for line_entry in line_changes.lines[start_index:]:
+            if line_entry.new_line_number is not None:
+                return line_entry.new_line_number
+        return None
 
-    def push_replacement_once() -> None:
-        nonlocal inserted_replacement
-        if inserted_replacement:
-            return
-        output_lines.extend(replacement_lines)
-        inserted_replacement = True
+    first_selected_line = line_changes.lines[span_start_index]
+    if first_selected_line.new_line_number is not None:
+        replace_start = max(first_selected_line.new_line_number - 1, 0)
+    else:
+        next_new_line_number = find_next_new_line_number(span_start_index + 1)
+        replace_start = (
+            max(next_new_line_number - 1, 0)
+            if next_new_line_number is not None
+            else working_line_count
+        )
 
-    for index in range(0, min(working_pointer, working_line_count)):
-        push_output(working_lines[index])
+    replace_end = working_line_count
+    for line_entry in reversed(line_changes.lines[span_start_index:span_end_index + 1]):
+        if line_entry.new_line_number is not None:
+            replace_end = line_entry.new_line_number
+            break
+    else:
+        next_new_line_number = find_next_new_line_number(span_end_index + 1)
+        replace_end = (
+            max(next_new_line_number - 1, 0)
+            if next_new_line_number is not None
+            else working_line_count
+        )
 
-    for line_entry in line_changes.lines:
-        is_selected = line_entry.id in replace_ids if line_entry.id is not None else False
+    if trim_unchanged_edge_anchors:
+        before_context = working_lines[:replace_start]
+        after_context = working_lines[replace_end:]
 
-        if is_selected:
-            push_replacement_once()
-            if line_entry.kind in (" ", "+") and working_pointer < working_line_count:
-                working_pointer += 1
-            continue
+        prefix_trim = longest_prefix_context_match(replacement_lines, before_context)
+        if prefix_trim:
+            replacement_lines = replacement_lines[prefix_trim:]
 
-        if line_entry.kind == " ":
-            if working_pointer < working_line_count:
-                push_output(working_lines[working_pointer])
-                working_pointer += 1
-        elif line_entry.kind == "-":
-            continue
-        elif line_entry.kind == "+":
-            if working_pointer < working_line_count:
-                push_output(working_lines[working_pointer])
-                working_pointer += 1
+        suffix_trim = longest_suffix_context_match(replacement_lines, after_context)
+        if suffix_trim:
+            replacement_lines = replacement_lines[:-suffix_trim]
 
-    while 0 <= working_pointer < working_line_count:
-        push_output(working_lines[working_pointer])
-        working_pointer += 1
+        if longest_prefix_context_match(replacement_lines, before_context) >= 2:
+            raise ValueError(
+                "Replacement text still includes unchanged anchor lines before the selected span. "
+                "Provide replacement text only for the selected span, use --file --as for a full-file replacement, "
+                "or pass --no-anchor to keep the anchor text."
+            )
+
+        if longest_suffix_context_match(replacement_lines, after_context) >= 2:
+            raise ValueError(
+                "Replacement text still includes unchanged anchor lines after the selected span. "
+                "Provide replacement text only for the selected span, use --file --as for a full-file replacement, "
+                "or pass --no-anchor to keep the anchor text."
+            )
+
+    output_lines = (
+        working_lines[:replace_start]
+        + replacement_lines
+        + working_lines[replace_end:]
+    )
 
     trailing_newline = (
         replacement_text.endswith("\n")

--- a/src/git_stage_batch/staging/operations.py
+++ b/src/git_stage_batch/staging/operations.py
@@ -24,38 +24,65 @@ def build_target_index_content_with_selected_lines(
     """
     base_lines = base_text.splitlines()
     output_lines: list[str] = []
+    pending_additions: list[str] = []
 
-    base_pointer = line_changes.header.old_start - 1  # 0-based
+    base_pointer = 0
     base_line_count = len(base_lines)
 
     def push_output(line: str) -> None:
         output_lines.append(line)
 
-    # Copy lines before the hunk
-    for index in range(0, min(base_pointer, base_line_count)):
-        push_output(base_lines[index])
+    def flush_pending_additions() -> None:
+        if pending_additions:
+            output_lines.extend(pending_additions)
+            pending_additions.clear()
 
-    # Process hunk lines
+    def base_line_matches(text: str) -> bool:
+        return base_pointer < base_line_count and base_lines[base_pointer] == text
+
+    def copy_unchanged_lines_before(old_line_number: int | None) -> None:
+        nonlocal base_pointer
+        if old_line_number is None:
+            return
+        target_index = max(old_line_number - 1, 0)
+        while base_pointer < min(target_index, base_line_count):
+            push_output(base_lines[base_pointer])
+            base_pointer += 1
+
     for line_entry in line_changes.lines:
+        is_gap_line = (
+            line_entry.kind == " "
+            and line_entry.old_line_number is None
+            and line_entry.new_line_number is None
+        )
+        if is_gap_line:
+            flush_pending_additions()
+            continue
+
         if line_entry.kind == " ":
-            # Context line: always include
+            copy_unchanged_lines_before(line_entry.old_line_number)
+            flush_pending_additions()
             if base_pointer < base_line_count:
                 push_output(base_lines[base_pointer])
                 base_pointer += 1
         elif line_entry.kind == "-":
-            # Deletion: remove from base if included
-            if base_pointer < base_line_count:
-                if line_entry.id in include_ids:
-                    base_pointer += 1      # drop deletion target
-                else:
-                    push_output(base_lines[base_pointer])
-                    base_pointer += 1
-        elif line_entry.kind == "+":
-            # Addition: insert if included
+            copy_unchanged_lines_before(line_entry.old_line_number)
+            flush_pending_additions()
             if line_entry.id in include_ids:
-                push_output(line_entry.text)
+                if base_line_matches(line_entry.text):
+                    base_pointer += 1
+            elif base_line_matches(line_entry.text):
+                push_output(base_lines[base_pointer])
+                base_pointer += 1
+        elif line_entry.kind == "+":
+            if base_line_matches(line_entry.text):
+                flush_pending_additions()
+                push_output(base_lines[base_pointer])
+                base_pointer += 1
+            elif line_entry.id in include_ids:
+                pending_additions.append(line_entry.text)
 
-    # Copy remaining lines after the hunk
+    flush_pending_additions()
     while 0 <= base_pointer < base_line_count:
         push_output(base_lines[base_pointer])
         base_pointer += 1
@@ -72,32 +99,65 @@ def build_target_index_content_bytes_with_selected_lines(
     """Bytes-preserving variant of build_target_index_content_with_selected_lines."""
     base_lines = base_content.splitlines()
     output_lines: list[bytes] = []
+    pending_additions: list[bytes] = []
 
-    base_pointer = line_changes.header.old_start - 1
+    base_pointer = 0
     base_line_count = len(base_lines)
 
     def push_output(line: bytes) -> None:
         output_lines.append(line)
 
-    for index in range(0, min(base_pointer, base_line_count)):
-        push_output(base_lines[index])
+    def flush_pending_additions() -> None:
+        if pending_additions:
+            output_lines.extend(pending_additions)
+            pending_additions.clear()
+
+    def base_line_matches(text: bytes) -> bool:
+        return base_pointer < base_line_count and base_lines[base_pointer] == text
+
+    def copy_unchanged_lines_before(old_line_number: int | None) -> None:
+        nonlocal base_pointer
+        if old_line_number is None:
+            return
+        target_index = max(old_line_number - 1, 0)
+        while base_pointer < min(target_index, base_line_count):
+            push_output(base_lines[base_pointer])
+            base_pointer += 1
 
     for line_entry in line_changes.lines:
+        is_gap_line = (
+            line_entry.kind == " "
+            and line_entry.old_line_number is None
+            and line_entry.new_line_number is None
+        )
+        if is_gap_line:
+            flush_pending_additions()
+            continue
+
         if line_entry.kind == " ":
+            copy_unchanged_lines_before(line_entry.old_line_number)
+            flush_pending_additions()
             if base_pointer < base_line_count:
                 push_output(base_lines[base_pointer])
                 base_pointer += 1
         elif line_entry.kind == "-":
-            if base_pointer < base_line_count:
-                if line_entry.id in include_ids:
-                    base_pointer += 1
-                else:
-                    push_output(base_lines[base_pointer])
-                    base_pointer += 1
-        elif line_entry.kind == "+":
+            copy_unchanged_lines_before(line_entry.old_line_number)
+            flush_pending_additions()
             if line_entry.id in include_ids:
-                push_output(line_entry.text_bytes)
+                if base_line_matches(line_entry.text_bytes):
+                    base_pointer += 1
+            elif base_line_matches(line_entry.text_bytes):
+                push_output(base_lines[base_pointer])
+                base_pointer += 1
+        elif line_entry.kind == "+":
+            if base_line_matches(line_entry.text_bytes):
+                flush_pending_additions()
+                push_output(base_lines[base_pointer])
+                base_pointer += 1
+            elif line_entry.id in include_ids:
+                pending_additions.append(line_entry.text_bytes)
 
+    flush_pending_additions()
     while 0 <= base_pointer < base_line_count:
         push_output(base_lines[base_pointer])
         base_pointer += 1

--- a/src/git_stage_batch/utils/file_patterns.py
+++ b/src/git_stage_batch/utils/file_patterns.py
@@ -68,11 +68,18 @@ def resolve_gitignore_style_patterns(
         payload = b"".join(candidate.encode("utf-8") + b"\0" for candidate in normalized_candidates)
         result = subprocess.run(
             ["git", "check-ignore", "--no-index", "--stdin", "-z", "-v", "-n"],
-            check=True,
+            check=False,
             cwd=temp_root,
             input=payload,
             capture_output=True,
         )
+        if result.returncode not in (0, 1):
+            raise subprocess.CalledProcessError(
+                result.returncode,
+                result.args,
+                output=result.stdout,
+                stderr=result.stderr,
+            )
 
     fields = result.stdout.split(b"\0")
     resolved_status: dict[str, bool] = {}

--- a/src/git_stage_batch/utils/paths.py
+++ b/src/git_stage_batch/utils/paths.py
@@ -161,6 +161,11 @@ def get_selected_hunk_hash_file_path() -> Path:
     return get_selected_state_directory_path() / "hunk.hash.txt"
 
 
+def get_selected_change_kind_file_path() -> Path:
+    """Get the path to the selected change kind marker file."""
+    return get_selected_state_directory_path() / "change-kind.txt"
+
+
 def get_selected_binary_file_json_path() -> Path:
     """Get the path to the selected binary file JSON file.
 

--- a/tests/cli/test_argument_parser.py
+++ b/tests/cli/test_argument_parser.py
@@ -1,5 +1,6 @@
 """Tests for CLI argument parsing."""
 
+import io
 import os
 from unittest.mock import Mock, call
 
@@ -7,6 +8,11 @@ import pytest
 
 from git_stage_batch.cli import argument_parser
 from git_stage_batch.cli.argument_parser import parse_command_line
+
+
+def _stdin_with_bytes(data: bytes) -> io.TextIOWrapper:
+    """Build stdin carrying exact bytes for `--as-stdin` tests."""
+    return io.TextIOWrapper(io.BytesIO(data), encoding="utf-8", errors="surrogateescape")
 
 
 def test_build_manpath_with_existing_environment(monkeypatch):
@@ -297,6 +303,58 @@ def test_parse_command_line_include_with_file_and_as():
     assert callable(args.func)
 
 
+def test_parse_command_line_include_with_file_and_as_dispatches_file_replacement(monkeypatch):
+    """Include --file --as without --line should dispatch file replacement staging."""
+    mock_command = Mock()
+    monkeypatch.setattr(argument_parser.commands, "command_include_file_as", mock_command)
+
+    args = parse_command_line(
+        ["include", "--file", "path.txt", "--as", "replacement"],
+        quiet=True,
+    )
+
+    assert args is not None
+    args.func(args)
+    mock_command.assert_called_once_with("replacement", file="path.txt")
+
+
+def test_parse_command_line_include_with_file_and_as_stdin_dispatches_file_replacement(monkeypatch):
+    """Include --file --as-stdin should preserve trailing newlines."""
+    mock_command = Mock()
+    monkeypatch.setattr(argument_parser.commands, "command_include_file_as", mock_command)
+    monkeypatch.setattr(argument_parser.sys, "stdin", _stdin_with_bytes(b"replacement\n"))
+
+    args = parse_command_line(
+        ["include", "--file", "path.txt", "--as-stdin"],
+        quiet=True,
+    )
+
+    assert args is not None
+    args.func(args)
+    mock_command.assert_called_once_with("replacement\n", file="path.txt")
+
+
+def test_parse_command_line_include_with_line_range_and_as_stdin_dispatches_line_replacement(monkeypatch):
+    """Include --line range --as-stdin should forward exact replacement text."""
+    mock_command = Mock()
+    monkeypatch.setattr(argument_parser.commands, "command_include_line_as", mock_command)
+    monkeypatch.setattr(argument_parser.sys, "stdin", _stdin_with_bytes(b"replacement one\nreplacement two\n"))
+
+    args = parse_command_line(
+        ["include", "--file", "path.txt", "--line", "2-3", "--as-stdin"],
+        quiet=True,
+    )
+
+    assert args is not None
+    args.func(args)
+    mock_command.assert_called_once_with(
+        "2-3",
+        "replacement one\nreplacement two\n",
+        file="path.txt",
+        no_anchor=False,
+    )
+
+
 def test_parse_command_line_include_with_file_and_line_dispatches_file_scope(monkeypatch):
     """Include --file --line should dispatch to file-scoped line staging."""
     mock_command = Mock()
@@ -314,8 +372,12 @@ def test_parse_command_line_include_with_file_and_line_dispatches_file_scope(mon
 
 def test_parse_command_line_include_with_files_dispatches_per_file(monkeypatch):
     """Include should dispatch once per file resolved from --files."""
-    mock_command = Mock()
+    mock_command = Mock(return_value=1)
     monkeypatch.setattr(argument_parser.commands, "command_include_file", mock_command)
+    mock_advance_to_next_change = Mock()
+    monkeypatch.setattr(argument_parser, "advance_to_next_change", mock_advance_to_next_change)
+    mock_show_selected_change = Mock()
+    monkeypatch.setattr(argument_parser, "show_selected_change", mock_show_selected_change)
     monkeypatch.setattr(argument_parser, "list_changed_files", lambda: ["foo.py", "dir/bar.py", "baz.txt"])
 
     args = parse_command_line(["include", "--files", "*.py"], quiet=True)
@@ -323,7 +385,12 @@ def test_parse_command_line_include_with_files_dispatches_per_file(monkeypatch):
     assert args is not None
     assert args.file_patterns == ["*.py"]
     args.func(args)
-    assert mock_command.call_args_list == [call("foo.py"), call("dir/bar.py")]
+    assert mock_command.call_args_list == [
+        call("foo.py", quiet=True, advance=False),
+        call("dir/bar.py", quiet=True, advance=False),
+    ]
+    mock_advance_to_next_change.assert_called_once_with()
+    mock_show_selected_change.assert_called_once_with()
 
 
 def test_parse_command_line_include_from_with_as():
@@ -338,6 +405,48 @@ def test_parse_command_line_include_from_with_as():
     assert args.as_text == "replacement"
     assert hasattr(args, "func")
     assert callable(args.func)
+
+
+def test_parse_command_line_include_rejects_as_and_as_stdin_together(monkeypatch):
+    """Include should reject mixing literal and stdin replacement sources."""
+    monkeypatch.setattr(argument_parser.sys, "stdin", _stdin_with_bytes(b"replacement\n"))
+    args = parse_command_line(
+        ["include", "--file", "path.txt", "--as", "replacement", "--as-stdin"],
+        quiet=True,
+    )
+    assert args is not None
+
+    with pytest.raises(argument_parser.CommandError, match="Cannot use `--as` and `--as-stdin` together"):
+        args.func(args)
+
+
+def test_parse_command_line_include_with_no_anchor_dispatches_line_replacement(monkeypatch):
+    """Include --line --as --no-anchor should forward the no-anchor flag."""
+    mock_command = Mock()
+    monkeypatch.setattr(argument_parser.commands, "command_include_line_as", mock_command)
+
+    args = parse_command_line(
+        ["include", "--file", "path.txt", "--line", "2-3", "--as", "replacement", "--no-anchor"],
+        quiet=True,
+    )
+
+    assert args is not None
+    args.func(args)
+    mock_command.assert_called_once_with("2-3", "replacement", file="path.txt", no_anchor=True)
+
+
+def test_parse_command_line_include_rejects_no_anchor_without_line_as():
+    """Include should reject --no-anchor outside live include --line --as."""
+    args = parse_command_line(
+        ["include", "--file", "path.txt", "--no-anchor"],
+        quiet=True,
+    )
+    assert args is not None
+
+    with pytest.raises(argument_parser.CommandError, match="`--no-anchor` requires `include --line --as`"):
+        args.func(args)
+
+
 def test_parse_command_line_skip():
     """Test parsing skip command."""
     args = parse_command_line(["skip"], quiet=True)
@@ -392,15 +501,24 @@ def test_parse_command_line_skip_with_files():
 
 def test_parse_command_line_skip_files_dispatches_per_file(monkeypatch):
     """Skip should dispatch once per file resolved from --files."""
-    mock_command = Mock()
+    mock_command = Mock(side_effect=[1, 2])
     monkeypatch.setattr(argument_parser.commands, "command_skip_file", mock_command)
+    mock_advance_to_next_change = Mock()
+    monkeypatch.setattr(argument_parser, "advance_to_next_change", mock_advance_to_next_change)
+    mock_show_selected_change = Mock()
+    monkeypatch.setattr(argument_parser, "show_selected_change", mock_show_selected_change)
     monkeypatch.setattr(argument_parser, "list_changed_files", lambda: ["foo.py", "bar.py", "notes.txt"])
 
     args = parse_command_line(["skip", "--files", "*.py"], quiet=True)
 
     assert args is not None
     args.func(args)
-    assert mock_command.call_args_list == [call("foo.py"), call("bar.py")]
+    assert mock_command.call_args_list == [
+        call("foo.py", quiet=True, advance=False),
+        call("bar.py", quiet=True, advance=False),
+    ]
+    mock_advance_to_next_change.assert_called_once_with()
+    mock_show_selected_change.assert_called_once_with()
 
 
 def test_parse_command_line_skip_rejects_lines_with_multiple_files(monkeypatch):
@@ -471,6 +589,17 @@ def test_parse_command_line_show_with_files_only_last_result_is_selectable(monke
     ]
 
 
+def test_parse_command_line_show_with_files_raises_command_error_for_no_matches(monkeypatch):
+    """Show should report unmatched --files patterns without a traceback."""
+    monkeypatch.setattr(argument_parser, "list_changed_files", lambda: ["foo.py", "bar.py"])
+
+    args = parse_command_line(["show", "--files", "*.md"], quiet=True)
+
+    assert args is not None
+    with pytest.raises(argument_parser.CommandError, match="No changed files matched: \\*.md"):
+        args.func(args)
+
+
 def test_parse_command_line_discard():
     """Test parsing discard command."""
     args = parse_command_line(["discard"], quiet=True)
@@ -507,6 +636,105 @@ def test_parse_command_line_discard_to_with_file_and_as():
     assert args.as_text == "replacement"
     assert hasattr(args, "func")
     assert callable(args.func)
+
+
+def test_parse_command_line_discard_with_file_and_as_dispatches_file_replacement(monkeypatch):
+    """Discard --file --as without --line should dispatch file replacement."""
+    mock_command = Mock()
+    monkeypatch.setattr(argument_parser.commands, "command_discard_file_as", mock_command)
+
+    args = parse_command_line(
+        ["discard", "--file", "path.txt", "--as", "replacement"],
+        quiet=True,
+    )
+
+    assert args is not None
+    args.func(args)
+    mock_command.assert_called_once_with("replacement", file="path.txt")
+
+
+def test_parse_command_line_discard_with_file_and_as_stdin_dispatches_file_replacement(monkeypatch):
+    """Discard --file --as-stdin should preserve trailing newlines."""
+    mock_command = Mock()
+    monkeypatch.setattr(argument_parser.commands, "command_discard_file_as", mock_command)
+    monkeypatch.setattr(argument_parser.sys, "stdin", _stdin_with_bytes(b"replacement\n"))
+
+    args = parse_command_line(
+        ["discard", "--file", "path.txt", "--as-stdin"],
+        quiet=True,
+    )
+
+    assert args is not None
+    args.func(args)
+    mock_command.assert_called_once_with("replacement\n", file="path.txt")
+
+
+def test_parse_command_line_discard_to_line_range_and_as_stdin_dispatches_replacement(monkeypatch):
+    """Discard --to --line range --as-stdin should forward exact replacement text."""
+    mock_command = Mock()
+    monkeypatch.setattr(argument_parser.commands, "command_discard_line_as_to_batch", mock_command)
+    monkeypatch.setattr(argument_parser.sys, "stdin", _stdin_with_bytes(b"replacement one\nreplacement two\n"))
+
+    args = parse_command_line(
+        ["discard", "--to", "batch", "--file", "path.txt", "--line", "2-3", "--as-stdin"],
+        quiet=True,
+    )
+
+    assert args is not None
+    args.func(args)
+    mock_command.assert_called_once_with(
+        "batch",
+        "2-3",
+        "replacement one\nreplacement two\n",
+        file="path.txt",
+        no_anchor=False,
+    )
+
+
+def test_parse_command_line_discard_rejects_as_and_as_stdin_together(monkeypatch):
+    """Discard should reject mixing literal and stdin replacement sources."""
+    monkeypatch.setattr(argument_parser.sys, "stdin", _stdin_with_bytes(b"replacement\n"))
+    args = parse_command_line(
+        ["discard", "--file", "path.txt", "--as", "replacement", "--as-stdin"],
+        quiet=True,
+    )
+    assert args is not None
+
+    with pytest.raises(argument_parser.CommandError, match="Cannot use `--as` and `--as-stdin` together"):
+        args.func(args)
+
+
+def test_parse_command_line_discard_with_no_anchor_dispatches_line_replacement(monkeypatch):
+    """Discard --to --line --as --no-anchor should forward the no-anchor flag."""
+    mock_command = Mock()
+    monkeypatch.setattr(argument_parser.commands, "command_discard_line_as_to_batch", mock_command)
+
+    args = parse_command_line(
+        ["discard", "--to", "batch", "--file", "path.txt", "--line", "2-3", "--as", "replacement", "--no-anchor"],
+        quiet=True,
+    )
+
+    assert args is not None
+    args.func(args)
+    mock_command.assert_called_once_with(
+        "batch",
+        "2-3",
+        "replacement",
+        file="path.txt",
+        no_anchor=True,
+    )
+
+
+def test_parse_command_line_discard_rejects_no_anchor_without_to_line_as():
+    """Discard should reject --no-anchor outside discard --to --line --as."""
+    args = parse_command_line(
+        ["discard", "--file", "path.txt", "--no-anchor"],
+        quiet=True,
+    )
+    assert args is not None
+
+    with pytest.raises(argument_parser.CommandError, match="`--no-anchor` requires `discard --to --line --as`"):
+        args.func(args)
 
 
 def test_parse_command_line_discard_with_file_and_line_dispatches_file_scope(monkeypatch):

--- a/tests/commands/test_discard.py
+++ b/tests/commands/test_discard.py
@@ -511,3 +511,93 @@ class TestCommandDiscardToBatch:
 
         command_apply_from_batch("feature-batch")
         assert readme.read_text() == "# Test\nstaged1\nline2\nline3\nline4\nline5\nline6\nline7\nstaged8\n"
+
+    def test_discard_line_as_to_batch_replaces_disjoint_file_scoped_regions(self, temp_git_repo):
+        """Discard replacement should accept one contiguous range across regions."""
+        readme = temp_git_repo / "multi.txt"
+        base_lines = [f"line{i}\n" for i in range(1, 41)]
+        readme.write_text("".join(base_lines))
+        subprocess.run(["git", "add", "multi.txt"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add multi file"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        rewritten_lines = (
+            base_lines[:5]
+            + ["change-one-a\n", "change-one-b\n"]
+            + base_lines[5:20]
+            + ["change-two-a\n", "change-two-b\n"]
+            + base_lines[20:35]
+            + ["change-three-a\n", "change-three-b\n"]
+            + base_lines[35:]
+        )
+        readme.write_text("".join(rewritten_lines))
+
+        command_start()
+        staged_span = (
+            ["stage-one-a\n", "stage-one-b\n"]
+            + base_lines[5:20]
+            + ["stage-two-a\n", "stage-two-b\n"]
+            + base_lines[20:35]
+            + ["stage-three-a\n", "stage-three-b\n"]
+        )
+        command_discard_line_as_to_batch(
+            "feature-batch",
+            "1-6",
+            "".join(staged_span),
+            file="multi.txt",
+        )
+        assert readme.read_text() == "".join(base_lines)
+        assert batch_exists("feature-batch")
+
+        command_apply_from_batch("feature-batch")
+        assert readme.read_text() == (
+            "".join(base_lines[:5])
+            + "".join(staged_span)
+            + "".join(base_lines[35:])
+        )
+
+    def test_discard_line_as_to_batch_trims_matching_edge_anchors(self, temp_git_repo):
+        """Discard --to --line --as should accept unchanged edge anchors by default."""
+        readme = temp_git_repo / "README.md"
+        readme.write_text("keep1\nold\nkeep3\nkeep4\n")
+        subprocess.run(["git", "add", "README.md"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Seed readme"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        readme.write_text("keep1\nworking\nkeep3\nkeep4\n")
+
+        command_start()
+        fetch_next_change()
+
+        command_discard_line_as_to_batch(
+            "feature-batch",
+            "1-2",
+            "keep1\nstaged\nkeep3\nkeep4\n",
+        )
+
+        assert readme.read_text() == "keep1\nold\nkeep3\nkeep4\n"
+
+        command_apply_from_batch("feature-batch")
+        assert readme.read_text() == "keep1\nstaged\nkeep3\nkeep4\n"
+
+    def test_discard_line_as_to_batch_no_anchor_keeps_matching_edge_anchors(self, temp_git_repo):
+        """Discard --to --line --as --no-anchor should preserve duplicate anchors."""
+        readme = temp_git_repo / "README.md"
+        readme.write_text("keep1\nold\nkeep3\nkeep4\n")
+        subprocess.run(["git", "add", "README.md"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Seed readme"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        readme.write_text("keep1\nworking\nkeep3\nkeep4\n")
+
+        command_start()
+        fetch_next_change()
+
+        command_discard_line_as_to_batch(
+            "feature-batch",
+            "1-2",
+            "keep1\nstaged\nkeep3\nkeep4\n",
+            no_anchor=True,
+        )
+
+        assert readme.read_text() == "keep1\nold\nstaged\nkeep3\nkeep4\nkeep3\nkeep4\n"
+
+        command_apply_from_batch("feature-batch")
+        assert readme.read_text() == "keep1\nkeep1\nstaged\nkeep3\nkeep4\nkeep3\nkeep4\n"

--- a/tests/commands/test_discard.py
+++ b/tests/commands/test_discard.py
@@ -462,3 +462,52 @@ class TestCommandDiscardToBatch:
                 )
 
         assert readme.read_text() == "# Test\nprint('debug')\n"
+
+    def test_discard_line_as_to_batch_handles_followup_replacement_in_same_session(self, temp_git_repo):
+        """A second discard --as should refresh stale batch source state."""
+        readme = temp_git_repo / "README.md"
+        readme.write_text(
+            "# Test\n"
+            "line1\n"
+            "line2\n"
+            "line3\n"
+            "line4\n"
+            "line5\n"
+            "line6\n"
+            "line7\n"
+            "line8\n"
+        )
+        subprocess.run(["git", "add", "README.md"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Expand readme"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        readme.write_text(
+            "# Test\n"
+            "line1-edited\n"
+            "line2\n"
+            "line3\n"
+            "line4\n"
+            "line5\n"
+            "line6\n"
+            "line7\n"
+            "line8-edited\n"
+        )
+
+        command_start()
+        fetch_next_change()
+
+        command_discard_line_as_to_batch(
+            "feature-batch",
+            "1",
+            "staged1",
+        )
+        command_discard_line_as_to_batch(
+            "feature-batch",
+            "1",
+            "staged8",
+            file="README.md",
+        )
+
+        assert readme.read_text() == "# Test\nline1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\n"
+
+        command_apply_from_batch("feature-batch")
+        assert readme.read_text() == "# Test\nstaged1\nline2\nline3\nline4\nline5\nline6\nline7\nstaged8\n"

--- a/tests/commands/test_file_scoped_operations.py
+++ b/tests/commands/test_file_scoped_operations.py
@@ -15,7 +15,9 @@ from git_stage_batch.utils.paths import (
     get_selected_hunk_hash_file_path,
     get_selected_hunk_patch_file_path,
 )
-from git_stage_batch.commands.skip import command_skip
+from git_stage_batch.data.hunk_tracking import render_unstaged_file_as_single_hunk
+from git_stage_batch.commands.skip import command_skip, command_skip_line
+from git_stage_batch.cli.argument_parser import parse_command_line
 
 import subprocess
 
@@ -24,8 +26,10 @@ import pytest
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.commands.show import command_show
 from git_stage_batch.commands.include import (
+    command_include,
     command_include_to_batch,
     command_include_file,
+    command_include_file_as,
     command_include_line,
     command_include_line_as,
 )
@@ -141,6 +145,525 @@ class TestShowFileFlag:
         command_discard_line("3")
 
         assert (multi_file_repo / "beta.txt").read_text() == "beta1\nbeta2-modified\nbeta3\n"
+
+    def test_show_file_include_line_keeps_file_selection_for_multi_hunk_file(self, tmp_path, monkeypatch):
+        """Include --line from a file selection should keep the remaining file view."""
+        repo = tmp_path / "test_repo"
+        repo.mkdir()
+        monkeypatch.chdir(repo)
+
+        subprocess.run(["git", "init"], check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.name", "Test"], check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.email", "test@test.com"], check=True, capture_output=True)
+
+        lines = [f"line{i}\n" for i in range(1, 121)]
+        (repo / "multi.txt").write_text("".join(lines))
+        subprocess.run(["git", "add", "multi.txt"], check=True, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Initial"], check=True, capture_output=True)
+
+        content = lines[:]
+        content.insert(5, "change-one\n")
+        content.insert(55, "change-two\n")
+        content.insert(105, "change-three\n")
+        (repo / "multi.txt").write_text("".join(content))
+
+        command_start()
+        command_show(file="multi.txt")
+
+        command_include_line("1")
+
+        line_changes = load_line_changes_from_state()
+        assert line_changes is not None
+        changed_texts = [line.text for line in line_changes.lines if line.kind != " "]
+        assert "change-one" not in changed_texts
+        assert "change-two" in changed_texts
+        assert "change-three" in changed_texts
+
+    def test_explicit_file_include_line_uses_remaining_unstaged_diff(self, tmp_path, monkeypatch):
+        """Explicit file-scoped include --line should not rebase on HEAD after partial staging."""
+        repo = tmp_path / "test_repo"
+        repo.mkdir()
+        monkeypatch.chdir(repo)
+
+        subprocess.run(["git", "init"], check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.name", "Test"], check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.email", "test@test.com"], check=True, capture_output=True)
+
+        lines = [f"line{i}\n" for i in range(1, 81)]
+        lines[0] = "from old_alpha import thing\n"
+        lines[10] = "from old_beta import helper\n"
+        lines[60] = "body_call_old()\n"
+        file_path = repo / "module.py"
+        file_path.write_text("".join(lines))
+        subprocess.run(["git", "add", "module.py"], check=True, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Initial"], check=True, capture_output=True)
+
+        rewritten = lines[:]
+        rewritten[0] = "from new_alpha import thing\n"
+        rewritten[10] = "from new_beta import helper\n"
+        rewritten[60] = "body_call_new()\n"
+        file_path.write_text("".join(rewritten))
+
+        command_start()
+
+        def ids_for_texts(*texts: str) -> str:
+            command_show(file="module.py")
+            line_changes = load_line_changes_from_state()
+            assert line_changes is not None
+            selected_ids = [
+                str(line.id)
+                for line in line_changes.lines
+                if line.id is not None and line.text in texts
+            ]
+            assert len(selected_ids) == len(texts)
+            return ",".join(selected_ids)
+
+        body_ids = ids_for_texts("body_call_old()", "body_call_new()")
+        command_include_line(body_ids, file="module.py")
+
+        alpha_ids = ids_for_texts(
+            "from old_alpha import thing",
+            "from new_alpha import thing",
+        )
+        command_include_line(alpha_ids, file="module.py")
+
+        beta_ids = ids_for_texts(
+            "from old_beta import helper",
+            "from new_beta import helper",
+        )
+        command_include_line(beta_ids, file="module.py")
+
+        result = run_git_command(["show", ":module.py"])
+        assert result.stdout == "".join(rewritten)
+
+    def test_explicit_file_include_line_refreshes_the_selected_file_view(self, tmp_path, monkeypatch):
+        """Explicit file-scoped include --line should advance the selected file view."""
+        repo = tmp_path / "test_repo"
+        repo.mkdir()
+        monkeypatch.chdir(repo)
+
+        subprocess.run(["git", "init"], check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.name", "Test"], check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.email", "test@test.com"], check=True, capture_output=True)
+
+        lines = [f"line{i}\n" for i in range(1, 81)]
+        lines[0] = "from old_alpha import thing\n"
+        lines[10] = "from old_beta import helper\n"
+        lines[60] = "body_call_old()\n"
+        file_path = repo / "module.py"
+        file_path.write_text("".join(lines))
+        subprocess.run(["git", "add", "module.py"], check=True, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Initial"], check=True, capture_output=True)
+
+        rewritten = (
+            ["from new_alpha import (\n", "    thing,\n", "    helper,\n", ")\n"]
+            + lines[1:10]
+            + ["from new_beta import helper\n"]
+            + lines[11:60]
+            + ["body_call_new()\n"]
+            + lines[61:]
+        )
+        file_path.write_text("".join(rewritten))
+
+        command_start()
+        command_show(file="module.py")
+
+        line_changes = load_line_changes_from_state()
+        assert line_changes is not None
+
+        def ids_for_texts(*texts: str) -> str:
+            selected_ids = [
+                str(line.id)
+                for line in line_changes.lines
+                if line.id is not None and line.text in texts
+            ]
+            assert len(selected_ids) == len(texts)
+            return ",".join(selected_ids)
+
+        alpha_ids = ids_for_texts(
+            "from old_alpha import thing",
+            "from new_alpha import (",
+            "    thing,",
+            "    helper,",
+            ")",
+        )
+        beta_ids = ids_for_texts(
+            "from old_beta import helper",
+            "from new_beta import helper",
+        )
+        body_ids = ids_for_texts("body_call_old()", "body_call_new()")
+
+        command_include_line(body_ids, file="module.py")
+        line_changes = load_line_changes_from_state()
+        assert line_changes is not None
+        remaining_texts = [line.text for line in line_changes.lines if line.id is not None]
+        assert "body_call_old()" not in remaining_texts
+        assert "body_call_new()" not in remaining_texts
+        assert "from old_beta import helper" in remaining_texts
+
+        command_include_line(alpha_ids, file="module.py")
+        line_changes = load_line_changes_from_state()
+        assert line_changes is not None
+        remaining_ids = [line.id for line in line_changes.lines if line.id is not None]
+        remaining_texts = [line.text for line in line_changes.lines if line.id is not None]
+        assert remaining_ids == [1, 2]
+        assert remaining_texts == [
+            "from old_beta import helper",
+            "from new_beta import helper",
+        ]
+
+        command_include_line("1,2", file="module.py")
+
+        result = run_git_command(["show", ":module.py"])
+        assert result.stdout == "".join(rewritten)
+
+    def test_show_file_displays_gap_markers_between_real_hunks(self, tmp_path, monkeypatch, capsys):
+        """File-scoped displays should show omitted unchanged regions explicitly."""
+        repo = tmp_path / "test_repo"
+        repo.mkdir()
+        monkeypatch.chdir(repo)
+
+        subprocess.run(["git", "init"], check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.name", "Test"], check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.email", "test@test.com"], check=True, capture_output=True)
+
+        lines = [f"line{i}\n" for i in range(1, 121)]
+        (repo / "multi.txt").write_text("".join(lines))
+        subprocess.run(["git", "add", "multi.txt"], check=True, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Initial"], check=True, capture_output=True)
+
+        content = lines[:]
+        content.insert(5, "change-one\n")
+        content.insert(55, "change-two\n")
+        content.insert(105, "change-three\n")
+        (repo / "multi.txt").write_text("".join(content))
+
+        command_start()
+        capsys.readouterr()
+        command_show(file="multi.txt")
+
+        captured = capsys.readouterr()
+        assert captured.out.count("... 43 more lines ...") == 2
+
+    def test_show_file_discard_line_keeps_file_selection_for_multi_hunk_file(self, tmp_path, monkeypatch):
+        """Discard --line from a file selection should keep the remaining file view."""
+        repo = tmp_path / "test_repo"
+        repo.mkdir()
+        monkeypatch.chdir(repo)
+
+        subprocess.run(["git", "init"], check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.name", "Test"], check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.email", "test@test.com"], check=True, capture_output=True)
+
+        lines = [f"line{i}\n" for i in range(1, 121)]
+        (repo / "multi.txt").write_text("".join(lines))
+        subprocess.run(["git", "add", "multi.txt"], check=True, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Initial"], check=True, capture_output=True)
+
+        content = lines[:]
+        content.insert(5, "change-one\n")
+        content.insert(55, "change-two\n")
+        content.insert(105, "change-three\n")
+        (repo / "multi.txt").write_text("".join(content))
+
+        command_start()
+        command_show(file="multi.txt")
+
+        command_discard_line("1")
+
+        line_changes = load_line_changes_from_state()
+        assert line_changes is not None
+        changed_texts = [line.text for line in line_changes.lines if line.kind != " "]
+        assert "change-one" not in changed_texts
+        assert "change-two" in changed_texts
+        assert "change-three" in changed_texts
+
+    def test_explicit_file_discard_line_uses_the_refreshed_file_view(self, tmp_path, monkeypatch):
+        """Explicit file-scoped discard --line should follow the refreshed file view."""
+        repo = tmp_path / "test_repo"
+        repo.mkdir()
+        monkeypatch.chdir(repo)
+
+        subprocess.run(["git", "init"], check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.name", "Test"], check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.email", "test@test.com"], check=True, capture_output=True)
+
+        lines = [f"line{i}\n" for i in range(1, 81)]
+        lines[0] = "from old_alpha import thing\n"
+        lines[10] = "from old_beta import helper\n"
+        lines[60] = "body_call_old()\n"
+        file_path = repo / "module.py"
+        file_path.write_text("".join(lines))
+        subprocess.run(["git", "add", "module.py"], check=True, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Initial"], check=True, capture_output=True)
+
+        rewritten = lines[:]
+        rewritten[0] = "from new_alpha import thing\n"
+        rewritten[10] = "from new_beta import helper\n"
+        rewritten[60] = "body_call_new()\n"
+        file_path.write_text("".join(rewritten))
+
+        command_start()
+        command_show(file="module.py")
+
+        line_changes = load_line_changes_from_state()
+        assert line_changes is not None
+
+        def ids_for_texts(*texts: str) -> str:
+            selected_ids = [
+                str(line.id)
+                for line in line_changes.lines
+                if line.id is not None and line.text in texts
+            ]
+            assert len(selected_ids) == len(texts)
+            return ",".join(selected_ids)
+
+        alpha_ids = ids_for_texts(
+            "from old_alpha import thing",
+            "from new_alpha import thing",
+        )
+        body_ids = ids_for_texts("body_call_old()", "body_call_new()")
+
+        command_include_line(alpha_ids, file="module.py")
+
+        line_changes = load_line_changes_from_state()
+        assert line_changes is not None
+        remaining_texts = [line.text for line in line_changes.lines if line.id is not None]
+        assert "from old_beta import helper" in remaining_texts
+        assert "from new_beta import helper" in remaining_texts
+        assert "body_call_old()" in remaining_texts
+        assert "body_call_new()" in remaining_texts
+
+        body_ids = ",".join(
+            str(line.id)
+            for line in line_changes.lines
+            if line.id is not None and line.text in {
+                "body_call_old()",
+                "body_call_new()",
+            }
+        )
+        command_discard_line(body_ids, file="module.py")
+
+        line_changes = load_line_changes_from_state()
+        assert line_changes is not None
+        remaining_texts = [line.text for line in line_changes.lines if line.id is not None]
+        assert "body_call_old()" not in remaining_texts
+        assert "body_call_new()" not in remaining_texts
+
+        beta_ids = ",".join(
+            str(line.id)
+            for line in line_changes.lines
+            if line.id is not None and line.text in {
+                "from old_beta import helper",
+                "from new_beta import helper",
+            }
+        )
+        command_discard_line(beta_ids, file="module.py")
+
+        assert file_path.read_text() == (
+            "from new_alpha import thing\n"
+            + "".join(lines[1:10])
+            + "from old_beta import helper\n"
+            + "".join(lines[11:60])
+            + "body_call_old()\n"
+            + "".join(lines[61:])
+        )
+
+    def test_explicit_file_include_to_batch_line_uses_the_refreshed_file_view(self, tmp_path, monkeypatch):
+        """Explicit file-scoped include --to --line should follow the refreshed file view."""
+        repo = tmp_path / "test_repo"
+        repo.mkdir()
+        monkeypatch.chdir(repo)
+
+        subprocess.run(["git", "init"], check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.name", "Test"], check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.email", "test@test.com"], check=True, capture_output=True)
+
+        lines = [f"line{i}\n" for i in range(1, 81)]
+        lines[0] = "from old_alpha import thing\n"
+        lines[10] = "from old_beta import helper\n"
+        lines[60] = "body_call_old()\n"
+        file_path = repo / "module.py"
+        file_path.write_text("".join(lines))
+        subprocess.run(["git", "add", "module.py"], check=True, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Initial"], check=True, capture_output=True)
+
+        rewritten = lines[:]
+        rewritten[0] = "from new_alpha import thing\n"
+        rewritten[10] = "from new_beta import helper\n"
+        rewritten[60] = "body_call_new()\n"
+        file_path.write_text("".join(rewritten))
+
+        command_start()
+        command_show(file="module.py")
+
+        line_changes = load_line_changes_from_state()
+        assert line_changes is not None
+
+        alpha_ids = ",".join(
+            str(line.id)
+            for line in line_changes.lines
+            if line.id is not None and line.text in {
+                "from old_alpha import thing",
+                "from new_alpha import thing",
+            }
+        )
+        command_include_line(alpha_ids, file="module.py")
+
+        line_changes = load_line_changes_from_state()
+        assert line_changes is not None
+        body_ids = ",".join(
+            str(line.id)
+            for line in line_changes.lines
+            if line.id is not None and line.text in {
+                "body_call_old()",
+                "body_call_new()",
+            }
+        )
+
+        command_include_to_batch("body-only", line_ids=body_ids, file="module.py")
+
+        metadata = read_batch_metadata("body-only")
+        file_metadata = metadata["files"]["module.py"]
+        assert file_metadata["claimed_lines"] == ["61"]
+        assert file_metadata["deletions"][0]["after_source_line"] == 60
+
+        command_show_from_batch("body-only")
+        line_changes = load_line_changes_from_state()
+        assert line_changes is not None
+        non_context_texts = [line.text for line in line_changes.lines if line.id is not None]
+        assert "body_call_old()" in non_context_texts
+        assert "body_call_new()" in non_context_texts
+        assert "from old_beta import helper" not in non_context_texts
+        assert "from new_beta import helper" not in non_context_texts
+
+    def test_show_file_skip_line_keeps_file_selection_for_multi_hunk_file(self, tmp_path, monkeypatch):
+        """Skip --line from a file selection should keep the remaining file view."""
+        repo = tmp_path / "test_repo"
+        repo.mkdir()
+        monkeypatch.chdir(repo)
+
+        subprocess.run(["git", "init"], check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.name", "Test"], check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.email", "test@test.com"], check=True, capture_output=True)
+
+        lines = [f"line{i}\n" for i in range(1, 121)]
+        (repo / "multi.txt").write_text("".join(lines))
+        subprocess.run(["git", "add", "multi.txt"], check=True, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Initial"], check=True, capture_output=True)
+
+        content = lines[:]
+        content.insert(5, "change-one\n")
+        content.insert(55, "change-two\n")
+        content.insert(105, "change-three\n")
+        (repo / "multi.txt").write_text("".join(content))
+
+        command_start()
+        command_show(file="multi.txt")
+
+        command_skip_line("1")
+
+        line_changes = load_line_changes_from_state()
+        assert line_changes is not None
+        visible_ids = [line.id for line in line_changes.lines if line.id is not None]
+        changed_texts = [line.text for line in line_changes.lines if line.id is not None]
+        assert 1 not in visible_ids
+        assert "change-one" not in changed_texts
+        assert "change-two" in changed_texts
+        assert "change-three" in changed_texts
+
+    def test_show_files_selection_can_feed_include(self, multi_file_repo):
+        """Show --files should leave the final displayed file selected for include."""
+        command_start()
+
+        args = parse_command_line(["show", "--files", "*.txt"], quiet=True)
+        assert args is not None
+        args.func(args)
+
+        command_include(quiet=True)
+
+        result = run_git_command(["diff", "--cached", "--name-only"])
+        assert result.stdout.strip() == "gamma.txt"
+
+    def test_include_files_reports_aggregate_staged_scope(self, multi_file_repo, capsys):
+        """Include --files should report the full staged scope once."""
+        command_start()
+        capsys.readouterr()
+
+        args = parse_command_line(["include", "--files", "*.txt"], quiet=True)
+        assert args is not None
+        args.func(args)
+
+        captured = capsys.readouterr()
+        assert "✓ Staged 3 hunks from 3 files" in captured.err
+        assert "alpha.txt" not in captured.err
+        assert "beta.txt" not in captured.err
+        assert "gamma.txt" not in captured.err
+
+        result = run_git_command(["diff", "--cached", "--name-only"])
+        assert result.stdout.splitlines() == ["alpha.txt", "beta.txt", "gamma.txt"]
+
+    def test_include_files_can_restage_manually_unstaged_file_in_same_session(self, multi_file_repo, capsys):
+        """Manual unstaging should not leave file-scoped include blocked in-session."""
+        command_start()
+        capsys.readouterr()
+
+        args = parse_command_line(["include", "--files", "*.txt"], quiet=True)
+        assert args is not None
+        args.func(args)
+        capsys.readouterr()
+
+        subprocess.run(
+            ["git", "restore", "--staged", "gamma.txt"],
+            check=True,
+            cwd=multi_file_repo,
+            capture_output=True,
+        )
+
+        args = parse_command_line(["show", "--files", "gamma.txt"], quiet=True)
+        assert args is not None
+        args.func(args)
+        captured = capsys.readouterr()
+        assert "gamma2-modified" in captured.out
+        assert "gamma4-new" in captured.out
+
+        args = parse_command_line(["include", "--files", "gamma.txt"], quiet=True)
+        assert args is not None
+        args.func(args)
+
+        captured = capsys.readouterr()
+        assert "✓ Staged 1 hunk from gamma.txt" in captured.err
+
+        result = run_git_command(["diff", "--cached", "--name-only"])
+        assert result.stdout.splitlines() == ["alpha.txt", "beta.txt", "gamma.txt"]
+
+    def test_show_files_selection_can_feed_discard(self, multi_file_repo):
+        """Show --files should leave the final displayed file selected for discard."""
+        command_start()
+
+        args = parse_command_line(["show", "--files", "*.txt"], quiet=True)
+        assert args is not None
+        args.func(args)
+
+        command_discard(quiet=True)
+
+        assert (multi_file_repo / "alpha.txt").read_text() == "alpha1\nalpha2-modified\nalpha3\nalpha4-new\n"
+        assert (multi_file_repo / "beta.txt").read_text() == "beta1\nbeta2-modified\nbeta3\nbeta4-new\n"
+        assert (multi_file_repo / "gamma.txt").read_text() == "gamma1\ngamma2\ngamma3\n"
+
+    def test_show_files_selection_can_feed_skip(self, multi_file_repo):
+        """Show --files should leave the final displayed file selected for skip."""
+        command_start()
+
+        args = parse_command_line(["show", "--files", "*.txt"], quiet=True)
+        assert args is not None
+        args.func(args)
+
+        command_skip(quiet=True)
+        command_include(quiet=True)
+
+        result = run_git_command(["diff", "--cached", "--name-only"])
+        assert result.stdout.strip() == "alpha.txt"
 
 
 class TestIncludeToBatchWithFile:
@@ -692,6 +1215,367 @@ class TestExplicitFilePath:
         assert "beta4-new" in working_diff
         assert "beta2-modified" in working_diff
         assert "beta2-edited" in working_diff
+
+    def test_include_line_with_explicit_path_does_not_reuse_other_file_ids(self, multi_file_repo):
+        """Explicit file-scoped include --line should not inherit IDs from another file view."""
+        command_start()
+        command_show(file="alpha.txt")
+
+        command_include_line("3", file="alpha.txt")
+        command_include_line("1,2", file="beta.txt")
+
+        line_changes_after = load_line_changes_from_state()
+        assert line_changes_after.path == "alpha.txt"
+
+        staged_content = run_git_command(["show", ":beta.txt"]).stdout
+        assert staged_content == "beta1\nbeta2-modified\nbeta3\n"
+
+        working_diff = run_git_command(["diff", "beta.txt"]).stdout
+        assert "beta4-new" in working_diff
+        assert "beta2-modified" in working_diff
+
+    def test_include_line_with_explicit_path_preserves_gap_context_between_regions(self, tmp_path, monkeypatch):
+        """Explicit file-scoped include --line should keep unchanged lines between added regions."""
+        repo = tmp_path / "test_repo"
+        repo.mkdir()
+        monkeypatch.chdir(repo)
+
+        subprocess.run(["git", "init"], check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.name", "Test"], check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.email", "test@test.com"], check=True, capture_output=True)
+
+        base_lines = [
+            'from dataclasses import dataclass\n',
+            'from importlib import resources\n',
+            'from pathlib import Path\n',
+            'from typing import Protocol\n',
+            'import sys\n',
+            '\n',
+            '@dataclass(frozen=True)\n',
+            'class AssetGroup:\n',
+            '    source_segments: tuple[str, ...]\n',
+            '    target_segments: tuple[str, ...]\n',
+            '    display_name_singular: str\n',
+            '    display_name_plural: str\n',
+            '    required_entry: str\n',
+            '\n',
+        ]
+        base_lines.extend(f"filler{i}\n" for i in range(1, 33))
+        base_lines.extend([
+            'ASSET_GROUPS: dict[str, AssetGroup] = {\n',
+            '    "claude-skills": AssetGroup(\n',
+            '        source_segments=("assets", "claude-skills"),\n',
+            '        target_segments=(".claude", "skills"),\n',
+            '        display_name_singular="Claude skill",\n',
+            '        display_name_plural="Claude skills",\n',
+            '        required_entry="SKILL.md",\n',
+            '    ),\n',
+            '}\n',
+        ])
+        file_path = repo / "assets_module.py"
+        file_path.write_text("".join(base_lines))
+        subprocess.run(["git", "add", "assets_module.py"], check=True, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Initial"], check=True, capture_output=True)
+
+        rewritten = base_lines[:]
+        rewritten.insert(3, "import subprocess\n")
+        rewritten.insert(8, "from .patterns import resolve_gitignore_style_patterns\n")
+
+        helper_insert_at = 12
+        helper_lines = [
+            '\n',
+            '@dataclass(frozen=True)\n',
+            'class CompanionAsset:\n',
+            '    source_segments: tuple[str, ...]\n',
+            '    target_segments: tuple[str, ...]\n',
+            '    display_name: str\n',
+        ]
+        for offset, line in enumerate(helper_lines):
+            rewritten.insert(helper_insert_at + offset, line)
+
+        asset_insert_at = len(rewritten) - 1
+        codex_lines = [
+            '    "codex-skills": AssetGroup(\n',
+            '        source_segments=("assets", "codex-skills"),\n',
+            '        target_segments=(".agents", "skills"),\n',
+            '        display_name_singular="Codex skill",\n',
+            '        display_name_plural="Codex skills",\n',
+            '        required_entry="SKILL.md",\n',
+            '        companion_assets=(\n',
+            '            CompanionAsset(\n',
+            '                source_segments=("assets", "codex-skills", "config", "config.toml"),\n',
+            '                target_segments=(".codex", "config.toml"),\n',
+            '                display_name="Codex config",\n',
+            '            ),\n',
+            '        ),\n',
+            '    ),\n',
+        ]
+        for offset, line in enumerate(codex_lines):
+            rewritten.insert(asset_insert_at + offset, line)
+
+        file_path.write_text("".join(rewritten))
+
+        command_start()
+
+        def ids_for_texts(*texts: str) -> str:
+            line_changes = render_unstaged_file_as_single_hunk("assets_module.py")
+            assert line_changes is not None
+            selected_ids = [
+                str(line.id)
+                for line in line_changes.lines
+                if line.id is not None and line.text in texts
+            ]
+            assert len(selected_ids) == len(texts)
+            return ",".join(selected_ids)
+
+        helper_ids = ids_for_texts(
+            "import subprocess",
+            "from .patterns import resolve_gitignore_style_patterns",
+            "@dataclass(frozen=True)",
+            "class CompanionAsset:",
+            "    source_segments: tuple[str, ...]",
+            "    target_segments: tuple[str, ...]",
+            "    display_name: str",
+        )
+        command_include_line(helper_ids, file="assets_module.py")
+
+        remaining_line_changes = render_unstaged_file_as_single_hunk("assets_module.py")
+        assert remaining_line_changes is not None
+        codex_ids = ",".join(
+            str(line.id)
+            for line in remaining_line_changes.lines
+            if line.id is not None
+        )
+        command_include_line(codex_ids, file="assets_module.py")
+
+        staged_content = run_git_command(["show", ":assets_module.py"]).stdout
+        assert "@dataclass(frozen=True)" in staged_content
+        assert 'class CompanionAsset:' in staged_content
+        assert (
+            '        required_entry="SKILL.md",\n'
+            '    ),\n'
+            '    "codex-skills": AssetGroup(\n'
+        ) in staged_content
+
+    def test_include_line_as_with_explicit_path_preserves_gap_context_between_regions(self, tmp_path, monkeypatch):
+        """Explicit file-scoped include --line --as should replace the selected region only."""
+        repo = tmp_path / "test_repo"
+        repo.mkdir()
+        monkeypatch.chdir(repo)
+
+        subprocess.run(["git", "init"], check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.name", "Test"], check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.email", "test@test.com"], check=True, capture_output=True)
+
+        lines = [f"line{i}\n" for i in range(1, 41)]
+        file_path = repo / "multi.txt"
+        file_path.write_text("".join(lines))
+        subprocess.run(["git", "add", "multi.txt"], check=True, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Initial"], check=True, capture_output=True)
+
+        rewritten = lines[:]
+        rewritten[5] = "first working\n"
+        rewritten[20] = "middle working\n"
+        rewritten[35] = "last working\n"
+        file_path.write_text("".join(rewritten))
+
+        command_start()
+
+        line_changes = render_unstaged_file_as_single_hunk("multi.txt")
+        assert line_changes is not None
+        middle_ids = ",".join(
+            str(line.id)
+            for line in line_changes.lines
+            if line.id is not None and line.text in {"line21", "middle working"}
+        )
+        assert middle_ids == "3,4"
+
+        command_include_line_as(middle_ids, "middle staged", file="multi.txt")
+
+        staged_content = run_git_command(["show", ":multi.txt"]).stdout
+        expected = lines[:]
+        expected[20] = "middle staged\n"
+        assert staged_content == "".join(expected)
+
+        working_diff = run_git_command(["diff", "multi.txt"]).stdout
+        assert "-line6" in working_diff
+        assert "+first working" in working_diff
+        assert "-middle staged" in working_diff
+        assert "+middle working" in working_diff
+        assert "-line36" in working_diff
+        assert "+last working" in working_diff
+
+    def test_include_line_as_with_explicit_path_trims_matching_edge_anchors(self, tmp_path, monkeypatch):
+        """Explicit file-scoped include --line --as should accept unchanged edge anchors."""
+        repo = tmp_path / "test_repo"
+        repo.mkdir()
+        monkeypatch.chdir(repo)
+
+        subprocess.run(["git", "init"], check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.name", "Test"], check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.email", "test@test.com"], check=True, capture_output=True)
+
+        file_path = repo / "module.py"
+        file_path.write_text("keep1\nkeep2\nold\nkeep4\n")
+        subprocess.run(["git", "add", "module.py"], check=True, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Initial"], check=True, capture_output=True)
+
+        file_path.write_text("keep1\nkeep2\nnew\nkeep4\n")
+
+        command_start()
+        command_include_line_as("1-2", "keep1\nkeep2\nstaged\nkeep4\n", file="module.py")
+
+        staged_content = run_git_command(["show", ":module.py"]).stdout
+        assert staged_content == "keep1\nkeep2\nstaged\nkeep4\n"
+
+    def test_include_line_as_with_explicit_path_no_anchor_keeps_edge_anchors(self, tmp_path, monkeypatch):
+        """Explicit file-scoped include --line --as --no-anchor should preserve duplicate anchors."""
+        repo = tmp_path / "test_repo"
+        repo.mkdir()
+        monkeypatch.chdir(repo)
+
+        subprocess.run(["git", "init"], check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.name", "Test"], check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.email", "test@test.com"], check=True, capture_output=True)
+
+        file_path = repo / "module.py"
+        file_path.write_text("keep1\nkeep2\nold\nkeep4\n")
+        subprocess.run(["git", "add", "module.py"], check=True, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Initial"], check=True, capture_output=True)
+
+        file_path.write_text("keep1\nkeep2\nnew\nkeep4\n")
+
+        command_start()
+        command_include_line_as(
+            "1-2",
+            "keep1\nkeep2\nstaged\nkeep4\n",
+            file="module.py",
+            no_anchor=True,
+        )
+
+        staged_content = run_git_command(["show", ":module.py"]).stdout
+        assert staged_content == "keep1\nkeep2\nkeep1\nkeep2\nstaged\nkeep4\nkeep4\n"
+
+    def test_include_file_as_with_explicit_path_stages_full_file_text(self, tmp_path, monkeypatch):
+        """Explicit file-scoped include --as should stage the full replacement file text."""
+        repo = tmp_path / "test_repo"
+        repo.mkdir()
+        monkeypatch.chdir(repo)
+
+        subprocess.run(["git", "init"], check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.name", "Test"], check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.email", "test@test.com"], check=True, capture_output=True)
+
+        file_path = repo / "module.py"
+        file_path.write_text("keep1\nkeep2\nold\nkeep4\n")
+        subprocess.run(["git", "add", "module.py"], check=True, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Initial"], check=True, capture_output=True)
+
+        file_path.write_text("keep1\nkeep2\nnew\nkeep4\n")
+
+        command_start()
+        command_include_file_as("keep1\nkeep2\nstaged\nkeep4\n", file="module.py")
+
+        staged_content = run_git_command(["show", ":module.py"]).stdout
+        assert staged_content == "keep1\nkeep2\nstaged\nkeep4\n"
+        assert file_path.read_text() == "keep1\nkeep2\nnew\nkeep4\n"
+
+    def test_include_line_with_explicit_path_rejects_partial_replacement_range(self, tmp_path, monkeypatch):
+        """Explicit file-scoped include --line should refuse a partial replacement range."""
+        repo = tmp_path / "test_repo"
+        repo.mkdir()
+        monkeypatch.chdir(repo)
+
+        subprocess.run(["git", "init"], check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.name", "Test"], check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.email", "test@test.com"], check=True, capture_output=True)
+
+        file_path = repo / "module.py"
+        file_path.write_text("keep\nold value\n")
+        subprocess.run(["git", "add", "module.py"], check=True, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Initial"], check=True, capture_output=True)
+
+        file_path.write_text("keep\nnew value 1\nnew value 2\nnew value 3\n")
+
+        command_start()
+
+        with pytest.raises(CommandError) as exc_info:
+            command_include_line("1-2", file="module.py")
+
+        assert (
+            str(exc_info.value)
+            == "Contiguous line selections cannot split one replacement. "
+            "Select --lines 1-4 instead, pick individual "
+            "lines one at a time, or use --as."
+        )
+
+        result = run_git_command(["diff", "--cached", "--name-only"])
+        assert result.stdout == ""
+
+    def test_include_line_with_explicit_path_rejects_partial_later_structural_run(self, tmp_path, monkeypatch):
+        """Explicit file-scoped include --line should reject a partial later run."""
+        repo = tmp_path / "test_repo"
+        repo.mkdir()
+        monkeypatch.chdir(repo)
+
+        subprocess.run(["git", "init"], check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.name", "Test"], check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.email", "test@test.com"], check=True, capture_output=True)
+
+        file_path = repo / "module.py"
+        file_path.write_text(
+            "\n"
+            "\n"
+            "\n"
+            "\n"
+            "\n"
+            "\n"
+            "def omega():\n"
+            "    return 2\n"
+        )
+        subprocess.run(["git", "add", "module.py"], check=True, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Initial"], check=True, capture_output=True)
+
+        file_path.write_text(
+            "def alpha():\n"
+            "    value = 1\n"
+            "    return value\n"
+            "\n"
+            "\n"
+            "\n"
+            "\n"
+            "def omega():\n"
+            "    return 2\n"
+            "\n"
+            "def helper():\n"
+            "    if True:\n"
+            "        return 3\n"
+        )
+
+        command_start()
+
+        line_changes = render_unstaged_file_as_single_hunk("module.py")
+        assert line_changes is not None
+        helper_def_id = next(
+            line.id
+            for line in line_changes.lines
+            if line.id is not None and line.text == "def helper():"
+        )
+        first_changed_id = min(line_changes.changed_line_ids())
+        selection = f"{first_changed_id}-{helper_def_id}"
+
+        with pytest.raises(CommandError) as exc_info:
+            command_include_line(selection, file="module.py")
+
+        assert (
+            str(exc_info.value)
+            == "Contiguous file-scoped selections cannot span multiple structural change runs "
+            "while selecting only part of one run. Select one run at a time, fully include "
+            "each spanned run, or use --as."
+        )
+
+        result = run_git_command(["diff", "--cached", "--name-only"])
+        assert result.stdout == ""
 
     def test_discard_file_with_explicit_path(self, multi_file_repo):
         """Discard --file PATH should discard all hunks from specified file."""

--- a/tests/commands/test_file_scoped_operations.py
+++ b/tests/commands/test_file_scoped_operations.py
@@ -29,7 +29,7 @@ from git_stage_batch.commands.include import (
     command_include_line,
     command_include_line_as,
 )
-from git_stage_batch.commands.discard import command_discard_to_batch, command_discard_file, command_discard_line
+from git_stage_batch.commands.discard import command_discard, command_discard_to_batch, command_discard_file, command_discard_file_as, command_discard_line
 from git_stage_batch.commands.include_from import command_include_from_batch
 from git_stage_batch.commands.discard_from import command_discard_from_batch
 from git_stage_batch.commands.apply_from import command_apply_from_batch
@@ -752,6 +752,25 @@ class TestExplicitFilePath:
 
         applied_content = (multi_file_repo / "beta.txt").read_text()
         assert applied_content == "beta1\nbeta2-edited\nbeta3\nbeta4-new\n"
+
+    def test_discard_file_as_with_explicit_path_preserves_selected_position(self, multi_file_repo):
+        """Discard --file PATH --as should rewrite the working tree and preserve selection."""
+        command_start()
+
+        line_changes_before = load_line_changes_from_state()
+        assert line_changes_before.path == "alpha.txt"
+
+        command_discard_file_as("beta1\nbeta2-rewritten\nbeta3\n", file="beta.txt")
+
+        line_changes_after = load_line_changes_from_state()
+        assert line_changes_after.path == "alpha.txt"
+        assert line_changes_after.lines == line_changes_before.lines
+
+        beta_content = (multi_file_repo / "beta.txt").read_text()
+        assert beta_content == "beta1\nbeta2-rewritten\nbeta3\n"
+
+        result = run_git_command(["diff", "--cached", "--name-only"])
+        assert result.stdout.strip() == ""
 
     def test_include_file_explicit_path_multiple_hunks(self, tmp_path, monkeypatch):
         """Include --file PATH should stage all hunks from multi-hunk file."""

--- a/tests/commands/test_include.py
+++ b/tests/commands/test_include.py
@@ -358,3 +358,45 @@ class TestCommandIncludeLine:
         assert line_changes is not None
         changed_lines = [line for line in line_changes.lines if line.kind != " "]
         assert any("extra line" in line.text for line in changed_lines)
+
+    def test_include_line_as_replaces_disjoint_file_scoped_regions(self, temp_git_repo):
+        """File-scoped replacement should accept one contiguous range across regions."""
+        test_file = temp_git_repo / "multi.txt"
+        base_lines = [f"line{i}\n" for i in range(1, 41)]
+        test_file.write_text("".join(base_lines))
+        subprocess.run(["git", "add", "multi.txt"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add multi file"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        rewritten_lines = (
+            base_lines[:5]
+            + ["change-one-a\n", "change-one-b\n"]
+            + base_lines[5:20]
+            + ["change-two-a\n", "change-two-b\n"]
+            + base_lines[20:35]
+            + ["change-three-a\n", "change-three-b\n"]
+            + base_lines[35:]
+        )
+        test_file.write_text("".join(rewritten_lines))
+
+        command_start()
+        staged_span = (
+            ["stage-one-a\n", "stage-one-b\n"]
+            + base_lines[5:20]
+            + ["stage-two-a\n", "stage-two-b\n"]
+            + base_lines[20:35]
+            + ["stage-three-a\n", "stage-three-b\n"]
+        )
+        command_include_line_as("1-6", "".join(staged_span), file="multi.txt")
+
+        result = subprocess.run(
+            ["git", "show", ":multi.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+            text=True,
+        )
+        assert result.stdout == (
+            "".join(base_lines[:5])
+            + "".join(staged_span)
+            + "".join(base_lines[35:])
+        )

--- a/tests/commands/test_skip.py
+++ b/tests/commands/test_skip.py
@@ -7,6 +7,7 @@ import pytest
 from git_stage_batch.commands.skip import command_skip, command_skip_line
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.data.hunk_tracking import fetch_next_change
+from git_stage_batch.data.line_state import load_line_changes_from_state
 from git_stage_batch.exceptions import CommandError
 from git_stage_batch.utils.file_io import read_text_file_contents
 from git_stage_batch.utils.paths import get_processed_skip_ids_file_path
@@ -118,55 +119,46 @@ class TestCommandSkipLine:
             command_skip_line("1")
 
     def test_skip_line_marks_single_addition(self, temp_git_repo):
-        """Test skipping a single added line."""
+        """Test skipping a single added line advances past that selection."""
         readme = temp_git_repo / "README.md"
         readme.write_text("# Test\nNew line\n")
 
-        # Cache the hunk
         command_start()
         fetch_next_change()
 
-        # Skip line 1
         command_skip_line("1")
 
-        # Check that skip IDs were recorded
         skip_ids_content = read_text_file_contents(get_processed_skip_ids_file_path()).strip()
-        skip_ids = skip_ids_content.split("\n") if skip_ids_content else []
-        assert skip_ids == ["1"]
+        assert skip_ids_content == ""
+        assert load_line_changes_from_state() is None
 
     def test_skip_line_marks_single_deletion(self, temp_git_repo):
-        """Test skipping a single deleted line."""
+        """Test skipping a single deleted line advances past that selection."""
         readme = temp_git_repo / "README.md"
         readme.write_text("")
 
-        # Cache the hunk
         command_start()
         fetch_next_change()
 
-        # Skip line 1
         command_skip_line("1")
 
-        # Check that skip IDs were recorded
         skip_ids_content = read_text_file_contents(get_processed_skip_ids_file_path()).strip()
-        skip_ids = skip_ids_content.split("\n") if skip_ids_content else []
-        assert skip_ids == ["1"]
+        assert skip_ids_content == ""
+        assert load_line_changes_from_state() is None
 
     def test_skip_line_with_range(self, temp_git_repo):
-        """Test skipping a range of lines."""
+        """Test skipping a full range advances past that selection."""
         readme = temp_git_repo / "README.md"
         readme.write_text("# Test\nLine 1\nLine 2\nLine 3\n")
 
-        # Cache the hunk
         command_start()
         fetch_next_change()
 
-        # Skip lines 1-3
         command_skip_line("1-3")
 
-        # Check that all IDs were recorded
         skip_ids_content = read_text_file_contents(get_processed_skip_ids_file_path()).strip()
-        skip_ids = skip_ids_content.split("\n") if skip_ids_content else []
-        assert skip_ids == ["1", "2", "3"]
+        assert skip_ids_content == ""
+        assert load_line_changes_from_state() is None
 
     def test_skip_line_partial_selection(self, temp_git_repo):
         """Test skipping only some lines from a hunk."""
@@ -184,6 +176,32 @@ class TestCommandSkipLine:
         skip_ids_content = read_text_file_contents(get_processed_skip_ids_file_path()).strip()
         skip_ids = skip_ids_content.split("\n") if skip_ids_content else []
         assert skip_ids == ["1"]
+
+        line_changes = load_line_changes_from_state()
+        assert line_changes is not None
+        visible_ids = [line.id for line in line_changes.lines if line.id is not None]
+        assert visible_ids == [2, 3]
+
+    def test_skip_line_advances_when_selection_is_fully_skipped(self, temp_git_repo):
+        """Skipping every shown line should advance to the next hunk."""
+        file1 = temp_git_repo / "file1.txt"
+        file2 = temp_git_repo / "file2.txt"
+        file1.write_text("original 1\n")
+        file2.write_text("original 2\n")
+        subprocess.run(["git", "add", "file1.txt", "file2.txt"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add files"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        file1.write_text("modified 1\n")
+        file2.write_text("modified 2\n")
+
+        command_start()
+        fetch_next_change()
+
+        command_skip_line("1-2")
+
+        line_changes = load_line_changes_from_state()
+        assert line_changes is not None
+        assert line_changes.path == "file2.txt"
 
     def test_skip_line_accumulates_ids(self, temp_git_repo):
         """Test that multiple skip --line calls accumulate."""

--- a/tests/commands/test_status.py
+++ b/tests/commands/test_status.py
@@ -11,7 +11,7 @@ import subprocess
 import pytest
 
 from git_stage_batch.commands.include import command_include
-from git_stage_batch.commands.skip import command_skip
+from git_stage_batch.commands.skip import command_skip, command_skip_file
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.commands.status import command_status
 
@@ -119,6 +119,25 @@ class TestCommandStatus:
         assert "Remaining:" in captured.out
         # When all hunks are processed, should show completion message
         assert "complete" in captured.out or "Remaining: 0" in captured.out or "Remaining:  0" in captured.out
+
+    def test_status_counts_hunks_skipped_by_file_scope(self, temp_git_repo, capsys):
+        """File-scoped skip should update skipped progress metrics."""
+        test_file = temp_git_repo / "multi.txt"
+        test_file.write_text("line 1\nline 2\nline 3\nline 4\nline 5\n")
+        subprocess.run(["git", "add", "multi.txt"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add multi"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        test_file.write_text("line 1 modified\nline 2\nline 3\nline 4\nline 5 modified\n")
+
+        command_start()
+        command_skip_file()
+        capsys.readouterr()
+
+        command_status()
+
+        captured = capsys.readouterr()
+        assert "Skipped:   1 hunks" in captured.out
+        assert "multi.txt:1 [#1-4]" in captured.out
 
     def test_status_shows_line_range_when_cached(self, temp_git_repo, capsys):
         """Test that status shows line range when cached state is available."""

--- a/tests/data/test_consumed_selections.py
+++ b/tests/data/test_consumed_selections.py
@@ -1,0 +1,69 @@
+"""Tests for consumed-selection ownership persistence."""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from git_stage_batch.commands.start import command_start
+from git_stage_batch.core.models import LineEntry
+from git_stage_batch.data.consumed_selections import (
+    read_consumed_file_metadata,
+    record_consumed_selection,
+)
+
+
+@pytest.fixture
+def temp_git_repo(tmp_path, monkeypatch):
+    """Create a temporary git repository for testing."""
+    repo = tmp_path / "test_repo"
+    repo.mkdir()
+    monkeypatch.chdir(repo)
+
+    subprocess.run(["git", "init"], check=True, cwd=repo, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], check=True, cwd=repo, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], check=True, cwd=repo, capture_output=True)
+
+    return repo
+
+
+def test_record_consumed_selection_refreshes_stale_first_selection(temp_git_repo):
+    """Stale replacement selections should be translated in working-tree space."""
+    test_file = temp_git_repo / "test.txt"
+    test_file.write_text("header\n")
+    subprocess.run(["git", "add", "test.txt"], check=True, cwd=temp_git_repo, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "Add file"], check=True, cwd=temp_git_repo, capture_output=True)
+
+    test_file.write_text("header\nline1\n")
+
+    command_start()
+    record_consumed_selection(
+        "test.txt",
+        source_content=b"header\nline1\n",
+        selected_lines=[
+            LineEntry(
+                id=1,
+                kind="+",
+                old_line_number=None,
+                new_line_number=2,
+                text_bytes=b"line1",
+                text="line1",
+                source_line=None,
+            )
+        ],
+        replacement_mask={
+            "deleted_lines": ["staged line"],
+            "added_lines": ["line1"],
+        },
+    )
+
+    metadata = read_consumed_file_metadata("test.txt")
+    assert metadata is not None
+    assert metadata["claimed_lines"] == ["2"]
+    assert metadata["replacement_masks"] == [
+        {
+            "deleted_lines": ["staged line"],
+            "added_lines": ["line1"],
+        }
+    ]

--- a/tests/staging/test_operations.py
+++ b/tests/staging/test_operations.py
@@ -397,6 +397,202 @@ class TestBuildTargetIndexContent:
 
         assert result == b"keep\nstaged value\n"
 
+    def test_replace_selection_honors_old_line_numbers_after_gap_markers(self):
+        """File-scoped replacement staging should stay anchored after omitted regions."""
+        header = HunkHeader(2, 12, 2, 12)
+        lines = [
+            LineEntry(None, " ", 2, 2, text_bytes=b"line2", text="line2"),
+            LineEntry(
+                None,
+                " ",
+                None,
+                None,
+                text_bytes=b"... 7 more lines ...",
+                text="... 7 more lines ...",
+            ),
+            LineEntry(1, "-", 10, None, text_bytes=b"line10", text="line10"),
+            LineEntry(2, "+", None, 10, text_bytes=b"working10", text="working10"),
+            LineEntry(None, " ", 11, 11, text_bytes=b"line11", text="line11"),
+        ]
+        line_changes = LineLevelChange(path="test.txt", header=header, lines=lines)
+        base_content = b"".join(f"line{i}\n".encode("utf-8") for i in range(1, 21))
+
+        result = build_target_index_content_bytes_with_replaced_lines(
+            line_changes,
+            {1, 2},
+            "staged10",
+            base_content,
+        )
+
+        assert result == (
+            b"line1\n"
+            b"line2\n"
+            b"line3\n"
+            b"line4\n"
+            b"line5\n"
+            b"line6\n"
+            b"line7\n"
+            b"line8\n"
+            b"line9\n"
+            b"staged10\n"
+            b"line11\n"
+            b"line12\n"
+            b"line13\n"
+            b"line14\n"
+            b"line15\n"
+            b"line16\n"
+            b"line17\n"
+            b"line18\n"
+            b"line19\n"
+            b"line20\n"
+        )
+
+    def test_replace_selection_spans_multiple_file_scoped_regions(self):
+        """File-scoped replacement staging should replace the full selected span."""
+        header = HunkHeader(5, 32, 5, 38)
+        lines = [
+            LineEntry(None, " ", 5, 5, text_bytes=b"line5", text="line5"),
+            LineEntry(1, "+", None, 6, text_bytes=b"change-one-a", text="change-one-a"),
+            LineEntry(2, "+", None, 7, text_bytes=b"change-one-b", text="change-one-b"),
+            LineEntry(None, " ", 6, 8, text_bytes=b"line6", text="line6"),
+            LineEntry(
+                None,
+                " ",
+                None,
+                None,
+                text_bytes=b"... 14 more lines ...",
+                text="... 14 more lines ...",
+            ),
+            LineEntry(None, " ", 20, 22, text_bytes=b"line20", text="line20"),
+            LineEntry(3, "+", None, 23, text_bytes=b"change-two-a", text="change-two-a"),
+            LineEntry(4, "+", None, 24, text_bytes=b"change-two-b", text="change-two-b"),
+            LineEntry(None, " ", 21, 25, text_bytes=b"line21", text="line21"),
+            LineEntry(
+                None,
+                " ",
+                None,
+                None,
+                text_bytes=b"... 14 more lines ...",
+                text="... 14 more lines ...",
+            ),
+            LineEntry(None, " ", 35, 39, text_bytes=b"line35", text="line35"),
+            LineEntry(5, "+", None, 40, text_bytes=b"change-three-a", text="change-three-a"),
+            LineEntry(6, "+", None, 41, text_bytes=b"change-three-b", text="change-three-b"),
+            LineEntry(None, " ", 36, 42, text_bytes=b"line36", text="line36"),
+        ]
+        line_changes = LineLevelChange(path="test.txt", header=header, lines=lines)
+        base_content = b"".join(f"line{i}\n".encode("utf-8") for i in range(1, 41))
+        replacement_text = "".join(
+            ["stage-one-a\n", "stage-one-b\n"]
+            + [f"line{i}\n" for i in range(6, 21)]
+            + ["stage-two-a\n", "stage-two-b\n"]
+            + [f"line{i}\n" for i in range(21, 36)]
+            + ["stage-three-a\n", "stage-three-b\n"]
+        )
+
+        result = build_target_index_content_bytes_with_replaced_lines(
+            line_changes,
+            {1, 2, 3, 4, 5, 6},
+            replacement_text,
+            base_content,
+        )
+
+        assert result == (
+            b"".join(f"line{i}\n".encode("utf-8") for i in range(1, 6))
+            + replacement_text.encode("utf-8")
+            + b"".join(f"line{i}\n".encode("utf-8") for i in range(36, 41))
+        )
+
+    def test_replace_selection_trims_matching_edge_anchors(self):
+        """Replacement staging should ignore unchanged edge anchors by default."""
+        header = HunkHeader(1, 4, 1, 4)
+        lines = [
+            LineEntry(None, " ", 1, 1, text_bytes=b"keep1", text="keep1"),
+            LineEntry(1, "-", 2, None, text_bytes=b"old", text="old"),
+            LineEntry(2, "+", None, 2, text_bytes=b"working", text="working"),
+            LineEntry(None, " ", 3, 3, text_bytes=b"keep3", text="keep3"),
+            LineEntry(None, " ", 4, 4, text_bytes=b"keep4", text="keep4"),
+        ]
+        line_changes = LineLevelChange(path="test.txt", header=header, lines=lines)
+        base_content = b"keep1\nold\nkeep3\nkeep4\n"
+
+        result = build_target_index_content_bytes_with_replaced_lines(
+            line_changes,
+            {1, 2},
+            "keep1\nstaged\nkeep3\nkeep4\n",
+            base_content,
+        )
+
+        assert result == b"keep1\nstaged\nkeep3\nkeep4\n"
+
+    def test_replace_selection_keeps_matching_edge_anchors_with_no_anchor(self):
+        """Replacement staging should preserve duplicated anchors when requested."""
+        header = HunkHeader(1, 4, 1, 4)
+        lines = [
+            LineEntry(None, " ", 1, 1, text_bytes=b"keep1", text="keep1"),
+            LineEntry(1, "-", 2, None, text_bytes=b"old", text="old"),
+            LineEntry(2, "+", None, 2, text_bytes=b"working", text="working"),
+            LineEntry(None, " ", 3, 3, text_bytes=b"keep3", text="keep3"),
+            LineEntry(None, " ", 4, 4, text_bytes=b"keep4", text="keep4"),
+        ]
+        line_changes = LineLevelChange(path="test.txt", header=header, lines=lines)
+        base_content = b"keep1\nold\nkeep3\nkeep4\n"
+
+        result = build_target_index_content_bytes_with_replaced_lines(
+            line_changes,
+            {1, 2},
+            "keep1\nstaged\nkeep3\nkeep4\n",
+            base_content,
+            trim_unchanged_edge_anchors=False,
+        )
+
+        assert result == b"keep1\nkeep1\nstaged\nkeep3\nkeep4\nkeep3\nkeep4\n"
+
+    def test_working_tree_replace_selection_trims_matching_edge_anchors(self):
+        """Working-tree replacement should ignore unchanged edge anchors by default."""
+        header = HunkHeader(1, 4, 1, 4)
+        lines = [
+            LineEntry(None, " ", 1, 1, text_bytes=b"keep1", text="keep1"),
+            LineEntry(1, "-", 2, None, text_bytes=b"old", text="old"),
+            LineEntry(2, "+", None, 2, text_bytes=b"working", text="working"),
+            LineEntry(None, " ", 3, 3, text_bytes=b"keep3", text="keep3"),
+            LineEntry(None, " ", 4, 4, text_bytes=b"keep4", text="keep4"),
+        ]
+        line_changes = LineLevelChange(path="test.txt", header=header, lines=lines)
+        working_content = b"keep1\nworking\nkeep3\nkeep4\n"
+
+        result = build_target_working_tree_content_bytes_with_replaced_lines(
+            line_changes,
+            {1, 2},
+            "keep1\nstaged\nkeep3\nkeep4\n",
+            working_content,
+        )
+
+        assert result == b"keep1\nstaged\nkeep3\nkeep4\n"
+
+    def test_working_tree_replace_selection_keeps_matching_edge_anchors_with_no_anchor(self):
+        """Working-tree replacement should preserve duplicated anchors when requested."""
+        header = HunkHeader(1, 4, 1, 4)
+        lines = [
+            LineEntry(None, " ", 1, 1, text_bytes=b"keep1", text="keep1"),
+            LineEntry(1, "-", 2, None, text_bytes=b"old", text="old"),
+            LineEntry(2, "+", None, 2, text_bytes=b"working", text="working"),
+            LineEntry(None, " ", 3, 3, text_bytes=b"keep3", text="keep3"),
+            LineEntry(None, " ", 4, 4, text_bytes=b"keep4", text="keep4"),
+        ]
+        line_changes = LineLevelChange(path="test.txt", header=header, lines=lines)
+        working_content = b"keep1\nworking\nkeep3\nkeep4\n"
+
+        result = build_target_working_tree_content_bytes_with_replaced_lines(
+            line_changes,
+            {1, 2},
+            "keep1\nstaged\nkeep3\nkeep4\n",
+            working_content,
+            trim_unchanged_edge_anchors=False,
+        )
+
+        assert result == b"keep1\nkeep1\nstaged\nkeep3\nkeep4\nkeep3\nkeep4\n"
+
 
 class TestBuildTargetWorkingTreeContent:
     """Tests for build_target_working_tree_content_with_discarded_lines."""

--- a/tests/staging/test_operations.py
+++ b/tests/staging/test_operations.py
@@ -6,8 +6,10 @@ import pytest
 
 from git_stage_batch.core.models import LineLevelChange, HunkHeader, LineEntry
 from git_stage_batch.staging.operations import (
+    build_target_index_content_bytes_with_selected_lines,
     build_target_index_content_bytes_with_replaced_lines,
     build_target_index_content_with_selected_lines,
+    build_target_working_tree_content_bytes_with_replaced_lines,
     build_target_working_tree_content_with_discarded_lines,
     update_index_with_blob_content,
 )
@@ -214,6 +216,165 @@ class TestBuildTargetIndexContent:
 
         # No changes should be applied
         assert result == "line1\nline2\n"
+
+    def test_include_combined_file_hunk_preserves_gaps_between_real_hunks(self):
+        """Combined file-scoped views should keep untouched lines between hunks."""
+        header = HunkHeader(1, 15, 1, 13)
+        lines = [
+            LineEntry(None, " ", 1, 1, text_bytes=b"line1", text="line1"),
+            LineEntry(1, "-", 2, None, text_bytes=b"from old import a", text="from old import a"),
+            LineEntry(2, "+", None, 2, text_bytes=b"from new import a", text="from new import a"),
+            LineEntry(None, " ", 3, 3, text_bytes=b"line3", text="line3"),
+            LineEntry(None, " ", 4, 4, text_bytes=b"line4", text="line4"),
+            LineEntry(None, " ", 5, 5, text_bytes=b"line5", text="line5"),
+            LineEntry(None, " ", 11, 11, text_bytes=b"line11", text="line11"),
+            LineEntry(None, " ", 12, 12, text_bytes=b"line12", text="line12"),
+            LineEntry(3, "-", 13, None, text_bytes=b"ownership = old_value", text="ownership = old_value"),
+            LineEntry(4, "-", 14, None, text_bytes=b"", text=""),
+            LineEntry(5, "+", None, 13, text_bytes=b"selected_lines = selected_lines", text="selected_lines = selected_lines"),
+            LineEntry(None, " ", 15, 14, text_bytes=b"if binary:", text="if binary:"),
+        ]
+        line_changes = LineLevelChange(path="test.py", header=header, lines=lines)
+        base_content = (
+            b"line1\n"
+            b"from old import a\n"
+            b"line3\n"
+            b"line4\n"
+            b"line5\n"
+            b"line6\n"
+            b"line7\n"
+            b"line8\n"
+            b"line9\n"
+            b"line10\n"
+            b"line11\n"
+            b"line12\n"
+            b"ownership = old_value\n"
+            b"\n"
+            b"if binary:\n"
+        )
+
+        result = build_target_index_content_bytes_with_selected_lines(
+            line_changes,
+            {1, 2, 3, 4, 5},
+            base_content,
+        )
+
+        assert result == (
+            b"line1\n"
+            b"from new import a\n"
+            b"line3\n"
+            b"line4\n"
+            b"line5\n"
+            b"line6\n"
+            b"line7\n"
+            b"line8\n"
+            b"line9\n"
+            b"line10\n"
+            b"line11\n"
+            b"line12\n"
+            b"selected_lines = selected_lines\n"
+            b"if binary:\n"
+        )
+
+    def test_include_combined_file_hunk_keeps_insertions_with_their_anchor(self):
+        """Combined file-scoped views should not move insertions to the file start."""
+        header = HunkHeader(10, 3, 10, 4)
+        lines = [
+            LineEntry(1, "+", None, 10, text_bytes=b"inserted", text="inserted"),
+            LineEntry(None, " ", 10, 11, text_bytes=b"line10", text="line10"),
+            LineEntry(None, " ", 11, 12, text_bytes=b"line11", text="line11"),
+        ]
+        line_changes = LineLevelChange(path="test.txt", header=header, lines=lines)
+        base_content = (
+            b"line1\n"
+            b"line2\n"
+            b"line3\n"
+            b"line4\n"
+            b"line5\n"
+            b"line6\n"
+            b"line7\n"
+            b"line8\n"
+            b"line9\n"
+            b"line10\n"
+            b"line11\n"
+            b"line12\n"
+        )
+
+        result = build_target_index_content_bytes_with_selected_lines(
+            line_changes,
+            {1},
+            base_content,
+        )
+
+        assert result == (
+            b"line1\n"
+            b"line2\n"
+            b"line3\n"
+            b"line4\n"
+            b"line5\n"
+            b"line6\n"
+            b"line7\n"
+            b"line8\n"
+            b"line9\n"
+            b"inserted\n"
+            b"line10\n"
+            b"line11\n"
+            b"line12\n"
+        )
+
+    def test_include_combined_file_hunk_ignores_gap_markers_between_regions(self):
+        """Synthetic gap markers should not consume real file content."""
+        header = HunkHeader(1, 15, 1, 15)
+        lines = [
+            LineEntry(None, " ", 1, 1, text_bytes=b"line1", text="line1"),
+            LineEntry(1, "-", 2, None, text_bytes=b"old-a", text="old-a"),
+            LineEntry(2, "+", None, 2, text_bytes=b"new-a", text="new-a"),
+            LineEntry(
+                None,
+                " ",
+                None,
+                None,
+                text_bytes=b"... 7 more lines ...",
+                text="... 7 more lines ...",
+            ),
+            LineEntry(None, " ", 10, 10, text_bytes=b"line10", text="line10"),
+            LineEntry(3, "-", 11, None, text_bytes=b"old-b", text="old-b"),
+            LineEntry(4, "+", None, 11, text_bytes=b"new-b", text="new-b"),
+        ]
+        line_changes = LineLevelChange(path="test.txt", header=header, lines=lines)
+        base_content = (
+            b"line1\n"
+            b"old-a\n"
+            b"line3\n"
+            b"line4\n"
+            b"line5\n"
+            b"line6\n"
+            b"line7\n"
+            b"line8\n"
+            b"line9\n"
+            b"line10\n"
+            b"old-b\n"
+        )
+
+        result = build_target_index_content_bytes_with_selected_lines(
+            line_changes,
+            {1, 2, 3, 4},
+            base_content,
+        )
+
+        assert result == (
+            b"line1\n"
+            b"new-a\n"
+            b"line3\n"
+            b"line4\n"
+            b"line5\n"
+            b"line6\n"
+            b"line7\n"
+            b"line8\n"
+            b"line9\n"
+            b"line10\n"
+            b"new-b\n"
+        )
 
     def test_replace_selection_does_not_consume_trailing_additions(self):
         """Replacement staging should not absorb adjacent pure insertions."""

--- a/tests/utils/test_file_patterns.py
+++ b/tests/utils/test_file_patterns.py
@@ -91,3 +91,13 @@ def test_resolve_gitignore_style_patterns_supports_escaped_negation_marker():
     )
 
     assert resolved == ["!literal"]
+
+
+def test_resolve_gitignore_style_patterns_returns_empty_list_for_no_matches():
+    """Unmatched patterns should return an empty list instead of raising."""
+    resolved = resolve_gitignore_style_patterns(
+        ["foo.py", "bar.txt"],
+        ["*.md"],
+    )
+
+    assert resolved == []


### PR DESCRIPTION
The program supports batch staging and discard workflows, and it can
track selected changes across refreshed file views and semantic line
mappings.

Users still cannot reliably replace selected text during file-scoped
include and discard flows, especially when selections cross omitted
regions, refreshed sources, or repeated replacement passes. Without
that support, file-scoped workflows remain incomplete for users who
need to transform selected content instead of only staging or discarding
it as-is.

This PR addresses that by adding the state tracking, view rebuilding,
selection anchoring, staging behavior, command handling, parser support,
tests, and documentation needed for file-scoped replacement workflows.