### PR TITLE
batch: Defer realized line copies

### DIFF
--- a/src/git_stage_batch/batch/match.py
+++ b/src/git_stage_batch/batch/match.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 from array import array
 from collections.abc import Hashable, Sequence
-from contextlib import nullcontext
 from dataclasses import dataclass
-from typing import Any, TypeVar
+from typing import TypeVar
+
+from ..utils.text import AcquirableLineSequence, as_acquirable_line_sequence
 
 
 LineContent = TypeVar("LineContent", bound=Hashable)
@@ -75,13 +76,6 @@ def _lookup_line_mapping(mapping: array, line_number: int) -> int | None:
     if mapped_line == 0:
         return None
     return mapped_line
-
-
-def _acquire_line_sequence(lines: Sequence[LineContent]) -> Any:
-    acquire_lines = getattr(lines, "acquire_lines", None)
-    if acquire_lines is None:
-        return nullcontext(lines)
-    return acquire_lines()
 
 
 def _build_unique_position_map(
@@ -342,9 +336,9 @@ def _align_segment(
     )
 
 
-def match_lines(
-    source_lines: Sequence[LineContent],
-    target_lines: Sequence[LineContent]
+def match_acquirable_lines(
+    source_lines: AcquirableLineSequence[LineContent],
+    target_lines: AcquirableLineSequence[LineContent]
 ) -> LineMapping:
     """Compute conservative structural alignment between source and target.
 
@@ -379,8 +373,8 @@ def match_lines(
     target_to_source = _new_line_mapping(target_line_count, max_line_number)
 
     with (
-        _acquire_line_sequence(source_lines) as acquired_source_lines,
-        _acquire_line_sequence(target_lines) as acquired_target_lines,
+        source_lines.acquire_lines() as acquired_source_lines,
+        target_lines.acquire_lines() as acquired_target_lines,
     ):
         _align_segment(
             acquired_source_lines,
@@ -396,4 +390,15 @@ def match_lines(
     return LineMapping(
         source_to_target=source_to_target,
         target_to_source=target_to_source
+    )
+
+
+def match_lines(
+    source_lines: Sequence[LineContent],
+    target_lines: Sequence[LineContent]
+) -> LineMapping:
+    """Compute conservative structural alignment between source and target."""
+    return match_acquirable_lines(
+        as_acquirable_line_sequence(source_lines),
+        as_acquirable_line_sequence(target_lines),
     )

--- a/src/git_stage_batch/batch/merge.py
+++ b/src/git_stage_batch/batch/merge.py
@@ -2,15 +2,17 @@
 
 from __future__ import annotations
 
+from array import array
 from collections.abc import Iterable, Iterator, Sequence
 import difflib
 from dataclasses import dataclass
 from enum import Enum, auto
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from .match import LineMapping, match_lines
 from ..core.line_selection import parse_line_selection
 from ..editor import (
+    Editor,
     EditorBuffer,
     choose_line_ending,
     buffer_has_data,
@@ -19,6 +21,7 @@ from ..editor import (
 from ..exceptions import MergeError, MissingAnchorError, AmbiguousAnchorError
 from ..i18n import _
 from ..utils.text import (
+    AcquirableLineSequence,
     normalize_line_sequence_endings,
     normalize_line_endings,
 )
@@ -42,20 +45,234 @@ class RegionKind(Enum):
     REPLACE_BY_HUNK = auto()
 
 
-@dataclass
+@dataclass(slots=True)
 class RealizedEntry:
-    """A line in realized content with structural provenance.
+    """A line view in realized content with structural provenance.
 
     Tracks where each line came from in batch-source space, enabling
     exact anchored boundary resolution for absence constraints.
     """
-    content: bytes  # Line content with newline
+    content: Any  # Line content with newline
     source_line: int | None  # Batch-source line number (1-indexed), or None for working-tree extras
     target_line: int | None = None  # Working-tree line number (1-indexed), when known
     is_claimed: bool = False  # True if from a claimed source line (presence constraint)
 
 
-_BaselineLineEdit = tuple[int, int, list[bytes]]
+class _RealizedEntries(Sequence[RealizedEntry]):
+    """Compact realized content with parallel provenance storage.
+
+    Indexing returns RealizedEntry views for existing helper contracts. Streaming
+    and internal lookups use direct accessors so the result does not retain one
+    Python object per output line.
+    """
+
+    def __init__(self, entries: Iterable[RealizedEntry] = ()) -> None:
+        self._editor = Editor(())
+        self._source_lines = array("Q")
+        self._target_lines = array("Q")
+        self._claimed = bytearray()
+
+        for entry in entries:
+            self.append_entry(entry)
+
+    def __len__(self) -> int:
+        return len(self._source_lines)
+
+    def __getitem__(self, index: int | slice) -> RealizedEntry | _RealizedEntries:
+        if isinstance(index, slice):
+            start, stop, step = index.indices(len(self))
+            if step == 1:
+                return self.slice(start, stop)
+
+            result = _RealizedEntries()
+            for child_index in range(start, stop, step):
+                result.append_from(self, child_index)
+            return result
+
+        index = self._normalize_index(index)
+        return RealizedEntry(
+            content=self._editor[index],
+            source_line=self.source_line_at(index),
+            target_line=self.target_line_at(index),
+            is_claimed=self.is_claimed_at(index),
+        )
+
+    def append(
+        self,
+        content: Any,
+        *,
+        source_line: int | None = None,
+        target_line: int | None = None,
+        is_claimed: bool = False,
+    ) -> None:
+        self._editor.add_lines((content,), start=0, end=1)
+        self._append_metadata(
+            source_line=source_line,
+            target_line=target_line,
+            is_claimed=is_claimed,
+        )
+
+    def append_line_from(
+        self,
+        lines: Sequence[Any],
+        index: int,
+        *,
+        source_line: int | None = None,
+        target_line: int | None = None,
+        is_claimed: bool = False,
+    ) -> None:
+        self._editor.add_lines(lines, start=index, end=index + 1)
+        self._append_metadata(
+            source_line=source_line,
+            target_line=target_line,
+            is_claimed=is_claimed,
+        )
+
+    def _append_metadata(
+        self,
+        *,
+        source_line: int | None,
+        target_line: int | None,
+        is_claimed: bool,
+    ) -> None:
+        self._source_lines.append(source_line or 0)
+        self._target_lines.append(target_line or 0)
+        self._claimed.append(1 if is_claimed else 0)
+
+    def append_entry(self, entry: RealizedEntry) -> None:
+        self.append(
+            entry.content,
+            source_line=entry.source_line,
+            target_line=entry.target_line,
+            is_claimed=entry.is_claimed,
+        )
+
+    def append_from(
+        self,
+        entries: Sequence[RealizedEntry],
+        index: int,
+    ) -> None:
+        if isinstance(entries, _RealizedEntries):
+            index = entries._normalize_index(index)
+            self._editor.add_lines_from_editor(entries._editor, index, index + 1)
+            self._source_lines.append(entries._source_lines[index])
+            self._target_lines.append(entries._target_lines[index])
+            self._claimed.append(entries._claimed[index])
+            return
+
+        self.append_entry(entries[index])
+
+    def content_at(self, index: int) -> Any:
+        return self._editor[self._normalize_index(index)]
+
+    def source_line_at(self, index: int) -> int | None:
+        source_line = self._source_lines[self._normalize_index(index)]
+        if source_line == 0:
+            return None
+        return source_line
+
+    def target_line_at(self, index: int) -> int | None:
+        target_line = self._target_lines[self._normalize_index(index)]
+        if target_line == 0:
+            return None
+        return target_line
+
+    def is_claimed_at(self, index: int) -> bool:
+        return bool(self._claimed[self._normalize_index(index)])
+
+    def content_chunks(self) -> Iterator[bytes]:
+        yield from self._editor.line_chunks()
+
+    def slice(self, start: int, stop: int) -> _RealizedEntries:
+        result = _RealizedEntries()
+        result._append_range_from(self, start, stop)
+        return result
+
+    def without_range(self, start: int, stop: int) -> _RealizedEntries:
+        result = _RealizedEntries()
+        result._append_range_from(self, 0, start)
+        result._append_range_from(self, stop, len(self))
+        return result
+
+    def insert_entries(
+        self,
+        position: int,
+        entries: Sequence[RealizedEntry],
+    ) -> _RealizedEntries:
+        inserted = _as_realized_entries(entries)
+        result = _RealizedEntries()
+        result._append_range_from(self, 0, position)
+        result._append_range_from(inserted, 0, len(inserted))
+        result._append_range_from(self, position, len(self))
+        return result
+
+    def _append_range_from(
+        self,
+        entries: Sequence[RealizedEntry],
+        start: int,
+        stop: int,
+    ) -> None:
+        if start == stop:
+            return
+
+        if isinstance(entries, _RealizedEntries):
+            self._editor.add_lines_from_editor(entries._editor, start, stop)
+            self._source_lines.extend(entries._source_lines[start:stop])
+            self._target_lines.extend(entries._target_lines[start:stop])
+            self._claimed.extend(entries._claimed[start:stop])
+            return
+
+        for index in range(start, stop):
+            self.append_entry(entries[index])
+
+    def _normalize_index(self, index: int) -> int:
+        if index < 0:
+            index += len(self)
+        if index < 0 or index >= len(self):
+            raise IndexError(index)
+        return index
+
+
+def _as_realized_entries(entries: Sequence[RealizedEntry]) -> _RealizedEntries:
+    if isinstance(entries, _RealizedEntries):
+        return entries
+    return _RealizedEntries(entries)
+
+
+def _entry_content_at(entries: Sequence[RealizedEntry], index: int) -> Any:
+    if isinstance(entries, _RealizedEntries):
+        return entries.content_at(index)
+    return entries[index].content
+
+
+def _entry_source_line_at(entries: Sequence[RealizedEntry], index: int) -> int | None:
+    if isinstance(entries, _RealizedEntries):
+        return entries.source_line_at(index)
+    return entries[index].source_line
+
+
+def _entry_target_line_at(entries: Sequence[RealizedEntry], index: int) -> int | None:
+    if isinstance(entries, _RealizedEntries):
+        return entries.target_line_at(index)
+    return entries[index].target_line
+
+
+def _entry_is_claimed_at(entries: Sequence[RealizedEntry], index: int) -> bool:
+    if isinstance(entries, _RealizedEntries):
+        return entries.is_claimed_at(index)
+    return entries[index].is_claimed
+
+
+_BaselineLineEdit = tuple[int, int, list[Any]]
+
+
+def _byte_chunks(chunks: Iterable[Any]) -> Iterator[bytes]:
+    for chunk in chunks:
+        yield bytes(chunk)
+
+
+def _normalize_line_content(content: Any) -> bytes:
+    return normalize_line_endings(bytes(content))
 
 
 class _LineRange(Sequence[bytes]):
@@ -124,13 +341,19 @@ class _RealizedEntryContentSequence(Sequence[bytes]):
             index += len(self)
         if index < 0 or index >= len(self):
             raise IndexError(index)
-        return self._entries[index].content
+        return _entry_content_at(self._entries, index)
 
 
-def _realized_entry_content_chunks(entries: Iterable[RealizedEntry]) -> Iterator[bytes]:
+def _realized_entry_content_chunks(
+    entries: Iterable[RealizedEntry],
+) -> Iterator[bytes]:
     """Yield content bytes from realized entries."""
+    if isinstance(entries, _RealizedEntries):
+        yield from entries.content_chunks()
+        return
+
     for entry in entries:
-        yield entry.content
+        yield bytes(entry.content)
 
 
 def _merge_result_line_ending_from_lines(
@@ -623,7 +846,7 @@ def _apply_presence_constraints(
     presence_line_set: set[int],
     *,
     source_to_working_mapping: LineMapping | None = None,
-) -> list[RealizedEntry]:
+) -> _RealizedEntries:
     """Apply presence constraints: ensure all claimed lines exist in result.
 
     Uses structural alignment to determine which claimed lines are already present
@@ -641,19 +864,20 @@ def _apply_presence_constraints(
     mapping = source_to_working_mapping or match_lines(source_lines, working_lines)
 
     if not presence_line_set:
-        result: list[RealizedEntry] = []
-        for working_idx, working_line in enumerate(working_lines):
+        result = _RealizedEntries()
+        for working_idx in range(len(working_lines)):
             source_line = mapping.get_source_line_from_target_line(working_idx + 1)
-            result.append(RealizedEntry(
-                content=working_line,
+            result.append_line_from(
+                working_lines,
+                working_idx,
                 source_line=source_line,
                 target_line=working_idx + 1,
                 is_claimed=False,
-            ))
+            )
         return result
 
     present_claimed: dict[int, int] = {}
-    missing_claimed: dict[int, bytes] = {}
+    missing_claimed: set[int] = set()
 
     for source_line in presence_line_set:
         if 1 <= source_line <= len(source_lines):
@@ -661,22 +885,23 @@ def _apply_presence_constraints(
             if working_line is not None:
                 present_claimed[source_line] = working_line
             else:
-                missing_claimed[source_line] = source_lines[source_line - 1]
+                missing_claimed.add(source_line)
 
     if not missing_claimed:
-        result: list[RealizedEntry] = []
-        for working_idx, working_line in enumerate(working_lines):
+        result = _RealizedEntries()
+        for working_idx in range(len(working_lines)):
             source_line = mapping.get_source_line_from_target_line(working_idx + 1)
             is_claimed = source_line in presence_line_set if source_line else False
-            result.append(RealizedEntry(
-                content=working_line,
+            result.append_line_from(
+                working_lines,
+                working_idx,
                 source_line=source_line,
                 target_line=working_idx + 1,
                 is_claimed=is_claimed,
-            ))
+            )
         return result
 
-    result: list[RealizedEntry] = []
+    result = _RealizedEntries()
     working_idx = 0
 
     for source_line in range(1, len(source_lines) + 1):
@@ -684,56 +909,61 @@ def _apply_presence_constraints(
 
         if working_line is not None:
             while working_idx < working_line - 1:
-                result.append(RealizedEntry(
-                    content=working_lines[working_idx],
+                result.append_line_from(
+                    working_lines,
+                    working_idx,
                     source_line=None,
                     target_line=working_idx + 1,
                     is_claimed=False
-                ))
+                )
                 working_idx += 1
 
             is_claimed = source_line in presence_line_set
             if is_claimed:
-                result.append(RealizedEntry(
-                    content=source_lines[source_line - 1],
+                result.append_line_from(
+                    source_lines,
+                    source_line - 1,
                     source_line=source_line,
                     target_line=working_idx + 1,
                     is_claimed=True
-                ))
+                )
             else:
-                result.append(RealizedEntry(
-                    content=working_lines[working_idx],
+                result.append_line_from(
+                    working_lines,
+                    working_idx,
                     source_line=source_line,
                     target_line=working_idx + 1,
                     is_claimed=False
-                ))
+                )
             working_idx += 1
         else:
             if source_line in missing_claimed:
-                result.append(RealizedEntry(
-                    content=missing_claimed[source_line],
+                result.append_line_from(
+                    source_lines,
+                    source_line - 1,
                     source_line=source_line,
                     is_claimed=True
-                ))
+                )
 
     while working_idx < len(working_lines):
-        result.append(RealizedEntry(
-            content=working_lines[working_idx],
+        result.append_line_from(
+            working_lines,
+            working_idx,
             source_line=None,
             target_line=working_idx + 1,
             is_claimed=False
-        ))
+        )
         working_idx += 1
 
     return result
 
 
 def _apply_absence_constraints(
-    entries: list[RealizedEntry],
+    entries: Sequence[RealizedEntry],
     deletion_claims: list['DeletionClaim'],
     *,
     strict: bool = True
-) -> list[RealizedEntry]:
+) -> _RealizedEntries:
     """Apply absence constraints with boundary enforcement.
 
     For each deletion claim:
@@ -769,10 +999,9 @@ def _apply_absence_constraints(
         AmbiguousAnchorError: If anchor boundary cannot be determined uniquely
         MergeError: If strict=True and sequence found nearby but not at boundary
     """
+    result = _as_realized_entries(entries)
     if not deletion_claims:
-        return entries
-
-    result = entries
+        return result
 
     suppress_fn = _suppress_at_boundary_strict if strict else _suppress_at_boundary_for_realization
 
@@ -800,15 +1029,15 @@ def _apply_absence_constraints(
 
 
 def _missing_claimed_lines(
-    entries: list[RealizedEntry],
+    entries: Sequence[RealizedEntry],
     presence_line_set: set[int]
 ) -> set[int]:
     """Return claimed source lines that are not present as claimed entries."""
-    present_claimed = {
-        entry.source_line
-        for entry in entries
-        if entry.is_claimed and entry.source_line is not None
-    }
+    present_claimed = set()
+    for index in range(len(entries)):
+        source_line = _entry_source_line_at(entries, index)
+        if source_line is not None and _entry_is_claimed_at(entries, index):
+            present_claimed.add(source_line)
     return presence_line_set - present_claimed
 
 
@@ -820,7 +1049,7 @@ def _satisfy_constraints(
     *,
     strict: bool = True,
     source_to_working_mapping: LineMapping | None = None,
-) -> list[RealizedEntry]:
+) -> _RealizedEntries:
     """Apply presence and absence constraints until claimed lines survive."""
     realized_entries = _apply_presence_constraints(
         source_lines,
@@ -866,7 +1095,7 @@ def _satisfy_constraints(
 
 
 def _find_realization_fallback_boundary(
-    entries: list[RealizedEntry],
+    entries: Sequence[RealizedEntry],
     source_line: int | None
 ) -> int:
     """Find a lenient boundary for realization when an anchor is absent.
@@ -880,11 +1109,11 @@ def _find_realization_fallback_boundary(
     if source_line is None:
         return 0
 
-    prior_source_lines = [
-        entry.source_line
-        for entry in entries
-        if entry.source_line is not None and entry.source_line < source_line
-    ]
+    prior_source_lines = []
+    for index in range(len(entries)):
+        entry_source_line = _entry_source_line_at(entries, index)
+        if entry_source_line is not None and entry_source_line < source_line:
+            prior_source_lines.append(entry_source_line)
     if not prior_source_lines:
         return 0
 
@@ -892,7 +1121,7 @@ def _find_realization_fallback_boundary(
 
 
 def _find_boundary_after_source_line(
-    entries: list[RealizedEntry],
+    entries: Sequence[RealizedEntry],
     source_line: int | None
 ) -> int:
     """Find the index representing the boundary after a source line.
@@ -921,10 +1150,10 @@ def _find_boundary_after_source_line(
     matching_indices = []
     claimed_indices = []
 
-    for i, entry in enumerate(entries):
-        if entry.source_line == source_line:
+    for i in range(len(entries)):
+        if _entry_source_line_at(entries, i) == source_line:
             matching_indices.append(i)
-            if entry.is_claimed:
+            if _entry_is_claimed_at(entries, i):
                 claimed_indices.append(i)
 
     if not matching_indices:
@@ -952,7 +1181,7 @@ def _find_boundary_after_source_line(
 
 
 def _sequence_matches_at_position(
-    entries: list[RealizedEntry],
+    entries: Sequence[RealizedEntry],
     position: int,
     sequence: list[bytes]
 ) -> bool:
@@ -970,13 +1199,13 @@ def _sequence_matches_at_position(
         return False
 
     return all(
-        normalize_line_endings(entries[position + i].content) == sequence[i]
+        _normalize_line_content(_entry_content_at(entries, position + i)) == sequence[i]
         for i in range(len(sequence))
     )
 
 
 def _find_sequence_nearby(
-    entries: list[RealizedEntry],
+    entries: Sequence[RealizedEntry],
     position: int,
     sequence: list[bytes],
     window: int = 20
@@ -1002,10 +1231,10 @@ def _find_sequence_nearby(
 
 
 def _remove_sequence_at_position(
-    entries: list[RealizedEntry],
+    entries: Sequence[RealizedEntry],
     position: int,
     sequence: list[bytes]
-) -> list[RealizedEntry]:
+) -> _RealizedEntries:
     """Remove sequence from entries at exact position.
 
     Args:
@@ -1016,27 +1245,30 @@ def _remove_sequence_at_position(
     Returns:
         New list with sequence removed
     """
-    return entries[:position] + entries[position + len(sequence):]
+    return _as_realized_entries(entries).without_range(
+        position,
+        position + len(sequence),
+    )
 
 
 def _position_after_claimed_insertions_at_boundary(
-    entries: list[RealizedEntry],
+    entries: Sequence[RealizedEntry],
     position: int
 ) -> int:
     """Return the first position after contiguous claimed entries at boundary."""
     check_pos = position
 
-    while check_pos < len(entries) and entries[check_pos].is_claimed:
+    while check_pos < len(entries) and _entry_is_claimed_at(entries, check_pos):
         check_pos += 1
 
     return check_pos
 
 
 def _suppress_at_boundary_strict(
-    entries: list[RealizedEntry],
+    entries: Sequence[RealizedEntry],
     position: int,
     forbidden_sequence: list[bytes]
-) -> list[RealizedEntry]:
+) -> _RealizedEntries:
     """Suppress forbidden sequence with strict enforcement for merge operations.
 
     This enforces absence constraints with two-phase checking:
@@ -1098,14 +1330,14 @@ def _suppress_at_boundary_strict(
         )
 
     # Not found - already suppressed or never existed
-    return entries
+    return _as_realized_entries(entries)
 
 
 def _suppress_at_boundary_for_realization(
-    entries: list[RealizedEntry],
+    entries: Sequence[RealizedEntry],
     position: int,
     forbidden_sequence: list[bytes]
-) -> list[RealizedEntry]:
+) -> _RealizedEntries:
     """Suppress forbidden sequence with lenient enforcement for content realization.
 
     This enforces absence constraints only when exact match exists at boundary:
@@ -1146,12 +1378,12 @@ def _suppress_at_boundary_for_realization(
 
     # Not at boundary - no-op, don't suppress
     # (Baseline might not have this content or it might be elsewhere)
-    return entries
+    return _as_realized_entries(entries)
 
 
-def _line_payload_for_reference_match(content: bytes) -> bytes:
+def _line_payload_for_reference_match(content: Any) -> bytes:
     """Normalize one line for insertion-boundary identity checks."""
-    normalized = normalize_line_endings(content)
+    normalized = _normalize_line_content(content)
     if normalized.endswith(b"\n"):
         return normalized[:-1]
     return normalized
@@ -1516,11 +1748,13 @@ def can_merge_batch_from_line_sequences(
     source_to_working_mapping: LineMapping | None = None,
 ) -> bool:
     """Return whether a normalized line merge can be applied."""
+    normalized_source_lines = normalize_line_sequence_endings(source_lines)
+    normalized_working_lines = normalize_line_sequence_endings(working_lines)
     try:
         for _chunk in _merge_batch_line_chunks(
-            source_lines,
+            normalized_source_lines,
             ownership,
-            working_lines,
+            normalized_working_lines,
             source_to_working_mapping=source_to_working_mapping,
         ):
             pass
@@ -1530,14 +1764,33 @@ def can_merge_batch_from_line_sequences(
 
 
 def _merge_batch_line_chunks(
+    source_lines: AcquirableLineSequence[Any],
+    ownership: 'BatchOwnership',
+    working_lines: AcquirableLineSequence[Any],
+    *,
+    source_to_working_mapping: LineMapping | None = None,
+) -> Iterator[bytes]:
+    """Merge normalized byte-line sequences and yield normalized chunks."""
+    with (
+        source_lines.acquire_lines() as acquired_source_lines,
+        working_lines.acquire_lines() as acquired_working_lines,
+    ):
+        yield from _merge_batch_acquired_line_chunks(
+            acquired_source_lines,
+            ownership,
+            acquired_working_lines,
+            source_to_working_mapping=source_to_working_mapping,
+        )
+
+
+def _merge_batch_acquired_line_chunks(
     source_lines: Sequence[bytes],
     ownership: 'BatchOwnership',
     working_lines: Sequence[bytes],
     *,
     source_to_working_mapping: LineMapping | None = None,
 ) -> Iterator[bytes]:
-    """Merge normalized byte-line sequences and yield normalized chunks."""
-
+    """Merge acquired normalized line sequences and yield normalized chunks."""
     resolved = ownership.resolve()
     presence_line_set = resolved.presence_line_set
     deletion_claims = resolved.deletion_claims
@@ -1550,7 +1803,7 @@ def _merge_batch_line_chunks(
         deletion_claims,
     )
     if fallback_chunks is not None:
-        yield from fallback_chunks
+        yield from _byte_chunks(fallback_chunks)
         return
 
     mapping = source_to_working_mapping or match_lines(source_lines, working_lines)
@@ -1579,7 +1832,7 @@ def _merge_batch_line_chunks(
             deletion_claims,
         )
         if fallback_chunks is not None:
-            yield from fallback_chunks
+            yield from _byte_chunks(fallback_chunks)
             return
         raise
 
@@ -1615,13 +1868,32 @@ def discard_batch_from_line_sequences_as_buffer(
 
 
 def _discard_batch_line_chunks(
+    source_lines: AcquirableLineSequence[Any],
+    ownership: 'BatchOwnership',
+    working_lines: AcquirableLineSequence[Any],
+    baseline_lines: AcquirableLineSequence[Any],
+) -> Iterator[bytes]:
+    """Discard ownership from normalized byte-line sequences."""
+    with (
+        source_lines.acquire_lines() as acquired_source_lines,
+        working_lines.acquire_lines() as acquired_working_lines,
+        baseline_lines.acquire_lines() as acquired_baseline_lines,
+    ):
+        yield from _discard_batch_acquired_line_chunks(
+            acquired_source_lines,
+            ownership,
+            acquired_working_lines,
+            acquired_baseline_lines,
+        )
+
+
+def _discard_batch_acquired_line_chunks(
     source_lines: Sequence[bytes],
     ownership: 'BatchOwnership',
     working_lines: Sequence[bytes],
     baseline_lines: Sequence[bytes],
 ) -> Iterator[bytes]:
-    """Discard ownership from normalized byte-line sequences."""
-
+    """Discard ownership from acquired normalized byte-line sequences."""
     resolved = ownership.resolve()
     presence_line_set = resolved.presence_line_set
     deletion_claims = resolved.deletion_claims
@@ -1794,7 +2066,7 @@ def _build_realized_entries_for_discard(
     source_lines: Sequence[bytes],
     working_lines: Sequence[bytes],
     working_to_source: 'LineMapping'
-) -> list[RealizedEntry]:
+) -> _RealizedEntries:
     """Build structured entries from working tree with source provenance.
 
     This creates a realized representation of the current working tree content,
@@ -1809,25 +2081,26 @@ def _build_realized_entries_for_discard(
     Returns:
         Realized entries representing working tree with source provenance
     """
-    result: list[RealizedEntry] = []
+    result = _RealizedEntries()
 
-    for working_idx, working_line in enumerate(working_lines):
+    for working_idx in range(len(working_lines)):
         source_line = working_to_source.get_source_line_from_target_line(working_idx + 1)
-        result.append(RealizedEntry(
-            content=working_line,
+        result.append_line_from(
+            working_lines,
+            working_idx,
             source_line=source_line,
             target_line=working_idx + 1,
             is_claimed=False
-        ))
+        )
 
     return result
 
 
 def _reverse_presence_constraints(
-    entries: list[RealizedEntry],
+    entries: Sequence[RealizedEntry],
     presence_line_set: set[int],
     correspondence: BaselineCorrespondence
-) -> list[RealizedEntry]:
+) -> _RealizedEntries:
     """Reverse presence constraints: replace/remove batch-owned claimed lines.
 
     For each entry in the working tree that corresponds to a claimed source line:
@@ -1856,39 +2129,41 @@ def _reverse_presence_constraints(
     Raises:
         MergeError: If restoration is ambiguous or region not found
     """
-    result: list[RealizedEntry] = []
+    result = _RealizedEntries()
     processed_replace_regions: set[int] = set()
 
-    for entry in entries:
-        if entry.source_line is not None and entry.source_line in presence_line_set:
-            region = correspondence.get_region_for_source_line(entry.source_line)
+    for index in range(len(entries)):
+        source_line = _entry_source_line_at(entries, index)
+        if source_line is not None and source_line in presence_line_set:
+            region = correspondence.get_region_for_source_line(source_line)
 
             if region is None:
                 raise MergeError(
                     _("Cannot discard source line {line}: no baseline restoration region found").format(
-                        line=entry.source_line
+                        line=source_line
                     )
                 )
 
             if region.is_ambiguous:
                 raise MergeError(
                     _("Cannot discard source line {line}: baseline restoration is ambiguous").format(
-                        line=entry.source_line
+                        line=source_line
                     )
                 )
 
             if region.kind in (RegionKind.EQUAL, RegionKind.REPLACE_LINE_BY_LINE):
-                offset = entry.source_line - region.source_start_line
+                offset = source_line - region.source_start_line
                 if 0 <= offset < len(region.baseline_lines):
-                    result.append(RealizedEntry(
-                        content=region.baseline_lines[offset],
+                    result.append_line_from(
+                        region.baseline_lines,
+                        offset,
                         source_line=None,
                         is_claimed=False
-                    ))
+                    )
                 else:
                     raise MergeError(
                         _("Source line {line} offset {offset} outside region bounds").format(
-                            line=entry.source_line, offset=offset
+                            line=source_line, offset=offset
                         )
                     )
 
@@ -1914,12 +2189,13 @@ def _reverse_presence_constraints(
                             )
                         )
 
-                    for baseline_line in region.baseline_lines:
-                        result.append(RealizedEntry(
-                            content=baseline_line,
+                    for baseline_idx in range(len(region.baseline_lines)):
+                        result.append_line_from(
+                            region.baseline_lines,
+                            baseline_idx,
                             source_line=None,
                             is_claimed=False
-                        ))
+                        )
                     processed_replace_regions.add(region.region_id)
 
             else:
@@ -1928,15 +2204,15 @@ def _reverse_presence_constraints(
                 )
 
         else:
-            result.append(entry)
+            result.append_from(entries, index)
 
     return result
 
 
 def _restore_absence_constraints(
-    entries: list[RealizedEntry],
+    entries: Sequence[RealizedEntry],
     deletion_claims: list['DeletionClaim']
-) -> list[RealizedEntry]:
+) -> _RealizedEntries:
     """Restore absence constraints: insert deleted sequences at anchored boundaries.
 
     For each deletion claim, this function:
@@ -1965,10 +2241,9 @@ def _restore_absence_constraints(
         AmbiguousAnchorError: If anchor boundary is ambiguous
         (MissingAnchorError is caught and skipped gracefully)
     """
+    result = _as_realized_entries(entries)
     if not deletion_claims:
-        return entries
-
-    result = entries
+        return result
 
     for claim in deletion_claims:
         try:
@@ -1981,22 +2256,22 @@ def _restore_absence_constraints(
         if _sequence_present_at_boundary(result, boundary, claim.content_lines):
             continue
 
-        restored_entries = [
-            RealizedEntry(
-                content=line,
+        restored_entries = _RealizedEntries()
+        for line_index in range(len(claim.content_lines)):
+            restored_entries.append_line_from(
+                claim.content_lines,
+                line_index,
                 source_line=None,
-                is_claimed=False
+                is_claimed=False,
             )
-            for line in claim.content_lines
-        ]
 
-        result = result[:boundary] + restored_entries + result[boundary:]
+        result = result.insert_entries(boundary, restored_entries)
 
     return result
 
 
 def _sequence_present_at_boundary(
-    entries: list[RealizedEntry],
+    entries: Sequence[RealizedEntry],
     boundary: int,
     sequence: list[bytes]
 ) -> bool:
@@ -2017,6 +2292,7 @@ def _sequence_present_at_boundary(
         return False
 
     return all(
-        normalize_line_endings(entries[boundary + i].content) == normalize_line_endings(sequence[i])
+        _normalize_line_content(_entry_content_at(entries, boundary + i))
+        == normalize_line_endings(sequence[i])
         for i in range(len(sequence))
     )

--- a/src/git_stage_batch/batch/ownership.py
+++ b/src/git_stage_batch/batch/ownership.py
@@ -26,7 +26,12 @@ from ..utils.git import (
 )
 from .comparison import SemanticChangeKind, derive_semantic_change_runs
 from .match import match_lines
-from .merge import _apply_presence_constraints
+from .merge import (
+    _apply_presence_constraints,
+    _entry_source_line_at,
+    _entry_target_line_at,
+    _realized_entry_content_chunks,
+)
 
 
 @dataclass
@@ -1906,14 +1911,17 @@ def _advance_source_lines_preserving_existing_presence(
 
     source_line_map = {}
     working_line_map = {}
-    for index, entry in enumerate(entries, start=1):
-        if entry.source_line is not None:
-            source_line_map[entry.source_line] = index
-        if entry.target_line is not None:
-            working_line_map[entry.target_line] = index
+    for offset in range(len(entries)):
+        index = offset + 1
+        source_line = _entry_source_line_at(entries, offset)
+        target_line = _entry_target_line_at(entries, offset)
+        if source_line is not None:
+            source_line_map[source_line] = index
+        if target_line is not None:
+            working_line_map[target_line] = index
 
     return SourceContentWithLineProvenance(
-        source_buffer=EditorBuffer.from_chunks(entry.content for entry in entries),
+        source_buffer=EditorBuffer.from_chunks(_realized_entry_content_chunks(entries)),
         source_line_map=source_line_map,
         working_line_map=working_line_map,
     )

--- a/src/git_stage_batch/batch/storage.py
+++ b/src/git_stage_batch/batch/storage.py
@@ -49,7 +49,7 @@ from ..utils.git import (
 )
 from ..utils.paths import get_batch_metadata_file_path
 from ..utils.text import normalize_line_sequence_endings
-from .merge import _satisfy_constraints
+from .merge import _realized_entry_content_chunks, _satisfy_constraints
 
 if TYPE_CHECKING:
     from .ownership import BatchOwnership, DeletionClaim
@@ -465,8 +465,7 @@ def _stream_realized_content_chunks_from_lines(
         strict=False
     )
 
-    for entry in realized_entries:
-        yield entry.content
+    yield from _realized_entry_content_chunks(realized_entries)
 
 
 def _suppress_sequence_at_position_bytes(

--- a/src/git_stage_batch/editor/edit.py
+++ b/src/git_stage_batch/editor/edit.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Iterator, Sequence
 from dataclasses import dataclass
+from typing import SupportsBytes, overload
 
 from .buffer import EditorBuffer
 from .line_endings import detect_line_ending, restore_line_endings_in_chunks
@@ -26,23 +27,35 @@ class _SourceLineSegment:
     end: int | None
 
 
+_BytesLike = bytes | bytearray | memoryview
+_LineLike = _BytesLike | SupportsBytes
+
+
 @dataclass(slots=True)
-class _BufferLineSegment:
-    buffer: EditorBuffer
+class _IndexedLineSegment:
+    lines: Sequence[_LineLike]
     start: int
     end: int
+    owner: Editor | None = None
 
 
-_LineSegment = _SourceLineSegment | _BufferLineSegment
-_BytesLike = bytes | bytearray | memoryview
-_TransformResult = _BytesLike | Iterable[bytes]
+@dataclass(slots=True)
+class _LineSourceRange:
+    lines: Sequence[_LineLike]
+    start: int
+    end: int
+    owner: Editor | None
+
+
+_LineSegment = _SourceLineSegment | _IndexedLineSegment
+_TransformResult = _BytesLike | Iterable[_LineLike]
 _Selection = tuple[int, int | None]
 
 
-class Editor:
+class Editor(Sequence[_LineLike]):
     """Stateful line editor for indexed lines."""
 
-    def __init__(self, source: Sequence[bytes]) -> None:
+    def __init__(self, source: Sequence[_LineLike]) -> None:
         self._source = source
         self._segments: list[_LineSegment] = [
             _SourceLineSegment(0, None),
@@ -53,6 +66,8 @@ class Editor:
         self._cursor_positions: dict[int, int] = {}
         self._next_cursor_id = 0
         self._owned_buffers: list[EditorBuffer] = []
+        self._incoming_editor_leases: dict[Editor, _EditorLease] = {}
+        self._outgoing_editor_leases: set[_EditorLease] = set()
         self._closed = False
 
     def __enter__(self) -> Editor:
@@ -122,16 +137,112 @@ class Editor:
         self._require_open()
         self._selection = (0, None)
 
-    def add_line(self, payload: bytes) -> None:
+    @overload
+    def __getitem__(self, index: int) -> _LineLike: ...
+
+    @overload
+    def __getitem__(self, index: slice) -> Sequence[_LineLike]: ...
+
+    def __getitem__(self, index: int | slice) -> _LineLike | Sequence[_LineLike]:
+        self._require_open()
+        if isinstance(index, slice):
+            return _SelectedLineSliceSequence(self, index)
+
+        if index < 0:
+            index += len(self)
+        if index < 0:
+            raise IndexError(index)
+
+        try:
+            return self._line_at_position(index)
+        except IndexError as exc:
+            raise IndexError(index) from exc
+
+    def __len__(self) -> int:
+        self._require_open()
+        return self._current_line_count()
+
+    def line_chunks(self) -> Iterator[bytes]:
+        """Yield exact edited lines as byte chunks."""
+        self._require_open()
+        for line in self._lines():
+            yield bytes(line)
+
+    def add_line(self, payload: _LineLike) -> None:
         """Insert or replace with one line."""
         self.add_lines((payload,))
 
-    def add_lines(self, payloads: Iterable[bytes]) -> None:
-        """Insert or replace with generated line payloads."""
+    def add_lines(
+        self,
+        lines: Iterable[_LineLike],
+        *,
+        start: int | None = None,
+        end: int | None = None,
+    ) -> None:
+        """Insert or replace with generated lines or an indexed range."""
         self._require_open()
-        inserted_buffer = _spool_inserted_lines(payloads)
-        self._owned_buffers.append(inserted_buffer.buffer)
-        self._commit_edit(inserted_buffer)
+        range_requested = start is not None or end is not None
+        range_start, range_end = _line_range_bounds(start, end)
+        if range_requested and isinstance(lines, Sequence):
+            validate_end = range_end is not None
+            self._add_line_range(
+                lines,
+                range_start,
+                len(lines) if range_end is None else range_end,
+                validate_end=validate_end,
+            )
+            return
+
+        inserted_lines = _spool_inserted_lines(
+            lines,
+            start=range_start,
+            end=range_end,
+            owner=self,
+        )
+        if inserted_lines.owned_buffer is not None:
+            self._owned_buffers.append(inserted_lines.owned_buffer)
+        self._commit_edit(inserted_lines)
+
+    def add_lines_from_editor(
+        self,
+        editor: Editor,
+        start: int,
+        end: int,
+    ) -> None:
+        """Insert or replace with a range from another editor."""
+        self._require_open()
+        editor._require_open()
+        if start < 0 or end < start:
+            raise ValueError("invalid line range")
+        if end > len(editor):
+            raise ValueError("invalid line range")
+
+        for line_range in editor._line_sources(start, end):
+            self._add_line_range(
+                line_range.lines,
+                line_range.start,
+                line_range.end,
+                owner=line_range.owner,
+                validate_end=False,
+            )
+
+    def _add_line_range(
+        self,
+        lines: Sequence[_LineLike],
+        start: int,
+        end: int,
+        *,
+        owner: Editor | None = None,
+        validate_end: bool = True,
+    ) -> None:
+        _validate_line_range(lines, start, end, validate_end=validate_end)
+
+        self._commit_edit(
+            _InsertedLines(
+                segment=_IndexedLineSegment(lines, start, end, owner or self),
+                line_count=end - start,
+            )
+        )
 
     def add_bytes(self, data: bytes) -> None:
         """Insert raw bytes split on line endings."""
@@ -140,11 +251,17 @@ class Editor:
             raise TypeError(f"expected bytes object, got {type(data).__name__}")
 
         buffer = EditorBuffer.from_bytes(data)
+        line_count = _count_lines_in_bytes(data)
         self._owned_buffers.append(buffer)
         self._commit_edit(
-            _InsertedBuffer(
-                buffer=buffer,
-                line_count=_count_lines_in_bytes(data),
+            _InsertedLines(
+                segment=_IndexedLineSegment(
+                    buffer,
+                    0,
+                    line_count,
+                    self,
+                ),
+                line_count=line_count,
             )
         )
 
@@ -185,6 +302,7 @@ class Editor:
     ) -> EditorBuffer:
         """Materialize final buffer and freeze the editor."""
         self._require_open()
+        self._require_no_editor_borrowers()
         try:
             chunks = _line_body_chunks(
                 self._line_bodies(),
@@ -209,24 +327,22 @@ class Editor:
         if self._closed:
             return
 
+        self._require_no_editor_borrowers()
+        self._release_editor_leases()
         for buffer in self._owned_buffers:
             buffer.close()
         self._closed = True
 
-    def _commit_edit(self, inserted_buffer: _InsertedBuffer | None) -> None:
+    def _commit_edit(self, inserted_lines: _InsertedLines | None) -> None:
         selection_start, selection_end = self._selected_range()
         inserted_line_count = (
-            inserted_buffer.line_count
-            if inserted_buffer is not None
+            inserted_lines.line_count
+            if inserted_lines is not None
             else 0
         )
         inserted_segment = (
-            _BufferLineSegment(
-                inserted_buffer.buffer,
-                0,
-                inserted_buffer.line_count,
-            )
-            if inserted_buffer is not None and inserted_buffer.line_count > 0
+            inserted_lines.segment
+            if inserted_lines is not None and inserted_lines.line_count > 0
             else None
         )
 
@@ -249,6 +365,7 @@ class Editor:
             )
         self._position = selection_start + inserted_line_count
         self._selection = None
+        self._sync_editor_leases()
 
     def _selected_range(self) -> _Selection:
         if self._selection is None:
@@ -361,6 +478,10 @@ class Editor:
                 self._cursor_positions[cursor_id] = position + line_delta
 
     def _line_bodies(self) -> Iterator[bytes]:
+        for line in self._lines():
+            yield _line_body(line)
+
+    def _lines(self) -> Iterator[_LineLike]:
         for segment in self._segments:
             if isinstance(segment, _SourceLineSegment):
                 if segment.end is None:
@@ -370,16 +491,16 @@ class Editor:
                             line = self._source[index]
                         except IndexError:
                             break
-                        yield _line_body(line)
+                        yield line
                         index += 1
                 else:
                     for index in range(segment.start, segment.end):
-                        yield _line_body(self._source[index])
+                        yield self._source[index]
             else:
                 for index in range(segment.start, segment.end):
-                    yield _line_body(segment.buffer[index])
+                    yield segment.lines[index]
 
-    def _line_at_position(self, position: int) -> bytes:
+    def _line_at_position(self, position: int) -> _LineLike:
         destination_position = 0
 
         for segment in self._segments:
@@ -395,10 +516,48 @@ class Editor:
                 segment_index = segment.start + (position - segment_start)
                 if isinstance(segment, _SourceLineSegment):
                     return self._source[segment_index]
-                return segment.buffer[segment_index]
+                return segment.lines[segment_index]
             destination_position = segment_end
 
         raise IndexError(position)
+
+    def _line_sources(
+        self,
+        start: int,
+        end: int,
+    ) -> Iterator[_LineSourceRange]:
+        self._current_line_count()
+
+        destination_position = 0
+        for segment in self._segments:
+            segment_line_count = _known_segment_line_count(segment)
+            segment_end = destination_position + segment_line_count
+
+            if segment_end <= start:
+                destination_position = segment_end
+                continue
+            if destination_position >= end:
+                break
+
+            range_start = max(start, destination_position)
+            range_end = min(end, segment_end)
+            segment_start = segment.start + (range_start - destination_position)
+            segment_stop = segment.start + (range_end - destination_position)
+            if isinstance(segment, _SourceLineSegment):
+                yield _LineSourceRange(
+                    self._source,
+                    segment_start,
+                    segment_stop,
+                    self,
+                )
+            else:
+                yield _LineSourceRange(
+                    segment.lines,
+                    segment_start,
+                    segment_stop,
+                    segment.owner,
+                )
+            destination_position = segment_end
 
     def _destination_position_for_source_line(self, line: int) -> int | None:
         destination_position = 0
@@ -492,11 +651,66 @@ class Editor:
         if self._closed:
             raise ValueError("editor is closed")
 
+    def _require_no_editor_borrowers(self) -> None:
+        if self._outgoing_editor_leases:
+            raise ValueError("editor has active leases")
+
+    def _sync_editor_leases(self) -> None:
+        active_sources: set[Editor] = set()
+        for segment in self._segments:
+            if not isinstance(segment, _IndexedLineSegment):
+                continue
+
+            owner = segment.owner
+            if owner is not None and owner is not self:
+                active_sources.add(owner)
+
+        for source in active_sources:
+            self._borrow_editor(source)
+
+        for source, lease in list(self._incoming_editor_leases.items()):
+            if source not in active_sources:
+                lease.release()
+
+    def _borrow_editor(self, source: Editor) -> None:
+        self._require_open()
+        source._require_open()
+
+        if source is self or source in self._incoming_editor_leases:
+            return
+
+        lease = _EditorLease(source, self)
+        self._incoming_editor_leases[source] = lease
+        source._outgoing_editor_leases.add(lease)
+
+    def _release_editor_leases(self) -> None:
+        for lease in list(self._incoming_editor_leases.values()):
+            lease.release()
+
 
 @dataclass(slots=True)
-class _InsertedBuffer:
-    buffer: EditorBuffer
+class _InsertedLines:
+    segment: _LineSegment
     line_count: int
+    owned_buffer: EditorBuffer | None = None
+
+
+class _EditorLease:
+    """Borrow relationship between editors sharing line segments."""
+
+    def __init__(self, source: Editor, target: Editor) -> None:
+        self._source = source
+        self._target = target
+        self._released = False
+
+    def release(self) -> None:
+        if self._released:
+            return
+
+        self._released = True
+        if self._target._incoming_editor_leases.get(self._source) is self:
+            del self._target._incoming_editor_leases[self._source]
+        self._source._outgoing_editor_leases.discard(self)
 
 
 class _SelectedLineSequence(Sequence[bytes]):
@@ -529,7 +743,7 @@ class _SelectedLineSequence(Sequence[bytes]):
 
         try:
             return normalize_line_ending(
-                self._editor._line_at_position(self._selection_start + index)
+                bytes(self._editor._line_at_position(self._selection_start + index))
             )
         except IndexError as exc:
             raise IndexError(index) from exc
@@ -589,8 +803,8 @@ class _SelectedLineSliceSequence(Sequence[bytes]):
 
 
 def edit_lines_as_buffer(
-    source_lines: Sequence[bytes],
-    edited_lines: Iterable[bytes],
+    source_lines: Sequence[_LineLike],
+    edited_lines: Iterable[_LineLike],
     *,
     selection_start: int,
     selection_end: int,
@@ -622,7 +836,7 @@ def edit_lines_as_buffer(
 
 
 def export_lines_as_buffer(
-    lines: Iterable[bytes],
+    lines: Iterable[_LineLike],
     *,
     has_trailing_newline: bool = True,
     add_trailing_newline_when_nonempty: bool = False,
@@ -644,19 +858,62 @@ def export_lines_as_buffer(
     return EditorBuffer.from_chunks(chunks)
 
 
-def _spool_inserted_lines(lines: Iterable[bytes]) -> _InsertedBuffer:
+def _line_range_bounds(
+    start: int | None,
+    end: int | None,
+) -> tuple[int, int | None]:
+    range_start = 0 if start is None else start
+    if range_start < 0 or (end is not None and end < range_start):
+        raise ValueError("invalid line range")
+    return range_start, end
+
+
+def _validate_line_range(
+    lines: Sequence[_LineLike],
+    start: int,
+    end: int,
+    *,
+    validate_end: bool,
+) -> None:
+    if start < 0 or end < start:
+        raise ValueError("invalid line range")
+
+    if not validate_end or end == start:
+        return
+
+    try:
+        lines[end - 1]
+    except IndexError as exc:
+        raise ValueError("invalid line range") from exc
+
+
+def _spool_inserted_lines(
+    lines: Iterable[_LineLike],
+    *,
+    start: int = 0,
+    end: int | None = None,
+    owner: Editor | None = None,
+) -> _InsertedLines:
+    if start < 0 or (end is not None and end < start):
+        raise ValueError("invalid line range")
+
     line_count = 0
 
     def chunks() -> Iterator[bytes]:
         nonlocal line_count
-        for line in lines:
+        for index, line in enumerate(lines):
+            if index < start:
+                continue
+            if end is not None and index >= end:
+                break
             line_count += 1
             yield _line_body(line) + b"\n"
 
     buffer = EditorBuffer.from_chunks(chunks())
-    return _InsertedBuffer(
-        buffer=buffer,
+    return _InsertedLines(
+        segment=_IndexedLineSegment(buffer, 0, line_count, owner),
         line_count=line_count,
+        owned_buffer=buffer,
     )
 
 
@@ -694,8 +951,14 @@ def _append_segment(
     segments: list[_LineSegment],
     segment: _LineSegment | None,
 ) -> None:
-    if segment is not None and _known_segment_line_count(segment) > 0:
-        segments.append(segment)
+    if segment is None or _known_segment_line_count(segment) == 0:
+        return
+
+    if segments and _segments_are_adjacent(segments[-1], segment):
+        segments[-1].end = segment.end
+        return
+
+    segments.append(segment)
 
 
 def _slice_segment(
@@ -712,21 +975,44 @@ def _slice_segment(
     if end_offset is None:
         raise ValueError("buffer segment slice end is required")
 
-    return _BufferLineSegment(
-        segment.buffer,
+    return _IndexedLineSegment(
+        segment.lines,
         segment.start + start_offset,
         segment.start + end_offset,
+        segment.owner,
     )
 
 
-def _line_body(line: bytes) -> bytes:
-    if not isinstance(line, bytes):
-        raise TypeError(f"expected bytes object, got {type(line).__name__}")
-    if line.endswith(b"\r\n"):
-        return line[:-2]
-    if line.endswith(b"\n"):
-        return line[:-1]
-    return line
+def _segments_are_adjacent(left: _LineSegment, right: _LineSegment) -> bool:
+    if isinstance(left, _SourceLineSegment):
+        return (
+            isinstance(right, _SourceLineSegment)
+            and left.end == right.start
+        )
+
+    return (
+        isinstance(right, _IndexedLineSegment)
+        and left.lines is right.lines
+        and left.owner is right.owner
+        and left.end == right.start
+    )
+
+
+def _line_body(line: _LineLike) -> bytes:
+    line_bytes = _line_bytes(line)
+    if line_bytes.endswith(b"\r\n"):
+        return line_bytes[:-2]
+    if line_bytes.endswith(b"\n"):
+        return line_bytes[:-1]
+    return line_bytes
+
+
+def _line_bytes(line: _LineLike) -> bytes:
+    if isinstance(line, (bytes, bytearray, memoryview)):
+        return bytes(line)
+    if hasattr(line, "__bytes__"):
+        return bytes(line)
+    raise TypeError(f"expected bytes-compatible line, got {type(line).__name__}")
 
 
 def _line_body_chunks(

--- a/src/git_stage_batch/utils/text.py
+++ b/src/git_stage_batch/utils/text.py
@@ -4,7 +4,64 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Iterator, Sequence
 from contextlib import nullcontext
-from typing import Any, overload
+from typing import (
+    Any,
+    ContextManager,
+    Protocol,
+    TypeVar,
+    cast,
+    overload,
+    runtime_checkable,
+)
+
+
+_LineT = TypeVar("_LineT")
+
+
+@runtime_checkable
+class AcquirableLineSequence(Protocol[_LineT]):
+    """Indexed line sequence that can expose scoped line views."""
+
+    def __len__(self) -> int: ...
+
+    @overload
+    def __getitem__(self, index: int) -> _LineT: ...
+
+    @overload
+    def __getitem__(self, index: slice) -> Sequence[_LineT]: ...
+
+    def acquire_lines(self) -> ContextManager[Sequence[_LineT]]: ...
+
+
+class _PlainAcquirableLineSequence(Sequence[_LineT]):
+    """Acquirable adapter for ordinary indexed line sequences."""
+
+    def __init__(self, lines: Sequence[_LineT]) -> None:
+        self._lines = lines
+
+    def __len__(self) -> int:
+        return len(self._lines)
+
+    @overload
+    def __getitem__(self, index: int) -> _LineT: ...
+
+    @overload
+    def __getitem__(self, index: slice) -> Sequence[_LineT]: ...
+
+    def __getitem__(self, index: int | slice) -> _LineT | Sequence[_LineT]:
+        return self._lines[index]
+
+    def acquire_lines(self) -> ContextManager[Sequence[_LineT]]:
+        return nullcontext(self)
+
+
+def as_acquirable_line_sequence(
+    lines: Sequence[_LineT],
+) -> AcquirableLineSequence[_LineT]:
+    """Return an indexed line sequence with scoped acquisition support."""
+    if isinstance(lines, AcquirableLineSequence):
+        return cast(AcquirableLineSequence[_LineT], lines)
+    return _PlainAcquirableLineSequence(lines)
 
 
 def normalize_line_endings(content: bytes) -> bytes:

--- a/tests/batch/test_merge.py
+++ b/tests/batch/test_merge.py
@@ -9,9 +9,13 @@ from git_stage_batch.batch.match import (
 )
 from git_stage_batch.batch.merge import (
     RegionKind,
+    _RealizedEntries,
     _build_baseline_correspondence,
     _build_realized_entries_for_discard,
     _check_structural_validity,
+    _discard_batch_line_chunks,
+    _merge_batch_line_chunks,
+    _realized_entry_content_chunks,
     _try_apply_baseline_replacement_units,
     can_merge_batch_from_line_sequences,
     discard_batch_from_line_sequences_as_buffer,
@@ -34,6 +38,13 @@ class _IndexGuardedEditorBuffer(EditorBuffer):
 
     def __getitem__(self, index):
         raise AssertionError("public line indexing should not be used")
+
+
+class _IndexGuardedRealizedEntries(_RealizedEntries):
+    """Realized entries variant that rejects entry-view indexing in tests."""
+
+    def __getitem__(self, index):
+        raise AssertionError("entry indexing should not be used")
 
 
 def merge_batch(
@@ -299,6 +310,7 @@ class TestMergeLineSequences:
             source_to_working_mapping=mapping,
         )
 
+        assert isinstance(entries, _RealizedEntries)
         assert b"".join(entry.content for entry in entries) == b"line1\nline2\nline3\n"
 
     def test_discard_entry_builder_accepts_non_list_sequences(self, line_sequence):
@@ -309,8 +321,20 @@ class TestMergeLineSequences:
 
         entries = _build_realized_entries_for_discard(source, working, mapping)
 
+        assert isinstance(entries, _RealizedEntries)
         assert [entry.content for entry in entries] == [b"line1\n", b"line3\n"]
         assert [entry.source_line for entry in entries] == [1, 3]
+
+    def test_realized_entry_content_chunks_avoids_entry_views(self):
+        """Realized content streaming should not index compact entry storage."""
+        entries = _IndexGuardedRealizedEntries()
+        entries.append(b"line1\n")
+        entries.append(b"line2\n")
+
+        assert list(_realized_entry_content_chunks(entries)) == [
+            b"line1\n",
+            b"line2\n",
+        ]
 
     def test_baseline_correspondence_accepts_non_list_sequences(self, line_sequence):
         """Baseline correspondence accepts sized sliceable line sequences."""
@@ -361,6 +385,57 @@ class TestMergeLineSequences:
             baseline,
         ) as result:
             assert result.to_bytes() == b"line1\r\nold\r\nline3\r\n"
+
+    def test_merge_chunks_acquire_normalized_editor_buffer_lines(self):
+        """Merge realization uses scoped normalized line acquisition."""
+        with (
+            _IndexGuardedEditorBuffer.from_bytes(
+                b"line1\nline2\nline3\n"
+            ) as source_buffer,
+            _IndexGuardedEditorBuffer.from_bytes(
+                b"line1\nline3\n"
+            ) as working_buffer,
+        ):
+            source = normalize_line_sequence_endings(source_buffer)
+            working = normalize_line_sequence_endings(working_buffer)
+
+            result = b"".join(
+                _merge_batch_line_chunks(
+                    source,
+                    BatchOwnership.from_presence_lines(["2"], []),
+                    working,
+                )
+            )
+
+        assert result == b"line1\nline2\nline3\n"
+
+    def test_discard_chunks_acquire_normalized_editor_buffer_lines(self):
+        """Discard realization uses scoped normalized line acquisition."""
+        with (
+            _IndexGuardedEditorBuffer.from_bytes(
+                b"line1\nnew\nline3\n"
+            ) as source_buffer,
+            _IndexGuardedEditorBuffer.from_bytes(
+                b"line1\nnew\nline3\n"
+            ) as working_buffer,
+            _IndexGuardedEditorBuffer.from_bytes(
+                b"line1\nold\nline3\n"
+            ) as baseline_buffer,
+        ):
+            source = normalize_line_sequence_endings(source_buffer)
+            working = normalize_line_sequence_endings(working_buffer)
+            baseline = normalize_line_sequence_endings(baseline_buffer)
+
+            result = b"".join(
+                _discard_batch_line_chunks(
+                    source,
+                    BatchOwnership.from_presence_lines(["2"], []),
+                    working,
+                    baseline,
+                )
+            )
+
+        assert result == b"line1\nold\nline3\n"
 
 
 class TestMergeBatch:

--- a/tests/editor/test_edit.py
+++ b/tests/editor/test_edit.py
@@ -34,6 +34,16 @@ class _LengthGuardedSequence(Sequence[bytes]):
         return self._lines[index]
 
 
+class _BytesOnlyLine:
+    """Line object that only provides the bytes-compatible contract."""
+
+    def __init__(self, content: bytes) -> None:
+        self._content = content
+
+    def __bytes__(self) -> bytes:
+        return self._content
+
+
 def test_edit_lines_as_buffer_replaces_middle_lines(line_sequence):
     """Line edits render normalized LF content."""
     source_lines = line_sequence([b"one\r\n", b"two\r\n", b"three\r\n"])
@@ -135,6 +145,12 @@ def test_export_lines_as_buffer_restores_line_endings(line_sequence):
         assert buffer.to_bytes() == b"one\r\ntwo\r\n"
 
 
+def test_export_lines_as_buffer_rejects_byte_iteration():
+    """Line export rejects integers from accidental bytes iteration."""
+    with pytest.raises(TypeError, match="expected bytes-compatible line"):
+        export_lines_as_buffer(b"ab", has_trailing_newline=True)
+
+
 def test_editor_replaces_selected_lines(line_sequence):
     """Editor selections can be replaced with generated lines."""
     source_lines = line_sequence([b"one\r\n", b"two\r\n", b"three\r\n"])
@@ -146,6 +162,49 @@ def test_editor_replaces_selected_lines(line_sequence):
 
         with editor.export(has_trailing_newline=True) as buffer:
             assert buffer.to_bytes() == b"one\nnew\nagain\nthree\n"
+
+
+def test_editor_add_lines_rejects_byte_iteration(line_sequence):
+    """Generated editor insertion rejects accidental bytes iteration."""
+    source_lines = line_sequence([])
+
+    with Editor(source_lines) as editor:
+        with pytest.raises(TypeError, match="expected bytes-compatible line"):
+            editor.add_lines(b"ab")
+
+
+def test_editor_add_lines_accepts_generated_line_range(line_sequence):
+    """Generated line insertion can use range bounds."""
+    source_lines = line_sequence([])
+
+    with Editor(source_lines) as editor:
+        editor.add_lines(
+            (line for line in [b"skip\r\n", b"one\r\n", b"two\r\n", b"drop\r\n"]),
+            start=1,
+            end=3,
+        )
+
+        with editor.export(has_trailing_newline=True) as buffer:
+            assert buffer.to_bytes() == b"one\ntwo\n"
+
+
+def test_editor_add_lines_range_does_not_need_source_length():
+    """Bounded indexed insertion does not need full source length."""
+    lines = _LengthGuardedSequence([b"one\n", b"two\n", b"three\n"])
+
+    with Editor([]) as editor:
+        editor.add_lines(lines, start=1, end=3)
+
+        assert b"".join(editor.line_chunks()) == b"two\nthree\n"
+
+
+def test_editor_add_lines_range_rejects_missing_end(line_sequence):
+    """Bounded indexed insertion rejects a missing end line."""
+    lines = line_sequence([b"one\n", b"two\n"])
+
+    with Editor([]) as editor:
+        with pytest.raises(ValueError, match="invalid line range"):
+            editor.add_lines(lines, start=1, end=3)
 
 
 def test_editor_removes_selected_lines(line_sequence):
@@ -229,6 +288,126 @@ def test_editor_add_bytes_keeps_bare_cr_as_content(line_sequence):
 
         with editor.export(has_trailing_newline=False) as buffer:
             assert buffer.to_bytes() == b"one\rtwo\r"
+
+
+def test_editor_exposes_exact_indexed_lines(line_sequence):
+    """Editor can expose the current edited content as indexed lines."""
+    source_lines = line_sequence([b"one\r\n", b"two\r\n", b"three\r\n"])
+
+    with Editor(source_lines) as editor:
+        editor.move_to(1)
+        editor.select_lines(1)
+        editor.add_lines(
+            line_sequence([b"zero\n", b"new\n", b"again\n"]),
+            start=1,
+            end=3,
+        )
+
+        assert len(editor) == 4
+        assert editor[1] == b"new\n"
+        assert list(editor[1:3]) == [b"new\n", b"again\n"]
+        assert b"".join(editor.line_chunks()) == b"one\r\nnew\nagain\nthree\r\n"
+
+
+def test_editor_add_lines_accepts_acquired_line_views():
+    """add_lines can carry scoped editor-buffer line views by range."""
+    with (
+        EditorBuffer.from_bytes(b"one\ntwo\nthree\n") as buffer,
+        buffer.acquire_lines() as lines,
+        Editor([]) as editor,
+    ):
+        editor.add_lines(lines, start=1, end=3)
+
+        assert b"".join(editor.line_chunks()) == b"two\nthree\n"
+
+
+def test_editor_add_lines_accepts_bytes_only_lines(line_sequence):
+    """Indexed line editing only requires bytes-compatible line objects."""
+    lines = line_sequence([
+        _BytesOnlyLine(b"one\r\n"),
+        _BytesOnlyLine(b"two\r\n"),
+    ])
+
+    with Editor([]) as editor:
+        editor.add_lines(lines, start=0, end=2)
+
+        with editor.export(has_trailing_newline=True) as buffer:
+            assert buffer.to_bytes() == b"one\ntwo\n"
+
+
+def test_editor_add_lines_from_editor_copies_current_segments(line_sequence):
+    """One editor can insert a range from another editor without exporting."""
+    source_lines = line_sequence([b"one\n", b"two\n", b"three\n"])
+
+    with Editor(source_lines) as source_editor:
+        source_editor.move_to(1)
+        source_editor.select_lines(1)
+        source_editor.add_lines(
+            line_sequence([b"new\n", b"again\n"]),
+            start=0,
+            end=2,
+        )
+
+        with Editor([]) as target_editor:
+            target_editor.add_lines_from_editor(source_editor, 1, 3)
+
+            assert b"".join(target_editor.line_chunks()) == b"new\nagain\n"
+
+
+def test_editor_add_lines_from_editor_blocks_source_close():
+    """Borrowed editor ranges keep the source editor open."""
+    source_editor = Editor([])
+    target_editor = Editor([])
+    try:
+        source_editor.add_bytes(b"one\n")
+        target_editor.add_lines_from_editor(source_editor, 0, 1)
+
+        with pytest.raises(ValueError, match="active leases"):
+            source_editor.close()
+
+        assert b"".join(target_editor.line_chunks()) == b"one\n"
+    finally:
+        target_editor.close()
+        source_editor.close()
+
+
+def test_editor_removing_borrowed_lines_releases_source_editor():
+    """Removed borrowed ranges stop blocking source editor close."""
+    source_editor = Editor([])
+    target_editor = Editor([])
+    try:
+        source_editor.add_bytes(b"one\n")
+        target_editor.add_lines_from_editor(source_editor, 0, 1)
+        target_editor.select_all()
+        target_editor.remove()
+
+        source_editor.close()
+    finally:
+        target_editor.close()
+        source_editor.close()
+
+
+def test_editor_borrowed_ranges_keep_original_owner():
+    """Borrowed ranges copied through another editor keep the first owner."""
+    source_editor = Editor([])
+    middle_editor = Editor([])
+    target_editor = Editor([])
+    try:
+        source_editor.add_bytes(b"one\n")
+        middle_editor.add_lines_from_editor(source_editor, 0, 1)
+        target_editor.add_lines_from_editor(middle_editor, 0, 1)
+        middle_editor.select_all()
+        middle_editor.remove()
+        middle_editor.close()
+
+        with pytest.raises(ValueError, match="active leases"):
+            source_editor.close()
+
+        assert b"".join(target_editor.line_chunks()) == b"one\n"
+    finally:
+        target_editor.close()
+        middle_editor.close()
+        source_editor.close()
 
 
 def test_editor_defers_source_length_for_positioned_insert():


### PR DESCRIPTION
Editor can now compose selected ranges from existing line sequences, and EditorBuffer can expose scoped line views. Structural merge and discard still need to build realized output with source, working, baseline, and claimed-line provenance.

Right now, realized output paths can copy line content after structural matching by indexing EditorBuffer-backed inputs outside the acquisition scope. Large source or diff buffers therefore move from scoped line views back into per-line bytes objects before the final output stream is produced.

This pull request addresses that by giving the structural matcher an acquirable line-sequence contract, letting Editor keep reusable source ranges by reference with owner leases that block premature source closure, and moving realized content into an Editor-backed container with compact provenance side arrays. Generated iterators still stream into a generated buffer when there is no stable line sequence to reference.

Tests cover indexed editor ranges, generated iterator ranges, editor-to-editor lifetime leases, scoped line matching, acquired merge and discard content, and guarded buffers that fail if the realization path indexes entry views instead of streaming from Editor.