### PR TITLE
batch: Avoid per-line baseline discard allocations

### DIFF
--- a/src/git_stage_batch/batch/merge.py
+++ b/src/git_stage_batch/batch/merge.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 from array import array
+from bisect import bisect_right
 from collections.abc import Iterable, Iterator, Sequence
 import difflib
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum, auto
 from typing import TYPE_CHECKING, Any
 
@@ -402,14 +403,30 @@ class BaselineRegion:
 @dataclass
 class BaselineCorrespondence:
     """Restoration correspondence from source lines back to baseline regions."""
-    line_to_region: dict[int, 'BaselineRegion']
     regions: list['BaselineRegion']
+    _region_start_lines: array = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self._region_start_lines = array(
+            "Q",
+            (
+                region.source_start_line
+                for region in self.regions
+            )
+        )
 
     def get_region_for_source_line(
         self,
         source_line: int
     ) -> 'BaselineRegion | None':
-        return self.line_to_region.get(source_line)
+        region_index = bisect_right(self._region_start_lines, source_line) - 1
+        if region_index < 0:
+            return None
+
+        region = self.regions[region_index]
+        if source_line > region.source_end_line:
+            return None
+        return region
 
 
 @dataclass
@@ -1967,7 +1984,6 @@ def _build_baseline_correspondence(
     matcher = difflib.SequenceMatcher(None, baseline_lines, source_lines)
 
     regions: list[BaselineRegion] = []
-    line_to_region: dict[int, BaselineRegion] = {}
     next_region_id = 1
 
     for tag, base_start, base_end, src_start, src_end in matcher.get_opcodes():
@@ -1982,9 +1998,6 @@ def _build_baseline_correspondence(
             next_region_id += 1
             regions.append(region)
 
-            for src_line in range(src_start + 1, src_end + 1):
-                line_to_region[src_line] = region
-
         elif tag == 'insert':
             region = BaselineRegion(
                 source_start_line=src_start + 1,
@@ -1995,9 +2008,6 @@ def _build_baseline_correspondence(
             )
             next_region_id += 1
             regions.append(region)
-
-            for src_line in range(src_start + 1, src_end + 1):
-                line_to_region[src_line] = region
 
         elif tag == 'replace':
             base_len = base_end - base_start
@@ -2039,9 +2049,6 @@ def _build_baseline_correspondence(
                 next_region_id += 1
                 regions.append(region)
 
-                for src_line in range(src_start + 1, src_end + 1):
-                    line_to_region[src_line] = region
-
             else:
                 region = BaselineRegion(
                     source_start_line=src_start + 1,
@@ -2053,13 +2060,7 @@ def _build_baseline_correspondence(
                 next_region_id += 1
                 regions.append(region)
 
-                for src_line in range(src_start + 1, src_end + 1):
-                    line_to_region[src_line] = region
-
-    return BaselineCorrespondence(
-        line_to_region=line_to_region,
-        regions=regions
-    )
+    return BaselineCorrespondence(regions=regions)
 
 
 def _build_realized_entries_for_discard(

--- a/src/git_stage_batch/batch/merge.py
+++ b/src/git_stage_batch/batch/merge.py
@@ -2097,6 +2097,22 @@ def _build_realized_entries_for_discard(
     return result
 
 
+def _count_lines_in_range(line_set: set[int], start_line: int, end_line: int) -> int:
+    line_count = end_line - start_line + 1
+    if line_count <= len(line_set):
+        return sum(
+            1
+            for line_number in range(start_line, end_line + 1)
+            if line_number in line_set
+        )
+
+    return sum(
+        1
+        for line_number in line_set
+        if start_line <= line_number <= end_line
+    )
+
+
 def _reverse_presence_constraints(
     entries: Sequence[RealizedEntry],
     presence_line_set: set[int],
@@ -2173,20 +2189,23 @@ def _reverse_presence_constraints(
 
             elif region.kind == RegionKind.REPLACE_BY_HUNK:
                 if region.region_id not in processed_replace_regions:
-                    source_lines_in_region = set(range(
+                    total_lines_in_region = (
+                        region.source_end_line - region.source_start_line + 1
+                    )
+                    claimed_line_count = _count_lines_in_range(
+                        presence_line_set,
                         region.source_start_line,
-                        region.source_end_line + 1
-                    ))
-                    claimed_lines_in_region = source_lines_in_region & presence_line_set
+                        region.source_end_line
+                    )
 
-                    if claimed_lines_in_region != source_lines_in_region:
+                    if claimed_line_count != total_lines_in_region:
                         raise MergeError(
                             _("Cannot discard partial ownership of by-hunk replace region "
                               "(source lines {start}-{end}): batch owns {owned} of {total} lines").format(
                                 start=region.source_start_line,
                                 end=region.source_end_line,
-                                owned=len(claimed_lines_in_region),
-                                total=len(source_lines_in_region)
+                                owned=claimed_line_count,
+                                total=total_lines_in_region
                             )
                         )
 

--- a/tests/batch/test_merge.py
+++ b/tests/batch/test_merge.py
@@ -349,6 +349,20 @@ class TestMergeLineSequences:
         assert tuple(region.baseline_lines) == (b"old\n",)
         assert not isinstance(region.baseline_lines, list)
 
+    def test_baseline_correspondence_looks_up_adjacent_ranges(self):
+        """Baseline correspondence maps source lines through region bounds."""
+        baseline = [b"line1\n", b"line3\n"]
+        source = [b"line1\n", b"line2\n", b"line3\n"]
+
+        correspondence = _build_baseline_correspondence(baseline, source)
+
+        assert correspondence.get_region_for_source_line(0) is None
+        assert correspondence.get_region_for_source_line(1).kind == RegionKind.EQUAL
+        assert correspondence.get_region_for_source_line(2).kind == RegionKind.INSERT
+        assert correspondence.get_region_for_source_line(3).kind == RegionKind.EQUAL
+        assert correspondence.get_region_for_source_line(4) is None
+        assert not hasattr(correspondence, "line_to_region")
+
     def test_can_merge_accepts_non_list_sequences(self, line_sequence):
         """Mergeability probes accept indexed line sequences."""
         source = line_sequence([b"line1\n", b"line2\n", b"line3\n"])

--- a/tests/batch/test_merge.py
+++ b/tests/batch/test_merge.py
@@ -1431,6 +1431,16 @@ class TestDiscardBatch:
         # Should restore even lines from baseline
         assert result == b"1\n2\n3\n4\n5\n"
 
+    def test_discard_rejects_partial_by_hunk_ownership(self):
+        """Partial ownership of a by-hunk replace region is unsafe."""
+        baseline = b"A\nold1\nold2\nD\n"
+        batch_source = b"A\nnew1\nnew2\nnew3\nD\n"
+        working = b"A\nnew1\nnew2\nnew3\nD\n"
+        ownership = BatchOwnership.from_presence_lines(["2"], [])
+
+        with pytest.raises(MergeError, match="batch owns 1 of 3 lines"):
+            discard_batch(batch_source, ownership, working, baseline)
+
     def test_discard_insertion_not_present_does_nothing(self):
         """Test that discarding insertion when not in working tree does nothing."""
         baseline = b"line1\nline2\n"


### PR DESCRIPTION
Structural discard builds baseline correspondence and by-hunk replacement ownership facts over source line ranges. The code already has contiguous region data, but two paths still allocate Python containers at source-line scale.

This PR addresses that by replacing the persistent source-line-to-region dictionary with a compact region-start index and by counting claimed lines in by-hunk regions without constructing a full range set. The tests cover both the range lookup boundaries and the partial by-hunk ownership error.

Testing:
- pytest tests/batch/test_merge.py