### PR TITLE
batch: Preserve target line endings after merge

### DIFF
--- a/src/git_stage_batch/batch/merge.py
+++ b/src/git_stage_batch/batch/merge.py
@@ -44,6 +44,33 @@ class RealizedEntry:
     is_claimed: bool = False  # True if from a claimed source line (presence constraint)
 
 
+def _detect_line_ending(content: bytes) -> bytes | None:
+    """Return the first line ending style found in content."""
+    for index, byte in enumerate(content):
+        if byte == 13:  # \r
+            if index + 1 < len(content) and content[index + 1] == 10:
+                return b"\r\n"
+            return b"\r"
+        if byte == 10:  # \n
+            return b"\n"
+    return None
+
+
+def _restore_line_endings(content: bytes, line_ending: bytes | None) -> bytes:
+    """Restore normalized LF content to the selected line ending style."""
+    if line_ending in (None, b"\n"):
+        return content
+    return content.replace(b"\n", line_ending)
+
+
+def _merge_result_line_ending(
+    primary_content: bytes,
+    fallback_content: bytes,
+) -> bytes | None:
+    """Choose the line ending style for bytes emitted from a merge."""
+    return _detect_line_ending(primary_content) or _detect_line_ending(fallback_content)
+
+
 @dataclass
 class BaselineRegion:
     """A source-space region with baseline restoration content.
@@ -1095,6 +1122,10 @@ def merge_batch(
         MergeError: If constraints cannot be reliably satisfied or structural
                     displacement is detected
     """
+    result_line_ending = _merge_result_line_ending(
+        working_content,
+        batch_source_content,
+    )
     working_normalized = working_content.replace(b'\r\n', b'\n').replace(b'\r', b'\n')
     source_normalized = batch_source_content.replace(b'\r\n', b'\n').replace(b'\r', b'\n')
 
@@ -1122,7 +1153,10 @@ def merge_batch(
         source_to_working_mapping=mapping,
     )
 
-    return b"".join(entry.content for entry in realized_entries)
+    return _restore_line_endings(
+        b"".join(entry.content for entry in realized_entries),
+        result_line_ending,
+    )
 
 
 def discard_batch(
@@ -1175,6 +1209,10 @@ def discard_batch(
     Raises:
         MergeError: If inverse operations cannot be reliably performed
     """
+    result_line_ending = _merge_result_line_ending(
+        working_content,
+        baseline_content or batch_source_content,
+    )
     working_normalized = working_content.replace(b'\r\n', b'\n').replace(b'\r', b'\n')
     source_normalized = batch_source_content.replace(b'\r\n', b'\n').replace(b'\r', b'\n')
     baseline_normalized = baseline_content.replace(b'\r\n', b'\n').replace(b'\r', b'\n')
@@ -1213,7 +1251,10 @@ def discard_batch(
         deletion_claims
     )
 
-    return b"".join(entry.content for entry in realized_entries)
+    return _restore_line_endings(
+        b"".join(entry.content for entry in realized_entries),
+        result_line_ending,
+    )
 
 
 def _build_baseline_correspondence(

--- a/tests/batch/test_constraint_semantics.py
+++ b/tests/batch/test_constraint_semantics.py
@@ -212,13 +212,8 @@ class TestBytesBasedSemantics:
         # "extra" should be removed (deletion after line 2)
         assert b"extra" not in result
 
-    def test_crlf_line_endings_normalized(self):
-        """CRLF line endings are normalized to LF in merge logic.
-
-        The merge logic normalizes all line endings to LF for consistency
-        (git's internal format). CRLF preservation happens at the working
-        tree layer, not in the merge logic.
-        """
+    def test_crlf_line_endings_preserved(self):
+        """CRLF line endings are preserved after normalized matching."""
         batch_source = b"line1\r\nline2-modified\r\nline3\r\n"
         working = b"line1\r\nline2\r\nline3\r\n"
 
@@ -229,10 +224,7 @@ class TestBytesBasedSemantics:
 
         result = merge_batch(batch_source, ownership, working)
 
-        # Line endings should be normalized to LF
-        assert b"\r\n" not in result
-        assert b"\n" in result
-        # Result should have the claimed content
+        assert result == b"line1\r\nline2-modified\r\nline3\r\n"
         assert b"line2-modified" in result
 
 

--- a/tests/batch/test_merge.py
+++ b/tests/batch/test_merge.py
@@ -154,6 +154,16 @@ class TestMergeBatch:
         # Should insert line2 between line1 and line3
         assert result == b"line1\nline2\nline3\nline5\n"
 
+    def test_merge_preserves_target_crlf_endings(self):
+        """Merge should not turn a CRLF target into LF bytes."""
+        source = b"line1\r\nline2\r\nline3\r\n"
+        working = b"line1\r\nline3\r\n"
+        claimed = ["2"]
+
+        result = merge_batch(source, BatchOwnership(claimed, []), working)
+
+        assert result == b"line1\r\nline2\r\nline3\r\n"
+
     def test_merge_preserves_working_tree_extras(self):
         """Test that merge preserves working tree extras."""
         source = b"line1\nline2\nline3\n"
@@ -403,15 +413,14 @@ class TestMergeBatch:
         # Both occurrences should be suppressed
         assert result == b"line1\nline2\nline3\n"
 
-    def test_merge_normalizes_line_endings(self):
-        """Test that merge normalizes line endings."""
+    def test_merge_preserves_existing_crlf_line_endings(self):
+        """Test that merge keeps the target file's line endings."""
         source = b"line1\nline2\nline3\n"  # Already normalized
         working = b"line1\r\nline2\r\nline3\r\n"  # Windows line endings
 
         result = merge_batch(source, BatchOwnership([], []), working)
 
-        # Result should use \n (normalized)
-        assert result == b"line1\nline2\nline3\n"
+        assert result == working
 
     def test_merge_large_file_performance(self):
         """Test merge performance with large files (10k+ lines)."""


### PR DESCRIPTION
Batch merge normalizes line content before matching. It emits bytes from that normalized representation.

Users selecting or applying one line in a CRLF or CR file should not get a whole-file line-ending conversion. Merge output should keep the target file's line-ending style after matching has finished.

This patchset detects the target line-ending style. Merge and discard restore that style when they emit bytes, and the tests expect CRLF targets to stay CRLF in batch merge and constraint-semantics coverage.

Testing:

- `uv run ruff check src/git_stage_batch/batch/merge.py src/git_stage_batch/batch/selection.py src/git_stage_batch/commands/include.py src/git_stage_batch/commands/discard.py src/git_stage_batch/commands/skip.py src/git_stage_batch/commands/reset.py tests/batch/test_constraint_semantics.py tests/batch/test_merge.py tests/commands/test_include.py tests/commands/test_discard.py tests/commands/test_skip.py tests/commands/test_reset.py tests/commands/test_apply_from.py tests/functional/test_include_line_transient_staging.py tests/functional/test_include_file_renames.py`
- `uv run pytest -n auto tests/batch/test_constraint_semantics.py tests/batch/test_merge.py tests/commands/test_include.py tests/commands/test_discard.py tests/commands/test_skip.py tests/commands/test_reset.py tests/commands/test_apply_from.py tests/functional/test_include_line_transient_staging.py tests/functional/test_include_file_renames.py`
- `uv run pytest -n auto tests/batch tests/commands tests/functional`
