### PR TITLE
batch: Store matcher state in mapped storage

### DIFF
--- a/scripts/benchmark_matching.py
+++ b/scripts/benchmark_matching.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Benchmark structural matching storage and resource usage."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Iterable
+from contextlib import contextmanager
+import json
+import os
+from pathlib import Path
+import resource
+import sys
+import time
+import tracemalloc
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from git_stage_batch.batch import match as match_module
+from git_stage_batch.batch.match import LineMapping
+from git_stage_batch.batch.match_storage import MatcherWorkspace
+from git_stage_batch.editor import EditorBuffer
+
+
+class _MeasuredWorkspace(MatcherWorkspace):
+    """Matcher workspace that reports allocation counters on close."""
+
+    recorder: "_WorkspaceRecorder | None" = None
+
+    def close(self) -> None:
+        recorder = self.recorder
+        if recorder is not None:
+            recorder.observe_workspace(self)
+        super().close()
+
+
+class _WorkspaceRecorder:
+    """Collect matcher workspace metrics across recursive matching."""
+
+    def __init__(self) -> None:
+        self.high_water_bytes = 0
+        self.total_allocated_bytes = 0
+        self.workspace_count = 0
+        self.candidate_count = 0
+
+    def observe_workspace(self, workspace: MatcherWorkspace) -> None:
+        self.workspace_count += 1
+        self.high_water_bytes = max(
+            self.high_water_bytes,
+            workspace.high_water_bytes,
+        )
+        self.total_allocated_bytes += workspace.total_allocated_bytes
+
+
+def _open_fd_count() -> int | None:
+    fd_path = "/proc/self/fd"
+    if not os.path.isdir(fd_path):
+        return None
+    return len(os.listdir(fd_path))
+
+
+def _rss_bytes() -> int | None:
+    try:
+        return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * 1024
+    except Exception:
+        return None
+
+
+def _line_span_bytes(buffer: EditorBuffer) -> int:
+    line_spans = getattr(buffer, "_line_spans", None)
+    records = getattr(line_spans, "_records", None)
+    byte_count = getattr(records, "byte_count", 0)
+    return byte_count if isinstance(byte_count, int) else 0
+
+
+def _line_payloads(pattern: str, line_count: int) -> tuple[Iterable[bytes], Iterable[bytes]]:
+    if pattern == "identical":
+        source = [f"line {index}\n".encode() for index in range(line_count)]
+        return source, list(source)
+
+    if pattern == "unique-inserted-prefix":
+        source = [f"line {index}\n".encode() for index in range(line_count)]
+        target = [f"extra {index}\n".encode() for index in range(line_count // 10)]
+        target.extend(source)
+        return source, target
+
+    if pattern == "repeated":
+        source = [b"same\n" for _ in range(line_count)]
+        target = list(source)
+        return source, target
+
+    if pattern == "reversed-unique":
+        source = [f"line {index}\n".encode() for index in range(line_count)]
+        return source, list(reversed(source))
+
+    raise ValueError(f"unknown pattern: {pattern}")
+
+
+@contextmanager
+def _instrument_matcher(recorder: _WorkspaceRecorder):
+    original_workspace = match_module.MatcherWorkspace
+    original_lis = match_module._longest_increasing_subsequence_records
+
+    def measured_lis(pairs, target_start, target_end, workspace):
+        recorder.candidate_count += len(pairs)
+        return original_lis(pairs, target_start, target_end, workspace)
+
+    _MeasuredWorkspace.recorder = recorder
+    match_module.MatcherWorkspace = _MeasuredWorkspace
+    match_module._longest_increasing_subsequence_records = measured_lis
+    try:
+        yield
+    finally:
+        match_module._longest_increasing_subsequence_records = original_lis
+        match_module.MatcherWorkspace = original_workspace
+        _MeasuredWorkspace.recorder = None
+
+
+def _mapping_source_to_target_bytes(mapping: LineMapping) -> int:
+    source_bytes = getattr(mapping.source_to_target, "byte_count", 0)
+    target_bytes = getattr(mapping.target_to_source, "byte_count", 0)
+    return (
+        (source_bytes if isinstance(source_bytes, int) else 0)
+        + (target_bytes if isinstance(target_bytes, int) else 0)
+    )
+
+
+def run_benchmark(pattern: str, line_count: int) -> dict[str, Any]:
+    source_payloads, target_payloads = _line_payloads(pattern, line_count)
+    recorder = _WorkspaceRecorder()
+    fd_before = _open_fd_count()
+    rss_before = _rss_bytes()
+    tracemalloc.start()
+    start_time = time.perf_counter()
+
+    with (
+        EditorBuffer.from_chunks(source_payloads) as source,
+        EditorBuffer.from_chunks(target_payloads) as target,
+    ):
+        with _instrument_matcher(recorder):
+            with match_module.match_lines(source, target) as mapping:
+                mapped_line_count = sum(1 for _ in mapping.mapped_line_pairs())
+                mapping_bytes = _mapping_source_to_target_bytes(mapping)
+
+        source_line_count = len(source)
+        target_line_count = len(target)
+        line_span_bytes = _line_span_bytes(source) + _line_span_bytes(target)
+
+    elapsed = time.perf_counter() - start_time
+    _, peak_heap = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    rss_after = _rss_bytes()
+    fd_after = _open_fd_count()
+
+    return {
+        "pattern": pattern,
+        "requested_source_lines": line_count,
+        "source_lines": source_line_count,
+        "target_lines": target_line_count,
+        "mapped_line_count": mapped_line_count,
+        "candidate_count": recorder.candidate_count,
+        "tracemalloc_peak_bytes": peak_heap,
+        "rss_before_bytes": rss_before,
+        "rss_after_bytes": rss_after,
+        "elapsed_seconds": elapsed,
+        "fd_before": fd_before,
+        "fd_after": fd_after,
+        "line_span_bytes": line_span_bytes,
+        "line_mapping_bytes": mapping_bytes,
+        "matcher_workspace_high_water_bytes": recorder.high_water_bytes,
+        "matcher_workspace_total_allocated_bytes": recorder.total_allocated_bytes,
+        "matcher_workspace_count": recorder.workspace_count,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--pattern",
+        choices=[
+            "identical",
+            "unique-inserted-prefix",
+            "repeated",
+            "reversed-unique",
+        ],
+        default="unique-inserted-prefix",
+    )
+    parser.add_argument("--lines", type=int, default=10000)
+    args = parser.parse_args()
+
+    if args.lines < 0:
+        raise SystemExit("--lines must be non-negative")
+
+    print(json.dumps(run_benchmark(args.pattern, args.lines), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/git_stage_batch/batch/attribution.py
+++ b/src/git_stage_batch/batch/attribution.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from dataclasses import replace
 from enum import Enum
 
-from ..batch.match import match_lines
+from ..batch.match import LineMapping, match_lines
 from ..batch.query import list_batch_names, read_batch_metadata
 from ..core.line_selection import parse_line_selection
 from ..core.models import LineLevelChange
@@ -110,7 +110,17 @@ class FileComparison:
     file_path: str
     baseline_lines: Sequence[bytes]
     working_tree_lines: Sequence[bytes]
-    alignment: object
+    alignment: LineMapping
+
+    def close(self) -> None:
+        """Close the owned alignment mapping."""
+        self.alignment.close()
+
+    def __enter__(self) -> FileComparison:
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        self.close()
 
 
 def _make_unit_id(
@@ -434,13 +444,13 @@ def build_file_attribution(file_path: str) -> FileAttribution:
     baseline_buffer = load_git_object_as_buffer_or_empty(f"HEAD:{file_path}")
     working_tree_buffer = load_working_tree_file_as_buffer(file_path)
     with baseline_buffer as baseline_lines, working_tree_buffer as working_tree_lines:
-        comparison = _build_file_comparison_from_lines(
+        all_units_map: dict[str, AttributionUnit] = {}
+        with _build_file_comparison_from_lines(
             file_path,
             baseline_lines=baseline_lines,
             working_tree_lines=working_tree_lines,
-        )
-        all_units_map: dict[str, AttributionUnit] = {}
-        enumerate_units_from_file_comparison(comparison, all_units_map)
+        ) as comparison:
+            enumerate_units_from_file_comparison(comparison, all_units_map)
 
         if all_batch_metadata:
             _enumerate_units_from_batches(
@@ -484,65 +494,65 @@ def _enumerate_units_from_batches(
             if len(batch_source_lines) == 0 and _has_presence_source_lines(file_metadata):
                 continue
 
-            alignment = match_lines(
+            with match_lines(
                 source_lines=batch_source_lines,
                 target_lines=working_tree_lines,
-            )
+            ) as alignment:
 
-            for source_line in _parse_presence_source_lines(file_metadata):
-                if source_line < 1 or source_line > len(batch_source_lines):
-                    continue
+                for source_line in _parse_presence_source_lines(file_metadata):
+                    if source_line < 1 or source_line > len(batch_source_lines):
+                        continue
 
-                claimed_content = batch_source_lines[source_line - 1]
-                working_tree_line = alignment.get_target_line_from_source_line(source_line)
-                unit = AttributionUnit(
-                    unit_id=_make_unit_id(
-                        AttributionUnitKind.PRESENCE_ONLY,
-                        file_path,
-                        claimed_line=working_tree_line,
+                    claimed_content = batch_source_lines[source_line - 1]
+                    working_tree_line = alignment.get_target_line_from_source_line(source_line)
+                    unit = AttributionUnit(
+                        unit_id=_make_unit_id(
+                            AttributionUnitKind.PRESENCE_ONLY,
+                            file_path,
+                            claimed_line=working_tree_line,
+                            claimed_content=claimed_content,
+                        ),
+                        kind=AttributionUnitKind.PRESENCE_ONLY,
+                        file_path=file_path,
+                        claimed_line_in_working_tree=working_tree_line,
                         claimed_content=claimed_content,
-                    ),
-                    kind=AttributionUnitKind.PRESENCE_ONLY,
-                    file_path=file_path,
-                    claimed_line_in_working_tree=working_tree_line,
-                    claimed_content=claimed_content,
-                    deletion_anchor_in_working_tree=None,
-                    deletion_content=None,
-                )
-                units_map.setdefault(unit.unit_id, unit)
+                        deletion_anchor_in_working_tree=None,
+                        deletion_content=None,
+                    )
+                    units_map.setdefault(unit.unit_id, unit)
 
-            for deletion_entry in file_metadata.get("deletions", []):
-                blob_hash = deletion_entry.get("blob")
-                if not blob_hash:
-                    continue
+                for deletion_entry in file_metadata.get("deletions", []):
+                    blob_hash = deletion_entry.get("blob")
+                    if not blob_hash:
+                        continue
 
-                deletion_fingerprint = _fingerprint_git_blob(blob_hash)
-                if deletion_fingerprint is None:
-                    continue
+                    deletion_fingerprint = _fingerprint_git_blob(blob_hash)
+                    if deletion_fingerprint is None:
+                        continue
 
-                after_source_line = deletion_entry.get("after_source_line")
-                deletion_anchor = (
-                    None
-                    if after_source_line is None
-                    else alignment.get_target_line_from_source_line(after_source_line)
-                )
+                    after_source_line = deletion_entry.get("after_source_line")
+                    deletion_anchor = (
+                        None
+                        if after_source_line is None
+                        else alignment.get_target_line_from_source_line(after_source_line)
+                    )
 
-                unit = AttributionUnit(
-                    unit_id=_make_unit_id(
-                        AttributionUnitKind.DELETION_ONLY,
-                        file_path,
-                        deletion_anchor=deletion_anchor,
+                    unit = AttributionUnit(
+                        unit_id=_make_unit_id(
+                            AttributionUnitKind.DELETION_ONLY,
+                            file_path,
+                            deletion_anchor=deletion_anchor,
+                            deletion_fingerprint=deletion_fingerprint,
+                        ),
+                        kind=AttributionUnitKind.DELETION_ONLY,
+                        file_path=file_path,
+                        claimed_line_in_working_tree=None,
+                        claimed_content=None,
+                        deletion_anchor_in_working_tree=deletion_anchor,
+                        deletion_content=None,
                         deletion_fingerprint=deletion_fingerprint,
-                    ),
-                    kind=AttributionUnitKind.DELETION_ONLY,
-                    file_path=file_path,
-                    claimed_line_in_working_tree=None,
-                    claimed_content=None,
-                    deletion_anchor_in_working_tree=deletion_anchor,
-                    deletion_content=None,
-                    deletion_fingerprint=deletion_fingerprint,
-                )
-                units_map.setdefault(unit.unit_id, unit)
+                    )
+                    units_map.setdefault(unit.unit_id, unit)
 
 
 def _find_owning_batches(
@@ -562,33 +572,33 @@ def _find_owning_batches(
             f"{batch_source_commit}:{file_path}"
         )
         with batch_source_buffer as batch_source_lines:
-            alignment = match_lines(
+            with match_lines(
                 source_lines=batch_source_lines,
                 target_lines=working_tree_lines,
-            )
+            ) as alignment:
 
-            if unit.kind == AttributionUnitKind.PRESENCE_ONLY:
-                if _batch_owns_presence_unit(
-                    unit,
-                    file_metadata,
-                    alignment,
-                    batch_source_lines,
-                ):
-                    owning_batches.add(batch_name)
-            elif unit.kind == AttributionUnitKind.DELETION_ONLY:
-                if _batch_owns_deletion_unit(unit, file_metadata, alignment):
-                    owning_batches.add(batch_name)
-            elif unit.kind == AttributionUnitKind.REPLACEMENT:
-                if (
-                    _batch_owns_presence_unit(
+                if unit.kind == AttributionUnitKind.PRESENCE_ONLY:
+                    if _batch_owns_presence_unit(
                         unit,
                         file_metadata,
                         alignment,
                         batch_source_lines,
-                    )
-                    and _batch_owns_deletion_unit(unit, file_metadata, alignment)
-                ):
-                    owning_batches.add(batch_name)
+                    ):
+                        owning_batches.add(batch_name)
+                elif unit.kind == AttributionUnitKind.DELETION_ONLY:
+                    if _batch_owns_deletion_unit(unit, file_metadata, alignment):
+                        owning_batches.add(batch_name)
+                elif unit.kind == AttributionUnitKind.REPLACEMENT:
+                    if (
+                        _batch_owns_presence_unit(
+                            unit,
+                            file_metadata,
+                            alignment,
+                            batch_source_lines,
+                        )
+                        and _batch_owns_deletion_unit(unit, file_metadata, alignment)
+                    ):
+                        owning_batches.add(batch_name)
 
     return owning_batches
 

--- a/src/git_stage_batch/batch/comparison.py
+++ b/src/git_stage_batch/batch/comparison.py
@@ -135,25 +135,25 @@ def derive_semantic_change_runs(
     Returns:
         List of semantic change runs describing the delta
     """
-    # Align source and target
-    alignment = match_lines(source_lines=source_lines, target_lines=target_lines)
-    reverse_alignment = match_lines(source_lines=target_lines, target_lines=source_lines)
-
     # Build bidirectional mappings
     source_to_target: dict[int, int] = {}
     target_to_source: dict[int, int] = {}
 
-    for source_idx in range(len(source_lines)):
-        source_line_num = source_idx + 1
-        target_line_num = alignment.get_target_line_from_source_line(source_line_num)
-        if target_line_num is not None:
-            reverse_source_line = reverse_alignment.get_target_line_from_source_line(
-                target_line_num
-            )
-            if reverse_source_line != source_line_num:
-                continue
-            source_to_target[source_line_num] = target_line_num
-            target_to_source[target_line_num] = source_line_num
+    with (
+        match_lines(source_lines=source_lines, target_lines=target_lines) as alignment,
+        match_lines(source_lines=target_lines, target_lines=source_lines) as reverse_alignment,
+    ):
+        for source_idx in range(len(source_lines)):
+            source_line_num = source_idx + 1
+            target_line_num = alignment.get_target_line_from_source_line(source_line_num)
+            if target_line_num is not None:
+                reverse_source_line = reverse_alignment.get_target_line_from_source_line(
+                    target_line_num
+                )
+                if reverse_source_line != source_line_num:
+                    continue
+                source_to_target[source_line_num] = target_line_num
+                target_to_source[target_line_num] = source_line_num
 
     # Find unmatched lines
     source_unmatched = [

--- a/src/git_stage_batch/batch/display.py
+++ b/src/git_stage_batch/batch/display.py
@@ -334,5 +334,5 @@ def annotate_with_batch_source_lines(
     working_lines: Sequence[bytes],
 ) -> LineLevelChange:
     """Annotate LineLevelChange from indexed batch-source and working lines."""
-    mapping = match_lines(batch_source_lines, working_lines)
-    return _apply_batch_source_mapping(line_changes, mapping)
+    with match_lines(batch_source_lines, working_lines) as mapping:
+        return _apply_batch_source_mapping(line_changes, mapping)

--- a/src/git_stage_batch/batch/match.py
+++ b/src/git_stage_batch/batch/match.py
@@ -2,44 +2,49 @@
 
 from __future__ import annotations
 
-from array import array
 from bisect import bisect_left
 from collections.abc import Hashable, Iterator, Sequence
 from dataclasses import dataclass, field
-from typing import TypeVar
+from typing import Protocol, TypeVar
 
+from .match_storage import MatcherWorkspace
+from ..utils.mapped_storage import MappedIntVector, MappedRecordVector
 from ..utils.text import AcquirableLineSequence, as_acquirable_line_sequence
 
 
 LineContent = TypeVar("LineContent", bound=Hashable)
 _MAX_UINT32 = (1 << 32) - 1
+_MAX_UINT64 = (1 << 64) - 1
+_LINE_PAIR_RECORD_FORMAT = "QQ"
+_OCCURRENCE_RECORD_FORMAT = "QQQQQQ"
+_OCCURRENCE_HASH = 0
+_OCCURRENCE_SOURCE_INDEX = 1
+_OCCURRENCE_SOURCE_COUNT = 2
+_OCCURRENCE_TARGET_INDEX = 3
+_OCCURRENCE_TARGET_COUNT = 4
+_OCCURRENCE_NEXT = 5
 
 
-@dataclass(frozen=True, slots=True)
-class UniqueLinePosition:
-    """Position of a line that appears exactly once in a segment."""
+class IntVector(Protocol):
+    """Fixed-width integer vector used by line mappings."""
 
-    index: int
+    def __len__(self) -> int: ...
 
+    def __getitem__(self, index: int) -> int: ...
 
-@dataclass(slots=True)
-class _LineOccurrenceState:
-    """Occurrence state for one line content while scanning a segment."""
-
-    first_index: int
-    is_unique: bool = True
+    def __setitem__(self, index: int, value: int) -> None: ...
 
 
 @dataclass
 class LineMapping:
     """Alignment between batch source lines and working tree lines."""
 
-    source_to_target: array
-    target_to_source: array
+    source_to_target: IntVector
+    target_to_source: IntVector
     _closed: bool = field(default=False, init=False, repr=False)
     _close_on_exit: bool = field(default=True, init=False, repr=False)
 
-    def __enter__(self) -> "LineMapping":
+    def __enter__(self) -> LineMapping:
         self._require_open()
         self._close_on_exit = True
         return self
@@ -48,7 +53,7 @@ class LineMapping:
         if self._close_on_exit:
             self.close()
 
-    def detach(self) -> "LineMapping":
+    def detach(self) -> LineMapping:
         """Transfer ownership out of the current context manager."""
         self._require_open()
         self._close_on_exit = False
@@ -106,23 +111,27 @@ class LineMapping:
             raise ValueError("line mapping is closed")
 
 
-def _close_vector(vector: array) -> None:
+def _close_vector(vector: IntVector) -> None:
     close = getattr(vector, "close", None)
     if close is not None:
         close()
 
 
-def _line_mapping_typecode(max_line_number: int) -> str:
+def _line_mapping_width(max_line_number: int) -> int:
     if max_line_number <= _MAX_UINT32:
-        return "I"
-    return "Q"
+        return 4
+    return 8
 
 
-def _new_line_mapping(size: int, max_line_number: int) -> array:
-    return array(_line_mapping_typecode(max_line_number), [0]) * size
+def _new_line_mapping(size: int, max_line_number: int) -> MappedIntVector:
+    return MappedIntVector(
+        size,
+        width=_line_mapping_width(max_line_number),
+        fill=0,
+    )
 
 
-def _lookup_line_mapping(mapping: array, line_number: int) -> int | None:
+def _lookup_line_mapping(mapping: IntVector, line_number: int) -> int | None:
     if line_number < 1 or line_number > len(mapping):
         return None
 
@@ -132,168 +141,318 @@ def _lookup_line_mapping(mapping: array, line_number: int) -> int | None:
     return mapped_line
 
 
-def _build_unique_position_map(
-    lines: Sequence[LineContent],
-    start: int,
-    end: int
-) -> dict[LineContent, UniqueLinePosition]:
-    """Return content -> position for lines that appear exactly once.
+class _LineOccurrenceTable:
+    """Storage-backed occurrence table for one active source/target segment."""
 
-    Args:
-        lines: Full line sequence.
-        start: Inclusive segment start (0-based).
-        end: Exclusive segment end (0-based).
+    def __init__(
+        self,
+        workspace: MatcherWorkspace,
+        source_lines: Sequence[LineContent],
+        source_start: int,
+        source_end: int,
+    ) -> None:
+        source_length = source_end - source_start
+        self._workspace = workspace
+        self._source_lines = source_lines
+        self._bucket_count = _occurrence_bucket_capacity(source_length)
+        self._buckets = workspace.int_vector(
+            self._bucket_count,
+            width=8,
+            fill=0,
+        )
+        self._records = workspace.record_vector(
+            source_length,
+            _OCCURRENCE_RECORD_FORMAT,
+        )
+        self._closed = False
 
-    Returns:
-        Mapping for uniquely occurring lines within the segment.
-    """
-    occurrences: dict[LineContent, _LineOccurrenceState]
-    unique_positions: dict[LineContent, UniqueLinePosition]
-    index: int
-    content: LineContent
-    occurrence: _LineOccurrenceState
+    def scan_source(self, start: int, end: int) -> None:
+        """Record source-side occurrence counts."""
+        for index in range(start, end):
+            line_hash = _line_hash(self._source_lines[index])
+            record_index = self._find_record(
+                self._source_lines,
+                index,
+                line_hash,
+            )
+            if record_index is None:
+                bucket_index = self._bucket_index(line_hash)
+                next_record = self._buckets[bucket_index]
+                new_record_index = self._records.append((
+                    line_hash,
+                    index,
+                    1,
+                    0,
+                    0,
+                    next_record,
+                ))
+                self._buckets[bucket_index] = new_record_index + 1
+                continue
 
-    occurrences = {}
-
-    for index in range(start, end):
-        content = lines[index]
-        try:
-            occurrence = occurrences[content]
-        except KeyError:
-            occurrences[content] = _LineOccurrenceState(first_index=index)
-        else:
-            occurrence.is_unique = False
-
-    unique_positions = {}
-    for content, occurrence in occurrences.items():
-        if occurrence.is_unique:
-            unique_positions[content] = UniqueLinePosition(
-                index=occurrence.first_index
+            record = self._records[record_index]
+            self._records[record_index] = _replace_record_value(
+                record,
+                _OCCURRENCE_SOURCE_COUNT,
+                min(2, record[_OCCURRENCE_SOURCE_COUNT] + 1),
             )
 
-    return unique_positions
+    def scan_target(
+        self,
+        target_lines: Sequence[LineContent],
+        start: int,
+        end: int,
+    ) -> None:
+        """Record target-side occurrences for source-known content."""
+        for index in range(start, end):
+            line_hash = _line_hash(target_lines[index])
+            record_index = self._find_record(target_lines, index, line_hash)
+            if record_index is None:
+                continue
+
+            record = self._records[record_index]
+            target_count = record[_OCCURRENCE_TARGET_COUNT]
+            if target_count == 0:
+                record = _replace_record_value(
+                    record,
+                    _OCCURRENCE_TARGET_INDEX,
+                    index,
+                )
+            self._records[record_index] = _replace_record_value(
+                record,
+                _OCCURRENCE_TARGET_COUNT,
+                min(2, target_count + 1),
+            )
+
+    def emit_candidate_pairs(
+        self,
+        workspace: MatcherWorkspace,
+        source_start: int,
+        source_end: int,
+    ) -> MappedRecordVector:
+        """Return source-ordered candidate anchor pairs."""
+        candidates = workspace.record_vector(
+            source_end - source_start,
+            _LINE_PAIR_RECORD_FORMAT,
+        )
+
+        for source_index in range(source_start, source_end):
+            line_hash = _line_hash(self._source_lines[source_index])
+            record_index = self._find_record(
+                self._source_lines,
+                source_index,
+                line_hash,
+            )
+            if record_index is None:
+                continue
+
+            record = self._records[record_index]
+            if (
+                record[_OCCURRENCE_SOURCE_INDEX] == source_index
+                and record[_OCCURRENCE_SOURCE_COUNT] == 1
+                and record[_OCCURRENCE_TARGET_COUNT] == 1
+            ):
+                candidates.append((
+                    source_index,
+                    record[_OCCURRENCE_TARGET_INDEX],
+                ))
+
+        return candidates
+
+    def close(self) -> None:
+        """Release mapped occurrence storage."""
+        if self._closed:
+            return
+        self._workspace.close_resource(self._records)
+        self._workspace.close_resource(self._buckets)
+        self._closed = True
+
+    def _find_record(
+        self,
+        lines: Sequence[LineContent],
+        index: int,
+        line_hash: int,
+    ) -> int | None:
+        record_number = self._buckets[self._bucket_index(line_hash)]
+        line = lines[index]
+
+        while record_number != 0:
+            record_index = record_number - 1
+            record = self._records[record_index]
+            if (
+                record[_OCCURRENCE_HASH] == line_hash
+                and self._source_lines[record[_OCCURRENCE_SOURCE_INDEX]] == line
+            ):
+                return record_index
+            record_number = record[_OCCURRENCE_NEXT]
+
+        return None
+
+    def _bucket_index(self, line_hash: int) -> int:
+        return line_hash & (self._bucket_count - 1)
 
 
-def _is_better_lis_entry(
-    candidate: tuple[int, int],
-    current: tuple[int, int]
+def _occurrence_bucket_capacity(source_length: int) -> int:
+    capacity = 1
+    target_capacity = max(1, source_length * 2)
+    while capacity < target_capacity:
+        capacity <<= 1
+    return capacity
+
+
+def _line_hash(line: Hashable) -> int:
+    return hash(line) & _MAX_UINT64
+
+
+def _replace_record_value(
+    record: tuple[int, ...],
+    field_index: int,
+    value: int,
+) -> tuple[int, ...]:
+    mutable = list(record)
+    mutable[field_index] = value
+    return tuple(mutable)
+
+
+def _longest_increasing_subsequence_records(
+    pairs: MappedRecordVector,
+    target_start: int,
+    target_end: int,
+    workspace: MatcherWorkspace,
+) -> MappedRecordVector:
+    """Return mapped LIS anchors for source-ordered candidate records."""
+    pair_count = len(pairs)
+
+    if pair_count == 0 or target_end <= target_start:
+        return workspace.record_vector(0, _LINE_PAIR_RECORD_FORMAT)
+
+    target_indices = sorted({
+        pairs[pair_index][1]
+        for pair_index in range(pair_count)
+    })
+    best_lengths = workspace.int_vector(len(target_indices) + 1, width=8, fill=0)
+    best_indexes = workspace.int_vector(len(target_indices) + 1, width=8, fill=0)
+    predecessors = workspace.int_vector(pair_count, width=8, fill=0)
+    result_indexes = None
+
+    try:
+        best_length = 0
+        best_index_number = 0
+
+        for pair_index in range(pair_count):
+            _, target_index = pairs[pair_index]
+            target_rank = bisect_left(target_indices, target_index) + 1
+            predecessor_length, predecessor_index_number = (
+                _query_best_record_by_target_rank(
+                    best_lengths,
+                    best_indexes,
+                    target_rank - 1,
+                )
+            )
+            current_length = predecessor_length + 1
+
+            if predecessor_index_number != 0:
+                predecessors[pair_index] = predecessor_index_number
+
+            if current_length > best_length:
+                best_length = current_length
+                best_index_number = pair_index + 1
+
+            _update_best_record_by_target_rank(
+                best_lengths,
+                best_indexes,
+                target_rank,
+                current_length,
+                pair_index + 1,
+            )
+
+        anchors = workspace.record_vector(best_length, _LINE_PAIR_RECORD_FORMAT)
+        if best_length == 0:
+            return anchors
+
+        result_indexes = workspace.int_vector(best_length, width=8, fill=0)
+        result_offset = best_length - 1
+        index_number = best_index_number
+
+        while index_number != 0:
+            result_indexes[result_offset] = index_number
+            result_offset -= 1
+            index_number = predecessors[index_number - 1]
+
+        for result_offset in range(best_length):
+            source_index, target_index = pairs[result_indexes[result_offset] - 1]
+            anchors.append((source_index, target_index))
+
+        return anchors
+    finally:
+        if result_indexes is not None:
+            workspace.close_resource(result_indexes)
+        workspace.close_resource(predecessors)
+        workspace.close_resource(best_indexes)
+        workspace.close_resource(best_lengths)
+
+
+def _query_best_record_by_target_rank(
+    best_lengths: IntVector,
+    best_indexes: IntVector,
+    target_rank: int,
+) -> tuple[int, int]:
+    """Return the best mapped LIS record ending before a target rank."""
+    best_length = 0
+    best_index_number = 0
+
+    while target_rank > 0:
+        candidate_length = best_lengths[target_rank]
+        candidate_index_number = best_indexes[target_rank]
+        if _is_better_lis_record_entry(
+            candidate_length,
+            candidate_index_number,
+            best_length,
+            best_index_number,
+        ):
+            best_length = candidate_length
+            best_index_number = candidate_index_number
+        target_rank -= target_rank & -target_rank
+
+    return best_length, best_index_number
+
+
+def _update_best_record_by_target_rank(
+    best_lengths: IntVector,
+    best_indexes: IntVector,
+    target_rank: int,
+    candidate_length: int,
+    candidate_index_number: int,
+) -> None:
+    """Record a mapped LIS candidate ending at a target rank."""
+    while target_rank < len(best_lengths):
+        if _is_better_lis_record_entry(
+            candidate_length,
+            candidate_index_number,
+            best_lengths[target_rank],
+            best_indexes[target_rank],
+        ):
+            best_lengths[target_rank] = candidate_length
+            best_indexes[target_rank] = candidate_index_number
+        target_rank += target_rank & -target_rank
+
+
+def _is_better_lis_record_entry(
+    candidate_length: int,
+    candidate_index_number: int,
+    current_length: int,
+    current_index_number: int,
 ) -> bool:
-    """Prefer longer subsequences, then earlier source-ordered endings."""
-    candidate_length: int
-    candidate_index: int
-    current_length: int
-    current_index: int
-
-    candidate_length, candidate_index = candidate
-    current_length, current_index = current
-
+    """Prefer longer mapped subsequences, then earlier source endings."""
     if candidate_length != current_length:
         return candidate_length > current_length
 
     if candidate_length == 0:
         return False
 
-    return candidate_index < current_index
+    if current_index_number == 0:
+        return True
 
-
-def _query_best_by_target_rank(
-    best_by_target_rank: list[tuple[int, int]],
-    target_rank: int
-) -> tuple[int, int]:
-    """Return the best LIS ending before a target rank."""
-    best: tuple[int, int]
-    candidate: tuple[int, int]
-
-    best = (0, -1)
-
-    while target_rank > 0:
-        candidate = best_by_target_rank[target_rank]
-        if _is_better_lis_entry(candidate, best):
-            best = candidate
-        target_rank -= target_rank & -target_rank
-
-    return best
-
-
-def _update_best_by_target_rank(
-    best_by_target_rank: list[tuple[int, int]],
-    target_rank: int,
-    candidate: tuple[int, int]
-) -> None:
-    """Record a candidate LIS ending at a target rank."""
-    while target_rank < len(best_by_target_rank):
-        if _is_better_lis_entry(candidate, best_by_target_rank[target_rank]):
-            best_by_target_rank[target_rank] = candidate
-        target_rank += target_rank & -target_rank
-
-
-def _longest_increasing_subsequence(
-    pairs: list[tuple[int, int]]
-) -> list[tuple[int, int]]:
-    """Return a longest increasing subsequence by target index.
-
-    Uses an O(n log n) best_by_target_rank table.
-    Equal-length ties keep the earliest source-ordered pair.
-
-    Args:
-        pairs: Candidate (source_index, target_index) pairs sorted by source index.
-
-    Returns:
-        Monotonic anchor pairs preserving both source and target order.
-    """
-    target_indices: list[int]
-    best_by_target_rank: list[tuple[int, int]]
-    predecessors: list[int | None]
-    best_length: int
-    best_index: int
-    pair_index: int
-    target_index: int
-    target_rank: int
-    predecessor_length: int
-    predecessor_index: int
-    current_length: int
-    result: list[tuple[int, int]]
-    index: int | None
-
-    if not pairs:
-        return []
-
-    target_indices = sorted({target_index for _, target_index in pairs})
-    best_by_target_rank = [(0, -1)] * (len(target_indices) + 1)
-    predecessors = [None] * len(pairs)
-    best_length = 0
-    best_index = 0
-
-    for pair_index, (_, target_index) in enumerate(pairs):
-        target_rank = bisect_left(target_indices, target_index) + 1
-        predecessor_length, predecessor_index = _query_best_by_target_rank(
-            best_by_target_rank,
-            target_rank - 1
-        )
-        current_length = predecessor_length + 1
-
-        if predecessor_index >= 0:
-            predecessors[pair_index] = predecessor_index
-
-        if current_length > best_length:
-            best_length = current_length
-            best_index = pair_index
-
-        _update_best_by_target_rank(
-            best_by_target_rank,
-            target_rank,
-            (current_length, pair_index)
-        )
-
-    result = []
-    index = best_index
-
-    while index is not None:
-        result.append(pairs[index])
-        index = predecessors[index]
-
-    result.reverse()
-    return result
+    return candidate_index_number < current_index_number
 
 
 def _map_equal_prefix(
@@ -303,8 +462,8 @@ def _map_equal_prefix(
     source_end: int,
     target_start: int,
     target_end: int,
-    source_to_target: array,
-    target_to_source: array
+    source_to_target: IntVector,
+    target_to_source: IntVector
 ) -> tuple[int, int]:
     """Map equal prefix lines and return new segment starts."""
     while (
@@ -327,8 +486,8 @@ def _map_equal_suffix(
     source_end: int,
     target_start: int,
     target_end: int,
-    source_to_target: array,
-    target_to_source: array
+    source_to_target: IntVector,
+    target_to_source: IntVector
 ) -> tuple[int, int]:
     """Map equal suffix lines and return new segment ends."""
     while (
@@ -351,8 +510,9 @@ def _align_segment(
     source_end: int,
     target_start: int,
     target_end: int,
-    source_to_target: array,
-    target_to_source: array
+    source_to_target: IntVector,
+    target_to_source: IntVector,
+    workspace: MatcherWorkspace,
 ) -> None:
     """Conservatively align one source/target segment.
 
@@ -366,13 +526,9 @@ def _align_segment(
     This function is intentionally conservative. It never guesses inside
     structurally ambiguous regions.
     """
-    source_unique: dict[LineContent, UniqueLinePosition]
-    target_unique: dict[LineContent, UniqueLinePosition]
-    candidate_pairs: list[tuple[int, int]]
-    content: LineContent
-    source_position: UniqueLinePosition
-    target_position: UniqueLinePosition | None
-    anchors: list[tuple[int, int]]
+    occurrence_table: _LineOccurrenceTable
+    candidate_pairs: MappedRecordVector
+    anchors: MappedRecordVector
     previous_source: int
     previous_target: int
     anchor_source: int
@@ -403,59 +559,73 @@ def _align_segment(
     if source_start >= source_end or target_start >= target_end:
         return
 
-    source_unique = _build_unique_position_map(source_lines, source_start, source_end)
-    target_unique = _build_unique_position_map(target_lines, target_start, target_end)
+    occurrence_table = _LineOccurrenceTable(
+        workspace,
+        source_lines,
+        source_start,
+        source_end,
+    )
+    try:
+        occurrence_table.scan_source(source_start, source_end)
+        occurrence_table.scan_target(target_lines, target_start, target_end)
+        candidate_pairs = occurrence_table.emit_candidate_pairs(
+            workspace,
+            source_start,
+            source_end,
+        )
+    finally:
+        occurrence_table.close()
 
-    candidate_pairs = []
-    for content, source_position in source_unique.items():
-        target_position = target_unique.get(content)
-        if target_position is not None:
-            candidate_pairs.append(
-                (
-                    source_position.index,
-                    target_position.index
-                )
-            )
-
-    candidate_pairs.sort()
-    anchors = _longest_increasing_subsequence(candidate_pairs)
-
-    del source_unique, target_unique, candidate_pairs
+    try:
+        anchors = _longest_increasing_subsequence_records(
+            candidate_pairs,
+            target_start,
+            target_end,
+            workspace,
+        )
+    finally:
+        workspace.close_resource(candidate_pairs)
 
     if not anchors:
+        workspace.close_resource(anchors)
         return
 
     previous_source = source_start
     previous_target = target_start
 
-    for anchor_source, anchor_target in anchors:
+    try:
+        for anchor_source, anchor_target in anchors:
+            _align_segment(
+                source_lines,
+                target_lines,
+                previous_source,
+                anchor_source,
+                previous_target,
+                anchor_target,
+                source_to_target,
+                target_to_source,
+                workspace,
+            )
+
+            source_to_target[anchor_source] = anchor_target + 1
+            target_to_source[anchor_target] = anchor_source + 1
+
+            previous_source = anchor_source + 1
+            previous_target = anchor_target + 1
+
         _align_segment(
             source_lines,
             target_lines,
             previous_source,
-            anchor_source,
+            source_end,
             previous_target,
-            anchor_target,
+            target_end,
             source_to_target,
-            target_to_source
+            target_to_source,
+            workspace,
         )
-
-        source_to_target[anchor_source] = anchor_target + 1
-        target_to_source[anchor_target] = anchor_source + 1
-
-        previous_source = anchor_source + 1
-        previous_target = anchor_target + 1
-
-    _align_segment(
-        source_lines,
-        target_lines,
-        previous_source,
-        source_end,
-        previous_target,
-        target_end,
-        source_to_target,
-        target_to_source
-    )
+    finally:
+        workspace.close_resource(anchors)
 
 
 def match_acquirable_lines(
@@ -482,8 +652,9 @@ def match_acquirable_lines(
     Returns:
         A bidirectional line mapping with ambiguous lines left unmapped.
     """
-    source_to_target: array
-    target_to_source: array
+    source_to_target: MappedIntVector
+    target_to_source: MappedIntVector
+    workspace: MatcherWorkspace
     max_line_number: int
     source_line_count: int
     target_line_count: int
@@ -494,25 +665,32 @@ def match_acquirable_lines(
     source_to_target = _new_line_mapping(source_line_count, max_line_number)
     target_to_source = _new_line_mapping(target_line_count, max_line_number)
 
-    with (
-        source_lines.acquire_lines() as acquired_source_lines,
-        target_lines.acquire_lines() as acquired_target_lines,
-    ):
-        _align_segment(
-            acquired_source_lines,
-            acquired_target_lines,
-            0,
-            source_line_count,
-            0,
-            target_line_count,
-            source_to_target,
-            target_to_source
-        )
+    try:
+        with (
+            MatcherWorkspace() as workspace,
+            source_lines.acquire_lines() as acquired_source_lines,
+            target_lines.acquire_lines() as acquired_target_lines,
+        ):
+            _align_segment(
+                acquired_source_lines,
+                acquired_target_lines,
+                0,
+                source_line_count,
+                0,
+                target_line_count,
+                source_to_target,
+                target_to_source,
+                workspace,
+            )
 
-    return LineMapping(
-        source_to_target=source_to_target,
-        target_to_source=target_to_source
-    )
+        return LineMapping(
+            source_to_target=source_to_target,
+            target_to_source=target_to_source
+        )
+    except Exception:
+        source_to_target.close()
+        target_to_source.close()
+        raise
 
 
 def match_lines(

--- a/src/git_stage_batch/batch/match.py
+++ b/src/git_stage_batch/batch/match.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from array import array
 from bisect import bisect_left
-from collections.abc import Hashable, Sequence
-from dataclasses import dataclass
+from collections.abc import Hashable, Iterator, Sequence
+from dataclasses import dataclass, field
 from typing import TypeVar
 
 from ..utils.text import AcquirableLineSequence, as_acquirable_line_sequence
@@ -36,12 +36,45 @@ class LineMapping:
 
     source_to_target: array
     target_to_source: array
+    _closed: bool = field(default=False, init=False, repr=False)
+    _close_on_exit: bool = field(default=True, init=False, repr=False)
+
+    def __enter__(self) -> "LineMapping":
+        self._require_open()
+        self._close_on_exit = True
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        if self._close_on_exit:
+            self.close()
+
+    def detach(self) -> "LineMapping":
+        """Transfer ownership out of the current context manager."""
+        self._require_open()
+        self._close_on_exit = False
+        return self
+
+    def close(self) -> None:
+        """Close owned vector storage."""
+        if self._closed:
+            return
+
+        _close_vector(self.source_to_target)
+        _close_vector(self.target_to_source)
+        self._closed = True
+
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except Exception:
+            pass
 
     def is_source_line_present(
         self,
         source_line: int
     ) -> bool:
         """Check if a batch source line is present in working tree."""
+        self._require_open()
         return _lookup_line_mapping(self.source_to_target, source_line) is not None
 
     def get_target_line_from_source_line(
@@ -49,6 +82,7 @@ class LineMapping:
         source_line: int
     ) -> int | None:
         """Map batch source line to working tree line."""
+        self._require_open()
         return _lookup_line_mapping(self.source_to_target, source_line)
 
     def get_source_line_from_target_line(
@@ -56,7 +90,26 @@ class LineMapping:
         target_line: int
     ) -> int | None:
         """Map working tree line to batch source line."""
+        self._require_open()
         return _lookup_line_mapping(self.target_to_source, target_line)
+
+    def mapped_line_pairs(self) -> Iterator[tuple[int, int]]:
+        """Yield mapped source/target line pairs in source-line order."""
+        self._require_open()
+        for source_index in range(len(self.source_to_target)):
+            target_line = self.source_to_target[source_index]
+            if target_line != 0:
+                yield source_index + 1, target_line
+
+    def _require_open(self) -> None:
+        if self._closed:
+            raise ValueError("line mapping is closed")
+
+
+def _close_vector(vector: array) -> None:
+    close = getattr(vector, "close", None)
+    if close is not None:
+        close()
 
 
 def _line_mapping_typecode(max_line_number: int) -> str:

--- a/src/git_stage_batch/batch/match_storage.py
+++ b/src/git_stage_batch/batch/match_storage.py
@@ -1,0 +1,51 @@
+"""Mapped storage helpers for structural matching."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..utils.mapped_storage import (
+    ManagedMappedResources,
+    MappedIntVector,
+    MappedRecordVector,
+)
+
+
+class MatcherWorkspace(ManagedMappedResources):
+    """Own temporary mapped matcher scratch resources."""
+
+    def __init__(self, *, spool_dir: str | Path | None = None) -> None:
+        super().__init__()
+        self._spool_dir = spool_dir
+
+    def int_vector(
+        self,
+        length: int,
+        *,
+        width: int = 8,
+        fill: int = 0,
+    ) -> MappedIntVector:
+        """Create and track a fixed-width integer vector."""
+        vector = MappedIntVector(
+            length,
+            width=width,
+            fill=fill,
+            spool_dir=self._spool_dir,
+        )
+        return self.track(vector)  # type: ignore[return-value]
+
+    def record_vector(
+        self,
+        capacity: int,
+        record_format: str,
+        *,
+        length: int | None = None,
+    ) -> MappedRecordVector:
+        """Create and track a fixed-record vector."""
+        vector = MappedRecordVector(
+            capacity,
+            record_format,
+            length=length,
+            spool_dir=self._spool_dir,
+        )
+        return self.track(vector)  # type: ignore[return-value]

--- a/src/git_stage_batch/batch/merge.py
+++ b/src/git_stage_batch/batch/merge.py
@@ -893,7 +893,31 @@ def _apply_presence_constraints(
     Returns:
         Realized entries with all claimed lines present and provenance preserved
     """
-    mapping = source_to_working_mapping or match_lines(source_lines, working_lines)
+    owned_mapping: LineMapping | None = None
+    mapping = source_to_working_mapping
+    if mapping is None:
+        owned_mapping = match_lines(source_lines, working_lines)
+        mapping = owned_mapping
+
+    try:
+        return _apply_presence_constraints_with_mapping(
+            source_lines,
+            working_lines,
+            presence_line_set,
+            mapping,
+        )
+    finally:
+        if owned_mapping is not None:
+            owned_mapping.close()
+
+
+def _apply_presence_constraints_with_mapping(
+    source_lines: Sequence[bytes],
+    working_lines: Sequence[bytes],
+    presence_line_set: set[int],
+    mapping: LineMapping,
+) -> _RealizedEntries:
+    """Apply presence constraints using an existing source-to-working mapping."""
 
     if not presence_line_set:
         result = _RealizedEntries()
@@ -1838,7 +1862,11 @@ def _merge_batch_acquired_line_chunks(
         yield from _byte_chunks(fallback_chunks)
         return
 
-    mapping = source_to_working_mapping or match_lines(source_lines, working_lines)
+    owned_mapping: LineMapping | None = None
+    mapping = source_to_working_mapping
+    if mapping is None:
+        owned_mapping = match_lines(source_lines, working_lines)
+        mapping = owned_mapping
     try:
         _check_structural_validity(
             mapping,
@@ -1867,6 +1895,9 @@ def _merge_batch_acquired_line_chunks(
             yield from _byte_chunks(fallback_chunks)
             return
         raise
+    finally:
+        if owned_mapping is not None:
+            owned_mapping.close()
 
     yield from _realized_entry_content_chunks(realized_entries)
 
@@ -1930,18 +1961,17 @@ def _discard_batch_acquired_line_chunks(
     presence_line_set = resolved.presence_line_set
     deletion_claims = resolved.deletion_claims
 
-    working_to_source = match_lines(source_lines, working_lines)
+    with match_lines(source_lines, working_lines) as working_to_source:
+        correspondence = _build_baseline_correspondence(
+            baseline_lines,
+            source_lines
+        )
 
-    correspondence = _build_baseline_correspondence(
-        baseline_lines,
-        source_lines
-    )
-
-    realized_entries = _build_realized_entries_for_discard(
-        source_lines,
-        working_lines,
-        working_to_source
-    )
+        realized_entries = _build_realized_entries_for_discard(
+            source_lines,
+            working_lines,
+            working_to_source
+        )
 
     realized_entries = _reverse_presence_constraints(
         realized_entries,
@@ -1996,40 +2026,40 @@ def _build_baseline_correspondence(
     regions: list[BaselineRegion] = []
     state = _BaselineCorrespondenceScanState()
 
-    mapping = match_lines(baseline_lines, source_lines)
-    for baseline_index in range(len(baseline_lines)):
-        source_line = mapping.get_target_line_from_source_line(baseline_index + 1)
-        if source_line is None:
-            continue
+    with match_lines(baseline_lines, source_lines) as mapping:
+        for baseline_index in range(len(baseline_lines)):
+            source_line = mapping.get_target_line_from_source_line(baseline_index + 1)
+            if source_line is None:
+                continue
 
-        source_index = source_line - 1
+            source_index = source_line - 1
 
-        if not state.has_run:
+            if not state.has_run:
+                state = _start_baseline_anchor_run(
+                    state,
+                    baseline_index,
+                    source_index,
+                )
+                continue
+
+            if (
+                baseline_index == state.run_base_end
+                and source_index == state.run_source_end
+            ):
+                state = _extend_baseline_anchor_run(state)
+                continue
+
+            state = _flush_baseline_anchor_run(
+                regions,
+                state,
+                baseline_lines,
+                source_lines,
+            )
             state = _start_baseline_anchor_run(
                 state,
                 baseline_index,
                 source_index,
             )
-            continue
-
-        if (
-            baseline_index == state.run_base_end
-            and source_index == state.run_source_end
-        ):
-            state = _extend_baseline_anchor_run(state)
-            continue
-
-        state = _flush_baseline_anchor_run(
-            regions,
-            state,
-            baseline_lines,
-            source_lines,
-        )
-        state = _start_baseline_anchor_run(
-            state,
-            baseline_index,
-            source_index,
-        )
 
     state = _flush_baseline_anchor_run(
         regions,
@@ -2160,15 +2190,15 @@ def _append_baseline_gap_region(
         baseline_segment = _LineRange(baseline_lines, base_start, base_end)
         source_segment = _LineRange(source_lines, src_start, src_end)
 
-        sub_mapping = match_lines(baseline_segment, source_segment)
-        all_baseline_mapped = all(
-            sub_mapping.get_target_line_from_source_line(index + 1) is not None
-            for index in range(len(baseline_segment))
-        )
-        all_source_mapped = all(
-            sub_mapping.get_source_line_from_target_line(index + 1) is not None
-            for index in range(len(source_segment))
-        )
+        with match_lines(baseline_segment, source_segment) as sub_mapping:
+            all_baseline_mapped = all(
+                sub_mapping.get_target_line_from_source_line(index + 1) is not None
+                for index in range(len(baseline_segment))
+            )
+            all_source_mapped = all(
+                sub_mapping.get_source_line_from_target_line(index + 1) is not None
+                for index in range(len(source_segment))
+            )
 
         kind = (
             RegionKind.REPLACE_LINE_BY_LINE

--- a/src/git_stage_batch/batch/ownership.py
+++ b/src/git_stage_batch/batch/ownership.py
@@ -25,7 +25,7 @@ from ..utils.git import (
     read_git_blobs_as_bytes,
 )
 from .comparison import SemanticChangeKind, derive_semantic_change_runs
-from .match import match_lines
+from .match import LineMapping, match_lines
 from .merge import (
     _apply_presence_constraints,
     _entry_source_line_at,
@@ -1830,8 +1830,15 @@ def remap_batch_ownership_to_new_source_lines(
     new_source_lines: Sequence[bytes],
 ) -> BatchOwnership:
     """Remap batch ownership between old and new source line sequences."""
-    mapping = match_lines(old_source_lines, new_source_lines)
+    with match_lines(old_source_lines, new_source_lines) as mapping:
+        return _remap_batch_ownership_with_mapping(ownership, mapping)
 
+
+def _remap_batch_ownership_with_mapping(
+    ownership: BatchOwnership,
+    mapping: LineMapping,
+) -> BatchOwnership:
+    """Remap batch ownership using an existing old-to-new source mapping."""
     # Remap presence lines
     old_presence = ownership.presence_line_set()
     new_presence = set()

--- a/src/git_stage_batch/batch/source_refresh.py
+++ b/src/git_stage_batch/batch/source_refresh.py
@@ -231,45 +231,49 @@ def _refresh_selected_lines_against_source_lines(
     if working_line_map is None:
         mapping = match_lines(source_lines, working_lines)
 
-    def map_working_line(line_number: int | None) -> int | None:
-        if line_number is None:
-            return None
-        if working_line_map is not None:
-            return working_line_map.get(line_number)
-        assert mapping is not None
-        return mapping.get_source_line_from_target_line(line_number)
+    try:
+        def map_working_line(line_number: int | None) -> int | None:
+            if line_number is None:
+                return None
+            if working_line_map is not None:
+                return working_line_map.get(line_number)
+            assert mapping is not None
+            return mapping.get_source_line_from_target_line(line_number)
 
-    last_source_line = None
-    reannotated_lines = []
+        last_source_line = None
+        reannotated_lines = []
 
-    for line in selected_lines:
-        if line.kind in (' ', '+'):
-            source_line = map_working_line(line.new_line_number)
-            if source_line is not None:
-                last_source_line = source_line
-        elif line.kind == '-':
-            source_line = last_source_line
-            if source_line is None and line.old_line_number is not None and line.old_line_number > 1:
-                source_line = map_working_line(line.old_line_number - 1)
-        else:
-            source_line = None
+        for line in selected_lines:
+            if line.kind in (' ', '+'):
+                source_line = map_working_line(line.new_line_number)
+                if source_line is not None:
+                    last_source_line = source_line
+            elif line.kind == '-':
+                source_line = last_source_line
+                if source_line is None and line.old_line_number is not None and line.old_line_number > 1:
+                    source_line = map_working_line(line.old_line_number - 1)
+            else:
+                source_line = None
 
-        reannotated_lines.append(LineEntry(
-            id=line.id,
-            kind=line.kind,
-            old_line_number=line.old_line_number,
-            new_line_number=line.new_line_number,
-            text_bytes=line.text_bytes,
-            source_line=source_line,
-            baseline_reference_after_line=line.baseline_reference_after_line,
-            baseline_reference_after_text_bytes=line.baseline_reference_after_text_bytes,
-            has_baseline_reference_after=line.has_baseline_reference_after,
-            baseline_reference_before_line=line.baseline_reference_before_line,
-            baseline_reference_before_text_bytes=line.baseline_reference_before_text_bytes,
-            has_baseline_reference_before=line.has_baseline_reference_before,
-        ))
+            reannotated_lines.append(LineEntry(
+                id=line.id,
+                kind=line.kind,
+                old_line_number=line.old_line_number,
+                new_line_number=line.new_line_number,
+                text_bytes=line.text_bytes,
+                source_line=source_line,
+                baseline_reference_after_line=line.baseline_reference_after_line,
+                baseline_reference_after_text_bytes=line.baseline_reference_after_text_bytes,
+                has_baseline_reference_after=line.has_baseline_reference_after,
+                baseline_reference_before_line=line.baseline_reference_before_line,
+                baseline_reference_before_text_bytes=line.baseline_reference_before_text_bytes,
+                has_baseline_reference_before=line.has_baseline_reference_before,
+            ))
 
-    return reannotated_lines
+        return reannotated_lines
+    finally:
+        if mapping is not None:
+            mapping.close()
 
 def prepare_batch_ownership_update_for_selection(
     batch_name: str,

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -1060,35 +1060,35 @@ def _render_batch_file_display_from_ownership(
             working_tree_buffer = load_working_tree_file_as_buffer(file_path)
             with working_tree_buffer as working_tree_lines:
                 working_match_lines = normalize_line_sequence_endings(working_tree_lines)
-                source_to_working_mapping = match_lines(
+                with match_lines(
                     source_match_lines,
                     working_match_lines,
-                )
+                ) as source_to_working_mapping:
 
-                units = build_ownership_units_from_display_lines(
-                    ownership,
-                    display_lines,
-                )
+                    units = build_ownership_units_from_display_lines(
+                        ownership,
+                        display_lines,
+                    )
 
-                # Check each ownership unit once. All lines in an atomic unit
-                # share the same mergeability result.
-                for unit in units:
-                    try:
-                        validate_ownership_units([unit])
-                        ownership_for_unit = rebuild_ownership_from_units([unit])
-                        if ownership_for_unit.is_empty():
-                            continue
-                        if not batch_merge.can_merge_batch_from_line_sequences(
-                            source_match_lines,
-                            ownership_for_unit,
-                            working_match_lines,
-                            source_to_working_mapping=source_to_working_mapping,
-                        ):
-                            continue
-                        mergeable_ids.update(unit.display_line_ids)
-                    except (MergeError, ValueError, KeyError, Exception):
-                        # Unit not mergeable - exclude all its lines
-                        pass
+                    # Check each ownership unit once. All lines in an atomic unit
+                    # share the same mergeability result.
+                    for unit in units:
+                        try:
+                            validate_ownership_units([unit])
+                            ownership_for_unit = rebuild_ownership_from_units([unit])
+                            if ownership_for_unit.is_empty():
+                                continue
+                            if not batch_merge.can_merge_batch_from_line_sequences(
+                                source_match_lines,
+                                ownership_for_unit,
+                                working_match_lines,
+                                source_to_working_mapping=source_to_working_mapping,
+                            ):
+                                continue
+                            mergeable_ids.update(unit.display_line_ids)
+                        except (MergeError, ValueError, KeyError, Exception):
+                            # Unit not mergeable - exclude all its lines
+                            pass
 
     if not display_lines:
         change_type = file_meta.get("change_type", "modified")

--- a/src/git_stage_batch/editor/buffer.py
+++ b/src/git_stage_batch/editor/buffer.py
@@ -10,10 +10,36 @@ from pathlib import Path
 import tempfile
 from typing import Any, BinaryIO, Generic, Iterator, TypeVar, overload
 
+from ..utils.mapped_storage import ChunkedMappedRecordVector
+
 
 _DEFAULT_CHUNK_SIZE = 1024 * 1024
+_LINE_SPAN_CHUNK_CAPACITY = 65536
 _BytesLike = bytes | bytearray | memoryview
 _LineT = TypeVar("_LineT")
+
+
+class _LineSpanVector:
+    """Compact append-only storage for byte line spans."""
+
+    def __init__(self) -> None:
+        self._records = ChunkedMappedRecordVector(
+            record_format="QQ",
+            chunk_capacity=_LINE_SPAN_CHUNK_CAPACITY,
+        )
+
+    def __len__(self) -> int:
+        return len(self._records)
+
+    def append(self, start: int, end: int) -> None:
+        self._records.append((start, end))
+
+    def get(self, index: int) -> tuple[int, int]:
+        start, end = self._records[index]
+        return start, end
+
+    def close(self) -> None:
+        self._records.close()
 
 
 class EditorBuffer(Sequence[bytes]):
@@ -27,7 +53,7 @@ class EditorBuffer(Sequence[bytes]):
     ) -> None:
         self._data = data
         self._file_handle = file_handle
-        self._line_spans: list[tuple[int, int]] = []
+        self._line_spans = _LineSpanVector()
         self._scan_position = 0
         self._scan_complete = len(data) == 0
         self._closed = False
@@ -110,6 +136,7 @@ class EditorBuffer(Sequence[bytes]):
             data.close()
         if self._file_handle is not None:
             self._file_handle.close()
+        self._line_spans.close()
         self._closed = True
 
     def __del__(self) -> None:
@@ -151,7 +178,7 @@ class EditorBuffer(Sequence[bytes]):
 
     def __len__(self) -> int:
         self._scan_all_lines()
-        return len(self._line_spans)
+        return self._line_span_count()
 
     @overload
     def __getitem__(self, index: int) -> bytes: ...
@@ -170,10 +197,10 @@ class EditorBuffer(Sequence[bytes]):
             raise IndexError(index)
 
         self._scan_through_line(index)
-        if index >= len(self._line_spans):
+        if index >= self._line_span_count():
             raise IndexError(index)
 
-        start, end = self._line_spans[index]
+        start, end = self._get_line_span(index)
         return self._data[start:end]
 
     def _require_open(self) -> None:
@@ -187,8 +214,17 @@ class EditorBuffer(Sequence[bytes]):
 
     def _scan_through_line(self, index: int) -> None:
         self._require_open()
-        while len(self._line_spans) <= index and not self._scan_complete:
+        while self._line_span_count() <= index and not self._scan_complete:
             self._scan_next_line()
+
+    def _line_span_count(self) -> int:
+        return len(self._line_spans)
+
+    def _append_line_span(self, start: int, end: int) -> None:
+        self._line_spans.append(start, end)
+
+    def _get_line_span(self, index: int) -> tuple[int, int]:
+        return self._line_spans.get(index)
 
     def _scan_next_line(self) -> None:
         data = self._data
@@ -202,13 +238,13 @@ class EditorBuffer(Sequence[bytes]):
         next_lf = data.find(b"\n", start)
 
         if next_lf == -1:
-            self._line_spans.append((start, content_length))
+            self._append_line_span(start, content_length)
             self._scan_position = content_length
             self._scan_complete = True
             return
 
         end = next_lf + 1
-        self._line_spans.append((start, end))
+        self._append_line_span(start, end)
         self._scan_position = end
         if self._scan_position >= content_length:
             self._scan_complete = True
@@ -383,10 +419,10 @@ class _AcquiredBufferLineSequence(Sequence[_BufferLineView]):
             raise IndexError(index)
 
         self._buffer._scan_through_line(index)
-        if index >= len(self._buffer._line_spans):
+        if index >= self._buffer._line_span_count():
             raise IndexError(index)
 
-        start, end = self._buffer._line_spans[index]
+        start, end = self._buffer._get_line_span(index)
         return _BufferLineView(self, start, end)
 
     def _require_active(self) -> None:

--- a/src/git_stage_batch/utils/mapped_storage.py
+++ b/src/git_stage_batch/utils/mapped_storage.py
@@ -1,0 +1,490 @@
+"""Tempfile-backed fixed-width storage helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+import mmap
+import struct
+import tempfile
+from pathlib import Path
+from typing import BinaryIO
+
+
+_UINT32_MAX = (1 << 32) - 1
+_UINT64_MAX = (1 << 64) - 1
+_FILL_CHUNK_BYTES = 1024 * 1024
+
+
+def _normalize_width(width: int) -> int:
+    if width not in (4, 8):
+        raise ValueError("integer width must be 4 or 8 bytes")
+    return width
+
+
+def _typecode_for_width(width: int) -> str:
+    return "I" if width == 4 else "Q"
+
+
+def _format_for_width(width: int) -> str:
+    return "<I" if width == 4 else "<Q"
+
+
+def _max_for_width(width: int) -> int:
+    return _UINT32_MAX if width == 4 else _UINT64_MAX
+
+
+def _check_unsigned(value: int, max_value: int) -> None:
+    if value < 0 or value > max_value:
+        raise OverflowError("value does not fit in unsigned storage")
+
+
+class MappedIntVector(Sequence[int]):
+    """Fixed-width unsigned integer vector backed by a temporary mmap."""
+
+    def __init__(
+        self,
+        length: int,
+        *,
+        width: int = 8,
+        fill: int = 0,
+        spool_dir: str | Path | None = None,
+    ) -> None:
+        if length < 0:
+            raise ValueError("length must be non-negative")
+
+        self._width = _normalize_width(width)
+        self._length = length
+        self._format = struct.Struct(_format_for_width(self._width))
+        self._max_value = _max_for_width(self._width)
+        self._byte_count = length * self._width
+        self._file_handle: BinaryIO | None = None
+        self._mmap: mmap.mmap | None = None
+        self._closed = False
+
+        _check_unsigned(fill, self._max_value)
+        if self._byte_count > 0:
+            self._file_handle = tempfile.TemporaryFile(
+                dir=None if spool_dir is None else Path(spool_dir)
+            )
+            self._file_handle.truncate(self._byte_count)
+            self._mmap = mmap.mmap(self._file_handle.fileno(), self._byte_count)
+            if fill != 0:
+                self.fill(fill)
+
+    @property
+    def typecode(self) -> str:
+        """Return an array-compatible unsigned integer type code."""
+        return _typecode_for_width(self._width)
+
+    @property
+    def byte_count(self) -> int:
+        """Return allocated mmap bytes."""
+        return 0 if self._closed else self._byte_count
+
+    @property
+    def closed(self) -> bool:
+        """Return whether the vector has been closed."""
+        return self._closed
+
+    def __len__(self) -> int:
+        self._require_open()
+        return self._length
+
+    def __getitem__(self, index: int | slice) -> int | list[int]:
+        self._require_open()
+        if isinstance(index, slice):
+            return [self[item] for item in range(*index.indices(self._length))]
+
+        index = self._normalize_index(index)
+        mm = self._require_mmap()
+        return self._format.unpack_from(mm, index * self._width)[0]
+
+    def __setitem__(self, index: int, value: int) -> None:
+        self._require_open()
+        index = self._normalize_index(index)
+        _check_unsigned(value, self._max_value)
+        mm = self._require_mmap()
+        self._format.pack_into(mm, index * self._width, value)
+
+    def fill(self, value: int) -> None:
+        """Set every slot to one unsigned value."""
+        self._require_open()
+        _check_unsigned(value, self._max_value)
+        if self._length == 0:
+            return
+
+        mm = self._require_mmap()
+        packed = self._format.pack(value)
+        repeat = max(1, _FILL_CHUNK_BYTES // self._width)
+        chunk = packed * min(self._length, repeat)
+        offset = 0
+        remaining = self._length
+
+        while remaining:
+            count = min(remaining, len(chunk) // self._width)
+            byte_count = count * self._width
+            mm[offset:offset + byte_count] = chunk[:byte_count]
+            offset += byte_count
+            remaining -= count
+
+    def close(self) -> None:
+        """Close mmap and temporary file resources."""
+        if self._closed:
+            return
+
+        if self._mmap is not None:
+            self._mmap.close()
+            self._mmap = None
+        if self._file_handle is not None:
+            self._file_handle.close()
+            self._file_handle = None
+        self._closed = True
+
+    def __enter__(self) -> MappedIntVector:
+        self._require_open()
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        self.close()
+
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except Exception:
+            pass
+
+    def _normalize_index(self, index: int) -> int:
+        if index < 0:
+            index += self._length
+        if index < 0 or index >= self._length:
+            raise IndexError(index)
+        return index
+
+    def _require_mmap(self) -> mmap.mmap:
+        if self._mmap is None:
+            raise IndexError("empty vector has no storage")
+        return self._mmap
+
+    def _require_open(self) -> None:
+        if self._closed:
+            raise ValueError("mapped integer vector is closed")
+
+
+class MappedRecordVector(Sequence[tuple[int, ...]]):
+    """Fixed-size record vector backed by a temporary mmap."""
+
+    def __init__(
+        self,
+        capacity: int,
+        record_format: str,
+        *,
+        length: int | None = None,
+        spool_dir: str | Path | None = None,
+    ) -> None:
+        if capacity < 0:
+            raise ValueError("capacity must be non-negative")
+        if length is None:
+            length = 0
+        if length < 0 or length > capacity:
+            raise ValueError("length must fit within capacity")
+
+        if not record_format:
+            raise ValueError("record format must not be empty")
+        if record_format[0] not in "@=<>!":
+            record_format = "<" + record_format
+
+        self._struct = struct.Struct(record_format)
+        self._capacity = capacity
+        self._length = length
+        self._byte_count = capacity * self._struct.size
+        self._file_handle: BinaryIO | None = None
+        self._mmap: mmap.mmap | None = None
+        self._closed = False
+
+        if self._byte_count > 0:
+            self._file_handle = tempfile.TemporaryFile(
+                dir=None if spool_dir is None else Path(spool_dir)
+            )
+            self._file_handle.truncate(self._byte_count)
+            self._mmap = mmap.mmap(self._file_handle.fileno(), self._byte_count)
+
+    @property
+    def capacity(self) -> int:
+        """Return the maximum record count."""
+        self._require_open()
+        return self._capacity
+
+    @property
+    def record_size(self) -> int:
+        """Return bytes per record."""
+        return self._struct.size
+
+    @property
+    def byte_count(self) -> int:
+        """Return allocated mmap bytes."""
+        return 0 if self._closed else self._byte_count
+
+    @property
+    def closed(self) -> bool:
+        """Return whether the vector has been closed."""
+        return self._closed
+
+    def __len__(self) -> int:
+        self._require_open()
+        return self._length
+
+    def __getitem__(self, index: int | slice) -> tuple[int, ...] | list[tuple[int, ...]]:
+        self._require_open()
+        if isinstance(index, slice):
+            return [self[item] for item in range(*index.indices(self._length))]
+
+        index = self._normalize_index(index)
+        mm = self._require_mmap()
+        return self._struct.unpack_from(mm, index * self._struct.size)
+
+    def __setitem__(self, index: int, record: Sequence[int]) -> None:
+        self._require_open()
+        index = self._normalize_index(index)
+        self._write_record(index, record)
+
+    def append(self, record: Sequence[int]) -> int:
+        """Append a record and return its zero-based index."""
+        self._require_open()
+        if self._length >= self._capacity:
+            raise OverflowError("record vector capacity exceeded")
+
+        index = self._length
+        self._write_record(index, record)
+        self._length += 1
+        return index
+
+    def fill(self, record: Sequence[int]) -> None:
+        """Set every existing record to one value."""
+        self._require_open()
+        for index in range(self._length):
+            self._write_record(index, record)
+
+    def close(self) -> None:
+        """Close mmap and temporary file resources."""
+        if self._closed:
+            return
+
+        if self._mmap is not None:
+            self._mmap.close()
+            self._mmap = None
+        if self._file_handle is not None:
+            self._file_handle.close()
+            self._file_handle = None
+        self._closed = True
+
+    def __enter__(self) -> MappedRecordVector:
+        self._require_open()
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        self.close()
+
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except Exception:
+            pass
+
+    def _write_record(self, index: int, record: Sequence[int]) -> None:
+        mm = self._require_mmap()
+        self._struct.pack_into(mm, index * self._struct.size, *record)
+
+    def _normalize_index(self, index: int) -> int:
+        if index < 0:
+            index += self._length
+        if index < 0 or index >= self._length:
+            raise IndexError(index)
+        return index
+
+    def _require_mmap(self) -> mmap.mmap:
+        if self._mmap is None:
+            raise IndexError("empty record vector has no storage")
+        return self._mmap
+
+    def _require_open(self) -> None:
+        if self._closed:
+            raise ValueError("mapped record vector is closed")
+
+
+class ChunkedMappedRecordVector(Sequence[tuple[int, ...]]):
+    """Append-only record vector that grows by mmap-backed chunks."""
+
+    def __init__(
+        self,
+        *,
+        record_format: str,
+        chunk_capacity: int,
+        spool_dir: str | Path | None = None,
+    ) -> None:
+        if chunk_capacity <= 0:
+            raise ValueError("chunk capacity must be positive")
+
+        self._record_format = record_format
+        self._chunk_capacity = chunk_capacity
+        self._spool_dir = spool_dir
+        self._chunks: list[MappedRecordVector] = []
+        self._length = 0
+        self._closed = False
+
+    @property
+    def byte_count(self) -> int:
+        """Return allocated mmap bytes across chunks."""
+        if self._closed:
+            return 0
+        return sum(chunk.byte_count for chunk in self._chunks)
+
+    @property
+    def closed(self) -> bool:
+        """Return whether the vector has been closed."""
+        return self._closed
+
+    def __len__(self) -> int:
+        self._require_open()
+        return self._length
+
+    def __getitem__(self, index: int | slice) -> tuple[int, ...] | list[tuple[int, ...]]:
+        self._require_open()
+        if isinstance(index, slice):
+            return [self[item] for item in range(*index.indices(self._length))]
+
+        index = self._normalize_index(index)
+        chunk_index, record_index = divmod(index, self._chunk_capacity)
+        return self._chunks[chunk_index][record_index]
+
+    def append(self, record: Sequence[int]) -> int:
+        """Append a record and return its zero-based index."""
+        self._require_open()
+        if self._length == len(self._chunks) * self._chunk_capacity:
+            self._chunks.append(
+                MappedRecordVector(
+                    self._chunk_capacity,
+                    self._record_format,
+                    spool_dir=self._spool_dir,
+                )
+            )
+
+        index = self._length
+        self._chunks[-1].append(record)
+        self._length += 1
+        return index
+
+    def close(self) -> None:
+        """Close every allocated chunk."""
+        if self._closed:
+            return
+
+        for chunk in self._chunks:
+            chunk.close()
+        self._chunks.clear()
+        self._closed = True
+
+    def __enter__(self) -> ChunkedMappedRecordVector:
+        self._require_open()
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        self.close()
+
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except Exception:
+            pass
+
+    def _normalize_index(self, index: int) -> int:
+        if index < 0:
+            index += self._length
+        if index < 0 or index >= self._length:
+            raise IndexError(index)
+        return index
+
+    def _require_open(self) -> None:
+        if self._closed:
+            raise ValueError("chunked mapped record vector is closed")
+
+
+class ManagedMappedResources:
+    """Track mapped resources and byte high-water use."""
+
+    def __init__(self) -> None:
+        self._resources: list[object] = []
+        self._current_bytes = 0
+        self._high_water_bytes = 0
+        self._total_allocated_bytes = 0
+        self._closed = False
+
+    @property
+    def current_bytes(self) -> int:
+        """Return bytes currently owned by open tracked resources."""
+        return self._current_bytes
+
+    @property
+    def high_water_bytes(self) -> int:
+        """Return the highest simultaneously tracked byte count."""
+        return self._high_water_bytes
+
+    @property
+    def total_allocated_bytes(self) -> int:
+        """Return total bytes ever allocated through this manager."""
+        return self._total_allocated_bytes
+
+    def track(self, resource: object) -> object:
+        """Track a mapped resource for deterministic cleanup."""
+        self._require_open()
+        self._resources.append(resource)
+        byte_count = _resource_byte_count(resource)
+        self._current_bytes += byte_count
+        self._total_allocated_bytes += byte_count
+        self._high_water_bytes = max(self._high_water_bytes, self._current_bytes)
+        return resource
+
+    def close_resource(self, resource: object) -> None:
+        """Close one tracked resource and update current byte accounting."""
+        if resource not in self._resources:
+            _close_resource(resource)
+            return
+
+        self._resources.remove(resource)
+        byte_count = _resource_byte_count(resource)
+        _close_resource(resource)
+        self._current_bytes = max(0, self._current_bytes - byte_count)
+
+    def close(self) -> None:
+        """Close all tracked resources."""
+        if self._closed:
+            return
+
+        for resource in reversed(self._resources):
+            _close_resource(resource)
+        self._resources.clear()
+        self._current_bytes = 0
+        self._closed = True
+
+    def __enter__(self) -> ManagedMappedResources:
+        self._require_open()
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        self.close()
+
+    def _require_open(self) -> None:
+        if self._closed:
+            raise ValueError("mapped resource manager is closed")
+
+
+def _resource_byte_count(resource: object) -> int:
+    byte_count = getattr(resource, "byte_count", 0)
+    if isinstance(byte_count, int):
+        return byte_count
+    return 0
+
+
+def _close_resource(resource: object) -> None:
+    close = getattr(resource, "close", None)
+    if close is not None:
+        close()

--- a/tests/batch/test_match_storage.py
+++ b/tests/batch/test_match_storage.py
@@ -1,0 +1,109 @@
+"""Tests for mapped matcher storage primitives."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from git_stage_batch.batch.match_storage import MatcherWorkspace
+from git_stage_batch.utils.mapped_storage import MappedIntVector, MappedRecordVector
+
+
+def _open_fd_count() -> int | None:
+    fd_path = "/proc/self/fd"
+    if not os.path.isdir(fd_path):
+        return None
+    return len(os.listdir(fd_path))
+
+
+def test_mapped_int_vector_get_set_fill_and_close():
+    """Mapped integer vectors expose fixed-width unsigned slots."""
+    vector = MappedIntVector(4, width=4, fill=7)
+
+    assert vector.typecode == "I"
+    assert list(vector) == [7, 7, 7, 7]
+
+    vector[1] = 9
+    assert vector[1] == 9
+
+    vector.fill(3)
+    assert list(vector) == [3, 3, 3, 3]
+
+    with pytest.raises(OverflowError):
+        vector[0] = -1
+
+    vector.close()
+    vector.close()
+    with pytest.raises(ValueError, match="closed"):
+        vector[0]
+
+
+def test_mapped_int_vector_uses_64_bit_slots():
+    """Mapped integer vectors store values past the 32-bit range."""
+    value = (1 << 40) + 3
+
+    with MappedIntVector(1, width=8) as vector:
+        assert vector.typecode == "Q"
+        vector[0] = value
+        assert vector[0] == value
+
+
+def test_mapped_record_vector_append_and_indexed_write():
+    """Mapped record vectors support append and pre-sized writes."""
+    records = MappedRecordVector(3, "QQ")
+
+    records.append((1, 2))
+    records.append((3, 4))
+    assert records[0] == (1, 2)
+    assert list(records) == [(1, 2), (3, 4)]
+
+    records[1] = (5, 6)
+    assert records[1] == (5, 6)
+
+    with pytest.raises(IndexError):
+        records[2]
+
+    records.close()
+    with pytest.raises(ValueError, match="closed"):
+        len(records)
+
+
+def test_mapped_record_vector_can_start_presized():
+    """Pre-sized record vectors allow indexed population."""
+    with MappedRecordVector(2, "QQ", length=2) as records:
+        records[0] = (10, 20)
+        records[1] = (30, 40)
+        assert list(records) == [(10, 20), (30, 40)]
+
+
+def test_matcher_workspace_tracks_and_closes_resources():
+    """Matcher workspaces close all vectors they allocate."""
+    workspace = MatcherWorkspace()
+    vector = workspace.int_vector(2, width=4, fill=1)
+    records = workspace.record_vector(1, "QQ")
+    records.append((2, 3))
+
+    assert workspace.current_bytes == vector.byte_count + records.byte_count
+    assert workspace.high_water_bytes == workspace.current_bytes
+
+    workspace.close_resource(vector)
+    assert vector.closed
+    assert workspace.current_bytes == records.byte_count
+
+    workspace.close()
+    assert records.closed
+    assert workspace.current_bytes == 0
+
+
+def test_repeated_vector_open_close_does_not_leak_file_descriptors():
+    """Mapped vectors close their temporary file descriptors."""
+    before = _open_fd_count()
+
+    for _ in range(25):
+        with MappedIntVector(8, width=8) as vector:
+            vector.fill(4)
+
+    after = _open_fd_count()
+    if before is not None and after is not None:
+        assert after <= before + 2

--- a/tests/batch/test_merge.py
+++ b/tests/batch/test_merge.py
@@ -2,12 +2,7 @@
 
 import pytest
 
-from git_stage_batch.batch.match import (
-    UniqueLinePosition,
-    _build_unique_position_map,
-    _longest_increasing_subsequence,
-    match_lines,
-)
+from git_stage_batch.batch.match import match_lines
 from git_stage_batch.batch.merge import (
     RegionKind,
     _RealizedEntries,
@@ -46,6 +41,31 @@ class _IndexGuardedRealizedEntries(_RealizedEntries):
 
     def __getitem__(self, index):
         raise AssertionError("entry indexing should not be used")
+
+
+class _GuardedLine:
+    """Hashable line object that rejects materialization."""
+
+    def __init__(self, content: str, hash_value: int | None = None) -> None:
+        self.content = content
+        self.hash_value = hash(content) if hash_value is None else hash_value
+
+    def __hash__(self) -> int:
+        return self.hash_value
+
+    def __eq__(self, other):
+        if not isinstance(other, _GuardedLine):
+            return NotImplemented
+        return self.content == other.content
+
+    def __bytes__(self):
+        raise AssertionError("line content should not be materialized")
+
+    def __getitem__(self, index):
+        raise AssertionError("line content should not be sliced")
+
+    def endswith(self, suffix):
+        raise AssertionError("line endings should not be materialized")
 
 
 def merge_batch(
@@ -92,33 +112,6 @@ def discard_batch(
 
 class TestMatchLines:
     """Tests for structural line alignment."""
-
-    def test_unique_position_map_returns_structured_positions(self):
-        """Unique line scanning returns positions without duplicate entries."""
-        lines = [b"same\n", b"unique\n", b"same\n", b"other\n"]
-
-        positions = _build_unique_position_map(lines, 0, len(lines))
-
-        assert positions == {
-            b"unique\n": UniqueLinePosition(index=1),
-            b"other\n": UniqueLinePosition(index=3),
-        }
-
-    def test_lis_keeps_source_stable_ties(self):
-        """Equal-length LIS choices keep the earliest source-ordered anchor."""
-        pairs = [(0, 2), (1, 1), (2, 3)]
-
-        assert _longest_increasing_subsequence(pairs) == [(0, 2), (2, 3)]
-
-    def test_lis_uses_later_smaller_tail_for_longer_match(self):
-        """A later smaller target can produce a longer subsequence."""
-        pairs = [(0, 3), (1, 1), (2, 2), (3, 4)]
-
-        assert _longest_increasing_subsequence(pairs) == [
-            (1, 1),
-            (2, 2),
-            (3, 4),
-        ]
 
     def test_line_mapping_uses_zero_filled_arrays(self):
         """Line mappings store one integer slot per line."""
@@ -224,6 +217,65 @@ class TestMatchLines:
         assert mapping.get_target_line_from_source_line(2) == 3
         assert mapping.get_target_line_from_source_line(3) == 4
         assert mapping.get_source_line_from_target_line(2) is None
+
+    def test_match_lines_does_not_materialize_guarded_lines(self):
+        """Matching uses hashing and equality without bytes or slicing."""
+        source = [
+            _GuardedLine("start\n"),
+            _GuardedLine("unique\n"),
+            _GuardedLine("tail\n"),
+        ]
+        target = [
+            _GuardedLine("start\n"),
+            _GuardedLine("other\n"),
+            _GuardedLine("unique\n"),
+            _GuardedLine("tail\n"),
+        ]
+
+        with match_lines(source, target) as mapping:
+            assert mapping.get_target_line_from_source_line(2) == 3
+
+    def test_hash_collisions_do_not_conflate_unequal_lines(self):
+        """Equal hashes route lookup but do not define line identity."""
+        source = [
+            _GuardedLine("start\n", 2),
+            _GuardedLine("left\n", 1),
+            _GuardedLine("right\n", 1),
+            _GuardedLine("end\n", 3),
+        ]
+        target = [
+            _GuardedLine("start\n", 2),
+            _GuardedLine("right\n", 1),
+            _GuardedLine("end\n", 3),
+        ]
+
+        with match_lines(source, target) as mapping:
+            assert mapping.get_target_line_from_source_line(2) is None
+            assert mapping.get_target_line_from_source_line(3) == 2
+
+    def test_hash_collisions_coalesce_equal_repeated_lines(self):
+        """Equal collided content is counted as repeated, not unique."""
+        source = [
+            _GuardedLine("start\n", 1),
+            _GuardedLine("repeat\n", 1),
+            _GuardedLine("repeat\n", 1),
+            _GuardedLine("middle\n", 1),
+            _GuardedLine("end\n", 1),
+        ]
+        target = [
+            _GuardedLine("start\n", 1),
+            _GuardedLine("other\n", 1),
+            _GuardedLine("repeat\n", 1),
+            _GuardedLine("changed\n", 1),
+            _GuardedLine("end\n", 1),
+        ]
+
+        with match_lines(source, target) as mapping:
+            assert mapping.get_target_line_from_source_line(1) == 1
+            assert mapping.get_target_line_from_source_line(2) is None
+            assert mapping.get_target_line_from_source_line(3) is None
+            assert mapping.get_target_line_from_source_line(4) is None
+            assert mapping.get_target_line_from_source_line(5) == 5
 
     def test_working_tree_additions(self):
         """Test alignment when working tree has extra lines."""

--- a/tests/batch/test_merge.py
+++ b/tests/batch/test_merge.py
@@ -129,9 +129,37 @@ class TestMatchLines:
 
         assert mapping.source_to_target.typecode in {"I", "Q"}
         assert mapping.target_to_source.typecode in {"I", "Q"}
-        assert mapping.source_to_target.tolist() == [1, 0, 2]
-        assert mapping.target_to_source.tolist() == [1, 3]
+        assert list(mapping.source_to_target) == [1, 0, 2]
+        assert list(mapping.target_to_source) == [1, 3]
         assert mapping.get_target_line_from_source_line(2) is None
+
+    def test_line_mapping_context_manager_closes_mapping(self):
+        """Line mappings close their owned vector storage on context exit."""
+        with match_lines([b"a\n"], [b"a\n"]) as mapping:
+            assert mapping.get_target_line_from_source_line(1) == 1
+
+        with pytest.raises(ValueError, match="line mapping is closed"):
+            mapping.get_target_line_from_source_line(1)
+
+    def test_line_mapping_detach_transfers_context_ownership(self):
+        """Detached mappings remain usable until their new owner closes them."""
+        with match_lines([b"a\n"], [b"a\n"]) as mapping:
+            detached = mapping.detach()
+
+        assert detached.get_target_line_from_source_line(1) == 1
+        detached.close()
+        detached.close()
+
+        with pytest.raises(ValueError, match="line mapping is closed"):
+            detached.detach()
+
+    def test_line_mapping_exposes_mapped_line_pairs(self):
+        """Mapped pair iteration exposes source-order correspondence."""
+        with match_lines(
+            [b"line1\n", b"line2\n", b"line3\n"],
+            [b"line1\n", b"line3\n"],
+        ) as mapping:
+            assert list(mapping.mapped_line_pairs()) == [(1, 1), (3, 2)]
 
     def test_identical_files(self):
         """Test alignment of identical files."""


### PR DESCRIPTION
The editor and matcher keep line-oriented indexes and matcher workspace state in Python-owned containers. Matcher callers receive LineMapping results without an ownership boundary around any backing resources.

Large or ambiguous inputs can need one mapping slot plus multiple candidate records per line, keeping substantial per-line matcher state on the Python heap. Moving that state into mapped storage also requires callers to scope mapping lifetime explicitly before the backing storage changes.

This PR addresses that by adding mapped vector storage helpers, moving editor span indexes and matcher maps, occurrence buckets, and LIS records into mapped storage, and threading explicit LineMapping ownership through matcher callers.

The series closes with storage primitive coverage, LineMapping ownership coverage, storage-backed matcher behavior tests, and benchmark tooling for measuring matcher workspace allocation and mapped-storage counters.

Verification:

uv run pytest tests/batch/test_match_storage.py tests/batch/test_merge.py

uv run ruff check src/git_stage_batch/batch/attribution.py src/git_stage_batch/batch/comparison.py src/git_stage_batch/batch/display.py src/git_stage_batch/batch/match.py src/git_stage_batch/batch/match_storage.py src/git_stage_batch/batch/merge.py src/git_stage_batch/batch/ownership.py src/git_stage_batch/batch/source_refresh.py src/git_stage_batch/data/hunk_tracking.py src/git_stage_batch/editor/buffer.py src/git_stage_batch/utils/mapped_storage.py tests/batch/test_match_storage.py tests/batch/test_merge.py scripts/benchmark_matching.py