### PR TITLE
staging: Preserve zero-length selection and deletion-only anchors

### DIFF
--- a/src/git_stage_batch/batch/display.py
+++ b/src/git_stage_batch/batch/display.py
@@ -224,6 +224,10 @@ def _apply_batch_source_mapping(
         elif line.kind == "-":
             # Deletion: use last known batch source line as insertion position
             source_line = last_source_line
+            if source_line is None and line.old_line_number is not None and line.old_line_number > 1:
+                source_line = mapping.get_source_line_from_target_line(
+                    line.old_line_number - 1
+                )
 
         new_lines.append(
             LineEntry(
@@ -262,6 +266,8 @@ def _fill_source_from_working_tree(line_changes: LineLevelChange) -> LineLevelCh
                 last_source_line = source_line
         elif line.kind == "-":
             source_line = last_source_line
+            if source_line is None and line.old_line_number is not None and line.old_line_number > 1:
+                source_line = line.old_line_number - 1
 
         new_lines.append(
             LineEntry(

--- a/src/git_stage_batch/batch/ownership.py
+++ b/src/git_stage_batch/batch/ownership.py
@@ -349,6 +349,14 @@ def detect_stale_batch_source_for_selection(selected_lines: list) -> bool:
         # If they don't, the current batch source cannot express this change
         if line.kind in (' ', '+') and line.source_line is None:
             return True
+        # A None deletion anchor is only current for deletions before line 1.
+        if (
+            line.kind == '-'
+            and line.source_line is None
+            and line.old_line_number is not None
+            and line.old_line_number > 1
+        ):
+            return True
     return False
 
 
@@ -436,9 +444,10 @@ def translate_lines_to_batch_ownership(selected_lines: list) -> BatchOwnership:
         elif line.kind == '-':
             active_replacement_unit = None
             # Deletion: suppression constraint
-            # Use deletion's source_line as anchor if we haven't set one yet
-            # (This handles deletion-only selections where no context lines precede)
-            if current_deletion_anchor is None and line.source_line is not None:
+            # Anchor each deletion run at its first deleted line. A None anchor
+            # means the run starts before the first source line and must not be
+            # overwritten by later deleted lines in the same run.
+            if not current_deletion_lines:
                 current_deletion_anchor = line.source_line
             # text_bytes has line content with \r preserved but \n stripped (diff format)
             # Add back \n for proper round-tripping

--- a/src/git_stage_batch/batch/semantic_selection.py
+++ b/src/git_stage_batch/batch/semantic_selection.py
@@ -186,7 +186,7 @@ def _build_temporary_ownership_for_selected_hunk(
     selected_rows: list[SemanticSelectionRow] = []
     pairing_modes: set[str] = set()
 
-    old_pointer = max(line_changes.header.old_start - 1, 0)
+    old_pointer = line_changes.header.old_prefix_line_count()
     for index in range(0, min(old_pointer, len(hunk_base_lines))):
         source_lines.append(hunk_base_lines[index])
 

--- a/src/git_stage_batch/core/models.py
+++ b/src/git_stage_batch/core/models.py
@@ -14,6 +14,16 @@ class HunkHeader:
     new_start: int
     new_len: int
 
+    def old_prefix_line_count(self) -> int:
+        """Return the number of old-file lines before this hunk applies.
+
+        In insertion-only hunks, unified diff uses old_start as the anchor
+        before the inserted lines rather than as the first changed old line.
+        """
+        if self.old_len == 0:
+            return max(self.old_start, 0)
+        return max(self.old_start - 1, 0)
+
 
 @dataclass
 class SingleHunkPatch:

--- a/src/git_stage_batch/core/models.py
+++ b/src/git_stage_batch/core/models.py
@@ -24,6 +24,16 @@ class HunkHeader:
             return max(self.old_start, 0)
         return max(self.old_start - 1, 0)
 
+    def new_prefix_line_count(self) -> int:
+        """Return the number of new-file lines before this hunk applies.
+
+        In deletion-only hunks, unified diff uses new_start as the anchor
+        before the deleted lines rather than as the first changed new line.
+        """
+        if self.new_len == 0:
+            return max(self.new_start, 0)
+        return max(self.new_start - 1, 0)
+
 
 @dataclass
 class SingleHunkPatch:

--- a/src/git_stage_batch/staging/operations.py
+++ b/src/git_stage_batch/staging/operations.py
@@ -2,9 +2,52 @@
 
 from __future__ import annotations
 
-from ..core.models import LineLevelChange
+from ..core.models import LineEntry, LineLevelChange
 from ..utils.git import create_git_blob, run_git_command
 from ..utils.journal import log_journal
+
+
+def _is_synthetic_gap_line(line_entry: LineEntry) -> bool:
+    return (
+        line_entry.kind == " "
+        and line_entry.old_line_number is None
+        and line_entry.new_line_number is None
+    )
+
+
+def _old_index_for_new_anchor(
+    line_changes: LineLevelChange,
+    new_anchor: int,
+    before_index: int,
+) -> int:
+    """Translate a new-file anchor to an old-file insertion index.
+
+    File-scoped views can concatenate separate hunks and omit their individual
+    zero-length headers. Counting earlier changed entries restores the line
+    number delta at the selected row.
+    """
+    old_index = new_anchor
+    for line_entry in line_changes.lines[:before_index]:
+        if line_entry.kind == "+":
+            old_index -= 1
+        elif line_entry.kind == "-":
+            old_index += 1
+    return max(old_index, 0)
+
+
+def _new_index_for_old_anchor(
+    line_changes: LineLevelChange,
+    old_anchor: int,
+    before_index: int,
+) -> int:
+    """Translate an old-file anchor to a new-file insertion index."""
+    new_index = old_anchor
+    for line_entry in line_changes.lines[:before_index]:
+        if line_entry.kind == "-":
+            new_index -= 1
+        elif line_entry.kind == "+":
+            new_index += 1
+    return max(new_index, 0)
 
 
 def build_target_index_content_with_selected_lines(
@@ -234,20 +277,47 @@ def build_target_index_content_bytes_with_replaced_lines(
 
     def find_next_old_line_number(start_index: int) -> int | None:
         for line_entry in line_changes.lines[start_index:]:
+            if _is_synthetic_gap_line(line_entry):
+                return None
             if line_entry.old_line_number is not None:
                 return line_entry.old_line_number
         return None
+
+    def find_previous_old_line_number(end_index: int) -> int | None:
+        for line_entry in reversed(line_changes.lines[:end_index + 1]):
+            if _is_synthetic_gap_line(line_entry):
+                return None
+            if line_entry.old_line_number is not None:
+                return line_entry.old_line_number
+        return None
+
+    def old_insertion_index(index: int) -> int:
+        line_entry = line_changes.lines[index]
+        if line_entry.kind == "+" and line_entry.new_line_number is not None:
+            return min(
+                _old_index_for_new_anchor(
+                    line_changes,
+                    line_entry.new_line_number - 1,
+                    index,
+                ),
+                base_line_count,
+            )
+
+        previous_old_line_number = find_previous_old_line_number(index - 1)
+        if previous_old_line_number is not None:
+            return min(previous_old_line_number, base_line_count)
+
+        next_old_line_number = find_next_old_line_number(index + 1)
+        if next_old_line_number is not None:
+            return max(next_old_line_number - 1, 0)
+
+        return min(line_changes.header.old_prefix_line_count(), base_line_count)
 
     first_selected_line = line_changes.lines[span_start_index]
     if first_selected_line.old_line_number is not None:
         replace_start = max(first_selected_line.old_line_number - 1, 0)
     else:
-        next_old_line_number = find_next_old_line_number(span_start_index + 1)
-        replace_start = (
-            max(next_old_line_number - 1, 0)
-            if next_old_line_number is not None
-            else base_line_count
-        )
+        replace_start = old_insertion_index(span_start_index)
 
     replace_end = base_line_count
     for line_entry in reversed(line_changes.lines[span_start_index:span_end_index + 1]):
@@ -255,12 +325,7 @@ def build_target_index_content_bytes_with_replaced_lines(
             replace_end = line_entry.old_line_number
             break
     else:
-        next_old_line_number = find_next_old_line_number(span_end_index + 1)
-        replace_end = (
-            max(next_old_line_number - 1, 0)
-            if next_old_line_number is not None
-            else base_line_count
-        )
+        replace_end = replace_start
 
     if trim_unchanged_edge_anchors:
         before_context = base_lines[:replace_start]
@@ -317,7 +382,7 @@ def build_target_working_tree_content_with_discarded_lines(
     working_lines = working_text.splitlines()
     output_lines: list[str] = []
 
-    working_pointer = max(line_changes.header.new_start - 1, 0)
+    working_pointer = line_changes.header.new_prefix_line_count()
     working_line_count = len(working_lines)
 
     def push_output(line: str) -> None:
@@ -328,16 +393,31 @@ def build_target_working_tree_content_with_discarded_lines(
         if new_line_number is None:
             return
         target_index = max(new_line_number - 1, 0)
+        copy_unchanged_lines_until_index(target_index)
+
+    def copy_unchanged_lines_until_index(target_index: int) -> None:
+        nonlocal working_pointer
         while working_pointer < min(target_index, working_line_count):
             push_output(working_lines[working_pointer])
             working_pointer += 1
 
     def copy_remaining_lines_before_deletion(index: int) -> None:
+        line_entry = line_changes.lines[index]
+        if line_entry.old_line_number is not None:
+            copy_unchanged_lines_until_index(
+                _new_index_for_old_anchor(
+                    line_changes,
+                    line_entry.old_line_number - 1,
+                    index,
+                )
+            )
+
         for next_entry in line_changes.lines[index + 1:]:
+            if _is_synthetic_gap_line(next_entry):
+                return
             if next_entry.new_line_number is not None:
                 copy_unchanged_lines_before(next_entry.new_line_number)
                 return
-        copy_unchanged_lines_before(working_line_count + 1)
 
     # Copy lines before the hunk
     for index in range(0, min(working_pointer, working_line_count)):
@@ -387,7 +467,7 @@ def build_target_working_tree_content_bytes_with_discarded_lines(
     working_lines = working_content.splitlines()
     output_lines: list[bytes] = []
 
-    working_pointer = max(line_changes.header.new_start - 1, 0)
+    working_pointer = line_changes.header.new_prefix_line_count()
     working_line_count = len(working_lines)
 
     def push_output(line: bytes) -> None:
@@ -398,16 +478,31 @@ def build_target_working_tree_content_bytes_with_discarded_lines(
         if new_line_number is None:
             return
         target_index = max(new_line_number - 1, 0)
+        copy_unchanged_lines_until_index(target_index)
+
+    def copy_unchanged_lines_until_index(target_index: int) -> None:
+        nonlocal working_pointer
         while working_pointer < min(target_index, working_line_count):
             push_output(working_lines[working_pointer])
             working_pointer += 1
 
     def copy_remaining_lines_before_deletion(index: int) -> None:
+        line_entry = line_changes.lines[index]
+        if line_entry.old_line_number is not None:
+            copy_unchanged_lines_until_index(
+                _new_index_for_old_anchor(
+                    line_changes,
+                    line_entry.old_line_number - 1,
+                    index,
+                )
+            )
+
         for next_entry in line_changes.lines[index + 1:]:
+            if _is_synthetic_gap_line(next_entry):
+                return
             if next_entry.new_line_number is not None:
                 copy_unchanged_lines_before(next_entry.new_line_number)
                 return
-        copy_unchanged_lines_before(working_line_count + 1)
 
     for index in range(0, min(working_pointer, working_line_count)):
         push_output(working_lines[index])
@@ -502,20 +597,47 @@ def build_target_working_tree_content_bytes_with_replaced_lines(
 
     def find_next_new_line_number(start_index: int) -> int | None:
         for line_entry in line_changes.lines[start_index:]:
+            if _is_synthetic_gap_line(line_entry):
+                return None
             if line_entry.new_line_number is not None:
                 return line_entry.new_line_number
         return None
+
+    def find_previous_new_line_number(end_index: int) -> int | None:
+        for line_entry in reversed(line_changes.lines[:end_index + 1]):
+            if _is_synthetic_gap_line(line_entry):
+                return None
+            if line_entry.new_line_number is not None:
+                return line_entry.new_line_number
+        return None
+
+    def new_insertion_index(index: int) -> int:
+        line_entry = line_changes.lines[index]
+        if line_entry.kind == "-" and line_entry.old_line_number is not None:
+            return min(
+                _new_index_for_old_anchor(
+                    line_changes,
+                    line_entry.old_line_number - 1,
+                    index,
+                ),
+                working_line_count,
+            )
+
+        previous_new_line_number = find_previous_new_line_number(index - 1)
+        if previous_new_line_number is not None:
+            return min(previous_new_line_number, working_line_count)
+
+        next_new_line_number = find_next_new_line_number(index + 1)
+        if next_new_line_number is not None:
+            return max(next_new_line_number - 1, 0)
+
+        return min(line_changes.header.new_prefix_line_count(), working_line_count)
 
     first_selected_line = line_changes.lines[span_start_index]
     if first_selected_line.new_line_number is not None:
         replace_start = max(first_selected_line.new_line_number - 1, 0)
     else:
-        next_new_line_number = find_next_new_line_number(span_start_index + 1)
-        replace_start = (
-            max(next_new_line_number - 1, 0)
-            if next_new_line_number is not None
-            else working_line_count
-        )
+        replace_start = new_insertion_index(span_start_index)
 
     replace_end = working_line_count
     for line_entry in reversed(line_changes.lines[span_start_index:span_end_index + 1]):
@@ -523,12 +645,7 @@ def build_target_working_tree_content_bytes_with_replaced_lines(
             replace_end = line_entry.new_line_number
             break
     else:
-        next_new_line_number = find_next_new_line_number(span_end_index + 1)
-        replace_end = (
-            max(next_new_line_number - 1, 0)
-            if next_new_line_number is not None
-            else working_line_count
-        )
+        replace_end = replace_start
 
     if trim_unchanged_edge_anchors:
         before_context = working_lines[:replace_start]

--- a/src/git_stage_batch/staging/operations.py
+++ b/src/git_stage_batch/staging/operations.py
@@ -26,7 +26,7 @@ def build_target_index_content_with_selected_lines(
     output_lines: list[str] = []
     pending_additions: list[str] = []
 
-    base_pointer = 0
+    base_pointer = line_changes.header.old_prefix_line_count()
     base_line_count = len(base_lines)
 
     def push_output(line: str) -> None:
@@ -48,6 +48,9 @@ def build_target_index_content_with_selected_lines(
         while base_pointer < min(target_index, base_line_count):
             push_output(base_lines[base_pointer])
             base_pointer += 1
+
+    for index in range(0, min(base_pointer, base_line_count)):
+        push_output(base_lines[index])
 
     for line_entry in line_changes.lines:
         is_gap_line = (
@@ -101,7 +104,7 @@ def build_target_index_content_bytes_with_selected_lines(
     output_lines: list[bytes] = []
     pending_additions: list[bytes] = []
 
-    base_pointer = 0
+    base_pointer = line_changes.header.old_prefix_line_count()
     base_line_count = len(base_lines)
 
     def push_output(line: bytes) -> None:
@@ -123,6 +126,9 @@ def build_target_index_content_bytes_with_selected_lines(
         while base_pointer < min(target_index, base_line_count):
             push_output(base_lines[base_pointer])
             base_pointer += 1
+
+    for index in range(0, min(base_pointer, base_line_count)):
+        push_output(base_lines[index])
 
     for line_entry in line_changes.lines:
         is_gap_line = (

--- a/tests/batch/test_ownership_incremental.py
+++ b/tests/batch/test_ownership_incremental.py
@@ -78,3 +78,19 @@ def test_translate_lines_preserves_deletion_structure():
     assert ownership.deletions[1].content_lines == [b'del3\n']
     assert ownership.deletions[1].anchor_line == 1  # after source line 1
     assert ownership.replacement_units == []
+
+
+def test_translate_lines_keeps_file_start_anchor_for_deletion_run():
+    """A file-start deletion run should keep its None anchor."""
+    lines = [
+        LineEntry(id=1, kind='-', old_line_number=1, new_line_number=None,
+                  text_bytes=b'first', text='first', source_line=None),
+        LineEntry(id=2, kind='-', old_line_number=2, new_line_number=None,
+                  text_bytes=b'second', text='second', source_line=1),
+    ]
+
+    ownership = translate_lines_to_batch_ownership(lines)
+
+    assert len(ownership.deletions) == 1
+    assert ownership.deletions[0].anchor_line is None
+    assert ownership.deletions[0].content_lines == [b'first\n', b'second\n']

--- a/tests/batch/test_source_refresh.py
+++ b/tests/batch/test_source_refresh.py
@@ -133,6 +133,28 @@ def test_prepare_batch_ownership_update_first_time_stale_blank_context():
     assert result.ownership_after.claimed_lines == ["1-2"]
 
 
+def test_prepare_batch_ownership_update_first_time_deletion_anchor():
+    """First-time deletion-only selections keep their source anchor."""
+    lines = [
+        LineEntry(
+            id=1, kind='-', old_line_number=2, new_line_number=None,
+            text_bytes=b"old line", text="old line", source_line=None
+        ),
+    ]
+
+    result = prepare_batch_ownership_update_for_selection(
+        batch_name="test-batch",
+        file_path="test.py",
+        current_batch_source_commit=None,
+        existing_ownership=None,
+        selected_lines=lines
+    )
+
+    assert result.batch_source_commit is None
+    assert result.ownership_before is None
+    assert result.ownership_after.deletions[0].anchor_line == 1
+
+
 def test_prepare_batch_ownership_update_first_time():
     """Test prepare_batch_ownership_update_for_selection for first-time add."""
     # Lines with valid source_line (first add to batch)

--- a/tests/batch/test_stale_source_advancement.py
+++ b/tests/batch/test_stale_source_advancement.py
@@ -42,6 +42,26 @@ def test_detect_current_batch_source_with_valid_source_lines():
     assert detect_stale_batch_source_for_selection(current_lines) is False
 
 
+def test_detect_stale_batch_source_with_missing_deletion_anchor():
+    """Deletion-only selections after file start need source refresh."""
+    stale_lines = [
+        LineEntry(id=1, kind='-', old_line_number=2, new_line_number=None,
+                 text_bytes=b"old line", text="old line", source_line=None),
+    ]
+
+    assert detect_stale_batch_source_for_selection(stale_lines) is True
+
+
+def test_detect_current_batch_source_with_file_start_deletion_anchor():
+    """A missing deletion source line is valid before the first line."""
+    current_lines = [
+        LineEntry(id=1, kind='-', old_line_number=1, new_line_number=None,
+                 text_bytes=b"old first", text="old first", source_line=None),
+    ]
+
+    assert detect_stale_batch_source_for_selection(current_lines) is False
+
+
 def test_translate_fails_loudly_with_none_source_line():
     """Test that translation fails loudly instead of silently dropping None source_lines."""
     stale_lines = [

--- a/tests/core/test_models.py
+++ b/tests/core/test_models.py
@@ -25,6 +25,30 @@ class TestHunkHeader:
         assert header1 == header2
         assert header1 != header3
 
+    def test_old_prefix_line_count_for_non_empty_range(self):
+        """Non-empty old ranges start at the first changed old line."""
+        header = HunkHeader(old_start=10, old_len=3, new_start=12, new_len=5)
+
+        assert header.old_prefix_line_count() == 9
+
+    def test_old_prefix_line_count_for_zero_length_range(self):
+        """Zero-length old ranges are anchored after old_start."""
+        header = HunkHeader(old_start=10, old_len=0, new_start=11, new_len=2)
+
+        assert header.old_prefix_line_count() == 10
+
+    def test_new_prefix_line_count_for_non_empty_range(self):
+        """Non-empty new ranges start at the first changed new line."""
+        header = HunkHeader(old_start=10, old_len=5, new_start=12, new_len=3)
+
+        assert header.new_prefix_line_count() == 11
+
+    def test_new_prefix_line_count_for_zero_length_range(self):
+        """Zero-length new ranges are anchored after new_start."""
+        header = HunkHeader(old_start=10, old_len=2, new_start=9, new_len=0)
+
+        assert header.new_prefix_line_count() == 9
+
 
 class TestSingleHunkPatch:
     """Tests for SingleHunkPatch dataclass."""

--- a/tests/functional/test_semantic_partial_staging.py
+++ b/tests/functional/test_semantic_partial_staging.py
@@ -90,6 +90,54 @@ def test_semantic_partial_staging_pure_addition(functional_repo):
     assert _index_content(functional_repo, "file.txt") == "base\nfoo\n"
 
 
+def test_semantic_partial_staging_pure_addition_preserves_blank_anchor(functional_repo):
+    _commit_file(
+        functional_repo,
+        "CONTRIBUTING.md",
+        "# Contributing\n"
+        "\n"
+        "```bash\n"
+        "uv run pytest -n auto\n"
+        "```\n"
+        "\n"
+        "## Commit Message Guidelines\n",
+    )
+    (functional_repo / "CONTRIBUTING.md").write_text(
+        "# Contributing\n"
+        "\n"
+        "```bash\n"
+        "uv run pytest -n auto\n"
+        "```\n"
+        "\n"
+        "Use the xdist form (`-n auto`) for full-suite runs.\n"
+        "\n"
+        "## Commit Message Guidelines\n"
+    )
+
+    git_stage_batch("start", "-U0")
+    git_stage_batch("include", "--line", "1-2")
+
+    assert _index_content(functional_repo, "CONTRIBUTING.md") == (
+        "# Contributing\n"
+        "\n"
+        "```bash\n"
+        "uv run pytest -n auto\n"
+        "```\n"
+        "\n"
+        "Use the xdist form (`-n auto`) for full-suite runs.\n"
+        "\n"
+        "## Commit Message Guidelines\n"
+    )
+    result = subprocess.run(
+        ["git", "diff", "--", "CONTRIBUTING.md"],
+        check=True,
+        cwd=functional_repo,
+        capture_output=True,
+        text=True,
+    )
+    assert result.stdout == ""
+
+
 def test_semantic_partial_staging_pure_deletion(functional_repo):
     _commit_file(functional_repo, "file.txt", "a\nb\nc\n")
     (functional_repo / "file.txt").write_text("a\nc\n")

--- a/tests/functional/test_semantic_partial_staging.py
+++ b/tests/functional/test_semantic_partial_staging.py
@@ -138,6 +138,52 @@ def test_semantic_partial_staging_pure_addition_preserves_blank_anchor(functiona
     assert result.stdout == ""
 
 
+def test_include_line_as_pure_addition_preserves_anchor(functional_repo):
+    _commit_file(functional_repo, "file.txt", "A\nC\n")
+    (functional_repo / "file.txt").write_text("A\nB\nC\n")
+
+    git_stage_batch("start", "-U0")
+    git_stage_batch("include", "--line", "1", "--as", "X")
+
+    assert _index_content(functional_repo, "file.txt") == "A\nX\nC\n"
+
+
+def test_discard_line_pure_deletion_preserves_anchor(functional_repo):
+    _commit_file(functional_repo, "file.txt", "A\nB\nC\n")
+    (functional_repo / "file.txt").write_text("A\nC\n")
+
+    git_stage_batch("start", "-U0")
+    git_stage_batch("discard", "--line", "1")
+
+    assert (functional_repo / "file.txt").read_text() == "A\nB\nC\n"
+    result = subprocess.run(
+        ["git", "diff", "--", "file.txt"],
+        check=True,
+        cwd=functional_repo,
+        capture_output=True,
+        text=True,
+    )
+    assert result.stdout == ""
+
+
+def test_discard_file_line_pure_deletion_preserves_anchor(functional_repo):
+    _commit_file(
+        functional_repo,
+        "file.txt",
+        "line1\nold-a\nline3\nline4\nline5\nold-b\nline7\n",
+    )
+    (functional_repo / "file.txt").write_text(
+        "line1\nline3\nline4\nline5\nline7\n"
+    )
+
+    git_stage_batch("start", "-U0")
+    git_stage_batch("discard", "--file", "file.txt", "--line", "1")
+
+    assert (functional_repo / "file.txt").read_text() == (
+        "line1\nold-a\nline3\nline4\nline5\nline7\n"
+    )
+
+
 def test_semantic_partial_staging_pure_deletion(functional_repo):
     _commit_file(functional_repo, "file.txt", "a\nb\nc\n")
     (functional_repo / "file.txt").write_text("a\nc\n")

--- a/tests/staging/test_operations.py
+++ b/tests/staging/test_operations.py
@@ -187,6 +187,42 @@ class TestBuildTargetIndexContent:
 
         assert result == "line1\nline2\n"
 
+    def test_insertion_only_hunk_keeps_anchor_line(self):
+        """Zero-length old ranges insert after the old start line."""
+        header = HunkHeader(2, 0, 3, 2)
+        lines = [
+            LineEntry(1, "+", None, 3, text_bytes=b"inserted", text="inserted"),
+            LineEntry(2, "+", None, 4, text_bytes=b"", text=""),
+        ]
+        line_changes = LineLevelChange(path="test.txt", header=header, lines=lines)
+        base_text = "line1\n\nline3\n"
+
+        result = build_target_index_content_with_selected_lines(
+            line_changes,
+            {1, 2},
+            base_text,
+        )
+
+        assert result == "line1\n\ninserted\n\nline3\n"
+
+    def test_insertion_only_hunk_keeps_anchor_line_bytes(self):
+        """Bytes-preserving insertion staging should keep the anchor line."""
+        header = HunkHeader(2, 0, 3, 2)
+        lines = [
+            LineEntry(1, "+", None, 3, text_bytes=b"inserted", text="inserted"),
+            LineEntry(2, "+", None, 4, text_bytes=b"", text=""),
+        ]
+        line_changes = LineLevelChange(path="test.txt", header=header, lines=lines)
+        base_content = b"line1\n\nline3\n"
+
+        result = build_target_index_content_bytes_with_selected_lines(
+            line_changes,
+            {1, 2},
+            base_content,
+        )
+
+        assert result == b"line1\n\ninserted\n\nline3\n"
+
     def test_preserves_trailing_newline(self):
         """Test that trailing newline is preserved from base."""
         header = HunkHeader(1, 1, 1, 2)

--- a/tests/staging/test_operations.py
+++ b/tests/staging/test_operations.py
@@ -9,6 +9,7 @@ from git_stage_batch.staging.operations import (
     build_target_index_content_bytes_with_selected_lines,
     build_target_index_content_bytes_with_replaced_lines,
     build_target_index_content_with_selected_lines,
+    build_target_working_tree_content_bytes_with_discarded_lines,
     build_target_working_tree_content_bytes_with_replaced_lines,
     build_target_working_tree_content_with_discarded_lines,
     update_index_with_blob_content,
@@ -483,6 +484,51 @@ class TestBuildTargetIndexContent:
             b"line20\n"
         )
 
+    def test_replace_insertion_only_hunk_uses_old_anchor(self):
+        """Pure insertion replacement should not move to the file end."""
+        header = HunkHeader(2, 0, 3, 1)
+        lines = [
+            LineEntry(1, "+", None, 3, text_bytes=b"inserted", text="inserted"),
+        ]
+        line_changes = LineLevelChange(path="test.txt", header=header, lines=lines)
+        base_content = b"line1\n\nline3\n"
+
+        result = build_target_index_content_bytes_with_replaced_lines(
+            line_changes,
+            {1},
+            "replacement",
+            base_content,
+        )
+
+        assert result == b"line1\n\nreplacement\nline3\n"
+
+    def test_replace_file_scoped_insertion_uses_prior_change_delta(self):
+        """File-scoped pure insertions should keep anchors after prior hunks."""
+        header = HunkHeader(1, 1, 2, 3)
+        lines = [
+            LineEntry(1, "+", None, 2, text_bytes=b"add-a", text="add-a"),
+            LineEntry(
+                None,
+                " ",
+                None,
+                None,
+                text_bytes=b"... 1 more line ...",
+                text="... 1 more line ...",
+            ),
+            LineEntry(2, "+", None, 4, text_bytes=b"add-b", text="add-b"),
+        ]
+        line_changes = LineLevelChange(path="test.txt", header=header, lines=lines)
+        base_content = b"line1\nline3\nline5\n"
+
+        result = build_target_index_content_bytes_with_replaced_lines(
+            line_changes,
+            {2},
+            "replacement",
+            base_content,
+        )
+
+        assert result == b"line1\nline3\nreplacement\nline5\n"
+
     def test_replace_selection_spans_multiple_file_scoped_regions(self):
         """File-scoped replacement staging should replace the full selected span."""
         header = HunkHeader(5, 32, 5, 38)
@@ -629,6 +675,24 @@ class TestBuildTargetIndexContent:
 
         assert result == b"keep1\nkeep1\nstaged\nkeep3\nkeep4\nkeep3\nkeep4\n"
 
+    def test_working_tree_replace_deletion_only_hunk_uses_new_anchor(self):
+        """Pure deletion replacement should not move to the file end."""
+        header = HunkHeader(2, 1, 1, 0)
+        lines = [
+            LineEntry(1, "-", 2, None, text_bytes=b"deleted", text="deleted"),
+        ]
+        line_changes = LineLevelChange(path="test.txt", header=header, lines=lines)
+        working_content = b"line1\nline3\n"
+
+        result = build_target_working_tree_content_bytes_with_replaced_lines(
+            line_changes,
+            {1},
+            "replacement",
+            working_content,
+        )
+
+        assert result == b"line1\nreplacement\nline3\n"
+
 
 class TestBuildTargetWorkingTreeContent:
     """Tests for build_target_working_tree_content_with_discarded_lines."""
@@ -664,6 +728,72 @@ class TestBuildTargetWorkingTreeContent:
 
         # Discarding the deletion reinserts it
         assert result == "line1\ndeleted line\nline2\n"
+
+    def test_deletion_only_hunk_keeps_new_anchor_line(self):
+        """Zero-length new ranges reinsert after the new start line."""
+        header = HunkHeader(2, 1, 1, 0)
+        lines = [
+            LineEntry(1, "-", 2, None, text_bytes=b"deleted", text="deleted"),
+        ]
+        line_changes = LineLevelChange(path="test.txt", header=header, lines=lines)
+        working_text = "line1\nline3\n"
+
+        result = build_target_working_tree_content_with_discarded_lines(
+            line_changes,
+            {1},
+            working_text,
+        )
+
+        assert result == "line1\ndeleted\nline3\n"
+
+    def test_deletion_only_hunk_keeps_new_anchor_line_bytes(self):
+        """Bytes-preserving deletion discard should keep the anchor line."""
+        header = HunkHeader(2, 1, 1, 0)
+        lines = [
+            LineEntry(1, "-", 2, None, text_bytes=b"deleted", text="deleted"),
+        ]
+        line_changes = LineLevelChange(path="test.txt", header=header, lines=lines)
+        working_content = b"line1\nline3\n"
+
+        result = build_target_working_tree_content_bytes_with_discarded_lines(
+            line_changes,
+            {1},
+            working_content,
+        )
+
+        assert result == b"line1\ndeleted\nline3\n"
+
+    def test_file_scoped_deletion_uses_prior_change_delta(self):
+        """File-scoped deletions should keep anchors after prior hunks."""
+        header = HunkHeader(2, 5, 1, 3)
+        lines = [
+            LineEntry(1, "-", 2, None, text_bytes=b"old-a", text="old-a"),
+            LineEntry(
+                None,
+                " ",
+                None,
+                None,
+                text_bytes=b"... 3 more lines ...",
+                text="... 3 more lines ...",
+            ),
+            LineEntry(2, "-", 6, None, text_bytes=b"old-b", text="old-b"),
+        ]
+        line_changes = LineLevelChange(path="test.txt", header=header, lines=lines)
+        working_text = "line1\nline3\nline4\nline5\nline7\n"
+
+        first_result = build_target_working_tree_content_with_discarded_lines(
+            line_changes,
+            {1},
+            working_text,
+        )
+        second_result = build_target_working_tree_content_with_discarded_lines(
+            line_changes,
+            {2},
+            working_text,
+        )
+
+        assert first_result == "line1\nold-a\nline3\nline4\nline5\nline7\n"
+        assert second_result == "line1\nline3\nline4\nline5\nold-b\nline7\n"
 
     def test_keep_addition(self):
         """Test keeping an added line (not discarding)."""


### PR DESCRIPTION
Line-level staging rebuilds index and worktree content from hunk line
numbers. Hunk headers expose old-range start positions and prefix
counts, and selection builders use those values to place additions and
deletions.

Pure insertions and pure deletions are zero-width spans on one side of a
diff. When a hunk or file-scoped view lacks context, the only anchor can
be old_start, new_start, or prior changed rows. Treating the span as the
file end or scanning across an omitted gap moves replacement text and
restored deletions away from their source position. Batch ownership has a
similar problem: deletion-only selections can arrive without context
before the deleted run, and missing anchors land claims at the wrong
source line.

This series addresses those gaps across three layers. HunkHeader now
exposes a shared prefix count so insertion anchors stay correct. Selection
builders stop at synthetic gaps and derive zero-width insertion indexes
from prior diff rows. Batch ownership refreshes stale deletion anchors
from old-side predecessors while preserving None anchors for file-start
deletions. Each fix includes unit and functional test coverage.