### PR TITLE
cli: Refresh targeted untracked file scopes

### DIFF
--- a/src/git_stage_batch/cli/argument_parser.py
+++ b/src/git_stage_batch/cli/argument_parser.py
@@ -18,6 +18,7 @@ from .. import __version__
 from ..batch.validation import batch_exists
 from .. import commands
 from ..batch.query import read_batch_metadata
+from ..data.file_tracking import list_untracked_files
 from ..data.hunk_tracking import advance_to_next_change, show_selected_change
 from ..data.undo import undo_checkpoint
 from ..exceptions import CommandError
@@ -391,7 +392,8 @@ def _resolve_live_file_scope(
     if file_patterns is None:
         return FileScope.implicit() if file_arg is None else FileScope.explicit(file_arg)
 
-    resolved_files = resolve_gitignore_style_patterns(list_changed_files(), file_patterns)
+    candidate_files = list(dict.fromkeys([*list_changed_files(), *list_untracked_files()]))
+    resolved_files = resolve_gitignore_style_patterns(candidate_files, file_patterns)
     if not resolved_files:
         raise CommandError(
             _("No changed files matched: {patterns}").format(

--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -76,6 +76,7 @@ from ..data.file_review_state import (
     resolve_live_to_batch_action_scope,
     ReviewSource,
 )
+from ..data.file_tracking import auto_add_untracked_files
 from ..data.line_state import load_line_changes_from_state
 from ..data.batch_sources import create_batch_source_commit, load_session_batch_sources, save_session_batch_sources
 from ..data.session import require_session_started, snapshot_file_if_untracked, snapshot_files_if_untracked
@@ -212,6 +213,7 @@ def _path_contains_only_whitespace(path: Path) -> bool:
 
 def _load_explicit_file_selection(file_path: str):
     """Return the active file-scoped view for an explicit discard target."""
+    auto_add_untracked_files([file_path])
     reuse_selected_file_view = (
         read_selected_change_kind() == SelectedChangeKind.FILE
         and get_selected_change_file_path() == file_path
@@ -469,6 +471,7 @@ def command_discard_file(file: str) -> None:
     else:
         # Explicit path provided
         target_file = file
+    auto_add_untracked_files([target_file])
     with undo_checkpoint(f"discard --file {file}".rstrip()):
         # Load blocklist
         blocklist_path = get_block_list_file_path()
@@ -1305,6 +1308,7 @@ def command_discard_files_to_batch(
 
     if not files:
         return DiscardFilesToBatchResult(discarded_hunks=0, discarded_files=[])
+    auto_add_untracked_files(files)
     if not batch_exists(batch_name):
         create_batch(batch_name, "Auto-created")
 
@@ -1390,6 +1394,7 @@ def _command_discard_file_to_batch(
     advance: bool = True,
 ) -> int:
     """Discard entire file to batch (internal helper for file-scoped operations)."""
+    auto_add_untracked_files([file_path])
 
     log_journal("discard_file_to_batch_start", batch_name=batch_name, file_path=file_path, quiet=quiet)
 

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -83,6 +83,7 @@ from ..data.file_review_state import (
 )
 from ..data.consumed_selections import record_consumed_selection
 from ..data.batch_sources import create_batch_source_commit
+from ..data.file_tracking import auto_add_untracked_files
 from ..data.line_state import load_line_changes_from_state
 from ..data.session import require_session_started, snapshot_file_if_untracked
 from ..data.undo import undo_checkpoint
@@ -643,6 +644,7 @@ def command_include_file(
     else:
         # Explicit path provided
         target_file = file
+    auto_add_untracked_files([target_file])
     with undo_checkpoint(f"include --file {file}".rstrip()):
         # Stream through the remaining unstaged hunks for this file.
         #
@@ -789,6 +791,7 @@ def command_include_file_as(replacement_text: str, file: str | None = None) -> N
             saved_selected_state = selected_state_stack.enter_context(
                 snapshot_selected_change_state()
             )
+        auto_add_untracked_files([target_file])
 
         if preserve_selected_state:
             line_changes = cache_unstaged_file_as_single_hunk(target_file)
@@ -859,6 +862,7 @@ def command_include_line(line_id_specification: str, file: str | None = None) ->
                     exit_with_error(_("No selected hunk. Run 'show' first or specify file path."))
             else:
                 target_file = file
+            auto_add_untracked_files([target_file])
             selected_file_view_targets_file = _selected_file_view_targets(target_file)
             reuse_selected_file_view = _selected_file_view_is_fresh_for(target_file)
             if reuse_selected_file_view:
@@ -1500,6 +1504,7 @@ def _command_include_gitlink_to_batch(
 
 def _command_include_file_to_batch(batch_name: str, file_path: str, *, quiet: bool = False) -> None:
     """Include entire file to batch (internal helper for file-scoped operations)."""
+    auto_add_untracked_files([file_path])
 
     # Auto-create batch if it doesn't exist
     if not batch_exists(batch_name):

--- a/src/git_stage_batch/commands/skip.py
+++ b/src/git_stage_batch/commands/skip.py
@@ -40,6 +40,7 @@ from ..data.file_review_state import (
     refuse_live_action_for_batch_selection,
     resolve_live_line_action_scope,
 )
+from ..data.file_tracking import auto_add_untracked_files
 from ..data.line_state import convert_line_changes_to_serializable_dict, load_line_changes_from_state
 from ..data.session import require_session_started
 from ..data.undo import undo_checkpoint
@@ -194,6 +195,7 @@ def command_skip_file(
     else:
         target_file = file
 
+    auto_add_untracked_files([target_file])
     with undo_checkpoint(f"skip --file {file}".rstrip()):
         # Stream through hunks and skip all from target file.
         blocklist_path = get_block_list_file_path()
@@ -301,6 +303,7 @@ def command_skip_line(line_id_specification: str, file: str | None = None) -> No
                 exit_with_error(_("No selected hunk. Run 'show' first or specify file path."))
         else:
             target_file = file
+        auto_add_untracked_files([target_file])
         from ..data.hunk_tracking import cache_unstaged_file_as_single_hunk
         from ..data.hunk_tracking import render_unstaged_file_as_single_hunk
 

--- a/src/git_stage_batch/data/file_tracking.py
+++ b/src/git_stage_batch/data/file_tracking.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
+
 from ..utils.file_io import append_file_path_to_file, read_file_paths_file
 from ..utils.git import get_git_repository_root_path, run_git_command
 from ..utils.journal import log_journal
@@ -13,45 +15,62 @@ def _is_embedded_git_repository(file_path: str) -> bool:
     return path.is_dir() and (path / ".git").exists()
 
 
-def auto_add_untracked_files() -> None:
+def list_untracked_files(paths: Iterable[str] | None = None) -> list[str]:
+    """Return untracked, non-ignored files, optionally limited to paths."""
+    arguments = ["ls-files", "--others", "--exclude-standard"]
+    if paths is not None:
+        unique_paths = list(dict.fromkeys(paths))
+        if not unique_paths:
+            return []
+        arguments.extend(["--", *unique_paths])
+
+    result = run_git_command(arguments, check=False)
+    if result.returncode != 0:
+        return []
+
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def auto_add_untracked_files(paths: Iterable[str] | None = None) -> None:
     """Automatically run git add -N on untracked files (except blocked ones).
 
     This makes untracked files visible to git diff without staging their
     content, enabling the interactive staging workflow for new files.
     Files matching .gitignore patterns are automatically excluded.
     """
-    # Get list of untracked files
-    result = run_git_command(["ls-files", "--others", "--exclude-standard"], check=False)
-    if result.returncode != 0:
-        return
-
-    untracked_files = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    untracked_files = list_untracked_files(paths)
     if not untracked_files:
         return
 
+    untracked_files = list(dict.fromkeys(untracked_files))
     # Get already auto-added files
     auto_added_path = get_auto_added_files_file_path()
     auto_added_files = set(read_file_paths_file(auto_added_path))
 
-    # Add untracked files that haven't been auto-added yet
+    # Add untracked files even when they were recorded earlier. A user may have
+    # removed the intent-to-add entry with git restore --staged during a session.
     for file_path in untracked_files:
         if _is_embedded_git_repository(file_path):
             log_journal("skip_auto_add_embedded_git_repository", file_path=file_path)
             continue
-        if file_path not in auto_added_files:
-            # Get before state
-            ls_before = run_git_command(["ls-files", "--stage", "--", file_path], check=False).stdout.strip()
 
-            result = run_git_command(["add", "-N", "--", file_path], check=False)
-            if result.returncode == 0:
+        # Get before state
+        ls_before = run_git_command(["ls-files", "--stage", "--", file_path], check=False).stdout.strip()
+
+        result = run_git_command(["add", "-N", "--", file_path], check=False)
+        if result.returncode == 0:
+            already_recorded = file_path in auto_added_files
+            if not already_recorded:
                 append_file_path_to_file(auto_added_path, file_path)
+                auto_added_files.add(file_path)
 
-                # Get after state
-                ls_after = run_git_command(["ls-files", "--stage", "--", file_path], check=False).stdout.strip()
-                log_journal(
-                    "git_add_intent_to_add",
-                    file_path=file_path,
-                    index_before=ls_before,
-                    index_after=ls_after,
-                    returncode=result.returncode
-                )
+            # Get after state
+            ls_after = run_git_command(["ls-files", "--stage", "--", file_path], check=False).stdout.strip()
+            log_journal(
+                "git_add_intent_to_add",
+                file_path=file_path,
+                index_before=ls_before,
+                index_after=ls_after,
+                already_recorded=already_recorded,
+                returncode=result.returncode,
+            )

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -59,6 +59,7 @@ from ..exceptions import CommandError, MergeError, NoMoreHunks, exit_with_error
 from ..i18n import _, ngettext
 from ..output import print_line_level_changes, print_binary_file_change, print_gitlink_change
 from .consumed_selections import read_consumed_file_metadata
+from .file_tracking import auto_add_untracked_files
 from ..utils.file_io import (
     read_file_paths_file,
     read_text_file_line_set,
@@ -1500,6 +1501,7 @@ def _cache_combined_file_line_changes(
 
 def render_file_as_single_hunk(file_path: str) -> Optional[LineLevelChange]:
     """Render all changes for a file as a single hunk without caching state."""
+    auto_add_untracked_files([file_path])
     return _build_combined_file_line_changes(
         file_path,
         parse_unified_diff_streaming(
@@ -1517,6 +1519,7 @@ def render_file_as_single_hunk(file_path: str) -> Optional[LineLevelChange]:
 
 def render_binary_file_change(file_path: str) -> Optional[BinaryFileChange]:
     """Render a binary file change for file-scoped display without caching state."""
+    auto_add_untracked_files([file_path])
     try:
         for item in parse_unified_diff_streaming(
             stream_git_diff(
@@ -1536,6 +1539,7 @@ def render_binary_file_change(file_path: str) -> Optional[BinaryFileChange]:
 
 def render_gitlink_change(file_path: str) -> Optional[GitlinkChange]:
     """Render a gitlink change for file-scoped display without caching state."""
+    auto_add_untracked_files([file_path])
     try:
         for item in parse_unified_diff_streaming(
             stream_git_diff(
@@ -1555,6 +1559,7 @@ def render_gitlink_change(file_path: str) -> Optional[GitlinkChange]:
 
 def render_unstaged_file_as_single_hunk(file_path: str) -> Optional[LineLevelChange]:
     """Render the remaining unstaged changes for a file as a single hunk."""
+    auto_add_untracked_files([file_path])
     return _build_combined_file_line_changes(
         file_path,
         parse_unified_diff_streaming(

--- a/tests/cli/test_argument_parser.py
+++ b/tests/cli/test_argument_parser.py
@@ -177,12 +177,23 @@ def test_resolve_live_file_scope_marks_explicit_scope():
 
 def test_resolve_live_file_scope_keeps_single_pattern_scope_kind(monkeypatch):
     monkeypatch.setattr(argument_parser, "list_changed_files", lambda: ["src/parser.py", "notes.txt"])
+    monkeypatch.setattr(argument_parser, "list_untracked_files", lambda: [])
 
     scope = argument_parser._resolve_live_file_scope(None, ["*.py"])
 
     assert scope.kind is argument_parser.FileScopeKind.PATTERN
     assert scope.files == ("src/parser.py",)
     assert scope.optional_file() == "src/parser.py"
+
+
+def test_resolve_live_file_scope_matches_untracked_pattern_candidates(monkeypatch):
+    monkeypatch.setattr(argument_parser, "list_changed_files", lambda: ["src/parser.py"])
+    monkeypatch.setattr(argument_parser, "list_untracked_files", lambda: ["notes.txt"])
+
+    scope = argument_parser._resolve_live_file_scope(None, ["*.txt"])
+
+    assert scope.kind is argument_parser.FileScopeKind.PATTERN
+    assert scope.files == ("notes.txt",)
 
 
 def test_resolve_batch_file_scope_marks_implicit_scope():

--- a/tests/commands/test_include_file.py
+++ b/tests/commands/test_include_file.py
@@ -118,3 +118,44 @@ class TestCommandIncludeFile:
             text=True,
         )
         assert "file2.txt" in result.stdout
+
+    def test_include_file_refreshes_untracked_path_after_external_unstage(
+        self,
+        temp_git_repo,
+        capsys,
+    ):
+        """Test explicit include can recover a recorded path that became untracked again."""
+        (temp_git_repo / "a.txt").write_text("a\n")
+        (temp_git_repo / "b.txt").write_text("b\n")
+
+        command_start()
+        command_include_file(file="a.txt")
+        command_include_file(file="b.txt")
+        capsys.readouterr()
+
+        subprocess.run(
+            ["git", "restore", "--staged", "b.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add a"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+
+        command_include_file(file="b.txt")
+
+        result = subprocess.run(
+            ["git", "diff", "--cached", "--name-only"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+            text=True,
+        )
+        assert result.stdout.strip() == "b.txt"
+
+        captured = capsys.readouterr()
+        assert "No hunks staged from b.txt" not in captured.err

--- a/tests/data/test_file_tracking.py
+++ b/tests/data/test_file_tracking.py
@@ -123,6 +123,56 @@ class TestAutoAddUntrackedFiles:
         auto_added = read_file_paths_file(get_auto_added_files_file_path())
         assert auto_added.count("file.txt") == 1
 
+    def test_auto_add_accepts_target_paths(self, temp_git_repo):
+        """Test auto-adding only the requested untracked paths."""
+        ensure_state_directory_exists()
+
+        (temp_git_repo / "target.txt").write_text("target\n")
+        (temp_git_repo / "other.txt").write_text("other\n")
+
+        auto_add_untracked_files(["target.txt"])
+
+        auto_added = read_file_paths_file(get_auto_added_files_file_path())
+        assert auto_added == ["target.txt"]
+
+        result = subprocess.run(
+            ["git", "ls-files", "--", "target.txt", "other.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+            text=True,
+        )
+        assert "target.txt" in result.stdout
+        assert "other.txt" not in result.stdout
+
+    def test_auto_add_reruns_for_recorded_untracked_path(self, temp_git_repo):
+        """Test re-adding a recorded path after its intent-to-add entry is removed."""
+        ensure_state_directory_exists()
+
+        (temp_git_repo / "file.txt").write_text("content\n")
+        auto_add_untracked_files()
+
+        subprocess.run(
+            ["git", "restore", "--staged", "file.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+
+        auto_add_untracked_files(["file.txt"])
+
+        auto_added = read_file_paths_file(get_auto_added_files_file_path())
+        assert auto_added.count("file.txt") == 1
+
+        result = subprocess.run(
+            ["git", "ls-files", "--", "file.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+            text=True,
+        )
+        assert result.stdout.strip() == "file.txt"
+
     def test_auto_add_handles_no_untracked_files(self, temp_git_repo):
         """Test auto_add when there are no untracked files."""
         ensure_state_directory_exists()


### PR DESCRIPTION
The program makes untracked files visible to diff-based review by adding
intent-to-add entries during `start` and `again`. File-scoped commands and
live `--files` scopes then read `git diff` to find the hunks that should be
shown, staged, skipped, discarded, or moved to a batch.

If a recorded path loses its intent-to-add entry during an active session,
that file becomes untracked again and drops out of `git diff`. Explicit file
operations can then report no hunks for a file that still exists in the
worktree, and pattern-scoped live commands cannot match an untracked path
until a broad refresh runs.

This pull request addresses that by letting `auto_add_untracked_files()`
accept an optional path scope, reapplying intent-to-add for recorded paths
without duplicating state, adding untracked candidates to live pattern
resolution, and refreshing resolved file targets before include, skip,
discard, and shared render flows read `git diff`.

Verification:

- `ruff check src/git_stage_batch/data/file_tracking.py src/git_stage_batch/cli/argument_parser.py src/git_stage_batch/data/hunk_tracking.py src/git_stage_batch/commands/include.py src/git_stage_batch/commands/skip.py src/git_stage_batch/commands/discard.py tests/data/test_file_tracking.py tests/commands/test_include_file.py tests/cli/test_argument_parser.py`
- `pytest tests/data/test_file_tracking.py tests/commands/test_include_file.py tests/cli/test_argument_parser.py`
- `pytest tests/commands/test_skip_file.py tests/commands/test_discard_file.py tests/commands/test_discard_file_to_batch.py tests/commands/test_show.py tests/commands/test_file_scoped_operations.py tests/data/test_hunk_tracking.py`
