### PR TITLE
batch: Release aligner temporaries before recursion

### DIFF
--- a/src/git_stage_batch/batch/match.py
+++ b/src/git_stage_batch/batch/match.py
@@ -296,6 +296,8 @@ def _align_segment(
     candidate_pairs.sort()
     anchors = _longest_increasing_subsequence(candidate_pairs)
 
+    del source_unique, target_unique, candidate_pairs
+
     if not anchors:
         return
 


### PR DESCRIPTION
The structural line matcher aligns source and target files by mapping equal
prefixes and suffixes, finding lines that are unique in the remaining source
and target segments, and recursing between those trusted anchors.

For large or deeply segmented files, each recursive alignment step builds
temporary maps of unique line positions and candidate anchor pairs. Those
temporaries are only needed until the trusted anchor list is chosen, but they
can otherwise remain live while deeper recursive calls continue.

This pull request addresses that by releasing the unique-position maps and
candidate-pair list before recursive alignment proceeds. The behavior stays
the same; the lifetime of temporary alignment data is narrower.

Verification:

- covered as part of the focused parser and affected command test pass from
  the dependent scoped parser series
