### PR TITLE
File review foundations: page-aware models, navigation, and scope resolution

### DIFF
--- a/src/git_stage_batch/batch/selection.py
+++ b/src/git_stage_batch/batch/selection.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import TYPE_CHECKING, Optional
 
 from .ownership import (
@@ -19,6 +20,7 @@ from ..utils.file_patterns import resolve_gitignore_style_patterns
 if TYPE_CHECKING:
     from ..exceptions import AtomicUnitError
     from ..core.models import RenderedBatchDisplay
+    from ..data.file_review_state import FileReviewAction
 
 
 def resolve_batch_file_scope(
@@ -163,6 +165,67 @@ def translate_atomic_unit_error_to_gutter_ids(
         name=batch_name,
         error=str(error)
     ))
+
+
+def translate_batch_file_gutter_ids_to_selection_ids(
+    batch_name: str,
+    file_path: str,
+    selected_ids: set[int] | None,
+    action: 'FileReviewAction | str',
+) -> tuple[set[int] | None, 'RenderedBatchDisplay | None']:
+    """Translate displayed batch-file gutter IDs to internal selection IDs.
+
+    If the IDs came after a fresh matching file review, validate them against
+    the complete actions shown by that review before consulting the full batch
+    display. Without a matching review, keep the historical raw batch display
+    behavior.
+    """
+    if selected_ids is None:
+        return None, None
+
+    from ..data.file_review_state import (
+        fresh_batch_review_selection_groups_for_action,
+        validate_review_scoped_line_selection,
+    )
+    from ..data.hunk_tracking import render_batch_file_display
+
+    review_groups = fresh_batch_review_selection_groups_for_action(batch_name, file_path, action)
+    if review_groups is not None:
+        validate_review_scoped_line_selection(selected_ids, review_groups)
+
+    rendered = render_batch_file_display(batch_name, file_path)
+    if rendered is None:
+        return selected_ids, None
+
+    display_id_map = (
+        rendered.review_gutter_to_selection_id or rendered.gutter_to_selection_id
+        if review_groups is not None else
+        rendered.gutter_to_selection_id
+    )
+    rendered_for_messages = (
+        replace(
+            rendered,
+            gutter_to_selection_id=dict(display_id_map),
+            selection_id_to_gutter={
+                selection_id: gutter_id
+                for gutter_id, selection_id in display_id_map.items()
+            },
+        )
+        if review_groups is not None else
+        rendered
+    )
+    selection_ids: set[int] = set()
+    for gutter_id in selected_ids:
+        if gutter_id in display_id_map:
+            selection_ids.add(display_id_map[gutter_id])
+        else:
+            exit_with_error(
+                _("Line ID {id} is not available for this action. Select one of the numbered lines shown for this batch file.").format(
+                    id=gutter_id
+                )
+            )
+
+    return selection_ids, rendered_for_messages
 
 
 def select_batch_ownership_for_display_ids(

--- a/src/git_stage_batch/batch/selection.py
+++ b/src/git_stage_batch/batch/selection.py
@@ -48,15 +48,13 @@ def resolve_batch_file_scope(
     """
     if file is not None:
         # Specific file requested
-        from ..data.hunk_tracking import get_batch_file_for_line_operation
+        from ..data.hunk_tracking import get_batch_file_for_line_operation, get_selected_change_file_path
 
         # If file is empty string, use selected hunk's file
         if file == "":
-            from ..data.line_state import load_line_changes_from_state
-            line_changes = load_line_changes_from_state()
-            if line_changes is None:
+            file_to_use = get_selected_change_file_path()
+            if file_to_use is None:
                 exit_with_error(_("No selected hunk. Run 'show' first or specify file path."))
-            file_to_use = line_changes.path
         else:
             file_to_use = file
 

--- a/src/git_stage_batch/cli/argument_parser.py
+++ b/src/git_stage_batch/cli/argument_parser.py
@@ -487,13 +487,7 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
             if isinstance(resolved_file_scope, list):
                 if args.line_ids:
                     raise CommandError(_("Cannot use --lines with multiple files."))
-                last_index = len(resolved_file_scope) - 1
-                for index, file in enumerate(resolved_file_scope):
-                    commands.command_show(
-                        file=file,
-                        porcelain=args.porcelain,
-                        selectable=(index == last_index),
-                    )
+                commands.command_show_file_list(resolved_file_scope)
             else:
                 commands.command_show(file=resolved_file_scope, porcelain=args.porcelain)
             return

--- a/src/git_stage_batch/cli/argument_parser.py
+++ b/src/git_stage_batch/cli/argument_parser.py
@@ -572,18 +572,17 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
     )
 
     def dispatch_include(args: argparse.Namespace) -> None:
-        replacement_text = _resolve_replacement_text(args)
-        resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
-        resolved_batch_scope = (
-            _resolve_batch_file_scope(args.from_batch, args.file, args.file_patterns)
-            if args.from_batch else None
-        )
-        if replacement_text is not None:
+        replacement_requested = args.as_text is not None or args.as_stdin
+        if replacement_requested:
+            if args.as_text is not None and args.as_stdin:
+                raise CommandError(_("Cannot use `--as` and `--as-stdin` together."))
             if args.line_ids and args.from_batch and not args.to_batch:
                 if args.no_edge_overlap:
                     raise CommandError(_("`--no-edge-overlap` only applies to live `include --line --as` operations."))
+                resolved_batch_scope = _resolve_batch_file_scope(args.from_batch, args.file, args.file_patterns)
                 if isinstance(resolved_batch_scope, list):
                     raise CommandError(_("Cannot use --lines with multiple files."))
+                replacement_text = _resolve_replacement_text(args)
                 commands.command_include_from_batch(
                     args.from_batch,
                     args.line_ids,
@@ -592,8 +591,10 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
                 )
                 return
             if args.line_ids and not args.from_batch and not args.to_batch:
+                resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
                 if isinstance(resolved_live_scope, list):
                     raise CommandError(_("Cannot use --lines with multiple files."))
+                replacement_text = _resolve_replacement_text(args)
                 commands.command_include_line_as(
                     args.line_ids,
                     replacement_text,
@@ -605,12 +606,17 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
                 args.line_ids is None
                 and args.from_batch is None
                 and args.to_batch is None
-                and resolved_live_scope is not None
             ):
+                resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
+                if resolved_live_scope is None:
+                    raise CommandError(
+                        _("`include --as` requires `--file` or `--line` and does not support `--to`.")
+                    )
                 if args.no_edge_overlap:
                     raise CommandError(_("`--no-edge-overlap` requires `include --line --as`."))
                 if isinstance(resolved_live_scope, list):
                     raise CommandError(_("Cannot use --as with multiple files."))
+                replacement_text = _resolve_replacement_text(args)
                 commands.command_include_file_as(replacement_text, file=resolved_live_scope)
                 return
             raise CommandError(
@@ -619,28 +625,32 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
         if args.no_edge_overlap:
             raise CommandError(_("`--no-edge-overlap` requires `include --line --as`."))
         if args.from_batch:
+            resolved_batch_scope = _resolve_batch_file_scope(args.from_batch, args.file, args.file_patterns)
             _run_for_each_file(
                 resolved_batch_scope,
                 lambda file: commands.command_include_from_batch(args.from_batch, args.line_ids, file),
                 line_ids=args.line_ids,
             )
         elif args.to_batch:
+            resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
             _run_for_each_file(
                 resolved_live_scope,
                 lambda file: commands.command_include_to_batch(args.to_batch, args.line_ids, file),
                 line_ids=args.line_ids,
             )
         elif args.line_ids:
+            resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
             if isinstance(resolved_live_scope, list):
                 raise CommandError(_("Cannot use --lines with multiple files."))
             commands.command_include_line(args.line_ids, file=resolved_live_scope)
-        elif resolved_live_scope is not None:
+        else:
+            resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
             if isinstance(resolved_live_scope, list):
                 _include_each_resolved_file(resolved_live_scope)
-            else:
+            elif resolved_live_scope is not None:
                 commands.command_include_file(resolved_live_scope)
-        else:
-            commands.command_include()
+            else:
+                commands.command_include()
 
     parser_include.set_defaults(func=dispatch_include)
 
@@ -669,7 +679,7 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
         if args.line_ids:
             if isinstance(resolved_file_scope, list):
                 raise CommandError(_("Cannot use --lines with multiple files."))
-            commands.command_skip_line(args.line_ids)
+            commands.command_skip_line(args.line_ids, file=resolved_file_scope)
         elif resolved_file_scope is not None:
             if isinstance(resolved_file_scope, list):
                 _skip_each_resolved_file(resolved_file_scope)
@@ -738,16 +748,15 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
     )
 
     def dispatch_discard(args: argparse.Namespace) -> None:
-        replacement_text = _resolve_replacement_text(args)
-        resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
-        resolved_batch_scope = (
-            _resolve_batch_file_scope(args.from_batch, args.file, args.file_patterns)
-            if args.from_batch else None
-        )
-        if replacement_text is not None:
+        replacement_requested = args.as_text is not None or args.as_stdin
+        if replacement_requested:
+            if args.as_text is not None and args.as_stdin:
+                raise CommandError(_("Cannot use `--as` and `--as-stdin` together."))
             if args.to_batch and args.line_ids and not args.from_batch:
+                resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
                 if isinstance(resolved_live_scope, list):
                     raise CommandError(_("Cannot use --lines with multiple files."))
+                replacement_text = _resolve_replacement_text(args)
                 commands.command_discard_line_as_to_batch(
                     args.to_batch,
                     args.line_ids,
@@ -760,12 +769,17 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
                 args.to_batch is None
                 and args.from_batch is None
                 and args.line_ids is None
-                and resolved_live_scope is not None
             ):
+                resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
+                if resolved_live_scope is None:
+                    raise CommandError(
+                        _("`discard --as` requires `--file`, or `--to` with `--line`.")
+                    )
                 if args.no_edge_overlap:
                     raise CommandError(_("`--no-edge-overlap` requires `discard --to --line --as`."))
                 if isinstance(resolved_live_scope, list):
                     raise CommandError(_("Cannot use --as with multiple files."))
+                replacement_text = _resolve_replacement_text(args)
                 commands.command_discard_file_as(replacement_text, file=resolved_live_scope)
                 return
             raise CommandError(
@@ -774,25 +788,30 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
         if args.no_edge_overlap:
             raise CommandError(_("`--no-edge-overlap` requires `discard --to --line --as`."))
         if args.from_batch:
+            resolved_batch_scope = _resolve_batch_file_scope(args.from_batch, args.file, args.file_patterns)
             _run_for_each_file(
                 resolved_batch_scope,
                 lambda file: commands.command_discard_from_batch(args.from_batch, args.line_ids, file),
                 line_ids=args.line_ids,
             )
         elif args.to_batch:
+            resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
             _run_for_each_file(
                 resolved_live_scope,
                 lambda file: commands.command_discard_to_batch(args.to_batch, args.line_ids, file),
                 line_ids=args.line_ids,
             )
         elif args.line_ids:
+            resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
             if isinstance(resolved_live_scope, list):
                 raise CommandError(_("Cannot use --lines with multiple files."))
             commands.command_discard_line(args.line_ids, file=resolved_live_scope)
-        elif resolved_live_scope is not None:
-            _run_for_each_file(resolved_live_scope, commands.command_discard_file)
         else:
-            commands.command_discard()
+            resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
+            if resolved_live_scope is not None:
+                _run_for_each_file(resolved_live_scope, commands.command_discard_file)
+            else:
+                commands.command_discard()
 
     parser_discard.set_defaults(func=dispatch_discard)
 

--- a/src/git_stage_batch/commands/__init__.py
+++ b/src/git_stage_batch/commands/__init__.py
@@ -17,7 +17,7 @@ from .interactive import command_interactive
 from .list import command_list_batches
 from .new import command_new_batch
 from .reset import command_reset_from_batch
-from .show import command_show
+from .show import command_show, command_show_file_list
 from .show_from import command_show_from_batch
 from .sift import command_sift_batch
 from .skip import command_skip, command_skip_file, command_skip_line
@@ -56,6 +56,7 @@ __all__ = [
     "command_new_batch",
     "command_reset_from_batch",
     "command_show",
+    "command_show_file_list",
     "command_show_from_batch",
     "command_sift_batch",
     "command_skip",

--- a/src/git_stage_batch/commands/apply_from.py
+++ b/src/git_stage_batch/commands/apply_from.py
@@ -13,6 +13,7 @@ from ..batch.selection import (
     resolve_batch_file_scope,
     require_single_file_context_for_line_selection,
     select_batch_ownership_for_display_ids,
+    translate_batch_file_gutter_ids_to_selection_ids,
     translate_atomic_unit_error_to_gutter_ids,
 )
 from ..batch.validation import batch_exists
@@ -22,7 +23,13 @@ from ..core.text_lifecycle import (
     normalized_text_change_type,
     selected_text_target_change_type,
 )
-from ..data.hunk_tracking import render_batch_file_display
+from ..data.file_review_state import (
+    FileReviewAction,
+    resolve_batch_source_action_scope,
+)
+from ..data.hunk_tracking import (
+    render_batch_file_display,
+)
 from ..data.session import snapshot_file_if_untracked
 from ..data.undo import undo_checkpoint
 from ..exceptions import exit_with_error, MergeError, CommandError, AtomicUnitError, BatchMetadataError
@@ -136,6 +143,15 @@ def command_apply_from_batch(
         patterns: Optional gitignore-style file patterns to filter batch files.
     """
     require_git_repository()
+    scope_resolution = resolve_batch_source_action_scope(
+        FileReviewAction.APPLY_FROM_BATCH,
+        command_name="apply",
+        batch_name=batch_name,
+        line_ids=line_ids,
+        file=file,
+        patterns=patterns,
+    )
+    file = scope_resolution.file
 
     # Check batch exists
     if not batch_exists(batch_name):
@@ -170,17 +186,13 @@ def command_apply_from_batch(
     selection_ids_to_apply = selected_ids
     rendered = None  # Store for error translation
     if selected_ids:
-        # Use pure render helper to get gutter ID mapping (no side effects)
         file_path_for_render = list(files.keys())[0]  # Single file context enforced above
-        rendered = render_batch_file_display(batch_name, file_path_for_render)
-        if rendered:
-            # Translate gutter IDs (what user sees) to selection IDs (internal)
-            selection_ids_to_apply = set()
-            for gutter_id in selected_ids:
-                if gutter_id in rendered.gutter_to_selection_id:
-                    selection_ids_to_apply.add(rendered.gutter_to_selection_id[gutter_id])
-                else:
-                    exit_with_error(_("Line ID {id} not found or not individually mergeable").format(id=gutter_id))
+        selection_ids_to_apply, rendered = translate_batch_file_gutter_ids_to_selection_ids(
+            batch_name,
+            file_path_for_render,
+            selected_ids,
+            FileReviewAction.APPLY_FROM_BATCH,
+        )
     operation_parts = ["apply", "--from", batch_name]
     if line_ids is not None:
         operation_parts.extend(["--line", line_ids])

--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -39,6 +39,8 @@ from ..data.hunk_tracking import (
     recalculate_selected_hunk_for_file,
     record_hunk_discarded,
     require_selected_hunk,
+    restore_selected_change_state,
+    snapshot_selected_change_state,
 )
 from ..data.line_state import load_line_changes_from_state
 from ..data.batch_sources import create_batch_source_commit, load_session_batch_sources, save_session_batch_sources
@@ -61,8 +63,6 @@ from ..utils.paths import (
 )
 from .include import (
     _expand_replacement_selection_ids,
-    _restore_selected_change_state,
-    _snapshot_selected_change_state,
 )
 
 
@@ -342,7 +342,7 @@ def command_discard_file_as(replacement_text: str, file: str | None = None) -> N
         else:
             target_file = file
             preserve_selected_state = True
-            saved_selected_state = _snapshot_selected_change_state()
+            saved_selected_state = snapshot_selected_change_state()
 
         line_changes = _load_explicit_file_selection(target_file)
         snapshot_file_if_untracked(target_file)
@@ -352,7 +352,7 @@ def command_discard_file_as(replacement_text: str, file: str | None = None) -> N
         absolute_path.write_text(replacement_text, encoding="utf-8", errors="surrogateescape")
 
         if preserve_selected_state:
-            _restore_selected_change_state(saved_selected_state)
+            restore_selected_change_state(saved_selected_state)
         else:
             recalculate_selected_hunk_for_file(line_changes.path)
 
@@ -481,8 +481,8 @@ def command_discard_line_as_to_batch(
     if file is not None:
         operation_parts.extend(["--file", file])
     with undo_checkpoint(" ".join(operation_parts)):
-        saved_selected_state = _snapshot_selected_change_state()
         preserve_selected_state = file is not None
+        saved_selected_state = snapshot_selected_change_state()
 
         try:
             if file is None:
@@ -506,9 +506,9 @@ def command_discard_line_as_to_batch(
             )
 
             if preserve_selected_state:
-                _restore_selected_change_state(saved_selected_state)
+                restore_selected_change_state(saved_selected_state)
         except Exception:
-            _restore_selected_change_state(saved_selected_state)
+            restore_selected_change_state(saved_selected_state)
             raise
 
 

--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -25,6 +25,7 @@ from ..core.diff_parser import (
 from ..core.hashing import compute_stable_hunk_hash
 from ..core.line_selection import parse_line_selection
 from ..core.models import BinaryFileChange
+from ..core.text_lifecycle import TextFileChangeType, detect_empty_text_lifecycle_change
 from ..data.hunk_tracking import (
     SelectedChangeKind,
     advance_to_and_show_next_change,
@@ -757,34 +758,34 @@ def _command_discard_file_to_batch(batch_name: str, file_path: str, *, quiet: bo
         patches_to_discard.append((patch_bytes_loop, patch_hash))
 
     if not all_lines_to_batch:
-        # Special case: empty new file (exists in working tree but not in HEAD)
+        # Special case: empty text lifecycle changes have no hunk body.
         repo_root = get_git_repository_root_path()
         full_path = repo_root / file_path
-        if full_path.exists():
-            # Check if file exists in HEAD
-            head_result = run_git_command(["cat-file", "-e", f"HEAD:{file_path}"], check=False)
-            if head_result.returncode != 0:
-                # File doesn't exist in HEAD - it's a new empty file
-                # Save empty file metadata to batch and delete it
-                empty_ownership = BatchOwnership(claimed_lines=[], deletions=[])
+        lifecycle_change_type = detect_empty_text_lifecycle_change(file_path)
+        if lifecycle_change_type is not None:
+            snapshot_file_if_untracked(file_path)
+            add_file_to_batch(
+                batch_name,
+                file_path,
+                BatchOwnership(claimed_lines=[], deletions=[]),
+                file_mode,
+                change_type=lifecycle_change_type,
+            )
 
-                # Snapshot before deleting
-                snapshot_file_if_untracked(file_path)
-
-                # Save to batch
-                add_file_to_batch(batch_name, file_path, empty_ownership, file_mode)
-
+            if lifecycle_change_type == TextFileChangeType.ADDED:
                 # Delete from working tree
                 full_path.unlink()
 
                 # Remove from index if present (from intent-to-add)
                 run_git_command(["rm", "--cached", "--quiet", "--", file_path], check=False)
+            else:
+                run_git_command(["checkout", "HEAD", "--", file_path], check=False)
 
-                if not quiet:
-                    print(_("Discarded file '{file}' to batch '{batch}'").format(file=file_path, batch=batch_name), file=sys.stderr)
+            if not quiet:
+                print(_("Discarded file '{file}' to batch '{batch}'").format(file=file_path, batch=batch_name), file=sys.stderr)
 
-                log_journal("discard_file_to_batch_end", batch_name=batch_name, file_path=file_path)
-                return
+            log_journal("discard_file_to_batch_end", batch_name=batch_name, file_path=file_path)
+            return
 
         if not quiet:
             print(_("No changes in file '{file}' to discard.").format(file=file_path), file=sys.stderr)

--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -49,6 +49,7 @@ from ..data.session import require_session_started, snapshot_file_if_untracked
 from ..data.undo import undo_checkpoint
 from ..exceptions import CommandError, exit_with_error, NoMoreHunks
 from ..i18n import _, ngettext
+from ..output import print_remaining_line_changes_header
 from ..staging.operations import build_target_working_tree_content_bytes_with_discarded_lines
 from ..staging.operations import build_target_working_tree_content_bytes_with_replaced_lines
 from ..utils.command import ExitEvent, OutputEvent, stream_command
@@ -409,9 +410,15 @@ def command_discard_line(line_id_specification: str, file: str | None = None) ->
         working_file_path.write_bytes(target_working_content)
 
         # After modifying working tree, recalculate hunk for the SAME file
+        print(
+            _("✓ Discarded line(s): {lines} from {file}").format(
+                lines=line_id_specification,
+                file=line_changes.path,
+            ),
+            file=sys.stderr,
+        )
+        print_remaining_line_changes_header(line_changes.path)
         recalculate_selected_hunk_for_file(line_changes.path)
-
-    print(_("✓ Discarded line(s): {lines}").format(lines=line_id_specification), file=sys.stderr)
 
 
 def command_discard_to_batch(batch_name: str, line_ids: str | None = None, file: str | None = None, *, quiet: bool = False) -> None:

--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -38,6 +38,7 @@ from ..data.hunk_tracking import (
     read_selected_change_kind,
     recalculate_selected_hunk_for_file,
     record_hunk_discarded,
+    refuse_bare_action_after_file_list,
     require_selected_hunk,
     restore_selected_change_state,
     snapshot_selected_change_state,
@@ -91,6 +92,7 @@ def command_discard(*, quiet: bool = False) -> None:
     require_session_started()
     ensure_state_directory_exists()
 
+    refuse_bare_action_after_file_list("discard")
     if read_selected_change_kind() == SelectedChangeKind.FILE:
         _command_discard_selected_file(quiet=quiet)
         return
@@ -269,6 +271,8 @@ def command_discard_file(file: str) -> None:
     require_session_started()
     ensure_state_directory_exists()
 
+    if file == "":
+        refuse_bare_action_after_file_list("discard --file")
     # Determine target file
     if file == "":
         target_file = get_selected_change_file_path()

--- a/src/git_stage_batch/commands/discard_from.py
+++ b/src/git_stage_batch/commands/discard_from.py
@@ -13,6 +13,7 @@ from ..batch.selection import (
     resolve_batch_file_scope,
     require_single_file_context_for_line_selection,
     select_batch_ownership_for_display_ids,
+    translate_batch_file_gutter_ids_to_selection_ids,
     translate_atomic_unit_error_to_gutter_ids,
 )
 from ..batch.validation import batch_exists
@@ -22,7 +23,10 @@ from ..core.text_lifecycle import (
     normalized_text_change_type,
     selected_text_discard_change_type,
 )
-from ..data.hunk_tracking import render_batch_file_display
+from ..data.file_review_state import (
+    FileReviewAction,
+    resolve_batch_source_action_scope,
+)
 from ..data.session import snapshot_file_if_untracked
 from ..data.undo import undo_checkpoint
 from ..exceptions import exit_with_error, AtomicUnitError, CommandError, MergeError, BatchMetadataError
@@ -132,6 +136,15 @@ def command_discard_from_batch(
         patterns: Optional gitignore-style file patterns to filter batch files.
     """
     require_git_repository()
+    scope_resolution = resolve_batch_source_action_scope(
+        FileReviewAction.DISCARD_FROM_BATCH,
+        command_name="discard",
+        batch_name=batch_name,
+        line_ids=line_ids,
+        file=file,
+        patterns=patterns,
+    )
+    file = scope_resolution.file
 
     # Check batch exists
     if not batch_exists(batch_name):
@@ -166,17 +179,13 @@ def command_discard_from_batch(
     selection_ids_to_discard = selected_ids
     rendered = None
     if selected_ids:
-        # Use pure render helper to get gutter ID mapping (no side effects)
         file_path_for_render = list(files.keys())[0]  # Single file context enforced above
-        rendered = render_batch_file_display(batch_name, file_path_for_render)
-        if rendered:
-            # Translate gutter IDs (what user sees) to selection IDs (internal)
-            selection_ids_to_discard = set()
-            for gutter_id in selected_ids:
-                if gutter_id in rendered.gutter_to_selection_id:
-                    selection_ids_to_discard.add(rendered.gutter_to_selection_id[gutter_id])
-                else:
-                    exit_with_error(_("Line ID {id} not found or not individually mergeable").format(id=gutter_id))
+        selection_ids_to_discard, rendered = translate_batch_file_gutter_ids_to_selection_ids(
+            batch_name,
+            file_path_for_render,
+            selected_ids,
+            FileReviewAction.DISCARD_FROM_BATCH,
+        )
 
     # Get baseline commit (raises BatchMetadataError with clear message if missing)
     try:

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -35,7 +35,6 @@ from ..data.hunk_tracking import (
     advance_to_and_show_next_change,
     advance_to_next_change,
     apply_line_level_batch_filter_to_cached_hunk,
-    cache_file_as_single_hunk,
     cache_unstaged_file_as_single_hunk,
     clear_selected_change_state_files,
     fetch_next_change,
@@ -47,6 +46,8 @@ from ..data.hunk_tracking import (
     record_hunk_included,
     record_hunk_skipped,
     require_selected_hunk,
+    restore_selected_change_state,
+    snapshot_selected_change_state,
 )
 from ..data.consumed_selections import record_consumed_selection
 from ..data.line_state import load_line_changes_from_state
@@ -291,7 +292,7 @@ def command_include_file_as(replacement_text: str, file: str | None = None) -> N
         else:
             target_file = file
             preserve_selected_state = True
-            saved_selected_state = _snapshot_selected_change_state()
+            saved_selected_state = snapshot_selected_change_state()
 
         if preserve_selected_state:
             line_changes = cache_unstaged_file_as_single_hunk(target_file)
@@ -310,7 +311,7 @@ def command_include_file_as(replacement_text: str, file: str | None = None) -> N
         )
 
         if preserve_selected_state:
-            _restore_selected_change_state(saved_selected_state)
+            restore_selected_change_state(saved_selected_state)
         else:
             write_line_ids_file(get_processed_include_ids_file_path(), set())
             recalculate_selected_hunk_for_file(target_file)
@@ -358,7 +359,7 @@ def command_include_line(line_id_specification: str, file: str | None = None) ->
             else:
                 if file != "":
                     preserve_selected_state = True
-                    saved_selected_state = _snapshot_selected_change_state()
+                    saved_selected_state = snapshot_selected_change_state()
 
                 line_changes = cache_unstaged_file_as_single_hunk(target_file)
                 if line_changes is None:
@@ -436,7 +437,7 @@ def command_include_line(line_id_specification: str, file: str | None = None) ->
         update_index_with_blob_content(line_changes.path, target_index_content)
 
         if preserve_selected_state:
-            _restore_selected_change_state(saved_selected_state)
+            restore_selected_change_state(saved_selected_state)
         else:
             # Update processed include IDs only when the selected display remains
             # current for incremental line inclusion.
@@ -635,45 +636,6 @@ def _apply_include_line_replacement(
     )
 
 
-def _snapshot_selected_change_state() -> dict[str, bytes | None]:
-    """Capture the current selected change cache so explicit file ops can restore it."""
-    paths = {
-        "patch": get_selected_hunk_patch_file_path(),
-        "hash": get_selected_hunk_hash_file_path(),
-        "kind": get_selected_change_kind_file_path(),
-        "line_state": get_line_changes_json_file_path(),
-        "binary": get_selected_binary_file_json_path(),
-        "index_snapshot": get_index_snapshot_file_path(),
-        "working_snapshot": get_working_tree_snapshot_file_path(),
-        "processed_include_ids": get_processed_include_ids_file_path(),
-    }
-    return {
-        name: (read_file_bytes(path) if path.exists() else None)
-        for name, path in paths.items()
-    }
-
-
-def _restore_selected_change_state(snapshot: dict[str, bytes | None]) -> None:
-    """Restore a previously captured selected change cache."""
-    paths = {
-        "patch": get_selected_hunk_patch_file_path(),
-        "hash": get_selected_hunk_hash_file_path(),
-        "kind": get_selected_change_kind_file_path(),
-        "line_state": get_line_changes_json_file_path(),
-        "binary": get_selected_binary_file_json_path(),
-        "index_snapshot": get_index_snapshot_file_path(),
-        "working_snapshot": get_working_tree_snapshot_file_path(),
-        "processed_include_ids": get_processed_include_ids_file_path(),
-    }
-    for name, path in paths.items():
-        data = snapshot.get(name)
-        if data is None:
-            path.unlink(missing_ok=True)
-        else:
-            path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_bytes(data)
-
-
 def command_include_line_as(
     line_id_specification: str,
     replacement_text: str,
@@ -733,7 +695,7 @@ def command_include_line_as(
             else:
                 if file != "":
                     preserve_selected_state = True
-                saved_selected_state = _snapshot_selected_change_state() if preserve_selected_state else None
+                saved_selected_state = snapshot_selected_change_state() if preserve_selected_state else None
 
                 cached_lines = cache_unstaged_file_as_single_hunk(target_file)
                 if cached_lines is None:
@@ -758,7 +720,7 @@ def command_include_line_as(
             )
 
             if preserve_selected_state:
-                _restore_selected_change_state(saved_selected_state)
+                restore_selected_change_state(saved_selected_state)
             else:
                 write_line_ids_file(get_processed_include_ids_file_path(), set())
                 recalculate_selected_hunk_for_file(target_file)

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -45,6 +45,7 @@ from ..data.hunk_tracking import (
     record_binary_hunk_skipped,
     record_hunk_included,
     record_hunk_skipped,
+    refuse_bare_action_after_file_list,
     require_selected_hunk,
     restore_selected_change_state,
     snapshot_selected_change_state,
@@ -103,6 +104,7 @@ def command_include(*, quiet: bool = False) -> None:
     require_session_started()
     ensure_state_directory_exists()
 
+    refuse_bare_action_after_file_list("include")
     if read_selected_change_kind() == SelectedChangeKind.FILE:
         command_include_file("")
         return 0
@@ -199,6 +201,8 @@ def command_include_file(
     require_session_started()
     ensure_state_directory_exists()
 
+    if file == "":
+        refuse_bare_action_after_file_list("include --file")
     # Determine target file
     if file == "":
         target_file = get_selected_change_file_path()

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -56,7 +56,7 @@ from ..data.session import require_session_started, snapshot_file_if_untracked
 from ..data.undo import undo_checkpoint
 from ..exceptions import NoMoreHunks, exit_with_error
 from ..i18n import _, ngettext
-from ..output import print_line_level_changes
+from ..output import print_line_level_changes, print_remaining_line_changes_header
 from ..staging.operations import (
     build_target_index_content_bytes_with_replaced_lines,
     build_target_index_content_bytes_with_selected_lines,
@@ -446,9 +446,23 @@ def command_include_line(line_id_specification: str, file: str | None = None) ->
             # Update processed include IDs only when the selected display remains
             # current for incremental line inclusion.
             write_line_ids_file(get_processed_include_ids_file_path(), combined_include_ids)
+            print(
+                _("✓ Included line(s): {lines} from {file}").format(
+                    lines=line_id_specification,
+                    file=line_changes.path,
+                ),
+                file=sys.stderr,
+            )
+            print_remaining_line_changes_header(line_changes.path)
             recalculate_selected_hunk_for_file(line_changes.path)
-
-    print(_("✓ Included line(s): {lines}").format(lines=line_id_specification), file=sys.stderr)
+    if preserve_selected_state:
+        print(
+            _("✓ Included line(s): {lines} from {file}").format(
+                lines=line_id_specification,
+                file=line_changes.path,
+            ),
+            file=sys.stderr,
+        )
 
 
 def _derive_replacement_unit_display_ids(

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -29,6 +29,7 @@ from ..core.line_selection import (
     write_line_ids_file,
 )
 from ..core.models import BinaryFileChange
+from ..core.text_lifecycle import detect_empty_text_lifecycle_change
 from ..data.hunk_tracking import (
     SelectedChangeKind,
     advance_to_and_show_next_change,
@@ -856,6 +857,27 @@ def _command_include_binary_to_batch(
         advance_to_and_show_next_change()
 
 
+def _save_empty_text_lifecycle_to_batch(
+    batch_name: str,
+    file_path: str,
+    file_mode: str,
+) -> str | None:
+    """Persist an empty added/deleted text path, returning its lifecycle type."""
+    change_type = detect_empty_text_lifecycle_change(file_path)
+    if change_type is None:
+        return None
+
+    snapshot_file_if_untracked(file_path)
+    add_file_to_batch(
+        batch_name,
+        file_path,
+        BatchOwnership(claimed_lines=[], deletions=[]),
+        file_mode,
+        change_type=change_type,
+    )
+    return change_type.value
+
+
 def _command_include_file_to_batch(batch_name: str, file_path: str, *, quiet: bool = False) -> None:
     """Include entire file to batch (internal helper for file-scoped operations)."""
 
@@ -875,6 +897,15 @@ def _command_include_file_to_batch(batch_name: str, file_path: str, *, quiet: bo
         all_lines_to_batch.extend(hunk_lines.lines)
 
     if not all_lines_to_batch:
+        if _save_empty_text_lifecycle_to_batch(batch_name, file_path, file_mode) is not None:
+            if not quiet:
+                print(_("Included file '{file}' to batch '{batch}'").format(file=file_path, batch=batch_name), file=sys.stderr)
+            if quiet:
+                advance_to_next_change()
+            else:
+                advance_to_and_show_next_change()
+            return
+
         if not quiet:
             print(_("No changes in file '{file}' to include.").format(file=file_path), file=sys.stderr)
         return

--- a/src/git_stage_batch/commands/include_from.py
+++ b/src/git_stage_batch/commands/include_from.py
@@ -23,7 +23,13 @@ from ..core.text_lifecycle import (
     normalized_text_change_type,
     selected_text_target_change_type,
 )
-from ..data.hunk_tracking import render_batch_file_display
+from ..data.file_review_state import (
+    FileReviewAction,
+    resolve_batch_source_action_scope,
+)
+from ..data.hunk_tracking import (
+    render_batch_file_display,
+)
 from ..data.session import snapshot_file_if_untracked
 from ..data.undo import undo_checkpoint
 from ..exceptions import (
@@ -197,6 +203,15 @@ def command_include_from_batch(
         replacement_text: Optional replacement text for selected batch lines.
     """
     require_git_repository()
+    scope_resolution = resolve_batch_source_action_scope(
+        FileReviewAction.INCLUDE_FROM_BATCH,
+        command_name="include",
+        batch_name=batch_name,
+        line_ids=line_ids,
+        file=file,
+        patterns=patterns,
+    )
+    file = scope_resolution.file
 
     # Refresh index to ensure git's cached stat info is up-to-date
     run_git_command(["update-index", "--refresh"], check=False)

--- a/src/git_stage_batch/commands/reset.py
+++ b/src/git_stage_batch/commands/reset.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import json
+import shlex
 import sys
 
+from ..core.line_selection import format_line_ids
 from ..batch.operations import create_batch
 from ..batch.ownership import (
     BatchOwnership,
@@ -28,6 +30,13 @@ from ..batch.state_refs import sync_batch_state_refs
 from ..batch.validation import batch_exists, validate_batch_name
 from ..exceptions import MergeError, exit_with_error
 from ..i18n import _
+from ..data.file_review_state import (
+    FileReviewAction,
+    fresh_batch_review_selection_groups_for_action,
+    resolve_batch_source_action_scope,
+    validate_review_scoped_line_selection,
+)
+from ..data.hunk_tracking import render_batch_file_display
 from ..data.undo import undo_checkpoint
 from ..utils.file_io import write_text_file_contents
 from ..utils.git import require_git_repository, run_git_command
@@ -57,14 +66,36 @@ def command_reset_from_batch(
     require_git_repository()
     ensure_state_directory_exists()
     validate_batch_name(batch_name)
+    extra_action_parts = ()
+    if to_batch is not None:
+        extra_action_parts = ("--to", shlex.quote(to_batch))
+    scope_resolution = resolve_batch_source_action_scope(
+        FileReviewAction.RESET_FROM_BATCH,
+        command_name="reset",
+        batch_name=batch_name,
+        line_ids=line_ids,
+        file=file,
+        patterns=patterns,
+        extra_action_parts=extra_action_parts,
+    )
+    file = scope_resolution.file
 
     if not batch_exists(batch_name):
         exit_with_error(_("Batch '{name}' does not exist").format(name=batch_name))
+
+    metadata = read_batch_metadata(batch_name)
+    all_files = metadata.get("files", {})
 
     if to_batch is not None:
         validate_batch_name(to_batch)
         if to_batch == batch_name:
             exit_with_error(_("--to must name a different batch"))
+
+    effective_line_ids = (
+        _translate_reset_line_ids_to_selection_ids(batch_name, all_files, file, patterns, line_ids)
+        if line_ids is not None else
+        None
+    )
     operation_parts = ["reset", "--from", batch_name]
     if to_batch is not None:
         operation_parts.extend(["--to", to_batch])
@@ -74,13 +105,13 @@ def command_reset_from_batch(
         operation_parts.extend(["--file", file])
     with undo_checkpoint(" ".join(operation_parts)):
         if to_batch is not None:
-            _move_claims_between_batches(batch_name, to_batch, file, patterns, line_ids)
+            _move_claims_between_batches(batch_name, to_batch, file, patterns, effective_line_ids)
         elif file is not None:
-            _reset_file_claims_from_batch(batch_name, file, line_ids)
+            _reset_file_claims_from_batch(batch_name, file, effective_line_ids)
         elif patterns is not None:
-            _reset_pattern_claims_from_batch(batch_name, patterns, line_ids)
+            _reset_pattern_claims_from_batch(batch_name, patterns, effective_line_ids)
         elif line_ids is not None:
-            _reset_line_claims_from_batch(batch_name, line_ids)
+            _reset_line_claims_from_batch(batch_name, effective_line_ids)
         else:
             _reset_all_claims_from_batch(batch_name)
 
@@ -100,6 +131,64 @@ def command_reset_from_batch(
         print(_("✓ Reset file from batch '{name}'").format(name=batch_name), file=sys.stderr)
     else:
         print(_("✓ Reset all claims from batch '{name}'").format(name=batch_name), file=sys.stderr)
+
+
+def _translate_reset_line_ids_to_selection_ids(
+    batch_name: str,
+    all_files: dict[str, dict],
+    file: str | None,
+    patterns: list[str] | None,
+    line_id_specification: str,
+) -> str:
+    """Translate fresh file-review gutter IDs to batch selection IDs.
+
+    Reset is a metadata operation, so explicit reset line IDs must keep working
+    even when a batch change is not currently mergeable into the worktree. Only
+    translate through the mergeability-filtered gutter map when a fresh batch
+    file review is in scope; otherwise leave the batch display IDs untouched.
+    """
+    files = resolve_batch_file_scope(batch_name, all_files, file, patterns)
+    selected_ids = require_single_file_context_for_line_selection(
+        batch_name, files, line_id_specification, "reset"
+    )
+    if selected_ids is None:
+        return line_id_specification
+
+    file_path = list(files.keys())[0]
+    if files[file_path].get("file_type") == "binary":
+        exit_with_error(_("Cannot use --lines with binary files. Reset the whole file instead."))
+
+    review_groups = fresh_batch_review_selection_groups_for_action(
+        batch_name,
+        file_path,
+        FileReviewAction.RESET_FROM_BATCH,
+    )
+    if review_groups is None:
+        return line_id_specification
+    validate_review_scoped_line_selection(selected_ids, review_groups)
+
+    rendered = render_batch_file_display(batch_name, file_path)
+    if rendered is None:
+        exit_with_error(
+            _("No changes for file '{file}' in batch '{name}'.").format(
+                file=file_path,
+                name=batch_name,
+            )
+        )
+
+    display_id_map = rendered.review_gutter_to_selection_id or rendered.gutter_to_selection_id
+    selection_ids = set()
+    for gutter_id in selected_ids:
+        if gutter_id in display_id_map:
+            selection_ids.add(display_id_map[gutter_id])
+        else:
+            exit_with_error(
+                _("Line ID {id} is not available for this action. Select one of the numbered lines shown for this batch file.").format(
+                    id=gutter_id
+                )
+            )
+
+    return format_line_ids(sorted(selection_ids))
 
 
 def _ensure_destination_batch(source_batch: str, dest_batch: str, source_metadata: dict) -> None:

--- a/src/git_stage_batch/commands/show.py
+++ b/src/git_stage_batch/commands/show.py
@@ -14,15 +14,19 @@ from ..data.hunk_tracking import (
     SelectedChangeKind,
     apply_line_level_batch_filter_to_cached_hunk,
     cache_file_as_single_hunk,
+    clear_selected_change_state_files,
     get_selected_change_file_path,
+    mark_selected_change_cleared_by_file_list,
     render_file_as_single_hunk,
     write_selected_change_kind,
 )
+from ..data.file_review_state import ReviewSource
 from ..data.line_state import convert_line_changes_to_serializable_dict, load_line_changes_from_state
 from ..data.session import require_session_started
 from ..exceptions import exit_with_error
 from ..i18n import _
 from ..output import print_line_level_changes
+from ..output.file_review_list import make_file_review_list_entry, print_file_review_list
 from ..utils.file_io import read_text_file_contents, write_file_bytes, write_text_file_contents
 from ..utils.git import require_git_repository, stream_git_command
 from ..utils.paths import (
@@ -33,6 +37,28 @@ from ..utils.paths import (
     get_selected_hunk_hash_file_path,
     get_selected_hunk_patch_file_path,
 )
+
+
+def command_show_file_list(files: list[str]) -> None:
+    """Show a navigational file list for multiple live file reviews."""
+    require_git_repository()
+    require_session_started()
+    ensure_state_directory_exists()
+
+    entries = []
+    for file_path in files:
+        line_changes = render_file_as_single_hunk(file_path)
+        if line_changes is not None:
+            entries.append(make_file_review_list_entry(line_changes))
+
+    if not entries:
+        print(_("No reviewable changes in matched files."), file=sys.stderr)
+        return
+
+    clear_selected_change_state_files()
+    mark_selected_change_cleared_by_file_list(source=ReviewSource.FILE_VS_HEAD.value)
+
+    print_file_review_list(source_label=_("Changes: file vs HEAD"), entries=entries)
 
 
 def command_show(file: str | None = None, *, porcelain: bool = False, selectable: bool = True) -> None:

--- a/src/git_stage_batch/commands/show_from.py
+++ b/src/git_stage_batch/commands/show_from.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shlex
 import sys
 from typing import Optional
 
@@ -13,15 +14,21 @@ from ..batch.selection import (
 from ..batch.validation import batch_exists
 from ..data.hunk_tracking import (
     cache_batch_as_single_hunk,
-    cache_batch_files_generator,
-    cache_rendered_batch_file_display,
+    clear_selected_change_state_files,
+    mark_selected_change_cleared_by_file_list,
     render_batch_file_display,
 )
+from ..data.file_review_state import ReviewSource
 from ..output import print_line_level_changes
+from ..output.file_review_list import make_file_review_list_entry, print_file_review_list
 from ..exceptions import exit_with_error, BatchMetadataError
 from ..i18n import _
 from ..core.models import LineLevelChange
 from ..utils.git import require_git_repository
+
+
+def _batch_source_args(batch_name: str) -> str:
+    return f" --from {shlex.quote(batch_name)}"
 
 
 def command_show_from_batch(
@@ -109,22 +116,30 @@ def command_show_from_batch(
 
         return
 
-    # Show all files in batch
-    has_content = False
-    first_rendered = None
-    for rendered in cache_batch_files_generator(batch_name, metadata=metadata):
-        if not has_content:
-            has_content = True
-            first_rendered = rendered
-        else:
-            # Print blank line separator between files
-            print()
+    entries = []
+    for file_path in files:
+        rendered = render_batch_file_display(batch_name, file_path, metadata=metadata)
+        if rendered is not None:
+            entries.append(
+                make_file_review_list_entry(
+                    rendered.line_changes,
+                    gutter_to_selection_id=rendered.gutter_to_selection_id,
+                )
+            )
 
-        print_line_level_changes(rendered.line_changes, gutter_to_selection_id=rendered.gutter_to_selection_id)
-
-    # Cache first file for subsequent commands
-    if first_rendered is not None:
-        cache_rendered_batch_file_display(first_rendered.line_changes.path, first_rendered)
+    if entries:
+        # Multi-file batch output is navigational; it must not leave a hidden
+        # selected file that a later bare action could operate on.
+        if selectable:
+            clear_selected_change_state_files()
+            mark_selected_change_cleared_by_file_list(
+                source=ReviewSource.BATCH.value,
+                batch_name=batch_name,
+            )
+        print_file_review_list(
+            source_label=_("Changes: batch {name}").format(name=batch_name),
+            entries=entries,
+            command_source_args=_batch_source_args(batch_name),
+        )
     else:
-        # Empty batch
         print(_("Batch '{name}' is empty").format(name=batch_name), file=sys.stderr)

--- a/src/git_stage_batch/commands/skip.py
+++ b/src/git_stage_batch/commands/skip.py
@@ -14,7 +14,18 @@ from ..core.line_selection import (
     write_line_ids_file,
 )
 from ..core.models import BinaryFileChange
-from ..data.hunk_tracking import SelectedChangeKind, advance_to_and_show_next_change, advance_to_next_change, fetch_next_change, get_selected_change_file_path, load_selected_change, read_selected_change_kind, record_hunk_skipped, require_selected_hunk
+from ..data.hunk_tracking import (
+    SelectedChangeKind,
+    advance_to_and_show_next_change,
+    advance_to_next_change,
+    fetch_next_change,
+    get_selected_change_file_path,
+    load_selected_change,
+    read_selected_change_kind,
+    record_hunk_skipped,
+    refuse_bare_action_after_file_list,
+    require_selected_hunk,
+)
 from ..data.line_state import convert_line_changes_to_serializable_dict, load_line_changes_from_state
 from ..data.session import require_session_started
 from ..data.undo import undo_checkpoint
@@ -42,6 +53,7 @@ def command_skip(*, quiet: bool = False) -> None:
     require_session_started()
     ensure_state_directory_exists()
 
+    refuse_bare_action_after_file_list("skip")
     if read_selected_change_kind() == SelectedChangeKind.FILE:
         command_skip_file("")
         return
@@ -121,6 +133,8 @@ def command_skip_file(
     require_session_started()
     ensure_state_directory_exists()
 
+    if file == "":
+        refuse_bare_action_after_file_list("skip --file")
     # Determine target file
     if file == "":
         target_file = get_selected_change_file_path()

--- a/src/git_stage_batch/commands/skip.py
+++ b/src/git_stage_batch/commands/skip.py
@@ -31,7 +31,7 @@ from ..data.session import require_session_started
 from ..data.undo import undo_checkpoint
 from ..exceptions import NoMoreHunks
 from ..i18n import _, ngettext
-from ..output import print_line_level_changes
+from ..output import print_line_level_changes, print_remaining_line_changes_header
 from ..utils.file_io import append_lines_to_file, read_text_file_contents, write_text_file_contents
 from ..utils.git import require_git_repository, stream_git_command
 from ..utils.journal import log_journal
@@ -247,4 +247,5 @@ def command_skip_line(line_id_specification: str) -> None:
         )
 
     print(_("✓ Skipped line(s): {lines}").format(lines=line_id_specification), file=sys.stderr)
+    print_remaining_line_changes_header(filtered_line_changes.path)
     print_line_level_changes(filtered_line_changes)

--- a/src/git_stage_batch/core/actionable_changes.py
+++ b/src/git_stage_batch/core/actionable_changes.py
@@ -1,0 +1,106 @@
+"""Shared actionable selection derivation for file reviews and validation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Mapping
+
+from .models import LineEntry, LineLevelChange
+
+
+class ActionableSelectionReason(str, Enum):
+    """Why a file-review selection is treated as one actionable atom."""
+
+    SIMPLE = "simple"
+    REPLACEMENT = "replacement"
+    STRUCTURAL_RUN = "structural-run"
+
+
+@dataclass(frozen=True)
+class ActionableSelection:
+    """One atomic line selection that can be suggested as a complete change."""
+
+    display_ids: tuple[int, ...]
+    selection_ids: tuple[int, ...]
+    reason: ActionableSelectionReason
+    note: str | None = None
+    actions: tuple[str, ...] = ()
+
+
+def derive_actionable_selections(
+    line_changes: LineLevelChange,
+    *,
+    gutter_to_selection_id: Mapping[int, int] | None = None,
+) -> tuple[ActionableSelection, ...]:
+    """Derive conservative complete selection atoms from a rendered file diff.
+
+    The initial shared policy keeps each contiguous changed run inside a
+    displayed hunk together. Mixed deletion/addition runs are marked as
+    replacements so renderers can use "select together" wording.
+    """
+    selections: list[ActionableSelection] = []
+    changed_run: list[LineEntry] = []
+    selection_to_gutter = (
+        {
+            selection_id: gutter_id
+            for gutter_id, selection_id in gutter_to_selection_id.items()
+        }
+        if gutter_to_selection_id is not None else
+        None
+    )
+
+    def flush_changed_run() -> None:
+        nonlocal changed_run
+        if not changed_run:
+            return
+
+        selection_ids = tuple(
+            line.id
+            for line in changed_run
+            if line.id is not None
+        )
+        if not selection_ids:
+            changed_run = []
+            return
+
+        if selection_to_gutter is None:
+            display_ids = selection_ids
+        else:
+            if any(selection_id not in selection_to_gutter for selection_id in selection_ids):
+                changed_run = []
+                return
+            display_ids = tuple(
+                selection_to_gutter[selection_id]
+                for selection_id in selection_ids
+            )
+
+        if display_ids:
+            changed_kinds = {line.kind for line in changed_run}
+            reason: ActionableSelectionReason = (
+                ActionableSelectionReason.REPLACEMENT
+                if {"-", "+"}.issubset(changed_kinds)
+                else ActionableSelectionReason.SIMPLE
+            )
+            selections.append(
+                ActionableSelection(
+                    display_ids=display_ids,
+                    selection_ids=selection_ids,
+                    reason=reason,
+                    note=None,
+                )
+            )
+
+        changed_run = []
+
+    for line in line_changes.lines:
+        if line.kind in ("+", "-") and line.id is not None:
+            if selection_to_gutter is not None and line.id not in selection_to_gutter:
+                flush_changed_run()
+                continue
+            changed_run.append(line)
+            continue
+        flush_changed_run()
+
+    flush_changed_run()
+    return tuple(selections)

--- a/src/git_stage_batch/core/line_selection.py
+++ b/src/git_stage_batch/core/line_selection.py
@@ -7,8 +7,13 @@ from typing import Iterable
 from ..utils.file_io import read_text_file_contents, write_text_file_contents
 
 
-def parse_line_selection(selection: str) -> list[int]:
-    """Parse a line selection string into a list of line IDs.
+def parse_positive_selection(
+    selection: str,
+    *,
+    item_name: str = "Line ID",
+    reject_empty_items: bool = False,
+) -> list[int]:
+    """Parse a positive integer selection string into sorted unique IDs.
 
     Supports:
     - Individual IDs: "1,2,3" → [1, 2, 3]
@@ -16,10 +21,12 @@ def parse_line_selection(selection: str) -> list[int]:
     - Mixed: "1,3,5-7" → [1, 3, 5, 6, 7]
 
     Args:
-        selection: Comma-separated line IDs and/or ranges (e.g., "1,3,5-7")
+        selection: Comma-separated IDs and/or ranges (e.g., "1,3,5-7")
+        item_name: Name used in error messages.
+        reject_empty_items: If True, reject empty comma-separated items.
 
     Returns:
-        Sorted list of unique line IDs
+        Sorted list of unique IDs
 
     Raises:
         ValueError: If the selection string is invalid
@@ -27,12 +34,15 @@ def parse_line_selection(selection: str) -> list[int]:
     if not selection or not selection.strip():
         raise ValueError("Selection string cannot be empty")
 
-    line_ids = set()
+    selected_ids = set()
     parts = selection.split(",")
+    invalid_item_name = "line ID" if item_name == "Line ID" else item_name
 
     for part in parts:
         part = part.strip()
         if not part:
+            if reject_empty_items:
+                raise ValueError("Selection contains an empty item")
             continue
 
         # Check if this looks like a range (contains "-" that's not at the start)
@@ -51,25 +61,30 @@ def parse_line_selection(selection: str) -> list[int]:
                 raise ValueError(f"Invalid range: {part}") from e
 
             if start <= 0 or end <= 0:
-                raise ValueError(f"Line IDs must be positive: {part}")
+                raise ValueError(f"{item_name}s must be positive: {part}")
 
             if start > end:
                 raise ValueError(f"Range start must be <= end: {part}")
 
-            line_ids.update(range(start, end + 1))
+            selected_ids.update(range(start, end + 1))
         else:
             # Handle single ID (including negative numbers which we'll reject)
             try:
-                line_id = int(part)
+                selected_id = int(part)
             except ValueError as e:
-                raise ValueError(f"Invalid line ID: {part}") from e
+                raise ValueError(f"Invalid {invalid_item_name}: {part}") from e
 
-            if line_id <= 0:
-                raise ValueError(f"Line ID must be positive: {part}")
+            if selected_id <= 0:
+                raise ValueError(f"{item_name} must be positive: {part}")
 
-            line_ids.add(line_id)
+            selected_ids.add(selected_id)
 
-    return sorted(line_ids)
+    return sorted(selected_ids)
+
+
+def parse_line_selection(selection: str) -> list[int]:
+    """Parse a line selection string into a list of line IDs."""
+    return parse_positive_selection(selection, item_name="Line ID")
 
 
 def read_line_ids_file(path: Path) -> list[int]:

--- a/src/git_stage_batch/core/models.py
+++ b/src/git_stage_batch/core/models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Literal
 
 
@@ -95,6 +95,16 @@ class LineLevelChange:
         return len(str(max(changed_ids)))
 
 
+@dataclass(frozen=True)
+class ReviewActionGroup:
+    """One user-visible file-review selection and the actions it supports."""
+
+    display_ids: tuple[int, ...]
+    selection_ids: tuple[int, ...]
+    actions: tuple[str, ...]
+    reason: str = "simple"
+
+
 @dataclass
 class RenderedBatchDisplay:
     """Rendered batch display with gutter ID translation for selection.
@@ -110,7 +120,15 @@ class RenderedBatchDisplay:
         line_changes: What gets shown to the user (contains original selection IDs)
         gutter_to_selection_id: Map from filtered gutter number to selection ID (for ownership selection)
         selection_id_to_gutter: Reverse map from selection ID to filtered gutter number
+        actionable_selection_groups: Complete original selection-ID groups that may be acted on from review output
+        review_gutter_to_selection_id: Map from review gutter number to selection ID
+        review_selection_id_to_gutter: Reverse map for review gutter IDs
+        review_action_groups: Action-specific groups for page-aware review state
     """
     line_changes: LineLevelChange
     gutter_to_selection_id: dict[int, int]
     selection_id_to_gutter: dict[int, int]
+    actionable_selection_groups: tuple[tuple[int, ...], ...] = ()
+    review_gutter_to_selection_id: dict[int, int] = field(default_factory=dict)
+    review_selection_id_to_gutter: dict[int, int] = field(default_factory=dict)
+    review_action_groups: tuple[ReviewActionGroup, ...] = ()

--- a/src/git_stage_batch/data/file_review_state.py
+++ b/src/git_stage_batch/data/file_review_state.py
@@ -1,0 +1,1036 @@
+"""Persisted safety state for page-aware file reviews."""
+
+from __future__ import annotations
+
+import json
+import shlex
+from dataclasses import asdict, dataclass
+from enum import Enum
+from hashlib import sha256
+from typing import Any
+
+from ..core.actionable_changes import ActionableSelectionReason
+from ..core.line_selection import parse_line_selection
+from ..core.models import ReviewActionGroup
+from ..data.line_state import convert_line_changes_to_serializable_dict, load_line_changes_from_state
+from ..exceptions import CommandError
+from ..i18n import _
+from ..utils.file_io import read_file_bytes, read_text_file_contents, write_text_file_contents
+from ..utils.paths import (
+    get_index_snapshot_file_path,
+    get_last_file_review_state_file_path,
+    get_working_tree_snapshot_file_path,
+)
+from .hunk_tracking import SelectedChangeKind, get_selected_change_file_path, read_selected_change_kind
+
+
+class ReviewSource(str, Enum):
+    """Source of the selected file review."""
+
+    FILE_VS_HEAD = "file-vs-head"
+    UNSTAGED = "unstaged"
+    BATCH = "batch"
+
+
+class FileReviewAction(str, Enum):
+    """Commands that may act on a file-review selection."""
+
+    INCLUDE = "include"
+    SKIP = "skip"
+    DISCARD = "discard"
+    INCLUDE_TO_BATCH = "include-to-batch"
+    DISCARD_TO_BATCH = "discard-to-batch"
+    INCLUDE_FROM_BATCH = "include-from-batch"
+    DISCARD_FROM_BATCH = "discard-from-batch"
+    APPLY_FROM_BATCH = "apply-from-batch"
+    RESET_FROM_BATCH = "reset-from-batch"
+
+
+@dataclass(frozen=True)
+class FileReviewSelectionState:
+    """One complete actionable selection shown by a file review."""
+
+    display_ids: tuple[int, ...]
+    selection_ids: tuple[int, ...]
+    change_index: int
+    first_page: int
+    last_page: int
+    reason: ActionableSelectionReason
+    actions: tuple[FileReviewAction, ...]
+
+
+@dataclass(frozen=True)
+class FileReviewState:
+    """Persisted identity and safety state for the last file review."""
+
+    source: ReviewSource
+    batch_name: str | None
+    file_path: str
+    page_spec: str
+    shown_pages: tuple[int, ...]
+    page_count: int
+    entire_file_shown: bool
+    selections: tuple[FileReviewSelectionState, ...]
+    selected_change_kind: SelectedChangeKind
+    selected_file_fingerprint: str
+    diff_fingerprint: str
+
+
+@dataclass(frozen=True)
+class ImplicitLiveToBatchFileActionResult:
+    """Validated target for `--to --file` with no path."""
+
+    reviewed_file: str | None = None
+    review_state: FileReviewState | None = None
+    should_stop: bool = False
+
+
+@dataclass(frozen=True)
+class ActionScopeResolution:
+    """Resolved file-review scope for a command prologue."""
+
+    file: str | None
+    review_state: FileReviewState | None = None
+    should_stop: bool = False
+
+
+class ReviewScopedSelectionError(CommandError):
+    """Raised when a pathless line action is not valid for the current review."""
+
+
+def _coerce_review_source(source: ReviewSource | str) -> ReviewSource:
+    return source if isinstance(source, ReviewSource) else ReviewSource(source)
+
+
+def _coerce_review_action(action: FileReviewAction | str) -> FileReviewAction:
+    return action if isinstance(action, FileReviewAction) else FileReviewAction(action)
+
+
+def _json_hash(payload: Any) -> str:
+    data = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return sha256(data.encode("utf-8", errors="surrogateescape")).hexdigest()
+
+
+def fingerprint_selected_file_view(
+    *,
+    source: ReviewSource,
+    batch_name: str | None,
+    file_path: str,
+    selected_change_kind: SelectedChangeKind,
+    gutter_to_selection_id: dict[int, int] | None = None,
+    actionable_selection_groups: tuple[tuple[int, ...], ...] | None = None,
+    review_action_groups: tuple[ReviewActionGroup, ...] | None = None,
+    line_changes=None,
+) -> str:
+    """Fingerprint the selected file view and its current line ID space."""
+    if line_changes is None:
+        line_changes = load_line_changes_from_state()
+    snapshots = {}
+    for name, path in (
+        ("index", get_index_snapshot_file_path()),
+        ("working_tree", get_working_tree_snapshot_file_path()),
+    ):
+        snapshots[name] = sha256(read_file_bytes(path)).hexdigest() if path.exists() else None
+    return _json_hash(
+        {
+            "source": source,
+            "batch_name": batch_name,
+            "file_path": file_path,
+            "selected_change_kind": selected_change_kind.value,
+            "snapshots": snapshots,
+            "line_changes": (
+                convert_line_changes_to_serializable_dict(line_changes)
+                if line_changes is not None else None
+            ),
+            "gutter_to_selection_id": gutter_to_selection_id,
+            "actionable_selection_groups": actionable_selection_groups,
+            "review_action_groups": [
+                {
+                    "display_ids": group.display_ids,
+                    "selection_ids": group.selection_ids,
+                    "actions": group.actions,
+                    "reason": group.reason,
+                }
+                for group in (review_action_groups or ())
+            ],
+        }
+    )
+
+
+def compute_current_file_review_diff_fingerprint(file_path: str, line_changes=None) -> str:
+    """Fingerprint the cached selected file diff for freshness checks."""
+    if line_changes is None:
+        line_changes = load_line_changes_from_state()
+    return _json_hash(
+        {
+            "file_path": file_path,
+            "line_changes": (
+                convert_line_changes_to_serializable_dict(line_changes)
+                if line_changes is not None else None
+            ),
+        }
+    )
+
+
+def write_last_file_review_state(review_state: FileReviewState) -> None:
+    """Persist the last file review state."""
+    write_text_file_contents(
+        get_last_file_review_state_file_path(),
+        json.dumps(asdict(review_state), ensure_ascii=False, indent=0),
+    )
+
+
+def read_last_file_review_state() -> FileReviewState | None:
+    """Read the last file review state, if present and valid."""
+    path = get_last_file_review_state_file_path()
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(read_text_file_contents(path))
+        selections = tuple(
+            FileReviewSelectionState(
+                display_ids=tuple(selection["display_ids"]),
+                selection_ids=tuple(selection["selection_ids"]),
+                change_index=selection["change_index"],
+                first_page=selection["first_page"],
+                last_page=selection["last_page"],
+                reason=ActionableSelectionReason(selection["reason"]),
+                actions=tuple(FileReviewAction(action) for action in selection["actions"]),
+            )
+            for selection in data.get("selections", [])
+        )
+        return FileReviewState(
+            source=ReviewSource(data["source"]),
+            batch_name=data.get("batch_name"),
+            file_path=data["file_path"],
+            page_spec=data["page_spec"],
+            shown_pages=tuple(data["shown_pages"]),
+            page_count=data["page_count"],
+            entire_file_shown=data["entire_file_shown"],
+            selections=selections,
+            selected_change_kind=SelectedChangeKind(data["selected_change_kind"]),
+            selected_file_fingerprint=data["selected_file_fingerprint"],
+            diff_fingerprint=data["diff_fingerprint"],
+        )
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+        clear_last_file_review_state()
+        return None
+
+
+def clear_last_file_review_state() -> None:
+    """Remove the last file review state."""
+    get_last_file_review_state_file_path().unlink(missing_ok=True)
+
+
+def clear_last_file_review_state_if_file_matches(file_path: str) -> None:
+    """Remove the last file review state if it belongs to the given file."""
+    review_state = read_last_file_review_state()
+    if review_state is not None and review_state.file_path == file_path:
+        clear_last_file_review_state()
+
+
+def line_action_came_from_partial_review(review_state: FileReviewState | None) -> bool:
+    """Return whether a line action was validated by a partial file review."""
+    return review_state is not None and not review_state.entire_file_shown
+
+
+def finish_review_scoped_line_action(
+    review_state: FileReviewState | None,
+    *,
+    file_path: str | None = None,
+) -> None:
+    """Clear review state after a line action unless a partial review must guard follow-ups."""
+    if line_action_came_from_partial_review(review_state):
+        return
+    if file_path is None:
+        clear_last_file_review_state()
+    else:
+        clear_last_file_review_state_if_file_matches(file_path)
+
+
+def _batch_from_action_command(
+    command_name: str,
+    batch_name: str,
+    *,
+    file_scope: bool,
+    line_ids: str | None,
+    extra_action_parts: tuple[str, ...] = (),
+) -> str:
+    parts = [command_name, "--from", shlex.quote(batch_name)]
+    if file_scope:
+        parts.append("--file")
+    parts.extend(extra_action_parts)
+    if line_ids is not None:
+        parts.extend(["--line", line_ids])
+    return " ".join(parts)
+
+
+def resolve_batch_source_action_scope(
+    action: FileReviewAction | str,
+    *,
+    command_name: str,
+    batch_name: str,
+    line_ids: str | None,
+    file: str | None,
+    patterns: list[str] | None,
+    extra_action_parts: tuple[str, ...] = (),
+) -> ActionScopeResolution:
+    """Resolve pathless and implicit-file batch actions against the last batch review."""
+    from .hunk_tracking import (
+        refuse_bare_action_after_file_list,
+        refuse_bare_action_after_stale_batch_selection,
+    )
+
+    review_action = _coerce_review_action(action)
+    if patterns is not None:
+        return ActionScopeResolution(file=file)
+
+    if file is None:
+        action_command = _batch_from_action_command(
+            command_name,
+            batch_name,
+            file_scope=False,
+            line_ids=line_ids,
+            extra_action_parts=extra_action_parts,
+        )
+        refuse_bare_action_after_file_list(
+            action_command,
+            open_command=f"git-stage-batch show --from {shlex.quote(batch_name)} --file PATH",
+            source=ReviewSource.BATCH.value,
+            batch_name=batch_name,
+        )
+        refuse_bare_action_after_stale_batch_selection(action_command, batch_name=batch_name)
+
+        if line_ids is None:
+            reviewed_file = resolve_review_file_for_bare_whole_file_action(
+                review_action,
+                source=ReviewSource.BATCH,
+                batch_name=batch_name,
+            )
+            return ActionScopeResolution(file=reviewed_file if reviewed_file is not None else file)
+
+        review_state = validate_pathless_review_line_action(
+            review_action,
+            line_ids,
+            source=ReviewSource.BATCH,
+            batch_name=batch_name,
+        )
+        return ActionScopeResolution(
+            file=review_state.file_path if review_state is not None else file,
+            review_state=review_state,
+        )
+
+    if file == "":
+        action_command = _batch_from_action_command(
+            command_name,
+            batch_name,
+            file_scope=True,
+            line_ids=line_ids,
+            extra_action_parts=extra_action_parts,
+        )
+        refuse_bare_action_after_file_list(
+            action_command,
+            open_command=f"git-stage-batch show --from {shlex.quote(batch_name)} --file PATH",
+            source=ReviewSource.BATCH.value,
+            batch_name=batch_name,
+        )
+        refuse_bare_action_after_stale_batch_selection(action_command, batch_name=batch_name)
+
+        if line_ids is None:
+            reviewed_file = resolve_review_file_for_bare_whole_file_action(
+                review_action,
+                source=ReviewSource.BATCH,
+                batch_name=batch_name,
+            )
+            return ActionScopeResolution(file=reviewed_file if reviewed_file is not None else file)
+
+        review_state = validate_pathless_review_line_action(
+            review_action,
+            line_ids,
+            source=ReviewSource.BATCH,
+            batch_name=batch_name,
+        )
+        return ActionScopeResolution(
+            file=review_state.file_path if review_state is not None else file,
+            review_state=review_state,
+        )
+
+    return ActionScopeResolution(file=file)
+
+
+def selected_change_kind_matches_review_source(
+    selected_kind: SelectedChangeKind | None,
+    review_state: FileReviewState,
+) -> bool:
+    """Return whether the selected kind is compatible with the review source."""
+    if review_state.source in (ReviewSource.FILE_VS_HEAD, ReviewSource.UNSTAGED):
+        return selected_kind == SelectedChangeKind.FILE
+    if review_state.source == ReviewSource.BATCH:
+        return selected_kind in (SelectedChangeKind.BATCH_FILE, SelectedChangeKind.BATCH_BINARY)
+    return False
+
+
+def selected_change_matches_review_state(review_state: FileReviewState) -> bool:
+    """Return whether selected state still matches the persisted review state."""
+    selected_kind = read_selected_change_kind()
+    if not selected_change_kind_matches_review_source(selected_kind, review_state):
+        return False
+    if get_selected_change_file_path() != review_state.file_path:
+        return False
+    if selected_kind is None:
+        return False
+    gutter_to_selection_id = None
+    line_changes = None
+    if review_state.source == ReviewSource.BATCH and review_state.batch_name is not None:
+        from .hunk_tracking import render_batch_file_display
+
+        rendered = render_batch_file_display(review_state.batch_name, review_state.file_path)
+        if rendered is None:
+            return False
+        gutter_to_selection_id = (
+            rendered.review_gutter_to_selection_id
+            or rendered.gutter_to_selection_id
+        )
+        actionable_selection_groups = rendered.actionable_selection_groups
+        review_action_groups = rendered.review_action_groups or None
+        line_changes = rendered.line_changes
+    else:
+        from .hunk_tracking import snapshots_are_stale
+
+        if snapshots_are_stale(review_state.file_path):
+            return False
+        actionable_selection_groups = None
+        review_action_groups = None
+
+    current_selected_fingerprint = fingerprint_selected_file_view(
+        source=review_state.source,
+        batch_name=review_state.batch_name,
+        file_path=review_state.file_path,
+        selected_change_kind=selected_kind,
+        gutter_to_selection_id=gutter_to_selection_id,
+        actionable_selection_groups=actionable_selection_groups,
+        review_action_groups=review_action_groups,
+        line_changes=line_changes,
+    )
+    if current_selected_fingerprint != review_state.selected_file_fingerprint:
+        return False
+    return (
+        compute_current_file_review_diff_fingerprint(review_state.file_path, line_changes=line_changes)
+        == review_state.diff_fingerprint
+    )
+
+
+def selected_batch_review_matches_reset_state(review_state: FileReviewState) -> bool:
+    """Return whether a batch review still has stable reset IDs."""
+    selected_kind = read_selected_change_kind()
+    if review_state.source != ReviewSource.BATCH or review_state.batch_name is None:
+        return False
+    if not selected_change_kind_matches_review_source(selected_kind, review_state):
+        return False
+    if get_selected_change_file_path() != review_state.file_path:
+        return False
+
+    from .hunk_tracking import render_batch_file_display
+
+    rendered = render_batch_file_display(review_state.batch_name, review_state.file_path)
+    if rendered is None:
+        return False
+    if (
+        compute_current_file_review_diff_fingerprint(
+            review_state.file_path,
+            line_changes=rendered.line_changes,
+        )
+        != review_state.diff_fingerprint
+    ):
+        return False
+
+    current_reset_groups = [
+        (group.display_ids, group.selection_ids)
+        for group in rendered.review_action_groups
+        if FileReviewAction.RESET_FROM_BATCH.value in group.actions
+    ]
+    persisted_reset_groups = {
+        (selection.display_ids, selection.selection_ids)
+        for selection in review_state.selections
+        if FileReviewAction.RESET_FROM_BATCH in selection.actions
+    }
+
+    def can_cover(
+        remaining_pairs: frozenset[tuple[int, int]],
+    ) -> bool:
+        if not remaining_pairs:
+            return True
+        first_pair = min(remaining_pairs)
+        for display_ids, selection_ids in current_reset_groups:
+            group_pairs = frozenset(zip(display_ids, selection_ids))
+            if first_pair not in group_pairs:
+                continue
+            if not group_pairs.issubset(remaining_pairs):
+                continue
+            if can_cover(remaining_pairs - group_pairs):
+                return True
+        return False
+
+    return all(
+        can_cover(frozenset(zip(display_ids, selection_ids)))
+        for display_ids, selection_ids in persisted_reset_groups
+    )
+
+
+def _review_state_matches_action(
+    review_state: FileReviewState,
+    action: FileReviewAction | str,
+) -> bool:
+    """Return whether a review is fresh for a specific action."""
+    review_action = _coerce_review_action(action)
+    if (
+        review_state.source == ReviewSource.BATCH
+        and review_action == FileReviewAction.RESET_FROM_BATCH
+    ):
+        return selected_batch_review_matches_reset_state(review_state)
+    return selected_change_matches_review_state(review_state)
+
+
+def _format_pages(pages: set[int]) -> str:
+    from ..core.line_selection import format_line_ids
+
+    return format_line_ids(sorted(pages))
+
+
+def shown_complete_review_selection_groups(
+    review_state: FileReviewState,
+    action: FileReviewAction | str,
+) -> list[set[int]]:
+    """Return complete actionable display-ID groups from shown review pages."""
+    review_action = _coerce_review_action(action)
+    shown_pages = (
+        set(range(1, review_state.page_count + 1))
+        if review_state.entire_file_shown else
+        set(review_state.shown_pages)
+    )
+    return [
+        set(selection.display_ids)
+        for selection in review_state.selections
+        if review_action in selection.actions
+        and set(range(selection.first_page, selection.last_page + 1)).issubset(shown_pages)
+    ]
+
+
+def fresh_batch_review_selection_groups_for_action(
+    batch_name: str,
+    file_path: str,
+    action: FileReviewAction | str,
+) -> list[set[int]] | None:
+    """Return shown review groups for a fresh matching batch review, if one is active."""
+    review_state = read_last_file_review_state()
+    if review_state is None:
+        return None
+    if review_state.source != ReviewSource.BATCH:
+        return None
+    if review_state.batch_name != batch_name or review_state.file_path != file_path:
+        return None
+    review_action = _coerce_review_action(action)
+    try:
+        review_is_fresh = _review_state_matches_action(review_state, review_action)
+    except Exception:
+        review_is_fresh = False
+    if not review_is_fresh:
+        raise CommandError(
+            _(
+                "The file review for {file} no longer matches batch '{batch}'.\n"
+                "Line IDs may no longer match.\n\n"
+                "Run:\n"
+                "  git-stage-batch show --from {batch} --file {file}"
+            ).format(
+                batch=shlex.quote(batch_name),
+                file=shlex.quote(file_path),
+            )
+        )
+
+    return shown_complete_review_selection_groups(review_state, action)
+
+
+def fresh_batch_review_display_ids_for_action(
+    batch_name: str,
+    file_path: str,
+    action: FileReviewAction | str,
+) -> set[int] | None:
+    """Return shown display IDs for a fresh matching batch review, if one is active."""
+    groups = fresh_batch_review_selection_groups_for_action(batch_name, file_path, action)
+    if groups is None:
+        return None
+    return {display_id for group in groups for display_id in group}
+
+
+def _print_stale_or_mismatched_file_review_help(action: str, review_state: FileReviewState) -> None:
+    show_command = _show_command_for_review_state(review_state)
+    raise ReviewScopedSelectionError(
+        _(
+            "The file review for {file} no longer matches the selected file view.\n"
+            "Line IDs may no longer match.\n\n"
+            "Run:\n"
+            "  {command}"
+        ).format(file=review_state.file_path, command=show_command)
+    )
+
+
+def _quote(value: str) -> str:
+    return shlex.quote(value)
+
+
+def _show_command_for_review_state(review_state: FileReviewState, *, page: str | None = None) -> str:
+    command = "git-stage-batch show"
+    if review_state.source == ReviewSource.BATCH and review_state.batch_name is not None:
+        command += f" --from {_quote(review_state.batch_name)}"
+    command += f" --file {_quote(review_state.file_path)}"
+    if page is not None:
+        command += f" --page {page}"
+    return command
+
+
+def _line_action_command(
+    action: FileReviewAction | str,
+    review_state: FileReviewState,
+    *,
+    line_spec: str | None = None,
+    whole_file: bool = False,
+    pathless_line: bool = False,
+) -> str | None:
+    review_action = _coerce_review_action(action)
+    action_value = review_action.value
+    if review_action in (FileReviewAction.INCLUDE_TO_BATCH, FileReviewAction.DISCARD_TO_BATCH):
+        return None
+    if review_state.source == ReviewSource.BATCH:
+        if review_action in (FileReviewAction.INCLUDE, FileReviewAction.INCLUDE_FROM_BATCH):
+            action_value = FileReviewAction.INCLUDE.value
+        elif review_action in (FileReviewAction.DISCARD, FileReviewAction.DISCARD_FROM_BATCH):
+            action_value = FileReviewAction.DISCARD.value
+        elif review_action == FileReviewAction.APPLY_FROM_BATCH:
+            action_value = "apply"
+        elif review_action == FileReviewAction.RESET_FROM_BATCH:
+            action_value = "reset"
+        else:
+            return None
+        command = f"git-stage-batch {action_value} --from {_quote(review_state.batch_name or '')}"
+        file_args = f" --file {_quote(review_state.file_path)}"
+    else:
+        command = f"git-stage-batch {action_value}"
+        file_args = f" --file {_quote(review_state.file_path)}"
+
+    if line_spec is not None:
+        if pathless_line:
+            return f"{command} --line {line_spec}"
+        return f"{command}{file_args} --line {line_spec}"
+    if whole_file:
+        return f"{command}{file_args}"
+    return command
+
+
+def refuse_live_action_for_batch_selection(action: FileReviewAction | str) -> bool:
+    """Refuse bare live actions when the current selection came from a batch view."""
+    review_action = _coerce_review_action(action)
+    if read_selected_change_kind() not in (SelectedChangeKind.BATCH_FILE, SelectedChangeKind.BATCH_BINARY):
+        return False
+
+    review_state = read_last_file_review_state()
+    if review_state is not None:
+        if review_state.source != ReviewSource.BATCH:
+            _print_stale_or_mismatched_file_review_help(review_action.value, review_state)
+        if not selected_change_matches_review_state(review_state):
+            _print_stale_or_mismatched_file_review_help(review_action.value, review_state)
+
+        lines = [
+            _("The selected file view for {file} came from batch '{batch}', not the live working tree.").format(
+                file=review_state.file_path,
+                batch=review_state.batch_name,
+            )
+        ]
+        if not review_state.entire_file_shown:
+            lines.extend(
+                [
+                    "",
+                    _("To review all pages from the batch:"),
+                    f"  {_show_command_for_review_state(review_state, page='all')}",
+                ]
+            )
+
+        whole_file_command = _line_action_command(review_action, review_state, whole_file=True)
+        if whole_file_command is not None:
+            lines.extend(
+                [
+                    "",
+                    _("To act on the batch file:"),
+                    f"  {whole_file_command}",
+                ]
+            )
+        else:
+            lines.extend(
+                [
+                    "",
+                    _("Batch reviews do not support this action."),
+                    _("If you meant to act on live working-tree changes, open a live file review:"),
+                    f"  git-stage-batch show --file {_quote(review_state.file_path)}",
+                ]
+            )
+        raise CommandError("\n".join(lines))
+
+    file_path = get_selected_change_file_path() or _("the selected file")
+    raise CommandError(
+        _(
+            "The selected file view for {file} came from a batch, not the live working tree.\n"
+            "Show the batch file again and use `include --from` or `discard --from`,\n"
+            "or open a live file review with:\n"
+            "  git-stage-batch show --file {file}"
+        ).format(file=file_path)
+    )
+
+
+def refuse_ambiguous_bare_action_after_partial_file_review(action: FileReviewAction | str) -> bool:
+    """Refuse pathless whole-file actions after a partial file review."""
+    review_action = _coerce_review_action(action)
+    review_state = read_last_file_review_state()
+    if review_state is None:
+        return False
+
+    selected_kind = read_selected_change_kind()
+    if not selected_change_kind_matches_review_source(selected_kind, review_state):
+        if selected_kind in (SelectedChangeKind.FILE, SelectedChangeKind.BATCH_FILE, SelectedChangeKind.BATCH_BINARY):
+            _print_stale_or_mismatched_file_review_help(review_action.value, review_state)
+        clear_last_file_review_state()
+        return False
+
+    if not _review_state_matches_action(review_state, review_action):
+        _print_stale_or_mismatched_file_review_help(review_action.value, review_state)
+
+    if review_state.entire_file_shown:
+        return False
+
+    shown = set(review_state.shown_pages)
+    missing = set(range(1, review_state.page_count + 1)) - shown
+    complete_selections = [
+        selection
+        for selection in review_state.selections
+        if review_action in selection.actions
+        and set(range(selection.first_page, selection.last_page + 1)).issubset(shown)
+    ]
+    selection_specs = [
+        _format_pages(set(selection.display_ids))
+        for selection in complete_selections
+    ]
+
+    lines = [
+        _("Only pages {shown} of {count} of {file} were shown.").format(
+            shown=_format_pages(shown),
+            count=review_state.page_count,
+            file=review_state.file_path,
+        )
+    ]
+    if missing:
+        lines.append(_("Pages {pages} were not shown.").format(pages=_format_pages(missing)))
+    if selection_specs:
+        line_command = _line_action_command(
+            review_action, review_state, line_spec=",".join(selection_specs)
+        )
+        if line_command is not None:
+            lines.extend(
+                [
+                    "",
+                    _("To act on complete changes shown here:"),
+                    f"  {line_command}",
+                ]
+            )
+    lines.extend(
+        [
+            "",
+            _("To review all pages:"),
+            f"  {_show_command_for_review_state(review_state, page='all')}",
+        ]
+    )
+
+    whole_file_command = _line_action_command(review_action, review_state, whole_file=True)
+    if whole_file_command is not None:
+        lines.extend(
+            [
+                "",
+                _("To act on the whole file:"),
+                f"  {whole_file_command}",
+            ]
+        )
+    raise CommandError("\n".join(lines))
+
+
+def resolve_review_file_for_bare_whole_file_action(
+    action: FileReviewAction | str,
+    *,
+    source: ReviewSource | str,
+    batch_name: str | None = None,
+) -> str | None:
+    """Return the reviewed file for a fresh full-file review, or refuse if partial."""
+    review_state = read_last_file_review_state()
+    if review_state is None:
+        return None
+
+    if review_state.source != _coerce_review_source(source):
+        return None
+    if batch_name is not None and review_state.batch_name != batch_name:
+        return None
+
+    if refuse_ambiguous_bare_action_after_partial_file_review(action):
+        return None
+    if read_last_file_review_state() != review_state:
+        return None
+    return review_state.file_path
+
+
+def validate_implicit_live_to_batch_file_action(
+    action: FileReviewAction | str,
+    action_command: str,
+    line_id_specification: str | None,
+) -> ImplicitLiveToBatchFileActionResult:
+    """Validate `--to --file` with no path against the current live review.
+
+    Returns the reviewed file for a full live-file review when the caller should
+    use that explicit file path. The boolean is true when the caller should stop
+    after a live-action guard handled the request.
+    """
+    from .hunk_tracking import refuse_bare_action_after_file_list
+
+    review_action = _coerce_review_action(action)
+    refuse_bare_action_after_file_list(action_command)
+    if line_id_specification is None:
+        return ImplicitLiveToBatchFileActionResult(
+            reviewed_file=resolve_review_file_for_bare_whole_file_action(
+                review_action,
+                source=ReviewSource.FILE_VS_HEAD,
+            ),
+        )
+    if refuse_live_action_for_batch_selection(review_action):
+        return ImplicitLiveToBatchFileActionResult(should_stop=True)
+    review_state = validate_pathless_review_line_action(
+        review_action,
+        line_id_specification,
+        source=ReviewSource.FILE_VS_HEAD,
+    )
+    return ImplicitLiveToBatchFileActionResult(review_state=review_state)
+
+
+def _live_to_batch_action_command(
+    command_name: str,
+    batch_name: str,
+    *,
+    file_scope: bool,
+    line_ids: str | None,
+) -> str:
+    parts = [command_name, "--to", batch_name]
+    if file_scope:
+        parts.append("--file")
+    if line_ids is not None:
+        parts.extend(["--line", line_ids])
+    return " ".join(parts)
+
+
+def resolve_live_to_batch_action_scope(
+    action: FileReviewAction | str,
+    *,
+    command_name: str,
+    batch_name: str,
+    line_ids: str | None,
+    file: str | None,
+) -> ActionScopeResolution:
+    """Resolve pathless and implicit-file live-to-batch actions against live reviews."""
+    from .hunk_tracking import refuse_bare_action_after_file_list
+
+    review_action = _coerce_review_action(action)
+    if file is None:
+        action_command = _live_to_batch_action_command(
+            command_name,
+            batch_name,
+            file_scope=False,
+            line_ids=line_ids,
+        )
+        refuse_bare_action_after_file_list(action_command)
+        if refuse_live_action_for_batch_selection(review_action):
+            return ActionScopeResolution(file=file, should_stop=True)
+        if line_ids is None:
+            reviewed_file = resolve_review_file_for_bare_whole_file_action(
+                review_action,
+                source=ReviewSource.FILE_VS_HEAD,
+            )
+            return ActionScopeResolution(file=reviewed_file if reviewed_file is not None else file)
+        review_state = validate_pathless_review_line_action(
+            review_action,
+            line_ids,
+            source=ReviewSource.FILE_VS_HEAD,
+        )
+        return ActionScopeResolution(file=file, review_state=review_state)
+
+    if file == "":
+        action_command = _live_to_batch_action_command(
+            command_name,
+            batch_name,
+            file_scope=True,
+            line_ids=line_ids,
+        )
+        action_result = validate_implicit_live_to_batch_file_action(
+            review_action,
+            action_command,
+            line_ids,
+        )
+        if action_result.should_stop:
+            return ActionScopeResolution(file=file, should_stop=True)
+        return ActionScopeResolution(
+            file=action_result.reviewed_file if action_result.reviewed_file is not None else file,
+            review_state=action_result.review_state,
+        )
+
+    return ActionScopeResolution(file=file)
+
+
+def resolve_live_line_action_scope(
+    action: FileReviewAction | str,
+    *,
+    action_command: str,
+    line_id_specification: str,
+    file: str | None,
+    source: ReviewSource | str | None = None,
+    batch_name: str | None = None,
+    validate_pathless_before_live_guard: bool = False,
+) -> ActionScopeResolution:
+    """Validate a pathless or implicit-file live line action against review state."""
+    from .hunk_tracking import refuse_bare_action_after_file_list
+
+    if file not in (None, ""):
+        return ActionScopeResolution(file=file)
+
+    review_action = _coerce_review_action(action)
+    refuse_bare_action_after_file_list(action_command)
+
+    if file is None and validate_pathless_before_live_guard:
+        review_state = validate_pathless_review_line_action(
+            review_action,
+            line_id_specification,
+            source=source,
+            batch_name=batch_name,
+        )
+        if refuse_live_action_for_batch_selection(review_action):
+            return ActionScopeResolution(file=file, review_state=review_state, should_stop=True)
+        return ActionScopeResolution(file=file, review_state=review_state)
+
+    if refuse_live_action_for_batch_selection(review_action):
+        return ActionScopeResolution(file=file, should_stop=True)
+
+    review_state = validate_pathless_review_line_action(
+        review_action,
+        line_id_specification,
+        source=source,
+        batch_name=batch_name,
+    )
+    return ActionScopeResolution(file=file, review_state=review_state)
+
+
+def validate_review_scoped_line_selection(
+    requested_ids: set[int],
+    valid_selection_groups: list[set[int]],
+) -> None:
+    """Validate a union of complete actionable review selections."""
+    groups = [set(group) for group in valid_selection_groups if group]
+
+    def can_cover(remaining_ids: frozenset[int]) -> bool:
+        if not remaining_ids:
+            return True
+        first_id = min(remaining_ids)
+        for group in groups:
+            if first_id not in group:
+                continue
+            if not group.issubset(remaining_ids):
+                continue
+            if can_cover(frozenset(remaining_ids - group)):
+                return True
+        return False
+
+    if can_cover(frozenset(requested_ids)):
+        return
+
+    matched_ids = {
+        display_id
+        for group in groups
+        if group.issubset(requested_ids)
+        for display_id in group
+    }
+
+    outside_ids = requested_ids - matched_ids
+    for group in groups:
+        overlap = outside_ids & group
+        if overlap and overlap != group:
+            raise CommandError(
+                _("Line selection #{requested} only partly selects a reviewed change.\nUse: --line {required}").format(
+                    requested=_format_pages(requested_ids),
+                    required=_format_pages(group),
+                )
+            )
+
+    if outside_ids:
+        raise CommandError(
+            _("Line selection #{ids} is not valid from the current file review.").format(
+                ids=_format_pages(outside_ids),
+            )
+        )
+
+
+def validate_pathless_review_line_action(
+    action: FileReviewAction | str,
+    line_id_specification: str,
+    *,
+    source: ReviewSource | str | None = None,
+    batch_name: str | None = None,
+) -> FileReviewState | None:
+    """Validate pathless --line against the last file review."""
+    review_action = _coerce_review_action(action)
+    review_state = read_last_file_review_state()
+    if review_state is None:
+        return None
+    if source is not None and review_state.source != _coerce_review_source(source):
+        _print_stale_or_mismatched_file_review_help(review_action.value, review_state)
+    if batch_name is not None and review_state.batch_name != batch_name:
+        _print_stale_or_mismatched_file_review_help(review_action.value, review_state)
+    if not _review_state_matches_action(review_state, review_action):
+        _print_stale_or_mismatched_file_review_help(review_action.value, review_state)
+    if (
+        review_state.source == ReviewSource.BATCH
+        and review_action in (
+            FileReviewAction.INCLUDE,
+            FileReviewAction.SKIP,
+            FileReviewAction.DISCARD,
+            FileReviewAction.INCLUDE_TO_BATCH,
+            FileReviewAction.DISCARD_TO_BATCH,
+        )
+        and not any(review_action in selection.actions for selection in review_state.selections)
+    ):
+        lines = [
+            _("The selected file view for {file} came from batch '{batch}', not the live working tree.").format(
+                file=review_state.file_path,
+                batch=review_state.batch_name,
+            )
+        ]
+        line_command = _line_action_command(review_action, review_state, line_spec=line_id_specification)
+        if line_command is not None:
+            lines.extend(["", _("To act on the batch file:"), f"  {line_command}"])
+        else:
+            lines.extend(
+                [
+                    "",
+                    _("Batch reviews do not support this action."),
+                    _("If you meant to act on live working-tree changes, open a live file review:"),
+                    f"  git-stage-batch show --file {_quote(review_state.file_path)}",
+                ]
+            )
+        raise CommandError("\n".join(lines))
+
+    try:
+        requested_ids = set(parse_line_selection(line_id_specification))
+    except ValueError as error:
+        raise CommandError(str(error)) from error
+
+    valid_groups = shown_complete_review_selection_groups(review_state, review_action)
+    validate_review_scoped_line_selection(requested_ids, valid_groups)
+    return review_state

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -45,6 +45,7 @@ from ..utils.paths import (
     get_block_list_file_path,
     get_blocked_files_file_path,
     get_context_lines,
+    get_selected_change_clear_reason_file_path,
     get_selected_change_kind_file_path,
     get_selected_binary_file_json_path,
     get_selected_hunk_hash_file_path,
@@ -70,18 +71,220 @@ class SelectedChangeKind(str, Enum):
     BATCH_FILE = "batch-file"
 
 
+class SelectedChangeClearReason(str, Enum):
+    """Reasons selected change state was intentionally cleared."""
+
+    FILE_LIST = "file-list"
+    STALE_BATCH_SELECTION = "stale-batch-selection"
+
+
+def _selected_change_state_paths():
+    """Return files that make up the cached selected change state."""
+    return {
+        "patch": get_selected_hunk_patch_file_path(),
+        "hash": get_selected_hunk_hash_file_path(),
+        "clear_reason": get_selected_change_clear_reason_file_path(),
+        "kind": get_selected_change_kind_file_path(),
+        "line_state": get_line_changes_json_file_path(),
+        "binary": get_selected_binary_file_json_path(),
+        "index_snapshot": get_index_snapshot_file_path(),
+        "working_snapshot": get_working_tree_snapshot_file_path(),
+        "processed_include_ids": get_processed_include_ids_file_path(),
+        "processed_skip_ids": get_processed_skip_ids_file_path(),
+    }
+
+
+def snapshot_selected_change_state() -> dict[str, bytes | None]:
+    """Capture the current selected change cache."""
+    return {
+        name: (read_file_bytes(path) if path.exists() else None)
+        for name, path in _selected_change_state_paths().items()
+    }
+
+
+def restore_selected_change_state(snapshot: dict[str, bytes | None]) -> None:
+    """Restore a previously captured selected change cache."""
+    for name, path in _selected_change_state_paths().items():
+        data = snapshot.get(name)
+        if data is None:
+            path.unlink(missing_ok=True)
+        else:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(data)
+
+
 def clear_selected_change_state_files() -> None:
     """Clear all cached selected hunk state files."""
-    get_selected_hunk_patch_file_path().unlink(missing_ok=True)
-    get_selected_hunk_hash_file_path().unlink(missing_ok=True)
-    get_selected_change_kind_file_path().unlink(missing_ok=True)
-    get_line_changes_json_file_path().unlink(missing_ok=True)
-    get_selected_binary_file_json_path().unlink(missing_ok=True)
-    get_index_snapshot_file_path().unlink(missing_ok=True)
-    get_working_tree_snapshot_file_path().unlink(missing_ok=True)
-    get_processed_include_ids_file_path().unlink(missing_ok=True)
-    get_processed_skip_ids_file_path().unlink(missing_ok=True)
+    from .file_review_state import clear_last_file_review_state
+
+    for path in _selected_change_state_paths().values():
+        path.unlink(missing_ok=True)
+    clear_last_file_review_state()
     # processed_batch_ids is global state (union of all batches), not per-hunk state
+
+
+def mark_selected_change_cleared_by_file_list(
+    *,
+    source: str,
+    batch_name: str | None = None,
+) -> None:
+    """Record that a navigational file list intentionally cleared selection."""
+    _write_selected_change_clear_reason(
+        reason=SelectedChangeClearReason.FILE_LIST,
+        source=source,
+        batch_name=batch_name,
+    )
+
+
+def mark_selected_change_cleared_by_stale_batch_selection(
+    *,
+    batch_name: str,
+    file_path: str,
+) -> None:
+    """Record that a batch mutation invalidated the selected batch file."""
+    _write_selected_change_clear_reason(
+        reason=SelectedChangeClearReason.STALE_BATCH_SELECTION,
+        source="batch",
+        batch_name=batch_name,
+        file_path=file_path,
+    )
+
+
+def _write_selected_change_clear_reason(
+    *,
+    reason: SelectedChangeClearReason,
+    source: str,
+    batch_name: str | None = None,
+    file_path: str | None = None,
+) -> None:
+    """Write a structured selected-change clear marker."""
+    write_text_file_contents(
+        get_selected_change_clear_reason_file_path(),
+        json.dumps(
+            {
+                "reason": reason.value,
+                "source": source,
+                "batch_name": batch_name,
+                "file_path": file_path,
+            },
+            ensure_ascii=False,
+            indent=0,
+        ),
+    )
+
+
+def _read_selected_change_clear_reason() -> dict[str, str | None] | None:
+    """Return the structured clear marker, tolerating legacy plain-text state."""
+    raw_reason = read_text_file_contents(get_selected_change_clear_reason_file_path()).strip()
+    if not raw_reason:
+        return None
+    if raw_reason == SelectedChangeClearReason.FILE_LIST.value:
+        return {
+            "reason": SelectedChangeClearReason.FILE_LIST.value,
+            "source": None,
+            "batch_name": None,
+        }
+    try:
+        data = json.loads(raw_reason)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    reason = data.get("reason")
+    if reason not in {item.value for item in SelectedChangeClearReason}:
+        return None
+    return {
+        "reason": reason,
+        "source": data.get("source") if isinstance(data.get("source"), str) else None,
+        "batch_name": data.get("batch_name") if isinstance(data.get("batch_name"), str) else None,
+        "file_path": data.get("file_path") if isinstance(data.get("file_path"), str) else None,
+    }
+
+
+def selected_change_was_cleared_by_file_list(
+    *,
+    source: str | None = None,
+    batch_name: str | None = None,
+) -> bool:
+    """Return whether the current empty selection came from a file list."""
+    if read_selected_change_kind() is not None:
+        return False
+    marker = _read_selected_change_clear_reason()
+    if marker is None:
+        return False
+    if marker["reason"] != SelectedChangeClearReason.FILE_LIST.value:
+        return False
+    marker_source = marker["source"]
+    marker_batch_name = marker["batch_name"]
+    if source is not None and marker_source != source:
+        return False
+    if batch_name is not None and marker_batch_name != batch_name:
+        return False
+    return True
+
+
+def selected_change_was_cleared_by_stale_batch_selection(
+    *,
+    batch_name: str | None = None,
+) -> bool:
+    """Return whether the current empty selection is a stale batch selection."""
+    if read_selected_change_kind() is not None:
+        return False
+    marker = _read_selected_change_clear_reason()
+    if marker is None:
+        return False
+    if marker["reason"] != SelectedChangeClearReason.STALE_BATCH_SELECTION.value:
+        return False
+    if batch_name is not None and marker["batch_name"] != batch_name:
+        return False
+    return True
+
+
+def refuse_bare_action_after_file_list(
+    action_command: str,
+    *,
+    open_command: str = "git-stage-batch show --file PATH",
+    source: str | None = None,
+    batch_name: str | None = None,
+) -> None:
+    """Refuse a bare action after a navigational file list cleared selection."""
+    if not selected_change_was_cleared_by_file_list(source=source, batch_name=batch_name):
+        return
+    raise CommandError(
+        _(
+            "No selected change.\n"
+            "The last command only showed files; it did not choose one for follow-up actions.\n\n"
+            "Run:\n"
+            "  git-stage-batch show\n"
+            "or choose a file with:\n"
+            "  {open_command}\n"
+            "before running:\n"
+            "  git-stage-batch {action}"
+        ).format(open_command=open_command, action=action_command)
+    )
+
+
+def refuse_bare_action_after_stale_batch_selection(
+    action_command: str,
+    *,
+    batch_name: str,
+) -> None:
+    """Refuse a bare batch action after the selected batch file went stale."""
+    if not selected_change_was_cleared_by_stale_batch_selection(batch_name=batch_name):
+        return
+
+    marker = _read_selected_change_clear_reason() or {}
+    file_path = marker.get("file_path") or "the previously selected file"
+    raise CommandError(
+        _(
+            "No selected change.\n"
+            "The selected batch file '{file}' was changed or removed from batch '{batch}'.\n\n"
+            "Open a current batch file with:\n"
+            "  git-stage-batch show --from {batch} --file PATH\n"
+            "before running:\n"
+            "  git-stage-batch {action}"
+        ).format(file=file_path, batch=batch_name, action=action_command)
+    )
 
 
 def load_selected_binary_file() -> Optional[BinaryFileChange]:
@@ -107,6 +310,7 @@ def load_selected_binary_file() -> Optional[BinaryFileChange]:
 
 def write_selected_change_kind(kind: SelectedChangeKind) -> None:
     """Persist the kind of selected change cached in session state."""
+    get_selected_change_clear_reason_file_path().unlink(missing_ok=True)
     write_text_file_contents(get_selected_change_kind_file_path(), kind)
 
 

--- a/src/git_stage_batch/output/__init__.py
+++ b/src/git_stage_batch/output/__init__.py
@@ -1,7 +1,7 @@
 """Display utilities."""
 
 from .colors import Colors, format_hotkey, format_option_list
-from .hunk import print_line_level_changes
+from .hunk import print_line_level_changes, print_remaining_line_changes_header
 from .patch import print_binary_file_change, print_colored_patch
 
 __all__ = [
@@ -9,6 +9,7 @@ __all__ = [
     "format_hotkey",
     "format_option_list",
     "print_line_level_changes",
+    "print_remaining_line_changes_header",
     "print_binary_file_change",
     "print_colored_patch",
 ]

--- a/src/git_stage_batch/output/file_review.py
+++ b/src/git_stage_batch/output/file_review.py
@@ -1,0 +1,1181 @@
+"""Page-aware file review rendering."""
+
+from __future__ import annotations
+
+import os
+import shlex
+import shutil
+import sys
+from dataclasses import dataclass
+
+from ..core.actionable_changes import (
+    ActionableSelection,
+    ActionableSelectionReason,
+    derive_actionable_selections,
+)
+from ..core.line_selection import format_line_ids, parse_positive_selection
+from ..core.models import HunkHeader, LineEntry, LineLevelChange, ReviewActionGroup
+from ..data.file_review_state import (
+    FileReviewAction,
+    FileReviewState,
+    FileReviewSelectionState,
+    ReviewSource,
+    compute_current_file_review_diff_fingerprint,
+    fingerprint_selected_file_view,
+    _line_action_command,
+)
+from ..data.hunk_tracking import SelectedChangeKind
+from ..exceptions import CommandError
+from ..i18n import _
+
+DEFAULT_NON_TTY_REVIEW_LINES = 80
+DEFAULT_REVIEW_WIDTH = 80
+REVIEW_HEADER_LINES = 4
+REVIEW_FOOTER_LINES = 12
+MINIMUM_BODY_LINES = 8
+
+
+def _quote(value: str) -> str:
+    return shlex.quote(value)
+
+
+@dataclass(frozen=True)
+class ReviewChange:
+    """A complete actionable change group in a file review."""
+
+    index: int
+    total: int
+    path: str
+    hunk_header: HunkHeader
+    old_start: int | None
+    old_end: int | None
+    new_start: int | None
+    new_end: int | None
+    rows: tuple[LineEntry, ...]
+    display_ids: tuple[int, ...]
+    selection_ids: tuple[int, ...]
+    select_as: str | None
+    reason: ActionableSelectionReason
+    is_oversized: bool
+    note: str | None
+    actions: tuple[str, ...] = ()
+    first_page: int = 1
+    last_page: int = 1
+
+
+@dataclass(frozen=True)
+class ReviewChangeFragment:
+    """A rendered fragment of a review change on one page."""
+
+    change: ReviewChange
+    rows: tuple[LineEntry, ...]
+    is_first_fragment: bool
+    is_last_fragment: bool
+
+
+@dataclass(frozen=True)
+class FileReviewPage:
+    """One semantic review page."""
+
+    page: int
+    changes: tuple[ReviewChangeFragment, ...]
+
+
+@dataclass(frozen=True)
+class FileReviewModel:
+    """A paginated file review model."""
+
+    line_changes: LineLevelChange
+    changes: tuple[ReviewChange, ...]
+    pages: tuple[FileReviewPage, ...]
+    display_id_by_selection_id: dict[int, int] | None = None
+    review_action_groups: tuple[ReviewActionGroup, ...] = ()
+
+
+@dataclass(frozen=True)
+class FileReviewView:
+    """Selected pages from a file review model."""
+
+    source: ReviewSource
+    path: str
+    page_spec: str
+    shown_pages: tuple[int, ...]
+    page_count: int
+    pages: tuple[FileReviewPage, ...]
+    complete_changes: tuple[ReviewChange, ...]
+    partial_changes: tuple[ReviewChange, ...]
+    entire_file_shown: bool
+
+
+def parse_page_selection(page_spec: str, page_count: int, file_path: str) -> tuple[int, ...]:
+    """Parse and validate a page selection after page count is known."""
+    normalized_spec = page_spec.strip().lower()
+    if normalized_spec == "all":
+        return tuple(range(1, page_count + 1))
+
+    tokens = [token.strip() for token in normalized_spec.split(",")]
+    if any(token == "" for token in tokens):
+        raise CommandError(_("Page selection contains an empty item."))
+    if any(token == "all" for token in tokens):
+        raise CommandError(_("`all` cannot be combined with other page selections."))
+
+    try:
+        pages = parse_positive_selection(
+            normalized_spec,
+            item_name=_("Page"),
+            reject_empty_items=True,
+        )
+    except ValueError as error:
+        raise CommandError(
+            _("Invalid page selection '{spec}': {error}").format(
+                spec=page_spec,
+                error=error,
+            )
+        ) from error
+
+    if not pages:
+        raise CommandError(_("Page selection cannot be empty."))
+    highest_page = max(pages)
+    if highest_page > page_count:
+        raise CommandError(
+            _("Page {page} is outside the file review for {file}.\n"
+              "Available pages: 1-{page_count}.").format(
+                page=highest_page,
+                file=file_path,
+                page_count=page_count,
+            )
+        )
+    return tuple(sorted(set(pages)))
+
+
+def normalize_page_spec(shown_pages: tuple[int, ...], page_count: int) -> str:
+    """Return a compact persisted page specification."""
+    if set(shown_pages) == set(range(1, page_count + 1)):
+        return "all"
+    return format_line_ids(list(shown_pages))
+
+
+def _partly_selects_ownership_group(
+    selection: ActionableSelection,
+    ownership_group_sets: list[set[int]],
+) -> bool:
+    """Return whether a review selection splits a complete batch ownership group."""
+    selected_ids = set(selection.selection_ids)
+    return any(
+        selected_ids & ownership_group
+        and not ownership_group.issubset(selected_ids)
+        for ownership_group in ownership_group_sets
+    )
+
+
+def _coerce_actionable_reason(reason: str) -> ActionableSelectionReason:
+    try:
+        return ActionableSelectionReason(reason)
+    except ValueError:
+        return ActionableSelectionReason.SIMPLE
+
+
+def _reason_for_selection_ids(
+    line_changes: LineLevelChange,
+    selection_ids: tuple[int, ...],
+) -> ActionableSelectionReason:
+    selected_id_set = set(selection_ids)
+    changed_kinds = {
+        line.kind
+        for line in line_changes.lines
+        if line.id in selected_id_set
+        and line.kind in ("+", "-")
+    }
+    return (
+        ActionableSelectionReason.REPLACEMENT
+        if {"-", "+"}.issubset(changed_kinds)
+        else ActionableSelectionReason.SIMPLE
+    )
+
+
+def _actionable_selections_from_selection_groups(
+    line_changes: LineLevelChange,
+    selection_groups: tuple[tuple[int, ...], ...],
+    display_id_by_selection_id: dict[int, int] | None,
+) -> tuple[ActionableSelection, ...]:
+    """Create review selections directly from complete ownership groups."""
+    selections: list[ActionableSelection] = []
+    for group in selection_groups:
+        selection_ids = tuple(selection_id for selection_id in group if selection_id is not None)
+        if not selection_ids:
+            continue
+        if display_id_by_selection_id is None:
+            display_ids = selection_ids
+        else:
+            if any(selection_id not in display_id_by_selection_id for selection_id in selection_ids):
+                continue
+            display_ids = tuple(
+                display_id_by_selection_id[selection_id]
+                for selection_id in selection_ids
+            )
+        selections.append(
+            ActionableSelection(
+                display_ids=display_ids,
+                selection_ids=selection_ids,
+                reason=_reason_for_selection_ids(line_changes, selection_ids),
+            )
+        )
+    return tuple(selections)
+
+
+def _display_actionable_selections_from_review_action_groups(
+    line_changes: LineLevelChange,
+    review_action_groups: tuple[ReviewActionGroup, ...],
+    gutter_to_selection_id: dict[int, int] | None,
+) -> tuple[ActionableSelection, ...]:
+    """Derive user-facing batch review changes without splitting reset atoms."""
+    action_group_by_selection_id = {
+        selection_id: group
+        for group in review_action_groups
+        for selection_id in group.selection_ids
+    }
+    atomic_group_sets = [
+        set(group.selection_ids)
+        for group in review_action_groups
+        if group.reason in (
+            ActionableSelectionReason.REPLACEMENT.value,
+            ActionableSelectionReason.STRUCTURAL_RUN.value,
+        )
+    ]
+    selections = []
+    for selection in derive_actionable_selections(
+        line_changes,
+        gutter_to_selection_id=gutter_to_selection_id,
+    ):
+        chunk_display_ids: list[int] = []
+        chunk_selection_ids: list[int] = []
+        chunk_actions: tuple[str, ...] | None = None
+
+        def flush_chunk() -> None:
+            nonlocal chunk_display_ids, chunk_selection_ids, chunk_actions
+            if not chunk_display_ids or chunk_actions is None:
+                chunk_display_ids = []
+                chunk_selection_ids = []
+                chunk_actions = None
+                return
+            chunk = ActionableSelection(
+                display_ids=tuple(chunk_display_ids),
+                selection_ids=tuple(chunk_selection_ids),
+                reason=_reason_for_selection_ids(
+                    line_changes,
+                    tuple(chunk_selection_ids),
+                ),
+                actions=chunk_actions,
+            )
+            if not _partly_selects_ownership_group(chunk, atomic_group_sets):
+                selections.append(chunk)
+            chunk_display_ids = []
+            chunk_selection_ids = []
+            chunk_actions = None
+
+        for display_id, selection_id in zip(selection.display_ids, selection.selection_ids):
+            action_group = action_group_by_selection_id.get(selection_id)
+            if action_group is None:
+                flush_chunk()
+                continue
+            actions = action_group.actions
+            if chunk_actions is not None and actions != chunk_actions:
+                flush_chunk()
+            chunk_display_ids.append(display_id)
+            chunk_selection_ids.append(selection_id)
+            chunk_actions = actions
+        flush_chunk()
+    return tuple(selections)
+
+
+def build_file_review_model(
+    line_changes: LineLevelChange,
+    *,
+    gutter_to_selection_id: dict[int, int] | None = None,
+    actionable_selection_groups: tuple[tuple[int, ...], ...] | None = None,
+    review_action_groups: tuple[ReviewActionGroup, ...] | None = None,
+) -> FileReviewModel:
+    """Build a conservative change-first page model from a file-scoped hunk."""
+    changes: list[ReviewChange] = []
+    current_rows: list[LineEntry] = []
+    display_id_by_selection_id = (
+        {
+            selection_id: gutter_id
+            for gutter_id, selection_id in gutter_to_selection_id.items()
+        }
+        if gutter_to_selection_id is not None else None
+    )
+    if review_action_groups is not None:
+        actionable_selections = _display_actionable_selections_from_review_action_groups(
+            line_changes,
+            review_action_groups,
+            gutter_to_selection_id,
+        )
+    elif actionable_selection_groups is not None:
+        actionable_selections = _actionable_selections_from_selection_groups(
+            line_changes,
+            actionable_selection_groups,
+            display_id_by_selection_id,
+        )
+        ownership_group_sets = [
+            set(group)
+            for group in actionable_selection_groups
+            if group
+        ]
+        actionable_selections = tuple(
+            selection
+            for selection in actionable_selections
+            if not _partly_selects_ownership_group(selection, ownership_group_sets)
+        )
+    else:
+        actionable_selections = derive_actionable_selections(
+            line_changes,
+            gutter_to_selection_id=gutter_to_selection_id,
+        )
+    actionable_by_selection = {
+        selection.selection_ids: selection
+        for selection in actionable_selections
+    }
+
+    def append_change(rows: list[LineEntry], actionable: ActionableSelection | None) -> None:
+        old_line_numbers = [
+            line.old_line_number
+            for line in rows
+            if line.kind != "+" and line.old_line_number is not None
+        ]
+        new_line_numbers = [
+            line.new_line_number
+            for line in rows
+            if line.kind != "-" and line.new_line_number is not None
+        ]
+        changed_kinds = {line.kind for line in rows if line.kind in ("+", "-")}
+        reason = (
+            ActionableSelectionReason.REPLACEMENT
+            if {"-", "+"}.issubset(changed_kinds)
+            else ActionableSelectionReason.SIMPLE
+        )
+        display_ids = actionable.display_ids if actionable is not None else tuple()
+        selection_ids = (
+            actionable.selection_ids
+            if actionable is not None else
+            tuple(line.id for line in rows if line.kind in ("+", "-") and line.id is not None)
+        )
+        selection_text = format_line_ids(list(display_ids)) if display_ids else None
+        changes.append(
+            ReviewChange(
+                index=len(changes) + 1,
+                total=0,
+                path=line_changes.path,
+                hunk_header=line_changes.header,
+                old_start=min(old_line_numbers) if old_line_numbers else None,
+                old_end=max(old_line_numbers) if old_line_numbers else None,
+                new_start=min(new_line_numbers) if new_line_numbers else None,
+                new_end=max(new_line_numbers) if new_line_numbers else None,
+                rows=tuple(rows),
+                display_ids=display_ids,
+                selection_ids=selection_ids,
+                select_as=selection_text,
+                reason=actionable.reason if actionable is not None else reason,
+                is_oversized=False,
+                note=actionable.note if actionable is not None else _("not currently selectable"),
+                actions=actionable.actions if actionable is not None else tuple(),
+            )
+        )
+
+    def flush_segment() -> None:
+        nonlocal current_rows
+        pending_rows: list[LineEntry] = []
+        active_rows: list[LineEntry] = []
+        active_actionable: ActionableSelection | None = None
+        has_active_change = False
+        changed_run: list[LineEntry] = []
+        changed_run_displayable: bool | None = None
+        actionable_group_by_selection_id = {
+            selection_id: selection.selection_ids
+            for selection in actionable_selections
+            for selection_id in selection.selection_ids
+        }
+
+        def flush_active_change() -> None:
+            nonlocal active_rows, active_actionable, has_active_change
+            if has_active_change and active_rows:
+                append_change(active_rows, active_actionable)
+            active_rows = []
+            active_actionable = None
+            has_active_change = False
+
+        def activate_changed_run(*, trailing_rows: list[LineEntry] | None = None) -> None:
+            nonlocal pending_rows, changed_run, active_rows, active_actionable, has_active_change, changed_run_displayable
+            def actionable_for_chunk(
+                chunk_rows: list[LineEntry],
+                group: tuple[int, ...] | None,
+            ) -> ActionableSelection | None:
+                if group is None:
+                    return None
+                chunk_selection_ids = tuple(
+                    line.id
+                    for line in chunk_rows
+                    if line.id is not None
+                )
+                if chunk_selection_ids != group:
+                    return None
+                return actionable_by_selection.get(group)
+
+            chunks: list[tuple[list[LineEntry], ActionableSelection | None]] = []
+            current_chunk: list[LineEntry] = []
+            current_group: tuple[int, ...] | None = None
+            for line in changed_run:
+                group = (
+                    actionable_group_by_selection_id.get(line.id)
+                    if changed_run_displayable else
+                    None
+                )
+                if current_chunk and group != current_group:
+                    chunks.append(
+                        (
+                            current_chunk,
+                            actionable_for_chunk(current_chunk, current_group),
+                        )
+                    )
+                    current_chunk = []
+                current_chunk.append(line)
+                current_group = group
+
+            if current_chunk:
+                chunks.append(
+                    (
+                        current_chunk,
+                        actionable_for_chunk(current_chunk, current_group),
+                    )
+                )
+
+            for index, (chunk_rows, actionable) in enumerate(chunks):
+                flush_active_change()
+                active_rows = (pending_rows if index == 0 else []) + chunk_rows
+                if trailing_rows is not None and index == len(chunks) - 1:
+                    active_rows.extend(trailing_rows)
+                active_actionable = actionable
+                has_active_change = True
+            pending_rows = []
+            changed_run = []
+            changed_run_displayable = None
+
+        def changed_row_displayable(row: LineEntry) -> bool | None:
+            if row.kind not in ("+", "-") or row.id is None:
+                return None
+            if display_id_by_selection_id is None:
+                return True
+            return row.id in display_id_by_selection_id
+
+        for row in current_rows:
+            row_displayable = changed_row_displayable(row)
+            if row_displayable is not None:
+                if changed_run and changed_run_displayable != row_displayable:
+                    activate_changed_run()
+                changed_run.append(row)
+                changed_run_displayable = row_displayable
+                continue
+            if changed_run:
+                activate_changed_run(trailing_rows=[row])
+                continue
+            if has_active_change:
+                active_rows.append(row)
+            else:
+                pending_rows.append(row)
+
+        if changed_run:
+            activate_changed_run()
+        flush_active_change()
+        current_rows = []
+
+    for line in line_changes.lines:
+        is_gap = (
+            line.id is None
+            and line.kind == " "
+            and line.old_line_number is None
+            and line.new_line_number is None
+            and line.source_line is None
+        )
+        if is_gap:
+            flush_segment()
+            current_rows.append(line)
+            continue
+        current_rows.append(line)
+    flush_segment()
+
+    total = len(changes)
+    changes = [
+        ReviewChange(
+            index=change.index,
+            total=total,
+            path=change.path,
+            hunk_header=change.hunk_header,
+            old_start=change.old_start,
+            old_end=change.old_end,
+            new_start=change.new_start,
+            new_end=change.new_end,
+            rows=change.rows,
+            display_ids=change.display_ids,
+            selection_ids=change.selection_ids,
+            select_as=change.select_as,
+            reason=change.reason,
+            is_oversized=change.is_oversized,
+            note=change.note,
+            actions=change.actions,
+        )
+        for change in changes
+    ]
+
+    body_budget = _body_budget()
+    pages: list[list[ReviewChange]] = []
+    current_page: list[ReviewChange] = []
+    current_height = 0
+    for change in changes:
+        change_height = len(change.rows) + 2
+        if current_page and current_height + change_height > body_budget:
+            pages.append(current_page)
+            current_page = []
+            current_height = 0
+        current_page.append(change)
+        current_height += change_height
+    if current_page:
+        pages.append(current_page)
+    if not pages:
+        pages = [[]]
+
+    paged_changes: list[ReviewChange] = []
+    for page_number, page_changes in enumerate(pages, start=1):
+        for change in page_changes:
+            paged_changes.append(
+                ReviewChange(
+                    index=change.index,
+                    total=change.total,
+                    path=change.path,
+                    hunk_header=change.hunk_header,
+                    old_start=change.old_start,
+                    old_end=change.old_end,
+                    new_start=change.new_start,
+                    new_end=change.new_end,
+                    rows=change.rows,
+                    display_ids=change.display_ids,
+                    selection_ids=change.selection_ids,
+                    select_as=change.select_as,
+                    reason=change.reason,
+                    is_oversized=(len(change.rows) + 2) > body_budget,
+                    note=change.note,
+                    actions=change.actions,
+                    first_page=page_number,
+                    last_page=page_number,
+                )
+            )
+    by_index = {change.index: change for change in paged_changes}
+    final_pages = tuple(
+        FileReviewPage(
+            page=page_number,
+            changes=tuple(
+                ReviewChangeFragment(
+                    change=by_index[change.index],
+                    rows=by_index[change.index].rows,
+                    is_first_fragment=True,
+                    is_last_fragment=True,
+                )
+                for change in page_changes
+            ),
+        )
+        for page_number, page_changes in enumerate(pages, start=1)
+    )
+    return FileReviewModel(
+        line_changes=line_changes,
+        changes=tuple(paged_changes),
+        pages=final_pages,
+        display_id_by_selection_id=display_id_by_selection_id,
+        review_action_groups=review_action_groups or (),
+    )
+
+
+def _body_budget() -> int:
+    size = _review_terminal_size()
+    estimated_footer_lines = _estimate_file_review_footer_height()
+    return max(MINIMUM_BODY_LINES, size.lines - REVIEW_HEADER_LINES - estimated_footer_lines)
+
+
+def _review_terminal_size():
+    if not sys.stdout.isatty():
+        return os.terminal_size((DEFAULT_REVIEW_WIDTH, DEFAULT_NON_TTY_REVIEW_LINES))
+    return shutil.get_terminal_size(fallback=(DEFAULT_REVIEW_WIDTH, DEFAULT_NON_TTY_REVIEW_LINES))
+
+
+def _estimate_file_review_footer_height(complete_change_count: int = 3) -> int:
+    base_lines = 9
+    if complete_change_count == 0:
+        return base_lines
+    individual_lines = min(complete_change_count, 5) + 2
+    return min(18, base_lines + individual_lines)
+
+
+def resolve_default_review_pages(
+    model: FileReviewModel,
+    *,
+    requested_page_spec: str | None,
+    previous_selection: LineLevelChange | None = None,
+) -> tuple[int, ...]:
+    """Resolve explicit pages, selected-hunk anchor, or default page 1."""
+    page_count = len(model.pages)
+    if requested_page_spec is not None:
+        return parse_page_selection(requested_page_spec, page_count, model.line_changes.path)
+    if page_count <= 1:
+        return (1,)
+    if previous_selection is not None and previous_selection.path == model.line_changes.path:
+        for change in model.changes:
+            if _change_overlaps_line_change(change, previous_selection):
+                return (change.first_page,)
+    return (1,)
+
+
+def _change_overlaps_line_change(change: ReviewChange, line_changes: LineLevelChange) -> bool:
+    old_numbers = [
+        line.old_line_number
+        for line in line_changes.lines
+        if line.kind != "+" and line.old_line_number is not None
+    ]
+    new_numbers = [
+        line.new_line_number
+        for line in line_changes.lines
+        if line.kind != "-" and line.new_line_number is not None
+    ]
+    return (
+        _ranges_overlap(change.old_start, change.old_end, min(old_numbers, default=None), max(old_numbers, default=None))
+        or _ranges_overlap(change.new_start, change.new_end, min(new_numbers, default=None), max(new_numbers, default=None))
+    )
+
+
+def _ranges_overlap(
+    left_start: int | None,
+    left_end: int | None,
+    right_start: int | None,
+    right_end: int | None,
+) -> bool:
+    if left_start is None or left_end is None or right_start is None or right_end is None:
+        return False
+    return left_start <= right_end and right_start <= left_end
+
+
+def _pages_containing_review_display_ids(
+    model: FileReviewModel,
+    display_ids: tuple[int, ...],
+) -> tuple[int, ...]:
+    """Return review pages containing all of the requested display IDs."""
+    if model.display_id_by_selection_id is None:
+        display_id_for_row = lambda row: row.id
+    else:
+        display_id_for_row = lambda row: model.display_id_by_selection_id.get(row.id)
+
+    wanted = set(display_ids)
+    found: set[int] = set()
+    pages: set[int] = set()
+    for page in model.pages:
+        for fragment in page.changes:
+            for row in fragment.rows:
+                if row.id is None:
+                    continue
+                display_id = display_id_for_row(row)
+                if display_id in wanted:
+                    found.add(display_id)
+                    pages.add(page.page)
+    if found != wanted:
+        return tuple()
+    return tuple(sorted(pages))
+
+
+def _change_index_containing_review_display_ids(
+    model: FileReviewModel,
+    display_ids: tuple[int, ...],
+) -> int:
+    """Return a stable nearby change index for supplemental review selections."""
+    if model.display_id_by_selection_id is None:
+        display_id_for_row = lambda row: row.id
+    else:
+        display_id_for_row = lambda row: model.display_id_by_selection_id.get(row.id)
+
+    wanted = set(display_ids)
+    for page in model.pages:
+        for fragment in page.changes:
+            row_display_ids = {
+                display_id_for_row(row)
+                for row in fragment.rows
+                if row.id is not None
+            }
+            if wanted & row_display_ids:
+                return fragment.change.index
+    return 0
+
+
+def _supplemental_batch_review_selections(
+    model: FileReviewModel,
+    *,
+    visible_display_ids: set[int] | None,
+) -> tuple[FileReviewSelectionState, ...]:
+    """Persist reset ownership atoms without making them pagination changes."""
+    selections: list[FileReviewSelectionState] = []
+    primary_reset_groups = {
+        change.display_ids
+        for change in model.changes
+        if FileReviewAction.RESET_FROM_BATCH.value in change.actions
+    }
+    for group in model.review_action_groups:
+        if not group.display_ids:
+            continue
+        if group.display_ids in primary_reset_groups:
+            continue
+        display_id_set = set(group.display_ids)
+        if visible_display_ids is not None and not display_id_set.issubset(visible_display_ids):
+            continue
+        if FileReviewAction.RESET_FROM_BATCH.value not in group.actions:
+            continue
+        pages = _pages_containing_review_display_ids(model, group.display_ids)
+        if not pages:
+            continue
+        selections.append(
+            FileReviewSelectionState(
+                display_ids=group.display_ids,
+                selection_ids=group.selection_ids,
+                change_index=_change_index_containing_review_display_ids(
+                    model,
+                    group.display_ids,
+                ),
+                first_page=pages[0],
+                last_page=pages[-1],
+                reason=_coerce_actionable_reason(group.reason),
+                actions=(FileReviewAction.RESET_FROM_BATCH,),
+            )
+        )
+    return tuple(selections)
+
+
+def make_file_review_state(
+    model: FileReviewModel,
+    *,
+    source: ReviewSource,
+    batch_name: str | None,
+    shown_pages: tuple[int, ...],
+    selected_change_kind: SelectedChangeKind,
+    gutter_to_selection_id: dict[int, int] | None = None,
+    actionable_selection_groups: tuple[tuple[int, ...], ...] | None = None,
+    review_action_groups: tuple[ReviewActionGroup, ...] | None = None,
+    visible_display_ids: set[int] | None = None,
+    entire_file_shown: bool | None = None,
+) -> FileReviewState:
+    """Create persisted review state from a rendered page selection."""
+    page_count = len(model.pages)
+    shown_page_set = set(shown_pages)
+    selection_actions = (
+        (
+            FileReviewAction.INCLUDE_FROM_BATCH,
+            FileReviewAction.DISCARD_FROM_BATCH,
+            FileReviewAction.APPLY_FROM_BATCH,
+            FileReviewAction.RESET_FROM_BATCH,
+        )
+        if source == ReviewSource.BATCH
+        else (
+            FileReviewAction.INCLUDE,
+            FileReviewAction.SKIP,
+            FileReviewAction.DISCARD,
+            FileReviewAction.INCLUDE_TO_BATCH,
+            FileReviewAction.DISCARD_TO_BATCH,
+        )
+    )
+    selections = []
+    for change in model.changes:
+        if not change.display_ids:
+            continue
+        if visible_display_ids is not None and not set(change.display_ids).issubset(visible_display_ids):
+            continue
+        change_actions = (
+            tuple(FileReviewAction(action) for action in change.actions)
+            if change.actions else
+            selection_actions
+        )
+        selections.append(
+            FileReviewSelectionState(
+                display_ids=change.display_ids,
+                selection_ids=change.selection_ids,
+                change_index=change.index,
+                first_page=change.first_page,
+                last_page=change.last_page,
+                reason=change.reason,
+                actions=change_actions,
+            )
+        )
+    if source == ReviewSource.BATCH and review_action_groups is not None:
+        selections.extend(
+            _supplemental_batch_review_selections(
+                model,
+                visible_display_ids=visible_display_ids,
+            )
+        )
+    computed_entire_file_shown = shown_page_set == set(range(1, page_count + 1))
+    return FileReviewState(
+        source=source,
+        batch_name=batch_name,
+        file_path=model.line_changes.path,
+        page_spec=normalize_page_spec(shown_pages, page_count),
+        shown_pages=shown_pages,
+        page_count=page_count,
+        entire_file_shown=(
+            computed_entire_file_shown
+            if entire_file_shown is None else
+            entire_file_shown
+        ),
+        selections=tuple(selections),
+        selected_change_kind=selected_change_kind,
+        selected_file_fingerprint=fingerprint_selected_file_view(
+            source=source,
+            batch_name=batch_name,
+            file_path=model.line_changes.path,
+            selected_change_kind=selected_change_kind,
+            gutter_to_selection_id=gutter_to_selection_id,
+            actionable_selection_groups=actionable_selection_groups,
+            review_action_groups=review_action_groups,
+        ),
+        diff_fingerprint=compute_current_file_review_diff_fingerprint(model.line_changes.path),
+    )
+
+
+def print_file_review(
+    model: FileReviewModel,
+    *,
+    shown_pages: tuple[int, ...],
+    source_label: str,
+    page_spec: str,
+    command_source_args: str = "",
+    source: ReviewSource,
+    batch_name: str | None = None,
+    opened_near_selected_hunk: bool = False,
+) -> None:
+    """Print a page-aware file review."""
+    page_count = len(model.pages)
+    shown_page_set = set(shown_pages)
+    shown_changes = [
+        fragment.change
+        for page in shown_pages
+        for fragment in model.pages[page - 1].changes
+    ]
+    complete_changes = [
+        change
+        for change in shown_changes
+        if change.display_ids
+        if set(range(change.first_page, change.last_page + 1)).issubset(shown_page_set)
+    ]
+
+    _print_header(
+        model.line_changes.path,
+        source_label=source_label,
+        shown_pages=shown_pages,
+        page_count=page_count,
+        shown_changes=shown_changes,
+        total_changes=len(model.changes),
+        opened_near_selected_hunk=opened_near_selected_hunk,
+    )
+
+    multi_page = len(shown_pages) > 1
+    for page in shown_pages:
+        if multi_page:
+            print()
+            print(f"── page {page}/{page_count} " + "─" * 48)
+        for fragment in model.pages[page - 1].changes:
+            change = fragment.change
+            print()
+            selection_spec = change.select_as or format_line_ids(list(change.display_ids))
+            heading_action = _review_change_heading_action(change)
+            span_text = (
+                _(" · large change")
+                if change.is_oversized
+                else ""
+            )
+            if change.display_ids:
+                print(
+                    _("Change {index} of {total} · {action}: --line {lines}{span}").format(
+                        index=change.index,
+                        total=change.total,
+                        action=heading_action,
+                        lines=selection_spec,
+                        span=span_text,
+                    )
+                )
+            else:
+                print(
+                    _("Change {index} of {total} · {note}{span}").format(
+                        index=change.index,
+                        total=change.total,
+                        note=change.note or _("not currently selectable"),
+                        span=span_text,
+                    )
+                )
+            _print_rows(
+                fragment.rows,
+                _maximum_display_id_digit_count(model),
+                display_id_by_selection_id=model.display_id_by_selection_id,
+                allowed_selection_ids=set(change.selection_ids) if change.display_ids else set(),
+            )
+
+    _print_footer(
+        model.line_changes.path,
+        shown_pages=shown_pages,
+        page_count=page_count,
+        shown_changes=shown_changes,
+        complete_changes=complete_changes,
+        total_changes=len(model.changes),
+        page_spec=page_spec,
+        command_source_args=command_source_args,
+        source=source,
+        batch_name=batch_name,
+    )
+
+
+def _change_supports_action(change: ReviewChange, action: FileReviewAction) -> bool:
+    """Return whether a rendered review change supports an action."""
+    return not change.actions or action.value in change.actions
+
+
+def _review_change_heading_action(change: ReviewChange) -> str:
+    """Return the concise action label shown for one review change."""
+    if change.reason == ActionableSelectionReason.REPLACEMENT:
+        return _("select together")
+    if change.actions == (FileReviewAction.RESET_FROM_BATCH.value,):
+        return _("reset")
+    return _("select")
+
+
+def _print_header(
+    path: str,
+    *,
+    source_label: str,
+    shown_pages: tuple[int, ...],
+    page_count: int,
+    shown_changes: list[ReviewChange],
+    total_changes: int,
+    opened_near_selected_hunk: bool,
+) -> None:
+    print(f"── {path} " + "─" * 60)
+    print(source_label)
+    page_word = _("page") if len(shown_pages) == 1 else _("pages")
+    page_text = format_line_ids(list(shown_pages))
+    change_ids = [change.index for change in shown_changes]
+    change_text = format_line_ids(change_ids) if change_ids else ""
+    print(
+        _("Showing {page_word} {pages} of {page_count} · shown changes {changes} of {total}").format(
+            page_word=page_word,
+            pages=page_text,
+            page_count=page_count,
+            changes=change_text or "-",
+            total=total_changes,
+        )
+    )
+    if opened_near_selected_hunk:
+        print(_("Showing the area around the change you were viewing."))
+    else:
+        _print_page_coverage(shown_pages, page_count)
+    print("─" * 72)
+
+
+def _print_page_coverage(shown_pages: tuple[int, ...], page_count: int) -> None:
+    shown = set(shown_pages)
+    all_pages = set(range(1, page_count + 1))
+    if shown == all_pages:
+        print(_("Entire file shown."))
+        return
+    missing = sorted(all_pages - shown)
+    if missing:
+        print(_("Pages {pages} are not shown.").format(pages=format_line_ids(missing)))
+
+
+def _maximum_display_id_digit_count(model: FileReviewModel) -> int:
+    if model.display_id_by_selection_id is None:
+        return model.line_changes.maximum_line_id_digit_count()
+    if not model.display_id_by_selection_id:
+        return 1
+    return len(str(max(model.display_id_by_selection_id.values())))
+
+
+def _print_rows(
+    rows: tuple[LineEntry, ...],
+    maximum_digits: int,
+    *,
+    display_id_by_selection_id: dict[int, int] | None,
+    allowed_selection_ids: set[int] | None = None,
+) -> None:
+    label_width = maximum_digits + 3
+    for line in rows:
+        if line.id is None or (
+            allowed_selection_ids is not None
+            and line.id not in allowed_selection_ids
+        ):
+            display_id = None
+        elif display_id_by_selection_id is not None:
+            display_id = display_id_by_selection_id.get(line.id)
+        else:
+            display_id = line.id
+        if display_id is None:
+            label = ""
+        else:
+            label = f"[#{display_id}]"
+        padding = " " * max(0, label_width - len(label))
+        print(f"{label}{padding} {line.kind} {line.text}")
+
+
+def _print_footer(
+    path: str,
+    *,
+    shown_pages: tuple[int, ...],
+    page_count: int,
+    shown_changes: list[ReviewChange],
+    complete_changes: list[ReviewChange],
+    total_changes: int,
+    page_spec: str,
+    command_source_args: str,
+    source: ReviewSource,
+    batch_name: str | None,
+) -> None:
+    shown = set(shown_pages)
+    is_entire = shown == set(range(1, page_count + 1))
+    marker = "end" if max(shown_pages) == page_count else "more"
+    print()
+    print(f"── {marker} " + "─" * 63)
+    page_label = "page" if len(shown_pages) == 1 else "pages"
+    print(
+        f"{path} · {page_label} {format_line_ids(list(shown_pages))}/{page_count} "
+        f"· shown changes {format_line_ids([c.index for c in shown_changes])} of {total_changes}"
+    )
+    if not is_entire and max(shown_pages) < page_count:
+        print(
+            f"Next: git-stage-batch show{command_source_args} --file {_quote(path)} --page {max(shown_pages) + 1}"
+        )
+
+    review_state = _footer_review_state(
+        path=path,
+        shown_pages=shown_pages,
+        page_count=page_count,
+        source=source,
+        batch_name=batch_name,
+    )
+    primary_action = (
+        FileReviewAction.INCLUDE_FROM_BATCH
+        if source == ReviewSource.BATCH else
+        FileReviewAction.INCLUDE
+    )
+    primary_changes = [
+        change
+        for change in complete_changes
+        if _change_supports_action(change, primary_action)
+    ]
+    reset_changes = [
+        change
+        for change in complete_changes
+        if _change_supports_action(change, FileReviewAction.RESET_FROM_BATCH)
+    ]
+
+    if primary_changes:
+        combined_selection = ",".join(format_line_ids(list(change.display_ids)) for change in primary_changes)
+        print()
+        print(_("Complete changes shown:"))
+        include_line_command = (
+            _line_action_command("include", review_state, line_spec=combined_selection, pathless_line=True)
+            if review_state is not None else
+            None
+        )
+        print(f"  {include_line_command or f'git-stage-batch include{command_source_args} --line {combined_selection}'}")
+        print()
+        if command_source_args:
+            print(_("Same selection also works with:"))
+            discard_line_command = (
+                _line_action_command("discard", review_state, line_spec=combined_selection, pathless_line=True)
+                if review_state is not None else
+                None
+            )
+            print(f"  {discard_line_command or f'git-stage-batch discard{command_source_args} --line {combined_selection}'}")
+        else:
+            print(_("Also works with: skip, discard"))
+        if source == ReviewSource.BATCH and reset_changes:
+            reset_selection = ",".join(format_line_ids(list(change.display_ids)) for change in reset_changes)
+            reset_line_command = _line_action_command(
+                FileReviewAction.RESET_FROM_BATCH,
+                review_state,
+                line_spec=reset_selection,
+                pathless_line=True,
+            )
+            print(f"  {reset_line_command or f'git-stage-batch reset{command_source_args} --line {reset_selection}'}")
+        if len(primary_changes) <= 5:
+            print()
+            print(_("Individual changes:"))
+            for change in primary_changes:
+                selection_spec = format_line_ids(list(change.display_ids))
+                include_change_command = (
+                    _line_action_command("include", review_state, line_spec=selection_spec, pathless_line=True)
+                    if review_state is not None else
+                    None
+                )
+                print(f"  {include_change_command or f'git-stage-batch include{command_source_args} --line {selection_spec}'}")
+    elif reset_changes:
+        reset_selection = ",".join(format_line_ids(list(change.display_ids)) for change in reset_changes)
+        reset_line_command = _line_action_command(
+            FileReviewAction.RESET_FROM_BATCH,
+            review_state,
+            line_spec=reset_selection,
+            pathless_line=True,
+        )
+        print()
+        print(_("Resettable changes shown:"))
+        print(f"  {reset_line_command or f'git-stage-batch reset{command_source_args} --line {reset_selection}'}")
+    elif not is_entire:
+        print()
+        print(_("No complete change is actionable from this page."))
+
+    if is_entire:
+        print()
+        print(_("Actions:"))
+        print(f"  git-stage-batch include{command_source_args} --file {_quote(path)}")
+        if not command_source_args:
+            print("  git-stage-batch include")
+    else:
+        print()
+        print(_("All:") + f" git-stage-batch show{command_source_args} --file {_quote(path)} --page all")
+        print()
+        print(_("Whole file:"))
+        print(f"  git-stage-batch include{command_source_args} --file {_quote(path)}")
+
+
+def _footer_review_state(
+    *,
+    path: str,
+    shown_pages: tuple[int, ...],
+    page_count: int,
+    source: ReviewSource,
+    batch_name: str | None,
+) -> FileReviewState:
+    if source == ReviewSource.BATCH:
+        return FileReviewState(
+            source=ReviewSource.BATCH,
+            batch_name=batch_name,
+            file_path=path,
+            page_spec="all",
+            shown_pages=shown_pages,
+            page_count=page_count,
+            entire_file_shown=set(shown_pages) == set(range(1, page_count + 1)),
+            selections=tuple(),
+            selected_change_kind=SelectedChangeKind.BATCH_FILE,
+            selected_file_fingerprint="",
+            diff_fingerprint="",
+        )
+    return FileReviewState(
+        source=source,
+        batch_name=None,
+        file_path=path,
+        page_spec="all",
+        shown_pages=shown_pages,
+        page_count=page_count,
+        entire_file_shown=set(shown_pages) == set(range(1, page_count + 1)),
+        selections=tuple(),
+        selected_change_kind=SelectedChangeKind.FILE,
+        selected_file_fingerprint="",
+        diff_fingerprint="",
+    )

--- a/src/git_stage_batch/output/file_review_list.py
+++ b/src/git_stage_batch/output/file_review_list.py
@@ -1,0 +1,109 @@
+"""Multi-file review list output."""
+
+from __future__ import annotations
+
+import shlex
+from dataclasses import dataclass
+
+from ..core.models import BinaryFileChange, LineLevelChange
+from ..i18n import _
+from .file_review import build_file_review_model
+
+
+@dataclass(frozen=True)
+class FileReviewListEntry:
+    """One file listed in a multi-file review list."""
+
+    path: str
+    change_count: int
+    changed_line_count: int
+    addition_count: int
+    deletion_count: int
+    page_count: int
+    binary_change_type: str | None = None
+
+
+def make_file_review_list_entry(
+    line_changes: LineLevelChange,
+    *,
+    gutter_to_selection_id: dict[int, int] | None = None,
+) -> FileReviewListEntry:
+    """Build a list entry from a file review model."""
+    model = build_file_review_model(line_changes, gutter_to_selection_id=gutter_to_selection_id)
+    actionable_selection_ids = (
+        set(gutter_to_selection_id.values())
+        if gutter_to_selection_id is not None else
+        {line.id for line in line_changes.lines if line.id is not None}
+    )
+    addition_count = sum(1 for line in line_changes.lines if line.kind == "+" and line.id in actionable_selection_ids)
+    deletion_count = sum(1 for line in line_changes.lines if line.kind == "-" and line.id in actionable_selection_ids)
+    return FileReviewListEntry(
+        path=line_changes.path,
+        change_count=len(model.changes),
+        changed_line_count=addition_count + deletion_count,
+        addition_count=addition_count,
+        deletion_count=deletion_count,
+        page_count=len(model.pages),
+    )
+
+
+def make_binary_file_review_list_entry(binary_change: BinaryFileChange) -> FileReviewListEntry:
+    """Build a list entry from a binary file change."""
+    path = binary_change.new_path if binary_change.new_path != "/dev/null" else binary_change.old_path
+    return FileReviewListEntry(
+        path=path,
+        change_count=1,
+        changed_line_count=0,
+        addition_count=0,
+        deletion_count=0,
+        page_count=1,
+        binary_change_type=binary_change.change_type,
+    )
+
+
+def print_file_review_list(
+    *,
+    source_label: str,
+    entries: list[FileReviewListEntry],
+    command_source_args: str = "",
+) -> None:
+    """Print a navigational file list for multiple file reviews."""
+    print("── matched files " + "─" * 55)
+    print(source_label)
+    total_changes = sum(entry.change_count for entry in entries)
+    total_lines = sum(entry.changed_line_count for entry in entries)
+    print(
+        _("Matched: {files} files · {changes} changes · {lines} changed lines").format(
+            files=len(entries),
+            changes=total_changes,
+            lines=total_lines,
+        )
+    )
+    print()
+    path_width = max((len(entry.path) for entry in entries), default=4)
+    for index, entry in enumerate(entries, start=1):
+        change_word = _("change") if entry.change_count == 1 else _("changes")
+        page_word = _("page") if entry.page_count == 1 else _("pages")
+        if entry.binary_change_type is not None:
+            print(
+                f"{index}. {entry.path.ljust(path_width)}  "
+                f"{entry.change_count} {change_word} · "
+                f"binary {entry.binary_change_type} · "
+                f"{entry.page_count} {page_word}"
+            )
+        else:
+            print(
+                f"{index}. {entry.path.ljust(path_width)}  "
+                f"{entry.change_count} {change_word} · "
+                f"+{entry.addition_count}/-{entry.deletion_count} · "
+                f"{entry.page_count} {page_word}"
+            )
+
+    if entries:
+        print()
+        print(_("Open:"))
+        for entry in entries[:5]:
+            print(f"  git-stage-batch show{command_source_args} --file {shlex.quote(entry.path)}")
+        if len(entries) > 5:
+            remaining = len(entries) - 5
+            print(_("  ... {count} more files matched").format(count=remaining))

--- a/src/git_stage_batch/output/hunk.py
+++ b/src/git_stage_batch/output/hunk.py
@@ -3,7 +3,14 @@
 from __future__ import annotations
 
 from ..core.models import LineLevelChange
+from ..i18n import _
 from .colors import Colors
+
+
+def print_remaining_line_changes_header(file_path: str) -> None:
+    """Print a boundary before refreshed remaining line changes."""
+    print()
+    print(_("── remaining unstaged changes in {file} ──").format(file=file_path))
 
 
 def print_line_level_changes(line_changes: LineLevelChange, *, gutter_to_selection_id: dict[int, int] | None = None) -> None:

--- a/src/git_stage_batch/staging/operations.py
+++ b/src/git_stage_batch/staging/operations.py
@@ -361,7 +361,7 @@ def build_target_working_tree_content_with_discarded_lines(
         push_output(working_lines[working_pointer])
         working_pointer += 1
 
-    return "\n".join(output_lines) + ("\n" if (working_text.endswith("\n") or output_lines) else "")
+    return "\n".join(output_lines) + ("\n" if output_lines else "")
 
 
 def build_target_working_tree_content_bytes_with_discarded_lines(
@@ -421,7 +421,7 @@ def build_target_working_tree_content_bytes_with_discarded_lines(
         push_output(working_lines[working_pointer])
         working_pointer += 1
 
-    trailing_newline = working_content.endswith(b"\n") or bool(output_lines)
+    trailing_newline = bool(output_lines)
     return b"\n".join(output_lines) + (b"\n" if trailing_newline else b"")
 
 

--- a/src/git_stage_batch/utils/paths.py
+++ b/src/git_stage_batch/utils/paths.py
@@ -166,6 +166,16 @@ def get_selected_change_kind_file_path() -> Path:
     return get_selected_state_directory_path() / "change-kind.txt"
 
 
+def get_selected_change_clear_reason_file_path() -> Path:
+    """Get the path to the marker explaining an intentionally cleared selection."""
+    return get_selected_state_directory_path() / "clear-reason.txt"
+
+
+def get_last_file_review_state_file_path() -> Path:
+    """Get the path to the most recent file-review safety state."""
+    return get_selected_state_directory_path() / "file-review.json"
+
+
 def get_selected_binary_file_json_path() -> Path:
     """Get the path to the selected binary file JSON file.
 

--- a/tests/cli/test_argument_parser.py
+++ b/tests/cli/test_argument_parser.py
@@ -15,6 +15,16 @@ def _stdin_with_bytes(data: bytes) -> io.TextIOWrapper:
     return io.TextIOWrapper(io.BytesIO(data), encoding="utf-8", errors="surrogateescape")
 
 
+class _UnreadableStdin:
+    """Stdin stub that fails if a command reads replacement text too early."""
+
+    class _Buffer:
+        def read(self):
+            raise AssertionError("stdin should not be read")
+
+    buffer = _Buffer()
+
+
 def test_build_manpath_with_existing_environment(monkeypatch):
     """Existing MANPATH should be preserved after the packaged root."""
     monkeypatch.setattr(argument_parser, "_resolve_default_manpath", lambda: "/ignored")
@@ -393,6 +403,32 @@ def test_parse_command_line_include_with_files_dispatches_per_file(monkeypatch):
     mock_show_selected_change.assert_called_once_with()
 
 
+def test_parse_command_line_include_from_with_files_resolves_batch_scope_only(monkeypatch):
+    """include --from --files should match batch files, not current live changes."""
+    mock_command = Mock()
+    monkeypatch.setattr(argument_parser.commands, "command_include_from_batch", mock_command)
+    monkeypatch.setattr(argument_parser, "batch_exists", lambda name: True)
+    monkeypatch.setattr(
+        argument_parser,
+        "read_batch_metadata",
+        lambda name: {"files": {"foo.py": {}, "bar.py": {}, "notes.txt": {}}},
+    )
+    monkeypatch.setattr(
+        argument_parser,
+        "list_changed_files",
+        Mock(side_effect=AssertionError("live scope should not be resolved")),
+    )
+
+    args = parse_command_line(["include", "--from", "batch", "--files", "*.py"], quiet=True)
+
+    assert args is not None
+    args.func(args)
+    assert mock_command.call_args_list == [
+        call("batch", None, "foo.py"),
+        call("batch", None, "bar.py"),
+    ]
+
+
 def test_parse_command_line_include_from_with_as():
     """Test parsing include --from with replacement text."""
     args = parse_command_line(
@@ -444,6 +480,16 @@ def test_parse_command_line_include_rejects_no_edge_overlap_without_line_as():
     assert args is not None
 
     with pytest.raises(argument_parser.CommandError, match="`--no-edge-overlap` requires `include --line --as`"):
+        args.func(args)
+
+
+def test_parse_command_line_include_invalid_as_stdin_shape_does_not_read(monkeypatch):
+    """Invalid include --as-stdin combinations should fail before consuming stdin."""
+    monkeypatch.setattr(argument_parser.sys, "stdin", _UnreadableStdin())
+    args = parse_command_line(["include", "--to", "batch", "--as-stdin"], quiet=True)
+    assert args is not None
+
+    with pytest.raises(argument_parser.CommandError, match="`include --as` requires"):
         args.func(args)
 
 
@@ -551,6 +597,32 @@ def test_parse_command_line_discard_with_files_dispatches_per_file(monkeypatch):
     assert args is not None
     args.func(args)
     assert mock_command.call_args_list == [call("foo.py"), call("bar.py")]
+
+
+def test_parse_command_line_discard_from_with_files_resolves_batch_scope_only(monkeypatch):
+    """discard --from --files should match batch files, not current live changes."""
+    mock_command = Mock()
+    monkeypatch.setattr(argument_parser.commands, "command_discard_from_batch", mock_command)
+    monkeypatch.setattr(argument_parser, "batch_exists", lambda name: True)
+    monkeypatch.setattr(
+        argument_parser,
+        "read_batch_metadata",
+        lambda name: {"files": {"foo.py": {}, "bar.py": {}, "notes.txt": {}}},
+    )
+    monkeypatch.setattr(
+        argument_parser,
+        "list_changed_files",
+        Mock(side_effect=AssertionError("live scope should not be resolved")),
+    )
+
+    args = parse_command_line(["discard", "--from", "batch", "--files", "*.py"], quiet=True)
+
+    assert args is not None
+    args.func(args)
+    assert mock_command.call_args_list == [
+        call("batch", None, "foo.py"),
+        call("batch", None, "bar.py"),
+    ]
 
 
 def test_parse_command_line_apply_with_files_dispatches_per_file(monkeypatch):
@@ -811,6 +883,16 @@ def test_parse_command_line_discard_rejects_no_edge_overlap_without_to_line_as()
     assert args is not None
 
     with pytest.raises(argument_parser.CommandError, match="`--no-edge-overlap` requires `discard --to --line --as`"):
+        args.func(args)
+
+
+def test_parse_command_line_discard_invalid_as_stdin_shape_does_not_read(monkeypatch):
+    """Invalid discard --as-stdin combinations should fail before consuming stdin."""
+    monkeypatch.setattr(argument_parser.sys, "stdin", _UnreadableStdin())
+    args = parse_command_line(["discard", "--from", "batch", "--as-stdin"], quiet=True)
+    assert args is not None
+
+    with pytest.raises(argument_parser.CommandError, match="`discard --as` requires"):
         args.func(args)
 
 

--- a/tests/commands/test_discard_empty_file.py
+++ b/tests/commands/test_discard_empty_file.py
@@ -6,8 +6,12 @@ import pytest
 
 from git_stage_batch.commands.discard import command_discard_to_batch
 from git_stage_batch.commands.start import command_start
+from git_stage_batch.batch import read_file_from_batch
 from git_stage_batch.batch.operations import create_batch
+from git_stage_batch.batch.query import read_batch_metadata
+from git_stage_batch.data.session import initialize_abort_state
 from git_stage_batch.utils.git import get_git_repository_root_path
+from git_stage_batch.utils.paths import ensure_state_directory_exists
 
 
 @pytest.fixture
@@ -90,3 +94,23 @@ class TestDiscardEmptyFile:
             check=True
         )
         assert not ls_result.stdout.strip(), "File should not be in index"
+
+    def test_discard_empty_deleted_file_to_batch(self, temp_git_repo):
+        """Discarding an empty text deletion to batch should restore the file locally."""
+        empty_file = temp_git_repo / "empty.txt"
+        empty_file.write_bytes(b"")
+        subprocess.run(["git", "add", "empty.txt"], check=True, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add empty file"], check=True, capture_output=True)
+        empty_file.unlink()
+
+        ensure_state_directory_exists()
+        initialize_abort_state()
+        create_batch("delete-batch", "Test batch for empty deletion")
+
+        command_discard_to_batch("delete-batch", line_ids=None, file="empty.txt", quiet=True)
+
+        file_meta = read_batch_metadata("delete-batch")["files"]["empty.txt"]
+        assert file_meta["change_type"] == "deleted"
+        assert read_file_from_batch("delete-batch", "empty.txt") is None
+        assert empty_file.exists()
+        assert empty_file.read_bytes() == b""

--- a/tests/commands/test_file_scoped_operations.py
+++ b/tests/commands/test_file_scoped_operations.py
@@ -15,7 +15,7 @@ from git_stage_batch.utils.paths import (
     get_selected_hunk_hash_file_path,
     get_selected_hunk_patch_file_path,
 )
-from git_stage_batch.data.hunk_tracking import render_unstaged_file_as_single_hunk
+from git_stage_batch.data.hunk_tracking import read_selected_change_kind, render_unstaged_file_as_single_hunk
 from git_stage_batch.commands.skip import command_skip, command_skip_line
 from git_stage_batch.cli.argument_parser import parse_command_line
 
@@ -572,18 +572,25 @@ class TestShowFileFlag:
         assert "change-two" in changed_texts
         assert "change-three" in changed_texts
 
-    def test_show_files_selection_can_feed_include(self, multi_file_repo):
-        """Show --files should leave the final displayed file selected for include."""
+    def test_show_files_outputs_navigation_list_and_clears_selection(self, multi_file_repo, capsys):
+        """Show --files should be navigational, not a hidden selected-file action."""
         command_start()
+        capsys.readouterr()
 
         args = parse_command_line(["show", "--files", "*.txt"], quiet=True)
         assert args is not None
         args.func(args)
 
-        command_include(quiet=True)
-
+        captured = capsys.readouterr()
+        assert "── matched files" in captured.out
+        assert "Changes: file vs HEAD" in captured.out
+        assert "Open:" in captured.out
+        assert "git-stage-batch show --file alpha.txt" in captured.out
+        assert read_selected_change_kind() is None
+        with pytest.raises(CommandError, match="last command only showed files"):
+            command_include(quiet=True)
         result = run_git_command(["diff", "--cached", "--name-only"])
-        assert result.stdout.strip() == "gamma.txt"
+        assert result.stdout == ""
 
     def test_include_files_reports_aggregate_staged_scope(self, multi_file_repo, capsys):
         """Include --files should report the full staged scope once."""
@@ -637,33 +644,36 @@ class TestShowFileFlag:
         result = run_git_command(["diff", "--cached", "--name-only"])
         assert result.stdout.splitlines() == ["alpha.txt", "beta.txt", "gamma.txt"]
 
-    def test_show_files_selection_can_feed_discard(self, multi_file_repo):
-        """Show --files should leave the final displayed file selected for discard."""
+    def test_show_files_does_not_feed_bare_discard(self, multi_file_repo, capsys):
+        """A multi-file file list should not leave a selected file for discard."""
         command_start()
+        capsys.readouterr()
 
         args = parse_command_line(["show", "--files", "*.txt"], quiet=True)
         assert args is not None
         args.func(args)
+        capsys.readouterr()
 
-        command_discard(quiet=True)
-
+        assert read_selected_change_kind() is None
+        with pytest.raises(CommandError, match="last command only showed files"):
+            command_discard(quiet=True)
         assert (multi_file_repo / "alpha.txt").read_text() == "alpha1\nalpha2-modified\nalpha3\nalpha4-new\n"
         assert (multi_file_repo / "beta.txt").read_text() == "beta1\nbeta2-modified\nbeta3\nbeta4-new\n"
-        assert (multi_file_repo / "gamma.txt").read_text() == "gamma1\ngamma2\ngamma3\n"
+        assert (multi_file_repo / "gamma.txt").read_text() == "gamma1\ngamma2-modified\ngamma3\ngamma4-new\n"
 
-    def test_show_files_selection_can_feed_skip(self, multi_file_repo):
-        """Show --files should leave the final displayed file selected for skip."""
+    def test_show_files_does_not_feed_bare_skip(self, multi_file_repo, capsys):
+        """A multi-file file list should not leave a selected file for skip."""
         command_start()
+        capsys.readouterr()
 
         args = parse_command_line(["show", "--files", "*.txt"], quiet=True)
         assert args is not None
         args.func(args)
+        capsys.readouterr()
 
-        command_skip(quiet=True)
-        command_include(quiet=True)
-
-        result = run_git_command(["diff", "--cached", "--name-only"])
-        assert result.stdout.strip() == "alpha.txt"
+        assert read_selected_change_kind() is None
+        with pytest.raises(CommandError, match="last command only showed files"):
+            command_skip(quiet=True)
 
 
 class TestIncludeToBatchWithFile:

--- a/tests/commands/test_file_scoped_operations.py
+++ b/tests/commands/test_file_scoped_operations.py
@@ -840,16 +840,16 @@ class TestBatchSourceWithFile:
         assert "alpha.txt" not in staged
         assert "gamma.txt" not in staged
 
-    def test_include_from_batch_file_empty_string(self, multi_file_repo):
-        """Include --from BATCH --file (empty) should use first file from batch display."""
+    def test_include_from_batch_file_empty_string_uses_selected_batch_file(self, multi_file_repo):
+        """Include --from BATCH --file (empty) should use a selected batch file."""
         command_start()
         command_include_to_batch("batch", file="alpha.txt")
         command_include_to_batch("batch", file="beta.txt")
 
         subprocess.run(["git", "checkout", "HEAD", "--", "."], check=True, capture_output=True)
 
-        # Show batch to cache first file
-        command_show_from_batch("batch")
+        # Show one batch file to cache an explicit selected file.
+        command_show_from_batch("batch", file="alpha.txt")
 
         # Include with empty string
         command_include_from_batch("batch", file="")
@@ -857,6 +857,19 @@ class TestBatchSourceWithFile:
         # First file (alpha.txt) should be staged
         result = run_git_command(["diff", "--cached", "--name-only"])
         assert "alpha.txt" in result.stdout
+
+    def test_include_from_batch_file_empty_string_after_file_list_fails(self, multi_file_repo):
+        """A multi-file batch file list should not select a hidden batch file."""
+        command_start()
+        command_include_to_batch("batch", file="alpha.txt")
+        command_include_to_batch("batch", file="beta.txt")
+
+        subprocess.run(["git", "checkout", "HEAD", "--", "."], check=True, capture_output=True)
+
+        command_show_from_batch("batch")
+
+        with pytest.raises(CommandError, match="last command only showed files"):
+            command_include_from_batch("batch", file="")
 
     def test_apply_from_batch_with_file(self, multi_file_repo):
         """Apply --from BATCH --file PATH should apply only that file."""
@@ -925,8 +938,8 @@ class TestBatchSourceWithFile:
 class TestMultiFileBatchDisplay:
     """Test displaying multi-file batches with separators."""
 
-    def test_show_from_multi_file_batch_separators(self, multi_file_repo, capsys):
-        """Show --from BATCH with multiple files should show file headers."""
+    def test_show_from_multi_file_batch_list(self, multi_file_repo, capsys):
+        """Show --from BATCH with multiple files should show a navigational file list."""
         command_start()
         capsys.readouterr()  # Clear start's output
         command_include_to_batch("multi", file="alpha.txt")
@@ -936,10 +949,10 @@ class TestMultiFileBatchDisplay:
         command_show_from_batch("multi")
 
         captured = capsys.readouterr()
-        # Should have file headers in standard format
-        assert "alpha.txt :: @@" in captured.out
-        assert "beta.txt :: @@" in captured.out
-        assert "gamma.txt :: @@" in captured.out
+        assert "── matched files" in captured.out
+        assert "Changes: batch multi" in captured.out
+        assert "git-stage-batch show --from multi --file alpha.txt" in captured.out
+        assert read_selected_change_kind() is None
 
     def test_show_from_multi_file_displays_all_content(self, multi_file_repo, capsys):
         """Show --from BATCH should display content from all files."""

--- a/tests/commands/test_include_from.py
+++ b/tests/commands/test_include_from.py
@@ -1,10 +1,5 @@
 """Tests for include from batch command."""
 
-from git_stage_batch.commands.start import command_start
-from git_stage_batch.commands.include import command_include_to_batch
-from unittest.mock import patch, MagicMock
-from git_stage_batch.core.models import LineLevelChange, LineEntry
-
 import stat
 import subprocess
 
@@ -16,7 +11,10 @@ from git_stage_batch.batch.query import read_batch_metadata
 from git_stage_batch.batch.storage import add_file_to_batch
 from git_stage_batch.commands.apply_from import command_apply_from_batch
 from git_stage_batch.commands.discard_from import command_discard_from_batch
+from git_stage_batch.commands.include import command_include_to_batch
 from git_stage_batch.commands.include_from import command_include_from_batch
+from git_stage_batch.commands.show_from import command_show_from_batch
+from git_stage_batch.commands.start import command_start
 from git_stage_batch.data.hunk_tracking import render_batch_file_display
 from git_stage_batch.data.session import initialize_abort_state
 from git_stage_batch.exceptions import CommandError
@@ -113,17 +111,11 @@ class TestCommandIncludeFromBatch:
         (temp_git_repo / "file1.txt").write_text("line 1\nline 2\n")
         (temp_git_repo / "file2.txt").write_text("line A\nline B\n")
 
-        # Mock cached hunk state to make it look like file1.txt is the selected file
-        mock_lines = LineLevelChange(
-            path="file1.txt",
-            header=MagicMock(),  # Mock header (not relevant for this test)
-            lines=[LineEntry(id=1, kind="+", text_bytes=b"file1 added\n", text="file1 added\n", old_line_number=None, new_line_number=3)]
-        )
+        # Show file1 from the batch so --file without PATH reuses that selected file.
+        command_show_from_batch("test-batch", file="file1.txt")
+        capsys.readouterr()
 
-        with patch("git_stage_batch.data.hunk_tracking.require_selected_hunk"):
-            with patch("git_stage_batch.data.line_state.load_line_changes_from_state", return_value=mock_lines):
-                # Use --file mode to stage from batch (should only stage file1)
-                command_include_from_batch("test-batch", file="")
+        command_include_from_batch("test-batch", file="")
 
         # Verify only file1 is staged (not file2)
         result = run_git_command(["diff", "--cached", "--name-only"])

--- a/tests/commands/test_include_to.py
+++ b/tests/commands/test_include_to.py
@@ -3,8 +3,11 @@
 from git_stage_batch.commands.include import command_include_to_batch
 from git_stage_batch.commands.again import command_again
 from git_stage_batch.batch import list_batch_files, read_file_from_batch
+from git_stage_batch.batch.query import read_batch_metadata
 from git_stage_batch.batch.validation import batch_exists
+from git_stage_batch.data.session import initialize_abort_state
 from git_stage_batch.exceptions import NoMoreHunks
+from git_stage_batch.utils.paths import ensure_state_directory_exists
 
 import subprocess
 
@@ -169,6 +172,44 @@ class TestCommandIncludeToBatch:
             text=True
         )
         assert result.stdout == ""
+
+    def test_include_empty_added_text_file_to_batch(self, temp_git_repo):
+        """Whole-file include to batch should persist empty added text files."""
+        empty_file = temp_git_repo / "empty.txt"
+        empty_file.write_bytes(b"")
+
+        command_start(quiet=True)
+        command_include_to_batch("empty-batch", file="empty.txt", quiet=True)
+
+        file_meta = read_batch_metadata("empty-batch")["files"]["empty.txt"]
+        assert file_meta["change_type"] == "added"
+        assert read_file_from_batch("empty-batch", "empty.txt") == ""
+        assert empty_file.exists()
+
+        command_again(quiet=True)
+        with pytest.raises(NoMoreHunks):
+            fetch_next_change()
+
+    def test_include_empty_deleted_text_file_to_batch(self, temp_git_repo):
+        """Whole-file include to batch should persist empty text deletions."""
+        empty_file = temp_git_repo / "empty.txt"
+        empty_file.write_bytes(b"")
+        subprocess.run(["git", "add", "empty.txt"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add empty file"], check=True, cwd=temp_git_repo, capture_output=True)
+        empty_file.unlink()
+
+        ensure_state_directory_exists()
+        initialize_abort_state()
+        command_include_to_batch("empty-delete-batch", file="empty.txt", quiet=True)
+
+        file_meta = read_batch_metadata("empty-delete-batch")["files"]["empty.txt"]
+        assert file_meta["change_type"] == "deleted"
+        assert read_file_from_batch("empty-delete-batch", "empty.txt") is None
+        assert not empty_file.exists()
+
+        command_again(quiet=True)
+        with pytest.raises(NoMoreHunks):
+            fetch_next_change()
 
     def test_include_to_batch_auto_creates_batch(self, temp_git_repo):
         """Test that include to batch auto-creates batch if it doesn't exist."""

--- a/tests/commands/test_reset.py
+++ b/tests/commands/test_reset.py
@@ -4,6 +4,9 @@ import subprocess
 
 import pytest
 
+import git_stage_batch.commands.reset as reset_module
+import git_stage_batch.commands.show_from as show_from_module
+import git_stage_batch.data.hunk_tracking as hunk_tracking_module
 from git_stage_batch.batch.ownership import BatchOwnership, DeletionClaim
 from git_stage_batch.batch.query import read_batch_metadata
 from git_stage_batch.batch.storage import add_file_to_batch, read_file_from_batch
@@ -11,11 +14,27 @@ from git_stage_batch.commands.again import command_again
 from git_stage_batch.commands.include import command_include_to_batch
 from git_stage_batch.commands.new import command_new_batch
 from git_stage_batch.commands.reset import command_reset_from_batch
+from git_stage_batch.commands.show_from import command_show_from_batch
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.core.line_selection import parse_line_selection
+from git_stage_batch.core.models import RenderedBatchDisplay, ReviewActionGroup
 from git_stage_batch.data.batch_sources import create_batch_source_commit, save_session_batch_sources
-from git_stage_batch.data.hunk_tracking import fetch_next_change
+from git_stage_batch.data.hunk_tracking import fetch_next_change, render_batch_file_display
 from git_stage_batch.exceptions import CommandError, NoMoreHunks
+
+
+_RESET_ACTIONS = ("reset-from-batch",)
+
+
+def _review_action_groups_from_map(gutter_to_selection_id: dict[int, int]) -> tuple[ReviewActionGroup, ...]:
+    return tuple(
+        ReviewActionGroup(
+            display_ids=(gutter_id,),
+            selection_ids=(selection_id,),
+            actions=_RESET_ACTIONS,
+        )
+        for gutter_id, selection_id in gutter_to_selection_id.items()
+    )
 
 
 @pytest.fixture
@@ -117,6 +136,269 @@ class TestResetFromBatch:
         for range_str in batch_ownership_after.get("claimed_lines", []):
             batch_line_ids_after.update(parse_line_selection(range_str))
         assert batch_line_ids_after == {1, 3}
+
+    def test_reset_line_claims_translate_batch_review_gutter_ids(self, temp_git_repo, monkeypatch):
+        """Reset --line should use user-visible batch review gutter IDs."""
+        test_file = temp_git_repo / "test.py"
+        test_file.write_text("line 1\nline 2\nline 3\n")
+        subprocess.run(["git", "add", "test.py"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add test.py"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        test_file.write_text("line 1 modified\nline 2\nline 3 modified\n")
+        command_new_batch("mybatch", "test batch")
+        command_start()
+        add_file_to_batch(
+            "mybatch",
+            "test.py",
+            BatchOwnership(claimed_lines=["1", "3"], deletions=[]),
+            "100644",
+        )
+
+        original_render = reset_module.render_batch_file_display
+
+        def render_with_shifted_gutter(batch_name, file_path, metadata=None):
+            rendered = original_render(batch_name, file_path, metadata=metadata)
+            assert rendered is not None
+            gutter_to_selection_id = {1: 2, 2: 1}
+            selection_id_to_gutter = {2: 1, 1: 2}
+            return RenderedBatchDisplay(
+                line_changes=rendered.line_changes,
+                gutter_to_selection_id=gutter_to_selection_id,
+                selection_id_to_gutter=selection_id_to_gutter,
+                actionable_selection_groups=rendered.actionable_selection_groups,
+                review_gutter_to_selection_id=gutter_to_selection_id,
+                review_selection_id_to_gutter=selection_id_to_gutter,
+                review_action_groups=_review_action_groups_from_map(gutter_to_selection_id),
+            )
+
+        monkeypatch.setattr(reset_module, "render_batch_file_display", render_with_shifted_gutter)
+        monkeypatch.setattr(show_from_module, "render_batch_file_display", render_with_shifted_gutter)
+        monkeypatch.setattr(hunk_tracking_module, "render_batch_file_display", render_with_shifted_gutter)
+
+        command_show_from_batch("mybatch", file="test.py", page="all")
+
+        command_reset_from_batch("mybatch", line_ids="1", file="test.py")
+
+        metadata_after = read_batch_metadata("mybatch")
+        batch_ownership_after = metadata_after["files"]["test.py"]
+        batch_line_ids_after = set()
+        for range_str in batch_ownership_after.get("claimed_lines", []):
+            batch_line_ids_after.update(parse_line_selection(range_str))
+        assert batch_line_ids_after == {1}
+
+    def test_reset_line_claims_reject_mixed_fresh_review_and_raw_ids(self, temp_git_repo, monkeypatch):
+        """Fresh review IDs must not silently fall back to raw batch display IDs."""
+        test_file = temp_git_repo / "test.py"
+        test_file.write_text("line 1\nline 2\nline 3\n")
+        subprocess.run(["git", "add", "test.py"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add test.py"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        test_file.write_text("line 1 modified\nline 2\nline 3 modified\n")
+        command_new_batch("mybatch", "test batch")
+        command_start()
+        add_file_to_batch(
+            "mybatch",
+            "test.py",
+            BatchOwnership(claimed_lines=["1", "3"], deletions=[]),
+            "100644",
+        )
+
+        original_render = reset_module.render_batch_file_display
+
+        def render_with_shifted_gutter(batch_name, file_path, metadata=None):
+            rendered = original_render(batch_name, file_path, metadata=metadata)
+            assert rendered is not None
+            gutter_to_selection_id = {1: 2, 2: 1}
+            selection_id_to_gutter = {2: 1, 1: 2}
+            return RenderedBatchDisplay(
+                line_changes=rendered.line_changes,
+                gutter_to_selection_id=gutter_to_selection_id,
+                selection_id_to_gutter=selection_id_to_gutter,
+                actionable_selection_groups=rendered.actionable_selection_groups,
+                review_gutter_to_selection_id=gutter_to_selection_id,
+                review_selection_id_to_gutter=selection_id_to_gutter,
+                review_action_groups=_review_action_groups_from_map(gutter_to_selection_id),
+            )
+
+        monkeypatch.setattr(reset_module, "render_batch_file_display", render_with_shifted_gutter)
+        monkeypatch.setattr(show_from_module, "render_batch_file_display", render_with_shifted_gutter)
+        monkeypatch.setattr(hunk_tracking_module, "render_batch_file_display", render_with_shifted_gutter)
+
+        command_show_from_batch("mybatch", file="test.py", page="all")
+
+        with pytest.raises(CommandError, match="not valid from the current file review"):
+            command_reset_from_batch("mybatch", line_ids="1,99", file="test.py")
+
+        metadata_after = read_batch_metadata("mybatch")
+        batch_ownership_after = metadata_after["files"]["test.py"]
+        batch_line_ids_after = set()
+        for range_str in batch_ownership_after.get("claimed_lines", []):
+            batch_line_ids_after.update(parse_line_selection(range_str))
+        assert batch_line_ids_after == {1, 3}
+
+    def test_reset_line_claims_reject_stale_review_before_raw_id_fallback(self, temp_git_repo, monkeypatch):
+        """Stale review gutter IDs must not be reinterpreted as raw batch IDs."""
+        test_file = temp_git_repo / "test.py"
+        test_file.write_text("line 1\nline 2\n")
+        subprocess.run(["git", "add", "test.py"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add test.py"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        test_file.write_text("line 1 modified\nline 2 modified\n")
+        command_new_batch("mybatch", "test batch")
+        command_start()
+        add_file_to_batch(
+            "mybatch",
+            "test.py",
+            BatchOwnership(claimed_lines=["1", "2"], deletions=[]),
+            "100644",
+        )
+
+        original_render = reset_module.render_batch_file_display
+
+        def render_with_shifted_gutter(batch_name, file_path, metadata=None):
+            rendered = original_render(batch_name, file_path, metadata=metadata)
+            assert rendered is not None
+            gutter_to_selection_id = {1: 2, 2: 1}
+            selection_id_to_gutter = {2: 1, 1: 2}
+            return RenderedBatchDisplay(
+                line_changes=rendered.line_changes,
+                gutter_to_selection_id=gutter_to_selection_id,
+                selection_id_to_gutter=selection_id_to_gutter,
+                actionable_selection_groups=rendered.actionable_selection_groups,
+                review_gutter_to_selection_id=gutter_to_selection_id,
+                review_selection_id_to_gutter=selection_id_to_gutter,
+                review_action_groups=_review_action_groups_from_map(gutter_to_selection_id),
+            )
+
+        def render_with_raw_gutter(batch_name, file_path, metadata=None):
+            rendered = original_render(batch_name, file_path, metadata=metadata)
+            assert rendered is not None
+            gutter_to_selection_id = {1: 1, 2: 2}
+            selection_id_to_gutter = {1: 1, 2: 2}
+            return RenderedBatchDisplay(
+                line_changes=rendered.line_changes,
+                gutter_to_selection_id=gutter_to_selection_id,
+                selection_id_to_gutter=selection_id_to_gutter,
+                actionable_selection_groups=rendered.actionable_selection_groups,
+                review_gutter_to_selection_id=gutter_to_selection_id,
+                review_selection_id_to_gutter=selection_id_to_gutter,
+                review_action_groups=_review_action_groups_from_map(gutter_to_selection_id),
+            )
+
+        monkeypatch.setattr(reset_module, "render_batch_file_display", render_with_shifted_gutter)
+        monkeypatch.setattr(show_from_module, "render_batch_file_display", render_with_shifted_gutter)
+        monkeypatch.setattr(hunk_tracking_module, "render_batch_file_display", render_with_shifted_gutter)
+
+        command_show_from_batch("mybatch", file="test.py", page="all")
+
+        monkeypatch.setattr(hunk_tracking_module, "render_batch_file_display", render_with_raw_gutter)
+
+        with pytest.raises(CommandError, match="no longer matches"):
+            command_reset_from_batch("mybatch", line_ids="1", file="test.py")
+
+        metadata_after = read_batch_metadata("mybatch")
+        batch_ownership_after = metadata_after["files"]["test.py"]
+        batch_line_ids_after = set()
+        for range_str in batch_ownership_after.get("claimed_lines", []):
+            batch_line_ids_after.update(parse_line_selection(range_str))
+        assert batch_line_ids_after == {1, 2}
+
+    def test_reset_line_claims_do_not_require_live_mergeability(self, temp_git_repo):
+        """Resetting batch metadata should not depend on current worktree mergeability."""
+        test_file = temp_git_repo / "test.py"
+        test_file.write_text("line 1\nline 2\n")
+        subprocess.run(["git", "add", "test.py"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add test.py"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        test_file.write_text("line 1 modified\nline 2\n")
+        command_start()
+        fetch_next_change()
+        command_include_to_batch("mybatch", line_ids="2", quiet=True)
+
+        test_file.write_text("totally different\ncontent\n")
+        rendered = render_batch_file_display("mybatch", "test.py")
+        assert rendered is not None
+        assert rendered.gutter_to_selection_id == {}
+
+        command_reset_from_batch("mybatch", line_ids="1", file="test.py")
+
+        metadata_after = read_batch_metadata("mybatch")
+        assert "test.py" not in metadata_after.get("files", {})
+
+    def test_reset_line_claims_after_review_do_not_require_live_mergeability(self, temp_git_repo):
+        """A fresh batch review should not make reset depend on mergeability."""
+        test_file = temp_git_repo / "test.py"
+        test_file.write_text("line 1\nline 2\n")
+        subprocess.run(["git", "add", "test.py"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add test.py"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        test_file.write_text("line 1 modified\nline 2\n")
+        command_start()
+        fetch_next_change()
+        command_include_to_batch("mybatch", line_ids="2", quiet=True)
+
+        test_file.write_text("totally different\ncontent\n")
+        rendered = render_batch_file_display("mybatch", "test.py")
+        assert rendered is not None
+        assert rendered.gutter_to_selection_id == {}
+
+        command_show_from_batch("mybatch", file="test.py", page="all")
+        command_reset_from_batch("mybatch", line_ids="1", file="test.py")
+
+        metadata_after = read_batch_metadata("mybatch")
+        assert "test.py" not in metadata_after.get("files", {})
+
+    def test_reset_line_claims_after_review_ignore_later_worktree_changes(self, temp_git_repo):
+        """Reset review IDs should stay valid when only mergeability changes."""
+        test_file = temp_git_repo / "test.py"
+        test_file.write_text("line 1\nline 2\n")
+        subprocess.run(["git", "add", "test.py"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add test.py"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        test_file.write_text("line 1 modified\nline 2\n")
+        command_new_batch("mybatch", "test batch")
+        command_start()
+        add_file_to_batch(
+            "mybatch",
+            "test.py",
+            BatchOwnership(claimed_lines=["1"], deletions=[]),
+            "100644",
+        )
+
+        test_file.write_text("line 1\nline 2\n")
+        command_show_from_batch("mybatch", file="test.py", page="all")
+        test_file.write_text("totally different\ncontent\n")
+
+        command_reset_from_batch("mybatch", line_ids="1", file="test.py")
+
+        metadata_after = read_batch_metadata("mybatch")
+        assert "test.py" not in metadata_after.get("files", {})
+
+    def test_pathless_reset_line_claims_after_review_ignore_later_worktree_changes(self, temp_git_repo):
+        """Pathless reset review IDs should not depend on live mergeability."""
+        test_file = temp_git_repo / "test.py"
+        test_file.write_text("line 1\nline 2\n")
+        subprocess.run(["git", "add", "test.py"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add test.py"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        test_file.write_text("line 1 modified\nline 2\n")
+        command_new_batch("mybatch", "test batch")
+        command_start()
+        add_file_to_batch(
+            "mybatch",
+            "test.py",
+            BatchOwnership(claimed_lines=["1"], deletions=[]),
+            "100644",
+        )
+
+        test_file.write_text("line 1\nline 2\n")
+        command_show_from_batch("mybatch", file="test.py", page="all")
+        test_file.write_text("totally different\ncontent\n")
+
+        command_reset_from_batch("mybatch", line_ids="1")
+
+        metadata_after = read_batch_metadata("mybatch")
+        assert "test.py" not in metadata_after.get("files", {})
 
     def test_reset_with_multiple_batches(self, temp_git_repo):
         """Test that reset only makes hunks visible if not claimed by other batches."""

--- a/tests/commands/test_show_from.py
+++ b/tests/commands/test_show_from.py
@@ -2,6 +2,7 @@
 
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.commands.include import command_include_to_batch
+from git_stage_batch.commands.show import command_show
 from git_stage_batch.batch.ownership import BatchOwnership
 from git_stage_batch.batch.storage import add_file_to_batch
 from git_stage_batch.batch.ownership import DeletionClaim
@@ -9,6 +10,7 @@ from git_stage_batch.data.hunk_tracking import render_batch_file_display
 import git_stage_batch.batch.merge as merge_module
 import git_stage_batch.batch.display as display_module
 import git_stage_batch.data.hunk_tracking as hunk_tracking
+import git_stage_batch.commands.show_from as show_from_module
 
 import subprocess
 
@@ -227,8 +229,8 @@ class TestCommandShowFromBatch:
         assert rendered is not None
         assert len(calls) == 1
 
-    def test_show_from_multi_file_caches_first_render_without_rerendering(self, temp_git_repo, monkeypatch, capsys):
-        """Showing all files should not render the first file twice for cache state."""
+    def test_show_from_multi_file_list_renders_each_file_once(self, temp_git_repo, monkeypatch, capsys):
+        """Showing a multi-file batch file list should render each file once."""
 
         (temp_git_repo / "file1.txt").write_text("line 1\nline 2\n")
         (temp_git_repo / "file2.txt").write_text("line A\nline B\n")
@@ -250,8 +252,39 @@ class TestCommandShowFromBatch:
             rendered_files.append(file_path)
             return original_render(batch_name, file_path, metadata=metadata)
 
-        monkeypatch.setattr(hunk_tracking, "render_batch_file_display", counting_render)
+        monkeypatch.setattr(show_from_module, "render_batch_file_display", counting_render)
 
         command_show_from_batch("multi-file-batch")
 
         assert rendered_files == ["file1.txt", "file2.txt"]
+        captured = capsys.readouterr()
+        assert "── matched files" in captured.out
+
+    def test_non_selectable_multi_file_batch_preview_preserves_selection(self, temp_git_repo, capsys):
+        """A non-selectable multi-file batch preview should not clear selected state."""
+        readme = temp_git_repo / "README.md"
+        readme.write_text("# Test\nselected\n")
+        command_show()
+        capsys.readouterr()
+        assert hunk_tracking.get_selected_change_file_path() == "README.md"
+
+        (temp_git_repo / "file1.txt").write_text("one\n")
+        (temp_git_repo / "file2.txt").write_text("two\n")
+        create_batch("multi-file-batch")
+        add_file_to_batch(
+            "multi-file-batch",
+            "file1.txt",
+            BatchOwnership(claimed_lines=["1"], deletions=[]),
+            "100644",
+        )
+        add_file_to_batch(
+            "multi-file-batch",
+            "file2.txt",
+            BatchOwnership(claimed_lines=["1"], deletions=[]),
+            "100644",
+        )
+
+        command_show_from_batch("multi-file-batch", selectable=False)
+        capsys.readouterr()
+
+        assert hunk_tracking.get_selected_change_file_path() == "README.md"


### PR DESCRIPTION
The batch system now tracks text lifecycle metadata, file modes, and
binary progress across include, discard, apply, and sift workflows.
CLI option naming and session start behavior are also in place.

Several command paths still resolve file scope and line selections
from raw batch display IDs. Multi-file batch and live output expand
every matching file rather than treating file lists as navigation.
Commands that follow bare actions after a file list can silently
operate on a file chosen by output traversal rather than by explicit
review. The program also lacks shared models for page-aware file
reviews and review-level selection grouping.

This series addresses those gaps across 22 commits:

- **Empty text lifecycle** preserves added and deleted empty-file
  states in whole-file include-to and discard-to paths, and omits
  synthetic trailing newlines from empty discard results.
- **File-review selection atoms** add ActionableSelection derivation
  and ReviewActionGroup metadata to the core models, laying groundwork
  for page-aware file reviews.
- **CLI scope resolution** moves file-pattern and replacement-text
  reads into the operation branches that consume them, preventing
  batch-source commands from matching live files and invalid
  replacement forms from consuming stdin early.
- **Positive selection parsing** extracts a generic numeric-range
  parser with custom item names so page IDs can reuse the same syntax
  as line IDs.
- **File review state models** add data and output modules for
  page-aware file reviews, selected-state path helpers, and clear
  markers for review state.
- **Selected change tracking** adds clear reasons and guard helpers
  so commands can distinguish no selection from a file-list clear or
  stale batch selection.
- **Live and batch navigation** treats multi-file output as
  navigational file lists that clear selected state, requiring an
  explicit file open before bare follow-up actions.
- **Batch review scope** routes include-from, discard-from, apply-from,
  and reset through a shared review scope resolver with gutter-ID
  translation.
- **Implicit file resolution** reads selected-change state instead of
  raw text line state for batch file-scope resolution.

Each functional area has corresponding test coverage.