### PR TITLE
status: Detect active sessions via abort-head marker

### DIFF
--- a/src/git_stage_batch/commands/status.py
+++ b/src/git_stage_batch/commands/status.py
@@ -14,6 +14,7 @@ from ..i18n import _
 from ..utils.file_io import read_file_paths_file, read_text_file_contents
 from ..utils.git import require_git_repository, stream_git_command
 from ..utils.paths import (
+    get_abort_head_file_path,
     get_block_list_file_path,
     get_blocked_files_file_path,
     get_context_lines,
@@ -22,7 +23,6 @@ from ..utils.paths import (
     get_discarded_hunks_file_path,
     get_included_hunks_file_path,
     get_skipped_hunks_jsonl_file_path,
-    get_state_directory_path,
 )
 
 
@@ -62,9 +62,9 @@ def command_status(*, porcelain: bool = False) -> None:
     """
     require_git_repository()
 
-    # Check if session is active
-    state_dir = get_state_directory_path()
-    if not state_dir.exists():
+    # Only treat an active abort marker as a live session. The state directory
+    # can persist after cleanup because batch metadata is intentionally kept.
+    if not get_abort_head_file_path().exists():
         if porcelain:
             print(json.dumps({"session_active": False}))
         else:

--- a/tests/commands/test_status.py
+++ b/tests/commands/test_status.py
@@ -3,7 +3,7 @@
 from git_stage_batch.commands.show import command_show
 from git_stage_batch.data.session import initialize_abort_state
 from git_stage_batch.utils.paths import get_iteration_count_file_path
-from git_stage_batch.utils.paths import ensure_state_directory_exists
+from git_stage_batch.utils.paths import ensure_state_directory_exists, get_state_directory_path
 
 import json
 import subprocess
@@ -210,6 +210,16 @@ class TestCommandStatus:
         captured = capsys.readouterr()
         output = json.loads(captured.out)
         assert output == {"session_active": False}
+
+    def test_status_ignores_persistent_batch_state_without_session(self, temp_git_repo, capsys):
+        """Persistent batch metadata alone should not count as an active session."""
+        state_dir = get_state_directory_path()
+        (state_dir / "batches").mkdir(parents=True, exist_ok=True)
+
+        command_status()
+
+        captured = capsys.readouterr()
+        assert "No batch staging session in progress" in captured.err
 
     def test_status_porcelain_with_session(self, temp_git_repo, capsys):
         """Test status --porcelain outputs JSON with session data."""


### PR DESCRIPTION
The status command checks whether a batch staging session is active
before reporting progress metrics. It determines session liveness by
testing whether the state directory exists on disk.

The state directory can persist after a session ends because batch
metadata is intentionally retained for future iterations. When that
happens, the status command falsely reports a session as active,
misleading both human callers and scripting consumers that rely on
the porcelain output.

This PR addresses that by switching the session-active check from the
state directory to the abort-head marker file, which is created when
a session starts and removed when it ends, and by adding test coverage
for the case where a state directory persists without an active session.