### PR TITLE
Keep display ranges compact

### DIFF
--- a/src/git_stage_batch/batch/display.py
+++ b/src/git_stage_batch/batch/display.py
@@ -74,29 +74,35 @@ def _build_display_lines_from_batch_source_lines(
                 })
                 display_id += 1
 
-    # Collect all positions (claimed lines + deletion positions)
-    all_positions = set(claimed_set)
-    for pos in deletions_by_position.keys():
-        if pos is not None:
-            all_positions.add(pos)
+    # Collect displayed source ranges without expanding claimed ranges to lines.
+    display_ranges: list[tuple[int, int]] = []
 
-    ranges: list[tuple[int, int]] = []
-    for position in sorted(all_positions):
-        start = max(1, position - context_lines)
-        end = position + context_lines
+    def add_display_range(start: int, end: int) -> None:
         if start <= end:
-            if ranges and start <= ranges[-1][1] + 1:
-                ranges[-1] = (ranges[-1][0], max(ranges[-1][1], end))
-            else:
-                ranges.append((start, end))
+            display_ranges.append((start, end))
+
+    for claimed_start, claimed_end in claimed_set.ranges():
+        add_display_range(
+            max(1, claimed_start - context_lines),
+            claimed_end + context_lines,
+        )
+
+    for position in deletions_by_position:
+        if position is not None:
+            add_display_range(
+                max(1, position - context_lines),
+                position + context_lines,
+            )
 
     if None in deletions_by_position and context_lines > 0:
-        start = 1
-        end = context_lines
-        if ranges and end >= ranges[0][0] - 1:
-            ranges[0] = (start, max(ranges[0][1], end))
+        add_display_range(1, context_lines)
+
+    ranges: list[tuple[int, int]] = []
+    for start, end in sorted(display_ranges):
+        if ranges and start <= ranges[-1][1] + 1:
+            ranges[-1] = (ranges[-1][0], max(ranges[-1][1], end))
         else:
-            ranges.insert(0, (start, end))
+            ranges.append((start, end))
 
     # Add claimed lines, source context, and deletions in batch source order.
     # Context prevents unrelated owned lines from being visually glued together

--- a/tests/batch/test_batch_display.py
+++ b/tests/batch/test_batch_display.py
@@ -39,6 +39,42 @@ class _NoLenByteLines(Sequence[bytes]):
         return self._lines[index]
 
 
+class _IterationGuardedLineSelection:
+    """Line selection that rejects full expansion in display tests."""
+
+    def __init__(self, ranges: tuple[tuple[int, int], ...]) -> None:
+        self._ranges = ranges
+
+    def __contains__(self, line_number: object) -> bool:
+        if type(line_number) is not int:
+            return False
+        return any(start <= line_number <= end for start, end in self._ranges)
+
+    def __bool__(self) -> bool:
+        return bool(self._ranges)
+
+    def __iter__(self):
+        raise AssertionError("claimed selection should not be expanded")
+
+    def ranges(self) -> tuple[tuple[int, int], ...]:
+        return self._ranges
+
+
+class _RangeBackedDisplayOwnership:
+    """Ownership stub that returns a guarded range-backed selection."""
+
+    def __init__(
+        self,
+        selection: _IterationGuardedLineSelection,
+        deletions: Iterable[DeletionClaim] = (),
+    ) -> None:
+        self._selection = selection
+        self.deletions = list(deletions)
+
+    def presence_line_set(self) -> _IterationGuardedLineSelection:
+        return self._selection
+
+
 def test_display_builder_accepts_non_list_byte_line_sequences(line_sequence):
     """Batch display construction accepts indexed byte-line sequences."""
     source_lines = line_sequence([
@@ -98,6 +134,55 @@ def test_display_builder_does_not_require_source_line_count():
     ]
     assert [line["id"] for line in display_lines] == [None, 1, None]
     assert source_lines.accessed_indexes == [498, 499, 500]
+
+
+def test_display_builder_uses_ranges_without_expanding_claims():
+    """Display construction keeps claimed ranges compact."""
+    source_lines = _NoLenByteLines(
+        f"line {line_number}\n".encode("utf-8")
+        for line_number in range(1, 101)
+    )
+    ownership = _RangeBackedDisplayOwnership(
+        _IterationGuardedLineSelection(((50, 52),)),
+        [
+            DeletionClaim(
+                anchor_line=60,
+                content_lines=[b"deleted\n"],
+            ),
+        ],
+    )
+
+    display_lines = build_display_lines_from_batch_source_lines(
+        source_lines,
+        ownership,
+        context_lines=1,
+    )
+
+    assert [line["content"] for line in display_lines] == [
+        "line 49\n",
+        "line 50\n",
+        "line 51\n",
+        "line 52\n",
+        "line 53\n",
+        "... 5 more lines ...\n",
+        "line 59\n",
+        "line 60\n",
+        "deleted\n",
+        "line 61\n",
+    ]
+    assert [line["type"] for line in display_lines] == [
+        "context",
+        "claimed",
+        "claimed",
+        "claimed",
+        "context",
+        "gap",
+        "context",
+        "context",
+        "deletion",
+        "context",
+    ]
+    assert source_lines.accessed_indexes == [48, 49, 50, 51, 52, 58, 59, 60]
 
 
 def test_annotate_with_batch_source_lines_accepts_non_list_byte_sequences(line_sequence):


### PR DESCRIPTION
Ownership resolution returns presence claims as `LineRanges`, a compact selection value that stores normalized inclusive ranges instead of one Python object per selected line. The display builder receives that value before rendering selected batch-source lines.

`build_display_lines_from_batch_source_lines()` still calls `set(...)` on that selection before computing visible display ranges. Large contiguous claims therefore expand back to one Python entry per selected line before rendering.

This pull request keeps the display range calculation range-based. It expands each claimed range by the requested context width, adds deletion-anchor ranges, normalizes those visible ranges, and keeps direct membership checks against the original selection while emitting display lines.

The tests add a guarded selection object that raises if display construction tries to iterate every claimed line. They also check that claimed lines, context, gaps, and deletion anchors render in the expected order.

Verification:
- `git diff --check origin/main..HEAD`
- `PYTHONPATH=src uv run pytest tests/batch/test_batch_display.py`
- `PYTHONPATH=src uv run pytest -n auto`
