### PR TITLE
cli/undo: Add typed file scopes and coalesce multi-file undo

### DIFF
--- a/src/git_stage_batch/cli/argument_parser.py
+++ b/src/git_stage_batch/cli/argument_parser.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import argparse
 import os
+import shlex
 import sys
 import tempfile
-from collections.abc import Callable
-from contextlib import nullcontext
+from collections.abc import Callable, Sequence
+from contextlib import AbstractContextManager, nullcontext
 from dataclasses import dataclass
 from enum import Enum
 from importlib import resources
@@ -18,6 +19,7 @@ from ..batch.validation import batch_exists
 from .. import commands
 from ..batch.query import read_batch_metadata
 from ..data.hunk_tracking import advance_to_next_change, show_selected_change
+from ..data.undo import undo_checkpoint
 from ..exceptions import CommandError
 from ..i18n import _, ngettext
 from ..utils.command import run_command
@@ -212,15 +214,46 @@ def _run_for_each_file(
     callback: Callable[[str | None], None],
     *,
     line_ids: str | None = None,
+    undo_operation: str | None = None,
+    worktree_paths: Sequence[str] | None = None,
 ) -> None:
     """Run a callback once per resolved file argument."""
     if file_scope.is_multiple and line_ids is not None:
         raise CommandError(_("Cannot use --lines with multiple files."))
     if file_scope.is_multiple:
-        for file in file_scope.files:
-            callback(file)
+        checkpoint = (
+            _multi_file_undo_checkpoint(
+                undo_operation,
+                file_scope.files,
+                worktree_paths=worktree_paths,
+            )
+            if undo_operation is not None else
+            nullcontext()
+        )
+        with checkpoint:
+            for file in file_scope.files:
+                callback(file)
         return
     callback(file_scope.optional_file())
+
+
+def _format_multi_file_operation(command: str, files: Sequence[str]) -> str:
+    """Return a readable undo operation for a resolved multi-file command."""
+    return f"{command} --files {' '.join(shlex.quote(file) for file in files)}"
+
+
+def _multi_file_undo_checkpoint(
+    command: str,
+    files: Sequence[str],
+    *,
+    worktree_paths: Sequence[str] | None = None,
+) -> AbstractContextManager[None]:
+    """Create one undo checkpoint for a resolved multi-file command."""
+    paths = list(worktree_paths) if worktree_paths is not None else None
+    return undo_checkpoint(
+        _format_multi_file_operation(command, files),
+        worktree_paths=paths,
+    )
 
 
 def _include_each_resolved_file(files: list[str]) -> None:
@@ -228,15 +261,16 @@ def _include_each_resolved_file(files: list[str]) -> None:
     total_hunks = 0
     staged_files: list[str] = []
 
-    for file_path in files:
-        staged_hunks = commands.command_include_file(
-            file_path,
-            quiet=True,
-            advance=False,
-        )
-        if staged_hunks > 0:
-            total_hunks += staged_hunks
-            staged_files.append(file_path)
+    with _multi_file_undo_checkpoint("include", files):
+        for file_path in files:
+            staged_hunks = commands.command_include_file(
+                file_path,
+                quiet=True,
+                advance=False,
+            )
+            if staged_hunks > 0:
+                total_hunks += staged_hunks
+                staged_files.append(file_path)
 
     if total_hunks == 0:
         print(_("No hunks staged from matched files."), file=sys.stderr)
@@ -269,15 +303,16 @@ def _skip_each_resolved_file(files: list[str]) -> None:
     total_hunks = 0
     skipped_files: list[str] = []
 
-    for file_path in files:
-        skipped_hunks = commands.command_skip_file(
-            file_path,
-            quiet=True,
-            advance=False,
-        )
-        if skipped_hunks > 0:
-            total_hunks += skipped_hunks
-            skipped_files.append(file_path)
+    with _multi_file_undo_checkpoint("skip", files):
+        for file_path in files:
+            skipped_hunks = commands.command_skip_file(
+                file_path,
+                quiet=True,
+                advance=False,
+            )
+            if skipped_hunks > 0:
+                total_hunks += skipped_hunks
+                skipped_files.append(file_path)
 
     if total_hunks == 0:
         print(_("No hunks skipped from matched files."), file=sys.stderr)
@@ -310,16 +345,18 @@ def _discard_to_batch_each_resolved_file(batch_name: str, files: list[str]) -> N
     total_hunks = 0
     discarded_files: list[str] = []
 
-    for file_path in files:
-        discarded_hunks = commands.command_discard_to_batch(
-            batch_name,
-            file=file_path,
-            quiet=True,
-            advance=False,
-        )
-        if discarded_hunks > 0:
-            total_hunks += discarded_hunks
-            discarded_files.append(file_path)
+    operation = f"discard --to {shlex.quote(batch_name)}"
+    with _multi_file_undo_checkpoint(operation, files, worktree_paths=files):
+        for file_path in files:
+            discarded_hunks = commands.command_discard_to_batch(
+                batch_name,
+                file=file_path,
+                quiet=True,
+                advance=False,
+            )
+            if discarded_hunks > 0:
+                total_hunks += discarded_hunks
+                discarded_files.append(file_path)
 
     if total_hunks == 0:
         print(_("No hunks saved to batch from matched files."), file=sys.stderr)
@@ -747,6 +784,8 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
                 resolved_batch_scope,
                 lambda file: commands.command_include_from_batch(args.from_batch, args.line_ids, file),
                 line_ids=args.line_ids,
+                undo_operation=f"include --from {shlex.quote(args.from_batch)}",
+                worktree_paths=resolved_batch_scope.files,
             )
         elif args.to_batch:
             resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
@@ -754,6 +793,7 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
                 resolved_live_scope,
                 lambda file: commands.command_include_to_batch(args.to_batch, args.line_ids, file),
                 line_ids=args.line_ids,
+                undo_operation=f"include --to {shlex.quote(args.to_batch)}",
             )
         elif args.line_ids:
             resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
@@ -907,6 +947,8 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
                 resolved_batch_scope,
                 lambda file: commands.command_discard_from_batch(args.from_batch, args.line_ids, file),
                 line_ids=args.line_ids,
+                undo_operation=f"discard --from {shlex.quote(args.from_batch)}",
+                worktree_paths=resolved_batch_scope.files,
             )
         elif args.to_batch:
             resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
@@ -917,6 +959,8 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
                     resolved_live_scope,
                     lambda file: commands.command_discard_to_batch(args.to_batch, args.line_ids, file),
                     line_ids=args.line_ids,
+                    undo_operation=f"discard --to {shlex.quote(args.to_batch)}",
+                    worktree_paths=resolved_live_scope.files,
                 )
         elif args.line_ids:
             resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
@@ -925,7 +969,12 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
         else:
             resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
             if not resolved_live_scope.is_implicit:
-                _run_for_each_file(resolved_live_scope, commands.command_discard_file)
+                _run_for_each_file(
+                    resolved_live_scope,
+                    commands.command_discard_file,
+                    undo_operation="discard",
+                    worktree_paths=resolved_live_scope.files,
+                )
             else:
                 commands.command_discard()
 
@@ -1099,6 +1148,8 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
                 file=file,
             ),
             line_ids=args.line_ids if hasattr(args, "line_ids") else None,
+            undo_operation=f"apply --from {shlex.quote(args.from_batch)}",
+            worktree_paths=resolved_file_scope.files,
         )
 
     parser_apply.set_defaults(func=dispatch_apply)
@@ -1137,6 +1188,11 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
 
     def dispatch_reset(args: argparse.Namespace) -> None:
         resolved_file_scope = _resolve_batch_file_scope(args.from_batch, args.file, args.file_patterns)
+        command_parts = ["reset", "--from", shlex.quote(args.from_batch)]
+        if args.to_batch is not None:
+            command_parts.extend(["--to", shlex.quote(args.to_batch)])
+        if args.line_ids is not None:
+            command_parts.extend(["--line", shlex.quote(args.line_ids)])
         _run_for_each_file(
             resolved_file_scope,
             lambda file: commands.command_reset_from_batch(
@@ -1147,6 +1203,7 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
                 args.to_batch,
             ),
             line_ids=args.line_ids,
+            undo_operation=" ".join(command_parts),
         )
 
     parser_reset.set_defaults(func=dispatch_reset)

--- a/src/git_stage_batch/cli/argument_parser.py
+++ b/src/git_stage_batch/cli/argument_parser.py
@@ -8,6 +8,8 @@ import sys
 import tempfile
 from collections.abc import Callable
 from contextlib import nullcontext
+from dataclasses import dataclass
+from enum import Enum
 from importlib import resources
 from pathlib import Path
 
@@ -21,6 +23,56 @@ from ..i18n import _, ngettext
 from ..utils.command import run_command
 from ..utils.file_patterns import list_changed_files, resolve_gitignore_style_patterns
 from .completion import command_complete_files
+
+
+class FileScopeKind(str, Enum):
+    """How a command's optional file scope was requested."""
+
+    IMPLICIT = "implicit"
+    EXPLICIT = "explicit"
+    PATTERN = "pattern"
+
+
+@dataclass(frozen=True)
+class FileScope:
+    """Resolved command file scope with explicit origin and concrete files."""
+
+    kind: FileScopeKind
+    files: tuple[str, ...] = ()
+
+    @classmethod
+    def implicit(cls) -> "FileScope":
+        return cls(FileScopeKind.IMPLICIT)
+
+    @classmethod
+    def explicit(cls, file_path: str) -> "FileScope":
+        return cls(FileScopeKind.EXPLICIT, (file_path,))
+
+    @classmethod
+    def pattern(cls, files: list[str]) -> "FileScope":
+        return cls(FileScopeKind.PATTERN, tuple(files))
+
+    @property
+    def is_implicit(self) -> bool:
+        return self.kind == FileScopeKind.IMPLICIT
+
+    @property
+    def is_multiple(self) -> bool:
+        return len(self.files) > 1
+
+    def optional_file(self) -> str | None:
+        """Return the single file path for this scope, or None for implicit scope."""
+        if self.is_implicit:
+            return None
+        if self.is_multiple:
+            raise ValueError("multiple file scope cannot be represented by one path")
+        return self.files[0]
+
+    def require_single_file(self, error_message: str) -> str | None:
+        """Return an optional single file path, or raise for a multi-file scope."""
+        if self.is_multiple:
+            raise CommandError(error_message)
+        return self.optional_file()
 
 
 class GitHelpArgumentParser(argparse.ArgumentParser):
@@ -156,19 +208,19 @@ def _validate_file_inputs(
 
 
 def _run_for_each_file(
-    file_arg: str | list[str] | None,
+    file_scope: FileScope,
     callback: Callable[[str | None], None],
     *,
     line_ids: str | None = None,
 ) -> None:
     """Run a callback once per resolved file argument."""
-    if isinstance(file_arg, list) and line_ids is not None:
+    if file_scope.is_multiple and line_ids is not None:
         raise CommandError(_("Cannot use --lines with multiple files."))
-    if isinstance(file_arg, list):
-        for file in file_arg:
+    if file_scope.is_multiple:
+        for file in file_scope.files:
             callback(file)
         return
-    callback(file_arg)
+    callback(file_scope.optional_file())
 
 
 def _include_each_resolved_file(files: list[str]) -> None:
@@ -298,11 +350,11 @@ def _discard_to_batch_each_resolved_file(batch_name: str, files: list[str]) -> N
 def _resolve_live_file_scope(
     file_arg: str | None,
     file_patterns: list[str] | None,
-) -> str | list[str] | None:
+) -> FileScope:
     """Resolve single-file or pattern-based live file scope."""
     _validate_file_inputs(file_arg, file_patterns)
     if file_patterns is None:
-        return file_arg
+        return FileScope.implicit() if file_arg is None else FileScope.explicit(file_arg)
 
     resolved_files = resolve_gitignore_style_patterns(list_changed_files(), file_patterns)
     if not resolved_files:
@@ -311,20 +363,18 @@ def _resolve_live_file_scope(
                 patterns=", ".join(file_patterns),
             )
         )
-    if len(resolved_files) == 1:
-        return resolved_files[0]
-    return resolved_files
+    return FileScope.pattern(resolved_files)
 
 
 def _resolve_batch_file_scope(
     batch_name: str,
     file_arg: str | None,
     file_patterns: list[str] | None,
-) -> str | list[str] | None:
+) -> FileScope:
     """Resolve single-file or pattern-based batch file scope."""
     _validate_file_inputs(file_arg, file_patterns)
     if file_patterns is None:
-        return file_arg
+        return FileScope.implicit() if file_arg is None else FileScope.explicit(file_arg)
     if not batch_exists(batch_name):
         raise CommandError(_("Batch '{name}' does not exist").format(name=batch_name))
 
@@ -337,9 +387,7 @@ def _resolve_batch_file_scope(
                 patterns=", ".join(file_patterns),
             )
         )
-    if len(resolved_files) == 1:
-        return resolved_files[0]
-    return resolved_files
+    return FileScope.pattern(resolved_files)
 
 
 def _resolve_replacement_text(args: argparse.Namespace) -> str | None:
@@ -518,7 +566,7 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
         if args.page is not None:
             if args.from_batch and not batch_exists(args.from_batch):
                 raise CommandError(_("Batch '{name}' does not exist").format(name=args.from_batch))
-            if resolved_file_scope is None:
+            if resolved_file_scope.is_implicit:
                 if not (
                     args.from_batch
                     and batch_exists(args.from_batch)
@@ -530,14 +578,14 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
                             "unless `--from` names a single-file batch."
                         )
                     )
-            if isinstance(resolved_file_scope, list):
+            if resolved_file_scope.is_multiple:
                 raise CommandError(_("`show --page` requires exactly one resolved file."))
             if args.line_ids is not None:
                 raise CommandError(_("Cannot use `show --page` together with `show --line`."))
             if args.porcelain:
                 raise CommandError(_("Cannot use `show --page` with `--porcelain`."))
         if args.from_batch:
-            if isinstance(resolved_file_scope, list):
+            if resolved_file_scope.is_multiple:
                 if args.line_ids:
                     raise CommandError(_("Cannot use --lines with multiple files."))
                 commands.command_show_from_batch(
@@ -547,17 +595,26 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
                     page=args.page,
                 )
             else:
-                commands.command_show_from_batch(args.from_batch, args.line_ids, resolved_file_scope, page=args.page)
+                commands.command_show_from_batch(
+                    args.from_batch,
+                    args.line_ids,
+                    resolved_file_scope.optional_file(),
+                    page=args.page,
+                )
             return
-        if args.line_ids or resolved_file_scope is not None:
-            if isinstance(resolved_file_scope, list) and args.porcelain:
+        if args.line_ids or not resolved_file_scope.is_implicit:
+            if resolved_file_scope.is_multiple and args.porcelain:
                 raise CommandError(_("Cannot use --porcelain with multiple files."))
-            if isinstance(resolved_file_scope, list):
+            if resolved_file_scope.is_multiple:
                 if args.line_ids:
                     raise CommandError(_("Cannot use --lines with multiple files."))
-                commands.command_show_file_list(resolved_file_scope)
+                commands.command_show_file_list(list(resolved_file_scope.files))
             else:
-                commands.command_show(file=resolved_file_scope, page=args.page, porcelain=args.porcelain)
+                commands.command_show(
+                    file=resolved_file_scope.optional_file(),
+                    page=args.page,
+                    porcelain=args.porcelain,
+                )
             return
         commands.command_show(porcelain=args.porcelain)
 
@@ -642,25 +699,23 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
                 if args.no_edge_overlap:
                     raise CommandError(_("`--no-edge-overlap` only applies to live `include --line --as` operations."))
                 resolved_batch_scope = _resolve_batch_file_scope(args.from_batch, args.file, args.file_patterns)
-                if isinstance(resolved_batch_scope, list):
-                    raise CommandError(_("Cannot use --lines with multiple files."))
+                resolved_file = resolved_batch_scope.require_single_file(_("Cannot use --lines with multiple files."))
                 replacement_text = _resolve_replacement_text(args)
                 commands.command_include_from_batch(
                     args.from_batch,
                     args.line_ids,
-                    file=resolved_batch_scope,
+                    file=resolved_file,
                     replacement_text=replacement_text,
                 )
                 return
             if args.line_ids and not args.from_batch and not args.to_batch:
                 resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
-                if isinstance(resolved_live_scope, list):
-                    raise CommandError(_("Cannot use --lines with multiple files."))
+                resolved_file = resolved_live_scope.require_single_file(_("Cannot use --lines with multiple files."))
                 replacement_text = _resolve_replacement_text(args)
                 commands.command_include_line_as(
                     args.line_ids,
                     replacement_text,
-                    file=resolved_live_scope,
+                    file=resolved_file,
                     no_edge_overlap=args.no_edge_overlap,
                 )
                 return
@@ -670,16 +725,16 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
                 and args.to_batch is None
             ):
                 resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
-                if resolved_live_scope is None:
+                if resolved_live_scope.is_implicit:
                     raise CommandError(
                         _("`include --as` requires `--file` or `--line` and does not support `--to`.")
                     )
                 if args.no_edge_overlap:
                     raise CommandError(_("`--no-edge-overlap` requires `include --line --as`."))
-                if isinstance(resolved_live_scope, list):
+                if resolved_live_scope.is_multiple:
                     raise CommandError(_("Cannot use --as with multiple files."))
                 replacement_text = _resolve_replacement_text(args)
-                commands.command_include_file_as(replacement_text, file=resolved_live_scope)
+                commands.command_include_file_as(replacement_text, file=resolved_live_scope.optional_file())
                 return
             raise CommandError(
                 _("`include --as` requires `--file` or `--line` and does not support `--to`.")
@@ -702,15 +757,14 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
             )
         elif args.line_ids:
             resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
-            if isinstance(resolved_live_scope, list):
-                raise CommandError(_("Cannot use --lines with multiple files."))
-            commands.command_include_line(args.line_ids, file=resolved_live_scope)
+            resolved_file = resolved_live_scope.require_single_file(_("Cannot use --lines with multiple files."))
+            commands.command_include_line(args.line_ids, file=resolved_file)
         else:
             resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
-            if isinstance(resolved_live_scope, list):
-                _include_each_resolved_file(resolved_live_scope)
-            elif resolved_live_scope is not None:
-                commands.command_include_file(resolved_live_scope)
+            if resolved_live_scope.is_multiple:
+                _include_each_resolved_file(list(resolved_live_scope.files))
+            elif not resolved_live_scope.is_implicit:
+                commands.command_include_file(resolved_live_scope.optional_file())
             else:
                 commands.command_include()
 
@@ -739,14 +793,13 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
     def dispatch_skip(args: argparse.Namespace) -> None:
         resolved_file_scope = _resolve_live_file_scope(args.file, args.file_patterns)
         if args.line_ids:
-            if isinstance(resolved_file_scope, list):
-                raise CommandError(_("Cannot use --lines with multiple files."))
-            commands.command_skip_line(args.line_ids, file=resolved_file_scope)
-        elif resolved_file_scope is not None:
-            if isinstance(resolved_file_scope, list):
-                _skip_each_resolved_file(resolved_file_scope)
+            resolved_file = resolved_file_scope.require_single_file(_("Cannot use --lines with multiple files."))
+            commands.command_skip_line(args.line_ids, file=resolved_file)
+        elif not resolved_file_scope.is_implicit:
+            if resolved_file_scope.is_multiple:
+                _skip_each_resolved_file(list(resolved_file_scope.files))
             else:
-                commands.command_skip_file(resolved_file_scope)
+                commands.command_skip_file(resolved_file_scope.optional_file())
         else:
             commands.command_skip()
 
@@ -816,14 +869,13 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
                 raise CommandError(_("Cannot use `--as` and `--as-stdin` together."))
             if args.to_batch and args.line_ids and not args.from_batch:
                 resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
-                if isinstance(resolved_live_scope, list):
-                    raise CommandError(_("Cannot use --lines with multiple files."))
+                resolved_file = resolved_live_scope.require_single_file(_("Cannot use --lines with multiple files."))
                 replacement_text = _resolve_replacement_text(args)
                 commands.command_discard_line_as_to_batch(
                     args.to_batch,
                     args.line_ids,
                     replacement_text,
-                    file=resolved_live_scope,
+                    file=resolved_file,
                     no_edge_overlap=args.no_edge_overlap,
                 )
                 return
@@ -833,16 +885,16 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
                 and args.line_ids is None
             ):
                 resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
-                if resolved_live_scope is None:
+                if resolved_live_scope.is_implicit:
                     raise CommandError(
                         _("`discard --as` requires `--file`, or `--to` with `--line`.")
                     )
                 if args.no_edge_overlap:
                     raise CommandError(_("`--no-edge-overlap` requires `discard --to --line --as`."))
-                if isinstance(resolved_live_scope, list):
+                if resolved_live_scope.is_multiple:
                     raise CommandError(_("Cannot use --as with multiple files."))
                 replacement_text = _resolve_replacement_text(args)
-                commands.command_discard_file_as(replacement_text, file=resolved_live_scope)
+                commands.command_discard_file_as(replacement_text, file=resolved_live_scope.optional_file())
                 return
             raise CommandError(
                 _("`discard --as` requires `--file`, or `--to` with `--line`.")
@@ -858,8 +910,8 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
             )
         elif args.to_batch:
             resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
-            if isinstance(resolved_live_scope, list) and args.line_ids is None:
-                _discard_to_batch_each_resolved_file(args.to_batch, resolved_live_scope)
+            if resolved_live_scope.is_multiple and args.line_ids is None:
+                _discard_to_batch_each_resolved_file(args.to_batch, list(resolved_live_scope.files))
             else:
                 _run_for_each_file(
                     resolved_live_scope,
@@ -868,12 +920,11 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
                 )
         elif args.line_ids:
             resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
-            if isinstance(resolved_live_scope, list):
-                raise CommandError(_("Cannot use --lines with multiple files."))
-            commands.command_discard_line(args.line_ids, file=resolved_live_scope)
+            resolved_file = resolved_live_scope.require_single_file(_("Cannot use --lines with multiple files."))
+            commands.command_discard_line(args.line_ids, file=resolved_file)
         else:
             resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
-            if resolved_live_scope is not None:
+            if not resolved_live_scope.is_implicit:
                 _run_for_each_file(resolved_live_scope, commands.command_discard_file)
             else:
                 commands.command_discard()

--- a/src/git_stage_batch/data/undo.py
+++ b/src/git_stage_batch/data/undo.py
@@ -211,6 +211,10 @@ def _create_undo_checkpoint(operation: str, *, worktree_paths: list[str] | None 
 @contextmanager
 def undo_checkpoint(operation: str, *, worktree_paths: list[str] | None = None) -> Iterator[None]:
     """Bracket an undoable operation with before and after snapshots."""
+    if _PENDING_CHECKPOINT is not None:
+        yield
+        return
+
     checkpoint = _create_undo_checkpoint(operation, worktree_paths=worktree_paths)
     try:
         yield

--- a/tests/cli/test_argument_parser.py
+++ b/tests/cli/test_argument_parser.py
@@ -159,6 +159,62 @@ def test_show_git_stage_batch_help_materializes_editable_manpage(monkeypatch, tm
     assert calls[0][1]["MANPATH"].endswith(f"{os.pathsep}/usr/share/man")
 
 
+def test_resolve_live_file_scope_marks_implicit_scope():
+    scope = argument_parser._resolve_live_file_scope(None, None)
+
+    assert scope.kind is argument_parser.FileScopeKind.IMPLICIT
+    assert scope.files == ()
+    assert scope.optional_file() is None
+
+
+def test_resolve_live_file_scope_marks_explicit_scope():
+    scope = argument_parser._resolve_live_file_scope("src/parser.py", None)
+
+    assert scope.kind is argument_parser.FileScopeKind.EXPLICIT
+    assert scope.files == ("src/parser.py",)
+    assert scope.optional_file() == "src/parser.py"
+
+
+def test_resolve_live_file_scope_keeps_single_pattern_scope_kind(monkeypatch):
+    monkeypatch.setattr(argument_parser, "list_changed_files", lambda: ["src/parser.py", "notes.txt"])
+
+    scope = argument_parser._resolve_live_file_scope(None, ["*.py"])
+
+    assert scope.kind is argument_parser.FileScopeKind.PATTERN
+    assert scope.files == ("src/parser.py",)
+    assert scope.optional_file() == "src/parser.py"
+
+
+def test_resolve_batch_file_scope_marks_implicit_scope():
+    scope = argument_parser._resolve_batch_file_scope("batch", None, None)
+
+    assert scope.kind is argument_parser.FileScopeKind.IMPLICIT
+    assert scope.files == ()
+    assert scope.optional_file() is None
+
+
+def test_resolve_batch_file_scope_marks_explicit_scope():
+    scope = argument_parser._resolve_batch_file_scope("batch", "src/parser.py", None)
+
+    assert scope.kind is argument_parser.FileScopeKind.EXPLICIT
+    assert scope.files == ("src/parser.py",)
+    assert scope.optional_file() == "src/parser.py"
+
+
+def test_resolve_batch_file_scope_keeps_pattern_scope_kind(monkeypatch):
+    monkeypatch.setattr(argument_parser, "batch_exists", lambda name: True)
+    monkeypatch.setattr(
+        argument_parser,
+        "read_batch_metadata",
+        lambda name: {"files": {"src/parser.py": {}, "src/render.py": {}, "notes.txt": {}}},
+    )
+
+    scope = argument_parser._resolve_batch_file_scope("batch", None, ["*.py"])
+
+    assert scope.kind is argument_parser.FileScopeKind.PATTERN
+    assert scope.files == ("src/parser.py", "src/render.py")
+
+
 def test_parse_command_line_version():
     """Test parsing --version flag."""
     # --version causes argparse to exit, which is expected

--- a/tests/functional/test_undo.py
+++ b/tests/functional/test_undo.py
@@ -1,5 +1,6 @@
 """Functional tests for undo support."""
 
+import json
 import subprocess
 
 from .conftest import git_stage_batch, get_staged_diff
@@ -13,6 +14,16 @@ def _commit_file(path, content: str) -> None:
     path.write_text(content)
     _git("add", str(path))
     _git("commit", "-m", f"Add {path.name}")
+
+
+def _create_two_changed_text_files(repo):
+    alpha = repo / "alpha.txt"
+    beta = repo / "beta.txt"
+    _commit_file(alpha, "alpha\n")
+    _commit_file(beta, "beta\n")
+    alpha.write_text("alpha\nalpha change\n")
+    beta.write_text("beta\nbeta change\n")
+    return alpha, beta
 
 
 def test_undo_skip_restores_selected_hunk(repo_with_changes):
@@ -116,6 +127,83 @@ def test_undo_include_to_batch_restores_batch_refs(functional_repo):
     assert git_stage_batch("show", "--from", "undo-batch").stdout == ""
     assert _git("rev-parse", "refs/git-stage-batch/batches/undo-batch").stdout.strip() != content_ref
     assert _git("rev-parse", "refs/git-stage-batch/state/undo-batch").stdout.strip() != state_ref
+
+
+def test_undo_include_files_restores_entire_multi_file_operation(functional_repo):
+    """Undoing include --files should unstage every matched file."""
+    alpha, beta = _create_two_changed_text_files(functional_repo)
+
+    git_stage_batch("start")
+    git_stage_batch("include", "--files", "*.txt")
+
+    assert set(_git("diff", "--cached", "--name-only").stdout.splitlines()) == {
+        "alpha.txt",
+        "beta.txt",
+    }
+
+    git_stage_batch("undo")
+
+    assert _git("diff", "--cached", "--name-only").stdout == ""
+    assert alpha.read_text() == "alpha\nalpha change\n"
+    assert beta.read_text() == "beta\nbeta change\n"
+
+
+def test_undo_skip_files_restores_entire_multi_file_operation(functional_repo):
+    """Undoing skip --files should clear every skipped hunk."""
+    _create_two_changed_text_files(functional_repo)
+
+    git_stage_batch("start")
+    git_stage_batch("skip", "--files", "*.txt")
+
+    skipped_status = json.loads(git_stage_batch("status", "--porcelain").stdout)
+    assert skipped_status["progress"]["skipped"] == 2
+
+    git_stage_batch("undo")
+
+    restored_status = json.loads(git_stage_batch("status", "--porcelain").stdout)
+    assert restored_status["progress"]["skipped"] == 0
+
+
+def test_undo_discard_files_restores_entire_multi_file_operation(functional_repo):
+    """Undoing discard --files should restore every matched file."""
+    alpha, beta = _create_two_changed_text_files(functional_repo)
+
+    git_stage_batch("start")
+    git_stage_batch("discard", "--files", "*.txt")
+
+    assert set(_git("diff", "--cached", "--name-only").stdout.splitlines()) == {
+        "alpha.txt",
+        "beta.txt",
+    }
+
+    git_stage_batch("undo")
+
+    assert _git("diff", "--cached", "--name-only").stdout == ""
+    assert set(_git("diff", "--name-only").stdout.splitlines()) == {
+        "alpha.txt",
+        "beta.txt",
+    }
+    assert alpha.read_text() == "alpha\nalpha change\n"
+    assert beta.read_text() == "beta\nbeta change\n"
+
+
+def test_undo_discard_to_batch_files_restores_entire_multi_file_operation(functional_repo):
+    """Undoing discard --to --files should restore every discarded file."""
+    alpha, beta = _create_two_changed_text_files(functional_repo)
+
+    git_stage_batch("start")
+    git_stage_batch("discard", "--to", "saved", "--files", "*.txt")
+
+    assert _git("diff", "--name-only").stdout == ""
+
+    git_stage_batch("undo")
+
+    assert set(_git("diff", "--name-only").stdout.splitlines()) == {
+        "alpha.txt",
+        "beta.txt",
+    }
+    assert alpha.read_text() == "alpha\nalpha change\n"
+    assert beta.read_text() == "beta\nbeta change\n"
 
 
 def test_undo_block_file_restores_gitignore_session_and_index(functional_repo):


### PR DESCRIPTION
## Summary

The parser resolves `--file` and `--files` inputs into scopes before
command handlers run, but that scope is encoded as None, a string, or a
list. A single pattern match loses its origin before dispatch can inspect
it, and multi-file loops push one undo checkpoint per file instead of one
per command.

This series addresses both problems:

- **Typed file scopes**: Adds `FileScopeKind` and `FileScope` so the
  live and batch resolvers return a typed scope that preserves whether
  input was implicit, explicit, or a pattern match.
- **Undo coalescing**: Lets parser multi-file loops declare one undo
  operation so that a single include, skip, discard, apply, or reset
  invocation across multiple files can be undone in one step.

## Commits

1. `cli: Return typed file scopes from parser resolvers`
2. `tests: Cover typed parser file scopes`
3. `undo: Coalesce multi-file parser checkpoints`
4. `tests: Cover multi-file undo checkpoints`

## Test plan

- [ ] `uv run pytest -n auto` passes all tests
- [ ] New typed-scope tests cover implicit, explicit, and pattern scopes
- [ ] New undo tests cover include/skip/discard --files coalescing