### PR TITLE
core: Scope unified diff parser lifetime

### DIFF
--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -35,8 +35,8 @@ from ..batch.source_refresh import _refresh_selected_lines_against_source_lines
 from ..batch.validation import batch_exists
 from ..batch.submodule_pointer import discard_submodule_pointer_from_batch
 from ..core.diff_parser import (
+    acquire_unified_diff,
     build_line_changes_from_patch_lines,
-    parse_unified_diff_streaming,
 )
 from ..core.hashing import (
     compute_binary_file_hash,
@@ -497,26 +497,27 @@ def command_discard_file(file: str) -> None:
         # Stream through hunks and collect hashes from target file BEFORE removing it
         # (git rm -f will stage the deletion, making hunks disappear from git diff)
         hashes_to_block = []
-        for patch in parse_unified_diff_streaming(
+        with acquire_unified_diff(
             stream_git_diff(context_lines=get_context_lines())
-        ):
-            if isinstance(patch, BinaryFileChange):
-                file_path = patch.new_path if patch.new_path != "/dev/null" else patch.old_path
-                if file_path != target_file:
+        ) as patches:
+            for patch in patches:
+                if isinstance(patch, BinaryFileChange):
+                    file_path = patch.new_path if patch.new_path != "/dev/null" else patch.old_path
+                    if file_path != target_file:
+                        continue
+
+                    patch_hash = compute_binary_file_hash(patch)
+                    if patch_hash not in blocked_hashes:
+                        hashes_to_block.append(patch_hash)
                     continue
 
-                patch_hash = compute_binary_file_hash(patch)
+                if patch.new_path != target_file:
+                    continue
+
+                patch_hash = compute_stable_hunk_hash_from_lines(patch.lines)
+
                 if patch_hash not in blocked_hashes:
                     hashes_to_block.append(patch_hash)
-                continue
-
-            if patch.new_path != target_file:
-                continue
-
-            patch_hash = compute_stable_hunk_hash_from_lines(patch.lines)
-
-            if patch_hash not in blocked_hashes:
-                hashes_to_block.append(patch_hash)
 
         # Remove the file from working tree
         result = run_git_command(["rm", "-f", target_file], check=False)
@@ -1170,49 +1171,50 @@ def _collect_text_file_discard_inputs(
     inputs_by_file: dict[str, _TextFileDiscardInput] = {}
     files_with_text_patches: set[str] = set()
 
-    for patch in parse_unified_diff_streaming(
+    with acquire_unified_diff(
         stream_git_diff(
             base="HEAD",
             context_lines=get_context_lines(),
             paths=files,
         )
-    ):
-        if isinstance(patch, GitlinkChange):
-            exit_with_error(_("Discarding submodule pointer changes to a batch is not supported yet."))
+    ) as patches:
+        for patch in patches:
+            if isinstance(patch, GitlinkChange):
+                exit_with_error(_("Discarding submodule pointer changes to a batch is not supported yet."))
 
-        if isinstance(patch, BinaryFileChange):
-            continue
+            if isinstance(patch, BinaryFileChange):
+                continue
 
-        file_path = patch.new_path if patch.new_path != "/dev/null" else patch.old_path
-        files_with_text_patches.add(file_path)
+            file_path = patch.new_path if patch.new_path != "/dev/null" else patch.old_path
+            files_with_text_patches.add(file_path)
 
-        patch_hash = compute_stable_hunk_hash_from_lines(patch.lines)
-        if patch_hash in blocked_hashes:
-            continue
+            patch_hash = compute_stable_hunk_hash_from_lines(patch.lines)
+            if patch_hash in blocked_hashes:
+                continue
 
-        hunk_lines = build_line_changes_from_patch_lines(
-            patch.lines,
-            annotator=annotate_with_batch_source,
-        )
-        discard_input = inputs_by_file.get(file_path)
-        if discard_input is None:
-            discard_input = _TextFileDiscardInput(
-                file_path=file_path,
-                file_mode=_detect_file_mode_from_root(repo_root, file_path),
-                all_lines_to_batch=[],
-                patches_to_discard=[],
+            hunk_lines = build_line_changes_from_patch_lines(
+                patch.lines,
+                annotator=annotate_with_batch_source,
             )
-            inputs_by_file[file_path] = discard_input
-        discard_input.all_lines_to_batch.extend(hunk_lines.lines)
-        discard_input.patches_to_discard.append(
-            _PreparedPatchDiscard(
-                patch_lines=patch_stack.enter_context(
-                    EditorBuffer.from_chunks(patch.lines)
-                ),
-                patch_hash=patch_hash,
+            discard_input = inputs_by_file.get(file_path)
+            if discard_input is None:
+                discard_input = _TextFileDiscardInput(
+                    file_path=file_path,
+                    file_mode=_detect_file_mode_from_root(repo_root, file_path),
+                    all_lines_to_batch=[],
+                    patches_to_discard=[],
+                )
+                inputs_by_file[file_path] = discard_input
+            discard_input.all_lines_to_batch.extend(hunk_lines.lines)
+            discard_input.patches_to_discard.append(
+                _PreparedPatchDiscard(
+                    patch_lines=patch_stack.enter_context(
+                        EditorBuffer.from_chunks(patch.lines)
+                    ),
+                    patch_hash=patch_hash,
+                )
             )
-        )
-        blocked_hashes.add(patch_hash)
+            blocked_hashes.add(patch_hash)
 
     return _CollectedTextFileDiscards(
         inputs_by_file=inputs_by_file,
@@ -1415,151 +1417,156 @@ def _command_discard_file_to_batch(
     # Detect file mode
     file_mode = _detect_file_mode(file_path)
 
-    # Collect ALL hunks from this file (live working tree state)
-    all_lines_to_batch = []
-    patches_to_discard = []
+    with ExitStack() as patch_stack:
+        # Collect ALL hunks from this file (live working tree state)
+        all_lines_to_batch = []
+        patches_to_discard = []
 
-    for patch in parse_unified_diff_streaming(
-        stream_git_diff(
-            base="HEAD",
-            context_lines=get_context_lines(),
-            paths=[file_path],
-        )
-    ):
-        if isinstance(patch, GitlinkChange):
-            exit_with_error(_("Discarding submodule pointer changes to a batch is not supported yet."))
+        with acquire_unified_diff(
+            stream_git_diff(
+                base="HEAD",
+                context_lines=get_context_lines(),
+                paths=[file_path],
+            )
+        ) as patches:
+            for patch in patches:
+                if isinstance(patch, GitlinkChange):
+                    exit_with_error(_("Discarding submodule pointer changes to a batch is not supported yet."))
 
-        patch_hash = compute_stable_hunk_hash_from_lines(patch.lines)
+                patch_hash = compute_stable_hunk_hash_from_lines(patch.lines)
 
-        if patch_hash in blocked_hashes:
-            continue
+                if patch_hash in blocked_hashes:
+                    continue
 
-        # Parse hunk to get lines
-        hunk_lines = build_line_changes_from_patch_lines(
-            patch.lines,
-            annotator=annotate_with_batch_source,
-        )
-        all_lines_to_batch.extend(hunk_lines.lines)
-        patches_to_discard.append((patch.lines, patch_hash))
+                # Parse hunk to get lines
+                hunk_lines = build_line_changes_from_patch_lines(
+                    patch.lines,
+                    annotator=annotate_with_batch_source,
+                )
+                all_lines_to_batch.extend(hunk_lines.lines)
+                patches_to_discard.append((
+                    patch_stack.enter_context(EditorBuffer.from_chunks(patch.lines)),
+                    patch_hash,
+                ))
 
-    if not all_lines_to_batch:
-        # Special case: empty text lifecycle changes have no hunk body.
-        repo_root = get_git_repository_root_path()
-        full_path = repo_root / file_path
-        lifecycle_change_type = detect_empty_text_lifecycle_change(file_path)
-        if lifecycle_change_type is not None:
+        if not all_lines_to_batch:
+            # Special case: empty text lifecycle changes have no hunk body.
+            repo_root = get_git_repository_root_path()
+            full_path = repo_root / file_path
+            lifecycle_change_type = detect_empty_text_lifecycle_change(file_path)
+            if lifecycle_change_type is not None:
+                snapshot_file_if_untracked(file_path)
+                add_file_to_batch(
+                    batch_name,
+                    file_path,
+                    BatchOwnership([], []),
+                    file_mode,
+                    change_type=lifecycle_change_type,
+                )
+
+                if lifecycle_change_type == TextFileChangeType.ADDED:
+                    # Delete from working tree
+                    full_path.unlink()
+
+                    # Remove from index if present (from intent-to-add)
+                    run_git_command(["rm", "--cached", "--quiet", "--", file_path], check=False)
+                else:
+                    run_git_command(["checkout", "HEAD", "--", file_path], check=False)
+
+                if not quiet:
+                    print(_("Discarded file '{file}' to batch '{batch}'").format(file=file_path, batch=batch_name), file=sys.stderr)
+
+                log_journal("discard_file_to_batch_end", batch_name=batch_name, file_path=file_path)
+                return 1
+
+            if not quiet:
+                print(_("No changes in file '{file}' to discard.").format(file=file_path), file=sys.stderr)
+            return 0
+
+        # Prepare batch ownership update (handles stale source, translation, merge)
+
+        metadata = read_batch_metadata(batch_name)
+        file_metadata = metadata.get("files", {}).get(file_path)
+
+        with ExitStack() as ownership_stack:
+            try:
+                update = ownership_stack.enter_context(
+                    acquire_batch_ownership_update_for_selection(
+                        batch_name=batch_name,
+                        file_path=file_path,
+                        file_metadata=file_metadata,
+                        selected_lines=all_lines_to_batch,
+                    )
+                )
+            except ValueError as e:
+                exit_with_error(
+                    _("Cannot discard file to batch: batch source is stale and remapping failed.\n"
+                      "File: {file}\n"
+                      "Batch: {batch}\n"
+                      "Error: {error}").format(file=file_path, batch=batch_name, error=str(e))
+                )
+
+            # Snapshot file before modifying
             snapshot_file_if_untracked(file_path)
+
+            # Save to batch
             add_file_to_batch(
                 batch_name,
                 file_path,
-                BatchOwnership([], []),
+                update.ownership_after,
                 file_mode,
-                change_type=lifecycle_change_type,
             )
 
-            if lifecycle_change_type == TextFileChangeType.ADDED:
-                # Delete from working tree
-                full_path.unlink()
+        # Record hunks as discarded for progress tracking
+        for _patch_lines, patch_hash in patches_to_discard:
+            record_hunk_discarded(patch_hash)
 
-                # Remove from index if present (from intent-to-add)
-                run_git_command(["rm", "--cached", "--quiet", "--", file_path], check=False)
-            else:
-                run_git_command(["checkout", "HEAD", "--", file_path], check=False)
+        # Discard from working tree (reverse patches)
+        for patch_lines_item, patch_hash in patches_to_discard:
+            log_journal(
+                "discard_file_to_batch_before_git_apply",
+                batch_name=batch_name,
+                patch_hash=patch_hash,
+                file_path=file_path,
+                patch_line_count=len(patch_lines_item),
+            )
 
-            if not quiet:
-                print(_("Discarded file '{file}' to batch '{batch}'").format(file=file_path, batch=batch_name), file=sys.stderr)
+            exit_code = 0
+            stderr_chunks = []
 
-            log_journal("discard_file_to_batch_end", batch_name=batch_name, file_path=file_path)
-            return 1
+            for event in stream_command(
+                ["git", "apply", "--reverse", "--unidiff-zero"],
+                stdin_chunks=patch_lines_item,
+            ):
+                if isinstance(event, ExitEvent):
+                    exit_code = event.exit_code
+                elif isinstance(event, OutputEvent) and event.fd == 2:  # stderr
+                    stderr_chunks.append(event.data)
+
+            if exit_code != 0:
+                stderr_text = b"".join(stderr_chunks).decode('utf-8', errors='replace')
+                exit_with_error(_("Failed to discard changes from file: {err}").format(err=stderr_text))
+
+            log_journal("discard_file_to_batch_after_git_apply", batch_name=batch_name, patch_hash=patch_hash, exit_code=exit_code)
+
+        # If file was deleted from working tree, remove from index too
+        repo_root = get_git_repository_root_path()
+        full_path = repo_root / file_path
+        if not full_path.exists():
+            # File was deleted by git apply --reverse, remove from index
+            run_git_command(["rm", "--cached", "--quiet", "--", file_path], check=False)
 
         if not quiet:
-            print(_("No changes in file '{file}' to discard.").format(file=file_path), file=sys.stderr)
-        return 0
+            print(_("Discarded file '{file}' to batch '{batch}'").format(file=file_path, batch=batch_name), file=sys.stderr)
 
-    # Prepare batch ownership update (handles stale source, translation, merge)
+        log_journal("discard_file_to_batch_end", batch_name=batch_name, file_path=file_path)
 
-    metadata = read_batch_metadata(batch_name)
-    file_metadata = metadata.get("files", {}).get(file_path)
-
-    with ExitStack() as ownership_stack:
-        try:
-            update = ownership_stack.enter_context(
-                acquire_batch_ownership_update_for_selection(
-                    batch_name=batch_name,
-                    file_path=file_path,
-                    file_metadata=file_metadata,
-                    selected_lines=all_lines_to_batch,
-                )
-            )
-        except ValueError as e:
-            exit_with_error(
-                _("Cannot discard file to batch: batch source is stale and remapping failed.\n"
-                  "File: {file}\n"
-                  "Batch: {batch}\n"
-                  "Error: {error}").format(file=file_path, batch=batch_name, error=str(e))
-            )
-
-        # Snapshot file before modifying
-        snapshot_file_if_untracked(file_path)
-
-        # Save to batch
-        add_file_to_batch(
-            batch_name,
-            file_path,
-            update.ownership_after,
-            file_mode,
-        )
-
-    # Record hunks as discarded for progress tracking
-    for _patch_lines, patch_hash in patches_to_discard:
-        record_hunk_discarded(patch_hash)
-
-    # Discard from working tree (reverse patches)
-    for patch_lines_item, patch_hash in patches_to_discard:
-        log_journal(
-            "discard_file_to_batch_before_git_apply",
-            batch_name=batch_name,
-            patch_hash=patch_hash,
-            file_path=file_path,
-            patch_line_count=len(patch_lines_item),
-        )
-
-        exit_code = 0
-        stderr_chunks = []
-
-        for event in stream_command(
-            ["git", "apply", "--reverse", "--unidiff-zero"],
-            stdin_chunks=patch_lines_item,
-        ):
-            if isinstance(event, ExitEvent):
-                exit_code = event.exit_code
-            elif isinstance(event, OutputEvent) and event.fd == 2:  # stderr
-                stderr_chunks.append(event.data)
-
-        if exit_code != 0:
-            stderr_text = b"".join(stderr_chunks).decode('utf-8', errors='replace')
-            exit_with_error(_("Failed to discard changes from file: {err}").format(err=stderr_text))
-
-        log_journal("discard_file_to_batch_after_git_apply", batch_name=batch_name, patch_hash=patch_hash, exit_code=exit_code)
-
-    # If file was deleted from working tree, remove from index too
-    repo_root = get_git_repository_root_path()
-    full_path = repo_root / file_path
-    if not full_path.exists():
-        # File was deleted by git apply --reverse, remove from index
-        run_git_command(["rm", "--cached", "--quiet", "--", file_path], check=False)
-
-    if not quiet:
-        print(_("Discarded file '{file}' to batch '{batch}'").format(file=file_path, batch=batch_name), file=sys.stderr)
-
-    log_journal("discard_file_to_batch_end", batch_name=batch_name, file_path=file_path)
-
-    # Show next hunk
-    if quiet and advance:
-        advance_to_next_change()
-    elif not quiet:
-        advance_to_and_show_next_change()
-    return len(patches_to_discard)
+        # Show next hunk
+        if quiet and advance:
+            advance_to_next_change()
+        elif not quiet:
+            advance_to_and_show_next_change()
+        return len(patches_to_discard)
 
 
 def _command_discard_file_lines_to_batch(batch_name: str, file_path: str, line_id_specification: str, *, quiet: bool = False) -> int:
@@ -1802,161 +1809,166 @@ def _command_discard_text_hunk_to_batch(
 
     file_mode = _detect_file_mode(file_path)
 
-    # Collect all lines to batch (either selected hunk or all hunks from file)
-    all_lines_to_batch = []
-    patches_to_discard: list[tuple[Sequence[bytes], str]] = []
+    with ExitStack() as patch_stack:
+        # Collect all lines to batch (either selected hunk or all hunks from file)
+        all_lines_to_batch = []
+        patches_to_discard: list[tuple[Sequence[bytes], str]] = []
 
-    if file_only:
-        # Collect ALL hunks from this file
-        for patch in parse_unified_diff_streaming(
-            stream_git_diff(context_lines=get_context_lines())
-        ):
-            if isinstance(patch, GitlinkChange):
-                exit_with_error(_("Discarding submodule pointer changes to a batch is not supported yet."))
+        if file_only:
+            # Collect ALL hunks from this file
+            with acquire_unified_diff(
+                stream_git_diff(context_lines=get_context_lines())
+            ) as patches:
+                for patch in patches:
+                    if isinstance(patch, GitlinkChange):
+                        exit_with_error(_("Discarding submodule pointer changes to a batch is not supported yet."))
 
-            if patch.new_path != file_path:
-                continue
+                    if patch.new_path != file_path:
+                        continue
 
-            patch_hash = compute_stable_hunk_hash_from_lines(patch.lines)
+                    patch_hash = compute_stable_hunk_hash_from_lines(patch.lines)
 
-            if patch_hash in blocked_hashes:
-                continue
+                    if patch_hash in blocked_hashes:
+                        continue
 
-            # Parse hunk to get lines
-            hunk_lines = build_line_changes_from_patch_lines(
-                patch.lines,
-                annotator=annotate_with_batch_source,
-            )
-            all_lines_to_batch.extend(hunk_lines.lines)
-            patches_to_discard.append((patch.lines, patch_hash))
-    else:
-        # Just selected hunk (already loaded above)
-        all_lines_to_batch = line_changes.lines
-        patches_to_discard = [(selected_patch_lines, selected_patch_hash)]
+                    # Parse hunk to get lines
+                    hunk_lines = build_line_changes_from_patch_lines(
+                        patch.lines,
+                        annotator=annotate_with_batch_source,
+                    )
+                    all_lines_to_batch.extend(hunk_lines.lines)
+                    patches_to_discard.append((
+                        patch_stack.enter_context(EditorBuffer.from_chunks(patch.lines)),
+                        patch_hash,
+                    ))
+        else:
+            # Just selected hunk (already loaded above)
+            all_lines_to_batch = line_changes.lines
+            patches_to_discard = [(selected_patch_lines, selected_patch_hash)]
 
-    # Prepare batch ownership update (handles stale source, translation, merge)
+        # Prepare batch ownership update (handles stale source, translation, merge)
 
-    metadata = read_batch_metadata(batch_name)
-    file_metadata = metadata.get("files", {}).get(file_path)
+        metadata = read_batch_metadata(batch_name)
+        file_metadata = metadata.get("files", {}).get(file_path)
 
-    with ExitStack() as ownership_stack:
-        try:
-            update = ownership_stack.enter_context(
-                acquire_batch_ownership_update_for_selection(
-                    batch_name=batch_name,
-                    file_path=file_path,
-                    file_metadata=file_metadata,
-                    selected_lines=all_lines_to_batch,
+        with ExitStack() as ownership_stack:
+            try:
+                update = ownership_stack.enter_context(
+                    acquire_batch_ownership_update_for_selection(
+                        batch_name=batch_name,
+                        file_path=file_path,
+                        file_metadata=file_metadata,
+                        selected_lines=all_lines_to_batch,
+                    )
                 )
-            )
-        except ValueError as e:
-            # Remapping failed - fail loudly
-            exit_with_error(
-                _("Cannot discard to batch: batch source is stale and remapping failed.\n"
-                  "File: {file}\n"
-                  "Batch: {batch}\n"
-                  "Error: {error}").format(file=file_path, batch=batch_name, error=str(e))
-            )
+            except ValueError as e:
+                # Remapping failed - fail loudly
+                exit_with_error(
+                    _("Cannot discard to batch: batch source is stale and remapping failed.\n"
+                      "File: {file}\n"
+                      "Batch: {batch}\n"
+                      "Error: {error}").format(file=file_path, batch=batch_name, error=str(e))
+                )
 
-        # add_file_to_batch creates the batch source commit from this snapshot.
-        snapshot_file_if_untracked(file_path)
+            # add_file_to_batch creates the batch source commit from this snapshot.
+            snapshot_file_if_untracked(file_path)
 
-        log_journal("discard_hunk_to_batch_before_add", batch_name=batch_name, file_path=file_path, num_patches=len(patches_to_discard))
+            log_journal("discard_hunk_to_batch_before_add", batch_name=batch_name, file_path=file_path, num_patches=len(patches_to_discard))
 
-        # Save to batch using batch source model (once, with all accumulated data)
-        add_file_to_batch(batch_name, file_path, update.ownership_after, file_mode)
+            # Save to batch using batch source model (once, with all accumulated data)
+            add_file_to_batch(batch_name, file_path, update.ownership_after, file_mode)
 
-    log_journal("discard_hunk_to_batch_after_add", batch_name=batch_name, file_path=file_path)
+        log_journal("discard_hunk_to_batch_after_add", batch_name=batch_name, file_path=file_path)
 
-    # Check if this is a new file (before applying patches)
-    is_new_file = any(
-        _patch_lines_contain_line(patch_lines_item, b"--- /dev/null")
-        for patch_lines_item, _ in patches_to_discard
-    )
-
-    # Apply reverse patches to discard from working tree
-    for patch_lines_item, patch_hash in patches_to_discard:
-        # Check if this is an empty file patch (@@ -0,0 +0,0 @@)
-        # Empty file patches are synthetic and cannot be reversed with git apply
-        is_empty_file_patch = _patch_lines_contain_line(
-            patch_lines_item,
-            b"@@ -0,0 +0,0 @@",
+        # Check if this is a new file (before applying patches)
+        is_new_file = any(
+            _patch_lines_contain_line(patch_lines_item, b"--- /dev/null")
+            for patch_lines_item, _ in patches_to_discard
         )
 
-        if not is_empty_file_patch:
-            log_journal(
-                "discard_hunk_to_batch_before_git_apply",
-                batch_name=batch_name,
-                patch_hash=patch_hash,
-                file_path=file_path,
-                patch_line_count=len(patch_lines_item),
+        # Apply reverse patches to discard from working tree
+        for patch_lines_item, patch_hash in patches_to_discard:
+            # Check if this is an empty file patch (@@ -0,0 +0,0 @@)
+            # Empty file patches are synthetic and cannot be reversed with git apply
+            is_empty_file_patch = _patch_lines_contain_line(
+                patch_lines_item,
+                b"@@ -0,0 +0,0 @@",
             )
 
-            # Use stream_command to apply reverse patch
-            stderr_chunks = []
-            exit_code = 0
+            if not is_empty_file_patch:
+                log_journal(
+                    "discard_hunk_to_batch_before_git_apply",
+                    batch_name=batch_name,
+                    patch_hash=patch_hash,
+                    file_path=file_path,
+                    patch_line_count=len(patch_lines_item),
+                )
 
-            for event in stream_command(
-                ["git", "apply", "--reverse", "--unidiff-zero"],
-                patch_lines_item,
-            ):
-                if isinstance(event, ExitEvent):
-                    exit_code = event.exit_code
-                elif isinstance(event, OutputEvent):
-                    if event.fd == 2:  # stderr
-                        stderr_chunks.append(event.data)
+                # Use stream_command to apply reverse patch
+                stderr_chunks = []
+                exit_code = 0
 
-            stderr_text = b"".join(stderr_chunks).decode('utf-8', errors='replace') if stderr_chunks else ""
-            log_journal("discard_hunk_to_batch_after_git_apply", batch_name=batch_name, patch_hash=patch_hash, exit_code=exit_code, stderr_len=len(stderr_text))
+                for event in stream_command(
+                    ["git", "apply", "--reverse", "--unidiff-zero"],
+                    patch_lines_item,
+                ):
+                    if isinstance(event, ExitEvent):
+                        exit_code = event.exit_code
+                    elif isinstance(event, OutputEvent):
+                        if event.fd == 2:  # stderr
+                            stderr_chunks.append(event.data)
 
-            if exit_code != 0:
-                log_journal("discard_hunk_to_batch_git_apply_failed", batch_name=batch_name, patch_hash=patch_hash, exit_code=exit_code, stderr=stderr_text)
-                exit_with_error(_("Failed to apply reverse patch: {error}").format(error=stderr_text))
-        else:
-            log_journal("discard_hunk_to_batch_skipping_empty_patch", batch_name=batch_name, patch_hash=patch_hash)
-        # else: skip reverse for empty files - nothing to reverse, cleanup code below handles file removal
+                stderr_text = b"".join(stderr_chunks).decode('utf-8', errors='replace') if stderr_chunks else ""
+                log_journal("discard_hunk_to_batch_after_git_apply", batch_name=batch_name, patch_hash=patch_hash, exit_code=exit_code, stderr_len=len(stderr_text))
 
-        # Mark this hunk as processed
-        append_lines_to_file(blocklist_path, [patch_hash])
+                if exit_code != 0:
+                    log_journal("discard_hunk_to_batch_git_apply_failed", batch_name=batch_name, patch_hash=patch_hash, exit_code=exit_code, stderr=stderr_text)
+                    exit_with_error(_("Failed to apply reverse patch: {error}").format(error=stderr_text))
+            else:
+                log_journal("discard_hunk_to_batch_skipping_empty_patch", batch_name=batch_name, patch_hash=patch_hash)
+            # else: skip reverse for empty files - nothing to reverse, cleanup code below handles file removal
 
-        # Record hunk as discarded for progress tracking
-        record_hunk_discarded(patch_hash)
+            # Mark this hunk as processed
+            append_lines_to_file(blocklist_path, [patch_hash])
 
-    # Clean up file and index after discarding to batch
-    # Only remove file if it's actually meant to be gone:
-    # - New file that's now empty after reversal
-    # - File deleted in diff (doesn't exist in working tree after reversal)
-    if is_new_file or file_only:
-        absolute_path = get_git_repository_root_path() / file_path
+            # Record hunk as discarded for progress tracking
+            record_hunk_discarded(patch_hash)
 
-        # Check if file still exists after git apply --reverse
-        if not absolute_path.exists():
-            # File was deleted by reverse patches (was a file deletion diff)
-            # Remove from index to complete the deletion
-            run_git_command(["rm", "--cached", "--quiet", file_path], check=False)
-        elif is_new_file:
-            # New file: only remove if it's empty after reverse patches
-            if _path_contains_only_whitespace(absolute_path):
-                absolute_path.unlink()
+        # Clean up file and index after discarding to batch
+        # Only remove file if it's actually meant to be gone:
+        # - New file that's now empty after reversal
+        # - File deleted in diff (doesn't exist in working tree after reversal)
+        if is_new_file or file_only:
+            absolute_path = get_git_repository_root_path() / file_path
+
+            # Check if file still exists after git apply --reverse
+            if not absolute_path.exists():
+                # File was deleted by reverse patches (was a file deletion diff)
+                # Remove from index to complete the deletion
                 run_git_command(["rm", "--cached", "--quiet", file_path], check=False)
-        # else: file still exists with content (reverted to HEAD state), leave it alone
+            elif is_new_file:
+                # New file: only remove if it's empty after reverse patches
+                if _path_contains_only_whitespace(absolute_path):
+                    absolute_path.unlink()
+                    run_git_command(["rm", "--cached", "--quiet", file_path], check=False)
+            # else: file still exists with content (reverted to HEAD state), leave it alone
 
-    log_journal("discard_hunk_to_batch_success", batch_name=batch_name, file_path=file_path, num_patches=len(patches_to_discard))
+        log_journal("discard_hunk_to_batch_success", batch_name=batch_name, file_path=file_path, num_patches=len(patches_to_discard))
 
-    # Print success message
-    if not quiet:
-        if file_only:
-            msg = ngettext(
-                "✓ {count} hunk from {file} saved to batch '{name}' and discarded",
-                "✓ {count} hunks from {file} saved to batch '{name}' and discarded",
-                len(patches_to_discard)
-            ).format(count=len(patches_to_discard), file=file_path, name=batch_name)
-            print(msg, file=sys.stderr)
+        # Print success message
+        if not quiet:
+            if file_only:
+                msg = ngettext(
+                    "✓ {count} hunk from {file} saved to batch '{name}' and discarded",
+                    "✓ {count} hunks from {file} saved to batch '{name}' and discarded",
+                    len(patches_to_discard)
+                ).format(count=len(patches_to_discard), file=file_path, name=batch_name)
+                print(msg, file=sys.stderr)
+            else:
+                print(_("✓ Hunk saved to batch '{name}' and discarded from working tree").format(name=batch_name), file=sys.stderr)
+
+        if quiet:
+            advance_to_next_change()
         else:
-            print(_("✓ Hunk saved to batch '{name}' and discarded from working tree").format(name=batch_name), file=sys.stderr)
-
-    if quiet:
-        advance_to_next_change()
-    else:
-        advance_to_and_show_next_change()
-    return len(patches_to_discard)
+            advance_to_and_show_next_change()
+        return len(patches_to_discard)

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -32,8 +32,8 @@ from ..batch.selection import (
 from ..batch.source_refresh import acquire_batch_ownership_update_for_selection
 from ..batch.validation import batch_exists
 from ..core.diff_parser import (
+    acquire_unified_diff,
     build_line_changes_from_patch_lines,
-    parse_unified_diff_streaming,
 )
 from ..core.hashing import (
     compute_binary_file_hash,
@@ -654,82 +654,83 @@ def command_include_file(
         # follow-up `show --files` / `include --files` passes in the same session.
         hunks_staged = 0
         submodule_pointers_staged = 0
-        for patch in parse_unified_diff_streaming(
+        with acquire_unified_diff(
             stream_git_diff(
                 full_index=True,
                 ignore_submodules="none",
                 submodule_format="short",
             )
-        ):
-            if isinstance(patch, GitlinkChange):
-                if patch.path() == target_file:
-                    result = _update_index_for_gitlink_change(patch)
-                    if result.returncode != 0:
-                        print(
-                            _("Failed to stage submodule pointer: {error}").format(
-                                error=result.stderr,
-                            ),
-                            file=sys.stderr,
-                        )
-                        break
-                    record_hunk_included(compute_gitlink_change_hash(patch))
-                    hunks_staged += 1
-                    submodule_pointers_staged += 1
-                continue
-
-            if isinstance(patch, BinaryFileChange):
-                file_path = patch.new_path if patch.new_path != "/dev/null" else patch.old_path
-                if file_path != target_file:
+        ) as patches:
+            for patch in patches:
+                if isinstance(patch, GitlinkChange):
+                    if patch.path() == target_file:
+                        result = _update_index_for_gitlink_change(patch)
+                        if result.returncode != 0:
+                            print(
+                                _("Failed to stage submodule pointer: {error}").format(
+                                    error=result.stderr,
+                                ),
+                                file=sys.stderr,
+                            )
+                            break
+                        record_hunk_included(compute_gitlink_change_hash(patch))
+                        hunks_staged += 1
+                        submodule_pointers_staged += 1
                     continue
 
-                result = run_git_command(["add", "--", file_path], check=False)
-                if result.returncode != 0:
-                    print(_("Failed to stage binary file: {error}").format(error=result.stderr), file=sys.stderr)
+                if isinstance(patch, BinaryFileChange):
+                    file_path = patch.new_path if patch.new_path != "/dev/null" else patch.old_path
+                    if file_path != target_file:
+                        continue
+
+                    result = run_git_command(["add", "--", file_path], check=False)
+                    if result.returncode != 0:
+                        print(_("Failed to stage binary file: {error}").format(error=result.stderr), file=sys.stderr)
+                        break
+
+                    record_hunk_included(compute_binary_file_hash(patch))
+                    hunks_staged += 1
+                    continue
+
+                patch_paths = {
+                    path for path in (patch.old_path, patch.new_path)
+                    if path != "/dev/null"
+                }
+                if target_file not in patch_paths:
+                    continue
+
+                patch_hash = compute_stable_hunk_hash_from_lines(patch.lines)
+
+                if patch.old_path != patch.new_path:
+                    result = run_git_command(["add", "--", *sorted(patch_paths)], check=False)
+                    if result.returncode != 0:
+                        print(_("Failed to stage file: {error}").format(error=result.stderr), file=sys.stderr)
+                        break
+
+                    record_hunk_included(patch_hash)
+                    hunks_staged += 1
+                    continue
+
+                # Apply the hunk to the index using streaming
+                stderr_chunks = []
+                exit_code = 0
+
+                for event in stream_command(["git", "apply", "--cached"], patch.lines):
+                    if isinstance(event, ExitEvent):
+                        exit_code = event.exit_code
+                    elif isinstance(event, OutputEvent):
+                        if event.fd == 2:  # stderr
+                            stderr_chunks.append(event.data)
+
+                if exit_code == 0:
+                    # Record for progress tracking
+                    record_hunk_included(patch_hash)
+
+                    hunks_staged += 1
+                else:
+                    stderr_text = b"".join(stderr_chunks).decode('utf-8', errors='replace')
+                    print(_("Failed to apply hunk: {error}").format(error=stderr_text), file=sys.stderr)
                     break
-
-                record_hunk_included(compute_binary_file_hash(patch))
-                hunks_staged += 1
-                continue
-
-            patch_paths = {
-                path for path in (patch.old_path, patch.new_path)
-                if path != "/dev/null"
-            }
-            if target_file not in patch_paths:
-                continue
-
-            patch_hash = compute_stable_hunk_hash_from_lines(patch.lines)
-
-            if patch.old_path != patch.new_path:
-                result = run_git_command(["add", "--", *sorted(patch_paths)], check=False)
-                if result.returncode != 0:
-                    print(_("Failed to stage file: {error}").format(error=result.stderr), file=sys.stderr)
-                    break
-
-                record_hunk_included(patch_hash)
-                hunks_staged += 1
-                continue
-
-            # Apply the hunk to the index using streaming
-            stderr_chunks = []
-            exit_code = 0
-
-            for event in stream_command(["git", "apply", "--cached"], patch.lines):
-                if isinstance(event, ExitEvent):
-                    exit_code = event.exit_code
-                elif isinstance(event, OutputEvent):
-                    if event.fd == 2:  # stderr
-                        stderr_chunks.append(event.data)
-
-            if exit_code == 0:
-                # Record for progress tracking
-                record_hunk_included(patch_hash)
-
-                hunks_staged += 1
-            else:
-                stderr_text = b"".join(stderr_chunks).decode('utf-8', errors='replace')
-                print(_("Failed to apply hunk: {error}").format(error=stderr_text), file=sys.stderr)
-                break
 
     if hunks_staged == 0:
         if not quiet:
@@ -1525,18 +1526,19 @@ def _command_include_file_to_batch(batch_name: str, file_path: str, *, quiet: bo
     # Collect ALL hunks from this file (live working tree state)
     all_lines_to_batch = []
 
-    for patch in parse_unified_diff_streaming(
+    with acquire_unified_diff(
         stream_git_diff(
             base="HEAD",
             context_lines=get_context_lines(),
             paths=[file_path],
         )
-    ):
-        hunk_lines = build_line_changes_from_patch_lines(
-            patch.lines,
-            annotator=annotate_with_batch_source,
-        )
-        all_lines_to_batch.extend(hunk_lines.lines)
+    ) as patches:
+        for patch in patches:
+            hunk_lines = build_line_changes_from_patch_lines(
+                patch.lines,
+                annotator=annotate_with_batch_source,
+            )
+            all_lines_to_batch.extend(hunk_lines.lines)
 
     if not all_lines_to_batch:
         if _save_empty_text_lifecycle_to_batch(batch_name, file_path, file_mode) is not None:
@@ -1772,42 +1774,48 @@ def _command_include_hunk_to_batch(batch_name: str, file_only: bool = False, *, 
     blocked_hashes = read_text_file_line_set(blocklist_path)
 
     # Stream diff to find first non-blocked hunk
-    selected_patch = None
+    selected_file_path = None
+    selected_line_changes = None
     selected_hash = None
-    for patch in parse_unified_diff_streaming(
+    with acquire_unified_diff(
         stream_git_diff(
             context_lines=get_context_lines(),
             full_index=True,
             ignore_submodules="none",
             submodule_format="short",
         )
-    ):
-        if isinstance(patch, GitlinkChange):
-            patch_hash = compute_gitlink_change_hash(patch)
+    ) as patches:
+        for patch in patches:
+            if isinstance(patch, GitlinkChange):
+                patch_hash = compute_gitlink_change_hash(patch)
+                if patch_hash not in blocked_hashes:
+                    _command_include_gitlink_to_batch(batch_name, patch, quiet=quiet)
+                    return
+                continue
+
+            if isinstance(patch, BinaryFileChange):
+                patch_hash = compute_binary_file_hash(patch)
+                if patch_hash not in blocked_hashes:
+                    _command_include_binary_to_batch(batch_name, patch, quiet=quiet)
+                    return
+                continue
+
+            patch_hash = compute_stable_hunk_hash_from_lines(patch.lines)
             if patch_hash not in blocked_hashes:
-                _command_include_gitlink_to_batch(batch_name, patch, quiet=quiet)
-                return
-            continue
+                selected_file_path = patch.new_path
+                selected_line_changes = build_line_changes_from_patch_lines(
+                    patch.lines,
+                    annotator=annotate_with_batch_source,
+                )
+                selected_hash = patch_hash
+                break
 
-        if isinstance(patch, BinaryFileChange):
-            patch_hash = compute_binary_file_hash(patch)
-            if patch_hash not in blocked_hashes:
-                _command_include_binary_to_batch(batch_name, patch, quiet=quiet)
-                return
-            continue
-
-        patch_hash = compute_stable_hunk_hash_from_lines(patch.lines)
-        if patch_hash not in blocked_hashes:
-            selected_patch = patch
-            selected_hash = patch_hash
-            break
-
-    if selected_patch is None:
+    if selected_file_path is None or selected_line_changes is None or selected_hash is None:
         print(_("No changes to process."), file=sys.stderr)
         return
 
     # Get the file path
-    file_path = selected_patch.new_path
+    file_path = selected_file_path
 
     # Detect file mode
     file_mode = _detect_file_mode(file_path)
@@ -1815,43 +1823,41 @@ def _command_include_hunk_to_batch(batch_name: str, file_only: bool = False, *, 
     # Collect all lines to batch (either selected hunk or all hunks from file)
     all_lines_to_batch = []
     all_display_ids_to_batch = set()
-    patches_to_process = []
+    processed_hunks = []
 
     if file_only:
         # Collect ALL hunks from this file
-        for patch in parse_unified_diff_streaming(
+        with acquire_unified_diff(
             stream_git_diff(
                 context_lines=get_context_lines(),
                 full_index=True,
                 ignore_submodules="none",
                 submodule_format="short",
             )
-        ):
-            if patch.new_path != file_path:
-                continue
+        ) as patches:
+            for patch in patches:
+                if patch.new_path != file_path:
+                    continue
 
-            patch_hash = compute_stable_hunk_hash_from_lines(patch.lines)
+                patch_hash = compute_stable_hunk_hash_from_lines(patch.lines)
 
-            if patch_hash in blocked_hashes:
-                continue
+                if patch_hash in blocked_hashes:
+                    continue
 
-            # Parse hunk to get lines
-            line_changes = build_line_changes_from_patch_lines(
-                patch.lines,
-                annotator=annotate_with_batch_source,
-            )
-            all_lines_to_batch.extend(line_changes.lines)
-            all_display_ids_to_batch.update(line.id for line in line_changes.lines if line.id is not None)
-            patches_to_process.append((patch.lines, patch_hash))
+                # Parse hunk to get lines
+                line_changes = build_line_changes_from_patch_lines(
+                    patch.lines,
+                    annotator=annotate_with_batch_source,
+                )
+                all_lines_to_batch.extend(line_changes.lines)
+                all_display_ids_to_batch.update(line.id for line in line_changes.lines if line.id is not None)
+                processed_hunks.append((line_changes, patch_hash))
     else:
         # Just selected hunk
-        line_changes = build_line_changes_from_patch_lines(
-            selected_patch.lines,
-            annotator=annotate_with_batch_source,
-        )
+        line_changes = selected_line_changes
         all_lines_to_batch = line_changes.lines
         all_display_ids_to_batch = {line.id for line in line_changes.lines if line.id is not None}
-        patches_to_process = [(selected_patch.lines, selected_hash)]
+        processed_hunks = [(line_changes, selected_hash)]
 
     # Prepare batch ownership update (handles stale source, translation, merge)
 
@@ -1879,12 +1885,11 @@ def _command_include_hunk_to_batch(batch_name: str, file_only: bool = False, *, 
         add_file_to_batch(batch_name, file_path, update.ownership_after, file_mode)
 
     # Mark hunks as processed
-    for patch_lines, patch_hash in patches_to_process:
+    for hunk_lines, patch_hash in processed_hunks:
         # Mark this hunk as processed
         append_lines_to_file(blocklist_path, [patch_hash])
 
         # Record hunk as skipped for progress tracking
-        hunk_lines = build_line_changes_from_patch_lines(patch_lines)
         record_hunk_skipped(hunk_lines, patch_hash)
 
     # Print success message
@@ -1893,8 +1898,8 @@ def _command_include_hunk_to_batch(batch_name: str, file_only: bool = False, *, 
             msg = ngettext(
                 "✓ {count} hunk from {file} saved to batch '{name}'",
                 "✓ {count} hunks from {file} saved to batch '{name}'",
-                len(patches_to_process)
-            ).format(count=len(patches_to_process), file=file_path, name=batch_name)
+                len(processed_hunks)
+            ).format(count=len(processed_hunks), file=file_path, name=batch_name)
             print(msg, file=sys.stderr)
         else:
             print(_("✓ Hunk saved to batch '{name}'").format(name=batch_name), file=sys.stderr)

--- a/src/git_stage_batch/commands/show.py
+++ b/src/git_stage_batch/commands/show.py
@@ -6,7 +6,7 @@ import json
 import sys
 
 from ..batch.display import annotate_with_batch_source
-from ..core.diff_parser import build_line_changes_from_patch_lines, parse_unified_diff_streaming
+from ..core.diff_parser import acquire_unified_diff, build_line_changes_from_patch_lines
 from ..core.diff_parser import write_snapshots_for_selected_file_path
 from ..core.hashing import (
     compute_binary_file_hash,
@@ -239,66 +239,67 @@ def command_show(
     blocked_hashes = read_text_file_line_set(blocklist_path)
 
     # Stream diff and show first unblocked hunk
-    for patch in parse_unified_diff_streaming(
+    with acquire_unified_diff(
         stream_git_diff(
             context_lines=get_context_lines(),
             full_index=True,
             ignore_submodules="none",
             submodule_format="short",
         )
-    ):
-        if isinstance(patch, GitlinkChange):
-            gitlink_hash = compute_gitlink_change_hash(patch)
-            if gitlink_hash not in blocked_hashes:
-                cache_gitlink_change(patch)
+    ) as patches:
+        for patch in patches:
+            if isinstance(patch, GitlinkChange):
+                gitlink_hash = compute_gitlink_change_hash(patch)
+                if gitlink_hash not in blocked_hashes:
+                    cache_gitlink_change(patch)
+                    clear_last_file_review_state()
+                    if not porcelain:
+                        print_gitlink_change(patch)
+                    return
+                continue
+
+            if isinstance(patch, BinaryFileChange):
+                binary_hash = compute_binary_file_hash(patch)
+                if binary_hash not in blocked_hashes:
+                    cache_binary_file_change(patch)
+                    clear_last_file_review_state()
+                    if not porcelain:
+                        print_binary_file_change(patch)
+                    return
+                continue
+
+            patch_hash = compute_stable_hunk_hash_from_lines(patch.lines)
+            if patch_hash not in blocked_hashes:
+                with snapshot_selected_change_state() as previous_selected_state:
+                    # Cache selected hunk bytes exactly; display text is derived from parsed lines.
+                    write_selected_hunk_patch_lines(patch.lines)
+                    write_text_file_contents(get_selected_hunk_hash_file_path(), patch_hash)
+                    write_selected_change_kind(SelectedChangeKind.HUNK)
+
+                    # Parse and cache line_changes for batch filtering
+                    line_changes = build_line_changes_from_patch_lines(
+                        patch.lines,
+                        annotator=annotate_with_batch_source,
+                    )
+                    write_text_file_contents(get_line_changes_json_file_path(),
+                                            json.dumps(convert_line_changes_to_serializable_dict(line_changes),
+                                                      ensure_ascii=False, indent=0))
+                    write_snapshots_for_selected_file_path(line_changes.path)
+
+                    # Apply line-level batch filtering
+                    if apply_line_level_batch_filter_to_cached_hunk():
+                        # All lines in this hunk are batched, skip to next
+                        restore_selected_change_state(previous_selected_state)
+                        continue
+
                 clear_last_file_review_state()
+
+                # Display this unprocessed hunk (unless porcelain mode)
                 if not porcelain:
-                    print_gitlink_change(patch)
+                    line_changes = load_line_changes_from_state()
+                    if line_changes is not None:
+                        print_line_level_changes(line_changes)
                 return
-            continue
-
-        if isinstance(patch, BinaryFileChange):
-            binary_hash = compute_binary_file_hash(patch)
-            if binary_hash not in blocked_hashes:
-                cache_binary_file_change(patch)
-                clear_last_file_review_state()
-                if not porcelain:
-                    print_binary_file_change(patch)
-                return
-            continue
-
-        patch_hash = compute_stable_hunk_hash_from_lines(patch.lines)
-        if patch_hash not in blocked_hashes:
-            with snapshot_selected_change_state() as previous_selected_state:
-                # Cache selected hunk bytes exactly; display text is derived from parsed lines.
-                write_selected_hunk_patch_lines(patch.lines)
-                write_text_file_contents(get_selected_hunk_hash_file_path(), patch_hash)
-                write_selected_change_kind(SelectedChangeKind.HUNK)
-
-                # Parse and cache line_changes for batch filtering
-                line_changes = build_line_changes_from_patch_lines(
-                    patch.lines,
-                    annotator=annotate_with_batch_source,
-                )
-                write_text_file_contents(get_line_changes_json_file_path(),
-                                        json.dumps(convert_line_changes_to_serializable_dict(line_changes),
-                                                  ensure_ascii=False, indent=0))
-                write_snapshots_for_selected_file_path(line_changes.path)
-
-                # Apply line-level batch filtering
-                if apply_line_level_batch_filter_to_cached_hunk():
-                    # All lines in this hunk are batched, skip to next
-                    restore_selected_change_state(previous_selected_state)
-                    continue
-
-            clear_last_file_review_state()
-
-            # Display this unprocessed hunk (unless porcelain mode)
-            if not porcelain:
-                line_changes = load_line_changes_from_state()
-                if line_changes is not None:
-                    print_line_level_changes(line_changes)
-            return
 
     # Either no changes or all hunks are blocked
     if porcelain:

--- a/src/git_stage_batch/commands/skip.py
+++ b/src/git_stage_batch/commands/skip.py
@@ -6,7 +6,7 @@ from dataclasses import replace
 import json
 import sys
 
-from ..core.diff_parser import build_line_changes_from_patch_lines, parse_unified_diff_streaming
+from ..core.diff_parser import acquire_unified_diff, build_line_changes_from_patch_lines
 from ..core.hashing import (
     compute_binary_file_hash,
     compute_gitlink_change_hash,
@@ -202,60 +202,61 @@ def command_skip_file(
         blocked_hashes = read_text_file_line_set(blocklist_path)
 
         hunks_skipped = 0
-        for patch in parse_unified_diff_streaming(
+        with acquire_unified_diff(
             stream_git_diff(
                 context_lines=get_context_lines(),
                 full_index=True,
                 ignore_submodules="none",
                 submodule_format="short",
             )
-        ):
-            if isinstance(patch, GitlinkChange):
-                if patch.path() != target_file:
+        ) as patches:
+            for patch in patches:
+                if isinstance(patch, GitlinkChange):
+                    if patch.path() != target_file:
+                        continue
+
+                    patch_hash = compute_gitlink_change_hash(patch)
+                    if patch_hash in blocked_hashes:
+                        continue
+
+                    append_lines_to_file(blocklist_path, [patch_hash])
+                    blocked_hashes.add(patch_hash)
+                    record_gitlink_hunk_skipped(patch, patch_hash)
+                    hunks_skipped += 1
                     continue
 
-                patch_hash = compute_gitlink_change_hash(patch)
+                if isinstance(patch, BinaryFileChange):
+                    file_path = patch.new_path if patch.new_path != "/dev/null" else patch.old_path
+                    if file_path != target_file:
+                        continue
+
+                    patch_hash = compute_binary_file_hash(patch)
+                    if patch_hash in blocked_hashes:
+                        continue
+
+                    append_lines_to_file(blocklist_path, [patch_hash])
+                    blocked_hashes.add(patch_hash)
+                    record_binary_hunk_skipped(patch, patch_hash)
+                    hunks_skipped += 1
+                    continue
+
+                if patch.new_path != target_file:
+                    continue
+
+                patch_hash = compute_stable_hunk_hash_from_lines(patch.lines)
+
+                # Skip if already blocked
                 if patch_hash in blocked_hashes:
                     continue
 
+                # Add to blocklist without staging
                 append_lines_to_file(blocklist_path, [patch_hash])
                 blocked_hashes.add(patch_hash)
-                record_gitlink_hunk_skipped(patch, patch_hash)
+                record_hunk_skipped(
+                    build_line_changes_from_patch_lines(patch.lines),
+                    patch_hash,
+                )
                 hunks_skipped += 1
-                continue
-
-            if isinstance(patch, BinaryFileChange):
-                file_path = patch.new_path if patch.new_path != "/dev/null" else patch.old_path
-                if file_path != target_file:
-                    continue
-
-                patch_hash = compute_binary_file_hash(patch)
-                if patch_hash in blocked_hashes:
-                    continue
-
-                append_lines_to_file(blocklist_path, [patch_hash])
-                blocked_hashes.add(patch_hash)
-                record_binary_hunk_skipped(patch, patch_hash)
-                hunks_skipped += 1
-                continue
-
-            if patch.new_path != target_file:
-                continue
-
-            patch_hash = compute_stable_hunk_hash_from_lines(patch.lines)
-
-            # Skip if already blocked
-            if patch_hash in blocked_hashes:
-                continue
-
-            # Add to blocklist without staging
-            append_lines_to_file(blocklist_path, [patch_hash])
-            blocked_hashes.add(patch_hash)
-            record_hunk_skipped(
-                build_line_changes_from_patch_lines(patch.lines),
-                patch_hash,
-            )
-            hunks_skipped += 1
 
         if quiet and advance:
             advance_to_next_change()

--- a/src/git_stage_batch/commands/status.py
+++ b/src/git_stage_batch/commands/status.py
@@ -14,7 +14,7 @@ from ..core.hashing import (
     compute_gitlink_change_hash,
     compute_stable_hunk_hash_from_lines,
 )
-from ..core.diff_parser import parse_unified_diff_streaming
+from ..core.diff_parser import acquire_unified_diff
 from ..core.models import BinaryFileChange, GitlinkChange
 from ..data.file_review_state import (
     FileReviewAction,
@@ -104,27 +104,28 @@ def estimate_remaining_hunks() -> int:
 
     remaining = 0
     try:
-        for patch in parse_unified_diff_streaming(
+        with acquire_unified_diff(
             stream_git_diff(
                 context_lines=get_context_lines(),
                 full_index=True,
                 ignore_submodules="none",
                 submodule_format="short",
             )
-        ):
-            if isinstance(patch, GitlinkChange):
-                hunk_hash = compute_gitlink_change_hash(patch)
-                file_path = patch.path()
-            elif isinstance(patch, BinaryFileChange):
-                hunk_hash = compute_binary_file_hash(patch)
-                file_path = patch.new_path if patch.new_path != "/dev/null" else patch.old_path
-            else:
-                hunk_hash = compute_stable_hunk_hash_from_lines(patch.lines)
-                file_path = patch.old_path if patch.old_path != "/dev/null" else patch.new_path
-            file_path = file_path.removeprefix("a/").removeprefix("b/")
+        ) as patches:
+            for patch in patches:
+                if isinstance(patch, GitlinkChange):
+                    hunk_hash = compute_gitlink_change_hash(patch)
+                    file_path = patch.path()
+                elif isinstance(patch, BinaryFileChange):
+                    hunk_hash = compute_binary_file_hash(patch)
+                    file_path = patch.new_path if patch.new_path != "/dev/null" else patch.old_path
+                else:
+                    hunk_hash = compute_stable_hunk_hash_from_lines(patch.lines)
+                    file_path = patch.old_path if patch.old_path != "/dev/null" else patch.new_path
+                file_path = file_path.removeprefix("a/").removeprefix("b/")
 
-            if hunk_hash not in blocked_hashes and file_path not in blocked_files:
-                remaining += 1
+                if hunk_hash not in blocked_hashes and file_path not in blocked_files:
+                    remaining += 1
     except Exception:
         return 0
 

--- a/src/git_stage_batch/core/diff_parser.py
+++ b/src/git_stage_batch/core/diff_parser.py
@@ -39,6 +39,15 @@ SUBPROJECT_COMMIT_PATTERN = re.compile(br"^[+-]Subproject commit ([0-9a-f]+)")
 NULL_OBJECT_PREFIX = "0" * 7
 
 
+def detach_single_hunk_patch(patch: SingleHunkPatch) -> SingleHunkPatch:
+    """Return a patch whose line payload is independent of parser-owned buffers."""
+    return SingleHunkPatch(
+        old_path=patch.old_path,
+        new_path=patch.new_path,
+        lines=list(patch.lines),
+    )
+
+
 def _metadata_indicates_gitlink(metadata_lines: list[bytes]) -> bool:
     """Return whether diff metadata describes a mode-160000 entry."""
     for line in metadata_lines:

--- a/src/git_stage_batch/core/diff_parser.py
+++ b/src/git_stage_batch/core/diff_parser.py
@@ -40,15 +40,6 @@ SUBPROJECT_COMMIT_PATTERN = re.compile(br"^[+-]Subproject commit ([0-9a-f]+)")
 NULL_OBJECT_PREFIX = "0" * 7
 
 
-def detach_single_hunk_patch(patch: SingleHunkPatch) -> SingleHunkPatch:
-    """Return a patch whose line payload is independent of parser-owned buffers."""
-    return SingleHunkPatch(
-        old_path=patch.old_path,
-        new_path=patch.new_path,
-        lines=list(patch.lines),
-    )
-
-
 def _metadata_indicates_gitlink(metadata_lines: list[bytes]) -> bool:
     """Return whether diff metadata describes a mode-160000 entry."""
     for line in metadata_lines:
@@ -496,27 +487,6 @@ class _UnifiedDiffParserBuildContext:
 def acquire_unified_diff(lines: Iterable[bytes]) -> _UnifiedDiffParserBuildContext:
     """Acquire a scoped unified diff parser with parser-owned hunk buffers."""
     return _UnifiedDiffParserBuildContext(lines)
-
-
-def parse_unified_diff_streaming(
-    lines: Iterable[bytes],
-) -> Iterator[UnifiedDiffItem]:
-    """Parse a unified diff and yield detached patches and binary changes.
-
-    This compatibility parser returns SingleHunkPatch values whose lines remain
-    usable after iteration advances. Use acquire_unified_diff() for scoped
-    EditorBuffer-backed hunk payloads.
-    """
-    context = acquire_unified_diff(lines)
-    with context as items:
-        for item in items:
-            if isinstance(item, SingleHunkPatch):
-                detached_item = detach_single_hunk_patch(item)
-                if isinstance(item.lines, EditorBuffer):
-                    context._release_buffer(item.lines)
-                yield detached_item
-            else:
-                yield item
 
 
 def write_snapshots_for_selected_file_path(file_path: str) -> None:

--- a/src/git_stage_batch/core/diff_parser.py
+++ b/src/git_stage_batch/core/diff_parser.py
@@ -171,7 +171,7 @@ class _UnifiedDiffParserBuildContext:
             raise ValueError("parser context is closed")
         if self._parser is not None:
             raise RuntimeError("parser context can only be entered once")
-        self._parser = self._parse()
+        self._parser = self._iter_owned()
         return self._parser
 
     def __exit__(self, exc_type, exc, traceback) -> None:
@@ -187,6 +187,26 @@ class _UnifiedDiffParserBuildContext:
         except ValueError:
             return
         buffer.close()
+
+    def _release_item(self, item: UnifiedDiffItem | None) -> None:
+        if isinstance(item, SingleHunkPatch) and isinstance(item.lines, EditorBuffer):
+            self._release_buffer(item.lines)
+
+    def _iter_owned(self) -> Iterator[UnifiedDiffItem]:
+        current_item: UnifiedDiffItem | None = None
+        parser = self._parse()
+
+        try:
+            while True:
+                self._release_item(current_item)
+                current_item = None
+                current_item = next(parser)
+                yield current_item
+        except StopIteration:
+            return
+        finally:
+            self._release_item(current_item)
+            parser.close()
 
     def _build_single_hunk_patch(
         self,

--- a/src/git_stage_batch/core/diff_parser.py
+++ b/src/git_stage_batch/core/diff_parser.py
@@ -31,6 +31,7 @@ from ..utils.paths import get_index_snapshot_file_path, get_working_tree_snapsho
 
 # Type for annotator hooks that enrich LineLevelChange with additional metadata
 LineLevelChangeAnnotator = Callable[[str, LineLevelChange], LineLevelChange]
+UnifiedDiffItem = Union[SingleHunkPatch, BinaryFileChange, GitlinkChange]
 
 
 HUNK_HEADER_PATTERN = re.compile(r"^@@\s+-(\d+)(?:,(\d+))?\s+\+(\d+)(?:,(\d+))?\s+@@")
@@ -143,276 +144,359 @@ def _consume_gitlink_hunks(
     return old_oid, new_oid
 
 
-def parse_unified_diff_streaming(
-    lines: Iterable[bytes],
-) -> Iterator[Union[SingleHunkPatch, BinaryFileChange, GitlinkChange]]:
-    """Parse a unified diff from a byte line iterator, yielding patches and binary changes.
+class _UnifiedDiffParserBuildContext:
+    """Own parser-created hunk buffers for a scoped unified diff parse."""
 
-    This is the core streaming parser that accepts any iterable of byte lines
-    (from bytes_to_lines(), list[bytes], etc.) and yields SingleHunkPatch objects
-    for text file hunks and BinaryFileChange objects for binary files.
-    Callers can stop iterating early to avoid parsing the entire diff.
+    def __init__(self, lines: Iterable[bytes]) -> None:
+        self._lines = lines
+        self._buffers: list[EditorBuffer] = []
+        self._parser: Iterator[UnifiedDiffItem] | None = None
+        self._closed = False
 
-    Args:
-        lines: Iterable of diff lines as bytes (each line includes its \\n terminator)
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
 
-    Yields:
-        SingleHunkPatch objects for text hunks, BinaryFileChange objects for
-        binary files, and GitlinkChange objects for submodule pointer changes.
-    """
-    line_iter = iter(lines)
-    lookahead = None  # One-line lookahead buffer
+        if self._parser is not None:
+            self._parser.close()
+            self._parser = None
 
-    def next_line():
-        """Get next line, using lookahead if available."""
-        nonlocal lookahead
-        if lookahead is not None:
-            line = lookahead
-            lookahead = None
-            return line
+        for buffer in self._buffers:
+            buffer.close()
+        self._buffers.clear()
+
+    def __enter__(self) -> Iterator[UnifiedDiffItem]:
+        if self._closed:
+            raise ValueError("parser context is closed")
+        if self._parser is not None:
+            raise RuntimeError("parser context can only be entered once")
+        self._parser = self._parse()
+        return self._parser
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        self.close()
+
+    def _own_buffer(self, buffer: EditorBuffer) -> EditorBuffer:
+        self._buffers.append(buffer)
+        return buffer
+
+    def _release_buffer(self, buffer: EditorBuffer) -> None:
         try:
-            return next(line_iter)
-        except StopIteration:
-            return None
+            self._buffers.remove(buffer)
+        except ValueError:
+            return
+        buffer.close()
 
-    def peek_line():
-        """Peek at next line without consuming it."""
-        nonlocal lookahead
-        if lookahead is None:
-            try:
-                lookahead = next(line_iter)
-            except StopIteration:
+    def _build_single_hunk_patch(
+        self,
+        *,
+        old_path: str,
+        new_path: str,
+        lines: Iterable[bytes],
+    ) -> SingleHunkPatch:
+        return SingleHunkPatch(
+            old_path=old_path,
+            new_path=new_path,
+            lines=self._own_buffer(EditorBuffer.from_chunks(lines)),
+        )
+
+    def _parse(self) -> Iterator[UnifiedDiffItem]:
+        line_iter = iter(self._lines)
+        lookahead = None  # One-line lookahead buffer
+
+        def next_line():
+            """Get next line, using lookahead if available."""
+            nonlocal lookahead
+            if lookahead is not None:
+                line = lookahead
                 lookahead = None
-        return lookahead
+                return line
+            try:
+                return next(line_iter)
+            except StopIteration:
+                return None
 
-    while True:
-        line = next_line()
-        if line is None:
-            break
+        def peek_line():
+            """Peek at next line without consuming it."""
+            nonlocal lookahead
+            if lookahead is None:
+                try:
+                    lookahead = next(line_iter)
+                except StopIteration:
+                    lookahead = None
+            return lookahead
 
-        # Strip only the diff format's \n terminator (preserve \r in content)
-        line = line.rstrip(b'\n')
+        def hunk_line_chunks(
+            old_file_line: bytes,
+            new_file_line: bytes,
+            hunk_header_line: bytes,
+        ) -> Iterator[bytes]:
+            nonlocal lookahead
 
-        # Look for start of a file diff
-        if line.startswith(b"diff --git "):
-            # Extract file paths from the diff --git line
-            # Format: diff --git a/path b/path
-            rest = line[len(b"diff --git "):]
+            yield old_file_line + b'\n'
+            yield new_file_line + b'\n'
+            yield hunk_header_line + b'\n'
 
-            # Find a/ and b/ markers
-            a_start = rest.find(b"a/")
-            b_start = rest.find(b" b/")
-
-            if a_start == -1 or b_start == -1:
-                continue
-
-            # Paths in git are always valid UTF-8, decode them to str
-            old_path = rest[a_start + 2:b_start].decode('utf-8')
-            new_path = rest[b_start + 3:].decode('utf-8')  # Skip " b/"
-
-            # Collect metadata lines until we hit the --- line (start of unified diff)
-            # Files with no hunks (binary, mode-only, rename-only, empty) won't have --- line
-            metadata_lines = []
-            old_file_line = None
+            # Collect hunk body (lines starting with space, +, or -)
             while True:
-                next_l = next_line()
-                if next_l is None:
-                    # End of input - check for empty file before returning
-                    break
-                next_l = next_l.rstrip(b'\n')
-                if next_l.startswith(b"---"):
-                    old_file_line = next_l
-                    break
-                # Collect metadata lines
-                metadata_lines.append(next_l)
-                # If we hit another diff header, this file has no hunks - check if it's an empty new file
-                if next_l.startswith(b"diff --git "):
-                    # Put the line back for next iteration (with \n restored for consistency)
-                    lookahead = next_l + b'\n'
+                body_line = peek_line()
+                if body_line is None:
+                    # End of input
                     break
 
-            is_gitlink = _metadata_indicates_gitlink(metadata_lines)
-            index_old_oid, index_new_oid = _gitlink_oids_from_index(metadata_lines)
+                body_line_stripped = body_line.rstrip(b'\n')
 
-            # Handle files without unified diff hunks
-            if old_file_line is None:
-                if is_gitlink:
-                    yield GitlinkChange(
-                        old_path=_gitlink_old_path(old_path, index_old_oid),
-                        new_path=_gitlink_new_path(new_path, index_new_oid),
-                        old_oid=_non_null_git_oid(index_old_oid),
-                        new_oid=_non_null_git_oid(index_new_oid),
-                        change_type=_gitlink_change_type(
-                            metadata_lines,
-                            index_old_oid,
-                            index_new_oid,
-                        ),
-                    )
+                if body_line_stripped.startswith(b"diff --git "):
+                    # Next file starting
+                    break
+                if body_line_stripped.startswith(b"@@"):
+                    # Next hunk for same file
+                    break
+                # Check for start of new file diff (---/+++)
+                if body_line_stripped.startswith(b"---"):
+                    # Peek ahead one more line to see if it's followed by +++
+                    next_line()  # consume ---
+                    peek_plus = peek_line()
+                    if peek_plus and peek_plus.rstrip(b'\n').startswith(b"+++"):
+                        # This is a new file diff, put --- back in lookahead
+                        lookahead = body_line
+                        break
+
+                    # False alarm, this --- is part of the hunk body
+                    # Add with \n terminator
+                    yield body_line_stripped + b'\n'
                     continue
 
-                # Check if this is a binary file
-                # Binary files have lines like "Binary files a/X and b/X differ"
-                is_binary = any(b"Binary files" in m for m in metadata_lines)
-
-                if is_binary:
-                    # Yield binary file change
-                    # Extract the binary file line to determine change type
-                    binary_line = next((m for m in metadata_lines if b"Binary files" in m), b"Binary files differ")
-
-                    # Determine if it's a new, modified, or deleted binary file
-                    is_new_binary = b"/dev/null" in binary_line and b"and b/" in binary_line
-                    is_deleted_binary = b"a/" in binary_line and b"/dev/null" in binary_line
-
-                    if is_new_binary:
-                        change_type = "added"
-                    elif is_deleted_binary:
-                        change_type = "deleted"
-                    else:
-                        change_type = "modified"
-
-                    yield BinaryFileChange(
-                        old_path=old_path,
-                        new_path=new_path,
-                        change_type=change_type
-                    )
-                    continue
-
-                # Check if this is an empty new file (new file with no content)
-                # Empty new files have "new file mode" and "index 0000000..e69de29" (empty blob, short hash)
-                EMPTY_BLOB_SHORT_HASH = b"e69de29"  # Short hash for empty blob
-                is_new_file = any(b"new file mode" in m for m in metadata_lines)
-                is_empty = any(EMPTY_BLOB_SHORT_HASH in m for m in metadata_lines)
-
-                if is_new_file and is_empty:
-                    # Yield empty new file as a special patch with synthetic hunk
-                    # Create fake ---/+++ lines and an empty hunk header (with \n terminators)
-                    yield SingleHunkPatch(
-                        old_path="/dev/null",
-                        new_path=new_path,
-                        lines=[
-                            b"--- /dev/null\n",
-                            f"+++ b/{new_path}\n".encode('utf-8'),
-                            b"@@ -0,0 +0,0 @@\n",
-                        ]
-                    )
-                # Skip other files without hunks (mode-only, rename-only, etc.)
-                continue
-
-            # Get +++ line
-            plus_line = next_line()
-            if plus_line is None:
-                return
-            plus_line_stripped = plus_line.rstrip(b'\n')
-            if not plus_line_stripped.startswith(b"+++"):
-                continue
-            new_file_line = plus_line_stripped
-
-            if is_gitlink:
-                hunk_old_oid, hunk_new_oid = _consume_gitlink_hunks(next_line, peek_line)
-                old_oid = hunk_old_oid or _non_null_git_oid(index_old_oid)
-                new_oid = hunk_new_oid or _non_null_git_oid(index_new_oid)
-                yield GitlinkChange(
-                    old_path=_gitlink_old_path(old_path, old_oid or index_old_oid),
-                    new_path=_gitlink_new_path(new_path, new_oid or index_new_oid),
-                    old_oid=old_oid,
-                    new_oid=new_oid,
-                    change_type=_gitlink_change_type(
-                        metadata_lines,
-                        old_oid or index_old_oid,
-                        new_oid or index_new_oid,
-                    ),
-                )
-                continue
-
-            # Process all hunks for this file
-            has_hunks = False
-            while True:
-                # Check if next line is a hunk header
-                hunk_header_line = peek_line()
-                if hunk_header_line is None:
-                    return
-                hunk_header_stripped = hunk_header_line.rstrip(b'\n')
-                if not hunk_header_stripped.startswith(b"@@"):
-                    # No more hunks for this file
+                # Include lines that are part of the hunk
+                if body_line_stripped.startswith((b" ", b"+", b"-", b"\\")):
+                    next_line()  # consume
+                    # Add with \n terminator
+                    yield body_line_stripped + b'\n'
+                else:
+                    # Unknown line, stop collecting this hunk
                     break
 
-                has_hunks = True
+        try:
+            while True:
+                line = next_line()
+                if line is None:
+                    break
 
-                # Consume the hunk header
-                next_line()
+                # Strip only the diff format's \n terminator (preserve \r in content)
+                line = line.rstrip(b'\n')
 
-                # Build hunk with \n terminators for proper round-tripping
-                hunk_lines = [
-                    old_file_line + b'\n',
-                    new_file_line + b'\n',
-                    hunk_header_stripped + b'\n'
-                ]
+                # Look for start of a file diff
+                if line.startswith(b"diff --git "):
+                    # Extract file paths from the diff --git line
+                    # Format: diff --git a/path b/path
+                    rest = line[len(b"diff --git "):]
 
-                # Collect hunk body (lines starting with space, +, or -)
-                while True:
-                    body_line = peek_line()
-                    if body_line is None:
-                        # End of input
-                        break
+                    # Find a/ and b/ markers
+                    a_start = rest.find(b"a/")
+                    b_start = rest.find(b" b/")
 
-                    body_line_stripped = body_line.rstrip(b'\n')
+                    if a_start == -1 or b_start == -1:
+                        continue
 
-                    if body_line_stripped.startswith(b"diff --git "):
-                        # Next file starting
-                        break
-                    if body_line_stripped.startswith(b"@@"):
-                        # Next hunk for same file
-                        break
-                    # Check for start of new file diff (---/+++)
-                    if body_line_stripped.startswith(b"---"):
-                        # Peek ahead one more line to see if it's followed by +++
-                        next_line()  # consume ---
-                        peek_plus = peek_line()
-                        if peek_plus and peek_plus.rstrip(b'\n').startswith(b"+++"):
-                            # This is a new file diff, put --- back in lookahead
-                            lookahead = body_line
+                    # Paths in git are always valid UTF-8, decode them to str
+                    old_path = rest[a_start + 2:b_start].decode('utf-8')
+                    new_path = rest[b_start + 3:].decode('utf-8')  # Skip " b/"
+
+                    # Collect metadata lines until we hit the --- line (start of unified diff)
+                    # Files with no hunks (binary, mode-only, rename-only, empty) won't have --- line
+                    metadata_lines = []
+                    old_file_line = None
+                    while True:
+                        next_l = next_line()
+                        if next_l is None:
+                            # End of input - check for empty file before returning
                             break
-                        else:
-                            # False alarm, this --- is part of the hunk body
-                            # Add with \n terminator
-                            hunk_lines.append(body_line_stripped + b'\n')
+                        next_l = next_l.rstrip(b'\n')
+                        if next_l.startswith(b"---"):
+                            old_file_line = next_l
+                            break
+                        # Collect metadata lines
+                        metadata_lines.append(next_l)
+                        # If we hit another diff header, this file has no hunks - check if it's an empty new file
+                        if next_l.startswith(b"diff --git "):
+                            # Put the line back for next iteration (with \n restored for consistency)
+                            lookahead = next_l + b'\n'
+                            break
+
+                    is_gitlink = _metadata_indicates_gitlink(metadata_lines)
+                    index_old_oid, index_new_oid = _gitlink_oids_from_index(metadata_lines)
+
+                    # Handle files without unified diff hunks
+                    if old_file_line is None:
+                        if is_gitlink:
+                            yield GitlinkChange(
+                                old_path=_gitlink_old_path(old_path, index_old_oid),
+                                new_path=_gitlink_new_path(new_path, index_new_oid),
+                                old_oid=_non_null_git_oid(index_old_oid),
+                                new_oid=_non_null_git_oid(index_new_oid),
+                                change_type=_gitlink_change_type(
+                                    metadata_lines,
+                                    index_old_oid,
+                                    index_new_oid,
+                                ),
+                            )
                             continue
 
-                    # Include lines that are part of the hunk
-                    if body_line_stripped.startswith((b" ", b"+", b"-", b"\\")):
-                        next_line()  # consume
-                        # Add with \n terminator
-                        hunk_lines.append(body_line_stripped + b'\n')
-                    else:
-                        # Unknown line, stop collecting this hunk
-                        break
+                        # Check if this is a binary file
+                        # Binary files have lines like "Binary files a/X and b/X differ"
+                        is_binary = any(b"Binary files" in m for m in metadata_lines)
 
-                # Yield this hunk immediately
-                yield SingleHunkPatch(
-                    old_path=old_path,
-                    new_path=new_path,
-                    lines=hunk_lines
-                )
+                        if is_binary:
+                            # Yield binary file change
+                            # Extract the binary file line to determine change type
+                            binary_line = next(
+                                (m for m in metadata_lines if b"Binary files" in m),
+                                b"Binary files differ",
+                            )
 
-            # If we got --- and +++ but no hunks, check if it's an empty new file
-            if not has_hunks:
-                # Check if this is an empty new file (new file with no content)
-                # Empty new files have "new file mode" and "index 0000000..e69de29" (empty blob)
-                EMPTY_BLOB_SHORT_HASH = b"e69de29"
-                is_new_file = any(b"new file mode" in m for m in metadata_lines)
-                is_empty = any(EMPTY_BLOB_SHORT_HASH in m for m in metadata_lines)
+                            # Determine if it's a new, modified, or deleted binary file
+                            is_new_binary = b"/dev/null" in binary_line and b"and b/" in binary_line
+                            is_deleted_binary = b"a/" in binary_line and b"/dev/null" in binary_line
 
-                if is_new_file and is_empty:
-                    # Yield empty new file as a special patch with synthetic hunk
-                    yield SingleHunkPatch(
-                        old_path=old_path,
-                        new_path=new_path,
-                        lines=[
-                            old_file_line + b'\n',
-                            new_file_line + b'\n',
-                            b"@@ -0,0 +0,0 @@\n",
-                        ]
-                    )
+                            if is_new_binary:
+                                change_type = "added"
+                            elif is_deleted_binary:
+                                change_type = "deleted"
+                            else:
+                                change_type = "modified"
+
+                            yield BinaryFileChange(
+                                old_path=old_path,
+                                new_path=new_path,
+                                change_type=change_type
+                            )
+                            continue
+
+                        # Check if this is an empty new file (new file with no content)
+                        # Empty new files have "new file mode" and "index 0000000..e69de29" (empty blob, short hash)
+                        EMPTY_BLOB_SHORT_HASH = b"e69de29"  # Short hash for empty blob
+                        is_new_file = any(b"new file mode" in m for m in metadata_lines)
+                        is_empty = any(EMPTY_BLOB_SHORT_HASH in m for m in metadata_lines)
+
+                        if is_new_file and is_empty:
+                            # Yield empty new file as a special patch with synthetic hunk
+                            # Create fake ---/+++ lines and an empty hunk header (with \n terminators)
+                            yield self._build_single_hunk_patch(
+                                old_path="/dev/null",
+                                new_path=new_path,
+                                lines=[
+                                    b"--- /dev/null\n",
+                                    f"+++ b/{new_path}\n".encode('utf-8'),
+                                    b"@@ -0,0 +0,0 @@\n",
+                                ],
+                            )
+                        # Skip other files without hunks (mode-only, rename-only, etc.)
+                        continue
+
+                    # Get +++ line
+                    plus_line = next_line()
+                    if plus_line is None:
+                        return
+                    plus_line_stripped = plus_line.rstrip(b'\n')
+                    if not plus_line_stripped.startswith(b"+++"):
+                        continue
+                    new_file_line = plus_line_stripped
+
+                    if is_gitlink:
+                        hunk_old_oid, hunk_new_oid = _consume_gitlink_hunks(next_line, peek_line)
+                        old_oid = hunk_old_oid or _non_null_git_oid(index_old_oid)
+                        new_oid = hunk_new_oid or _non_null_git_oid(index_new_oid)
+                        yield GitlinkChange(
+                            old_path=_gitlink_old_path(old_path, old_oid or index_old_oid),
+                            new_path=_gitlink_new_path(new_path, new_oid or index_new_oid),
+                            old_oid=old_oid,
+                            new_oid=new_oid,
+                            change_type=_gitlink_change_type(
+                                metadata_lines,
+                                old_oid or index_old_oid,
+                                new_oid or index_new_oid,
+                            ),
+                        )
+                        continue
+
+                    # Process all hunks for this file
+                    has_hunks = False
+                    while True:
+                        # Check if next line is a hunk header
+                        hunk_header_line = peek_line()
+                        if hunk_header_line is None:
+                            return
+                        hunk_header_stripped = hunk_header_line.rstrip(b'\n')
+                        if not hunk_header_stripped.startswith(b"@@"):
+                            # No more hunks for this file
+                            break
+
+                        has_hunks = True
+
+                        # Consume the hunk header
+                        next_line()
+
+                        # Yield this hunk immediately
+                        yield self._build_single_hunk_patch(
+                            old_path=old_path,
+                            new_path=new_path,
+                            lines=hunk_line_chunks(
+                                old_file_line,
+                                new_file_line,
+                                hunk_header_stripped,
+                            ),
+                        )
+
+                    # If we got --- and +++ but no hunks, check if it's an empty new file
+                    if not has_hunks:
+                        # Check if this is an empty new file (new file with no content)
+                        # Empty new files have "new file mode" and "index 0000000..e69de29" (empty blob)
+                        EMPTY_BLOB_SHORT_HASH = b"e69de29"
+                        is_new_file = any(b"new file mode" in m for m in metadata_lines)
+                        is_empty = any(EMPTY_BLOB_SHORT_HASH in m for m in metadata_lines)
+
+                        if is_new_file and is_empty:
+                            # Yield empty new file as a special patch with synthetic hunk
+                            yield self._build_single_hunk_patch(
+                                old_path=old_path,
+                                new_path=new_path,
+                                lines=[
+                                    old_file_line + b'\n',
+                                    new_file_line + b'\n',
+                                    b"@@ -0,0 +0,0 @@\n",
+                                ],
+                            )
+        finally:
+            close = getattr(line_iter, "close", None)
+            if close is not None:
+                close()
+
+
+def acquire_unified_diff(lines: Iterable[bytes]) -> _UnifiedDiffParserBuildContext:
+    """Acquire a scoped unified diff parser with parser-owned hunk buffers."""
+    return _UnifiedDiffParserBuildContext(lines)
+
+
+def parse_unified_diff_streaming(
+    lines: Iterable[bytes],
+) -> Iterator[UnifiedDiffItem]:
+    """Parse a unified diff and yield detached patches and binary changes.
+
+    This compatibility parser returns SingleHunkPatch values whose lines remain
+    usable after iteration advances. Use acquire_unified_diff() for scoped
+    EditorBuffer-backed hunk payloads.
+    """
+    context = acquire_unified_diff(lines)
+    with context as items:
+        for item in items:
+            if isinstance(item, SingleHunkPatch):
+                detached_item = detach_single_hunk_patch(item)
+                if isinstance(item.lines, EditorBuffer):
+                    context._release_buffer(item.lines)
+                yield detached_item
+            else:
+                yield item
 
 
 def write_snapshots_for_selected_file_path(file_path: str) -> None:

--- a/src/git_stage_batch/core/models.py
+++ b/src/git_stage_batch/core/models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Literal
 
@@ -45,7 +46,7 @@ class SingleHunkPatch:
     """
     old_path: str
     new_path: str
-    lines: list[bytes]  # includes ---/+++ and a single @@ hunk body, with \n terminators
+    lines: Sequence[bytes]  # includes ---/+++ and a single @@ hunk body, with \n terminators
 
 
 @dataclass

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -43,8 +43,8 @@ from ..core.models import (
 )
 from ..core.text_lifecycle import detect_empty_text_lifecycle_change
 from ..core.diff_parser import (
+    acquire_unified_diff,
     build_line_changes_from_patch_lines,
-    parse_unified_diff_streaming,
     write_snapshots_for_selected_file_path,
 )
 from ..editor import (
@@ -1502,26 +1502,27 @@ def _cache_combined_file_line_changes(
 def render_file_as_single_hunk(file_path: str) -> Optional[LineLevelChange]:
     """Render all changes for a file as a single hunk without caching state."""
     auto_add_untracked_files([file_path])
-    return _build_combined_file_line_changes(
-        file_path,
-        parse_unified_diff_streaming(
-            stream_git_diff(
-                base="HEAD",
-                context_lines=get_context_lines(),
-                full_index=True,
-                ignore_submodules="none",
-                submodule_format="short",
-                paths=[file_path],
-            )
-        ),
-    )
+    with acquire_unified_diff(
+        stream_git_diff(
+            base="HEAD",
+            context_lines=get_context_lines(),
+            full_index=True,
+            ignore_submodules="none",
+            submodule_format="short",
+            paths=[file_path],
+        )
+    ) as patches:
+        return _build_combined_file_line_changes(
+            file_path,
+            patches,
+        )
 
 
 def render_binary_file_change(file_path: str) -> Optional[BinaryFileChange]:
     """Render a binary file change for file-scoped display without caching state."""
     auto_add_untracked_files([file_path])
     try:
-        for item in parse_unified_diff_streaming(
+        with acquire_unified_diff(
             stream_git_diff(
                 base="HEAD",
                 full_index=True,
@@ -1529,9 +1530,10 @@ def render_binary_file_change(file_path: str) -> Optional[BinaryFileChange]:
                 submodule_format="short",
                 paths=[file_path],
             )
-        ):
-            if isinstance(item, BinaryFileChange):
-                return item
+        ) as patches:
+            for item in patches:
+                if isinstance(item, BinaryFileChange):
+                    return item
     except subprocess.CalledProcessError:
         return None
     return None
@@ -1541,7 +1543,7 @@ def render_gitlink_change(file_path: str) -> Optional[GitlinkChange]:
     """Render a gitlink change for file-scoped display without caching state."""
     auto_add_untracked_files([file_path])
     try:
-        for item in parse_unified_diff_streaming(
+        with acquire_unified_diff(
             stream_git_diff(
                 base="HEAD",
                 full_index=True,
@@ -1549,9 +1551,10 @@ def render_gitlink_change(file_path: str) -> Optional[GitlinkChange]:
                 submodule_format="short",
                 paths=[file_path],
             )
-        ):
-            if isinstance(item, GitlinkChange):
-                return item
+        ) as patches:
+            for item in patches:
+                if isinstance(item, GitlinkChange):
+                    return item
     except subprocess.CalledProcessError:
         return None
     return None
@@ -1560,18 +1563,19 @@ def render_gitlink_change(file_path: str) -> Optional[GitlinkChange]:
 def render_unstaged_file_as_single_hunk(file_path: str) -> Optional[LineLevelChange]:
     """Render the remaining unstaged changes for a file as a single hunk."""
     auto_add_untracked_files([file_path])
-    return _build_combined_file_line_changes(
-        file_path,
-        parse_unified_diff_streaming(
-            stream_git_diff(
-                context_lines=get_context_lines(),
-                full_index=True,
-                ignore_submodules="none",
-                submodule_format="short",
-                paths=[file_path],
-            )
-        ),
-    )
+    with acquire_unified_diff(
+        stream_git_diff(
+            context_lines=get_context_lines(),
+            full_index=True,
+            ignore_submodules="none",
+            submodule_format="short",
+            paths=[file_path],
+        )
+    ) as patches:
+        return _build_combined_file_line_changes(
+            file_path,
+            patches,
+        )
 
 
 def build_file_hunk_from_buffer(
@@ -1593,16 +1597,17 @@ def build_file_hunk_from_buffer(
         new_path = new_tmp.name
 
     try:
-        return _build_combined_file_line_changes(
-            file_path,
-            parse_unified_diff_streaming(
-                _stream_no_index_diff_lines(
-                    file_path=file_path,
-                    old_path=old_path,
-                    new_path=new_path,
-                )
-            ),
-        )
+        with acquire_unified_diff(
+            _stream_no_index_diff_lines(
+                file_path=file_path,
+                old_path=old_path,
+                new_path=new_path,
+            )
+        ) as patches:
+            return _build_combined_file_line_changes(
+                file_path,
+                patches,
+            )
     finally:
         try:
             import os
@@ -1773,71 +1778,72 @@ def fetch_next_change() -> Union[LineLevelChange, BinaryFileChange, GitlinkChang
 
     # Stream git diff and parse incrementally - stops after first unblocked item found
     try:
-        for item in parse_unified_diff_streaming(
+        with acquire_unified_diff(
             stream_git_diff(
                 context_lines=get_context_lines(),
                 full_index=True,
                 ignore_submodules="none",
                 submodule_format="short",
             )
-        ):
-            if isinstance(item, GitlinkChange):
-                gitlink_hash = compute_gitlink_change_hash(item)
-                if gitlink_hash in blocked_hashes:
+        ) as patches:
+            for item in patches:
+                if isinstance(item, GitlinkChange):
+                    gitlink_hash = compute_gitlink_change_hash(item)
+                    if gitlink_hash in blocked_hashes:
+                        continue
+
+                    if item.path() in blocked_files:
+                        continue
+
+                    cache_gitlink_change(item)
+                    return item
+
+                # Handle binary files
+                if isinstance(item, BinaryFileChange):
+                    binary_hash = compute_binary_file_hash(item)
+                    if binary_hash in blocked_hashes:
+                        continue
+
+                    # Determine file path for blocked files check
+                    file_path = item.new_path if item.new_path != "/dev/null" else item.old_path
+                    if file_path in blocked_files:
+                        continue
+
+                    cache_binary_file_change(item)
+
+                    # Return the BinaryFileChange object directly
+                    return item
+
+                # Handle text hunks (SingleHunkPatch)
+                hunk_hash = compute_stable_hunk_hash_from_lines(item.lines)
+                if hunk_hash in blocked_hashes:
                     continue
 
-                if item.path() in blocked_files:
+                # Skip hunks from blocked files
+                line_changes = build_line_changes_from_patch_lines(
+                    item.lines,
+                    annotator=annotate_with_batch_source,
+                )
+                if line_changes.path in blocked_files:
                     continue
 
-                cache_gitlink_change(item)
-                return item
+                write_selected_hunk_patch_lines(item.lines)
+                write_text_file_contents(get_selected_hunk_hash_file_path(), hunk_hash)
+                write_selected_change_kind(SelectedChangeKind.HUNK)
 
-            # Handle binary files
-            if isinstance(item, BinaryFileChange):
-                binary_hash = compute_binary_file_hash(item)
-                if binary_hash in blocked_hashes:
+                write_text_file_contents(get_line_changes_json_file_path(),
+                                         json.dumps(convert_line_changes_to_serializable_dict(line_changes),
+                                                    ensure_ascii=False, indent=0))
+                write_snapshots_for_selected_file_path(line_changes.path)
+
+                # Apply line-level batch filtering
+                if apply_line_level_batch_filter_to_cached_hunk():
+                    # All lines were batched, skip this hunk and continue
+                    clear_selected_change_state_files()
                     continue
 
-                # Determine file path for blocked files check
-                file_path = item.new_path if item.new_path != "/dev/null" else item.old_path
-                if file_path in blocked_files:
-                    continue
-
-                cache_binary_file_change(item)
-
-                # Return the BinaryFileChange object directly
-                return item
-
-            # Handle text hunks (SingleHunkPatch)
-            hunk_hash = compute_stable_hunk_hash_from_lines(item.lines)
-            if hunk_hash in blocked_hashes:
-                continue
-
-            # Skip hunks from blocked files
-            line_changes = build_line_changes_from_patch_lines(
-                item.lines,
-                annotator=annotate_with_batch_source,
-            )
-            if line_changes.path in blocked_files:
-                continue
-
-            write_selected_hunk_patch_lines(item.lines)
-            write_text_file_contents(get_selected_hunk_hash_file_path(), hunk_hash)
-            write_selected_change_kind(SelectedChangeKind.HUNK)
-
-            write_text_file_contents(get_line_changes_json_file_path(),
-                                     json.dumps(convert_line_changes_to_serializable_dict(line_changes),
-                                                ensure_ascii=False, indent=0))
-            write_snapshots_for_selected_file_path(line_changes.path)
-
-            # Apply line-level batch filtering
-            if apply_line_level_batch_filter_to_cached_hunk():
-                # All lines were batched, skip this hunk and continue
-                clear_selected_change_state_files()
-                continue
-
-            # Return filtered hunk (or original if no filtering applied)
-            return load_line_changes_from_state()
+                # Return filtered hunk (or original if no filtering applied)
+                return load_line_changes_from_state()
     except subprocess.CalledProcessError:
         # Git diff failed (e.g., no changes)
         pass
@@ -2019,58 +2025,59 @@ def recalculate_selected_hunk_for_file(file_path: str) -> None:
 
     # Stream git diff and parse incrementally - stops after first matching hunk found
     try:
-        for single_hunk in parse_unified_diff_streaming(
+        with acquire_unified_diff(
             stream_git_diff(
                 context_lines=get_context_lines(),
                 full_index=True,
                 ignore_submodules="none",
                 submodule_format="short",
             )
-        ):
-            if single_hunk.old_path != file_path and single_hunk.new_path != file_path:
-                continue
-
-            if isinstance(single_hunk, GitlinkChange):
-                gitlink_hash = compute_gitlink_change_hash(single_hunk)
-                if gitlink_hash in blocked_hashes:
+        ) as patches:
+            for single_hunk in patches:
+                if single_hunk.old_path != file_path and single_hunk.new_path != file_path:
                     continue
-                cache_gitlink_change(single_hunk)
-                print_gitlink_change(single_hunk)
+
+                if isinstance(single_hunk, GitlinkChange):
+                    gitlink_hash = compute_gitlink_change_hash(single_hunk)
+                    if gitlink_hash in blocked_hashes:
+                        continue
+                    cache_gitlink_change(single_hunk)
+                    print_gitlink_change(single_hunk)
+                    return
+
+                if isinstance(single_hunk, BinaryFileChange):
+                    continue
+
+                hunk_hash = compute_stable_hunk_hash_from_lines(single_hunk.lines)
+
+                if hunk_hash in blocked_hashes:
+                    continue
+
+                write_selected_hunk_patch_lines(single_hunk.lines)
+                write_text_file_contents(get_selected_hunk_hash_file_path(), hunk_hash)
+                write_selected_change_kind(SelectedChangeKind.HUNK)
+
+                line_changes = build_line_changes_from_patch_lines(
+                    single_hunk.lines,
+                    annotator=annotate_with_batch_source,
+                )
+                write_text_file_contents(get_line_changes_json_file_path(),
+                                        json.dumps(convert_line_changes_to_serializable_dict(line_changes),
+                                                  ensure_ascii=False, indent=0))
+                write_snapshots_for_selected_file_path(line_changes.path)
+
+                # Apply batch filter to exclude batched lines
+                if apply_line_level_batch_filter_to_cached_hunk():
+                    # All lines were batched, clear the hunk
+                    clear_selected_change_state_files()
+                    print(_("No more lines in this hunk."), file=sys.stderr)
+                    return
+
+                # Display filtered hunk
+                line_changes = load_line_changes_from_state()
+                if line_changes is not None:
+                    print_line_level_changes(line_changes)
                 return
-
-            if isinstance(single_hunk, BinaryFileChange):
-                continue
-
-            hunk_hash = compute_stable_hunk_hash_from_lines(single_hunk.lines)
-
-            if hunk_hash in blocked_hashes:
-                continue
-
-            write_selected_hunk_patch_lines(single_hunk.lines)
-            write_text_file_contents(get_selected_hunk_hash_file_path(), hunk_hash)
-            write_selected_change_kind(SelectedChangeKind.HUNK)
-
-            line_changes = build_line_changes_from_patch_lines(
-                single_hunk.lines,
-                annotator=annotate_with_batch_source,
-            )
-            write_text_file_contents(get_line_changes_json_file_path(),
-                                    json.dumps(convert_line_changes_to_serializable_dict(line_changes),
-                                              ensure_ascii=False, indent=0))
-            write_snapshots_for_selected_file_path(line_changes.path)
-
-            # Apply batch filter to exclude batched lines
-            if apply_line_level_batch_filter_to_cached_hunk():
-                # All lines were batched, clear the hunk
-                clear_selected_change_state_files()
-                print(_("No more lines in this hunk."), file=sys.stderr)
-                return
-
-            # Display filtered hunk
-            line_changes = load_line_changes_from_state()
-            if line_changes is not None:
-                print_line_level_changes(line_changes)
-            return
     except subprocess.CalledProcessError:
         # Git diff failed (e.g., no changes)
         clear_selected_change_state_files()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package helpers."""

--- a/tests/batch/test_ownership_hardening.py
+++ b/tests/batch/test_ownership_hardening.py
@@ -1,7 +1,7 @@
 """Tests for ownership attribution behavior."""
 
 import subprocess
-from git_stage_batch.core.diff_parser import parse_unified_diff_streaming
+from tests.diff_parser_helpers import collect_unified_diff
 
 import pytest
 
@@ -429,7 +429,7 @@ class TestReplacementProjection:
 
         # Parse diff
 
-        patches = list(parse_unified_diff_streaming(
+        patches = list(collect_unified_diff(
             stream_git_command(["diff", "HEAD", "test.txt"])
         ))
         assert len(patches) >= 1
@@ -467,7 +467,7 @@ class TestAnchorConsistency:
 
         # Get diff with different context settings
         for context_lines in [0, 3, 10]:
-            patches = list(parse_unified_diff_streaming(
+            patches = list(collect_unified_diff(
                 stream_git_command(["diff", f"-U{context_lines}", "HEAD", "test.txt"])
             ))
             if not patches:
@@ -504,7 +504,7 @@ class TestAnchorConsistency:
         assert len(deletion_units) == 1
 
         # Get diff
-        patches = list(parse_unified_diff_streaming(
+        patches = list(collect_unified_diff(
             stream_git_command(["diff", "HEAD", "test.txt"])
         ))
         line_changes = build_line_changes_from_patch_lines(patches[0].lines)
@@ -541,7 +541,7 @@ class TestAnchorConsistency:
         assert deletion_units[0].deletion_anchor_in_working_tree == 1
 
         # Get diff
-        patches = list(parse_unified_diff_streaming(
+        patches = list(collect_unified_diff(
             stream_git_command(["diff", "HEAD", "test.txt"])
         ))
         line_changes = build_line_changes_from_patch_lines(patches[0].lines)
@@ -580,7 +580,7 @@ class TestSemanticConsistency:
         assert len(units_map) == len(attribution.units)
 
         # Get diff for projection layer
-        patches = list(parse_unified_diff_streaming(
+        patches = list(collect_unified_diff(
             stream_git_command(["diff", "HEAD", "test.txt"])
         ))
         line_changes = build_line_changes_from_patch_lines(patches[0].lines)

--- a/tests/commands/test_discard_file.py
+++ b/tests/commands/test_discard_file.py
@@ -8,7 +8,7 @@ from git_stage_batch.commands.abort import command_abort
 from git_stage_batch.commands.discard import command_discard_file
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.core.hashing import compute_stable_hunk_hash_from_lines
-from git_stage_batch.core.diff_parser import parse_unified_diff_streaming
+from tests.diff_parser_helpers import collect_unified_diff
 from git_stage_batch.utils.file_io import read_text_file_contents
 from git_stage_batch.utils.paths import (
     ensure_state_directory_exists,
@@ -199,7 +199,7 @@ class TestCommandDiscardFile:
             cwd=temp_git_repo,
             capture_output=True,)
         stdout_bytes = result.stdout if isinstance(result.stdout, bytes) else result.stdout.encode("utf-8")
-        patches = list(parse_unified_diff_streaming(stdout_bytes.splitlines(keepends=True)))
+        patches = list(collect_unified_diff(stdout_bytes.splitlines(keepends=True)))
         expected_hashes = {
             compute_stable_hunk_hash_from_lines(patch.lines)
             for patch in patches

--- a/tests/commands/test_show.py
+++ b/tests/commands/test_show.py
@@ -1,7 +1,7 @@
 """Tests for show command."""
 
 from git_stage_batch.core.hashing import compute_stable_hunk_hash_from_lines
-from git_stage_batch.core.diff_parser import parse_unified_diff_streaming
+from tests.diff_parser_helpers import collect_unified_diff
 from git_stage_batch.utils.git import stream_git_command
 from git_stage_batch.utils.paths import get_block_list_file_path, get_context_lines
 from git_stage_batch.data.session import initialize_abort_state
@@ -145,7 +145,7 @@ class TestCommandShow:
         capsys.readouterr()
 
         # Get the hash of the first hunk and block it
-        patches = list(parse_unified_diff_streaming(stream_git_command(["diff", f"-U{get_context_lines()}", "--no-color"])))
+        patches = list(collect_unified_diff(stream_git_command(["diff", f"-U{get_context_lines()}", "--no-color"])))
         first_patch_hash = compute_stable_hunk_hash_from_lines(patches[0].lines)
 
         blocklist_path = get_block_list_file_path()
@@ -172,7 +172,7 @@ class TestCommandShow:
         command_start()
 
         # Get the hash and block it
-        patches = list(parse_unified_diff_streaming(stream_git_command(["diff", f"-U{get_context_lines()}", "--no-color"])))
+        patches = list(collect_unified_diff(stream_git_command(["diff", f"-U{get_context_lines()}", "--no-color"])))
         patch_hash = compute_stable_hunk_hash_from_lines(patches[0].lines)
 
         blocklist_path = get_block_list_file_path()
@@ -195,7 +195,7 @@ class TestCommandShow:
         initialize_abort_state()
 
         # Get expected patch and hash
-        patches = list(parse_unified_diff_streaming(stream_git_command(["diff", f"-U{get_context_lines()}", "--no-color"])))
+        patches = list(collect_unified_diff(stream_git_command(["diff", f"-U{get_context_lines()}", "--no-color"])))
         expected_patch = b"".join(patches[0].lines)
         expected_hash = compute_stable_hunk_hash_from_lines(patches[0].lines)
 
@@ -256,7 +256,7 @@ class TestCommandShow:
         initialize_abort_state()
 
         # Block the hunk
-        patches = list(parse_unified_diff_streaming(stream_git_command(["diff", f"-U{get_context_lines()}", "--no-color"])))
+        patches = list(collect_unified_diff(stream_git_command(["diff", f"-U{get_context_lines()}", "--no-color"])))
         patch_hash = compute_stable_hunk_hash_from_lines(patches[0].lines)
 
         blocklist_path = get_block_list_file_path()

--- a/tests/core/test_diff_parser.py
+++ b/tests/core/test_diff_parser.py
@@ -9,12 +9,11 @@ import pytest
 from git_stage_batch.core.diff_parser import (
     acquire_unified_diff,
     build_line_changes_from_patch_lines,
-    detach_single_hunk_patch,
-    parse_unified_diff_streaming,
     write_snapshots_for_selected_file_path,
 )
 from git_stage_batch.core.models import SingleHunkPatch
 from git_stage_batch.editor import EditorBuffer
+from tests.diff_parser_helpers import collect_unified_diff
 from git_stage_batch.utils.file_io import read_text_file_contents
 from git_stage_batch.utils.paths import get_index_snapshot_file_path, get_working_tree_snapshot_file_path
 
@@ -39,7 +38,7 @@ diff --git a/file.txt b/file.txt
 
 
 class TestParseUnifiedDiff:
-    """Tests for parse_unified_diff_streaming."""
+    """Tests for collect_unified_diff."""
 
     def test_single_file_single_hunk(self):
         """Test parsing a simple diff with one file and one hunk."""
@@ -54,7 +53,7 @@ index abc123..def456 100644
 +new line
  another context
 """
-        patches = list(parse_unified_diff_streaming(diff.encode('utf-8').splitlines(keepends=True)))
+        patches = list(collect_unified_diff(diff.encode('utf-8').splitlines(keepends=True)))
 
         assert len(patches) == 1
         patch = patches[0]
@@ -67,7 +66,7 @@ index abc123..def456 100644
 
     def test_single_file_multiple_hunks(self):
         """Test parsing a diff with one file and multiple hunks."""
-        patches = list(parse_unified_diff_streaming(_two_hunk_diff_lines()))
+        patches = list(collect_unified_diff(_two_hunk_diff_lines()))
 
         assert len(patches) == 2
         assert patches[0].old_path == "file.txt"
@@ -103,22 +102,6 @@ index abc123..def456 100644
 
         with pytest.raises(ValueError, match="buffer is closed"):
             list(second.lines)
-
-    def test_detached_scoped_patch_survives_parser_close(self):
-        """Test detached scoped patches keep list-backed line payloads."""
-        with acquire_unified_diff(_two_hunk_diff_lines()) as patches:
-            patch = next(patches)
-            detached = detach_single_hunk_patch(patch)
-
-        assert isinstance(detached.lines, list)
-        assert b"old 1" in b"".join(detached.lines)
-
-    def test_compatibility_parser_returns_detached_patches(self):
-        """Test compatibility parsing keeps patch lines usable after iteration."""
-        patches = list(parse_unified_diff_streaming(_two_hunk_diff_lines()))
-
-        assert isinstance(patches[0].lines, list)
-        assert b"old 1" in b"".join(patches[0].lines)
 
     def test_scoped_parser_closes_source_on_early_exit(self):
         """Test closing a scoped parser closes an unfinished source iterator."""
@@ -156,7 +139,7 @@ diff --git a/file2.txt b/file2.txt
 -old 2
 +new 2
 """
-        patches = list(parse_unified_diff_streaming(diff.encode('utf-8').splitlines(keepends=True)))
+        patches = list(collect_unified_diff(diff.encode('utf-8').splitlines(keepends=True)))
 
         assert len(patches) == 2
         assert patches[0].old_path == "file1.txt"
@@ -174,7 +157,7 @@ index 0000000..abc123
 +first line
 +second line
 """
-        patches = list(parse_unified_diff_streaming(diff.encode('utf-8').splitlines(keepends=True)))
+        patches = list(collect_unified_diff(diff.encode('utf-8').splitlines(keepends=True)))
 
         assert len(patches) == 1
         assert patches[0].old_path == "new.txt"
@@ -193,7 +176,7 @@ index abc123..0000000
 -first line
 -second line
 """
-        patches = list(parse_unified_diff_streaming(diff.encode('utf-8').splitlines(keepends=True)))
+        patches = list(collect_unified_diff(diff.encode('utf-8').splitlines(keepends=True)))
 
         assert len(patches) == 1
         assert patches[0].old_path == "deleted.txt"
@@ -202,7 +185,7 @@ index abc123..0000000
 
     def test_empty_diff(self):
         """Test parsing an empty diff."""
-        patches = list(parse_unified_diff_streaming([]))
+        patches = list(collect_unified_diff([]))
         assert patches == []
 
     def test_no_newline_marker(self):
@@ -216,7 +199,7 @@ diff --git a/file.txt b/file.txt
 \\ No newline at end of file
 +new line
 """
-        patches = list(parse_unified_diff_streaming(diff.encode('utf-8').splitlines(keepends=True)))
+        patches = list(collect_unified_diff(diff.encode('utf-8').splitlines(keepends=True)))
 
         assert len(patches) == 1
         # Should include the backslash line
@@ -232,7 +215,7 @@ diff --git a/path with spaces/file.txt b/path with spaces/file.txt
 -old
 +new
 """
-        patches = list(parse_unified_diff_streaming(diff.encode('utf-8').splitlines(keepends=True)))
+        patches = list(collect_unified_diff(diff.encode('utf-8').splitlines(keepends=True)))
 
         assert len(patches) == 1
         assert patches[0].old_path == "path with spaces/file.txt"
@@ -259,7 +242,7 @@ diff --git a/file2.py b/file2.py
  import sys
 +import os
 """
-        patches = list(parse_unified_diff_streaming(diff.encode('utf-8').splitlines(keepends=True)))
+        patches = list(collect_unified_diff(diff.encode('utf-8').splitlines(keepends=True)))
 
         assert len(patches) == 3
         assert patches[0].old_path == "file1.py"

--- a/tests/core/test_diff_parser.py
+++ b/tests/core/test_diff_parser.py
@@ -7,12 +7,35 @@ import subprocess
 import pytest
 
 from git_stage_batch.core.diff_parser import (
+    acquire_unified_diff,
     build_line_changes_from_patch_lines,
+    detach_single_hunk_patch,
     parse_unified_diff_streaming,
     write_snapshots_for_selected_file_path,
 )
+from git_stage_batch.core.models import SingleHunkPatch
+from git_stage_batch.editor import EditorBuffer
 from git_stage_batch.utils.file_io import read_text_file_contents
 from git_stage_batch.utils.paths import get_index_snapshot_file_path, get_working_tree_snapshot_file_path
+
+
+def _two_hunk_diff_lines() -> list[bytes]:
+    diff = """\
+diff --git a/file.txt b/file.txt
+--- a/file.txt
++++ b/file.txt
+@@ -1,3 +1,3 @@
+ context
+-old 1
++new 1
+ context
+@@ -10,3 +10,3 @@
+ context
+-old 2
++new 2
+ context
+"""
+    return diff.encode("utf-8").splitlines(keepends=True)
 
 
 class TestParseUnifiedDiff:
@@ -44,28 +67,78 @@ index abc123..def456 100644
 
     def test_single_file_multiple_hunks(self):
         """Test parsing a diff with one file and multiple hunks."""
-        diff = """\
-diff --git a/file.txt b/file.txt
---- a/file.txt
-+++ b/file.txt
-@@ -1,3 +1,3 @@
- context
--old 1
-+new 1
- context
-@@ -10,3 +10,3 @@
- context
--old 2
-+new 2
- context
-"""
-        patches = list(parse_unified_diff_streaming(diff.encode('utf-8').splitlines(keepends=True)))
+        patches = list(parse_unified_diff_streaming(_two_hunk_diff_lines()))
 
         assert len(patches) == 2
         assert patches[0].old_path == "file.txt"
         assert patches[1].old_path == "file.txt"
         assert b"@@ -1,3 +1,3 @@" in patches[0].lines[2]
         assert b"@@ -10,3 +10,3 @@" in patches[1].lines[2]
+
+    def test_scoped_parser_uses_editor_buffers(self):
+        """Test scoped parsing returns buffer-backed hunk payloads."""
+        with acquire_unified_diff(_two_hunk_diff_lines()) as patches:
+            patch = next(patches)
+
+            assert isinstance(patch, SingleHunkPatch)
+            assert isinstance(patch.lines, EditorBuffer)
+            assert b"".join(patch.lines).startswith(b"--- a/file.txt\n")
+
+        with pytest.raises(ValueError, match="buffer is closed"):
+            list(patch.lines)
+
+    def test_scoped_parser_releases_previous_hunk_on_advance(self):
+        """Test advancing a scoped parser closes the prior hunk payload."""
+        with acquire_unified_diff(_two_hunk_diff_lines()) as patches:
+            first = next(patches)
+            assert isinstance(first, SingleHunkPatch)
+            assert b"old 1" in b"".join(first.lines)
+
+            second = next(patches)
+            assert isinstance(second, SingleHunkPatch)
+            assert b"old 2" in b"".join(second.lines)
+
+            with pytest.raises(ValueError, match="buffer is closed"):
+                list(first.lines)
+
+        with pytest.raises(ValueError, match="buffer is closed"):
+            list(second.lines)
+
+    def test_detached_scoped_patch_survives_parser_close(self):
+        """Test detached scoped patches keep list-backed line payloads."""
+        with acquire_unified_diff(_two_hunk_diff_lines()) as patches:
+            patch = next(patches)
+            detached = detach_single_hunk_patch(patch)
+
+        assert isinstance(detached.lines, list)
+        assert b"old 1" in b"".join(detached.lines)
+
+    def test_compatibility_parser_returns_detached_patches(self):
+        """Test compatibility parsing keeps patch lines usable after iteration."""
+        patches = list(parse_unified_diff_streaming(_two_hunk_diff_lines()))
+
+        assert isinstance(patches[0].lines, list)
+        assert b"old 1" in b"".join(patches[0].lines)
+
+    def test_scoped_parser_closes_source_on_early_exit(self):
+        """Test closing a scoped parser closes an unfinished source iterator."""
+        source_closed = False
+
+        def source():
+            nonlocal source_closed
+            try:
+                yield from _two_hunk_diff_lines()
+            finally:
+                source_closed = True
+
+        with acquire_unified_diff(source()) as patches:
+            patch = next(patches)
+            assert isinstance(patch, SingleHunkPatch)
+            assert b"old 1" in b"".join(patch.lines)
+
+        assert source_closed
+        with pytest.raises(ValueError, match="buffer is closed"):
+            list(patch.lines)
 
     def test_multiple_files(self):
         """Test parsing a diff with multiple files."""

--- a/tests/core/test_diff_parser_edge_cases.py
+++ b/tests/core/test_diff_parser_edge_cases.py
@@ -1,4 +1,4 @@
-"""Comprehensive edge case tests for parse_unified_diff_streaming.
+"""Comprehensive edge case tests for collect_unified_diff.
 
 Tests for handling:
 - Empty files (new and deleted)
@@ -10,7 +10,7 @@ Tests for handling:
 
 from git_stage_batch.core.models import BinaryFileChange, GitlinkChange, SingleHunkPatch
 
-from git_stage_batch.core.diff_parser import parse_unified_diff_streaming
+from tests.diff_parser_helpers import collect_unified_diff
 
 
 class TestEmptyFileDeletion:
@@ -34,7 +34,7 @@ index abc1234..def5678 100644
 +new line
  line3
 """
-        patches = list(parse_unified_diff_streaming(diff.splitlines(keepends=True)))
+        patches = list(collect_unified_diff(diff.splitlines(keepends=True)))
 
         # Should parse the normal.txt patch (empty.txt has no hunks)
         assert len(patches) == 1
@@ -59,7 +59,7 @@ index 0000000..83db48f
 +line2
 +line3
 """
-        patches = list(parse_unified_diff_streaming(diff.splitlines(keepends=True)))
+        patches = list(collect_unified_diff(diff.splitlines(keepends=True)))
 
         assert len(patches) == 1
         assert patches[0].new_path == "new.txt"
@@ -86,7 +86,7 @@ index abc1234..def5678 100644
  line1
 +line2
 """
-        patches = list(parse_unified_diff_streaming(diff.splitlines(keepends=True)))
+        patches = list(collect_unified_diff(diff.splitlines(keepends=True)))
 
         # Should only parse normal.txt (the empty files have no hunks)
         assert len(patches) == 1
@@ -112,7 +112,7 @@ index abc1234..def5678 100644
  line1
 +line2
 """
-        patches = list(parse_unified_diff_streaming(diff.splitlines(keepends=True)))
+        patches = list(collect_unified_diff(diff.splitlines(keepends=True)))
 
         # Empty files now yield a synthetic patch with @@ -0,0 +0,0 @@
         assert len(patches) == 2
@@ -144,7 +144,7 @@ index abc1234..def5678 100644
 +line2
 """
 
-        patches = list(parse_unified_diff_streaming(diff.splitlines(keepends=True)))
+        patches = list(collect_unified_diff(diff.splitlines(keepends=True)))
 
         # Should parse both: binary file as BinaryFileChange and text file as SingleHunkPatch
         assert len(patches) == 2
@@ -176,7 +176,7 @@ index ghi789..jkl012 100644
 +lineB
 """
 
-        patches = list(parse_unified_diff_streaming(diff.splitlines(keepends=True)))
+        patches = list(collect_unified_diff(diff.splitlines(keepends=True)))
 
         # Should parse all three: text, binary, text
         assert len(patches) == 3
@@ -197,7 +197,7 @@ index 0000000..abc1234
 Binary files /dev/null and b/new_image.jpg differ
 """
 
-        patches = list(parse_unified_diff_streaming(diff.splitlines(keepends=True)))
+        patches = list(collect_unified_diff(diff.splitlines(keepends=True)))
 
         assert len(patches) == 1
         assert isinstance(patches[0], BinaryFileChange)
@@ -217,7 +217,7 @@ index def5678..0000000
 Binary files a/old_image.png and /dev/null differ
 """
 
-        patches = list(parse_unified_diff_streaming(diff.splitlines(keepends=True)))
+        patches = list(collect_unified_diff(diff.splitlines(keepends=True)))
 
         assert len(patches) == 1
         assert isinstance(patches[0], BinaryFileChange)
@@ -246,7 +246,7 @@ index 1111111..2222222 160000
 +Subproject commit """ + new_oid + b"""
 """
 
-        patches = list(parse_unified_diff_streaming(diff.splitlines(keepends=True)))
+        patches = list(collect_unified_diff(diff.splitlines(keepends=True)))
 
         assert len(patches) == 1
         assert isinstance(patches[0], GitlinkChange)
@@ -269,7 +269,7 @@ index 0000000..3333333
 +Subproject commit """ + new_oid + b"""
 """
 
-        patches = list(parse_unified_diff_streaming(diff.splitlines(keepends=True)))
+        patches = list(collect_unified_diff(diff.splitlines(keepends=True)))
 
         assert len(patches) == 1
         assert isinstance(patches[0], GitlinkChange)
@@ -292,7 +292,7 @@ index 4444444..0000000
 -Subproject commit """ + old_oid + b"""
 """
 
-        patches = list(parse_unified_diff_streaming(diff.splitlines(keepends=True)))
+        patches = list(collect_unified_diff(diff.splitlines(keepends=True)))
 
         assert len(patches) == 1
         assert isinstance(patches[0], GitlinkChange)
@@ -321,7 +321,7 @@ index abc1234..def5678 100644
 +next
 """
 
-        patches = list(parse_unified_diff_streaming(diff.splitlines(keepends=True)))
+        patches = list(collect_unified_diff(diff.splitlines(keepends=True)))
 
         assert len(patches) == 2
         assert isinstance(patches[0], GitlinkChange)
@@ -342,7 +342,7 @@ index abc1234..def5678 100644
 +next
 """
 
-        patches = list(parse_unified_diff_streaming(diff.splitlines(keepends=True)))
+        patches = list(collect_unified_diff(diff.splitlines(keepends=True)))
 
         assert len(patches) == 2
         assert isinstance(patches[0], GitlinkChange)
@@ -370,7 +370,7 @@ index abc1234..def5678 100644
  line1
 +line2
 """
-        patches = list(parse_unified_diff_streaming(diff.splitlines(keepends=True)))
+        patches = list(collect_unified_diff(diff.splitlines(keepends=True)))
 
         # Should parse other.txt (renamed file has no hunks)
         assert len(patches) == 1
@@ -392,7 +392,7 @@ index abc1234..def5678 100644
 +new line
  line3
 """
-        patches = list(parse_unified_diff_streaming(diff.splitlines(keepends=True)))
+        patches = list(collect_unified_diff(diff.splitlines(keepends=True)))
 
         assert len(patches) == 1
         assert patches[0].old_path == "old_name.txt"
@@ -416,7 +416,7 @@ index abc1234..def5678 100644
  line1
 +line2
 """
-        patches = list(parse_unified_diff_streaming(diff.splitlines(keepends=True)))
+        patches = list(collect_unified_diff(diff.splitlines(keepends=True)))
 
         # Should parse other.txt (mode change has no hunks)
         assert len(patches) == 1
@@ -436,7 +436,7 @@ index abc1234..def5678
  echo "hello"
 +echo "world"
 """
-        patches = list(parse_unified_diff_streaming(diff.splitlines(keepends=True)))
+        patches = list(collect_unified_diff(diff.splitlines(keepends=True)))
 
         assert len(patches) == 1
         assert patches[0].new_path == "script.sh"
@@ -484,7 +484,7 @@ index ghi789..jkl012 100644
 +lineB
 """
 
-        patches = list(parse_unified_diff_streaming(diff.splitlines(keepends=True)))
+        patches = list(collect_unified_diff(diff.splitlines(keepends=True)))
 
         # Should parse files with hunks plus binary file and empty new file
         # Expected: new_empty.txt (empty), image.png (binary), normal1.txt, normal2.txt
@@ -526,7 +526,7 @@ index 0000000..7654321
 +def func_b():
 +    return 'B'
 """
-        patches = list(parse_unified_diff_streaming(diff.splitlines(keepends=True)))
+        patches = list(collect_unified_diff(diff.splitlines(keepends=True)))
 
         # Should parse both file_a.py and file_b.py
         # The deleted_intent.py has no hunks
@@ -565,7 +565,7 @@ index mno345..pqr678 100644
 """
         # Take only first patch
         patches = []
-        for patch in parse_unified_diff_streaming(diff.splitlines(keepends=True)):
+        for patch in collect_unified_diff(diff.splitlines(keepends=True)):
             patches.append(patch)
             break
 

--- a/tests/core/test_encoding_and_line_endings.py
+++ b/tests/core/test_encoding_and_line_endings.py
@@ -14,10 +14,10 @@ import subprocess
 import pytest
 
 from git_stage_batch.core.diff_parser import (
-    parse_unified_diff_streaming,
     build_line_changes_from_patch_lines,
 )
 from git_stage_batch.core.models import LineEntry
+from tests.diff_parser_helpers import collect_unified_diff
 from git_stage_batch.utils.git import stream_git_command
 
 
@@ -58,7 +58,7 @@ class TestCRLFLineEndings:
         test_file.write_bytes(b"line1\r\nmodified\r\nline3\r\n")
 
         # Parse diff
-        patches = list(parse_unified_diff_streaming(stream_git_command(["diff", "--no-color"])))
+        patches = list(collect_unified_diff(stream_git_command(["diff", "--no-color"])))
 
         assert len(patches) == 1
         patch = patches[0]
@@ -124,7 +124,7 @@ class TestMixedLineEndings:
         test_file.write_bytes(modified_content)
 
         # Parse diff
-        patches = list(parse_unified_diff_streaming(stream_git_command(["diff", "--no-color"])))
+        patches = list(collect_unified_diff(stream_git_command(["diff", "--no-color"])))
         assert len(patches) == 1
 
         # Build selected lines
@@ -203,7 +203,7 @@ class TestLatin1Encoding:
         test_file.write_bytes(modified_content)
 
         # Should parse without crashing
-        patches = list(parse_unified_diff_streaming(stream_git_command(["diff", "--no-color"])))
+        patches = list(collect_unified_diff(stream_git_command(["diff", "--no-color"])))
         assert len(patches) == 1
 
         # Build selected lines - should decode with replacement character
@@ -230,7 +230,7 @@ class TestLatin1Encoding:
         subprocess.run(["git", "commit", "-m", "Add Latin-1"], check=True, cwd=temp_git_repo, capture_output=True)
 
         test_file.write_bytes(b"cafe\nna\xefve modified\n")
-        patches = list(parse_unified_diff_streaming(stream_git_command(["diff", "--no-color"])))
+        patches = list(collect_unified_diff(stream_git_command(["diff", "--no-color"])))
         expected_patch = b"".join(patches[0].lines)
 
         command_start(quiet=True)
@@ -339,7 +339,7 @@ class TestBinaryContent:
 
         # Git will treat this as binary and show "Binary files differ"
         # Our code should handle this gracefully
-        list(parse_unified_diff_streaming(stream_git_command(["diff", "--no-color"])))
+        list(collect_unified_diff(stream_git_command(["diff", "--no-color"])))
 
         # Git doesn't create unified diffs for binary files
         # So we might get 0 patches or a special binary indicator
@@ -364,7 +364,7 @@ class TestInvalidUTF8Sequences:
         test_file.write_bytes(modified_content)
 
         # Should parse without crashing
-        patches = list(parse_unified_diff_streaming(stream_git_command(["diff", "--no-color"])))
+        patches = list(collect_unified_diff(stream_git_command(["diff", "--no-color"])))
         assert len(patches) == 1
 
         # Build selected lines
@@ -396,7 +396,7 @@ class TestLineEndingEdgeCases:
         test_file.write_bytes(b"line1\nchanged")  # Still no final \n
 
         # Should parse correctly
-        patches = list(parse_unified_diff_streaming(stream_git_command(["diff", "--no-color"])))
+        patches = list(collect_unified_diff(stream_git_command(["diff", "--no-color"])))
         assert len(patches) == 1
 
         # Git adds "\ No newline at end of file" - we should handle this
@@ -414,7 +414,7 @@ class TestLineEndingEdgeCases:
         test_file.write_bytes(b"line1\rchanged\rline3\r")
 
         # Parse diff
-        list(parse_unified_diff_streaming(stream_git_command(["diff", "--no-color"])))
+        list(collect_unified_diff(stream_git_command(["diff", "--no-color"])))
 
         # Git treats CR as part of the line content (not a line separator)
         # So this might show as one big line or git might handle it specially
@@ -432,7 +432,7 @@ class TestLineEndingEdgeCases:
         test_file.write_bytes(b"line1\r\n\r\nchanged\r\n")
 
         # Should parse correctly
-        patches = list(parse_unified_diff_streaming(stream_git_command(["diff", "--no-color"])))
+        patches = list(collect_unified_diff(stream_git_command(["diff", "--no-color"])))
         assert len(patches) == 1
 
         patch_bytes = b"".join(patches[0].lines)
@@ -454,7 +454,7 @@ class TestDiffParserBytesHandling:
             b"-old\n",
             b"+new\n",
         ]
-        patches = list(parse_unified_diff_streaming(diff_lines))
+        patches = list(collect_unified_diff(diff_lines))
         assert len(patches) == 1
         # Filename should be decoded as UTF-8
         assert "café" in patches[0].new_path

--- a/tests/data/test_hunk_tracking.py
+++ b/tests/data/test_hunk_tracking.py
@@ -2,7 +2,7 @@
 
 import json
 from git_stage_batch.core.hashing import compute_stable_hunk_hash_from_lines
-from git_stage_batch.core.diff_parser import parse_unified_diff_streaming
+from tests.diff_parser_helpers import collect_unified_diff
 from git_stage_batch.utils.paths import get_blocked_files_file_path
 from git_stage_batch.utils.file_io import append_file_path_to_file
 from git_stage_batch.exceptions import NoMoreHunks
@@ -176,7 +176,7 @@ class TestFindAndCacheNextUnblockedHunk:
             cwd=temp_git_repo,
             capture_output=True,)
         stdout_bytes = result.stdout if isinstance(result.stdout, bytes) else result.stdout.encode("utf-8")
-        patches = list(parse_unified_diff_streaming(stdout_bytes.splitlines(keepends=True)))
+        patches = list(collect_unified_diff(stdout_bytes.splitlines(keepends=True)))
         first_hash = compute_stable_hunk_hash_from_lines(patches[0].lines)
 
         append_lines_to_file(get_block_list_file_path(), [first_hash])
@@ -234,7 +234,7 @@ class TestFindAndCacheNextUnblockedHunk:
             cwd=temp_git_repo,
             capture_output=True,)
         stdout_bytes = result.stdout if isinstance(result.stdout, bytes) else result.stdout.encode("utf-8")
-        patches = list(parse_unified_diff_streaming(stdout_bytes.splitlines(keepends=True)))
+        patches = list(collect_unified_diff(stdout_bytes.splitlines(keepends=True)))
         hunk_hash = compute_stable_hunk_hash_from_lines(patches[0].lines)
 
         append_lines_to_file(get_block_list_file_path(), [hunk_hash])
@@ -562,7 +562,7 @@ class TestRecalculateCurrentHunkForFile:
             cwd=temp_git_repo,
             capture_output=True,)
         stdout_bytes = result.stdout if isinstance(result.stdout, bytes) else result.stdout.encode("utf-8")
-        patches = list(parse_unified_diff_streaming(stdout_bytes.splitlines(keepends=True)))
+        patches = list(collect_unified_diff(stdout_bytes.splitlines(keepends=True)))
         hunk_hash = compute_stable_hunk_hash_from_lines(patches[0].lines)
 
         append_lines_to_file(get_block_list_file_path(), [hunk_hash])

--- a/tests/diff_parser_helpers.py
+++ b/tests/diff_parser_helpers.py
@@ -1,0 +1,26 @@
+"""Test helpers for unified diff parser assertions."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from git_stage_batch.core.diff_parser import UnifiedDiffItem, acquire_unified_diff
+from git_stage_batch.core.models import SingleHunkPatch
+
+
+def collect_unified_diff(lines: Iterable[bytes]) -> list[UnifiedDiffItem]:
+    """Collect scoped diff items with text hunk payloads materialized."""
+    collected = []
+    with acquire_unified_diff(lines) as items:
+        for item in items:
+            if isinstance(item, SingleHunkPatch):
+                collected.append(
+                    SingleHunkPatch(
+                        old_path=item.old_path,
+                        new_path=item.new_path,
+                        lines=list(item.lines),
+                    )
+                )
+            else:
+                collected.append(item)
+    return collected


### PR DESCRIPTION
The program reads unified diffs for command flows such as status, show,
include, skip, discard, and selected hunk caching. Those flows use parsed
hunk objects to compute hashes, render line-level selections, update state,
and move changes into batches.

Large diffs can make that parsing expensive in memory when every hunk payload
is materialized as a Python list and kept alive longer than the caller needs.
That also makes it hard to reason about ownership of parser-created hunk
payloads, because the parser API returns detached objects by default.

This pull request addresses that by adding a scoped unified diff parser whose
text hunk payloads live in parser-owned `EditorBuffer` instances. Command
paths consume or copy hunk data inside the parser scope, selected-hunk state
continues to persist the bytes it needs, and the old detached compatibility
wrapper is removed after tests move their collection needs into a test-only
helper.

Verification:

- `uv run ruff check src/git_stage_batch/core/diff_parser.py tests/diff_parser_helpers.py tests/core/test_diff_parser.py tests/core/test_diff_parser_edge_cases.py tests/core/test_encoding_and_line_endings.py tests/data/test_hunk_tracking.py tests/batch/test_ownership_hardening.py tests/commands/test_discard_file.py tests/commands/test_show.py`
- `uv run pytest tests/core/test_diff_parser.py tests/core/test_diff_parser_edge_cases.py tests/core/test_encoding_and_line_endings.py tests/data/test_hunk_tracking.py tests/batch/test_ownership_hardening.py tests/commands/test_discard_file.py tests/commands/test_show.py`
