### PR TITLE
process: Normalize spawned command PWD

### DIFF
--- a/src/git_stage_batch/utils/command.py
+++ b/src/git_stage_batch/utils/command.py
@@ -253,6 +253,12 @@ def _resolve_spawn_executable(executable: str, env: dict[str, str]) -> str:
     return _resolve_spawn_executable_from_paths(executable, os.get_exec_path(env))
 
 
+def _spawn_environment(env: dict[str, str] | None) -> dict[str, str]:
+    spawn_env = os.environ.copy() if env is None else dict(env)
+    spawn_env["PWD"] = os.getcwd()
+    return spawn_env
+
+
 def _add_spawn_close_action(
     file_actions: list[tuple[int, int] | tuple[int, int, int]],
     fd: int,
@@ -597,7 +603,7 @@ def start_command(
         child_fds_seen.add(captured.child_fd)
 
     executable, spawn_arguments = _spawn_arguments_for_cwd(arguments, cwd)
-    spawn_env = os.environ.copy() if env is None else env
+    spawn_env = _spawn_environment(env)
     executable_path = _resolve_spawn_executable(executable, spawn_env)
 
     # Create pipes for stdin/stdout/stderr

--- a/tests/utils/test_stream_process.py
+++ b/tests/utils/test_stream_process.py
@@ -698,6 +698,43 @@ class TestCwdAndEnv:
 
         assert output_data == b"absolute\n"
 
+    def test_command_receives_current_pwd_when_parent_env_is_stale(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        """Test direct child PWD matches the process cwd."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("PWD", "/stale/logical/path")
+
+        result = run_command([
+            sys.executable,
+            "-c",
+            "import os; print(os.environ['PWD'])",
+        ])
+
+        assert result.stdout == f"{os.getcwd()}\n"
+
+    def test_env_parameter_pwd_is_copied_and_normalized(self, tmp_path, monkeypatch):
+        """Test caller env mappings are not mutated while normalizing PWD."""
+        monkeypatch.chdir(tmp_path)
+        child_env = {
+            "PATH": os.environ.get("PATH", ""),
+            "PWD": "/stale/logical/path",
+        }
+
+        result = run_command(
+            [
+                sys.executable,
+                "-c",
+                "import os; print(os.environ['PWD'])",
+            ],
+            env=child_env,
+        )
+
+        assert result.stdout == f"{os.getcwd()}\n"
+        assert child_env["PWD"] == "/stale/logical/path"
+
     def test_env_parameter(self):
         """Test that env parameter works."""
         events = list(stream_command(


### PR DESCRIPTION
The streaming command runner starts child processes in the current
directory unless a command asks for an explicit cwd.

In toolbox mounts, the inherited PWD can name the same directory through
another path. Git accepts that logical path and can report index lock
paths under that spelling, which makes diagnostics point at
/run/host/run/host/... instead of the physical repository path.

This series copies the spawn environment and resets PWD to os.getcwd()
for child processes that run from the current directory. Callers that
pass env dictionaries keep their original mapping untouched. Tests
verify PWD normalization under a stale value and env-dict immutability.