### PR TITLE
batch: Preserve captured replacement identity through source refresh

### DIFF
--- a/BATCHES.md
+++ b/BATCHES.md
@@ -176,7 +176,7 @@ Per text file:
 - `batch_source_commit`
 - `claimed_lines`
 - `deletions`
-- `replacement_units`
+- `replacement_units` (optional; omitted when empty)
 - `mode`
 
 Per binary file:
@@ -187,9 +187,10 @@ Per binary file:
 - `mode`
 
 `deletions` are serialized as anchored blobs, not inline text.
-`replacement_units` is optional and records explicit coupling between claimed
-source ranges and deletion indexes so replacement atomicity does not need to be
-rediscovered from display adjacency.
+`replacement_units` records explicit coupling between claimed source ranges and
+deletion indexes so replacement atomicity does not need to be rediscovered from
+display adjacency. The field is omitted when no explicit replacement units are
+stored.
 
 ---
 
@@ -452,19 +453,33 @@ context or addition line cannot be expressed in source space, meaning its
 
 ### How source advancement works
 
-`advance_batch_source_for_file()` in `src/git_stage_batch/batch/ownership.py`:
+The stale-source repair path coordinates
+`advance_batch_source_for_file_with_provenance()` in
+`src/git_stage_batch/batch/ownership.py` with selection refresh in
+`src/git_stage_batch/batch/source_refresh.py`:
 
 1. reads the old source content
 2. reads the current working-tree content
 3. builds a new synthetic source that preserves already-owned presence lines,
    even if they have been removed from the working tree by earlier discard-to-
    batch operations
-4. creates a new batch source commit from that advanced content
-5. remaps existing ownership into the new source coordinate space
+4. records provenance maps while building that source:
+   - old source line -> advanced source line
+   - working-tree line -> advanced source line
+5. creates a new batch source commit from that advanced content
+6. remaps existing ownership into the new source coordinate space
+7. returns the working-tree provenance map so the selected lines can be
+   re-annotated without matching synthesized source text again
 
 This is a major detail the old document missed: advanced sources are not
 necessarily equal to the live working tree. They can intentionally carry forward
 already-owned lines that are absent from the current file.
+
+The provenance maps are part of the safety model. Existing ownership is remapped
+through the old-source map, while newly selected lines are re-annotated through
+the working-tree map when that map is available. That avoids rediscovering line
+identity from text in synthesized sources, especially when repeated lines would
+make structural matching ambiguous.
 
 ### Session cache
 
@@ -661,11 +676,15 @@ The current implementation relies on these invariants:
    start use their current working-tree content.
 3. Advanced batch sources may preserve already-owned lines that are absent from
    the live working tree.
-4. The content ref and state ref must stay in sync.
-5. Deletion claims are anchored structural constraints, not generic search and
+4. When source content is synthesized with known provenance, remapping and
+   selected-line re-annotation should treat those provenance maps as
+   authoritative. Text matching is a fallback only when no provenance map is
+   available.
+5. The content ref and state ref must stay in sync.
+6. Deletion claims are anchored structural constraints, not generic search and
    delete instructions.
-6. Line-level batch operations must preserve semantic atomicity.
-7. Merge and discard favor refusal over ambiguous structural guesses.
+7. Line-level batch operations must preserve semantic atomicity.
+8. Merge and discard favor refusal over ambiguous structural guesses.
 
 If any of these change, the command behavior and the safety model change with
 them.

--- a/BATCHES.md
+++ b/BATCHES.md
@@ -176,6 +176,7 @@ Per text file:
 - `batch_source_commit`
 - `claimed_lines`
 - `deletions`
+- `replacement_units`
 - `mode`
 
 Per binary file:
@@ -186,6 +187,9 @@ Per binary file:
 - `mode`
 
 `deletions` are serialized as anchored blobs, not inline text.
+`replacement_units` is optional and records explicit coupling between claimed
+source ranges and deletion indexes so replacement atomicity does not need to be
+rediscovered from display adjacency.
 
 ---
 
@@ -234,7 +238,7 @@ snapshot even if the user keeps editing.
 With the session model in place, ownership can be stated precisely.
 Ownership is defined in `src/git_stage_batch/batch/ownership.py`.
 
-`BatchOwnership` has two parts:
+`BatchOwnership` has three persistent fields:
 
 - `claimed_lines`
   Source-space line ranges like `["3-7", "10"]`
@@ -242,6 +246,11 @@ Ownership is defined in `src/git_stage_batch/batch/ownership.py`.
   `DeletionClaim(anchor_line, content_lines)` records that a specific baseline
   sequence must be absent after a given source line, or at start-of-file if the
   anchor is `None`
+- `replacement_units`
+  Optional metadata linking claimed line ranges to entries in `deletions` when
+  the capture path knows they form one replacement. These persisted units are
+  selected atomically as a whole; display-adjacency grouping is only the fallback
+  for ownership without explicit replacement metadata.
 
 This distinction is central:
 

--- a/STORAGE.md
+++ b/STORAGE.md
@@ -334,7 +334,6 @@ Example:
       "batch_source_commit": "def456...",
       "claimed_lines": ["10-12"],
       "deletions": [],
-      "replacement_units": [],
       "mode": "100644"
     }
   }
@@ -351,7 +350,7 @@ model used to reconstruct and validate a batch:
 * `claimed_lines` define source lines that must be present.
 * `deletions` define anchored absence constraints.
 * `replacement_units` optionally links claimed ranges to deletion indexes for
-  explicit replacement atomicity.
+  explicit replacement atomicity. It is omitted when empty.
 * `mode` defines the file mode for realized content.
 
 ### Limitations
@@ -448,7 +447,6 @@ information:
       "source_path": "sources/src/main.py",
       "claimed_lines": ["10-12"],
       "deletions": [],
-      "replacement_units": [],
       "mode": "100644"
     }
   }

--- a/STORAGE.md
+++ b/STORAGE.md
@@ -334,6 +334,7 @@ Example:
       "batch_source_commit": "def456...",
       "claimed_lines": ["10-12"],
       "deletions": [],
+      "replacement_units": [],
       "mode": "100644"
     }
   }
@@ -349,6 +350,8 @@ model used to reconstruct and validate a batch:
 * `batch_source_commit` defines the coordinate space for ownership.
 * `claimed_lines` define source lines that must be present.
 * `deletions` define anchored absence constraints.
+* `replacement_units` optionally links claimed ranges to deletion indexes for
+  explicit replacement atomicity.
 * `mode` defines the file mode for realized content.
 
 ### Limitations
@@ -445,6 +448,7 @@ information:
       "source_path": "sources/src/main.py",
       "claimed_lines": ["10-12"],
       "deletions": [],
+      "replacement_units": [],
       "mode": "100644"
     }
   }

--- a/src/git_stage_batch/batch/merge.py
+++ b/src/git_stage_batch/batch/merge.py
@@ -40,6 +40,7 @@ class RealizedEntry:
     """
     content: bytes  # Line content with newline
     source_line: int | None  # Batch-source line number (1-indexed), or None for working-tree extras
+    target_line: int | None = None  # Working-tree line number (1-indexed), when known
     is_claimed: bool = False  # True if from a claimed source line (presence constraint)
 
 
@@ -530,7 +531,12 @@ def _apply_presence_constraints(
         result: list[RealizedEntry] = []
         for working_idx, working_line in enumerate(working_lines):
             source_line = mapping.get_source_line_from_target_line(working_idx + 1)
-            result.append(RealizedEntry(content=working_line, source_line=source_line, is_claimed=False))
+            result.append(RealizedEntry(
+                content=working_line,
+                source_line=source_line,
+                target_line=working_idx + 1,
+                is_claimed=False,
+            ))
         return result
 
     mapping = match_lines(source_lines, working_lines)
@@ -551,7 +557,12 @@ def _apply_presence_constraints(
         for working_idx, working_line in enumerate(working_lines):
             source_line = mapping.get_source_line_from_target_line(working_idx + 1)
             is_claimed = source_line in claimed_line_set if source_line else False
-            result.append(RealizedEntry(content=working_line, source_line=source_line, is_claimed=is_claimed))
+            result.append(RealizedEntry(
+                content=working_line,
+                source_line=source_line,
+                target_line=working_idx + 1,
+                is_claimed=is_claimed,
+            ))
         return result
 
     result: list[RealizedEntry] = []
@@ -565,6 +576,7 @@ def _apply_presence_constraints(
                 result.append(RealizedEntry(
                     content=working_lines[working_idx],
                     source_line=None,
+                    target_line=working_idx + 1,
                     is_claimed=False
                 ))
                 working_idx += 1
@@ -574,12 +586,14 @@ def _apply_presence_constraints(
                 result.append(RealizedEntry(
                     content=source_lines[source_line - 1],
                     source_line=source_line,
+                    target_line=working_idx + 1,
                     is_claimed=True
                 ))
             else:
                 result.append(RealizedEntry(
                     content=working_lines[working_idx],
                     source_line=source_line,
+                    target_line=working_idx + 1,
                     is_claimed=False
                 ))
             working_idx += 1
@@ -595,6 +609,7 @@ def _apply_presence_constraints(
         result.append(RealizedEntry(
             content=working_lines[working_idx],
             source_line=None,
+            target_line=working_idx + 1,
             is_claimed=False
         ))
         working_idx += 1
@@ -1357,6 +1372,7 @@ def _build_realized_entries_for_discard(
         result.append(RealizedEntry(
             content=working_line,
             source_line=source_line,
+            target_line=working_idx + 1,
             is_claimed=False
         ))
 

--- a/src/git_stage_batch/batch/ownership.py
+++ b/src/git_stage_batch/batch/ownership.py
@@ -449,6 +449,7 @@ class OwnershipUnit:
         display_line_ids: Display line IDs that map to this unit (from reconstructed display)
         is_atomic: If True, partial removal is not allowed
         atomic_reason: Explanation for why unit is atomic (for debugging/errors)
+        preserves_replacement_unit: True when this unit came from persisted replacement metadata
     """
     kind: OwnershipUnitKind
     claimed_source_lines: set[int]
@@ -456,6 +457,7 @@ class OwnershipUnit:
     display_line_ids: set[int]
     is_atomic: bool = False
     atomic_reason: str | None = None
+    preserves_replacement_unit: bool = False
 
 
 def build_ownership_units_from_display(
@@ -519,19 +521,45 @@ def build_ownership_units_from_display_lines(
     rendering.  It preserves the same grouping rules as
     build_ownership_units_from_display() without rebuilding the display model.
     """
-    units = []
+    units, consumed_claimed_lines, consumed_deletion_indices = (
+        _build_explicit_replacement_units_from_display_lines(
+            ownership,
+            display_lines,
+        )
+    )
     i = 0
 
     while i < len(display_lines):
         line = display_lines[i]
+        if _display_line_is_consumed(
+            line,
+            consumed_claimed_lines,
+            consumed_deletion_indices,
+        ):
+            i += 1
+            continue
 
         if line["type"] == "deletion":
             # Collect consecutive deletion block
-            deletion_run = _collect_display_run(display_lines, i, "deletion")
+            deletion_run = _collect_display_run(
+                display_lines,
+                i,
+                "deletion",
+                consumed_claimed_lines,
+                consumed_deletion_indices,
+            )
             i = deletion_run["next_index"]
 
             # Check if immediately followed by claimed line (display adjacency)
-            if i < len(display_lines) and display_lines[i]["type"] == "claimed":
+            if (
+                i < len(display_lines)
+                and display_lines[i]["type"] == "claimed"
+                and not _display_line_is_consumed(
+                    display_lines[i],
+                    consumed_claimed_lines,
+                    consumed_deletion_indices,
+                )
+            ):
                 # Collect single claimed line (to preserve fine-grained reset)
                 claimed_display_id = display_lines[i]["id"]
                 claimed_source_line = display_lines[i]["source_line"]
@@ -561,9 +589,23 @@ def build_ownership_units_from_display_lines(
             i += 1
 
             # Check if immediately followed by deletion block (display adjacency)
-            if i < len(display_lines) and display_lines[i]["type"] == "deletion":
+            if (
+                i < len(display_lines)
+                and display_lines[i]["type"] == "deletion"
+                and not _display_line_is_consumed(
+                    display_lines[i],
+                    consumed_claimed_lines,
+                    consumed_deletion_indices,
+                )
+            ):
                 # Collect consecutive deletion block
-                deletion_run = _collect_display_run(display_lines, i, "deletion")
+                deletion_run = _collect_display_run(
+                    display_lines,
+                    i,
+                    "deletion",
+                    consumed_claimed_lines,
+                    consumed_deletion_indices,
+                )
                 i = deletion_run["next_index"]
 
                 # Replacement unit: claimed line adjacent to deletion block
@@ -591,10 +633,96 @@ def build_ownership_units_from_display_lines(
             # Unknown type - skip
             i += 1
 
-    return units
+    return sorted(units, key=_ownership_unit_display_order_key)
 
 
-def _collect_display_run(display_lines: list, start_index: int, expected_type: str) -> dict:
+def _ownership_unit_display_order_key(unit: OwnershipUnit) -> int:
+    """Return the first visible display line covered by a semantic unit."""
+    if not unit.display_line_ids:
+        return 10**12
+    return min(unit.display_line_ids)
+
+
+def _build_explicit_replacement_units_from_display_lines(
+    ownership: BatchOwnership,
+    display_lines: list[dict],
+) -> tuple[list[OwnershipUnit], set[int], set[int]]:
+    """Build units from persisted replacement metadata."""
+    units: list[OwnershipUnit] = []
+    consumed_claimed_lines: set[int] = set()
+    consumed_deletion_indices: set[int] = set()
+
+    replacement_units = _normalize_replacement_units(
+        ownership.replacement_units,
+        deletion_count=len(ownership.deletions),
+    )
+    if not replacement_units:
+        return units, consumed_claimed_lines, consumed_deletion_indices
+
+    for replacement_unit in replacement_units:
+        claimed_source_lines = _parse_claimed_ranges(replacement_unit.claimed_lines)
+        deletion_indices = set(replacement_unit.deletion_indices)
+        claimed_display_ids: set[int] = set()
+        deletion_display_ids: set[int] = set()
+
+        for display_line in display_lines:
+            display_id = display_line.get("id")
+            if display_id is None:
+                continue
+
+            if (
+                display_line["type"] == "claimed"
+                and display_line["source_line"] in claimed_source_lines
+            ):
+                claimed_display_ids.add(display_id)
+            elif (
+                display_line["type"] == "deletion"
+                and display_line["deletion_index"] in deletion_indices
+            ):
+                deletion_display_ids.add(display_id)
+
+        if not claimed_display_ids or not deletion_display_ids:
+            continue
+
+        deletion_claims = [
+            ownership.deletions[index]
+            for index in sorted(deletion_indices)
+        ]
+        units.append(OwnershipUnit(
+            kind=OwnershipUnitKind.REPLACEMENT,
+            claimed_source_lines=claimed_source_lines,
+            deletion_claims=deletion_claims,
+            display_line_ids=claimed_display_ids | deletion_display_ids,
+            is_atomic=True,
+            atomic_reason="explicit_replacement",
+            preserves_replacement_unit=True,
+        ))
+        consumed_claimed_lines.update(claimed_source_lines)
+        consumed_deletion_indices.update(deletion_indices)
+
+    return units, consumed_claimed_lines, consumed_deletion_indices
+
+
+def _display_line_is_consumed(
+    display_line: dict,
+    consumed_claimed_lines: set[int],
+    consumed_deletion_indices: set[int],
+) -> bool:
+    """Return True when a display line is already covered by an explicit unit."""
+    if display_line["type"] == "claimed":
+        return display_line["source_line"] in consumed_claimed_lines
+    if display_line["type"] == "deletion":
+        return display_line["deletion_index"] in consumed_deletion_indices
+    return False
+
+
+def _collect_display_run(
+    display_lines: list,
+    start_index: int,
+    expected_type: str,
+    consumed_claimed_lines: set[int],
+    consumed_deletion_indices: set[int],
+) -> dict:
     """Collect a consecutive run of display lines of the same type.
 
     Args:
@@ -614,7 +742,15 @@ def _collect_display_run(display_lines: list, start_index: int, expected_type: s
     deletion_indices = [] if expected_type == "deletion" else None
 
     i = start_index
-    while i < len(display_lines) and display_lines[i]["type"] == expected_type:
+    while (
+        i < len(display_lines)
+        and display_lines[i]["type"] == expected_type
+        and not _display_line_is_consumed(
+            display_lines[i],
+            consumed_claimed_lines,
+            consumed_deletion_indices,
+        )
+    ):
         display_ids.append(display_lines[i]["id"])
 
         if expected_type == "claimed":
@@ -815,20 +951,31 @@ def rebuild_ownership_from_units(units: list[OwnershipUnit]) -> BatchOwnership:
     """
     all_claimed_lines = set()
     all_deletions = []
+    replacement_units: list[ReplacementUnit] = []
 
     for unit in units:
         all_claimed_lines.update(unit.claimed_source_lines)
-        all_deletions.extend(unit.deletion_claims)
+        deletion_indices = []
+        for deletion in unit.deletion_claims:
+            all_deletions.append(deletion)
+            deletion_indices.append(len(all_deletions) - 1)
+        if unit.kind == OwnershipUnitKind.REPLACEMENT and unit.preserves_replacement_unit:
+            replacement_units.append(ReplacementUnit(
+                claimed_lines=_format_claimed_set(unit.claimed_source_lines),
+                deletion_indices=deletion_indices,
+            ))
 
     # Format claimed lines as range strings
-    if all_claimed_lines:
-        claimed_lines_formatted = [format_line_ids(sorted(all_claimed_lines))]
-    else:
-        claimed_lines_formatted = []
+    claimed_lines_formatted = _format_claimed_set(all_claimed_lines)
 
     return BatchOwnership(
         claimed_lines=claimed_lines_formatted,
-        deletions=all_deletions
+        deletions=all_deletions,
+        replacement_units=_normalize_replacement_units(
+            replacement_units,
+            deletion_count=len(all_deletions),
+        ),
+    )
 
 
 def _remap_replacement_units(

--- a/src/git_stage_batch/batch/ownership.py
+++ b/src/git_stage_batch/batch/ownership.py
@@ -151,6 +151,26 @@ class ResolvedBatchOwnership:
     deletion_claims: list[DeletionClaim]  # Separate constraints, not collapsed
 
 
+@dataclass
+class AdvancedSourceContent:
+    """Synthesized source content with line provenance from its inputs."""
+
+    content: bytes
+    source_line_map: dict[int, int]
+    working_line_map: dict[int, int]
+
+
+@dataclass
+class BatchSourceAdvanceResult:
+    """Result of advancing one file's batch source."""
+
+    batch_source_commit: str
+    ownership: BatchOwnership
+    source_content: bytes
+    working_content: bytes
+    working_line_map: dict[int, int]
+
+
 def _deletion_signature(deletion: DeletionClaim) -> tuple[int | None, bytes]:
     """Return a stable signature for a deletion claim."""
     return deletion.anchor_line, b"".join(deletion.content_lines)
@@ -1111,6 +1131,20 @@ def _advance_source_content_preserving_existing_presence(
     Returns:
         Tuple of (new source bytes, old source line -> new source line map).
     """
+    advanced = _advance_source_content_preserving_existing_presence_with_provenance(
+        old_source_content=old_source_content,
+        working_content=working_content,
+        ownership=ownership,
+    )
+    return advanced.content, advanced.source_line_map
+
+
+def _advance_source_content_preserving_existing_presence_with_provenance(
+    old_source_content: bytes,
+    working_content: bytes,
+    ownership: BatchOwnership,
+) -> AdvancedSourceContent:
+    """Build advanced source content and preserve input line provenance."""
     old_lines = old_source_content.splitlines(keepends=True)
     working_lines = working_content.splitlines(keepends=True)
     claimed_lines = (
@@ -1126,11 +1160,18 @@ def _advance_source_content_preserving_existing_presence(
     )
 
     source_line_map = {}
+    working_line_map = {}
     for index, entry in enumerate(entries, start=1):
         if entry.source_line is not None:
             source_line_map[entry.source_line] = index
+        if entry.target_line is not None:
+            working_line_map[entry.target_line] = index
 
-    return b"".join(entry.content for entry in entries), source_line_map
+    return AdvancedSourceContent(
+        content=b"".join(entry.content for entry in entries),
+        source_line_map=source_line_map,
+        working_line_map=working_line_map,
+    )
 
 
 def _remap_batch_ownership_with_source_line_map(
@@ -1213,6 +1254,27 @@ def advance_batch_source_for_file(
     Raises:
         ValueError: If remapping is ambiguous or working tree content unavailable
     """
+    result = advance_batch_source_for_file_with_provenance(
+        batch_name=batch_name,
+        file_path=file_path,
+        old_batch_source_commit=old_batch_source_commit,
+        existing_ownership=existing_ownership,
+    )
+    return (
+        result.batch_source_commit,
+        result.ownership,
+        result.source_content,
+        result.working_content,
+    )
+
+
+def advance_batch_source_for_file_with_provenance(
+    batch_name: str,
+    file_path: str,
+    old_batch_source_commit: str,
+    existing_ownership: BatchOwnership,
+) -> BatchSourceAdvanceResult:
+    """Advance batch source and expose provenance for re-annotation."""
     # Read old batch source content
     old_source_result = run_git_command(
         ["show", f"{old_batch_source_commit}:{file_path}"],
@@ -1236,7 +1298,7 @@ def advance_batch_source_for_file(
         )
     working_content = working_file_path.read_bytes()
 
-    new_source_content, source_line_map = _advance_source_content_preserving_existing_presence(
+    advanced_source = _advance_source_content_preserving_existing_presence_with_provenance(
         old_source_content=old_source_content,
         working_content=working_content,
         ownership=existing_ownership,
@@ -1247,7 +1309,7 @@ def advance_batch_source_for_file(
     # session-start snapshot for abort/discard correctness.
     new_batch_source_commit = create_batch_source_commit(
         file_path,
-        file_content_override=new_source_content
+        file_content_override=advanced_source.content
     )
 
     # Remap ownership using provenance produced while constructing the advanced
@@ -1255,12 +1317,13 @@ def advance_batch_source_for_file(
     # working tree after earlier discard operations.
     remapped_ownership = _remap_batch_ownership_with_source_line_map(
         ownership=existing_ownership,
-        source_line_map=source_line_map,
+        source_line_map=advanced_source.source_line_map,
     )
 
-    return (
-        new_batch_source_commit,
-        remapped_ownership,
-        new_source_content,
-        working_content,
+    return BatchSourceAdvanceResult(
+        batch_source_commit=new_batch_source_commit,
+        ownership=remapped_ownership,
+        source_content=advanced_source.content,
+        working_content=working_content,
+        working_line_map=advanced_source.working_line_map,
     )

--- a/src/git_stage_batch/batch/ownership.py
+++ b/src/git_stage_batch/batch/ownership.py
@@ -341,12 +341,14 @@ def translate_lines_to_batch_ownership(selected_lines: list) -> BatchOwnership:
 
     claimed_source_lines: list[int] = []
     deletion_claims: list[DeletionClaim] = []
+    replacement_units: list[ReplacementUnit] = []
 
     # Track current deletion run
     current_deletion_anchor: int | None = None
     current_deletion_lines: list[bytes] = []
+    active_replacement_unit: ReplacementUnit | None = None
 
-    def flush_deletion_run():
+    def flush_deletion_run() -> list[int]:
         """Finalize current deletion run as a DeletionClaim."""
         nonlocal current_deletion_anchor, current_deletion_lines
         if current_deletion_lines:
@@ -356,13 +358,16 @@ def translate_lines_to_batch_ownership(selected_lines: list) -> BatchOwnership:
                     content_lines=current_deletion_lines[:]
                 )
             )
+            deletion_index = len(deletion_claims) - 1
             current_deletion_lines = []
+            return [deletion_index]
+        return []
 
     for line in selected_lines:
         if line.kind in (' ', '+'):
             # Context or addition: exists in batch source (working tree)
             # Flush any pending deletion run
-            flush_deletion_run()
+            flushed_deletion_indices = flush_deletion_run()
 
             if line.source_line is None:
                 raise ValueError(
@@ -372,10 +377,26 @@ def translate_lines_to_batch_ownership(selected_lines: list) -> BatchOwnership:
                 )
 
             claimed_source_lines.append(line.source_line)
+            if line.kind == '+':
+                if flushed_deletion_indices:
+                    active_replacement_unit = ReplacementUnit(
+                        claimed_lines=[],
+                        deletion_indices=flushed_deletion_indices,
+                    )
+                    replacement_units.append(active_replacement_unit)
+
+                if active_replacement_unit is not None:
+                    claimed = _parse_claimed_ranges(active_replacement_unit.claimed_lines)
+                    claimed.add(line.source_line)
+                    active_replacement_unit.claimed_lines = _format_claimed_set(claimed)
+            else:
+                active_replacement_unit = None
+
             # Update anchor for next deletion run
             current_deletion_anchor = line.source_line
 
         elif line.kind == '-':
+            active_replacement_unit = None
             # Deletion: suppression constraint
             # Use deletion's source_line as anchor if we haven't set one yet
             # (This handles deletion-only selections where no context lines precede)
@@ -389,11 +410,16 @@ def translate_lines_to_batch_ownership(selected_lines: list) -> BatchOwnership:
     flush_deletion_run()
 
     # Normalize claimed lines into range strings
-    claimed_lines = []
-    if claimed_source_lines:
-        claimed_lines = [format_line_ids(claimed_source_lines)]
+    claimed_lines = [format_line_ids(claimed_source_lines)] if claimed_source_lines else []
 
-    return BatchOwnership(claimed_lines=claimed_lines, deletions=deletion_claims)
+    return BatchOwnership(
+        claimed_lines=claimed_lines,
+        deletions=deletion_claims,
+        replacement_units=_normalize_replacement_units(
+            replacement_units,
+            deletion_count=len(deletion_claims),
+        ),
+    )
 
 
 class OwnershipUnitKind(Enum):

--- a/src/git_stage_batch/batch/ownership.py
+++ b/src/git_stage_batch/batch/ownership.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 
 from ..core.line_selection import format_line_ids, parse_line_selection
@@ -49,15 +49,44 @@ class DeletionClaim:
 
 
 @dataclass
+class ReplacementUnit:
+    """Explicit coupling between presence claims and deletion claims.
+
+    The deletion side references indexes in BatchOwnership.deletions so the
+    canonical deletion constraint is stored only once in metadata.
+    """
+
+    claimed_lines: list[str]
+    deletion_indices: list[int]
+
+    def to_dict(self) -> dict:
+        """Serialize to metadata dictionary."""
+        return {
+            "claimed_lines": self.claimed_lines,
+            "deletion_indices": self.deletion_indices,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> ReplacementUnit:
+        """Deserialize from metadata dictionary."""
+        return cls(
+            claimed_lines=data.get("claimed_lines", []),
+            deletion_indices=data.get("deletion_indices", []),
+        )
+
+
+@dataclass
 class BatchOwnership:
     """Represents batch ownership in batch source space.
 
     A batch owns content relative to its batch source commit:
     - claimed_lines: Line ranges that exist in batch source (presence claims)
     - deletions: Suppression constraints for baseline content (absence claims)
+    - replacement_units: Optional explicit coupling between claims and deletions
     """
     claimed_lines: list[str]  # Range strings like ["1-5", "10-15", "18"]
     deletions: list[DeletionClaim]  # Separate deletion constraints
+    replacement_units: list[ReplacementUnit] = field(default_factory=list)
 
     def is_empty(self) -> bool:
         """Check if this ownership is empty (no claimed lines or deletions)."""
@@ -65,10 +94,20 @@ class BatchOwnership:
 
     def to_metadata_dict(self) -> dict:
         """Convert to metadata dictionary format for storage."""
-        return {
+        data = {
             "claimed_lines": self.claimed_lines,
             "deletions": [claim.to_dict() for claim in self.deletions]
         }
+        replacement_units = [
+            unit.to_dict()
+            for unit in _normalize_replacement_units(
+                self.replacement_units,
+                deletion_count=len(self.deletions),
+            )
+        ]
+        if replacement_units:
+            data["replacement_units"] = replacement_units
+        return data
 
     @classmethod
     def from_metadata_dict(cls, data: dict) -> BatchOwnership:
@@ -76,9 +115,14 @@ class BatchOwnership:
         deletions = [
             DeletionClaim.from_dict(d) for d in data.get("deletions", [])
         ]
+        replacement_units = [
+            ReplacementUnit.from_dict(d)
+            for d in data.get("replacement_units", [])
+        ]
         return cls(
             claimed_lines=data.get("claimed_lines", []),
-            deletions=deletions
+            deletions=deletions,
+            replacement_units=replacement_units,
         )
 
     def resolve(self) -> ResolvedBatchOwnership:
@@ -107,6 +151,71 @@ class ResolvedBatchOwnership:
     deletion_claims: list[DeletionClaim]  # Separate constraints, not collapsed
 
 
+def _deletion_signature(deletion: DeletionClaim) -> tuple[int | None, bytes]:
+    """Return a stable signature for a deletion claim."""
+    return deletion.anchor_line, b"".join(deletion.content_lines)
+
+
+def _parse_claimed_ranges(claimed_lines: list[str]) -> set[int]:
+    """Parse claimed line range strings into a set."""
+    return set(parse_line_selection(",".join(claimed_lines))) if claimed_lines else set()
+
+
+def _format_claimed_set(claimed_lines: set[int]) -> list[str]:
+    """Format a claimed line set as normalized range strings."""
+    if not claimed_lines:
+        return []
+    return [format_line_ids(sorted(claimed_lines))]
+
+
+def _normalize_replacement_units(
+    replacement_units: list[ReplacementUnit],
+    *,
+    deletion_count: int,
+) -> list[ReplacementUnit]:
+    """Drop invalid references and coalesce overlapping replacement units."""
+    components: list[tuple[set[int], set[int]]] = []
+
+    for unit in replacement_units:
+        claimed = _parse_claimed_ranges(unit.claimed_lines)
+        deletion_indices = {
+            index
+            for index in unit.deletion_indices
+            if type(index) is int and 0 <= index < deletion_count
+        }
+        if not claimed or not deletion_indices:
+            continue
+
+        overlapping_component_indices = [
+            index
+            for index, (component_claimed, component_deletions)
+            in enumerate(components)
+            if component_claimed & claimed or component_deletions & deletion_indices
+        ]
+        if not overlapping_component_indices:
+            components.append((set(claimed), set(deletion_indices)))
+            continue
+
+        target_index = overlapping_component_indices[0]
+        target_claimed, target_deletions = components[target_index]
+        target_claimed.update(claimed)
+        target_deletions.update(deletion_indices)
+
+        for source_index in reversed(overlapping_component_indices[1:]):
+            source_claimed, source_deletions = components[source_index]
+            target_claimed.update(source_claimed)
+            target_deletions.update(source_deletions)
+            del components[source_index]
+
+    return [
+        ReplacementUnit(
+            claimed_lines=_format_claimed_set(claimed),
+            deletion_indices=sorted(deletion_indices),
+        )
+        for claimed, deletion_indices in components
+    ]
+
+
 def merge_batch_ownership(existing: BatchOwnership, new: BatchOwnership) -> BatchOwnership:
     """Merge two BatchOwnership objects.
 
@@ -124,31 +233,65 @@ def merge_batch_ownership(existing: BatchOwnership, new: BatchOwnership) -> Batc
         Merged BatchOwnership with combined claims and deduplicated deletions
     """
     # Merge claimed lines (combine and normalize ranges)
-    existing_claimed = set(parse_line_selection(",".join(existing.claimed_lines))) if existing.claimed_lines else set()
-    new_claimed = set(parse_line_selection(",".join(new.claimed_lines))) if new.claimed_lines else set()
+    existing_claimed = _parse_claimed_ranges(existing.claimed_lines)
+    new_claimed = _parse_claimed_ranges(new.claimed_lines)
     combined_claimed = existing_claimed | new_claimed
 
     # Normalize to range strings
-    claimed_lines = []
-    if combined_claimed:
-        claimed_lines = [format_line_ids(sorted(combined_claimed))]
+    claimed_lines = _format_claimed_set(combined_claimed)
 
     # Merge deletion claims: deduplicate by anchor and content
     # When batch source advances and ownership is remapped, the same deletion can appear
     # in both existing (remapped) and new (from current diff). We need to deduplicate.
     seen_deletions = set()
     combined_deletions = []
+    existing_deletion_index_map: dict[int, int] = {}
+    new_deletion_index_map: dict[int, int] = {}
 
-    for deletion in existing.deletions + new.deletions:
+    for source_name, source_index, deletion in (
+        [("existing", index, deletion) for index, deletion in enumerate(existing.deletions)]
+        + [("new", index, deletion) for index, deletion in enumerate(new.deletions)]
+    ):
         # Create a signature for this deletion: anchor + content
-        content_bytes = b"".join(deletion.content_lines)
-        signature = (deletion.anchor_line, content_bytes)
+        signature = _deletion_signature(deletion)
 
         if signature not in seen_deletions:
             seen_deletions.add(signature)
             combined_deletions.append(deletion)
+        combined_index = next(
+            index
+            for index, combined in enumerate(combined_deletions)
+            if _deletion_signature(combined) == signature
+        )
+        if source_name == "existing":
+            existing_deletion_index_map[source_index] = combined_index
+        else:
+            new_deletion_index_map[source_index] = combined_index
 
-    return BatchOwnership(claimed_lines=claimed_lines, deletions=combined_deletions)
+    combined_replacement_units: list[ReplacementUnit] = []
+    for source_units, index_map in (
+        (existing.replacement_units, existing_deletion_index_map),
+        (new.replacement_units, new_deletion_index_map),
+    ):
+        for unit in source_units:
+            remapped_indices = [
+                index_map[index]
+                for index in unit.deletion_indices
+                if type(index) is int and index in index_map
+            ]
+            combined_replacement_units.append(ReplacementUnit(
+                claimed_lines=unit.claimed_lines,
+                deletion_indices=remapped_indices,
+            ))
+
+    return BatchOwnership(
+        claimed_lines=claimed_lines,
+        deletions=combined_deletions,
+        replacement_units=_normalize_replacement_units(
+            combined_replacement_units,
+            deletion_count=len(combined_deletions),
+        ),
+    )
 
 
 def detect_stale_batch_source_for_selection(selected_lines: list) -> bool:
@@ -295,7 +438,9 @@ def build_ownership_units_from_display(
 ) -> list[OwnershipUnit]:
     """Build semantic ownership units from reconstructed display lines.
 
-    Groups display lines into units based on adjacency in the reconstructed
+    Persisted replacement metadata is honored first, so captured replacements
+    remain whole atomic units even if their lines are no longer display-adjacent.
+    Remaining lines fall back to display-adjacency grouping in reconstructed
     display order, not source-line proximity. This reflects what the user
     actually sees in the batch display.
 
@@ -305,9 +450,10 @@ def build_ownership_units_from_display(
     - Deletion block with no adjacent claimed line → DELETION_ONLY unit (atomic)
     - Claimed line with no adjacent deletion → PRESENCE_ONLY unit (non-atomic)
 
-    Claimed lines are processed individually (not as blocks) to preserve fine-grained
-    reset capability. When a deletion block is followed by multiple claimed lines,
-    only the first claimed line couples with the deletion to form a REPLACEMENT unit.
+    For fallback display-adjacent grouping, claimed lines are processed
+    individually (not as blocks) to preserve fine-grained reset capability.
+    When a deletion block is followed by multiple claimed lines, only the first
+    claimed line couples with the deletion to form a REPLACEMENT unit.
     Subsequent claimed lines remain independent PRESENCE_ONLY units.
 
     "Adjacent" means consecutive in the display_lines sequence with no intervening
@@ -657,6 +803,36 @@ def rebuild_ownership_from_units(units: list[OwnershipUnit]) -> BatchOwnership:
     return BatchOwnership(
         claimed_lines=claimed_lines_formatted,
         deletions=all_deletions
+
+
+def _remap_replacement_units(
+    replacement_units: list[ReplacementUnit],
+    *,
+    map_claimed_line,
+    deletion_count: int,
+) -> list[ReplacementUnit]:
+    """Remap explicit replacement-unit claimed lines into a new source space."""
+    remapped_units: list[ReplacementUnit] = []
+
+    for unit in replacement_units:
+        new_claimed_lines: set[int] = set()
+        for old_line_num in _parse_claimed_ranges(unit.claimed_lines):
+            new_line_num = map_claimed_line(old_line_num)
+            if new_line_num is None:
+                raise ValueError(
+                    f"Cannot remap replacement unit claimed line {old_line_num} "
+                    f"from old source to new source: no unique mapping found."
+                )
+            new_claimed_lines.add(new_line_num)
+
+        remapped_units.append(ReplacementUnit(
+            claimed_lines=_format_claimed_set(new_claimed_lines),
+            deletion_indices=unit.deletion_indices,
+        ))
+
+    return _normalize_replacement_units(
+        remapped_units,
+        deletion_count=deletion_count,
     )
 
 
@@ -708,9 +884,7 @@ def remap_batch_ownership_to_new_source(
         new_claimed.add(new_line_num)
 
     # Format new claimed lines
-    new_claimed_lines = []
-    if new_claimed:
-        new_claimed_lines = [format_line_ids(sorted(new_claimed))]
+    new_claimed_lines = _format_claimed_set(new_claimed)
 
     # Remap deletion anchors
     new_deletions = []
@@ -736,7 +910,17 @@ def remap_batch_ownership_to_new_source(
                 content_lines=deletion.content_lines
             ))
 
-    return BatchOwnership(claimed_lines=new_claimed_lines, deletions=new_deletions)
+    new_replacement_units = _remap_replacement_units(
+        ownership.replacement_units,
+        map_claimed_line=mapping.get_target_line_from_source_line,
+        deletion_count=len(new_deletions),
+    )
+
+    return BatchOwnership(
+        claimed_lines=new_claimed_lines,
+        deletions=new_deletions,
+        replacement_units=new_replacement_units,
+    )
 
 
 def _advance_source_content_preserving_existing_presence(
@@ -793,9 +977,7 @@ def _remap_batch_ownership_with_source_line_map(
             )
         new_claimed.add(new_line_num)
 
-    new_claimed_lines = []
-    if new_claimed:
-        new_claimed_lines = [format_line_ids(sorted(new_claimed))]
+    new_claimed_lines = _format_claimed_set(new_claimed)
 
     new_deletions = []
     for deletion in ownership.deletions:
@@ -817,7 +999,17 @@ def _remap_batch_ownership_with_source_line_map(
             content_lines=deletion.content_lines
         ))
 
-    return BatchOwnership(claimed_lines=new_claimed_lines, deletions=new_deletions)
+    new_replacement_units = _remap_replacement_units(
+        ownership.replacement_units,
+        map_claimed_line=source_line_map.get,
+        deletion_count=len(new_deletions),
+    )
+
+    return BatchOwnership(
+        claimed_lines=new_claimed_lines,
+        deletions=new_deletions,
+        replacement_units=new_replacement_units,
+    )
 
 
 def advance_batch_source_for_file(

--- a/src/git_stage_batch/batch/query.py
+++ b/src/git_stage_batch/batch/query.py
@@ -29,7 +29,8 @@ def read_batch_metadata(name: str) -> dict:
             "path": {
                 "batch_source_commit": str,  # Batch source SHA
                 "claimed_lines": list[str],  # e.g. ["1-5", "10", "15-20"]
-                "insertions": list[dict],  # [{"after_source_line": int|None, "blob": str}]
+                "deletions": list[dict],  # [{"after_source_line": int|None, "blob": str}]
+                "replacement_units": list[dict],  # optional claimed/deletion coupling
                 "mode": str  # File mode (e.g. "100644")
             }
         }

--- a/src/git_stage_batch/batch/replacement.py
+++ b/src/git_stage_batch/batch/replacement.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from ..core.line_selection import format_line_ids, parse_line_selection
-from .ownership import BatchOwnership, DeletionClaim
+from .ownership import BatchOwnership, DeletionClaim, ReplacementUnit
 
 
 def _format_claimed_lines(line_numbers: list[int]) -> list[str]:
@@ -71,6 +71,12 @@ def build_replacement_batch_view(
             BatchOwnership(
                 claimed_lines=_format_claimed_lines(new_claimed_lines),
                 deletions=new_deletions,
+                replacement_units=[
+                    ReplacementUnit(
+                        claimed_lines=_format_claimed_lines(new_claimed_lines),
+                        deletion_indices=list(range(len(new_deletions))),
+                    )
+                ] if new_claimed_lines and new_deletions else [],
             ),
         )
 
@@ -115,5 +121,11 @@ def build_replacement_batch_view(
         BatchOwnership(
             claimed_lines=_format_claimed_lines(new_claimed_lines),
             deletions=new_deletions,
+            replacement_units=[
+                ReplacementUnit(
+                    claimed_lines=_format_claimed_lines(new_claimed_lines),
+                    deletion_indices=list(range(len(new_deletions))),
+                )
+            ] if new_claimed_lines and new_deletions else [],
         ),
     )

--- a/src/git_stage_batch/batch/source_refresh.py
+++ b/src/git_stage_batch/batch/source_refresh.py
@@ -220,7 +220,12 @@ def _refresh_selected_lines_against_source_content(
     working_content: bytes,
     working_line_map: dict[int, int] | None = None,
 ) -> list:
-    """Re-annotate selected lines against a concrete source snapshot."""
+    """Re-annotate selected lines against a concrete source snapshot.
+
+    If a working-line provenance map is supplied, it describes how the source
+    content was synthesized and is treated as authoritative. Text matching is
+    used only when no provenance map is available.
+    """
     mapping = None
     if working_line_map is None:
         source_lines = source_content.splitlines(keepends=True)

--- a/src/git_stage_batch/batch/source_refresh.py
+++ b/src/git_stage_batch/batch/source_refresh.py
@@ -14,7 +14,7 @@ from ..data.batch_sources import load_session_batch_sources, save_session_batch_
 from .match import match_lines
 from .ownership import (
     BatchOwnership,
-    advance_batch_source_for_file,
+    advance_batch_source_for_file_with_provenance,
     detect_stale_batch_source_for_selection,
     merge_batch_ownership,
     translate_lines_to_batch_ownership,
@@ -101,12 +101,7 @@ def ensure_batch_source_current_for_selection(
 
     if is_stale and current_batch_source_commit and existing_ownership:
         # Batch source is stale - advance it and remap existing ownership
-        (
-            new_batch_source_commit,
-            remapped_ownership,
-            new_source_content,
-            working_content,
-        ) = advance_batch_source_for_file(
+        advance_result = advance_batch_source_for_file_with_provenance(
             batch_name=batch_name,
             file_path=file_path,
             old_batch_source_commit=current_batch_source_commit,
@@ -115,7 +110,7 @@ def ensure_batch_source_current_for_selection(
 
         # Update session cache so add_file_to_batch uses the new source.
         batch_sources = load_session_batch_sources()
-        batch_sources[file_path] = new_batch_source_commit
+        batch_sources[file_path] = advance_result.batch_source_commit
         save_session_batch_sources(batch_sources)
 
         # Re-annotate lines against the actual advanced source. The advanced
@@ -123,13 +118,14 @@ def ensure_batch_source_current_for_selection(
         # working tree after earlier discard operations.
         reannotated_lines = _refresh_selected_lines_against_source_content(
             selected_lines,
-            source_content=new_source_content,
-            working_content=working_content,
+            source_content=advance_result.source_content,
+            working_content=advance_result.working_content,
+            working_line_map=advance_result.working_line_map,
         )
 
         return RefreshedBatchSelection(
-            batch_source_commit=new_batch_source_commit,
-            ownership=remapped_ownership,
+            batch_source_commit=advance_result.batch_source_commit,
+            ownership=advance_result.ownership,
             selected_lines=reannotated_lines,
             source_was_advanced=True
         )
@@ -222,30 +218,35 @@ def _refresh_selected_lines_against_source_content(
     *,
     source_content: bytes,
     working_content: bytes,
+    working_line_map: dict[int, int] | None = None,
 ) -> list:
     """Re-annotate selected lines against a concrete source snapshot."""
-    source_lines = source_content.splitlines(keepends=True)
-    working_lines = working_content.splitlines(keepends=True)
-    mapping = match_lines(source_lines, working_lines)
+    mapping = None
+    if working_line_map is None:
+        source_lines = source_content.splitlines(keepends=True)
+        working_lines = working_content.splitlines(keepends=True)
+        mapping = match_lines(source_lines, working_lines)
+
+    def map_working_line(line_number: int | None) -> int | None:
+        if line_number is None:
+            return None
+        if working_line_map is not None:
+            return working_line_map.get(line_number)
+        assert mapping is not None
+        return mapping.get_source_line_from_target_line(line_number)
 
     last_source_line = None
     reannotated_lines = []
 
     for line in selected_lines:
         if line.kind in (' ', '+'):
-            source_line = None
-            if line.new_line_number is not None:
-                source_line = mapping.get_source_line_from_target_line(
-                    line.new_line_number
-                )
+            source_line = map_working_line(line.new_line_number)
             if source_line is not None:
                 last_source_line = source_line
         elif line.kind == '-':
             source_line = last_source_line
             if source_line is None and line.old_line_number is not None and line.old_line_number > 1:
-                source_line = mapping.get_source_line_from_target_line(
-                    line.old_line_number - 1
-                )
+                source_line = map_working_line(line.old_line_number - 1)
         else:
             source_line = None
 

--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -9,7 +9,7 @@ from ..batch import add_file_to_batch, create_batch
 from ..batch.display import annotate_with_batch_source, annotate_with_batch_source_content
 from ..batch.ownership import (
     BatchOwnership,
-    _advance_source_content_preserving_existing_presence,
+    _advance_source_content_preserving_existing_presence_with_provenance,
     _remap_batch_ownership_with_source_line_map,
     merge_batch_ownership,
     translate_lines_to_batch_ownership,
@@ -30,7 +30,6 @@ from ..data.hunk_tracking import (
     advance_to_and_show_next_change,
     advance_to_next_change,
     build_file_hunk_from_content,
-    cache_file_as_single_hunk,
     cache_unstaged_file_as_single_hunk,
     fetch_next_change,
     get_selected_change_file_path,
@@ -500,7 +499,7 @@ def command_discard_line_as_to_batch(
                 else:
                     target_file = file
 
-                cached_lines = _load_explicit_file_selection(target_file)
+                _load_explicit_file_selection(target_file)
 
             _command_discard_lines_to_batch_as(
                 batch_name,
@@ -600,25 +599,26 @@ def _command_discard_lines_to_batch_as(
                         )
                     )
 
-                new_source_content, source_line_map = _advance_source_content_preserving_existing_presence(
+                advanced_source = _advance_source_content_preserving_existing_presence_with_provenance(
                     old_source_content=old_source_result.stdout,
                     working_content=rewritten_working_content,
                     ownership=existing_ownership,
                 )
                 remapped_existing_ownership = _remap_batch_ownership_with_source_line_map(
                     ownership=existing_ownership,
-                    source_line_map=source_line_map,
+                    source_line_map=advanced_source.source_line_map,
                 )
                 refreshed_selected_lines = _refresh_selected_lines_against_source_content(
                     rewritten_selected_lines,
-                    source_content=new_source_content,
+                    source_content=advanced_source.content,
                     working_content=rewritten_working_content,
+                    working_line_map=advanced_source.working_line_map,
                 )
                 new_ownership = translate_lines_to_batch_ownership(refreshed_selected_lines)
                 ownership = merge_batch_ownership(remapped_existing_ownership, new_ownership)
                 batch_source_commit = create_batch_source_commit(
                     line_changes.path,
-                    file_content_override=new_source_content,
+                    file_content_override=advanced_source.content,
                 )
                 batch_sources = load_session_batch_sources()
                 batch_sources[line_changes.path] = batch_source_commit

--- a/src/git_stage_batch/commands/include_from.py
+++ b/src/git_stage_batch/commands/include_from.py
@@ -5,14 +5,9 @@ from __future__ import annotations
 import sys
 from typing import Optional
 
-from ..batch.display import build_display_lines_from_batch_source
 from ..batch.merge import merge_batch
 from ..batch.metadata_validation import read_validated_batch_metadata
 from ..batch.replacement import build_replacement_batch_view
-from ..batch.ownership import (
-    BatchOwnership,
-    DeletionClaim,
-)
 from ..batch.selection import (
     resolve_batch_file_scope,
     require_single_file_context_for_line_selection,
@@ -24,7 +19,6 @@ from ..data.hunk_tracking import render_batch_file_display
 from ..data.undo import undo_checkpoint
 from ..exceptions import exit_with_error, MergeError, CommandError, AtomicUnitError, BatchMetadataError
 from ..i18n import _
-from ..core.line_selection import format_line_ids
 from ..staging.operations import update_index_with_blob_content
 from ..utils.git import require_git_repository, run_git_command
 
@@ -37,44 +31,6 @@ def _require_contiguous_display_selection(selected_ids: set[int]) -> None:
     selected_range = list(range(min(selected_ids), max(selected_ids) + 1))
     if sorted(selected_ids) != selected_range:
         exit_with_error(_("Replacement selection must be one contiguous line range."))
-
-
-def _select_batch_replacement_ownership(
-    file_meta: dict,
-    batch_source_content: bytes,
-    selected_display_ids: set[int],
-) -> BatchOwnership:
-    """Select exactly the visible batch lines chosen for replacement text."""
-    ownership = BatchOwnership.from_metadata_dict(file_meta)
-    display_lines = build_display_lines_from_batch_source(
-        batch_source_content.decode("utf-8", errors="replace"),
-        ownership,
-    )
-    deletion_by_index = {
-        index: deletion
-        for index, deletion in enumerate(ownership.deletions)
-    }
-    selected_claimed_lines: list[int] = []
-    selected_deletions: list[DeletionClaim] = []
-    seen_deletion_indexes: set[int] = set()
-
-    for display_line in display_lines:
-        display_id = display_line.get("id")
-        if display_id not in selected_display_ids:
-            continue
-
-        if display_line["type"] == "claimed":
-            selected_claimed_lines.append(display_line["source_line"])
-        elif display_line["type"] == "deletion":
-            deletion_index = display_line["deletion_index"]
-            if deletion_index not in seen_deletion_indexes:
-                selected_deletions.append(deletion_by_index[deletion_index])
-                seen_deletion_indexes.add(deletion_index)
-
-    return BatchOwnership(
-        claimed_lines=[format_line_ids(selected_claimed_lines)] if selected_claimed_lines else [],
-        deletions=selected_deletions,
-    )
 
 
 def command_include_from_batch(
@@ -179,16 +135,9 @@ def command_include_from_batch(
 
                 # Get ownership from metadata, filtered by selected selection IDs if specified
                 try:
-                    if replacement_text is not None and selection_ids_to_include is not None:
-                        ownership = _select_batch_replacement_ownership(
-                            file_meta,
-                            batch_source_content,
-                            selection_ids_to_include,
-                        )
-                    else:
-                        ownership = select_batch_ownership_for_display_ids(
-                            file_meta, batch_source_content, selection_ids_to_include
-                        )
+                    ownership = select_batch_ownership_for_display_ids(
+                        file_meta, batch_source_content, selection_ids_to_include
+                    )
                 except AtomicUnitError as e:
                     # Translate selection IDs to gutter IDs and exit with user-friendly error
                     if rendered:

--- a/src/git_stage_batch/data/consumed_selections.py
+++ b/src/git_stage_batch/data/consumed_selections.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from ..batch.ownership import (
     BatchOwnership,
-    advance_batch_source_for_file,
+    advance_batch_source_for_file_with_provenance,
     detect_stale_batch_source_for_selection,
     merge_batch_ownership,
     translate_lines_to_batch_ownership,
@@ -61,21 +61,19 @@ def record_consumed_selection(
         existing_ownership = BatchOwnership.from_metadata_dict(existing_file_metadata)
         batch_source_commit = existing_file_metadata["batch_source_commit"]
         if detect_stale_batch_source_for_selection(selected_lines):
-            (
-                batch_source_commit,
-                existing_ownership,
-                refreshed_source_content,
-                working_content,
-            ) = advance_batch_source_for_file(
+            advance_result = advance_batch_source_for_file_with_provenance(
                 batch_name="consumed-selections",
                 file_path=file_path,
                 old_batch_source_commit=batch_source_commit,
                 existing_ownership=existing_ownership,
             )
+            batch_source_commit = advance_result.batch_source_commit
+            existing_ownership = advance_result.ownership
             selected_lines = _refresh_selected_lines_against_source_content(
                 selected_lines,
-                source_content=refreshed_source_content,
-                working_content=working_content,
+                source_content=advance_result.source_content,
+                working_content=advance_result.working_content,
+                working_line_map=advance_result.working_line_map,
             )
         new_ownership = translate_lines_to_batch_ownership(selected_lines)
         merged_ownership = merge_batch_ownership(existing_ownership, new_ownership)

--- a/tests/batch/test_ownership_incremental.py
+++ b/tests/batch/test_ownership_incremental.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
-from git_stage_batch.batch.ownership import translate_lines_to_batch_ownership, DeletionClaim
+from git_stage_batch.batch.ownership import (
+    DeletionClaim,
+    ReplacementUnit,
+    translate_lines_to_batch_ownership,
+)
 from git_stage_batch.core.models import LineEntry
 
 
@@ -24,6 +28,29 @@ def test_translate_lines_creates_deletion_constraints():
     assert len(ownership.deletions) == 1
     assert isinstance(ownership.deletions[0], DeletionClaim)
     assert ownership.deletions[0].content_lines == [b'old_version\n']
+    assert len(ownership.replacement_units) == 1
+    assert ownership.replacement_units[0].claimed_lines == ["1"]
+    assert ownership.replacement_units[0].deletion_indices == [0]
+
+
+def test_translate_lines_records_multi_line_replacement_unit():
+    """Captured multi-line replacements should remain one atomic unit."""
+    lines = [
+        LineEntry(id=1, kind='-', old_line_number=1, new_line_number=None,
+                  text_bytes=b'old one', text='old one', source_line=None),
+        LineEntry(id=2, kind='-', old_line_number=2, new_line_number=None,
+                  text_bytes=b'old two', text='old two', source_line=None),
+        LineEntry(id=3, kind='+', old_line_number=None, new_line_number=1,
+                  text_bytes=b'new one', text='new one', source_line=1),
+        LineEntry(id=4, kind='+', old_line_number=None, new_line_number=2,
+                  text_bytes=b'new two', text='new two', source_line=2),
+    ]
+
+    ownership = translate_lines_to_batch_ownership(lines)
+
+    assert ownership.replacement_units == [
+        ReplacementUnit(claimed_lines=["1-2"], deletion_indices=[0]),
+    ]
 
 
 def test_translate_lines_preserves_deletion_structure():
@@ -50,3 +77,4 @@ def test_translate_lines_preserves_deletion_structure():
     assert ownership.deletions[0].anchor_line is None  # before any source line
     assert ownership.deletions[1].content_lines == [b'del3\n']
     assert ownership.deletions[1].anchor_line == 1  # after source line 1
+    assert ownership.replacement_units == []

--- a/tests/batch/test_ownership_unit_grouping.py
+++ b/tests/batch/test_ownership_unit_grouping.py
@@ -1,7 +1,8 @@
-"""Tests for ownership unit grouping based on display adjacency.
+"""Tests for ownership unit grouping based on replacement metadata and display.
 
-These tests verify that replacement units are formed based on adjacency
-in reconstructed display order, not source-line proximity.
+These tests verify that explicit replacement metadata is honored first, and
+remaining replacement units are formed based on adjacency in reconstructed
+display order, not source-line proximity.
 """
 
 from __future__ import annotations
@@ -12,6 +13,8 @@ from git_stage_batch.batch.ownership import (
     DeletionClaim,
     build_ownership_units_from_display,
     OwnershipUnitKind,
+    ReplacementUnit,
+    rebuild_ownership_from_units,
 )
 from git_stage_batch.batch.display import build_display_lines_from_batch_source
 
@@ -366,9 +369,10 @@ def test_multiple_presence_only_lines_remain_independently_selectable():
 
 
 def test_multiple_consecutive_deletions_and_claims_form_single_replacement():
-    """Test that deletion block couples with first claimed line, rest are separate.
+    """Test legacy display-adjacency fallback for replacement grouping.
 
-    This preserves fine-grained reset: each claimed line can be independently reset.
+    Without persisted replacement metadata, a deletion block couples with the
+    first claimed line and the remaining claimed lines stay independent.
     """
     # Source content:
     # 1: old line 1
@@ -418,3 +422,154 @@ def test_multiple_consecutive_deletions_and_claims_form_single_replacement():
     # Second claimed line is PRESENCE_ONLY (independently selectable)
     assert presence_units[0].claimed_source_lines == {2}
     assert presence_units[0].is_atomic is False
+
+
+def test_rebuild_does_not_promote_display_adjacency_to_explicit_metadata():
+    """Inferred display adjacency should not become persisted replacement intent."""
+    batch_source = b"new line\n"
+    ownership = BatchOwnership(
+        claimed_lines=["1"],
+        deletions=[
+            DeletionClaim(anchor_line=None, content_lines=[b"old line\n"])
+        ],
+    )
+
+    rebuilt = rebuild_ownership_from_units(
+        build_ownership_units_from_display(ownership, batch_source)
+    )
+
+    assert rebuilt.claimed_lines == ["1"]
+    assert len(rebuilt.deletions) == 1
+    assert rebuilt.replacement_units == []
+
+
+def test_explicit_replacement_unit_overrides_display_adjacency():
+    """Persisted replacement metadata should couple non-adjacent display lines."""
+    batch_source = b"new first\ncontext\nanchor\n"
+    ownership = BatchOwnership(
+        claimed_lines=["1"],
+        deletions=[
+            DeletionClaim(anchor_line=3, content_lines=[b"old later\n"]),
+        ],
+        replacement_units=[
+            ReplacementUnit(claimed_lines=["1"], deletion_indices=[0]),
+        ],
+    )
+
+    units = build_ownership_units_from_display(ownership, batch_source)
+
+    assert len(units) == 1
+    assert units[0].kind == OwnershipUnitKind.REPLACEMENT
+    assert units[0].atomic_reason == "explicit_replacement"
+    assert units[0].preserves_replacement_unit is True
+    assert units[0].claimed_source_lines == {1}
+    assert units[0].deletion_claims == ownership.deletions
+
+
+def test_explicit_replacement_unit_can_group_multiple_claimed_lines():
+    """Explicit metadata can preserve a whole multi-line replacement unit."""
+    batch_source = b"new one\nnew two\nkeep\n"
+    ownership = BatchOwnership(
+        claimed_lines=["1-2"],
+        deletions=[
+            DeletionClaim(anchor_line=None, content_lines=[b"old one\n", b"old two\n"]),
+        ],
+        replacement_units=[
+            ReplacementUnit(claimed_lines=["1-2"], deletion_indices=[0]),
+        ],
+    )
+
+    units = build_ownership_units_from_display(ownership, batch_source)
+
+    assert len(units) == 1
+    assert units[0].kind == OwnershipUnitKind.REPLACEMENT
+    assert units[0].claimed_source_lines == {1, 2}
+    assert units[0].display_line_ids == {1, 2, 3, 4}
+
+
+def test_rebuild_preserves_explicit_replacement_units():
+    """Filtering/rebuilding ownership should persist replacement couplings."""
+    batch_source = b"new one\nnew two\nkeep\n"
+    ownership = BatchOwnership(
+        claimed_lines=["1-2"],
+        deletions=[
+            DeletionClaim(anchor_line=None, content_lines=[b"old one\n", b"old two\n"]),
+        ],
+        replacement_units=[
+            ReplacementUnit(claimed_lines=["1-2"], deletion_indices=[0]),
+        ],
+    )
+
+    rebuilt = rebuild_ownership_from_units(
+        build_ownership_units_from_display(ownership, batch_source)
+    )
+
+    assert rebuilt.claimed_lines == ["1-2"]
+    assert len(rebuilt.deletions) == 1
+    assert rebuilt.replacement_units == [
+        ReplacementUnit(claimed_lines=["1-2"], deletion_indices=[0]),
+    ]
+
+
+def test_rebuild_preserves_mixed_same_anchor_deletion_order():
+    """Same-anchor explicit and inferred deletions should keep stable indexes."""
+    batch_source = b"new explicit\nnew inferred\nkeep\n"
+    explicit_deletion = DeletionClaim(
+        anchor_line=None,
+        content_lines=[b"old explicit\n"],
+    )
+    inferred_deletion = DeletionClaim(
+        anchor_line=None,
+        content_lines=[b"old inferred\n"],
+    )
+    ownership = BatchOwnership(
+        claimed_lines=["1-2"],
+        deletions=[
+            explicit_deletion,
+            inferred_deletion,
+        ],
+        replacement_units=[
+            ReplacementUnit(claimed_lines=["1"], deletion_indices=[0]),
+        ],
+    )
+
+    rebuilt = rebuild_ownership_from_units(
+        build_ownership_units_from_display(ownership, batch_source)
+    )
+
+    assert rebuilt.deletions == [explicit_deletion, inferred_deletion]
+    assert rebuilt.replacement_units == [
+        ReplacementUnit(claimed_lines=["1"], deletion_indices=[0]),
+    ]
+
+
+def test_rebuild_preserves_mixed_same_anchor_order_when_explicit_is_later():
+    """Later explicit replacements should not reorder earlier inferred deletions."""
+    batch_source = b"new explicit\nkeep\n"
+    inferred_deletion = DeletionClaim(
+        anchor_line=None,
+        content_lines=[b"old inferred\n"],
+    )
+    explicit_deletion = DeletionClaim(
+        anchor_line=None,
+        content_lines=[b"old explicit\n"],
+    )
+    ownership = BatchOwnership(
+        claimed_lines=["1"],
+        deletions=[
+            inferred_deletion,
+            explicit_deletion,
+        ],
+        replacement_units=[
+            ReplacementUnit(claimed_lines=["1"], deletion_indices=[1]),
+        ],
+    )
+
+    rebuilt = rebuild_ownership_from_units(
+        build_ownership_units_from_display(ownership, batch_source)
+    )
+
+    assert rebuilt.deletions == [inferred_deletion, explicit_deletion]
+    assert rebuilt.replacement_units == [
+        ReplacementUnit(claimed_lines=["1"], deletion_indices=[1]),
+    ]

--- a/tests/batch/test_source_refresh.py
+++ b/tests/batch/test_source_refresh.py
@@ -13,10 +13,14 @@ from git_stage_batch.commands import include, discard
 from git_stage_batch.batch.source_refresh import (
     RefreshedBatchSelection,
     PreparedBatchUpdate,
+    _refresh_selected_lines_against_source_content,
     ensure_batch_source_current_for_selection,
     prepare_batch_ownership_update_for_selection,
 )
-from git_stage_batch.batch.ownership import BatchOwnership
+from git_stage_batch.batch.ownership import (
+    BatchOwnership,
+    _advance_source_content_preserving_existing_presence_with_provenance,
+)
 from git_stage_batch.core.models import LineEntry
 
 
@@ -186,6 +190,35 @@ def test_prepare_batch_ownership_update_with_existing():
     assert result.ownership_after is not None
     # Should merge 1-2 with 3-4
     assert "1-4" in ",".join(result.ownership_after.claimed_lines)
+
+
+def test_refresh_selected_lines_uses_synthesized_working_line_provenance():
+    """Repeated working lines should use known synthesis identity."""
+    ownership = BatchOwnership(claimed_lines=["1,4"], deletions=[])
+    advanced = _advance_source_content_preserving_existing_presence_with_provenance(
+        old_source_content=b"owned before\nsame\nsame\nowned after\n",
+        working_content=b"same\nsame\n",
+        ownership=ownership,
+    )
+    selected_lines = [
+        LineEntry(
+            id=1, kind='+', old_line_number=None, new_line_number=1,
+            text_bytes=b"same", text="same", source_line=None
+        ),
+        LineEntry(
+            id=2, kind='+', old_line_number=None, new_line_number=2,
+            text_bytes=b"same", text="same", source_line=None
+        ),
+    ]
+
+    refreshed = _refresh_selected_lines_against_source_content(
+        selected_lines,
+        source_content=advanced.content,
+        working_content=b"same\nsame\n",
+        working_line_map=advanced.working_line_map,
+    )
+
+    assert [line.source_line for line in refreshed] == [3, 4]
 
 
 def test_both_commands_use_same_helper_interface():

--- a/tests/batch/test_stale_source_advancement.py
+++ b/tests/batch/test_stale_source_advancement.py
@@ -7,9 +7,11 @@ import pytest
 from git_stage_batch.batch.ownership import (
     BatchOwnership,
     DeletionClaim,
+    ReplacementUnit,
     _advance_source_content_preserving_existing_presence,
     _remap_batch_ownership_with_source_line_map,
     detect_stale_batch_source_for_selection,
+    merge_batch_ownership,
     remap_batch_ownership_to_new_source,
     translate_lines_to_batch_ownership,
 )
@@ -212,6 +214,84 @@ def test_remap_preserves_deletion_content():
 
     # Content should be preserved exactly
     assert new_ownership.deletions[0].content_lines == deletion_content
+
+
+def test_remap_preserves_explicit_replacement_units():
+    """Replacement metadata should follow claimed-line source remapping."""
+    old_source = b"new value\nanchor\n"
+    new_source = b"prefix\nnew value\nanchor\n"
+
+    old_ownership = BatchOwnership(
+        claimed_lines=["1"],
+        deletions=[
+            DeletionClaim(anchor_line=2, content_lines=[b"old value\n"]),
+        ],
+        replacement_units=[
+            ReplacementUnit(claimed_lines=["1"], deletion_indices=[0]),
+        ],
+    )
+
+    new_ownership = remap_batch_ownership_to_new_source(
+        ownership=old_ownership,
+        old_source_content=old_source,
+        new_source_content=new_source,
+    )
+
+    assert new_ownership.claimed_lines == ["2"]
+    assert new_ownership.deletions[0].anchor_line == 3
+    assert new_ownership.replacement_units == [
+        ReplacementUnit(claimed_lines=["2"], deletion_indices=[0]),
+    ]
+
+
+def test_merge_coalesces_overlapping_replacement_units_after_deduplication():
+    """Deduplicated deletion claims should keep replacement metadata disjoint."""
+    deletion = DeletionClaim(anchor_line=None, content_lines=[b"old value\n"])
+    existing = BatchOwnership(
+        claimed_lines=["1"],
+        deletions=[deletion],
+        replacement_units=[
+            ReplacementUnit(claimed_lines=["1"], deletion_indices=[0]),
+        ],
+    )
+    new = BatchOwnership(
+        claimed_lines=["2"],
+        deletions=[
+            DeletionClaim(anchor_line=None, content_lines=[b"old value\n"]),
+        ],
+        replacement_units=[
+            ReplacementUnit(claimed_lines=["2"], deletion_indices=[0]),
+        ],
+    )
+
+    merged = merge_batch_ownership(existing, new)
+
+    assert merged.claimed_lines == ["1-2"]
+    assert merged.deletions == [deletion]
+    assert merged.replacement_units == [
+        ReplacementUnit(claimed_lines=["1-2"], deletion_indices=[0]),
+    ]
+
+
+def test_merge_ignores_boolean_replacement_unit_deletion_indices():
+    """JSON booleans should not be accepted as deletion indexes."""
+    new = BatchOwnership(
+        claimed_lines=["1"],
+        deletions=[
+            DeletionClaim(anchor_line=None, content_lines=[b"old one\n"]),
+            DeletionClaim(anchor_line=None, content_lines=[b"old two\n"]),
+        ],
+        replacement_units=[
+            ReplacementUnit(claimed_lines=["1"], deletion_indices=[True]),
+        ],
+    )
+
+    merged = merge_batch_ownership(
+        BatchOwnership(claimed_lines=[], deletions=[]),
+        new,
+    )
+
+    assert merged.replacement_units == []
 
 
 def test_advance_source_preserves_claimed_lines_missing_from_working_tree():

--- a/tests/batch/test_stale_source_advancement.py
+++ b/tests/batch/test_stale_source_advancement.py
@@ -9,6 +9,7 @@ from git_stage_batch.batch.ownership import (
     DeletionClaim,
     ReplacementUnit,
     _advance_source_content_preserving_existing_presence,
+    _advance_source_content_preserving_existing_presence_with_provenance,
     _remap_batch_ownership_with_source_line_map,
     detect_stale_batch_source_for_selection,
     merge_batch_ownership,
@@ -315,3 +316,29 @@ def test_advance_source_preserves_claimed_lines_missing_from_working_tree():
 
     assert new_source == b"owned one\nowned two\nremaining change\nnew later change\n"
     assert remapped.claimed_lines == ["1-2"]
+
+
+def test_advance_source_tracks_working_line_provenance_for_ambiguous_duplicates():
+    """Synthesized source should remember working-line identity."""
+    old_source = b"owned before\nsame\nsame\nowned after\n"
+    working_tree = b"same\nsame\n"
+    ownership = BatchOwnership(
+        claimed_lines=["1,4"],
+        deletions=[],
+    )
+
+    advanced = _advance_source_content_preserving_existing_presence_with_provenance(
+        old_source_content=old_source,
+        working_content=working_tree,
+        ownership=ownership,
+    )
+
+    assert advanced.content == b"owned before\nowned after\nsame\nsame\n"
+    assert advanced.source_line_map == {
+        1: 1,
+        4: 2,
+    }
+    assert advanced.working_line_map == {
+        1: 3,
+        2: 4,
+    }

--- a/tests/batch/test_storage.py
+++ b/tests/batch/test_storage.py
@@ -7,8 +7,9 @@ import subprocess
 import pytest
 
 from git_stage_batch.batch.operations import create_batch
+from git_stage_batch.batch.query import read_batch_metadata
 from git_stage_batch.batch.storage import add_file_to_batch, get_batch_diff, read_file_from_batch
-from git_stage_batch.batch.ownership import BatchOwnership
+from git_stage_batch.batch.ownership import BatchOwnership, DeletionClaim, ReplacementUnit
 from git_stage_batch.data.session import initialize_abort_state
 
 
@@ -58,6 +59,62 @@ def test_add_file_to_batch_existing_batch(temp_git_repo):
     content = read_file_from_batch("test-batch", "file.txt")
     assert content is not None
     assert "line1" in content
+
+
+def test_add_file_to_batch_persists_replacement_units(temp_git_repo):
+    """Text metadata should round-trip explicit replacement-unit references."""
+    create_batch("test-batch", "Test")
+
+    ownership = BatchOwnership(
+        claimed_lines=["1"],
+        deletions=[
+            DeletionClaim(anchor_line=None, content_lines=[b"old\n"]),
+        ],
+        replacement_units=[
+            ReplacementUnit(claimed_lines=["1"], deletion_indices=[0]),
+        ],
+    )
+
+    add_file_to_batch("test-batch", "file.txt", ownership)
+
+    file_meta = read_batch_metadata("test-batch")["files"]["file.txt"]
+    assert file_meta["replacement_units"] == [
+        {"claimed_lines": ["1"], "deletion_indices": [0]},
+    ]
+
+    round_tripped = BatchOwnership.from_metadata_dict(file_meta)
+    assert round_tripped.replacement_units == [
+        ReplacementUnit(claimed_lines=["1"], deletion_indices=[0]),
+    ]
+
+
+def test_empty_replacement_units_are_omitted_from_metadata():
+    """Empty replacement-unit references should not serialize an empty key."""
+    ownership = BatchOwnership(
+        claimed_lines=[],
+        deletions=[],
+        replacement_units=[
+            ReplacementUnit(claimed_lines=[], deletion_indices=[]),
+        ],
+    )
+
+    assert "replacement_units" not in ownership.to_metadata_dict()
+
+
+def test_boolean_replacement_unit_indices_are_omitted_from_metadata(temp_git_repo):
+    """JSON booleans should not serialize as replacement deletion indexes."""
+    ownership = BatchOwnership(
+        claimed_lines=["1"],
+        deletions=[
+            DeletionClaim(anchor_line=None, content_lines=[b"old one\n"]),
+            DeletionClaim(anchor_line=None, content_lines=[b"old two\n"]),
+        ],
+        replacement_units=[
+            ReplacementUnit(claimed_lines=["1"], deletion_indices=[True]),
+        ],
+    )
+
+    assert "replacement_units" not in ownership.to_metadata_dict()
 
 
 def test_add_file_to_batch_update_file(temp_git_repo):

--- a/tests/commands/test_include_from.py
+++ b/tests/commands/test_include_from.py
@@ -204,3 +204,35 @@ class TestCommandIncludeFromBatch:
 
         result = run_git_command(["show", ":test.txt"])
         assert result.stdout == "keep\nedited value\n"
+
+    def test_include_from_batch_as_rejects_partial_replacement_unit(self, temp_git_repo):
+        """Test include --from --line --as honors explicit replacement atomicity."""
+        test_file = temp_git_repo / "test.txt"
+        test_file.write_text("old one\nold two\nkeep\n")
+        subprocess.run(["git", "add", "test.txt"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add file"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        test_file.write_text("new one\nnew two\nkeep\n")
+        command_start()
+        command_include_to_batch("test-batch", quiet=True)
+
+        test_file.write_text("old one\nold two\nkeep\n")
+        run_git_command(["reset", "HEAD", "test.txt"], check=False)
+
+        rendered = render_batch_file_display("test-batch", "test.txt")
+        new_one_gutter = next(
+            rendered.selection_id_to_gutter[line.id]
+            for line in rendered.line_changes.lines
+            if line.id is not None and line.text == "new one"
+        )
+
+        with pytest.raises(CommandError, match="must be selected together"):
+            command_include_from_batch(
+                "test-batch",
+                line_ids=str(new_one_gutter),
+                file="test.txt",
+                replacement_text="edited value",
+            )
+
+        result = run_git_command(["show", ":test.txt"])
+        assert result.stdout == "old one\nold two\nkeep\n"

--- a/tests/functional/test_batch_operations.py
+++ b/tests/functional/test_batch_operations.py
@@ -195,8 +195,9 @@ class TestApplyFromBatch:
     def test_apply_from_batch_with_line_selection(self, repo_with_changes):
         """Test applying specific lines from a batch.
 
-        Note: Lines 1,2,3 form an atomic replacement unit (deletion + coupled additions),
-        so we select all three to respect the semantic boundary.
+        Note: Lines 1,2,3,4 form an explicit atomic replacement unit
+        (deletion + coupled additions), so we select all four to respect the
+        semantic boundary.
         """
         git_stage_batch("new", "test-batch")
         git_stage_batch("start")
@@ -205,8 +206,8 @@ class TestApplyFromBatch:
         subprocess.run(["git", "restore", "."], check=True, capture_output=True)
 
         # Apply only specific lines (must respect atomic unit boundaries)
-        # Lines 1,2,3 form one atomic replacement unit
-        result = git_stage_batch("apply", "--from", "test-batch", "--line", "1,2,3")
+        # Lines 1,2,3,4 form one explicit atomic replacement unit
+        result = git_stage_batch("apply", "--from", "test-batch", "--line", "1,2,3,4")
         assert result.returncode == 0
 
         unstaged = get_unstaged_diff()


### PR DESCRIPTION
Line-level batch operations can already save selected changes and replay or reset
them later through batch ownership over claimed lines and deletion constraints.

Users can see surprising behavior after a replacement is captured, because later
operations may reconstruct the replacement boundary from display adjacency rather
than from the original capture. Stale-source refresh can also refuse or misplace
a later selection when synthesized source content contains repeated lines whose
identity cannot be rediscovered from text alone.

This PR addresses those cases by preserving more known identity. Replacement
captures now persist explicit coupling between claimed lines and deletion claims,
and stale-source advancement now carries old-source and working-tree provenance
maps so selection refresh can use constructed line identity before falling back to
text matching.

## User Impact

Users should see more stable line-level `apply --from`, `reset --from`, and
`discard --from` behavior after saving replacements into batches, especially
when later edits or repeated lines make display adjacency or text matching
ambiguous.

Some partial selections are now rejected more intentionally: when a replacement
was captured as one atomic unit, later line-level operations must select the full
unit boundary instead of applying only one side of the replacement.