### PR TITLE
Aggregate multi-file discard-to-batch dispatch

### DIFF
--- a/src/git_stage_batch/cli/argument_parser.py
+++ b/src/git_stage_batch/cli/argument_parser.py
@@ -253,6 +253,48 @@ def _skip_each_resolved_file(files: list[str]) -> None:
     show_selected_change()
 
 
+def _discard_to_batch_each_resolved_file(batch_name: str, files: list[str]) -> None:
+    """Save a multi-file live scope to a batch and report one aggregate summary."""
+    total_hunks = 0
+    discarded_files: list[str] = []
+
+    for file_path in files:
+        discarded_hunks = commands.command_discard_to_batch(
+            batch_name,
+            file=file_path,
+            quiet=True,
+            advance=False,
+        )
+        if discarded_hunks > 0:
+            total_hunks += discarded_hunks
+            discarded_files.append(file_path)
+
+    if total_hunks == 0:
+        print(_("No hunks saved to batch from matched files."), file=sys.stderr)
+        return
+
+    advance_to_next_change()
+
+    if len(discarded_files) == 1:
+        file_summary = discarded_files[0]
+    else:
+        file_summary = ngettext(
+            "{count} file",
+            "{count} files",
+            len(discarded_files),
+        ).format(count=len(discarded_files))
+
+    print(
+        ngettext(
+            "✓ Saved {count} hunk from {files} to batch '{batch}' and discarded it",
+            "✓ Saved {count} hunks from {files} to batch '{batch}' and discarded them",
+            total_hunks,
+        ).format(count=total_hunks, files=file_summary, batch=batch_name),
+        file=sys.stderr,
+    )
+    show_selected_change()
+
+
 def _resolve_live_file_scope(
     file_arg: str | None,
     file_patterns: list[str] | None,
@@ -816,11 +858,14 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
             )
         elif args.to_batch:
             resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
-            _run_for_each_file(
-                resolved_live_scope,
-                lambda file: commands.command_discard_to_batch(args.to_batch, args.line_ids, file),
-                line_ids=args.line_ids,
-            )
+            if isinstance(resolved_live_scope, list) and args.line_ids is None:
+                _discard_to_batch_each_resolved_file(args.to_batch, resolved_live_scope)
+            else:
+                _run_for_each_file(
+                    resolved_live_scope,
+                    lambda file: commands.command_discard_to_batch(args.to_batch, args.line_ids, file),
+                    line_ids=args.line_ids,
+                )
         elif args.line_ids:
             resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
             if isinstance(resolved_live_scope, list):

--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -470,7 +470,14 @@ def command_discard_line(line_id_specification: str, file: str | None = None) ->
         finish_review_scoped_line_action(review_state)
 
 
-def command_discard_to_batch(batch_name: str, line_ids: str | None = None, file: str | None = None, *, quiet: bool = False) -> None:
+def command_discard_to_batch(
+    batch_name: str,
+    line_ids: str | None = None,
+    file: str | None = None,
+    *,
+    quiet: bool = False,
+    advance: bool = True,
+) -> int:
     """Save to batch then discard from working tree.
 
     Args:
@@ -480,6 +487,10 @@ def command_discard_to_batch(batch_name: str, line_ids: str | None = None, file:
               If empty string, uses selected hunk's file.
               If None, uses selected hunk (cached state).
         quiet: Suppress output
+        advance: When quiet, advance the selection after discarding this file.
+
+    Returns:
+        Number of hunks saved to the batch and discarded.
     """
     require_git_repository()
     ensure_state_directory_exists()
@@ -492,7 +503,7 @@ def command_discard_to_batch(batch_name: str, line_ids: str | None = None, file:
         file=file,
     )
     if scope_resolution.should_stop:
-        return
+        return 0
     file = scope_resolution.file
     review_state = scope_resolution.review_state
     operation_parts = ["discard", "--to", batch_name]
@@ -508,9 +519,9 @@ def command_discard_to_batch(batch_name: str, line_ids: str | None = None, file:
         ):
             selected_change = load_selected_change()
             if isinstance(selected_change, BinaryFileChange):
-                _command_discard_binary_to_batch(batch_name, selected_change, quiet=quiet)
+                saved_hunks = _command_discard_binary_to_batch(batch_name, selected_change, quiet=quiet)
             else:
-                _command_discard_hunk_to_batch(batch_name, file_only=False, quiet=quiet)
+                saved_hunks = _command_discard_hunk_to_batch(batch_name, file_only=False, quiet=quiet)
         elif file is not None:
             # File-scoped operation
 
@@ -525,19 +536,20 @@ def command_discard_to_batch(batch_name: str, line_ids: str | None = None, file:
 
             if line_ids is None:
                 # --file without --line: discard entire file
-                _command_discard_file_to_batch(batch_name, target_file, quiet=quiet)
+                saved_hunks = _command_discard_file_to_batch(batch_name, target_file, quiet=quiet, advance=advance)
             else:
                 # --file with --line: discard specific lines from file
-                _command_discard_file_lines_to_batch(batch_name, target_file, line_ids, quiet=quiet)
+                saved_hunks = _command_discard_file_lines_to_batch(batch_name, target_file, line_ids, quiet=quiet)
         else:
             # Hunk-scoped operation (selected behavior)
             if line_ids is not None:
-                _command_discard_lines_to_batch(batch_name, line_ids, quiet=quiet)
+                saved_hunks = _command_discard_lines_to_batch(batch_name, line_ids, quiet=quiet)
             else:
                 # Discard entire selected hunk
-                _command_discard_hunk_to_batch(batch_name, file_only=False, quiet=quiet)
+                saved_hunks = _command_discard_hunk_to_batch(batch_name, file_only=False, quiet=quiet)
     if original_file_scope in (None, "") and line_ids is not None:
         finish_review_scoped_line_action(review_state)
+    return saved_hunks
 
 
 def command_discard_line_as_to_batch(
@@ -843,7 +855,8 @@ def _command_discard_binary_to_batch(
     binary_change: BinaryFileChange,
     *,
     quiet: bool = False,
-) -> None:
+    advance: bool = True,
+) -> int:
     """Save one binary change to a batch, then discard it from the working tree."""
     file_path = binary_change.new_path if binary_change.new_path != "/dev/null" else binary_change.old_path
     patch_hash = compute_binary_file_hash(binary_change)
@@ -868,13 +881,20 @@ def _command_discard_binary_to_batch(
             file=sys.stderr,
         )
 
-    if quiet:
+    if quiet and advance:
         advance_to_next_change()
-    else:
+    elif not quiet:
         advance_to_and_show_next_change()
+    return 1
 
 
-def _command_discard_file_to_batch(batch_name: str, file_path: str, *, quiet: bool = False) -> None:
+def _command_discard_file_to_batch(
+    batch_name: str,
+    file_path: str,
+    *,
+    quiet: bool = False,
+    advance: bool = True,
+) -> int:
     """Discard entire file to batch (internal helper for file-scoped operations)."""
 
     log_journal("discard_file_to_batch_start", batch_name=batch_name, file_path=file_path, quiet=quiet)
@@ -885,8 +905,7 @@ def _command_discard_file_to_batch(batch_name: str, file_path: str, *, quiet: bo
 
     binary_change = render_binary_file_change(file_path)
     if binary_change is not None:
-        _command_discard_binary_to_batch(batch_name, binary_change, quiet=quiet)
-        return
+        return _command_discard_binary_to_batch(batch_name, binary_change, quiet=quiet, advance=advance)
 
     # Load blocklist
     blocklist_path = get_block_list_file_path()
@@ -940,11 +959,11 @@ def _command_discard_file_to_batch(batch_name: str, file_path: str, *, quiet: bo
                 print(_("Discarded file '{file}' to batch '{batch}'").format(file=file_path, batch=batch_name), file=sys.stderr)
 
             log_journal("discard_file_to_batch_end", batch_name=batch_name, file_path=file_path)
-            return
+            return 1
 
         if not quiet:
             print(_("No changes in file '{file}' to discard.").format(file=file_path), file=sys.stderr)
-        return
+        return 0
 
     # Prepare batch ownership update (handles stale source, translation, merge)
 
@@ -1022,13 +1041,14 @@ def _command_discard_file_to_batch(batch_name: str, file_path: str, *, quiet: bo
     log_journal("discard_file_to_batch_end", batch_name=batch_name, file_path=file_path)
 
     # Show next hunk
-    if quiet:
+    if quiet and advance:
         advance_to_next_change()
-    else:
+    elif not quiet:
         advance_to_and_show_next_change()
+    return len(patches_to_discard)
 
 
-def _command_discard_file_lines_to_batch(batch_name: str, file_path: str, line_id_specification: str, *, quiet: bool = False) -> None:
+def _command_discard_file_lines_to_batch(batch_name: str, file_path: str, line_id_specification: str, *, quiet: bool = False) -> int:
     """Discard specific lines from a file to batch (file-scoped with line IDs)."""
 
     cached_lines = _load_explicit_file_selection(file_path)
@@ -1046,7 +1066,7 @@ def _command_discard_file_lines_to_batch(batch_name: str, file_path: str, line_i
     if not selected_lines:
         if not quiet:
             print(_("No lines match the specified IDs in file '{file}'.").format(file=file_path), file=sys.stderr)
-        return
+        return 0
 
     file_mode = _detect_file_mode(file_path)
 
@@ -1113,9 +1133,10 @@ def _command_discard_file_lines_to_batch(batch_name: str, file_path: str, line_i
         advance_to_next_change()
     else:
         advance_to_and_show_next_change()
+    return 1
 
 
-def _command_discard_lines_to_batch(batch_name: str, line_id_specification: str, *, quiet: bool = False) -> None:
+def _command_discard_lines_to_batch(batch_name: str, line_id_specification: str, *, quiet: bool = False) -> int:
     """Save specific lines to batch and discard them from working tree (internal helper)."""
 
     log_journal("discard_lines_to_batch_start", batch_name=batch_name, line_ids=line_id_specification, quiet=quiet)
@@ -1200,9 +1221,10 @@ def _command_discard_lines_to_batch(batch_name: str, line_id_specification: str,
     recalculate_selected_hunk_for_file(line_changes.path)
 
     log_journal("discard_lines_to_batch_success", batch_name=batch_name, line_ids=line_id_specification, file_path=line_changes.path)
+    return 1
 
 
-def _command_discard_hunk_to_batch(batch_name: str, file_only: bool = False, *, quiet: bool = False) -> None:
+def _command_discard_hunk_to_batch(batch_name: str, file_only: bool = False, *, quiet: bool = False) -> int:
     """Save whole hunk or file to batch and discard from working tree (internal helper)."""
 
     log_journal("discard_hunk_to_batch_start", batch_name=batch_name, file_only=file_only, quiet=quiet)
@@ -1217,10 +1239,9 @@ def _command_discard_hunk_to_batch(batch_name: str, file_only: bool = False, *, 
         selected_item = fetch_next_change()
     except NoMoreHunks:
         print(_("No changes to process."), file=sys.stderr)
-        return
+        return 0
     if isinstance(selected_item, BinaryFileChange):
-        _command_discard_binary_to_batch(batch_name, selected_item, quiet=quiet)
-        return
+        return _command_discard_binary_to_batch(batch_name, selected_item, quiet=quiet)
 
     # Get the file path and hash from currently cached hunk
     patch_hash = read_text_file_contents(get_selected_hunk_hash_file_path()).strip()
@@ -1383,3 +1404,4 @@ def _command_discard_hunk_to_batch(batch_name: str, file_only: bool = False, *, 
         advance_to_next_change()
     else:
         advance_to_and_show_next_change()
+    return len(patches_to_discard)

--- a/tests/cli/test_argument_parser.py
+++ b/tests/cli/test_argument_parser.py
@@ -729,6 +729,28 @@ def test_parse_command_line_discard_from_with_files_resolves_batch_scope_only(mo
     ]
 
 
+def test_parse_command_line_discard_to_with_files_uses_aggregate_dispatch(monkeypatch):
+    """discard --to --files should suppress per-file selected-change display."""
+    mock_command = Mock(return_value=1)
+    mock_advance = Mock()
+    mock_show = Mock()
+    monkeypatch.setattr(argument_parser.commands, "command_discard_to_batch", mock_command)
+    monkeypatch.setattr(argument_parser, "advance_to_next_change", mock_advance)
+    monkeypatch.setattr(argument_parser, "show_selected_change", mock_show)
+    monkeypatch.setattr(argument_parser, "list_changed_files", lambda: ["foo.py", "bar.py", "notes.txt"])
+
+    args = parse_command_line(["discard", "--to", "batch", "--files", "*.py"], quiet=True)
+
+    assert args is not None
+    args.func(args)
+    assert mock_command.call_args_list == [
+        call("batch", file="foo.py", quiet=True, advance=False),
+        call("batch", file="bar.py", quiet=True, advance=False),
+    ]
+    mock_advance.assert_called_once_with()
+    mock_show.assert_called_once_with()
+
+
 def test_parse_command_line_apply_with_files_dispatches_per_file(monkeypatch):
     """Apply should dispatch once per file resolved from --files."""
     mock_command = Mock()

--- a/tests/commands/test_file_scoped_operations.py
+++ b/tests/commands/test_file_scoped_operations.py
@@ -610,6 +610,26 @@ class TestShowFileFlag:
         result = run_git_command(["diff", "--cached", "--name-only"])
         assert result.stdout.splitlines() == ["alpha.txt", "beta.txt", "gamma.txt"]
 
+    def test_discard_to_batch_files_reports_aggregate_scope_once(self, multi_file_repo, capsys):
+        """Discard --to --files should not render the next selected hunk per file."""
+        command_start()
+        capsys.readouterr()
+
+        args = parse_command_line(["discard", "--to", "saved", "--files", "*.txt"], quiet=True)
+        assert args is not None
+        args.func(args)
+
+        captured = capsys.readouterr()
+        assert "✓ Saved 3 hunks from 3 files to batch 'saved' and discarded them" in captured.err
+        assert captured.out.count("alpha.txt") == 0
+        assert captured.out.count("beta.txt") == 0
+        assert captured.out.count("gamma.txt") == 0
+
+        result = run_git_command(["diff", "--name-only"])
+        assert result.stdout == ""
+        metadata = read_batch_metadata("saved")
+        assert sorted(metadata["files"]) == ["alpha.txt", "beta.txt", "gamma.txt"]
+
     def test_include_files_can_restage_manually_unstaged_file_in_same_session(self, multi_file_repo, capsys):
         """Manual unstaging should not leave file-scoped include blocked in-session."""
         command_start()


### PR DESCRIPTION
The discard --to command resolves --files patterns to individual file paths and dispatches command_discard_to_batch for each one. Each per-file call prints its own status line and advances the selected change independently, producing noisy intermediate output that does not match the aggregate summary pattern used by include --files and skip --files.

Users discarding multiple files to a batch see one status line and one selected-change display per file instead of a single aggregate summary.

This PR addresses that across three commits:

- **Return saved hunk counts** from discard-to-batch helpers, changing the void return types to report how many hunks were saved. An advance parameter lets callers defer selection advancement until after all files are processed.
- **Aggregate dispatch** adds a helper that iterates the resolved file list with quiet=True and advance=False, collects per-file hunk counts, and prints one aggregate summary at the end.
- **Test coverage** verifies that the argument parser routes multi-file --files patterns through the aggregate helper with the correct flags, and that the aggregate summary reports the total hunk count across all files without per-file output.