### PR TITLE
Use first-person maintainer voice in commit message guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,13 +40,13 @@ We follow strict commit message conventions to maintain a clear and understandab
 ### Key Principles
 
 - **Write for drive-by reviewers with limited context.** Assume the reader does not know the project well.
-- **Write from the maintainer's voice to a casual reader.** The commit message is a maintainer explaining the change to someone unfamiliar with the codebase.
+- **You are the maintainer; write to a casual reader.** The commit message is you explaining the change to someone unfamiliar with the codebase. Never refer to maintainers in the third person.
 - **Tell a story.** The events in history are connected, and that connection should be considered when crafting messages. Do not treat each commit as an isolated writing exercise. If a series of commits contribute collectively to a goal, each commit message should describe how it helps achieve that goal. Early commits can foreshadow later commits if it helps tell the story.
 - **Separate independent series.** A dirty worktree can contain multiple unrelated commit series. Split them into separate series with separate opening and concluding commits instead of forcing one message thread across all unstaged changes.
 - **Introduce the series in its first commit.** When a commit opens a multi-commit series, its message should name the larger goal and explain why the series exists, even if the first change is narrow groundwork. Do not limit the opening message to mechanics that only matter to that first change.
 - **Conclude the series in its final commit.** The final commit should make clear that the series has reached its intended goal. Its message should close the thread opened by the first commit instead of only describing the last small change.
 - **Use the tense that reflects the state of the project just before the commit is applied.** When discussing the old behavior, treat it as the selected behavior. When discussing the changes, treat them as new behavior.
-- **Describe problems at the product level, not just the file level.** Focus on what users or maintainers experience, not only what is missing in a specific file or function.
+- **Describe problems at the product level, not just the file level.** Focus on what users experience or what you find problematic as the maintainer, not only what is missing in a specific file or function.
 - **Focus on missing capabilities, not symptoms.** Documentation gaps, code organization, and naming issues are often symptoms. Identify the underlying limitation or missing behavior that motivates the change.
 - **Do not describe secondary effects as the primary problem.** Code organization, maintainability, or cleanliness are rarely the main reason for a change.
 - **Be precise about scope.** If a change only improves one aspect of a problem, do not imply it fully solves it.
@@ -101,7 +101,7 @@ Do not describe the diff, the change itself, or future goals.
 Explain the underlying problem from the appropriate perspective.
 
 **Choose the perspective based on who experiences the problem:**
-- Use **maintainer perspective** for internal concerns (missing infrastructure, lack of test coverage, missing translations, build system gaps). Frame as "The program lacks X" or "The project does not provide Y."
+- Use **first-person maintainer perspective** for internal concerns (missing infrastructure, lack of test coverage, missing translations, build system gaps). You are the maintainer — frame as "The program lacks X" or "The project does not provide Y", never as "Maintainers cannot X."
 - Use **user perspective** for external concerns (confusing interfaces, missing documentation, poor workflows). Frame as "Users cannot X" or "Users must Y."
 
 Describe what is non-obvious, hard to discover, confusing, missing, or limited
@@ -112,7 +112,7 @@ Prefer the broadest accurate framing of the problem.
 
 Useful tests:
 - Would this problem still exist even if the specific file being edited were perfect?
-- Is this something users would notice, or only maintainers?
+- Is this something users would notice, or only you as the maintainer?
 
 For opening commits in a feature series, prefer framing the problem
 around the missing user-facing capability instead of the missing internal
@@ -169,8 +169,8 @@ Before finalizing a commit message, check:
 - If the worktree contains multiple independent series, are they split into separate series?
 - If this is the first commit in a series, does the message introduce the whole series goal rather than only the first change?
 - If this is the final commit in a series, does the message conclude the series goal rather than read like another incremental step?
-- Does the second paragraph use the appropriate perspective (maintainer for internal concerns, user for external concerns)?
-- Does the second paragraph describe the real user-visible or maintainer-visible problem?
+- Does the second paragraph use the appropriate perspective (first-person maintainer for internal concerns, user for external concerns)?
+- Does the second paragraph describe the real problem from either the user's or your own maintainer perspective?
 - Is the problem broader than just the file being edited?
 - Does the message focus on a missing capability rather than a symptom?
 - If this is the first commit in a feature series, does the message name the eventual user-facing feature rather than only the internal machinery?

--- a/assets/claude-skills/commit-unstaged-changes/SKILL.md
+++ b/assets/claude-skills/commit-unstaged-changes/SKILL.md
@@ -641,8 +641,9 @@ currently has or provides. Do not mention the patch or what is
 missing yet.]
 
 [Description of what is missing, broken, or insufficient — and why
-that matters. Use maintainer perspective for internal concerns,
-user perspective for external ones.]
+that matters. Use first-person maintainer perspective for internal
+concerns, user perspective for external ones. Never refer to
+maintainers in the third person.]
 
 This commit [addresses|mitigates|resolves] that [problem] by [precise
 description of what this commit changes and how it solves the problem
@@ -665,8 +666,9 @@ Check for all three before committing.
 
 ## Commit Message Guidelines
 
-Write for drive-by reviewers with limited context. Write from the
-maintainer's voice to a casual reader who does not know the codebase well.
+Write for drive-by reviewers with limited context. You are the
+maintainer — write to a casual reader who does not know the codebase
+well. Never refer to maintainers in the third person.
 
 ### Required structure
 
@@ -709,8 +711,9 @@ Fourth paragraph for follow-up or final series conclusion when useful.
 ### Second paragraph
 
 - Describe the real underlying problem from the right perspective.
-- Use maintainer perspective for internal concerns such as missing
-  infrastructure, coverage, or build support.
+- Use first-person maintainer perspective for internal concerns such as
+  missing infrastructure, coverage, or build support. Frame as "The
+  program lacks X", never as "Maintainers cannot X."
 - Use user perspective for external concerns such as unclear workflows,
   missing discoverability, or absent functionality.
 - Focus on missing capabilities, not symptoms tied only to a file.

--- a/assets/codex-skills/commit-unstaged-changes/SKILL.md
+++ b/assets/codex-skills/commit-unstaged-changes/SKILL.md
@@ -260,7 +260,7 @@ not count as coupling.
    2. Does this commit fix more than one stale-state path, error path, or
       incorrect-selection path?
    3. Does this commit resolve more than one independently describable user
-      complaint or maintainer complaint?
+      complaint or complaint you have as the maintainer?
    If any answer is yes, split by default even when the lines share one
    helper, one state file, one data structure, or one command name. Only keep
    the work combined if you can name the exact invariant that is common to all
@@ -907,8 +907,9 @@ currently has or provides. Do not mention the patch or what is
 missing yet.]
 
 [Description of what is missing, broken, or insufficient, and why
-that matters. Use maintainer or commit-author perspective for
-internal concerns, user perspective for external ones.]
+that matters. Use first-person maintainer perspective for internal
+concerns, user perspective for external ones. Never refer to
+maintainers in the third person.]
 
 This commit [addresses|mitigates|resolves] that [problem] by [precise
 description of what this commit changes and how it solves the problem
@@ -957,11 +958,12 @@ Do not describe the diff, the change itself, or future goals.
 Explain the underlying problem from the appropriate perspective.
 
 Choose the perspective based on who experiences the problem:
-- Use **maintainer perspective** for internal concerns (missing
-  infrastructure, lack of test coverage, missing translations,
-  build system gaps). This is also the commit author's perspective:
-  the reason the change belongs in history. Frame as "The program
-  lacks X" or "The project does not provide Y."
+- Use **first-person maintainer perspective** for internal concerns
+  (missing infrastructure, lack of test coverage, missing
+  translations, build system gaps). You are the maintainer — this
+  is your own perspective on the project. Frame as "The program
+  lacks X" or "The project does not provide Y", never as
+  "Maintainers cannot X."
 - Use **user perspective** for external concerns (confusing
   interfaces, missing documentation, poor workflows). Frame as
   "Users cannot X" or "Users must Y."
@@ -975,7 +977,8 @@ Prefer the broadest accurate framing of the problem.
 Useful tests:
 - Would this problem still exist even if the specific file being
   edited were perfect?
-- Is this something users would notice, or only maintainers?
+- Is this something users would notice, or only you as the
+  maintainer?
 
 For opening commits in a feature series, prefer framing
 the problem around the missing user-facing capability instead of
@@ -1054,9 +1057,9 @@ Fourth paragraph for follow-up or final series conclusion when useful.
 
 - Write for drive-by reviewers with limited context. Assume the
   reader does not know the project well.
-- Write from the maintainer's voice to a casual reader. The commit
-  message is a maintainer explaining the change to someone
-  unfamiliar with the codebase.
+- You are the maintainer; write to a casual reader. The commit
+  message is you explaining the change to someone unfamiliar with
+  the codebase. Never refer to maintainers in the third person.
 - Tell a story. The events in history are connected, and that
   connection should be considered when crafting messages. Do not
   treat each commit as an isolated writing exercise. If a series
@@ -1079,7 +1082,8 @@ Fourth paragraph for follow-up or final series conclusion when useful.
   it as the current behavior. When discussing the changes, treat
   them as new behavior.
 - Describe problems at the product level, not just the file level.
-  Focus on what users or maintainers experience, not only what is
+  Focus on what users experience or what you find problematic as the
+  maintainer, not only what is
   missing in a specific file or function.
 - Focus on missing capabilities, not symptoms. Documentation gaps,
   code organization, and naming issues are often symptoms. Identify
@@ -1134,10 +1138,10 @@ Before finalizing a commit message, check:
   conclude the series goal rather than read like another
   incremental step?
 - Does the second paragraph use the appropriate perspective
-  (maintainer or commit author for internal concerns, user for
+  (first-person maintainer for internal concerns, user for
   external concerns)?
-- Does the second paragraph describe the real user-visible or
-  maintainer-visible problem?
+- Does the second paragraph describe the real problem from either
+  the user's or your own maintainer perspective?
 - Is the problem broader than just the file being edited?
 - Does the message focus on a missing capability rather than a
   symptom?
@@ -1542,7 +1546,8 @@ Before committing, verify:
 - If this is part of a series, the first paragraph reflects the cumulative
   state after all previous commits.
 - The second paragraph explains the broader problem from the right
-  perspective (maintainer for internal concerns, user for external ones).
+  perspective (first-person maintainer for internal concerns, user for
+  external ones).
 - The third paragraph opens with `This commit` and describes how it addresses
   the problem.
 - The message reflects a larger series narrative when the work is split across

--- a/docs/ai-assistants.md
+++ b/docs/ai-assistants.md
@@ -79,7 +79,7 @@ the reader does not know the project well.
   - If part of a series, reflect the cumulative state after previous commits
   - Don't describe the diff, the change, or future goals
 - **Second paragraph**: explain the underlying problem
-  - Choose perspective: maintainer (internal concerns) or user (external concerns)
+  - Choose perspective: first-person maintainer (internal concerns) or user (external concerns)
   - Focus on **missing capabilities**, not symptoms
   - Prefer concrete limitations over vague words like "cumbersome" or "better"
 - **Third paragraph**: describe how this commit addresses the problem


### PR DESCRIPTION
The commit message guidelines in CONTRIBUTING.md, the Claude and
Codex commit workflow skills, and docs/ai-assistants.md all
instruct the commit author to write from "the maintainer's voice"
and refer to maintainers in the third person when explaining
perspective choices.

That third-person framing creates distance between the author and
the role. AI assistants following the instructions sometimes
produce commit messages that reference "maintainers" as a separate
group rather than writing as the maintainer directly, which
undermines the intent of the guidance.

This series addresses that by rewriting every maintainer reference
across all four files to use first-person voice. "Write from the
maintainer's voice" becomes "You are the maintainer; write to a
casual reader", perspective labels change from "maintainer
perspective" to "first-person maintainer perspective", and each
location gains an explicit instruction to never refer to
maintainers in the third person.