### PR TITLE
Existing workflow fixes: lifecycle tracking, file modes, and CLI rename

### DIFF
--- a/completions/git-stage-batch
+++ b/completions/git-stage-batch
@@ -102,12 +102,12 @@ _git_stage_batch()
                     __git_stage_batch_set_nospace_for_dirs
                     return
                     ;;
-                --line)
-                    # Line IDs - no completion
+                --line|--lines|--as)
+                    # Free-form values - no completion
                     return
                     ;;
             esac
-            COMPREPLY=($(compgen -W "--file --files --from --to --line --no-edge-overlap" -- "$cur"))
+            COMPREPLY=($(compgen -W "--file --files --from --to --line --lines --as --as-stdin --no-edge-overlap" -- "$cur"))
             ;;
         skip)
             case "$prev" in
@@ -138,12 +138,12 @@ _git_stage_batch()
                     __git_stage_batch_set_nospace_for_dirs
                     return
                     ;;
-                --line)
-                    # Line IDs - no completion
+                --line|--lines|--as)
+                    # Free-form values - no completion
                     return
                     ;;
             esac
-            COMPREPLY=($(compgen -W "--file --files --from --to --line --no-edge-overlap" -- "$cur"))
+            COMPREPLY=($(compgen -W "--file --files --from --to --line --lines --as --as-stdin --no-edge-overlap" -- "$cur"))
             ;;
         apply)
             case "$prev" in

--- a/completions/git-stage-batch
+++ b/completions/git-stage-batch
@@ -107,7 +107,7 @@ _git_stage_batch()
                     return
                     ;;
             esac
-            COMPREPLY=($(compgen -W "--file --files --from --to --line" -- "$cur"))
+            COMPREPLY=($(compgen -W "--file --files --from --to --line --no-edge-overlap" -- "$cur"))
             ;;
         skip)
             case "$prev" in
@@ -143,7 +143,7 @@ _git_stage_batch()
                     return
                     ;;
             esac
-            COMPREPLY=($(compgen -W "--file --files --from --to --line" -- "$cur"))
+            COMPREPLY=($(compgen -W "--file --files --from --to --line --no-edge-overlap" -- "$cur"))
             ;;
         apply)
             case "$prev" in

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -493,10 +493,10 @@ file-scoped path with `TEXT` without staging it.
 `discard --to BATCH --line ... --as TEXT` saves replacement text to the batch
 and removes the original selected lines from the working tree.
 
-For line-scoped replacement workflows, `--as` now trims exact unchanged edge
-anchor lines by default when the provided text includes surrounding preserved
-context from the selected file span. Pass `--no-anchor` to keep those edge
-anchors literally.
+For line-scoped replacement workflows, `--as` now trims exact unchanged lines
+that overlap the preserved file context immediately before or after the
+selected span. Pass `--no-edge-overlap` to keep those edge-overlap lines
+literally.
 
 If the replacement text should come from a file or another command exactly,
 use `--as-stdin` instead of shell command substitution. For example:
@@ -506,7 +506,7 @@ use `--as-stdin` instead of shell command substitution. For example:
 ❯ some-command | git-stage-batch include --line 1-3 --as-stdin
 ❯ git-stage-batch discard --file path.txt --as-stdin < replacement.txt
 ❯ some-command | git-stage-batch discard --to batch --line 1-3 --as-stdin
-❯ git-stage-batch include --line 1-3 --as 'keep1\nstaged\nkeep4' --no-anchor
+❯ git-stage-batch include --line 1-3 --as 'keep1\nstaged\nkeep4' --no-edge-overlap
 ```
 
 Unlike `--as "$(cat replacement.txt)"`, `--as-stdin` preserves trailing

--- a/docs/git-stage-batch.1.in
+++ b/docs/git-stage-batch.1.in
@@ -216,14 +216,15 @@ Allows surgical removal of debug code or unwanted modifications.
 .TP
 .B include \-\-line \fILINE_IDS\fR \-\-as \fITEXT\fR
 Stage replacement text for the selected changed region.
-When TEXT includes exact unchanged edge anchors from the preserved file
-context, those anchors are stripped by default.
+When TEXT includes exact unchanged lines overlapping the preserved file
+context immediately before or after the selected span, those edge-overlap
+lines are stripped by default.
 Replacement selections must form one contiguous displayed line-ID range.
 File-scoped views may span omitted gap markers when the selected IDs remain
 contiguous, but disjoint ranges still require separate commands.
 .TP
-.B include \-\-line \fILINE_IDS\fR \-\-as \fITEXT\fR \-\-no\-anchor
-Do not strip unchanged edge anchor lines from replacement text.
+.B include \-\-line \fILINE_IDS\fR \-\-as \fITEXT\fR \-\-no\-edge\-overlap
+Do not strip unchanged edge-overlap lines from replacement text.
 .TP
 .B include \-\-file \fIPATH\fR \-\-as \fITEXT\fR
 Stage TEXT as the full index content for the selected file-scoped path while
@@ -236,14 +237,15 @@ without staging it.
 .B discard \-\-to \fIBATCH\fR \-\-line \fILINE_IDS\fR \-\-as \fITEXT\fR
 Save replacement text to a batch and discard the original selected lines
 from the working tree.
-When TEXT includes exact unchanged edge anchors from the preserved file
-context, those anchors are stripped by default.
+When TEXT includes exact unchanged lines overlapping the preserved file
+context immediately before or after the selected span, those edge-overlap
+lines are stripped by default.
 Replacement selections must form one contiguous displayed line-ID range.
 File-scoped views may span omitted gap markers when the selected IDs remain
 contiguous, but disjoint ranges still require separate commands.
 .TP
-.B discard \-\-to \fIBATCH\fR \-\-line \fILINE_IDS\fR \-\-as \fITEXT\fR \-\-no\-anchor
-Do not strip unchanged edge anchor lines from replacement text.
+.B discard \-\-to \fIBATCH\fR \-\-line \fILINE_IDS\fR \-\-as \fITEXT\fR \-\-no\-edge\-overlap
+Do not strip unchanged edge-overlap lines from replacement text.
 .SS Permanent File Exclusion
 .TP
 .B block-file \fR[\fIPATH\fR]

--- a/docs/index.md
+++ b/docs/index.md
@@ -185,8 +185,8 @@ Similar to `git add -p` but **more granular and flexible**:
 # Exact unchanged edge anchors are stripped by default for line-scoped --as
 ❯ git-stage-batch include --line 1-2 --as 'keep1\nreplacement\nkeep4'
 
-# Keep those anchors literally with --no-anchor
-❯ git-stage-batch include --line 1-2 --as 'keep1\nreplacement\nkeep4' --no-anchor
+# Keep those edge-overlap lines literally with --no-edge-overlap
+❯ git-stage-batch include --line 1-2 --as 'keep1\nreplacement\nkeep4' --no-edge-overlap
 
 # Or stage full replacement text for one file-scoped path
 ❯ git-stage-batch include --file path.txt --as 'full staged file text'

--- a/src/git_stage_batch/batch/ownership.py
+++ b/src/git_stage_batch/batch/ownership.py
@@ -877,12 +877,12 @@ def validate_ownership_units(units: list[OwnershipUnit]) -> None:
             if unit.kind == OwnershipUnitKind.REPLACEMENT:
                 if not unit.claimed_source_lines or not unit.deletion_claims:
                     raise MergeError(
-                        _("Invalid replacement unit: must have both claimed lines and deletions")
+                        _("Invalid replacement in batch metadata: expected both added and removed lines.")
                     )
             elif unit.kind == OwnershipUnitKind.DELETION_ONLY:
                 if unit.claimed_source_lines or not unit.deletion_claims:
                     raise MergeError(
-                        _("Invalid deletion-only unit: must have deletions but no claimed lines")
+                        _("Invalid deletion in batch metadata: expected removed lines only.")
                     )
 
 
@@ -915,15 +915,12 @@ def select_ownership_units_by_display_ids(
             continue
         elif unit.is_atomic and intersection != unit.display_line_ids:
             # Partial selection of atomic unit - error
-            reason_text = f" ({unit.atomic_reason})" if unit.atomic_reason else ""
-
             raise AtomicUnitError(
-                _("Cannot partially select atomic ownership unit.\n"
-                  "Unit kind: {kind}{reason}\n"
-                  "Selected: {selected_ids}").format(
-                    kind=unit.kind.value,
-                    reason=reason_text,
-                    selected_ids=sorted(intersection)
+                _("Cannot select only part of this change.\n"
+                  "Select all related lines together: {required_ids}\n"
+                  "You selected: {selected_ids}").format(
+                    required_ids=format_line_ids(sorted(unit.display_line_ids)),
+                    selected_ids=format_line_ids(sorted(intersection))
                 ),
                 required_selection_ids=unit.display_line_ids,
                 unit_kind=unit.kind.value

--- a/src/git_stage_batch/batch/query.py
+++ b/src/git_stage_batch/batch/query.py
@@ -31,7 +31,8 @@ def read_batch_metadata(name: str) -> dict:
                 "claimed_lines": list[str],  # e.g. ["1-5", "10", "15-20"]
                 "deletions": list[dict],  # [{"after_source_line": int|None, "blob": str}]
                 "replacement_units": list[dict],  # optional claimed/deletion coupling
-                "mode": str  # File mode (e.g. "100644")
+                "mode": str,  # File mode (e.g. "100644")
+                "change_type": str,  # optional text lifecycle: "added" or "deleted"
             }
         }
     }

--- a/src/git_stage_batch/batch/storage.py
+++ b/src/git_stage_batch/batch/storage.py
@@ -12,6 +12,7 @@ from .query import get_batch_baseline_commit, get_batch_commit_sha, read_batch_m
 from .state_refs import read_file_backed_batch_metadata
 from .validation import batch_exists, validate_batch_name
 from ..core.models import BinaryFileChange
+from ..core.text_lifecycle import TextFileChangeType, resolve_text_change_type
 from ..data.batch_sources import (
     create_batch_source_commit,
     get_batch_source_for_file,
@@ -41,6 +42,7 @@ def add_file_to_batch(
     ownership: 'BatchOwnership',
     file_mode: str = "100644",
     batch_source_commit: str | None = None,
+    change_type: str | None = None,
 ) -> None:
     """Add or update a file in a batch using batch source-based storage.
 
@@ -55,6 +57,8 @@ def add_file_to_batch(
         file_mode: Git file mode (default: 100644)
         batch_source_commit: Optional existing batch source commit to use.
             When omitted, uses the active session batch-source cache.
+        change_type: Optional persisted text lifecycle type from another batch.
+            Only whole-file added/deleted lifecycle states are retained.
     """
     validate_batch_name(batch_name)
 
@@ -78,7 +82,8 @@ def add_file_to_batch(
 
     # Read base file content as bytes
     base_result = run_git_command(["show", f"{baseline_commit}:{file_path}"], check=False, text_output=False)
-    base_content = base_result.stdout if base_result.returncode == 0 else b""
+    baseline_exists = base_result.returncode == 0
+    base_content = base_result.stdout if baseline_exists else b""
 
     # Read batch source content as bytes
     batch_source_result = run_git_command(["show", f"{batch_source_commit}:{file_path}"], check=False, text_output=False)
@@ -91,26 +96,39 @@ def add_file_to_batch(
         ownership
     )
 
-    # Create blob for realized content (already bytes, no encoding needed)
-    blob_sha = create_git_blob([realized_content_bytes])
+    text_change_type = resolve_text_change_type(
+        file_path=file_path,
+        baseline_exists=baseline_exists,
+        batch_source_content=batch_source_content,
+        realized_content=realized_content_bytes,
+        requested_change_type=change_type,
+    )
 
     # Update batch metadata
     metadata = read_batch_metadata(batch_name)
     if "files" not in metadata:
         metadata["files"] = {}
 
-    metadata["files"][file_path] = {
+    file_metadata = {
         "batch_source_commit": batch_source_commit,
         **ownership.to_metadata_dict(),
         "mode": file_mode
     }
+    if text_change_type != TextFileChangeType.MODIFIED:
+        file_metadata["change_type"] = text_change_type.value
+    metadata["files"][file_path] = file_metadata
 
     # Write updated metadata
     metadata_path = get_batch_metadata_file_path(batch_name)
     write_text_file_contents(metadata_path, json.dumps(metadata, indent=2))
 
-    # Build batch commit tree with realized content
-    _update_batch_commit(batch_name, file_path, blob_sha, file_mode)
+    # Build batch commit tree with realized content. Deleted text paths are
+    # represented by metadata plus path absence in the batch tree.
+    if text_change_type == TextFileChangeType.DELETED:
+        _remove_file_from_batch_commit(batch_name, file_path)
+    else:
+        blob_sha = create_git_blob([realized_content_bytes])
+        _update_batch_commit(batch_name, file_path, blob_sha, file_mode)
 
 
 def add_binary_file_to_batch(

--- a/src/git_stage_batch/batch/storage.py
+++ b/src/git_stage_batch/batch/storage.py
@@ -161,6 +161,8 @@ def add_binary_file_to_batch(
 
     current_binary_content: bytes | None = None
     if binary_change.is_deleted_file():
+        # Deleted binaries need the pre-delete source for baseline-style
+        # operations, so reuse/create the normal session source.
         batch_source_commit = get_batch_source_for_file(file_path)
         if not batch_source_commit:
             batch_source_commit = create_batch_source_commit(file_path)
@@ -168,6 +170,9 @@ def add_binary_file_to_batch(
             batch_sources[file_path] = batch_source_commit
             save_session_batch_sources(batch_sources)
     else:
+        # Added/modified binaries are atomic and cannot be reconstructed from
+        # line ownership. Capture the current bytes as their source, even when
+        # the session already has an older source commit for this path.
         if file_content_override is None:
             full_path = get_git_repository_root_path() / file_path
             if not full_path.exists():
@@ -180,7 +185,11 @@ def add_binary_file_to_batch(
             file_content_override=current_binary_content,
         )
 
+    # For binary files, store the full live file bytes as the realized content.
+    # Binary batches are atomic, so the batch commit must carry the exact bytes
+    # the user is saving.
     if binary_change.is_deleted_file():
+        # Deleted file: no content in batch (will be deleted when applied)
         blob_sha = None
     else:
         assert current_binary_content is not None

--- a/src/git_stage_batch/batch/storage.py
+++ b/src/git_stage_batch/batch/storage.py
@@ -22,6 +22,7 @@ from ..data.batch_sources import (
 from ..utils.file_io import write_text_file_contents
 from ..utils.git import (
     create_git_blob,
+    get_git_repository_root_path,
     git_commit_tree,
     git_read_tree,
     git_update_index,
@@ -134,7 +135,8 @@ def add_file_to_batch(
 def add_binary_file_to_batch(
     batch_name: str,
     binary_change: BinaryFileChange,
-    file_mode: str = "100644"
+    file_mode: str = "100644",
+    file_content_override: bytes | None = None,
 ) -> None:
     """Add a binary file change to a batch as an atomic unit.
 
@@ -145,6 +147,8 @@ def add_binary_file_to_batch(
         batch_name: Name of the batch
         binary_change: BinaryFileChange describing the change
         file_mode: Git file mode (default: 100644)
+        file_content_override: Optional bytes to persist for added/modified
+            binary changes instead of reading the current working tree.
     """
     validate_batch_name(batch_name)
 
@@ -155,32 +159,32 @@ def add_binary_file_to_batch(
     # Determine file path
     file_path = binary_change.new_path if binary_change.new_path != "/dev/null" else binary_change.old_path
 
-    # Get or create batch source commit for this file
-    batch_source_commit = get_batch_source_for_file(file_path)
-    if not batch_source_commit:
-        # Create batch source commit
-        batch_source_commit = create_batch_source_commit(file_path)
-        # Save to session cache
-        batch_sources = load_session_batch_sources()
-        batch_sources[file_path] = batch_source_commit
-        save_session_batch_sources(batch_sources)
-
-    # For binary files, store the full file from batch source as the realized content
+    current_binary_content: bytes | None = None
     if binary_change.is_deleted_file():
-        # Deleted file: no content in batch (will be deleted when applied)
+        batch_source_commit = get_batch_source_for_file(file_path)
+        if not batch_source_commit:
+            batch_source_commit = create_batch_source_commit(file_path)
+            batch_sources = load_session_batch_sources()
+            batch_sources[file_path] = batch_source_commit
+            save_session_batch_sources(batch_sources)
+    else:
+        if file_content_override is None:
+            full_path = get_git_repository_root_path() / file_path
+            if not full_path.exists():
+                raise FileNotFoundError(file_path)
+            current_binary_content = full_path.read_bytes()
+        else:
+            current_binary_content = file_content_override
+        batch_source_commit = create_batch_source_commit(
+            file_path,
+            file_content_override=current_binary_content,
+        )
+
+    if binary_change.is_deleted_file():
         blob_sha = None
     else:
-        # Added or modified: read full file from batch source
-        batch_source_result = run_git_command(
-            ["show", f"{batch_source_commit}:{file_path}"],
-            check=False,
-            text_output=False
-        )
-        if batch_source_result.returncode == 0:
-            blob_sha = create_git_blob([batch_source_result.stdout])
-        else:
-            # File doesn't exist in batch source (shouldn't happen for binary files)
-            blob_sha = None
+        assert current_binary_content is not None
+        blob_sha = create_git_blob([current_binary_content])
 
     # Update batch metadata with binary file marker
     metadata = read_batch_metadata(batch_name)

--- a/src/git_stage_batch/cli/argument_parser.py
+++ b/src/git_stage_batch/cli/argument_parser.py
@@ -559,10 +559,16 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
         help=_("Read replacement text from standard input exactly, preserving trailing newlines"),
     )
     parser_include.add_argument(
-        "--no-anchor",
-        dest="no_anchor",
+        "--no-edge-overlap",
+        dest="no_edge_overlap",
         action="store_true",
-        help=_("Do not strip unchanged edge anchor lines from replacement text used with --as"),
+        help=_("Do not strip unchanged edge-overlap lines from replacement text used with --as"),
+    )
+    parser_include.add_argument(
+        "--no-anchor",
+        dest="no_edge_overlap",
+        action="store_true",
+        help=argparse.SUPPRESS,
     )
 
     def dispatch_include(args: argparse.Namespace) -> None:
@@ -574,8 +580,8 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
         )
         if replacement_text is not None:
             if args.line_ids and args.from_batch and not args.to_batch:
-                if args.no_anchor:
-                    raise CommandError(_("`--no-anchor` only applies to live `include --line --as` operations."))
+                if args.no_edge_overlap:
+                    raise CommandError(_("`--no-edge-overlap` only applies to live `include --line --as` operations."))
                 if isinstance(resolved_batch_scope, list):
                     raise CommandError(_("Cannot use --lines with multiple files."))
                 commands.command_include_from_batch(
@@ -592,7 +598,7 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
                     args.line_ids,
                     replacement_text,
                     file=resolved_live_scope,
-                    no_anchor=args.no_anchor,
+                    no_edge_overlap=args.no_edge_overlap,
                 )
                 return
             if (
@@ -601,8 +607,8 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
                 and args.to_batch is None
                 and resolved_live_scope is not None
             ):
-                if args.no_anchor:
-                    raise CommandError(_("`--no-anchor` requires `include --line --as`."))
+                if args.no_edge_overlap:
+                    raise CommandError(_("`--no-edge-overlap` requires `include --line --as`."))
                 if isinstance(resolved_live_scope, list):
                     raise CommandError(_("Cannot use --as with multiple files."))
                 commands.command_include_file_as(replacement_text, file=resolved_live_scope)
@@ -610,8 +616,8 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
             raise CommandError(
                 _("`include --as` requires `--file` or `--line` and does not support `--to`.")
             )
-        if args.no_anchor:
-            raise CommandError(_("`--no-anchor` requires `include --line --as`."))
+        if args.no_edge_overlap:
+            raise CommandError(_("`--no-edge-overlap` requires `include --line --as`."))
         if args.from_batch:
             _run_for_each_file(
                 resolved_batch_scope,
@@ -719,10 +725,16 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
         help=_("Read replacement text from standard input exactly, preserving trailing newlines"),
     )
     parser_discard.add_argument(
-        "--no-anchor",
-        dest="no_anchor",
+        "--no-edge-overlap",
+        dest="no_edge_overlap",
         action="store_true",
-        help=_("Do not strip unchanged edge anchor lines from replacement text used with --as"),
+        help=_("Do not strip unchanged edge-overlap lines from replacement text used with --as"),
+    )
+    parser_discard.add_argument(
+        "--no-anchor",
+        dest="no_edge_overlap",
+        action="store_true",
+        help=argparse.SUPPRESS,
     )
 
     def dispatch_discard(args: argparse.Namespace) -> None:
@@ -741,7 +753,7 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
                     args.line_ids,
                     replacement_text,
                     file=resolved_live_scope,
-                    no_anchor=args.no_anchor,
+                    no_edge_overlap=args.no_edge_overlap,
                 )
                 return
             if (
@@ -750,8 +762,8 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
                 and args.line_ids is None
                 and resolved_live_scope is not None
             ):
-                if args.no_anchor:
-                    raise CommandError(_("`--no-anchor` requires `discard --to --line --as`."))
+                if args.no_edge_overlap:
+                    raise CommandError(_("`--no-edge-overlap` requires `discard --to --line --as`."))
                 if isinstance(resolved_live_scope, list):
                     raise CommandError(_("Cannot use --as with multiple files."))
                 commands.command_discard_file_as(replacement_text, file=resolved_live_scope)
@@ -759,8 +771,8 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
             raise CommandError(
                 _("`discard --as` requires `--file`, or `--to` with `--line`.")
             )
-        if args.no_anchor:
-            raise CommandError(_("`--no-anchor` requires `discard --to --line --as`."))
+        if args.no_edge_overlap:
+            raise CommandError(_("`--no-edge-overlap` requires `discard --to --line --as`."))
         if args.from_batch:
             _run_for_each_file(
                 resolved_batch_scope,

--- a/src/git_stage_batch/commands/apply_from.py
+++ b/src/git_stage_batch/commands/apply_from.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import stat
 import sys
 from typing import Optional
 
@@ -21,6 +22,17 @@ from ..data.undo import undo_checkpoint
 from ..exceptions import exit_with_error, MergeError, CommandError, AtomicUnitError, BatchMetadataError
 from ..i18n import _
 from ..utils.git import get_git_repository_root_path, require_git_repository, run_git_command
+
+
+def _apply_working_tree_file_mode(full_path, file_mode: str | None) -> None:
+    """Apply a normal Git file mode to a working-tree file."""
+    if file_mode is None:
+        return
+    current_mode = full_path.stat().st_mode
+    if file_mode == "100755":
+        full_path.chmod(current_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    else:
+        full_path.chmod(current_mode & ~(stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH))
 
 
 def _apply_binary_file_from_batch(batch_name: str, file_path: str, file_meta: dict) -> None:
@@ -47,6 +59,11 @@ def _apply_binary_file_from_batch(batch_name: str, file_path: str, file_meta: di
         raise RuntimeError(f"Batch commit not found for batch '{batch_name}'")
 
     change_type = file_meta.get("change_type", "modified")
+    if change_type == "deleted":
+        if full_path.exists():
+            full_path.unlink()
+            print(_("✓ Deleted binary file: {file}").format(file=file_path), file=sys.stderr)
+        return
 
     # Read file from batch commit tree
     result = run_git_command(
@@ -55,24 +72,23 @@ def _apply_binary_file_from_batch(batch_name: str, file_path: str, file_meta: di
         text_output=False
     )
 
-    if result.returncode == 0:
-        # File exists in batch commit - write to working tree
-        binary_content = result.stdout
-        full_path.parent.mkdir(parents=True, exist_ok=True)
-        full_path.write_bytes(binary_content)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"Binary file metadata for {file_path} says {change_type}, "
+            "but the batch content is missing"
+        )
 
-        if change_type == "added":
-            print(_("✓ Applied new binary file: {file}").format(file=file_path), file=sys.stderr)
-        else:
-            print(_("✓ Replaced binary file: {file}").format(file=file_path), file=sys.stderr)
+    # File exists in batch commit - write to working tree
+    binary_content = result.stdout
+    full_path.parent.mkdir(parents=True, exist_ok=True)
+    full_path.write_bytes(binary_content)
+
+    _apply_working_tree_file_mode(full_path, str(file_meta.get("mode", "100644")))
+
+    if change_type == "added":
+        print(_("✓ Applied new binary file: {file}").format(file=file_path), file=sys.stderr)
     else:
-        # File doesn't exist in batch commit - this is a deletion
-        if full_path.exists():
-            full_path.unlink()
-            print(_("✓ Deleted binary file: {file}").format(file=file_path), file=sys.stderr)
-        else:
-            # File already doesn't exist - no-op
-            pass
+        print(_("✓ Replaced binary file: {file}").format(file=file_path), file=sys.stderr)
 
 
 def command_apply_from_batch(

--- a/src/git_stage_batch/commands/apply_from.py
+++ b/src/git_stage_batch/commands/apply_from.py
@@ -261,6 +261,9 @@ def command_apply_from_batch(
                         working_content
                     )
 
+                # Write merged content to working tree (bytes). A selected
+                # deleted-text file still represents path absence once the
+                # selected deletion leaves the destination empty.
                 effective_change_type = selected_text_target_change_type(
                     text_change_type,
                     selected_ids,

--- a/src/git_stage_batch/commands/apply_from.py
+++ b/src/git_stage_batch/commands/apply_from.py
@@ -16,6 +16,12 @@ from ..batch.selection import (
     translate_atomic_unit_error_to_gutter_ids,
 )
 from ..batch.validation import batch_exists
+from ..core.text_lifecycle import (
+    TextFileChangeType,
+    mode_for_text_materialization,
+    normalized_text_change_type,
+    selected_text_target_change_type,
+)
 from ..data.hunk_tracking import render_batch_file_display
 from ..data.session import snapshot_file_if_untracked
 from ..data.undo import undo_checkpoint
@@ -91,6 +97,29 @@ def _apply_binary_file_from_batch(batch_name: str, file_path: str, file_meta: di
         print(_("✓ Replaced binary file: {file}").format(file=file_path), file=sys.stderr)
 
 
+def _write_text_file_from_batch(
+    file_path: str,
+    content: bytes | None,
+    file_mode: str | None,
+    change_type: str = "modified",
+) -> None:
+    """Write one text batch target into the working tree."""
+    repo_root = get_git_repository_root_path()
+    full_path = repo_root / file_path
+
+    if normalized_text_change_type(change_type) == TextFileChangeType.DELETED:
+        if full_path.exists():
+            full_path.unlink()
+        return
+
+    if content is None:
+        raise RuntimeError(f"Text file not found in batch content: {file_path}")
+
+    full_path.parent.mkdir(parents=True, exist_ok=True)
+    full_path.write_bytes(content)
+    _apply_working_tree_file_mode(full_path, file_mode)
+
+
 def command_apply_from_batch(
     batch_name: str,
     line_ids: Optional[str] = None,
@@ -157,7 +186,7 @@ def command_apply_from_batch(
         operation_parts.extend(["--line", line_ids])
     if file is not None:
         operation_parts.extend(["--file", file])
-    with undo_checkpoint(" ".join(operation_parts)):
+    with undo_checkpoint(" ".join(operation_parts), worktree_paths=list(files)):
         # Apply all files in batch
         repo_root = get_git_repository_root_path()
         failed_files = []
@@ -171,6 +200,8 @@ def command_apply_from_batch(
                 if file_meta.get("file_type") == "binary":
                     _apply_binary_file_from_batch(batch_name, file_path, file_meta)
                     continue
+
+                text_change_type = normalized_text_change_type(file_meta.get("change_type"))
 
                 # Get batch source commit content (as bytes)
                 batch_source_commit = file_meta["batch_source_commit"]
@@ -186,10 +217,20 @@ def command_apply_from_batch(
 
                 # Get selected working tree content (as bytes)
                 full_path = repo_root / file_path
-                if full_path.exists():
+                working_exists = full_path.exists()
+                if working_exists:
                     working_content = full_path.read_bytes()
                 else:
                     working_content = b""
+
+                file_mode = mode_for_text_materialization(
+                    str(file_meta.get("mode", "100644")),
+                    selected_ids,
+                    destination_exists=working_exists,
+                )
+                if selected_ids is None and text_change_type == TextFileChangeType.DELETED:
+                    _write_text_file_from_batch(file_path, None, file_mode, text_change_type)
+                    continue
 
                 # Get ownership from metadata, filtered by selected selection IDs if specified
                 try:
@@ -208,18 +249,29 @@ def command_apply_from_batch(
 
                 # If nothing selected for this file, skip it
                 if ownership.is_empty():
-                    continue
+                    if selected_ids is None and text_change_type == TextFileChangeType.ADDED:
+                        merged_content = b""
+                    else:
+                        continue
+                else:
+                    # Perform structural merge
+                    merged_content = merge_batch(
+                        batch_source_content,
+                        ownership,
+                        working_content
+                    )
 
-                # Perform structural merge
-                merged_content = merge_batch(
-                    batch_source_content,
-                    ownership,
-                    working_content
+                effective_change_type = selected_text_target_change_type(
+                    text_change_type,
+                    selected_ids,
+                    merged_content,
                 )
-
-                # Write merged content to working tree (bytes)
-                full_path.parent.mkdir(parents=True, exist_ok=True)
-                full_path.write_bytes(merged_content)
+                _write_text_file_from_batch(
+                    file_path,
+                    merged_content,
+                    file_mode,
+                    effective_change_type,
+                )
 
             except MergeError:
                 # Merge conflict - batch created from different file version

--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import stat
 import sys
 
 from ..batch import add_file_to_batch, create_batch
@@ -625,12 +626,7 @@ def _command_discard_lines_to_batch_as(
                   "Error: {error}").format(file=line_changes.path, batch=batch_name, error=str(e))
             )
 
-        ls_result = run_git_command(["ls-files", "-s", "--", line_changes.path], check=False)
-        file_mode = "100644"
-        if ls_result.returncode == 0 and ls_result.stdout.strip():
-            parts = ls_result.stdout.strip().split()
-            if parts:
-                file_mode = parts[0]
+        file_mode = _detect_file_mode(line_changes.path)
 
         if batch_source_commit is None:
             batch_source_commit = create_batch_source_commit(
@@ -713,6 +709,20 @@ def _select_rewritten_replacement_lines(
     exit_with_error(_("Replacement selection could not be located after rewriting the file."))
 
 
+def _detect_file_mode(file_path: str) -> str:
+    """Return the current git file mode for a path, defaulting to a regular file."""
+    absolute_path = get_git_repository_root_path() / file_path
+    if absolute_path.exists():
+        return "100755" if absolute_path.stat().st_mode & stat.S_IXUSR else "100644"
+
+    ls_result = run_git_command(["ls-files", "-s", "--", file_path], check=False)
+    if ls_result.returncode == 0 and ls_result.stdout.strip():
+        parts = ls_result.stdout.strip().split()
+        if parts:
+            return parts[0]
+    return "100644"
+
+
 def _command_discard_file_to_batch(batch_name: str, file_path: str, *, quiet: bool = False) -> None:
     """Discard entire file to batch (internal helper for file-scoped operations)."""
 
@@ -728,12 +738,7 @@ def _command_discard_file_to_batch(batch_name: str, file_path: str, *, quiet: bo
     blocked_hashes = set(blocklist_text.splitlines())
 
     # Detect file mode
-    ls_result = run_git_command(["ls-files", "-s", "--", file_path], check=False)
-    file_mode = "100644"  # default
-    if ls_result.returncode == 0 and ls_result.stdout.strip():
-        parts = ls_result.stdout.strip().split()
-        if parts:
-            file_mode = parts[0]
+    file_mode = _detect_file_mode(file_path)
 
     # Collect ALL hunks from this file (live working tree state)
     all_lines_to_batch = []
@@ -888,12 +893,7 @@ def _command_discard_file_lines_to_batch(batch_name: str, file_path: str, line_i
         return
 
     # Detect file mode
-    ls_result = run_git_command(["ls-files", "-s", "--", file_path], check=False)
-    file_mode = "100644"  # default
-    if ls_result.returncode == 0 and ls_result.stdout.strip():
-        parts = ls_result.stdout.strip().split()
-        if parts:
-            file_mode = parts[0]
+    file_mode = _detect_file_mode(file_path)
 
     # Prepare batch ownership update (handles stale source, translation, merge)
 
@@ -1011,12 +1011,7 @@ def _command_discard_lines_to_batch(batch_name: str, line_id_specification: str,
         )
 
     # Detect file mode
-    ls_result = run_git_command(["ls-files", "-s", "--", line_changes.path], check=False)
-    file_mode = "100644"  # default
-    if ls_result.returncode == 0 and ls_result.stdout.strip():
-        parts = ls_result.stdout.strip().split()
-        if parts:
-            file_mode = parts[0]
+    file_mode = _detect_file_mode(line_changes.path)
 
     # add_file_to_batch creates the batch source commit from this snapshot.
     snapshot_file_if_untracked(line_changes.path)
@@ -1082,12 +1077,7 @@ def _command_discard_hunk_to_batch(batch_name: str, file_only: bool = False, *, 
     blocked_hashes = set(blocklist_text.splitlines())
 
     # Detect file mode
-    ls_result = run_git_command(["ls-files", "-s", "--", file_path], check=False)
-    file_mode = "100644"  # default
-    if ls_result.returncode == 0 and ls_result.stdout.strip():
-        parts = ls_result.stdout.strip().split()
-        if parts:
-            file_mode = parts[0]
+    file_mode = _detect_file_mode(file_path)
 
     # Collect all lines to batch (either selected hunk or all hunks from file)
     all_lines_to_batch = []

--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -460,7 +460,7 @@ def command_discard_line_as_to_batch(
     replacement_text: str,
     file: str | None = None,
     *,
-    no_anchor: bool = False,
+    no_edge_overlap: bool = False,
     quiet: bool = False,
 ) -> None:
     """Save replacement text to batch, then discard the original selection locally."""
@@ -474,8 +474,8 @@ def command_discard_line_as_to_batch(
         "--line", line_id_specification,
         "--as", replacement_text,
     ]
-    if no_anchor:
-        operation_parts.append("--no-anchor")
+    if no_edge_overlap:
+        operation_parts.append("--no-edge-overlap")
     if file is not None:
         operation_parts.extend(["--file", file])
     with undo_checkpoint(" ".join(operation_parts)):
@@ -499,7 +499,7 @@ def command_discard_line_as_to_batch(
                 batch_name,
                 line_id_specification,
                 replacement_text,
-                no_anchor=no_anchor,
+                no_edge_overlap=no_edge_overlap,
                 quiet=quiet,
             )
 
@@ -515,7 +515,7 @@ def _command_discard_lines_to_batch_as(
     line_id_specification: str,
     replacement_text: str,
     *,
-    no_anchor: bool = False,
+    no_edge_overlap: bool = False,
     quiet: bool = False,
 ) -> None:
     """Persist replacement text to batch and discard original selected lines."""
@@ -541,7 +541,7 @@ def _command_discard_lines_to_batch_as(
             effective_ids,
             replacement_text,
             working_bytes,
-            trim_unchanged_edge_anchors=not no_anchor,
+            trim_unchanged_edge_anchors=not no_edge_overlap,
         )
     except ValueError as e:
         exit_with_error(str(e))

--- a/src/git_stage_batch/commands/discard_from.py
+++ b/src/git_stage_batch/commands/discard_from.py
@@ -13,12 +13,19 @@ from ..batch.selection import (
     resolve_batch_file_scope,
     require_single_file_context_for_line_selection,
     select_batch_ownership_for_display_ids,
+    translate_atomic_unit_error_to_gutter_ids,
 )
 from ..batch.validation import batch_exists
+from ..core.text_lifecycle import (
+    TextFileChangeType,
+    mode_for_text_materialization,
+    normalized_text_change_type,
+    selected_text_discard_change_type,
+)
 from ..data.hunk_tracking import render_batch_file_display
 from ..data.session import snapshot_file_if_untracked
 from ..data.undo import undo_checkpoint
-from ..exceptions import exit_with_error, MergeError, BatchMetadataError
+from ..exceptions import exit_with_error, AtomicUnitError, CommandError, MergeError, BatchMetadataError
 from ..i18n import _
 from ..utils.git import get_git_repository_root_path, require_git_repository, run_git_command
 
@@ -88,6 +95,27 @@ def _discard_binary_file_from_batch(file_path: str, baseline_commit: str) -> Non
             pass
 
 
+def _discard_text_file_lifecycle_from_batch(file_path: str, baseline_commit: str) -> None:
+    """Discard a whole-path text add/delete by restoring baseline state."""
+    repo_root = get_git_repository_root_path()
+    full_path = repo_root / file_path
+
+    result = run_git_command(
+        ["show", f"{baseline_commit}:{file_path}"],
+        check=False,
+        text_output=False,
+    )
+    if result.returncode == 0:
+        full_path.parent.mkdir(parents=True, exist_ok=True)
+        full_path.write_bytes(result.stdout)
+        _restore_working_tree_file_mode(
+            full_path,
+            _baseline_file_mode(baseline_commit, file_path),
+        )
+    elif full_path.exists():
+        full_path.unlink()
+
+
 def command_discard_from_batch(
     batch_name: str,
     line_ids: Optional[str] = None,
@@ -136,6 +164,7 @@ def command_discard_from_batch(
 
     # Translate gutter IDs to selection IDs if line selection is active
     selection_ids_to_discard = selected_ids
+    rendered = None
     if selected_ids:
         # Use pure render helper to get gutter ID mapping (no side effects)
         file_path_for_render = list(files.keys())[0]  # Single file context enforced above
@@ -159,7 +188,7 @@ def command_discard_from_batch(
         operation_parts.extend(["--line", line_ids])
     if file is not None:
         operation_parts.extend(["--file", file])
-    with undo_checkpoint(" ".join(operation_parts)):
+    with undo_checkpoint(" ".join(operation_parts), worktree_paths=list(files)):
         # Discard all files in batch
         repo_root = get_git_repository_root_path()
         failed_files = []
@@ -172,6 +201,14 @@ def command_discard_from_batch(
                 # Binary files are atomic units - handle separately without ownership/merge logic
                 if file_meta.get("file_type") == "binary":
                     _discard_binary_file_from_batch(file_path, baseline_commit)
+                    continue
+
+                text_change_type = normalized_text_change_type(file_meta.get("change_type"))
+                if selected_ids is None and text_change_type in {
+                    TextFileChangeType.ADDED,
+                    TextFileChangeType.DELETED,
+                }:
+                    _discard_text_file_lifecycle_from_batch(file_path, baseline_commit)
                     continue
 
                 # Get batch source commit content (as bytes)
@@ -192,19 +229,35 @@ def command_discard_from_batch(
                     check=False,
                     text_output=False
                 )
-                baseline_content = baseline_result.stdout if baseline_result.returncode == 0 else b""
+                baseline_exists = baseline_result.returncode == 0
+                baseline_content = baseline_result.stdout if baseline_exists else b""
 
                 # Get selected working tree content (as bytes)
                 full_path = repo_root / file_path
-                if full_path.exists():
+                working_exists = full_path.exists()
+                if working_exists:
                     working_content = full_path.read_bytes()
                 else:
                     working_content = b""
+                baseline_mode = _baseline_file_mode(baseline_commit, file_path)
+                restore_mode = mode_for_text_materialization(
+                    baseline_mode,
+                    selected_ids,
+                    destination_exists=working_exists,
+                )
 
                 # Get ownership from metadata, filtered by selected selection IDs if specified
-                ownership = select_batch_ownership_for_display_ids(
-                    file_meta, batch_source_content, selection_ids_to_discard
-                )
+                try:
+                    ownership = select_batch_ownership_for_display_ids(
+                        file_meta, batch_source_content, selection_ids_to_discard
+                    )
+                except AtomicUnitError as e:
+                    if rendered:
+                        translate_atomic_unit_error_to_gutter_ids(e, rendered, "discard from", batch_name)
+                    exit_with_error(_("Failed to discard from batch '{name}': {error}").format(
+                        name=batch_name,
+                        error=str(e),
+                    ))
 
                 # If nothing selected for this file, skip it
                 if ownership.is_empty():
@@ -218,10 +271,22 @@ def command_discard_from_batch(
                     baseline_content
                 )
 
-                # Write to working tree (bytes)
-                full_path.parent.mkdir(parents=True, exist_ok=True)
-                full_path.write_bytes(discarded_content)
+                effective_change_type = selected_text_discard_change_type(
+                    text_change_type,
+                    selected_ids,
+                    discarded_content,
+                    baseline_exists=baseline_exists,
+                )
+                if effective_change_type == TextFileChangeType.DELETED:
+                    if full_path.exists():
+                        full_path.unlink()
+                else:
+                    full_path.parent.mkdir(parents=True, exist_ok=True)
+                    full_path.write_bytes(discarded_content)
+                    _restore_working_tree_file_mode(full_path, restore_mode)
 
+            except CommandError:
+                raise
             except MergeError as e:
                 print(_("Error discarding {file}: {error}").format(file=file_path, error=str(e)), file=sys.stderr)
                 failed_files.append(file_path)

--- a/src/git_stage_batch/commands/discard_from.py
+++ b/src/git_stage_batch/commands/discard_from.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import stat
 import sys
+from pathlib import Path
 from typing import Optional
 
 from ..batch.merge import discard_batch
@@ -19,6 +21,28 @@ from ..data.undo import undo_checkpoint
 from ..exceptions import exit_with_error, MergeError, BatchMetadataError
 from ..i18n import _
 from ..utils.git import get_git_repository_root_path, require_git_repository, run_git_command
+
+
+def _baseline_file_mode(baseline_commit: str, file_path: str) -> str | None:
+    """Return file mode for a path in the baseline tree, if present."""
+    result = run_git_command(
+        ["ls-tree", baseline_commit, "--", file_path],
+        check=False,
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+    return result.stdout.split(maxsplit=1)[0]
+
+
+def _restore_working_tree_file_mode(file_path: Path, file_mode: str | None) -> None:
+    """Restore executable bits for a working-tree file from a Git file mode."""
+    if file_mode is None:
+        return
+    current_mode = file_path.stat().st_mode
+    if file_mode == "100755":
+        file_path.chmod(current_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    else:
+        file_path.chmod(current_mode & ~(stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH))
 
 
 def _discard_binary_file_from_batch(file_path: str, baseline_commit: str) -> None:
@@ -49,6 +73,10 @@ def _discard_binary_file_from_batch(file_path: str, baseline_commit: str) -> Non
         baseline_content = result.stdout
         full_path.parent.mkdir(parents=True, exist_ok=True)
         full_path.write_bytes(baseline_content)
+        _restore_working_tree_file_mode(
+            full_path,
+            _baseline_file_mode(baseline_commit, file_path),
+        )
         print(_("✓ Restored binary file to baseline: {file}").format(file=file_path), file=sys.stderr)
     else:
         # File doesn't exist in baseline - delete from working tree

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -662,7 +662,7 @@ def command_include_line_as(
     replacement_text: str,
     file: str | None = None,
     *,
-    no_anchor: bool = False,
+    no_edge_overlap: bool = False,
 ) -> None:
     """Stage a replacement for one contiguous selected line span and mask it."""
     require_git_repository()
@@ -670,8 +670,8 @@ def command_include_line_as(
     ensure_state_directory_exists()
 
     operation_parts = ["include", "--line", line_id_specification, "--as", replacement_text]
-    if no_anchor:
-        operation_parts.append("--no-anchor")
+    if no_edge_overlap:
+        operation_parts.append("--no-edge-overlap")
     if file is not None:
         operation_parts.extend(["--file", file])
 
@@ -691,7 +691,7 @@ def command_include_line_as(
                 replacement_text=replacement_text,
                 hunk_base_content=hunk_base_content,
                 hunk_source_content=hunk_source_content,
-                trim_unchanged_edge_anchors=not no_anchor,
+                trim_unchanged_edge_anchors=not no_edge_overlap,
             )
 
             write_line_ids_file(get_processed_include_ids_file_path(), set())
@@ -737,7 +737,7 @@ def command_include_line_as(
                 replacement_text=replacement_text,
                 hunk_base_content=hunk_base_content,
                 hunk_source_content=hunk_source_content,
-                trim_unchanged_edge_anchors=not no_anchor,
+                trim_unchanged_edge_anchors=not no_edge_overlap,
             )
 
             if preserve_selected_state:

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import stat
 import sys
 
 from ..batch import add_file_to_batch, create_batch
@@ -74,6 +75,20 @@ from ..utils.paths import (
     get_processed_include_ids_file_path,
     get_working_tree_snapshot_file_path,
 )
+
+
+def _detect_file_mode(file_path: str) -> str:
+    """Return the current git file mode for a path, defaulting to a regular file."""
+    absolute_path = get_git_repository_root_path() / file_path
+    if absolute_path.exists():
+        return "100755" if absolute_path.stat().st_mode & stat.S_IXUSR else "100644"
+
+    ls_result = run_git_command(["ls-files", "-s", "--", file_path], check=False)
+    if ls_result.returncode == 0 and ls_result.stdout.strip():
+        parts = ls_result.stdout.strip().split()
+        if parts:
+            return parts[0]
+    return "100644"
 
 
 def command_include(*, quiet: bool = False) -> None:
@@ -806,12 +821,7 @@ def _command_include_file_to_batch(batch_name: str, file_path: str, *, quiet: bo
         create_batch(batch_name, "Auto-created")
 
     # Detect file mode
-    ls_result = run_git_command(["ls-files", "-s", "--", file_path], check=False)
-    file_mode = "100644"  # default
-    if ls_result.returncode == 0 and ls_result.stdout.strip():
-        parts = ls_result.stdout.strip().split()
-        if parts:
-            file_mode = parts[0]
+    file_mode = _detect_file_mode(file_path)
 
     # Collect ALL hunks from this file (live working tree state)
     all_lines_to_batch = []
@@ -903,12 +913,7 @@ def _command_include_file_lines_to_batch(batch_name: str, file_path: str, line_i
         return
 
     # Detect file mode
-    ls_result = run_git_command(["ls-files", "-s", "--", file_path], check=False)
-    file_mode = "100644"  # default
-    if ls_result.returncode == 0 and ls_result.stdout.strip():
-        parts = ls_result.stdout.strip().split()
-        if parts:
-            file_mode = parts[0]
+    file_mode = _detect_file_mode(file_path)
 
     # Prepare batch ownership update (handles stale source, translation, merge)
 
@@ -1008,12 +1013,7 @@ def _command_include_lines_to_batch(batch_name: str, line_id_specification: str,
         )
 
     # Detect file mode
-    ls_result = run_git_command(["ls-files", "-s", "--", line_changes.path], check=False)
-    file_mode = "100644"  # default
-    if ls_result.returncode == 0 and ls_result.stdout.strip():
-        parts = ls_result.stdout.strip().split()
-        if parts:
-            file_mode = parts[0]
+    file_mode = _detect_file_mode(line_changes.path)
 
     # Save to batch using batch source model
     add_file_to_batch(batch_name, line_changes.path, ownership, file_mode)
@@ -1079,12 +1079,7 @@ def _command_include_hunk_to_batch(batch_name: str, file_only: bool = False, *, 
     file_path = selected_patch.new_path
 
     # Detect file mode
-    ls_result = run_git_command(["ls-files", "-s", "--", file_path], check=False)
-    file_mode = "100644"  # default
-    if ls_result.returncode == 0 and ls_result.stdout.strip():
-        parts = ls_result.stdout.strip().split()
-        if parts:
-            file_mode = parts[0]
+    file_mode = _detect_file_mode(file_path)
 
     # Collect all lines to batch (either selected hunk or all hunks from file)
     all_lines_to_batch = []

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import stat
 import sys
 
-from ..batch import add_file_to_batch, create_batch
+from ..batch import add_binary_file_to_batch, add_file_to_batch, create_batch
 from ..batch.comparison import (
     SemanticChangeKind,
     derive_display_id_run_sets,
@@ -21,7 +21,7 @@ from ..core.diff_parser import (
     build_line_changes_from_patch_bytes,
     parse_unified_diff_streaming,
 )
-from ..core.hashing import compute_stable_hunk_hash
+from ..core.hashing import compute_binary_file_hash, compute_stable_hunk_hash
 from ..core.line_selection import (
     format_line_ids,
     parse_line_selection,
@@ -42,6 +42,7 @@ from ..data.hunk_tracking import (
     load_selected_change,
     read_selected_change_kind,
     recalculate_selected_hunk_for_file,
+    record_binary_hunk_skipped,
     record_hunk_included,
     record_hunk_skipped,
     require_selected_hunk,
@@ -806,11 +807,53 @@ def command_include_to_batch(batch_name: str, line_ids: str | None = None, file:
                 _command_include_file_lines_to_batch(batch_name, target_file, line_ids, quiet=quiet)
         else:
             # Hunk-scoped operation (selected behavior)
-            if line_ids is not None:
+            if (
+                line_ids is None
+                and read_selected_change_kind() == SelectedChangeKind.BINARY
+            ):
+                selected_change = load_selected_change()
+                if isinstance(selected_change, BinaryFileChange):
+                    _command_include_binary_to_batch(batch_name, selected_change, quiet=quiet)
+                else:
+                    _command_include_hunk_to_batch(batch_name, file_only=False, quiet=quiet)
+            elif line_ids is not None:
                 _command_include_lines_to_batch(batch_name, line_ids, quiet=quiet)
             else:
                 # Include entire selected hunk
                 _command_include_hunk_to_batch(batch_name, file_only=False, quiet=quiet)
+
+
+def _command_include_binary_to_batch(
+    batch_name: str,
+    binary_change: BinaryFileChange,
+    *,
+    quiet: bool = False,
+) -> None:
+    """Save one binary change to a batch and mark it processed."""
+    file_path = binary_change.new_path if binary_change.new_path != "/dev/null" else binary_change.old_path
+    patch_hash = compute_binary_file_hash(binary_change)
+
+    add_binary_file_to_batch(
+        batch_name,
+        binary_change,
+        file_mode=_detect_file_mode(file_path),
+    )
+    append_lines_to_file(get_block_list_file_path(), [patch_hash])
+    record_binary_hunk_skipped(binary_change, patch_hash)
+
+    if not quiet:
+        print(
+            _("Included binary file '{file}' to batch '{batch}'").format(
+                file=file_path,
+                batch=batch_name,
+            ),
+            file=sys.stderr,
+        )
+
+    if quiet:
+        advance_to_next_change()
+    else:
+        advance_to_and_show_next_change()
 
 
 def _command_include_file_to_batch(batch_name: str, file_path: str, *, quiet: bool = False) -> None:

--- a/src/git_stage_batch/commands/include_from.py
+++ b/src/git_stage_batch/commands/include_from.py
@@ -370,6 +370,9 @@ def command_include_from_batch(
 
                 snapshot_file_if_untracked(file_path)
 
+                # Update index and working tree with their independently merged
+                # targets. A selected deleted-text file still represents path
+                # absence once the selected deletion leaves that destination empty.
                 index_change_type = selected_text_target_change_type(
                     text_change_type,
                     selected_ids,

--- a/src/git_stage_batch/commands/include_from.py
+++ b/src/git_stage_batch/commands/include_from.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import stat
 import sys
 from typing import Optional
 
 from ..batch.merge import merge_batch
 from ..batch.metadata_validation import read_validated_batch_metadata
+from ..batch.query import get_batch_commit_sha
 from ..batch.replacement import build_replacement_batch_view
 from ..batch.selection import (
     resolve_batch_file_scope,
@@ -15,12 +17,156 @@ from ..batch.selection import (
     translate_atomic_unit_error_to_gutter_ids,
 )
 from ..batch.validation import batch_exists
+from ..core.text_lifecycle import (
+    TextFileChangeType,
+    mode_for_text_materialization,
+    normalized_text_change_type,
+    selected_text_target_change_type,
+)
 from ..data.hunk_tracking import render_batch_file_display
+from ..data.session import snapshot_file_if_untracked
 from ..data.undo import undo_checkpoint
-from ..exceptions import exit_with_error, MergeError, CommandError, AtomicUnitError, BatchMetadataError
+from ..exceptions import (
+    AtomicUnitError,
+    BatchMetadataError,
+    CommandError,
+    MergeError,
+    exit_with_error,
+)
 from ..i18n import _
 from ..staging.operations import update_index_with_blob_content
-from ..utils.git import require_git_repository, run_git_command
+from ..utils.git import (
+    create_git_blob,
+    get_git_repository_root_path,
+    require_git_repository,
+    run_git_command,
+)
+
+
+def _read_binary_file_from_batch(
+    batch_name: str,
+    file_path: str,
+    file_meta: dict,
+) -> bytes | None:
+    """Read one binary batch target, or return None for a stored deletion."""
+    batch_commit = get_batch_commit_sha(batch_name)
+    if not batch_commit:
+        raise RuntimeError(f"Batch commit not found for batch '{batch_name}'")
+
+    change_type = file_meta.get("change_type", "modified")
+    if change_type == "deleted":
+        return None
+
+    result = run_git_command(
+        ["show", f"{batch_commit}:{file_path}"],
+        check=False,
+        text_output=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"Binary file not found in batch commit: {file_path}")
+
+    return result.stdout
+
+
+def _stage_binary_file_from_batch(
+    file_path: str,
+    file_meta: dict,
+    batch_content: bytes | None,
+) -> None:
+    """Stage one binary batch target into the index."""
+    change_type = file_meta.get("change_type", "modified")
+    if change_type == "deleted":
+        result = run_git_command(["update-index", "--force-remove", "--", file_path], check=False)
+        if result.returncode != 0:
+            raise RuntimeError(f"Failed to stage binary deletion for {file_path}: {result.stderr}")
+        return
+
+    if batch_content is None:
+        raise RuntimeError(f"Binary file not found in batch commit: {file_path}")
+
+    blob_hash = create_git_blob([batch_content])
+    file_mode = file_meta.get("mode", "100644")
+    run_git_command(["update-index", "--add", "--cacheinfo", str(file_mode), blob_hash, file_path])
+
+
+def _apply_working_tree_file_mode(full_path, file_mode: str) -> None:
+    """Apply a normal Git file mode to a working-tree file."""
+    current_mode = full_path.stat().st_mode
+    if file_mode == "100755":
+        full_path.chmod(current_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    else:
+        full_path.chmod(current_mode & ~(stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH))
+
+
+def _stage_text_file_from_batch(
+    file_path: str,
+    content: bytes | None,
+    file_mode: str | None,
+    change_type: str = "modified",
+) -> None:
+    """Stage text content, optionally forcing the batch target mode."""
+    if normalized_text_change_type(change_type) == TextFileChangeType.DELETED:
+        result = run_git_command(["update-index", "--force-remove", "--", file_path], check=False)
+        if result.returncode != 0:
+            raise RuntimeError(f"Failed to stage text deletion for {file_path}: {result.stderr}")
+        return
+
+    if content is None:
+        raise RuntimeError(f"Text file not found in batch content: {file_path}")
+
+    if file_mode is None:
+        update_index_with_blob_content(file_path, content)
+        return
+
+    blob_hash = create_git_blob([content])
+    run_git_command(["update-index", "--add", "--cacheinfo", file_mode, blob_hash, file_path])
+
+
+def _write_text_file_from_batch(
+    file_path: str,
+    content: bytes | None,
+    file_mode: str | None,
+    change_type: str = "modified",
+) -> None:
+    """Write one text batch target into the working tree."""
+    repo_root = get_git_repository_root_path()
+    full_path = repo_root / file_path
+
+    if normalized_text_change_type(change_type) == TextFileChangeType.DELETED:
+        if full_path.exists():
+            full_path.unlink()
+        return
+
+    if content is None:
+        raise RuntimeError(f"Text file not found in batch content: {file_path}")
+
+    full_path.parent.mkdir(parents=True, exist_ok=True)
+    full_path.write_bytes(content)
+    if file_mode is not None:
+        _apply_working_tree_file_mode(full_path, file_mode)
+
+
+def _write_binary_file_from_batch(
+    file_path: str,
+    file_meta: dict,
+    batch_content: bytes | None,
+) -> None:
+    """Write one binary batch target into the working tree."""
+    repo_root = get_git_repository_root_path()
+    full_path = repo_root / file_path
+    change_type = file_meta.get("change_type", "modified")
+
+    if change_type == "deleted":
+        if full_path.exists():
+            full_path.unlink()
+        return
+
+    if batch_content is None:
+        raise RuntimeError(f"Binary file not found in batch commit: {file_path}")
+
+    full_path.parent.mkdir(parents=True, exist_ok=True)
+    full_path.write_bytes(batch_content)
+    _apply_working_tree_file_mode(full_path, str(file_meta.get("mode", "100644")))
 
 
 def _require_contiguous_display_selection(selected_ids: set[int]) -> None:
@@ -40,7 +186,7 @@ def command_include_from_batch(
     patterns: Optional[list[str]] = None,
     replacement_text: Optional[str] = None,
 ) -> None:
-    """Stage batch changes to index using structural merge.
+    """Stage batch changes to index and working tree using structural merge.
 
     Args:
         batch_name: Name of batch to include from
@@ -80,6 +226,12 @@ def command_include_from_batch(
     if replacement_text is not None and not selected_ids:
         exit_with_error(_("`include --from --as` requires `--line`."))
 
+    # Reject line selection for binary files (binary files are atomic units)
+    if selected_ids:
+        file_path_for_check = list(files.keys())[0]  # Single file context enforced above
+        if files[file_path_for_check].get("file_type") == "binary":
+            exit_with_error(_("Cannot use --lines with binary files. Include the whole file instead."))
+
     # Translate gutter IDs to selection IDs if line selection is active
     selection_ids_to_include = selected_ids
     rendered = None  # Store for error translation
@@ -104,12 +256,22 @@ def command_include_from_batch(
         operation_parts.extend(["--file", file])
     if replacement_text is not None:
         operation_parts.extend(["--as", replacement_text])
-    with undo_checkpoint(" ".join(operation_parts)):
+    with undo_checkpoint(" ".join(operation_parts), worktree_paths=list(files)):
         # Apply all files in batch
+        repo_root = get_git_repository_root_path()
         failed_files = []
 
         for file_path, file_meta in files.items():
             try:
+                if file_meta.get("file_type") == "binary":
+                    batch_content = _read_binary_file_from_batch(batch_name, file_path, file_meta)
+                    snapshot_file_if_untracked(file_path)
+                    _stage_binary_file_from_batch(file_path, file_meta, batch_content)
+                    _write_binary_file_from_batch(file_path, file_meta, batch_content)
+                    continue
+
+                text_change_type = normalized_text_change_type(file_meta.get("change_type"))
+
                 # Get batch source commit content (as bytes)
                 batch_source_commit = file_meta["batch_source_commit"]
                 batch_source_result = run_git_command(
@@ -128,10 +290,36 @@ def command_include_from_batch(
                     check=False,
                     text_output=False
                 )
-                if index_result.returncode == 0:
+                index_exists = index_result.returncode == 0
+                if index_exists:
                     index_content = index_result.stdout
                 else:
                     index_content = b""
+
+                # Get selected working tree content (as bytes)
+                full_path = repo_root / file_path
+                working_exists = full_path.exists()
+                if working_exists:
+                    working_content = full_path.read_bytes()
+                else:
+                    working_content = b""
+
+                batch_file_mode = str(file_meta.get("mode", "100644"))
+                index_file_mode = mode_for_text_materialization(
+                    batch_file_mode,
+                    selected_ids,
+                    destination_exists=index_exists,
+                )
+                working_file_mode = mode_for_text_materialization(
+                    batch_file_mode,
+                    selected_ids,
+                    destination_exists=working_exists,
+                )
+                if selected_ids is None and text_change_type == TextFileChangeType.DELETED:
+                    snapshot_file_if_untracked(file_path)
+                    _stage_text_file_from_batch(file_path, None, index_file_mode, text_change_type)
+                    _write_text_file_from_batch(file_path, None, working_file_mode, text_change_type)
+                    continue
 
                 # Get ownership from metadata, filtered by selected selection IDs if specified
                 try:
@@ -150,27 +338,60 @@ def command_include_from_batch(
 
                 # If nothing selected for this file, skip it
                 if ownership.is_empty():
-                    continue
+                    if selected_ids is None and text_change_type == TextFileChangeType.ADDED:
+                        merged_index_content = b""
+                        merged_working_content = b""
+                    else:
+                        continue
+                else:
+                    if replacement_text is not None:
+                        try:
+                            batch_source_content, ownership = build_replacement_batch_view(
+                                batch_source_content,
+                                ownership,
+                                replacement_text,
+                            )
+                        except ValueError as e:
+                            exit_with_error(str(e))
 
-                if replacement_text is not None:
-                    try:
-                        batch_source_content, ownership = build_replacement_batch_view(
-                            batch_source_content,
-                            ownership,
-                            replacement_text,
-                        )
-                    except ValueError as e:
-                        exit_with_error(str(e))
+                    # Perform structural merge against both destinations. include --from
+                    # is the staged form of apply --from, so the working tree must
+                    # receive the selected batch content too.
+                    merged_index_content = merge_batch(
+                        batch_source_content,
+                        ownership,
+                        index_content
+                    )
+                    merged_working_content = merge_batch(
+                        batch_source_content,
+                        ownership,
+                        working_content
+                    )
 
-                # Perform structural merge
-                merged_content = merge_batch(
-                    batch_source_content,
-                    ownership,
-                    index_content
+                snapshot_file_if_untracked(file_path)
+
+                index_change_type = selected_text_target_change_type(
+                    text_change_type,
+                    selected_ids,
+                    merged_index_content,
                 )
-
-                # Update index with merged content
-                update_index_with_blob_content(file_path, merged_content)
+                working_change_type = selected_text_target_change_type(
+                    text_change_type,
+                    selected_ids,
+                    merged_working_content,
+                )
+                _stage_text_file_from_batch(
+                    file_path,
+                    merged_index_content,
+                    index_file_mode,
+                    index_change_type,
+                )
+                _write_text_file_from_batch(
+                    file_path,
+                    merged_working_content,
+                    working_file_mode,
+                    working_change_type,
+                )
 
             except MergeError:
                 # Merge conflict - batch created from different file version

--- a/src/git_stage_batch/commands/sift.py
+++ b/src/git_stage_batch/commands/sift.py
@@ -59,18 +59,6 @@ from ..utils.paths import (
 )
 
 
-def _set_batch_baseline(
-    batch_name: str,
-    baseline_commit: str,
-) -> None:
-    """Update a batch's baseline commit in metadata."""
-    metadata = read_batch_metadata(batch_name)
-    metadata["baseline"] = baseline_commit
-    metadata_path = get_batch_metadata_file_path(batch_name)
-    write_text_file_contents(metadata_path, json.dumps(metadata, indent=2))
-
-
-
 def create_synthetic_batch_source_commit(
     baseline_commit: str,
     file_path: str,
@@ -185,9 +173,12 @@ def command_sift_batch(source_batch: str, dest_batch: str) -> None:
                 )
             )
 
-        create_batch(dest_batch, note=f"Sifted from {source_batch}")
+        create_batch(
+            dest_batch,
+            note=f"Sifted from {source_batch}",
+            baseline_commit=source_metadata.get("baseline"),
+        )
         dest_created = True
-        _set_batch_baseline(dest_batch, source_metadata.get("baseline"))
 
     try:
         repo_root = get_git_repository_root_path()
@@ -310,8 +301,11 @@ def _perform_atomic_in_place_sift(
     if batch_exists(temp_batch_name):
         delete_batch(temp_batch_name)
 
-    create_batch(temp_batch_name, note=f"Temporary sift of {batch_name}")
-    _set_batch_baseline(temp_batch_name, source_metadata.get("baseline"))
+    create_batch(
+        temp_batch_name,
+        note=f"Temporary sift of {batch_name}",
+        baseline_commit=source_metadata.get("baseline"),
+    )
 
     try:
         for file_path, file_meta, result in retained_files:
@@ -354,8 +348,11 @@ def _handle_empty_source_batch(source_batch: str, dest_batch: str) -> None:
         return
 
     source_metadata = read_batch_metadata(source_batch)
-    create_batch(dest_batch, note=f"Sifted from {source_batch} (was empty)")
-    _set_batch_baseline(dest_batch, source_metadata.get("baseline"))
+    create_batch(
+        dest_batch,
+        note=f"Sifted from {source_batch} (was empty)",
+        baseline_commit=source_metadata.get("baseline"),
+    )
 
     print(
         _("✓ Sifted batch '{source}' to '{dest}': source was empty").format(

--- a/src/git_stage_batch/commands/sift.py
+++ b/src/git_stage_batch/commands/sift.py
@@ -36,10 +36,20 @@ from ..batch.state_refs import (
     get_batch_content_ref_name,
     sync_batch_state_refs,
 )
-from ..batch.storage import add_binary_file_to_batch, _build_realized_content, _update_batch_commit
+from ..batch.storage import (
+    add_binary_file_to_batch,
+    _build_realized_content,
+    _remove_file_from_batch_commit,
+    _update_batch_commit,
+)
 from ..batch.validation import batch_exists, validate_batch_name
 from ..core.line_selection import format_line_ids
 from ..core.models import BinaryFileChange
+from ..core.text_lifecycle import (
+    TextFileChangeType,
+    normalized_text_change_type,
+    sifted_empty_text_path_change_type,
+)
 from ..exceptions import BatchMetadataError, exit_with_error
 from ..i18n import _
 from ..utils.file_io import write_text_file_contents
@@ -93,6 +103,7 @@ def add_sifted_text_file_to_batch(
     target_content: bytes,
     ownership: BatchOwnership,
     file_mode: str = "100644",
+    change_type: str | None = None,
 ) -> None:
     """Persist a sifted text file into a batch.
 
@@ -126,16 +137,23 @@ def add_sifted_text_file_to_batch(
     if "files" not in metadata:
         metadata["files"] = {}
 
-    metadata["files"][file_path] = {
+    text_change_type = normalized_text_change_type(change_type)
+    file_metadata = {
         "batch_source_commit": batch_source_commit,
         **ownership.to_metadata_dict(),
         "mode": file_mode,
     }
+    if text_change_type != TextFileChangeType.MODIFIED:
+        file_metadata["change_type"] = text_change_type.value
+    metadata["files"][file_path] = file_metadata
 
     metadata_path = get_batch_metadata_file_path(batch_name)
     write_text_file_contents(metadata_path, json.dumps(metadata, indent=2))
 
-    _update_batch_commit(batch_name, file_path, target_blob_sha, file_mode)
+    if text_change_type == TextFileChangeType.DELETED:
+        _remove_file_from_batch_commit(batch_name, file_path)
+    else:
+        _update_batch_commit(batch_name, file_path, target_blob_sha, file_mode)
 
 
 
@@ -234,6 +252,7 @@ def command_sift_batch(source_batch: str, dest_batch: str) -> None:
                         target_content=result["target_content"],
                         ownership=result["ownership"],
                         file_mode=file_meta.get("mode", "100644"),
+                        change_type=result.get("change_type"),
                     )
     except MergeError as e:
         if dest_created and batch_exists(dest_batch):
@@ -322,6 +341,7 @@ def _perform_atomic_in_place_sift(
                     target_content=result["target_content"],
                     ownership=result["ownership"],
                     file_mode=file_meta.get("mode", "100644"),
+                    change_type=result.get("change_type"),
                 )
 
         temp_commit = run_git_command(["rev-parse", get_batch_content_ref_name(temp_batch_name)], check=False)
@@ -423,6 +443,7 @@ def _compute_sifted_text_file(
     target content itself.
     """
     batch_source_commit = file_meta["batch_source_commit"]
+    change_type = normalized_text_change_type(file_meta.get("change_type"))
 
     batch_source_result = run_git_command(
         ["show", f"{batch_source_commit}:{file_path}"],
@@ -461,7 +482,9 @@ def _compute_sifted_text_file(
         source_ownership,
     )
 
-    if working_content == target_content:
+    target_exists = change_type != TextFileChangeType.DELETED
+    working_exists = full_path.exists()
+    if target_exists == working_exists and working_content == target_content:
         return None
 
     new_ownership = build_ownership_from_working_to_target_delta(
@@ -469,7 +492,18 @@ def _compute_sifted_text_file(
         target_content=target_content,
     )
     if new_ownership is None or new_ownership.is_empty():
-        return None
+        result_change_type = sifted_empty_text_path_change_type(
+            change_type,
+            target_exists=target_exists,
+            working_exists=working_exists,
+            target_content=target_content,
+            ownership_is_empty=True,
+        )
+        if result_change_type == TextFileChangeType.MODIFIED:
+            return None
+        new_ownership = BatchOwnership(claimed_lines=[], deletions=[])
+    else:
+        result_change_type = change_type
 
     _validate_sifted_text_file_result(
         target_content=target_content,
@@ -481,6 +515,7 @@ def _compute_sifted_text_file(
         "type": "text",
         "ownership": new_ownership,
         "target_content": target_content,
+        "change_type": result_change_type.value,
     }
 
 

--- a/src/git_stage_batch/commands/sift.py
+++ b/src/git_stage_batch/commands/sift.py
@@ -244,6 +244,7 @@ def command_sift_batch(source_batch: str, dest_batch: str) -> None:
                         dest_batch,
                         result["binary_change"],
                         file_mode=file_meta.get("mode", "100644"),
+                        file_content_override=result.get("target_content"),
                     )
                 else:
                     add_sifted_text_file_to_batch(
@@ -333,6 +334,7 @@ def _perform_atomic_in_place_sift(
                     temp_batch_name,
                     result["binary_change"],
                     file_mode=file_meta.get("mode", "100644"),
+                    file_content_override=result.get("target_content"),
                 )
             else:
                 add_sifted_text_file_to_batch(
@@ -405,22 +407,23 @@ def _compute_sifted_binary_file(
         batch_source_content = batch_source_result.stdout
 
     full_path = repo_root / file_path
-    if full_path.exists():
+    working_exists = full_path.exists()
+    if working_exists:
         working_content = full_path.read_bytes()
     else:
         working_content = b""
 
     if change_type == "deleted":
-        if not full_path.exists():
+        if not working_exists:
             return None
     elif change_type in ("added", "modified"):
-        if working_content == batch_source_content:
+        if working_exists and working_content == batch_source_content:
             return None
 
     old_path = file_path if change_type != "added" else "/dev/null"
     new_path = file_path if change_type != "deleted" else "/dev/null"
 
-    return {
+    result = {
         "type": "binary",
         "binary_change": BinaryFileChange(
             old_path=old_path,
@@ -428,6 +431,9 @@ def _compute_sifted_binary_file(
             change_type=change_type,
         ),
     }
+    if change_type != "deleted":
+        result["target_content"] = batch_source_content
+    return result
 
 
 

--- a/src/git_stage_batch/commands/start.py
+++ b/src/git_stage_batch/commands/start.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Optional
 
 from .again import command_again
-from ..data.hunk_tracking import fetch_next_change, show_selected_change
+from ..data.hunk_tracking import clear_selected_change_state_files, fetch_next_change, show_selected_change
 from ..data.file_tracking import auto_add_untracked_files
 from ..data.session import initialize_abort_state
 from ..exceptions import CommandError, NoMoreHunks
@@ -29,6 +29,8 @@ def command_start(*, context_lines: Optional[int] = None, quiet: bool = False) -
     if get_abort_head_file_path().exists():
         command_again(quiet=quiet)
         return
+
+    clear_selected_change_state_files()
 
     # Initialize abort state for new session
     initialize_abort_state()

--- a/src/git_stage_batch/commands/status.py
+++ b/src/git_stage_batch/commands/status.py
@@ -156,5 +156,19 @@ def command_status(*, porcelain: bool = False) -> None:
             print()
             print(_("Skipped hunks:"))
             for hunk in skipped_hunks:
-                ids_str = format_id_range(hunk["ids"])
-                print(_("  {}:{} [#{}]").format(hunk['file'], hunk['line'], ids_str))
+                if hunk.get("line") is None:
+                    print(
+                        _("  {file} [binary {change_type}]").format(
+                            file=hunk["file"],
+                            change_type=hunk.get("change_type", "modified"),
+                        )
+                    )
+                else:
+                    ids_str = format_id_range(hunk["ids"])
+                    print(
+                        _("  {file}:{line} [#{ids}]").format(
+                            file=hunk["file"],
+                            line=hunk["line"],
+                            ids=ids_str,
+                        )
+                    )

--- a/src/git_stage_batch/core/text_lifecycle.py
+++ b/src/git_stage_batch/core/text_lifecycle.py
@@ -1,0 +1,162 @@
+"""Shared text path lifecycle decisions."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from enum import Enum
+
+from ..utils.git import get_git_repository_root_path, run_git_command
+
+
+class TextFileChangeType(str, Enum):
+    """Text path lifecycle states persisted in batch metadata."""
+
+    ADDED = "added"
+    MODIFIED = "modified"
+    DELETED = "deleted"
+
+
+def normalized_text_change_type(change_type: str | TextFileChangeType | None) -> TextFileChangeType:
+    """Return a supported text change type, defaulting to modified."""
+    if isinstance(change_type, TextFileChangeType):
+        return change_type
+    try:
+        return TextFileChangeType(change_type or TextFileChangeType.MODIFIED.value)
+    except ValueError:
+        return TextFileChangeType.MODIFIED
+
+
+def detect_empty_text_lifecycle_change(
+    file_path: str,
+    *,
+    baseline_ref: str = "HEAD",
+) -> TextFileChangeType | None:
+    """Return added/deleted for empty text lifecycle diffs with no hunk body."""
+    full_path = get_git_repository_root_path() / file_path
+    baseline_result = run_git_command(
+        ["show", f"{baseline_ref}:{file_path}"],
+        check=False,
+        text_output=False,
+    )
+
+    if full_path.exists() and full_path.is_file():
+        if full_path.read_bytes() != b"":
+            return None
+        if baseline_result.returncode != 0:
+            return TextFileChangeType.ADDED
+        return None
+
+    if baseline_result.returncode == 0 and baseline_result.stdout == b"":
+        return TextFileChangeType.DELETED
+    return None
+
+
+def resolve_text_change_type(
+    *,
+    file_path: str,
+    baseline_exists: bool,
+    batch_source_content: bytes,
+    realized_content: bytes,
+    requested_change_type: str | TextFileChangeType | None = None,
+    working_exists: bool | None = None,
+) -> TextFileChangeType:
+    """Classify text batches that represent whole-path lifecycle states."""
+    requested = (
+        None
+        if requested_change_type is None else
+        normalized_text_change_type(requested_change_type)
+    )
+
+    if requested == TextFileChangeType.DELETED:
+        return (
+            TextFileChangeType.DELETED
+            if baseline_exists and realized_content == b"" else
+            TextFileChangeType.MODIFIED
+        )
+
+    if requested == TextFileChangeType.ADDED:
+        return (
+            TextFileChangeType.ADDED
+            if not baseline_exists and realized_content == batch_source_content
+            else TextFileChangeType.MODIFIED
+        )
+
+    if requested == TextFileChangeType.MODIFIED:
+        return TextFileChangeType.MODIFIED
+
+    if not baseline_exists and realized_content == batch_source_content:
+        return TextFileChangeType.ADDED
+
+    if working_exists is None:
+        working_exists = (get_git_repository_root_path() / file_path).exists()
+    if baseline_exists and not working_exists and realized_content == b"":
+        return TextFileChangeType.DELETED
+
+    return TextFileChangeType.MODIFIED
+
+
+def selected_text_target_change_type(
+    text_change_type: str | TextFileChangeType,
+    selected_ids: Iterable[int] | None,
+    target_content: bytes,
+) -> TextFileChangeType:
+    """Return the path state for applying selected batch text to a target."""
+    text_change_type = normalized_text_change_type(text_change_type)
+    if selected_ids is None:
+        return text_change_type
+    if text_change_type == TextFileChangeType.DELETED and target_content == b"":
+        return TextFileChangeType.DELETED
+    return TextFileChangeType.MODIFIED
+
+
+def selected_text_discard_change_type(
+    text_change_type: str | TextFileChangeType,
+    selected_ids: Iterable[int] | None,
+    discarded_content: bytes,
+    *,
+    baseline_exists: bool,
+) -> TextFileChangeType:
+    """Return the path state for discarding selected batch text from a target."""
+    text_change_type = normalized_text_change_type(text_change_type)
+    if not baseline_exists and discarded_content == b"":
+        return TextFileChangeType.DELETED
+    if selected_ids is None:
+        return (
+            TextFileChangeType.DELETED
+            if text_change_type == TextFileChangeType.ADDED and not baseline_exists else
+            TextFileChangeType.MODIFIED
+        )
+    return TextFileChangeType.MODIFIED
+
+
+def mode_for_text_materialization(
+    file_mode: str | None,
+    selected_ids: Iterable[int] | None,
+    *,
+    destination_exists: bool,
+) -> str | None:
+    """Return a mode only when writing a whole file or creating a path."""
+    if file_mode is None:
+        return None
+    if selected_ids is None or not destination_exists:
+        return str(file_mode)
+    return None
+
+
+def sifted_empty_text_path_change_type(
+    change_type: str | TextFileChangeType,
+    *,
+    target_exists: bool,
+    working_exists: bool,
+    target_content: bytes,
+    ownership_is_empty: bool,
+) -> TextFileChangeType:
+    """Preserve path-presence-only empty text changes after sift."""
+    change_type = normalized_text_change_type(change_type)
+    if not ownership_is_empty or target_content != b"":
+        return change_type
+    if target_exists and not working_exists:
+        return TextFileChangeType.ADDED
+    if not target_exists and working_exists:
+        return TextFileChangeType.DELETED
+    return change_type

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -1153,6 +1153,22 @@ def record_hunk_skipped(line_changes: LineLevelChange, hunk_hash: str) -> None:
         f.write(json.dumps(metadata) + "\n")
 
 
+def record_binary_hunk_skipped(binary_change: BinaryFileChange, hunk_hash: str) -> None:
+    """Record that a binary change was skipped with file-level metadata."""
+    file_path = binary_change.new_path if binary_change.new_path != "/dev/null" else binary_change.old_path
+    metadata = {
+        "hash": hunk_hash,
+        "file": file_path,
+        "line": None,
+        "ids": [],
+        "change_type": binary_change.change_type,
+    }
+
+    jsonl_path = get_skipped_hunks_jsonl_file_path()
+    with jsonl_path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(metadata) + "\n")
+
+
 def format_id_range(ids: list[int]) -> str:
     """Format list of IDs as compact range string (e.g., '1-5,7,9-11').
 

--- a/src/git_stage_batch/staging/operations.py
+++ b/src/git_stage_batch/staging/operations.py
@@ -272,14 +272,14 @@ def build_target_index_content_bytes_with_replaced_lines(
             raise ValueError(
                 "Replacement text still includes unchanged anchor lines before the selected span. "
                 "Provide replacement text only for the selected span, use --file --as for a full-file replacement, "
-                "or pass --no-anchor to keep the anchor text."
+                "or pass --no-edge-overlap to keep the edge-overlap text."
             )
 
         if longest_suffix_context_match(replacement_lines, after_context) >= 2:
             raise ValueError(
                 "Replacement text still includes unchanged anchor lines after the selected span. "
                 "Provide replacement text only for the selected span, use --file --as for a full-file replacement, "
-                "or pass --no-anchor to keep the anchor text."
+                "or pass --no-edge-overlap to keep the edge-overlap text."
             )
 
     output_lines = (
@@ -524,14 +524,14 @@ def build_target_working_tree_content_bytes_with_replaced_lines(
             raise ValueError(
                 "Replacement text still includes unchanged anchor lines before the selected span. "
                 "Provide replacement text only for the selected span, use --file --as for a full-file replacement, "
-                "or pass --no-anchor to keep the anchor text."
+                "or pass --no-edge-overlap to keep the edge-overlap text."
             )
 
         if longest_suffix_context_match(replacement_lines, after_context) >= 2:
             raise ValueError(
                 "Replacement text still includes unchanged anchor lines after the selected span. "
                 "Provide replacement text only for the selected span, use --file --as for a full-file replacement, "
-                "or pass --no-anchor to keep the anchor text."
+                "or pass --no-edge-overlap to keep the edge-overlap text."
             )
 
     output_lines = (

--- a/tests/batch/test_storage.py
+++ b/tests/batch/test_storage.py
@@ -117,6 +117,52 @@ def test_boolean_replacement_unit_indices_are_omitted_from_metadata(temp_git_rep
     assert "replacement_units" not in ownership.to_metadata_dict()
 
 
+def test_add_file_to_batch_marks_whole_added_empty_text_file(temp_git_repo):
+    """Whole empty added text files need path lifecycle metadata."""
+    empty_file = temp_git_repo / "empty.txt"
+    empty_file.write_text("")
+
+    ownership = BatchOwnership(claimed_lines=[], deletions=[])
+    add_file_to_batch("test-batch", "empty.txt", ownership)
+
+    file_meta = read_batch_metadata("test-batch")["files"]["empty.txt"]
+    assert file_meta["change_type"] == "added"
+    assert read_file_from_batch("test-batch", "empty.txt") == ""
+
+
+def test_add_file_to_batch_does_not_mark_partial_added_text_file_as_lifecycle(temp_git_repo):
+    """Partial line batches from a new file should stay content-scoped."""
+    partial_file = temp_git_repo / "partial.txt"
+    partial_file.write_text("one\ntwo\n")
+
+    ownership = BatchOwnership(claimed_lines=["1"], deletions=[])
+    add_file_to_batch("test-batch", "partial.txt", ownership)
+
+    file_meta = read_batch_metadata("test-batch")["files"]["partial.txt"]
+    assert "change_type" not in file_meta
+    assert read_file_from_batch("test-batch", "partial.txt") == "one\n"
+
+
+def test_add_file_to_batch_marks_whole_deleted_text_file(temp_git_repo):
+    """Whole deleted text files need deletion metadata and no batch-tree path."""
+    gone_file = temp_git_repo / "gone.txt"
+    gone_file.write_text("gone\n")
+    subprocess.run(["git", "add", "gone.txt"], check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "Add gone"], check=True, capture_output=True)
+    initialize_abort_state()
+
+    gone_file.unlink()
+    ownership = BatchOwnership(
+        claimed_lines=[],
+        deletions=[DeletionClaim(anchor_line=None, content_lines=[b"gone\n"])],
+    )
+    add_file_to_batch("test-batch", "gone.txt", ownership)
+
+    file_meta = read_batch_metadata("test-batch")["files"]["gone.txt"]
+    assert file_meta["change_type"] == "deleted"
+    assert read_file_from_batch("test-batch", "gone.txt") is None
+
+
 def test_add_file_to_batch_update_file(temp_git_repo):
     """Test updating existing file in batch."""
     create_batch("test-batch", "Test")

--- a/tests/cli/test_argument_parser.py
+++ b/tests/cli/test_argument_parser.py
@@ -351,7 +351,7 @@ def test_parse_command_line_include_with_line_range_and_as_stdin_dispatches_line
         "2-3",
         "replacement one\nreplacement two\n",
         file="path.txt",
-        no_anchor=False,
+        no_edge_overlap=False,
     )
 
 
@@ -420,30 +420,30 @@ def test_parse_command_line_include_rejects_as_and_as_stdin_together(monkeypatch
         args.func(args)
 
 
-def test_parse_command_line_include_with_no_anchor_dispatches_line_replacement(monkeypatch):
-    """Include --line --as --no-anchor should forward the no-anchor flag."""
+def test_parse_command_line_include_with_no_edge_overlap_dispatches_line_replacement(monkeypatch):
+    """Include --line --as --no-edge-overlap should forward the no-edge-overlap flag."""
     mock_command = Mock()
     monkeypatch.setattr(argument_parser.commands, "command_include_line_as", mock_command)
 
     args = parse_command_line(
-        ["include", "--file", "path.txt", "--line", "2-3", "--as", "replacement", "--no-anchor"],
+        ["include", "--file", "path.txt", "--line", "2-3", "--as", "replacement", "--no-edge-overlap"],
         quiet=True,
     )
 
     assert args is not None
     args.func(args)
-    mock_command.assert_called_once_with("2-3", "replacement", file="path.txt", no_anchor=True)
+    mock_command.assert_called_once_with("2-3", "replacement", file="path.txt", no_edge_overlap=True)
 
 
-def test_parse_command_line_include_rejects_no_anchor_without_line_as():
-    """Include should reject --no-anchor outside live include --line --as."""
+def test_parse_command_line_include_rejects_no_edge_overlap_without_line_as():
+    """Include should reject --no-edge-overlap outside live include --line --as."""
     args = parse_command_line(
-        ["include", "--file", "path.txt", "--no-anchor"],
+        ["include", "--file", "path.txt", "--no-edge-overlap"],
         quiet=True,
     )
     assert args is not None
 
-    with pytest.raises(argument_parser.CommandError, match="`--no-anchor` requires `include --line --as`"):
+    with pytest.raises(argument_parser.CommandError, match="`--no-edge-overlap` requires `include --line --as`"):
         args.func(args)
 
 
@@ -764,7 +764,7 @@ def test_parse_command_line_discard_to_line_range_and_as_stdin_dispatches_replac
         "2-3",
         "replacement one\nreplacement two\n",
         file="path.txt",
-        no_anchor=False,
+        no_edge_overlap=False,
     )
 
 
@@ -781,13 +781,13 @@ def test_parse_command_line_discard_rejects_as_and_as_stdin_together(monkeypatch
         args.func(args)
 
 
-def test_parse_command_line_discard_with_no_anchor_dispatches_line_replacement(monkeypatch):
-    """Discard --to --line --as --no-anchor should forward the no-anchor flag."""
+def test_parse_command_line_discard_with_no_edge_overlap_dispatches_line_replacement(monkeypatch):
+    """Discard --to --line --as --no-edge-overlap should forward the no-edge-overlap flag."""
     mock_command = Mock()
     monkeypatch.setattr(argument_parser.commands, "command_discard_line_as_to_batch", mock_command)
 
     args = parse_command_line(
-        ["discard", "--to", "batch", "--file", "path.txt", "--line", "2-3", "--as", "replacement", "--no-anchor"],
+        ["discard", "--to", "batch", "--file", "path.txt", "--line", "2-3", "--as", "replacement", "--no-edge-overlap"],
         quiet=True,
     )
 
@@ -798,19 +798,19 @@ def test_parse_command_line_discard_with_no_anchor_dispatches_line_replacement(m
         "2-3",
         "replacement",
         file="path.txt",
-        no_anchor=True,
+        no_edge_overlap=True,
     )
 
 
-def test_parse_command_line_discard_rejects_no_anchor_without_to_line_as():
-    """Discard should reject --no-anchor outside discard --to --line --as."""
+def test_parse_command_line_discard_rejects_no_edge_overlap_without_to_line_as():
+    """Discard should reject --no-edge-overlap outside discard --to --line --as."""
     args = parse_command_line(
-        ["discard", "--file", "path.txt", "--no-anchor"],
+        ["discard", "--file", "path.txt", "--no-edge-overlap"],
         quiet=True,
     )
     assert args is not None
 
-    with pytest.raises(argument_parser.CommandError, match="`--no-anchor` requires `discard --to --line --as`"):
+    with pytest.raises(argument_parser.CommandError, match="`--no-edge-overlap` requires `discard --to --line --as`"):
         args.func(args)
 
 

--- a/tests/commands/test_binary_files.py
+++ b/tests/commands/test_binary_files.py
@@ -3,12 +3,16 @@
 from __future__ import annotations
 
 import json
+import stat
 import subprocess
 from pathlib import Path
 
 import pytest
 
+from git_stage_batch.batch.storage import add_binary_file_to_batch
+from git_stage_batch.commands.apply_from import command_apply_from_batch
 from git_stage_batch.commands.discard import command_discard
+from git_stage_batch.commands.discard_from import command_discard_from_batch
 from git_stage_batch.commands.include import command_include, command_include_to_batch
 from git_stage_batch.commands.skip import command_skip
 from git_stage_batch.commands.status import command_status
@@ -147,6 +151,65 @@ def test_selected_binary_include_to_batch_updates_skipped_progress(
     assert skipped_hunk["line"] is None
     assert skipped_hunk["ids"] == []
     assert skipped_hunk["change_type"] == "modified"
+
+
+def test_binary_apply_from_batch_restores_executable_mode(
+    binary_file_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Applying a binary batch entry should honor the stored executable bit."""
+    monkeypatch.chdir(binary_file_repo)
+
+    tool_path = binary_file_repo / "tool.bin"
+    modified_content = b"\x00BATCHED"
+    tool_path.write_bytes(b"\x00BASE")
+    tool_path.chmod(0o644)
+    subprocess.run(["git", "add", "tool.bin"], check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "Add binary tool"], check=True, capture_output=True)
+
+    initialize_abort_state()
+    tool_path.write_bytes(modified_content)
+    add_binary_file_to_batch(
+        "bin-batch",
+        BinaryFileChange("tool.bin", "tool.bin", "modified"),
+        file_mode="100755",
+    )
+    subprocess.run(["git", "checkout", "HEAD", "--", "tool.bin"], check=True, capture_output=True)
+    tool_path.chmod(0o644)
+
+    command_apply_from_batch("bin-batch", file="tool.bin")
+
+    assert tool_path.read_bytes() == modified_content
+    assert stat.S_IMODE(tool_path.stat().st_mode) & stat.S_IXUSR
+
+
+def test_binary_discard_from_batch_restores_baseline_executable_mode(
+    binary_file_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """discard --from should restore baseline executable bits for binaries."""
+    monkeypatch.chdir(binary_file_repo)
+
+    tool_path = binary_file_repo / "tool.bin"
+    tool_path.write_bytes(b"\x00BASE")
+    tool_path.chmod(0o755)
+    subprocess.run(["git", "add", "tool.bin"], check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "Add executable binary"], check=True, capture_output=True)
+
+    initialize_abort_state()
+    tool_path.write_bytes(b"\x00BATCHED")
+    add_binary_file_to_batch(
+        "bin-batch",
+        BinaryFileChange("tool.bin", "tool.bin", "modified"),
+        file_mode="100644",
+    )
+    tool_path.write_bytes(b"\x00WORKTREE")
+    tool_path.chmod(0o644)
+
+    command_discard_from_batch("bin-batch", file="tool.bin")
+
+    assert tool_path.read_bytes() == b"\x00BASE"
+    assert stat.S_IMODE(tool_path.stat().st_mode) & stat.S_IXUSR
 
 
 def test_binary_file_added_discard(binary_file_repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/commands/test_binary_files.py
+++ b/tests/commands/test_binary_files.py
@@ -2,14 +2,16 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
 from pathlib import Path
 
 import pytest
 
 from git_stage_batch.commands.discard import command_discard
-from git_stage_batch.commands.include import command_include
+from git_stage_batch.commands.include import command_include, command_include_to_batch
 from git_stage_batch.commands.skip import command_skip
+from git_stage_batch.commands.status import command_status
 from git_stage_batch.core.models import BinaryFileChange, LineLevelChange
 from git_stage_batch.data.file_tracking import auto_add_untracked_files
 from git_stage_batch.data.hunk_tracking import fetch_next_change
@@ -115,6 +117,36 @@ def test_binary_file_deleted_include(binary_file_repo: Path, monkeypatch: pytest
     # Verify deletion was staged (D  means fully staged deletion)
     status_result = run_git_command(["status", "--porcelain"])
     assert "D  image.png" in status_result.stdout
+
+
+def test_selected_binary_include_to_batch_updates_skipped_progress(
+    binary_file_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Selected binary include --to should count as processed in status."""
+    monkeypatch.chdir(binary_file_repo)
+
+    (binary_file_repo / "image.png").write_bytes(b"\x89PNG\r\n\x1a\nBATCHED")
+
+    initialize_abort_state()
+    auto_add_untracked_files()
+
+    result = fetch_next_change()
+    assert isinstance(result, BinaryFileChange)
+
+    command_include_to_batch("bin-batch", quiet=True)
+
+    command_status(porcelain=True)
+    status_output = json.loads(capsys.readouterr().out)
+
+    assert status_output["progress"]["skipped"] == 1
+    assert len(status_output["skipped_hunks"]) == 1
+    skipped_hunk = status_output["skipped_hunks"][0]
+    assert skipped_hunk["file"] == "image.png"
+    assert skipped_hunk["line"] is None
+    assert skipped_hunk["ids"] == []
+    assert skipped_hunk["change_type"] == "modified"
 
 
 def test_binary_file_added_discard(binary_file_repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/commands/test_discard.py
+++ b/tests/commands/test_discard.py
@@ -578,8 +578,8 @@ class TestCommandDiscardToBatch:
         command_apply_from_batch("feature-batch")
         assert readme.read_text() == "keep1\nstaged\nkeep3\nkeep4\n"
 
-    def test_discard_line_as_to_batch_no_anchor_keeps_matching_edge_anchors(self, temp_git_repo):
-        """Discard --to --line --as --no-anchor should preserve duplicate anchors."""
+    def test_discard_line_as_to_batch_no_edge_overlap_keeps_matching_edge_anchors(self, temp_git_repo):
+        """Discard --to --line --as --no-edge-overlap should preserve duplicate anchors."""
         readme = temp_git_repo / "README.md"
         readme.write_text("keep1\nold\nkeep3\nkeep4\n")
         subprocess.run(["git", "add", "README.md"], check=True, cwd=temp_git_repo, capture_output=True)
@@ -594,7 +594,7 @@ class TestCommandDiscardToBatch:
             "feature-batch",
             "1-2",
             "keep1\nstaged\nkeep3\nkeep4\n",
-            no_anchor=True,
+            no_edge_overlap=True,
         )
 
         assert readme.read_text() == "keep1\nold\nstaged\nkeep3\nkeep4\nkeep3\nkeep4\n"

--- a/tests/commands/test_discard.py
+++ b/tests/commands/test_discard.py
@@ -3,7 +3,7 @@
 from unittest.mock import patch
 
 from git_stage_batch.utils.paths import get_abort_snapshots_directory_path
-from git_stage_batch.batch import list_batch_files, read_file_from_batch
+from git_stage_batch.batch import list_batch_files, read_batch_metadata, read_file_from_batch
 from git_stage_batch.commands.discard import command_discard_to_batch
 from git_stage_batch.batch.validation import batch_exists
 from git_stage_batch.commands.apply_from import command_apply_from_batch
@@ -174,6 +174,57 @@ class TestCommandDiscardLine:
         with pytest.raises(CommandError):
             command_discard_line("1")
 
+    def test_discard_to_batch_line_captures_worktree_executable_mode(self, temp_git_repo):
+        """discard --to --line should store chmod changes from the working tree."""
+        tool_path = temp_git_repo / "tool.sh"
+        tool_path.write_text("#!/bin/sh\necho base\n")
+        tool_path.chmod(0o644)
+        subprocess.run(["git", "add", "tool.sh"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add tool"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        tool_path.write_text("#!/bin/sh\necho base\necho added\n")
+        tool_path.chmod(0o755)
+
+        command_start()
+        command_discard_to_batch("mode-batch", line_ids="1", quiet=True)
+
+        metadata = read_batch_metadata("mode-batch")
+        assert metadata["files"]["tool.sh"]["mode"] == "100755"
+
+    def test_discard_to_batch_line_as_captures_worktree_executable_mode(self, temp_git_repo):
+        """discard --to --line --as should store chmod changes from the working tree."""
+        tool_path = temp_git_repo / "tool.sh"
+        tool_path.write_text("#!/bin/sh\necho base\n")
+        tool_path.chmod(0o644)
+        subprocess.run(["git", "add", "tool.sh"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add tool"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        tool_path.write_text("#!/bin/sh\necho base\necho added\n")
+        tool_path.chmod(0o755)
+
+        command_start()
+        command_discard_line_as_to_batch("mode-batch", "1", "replacement", quiet=True)
+
+        metadata = read_batch_metadata("mode-batch")
+        assert metadata["files"]["tool.sh"]["mode"] == "100755"
+
+    def test_discard_to_batch_file_line_captures_worktree_executable_mode(self, temp_git_repo):
+        """discard --to --file --line should store chmod changes from the working tree."""
+        tool_path = temp_git_repo / "tool.sh"
+        tool_path.write_text("#!/bin/sh\necho base\n")
+        tool_path.chmod(0o644)
+        subprocess.run(["git", "add", "tool.sh"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add tool"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        tool_path.write_text("#!/bin/sh\necho base\necho added\n")
+        tool_path.chmod(0o755)
+
+        command_start()
+        command_discard_to_batch("mode-batch", file="tool.sh", line_ids="1", quiet=True)
+
+        metadata = read_batch_metadata("mode-batch")
+        assert metadata["files"]["tool.sh"]["mode"] == "100755"
+
     def test_discard_line_removes_single_addition(self, temp_git_repo):
         """Test discarding a single added line."""
         readme = temp_git_repo / "README.md"
@@ -322,6 +373,23 @@ class TestCommandDiscardToBatch:
         # Changes should be discarded
         file_txt = temp_git_repo_with_session / "file.txt"
         assert not file_txt.exists()
+
+    def test_discard_to_batch_hunk_captures_worktree_executable_mode(self, temp_git_repo):
+        """discard --to should store chmod changes from the working tree."""
+        tool_path = temp_git_repo / "tool.sh"
+        tool_path.write_text("#!/bin/sh\necho base\n")
+        tool_path.chmod(0o644)
+        subprocess.run(["git", "add", "tool.sh"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add tool"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        tool_path.write_text("#!/bin/sh\necho base\necho added\n")
+        tool_path.chmod(0o755)
+
+        command_start()
+        command_discard_to_batch("mode-batch", quiet=True)
+
+        metadata = read_batch_metadata("mode-batch")
+        assert metadata["files"]["tool.sh"]["mode"] == "100755"
 
     def test_discard_lines_to_batch_saves_partial_content(self, temp_git_repo):
         """Test that line-level discard to batch synthesizes correct partial content."""

--- a/tests/commands/test_file_scoped_operations.py
+++ b/tests/commands/test_file_scoped_operations.py
@@ -1428,8 +1428,8 @@ class TestExplicitFilePath:
         staged_content = run_git_command(["show", ":module.py"]).stdout
         assert staged_content == "keep1\nkeep2\nstaged\nkeep4\n"
 
-    def test_include_line_as_with_explicit_path_no_anchor_keeps_edge_anchors(self, tmp_path, monkeypatch):
-        """Explicit file-scoped include --line --as --no-anchor should preserve duplicate anchors."""
+    def test_include_line_as_with_explicit_path_no_edge_overlap_keeps_edge_anchors(self, tmp_path, monkeypatch):
+        """Explicit file-scoped include --line --as --no-edge-overlap should preserve duplicate anchors."""
         repo = tmp_path / "test_repo"
         repo.mkdir()
         monkeypatch.chdir(repo)
@@ -1450,7 +1450,7 @@ class TestExplicitFilePath:
             "1-2",
             "keep1\nkeep2\nstaged\nkeep4\n",
             file="module.py",
-            no_anchor=True,
+            no_edge_overlap=True,
         )
 
         staged_content = run_git_command(["show", ":module.py"]).stdout

--- a/tests/commands/test_include.py
+++ b/tests/commands/test_include.py
@@ -4,7 +4,8 @@ import subprocess
 
 import pytest
 
-from git_stage_batch.commands.include import command_include, command_include_line, command_include_line_as
+from git_stage_batch.batch.query import read_batch_metadata
+from git_stage_batch.commands.include import command_include, command_include_line, command_include_line_as, command_include_to_batch
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.data.hunk_tracking import fetch_next_change
 from git_stage_batch.data.line_state import load_line_changes_from_state
@@ -136,6 +137,40 @@ class TestCommandIncludeLine:
         """Test that include --line requires an active hunk."""
         with pytest.raises(CommandError):
             command_include_line("1")
+
+    def test_include_to_batch_line_captures_worktree_executable_mode(self, temp_git_repo):
+        """include --to --line should store chmod changes from the working tree."""
+        tool_path = temp_git_repo / "tool.sh"
+        tool_path.write_text("#!/bin/sh\necho base\n")
+        tool_path.chmod(0o644)
+        subprocess.run(["git", "add", "tool.sh"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add tool"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        tool_path.write_text("#!/bin/sh\necho base\necho added\n")
+        tool_path.chmod(0o755)
+
+        command_start()
+        command_include_to_batch("mode-batch", line_ids="1", quiet=True)
+
+        metadata = read_batch_metadata("mode-batch")
+        assert metadata["files"]["tool.sh"]["mode"] == "100755"
+
+    def test_include_to_batch_file_line_captures_worktree_executable_mode(self, temp_git_repo):
+        """include --to --file --line should store chmod changes from the working tree."""
+        tool_path = temp_git_repo / "tool.sh"
+        tool_path.write_text("#!/bin/sh\necho base\n")
+        tool_path.chmod(0o644)
+        subprocess.run(["git", "add", "tool.sh"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add tool"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        tool_path.write_text("#!/bin/sh\necho base\necho added\n")
+        tool_path.chmod(0o755)
+
+        command_start()
+        command_include_to_batch("mode-batch", file="tool.sh", line_ids="1", quiet=True)
+
+        metadata = read_batch_metadata("mode-batch")
+        assert metadata["files"]["tool.sh"]["mode"] == "100755"
 
     def test_include_line_stages_single_addition(self, temp_git_repo):
         """Test including a single added line."""

--- a/tests/commands/test_include_from.py
+++ b/tests/commands/test_include_from.py
@@ -61,6 +61,7 @@ class TestCommandIncludeFromBatch:
         # Verify file is staged
         result = run_git_command(["diff", "--cached", "--name-only"])
         assert "new.txt" in result.stdout
+        assert (temp_git_repo / "new.txt").read_text() == "new content\n"
 
         captured = capsys.readouterr()
         assert "Staged changes from batch" in captured.err
@@ -127,6 +128,8 @@ class TestCommandIncludeFromBatch:
         # Verify file1 has the added line
         result = run_git_command(["show", ":file1.txt"])
         assert "file1 added" in result.stdout
+        assert (temp_git_repo / "file1.txt").read_text() == "line 1\nline 2\nfile1 added\n"
+        assert (temp_git_repo / "file2.txt").read_text() == "line A\nline B\n"
 
         captured = capsys.readouterr()
         assert "Staged changes for file1.txt from batch" in captured.err
@@ -173,6 +176,7 @@ class TestCommandIncludeFromBatch:
 
         result = run_git_command(["show", ":test.txt"])
         assert result.stdout == "keep\nedited value\n"
+        assert test_file.read_text() == "keep\nedited value\n"
 
     def test_include_from_batch_as_replaces_atomic_replacement_unit(self, temp_git_repo):
         """Test include --from --line --as preserves batch deletion semantics."""
@@ -204,6 +208,7 @@ class TestCommandIncludeFromBatch:
 
         result = run_git_command(["show", ":test.txt"])
         assert result.stdout == "keep\nedited value\n"
+        assert test_file.read_text() == "keep\nedited value\n"
 
     def test_include_from_batch_as_rejects_partial_replacement_unit(self, temp_git_repo):
         """Test include --from --line --as honors explicit replacement atomicity."""
@@ -236,3 +241,4 @@ class TestCommandIncludeFromBatch:
 
         result = run_git_command(["show", ":test.txt"])
         assert result.stdout == "old one\nold two\nkeep\n"
+        assert test_file.read_text() == "old one\nold two\nkeep\n"

--- a/tests/commands/test_include_from.py
+++ b/tests/commands/test_include_from.py
@@ -5,11 +5,17 @@ from git_stage_batch.commands.include import command_include_to_batch
 from unittest.mock import patch, MagicMock
 from git_stage_batch.core.models import LineLevelChange, LineEntry
 
+import stat
 import subprocess
 
 import pytest
 
 from git_stage_batch.batch import create_batch
+from git_stage_batch.batch.ownership import BatchOwnership
+from git_stage_batch.batch.query import read_batch_metadata
+from git_stage_batch.batch.storage import add_file_to_batch
+from git_stage_batch.commands.apply_from import command_apply_from_batch
+from git_stage_batch.commands.discard_from import command_discard_from_batch
 from git_stage_batch.commands.include_from import command_include_from_batch
 from git_stage_batch.data.hunk_tracking import render_batch_file_display
 from git_stage_batch.data.session import initialize_abort_state
@@ -145,6 +151,240 @@ class TestCommandIncludeFromBatch:
         # Try to use --file without cached hunk (no fetch_next_change call after command_start)
         with pytest.raises(CommandError):
             command_include_from_batch("test-batch", file="")
+
+    def test_include_from_batch_restores_text_executable_mode(self, temp_git_repo):
+        """Test whole-file include --from honors the batch target mode for text files."""
+        tool_path = temp_git_repo / "tool.sh"
+        tool_path.write_text("#!/bin/sh\necho base\n")
+        tool_path.chmod(0o644)
+        subprocess.run(["git", "add", "tool.sh"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add tool"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        tool_path.write_text("#!/bin/sh\necho batched\n")
+        tool_path.chmod(0o755)
+        command_start()
+        command_include_to_batch("test-batch", file="tool.sh", quiet=True)
+
+        subprocess.run(["git", "checkout", "HEAD", "--", "tool.sh"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        command_include_from_batch("test-batch", file="tool.sh")
+
+        index_entry = run_git_command(["ls-files", "-s", "--", "tool.sh"]).stdout
+        assert index_entry.startswith("100755 ")
+        assert tool_path.read_text() == "#!/bin/sh\necho batched\n"
+        assert stat.S_IMODE(tool_path.stat().st_mode) & stat.S_IXUSR
+
+    def test_apply_from_batch_restores_text_executable_mode(self, temp_git_repo):
+        """Test whole-file apply --from honors the batch target mode for text files."""
+        tool_path = temp_git_repo / "tool.sh"
+        tool_path.write_text("#!/bin/sh\necho base\n")
+        tool_path.chmod(0o644)
+        subprocess.run(["git", "add", "tool.sh"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add tool"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        tool_path.write_text("#!/bin/sh\necho batched\n")
+        tool_path.chmod(0o755)
+        command_start()
+        command_include_to_batch("test-batch", file="tool.sh", quiet=True)
+
+        subprocess.run(["git", "checkout", "HEAD", "--", "tool.sh"], check=True, cwd=temp_git_repo, capture_output=True)
+        tool_path.chmod(0o644)
+
+        command_apply_from_batch("test-batch", file="tool.sh")
+
+        assert tool_path.read_text() == "#!/bin/sh\necho batched\n"
+        assert stat.S_IMODE(tool_path.stat().st_mode) & stat.S_IXUSR
+
+    def test_discard_from_batch_restores_text_baseline_executable_mode(self, temp_git_repo):
+        """Test whole-file discard --from honors the baseline mode for text files."""
+        tool_path = temp_git_repo / "tool.sh"
+        tool_path.write_text("#!/bin/sh\necho base\n")
+        tool_path.chmod(0o755)
+        subprocess.run(["git", "add", "tool.sh"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add executable tool"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        tool_path.write_text("#!/bin/sh\necho batched\n")
+        command_start()
+        command_include_to_batch("test-batch", file="tool.sh", quiet=True)
+
+        tool_path.write_text("#!/bin/sh\necho batched\n")
+        tool_path.chmod(0o644)
+
+        command_discard_from_batch("test-batch", file="tool.sh")
+
+        assert tool_path.read_text() == "#!/bin/sh\necho base\n"
+        assert stat.S_IMODE(tool_path.stat().st_mode) & stat.S_IXUSR
+
+    def test_discard_from_batch_removes_added_text_file(self, temp_git_repo):
+        """Whole added text files saved to a batch discard back to absence."""
+        new_path = temp_git_repo / "new.txt"
+        new_path.write_text("new content\n")
+        command_start()
+        command_include_to_batch("test-batch", file="new.txt", quiet=True)
+
+        file_meta = read_batch_metadata("test-batch")["files"]["new.txt"]
+        assert file_meta["change_type"] == "added"
+
+        command_discard_from_batch("test-batch", file="new.txt")
+
+        assert not new_path.exists()
+
+    def test_apply_from_batch_removes_deleted_text_file(self, temp_git_repo):
+        """Whole deleted text files saved to a batch apply back to absence."""
+        gone_path = temp_git_repo / "gone.txt"
+        gone_path.write_text("gone\n")
+        subprocess.run(["git", "add", "gone.txt"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add gone"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        gone_path.unlink()
+        command_start()
+        command_include_to_batch("test-batch", file="gone.txt", quiet=True)
+
+        file_meta = read_batch_metadata("test-batch")["files"]["gone.txt"]
+        assert file_meta["change_type"] == "deleted"
+
+        subprocess.run(["git", "checkout", "HEAD", "--", "gone.txt"], check=True, cwd=temp_git_repo, capture_output=True)
+        command_apply_from_batch("test-batch", file="gone.txt")
+
+        assert not gone_path.exists()
+        assert run_git_command(["diff", "--cached", "--name-only", "--", "gone.txt"]).stdout == ""
+
+    def test_apply_from_batch_line_scoped_deleted_text_file_removes_path(self, temp_git_repo):
+        """Selecting every deleted text line should preserve deleted-path semantics."""
+        gone_path = temp_git_repo / "gone.txt"
+        gone_path.write_text("gone\n")
+        subprocess.run(["git", "add", "gone.txt"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add gone"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        gone_path.unlink()
+        command_start()
+        command_include_to_batch("test-batch", file="gone.txt", quiet=True)
+
+        subprocess.run(["git", "checkout", "HEAD", "--", "gone.txt"], check=True, cwd=temp_git_repo, capture_output=True)
+        command_apply_from_batch("test-batch", line_ids="1", file="gone.txt")
+
+        assert not gone_path.exists()
+        assert run_git_command(["diff", "--cached", "--name-only", "--", "gone.txt"]).stdout == ""
+
+    def test_apply_from_batch_line_scoped_added_text_file_restores_executable_mode(self, temp_git_repo):
+        """Line-scoped apply that creates a text path should use the batch mode."""
+        tool_path = temp_git_repo / "tool.sh"
+        tool_path.write_text("#!/bin/sh\necho batched\n")
+        tool_path.chmod(0o755)
+        command_start()
+        command_include_to_batch("test-batch", file="tool.sh", quiet=True)
+
+        tool_path.unlink()
+        command_apply_from_batch("test-batch", line_ids="1-2", file="tool.sh")
+
+        assert tool_path.read_text() == "#!/bin/sh\necho batched\n"
+        assert stat.S_IMODE(tool_path.stat().st_mode) & stat.S_IXUSR
+
+    def test_include_from_batch_stages_deleted_text_file_and_removes_worktree_path(self, temp_git_repo):
+        """Whole deleted text files saved to a batch include as staged deletions."""
+        gone_path = temp_git_repo / "gone.txt"
+        gone_path.write_text("gone\n")
+        subprocess.run(["git", "add", "gone.txt"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add gone"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        gone_path.unlink()
+        command_start()
+        command_include_to_batch("test-batch", file="gone.txt", quiet=True)
+
+        subprocess.run(["git", "checkout", "HEAD", "--", "gone.txt"], check=True, cwd=temp_git_repo, capture_output=True)
+        command_include_from_batch("test-batch", file="gone.txt")
+
+        assert not gone_path.exists()
+        assert run_git_command(["status", "--short", "--", "gone.txt"]).stdout == "D  gone.txt\n"
+
+    def test_include_from_batch_line_scoped_added_text_file_restores_executable_mode(self, temp_git_repo):
+        """Line-scoped include that creates a text path should use the batch mode."""
+        tool_path = temp_git_repo / "tool.sh"
+        tool_path.write_text("#!/bin/sh\necho batched\n")
+        tool_path.chmod(0o755)
+        command_start()
+        command_include_to_batch("test-batch", file="tool.sh", quiet=True)
+
+        tool_path.unlink()
+        run_git_command(["reset", "HEAD", "tool.sh"], check=False)
+        command_include_from_batch("test-batch", line_ids="1-2", file="tool.sh")
+
+        index_entry = run_git_command(["ls-files", "-s", "--", "tool.sh"]).stdout
+        assert index_entry.startswith("100755 ")
+        assert tool_path.read_text() == "#!/bin/sh\necho batched\n"
+        assert stat.S_IMODE(tool_path.stat().st_mode) & stat.S_IXUSR
+
+    def test_include_from_batch_line_scoped_deleted_text_file_stages_deletion(self, temp_git_repo):
+        """Line-scoped include of a full deleted text file should stage path deletion."""
+        gone_path = temp_git_repo / "gone.txt"
+        gone_path.write_text("gone\n")
+        subprocess.run(["git", "add", "gone.txt"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add gone"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        gone_path.unlink()
+        command_start()
+        command_include_to_batch("test-batch", file="gone.txt", quiet=True)
+
+        subprocess.run(["git", "checkout", "HEAD", "--", "gone.txt"], check=True, cwd=temp_git_repo, capture_output=True)
+        command_include_from_batch("test-batch", line_ids="1", file="gone.txt")
+
+        assert not gone_path.exists()
+        assert run_git_command(["status", "--short", "--", "gone.txt"]).stdout == "D  gone.txt\n"
+
+    def test_include_from_batch_creates_added_empty_text_file(self, temp_git_repo):
+        """Empty added text files should not be skipped as empty ownership."""
+        empty_path = temp_git_repo / "empty.txt"
+        empty_path.write_text("")
+        command_start()
+        add_file_to_batch("test-batch", "empty.txt", BatchOwnership(claimed_lines=[], deletions=[]))
+
+        empty_path.unlink()
+        command_include_from_batch("test-batch", file="empty.txt")
+
+        assert empty_path.exists()
+        assert empty_path.read_bytes() == b""
+        assert run_git_command(["diff", "--cached", "--name-only", "--", "empty.txt"]).stdout == "empty.txt\n"
+
+    def test_discard_from_batch_line_scoped_added_text_file_removes_path(self, temp_git_repo):
+        """Line-scoped discard of a full added text file should restore absence."""
+        new_path = temp_git_repo / "new.txt"
+        new_path.write_text("new\n")
+        command_start()
+        command_include_to_batch("test-batch", file="new.txt", quiet=True)
+
+        command_discard_from_batch("test-batch", line_ids="1", file="new.txt")
+
+        assert not new_path.exists()
+
+    def test_discard_from_batch_partial_new_text_file_removes_path_when_exhausted(self, temp_git_repo):
+        """Discarding the remaining owned content of a partial new file should restore absence."""
+        new_path = temp_git_repo / "new.txt"
+        new_path.write_text("owned\nunowned\n")
+        command_start()
+        command_include_to_batch("test-batch", line_ids="1", file="new.txt", quiet=True)
+
+        new_path.write_text("owned\n")
+
+        command_discard_from_batch("test-batch", file="new.txt")
+
+        assert not new_path.exists()
+
+    def test_discard_from_batch_line_scoped_deleted_text_file_restores_executable_mode(self, temp_git_repo):
+        """Line-scoped discard that restores a deleted text path should use baseline mode."""
+        tool_path = temp_git_repo / "tool.sh"
+        tool_path.write_text("#!/bin/sh\necho base\n")
+        tool_path.chmod(0o755)
+        subprocess.run(["git", "add", "tool.sh"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add executable tool"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        tool_path.unlink()
+        command_start()
+        command_include_to_batch("test-batch", file="tool.sh", quiet=True)
+
+        command_discard_from_batch("test-batch", line_ids="1-2", file="tool.sh")
+
+        assert tool_path.read_text() == "#!/bin/sh\necho base\n"
+        assert stat.S_IMODE(tool_path.stat().st_mode) & stat.S_IXUSR
 
     def test_include_from_batch_as_replaces_presence_only_selection(self, temp_git_repo):
         """Test include --from --line --as replaces claimed batch content before staging."""

--- a/tests/staging/test_operations.py
+++ b/tests/staging/test_operations.py
@@ -525,7 +525,7 @@ class TestBuildTargetIndexContent:
 
         assert result == b"keep1\nstaged\nkeep3\nkeep4\n"
 
-    def test_replace_selection_keeps_matching_edge_anchors_with_no_anchor(self):
+    def test_replace_selection_keeps_matching_edge_anchors_with_no_edge_overlap(self):
         """Replacement staging should preserve duplicated anchors when requested."""
         header = HunkHeader(1, 4, 1, 4)
         lines = [
@@ -570,7 +570,7 @@ class TestBuildTargetIndexContent:
 
         assert result == b"keep1\nstaged\nkeep3\nkeep4\n"
 
-    def test_working_tree_replace_selection_keeps_matching_edge_anchors_with_no_anchor(self):
+    def test_working_tree_replace_selection_keeps_matching_edge_anchors_with_no_edge_overlap(self):
         """Working-tree replacement should preserve duplicated anchors when requested."""
         header = HunkHeader(1, 4, 1, 4)
         lines = [


### PR DESCRIPTION
The batch system handles text and binary file staging across include,
discard, apply, and sift workflows. Session start, ownership
validation, and CLI option naming round out the command surface.

Several workflow paths have gaps: stale selected-change state can
persist across sessions, binary and text file modes can be lost during
batch operations, lifecycle metadata for added and deleted paths is not
tracked, and the `--no-anchor` flag name does not convey what it
controls. Batch source annotations and include-from working tree
writes are also incomplete.

This series addresses those gaps across 28 commits:

- **Session start** clears stale selected-change state so that a new
  session begins from a blank slate.
- **Ownership validation** includes rendered row and path context in
  error diagnostics.
- **CLI rename** changes `--no-anchor` to `--no-edge-overlap` across
  source, docs, tests, and completions (old spelling kept as hidden alias).
- **Text lifecycle tracking** adds `TextFileChangeType` helpers and
  batch metadata for whole-path added and deleted states, used by sift,
  apply-from, discard-from, and include-from.
- **Sift** preserves source baselines, empty text lifecycle states, and
  retained binary target bytes across batch rebuilds.
- **File modes** are now detected from the working tree (not only the
  index) for include-to and discard-to, and restored for binary
  apply-from and discard-from.
- **Include-from** writes to both index and working tree in a single
  operation, and tracks selected binary progress.
- **Completions** offer `--no-edge-overlap` and edited-line replacement
  options.
- **Batch annotations** record binary source choices and deleted-text
  empty-target rules at write points.

Each functional area has corresponding test coverage.