### PR TITLE
Add page-aware file review workflows

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -35,7 +35,7 @@ The codebase is organized as a set of layers:
   User-facing command implementations.
 - `data/`
   Session-persistent state, selected-hunk caches, progress tracking, undo/redo,
-  and other workflow bookkeeping.
+  page-aware file review safety state, and other workflow bookkeeping.
 - `core/`
   Neutral models and parsing logic for diffs, hunks, hashes, and line
   selections.
@@ -46,7 +46,8 @@ The codebase is organized as a set of layers:
   The advanced named-batch subsystem: ownership, storage, merge, attribution,
   source refresh, and batch-specific selection logic.
 - `output/`
-  Rendering of hunks, patches, and colors for terminal display.
+  Rendering of hunks, page-aware file reviews, multi-file review lists,
+  patches, and colors for terminal display.
 - `tui/`
   The interactive single-key interface built on top of the command layer.
 - `utils/`
@@ -83,6 +84,17 @@ For a typical non-batch staging workflow:
 The program therefore behaves like a state machine spread across CLI
 invocations. The on-disk state in `data/` is what keeps the workflow coherent.
 
+File-scoped `show --file` and single-file `show --from <batch> --file` add a
+page-aware review layer on top of the selected-change cache. Large file reviews
+can show only one page or a page range. When not all pages are shown, pathless
+or omitted-path actions such as `include`, `skip`, `discard`, or `include
+--file` without a path refuse unless the user names a file explicitly or selects
+complete actionable changes that were actually shown. Multi-file `show --files`
+and multi-file `show --from <batch>` are navigational lists; they intentionally
+clear selected-change state instead of leaving a hidden selected file behind,
+and later pathless or omitted-path actions refuse until the user shows a hunk or
+opens one listed file.
+
 ## Core Representation of Changes
 
 The `core/` package defines the models and parsing logic used throughout the
@@ -118,6 +130,8 @@ It stores information such as:
 - the starting `HEAD`
 - stash-like abort restoration data
 - the currently selected hunk or file
+- the last page-aware file review, including which pages and complete
+  actionable selections were shown
 - included, skipped, or discarded progress
 - iteration state for `again`
 - undo/redo checkpoints
@@ -134,6 +148,10 @@ Important modules include:
   Undo/redo checkpoints for session operations.
 - `data.line_state`
   Serialization of the currently selected line-level view.
+- `data.file_review_state`
+  Safety metadata for page-aware file reviews. It records the review source,
+  shown pages, complete actionable selections, and fingerprints of the selected
+  file view so later pathless actions can refuse stale or ambiguous operations.
 - `data.progress`, `data.file_tracking`, `data.hunk_tracking`
   Progress bookkeeping across files and hunks.
 
@@ -227,7 +245,8 @@ Key modules:
 The program separates data modeling from terminal rendering.
 
 - `output/`
-  Knows how to print line-level changes, binary changes, patches, and colors.
+  Knows how to print line-level changes, page-aware file reviews, multi-file
+  review lists, binary changes, patches, and colors.
 - `tui/`
   Adds the interactive menu-driven front end.
 
@@ -290,6 +309,11 @@ A recurring theme in the codebase is conservative refusal.
 This shows up in several places:
 
 - stale selected hunks are rejected and recalculated
+- stale or mismatched file-review safety state is rejected before pathless or
+  omitted-path line actions are accepted
+- partial file reviews block ambiguous pathless or omitted-path actions until
+  the user shows all pages, names the file explicitly, or selects complete shown
+  changes
 - batch merge paths fail when structure is ambiguous
 - atomic ownership units cannot be partially selected
 - abort snapshots are captured up front so destructive operations can be rolled

--- a/BATCHES.md
+++ b/BATCHES.md
@@ -44,7 +44,7 @@ newer code.
 
 Concretely, a batch can later:
 
-- stage its changes into the index
+- stage its changes into the index and working tree
 - apply its changes back to the working tree
 - discard its changes from the working tree
 - move or reset its claims
@@ -178,6 +178,7 @@ Per text file:
 - `deletions`
 - `replacement_units` (optional; omitted when empty)
 - `mode`
+- `change_type` (optional; `added` or `deleted` for whole-path lifecycle changes)
 
 Per binary file:
 
@@ -191,6 +192,10 @@ Per binary file:
 deletion indexes so replacement atomicity does not need to be rediscovered from
 display adjacency. The field is omitted when no explicit replacement units are
 stored.
+Text `change_type` is omitted for ordinary modified-file batches. It is only
+stored when a text batch owns the whole added path or the whole deleted path;
+deleted text paths are absent from the batch content tree just like deleted
+binary paths.
 
 ---
 
@@ -318,13 +323,14 @@ working tree right now?"
 
 The user-facing commands that consume this model fall into three groups:
 
-- commands that stage batch content into the index
+- commands that stage batch content into the index and working tree
 - commands that apply batch content to the working tree
 - commands that remove batch content from the working tree
 
 ### `include --from`
 
-`include --from <batch>` stages batch content into the index.
+`include --from <batch>` stages batch content into the index and writes it to
+the working tree.
 
 Implementation:
 
@@ -336,13 +342,14 @@ For each file, the command:
 1. reads batch metadata
 2. reads the file's batch source content
 3. optionally narrows ownership by display line IDs or file scope
-4. merges source constraints into current working-tree bytes with `merge_batch()`
-5. writes the result to the index
+4. merges source constraints into current index bytes with `merge_batch()`
+5. merges source constraints into current working-tree bytes with `merge_batch()`
+6. writes the merged targets to the index and working tree
 
 ### `apply --from`
 
 `apply --from <batch>` uses the same merge model, but writes the merged result
-to the working tree instead of the index.
+only to the working tree, leaving the index untouched.
 
 Implementation:
 
@@ -503,7 +510,14 @@ Two different mechanisms drive what the user sees:
 ownership using `build_display_lines_from_batch_source()` in
 `src/git_stage_batch/batch/display.py`.
 
-That reconstructed view contains:
+For a single file, the command caches that reconstructed view as a selected
+batch-file view and renders it through the page-aware file review output. For
+multiple files, `show --from <batch>` prints a navigational file list instead
+of caching one hidden selected file. Pathless or omitted-path actions after
+that list refuse until the user opens a specific file with
+`show --from <batch> --file <path>`.
+
+The reconstructed single-file view contains:
 
 - claimed lines
 - deleted lines represented from deletion claims
@@ -511,7 +525,28 @@ That reconstructed view contains:
 - ephemeral display IDs
 
 Those display IDs are not source line numbers. They are UI identifiers used for
-line-level batch operations.
+line-level batch operations. Batch display has two related line-ID spaces:
+
+- mergeable gutter IDs, used by historical line actions when there is no fresh
+  matching file review
+- review gutter IDs, used by page-aware file reviews
+
+The review gutter ID space can include resettable lines that are not currently
+mergeable into the working tree. Review selections therefore persist
+action-specific groups: `include --from`, `apply --from`, and `discard --from`
+only accept groups that are mergeable for that action, while `reset --from` can
+also accept reset-only groups.
+
+Page-aware batch reviews also persist short-lived safety state in
+`data.file_review_state`. That state records the batch name, file path, shown
+pages, complete action-specific review selections, and fingerprints of the
+selected batch view. Pathless line actions from batch commands, the
+corresponding omitted-path `--file` forms, and explicit `--file <path> --line`
+forms with a fresh matching review validate against this state so users cannot
+accidentally act on unshown pages, stale display IDs, or a selection that is not
+supported by the requested action. Whole-file batch actions may use the reviewed
+file only after a fresh full-file review; partial reviews refuse until all pages
+are shown or the file path is named explicitly.
 
 This is an important separation of concerns:
 

--- a/STORAGE.md
+++ b/STORAGE.md
@@ -320,6 +320,7 @@ Git-backed state ref exists. It records:
 * Per-file ownership
 * Per-file source snapshot commit
 * Per-file mode
+* Text file lifecycle markers when a batch owns a whole added/deleted path
 * Binary file markers when needed
 
 Example:
@@ -335,6 +336,15 @@ Example:
       "claimed_lines": ["10-12"],
       "deletions": [],
       "mode": "100644"
+    },
+    "src/removed.py": {
+      "batch_source_commit": "fed456...",
+      "claimed_lines": [],
+      "deletions": [
+        {"after_source_line": null, "blob": "789abc..."}
+      ],
+      "mode": "100644",
+      "change_type": "deleted"
     }
   }
 }
@@ -352,6 +362,10 @@ model used to reconstruct and validate a batch:
 * `replacement_units` optionally links claimed ranges to deletion indexes for
   explicit replacement atomicity. It is omitted when empty.
 * `mode` defines the file mode for realized content.
+* `change_type` is optional for text files and omitted for ordinary modified
+  content. `added` means the batch owns the whole added text path. `deleted`
+  means the batch owns the whole removed text path, and the path is omitted
+  from the batch content ref.
 
 ### Limitations
 
@@ -717,9 +731,11 @@ hunk.hash.txt
 hunk.patch
 hunk.lines.json
 change-kind.txt
+clear-reason.txt
 binary-file.json
 index.snapshot
 working-tree.snapshot
+file-review.json
 ```
 
 ### `hunk.patch`
@@ -751,6 +767,13 @@ Stores whether the selected cached item is a text hunk, a file-scoped view, a
 binary file, or a batch-file view. Commands use it to decide how to interpret
 the rest of the selected-state cache.
 
+### `clear-reason.txt`
+
+Stores why selected-change state was intentionally cleared. Multi-file review
+lists write `file-list` here after clearing the selected cache so later bare
+`include`, `skip`, `discard`, omitted-path `--file`, or batch-from actions
+refuse instead of auto-selecting the next hunk or hidden file.
+
 ### `index.snapshot`
 
 Stores the file's index bytes when the hunk is selected.
@@ -758,6 +781,30 @@ Stores the file's index bytes when the hunk is selected.
 ### `working-tree.snapshot`
 
 Stores the file's working tree bytes when the hunk is selected.
+
+### `file-review.json`
+
+Stores short-lived safety state for the most recent page-aware file review. It
+is not the selected change itself; it is a guardrail layered on top of the
+selected hunk/file cache.
+
+The file records:
+
+* The review source: live file-vs-HEAD, unstaged, or batch.
+* The batch name for batch reviews.
+* The file path, page count, shown pages, and whether the full file was shown.
+* Complete actionable line selections that were visible in the shown pages.
+* Fingerprints of the selected file view and rendered diff.
+
+Pathless and omitted-path line actions use this file to make sure requested
+display IDs still refer to the same shown review. Pathless or omitted-path
+whole-file actions use it to refuse after partial reviews, where acting on the
+whole selected file would be ambiguous.
+
+Multi-file review lists deliberately clear this file and the selected-change
+cache, then record `clear-reason.txt`; they are navigation, not selection.
+Invalid explicit page requests are validated before rewriting selected state, so
+a mistyped page number does not silently select a file or batch-file view.
 
 ### Staleness Detection
 
@@ -768,6 +815,12 @@ the operation is rejected.
 Batch hunks and file-scoped live operations do not use these staleness
 snapshots in the same way, because they are rendered from batch state or live
 working tree state rather than from the cached selected hunk.
+
+Page-aware file-review freshness is tracked separately by `file-review.json`.
+The persisted fingerprints include the selected line-level view and, for live
+reviews, the index and working-tree snapshots. Batch review validation also
+re-renders the batch file to verify the gutter-to-selection-ID mapping before
+accepting pathless or omitted-path batch line actions.
 
 ---
 

--- a/completions/git-stage-batch
+++ b/completions/git-stage-batch
@@ -80,12 +80,12 @@ _git_stage_batch()
                     __git_stage_batch_set_nospace_for_dirs
                     return
                     ;;
-                --line)
+                --line|--page|--pages)
                     # Line IDs - no completion
                     return
                     ;;
             esac
-            COMPREPLY=($(compgen -W "--porcelain --from --file --files --line" -- "$cur"))
+            COMPREPLY=($(compgen -W "--porcelain --from --file --files --line --page --pages" -- "$cur"))
             ;;
         include)
             case "$prev" in

--- a/docs/ai-assistants.md
+++ b/docs/ai-assistants.md
@@ -242,9 +242,9 @@ fi
 
 # Get structured status
 status=$(git-stage-batch status --porcelain)
-echo "$status" | jq '.selected_hunk'
-echo "$status" | jq '.remaining_line_ids'
-echo "$status" | jq '.blocked_hunks'
+echo "$status" | jq '.selected_change'
+echo "$status" | jq '.file_review'
+echo "$status" | jq '.progress.remaining'
 ```
 
 ## Tips for AI Configuration

--- a/docs/batches.md
+++ b/docs/batches.md
@@ -169,35 +169,41 @@ file list and does not leave a hidden selected batch file behind.
 
 ## `include --from BATCH`
 
-Stage the changes from a batch to the index.
+Stage the changes from a batch to the index and write them to the working tree.
 
 **Stage entire batch:**
 ```
 ❯ git-stage-batch include --from batch-name
 ```
 
-Applies the batch's accumulated changes to the index, staging them for commit.
+Applies the batch's accumulated changes to the index and working tree, staging
+them for commit.
 
 **Line-level staging:**
 ```
 ❯ git-stage-batch include --from batch-name --line 1-5
 ```
 
-Stage only specific lines from the batch, allowing partial application of batch changes.
+Stage only specific lines from the batch, allowing partial application of batch
+changes to the index and working tree.
 
 **File-level staging (selected file):**
 ```
 ❯ git-stage-batch include --from batch-name --file
 ```
 
-Stage changes from the batch for the selected hunk's file only. Use this during a staging session when you want to pull in batch changes for the file you're reviewing, without affecting other files in the batch.
+Stage changes from the batch for the selected hunk's file only. Use this during
+a staging session when you want to pull in batch changes for the file you're
+reviewing, without affecting other files in the batch.
 
 **File-level staging (specific file):**
 ```
 ❯ git-stage-batch include --from batch-name --file src/config.py
 ```
 
-Stage changes from the batch for `src/config.py` only, without needing a selected hunk. Useful for applying specific files from multi-file batches outside of an active staging session.
+Stage changes from the batch for `src/config.py` only, without needing a
+selected hunk. Useful for applying specific files from multi-file batches
+outside of an active staging session.
 
 **Pattern-based staging:**
 ```bash
@@ -305,7 +311,9 @@ Apply batch changes to the working tree without staging them.
 ❯ git-stage-batch apply --from batch-name
 ```
 
-Applies the batch's accumulated changes to your working tree, leaving the index untouched. This is different from `include --from` which stages changes to the index.
+Applies the batch's accumulated changes to your working tree, leaving the index
+untouched. This is different from `include --from`, which writes the selected
+batch changes to both the index and working tree.
 
 **Use cases:**
 - Temporarily applying batched changes to test them before committing
@@ -349,9 +357,9 @@ Apply batch changes for `src/debug.py` only to the working tree, without needing
     filter to a specific file, or `--line` to apply only specific lines.
 
 !!! info "Working Tree Only"
-    Unlike `include --from`, this command modifies only the working tree and leaves
-    the index (staging area) untouched. Use this when you want to preview or test
-    changes before staging them.
+    Unlike `include --from`, this command modifies only the working tree and
+    leaves the index (staging area) untouched. Use this when you want to preview
+    or test changes before staging them.
 
 **Example workflow:**
 ```bash

--- a/docs/batches.md
+++ b/docs/batches.md
@@ -146,7 +146,9 @@ Show the accumulated changes stored in a batch.
 ❯ git-stage-batch show --from batch-name
 ```
 
-Displays the diff representing all changes accumulated in the batch, showing what would be staged or discarded if you operate on the batch.
+Displays a matched-files list for multi-file batches. Open one listed file with
+`show --from batch-name --file PATH` to review its page-aware batch diff and
+use its line IDs.
 
 **Line-level filtering:**
 ```
@@ -160,7 +162,8 @@ Filter the display to show only specific line IDs from the batch.
 ❯ git-stage-batch show --from batch-name --files "src/**/*.py" "!src/vendor/**"
 ```
 
-When `--files` resolves to multiple files, only the final displayed file remains selected for later `--line` operations.
+When `--files` resolves to multiple files, `show --from` prints a navigational
+file list and does not leave a hidden selected batch file behind.
 
 ---
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -25,7 +25,7 @@ Resets state if a session is already in progress.
 
 ### `show [--file [PATH] | --files PATTERN...]`
 
-Display the cached "selected" hunk or an entire file's changes.
+Display the cached "selected" hunk, one file review, or a matched-files list.
 
 **Show selected hunk:**
 ```
@@ -42,12 +42,30 @@ Display the cached "selected" hunk or an entire file's changes.
 ❯ git-stage-batch show --file src/config.py
 ```
 
-**Show all changes from files matched by Git-style patterns:**
+**Show a review page from a file:**
+```bash
+❯ git-stage-batch show --file src/config.py --page 2
+❯ git-stage-batch show --file src/config.py --page 3-4
+❯ git-stage-batch show --file src/config.py --page all
+❯ git-stage-batch show --file src/config.py --pages 1,3,5
+```
+
+**Show files matched by Git-style patterns:**
 ```bash
 ❯ git-stage-batch show --files "src/**/*.py" "!src/vendor/**"
 ```
 
-When `--file` or `--files` is used, `show` displays all changes from the resolved file or files (all hunks merged into a unified view), rather than just the selected hunk. This is useful for reviewing all changes in a file before staging or discarding them.
+**Show files in a batch:**
+```bash
+❯ git-stage-batch show --from cleanup-ui
+❯ git-stage-batch show --from cleanup-ui --file src/config.py --page 2
+```
+
+When `--file` is used, `show` displays a structured file review with global line IDs, page orientation, and exact follow-up commands. By default, large file reviews are bounded to the first relevant page. Use `--page all` or `--pages all` to review the whole file.
+
+When `--files` resolves to multiple files, `show` prints a matched-files list with per-file change counts, changed-line counts, review page counts, and exact `show --file PATH` commands. This list is navigational: it does not select a hidden file for later bare actions.
+
+For multi-file batches, `show --from BATCH` uses the same matched-files list and repeats `--from BATCH` in the suggested open commands.
 
 **Options:**
 - `--file [PATH]`: Display entire file instead of single hunk
@@ -57,9 +75,13 @@ When `--file` or `--files` is used, `show` displays all changes from the resolve
   - Patterns follow Git's ignore matcher semantics, including `*`, `**`, `?`, character classes, and ordered `!` exclusions
   - Resolution is performed against the current changed-file set
   - `--file` and `--files` are mutually exclusive
+- `--page PAGES`, `--pages PAGES`: Show file-review pages, such as `2`, `3-4`, `1,3,5-7`, or `all`
+  - Requires `--file`, or `--files` resolving to exactly one changed file
+  - Cannot be combined with `--line`, multiple resolved `--files` matches, or `--porcelain`
 - `--porcelain`: Exit silently with status code only (no output)
+- `--from BATCH`: Show changes from a batch instead of live file-vs-HEAD changes
 
-When `--files` resolves to multiple files, `show` displays each file in order. Only the final displayed file remains selected for later `--line` operations, so earlier files are shown without selectable gutter IDs.
+When `--files` resolves to one file, `show` opens that single file review directly. When it resolves to multiple files, open one listed file with `show --file PATH` before using pathless `--line` actions.
 
 **Exit codes:**
 - `0` if hunk/file has changes

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -63,6 +63,8 @@ Display the cached "selected" hunk, one file review, or a matched-files list.
 
 When `--file` is used, `show` displays a structured file review with global line IDs, page orientation, and exact follow-up commands. By default, large file reviews are bounded to the first relevant page. Use `--page all` or `--pages all` to review the whole file.
 
+When only part of a file review has been shown, unqualified actions such as `include`, `skip`, and `discard` refuse. Use one of the shown pathless `--line` selections for a complete change, show the page range that covers the complete change, or use `--file PATH` for the whole file.
+
 When `--files` resolves to multiple files, `show` prints a matched-files list with per-file change counts, changed-line counts, review page counts, and exact `show --file PATH` commands. This list is navigational: it does not select a hidden file for later bare actions.
 
 For multi-file batches, `show --from BATCH` uses the same matched-files list and repeats `--from BATCH` in the suggested open commands.
@@ -182,14 +184,18 @@ Outputs JSON with stable fields for script integration:
 ```json
 {
   "session": {
+    "active": true,
     "iteration": 1,
+    "status": "in_progress",
     "in_progress": true
   },
-  "selected": {
+  "selected_change": {
+    "kind": "hunk",
     "file": "auth.py",
     "line": 42,
     "ids": [1, 2, 3]
   },
+  "file_review": null,
   "progress": {
     "included": 2,
     "skipped": 1,

--- a/docs/git-stage-batch.1.in
+++ b/docs/git-stage-batch.1.in
@@ -131,8 +131,10 @@ Displays iteration number, selected hunk location, progress metrics
 .TP
 .B \-\-porcelain
 Output in machine-readable JSON format for script integration.
-The JSON includes: session (iteration and in_progress flag), selected
-(selected hunk location or null), progress (counts), and skipped_hunks (array).
+The JSON includes: session (active, iteration, status, and in_progress),
+selected_change (selected hunk/file/batch-file/binary details or null),
+file_review (last page-aware review details or null), progress (counts), and
+skipped_hunks (array).
 .RE
 .SS Session Management
 .TP
@@ -235,9 +237,17 @@ Do not strip unchanged edge-overlap lines from replacement text.
 Stage TEXT as the full index content for the selected file-scoped path while
 leaving the working tree unchanged.
 .TP
+.B include \fR[\fB\-\-file \fIPATH\fR | \fB\-\-line \fILINE_IDS\fR]\fB \-\-as\-stdin
+Read replacement text from standard input exactly instead of from \fB\-\-as\fR.
+Preserves trailing newlines.
+.TP
 .B discard \-\-file \fIPATH\fR \-\-as \fITEXT\fR
 Replace the working-tree content for the selected file-scoped path with TEXT
 without staging it.
+.TP
+.B discard \fR[\fB\-\-file \fIPATH\fR | \fB\-\-to \fIBATCH\fR \fB\-\-line \fILINE_IDS\fR]\fB \-\-as\-stdin
+Read replacement text from standard input exactly instead of from \fB\-\-as\fR.
+Preserves trailing newlines.
 .TP
 .B discard \-\-to \fIBATCH\fR \-\-line \fILINE_IDS\fR \-\-as \fITEXT\fR
 Save replacement text to a batch and discard the original selected lines
@@ -365,11 +375,13 @@ The following commands accept \fB\-\-from\fR flags to work with batches:
 .B show \-\-from \fIBATCH\fR [\fB\-\-line\fR \fILINE_IDS\fR | \fB\-\-file\fR [\fIPATH\fR] | \fB\-\-files\fR \fIPATTERN\fR...]
 Show the accumulated changes stored in a batch.
 Use \fB\-\-line\fR to filter display to specific line IDs.
-Use \fB\-\-file\fR or \fB\-\-files\fR to limit display to specific batch files.
+Use \fB\-\-file\fR to open one page-aware batch file review.
+Use \fB\-\-files\fR to list matching batch files; multi-file lists are
+navigational and do not select a hidden batch file.
 .TP
 .B include \-\-from \fIBATCH\fR [\fB\-\-line\fR \fILINE_IDS\fR | \fB\-\-file\fR [\fIPATH\fR] | \fB\-\-files\fR \fIPATTERN\fR...]
-Stage the changes from a batch to the index. Fails if the batch's changes
-cannot be applied cleanly to the selected state.
+Stage the changes from a batch to the index and write them to the working tree.
+Fails if the batch's changes cannot be applied cleanly to the selected state.
 Use \fB\-\-line\fR to stage only specific lines from the batch.
 Use \fB\-\-file\fR to apply one file from the batch.
 Use \fB\-\-files\fR to apply all batch files matched by Git-style patterns.

--- a/docs/git-stage-batch.1.in
+++ b/docs/git-stage-batch.1.in
@@ -90,10 +90,15 @@ Reprint the cached "selected" hunk.
 Show all changes from one file. Without PATH, uses the selected hunk's file.
 .TP
 .B \-\-files \fIPATTERN\fR...
-Show all changes from files matched by Git-style patterns.
+Show files matched by Git-style patterns.
 Patterns use Git's ignore matcher semantics, including ordered \fB!\fR exclusions.
-When multiple files are shown, only the final displayed file remains selected
-for later \fB\-\-line\fR operations.
+When multiple files match, prints a navigational file list and does not leave
+a hidden selected file for later bare actions.
+.TP
+.B \-\-page \fIPAGES\fR, \-\-pages \fIPAGES\fR
+Show one or more file-review pages, such as \fB2\fR, \fB3-4\fR, or
+\fBall\fR. Requires \fB\-\-file\fR, or \fB\-\-files\fR resolving to exactly
+one file. Cannot be combined with \fB\-\-line\fR or \fB\-\-porcelain\fR.
 .TP
 .B \-\-porcelain
 Exit silently with status code only (0 if hunk exists, 1 if no hunk).

--- a/docs/index.md
+++ b/docs/index.md
@@ -182,7 +182,7 @@ Similar to `git add -p` but **more granular and flexible**:
 # Replacement text must use one contiguous displayed line-ID span
 ❯ git-stage-batch include --line 1-2 --as 'replacement'
 
-# Exact unchanged edge anchors are stripped by default for line-scoped --as
+# Exact unchanged edge-overlap lines are stripped by default for line-scoped --as
 ❯ git-stage-batch include --line 1-2 --as 'keep1\nreplacement\nkeep4'
 
 # Keep those edge-overlap lines literally with --no-edge-overlap

--- a/src/git_stage_batch/batch/selection.py
+++ b/src/git_stage_batch/batch/selection.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import TYPE_CHECKING, Optional
 
 from .ownership import (
@@ -19,6 +20,7 @@ from ..utils.file_patterns import resolve_gitignore_style_patterns
 if TYPE_CHECKING:
     from ..exceptions import AtomicUnitError
     from ..core.models import RenderedBatchDisplay
+    from ..data.file_review_state import FileReviewAction
 
 
 def resolve_batch_file_scope(
@@ -46,15 +48,13 @@ def resolve_batch_file_scope(
     """
     if file is not None:
         # Specific file requested
-        from ..data.hunk_tracking import get_batch_file_for_line_operation
+        from ..data.hunk_tracking import get_batch_file_for_line_operation, get_selected_change_file_path
 
         # If file is empty string, use selected hunk's file
         if file == "":
-            from ..data.line_state import load_line_changes_from_state
-            line_changes = load_line_changes_from_state()
-            if line_changes is None:
+            file_to_use = get_selected_change_file_path()
+            if file_to_use is None:
                 exit_with_error(_("No selected hunk. Run 'show' first or specify file path."))
-            file_to_use = line_changes.path
         else:
             file_to_use = file
 
@@ -73,6 +73,36 @@ def resolve_batch_file_scope(
     else:
         # All files in batch (default)
         return all_files
+
+
+def resolve_current_batch_binary_file_scope(
+    batch_name: str,
+    all_files: dict[str, dict],
+    file: Optional[str] = None,
+    patterns: Optional[list[str]] = None,
+    line_ids: Optional[str] = None,
+) -> Optional[str]:
+    """Resolve a pathless whole-file batch action through the selected binary.
+
+    A selected batch binary is an atomic current-file selection. Both the bare
+    command and `--file` with no path are pathless whole-file actions, so both
+    must revalidate the cached batch fingerprint before they can narrow to the
+    selected file.
+    """
+    if patterns is not None or line_ids is not None or file not in (None, ""):
+        return file
+
+    from ..data.hunk_tracking import (
+        SelectedChangeKind,
+        read_selected_change_kind,
+        require_current_selected_batch_binary_file_for_batch,
+    )
+
+    if read_selected_change_kind() != SelectedChangeKind.BATCH_BINARY:
+        return file
+
+    selected_file = require_current_selected_batch_binary_file_for_batch(batch_name, all_files)
+    return selected_file if selected_file is not None else file
 
 
 def require_single_file_context_for_line_selection(
@@ -105,7 +135,8 @@ def require_single_file_context_for_line_selection(
     if len(files) != 1:
         exit_with_error(
             _("Line-level {operation} (--line) requires single-file context.\n"
-              "Use --file to specify a file, or run 'show --from {name}' first to select a file.").format(
+              "Use --file to specify a file, or open one listed file with "
+              "'show --from {name} --file PATH'.").format(
                 operation=operation_verb,
                 name=batch_name
             )
@@ -163,6 +194,67 @@ def translate_atomic_unit_error_to_gutter_ids(
         name=batch_name,
         error=str(error)
     ))
+
+
+def translate_batch_file_gutter_ids_to_selection_ids(
+    batch_name: str,
+    file_path: str,
+    selected_ids: set[int] | None,
+    action: 'FileReviewAction | str',
+) -> tuple[set[int] | None, 'RenderedBatchDisplay | None']:
+    """Translate displayed batch-file gutter IDs to internal selection IDs.
+
+    If the IDs came after a fresh matching file review, validate them against
+    the complete actions shown by that review before consulting the full batch
+    display. Without a matching review, keep the historical raw batch display
+    behavior.
+    """
+    if selected_ids is None:
+        return None, None
+
+    from ..data.file_review_state import (
+        fresh_batch_review_selection_groups_for_action,
+        validate_review_scoped_line_selection,
+    )
+    from ..data.hunk_tracking import render_batch_file_display
+
+    review_groups = fresh_batch_review_selection_groups_for_action(batch_name, file_path, action)
+    if review_groups is not None:
+        validate_review_scoped_line_selection(selected_ids, review_groups)
+
+    rendered = render_batch_file_display(batch_name, file_path)
+    if rendered is None:
+        return selected_ids, None
+
+    display_id_map = (
+        rendered.review_gutter_to_selection_id or rendered.gutter_to_selection_id
+        if review_groups is not None else
+        rendered.gutter_to_selection_id
+    )
+    rendered_for_messages = (
+        replace(
+            rendered,
+            gutter_to_selection_id=dict(display_id_map),
+            selection_id_to_gutter={
+                selection_id: gutter_id
+                for gutter_id, selection_id in display_id_map.items()
+            },
+        )
+        if review_groups is not None else
+        rendered
+    )
+    selection_ids: set[int] = set()
+    for gutter_id in selected_ids:
+        if gutter_id in display_id_map:
+            selection_ids.add(display_id_map[gutter_id])
+        else:
+            exit_with_error(
+                _("Line ID {id} is not available for this action. Select one of the numbered lines shown for this batch file.").format(
+                    id=gutter_id
+                )
+            )
+
+    return selection_ids, rendered_for_messages
 
 
 def select_batch_ownership_for_display_ids(

--- a/src/git_stage_batch/cli/argument_parser.py
+++ b/src/git_stage_batch/cli/argument_parser.py
@@ -449,6 +449,13 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
         metavar="IDS",
         help=_("Show only specific line IDs (e.g., '1,3,5-7')"),
     )
+    parser_show.add_argument(
+        "--page",
+        "--pages",
+        metavar="PAGES",
+        dest="page",
+        help=_("Show page selection for a file review, e.g. '3', '3-5', '1,3,5-7', or 'all'."),
+    )
     _add_file_argument(
         parser_show,
         _("Operate on entire file (live working tree state). "
@@ -466,20 +473,39 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
             if args.from_batch
             else _resolve_live_file_scope(args.file, args.file_patterns)
         )
+        if args.page is not None:
+            if args.from_batch and not batch_exists(args.from_batch):
+                raise CommandError(_("Batch '{name}' does not exist").format(name=args.from_batch))
+            if resolved_file_scope is None:
+                if not (
+                    args.from_batch
+                    and batch_exists(args.from_batch)
+                    and len(read_batch_metadata(args.from_batch).get("files", {})) == 1
+                ):
+                    raise CommandError(
+                        _(
+                            "`show --page` requires `--file` or a single-file `--files` match, "
+                            "unless `--from` names a single-file batch."
+                        )
+                    )
+            if isinstance(resolved_file_scope, list):
+                raise CommandError(_("`show --page` requires exactly one resolved file."))
+            if args.line_ids is not None:
+                raise CommandError(_("Cannot use `show --page` together with `show --line`."))
+            if args.porcelain:
+                raise CommandError(_("Cannot use `show --page` with `--porcelain`."))
         if args.from_batch:
             if isinstance(resolved_file_scope, list):
                 if args.line_ids:
                     raise CommandError(_("Cannot use --lines with multiple files."))
-                last_index = len(resolved_file_scope) - 1
-                for index, file in enumerate(resolved_file_scope):
-                    commands.command_show_from_batch(
-                        args.from_batch,
-                        args.line_ids,
-                        file,
-                        selectable=(index == last_index),
-                    )
+                commands.command_show_from_batch(
+                    args.from_batch,
+                    args.line_ids,
+                    patterns=args.file_patterns,
+                    page=args.page,
+                )
             else:
-                commands.command_show_from_batch(args.from_batch, args.line_ids, resolved_file_scope)
+                commands.command_show_from_batch(args.from_batch, args.line_ids, resolved_file_scope, page=args.page)
             return
         if args.line_ids or resolved_file_scope is not None:
             if isinstance(resolved_file_scope, list) and args.porcelain:
@@ -487,15 +513,9 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
             if isinstance(resolved_file_scope, list):
                 if args.line_ids:
                     raise CommandError(_("Cannot use --lines with multiple files."))
-                last_index = len(resolved_file_scope) - 1
-                for index, file in enumerate(resolved_file_scope):
-                    commands.command_show(
-                        file=file,
-                        porcelain=args.porcelain,
-                        selectable=(index == last_index),
-                    )
+                commands.command_show_file_list(resolved_file_scope)
             else:
-                commands.command_show(file=resolved_file_scope, porcelain=args.porcelain)
+                commands.command_show(file=resolved_file_scope, page=args.page, porcelain=args.porcelain)
             return
         commands.command_show(porcelain=args.porcelain)
 
@@ -572,18 +592,17 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
     )
 
     def dispatch_include(args: argparse.Namespace) -> None:
-        replacement_text = _resolve_replacement_text(args)
-        resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
-        resolved_batch_scope = (
-            _resolve_batch_file_scope(args.from_batch, args.file, args.file_patterns)
-            if args.from_batch else None
-        )
-        if replacement_text is not None:
+        replacement_requested = args.as_text is not None or args.as_stdin
+        if replacement_requested:
+            if args.as_text is not None and args.as_stdin:
+                raise CommandError(_("Cannot use `--as` and `--as-stdin` together."))
             if args.line_ids and args.from_batch and not args.to_batch:
                 if args.no_edge_overlap:
                     raise CommandError(_("`--no-edge-overlap` only applies to live `include --line --as` operations."))
+                resolved_batch_scope = _resolve_batch_file_scope(args.from_batch, args.file, args.file_patterns)
                 if isinstance(resolved_batch_scope, list):
                     raise CommandError(_("Cannot use --lines with multiple files."))
+                replacement_text = _resolve_replacement_text(args)
                 commands.command_include_from_batch(
                     args.from_batch,
                     args.line_ids,
@@ -592,8 +611,10 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
                 )
                 return
             if args.line_ids and not args.from_batch and not args.to_batch:
+                resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
                 if isinstance(resolved_live_scope, list):
                     raise CommandError(_("Cannot use --lines with multiple files."))
+                replacement_text = _resolve_replacement_text(args)
                 commands.command_include_line_as(
                     args.line_ids,
                     replacement_text,
@@ -605,12 +626,17 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
                 args.line_ids is None
                 and args.from_batch is None
                 and args.to_batch is None
-                and resolved_live_scope is not None
             ):
+                resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
+                if resolved_live_scope is None:
+                    raise CommandError(
+                        _("`include --as` requires `--file` or `--line` and does not support `--to`.")
+                    )
                 if args.no_edge_overlap:
                     raise CommandError(_("`--no-edge-overlap` requires `include --line --as`."))
                 if isinstance(resolved_live_scope, list):
                     raise CommandError(_("Cannot use --as with multiple files."))
+                replacement_text = _resolve_replacement_text(args)
                 commands.command_include_file_as(replacement_text, file=resolved_live_scope)
                 return
             raise CommandError(
@@ -619,28 +645,32 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
         if args.no_edge_overlap:
             raise CommandError(_("`--no-edge-overlap` requires `include --line --as`."))
         if args.from_batch:
+            resolved_batch_scope = _resolve_batch_file_scope(args.from_batch, args.file, args.file_patterns)
             _run_for_each_file(
                 resolved_batch_scope,
                 lambda file: commands.command_include_from_batch(args.from_batch, args.line_ids, file),
                 line_ids=args.line_ids,
             )
         elif args.to_batch:
+            resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
             _run_for_each_file(
                 resolved_live_scope,
                 lambda file: commands.command_include_to_batch(args.to_batch, args.line_ids, file),
                 line_ids=args.line_ids,
             )
         elif args.line_ids:
+            resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
             if isinstance(resolved_live_scope, list):
                 raise CommandError(_("Cannot use --lines with multiple files."))
             commands.command_include_line(args.line_ids, file=resolved_live_scope)
-        elif resolved_live_scope is not None:
+        else:
+            resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
             if isinstance(resolved_live_scope, list):
                 _include_each_resolved_file(resolved_live_scope)
-            else:
+            elif resolved_live_scope is not None:
                 commands.command_include_file(resolved_live_scope)
-        else:
-            commands.command_include()
+            else:
+                commands.command_include()
 
     parser_include.set_defaults(func=dispatch_include)
 
@@ -669,7 +699,7 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
         if args.line_ids:
             if isinstance(resolved_file_scope, list):
                 raise CommandError(_("Cannot use --lines with multiple files."))
-            commands.command_skip_line(args.line_ids)
+            commands.command_skip_line(args.line_ids, file=resolved_file_scope)
         elif resolved_file_scope is not None:
             if isinstance(resolved_file_scope, list):
                 _skip_each_resolved_file(resolved_file_scope)
@@ -738,16 +768,15 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
     )
 
     def dispatch_discard(args: argparse.Namespace) -> None:
-        replacement_text = _resolve_replacement_text(args)
-        resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
-        resolved_batch_scope = (
-            _resolve_batch_file_scope(args.from_batch, args.file, args.file_patterns)
-            if args.from_batch else None
-        )
-        if replacement_text is not None:
+        replacement_requested = args.as_text is not None or args.as_stdin
+        if replacement_requested:
+            if args.as_text is not None and args.as_stdin:
+                raise CommandError(_("Cannot use `--as` and `--as-stdin` together."))
             if args.to_batch and args.line_ids and not args.from_batch:
+                resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
                 if isinstance(resolved_live_scope, list):
                     raise CommandError(_("Cannot use --lines with multiple files."))
+                replacement_text = _resolve_replacement_text(args)
                 commands.command_discard_line_as_to_batch(
                     args.to_batch,
                     args.line_ids,
@@ -760,12 +789,17 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
                 args.to_batch is None
                 and args.from_batch is None
                 and args.line_ids is None
-                and resolved_live_scope is not None
             ):
+                resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
+                if resolved_live_scope is None:
+                    raise CommandError(
+                        _("`discard --as` requires `--file`, or `--to` with `--line`.")
+                    )
                 if args.no_edge_overlap:
                     raise CommandError(_("`--no-edge-overlap` requires `discard --to --line --as`."))
                 if isinstance(resolved_live_scope, list):
                     raise CommandError(_("Cannot use --as with multiple files."))
+                replacement_text = _resolve_replacement_text(args)
                 commands.command_discard_file_as(replacement_text, file=resolved_live_scope)
                 return
             raise CommandError(
@@ -774,25 +808,30 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
         if args.no_edge_overlap:
             raise CommandError(_("`--no-edge-overlap` requires `discard --to --line --as`."))
         if args.from_batch:
+            resolved_batch_scope = _resolve_batch_file_scope(args.from_batch, args.file, args.file_patterns)
             _run_for_each_file(
                 resolved_batch_scope,
                 lambda file: commands.command_discard_from_batch(args.from_batch, args.line_ids, file),
                 line_ids=args.line_ids,
             )
         elif args.to_batch:
+            resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
             _run_for_each_file(
                 resolved_live_scope,
                 lambda file: commands.command_discard_to_batch(args.to_batch, args.line_ids, file),
                 line_ids=args.line_ids,
             )
         elif args.line_ids:
+            resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
             if isinstance(resolved_live_scope, list):
                 raise CommandError(_("Cannot use --lines with multiple files."))
             commands.command_discard_line(args.line_ids, file=resolved_live_scope)
-        elif resolved_live_scope is not None:
-            _run_for_each_file(resolved_live_scope, commands.command_discard_file)
         else:
-            commands.command_discard()
+            resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
+            if resolved_live_scope is not None:
+                _run_for_each_file(resolved_live_scope, commands.command_discard_file)
+            else:
+                commands.command_discard()
 
     parser_discard.set_defaults(func=dispatch_discard)
 

--- a/src/git_stage_batch/commands/__init__.py
+++ b/src/git_stage_batch/commands/__init__.py
@@ -17,7 +17,7 @@ from .interactive import command_interactive
 from .list import command_list_batches
 from .new import command_new_batch
 from .reset import command_reset_from_batch
-from .show import command_show
+from .show import command_show, command_show_file_list
 from .show_from import command_show_from_batch
 from .sift import command_sift_batch
 from .skip import command_skip, command_skip_file, command_skip_line
@@ -56,6 +56,7 @@ __all__ = [
     "command_new_batch",
     "command_reset_from_batch",
     "command_show",
+    "command_show_file_list",
     "command_show_from_batch",
     "command_sift_batch",
     "command_skip",

--- a/src/git_stage_batch/commands/apply_from.py
+++ b/src/git_stage_batch/commands/apply_from.py
@@ -10,9 +10,11 @@ from ..batch.merge import merge_batch
 from ..batch.metadata_validation import read_validated_batch_metadata
 from ..batch.query import get_batch_commit_sha
 from ..batch.selection import (
+    resolve_current_batch_binary_file_scope,
     resolve_batch_file_scope,
     require_single_file_context_for_line_selection,
     select_batch_ownership_for_display_ids,
+    translate_batch_file_gutter_ids_to_selection_ids,
     translate_atomic_unit_error_to_gutter_ids,
 )
 from ..batch.validation import batch_exists
@@ -22,7 +24,13 @@ from ..core.text_lifecycle import (
     normalized_text_change_type,
     selected_text_target_change_type,
 )
-from ..data.hunk_tracking import render_batch_file_display
+from ..data.file_review_state import (
+    FileReviewAction,
+    resolve_batch_source_action_scope,
+)
+from ..data.hunk_tracking import (
+    render_batch_file_display,
+)
 from ..data.session import snapshot_file_if_untracked
 from ..data.undo import undo_checkpoint
 from ..exceptions import exit_with_error, MergeError, CommandError, AtomicUnitError, BatchMetadataError
@@ -136,6 +144,15 @@ def command_apply_from_batch(
         patterns: Optional gitignore-style file patterns to filter batch files.
     """
     require_git_repository()
+    scope_resolution = resolve_batch_source_action_scope(
+        FileReviewAction.APPLY_FROM_BATCH,
+        command_name="apply",
+        batch_name=batch_name,
+        line_ids=line_ids,
+        file=file,
+        patterns=patterns,
+    )
+    file = scope_resolution.file
 
     # Check batch exists
     if not batch_exists(batch_name):
@@ -152,6 +169,8 @@ def command_apply_from_batch(
     if not all_files:
         exit_with_error(_("Batch '{name}' is empty").format(name=batch_name))
 
+    file = resolve_current_batch_binary_file_scope(batch_name, all_files, file, patterns, line_ids)
+
     # Determine which files to operate on
     files = resolve_batch_file_scope(batch_name, all_files, file, patterns)
 
@@ -164,23 +183,19 @@ def command_apply_from_batch(
     if selected_ids:
         file_path_for_check = list(files.keys())[0]  # Single file context enforced above
         if files[file_path_for_check].get("file_type") == "binary":
-            exit_with_error(_("Cannot use --lines with binary files. Binary files must be applied as complete units."))
+            exit_with_error(_("Cannot use --lines with binary files. Apply the whole file instead."))
 
     # Translate gutter IDs to selection IDs if line selection is active
     selection_ids_to_apply = selected_ids
     rendered = None  # Store for error translation
     if selected_ids:
-        # Use pure render helper to get gutter ID mapping (no side effects)
         file_path_for_render = list(files.keys())[0]  # Single file context enforced above
-        rendered = render_batch_file_display(batch_name, file_path_for_render)
-        if rendered:
-            # Translate gutter IDs (what user sees) to selection IDs (internal)
-            selection_ids_to_apply = set()
-            for gutter_id in selected_ids:
-                if gutter_id in rendered.gutter_to_selection_id:
-                    selection_ids_to_apply.add(rendered.gutter_to_selection_id[gutter_id])
-                else:
-                    exit_with_error(_("Line ID {id} not found or not individually mergeable").format(id=gutter_id))
+        selection_ids_to_apply, rendered = translate_batch_file_gutter_ids_to_selection_ids(
+            batch_name,
+            file_path_for_render,
+            selected_ids,
+            FileReviewAction.APPLY_FROM_BATCH,
+        )
     operation_parts = ["apply", "--from", batch_name]
     if line_ids is not None:
         operation_parts.extend(["--line", line_ids])

--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import stat
 import sys
 
-from ..batch import add_file_to_batch, create_batch
+from ..batch import add_binary_file_to_batch, add_file_to_batch, create_batch
 from ..batch.display import annotate_with_batch_source, annotate_with_batch_source_content
 from ..batch.ownership import (
     BatchOwnership,
@@ -22,9 +22,10 @@ from ..core.diff_parser import (
     build_line_changes_from_patch_bytes,
     parse_unified_diff_streaming,
 )
-from ..core.hashing import compute_stable_hunk_hash
+from ..core.hashing import compute_binary_file_hash, compute_stable_hunk_hash
 from ..core.line_selection import parse_line_selection
 from ..core.models import BinaryFileChange
+from ..core.text_lifecycle import TextFileChangeType, detect_empty_text_lifecycle_change
 from ..data.hunk_tracking import (
     SelectedChangeKind,
     advance_to_and_show_next_change,
@@ -37,7 +38,21 @@ from ..data.hunk_tracking import (
     read_selected_change_kind,
     recalculate_selected_hunk_for_file,
     record_hunk_discarded,
+    refuse_bare_action_after_file_list,
+    render_binary_file_change,
     require_selected_hunk,
+    restore_selected_change_state,
+    snapshot_selected_change_state,
+)
+from ..data.file_review_state import (
+    FileReviewAction,
+    clear_last_file_review_state_if_file_matches,
+    finish_review_scoped_line_action,
+    refuse_ambiguous_bare_action_after_partial_file_review,
+    refuse_live_action_for_batch_selection,
+    resolve_live_line_action_scope,
+    resolve_live_to_batch_action_scope,
+    ReviewSource,
 )
 from ..data.line_state import load_line_changes_from_state
 from ..data.batch_sources import create_batch_source_commit, load_session_batch_sources, save_session_batch_sources
@@ -45,6 +60,7 @@ from ..data.session import require_session_started, snapshot_file_if_untracked
 from ..data.undo import undo_checkpoint
 from ..exceptions import CommandError, exit_with_error, NoMoreHunks
 from ..i18n import _, ngettext
+from ..output import print_remaining_line_changes_header
 from ..staging.operations import build_target_working_tree_content_bytes_with_discarded_lines
 from ..staging.operations import build_target_working_tree_content_bytes_with_replaced_lines
 from ..utils.command import ExitEvent, OutputEvent, stream_command
@@ -60,8 +76,6 @@ from ..utils.paths import (
 )
 from .include import (
     _expand_replacement_selection_ids,
-    _restore_selected_change_state,
-    _snapshot_selected_change_state,
 )
 
 
@@ -89,6 +103,12 @@ def command_discard(*, quiet: bool = False) -> None:
     require_git_repository()
     require_session_started()
     ensure_state_directory_exists()
+
+    if refuse_live_action_for_batch_selection(FileReviewAction.DISCARD):
+        return
+    if refuse_ambiguous_bare_action_after_partial_file_review(FileReviewAction.DISCARD):
+        return
+    refuse_bare_action_after_file_list("discard")
 
     if read_selected_change_kind() == SelectedChangeKind.FILE:
         _command_discard_selected_file(quiet=quiet)
@@ -268,6 +288,13 @@ def command_discard_file(file: str) -> None:
     require_session_started()
     ensure_state_directory_exists()
 
+    if file == "":
+        if refuse_live_action_for_batch_selection(FileReviewAction.DISCARD):
+            return
+        if refuse_ambiguous_bare_action_after_partial_file_review(FileReviewAction.DISCARD):
+            return
+        refuse_bare_action_after_file_list("discard --file")
+
     # Determine target file
     if file == "":
         target_file = get_selected_change_file_path()
@@ -294,6 +321,16 @@ def command_discard_file(file: str) -> None:
         # (git rm -f will stage the deletion, making hunks disappear from git diff)
         hashes_to_block = []
         for patch in parse_unified_diff_streaming(stream_git_command(["diff", f"-U{get_context_lines()}", "--no-color"])):
+            if isinstance(patch, BinaryFileChange):
+                file_path = patch.new_path if patch.new_path != "/dev/null" else patch.old_path
+                if file_path != target_file:
+                    continue
+
+                patch_hash = compute_binary_file_hash(patch)
+                if patch_hash not in blocked_hashes:
+                    hashes_to_block.append(patch_hash)
+                continue
+
             if patch.new_path != target_file:
                 continue
 
@@ -325,6 +362,12 @@ def command_discard_file_as(replacement_text: str, file: str | None = None) -> N
     require_git_repository()
     require_session_started()
     ensure_state_directory_exists()
+    if file is None or file == "":
+        if refuse_live_action_for_batch_selection(FileReviewAction.DISCARD):
+            return
+        if refuse_ambiguous_bare_action_after_partial_file_review(FileReviewAction.DISCARD):
+            return
+        refuse_bare_action_after_file_list("discard --file --as")
 
     operation_parts = ["discard", "--as", replacement_text]
     if file is not None:
@@ -341,7 +384,7 @@ def command_discard_file_as(replacement_text: str, file: str | None = None) -> N
         else:
             target_file = file
             preserve_selected_state = True
-            saved_selected_state = _snapshot_selected_change_state()
+            saved_selected_state = snapshot_selected_change_state()
 
         line_changes = _load_explicit_file_selection(target_file)
         snapshot_file_if_untracked(target_file)
@@ -351,9 +394,10 @@ def command_discard_file_as(replacement_text: str, file: str | None = None) -> N
         absolute_path.write_text(replacement_text, encoding="utf-8", errors="surrogateescape")
 
         if preserve_selected_state:
-            _restore_selected_change_state(saved_selected_state)
+            restore_selected_change_state(saved_selected_state)
         else:
             recalculate_selected_hunk_for_file(line_changes.path)
+        clear_last_file_review_state_if_file_matches(target_file)
 
     print(_("✓ Discarded file as replacement: {file}").format(file=target_file), file=sys.stderr)
 
@@ -370,6 +414,16 @@ def command_discard_line(line_id_specification: str, file: str | None = None) ->
     require_git_repository()
     require_session_started()
     ensure_state_directory_exists()
+    scope_resolution = resolve_live_line_action_scope(
+        FileReviewAction.DISCARD,
+        action_command=f"discard --line {line_id_specification}",
+        line_id_specification=line_id_specification,
+        file=file,
+        validate_pathless_before_live_guard=True,
+    )
+    if scope_resolution.should_stop:
+        return
+    review_state = scope_resolution.review_state
     operation_parts = ["discard", "--line", line_id_specification]
     if file is not None:
         operation_parts.extend(["--file", file])
@@ -404,9 +458,16 @@ def command_discard_line(line_id_specification: str, file: str | None = None) ->
         working_file_path.write_bytes(target_working_content)
 
         # After modifying working tree, recalculate hunk for the SAME file
+        print(
+            _("✓ Discarded line(s): {lines} from {file}").format(
+                lines=line_id_specification,
+                file=line_changes.path,
+            ),
+            file=sys.stderr,
+        )
+        print_remaining_line_changes_header(line_changes.path)
         recalculate_selected_hunk_for_file(line_changes.path)
-
-    print(_("✓ Discarded line(s): {lines}").format(lines=line_id_specification), file=sys.stderr)
+        finish_review_scoped_line_action(review_state)
 
 
 def command_discard_to_batch(batch_name: str, line_ids: str | None = None, file: str | None = None, *, quiet: bool = False) -> None:
@@ -422,13 +483,35 @@ def command_discard_to_batch(batch_name: str, line_ids: str | None = None, file:
     """
     require_git_repository()
     ensure_state_directory_exists()
+    original_file_scope = file
+    scope_resolution = resolve_live_to_batch_action_scope(
+        FileReviewAction.DISCARD_TO_BATCH,
+        command_name="discard",
+        batch_name=batch_name,
+        line_ids=line_ids,
+        file=file,
+    )
+    if scope_resolution.should_stop:
+        return
+    file = scope_resolution.file
+    review_state = scope_resolution.review_state
     operation_parts = ["discard", "--to", batch_name]
     if line_ids is not None:
         operation_parts.extend(["--line", line_ids])
     if file is not None:
         operation_parts.extend(["--file", file])
     with undo_checkpoint(" ".join(operation_parts)):
-        if file is not None:
+        if (
+            file is None
+            and line_ids is None
+            and read_selected_change_kind() == SelectedChangeKind.BINARY
+        ):
+            selected_change = load_selected_change()
+            if isinstance(selected_change, BinaryFileChange):
+                _command_discard_binary_to_batch(batch_name, selected_change, quiet=quiet)
+            else:
+                _command_discard_hunk_to_batch(batch_name, file_only=False, quiet=quiet)
+        elif file is not None:
             # File-scoped operation
 
             # Determine target file
@@ -453,6 +536,8 @@ def command_discard_to_batch(batch_name: str, line_ids: str | None = None, file:
             else:
                 # Discard entire selected hunk
                 _command_discard_hunk_to_batch(batch_name, file_only=False, quiet=quiet)
+    if original_file_scope in (None, "") and line_ids is not None:
+        finish_review_scoped_line_action(review_state)
 
 
 def command_discard_line_as_to_batch(
@@ -468,6 +553,16 @@ def command_discard_line_as_to_batch(
     require_git_repository()
     require_session_started()
     ensure_state_directory_exists()
+    scope_resolution = resolve_live_line_action_scope(
+        FileReviewAction.DISCARD_TO_BATCH,
+        action_command=f"discard --to {batch_name} --line {line_id_specification} --as",
+        line_id_specification=line_id_specification,
+        file=file,
+        source=ReviewSource.FILE_VS_HEAD,
+    )
+    if scope_resolution.should_stop:
+        return
+    review_state = scope_resolution.review_state
 
     operation_parts = [
         "discard",
@@ -480,8 +575,8 @@ def command_discard_line_as_to_batch(
     if file is not None:
         operation_parts.extend(["--file", file])
     with undo_checkpoint(" ".join(operation_parts)):
-        saved_selected_state = _snapshot_selected_change_state()
-        preserve_selected_state = file is not None
+        saved_selected_state = snapshot_selected_change_state()
+        preserve_selected_state = file not in (None, "")
 
         try:
             if file is None:
@@ -505,10 +600,14 @@ def command_discard_line_as_to_batch(
             )
 
             if preserve_selected_state:
-                _restore_selected_change_state(saved_selected_state)
+                restore_selected_change_state(saved_selected_state)
         except Exception:
-            _restore_selected_change_state(saved_selected_state)
+            restore_selected_change_state(saved_selected_state)
             raise
+    if file is None:
+        finish_review_scoped_line_action(review_state)
+    else:
+        finish_review_scoped_line_action(review_state, file_path=target_file)
 
 
 def _command_discard_lines_to_batch_as(
@@ -723,6 +822,58 @@ def _detect_file_mode(file_path: str) -> str:
     return "100644"
 
 
+def _discard_binary_change_from_working_tree(binary_change: BinaryFileChange) -> None:
+    """Discard one live binary change from the working tree."""
+    file_path = binary_change.new_path if binary_change.new_path != "/dev/null" else binary_change.old_path
+    absolute_path = get_git_repository_root_path() / file_path
+
+    if binary_change.is_new_file():
+        if absolute_path.exists():
+            absolute_path.unlink()
+        run_git_command(["rm", "--cached", "--quiet", "--", file_path], check=False)
+        return
+
+    result = run_git_command(["checkout", "HEAD", "--", file_path], check=False)
+    if result.returncode != 0:
+        exit_with_error(_("Failed to restore binary file: {error}").format(error=result.stderr))
+
+
+def _command_discard_binary_to_batch(
+    batch_name: str,
+    binary_change: BinaryFileChange,
+    *,
+    quiet: bool = False,
+) -> None:
+    """Save one binary change to a batch, then discard it from the working tree."""
+    file_path = binary_change.new_path if binary_change.new_path != "/dev/null" else binary_change.old_path
+    patch_hash = compute_binary_file_hash(binary_change)
+
+    snapshot_file_if_untracked(file_path)
+    add_binary_file_to_batch(
+        batch_name,
+        binary_change,
+        file_mode=_detect_file_mode(file_path),
+    )
+    _discard_binary_change_from_working_tree(binary_change)
+
+    append_lines_to_file(get_block_list_file_path(), [patch_hash])
+    record_hunk_discarded(patch_hash)
+
+    if not quiet:
+        print(
+            _("Discarded binary file '{file}' to batch '{batch}'").format(
+                file=file_path,
+                batch=batch_name,
+            ),
+            file=sys.stderr,
+        )
+
+    if quiet:
+        advance_to_next_change()
+    else:
+        advance_to_and_show_next_change()
+
+
 def _command_discard_file_to_batch(batch_name: str, file_path: str, *, quiet: bool = False) -> None:
     """Discard entire file to batch (internal helper for file-scoped operations)."""
 
@@ -731,6 +882,11 @@ def _command_discard_file_to_batch(batch_name: str, file_path: str, *, quiet: bo
     # Auto-create batch if it doesn't exist
     if not batch_exists(batch_name):
         create_batch(batch_name, "Auto-created")
+
+    binary_change = render_binary_file_change(file_path)
+    if binary_change is not None:
+        _command_discard_binary_to_batch(batch_name, binary_change, quiet=quiet)
+        return
 
     # Load blocklist
     blocklist_path = get_block_list_file_path()
@@ -757,34 +913,34 @@ def _command_discard_file_to_batch(batch_name: str, file_path: str, *, quiet: bo
         patches_to_discard.append((patch_bytes_loop, patch_hash))
 
     if not all_lines_to_batch:
-        # Special case: empty new file (exists in working tree but not in HEAD)
+        # Special case: empty text lifecycle changes have no hunk body.
         repo_root = get_git_repository_root_path()
         full_path = repo_root / file_path
-        if full_path.exists():
-            # Check if file exists in HEAD
-            head_result = run_git_command(["cat-file", "-e", f"HEAD:{file_path}"], check=False)
-            if head_result.returncode != 0:
-                # File doesn't exist in HEAD - it's a new empty file
-                # Save empty file metadata to batch and delete it
-                empty_ownership = BatchOwnership(claimed_lines=[], deletions=[])
+        lifecycle_change_type = detect_empty_text_lifecycle_change(file_path)
+        if lifecycle_change_type is not None:
+            snapshot_file_if_untracked(file_path)
+            add_file_to_batch(
+                batch_name,
+                file_path,
+                BatchOwnership(claimed_lines=[], deletions=[]),
+                file_mode,
+                change_type=lifecycle_change_type,
+            )
 
-                # Snapshot before deleting
-                snapshot_file_if_untracked(file_path)
-
-                # Save to batch
-                add_file_to_batch(batch_name, file_path, empty_ownership, file_mode)
-
+            if lifecycle_change_type == TextFileChangeType.ADDED:
                 # Delete from working tree
                 full_path.unlink()
 
                 # Remove from index if present (from intent-to-add)
                 run_git_command(["rm", "--cached", "--quiet", "--", file_path], check=False)
+            else:
+                run_git_command(["checkout", "HEAD", "--", file_path], check=False)
 
-                if not quiet:
-                    print(_("Discarded file '{file}' to batch '{batch}'").format(file=file_path, batch=batch_name), file=sys.stderr)
+            if not quiet:
+                print(_("Discarded file '{file}' to batch '{batch}'").format(file=file_path, batch=batch_name), file=sys.stderr)
 
-                log_journal("discard_file_to_batch_end", batch_name=batch_name, file_path=file_path)
-                return
+            log_journal("discard_file_to_batch_end", batch_name=batch_name, file_path=file_path)
+            return
 
         if not quiet:
             print(_("No changes in file '{file}' to discard.").format(file=file_path), file=sys.stderr)
@@ -892,7 +1048,6 @@ def _command_discard_file_lines_to_batch(batch_name: str, file_path: str, line_i
             print(_("No lines match the specified IDs in file '{file}'.").format(file=file_path), file=sys.stderr)
         return
 
-    # Detect file mode
     file_mode = _detect_file_mode(file_path)
 
     # Prepare batch ownership update (handles stale source, translation, merge)
@@ -1010,7 +1165,6 @@ def _command_discard_lines_to_batch(batch_name: str, line_id_specification: str,
               "Error: {error}").format(file=line_changes.path, batch=batch_name, error=str(e))
         )
 
-    # Detect file mode
     file_mode = _detect_file_mode(line_changes.path)
 
     # add_file_to_batch creates the batch source commit from this snapshot.
@@ -1060,9 +1214,12 @@ def _command_discard_hunk_to_batch(batch_name: str, file_only: bool = False, *, 
 
     # Ensure cached hunk is selected
     try:
-        fetch_next_change()
+        selected_item = fetch_next_change()
     except NoMoreHunks:
         print(_("No changes to process."), file=sys.stderr)
+        return
+    if isinstance(selected_item, BinaryFileChange):
+        _command_discard_binary_to_batch(batch_name, selected_item, quiet=quiet)
         return
 
     # Get the file path and hash from currently cached hunk
@@ -1076,7 +1233,6 @@ def _command_discard_hunk_to_batch(batch_name: str, file_only: bool = False, *, 
     blocklist_text = read_text_file_contents(blocklist_path)
     blocked_hashes = set(blocklist_text.splitlines())
 
-    # Detect file mode
     file_mode = _detect_file_mode(file_path)
 
     # Collect all lines to batch (either selected hunk or all hunks from file)

--- a/src/git_stage_batch/commands/discard_from.py
+++ b/src/git_stage_batch/commands/discard_from.py
@@ -10,9 +10,11 @@ from typing import Optional
 from ..batch.merge import discard_batch
 from ..batch.metadata_validation import get_validated_baseline_commit, read_validated_batch_metadata
 from ..batch.selection import (
+    resolve_current_batch_binary_file_scope,
     resolve_batch_file_scope,
     require_single_file_context_for_line_selection,
     select_batch_ownership_for_display_ids,
+    translate_batch_file_gutter_ids_to_selection_ids,
     translate_atomic_unit_error_to_gutter_ids,
 )
 from ..batch.validation import batch_exists
@@ -22,7 +24,10 @@ from ..core.text_lifecycle import (
     normalized_text_change_type,
     selected_text_discard_change_type,
 )
-from ..data.hunk_tracking import render_batch_file_display
+from ..data.file_review_state import (
+    FileReviewAction,
+    resolve_batch_source_action_scope,
+)
 from ..data.session import snapshot_file_if_untracked
 from ..data.undo import undo_checkpoint
 from ..exceptions import exit_with_error, AtomicUnitError, CommandError, MergeError, BatchMetadataError
@@ -132,6 +137,15 @@ def command_discard_from_batch(
         patterns: Optional gitignore-style file patterns to filter batch files.
     """
     require_git_repository()
+    scope_resolution = resolve_batch_source_action_scope(
+        FileReviewAction.DISCARD_FROM_BATCH,
+        command_name="discard",
+        batch_name=batch_name,
+        line_ids=line_ids,
+        file=file,
+        patterns=patterns,
+    )
+    file = scope_resolution.file
 
     # Check batch exists
     if not batch_exists(batch_name):
@@ -148,6 +162,8 @@ def command_discard_from_batch(
     if not all_files:
         exit_with_error(_("Batch '{name}' is empty").format(name=batch_name))
 
+    file = resolve_current_batch_binary_file_scope(batch_name, all_files, file, patterns, line_ids)
+
     # Determine which files to operate on
     files = resolve_batch_file_scope(batch_name, all_files, file, patterns)
 
@@ -160,23 +176,19 @@ def command_discard_from_batch(
     if selected_ids:
         file_path_for_check = list(files.keys())[0]  # Single file context enforced above
         if files[file_path_for_check].get("file_type") == "binary":
-            exit_with_error(_("Cannot use --lines with binary files. Binary files must be discarded as complete units."))
+            exit_with_error(_("Cannot use --lines with binary files. Discard the whole file instead."))
 
     # Translate gutter IDs to selection IDs if line selection is active
     selection_ids_to_discard = selected_ids
     rendered = None
     if selected_ids:
-        # Use pure render helper to get gutter ID mapping (no side effects)
         file_path_for_render = list(files.keys())[0]  # Single file context enforced above
-        rendered = render_batch_file_display(batch_name, file_path_for_render)
-        if rendered:
-            # Translate gutter IDs (what user sees) to selection IDs (internal)
-            selection_ids_to_discard = set()
-            for gutter_id in selected_ids:
-                if gutter_id in rendered.gutter_to_selection_id:
-                    selection_ids_to_discard.add(rendered.gutter_to_selection_id[gutter_id])
-                else:
-                    exit_with_error(_("Line ID {id} not found or not individually mergeable").format(id=gutter_id))
+        selection_ids_to_discard, rendered = translate_batch_file_gutter_ids_to_selection_ids(
+            batch_name,
+            file_path_for_render,
+            selected_ids,
+            FileReviewAction.DISCARD_FROM_BATCH,
+        )
 
     # Get baseline commit (raises BatchMetadataError with clear message if missing)
     try:

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -29,12 +29,12 @@ from ..core.line_selection import (
     write_line_ids_file,
 )
 from ..core.models import BinaryFileChange
+from ..core.text_lifecycle import detect_empty_text_lifecycle_change
 from ..data.hunk_tracking import (
     SelectedChangeKind,
     advance_to_and_show_next_change,
     advance_to_next_change,
     apply_line_level_batch_filter_to_cached_hunk,
-    cache_file_as_single_hunk,
     cache_unstaged_file_as_single_hunk,
     clear_selected_change_state_files,
     fetch_next_change,
@@ -45,7 +45,20 @@ from ..data.hunk_tracking import (
     record_binary_hunk_skipped,
     record_hunk_included,
     record_hunk_skipped,
+    refuse_bare_action_after_file_list,
+    render_binary_file_change,
     require_selected_hunk,
+    restore_selected_change_state,
+    snapshot_selected_change_state,
+)
+from ..data.file_review_state import (
+    FileReviewAction,
+    clear_last_file_review_state_if_file_matches,
+    finish_review_scoped_line_action,
+    refuse_ambiguous_bare_action_after_partial_file_review,
+    refuse_live_action_for_batch_selection,
+    resolve_live_line_action_scope,
+    resolve_live_to_batch_action_scope,
 )
 from ..data.consumed_selections import record_consumed_selection
 from ..data.line_state import load_line_changes_from_state
@@ -53,7 +66,7 @@ from ..data.session import require_session_started, snapshot_file_if_untracked
 from ..data.undo import undo_checkpoint
 from ..exceptions import NoMoreHunks, exit_with_error
 from ..i18n import _, ngettext
-from ..output import print_line_level_changes
+from ..output import print_line_level_changes, print_remaining_line_changes_header
 from ..staging.operations import (
     build_target_index_content_bytes_with_replaced_lines,
     build_target_index_content_bytes_with_selected_lines,
@@ -67,29 +80,12 @@ from ..utils.paths import (
     ensure_state_directory_exists,
     get_block_list_file_path,
     get_context_lines,
-    get_line_changes_json_file_path,
-    get_selected_change_kind_file_path,
+    get_index_snapshot_file_path,
     get_selected_hunk_hash_file_path,
     get_selected_hunk_patch_file_path,
-    get_selected_binary_file_json_path,
-    get_index_snapshot_file_path,
     get_processed_include_ids_file_path,
     get_working_tree_snapshot_file_path,
 )
-
-
-def _detect_file_mode(file_path: str) -> str:
-    """Return the current git file mode for a path, defaulting to a regular file."""
-    absolute_path = get_git_repository_root_path() / file_path
-    if absolute_path.exists():
-        return "100755" if absolute_path.stat().st_mode & stat.S_IXUSR else "100644"
-
-    ls_result = run_git_command(["ls-files", "-s", "--", file_path], check=False)
-    if ls_result.returncode == 0 and ls_result.stdout.strip():
-        parts = ls_result.stdout.strip().split()
-        if parts:
-            return parts[0]
-    return "100644"
 
 
 def command_include(*, quiet: bool = False) -> None:
@@ -100,6 +96,12 @@ def command_include(*, quiet: bool = False) -> None:
     require_git_repository()
     require_session_started()
     ensure_state_directory_exists()
+
+    if refuse_live_action_for_batch_selection(FileReviewAction.INCLUDE):
+        return 0
+    if refuse_ambiguous_bare_action_after_partial_file_review(FileReviewAction.INCLUDE):
+        return 0
+    refuse_bare_action_after_file_list("include")
 
     if read_selected_change_kind() == SelectedChangeKind.FILE:
         command_include_file("")
@@ -125,7 +127,7 @@ def command_include(*, quiet: bool = False) -> None:
             # Stage the binary file using git add
             result = run_git_command(["add", "--", file_path], check=False)
             if result.returncode != 0:
-                print(_("Failed to stage binary file: {}").format(result.stderr), file=sys.stderr)
+                print(_("Failed to stage binary file: {error}").format(error=result.stderr), file=sys.stderr)
                 return
 
             # Record for progress tracking
@@ -160,7 +162,7 @@ def command_include(*, quiet: bool = False) -> None:
 
         if exit_code != 0:
             stderr_text = b"".join(stderr_chunks).decode('utf-8', errors='replace')
-            print(_("Failed to apply hunk: {}").format(stderr_text), file=sys.stderr)
+            print(_("Failed to apply hunk: {error}").format(error=stderr_text), file=sys.stderr)
             return
 
         # Record for progress tracking
@@ -197,6 +199,13 @@ def command_include_file(
     require_session_started()
     ensure_state_directory_exists()
 
+    if file == "":
+        if refuse_live_action_for_batch_selection(FileReviewAction.INCLUDE):
+            return 0
+        if refuse_ambiguous_bare_action_after_partial_file_review(FileReviewAction.INCLUDE):
+            return 0
+        refuse_bare_action_after_file_list("include --file")
+
     # Determine target file
     if file == "":
         target_file = get_selected_change_file_path()
@@ -219,6 +228,20 @@ def command_include_file(
         # follow-up `show --files` / `include --files` passes in the same session.
         hunks_staged = 0
         for patch in parse_unified_diff_streaming(stream_git_command(["diff", "--no-color"])):
+            if isinstance(patch, BinaryFileChange):
+                file_path = patch.new_path if patch.new_path != "/dev/null" else patch.old_path
+                if file_path != target_file:
+                    continue
+
+                result = run_git_command(["add", "--", file_path], check=False)
+                if result.returncode != 0:
+                    print(_("Failed to stage binary file: {error}").format(error=result.stderr), file=sys.stderr)
+                    break
+
+                record_hunk_included(compute_binary_file_hash(patch))
+                hunks_staged += 1
+                continue
+
             if patch.new_path != target_file:
                 continue
 
@@ -274,6 +297,12 @@ def command_include_file_as(replacement_text: str, file: str | None = None) -> N
     require_git_repository()
     require_session_started()
     ensure_state_directory_exists()
+    if file is None or file == "":
+        if refuse_live_action_for_batch_selection(FileReviewAction.INCLUDE):
+            return
+        if refuse_ambiguous_bare_action_after_partial_file_review(FileReviewAction.INCLUDE):
+            return
+        refuse_bare_action_after_file_list("include --file --as")
 
     operation_parts = ["include", "--as", replacement_text]
     if file is not None:
@@ -290,7 +319,7 @@ def command_include_file_as(replacement_text: str, file: str | None = None) -> N
         else:
             target_file = file
             preserve_selected_state = True
-            saved_selected_state = _snapshot_selected_change_state()
+            saved_selected_state = snapshot_selected_change_state()
 
         if preserve_selected_state:
             line_changes = cache_unstaged_file_as_single_hunk(target_file)
@@ -309,10 +338,11 @@ def command_include_file_as(replacement_text: str, file: str | None = None) -> N
         )
 
         if preserve_selected_state:
-            _restore_selected_change_state(saved_selected_state)
+            restore_selected_change_state(saved_selected_state)
         else:
             write_line_ids_file(get_processed_include_ids_file_path(), set())
             recalculate_selected_hunk_for_file(target_file)
+        clear_last_file_review_state_if_file_matches(target_file)
 
     print(_("✓ Included file as replacement: {file}").format(file=target_file), file=sys.stderr)
 
@@ -329,6 +359,16 @@ def command_include_line(line_id_specification: str, file: str | None = None) ->
     require_git_repository()
     require_session_started()
     ensure_state_directory_exists()
+    scope_resolution = resolve_live_line_action_scope(
+        FileReviewAction.INCLUDE,
+        action_command=f"include --line {line_id_specification}",
+        line_id_specification=line_id_specification,
+        file=file,
+        validate_pathless_before_live_guard=True,
+    )
+    if scope_resolution.should_stop:
+        return
+    review_state = scope_resolution.review_state
 
     operation_parts = ["include", "--line", line_id_specification]
     if file is not None:
@@ -357,7 +397,7 @@ def command_include_line(line_id_specification: str, file: str | None = None) ->
             else:
                 if file != "":
                     preserve_selected_state = True
-                    saved_selected_state = _snapshot_selected_change_state()
+                    saved_selected_state = snapshot_selected_change_state()
 
                 line_changes = cache_unstaged_file_as_single_hunk(target_file)
                 if line_changes is None:
@@ -435,14 +475,29 @@ def command_include_line(line_id_specification: str, file: str | None = None) ->
         update_index_with_blob_content(line_changes.path, target_index_content)
 
         if preserve_selected_state:
-            _restore_selected_change_state(saved_selected_state)
+            restore_selected_change_state(saved_selected_state)
         else:
             # Update processed include IDs only when the selected display remains
             # current for incremental line inclusion.
             write_line_ids_file(get_processed_include_ids_file_path(), combined_include_ids)
+            print(
+                _("✓ Included line(s): {lines} from {file}").format(
+                    lines=line_id_specification,
+                    file=line_changes.path,
+                ),
+                file=sys.stderr,
+            )
+            print_remaining_line_changes_header(line_changes.path)
             recalculate_selected_hunk_for_file(line_changes.path)
-
-    print(_("✓ Included line(s): {lines}").format(lines=line_id_specification), file=sys.stderr)
+        finish_review_scoped_line_action(review_state, file_path=line_changes.path)
+    if preserve_selected_state:
+        print(
+            _("✓ Included line(s): {lines} from {file}").format(
+                lines=line_id_specification,
+                file=line_changes.path,
+            ),
+            file=sys.stderr,
+        )
 
 
 def _derive_replacement_unit_display_ids(
@@ -545,9 +600,8 @@ def _build_partial_structural_run_selection_error(
         return None
 
     return _(
-        "Contiguous file-scoped selections cannot span multiple structural change runs "
-        "while selecting only part of one run. Select one run at a time, fully include "
-        "each spanned run, or use --as."
+        "That line range crosses separate changes while selecting only part of one. "
+        "Select one change at a time, include every line in the range, or use --as."
     )
 
 
@@ -634,45 +688,6 @@ def _apply_include_line_replacement(
     )
 
 
-def _snapshot_selected_change_state() -> dict[str, bytes | None]:
-    """Capture the current selected change cache so explicit file ops can restore it."""
-    paths = {
-        "patch": get_selected_hunk_patch_file_path(),
-        "hash": get_selected_hunk_hash_file_path(),
-        "kind": get_selected_change_kind_file_path(),
-        "line_state": get_line_changes_json_file_path(),
-        "binary": get_selected_binary_file_json_path(),
-        "index_snapshot": get_index_snapshot_file_path(),
-        "working_snapshot": get_working_tree_snapshot_file_path(),
-        "processed_include_ids": get_processed_include_ids_file_path(),
-    }
-    return {
-        name: (read_file_bytes(path) if path.exists() else None)
-        for name, path in paths.items()
-    }
-
-
-def _restore_selected_change_state(snapshot: dict[str, bytes | None]) -> None:
-    """Restore a previously captured selected change cache."""
-    paths = {
-        "patch": get_selected_hunk_patch_file_path(),
-        "hash": get_selected_hunk_hash_file_path(),
-        "kind": get_selected_change_kind_file_path(),
-        "line_state": get_line_changes_json_file_path(),
-        "binary": get_selected_binary_file_json_path(),
-        "index_snapshot": get_index_snapshot_file_path(),
-        "working_snapshot": get_working_tree_snapshot_file_path(),
-        "processed_include_ids": get_processed_include_ids_file_path(),
-    }
-    for name, path in paths.items():
-        data = snapshot.get(name)
-        if data is None:
-            path.unlink(missing_ok=True)
-        else:
-            path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_bytes(data)
-
-
 def command_include_line_as(
     line_id_specification: str,
     replacement_text: str,
@@ -684,6 +699,16 @@ def command_include_line_as(
     require_git_repository()
     require_session_started()
     ensure_state_directory_exists()
+    scope_resolution = resolve_live_line_action_scope(
+        FileReviewAction.INCLUDE,
+        action_command=f"include --line {line_id_specification} --as",
+        line_id_specification=line_id_specification,
+        file=file,
+        validate_pathless_before_live_guard=True,
+    )
+    if scope_resolution.should_stop:
+        return
+    review_state = scope_resolution.review_state
 
     operation_parts = ["include", "--line", line_id_specification, "--as", replacement_text]
     if no_edge_overlap:
@@ -711,7 +736,16 @@ def command_include_line_as(
             )
 
             write_line_ids_file(get_processed_include_ids_file_path(), set())
+            print(
+                _("✓ Included line(s) as replacement: {lines} from {file}").format(
+                    lines=line_id_specification,
+                    file=line_changes.path,
+                ),
+                file=sys.stderr,
+            )
+            print_remaining_line_changes_header(line_changes.path)
             recalculate_selected_hunk_for_file(line_changes.path)
+            finish_review_scoped_line_action(review_state, file_path=line_changes.path)
         else:
             if file == "":
                 target_file = get_selected_change_file_path()
@@ -732,7 +766,7 @@ def command_include_line_as(
             else:
                 if file != "":
                     preserve_selected_state = True
-                saved_selected_state = _snapshot_selected_change_state() if preserve_selected_state else None
+                saved_selected_state = snapshot_selected_change_state() if preserve_selected_state else None
 
                 cached_lines = cache_unstaged_file_as_single_hunk(target_file)
                 if cached_lines is None:
@@ -757,15 +791,28 @@ def command_include_line_as(
             )
 
             if preserve_selected_state:
-                _restore_selected_change_state(saved_selected_state)
+                restore_selected_change_state(saved_selected_state)
             else:
                 write_line_ids_file(get_processed_include_ids_file_path(), set())
+                print(
+                    _("✓ Included line(s) as replacement: {lines} from {file}").format(
+                        lines=line_id_specification,
+                        file=target_file,
+                    ),
+                    file=sys.stderr,
+                )
+                print_remaining_line_changes_header(target_file)
                 recalculate_selected_hunk_for_file(target_file)
+            finish_review_scoped_line_action(review_state, file_path=target_file)
 
-    print(
-        _("✓ Included line(s) as replacement: {lines}").format(lines=line_id_specification),
-        file=sys.stderr,
-    )
+    if preserve_selected_state:
+        print(
+            _("✓ Included line(s) as replacement: {lines} from {file}").format(
+                lines=line_id_specification,
+                file=target_file,
+            ),
+            file=sys.stderr,
+        )
 
 
 def command_include_to_batch(batch_name: str, line_ids: str | None = None, file: str | None = None, *, quiet: bool = False) -> None:
@@ -781,13 +828,35 @@ def command_include_to_batch(batch_name: str, line_ids: str | None = None, file:
     """
     require_git_repository()
     ensure_state_directory_exists()
+    original_file_scope = file
+    scope_resolution = resolve_live_to_batch_action_scope(
+        FileReviewAction.INCLUDE_TO_BATCH,
+        command_name="include",
+        batch_name=batch_name,
+        line_ids=line_ids,
+        file=file,
+    )
+    if scope_resolution.should_stop:
+        return
+    file = scope_resolution.file
+    review_state = scope_resolution.review_state
     operation_parts = ["include", "--to", batch_name]
     if line_ids is not None:
         operation_parts.extend(["--line", line_ids])
     if file is not None:
         operation_parts.extend(["--file", file])
     with undo_checkpoint(" ".join(operation_parts)):
-        if file is not None:
+        if (
+            file is None
+            and line_ids is None
+            and read_selected_change_kind() == SelectedChangeKind.BINARY
+        ):
+            selected_change = load_selected_change()
+            if isinstance(selected_change, BinaryFileChange):
+                _command_include_binary_to_batch(batch_name, selected_change, quiet=quiet)
+            else:
+                _command_include_hunk_to_batch(batch_name, file_only=False, quiet=quiet)
+        elif file is not None:
             # File-scoped operation
 
             # Determine target file
@@ -807,20 +876,48 @@ def command_include_to_batch(batch_name: str, line_ids: str | None = None, file:
                 _command_include_file_lines_to_batch(batch_name, target_file, line_ids, quiet=quiet)
         else:
             # Hunk-scoped operation (selected behavior)
-            if (
-                line_ids is None
-                and read_selected_change_kind() == SelectedChangeKind.BINARY
-            ):
-                selected_change = load_selected_change()
-                if isinstance(selected_change, BinaryFileChange):
-                    _command_include_binary_to_batch(batch_name, selected_change, quiet=quiet)
-                else:
-                    _command_include_hunk_to_batch(batch_name, file_only=False, quiet=quiet)
-            elif line_ids is not None:
+            if line_ids is not None:
                 _command_include_lines_to_batch(batch_name, line_ids, quiet=quiet)
             else:
                 # Include entire selected hunk
                 _command_include_hunk_to_batch(batch_name, file_only=False, quiet=quiet)
+    if original_file_scope in (None, "") and line_ids is not None:
+        finish_review_scoped_line_action(review_state)
+
+
+def _detect_file_mode(file_path: str) -> str:
+    """Return the current git file mode for a path, defaulting to a regular file."""
+    absolute_path = get_git_repository_root_path() / file_path
+    if absolute_path.exists():
+        return "100755" if absolute_path.stat().st_mode & stat.S_IXUSR else "100644"
+
+    ls_result = run_git_command(["ls-files", "-s", "--", file_path], check=False)
+    if ls_result.returncode == 0 and ls_result.stdout.strip():
+        parts = ls_result.stdout.strip().split()
+        if parts:
+            return parts[0]
+    return "100644"
+
+
+def _save_empty_text_lifecycle_to_batch(
+    batch_name: str,
+    file_path: str,
+    file_mode: str,
+) -> str | None:
+    """Persist an empty added/deleted text path, returning its lifecycle type."""
+    change_type = detect_empty_text_lifecycle_change(file_path)
+    if change_type is None:
+        return None
+
+    snapshot_file_if_untracked(file_path)
+    add_file_to_batch(
+        batch_name,
+        file_path,
+        BatchOwnership(claimed_lines=[], deletions=[]),
+        file_mode,
+        change_type=change_type,
+    )
+    return change_type.value
 
 
 def _command_include_binary_to_batch(
@@ -863,6 +960,11 @@ def _command_include_file_to_batch(batch_name: str, file_path: str, *, quiet: bo
     if not batch_exists(batch_name):
         create_batch(batch_name, "Auto-created")
 
+    binary_change = render_binary_file_change(file_path)
+    if binary_change is not None:
+        _command_include_binary_to_batch(batch_name, binary_change, quiet=quiet)
+        return
+
     # Detect file mode
     file_mode = _detect_file_mode(file_path)
 
@@ -875,6 +977,15 @@ def _command_include_file_to_batch(batch_name: str, file_path: str, *, quiet: bo
         all_lines_to_batch.extend(hunk_lines.lines)
 
     if not all_lines_to_batch:
+        if _save_empty_text_lifecycle_to_batch(batch_name, file_path, file_mode) is not None:
+            if not quiet:
+                print(_("Included file '{file}' to batch '{batch}'").format(file=file_path, batch=batch_name), file=sys.stderr)
+            if quiet:
+                advance_to_next_change()
+            else:
+                advance_to_and_show_next_change()
+            return
+
         if not quiet:
             print(_("No changes in file '{file}' to include.").format(file=file_path), file=sys.stderr)
         return
@@ -955,7 +1066,6 @@ def _command_include_file_lines_to_batch(batch_name: str, file_path: str, line_i
             print(_("No lines match the specified IDs in file '{file}'.").format(file=file_path), file=sys.stderr)
         return
 
-    # Detect file mode
     file_mode = _detect_file_mode(file_path)
 
     # Prepare batch ownership update (handles stale source, translation, merge)
@@ -1055,7 +1165,6 @@ def _command_include_lines_to_batch(batch_name: str, line_id_specification: str,
                 file=line_changes.path, batch=batch_name, error=str(e))
         )
 
-    # Detect file mode
     file_mode = _detect_file_mode(line_changes.path)
 
     # Save to batch using batch source model
@@ -1107,6 +1216,13 @@ def _command_include_hunk_to_batch(batch_name: str, file_only: bool = False, *, 
     selected_patch = None
     selected_hash = None
     for patch in parse_unified_diff_streaming(stream_git_command(["diff", f"-U{get_context_lines()}", "--no-color"])):
+        if isinstance(patch, BinaryFileChange):
+            patch_hash = compute_binary_file_hash(patch)
+            if patch_hash not in blocked_hashes:
+                _command_include_binary_to_batch(batch_name, patch, quiet=quiet)
+                return
+            continue
+
         patch_bytes = patch.to_patch_bytes()
         patch_hash = compute_stable_hunk_hash(patch_bytes)
         if patch_hash not in blocked_hashes:

--- a/src/git_stage_batch/commands/include_from.py
+++ b/src/git_stage_batch/commands/include_from.py
@@ -11,9 +11,11 @@ from ..batch.metadata_validation import read_validated_batch_metadata
 from ..batch.query import get_batch_commit_sha
 from ..batch.replacement import build_replacement_batch_view
 from ..batch.selection import (
+    resolve_current_batch_binary_file_scope,
     resolve_batch_file_scope,
     require_single_file_context_for_line_selection,
     select_batch_ownership_for_display_ids,
+    translate_batch_file_gutter_ids_to_selection_ids,
     translate_atomic_unit_error_to_gutter_ids,
 )
 from ..batch.validation import batch_exists
@@ -23,7 +25,13 @@ from ..core.text_lifecycle import (
     normalized_text_change_type,
     selected_text_target_change_type,
 )
-from ..data.hunk_tracking import render_batch_file_display
+from ..data.file_review_state import (
+    FileReviewAction,
+    resolve_batch_source_action_scope,
+)
+from ..data.hunk_tracking import (
+    render_batch_file_display,
+)
 from ..data.session import snapshot_file_if_untracked
 from ..data.undo import undo_checkpoint
 from ..exceptions import (
@@ -197,6 +205,15 @@ def command_include_from_batch(
         replacement_text: Optional replacement text for selected batch lines.
     """
     require_git_repository()
+    scope_resolution = resolve_batch_source_action_scope(
+        FileReviewAction.INCLUDE_FROM_BATCH,
+        command_name="include",
+        batch_name=batch_name,
+        line_ids=line_ids,
+        file=file,
+        patterns=patterns,
+    )
+    file = scope_resolution.file
 
     # Refresh index to ensure git's cached stat info is up-to-date
     run_git_command(["update-index", "--refresh"], check=False)
@@ -216,6 +233,8 @@ def command_include_from_batch(
     if not all_files:
         exit_with_error(_("Batch '{name}' is empty").format(name=batch_name))
 
+    file = resolve_current_batch_binary_file_scope(batch_name, all_files, file, patterns, line_ids)
+
     # Determine which files to operate on
     files = resolve_batch_file_scope(batch_name, all_files, file, patterns)
 
@@ -226,7 +245,6 @@ def command_include_from_batch(
     if replacement_text is not None and not selected_ids:
         exit_with_error(_("`include --from --as` requires `--line`."))
 
-    # Reject line selection for binary files (binary files are atomic units)
     if selected_ids:
         file_path_for_check = list(files.keys())[0]  # Single file context enforced above
         if files[file_path_for_check].get("file_type") == "binary":
@@ -238,17 +256,13 @@ def command_include_from_batch(
     if selected_ids:
         if replacement_text is not None:
             _require_contiguous_display_selection(selected_ids)
-        # Use pure render helper to get gutter ID mapping (no side effects)
         file_path_for_render = list(files.keys())[0]  # Single file context enforced above
-        rendered = render_batch_file_display(batch_name, file_path_for_render)
-        if rendered:
-            # Translate gutter IDs (what user sees) to selection IDs (internal)
-            selection_ids_to_include = set()
-            for gutter_id in selected_ids:
-                if gutter_id in rendered.gutter_to_selection_id:
-                    selection_ids_to_include.add(rendered.gutter_to_selection_id[gutter_id])
-                else:
-                    exit_with_error(_("Line ID {id} not found or not individually mergeable").format(id=gutter_id))
+        selection_ids_to_include, rendered = translate_batch_file_gutter_ids_to_selection_ids(
+            batch_name,
+            file_path_for_render,
+            selected_ids,
+            FileReviewAction.INCLUDE_FROM_BATCH,
+        )
     operation_parts = ["include", "--from", batch_name]
     if line_ids is not None:
         operation_parts.extend(["--line", line_ids])

--- a/src/git_stage_batch/commands/reset.py
+++ b/src/git_stage_batch/commands/reset.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import json
+import shlex
 import sys
 
+from ..core.line_selection import format_line_ids
 from ..batch.operations import create_batch
 from ..batch.ownership import (
     BatchOwnership,
@@ -17,6 +19,7 @@ from ..batch.ownership import (
 from ..batch.query import read_batch_metadata
 from ..batch.selection import (
     require_single_file_context_for_line_selection,
+    resolve_current_batch_binary_file_scope,
     resolve_batch_file_scope,
 )
 from ..batch.storage import (
@@ -28,6 +31,24 @@ from ..batch.state_refs import sync_batch_state_refs
 from ..batch.validation import batch_exists, validate_batch_name
 from ..exceptions import MergeError, exit_with_error
 from ..i18n import _
+from ..data.file_review_state import (
+    FileReviewAction,
+    ReviewSource,
+    fresh_batch_review_selection_groups_for_action,
+    read_last_file_review_state,
+    resolve_batch_source_action_scope,
+    validate_pathless_review_line_action,
+    validate_review_scoped_line_selection,
+)
+from ..data.hunk_tracking import (
+    SelectedChangeKind,
+    clear_selected_change_state_files,
+    get_selected_change_file_path,
+    mark_selected_change_cleared_by_stale_batch_selection,
+    read_selected_change_kind,
+    render_batch_file_display,
+    selected_batch_binary_matches_batch,
+)
 from ..data.undo import undo_checkpoint
 from ..utils.file_io import write_text_file_contents
 from ..utils.git import require_git_repository, run_git_command
@@ -57,14 +78,38 @@ def command_reset_from_batch(
     require_git_repository()
     ensure_state_directory_exists()
     validate_batch_name(batch_name)
+    extra_action_parts = ()
+    if to_batch is not None:
+        extra_action_parts = ("--to", shlex.quote(to_batch))
+    scope_resolution = resolve_batch_source_action_scope(
+        FileReviewAction.RESET_FROM_BATCH,
+        command_name="reset",
+        batch_name=batch_name,
+        line_ids=line_ids,
+        file=file,
+        patterns=patterns,
+        extra_action_parts=extra_action_parts,
+    )
+    file = scope_resolution.file
 
     if not batch_exists(batch_name):
         exit_with_error(_("Batch '{name}' does not exist").format(name=batch_name))
+
+    metadata = read_batch_metadata(batch_name)
+    all_files = metadata.get("files", {})
+    file = resolve_current_batch_binary_file_scope(batch_name, all_files, file, patterns, line_ids)
 
     if to_batch is not None:
         validate_batch_name(to_batch)
         if to_batch == batch_name:
             exit_with_error(_("--to must name a different batch"))
+
+    effective_line_ids = (
+        _translate_reset_line_ids_to_selection_ids(batch_name, all_files, file, patterns, line_ids)
+        if line_ids is not None else
+        None
+    )
+    affected_files = set(resolve_batch_file_scope(batch_name, all_files, file, patterns).keys())
     operation_parts = ["reset", "--from", batch_name]
     if to_batch is not None:
         operation_parts.extend(["--to", to_batch])
@@ -74,15 +119,21 @@ def command_reset_from_batch(
         operation_parts.extend(["--file", file])
     with undo_checkpoint(" ".join(operation_parts)):
         if to_batch is not None:
-            _move_claims_between_batches(batch_name, to_batch, file, patterns, line_ids)
+            _move_claims_between_batches(batch_name, to_batch, file, patterns, effective_line_ids)
         elif file is not None:
-            _reset_file_claims_from_batch(batch_name, file, line_ids)
+            _reset_file_claims_from_batch(batch_name, file, effective_line_ids)
         elif patterns is not None:
-            _reset_pattern_claims_from_batch(batch_name, patterns, line_ids)
+            _reset_pattern_claims_from_batch(batch_name, patterns, effective_line_ids)
         elif line_ids is not None:
-            _reset_line_claims_from_batch(batch_name, line_ids)
+            _reset_line_claims_from_batch(batch_name, effective_line_ids)
         else:
             _reset_all_claims_from_batch(batch_name)
+
+    _clear_selected_batch_state_after_batch_mutation(
+        source_batch=batch_name,
+        dest_batch=to_batch,
+        affected_files=affected_files,
+    )
 
     if to_batch is not None and line_ids:
         print(_("✓ Moved line(s) {lines} from batch '{source}' to '{dest}'").format(
@@ -101,6 +152,110 @@ def command_reset_from_batch(
     else:
         print(_("✓ Reset all claims from batch '{name}'").format(name=batch_name), file=sys.stderr)
 
+
+def _clear_selected_batch_state_after_batch_mutation(
+    *,
+    source_batch: str,
+    dest_batch: str | None,
+    affected_files: set[str],
+) -> None:
+    """Clear selected batch views that point at files changed by reset."""
+    selected_kind = read_selected_change_kind()
+    if selected_kind not in (SelectedChangeKind.BATCH_FILE, SelectedChangeKind.BATCH_BINARY):
+        return
+
+    selected_file = get_selected_change_file_path()
+    if selected_file is None or selected_file not in affected_files:
+        return
+
+    if selected_kind == SelectedChangeKind.BATCH_BINARY:
+        if selected_batch_binary_matches_batch(source_batch) or (
+            dest_batch is not None and selected_batch_binary_matches_batch(dest_batch)
+        ):
+            stale_batch = source_batch if selected_batch_binary_matches_batch(source_batch) else dest_batch
+            clear_selected_change_state_files()
+            mark_selected_change_cleared_by_stale_batch_selection(
+                batch_name=stale_batch or source_batch,
+                file_path=selected_file,
+            )
+        return
+
+    review_state = read_last_file_review_state()
+    if review_state is not None:
+        if review_state.source == ReviewSource.BATCH and review_state.batch_name in {source_batch, dest_batch}:
+            stale_batch = review_state.batch_name or source_batch
+            clear_selected_change_state_files()
+            mark_selected_change_cleared_by_stale_batch_selection(
+                batch_name=stale_batch,
+                file_path=selected_file,
+            )
+        return
+
+    # Filtered batch text views do not persist the batch name, so clear on a
+    # matching path rather than leave a stale pathless action target behind.
+    clear_selected_change_state_files()
+    mark_selected_change_cleared_by_stale_batch_selection(
+        batch_name=source_batch,
+        file_path=selected_file,
+    )
+
+
+def _translate_reset_line_ids_to_selection_ids(
+    batch_name: str,
+    all_files: dict[str, dict],
+    file: str | None,
+    patterns: list[str] | None,
+    line_id_specification: str,
+) -> str:
+    """Translate fresh file-review gutter IDs to batch selection IDs.
+
+    Reset is a metadata operation, so explicit reset line IDs must keep working
+    even when a batch change is not currently mergeable into the worktree. Only
+    translate through the mergeability-filtered gutter map when a fresh batch
+    file review is in scope; otherwise leave the batch display IDs untouched.
+    """
+    files = resolve_batch_file_scope(batch_name, all_files, file, patterns)
+    selected_ids = require_single_file_context_for_line_selection(
+        batch_name, files, line_id_specification, "reset"
+    )
+    if selected_ids is None:
+        return line_id_specification
+
+    file_path = list(files.keys())[0]
+    if files[file_path].get("file_type") == "binary":
+        exit_with_error(_("Cannot use --lines with binary files. Reset the whole file instead."))
+
+    review_groups = fresh_batch_review_selection_groups_for_action(
+        batch_name,
+        file_path,
+        FileReviewAction.RESET_FROM_BATCH,
+    )
+    if review_groups is None:
+        return line_id_specification
+    validate_review_scoped_line_selection(selected_ids, review_groups)
+
+    rendered = render_batch_file_display(batch_name, file_path)
+    if rendered is None:
+        exit_with_error(
+            _("No changes for file '{file}' in batch '{name}'.").format(
+                file=file_path,
+                name=batch_name,
+            )
+        )
+
+    display_id_map = rendered.review_gutter_to_selection_id or rendered.gutter_to_selection_id
+    selection_ids = set()
+    for gutter_id in selected_ids:
+        if gutter_id in display_id_map:
+            selection_ids.add(display_id_map[gutter_id])
+        else:
+            exit_with_error(
+                _("Line ID {id} is not available for this action. Select one of the numbered lines shown for this batch file.").format(
+                    id=gutter_id
+                )
+            )
+
+    return format_line_ids(sorted(selection_ids))
 
 def _ensure_destination_batch(source_batch: str, dest_batch: str, source_metadata: dict) -> None:
     """Create destination batch from source baseline, or verify compatibility."""
@@ -172,7 +327,11 @@ def _add_ownership_to_destination(
 
     if dest_file_meta is not None:
         if dest_file_meta.get("file_type") == "binary":
-            exit_with_error(_("Cannot merge text claims into binary file '{file}' in destination batch").format(file=file_path))
+            exit_with_error(
+                _("Destination batch already has a binary version of '{file}', so text changes for the same file cannot be moved there.").format(
+                    file=file_path
+                )
+            )
         if dest_file_meta.get("batch_source_commit") != batch_source_commit:
             exit_with_error(
                 _("Destination batch already has file '{file}' with a different batch source").format(
@@ -189,6 +348,7 @@ def _add_ownership_to_destination(
         ownership,
         file_mode,
         batch_source_commit=batch_source_commit,
+        change_type=source_file_meta.get("change_type"),
     )
 
 
@@ -273,7 +433,7 @@ def _reset_line_claims_for_file(
 
     # Get current ownership for the file
     if metadata["files"][file_path].get("file_type") == "binary":
-        exit_with_error(_("Cannot use --lines with binary files. Binary files must be reset as complete units."))
+        exit_with_error(_("Cannot use --lines with binary files. Reset the whole file instead."))
 
     ownership = BatchOwnership.from_metadata_dict(metadata["files"][file_path])
 
@@ -309,6 +469,7 @@ def _reset_line_claims_for_file(
             new_ownership,
             file_mode,
             batch_source_commit=batch_source_commit,
+            change_type=metadata["files"][file_path].get("change_type"),
         )
 
 
@@ -321,7 +482,7 @@ def _select_line_ownership_for_file(
     metadata = read_batch_metadata(batch_name)
 
     if metadata["files"][file_path].get("file_type") == "binary":
-        exit_with_error(_("Cannot use --lines with binary files. Binary files must be reset as complete units."))
+        exit_with_error(_("Cannot use --lines with binary files. Reset the whole file instead."))
 
     ownership = BatchOwnership.from_metadata_dict(metadata["files"][file_path])
     batch_source_commit = metadata["files"][file_path]["batch_source_commit"]

--- a/src/git_stage_batch/commands/show.py
+++ b/src/git_stage_batch/commands/show.py
@@ -8,21 +8,44 @@ import sys
 from ..batch.display import annotate_with_batch_source
 from ..core.diff_parser import build_line_changes_from_patch_bytes, parse_unified_diff_streaming
 from ..core.diff_parser import write_snapshots_for_selected_file_path
-from ..core.hashing import compute_stable_hunk_hash
+from ..core.hashing import compute_binary_file_hash, compute_stable_hunk_hash
 from ..core.models import BinaryFileChange
 from ..data.hunk_tracking import (
     SelectedChangeKind,
     apply_line_level_batch_filter_to_cached_hunk,
+    cache_binary_file_change,
     cache_file_as_single_hunk,
+    clear_selected_change_state_files,
     get_selected_change_file_path,
+    mark_selected_change_cleared_by_file_list,
+    render_binary_file_change,
     render_file_as_single_hunk,
+    restore_selected_change_state,
+    snapshot_selected_change_state,
     write_selected_change_kind,
+)
+from ..data.file_review_state import (
+    clear_last_file_review_state,
+    ReviewSource,
+    write_last_file_review_state,
 )
 from ..data.line_state import convert_line_changes_to_serializable_dict, load_line_changes_from_state
 from ..data.session import require_session_started
 from ..exceptions import exit_with_error
 from ..i18n import _
-from ..output import print_line_level_changes
+from ..output import print_binary_file_change, print_line_level_changes
+from ..output.file_review import (
+    build_file_review_model,
+    make_file_review_state,
+    normalize_page_spec,
+    print_file_review,
+    resolve_default_review_pages,
+)
+from ..output.file_review_list import (
+    make_binary_file_review_list_entry,
+    make_file_review_list_entry,
+    print_file_review_list,
+)
 from ..utils.file_io import read_text_file_contents, write_file_bytes, write_text_file_contents
 from ..utils.git import require_git_repository, stream_git_command
 from ..utils.paths import (
@@ -35,13 +58,57 @@ from ..utils.paths import (
 )
 
 
-def command_show(file: str | None = None, *, porcelain: bool = False, selectable: bool = True) -> None:
+def _load_previous_selection_for_review():
+    """Best-effort load of the prior selection for page anchoring."""
+    try:
+        return load_line_changes_from_state()
+    except Exception:
+        return None
+
+
+def command_show_file_list(files: list[str]) -> None:
+    """Show a navigational file list for multiple live file reviews."""
+    require_git_repository()
+    require_session_started()
+    ensure_state_directory_exists()
+
+    entries = []
+    for file_path in files:
+        line_changes = render_file_as_single_hunk(file_path)
+        if line_changes is not None:
+            entries.append(make_file_review_list_entry(line_changes))
+            continue
+        binary_change = render_binary_file_change(file_path)
+        if binary_change is not None:
+            entries.append(make_binary_file_review_list_entry(binary_change))
+
+    if not entries:
+        print(_("No reviewable changes in matched files."), file=sys.stderr)
+        return
+
+    clear_selected_change_state_files()
+    mark_selected_change_cleared_by_file_list(source=ReviewSource.FILE_VS_HEAD.value)
+
+    print_file_review_list(
+        source_label=_("Changes: file vs HEAD"),
+        entries=entries,
+    )
+
+
+def command_show(
+    file: str | None = None,
+    *,
+    page: str | None = None,
+    porcelain: bool = False,
+    selectable: bool = True,
+) -> None:
     """Show the first unprocessed hunk or entire file.
 
     Args:
         file: Optional file path for file-scoped display.
               If empty string, uses selected hunk's file.
               If None, shows selected hunk (normal behavior).
+        page: Optional file-review page selection.
         porcelain: If True, produce no output and exit with code 0 if hunk found, 1 if none
         selectable: If True, cache the file and show selectable gutter IDs.
                     If False, only preview the file and hide gutter IDs.
@@ -52,6 +119,8 @@ def command_show(file: str | None = None, *, porcelain: bool = False, selectable
 
     # File-scoped operation
     if file is not None:
+        previous_selection = _load_previous_selection_for_review()
+
         # Determine target file
         if file == "":
             # --file with no arg: use selected hunk's file
@@ -61,11 +130,32 @@ def command_show(file: str | None = None, *, porcelain: bool = False, selectable
         else:
             target_file = file
 
+        preview_lines = render_file_as_single_hunk(target_file)
+        binary_change = render_binary_file_change(target_file) if preview_lines is None else None
+        if binary_change is not None:
+            if page is not None:
+                exit_with_error(_("File review pages are only available for text changes."))
+            if selectable:
+                clear_last_file_review_state()
+                cache_binary_file_change(binary_change)
+            if porcelain:
+                return
+            print_binary_file_change(binary_change)
+            return
+
+        if selectable and page is not None and preview_lines is not None:
+            preview_model = build_file_review_model(preview_lines)
+            resolve_default_review_pages(
+                preview_model,
+                requested_page_spec=page,
+                previous_selection=previous_selection,
+            )
+
         # Cache and display entire file when it's the active selection.
         file_lines = (
             cache_file_as_single_hunk(target_file)
             if selectable else
-            render_file_as_single_hunk(target_file)
+            preview_lines
         )
         if file_lines is None:
             if porcelain:
@@ -74,8 +164,44 @@ def command_show(file: str | None = None, *, porcelain: bool = False, selectable
                 print(_("No changes in file '{file}'.").format(file=target_file), file=sys.stderr)
             return
 
+        if selectable:
+            clear_last_file_review_state()
+
+        if porcelain:
+            return
+
         if not porcelain:
-            print_line_level_changes(file_lines, gutter_to_selection_id=None if selectable else {})
+            if selectable:
+                review_model = build_file_review_model(file_lines)
+                shown_pages = resolve_default_review_pages(
+                    review_model,
+                    requested_page_spec=page,
+                    previous_selection=previous_selection,
+                )
+                page_spec = normalize_page_spec(shown_pages, len(review_model.pages))
+                review_state = make_file_review_state(
+                    review_model,
+                    source=ReviewSource.FILE_VS_HEAD,
+                    batch_name=None,
+                    shown_pages=shown_pages,
+                    selected_change_kind=SelectedChangeKind.FILE,
+                )
+                write_last_file_review_state(review_state)
+                print_file_review(
+                    review_model,
+                    shown_pages=shown_pages,
+                    source_label=_("Changes: file vs HEAD"),
+                    page_spec=page_spec,
+                    source=ReviewSource.FILE_VS_HEAD,
+                    opened_near_selected_hunk=(
+                        page is None
+                        and previous_selection is not None
+                        and previous_selection.path == file_lines.path
+                        and len(review_model.pages) > 1
+                    ),
+                )
+            else:
+                print_line_level_changes(file_lines, gutter_to_selection_id={})
         return
 
     # Hunk-scoped operation (selected behavior)
@@ -86,13 +212,20 @@ def command_show(file: str | None = None, *, porcelain: bool = False, selectable
 
     # Stream diff and show first unblocked hunk
     for patch in parse_unified_diff_streaming(stream_git_command(["diff", f"-U{get_context_lines()}", "--no-color"])):
-        # Skip binary files for now (they need special handling)
         if isinstance(patch, BinaryFileChange):
+            binary_hash = compute_binary_file_hash(patch)
+            if binary_hash not in blocked_hashes:
+                cache_binary_file_change(patch)
+                clear_last_file_review_state()
+                if not porcelain:
+                    print_binary_file_change(patch)
+                return
             continue
 
         patch_bytes = patch.to_patch_bytes()
         patch_hash = compute_stable_hunk_hash(patch_bytes)
         if patch_hash not in blocked_hashes:
+            previous_selected_state = snapshot_selected_change_state()
             # Cache selected hunk bytes exactly; display text is derived from parsed lines.
             write_file_bytes(get_selected_hunk_patch_file_path(), patch_bytes)
             write_text_file_contents(get_selected_hunk_hash_file_path(), patch_hash)
@@ -108,7 +241,10 @@ def command_show(file: str | None = None, *, porcelain: bool = False, selectable
             # Apply line-level batch filtering
             if apply_line_level_batch_filter_to_cached_hunk():
                 # All lines in this hunk are batched, skip to next
+                restore_selected_change_state(previous_selected_state)
                 continue
+
+            clear_last_file_review_state()
 
             # Display this unprocessed hunk (unless porcelain mode)
             if not porcelain:

--- a/src/git_stage_batch/commands/show_from.py
+++ b/src/git_stage_batch/commands/show_from.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shlex
 import sys
 from typing import Optional
 
@@ -12,16 +13,63 @@ from ..batch.selection import (
 )
 from ..batch.validation import batch_exists
 from ..data.hunk_tracking import (
-    cache_batch_as_single_hunk,
-    cache_batch_files_generator,
+    SelectedChangeKind,
+    cache_binary_file_change,
     cache_rendered_batch_file_display,
+    clear_selected_change_state_files,
+    compute_batch_binary_fingerprint,
+    mark_selected_change_cleared_by_file_list,
     render_batch_file_display,
 )
-from ..output import print_line_level_changes
+from ..data.file_review_state import (
+    ReviewSource,
+    clear_last_file_review_state,
+    write_last_file_review_state,
+)
+from ..output import print_binary_file_change, print_line_level_changes
+from ..output.file_review import (
+    build_file_review_model,
+    make_file_review_state,
+    normalize_page_spec,
+    print_file_review,
+    resolve_default_review_pages,
+)
+from ..output.file_review_list import make_binary_file_review_list_entry, make_file_review_list_entry, print_file_review_list
 from ..exceptions import exit_with_error, BatchMetadataError
 from ..i18n import _
-from ..core.models import LineLevelChange
+from ..core.models import BinaryFileChange, LineLevelChange
 from ..utils.git import require_git_repository
+
+
+def _batch_source_args(batch_name: str) -> str:
+    return f" --from {shlex.quote(batch_name)}"
+
+
+def _render_batch_binary_file_change(file_path: str, file_meta: dict) -> BinaryFileChange | None:
+    """Return an atomic binary batch change for display, if the entry is binary."""
+    if file_meta.get("file_type") != "binary":
+        return None
+    change_type = file_meta.get("change_type")
+    if change_type not in ("added", "modified", "deleted"):
+        return None
+    return BinaryFileChange(
+        old_path="/dev/null" if change_type == "added" else file_path,
+        new_path="/dev/null" if change_type == "deleted" else file_path,
+        change_type=change_type,
+    )
+
+
+def _shown_pages_for_display_ids(review_model, display_ids: set[int]) -> tuple[int, ...]:
+    """Return review pages that contain the selected display IDs."""
+    return tuple(
+        sorted(
+            {
+                change.first_page
+                for change in review_model.changes
+                if set(change.display_ids) & display_ids
+            }
+        )
+    )
 
 
 def command_show_from_batch(
@@ -30,6 +78,7 @@ def command_show_from_batch(
     file: Optional[str] = None,
     patterns: Optional[list[str]] = None,
     selectable: bool = True,
+    page: str | None = None,
 ) -> None:
     """Show changes from a batch.
 
@@ -40,6 +89,7 @@ def command_show_from_batch(
               If None, shows all files in batch.
         patterns: Optional gitignore-style file patterns to filter batch files.
         selectable: If True, cache the displayed file for later line operations.
+        page: Optional file-review page selection.
     """
     require_git_repository()
 
@@ -71,26 +121,147 @@ def command_show_from_batch(
         # Show specific file from batch
         # Get the resolved file path
         file_path = list(files.keys())[0]
+        binary_change = _render_batch_binary_file_change(file_path, files[file_path])
+        if binary_change is not None:
+            if selected_ids:
+                exit_with_error(
+                    _("Cannot use --lines with binary files. Run without --lines to view the binary change summary.")
+                )
+            if page is not None:
+                exit_with_error(_("File review pages are only available for text changes."))
+            if selectable:
+                clear_selected_change_state_files()
+                cache_binary_file_change(
+                    binary_change,
+                    kind=SelectedChangeKind.BATCH_BINARY,
+                    batch_name=batch_name,
+                    batch_binary_fingerprint=compute_batch_binary_fingerprint(
+                        batch_name,
+                        file_path,
+                        files[file_path],
+                    ),
+                )
+            print_binary_file_change(binary_change)
+            return
 
-        # Cache that file from batch
-        rendered = (
-            cache_batch_as_single_hunk(batch_name, file_path=file_path, metadata=metadata)
-            if selectable else
-            render_batch_file_display(batch_name, file_path, metadata=metadata)
-        )
+        rendered = render_batch_file_display(batch_name, file_path, metadata=metadata)
         if rendered is None:
             print(_("No changes for file '{file}' in batch '{name}'.").format(file=file_path, name=batch_name), file=sys.stderr)
             return
 
+        review_model = None
+        review_gutter_to_selection_id = (
+            rendered.review_gutter_to_selection_id
+            or rendered.gutter_to_selection_id
+        )
+        review_selection_id_to_gutter = (
+            rendered.review_selection_id_to_gutter
+            or rendered.selection_id_to_gutter
+        )
+        review_action_groups = rendered.review_action_groups or None
+
+        def get_review_model():
+            nonlocal review_model
+            if review_model is None:
+                review_model = build_file_review_model(
+                    rendered.line_changes,
+                    gutter_to_selection_id=review_gutter_to_selection_id,
+                    actionable_selection_groups=rendered.actionable_selection_groups,
+                    review_action_groups=review_action_groups,
+                )
+            return review_model
+
+        if selectable and page is not None:
+            resolve_default_review_pages(
+                get_review_model(),
+                requested_page_spec=page,
+                previous_selection=None,
+            )
+
+        if page is not None or (selectable and not selected_ids):
+            review_model = get_review_model()
+            shown_pages = resolve_default_review_pages(
+                review_model,
+                requested_page_spec=page,
+                previous_selection=None,
+            )
+            page_spec = normalize_page_spec(shown_pages, len(review_model.pages))
+            if selectable:
+                clear_last_file_review_state()
+                cache_rendered_batch_file_display(file_path, rendered)
+                write_last_file_review_state(
+                    make_file_review_state(
+                        review_model,
+                        source=ReviewSource.BATCH,
+                        batch_name=batch_name,
+                        shown_pages=shown_pages,
+                        selected_change_kind=SelectedChangeKind.BATCH_FILE,
+                        gutter_to_selection_id=review_gutter_to_selection_id,
+                        actionable_selection_groups=rendered.actionable_selection_groups,
+                        review_action_groups=review_action_groups,
+                    )
+                )
+            print_file_review(
+                review_model,
+                shown_pages=shown_pages,
+                source_label=_("Changes: batch {name}").format(name=batch_name),
+                page_spec=page_spec,
+                command_source_args=_batch_source_args(batch_name),
+                source=ReviewSource.BATCH,
+                batch_name=batch_name,
+            )
+            return
+
         # Filter by line IDs if specified (for display only)
         if selected_ids:
+            line_gutter_to_selection_id = (
+                review_gutter_to_selection_id
+                if selectable else
+                rendered.gutter_to_selection_id
+            )
+            line_selection_id_to_gutter = (
+                review_selection_id_to_gutter
+                if selectable else
+                rendered.selection_id_to_gutter
+            )
+
             # Translate gutter IDs (what user sees) to selection IDs (internal)
             selection_ids = set()
             for gutter_id in selected_ids:
-                if gutter_id in rendered.gutter_to_selection_id:
-                    selection_ids.add(rendered.gutter_to_selection_id[gutter_id])
+                if gutter_id in line_gutter_to_selection_id:
+                    selection_ids.add(line_gutter_to_selection_id[gutter_id])
                 else:
-                    exit_with_error(_("Line ID {id} not found or not individually mergeable").format(id=gutter_id))
+                    exit_with_error(
+                        _("Line ID {id} is not available for this action. Select one of the numbered lines shown for this batch file.").format(
+                            id=gutter_id
+                        )
+                    )
+
+            if selectable:
+                clear_last_file_review_state()
+                cache_rendered_batch_file_display(file_path, rendered)
+                review_model = get_review_model()
+                visible_review_display_ids = {
+                    review_selection_id_to_gutter[selection_id]
+                    for selection_id in selection_ids
+                    if selection_id in review_selection_id_to_gutter
+                }
+                shown_pages = _shown_pages_for_display_ids(review_model, visible_review_display_ids)
+                if shown_pages:
+                    write_last_file_review_state(
+                        make_file_review_state(
+                            review_model,
+                            source=ReviewSource.BATCH,
+                            batch_name=batch_name,
+                            shown_pages=shown_pages,
+                            selected_change_kind=SelectedChangeKind.BATCH_FILE,
+                            gutter_to_selection_id=review_gutter_to_selection_id,
+                            actionable_selection_groups=rendered.actionable_selection_groups,
+                            review_action_groups=review_action_groups,
+                            visible_display_ids=visible_review_display_ids,
+                            entire_file_shown=False,
+                        )
+                    )
 
             # Filter by selection IDs (not gutter IDs)
             filtered_lines = [line for line in rendered.line_changes.lines if line.id in selection_ids]
@@ -100,31 +271,47 @@ def command_show_from_batch(
                     lines=filtered_lines,
                     header=rendered.line_changes.header
                 )
-                print_line_level_changes(filtered_line_changes, gutter_to_selection_id=rendered.gutter_to_selection_id)
+                print_line_level_changes(filtered_line_changes, gutter_to_selection_id=line_gutter_to_selection_id)
         else:
             print_line_level_changes(
-                rendered.line_changes,
-                gutter_to_selection_id=rendered.gutter_to_selection_id if selectable else {},
-            )
+                    rendered.line_changes,
+                    gutter_to_selection_id=(
+                        review_gutter_to_selection_id
+                        if selectable else
+                        {}
+                    ),
+                )
 
         return
 
-    # Show all files in batch
-    has_content = False
-    first_rendered = None
-    for rendered in cache_batch_files_generator(batch_name, metadata=metadata):
-        if not has_content:
-            has_content = True
-            first_rendered = rendered
-        else:
-            # Print blank line separator between files
-            print()
+    entries = []
+    for file_path, file_meta in files.items():
+        binary_change = _render_batch_binary_file_change(file_path, file_meta)
+        if binary_change is not None:
+            entries.append(make_binary_file_review_list_entry(binary_change))
+            continue
+        rendered = render_batch_file_display(batch_name, file_path, metadata=metadata)
+        if rendered is not None:
+            entries.append(
+                make_file_review_list_entry(
+                    rendered.line_changes,
+                    gutter_to_selection_id=rendered.review_gutter_to_selection_id or rendered.gutter_to_selection_id,
+                )
+            )
 
-        print_line_level_changes(rendered.line_changes, gutter_to_selection_id=rendered.gutter_to_selection_id)
-
-    # Cache first file for subsequent commands
-    if first_rendered is not None:
-        cache_rendered_batch_file_display(first_rendered.line_changes.path, first_rendered)
+    if entries:
+        # Multi-file batch output is navigational; it must not leave a hidden
+        # selected file that a later bare action could operate on.
+        if selectable:
+            clear_selected_change_state_files()
+            mark_selected_change_cleared_by_file_list(
+                source=ReviewSource.BATCH.value,
+                batch_name=batch_name,
+            )
+        print_file_review_list(
+            source_label=_("Changes: batch {name}").format(name=batch_name),
+            entries=entries,
+            command_source_args=_batch_source_args(batch_name),
+        )
     else:
-        # Empty batch
         print(_("Batch '{name}' is empty").format(name=batch_name), file=sys.stderr)

--- a/src/git_stage_batch/commands/skip.py
+++ b/src/git_stage_batch/commands/skip.py
@@ -7,20 +7,39 @@ import json
 import sys
 
 from ..core.diff_parser import build_line_changes_from_patch_bytes, parse_unified_diff_streaming
-from ..core.hashing import compute_stable_hunk_hash
+from ..core.hashing import compute_binary_file_hash, compute_stable_hunk_hash
 from ..core.line_selection import (
     parse_line_selection,
     read_line_ids_file,
     write_line_ids_file,
 )
 from ..core.models import BinaryFileChange
-from ..data.hunk_tracking import SelectedChangeKind, advance_to_and_show_next_change, advance_to_next_change, fetch_next_change, get_selected_change_file_path, load_selected_change, read_selected_change_kind, record_hunk_skipped, require_selected_hunk
+from ..data.hunk_tracking import (
+    SelectedChangeKind,
+    advance_to_and_show_next_change,
+    advance_to_next_change,
+    fetch_next_change,
+    get_selected_change_file_path,
+    load_selected_change,
+    read_selected_change_kind,
+    record_binary_hunk_skipped,
+    record_hunk_skipped,
+    refuse_bare_action_after_file_list,
+    require_selected_hunk,
+)
+from ..data.file_review_state import (
+    FileReviewAction,
+    finish_review_scoped_line_action,
+    refuse_ambiguous_bare_action_after_partial_file_review,
+    refuse_live_action_for_batch_selection,
+    resolve_live_line_action_scope,
+)
 from ..data.line_state import convert_line_changes_to_serializable_dict, load_line_changes_from_state
 from ..data.session import require_session_started
 from ..data.undo import undo_checkpoint
-from ..exceptions import NoMoreHunks
+from ..exceptions import NoMoreHunks, exit_with_error
 from ..i18n import _, ngettext
-from ..output import print_line_level_changes
+from ..output import print_line_level_changes, print_remaining_line_changes_header
 from ..utils.file_io import append_lines_to_file, read_text_file_contents, write_text_file_contents
 from ..utils.git import require_git_repository, stream_git_command
 from ..utils.journal import log_journal
@@ -41,6 +60,12 @@ def command_skip(*, quiet: bool = False) -> None:
     require_git_repository()
     require_session_started()
     ensure_state_directory_exists()
+
+    if refuse_live_action_for_batch_selection(FileReviewAction.SKIP):
+        return
+    if refuse_ambiguous_bare_action_after_partial_file_review(FileReviewAction.SKIP):
+        return
+    refuse_bare_action_after_file_list("skip")
 
     if read_selected_change_kind() == SelectedChangeKind.FILE:
         command_skip_file("")
@@ -67,7 +92,7 @@ def command_skip(*, quiet: bool = False) -> None:
             blocklist_path = get_block_list_file_path()
             append_lines_to_file(blocklist_path, [patch_hash])
 
-            # Binary files don't have line-level tracking, so skip record_hunk_skipped
+            record_binary_hunk_skipped(item, patch_hash)
 
             if not quiet:
                 change_desc = "added" if item.is_new_file() else ("deleted" if item.is_deleted_file() else "modified")
@@ -121,6 +146,13 @@ def command_skip_file(
     require_session_started()
     ensure_state_directory_exists()
 
+    if file == "":
+        if refuse_live_action_for_batch_selection(FileReviewAction.SKIP):
+            return 0
+        if refuse_ambiguous_bare_action_after_partial_file_review(FileReviewAction.SKIP):
+            return 0
+        refuse_bare_action_after_file_list("skip --file")
+
     # Determine target file
     if file == "":
         target_file = get_selected_change_file_path()
@@ -139,6 +171,21 @@ def command_skip_file(
 
         hunks_skipped = 0
         for patch in parse_unified_diff_streaming(stream_git_command(["diff", f"-U{get_context_lines()}", "--no-color"])):
+            if isinstance(patch, BinaryFileChange):
+                file_path = patch.new_path if patch.new_path != "/dev/null" else patch.old_path
+                if file_path != target_file:
+                    continue
+
+                patch_hash = compute_binary_file_hash(patch)
+                if patch_hash in blocked_hashes:
+                    continue
+
+                append_lines_to_file(blocklist_path, [patch_hash])
+                blocked_hashes.add(patch_hash)
+                record_binary_hunk_skipped(patch, patch_hash)
+                hunks_skipped += 1
+                continue
+
             if patch.new_path != target_file:
                 continue
 
@@ -174,7 +221,7 @@ def command_skip_file(
         return hunks_skipped
 
 
-def command_skip_line(line_id_specification: str) -> None:
+def command_skip_line(line_id_specification: str, file: str | None = None) -> None:
     """Mark only the specified lines as skipped.
 
     Args:
@@ -183,16 +230,58 @@ def command_skip_line(line_id_specification: str) -> None:
     require_git_repository()
     require_session_started()
     ensure_state_directory_exists()
-    require_selected_hunk()
+    target_file = None
+    reuse_selected_file_view = False
+    scope_resolution = resolve_live_line_action_scope(
+        FileReviewAction.SKIP,
+        action_command=f"skip --line {line_id_specification}",
+        line_id_specification=line_id_specification,
+        file=file,
+        validate_pathless_before_live_guard=True,
+    )
+    if scope_resolution.should_stop:
+        return
+    review_state = scope_resolution.review_state
+    if file is None:
+        require_selected_hunk()
+    else:
+        if file == "":
+            target_file = get_selected_change_file_path()
+            if target_file is None:
+                exit_with_error(_("No selected hunk. Run 'show' first or specify file path."))
+        else:
+            target_file = file
+        from ..data.hunk_tracking import cache_unstaged_file_as_single_hunk
+        from ..data.hunk_tracking import render_unstaged_file_as_single_hunk
 
-    line_changes = load_line_changes_from_state()
-    if line_changes is None:
-        raise NoMoreHunks()
+        reuse_selected_file_view = (
+            read_selected_change_kind() == SelectedChangeKind.FILE
+            and get_selected_change_file_path() == target_file
+        )
+        if not reuse_selected_file_view and render_unstaged_file_as_single_hunk(target_file) is None:
+            exit_with_error(_("No changes in file '{file}'.").format(file=target_file))
 
     requested_ids = parse_line_selection(line_id_specification)
-    already_skipped_ids = set(read_line_ids_file(get_processed_skip_ids_file_path()))
-    combined_skip_ids = already_skipped_ids | set(requested_ids)
-    with undo_checkpoint(f"skip --line {line_id_specification}"):
+    operation_parts = ["skip", "--line", line_id_specification]
+    if file is not None:
+        operation_parts.extend(["--file", file])
+    with undo_checkpoint(" ".join(operation_parts)):
+        if file is not None:
+            if not reuse_selected_file_view:
+                if cache_unstaged_file_as_single_hunk(target_file) is None:
+                    exit_with_error(_("No changes in file '{file}'.").format(file=target_file))
+            require_selected_hunk()
+
+        line_changes = load_line_changes_from_state()
+        if line_changes is None:
+            raise NoMoreHunks()
+
+        already_skipped_ids = (
+            set(read_line_ids_file(get_processed_skip_ids_file_path()))
+            if file is None or reuse_selected_file_view else
+            set()
+        )
+        combined_skip_ids = already_skipped_ids | set(requested_ids)
         # Update processed skip IDs
         write_line_ids_file(get_processed_skip_ids_file_path(), combined_skip_ids)
 
@@ -205,6 +294,7 @@ def command_skip_line(line_id_specification: str) -> None:
         if not visible_changed_ids:
             if read_selected_change_kind() == SelectedChangeKind.FILE:
                 print(_("✓ Skipped line(s): {lines}").format(lines=line_id_specification), file=sys.stderr)
+                finish_review_scoped_line_action(review_state)
                 command_skip_file("")
                 return
 
@@ -213,6 +303,7 @@ def command_skip_line(line_id_specification: str) -> None:
             append_lines_to_file(blocklist_path, [patch_hash])
             record_hunk_skipped(line_changes, patch_hash)
             print(_("✓ Skipped line(s): {lines}").format(lines=line_id_specification), file=sys.stderr)
+            finish_review_scoped_line_action(review_state)
             advance_to_and_show_next_change()
             return
 
@@ -233,4 +324,6 @@ def command_skip_line(line_id_specification: str) -> None:
         )
 
     print(_("✓ Skipped line(s): {lines}").format(lines=line_id_specification), file=sys.stderr)
+    print_remaining_line_changes_header(filtered_line_changes.path)
     print_line_level_changes(filtered_line_changes)
+    finish_review_scoped_line_action(review_state)

--- a/src/git_stage_batch/commands/start.py
+++ b/src/git_stage_batch/commands/start.py
@@ -30,6 +30,8 @@ def command_start(*, context_lines: Optional[int] = None, quiet: bool = False) -
         command_again(quiet=quiet)
         return
 
+    # Batch reviews may be shown outside an active session. A new session must
+    # not inherit that selected/review cache before selecting the first live hunk.
     clear_selected_change_state_files()
 
     # Initialize abort state for new session

--- a/src/git_stage_batch/commands/status.py
+++ b/src/git_stage_batch/commands/status.py
@@ -5,9 +5,29 @@ from __future__ import annotations
 import json
 import sys
 
-from ..core.hashing import compute_stable_hunk_hash
+from ..batch.query import read_batch_metadata
+from ..core.hashing import compute_binary_file_hash, compute_stable_hunk_hash
 from ..core.diff_parser import parse_unified_diff_streaming
-from ..data.hunk_tracking import format_id_range, snapshots_are_stale
+from ..core.models import BinaryFileChange
+from ..data.file_review_state import (
+    FileReviewAction,
+    ReviewSource,
+    read_last_file_review_state,
+    selected_change_matches_review_state,
+    shown_complete_review_selection_groups,
+)
+from ..data.hunk_tracking import (
+    SelectedChangeKind,
+    binary_file_change_is_stale,
+    clear_selected_change_state_files,
+    format_id_range,
+    load_selected_binary_file,
+    mark_selected_change_cleared_by_stale_batch_selection,
+    read_selected_change_kind,
+    selected_batch_binary_batch_name,
+    selected_batch_binary_file_for_batch,
+    snapshots_are_stale,
+)
 from ..data.line_state import load_line_changes_from_state
 from ..data.session import get_iteration_count
 from ..i18n import _
@@ -42,8 +62,12 @@ def estimate_remaining_hunks() -> int:
     remaining = 0
     try:
         for patch in parse_unified_diff_streaming(stream_git_command(["diff", f"-U{get_context_lines()}", "--no-color"])):
-            hunk_hash = compute_stable_hunk_hash(patch.to_patch_bytes())
-            file_path = patch.old_path if patch.old_path != "/dev/null" else patch.new_path
+            if isinstance(patch, BinaryFileChange):
+                hunk_hash = compute_binary_file_hash(patch)
+                file_path = patch.new_path if patch.new_path != "/dev/null" else patch.old_path
+            else:
+                hunk_hash = compute_stable_hunk_hash(patch.to_patch_bytes())
+                file_path = patch.old_path if patch.old_path != "/dev/null" else patch.new_path
             file_path = file_path.removeprefix("a/").removeprefix("b/")
 
             if hunk_hash not in blocked_hashes and file_path not in blocked_files:
@@ -52,6 +76,174 @@ def estimate_remaining_hunks() -> int:
         return 0
 
     return remaining
+
+
+def _selected_change_is_stale(selected_kind: SelectedChangeKind | None, file_path: str) -> bool:
+    """Return whether selected state should be treated as stale by status."""
+    if selected_kind in (SelectedChangeKind.BATCH_FILE, SelectedChangeKind.BATCH_BINARY):
+        return False
+    return snapshots_are_stale(file_path)
+
+
+def _selected_kind_label(selected_kind: str | None) -> str:
+    labels = {
+        SelectedChangeKind.HUNK.value: _("Current hunk:"),
+        SelectedChangeKind.FILE.value: _("Current file review:"),
+        SelectedChangeKind.BATCH_FILE.value: _("Current batch file review:"),
+        SelectedChangeKind.BINARY.value: _("Current binary file:"),
+        SelectedChangeKind.BATCH_BINARY.value: _("Current batch binary file:"),
+    }
+    return labels.get(selected_kind or SelectedChangeKind.HUNK.value, _("Current selection:"))
+
+
+def _read_batch_review_display_ids(file_path: str) -> list[int]:
+    """Return user-visible gutter IDs for the current batch file review."""
+    review_state = read_last_file_review_state()
+    if review_state is None:
+        return []
+    if review_state.source != ReviewSource.BATCH or review_state.file_path != file_path:
+        return []
+    try:
+        if not selected_change_matches_review_state(review_state):
+            return []
+    except Exception:
+        return []
+
+    return sorted({
+        display_id
+        for group in shown_complete_review_selection_groups(
+            review_state,
+            FileReviewAction.INCLUDE_FROM_BATCH,
+        )
+        for display_id in group
+    })
+
+
+def _read_live_review_display_ids(file_path: str) -> list[int] | None:
+    """Return shown live-review gutter IDs.
+
+    None means no matching live review exists; an empty list can also mean a
+    matching review exists but is no longer fresh.
+    """
+    review_state = read_last_file_review_state()
+    if review_state is None:
+        return None
+    if review_state.source != ReviewSource.FILE_VS_HEAD or review_state.file_path != file_path:
+        return None
+    try:
+        if not selected_change_matches_review_state(review_state):
+            return []
+    except Exception:
+        return []
+
+    return sorted({
+        display_id
+        for group in shown_complete_review_selection_groups(
+            review_state,
+            FileReviewAction.INCLUDE,
+        )
+        for display_id in group
+    })
+
+
+def _read_selected_change_summary() -> tuple[bool, dict | None]:
+    """Return whether a non-stale selected change exists and its status summary."""
+    selected_kind = read_selected_change_kind()
+    if selected_kind in (SelectedChangeKind.BINARY, SelectedChangeKind.BATCH_BINARY):
+        binary_file = load_selected_binary_file()
+        if binary_file is None:
+            return False, None
+        if selected_kind == SelectedChangeKind.BINARY and binary_file_change_is_stale(binary_file):
+            return False, None
+        file_path = binary_file.new_path if binary_file.new_path != "/dev/null" else binary_file.old_path
+        if selected_kind == SelectedChangeKind.BATCH_BINARY:
+            batch_name = selected_batch_binary_batch_name()
+            if batch_name is None:
+                clear_selected_change_state_files()
+                return False, None
+            metadata = read_batch_metadata(batch_name)
+            if selected_batch_binary_file_for_batch(batch_name, metadata.get("files", {})) is None:
+                clear_selected_change_state_files()
+                mark_selected_change_cleared_by_stale_batch_selection(
+                    batch_name=batch_name,
+                    file_path=file_path,
+                )
+                return False, None
+        return True, {
+            "kind": selected_kind.value,
+            "file": file_path,
+            "line": None,
+            "ids": [],
+            "change_type": binary_file.change_type,
+        }
+
+    if not get_selected_hunk_patch_file_path().exists() or not get_line_changes_json_file_path().exists():
+        return False, None
+
+    try:
+        line_changes = load_line_changes_from_state()
+        if line_changes is None:
+            return False, None
+        if selected_kind == SelectedChangeKind.BATCH_FILE:
+            review_state = read_last_file_review_state()
+            if review_state is not None:
+                try:
+                    if not selected_change_matches_review_state(review_state):
+                        if review_state.source == ReviewSource.BATCH and review_state.batch_name is not None:
+                            mark_batch_name = review_state.batch_name
+                            mark_file_path = review_state.file_path
+                        else:
+                            mark_batch_name = None
+                            mark_file_path = None
+                        clear_selected_change_state_files()
+                        if mark_batch_name is not None and mark_file_path is not None:
+                            mark_selected_change_cleared_by_stale_batch_selection(
+                                batch_name=mark_batch_name,
+                                file_path=mark_file_path,
+                            )
+                        return False, None
+                except Exception:
+                    clear_selected_change_state_files()
+                    return False, None
+        if _selected_change_is_stale(selected_kind, line_changes.path):
+            return False, None
+        kind_value = selected_kind.value if selected_kind is not None else SelectedChangeKind.HUNK.value
+        if selected_kind == SelectedChangeKind.BATCH_FILE:
+            ids = _read_batch_review_display_ids(line_changes.path)
+        elif selected_kind == SelectedChangeKind.FILE:
+            ids = _read_live_review_display_ids(line_changes.path)
+            if ids is None:
+                ids = line_changes.changed_line_ids()
+        else:
+            ids = line_changes.changed_line_ids()
+        return True, {
+            "kind": kind_value,
+            "file": line_changes.path,
+            "line": line_changes.header.old_start,
+            "ids": ids,
+        }
+    except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+        return False, None
+
+
+def _read_file_review_summary() -> dict | None:
+    review_state = read_last_file_review_state()
+    if review_state is None:
+        return None
+    try:
+        fresh = selected_change_matches_review_state(review_state)
+    except Exception:
+        fresh = False
+    return {
+        "source": review_state.source.value,
+        "batch_name": review_state.batch_name,
+        "file": review_state.file_path,
+        "page_spec": review_state.page_spec,
+        "shown_pages": list(review_state.shown_pages),
+        "page_count": review_state.page_count,
+        "entire_file_shown": review_state.entire_file_shown,
+        "fresh": fresh,
+    }
 
 
 def command_status(*, porcelain: bool = False) -> None:
@@ -66,7 +258,7 @@ def command_status(*, porcelain: bool = False) -> None:
     # can persist after cleanup because batch metadata is intentionally kept.
     if not get_abort_head_file_path().exists():
         if porcelain:
-            print(json.dumps({"session_active": False}))
+            print(json.dumps({"session": {"active": False}}))
         else:
             print(_("No batch staging session in progress."), file=sys.stderr)
             print(_("Run 'git-stage-batch start' to begin."), file=sys.stderr)
@@ -93,37 +285,24 @@ def command_status(*, porcelain: bool = False) -> None:
                 except json.JSONDecodeError:
                     pass  # Skip malformed lines
 
-    # Check for selected hunk
-    has_selected = get_selected_hunk_patch_file_path().exists()
-    selected_summary = None
-    if has_selected:
-        if get_line_changes_json_file_path().exists():
-            try:
-                data = json.loads(read_text_file_contents(get_line_changes_json_file_path()))
-                file_path = data["path"]
-                if snapshots_are_stale(file_path):
-                    # Stale cache, no selected hunk
-                    has_selected = False
-                else:
-                    line_changes = load_line_changes_from_state()
-                    selected_summary = {
-                        "file": line_changes.path,
-                        "line": line_changes.header.old_start,
-                        "ids": line_changes.changed_line_ids()
-                    }
-            except (json.JSONDecodeError, KeyError):
-                has_selected = False
+    has_selected, selected_summary = _read_selected_change_summary()
+    file_review_summary = _read_file_review_summary()
 
     # Estimate remaining hunks
     remaining_estimate = estimate_remaining_hunks()
+    status_value = "in_progress" if has_selected or remaining_estimate > 0 else "complete"
 
     if porcelain:
         # Machine-readable JSON output
         output = {
-            "session_active": True,
-            "iteration": iteration,
-            "status": "in_progress" if has_selected else "complete",
-            "selected_hunk": selected_summary,
+            "session": {
+                "active": True,
+                "iteration": iteration,
+                "status": status_value,
+                "in_progress": status_value == "in_progress",
+            },
+            "selected_change": selected_summary,
+            "file_review": file_review_summary,
             "progress": {
                 "included": included_count,
                 "skipped": len(skipped_hunks),
@@ -135,40 +314,65 @@ def command_status(*, porcelain: bool = False) -> None:
         print(json.dumps(output, indent=2))
     else:
         # Human-readable progress report
-        status = _("in progress") if has_selected else _("complete")
-        print(_("Session: iteration {} ({})").format(iteration, status))
+        status_label = _("in progress") if status_value == "in_progress" else _("complete")
+        print(_("Session: iteration {iteration} ({status})").format(
+            iteration=iteration,
+            status=status_label,
+        ))
         print()
 
         if selected_summary:
             ids_str = format_id_range(selected_summary["ids"])
-            print(_("Current hunk:"))
-            print(_("  {}:{}").format(selected_summary['file'], selected_summary['line']))
-            print(_("  [#{}]").format(ids_str))
+            print(_selected_kind_label(selected_summary.get("kind")))
+            if selected_summary.get("line") is None:
+                print(_("  {file}").format(file=selected_summary["file"]))
+            else:
+                print(_("  {file}:{line}").format(
+                    file=selected_summary["file"],
+                    line=selected_summary["line"],
+                ))
+            if ids_str:
+                print(_("  [#{ids}]").format(ids=ids_str))
+            if selected_summary.get("change_type"):
+                print(_("  {change_type}").format(change_type=selected_summary["change_type"]))
+            print()
+
+        if file_review_summary:
+            print(_("Last file review:"))
+            source = file_review_summary["source"]
+            if file_review_summary["batch_name"]:
+                source = _("batch {name}").format(name=file_review_summary["batch_name"])
+            print(_("  source: {source}").format(source=source))
+            print(
+                _("  pages: {pages}/{count}").format(
+                    pages=format_id_range(file_review_summary["shown_pages"]),
+                    count=file_review_summary["page_count"],
+                )
+            )
+            if not file_review_summary["entire_file_shown"]:
+                print(_("  partial review; bare whole-file actions will require confirmation by command"))
+            if not file_review_summary["fresh"]:
+                print(_("  stale; run show again before using pathless line actions"))
             print()
 
         print(_("Progress this iteration:"))
-        print(_("  Included:  {} hunks").format(included_count))
-        print(_("  Skipped:   {} hunks").format(len(skipped_hunks)))
-        print(_("  Discarded: {} hunks").format(discarded_count))
-        print(_("  Remaining: ~{} hunks").format(remaining_estimate))
+        print(_("  Included:  {count} hunks").format(count=included_count))
+        print(_("  Skipped:   {count} hunks").format(count=len(skipped_hunks)))
+        print(_("  Discarded: {count} hunks").format(count=discarded_count))
+        print(_("  Remaining: ~{count} hunks").format(count=remaining_estimate))
 
         if skipped_hunks:
             print()
             print(_("Skipped hunks:"))
             for hunk in skipped_hunks:
+                ids_str = format_id_range(hunk.get("ids", []))
                 if hunk.get("line") is None:
-                    print(
-                        _("  {file} [binary {change_type}]").format(
-                            file=hunk["file"],
-                            change_type=hunk.get("change_type", "modified"),
-                        )
-                    )
+                    print(_("  {file}").format(file=hunk["file"]))
+                elif ids_str:
+                    print(_("  {file}:{line} [#{ids}]").format(
+                        file=hunk["file"],
+                        line=hunk["line"],
+                        ids=ids_str,
+                    ))
                 else:
-                    ids_str = format_id_range(hunk["ids"])
-                    print(
-                        _("  {file}:{line} [#{ids}]").format(
-                            file=hunk["file"],
-                            line=hunk["line"],
-                            ids=ids_str,
-                        )
-                    )
+                    print(_("  {file}:{line}").format(file=hunk["file"], line=hunk["line"]))

--- a/src/git_stage_batch/core/actionable_changes.py
+++ b/src/git_stage_batch/core/actionable_changes.py
@@ -1,0 +1,106 @@
+"""Shared actionable selection derivation for file reviews and validation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Mapping
+
+from .models import LineEntry, LineLevelChange
+
+
+class ActionableSelectionReason(str, Enum):
+    """Why a file-review selection is treated as one actionable atom."""
+
+    SIMPLE = "simple"
+    REPLACEMENT = "replacement"
+    STRUCTURAL_RUN = "structural-run"
+
+
+@dataclass(frozen=True)
+class ActionableSelection:
+    """One atomic line selection that can be suggested as a complete change."""
+
+    display_ids: tuple[int, ...]
+    selection_ids: tuple[int, ...]
+    reason: ActionableSelectionReason
+    note: str | None = None
+    actions: tuple[str, ...] = ()
+
+
+def derive_actionable_selections(
+    line_changes: LineLevelChange,
+    *,
+    gutter_to_selection_id: Mapping[int, int] | None = None,
+) -> tuple[ActionableSelection, ...]:
+    """Derive conservative complete selection atoms from a rendered file diff.
+
+    The initial shared policy keeps each contiguous changed run inside a
+    displayed hunk together. Mixed deletion/addition runs are marked as
+    replacements so renderers can use "select together" wording.
+    """
+    selections: list[ActionableSelection] = []
+    changed_run: list[LineEntry] = []
+    selection_to_gutter = (
+        {
+            selection_id: gutter_id
+            for gutter_id, selection_id in gutter_to_selection_id.items()
+        }
+        if gutter_to_selection_id is not None else
+        None
+    )
+
+    def flush_changed_run() -> None:
+        nonlocal changed_run
+        if not changed_run:
+            return
+
+        selection_ids = tuple(
+            line.id
+            for line in changed_run
+            if line.id is not None
+        )
+        if not selection_ids:
+            changed_run = []
+            return
+
+        if selection_to_gutter is None:
+            display_ids = selection_ids
+        else:
+            if any(selection_id not in selection_to_gutter for selection_id in selection_ids):
+                changed_run = []
+                return
+            display_ids = tuple(
+                selection_to_gutter[selection_id]
+                for selection_id in selection_ids
+            )
+
+        if display_ids:
+            changed_kinds = {line.kind for line in changed_run}
+            reason: ActionableSelectionReason = (
+                ActionableSelectionReason.REPLACEMENT
+                if {"-", "+"}.issubset(changed_kinds)
+                else ActionableSelectionReason.SIMPLE
+            )
+            selections.append(
+                ActionableSelection(
+                    display_ids=display_ids,
+                    selection_ids=selection_ids,
+                    reason=reason,
+                    note=None,
+                )
+            )
+
+        changed_run = []
+
+    for line in line_changes.lines:
+        if line.kind in ("+", "-") and line.id is not None:
+            if selection_to_gutter is not None and line.id not in selection_to_gutter:
+                flush_changed_run()
+                continue
+            changed_run.append(line)
+            continue
+        flush_changed_run()
+
+    flush_changed_run()
+    return tuple(selections)

--- a/src/git_stage_batch/core/line_selection.py
+++ b/src/git_stage_batch/core/line_selection.py
@@ -7,8 +7,13 @@ from typing import Iterable
 from ..utils.file_io import read_text_file_contents, write_text_file_contents
 
 
-def parse_line_selection(selection: str) -> list[int]:
-    """Parse a line selection string into a list of line IDs.
+def parse_positive_selection(
+    selection: str,
+    *,
+    item_name: str = "Line ID",
+    reject_empty_items: bool = False,
+) -> list[int]:
+    """Parse a positive integer selection string into sorted unique IDs.
 
     Supports:
     - Individual IDs: "1,2,3" → [1, 2, 3]
@@ -16,10 +21,12 @@ def parse_line_selection(selection: str) -> list[int]:
     - Mixed: "1,3,5-7" → [1, 3, 5, 6, 7]
 
     Args:
-        selection: Comma-separated line IDs and/or ranges (e.g., "1,3,5-7")
+        selection: Comma-separated IDs and/or ranges (e.g., "1,3,5-7")
+        item_name: Name used in error messages.
+        reject_empty_items: If True, reject empty comma-separated items.
 
     Returns:
-        Sorted list of unique line IDs
+        Sorted list of unique IDs
 
     Raises:
         ValueError: If the selection string is invalid
@@ -27,12 +34,15 @@ def parse_line_selection(selection: str) -> list[int]:
     if not selection or not selection.strip():
         raise ValueError("Selection string cannot be empty")
 
-    line_ids = set()
+    selected_ids = set()
     parts = selection.split(",")
+    invalid_item_name = "line ID" if item_name == "Line ID" else item_name
 
     for part in parts:
         part = part.strip()
         if not part:
+            if reject_empty_items:
+                raise ValueError("Selection contains an empty item")
             continue
 
         # Check if this looks like a range (contains "-" that's not at the start)
@@ -51,25 +61,30 @@ def parse_line_selection(selection: str) -> list[int]:
                 raise ValueError(f"Invalid range: {part}") from e
 
             if start <= 0 or end <= 0:
-                raise ValueError(f"Line IDs must be positive: {part}")
+                raise ValueError(f"{item_name}s must be positive: {part}")
 
             if start > end:
                 raise ValueError(f"Range start must be <= end: {part}")
 
-            line_ids.update(range(start, end + 1))
+            selected_ids.update(range(start, end + 1))
         else:
             # Handle single ID (including negative numbers which we'll reject)
             try:
-                line_id = int(part)
+                selected_id = int(part)
             except ValueError as e:
-                raise ValueError(f"Invalid line ID: {part}") from e
+                raise ValueError(f"Invalid {invalid_item_name}: {part}") from e
 
-            if line_id <= 0:
-                raise ValueError(f"Line ID must be positive: {part}")
+            if selected_id <= 0:
+                raise ValueError(f"{item_name} must be positive: {part}")
 
-            line_ids.add(line_id)
+            selected_ids.add(selected_id)
 
-    return sorted(line_ids)
+    return sorted(selected_ids)
+
+
+def parse_line_selection(selection: str) -> list[int]:
+    """Parse a line selection string into a list of line IDs."""
+    return parse_positive_selection(selection, item_name="Line ID")
 
 
 def read_line_ids_file(path: Path) -> list[int]:

--- a/src/git_stage_batch/core/models.py
+++ b/src/git_stage_batch/core/models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Literal
 
 
@@ -95,6 +95,16 @@ class LineLevelChange:
         return len(str(max(changed_ids)))
 
 
+@dataclass(frozen=True)
+class ReviewActionGroup:
+    """One user-visible file-review selection and the actions it supports."""
+
+    display_ids: tuple[int, ...]
+    selection_ids: tuple[int, ...]
+    actions: tuple[str, ...]
+    reason: str = "simple"
+
+
 @dataclass
 class RenderedBatchDisplay:
     """Rendered batch display with gutter ID translation for selection.
@@ -110,7 +120,15 @@ class RenderedBatchDisplay:
         line_changes: What gets shown to the user (contains original selection IDs)
         gutter_to_selection_id: Map from filtered gutter number to selection ID (for ownership selection)
         selection_id_to_gutter: Reverse map from selection ID to filtered gutter number
+        actionable_selection_groups: Complete original selection-ID groups that may be acted on from review output
+        review_gutter_to_selection_id: Map from review gutter number to selection ID
+        review_selection_id_to_gutter: Reverse map for review gutter IDs
+        review_action_groups: Action-specific groups for page-aware review state
     """
     line_changes: LineLevelChange
     gutter_to_selection_id: dict[int, int]
     selection_id_to_gutter: dict[int, int]
+    actionable_selection_groups: tuple[tuple[int, ...], ...] = ()
+    review_gutter_to_selection_id: dict[int, int] = field(default_factory=dict)
+    review_selection_id_to_gutter: dict[int, int] = field(default_factory=dict)
+    review_action_groups: tuple[ReviewActionGroup, ...] = ()

--- a/src/git_stage_batch/data/file_review_state.py
+++ b/src/git_stage_batch/data/file_review_state.py
@@ -1,0 +1,248 @@
+"""Persisted safety state for page-aware file reviews."""
+
+from __future__ import annotations
+
+import json
+import shlex
+from dataclasses import asdict, dataclass
+from enum import Enum
+from hashlib import sha256
+from typing import Any
+
+from ..core.actionable_changes import ActionableSelectionReason
+from ..core.line_selection import parse_line_selection
+from ..core.models import ReviewActionGroup
+from ..data.line_state import convert_line_changes_to_serializable_dict, load_line_changes_from_state
+from ..exceptions import CommandError
+from ..i18n import _
+from ..utils.file_io import read_file_bytes, read_text_file_contents, write_text_file_contents
+from ..utils.paths import (
+    get_index_snapshot_file_path,
+    get_last_file_review_state_file_path,
+    get_working_tree_snapshot_file_path,
+)
+from .hunk_tracking import SelectedChangeKind, get_selected_change_file_path, read_selected_change_kind
+
+
+class ReviewSource(str, Enum):
+    """Source of the selected file review."""
+
+    FILE_VS_HEAD = "file-vs-head"
+    UNSTAGED = "unstaged"
+    BATCH = "batch"
+
+
+class FileReviewAction(str, Enum):
+    """Commands that may act on a file-review selection."""
+
+    INCLUDE = "include"
+    SKIP = "skip"
+    DISCARD = "discard"
+    INCLUDE_TO_BATCH = "include-to-batch"
+    DISCARD_TO_BATCH = "discard-to-batch"
+    INCLUDE_FROM_BATCH = "include-from-batch"
+    DISCARD_FROM_BATCH = "discard-from-batch"
+    APPLY_FROM_BATCH = "apply-from-batch"
+    RESET_FROM_BATCH = "reset-from-batch"
+
+
+@dataclass(frozen=True)
+class FileReviewSelectionState:
+    """One complete actionable selection shown by a file review."""
+
+    display_ids: tuple[int, ...]
+    selection_ids: tuple[int, ...]
+    change_index: int
+    first_page: int
+    last_page: int
+    reason: ActionableSelectionReason
+    actions: tuple[FileReviewAction, ...]
+
+
+@dataclass(frozen=True)
+class FileReviewState:
+    """Persisted identity and safety state for the last file review."""
+
+    source: ReviewSource
+    batch_name: str | None
+    file_path: str
+    page_spec: str
+    shown_pages: tuple[int, ...]
+    page_count: int
+    entire_file_shown: bool
+    selections: tuple[FileReviewSelectionState, ...]
+    selected_change_kind: SelectedChangeKind
+    selected_file_fingerprint: str
+    diff_fingerprint: str
+
+
+@dataclass(frozen=True)
+class ImplicitLiveToBatchFileActionResult:
+    """Validated target for `--to --file` with no path."""
+
+    reviewed_file: str | None = None
+    review_state: FileReviewState | None = None
+    should_stop: bool = False
+
+
+@dataclass(frozen=True)
+class ActionScopeResolution:
+    """Resolved file-review scope for a command prologue."""
+
+    file: str | None
+    review_state: FileReviewState | None = None
+    should_stop: bool = False
+
+
+class ReviewScopedSelectionError(CommandError):
+    """Raised when a pathless line action is not valid for the current review."""
+
+
+def _coerce_review_source(source: ReviewSource | str) -> ReviewSource:
+    return source if isinstance(source, ReviewSource) else ReviewSource(source)
+
+
+def _coerce_review_action(action: FileReviewAction | str) -> FileReviewAction:
+    return action if isinstance(action, FileReviewAction) else FileReviewAction(action)
+
+
+def _json_hash(payload: Any) -> str:
+    data = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return sha256(data.encode("utf-8", errors="surrogateescape")).hexdigest()
+
+
+def fingerprint_selected_file_view(
+    *,
+    source: ReviewSource,
+    batch_name: str | None,
+    file_path: str,
+    selected_change_kind: SelectedChangeKind,
+    gutter_to_selection_id: dict[int, int] | None = None,
+    actionable_selection_groups: tuple[tuple[int, ...], ...] | None = None,
+    review_action_groups: tuple[ReviewActionGroup, ...] | None = None,
+    line_changes=None,
+) -> str:
+    """Fingerprint the selected file view and its current line ID space."""
+    if line_changes is None:
+        line_changes = load_line_changes_from_state()
+    snapshots = {}
+    for name, path in (
+        ("index", get_index_snapshot_file_path()),
+        ("working_tree", get_working_tree_snapshot_file_path()),
+    ):
+        snapshots[name] = sha256(read_file_bytes(path)).hexdigest() if path.exists() else None
+    return _json_hash(
+        {
+            "source": source,
+            "batch_name": batch_name,
+            "file_path": file_path,
+            "selected_change_kind": selected_change_kind.value,
+            "snapshots": snapshots,
+            "line_changes": (
+                convert_line_changes_to_serializable_dict(line_changes)
+                if line_changes is not None else None
+            ),
+            "gutter_to_selection_id": gutter_to_selection_id,
+            "actionable_selection_groups": actionable_selection_groups,
+            "review_action_groups": [
+                {
+                    "display_ids": group.display_ids,
+                    "selection_ids": group.selection_ids,
+                    "actions": group.actions,
+                    "reason": group.reason,
+                }
+                for group in (review_action_groups or ())
+            ],
+        }
+    )
+
+
+def compute_current_file_review_diff_fingerprint(file_path: str, line_changes=None) -> str:
+    """Fingerprint the cached selected file diff for freshness checks."""
+    if line_changes is None:
+        line_changes = load_line_changes_from_state()
+    return _json_hash(
+        {
+            "file_path": file_path,
+            "line_changes": (
+                convert_line_changes_to_serializable_dict(line_changes)
+                if line_changes is not None else None
+            ),
+        }
+    )
+
+
+def write_last_file_review_state(review_state: FileReviewState) -> None:
+    """Persist the last file review state."""
+    write_text_file_contents(
+        get_last_file_review_state_file_path(),
+        json.dumps(asdict(review_state), ensure_ascii=False, indent=0),
+    )
+
+
+def read_last_file_review_state() -> FileReviewState | None:
+    """Read the last file review state, if present and valid."""
+    path = get_last_file_review_state_file_path()
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(read_text_file_contents(path))
+        selections = tuple(
+            FileReviewSelectionState(
+                display_ids=tuple(selection["display_ids"]),
+                selection_ids=tuple(selection["selection_ids"]),
+                change_index=selection["change_index"],
+                first_page=selection["first_page"],
+                last_page=selection["last_page"],
+                reason=ActionableSelectionReason(selection["reason"]),
+                actions=tuple(FileReviewAction(action) for action in selection["actions"]),
+            )
+            for selection in data.get("selections", [])
+        )
+        return FileReviewState(
+            source=ReviewSource(data["source"]),
+            batch_name=data.get("batch_name"),
+            file_path=data["file_path"],
+            page_spec=data["page_spec"],
+            shown_pages=tuple(data["shown_pages"]),
+            page_count=data["page_count"],
+            entire_file_shown=data["entire_file_shown"],
+            selections=selections,
+            selected_change_kind=SelectedChangeKind(data["selected_change_kind"]),
+            selected_file_fingerprint=data["selected_file_fingerprint"],
+            diff_fingerprint=data["diff_fingerprint"],
+        )
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+        clear_last_file_review_state()
+        return None
+
+
+def clear_last_file_review_state() -> None:
+    """Remove the last file review state."""
+    get_last_file_review_state_file_path().unlink(missing_ok=True)
+
+
+def clear_last_file_review_state_if_file_matches(file_path: str) -> None:
+    """Remove the last file review state if it belongs to the given file."""
+    review_state = read_last_file_review_state()
+    if review_state is not None and review_state.file_path == file_path:
+        clear_last_file_review_state()
+
+
+def line_action_came_from_partial_review(review_state: FileReviewState | None) -> bool:
+    """Return whether a line action was validated by a partial file review."""
+    return review_state is not None and not review_state.entire_file_shown
+
+
+def finish_review_scoped_line_action(
+    review_state: FileReviewState | None,
+    *,
+    file_path: str | None = None,
+) -> None:
+    """Clear review state after a line action unless a partial review must guard follow-ups."""
+    if line_action_came_from_partial_review(review_state):
+        return
+    if file_path is None:
+        clear_last_file_review_state()
+    else:
+        clear_last_file_review_state_if_file_matches(file_path)

--- a/src/git_stage_batch/data/file_review_state.py
+++ b/src/git_stage_batch/data/file_review_state.py
@@ -448,3 +448,68 @@ def fresh_batch_review_display_ids_for_action(
     if groups is None:
         return None
     return {display_id for group in groups for display_id in group}
+
+
+
+def _print_stale_or_mismatched_file_review_help(action: str, review_state: FileReviewState) -> None:
+    show_command = _show_command_for_review_state(review_state)
+    raise ReviewScopedSelectionError(
+        _(
+            "The file review for {file} no longer matches the selected file view.\n"
+            "Line IDs may no longer match.\n\n"
+            "Run:\n"
+            "  {command}"
+        ).format(file=review_state.file_path, command=show_command)
+    )
+
+
+def _quote(value: str) -> str:
+    return shlex.quote(value)
+
+
+def _show_command_for_review_state(review_state: FileReviewState, *, page: str | None = None) -> str:
+    command = "git-stage-batch show"
+    if review_state.source == ReviewSource.BATCH and review_state.batch_name is not None:
+        command += f" --from {_quote(review_state.batch_name)}"
+    command += f" --file {_quote(review_state.file_path)}"
+    if page is not None:
+        command += f" --page {page}"
+    return command
+
+
+def _line_action_command(
+    action: FileReviewAction | str,
+    review_state: FileReviewState,
+    *,
+    line_spec: str | None = None,
+    whole_file: bool = False,
+    pathless_line: bool = False,
+) -> str | None:
+    review_action = _coerce_review_action(action)
+    action_value = review_action.value
+    if review_action in (FileReviewAction.INCLUDE_TO_BATCH, FileReviewAction.DISCARD_TO_BATCH):
+        return None
+    if review_state.source == ReviewSource.BATCH:
+        if review_action in (FileReviewAction.INCLUDE, FileReviewAction.INCLUDE_FROM_BATCH):
+            action_value = FileReviewAction.INCLUDE.value
+        elif review_action in (FileReviewAction.DISCARD, FileReviewAction.DISCARD_FROM_BATCH):
+            action_value = FileReviewAction.DISCARD.value
+        elif review_action == FileReviewAction.APPLY_FROM_BATCH:
+            action_value = "apply"
+        elif review_action == FileReviewAction.RESET_FROM_BATCH:
+            action_value = "reset"
+        else:
+            return None
+        command = f"git-stage-batch {action_value} --from {_quote(review_state.batch_name or '')}"
+        file_args = f" --file {_quote(review_state.file_path)}"
+    else:
+        command = f"git-stage-batch {action_value}"
+        file_args = f" --file {_quote(review_state.file_path)}"
+
+    if line_spec is not None:
+        if pathless_line:
+            return f"{command} --line {line_spec}"
+        return f"{command}{file_args} --line {line_spec}"
+    if whole_file:
+        return f"{command}{file_args}"
+    return command

--- a/src/git_stage_batch/data/file_review_state.py
+++ b/src/git_stage_batch/data/file_review_state.py
@@ -246,6 +246,118 @@ def finish_review_scoped_line_action(
         clear_last_file_review_state()
     else:
         clear_last_file_review_state_if_file_matches(file_path)
+
+
+def _batch_from_action_command(
+    command_name: str,
+    batch_name: str,
+    *,
+    file_scope: bool,
+    line_ids: str | None,
+    extra_action_parts: tuple[str, ...] = (),
+) -> str:
+    parts = [command_name, "--from", shlex.quote(batch_name)]
+    if file_scope:
+        parts.append("--file")
+    parts.extend(extra_action_parts)
+    if line_ids is not None:
+        parts.extend(["--line", line_ids])
+    return " ".join(parts)
+
+
+def resolve_batch_source_action_scope(
+    action: FileReviewAction | str,
+    *,
+    command_name: str,
+    batch_name: str,
+    line_ids: str | None,
+    file: str | None,
+    patterns: list[str] | None,
+    extra_action_parts: tuple[str, ...] = (),
+) -> ActionScopeResolution:
+    """Resolve pathless and implicit-file batch actions against the last batch review."""
+    from .hunk_tracking import (
+        refuse_bare_action_after_file_list,
+        refuse_bare_action_after_stale_batch_selection,
+    )
+
+    review_action = _coerce_review_action(action)
+    if patterns is not None:
+        return ActionScopeResolution(file=file)
+
+    if file is None:
+        action_command = _batch_from_action_command(
+            command_name,
+            batch_name,
+            file_scope=False,
+            line_ids=line_ids,
+            extra_action_parts=extra_action_parts,
+        )
+        refuse_bare_action_after_file_list(
+            action_command,
+            open_command=f"git-stage-batch show --from {shlex.quote(batch_name)} --file PATH",
+            source=ReviewSource.BATCH.value,
+            batch_name=batch_name,
+        )
+        refuse_bare_action_after_stale_batch_selection(action_command, batch_name=batch_name)
+
+        if line_ids is None:
+            reviewed_file = resolve_review_file_for_bare_whole_file_action(
+                review_action,
+                source=ReviewSource.BATCH,
+                batch_name=batch_name,
+            )
+            return ActionScopeResolution(file=reviewed_file if reviewed_file is not None else file)
+
+        review_state = validate_pathless_review_line_action(
+            review_action,
+            line_ids,
+            source=ReviewSource.BATCH,
+            batch_name=batch_name,
+        )
+        return ActionScopeResolution(
+            file=review_state.file_path if review_state is not None else file,
+            review_state=review_state,
+        )
+
+    if file == "":
+        action_command = _batch_from_action_command(
+            command_name,
+            batch_name,
+            file_scope=True,
+            line_ids=line_ids,
+            extra_action_parts=extra_action_parts,
+        )
+        refuse_bare_action_after_file_list(
+            action_command,
+            open_command=f"git-stage-batch show --from {shlex.quote(batch_name)} --file PATH",
+            source=ReviewSource.BATCH.value,
+            batch_name=batch_name,
+        )
+        refuse_bare_action_after_stale_batch_selection(action_command, batch_name=batch_name)
+
+        if line_ids is None:
+            reviewed_file = resolve_review_file_for_bare_whole_file_action(
+                review_action,
+                source=ReviewSource.BATCH,
+                batch_name=batch_name,
+            )
+            return ActionScopeResolution(file=reviewed_file if reviewed_file is not None else file)
+
+        review_state = validate_pathless_review_line_action(
+            review_action,
+            line_ids,
+            source=ReviewSource.BATCH,
+            batch_name=batch_name,
+        )
+        return ActionScopeResolution(
+            file=review_state.file_path if review_state is not None else file,
+            review_state=review_state,
+        )
+
+    return ActionScopeResolution(file=file)
+
+
 def selected_change_kind_matches_review_source(
     selected_kind: SelectedChangeKind | None,
     review_state: FileReviewState,
@@ -450,7 +562,6 @@ def fresh_batch_review_display_ids_for_action(
     return {display_id for group in groups for display_id in group}
 
 
-
 def _print_stale_or_mismatched_file_review_help(action: str, review_state: FileReviewState) -> None:
     show_command = _show_command_for_review_state(review_state)
     raise ReviewScopedSelectionError(
@@ -513,3 +624,413 @@ def _line_action_command(
     if whole_file:
         return f"{command}{file_args}"
     return command
+
+
+def refuse_live_action_for_batch_selection(action: FileReviewAction | str) -> bool:
+    """Refuse bare live actions when the current selection came from a batch view."""
+    review_action = _coerce_review_action(action)
+    if read_selected_change_kind() not in (SelectedChangeKind.BATCH_FILE, SelectedChangeKind.BATCH_BINARY):
+        return False
+
+    review_state = read_last_file_review_state()
+    if review_state is not None:
+        if review_state.source != ReviewSource.BATCH:
+            _print_stale_or_mismatched_file_review_help(review_action.value, review_state)
+        if not selected_change_matches_review_state(review_state):
+            _print_stale_or_mismatched_file_review_help(review_action.value, review_state)
+
+        lines = [
+            _("The selected file view for {file} came from batch '{batch}', not the live working tree.").format(
+                file=review_state.file_path,
+                batch=review_state.batch_name,
+            )
+        ]
+        if not review_state.entire_file_shown:
+            lines.extend(
+                [
+                    "",
+                    _("To review all pages from the batch:"),
+                    f"  {_show_command_for_review_state(review_state, page='all')}",
+                ]
+            )
+
+        whole_file_command = _line_action_command(review_action, review_state, whole_file=True)
+        if whole_file_command is not None:
+            lines.extend(
+                [
+                    "",
+                    _("To act on the batch file:"),
+                    f"  {whole_file_command}",
+                ]
+            )
+        else:
+            lines.extend(
+                [
+                    "",
+                    _("Batch reviews do not support this action."),
+                    _("If you meant to act on live working-tree changes, open a live file review:"),
+                    f"  git-stage-batch show --file {_quote(review_state.file_path)}",
+                ]
+            )
+        raise CommandError("\n".join(lines))
+
+    file_path = get_selected_change_file_path() or _("the selected file")
+    raise CommandError(
+        _(
+            "The selected file view for {file} came from a batch, not the live working tree.\n"
+            "Show the batch file again and use `include --from` or `discard --from`,\n"
+            "or open a live file review with:\n"
+            "  git-stage-batch show --file {file}"
+        ).format(file=file_path)
+    )
+
+
+def refuse_ambiguous_bare_action_after_partial_file_review(action: FileReviewAction | str) -> bool:
+    """Refuse pathless whole-file actions after a partial file review."""
+    review_action = _coerce_review_action(action)
+    review_state = read_last_file_review_state()
+    if review_state is None:
+        return False
+
+    selected_kind = read_selected_change_kind()
+    if not selected_change_kind_matches_review_source(selected_kind, review_state):
+        if selected_kind in (SelectedChangeKind.FILE, SelectedChangeKind.BATCH_FILE, SelectedChangeKind.BATCH_BINARY):
+            _print_stale_or_mismatched_file_review_help(review_action.value, review_state)
+        clear_last_file_review_state()
+        return False
+
+    if not _review_state_matches_action(review_state, review_action):
+        _print_stale_or_mismatched_file_review_help(review_action.value, review_state)
+
+    if review_state.entire_file_shown:
+        return False
+
+    shown = set(review_state.shown_pages)
+    missing = set(range(1, review_state.page_count + 1)) - shown
+    complete_selections = [
+        selection
+        for selection in review_state.selections
+        if review_action in selection.actions
+        and set(range(selection.first_page, selection.last_page + 1)).issubset(shown)
+    ]
+    selection_specs = [
+        _format_pages(set(selection.display_ids))
+        for selection in complete_selections
+    ]
+
+    lines = [
+        _("Only pages {shown} of {count} of {file} were shown.").format(
+            shown=_format_pages(shown),
+            count=review_state.page_count,
+            file=review_state.file_path,
+        )
+    ]
+    if missing:
+        lines.append(_("Pages {pages} were not shown.").format(pages=_format_pages(missing)))
+    if selection_specs:
+        line_command = _line_action_command(
+            review_action, review_state, line_spec=",".join(selection_specs)
+        )
+        if line_command is not None:
+            lines.extend(
+                [
+                    "",
+                    _("To act on complete changes shown here:"),
+                    f"  {line_command}",
+                ]
+            )
+    lines.extend(
+        [
+            "",
+            _("To review all pages:"),
+            f"  {_show_command_for_review_state(review_state, page='all')}",
+        ]
+    )
+
+    whole_file_command = _line_action_command(review_action, review_state, whole_file=True)
+    if whole_file_command is not None:
+        lines.extend(
+            [
+                "",
+                _("To act on the whole file:"),
+                f"  {whole_file_command}",
+            ]
+        )
+    raise CommandError("\n".join(lines))
+
+
+def resolve_review_file_for_bare_whole_file_action(
+    action: FileReviewAction | str,
+    *,
+    source: ReviewSource | str,
+    batch_name: str | None = None,
+) -> str | None:
+    """Return the reviewed file for a fresh full-file review, or refuse if partial."""
+    review_state = read_last_file_review_state()
+    if review_state is None:
+        return None
+
+    if review_state.source != _coerce_review_source(source):
+        return None
+    if batch_name is not None and review_state.batch_name != batch_name:
+        return None
+
+    if refuse_ambiguous_bare_action_after_partial_file_review(action):
+        return None
+    if read_last_file_review_state() != review_state:
+        return None
+    return review_state.file_path
+
+
+def validate_implicit_live_to_batch_file_action(
+    action: FileReviewAction | str,
+    action_command: str,
+    line_id_specification: str | None,
+) -> ImplicitLiveToBatchFileActionResult:
+    """Validate `--to --file` with no path against the current live review.
+
+    Returns the reviewed file for a full live-file review when the caller should
+    use that explicit file path. The boolean is true when the caller should stop
+    after a live-action guard handled the request.
+    """
+    from .hunk_tracking import refuse_bare_action_after_file_list
+
+    review_action = _coerce_review_action(action)
+    refuse_bare_action_after_file_list(action_command)
+    if line_id_specification is None:
+        return ImplicitLiveToBatchFileActionResult(
+            reviewed_file=resolve_review_file_for_bare_whole_file_action(
+                review_action,
+                source=ReviewSource.FILE_VS_HEAD,
+            ),
+        )
+    if refuse_live_action_for_batch_selection(review_action):
+        return ImplicitLiveToBatchFileActionResult(should_stop=True)
+    review_state = validate_pathless_review_line_action(
+        review_action,
+        line_id_specification,
+        source=ReviewSource.FILE_VS_HEAD,
+    )
+    return ImplicitLiveToBatchFileActionResult(review_state=review_state)
+
+
+def _live_to_batch_action_command(
+    command_name: str,
+    batch_name: str,
+    *,
+    file_scope: bool,
+    line_ids: str | None,
+) -> str:
+    parts = [command_name, "--to", batch_name]
+    if file_scope:
+        parts.append("--file")
+    if line_ids is not None:
+        parts.extend(["--line", line_ids])
+    return " ".join(parts)
+
+
+def resolve_live_to_batch_action_scope(
+    action: FileReviewAction | str,
+    *,
+    command_name: str,
+    batch_name: str,
+    line_ids: str | None,
+    file: str | None,
+) -> ActionScopeResolution:
+    """Resolve pathless and implicit-file live-to-batch actions against live reviews."""
+    from .hunk_tracking import refuse_bare_action_after_file_list
+
+    review_action = _coerce_review_action(action)
+    if file is None:
+        action_command = _live_to_batch_action_command(
+            command_name,
+            batch_name,
+            file_scope=False,
+            line_ids=line_ids,
+        )
+        refuse_bare_action_after_file_list(action_command)
+        if refuse_live_action_for_batch_selection(review_action):
+            return ActionScopeResolution(file=file, should_stop=True)
+        if line_ids is None:
+            reviewed_file = resolve_review_file_for_bare_whole_file_action(
+                review_action,
+                source=ReviewSource.FILE_VS_HEAD,
+            )
+            return ActionScopeResolution(file=reviewed_file if reviewed_file is not None else file)
+        review_state = validate_pathless_review_line_action(
+            review_action,
+            line_ids,
+            source=ReviewSource.FILE_VS_HEAD,
+        )
+        return ActionScopeResolution(file=file, review_state=review_state)
+
+    if file == "":
+        action_command = _live_to_batch_action_command(
+            command_name,
+            batch_name,
+            file_scope=True,
+            line_ids=line_ids,
+        )
+        action_result = validate_implicit_live_to_batch_file_action(
+            review_action,
+            action_command,
+            line_ids,
+        )
+        if action_result.should_stop:
+            return ActionScopeResolution(file=file, should_stop=True)
+        return ActionScopeResolution(
+            file=action_result.reviewed_file if action_result.reviewed_file is not None else file,
+            review_state=action_result.review_state,
+        )
+
+    return ActionScopeResolution(file=file)
+
+
+def resolve_live_line_action_scope(
+    action: FileReviewAction | str,
+    *,
+    action_command: str,
+    line_id_specification: str,
+    file: str | None,
+    source: ReviewSource | str | None = None,
+    batch_name: str | None = None,
+    validate_pathless_before_live_guard: bool = False,
+) -> ActionScopeResolution:
+    """Validate a pathless or implicit-file live line action against review state."""
+    from .hunk_tracking import refuse_bare_action_after_file_list
+
+    if file not in (None, ""):
+        return ActionScopeResolution(file=file)
+
+    review_action = _coerce_review_action(action)
+    refuse_bare_action_after_file_list(action_command)
+
+    if file is None and validate_pathless_before_live_guard:
+        review_state = validate_pathless_review_line_action(
+            review_action,
+            line_id_specification,
+            source=source,
+            batch_name=batch_name,
+        )
+        if refuse_live_action_for_batch_selection(review_action):
+            return ActionScopeResolution(file=file, review_state=review_state, should_stop=True)
+        return ActionScopeResolution(file=file, review_state=review_state)
+
+    if refuse_live_action_for_batch_selection(review_action):
+        return ActionScopeResolution(file=file, should_stop=True)
+
+    review_state = validate_pathless_review_line_action(
+        review_action,
+        line_id_specification,
+        source=source,
+        batch_name=batch_name,
+    )
+    return ActionScopeResolution(file=file, review_state=review_state)
+
+
+def validate_review_scoped_line_selection(
+    requested_ids: set[int],
+    valid_selection_groups: list[set[int]],
+) -> None:
+    """Validate a union of complete actionable review selections."""
+    groups = [set(group) for group in valid_selection_groups if group]
+
+    def can_cover(remaining_ids: frozenset[int]) -> bool:
+        if not remaining_ids:
+            return True
+        first_id = min(remaining_ids)
+        for group in groups:
+            if first_id not in group:
+                continue
+            if not group.issubset(remaining_ids):
+                continue
+            if can_cover(frozenset(remaining_ids - group)):
+                return True
+        return False
+
+    if can_cover(frozenset(requested_ids)):
+        return
+
+    matched_ids = {
+        display_id
+        for group in groups
+        if group.issubset(requested_ids)
+        for display_id in group
+    }
+
+    outside_ids = requested_ids - matched_ids
+    for group in groups:
+        overlap = outside_ids & group
+        if overlap and overlap != group:
+            raise CommandError(
+                _("Line selection #{requested} only partly selects a reviewed change.\nUse: --line {required}").format(
+                    requested=_format_pages(requested_ids),
+                    required=_format_pages(group),
+                )
+            )
+
+    if outside_ids:
+        raise CommandError(
+            _("Line selection #{ids} is not valid from the current file review.").format(
+                ids=_format_pages(outside_ids),
+            )
+        )
+
+
+def validate_pathless_review_line_action(
+    action: FileReviewAction | str,
+    line_id_specification: str,
+    *,
+    source: ReviewSource | str | None = None,
+    batch_name: str | None = None,
+) -> FileReviewState | None:
+    """Validate pathless --line against the last file review."""
+    review_action = _coerce_review_action(action)
+    review_state = read_last_file_review_state()
+    if review_state is None:
+        return None
+    if source is not None and review_state.source != _coerce_review_source(source):
+        _print_stale_or_mismatched_file_review_help(review_action.value, review_state)
+    if batch_name is not None and review_state.batch_name != batch_name:
+        _print_stale_or_mismatched_file_review_help(review_action.value, review_state)
+    if not _review_state_matches_action(review_state, review_action):
+        _print_stale_or_mismatched_file_review_help(review_action.value, review_state)
+    if (
+        review_state.source == ReviewSource.BATCH
+        and review_action in (
+            FileReviewAction.INCLUDE,
+            FileReviewAction.SKIP,
+            FileReviewAction.DISCARD,
+            FileReviewAction.INCLUDE_TO_BATCH,
+            FileReviewAction.DISCARD_TO_BATCH,
+        )
+        and not any(review_action in selection.actions for selection in review_state.selections)
+    ):
+        lines = [
+            _("The selected file view for {file} came from batch '{batch}', not the live working tree.").format(
+                file=review_state.file_path,
+                batch=review_state.batch_name,
+            )
+        ]
+        line_command = _line_action_command(review_action, review_state, line_spec=line_id_specification)
+        if line_command is not None:
+            lines.extend(["", _("To act on the batch file:"), f"  {line_command}"])
+        else:
+            lines.extend(
+                [
+                    "",
+                    _("Batch reviews do not support this action."),
+                    _("If you meant to act on live working-tree changes, open a live file review:"),
+                    f"  git-stage-batch show --file {_quote(review_state.file_path)}",
+                ]
+            )
+        raise CommandError("\n".join(lines))
+
+    try:
+        requested_ids = set(parse_line_selection(line_id_specification))
+    except ValueError as error:
+        raise CommandError(str(error)) from error
+
+    valid_groups = shown_complete_review_selection_groups(review_state, review_action)
+    validate_review_scoped_line_selection(requested_ids, valid_groups)
+    return review_state

--- a/src/git_stage_batch/data/file_review_state.py
+++ b/src/git_stage_batch/data/file_review_state.py
@@ -246,3 +246,205 @@ def finish_review_scoped_line_action(
         clear_last_file_review_state()
     else:
         clear_last_file_review_state_if_file_matches(file_path)
+def selected_change_kind_matches_review_source(
+    selected_kind: SelectedChangeKind | None,
+    review_state: FileReviewState,
+) -> bool:
+    """Return whether the selected kind is compatible with the review source."""
+    if review_state.source in (ReviewSource.FILE_VS_HEAD, ReviewSource.UNSTAGED):
+        return selected_kind == SelectedChangeKind.FILE
+    if review_state.source == ReviewSource.BATCH:
+        return selected_kind in (SelectedChangeKind.BATCH_FILE, SelectedChangeKind.BATCH_BINARY)
+    return False
+
+
+def selected_change_matches_review_state(review_state: FileReviewState) -> bool:
+    """Return whether selected state still matches the persisted review state."""
+    selected_kind = read_selected_change_kind()
+    if not selected_change_kind_matches_review_source(selected_kind, review_state):
+        return False
+    if get_selected_change_file_path() != review_state.file_path:
+        return False
+    if selected_kind is None:
+        return False
+    gutter_to_selection_id = None
+    line_changes = None
+    if review_state.source == ReviewSource.BATCH and review_state.batch_name is not None:
+        from .hunk_tracking import render_batch_file_display
+
+        rendered = render_batch_file_display(review_state.batch_name, review_state.file_path)
+        if rendered is None:
+            return False
+        gutter_to_selection_id = (
+            rendered.review_gutter_to_selection_id
+            or rendered.gutter_to_selection_id
+        )
+        actionable_selection_groups = rendered.actionable_selection_groups
+        review_action_groups = rendered.review_action_groups or None
+        line_changes = rendered.line_changes
+    else:
+        from .hunk_tracking import snapshots_are_stale
+
+        if snapshots_are_stale(review_state.file_path):
+            return False
+        actionable_selection_groups = None
+        review_action_groups = None
+
+    current_selected_fingerprint = fingerprint_selected_file_view(
+        source=review_state.source,
+        batch_name=review_state.batch_name,
+        file_path=review_state.file_path,
+        selected_change_kind=selected_kind,
+        gutter_to_selection_id=gutter_to_selection_id,
+        actionable_selection_groups=actionable_selection_groups,
+        review_action_groups=review_action_groups,
+        line_changes=line_changes,
+    )
+    if current_selected_fingerprint != review_state.selected_file_fingerprint:
+        return False
+    return (
+        compute_current_file_review_diff_fingerprint(review_state.file_path, line_changes=line_changes)
+        == review_state.diff_fingerprint
+    )
+
+
+def selected_batch_review_matches_reset_state(review_state: FileReviewState) -> bool:
+    """Return whether a batch review still has stable reset IDs."""
+    selected_kind = read_selected_change_kind()
+    if review_state.source != ReviewSource.BATCH or review_state.batch_name is None:
+        return False
+    if not selected_change_kind_matches_review_source(selected_kind, review_state):
+        return False
+    if get_selected_change_file_path() != review_state.file_path:
+        return False
+
+    from .hunk_tracking import render_batch_file_display
+
+    rendered = render_batch_file_display(review_state.batch_name, review_state.file_path)
+    if rendered is None:
+        return False
+    if (
+        compute_current_file_review_diff_fingerprint(
+            review_state.file_path,
+            line_changes=rendered.line_changes,
+        )
+        != review_state.diff_fingerprint
+    ):
+        return False
+
+    current_reset_groups = [
+        (group.display_ids, group.selection_ids)
+        for group in rendered.review_action_groups
+        if FileReviewAction.RESET_FROM_BATCH.value in group.actions
+    ]
+    persisted_reset_groups = {
+        (selection.display_ids, selection.selection_ids)
+        for selection in review_state.selections
+        if FileReviewAction.RESET_FROM_BATCH in selection.actions
+    }
+
+    def can_cover(
+        remaining_pairs: frozenset[tuple[int, int]],
+    ) -> bool:
+        if not remaining_pairs:
+            return True
+        first_pair = min(remaining_pairs)
+        for display_ids, selection_ids in current_reset_groups:
+            group_pairs = frozenset(zip(display_ids, selection_ids))
+            if first_pair not in group_pairs:
+                continue
+            if not group_pairs.issubset(remaining_pairs):
+                continue
+            if can_cover(remaining_pairs - group_pairs):
+                return True
+        return False
+
+    return all(
+        can_cover(frozenset(zip(display_ids, selection_ids)))
+        for display_ids, selection_ids in persisted_reset_groups
+    )
+
+
+def _review_state_matches_action(
+    review_state: FileReviewState,
+    action: FileReviewAction | str,
+) -> bool:
+    """Return whether a review is fresh for a specific action."""
+    review_action = _coerce_review_action(action)
+    if (
+        review_state.source == ReviewSource.BATCH
+        and review_action == FileReviewAction.RESET_FROM_BATCH
+    ):
+        return selected_batch_review_matches_reset_state(review_state)
+    return selected_change_matches_review_state(review_state)
+
+
+def _format_pages(pages: set[int]) -> str:
+    from ..core.line_selection import format_line_ids
+
+    return format_line_ids(sorted(pages))
+
+
+def shown_complete_review_selection_groups(
+    review_state: FileReviewState,
+    action: FileReviewAction | str,
+) -> list[set[int]]:
+    """Return complete actionable display-ID groups from shown review pages."""
+    review_action = _coerce_review_action(action)
+    shown_pages = (
+        set(range(1, review_state.page_count + 1))
+        if review_state.entire_file_shown else
+        set(review_state.shown_pages)
+    )
+    return [
+        set(selection.display_ids)
+        for selection in review_state.selections
+        if review_action in selection.actions
+        and set(range(selection.first_page, selection.last_page + 1)).issubset(shown_pages)
+    ]
+
+
+def fresh_batch_review_selection_groups_for_action(
+    batch_name: str,
+    file_path: str,
+    action: FileReviewAction | str,
+) -> list[set[int]] | None:
+    """Return shown review groups for a fresh matching batch review, if one is active."""
+    review_state = read_last_file_review_state()
+    if review_state is None:
+        return None
+    if review_state.source != ReviewSource.BATCH:
+        return None
+    if review_state.batch_name != batch_name or review_state.file_path != file_path:
+        return None
+    review_action = _coerce_review_action(action)
+    try:
+        review_is_fresh = _review_state_matches_action(review_state, review_action)
+    except Exception:
+        review_is_fresh = False
+    if not review_is_fresh:
+        raise CommandError(
+            _(
+                "The file review for {file} no longer matches batch '{batch}'.\n"
+                "Line IDs may no longer match.\n\n"
+                "Run:\n"
+                "  git-stage-batch show --from {batch} --file {file}"
+            ).format(
+                batch=shlex.quote(batch_name),
+                file=shlex.quote(file_path),
+            )
+        )
+
+    return shown_complete_review_selection_groups(review_state, action)
+
+
+def fresh_batch_review_display_ids_for_action(
+    batch_name: str,
+    file_path: str,
+    action: FileReviewAction | str,
+) -> set[int] | None:
+    """Return shown display IDs for a fresh matching batch review, if one is active."""
+    groups = fresh_batch_review_selection_groups_for_action(batch_name, file_path, action)
+    if groups is None:
+        return None
+    return {display_id for group in groups for display_id in group}

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -45,6 +45,7 @@ from ..utils.paths import (
     get_block_list_file_path,
     get_blocked_files_file_path,
     get_context_lines,
+    get_selected_change_clear_reason_file_path,
     get_selected_change_kind_file_path,
     get_selected_binary_file_json_path,
     get_selected_hunk_hash_file_path,
@@ -68,6 +69,41 @@ class SelectedChangeKind(str, Enum):
     FILE = "file"
     BINARY = "binary"
     BATCH_FILE = "batch-file"
+
+
+def _selected_change_state_paths():
+    """Return files that make up the cached selected change state."""
+    return {
+        "patch": get_selected_hunk_patch_file_path(),
+        "hash": get_selected_hunk_hash_file_path(),
+        "clear_reason": get_selected_change_clear_reason_file_path(),
+        "kind": get_selected_change_kind_file_path(),
+        "line_state": get_line_changes_json_file_path(),
+        "binary": get_selected_binary_file_json_path(),
+        "index_snapshot": get_index_snapshot_file_path(),
+        "working_snapshot": get_working_tree_snapshot_file_path(),
+        "processed_include_ids": get_processed_include_ids_file_path(),
+        "processed_skip_ids": get_processed_skip_ids_file_path(),
+    }
+
+
+def snapshot_selected_change_state() -> dict[str, bytes | None]:
+    """Capture the current selected change cache."""
+    return {
+        name: (read_file_bytes(path) if path.exists() else None)
+        for name, path in _selected_change_state_paths().items()
+    }
+
+
+def restore_selected_change_state(snapshot: dict[str, bytes | None]) -> None:
+    """Restore a previously captured selected change cache."""
+    for name, path in _selected_change_state_paths().items():
+        data = snapshot.get(name)
+        if data is None:
+            path.unlink(missing_ok=True)
+        else:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(data)
 
 
 def clear_selected_change_state_files() -> None:

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -108,15 +108,11 @@ def restore_selected_change_state(snapshot: dict[str, bytes | None]) -> None:
 
 def clear_selected_change_state_files() -> None:
     """Clear all cached selected hunk state files."""
-    get_selected_hunk_patch_file_path().unlink(missing_ok=True)
-    get_selected_hunk_hash_file_path().unlink(missing_ok=True)
-    get_selected_change_kind_file_path().unlink(missing_ok=True)
-    get_line_changes_json_file_path().unlink(missing_ok=True)
-    get_selected_binary_file_json_path().unlink(missing_ok=True)
-    get_index_snapshot_file_path().unlink(missing_ok=True)
-    get_working_tree_snapshot_file_path().unlink(missing_ok=True)
-    get_processed_include_ids_file_path().unlink(missing_ok=True)
-    get_processed_skip_ids_file_path().unlink(missing_ok=True)
+    from .file_review_state import clear_last_file_review_state
+
+    for path in _selected_change_state_paths().values():
+        path.unlink(missing_ok=True)
+    clear_last_file_review_state()
     # processed_batch_ids is global state (union of all batches), not per-hunk state
 
 

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -71,6 +71,12 @@ class SelectedChangeKind(str, Enum):
     BATCH_FILE = "batch-file"
 
 
+class SelectedChangeClearReason(str, Enum):
+    """Reasons selected change state was intentionally cleared."""
+
+    FILE_LIST = "file-list"
+
+
 def _selected_change_state_paths():
     """Return files that make up the cached selected change state."""
     return {
@@ -114,6 +120,116 @@ def clear_selected_change_state_files() -> None:
         path.unlink(missing_ok=True)
     clear_last_file_review_state()
     # processed_batch_ids is global state (union of all batches), not per-hunk state
+
+
+def mark_selected_change_cleared_by_file_list(
+    *,
+    source: str,
+    batch_name: str | None = None,
+) -> None:
+    """Record that a navigational file list intentionally cleared selection."""
+    _write_selected_change_clear_reason(
+        reason=SelectedChangeClearReason.FILE_LIST,
+        source=source,
+        batch_name=batch_name,
+    )
+
+
+def _write_selected_change_clear_reason(
+    *,
+    reason: SelectedChangeClearReason,
+    source: str,
+    batch_name: str | None = None,
+    file_path: str | None = None,
+) -> None:
+    """Write a structured selected-change clear marker."""
+    write_text_file_contents(
+        get_selected_change_clear_reason_file_path(),
+        json.dumps(
+            {
+                "reason": reason.value,
+                "source": source,
+                "batch_name": batch_name,
+                "file_path": file_path,
+            },
+            ensure_ascii=False,
+            indent=0,
+        ),
+    )
+
+
+def _read_selected_change_clear_reason() -> dict[str, str | None] | None:
+    """Return the structured clear marker, tolerating legacy plain-text state."""
+    raw_reason = read_text_file_contents(get_selected_change_clear_reason_file_path()).strip()
+    if not raw_reason:
+        return None
+    if raw_reason == SelectedChangeClearReason.FILE_LIST.value:
+        return {
+            "reason": SelectedChangeClearReason.FILE_LIST.value,
+            "source": None,
+            "batch_name": None,
+        }
+    try:
+        data = json.loads(raw_reason)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    reason = data.get("reason")
+    if reason not in {item.value for item in SelectedChangeClearReason}:
+        return None
+    return {
+        "reason": reason,
+        "source": data.get("source") if isinstance(data.get("source"), str) else None,
+        "batch_name": data.get("batch_name") if isinstance(data.get("batch_name"), str) else None,
+        "file_path": data.get("file_path") if isinstance(data.get("file_path"), str) else None,
+    }
+
+
+def selected_change_was_cleared_by_file_list(
+    *,
+    source: str | None = None,
+    batch_name: str | None = None,
+) -> bool:
+    """Return whether the current empty selection came from a file list."""
+    if read_selected_change_kind() is not None:
+        return False
+    marker = _read_selected_change_clear_reason()
+    if marker is None:
+        return False
+    if marker["reason"] != SelectedChangeClearReason.FILE_LIST.value:
+        return False
+    marker_source = marker["source"]
+    marker_batch_name = marker["batch_name"]
+    if source is not None and marker_source != source:
+        return False
+    if batch_name is not None and marker_batch_name != batch_name:
+        return False
+    return True
+
+
+def refuse_bare_action_after_file_list(
+    action_command: str,
+    *,
+    open_command: str = "git-stage-batch show --file PATH",
+    source: str | None = None,
+    batch_name: str | None = None,
+) -> None:
+    """Refuse a bare action after a navigational file list cleared selection."""
+    if not selected_change_was_cleared_by_file_list(source=source, batch_name=batch_name):
+        return
+    raise CommandError(
+        _(
+            "No selected change.\n"
+            "The last command only showed files; it did not choose one for follow-up actions.\n\n"
+            "Run:\n"
+            "  git-stage-batch show\n"
+            "or choose a file with:\n"
+            "  {open_command}\n"
+            "before running:\n"
+            "  git-stage-batch {action}"
+        ).format(open_command=open_command, action=action_command)
+    )
 
 
 def load_selected_binary_file() -> Optional[BinaryFileChange]:

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -8,7 +8,8 @@ import subprocess
 import sys
 from dataclasses import replace
 from enum import Enum
-from typing import Generator, Optional, Union
+from hashlib import sha256
+from typing import Generator, Mapping, Optional, Union
 
 from ..batch.attribution import build_file_attribution, filter_owned_diff_fragments
 from ..batch import display as batch_display
@@ -20,9 +21,10 @@ from ..batch.ownership import (
     rebuild_ownership_from_units,
     validate_ownership_units,
 )
-from ..batch.query import read_batch_metadata
+from ..batch.query import get_batch_commit_sha, list_batch_names, read_batch_metadata
 from ..core.hashing import compute_binary_file_hash, compute_stable_hunk_hash
-from ..core.models import BinaryFileChange, LineLevelChange, HunkHeader, LineEntry, RenderedBatchDisplay
+from ..core.models import BinaryFileChange, LineLevelChange, HunkHeader, LineEntry, RenderedBatchDisplay, ReviewActionGroup
+from ..core.text_lifecycle import detect_empty_text_lifecycle_change
 from ..core.diff_parser import (
     build_line_changes_from_patch_bytes,
     parse_unified_diff_streaming,
@@ -69,6 +71,15 @@ class SelectedChangeKind(str, Enum):
     FILE = "file"
     BINARY = "binary"
     BATCH_FILE = "batch-file"
+    BATCH_BINARY = "batch-binary"
+
+
+_BATCH_MERGE_REVIEW_ACTIONS = (
+    "include-from-batch",
+    "discard-from-batch",
+    "apply-from-batch",
+)
+_BATCH_RESET_REVIEW_ACTION = "reset-from-batch"
 
 
 class SelectedChangeClearReason(str, Enum):
@@ -287,29 +298,219 @@ def refuse_bare_action_after_stale_batch_selection(
     )
 
 
+def _read_selected_binary_data() -> dict | None:
+    """Read cached binary selection data, if structurally valid."""
+    binary_path = get_selected_binary_file_json_path()
+    if not binary_path.exists():
+        return None
+    try:
+        binary_data = json.loads(read_text_file_contents(binary_path))
+    except json.JSONDecodeError:
+        return None
+    return binary_data if isinstance(binary_data, dict) else None
+
+
 def load_selected_binary_file() -> Optional[BinaryFileChange]:
     """Load the currently cached binary file.
 
     Returns:
         BinaryFileChange if a binary file is cached, None otherwise
     """
-    binary_path = get_selected_binary_file_json_path()
-    if not binary_path.exists():
+    if read_selected_change_kind() not in (SelectedChangeKind.BINARY, SelectedChangeKind.BATCH_BINARY):
+        return None
+
+    binary_data = _read_selected_binary_data()
+    if binary_data is None:
         return None
 
     try:
-        binary_data = json.loads(read_text_file_contents(binary_path))
         return BinaryFileChange(
             old_path=binary_data["old_path"],
             new_path=binary_data["new_path"],
             change_type=binary_data["change_type"]
         )
-    except (json.JSONDecodeError, KeyError):
+    except KeyError:
         return None
+
+
+def compute_batch_binary_fingerprint(
+    batch_name: str,
+    file_path: str,
+    file_meta: Mapping[str, object],
+) -> str:
+    """Return a stable identity for the current binary content stored in a batch."""
+    batch_blob = None
+    if file_meta.get("change_type") != "deleted":
+        batch_commit = get_batch_commit_sha(batch_name)
+        if batch_commit is not None:
+            blob_result = run_git_command(
+                ["rev-parse", "--verify", f"{batch_commit}:{file_path}"],
+                check=False,
+            )
+            if blob_result.returncode == 0:
+                batch_blob = blob_result.stdout.strip()
+
+    payload = {
+        "file_path": file_path,
+        "file_type": file_meta.get("file_type"),
+        "change_type": file_meta.get("change_type"),
+        "mode": file_meta.get("mode"),
+        "batch_source_commit": file_meta.get("batch_source_commit"),
+        "batch_blob": batch_blob,
+    }
+    data = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return sha256(data.encode("utf-8", errors="surrogateescape")).hexdigest()
+
+
+def cache_binary_file_change(
+    binary_change: BinaryFileChange,
+    *,
+    kind: SelectedChangeKind = SelectedChangeKind.BINARY,
+    batch_name: str | None = None,
+    batch_binary_fingerprint: str | None = None,
+) -> None:
+    """Cache a binary file change as the current selected change."""
+    if kind not in (SelectedChangeKind.BINARY, SelectedChangeKind.BATCH_BINARY):
+        raise ValueError("binary selections must use a binary selected-change kind")
+    file_path = binary_change.new_path if binary_change.new_path != "/dev/null" else binary_change.old_path
+    binary_data = {
+        "old_path": binary_change.old_path,
+        "new_path": binary_change.new_path,
+        "change_type": binary_change.change_type,
+        "batch_name": batch_name if kind == SelectedChangeKind.BATCH_BINARY else None,
+        "batch_binary_fingerprint": (
+            batch_binary_fingerprint
+            if kind == SelectedChangeKind.BATCH_BINARY else
+            None
+        ),
+    }
+    get_selected_hunk_patch_file_path().unlink(missing_ok=True)
+    get_line_changes_json_file_path().unlink(missing_ok=True)
+    get_index_snapshot_file_path().unlink(missing_ok=True)
+    get_working_tree_snapshot_file_path().unlink(missing_ok=True)
+    get_processed_include_ids_file_path().unlink(missing_ok=True)
+    get_processed_skip_ids_file_path().unlink(missing_ok=True)
+    write_text_file_contents(
+        get_selected_binary_file_json_path(),
+        json.dumps(binary_data, ensure_ascii=False, indent=0),
+    )
+    write_text_file_contents(
+        get_selected_hunk_hash_file_path(),
+        compute_binary_file_hash(binary_change),
+    )
+    if kind == SelectedChangeKind.BINARY:
+        write_snapshots_for_selected_file_path(file_path)
+    write_selected_change_kind(kind)
+
+
+def selected_batch_binary_matches_batch(batch_name: str) -> bool:
+    """Return whether the cached batch-binary selection came from this batch."""
+    if read_selected_change_kind() != SelectedChangeKind.BATCH_BINARY:
+        return False
+    binary_data = _read_selected_binary_data()
+    if binary_data is None:
+        return False
+    return binary_data.get("batch_name") == batch_name
+
+
+def selected_batch_binary_batch_name() -> str | None:
+    """Return the source batch name for the cached batch-binary selection."""
+    if read_selected_change_kind() != SelectedChangeKind.BATCH_BINARY:
+        return None
+    binary_data = _read_selected_binary_data()
+    if binary_data is None:
+        return None
+    batch_name = binary_data.get("batch_name")
+    return batch_name if isinstance(batch_name, str) else None
+
+
+def selected_batch_binary_file_for_batch(
+    batch_name: str,
+    all_files: Mapping[str, dict],
+) -> str | None:
+    """Return the selected batch-binary file if it still exists in batch metadata."""
+    if not selected_batch_binary_matches_batch(batch_name):
+        return None
+
+    binary_file = load_selected_binary_file()
+    if binary_file is None:
+        return None
+
+    file_path = binary_file.new_path if binary_file.new_path != "/dev/null" else binary_file.old_path
+    file_meta = all_files.get(file_path)
+    if file_meta is None:
+        return None
+    if file_meta.get("file_type") != "binary":
+        return None
+    if file_meta.get("change_type") != binary_file.change_type:
+        return None
+
+    binary_data = _read_selected_binary_data()
+    if binary_data is None:
+        return None
+    cached_fingerprint = binary_data.get("batch_binary_fingerprint")
+    if not isinstance(cached_fingerprint, str):
+        return None
+    current_fingerprint = compute_batch_binary_fingerprint(batch_name, file_path, file_meta)
+    if current_fingerprint != cached_fingerprint:
+        return None
+
+    return file_path
+
+
+def require_current_selected_batch_binary_file_for_batch(
+    batch_name: str,
+    all_files: Mapping[str, dict],
+) -> str | None:
+    """Return selected batch-binary file for this batch, or refuse if it went stale."""
+    if not selected_batch_binary_matches_batch(batch_name):
+        return None
+
+    selected_file = selected_batch_binary_file_for_batch(batch_name, all_files)
+    if selected_file is not None:
+        return selected_file
+
+    binary_file = load_selected_binary_file()
+    file_path = (
+        binary_file.new_path
+        if binary_file is not None and binary_file.new_path != "/dev/null" else
+        binary_file.old_path
+        if binary_file is not None else
+        "the selected batch binary"
+    )
+    clear_selected_change_state_files()
+    mark_selected_change_cleared_by_stale_batch_selection(
+        batch_name=batch_name,
+        file_path=file_path,
+    )
+    exit_with_error(
+        _(
+            "The selected batch binary no longer matches batch '{name}'.\n"
+            "Show the batch again before using a pathless batch action."
+        ).format(name=batch_name)
+    )
+
+
+def binary_file_change_is_stale(binary_change: BinaryFileChange) -> bool:
+    """Return whether a cached binary selection no longer matches repository state."""
+    file_path = binary_change.new_path if binary_change.new_path != "/dev/null" else binary_change.old_path
+    if snapshots_are_stale(file_path):
+        return True
+    current_change = render_binary_file_change(file_path)
+    if current_change is None:
+        return True
+    return (
+        current_change.old_path != binary_change.old_path
+        or current_change.new_path != binary_change.new_path
+        or current_change.change_type != binary_change.change_type
+    )
 
 
 def write_selected_change_kind(kind: SelectedChangeKind) -> None:
     """Persist the kind of selected change cached in session state."""
+    get_selected_change_clear_reason_file_path().unlink(missing_ok=True)
+    if kind not in (SelectedChangeKind.BINARY, SelectedChangeKind.BATCH_BINARY):
+        get_selected_binary_file_json_path().unlink(missing_ok=True)
     write_text_file_contents(get_selected_change_kind_file_path(), kind)
 
 
@@ -331,8 +532,17 @@ def read_selected_change_kind() -> Optional[SelectedChangeKind]:
 
 def load_selected_change() -> Optional[Union[LineLevelChange, BinaryFileChange]]:
     """Load the currently cached selected change, if any."""
+    selected_kind = read_selected_change_kind()
     binary_file = load_selected_binary_file()
     if binary_file is not None:
+        if selected_kind == SelectedChangeKind.BINARY and binary_file_change_is_stale(binary_file):
+            file_path = binary_file.new_path if binary_file.new_path != "/dev/null" else binary_file.old_path
+            raise CommandError(
+                _(
+                    "Selected binary file no longer matches the working tree: {file}.\n"
+                    "Run 'show' again before using a pathless action."
+                ).format(file=file_path)
+            )
         return binary_file
 
     patch_path = get_selected_hunk_patch_file_path()
@@ -387,6 +597,9 @@ def apply_line_level_batch_filter_to_cached_hunk() -> bool:
 
     file_path = line_changes.path
 
+    if not line_changes.lines and _empty_text_lifecycle_change_is_batched(file_path):
+        return True
+
     # Step 1: Build file attribution (file-centric, not diff-centric)
     attribution = build_file_attribution(file_path)
 
@@ -409,6 +622,19 @@ def apply_line_level_batch_filter_to_cached_hunk() -> bool:
                   ensure_ascii=False, indent=0)
     )
 
+    return False
+
+
+def _empty_text_lifecycle_change_is_batched(file_path: str) -> bool:
+    """Return whether the current empty text lifecycle diff is already batched."""
+    change_type = detect_empty_text_lifecycle_change(file_path)
+    if change_type is None:
+        return False
+
+    for batch_name in list_batch_names():
+        file_meta = read_batch_metadata(batch_name).get("files", {}).get(file_path)
+        if file_meta is not None and file_meta.get("change_type") == change_type:
+            return True
     return False
 
 
@@ -538,6 +764,35 @@ def render_batch_file_display(
     )
 
     if not display_lines:
+        change_type = file_meta.get("change_type", "modified")
+        if change_type in {"added", "deleted"}:
+            marker_kind = "+" if change_type == "added" else "-"
+            line_changes = LineLevelChange(
+                path=file_path,
+                header=HunkHeader(
+                    old_start=0 if change_type == "added" else 1,
+                    old_len=0 if change_type == "added" else 1,
+                    new_start=1 if change_type == "added" else 0,
+                    new_len=1 if change_type == "added" else 0,
+                ),
+                lines=[
+                    LineEntry(
+                        id=1,
+                        kind=marker_kind,
+                        old_line_number=1 if change_type == "deleted" else None,
+                        new_line_number=1 if change_type == "added" else None,
+                        text_bytes=b"<empty file>",
+                        text="<empty file>",
+                        source_line=None,
+                    )
+                ],
+            )
+            return RenderedBatchDisplay(
+                line_changes=line_changes,
+                gutter_to_selection_id={},
+                selection_id_to_gutter={},
+                actionable_selection_groups=(),
+            )
         return None
 
     # Determine which display lines should get gutter IDs
@@ -654,10 +909,74 @@ def render_batch_file_display(
             selection_id_to_gutter[entry.id] = gutter_num
             gutter_num += 1
 
+    line_id_display_order = [
+        entry.id
+        for entry in line_entries
+        if entry.id is not None
+    ]
+    resettable_ids = {
+        line_id
+        for unit in units
+        for line_id in unit.display_line_ids
+    }
+    review_gutter_to_selection_id = {}
+    review_selection_id_to_gutter = {}
+    review_gutter_num = 1
+    for entry in line_entries:
+        if entry.id is not None and entry.id in resettable_ids:
+            review_gutter_to_selection_id[review_gutter_num] = entry.id
+            review_selection_id_to_gutter[entry.id] = review_gutter_num
+            review_gutter_num += 1
+
+    actionable_selection_groups = []
+    review_action_groups = []
+    for unit in units:
+        if not unit.display_line_ids:
+            continue
+        ordered_group = tuple(
+            line_id
+            for line_id in line_id_display_order
+            if line_id in unit.display_line_ids
+        )
+        if len(ordered_group) != len(unit.display_line_ids):
+            continue
+
+        actions = [_BATCH_RESET_REVIEW_ACTION]
+        if unit.display_line_ids.issubset(mergeable_ids):
+            actionable_selection_groups.append(ordered_group)
+            actions = [
+                *_BATCH_MERGE_REVIEW_ACTIONS,
+                _BATCH_RESET_REVIEW_ACTION,
+            ]
+
+        review_display_ids = tuple(
+            review_selection_id_to_gutter[line_id]
+            for line_id in ordered_group
+            if line_id in review_selection_id_to_gutter
+        )
+        if len(review_display_ids) == len(ordered_group):
+            if unit.kind.value == "replacement":
+                reason = "replacement"
+            elif unit.kind.value == "deletion_only":
+                reason = "structural-run"
+            else:
+                reason = "simple"
+            review_action_groups.append(
+                ReviewActionGroup(
+                    display_ids=review_display_ids,
+                    selection_ids=ordered_group,
+                    actions=tuple(actions),
+                    reason=reason,
+                )
+            )
     return RenderedBatchDisplay(
         line_changes=line_changes,
         gutter_to_selection_id=gutter_to_selection_id,
-        selection_id_to_gutter=selection_id_to_gutter
+        selection_id_to_gutter=selection_id_to_gutter,
+        actionable_selection_groups=tuple(actionable_selection_groups),
+        review_gutter_to_selection_id=review_gutter_to_selection_id,
+        review_selection_id_to_gutter=review_selection_id_to_gutter,
+        review_action_groups=tuple(review_action_groups),
     )
 
 
@@ -862,6 +1181,8 @@ def _cache_combined_file_line_changes(
     write_file_bytes(get_selected_hunk_patch_file_path(), patch_bytes)
     write_text_file_contents(get_selected_hunk_hash_file_path(), patch_hash)
     write_selected_change_kind(SelectedChangeKind.FILE)
+    write_line_ids_file(get_processed_include_ids_file_path(), set())
+    write_line_ids_file(get_processed_skip_ids_file_path(), set())
     write_text_file_contents(get_line_changes_json_file_path(),
                             json.dumps(convert_line_changes_to_serializable_dict(combined_line_changes),
                                       ensure_ascii=False, indent=0))
@@ -881,6 +1202,19 @@ def render_file_as_single_hunk(file_path: str) -> Optional[LineLevelChange]:
             stream_git_command(["diff", f"-U{get_context_lines()}", "--no-color", "HEAD", "--", file_path])
         ),
     )
+
+
+def render_binary_file_change(file_path: str) -> Optional[BinaryFileChange]:
+    """Render a binary file change for file-scoped display without caching state."""
+    try:
+        for item in parse_unified_diff_streaming(
+            stream_git_command(["diff", "--no-color", "HEAD", "--", file_path])
+        ):
+            if isinstance(item, BinaryFileChange):
+                return item
+    except subprocess.CalledProcessError:
+        return None
+    return None
 
 
 def render_unstaged_file_as_single_hunk(file_path: str) -> Optional[LineLevelChange]:
@@ -962,6 +1296,9 @@ def _build_combined_file_line_changes(
     previous_new_end = None
 
     for single_hunk in patches:
+        if isinstance(single_hunk, BinaryFileChange):
+            continue
+
         patch_bytes = single_hunk.to_patch_bytes()
         line_changes = build_line_changes_from_patch_bytes(patch_bytes)
 
@@ -1067,16 +1404,7 @@ def fetch_next_change() -> Union[LineLevelChange, BinaryFileChange]:
                 if file_path in blocked_files:
                     continue
 
-                # Cache binary file as JSON (for state persistence)
-                binary_data = {
-                    "old_path": item.old_path,
-                    "new_path": item.new_path,
-                    "change_type": item.change_type,
-                }
-                write_text_file_contents(get_selected_binary_file_json_path(),
-                                       json.dumps(binary_data, ensure_ascii=False, indent=0))
-                write_text_file_contents(get_selected_hunk_hash_file_path(), binary_hash)
-                write_selected_change_kind(SelectedChangeKind.BINARY)
+                cache_binary_file_change(item)
 
                 # Return the BinaryFileChange object directly
                 return item
@@ -1211,7 +1539,7 @@ def snapshots_are_stale(file_path: str) -> bool:
     repo_root = get_git_repository_root_path()
     file_full_path = repo_root / file_path
     try:
-        selected_worktree_content = read_file_bytes(file_full_path)
+        selected_worktree_content = read_file_bytes(file_full_path) if file_full_path.exists() else b""
     except Exception:
         return True  # Error reading means state is stale
 
@@ -1222,6 +1550,14 @@ def snapshots_are_stale(file_path: str) -> bool:
 
 def require_selected_hunk() -> None:
     """Ensure selected hunk exists and is not stale, exit with error otherwise."""
+    if read_selected_change_kind() in (SelectedChangeKind.BATCH_FILE, SelectedChangeKind.BATCH_BINARY):
+        exit_with_error(
+            _(
+                "Selected file came from a batch, not a live hunk. "
+                "Open a live hunk with 'show' or use the matching '--from' command."
+            )
+        )
+
     if not get_selected_hunk_patch_file_path().exists():
         exit_with_error(_("No selected hunk. Run 'start' first."))
 
@@ -1256,7 +1592,15 @@ def recalculate_selected_hunk_for_file(file_path: str) -> None:
             command_show()
             return
 
-        print_line_level_changes(line_changes)
+        if apply_line_level_batch_filter_to_cached_hunk():
+            clear_selected_change_state_files()
+            from ..commands.show import command_show
+            command_show()
+            return
+
+        line_changes = load_line_changes_from_state()
+        if line_changes is not None:
+            print_line_level_changes(line_changes)
         return
 
     # Load blocklist

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -75,6 +75,7 @@ class SelectedChangeClearReason(str, Enum):
     """Reasons selected change state was intentionally cleared."""
 
     FILE_LIST = "file-list"
+    STALE_BATCH_SELECTION = "stale-batch-selection"
 
 
 def _selected_change_state_paths():
@@ -132,6 +133,20 @@ def mark_selected_change_cleared_by_file_list(
         reason=SelectedChangeClearReason.FILE_LIST,
         source=source,
         batch_name=batch_name,
+    )
+
+
+def mark_selected_change_cleared_by_stale_batch_selection(
+    *,
+    batch_name: str,
+    file_path: str,
+) -> None:
+    """Record that a batch mutation invalidated the selected batch file."""
+    _write_selected_change_clear_reason(
+        reason=SelectedChangeClearReason.STALE_BATCH_SELECTION,
+        source="batch",
+        batch_name=batch_name,
+        file_path=file_path,
     )
 
 
@@ -208,6 +223,23 @@ def selected_change_was_cleared_by_file_list(
     return True
 
 
+def selected_change_was_cleared_by_stale_batch_selection(
+    *,
+    batch_name: str | None = None,
+) -> bool:
+    """Return whether the current empty selection is a stale batch selection."""
+    if read_selected_change_kind() is not None:
+        return False
+    marker = _read_selected_change_clear_reason()
+    if marker is None:
+        return False
+    if marker["reason"] != SelectedChangeClearReason.STALE_BATCH_SELECTION.value:
+        return False
+    if batch_name is not None and marker["batch_name"] != batch_name:
+        return False
+    return True
+
+
 def refuse_bare_action_after_file_list(
     action_command: str,
     *,
@@ -229,6 +261,29 @@ def refuse_bare_action_after_file_list(
             "before running:\n"
             "  git-stage-batch {action}"
         ).format(open_command=open_command, action=action_command)
+    )
+
+
+def refuse_bare_action_after_stale_batch_selection(
+    action_command: str,
+    *,
+    batch_name: str,
+) -> None:
+    """Refuse a bare batch action after the selected batch file went stale."""
+    if not selected_change_was_cleared_by_stale_batch_selection(batch_name=batch_name):
+        return
+
+    marker = _read_selected_change_clear_reason() or {}
+    file_path = marker.get("file_path") or "the previously selected file"
+    raise CommandError(
+        _(
+            "No selected change.\n"
+            "The selected batch file '{file}' was changed or removed from batch '{batch}'.\n\n"
+            "Open a current batch file with:\n"
+            "  git-stage-batch show --from {batch} --file PATH\n"
+            "before running:\n"
+            "  git-stage-batch {action}"
+        ).format(file=file_path, batch=batch_name, action=action_command)
     )
 
 

--- a/src/git_stage_batch/output/__init__.py
+++ b/src/git_stage_batch/output/__init__.py
@@ -1,7 +1,7 @@
 """Display utilities."""
 
 from .colors import Colors, format_hotkey, format_option_list
-from .hunk import print_line_level_changes
+from .hunk import print_line_level_changes, print_remaining_line_changes_header
 from .patch import print_binary_file_change, print_colored_patch
 
 __all__ = [
@@ -9,6 +9,7 @@ __all__ = [
     "format_hotkey",
     "format_option_list",
     "print_line_level_changes",
+    "print_remaining_line_changes_header",
     "print_binary_file_change",
     "print_colored_patch",
 ]

--- a/src/git_stage_batch/output/file_review.py
+++ b/src/git_stage_batch/output/file_review.py
@@ -1,0 +1,1181 @@
+"""Page-aware file review rendering."""
+
+from __future__ import annotations
+
+import os
+import shlex
+import shutil
+import sys
+from dataclasses import dataclass
+
+from ..core.actionable_changes import (
+    ActionableSelection,
+    ActionableSelectionReason,
+    derive_actionable_selections,
+)
+from ..core.line_selection import format_line_ids, parse_positive_selection
+from ..core.models import HunkHeader, LineEntry, LineLevelChange, ReviewActionGroup
+from ..data.file_review_state import (
+    FileReviewAction,
+    FileReviewState,
+    FileReviewSelectionState,
+    ReviewSource,
+    compute_current_file_review_diff_fingerprint,
+    fingerprint_selected_file_view,
+    _line_action_command,
+)
+from ..data.hunk_tracking import SelectedChangeKind
+from ..exceptions import CommandError
+from ..i18n import _
+
+DEFAULT_NON_TTY_REVIEW_LINES = 80
+DEFAULT_REVIEW_WIDTH = 80
+REVIEW_HEADER_LINES = 4
+REVIEW_FOOTER_LINES = 12
+MINIMUM_BODY_LINES = 8
+
+
+def _quote(value: str) -> str:
+    return shlex.quote(value)
+
+
+@dataclass(frozen=True)
+class ReviewChange:
+    """A complete actionable change group in a file review."""
+
+    index: int
+    total: int
+    path: str
+    hunk_header: HunkHeader
+    old_start: int | None
+    old_end: int | None
+    new_start: int | None
+    new_end: int | None
+    rows: tuple[LineEntry, ...]
+    display_ids: tuple[int, ...]
+    selection_ids: tuple[int, ...]
+    select_as: str | None
+    reason: ActionableSelectionReason
+    is_oversized: bool
+    note: str | None
+    actions: tuple[str, ...] = ()
+    first_page: int = 1
+    last_page: int = 1
+
+
+@dataclass(frozen=True)
+class ReviewChangeFragment:
+    """A rendered fragment of a review change on one page."""
+
+    change: ReviewChange
+    rows: tuple[LineEntry, ...]
+    is_first_fragment: bool
+    is_last_fragment: bool
+
+
+@dataclass(frozen=True)
+class FileReviewPage:
+    """One semantic review page."""
+
+    page: int
+    changes: tuple[ReviewChangeFragment, ...]
+
+
+@dataclass(frozen=True)
+class FileReviewModel:
+    """A paginated file review model."""
+
+    line_changes: LineLevelChange
+    changes: tuple[ReviewChange, ...]
+    pages: tuple[FileReviewPage, ...]
+    display_id_by_selection_id: dict[int, int] | None = None
+    review_action_groups: tuple[ReviewActionGroup, ...] = ()
+
+
+@dataclass(frozen=True)
+class FileReviewView:
+    """Selected pages from a file review model."""
+
+    source: ReviewSource
+    path: str
+    page_spec: str
+    shown_pages: tuple[int, ...]
+    page_count: int
+    pages: tuple[FileReviewPage, ...]
+    complete_changes: tuple[ReviewChange, ...]
+    partial_changes: tuple[ReviewChange, ...]
+    entire_file_shown: bool
+
+
+def parse_page_selection(page_spec: str, page_count: int, file_path: str) -> tuple[int, ...]:
+    """Parse and validate a page selection after page count is known."""
+    normalized_spec = page_spec.strip().lower()
+    if normalized_spec == "all":
+        return tuple(range(1, page_count + 1))
+
+    tokens = [token.strip() for token in normalized_spec.split(",")]
+    if any(token == "" for token in tokens):
+        raise CommandError(_("Page selection contains an empty item."))
+    if any(token == "all" for token in tokens):
+        raise CommandError(_("`all` cannot be combined with other page selections."))
+
+    try:
+        pages = parse_positive_selection(
+            normalized_spec,
+            item_name=_("Page"),
+            reject_empty_items=True,
+        )
+    except ValueError as error:
+        raise CommandError(
+            _("Invalid page selection '{spec}': {error}").format(
+                spec=page_spec,
+                error=error,
+            )
+        ) from error
+
+    if not pages:
+        raise CommandError(_("Page selection cannot be empty."))
+    highest_page = max(pages)
+    if highest_page > page_count:
+        raise CommandError(
+            _("Page {page} is outside the file review for {file}.\n"
+              "Available pages: 1-{page_count}.").format(
+                page=highest_page,
+                file=file_path,
+                page_count=page_count,
+            )
+        )
+    return tuple(sorted(set(pages)))
+
+
+def normalize_page_spec(shown_pages: tuple[int, ...], page_count: int) -> str:
+    """Return a compact persisted page specification."""
+    if set(shown_pages) == set(range(1, page_count + 1)):
+        return "all"
+    return format_line_ids(list(shown_pages))
+
+
+def _partly_selects_ownership_group(
+    selection: ActionableSelection,
+    ownership_group_sets: list[set[int]],
+) -> bool:
+    """Return whether a review selection splits a complete batch ownership group."""
+    selected_ids = set(selection.selection_ids)
+    return any(
+        selected_ids & ownership_group
+        and not ownership_group.issubset(selected_ids)
+        for ownership_group in ownership_group_sets
+    )
+
+
+def _coerce_actionable_reason(reason: str) -> ActionableSelectionReason:
+    try:
+        return ActionableSelectionReason(reason)
+    except ValueError:
+        return ActionableSelectionReason.SIMPLE
+
+
+def _reason_for_selection_ids(
+    line_changes: LineLevelChange,
+    selection_ids: tuple[int, ...],
+) -> ActionableSelectionReason:
+    selected_id_set = set(selection_ids)
+    changed_kinds = {
+        line.kind
+        for line in line_changes.lines
+        if line.id in selected_id_set
+        and line.kind in ("+", "-")
+    }
+    return (
+        ActionableSelectionReason.REPLACEMENT
+        if {"-", "+"}.issubset(changed_kinds)
+        else ActionableSelectionReason.SIMPLE
+    )
+
+
+def _actionable_selections_from_selection_groups(
+    line_changes: LineLevelChange,
+    selection_groups: tuple[tuple[int, ...], ...],
+    display_id_by_selection_id: dict[int, int] | None,
+) -> tuple[ActionableSelection, ...]:
+    """Create review selections directly from complete ownership groups."""
+    selections: list[ActionableSelection] = []
+    for group in selection_groups:
+        selection_ids = tuple(selection_id for selection_id in group if selection_id is not None)
+        if not selection_ids:
+            continue
+        if display_id_by_selection_id is None:
+            display_ids = selection_ids
+        else:
+            if any(selection_id not in display_id_by_selection_id for selection_id in selection_ids):
+                continue
+            display_ids = tuple(
+                display_id_by_selection_id[selection_id]
+                for selection_id in selection_ids
+            )
+        selections.append(
+            ActionableSelection(
+                display_ids=display_ids,
+                selection_ids=selection_ids,
+                reason=_reason_for_selection_ids(line_changes, selection_ids),
+            )
+        )
+    return tuple(selections)
+
+
+def _display_actionable_selections_from_review_action_groups(
+    line_changes: LineLevelChange,
+    review_action_groups: tuple[ReviewActionGroup, ...],
+    gutter_to_selection_id: dict[int, int] | None,
+) -> tuple[ActionableSelection, ...]:
+    """Derive user-facing batch review changes without splitting reset atoms."""
+    action_group_by_selection_id = {
+        selection_id: group
+        for group in review_action_groups
+        for selection_id in group.selection_ids
+    }
+    atomic_group_sets = [
+        set(group.selection_ids)
+        for group in review_action_groups
+        if group.reason in (
+            ActionableSelectionReason.REPLACEMENT.value,
+            ActionableSelectionReason.STRUCTURAL_RUN.value,
+        )
+    ]
+    selections = []
+    for selection in derive_actionable_selections(
+        line_changes,
+        gutter_to_selection_id=gutter_to_selection_id,
+    ):
+        chunk_display_ids: list[int] = []
+        chunk_selection_ids: list[int] = []
+        chunk_actions: tuple[str, ...] | None = None
+
+        def flush_chunk() -> None:
+            nonlocal chunk_display_ids, chunk_selection_ids, chunk_actions
+            if not chunk_display_ids or chunk_actions is None:
+                chunk_display_ids = []
+                chunk_selection_ids = []
+                chunk_actions = None
+                return
+            chunk = ActionableSelection(
+                display_ids=tuple(chunk_display_ids),
+                selection_ids=tuple(chunk_selection_ids),
+                reason=_reason_for_selection_ids(
+                    line_changes,
+                    tuple(chunk_selection_ids),
+                ),
+                actions=chunk_actions,
+            )
+            if not _partly_selects_ownership_group(chunk, atomic_group_sets):
+                selections.append(chunk)
+            chunk_display_ids = []
+            chunk_selection_ids = []
+            chunk_actions = None
+
+        for display_id, selection_id in zip(selection.display_ids, selection.selection_ids):
+            action_group = action_group_by_selection_id.get(selection_id)
+            if action_group is None:
+                flush_chunk()
+                continue
+            actions = action_group.actions
+            if chunk_actions is not None and actions != chunk_actions:
+                flush_chunk()
+            chunk_display_ids.append(display_id)
+            chunk_selection_ids.append(selection_id)
+            chunk_actions = actions
+        flush_chunk()
+    return tuple(selections)
+
+
+def build_file_review_model(
+    line_changes: LineLevelChange,
+    *,
+    gutter_to_selection_id: dict[int, int] | None = None,
+    actionable_selection_groups: tuple[tuple[int, ...], ...] | None = None,
+    review_action_groups: tuple[ReviewActionGroup, ...] | None = None,
+) -> FileReviewModel:
+    """Build a conservative change-first page model from a file-scoped hunk."""
+    changes: list[ReviewChange] = []
+    current_rows: list[LineEntry] = []
+    display_id_by_selection_id = (
+        {
+            selection_id: gutter_id
+            for gutter_id, selection_id in gutter_to_selection_id.items()
+        }
+        if gutter_to_selection_id is not None else None
+    )
+    if review_action_groups is not None:
+        actionable_selections = _display_actionable_selections_from_review_action_groups(
+            line_changes,
+            review_action_groups,
+            gutter_to_selection_id,
+        )
+    elif actionable_selection_groups is not None:
+        actionable_selections = _actionable_selections_from_selection_groups(
+            line_changes,
+            actionable_selection_groups,
+            display_id_by_selection_id,
+        )
+        ownership_group_sets = [
+            set(group)
+            for group in actionable_selection_groups
+            if group
+        ]
+        actionable_selections = tuple(
+            selection
+            for selection in actionable_selections
+            if not _partly_selects_ownership_group(selection, ownership_group_sets)
+        )
+    else:
+        actionable_selections = derive_actionable_selections(
+            line_changes,
+            gutter_to_selection_id=gutter_to_selection_id,
+        )
+    actionable_by_selection = {
+        selection.selection_ids: selection
+        for selection in actionable_selections
+    }
+
+    def append_change(rows: list[LineEntry], actionable: ActionableSelection | None) -> None:
+        old_line_numbers = [
+            line.old_line_number
+            for line in rows
+            if line.kind != "+" and line.old_line_number is not None
+        ]
+        new_line_numbers = [
+            line.new_line_number
+            for line in rows
+            if line.kind != "-" and line.new_line_number is not None
+        ]
+        changed_kinds = {line.kind for line in rows if line.kind in ("+", "-")}
+        reason = (
+            ActionableSelectionReason.REPLACEMENT
+            if {"-", "+"}.issubset(changed_kinds)
+            else ActionableSelectionReason.SIMPLE
+        )
+        display_ids = actionable.display_ids if actionable is not None else tuple()
+        selection_ids = (
+            actionable.selection_ids
+            if actionable is not None else
+            tuple(line.id for line in rows if line.kind in ("+", "-") and line.id is not None)
+        )
+        selection_text = format_line_ids(list(display_ids)) if display_ids else None
+        changes.append(
+            ReviewChange(
+                index=len(changes) + 1,
+                total=0,
+                path=line_changes.path,
+                hunk_header=line_changes.header,
+                old_start=min(old_line_numbers) if old_line_numbers else None,
+                old_end=max(old_line_numbers) if old_line_numbers else None,
+                new_start=min(new_line_numbers) if new_line_numbers else None,
+                new_end=max(new_line_numbers) if new_line_numbers else None,
+                rows=tuple(rows),
+                display_ids=display_ids,
+                selection_ids=selection_ids,
+                select_as=selection_text,
+                reason=actionable.reason if actionable is not None else reason,
+                is_oversized=False,
+                note=actionable.note if actionable is not None else _("not currently selectable"),
+                actions=actionable.actions if actionable is not None else tuple(),
+            )
+        )
+
+    def flush_segment() -> None:
+        nonlocal current_rows
+        pending_rows: list[LineEntry] = []
+        active_rows: list[LineEntry] = []
+        active_actionable: ActionableSelection | None = None
+        has_active_change = False
+        changed_run: list[LineEntry] = []
+        changed_run_displayable: bool | None = None
+        actionable_group_by_selection_id = {
+            selection_id: selection.selection_ids
+            for selection in actionable_selections
+            for selection_id in selection.selection_ids
+        }
+
+        def flush_active_change() -> None:
+            nonlocal active_rows, active_actionable, has_active_change
+            if has_active_change and active_rows:
+                append_change(active_rows, active_actionable)
+            active_rows = []
+            active_actionable = None
+            has_active_change = False
+
+        def activate_changed_run(*, trailing_rows: list[LineEntry] | None = None) -> None:
+            nonlocal pending_rows, changed_run, active_rows, active_actionable, has_active_change, changed_run_displayable
+            def actionable_for_chunk(
+                chunk_rows: list[LineEntry],
+                group: tuple[int, ...] | None,
+            ) -> ActionableSelection | None:
+                if group is None:
+                    return None
+                chunk_selection_ids = tuple(
+                    line.id
+                    for line in chunk_rows
+                    if line.id is not None
+                )
+                if chunk_selection_ids != group:
+                    return None
+                return actionable_by_selection.get(group)
+
+            chunks: list[tuple[list[LineEntry], ActionableSelection | None]] = []
+            current_chunk: list[LineEntry] = []
+            current_group: tuple[int, ...] | None = None
+            for line in changed_run:
+                group = (
+                    actionable_group_by_selection_id.get(line.id)
+                    if changed_run_displayable else
+                    None
+                )
+                if current_chunk and group != current_group:
+                    chunks.append(
+                        (
+                            current_chunk,
+                            actionable_for_chunk(current_chunk, current_group),
+                        )
+                    )
+                    current_chunk = []
+                current_chunk.append(line)
+                current_group = group
+
+            if current_chunk:
+                chunks.append(
+                    (
+                        current_chunk,
+                        actionable_for_chunk(current_chunk, current_group),
+                    )
+                )
+
+            for index, (chunk_rows, actionable) in enumerate(chunks):
+                flush_active_change()
+                active_rows = (pending_rows if index == 0 else []) + chunk_rows
+                if trailing_rows is not None and index == len(chunks) - 1:
+                    active_rows.extend(trailing_rows)
+                active_actionable = actionable
+                has_active_change = True
+            pending_rows = []
+            changed_run = []
+            changed_run_displayable = None
+
+        def changed_row_displayable(row: LineEntry) -> bool | None:
+            if row.kind not in ("+", "-") or row.id is None:
+                return None
+            if display_id_by_selection_id is None:
+                return True
+            return row.id in display_id_by_selection_id
+
+        for row in current_rows:
+            row_displayable = changed_row_displayable(row)
+            if row_displayable is not None:
+                if changed_run and changed_run_displayable != row_displayable:
+                    activate_changed_run()
+                changed_run.append(row)
+                changed_run_displayable = row_displayable
+                continue
+            if changed_run:
+                activate_changed_run(trailing_rows=[row])
+                continue
+            if has_active_change:
+                active_rows.append(row)
+            else:
+                pending_rows.append(row)
+
+        if changed_run:
+            activate_changed_run()
+        flush_active_change()
+        current_rows = []
+
+    for line in line_changes.lines:
+        is_gap = (
+            line.id is None
+            and line.kind == " "
+            and line.old_line_number is None
+            and line.new_line_number is None
+            and line.source_line is None
+        )
+        if is_gap:
+            flush_segment()
+            current_rows.append(line)
+            continue
+        current_rows.append(line)
+    flush_segment()
+
+    total = len(changes)
+    changes = [
+        ReviewChange(
+            index=change.index,
+            total=total,
+            path=change.path,
+            hunk_header=change.hunk_header,
+            old_start=change.old_start,
+            old_end=change.old_end,
+            new_start=change.new_start,
+            new_end=change.new_end,
+            rows=change.rows,
+            display_ids=change.display_ids,
+            selection_ids=change.selection_ids,
+            select_as=change.select_as,
+            reason=change.reason,
+            is_oversized=change.is_oversized,
+            note=change.note,
+            actions=change.actions,
+        )
+        for change in changes
+    ]
+
+    body_budget = _body_budget()
+    pages: list[list[ReviewChange]] = []
+    current_page: list[ReviewChange] = []
+    current_height = 0
+    for change in changes:
+        change_height = len(change.rows) + 2
+        if current_page and current_height + change_height > body_budget:
+            pages.append(current_page)
+            current_page = []
+            current_height = 0
+        current_page.append(change)
+        current_height += change_height
+    if current_page:
+        pages.append(current_page)
+    if not pages:
+        pages = [[]]
+
+    paged_changes: list[ReviewChange] = []
+    for page_number, page_changes in enumerate(pages, start=1):
+        for change in page_changes:
+            paged_changes.append(
+                ReviewChange(
+                    index=change.index,
+                    total=change.total,
+                    path=change.path,
+                    hunk_header=change.hunk_header,
+                    old_start=change.old_start,
+                    old_end=change.old_end,
+                    new_start=change.new_start,
+                    new_end=change.new_end,
+                    rows=change.rows,
+                    display_ids=change.display_ids,
+                    selection_ids=change.selection_ids,
+                    select_as=change.select_as,
+                    reason=change.reason,
+                    is_oversized=(len(change.rows) + 2) > body_budget,
+                    note=change.note,
+                    actions=change.actions,
+                    first_page=page_number,
+                    last_page=page_number,
+                )
+            )
+    by_index = {change.index: change for change in paged_changes}
+    final_pages = tuple(
+        FileReviewPage(
+            page=page_number,
+            changes=tuple(
+                ReviewChangeFragment(
+                    change=by_index[change.index],
+                    rows=by_index[change.index].rows,
+                    is_first_fragment=True,
+                    is_last_fragment=True,
+                )
+                for change in page_changes
+            ),
+        )
+        for page_number, page_changes in enumerate(pages, start=1)
+    )
+    return FileReviewModel(
+        line_changes=line_changes,
+        changes=tuple(paged_changes),
+        pages=final_pages,
+        display_id_by_selection_id=display_id_by_selection_id,
+        review_action_groups=review_action_groups or (),
+    )
+
+
+def _body_budget() -> int:
+    size = _review_terminal_size()
+    estimated_footer_lines = _estimate_file_review_footer_height()
+    return max(MINIMUM_BODY_LINES, size.lines - REVIEW_HEADER_LINES - estimated_footer_lines)
+
+
+def _review_terminal_size():
+    if not sys.stdout.isatty():
+        return os.terminal_size((DEFAULT_REVIEW_WIDTH, DEFAULT_NON_TTY_REVIEW_LINES))
+    return shutil.get_terminal_size(fallback=(DEFAULT_REVIEW_WIDTH, DEFAULT_NON_TTY_REVIEW_LINES))
+
+
+def _estimate_file_review_footer_height(complete_change_count: int = 3) -> int:
+    base_lines = 9
+    if complete_change_count == 0:
+        return base_lines
+    individual_lines = min(complete_change_count, 5) + 2
+    return min(18, base_lines + individual_lines)
+
+
+def resolve_default_review_pages(
+    model: FileReviewModel,
+    *,
+    requested_page_spec: str | None,
+    previous_selection: LineLevelChange | None = None,
+) -> tuple[int, ...]:
+    """Resolve explicit pages, selected-hunk anchor, or default page 1."""
+    page_count = len(model.pages)
+    if requested_page_spec is not None:
+        return parse_page_selection(requested_page_spec, page_count, model.line_changes.path)
+    if page_count <= 1:
+        return (1,)
+    if previous_selection is not None and previous_selection.path == model.line_changes.path:
+        for change in model.changes:
+            if _change_overlaps_line_change(change, previous_selection):
+                return (change.first_page,)
+    return (1,)
+
+
+def _change_overlaps_line_change(change: ReviewChange, line_changes: LineLevelChange) -> bool:
+    old_numbers = [
+        line.old_line_number
+        for line in line_changes.lines
+        if line.kind != "+" and line.old_line_number is not None
+    ]
+    new_numbers = [
+        line.new_line_number
+        for line in line_changes.lines
+        if line.kind != "-" and line.new_line_number is not None
+    ]
+    return (
+        _ranges_overlap(change.old_start, change.old_end, min(old_numbers, default=None), max(old_numbers, default=None))
+        or _ranges_overlap(change.new_start, change.new_end, min(new_numbers, default=None), max(new_numbers, default=None))
+    )
+
+
+def _ranges_overlap(
+    left_start: int | None,
+    left_end: int | None,
+    right_start: int | None,
+    right_end: int | None,
+) -> bool:
+    if left_start is None or left_end is None or right_start is None or right_end is None:
+        return False
+    return left_start <= right_end and right_start <= left_end
+
+
+def _pages_containing_review_display_ids(
+    model: FileReviewModel,
+    display_ids: tuple[int, ...],
+) -> tuple[int, ...]:
+    """Return review pages containing all of the requested display IDs."""
+    if model.display_id_by_selection_id is None:
+        display_id_for_row = lambda row: row.id
+    else:
+        display_id_for_row = lambda row: model.display_id_by_selection_id.get(row.id)
+
+    wanted = set(display_ids)
+    found: set[int] = set()
+    pages: set[int] = set()
+    for page in model.pages:
+        for fragment in page.changes:
+            for row in fragment.rows:
+                if row.id is None:
+                    continue
+                display_id = display_id_for_row(row)
+                if display_id in wanted:
+                    found.add(display_id)
+                    pages.add(page.page)
+    if found != wanted:
+        return tuple()
+    return tuple(sorted(pages))
+
+
+def _change_index_containing_review_display_ids(
+    model: FileReviewModel,
+    display_ids: tuple[int, ...],
+) -> int:
+    """Return a stable nearby change index for supplemental review selections."""
+    if model.display_id_by_selection_id is None:
+        display_id_for_row = lambda row: row.id
+    else:
+        display_id_for_row = lambda row: model.display_id_by_selection_id.get(row.id)
+
+    wanted = set(display_ids)
+    for page in model.pages:
+        for fragment in page.changes:
+            row_display_ids = {
+                display_id_for_row(row)
+                for row in fragment.rows
+                if row.id is not None
+            }
+            if wanted & row_display_ids:
+                return fragment.change.index
+    return 0
+
+
+def _supplemental_batch_review_selections(
+    model: FileReviewModel,
+    *,
+    visible_display_ids: set[int] | None,
+) -> tuple[FileReviewSelectionState, ...]:
+    """Persist reset ownership atoms without making them pagination changes."""
+    selections: list[FileReviewSelectionState] = []
+    primary_reset_groups = {
+        change.display_ids
+        for change in model.changes
+        if FileReviewAction.RESET_FROM_BATCH.value in change.actions
+    }
+    for group in model.review_action_groups:
+        if not group.display_ids:
+            continue
+        if group.display_ids in primary_reset_groups:
+            continue
+        display_id_set = set(group.display_ids)
+        if visible_display_ids is not None and not display_id_set.issubset(visible_display_ids):
+            continue
+        if FileReviewAction.RESET_FROM_BATCH.value not in group.actions:
+            continue
+        pages = _pages_containing_review_display_ids(model, group.display_ids)
+        if not pages:
+            continue
+        selections.append(
+            FileReviewSelectionState(
+                display_ids=group.display_ids,
+                selection_ids=group.selection_ids,
+                change_index=_change_index_containing_review_display_ids(
+                    model,
+                    group.display_ids,
+                ),
+                first_page=pages[0],
+                last_page=pages[-1],
+                reason=_coerce_actionable_reason(group.reason),
+                actions=(FileReviewAction.RESET_FROM_BATCH,),
+            )
+        )
+    return tuple(selections)
+
+
+def make_file_review_state(
+    model: FileReviewModel,
+    *,
+    source: ReviewSource,
+    batch_name: str | None,
+    shown_pages: tuple[int, ...],
+    selected_change_kind: SelectedChangeKind,
+    gutter_to_selection_id: dict[int, int] | None = None,
+    actionable_selection_groups: tuple[tuple[int, ...], ...] | None = None,
+    review_action_groups: tuple[ReviewActionGroup, ...] | None = None,
+    visible_display_ids: set[int] | None = None,
+    entire_file_shown: bool | None = None,
+) -> FileReviewState:
+    """Create persisted review state from a rendered page selection."""
+    page_count = len(model.pages)
+    shown_page_set = set(shown_pages)
+    selection_actions = (
+        (
+            FileReviewAction.INCLUDE_FROM_BATCH,
+            FileReviewAction.DISCARD_FROM_BATCH,
+            FileReviewAction.APPLY_FROM_BATCH,
+            FileReviewAction.RESET_FROM_BATCH,
+        )
+        if source == ReviewSource.BATCH
+        else (
+            FileReviewAction.INCLUDE,
+            FileReviewAction.SKIP,
+            FileReviewAction.DISCARD,
+            FileReviewAction.INCLUDE_TO_BATCH,
+            FileReviewAction.DISCARD_TO_BATCH,
+        )
+    )
+    selections = []
+    for change in model.changes:
+        if not change.display_ids:
+            continue
+        if visible_display_ids is not None and not set(change.display_ids).issubset(visible_display_ids):
+            continue
+        change_actions = (
+            tuple(FileReviewAction(action) for action in change.actions)
+            if change.actions else
+            selection_actions
+        )
+        selections.append(
+            FileReviewSelectionState(
+                display_ids=change.display_ids,
+                selection_ids=change.selection_ids,
+                change_index=change.index,
+                first_page=change.first_page,
+                last_page=change.last_page,
+                reason=change.reason,
+                actions=change_actions,
+            )
+        )
+    if source == ReviewSource.BATCH and review_action_groups is not None:
+        selections.extend(
+            _supplemental_batch_review_selections(
+                model,
+                visible_display_ids=visible_display_ids,
+            )
+        )
+    computed_entire_file_shown = shown_page_set == set(range(1, page_count + 1))
+    return FileReviewState(
+        source=source,
+        batch_name=batch_name,
+        file_path=model.line_changes.path,
+        page_spec=normalize_page_spec(shown_pages, page_count),
+        shown_pages=shown_pages,
+        page_count=page_count,
+        entire_file_shown=(
+            computed_entire_file_shown
+            if entire_file_shown is None else
+            entire_file_shown
+        ),
+        selections=tuple(selections),
+        selected_change_kind=selected_change_kind,
+        selected_file_fingerprint=fingerprint_selected_file_view(
+            source=source,
+            batch_name=batch_name,
+            file_path=model.line_changes.path,
+            selected_change_kind=selected_change_kind,
+            gutter_to_selection_id=gutter_to_selection_id,
+            actionable_selection_groups=actionable_selection_groups,
+            review_action_groups=review_action_groups,
+        ),
+        diff_fingerprint=compute_current_file_review_diff_fingerprint(model.line_changes.path),
+    )
+
+
+def print_file_review(
+    model: FileReviewModel,
+    *,
+    shown_pages: tuple[int, ...],
+    source_label: str,
+    page_spec: str,
+    command_source_args: str = "",
+    source: ReviewSource,
+    batch_name: str | None = None,
+    opened_near_selected_hunk: bool = False,
+) -> None:
+    """Print a page-aware file review."""
+    page_count = len(model.pages)
+    shown_page_set = set(shown_pages)
+    shown_changes = [
+        fragment.change
+        for page in shown_pages
+        for fragment in model.pages[page - 1].changes
+    ]
+    complete_changes = [
+        change
+        for change in shown_changes
+        if change.display_ids
+        if set(range(change.first_page, change.last_page + 1)).issubset(shown_page_set)
+    ]
+
+    _print_header(
+        model.line_changes.path,
+        source_label=source_label,
+        shown_pages=shown_pages,
+        page_count=page_count,
+        shown_changes=shown_changes,
+        total_changes=len(model.changes),
+        opened_near_selected_hunk=opened_near_selected_hunk,
+    )
+
+    multi_page = len(shown_pages) > 1
+    for page in shown_pages:
+        if multi_page:
+            print()
+            print(f"── page {page}/{page_count} " + "─" * 48)
+        for fragment in model.pages[page - 1].changes:
+            change = fragment.change
+            print()
+            selection_spec = change.select_as or format_line_ids(list(change.display_ids))
+            heading_action = _review_change_heading_action(change)
+            span_text = (
+                _(" · large change")
+                if change.is_oversized
+                else ""
+            )
+            if change.display_ids:
+                print(
+                    _("Change {index} of {total} · {action}: --line {lines}{span}").format(
+                        index=change.index,
+                        total=change.total,
+                        action=heading_action,
+                        lines=selection_spec,
+                        span=span_text,
+                    )
+                )
+            else:
+                print(
+                    _("Change {index} of {total} · {note}{span}").format(
+                        index=change.index,
+                        total=change.total,
+                        note=change.note or _("not currently selectable"),
+                        span=span_text,
+                    )
+                )
+            _print_rows(
+                fragment.rows,
+                _maximum_display_id_digit_count(model),
+                display_id_by_selection_id=model.display_id_by_selection_id,
+                allowed_selection_ids=set(change.selection_ids) if change.display_ids else set(),
+            )
+
+    _print_footer(
+        model.line_changes.path,
+        shown_pages=shown_pages,
+        page_count=page_count,
+        shown_changes=shown_changes,
+        complete_changes=complete_changes,
+        total_changes=len(model.changes),
+        page_spec=page_spec,
+        command_source_args=command_source_args,
+        source=source,
+        batch_name=batch_name,
+    )
+
+
+def _change_supports_action(change: ReviewChange, action: FileReviewAction) -> bool:
+    """Return whether a rendered review change supports an action."""
+    return not change.actions or action.value in change.actions
+
+
+def _review_change_heading_action(change: ReviewChange) -> str:
+    """Return the concise action label shown for one review change."""
+    if change.reason == ActionableSelectionReason.REPLACEMENT:
+        return _("select together")
+    if change.actions == (FileReviewAction.RESET_FROM_BATCH.value,):
+        return _("reset")
+    return _("select")
+
+
+def _print_header(
+    path: str,
+    *,
+    source_label: str,
+    shown_pages: tuple[int, ...],
+    page_count: int,
+    shown_changes: list[ReviewChange],
+    total_changes: int,
+    opened_near_selected_hunk: bool,
+) -> None:
+    print(f"── {path} " + "─" * 60)
+    print(source_label)
+    page_word = _("page") if len(shown_pages) == 1 else _("pages")
+    page_text = format_line_ids(list(shown_pages))
+    change_ids = [change.index for change in shown_changes]
+    change_text = format_line_ids(change_ids) if change_ids else ""
+    print(
+        _("Showing {page_word} {pages} of {page_count} · shown changes {changes} of {total}").format(
+            page_word=page_word,
+            pages=page_text,
+            page_count=page_count,
+            changes=change_text or "-",
+            total=total_changes,
+        )
+    )
+    if opened_near_selected_hunk:
+        print(_("Showing the area around the change you were viewing."))
+    else:
+        _print_page_coverage(shown_pages, page_count)
+    print("─" * 72)
+
+
+def _print_page_coverage(shown_pages: tuple[int, ...], page_count: int) -> None:
+    shown = set(shown_pages)
+    all_pages = set(range(1, page_count + 1))
+    if shown == all_pages:
+        print(_("Entire file shown."))
+        return
+    missing = sorted(all_pages - shown)
+    if missing:
+        print(_("Pages {pages} are not shown.").format(pages=format_line_ids(missing)))
+
+
+def _maximum_display_id_digit_count(model: FileReviewModel) -> int:
+    if model.display_id_by_selection_id is None:
+        return model.line_changes.maximum_line_id_digit_count()
+    if not model.display_id_by_selection_id:
+        return 1
+    return len(str(max(model.display_id_by_selection_id.values())))
+
+
+def _print_rows(
+    rows: tuple[LineEntry, ...],
+    maximum_digits: int,
+    *,
+    display_id_by_selection_id: dict[int, int] | None,
+    allowed_selection_ids: set[int] | None = None,
+) -> None:
+    label_width = maximum_digits + 3
+    for line in rows:
+        if line.id is None or (
+            allowed_selection_ids is not None
+            and line.id not in allowed_selection_ids
+        ):
+            display_id = None
+        elif display_id_by_selection_id is not None:
+            display_id = display_id_by_selection_id.get(line.id)
+        else:
+            display_id = line.id
+        if display_id is None:
+            label = ""
+        else:
+            label = f"[#{display_id}]"
+        padding = " " * max(0, label_width - len(label))
+        print(f"{label}{padding} {line.kind} {line.text}")
+
+
+def _print_footer(
+    path: str,
+    *,
+    shown_pages: tuple[int, ...],
+    page_count: int,
+    shown_changes: list[ReviewChange],
+    complete_changes: list[ReviewChange],
+    total_changes: int,
+    page_spec: str,
+    command_source_args: str,
+    source: ReviewSource,
+    batch_name: str | None,
+) -> None:
+    shown = set(shown_pages)
+    is_entire = shown == set(range(1, page_count + 1))
+    marker = "end" if max(shown_pages) == page_count else "more"
+    print()
+    print(f"── {marker} " + "─" * 63)
+    page_label = "page" if len(shown_pages) == 1 else "pages"
+    print(
+        f"{path} · {page_label} {format_line_ids(list(shown_pages))}/{page_count} "
+        f"· shown changes {format_line_ids([c.index for c in shown_changes])} of {total_changes}"
+    )
+    if not is_entire and max(shown_pages) < page_count:
+        print(
+            f"Next: git-stage-batch show{command_source_args} --file {_quote(path)} --page {max(shown_pages) + 1}"
+        )
+
+    review_state = _footer_review_state(
+        path=path,
+        shown_pages=shown_pages,
+        page_count=page_count,
+        source=source,
+        batch_name=batch_name,
+    )
+    primary_action = (
+        FileReviewAction.INCLUDE_FROM_BATCH
+        if source == ReviewSource.BATCH else
+        FileReviewAction.INCLUDE
+    )
+    primary_changes = [
+        change
+        for change in complete_changes
+        if _change_supports_action(change, primary_action)
+    ]
+    reset_changes = [
+        change
+        for change in complete_changes
+        if _change_supports_action(change, FileReviewAction.RESET_FROM_BATCH)
+    ]
+
+    if primary_changes:
+        combined_selection = ",".join(format_line_ids(list(change.display_ids)) for change in primary_changes)
+        print()
+        print(_("Complete changes shown:"))
+        include_line_command = (
+            _line_action_command("include", review_state, line_spec=combined_selection, pathless_line=True)
+            if review_state is not None else
+            None
+        )
+        print(f"  {include_line_command or f'git-stage-batch include{command_source_args} --line {combined_selection}'}")
+        print()
+        if command_source_args:
+            print(_("Same selection also works with:"))
+            discard_line_command = (
+                _line_action_command("discard", review_state, line_spec=combined_selection, pathless_line=True)
+                if review_state is not None else
+                None
+            )
+            print(f"  {discard_line_command or f'git-stage-batch discard{command_source_args} --line {combined_selection}'}")
+        else:
+            print(_("Also works with: skip, discard"))
+        if source == ReviewSource.BATCH and reset_changes:
+            reset_selection = ",".join(format_line_ids(list(change.display_ids)) for change in reset_changes)
+            reset_line_command = _line_action_command(
+                FileReviewAction.RESET_FROM_BATCH,
+                review_state,
+                line_spec=reset_selection,
+                pathless_line=True,
+            )
+            print(f"  {reset_line_command or f'git-stage-batch reset{command_source_args} --line {reset_selection}'}")
+        if len(primary_changes) <= 5:
+            print()
+            print(_("Individual changes:"))
+            for change in primary_changes:
+                selection_spec = format_line_ids(list(change.display_ids))
+                include_change_command = (
+                    _line_action_command("include", review_state, line_spec=selection_spec, pathless_line=True)
+                    if review_state is not None else
+                    None
+                )
+                print(f"  {include_change_command or f'git-stage-batch include{command_source_args} --line {selection_spec}'}")
+    elif reset_changes:
+        reset_selection = ",".join(format_line_ids(list(change.display_ids)) for change in reset_changes)
+        reset_line_command = _line_action_command(
+            FileReviewAction.RESET_FROM_BATCH,
+            review_state,
+            line_spec=reset_selection,
+            pathless_line=True,
+        )
+        print()
+        print(_("Resettable changes shown:"))
+        print(f"  {reset_line_command or f'git-stage-batch reset{command_source_args} --line {reset_selection}'}")
+    elif not is_entire:
+        print()
+        print(_("No complete change is actionable from this page."))
+
+    if is_entire:
+        print()
+        print(_("Actions:"))
+        print(f"  git-stage-batch include{command_source_args} --file {_quote(path)}")
+        if not command_source_args:
+            print("  git-stage-batch include")
+    else:
+        print()
+        print(_("All:") + f" git-stage-batch show{command_source_args} --file {_quote(path)} --page all")
+        print()
+        print(_("Whole file:"))
+        print(f"  git-stage-batch include{command_source_args} --file {_quote(path)}")
+
+
+def _footer_review_state(
+    *,
+    path: str,
+    shown_pages: tuple[int, ...],
+    page_count: int,
+    source: ReviewSource,
+    batch_name: str | None,
+) -> FileReviewState:
+    if source == ReviewSource.BATCH:
+        return FileReviewState(
+            source=ReviewSource.BATCH,
+            batch_name=batch_name,
+            file_path=path,
+            page_spec="all",
+            shown_pages=shown_pages,
+            page_count=page_count,
+            entire_file_shown=set(shown_pages) == set(range(1, page_count + 1)),
+            selections=tuple(),
+            selected_change_kind=SelectedChangeKind.BATCH_FILE,
+            selected_file_fingerprint="",
+            diff_fingerprint="",
+        )
+    return FileReviewState(
+        source=source,
+        batch_name=None,
+        file_path=path,
+        page_spec="all",
+        shown_pages=shown_pages,
+        page_count=page_count,
+        entire_file_shown=set(shown_pages) == set(range(1, page_count + 1)),
+        selections=tuple(),
+        selected_change_kind=SelectedChangeKind.FILE,
+        selected_file_fingerprint="",
+        diff_fingerprint="",
+    )

--- a/src/git_stage_batch/output/file_review_list.py
+++ b/src/git_stage_batch/output/file_review_list.py
@@ -1,0 +1,109 @@
+"""Multi-file review list output."""
+
+from __future__ import annotations
+
+import shlex
+from dataclasses import dataclass
+
+from ..core.models import BinaryFileChange, LineLevelChange
+from ..i18n import _
+from .file_review import build_file_review_model
+
+
+@dataclass(frozen=True)
+class FileReviewListEntry:
+    """One file listed in a multi-file review list."""
+
+    path: str
+    change_count: int
+    changed_line_count: int
+    addition_count: int
+    deletion_count: int
+    page_count: int
+    binary_change_type: str | None = None
+
+
+def make_file_review_list_entry(
+    line_changes: LineLevelChange,
+    *,
+    gutter_to_selection_id: dict[int, int] | None = None,
+) -> FileReviewListEntry:
+    """Build a list entry from a file review model."""
+    model = build_file_review_model(line_changes, gutter_to_selection_id=gutter_to_selection_id)
+    actionable_selection_ids = (
+        set(gutter_to_selection_id.values())
+        if gutter_to_selection_id is not None else
+        {line.id for line in line_changes.lines if line.id is not None}
+    )
+    addition_count = sum(1 for line in line_changes.lines if line.kind == "+" and line.id in actionable_selection_ids)
+    deletion_count = sum(1 for line in line_changes.lines if line.kind == "-" and line.id in actionable_selection_ids)
+    return FileReviewListEntry(
+        path=line_changes.path,
+        change_count=len(model.changes),
+        changed_line_count=addition_count + deletion_count,
+        addition_count=addition_count,
+        deletion_count=deletion_count,
+        page_count=len(model.pages),
+    )
+
+
+def make_binary_file_review_list_entry(binary_change: BinaryFileChange) -> FileReviewListEntry:
+    """Build a list entry from a binary file change."""
+    path = binary_change.new_path if binary_change.new_path != "/dev/null" else binary_change.old_path
+    return FileReviewListEntry(
+        path=path,
+        change_count=1,
+        changed_line_count=0,
+        addition_count=0,
+        deletion_count=0,
+        page_count=1,
+        binary_change_type=binary_change.change_type,
+    )
+
+
+def print_file_review_list(
+    *,
+    source_label: str,
+    entries: list[FileReviewListEntry],
+    command_source_args: str = "",
+) -> None:
+    """Print a navigational file list for multiple file reviews."""
+    print("── matched files " + "─" * 55)
+    print(source_label)
+    total_changes = sum(entry.change_count for entry in entries)
+    total_lines = sum(entry.changed_line_count for entry in entries)
+    print(
+        _("Matched: {files} files · {changes} changes · {lines} changed lines").format(
+            files=len(entries),
+            changes=total_changes,
+            lines=total_lines,
+        )
+    )
+    print()
+    path_width = max((len(entry.path) for entry in entries), default=4)
+    for index, entry in enumerate(entries, start=1):
+        change_word = _("change") if entry.change_count == 1 else _("changes")
+        page_word = _("page") if entry.page_count == 1 else _("pages")
+        if entry.binary_change_type is not None:
+            print(
+                f"{index}. {entry.path.ljust(path_width)}  "
+                f"{entry.change_count} {change_word} · "
+                f"binary {entry.binary_change_type} · "
+                f"{entry.page_count} {page_word}"
+            )
+        else:
+            print(
+                f"{index}. {entry.path.ljust(path_width)}  "
+                f"{entry.change_count} {change_word} · "
+                f"+{entry.addition_count}/-{entry.deletion_count} · "
+                f"{entry.page_count} {page_word}"
+            )
+
+    if entries:
+        print()
+        print(_("Open:"))
+        for entry in entries[:5]:
+            print(f"  git-stage-batch show{command_source_args} --file {shlex.quote(entry.path)}")
+        if len(entries) > 5:
+            remaining = len(entries) - 5
+            print(_("  ... {count} more files matched").format(count=remaining))

--- a/src/git_stage_batch/output/hunk.py
+++ b/src/git_stage_batch/output/hunk.py
@@ -3,7 +3,14 @@
 from __future__ import annotations
 
 from ..core.models import LineLevelChange
+from ..i18n import _
 from .colors import Colors
+
+
+def print_remaining_line_changes_header(file_path: str) -> None:
+    """Print a boundary before refreshed remaining line changes."""
+    print()
+    print(_("── remaining unstaged changes in {file} ──").format(file=file_path))
 
 
 def print_line_level_changes(line_changes: LineLevelChange, *, gutter_to_selection_id: dict[int, int] | None = None) -> None:

--- a/src/git_stage_batch/staging/operations.py
+++ b/src/git_stage_batch/staging/operations.py
@@ -361,7 +361,7 @@ def build_target_working_tree_content_with_discarded_lines(
         push_output(working_lines[working_pointer])
         working_pointer += 1
 
-    return "\n".join(output_lines) + ("\n" if (working_text.endswith("\n") or output_lines) else "")
+    return "\n".join(output_lines) + ("\n" if output_lines else "")
 
 
 def build_target_working_tree_content_bytes_with_discarded_lines(
@@ -421,7 +421,7 @@ def build_target_working_tree_content_bytes_with_discarded_lines(
         push_output(working_lines[working_pointer])
         working_pointer += 1
 
-    trailing_newline = working_content.endswith(b"\n") or bool(output_lines)
+    trailing_newline = bool(output_lines)
     return b"\n".join(output_lines) + (b"\n" if trailing_newline else b"")
 
 

--- a/src/git_stage_batch/utils/paths.py
+++ b/src/git_stage_batch/utils/paths.py
@@ -166,6 +166,16 @@ def get_selected_change_kind_file_path() -> Path:
     return get_selected_state_directory_path() / "change-kind.txt"
 
 
+def get_selected_change_clear_reason_file_path() -> Path:
+    """Get the path to the marker explaining an intentionally cleared selection."""
+    return get_selected_state_directory_path() / "clear-reason.txt"
+
+
+def get_last_file_review_state_file_path() -> Path:
+    """Get the path to the most recent file-review safety state."""
+    return get_selected_state_directory_path() / "file-review.json"
+
+
 def get_selected_binary_file_json_path() -> Path:
     """Get the path to the selected binary file JSON file.
 

--- a/tests/cli/test_argument_parser.py
+++ b/tests/cli/test_argument_parser.py
@@ -225,6 +225,110 @@ def test_parse_command_line_show():
     assert callable(args.func)
 
 
+def test_show_page_requires_file():
+    args = parse_command_line(["show", "--page", "2"], quiet=True)
+    assert args is not None
+    with pytest.raises(argument_parser.CommandError, match="requires `--file`"):
+        args.func(args)
+
+
+def test_show_pages_alias_requires_file():
+    args = parse_command_line(["show", "--pages", "2"], quiet=True)
+    assert args is not None
+    assert args.page == "2"
+    with pytest.raises(argument_parser.CommandError, match="requires `--file` or a single-file `--files` match"):
+        args.func(args)
+
+
+def test_show_page_accepts_single_files_match(monkeypatch):
+    mock_command = Mock()
+    monkeypatch.setattr(argument_parser.commands, "command_show", mock_command)
+    monkeypatch.setattr(argument_parser, "list_changed_files", lambda: ["src/parser.py", "notes.txt"])
+
+    args = parse_command_line(["show", "--files", "*.py", "--page", "2"], quiet=True)
+
+    assert args is not None
+    args.func(args)
+    mock_command.assert_called_once_with(file="src/parser.py", page="2", porcelain=False)
+
+
+def test_show_page_rejects_multiple_files_matches(monkeypatch):
+    monkeypatch.setattr(argument_parser, "list_changed_files", lambda: ["foo.py", "bar.py"])
+
+    args = parse_command_line(["show", "--files", "*.py", "--page", "2"], quiet=True)
+
+    assert args is not None
+    with pytest.raises(argument_parser.CommandError, match="requires exactly one resolved file"):
+        args.func(args)
+
+
+def test_show_page_rejects_line_selection():
+    args = parse_command_line(["show", "--file", "src/parser.py", "--page", "2", "--line", "1"], quiet=True)
+    assert args is not None
+    with pytest.raises(argument_parser.CommandError, match="together with `show --line`"):
+        args.func(args)
+
+
+def test_show_page_rejects_porcelain():
+    args = parse_command_line(["show", "--file", "src/parser.py", "--page", "2", "--porcelain"], quiet=True)
+    assert args is not None
+    with pytest.raises(argument_parser.CommandError, match="with `--porcelain`"):
+        args.func(args)
+
+
+def test_show_from_page_accepts_single_file_batch_without_file(monkeypatch):
+    mock_command = Mock()
+    monkeypatch.setattr(argument_parser.commands, "command_show_from_batch", mock_command)
+    monkeypatch.setattr(argument_parser, "batch_exists", lambda name: True)
+    monkeypatch.setattr(
+        argument_parser,
+        "read_batch_metadata",
+        lambda name: {"files": {"src/parser.py": {}}},
+    )
+
+    args = parse_command_line(["show", "--from", "batch", "--page", "2"], quiet=True)
+
+    assert args is not None
+    args.func(args)
+    mock_command.assert_called_once_with("batch", None, None, page="2")
+
+
+def test_show_from_page_rejects_multi_file_batch_without_file(monkeypatch):
+    mock_command = Mock()
+    monkeypatch.setattr(argument_parser.commands, "command_show_from_batch", mock_command)
+    monkeypatch.setattr(argument_parser, "batch_exists", lambda name: True)
+    monkeypatch.setattr(
+        argument_parser,
+        "read_batch_metadata",
+        lambda name: {"files": {"src/parser.py": {}, "src/render.py": {}}},
+    )
+
+    args = parse_command_line(["show", "--from", "batch", "--page", "2"], quiet=True)
+
+    assert args is not None
+    with pytest.raises(argument_parser.CommandError, match="single-file batch"):
+        args.func(args)
+    mock_command.assert_not_called()
+
+
+def test_show_from_page_missing_batch_reports_missing_batch(monkeypatch):
+    mock_command = Mock()
+    monkeypatch.setattr(argument_parser.commands, "command_show_from_batch", mock_command)
+    monkeypatch.setattr(argument_parser, "batch_exists", lambda name: False)
+    monkeypatch.setattr(
+        argument_parser,
+        "read_batch_metadata",
+        Mock(side_effect=AssertionError("missing batch should not be read")),
+    )
+
+    args = parse_command_line(["show", "--from", "missing", "--page", "2"], quiet=True)
+
+    assert args is not None
+    with pytest.raises(argument_parser.CommandError, match="Batch 'missing' does not exist"):
+        args.func(args)
+    mock_command.assert_not_called()
+
+
 def test_parse_command_line_status():
     """Test parsing status command."""
     args = parse_command_line(["status"], quiet=True)
@@ -573,20 +677,17 @@ def test_parse_command_line_apply_with_files_dispatches_per_file(monkeypatch):
     ]
 
 
-def test_parse_command_line_show_with_files_only_last_result_is_selectable(monkeypatch):
-    """Show should hide gutters for earlier files resolved from --files."""
+def test_parse_command_line_show_with_files_uses_file_list(monkeypatch):
+    """Show should route multi-file matches to a navigational file list."""
     mock_command = Mock()
-    monkeypatch.setattr(argument_parser.commands, "command_show", mock_command)
+    monkeypatch.setattr(argument_parser.commands, "command_show_file_list", mock_command)
     monkeypatch.setattr(argument_parser, "list_changed_files", lambda: ["foo.py", "bar.py", "notes.txt"])
 
     args = parse_command_line(["show", "--files", "*.py"], quiet=True)
 
     assert args is not None
     args.func(args)
-    assert mock_command.call_args_list == [
-        call(file="foo.py", porcelain=False, selectable=False),
-        call(file="bar.py", porcelain=False, selectable=True),
-    ]
+    mock_command.assert_called_once_with(["foo.py", "bar.py"])
 
 
 def test_parse_command_line_show_with_files_raises_command_error_for_no_matches(monkeypatch):

--- a/tests/cli/test_argument_parser.py
+++ b/tests/cli/test_argument_parser.py
@@ -15,6 +15,16 @@ def _stdin_with_bytes(data: bytes) -> io.TextIOWrapper:
     return io.TextIOWrapper(io.BytesIO(data), encoding="utf-8", errors="surrogateescape")
 
 
+class _UnreadableStdin:
+    """Stdin stub that fails if a command reads replacement text too early."""
+
+    class _Buffer:
+        def read(self):
+            raise AssertionError("stdin should not be read")
+
+    buffer = _Buffer()
+
+
 def test_build_manpath_with_existing_environment(monkeypatch):
     """Existing MANPATH should be preserved after the packaged root."""
     monkeypatch.setattr(argument_parser, "_resolve_default_manpath", lambda: "/ignored")
@@ -497,6 +507,32 @@ def test_parse_command_line_include_with_files_dispatches_per_file(monkeypatch):
     mock_show_selected_change.assert_called_once_with()
 
 
+def test_parse_command_line_include_from_with_files_resolves_batch_scope_only(monkeypatch):
+    """include --from --files should match batch files, not current live changes."""
+    mock_command = Mock()
+    monkeypatch.setattr(argument_parser.commands, "command_include_from_batch", mock_command)
+    monkeypatch.setattr(argument_parser, "batch_exists", lambda name: True)
+    monkeypatch.setattr(
+        argument_parser,
+        "read_batch_metadata",
+        lambda name: {"files": {"foo.py": {}, "bar.py": {}, "notes.txt": {}}},
+    )
+    monkeypatch.setattr(
+        argument_parser,
+        "list_changed_files",
+        Mock(side_effect=AssertionError("live scope should not be resolved")),
+    )
+
+    args = parse_command_line(["include", "--from", "batch", "--files", "*.py"], quiet=True)
+
+    assert args is not None
+    args.func(args)
+    assert mock_command.call_args_list == [
+        call("batch", None, "foo.py"),
+        call("batch", None, "bar.py"),
+    ]
+
+
 def test_parse_command_line_include_from_with_as():
     """Test parsing include --from with replacement text."""
     args = parse_command_line(
@@ -548,6 +584,16 @@ def test_parse_command_line_include_rejects_no_edge_overlap_without_line_as():
     assert args is not None
 
     with pytest.raises(argument_parser.CommandError, match="`--no-edge-overlap` requires `include --line --as`"):
+        args.func(args)
+
+
+def test_parse_command_line_include_invalid_as_stdin_shape_does_not_read(monkeypatch):
+    """Invalid include --as-stdin combinations should fail before consuming stdin."""
+    monkeypatch.setattr(argument_parser.sys, "stdin", _UnreadableStdin())
+    args = parse_command_line(["include", "--to", "batch", "--as-stdin"], quiet=True)
+    assert args is not None
+
+    with pytest.raises(argument_parser.CommandError, match="`include --as` requires"):
         args.func(args)
 
 
@@ -655,6 +701,32 @@ def test_parse_command_line_discard_with_files_dispatches_per_file(monkeypatch):
     assert args is not None
     args.func(args)
     assert mock_command.call_args_list == [call("foo.py"), call("bar.py")]
+
+
+def test_parse_command_line_discard_from_with_files_resolves_batch_scope_only(monkeypatch):
+    """discard --from --files should match batch files, not current live changes."""
+    mock_command = Mock()
+    monkeypatch.setattr(argument_parser.commands, "command_discard_from_batch", mock_command)
+    monkeypatch.setattr(argument_parser, "batch_exists", lambda name: True)
+    monkeypatch.setattr(
+        argument_parser,
+        "read_batch_metadata",
+        lambda name: {"files": {"foo.py": {}, "bar.py": {}, "notes.txt": {}}},
+    )
+    monkeypatch.setattr(
+        argument_parser,
+        "list_changed_files",
+        Mock(side_effect=AssertionError("live scope should not be resolved")),
+    )
+
+    args = parse_command_line(["discard", "--from", "batch", "--files", "*.py"], quiet=True)
+
+    assert args is not None
+    args.func(args)
+    assert mock_command.call_args_list == [
+        call("batch", None, "foo.py"),
+        call("batch", None, "bar.py"),
+    ]
 
 
 def test_parse_command_line_apply_with_files_dispatches_per_file(monkeypatch):
@@ -912,6 +984,16 @@ def test_parse_command_line_discard_rejects_no_edge_overlap_without_to_line_as()
     assert args is not None
 
     with pytest.raises(argument_parser.CommandError, match="`--no-edge-overlap` requires `discard --to --line --as`"):
+        args.func(args)
+
+
+def test_parse_command_line_discard_invalid_as_stdin_shape_does_not_read(monkeypatch):
+    """Invalid discard --as-stdin combinations should fail before consuming stdin."""
+    monkeypatch.setattr(argument_parser.sys, "stdin", _UnreadableStdin())
+    args = parse_command_line(["discard", "--from", "batch", "--as-stdin"], quiet=True)
+    assert args is not None
+
+    with pytest.raises(argument_parser.CommandError, match="`discard --as` requires"):
         args.func(args)
 
 

--- a/tests/commands/test_again.py
+++ b/tests/commands/test_again.py
@@ -3,7 +3,15 @@
 import json
 from git_stage_batch.core.line_selection import parse_line_selection
 from git_stage_batch.commands.discard import command_discard_to_batch
-from git_stage_batch.data.hunk_tracking import fetch_next_change
+from git_stage_batch.commands.include import command_include
+from git_stage_batch.commands.show import command_show, command_show_file_list
+from git_stage_batch.data.file_review_state import read_last_file_review_state
+from git_stage_batch.data.hunk_tracking import (
+    SelectedChangeKind,
+    fetch_next_change,
+    get_selected_change_file_path,
+    read_selected_change_kind,
+)
 from git_stage_batch.exceptions import NoMoreHunks
 
 import subprocess
@@ -23,6 +31,7 @@ from git_stage_batch.utils.paths import (
     get_batch_claimed_hunks_file_path,
     get_batch_directory_path,
     get_batches_directory_path,
+    get_selected_change_clear_reason_file_path,
     get_session_batch_sources_file_path,
     get_state_directory_path,
 )
@@ -80,6 +89,69 @@ class TestCommandAgain:
         # Permanent files should be preserved
         assert journal.exists()
         assert abort_head.exists()
+
+    def test_again_clears_file_list_clear_reason(self, temp_git_repo):
+        """Again should make a fresh selection after a navigational file list."""
+        (temp_git_repo / "README.md").write_text("# Test\nmodified\n")
+
+        command_start()
+        command_show_file_list(["README.md"])
+
+        assert read_selected_change_kind() is None
+        assert get_selected_change_clear_reason_file_path().exists()
+
+        command_again(quiet=True)
+
+        assert not get_selected_change_clear_reason_file_path().exists()
+        assert read_selected_change_kind() == SelectedChangeKind.HUNK
+        assert get_selected_change_file_path() == "README.md"
+
+    def test_again_clears_file_review_state(self, temp_git_repo):
+        """Again should not leave page-review state from the previous selected file."""
+        (temp_git_repo / "README.md").write_text("# Test\nmodified\n")
+
+        command_start()
+        command_show(file="README.md", page="all")
+
+        assert read_last_file_review_state() is not None
+        assert read_selected_change_kind() == SelectedChangeKind.FILE
+
+        command_again(quiet=True)
+
+        assert read_last_file_review_state() is None
+        assert read_selected_change_kind() == SelectedChangeKind.HUNK
+        assert get_selected_change_file_path() == "README.md"
+
+    def test_again_clears_stale_binary_guard_for_fresh_pass(self, temp_git_repo):
+        """A stale binary selection should not survive an explicit fresh pass."""
+        binary_file = temp_git_repo / "asset.bin"
+        binary_file.write_bytes(b"\x00\x01\x02")
+        subprocess.run(["git", "add", "asset.bin"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add binary"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        (temp_git_repo / "README.md").write_text("# Test\nmodified\n")
+        binary_file.write_bytes(b"\x00\x03\x04")
+
+        command_start()
+        command_show(file="asset.bin", porcelain=True)
+        subprocess.run(["git", "restore", "asset.bin"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        assert read_selected_change_kind() == SelectedChangeKind.BINARY
+
+        command_again(quiet=True)
+
+        assert read_selected_change_kind() == SelectedChangeKind.HUNK
+        assert get_selected_change_file_path() == "README.md"
+
+        command_include(quiet=True)
+        status = subprocess.run(
+            ["git", "status", "--porcelain"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+            text=True,
+        ).stdout
+        assert "M  README.md" in status
 
     def test_again_when_no_state_exists(self, temp_git_repo):
         """Test that again works when state directory gets recreated."""

--- a/tests/commands/test_apply_binary.py
+++ b/tests/commands/test_apply_binary.py
@@ -185,10 +185,10 @@ class TestBinaryApply:
         with pytest.raises(CommandError) as exc_info:
             command_apply_from_batch("test-batch", line_ids="1", file="data.bin")
 
-        # Verify error message mentions binary files and atomicity
+        # Verify error message is user-facing.
         error_msg = str(exc_info.value).lower()
         assert "binary" in error_msg
-        assert ("complete units" in error_msg or "atomic" in error_msg)
+        assert "apply the whole file" in error_msg
 
     def test_apply_binary_creates_parent_directories(self, binary_repo):
         """Test that applying binary file creates parent directories if needed."""

--- a/tests/commands/test_binary_files.py
+++ b/tests/commands/test_binary_files.py
@@ -9,17 +9,30 @@ from pathlib import Path
 
 import pytest
 
+import git_stage_batch.commands.apply_from as apply_from_module
+import git_stage_batch.commands.include_from as include_from_module
+from git_stage_batch.batch.query import read_batch_metadata
 from git_stage_batch.batch.storage import add_binary_file_to_batch
 from git_stage_batch.commands.apply_from import command_apply_from_batch
-from git_stage_batch.commands.discard import command_discard
+from git_stage_batch.commands.discard import command_discard, command_discard_file, command_discard_to_batch
 from git_stage_batch.commands.discard_from import command_discard_from_batch
-from git_stage_batch.commands.include import command_include, command_include_to_batch
-from git_stage_batch.commands.skip import command_skip
+from git_stage_batch.commands.include_from import command_include_from_batch
+from git_stage_batch.commands.include import command_include, command_include_file, command_include_to_batch
+from git_stage_batch.commands.reset import command_reset_from_batch
+from git_stage_batch.commands.show import command_show
+from git_stage_batch.commands.show_from import command_show_from_batch
+from git_stage_batch.commands.skip import command_skip, command_skip_file
 from git_stage_batch.commands.status import command_status
 from git_stage_batch.core.models import BinaryFileChange, LineLevelChange
 from git_stage_batch.data.file_tracking import auto_add_untracked_files
-from git_stage_batch.data.hunk_tracking import fetch_next_change
+from git_stage_batch.data.hunk_tracking import (
+    SelectedChangeKind,
+    fetch_next_change,
+    get_selected_change_file_path,
+    read_selected_change_kind,
+)
 from git_stage_batch.data.session import initialize_abort_state
+from git_stage_batch.exceptions import CommandError
 from git_stage_batch.utils.git import run_git_command
 
 
@@ -153,6 +166,31 @@ def test_selected_binary_include_to_batch_updates_skipped_progress(
     assert skipped_hunk["change_type"] == "modified"
 
 
+
+def test_binary_apply_from_batch_refuses_missing_non_deleted_content(
+    binary_file_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Modified binary metadata with missing batch content must not apply as a deletion."""
+    monkeypatch.chdir(binary_file_repo)
+
+    new_path = binary_file_repo / "new.bin"
+    new_content = b"\x00BATCHED"
+    new_path.write_bytes(new_content)
+
+    initialize_abort_state()
+    auto_add_untracked_files()
+    command_include_to_batch("bin-batch", file="new.bin", quiet=True)
+    head_commit = run_git_command(["rev-parse", "HEAD"]).stdout.strip()
+    monkeypatch.setattr(apply_from_module, "get_batch_commit_sha", lambda name: head_commit)
+
+    with pytest.raises(CommandError, match="incompatible"):
+        command_apply_from_batch("bin-batch", file="new.bin")
+
+    assert new_path.exists()
+    assert new_path.read_bytes() == new_content
+
+
 def test_binary_apply_from_batch_restores_executable_mode(
     binary_file_repo: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -163,17 +201,13 @@ def test_binary_apply_from_batch_restores_executable_mode(
     tool_path = binary_file_repo / "tool.bin"
     modified_content = b"\x00BATCHED"
     tool_path.write_bytes(b"\x00BASE")
-    tool_path.chmod(0o644)
+    tool_path.chmod(0o755)
     subprocess.run(["git", "add", "tool.bin"], check=True, capture_output=True)
-    subprocess.run(["git", "commit", "-m", "Add binary tool"], check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "Add executable binary"], check=True, capture_output=True)
 
     initialize_abort_state()
     tool_path.write_bytes(modified_content)
-    add_binary_file_to_batch(
-        "bin-batch",
-        BinaryFileChange("tool.bin", "tool.bin", "modified"),
-        file_mode="100755",
-    )
+    command_include_to_batch("bin-batch", file="tool.bin", quiet=True)
     subprocess.run(["git", "checkout", "HEAD", "--", "tool.bin"], check=True, capture_output=True)
     tool_path.chmod(0o644)
 
@@ -198,11 +232,7 @@ def test_binary_discard_from_batch_restores_baseline_executable_mode(
 
     initialize_abort_state()
     tool_path.write_bytes(b"\x00BATCHED")
-    add_binary_file_to_batch(
-        "bin-batch",
-        BinaryFileChange("tool.bin", "tool.bin", "modified"),
-        file_mode="100644",
-    )
+    command_include_to_batch("bin-batch", file="tool.bin", quiet=True)
     tool_path.write_bytes(b"\x00WORKTREE")
     tool_path.chmod(0o644)
 
@@ -210,7 +240,6 @@ def test_binary_discard_from_batch_restores_baseline_executable_mode(
 
     assert tool_path.read_bytes() == b"\x00BASE"
     assert stat.S_IMODE(tool_path.stat().st_mode) & stat.S_IXUSR
-
 
 def test_binary_file_added_discard(binary_file_repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Test discarding a newly added binary file."""
@@ -317,6 +346,764 @@ def test_binary_file_skip(binary_file_repo: Path, monkeypatch: pytest.MonkeyPatc
     status_result = run_git_command(["status", "--porcelain"])
     assert "A  new_image.png" not in status_result.stdout  # Not fully staged
 
+
+def test_selected_binary_include_to_batch(binary_file_repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Selected binary include --to should not treat the binary as a text patch."""
+    monkeypatch.chdir(binary_file_repo)
+
+    (binary_file_repo / "image.png").write_bytes(b"\x89PNG\r\n\x1a\nBATCHED")
+
+    initialize_abort_state()
+    result = fetch_next_change()
+    assert isinstance(result, BinaryFileChange)
+
+    command_include_to_batch("bin-batch", quiet=True)
+
+    metadata = read_batch_metadata("bin-batch")
+    assert metadata["files"]["image.png"]["file_type"] == "binary"
+
+
+def test_pathless_include_to_batch_uses_selected_binary_not_first_text_change(
+    binary_file_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pathless include --to should honor an explicitly selected binary file."""
+    monkeypatch.chdir(binary_file_repo)
+
+    (binary_file_repo / "README.md").write_text("# Test Repository\ntext change\n")
+    (binary_file_repo / "image.png").write_bytes(b"\x89PNG\r\n\x1a\nBATCHED")
+
+    initialize_abort_state()
+    command_show(file="image.png", porcelain=True)
+
+    command_include_to_batch("bin-batch", quiet=True)
+
+    metadata = read_batch_metadata("bin-batch")
+    assert list(metadata["files"].keys()) == ["image.png"]
+    assert metadata["files"]["image.png"]["file_type"] == "binary"
+
+
+def test_pathless_batch_binary_action_refuses_after_batch_bytes_change(
+    binary_file_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A pathless batch binary action must not reuse stale reviewed bytes."""
+    monkeypatch.chdir(binary_file_repo)
+
+    image_path = binary_file_repo / "image.png"
+    original_content = image_path.read_bytes()
+
+    initialize_abort_state()
+    image_path.write_bytes(b"\x89PNG\r\n\x1a\nREVIEWED")
+    command_include_to_batch("bin-batch", file="image.png", quiet=True)
+    command_show_from_batch("bin-batch", file="image.png")
+    assert read_selected_change_kind() == SelectedChangeKind.BATCH_BINARY
+    assert get_selected_change_file_path() == "image.png"
+
+    image_path.write_bytes(b"\x89PNG\r\n\x1a\nUPDATED")
+    add_binary_file_to_batch(
+        "bin-batch",
+        BinaryFileChange(
+            old_path="image.png",
+            new_path="image.png",
+            change_type="modified",
+        ),
+    )
+    subprocess.run(["git", "checkout", "HEAD", "--", "image.png"], check=True, capture_output=True)
+
+    with pytest.raises(CommandError, match="selected batch binary no longer matches"):
+        command_apply_from_batch("bin-batch")
+    assert image_path.read_bytes() == original_content
+
+
+def test_stale_batch_binary_refusal_survives_repeated_pathless_action(
+    binary_file_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After a stale batch-binary refusal, a second bare action must not use the whole batch."""
+    monkeypatch.chdir(binary_file_repo)
+
+    image_path = binary_file_repo / "image.png"
+    other_path = binary_file_repo / "other.bin"
+    other_path.write_bytes(b"\x00OTHER BASE")
+    subprocess.run(["git", "add", "other.bin"], check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "Add other binary"], check=True, capture_output=True)
+
+    initialize_abort_state()
+    image_path.write_bytes(b"\x89PNG\r\n\x1a\nREVIEWED")
+    other_path.write_bytes(b"\x00OTHER BATCHED")
+    command_include_to_batch("mixed-batch", file="image.png", quiet=True)
+    command_include_to_batch("mixed-batch", file="other.bin", quiet=True)
+    subprocess.run(["git", "checkout", "HEAD", "--", "."], check=True, capture_output=True)
+
+    command_show_from_batch("mixed-batch", file="image.png")
+    image_path.write_bytes(b"\x89PNG\r\n\x1a\nUPDATED")
+    add_binary_file_to_batch(
+        "mixed-batch",
+        BinaryFileChange(
+            old_path="image.png",
+            new_path="image.png",
+            change_type="modified",
+        ),
+    )
+    subprocess.run(["git", "checkout", "HEAD", "--", "image.png"], check=True, capture_output=True)
+
+    with pytest.raises(CommandError, match="selected batch binary no longer matches"):
+        command_include_from_batch("mixed-batch")
+    with pytest.raises(CommandError, match="changed or removed from batch"):
+        command_include_from_batch("mixed-batch")
+
+    staged_files = run_git_command(["diff", "--cached", "--name-only"]).stdout.splitlines()
+    assert staged_files == []
+
+
+@pytest.mark.parametrize(
+    "batch_binary_action",
+    [
+        lambda batch_name: command_include_from_batch(batch_name, file=""),
+        lambda batch_name: command_discard_from_batch(batch_name, file=""),
+        lambda batch_name: command_apply_from_batch(batch_name, file=""),
+        lambda batch_name: command_reset_from_batch(batch_name, file=""),
+    ],
+)
+def test_stale_batch_binary_empty_file_scope_refuses(
+    binary_file_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    batch_binary_action,
+) -> None:
+    """`--file` with no path must use the same batch-binary freshness check as bare actions."""
+    monkeypatch.chdir(binary_file_repo)
+
+    image_path = binary_file_repo / "image.png"
+    original_content = image_path.read_bytes()
+
+    initialize_abort_state()
+    image_path.write_bytes(b"\x89PNG\r\n\x1a\nREVIEWED")
+    command_include_to_batch("bin-batch", file="image.png", quiet=True)
+    command_show_from_batch("bin-batch", file="image.png")
+
+    image_path.write_bytes(b"\x89PNG\r\n\x1a\nUPDATED")
+    add_binary_file_to_batch(
+        "bin-batch",
+        BinaryFileChange(
+            old_path="image.png",
+            new_path="image.png",
+            change_type="modified",
+        ),
+    )
+    subprocess.run(["git", "checkout", "HEAD", "--", "image.png"], check=True, capture_output=True)
+
+    with pytest.raises(CommandError, match="selected batch binary no longer matches"):
+        batch_binary_action("bin-batch")
+
+    assert image_path.read_bytes() == original_content
+    assert "image.png" in read_batch_metadata("bin-batch").get("files", {})
+    staged_files = run_git_command(["diff", "--cached", "--name-only"]).stdout.splitlines()
+    assert staged_files == []
+
+
+def test_show_from_batch_binary_selects_file_for_empty_file_scope(
+    binary_file_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Showing one batch binary should let --file reuse that file path."""
+    monkeypatch.chdir(binary_file_repo)
+
+    image_path = binary_file_repo / "image.png"
+    modified_content = b"\x89PNG\r\n\x1a\nBATCHED"
+    image_path.write_bytes(modified_content)
+    (binary_file_repo / "README.md").write_text("# Test Repository\ntext change\n")
+
+    initialize_abort_state()
+    command_include_to_batch("mixed-batch", file="image.png", quiet=True)
+    command_include_to_batch("mixed-batch", file="README.md", quiet=True)
+    subprocess.run(["git", "checkout", "HEAD", "--", "."], check=True, capture_output=True)
+    capsys.readouterr()
+
+    command_show_from_batch("mixed-batch", file="image.png")
+    capsys.readouterr()
+
+    assert read_selected_change_kind() == SelectedChangeKind.BATCH_BINARY
+
+    command_include_from_batch("mixed-batch", file="")
+
+    staged_files = run_git_command(["diff", "--cached", "--name-only"]).stdout.splitlines()
+    assert staged_files == ["image.png"]
+    assert run_git_command(["show", ":image.png"], text_output=False).stdout == modified_content
+
+
+def test_selected_batch_binary_bare_apply_from_batch_uses_selected_file(
+    binary_file_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Bare apply --from should honor a selected batch binary in a multi-file batch."""
+    monkeypatch.chdir(binary_file_repo)
+
+    image_path = binary_file_repo / "image.png"
+    readme_path = binary_file_repo / "README.md"
+    modified_content = b"\x89PNG\r\n\x1a\nBATCHED"
+    image_path.write_bytes(modified_content)
+    readme_path.write_text("# Test Repository\ntext change\n")
+
+    initialize_abort_state()
+    command_include_to_batch("mixed-batch", file="image.png", quiet=True)
+    command_include_to_batch("mixed-batch", file="README.md", quiet=True)
+    subprocess.run(
+        ["git", "checkout", "HEAD", "--", "image.png", "README.md"],
+        check=True,
+        capture_output=True,
+    )
+    capsys.readouterr()
+
+    command_show_from_batch("mixed-batch", file="image.png")
+    capsys.readouterr()
+    command_apply_from_batch("mixed-batch")
+
+    assert image_path.read_bytes() == modified_content
+    assert readme_path.read_text() == "# Test Repository\n"
+
+
+def test_selected_batch_binary_bare_reset_from_batch_uses_selected_file(
+    binary_file_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Bare reset --from should not clear an entire multi-file batch after binary selection."""
+    monkeypatch.chdir(binary_file_repo)
+
+    image_path = binary_file_repo / "image.png"
+    readme_path = binary_file_repo / "README.md"
+    image_path.write_bytes(b"\x89PNG\r\n\x1a\nBATCHED")
+    readme_path.write_text("# Test Repository\ntext change\n")
+
+    initialize_abort_state()
+    command_include_to_batch("mixed-batch", file="image.png", quiet=True)
+    command_include_to_batch("mixed-batch", file="README.md", quiet=True)
+    capsys.readouterr()
+
+    command_show_from_batch("mixed-batch", file="image.png")
+    capsys.readouterr()
+    command_reset_from_batch("mixed-batch")
+
+    metadata = read_batch_metadata("mixed-batch")
+    assert list(metadata["files"].keys()) == ["README.md"]
+
+
+def test_removed_selected_batch_binary_does_not_fall_back_to_whole_batch(
+    binary_file_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """After resetting a selected binary, bare include --from should not include remaining files."""
+    monkeypatch.chdir(binary_file_repo)
+
+    image_path = binary_file_repo / "image.png"
+    readme_path = binary_file_repo / "README.md"
+    image_path.write_bytes(b"\x00BATCHED")
+    readme_path.write_text("# Test Repository\ntext change\n")
+
+    initialize_abort_state()
+    command_include_to_batch("mixed-batch", file="image.png", quiet=True)
+    command_include_to_batch("mixed-batch", file="README.md", quiet=True)
+    subprocess.run(["git", "checkout", "HEAD", "--", "."], check=True, capture_output=True)
+    capsys.readouterr()
+
+    command_show_from_batch("mixed-batch", file="image.png")
+    capsys.readouterr()
+    command_reset_from_batch("mixed-batch")
+    capsys.readouterr()
+
+    with pytest.raises(CommandError, match="changed or removed from batch"):
+        command_include_from_batch("mixed-batch")
+
+    staged_files = run_git_command(["diff", "--cached", "--name-only"]).stdout.splitlines()
+    assert staged_files == []
+
+
+def test_show_from_batch_binary_selects_file_for_pathless_include_from(
+    binary_file_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Showing one batch binary should make bare include --from use that file."""
+    monkeypatch.chdir(binary_file_repo)
+
+    image_path = binary_file_repo / "image.png"
+    modified_content = b"\x89PNG\r\n\x1a\nBATCHED"
+    image_path.write_bytes(modified_content)
+    (binary_file_repo / "README.md").write_text("# Test Repository\ntext change\n")
+
+    initialize_abort_state()
+    command_include_to_batch("mixed-batch", file="image.png", quiet=True)
+    command_include_to_batch("mixed-batch", file="README.md", quiet=True)
+    subprocess.run(["git", "checkout", "HEAD", "--", "."], check=True, capture_output=True)
+    capsys.readouterr()
+
+    command_show_from_batch("mixed-batch", file="image.png")
+    capsys.readouterr()
+
+    command_include_from_batch("mixed-batch")
+
+    staged_files = run_git_command(["diff", "--cached", "--name-only"]).stdout.splitlines()
+    assert staged_files == ["image.png"]
+    assert run_git_command(["show", ":image.png"], text_output=False).stdout == modified_content
+
+
+def test_selected_batch_binary_does_not_narrow_other_batch_pathless_include_from(
+    binary_file_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A batch-binary selection should only narrow actions for its source batch."""
+    monkeypatch.chdir(binary_file_repo)
+
+    image_path = binary_file_repo / "image.png"
+    other_path = binary_file_repo / "other.bin"
+    first_content = b"\x89PNG\r\n\x1a\nFIRST"
+    second_content = b"\x89PNG\r\n\x1a\nSECOND"
+    other_content = b"\x00OTHER SECOND"
+
+    other_path.write_bytes(b"\x00OTHER BASE")
+    subprocess.run(["git", "add", "other.bin"], check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "Add other binary"], check=True, capture_output=True)
+
+    initialize_abort_state()
+    image_path.write_bytes(first_content)
+    command_include_to_batch("first", file="image.png", quiet=True)
+    image_path.write_bytes(second_content)
+    other_path.write_bytes(other_content)
+    command_include_to_batch("second", file="image.png", quiet=True)
+    command_include_to_batch("second", file="other.bin", quiet=True)
+    subprocess.run(["git", "checkout", "HEAD", "--", "."], check=True, capture_output=True)
+    capsys.readouterr()
+
+    command_show_from_batch("first", file="image.png")
+    capsys.readouterr()
+
+    command_include_from_batch("second")
+
+    staged_files = set(run_git_command(["diff", "--cached", "--name-only"]).stdout.splitlines())
+    assert staged_files == {"image.png", "other.bin"}
+    assert run_git_command(["show", ":image.png"], text_output=False).stdout == second_content
+    assert run_git_command(["show", ":other.bin"], text_output=False).stdout == other_content
+
+
+def test_show_from_batch_binary_preview_preserves_existing_selection(
+    binary_file_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Non-selectable batch binary previews should not replace the selected file."""
+    monkeypatch.chdir(binary_file_repo)
+
+    (binary_file_repo / "image.png").write_bytes(b"\x89PNG\r\n\x1a\nBATCHED")
+
+    initialize_abort_state()
+    command_include_to_batch("bin-batch", file="image.png", quiet=True)
+    (binary_file_repo / "README.md").write_text("# Test Repository\ntext change\n")
+
+    command_show(file="README.md", porcelain=True)
+    assert read_selected_change_kind() == SelectedChangeKind.FILE
+    assert get_selected_change_file_path() == "README.md"
+
+    command_show_from_batch("bin-batch", file="image.png", selectable=False)
+    capsys.readouterr()
+
+    assert read_selected_change_kind() == SelectedChangeKind.FILE
+    assert get_selected_change_file_path() == "README.md"
+
+
+def test_show_from_batch_displays_binary_entries(
+    binary_file_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """show --from should display binary files directly and in matched-file lists."""
+    monkeypatch.chdir(binary_file_repo)
+
+    (binary_file_repo / "image.png").write_bytes(b"\x89PNG\r\n\x1a\nBATCHED")
+    (binary_file_repo / "README.md").write_text("# Test Repository\ntext change\n")
+
+    initialize_abort_state()
+    command_include_to_batch("mixed-batch", file="image.png", quiet=True)
+    command_include_to_batch("mixed-batch", file="README.md", quiet=True)
+    capsys.readouterr()
+
+    command_show_from_batch("mixed-batch", file="image.png")
+    captured = capsys.readouterr()
+    assert "image.png :: Binary file modified" in captured.out
+
+    with pytest.raises(CommandError) as exc_info:
+        command_show_from_batch("mixed-batch", file="image.png", line_ids="1")
+    assert "binary change summary" in exc_info.value.message
+
+    command_show_from_batch("mixed-batch")
+    captured = capsys.readouterr()
+    assert "image.png" in captured.out
+    assert "binary modified" in captured.out
+    assert "README.md" in captured.out
+
+
+def test_binary_file_modified_discard_file(binary_file_repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """File-scoped discard should remove binary files atomically like text files."""
+    monkeypatch.chdir(binary_file_repo)
+
+    image_path = binary_file_repo / "image.png"
+    image_path.write_bytes(b"\x89PNG\r\n\x1a\nMODIFIED")
+
+    initialize_abort_state()
+
+    command_discard_file("image.png")
+
+    assert not image_path.exists()
+    status_result = run_git_command(["status", "--porcelain"])
+    assert "D  image.png" in status_result.stdout
+
+def test_binary_file_modified_include_file(binary_file_repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """File-scoped include should stage binary files atomically."""
+    monkeypatch.chdir(binary_file_repo)
+
+    (binary_file_repo / "image.png").write_bytes(b"\x89PNG\r\n\x1a\nMODIFIED")
+
+    initialize_abort_state()
+
+    staged = command_include_file("image.png", quiet=True)
+
+    assert staged == 1
+    status_result = run_git_command(["status", "--porcelain"])
+    assert "M  image.png" in status_result.stdout
+
+
+def test_binary_file_modified_include_to_batch_file(binary_file_repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """File-scoped include --to should save binary files atomically."""
+    monkeypatch.chdir(binary_file_repo)
+
+    image_path = binary_file_repo / "image.png"
+    modified_content = b"\x89PNG\r\n\x1a\nBATCHED"
+    image_path.write_bytes(modified_content)
+
+    initialize_abort_state()
+
+    command_include_to_batch("bin-batch", file="image.png", quiet=True)
+
+    metadata = read_batch_metadata("bin-batch")
+    assert metadata["files"]["image.png"]["file_type"] == "binary"
+    assert metadata["files"]["image.png"]["change_type"] == "modified"
+    assert image_path.read_bytes() == modified_content
+
+    subprocess.run(["git", "checkout", "HEAD", "--", "image.png"], check=True, capture_output=True)
+    command_apply_from_batch("bin-batch", file="image.png")
+    assert image_path.read_bytes() == modified_content
+
+
+def test_binary_include_to_batch_captures_current_bytes_after_session_start(
+    binary_file_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Binary include --to should not save stale session-start bytes."""
+    monkeypatch.chdir(binary_file_repo)
+
+    image_path = binary_file_repo / "image.png"
+    modified_content = b"\x89PNG\r\n\x1a\nCHANGED AFTER START"
+
+    initialize_abort_state()
+    image_path.write_bytes(modified_content)
+
+    command_include_to_batch("bin-batch", file="image.png", quiet=True)
+    subprocess.run(["git", "checkout", "HEAD", "--", "image.png"], check=True, capture_output=True)
+
+    command_apply_from_batch("bin-batch", file="image.png")
+
+    assert image_path.read_bytes() == modified_content
+
+
+def test_binary_include_to_batch_captures_worktree_executable_mode(
+    binary_file_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Binary include --to should save the executable bit from the worktree."""
+    monkeypatch.chdir(binary_file_repo)
+
+    tool_path = binary_file_repo / "tool.bin"
+    tool_path.write_bytes(b"\x00BASE")
+    tool_path.chmod(0o644)
+    subprocess.run(["git", "add", "tool.bin"], check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "Add non-executable binary"], check=True, capture_output=True)
+
+    initialize_abort_state()
+    tool_path.write_bytes(b"\x00BATCHED")
+    tool_path.chmod(0o755)
+
+    command_include_to_batch("bin-batch", file="tool.bin", quiet=True)
+
+    metadata = read_batch_metadata("bin-batch")
+    assert metadata["files"]["tool.bin"]["mode"] == "100755"
+
+    subprocess.run(["git", "checkout", "HEAD", "--", "tool.bin"], check=True, capture_output=True)
+    command_apply_from_batch("bin-batch", file="tool.bin")
+
+    assert tool_path.read_bytes() == b"\x00BATCHED"
+    assert stat.S_IMODE(tool_path.stat().st_mode) & stat.S_IXUSR
+
+
+def test_binary_file_modified_discard_to_batch_file(binary_file_repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """File-scoped discard --to should save binary files before restoring them."""
+    monkeypatch.chdir(binary_file_repo)
+
+    image_path = binary_file_repo / "image.png"
+    original_content = image_path.read_bytes()
+    modified_content = b"\x89PNG\r\n\x1a\nBATCHED"
+    image_path.write_bytes(modified_content)
+
+    initialize_abort_state()
+
+    command_discard_to_batch("bin-batch", file="image.png", quiet=True)
+
+    metadata = read_batch_metadata("bin-batch")
+    assert metadata["files"]["image.png"]["file_type"] == "binary"
+    assert metadata["files"]["image.png"]["change_type"] == "modified"
+    assert image_path.read_bytes() == original_content
+
+    command_apply_from_batch("bin-batch", file="image.png")
+    assert image_path.read_bytes() == modified_content
+
+
+def test_binary_discard_to_batch_captures_current_bytes_after_session_start(
+    binary_file_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Binary discard --to should preserve bytes changed after session start."""
+    monkeypatch.chdir(binary_file_repo)
+
+    image_path = binary_file_repo / "image.png"
+    original_content = image_path.read_bytes()
+    modified_content = b"\x89PNG\r\n\x1a\nDISCARDED AFTER START"
+
+    initialize_abort_state()
+    image_path.write_bytes(modified_content)
+
+    command_discard_to_batch("bin-batch", file="image.png", quiet=True)
+
+    assert image_path.read_bytes() == original_content
+
+    command_apply_from_batch("bin-batch", file="image.png")
+    assert image_path.read_bytes() == modified_content
+
+
+def test_binary_discard_to_batch_captures_worktree_executable_mode(
+    binary_file_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Binary discard --to should save the executable bit before restoring HEAD."""
+    monkeypatch.chdir(binary_file_repo)
+
+    tool_path = binary_file_repo / "tool.bin"
+    tool_path.write_bytes(b"\x00BASE")
+    tool_path.chmod(0o644)
+    subprocess.run(["git", "add", "tool.bin"], check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "Add non-executable binary"], check=True, capture_output=True)
+
+    initialize_abort_state()
+    tool_path.write_bytes(b"\x00BATCHED")
+    tool_path.chmod(0o755)
+
+    command_discard_to_batch("bin-batch", file="tool.bin", quiet=True)
+
+    metadata = read_batch_metadata("bin-batch")
+    assert metadata["files"]["tool.bin"]["mode"] == "100755"
+    assert tool_path.read_bytes() == b"\x00BASE"
+    assert not (stat.S_IMODE(tool_path.stat().st_mode) & stat.S_IXUSR)
+
+    command_apply_from_batch("bin-batch", file="tool.bin")
+
+    assert tool_path.read_bytes() == b"\x00BATCHED"
+    assert stat.S_IMODE(tool_path.stat().st_mode) & stat.S_IXUSR
+
+
+def test_selected_binary_discard_to_batch(binary_file_repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Selected binary discard --to should save then restore the binary atomically."""
+    monkeypatch.chdir(binary_file_repo)
+
+    image_path = binary_file_repo / "image.png"
+    original_content = image_path.read_bytes()
+    image_path.write_bytes(b"\x89PNG\r\n\x1a\nBATCHED")
+
+    initialize_abort_state()
+    result = fetch_next_change()
+    assert isinstance(result, BinaryFileChange)
+
+    command_discard_to_batch("bin-batch", quiet=True)
+
+    metadata = read_batch_metadata("bin-batch")
+    assert metadata["files"]["image.png"]["file_type"] == "binary"
+    assert image_path.read_bytes() == original_content
+
+
+def test_pathless_discard_to_batch_uses_selected_binary_not_first_text_change(
+    binary_file_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pathless discard --to should honor an explicitly selected binary file."""
+    monkeypatch.chdir(binary_file_repo)
+
+    image_path = binary_file_repo / "image.png"
+    original_content = image_path.read_bytes()
+    (binary_file_repo / "README.md").write_text("# Test Repository\ntext change\n")
+    image_path.write_bytes(b"\x89PNG\r\n\x1a\nBATCHED")
+
+    initialize_abort_state()
+    command_show(file="image.png", porcelain=True)
+
+    command_discard_to_batch("bin-batch", quiet=True)
+
+    metadata = read_batch_metadata("bin-batch")
+    assert list(metadata["files"].keys()) == ["image.png"]
+    assert metadata["files"]["image.png"]["file_type"] == "binary"
+    assert image_path.read_bytes() == original_content
+    assert "text change" in (binary_file_repo / "README.md").read_text()
+
+
+def test_binary_include_from_batch_stages_binary_file(
+    binary_file_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """include --from should stage and write binary batch entries atomically."""
+    monkeypatch.chdir(binary_file_repo)
+
+    image_path = binary_file_repo / "image.png"
+    modified_content = b"\x89PNG\r\n\x1a\nBATCHED"
+    image_path.write_bytes(modified_content)
+
+    initialize_abort_state()
+    command_include_to_batch("bin-batch", file="image.png", quiet=True)
+    subprocess.run(["git", "checkout", "HEAD", "--", "image.png"], check=True, capture_output=True)
+
+    command_include_from_batch("bin-batch", file="image.png")
+
+    status_result = run_git_command(["status", "--porcelain"])
+    assert any(line.startswith("M") and line.endswith(" image.png") for line in status_result.stdout.splitlines())
+    assert run_git_command(["show", ":image.png"], text_output=False).stdout == modified_content
+    assert image_path.read_bytes() == modified_content
+
+
+def test_binary_include_from_batch_stages_binary_deletion(
+    binary_file_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """include --from should stage and write binary deletions from batch entries."""
+    monkeypatch.chdir(binary_file_repo)
+
+    image_path = binary_file_repo / "image.png"
+    image_path.unlink()
+
+    initialize_abort_state()
+    command_include_to_batch("bin-batch", file="image.png", quiet=True)
+    subprocess.run(["git", "checkout", "HEAD", "--", "image.png"], check=True, capture_output=True)
+
+    command_include_from_batch("bin-batch", file="image.png")
+
+    status_result = run_git_command(["status", "--porcelain"])
+    assert any(line.startswith("D") and line.endswith(" image.png") for line in status_result.stdout.splitlines())
+    assert run_git_command(["cat-file", "-e", ":image.png"], check=False).returncode != 0
+    assert not image_path.exists()
+
+
+def test_binary_include_from_batch_reports_failed_binary_deletion_staging(
+    binary_file_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """include --from should not report success when staging a binary deletion fails."""
+    monkeypatch.chdir(binary_file_repo)
+
+    image_path = binary_file_repo / "image.png"
+    image_path.unlink()
+
+    initialize_abort_state()
+    command_include_to_batch("bin-batch", file="image.png", quiet=True)
+    subprocess.run(["git", "checkout", "HEAD", "--", "image.png"], check=True, capture_output=True)
+
+    original_run_git_command = include_from_module.run_git_command
+
+    def fail_force_remove(args, *positional_args, **keyword_args):
+        if args[:3] == ["update-index", "--force-remove", "--"]:
+            return subprocess.CompletedProcess(args, 1, stdout="", stderr="boom")
+        return original_run_git_command(args, *positional_args, **keyword_args)
+
+    monkeypatch.setattr(include_from_module, "run_git_command", fail_force_remove)
+
+    with pytest.raises(CommandError, match="incompatible"):
+        command_include_from_batch("bin-batch", file="image.png")
+
+    assert run_git_command(["cat-file", "-e", ":image.png"], check=False).returncode == 0
+    assert image_path.exists()
+
+
+def test_stale_selected_binary_include_refuses_without_fetching_next_change(
+    binary_file_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stale selected binary must not make bare include act on a different file."""
+    monkeypatch.chdir(binary_file_repo)
+
+    (binary_file_repo / "README.md").write_text("# Test Repository\ntext change\n")
+    (binary_file_repo / "image.png").write_bytes(b"\x89PNG\r\n\x1a\nBATCHED")
+
+    initialize_abort_state()
+    command_show(file="image.png", porcelain=True)
+    subprocess.run(["git", "restore", "image.png"], check=True, capture_output=True)
+
+    with pytest.raises(CommandError, match="Selected binary file no longer matches"):
+        command_include(quiet=True)
+    with pytest.raises(CommandError, match="Selected binary file no longer matches"):
+        command_include(quiet=True)
+
+    staged_files = run_git_command(["diff", "--cached", "--name-only"]).stdout.splitlines()
+    assert staged_files == []
+    assert (binary_file_repo / "README.md").read_text() == "# Test Repository\ntext change\n"
+
+
+def test_status_does_not_clear_stale_selected_binary(
+    binary_file_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Status should not turn a stale selected binary into a different bare action."""
+    monkeypatch.chdir(binary_file_repo)
+
+    readme_path = binary_file_repo / "README.md"
+    image_path = binary_file_repo / "image.png"
+    readme_path.write_text("# Test Repository\ntext change\n")
+    image_path.write_bytes(b"\x89PNG\r\n\x1a\nBATCHED")
+
+    initialize_abort_state()
+    command_show(file="image.png", porcelain=True)
+    subprocess.run(["git", "restore", "image.png"], check=True, capture_output=True)
+
+    command_status(porcelain=True)
+    capsys.readouterr()
+
+    with pytest.raises(CommandError, match="Selected binary file no longer matches"):
+        command_include(quiet=True)
+
+    staged_files = run_git_command(["diff", "--cached", "--name-only"]).stdout.splitlines()
+    assert staged_files == []
+    assert readme_path.read_text() == "# Test Repository\ntext change\n"
+
+def test_binary_file_modified_skip_file(binary_file_repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """File-scoped skip should mark binary files processed without staging them."""
+    monkeypatch.chdir(binary_file_repo)
+
+    (binary_file_repo / "image.png").write_bytes(b"\x89PNG\r\n\x1a\nMODIFIED")
+
+    initialize_abort_state()
+
+    skipped = command_skip_file("image.png", quiet=True)
+
+    assert skipped == 1
+    status_result = run_git_command(["status", "--porcelain"])
+    assert " M image.png" in status_result.stdout
 
 def test_binary_and_text_mixed(binary_file_repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Test iteration through mixed binary and text files."""

--- a/tests/commands/test_discard_binary.py
+++ b/tests/commands/test_discard_binary.py
@@ -191,10 +191,10 @@ class TestBinaryDiscard:
         with pytest.raises(CommandError) as exc_info:
             command_discard_from_batch("test-batch", line_ids="1", file="data.bin")
 
-        # Verify error message mentions binary files and atomicity
+        # Verify error message is user-facing.
         error_msg = str(exc_info.value).lower()
         assert "binary" in error_msg
-        assert ("complete units" in error_msg or "atomic" in error_msg)
+        assert "discard the whole file" in error_msg
 
     def test_discard_binary_creates_parent_directories(self, binary_repo):
         """Test that discarding binary file creates parent directories if needed."""

--- a/tests/commands/test_discard_empty_file.py
+++ b/tests/commands/test_discard_empty_file.py
@@ -6,8 +6,12 @@ import pytest
 
 from git_stage_batch.commands.discard import command_discard_to_batch
 from git_stage_batch.commands.start import command_start
+from git_stage_batch.batch import read_file_from_batch
 from git_stage_batch.batch.operations import create_batch
+from git_stage_batch.batch.query import read_batch_metadata
+from git_stage_batch.data.session import initialize_abort_state
 from git_stage_batch.utils.git import get_git_repository_root_path
+from git_stage_batch.utils.paths import ensure_state_directory_exists
 
 
 @pytest.fixture
@@ -90,3 +94,23 @@ class TestDiscardEmptyFile:
             check=True
         )
         assert not ls_result.stdout.strip(), "File should not be in index"
+
+    def test_discard_empty_deleted_file_to_batch(self, temp_git_repo):
+        """Discarding an empty text deletion to batch should restore the file locally."""
+        empty_file = temp_git_repo / "empty.txt"
+        empty_file.write_bytes(b"")
+        subprocess.run(["git", "add", "empty.txt"], check=True, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add empty file"], check=True, capture_output=True)
+        empty_file.unlink()
+
+        ensure_state_directory_exists()
+        initialize_abort_state()
+        create_batch("delete-batch", "Test batch for empty deletion")
+
+        command_discard_to_batch("delete-batch", line_ids=None, file="empty.txt", quiet=True)
+
+        file_meta = read_batch_metadata("delete-batch")["files"]["empty.txt"]
+        assert file_meta["change_type"] == "deleted"
+        assert read_file_from_batch("delete-batch", "empty.txt") is None
+        assert empty_file.exists()
+        assert empty_file.read_bytes() == b""

--- a/tests/commands/test_discard_from.py
+++ b/tests/commands/test_discard_from.py
@@ -8,6 +8,7 @@ import subprocess
 import pytest
 
 from git_stage_batch.batch import create_batch
+from git_stage_batch.data.hunk_tracking import render_batch_file_display
 from git_stage_batch.commands.discard_from import command_discard_from_batch
 from git_stage_batch.data.session import initialize_abort_state
 from git_stage_batch.exceptions import CommandError
@@ -62,6 +63,29 @@ class TestCommandDiscardFromBatch:
 
         captured = capsys.readouterr()
         assert "Discarded changes from batch" in captured.err
+
+    def test_discard_from_batch_partial_atomic_unit_shows_required_lines(self, temp_git_repo):
+        """Partial replacement selections should keep the atomic-selection guidance."""
+        test_file = temp_git_repo / "file.txt"
+        test_file.write_text("old value\nkeep\n")
+        subprocess.run(["git", "add", "file.txt"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add file"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        test_file.write_text("new value\nkeep\n")
+        command_start()
+        command_include_to_batch("test-batch", quiet=True)
+
+        rendered = render_batch_file_display("test-batch", "file.txt")
+        new_value_gutter = next(
+            rendered.selection_id_to_gutter[line.id]
+            for line in rendered.line_changes.lines
+            if line.id is not None and line.text == "new value"
+        )
+
+        with pytest.raises(CommandError, match="must be selected together") as exc_info:
+            command_discard_from_batch("test-batch", line_ids=str(new_value_gutter), file="file.txt")
+
+        assert "Use: --line" in exc_info.value.message
 
     def test_discard_from_empty_batch_fails(self, temp_git_repo):
         """Test discarding from an empty batch fails."""

--- a/tests/commands/test_file_review.py
+++ b/tests/commands/test_file_review.py
@@ -1,0 +1,220 @@
+"""Tests for page-aware file review state and safety."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+import subprocess
+
+import pytest
+
+from git_stage_batch.batch import create_batch
+from git_stage_batch.batch.ownership import BatchOwnership, DeletionClaim, ReplacementUnit
+from git_stage_batch.batch.query import read_batch_metadata
+from git_stage_batch.batch.storage import add_file_to_batch
+from git_stage_batch.commands.apply_from import command_apply_from_batch
+from git_stage_batch.commands.discard_from import command_discard_from_batch
+from git_stage_batch.commands.discard import command_discard_file, command_discard_file_as, command_discard_line, command_discard_line_as_to_batch, command_discard_to_batch
+from git_stage_batch.commands.include import command_include, command_include_file, command_include_file_as, command_include_line, command_include_line_as
+from git_stage_batch.commands.include_from import command_include_from_batch
+from git_stage_batch.commands.reset import command_reset_from_batch
+from git_stage_batch.commands.show_from import command_show_from_batch
+import git_stage_batch.commands.show_from as show_from_module
+from git_stage_batch.commands.show import command_show, command_show_file_list
+import git_stage_batch.commands.show as show_module
+from git_stage_batch.commands.skip import command_skip, command_skip_file, command_skip_line
+from git_stage_batch.commands.start import command_start
+from git_stage_batch.commands.stop import command_stop
+from git_stage_batch.commands.include import command_include_to_batch
+from git_stage_batch.commands.suggest_fixup import command_suggest_fixup
+import git_stage_batch.data.hunk_tracking as hunk_tracking_module
+from git_stage_batch.data.file_review_state import (
+    FileReviewAction,
+    ReviewSource,
+    read_last_file_review_state,
+    shown_complete_review_selection_groups,
+)
+from git_stage_batch.data.hunk_tracking import (
+    SelectedChangeKind,
+    get_selected_change_file_path,
+    read_selected_change_kind,
+)
+from git_stage_batch.data.line_state import load_line_changes_from_state
+from git_stage_batch.exceptions import CommandError
+from git_stage_batch.core.line_selection import format_line_ids
+from git_stage_batch.core.models import HunkHeader, LineEntry, LineLevelChange, RenderedBatchDisplay, ReviewActionGroup
+from git_stage_batch.data.session import initialize_abort_state
+from git_stage_batch.output.file_review import build_file_review_model, make_file_review_state, print_file_review
+from git_stage_batch.utils.paths import (
+    ensure_state_directory_exists,
+    get_line_changes_json_file_path,
+    get_selected_change_clear_reason_file_path,
+)
+
+
+@pytest.fixture
+def paged_file_repo(tmp_path, monkeypatch):
+    """Create a repo with three separated file changes."""
+    monkeypatch.chdir(tmp_path)
+    subprocess.run(["git", "init"], check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], check=True)
+
+    original = [f"line {number}\n" for number in range(1, 31)]
+    (tmp_path / "file.txt").write_text("".join(original))
+    subprocess.run(["git", "add", "file.txt"], check=True)
+    subprocess.run(["git", "commit", "-m", "Initial"], check=True, capture_output=True)
+
+    changed = original[:]
+    changed[1] = "line 2 changed\n"
+    changed[11] = "line 12 changed\n"
+    changed[21] = "line 22 changed\n"
+    (tmp_path / "file.txt").write_text("".join(changed))
+
+    ensure_state_directory_exists()
+    initialize_abort_state()
+    return tmp_path
+
+
+@pytest.fixture
+def paged_batch_repo(paged_file_repo):
+    """Create a batch with the paged file changes."""
+    command_start()
+    command_include_to_batch("cleanup", file="file.txt", quiet=True)
+    return paged_file_repo
+
+
+def _force_one_change_per_page(monkeypatch):
+    from git_stage_batch.output import file_review
+
+    monkeypatch.setattr(file_review, "_body_budget", lambda: 1)
+
+
+def _add_second_changed_file(repo):
+    other_file = repo / "other.txt"
+    other_file.write_text("other 1\nother 2\n")
+    subprocess.run(["git", "add", "other.txt"], check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "Add other"], check=True, capture_output=True)
+    other_file.write_text("other 1\nother changed\n")
+
+
+def _create_multi_file_batch(repo):
+    _add_second_changed_file(repo)
+    command_start()
+    command_include_to_batch("cleanup", file="file.txt", quiet=True)
+    command_include_to_batch("cleanup", file="other.txt", quiet=True)
+
+
+def test_show_file_page_range_renders_pages_and_persists_state(paged_file_repo, monkeypatch, capsys):
+    _force_one_change_per_page(monkeypatch)
+
+    command_show(file="file.txt", page="2-3")
+
+    captured = capsys.readouterr()
+    assert "── page 2/3" in captured.out
+    assert "── page 3/3" in captured.out
+    state = read_last_file_review_state()
+    assert state is not None
+    assert state.shown_pages == (2, 3)
+    assert state.page_spec == "2-3"
+    assert state.entire_file_shown is False
+
+
+def test_show_file_page_all_sets_entire_file_shown(paged_file_repo, monkeypatch, capsys):
+    _force_one_change_per_page(monkeypatch)
+
+    command_show(file="file.txt", page="all")
+
+    capsys.readouterr()
+    state = read_last_file_review_state()
+    assert state is not None
+    assert state.shown_pages == (1, 2, 3)
+    assert state.page_spec == "all"
+    assert state.entire_file_shown is True
+
+
+def test_show_file_numeric_all_pages_normalizes_to_all(paged_file_repo, monkeypatch, capsys):
+    _force_one_change_per_page(monkeypatch)
+
+    command_show(file="file.txt", page="1,3,2")
+
+    capsys.readouterr()
+    state = read_last_file_review_state()
+    assert state is not None
+    assert state.shown_pages == (1, 2, 3)
+    assert state.page_spec == "all"
+    assert state.entire_file_shown is True
+
+
+def test_show_file_duplicate_pages_normalize_to_compact_set(paged_file_repo, monkeypatch, capsys):
+    _force_one_change_per_page(monkeypatch)
+
+    command_show(file="file.txt", page="3,2,2")
+
+    capsys.readouterr()
+    state = read_last_file_review_state()
+    assert state is not None
+    assert state.shown_pages == (2, 3)
+    assert state.page_spec == "2-3"
+
+
+def test_show_file_rejects_invalid_page_specs(paged_file_repo, monkeypatch):
+    _force_one_change_per_page(monkeypatch)
+
+    with pytest.raises(CommandError, match="Available pages: 1-3"):
+        command_show(file="file.txt", page="99")
+    with pytest.raises(CommandError, match="cannot be combined"):
+        command_show(file="file.txt", page="all,3")
+    with pytest.raises(CommandError, match="cannot be combined"):
+        command_show(file="file.txt", page="1, all")
+    with pytest.raises(CommandError, match="Invalid page selection"):
+        command_show(file="file.txt", page="1-all")
+    with pytest.raises(CommandError, match="Invalid page selection"):
+        command_show(file="file.txt", page="all-3")
+    with pytest.raises(CommandError, match="Invalid page selection"):
+        command_show(file="file.txt", page="small")
+    with pytest.raises(CommandError, match="empty"):
+        command_show(file="file.txt", page="")
+    with pytest.raises(CommandError, match="empty"):
+        command_show(file="file.txt", page="1,,2")
+
+
+def test_show_file_invalid_page_preserves_previous_review_state(paged_file_repo, monkeypatch, capsys):
+    _force_one_change_per_page(monkeypatch)
+    command_show(file="file.txt", page="1")
+    capsys.readouterr()
+    assert read_last_file_review_state() is not None
+
+    with pytest.raises(CommandError, match="Available pages: 1-3"):
+        command_show(file="file.txt", page="99")
+
+    state = read_last_file_review_state()
+    assert state is not None
+    assert state.shown_pages == (1,)
+
+
+def test_show_file_invalid_page_does_not_select_file_review(paged_file_repo, monkeypatch, capsys):
+    _force_one_change_per_page(monkeypatch)
+    command_start()
+    capsys.readouterr()
+    assert read_selected_change_kind() == SelectedChangeKind.HUNK
+    assert get_selected_change_file_path() == "file.txt"
+
+    with pytest.raises(CommandError, match="Available pages: 1-3"):
+        command_show(file="file.txt", page="99")
+
+    assert read_selected_change_kind() == SelectedChangeKind.HUNK
+    assert get_selected_change_file_path() == "file.txt"
+    assert read_last_file_review_state() is None
+
+def test_show_from_batch_file_defaults_to_page_review_and_persists_state(paged_batch_repo, monkeypatch, capsys):
+    _force_one_change_per_page(monkeypatch)
+
+    command_show_from_batch("cleanup", file="file.txt")
+
+    captured = capsys.readouterr()
+    assert "Changes: batch cleanup" in captured.out
+    assert "Showing page 1 of 3" in captured.out
+    state = read_last_file_review_state()
+    assert state is not None
+    assert state.source == "batch"
+    assert state.shown_pages == (1,)

--- a/tests/commands/test_file_review.py
+++ b/tests/commands/test_file_review.py
@@ -1744,3 +1744,28 @@ def test_explicit_reset_from_batch_rejects_unshown_review_selection(
 
     metadata = read_batch_metadata("cleanup")
     assert "file.txt" in metadata.get("files", {})
+def test_start_clears_batch_review_state_left_outside_session(paged_batch_repo, monkeypatch, capsys):
+    _force_one_change_per_page(monkeypatch)
+    command_stop()
+    capsys.readouterr()
+    subprocess.run(["git", "restore", "file.txt"], check=True, capture_output=True)
+
+    command_show_from_batch("cleanup", file="file.txt", page="1")
+    capsys.readouterr()
+    assert read_last_file_review_state() is not None
+
+    live_file = paged_batch_repo / "live.txt"
+    live_file.write_text("live 1\nlive 2\n")
+    subprocess.run(["git", "add", "live.txt"], check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "Add live file"], check=True, capture_output=True)
+    live_file.write_text("live changed\nlive 2\n")
+
+    command_start(quiet=True)
+
+    assert read_last_file_review_state() is None
+    assert get_selected_change_file_path() == "live.txt"
+
+    command_include_line("1")
+
+    captured = capsys.readouterr()
+    assert "Included line(s): 1" in captured.err

--- a/tests/commands/test_file_review.py
+++ b/tests/commands/test_file_review.py
@@ -218,3 +218,729 @@ def test_show_from_batch_file_defaults_to_page_review_and_persists_state(paged_b
     assert state is not None
     assert state.source == "batch"
     assert state.shown_pages == (1,)
+def test_non_selectable_live_preview_preserves_partial_review_guard(
+    paged_file_repo,
+    monkeypatch,
+    capsys,
+):
+    _force_one_change_per_page(monkeypatch)
+    _add_second_changed_file(paged_file_repo)
+    command_show(file="file.txt", page="1")
+    capsys.readouterr()
+    state = read_last_file_review_state()
+    assert state is not None
+    assert state.entire_file_shown is False
+
+    command_show(file="other.txt", selectable=False)
+    capsys.readouterr()
+
+    preserved_state = read_last_file_review_state()
+    assert preserved_state is not None
+    assert preserved_state.file_path == "file.txt"
+    with pytest.raises(CommandError, match="Only pages 1 of 3"):
+        command_include(quiet=True)
+
+def test_show_file_porcelain_clears_previous_review_state(paged_file_repo, monkeypatch, capsys):
+    _force_one_change_per_page(monkeypatch)
+    command_show(file="file.txt", page="1")
+    capsys.readouterr()
+    assert read_last_file_review_state() is not None
+
+    command_show(file="file.txt", porcelain=True)
+
+    assert read_last_file_review_state() is None
+
+def test_bare_include_refuses_after_partial_file_review(paged_file_repo, monkeypatch, capsys):
+    _force_one_change_per_page(monkeypatch)
+    command_show(file="file.txt", page="1")
+    capsys.readouterr()
+
+    with pytest.raises(CommandError) as exc_info:
+        command_include()
+
+    assert "Only pages 1 of 3 of file.txt were shown" in exc_info.value.message
+    assert "git-stage-batch include --file file.txt" in exc_info.value.message
+
+def test_show_unchanged_file_preserves_partial_file_review_guard(
+    paged_file_repo,
+    monkeypatch,
+    capsys,
+):
+    _force_one_change_per_page(monkeypatch)
+    unchanged_file = paged_file_repo / "unchanged.txt"
+    unchanged_file.write_text("same\n")
+    subprocess.run(["git", "add", "unchanged.txt"], check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "Add unchanged"], check=True, capture_output=True)
+
+    command_show(file="file.txt", page="1")
+    capsys.readouterr()
+    state = read_last_file_review_state()
+    assert state is not None
+    assert state.entire_file_shown is False
+
+    command_show(file="unchanged.txt")
+    capsys.readouterr()
+
+    preserved_state = read_last_file_review_state()
+    assert preserved_state is not None
+    assert preserved_state.file_path == "file.txt"
+    assert preserved_state.shown_pages == (1,)
+    with pytest.raises(CommandError, match="Only pages 1 of 3"):
+        command_include(quiet=True)
+
+def test_show_file_list_without_entries_preserves_partial_file_review_guard(
+    paged_file_repo,
+    monkeypatch,
+    capsys,
+):
+    _force_one_change_per_page(monkeypatch)
+    unchanged_file = paged_file_repo / "unchanged.txt"
+    unchanged_file.write_text("same\n")
+    subprocess.run(["git", "add", "unchanged.txt"], check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "Add unchanged"], check=True, capture_output=True)
+
+    command_show(file="file.txt", page="1")
+    capsys.readouterr()
+    state = read_last_file_review_state()
+    assert state is not None
+
+    command_show_file_list(["unchanged.txt"])
+    capsys.readouterr()
+
+    assert read_last_file_review_state() == state
+    with pytest.raises(CommandError, match="Only pages 1 of 3"):
+        command_include(quiet=True)
+
+def test_plain_show_without_unblocked_hunk_preserves_partial_file_review_guard(
+    paged_file_repo,
+    monkeypatch,
+    capsys,
+):
+    _force_one_change_per_page(monkeypatch)
+    command_show(file="file.txt", page="1")
+    capsys.readouterr()
+    state = read_last_file_review_state()
+    assert state is not None
+
+    command_skip_file("file.txt", quiet=True, advance=False)
+    capsys.readouterr()
+    command_show()
+    capsys.readouterr()
+
+    assert read_last_file_review_state() == state
+    with pytest.raises(CommandError, match="Only pages 1 of 3"):
+        command_include(quiet=True)
+
+def test_plain_show_with_only_batch_filtered_hunks_preserves_partial_file_review_guard(
+    paged_file_repo,
+    monkeypatch,
+    capsys,
+):
+    _force_one_change_per_page(monkeypatch)
+    command_show(file="file.txt", page="1")
+    capsys.readouterr()
+    state = read_last_file_review_state()
+    assert state is not None
+
+    monkeypatch.setattr(show_module, "apply_line_level_batch_filter_to_cached_hunk", lambda: True)
+
+    command_show()
+    capsys.readouterr()
+
+    assert read_last_file_review_state() == state
+    assert read_selected_change_kind() == SelectedChangeKind.FILE
+    assert get_selected_change_file_path() == "file.txt"
+    with pytest.raises(CommandError, match="Only pages 1 of 3"):
+        command_include(quiet=True)
+
+def test_bare_include_to_batch_refuses_after_partial_file_review(paged_file_repo, monkeypatch, capsys):
+    _force_one_change_per_page(monkeypatch)
+    command_show(file="file.txt", page="2")
+    capsys.readouterr()
+
+    with pytest.raises(CommandError) as exc_info:
+        command_include_to_batch("later")
+
+    assert "Only pages 2 of 3 of file.txt were shown" in exc_info.value.message
+    assert "git-stage-batch show --file file.txt --page all" in exc_info.value.message
+
+
+@pytest.mark.parametrize(
+    "to_batch_action",
+    [
+        lambda: command_include_to_batch("later", file="", quiet=True),
+        lambda: command_discard_to_batch("later", file="", quiet=True),
+    ],
+)
+
+def test_default_to_batch_file_actions_refuse_after_partial_file_review(
+    paged_file_repo,
+    monkeypatch,
+    capsys,
+    to_batch_action,
+):
+    _force_one_change_per_page(monkeypatch)
+    original_content = (paged_file_repo / "file.txt").read_text()
+    command_show(file="file.txt", page="1")
+    capsys.readouterr()
+
+    with pytest.raises(CommandError) as exc_info:
+        to_batch_action()
+
+    assert "Only pages 1 of 3 of file.txt were shown" in exc_info.value.message
+    assert (paged_file_repo / "file.txt").read_text() == original_content
+
+def test_default_discard_line_as_to_batch_keeps_partial_review_guard(
+    paged_file_repo,
+    monkeypatch,
+    capsys,
+):
+    _force_one_change_per_page(monkeypatch)
+    command_show(file="file.txt", page="1")
+    capsys.readouterr()
+    state = read_last_file_review_state()
+    assert state is not None
+    line_spec = format_line_ids(list(state.selections[0].display_ids))
+    unshown_spec = format_line_ids(list(state.selections[1].display_ids))
+
+    command_discard_line_as_to_batch(
+        "later",
+        line_spec,
+        "replacement\n",
+        file="",
+        quiet=True,
+    )
+    capsys.readouterr()
+
+    assert read_last_file_review_state() is not None
+    with pytest.raises(CommandError, match="no longer matches"):
+        command_discard_line_as_to_batch(
+            "later",
+            unshown_spec,
+            "replacement\n",
+            file="",
+            quiet=True,
+        )
+
+    line_changes = load_line_changes_from_state()
+    assert line_changes is not None
+    visible_changed_texts = [
+        line.text
+        for line in line_changes.lines
+        if line.id is not None
+    ]
+    assert "line 2" not in visible_changed_texts
+    assert "line 2 changed" not in visible_changed_texts
+
+def test_include_to_batch_refuses_after_navigational_file_list(paged_file_repo, capsys):
+    _add_second_changed_file(paged_file_repo)
+
+    command_show_file_list(["file.txt", "other.txt"])
+    capsys.readouterr()
+
+    with pytest.raises(CommandError, match="last command only showed files"):
+        command_include_to_batch("later", quiet=True)
+
+
+@pytest.mark.parametrize(
+    "line_command",
+    [command_include_line, command_skip_line, command_discard_line],
+)
+
+def test_pathless_line_actions_refuse_after_navigational_file_list(
+    paged_file_repo,
+    capsys,
+    line_command,
+):
+    _add_second_changed_file(paged_file_repo)
+
+    command_show_file_list(["file.txt", "other.txt"])
+    capsys.readouterr()
+
+    with pytest.raises(CommandError, match="last command only showed files"):
+        line_command("1")
+
+def test_file_list_marker_survives_explicit_file_include_line(
+    paged_file_repo,
+    capsys,
+):
+    _add_second_changed_file(paged_file_repo)
+
+    command_show_file_list(["file.txt", "other.txt"])
+    capsys.readouterr()
+
+    command_include_line("1", file="other.txt")
+    capsys.readouterr()
+
+    with pytest.raises(CommandError, match="last command only showed files"):
+        command_include_to_batch("later", quiet=True)
+
+def test_bare_include_to_batch_after_full_file_review_uses_reviewed_file(
+    paged_file_repo,
+    monkeypatch,
+    capsys,
+):
+    _force_one_change_per_page(monkeypatch)
+    _add_second_changed_file(paged_file_repo)
+    command_show(file="other.txt", page="all")
+    capsys.readouterr()
+
+    command_include_to_batch("reviewed", quiet=True)
+
+    metadata = read_batch_metadata("reviewed")
+    assert list(metadata.get("files", {}).keys()) == ["other.txt"]
+
+def test_pathless_include_to_batch_line_filters_file_review_selection(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.chdir(repo)
+
+    subprocess.run(["git", "init"], check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], check=True, capture_output=True)
+
+    test_file = repo / "file.txt"
+    test_file.write_text("a\nb\n")
+    subprocess.run(["git", "add", "file.txt"], check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "Initial"], check=True, capture_output=True)
+    test_file.write_text("a\nX\nb\nY\n")
+
+    ensure_state_directory_exists()
+    initialize_abort_state()
+    command_show(file="file.txt", page="all")
+    capsys.readouterr()
+
+    command_include_to_batch("first", line_ids="1", quiet=True)
+    capsys.readouterr()
+
+    filtered = load_line_changes_from_state()
+    assert filtered is not None
+    assert [line.text for line in filtered.lines if line.id is not None] == ["Y"]
+
+    command_include_to_batch("second", line_ids="1", quiet=True)
+
+    first_metadata = read_batch_metadata("first")
+    second_metadata = read_batch_metadata("second")
+    assert first_metadata["files"]["file.txt"]["claimed_lines"] != second_metadata["files"]["file.txt"]["claimed_lines"]
+    assert read_selected_change_kind() is None
+
+def test_bare_discard_to_batch_refuses_after_partial_file_review(paged_file_repo, monkeypatch, capsys):
+    _force_one_change_per_page(monkeypatch)
+    command_show(file="file.txt", page="2")
+    capsys.readouterr()
+
+    with pytest.raises(CommandError) as exc_info:
+        command_discard_to_batch("later")
+
+    assert "Only pages 2 of 3 of file.txt were shown" in exc_info.value.message
+    assert "line 12 changed" in (paged_file_repo / "file.txt").read_text()
+
+def test_discard_to_batch_refuses_after_navigational_file_list(paged_file_repo, capsys):
+    _add_second_changed_file(paged_file_repo)
+    original_file = (paged_file_repo / "file.txt").read_text()
+    original_other = (paged_file_repo / "other.txt").read_text()
+
+    command_show_file_list(["file.txt", "other.txt"])
+    capsys.readouterr()
+
+    with pytest.raises(CommandError, match="last command only showed files"):
+        command_discard_to_batch("later", quiet=True)
+
+    assert (paged_file_repo / "file.txt").read_text() == original_file
+    assert (paged_file_repo / "other.txt").read_text() == original_other
+
+def test_bare_discard_to_batch_after_full_file_review_uses_reviewed_file(
+    paged_file_repo,
+    monkeypatch,
+    capsys,
+):
+    _force_one_change_per_page(monkeypatch)
+    _add_second_changed_file(paged_file_repo)
+    command_show(file="other.txt", page="all")
+    capsys.readouterr()
+
+    command_discard_to_batch("reviewed", quiet=True)
+
+    metadata = read_batch_metadata("reviewed")
+    assert list(metadata.get("files", {}).keys()) == ["other.txt"]
+    assert (paged_file_repo / "other.txt").read_text() == "other 1\nother 2\n"
+    assert "line 2 changed" in (paged_file_repo / "file.txt").read_text()
+
+def test_bare_include_allowed_after_entire_file_review(paged_file_repo, monkeypatch, capsys):
+    _force_one_change_per_page(monkeypatch)
+    command_show(file="file.txt", page="all")
+    capsys.readouterr()
+
+    command_include()
+
+    captured = capsys.readouterr()
+    assert "Staged" in captured.err
+
+def test_bare_include_after_full_file_review_refuses_when_file_changed(paged_file_repo, monkeypatch, capsys):
+    _force_one_change_per_page(monkeypatch)
+    command_show(file="file.txt", page="all")
+    capsys.readouterr()
+
+    file_path = paged_file_repo / "file.txt"
+    file_path.write_text(file_path.read_text() + "unreviewed change\n")
+
+    with pytest.raises(CommandError, match="no longer matches"):
+        command_include()
+
+def test_pathless_include_line_accepts_complete_shown_change_and_keeps_partial_review_guard(
+    paged_file_repo,
+    monkeypatch,
+    capsys,
+):
+    _force_one_change_per_page(monkeypatch)
+    command_show(file="file.txt", page="1")
+    capsys.readouterr()
+    state = read_last_file_review_state()
+    assert state is not None
+    line_spec = format_line_ids(list(state.selections[0].display_ids))
+
+    command_include_line(line_spec)
+
+    captured = capsys.readouterr()
+    assert f"Included line(s): {line_spec}" in captured.err
+    assert read_last_file_review_state() is not None
+
+def test_pathless_include_line_as_keeps_partial_review_guard_for_bare_action(
+    paged_file_repo,
+    monkeypatch,
+    capsys,
+):
+    _force_one_change_per_page(monkeypatch)
+    command_show(file="file.txt", page="1")
+    capsys.readouterr()
+    state = read_last_file_review_state()
+    assert state is not None
+    line_spec = format_line_ids(list(state.selections[0].display_ids))
+
+    command_include_line_as(line_spec, "replacement\n")
+    capsys.readouterr()
+
+    assert read_last_file_review_state() is not None
+    with pytest.raises(CommandError, match="no longer matches"):
+        command_include(quiet=True)
+
+def test_discard_line_as_to_batch_keeps_partial_review_guard_for_bare_action(
+    paged_file_repo,
+    monkeypatch,
+    capsys,
+):
+    _force_one_change_per_page(monkeypatch)
+    command_show(file="file.txt", page="1")
+    capsys.readouterr()
+    state = read_last_file_review_state()
+    assert state is not None
+    line_spec = format_line_ids(list(state.selections[0].display_ids))
+
+    command_discard_line_as_to_batch(
+        "later",
+        line_spec,
+        "replacement\n",
+        file="",
+        quiet=True,
+    )
+    capsys.readouterr()
+
+    assert read_last_file_review_state() is not None
+    with pytest.raises(CommandError, match="no longer matches"):
+        command_include(quiet=True)
+
+def test_show_file_resets_processed_skip_ids_before_review_line_action(tmp_path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    subprocess.run(["git", "init"], check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], check=True)
+
+    (tmp_path / "a.txt").write_text("a1\na2\na3\n")
+    (tmp_path / "b.txt").write_text("b1\nb2\nb3\nb4\nb5\n")
+    subprocess.run(["git", "add", "a.txt", "b.txt"], check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "Initial"], check=True, capture_output=True)
+
+    (tmp_path / "a.txt").write_text("a1 changed\na2\na3 changed\n")
+    (tmp_path / "b.txt").write_text("b1 changed\nb2\nb3 changed\nb4\nb5\n")
+
+    command_start(quiet=True)
+    command_skip_line("1")
+    capsys.readouterr()
+
+    command_show(file="b.txt", page="all")
+    capsys.readouterr()
+    state = read_last_file_review_state()
+    assert state is not None
+    second_change_spec = format_line_ids(list(state.selections[1].display_ids))
+
+    command_skip_line(second_change_spec)
+
+    line_changes = load_line_changes_from_state()
+    assert line_changes is not None
+    visible_changed_texts = [
+        line.text
+        for line in line_changes.lines
+        if line.id is not None
+    ]
+    assert "b1" in visible_changed_texts
+    assert "b1 changed" in visible_changed_texts
+    assert "b3" not in visible_changed_texts
+    assert "b3 changed" not in visible_changed_texts
+
+def test_file_review_footer_suggests_pathless_line_commands(paged_file_repo, monkeypatch, capsys):
+    _force_one_change_per_page(monkeypatch)
+
+    command_show(file="file.txt", page="1")
+
+    captured = capsys.readouterr()
+    assert "git-stage-batch include --line" in captured.out
+    assert "git-stage-batch include --file file.txt --line" not in captured.out
+
+def test_pathless_include_line_rejects_partial_replacement_selection(paged_file_repo, monkeypatch, capsys):
+    _force_one_change_per_page(monkeypatch)
+    command_show(file="file.txt", page="1")
+    captured = capsys.readouterr()
+    assert "select together:" in captured.out
+
+    state = read_last_file_review_state()
+    assert state is not None
+    partial_id = str(state.selections[0].display_ids[0])
+
+    with pytest.raises(CommandError, match="only partly selects"):
+        command_include_line(partial_id)
+
+def test_pathless_include_line_rejects_unshown_change(paged_file_repo, monkeypatch, capsys):
+    _force_one_change_per_page(monkeypatch)
+    command_show(file="file.txt", page="1")
+    capsys.readouterr()
+    state = read_last_file_review_state()
+    assert state is not None
+    unshown_spec = format_line_ids(list(state.selections[1].display_ids))
+
+    with pytest.raises(CommandError, match="not valid from the current file review"):
+        command_include_line(unshown_spec)
+
+def test_partial_review_line_action_keeps_stale_guard_for_followup_bare_action(
+    paged_file_repo,
+    monkeypatch,
+    capsys,
+):
+    _force_one_change_per_page(monkeypatch)
+    command_show(file="file.txt", page="1")
+    capsys.readouterr()
+    state = read_last_file_review_state()
+    assert state is not None
+    shown_spec = format_line_ids(list(state.selections[0].display_ids))
+
+    command_include_line(shown_spec)
+    capsys.readouterr()
+
+    assert read_last_file_review_state() is not None
+    with pytest.raises(CommandError, match="no longer matches"):
+        command_include()
+
+def test_partial_review_line_action_keeps_stale_guard_for_followup_line_action(
+    paged_file_repo,
+    monkeypatch,
+    capsys,
+):
+    _force_one_change_per_page(monkeypatch)
+    command_show(file="file.txt", page="1")
+    capsys.readouterr()
+    state = read_last_file_review_state()
+    assert state is not None
+    shown_spec = format_line_ids(list(state.selections[0].display_ids))
+    unshown_spec = format_line_ids(list(state.selections[1].display_ids))
+
+    command_skip_line(shown_spec)
+    capsys.readouterr()
+
+    assert read_last_file_review_state() is not None
+    with pytest.raises(CommandError, match="no longer matches"):
+        command_skip_line(unshown_spec)
+
+
+@pytest.mark.parametrize(
+    "to_batch_command",
+    [command_include_to_batch, command_discard_to_batch],
+)
+
+def test_partial_review_to_batch_line_action_keeps_stale_guard_for_followup_line_action(
+    paged_file_repo,
+    monkeypatch,
+    capsys,
+    to_batch_command,
+):
+    _force_one_change_per_page(monkeypatch)
+    command_show(file="file.txt", page="1")
+    capsys.readouterr()
+    state = read_last_file_review_state()
+    assert state is not None
+    shown_spec = format_line_ids(list(state.selections[0].display_ids))
+    unshown_spec = format_line_ids(list(state.selections[1].display_ids))
+
+    to_batch_command("cleanup", line_ids=shown_spec)
+    capsys.readouterr()
+
+    assert read_last_file_review_state() is not None
+    with pytest.raises(CommandError, match="no longer matches"):
+        command_include_to_batch("cleanup", line_ids=unshown_spec)
+
+
+@pytest.mark.parametrize(
+    "to_batch_command",
+    [command_include_to_batch, command_discard_to_batch],
+)
+
+def test_implicit_to_batch_line_action_clears_full_review_state(
+    paged_file_repo,
+    capsys,
+    to_batch_command,
+):
+    command_show(file="file.txt", page="all")
+    capsys.readouterr()
+    state = read_last_file_review_state()
+    assert state is not None
+    shown_spec = format_line_ids(list(state.selections[0].display_ids))
+
+    to_batch_command("cleanup", line_ids=shown_spec, file="")
+
+    assert read_last_file_review_state() is None
+
+
+@pytest.mark.parametrize(
+    "line_command",
+    [command_include_line, command_skip_line, command_discard_line],
+)
+
+def test_omitted_file_line_actions_reject_unshown_change(
+    paged_file_repo,
+    monkeypatch,
+    capsys,
+    line_command,
+):
+    _force_one_change_per_page(monkeypatch)
+    command_show(file="file.txt", page="1")
+    capsys.readouterr()
+    state = read_last_file_review_state()
+    assert state is not None
+    unshown_spec = format_line_ids(list(state.selections[1].display_ids))
+
+    with pytest.raises(CommandError, match="not valid from the current file review"):
+        line_command(unshown_spec, file="")
+
+def test_explicit_include_file_line_from_review_clears_review_state(paged_file_repo, monkeypatch, capsys):
+    _force_one_change_per_page(monkeypatch)
+    command_show(file="file.txt", page="1")
+    capsys.readouterr()
+    state = read_last_file_review_state()
+    assert state is not None
+    line_spec = format_line_ids(list(state.selections[0].display_ids))
+
+    command_include_line(line_spec, file="file.txt")
+
+    assert read_last_file_review_state() is None
+
+def test_explicit_skip_file_line_from_review_clears_review_state(paged_file_repo, monkeypatch, capsys):
+    _force_one_change_per_page(monkeypatch)
+    command_show(file="file.txt", page="1")
+    capsys.readouterr()
+    state = read_last_file_review_state()
+    assert state is not None
+    line_spec = format_line_ids(list(state.selections[0].display_ids))
+
+    command_skip_line(line_spec, file="file.txt")
+
+    assert read_last_file_review_state() is None
+
+def test_explicit_discard_file_line_from_review_clears_review_state(paged_file_repo, monkeypatch, capsys):
+    _force_one_change_per_page(monkeypatch)
+    command_show(file="file.txt", page="1")
+    capsys.readouterr()
+    state = read_last_file_review_state()
+    assert state is not None
+    line_spec = format_line_ids(list(state.selections[0].display_ids))
+
+    command_discard_line(line_spec, file="file.txt")
+
+    assert read_last_file_review_state() is None
+
+
+@pytest.mark.parametrize(
+    "replace_file",
+    [
+        lambda file_path: command_include_file_as("replacement\n", file=file_path),
+        lambda file_path: command_discard_file_as("replacement\n", file=file_path),
+    ],
+)
+
+def test_explicit_file_as_from_review_clears_matching_review_state(
+    paged_file_repo,
+    monkeypatch,
+    capsys,
+    replace_file,
+):
+    _force_one_change_per_page(monkeypatch)
+    command_show(file="file.txt", page="all")
+    capsys.readouterr()
+    assert read_last_file_review_state() is not None
+
+    replace_file("file.txt")
+
+    assert read_last_file_review_state() is None
+
+def test_explicit_discard_to_batch_line_as_from_review_clears_matching_review_state(
+    paged_file_repo,
+    monkeypatch,
+    capsys,
+):
+    _force_one_change_per_page(monkeypatch)
+    command_show(file="file.txt", page="all")
+    capsys.readouterr()
+    state = read_last_file_review_state()
+    assert state is not None
+    line_spec = format_line_ids(list(state.selections[0].display_ids))
+
+    command_discard_line_as_to_batch(
+        "cleanup",
+        line_spec,
+        "replacement\n",
+        file="file.txt",
+        quiet=True,
+    )
+
+    assert read_last_file_review_state() is None
+
+def test_explicit_skip_line_on_different_file_clears_previous_review_state(
+    paged_file_repo,
+    monkeypatch,
+    capsys,
+):
+    _force_one_change_per_page(monkeypatch)
+    _add_second_changed_file(paged_file_repo)
+    command_show(file="file.txt", page="1")
+    capsys.readouterr()
+    assert read_last_file_review_state() is not None
+
+    command_skip_line("1", file="other.txt")
+
+    assert read_last_file_review_state() is None
+
+def test_explicit_discard_line_on_different_file_clears_previous_review_state(
+    paged_file_repo,
+    monkeypatch,
+    capsys,
+):
+    _force_one_change_per_page(monkeypatch)
+    _add_second_changed_file(paged_file_repo)
+    command_show(file="file.txt", page="1")
+    capsys.readouterr()
+    assert read_last_file_review_state() is not None
+
+    command_discard_line("1", file="other.txt")
+
+    assert read_last_file_review_state() is None

--- a/tests/commands/test_file_review.py
+++ b/tests/commands/test_file_review.py
@@ -1624,3 +1624,123 @@ def test_pathless_include_from_other_batch_after_full_batch_review_refuses(paged
 
     with pytest.raises(CommandError, match="no longer matches"):
         command_include_from_batch("other-batch", line_ids=line_spec)
+def test_reset_from_batch_refuses_after_navigational_batch_file_list(paged_file_repo, capsys):
+    _create_multi_file_batch(paged_file_repo)
+    capsys.readouterr()
+
+    command_show_from_batch("cleanup")
+    capsys.readouterr()
+
+    with pytest.raises(CommandError, match="last command only showed files"):
+        command_reset_from_batch("cleanup")
+
+    metadata = read_batch_metadata("cleanup")
+    assert set(metadata.get("files", {})) == {"file.txt", "other.txt"}
+
+@pytest.mark.parametrize(
+    "batch_file_action",
+    [
+        lambda: command_include_from_batch("cleanup", file=""),
+        lambda: command_discard_from_batch("cleanup", file=""),
+        lambda: command_apply_from_batch("cleanup", file=""),
+        lambda: command_reset_from_batch("cleanup", file=""),
+    ],
+)
+def test_default_batch_file_actions_refuse_after_partial_batch_review(
+    paged_batch_repo,
+    monkeypatch,
+    capsys,
+    batch_file_action,
+):
+    _force_one_change_per_page(monkeypatch)
+    command_show_from_batch("cleanup", file="file.txt", page="1")
+    capsys.readouterr()
+    original_content = (paged_batch_repo / "file.txt").read_text()
+
+    with pytest.raises(CommandError) as exc_info:
+        batch_file_action()
+
+    assert "Only pages 1 of 3 of file.txt were shown" in exc_info.value.message
+    assert (paged_batch_repo / "file.txt").read_text() == original_content
+    assert "file.txt" in read_batch_metadata("cleanup").get("files", {})
+
+@pytest.mark.parametrize(
+    "batch_file_action",
+    [
+        lambda: command_include_from_batch("cleanup", file=""),
+        lambda: command_discard_from_batch("cleanup", file=""),
+        lambda: command_apply_from_batch("cleanup", file=""),
+        lambda: command_reset_from_batch("cleanup", file=""),
+    ],
+)
+def test_default_batch_file_actions_refuse_after_batch_file_list(
+    paged_file_repo,
+    capsys,
+    batch_file_action,
+):
+    _create_multi_file_batch(paged_file_repo)
+    capsys.readouterr()
+    command_show_from_batch("cleanup")
+    capsys.readouterr()
+
+    with pytest.raises(CommandError, match="last command only showed files"):
+        batch_file_action()
+
+    metadata = read_batch_metadata("cleanup")
+    assert set(metadata.get("files", {})) == {"file.txt", "other.txt"}
+
+def test_bare_reset_from_batch_after_full_single_file_review_uses_reviewed_file(
+    paged_file_repo,
+    monkeypatch,
+    capsys,
+):
+    _force_one_change_per_page(monkeypatch)
+    _create_multi_file_batch(paged_file_repo)
+    capsys.readouterr()
+    command_show_from_batch("cleanup", file="file.txt", page="all")
+    capsys.readouterr()
+
+    command_reset_from_batch("cleanup")
+
+    metadata = read_batch_metadata("cleanup")
+    assert set(metadata.get("files", {})) == {"other.txt"}
+
+def test_pathless_reset_from_batch_uses_reviewed_file_in_multi_file_batch(
+    paged_file_repo,
+    monkeypatch,
+    capsys,
+):
+    _force_one_change_per_page(monkeypatch)
+    _create_multi_file_batch(paged_file_repo)
+    capsys.readouterr()
+    command_show_from_batch("cleanup", file="file.txt", page="1")
+    capsys.readouterr()
+    state = read_last_file_review_state()
+    assert state is not None
+    line_spec = format_line_ids(list(state.selections[0].display_ids))
+
+    command_reset_from_batch("cleanup", line_ids=line_spec)
+
+    captured = capsys.readouterr()
+    assert f"Reset line(s) {line_spec} from batch 'cleanup'" in captured.err
+    metadata = read_batch_metadata("cleanup")
+    assert set(metadata.get("files", {})) == {"file.txt", "other.txt"}
+
+def test_explicit_reset_from_batch_rejects_unshown_review_selection(
+    paged_batch_repo,
+    monkeypatch,
+    capsys,
+):
+    _force_one_change_per_page(monkeypatch)
+    command_show_from_batch("cleanup", file="file.txt", page="1")
+    capsys.readouterr()
+    state = read_last_file_review_state()
+    assert state is not None
+    assert len(state.selections) > 1
+    unshown_spec = format_line_ids(list(state.selections[1].display_ids))
+
+    with pytest.raises(CommandError, match="not valid from the current file review"):
+        command_reset_from_batch("cleanup", line_ids=unshown_spec, file="file.txt")
+
+    metadata = read_batch_metadata("cleanup")
+    assert "file.txt" in metadata.get("files", {})

--- a/tests/commands/test_file_review.py
+++ b/tests/commands/test_file_review.py
@@ -944,3 +944,683 @@ def test_explicit_discard_line_on_different_file_clears_previous_review_state(
     command_discard_line("1", file="other.txt")
 
     assert read_last_file_review_state() is None
+def test_non_selectable_batch_preview_preserves_partial_review_guard(
+    paged_file_repo,
+    monkeypatch,
+    capsys,
+):
+    _force_one_change_per_page(monkeypatch)
+    _create_multi_file_batch(paged_file_repo)
+    command_show_from_batch("cleanup", file="file.txt", page="1")
+    capsys.readouterr()
+    state = read_last_file_review_state()
+    assert state is not None
+    assert state.entire_file_shown is False
+
+    command_show_from_batch("cleanup", file="other.txt", selectable=False)
+    capsys.readouterr()
+
+    preserved_state = read_last_file_review_state()
+    assert preserved_state is not None
+    assert preserved_state.file_path == "file.txt"
+    with pytest.raises(CommandError, match="Only pages 1 of 3"):
+        command_include_from_batch("cleanup")
+
+def test_show_from_batch_invalid_page_does_not_select_batch_file(paged_batch_repo, monkeypatch, capsys):
+    _force_one_change_per_page(monkeypatch)
+    capsys.readouterr()
+    before_kind = read_selected_change_kind()
+    before_file = get_selected_change_file_path()
+
+    with pytest.raises(CommandError, match="Available pages: 1-3"):
+        command_show_from_batch("cleanup", file="file.txt", page="99")
+
+    assert read_selected_change_kind() == before_kind
+    assert get_selected_change_file_path() == before_file
+    assert read_last_file_review_state() is None
+
+def test_show_from_batch_invalid_line_does_not_select_batch_file(paged_batch_repo, monkeypatch, capsys):
+    _force_one_change_per_page(monkeypatch)
+    command_show(file="file.txt", page="1")
+    capsys.readouterr()
+    before_kind = read_selected_change_kind()
+    before_file = get_selected_change_file_path()
+    before_state = read_last_file_review_state()
+    assert before_kind == SelectedChangeKind.FILE
+    assert before_file == "file.txt"
+    assert before_state is not None
+
+    with pytest.raises(CommandError, match="Line ID 999 is not available"):
+        command_show_from_batch("cleanup", file="file.txt", line_ids="999")
+
+    assert read_selected_change_kind() == before_kind
+    assert get_selected_change_file_path() == before_file
+    assert read_last_file_review_state() == before_state
+
+def test_show_from_empty_batch_preserves_partial_batch_review_guard(
+    paged_batch_repo,
+    monkeypatch,
+    capsys,
+):
+    _force_one_change_per_page(monkeypatch)
+    command_show_from_batch("cleanup", file="file.txt", page="1")
+    capsys.readouterr()
+    state = read_last_file_review_state()
+    assert state is not None
+
+    create_batch("empty")
+    command_show_from_batch("empty")
+    capsys.readouterr()
+
+    assert read_last_file_review_state() == state
+    with pytest.raises(CommandError, match="Only pages 1 of 3"):
+        command_include_from_batch("cleanup")
+
+def test_include_from_batch_refuses_after_navigational_batch_file_list(paged_file_repo, capsys):
+    _create_multi_file_batch(paged_file_repo)
+    capsys.readouterr()
+
+    command_show_from_batch("cleanup")
+    capsys.readouterr()
+
+    with pytest.raises(CommandError, match="last command only showed files"):
+        command_include_from_batch("cleanup")
+
+    result = subprocess.run(["git", "diff", "--cached", "--quiet"], check=False)
+    assert result.returncode == 0
+
+def test_live_file_list_does_not_block_unrelated_batch_action(paged_file_repo, capsys):
+    command_start()
+    command_include_to_batch("cleanup", file="file.txt", quiet=True)
+    _add_second_changed_file(paged_file_repo)
+    capsys.readouterr()
+
+    command_show_file_list(["file.txt", "other.txt"])
+    capsys.readouterr()
+
+    command_include_from_batch("cleanup")
+
+    captured = capsys.readouterr()
+    assert "Staged changes from batch 'cleanup'" in captured.err
+    result = subprocess.run(
+        ["git", "diff", "--cached", "--name-only"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert result.stdout.splitlines() == ["file.txt"]
+
+def test_legacy_file_list_marker_does_not_block_batch_action(paged_file_repo, capsys):
+    command_start()
+    command_include_to_batch("cleanup", file="file.txt", quiet=True)
+    capsys.readouterr()
+    get_selected_change_clear_reason_file_path().write_text("file-list")
+
+    command_include_from_batch("cleanup")
+
+    result = subprocess.run(
+        ["git", "diff", "--cached", "--name-only"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert result.stdout.splitlines() == ["file.txt"]
+
+def test_discard_from_batch_refuses_after_navigational_batch_file_list(paged_file_repo, capsys):
+    _create_multi_file_batch(paged_file_repo)
+    capsys.readouterr()
+    original_file = (paged_file_repo / "file.txt").read_text()
+    original_other = (paged_file_repo / "other.txt").read_text()
+
+    command_show_from_batch("cleanup")
+    capsys.readouterr()
+
+    with pytest.raises(CommandError, match="last command only showed files"):
+        command_discard_from_batch("cleanup")
+
+    assert (paged_file_repo / "file.txt").read_text() == original_file
+    assert (paged_file_repo / "other.txt").read_text() == original_other
+
+def test_apply_from_batch_refuses_after_navigational_batch_file_list(paged_file_repo, capsys):
+    _create_multi_file_batch(paged_file_repo)
+    capsys.readouterr()
+    original_file = (paged_file_repo / "file.txt").read_text()
+    original_other = (paged_file_repo / "other.txt").read_text()
+
+    command_show_from_batch("cleanup")
+    capsys.readouterr()
+
+    with pytest.raises(CommandError, match="last command only showed files"):
+        command_apply_from_batch("cleanup")
+
+    assert (paged_file_repo / "file.txt").read_text() == original_file
+    assert (paged_file_repo / "other.txt").read_text() == original_other
+
+def test_show_from_batch_file_page_uses_gutter_ids_in_output_and_state(paged_batch_repo, monkeypatch, capsys):
+    _force_one_change_per_page(monkeypatch)
+
+    command_show_from_batch("cleanup", file="file.txt", page="1")
+
+    captured = capsys.readouterr()
+    assert "Changes: batch cleanup" in captured.out
+    assert "git-stage-batch include --from cleanup --file file.txt" in captured.out
+    assert "[#1]" in captured.out
+    state = read_last_file_review_state()
+    assert state is not None
+    assert state.source == "batch"
+    assert state.batch_name == "cleanup"
+    assert state.selected_change_kind == "batch-file"
+    assert state.selections[0].display_ids
+    assert state.selections[0].selection_ids
+
+    command_show_from_batch("cleanup", file="file.txt", page="all")
+
+    captured = capsys.readouterr()
+    assert "git-stage-batch include --from cleanup --line" in captured.out
+    assert "git-stage-batch discard --from cleanup --line" in captured.out
+
+def test_pathless_include_from_batch_accepts_same_batch_review_selection(paged_batch_repo, monkeypatch, capsys):
+    _force_one_change_per_page(monkeypatch)
+    command_show_from_batch("cleanup", file="file.txt", page="1")
+    capsys.readouterr()
+    state = read_last_file_review_state()
+    assert state is not None
+    line_spec = format_line_ids(list(state.selections[0].display_ids))
+    unshown_spec = format_line_ids(list(state.selections[1].display_ids))
+
+    command_include_from_batch("cleanup", line_ids=line_spec)
+
+    captured = capsys.readouterr()
+    assert "Staged selected lines from batch 'cleanup'" in captured.err
+    assert read_last_file_review_state() is not None
+
+    with pytest.raises(CommandError, match="not valid from the current file review"):
+        command_include_from_batch("cleanup", line_ids=unshown_spec)
+
+def test_pathless_include_from_batch_uses_reviewed_file_in_multi_file_batch(
+    paged_file_repo,
+    monkeypatch,
+    capsys,
+):
+    _force_one_change_per_page(monkeypatch)
+    _create_multi_file_batch(paged_file_repo)
+    capsys.readouterr()
+    command_show_from_batch("cleanup", file="file.txt", page="1")
+    capsys.readouterr()
+    state = read_last_file_review_state()
+    assert state is not None
+    line_spec = format_line_ids(list(state.selections[0].display_ids))
+
+    command_include_from_batch("cleanup", line_ids=line_spec)
+
+    captured = capsys.readouterr()
+    assert "Staged selected lines from batch 'cleanup'" in captured.err
+    assert read_last_file_review_state() is not None
+
+def test_pathless_live_line_after_full_batch_review_refuses_with_batch_help(paged_batch_repo, monkeypatch, capsys):
+    _force_one_change_per_page(monkeypatch)
+    command_show_from_batch("cleanup", file="file.txt", page="all")
+    capsys.readouterr()
+
+    with pytest.raises(CommandError) as exc_info:
+        command_include_line("1")
+
+    assert "came from batch 'cleanup', not the live working tree" in exc_info.value.message
+    assert "git-stage-batch include --from cleanup --file file.txt --line 1" in exc_info.value.message
+
+
+@pytest.mark.parametrize(
+    "action",
+    [
+        lambda: command_include_line("1", file=""),
+        lambda: command_skip_line("1", file=""),
+        lambda: command_discard_line("1", file=""),
+    ],
+)
+
+def test_live_default_file_line_actions_after_batch_review_refuse(
+    paged_batch_repo,
+    monkeypatch,
+    capsys,
+    action,
+):
+    _force_one_change_per_page(monkeypatch)
+    command_show_from_batch("cleanup", file="file.txt", page="all")
+    capsys.readouterr()
+
+    with pytest.raises(CommandError) as exc_info:
+        action()
+
+    assert "came from batch 'cleanup', not the live working tree" in exc_info.value.message
+
+
+@pytest.mark.parametrize(
+    "file_command",
+    [command_include_file, command_skip_file, command_discard_file],
+)
+
+def test_live_default_file_actions_after_batch_review_refuse(
+    paged_batch_repo,
+    monkeypatch,
+    capsys,
+    file_command,
+):
+    _force_one_change_per_page(monkeypatch)
+    original_content = (paged_batch_repo / "file.txt").read_text()
+    command_show_from_batch("cleanup", file="file.txt", page="all")
+    capsys.readouterr()
+
+    with pytest.raises(CommandError) as exc_info:
+        file_command("")
+
+    assert "came from batch 'cleanup', not the live working tree" in exc_info.value.message
+    assert (paged_batch_repo / "file.txt").read_text() == original_content
+
+
+@pytest.mark.parametrize(
+    "as_command",
+    [
+        lambda: command_include_file_as("replacement\n", file=""),
+        lambda: command_discard_file_as("replacement\n", file=""),
+    ],
+)
+
+def test_live_default_file_as_actions_after_batch_review_refuse(
+    paged_batch_repo,
+    monkeypatch,
+    capsys,
+    as_command,
+):
+    _force_one_change_per_page(monkeypatch)
+    original_content = (paged_batch_repo / "file.txt").read_text()
+    command_show_from_batch("cleanup", file="file.txt", page="all")
+    capsys.readouterr()
+
+    with pytest.raises(CommandError) as exc_info:
+        as_command()
+
+    assert "came from batch 'cleanup', not the live working tree" in exc_info.value.message
+    assert (paged_batch_repo / "file.txt").read_text() == original_content
+
+def test_pathless_live_line_after_filtered_batch_show_refuses_before_stale_snapshot(
+    paged_batch_repo,
+    capsys,
+):
+    command_show_from_batch("cleanup", file="file.txt", line_ids="1")
+    capsys.readouterr()
+    assert read_last_file_review_state() is not None
+
+    with pytest.raises(CommandError) as exc_info:
+        command_include_line("1")
+
+    assert "came from batch 'cleanup', not the live working tree" in exc_info.value.message
+    assert "Cached hunk is stale" not in exc_info.value.message
+
+def test_bare_include_from_batch_after_filtered_file_show_does_not_widen_to_whole_batch(
+    paged_file_repo,
+    monkeypatch,
+    capsys,
+):
+    _force_one_change_per_page(monkeypatch)
+    _create_multi_file_batch(paged_file_repo)
+    capsys.readouterr()
+
+    command_show_from_batch("cleanup", file="file.txt", line_ids="1")
+    capsys.readouterr()
+
+    state = read_last_file_review_state()
+    assert state is not None
+    assert state.file_path == "file.txt"
+    assert state.entire_file_shown is False
+
+    with pytest.raises(CommandError) as exc_info:
+        command_include_from_batch("cleanup")
+
+    assert "Only pages 1 of 3 of file.txt were shown" in exc_info.value.message
+    staged_files = subprocess.run(
+        ["git", "diff", "--cached", "--name-only"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.splitlines()
+    assert staged_files == []
+
+def test_filtered_batch_show_state_only_allows_displayed_selection(
+    paged_batch_repo,
+    capsys,
+):
+    command_show_from_batch("cleanup", file="file.txt", line_ids="1")
+    capsys.readouterr()
+
+    with pytest.raises(CommandError, match="not valid from the current file review"):
+        command_include_from_batch("cleanup", line_ids="2")
+
+    staged_files = subprocess.run(
+        ["git", "diff", "--cached", "--name-only"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.splitlines()
+    assert staged_files == []
+
+
+@pytest.mark.parametrize(
+    "file_command",
+    [command_include_file, command_skip_file, command_discard_file],
+)
+
+def test_live_hunk_only_command_after_batch_review_refuses_without_clearing_state(
+    paged_batch_repo,
+    monkeypatch,
+    capsys,
+):
+    _force_one_change_per_page(monkeypatch)
+    command_show_from_batch("cleanup", file="file.txt", page="all")
+    capsys.readouterr()
+
+    with pytest.raises(CommandError) as exc_info:
+        command_suggest_fixup()
+
+    assert "came from a batch, not a live hunk" in exc_info.value.message
+    assert read_selected_change_kind() == SelectedChangeKind.BATCH_FILE
+    assert read_last_file_review_state() is not None
+
+def test_bare_include_to_batch_after_full_batch_review_refuses_with_batch_help(
+    paged_batch_repo,
+    monkeypatch,
+    capsys,
+):
+    _force_one_change_per_page(monkeypatch)
+    command_show_from_batch("cleanup", file="file.txt", page="all")
+    capsys.readouterr()
+
+    with pytest.raises(CommandError) as exc_info:
+        command_include_to_batch("later")
+
+    assert "came from batch 'cleanup', not the live working tree" in exc_info.value.message
+    assert "Batch reviews do not support this action" in exc_info.value.message
+
+def test_bare_discard_to_batch_after_full_batch_review_refuses_with_batch_help(
+    paged_batch_repo,
+    monkeypatch,
+    capsys,
+):
+    _force_one_change_per_page(monkeypatch)
+    command_show_from_batch("cleanup", file="file.txt", page="all")
+    capsys.readouterr()
+
+    with pytest.raises(CommandError) as exc_info:
+        command_discard_to_batch("later")
+
+    assert "came from batch 'cleanup', not the live working tree" in exc_info.value.message
+    assert "Batch reviews do not support this action" in exc_info.value.message
+
+def test_explicit_empty_file_discard_to_batch_after_batch_review_uses_selected_file(
+    paged_batch_repo,
+    monkeypatch,
+    capsys,
+):
+    _force_one_change_per_page(monkeypatch)
+    command_show_from_batch("cleanup", file="file.txt", page="all")
+    capsys.readouterr()
+
+    command_discard_to_batch("later", file="", quiet=True)
+
+    metadata = read_batch_metadata("later")
+    assert list(metadata.get("files", {}).keys()) == ["file.txt"]
+
+def test_bare_include_from_batch_refuses_after_partial_batch_review(
+    paged_batch_repo,
+    monkeypatch,
+    capsys,
+):
+    _force_one_change_per_page(monkeypatch)
+    command_show_from_batch("cleanup", file="file.txt", page="1")
+    capsys.readouterr()
+
+    with pytest.raises(CommandError) as exc_info:
+        command_include_from_batch("cleanup")
+
+    assert "Only pages 1 of 3 of file.txt were shown" in exc_info.value.message
+    assert "git-stage-batch include --from cleanup --file file.txt" in exc_info.value.message
+    result = subprocess.run(["git", "diff", "--cached", "--quiet"], check=False)
+    assert result.returncode == 0
+
+def test_bare_discard_from_batch_refuses_after_partial_batch_review(
+    paged_batch_repo,
+    monkeypatch,
+    capsys,
+):
+    _force_one_change_per_page(monkeypatch)
+    command_show_from_batch("cleanup", file="file.txt", page="1")
+    capsys.readouterr()
+    original_content = (paged_batch_repo / "file.txt").read_text()
+
+    with pytest.raises(CommandError) as exc_info:
+        command_discard_from_batch("cleanup")
+
+    assert "Only pages 1 of 3 of file.txt were shown" in exc_info.value.message
+    assert "git-stage-batch discard --from cleanup --file file.txt" in exc_info.value.message
+    assert (paged_batch_repo / "file.txt").read_text() == original_content
+
+
+@pytest.mark.parametrize(
+    "batch_file_action",
+    [
+        lambda: command_include_from_batch("cleanup", file=""),
+        lambda: command_discard_from_batch("cleanup", file=""),
+        lambda: command_apply_from_batch("cleanup", file=""),
+        lambda: command_reset_from_batch("cleanup", file=""),
+    ],
+)
+
+def test_bare_include_from_batch_after_full_single_file_review_uses_reviewed_file(
+    paged_file_repo,
+    monkeypatch,
+    capsys,
+):
+    _force_one_change_per_page(monkeypatch)
+    _create_multi_file_batch(paged_file_repo)
+    capsys.readouterr()
+    command_show_from_batch("cleanup", file="file.txt", page="all")
+    capsys.readouterr()
+
+    command_include_from_batch("cleanup")
+
+    result = subprocess.run(
+        ["git", "diff", "--cached", "--name-only"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert result.stdout.splitlines() == ["file.txt"]
+
+def test_bare_discard_from_batch_after_full_single_file_review_uses_reviewed_file(
+    paged_file_repo,
+    monkeypatch,
+    capsys,
+):
+    _force_one_change_per_page(monkeypatch)
+    _create_multi_file_batch(paged_file_repo)
+    capsys.readouterr()
+    command_show_from_batch("cleanup", file="file.txt", page="all")
+    capsys.readouterr()
+
+    command_discard_from_batch("cleanup")
+
+    assert "line 2 changed" not in (paged_file_repo / "file.txt").read_text()
+    assert (paged_file_repo / "other.txt").read_text() == "other 1\nother changed\n"
+
+def test_bare_apply_from_batch_after_full_single_file_review_uses_reviewed_file(
+    paged_file_repo,
+    monkeypatch,
+    capsys,
+):
+    _force_one_change_per_page(monkeypatch)
+    _create_multi_file_batch(paged_file_repo)
+    capsys.readouterr()
+    subprocess.run(["git", "restore", "file.txt", "other.txt"], check=True, capture_output=True)
+    command_show_from_batch("cleanup", file="file.txt", page="all")
+    capsys.readouterr()
+
+    command_apply_from_batch("cleanup")
+
+    assert "line 2 changed" in (paged_file_repo / "file.txt").read_text()
+    assert (paged_file_repo / "other.txt").read_text() == "other 1\nother 2\n"
+
+def test_pathless_include_from_batch_refuses_when_rerendered_batch_diff_changes(
+    paged_batch_repo,
+    monkeypatch,
+    capsys,
+):
+    _force_one_change_per_page(monkeypatch)
+    command_show_from_batch("cleanup", file="file.txt", page="1")
+    capsys.readouterr()
+    state = read_last_file_review_state()
+    assert state is not None
+    line_spec = format_line_ids(list(state.selections[0].display_ids))
+
+    original_render = hunk_tracking_module.render_batch_file_display
+
+    def changed_render(batch_name, file_path, metadata=None):
+        rendered = original_render(batch_name, file_path, metadata=metadata)
+        assert rendered is not None
+        changed_lines = [
+            replace(
+                line,
+                text="changed after review" if line.id is not None else line.text,
+                text_bytes=b"changed after review" if line.id is not None else line.text_bytes,
+            )
+            for line in rendered.line_changes.lines
+        ]
+        return RenderedBatchDisplay(
+            line_changes=LineLevelChange(
+                path=rendered.line_changes.path,
+                header=rendered.line_changes.header,
+                lines=changed_lines,
+            ),
+            gutter_to_selection_id=rendered.gutter_to_selection_id,
+            selection_id_to_gutter=rendered.selection_id_to_gutter,
+        )
+
+    monkeypatch.setattr(hunk_tracking_module, "render_batch_file_display", changed_render)
+
+    with pytest.raises(CommandError, match="no longer matches"):
+        command_include_from_batch("cleanup", line_ids=line_spec)
+
+def test_pathless_discard_from_batch_accepts_same_batch_review_selection(paged_batch_repo, monkeypatch, capsys):
+    _force_one_change_per_page(monkeypatch)
+    command_show_from_batch("cleanup", file="file.txt", page="1")
+    capsys.readouterr()
+    state = read_last_file_review_state()
+    assert state is not None
+    line_spec = format_line_ids(list(state.selections[0].display_ids))
+
+    command_discard_from_batch("cleanup", line_ids=line_spec)
+
+    captured = capsys.readouterr()
+    assert "Discarded selected lines from batch 'cleanup'" in captured.err
+    assert read_last_file_review_state() is not None
+
+def test_pathless_discard_from_batch_uses_reviewed_file_in_multi_file_batch(
+    paged_file_repo,
+    monkeypatch,
+    capsys,
+):
+    _force_one_change_per_page(monkeypatch)
+    _create_multi_file_batch(paged_file_repo)
+    capsys.readouterr()
+    command_show_from_batch("cleanup", file="file.txt", page="1")
+    capsys.readouterr()
+    state = read_last_file_review_state()
+    assert state is not None
+    line_spec = format_line_ids(list(state.selections[0].display_ids))
+
+    command_discard_from_batch("cleanup", line_ids=line_spec)
+
+    captured = capsys.readouterr()
+    assert "Discarded selected lines from batch 'cleanup'" in captured.err
+    assert read_last_file_review_state() is not None
+
+def test_pathless_apply_from_batch_uses_reviewed_file_in_multi_file_batch(
+    paged_file_repo,
+    monkeypatch,
+    capsys,
+):
+    _force_one_change_per_page(monkeypatch)
+    _create_multi_file_batch(paged_file_repo)
+    subprocess.run(["git", "restore", "file.txt", "other.txt"], check=True, capture_output=True)
+    capsys.readouterr()
+    command_show_from_batch("cleanup", file="file.txt", page="1")
+    capsys.readouterr()
+    state = read_last_file_review_state()
+    assert state is not None
+    line_spec = format_line_ids(list(state.selections[0].display_ids))
+
+    command_apply_from_batch("cleanup", line_ids=line_spec)
+
+    captured = capsys.readouterr()
+    assert "Applied selected lines from batch 'cleanup'" in captured.err
+    assert "line 2 changed" in (paged_file_repo / "file.txt").read_text()
+    assert (paged_file_repo / "other.txt").read_text() == "other 1\nother 2\n"
+
+def test_explicit_batch_file_line_actions_reject_unshown_review_selection(
+    paged_batch_repo,
+    monkeypatch,
+    capsys,
+    batch_command,
+):
+    _force_one_change_per_page(monkeypatch)
+    command_show_from_batch("cleanup", file="file.txt", page="1")
+    capsys.readouterr()
+    state = read_last_file_review_state()
+    assert state is not None
+    assert len(state.selections) > 1
+    unshown_spec = format_line_ids(list(state.selections[1].display_ids))
+
+    with pytest.raises(CommandError, match="not valid from the current file review"):
+        batch_command("cleanup", line_ids=unshown_spec, file="file.txt")
+
+def test_explicit_include_from_batch_file_line_as_rejects_unshown_review_selection(
+    paged_batch_repo,
+    monkeypatch,
+    capsys,
+):
+    _force_one_change_per_page(monkeypatch)
+    command_show_from_batch("cleanup", file="file.txt", page="1")
+    capsys.readouterr()
+    state = read_last_file_review_state()
+    assert state is not None
+    assert len(state.selections) > 1
+    unshown_spec = format_line_ids(list(state.selections[1].display_ids))
+
+    with pytest.raises(CommandError, match="not valid from the current file review"):
+        command_include_from_batch(
+            "cleanup",
+            line_ids=unshown_spec,
+            file="file.txt",
+            replacement_text="replacement\n",
+        )
+
+def test_pathless_include_from_other_batch_after_batch_review_refuses(paged_batch_repo, monkeypatch, capsys):
+    _force_one_change_per_page(monkeypatch)
+    command_show_from_batch("cleanup", file="file.txt", page="1")
+    capsys.readouterr()
+    state = read_last_file_review_state()
+    assert state is not None
+    line_spec = format_line_ids(list(state.selections[0].display_ids))
+
+    with pytest.raises(CommandError, match="no longer matches"):
+        command_include_from_batch("other-batch", line_ids=line_spec)
+
+def test_pathless_include_from_other_batch_after_full_batch_review_refuses(paged_batch_repo, monkeypatch, capsys):
+    _force_one_change_per_page(monkeypatch)
+    command_show_from_batch("cleanup", file="file.txt", page="all")
+    capsys.readouterr()
+    state = read_last_file_review_state()
+    assert state is not None
+    assert state.entire_file_shown is True
+    line_spec = format_line_ids(list(state.selections[0].display_ids))
+
+    with pytest.raises(CommandError, match="no longer matches"):
+        command_include_from_batch("other-batch", line_ids=line_spec)

--- a/tests/commands/test_file_review.py
+++ b/tests/commands/test_file_review.py
@@ -206,18 +206,7 @@ def test_show_file_invalid_page_does_not_select_file_review(paged_file_repo, mon
     assert get_selected_change_file_path() == "file.txt"
     assert read_last_file_review_state() is None
 
-def test_show_from_batch_file_defaults_to_page_review_and_persists_state(paged_batch_repo, monkeypatch, capsys):
-    _force_one_change_per_page(monkeypatch)
 
-    command_show_from_batch("cleanup", file="file.txt")
-
-    captured = capsys.readouterr()
-    assert "Changes: batch cleanup" in captured.out
-    assert "Showing page 1 of 3" in captured.out
-    state = read_last_file_review_state()
-    assert state is not None
-    assert state.source == "batch"
-    assert state.shown_pages == (1,)
 def test_non_selectable_live_preview_preserves_partial_review_guard(
     paged_file_repo,
     monkeypatch,
@@ -240,6 +229,111 @@ def test_non_selectable_live_preview_preserves_partial_review_guard(
     with pytest.raises(CommandError, match="Only pages 1 of 3"):
         command_include(quiet=True)
 
+
+def test_non_selectable_batch_preview_preserves_partial_review_guard(
+    paged_file_repo,
+    monkeypatch,
+    capsys,
+):
+    _force_one_change_per_page(monkeypatch)
+    _create_multi_file_batch(paged_file_repo)
+    command_show_from_batch("cleanup", file="file.txt", page="1")
+    capsys.readouterr()
+    state = read_last_file_review_state()
+    assert state is not None
+    assert state.entire_file_shown is False
+
+    command_show_from_batch("cleanup", file="other.txt", selectable=False)
+    capsys.readouterr()
+
+    preserved_state = read_last_file_review_state()
+    assert preserved_state is not None
+    assert preserved_state.file_path == "file.txt"
+    with pytest.raises(CommandError, match="Only pages 1 of 3"):
+        command_include_from_batch("cleanup")
+
+
+def test_show_file_and_file_list_tolerate_binary_changes(paged_file_repo, capsys):
+    binary_path = paged_file_repo / "asset.bin"
+    binary_path.write_bytes(b"\x00\x01\x02")
+    subprocess.run(["git", "add", "asset.bin"], check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "Add binary"], check=True, capture_output=True)
+    binary_path.write_bytes(b"\x00\x03\x04")
+
+    command_show(file="asset.bin")
+
+    captured = capsys.readouterr()
+    assert "asset.bin :: Binary file modified" in captured.out
+    assert read_selected_change_kind() == SelectedChangeKind.BINARY
+
+    command_show_file_list(["file.txt", "asset.bin"])
+
+    captured = capsys.readouterr()
+    assert "asset.bin" in captured.out
+    assert "binary modified" in captured.out
+
+
+def test_show_text_file_after_binary_file_drops_stale_binary_selection(paged_file_repo, capsys):
+    binary_path = paged_file_repo / "asset.bin"
+    binary_path.write_bytes(b"\x00\x01\x02")
+    subprocess.run(["git", "add", "asset.bin"], check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "Add binary"], check=True, capture_output=True)
+    binary_path.write_bytes(b"\x00\x03\x04")
+
+    command_show(file="asset.bin")
+    capsys.readouterr()
+    assert read_selected_change_kind() == SelectedChangeKind.BINARY
+    assert get_selected_change_file_path() == "asset.bin"
+
+    command_show(file="file.txt", porcelain=True)
+
+    assert read_selected_change_kind() == SelectedChangeKind.FILE
+    assert get_selected_change_file_path() == "file.txt"
+
+    command_include(quiet=True)
+
+    result = subprocess.run(
+        ["git", "diff", "--cached", "--name-only"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert result.stdout.splitlines() == ["file.txt"]
+
+
+def test_show_from_batch_invalid_page_does_not_select_batch_file(paged_batch_repo, monkeypatch, capsys):
+    _force_one_change_per_page(monkeypatch)
+    capsys.readouterr()
+    before_kind = read_selected_change_kind()
+    before_file = get_selected_change_file_path()
+
+    with pytest.raises(CommandError, match="Available pages: 1-3"):
+        command_show_from_batch("cleanup", file="file.txt", page="99")
+
+    assert read_selected_change_kind() == before_kind
+    assert get_selected_change_file_path() == before_file
+    assert read_last_file_review_state() is None
+
+
+def test_show_from_batch_invalid_line_does_not_select_batch_file(paged_batch_repo, monkeypatch, capsys):
+    _force_one_change_per_page(monkeypatch)
+    command_show(file="file.txt", page="1")
+    capsys.readouterr()
+    before_kind = read_selected_change_kind()
+    before_file = get_selected_change_file_path()
+    before_state = read_last_file_review_state()
+    assert before_kind == SelectedChangeKind.FILE
+    assert before_file == "file.txt"
+    assert before_state is not None
+
+    with pytest.raises(CommandError, match="Line ID 999 is not available"):
+        command_show_from_batch("cleanup", file="file.txt", line_ids="999")
+
+    assert read_selected_change_kind() == before_kind
+    assert get_selected_change_file_path() == before_file
+    assert read_last_file_review_state() == before_state
+
+
 def test_show_file_porcelain_clears_previous_review_state(paged_file_repo, monkeypatch, capsys):
     _force_one_change_per_page(monkeypatch)
     command_show(file="file.txt", page="1")
@@ -249,6 +343,7 @@ def test_show_file_porcelain_clears_previous_review_state(paged_file_repo, monke
     command_show(file="file.txt", porcelain=True)
 
     assert read_last_file_review_state() is None
+
 
 def test_bare_include_refuses_after_partial_file_review(paged_file_repo, monkeypatch, capsys):
     _force_one_change_per_page(monkeypatch)
@@ -260,6 +355,7 @@ def test_bare_include_refuses_after_partial_file_review(paged_file_repo, monkeyp
 
     assert "Only pages 1 of 3 of file.txt were shown" in exc_info.value.message
     assert "git-stage-batch include --file file.txt" in exc_info.value.message
+
 
 def test_show_unchanged_file_preserves_partial_file_review_guard(
     paged_file_repo,
@@ -288,6 +384,7 @@ def test_show_unchanged_file_preserves_partial_file_review_guard(
     with pytest.raises(CommandError, match="Only pages 1 of 3"):
         command_include(quiet=True)
 
+
 def test_show_file_list_without_entries_preserves_partial_file_review_guard(
     paged_file_repo,
     monkeypatch,
@@ -311,6 +408,27 @@ def test_show_file_list_without_entries_preserves_partial_file_review_guard(
     with pytest.raises(CommandError, match="Only pages 1 of 3"):
         command_include(quiet=True)
 
+
+def test_show_from_empty_batch_preserves_partial_batch_review_guard(
+    paged_batch_repo,
+    monkeypatch,
+    capsys,
+):
+    _force_one_change_per_page(monkeypatch)
+    command_show_from_batch("cleanup", file="file.txt", page="1")
+    capsys.readouterr()
+    state = read_last_file_review_state()
+    assert state is not None
+
+    create_batch("empty")
+    command_show_from_batch("empty")
+    capsys.readouterr()
+
+    assert read_last_file_review_state() == state
+    with pytest.raises(CommandError, match="Only pages 1 of 3"):
+        command_include_from_batch("cleanup")
+
+
 def test_plain_show_without_unblocked_hunk_preserves_partial_file_review_guard(
     paged_file_repo,
     monkeypatch,
@@ -330,6 +448,7 @@ def test_plain_show_without_unblocked_hunk_preserves_partial_file_review_guard(
     assert read_last_file_review_state() == state
     with pytest.raises(CommandError, match="Only pages 1 of 3"):
         command_include(quiet=True)
+
 
 def test_plain_show_with_only_batch_filtered_hunks_preserves_partial_file_review_guard(
     paged_file_repo,
@@ -353,6 +472,7 @@ def test_plain_show_with_only_batch_filtered_hunks_preserves_partial_file_review
     with pytest.raises(CommandError, match="Only pages 1 of 3"):
         command_include(quiet=True)
 
+
 def test_bare_include_to_batch_refuses_after_partial_file_review(paged_file_repo, monkeypatch, capsys):
     _force_one_change_per_page(monkeypatch)
     command_show(file="file.txt", page="2")
@@ -372,7 +492,6 @@ def test_bare_include_to_batch_refuses_after_partial_file_review(paged_file_repo
         lambda: command_discard_to_batch("later", file="", quiet=True),
     ],
 )
-
 def test_default_to_batch_file_actions_refuse_after_partial_file_review(
     paged_file_repo,
     monkeypatch,
@@ -389,6 +508,7 @@ def test_default_to_batch_file_actions_refuse_after_partial_file_review(
 
     assert "Only pages 1 of 3 of file.txt were shown" in exc_info.value.message
     assert (paged_file_repo / "file.txt").read_text() == original_content
+
 
 def test_default_discard_line_as_to_batch_keeps_partial_review_guard(
     paged_file_repo,
@@ -432,6 +552,7 @@ def test_default_discard_line_as_to_batch_keeps_partial_review_guard(
     assert "line 2" not in visible_changed_texts
     assert "line 2 changed" not in visible_changed_texts
 
+
 def test_include_to_batch_refuses_after_navigational_file_list(paged_file_repo, capsys):
     _add_second_changed_file(paged_file_repo)
 
@@ -446,7 +567,6 @@ def test_include_to_batch_refuses_after_navigational_file_list(paged_file_repo, 
     "line_command",
     [command_include_line, command_skip_line, command_discard_line],
 )
-
 def test_pathless_line_actions_refuse_after_navigational_file_list(
     paged_file_repo,
     capsys,
@@ -459,6 +579,7 @@ def test_pathless_line_actions_refuse_after_navigational_file_list(
 
     with pytest.raises(CommandError, match="last command only showed files"):
         line_command("1")
+
 
 def test_file_list_marker_survives_explicit_file_include_line(
     paged_file_repo,
@@ -475,6 +596,7 @@ def test_file_list_marker_survives_explicit_file_include_line(
     with pytest.raises(CommandError, match="last command only showed files"):
         command_include_to_batch("later", quiet=True)
 
+
 def test_bare_include_to_batch_after_full_file_review_uses_reviewed_file(
     paged_file_repo,
     monkeypatch,
@@ -489,6 +611,7 @@ def test_bare_include_to_batch_after_full_file_review_uses_reviewed_file(
 
     metadata = read_batch_metadata("reviewed")
     assert list(metadata.get("files", {}).keys()) == ["other.txt"]
+
 
 def test_pathless_include_to_batch_line_filters_file_review_selection(
     tmp_path,
@@ -528,6 +651,7 @@ def test_pathless_include_to_batch_line_filters_file_review_selection(
     assert first_metadata["files"]["file.txt"]["claimed_lines"] != second_metadata["files"]["file.txt"]["claimed_lines"]
     assert read_selected_change_kind() is None
 
+
 def test_bare_discard_to_batch_refuses_after_partial_file_review(paged_file_repo, monkeypatch, capsys):
     _force_one_change_per_page(monkeypatch)
     command_show(file="file.txt", page="2")
@@ -538,6 +662,7 @@ def test_bare_discard_to_batch_refuses_after_partial_file_review(paged_file_repo
 
     assert "Only pages 2 of 3 of file.txt were shown" in exc_info.value.message
     assert "line 12 changed" in (paged_file_repo / "file.txt").read_text()
+
 
 def test_discard_to_batch_refuses_after_navigational_file_list(paged_file_repo, capsys):
     _add_second_changed_file(paged_file_repo)
@@ -552,6 +677,106 @@ def test_discard_to_batch_refuses_after_navigational_file_list(paged_file_repo, 
 
     assert (paged_file_repo / "file.txt").read_text() == original_file
     assert (paged_file_repo / "other.txt").read_text() == original_other
+
+
+def test_include_from_batch_refuses_after_navigational_batch_file_list(paged_file_repo, capsys):
+    _create_multi_file_batch(paged_file_repo)
+    capsys.readouterr()
+
+    command_show_from_batch("cleanup")
+    capsys.readouterr()
+
+    with pytest.raises(CommandError, match="last command only showed files"):
+        command_include_from_batch("cleanup")
+
+    result = subprocess.run(["git", "diff", "--cached", "--quiet"], check=False)
+    assert result.returncode == 0
+
+
+def test_live_file_list_does_not_block_unrelated_batch_action(paged_file_repo, capsys):
+    command_start()
+    command_include_to_batch("cleanup", file="file.txt", quiet=True)
+    _add_second_changed_file(paged_file_repo)
+    capsys.readouterr()
+
+    command_show_file_list(["file.txt", "other.txt"])
+    capsys.readouterr()
+
+    command_include_from_batch("cleanup")
+
+    captured = capsys.readouterr()
+    assert "Staged changes from batch 'cleanup'" in captured.err
+    result = subprocess.run(
+        ["git", "diff", "--cached", "--name-only"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert result.stdout.splitlines() == ["file.txt"]
+
+
+def test_legacy_file_list_marker_does_not_block_batch_action(paged_file_repo, capsys):
+    command_start()
+    command_include_to_batch("cleanup", file="file.txt", quiet=True)
+    capsys.readouterr()
+    get_selected_change_clear_reason_file_path().write_text("file-list")
+
+    command_include_from_batch("cleanup")
+
+    result = subprocess.run(
+        ["git", "diff", "--cached", "--name-only"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert result.stdout.splitlines() == ["file.txt"]
+
+
+def test_discard_from_batch_refuses_after_navigational_batch_file_list(paged_file_repo, capsys):
+    _create_multi_file_batch(paged_file_repo)
+    capsys.readouterr()
+    original_file = (paged_file_repo / "file.txt").read_text()
+    original_other = (paged_file_repo / "other.txt").read_text()
+
+    command_show_from_batch("cleanup")
+    capsys.readouterr()
+
+    with pytest.raises(CommandError, match="last command only showed files"):
+        command_discard_from_batch("cleanup")
+
+    assert (paged_file_repo / "file.txt").read_text() == original_file
+    assert (paged_file_repo / "other.txt").read_text() == original_other
+
+
+def test_apply_from_batch_refuses_after_navigational_batch_file_list(paged_file_repo, capsys):
+    _create_multi_file_batch(paged_file_repo)
+    capsys.readouterr()
+    original_file = (paged_file_repo / "file.txt").read_text()
+    original_other = (paged_file_repo / "other.txt").read_text()
+
+    command_show_from_batch("cleanup")
+    capsys.readouterr()
+
+    with pytest.raises(CommandError, match="last command only showed files"):
+        command_apply_from_batch("cleanup")
+
+    assert (paged_file_repo / "file.txt").read_text() == original_file
+    assert (paged_file_repo / "other.txt").read_text() == original_other
+
+
+def test_reset_from_batch_refuses_after_navigational_batch_file_list(paged_file_repo, capsys):
+    _create_multi_file_batch(paged_file_repo)
+    capsys.readouterr()
+
+    command_show_from_batch("cleanup")
+    capsys.readouterr()
+
+    with pytest.raises(CommandError, match="last command only showed files"):
+        command_reset_from_batch("cleanup")
+
+    metadata = read_batch_metadata("cleanup")
+    assert set(metadata.get("files", {})) == {"file.txt", "other.txt"}
+
 
 def test_bare_discard_to_batch_after_full_file_review_uses_reviewed_file(
     paged_file_repo,
@@ -570,6 +795,7 @@ def test_bare_discard_to_batch_after_full_file_review_uses_reviewed_file(
     assert (paged_file_repo / "other.txt").read_text() == "other 1\nother 2\n"
     assert "line 2 changed" in (paged_file_repo / "file.txt").read_text()
 
+
 def test_bare_include_allowed_after_entire_file_review(paged_file_repo, monkeypatch, capsys):
     _force_one_change_per_page(monkeypatch)
     command_show(file="file.txt", page="all")
@@ -579,6 +805,7 @@ def test_bare_include_allowed_after_entire_file_review(paged_file_repo, monkeypa
 
     captured = capsys.readouterr()
     assert "Staged" in captured.err
+
 
 def test_bare_include_after_full_file_review_refuses_when_file_changed(paged_file_repo, monkeypatch, capsys):
     _force_one_change_per_page(monkeypatch)
@@ -590,6 +817,7 @@ def test_bare_include_after_full_file_review_refuses_when_file_changed(paged_fil
 
     with pytest.raises(CommandError, match="no longer matches"):
         command_include()
+
 
 def test_pathless_include_line_accepts_complete_shown_change_and_keeps_partial_review_guard(
     paged_file_repo,
@@ -609,6 +837,7 @@ def test_pathless_include_line_accepts_complete_shown_change_and_keeps_partial_r
     assert f"Included line(s): {line_spec}" in captured.err
     assert read_last_file_review_state() is not None
 
+
 def test_pathless_include_line_as_keeps_partial_review_guard_for_bare_action(
     paged_file_repo,
     monkeypatch,
@@ -627,6 +856,7 @@ def test_pathless_include_line_as_keeps_partial_review_guard_for_bare_action(
     assert read_last_file_review_state() is not None
     with pytest.raises(CommandError, match="no longer matches"):
         command_include(quiet=True)
+
 
 def test_discard_line_as_to_batch_keeps_partial_review_guard_for_bare_action(
     paged_file_repo,
@@ -652,6 +882,7 @@ def test_discard_line_as_to_batch_keeps_partial_review_guard_for_bare_action(
     assert read_last_file_review_state() is not None
     with pytest.raises(CommandError, match="no longer matches"):
         command_include(quiet=True)
+
 
 def test_show_file_resets_processed_skip_ids_before_review_line_action(tmp_path, monkeypatch, capsys):
     monkeypatch.chdir(tmp_path)
@@ -691,6 +922,7 @@ def test_show_file_resets_processed_skip_ids_before_review_line_action(tmp_path,
     assert "b3" not in visible_changed_texts
     assert "b3 changed" not in visible_changed_texts
 
+
 def test_file_review_footer_suggests_pathless_line_commands(paged_file_repo, monkeypatch, capsys):
     _force_one_change_per_page(monkeypatch)
 
@@ -699,6 +931,7 @@ def test_file_review_footer_suggests_pathless_line_commands(paged_file_repo, mon
     captured = capsys.readouterr()
     assert "git-stage-batch include --line" in captured.out
     assert "git-stage-batch include --file file.txt --line" not in captured.out
+
 
 def test_pathless_include_line_rejects_partial_replacement_selection(paged_file_repo, monkeypatch, capsys):
     _force_one_change_per_page(monkeypatch)
@@ -713,6 +946,7 @@ def test_pathless_include_line_rejects_partial_replacement_selection(paged_file_
     with pytest.raises(CommandError, match="only partly selects"):
         command_include_line(partial_id)
 
+
 def test_pathless_include_line_rejects_unshown_change(paged_file_repo, monkeypatch, capsys):
     _force_one_change_per_page(monkeypatch)
     command_show(file="file.txt", page="1")
@@ -723,6 +957,7 @@ def test_pathless_include_line_rejects_unshown_change(paged_file_repo, monkeypat
 
     with pytest.raises(CommandError, match="not valid from the current file review"):
         command_include_line(unshown_spec)
+
 
 def test_partial_review_line_action_keeps_stale_guard_for_followup_bare_action(
     paged_file_repo,
@@ -742,6 +977,7 @@ def test_partial_review_line_action_keeps_stale_guard_for_followup_bare_action(
     assert read_last_file_review_state() is not None
     with pytest.raises(CommandError, match="no longer matches"):
         command_include()
+
 
 def test_partial_review_line_action_keeps_stale_guard_for_followup_line_action(
     paged_file_repo,
@@ -768,7 +1004,6 @@ def test_partial_review_line_action_keeps_stale_guard_for_followup_line_action(
     "to_batch_command",
     [command_include_to_batch, command_discard_to_batch],
 )
-
 def test_partial_review_to_batch_line_action_keeps_stale_guard_for_followup_line_action(
     paged_file_repo,
     monkeypatch,
@@ -795,7 +1030,6 @@ def test_partial_review_to_batch_line_action_keeps_stale_guard_for_followup_line
     "to_batch_command",
     [command_include_to_batch, command_discard_to_batch],
 )
-
 def test_implicit_to_batch_line_action_clears_full_review_state(
     paged_file_repo,
     capsys,
@@ -816,7 +1050,6 @@ def test_implicit_to_batch_line_action_clears_full_review_state(
     "line_command",
     [command_include_line, command_skip_line, command_discard_line],
 )
-
 def test_omitted_file_line_actions_reject_unshown_change(
     paged_file_repo,
     monkeypatch,
@@ -833,6 +1066,7 @@ def test_omitted_file_line_actions_reject_unshown_change(
     with pytest.raises(CommandError, match="not valid from the current file review"):
         line_command(unshown_spec, file="")
 
+
 def test_explicit_include_file_line_from_review_clears_review_state(paged_file_repo, monkeypatch, capsys):
     _force_one_change_per_page(monkeypatch)
     command_show(file="file.txt", page="1")
@@ -845,6 +1079,7 @@ def test_explicit_include_file_line_from_review_clears_review_state(paged_file_r
 
     assert read_last_file_review_state() is None
 
+
 def test_explicit_skip_file_line_from_review_clears_review_state(paged_file_repo, monkeypatch, capsys):
     _force_one_change_per_page(monkeypatch)
     command_show(file="file.txt", page="1")
@@ -856,6 +1091,7 @@ def test_explicit_skip_file_line_from_review_clears_review_state(paged_file_repo
     command_skip_line(line_spec, file="file.txt")
 
     assert read_last_file_review_state() is None
+
 
 def test_explicit_discard_file_line_from_review_clears_review_state(paged_file_repo, monkeypatch, capsys):
     _force_one_change_per_page(monkeypatch)
@@ -877,7 +1113,6 @@ def test_explicit_discard_file_line_from_review_clears_review_state(paged_file_r
         lambda file_path: command_discard_file_as("replacement\n", file=file_path),
     ],
 )
-
 def test_explicit_file_as_from_review_clears_matching_review_state(
     paged_file_repo,
     monkeypatch,
@@ -892,6 +1127,7 @@ def test_explicit_file_as_from_review_clears_matching_review_state(
     replace_file("file.txt")
 
     assert read_last_file_review_state() is None
+
 
 def test_explicit_discard_to_batch_line_as_from_review_clears_matching_review_state(
     paged_file_repo,
@@ -915,6 +1151,7 @@ def test_explicit_discard_to_batch_line_as_from_review_clears_matching_review_st
 
     assert read_last_file_review_state() is None
 
+
 def test_explicit_skip_line_on_different_file_clears_previous_review_state(
     paged_file_repo,
     monkeypatch,
@@ -930,6 +1167,7 @@ def test_explicit_skip_line_on_different_file_clears_previous_review_state(
 
     assert read_last_file_review_state() is None
 
+
 def test_explicit_discard_line_on_different_file_clears_previous_review_state(
     paged_file_repo,
     monkeypatch,
@@ -944,157 +1182,24 @@ def test_explicit_discard_line_on_different_file_clears_previous_review_state(
     command_discard_line("1", file="other.txt")
 
     assert read_last_file_review_state() is None
-def test_non_selectable_batch_preview_preserves_partial_review_guard(
-    paged_file_repo,
-    monkeypatch,
-    capsys,
-):
+
+
+def test_show_file_opens_near_selected_hunk_by_line_span(paged_file_repo, monkeypatch, capsys):
     _force_one_change_per_page(monkeypatch)
-    _create_multi_file_batch(paged_file_repo)
-    command_show_from_batch("cleanup", file="file.txt", page="1")
+    command_show()
     capsys.readouterr()
-    state = read_last_file_review_state()
-    assert state is not None
-    assert state.entire_file_shown is False
-
-    command_show_from_batch("cleanup", file="other.txt", selectable=False)
+    command_skip()
     capsys.readouterr()
 
-    preserved_state = read_last_file_review_state()
-    assert preserved_state is not None
-    assert preserved_state.file_path == "file.txt"
-    with pytest.raises(CommandError, match="Only pages 1 of 3"):
-        command_include_from_batch("cleanup")
-
-def test_show_from_batch_invalid_page_does_not_select_batch_file(paged_batch_repo, monkeypatch, capsys):
-    _force_one_change_per_page(monkeypatch)
-    capsys.readouterr()
-    before_kind = read_selected_change_kind()
-    before_file = get_selected_change_file_path()
-
-    with pytest.raises(CommandError, match="Available pages: 1-3"):
-        command_show_from_batch("cleanup", file="file.txt", page="99")
-
-    assert read_selected_change_kind() == before_kind
-    assert get_selected_change_file_path() == before_file
-    assert read_last_file_review_state() is None
-
-def test_show_from_batch_invalid_line_does_not_select_batch_file(paged_batch_repo, monkeypatch, capsys):
-    _force_one_change_per_page(monkeypatch)
-    command_show(file="file.txt", page="1")
-    capsys.readouterr()
-    before_kind = read_selected_change_kind()
-    before_file = get_selected_change_file_path()
-    before_state = read_last_file_review_state()
-    assert before_kind == SelectedChangeKind.FILE
-    assert before_file == "file.txt"
-    assert before_state is not None
-
-    with pytest.raises(CommandError, match="Line ID 999 is not available"):
-        command_show_from_batch("cleanup", file="file.txt", line_ids="999")
-
-    assert read_selected_change_kind() == before_kind
-    assert get_selected_change_file_path() == before_file
-    assert read_last_file_review_state() == before_state
-
-def test_show_from_empty_batch_preserves_partial_batch_review_guard(
-    paged_batch_repo,
-    monkeypatch,
-    capsys,
-):
-    _force_one_change_per_page(monkeypatch)
-    command_show_from_batch("cleanup", file="file.txt", page="1")
-    capsys.readouterr()
-    state = read_last_file_review_state()
-    assert state is not None
-
-    create_batch("empty")
-    command_show_from_batch("empty")
-    capsys.readouterr()
-
-    assert read_last_file_review_state() == state
-    with pytest.raises(CommandError, match="Only pages 1 of 3"):
-        command_include_from_batch("cleanup")
-
-def test_include_from_batch_refuses_after_navigational_batch_file_list(paged_file_repo, capsys):
-    _create_multi_file_batch(paged_file_repo)
-    capsys.readouterr()
-
-    command_show_from_batch("cleanup")
-    capsys.readouterr()
-
-    with pytest.raises(CommandError, match="last command only showed files"):
-        command_include_from_batch("cleanup")
-
-    result = subprocess.run(["git", "diff", "--cached", "--quiet"], check=False)
-    assert result.returncode == 0
-
-def test_live_file_list_does_not_block_unrelated_batch_action(paged_file_repo, capsys):
-    command_start()
-    command_include_to_batch("cleanup", file="file.txt", quiet=True)
-    _add_second_changed_file(paged_file_repo)
-    capsys.readouterr()
-
-    command_show_file_list(["file.txt", "other.txt"])
-    capsys.readouterr()
-
-    command_include_from_batch("cleanup")
+    command_show(file="file.txt")
 
     captured = capsys.readouterr()
-    assert "Staged changes from batch 'cleanup'" in captured.err
-    result = subprocess.run(
-        ["git", "diff", "--cached", "--name-only"],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    assert result.stdout.splitlines() == ["file.txt"]
+    assert "Showing page 2 of 3" in captured.out
+    assert "Showing the area around the change you were viewing." in captured.out
+    state = read_last_file_review_state()
+    assert state is not None
+    assert state.shown_pages == (2,)
 
-def test_legacy_file_list_marker_does_not_block_batch_action(paged_file_repo, capsys):
-    command_start()
-    command_include_to_batch("cleanup", file="file.txt", quiet=True)
-    capsys.readouterr()
-    get_selected_change_clear_reason_file_path().write_text("file-list")
-
-    command_include_from_batch("cleanup")
-
-    result = subprocess.run(
-        ["git", "diff", "--cached", "--name-only"],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    assert result.stdout.splitlines() == ["file.txt"]
-
-def test_discard_from_batch_refuses_after_navigational_batch_file_list(paged_file_repo, capsys):
-    _create_multi_file_batch(paged_file_repo)
-    capsys.readouterr()
-    original_file = (paged_file_repo / "file.txt").read_text()
-    original_other = (paged_file_repo / "other.txt").read_text()
-
-    command_show_from_batch("cleanup")
-    capsys.readouterr()
-
-    with pytest.raises(CommandError, match="last command only showed files"):
-        command_discard_from_batch("cleanup")
-
-    assert (paged_file_repo / "file.txt").read_text() == original_file
-    assert (paged_file_repo / "other.txt").read_text() == original_other
-
-def test_apply_from_batch_refuses_after_navigational_batch_file_list(paged_file_repo, capsys):
-    _create_multi_file_batch(paged_file_repo)
-    capsys.readouterr()
-    original_file = (paged_file_repo / "file.txt").read_text()
-    original_other = (paged_file_repo / "other.txt").read_text()
-
-    command_show_from_batch("cleanup")
-    capsys.readouterr()
-
-    with pytest.raises(CommandError, match="last command only showed files"):
-        command_apply_from_batch("cleanup")
-
-    assert (paged_file_repo / "file.txt").read_text() == original_file
-    assert (paged_file_repo / "other.txt").read_text() == original_other
 
 def test_show_from_batch_file_page_uses_gutter_ids_in_output_and_state(paged_batch_repo, monkeypatch, capsys):
     _force_one_change_per_page(monkeypatch)
@@ -1119,6 +1224,7 @@ def test_show_from_batch_file_page_uses_gutter_ids_in_output_and_state(paged_bat
     assert "git-stage-batch include --from cleanup --line" in captured.out
     assert "git-stage-batch discard --from cleanup --line" in captured.out
 
+
 def test_pathless_include_from_batch_accepts_same_batch_review_selection(paged_batch_repo, monkeypatch, capsys):
     _force_one_change_per_page(monkeypatch)
     command_show_from_batch("cleanup", file="file.txt", page="1")
@@ -1136,6 +1242,7 @@ def test_pathless_include_from_batch_accepts_same_batch_review_selection(paged_b
 
     with pytest.raises(CommandError, match="not valid from the current file review"):
         command_include_from_batch("cleanup", line_ids=unshown_spec)
+
 
 def test_pathless_include_from_batch_uses_reviewed_file_in_multi_file_batch(
     paged_file_repo,
@@ -1157,6 +1264,7 @@ def test_pathless_include_from_batch_uses_reviewed_file_in_multi_file_batch(
     assert "Staged selected lines from batch 'cleanup'" in captured.err
     assert read_last_file_review_state() is not None
 
+
 def test_pathless_live_line_after_full_batch_review_refuses_with_batch_help(paged_batch_repo, monkeypatch, capsys):
     _force_one_change_per_page(monkeypatch)
     command_show_from_batch("cleanup", file="file.txt", page="all")
@@ -1177,7 +1285,6 @@ def test_pathless_live_line_after_full_batch_review_refuses_with_batch_help(page
         lambda: command_discard_line("1", file=""),
     ],
 )
-
 def test_live_default_file_line_actions_after_batch_review_refuse(
     paged_batch_repo,
     monkeypatch,
@@ -1198,7 +1305,6 @@ def test_live_default_file_line_actions_after_batch_review_refuse(
     "file_command",
     [command_include_file, command_skip_file, command_discard_file],
 )
-
 def test_live_default_file_actions_after_batch_review_refuse(
     paged_batch_repo,
     monkeypatch,
@@ -1224,7 +1330,6 @@ def test_live_default_file_actions_after_batch_review_refuse(
         lambda: command_discard_file_as("replacement\n", file=""),
     ],
 )
-
 def test_live_default_file_as_actions_after_batch_review_refuse(
     paged_batch_repo,
     monkeypatch,
@@ -1242,6 +1347,7 @@ def test_live_default_file_as_actions_after_batch_review_refuse(
     assert "came from batch 'cleanup', not the live working tree" in exc_info.value.message
     assert (paged_batch_repo / "file.txt").read_text() == original_content
 
+
 def test_pathless_live_line_after_filtered_batch_show_refuses_before_stale_snapshot(
     paged_batch_repo,
     capsys,
@@ -1255,6 +1361,7 @@ def test_pathless_live_line_after_filtered_batch_show_refuses_before_stale_snaps
 
     assert "came from batch 'cleanup', not the live working tree" in exc_info.value.message
     assert "Cached hunk is stale" not in exc_info.value.message
+
 
 def test_bare_include_from_batch_after_filtered_file_show_does_not_widen_to_whole_batch(
     paged_file_repo,
@@ -1285,6 +1392,7 @@ def test_bare_include_from_batch_after_filtered_file_show_does_not_widen_to_whol
     ).stdout.splitlines()
     assert staged_files == []
 
+
 def test_filtered_batch_show_state_only_allows_displayed_selection(
     paged_batch_repo,
     capsys,
@@ -1308,6 +1416,48 @@ def test_filtered_batch_show_state_only_allows_displayed_selection(
     "file_command",
     [command_include_file, command_skip_file, command_discard_file],
 )
+def test_default_file_actions_refuse_after_partial_live_file_review(
+    paged_file_repo,
+    monkeypatch,
+    capsys,
+    file_command,
+):
+    _force_one_change_per_page(monkeypatch)
+    original_content = (paged_file_repo / "file.txt").read_text()
+    command_show(file="file.txt", page="1")
+    capsys.readouterr()
+
+    with pytest.raises(CommandError) as exc_info:
+        file_command("")
+
+    assert "Only pages 1 of 3 of file.txt were shown" in exc_info.value.message
+    assert (paged_file_repo / "file.txt").read_text() == original_content
+
+
+@pytest.mark.parametrize(
+    "as_command",
+    [
+        lambda: command_include_file_as("replacement\n", file=""),
+        lambda: command_discard_file_as("replacement\n", file=""),
+    ],
+)
+def test_default_file_as_actions_refuse_after_partial_live_file_review(
+    paged_file_repo,
+    monkeypatch,
+    capsys,
+    as_command,
+):
+    _force_one_change_per_page(monkeypatch)
+    original_content = (paged_file_repo / "file.txt").read_text()
+    command_show(file="file.txt", page="1")
+    capsys.readouterr()
+
+    with pytest.raises(CommandError) as exc_info:
+        as_command()
+
+    assert "Only pages 1 of 3 of file.txt were shown" in exc_info.value.message
+    assert (paged_file_repo / "file.txt").read_text() == original_content
+
 
 def test_live_hunk_only_command_after_batch_review_refuses_without_clearing_state(
     paged_batch_repo,
@@ -1325,6 +1475,7 @@ def test_live_hunk_only_command_after_batch_review_refuses_without_clearing_stat
     assert read_selected_change_kind() == SelectedChangeKind.BATCH_FILE
     assert read_last_file_review_state() is not None
 
+
 def test_bare_include_to_batch_after_full_batch_review_refuses_with_batch_help(
     paged_batch_repo,
     monkeypatch,
@@ -1339,6 +1490,7 @@ def test_bare_include_to_batch_after_full_batch_review_refuses_with_batch_help(
 
     assert "came from batch 'cleanup', not the live working tree" in exc_info.value.message
     assert "Batch reviews do not support this action" in exc_info.value.message
+
 
 def test_bare_discard_to_batch_after_full_batch_review_refuses_with_batch_help(
     paged_batch_repo,
@@ -1355,6 +1507,7 @@ def test_bare_discard_to_batch_after_full_batch_review_refuses_with_batch_help(
     assert "came from batch 'cleanup', not the live working tree" in exc_info.value.message
     assert "Batch reviews do not support this action" in exc_info.value.message
 
+
 def test_explicit_empty_file_discard_to_batch_after_batch_review_uses_selected_file(
     paged_batch_repo,
     monkeypatch,
@@ -1368,6 +1521,7 @@ def test_explicit_empty_file_discard_to_batch_after_batch_review_uses_selected_f
 
     metadata = read_batch_metadata("later")
     assert list(metadata.get("files", {}).keys()) == ["file.txt"]
+
 
 def test_bare_include_from_batch_refuses_after_partial_batch_review(
     paged_batch_repo,
@@ -1385,6 +1539,7 @@ def test_bare_include_from_batch_refuses_after_partial_batch_review(
     assert "git-stage-batch include --from cleanup --file file.txt" in exc_info.value.message
     result = subprocess.run(["git", "diff", "--cached", "--quiet"], check=False)
     assert result.returncode == 0
+
 
 def test_bare_discard_from_batch_refuses_after_partial_batch_review(
     paged_batch_repo,
@@ -1413,6 +1568,50 @@ def test_bare_discard_from_batch_refuses_after_partial_batch_review(
         lambda: command_reset_from_batch("cleanup", file=""),
     ],
 )
+def test_default_batch_file_actions_refuse_after_partial_batch_review(
+    paged_batch_repo,
+    monkeypatch,
+    capsys,
+    batch_file_action,
+):
+    _force_one_change_per_page(monkeypatch)
+    command_show_from_batch("cleanup", file="file.txt", page="1")
+    capsys.readouterr()
+    original_content = (paged_batch_repo / "file.txt").read_text()
+
+    with pytest.raises(CommandError) as exc_info:
+        batch_file_action()
+
+    assert "Only pages 1 of 3 of file.txt were shown" in exc_info.value.message
+    assert (paged_batch_repo / "file.txt").read_text() == original_content
+    assert "file.txt" in read_batch_metadata("cleanup").get("files", {})
+
+
+@pytest.mark.parametrize(
+    "batch_file_action",
+    [
+        lambda: command_include_from_batch("cleanup", file=""),
+        lambda: command_discard_from_batch("cleanup", file=""),
+        lambda: command_apply_from_batch("cleanup", file=""),
+        lambda: command_reset_from_batch("cleanup", file=""),
+    ],
+)
+def test_default_batch_file_actions_refuse_after_batch_file_list(
+    paged_file_repo,
+    capsys,
+    batch_file_action,
+):
+    _create_multi_file_batch(paged_file_repo)
+    capsys.readouterr()
+    command_show_from_batch("cleanup")
+    capsys.readouterr()
+
+    with pytest.raises(CommandError, match="last command only showed files"):
+        batch_file_action()
+
+    metadata = read_batch_metadata("cleanup")
+    assert set(metadata.get("files", {})) == {"file.txt", "other.txt"}
+
 
 def test_bare_include_from_batch_after_full_single_file_review_uses_reviewed_file(
     paged_file_repo,
@@ -1435,6 +1634,7 @@ def test_bare_include_from_batch_after_full_single_file_review_uses_reviewed_fil
     )
     assert result.stdout.splitlines() == ["file.txt"]
 
+
 def test_bare_discard_from_batch_after_full_single_file_review_uses_reviewed_file(
     paged_file_repo,
     monkeypatch,
@@ -1450,6 +1650,7 @@ def test_bare_discard_from_batch_after_full_single_file_review_uses_reviewed_fil
 
     assert "line 2 changed" not in (paged_file_repo / "file.txt").read_text()
     assert (paged_file_repo / "other.txt").read_text() == "other 1\nother changed\n"
+
 
 def test_bare_apply_from_batch_after_full_single_file_review_uses_reviewed_file(
     paged_file_repo,
@@ -1467,6 +1668,24 @@ def test_bare_apply_from_batch_after_full_single_file_review_uses_reviewed_file(
 
     assert "line 2 changed" in (paged_file_repo / "file.txt").read_text()
     assert (paged_file_repo / "other.txt").read_text() == "other 1\nother 2\n"
+
+
+def test_bare_reset_from_batch_after_full_single_file_review_uses_reviewed_file(
+    paged_file_repo,
+    monkeypatch,
+    capsys,
+):
+    _force_one_change_per_page(monkeypatch)
+    _create_multi_file_batch(paged_file_repo)
+    capsys.readouterr()
+    command_show_from_batch("cleanup", file="file.txt", page="all")
+    capsys.readouterr()
+
+    command_reset_from_batch("cleanup")
+
+    metadata = read_batch_metadata("cleanup")
+    assert set(metadata.get("files", {})) == {"other.txt"}
+
 
 def test_pathless_include_from_batch_refuses_when_rerendered_batch_diff_changes(
     paged_batch_repo,
@@ -1508,6 +1727,7 @@ def test_pathless_include_from_batch_refuses_when_rerendered_batch_diff_changes(
     with pytest.raises(CommandError, match="no longer matches"):
         command_include_from_batch("cleanup", line_ids=line_spec)
 
+
 def test_pathless_discard_from_batch_accepts_same_batch_review_selection(paged_batch_repo, monkeypatch, capsys):
     _force_one_change_per_page(monkeypatch)
     command_show_from_batch("cleanup", file="file.txt", page="1")
@@ -1521,6 +1741,7 @@ def test_pathless_discard_from_batch_accepts_same_batch_review_selection(paged_b
     captured = capsys.readouterr()
     assert "Discarded selected lines from batch 'cleanup'" in captured.err
     assert read_last_file_review_state() is not None
+
 
 def test_pathless_discard_from_batch_uses_reviewed_file_in_multi_file_batch(
     paged_file_repo,
@@ -1541,6 +1762,7 @@ def test_pathless_discard_from_batch_uses_reviewed_file_in_multi_file_batch(
     captured = capsys.readouterr()
     assert "Discarded selected lines from batch 'cleanup'" in captured.err
     assert read_last_file_review_state() is not None
+
 
 def test_pathless_apply_from_batch_uses_reviewed_file_in_multi_file_batch(
     paged_file_repo,
@@ -1564,146 +1786,6 @@ def test_pathless_apply_from_batch_uses_reviewed_file_in_multi_file_batch(
     assert "line 2 changed" in (paged_file_repo / "file.txt").read_text()
     assert (paged_file_repo / "other.txt").read_text() == "other 1\nother 2\n"
 
-def test_explicit_batch_file_line_actions_reject_unshown_review_selection(
-    paged_batch_repo,
-    monkeypatch,
-    capsys,
-    batch_command,
-):
-    _force_one_change_per_page(monkeypatch)
-    command_show_from_batch("cleanup", file="file.txt", page="1")
-    capsys.readouterr()
-    state = read_last_file_review_state()
-    assert state is not None
-    assert len(state.selections) > 1
-    unshown_spec = format_line_ids(list(state.selections[1].display_ids))
-
-    with pytest.raises(CommandError, match="not valid from the current file review"):
-        batch_command("cleanup", line_ids=unshown_spec, file="file.txt")
-
-def test_explicit_include_from_batch_file_line_as_rejects_unshown_review_selection(
-    paged_batch_repo,
-    monkeypatch,
-    capsys,
-):
-    _force_one_change_per_page(monkeypatch)
-    command_show_from_batch("cleanup", file="file.txt", page="1")
-    capsys.readouterr()
-    state = read_last_file_review_state()
-    assert state is not None
-    assert len(state.selections) > 1
-    unshown_spec = format_line_ids(list(state.selections[1].display_ids))
-
-    with pytest.raises(CommandError, match="not valid from the current file review"):
-        command_include_from_batch(
-            "cleanup",
-            line_ids=unshown_spec,
-            file="file.txt",
-            replacement_text="replacement\n",
-        )
-
-def test_pathless_include_from_other_batch_after_batch_review_refuses(paged_batch_repo, monkeypatch, capsys):
-    _force_one_change_per_page(monkeypatch)
-    command_show_from_batch("cleanup", file="file.txt", page="1")
-    capsys.readouterr()
-    state = read_last_file_review_state()
-    assert state is not None
-    line_spec = format_line_ids(list(state.selections[0].display_ids))
-
-    with pytest.raises(CommandError, match="no longer matches"):
-        command_include_from_batch("other-batch", line_ids=line_spec)
-
-def test_pathless_include_from_other_batch_after_full_batch_review_refuses(paged_batch_repo, monkeypatch, capsys):
-    _force_one_change_per_page(monkeypatch)
-    command_show_from_batch("cleanup", file="file.txt", page="all")
-    capsys.readouterr()
-    state = read_last_file_review_state()
-    assert state is not None
-    assert state.entire_file_shown is True
-    line_spec = format_line_ids(list(state.selections[0].display_ids))
-
-    with pytest.raises(CommandError, match="no longer matches"):
-        command_include_from_batch("other-batch", line_ids=line_spec)
-def test_reset_from_batch_refuses_after_navigational_batch_file_list(paged_file_repo, capsys):
-    _create_multi_file_batch(paged_file_repo)
-    capsys.readouterr()
-
-    command_show_from_batch("cleanup")
-    capsys.readouterr()
-
-    with pytest.raises(CommandError, match="last command only showed files"):
-        command_reset_from_batch("cleanup")
-
-    metadata = read_batch_metadata("cleanup")
-    assert set(metadata.get("files", {})) == {"file.txt", "other.txt"}
-
-@pytest.mark.parametrize(
-    "batch_file_action",
-    [
-        lambda: command_include_from_batch("cleanup", file=""),
-        lambda: command_discard_from_batch("cleanup", file=""),
-        lambda: command_apply_from_batch("cleanup", file=""),
-        lambda: command_reset_from_batch("cleanup", file=""),
-    ],
-)
-def test_default_batch_file_actions_refuse_after_partial_batch_review(
-    paged_batch_repo,
-    monkeypatch,
-    capsys,
-    batch_file_action,
-):
-    _force_one_change_per_page(monkeypatch)
-    command_show_from_batch("cleanup", file="file.txt", page="1")
-    capsys.readouterr()
-    original_content = (paged_batch_repo / "file.txt").read_text()
-
-    with pytest.raises(CommandError) as exc_info:
-        batch_file_action()
-
-    assert "Only pages 1 of 3 of file.txt were shown" in exc_info.value.message
-    assert (paged_batch_repo / "file.txt").read_text() == original_content
-    assert "file.txt" in read_batch_metadata("cleanup").get("files", {})
-
-@pytest.mark.parametrize(
-    "batch_file_action",
-    [
-        lambda: command_include_from_batch("cleanup", file=""),
-        lambda: command_discard_from_batch("cleanup", file=""),
-        lambda: command_apply_from_batch("cleanup", file=""),
-        lambda: command_reset_from_batch("cleanup", file=""),
-    ],
-)
-def test_default_batch_file_actions_refuse_after_batch_file_list(
-    paged_file_repo,
-    capsys,
-    batch_file_action,
-):
-    _create_multi_file_batch(paged_file_repo)
-    capsys.readouterr()
-    command_show_from_batch("cleanup")
-    capsys.readouterr()
-
-    with pytest.raises(CommandError, match="last command only showed files"):
-        batch_file_action()
-
-    metadata = read_batch_metadata("cleanup")
-    assert set(metadata.get("files", {})) == {"file.txt", "other.txt"}
-
-def test_bare_reset_from_batch_after_full_single_file_review_uses_reviewed_file(
-    paged_file_repo,
-    monkeypatch,
-    capsys,
-):
-    _force_one_change_per_page(monkeypatch)
-    _create_multi_file_batch(paged_file_repo)
-    capsys.readouterr()
-    command_show_from_batch("cleanup", file="file.txt", page="all")
-    capsys.readouterr()
-
-    command_reset_from_batch("cleanup")
-
-    metadata = read_batch_metadata("cleanup")
-    assert set(metadata.get("files", {})) == {"other.txt"}
 
 def test_pathless_reset_from_batch_uses_reviewed_file_in_multi_file_batch(
     paged_file_repo,
@@ -1726,6 +1808,7 @@ def test_pathless_reset_from_batch_uses_reviewed_file_in_multi_file_batch(
     metadata = read_batch_metadata("cleanup")
     assert set(metadata.get("files", {})) == {"file.txt", "other.txt"}
 
+
 def test_explicit_reset_from_batch_rejects_unshown_review_selection(
     paged_batch_repo,
     monkeypatch,
@@ -1744,6 +1827,106 @@ def test_explicit_reset_from_batch_rejects_unshown_review_selection(
 
     metadata = read_batch_metadata("cleanup")
     assert "file.txt" in metadata.get("files", {})
+
+
+@pytest.mark.parametrize(
+    "batch_command",
+    [
+        command_include_from_batch,
+        command_apply_from_batch,
+        command_discard_from_batch,
+    ],
+)
+def test_explicit_batch_file_line_actions_reject_unshown_review_selection(
+    paged_batch_repo,
+    monkeypatch,
+    capsys,
+    batch_command,
+):
+    _force_one_change_per_page(monkeypatch)
+    command_show_from_batch("cleanup", file="file.txt", page="1")
+    capsys.readouterr()
+    state = read_last_file_review_state()
+    assert state is not None
+    assert len(state.selections) > 1
+    unshown_spec = format_line_ids(list(state.selections[1].display_ids))
+
+    with pytest.raises(CommandError, match="not valid from the current file review"):
+        batch_command("cleanup", line_ids=unshown_spec, file="file.txt")
+
+
+def test_explicit_include_from_batch_file_line_as_rejects_unshown_review_selection(
+    paged_batch_repo,
+    monkeypatch,
+    capsys,
+):
+    _force_one_change_per_page(monkeypatch)
+    command_show_from_batch("cleanup", file="file.txt", page="1")
+    capsys.readouterr()
+    state = read_last_file_review_state()
+    assert state is not None
+    assert len(state.selections) > 1
+    unshown_spec = format_line_ids(list(state.selections[1].display_ids))
+
+    with pytest.raises(CommandError, match="not valid from the current file review"):
+        command_include_from_batch(
+            "cleanup",
+            line_ids=unshown_spec,
+            file="file.txt",
+            replacement_text="replacement\n",
+        )
+
+
+def test_pathless_include_from_other_batch_after_batch_review_refuses(paged_batch_repo, monkeypatch, capsys):
+    _force_one_change_per_page(monkeypatch)
+    command_show_from_batch("cleanup", file="file.txt", page="1")
+    capsys.readouterr()
+    state = read_last_file_review_state()
+    assert state is not None
+    line_spec = format_line_ids(list(state.selections[0].display_ids))
+
+    with pytest.raises(CommandError, match="no longer matches"):
+        command_include_from_batch("other-batch", line_ids=line_spec)
+
+
+def test_pathless_include_from_other_batch_after_full_batch_review_refuses(paged_batch_repo, monkeypatch, capsys):
+    _force_one_change_per_page(monkeypatch)
+    command_show_from_batch("cleanup", file="file.txt", page="all")
+    capsys.readouterr()
+    state = read_last_file_review_state()
+    assert state is not None
+    assert state.entire_file_shown is True
+    line_spec = format_line_ids(list(state.selections[0].display_ids))
+
+    with pytest.raises(CommandError, match="no longer matches"):
+        command_include_from_batch("other-batch", line_ids=line_spec)
+
+
+def test_show_from_batch_file_defaults_to_page_review_and_persists_state(paged_batch_repo, monkeypatch, capsys):
+    _force_one_change_per_page(monkeypatch)
+
+    command_show_from_batch("cleanup", file="file.txt")
+
+    captured = capsys.readouterr()
+    assert "Changes: batch cleanup" in captured.out
+    assert "Showing page 1 of 3" in captured.out
+    state = read_last_file_review_state()
+    assert state is not None
+    assert state.source == "batch"
+    assert state.shown_pages == (1,)
+
+
+def test_plain_show_ignores_corrupt_previous_line_state(paged_file_repo, capsys):
+    command_start()
+    capsys.readouterr()
+    get_line_changes_json_file_path().write_text("{ not json")
+
+    command_show()
+
+    captured = capsys.readouterr()
+    assert "file.txt" in captured.out
+
+
 def test_start_clears_batch_review_state_left_outside_session(paged_batch_repo, monkeypatch, capsys):
     _force_one_change_per_page(monkeypatch)
     command_stop()
@@ -1769,3 +1952,422 @@ def test_start_clears_batch_review_state_left_outside_session(paged_batch_repo, 
 
     captured = capsys.readouterr()
     assert "Included line(s): 1" in captured.err
+
+
+def test_batch_review_model_keeps_unselectable_changed_rows(capsys):
+    line_changes = LineLevelChange(
+        path="file.txt",
+        header=HunkHeader(old_start=1, old_len=1, new_start=1, new_len=1),
+        lines=[
+            LineEntry(
+                id=10,
+                kind="+",
+                old_line_number=None,
+                new_line_number=1,
+                text_bytes=b"unmergeable\n",
+                text="unmergeable\n",
+            ),
+        ],
+    )
+
+    model = build_file_review_model(line_changes, gutter_to_selection_id={})
+
+    assert len(model.changes) == 1
+    assert model.changes[0].display_ids == ()
+    assert model.changes[0].selection_ids == (10,)
+
+    print_file_review(
+        model,
+        shown_pages=(1,),
+        source_label="Localized batch label",
+        page_spec="all",
+        command_source_args=" --from cleanup",
+        source=ReviewSource.BATCH,
+        batch_name="cleanup",
+    )
+
+    captured = capsys.readouterr()
+    assert "not currently selectable" in captured.out
+    assert "unmergeable" in captured.out
+
+
+def test_batch_review_model_splits_visible_runs_around_hidden_rows(capsys):
+    line_changes = LineLevelChange(
+        path="file.txt",
+        header=HunkHeader(old_start=1, old_len=0, new_start=1, new_len=3),
+        lines=[
+            LineEntry(
+                id=10,
+                kind="+",
+                old_line_number=None,
+                new_line_number=1,
+                text_bytes=b"first\n",
+                text="first\n",
+            ),
+            LineEntry(
+                id=11,
+                kind="+",
+                old_line_number=None,
+                new_line_number=2,
+                text_bytes=b"hidden\n",
+                text="hidden\n",
+            ),
+            LineEntry(
+                id=12,
+                kind="+",
+                old_line_number=None,
+                new_line_number=3,
+                text_bytes=b"third\n",
+                text="third\n",
+            ),
+        ],
+    )
+
+    model = build_file_review_model(line_changes, gutter_to_selection_id={1: 10, 2: 12})
+
+    assert [change.display_ids for change in model.changes] == [(1,), (), (2,)]
+
+    print_file_review(
+        model,
+        shown_pages=(1,),
+        source_label="Localized batch label",
+        page_spec="all",
+        command_source_args=" --from cleanup",
+        source=ReviewSource.BATCH,
+        batch_name="cleanup",
+    )
+
+    captured = capsys.readouterr()
+    assert "Change 1 of 3 · select: --line 1" in captured.out
+    assert "Change 2 of 3 · not currently selectable" in captured.out
+    assert "Change 3 of 3 · select: --line 2" in captured.out
+    hidden_rows = [
+        line
+        for line in captured.out.splitlines()
+        if "hidden" in line
+    ]
+    assert hidden_rows
+    assert all("[#" not in line for line in hidden_rows)
+
+
+def test_batch_footer_commands_do_not_depend_on_source_label(capsys):
+    line_changes = LineLevelChange(
+        path="file.txt",
+        header=HunkHeader(old_start=1, old_len=0, new_start=1, new_len=1),
+        lines=[
+            LineEntry(
+                id=10,
+                kind="+",
+                old_line_number=None,
+                new_line_number=1,
+                text_bytes=b"mergeable\n",
+                text="mergeable\n",
+            ),
+        ],
+    )
+    model = build_file_review_model(line_changes, gutter_to_selection_id={1: 10})
+
+    print_file_review(
+        model,
+        shown_pages=(1,),
+        source_label="Localized batch label",
+        page_spec="all",
+        command_source_args=" --from cleanup",
+        source=ReviewSource.BATCH,
+        batch_name="cleanup",
+    )
+
+    captured = capsys.readouterr()
+    assert "git-stage-batch include --from cleanup --line 1" in captured.out
+    assert "git-stage-batch discard --from cleanup --line 1" in captured.out
+
+
+def test_batch_review_does_not_suggest_partial_non_adjacent_atomic_replacement(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    monkeypatch.chdir(tmp_path)
+    subprocess.run(["git", "init"], check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], check=True)
+
+    test_file = tmp_path / "file.txt"
+    test_file.write_text("context\nold later\nanchor\n")
+    subprocess.run(["git", "add", "file.txt"], check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "Initial"], check=True, capture_output=True)
+
+    ensure_state_directory_exists()
+    initialize_abort_state()
+    create_batch("atomic")
+
+    test_file.write_text("new first\ncontext\nanchor\n")
+    add_file_to_batch(
+        "atomic",
+        "file.txt",
+        BatchOwnership(
+            claimed_lines=["1"],
+            deletions=[
+                DeletionClaim(anchor_line=3, content_lines=[b"old later\n"]),
+            ],
+            replacement_units=[
+                ReplacementUnit(claimed_lines=["1"], deletion_indices=[0]),
+            ],
+        ),
+        "100644",
+    )
+    test_file.write_text("context\nold later\nanchor\n")
+
+    command_show_from_batch("atomic", file="file.txt", page="all")
+
+    captured = capsys.readouterr()
+    assert "git-stage-batch include --from atomic --file file.txt --line 1\n" not in captured.out
+    assert "git-stage-batch include --from atomic --file file.txt --line 2\n" not in captured.out
+
+    state = read_last_file_review_state()
+    assert state is not None
+    assert all(set(selection.display_ids) != {1} for selection in state.selections)
+    assert all(set(selection.display_ids) != {2} for selection in state.selections)
+
+    with pytest.raises(CommandError, match="only partly selects|not valid"):
+        command_include_from_batch("atomic", line_ids="1")
+
+
+def test_batch_review_preserves_mergeable_change_next_to_reset_only_change():
+    """Mixed action neighbors should not collapse into one reset-only change."""
+    line_changes = LineLevelChange(
+        path="file.txt",
+        header=HunkHeader(old_start=0, old_len=0, new_start=1, new_len=2),
+        lines=[
+            LineEntry(
+                id=1,
+                kind="+",
+                old_line_number=None,
+                new_line_number=1,
+                text_bytes=b"mergeable",
+                text="mergeable",
+                source_line=1,
+            ),
+            LineEntry(
+                id=2,
+                kind="+",
+                old_line_number=None,
+                new_line_number=2,
+                text_bytes=b"reset only",
+                text="reset only",
+                source_line=2,
+            ),
+        ],
+    )
+    review_action_groups = (
+        ReviewActionGroup(
+            display_ids=(1,),
+            selection_ids=(1,),
+            actions=(
+                FileReviewAction.INCLUDE_FROM_BATCH.value,
+                FileReviewAction.DISCARD_FROM_BATCH.value,
+                FileReviewAction.APPLY_FROM_BATCH.value,
+                FileReviewAction.RESET_FROM_BATCH.value,
+            ),
+        ),
+        ReviewActionGroup(
+            display_ids=(2,),
+            selection_ids=(2,),
+            actions=(FileReviewAction.RESET_FROM_BATCH.value,),
+        ),
+    )
+    model = build_file_review_model(
+        line_changes,
+        gutter_to_selection_id={1: 1, 2: 2},
+        review_action_groups=review_action_groups,
+    )
+    review_state = make_file_review_state(
+        model,
+        source=ReviewSource.BATCH,
+        batch_name="cleanup",
+        shown_pages=(1,),
+        selected_change_kind=SelectedChangeKind.BATCH_FILE,
+        gutter_to_selection_id={1: 1, 2: 2},
+        review_action_groups=review_action_groups,
+    )
+
+    assert shown_complete_review_selection_groups(
+        review_state,
+        FileReviewAction.INCLUDE_FROM_BATCH,
+    ) == [{1}]
+    assert shown_complete_review_selection_groups(
+        review_state,
+        FileReviewAction.RESET_FROM_BATCH,
+    ) == [{1}, {2}]
+
+
+def test_show_from_batch_line_after_review_uses_review_id_space(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    """Filtered show should accept IDs from the last batch review."""
+    monkeypatch.chdir(tmp_path)
+    subprocess.run(["git", "init"], check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], check=True)
+    ensure_state_directory_exists()
+
+    test_file = tmp_path / "file.txt"
+    test_file.write_text("one\ntwo\n")
+    subprocess.run(["git", "add", "file.txt"], check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "Add file"], check=True, capture_output=True)
+    initialize_abort_state()
+
+    test_file.write_text("one changed\ntwo changed\n")
+    create_batch("manual")
+    command_start()
+    add_file_to_batch(
+        "manual",
+        "file.txt",
+        BatchOwnership(claimed_lines=["1", "2"], deletions=[]),
+        "100644",
+    )
+
+    original_render = show_from_module.render_batch_file_display
+
+    def render_with_review_only_first_line(batch_name, file_path, metadata=None):
+        rendered = original_render(batch_name, file_path, metadata=metadata)
+        assert rendered is not None
+        return RenderedBatchDisplay(
+            line_changes=rendered.line_changes,
+            gutter_to_selection_id={1: 2},
+            selection_id_to_gutter={2: 1},
+            actionable_selection_groups=rendered.actionable_selection_groups,
+            review_gutter_to_selection_id={1: 1, 2: 2},
+            review_selection_id_to_gutter={1: 1, 2: 2},
+            review_action_groups=(
+                ReviewActionGroup(
+                    display_ids=(1,),
+                    selection_ids=(1,),
+                    actions=(FileReviewAction.RESET_FROM_BATCH.value,),
+                ),
+                ReviewActionGroup(
+                    display_ids=(2,),
+                    selection_ids=(2,),
+                    actions=(
+                        FileReviewAction.INCLUDE_FROM_BATCH.value,
+                        FileReviewAction.DISCARD_FROM_BATCH.value,
+                        FileReviewAction.APPLY_FROM_BATCH.value,
+                        FileReviewAction.RESET_FROM_BATCH.value,
+                    ),
+                ),
+            ),
+        )
+
+    monkeypatch.setattr(show_from_module, "render_batch_file_display", render_with_review_only_first_line)
+    monkeypatch.setattr(hunk_tracking_module, "render_batch_file_display", render_with_review_only_first_line)
+
+    command_show_from_batch("manual", file="file.txt", page="all")
+    capsys.readouterr()
+
+    command_show_from_batch("manual", file="file.txt", line_ids="2")
+
+    captured = capsys.readouterr()
+    assert "[#2]" in captured.out
+    assert "two" in captured.out
+    assert "one" not in captured.out
+
+
+def test_show_from_batch_line_without_review_uses_printed_review_id_space(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    """Filtered batch show should persist the same IDs it prints."""
+    monkeypatch.chdir(tmp_path)
+    subprocess.run(["git", "init"], check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], check=True)
+    ensure_state_directory_exists()
+
+    test_file = tmp_path / "file.txt"
+    test_file.write_text("one\ntwo\n")
+    subprocess.run(["git", "add", "file.txt"], check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "Add file"], check=True, capture_output=True)
+    initialize_abort_state()
+
+    test_file.write_text("one changed\ntwo changed\n")
+    create_batch("manual")
+    command_start()
+    add_file_to_batch(
+        "manual",
+        "file.txt",
+        BatchOwnership(claimed_lines=["1", "2"], deletions=[]),
+        "100644",
+    )
+    test_file.write_text("one\ntwo\n")
+    capsys.readouterr()
+
+    def render_with_review_only_second_line(batch_name, file_path, metadata=None):
+        line_changes = LineLevelChange(
+            path=file_path,
+            header=HunkHeader(old_start=0, old_len=0, new_start=1, new_len=2),
+            lines=(
+                LineEntry(
+                    id=1,
+                    kind="+",
+                    old_line_number=None,
+                    new_line_number=1,
+                    text_bytes=b"one changed",
+                    text="one changed",
+                ),
+                LineEntry(
+                    id=2,
+                    kind="+",
+                    old_line_number=None,
+                    new_line_number=2,
+                    text_bytes=b"two changed",
+                    text="two changed",
+                ),
+            ),
+        )
+        return RenderedBatchDisplay(
+            line_changes=line_changes,
+            gutter_to_selection_id={1: 2},
+            selection_id_to_gutter={2: 1},
+            actionable_selection_groups=((2,),),
+            review_gutter_to_selection_id={1: 1, 2: 2},
+            review_selection_id_to_gutter={1: 1, 2: 2},
+            review_action_groups=(
+                ReviewActionGroup(
+                    display_ids=(1,),
+                    selection_ids=(1,),
+                    actions=(FileReviewAction.RESET_FROM_BATCH.value,),
+                ),
+                ReviewActionGroup(
+                    display_ids=(2,),
+                    selection_ids=(2,),
+                    actions=(
+                        FileReviewAction.INCLUDE_FROM_BATCH.value,
+                        FileReviewAction.DISCARD_FROM_BATCH.value,
+                        FileReviewAction.APPLY_FROM_BATCH.value,
+                        FileReviewAction.RESET_FROM_BATCH.value,
+                    ),
+                ),
+            ),
+        )
+
+    monkeypatch.setattr(show_from_module, "render_batch_file_display", render_with_review_only_second_line)
+    monkeypatch.setattr(hunk_tracking_module, "render_batch_file_display", render_with_review_only_second_line)
+
+    command_show_from_batch("manual", file="file.txt", line_ids="2")
+
+    captured = capsys.readouterr()
+    assert "[#2]" in captured.out
+    assert "two" in captured.out
+    assert "one" not in captured.out
+
+    state = read_last_file_review_state()
+    assert state is not None
+    assert any(selection.display_ids == (2,) for selection in state.selections)
+
+    command_include_from_batch("manual", line_ids="2")
+
+    captured = capsys.readouterr()
+    assert "Staged selected lines from batch 'manual'" in captured.err

--- a/tests/commands/test_file_scoped_operations.py
+++ b/tests/commands/test_file_scoped_operations.py
@@ -15,7 +15,7 @@ from git_stage_batch.utils.paths import (
     get_selected_hunk_hash_file_path,
     get_selected_hunk_patch_file_path,
 )
-from git_stage_batch.data.hunk_tracking import render_unstaged_file_as_single_hunk
+from git_stage_batch.data.hunk_tracking import read_selected_change_kind, render_unstaged_file_as_single_hunk
 from git_stage_batch.commands.skip import command_skip, command_skip_line
 from git_stage_batch.cli.argument_parser import parse_command_line
 
@@ -287,7 +287,7 @@ class TestShowFileFlag:
             "    helper,",
             ")",
         )
-        beta_ids = ids_for_texts(
+        assert ids_for_texts(
             "from old_beta import helper",
             "from new_beta import helper",
         )
@@ -572,18 +572,25 @@ class TestShowFileFlag:
         assert "change-two" in changed_texts
         assert "change-three" in changed_texts
 
-    def test_show_files_selection_can_feed_include(self, multi_file_repo):
-        """Show --files should leave the final displayed file selected for include."""
+    def test_show_files_outputs_navigation_list_and_clears_selection(self, multi_file_repo, capsys):
+        """Show --files should be navigational, not a hidden selected-file action."""
         command_start()
+        capsys.readouterr()
 
         args = parse_command_line(["show", "--files", "*.txt"], quiet=True)
         assert args is not None
         args.func(args)
 
-        command_include(quiet=True)
-
+        captured = capsys.readouterr()
+        assert "── matched files" in captured.out
+        assert "Changes: file vs HEAD" in captured.out
+        assert "Open:" in captured.out
+        assert "git-stage-batch show --file alpha.txt" in captured.out
+        assert read_selected_change_kind() is None
+        with pytest.raises(CommandError, match="last command only showed files"):
+            command_include(quiet=True)
         result = run_git_command(["diff", "--cached", "--name-only"])
-        assert result.stdout.strip() == "gamma.txt"
+        assert result.stdout == ""
 
     def test_include_files_reports_aggregate_staged_scope(self, multi_file_repo, capsys):
         """Include --files should report the full staged scope once."""
@@ -637,33 +644,36 @@ class TestShowFileFlag:
         result = run_git_command(["diff", "--cached", "--name-only"])
         assert result.stdout.splitlines() == ["alpha.txt", "beta.txt", "gamma.txt"]
 
-    def test_show_files_selection_can_feed_discard(self, multi_file_repo):
-        """Show --files should leave the final displayed file selected for discard."""
+    def test_show_files_does_not_feed_bare_discard(self, multi_file_repo, capsys):
+        """A multi-file file list should not leave a selected file for discard."""
         command_start()
+        capsys.readouterr()
 
         args = parse_command_line(["show", "--files", "*.txt"], quiet=True)
         assert args is not None
         args.func(args)
+        capsys.readouterr()
 
-        command_discard(quiet=True)
-
+        assert read_selected_change_kind() is None
+        with pytest.raises(CommandError, match="last command only showed files"):
+            command_discard(quiet=True)
         assert (multi_file_repo / "alpha.txt").read_text() == "alpha1\nalpha2-modified\nalpha3\nalpha4-new\n"
         assert (multi_file_repo / "beta.txt").read_text() == "beta1\nbeta2-modified\nbeta3\nbeta4-new\n"
-        assert (multi_file_repo / "gamma.txt").read_text() == "gamma1\ngamma2\ngamma3\n"
+        assert (multi_file_repo / "gamma.txt").read_text() == "gamma1\ngamma2-modified\ngamma3\ngamma4-new\n"
 
-    def test_show_files_selection_can_feed_skip(self, multi_file_repo):
-        """Show --files should leave the final displayed file selected for skip."""
+    def test_show_files_does_not_feed_bare_skip(self, multi_file_repo, capsys):
+        """A multi-file file list should not leave a selected file for skip."""
         command_start()
+        capsys.readouterr()
 
         args = parse_command_line(["show", "--files", "*.txt"], quiet=True)
         assert args is not None
         args.func(args)
+        capsys.readouterr()
 
-        command_skip(quiet=True)
-        command_include(quiet=True)
-
-        result = run_git_command(["diff", "--cached", "--name-only"])
-        assert result.stdout.strip() == "alpha.txt"
+        assert read_selected_change_kind() is None
+        with pytest.raises(CommandError, match="last command only showed files"):
+            command_skip(quiet=True)
 
 
 class TestIncludeToBatchWithFile:
@@ -830,16 +840,16 @@ class TestBatchSourceWithFile:
         assert "alpha.txt" not in staged
         assert "gamma.txt" not in staged
 
-    def test_include_from_batch_file_empty_string(self, multi_file_repo):
-        """Include --from BATCH --file (empty) should use first file from batch display."""
+    def test_include_from_batch_file_empty_string_uses_selected_batch_file(self, multi_file_repo):
+        """Include --from BATCH --file (empty) should use a selected batch file."""
         command_start()
         command_include_to_batch("batch", file="alpha.txt")
         command_include_to_batch("batch", file="beta.txt")
 
         subprocess.run(["git", "checkout", "HEAD", "--", "."], check=True, capture_output=True)
 
-        # Show batch to cache first file
-        command_show_from_batch("batch")
+        # Show one batch file to cache an explicit selected file.
+        command_show_from_batch("batch", file="alpha.txt")
 
         # Include with empty string
         command_include_from_batch("batch", file="")
@@ -847,6 +857,19 @@ class TestBatchSourceWithFile:
         # First file (alpha.txt) should be staged
         result = run_git_command(["diff", "--cached", "--name-only"])
         assert "alpha.txt" in result.stdout
+
+    def test_include_from_batch_file_empty_string_after_file_list_fails(self, multi_file_repo):
+        """A multi-file batch file list should not select a hidden batch file."""
+        command_start()
+        command_include_to_batch("batch", file="alpha.txt")
+        command_include_to_batch("batch", file="beta.txt")
+
+        subprocess.run(["git", "checkout", "HEAD", "--", "."], check=True, capture_output=True)
+
+        command_show_from_batch("batch")
+
+        with pytest.raises(CommandError, match="last command only showed files"):
+            command_include_from_batch("batch", file="")
 
     def test_apply_from_batch_with_file(self, multi_file_repo):
         """Apply --from BATCH --file PATH should apply only that file."""
@@ -915,8 +938,8 @@ class TestBatchSourceWithFile:
 class TestMultiFileBatchDisplay:
     """Test displaying multi-file batches with separators."""
 
-    def test_show_from_multi_file_batch_separators(self, multi_file_repo, capsys):
-        """Show --from BATCH with multiple files should show file headers."""
+    def test_show_from_multi_file_batch_list(self, multi_file_repo, capsys):
+        """Show --from BATCH with multiple files should show a navigational file list."""
         command_start()
         capsys.readouterr()  # Clear start's output
         command_include_to_batch("multi", file="alpha.txt")
@@ -926,13 +949,13 @@ class TestMultiFileBatchDisplay:
         command_show_from_batch("multi")
 
         captured = capsys.readouterr()
-        # Should have file headers in standard format
-        assert "alpha.txt :: @@" in captured.out
-        assert "beta.txt :: @@" in captured.out
-        assert "gamma.txt :: @@" in captured.out
+        assert "── matched files" in captured.out
+        assert "Changes: batch multi" in captured.out
+        assert "git-stage-batch show --from multi --file alpha.txt" in captured.out
+        assert read_selected_change_kind() is None
 
-    def test_show_from_multi_file_displays_all_content(self, multi_file_repo, capsys):
-        """Show --from BATCH should display content from all files."""
+    def test_show_from_multi_file_list_summarizes_all_files(self, multi_file_repo, capsys):
+        """Show --from BATCH should summarize every matched file."""
         command_start()
         capsys.readouterr()  # Clear start's output
         command_include_to_batch("all", file="alpha.txt")
@@ -942,10 +965,25 @@ class TestMultiFileBatchDisplay:
         command_show_from_batch("all")
 
         captured = capsys.readouterr()
-        # Should see content from all three files
-        assert "alpha" in captured.out.lower()
-        assert "beta" in captured.out.lower()
-        assert "gamma" in captured.out.lower()
+        assert "alpha.txt" in captured.out
+        assert "beta.txt" in captured.out
+        assert "gamma.txt" in captured.out
+
+    def test_show_from_multi_file_open_command_uses_page_review(self, multi_file_repo, capsys):
+        """Matched-file open commands should route to the page-aware batch review."""
+        command_start()
+        capsys.readouterr()
+        command_include_to_batch("multi", file="alpha.txt")
+        command_include_to_batch("multi", file="beta.txt")
+
+        command_show_from_batch("multi")
+        capsys.readouterr()
+
+        command_show_from_batch("multi", file="alpha.txt")
+
+        captured = capsys.readouterr()
+        assert "Changes: batch multi" in captured.out
+        assert "Showing page 1 of 1" in captured.out
 
     def test_batch_files_maintain_insertion_order(self, multi_file_repo):
         """Files in batch should maintain insertion order, not alphabetical."""
@@ -1569,9 +1607,8 @@ class TestExplicitFilePath:
 
         assert (
             str(exc_info.value)
-            == "Contiguous file-scoped selections cannot span multiple structural change runs "
-            "while selecting only part of one run. Select one run at a time, fully include "
-            "each spanned run, or use --as."
+            == "That line range crosses separate changes while selecting only part of one. "
+            "Select one change at a time, include every line in the range, or use --as."
         )
 
         result = run_git_command(["diff", "--cached", "--name-only"])

--- a/tests/commands/test_include_from.py
+++ b/tests/commands/test_include_from.py
@@ -1,10 +1,5 @@
 """Tests for include from batch command."""
 
-from git_stage_batch.commands.start import command_start
-from git_stage_batch.commands.include import command_include_to_batch
-from unittest.mock import patch, MagicMock
-from git_stage_batch.core.models import LineLevelChange, LineEntry
-
 import stat
 import subprocess
 
@@ -16,7 +11,10 @@ from git_stage_batch.batch.query import read_batch_metadata
 from git_stage_batch.batch.storage import add_file_to_batch
 from git_stage_batch.commands.apply_from import command_apply_from_batch
 from git_stage_batch.commands.discard_from import command_discard_from_batch
+from git_stage_batch.commands.include import command_include_to_batch
 from git_stage_batch.commands.include_from import command_include_from_batch
+from git_stage_batch.commands.show_from import command_show_from_batch
+from git_stage_batch.commands.start import command_start
 from git_stage_batch.data.hunk_tracking import render_batch_file_display
 from git_stage_batch.data.session import initialize_abort_state
 from git_stage_batch.exceptions import CommandError
@@ -113,17 +111,11 @@ class TestCommandIncludeFromBatch:
         (temp_git_repo / "file1.txt").write_text("line 1\nline 2\n")
         (temp_git_repo / "file2.txt").write_text("line A\nline B\n")
 
-        # Mock cached hunk state to make it look like file1.txt is the selected file
-        mock_lines = LineLevelChange(
-            path="file1.txt",
-            header=MagicMock(),  # Mock header (not relevant for this test)
-            lines=[LineEntry(id=1, kind="+", text_bytes=b"file1 added\n", text="file1 added\n", old_line_number=None, new_line_number=3)]
-        )
+        # Show file1 from the batch so --file without PATH reuses that selected file.
+        command_show_from_batch("test-batch", file="file1.txt")
+        capsys.readouterr()
 
-        with patch("git_stage_batch.data.hunk_tracking.require_selected_hunk"):
-            with patch("git_stage_batch.data.line_state.load_line_changes_from_state", return_value=mock_lines):
-                # Use --file mode to stage from batch (should only stage file1)
-                command_include_from_batch("test-batch", file="")
+        command_include_from_batch("test-batch", file="")
 
         # Verify only file1 is staged (not file2)
         result = run_git_command(["diff", "--cached", "--name-only"])

--- a/tests/commands/test_include_to.py
+++ b/tests/commands/test_include_to.py
@@ -3,8 +3,11 @@
 from git_stage_batch.commands.include import command_include_to_batch
 from git_stage_batch.commands.again import command_again
 from git_stage_batch.batch import list_batch_files, read_file_from_batch
+from git_stage_batch.batch.query import read_batch_metadata
 from git_stage_batch.batch.validation import batch_exists
+from git_stage_batch.data.session import initialize_abort_state
 from git_stage_batch.exceptions import NoMoreHunks
+from git_stage_batch.utils.paths import ensure_state_directory_exists
 
 import subprocess
 
@@ -169,6 +172,44 @@ class TestCommandIncludeToBatch:
             text=True
         )
         assert result.stdout == ""
+
+    def test_include_empty_added_text_file_to_batch(self, temp_git_repo):
+        """Whole-file include to batch should persist empty added text files."""
+        empty_file = temp_git_repo / "empty.txt"
+        empty_file.write_bytes(b"")
+
+        command_start(quiet=True)
+        command_include_to_batch("empty-batch", file="empty.txt", quiet=True)
+
+        file_meta = read_batch_metadata("empty-batch")["files"]["empty.txt"]
+        assert file_meta["change_type"] == "added"
+        assert read_file_from_batch("empty-batch", "empty.txt") == ""
+        assert empty_file.exists()
+
+        command_again(quiet=True)
+        with pytest.raises(NoMoreHunks):
+            fetch_next_change()
+
+    def test_include_empty_deleted_text_file_to_batch(self, temp_git_repo):
+        """Whole-file include to batch should persist empty text deletions."""
+        empty_file = temp_git_repo / "empty.txt"
+        empty_file.write_bytes(b"")
+        subprocess.run(["git", "add", "empty.txt"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add empty file"], check=True, cwd=temp_git_repo, capture_output=True)
+        empty_file.unlink()
+
+        ensure_state_directory_exists()
+        initialize_abort_state()
+        command_include_to_batch("empty-delete-batch", file="empty.txt", quiet=True)
+
+        file_meta = read_batch_metadata("empty-delete-batch")["files"]["empty.txt"]
+        assert file_meta["change_type"] == "deleted"
+        assert read_file_from_batch("empty-delete-batch", "empty.txt") is None
+        assert not empty_file.exists()
+
+        command_again(quiet=True)
+        with pytest.raises(NoMoreHunks):
+            fetch_next_change()
 
     def test_include_to_batch_auto_creates_batch(self, temp_git_repo):
         """Test that include to batch auto-creates batch if it doesn't exist."""

--- a/tests/commands/test_reset.py
+++ b/tests/commands/test_reset.py
@@ -4,6 +4,9 @@ import subprocess
 
 import pytest
 
+import git_stage_batch.commands.reset as reset_module
+import git_stage_batch.commands.show_from as show_from_module
+import git_stage_batch.data.hunk_tracking as hunk_tracking_module
 from git_stage_batch.batch.ownership import BatchOwnership, DeletionClaim
 from git_stage_batch.batch.query import read_batch_metadata
 from git_stage_batch.batch.storage import add_file_to_batch, read_file_from_batch
@@ -11,11 +14,27 @@ from git_stage_batch.commands.again import command_again
 from git_stage_batch.commands.include import command_include_to_batch
 from git_stage_batch.commands.new import command_new_batch
 from git_stage_batch.commands.reset import command_reset_from_batch
+from git_stage_batch.commands.show_from import command_show_from_batch
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.core.line_selection import parse_line_selection
+from git_stage_batch.core.models import RenderedBatchDisplay, ReviewActionGroup
 from git_stage_batch.data.batch_sources import create_batch_source_commit, save_session_batch_sources
-from git_stage_batch.data.hunk_tracking import fetch_next_change
+from git_stage_batch.data.hunk_tracking import fetch_next_change, render_batch_file_display
 from git_stage_batch.exceptions import CommandError, NoMoreHunks
+
+
+_RESET_ACTIONS = ("reset-from-batch",)
+
+
+def _review_action_groups_from_map(gutter_to_selection_id: dict[int, int]) -> tuple[ReviewActionGroup, ...]:
+    return tuple(
+        ReviewActionGroup(
+            display_ids=(gutter_id,),
+            selection_ids=(selection_id,),
+            actions=_RESET_ACTIONS,
+        )
+        for gutter_id, selection_id in gutter_to_selection_id.items()
+    )
 
 
 @pytest.fixture
@@ -117,6 +136,269 @@ class TestResetFromBatch:
         for range_str in batch_ownership_after.get("claimed_lines", []):
             batch_line_ids_after.update(parse_line_selection(range_str))
         assert batch_line_ids_after == {1, 3}
+
+    def test_reset_line_claims_translate_batch_review_gutter_ids(self, temp_git_repo, monkeypatch):
+        """Reset --line should use user-visible batch review gutter IDs."""
+        test_file = temp_git_repo / "test.py"
+        test_file.write_text("line 1\nline 2\nline 3\n")
+        subprocess.run(["git", "add", "test.py"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add test.py"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        test_file.write_text("line 1 modified\nline 2\nline 3 modified\n")
+        command_new_batch("mybatch", "test batch")
+        command_start()
+        add_file_to_batch(
+            "mybatch",
+            "test.py",
+            BatchOwnership(claimed_lines=["1", "3"], deletions=[]),
+            "100644",
+        )
+
+        original_render = reset_module.render_batch_file_display
+
+        def render_with_shifted_gutter(batch_name, file_path, metadata=None):
+            rendered = original_render(batch_name, file_path, metadata=metadata)
+            assert rendered is not None
+            gutter_to_selection_id = {1: 2, 2: 1}
+            selection_id_to_gutter = {2: 1, 1: 2}
+            return RenderedBatchDisplay(
+                line_changes=rendered.line_changes,
+                gutter_to_selection_id=gutter_to_selection_id,
+                selection_id_to_gutter=selection_id_to_gutter,
+                actionable_selection_groups=rendered.actionable_selection_groups,
+                review_gutter_to_selection_id=gutter_to_selection_id,
+                review_selection_id_to_gutter=selection_id_to_gutter,
+                review_action_groups=_review_action_groups_from_map(gutter_to_selection_id),
+            )
+
+        monkeypatch.setattr(reset_module, "render_batch_file_display", render_with_shifted_gutter)
+        monkeypatch.setattr(show_from_module, "render_batch_file_display", render_with_shifted_gutter)
+        monkeypatch.setattr(hunk_tracking_module, "render_batch_file_display", render_with_shifted_gutter)
+
+        command_show_from_batch("mybatch", file="test.py", page="all")
+
+        command_reset_from_batch("mybatch", line_ids="1", file="test.py")
+
+        metadata_after = read_batch_metadata("mybatch")
+        batch_ownership_after = metadata_after["files"]["test.py"]
+        batch_line_ids_after = set()
+        for range_str in batch_ownership_after.get("claimed_lines", []):
+            batch_line_ids_after.update(parse_line_selection(range_str))
+        assert batch_line_ids_after == {1}
+
+    def test_reset_line_claims_reject_mixed_fresh_review_and_raw_ids(self, temp_git_repo, monkeypatch):
+        """Fresh review IDs must not silently fall back to raw batch display IDs."""
+        test_file = temp_git_repo / "test.py"
+        test_file.write_text("line 1\nline 2\nline 3\n")
+        subprocess.run(["git", "add", "test.py"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add test.py"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        test_file.write_text("line 1 modified\nline 2\nline 3 modified\n")
+        command_new_batch("mybatch", "test batch")
+        command_start()
+        add_file_to_batch(
+            "mybatch",
+            "test.py",
+            BatchOwnership(claimed_lines=["1", "3"], deletions=[]),
+            "100644",
+        )
+
+        original_render = reset_module.render_batch_file_display
+
+        def render_with_shifted_gutter(batch_name, file_path, metadata=None):
+            rendered = original_render(batch_name, file_path, metadata=metadata)
+            assert rendered is not None
+            gutter_to_selection_id = {1: 2, 2: 1}
+            selection_id_to_gutter = {2: 1, 1: 2}
+            return RenderedBatchDisplay(
+                line_changes=rendered.line_changes,
+                gutter_to_selection_id=gutter_to_selection_id,
+                selection_id_to_gutter=selection_id_to_gutter,
+                actionable_selection_groups=rendered.actionable_selection_groups,
+                review_gutter_to_selection_id=gutter_to_selection_id,
+                review_selection_id_to_gutter=selection_id_to_gutter,
+                review_action_groups=_review_action_groups_from_map(gutter_to_selection_id),
+            )
+
+        monkeypatch.setattr(reset_module, "render_batch_file_display", render_with_shifted_gutter)
+        monkeypatch.setattr(show_from_module, "render_batch_file_display", render_with_shifted_gutter)
+        monkeypatch.setattr(hunk_tracking_module, "render_batch_file_display", render_with_shifted_gutter)
+
+        command_show_from_batch("mybatch", file="test.py", page="all")
+
+        with pytest.raises(CommandError, match="not valid from the current file review"):
+            command_reset_from_batch("mybatch", line_ids="1,99", file="test.py")
+
+        metadata_after = read_batch_metadata("mybatch")
+        batch_ownership_after = metadata_after["files"]["test.py"]
+        batch_line_ids_after = set()
+        for range_str in batch_ownership_after.get("claimed_lines", []):
+            batch_line_ids_after.update(parse_line_selection(range_str))
+        assert batch_line_ids_after == {1, 3}
+
+    def test_reset_line_claims_reject_stale_review_before_raw_id_fallback(self, temp_git_repo, monkeypatch):
+        """Stale review gutter IDs must not be reinterpreted as raw batch IDs."""
+        test_file = temp_git_repo / "test.py"
+        test_file.write_text("line 1\nline 2\n")
+        subprocess.run(["git", "add", "test.py"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add test.py"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        test_file.write_text("line 1 modified\nline 2 modified\n")
+        command_new_batch("mybatch", "test batch")
+        command_start()
+        add_file_to_batch(
+            "mybatch",
+            "test.py",
+            BatchOwnership(claimed_lines=["1", "2"], deletions=[]),
+            "100644",
+        )
+
+        original_render = reset_module.render_batch_file_display
+
+        def render_with_shifted_gutter(batch_name, file_path, metadata=None):
+            rendered = original_render(batch_name, file_path, metadata=metadata)
+            assert rendered is not None
+            gutter_to_selection_id = {1: 2, 2: 1}
+            selection_id_to_gutter = {2: 1, 1: 2}
+            return RenderedBatchDisplay(
+                line_changes=rendered.line_changes,
+                gutter_to_selection_id=gutter_to_selection_id,
+                selection_id_to_gutter=selection_id_to_gutter,
+                actionable_selection_groups=rendered.actionable_selection_groups,
+                review_gutter_to_selection_id=gutter_to_selection_id,
+                review_selection_id_to_gutter=selection_id_to_gutter,
+                review_action_groups=_review_action_groups_from_map(gutter_to_selection_id),
+            )
+
+        def render_with_raw_gutter(batch_name, file_path, metadata=None):
+            rendered = original_render(batch_name, file_path, metadata=metadata)
+            assert rendered is not None
+            gutter_to_selection_id = {1: 1, 2: 2}
+            selection_id_to_gutter = {1: 1, 2: 2}
+            return RenderedBatchDisplay(
+                line_changes=rendered.line_changes,
+                gutter_to_selection_id=gutter_to_selection_id,
+                selection_id_to_gutter=selection_id_to_gutter,
+                actionable_selection_groups=rendered.actionable_selection_groups,
+                review_gutter_to_selection_id=gutter_to_selection_id,
+                review_selection_id_to_gutter=selection_id_to_gutter,
+                review_action_groups=_review_action_groups_from_map(gutter_to_selection_id),
+            )
+
+        monkeypatch.setattr(reset_module, "render_batch_file_display", render_with_shifted_gutter)
+        monkeypatch.setattr(show_from_module, "render_batch_file_display", render_with_shifted_gutter)
+        monkeypatch.setattr(hunk_tracking_module, "render_batch_file_display", render_with_shifted_gutter)
+
+        command_show_from_batch("mybatch", file="test.py", page="all")
+
+        monkeypatch.setattr(hunk_tracking_module, "render_batch_file_display", render_with_raw_gutter)
+
+        with pytest.raises(CommandError, match="no longer matches"):
+            command_reset_from_batch("mybatch", line_ids="1", file="test.py")
+
+        metadata_after = read_batch_metadata("mybatch")
+        batch_ownership_after = metadata_after["files"]["test.py"]
+        batch_line_ids_after = set()
+        for range_str in batch_ownership_after.get("claimed_lines", []):
+            batch_line_ids_after.update(parse_line_selection(range_str))
+        assert batch_line_ids_after == {1, 2}
+
+    def test_reset_line_claims_do_not_require_live_mergeability(self, temp_git_repo):
+        """Resetting batch metadata should not depend on current worktree mergeability."""
+        test_file = temp_git_repo / "test.py"
+        test_file.write_text("line 1\nline 2\n")
+        subprocess.run(["git", "add", "test.py"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add test.py"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        test_file.write_text("line 1 modified\nline 2\n")
+        command_start()
+        fetch_next_change()
+        command_include_to_batch("mybatch", line_ids="2", quiet=True)
+
+        test_file.write_text("totally different\ncontent\n")
+        rendered = render_batch_file_display("mybatch", "test.py")
+        assert rendered is not None
+        assert rendered.gutter_to_selection_id == {}
+
+        command_reset_from_batch("mybatch", line_ids="1", file="test.py")
+
+        metadata_after = read_batch_metadata("mybatch")
+        assert "test.py" not in metadata_after.get("files", {})
+
+    def test_reset_line_claims_after_review_do_not_require_live_mergeability(self, temp_git_repo):
+        """A fresh batch review should not make reset depend on mergeability."""
+        test_file = temp_git_repo / "test.py"
+        test_file.write_text("line 1\nline 2\n")
+        subprocess.run(["git", "add", "test.py"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add test.py"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        test_file.write_text("line 1 modified\nline 2\n")
+        command_start()
+        fetch_next_change()
+        command_include_to_batch("mybatch", line_ids="2", quiet=True)
+
+        test_file.write_text("totally different\ncontent\n")
+        rendered = render_batch_file_display("mybatch", "test.py")
+        assert rendered is not None
+        assert rendered.gutter_to_selection_id == {}
+
+        command_show_from_batch("mybatch", file="test.py", page="all")
+        command_reset_from_batch("mybatch", line_ids="1", file="test.py")
+
+        metadata_after = read_batch_metadata("mybatch")
+        assert "test.py" not in metadata_after.get("files", {})
+
+    def test_reset_line_claims_after_review_ignore_later_worktree_changes(self, temp_git_repo):
+        """Reset review IDs should stay valid when only mergeability changes."""
+        test_file = temp_git_repo / "test.py"
+        test_file.write_text("line 1\nline 2\n")
+        subprocess.run(["git", "add", "test.py"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add test.py"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        test_file.write_text("line 1 modified\nline 2\n")
+        command_new_batch("mybatch", "test batch")
+        command_start()
+        add_file_to_batch(
+            "mybatch",
+            "test.py",
+            BatchOwnership(claimed_lines=["1"], deletions=[]),
+            "100644",
+        )
+
+        test_file.write_text("line 1\nline 2\n")
+        command_show_from_batch("mybatch", file="test.py", page="all")
+        test_file.write_text("totally different\ncontent\n")
+
+        command_reset_from_batch("mybatch", line_ids="1", file="test.py")
+
+        metadata_after = read_batch_metadata("mybatch")
+        assert "test.py" not in metadata_after.get("files", {})
+
+    def test_pathless_reset_line_claims_after_review_ignore_later_worktree_changes(self, temp_git_repo):
+        """Pathless reset review IDs should not depend on live mergeability."""
+        test_file = temp_git_repo / "test.py"
+        test_file.write_text("line 1\nline 2\n")
+        subprocess.run(["git", "add", "test.py"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add test.py"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        test_file.write_text("line 1 modified\nline 2\n")
+        command_new_batch("mybatch", "test batch")
+        command_start()
+        add_file_to_batch(
+            "mybatch",
+            "test.py",
+            BatchOwnership(claimed_lines=["1"], deletions=[]),
+            "100644",
+        )
+
+        test_file.write_text("line 1\nline 2\n")
+        command_show_from_batch("mybatch", file="test.py", page="all")
+        test_file.write_text("totally different\ncontent\n")
+
+        command_reset_from_batch("mybatch", line_ids="1")
+
+        metadata_after = read_batch_metadata("mybatch")
+        assert "test.py" not in metadata_after.get("files", {})
 
     def test_reset_with_multiple_batches(self, temp_git_repo):
         """Test that reset only makes hunks visible if not claimed by other batches."""
@@ -426,8 +708,35 @@ class TestResetFromBatch:
         with pytest.raises(CommandError) as exc_info:
             command_reset_from_batch("mybatch", line_ids="1")
 
-        assert "atomic ownership unit" in str(exc_info.value.message).lower()
-        assert "replacement" in str(exc_info.value.message).lower()
+        assert "cannot select only part of this change" in str(exc_info.value.message).lower()
+        assert "select all related lines together" in str(exc_info.value.message).lower()
+
+    def test_reset_explicit_file_rejects_partial_review_group(self, temp_git_repo):
+        """Fresh batch file reviews should reject partial reset selections before raw IDs."""
+
+        test_file = temp_git_repo / "test.py"
+        test_file.write_text("line 1\nline 2\nline 3\n")
+        subprocess.run(["git", "add", "test.py"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add test.py"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        test_file.write_text("line 1 modified\nline 2\nline 3\n")
+
+        command_new_batch("mybatch", "test batch")
+        command_start()
+        fetch_next_change()
+        ownership = BatchOwnership(
+            claimed_lines=["1"],
+            deletions=[DeletionClaim(anchor_line=None, content_lines=[b"line 1\n"])]
+        )
+        add_file_to_batch("mybatch", "test.py", ownership, "100644")
+
+        command_show_from_batch("mybatch", file="test.py", page="all")
+
+        with pytest.raises(CommandError) as exc_info:
+            command_reset_from_batch("mybatch", line_ids="1", file="test.py")
+
+        assert "only partly selects a reviewed change" in exc_info.value.message
+        assert "Use: --line 1-2" in exc_info.value.message
 
     def test_reset_presence_only_keeps_unrelated_deletions(self, temp_git_repo):
         """Test that resetting presence-only lines preserves unrelated deletion claims."""
@@ -569,3 +878,36 @@ class TestResetFromBatch:
         assert 2 not in claimed_ids, "Source line 2 should be removed (selected)"
         assert 3 in claimed_ids, "Source line 3 should remain (separate unit)"
         assert len(file_ownership.deletions) == 0, "No deletions in this ownership"
+
+    def test_reset_single_presence_line_after_batch_review(self, temp_git_repo):
+        """Batch reviews should not merge adjacent presence-only reset targets."""
+
+        test_file = temp_git_repo / "test.py"
+        test_file.write_text("line 1\nline 2\nline 3\nline 4\n")
+        subprocess.run(["git", "add", "test.py"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add test.py"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        test_file.write_text("line 1 modified\nline 2 modified\nline 3 modified\nline 4\n")
+
+        command_new_batch("mybatch", "test batch")
+        command_start()
+        fetch_next_change()
+        ownership = BatchOwnership(
+            claimed_lines=["1", "2", "3"],
+            deletions=[],
+        )
+        add_file_to_batch("mybatch", "test.py", ownership, "100644")
+
+        command_show_from_batch("mybatch", file="test.py", page="all")
+        command_reset_from_batch("mybatch", line_ids="2")
+
+        metadata_after = read_batch_metadata("mybatch")
+        file_ownership = BatchOwnership.from_metadata_dict(metadata_after["files"]["test.py"])
+        claimed_ids = set()
+        for range_str in file_ownership.claimed_lines:
+            claimed_ids.update(parse_line_selection(range_str))
+
+        assert 1 in claimed_ids
+        assert 2 not in claimed_ids
+        assert 3 in claimed_ids
+        assert len(file_ownership.deletions) == 0

--- a/tests/commands/test_show.py
+++ b/tests/commands/test_show.py
@@ -15,8 +15,10 @@ import subprocess
 
 import pytest
 
+import git_stage_batch.commands.show as show_module
 from git_stage_batch.commands.show import command_show
 from git_stage_batch.commands.start import command_start
+from git_stage_batch.data.hunk_tracking import get_selected_change_file_path
 from git_stage_batch.data.line_state import load_line_changes_from_state
 
 
@@ -55,6 +57,34 @@ class TestCommandShow:
         assert "README.md" in captured.out
         assert "New line added" in captured.out
         assert "[#1]" in captured.out  # Check for line ID annotation
+
+    def test_show_restores_previous_selection_when_hunk_is_fully_filtered(
+        self,
+        temp_git_repo,
+        monkeypatch,
+        capsys,
+    ):
+        """Invisible filtered traversal should not replace the last selection."""
+        a_file = temp_git_repo / "a.txt"
+        b_file = temp_git_repo / "b.txt"
+        a_file.write_text("a\n")
+        b_file.write_text("b\n")
+        subprocess.run(["git", "add", "a.txt", "b.txt"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add files"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        a_file.write_text("a changed\n")
+        b_file.write_text("b changed\n")
+
+        command_start()
+        capsys.readouterr()
+        command_show(file="a.txt", porcelain=True)
+        assert get_selected_change_file_path() == "a.txt"
+
+        monkeypatch.setattr(show_module, "apply_line_level_batch_filter_to_cached_hunk", lambda: True)
+
+        command_show()
+
+        assert get_selected_change_file_path() == "a.txt"
 
     def test_show_no_changes(self, temp_git_repo, capsys):
         """Test that show displays message when no more hunks remain."""
@@ -237,6 +267,24 @@ class TestCommandShow:
             command_show(porcelain=True)
 
         assert exc_info.value.code == 1
+
+    def test_show_displays_binary_change_in_hunk_mode(self, temp_git_repo, capsys):
+        """Plain show should display binary changes instead of reporting no hunks."""
+        binary_file = temp_git_repo / "asset.bin"
+        binary_file.write_bytes(b"\x00\x01\x02")
+        subprocess.run(["git", "add", "asset.bin"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add binary"], check=True, cwd=temp_git_repo, capture_output=True)
+        binary_file.write_bytes(b"\x00\x03\x04")
+
+        ensure_state_directory_exists()
+        initialize_abort_state()
+
+        command_show()
+
+        captured = capsys.readouterr()
+        assert "asset.bin" in captured.out
+        assert "Binary file modified" in captured.out
+        assert "No more hunks to process" not in captured.err
 
     def test_show_file_preview_hides_gutter_ids_without_replacing_selection(self, temp_git_repo, capsys):
         """Non-selectable file previews should hide gutter IDs and preserve cached selection."""

--- a/tests/commands/test_show_from.py
+++ b/tests/commands/test_show_from.py
@@ -2,6 +2,7 @@
 
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.commands.include import command_include_to_batch
+from git_stage_batch.commands.show import command_show
 from git_stage_batch.batch.ownership import BatchOwnership
 from git_stage_batch.batch.storage import add_file_to_batch
 from git_stage_batch.batch.ownership import DeletionClaim
@@ -9,6 +10,7 @@ from git_stage_batch.data.hunk_tracking import render_batch_file_display
 import git_stage_batch.batch.merge as merge_module
 import git_stage_batch.batch.display as display_module
 import git_stage_batch.data.hunk_tracking as hunk_tracking
+import git_stage_batch.commands.show_from as show_from_module
 
 import subprocess
 
@@ -61,6 +63,52 @@ class TestCommandShowFromBatch:
         assert "file.txt" in captured.out
         assert "content" in captured.out
         assert "[#1]" in captured.out  # Check for line ID annotation
+
+    def test_show_from_empty_added_text_file_is_visible(self, temp_git_repo, capsys):
+        """Empty text lifecycle entries should not look like missing batch changes."""
+        (temp_git_repo / "empty.txt").write_bytes(b"")
+        add_file_to_batch(
+            "test-batch",
+            "empty.txt",
+            BatchOwnership(claimed_lines=[], deletions=[]),
+            "100644",
+            change_type="added",
+        )
+
+        command_show_from_batch("test-batch", file="empty.txt")
+
+        captured = capsys.readouterr()
+        assert "empty.txt" in captured.out
+        assert "<empty file>" in captured.out
+        assert "not currently selectable" in captured.out
+        assert "No changes for file" not in captured.err
+
+    def test_show_from_file_list_includes_empty_text_lifecycle(self, temp_git_repo, capsys):
+        """The batch file list should include empty added/deleted text files."""
+        (temp_git_repo / "empty.txt").write_bytes(b"")
+        (temp_git_repo / "content.txt").write_text("content\n")
+        add_file_to_batch(
+            "test-batch",
+            "empty.txt",
+            BatchOwnership(claimed_lines=[], deletions=[]),
+            "100644",
+            change_type="added",
+        )
+        add_file_to_batch(
+            "test-batch",
+            "content.txt",
+            BatchOwnership(claimed_lines=["1"], deletions=[]),
+            "100644",
+            change_type="added",
+        )
+
+        command_show_from_batch("test-batch")
+
+        captured = capsys.readouterr()
+        assert "── matched files" in captured.out
+        assert "empty.txt" in captured.out
+        assert "content.txt" in captured.out
+        assert "Batch 'test-batch' is empty" not in captured.err
 
     def test_show_from_empty_batch_succeeds(self, temp_git_repo):
         """Test showing from an empty batch succeeds with no output."""
@@ -227,8 +275,8 @@ class TestCommandShowFromBatch:
         assert rendered is not None
         assert len(calls) == 1
 
-    def test_show_from_multi_file_caches_first_render_without_rerendering(self, temp_git_repo, monkeypatch, capsys):
-        """Showing all files should not render the first file twice for cache state."""
+    def test_show_from_multi_file_list_renders_each_file_once(self, temp_git_repo, monkeypatch, capsys):
+        """Showing a multi-file batch file list should render each file once."""
 
         (temp_git_repo / "file1.txt").write_text("line 1\nline 2\n")
         (temp_git_repo / "file2.txt").write_text("line A\nline B\n")
@@ -250,8 +298,39 @@ class TestCommandShowFromBatch:
             rendered_files.append(file_path)
             return original_render(batch_name, file_path, metadata=metadata)
 
-        monkeypatch.setattr(hunk_tracking, "render_batch_file_display", counting_render)
+        monkeypatch.setattr(show_from_module, "render_batch_file_display", counting_render)
 
         command_show_from_batch("multi-file-batch")
 
         assert rendered_files == ["file1.txt", "file2.txt"]
+        captured = capsys.readouterr()
+        assert "── matched files" in captured.out
+
+    def test_non_selectable_multi_file_batch_preview_preserves_selection(self, temp_git_repo, capsys):
+        """A non-selectable multi-file batch preview should not clear selected state."""
+        readme = temp_git_repo / "README.md"
+        readme.write_text("# Test\nselected\n")
+        command_show()
+        capsys.readouterr()
+        assert hunk_tracking.get_selected_change_file_path() == "README.md"
+
+        (temp_git_repo / "file1.txt").write_text("one\n")
+        (temp_git_repo / "file2.txt").write_text("two\n")
+        create_batch("multi-file-batch")
+        add_file_to_batch(
+            "multi-file-batch",
+            "file1.txt",
+            BatchOwnership(claimed_lines=["1"], deletions=[]),
+            "100644",
+        )
+        add_file_to_batch(
+            "multi-file-batch",
+            "file2.txt",
+            BatchOwnership(claimed_lines=["1"], deletions=[]),
+            "100644",
+        )
+
+        command_show_from_batch("multi-file-batch", selectable=False)
+        capsys.readouterr()
+
+        assert hunk_tracking.get_selected_change_file_path() == "README.md"

--- a/tests/commands/test_status.py
+++ b/tests/commands/test_status.py
@@ -1,6 +1,14 @@
 """Tests for status command."""
 
-from git_stage_batch.commands.show import command_show
+from git_stage_batch.batch import create_batch
+from git_stage_batch.batch.ownership import BatchOwnership
+from git_stage_batch.batch.storage import add_binary_file_to_batch
+from git_stage_batch.batch.storage import add_file_to_batch
+from git_stage_batch.commands.include import command_include_line, command_include_to_batch
+from git_stage_batch.commands.reset import command_reset_from_batch
+from git_stage_batch.commands.show import command_show, command_show_file_list
+from git_stage_batch.commands.show_from import command_show_from_batch
+from git_stage_batch.data.hunk_tracking import SelectedChangeKind, read_selected_change_kind
 from git_stage_batch.data.session import initialize_abort_state
 from git_stage_batch.utils.paths import get_iteration_count_file_path
 from git_stage_batch.utils.paths import ensure_state_directory_exists, get_state_directory_path
@@ -10,10 +18,13 @@ import subprocess
 
 import pytest
 
+from git_stage_batch.core.models import BinaryFileChange
 from git_stage_batch.commands.include import command_include
 from git_stage_batch.commands.skip import command_skip, command_skip_file
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.commands.status import command_status
+from git_stage_batch.core.line_selection import format_line_ids
+from git_stage_batch.data.file_review_state import read_last_file_review_state
 
 
 @pytest.fixture
@@ -209,7 +220,7 @@ class TestCommandStatus:
 
         captured = capsys.readouterr()
         output = json.loads(captured.out)
-        assert output == {"session_active": False}
+        assert output == {"session": {"active": False}}
 
     def test_status_ignores_persistent_batch_state_without_session(self, temp_git_repo, capsys):
         """Persistent batch metadata alone should not count as an active session."""
@@ -248,9 +259,10 @@ class TestCommandStatus:
         output = json.loads(captured.out)
 
         # Verify JSON structure
-        assert output["session_active"] is True
-        assert output["iteration"] == 1
-        assert output["status"] in ("in_progress", "complete")
+        assert output["session"]["active"] is True
+        assert output["session"]["iteration"] == 1
+        assert output["session"]["status"] in ("in_progress", "complete")
+        assert isinstance(output["session"]["in_progress"], bool)
         assert "progress" in output
         assert "included" in output["progress"]
         assert "skipped" in output["progress"]
@@ -258,8 +270,8 @@ class TestCommandStatus:
         assert "remaining" in output["progress"]
         assert "skipped_hunks" in output
 
-    def test_status_porcelain_includes_selected_hunk(self, temp_git_repo, capsys):
-        """Test status --porcelain includes selected hunk details."""
+    def test_status_porcelain_includes_selected_change(self, temp_git_repo, capsys):
+        """Test status --porcelain includes selected change details."""
 
         # Create and commit a file
         test_file = temp_git_repo / "test.txt"
@@ -282,10 +294,297 @@ class TestCommandStatus:
         captured = capsys.readouterr()
         output = json.loads(captured.out)
 
-        # Should have selected hunk details (if full state caching is implemented)
-        # At this stage, show.py may only cache patch+hash, not full LineLevelChange
-        if output["selected_hunk"] is not None:
-            assert "file" in output["selected_hunk"]
-            assert "line" in output["selected_hunk"]
-            assert "ids" in output["selected_hunk"]
-            assert output["selected_hunk"]["file"] == "test.txt"
+        assert output["selected_change"] is not None
+        assert output["selected_change"]["kind"] == "hunk"
+        assert output["selected_change"]["file"] == "test.txt"
+        assert "line" in output["selected_change"]
+        assert "ids" in output["selected_change"]
+
+    def test_status_in_progress_when_no_selection_but_hunks_remain(self, temp_git_repo, capsys):
+        """Navigational file lists clear selection without making the session complete."""
+        (temp_git_repo / "a.txt").write_text("a\n")
+        (temp_git_repo / "b.txt").write_text("b\n")
+        subprocess.run(["git", "add", "a.txt", "b.txt"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add files"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        (temp_git_repo / "a.txt").write_text("a changed\n")
+        (temp_git_repo / "b.txt").write_text("b changed\n")
+
+        command_start()
+        capsys.readouterr()
+        command_show_file_list(["a.txt", "b.txt"])
+        capsys.readouterr()
+
+        command_status()
+
+        captured = capsys.readouterr()
+        assert "Session: iteration 1 (in progress)" in captured.out
+        assert "Current hunk:" not in captured.out
+        assert "Remaining: ~2 hunks" in captured.out
+
+    def test_status_reports_selected_batch_file_review_without_snapshots(self, temp_git_repo, capsys):
+        """Batch-file reviews intentionally lack live snapshots but remain selected."""
+        readme = temp_git_repo / "README.md"
+        readme.write_text("# Test\nbatched\n")
+
+        command_start()
+        capsys.readouterr()
+        command_include_to_batch("cleanup", file="README.md", quiet=True)
+        capsys.readouterr()
+        command_show_from_batch("cleanup", file="README.md")
+        capsys.readouterr()
+
+        command_status()
+
+        captured = capsys.readouterr()
+        assert "Session: iteration 1 (in progress)" in captured.out
+        assert "Current batch file review:" in captured.out
+        assert "Last file review:" in captured.out
+        assert "source: batch cleanup" in captured.out
+
+        command_status(porcelain=True)
+        output = json.loads(capsys.readouterr().out)
+        assert output["session"]["status"] == "in_progress"
+        assert output["selected_change"]["kind"] == "batch-file"
+        assert output["selected_change"]["file"] == "README.md"
+        assert output["file_review"]["source"] == "batch"
+        assert output["file_review"]["batch_name"] == "cleanup"
+
+    def test_status_reports_batch_review_gutter_ids(self, temp_git_repo, capsys):
+        """Batch-file status should show user-visible gutter IDs, not source IDs."""
+        test_file = temp_git_repo / "file.txt"
+        test_file.write_text("keep\nold\n")
+        subprocess.run(["git", "add", "file.txt"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add file"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        ensure_state_directory_exists()
+        initialize_abort_state()
+        test_file.write_text("keep\nnew\n")
+        create_batch("manual")
+        add_file_to_batch(
+            "manual",
+            "file.txt",
+            BatchOwnership(claimed_lines=["2"], deletions=[]),
+            "100644",
+        )
+        test_file.write_text("keep\nold\n")
+
+        command_show_from_batch("manual", file="file.txt", page="all")
+        capsys.readouterr()
+
+        command_status(porcelain=True)
+        output = json.loads(capsys.readouterr().out)
+
+        assert output["selected_change"]["kind"] == "batch-file"
+        assert output["selected_change"]["ids"] == [1]
+
+        command_status()
+        captured = capsys.readouterr()
+        assert "[#1]" in captured.out
+        assert "[#2]" not in captured.out
+
+    def test_status_reports_only_shown_batch_review_gutter_ids(
+        self,
+        temp_git_repo,
+        monkeypatch,
+        capsys,
+    ):
+        """Batch-file status should not advertise hidden-page line IDs."""
+        from git_stage_batch.output import file_review
+
+        monkeypatch.setattr(file_review, "_body_budget", lambda: 1)
+        test_file = temp_git_repo / "file.txt"
+        original = [f"line {number}\n" for number in range(1, 31)]
+        test_file.write_text("".join(original))
+        subprocess.run(["git", "add", "file.txt"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add file"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        changed = original[:]
+        changed[1] = "line 2 changed\n"
+        changed[11] = "line 12 changed\n"
+        changed[21] = "line 22 changed\n"
+        test_file.write_text("".join(changed))
+
+        ensure_state_directory_exists()
+        initialize_abort_state()
+        add_file_to_batch(
+            "cleanup",
+            "file.txt",
+            BatchOwnership(claimed_lines=["2", "12", "22"], deletions=[]),
+            "100644",
+        )
+
+        command_show_from_batch("cleanup", file="file.txt", page="1")
+        capsys.readouterr()
+
+        command_status(porcelain=True)
+        output = json.loads(capsys.readouterr().out)
+
+        assert output["selected_change"]["kind"] == "batch-file"
+        assert output["selected_change"]["ids"] == [1]
+
+    def test_status_reports_only_shown_live_review_gutter_ids(
+        self,
+        temp_git_repo,
+        monkeypatch,
+        capsys,
+    ):
+        """Live file status should not advertise hidden-page line IDs."""
+        from git_stage_batch.output import file_review
+
+        monkeypatch.setattr(file_review, "_body_budget", lambda: 1)
+        test_file = temp_git_repo / "file.txt"
+        original = [f"line {number}\n" for number in range(1, 31)]
+        test_file.write_text("".join(original))
+        subprocess.run(["git", "add", "file.txt"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add file"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        changed = original[:]
+        changed[1] = "line 2 changed\n"
+        changed[11] = "line 12 changed\n"
+        changed[21] = "line 22 changed\n"
+        test_file.write_text("".join(changed))
+
+        command_start()
+        capsys.readouterr()
+        command_show(file="file.txt", page="1")
+        capsys.readouterr()
+
+        command_status(porcelain=True)
+        output = json.loads(capsys.readouterr().out)
+
+        assert output["selected_change"]["kind"] == "file"
+        assert output["selected_change"]["ids"] == [1, 2]
+
+    def test_status_hides_ids_from_stale_live_review(
+        self,
+        temp_git_repo,
+        monkeypatch,
+        capsys,
+    ):
+        """Status should not fall back to raw IDs from a stale live review."""
+        from git_stage_batch.output import file_review
+
+        monkeypatch.setattr(file_review, "_body_budget", lambda: 1)
+        test_file = temp_git_repo / "file.txt"
+        original = [f"line {number}\n" for number in range(1, 31)]
+        test_file.write_text("".join(original))
+        subprocess.run(["git", "add", "file.txt"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add file"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        changed = original[:]
+        changed[1] = "line 2 changed\n"
+        changed[11] = "line 12 changed\n"
+        changed[21] = "line 22 changed\n"
+        test_file.write_text("".join(changed))
+
+        command_start()
+        capsys.readouterr()
+        command_show(file="file.txt", page="1")
+        capsys.readouterr()
+        state = read_last_file_review_state()
+        assert state is not None
+        line_spec = format_line_ids(list(state.selections[0].display_ids))
+
+        command_include_line(line_spec)
+        capsys.readouterr()
+
+        command_status(porcelain=True)
+        output = json.loads(capsys.readouterr().out)
+
+        assert output["file_review"]["fresh"] is False
+        assert output["selected_change"]["kind"] == "file"
+        assert output["selected_change"]["ids"] == []
+
+    def test_status_complete_after_selected_batch_file_is_reset(self, temp_git_repo, capsys):
+        """Resetting the selected batch file should not leave status in progress."""
+        readme = temp_git_repo / "README.md"
+        readme.write_text("# Test\nbatched\n")
+
+        command_start()
+        capsys.readouterr()
+        command_include_to_batch("cleanup", file="README.md", quiet=True)
+        capsys.readouterr()
+        subprocess.run(["git", "checkout", "HEAD", "--", "README.md"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        command_show_from_batch("cleanup", file="README.md", page="all")
+        capsys.readouterr()
+        command_reset_from_batch("cleanup")
+        capsys.readouterr()
+
+        command_status(porcelain=True)
+
+        output = json.loads(capsys.readouterr().out)
+        assert output["session"]["status"] == "complete"
+        assert output["selected_change"] is None
+        assert output["progress"]["remaining"] == 0
+
+    def test_status_hides_stale_binary_selection_without_clearing_it(self, temp_git_repo, capsys):
+        """A stale binary selection should not affect progress or lose its pathless-action guard."""
+        binary_file = temp_git_repo / "asset.bin"
+        binary_file.write_bytes(b"\x00\x01\x02")
+        subprocess.run(["git", "add", "asset.bin"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add binary"], check=True, cwd=temp_git_repo, capture_output=True)
+        binary_file.write_bytes(b"\x00\x03\x04")
+
+        ensure_state_directory_exists()
+        initialize_abort_state()
+        command_show(file="asset.bin", porcelain=True)
+        subprocess.run(["git", "restore", "asset.bin"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        command_status(porcelain=True)
+
+        output = json.loads(capsys.readouterr().out)
+        assert output["session"]["status"] == "complete"
+        assert output["selected_change"] is None
+        assert output["progress"]["remaining"] == 0
+        assert read_selected_change_kind() == SelectedChangeKind.BINARY
+
+    def test_status_keeps_current_deleted_binary_selection(self, temp_git_repo, capsys):
+        """A binary deletion should remain selected while the deletion is still present."""
+        binary_file = temp_git_repo / "asset.bin"
+        binary_file.write_bytes(b"\x00\x01\x02")
+        subprocess.run(["git", "add", "asset.bin"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add binary"], check=True, cwd=temp_git_repo, capture_output=True)
+        binary_file.unlink()
+
+        ensure_state_directory_exists()
+        initialize_abort_state()
+        command_show(file="asset.bin", porcelain=True)
+
+        command_status(porcelain=True)
+
+        output = json.loads(capsys.readouterr().out)
+        assert output["session"]["status"] == "in_progress"
+        assert output["selected_change"]["kind"] == "binary"
+        assert output["selected_change"]["file"] == "asset.bin"
+        assert output["selected_change"]["change_type"] == "deleted"
+
+    def test_status_drops_stale_batch_binary_selection(self, temp_git_repo, capsys):
+        """A cached batch-binary selection should not survive changed batch bytes."""
+        binary_file = temp_git_repo / "asset.bin"
+        binary_file.write_bytes(b"\x00\x01\x02")
+        subprocess.run(["git", "add", "asset.bin"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add binary"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        ensure_state_directory_exists()
+        initialize_abort_state()
+        binary_file.write_bytes(b"\x00\x03\x04")
+        add_binary_file_to_batch(
+            "bin-batch",
+            BinaryFileChange("asset.bin", "asset.bin", "modified"),
+        )
+        command_show_from_batch("bin-batch", file="asset.bin")
+        capsys.readouterr()
+
+        binary_file.write_bytes(b"\x00\x05\x06")
+        add_binary_file_to_batch(
+            "bin-batch",
+            BinaryFileChange("asset.bin", "asset.bin", "modified"),
+        )
+
+        command_status(porcelain=True)
+
+        output = json.loads(capsys.readouterr().out)
+        assert output["selected_change"] is None
+        assert read_selected_change_kind() is None


### PR DESCRIPTION
The tool can review individual hunks, whole files, and named batches, with selected state persisted across separate command invocations.

For larger files and batches, it is useful to browse changes in smaller page-sized views while keeping follow-up commands tied to the review that was just shown. That makes it easier to inspect a file incrementally, without having to e.g. have a 1000 lines all scroll by at once.

This PR adds page-aware reviews for live and batch files, persists review state and freshness fingerprints, routes include/skip/discard/apply/reset/status through review-aware selection handling, and updates CLI dispatch, completion, tests, and docs for the new review flow.
