### PR TITLE
batch: Track LIS candidates by target rank

### DIFF
--- a/src/git_stage_batch/batch/match.py
+++ b/src/git_stage_batch/batch/match.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from array import array
+from bisect import bisect_left
 from collections.abc import Hashable, Sequence
 from dataclasses import dataclass
 from typing import TypeVar
@@ -120,10 +121,66 @@ def _build_unique_position_map(
     return unique_positions
 
 
+def _is_better_lis_entry(
+    candidate: tuple[int, int],
+    current: tuple[int, int]
+) -> bool:
+    """Prefer longer subsequences, then earlier source-ordered endings."""
+    candidate_length: int
+    candidate_index: int
+    current_length: int
+    current_index: int
+
+    candidate_length, candidate_index = candidate
+    current_length, current_index = current
+
+    if candidate_length != current_length:
+        return candidate_length > current_length
+
+    if candidate_length == 0:
+        return False
+
+    return candidate_index < current_index
+
+
+def _query_best_by_target_rank(
+    best_by_target_rank: list[tuple[int, int]],
+    target_rank: int
+) -> tuple[int, int]:
+    """Return the best LIS ending before a target rank."""
+    best: tuple[int, int]
+    candidate: tuple[int, int]
+
+    best = (0, -1)
+
+    while target_rank > 0:
+        candidate = best_by_target_rank[target_rank]
+        if _is_better_lis_entry(candidate, best):
+            best = candidate
+        target_rank -= target_rank & -target_rank
+
+    return best
+
+
+def _update_best_by_target_rank(
+    best_by_target_rank: list[tuple[int, int]],
+    target_rank: int,
+    candidate: tuple[int, int]
+) -> None:
+    """Record a candidate LIS ending at a target rank."""
+    while target_rank < len(best_by_target_rank):
+        if _is_better_lis_entry(candidate, best_by_target_rank[target_rank]):
+            best_by_target_rank[target_rank] = candidate
+        target_rank += target_rank & -target_rank
+
+
 def _longest_increasing_subsequence(
     pairs: list[tuple[int, int]]
 ) -> list[tuple[int, int]]:
     """Return a longest increasing subsequence by target index.
+
+    Uses an O(n log n) best_by_target_rank table.
+    Equal-length ties keep the earliest source-ordered pair.
 
     Args:
         pairs: Candidate (source_index, target_index) pairs sorted by source index.
@@ -131,44 +188,56 @@ def _longest_increasing_subsequence(
     Returns:
         Monotonic anchor pairs preserving both source and target order.
     """
-    lengths: list[int]
-    previous: list[int | None]
+    target_indices: list[int]
+    best_by_target_rank: list[tuple[int, int]]
+    predecessors: list[int | None]
     best_length: int
     best_index: int
-    current: int
-    candidate: int
-    current_target: int
-    candidate_target: int
+    pair_index: int
+    target_index: int
+    target_rank: int
+    predecessor_length: int
+    predecessor_index: int
+    current_length: int
     result: list[tuple[int, int]]
     index: int | None
 
     if not pairs:
         return []
 
-    lengths = [1] * len(pairs)
-    previous = [None] * len(pairs)
-    best_length = 1
+    target_indices = sorted({target_index for _, target_index in pairs})
+    best_by_target_rank = [(0, -1)] * (len(target_indices) + 1)
+    predecessors = [None] * len(pairs)
+    best_length = 0
     best_index = 0
 
-    for current in range(len(pairs)):
-        current_target = pairs[current][1]
+    for pair_index, (_, target_index) in enumerate(pairs):
+        target_rank = bisect_left(target_indices, target_index) + 1
+        predecessor_length, predecessor_index = _query_best_by_target_rank(
+            best_by_target_rank,
+            target_rank - 1
+        )
+        current_length = predecessor_length + 1
 
-        for candidate in range(current):
-            candidate_target = pairs[candidate][1]
-            if candidate_target < current_target and lengths[candidate] + 1 > lengths[current]:
-                lengths[current] = lengths[candidate] + 1
-                previous[current] = candidate
+        if predecessor_index >= 0:
+            predecessors[pair_index] = predecessor_index
 
-        if lengths[current] > best_length:
-            best_length = lengths[current]
-            best_index = current
+        if current_length > best_length:
+            best_length = current_length
+            best_index = pair_index
+
+        _update_best_by_target_rank(
+            best_by_target_rank,
+            target_rank,
+            (current_length, pair_index)
+        )
 
     result = []
     index = best_index
 
     while index is not None:
         result.append(pairs[index])
-        index = previous[index]
+        index = predecessors[index]
 
     result.reverse()
     return result

--- a/tests/batch/test_merge.py
+++ b/tests/batch/test_merge.py
@@ -5,6 +5,7 @@ import pytest
 from git_stage_batch.batch.match import (
     UniqueLinePosition,
     _build_unique_position_map,
+    _longest_increasing_subsequence,
     match_lines,
 )
 from git_stage_batch.batch.merge import (
@@ -102,6 +103,22 @@ class TestMatchLines:
             b"unique\n": UniqueLinePosition(index=1),
             b"other\n": UniqueLinePosition(index=3),
         }
+
+    def test_lis_keeps_source_stable_ties(self):
+        """Equal-length LIS choices keep the earliest source-ordered anchor."""
+        pairs = [(0, 2), (1, 1), (2, 3)]
+
+        assert _longest_increasing_subsequence(pairs) == [(0, 2), (2, 3)]
+
+    def test_lis_uses_later_smaller_tail_for_longer_match(self):
+        """A later smaller target can produce a longer subsequence."""
+        pairs = [(0, 3), (1, 1), (2, 2), (3, 4)]
+
+        assert _longest_increasing_subsequence(pairs) == [
+            (1, 1),
+            (2, 2),
+            (3, 4),
+        ]
 
     def test_line_mapping_uses_zero_filled_arrays(self):
         """Line mappings store one integer slot per line."""

--- a/tests/batch/test_merge.py
+++ b/tests/batch/test_merge.py
@@ -91,7 +91,7 @@ def discard_batch(
 
 
 class TestMatchLines:
-    """Tests for line alignment using difflib.SequenceMatcher."""
+    """Tests for structural line alignment."""
 
     def test_unique_position_map_returns_structured_positions(self):
         """Unique line scanning returns positions without duplicate entries."""
@@ -274,9 +274,7 @@ class TestMatchLines:
         assert mapping.get_target_line_from_source_line(1) == 1
         assert mapping.get_target_line_from_source_line(5) == 5
 
-        # Sub-matcher behavior with reordering:
-        # SequenceMatcher may not perfectly handle all reorderings
-        # It finds longest common subsequences, which in this case:
+        # Structural anchors preserve source and target order:
         # - A (source line 2) maps to A (target line 3)
         # - B gets treated as delete + reinsert (maps to None)
         # - C (source line 4) maps to C (target line 4)
@@ -284,8 +282,7 @@ class TestMatchLines:
         assert mapping.get_target_line_from_source_line(3) is None  # B seen as moved
         assert mapping.get_target_line_from_source_line(4) == 4  # C matches
 
-        # This shows that sub-matching is better than pure positional,
-        # but not perfect for all reorderings (trade-off for performance)
+        # Moved lines stay unmapped unless they fit the ordered anchor sequence.
 
     def test_replace_block_strict(self):
         """Test alignment with replace block in strict mode."""
@@ -535,7 +532,7 @@ class TestMergeBatch:
         assert result == working
 
     def test_baseline_referenced_presence_inserts_when_missing(self):
-        """Baseline-coordinate insertion fallback still handles baseline targets."""
+        """Baseline-coordinate insertion fallback handles baseline targets."""
         source = b"base\nfoo\nbar\n"
         working = b"base\nbar\n"
         ownership = BatchOwnership.from_presence_lines(
@@ -1026,7 +1023,7 @@ class TestMergeBatch:
         # Claim every 100th line
         claimed = [str(i) for i in range(100, 10001, 100)]
 
-        # This should complete quickly (difflib.SequenceMatcher is fast in practice)
+        # Structural matching should complete quickly for shifted large files.
         result = merge_batch(source, BatchOwnership.from_presence_lines(claimed, []), working)
 
         # Verify result has both extras and source


### PR DESCRIPTION
The structural matcher chooses monotonic anchors from unique source and target line pairs. The selected anchor chain is part of the safety boundary for batch merge placement.

Large reordered segments can contain many candidate anchors. The matcher needs target-rank state that keeps that ordering contract without pairwise scans across each candidate.

This pull request addresses that by replacing the LIS search with an O(n log n) best_by_target_rank table over compressed target ranks, adding focused LIS coverage, and updating nearby test wording to describe structural matching directly.

Verification completed with `pytest tests/batch/test_merge.py`, the earlier full `pytest` run, an exhaustive local LIS comparison over target sequences up to length 7, and `git diff --check`.