### PR TITLE
batch: Match with scoped line views

### DIFF
--- a/src/git_stage_batch/batch/match.py
+++ b/src/git_stage_batch/batch/match.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 from array import array
-from collections.abc import Sequence
+from collections.abc import Hashable, Sequence
+from contextlib import nullcontext
 from dataclasses import dataclass
-from typing import TypeVar
+from typing import Any, TypeVar
 
 
-LineContent = TypeVar("LineContent", bytes, str)
+LineContent = TypeVar("LineContent", bound=Hashable)
 _MAX_UINT32 = (1 << 32) - 1
 
 
@@ -74,6 +75,13 @@ def _lookup_line_mapping(mapping: array, line_number: int) -> int | None:
     if mapped_line == 0:
         return None
     return mapped_line
+
+
+def _acquire_line_sequence(lines: Sequence[LineContent]) -> Any:
+    acquire_lines = getattr(lines, "acquire_lines", None)
+    if acquire_lines is None:
+        return nullcontext(lines)
+    return acquire_lines()
 
 
 def _build_unique_position_map(
@@ -361,21 +369,29 @@ def match_lines(
     source_to_target: array
     target_to_source: array
     max_line_number: int
+    source_line_count: int
+    target_line_count: int
 
-    max_line_number = max(len(source_lines), len(target_lines))
-    source_to_target = _new_line_mapping(len(source_lines), max_line_number)
-    target_to_source = _new_line_mapping(len(target_lines), max_line_number)
+    source_line_count = len(source_lines)
+    target_line_count = len(target_lines)
+    max_line_number = max(source_line_count, target_line_count)
+    source_to_target = _new_line_mapping(source_line_count, max_line_number)
+    target_to_source = _new_line_mapping(target_line_count, max_line_number)
 
-    _align_segment(
-        source_lines,
-        target_lines,
-        0,
-        len(source_lines),
-        0,
-        len(target_lines),
-        source_to_target,
-        target_to_source
-    )
+    with (
+        _acquire_line_sequence(source_lines) as acquired_source_lines,
+        _acquire_line_sequence(target_lines) as acquired_target_lines,
+    ):
+        _align_segment(
+            acquired_source_lines,
+            acquired_target_lines,
+            0,
+            source_line_count,
+            0,
+            target_line_count,
+            source_to_target,
+            target_to_source
+        )
 
     return LineMapping(
         source_to_target=source_to_target,

--- a/src/git_stage_batch/editor/buffer.py
+++ b/src/git_stage_batch/editor/buffer.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Sequence
+from contextlib import nullcontext
 import mmap
 import os
 from pathlib import Path
 import tempfile
-from typing import BinaryIO, Generic, Iterator, TypeVar, overload
+from typing import Any, BinaryIO, Generic, Iterator, TypeVar, overload
 
 
 _DEFAULT_CHUNK_SIZE = 1024 * 1024
@@ -425,6 +426,13 @@ class _BufferLineSliceSequence(Sequence[_LineT], Generic[_LineT]):
     def __len__(self) -> int:
         return len(range(*self._resolved_range()))
 
+    def acquire_lines(self) -> Any:
+        """Return a context manager for acquired lines from this slice."""
+        acquire_lines = getattr(self._parent, "acquire_lines", None)
+        if acquire_lines is None:
+            return nullcontext(self)
+        return _AcquiredBufferLineSliceContext(acquire_lines(), self._slice)
+
     @overload
     def __getitem__(self, index: int) -> _LineT: ...
 
@@ -478,6 +486,24 @@ class _BufferLineSliceSequence(Sequence[_LineT], Generic[_LineT]):
 
     def _resolved_range(self) -> tuple[int, int, int]:
         return self._slice.indices(len(self._parent))
+
+
+class _AcquiredBufferLineSliceContext:
+    """Context manager for acquired line views from a slice sequence."""
+
+    def __init__(self, parent_context: Any, line_slice: slice) -> None:
+        self._parent_context = parent_context
+        self._slice = line_slice
+        self._lines: Sequence[Any] | None = None
+
+    def __enter__(self) -> Sequence[Any]:
+        parent = self._parent_context.__enter__()
+        self._lines = _BufferLineSliceSequence(parent, self._slice)
+        return self._lines
+
+    def __exit__(self, exc_type, exc, traceback) -> Any:
+        self._lines = None
+        return self._parent_context.__exit__(exc_type, exc, traceback)
 
 
 def _slice_uses_negative_bounds(line_slice: slice) -> bool:

--- a/src/git_stage_batch/editor/buffer.py
+++ b/src/git_stage_batch/editor/buffer.py
@@ -7,11 +7,12 @@ import mmap
 import os
 from pathlib import Path
 import tempfile
-from typing import BinaryIO, Iterator, overload
+from typing import BinaryIO, Generic, Iterator, TypeVar, overload
 
 
 _DEFAULT_CHUNK_SIZE = 1024 * 1024
 _BytesLike = bytes | bytearray | memoryview
+_LineT = TypeVar("_LineT")
 
 
 class EditorBuffer(Sequence[bytes]):
@@ -139,6 +140,14 @@ class EditorBuffer(Sequence[bytes]):
     def __exit__(self, exc_type, exc, traceback) -> None:
         self.close()
 
+    def acquire_line(self, index: int) -> _AcquiredBufferLineContext:
+        """Return a context manager for a scoped no-copy line view."""
+        return _AcquiredBufferLineContext(self, index)
+
+    def acquire_lines(self) -> _AcquiredBufferLineSequence:
+        """Return a context manager for scoped no-copy line views."""
+        return _AcquiredBufferLineSequence(self)
+
     def __len__(self) -> int:
         self._scan_all_lines()
         return len(self._line_spans)
@@ -204,12 +213,208 @@ class EditorBuffer(Sequence[bytes]):
             self._scan_complete = True
 
 
-class _BufferLineSliceSequence(Sequence[bytes]):
+class _BufferLineView:
+    """Scoped no-copy view over one editor buffer line."""
+
+    __slots__ = ("_owner", "_start", "_end", "_hash")
+
+    def __init__(
+        self,
+        owner: _AcquiredBufferLineSequence,
+        start: int,
+        end: int,
+    ) -> None:
+        self._owner = owner
+        self._start = start
+        self._end = end
+        self._hash: int | None = None
+
+    def __bytes__(self) -> bytes:
+        view = self._memoryview()
+        try:
+            return bytes(view)
+        finally:
+            view.release()
+
+    def __len__(self) -> int:
+        self._require_active()
+        return self._end - self._start
+
+    @overload
+    def __getitem__(self, index: int) -> int: ...
+
+    @overload
+    def __getitem__(self, index: slice) -> bytes: ...
+
+    def __getitem__(self, index: int | slice) -> int | bytes:
+        view = self._memoryview()
+        try:
+            result = view[index]
+            if isinstance(index, slice):
+                try:
+                    return bytes(result)
+                finally:
+                    result.release()
+            return result
+        finally:
+            view.release()
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, _BufferLineView):
+            return self._equals_line_view(other)
+
+        if isinstance(other, (bytes, bytearray, memoryview)):
+            view = self._memoryview()
+            try:
+                return view == other
+            finally:
+                view.release()
+
+        return NotImplemented
+
+    def __hash__(self) -> int:
+        self._require_active()
+        if self._hash is not None:
+            return self._hash
+
+        view = self._memoryview()
+        try:
+            self._hash = hash(view)
+            return self._hash
+        finally:
+            view.release()
+
+    def __repr__(self) -> str:
+        if not self._owner.is_active:
+            return "<EditorBufferLineView closed>"
+        return f"<EditorBufferLineView {bytes(self)!r}>"
+
+    def endswith(self, suffix: _BytesLike | tuple[_BytesLike, ...]) -> bool:
+        """Return whether the line ends with the given bytes-like suffix."""
+        if isinstance(suffix, tuple):
+            return any(self.endswith(item) for item in suffix)
+        if not isinstance(suffix, (bytes, bytearray, memoryview)):
+            raise TypeError("suffix must be bytes-like")
+
+        suffix_bytes = bytes(suffix)
+        if suffix_bytes == b"":
+            self._require_active()
+            return True
+        if len(suffix_bytes) > len(self):
+            return False
+
+        view = self._memoryview()
+        tail = view[len(view) - len(suffix_bytes):]
+        try:
+            return tail == suffix_bytes
+        finally:
+            tail.release()
+            view.release()
+
+    def _require_active(self) -> None:
+        self._owner._require_active()
+
+    def _memoryview(self) -> memoryview:
+        self._require_active()
+        base = memoryview(self._owner.data)
+        try:
+            return base[self._start:self._end]
+        finally:
+            base.release()
+
+    def _equals_line_view(self, other: _BufferLineView) -> bool:
+        left = self._memoryview()
+        try:
+            right = other._memoryview()
+            try:
+                return left == right
+            finally:
+                right.release()
+        finally:
+            left.release()
+
+
+class _AcquiredBufferLineSequence(Sequence[_BufferLineView]):
+    """Context-managed sequence of scoped no-copy editor line views."""
+
+    def __init__(self, buffer: EditorBuffer) -> None:
+        self._buffer = buffer
+        self._active = False
+
+    @property
+    def data(self) -> bytes | mmap.mmap:
+        self._require_active()
+        return self._buffer._data
+
+    @property
+    def is_active(self) -> bool:
+        return self._active and not self._buffer._closed
+
+    def __enter__(self) -> _AcquiredBufferLineSequence:
+        self._buffer._require_open()
+        self._active = True
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        self._active = False
+
+    def __len__(self) -> int:
+        self._require_active()
+        return len(self._buffer)
+
+    @overload
+    def __getitem__(self, index: int) -> _BufferLineView: ...
+
+    @overload
+    def __getitem__(self, index: slice) -> Sequence[_BufferLineView]: ...
+
+    def __getitem__(
+        self,
+        index: int | slice,
+    ) -> _BufferLineView | Sequence[_BufferLineView]:
+        self._require_active()
+        if isinstance(index, slice):
+            return _BufferLineSliceSequence(self, index)
+
+        if index < 0:
+            index += len(self)
+        if index < 0:
+            raise IndexError(index)
+
+        self._buffer._scan_through_line(index)
+        if index >= len(self._buffer._line_spans):
+            raise IndexError(index)
+
+        start, end = self._buffer._line_spans[index]
+        return _BufferLineView(self, start, end)
+
+    def _require_active(self) -> None:
+        if not self._active:
+            raise ValueError("line view is closed")
+        self._buffer._require_open()
+
+
+class _AcquiredBufferLineContext:
+    """Context manager for a single scoped editor line view."""
+
+    def __init__(self, buffer: EditorBuffer, index: int) -> None:
+        self._lines_context = _AcquiredBufferLineSequence(buffer)
+        self._index = index
+
+    def __enter__(self) -> _BufferLineView:
+        lines = self._lines_context.__enter__()
+        return lines[self._index]
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        self._lines_context.__exit__(exc_type, exc, traceback)
+
+
+class _BufferLineSliceSequence(Sequence[_LineT], Generic[_LineT]):
     """Lazy slice view over editor buffer lines."""
 
     def __init__(
         self,
-        parent: Sequence[bytes],
+        parent: Sequence[_LineT],
         line_slice: slice,
     ) -> None:
         if line_slice.step == 0:
@@ -221,12 +426,12 @@ class _BufferLineSliceSequence(Sequence[bytes]):
         return len(range(*self._resolved_range()))
 
     @overload
-    def __getitem__(self, index: int) -> bytes: ...
+    def __getitem__(self, index: int) -> _LineT: ...
 
     @overload
-    def __getitem__(self, index: slice) -> Sequence[bytes]: ...
+    def __getitem__(self, index: slice) -> Sequence[_LineT]: ...
 
-    def __getitem__(self, index: int | slice) -> bytes | Sequence[bytes]:
+    def __getitem__(self, index: int | slice) -> _LineT | Sequence[_LineT]:
         if isinstance(index, slice):
             return _BufferLineSliceSequence(self, index)
 

--- a/src/git_stage_batch/utils/text.py
+++ b/src/git_stage_batch/utils/text.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Iterator, Sequence
-from typing import overload
+from contextlib import nullcontext
+from typing import Any, overload
 
 
 def normalize_line_endings(content: bytes) -> bytes:
@@ -46,6 +47,13 @@ class _LineEndingNormalizedSequence(Sequence[bytes]):
     def __len__(self) -> int:
         return len(self._lines)
 
+    def acquire_lines(self) -> Any:
+        """Return a scoped normalized line sequence."""
+        acquire_lines = getattr(self._lines, "acquire_lines", None)
+        if acquire_lines is None:
+            return nullcontext(self)
+        return _AcquiredNormalizedLineSequence(acquire_lines())
+
     @overload
     def __getitem__(self, index: int) -> bytes: ...
 
@@ -62,6 +70,39 @@ class _LineEndingNormalizedSequence(Sequence[bytes]):
             raise IndexError(index)
 
         return normalize_line_ending(self._lines[index])
+
+
+class _AcquiredNormalizedLineSequence(Sequence[bytes]):
+    """Context-managed normalized view over acquired line views."""
+
+    def __init__(self, line_context: Any) -> None:
+        self._line_context = line_context
+        self._lines: _LineEndingNormalizedSequence | None = None
+
+    def __enter__(self) -> _AcquiredNormalizedLineSequence:
+        self._lines = _LineEndingNormalizedSequence(self._line_context.__enter__())
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        self._lines = None
+        self._line_context.__exit__(exc_type, exc, traceback)
+
+    def __len__(self) -> int:
+        return len(self._require_lines())
+
+    @overload
+    def __getitem__(self, index: int) -> bytes: ...
+
+    @overload
+    def __getitem__(self, index: slice) -> list[bytes]: ...
+
+    def __getitem__(self, index: int | slice) -> bytes | list[bytes]:
+        return self._require_lines()[index]
+
+    def _require_lines(self) -> _LineEndingNormalizedSequence:
+        if self._lines is None:
+            raise ValueError("line view is closed")
+        return self._lines
 
 
 def normalize_line_sequence_endings(lines: Sequence[bytes]) -> Sequence[bytes]:

--- a/tests/batch/test_merge.py
+++ b/tests/batch/test_merge.py
@@ -26,6 +26,14 @@ from git_stage_batch.batch.ownership import (
     DeletionClaim,
     ReplacementUnit,
 )
+from git_stage_batch.utils.text import normalize_line_sequence_endings
+
+
+class _IndexGuardedEditorBuffer(EditorBuffer):
+    """EditorBuffer variant that rejects public line indexing in tests."""
+
+    def __getitem__(self, index):
+        raise AssertionError("public line indexing should not be used")
 
 
 def merge_batch(
@@ -118,6 +126,43 @@ class TestMatchLines:
         target = line_sequence([b"line1\n", b"extra\n", b"line2\n", b"line3\n"])
 
         mapping = match_lines(source, target)
+
+        assert mapping.get_target_line_from_source_line(1) == 1
+        assert mapping.get_target_line_from_source_line(2) == 3
+        assert mapping.get_target_line_from_source_line(3) == 4
+        assert mapping.get_source_line_from_target_line(2) is None
+
+    def test_acquires_editor_buffer_lines(self):
+        """EditorBuffer inputs are matched through scoped line acquisition."""
+        with (
+            _IndexGuardedEditorBuffer.from_bytes(
+                b"line1\nline2\nline3\n"
+            ) as source,
+            _IndexGuardedEditorBuffer.from_bytes(
+                b"line1\nextra\nline2\nline3\n"
+            ) as target,
+        ):
+            mapping = match_lines(source, target)
+
+        assert mapping.get_target_line_from_source_line(1) == 1
+        assert mapping.get_target_line_from_source_line(2) == 3
+        assert mapping.get_target_line_from_source_line(3) == 4
+        assert mapping.get_source_line_from_target_line(2) is None
+
+    def test_acquires_normalized_editor_buffer_lines(self):
+        """Normalized EditorBuffer inputs forward scoped acquisition."""
+        with (
+            _IndexGuardedEditorBuffer.from_bytes(
+                b"line1\r\nline2\nline3\n"
+            ) as source_buffer,
+            _IndexGuardedEditorBuffer.from_bytes(
+                b"line1\nextra\nline2\nline3\n"
+            ) as target_buffer,
+        ):
+            source = normalize_line_sequence_endings(source_buffer)
+            target = normalize_line_sequence_endings(target_buffer)
+
+            mapping = match_lines(source, target)
 
         assert mapping.get_target_line_from_source_line(1) == 1
         assert mapping.get_target_line_from_source_line(2) == 3

--- a/tests/editor/test_buffer.py
+++ b/tests/editor/test_buffer.py
@@ -82,6 +82,25 @@ def test_editor_buffer_acquires_single_scoped_line_view():
             assert line == b"beta\n"
 
 
+def test_editor_buffer_slices_acquire_scoped_line_views():
+    """Buffer slices forward scoped line acquisition to their parent."""
+    with EditorBuffer.from_bytes(b"zero\none\ntwo\nthree\n") as buffer:
+        sliced = buffer[-3:-1]
+
+        with sliced.acquire_lines() as lines:
+            first = lines[0]
+            nested = lines[1:]
+
+            assert len(lines) == 2
+            assert not isinstance(first, bytes)
+            assert first == b"one\n"
+            assert list(lines) == [b"one\n", b"two\n"]
+            assert list(nested) == [b"two\n"]
+
+        with pytest.raises(ValueError, match="line view is closed"):
+            bytes(first)
+
+
 def test_editor_buffer_line_views_use_acquisition_lifetime():
     """Line views reject access after their acquisition scope closes."""
     with EditorBuffer.from_bytes(b"alpha\n") as buffer:

--- a/tests/editor/test_buffer.py
+++ b/tests/editor/test_buffer.py
@@ -50,6 +50,68 @@ def test_editor_buffer_slices_are_lazy_sequences():
     assert list(nested) == [b"two\n", b"three\n"]
 
 
+def test_editor_buffer_acquires_scoped_line_views():
+    """Acquired line sequences expose bytes-compatible scoped views."""
+    with EditorBuffer.from_bytes(b"alpha\nbeta\r\n") as buffer:
+        with buffer.acquire_lines() as lines:
+            first = lines[0]
+            matching = lines[0]
+            second = lines[1]
+
+            assert len(lines) == 2
+            assert len(first) == len(b"alpha\n")
+            assert not isinstance(first, bytes)
+            assert first == b"alpha\n"
+            assert b"alpha\n" == first
+            assert first == matching
+            assert first != second
+            assert hash(first) == hash(b"alpha\n")
+            assert bytes(first) == b"alpha\n"
+            assert first[0] == ord("a")
+            assert first[:-1] == b"alpha"
+            assert first.endswith(b"\n")
+            assert first.endswith((b"\r\n", b"\n"))
+            assert list(lines[0:2]) == [b"alpha\n", b"beta\r\n"]
+
+
+def test_editor_buffer_acquires_single_scoped_line_view():
+    """Single-line acquisition supports negative indexes."""
+    with EditorBuffer.from_bytes(b"alpha\nbeta\n") as buffer:
+        with buffer.acquire_line(-1) as line:
+            assert not isinstance(line, bytes)
+            assert line == b"beta\n"
+
+
+def test_editor_buffer_line_views_use_acquisition_lifetime():
+    """Line views reject access after their acquisition scope closes."""
+    with EditorBuffer.from_bytes(b"alpha\n") as buffer:
+        with buffer.acquire_line(0) as line:
+            assert bytes(line) == b"alpha\n"
+
+        with pytest.raises(ValueError, match="line view is closed"):
+            bytes(line)
+        with pytest.raises(ValueError, match="line view is closed"):
+            len(line)
+        with pytest.raises(ValueError, match="line view is closed"):
+            hash(line)
+
+
+def test_editor_buffer_acquired_line_views_do_not_hold_mmap_exports(tmp_path):
+    """Acquired line views release temporary memoryviews before scope exit."""
+    file_path = tmp_path / "buffer.txt"
+    file_path.write_bytes(b"alpha\nbeta\n")
+    buffer = EditorBuffer.from_path(file_path)
+
+    with buffer.acquire_line(0) as line:
+        assert line == b"alpha\n"
+        assert hash(line) == hash(b"alpha\n")
+
+    buffer.close()
+
+    with pytest.raises(ValueError, match="line view is closed"):
+        bytes(line)
+
+
 def test_editor_buffer_slice_uses_parent_lifetime():
     """Buffer slices depend on the parent buffer remaining open."""
     buffer = EditorBuffer.from_bytes(b"one\ntwo\n")

--- a/tests/utils/test_text.py
+++ b/tests/utils/test_text.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from git_stage_batch.editor import EditorBuffer
 from git_stage_batch.utils.text import (
     bytes_to_lines,
     normalize_line_ending,
@@ -150,6 +151,35 @@ class TestNormalizeLineSequenceEndings:
         assert normalized[0] == b"one\n"
         assert normalized[0] == b"one\n"
         assert normalized[0] is not normalized[0]
+
+    def test_acquired_lf_lines_stay_scoped_views(self):
+        """Normalized acquisitions preserve unchanged acquired lines."""
+        with EditorBuffer.from_bytes(b"one\ntwo\r\nthree\r") as buffer:
+            normalized = normalize_line_sequence_endings(buffer)
+            with normalized.acquire_lines() as acquired:
+                unchanged = acquired[0]
+                crlf_line = acquired[1]
+                cr_line = acquired[2]
+
+                assert unchanged == b"one\n"
+                assert not isinstance(unchanged, bytes)
+                assert bytes(unchanged) == b"one\n"
+                assert crlf_line == b"two\n"
+                assert isinstance(crlf_line, bytes)
+                assert cr_line == b"three\n"
+                assert isinstance(cr_line, bytes)
+
+        with pytest.raises(ValueError, match="line view is closed"):
+            bytes(unchanged)
+
+    def test_acquire_lines_accepts_plain_sequences(self, line_sequence):
+        """Normalized acquisitions work without parent acquisition support."""
+        lines = line_sequence([b"one\r\n", b"two\n"])
+        normalized = normalize_line_sequence_endings(lines)
+
+        with normalized.acquire_lines() as acquired:
+            assert acquired[0] == b"one\n"
+            assert acquired[1] == b"two\n"
 
 
 class TestNormalizeLineEnding:


### PR DESCRIPTION
Editor buffers expose indexed byte lines and lazy slices, and structural matching consumes normalized line sequences for conservative source-to-target alignment. The project now uses mmap-backed buffers for large file content in several of those paths.

Large alignments still need a scoped way to compare and hash line content without copying each line into Python bytes. Without that interface, the matcher can avoid whole-file byte buffers while still materializing individual line payloads during unique-line scans.

This PR addresses that by adding scoped editor line views, forwarding acquisition through buffer slices and normalized line wrappers, and teaching match_lines() to acquire those sequences before alignment. The line views compare and hash through temporary memoryviews, and bytes(line) remains the explicit materialization point.

The series closes by covering direct, sliced, normalized, and matcher-level acquisition paths. The full test suite passes with `uv run pytest`.