### PR TITLE
Store ownership selections as line ranges

### DIFF
--- a/src/git_stage_batch/batch/merge.py
+++ b/src/git_stage_batch/batch/merge.py
@@ -2975,6 +2975,33 @@ def _reverse_presence_constraints(
 
     copy_start: int | None = 0
 
+    if isinstance(entries, _RealizedEntries):
+        presence_lines = _as_line_ranges(presence_line_set)
+        for run in entries.provenance_runs():
+            if run.source_start == 0:
+                continue
+
+            run_length = run.dest_end - run.dest_start
+            run_source_end = run.source_start + run_length - 1
+            selected_lines = presence_lines.intersection(
+                LineRanges.from_ranges([(run.source_start, run_source_end)])
+            )
+            if not selected_lines:
+                continue
+
+            for selected_start, selected_end in selected_lines.ranges():
+                for source_line in range(selected_start, selected_end + 1):
+                    index = run.dest_start + (source_line - run.source_start)
+                    flush_copy(copy_start, index)
+                    copy_start = None
+                    restore_source_line(source_line)
+                    copy_start = index + 1
+
+        if copy_start is not None:
+            flush_copy(copy_start, len(entries))
+
+        return result
+
     for index in range(len(entries)):
         source_line = _entry_source_line_at(entries, index)
         if source_line is not None and source_line in presence_line_set:

--- a/src/git_stage_batch/batch/merge.py
+++ b/src/git_stage_batch/batch/merge.py
@@ -10,7 +10,7 @@ from enum import Enum, auto
 from typing import TYPE_CHECKING, Any
 
 from .match import LineMapping, match_lines
-from ..core.line_selection import parse_line_selection
+from ..core.line_selection import LineRanges, LineSelection
 from ..editor import (
     Editor,
     EditorBuffer,
@@ -857,7 +857,7 @@ class ClaimedRunIntervalFacts:
 
 def _check_structural_validity(
     line_mapping: LineMapping,
-    claimed_lines: set[int],
+    claimed_lines: LineSelection,
     deletions: list,  # list[DeletionClaim]
     source_lines: Sequence[bytes],
     target_lines: Sequence[bytes]
@@ -877,7 +877,7 @@ def _check_structural_validity(
 
     Args:
         line_mapping: Alignment between batch source and working tree
-        claimed_lines: Set of claimed batch source line numbers
+        claimed_lines: Claimed batch source line numbers
         deletions: List of DeletionClaim objects
         source_lines: Batch source file lines (bytes)
         target_lines: Working tree file lines (bytes)
@@ -893,7 +893,7 @@ def _check_structural_validity(
 
     if present_count == 0 and len(target_lines) > 0:
         if claimed_lines:
-            first_claimed = min(claimed_lines)
+            first_claimed = _first_selected_line(claimed_lines)
             raise MergeError(
                 _("Cannot reliably place claimed line {line}: file completely rewritten").format(
                     line=first_claimed
@@ -964,7 +964,7 @@ def _check_structural_validity(
 
 def _check_claimed_region_compatibility(
     line_mapping: LineMapping,
-    claimed_lines: set[int],
+    claimed_lines: LineSelection,
     deletions: list,  # list[DeletionClaim]
     source_lines: Sequence[bytes],
     target_lines: Sequence[bytes]
@@ -989,23 +989,23 @@ def _check_claimed_region_compatibility(
 
     Args:
         line_mapping: Alignment between source and working tree
-        claimed_lines: Set of claimed source line numbers
+        claimed_lines: Claimed source line numbers
         source_lines: Batch source lines
         target_lines: Working tree lines
 
     Raises:
         MergeError: If claimed lines come from incompatible source region
     """
-    sorted_missing = _get_missing_claimed_lines(
+    missing_claimed = _get_missing_claimed_lines(
         line_mapping,
         claimed_lines,
         source_lines
     )
 
-    if not sorted_missing or len(target_lines) == 0:
+    if not missing_claimed or len(target_lines) == 0:
         return
 
-    for run_start, run_end in _build_contiguous_runs(sorted_missing):
+    for run_start, run_end in missing_claimed.ranges():
         facts = _collect_claimed_run_interval_facts(
             run_start,
             run_end,
@@ -1023,39 +1023,38 @@ def _check_claimed_region_compatibility(
 
 def _get_missing_claimed_lines(
     line_mapping: LineMapping,
-    claimed_lines: set[int],
+    claimed_lines: LineSelection,
     source_lines: Sequence[bytes]
-) -> list[int]:
+) -> LineRanges:
     """Return claimed source lines that are not present in the working tree."""
-    missing_claimed = []
-
-    for line_num in sorted(claimed_lines):
-        if 1 <= line_num <= len(source_lines):
-            if line_mapping.get_target_line_from_source_line(line_num) is None:
-                missing_claimed.append(line_num)
-
-    return missing_claimed
+    return _mapped_missing_source_lines(
+        claimed_lines,
+        len(source_lines),
+        line_mapping,
+    )
 
 
-def _build_contiguous_runs(sorted_line_numbers: list[int]) -> list[tuple[int, int]]:
-    """Build contiguous inclusive runs from sorted line numbers."""
-    if not sorted_line_numbers:
-        return []
+def _first_selected_line(lines: LineSelection) -> int | None:
+    first = getattr(lines, "first", None)
+    if first is not None:
+        return first()
+    return min(lines) if lines else None
 
-    runs = []
-    run_start = sorted_line_numbers[0]
-    run_end = sorted_line_numbers[0]
 
-    for line_num in sorted_line_numbers[1:]:
-        if line_num == run_end + 1:
-            run_end = line_num
-        else:
-            runs.append((run_start, run_end))
-            run_start = line_num
-            run_end = line_num
+def _as_line_ranges(lines: LineSelection | Iterable[int]) -> LineRanges:
+    if isinstance(lines, LineRanges):
+        return lines
+    ranges = getattr(lines, "ranges", None)
+    if ranges is not None:
+        return LineRanges.from_ranges(ranges())
+    return LineRanges.from_lines(lines)
 
-    runs.append((run_start, run_end))
-    return runs
+
+def _selection_outside_bounds(lines: LineSelection, max_line: int) -> bool:
+    for start, end in _as_line_ranges(lines).ranges():
+        if start < 1 or end > max_line:
+            return True
+    return False
 
 
 def _find_nearest_mapped_source_line_before(
@@ -1260,7 +1259,7 @@ def _is_claimed_run_structurally_coherent(
 def _apply_presence_constraints(
     source_lines: Sequence[bytes],
     working_lines: Sequence[bytes],
-    presence_line_set: set[int],
+    presence_line_set: LineSelection,
     *,
     source_to_working_mapping: LineMapping | None = None,
 ) -> _RealizedEntries:
@@ -1273,7 +1272,7 @@ def _apply_presence_constraints(
     Args:
         source_lines: Batch source file lines (bytes with newlines)
         working_lines: Working tree file lines (bytes with newlines)
-        presence_line_set: Set of source line numbers that must be present
+        presence_line_set: Source line numbers that must be present
 
     Returns:
         Realized entries with all claimed lines present and provenance preserved
@@ -1305,13 +1304,47 @@ def _source_lines_are_contiguous(
     return source_line == previous_source_line + 1
 
 
+def _mapped_missing_source_lines(
+    source_lines: LineSelection,
+    source_line_count: int,
+    mapping: LineMapping,
+) -> LineRanges:
+    missing_ranges: list[tuple[int, int]] = []
+    current_start: int | None = None
+    current_end: int | None = None
+    source_selection = _as_line_ranges(source_lines)
+
+    for start, end in source_selection.ranges():
+        for source_line in range(max(1, start), min(end, source_line_count) + 1):
+            if mapping.get_target_line_from_source_line(source_line) is not None:
+                if current_start is not None and current_end is not None:
+                    missing_ranges.append((current_start, current_end))
+                    current_start = None
+                    current_end = None
+                continue
+
+            if current_start is None:
+                current_start = source_line
+            current_end = source_line
+
+        if current_start is not None and current_end is not None:
+            missing_ranges.append((current_start, current_end))
+            current_start = None
+            current_end = None
+
+    if current_start is not None and current_end is not None:
+        missing_ranges.append((current_start, current_end))
+
+    return LineRanges.from_ranges(missing_ranges)
+
+
 def _append_working_range_with_mapping(
     result: _RealizedEntries,
     working_lines: Sequence[bytes],
     mapping: LineMapping,
     start: int,
     end: int,
-    presence_line_set: set[int],
+    presence_line_set: LineSelection,
 ) -> None:
     """Append a target range split only where provenance stops being contiguous."""
     if start == end:
@@ -1370,7 +1403,7 @@ def _append_working_range_with_mapping(
 def _apply_presence_constraints_with_mapping(
     source_lines: Sequence[bytes],
     working_lines: Sequence[bytes],
-    presence_line_set: set[int],
+    presence_line_set: LineSelection,
     mapping: LineMapping,
 ) -> _RealizedEntries:
     """Apply presence constraints using an existing source-to-working mapping."""
@@ -1387,13 +1420,11 @@ def _apply_presence_constraints_with_mapping(
         )
         return result
 
-    missing_claimed: set[int] = set()
-
-    for source_line in presence_line_set:
-        if 1 <= source_line <= len(source_lines):
-            working_line = mapping.get_target_line_from_source_line(source_line)
-            if working_line is None:
-                missing_claimed.add(source_line)
+    missing_claimed = _mapped_missing_source_lines(
+        presence_line_set,
+        len(source_lines),
+        mapping,
+    )
 
     if not missing_claimed:
         result = _RealizedEntries()
@@ -1541,40 +1572,37 @@ def _apply_absence_constraints(
 
 def _missing_claimed_lines(
     entries: Sequence[RealizedEntry],
-    presence_line_set: set[int]
-) -> set[int]:
+    presence_line_set: LineSelection
+) -> LineRanges:
     """Return claimed source lines that are not present as claimed entries."""
-    missing_claimed = set(presence_line_set)
-    if not missing_claimed:
-        return missing_claimed
+    claimed_ranges: list[tuple[int, int]] = []
+    presence_lines = _as_line_ranges(presence_line_set)
 
     if isinstance(entries, _RealizedEntries):
         for run in entries.provenance_runs():
             if not run.is_claimed or run.source_start == 0:
                 continue
-            missing_claimed.difference_update(
-                range(
-                    run.source_start,
-                    run.source_start + (run.dest_end - run.dest_start),
-                )
-            )
-            if not missing_claimed:
-                break
-        return missing_claimed
+            claimed_ranges.append((
+                run.source_start,
+                run.source_start + (run.dest_end - run.dest_start) - 1,
+            ))
+        return presence_lines.difference(
+            LineRanges.from_ranges(claimed_ranges)
+        )
 
     for index in range(len(entries)):
         source_line = _entry_source_line_at(entries, index)
         if source_line is not None and _entry_is_claimed_at(entries, index):
-            missing_claimed.discard(source_line)
-            if not missing_claimed:
-                break
-    return missing_claimed
+            claimed_ranges.append((source_line, source_line))
+    return presence_lines.difference(
+        LineRanges.from_ranges(claimed_ranges)
+    )
 
 
 def _satisfy_constraints(
     source_lines: Sequence[bytes],
     working_lines: Sequence[bytes],
-    presence_line_set: set[int],
+    presence_line_set: LineSelection,
     deletion_claims: list['DeletionClaim'],
     *,
     strict: bool = True,
@@ -1626,7 +1654,7 @@ def _satisfy_constraints(
         if missing_claimed:
             if not strict:
                 return realized_entries
-            first_missing = min(missing_claimed)
+            first_missing = missing_claimed.first()
             raise MergeError(
                 _("Cannot satisfy claimed line {line}: removed by absence constraints").format(
                     line=first_missing
@@ -2177,7 +2205,7 @@ def _iter_lines_with_baseline_edits(
 
 def _has_complete_baseline_references(
     ownership: 'BatchOwnership',
-    presence_line_set: set[int],
+    presence_line_set: LineSelection,
     deletion_claims: list['DeletionClaim'],
 ) -> bool:
     claimed_line_references = ownership.presence_baseline_references()
@@ -2196,7 +2224,7 @@ def _try_apply_baseline_replacement_units(
     source_lines: Sequence[bytes],
     working_lines: Sequence[bytes],
     ownership: 'BatchOwnership',
-    presence_line_set: set[int],
+    presence_line_set: LineSelection,
     deletion_claims: list['DeletionClaim'],
 ) -> Iterator[bytes] | None:
     """Apply baseline-coordinate edits when structural source anchors fail.
@@ -2207,7 +2235,7 @@ def _try_apply_baseline_replacement_units(
     even though the old baseline bytes still exist at an exact recorded
     coordinate.
     """
-    if any(claimed_line < 1 or claimed_line > len(source_lines) for claimed_line in presence_line_set):
+    if _selection_outside_bounds(presence_line_set, len(source_lines)):
         return None
 
     if (
@@ -2222,11 +2250,12 @@ def _try_apply_baseline_replacement_units(
 
     replacement_units = getattr(ownership, "replacement_units", [])
     edits: list[_BaselineLineEdit] = []
-    unit_claimed_lines: set[int] = set()
+    unit_claimed_lines = LineRanges.empty()
     unit_deletion_indices: set[int] = set()
 
     for unit in replacement_units:
-        claimed_lines = sorted(parse_line_selection(",".join(unit.presence_lines))) if unit.presence_lines else []
+        claimed_selection = LineRanges.from_specs(unit.presence_lines)
+        claimed_lines = list(claimed_selection)
         if not claimed_lines or len(unit.deletion_indices) != 1:
             return None
 
@@ -2247,7 +2276,7 @@ def _try_apply_baseline_replacement_units(
             return None
         start, end, _removed_lines = removal_edit
         edits.append((start, end, replacement_lines))
-        unit_claimed_lines.update(claimed_lines)
+        unit_claimed_lines = unit_claimed_lines.union(claimed_selection)
         unit_deletion_indices.add(deletion_index)
 
     for deletion_index, claim in enumerate(deletion_claims):
@@ -2258,7 +2287,8 @@ def _try_apply_baseline_replacement_units(
             return None
         edits.append(removal_edit)
 
-    remaining_claimed_lines = presence_line_set - unit_claimed_lines
+    presence_lines = _as_line_ranges(presence_line_set)
+    remaining_claimed_lines = presence_lines.difference(unit_claimed_lines)
     claimed_line_references = ownership.presence_baseline_references()
     if remaining_claimed_lines:
         grouped_insertions: dict[int, list[int]] = {}
@@ -2287,7 +2317,7 @@ def _try_apply_baseline_replacement_units(
                 insertion_lines,
             ))
 
-    if unit_claimed_lines | remaining_claimed_lines != presence_line_set:
+    if unit_claimed_lines.union(remaining_claimed_lines) != presence_lines:
         return None
 
     return _apply_non_overlapping_baseline_edits(working_lines, edits)
@@ -2829,25 +2859,17 @@ def _build_realized_entries_for_discard(
     return result
 
 
-def _count_lines_in_range(line_set: set[int], start_line: int, end_line: int) -> int:
-    line_count = end_line - start_line + 1
-    if line_count <= len(line_set):
-        return sum(
-            1
-            for line_number in range(start_line, end_line + 1)
-            if line_number in line_set
-        )
-
-    return sum(
-        1
-        for line_number in line_set
-        if start_line <= line_number <= end_line
-    )
+def _count_lines_in_range(
+    line_selection: LineSelection,
+    start_line: int,
+    end_line: int,
+) -> int:
+    return _as_line_ranges(line_selection).count(start_line, end_line)
 
 
 def _reverse_presence_constraints(
     entries: Sequence[RealizedEntry],
-    presence_line_set: set[int],
+    presence_line_set: LineSelection,
     correspondence: BaselineCorrespondence
 ) -> _RealizedEntries:
     """Reverse presence constraints: replace/remove batch-owned claimed lines.
@@ -2868,7 +2890,7 @@ def _reverse_presence_constraints(
 
     Args:
         entries: Realized entries from working tree with source provenance
-        presence_line_set: Set of source line numbers that are batch-owned
+        presence_line_set: Source line numbers that are batch-owned
         correspondence: Baseline restoration correspondence
 
     Returns:
@@ -2880,82 +2902,85 @@ def _reverse_presence_constraints(
     """
     result = _RealizedEntries()
     processed_replace_regions: set[int] = set()
-    copy_start: int | None = 0
 
     def flush_copy(start: int | None, stop: int) -> None:
         if start is not None and start < stop:
             result.copy_slice_from(entries, start, stop)
+
+    def restore_source_line(source_line: int) -> None:
+        region = correspondence.get_region_for_source_line(source_line)
+
+        if region is None:
+            raise MergeError(
+                _("Cannot discard source line {line}: no baseline restoration region found").format(
+                    line=source_line
+                )
+            )
+
+        if region.kind in (RegionKind.EQUAL, RegionKind.REPLACE_LINE_BY_LINE):
+            offset = source_line - region.source_start_line
+            if 0 <= offset < len(region.baseline_lines):
+                result.append_line_range_from(
+                    region.baseline_lines,
+                    offset,
+                    offset + 1,
+                    source_line_start=None,
+                    is_claimed=False,
+                )
+            else:
+                raise MergeError(
+                    _("Source line {line} offset {offset} outside region bounds").format(
+                        line=source_line, offset=offset
+                    )
+                )
+
+        elif region.kind == RegionKind.INSERT:
+            pass
+
+        elif region.kind == RegionKind.REPLACE_BY_HUNK:
+            if region.region_id not in processed_replace_regions:
+                total_lines_in_region = (
+                    region.source_end_line - region.source_start_line + 1
+                )
+                claimed_line_count = _count_lines_in_range(
+                    presence_line_set,
+                    region.source_start_line,
+                    region.source_end_line
+                )
+
+                if claimed_line_count != total_lines_in_region:
+                    raise MergeError(
+                        _("Cannot discard partial ownership of by-hunk replace region "
+                          "(source lines {start}-{end}): batch owns {owned} of {total} lines").format(
+                            start=region.source_start_line,
+                            end=region.source_end_line,
+                            owned=claimed_line_count,
+                            total=total_lines_in_region
+                        )
+                    )
+
+                result.append_line_range_from(
+                    region.baseline_lines,
+                    0,
+                    len(region.baseline_lines),
+                    source_line_start=None,
+                    is_claimed=False,
+                )
+                processed_replace_regions.add(region.region_id)
+
+        else:
+            raise MergeError(
+                _("Unknown region kind: {kind}").format(kind=region.kind)
+            )
+
+    copy_start: int | None = 0
 
     for index in range(len(entries)):
         source_line = _entry_source_line_at(entries, index)
         if source_line is not None and source_line in presence_line_set:
             flush_copy(copy_start, index)
             copy_start = None
-            region = correspondence.get_region_for_source_line(source_line)
-
-            if region is None:
-                raise MergeError(
-                    _("Cannot discard source line {line}: no baseline restoration region found").format(
-                        line=source_line
-                    )
-                )
-
-            if region.kind in (RegionKind.EQUAL, RegionKind.REPLACE_LINE_BY_LINE):
-                offset = source_line - region.source_start_line
-                if 0 <= offset < len(region.baseline_lines):
-                    result.append_line_range_from(
-                        region.baseline_lines,
-                        offset,
-                        offset + 1,
-                        source_line_start=None,
-                        is_claimed=False,
-                    )
-                else:
-                    raise MergeError(
-                        _("Source line {line} offset {offset} outside region bounds").format(
-                            line=source_line, offset=offset
-                        )
-                    )
-
-            elif region.kind == RegionKind.INSERT:
-                pass
-
-            elif region.kind == RegionKind.REPLACE_BY_HUNK:
-                if region.region_id not in processed_replace_regions:
-                    total_lines_in_region = (
-                        region.source_end_line - region.source_start_line + 1
-                    )
-                    claimed_line_count = _count_lines_in_range(
-                        presence_line_set,
-                        region.source_start_line,
-                        region.source_end_line
-                    )
-
-                    if claimed_line_count != total_lines_in_region:
-                        raise MergeError(
-                            _("Cannot discard partial ownership of by-hunk replace region "
-                              "(source lines {start}-{end}): batch owns {owned} of {total} lines").format(
-                                start=region.source_start_line,
-                                end=region.source_end_line,
-                                owned=claimed_line_count,
-                                total=total_lines_in_region
-                            )
-                        )
-
-                    result.append_line_range_from(
-                        region.baseline_lines,
-                        0,
-                        len(region.baseline_lines),
-                        source_line_start=None,
-                        is_claimed=False,
-                    )
-                    processed_replace_regions.add(region.region_id)
-
-            else:
-                raise MergeError(
-                    _("Unknown region kind: {kind}").format(kind=region.kind)
-                )
-
+            restore_source_line(source_line)
             copy_start = index + 1
         else:
             if copy_start is None:

--- a/src/git_stage_batch/batch/ownership.py
+++ b/src/git_stage_batch/batch/ownership.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from enum import Enum
 from hashlib import sha256
 
-from ..core.line_selection import format_line_ids, parse_line_selection
+from ..core.line_selection import (
+    LineRanges,
+    LineSelection,
+    format_line_ids,
+)
 from ..core.models import LineEntry
 from ..data.batch_sources import create_batch_source_commit
 from ..editor import (
@@ -187,7 +191,7 @@ class PresenceClaim:
     source_lines: list[str]
     baseline_references: dict[int, BaselineReference] = field(default_factory=dict)
 
-    def source_line_set(self) -> set[int]:
+    def source_line_set(self) -> LineRanges:
         """Return batch-source line numbers covered by this presence claim."""
         return _parse_line_ranges(self.source_lines)
 
@@ -349,11 +353,11 @@ class BatchOwnership:
         """Check if this ownership is empty (no presence claims or deletions)."""
         return not self.presence_claims and not self.deletions
 
-    def presence_line_set(self) -> set[int]:
+    def presence_line_set(self) -> LineRanges:
         """Return all batch-source lines claimed present by this ownership."""
-        presence_lines: set[int] = set()
+        presence_lines = LineRanges.empty()
         for claim in self.presence_claims:
-            presence_lines.update(claim.source_line_set())
+            presence_lines = presence_lines.union(claim.source_line_set())
         return presence_lines
 
     def presence_baseline_references(self) -> dict[int, BaselineReference]:
@@ -455,7 +459,8 @@ class BatchOwnership:
     def resolve(self) -> ResolvedBatchOwnership:
         """Resolve into representation for materialization and merge.
 
-        Returns presence lines as a set and deletion claims as a list (preserving structure).
+        Returns presence lines as a selection and deletion claims as a list
+        (preserving structure).
         """
         return ResolvedBatchOwnership(self.presence_line_set(), self.deletions)
 
@@ -488,7 +493,7 @@ class ResolvedBatchOwnership:
         presence_line_set: Batch source line numbers (1-indexed, identity-based)
         deletion_claims: List of suppression constraints (order and structure preserved)
     """
-    presence_line_set: set[int]  # Batch source line numbers (1-indexed)
+    presence_line_set: LineRanges  # Batch source line numbers (1-indexed)
     deletion_claims: list[DeletionClaim]  # Separate constraints, not collapsed
 
 
@@ -649,36 +654,41 @@ def _merge_deletion_claim_metadata(
     )
 
 
-def _parse_line_ranges(line_ranges: list[str] | list[int]) -> set[int]:
-    """Parse source line range strings into a set."""
-    return (
-        set(parse_line_selection(",".join(str(line) for line in line_ranges)))
-        if line_ranges else set()
-    )
+def _parse_line_ranges(line_ranges: list[str] | list[int]) -> LineRanges:
+    """Parse source line range strings into a selection."""
+    return LineRanges.from_specs(line_ranges)
 
 
-def _format_line_set(source_lines: set[int]) -> list[str]:
-    """Format a source line set as normalized range strings."""
-    if not source_lines:
+def _format_line_set(source_lines: LineSelection | Iterable[int]) -> list[str]:
+    """Format a source line selection as normalized range strings."""
+    if isinstance(source_lines, LineRanges):
+        return source_lines.to_range_strings()
+    source_selection = LineRanges.from_lines(source_lines)
+    if not source_selection:
         return []
-    return [format_line_ids(sorted(source_lines))]
+    return source_selection.to_range_strings()
 
 
 def _presence_claims_from_source_lines(
-    source_lines: set[int],
+    source_lines: LineSelection | Iterable[int],
     baseline_references: dict[int, BaselineReference] | None = None,
 ) -> list[PresenceClaim]:
-    """Build normalized presence claims from a source-line set."""
-    if not source_lines:
+    """Build normalized presence claims from a source-line selection."""
+    source_selection = (
+        source_lines
+        if isinstance(source_lines, LineRanges)
+        else LineRanges.from_lines(source_lines)
+    )
+    if not source_selection:
         return []
     references = baseline_references or {}
     return [
         PresenceClaim(
-            source_lines=_format_line_set(source_lines),
+            source_lines=_format_line_set(source_selection),
             baseline_references={
                 line: reference
                 for line, reference in references.items()
-                if line in source_lines
+                if line in source_selection
             },
         )
     ]
@@ -690,7 +700,7 @@ def _normalize_replacement_units(
     deletion_count: int,
 ) -> list[ReplacementUnit]:
     """Drop invalid references and coalesce overlapping replacement units."""
-    components: list[tuple[set[int], set[int]]] = []
+    components: list[tuple[LineRanges, set[int]]] = []
 
     for unit in replacement_units:
         claimed = _parse_line_ranges(unit.presence_lines)
@@ -706,22 +716,23 @@ def _normalize_replacement_units(
             index
             for index, (component_claimed, component_deletions)
             in enumerate(components)
-            if component_claimed & claimed or component_deletions & deletion_indices
+            if component_claimed.intersection(claimed) or component_deletions & deletion_indices
         ]
         if not overlapping_component_indices:
-            components.append((set(claimed), set(deletion_indices)))
+            components.append((claimed, set(deletion_indices)))
             continue
 
         target_index = overlapping_component_indices[0]
         target_claimed, target_deletions = components[target_index]
-        target_claimed.update(claimed)
+        target_claimed = target_claimed.union(claimed)
         target_deletions.update(deletion_indices)
 
         for source_index in reversed(overlapping_component_indices[1:]):
             source_claimed, source_deletions = components[source_index]
-            target_claimed.update(source_claimed)
+            target_claimed = target_claimed.union(source_claimed)
             target_deletions.update(source_deletions)
             del components[source_index]
+        components[target_index] = (target_claimed, target_deletions)
 
     return [
         ReplacementUnit(
@@ -751,7 +762,7 @@ def merge_batch_ownership(existing: BatchOwnership, new: BatchOwnership) -> Batc
     # Merge presence claims (combine and normalize ranges)
     existing_claimed = existing.presence_line_set()
     new_claimed = new.presence_line_set()
-    combined_claimed = existing_claimed | new_claimed
+    combined_claimed = existing_claimed.union(new_claimed)
     combined_presence_references = {
         **existing.presence_baseline_references(),
         **new.presence_baseline_references(),
@@ -932,7 +943,7 @@ def translate_lines_to_batch_ownership(selected_lines: list) -> BatchOwnership:
 
                 if active_replacement_unit is not None:
                     claimed = _parse_line_ranges(active_replacement_unit.presence_lines)
-                    claimed.add(line.source_line)
+                    claimed = claimed.union([line.source_line])
                     active_replacement_unit.presence_lines = _format_line_set(claimed)
             else:
                 active_replacement_unit = None
@@ -1219,7 +1230,7 @@ def translate_hunk_selection_to_batch_ownership(
 
                     if active_replacement_unit is not None:
                         claimed = _parse_line_ranges(active_replacement_unit.presence_lines)
-                        claimed.add(line.source_line)
+                        claimed = claimed.union([line.source_line])
                         active_replacement_unit.presence_lines = _format_line_set(claimed)
                 else:
                     active_replacement_unit = None
@@ -1481,7 +1492,7 @@ def _build_explicit_replacement_units_from_display_lines(
         return units, consumed_claimed_lines, consumed_deletion_indices
 
     for replacement_unit in replacement_units:
-        claimed_source_lines = _parse_line_ranges(replacement_unit.presence_lines)
+        claimed_source_lines = _parse_line_ranges(replacement_unit.presence_lines).to_set()
         deletion_indices = set(replacement_unit.deletion_indices)
         claimed_display_ids: set[int] = set()
         deletion_display_ids: set[int] = set()

--- a/src/git_stage_batch/core/line_selection.py
+++ b/src/git_stage_batch/core/line_selection.py
@@ -2,9 +2,246 @@
 
 from __future__ import annotations
 
+from bisect import bisect_right
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, Iterator, Protocol
 from ..utils.file_io import read_text_file_contents, write_text_file_contents
+
+
+class LineSelection(Protocol):
+    """Positive 1-based line selection with cheap range operations."""
+
+    def __contains__(self, line_number: object) -> bool:
+        ...
+
+    def __bool__(self) -> bool:
+        ...
+
+    def __iter__(self) -> Iterator[int]:
+        ...
+
+    def ranges(self) -> tuple[tuple[int, int], ...]:
+        """Return normalized inclusive ranges."""
+        ...
+
+    def count(self, start: int | None = None, end: int | None = None) -> int:
+        """Return selected-line count, optionally inside an inclusive range."""
+        ...
+
+    def intersection(self, other: LineSelection | Iterable[int]) -> LineRanges:
+        """Return selected lines also present in another selection."""
+        ...
+
+
+def _normalize_line_ranges(
+    ranges: Iterable[tuple[int, int]],
+) -> tuple[tuple[int, int], ...]:
+    sorted_ranges = sorted(ranges)
+    if not sorted_ranges:
+        return ()
+
+    normalized: list[tuple[int, int]] = []
+    current_start: int | None = None
+    current_end: int | None = None
+
+    for start, end in sorted_ranges:
+        if start <= 0 or end <= 0:
+            raise ValueError(f"Line IDs must be positive: {start}-{end}")
+        if start > end:
+            raise ValueError(f"Range start must be <= end: {start}-{end}")
+
+        if current_start is None or current_end is None:
+            current_start = start
+            current_end = end
+            continue
+
+        if start <= current_end + 1:
+            current_end = max(current_end, end)
+            continue
+
+        normalized.append((current_start, current_end))
+        current_start = start
+        current_end = end
+
+    if current_start is not None and current_end is not None:
+        normalized.append((current_start, current_end))
+
+    return tuple(normalized)
+
+
+def _line_ranges_count(ranges: Iterable[tuple[int, int]]) -> int:
+    return sum(end - start + 1 for start, end in ranges)
+
+
+def _selection_ranges(
+    selection: LineSelection | Iterable[int],
+) -> tuple[tuple[int, int], ...]:
+    ranges = getattr(selection, "ranges", None)
+    if ranges is not None:
+        return ranges()
+    return LineRanges.from_lines(selection).ranges()
+
+
+@dataclass(frozen=True, slots=True)
+class LineRanges:
+    """Immutable 1-based line selection stored as normalized inclusive ranges."""
+
+    _ranges: tuple[tuple[int, int], ...] = ()
+    _starts: tuple[int, ...] = field(init=False, repr=False, compare=False)
+    _count: int = field(init=False, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        ranges = _normalize_line_ranges(self._ranges)
+        object.__setattr__(self, "_ranges", ranges)
+        object.__setattr__(self, "_starts", tuple(start for start, _end in ranges))
+        object.__setattr__(self, "_count", _line_ranges_count(ranges))
+
+    @classmethod
+    def empty(cls) -> LineRanges:
+        return cls(())
+
+    @classmethod
+    def from_lines(cls, lines: Iterable[int]) -> LineRanges:
+        return cls(tuple((line, line) for line in lines))
+
+    @classmethod
+    def from_ranges(cls, ranges: Iterable[tuple[int, int]]) -> LineRanges:
+        return cls(tuple(ranges))
+
+    @classmethod
+    def from_specs(cls, line_ranges: Iterable[str | int]) -> LineRanges:
+        specs = [str(line) for line in line_ranges]
+        if not specs:
+            return cls.empty()
+        return parse_line_selection_ranges(",".join(specs))
+
+    def __contains__(self, line_number: object) -> bool:
+        if type(line_number) is not int:
+            return False
+        index = bisect_right(self._starts, line_number) - 1
+        if index < 0:
+            return False
+        _start, end = self._ranges[index]
+        return line_number <= end
+
+    def __bool__(self) -> bool:
+        return bool(self._ranges)
+
+    def __iter__(self) -> Iterator[int]:
+        for start, end in self._ranges:
+            yield from range(start, end + 1)
+
+    def __len__(self) -> int:
+        return self._count
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, LineRanges):
+            return self._ranges == other._ranges
+        if isinstance(other, set):
+            return set(self) == other
+        return NotImplemented
+
+    def ranges(self) -> tuple[tuple[int, int], ...]:
+        return self._ranges
+
+    def count(self, start: int | None = None, end: int | None = None) -> int:
+        if start is None and end is None:
+            return self._count
+        if start is None or end is None:
+            raise ValueError("range count requires both start and end")
+        if start > end:
+            return 0
+
+        total = 0
+        for range_start, range_end in self._ranges:
+            if range_end < start:
+                continue
+            if range_start > end:
+                break
+            total += max(0, min(range_end, end) - max(range_start, start) + 1)
+        return total
+
+    def intersection(
+        self,
+        other: LineSelection | Iterable[int],
+    ) -> LineRanges:
+        other_ranges = _selection_ranges(other)
+        intersections: list[tuple[int, int]] = []
+        left_index = 0
+        right_index = 0
+
+        while left_index < len(self._ranges) and right_index < len(other_ranges):
+            left_start, left_end = self._ranges[left_index]
+            right_start, right_end = other_ranges[right_index]
+            start = max(left_start, right_start)
+            end = min(left_end, right_end)
+            if start <= end:
+                intersections.append((start, end))
+
+            if left_end < right_end:
+                left_index += 1
+            else:
+                right_index += 1
+
+        return LineRanges.from_ranges(intersections)
+
+    def difference(
+        self,
+        other: LineSelection | Iterable[int],
+    ) -> LineRanges:
+        other_ranges = _selection_ranges(other)
+        if not self._ranges or not other_ranges:
+            return self
+
+        remaining: list[tuple[int, int]] = []
+        other_index = 0
+        for start, end in self._ranges:
+            current_start = start
+
+            while other_index < len(other_ranges) and other_ranges[other_index][1] < current_start:
+                other_index += 1
+
+            scan_index = other_index
+            while scan_index < len(other_ranges):
+                remove_start, remove_end = other_ranges[scan_index]
+                if remove_start > end:
+                    break
+                if remove_start > current_start:
+                    remaining.append((current_start, remove_start - 1))
+                current_start = max(current_start, remove_end + 1)
+                if current_start > end:
+                    break
+                scan_index += 1
+
+            if current_start <= end:
+                remaining.append((current_start, end))
+
+        return LineRanges.from_ranges(remaining)
+
+    def union(
+        self,
+        other: LineSelection | Iterable[int],
+    ) -> LineRanges:
+        return LineRanges.from_ranges((*self._ranges, *_selection_ranges(other)))
+
+    def first(self) -> int | None:
+        if not self._ranges:
+            return None
+        return self._ranges[0][0]
+
+    def to_set(self) -> set[int]:
+        return set(self)
+
+    def to_line_spec(self) -> str:
+        return ",".join(
+            str(start) if start == end else f"{start}-{end}"
+            for start, end in self._ranges
+        )
+
+    def to_range_strings(self) -> list[str]:
+        spec = self.to_line_spec()
+        return [spec] if spec else []
 
 
 def parse_positive_selection(
@@ -85,6 +322,52 @@ def parse_positive_selection(
 def parse_line_selection(selection: str) -> list[int]:
     """Parse a line selection string into a list of line IDs."""
     return parse_positive_selection(selection, item_name="Line ID")
+
+
+def parse_line_selection_ranges(selection: str) -> LineRanges:
+    """Parse a line selection string into normalized line ranges."""
+    if not selection or not selection.strip():
+        raise ValueError("Selection string cannot be empty")
+
+    ranges: list[tuple[int, int]] = []
+    parts = selection.split(",")
+
+    for part in parts:
+        part = part.strip()
+        if not part:
+            continue
+
+        range_separator_pos = part.find("-", 1)
+        if range_separator_pos != -1:
+            start_str = part[:range_separator_pos]
+            end_str = part[range_separator_pos + 1:]
+
+            try:
+                start = int(start_str.strip())
+                end = int(end_str.strip())
+            except ValueError as e:
+                raise ValueError(f"Invalid range: {part}") from e
+
+            if start <= 0 or end <= 0:
+                raise ValueError(f"Line IDs must be positive: {part}")
+
+            if start > end:
+                raise ValueError(f"Range start must be <= end: {part}")
+
+            ranges.append((start, end))
+            continue
+
+        try:
+            line_id = int(part)
+        except ValueError as e:
+            raise ValueError(f"Invalid line ID: {part}") from e
+
+        if line_id <= 0:
+            raise ValueError(f"Line ID must be positive: {part}")
+
+        ranges.append((line_id, line_id))
+
+    return LineRanges.from_ranges(ranges)
 
 
 def read_line_ids_file(path: Path) -> list[int]:

--- a/tests/batch/test_merge.py
+++ b/tests/batch/test_merge.py
@@ -13,6 +13,7 @@ from git_stage_batch.batch.merge import (
     _discard_batch_line_chunks,
     _merge_batch_line_chunks,
     _realized_entry_content_chunks,
+    _reverse_presence_constraints,
     _try_apply_baseline_replacement_units,
     can_merge_batch_from_line_sequences,
     discard_batch_from_line_sequences_as_buffer,
@@ -42,6 +43,13 @@ class _IndexGuardedRealizedEntries(_RealizedEntries):
 
     def __getitem__(self, index):
         raise AssertionError("entry indexing should not be used")
+
+
+class _SourceLookupGuardedRealizedEntries(_RealizedEntries):
+    """Realized entries variant that rejects per-line source lookups in tests."""
+
+    def source_line_at(self, index):
+        raise AssertionError("source lookup should not be used")
 
 
 class _GuardedLine:
@@ -666,6 +674,30 @@ class TestMergeLineSequences:
         assert entries.provenance_run_count == 1
         assert entries.target_line_at(999) == 1000
         entries.close()
+
+    def test_reverse_presence_constraints_scans_realized_runs(self):
+        """Discard restore scans realized runs instead of per-line lookups."""
+        baseline = [b"one\n", b"old\n", b"three\n"]
+        source = [b"one\n", b"new\n", b"three\n"]
+        correspondence = _build_baseline_correspondence(baseline, source)
+        entries = _SourceLookupGuardedRealizedEntries()
+        entries.append_line_range_from(
+            source,
+            0,
+            3,
+            source_line_start=1,
+            target_line_start=1,
+        )
+
+        try:
+            result = _reverse_presence_constraints(entries, {2}, correspondence)
+        finally:
+            entries.close()
+
+        try:
+            assert list(result.content_chunks()) == baseline
+        finally:
+            result.close()
 
     def test_baseline_correspondence_accepts_non_list_sequences(self, line_sequence):
         """Baseline correspondence accepts sized sliceable line sequences."""

--- a/tests/batch/test_ownership_incremental.py
+++ b/tests/batch/test_ownership_incremental.py
@@ -10,6 +10,7 @@ from git_stage_batch.batch.ownership import (
     translate_hunk_selection_to_batch_ownership,
     translate_lines_to_batch_ownership,
 )
+from git_stage_batch.core.line_selection import LineRanges
 from git_stage_batch.core.models import LineEntry
 
 
@@ -34,6 +35,25 @@ def test_translate_lines_creates_deletion_constraints():
     assert len(ownership.replacement_units) == 1
     assert ownership.replacement_units[0].presence_lines == ["1"]
     assert ownership.replacement_units[0].deletion_indices == [0]
+
+
+def test_presence_line_set_returns_line_ranges():
+    """Ownership presence lines stay range-backed after translation."""
+    lines = [
+        LineEntry(id=1, kind='+', old_line_number=None, new_line_number=1,
+                  text_bytes=b'one', text='one', source_line=1),
+        LineEntry(id=2, kind='+', old_line_number=None, new_line_number=2,
+                  text_bytes=b'two', text='two', source_line=2),
+        LineEntry(id=3, kind='+', old_line_number=None, new_line_number=4,
+                  text_bytes=b'four', text='four', source_line=4),
+    ]
+
+    ownership = translate_lines_to_batch_ownership(lines)
+    selection = ownership.presence_line_set()
+
+    assert isinstance(selection, LineRanges)
+    assert selection.ranges() == ((1, 2), (4, 4))
+    assert ownership.resolve().presence_line_set == selection
 
 
 def test_derive_replacement_line_runs_accepts_non_list_sequences(line_sequence):

--- a/tests/core/test_line_selection.py
+++ b/tests/core/test_line_selection.py
@@ -2,7 +2,12 @@
 
 import pytest
 
-from git_stage_batch.core.line_selection import format_line_ids, parse_line_selection
+from git_stage_batch.core.line_selection import (
+    LineRanges,
+    format_line_ids,
+    parse_line_selection,
+    parse_line_selection_ranges,
+)
 
 
 class TestParseLineSelection:
@@ -157,3 +162,37 @@ class TestFormatLineIds:
     def test_complex_mixed(self):
         """Test complex mixed ranges and singles."""
         assert format_line_ids([1, 2, 5, 6, 7, 10, 15, 16]) == "1-2,5-7,10,15-16"
+
+
+class TestLineRanges:
+    """Tests for range-backed line selections."""
+
+    def test_parse_selection_ranges_does_not_expand_ranges(self):
+        selection = parse_line_selection_ranges("1-1000000,1000002")
+
+        assert selection.ranges() == ((1, 1000000), (1000002, 1000002))
+        assert len(selection) == 1000001
+        assert 999999 in selection
+        assert 1000001 not in selection
+
+    def test_count_intersection_and_difference_use_ranges(self):
+        selection = parse_line_selection_ranges("1-10,20-30")
+
+        assert selection.count() == 21
+        assert selection.count(5, 22) == 9
+        assert selection.intersection(LineRanges.from_ranges([(8, 25)])).ranges() == (
+            (8, 10),
+            (20, 25),
+        )
+        assert selection.difference(LineRanges.from_ranges([(3, 8), (25, 40)])).ranges() == (
+            (1, 2),
+            (9, 10),
+            (20, 24),
+        )
+
+    def test_formats_ranges_without_line_expansion(self):
+        selection = LineRanges.from_ranges([(10, 12), (1, 3), (4, 5)])
+
+        assert selection.ranges() == ((1, 5), (10, 12))
+        assert selection.to_line_spec() == "1-5,10-12"
+        assert selection.to_range_strings() == ["1-5,10-12"]


### PR DESCRIPTION
The ownership metadata for batch presence claims identifies source lines that must exist after merge or discard operations. Those selections are usually contiguous or mostly contiguous ranges, but the ownership and merge APIs have been materializing them as `set[int]` values.

That set representation spends Python heap proportional to the number of selected lines before merge consumers can ask range-oriented questions such as membership, count within a range, intersection, or subtraction.

This pull request introduces `LineRanges`, a compact line-selection value that stores normalized inclusive ranges while still supporting iteration and set-style equality for existing callers. It then updates merge helpers and ownership resolution so presence claims can flow through the line-selection protocol instead of expanding to per-line sets.

Discard restoration now also scans realized-entry metadata runs directly. Those runs are the metadata that tracks where pertinent lines come from, so the discard path can match selected source ranges against runs rather than calling source-line lookup once per destination line.

Commit split:
- groundwork: core range selection value
- tests: core range selection behavior
- merge: selection protocol consumers
- batch: ownership resolves presence claims as `LineRanges`
- tests: ownership API behavior
- merge: realized-entry run scan for discard restore
- tests: run-scan guard

Verification:
- `git diff --check origin/main..HEAD`
- `PYTHONPATH=src uv run pytest tests/core/test_line_selection.py tests/batch/test_ownership_incremental.py tests/batch/test_merge.py tests/batch/test_match_storage.py`
- `PYTHONPATH=src uv run pytest -n auto`
