### PR TITLE
project: Run pytest with xdist by default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,9 @@ setup = ["-Dpython_wheel=true"]
 no-build-isolation = true
 preview = true
 
+[tool.pytest.ini_options]
+addopts = ["-n", "auto"]
+
 [tool.uv.extra-build-dependencies]
 git-stage-batch = [
     "meson-python>=0.17.0",


### PR DESCRIPTION
The project has pytest-xdist in the development dependencies and documents
`uv run pytest -n auto` as the full-suite test command.

The test configuration still leaves parallelism to each command invocation.
That means local runs and automation that call pytest through uv can fall
back to the slower serial suite unless they repeat the same option.

This PR addresses that by adding pytest addopts in pyproject.toml so
pytest uses xdist with auto workers by default.

Verification:
- `uv run pytest`