### PR TITLE
batch: Improve multi-file batching performance

### DIFF
--- a/src/git_stage_batch/batch/__init__.py
+++ b/src/git_stage_batch/batch/__init__.py
@@ -17,6 +17,8 @@ from .query import (
 from .storage import (
     add_binary_file_to_batch,
     add_file_to_batch,
+    add_files_to_batch,
+    BatchFileUpdate,
     copy_file_from_batch_to_batch,
     get_batch_diff,
     read_file_from_batch,
@@ -26,6 +28,8 @@ from .validation import batch_exists, validate_batch_name
 __all__ = [
     "add_binary_file_to_batch",
     "add_file_to_batch",
+    "add_files_to_batch",
+    "BatchFileUpdate",
     "batch_exists",
     "copy_file_from_batch_to_batch",
     "create_batch",

--- a/src/git_stage_batch/batch/state_refs.py
+++ b/src/git_stage_batch/batch/state_refs.py
@@ -4,21 +4,30 @@ from __future__ import annotations
 
 import json
 import shutil
+from dataclasses import dataclass
 from typing import Any
 
 from .ref_names import BATCH_CONTENT_REF_PREFIX, BATCH_STATE_REF_PREFIX, LEGACY_BATCH_REF_PREFIX
 from .validation import validate_batch_name
 from ..utils.file_io import read_text_file_contents
 from ..utils.git import (
-    create_git_blob,
+    create_git_blobs,
+    GitIndexEntryUpdate,
     git_commit_tree,
-    git_update_index,
+    git_update_index_entries,
     git_write_tree,
     run_git_command,
     temp_git_index,
     update_git_refs,
 )
 from ..utils.paths import get_batch_metadata_file_path
+
+
+@dataclass(frozen=True)
+class _StateContentUpdate:
+    path: str
+    data: bytes
+    mode: str = "100644"
 
 
 def get_batch_content_ref_name(batch_name: str) -> str:
@@ -116,7 +125,12 @@ def get_authoritative_batch_commit_sha(batch_name: str) -> str | None:
     return result.stdout.strip()
 
 
-def sync_batch_state_refs(batch_name: str, *, content_commit: str | None = None) -> None:
+def sync_batch_state_refs(
+    batch_name: str,
+    *,
+    content_commit: str | None = None,
+    source_contents: dict[str, bytes] | None = None,
+) -> None:
     """Publish batch metadata and source snapshots into authoritative Git refs."""
     validate_batch_name(batch_name)
 
@@ -136,36 +150,50 @@ def sync_batch_state_refs(batch_name: str, *, content_commit: str | None = None)
         "files": {},
     }
 
+    source_contents = source_contents or {}
+    content_updates: list[_StateContentUpdate] = []
+
     with temp_git_index() as env:
         for file_path, file_meta in metadata.get("files", {}).items():
             state_file_meta = dict(file_meta)
 
             source_commit = file_meta.get("batch_source_commit")
             if source_commit:
-                source_result = run_git_command(
-                    ["show", f"{source_commit}:{file_path}"],
-                    check=False,
-                    text_output=False,
-                )
-                if source_result.returncode == 0:
-                    source_blob = create_git_blob([source_result.stdout])
+                source_content = source_contents.get(file_path)
+                if source_content is None:
+                    source_result = run_git_command(
+                        ["show", f"{source_commit}:{file_path}"],
+                        check=False,
+                        text_output=False,
+                    )
+                    if source_result.returncode == 0:
+                        source_content = source_result.stdout
+
+                if source_content is not None:
                     source_path = f"sources/{file_path}"
-                    git_update_index(
-                        mode=file_meta.get("mode", "100644"),
-                        blob_sha=source_blob,
-                        file_path=source_path,
-                        env=env,
+                    content_updates.append(
+                        _StateContentUpdate(
+                            path=source_path,
+                            data=source_content,
+                            mode=file_meta.get("mode", "100644"),
+                        )
                     )
                     state_file_meta["source_path"] = source_path
 
             state_metadata["files"][file_path] = state_file_meta
 
         state_json = json.dumps(state_metadata, indent=2).encode("utf-8")
-        state_blob = create_git_blob([state_json])
-        git_update_index(
-            mode="100644",
-            blob_sha=state_blob,
-            file_path="batch.json",
+        content_updates.append(_StateContentUpdate(path="batch.json", data=state_json))
+        blob_shas = create_git_blobs(update.data for update in content_updates)
+        git_update_index_entries(
+            [
+                GitIndexEntryUpdate(
+                    file_path=update.path,
+                    mode=update.mode,
+                    blob_sha=blob_sha,
+                )
+                for update, blob_sha in zip(content_updates, blob_shas, strict=True)
+            ],
             env=env,
         )
 

--- a/src/git_stage_batch/batch/storage.py
+++ b/src/git_stage_batch/batch/storage.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from copy import deepcopy
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional
 
 from .metadata_validation import get_validated_baseline_commit
@@ -15,6 +16,7 @@ from ..core.models import BinaryFileChange
 from ..core.text_lifecycle import TextFileChangeType, resolve_text_change_type
 from ..data.batch_sources import (
     create_batch_source_commit,
+    create_batch_source_commits,
     get_batch_source_for_file,
     load_session_batch_sources,
     save_session_batch_sources,
@@ -22,11 +24,15 @@ from ..data.batch_sources import (
 from ..utils.file_io import write_text_file_contents
 from ..utils.git import (
     create_git_blob,
+    create_git_blobs,
+    GitIndexEntryUpdate,
     get_git_repository_root_path,
     git_commit_tree,
     git_read_tree,
     git_update_index,
+    git_update_index_entries,
     git_write_tree,
+    read_git_tree_file_contents,
     run_git_command,
     temp_git_index,
 )
@@ -35,6 +41,17 @@ from .merge import _satisfy_constraints
 
 if TYPE_CHECKING:
     from .ownership import BatchOwnership, DeletionClaim
+
+
+@dataclass(frozen=True)
+class BatchFileUpdate:
+    """One text file update to persist into a batch."""
+
+    file_path: str
+    ownership: BatchOwnership
+    file_mode: str = "100644"
+    batch_source_commit: str | None = None
+    change_type: str | None = None
 
 
 def add_file_to_batch(
@@ -61,75 +78,155 @@ def add_file_to_batch(
         change_type: Optional persisted text lifecycle type from another batch.
             Only whole-file added/deleted lifecycle states are retained.
     """
+    add_files_to_batch(
+        batch_name,
+        [
+            BatchFileUpdate(
+                file_path=file_path,
+                ownership=ownership,
+                file_mode=file_mode,
+                batch_source_commit=batch_source_commit,
+                change_type=change_type,
+            )
+        ],
+    )
+
+
+def add_files_to_batch(batch_name: str, updates: list[BatchFileUpdate]) -> None:
+    """Add or update text files in one batch content/state publication."""
+    if not updates:
+        return
+
     validate_batch_name(batch_name)
 
     # Auto-create batch if it doesn't exist
     if not batch_exists(batch_name):
         create_batch(batch_name, "Auto-created")
 
-    # Get or create batch source commit for this file
-    batch_source_commit = batch_source_commit or get_batch_source_for_file(file_path)
-    if not batch_source_commit:
-        # Create batch source commit
-        batch_source_commit = create_batch_source_commit(file_path)
-        # Save to session cache
-        batch_sources = load_session_batch_sources()
-        batch_sources[file_path] = batch_source_commit
-        save_session_batch_sources(batch_sources)
-
-    # Read baseline and batch source content
-    # Use validated version to get clear error if metadata is corrupted
     baseline_commit = get_validated_baseline_commit(batch_name)
-
-    # Read base file content as bytes
-    base_result = run_git_command(["show", f"{baseline_commit}:{file_path}"], check=False, text_output=False)
-    baseline_exists = base_result.returncode == 0
-    base_content = base_result.stdout if baseline_exists else b""
-
-    # Read batch source content as bytes
-    batch_source_result = run_git_command(["show", f"{batch_source_commit}:{file_path}"], check=False, text_output=False)
-    batch_source_content = batch_source_result.stdout if batch_source_result.returncode == 0 else b""
-
-    # Build realized content: base + claimed changes + deletions
-    realized_content_bytes = _build_realized_content(
-        base_content,
-        batch_source_content,
-        ownership
-    )
-
-    text_change_type = resolve_text_change_type(
-        file_path=file_path,
-        baseline_exists=baseline_exists,
-        batch_source_content=batch_source_content,
-        realized_content=realized_content_bytes,
-        requested_change_type=change_type,
-    )
-
-    # Update batch metadata
     metadata = read_batch_metadata(batch_name)
     if "files" not in metadata:
         metadata["files"] = {}
 
-    file_metadata = {
-        "batch_source_commit": batch_source_commit,
-        **ownership.to_metadata_dict(),
-        "mode": file_mode
-    }
-    if text_change_type != TextFileChangeType.MODIFIED:
-        file_metadata["change_type"] = text_change_type.value
-    metadata["files"][file_path] = file_metadata
+    batch_sources = load_session_batch_sources()
+    batch_sources_changed = False
+    batch_source_commits: dict[str, str] = {}
+    batch_source_contents: dict[str, bytes] = {}
+    missing_source_paths: list[str] = []
 
-    # Write updated metadata
-    metadata_path = get_batch_metadata_file_path(batch_name)
-    write_text_file_contents(metadata_path, json.dumps(metadata, indent=2))
+    for update in updates:
+        batch_source_commit = update.batch_source_commit or batch_sources.get(update.file_path)
+        if batch_source_commit:
+            batch_source_commits[update.file_path] = batch_source_commit
+        else:
+            missing_source_paths.append(update.file_path)
 
-    # Build batch commit tree with realized content. Deleted text paths are
-    # represented by metadata plus path absence in the batch tree.
-    if text_change_type == TextFileChangeType.DELETED:
-        _remove_file_from_batch_commit(batch_name, file_path)
-    else:
-        blob_sha = create_git_blob([realized_content_bytes])
-        _update_batch_commit(batch_name, file_path, blob_sha, file_mode)
+    created_sources = create_batch_source_commits(missing_source_paths)
+    if created_sources:
+        batch_sources_changed = True
+        for file_path, source in created_sources.items():
+            batch_sources[file_path] = source.commit_sha
+            batch_source_commits[file_path] = source.commit_sha
+            batch_source_contents[file_path] = source.file_content
+
+    update_paths = [update.file_path for update in updates]
+    baseline_contents = read_git_tree_file_contents(baseline_commit, update_paths)
+
+    existing_source_paths_by_commit: dict[str, list[str]] = {}
+    for update in updates:
+        if update.file_path in batch_source_contents:
+            continue
+        existing_source_paths_by_commit.setdefault(
+            batch_source_commits[update.file_path],
+            [],
+        ).append(update.file_path)
+
+    for source_commit, source_paths in existing_source_paths_by_commit.items():
+        batch_source_contents.update(
+            read_git_tree_file_contents(source_commit, source_paths)
+        )
+
+    with temp_git_index() as env:
+        existing_commit = get_batch_commit_sha(batch_name)
+        if existing_commit:
+            git_read_tree(existing_commit, env=env)
+
+        index_updates: list[GitIndexEntryUpdate] = []
+        realized_contents: list[bytes] = []
+        realized_content_indexes: list[int] = []
+        for update in updates:
+            file_path = update.file_path
+            batch_source_commit = batch_source_commits[file_path]
+            baseline_exists = file_path in baseline_contents
+            base_content = baseline_contents.get(file_path, b"")
+            batch_source_content = batch_source_contents.get(file_path, b"")
+
+            realized_content_bytes = _build_realized_content(
+                base_content,
+                batch_source_content,
+                update.ownership,
+            )
+
+            text_change_type = resolve_text_change_type(
+                file_path=file_path,
+                baseline_exists=baseline_exists,
+                batch_source_content=batch_source_content,
+                realized_content=realized_content_bytes,
+                requested_change_type=update.change_type,
+            )
+
+            file_metadata = {
+                "batch_source_commit": batch_source_commit,
+                **update.ownership.to_metadata_dict(),
+                "mode": update.file_mode
+            }
+            if text_change_type != TextFileChangeType.MODIFIED:
+                file_metadata["change_type"] = text_change_type.value
+            metadata["files"][file_path] = file_metadata
+
+            if text_change_type == TextFileChangeType.DELETED:
+                index_updates.append(
+                    GitIndexEntryUpdate(file_path=file_path, force_remove=True)
+                )
+            else:
+                realized_content_indexes.append(len(index_updates))
+                realized_contents.append(realized_content_bytes)
+                index_updates.append(
+                    GitIndexEntryUpdate(
+                        file_path=file_path,
+                        mode=update.file_mode,
+                    )
+                )
+
+        blob_shas = create_git_blobs(realized_contents)
+        for index_update_index, blob_sha in zip(realized_content_indexes, blob_shas, strict=True):
+            index_update = index_updates[index_update_index]
+            index_updates[index_update_index] = GitIndexEntryUpdate(
+                file_path=index_update.file_path,
+                mode=index_update.mode,
+                blob_sha=blob_sha,
+            )
+        git_update_index_entries(index_updates, env=env)
+
+        metadata_path = get_batch_metadata_file_path(batch_name)
+        write_text_file_contents(metadata_path, json.dumps(metadata, indent=2))
+        if batch_sources_changed:
+            save_session_batch_sources(batch_sources)
+
+        tree_sha = git_write_tree(env=env)
+
+    commit_sha = git_commit_tree(
+        tree_sha,
+        parents=_batch_commit_parents(batch_name),
+        message=f"Batch: {batch_name}",
+    )
+
+    from .state_refs import sync_batch_state_refs
+    sync_batch_state_refs(
+        batch_name,
+        content_commit=commit_sha,
+        source_contents=batch_source_contents,
+    )
 
 
 def add_binary_file_to_batch(

--- a/src/git_stage_batch/cli/argument_parser.py
+++ b/src/git_stage_batch/cli/argument_parser.py
@@ -347,16 +347,14 @@ def _discard_to_batch_each_resolved_file(batch_name: str, files: list[str]) -> N
 
     operation = f"discard --to {shlex.quote(batch_name)}"
     with _multi_file_undo_checkpoint(operation, files, worktree_paths=files):
-        for file_path in files:
-            discarded_hunks = commands.command_discard_to_batch(
-                batch_name,
-                file=file_path,
-                quiet=True,
-                advance=False,
-            )
-            if discarded_hunks > 0:
-                total_hunks += discarded_hunks
-                discarded_files.append(file_path)
+        result = commands.command_discard_files_to_batch(
+            batch_name,
+            files,
+            quiet=True,
+            advance=False,
+        )
+        total_hunks = result.discarded_hunks
+        discarded_files = result.discarded_files
 
     if total_hunks == 0:
         print(_("No hunks saved to batch from matched files."), file=sys.stderr)

--- a/src/git_stage_batch/commands/__init__.py
+++ b/src/git_stage_batch/commands/__init__.py
@@ -7,7 +7,16 @@ from .again import command_again
 from .annotate import command_annotate_batch
 from .apply_from import command_apply_from_batch
 from .block_file import command_block_file
-from .discard import command_discard, command_discard_file, command_discard_file_as, command_discard_line, command_discard_line_as_to_batch, command_discard_to_batch
+from .discard import (
+    command_discard,
+    command_discard_file,
+    command_discard_file_as,
+    command_discard_files_to_batch,
+    command_discard_line,
+    command_discard_line_as_to_batch,
+    command_discard_to_batch,
+    DiscardFilesToBatchResult,
+)
 from .discard_from import command_discard_from_batch
 from .drop import command_drop_batch
 from .include import command_include, command_include_file, command_include_file_as, command_include_line, command_include_line_as, command_include_to_batch
@@ -38,9 +47,11 @@ __all__ = [
     "command_discard",
     "command_discard_file",
     "command_discard_file_as",
+    "command_discard_files_to_batch",
     "command_discard_line",
     "command_discard_line_as_to_batch",
     "command_discard_to_batch",
+    "DiscardFilesToBatchResult",
     "command_discard_from_batch",
     "command_drop_batch",
     "command_include",

--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -2,10 +2,18 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 import stat
 import sys
+from dataclasses import dataclass
 
-from ..batch import add_binary_file_to_batch, add_file_to_batch, create_batch
+from ..batch import (
+    BatchFileUpdate,
+    add_binary_file_to_batch,
+    add_file_to_batch,
+    add_files_to_batch,
+    create_batch,
+)
 from ..batch.display import annotate_with_batch_source, annotate_with_batch_source_content
 from ..batch.ownership import (
     BatchOwnership,
@@ -38,6 +46,7 @@ from ..data.hunk_tracking import (
     read_selected_change_kind,
     recalculate_selected_hunk_for_file,
     record_hunk_discarded,
+    record_hunks_discarded,
     refuse_bare_action_after_file_list,
     render_binary_file_change,
     require_selected_hunk,
@@ -56,7 +65,7 @@ from ..data.file_review_state import (
 )
 from ..data.line_state import load_line_changes_from_state
 from ..data.batch_sources import create_batch_source_commit, load_session_batch_sources, save_session_batch_sources
-from ..data.session import require_session_started, snapshot_file_if_untracked
+from ..data.session import require_session_started, snapshot_file_if_untracked, snapshot_files_if_untracked
 from ..data.undo import undo_checkpoint
 from ..exceptions import CommandError, exit_with_error, NoMoreHunks
 from ..i18n import _, ngettext
@@ -77,6 +86,41 @@ from ..utils.paths import (
 from .include import (
     _expand_replacement_selection_ids,
 )
+
+
+@dataclass(frozen=True)
+class _PreparedPatchDiscard:
+    patch_bytes: bytes
+    patch_hash: str
+
+
+@dataclass
+class _TextFileDiscardInput:
+    file_path: str
+    file_mode: str
+    all_lines_to_batch: list
+    patches_to_discard: list[_PreparedPatchDiscard]
+
+
+@dataclass(frozen=True)
+class _CollectedTextFileDiscards:
+    inputs_by_file: dict[str, _TextFileDiscardInput]
+    files_with_text_patches: set[str]
+
+
+@dataclass(frozen=True)
+class _PreparedTextFileDiscardToBatch:
+    file_path: str
+    file_mode: str
+    ownership: BatchOwnership
+    batch_source_commit: str | None
+    patches_to_discard: list[_PreparedPatchDiscard]
+
+
+@dataclass(frozen=True)
+class DiscardFilesToBatchResult:
+    discarded_hunks: int
+    discarded_files: list[str]
 
 
 def _load_explicit_file_selection(file_path: str):
@@ -822,7 +866,12 @@ def _select_rewritten_replacement_lines(
 
 def _detect_file_mode(file_path: str) -> str:
     """Return the current git file mode for a path, defaulting to a regular file."""
-    absolute_path = get_git_repository_root_path() / file_path
+    return _detect_file_mode_from_root(get_git_repository_root_path(), file_path)
+
+
+def _detect_file_mode_from_root(repo_root: Path, file_path: str) -> str:
+    """Return the current git file mode using a known repository root."""
+    absolute_path = repo_root / file_path
     if absolute_path.exists():
         return "100755" if absolute_path.stat().st_mode & stat.S_IXUSR else "100644"
 
@@ -886,6 +935,261 @@ def _command_discard_binary_to_batch(
     elif not quiet:
         advance_to_and_show_next_change()
     return 1
+
+
+def _prepare_text_file_discard_to_batch(
+    batch_name: str,
+    discard_input: _TextFileDiscardInput,
+    *,
+    metadata: dict,
+) -> _PreparedTextFileDiscardToBatch | None:
+    """Prepare one normal text file discard without publishing batch state."""
+    if not discard_input.all_lines_to_batch:
+        return None
+
+    file_path = discard_input.file_path
+    existing_ownership = None
+    current_batch_source = None
+    if file_path in metadata.get("files", {}):
+        file_metadata = metadata["files"][file_path]
+        existing_ownership = BatchOwnership.from_metadata_dict(file_metadata)
+        current_batch_source = file_metadata.get("batch_source_commit")
+
+    try:
+        update = prepare_batch_ownership_update_for_selection(
+            batch_name=batch_name,
+            file_path=file_path,
+            current_batch_source_commit=current_batch_source,
+            existing_ownership=existing_ownership,
+            selected_lines=discard_input.all_lines_to_batch,
+        )
+    except ValueError as e:
+        exit_with_error(
+            _("Cannot discard file to batch: batch source is stale and remapping failed.\n"
+              "File: {file}\n"
+              "Batch: {batch}\n"
+              "Error: {error}").format(file=file_path, batch=batch_name, error=str(e))
+        )
+
+    return _PreparedTextFileDiscardToBatch(
+        file_path=file_path,
+        file_mode=discard_input.file_mode,
+        ownership=update.ownership_after,
+        batch_source_commit=update.batch_source_commit,
+        patches_to_discard=discard_input.patches_to_discard,
+    )
+
+
+def _collect_text_file_discard_inputs(
+    files: list[str],
+    *,
+    blocked_hashes: set[str],
+) -> _CollectedTextFileDiscards:
+    """Collect normal text file discard inputs from one Git diff."""
+    if not files:
+        return _CollectedTextFileDiscards(inputs_by_file={}, files_with_text_patches=set())
+
+    repo_root = get_git_repository_root_path()
+    inputs_by_file: dict[str, _TextFileDiscardInput] = {}
+    files_with_text_patches: set[str] = set()
+
+    for patch in parse_unified_diff_streaming(
+        stream_git_command(["diff", f"-U{get_context_lines()}", "--no-color", "HEAD", "--", *files])
+    ):
+        if isinstance(patch, BinaryFileChange):
+            continue
+
+        file_path = patch.new_path if patch.new_path != "/dev/null" else patch.old_path
+        files_with_text_patches.add(file_path)
+
+        patch_bytes = patch.to_patch_bytes()
+        patch_hash = compute_stable_hunk_hash(patch_bytes)
+        if patch_hash in blocked_hashes:
+            continue
+
+        hunk_lines = build_line_changes_from_patch_bytes(
+            patch_bytes,
+            annotator=annotate_with_batch_source,
+        )
+        discard_input = inputs_by_file.get(file_path)
+        if discard_input is None:
+            discard_input = _TextFileDiscardInput(
+                file_path=file_path,
+                file_mode=_detect_file_mode_from_root(repo_root, file_path),
+                all_lines_to_batch=[],
+                patches_to_discard=[],
+            )
+            inputs_by_file[file_path] = discard_input
+        discard_input.all_lines_to_batch.extend(hunk_lines.lines)
+        discard_input.patches_to_discard.append(
+            _PreparedPatchDiscard(
+                patch_bytes=patch_bytes,
+                patch_hash=patch_hash,
+            )
+        )
+        blocked_hashes.add(patch_hash)
+
+    return _CollectedTextFileDiscards(
+        inputs_by_file=inputs_by_file,
+        files_with_text_patches=files_with_text_patches,
+    )
+
+
+def _run_reverse_apply_for_prepared_discards(
+    prepared_discards: list[_PreparedTextFileDiscardToBatch],
+    *,
+    check_only: bool = False,
+) -> None:
+    arguments = ["git", "apply", "--reverse", "--unidiff-zero"]
+    if check_only:
+        arguments.append("--check")
+
+    exit_code = 0
+    stderr_chunks = []
+    patch_chunks = [
+        patch.patch_bytes
+        for prepared in prepared_discards
+        for patch in prepared.patches_to_discard
+    ]
+    for event in stream_command(arguments, stdin_chunks=patch_chunks):
+        if isinstance(event, ExitEvent):
+            exit_code = event.exit_code
+        elif isinstance(event, OutputEvent) and event.fd == 2:
+            stderr_chunks.append(event.data)
+
+    if exit_code != 0:
+        stderr_text = b"".join(stderr_chunks).decode("utf-8", errors="replace")
+        exit_with_error(_("Failed to discard changes from file: {err}").format(err=stderr_text))
+
+
+def _discard_prepared_text_files_to_batch(
+    batch_name: str,
+    prepared_discards: list[_PreparedTextFileDiscardToBatch],
+) -> DiscardFilesToBatchResult:
+    """Publish prepared text file discards once, then update the worktree."""
+    if not prepared_discards:
+        return DiscardFilesToBatchResult(discarded_hunks=0, discarded_files=[])
+
+    snapshot_files_if_untracked([prepared.file_path for prepared in prepared_discards])
+
+    _run_reverse_apply_for_prepared_discards(prepared_discards, check_only=True)
+    add_files_to_batch(
+        batch_name,
+        [
+            BatchFileUpdate(
+                file_path=prepared.file_path,
+                ownership=prepared.ownership,
+                file_mode=prepared.file_mode,
+                batch_source_commit=prepared.batch_source_commit,
+            )
+            for prepared in prepared_discards
+        ],
+    )
+    _run_reverse_apply_for_prepared_discards(prepared_discards)
+
+    repo_root = get_git_repository_root_path()
+    for prepared in prepared_discards:
+        full_path = repo_root / prepared.file_path
+        if not full_path.exists():
+            run_git_command(["rm", "--cached", "--quiet", "--", prepared.file_path], check=False)
+
+    hunk_hashes = [
+        patch.patch_hash
+        for prepared in prepared_discards
+        for patch in prepared.patches_to_discard
+    ]
+    record_hunks_discarded(hunk_hashes)
+
+    return DiscardFilesToBatchResult(
+        discarded_hunks=len(hunk_hashes),
+        discarded_files=[
+            prepared.file_path
+            for prepared in prepared_discards
+            if prepared.patches_to_discard
+        ],
+    )
+
+
+def command_discard_files_to_batch(
+    batch_name: str,
+    files: list[str],
+    *,
+    quiet: bool = False,
+    advance: bool = True,
+) -> DiscardFilesToBatchResult:
+    """Save resolved text files to a batch with one batch publication."""
+    require_git_repository()
+    ensure_state_directory_exists()
+
+    if not files:
+        return DiscardFilesToBatchResult(discarded_hunks=0, discarded_files=[])
+    if not batch_exists(batch_name):
+        create_batch(batch_name, "Auto-created")
+
+    blocklist_path = get_block_list_file_path()
+    blocklist_text = read_text_file_contents(blocklist_path)
+    blocked_hashes = set(blocklist_text.splitlines())
+    metadata = read_batch_metadata(batch_name)
+    collected_discards = _collect_text_file_discard_inputs(
+        files,
+        blocked_hashes=blocked_hashes,
+    )
+
+    prepared_discards: list[_PreparedTextFileDiscardToBatch] = []
+    total_hunks = 0
+    discarded_files: list[str] = []
+
+    def flush_prepared() -> None:
+        nonlocal metadata, total_hunks
+        nonlocal discarded_files, prepared_discards
+        result = _discard_prepared_text_files_to_batch(batch_name, prepared_discards)
+        if result.discarded_hunks:
+            total_hunks += result.discarded_hunks
+            discarded_files.extend(result.discarded_files)
+            metadata = read_batch_metadata(batch_name)
+        prepared_discards = []
+
+    for file_path in files:
+        log_journal("discard_file_to_batch_start", batch_name=batch_name, file_path=file_path, quiet=quiet)
+        discard_input = collected_discards.inputs_by_file.get(file_path)
+        if discard_input is None and file_path in collected_discards.files_with_text_patches:
+            continue
+
+        prepared = _prepare_text_file_discard_to_batch(
+            batch_name,
+            discard_input,
+            metadata=metadata,
+        ) if discard_input is not None else None
+        if prepared is None:
+            flush_prepared()
+            discarded_hunks = command_discard_to_batch(
+                batch_name,
+                file=file_path,
+                quiet=True,
+                advance=False,
+            )
+            if discarded_hunks > 0:
+                total_hunks += discarded_hunks
+                discarded_files.append(file_path)
+                metadata = read_batch_metadata(batch_name)
+                blocklist_text = read_text_file_contents(blocklist_path)
+                blocked_hashes = set(blocklist_text.splitlines())
+            continue
+
+        prepared_discards.append(prepared)
+        log_journal("discard_file_to_batch_end", batch_name=batch_name, file_path=file_path)
+
+    flush_prepared()
+
+    if quiet and advance:
+        advance_to_next_change()
+    elif not quiet:
+        advance_to_and_show_next_change()
+
+    return DiscardFilesToBatchResult(
+        discarded_hunks=total_hunks,
+        discarded_files=discarded_files,
+    )
 
 
 def _command_discard_file_to_batch(

--- a/src/git_stage_batch/data/batch_sources.py
+++ b/src/git_stage_batch/data/batch_sources.py
@@ -3,11 +3,16 @@
 from __future__ import annotations
 
 import json
+import os
 import stat
+import tempfile
+import uuid
+from dataclasses import dataclass
 
 from ..exceptions import CommandError
 from ..i18n import _
 from ..utils.file_io import read_file_paths_file, read_text_file_contents, write_text_file_contents
+from ..utils.command import run_command
 from ..utils.git import (
     create_git_blob,
     get_git_repository_root_path,
@@ -15,8 +20,11 @@ from ..utils.git import (
     git_read_tree,
     git_update_index,
     git_write_tree,
+    list_git_tree_blobs,
+    read_git_blobs_as_bytes,
     run_git_command,
     temp_git_index,
+    update_git_refs,
 )
 from ..utils.journal import log_journal
 from ..utils.paths import (
@@ -26,6 +34,14 @@ from ..utils.paths import (
     get_abort_stash_file_path,
     get_session_batch_sources_file_path,
 )
+
+
+@dataclass(frozen=True)
+class BatchSourceCommit:
+    """A per-file batch source commit and the file content it stores."""
+
+    commit_sha: str
+    file_content: bytes
 
 
 def get_saved_session_file_content(file_path: str) -> bytes:
@@ -82,6 +98,215 @@ def get_saved_session_file_content(file_path: str) -> bytes:
         return b""
 
     return result.stdout
+
+
+def _fast_import_quote_path(file_path: str) -> str:
+    """Quote a repository path for fast-import commands."""
+    raw_path = file_path.encode("utf-8")
+    if raw_path and all(byte not in b' \t\r\n"\\' and 32 <= byte < 127 for byte in raw_path):
+        return file_path
+
+    escaped = []
+    for byte in raw_path:
+        if byte == ord("\\"):
+            escaped.append("\\\\")
+        elif byte == ord('"'):
+            escaped.append('\\"')
+        elif byte == ord("\n"):
+            escaped.append("\\n")
+        elif byte == ord("\r"):
+            escaped.append("\\r")
+        elif byte == ord("\t"):
+            escaped.append("\\t")
+        elif 32 <= byte < 127:
+            escaped.append(chr(byte))
+        else:
+            escaped.append(f"\\{byte:03o}")
+    return '"' + "".join(escaped) + '"'
+
+
+def _read_session_file_contents(
+    file_paths: list[str],
+    *,
+    baseline_commit: str,
+) -> tuple[dict[str, bytes], set[str]]:
+    """Read session-start content for several files."""
+    unique_file_paths = list(dict.fromkeys(file_paths))
+    baseline_blobs = list_git_tree_blobs(baseline_commit, unique_file_paths)
+    baseline_existing_files = set(baseline_blobs)
+
+    snapshot_list_path = get_abort_snapshot_list_file_path()
+    snapshotted_files = (
+        set(read_file_paths_file(snapshot_list_path))
+        if snapshot_list_path.exists() else
+        set()
+    )
+
+    contents: dict[str, bytes] = {}
+    remaining_paths: list[str] = []
+    snapshot_directory = get_abort_snapshots_directory_path()
+    for file_path in unique_file_paths:
+        if file_path in snapshotted_files:
+            snapshot_path = snapshot_directory / file_path
+            if snapshot_path.exists():
+                contents[file_path] = snapshot_path.read_bytes()
+                continue
+            raise CommandError(
+                _("Snapshot for untracked file not found: {file}").format(file=file_path)
+            )
+        remaining_paths.append(file_path)
+
+    stash_file_path = get_abort_stash_file_path()
+    stash_blobs = {}
+    if stash_file_path.exists():
+        stash_commit = read_text_file_contents(stash_file_path).strip()
+        if stash_commit:
+            stash_blobs = list_git_tree_blobs(stash_commit, remaining_paths)
+
+    blob_shas = [
+        blob.blob_sha
+        for blob in [
+            *(stash_blobs.get(file_path) for file_path in remaining_paths),
+            *(baseline_blobs.get(file_path) for file_path in remaining_paths),
+        ]
+        if blob is not None
+    ]
+    blob_contents = read_git_blobs_as_bytes(blob_shas)
+
+    repo_root = get_git_repository_root_path()
+    for file_path in remaining_paths:
+        stash_blob = stash_blobs.get(file_path)
+        if stash_blob is not None and stash_blob.blob_sha in blob_contents:
+            contents[file_path] = blob_contents[stash_blob.blob_sha]
+            continue
+
+        baseline_blob = baseline_blobs.get(file_path)
+        if baseline_blob is not None and baseline_blob.blob_sha in blob_contents:
+            contents[file_path] = blob_contents[baseline_blob.blob_sha]
+            continue
+
+        file_full_path = repo_root / file_path
+        if file_path not in baseline_existing_files and file_full_path.exists():
+            contents[file_path] = file_full_path.read_bytes()
+        else:
+            contents[file_path] = b""
+
+    return contents, baseline_existing_files
+
+
+def create_batch_source_commits(file_paths: list[str]) -> dict[str, BatchSourceCommit]:
+    """Create per-file batch source commits in one fast-import transaction."""
+    unique_file_paths = list(dict.fromkeys(file_paths))
+    if not unique_file_paths:
+        return {}
+
+    baseline_commit = read_text_file_contents(get_abort_head_file_path()).strip()
+    file_contents, files_existing_at_session_start = _read_session_file_contents(
+        unique_file_paths,
+        baseline_commit=baseline_commit,
+    )
+
+    repo_root = get_git_repository_root_path()
+    file_modes: dict[str, str] = {}
+    for file_path in unique_file_paths:
+        full_path = repo_root / file_path
+        if full_path.exists():
+            mode = "100755" if full_path.stat().st_mode & stat.S_IXUSR else "100644"
+        else:
+            mode = "100644"
+        file_modes[file_path] = mode
+
+        log_journal(
+            "batch_source_creating",
+            file_path=file_path,
+            baseline_commit=baseline_commit,
+            file_existed_at_session_start=file_path in files_existing_at_session_start,
+            content_len=len(file_contents[file_path]),
+            content_lines=len(file_contents[file_path].splitlines()) if file_contents[file_path] else 0,
+            content_preview=file_contents[file_path][:200] if file_contents[file_path] else b"(empty)",
+        )
+
+    import_id = uuid.uuid4().hex
+    temp_refs = [
+        f"refs/git-stage-batch/tmp/batch-source/{import_id}/{index}"
+        for index, _file_path in enumerate(unique_file_paths)
+    ]
+    blob_mark_start = 1
+    commit_mark_start = blob_mark_start + len(unique_file_paths)
+
+    def fast_import_chunks():
+        for index, file_path in enumerate(unique_file_paths):
+            blob_mark = blob_mark_start + index
+            content = file_contents[file_path]
+            yield f"blob\nmark :{blob_mark}\ndata {len(content)}\n".encode("ascii")
+            yield content
+            yield b"\n"
+
+        for index, file_path in enumerate(unique_file_paths):
+            commit_mark = commit_mark_start + index
+            blob_mark = blob_mark_start + index
+            message = f"Batch source for {file_path}".encode("utf-8")
+            quoted_path = _fast_import_quote_path(file_path)
+            yield (
+                f"commit {temp_refs[index]}\n"
+                f"mark :{commit_mark}\n"
+                "committer Git Stage Batch <git-stage-batch@example.invalid> 0 +0000\n"
+                f"data {len(message)}\n"
+            ).encode("utf-8")
+            yield message
+            yield (
+                f"\nfrom {baseline_commit}\n"
+                f"M {file_modes[file_path]} :{blob_mark} {quoted_path}\n"
+            ).encode("utf-8")
+
+    with tempfile.NamedTemporaryFile(delete=False) as marks_file:
+        marks_path = marks_file.name
+
+    import_succeeded = False
+    try:
+        run_command(
+            [
+                "git",
+                "fast-import",
+                "--quiet",
+                "--date-format=raw",
+                f"--export-marks={marks_path}",
+            ],
+            fast_import_chunks(),
+            capture_stdout=False,
+        )
+        import_succeeded = True
+        marks: dict[int, str] = {}
+        with open(marks_path, "r", encoding="ascii") as file:
+            for line in file:
+                mark_text, object_sha = line.strip().split(" ", 1)
+                marks[int(mark_text[1:])] = object_sha
+    finally:
+        if import_succeeded:
+            update_git_refs(deletes=temp_refs, ignore_missing_deletes=False)
+        try:
+            os.unlink(marks_path)
+        except FileNotFoundError:
+            pass
+
+    results: dict[str, BatchSourceCommit] = {}
+    for index, file_path in enumerate(unique_file_paths):
+        commit_sha = marks[commit_mark_start + index]
+        results[file_path] = BatchSourceCommit(
+            commit_sha=commit_sha,
+            file_content=file_contents[file_path],
+        )
+        log_journal(
+            "batch_source_created",
+            file_path=file_path,
+            batch_source_commit=commit_sha,
+            blob_sha=marks[blob_mark_start + index],
+            mode=file_modes[file_path],
+            tree=None,
+            verified_content_len=len(file_contents[file_path]),
+            verified_lines=len(file_contents[file_path].splitlines()) if file_contents[file_path] else None,
+        )
+    return results
 
 
 def create_batch_source_commit(

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -1685,10 +1685,18 @@ def record_hunk_included(hunk_hash: str) -> None:
 
 def record_hunk_discarded(hunk_hash: str) -> None:
     """Record that a hunk was discarded (removed from working tree)."""
+    record_hunks_discarded([hunk_hash])
+
+
+def record_hunks_discarded(hunk_hashes: list[str]) -> None:
+    """Record that hunks were discarded (removed from working tree)."""
+    new_hashes = {hunk_hash for hunk_hash in hunk_hashes if hunk_hash}
+    if not new_hashes:
+        return
     discarded_path = get_discarded_hunks_file_path()
     content = read_text_file_contents(discarded_path)
     existing = set(content.splitlines()) if content else set()
-    existing.add(hunk_hash)
+    existing.update(new_hashes)
     write_text_file_contents(discarded_path, "\n".join(sorted(existing)) + "\n" if existing else "")
 
 

--- a/src/git_stage_batch/data/session.py
+++ b/src/git_stage_batch/data/session.py
@@ -187,6 +187,64 @@ def snapshot_file_if_untracked(file_path: str) -> None:
     append_file_path_to_file(get_abort_snapshot_list_file_path(), file_path)
 
 
+def snapshot_files_if_untracked(file_paths: list[str]) -> None:
+    """Snapshot untracked files before modifying several paths."""
+    unique_file_paths = list(dict.fromkeys(file_paths))
+    if not unique_file_paths:
+        return
+
+    empty_blob_hash = "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"
+    stage_result = run_git_command(
+        ["ls-files", "--stage", "-z", "--", *unique_file_paths],
+        check=False,
+        text_output=False,
+    )
+
+    tracked_real_content: set[str] = set()
+    tracked_empty_content: set[str] = set()
+    for record in stage_result.stdout.split(b"\0"):
+        if not record:
+            continue
+        try:
+            metadata, path_bytes = record.split(b"\t", 1)
+        except ValueError:
+            continue
+        parts = metadata.split()
+        if len(parts) < 2:
+            continue
+        file_path = path_bytes.decode("utf-8")
+        blob_hash = parts[1].decode("ascii", errors="replace")
+        if blob_hash == empty_blob_hash:
+            tracked_empty_content.add(file_path)
+        else:
+            tracked_real_content.add(file_path)
+
+    snapshotted_files = set(read_file_paths_file(get_abort_snapshot_list_file_path()))
+    repo_root = get_git_repository_root_path()
+    snapshot_dir = get_abort_snapshots_directory_path()
+    newly_snapshotted: list[str] = []
+    for file_path in unique_file_paths:
+        if file_path in tracked_real_content:
+            continue
+        if file_path in snapshotted_files:
+            continue
+
+        full_path = repo_root / file_path
+        if not full_path.exists():
+            continue
+
+        snapshot_path = snapshot_dir / file_path
+        snapshot_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(full_path, snapshot_path)
+        newly_snapshotted.append(file_path)
+
+    if newly_snapshotted:
+        write_file_paths_file(
+            get_abort_snapshot_list_file_path(),
+            [*snapshotted_files, *newly_snapshotted],
+        )
+
+
 def get_iteration_count() -> int:
     """Get selected iteration count, defaulting to 1.
 

--- a/src/git_stage_batch/data/undo.py
+++ b/src/git_stage_batch/data/undo.py
@@ -7,6 +7,7 @@ import shutil
 import stat
 import tempfile
 from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterator
 
@@ -15,11 +16,12 @@ from ..exceptions import CommandError
 from ..i18n import _
 from ..utils.file_io import read_file_paths_file
 from ..utils.git import (
-    create_git_blob,
+    create_git_blobs,
+    GitIndexEntryUpdate,
     get_git_repository_root_path,
     git_commit_tree,
     git_read_tree,
-    git_update_index,
+    git_update_index_entries,
     git_write_tree,
     run_git_command,
     temp_git_index,
@@ -41,6 +43,13 @@ REF_PREFIXES = (
     BATCH_STATE_REF_PREFIX,
 )
 _PENDING_CHECKPOINT: str | None = None
+
+
+@dataclass(frozen=True)
+class _IndexContentUpdate:
+    path: str
+    data: bytes
+    mode: str = "100644"
 
 
 def _list_refs() -> dict[str, str]:
@@ -75,15 +84,19 @@ def _changed_worktree_paths() -> list[str]:
 
 def _snapshot_worktree_paths(paths: list[str]) -> list[dict[str, Any]]:
     repo_root = get_git_repository_root_path()
-    worktree_paths = []
+    worktree_paths: list[dict[str, Any]] = []
+    existing_entry_indexes: list[int] = []
+    existing_contents: list[bytes] = []
     for file_path in sorted(set(paths)):
         full_path = repo_root / file_path
         if full_path.exists() and full_path.is_file():
+            existing_entry_indexes.append(len(worktree_paths))
+            existing_contents.append(full_path.read_bytes())
             worktree_paths.append({
                 "path": file_path,
                 "exists": True,
                 "mode": _file_mode_for_path(full_path),
-                "blob": create_git_blob([full_path.read_bytes()]),
+                "blob": None,
             })
         else:
             worktree_paths.append({
@@ -92,6 +105,13 @@ def _snapshot_worktree_paths(paths: list[str]) -> list[dict[str, Any]]:
                 "mode": "100644",
                 "blob": None,
             })
+
+    for entry_index, blob_sha in zip(
+        existing_entry_indexes,
+        create_git_blobs(existing_contents),
+        strict=True,
+    ):
+        worktree_paths[entry_index]["blob"] = blob_sha
     return worktree_paths
 
 
@@ -104,13 +124,26 @@ def _snapshot_current_state(paths: list[str]) -> dict[str, Any]:
     }
 
 
-def _run_update_index(env: dict[str, str], mode: str, blob_sha: str, path: str) -> None:
-    git_update_index(mode=mode, blob_sha=blob_sha, file_path=path, env=env)
+def _add_index_content_updates(env: dict[str, str], updates: list[_IndexContentUpdate]) -> None:
+    blob_shas = create_git_blobs(update.data for update in updates)
+    git_update_index_entries(
+        [
+            GitIndexEntryUpdate(
+                file_path=update.path,
+                mode=update.mode,
+                blob_sha=blob_sha,
+            )
+            for update, blob_sha in zip(updates, blob_shas, strict=True)
+        ],
+        env=env,
+    )
 
 
 def _add_blob_to_index(env: dict[str, str], path: str, data: bytes, mode: str = "100644") -> None:
-    blob_sha = create_git_blob([data])
-    _run_update_index(env, mode, blob_sha, path)
+    _add_index_content_updates(
+        env,
+        [_IndexContentUpdate(path=path, data=data, mode=mode)],
+    )
 
 
 def _file_mode_for_path(path: Path) -> str:
@@ -131,10 +164,18 @@ def _restore_file_mode(path: Path, mode: str) -> None:
 def _add_directory_to_index(env: dict[str, str], *, source_dir: Path, tree_prefix: str) -> None:
     if not source_dir.exists():
         return
+    updates: list[_IndexContentUpdate] = []
     for file_path in sorted(path for path in source_dir.rglob("*") if path.is_file()):
         relative_path = file_path.relative_to(source_dir).as_posix()
         tree_path = f"{tree_prefix}/{relative_path}"
-        _add_blob_to_index(env, tree_path, file_path.read_bytes(), _file_mode_for_path(file_path))
+        updates.append(
+            _IndexContentUpdate(
+                path=tree_path,
+                data=file_path.read_bytes(),
+                mode=_file_mode_for_path(file_path),
+            )
+        )
+    _add_index_content_updates(env, updates)
 
 
 def _current_stack_commit(ref_name: str) -> str | None:
@@ -182,18 +223,18 @@ def _create_undo_checkpoint(operation: str, *, worktree_paths: list[str] | None 
         _add_directory_to_index(env, source_dir=session_dir, tree_prefix="session")
         _add_directory_to_index(env, source_dir=get_batches_directory_path(), tree_prefix="batches")
 
-        repo_root = get_git_repository_root_path()
-        for entry in before["worktree_paths"]:
-            if not entry["exists"]:
-                continue
-            full_path = repo_root / entry["path"]
-            if full_path.exists() and full_path.is_file():
-                _add_blob_to_index(
-                    env,
-                    f"worktree/{entry['path']}",
-                    full_path.read_bytes(),
-                    entry["mode"],
+        git_update_index_entries(
+            [
+                GitIndexEntryUpdate(
+                    file_path=f"worktree/{entry['path']}",
+                    mode=entry["mode"],
+                    blob_sha=entry["blob"],
                 )
+                for entry in before["worktree_paths"]
+                if entry["exists"] and entry.get("blob")
+            ],
+            env=env,
+        )
 
         tree_sha = git_write_tree(env=env)
 
@@ -416,21 +457,32 @@ def _write_snapshot_commit(
         _add_directory_to_index(env, source_dir=batches_dir, tree_prefix="batches")
 
         repo_root = get_git_repository_root_path()
+        index_updates: list[GitIndexEntryUpdate] = []
+        content_updates: list[_IndexContentUpdate] = []
         for entry in worktree_entries:
             if not entry.get("exists", False):
                 continue
             blob_sha = entry.get("blob")
             if blob_sha:
-                _run_update_index(env, entry.get("mode", "100644"), blob_sha, f"worktree/{entry['path']}")
+                index_updates.append(
+                    GitIndexEntryUpdate(
+                        file_path=f"worktree/{entry['path']}",
+                        mode=entry.get("mode", "100644"),
+                        blob_sha=blob_sha,
+                    )
+                )
             else:
                 full_path = repo_root / entry["path"]
                 if full_path.exists() and full_path.is_file():
-                    _add_blob_to_index(
-                        env,
-                        f"worktree/{entry['path']}",
-                        full_path.read_bytes(),
-                        entry.get("mode", "100644"),
+                    content_updates.append(
+                        _IndexContentUpdate(
+                            path=f"worktree/{entry['path']}",
+                            data=full_path.read_bytes(),
+                            mode=entry.get("mode", "100644"),
+                        )
                     )
+        git_update_index_entries(index_updates, env=env)
+        _add_index_content_updates(env, content_updates)
 
         tree_sha = git_write_tree(env=env)
 

--- a/src/git_stage_batch/utils/git.py
+++ b/src/git_stage_batch/utils/git.py
@@ -8,6 +8,7 @@ import sys
 import tempfile
 from collections.abc import Iterable, Iterator
 from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
 
 from ..exceptions import exit_with_error
@@ -19,6 +20,25 @@ from .text import bytes_to_lines
 
 _GIT_REPOSITORY_ROOT_CACHE: dict[Path, Path] = {}
 _GIT_DIRECTORY_CACHE: dict[Path, Path] = {}
+
+
+@dataclass(frozen=True)
+class GitTreeBlob:
+    """One blob entry from a Git tree."""
+
+    file_path: str
+    mode: str
+    blob_sha: str
+
+
+@dataclass(frozen=True)
+class GitIndexEntryUpdate:
+    """One index-info update for a temporary Git index."""
+
+    file_path: str
+    mode: str | None = None
+    blob_sha: str | None = None
+    force_remove: bool = False
 
 
 def stream_git_command(
@@ -184,6 +204,46 @@ def git_update_index(
     )
 
 
+def git_update_index_entries(
+    entries: Iterable[GitIndexEntryUpdate],
+    *,
+    env: dict[str, str] | None = None,
+) -> None:
+    """Update several index entries through one update-index process."""
+    payload_chunks: list[bytes] = []
+    for entry in entries:
+        path_bytes = entry.file_path.encode("utf-8")
+        if entry.force_remove:
+            if entry.mode is not None or entry.blob_sha is not None:
+                raise ValueError("mode and blob_sha cannot be used with force_remove=True")
+            payload_chunks.extend([
+                b"0 0000000000000000000000000000000000000000\t",
+                path_bytes,
+                b"\0",
+            ])
+        else:
+            if entry.mode is None or entry.blob_sha is None:
+                raise ValueError("mode and blob_sha are required unless force_remove=True")
+            payload_chunks.extend([
+                entry.mode.encode("ascii"),
+                b" ",
+                entry.blob_sha.encode("ascii"),
+                b"\t",
+                path_bytes,
+                b"\0",
+            ])
+
+    if not payload_chunks:
+        return
+
+    for _chunk in stream_git_command(
+        ["update-index", "-z", "--index-info"],
+        payload_chunks,
+        env=env,
+    ):
+        pass
+
+
 def git_write_tree(*, env: dict[str, str] | None = None) -> str:
     """Write the current or provided index as a Git tree."""
     return run_git_command(["write-tree"], env=env).stdout.strip()
@@ -240,6 +300,34 @@ def create_git_blob(content_chunks: Iterable[bytes]) -> str:
     stdout_bytes = b"".join(stdout_chunks)
     blob_sha = stdout_bytes.strip().decode("utf-8")
     return blob_sha
+
+
+def create_git_blobs(contents: Iterable[bytes]) -> list[str]:
+    """Create several blob objects with one hash-object process."""
+    content_list = list(contents)
+    if not content_list:
+        return []
+
+    with tempfile.TemporaryDirectory(prefix="git-stage-batch-blobs-") as temp_dir:
+        temp_path = Path(temp_dir)
+        path_lines: list[str] = []
+        for index, content in enumerate(content_list):
+            path = temp_path / str(index)
+            path.write_bytes(content)
+            path_lines.append(str(path))
+
+        payload = ("\n".join(path_lines) + "\n").encode("utf-8")
+        result = run_command(
+            ["git", "hash-object", "-w", "--stdin-paths"],
+            [payload],
+        )
+
+    blob_shas = result.stdout.strip().splitlines()
+    if len(blob_shas) != len(content_list):
+        raise RuntimeError(
+            f"git hash-object returned {len(blob_shas)} hashes for {len(content_list)} blobs"
+        )
+    return blob_shas
 
 
 def read_git_blob(blob_sha: str) -> Iterator[bytes]:
@@ -307,6 +395,56 @@ def read_git_blobs_as_bytes(blob_hashes: Iterable[str]) -> dict[str, bytes]:
         blobs[object_hash] = content
 
     return blobs
+
+
+def list_git_tree_blobs(treeish: str, file_paths: Iterable[str]) -> dict[str, GitTreeBlob]:
+    """List blob entries for paths in one tree with one ls-tree process."""
+    unique_file_paths = list(dict.fromkeys(file_paths))
+    if not unique_file_paths:
+        return {}
+
+    result = run_git_command(
+        ["ls-tree", "-rz", treeish, "--", *unique_file_paths],
+        check=False,
+        text_output=False,
+    )
+    if result.returncode != 0:
+        return {}
+
+    entries: dict[str, GitTreeBlob] = {}
+    for record in result.stdout.split(b"\0"):
+        if not record:
+            continue
+        try:
+            metadata_bytes, path_bytes = record.split(b"\t", 1)
+        except ValueError:
+            continue
+        metadata = metadata_bytes.decode("ascii", errors="replace").split()
+        if len(metadata) < 3 or metadata[1] != "blob":
+            continue
+        file_path = path_bytes.decode("utf-8")
+        entries[file_path] = GitTreeBlob(
+            file_path=file_path,
+            mode=metadata[0],
+            blob_sha=metadata[2],
+        )
+    return entries
+
+
+def read_git_tree_file_contents(treeish: str, file_paths: Iterable[str]) -> dict[str, bytes]:
+    """Read several file contents from a tree with batched object IO."""
+    tree_blobs = list_git_tree_blobs(treeish, file_paths)
+    if not tree_blobs:
+        return {}
+
+    blob_contents = read_git_blobs_as_bytes(
+        blob.blob_sha for blob in tree_blobs.values()
+    )
+    return {
+        file_path: blob_contents[blob.blob_sha]
+        for file_path, blob in tree_blobs.items()
+        if blob.blob_sha in blob_contents
+    }
 
 
 def read_git_blob_as_bytes(blob_hash: str) -> bytes | None:

--- a/src/git_stage_batch/utils/git.py
+++ b/src/git_stage_batch/utils/git.py
@@ -17,6 +17,10 @@ from .file_io import read_text_file_contents, write_text_file_contents
 from .text import bytes_to_lines
 
 
+_GIT_REPOSITORY_ROOT_CACHE: dict[Path, Path] = {}
+_GIT_DIRECTORY_CACHE: dict[Path, Path] = {}
+
+
 def stream_git_command(
     arguments: list[str],
     stdin_chunks: Iterable[bytes] | None = None,
@@ -379,14 +383,28 @@ def get_git_repository_root_path() -> Path:
     Raises:
         subprocess.CalledProcessError: If not in a git repository
     """
+    cwd = Path.cwd()
+    cached = _GIT_REPOSITORY_ROOT_CACHE.get(cwd)
+    if cached is not None:
+        return cached
+
     output = run_git_command(["rev-parse", "--show-toplevel"]).stdout.strip()
-    return Path(output)
+    path = Path(output)
+    _GIT_REPOSITORY_ROOT_CACHE[cwd] = path
+    return path
 
 
 def get_git_directory_path() -> Path:
     """Get the absolute path to the repository's git directory."""
+    cwd = Path.cwd()
+    cached = _GIT_DIRECTORY_CACHE.get(cwd)
+    if cached is not None:
+        return cached
+
     output = run_git_command(["rev-parse", "--absolute-git-dir"]).stdout.strip()
-    return Path(output)
+    path = Path(output)
+    _GIT_DIRECTORY_CACHE[cwd] = path
+    return path
 
 
 def resolve_file_path_to_repo_relative(file_path: str) -> str:

--- a/src/git_stage_batch/utils/journal.py
+++ b/src/git_stage_batch/utils/journal.py
@@ -67,15 +67,6 @@ def log_journal(operation: str, **kwargs: Any) -> None:
             if "git_stage_batch" in s.filename
         ][-5:]  # Last 5 frames
 
-        # Get repository path for global journal (to distinguish different repos)
-        repo_path = None
-        try:
-            result = run_git_command(["rev-parse", "--show-toplevel"], check=False)
-            if result.returncode == 0:
-                repo_path = result.stdout.strip()
-        except Exception:
-            pass
-
         entry = {
             "timestamp": datetime.now().isoformat(),
             "pid": os.getpid(),
@@ -92,6 +83,15 @@ def log_journal(operation: str, **kwargs: Any) -> None:
 
         # Write to global persistent journal if debug mode enabled
         if os.environ.get("GIT_STAGE_BATCH_DEBUG"):
+            # Get repository path for global journal (to distinguish different repos)
+            repo_path = None
+            try:
+                result = run_git_command(["rev-parse", "--show-toplevel"], check=False)
+                if result.returncode == 0:
+                    repo_path = result.stdout.strip()
+            except Exception:
+                pass
+
             global_journal_path = Path("/var/tmp/git-stage-batch-journal.jsonl")
             global_entry = {
                 "repo": repo_path,


### PR DESCRIPTION
## Summary

Multi-file batch operations such as `discard --to --files` currently
process each resolved path through the single-file command path. That
repeats Git subprocess spawns, object writes, state ref publications,
and checkpoint bookkeeping for every file in the match set.

This series reduces that per-file overhead across the full stack:

- **Deferred and cached lookups**: Journal repo resolution moves into
  the debug branch so non-debug sessions skip the subprocess. Repository
  path lookups are cached per working directory so inner loops stop
  re-spawning `git rev-parse`.

- **Batched Git object helpers**: New bulk helpers for blob creation,
  index updates, tree reads, and tree content reads replace per-item
  subprocess calls with grouped operations.

- **Grouped undo checkpoints**: Directory, worktree, and redo snapshots
  now flush blob creation and index updates through the batched helpers
  instead of hashing and updating entries one at a time.

- **Grouped batch state and source creation**: State ref publication
  collects all source snapshots into one set of blob and index updates.
  Batch source commits stream through one `git fast-import` process
  instead of separate blob/tree/commit sequences per file.

- **Grouped batch storage publication**: `add_files_to_batch` prepares
  all text updates against one metadata snapshot and publishes one
  content commit plus one state ref update for the group.

- **Bulk progress tracking**: Hunk discard recording and untracked file
  snapshots each consolidate repeated read-modify-write cycles into
  single grouped operations.

- **Grouped discard-to-batch command**: `command_discard_files_to_batch`
  routes resolved text files through the grouped paths — one diff read,
  one ownership pass, one combined reverse patch check, one batch
  publish, one combined apply — while binary and unsupported files fall
  back to the existing single-file command.

## Commits

1.  `utils: Defer journal repo lookup to debug mode`
2.  `utils: Cache Git repository path lookups`
3.  `utils: Add batched Git object helpers`
4.  `undo: Batch checkpoint object writes`
5.  `batch: Batch state ref object writes`
6.  `batch: Add bulk batch source commit creation`
7.  `batch: Add multi-file batch storage publication`
8.  `data: Add bulk hunk discard recording`
9.  `data: Add bulk untracked file snapshots`
10. `discard: Add grouped file-scope batch discard`

## Test plan

- [ ] `uv run pytest -n auto` passes all tests
- [ ] Multi-file discard --to --files operates in grouped steps
- [ ] Single-file and binary fallback paths remain functional
- [ ] Undo after grouped discard restores all files in one step