### PR TITLE
status: Add prompt-oriented session output

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ For scripting and automation, use the `--porcelain` flag:
 # Get status as JSON
 git-stage-batch status --porcelain
 
+# Add active session status next to a __git_ps1 branch
+PS1=$PS1'\r$(__git_ps1 "\n╎\e[32m%s$(git-stage-batch status --for-prompt=\|{status}\ {processed}/{total})\e[0m")\n'
+
 # Check if a hunk exists (exit code 0/1)
 git-stage-batch show --porcelain
 ```

--- a/completions/git-stage-batch
+++ b/completions/git-stage-batch
@@ -182,7 +182,12 @@ _git_stage_batch()
             COMPREPLY=($(compgen -W "--from --to --line --file --files" -- "$cur"))
             ;;
         status)
-            COMPREPLY=($(compgen -W "--porcelain" -- "$cur"))
+            case "$prev" in
+                --for-prompt)
+                    return
+                    ;;
+            esac
+            COMPREPLY=($(compgen -W "--porcelain --for-prompt" -- "$cur"))
             ;;
         undo|redo)
             COMPREPLY=($(compgen -W "--force" -- "$cur"))

--- a/completions/git-stage-batch-prompt.sh
+++ b/completions/git-stage-batch-prompt.sh
@@ -1,6 +1,6 @@
 # git-stage-batch prompt integration for bash
 #
-# Shows "BATCH" in your prompt when a git-stage-batch session is active.
+# Shows "STAGING" in your prompt when a git-stage-batch session is active.
 #
 # Usage:
 #   Add to your ~/.bashrc:
@@ -8,15 +8,17 @@
 #     source /usr/share/git-stage-batch/git-stage-batch-prompt.sh
 #     PS1='$(__git_ps1 "(%s)")$(__git_stage_batch_ps1) \$ '
 #
-#   This will show: (main BATCH) $ when a session is active
+#   This will show: (main STAGING) $ when a session is active
+#
+#   Pass a custom format to include your own spacing, brackets, or fields:
+#
+#     PS1='$(__git_ps1 "(%s)")$(__git_stage_batch_ps1 " [{status} {processed}/{total}]") \$ '
 #
 
 __git_stage_batch_ps1()
 {
-    local git_dir
-    git_dir=$(git rev-parse --git-dir 2>/dev/null) || return
+    local format
 
-    if [ -f "$git_dir/git-stage-batch/session-state.json" ]; then
-        printf " BATCH"
-    fi
+    format=${1:-" STAGING"}
+    git-stage-batch status --for-prompt="$format" 2>/dev/null
 }

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -174,6 +174,7 @@ Skipped hunks:
 
 **Options:**
 - `--porcelain`: Output in machine-readable JSON format
+- `--for-prompt[=FORMAT]`: Print a prompt segment only when a session is active
 
 **Porcelain output:**
 ```bash
@@ -211,6 +212,21 @@ Outputs JSON with stable fields for script integration:
   ]
 }
 ```
+
+**Prompt output:**
+```bash
+PS1=$PS1'\r$(__git_ps1 "\n╎\e[32m%s$(git-stage-batch status --for-prompt=\|{status}\ {processed}/{total})\e[0m")\n'
+```
+
+When no session is active, `--for-prompt` prints nothing, so any spacing or
+brackets included in `FORMAT` are hidden too. Without `FORMAT`, it prints
+`STAGING`. In prompt output, `{status}` is the operation name `STAGING`;
+`{progress_status}` exposes the underlying `in_progress` or `complete` state.
+Format fields include `{status}`, `{status_label}`, `{progress_status}`,
+`{progress_label}`, `{iteration}`, `{processed}`, `{total}`, `{included}`,
+`{skipped}`, `{discarded}`, `{remaining}`, `{selected_file}`,
+`{selected_line}`, `{selected_ids}`, and `{selected_kind}`. `{processed}` is
+`included + skipped + discarded`; `{total}` is `{processed} + remaining`.
 
 ---
 

--- a/docs/git-stage-batch.1.in
+++ b/docs/git-stage-batch.1.in
@@ -123,7 +123,7 @@ Reverse-apply the cached hunk to the working tree; advance to next.
 .B WARNING:
 This permanently removes changes from your working tree.
 .TP
-.B status \fR[\fB\-\-porcelain\fR]
+.B status \fR[\fB\-\-porcelain\fR|\fB\-\-for\-prompt\fR[\fB=\fIFORMAT\fR]]
 Show session progress and remaining hunks.
 Displays iteration number, selected hunk location, progress metrics
 (included/skipped/discarded/remaining counts), and a list of skipped hunks.
@@ -135,6 +135,45 @@ The JSON includes: session (active, iteration, status, and in_progress),
 selected_change (selected hunk/file/batch-file/binary details or null),
 file_review (last page-aware review details or null), progress (counts), and
 skipped_hunks (array).
+.TP
+.B \-\-for\-prompt\fR[\fB=\fIFORMAT\fR]
+Print a shell-prompt segment only when a session is active. When no session is
+active, prints nothing, including any custom spacing or brackets in
+.IR FORMAT .
+Without
+.IR FORMAT ,
+prints
+.BR STAGING .
+In prompt output,
+.BR {status}
+is the operation name
+.BR STAGING ;
+.BR {progress_status}
+exposes the underlying
+.BR in_progress
+or
+.BR complete
+state. Format fields include
+.BR {status} ,
+.BR {status_label} ,
+.BR {progress_status} ,
+.BR {progress_label} ,
+.BR {iteration} ,
+.BR {processed} ,
+.BR {total} ,
+.BR {included} ,
+.BR {skipped} ,
+.BR {discarded} ,
+.BR {remaining} ,
+.BR {selected_file} ,
+.BR {selected_line} ,
+.BR {selected_ids} ,
+and
+.BR {selected_kind} .
+.BR {processed}
+is included + skipped + discarded;
+.BR {total}
+is processed + remaining.
 .RE
 .SS Session Management
 .TP

--- a/src/git_stage_batch/cli/argument_parser.py
+++ b/src/git_stage_batch/cli/argument_parser.py
@@ -661,12 +661,26 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
         aliases=["st"],
         help=_("Show selected session status"),
     )
-    parser_status.add_argument(
+    status_output = parser_status.add_mutually_exclusive_group()
+    status_output.add_argument(
         "--porcelain",
         action="store_true",
         help=_("Output JSON for scripting instead of human-readable text"),
     )
-    parser_status.set_defaults(func=lambda args: commands.command_status(porcelain=args.porcelain))
+    status_output.add_argument(
+        "--for-prompt",
+        dest="prompt_format",
+        nargs="?",
+        const=commands.DEFAULT_PROMPT_FORMAT,
+        metavar="FORMAT",
+        help=_("Print FORMAT only when a session is active, for shell prompts"),
+    )
+    parser_status.set_defaults(
+        func=lambda args: commands.command_status(
+            porcelain=args.porcelain,
+            prompt_format=args.prompt_format,
+        )
+    )
 
     # include - Stage the selected hunk
     parser_include = subparsers.add_parser(

--- a/src/git_stage_batch/cli/main.py
+++ b/src/git_stage_batch/cli/main.py
@@ -22,8 +22,13 @@ def main() -> None:
             if args.working_directory is not None:
                 os.chdir(args.working_directory)
             pager_context = pager_output() if should_page_output(args) else nullcontext()
+            lock_context = (
+                nullcontext()
+                if getattr(args, "prompt_format", None) is not None
+                else acquire_session_lock()
+            )
             with pager_context:
-                with acquire_session_lock():
+                with lock_context:
                     dispatch_args(args)
         else:
             # Parsing failed

--- a/src/git_stage_batch/cli/pager.py
+++ b/src/git_stage_batch/cli/pager.py
@@ -44,6 +44,9 @@ def should_page_output(args: argparse.Namespace) -> bool:
     if getattr(args, "porcelain", False):
         return False
 
+    if getattr(args, "prompt_format", None) is not None:
+        return False
+
     return command in _PAGEABLE_COMMANDS
 
 

--- a/src/git_stage_batch/commands/__init__.py
+++ b/src/git_stage_batch/commands/__init__.py
@@ -31,7 +31,7 @@ from .show_from import command_show_from_batch
 from .sift import command_sift_batch
 from .skip import command_skip, command_skip_file, command_skip_line
 from .start import command_start
-from .status import command_status
+from .status import DEFAULT_PROMPT_FORMAT, command_status
 from .stop import command_stop
 from .suggest_fixup import command_suggest_fixup, command_suggest_fixup_line
 from .unblock_file import command_unblock_file
@@ -75,6 +75,7 @@ __all__ = [
     "command_skip_line",
     "command_start",
     "command_status",
+    "DEFAULT_PROMPT_FORMAT",
     "command_stop",
     "command_suggest_fixup",
     "command_suggest_fixup_line",

--- a/src/git_stage_batch/commands/status.py
+++ b/src/git_stage_batch/commands/status.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
+from string import Formatter
+import subprocess
 import sys
 
 from ..batch.query import read_batch_metadata
@@ -30,11 +33,11 @@ from ..data.hunk_tracking import (
 )
 from ..data.line_state import load_line_changes_from_state
 from ..data.session import get_iteration_count
+from ..exceptions import CommandError
 from ..i18n import _
 from ..utils.file_io import read_file_paths_file, read_text_file_contents
-from ..utils.git import require_git_repository, stream_git_command
+from ..utils.git import require_git_repository, run_git_command, stream_git_command
 from ..utils.paths import (
-    get_abort_head_file_path,
     get_block_list_file_path,
     get_blocked_files_file_path,
     get_context_lines,
@@ -43,7 +46,37 @@ from ..utils.paths import (
     get_discarded_hunks_file_path,
     get_included_hunks_file_path,
     get_skipped_hunks_jsonl_file_path,
+    get_state_directory_path,
 )
+
+
+DEFAULT_PROMPT_FORMAT = "STAGING"
+_PROMPT_FIELDS = frozenset(
+    {
+        "active",
+        "change_type",
+        "discarded",
+        "file_review_batch",
+        "file_review_fresh",
+        "file_review_source",
+        "included",
+        "in_progress",
+        "iteration",
+        "processed",
+        "progress_label",
+        "progress_status",
+        "remaining",
+        "selected_file",
+        "selected_ids",
+        "selected_kind",
+        "selected_line",
+        "skipped",
+        "status",
+        "status_label",
+        "total",
+    }
+)
+_LIGHT_PROMPT_FIELDS = frozenset({"active"})
 
 
 def estimate_remaining_hunks() -> int:
@@ -246,35 +279,34 @@ def _read_file_review_summary() -> dict | None:
     }
 
 
-def command_status(*, porcelain: bool = False) -> None:
-    """Show session progress and selected state.
+def _session_marker_path(git_dir: Path | None = None) -> Path:
+    """Return the active-session marker path without creating state directories."""
+    state_dir = git_dir / "git-stage-batch" if git_dir is not None else get_state_directory_path()
+    return state_dir / "session" / "abort" / "head.txt"
 
-    Args:
-        porcelain: If True, output JSON for scripting instead of human-readable text
-    """
-    require_git_repository()
 
-    # Only treat an active abort marker as a live session. The state directory
-    # can persist after cleanup because batch metadata is intentionally kept.
-    if not get_abort_head_file_path().exists():
-        if porcelain:
-            print(json.dumps({"session": {"active": False}}))
-        else:
-            print(_("No batch staging session in progress."), file=sys.stderr)
-            print(_("Run 'git-stage-batch start' to begin."), file=sys.stderr)
-        return
+def _git_directory_for_prompt() -> Path | None:
+    """Return the git directory for prompt rendering, or None outside a repo."""
+    try:
+        result = run_git_command(["rev-parse", "--absolute-git-dir"], check=False)
+    except (FileNotFoundError, OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    git_dir = result.stdout.strip()
+    return Path(git_dir) if git_dir else None
 
-    # Gather metrics
+
+def _read_status_summary() -> dict:
+    """Read the complete machine-readable status summary for an active session."""
     iteration = get_iteration_count()
 
-    # Count processed hunks this iteration
     included_content = read_text_file_contents(get_included_hunks_file_path())
     included_count = len([h for h in included_content.splitlines() if h.strip()])
 
     discarded_content = read_text_file_contents(get_discarded_hunks_file_path())
     discarded_count = len([h for h in discarded_content.splitlines() if h.strip()])
 
-    # Parse skipped hunks JSONL
     skipped_hunks = []
     jsonl_path = get_skipped_hunks_jsonl_file_path()
     if jsonl_path.exists():
@@ -288,32 +320,152 @@ def command_status(*, porcelain: bool = False) -> None:
     has_selected, selected_summary = _read_selected_change_summary()
     file_review_summary = _read_file_review_summary()
 
-    # Estimate remaining hunks
     remaining_estimate = estimate_remaining_hunks()
     status_value = "in_progress" if has_selected or remaining_estimate > 0 else "complete"
 
+    return {
+        "session": {
+            "active": True,
+            "iteration": iteration,
+            "status": status_value,
+            "in_progress": status_value == "in_progress",
+        },
+        "selected_change": selected_summary,
+        "file_review": file_review_summary,
+        "progress": {
+            "included": included_count,
+            "skipped": len(skipped_hunks),
+            "discarded": discarded_count,
+            "remaining": remaining_estimate,
+        },
+        "skipped_hunks": skipped_hunks,
+    }
+
+
+def _prompt_field_names(prompt_format: str) -> set[str]:
+    """Return top-level field names used by a status prompt format string."""
+    fields: set[str] = set()
+    try:
+        parsed = Formatter().parse(prompt_format)
+        for _literal_text, field_name, _format_spec, _conversion in parsed:
+            if field_name is None:
+                continue
+            if field_name == "":
+                raise CommandError(_("Status prompt format cannot use positional fields."))
+            field_name = field_name.split(".", 1)[0].split("[", 1)[0]
+            if field_name not in _PROMPT_FIELDS:
+                raise CommandError(
+                    _("Unknown status prompt field '{field}'.").format(field=field_name)
+                )
+            fields.add(field_name)
+    except ValueError as error:
+        raise CommandError(
+            _("Invalid status prompt format: {error}").format(error=str(error))
+        ) from error
+    return fields
+
+
+def _prompt_values(summary: dict | None = None) -> dict:
+    """Return values available to `status --for-prompt` format strings."""
+    if summary is None:
+        return {"active": True}
+
+    session = summary["session"]
+    progress = summary["progress"]
+    selected = summary["selected_change"] or {}
+    file_review = summary["file_review"] or {}
+    progress_status = session["status"]
+    progress_label = _("in progress") if progress_status == "in_progress" else _("complete")
+    processed = progress["included"] + progress["skipped"] + progress["discarded"]
+    total = processed + progress["remaining"]
+    status = "STAGING"
+
+    return {
+        "active": session["active"],
+        "change_type": selected.get("change_type") or "",
+        "discarded": progress["discarded"],
+        "file_review_batch": file_review.get("batch_name") or "",
+        "file_review_fresh": file_review.get("fresh", ""),
+        "file_review_source": file_review.get("source") or "",
+        "included": progress["included"],
+        "in_progress": session["in_progress"],
+        "iteration": session["iteration"],
+        "processed": processed,
+        "progress_label": progress_label,
+        "progress_status": progress_status,
+        "remaining": progress["remaining"],
+        "selected_file": selected.get("file") or "",
+        "selected_ids": format_id_range(selected.get("ids") or []),
+        "selected_kind": selected.get("kind") or "",
+        "selected_line": selected.get("line") or "",
+        "skipped": progress["skipped"],
+        "status": status,
+        "status_label": status,
+        "total": total,
+    }
+
+
+def _render_prompt_status(prompt_format: str, summary: dict | None = None) -> str:
+    """Render a prompt status segment for an active session."""
+    fields = _prompt_field_names(prompt_format)
+    values = _prompt_values(summary if fields - _LIGHT_PROMPT_FIELDS else None)
+    try:
+        return prompt_format.format_map(values)
+    except KeyError as error:
+        raise CommandError(
+            _("Unknown status prompt field '{field}'.").format(field=error.args[0])
+        ) from error
+    except ValueError as error:
+        raise CommandError(
+            _("Invalid status prompt format: {error}").format(error=str(error))
+        ) from error
+
+
+def command_status(*, porcelain: bool = False, prompt_format: str | None = None) -> None:
+    """Show session progress and selected state.
+
+    Args:
+        porcelain: If True, output JSON for scripting instead of human-readable text
+        prompt_format: If set, render this format string only for active sessions
+    """
+    if porcelain and prompt_format is not None:
+        raise CommandError(_("Cannot use --porcelain with --for-prompt."))
+
+    if prompt_format is not None:
+        git_dir = _git_directory_for_prompt()
+        if git_dir is None or not _session_marker_path(git_dir).exists():
+            return
+    else:
+        require_git_repository()
+
+    # Only treat an active abort marker as a live session. The state directory
+    # can persist after cleanup because batch metadata is intentionally kept.
+    if prompt_format is None and not _session_marker_path().exists():
+        if porcelain:
+            print(json.dumps({"session": {"active": False}}))
+        else:
+            print(_("No batch staging session in progress."), file=sys.stderr)
+            print(_("Run 'git-stage-batch start' to begin."), file=sys.stderr)
+        return
+
+    if prompt_format is not None:
+        fields = _prompt_field_names(prompt_format)
+        output = _read_status_summary() if fields - _LIGHT_PROMPT_FIELDS else None
+        print(_render_prompt_status(prompt_format, output), end="")
+        return
+
+    output = _read_status_summary()
+
     if porcelain:
-        # Machine-readable JSON output
-        output = {
-            "session": {
-                "active": True,
-                "iteration": iteration,
-                "status": status_value,
-                "in_progress": status_value == "in_progress",
-            },
-            "selected_change": selected_summary,
-            "file_review": file_review_summary,
-            "progress": {
-                "included": included_count,
-                "skipped": len(skipped_hunks),
-                "discarded": discarded_count,
-                "remaining": remaining_estimate
-            },
-            "skipped_hunks": skipped_hunks
-        }
         print(json.dumps(output, indent=2))
     else:
         # Human-readable progress report
+        iteration = output["session"]["iteration"]
+        status_value = output["session"]["status"]
+        selected_summary = output["selected_change"]
+        file_review_summary = output["file_review"]
+        progress = output["progress"]
+        skipped_hunks = output["skipped_hunks"]
         status_label = _("in progress") if status_value == "in_progress" else _("complete")
         print(_("Session: iteration {iteration} ({status})").format(
             iteration=iteration,
@@ -356,10 +508,10 @@ def command_status(*, porcelain: bool = False) -> None:
             print()
 
         print(_("Progress this iteration:"))
-        print(_("  Included:  {count} hunks").format(count=included_count))
+        print(_("  Included:  {count} hunks").format(count=progress["included"]))
         print(_("  Skipped:   {count} hunks").format(count=len(skipped_hunks)))
-        print(_("  Discarded: {count} hunks").format(count=discarded_count))
-        print(_("  Remaining: ~{count} hunks").format(count=remaining_estimate))
+        print(_("  Discarded: {count} hunks").format(count=progress["discarded"]))
+        print(_("  Remaining: ~{count} hunks").format(count=progress["remaining"]))
 
         if skipped_hunks:
             print()

--- a/tests/cli/test_argument_parser.py
+++ b/tests/cli/test_argument_parser.py
@@ -413,6 +413,25 @@ def test_parse_command_line_status_alias():
     assert callable(args.func)
 
 
+def test_parse_command_line_status_for_prompt():
+    """Test parsing status prompt format."""
+    args = parse_command_line(["status", "--for-prompt", " [{status}]"], quiet=True)
+    assert args is not None
+    assert args.command == "status"
+    assert args.prompt_format == " [{status}]"
+    assert args.porcelain is False
+    assert hasattr(args, "func")
+    assert callable(args.func)
+
+
+def test_parse_command_line_status_for_prompt_default():
+    """Test parsing status prompt mode with the default label."""
+    args = parse_command_line(["status", "--for-prompt"], quiet=True)
+    assert args is not None
+    assert args.command == "status"
+    assert args.prompt_format == "STAGING"
+
+
 def test_parse_command_line_include():
     """Test parsing include command."""
     args = parse_command_line(["include"], quiet=True)

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -54,6 +54,29 @@ def test_main_acquires_session_lock_before_dispatch():
     assert events == ["lock-enter", "dispatch", "lock-exit"]
 
 
+def test_main_skips_session_lock_for_prompt_status():
+    """Prompt status should not create or lock session state before dispatch."""
+    events = []
+
+    def fake_dispatch(args):
+        events.append(("dispatch", args.prompt_format))
+
+    args = Namespace(working_directory=None, prompt_format="STAGING")
+
+    with patch.object(sys, "argv", ["git-stage-batch", "status", "--for-prompt"]):
+        with patch.object(main_module, "parse_command_line", return_value=args):
+            with patch.object(main_module, "should_page_output", return_value=False):
+                with patch.object(
+                    main_module,
+                    "acquire_session_lock",
+                    side_effect=AssertionError("prompt status must not lock"),
+                ):
+                    with patch.object(main_module, "dispatch_args", side_effect=fake_dispatch):
+                        main_module.main()
+
+    assert events == [("dispatch", "STAGING")]
+
+
 def test_main_handles_keyboard_interrupt_without_traceback(capsys):
     """Ctrl-C should exit cleanly without Python's KeyboardInterrupt traceback."""
     args = Namespace(working_directory=None)

--- a/tests/cli/test_pager.py
+++ b/tests/cli/test_pager.py
@@ -6,9 +6,10 @@ import argparse
 from contextlib import contextmanager
 from importlib import import_module
 
-main_module = import_module("git_stage_batch.cli.main")
 from git_stage_batch.cli import pager as pager_module
 from git_stage_batch.cli.pager import should_page_output
+
+main_module = import_module("git_stage_batch.cli.main")
 
 
 def _make_args(**overrides) -> argparse.Namespace:
@@ -41,6 +42,13 @@ def test_should_not_page_porcelain_output(monkeypatch):
     monkeypatch.setattr("sys.stdout.isatty", lambda: True)
 
     assert should_page_output(_make_args(command="status", porcelain=True)) is False
+
+
+def test_should_not_page_prompt_output(monkeypatch):
+    """Prompt output should bypass the pager."""
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+
+    assert should_page_output(_make_args(command="status", prompt_format="STAGING")) is False
 
 
 def test_should_not_page_interactive_mode(monkeypatch):

--- a/tests/commands/test_status.py
+++ b/tests/commands/test_status.py
@@ -25,6 +25,7 @@ from git_stage_batch.commands.start import command_start
 from git_stage_batch.commands.status import command_status
 from git_stage_batch.core.line_selection import format_line_ids
 from git_stage_batch.data.file_review_state import read_last_file_review_state
+from git_stage_batch.exceptions import CommandError
 
 
 @pytest.fixture
@@ -221,6 +222,106 @@ class TestCommandStatus:
         captured = capsys.readouterr()
         output = json.loads(captured.out)
         assert output == {"session": {"active": False}}
+
+    def test_status_for_prompt_no_session_is_silent(self, temp_git_repo, capsys):
+        """Prompt mode should hide the entire configured segment when inactive."""
+        command_status(prompt_format=" [{status}]")
+
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert captured.err == ""
+
+    def test_status_for_prompt_outside_repository_is_silent(self, tmp_path, monkeypatch, capsys):
+        """Prompt mode should be safe to call from non-git directories."""
+        monkeypatch.chdir(tmp_path)
+
+        command_status(prompt_format=" STAGING")
+
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert captured.err == ""
+
+    def test_status_for_prompt_default_static_label(self, temp_git_repo, capsys, monkeypatch):
+        """The default prompt segment should only need an active session marker."""
+        ensure_state_directory_exists()
+        initialize_abort_state()
+
+        def fail_estimate_remaining_hunks():
+            raise AssertionError("full status should not be read")
+
+        monkeypatch.setattr(
+            "git_stage_batch.commands.status.estimate_remaining_hunks",
+            fail_estimate_remaining_hunks,
+        )
+
+        command_status(prompt_format=" STAGING")
+
+        captured = capsys.readouterr()
+        assert captured.out == " STAGING"
+        assert captured.err == ""
+
+    def test_status_for_prompt_formats_status_fields(self, temp_git_repo, capsys):
+        """Prompt mode should render custom fields without a trailing newline."""
+        readme = temp_git_repo / "README.md"
+        readme.write_text("# Test\nNew content\n")
+        command_start()
+        capsys.readouterr()
+
+        command_status(
+            prompt_format=(
+                " [{status}:{status_label}:{progress_status}:"
+                "{progress_label}:{iteration}:{remaining}:{selected_file}]"
+            )
+        )
+
+        captured = capsys.readouterr()
+        assert captured.out.startswith(" [STAGING:STAGING:in_progress:in progress:1:")
+        assert captured.out.endswith(":README.md]")
+        assert "\n" not in captured.out
+        assert captured.err == ""
+
+    def test_status_for_prompt_formats_processed_and_total_counts(self, temp_git_repo, capsys):
+        """Prompt mode should expose processed and total progress counts."""
+        file1 = temp_git_repo / "file1.txt"
+        file1.write_text("original 1\n")
+        file2 = temp_git_repo / "file2.txt"
+        file2.write_text("original 2\n")
+        subprocess.run(["git", "add", "file1.txt", "file2.txt"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add files"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        file1.write_text("modified 1\n")
+        file2.write_text("modified 2\n")
+
+        command_start()
+        command_include()
+        capsys.readouterr()
+
+        command_status(prompt_format=" {processed}/{total}:{included}:{skipped}:{discarded}:{remaining}")
+
+        captured = capsys.readouterr()
+        assert captured.out == " 1/2:1:0:0:1"
+        assert captured.err == ""
+
+    def test_status_for_prompt_reports_complete_session(self, temp_git_repo, capsys):
+        """Prompt status should switch to complete when no work remains."""
+        readme = temp_git_repo / "README.md"
+        readme.write_text("# Test\nNew content\n")
+        command_start()
+        command_skip()
+        capsys.readouterr()
+
+        command_status(prompt_format="[{status}:{progress_status}]")
+
+        captured = capsys.readouterr()
+        assert captured.out == "[STAGING:complete]"
+
+    def test_status_for_prompt_unknown_field_errors_when_active(self, temp_git_repo):
+        """Unknown prompt fields should be reported for active sessions."""
+        ensure_state_directory_exists()
+        initialize_abort_state()
+
+        with pytest.raises(CommandError, match="Unknown status prompt field 'missing'"):
+            command_status(prompt_format="[{missing}]")
 
     def test_status_ignores_persistent_batch_state_without_session(self, temp_git_repo, capsys):
         """Persistent batch metadata alone should not count as an active session."""


### PR DESCRIPTION
The status command reports session progress for terminal output and
machine-readable JSON, but has no way to emit a compact string for shell
prompt integration. Users who want session state in their prompt must
parse JSON or probe git-stage-batch internals directly.

This series adds a --for-prompt flag that emits a single format string
only while a session is active, making shell-prompt integration
straightforward. The implementation, tests, command reference, man page,
and README example land together so the feature is documented from the
start.

The series proceeds in implementation order:

- `status: Add prompt-oriented session output` adds the --for-prompt
  flag, defines the prompt fields (label, progress state, selected
  change, counts), and suppresses output when no session is active.

- `tests: Cover prompt-oriented status output` exercises prompt mode
  parsing, inactive-repository silence, static labels, progress fields,
  lock avoidance, and pager avoidance.

- `docs: Document prompt status formatting` updates the command
  reference and man page with --for-prompt usage and field definitions,
  including the `__git_ps1` integration form.

- `project: Show prompt status in README` adds an overview example
  that nests `status --for-prompt` inside `__git_ps1` so the
  shell-prompt workflow is visible at the project level, not only in
  the command reference.

## Test plan

- [ ] `uv run pytest -n auto` passes
- [ ] `git stage-batch status --for-prompt` prints nothing outside a session
- [ ] `git stage-batch status --for-prompt` prints a prompt string during an active session
- [ ] `__git_ps1` integration example in README renders correctly