### PR TITLE
batch: Remove batch diff storage helper

### DIFF
--- a/src/git_stage_batch/batch/__init__.py
+++ b/src/git_stage_batch/batch/__init__.py
@@ -21,7 +21,6 @@ from .storage import (
     add_gitlink_to_batch,
     BatchFileUpdate,
     copy_file_from_batch_to_batch,
-    get_batch_diff,
     read_file_from_batch,
 )
 from .validation import batch_exists, validate_batch_name
@@ -38,7 +37,6 @@ __all__ = [
     "delete_batch",
     "get_batch_baseline_commit",
     "get_batch_commit_sha",
-    "get_batch_diff",
     "get_batch_tree_sha",
     "get_validated_baseline_commit",
     "list_batch_files",

--- a/src/git_stage_batch/batch/storage.py
+++ b/src/git_stage_batch/batch/storage.py
@@ -1,9 +1,8 @@
-"""Batch storage operations: file management and diff generation."""
+"""Batch storage operations: file management."""
 
 from __future__ import annotations
 
 import json
-import subprocess
 from collections.abc import Iterator, Sequence
 from copy import deepcopy
 from dataclasses import dataclass
@@ -46,7 +45,6 @@ from ..utils.git import (
     git_update_index_entries,
     git_write_tree,
     run_git_command,
-    stream_git_diff,
     temp_git_index,
 )
 from ..utils.paths import get_batch_metadata_file_path
@@ -752,34 +750,3 @@ def read_file_from_batch(batch_name: str, file_path: str) -> Optional[str]:
         return None
 
     return result.stdout
-
-
-def get_batch_diff(batch_name: str, context_lines: int = 3) -> bytes:
-    """
-    Get the unified diff from baseline to batch.
-
-    This shows what changes the batch represents. Returns empty bytes
-    if baseline cannot be determined or batch doesn't exist.
-    """
-    validate_batch_name(batch_name)
-
-    commit_sha = get_batch_commit_sha(batch_name)
-    if not commit_sha:
-        return b""
-
-    baseline = get_batch_baseline_commit(batch_name)
-    if not baseline:
-        # No baseline, diff against empty tree
-        empty_tree = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
-        baseline = empty_tree
-
-    try:
-        return b"".join(
-            stream_git_diff(
-                base=baseline,
-                target=commit_sha,
-                context_lines=context_lines,
-            )
-        )
-    except subprocess.CalledProcessError:
-        return b""

--- a/tests/batch/test_storage.py
+++ b/tests/batch/test_storage.py
@@ -9,7 +9,7 @@ import pytest
 from git_stage_batch.batch.operations import create_batch
 from git_stage_batch.batch.query import read_batch_metadata
 from git_stage_batch.batch.merge import merge_batch_from_line_sequences_as_buffer
-from git_stage_batch.batch.storage import add_file_to_batch, get_batch_diff, read_file_from_batch
+from git_stage_batch.batch.storage import add_file_to_batch, read_file_from_batch
 from git_stage_batch.batch.ownership import (
     BaselineReference,
     BatchOwnership,
@@ -402,42 +402,3 @@ def test_read_file_from_batch_nonexistent_file(temp_git_repo):
 
     content = read_file_from_batch("test-batch", "nonexistent.txt")
     assert content is None
-
-
-def test_get_batch_diff_empty_batch(temp_git_repo):
-    """Test getting diff for empty batch shows no changes."""
-    create_batch("test-batch", "Test")
-
-    diff = get_batch_diff("test-batch")
-    # Empty batch starts with HEAD's tree, so no diff (same as baseline)
-    assert diff == b""
-
-
-def test_get_batch_diff_with_file(temp_git_repo):
-    """Test getting diff for batch with file."""
-    create_batch("test-batch", "Test")
-
-    # Claim lines from file.txt
-    ownership = BatchOwnership.from_presence_lines(["1-2"], [])
-    add_file_to_batch("test-batch", "file.txt", ownership)
-
-    diff = get_batch_diff("test-batch")
-    assert b"file.txt" in diff
-    assert b"+line" in diff  # Should show added lines
-
-
-def test_get_batch_diff_nonexistent_batch(temp_git_repo):
-    """Test getting diff for nonexistent batch returns empty string."""
-    diff = get_batch_diff("nonexistent")
-    assert diff == b""
-
-
-def test_get_batch_diff_custom_context(temp_git_repo):
-    """Test getting diff with custom context lines."""
-    create_batch("test-batch", "Test")
-
-    ownership = BatchOwnership.from_presence_lines(["1-3"], [])
-    add_file_to_batch("test-batch", "file.txt", ownership)
-
-    diff = get_batch_diff("test-batch", context_lines=1)
-    assert b"file.txt" in diff

--- a/tests/core/test_encoding_and_line_endings.py
+++ b/tests/core/test_encoding_and_line_endings.py
@@ -5,7 +5,7 @@ from git_stage_batch.commands.include import command_include_line
 from git_stage_batch.commands.discard import command_discard_line
 from git_stage_batch.commands.discard import command_discard_to_batch
 from git_stage_batch.batch.operations import create_batch
-from git_stage_batch.batch.storage import get_batch_diff
+from git_stage_batch.batch.query import get_batch_baseline_commit, get_batch_commit_sha
 from git_stage_batch.utils.paths import get_selected_hunk_patch_file_path
 import binascii
 
@@ -18,7 +18,15 @@ from git_stage_batch.core.diff_parser import (
 )
 from git_stage_batch.core.models import LineEntry
 from tests.diff_parser_helpers import collect_unified_diff
-from git_stage_batch.utils.git import stream_git_command
+from git_stage_batch.utils.git import stream_git_command, stream_git_diff
+
+
+def _batch_diff(batch_name: str) -> bytes:
+    commit_sha = get_batch_commit_sha(batch_name)
+    assert commit_sha is not None
+    baseline = get_batch_baseline_commit(batch_name)
+    assert baseline is not None
+    return b"".join(stream_git_diff(base=baseline, target=commit_sha))
 
 
 @pytest.fixture
@@ -91,7 +99,7 @@ class TestCRLFLineEndings:
         assert test_file.read_bytes() == original_content
 
         # Apply from batch using git apply directly
-        batch_diff = get_batch_diff("test-batch")
+        batch_diff = _batch_diff("test-batch")
 
         result = subprocess.run(
             ["git", "apply"],
@@ -298,7 +306,7 @@ class TestLatin1Encoding:
         assert test_file.read_bytes() == original
 
         # Apply from batch directly using git apply
-        batch_diff = get_batch_diff("test-batch")
+        batch_diff = _batch_diff("test-batch")
 
         # Debug: check batch diff content
         print(f"\nBatch diff type: {type(batch_diff)}")


### PR DESCRIPTION
Batch storage persists text, binary, and gitlink content for named batches, while diff rendering already has streaming command paths for callers that need patch text.

The storage module still exposes a helper that materializes an entire batch diff in memory. That leaves an unbounded output path in the runtime API even though production callers do not need that helper.

This pull request resolves that by moving the remaining tests away from the storage helper, deleting direct helper coverage, removing the production helper, and dropping the batch package export.

Validation run:

- uv run ruff check src/git_stage_batch/batch/storage.py src/git_stage_batch/batch/__init__.py tests/batch/test_storage.py tests/core/test_encoding_and_line_endings.py
- uv run pytest tests/batch/test_storage.py tests/core/test_encoding_and_line_endings.py