### PR TITLE
include: Stage full-file line deletions as removals

### DIFF
--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -86,7 +86,13 @@ from ..staging.operations import (
 )
 from ..utils.command import ExitEvent, OutputEvent, stream_command
 from ..utils.file_io import append_lines_to_file, read_file_bytes, read_text_file_contents
-from ..utils.git import get_git_repository_root_path, require_git_repository, run_git_command, stream_git_command
+from ..utils.git import (
+    get_git_repository_root_path,
+    git_update_index,
+    require_git_repository,
+    run_git_command,
+    stream_git_command,
+)
 from ..utils.journal import log_journal
 from ..utils.paths import (
     ensure_state_directory_exists,
@@ -343,6 +349,27 @@ def _try_build_index_content_via_transient_batch(
         if created_batch and batch_exists(batch_name):
             delete_batch(batch_name)
         _restore_session_batch_sources_file(session_sources_existed, session_sources_content)
+
+
+def _stage_live_line_target_content(file_path: str, target_content: bytes) -> None:
+    """Stage the result of live line-level include."""
+    full_path = get_git_repository_root_path() / file_path
+    if target_content == b"" and not full_path.exists():
+        result = git_update_index(
+            file_path=file_path,
+            force_remove=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            exit_with_error(
+                _("Failed to stage deletion for {file}: {error}").format(
+                    file=file_path,
+                    error=result.stderr,
+                )
+            )
+        return
+
+    update_index_with_blob_content(file_path, target_content)
 
 
 def _transient_include_failure_message(
@@ -790,7 +817,7 @@ def command_include_line(line_id_specification: str, file: str | None = None) ->
                 )
             )
 
-        update_index_with_blob_content(line_changes.path, target_index_content)
+        _stage_live_line_target_content(line_changes.path, target_index_content)
 
         if preserve_selected_state:
             restore_selected_change_state(saved_selected_state)

--- a/tests/commands/test_include.py
+++ b/tests/commands/test_include.py
@@ -446,6 +446,38 @@ class TestCommandIncludeLine:
         assert "remove" not in result.stdout
         assert result.stdout == "keep1\nkeep2\n"
 
+    def test_include_line_stages_full_file_deletion(self, temp_git_repo):
+        """Full-file deletion selections should remove the path from the index."""
+        test_file = temp_git_repo / "test.txt"
+        test_file.write_text("remove1\nremove2\n")
+        subprocess.run(["git", "add", "test.txt"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add file"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        test_file.unlink()
+
+        command_start()
+        fetch_next_change()
+
+        command_include_line("1-2")
+
+        status = subprocess.run(
+            ["git", "status", "--short", "--", "test.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+            text=True,
+        )
+        assert status.stdout == "D  test.txt\n"
+
+        index_entry = subprocess.run(
+            ["git", "ls-files", "-s", "--", "test.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+            text=True,
+        )
+        assert index_entry.stdout == ""
+
     def test_include_line_as_replaces_staged_content_and_masks_hunk(self, temp_git_repo):
         """Test include --line --as stages replacement text and hides the line."""
         test_file = temp_git_repo / "test.txt"


### PR DESCRIPTION
Live include-line staging builds target index bytes through transient
batch ownership and writes those bytes back to the index.

When a user selects every deletion line of a tracked file that no longer
exists in the working tree, the target bytes are empty because the path
should leave the index entirely. Writing those empty bytes as a blob
keeps an empty tracked file staged instead of recording a removal.

This commit series addresses that by routing empty targets for missing
working-tree paths through `git update-index --force-remove`, and adds a
regression test that expects a full-file line selection to stage a path
removal instead of an empty blob.