### PR TITLE
Handle keyboard interrupts without tracebacks

### DIFF
--- a/src/git_stage_batch/cli/main.py
+++ b/src/git_stage_batch/cli/main.py
@@ -7,6 +7,7 @@ import sys
 from contextlib import nullcontext
 
 from ..exceptions import CommandError
+from ..i18n import _
 from ..utils.session_lock import acquire_session_lock
 from .argument_parser import parse_command_line
 from .dispatch import dispatch_args
@@ -31,6 +32,9 @@ def main() -> None:
         if e.message:
             print(e.message, file=sys.stderr)
         sys.exit(e.exit_code)
+    except KeyboardInterrupt:
+        print(_("Interrupted."), file=sys.stderr)
+        sys.exit(130)
 
 
 if __name__ == "__main__":

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -52,3 +52,20 @@ def test_main_acquires_session_lock_before_dispatch():
                         main_module.main()
 
     assert events == ["lock-enter", "dispatch", "lock-exit"]
+
+
+def test_main_handles_keyboard_interrupt_without_traceback(capsys):
+    """Ctrl-C should exit cleanly without Python's KeyboardInterrupt traceback."""
+    args = Namespace(working_directory=None)
+
+    with patch.object(sys, "argv", ["git-stage-batch", "show"]):
+        with patch.object(main_module, "parse_command_line", return_value=args):
+            with patch.object(main_module, "should_page_output", return_value=False):
+                with patch.object(main_module, "dispatch_args", side_effect=KeyboardInterrupt):
+                    with pytest.raises(SystemExit) as exc_info:
+                        main_module.main()
+
+    assert exc_info.value.code == 130
+    captured = capsys.readouterr()
+    assert "Interrupted." in captured.err
+    assert "Traceback" not in captured.err


### PR DESCRIPTION
The CLI entry point catches CommandError exceptions for controlled exits but does not handle KeyboardInterrupt. When a user presses Ctrl-C during a long operation, Python prints its default traceback and exits with status 1.

The traceback is confusing for users who expect Ctrl-C to silently cancel the operation, and exit status 1 does not follow the Unix convention of 128 + signal number for signal exits.

This PR addresses that across two commits:

- **Interrupt handling** catches KeyboardInterrupt in the main entry point, prints a brief "Interrupted." message to stderr, and exits with status 130 (128 + SIGINT).
- **Test coverage** verifies that the entry point exits with code 130, prints "Interrupted." to stderr, and does not include a traceback in the error output.