### PR TITLE
include: Preserve file-review line positions during include fallback

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -2,7 +2,7 @@
 name: release
 description: Cut a new release — bump VERSION, build, open a PR, merge, tag, push, upload to GitHub and PyPI.
 whenToUse: Use this when the user wants to cut, publish, or ship a new release of the project.
-allowed-tools: Bash(git *), Bash(gh *), Bash(uv build), Bash(uv publish), Bash(cat VERSION), Bash(ls dist/), Bash(rm -rf dist/), Read, Write, Edit
+allowed-tools: Bash(git *), Bash(gh *), Bash(uv run pytest *), Bash(uv build), Bash(uv publish), Bash(cat VERSION), Bash(ls dist/), Bash(rm -rf dist/), Read, Write, Edit
 user-invocable: true
 ---
 
@@ -15,7 +15,7 @@ Ask the user for the new version number if they have not already provided one. T
 Before starting, verify:
 1. The working tree is clean (`git status --short` produces no output).
 2. You are on the `main` branch.
-3. All tests pass (`uv run pytest`).
+3. All tests pass (`uv run pytest -n auto`).
 
 If any check fails, stop and report the problem.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.13"]
+        python-version: ["3.10"]
       fail-fast: false
 
     steps:
@@ -23,11 +23,11 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
 
-      - name: Set up venv
-        run: uv venv
-
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
+
+      - name: Set up venv
+        run: uv venv --python ${{ matrix.python-version }}
 
       - name: Install meson
         run: uv pip install meson-python
@@ -50,11 +50,11 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
 
-      - name: Set up venv
-        run: uv venv
-
       - name: Set up Python
-        run: uv python install 3.13
+        run: uv python install 3.10
+
+      - name: Set up venv
+        run: uv venv --python 3.10
 
       - name: Install meson
         run: uv pip install meson-python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         run: uv sync --all-groups
 
       - name: Run tests
-        run: uv run pytest
+        run: uv run pytest -n auto
 
   build:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,10 @@ uv sync
 uv run pytest -n auto
 ```
 
+Use the xdist form (`-n auto`) for full-suite runs. The suite is large enough
+that serial `uv run pytest` is mainly useful for focused debugging or when
+reproducing ordering-sensitive failures.
+
 ## Commit Message Guidelines
 
 We follow strict commit message conventions to maintain a clear and understandable project history.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Thank you for your interest in contributing!
 This project uses [uv](https://docs.astral.sh/uv/) for development workflow and [Meson](https://mesonbuild.com/) as the build backend.
 
 **Requirements:**
-- Python 3.13+
+- Python 3.10+
 - uv (for development)
 - meson and ninja-build (install via your system package manager)
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -70,7 +70,7 @@ This runs the tool without permanently installing it.
 
 ## Requirements
 
-- **Python 3.13+**
+- **Python 3.10+**
 - No other dependencies (pure stdlib!)
 
 ## Verify Installation

--- a/src/git_stage_batch/batch/semantic_selection.py
+++ b/src/git_stage_batch/batch/semantic_selection.py
@@ -138,6 +138,15 @@ def _build_claimed_ranges(claimed_source_lines: set[int]) -> list[str]:
     return [format_line_ids(sorted(claimed_source_lines))]
 
 
+def _has_synthetic_gap(line_changes: LineLevelChange) -> bool:
+    return any(
+        line.kind == " "
+        and line.old_line_number is None
+        and line.new_line_number is None
+        for line in line_changes.lines
+    )
+
+
 def _build_temporary_ownership_for_selected_hunk(
     *,
     line_changes: LineLevelChange,
@@ -162,6 +171,11 @@ def _build_temporary_ownership_for_selected_hunk(
         first_unknown = min(unknown_ids)
         raise SemanticSelectionAmbiguousError(
             _("Line ID {id} not found in selected hunk.").format(id=first_unknown)
+        )
+
+    if _has_synthetic_gap(line_changes):
+        raise SemanticSelectionUnsupportedError(
+            _("Selected lines contain omitted file-review context.")
         )
 
     hunk_base_lines = _split_content_lines(selected_hunk_base_content)

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -35,6 +35,7 @@ from ..data.hunk_tracking import (
     advance_to_and_show_next_change,
     advance_to_next_change,
     apply_line_level_batch_filter_to_cached_hunk,
+    build_file_hunk_from_content,
     cache_unstaged_file_as_single_hunk,
     clear_selected_change_state_files,
     fetch_next_change,
@@ -70,6 +71,7 @@ from ..output import print_line_level_changes, print_remaining_line_changes_head
 from ..staging.operations import (
     build_target_index_content_bytes_with_replaced_lines,
     build_target_index_content_bytes_with_selected_lines,
+    build_target_working_tree_content_bytes_with_discarded_lines,
     update_index_with_blob_content,
 )
 from ..utils.command import ExitEvent, OutputEvent, stream_command
@@ -86,6 +88,35 @@ from ..utils.paths import (
     get_processed_include_ids_file_path,
     get_working_tree_snapshot_file_path,
 )
+
+
+def _file_line_signature(line) -> tuple[str, int | None, int | None, bytes]:
+    return (
+        line.kind,
+        line.old_line_number,
+        line.new_line_number,
+        line.text_bytes,
+    )
+
+
+def _already_staged_file_review_ids(line_changes, current_index_content: bytes) -> set[int]:
+    staged_line_changes = build_file_hunk_from_content(
+        line_changes.path,
+        current_index_content,
+    )
+    if staged_line_changes is None:
+        return set()
+
+    staged_signatures = {
+        _file_line_signature(line)
+        for line in staged_line_changes.lines
+        if line.id is not None
+    }
+    return {
+        line.id
+        for line in line_changes.lines
+        if line.id is not None and _file_line_signature(line) in staged_signatures
+    }
 
 
 def command_include(*, quiet: bool = False) -> None:
@@ -466,11 +497,27 @@ def command_include_line(line_id_specification: str, file: str | None = None) ->
                 selected_ids=sorted(combined_include_ids),
                 reason=semantic_attempt.reason,
             )
-            target_index_content = build_target_index_content_bytes_with_selected_lines(
-                line_changes,
-                combined_include_ids,
-                hunk_base_content,
-            )
+            if read_selected_change_kind() == SelectedChangeKind.FILE:
+                already_staged_ids = _already_staged_file_review_ids(
+                    line_changes,
+                    current_index_content,
+                )
+                unselected_ids = (
+                    set(line_changes.changed_line_ids())
+                    - combined_include_ids
+                    - already_staged_ids
+                )
+                target_index_content = build_target_working_tree_content_bytes_with_discarded_lines(
+                    line_changes,
+                    unselected_ids,
+                    hunk_source_content,
+                )
+            else:
+                target_index_content = build_target_index_content_bytes_with_selected_lines(
+                    line_changes,
+                    combined_include_ids,
+                    hunk_base_content,
+                )
 
         update_index_with_blob_content(line_changes.path, target_index_content)
 

--- a/src/git_stage_batch/staging/operations.py
+++ b/src/git_stage_batch/staging/operations.py
@@ -311,7 +311,7 @@ def build_target_working_tree_content_with_discarded_lines(
     working_lines = working_text.splitlines()
     output_lines: list[str] = []
 
-    working_pointer = line_changes.header.new_start - 1  # 0-based
+    working_pointer = max(line_changes.header.new_start - 1, 0)
     working_line_count = len(working_lines)
 
     def push_output(line: str) -> None:
@@ -326,12 +326,19 @@ def build_target_working_tree_content_with_discarded_lines(
             push_output(working_lines[working_pointer])
             working_pointer += 1
 
+    def copy_remaining_lines_before_deletion(index: int) -> None:
+        for next_entry in line_changes.lines[index + 1:]:
+            if next_entry.new_line_number is not None:
+                copy_unchanged_lines_before(next_entry.new_line_number)
+                return
+        copy_unchanged_lines_before(working_line_count + 1)
+
     # Copy lines before the hunk
     for index in range(0, min(working_pointer, working_line_count)):
         push_output(working_lines[index])
 
     # Process hunk lines
-    for line_entry in line_changes.lines:
+    for index, line_entry in enumerate(line_changes.lines):
         is_gap_line = (
             line_entry.kind == " "
             and line_entry.old_line_number is None
@@ -347,6 +354,7 @@ def build_target_working_tree_content_with_discarded_lines(
                 working_pointer += 1
         elif line_entry.kind == "-":
             if line_entry.id in discard_ids:
+                copy_remaining_lines_before_deletion(index)
                 push_output(line_entry.text)
         elif line_entry.kind == "+":
             copy_unchanged_lines_before(line_entry.new_line_number)
@@ -373,7 +381,7 @@ def build_target_working_tree_content_bytes_with_discarded_lines(
     working_lines = working_content.splitlines()
     output_lines: list[bytes] = []
 
-    working_pointer = line_changes.header.new_start - 1
+    working_pointer = max(line_changes.header.new_start - 1, 0)
     working_line_count = len(working_lines)
 
     def push_output(line: bytes) -> None:
@@ -388,10 +396,17 @@ def build_target_working_tree_content_bytes_with_discarded_lines(
             push_output(working_lines[working_pointer])
             working_pointer += 1
 
+    def copy_remaining_lines_before_deletion(index: int) -> None:
+        for next_entry in line_changes.lines[index + 1:]:
+            if next_entry.new_line_number is not None:
+                copy_unchanged_lines_before(next_entry.new_line_number)
+                return
+        copy_unchanged_lines_before(working_line_count + 1)
+
     for index in range(0, min(working_pointer, working_line_count)):
         push_output(working_lines[index])
 
-    for line_entry in line_changes.lines:
+    for index, line_entry in enumerate(line_changes.lines):
         is_gap_line = (
             line_entry.kind == " "
             and line_entry.old_line_number is None
@@ -407,6 +422,7 @@ def build_target_working_tree_content_bytes_with_discarded_lines(
                 working_pointer += 1
         elif line_entry.kind == "-":
             if line_entry.id in discard_ids:
+                copy_remaining_lines_before_deletion(index)
                 push_output(line_entry.text_bytes)
         elif line_entry.kind == "+":
             copy_unchanged_lines_before(line_entry.new_line_number)

--- a/tests/functional/README.md
+++ b/tests/functional/README.md
@@ -71,7 +71,7 @@ Tests interactive/TUI mode:
 
 ```bash
 # Run all functional tests
-uv run pytest tests/functional/
+uv run pytest -n auto tests/functional/
 
 # Run specific test file
 uv run pytest tests/functional/test_basic_workflow.py
@@ -104,10 +104,8 @@ uv run pytest tests/functional/test_status.py::TestStatusCommand::test_status_af
 
 ## Current Status
 
-**Status & Interactive Tests**: 45/45 passing ✅
-**Other Functional Tests**: Some failures (expected - catching real issues)
-
-The failing tests are **valuable** - they're catching actual bugs and edge cases that need fixing.
+The functional suite is expected to pass. Treat failures as release blockers
+unless a test is explicitly marked as an expected failure.
 
 ## Fixtures
 

--- a/tests/functional/test_semantic_partial_staging.py
+++ b/tests/functional/test_semantic_partial_staging.py
@@ -202,3 +202,46 @@ def test_semantic_partial_staging_falls_back_for_replacement_plus_trailing_inser
 
     assert result.returncode == 0
     assert _index_content(functional_repo, "file.txt") == "keep\nworking value\n"
+
+
+def test_semantic_partial_staging_falls_back_for_move_plus_edit(functional_repo):
+    _commit_file(
+        functional_repo,
+        "workflow.yml",
+        "steps:\n"
+        "  - name: Set up venv\n"
+        "    run: uv venv\n"
+        "\n"
+        "  - name: Set up Python\n"
+        "    run: uv python install 3.10\n"
+        "\n"
+        "  - name: Run tests\n"
+        "    run: uv run pytest\n",
+    )
+    (functional_repo / "workflow.yml").write_text(
+        "steps:\n"
+        "  - name: Set up Python\n"
+        "    run: uv python install 3.10\n"
+        "\n"
+        "  - name: Set up venv\n"
+        "    run: uv venv --python 3.10\n"
+        "\n"
+        "  - name: Run tests\n"
+        "    run: uv run pytest -n auto\n"
+    )
+
+    git_stage_batch("start", "-U0")
+    git_stage_batch("show", "--file", "workflow.yml", "--page", "all")
+    git_stage_batch("include", "--line", "1-6")
+
+    assert _index_content(functional_repo, "workflow.yml") == (
+        "steps:\n"
+        "  - name: Set up Python\n"
+        "    run: uv python install 3.10\n"
+        "\n"
+        "  - name: Set up venv\n"
+        "    run: uv venv --python 3.10\n"
+        "\n"
+        "  - name: Run tests\n"
+        "    run: uv run pytest\n"
+    )


### PR DESCRIPTION
Live file reviews can show multiple changes from one file as one numbered
line-selection view, including omitted regions between distant hunks.

When include --line falls back from semantic staging in that view, it
builds staged content from incomplete display coordinates. Move-plus-edit
selections can land additions at the wrong location, and later includes
can drop changes already staged in the index.

This series addresses that by declining semantic staging for synthetic
file-review gaps and by constructing file-scoped fallback content from
the working-tree snapshot while preserving line IDs that are already
staged. A functional regression test covers moved-block staging in
file-review views.