### PR TITLE
ci: Lower project baseline to Python 3.10 and parallelize test runs

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -2,7 +2,7 @@
 name: release
 description: Cut a new release — bump VERSION, build, open a PR, merge, tag, push, upload to GitHub and PyPI.
 whenToUse: Use this when the user wants to cut, publish, or ship a new release of the project.
-allowed-tools: Bash(git *), Bash(gh *), Bash(uv build), Bash(uv publish), Bash(cat VERSION), Bash(ls dist/), Bash(rm -rf dist/), Read, Write, Edit
+allowed-tools: Bash(git *), Bash(gh *), Bash(uv run pytest *), Bash(uv build), Bash(uv publish), Bash(cat VERSION), Bash(ls dist/), Bash(rm -rf dist/), Read, Write, Edit
 user-invocable: true
 ---
 
@@ -15,7 +15,7 @@ Ask the user for the new version number if they have not already provided one. T
 Before starting, verify:
 1. The working tree is clean (`git status --short` produces no output).
 2. You are on the `main` branch.
-3. All tests pass (`uv run pytest`).
+3. All tests pass (`uv run pytest -n auto`).
 
 If any check fails, stop and report the problem.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.13"]
+        python-version: ["3.10"]
       fail-fast: false
 
     steps:
@@ -23,11 +23,11 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
 
-      - name: Set up venv
-        run: uv venv
-
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
+
+      - name: Set up venv
+        run: uv venv --python ${{ matrix.python-version }}
 
       - name: Install meson
         run: uv pip install meson-python
@@ -50,11 +50,11 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
 
-      - name: Set up venv
-        run: uv venv
-
       - name: Set up Python
-        run: uv python install 3.13
+        run: uv python install 3.10
+
+      - name: Set up venv
+        run: uv venv --python 3.10
 
       - name: Install meson
         run: uv pip install meson-python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         run: uv sync --all-groups
 
       - name: Run tests
-        run: uv run pytest
+        run: uv run pytest -n auto
 
   build:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,10 @@ uv sync
 uv run pytest -n auto
 ```
 
+Use the xdist form (`-n auto`) for full-suite runs. The suite is large enough
+that serial `uv run pytest` is mainly useful for focused debugging or when
+reproducing ordering-sensitive failures.
+
 ## Commit Message Guidelines
 
 We follow strict commit message conventions to maintain a clear and understandable project history.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Thank you for your interest in contributing!
 This project uses [uv](https://docs.astral.sh/uv/) for development workflow and [Meson](https://mesonbuild.com/) as the build backend.
 
 **Requirements:**
-- Python 3.13+
+- Python 3.10+
 - uv (for development)
 - meson and ninja-build (install via your system package manager)
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -70,7 +70,7 @@ This runs the tool without permanently installing it.
 
 ## Requirements
 
-- **Python 3.13+**
+- **Python 3.10+**
 - No other dependencies (pure stdlib!)
 
 ## Verify Installation

--- a/tests/functional/README.md
+++ b/tests/functional/README.md
@@ -71,7 +71,7 @@ Tests interactive/TUI mode:
 
 ```bash
 # Run all functional tests
-uv run pytest tests/functional/
+uv run pytest -n auto tests/functional/
 
 # Run specific test file
 uv run pytest tests/functional/test_basic_workflow.py
@@ -104,10 +104,8 @@ uv run pytest tests/functional/test_status.py::TestStatusCommand::test_status_af
 
 ## Current Status
 
-**Status & Interactive Tests**: 45/45 passing ✅
-**Other Functional Tests**: Some failures (expected - catching real issues)
-
-The failing tests are **valuable** - they're catching actual bugs and edge cases that need fixing.
+The functional suite is expected to pass. Treat failures as release blockers
+unless a test is explicitly marked as an expected failure.
 
 ## Fixtures
 


### PR DESCRIPTION
The package metadata accepts Python 3.10 as its minimum runtime, but CI
runs on Python 3.13, contributor docs require 3.13, and the installation
guide states 3.13. The test suite runs serially everywhere — CI, release
validation, and local contributor runs.

Maintainers cannot tell from CI whether the minimum supported interpreter
still runs the project, and serial test execution adds several minutes to
every CI run, release attempt, and full local validation pass.

This series addresses both gaps. It pins CI and contributor tooling to
Python 3.10, updates documentation to reflect that baseline, and adds
pytest-xdist parallelism to CI, the release skill, and contributor
guidance.