### PR TITLE
utils: Route subprocess and tree building through shared spawn-safe layers

### DIFF
--- a/src/git_stage_batch/batch/state_refs.py
+++ b/src/git_stage_batch/batch/state_refs.py
@@ -3,16 +3,21 @@
 from __future__ import annotations
 
 import json
-import os
 import shutil
-import subprocess
-import tempfile
 from typing import Any
 
 from .ref_names import BATCH_CONTENT_REF_PREFIX, BATCH_STATE_REF_PREFIX, LEGACY_BATCH_REF_PREFIX
 from .validation import validate_batch_name
 from ..utils.file_io import read_text_file_contents
-from ..utils.git import create_git_blob, run_git_command, update_git_refs
+from ..utils.git import (
+    create_git_blob,
+    git_commit_tree,
+    git_update_index,
+    git_write_tree,
+    run_git_command,
+    temp_git_index,
+    update_git_refs,
+)
 from ..utils.paths import get_batch_metadata_file_path
 
 
@@ -131,15 +136,7 @@ def sync_batch_state_refs(batch_name: str, *, content_commit: str | None = None)
         "files": {},
     }
 
-    temp_index = tempfile.NamedTemporaryFile(delete=False, suffix=".index")
-    temp_index_path = temp_index.name
-    temp_index.close()
-    os.unlink(temp_index_path)
-
-    env = os.environ.copy()
-    env["GIT_INDEX_FILE"] = temp_index_path
-
-    try:
+    with temp_git_index() as env:
         for file_path, file_meta in metadata.get("files", {}).items():
             state_file_meta = dict(file_meta)
 
@@ -153,17 +150,11 @@ def sync_batch_state_refs(batch_name: str, *, content_commit: str | None = None)
                 if source_result.returncode == 0:
                     source_blob = create_git_blob([source_result.stdout])
                     source_path = f"sources/{file_path}"
-                    subprocess.run(
-                        [
-                            "git",
-                            "update-index",
-                            "--add",
-                            "--cacheinfo",
-                            f"{file_meta.get('mode', '100644')},{source_blob},{source_path}",
-                        ],
+                    git_update_index(
+                        mode=file_meta.get("mode", "100644"),
+                        blob_sha=source_blob,
+                        file_path=source_path,
                         env=env,
-                        capture_output=True,
-                        check=True,
                     )
                     state_file_meta["source_path"] = source_path
 
@@ -171,52 +162,34 @@ def sync_batch_state_refs(batch_name: str, *, content_commit: str | None = None)
 
         state_json = json.dumps(state_metadata, indent=2).encode("utf-8")
         state_blob = create_git_blob([state_json])
-        subprocess.run(
-            [
-                "git",
-                "update-index",
-                "--add",
-                "--cacheinfo",
-                f"100644,{state_blob},batch.json",
-            ],
+        git_update_index(
+            mode="100644",
+            blob_sha=state_blob,
+            file_path="batch.json",
             env=env,
-            capture_output=True,
-            check=True,
         )
 
-        tree_result = subprocess.run(
-            ["git", "write-tree"],
-            env=env,
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        tree_sha = tree_result.stdout.strip()
+        tree_sha = git_write_tree(env=env)
 
-        existing_state = run_git_command(
-            ["rev-parse", "--verify", get_batch_state_ref_name(batch_name)],
-            check=False,
-        )
-        parent_args: list[str] = []
-        if existing_state.returncode == 0 and existing_state.stdout.strip():
-            parent_args = ["-p", existing_state.stdout.strip()]
+    existing_state = run_git_command(
+        ["rev-parse", "--verify", get_batch_state_ref_name(batch_name)],
+        check=False,
+    )
+    parents = []
+    if existing_state.returncode == 0 and existing_state.stdout.strip():
+        parents.append(existing_state.stdout.strip())
 
-        commit_result = subprocess.run(
-            ["git", "commit-tree", tree_sha, *parent_args, "-m", f"Batch state: {batch_name}"],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        state_commit = commit_result.stdout.strip()
+    state_commit = git_commit_tree(
+        tree_sha,
+        parents=parents,
+        message=f"Batch state: {batch_name}",
+    )
 
-        update_git_refs(
-            updates=[
-                (get_batch_content_ref_name(batch_name), content_commit),
-                (get_batch_state_ref_name(batch_name), state_commit),
-            ],
-            deletes=[get_legacy_batch_ref_name(batch_name)],
-        )
-        remove_file_backed_batch_metadata(batch_name)
-    finally:
-        if os.path.exists(temp_index_path):
-            os.unlink(temp_index_path)
+    update_git_refs(
+        updates=[
+            (get_batch_content_ref_name(batch_name), content_commit),
+            (get_batch_state_ref_name(batch_name), state_commit),
+        ],
+        deletes=[get_legacy_batch_ref_name(batch_name)],
+    )
+    remove_file_backed_batch_metadata(batch_name)

--- a/src/git_stage_batch/batch/storage.py
+++ b/src/git_stage_batch/batch/storage.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 import json
-import os
-import subprocess
 from copy import deepcopy
 from typing import TYPE_CHECKING, Optional
 
@@ -21,8 +19,16 @@ from ..data.batch_sources import (
     save_session_batch_sources,
 )
 from ..utils.file_io import write_text_file_contents
-from ..utils.git import create_git_blob, run_git_command
-from ..utils.paths import get_batch_metadata_file_path, get_state_directory_path
+from ..utils.git import (
+    create_git_blob,
+    git_commit_tree,
+    git_read_tree,
+    git_update_index,
+    git_write_tree,
+    run_git_command,
+    temp_git_index,
+)
+from ..utils.paths import get_batch_metadata_file_path
 from .merge import _satisfy_constraints
 
 if TYPE_CHECKING:
@@ -379,6 +385,23 @@ def copy_file_from_batch_to_batch(source_batch: str, dest_batch: str, file_path:
         _remove_file_from_batch_commit(dest_batch, file_path)
 
 
+def _batch_commit_parents(batch_name: str) -> list[str]:
+    """Return parent commits for a batch content commit."""
+    parents = []
+    baseline = get_batch_baseline_commit(batch_name)
+    if baseline:
+        parents.append(baseline)
+
+    metadata = read_file_backed_batch_metadata(batch_name)
+    batch_source_commits = {
+        file_meta["batch_source_commit"]
+        for file_meta in metadata.get("files", {}).values()
+        if "batch_source_commit" in file_meta
+    }
+    parents.extend(sorted(batch_source_commits))
+    return parents
+
+
 def _remove_file_from_batch_commit(batch_name: str, file_path: str) -> None:
     """Remove a file from batch commit tree (for deletions).
 
@@ -389,87 +412,26 @@ def _remove_file_from_batch_commit(batch_name: str, file_path: str) -> None:
         batch_name: Name of the batch
         file_path: Repository-relative path to the file to remove
     """
-    # Create temporary index
-    temp_index_path = get_state_directory_path() / f".batch_index_{batch_name}"
-    env = os.environ.copy()
-    env["GIT_INDEX_FILE"] = str(temp_index_path)
-
-    try:
-        # Load existing batch tree if exists
+    with temp_git_index() as env:
         existing_commit = get_batch_commit_sha(batch_name)
         if existing_commit:
-            subprocess.run(
-                ["git", "read-tree", existing_commit],
-                env=env,
-                check=True,
-                capture_output=True
-            )
+            git_read_tree(existing_commit, env=env)
 
         # Remove file from the temporary index regardless of the working tree.
         # `--remove` consults worktree state and can leave a baseline blob in
         # the batch tree when the file exists locally; stored deletions need the
         # path absent from the batch commit unconditionally.
-        subprocess.run(
-            ["git", "update-index", "--force-remove", "--", file_path],
-            env=env,
-            check=False,  # Don't fail if file not in index
-            capture_output=True
-        )
+        git_update_index(file_path=file_path, force_remove=True, check=False, env=env)
+        tree_sha = git_write_tree(env=env)
 
-        # Write tree
-        tree_result = subprocess.run(
-            ["git", "write-tree"],
-            env=env,
-            check=True,
-            capture_output=True,
-            text=True
-        )
-        tree_sha = tree_result.stdout.strip()
+    commit_sha = git_commit_tree(
+        tree_sha,
+        parents=_batch_commit_parents(batch_name),
+        message=f"Batch: {batch_name}",
+    )
 
-        # Collect parent commits: baseline + batch sources
-        baseline = get_batch_baseline_commit(batch_name)
-        metadata = read_file_backed_batch_metadata(batch_name)
-
-        parents = []
-        if baseline:
-            parents.append(baseline)
-
-        # Add batch source commits as parents
-        batch_source_commits = set()
-        for file_meta in metadata.get("files", {}).values():
-            if "batch_source_commit" in file_meta:
-                batch_source_commits.add(file_meta["batch_source_commit"])
-
-        parents.extend(sorted(batch_source_commits))
-
-        # Create commit with multi-parent
-        parent_args = []
-        for parent in parents:
-            parent_args.extend(["-p", parent])
-
-        if parent_args:
-            commit_result = subprocess.run(
-                ["git", "commit-tree", tree_sha] + parent_args + ["-m", f"Batch: {batch_name}"],
-                capture_output=True,
-                text=True,
-                check=True
-            )
-        else:
-            commit_result = subprocess.run(
-                ["git", "commit-tree", tree_sha, "-m", f"Batch: {batch_name}"],
-                capture_output=True,
-                text=True,
-                check=True
-            )
-
-        commit_sha = commit_result.stdout.strip()
-
-        from .state_refs import sync_batch_state_refs
-        sync_batch_state_refs(batch_name, content_commit=commit_sha)
-
-    finally:
-        if temp_index_path.exists():
-            temp_index_path.unlink(missing_ok=True)
+    from .state_refs import sync_batch_state_refs
+    sync_batch_state_refs(batch_name, content_commit=commit_sha)
 
 
 def _update_batch_commit(batch_name: str, file_path: str, blob_sha: str, file_mode: str) -> None:
@@ -483,84 +445,22 @@ def _update_batch_commit(batch_name: str, file_path: str, blob_sha: str, file_mo
         blob_sha: Blob SHA for the file content
         file_mode: File mode
     """
-    # Create temporary index
-    temp_index_path = get_state_directory_path() / f".batch_index_{batch_name}"
-    env = os.environ.copy()
-    env["GIT_INDEX_FILE"] = str(temp_index_path)
-
-    try:
-        # Load existing batch tree if exists
+    with temp_git_index() as env:
         existing_commit = get_batch_commit_sha(batch_name)
         if existing_commit:
-            subprocess.run(
-                ["git", "read-tree", existing_commit],
-                env=env,
-                check=True,
-                capture_output=True
-            )
+            git_read_tree(existing_commit, env=env)
 
-        # Update index with new blob
-        subprocess.run(
-            ["git", "update-index", "--add", "--cacheinfo", f"{file_mode},{blob_sha},{file_path}"],
-            env=env,
-            check=True,
-            capture_output=True
-        )
+        git_update_index(mode=file_mode, blob_sha=blob_sha, file_path=file_path, env=env)
+        tree_sha = git_write_tree(env=env)
 
-        # Write tree
-        tree_result = subprocess.run(
-            ["git", "write-tree"],
-            env=env,
-            check=True,
-            capture_output=True,
-            text=True
-        )
-        tree_sha = tree_result.stdout.strip()
+    commit_sha = git_commit_tree(
+        tree_sha,
+        parents=_batch_commit_parents(batch_name),
+        message=f"Batch: {batch_name}",
+    )
 
-        # Collect parent commits: baseline + batch sources
-        baseline = get_batch_baseline_commit(batch_name)
-        metadata = read_file_backed_batch_metadata(batch_name)
-
-        parents = []
-        if baseline:
-            parents.append(baseline)
-
-        # Add batch source commits as parents
-        batch_source_commits = set()
-        for file_meta in metadata.get("files", {}).values():
-            if "batch_source_commit" in file_meta:
-                batch_source_commits.add(file_meta["batch_source_commit"])
-
-        parents.extend(sorted(batch_source_commits))
-
-        # Create commit with multi-parent
-        parent_args = []
-        for parent in parents:
-            parent_args.extend(["-p", parent])
-
-        if parent_args:
-            commit_result = subprocess.run(
-                ["git", "commit-tree", tree_sha] + parent_args + ["-m", f"Batch: {batch_name}"],
-                capture_output=True,
-                text=True,
-                check=True
-            )
-        else:
-            commit_result = subprocess.run(
-                ["git", "commit-tree", tree_sha, "-m", f"Batch: {batch_name}"],
-                capture_output=True,
-                text=True,
-                check=True
-            )
-
-        commit_sha = commit_result.stdout.strip()
-
-        from .state_refs import sync_batch_state_refs
-        sync_batch_state_refs(batch_name, content_commit=commit_sha)
-
-    finally:
-        if temp_index_path.exists():
-            temp_index_path.unlink(missing_ok=True)
+    from .state_refs import sync_batch_state_refs
+    sync_batch_state_refs(batch_name, content_commit=commit_sha)
 
 
 def read_file_from_batch(batch_name: str, file_path: str) -> Optional[str]:

--- a/src/git_stage_batch/cli/argument_parser.py
+++ b/src/git_stage_batch/cli/argument_parser.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import argparse
 import os
-import subprocess
 import sys
 import tempfile
 from collections.abc import Callable
@@ -19,6 +18,7 @@ from ..batch.query import read_batch_metadata
 from ..data.hunk_tracking import advance_to_next_change, show_selected_change
 from ..exceptions import CommandError
 from ..i18n import _, ngettext
+from ..utils.command import run_command
 from ..utils.file_patterns import list_changed_files, resolve_gitignore_style_patterns
 from .completion import command_complete_files
 
@@ -40,12 +40,9 @@ def _resolve_default_manpath() -> str | None:
     env = os.environ.copy()
     env.pop("MANPATH", None)
     try:
-        result = subprocess.run(
+        result = run_command(
             ["manpath", "-q"],
             check=False,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
-            text=True,
             env=env,
         )
     except (FileNotFoundError, OSError):
@@ -70,10 +67,10 @@ def _build_manpath_with_packaged_page(man_root: Path, env: dict[str, str]) -> st
 def _try_git_help_with_environment(env: dict[str, str] | None = None) -> bool:
     """Run git help for git-stage-batch."""
     try:
-        result = subprocess.run(
+        result = run_command(
             ["git", "help", "stage-batch"],
             check=False,
-            stderr=subprocess.DEVNULL,
+            capture_stdout=False,
             env=env,
         )
     except (FileNotFoundError, OSError):

--- a/src/git_stage_batch/commands/abort.py
+++ b/src/git_stage_batch/commands/abort.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import os
 import shutil
-import subprocess
 import sys
 
 from ..data.batch_refs import restore_batch_refs
@@ -48,22 +47,18 @@ def command_abort() -> None:
     env["GIT_REFLOG_ACTION"] = "stage-batch abort"
 
     print(_("Resetting to {}...").format(abort_head[:7]), file=sys.stderr)
-    subprocess.run(
-        ["git", "reset", "--hard", abort_head],
+    run_git_command(
+        ["reset", "--hard", abort_head],
         env=env,
-        check=True,
-        capture_output=True,
-        text=True
     )
 
     # Apply original stash if it exists (with --index to restore staged state)
     if abort_stash:
         print(_("Applying original changes..."), file=sys.stderr)
-        result = subprocess.run(
-            ["git", "stash", "apply", "--index", abort_stash],
+        result = run_git_command(
+            ["stash", "apply", "--index", abort_stash],
             env=env,
-            capture_output=True,
-            text=True
+            check=False,
         )
         if result.returncode != 0:
             print(_("⚠ Warning: Could not apply stash cleanly: {}").format(result.stderr), file=sys.stderr)

--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import subprocess
 import sys
 
 from ..batch import add_file_to_batch, create_batch
@@ -304,14 +303,9 @@ def command_discard_file(file: str) -> None:
                 hashes_to_block.append(patch_hash)
 
         # Remove the file from working tree
-        try:
-            subprocess.run(
-                ["git", "rm", "-f", target_file],
-                check=True,
-                capture_output=True,
-            )
-        except subprocess.CalledProcessError as e:
-            print(_("Failed to discard file: {}").format(e.stderr.decode("utf-8", errors="replace")), file=sys.stderr)
+        result = run_git_command(["rm", "-f", target_file], check=False)
+        if result.returncode != 0:
+            print(_("Failed to discard file: {}").format(result.stderr), file=sys.stderr)
             return
 
         # Mark all collected hashes as processed

--- a/src/git_stage_batch/commands/sift.py
+++ b/src/git_stage_batch/commands/sift.py
@@ -20,10 +20,7 @@ produce the intended target content.
 from __future__ import annotations
 
 import json
-import os
-import subprocess
 import sys
-import tempfile
 from pathlib import Path
 from typing import Optional
 
@@ -49,8 +46,13 @@ from ..utils.file_io import write_text_file_contents
 from ..utils.git import (
     create_git_blob,
     get_git_repository_root_path,
+    git_commit_tree,
+    git_read_tree,
+    git_update_index,
+    git_write_tree,
     require_git_repository,
     run_git_command,
+    temp_git_index,
 )
 from ..utils.paths import (
     get_batch_metadata_file_path,
@@ -84,52 +86,16 @@ def create_synthetic_batch_source_commit(
     """
     blob_sha = create_git_blob([file_content])
 
-    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".index") as tmp:
-        temp_index = tmp.name
+    with temp_git_index() as env:
+        git_read_tree(baseline_commit, env=env)
+        git_update_index(mode=file_mode, blob_sha=blob_sha, file_path=file_path, env=env)
+        new_tree = git_write_tree(env=env)
 
-    try:
-        env = os.environ.copy()
-        env["GIT_INDEX_FILE"] = temp_index
-
-        subprocess.run(
-            ["git", "read-tree", baseline_commit],
-            env=env,
-            capture_output=True,
-            check=True,
-        )
-
-        subprocess.run(
-            [
-                "git",
-                "update-index",
-                "--add",
-                "--cacheinfo",
-                f"{file_mode},{blob_sha},{file_path}",
-            ],
-            env=env,
-            capture_output=True,
-            check=True,
-        )
-
-        tree_result = subprocess.run(
-            ["git", "write-tree"],
-            env=env,
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        new_tree = tree_result.stdout.strip()
-    finally:
-        if os.path.exists(temp_index):
-            os.unlink(temp_index)
-
-    commit_result = subprocess.run(
-        ["git", "commit-tree", new_tree, "-p", baseline_commit, "-m", f"Sift batch source for {file_path}"],
-        capture_output=True,
-        text=True,
-        check=True,
+    return git_commit_tree(
+        new_tree,
+        parents=[baseline_commit],
+        message=f"Sift batch source for {file_path}",
     )
-    return commit_result.stdout.strip()
 
 
 

--- a/src/git_stage_batch/data/batch_sources.py
+++ b/src/git_stage_batch/data/batch_sources.py
@@ -3,15 +3,21 @@
 from __future__ import annotations
 
 import json
-import os
 import stat
-import subprocess
-import tempfile
 
 from ..exceptions import CommandError
 from ..i18n import _
 from ..utils.file_io import read_file_paths_file, read_text_file_contents, write_text_file_contents
-from ..utils.git import create_git_blob, get_git_repository_root_path, run_git_command
+from ..utils.git import (
+    create_git_blob,
+    get_git_repository_root_path,
+    git_commit_tree,
+    git_read_tree,
+    git_update_index,
+    git_write_tree,
+    run_git_command,
+    temp_git_index,
+)
 from ..utils.journal import log_journal
 from ..utils.paths import (
     get_abort_head_file_path,
@@ -147,55 +153,16 @@ def create_batch_source_commit(
     else:
         mode = "100644"
 
-    # Create new tree by modifying baseline tree
-    # Use a temporary index to build the tree
-    with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.index') as tmp:
-        temp_index = tmp.name
+    with temp_git_index() as env:
+        git_read_tree(baseline_commit, env=env)
+        git_update_index(mode=mode, blob_sha=blob_sha, file_path=file_path, env=env)
+        new_tree = git_write_tree(env=env)
 
-    try:
-        # Set up environment to use temp index
-        env = os.environ.copy()
-        env['GIT_INDEX_FILE'] = temp_index
-
-        # Read baseline tree into temp index
-        subprocess.run(
-            ["git", "read-tree", baseline_commit],
-            env=env,
-            capture_output=True,
-            check=True
-        )
-
-        # Update the file in the index
-        subprocess.run(
-            ["git", "update-index", "--add", "--cacheinfo", f"{mode},{blob_sha},{file_path}"],
-            env=env,
-            capture_output=True,
-            check=True
-        )
-
-        # Write tree from the index
-        tree_result = subprocess.run(
-            ["git", "write-tree"],
-            env=env,
-            capture_output=True,
-            text=True,
-            check=True
-        )
-        new_tree = tree_result.stdout.strip()
-    finally:
-        # Clean up temp index
-        if os.path.exists(temp_index):
-            os.unlink(temp_index)
-
-    # Create commit with baseline as parent
-    commit_message = f"Batch source for {file_path}"
-    commit_result = subprocess.run(
-        ["git", "commit-tree", new_tree, "-p", baseline_commit, "-m", commit_message],
-        capture_output=True,
-        text=True,
-        check=True
+    batch_source_commit = git_commit_tree(
+        new_tree,
+        parents=[baseline_commit],
+        message=f"Batch source for {file_path}",
     )
-    batch_source_commit = commit_result.stdout.strip()
 
     # Verify the content in the batch source commit
     verify_result = run_git_command(["show", f"{batch_source_commit}:{file_path}"], check=False, text_output=False)

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -703,9 +703,8 @@ def build_file_hunk_from_content(file_path: str, file_content: bytes) -> Optiona
         new_path = new_tmp.name
 
     try:
-        diff_result = subprocess.run(
+        diff_result = run_git_command(
             [
-                "git",
                 "diff",
                 "--no-index",
                 f"-U{get_context_lines()}",
@@ -714,7 +713,7 @@ def build_file_hunk_from_content(file_path: str, file_content: bytes) -> Optiona
                 new_path,
             ],
             check=False,
-            capture_output=True,
+            text_output=False,
         )
         if diff_result.returncode not in (0, 1):
             raise subprocess.CalledProcessError(

--- a/src/git_stage_batch/data/undo.py
+++ b/src/git_stage_batch/data/undo.py
@@ -3,10 +3,8 @@
 from __future__ import annotations
 
 import json
-import os
 import shutil
 import stat
-import subprocess
 import tempfile
 from contextlib import contextmanager
 from pathlib import Path
@@ -16,7 +14,17 @@ from ..batch.ref_names import BATCH_CONTENT_REF_PREFIX, BATCH_STATE_REF_PREFIX, 
 from ..exceptions import CommandError
 from ..i18n import _
 from ..utils.file_io import read_file_paths_file
-from ..utils.git import create_git_blob, get_git_repository_root_path, run_git_command, update_git_refs
+from ..utils.git import (
+    create_git_blob,
+    get_git_repository_root_path,
+    git_commit_tree,
+    git_read_tree,
+    git_update_index,
+    git_write_tree,
+    run_git_command,
+    temp_git_index,
+    update_git_refs,
+)
 from ..utils.paths import (
     get_auto_added_files_file_path,
     get_batches_directory_path,
@@ -97,12 +105,7 @@ def _snapshot_current_state(paths: list[str]) -> dict[str, Any]:
 
 
 def _run_update_index(env: dict[str, str], mode: str, blob_sha: str, path: str) -> None:
-    subprocess.run(
-        ["git", "update-index", "--add", "--cacheinfo", mode, blob_sha, path],
-        env=env,
-        capture_output=True,
-        check=True,
-    )
+    git_update_index(mode=mode, blob_sha=blob_sha, file_path=path, env=env)
 
 
 def _add_blob_to_index(env: dict[str, str], path: str, data: bytes, mode: str = "100644") -> None:
@@ -174,15 +177,7 @@ def _create_undo_checkpoint(operation: str, *, worktree_paths: list[str] | None 
         "tracked_worktree_paths": tracked_worktree_paths,
     }
 
-    temp_index = tempfile.NamedTemporaryFile(delete=False, suffix=".index")
-    temp_index_path = temp_index.name
-    temp_index.close()
-    os.unlink(temp_index_path)
-
-    env = os.environ.copy()
-    env["GIT_INDEX_FILE"] = temp_index_path
-
-    try:
+    with temp_git_index() as env:
         _add_blob_to_index(env, "manifest.json", json.dumps(manifest, indent=2, sort_keys=True).encode("utf-8"))
         _add_directory_to_index(env, source_dir=session_dir, tree_prefix="session")
         _add_directory_to_index(env, source_dir=get_batches_directory_path(), tree_prefix="batches")
@@ -200,30 +195,17 @@ def _create_undo_checkpoint(operation: str, *, worktree_paths: list[str] | None 
                     entry["mode"],
                 )
 
-        tree_result = subprocess.run(
-            ["git", "write-tree"],
-            env=env,
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        tree_sha = tree_result.stdout.strip()
+        tree_sha = git_write_tree(env=env)
 
-        parent = _current_undo_commit()
-        parent_args = ["-p", parent] if parent else []
-        commit_result = subprocess.run(
-            ["git", "commit-tree", tree_sha, *parent_args, "-m", f"Undo checkpoint: {operation}"],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        checkpoint_commit = commit_result.stdout.strip()
-        run_git_command(["update-ref", SESSION_UNDO_STACK_REF, checkpoint_commit])
-        _PENDING_CHECKPOINT = checkpoint_commit
-        return checkpoint_commit
-    finally:
-        if os.path.exists(temp_index_path):
-            os.unlink(temp_index_path)
+    parent = _current_undo_commit()
+    checkpoint_commit = git_commit_tree(
+        tree_sha,
+        parents=[parent] if parent else [],
+        message=f"Undo checkpoint: {operation}",
+    )
+    run_git_command(["update-ref", SESSION_UNDO_STACK_REF, checkpoint_commit])
+    _PENDING_CHECKPOINT = checkpoint_commit
+    return checkpoint_commit
 
 
 @contextmanager
@@ -258,36 +240,18 @@ def finalize_pending_checkpoint() -> None:
     manifest["after"] = _snapshot_current_state(paths)
     manifest["after"]["worktree_paths"] = manifest["after"]["worktree_paths"]
 
-    temp_index = tempfile.NamedTemporaryFile(delete=False, suffix=".index")
-    temp_index_path = temp_index.name
-    temp_index.close()
-    os.unlink(temp_index_path)
-
-    env = os.environ.copy()
-    env["GIT_INDEX_FILE"] = temp_index_path
-    try:
-        subprocess.run(["git", "read-tree", checkpoint], env=env, capture_output=True, check=True)
+    with temp_git_index() as env:
+        git_read_tree(checkpoint, env=env)
         _add_blob_to_index(env, "manifest.json", json.dumps(manifest, indent=2, sort_keys=True).encode("utf-8"))
-        tree_result = subprocess.run(
-            ["git", "write-tree"],
-            env=env,
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        tree_sha = tree_result.stdout.strip()
-        parent = _checkpoint_parent(checkpoint)
-        parent_args = ["-p", parent] if parent else []
-        commit_result = subprocess.run(
-            ["git", "commit-tree", tree_sha, *parent_args, "-m", f"Undo checkpoint: {manifest.get('operation', 'operation')}"],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        run_git_command(["update-ref", SESSION_UNDO_STACK_REF, commit_result.stdout.strip()])
-    finally:
-        if os.path.exists(temp_index_path):
-            os.unlink(temp_index_path)
+        tree_sha = git_write_tree(env=env)
+
+    parent = _checkpoint_parent(checkpoint)
+    checkpoint_commit = git_commit_tree(
+        tree_sha,
+        parents=[parent] if parent else [],
+        message=f"Undo checkpoint: {manifest.get('operation', 'operation')}",
+    )
+    run_git_command(["update-ref", SESSION_UNDO_STACK_REF, checkpoint_commit])
 
 
 def _cat_blob(blob_sha: str) -> bytes:
@@ -442,15 +406,7 @@ def _write_snapshot_commit(
     worktree_entries: list[dict[str, Any]],
     parent: str | None,
 ) -> str:
-    temp_index = tempfile.NamedTemporaryFile(delete=False, suffix=".index")
-    temp_index_path = temp_index.name
-    temp_index.close()
-    os.unlink(temp_index_path)
-
-    env = os.environ.copy()
-    env["GIT_INDEX_FILE"] = temp_index_path
-
-    try:
+    with temp_git_index() as env:
         _add_blob_to_index(env, "manifest.json", json.dumps(manifest, indent=2, sort_keys=True).encode("utf-8"))
         _add_directory_to_index(env, source_dir=session_dir, tree_prefix="session")
         _add_directory_to_index(env, source_dir=batches_dir, tree_prefix="batches")
@@ -472,28 +428,15 @@ def _write_snapshot_commit(
                         entry.get("mode", "100644"),
                     )
 
-        tree_result = subprocess.run(
-            ["git", "write-tree"],
-            env=env,
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        tree_sha = tree_result.stdout.strip()
+        tree_sha = git_write_tree(env=env)
 
-        parent_args = ["-p", parent] if parent else []
-        commit_result = subprocess.run(
-            ["git", "commit-tree", tree_sha, *parent_args, "-m", message],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        commit_sha = commit_result.stdout.strip()
-        run_git_command(["update-ref", ref_name, commit_sha])
-        return commit_sha
-    finally:
-        if os.path.exists(temp_index_path):
-            os.unlink(temp_index_path)
+    commit_sha = git_commit_tree(
+        tree_sha,
+        parents=[parent] if parent else [],
+        message=message,
+    )
+    run_git_command(["update-ref", ref_name, commit_sha])
+    return commit_sha
 
 
 def _push_redo_node(
@@ -570,7 +513,7 @@ def undo_last_checkpoint(*, force: bool = False) -> str:
 
         index_tree = manifest.get("index_tree")
         if index_tree:
-            run_git_command(["read-tree", index_tree])
+            git_read_tree(index_tree)
 
         _restore_worktree(checkpoint, manifest)
         _restore_intent_to_add_entries()
@@ -623,7 +566,7 @@ def redo_last_checkpoint(*, force: bool = False) -> str:
 
     index_tree = manifest.get("index_tree")
     if index_tree:
-        run_git_command(["read-tree", index_tree])
+        git_read_tree(index_tree)
 
     _restore_worktree(redo_node, manifest)
     _restore_intent_to_add_entries()

--- a/src/git_stage_batch/utils/command.py
+++ b/src/git_stage_batch/utils/command.py
@@ -202,10 +202,24 @@ class StreamingProcess:
     def wait(self) -> int:
         """Wait for process exit and return exit code.
 
-        Safe to call before or after stream() iteration.
-        Returns the process exit code.
+        If stream() has not started, captured output is drained and
+        discarded so pipe resources are closed.
         """
-        return self._process.wait()
+        if self._events_started:
+            try:
+                return self._process.wait()
+            finally:
+                self._close_resources()
+
+        stdin_chunks: Iterable[bytes] | None = None
+        if self._stdin_fd is not None:
+            stdin_chunks = ()
+
+        exit_code = 0
+        for event in self.stream(stdin_chunks):
+            if isinstance(event, ExitEvent):
+                exit_code = event.exit_code
+        return exit_code
 
     def stream(self, stdin_chunks: Iterable[bytes] | None = None) -> Iterator[CommandEvent]:
         """Stream I/O with the child process.

--- a/src/git_stage_batch/utils/command.py
+++ b/src/git_stage_batch/utils/command.py
@@ -453,6 +453,8 @@ def start_command(
 
     Stdout and stderr are captured by default.
     """
+    if not arguments:
+        raise ValueError("arguments must not be empty")
     if extra_fds is None:
         extra_fds = []
     if stdin and stdin_fd is not None:

--- a/src/git_stage_batch/utils/command.py
+++ b/src/git_stage_batch/utils/command.py
@@ -29,6 +29,7 @@ Example usage:
 from __future__ import annotations
 
 import errno
+import locale
 import os
 import selectors
 import signal
@@ -322,8 +323,9 @@ class StreamingProcess:
     def stream(self, stdin_chunks: Iterable[bytes] | None = None) -> Iterator[CommandEvent]:
         """Stream I/O with the child process.
 
-        Iteration continues until all captured output file descriptors reach EOF.
-        After that, the child is waited for and a final ExitEvent is emitted.
+        Iteration continues until all captured output file descriptors reach EOF
+        and any managed stdin pipe has been closed. After that, the child is
+        waited for and a final ExitEvent is emitted.
 
         Args:
             stdin_chunks: Optional iterator of bytes to write to stdin. If provided,
@@ -356,13 +358,16 @@ class StreamingProcess:
             for parent_fd in self._output_fds:
                 self._selector.register(parent_fd, selectors.EVENT_READ)
 
-            # Stream until all output fds are closed
-            while self._output_fds:
+            while self._output_fds or self._has_pending_stdin():
                 self._update_stdin_registration()
 
                 if self._should_close_stdin_now():
                     self._close_stdin_now()
                     yield StdinClosedEvent(CommandEventRole.STDIN_CLOSED)
+                    continue
+
+                if not self._selector.get_map():
+                    break
 
                 events_list = self._selector.select()
 
@@ -388,6 +393,17 @@ class StreamingProcess:
             raise
         finally:
             self._close_resources()
+
+    def _has_pending_stdin(self) -> bool:
+        return (
+            self._stdin_fd is not None
+            and not self._stdin_closed_emitted
+            and (
+                self._stdin_selected_chunk is not None
+                or self._stdin_iter is not None
+                or self._stdin_close_requested
+            )
+        )
 
     def _update_stdin_registration(self) -> None:
         if self._selector is None or self._stdin_fd is None:
@@ -741,3 +757,64 @@ def stream_command(
         raise
     finally:
         proc._close_resources()
+
+
+def run_command(
+    arguments: list[str],
+    stdin_chunks: Iterable[bytes] | None = None,
+    *,
+    check: bool = True,
+    text_output: bool = True,
+    cwd: str | None = None,
+    env: dict[str, str] | None = None,
+    capture_stdout: bool = True,
+    capture_stderr: bool = True,
+) -> subprocess.CompletedProcess:
+    """Run a command to completion and capture stdout/stderr.
+
+    This is the one-shot counterpart to stream_command(). It returns a
+    subprocess.CompletedProcess-compatible object while using the same
+    streaming implementation underneath.
+    """
+    stdout_chunks: list[bytes] = []
+    stderr_chunks: list[bytes] = []
+    returncode = 0
+
+    for event in stream_command(
+        arguments,
+        stdin_chunks,
+        cwd=cwd,
+        env=env,
+        capture_stdout=capture_stdout,
+        capture_stderr=capture_stderr,
+    ):
+        if isinstance(event, ExitEvent):
+            returncode = event.exit_code
+        elif isinstance(event, OutputEvent):
+            if event.fd == 1:
+                stdout_chunks.append(event.data)
+            elif event.fd == 2:
+                stderr_chunks.append(event.data)
+
+    stdout = b"".join(stdout_chunks) if capture_stdout else None
+    stderr = b"".join(stderr_chunks) if capture_stderr else None
+
+    if text_output:
+        encoding = locale.getpreferredencoding(False)
+        stdout = stdout.decode(encoding) if stdout is not None else None
+        stderr = stderr.decode(encoding) if stderr is not None else None
+
+    result = subprocess.CompletedProcess(
+        arguments,
+        returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+    if check and returncode != 0:
+        raise subprocess.CalledProcessError(
+            returncode,
+            arguments,
+            output=stdout,
+            stderr=stderr,
+        )
+    return result

--- a/src/git_stage_batch/utils/command.py
+++ b/src/git_stage_batch/utils/command.py
@@ -163,6 +163,104 @@ class CapturedFd:
     child_fd: int
 
 
+def _close_fd_if_present(fd: int | None) -> None:
+    if fd is None:
+        return
+    try:
+        os.close(fd)
+    except OSError:
+        pass
+
+
+def _prepare_spawn_dup_source(
+    source_fd: int,
+    target_fds: set[int],
+    cleanup_fds: list[int],
+) -> int:
+    if source_fd not in target_fds:
+        return source_fd
+
+    while True:
+        duplicate_fd = os.dup(source_fd)
+        cleanup_fds.append(duplicate_fd)
+        if duplicate_fd not in target_fds:
+            return duplicate_fd
+
+
+def _add_spawn_dup2_action(
+    file_actions: list[tuple[int, int] | tuple[int, int, int]],
+    source_fd: int,
+    target_fd: int,
+    target_fds: set[int],
+    cleanup_fds: list[int],
+) -> None:
+    spawn_source_fd = _prepare_spawn_dup_source(
+        source_fd,
+        target_fds,
+        cleanup_fds,
+    )
+    file_actions.append((os.POSIX_SPAWN_DUP2, spawn_source_fd, target_fd))
+    if spawn_source_fd != source_fd or source_fd not in target_fds:
+        file_actions.append((os.POSIX_SPAWN_CLOSE, spawn_source_fd))
+
+
+def _spawn_arguments_for_cwd(arguments: list[str], cwd: str | None) -> tuple[str, list[str]]:
+    if cwd is None:
+        return arguments[0], arguments
+
+    shell = _resolve_spawn_executable_from_paths("sh", os.defpath.split(os.pathsep))
+    shell_cwd = _cwd_argument_for_shell(cwd)
+    script = 'cd "$1" || exit 127; shift; exec "$@"'
+    return shell, [shell, "-c", script, "sh", shell_cwd, *arguments]
+
+
+def _cwd_argument_for_shell(cwd: str) -> str:
+    if cwd.startswith("-") and not os.path.isabs(cwd):
+        return os.path.join(".", cwd)
+    return cwd
+
+
+def _close_fds(fds: Iterable[int | None]) -> None:
+    for fd in fds:
+        _close_fd_if_present(fd)
+
+
+def _resolve_spawn_executable_from_paths(
+    executable: str,
+    paths: Iterable[str],
+) -> str:
+    if os.path.dirname(executable):
+        return executable
+
+    permission_denied = False
+    for directory in paths:
+        candidate = os.path.join(directory, executable) if directory else executable
+        if os.path.isdir(candidate):
+            permission_denied = True
+            continue
+        if os.access(candidate, os.X_OK):
+            return candidate
+        if os.path.exists(candidate):
+            permission_denied = True
+
+    if permission_denied:
+        raise PermissionError(errno.EACCES, os.strerror(errno.EACCES), executable)
+    raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), executable)
+
+
+def _resolve_spawn_executable(executable: str, env: dict[str, str]) -> str:
+    return _resolve_spawn_executable_from_paths(executable, os.get_exec_path(env))
+
+
+def _add_spawn_close_action(
+    file_actions: list[tuple[int, int] | tuple[int, int, int]],
+    fd: int,
+    target_fds: set[int],
+) -> None:
+    if fd not in target_fds:
+        file_actions.append((os.POSIX_SPAWN_CLOSE, fd))
+
+
 class StreamingProcess:
     """A running subprocess with streaming I/O.
 
@@ -463,7 +561,7 @@ def start_command(
     capture_stdout: bool = True,
     capture_stderr: bool = True,
 ) -> StreamingProcess:
-    """Start a subprocess with streaming I/O using fork/exec.
+    """Start a subprocess with streaming I/O using posix_spawn.
 
     Stdout and stderr are captured by default.
     """
@@ -481,6 +579,10 @@ def start_command(
         if captured.child_fd in child_fds_seen:
             raise ValueError(f"duplicate or reserved child_fd: {captured.child_fd}")
         child_fds_seen.add(captured.child_fd)
+
+    executable, spawn_arguments = _spawn_arguments_for_cwd(arguments, cwd)
+    spawn_env = os.environ.copy() if env is None else env
+    executable_path = _resolve_spawn_executable(executable, spawn_env)
 
     # Create pipes for stdin/stdout/stderr
     if stdin:
@@ -504,86 +606,74 @@ def start_command(
         read_fd, write_fd = os.pipe()
         extra_pipes[captured.child_fd] = (read_fd, write_fd)
 
-    # Fork the process
+    cleanup_fds: list[int] = []
+    file_actions: list[tuple[int, int] | tuple[int, int, int]] = []
+    target_fds = set(extra_pipes)
+    if stdin or stdin_fd is not None:
+        target_fds.add(0)
+    if capture_stdout:
+        target_fds.add(1)
+    if capture_stderr:
+        target_fds.add(2)
+
+    if stdin:
+        assert stdin_read_fd is not None
+        assert stdin_write_fd is not None
+        _add_spawn_close_action(file_actions, stdin_write_fd, target_fds)
+        _add_spawn_dup2_action(file_actions, stdin_read_fd, 0, target_fds, cleanup_fds)
+    elif stdin_fd is not None:
+        _add_spawn_dup2_action(file_actions, stdin_fd, 0, target_fds, cleanup_fds)
+
+    if capture_stdout:
+        assert stdout_read_fd is not None
+        assert stdout_write_fd is not None
+        _add_spawn_close_action(file_actions, stdout_read_fd, target_fds)
+        _add_spawn_dup2_action(file_actions, stdout_write_fd, 1, target_fds, cleanup_fds)
+
+    if capture_stderr:
+        assert stderr_read_fd is not None
+        assert stderr_write_fd is not None
+        _add_spawn_close_action(file_actions, stderr_read_fd, target_fds)
+        _add_spawn_dup2_action(file_actions, stderr_write_fd, 2, target_fds, cleanup_fds)
+
+    for child_fd, (read_fd, write_fd) in extra_pipes.items():
+        _add_spawn_close_action(file_actions, read_fd, target_fds)
+        _add_spawn_dup2_action(file_actions, write_fd, child_fd, target_fds, cleanup_fds)
+
     try:
-        pid = os.fork()
+        pid = os.posix_spawn(
+            executable_path,
+            spawn_arguments,
+            spawn_env,
+            file_actions=file_actions,
+        )
     except Exception:
-        # Clean up pipes on fork failure
-        if stdin:
-            os.close(stdin_read_fd)
-            os.close(stdin_write_fd)
-        if capture_stdout:
-            os.close(stdout_read_fd)
-            os.close(stdout_write_fd)
-        if capture_stderr:
-            os.close(stderr_read_fd)
-            os.close(stderr_write_fd)
-        for read_fd, write_fd in extra_pipes.values():
-            os.close(read_fd)
-            os.close(write_fd)
+        _close_fds([
+            stdin_read_fd,
+            stdin_write_fd,
+            stdout_read_fd,
+            stdout_write_fd,
+            stderr_read_fd,
+            stderr_write_fd,
+            *cleanup_fds,
+        ])
+        for pipe_fds in extra_pipes.values():
+            _close_fds(pipe_fds)
         raise
-
-    if pid == 0:
-        # Child process
-        try:
-            # Close parent-side fds
-            if stdin:
-                os.close(stdin_write_fd)
-            if capture_stdout:
-                os.close(stdout_read_fd)
-            if capture_stderr:
-                os.close(stderr_read_fd)
-            for read_fd, _ in extra_pipes.values():
-                os.close(read_fd)
-
-            # Set up stdin (fd 0)
-            if stdin:
-                os.dup2(stdin_read_fd, 0)
-                os.close(stdin_read_fd)
-            elif stdin_fd is not None:
-                os.dup2(stdin_fd, 0)
-                os.close(stdin_fd)
-
-            # Set up stdout (fd 1)
-            if capture_stdout:
-                os.dup2(stdout_write_fd, 1)
-                os.close(stdout_write_fd)
-
-            # Set up stderr (fd 2)
-            if capture_stderr:
-                os.dup2(stderr_write_fd, 2)
-                os.close(stderr_write_fd)
-
-            # Set up extra fds
-            for child_fd, (_, write_fd) in extra_pipes.items():
-                os.dup2(write_fd, child_fd)
-                os.close(write_fd)
-
-            # Change working directory if requested
-            if cwd is not None:
-                os.chdir(cwd)
-
-            # Execute the command
-            if env is not None:
-                os.execvpe(arguments[0], arguments, env)
-            else:
-                os.execvp(arguments[0], arguments)
-        except Exception:
-            # If anything fails in the child, exit immediately
-            os._exit(127)
 
     # Parent process
     # Close child-side fds
     if stdin:
-        os.close(stdin_read_fd)
+        _close_fd_if_present(stdin_read_fd)
     elif stdin_fd is not None:
-        os.close(stdin_fd)
+        _close_fd_if_present(stdin_fd)
     if capture_stdout:
-        os.close(stdout_write_fd)
+        _close_fd_if_present(stdout_write_fd)
     if capture_stderr:
-        os.close(stderr_write_fd)
+        _close_fd_if_present(stderr_write_fd)
+    _close_fds(cleanup_fds)
     for _, write_fd in extra_pipes.values():
-        os.close(write_fd)
+        _close_fd_if_present(write_fd)
 
     # Build fd maps
     output_fds: dict[int, int] = {}

--- a/src/git_stage_batch/utils/file_patterns.py
+++ b/src/git_stage_batch/utils/file_patterns.py
@@ -7,8 +7,9 @@ import tempfile
 from collections.abc import Iterable
 from pathlib import Path
 
-from .git import run_git_command
+from .command import run_command
 from .file_io import write_text_file_contents
+from .git import run_git_command
 
 
 def _normalize_path(path: str) -> str:
@@ -56,22 +57,21 @@ def resolve_gitignore_style_patterns(
 
     with tempfile.TemporaryDirectory(prefix="git-stage-batch-patterns-") as temp_dir:
         temp_root = Path(temp_dir)
-        subprocess.run(
+        run_command(
             ["git", "init", "-q"],
-            check=True,
-            cwd=temp_root,
-            capture_output=True,
+            cwd=str(temp_root),
+            text_output=False,
         )
         write_text_file_contents(temp_root / ".gitignore", "".join(f"{pattern}\n" for pattern in normalized_patterns))
         _materialize_candidates(temp_root, normalized_candidates)
 
         payload = b"".join(candidate.encode("utf-8") + b"\0" for candidate in normalized_candidates)
-        result = subprocess.run(
+        result = run_command(
             ["git", "check-ignore", "--no-index", "--stdin", "-z", "-v", "-n"],
+            [payload],
+            cwd=str(temp_root),
             check=False,
-            cwd=temp_root,
-            input=payload,
-            capture_output=True,
+            text_output=False,
         )
         if result.returncode not in (0, 1):
             raise subprocess.CalledProcessError(

--- a/src/git_stage_batch/utils/git.py
+++ b/src/git_stage_batch/utils/git.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from ..exceptions import exit_with_error
 from ..i18n import _
-from .command import ExitEvent, OutputEvent, stream_command
+from .command import ExitEvent, OutputEvent, run_command, stream_command
 from .file_io import read_text_file_contents, write_text_file_contents
 from .text import bytes_to_lines
 
@@ -100,7 +100,10 @@ def update_git_refs(
 def run_git_command(
     arguments: list[str],
     check: bool = True,
-    text_output: bool = True
+    text_output: bool = True,
+    *,
+    cwd: str | None = None,
+    env: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess:
     """Execute a git command with error handling.
 
@@ -108,6 +111,8 @@ def run_git_command(
         arguments: Git command arguments (e.g., ["status", "--short"])
         check: Whether to raise CalledProcessError on non-zero exit
         text_output: Whether to decode stdout/stderr as text
+        cwd: Working directory for the command
+        env: Environment variables
 
     Returns:
         CompletedProcess with returncode, stdout, stderr
@@ -115,11 +120,12 @@ def run_git_command(
     Raises:
         subprocess.CalledProcessError: If check=True and command fails
     """
-    return subprocess.run(
+    return run_command(
         ["git", *arguments],
         check=check,
-        text=text_output,
-        capture_output=True
+        text_output=text_output,
+        cwd=cwd,
+        env=env,
     )
 
 

--- a/src/git_stage_batch/utils/git.py
+++ b/src/git_stage_batch/utils/git.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
+import tempfile
 from collections.abc import Iterable, Iterator
+from contextlib import contextmanager
 from pathlib import Path
 
 from ..exceptions import exit_with_error
@@ -127,6 +130,74 @@ def run_git_command(
         cwd=cwd,
         env=env,
     )
+
+
+@contextmanager
+def temp_git_index() -> Iterator[dict[str, str]]:
+    """Create a temporary Git index and yield an environment that uses it."""
+    temp_index = tempfile.NamedTemporaryFile(delete=False, suffix=".index")
+    temp_index_path = temp_index.name
+    temp_index.close()
+    os.unlink(temp_index_path)
+
+    env = os.environ.copy()
+    env["GIT_INDEX_FILE"] = temp_index_path
+    try:
+        yield env
+    finally:
+        if os.path.exists(temp_index_path):
+            os.unlink(temp_index_path)
+
+
+def git_read_tree(treeish: str, *, env: dict[str, str] | None = None) -> None:
+    """Read a Git tree into the current or provided index."""
+    run_git_command(["read-tree", treeish], env=env)
+
+
+def git_update_index(
+    *,
+    file_path: str,
+    mode: str | None = None,
+    blob_sha: str | None = None,
+    force_remove: bool = False,
+    check: bool = True,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess:
+    """Update one index entry from a blob, or force-remove it."""
+    if force_remove:
+        if mode is not None or blob_sha is not None:
+            raise ValueError("mode and blob_sha cannot be used with force_remove=True")
+        arguments = ["update-index", "--force-remove", "--", file_path]
+    else:
+        if mode is None or blob_sha is None:
+            raise ValueError("mode and blob_sha are required unless force_remove=True")
+        arguments = ["update-index", "--add", "--cacheinfo", mode, blob_sha, file_path]
+
+    return run_git_command(
+        arguments,
+        check=check,
+        env=env,
+    )
+
+
+def git_write_tree(*, env: dict[str, str] | None = None) -> str:
+    """Write the current or provided index as a Git tree."""
+    return run_git_command(["write-tree"], env=env).stdout.strip()
+
+
+def git_commit_tree(
+    tree_sha: str,
+    *,
+    parents: Iterable[str] = (),
+    message: str,
+    env: dict[str, str] | None = None,
+) -> str:
+    """Create a commit object from a tree and optional parents."""
+    arguments = ["commit-tree", tree_sha]
+    for parent in parents:
+        arguments.extend(["-p", parent])
+    arguments.extend(["-m", message])
+    return run_git_command(arguments, env=env).stdout.strip()
 
 
 def create_git_blob(content_chunks: Iterable[bytes]) -> str:

--- a/tests/cli/test_argument_parser.py
+++ b/tests/cli/test_argument_parser.py
@@ -60,7 +60,7 @@ def test_resolve_default_manpath_unsets_manpath(monkeypatch):
         captured_env = kwargs["env"]
         return Mock(returncode=0, stdout="/usr/share/man\n")
 
-    monkeypatch.setattr(argument_parser.subprocess, "run", fake_run)
+    monkeypatch.setattr(argument_parser, "run_command", fake_run)
     monkeypatch.setenv("MANPATH", "/custom/man")
 
     result = argument_parser._resolve_default_manpath()
@@ -100,7 +100,7 @@ def test_show_git_stage_batch_help_uses_packaged_page_first(monkeypatch, tmp_pat
         calls.append((cmd, kwargs.get("env")))
         return Mock(returncode=0)
 
-    monkeypatch.setattr(argument_parser.subprocess, "run", fake_run)
+    monkeypatch.setattr(argument_parser, "run_command", fake_run)
 
     assert argument_parser._show_git_stage_batch_help() is True
     assert calls[0][0] == ["git", "help", "stage-batch"]
@@ -143,7 +143,7 @@ def test_show_git_stage_batch_help_materializes_editable_manpage(monkeypatch, tm
         assert staged_manpage.read_text(encoding="utf-8") == "test"
         return Mock(returncode=0)
 
-    monkeypatch.setattr(argument_parser.subprocess, "run", fake_run)
+    monkeypatch.setattr(argument_parser, "run_command", fake_run)
 
     assert argument_parser._show_git_stage_batch_help() is True
     assert calls[0][1]["MANPATH"].endswith(f"{os.pathsep}/usr/share/man")

--- a/tests/utils/test_git.py
+++ b/tests/utils/test_git.py
@@ -68,6 +68,13 @@ class TestRunGitCommand:
         assert isinstance(result.stdout, str)
         assert isinstance(result.stderr, str)
 
+    def test_binary_output_returns_bytes(self, temp_git_repo):
+        """Test that text_output=False returns bytes output."""
+        result = run_git_command(["show", "HEAD:README.md"], text_output=False)
+
+        assert result.stdout == b"# Test\n"
+        assert isinstance(result.stderr, bytes)
+
     def test_captures_stdout(self, temp_git_repo):
         """Test that stdout is captured."""
         result = run_git_command(["rev-parse", "--git-dir"])

--- a/tests/utils/test_git.py
+++ b/tests/utils/test_git.py
@@ -15,9 +15,15 @@ import pytest
 
 from git_stage_batch.exceptions import CommandError
 from git_stage_batch.utils.git import (
+    create_git_blob,
     get_git_repository_root_path,
+    git_commit_tree,
+    git_read_tree,
+    git_update_index,
+    git_write_tree,
     require_git_repository,
     run_git_command,
+    temp_git_index,
 )
 
 
@@ -124,6 +130,91 @@ class TestStreamGitCommand:
         with pytest.raises(subprocess.CalledProcessError):
             # Consume the entire stream to trigger error check
             list(stream_git_command(["invalid-command"]))
+
+
+class TestGitIndexPlumbing:
+    """Tests for temporary index plumbing helpers."""
+
+    def test_temp_index_builds_commit_without_touching_main_index(self, temp_git_repo):
+        """Test creating a commit from a temporary index."""
+        blob_sha = create_git_blob([b"from temp index\n"])
+
+        with temp_git_index() as env:
+            temp_index_path = Path(env["GIT_INDEX_FILE"])
+            git_read_tree("HEAD", env=env)
+            git_update_index(
+                mode="100644",
+                blob_sha=blob_sha,
+                file_path="nested/file.txt",
+                env=env,
+            )
+            tree_sha = git_write_tree(env=env)
+
+        assert not temp_index_path.exists()
+
+        commit_sha = git_commit_tree(
+            tree_sha,
+            parents=["HEAD"],
+            message="Temporary index commit",
+        )
+        result = run_git_command(["show", f"{commit_sha}:nested/file.txt"])
+
+        assert result.stdout == "from temp index\n"
+        assert run_git_command(["status", "--short"]).stdout == ""
+
+    def test_update_index_cacheinfo_handles_comma_paths(self, temp_git_repo):
+        """Test that cacheinfo paths are passed as separate arguments."""
+        blob_sha = create_git_blob([b"comma path\n"])
+        file_path = "dir/name,with,commas.txt"
+
+        with temp_git_index() as env:
+            git_read_tree("HEAD", env=env)
+            git_update_index(
+                mode="100644",
+                blob_sha=blob_sha,
+                file_path=file_path,
+                env=env,
+            )
+            tree_sha = git_write_tree(env=env)
+
+        commit_sha = git_commit_tree(
+            tree_sha,
+            parents=["HEAD"],
+            message="Comma path commit",
+        )
+        result = run_git_command(["show", f"{commit_sha}:{file_path}"])
+
+        assert result.stdout == "comma path\n"
+
+    def test_update_index_force_remove_deletes_index_entry(self, temp_git_repo):
+        """Test force-removing a path from a temporary index."""
+        with temp_git_index() as env:
+            git_read_tree("HEAD", env=env)
+            git_update_index(file_path="README.md", force_remove=True, env=env)
+            tree_sha = git_write_tree(env=env)
+
+        commit_sha = git_commit_tree(
+            tree_sha,
+            parents=["HEAD"],
+            message="Remove file from temp index",
+        )
+        result = run_git_command(["show", f"{commit_sha}:README.md"], check=False)
+
+        assert result.returncode != 0
+        assert run_git_command(["status", "--short"]).stdout == ""
+
+    def test_update_index_rejects_ambiguous_modes(self, temp_git_repo):
+        """Test that update-index helper modes are explicit."""
+        with pytest.raises(ValueError, match="mode and blob_sha are required"):
+            git_update_index(file_path="README.md")
+
+        with pytest.raises(ValueError, match="cannot be used with force_remove"):
+            git_update_index(
+                file_path="README.md",
+                mode="100644",
+                blob_sha="0" * 40,
+                force_remove=True,
+            )
 
 
 class TestRequireGitRepository:

--- a/tests/utils/test_stream_process.py
+++ b/tests/utils/test_stream_process.py
@@ -2,6 +2,7 @@
 
 import errno
 import os
+import subprocess
 import time
 
 import sys
@@ -12,6 +13,7 @@ from git_stage_batch.utils.command import (
     CapturedFd,
     ExitEvent,
     OutputEvent,
+    run_command,
     StdinClosedEvent,
     start_command,
     stream_command,
@@ -70,6 +72,77 @@ class TestBasicStreaming:
 
         assert stdout_data == b"out"
         assert stderr_data == b"err"
+
+
+class TestRunCommand:
+    """Tests for one-shot command execution."""
+
+    def test_returns_completed_process_with_text_output(self):
+        """Test run_command captures text stdout and stderr."""
+        result = run_command([
+            sys.executable,
+            "-c",
+            "import sys; print('out'); print('err', file=sys.stderr)",
+        ])
+
+        assert result.returncode == 0
+        assert result.stdout == "out\n"
+        assert result.stderr == "err\n"
+
+    def test_returns_binary_output(self):
+        """Test run_command can capture bytes output."""
+        result = run_command(
+            [sys.executable, "-c", "import sys; sys.stdout.buffer.write(b'\\xff')"],
+            text_output=False,
+        )
+
+        assert result.stdout == b"\xff"
+        assert result.stderr == b""
+
+    def test_failed_command_with_check_raises_with_output(self):
+        """Test check=True raises CalledProcessError with captured output."""
+        with pytest.raises(subprocess.CalledProcessError) as exc_info:
+            run_command([
+                sys.executable,
+                "-c",
+                "import sys; print('out'); print('err', file=sys.stderr); sys.exit(3)",
+            ])
+
+        assert exc_info.value.returncode == 3
+        assert exc_info.value.stdout == "out\n"
+        assert exc_info.value.stderr == "err\n"
+
+    def test_failed_command_without_check_returns_result(self):
+        """Test check=False returns a CompletedProcess for nonzero exits."""
+        result = run_command(
+            [sys.executable, "-c", "import sys; sys.exit(4)"],
+            check=False,
+        )
+
+        assert result.returncode == 4
+
+    def test_stdin_chunks(self):
+        """Test run_command feeds stdin chunks."""
+        result = run_command(["cat"], stdin_chunks=[b"hello", b" world"])
+
+        assert result.stdout == "hello world"
+
+    def test_stdin_chunks_without_captured_output(self):
+        """Test run_command feeds stdin without captured output fds."""
+        result = run_command(
+            [
+                sys.executable,
+                "-c",
+                "import sys; assert sys.stdin.buffer.read() == b'hi'",
+            ],
+            stdin_chunks=[b"hi"],
+            capture_stdout=False,
+            capture_stderr=False,
+        )
+
+        assert result.returncode == 0
+        assert result.stdout is None
+        assert result.stderr is None
 
 
 class TestStdinHandling:

--- a/tests/utils/test_stream_process.py
+++ b/tests/utils/test_stream_process.py
@@ -351,6 +351,11 @@ class TestProcessControl:
 class TestEdgeCases:
     """Tests for edge cases."""
 
+    def test_empty_arguments_rejected(self):
+        """Test command launch rejects an empty argument list."""
+        with pytest.raises(ValueError, match="arguments"):
+            start_command([])
+
     def test_zero_length_chunks(self):
         """Test that zero-length chunks are handled safely."""
         events = list(stream_command(

--- a/tests/utils/test_stream_process.py
+++ b/tests/utils/test_stream_process.py
@@ -190,6 +190,50 @@ class TestExtraFdCapture:
         assert fd10_data == b"fd10"
         assert fd11_data == b"fd11"
 
+    def test_extra_fd_capture_handles_pipe_fd_collision(self):
+        """Test extra fd capture when pipe fds collide with child fd targets."""
+        probe_fds = []
+        try:
+            for _ in range(8):
+                probe_fds.append(os.open(os.devnull, os.O_RDONLY))
+            first_child_fd = probe_fds[6]
+            second_child_fd = probe_fds[7]
+
+            for fd in probe_fds:
+                os.close(fd)
+            probe_fds = []
+
+            events = list(stream_command(
+                [
+                    sys.executable,
+                    "-c",
+                    f"import os, sys; "
+                    f"os.write({first_child_fd}, b'fd1'); "
+                    f"os.close({first_child_fd}); "
+                    f"os.write({second_child_fd}, b'fd2'); "
+                    f"os.close({second_child_fd}); "
+                    "sys.exit(0)",
+                ],
+                extra_fds=[
+                    CapturedFd(first_child_fd),
+                    CapturedFd(second_child_fd),
+                ],
+            ))
+        finally:
+            for fd in probe_fds:
+                os.close(fd)
+
+        output_events = [e for e in events if isinstance(e, OutputEvent)]
+        exit_events = [e for e in events if isinstance(e, ExitEvent)]
+
+        fd1_data = b"".join(e.data for e in output_events if e.fd == first_child_fd)
+        fd2_data = b"".join(e.data for e in output_events if e.fd == second_child_fd)
+        stderr_data = b"".join(e.data for e in output_events if e.fd == 2)
+
+        assert exit_events[0].exit_code == 0, stderr_data.decode(errors="replace")
+        assert fd1_data == b"fd1"
+        assert fd2_data == b"fd2"
+
     def test_duplicate_captured_fd_rejected(self):
         """Test that duplicate CapturedFd entries are rejected."""
         with pytest.raises(ValueError, match="duplicate"):
@@ -440,6 +484,147 @@ class TestCwdAndEnv:
 
         assert output_data == b"content"
 
+    def test_cwd_parameter_does_not_use_fork(self, tmp_path, monkeypatch):
+        """Test cwd execution stays on the posix_spawn path."""
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("content")
+
+        def fail_fork():
+            raise AssertionError("fork should not be called")
+
+        monkeypatch.setattr(os, "fork", fail_fork)
+
+        events = list(stream_command(["cat", "test.txt"], cwd=str(tmp_path)))
+        output = b"".join(
+            event.data
+            for event in events
+            if isinstance(event, OutputEvent) and event.fd == 1
+        )
+
+        assert output == b"content"
+
+    def test_cwd_parameter_preserves_arguments(self, tmp_path):
+        """Test cwd shell wrapper does not reinterpret command arguments."""
+        events = list(stream_command(
+            [
+                sys.executable,
+                "-c",
+                "import os, sys; print(os.getcwd()); print('\\n'.join(sys.argv[1:]))",
+                "has space",
+                "*.txt",
+                "$HOME",
+                "semi;colon",
+            ],
+            cwd=str(tmp_path),
+        ))
+        output = b"".join(
+            event.data
+            for event in events
+            if isinstance(event, OutputEvent) and event.fd == 1
+        )
+
+        assert output.splitlines() == [
+            str(tmp_path).encode(),
+            b"has space",
+            b"*.txt",
+            b"$HOME",
+            b"semi;colon",
+        ]
+
+    def test_cwd_parameter_preserves_leading_dash_directory(self, tmp_path, monkeypatch):
+        """Test cwd shell wrapper does not reinterpret leading-dash paths."""
+        dashed_dir = tmp_path / "-"
+        dashed_dir.mkdir()
+        monkeypatch.chdir(tmp_path)
+
+        events = list(stream_command(
+            [
+                sys.executable,
+                "-c",
+                "import os; print(os.path.basename(os.getcwd()))",
+            ],
+            cwd="-",
+        ))
+        output = b"".join(
+            event.data
+            for event in events
+            if isinstance(event, OutputEvent) and event.fd == 1
+        )
+
+        assert output == b"-\n"
+
+    def test_cwd_parameter_with_extra_fd_capture(self, tmp_path):
+        """Test extra child fds remain available when cwd is set."""
+        events = list(stream_command(
+            [
+                sys.executable,
+                "-c",
+                "import os, sys; os.write(10, os.getcwd().encode()); sys.exit(0)",
+            ],
+            cwd=str(tmp_path),
+            extra_fds=[CapturedFd(10)],
+        ))
+
+        fd10_data = b"".join(
+            e.data for e in events
+            if isinstance(e, OutputEvent) and e.fd == 10
+        )
+
+        assert fd10_data == str(tmp_path).encode()
+
+    def test_cwd_shell_lookup_ignores_env_path(self, tmp_path):
+        """Test cwd shell wrapper lookup does not use the child PATH."""
+        marker = tmp_path / "used-sh"
+        shell = tmp_path / "sh"
+        shell.write_text(
+            "#!/bin/sh\n"
+            "printf used > \"$SH_MARKER\"\n"
+            "exec /bin/sh \"$@\"\n"
+        )
+        shell.chmod(0o755)
+
+        events = list(stream_command(
+            [sys.executable, "-c", "print('ok')"],
+            cwd=str(tmp_path),
+            env={"PATH": str(tmp_path), "SH_MARKER": str(marker)},
+        ))
+
+        output_events = [e for e in events if isinstance(e, OutputEvent) and e.fd == 1]
+        output_data = b"".join(e.data for e in output_events)
+
+        assert output_data == b"ok\n"
+        assert not marker.exists()
+
+    def test_cwd_restricted_path_finds_target_command(self, tmp_path):
+        """Test cwd execution can find the target in a restricted PATH."""
+        command = tmp_path / "hello"
+        command.write_text("#!/bin/sh\nprintf cwd-target\n")
+        command.chmod(0o755)
+
+        events = list(stream_command(
+            ["hello"],
+            cwd=str(tmp_path),
+            env={"PATH": str(tmp_path)},
+        ))
+
+        output_events = [e for e in events if isinstance(e, OutputEvent) and e.fd == 1]
+        output_data = b"".join(e.data for e in output_events)
+
+        assert output_data == b"cwd-target"
+
+    def test_cwd_absolute_command_allows_empty_env_path(self, tmp_path):
+        """Test cwd execution of absolute commands does not require PATH."""
+        events = list(stream_command(
+            [sys.executable, "-c", "print('absolute')"],
+            cwd=str(tmp_path),
+            env={"PATH": ""},
+        ))
+
+        output_events = [e for e in events if isinstance(e, OutputEvent) and e.fd == 1]
+        output_data = b"".join(e.data for e in output_events)
+
+        assert output_data == b"absolute\n"
+
     def test_env_parameter(self):
         """Test that env parameter works."""
         events = list(stream_command(
@@ -451,3 +636,41 @@ class TestCwdAndEnv:
         output_data = b"".join(e.data for e in output_events)
 
         assert b"test_value" in output_data
+
+    def test_env_path_controls_command_lookup(self, tmp_path):
+        """Test executable lookup uses PATH from the child environment."""
+        command = tmp_path / "hello-cmd"
+        command.write_text("#!/bin/sh\nprintf custom-path\n")
+        command.chmod(0o755)
+
+        events = list(stream_command(
+            ["hello-cmd"],
+            env={"PATH": str(tmp_path)},
+        ))
+
+        output_events = [e for e in events if isinstance(e, OutputEvent) and e.fd == 1]
+        output_data = b"".join(e.data for e in output_events)
+
+        assert output_data == b"custom-path"
+
+    def test_env_path_can_make_parent_path_commands_unavailable(self):
+        """Test command lookup does not fall back to the parent PATH."""
+        with pytest.raises(FileNotFoundError):
+            start_command(["true"], env={"PATH": ""})
+
+    def test_empty_env_path_searches_current_directory(self, tmp_path, monkeypatch):
+        """Test an empty PATH entry searches the current directory."""
+        command = tmp_path / "hello-current"
+        command.write_text("#!/bin/sh\nprintf current-dir\n")
+        command.chmod(0o755)
+        monkeypatch.chdir(tmp_path)
+
+        events = list(stream_command(
+            ["hello-current"],
+            env={"PATH": ""},
+        ))
+
+        output_events = [e for e in events if isinstance(e, OutputEvent) and e.fd == 1]
+        output_data = b"".join(e.data for e in output_events)
+
+        assert output_data == b"current-dir"

--- a/tests/utils/test_stream_process.py
+++ b/tests/utils/test_stream_process.py
@@ -1,5 +1,6 @@
 """Tests for POSIX subprocess streaming."""
 
+import errno
 import os
 import time
 
@@ -346,6 +347,24 @@ class TestProcessControl:
 
         exit_code = proc.wait()
         assert exit_code == 17
+
+    def test_wait_closes_captured_fds(self):
+        """Test wait() closes captured pipe fds when stream() is unused."""
+        proc = start_command([
+            sys.executable,
+            "-c",
+            "import sys; sys.stdout.write('out'); sys.stderr.write('err')",
+        ])
+        captured_fds = list(proc._output_fds)
+
+        exit_code = proc.wait()
+
+        assert exit_code == 0
+        assert proc._output_fds == {}
+        for fd in captured_fds:
+            with pytest.raises(OSError) as exc_info:
+                os.fstat(fd)
+            assert exc_info.value.errno == errno.EBADF
 
 
 class TestEdgeCases:


### PR DESCRIPTION
The program invokes Git commands and builds synthetic trees through
direct subprocess.run calls scattered across batch, sift, undo, abort,
discard, and hunk commands.

Those ad hoc process launches bypass posix_spawn safety, do not close
inherited file descriptors, and use predictable index paths that can
collide when commands run concurrently. Each caller reimplements its own
temporary index lifecycle, error capture, and resource cleanup.

This PR addresses that by introducing shared utility layers — a
spawn-safe command runner with one-shot capture, a Git-specific runner
that manages index environment, and temporary-index helpers with
automatic cleanup — then migrating every subprocess and synthetic tree
caller to use them.

## Commit series outline

**Foundation** (commits 1–12): empty-argument rejection, resource
cleanup on wait, posix_spawn-based streaming launch, one-shot capture,
Git-specific capture routing, temporary Git index helpers, and command
runner adoption in CLI help lookup and pattern matching — each paired
with test coverage.

**Caller migration** (commits 13–18): hunks, abort, and discard switch
from subprocess.run to the shared Git runner. Batch state refs, batch
source and content commits, sift synthetic sources, and undo/redo
checkpoints switch from hand-rolled index setup to the shared
temporary-index helpers.

At the end of the series, all command execution and synthetic Git tree
construction share the same spawn-safe utility layers.