### PR TITLE
Use mapped line tracking during source rebuild

### DIFF
--- a/src/git_stage_batch/batch/lineage.py
+++ b/src/git_stage_batch/batch/lineage.py
@@ -1,0 +1,376 @@
+"""Compact line lineage for refreshed batch sources."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass
+from pathlib import Path
+
+from ..core.line_selection import LineRanges, LineSelection
+from ..utils.mapped_storage import ChunkedMappedRecordVector
+
+
+_LINEAGE_RECORD_FORMAT = "QQQ"
+_LINEAGE_CHUNK_CAPACITY = 8192
+_LINEAGE_OLD_START = 0
+_LINEAGE_OLD_END = 1
+_LINEAGE_NEW_START = 2
+
+
+@dataclass(frozen=True, slots=True)
+class _LineageRun:
+    """Contiguous line translation from one coordinate space to another."""
+
+    old_start: int
+    old_end: int
+    new_start: int
+
+    def __post_init__(self) -> None:
+        if self.old_start <= 0 or self.old_end <= 0 or self.new_start <= 0:
+            raise ValueError("lineage coordinates must be positive")
+        if self.old_start > self.old_end:
+            raise ValueError("lineage run start must be <= end")
+
+    @property
+    def new_end(self) -> int:
+        return self.new_start + (self.old_end - self.old_start)
+
+    def translate(self, old_line: int) -> int | None:
+        if self.old_start <= old_line <= self.old_end:
+            return self.new_start + (old_line - self.old_start)
+        return None
+
+    def translate_range(self, old_start: int, old_end: int) -> tuple[int, int]:
+        if old_start < self.old_start or old_end > self.old_end:
+            raise ValueError("range is outside lineage run")
+        new_start = self.new_start + (old_start - self.old_start)
+        return new_start, new_start + (old_end - old_start)
+
+
+def _lineage_run_from_record(record: tuple[int, ...]) -> _LineageRun:
+    return _LineageRun(
+        record[_LINEAGE_OLD_START],
+        record[_LINEAGE_OLD_END],
+        record[_LINEAGE_NEW_START],
+    )
+
+
+def _selection_ranges(
+    selection: LineSelection | Iterable[int],
+) -> tuple[tuple[int, int], ...]:
+    ranges = getattr(selection, "ranges", None)
+    if ranges is not None:
+        return ranges()
+    return LineRanges.from_lines(selection).ranges()
+
+
+def _lineage_runs_can_merge(left: _LineageRun, right: _LineageRun) -> bool:
+    return (
+        right.old_start == left.old_end + 1
+        and right.new_start == left.new_end + 1
+    )
+
+
+class _LineageRunTable:
+    """Append-only mapped lineage runs with one pending Python run."""
+
+    def __init__(
+        self,
+        runs: Iterable[_LineageRun] = (),
+        *,
+        spool_dir: str | Path | None = None,
+    ) -> None:
+        self._runs = ChunkedMappedRecordVector(
+            record_format=_LINEAGE_RECORD_FORMAT,
+            chunk_capacity=_LINEAGE_CHUNK_CAPACITY,
+            spool_dir=spool_dir,
+        )
+        self._pending_run: _LineageRun | None = None
+        self._closed = False
+
+        for run in sorted(runs, key=lambda item: (item.old_start, item.old_end)):
+            self.append(run)
+
+    @property
+    def byte_count(self) -> int:
+        if self._closed:
+            return 0
+        return self._runs.byte_count
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    def __len__(self) -> int:
+        self._require_open()
+        return len(self._runs) + (1 if self._pending_run is not None else 0)
+
+    def append(self, run: _LineageRun) -> None:
+        self._require_open()
+        pending = self._pending_run
+        if pending is None:
+            self._pending_run = run
+            return
+
+        if run.old_start <= pending.old_end:
+            raise ValueError("lineage runs must not overlap")
+
+        if _lineage_runs_can_merge(pending, run):
+            self._pending_run = _LineageRun(
+                old_start=pending.old_start,
+                old_end=run.old_end,
+                new_start=pending.new_start,
+            )
+            return
+
+        self._flush_pending()
+        self._pending_run = run
+
+    def run_at(self, old_line: int) -> _LineageRun | None:
+        self._require_open()
+        if type(old_line) is not int:
+            return None
+
+        pending = self._pending_run
+        if (
+            pending is not None
+            and pending.old_start <= old_line <= pending.old_end
+        ):
+            return pending
+
+        low = 0
+        high = len(self._runs)
+        while low < high:
+            mid = (low + high) // 2
+            record = self._runs[mid]
+            if old_line < record[_LINEAGE_OLD_START]:
+                high = mid
+            elif old_line > record[_LINEAGE_OLD_END]:
+                low = mid + 1
+            else:
+                return _lineage_run_from_record(record)
+        return None
+
+    def runs(self) -> Iterator[_LineageRun]:
+        self._require_open()
+        for index in range(len(self._runs)):
+            yield _lineage_run_from_record(self._runs[index])
+        if self._pending_run is not None:
+            yield self._pending_run
+
+    def translate_line(self, old_line: int) -> int | None:
+        run = self.run_at(old_line)
+        if run is None:
+            return None
+        return run.translate(old_line)
+
+    def translate_selection(
+        self,
+        selection: LineSelection | Iterable[int],
+    ) -> LineRanges:
+        self._require_open()
+        translated_ranges: list[tuple[int, int]] = []
+        run_index = 0
+
+        for selected_start, selected_end in _selection_ranges(selection):
+            while (
+                run_index < len(self)
+                and self._run_at_index(run_index).old_end < selected_start
+            ):
+                run_index += 1
+
+            scan_index = run_index
+            while scan_index < len(self):
+                run = self._run_at_index(scan_index)
+                if run.old_start > selected_end:
+                    break
+
+                old_start = max(selected_start, run.old_start)
+                old_end = min(selected_end, run.old_end)
+                if old_start <= old_end:
+                    translated_ranges.append(run.translate_range(old_start, old_end))
+                if run.old_end >= selected_end:
+                    break
+                scan_index += 1
+
+        return LineRanges.from_ranges(translated_ranges)
+
+    def first_unmapped_line(
+        self,
+        selection: LineSelection | Iterable[int],
+    ) -> int | None:
+        self._require_open()
+        run_index = 0
+
+        for selected_start, selected_end in _selection_ranges(selection):
+            current_line = selected_start
+            while (
+                run_index < len(self)
+                and self._run_at_index(run_index).old_end < current_line
+            ):
+                run_index += 1
+
+            while current_line <= selected_end:
+                if run_index >= len(self):
+                    return current_line
+                run = self._run_at_index(run_index)
+                if run.old_start > current_line:
+                    return current_line
+                current_line = min(run.old_end, selected_end) + 1
+                if current_line <= selected_end:
+                    run_index += 1
+
+        return None
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._pending_run = None
+        self._runs.close()
+        self._closed = True
+
+    def __enter__(self) -> _LineageRunTable:
+        self._require_open()
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        self.close()
+
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except Exception:
+            pass
+
+    def _flush_pending(self) -> None:
+        pending = self._pending_run
+        if pending is None:
+            return
+        self._runs.append((
+            pending.old_start,
+            pending.old_end,
+            pending.new_start,
+        ))
+        self._pending_run = None
+
+    def _run_at_index(self, index: int) -> _LineageRun:
+        flushed_count = len(self._runs)
+        if 0 <= index < flushed_count:
+            return _lineage_run_from_record(self._runs[index])
+        if index == flushed_count and self._pending_run is not None:
+            return self._pending_run
+        raise IndexError(index)
+
+    def _require_open(self) -> None:
+        if self._closed:
+            raise ValueError("lineage run table is closed")
+
+
+class _BatchSourceLineage:
+    """Lineage from old source and working lines to refreshed source lines."""
+
+    def __init__(
+        self,
+        source_runs: Iterable[_LineageRun] = (),
+        working_runs: Iterable[_LineageRun] = (),
+        *,
+        spool_dir: str | Path | None = None,
+    ) -> None:
+        self._source_runs = _LineageRunTable(
+            source_runs,
+            spool_dir=spool_dir,
+        )
+        self._working_runs = _LineageRunTable(
+            working_runs,
+            spool_dir=spool_dir,
+        )
+        self._closed = False
+
+    @classmethod
+    def from_runs(
+        cls,
+        *,
+        source_runs: Iterable[_LineageRun] = (),
+        working_runs: Iterable[_LineageRun] = (),
+        spool_dir: str | Path | None = None,
+    ) -> _BatchSourceLineage:
+        return cls(source_runs, working_runs, spool_dir=spool_dir)
+
+    @property
+    def byte_count(self) -> int:
+        if self._closed:
+            return 0
+        return self._source_runs.byte_count + self._working_runs.byte_count
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    def source_runs(self) -> Iterator[_LineageRun]:
+        self._require_open()
+        return self._source_runs.runs()
+
+    def working_runs(self) -> Iterator[_LineageRun]:
+        self._require_open()
+        return self._working_runs.runs()
+
+    def append_source_run(self, run: _LineageRun) -> None:
+        self._require_open()
+        self._source_runs.append(run)
+
+    def append_working_run(self, run: _LineageRun) -> None:
+        self._require_open()
+        self._working_runs.append(run)
+
+    def translate_source_line(self, line_number: int) -> int | None:
+        self._require_open()
+        return self._source_runs.translate_line(line_number)
+
+    def translate_source_selection(
+        self,
+        selection: LineSelection | Iterable[int],
+    ) -> LineRanges:
+        self._require_open()
+        return self._source_runs.translate_selection(selection)
+
+    def first_unmapped_source_line(
+        self,
+        selection: LineSelection | Iterable[int],
+    ) -> int | None:
+        self._require_open()
+        return self._source_runs.first_unmapped_line(selection)
+
+    def translate_working_line(self, line_number: int) -> int | None:
+        self._require_open()
+        return self._working_runs.translate_line(line_number)
+
+    def translate_working_selection(
+        self,
+        selection: LineSelection | Iterable[int],
+    ) -> LineRanges:
+        self._require_open()
+        return self._working_runs.translate_selection(selection)
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._source_runs.close()
+        self._working_runs.close()
+        self._closed = True
+
+    def __enter__(self) -> _BatchSourceLineage:
+        self._require_open()
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        self.close()
+
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except Exception:
+            pass
+
+    def _require_open(self) -> None:
+        if self._closed:
+            raise ValueError("batch source lineage is closed")

--- a/src/git_stage_batch/batch/ownership.py
+++ b/src/git_stage_batch/batch/ownership.py
@@ -29,11 +29,10 @@ from ..utils.git import (
     read_git_blobs_as_bytes,
 )
 from .comparison import SemanticChangeKind, derive_semantic_change_runs
+from .lineage import _BatchSourceLineage, _LineageRun
 from .match import LineMapping, match_lines
 from .merge import (
     _apply_presence_constraints,
-    _entry_source_line_at,
-    _entry_target_line_at,
     _realized_entry_content_chunks,
 )
 
@@ -530,12 +529,12 @@ class SourceContentWithLineProvenance:
     """Synthesized source buffer with line provenance from its inputs."""
 
     source_buffer: EditorBuffer
-    source_line_map: dict[int, int]
-    working_line_map: dict[int, int]
+    lineage: _BatchSourceLineage
 
     def close(self) -> None:
-        """Release the synthesized buffer."""
+        """Release the synthesized buffer and line lineage."""
         self.source_buffer.close()
+        self.lineage.close()
 
     def __enter__(self) -> SourceContentWithLineProvenance:
         return self
@@ -551,11 +550,12 @@ class BatchSourceAdvanceResult:
     batch_source_commit: str
     ownership: BatchOwnership
     source_buffer: EditorBuffer
-    working_line_map: dict[int, int]
+    lineage: _BatchSourceLineage
 
     def close(self) -> None:
-        """Release the refreshed source buffer."""
+        """Release the refreshed source buffer and line lineage."""
         self.source_buffer.close()
+        self.lineage.close()
 
     def __enter__(self) -> BatchSourceAdvanceResult:
         return self
@@ -1835,6 +1835,44 @@ def _remap_replacement_units(
     )
 
 
+def _first_unmapped_line(
+    line_selection: LineSelection,
+    lineage: _BatchSourceLineage,
+) -> int | None:
+    return lineage.first_unmapped_source_line(line_selection)
+
+
+def _remap_replacement_units_with_lineage(
+    replacement_units: list[ReplacementUnit],
+    *,
+    lineage: _BatchSourceLineage,
+    deletion_count: int,
+) -> list[ReplacementUnit]:
+    """Remap replacement-unit presence lines with refreshed source lineage."""
+    remapped_units: list[ReplacementUnit] = []
+
+    for unit in replacement_units:
+        old_presence_lines = _parse_line_ranges(unit.presence_lines)
+        first_unmapped = _first_unmapped_line(old_presence_lines, lineage)
+        if first_unmapped is not None:
+            raise ValueError(
+                f"Cannot remap replacement unit presence line {first_unmapped} "
+                f"from old source to new source: no unique mapping found."
+            )
+
+        remapped_units.append(ReplacementUnit(
+            presence_lines=_format_line_set(
+                lineage.translate_source_selection(old_presence_lines)
+            ),
+            deletion_indices=unit.deletion_indices,
+        ))
+
+    return _normalize_replacement_units(
+        remapped_units,
+        deletion_count=deletion_count,
+    )
+
+
 def remap_batch_ownership_to_new_source_lines(
     ownership: BatchOwnership,
     old_source_lines: Sequence[bytes],
@@ -1927,40 +1965,54 @@ def _advance_source_lines_preserving_existing_presence(
         presence_lines,
     )
 
-    source_line_map = {}
-    working_line_map = {}
-    for offset in range(len(entries)):
-        index = offset + 1
-        source_line = _entry_source_line_at(entries, offset)
-        target_line = _entry_target_line_at(entries, offset)
-        if source_line is not None:
-            source_line_map[source_line] = index
-        if target_line is not None:
-            working_line_map[target_line] = index
+    lineage = _BatchSourceLineage()
+    try:
+        for run in entries.provenance_runs():
+            line_count = run.dest_end - run.dest_start
+            new_start = run.dest_start + 1
+            if run.source_start != 0:
+                lineage.append_source_run(
+                    _LineageRun(
+                        old_start=run.source_start,
+                        old_end=run.source_start + line_count - 1,
+                        new_start=new_start,
+                    )
+                )
+            if run.target_start != 0:
+                lineage.append_working_run(
+                    _LineageRun(
+                        old_start=run.target_start,
+                        old_end=run.target_start + line_count - 1,
+                        new_start=new_start,
+                    )
+                )
 
-    return SourceContentWithLineProvenance(
-        source_buffer=EditorBuffer.from_chunks(_realized_entry_content_chunks(entries)),
-        source_line_map=source_line_map,
-        working_line_map=working_line_map,
-    )
+        return SourceContentWithLineProvenance(
+            source_buffer=EditorBuffer.from_chunks(
+                _realized_entry_content_chunks(entries)
+            ),
+            lineage=lineage,
+        )
+    except Exception:
+        lineage.close()
+        raise
+    finally:
+        entries.close()
 
 
-def _remap_batch_ownership_with_source_line_map(
+def _remap_batch_ownership_with_lineage(
     ownership: BatchOwnership,
-    source_line_map: dict[int, int],
+    lineage: _BatchSourceLineage,
 ) -> BatchOwnership:
     """Remap ownership using provenance from source refresh construction."""
     old_presence = ownership.presence_line_set()
-    new_presence = set()
-
-    for old_line_num in old_presence:
-        new_line_num = source_line_map.get(old_line_num)
-        if new_line_num is None:
-            raise ValueError(
-                f"Cannot remap presence line {old_line_num} from old source to new source: "
-                f"no preserved source-line mapping found."
-            )
-        new_presence.add(new_line_num)
+    first_unmapped = _first_unmapped_line(old_presence, lineage)
+    if first_unmapped is not None:
+        raise ValueError(
+            f"Cannot remap presence line {first_unmapped} from old source to new source: "
+            f"no preserved source lineage found."
+        )
+    new_presence = lineage.translate_source_selection(old_presence)
 
     new_deletions = []
     for deletion in ownership.deletions:
@@ -1972,11 +2024,11 @@ def _remap_batch_ownership_with_source_line_map(
             ))
             continue
 
-        new_anchor = source_line_map.get(deletion.anchor_line)
+        new_anchor = lineage.translate_source_line(deletion.anchor_line)
         if new_anchor is None:
             raise ValueError(
                 f"Cannot remap deletion anchor line {deletion.anchor_line} from old source "
-                f"to new source: no preserved source-line mapping found."
+                f"to new source: no preserved source lineage found."
             )
         new_deletions.append(DeletionClaim(
             anchor_line=new_anchor,
@@ -1984,15 +2036,15 @@ def _remap_batch_ownership_with_source_line_map(
             baseline_reference=deletion.baseline_reference,
         ))
 
-    new_replacement_units = _remap_replacement_units(
+    new_replacement_units = _remap_replacement_units_with_lineage(
         ownership.replacement_units,
-        map_claimed_line=source_line_map.get,
+        lineage=lineage,
         deletion_count=len(new_deletions),
     )
 
     new_presence_baseline_references = {}
     for old_line_num, reference in ownership.presence_baseline_references().items():
-        new_line_num = source_line_map.get(old_line_num)
+        new_line_num = lineage.translate_source_line(old_line_num)
         if new_line_num is not None:
             new_presence_baseline_references[new_line_num] = reference
 
@@ -2049,19 +2101,19 @@ def advance_batch_source_for_file_with_provenance(
             file_buffer_override=source_with_provenance.source_buffer
         )
 
-        # Remap ownership using provenance produced while constructing the refreshed
+        # Remap ownership using lineage produced while constructing the refreshed
         # source. This preserves already-owned lines that no longer exist in the
         # working tree after earlier discard operations.
-        remapped_ownership = _remap_batch_ownership_with_source_line_map(
+        remapped_ownership = _remap_batch_ownership_with_lineage(
             ownership=existing_ownership,
-            source_line_map=source_with_provenance.source_line_map,
+            lineage=source_with_provenance.lineage,
         )
 
         return BatchSourceAdvanceResult(
             batch_source_commit=new_batch_source_commit,
             ownership=remapped_ownership,
             source_buffer=source_with_provenance.source_buffer,
-            working_line_map=source_with_provenance.working_line_map,
+            lineage=source_with_provenance.lineage,
         )
     except Exception:
         if source_with_provenance is not None:

--- a/src/git_stage_batch/batch/source_refresh.py
+++ b/src/git_stage_batch/batch/source_refresh.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 
 from ..core.models import LineEntry
 from ..data.batch_sources import load_session_batch_sources, save_session_batch_sources
+from .lineage import _BatchSourceLineage
 from .match import match_lines
 from .ownership import (
     BatchOwnership,
@@ -121,7 +122,7 @@ def ensure_batch_source_current_for_selection(
                 selected_lines,
                 source_lines=advance_result.source_buffer,
                 working_lines=(),
-                working_line_map=advance_result.working_line_map,
+                lineage=advance_result.lineage,
             )
 
             return RefreshedBatchSelection(
@@ -224,19 +225,19 @@ def _refresh_selected_lines_against_source_lines(
     *,
     source_lines: Sequence[bytes],
     working_lines: Sequence[bytes],
-    working_line_map: dict[int, int] | None = None,
+    lineage: _BatchSourceLineage | None = None,
 ) -> list:
     """Re-annotate selected lines against source and working-tree line sequences."""
     mapping = None
-    if working_line_map is None:
+    if lineage is None:
         mapping = match_lines(source_lines, working_lines)
 
     try:
         def map_working_line(line_number: int | None) -> int | None:
             if line_number is None:
                 return None
-            if working_line_map is not None:
-                return working_line_map.get(line_number)
+            if lineage is not None:
+                return lineage.translate_working_line(line_number)
             assert mapping is not None
             return mapping.get_source_line_from_target_line(line_number)
 

--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -24,7 +24,7 @@ from ..batch.display import (
 from ..batch.ownership import (
     BatchOwnership,
     _advance_source_lines_preserving_existing_presence,
-    _remap_batch_ownership_with_source_line_map,
+    _remap_batch_ownership_with_lineage,
     merge_batch_ownership,
     translate_lines_to_batch_ownership,
 )
@@ -919,15 +919,15 @@ def _command_discard_lines_to_batch_as(
                                 ownership=existing_ownership,
                             ) as source_with_provenance,
                         ):
-                            remapped_existing_ownership = _remap_batch_ownership_with_source_line_map(
+                            remapped_existing_ownership = _remap_batch_ownership_with_lineage(
                                 ownership=existing_ownership,
-                                source_line_map=source_with_provenance.source_line_map,
+                                lineage=source_with_provenance.lineage,
                             )
                             refreshed_selected_lines = _refresh_selected_lines_against_source_lines(
                                 rewritten_selected_lines,
                                 source_lines=source_with_provenance.source_buffer,
                                 working_lines=(),
-                                working_line_map=source_with_provenance.working_line_map,
+                                lineage=source_with_provenance.lineage,
                             )
                             new_ownership = translate_lines_to_batch_ownership(
                                 refreshed_selected_lines

--- a/src/git_stage_batch/data/consumed_selections.py
+++ b/src/git_stage_batch/data/consumed_selections.py
@@ -101,7 +101,7 @@ def record_consumed_selection(
                         selected_lines,
                         source_lines=advance_result.source_buffer,
                         working_lines=(),
-                        working_line_map=advance_result.working_line_map,
+                        lineage=advance_result.lineage,
                     )
             new_ownership = translate_lines_to_batch_ownership(selected_lines)
             persist_selection(

--- a/tests/batch/test_source_refresh.py
+++ b/tests/batch/test_source_refresh.py
@@ -308,7 +308,7 @@ def test_refresh_selected_lines_uses_synthesized_working_line_provenance():
             selected_lines,
             source_lines=source_with_provenance.source_buffer,
             working_lines=(),
-            working_line_map=source_with_provenance.working_line_map,
+            lineage=source_with_provenance.lineage,
         )
 
     assert [line.source_line for line in refreshed] == [3, 4]

--- a/tests/batch/test_stale_source_advancement.py
+++ b/tests/batch/test_stale_source_advancement.py
@@ -16,8 +16,31 @@ from git_stage_batch.batch.ownership import (
     remap_batch_ownership_to_new_source_lines,
     translate_lines_to_batch_ownership,
 )
+from git_stage_batch.batch.lineage import _BatchSourceLineage, _LineageRun
+from git_stage_batch.core.line_selection import LineRanges
 from git_stage_batch.core.models import LineEntry
 from git_stage_batch.editor import EditorBuffer
+
+
+class _IterationGuardedLineSelection:
+    """Line selection that rejects full expansion in stale-source tests."""
+
+    def __init__(self, ranges: tuple[tuple[int, int], ...]) -> None:
+        self._ranges = ranges
+
+    def __contains__(self, line_number: object) -> bool:
+        if type(line_number) is not int:
+            return False
+        return any(start <= line_number <= end for start, end in self._ranges)
+
+    def __bool__(self) -> bool:
+        return bool(self._ranges)
+
+    def __iter__(self):
+        raise AssertionError("line selection should not be expanded")
+
+    def ranges(self) -> tuple[tuple[int, int], ...]:
+        return self._ranges
 
 
 def _remap_ownership_from_content(
@@ -310,6 +333,86 @@ def test_remap_preserves_explicit_replacement_units():
     assert new_ownership.replacement_units == [
         ReplacementUnit(presence_lines=["2"], deletion_indices=[0]),
     ]
+
+
+def test_batch_source_lineage_translates_ranges():
+    """Batch source lineage should translate selections without per-line storage."""
+    with _BatchSourceLineage.from_runs(
+        source_runs=[
+            _LineageRun(old_start=1, old_end=2, new_start=10),
+            _LineageRun(old_start=3, old_end=4, new_start=12),
+            _LineageRun(old_start=8, old_end=9, new_start=20),
+        ],
+        working_runs=[
+            _LineageRun(old_start=20, old_end=21, new_start=30),
+        ],
+    ) as lineage:
+        assert tuple(lineage.source_runs()) == (
+            _LineageRun(old_start=1, old_end=4, new_start=10),
+            _LineageRun(old_start=8, old_end=9, new_start=20),
+        )
+        assert lineage.translate_source_line(3) == 12
+        assert lineage.translate_source_line(7) is None
+        assert lineage.translate_source_selection(
+            LineRanges.from_ranges([(2, 8)])
+        ).ranges() == ((11, 13), (20, 20))
+        assert lineage.translate_working_line(21) == 31
+        assert lineage.translate_working_selection(
+            LineRanges.from_ranges([(20, 21)])
+        ).ranges() == ((30, 31),)
+
+
+def test_batch_source_lineage_finds_unmapped_source_ranges():
+    """Unmapped-source lookup should scan runs without expanding selections."""
+    with _BatchSourceLineage.from_runs(
+        source_runs=[
+            _LineageRun(old_start=1, old_end=20, new_start=100),
+            _LineageRun(old_start=30, old_end=40, new_start=200),
+        ],
+    ) as lineage:
+        assert lineage.first_unmapped_source_line(
+            _IterationGuardedLineSelection(((5, 5), (10, 12)))
+        ) is None
+        assert lineage.first_unmapped_source_line(
+            _IterationGuardedLineSelection(((5, 5), (10, 12), (25, 26)))
+        ) == 25
+
+
+def test_batch_source_lineage_rejects_overlapping_appends():
+    """Lineage appends should require monotonic old-coordinate runs."""
+    with _BatchSourceLineage() as lineage:
+        lineage.append_source_run(
+            _LineageRun(old_start=10, old_end=20, new_start=100)
+        )
+
+        with pytest.raises(ValueError, match="lineage runs must not overlap"):
+            lineage.append_source_run(
+                _LineageRun(old_start=5, old_end=9, new_start=200)
+            )
+
+        with pytest.raises(ValueError, match="lineage runs must not overlap"):
+            lineage.append_source_run(
+                _LineageRun(old_start=20, old_end=25, new_start=300)
+            )
+
+
+def test_batch_source_lineage_closes_mapped_storage():
+    """Batch source lineage should close mapped run storage."""
+    lineage = _BatchSourceLineage.from_runs(
+        source_runs=[
+            _LineageRun(old_start=1, old_end=1000, new_start=1),
+            _LineageRun(old_start=2000, old_end=2000, new_start=5000),
+        ],
+    )
+
+    assert lineage.byte_count > 0
+
+    lineage.close()
+
+    assert lineage.closed is True
+    assert lineage.byte_count == 0
+    with pytest.raises(ValueError, match="batch source lineage is closed"):
+        lineage.translate_source_line(1)
 
 
 def test_merge_coalesces_overlapping_replacement_units_after_deduplication():

--- a/tests/batch/test_stale_source_advancement.py
+++ b/tests/batch/test_stale_source_advancement.py
@@ -10,7 +10,7 @@ from git_stage_batch.batch.ownership import (
     DeletionClaim,
     ReplacementUnit,
     _advance_source_lines_preserving_existing_presence,
-    _remap_batch_ownership_with_source_line_map,
+    _remap_batch_ownership_with_lineage,
     detect_stale_batch_source_for_selection,
     merge_batch_ownership,
     remap_batch_ownership_to_new_source_lines,
@@ -41,6 +41,17 @@ class _IterationGuardedLineSelection:
 
     def ranges(self) -> tuple[tuple[int, int], ...]:
         return self._ranges
+
+
+class _PresenceLineGuardedOwnership(BatchOwnership):
+    """Ownership that returns a guarded presence selection."""
+
+    def __init__(self, selection: _IterationGuardedLineSelection) -> None:
+        super().__init__(presence_claims=[], deletions=[])
+        self._selection = selection
+
+    def presence_line_set(self) -> _IterationGuardedLineSelection:
+        return self._selection
 
 
 def _remap_ownership_from_content(
@@ -415,6 +426,25 @@ def test_batch_source_lineage_closes_mapped_storage():
         lineage.translate_source_line(1)
 
 
+def test_source_lineage_remaps_guarded_presence_ranges():
+    """Source-line remapping should consume presence ranges directly."""
+    ownership = _PresenceLineGuardedOwnership(
+        _IterationGuardedLineSelection(((1, 1000), (2000, 2001)))
+    )
+    with _BatchSourceLineage.from_runs(
+        source_runs=[
+            _LineageRun(old_start=1, old_end=1000, new_start=10),
+            _LineageRun(old_start=2000, old_end=2001, new_start=5000),
+        ],
+    ) as lineage:
+        remapped = _remap_batch_ownership_with_lineage(
+            ownership,
+            lineage,
+        )
+
+    assert remapped.presence_claims[0].source_lines == ["10-1009,5000-5001"]
+
+
 def test_merge_coalesces_overlapping_replacement_units_after_deduplication():
     """Deduplicated deletion claims should keep replacement metadata disjoint."""
     deletion = DeletionClaim(anchor_line=None, content_lines=[b"old value\n"])
@@ -511,9 +541,9 @@ def test_advance_source_preserves_claimed_lines_missing_from_working_tree():
         working_buffer=working_tree,
         ownership=ownership,
     ) as source_with_provenance:
-        remapped = _remap_batch_ownership_with_source_line_map(
+        remapped = _remap_batch_ownership_with_lineage(
             ownership,
-            source_with_provenance.source_line_map,
+            source_with_provenance.lineage,
         )
 
         assert source_with_provenance.source_buffer.to_bytes() == (
@@ -536,14 +566,52 @@ def test_advance_source_tracks_working_line_provenance_for_ambiguous_duplicates(
         assert source_with_provenance.source_buffer.to_bytes() == (
             b"owned before\nowned after\nsame\nsame\n"
         )
-        assert source_with_provenance.source_line_map == {
-            1: 1,
-            4: 2,
-        }
-        assert source_with_provenance.working_line_map == {
-            1: 3,
-            2: 4,
-        }
+        assert tuple(source_with_provenance.lineage.source_runs()) == (
+            _LineageRun(old_start=1, old_end=1, new_start=1),
+            _LineageRun(old_start=4, old_end=4, new_start=2),
+        )
+        assert tuple(source_with_provenance.lineage.working_runs()) == (
+            _LineageRun(old_start=1, old_end=2, new_start=3),
+        )
+
+
+def test_advance_source_tracks_contiguous_lineage_as_runs():
+    """Large contiguous source refreshes should keep one source-line run."""
+    source_lines = b"".join(
+        f"line {index}\n".encode("utf-8")
+        for index in range(1, 1001)
+    )
+    ownership = BatchOwnership.from_presence_lines(["1-1000"], [])
+
+    with _advance_source_from_content(
+        old_source_buffer=source_lines,
+        working_buffer=source_lines,
+        ownership=ownership,
+    ) as source_with_provenance:
+        assert tuple(source_with_provenance.lineage.source_runs()) == (
+            _LineageRun(old_start=1, old_end=1000, new_start=1),
+        )
+        assert tuple(source_with_provenance.lineage.working_runs()) == (
+            _LineageRun(old_start=1, old_end=1000, new_start=1),
+        )
+
+
+def test_advance_source_context_closes_lineage():
+    """Source advancement context should release lineage resources."""
+    ownership = BatchOwnership.from_presence_lines(["1"], [])
+
+    with _advance_source_from_content(
+        old_source_buffer=b"owned\n",
+        working_buffer=b"owned\n",
+        ownership=ownership,
+    ) as source_with_provenance:
+        lineage = source_with_provenance.lineage
+        assert lineage.closed is False
+
+    assert lineage.closed is True
+    with pytest.raises(ValueError, match="batch source lineage is closed"):
+        lineage.translate_source_line(1)
+
 
 def test_advance_source_lines_accepts_non_list_line_sequences(line_sequence):
     """Source construction accepts indexed line sequences."""
@@ -564,11 +632,10 @@ def test_advance_source_lines_accepts_non_list_line_sequences(line_sequence):
         assert source_with_provenance.source_buffer.to_bytes() == (
             b"owned before\nowned after\nsame\nsame\n"
         )
-        assert source_with_provenance.source_line_map == {
-            1: 1,
-            4: 2,
-        }
-        assert source_with_provenance.working_line_map == {
-            1: 3,
-            2: 4,
-        }
+        assert tuple(source_with_provenance.lineage.source_runs()) == (
+            _LineageRun(old_start=1, old_end=1, new_start=1),
+            _LineageRun(old_start=4, old_end=4, new_start=2),
+        )
+        assert tuple(source_with_provenance.lineage.working_runs()) == (
+            _LineageRun(old_start=1, old_end=2, new_start=3),
+        )


### PR DESCRIPTION
git-stage-batch keeps a saved source file for each text file in a batch so
later add and discard operations can update the batch against stable content.
When the working tree changes after that saved source is created, the saved
source may need to be rebuilt before the batch metadata and selected diff
lines can be updated.

On main, that rebuild tracks how old saved-source lines and working-tree lines
land in the rebuilt batch source with `dict[int, int]` maps. Those maps are
filled by walking each rebuilt line, and existing batch metadata is updated by
expanding selected line ranges into individual line numbers. Large contiguous
selections therefore use selected-line-scale Python heap even though the needed
information is one contiguous old-to-new translation.

This pull request adds mapped run storage for those old-to-new line
translations. Each run records `old_start`, `old_end`, and `new_start`, so a
whole contiguous block can be translated as one record. The same value can
answer single-line lookups, translate selected saved-source ranges, translate
selected working-tree ranges, and find the first selected old source line that
has no mapping without building a separate range set.

The rebuild code now scans the run metadata produced while constructing the
rebuilt source and appends saved-source and working-tree translations to mapped
storage. Callers then use range translation to update existing batch metadata
and re-label selected diff lines, and the mapped resources close with the
rebuilt source buffer.

Commit split:
- groundwork: add mapped old-to-new source line tracking
- tests: mapped translation, append ordering, and cleanup
- batch: use mapped line tracking during source rebuild
- tests: guarded selected-line ranges, contiguous rebuilds, and cleanup

Verification:
- `git diff --check origin/main..HEAD`
- `rg -n "LineRunMap|LineMapRun|source_line_map|working_line_map" src tests`
- `rg -n "\\bsource_selection\\(" src tests`
- `PYTHONPATH=src uv run pytest tests/batch/test_stale_source_advancement.py tests/batch/test_source_refresh.py tests/data/test_consumed_selections.py`
- `PYTHONPATH=src uv run pytest -n auto`
