### PR TITLE
Keep sift claimed lines as ranges

### DIFF
--- a/src/git_stage_batch/commands/sift.py
+++ b/src/git_stage_batch/commands/sift.py
@@ -25,7 +25,10 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import Optional
 
-from ..batch.comparison import SemanticChangeKind, derive_semantic_change_runs
+from ..batch.comparison import (
+    SemanticChangeKind,
+    derive_semantic_change_runs,
+)
 from ..batch.merge import merge_batch_from_line_sequences_as_buffer
 from ..exceptions import MergeError
 from ..batch.metadata_validation import read_validated_batch_metadata
@@ -44,7 +47,7 @@ from ..batch.storage import (
     _update_batch_commit,
 )
 from ..batch.validation import batch_exists, validate_batch_name
-from ..core.line_selection import format_line_ids
+from ..core.line_selection import LineRanges
 from ..core.models import BinaryFileChange
 from ..core.text_lifecycle import (
     TextFileChangeType,
@@ -598,12 +601,13 @@ def build_ownership_from_working_and_target_lines(
         target_lines=target_lines,
     )
 
-    claimed_line_numbers = []
+    claimed_ranges: list[tuple[int, int]] = []
     deletion_claims = []
 
     for run in semantic_runs:
         if run.kind == SemanticChangeKind.PRESENCE:
-            claimed_line_numbers.extend(run.target_line_numbers())
+            if run.target_start is not None and run.target_end is not None:
+                claimed_ranges.append((run.target_start, run.target_end))
         elif run.kind == SemanticChangeKind.DELETION:
             if run.source_start is not None and run.source_end is not None:
                 deletion_content = [
@@ -628,19 +632,15 @@ def build_ownership_from_working_and_target_lines(
                         content_lines=deletion_content,
                     )
                 )
-            claimed_line_numbers.extend(run.target_line_numbers())
+            if run.target_start is not None and run.target_end is not None:
+                claimed_ranges.append((run.target_start, run.target_end))
 
-    if not claimed_line_numbers and not deletion_claims:
+    claimed_line_ranges = LineRanges.from_ranges(claimed_ranges)
+    if not claimed_line_ranges and not deletion_claims:
         return None
 
-    presence_lines = (
-        [format_line_ids(sorted(claimed_line_numbers))]
-        if claimed_line_numbers else
-        []
-    )
-
     return BatchOwnership.from_presence_lines(
-        presence_lines,
+        claimed_line_ranges.to_range_strings(),
         deletion_claims,
     )
 

--- a/tests/commands/test_sift.py
+++ b/tests/commands/test_sift.py
@@ -74,6 +74,33 @@ def test_build_sift_ownership_accepts_non_list_line_sequences(line_sequence):
     assert resolved.deletion_claims[0].content_lines == [b"old\n"]
 
 
+def test_build_sift_ownership_consumes_target_ranges(monkeypatch):
+    """Sift ownership derivation should not expand claimed target ranges."""
+
+    class TargetRangeOnlyRun:
+        kind = sift_module.SemanticChangeKind.PRESENCE
+        source_start = None
+        source_end = None
+        target_start = 2
+        target_end = 1001
+        target_anchor = None
+
+        def target_line_numbers(self):
+            raise AssertionError("sift should consume target range endpoints")
+
+    monkeypatch.setattr(
+        sift_module,
+        "derive_semantic_change_runs",
+        lambda source_lines, target_lines: [TargetRangeOnlyRun()],
+    )
+
+    ownership = build_ownership_from_working_and_target_lines([], [])
+
+    assert ownership is not None
+    assert ownership.presence_claims[0].source_lines == ["2-1001"]
+    assert ownership.presence_line_set().ranges() == ((2, 1001),)
+
+
 def test_validate_sifted_result_accepts_non_list_line_sequences(line_sequence):
     """Sift validation accepts indexed byte-line sequences."""
     target_lines = line_sequence([b"line1\n", b"new\n", b"line3\n"])


### PR DESCRIPTION
Sift compares the current working-tree lines with the target content a batch
wants to produce. The comparison result already describes added target lines as
start and end coordinates.

On main, the sift ownership builder expands those target ranges into a Python
list, sorts the list, and formats it before creating presence claims. Large
contiguous additions allocate one Python object per claimed line even though the
same result can be represented by range strings such as `2-1001`.

This pull request collects claimed target endpoint pairs while scanning the
comparison result, builds `LineRanges` once from those pairs, and formats those
ranges directly for presence claims. Presence claims can stay range-only because
the sifted batch source stores the target content, so those coordinates identify
bytes that already exist in the batch. Deletion claims are different: they tell
merge which bytes from the current working tree must be removed, and those bytes
are not stored in the target content. Keeping deletion claim bytes unchanged
avoids mixing this selection-memory change with a later change to deletion
content storage.

Commit split:
- `sift: Keep claimed lines as ranges`
- `tests: Add sift claimed range test`

Verification:
- `git diff --check main..HEAD`
- `rg -n "claimed_line_ranges = claimed_line_ranges\.union|claimed_line_numbers|format_line_ids|target_line_numbers\(\)|_semantic_target_line_ranges|SemanticChangeRun" src/git_stage_batch/commands/sift.py tests/commands/test_sift.py`
- `PYTHONPATH=src uv run pytest tests/commands/test_sift.py tests/batch/test_comparison.py`
- `PYTHONPATH=src uv run pytest -n auto`
