### PR TITLE
project: Require final commit conclusion paragraphs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,17 +144,19 @@ Use natural prose such as:
 
 #### Fourth Paragraph
 
-Use it for every commit except the final one in a multi-commit series.
-Use future tense because the work has not happened yet, and be specific
-about the next step rather than vague.
+Use it for every commit in a multi-commit series. For non-final commits, use
+future tense because the work has not happened yet, and be specific about the
+next step rather than vague.
 
 For example:
 - `Subsequent commits will provide ...`
 - `In the future, <behavior> will change to ...`
 
 The final commit should conclude the series goal introduced by the opening
-commit. Omit future-looking text unless repository-specific guidance requires
-otherwise. Vary the phrasing across a series.
+commit in a fourth paragraph instead of pointing toward more work. For the
+penultimate commit, refer to the upcoming final commit in the singular, such
+as `The final commit will ...`, instead of saying `subsequent commits`.
+Vary the phrasing across a series.
 
 ### Checklist
 
@@ -175,7 +177,8 @@ Before finalizing a commit message, check:
 - Does the third paragraph open with `This commit` and clearly state what this commit does without overstating its impact?
 - If this is part of a series, does it show progression (e.g., "begins", "continues", "completes")?
 - If this is an incremental step, does it clearly say so?
-- If this commit is not the last in the series, does the fourth paragraph name what subsequent commits will do?
+- If this is the penultimate commit in a series, does the fourth paragraph name what the upcoming final commit will do?
+- If this is an earlier non-final commit in a series, does the fourth paragraph name what subsequent commits will do?
 - Do body paragraphs wrap at 75 characters?
 
 ### Example: Single Commit

--- a/assets/claude-agents/commit-message-drafter.md
+++ b/assets/claude-agents/commit-message-drafter.md
@@ -31,6 +31,7 @@ Expect the caller to provide:
 - whether this is a single commit or part of a series
 - the current commit's one-clause purpose
 - whether this is the final commit in the series
+- whether this is the penultimate commit in the series, when known
 - any repository-specific commit rules already discovered
 - any known preferred prefixes
 
@@ -74,8 +75,11 @@ one fails.
   state in the first paragraph.
 - The second paragraph describes the underlying problem.
 - The third paragraph explains how this commit addresses that problem.
-- Add a forward-looking fourth paragraph only when the caller says this is not
-  the final commit in the series.
+- For a multi-commit series, include a fourth paragraph. If the caller says
+  this is the final commit, make that paragraph a closing conclusion for the
+  series goal. If the caller says this is the penultimate commit, refer to the
+  upcoming final commit in the singular instead of saying `subsequent commits`.
+  For earlier non-final commits, use future-looking text for what remains.
 - If the caller supplied wording bans or line-length limits, obey them.
 
 ## Output format

--- a/assets/claude-skills/commit-staged-changes/SKILL.md
+++ b/assets/claude-skills/commit-staged-changes/SKILL.md
@@ -111,6 +111,7 @@ When the current commit is fully staged, you may use the shared
   - the current commit's one-clause purpose
   - whether this is a single commit or part of a series
   - whether this is the final commit in the series
+  - whether this is the penultimate commit in the series, when known
   - the repository-specific message rules already discovered
   - any preferred prefixes established by history
   - the exact files staged for this commit
@@ -140,7 +141,7 @@ prefix: Summary under 72 chars
 This commit [addresses|mitigates|resolves] that [problem] by
 [precise description of what this commit changes].
 
-[Optional fourth paragraph: what comes next.]
+[Optional fourth paragraph: what comes next, or the final series conclusion.]
 ```
 
 ### Message Rules
@@ -154,8 +155,11 @@ This commit [addresses|mitigates|resolves] that [problem] by
   perspective.
 - The third paragraph starts with `This commit` and precisely explains what
   this commit changes.
-- Add a fourth paragraph only when this commit is part of a larger near-term
-  series and the next step matters.
+- In a multi-commit series, use the fourth paragraph for what comes next or,
+  in the final commit, for the series conclusion.
+- If this is the penultimate commit, refer to the upcoming final commit in the
+  singular, such as `The final commit will ...`, instead of saying
+  `subsequent commits`.
 - Do not use `this` for anything other than `this commit`.
 - Prefer concrete limitations over vague praise.
 

--- a/assets/claude-skills/commit-unstaged-changes/SKILL.md
+++ b/assets/claude-skills/commit-unstaged-changes/SKILL.md
@@ -452,6 +452,7 @@ owned only by this skill.
   - the one-clause purpose of the current commit
   - the exact repository message constraints already discovered
   - whether this is the final commit in the series
+  - whether this is the penultimate commit in the series, when known
   - the exact files staged for this commit
   - instructions to inspect `git diff --cached`, relevant `git log` history,
     `CONTRIBUTING.md`, and `.git/hooks/commit-msg` if present
@@ -647,9 +648,11 @@ This commit [addresses|mitigates|resolves] that [problem] by [precise
 description of what this commit changes and how it solves the problem
 stated above].
 
-[Connect to what comes next. Omit this paragraph for the final commit in the
-series. For the final commit, use the preceding paragraph or a short closing
-paragraph to state that the series goal has been reached.]
+[Connect to what comes next, or conclude the series when this is the final
+commit. For the penultimate commit, refer to the upcoming final commit in the
+singular, such as "The final commit will ...", instead of saying "subsequent
+commits". For the final commit, use this paragraph to state that the series
+goal has been reached.]
 ```
 
 The most common errors are:
@@ -730,11 +733,14 @@ Fourth paragraph for follow-up or final series conclusion when useful.
 
 ### Fourth paragraph
 
-- Use it for every commit except the final one in a multi-commit series.
-- Use future tense since the work has not happened yet.
+- Use it for every commit in a multi-commit series.
+- For non-final commits, use future tense since the work has not happened yet.
 - Be specific about what comes next rather than vague.
+- For the penultimate commit, refer to the upcoming final commit in the
+  singular, such as `The final commit will ...`, instead of saying
+  `subsequent commits`.
 - The final commit should conclude the series goal introduced by the opening
-  commit instead of pointing toward more work.
+  commit in a fourth paragraph instead of pointing toward more work.
 
 ## Required principles
 
@@ -808,8 +814,10 @@ Before committing, verify:
   series goal rather than only the first change.
 - If this is the final commit in a series, the message concludes the series
   goal rather than reading like another incremental step.
-- If the commit is not the last in the series, the fourth paragraph names what
-  subsequent commits will do.
+- If this is the penultimate commit in the series, the fourth paragraph names
+  what the upcoming final commit will do.
+- If the commit is an earlier non-final step in the series, the fourth
+  paragraph names what subsequent commits will do.
 - Body paragraphs wrap at 75 characters.
 
 ## Completion

--- a/assets/codex-skills/commit-staged-changes/SKILL.md
+++ b/assets/codex-skills/commit-staged-changes/SKILL.md
@@ -76,6 +76,7 @@ If you spawn a subagent for message drafting:
    - the current commit's one-clause purpose
    - whether this is a single commit or part of a series
    - whether this is the final commit in the series
+   - whether this is the penultimate commit in the series, when known
    - the repository-specific message rules already discovered
    - any preferred prefixes established by history
    - the exact files staged for this commit
@@ -114,7 +115,7 @@ prefix: Summary under 72 chars
 This commit [addresses|mitigates|resolves] that [problem] by
 [precise description of what this commit changes].
 
-[Optional fourth paragraph: what comes next.]
+[Optional fourth paragraph: what comes next, or the final series conclusion.]
 ```
 
 ### Message Rules
@@ -128,8 +129,11 @@ This commit [addresses|mitigates|resolves] that [problem] by
   perspective.
 - The third paragraph starts with `This commit` and precisely explains what
   this commit changes.
-- Add a fourth paragraph only when this commit is part of a larger near-term
-  series and the next step matters.
+- In a multi-commit series, use the fourth paragraph for what comes next or,
+  in the final commit, for the series conclusion.
+- If this is the penultimate commit, refer to the upcoming final commit in the
+  singular, such as `The final commit will ...`, instead of saying
+  `subsequent commits`.
 - Do not use `this` for anything other than `this commit`.
 - Prefer concrete limitations over vague praise.
 

--- a/assets/codex-skills/commit-unstaged-changes/SKILL.md
+++ b/assets/codex-skills/commit-unstaged-changes/SKILL.md
@@ -654,6 +654,7 @@ If you spawn a subagent for message drafting:
    - which independent series this commit belongs to when the unstaged tree
      contains more than one
    - whether this is the final commit in the series
+   - whether this is the penultimate commit in the series, when known
    - the repository-specific message rules already discovered
    - any preferred prefixes already established by history
    - the exact files staged for this commit
@@ -913,9 +914,11 @@ This commit [addresses|mitigates|resolves] that [problem] by [precise
 description of what this commit changes and how it solves the problem
 stated above].
 
-[Connect to what comes next. Omit this paragraph for the final
-commit in the series. For the final commit, use the preceding paragraph
-or a short closing paragraph to state that the series goal has been reached.]
+[Connect to what comes next, or conclude the series when this is the
+final commit. For the penultimate commit, refer to the upcoming final
+commit in the singular, such as "The final commit will ...", instead
+of saying "subsequent commits". For the final commit, use this
+paragraph to state that the series goal has been reached.]
 ```
 
 ### First Line (Summary)
@@ -1005,8 +1008,8 @@ Use natural prose such as:
 
 ### Fourth Paragraph
 
-Use it for every commit except the final one in a multi-commit series.
-Use future tense because the work has not happened yet, and be specific
+Use it for every commit in a multi-commit series. For non-final commits,
+use future tense because the work has not happened yet, and be specific
 about the next step rather than vague.
 
 For example:
@@ -1014,8 +1017,10 @@ For example:
 - `In the future, <behavior> will change to ...`
 
 The final commit should conclude the series goal introduced by the opening
-commit. Omit future-looking text unless repository-specific guidance requires
-otherwise. Vary the phrasing across a series.
+commit in a fourth paragraph instead of pointing toward more work. For the
+penultimate commit, refer to the upcoming final commit in the singular, such
+as `The final commit will ...`, instead of saying `subsequent commits`.
+Vary the phrasing across a series.
 
 The most common errors are opening with the problem, merging the
 first and second paragraphs with `but` or `however`, and using
@@ -1144,7 +1149,9 @@ Before finalizing a commit message, check:
 - If this is part of a series, does it show progression (e.g.,
   "begins", "continues", "completes")?
 - If this is an incremental step, does it clearly say so?
-- If this commit is not the last in the series, does the fourth
+- If this is the penultimate commit in a series, does the fourth paragraph
+  name what the upcoming final commit will do?
+- If this is an earlier non-final commit in a series, does the fourth
   paragraph name what subsequent commits will do?
 - Do body paragraphs wrap at 75 characters?
 
@@ -1544,8 +1551,10 @@ Before committing, verify:
   series goal rather than only the first change.
 - If this is the final commit in a series, the message concludes the series
   goal rather than reading like another incremental step.
-- If the commit is not the last in the series, the fourth paragraph names what
-  subsequent commits will do.
+- If this is the penultimate commit in the series, the fourth paragraph names
+  what the upcoming final commit will do.
+- If the commit is an earlier non-final step in the series, the fourth
+  paragraph names what subsequent commits will do.
 - Body paragraphs wrap at 75 characters.
 
 The most common errors are:

--- a/assets/codex-skills/internal/commit-message-drafter.md
+++ b/assets/codex-skills/internal/commit-message-drafter.md
@@ -28,6 +28,7 @@ Expect the caller to provide:
 - whether this is a single commit or part of a series
 - the current commit's one-clause purpose
 - whether this is the final commit in the series
+- whether this is the penultimate commit in the series, when known
 - any repository-specific commit rules already discovered
 - any known preferred prefixes
 
@@ -61,8 +62,11 @@ Prefer the smallest number of commands that gives a confident answer.
   project's state during a multi-commit series.
 - The second paragraph describes the underlying problem.
 - The third paragraph explains how this commit addresses that problem.
-- Add a forward-looking fourth paragraph only when the caller says this is not
-  the final commit in the series.
+- For a multi-commit series, include a fourth paragraph. If the caller says
+  this is the final commit, make that paragraph a closing conclusion for the
+  series goal. If the caller says this is the penultimate commit, refer to the
+  upcoming final commit in the singular instead of saying `subsequent commits`.
+  For earlier non-final commits, use future-looking text for what remains.
 - If the caller supplied wording bans or line-length limits, obey them.
 
 ## Output Format


### PR DESCRIPTION
The project documents commit-message expectations in CONTRIBUTING.md and mirrors those rules through bundled Claude and Codex commit workflow assets.

The series guidance still lets final commits look slightly different than the others, not using the fourth paragraph to tie the series together. And, it gives penultimate commits plural follow-up wording when there is only one commit that follows.

This PR addresses that by requiring fourth paragraphs across multi-commit series, teaching penultimate commits to refer to the final commit in the singular, and carrying the same rule through the Claude and Codex drafter and skill assets.

With both assistant families aligned to the repository guidance, the bundled commit workflows now close the thread opened by the first commit instead of dropping the final series conclusion.

Tested with `uv run pytest tests/commands/test_install_assets.py`.