### PR TITLE
Avoid claimed-line presence allocations

### DIFF
--- a/src/git_stage_batch/batch/merge.py
+++ b/src/git_stage_batch/batch/merge.py
@@ -1544,24 +1544,31 @@ def _missing_claimed_lines(
     presence_line_set: set[int]
 ) -> set[int]:
     """Return claimed source lines that are not present as claimed entries."""
-    present_claimed = set()
+    missing_claimed = set(presence_line_set)
+    if not missing_claimed:
+        return missing_claimed
+
     if isinstance(entries, _RealizedEntries):
         for run in entries.provenance_runs():
             if not run.is_claimed or run.source_start == 0:
                 continue
-            present_claimed.update(
+            missing_claimed.difference_update(
                 range(
                     run.source_start,
                     run.source_start + (run.dest_end - run.dest_start),
                 )
             )
-        return presence_line_set - present_claimed
+            if not missing_claimed:
+                break
+        return missing_claimed
 
     for index in range(len(entries)):
         source_line = _entry_source_line_at(entries, index)
         if source_line is not None and _entry_is_claimed_at(entries, index):
-            present_claimed.add(source_line)
-    return presence_line_set - present_claimed
+            missing_claimed.discard(source_line)
+            if not missing_claimed:
+                break
+    return missing_claimed
 
 
 def _satisfy_constraints(

--- a/src/git_stage_batch/batch/merge.py
+++ b/src/git_stage_batch/batch/merge.py
@@ -1387,15 +1387,12 @@ def _apply_presence_constraints_with_mapping(
         )
         return result
 
-    present_claimed: dict[int, int] = {}
     missing_claimed: set[int] = set()
 
     for source_line in presence_line_set:
         if 1 <= source_line <= len(source_lines):
             working_line = mapping.get_target_line_from_source_line(source_line)
-            if working_line is not None:
-                present_claimed[source_line] = working_line
-            else:
+            if working_line is None:
                 missing_claimed.add(source_line)
 
     if not missing_claimed:


### PR DESCRIPTION
The merge presence pass compares claimed source lines against the source-to-working mapping, then only uses the set of claimed lines that are missing from working content.

This pull request removes the unused map of claimed lines that are already present. It also changes the missing-claimed-line helper to subtract observed claimed lines from a missing-line copy instead of building a second set of present claimed lines. That avoids selected-line-scale heap allocation without changing the realized-entry output.

Verification:
- `PYTHONPATH=src uv run pytest tests/batch/test_merge.py tests/batch/test_match_storage.py`
- `rg -n "affine|Affine" src tests`
- `git diff --check`
