### PR TITLE
Rename deletion claim model to AbsenceClaim

### DIFF
--- a/docs/batches.md
+++ b/docs/batches.md
@@ -27,7 +27,7 @@ When you save content to a batch (via `include --to` or `discard --to`), the too
 
 1. **Batch source commit**: A snapshot of the working tree state at save time
 2. **Ownership claims**: Which specific lines or line ranges are batch-owned
-3. **Deletion claims**: Which sequences were deleted by the batch (if any)
+3. **Absence claims**: Which sequences were deleted by the batch (if any)
 
 This information is stored in:
 - A Git commit under `refs/git-stage-batch/batches/<name>` containing the realized batch content

--- a/src/git_stage_batch/batch/attribution.py
+++ b/src/git_stage_batch/batch/attribution.py
@@ -691,7 +691,7 @@ def _batch_owns_deletion_unit(
     file_metadata: dict,
     alignment,
 ) -> bool:
-    """Check whether a batch owns a deletion unit via explicit deletion claims."""
+    """Check whether a batch owns a deletion unit via explicit absence claims."""
     if unit.deletion_content is None and unit.deletion_fingerprint is None:
         return False
 

--- a/src/git_stage_batch/batch/display.py
+++ b/src/git_stage_batch/batch/display.py
@@ -14,7 +14,7 @@ from .match import match_lines
 
 if TYPE_CHECKING:
     from .match import LineMapping
-    from .ownership import BatchOwnership, DeletionClaim
+    from .ownership import BatchOwnership, AbsenceClaim
 
 
 LineForDisplay = TypeVar("LineForDisplay", bytes, str)
@@ -53,8 +53,8 @@ def _build_display_lines_from_batch_source_lines(
     display_lines = []
     display_id = 1
 
-    # Build map of deletion claim positions
-    deletions_by_position: dict[int | None, list[tuple[int, 'DeletionClaim']]] = {}
+    # Build map of absence claim positions
+    deletions_by_position: dict[int | None, list[tuple[int, 'AbsenceClaim']]] = {}
     for idx, claim in enumerate(ownership.deletions):
         anchor = claim.anchor_line
         if anchor not in deletions_by_position:

--- a/src/git_stage_batch/batch/merge.py
+++ b/src/git_stage_batch/batch/merge.py
@@ -28,7 +28,7 @@ from ..utils.text import (
 )
 
 if TYPE_CHECKING:
-    from .ownership import BatchOwnership, DeletionClaim
+    from .ownership import BatchOwnership, AbsenceClaim
 
 
 class RegionKind(Enum):
@@ -858,7 +858,7 @@ class ClaimedRunIntervalFacts:
 def _check_structural_validity(
     line_mapping: LineMapping,
     claimed_lines: LineSelection,
-    deletions: list,  # list[DeletionClaim]
+    deletions: list,  # list[AbsenceClaim]
     source_lines: Sequence[bytes],
     target_lines: Sequence[bytes]
 ) -> None:
@@ -878,7 +878,7 @@ def _check_structural_validity(
     Args:
         line_mapping: Alignment between batch source and working tree
         claimed_lines: Claimed batch source line numbers
-        deletions: List of DeletionClaim objects
+        deletions: List of AbsenceClaim objects
         source_lines: Batch source file lines (bytes)
         target_lines: Working tree file lines (bytes)
 
@@ -965,7 +965,7 @@ def _check_structural_validity(
 def _check_claimed_region_compatibility(
     line_mapping: LineMapping,
     claimed_lines: LineSelection,
-    deletions: list,  # list[DeletionClaim]
+    deletions: list,  # list[AbsenceClaim]
     source_lines: Sequence[bytes],
     target_lines: Sequence[bytes]
 ) -> None:
@@ -1499,13 +1499,13 @@ def _apply_presence_constraints_with_mapping(
 
 def _apply_absence_constraints(
     entries: Sequence[RealizedEntry],
-    deletion_claims: list['DeletionClaim'],
+    deletion_claims: list['AbsenceClaim'],
     *,
     strict: bool = True
 ) -> _RealizedEntries:
     """Apply absence constraints with boundary enforcement.
 
-    For each deletion claim:
+    For each absence claim:
     1. Find the structural boundary after the anchor line
     2. Suppress forbidden sequence at that boundary using appropriate mode
 
@@ -1603,7 +1603,7 @@ def _satisfy_constraints(
     source_lines: Sequence[bytes],
     working_lines: Sequence[bytes],
     presence_line_set: LineSelection,
-    deletion_claims: list['DeletionClaim'],
+    deletion_claims: list['AbsenceClaim'],
     *,
     strict: bool = True,
     source_to_working_mapping: LineMapping | None = None,
@@ -2123,7 +2123,7 @@ def _line_slice_equals(
 
 def _try_apply_baseline_absence_constraints(
     working_lines: Sequence[bytes],
-    deletion_claims: list['DeletionClaim'],
+    deletion_claims: list['AbsenceClaim'],
 ) -> Iterator[bytes] | None:
     """Apply absence-only constraints by exact baseline coordinates."""
     if not deletion_claims:
@@ -2152,7 +2152,7 @@ def _try_apply_baseline_absence_constraints(
 
 
 def _baseline_removal_edit(
-    claim: 'DeletionClaim',
+    claim: 'AbsenceClaim',
     working_lines: Sequence[bytes],
 ) -> _BaselineLineEdit | None:
     if not claim.content_lines:
@@ -2206,7 +2206,7 @@ def _iter_lines_with_baseline_edits(
 def _has_complete_baseline_references(
     ownership: 'BatchOwnership',
     presence_line_set: LineSelection,
-    deletion_claims: list['DeletionClaim'],
+    deletion_claims: list['AbsenceClaim'],
 ) -> bool:
     claimed_line_references = ownership.presence_baseline_references()
     for claimed_line in presence_line_set:
@@ -2225,7 +2225,7 @@ def _try_apply_baseline_replacement_units(
     working_lines: Sequence[bytes],
     ownership: 'BatchOwnership',
     presence_line_set: LineSelection,
-    deletion_claims: list['DeletionClaim'],
+    deletion_claims: list['AbsenceClaim'],
 ) -> Iterator[bytes] | None:
     """Apply baseline-coordinate edits when structural source anchors fail.
 
@@ -3021,11 +3021,11 @@ def _reverse_presence_constraints(
 
 def _restore_absence_constraints(
     entries: Sequence[RealizedEntry],
-    deletion_claims: list['DeletionClaim']
+    deletion_claims: list['AbsenceClaim']
 ) -> _RealizedEntries:
     """Restore absence constraints: insert deleted sequences at anchored boundaries.
 
-    For each deletion claim, this function:
+    For each absence claim, this function:
     1. Finds the exact boundary "after source line N" (or start-of-file)
     2. Checks if the deleted sequence is already present at that boundary
     3. If absent: inserts it at the exact boundary

--- a/src/git_stage_batch/batch/ownership.py
+++ b/src/git_stage_batch/batch/ownership.py
@@ -91,14 +91,14 @@ class BaselineReference:
 
 
 @dataclass
-class DeletionClaim:
+class AbsenceClaim:
     """A suppression constraint: specific baseline content that must not appear.
 
-    Deletions are constraints, not content to replay. Each deletion claim represents
+    Deletions are constraints, not content to replay. Each absence claim represents
     a contiguous run of lines that must be absent from the materialized result.
 
     Attributes:
-        anchor_line: Batch source line after which this deletion claim is anchored
+        anchor_line: Batch source line after which this absence claim is anchored
                      (None for start-of-file)
         content_lines: Exact baseline line content that must be suppressed,
                        with line endings preserved
@@ -129,7 +129,7 @@ class DeletionClaim:
         data: dict,
         blob_contents: dict[str, bytes] | None = None,
         blob_buffers: dict[str, EditorBuffer] | None = None,
-    ) -> DeletionClaim:
+    ) -> AbsenceClaim:
         """Deserialize from metadata dictionary."""
         anchor_line = data.get("after_source_line")
         blob_sha = data["blob"]
@@ -255,7 +255,7 @@ def _deletion_reference_blob_ids(deletion_metadata: list[dict]) -> list[str]:
 
 @dataclass
 class ReplacementUnit:
-    """Explicit coupling between presence claims and deletion claims.
+    """Explicit coupling between presence claims and absence claims.
 
     The deletion side references indexes in BatchOwnership.deletions so the
     canonical deletion constraint is stored only once in metadata.
@@ -341,14 +341,14 @@ class BatchOwnership:
     - replacement_units: Optional explicit coupling between claims and deletions
     """
     presence_claims: list[PresenceClaim]
-    deletions: list[DeletionClaim]  # Separate deletion constraints
+    deletions: list[AbsenceClaim]  # Separate deletion constraints
     replacement_units: list[ReplacementUnit] = field(default_factory=list)
 
     @classmethod
     def from_presence_lines(
         cls,
         source_lines: list[str],
-        deletions: list[DeletionClaim] | None = None,
+        deletions: list[AbsenceClaim] | None = None,
         *,
         replacement_units: list[ReplacementUnit] | None = None,
         baseline_references: dict[int, BaselineReference] | None = None,
@@ -462,7 +462,7 @@ class BatchOwnership:
                 _parse_line_ranges(legacy_claimed_lines)
             )
         deletions = [
-            DeletionClaim.from_dict(d, blob_contents, deletion_blob_buffers)
+            AbsenceClaim.from_dict(d, blob_contents, deletion_blob_buffers)
             for d in deletion_metadata
         ]
         replacement_units = [
@@ -478,7 +478,7 @@ class BatchOwnership:
     def resolve(self) -> ResolvedBatchOwnership:
         """Resolve into representation for materialization and merge.
 
-        Returns presence lines as a selection and deletion claims as a list
+        Returns presence lines as a selection and absence claims as a list
         (preserving structure).
         """
         return ResolvedBatchOwnership(self.presence_line_set(), self.deletions)
@@ -506,14 +506,14 @@ class _BatchOwnershipBuildContext:
 class ResolvedBatchOwnership:
     """Resolved ownership representation for materialization and merge.
 
-    Preserves the structure of deletion claims as separate constraints.
+    Preserves the structure of absence claims as separate constraints.
 
     Attributes:
         presence_line_set: Batch source line numbers (1-indexed, identity-based)
         deletion_claims: List of suppression constraints (order and structure preserved)
     """
     presence_line_set: LineRanges  # Batch source line numbers (1-indexed)
-    deletion_claims: list[DeletionClaim]  # Separate constraints, not collapsed
+    deletion_claims: list[AbsenceClaim]  # Separate constraints, not collapsed
 
 
 def detach_batch_ownership(ownership: BatchOwnership) -> BatchOwnership:
@@ -527,7 +527,7 @@ def detach_batch_ownership(ownership: BatchOwnership) -> BatchOwnership:
             for claim in ownership.presence_claims
         ],
         deletions=[
-            DeletionClaim(
+            AbsenceClaim(
                 anchor_line=deletion.anchor_line,
                 content_lines=list(deletion.content_lines),
                 baseline_reference=deletion.baseline_reference,
@@ -592,8 +592,8 @@ class _DeletionSignature:
     line_count: int
 
 
-def _deletion_signature(deletion: DeletionClaim) -> _DeletionSignature:
-    """Return a stable signature for a deletion claim."""
+def _deletion_signature(deletion: AbsenceClaim) -> _DeletionSignature:
+    """Return a stable signature for an absence claim."""
     digest = sha256()
     byte_count = 0
     line_count = 0
@@ -660,11 +660,11 @@ def _merge_baseline_references(
 
 
 def _merge_deletion_claim_metadata(
-    existing: DeletionClaim,
-    new: DeletionClaim,
-) -> DeletionClaim:
-    """Merge metadata for deletion claims with the same anchor and content."""
-    return DeletionClaim(
+    existing: AbsenceClaim,
+    new: AbsenceClaim,
+) -> AbsenceClaim:
+    """Merge metadata for absence claims with the same anchor and content."""
+    return AbsenceClaim(
         anchor_line=existing.anchor_line,
         content_lines=existing.content_lines,
         baseline_reference=_merge_baseline_references(
@@ -815,7 +815,7 @@ def merge_batch_ownership(existing: BatchOwnership, new: BatchOwnership) -> Batc
 
     Combines presence claims (union) and merges deletion constraints with deduplication.
 
-    Deletion claims are deduplicated by (anchor_line, content) signature to prevent
+    Absence claims are deduplicated by (anchor_line, content) signature to prevent
     duplicate deletions when batch source advances and ownership is remapped. The same
     deletion can appear in both existing (remapped) and new (from current diff).
 
@@ -835,7 +835,7 @@ def merge_batch_ownership(existing: BatchOwnership, new: BatchOwnership) -> Batc
         **new.presence_baseline_references(),
     }
 
-    # Merge deletion claims: deduplicate by anchor and content
+    # Merge absence claims: deduplicate by anchor and content
     # When batch source advances and ownership is remapped, the same deletion can appear
     # in both existing (remapped) and new (from current diff). We need to deduplicate.
     combined_deletions = []
@@ -926,7 +926,7 @@ def translate_lines_to_batch_ownership(selected_lines: list) -> BatchOwnership:
     """Translate display lines to batch source ownership.
 
     Creates presence claims and suppression constraints (deletion_claims).
-    Each contiguous run of deletions becomes a separate DeletionClaim.
+    Each contiguous run of deletions becomes a separate AbsenceClaim.
 
     This function assumes all selected lines can be expressed in batch source
     space. Call detect_stale_batch_source_for_selection() first and handle stale
@@ -937,7 +937,7 @@ def translate_lines_to_batch_ownership(selected_lines: list) -> BatchOwnership:
         selected_lines: List of LineEntry objects to translate
 
     Returns:
-        BatchOwnership with presence claims and deletion claims
+        BatchOwnership with presence claims and absence claims
 
     Raises:
         ValueError: If any claimed line has source_line=None (stale batch source)
@@ -945,11 +945,11 @@ def translate_lines_to_batch_ownership(selected_lines: list) -> BatchOwnership:
     # Translate to batch source-space ownership
     # Diff shows index→working tree, batch source = working tree
     # Context/addition lines exist in batch source → presence claims
-    # Deletion lines don't exist in batch source → deletion claims (suppression)
+    # Deletion lines don't exist in batch source → absence claims (suppression)
 
     claimed_source_lines = _LineRangeBuilder()
     presence_baseline_references: dict[int, BaselineReference] = {}
-    deletion_claims: list[DeletionClaim] = []
+    deletion_claims: list[AbsenceClaim] = []
     replacement_units: list[ReplacementUnit] = []
 
     # Track current deletion run
@@ -965,13 +965,13 @@ def translate_lines_to_batch_ownership(selected_lines: list) -> BatchOwnership:
             replacement_units.append(builder.finish())
 
     def flush_deletion_run() -> list[int]:
-        """Finalize current deletion run as a DeletionClaim."""
+        """Finalize current deletion run as an AbsenceClaim."""
         nonlocal current_deletion_anchor
         nonlocal current_deletion_baseline_reference
         nonlocal current_deletion_lines
         if current_deletion_lines:
             deletion_claims.append(
-                DeletionClaim(
+                AbsenceClaim(
                     anchor_line=current_deletion_anchor,
                     content_lines=current_deletion_lines[:],
                     baseline_reference=current_deletion_baseline_reference,
@@ -1224,7 +1224,7 @@ def translate_hunk_selection_to_batch_ownership(
     """
     claimed_source_lines = _LineRangeBuilder()
     presence_baseline_references: dict[int, BaselineReference] = {}
-    deletion_claims: list[DeletionClaim] = []
+    deletion_claims: list[AbsenceClaim] = []
     replacement_units: list[ReplacementUnit] = []
     old_line_content = _old_line_content_by_number(hunk_lines)
     consumed_replacement_ids: set[int] = set()
@@ -1273,7 +1273,7 @@ def translate_hunk_selection_to_batch_ownership(
                 )
 
         deletion_claims.append(
-            DeletionClaim(
+            AbsenceClaim(
                 anchor_line=deletion_anchor,
                 content_lines=deletion_content,
                 baseline_reference=_baseline_reference_for_old_line_range(
@@ -1389,7 +1389,7 @@ def translate_hunk_selection_to_batch_ownership(
             return []
 
         deletion_claims.append(
-            DeletionClaim(
+            AbsenceClaim(
                 anchor_line=current_deletion_anchor,
                 content_lines=current_deletion_lines[:],
                 baseline_reference=_baseline_reference_for_deletion_run(
@@ -1489,23 +1489,23 @@ class OwnershipUnitKind(Enum):
     """Pure claimed lines with no coupled deletions (non-atomic)."""
 
     REPLACEMENT = "replacement"
-    """Claimed lines coupled with deletion claims (atomic)."""
+    """Claimed lines coupled with absence claims (atomic)."""
 
     DELETION_ONLY = "deletion_only"
-    """Pure deletion claims with no claimed lines (atomic)."""
+    """Pure absence claims with no claimed lines (atomic)."""
 
 
 @dataclass
 class OwnershipUnit:
     """Semantic unit of ownership that should be manipulated atomically.
 
-    Represents the coupling between claimed lines and deletion claims.
+    Represents the coupling between claimed lines and absence claims.
     Used for semantic filtering operations like line-level reset.
 
     Attributes:
         kind: Type of ownership unit
         claimed_source_lines: Set of batch source line numbers owned by this unit
-        deletion_claims: Deletion claims that are part of this unit
+        deletion_claims: Absence claims that are part of this unit
         display_line_ids: Display line IDs that map to this unit (from reconstructed display)
         is_atomic: If True, partial removal is not allowed
         atomic_reason: Explanation for why unit is atomic (for debugging/errors)
@@ -1513,7 +1513,7 @@ class OwnershipUnit:
     """
     kind: OwnershipUnitKind
     claimed_source_lines: set[int]
-    deletion_claims: list[DeletionClaim]
+    deletion_claims: list[AbsenceClaim]
     display_line_ids: set[int]
     is_atomic: bool = False
     atomic_reason: str | None = None
@@ -1822,7 +1822,7 @@ def _build_replacement_unit(
     """Build a REPLACEMENT unit from adjacent deletion and claimed runs.
 
     Args:
-        ownership: BatchOwnership containing deletion claims
+        ownership: BatchOwnership containing absence claims
         deletion_run: Dict from _collect_display_run for deletions
         claimed_run: Dict from _collect_display_run for claimed lines
 
@@ -1851,7 +1851,7 @@ def _build_deletion_only_unit(
     """Build a DELETION_ONLY unit from a deletion run with no adjacent claimed lines.
 
     Args:
-        ownership: BatchOwnership containing deletion claims
+        ownership: BatchOwnership containing absence claims
         deletion_run: Dict from _collect_display_run for deletions
 
     Returns:
@@ -1876,8 +1876,8 @@ def validate_ownership_units(units: list[OwnershipUnit]) -> None:
     """Validate structural invariants of ownership units.
 
     Ensures:
-    - No orphaned deletion claims
-    - No duplicate ownership of deletion claims
+    - No orphaned absence claims
+    - No duplicate ownership of absence claims
     - Atomic units have valid structure
 
     Args:
@@ -1886,7 +1886,7 @@ def validate_ownership_units(units: list[OwnershipUnit]) -> None:
     Raises:
         MergeError: If units have invalid structure
     """
-    # Track deletion claim usage to ensure no orphans or duplicates
+    # Track absence claim usage to ensure no orphans or duplicates
     deletion_claim_usage = {}
 
     for unit in units:
@@ -2122,7 +2122,7 @@ def _remap_batch_ownership_with_mapping(
     for deletion in ownership.deletions:
         if deletion.anchor_line is None:
             # Start-of-file anchor remains None
-            new_deletions.append(DeletionClaim(
+            new_deletions.append(AbsenceClaim(
                 anchor_line=None,
                 content_lines=deletion.content_lines,
                 baseline_reference=deletion.baseline_reference,
@@ -2137,7 +2137,7 @@ def _remap_batch_ownership_with_mapping(
                     f"to new source: no unique mapping found. This indicates the anchor line "
                     f"was removed or significantly changed in the new source."
                 )
-            new_deletions.append(DeletionClaim(
+            new_deletions.append(AbsenceClaim(
                 anchor_line=new_anchor,
                 content_lines=deletion.content_lines,
                 baseline_reference=deletion.baseline_reference,
@@ -2231,7 +2231,7 @@ def _remap_batch_ownership_with_lineage(
     new_deletions = []
     for deletion in ownership.deletions:
         if deletion.anchor_line is None:
-            new_deletions.append(DeletionClaim(
+            new_deletions.append(AbsenceClaim(
                 anchor_line=None,
                 content_lines=deletion.content_lines,
                 baseline_reference=deletion.baseline_reference,
@@ -2244,7 +2244,7 @@ def _remap_batch_ownership_with_lineage(
                 f"Cannot remap deletion anchor line {deletion.anchor_line} from old source "
                 f"to new source: no preserved source lineage found."
             )
-        new_deletions.append(DeletionClaim(
+        new_deletions.append(AbsenceClaim(
             anchor_line=new_anchor,
             content_lines=deletion.content_lines,
             baseline_reference=deletion.baseline_reference,

--- a/src/git_stage_batch/batch/replacement.py
+++ b/src/git_stage_batch/batch/replacement.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 
 from ..core.line_selection import format_line_ids
 from ..editor import EditorBuffer
-from .ownership import BatchOwnership, DeletionClaim, ReplacementUnit
+from .ownership import BatchOwnership, AbsenceClaim, ReplacementUnit
 
 
 @dataclass(slots=True)
@@ -72,7 +72,7 @@ def build_replacement_batch_view_from_lines(
             else:
                 new_anchor = None
 
-            new_deletions.append(DeletionClaim(
+            new_deletions.append(AbsenceClaim(
                 anchor_line=new_anchor,
                 content_lines=deletion.content_lines,
             ))
@@ -124,7 +124,7 @@ def build_replacement_batch_view_from_lines(
         else:
             new_anchor = deletion.anchor_line + added_count
 
-        new_deletions.append(DeletionClaim(
+        new_deletions.append(AbsenceClaim(
             anchor_line=new_anchor,
             content_lines=deletion.content_lines,
         ))

--- a/src/git_stage_batch/batch/storage.py
+++ b/src/git_stage_batch/batch/storage.py
@@ -52,7 +52,7 @@ from ..utils.text import normalize_line_sequence_endings
 from .merge import _realized_entry_content_chunks, _satisfy_constraints
 
 if TYPE_CHECKING:
-    from .ownership import BatchOwnership, DeletionClaim
+    from .ownership import BatchOwnership, AbsenceClaim
 
 
 @dataclass(frozen=True)
@@ -518,12 +518,12 @@ def _suppress_sequence_at_position_bytes(
 
 def _enforce_deletion_constraint(
     lines: list[bytes],
-    claim: 'DeletionClaim'
+    claim: 'AbsenceClaim'
 ) -> list[bytes]:
     """Remove sequences matching a deletion constraint.
 
     Scans the line list and removes any occurrence of the exact sequence
-    specified by the deletion claim.
+    specified by the absence claim.
 
     Args:
         lines: Current content as list of lines (bytes with newlines)

--- a/src/git_stage_batch/commands/reset.py
+++ b/src/git_stage_batch/commands/reset.py
@@ -433,7 +433,7 @@ def _reset_line_claims_from_batch(batch_name: str, line_id_specification: str) -
     """Remove specific line claims from a batch using semantic ownership filtering.
 
     This implementation uses semantic ownership units to ensure that coupled
-    claimed lines and deletion claims are removed together, preventing orphaned
+    claimed lines and absence claims are removed together, preventing orphaned
     absence constraints.
 
     Args:

--- a/src/git_stage_batch/commands/sift.py
+++ b/src/git_stage_batch/commands/sift.py
@@ -33,7 +33,7 @@ from ..batch.merge import merge_batch_from_line_sequences_as_buffer
 from ..exceptions import MergeError
 from ..batch.metadata_validation import read_validated_batch_metadata
 from ..batch.operations import create_batch, delete_batch
-from ..batch.ownership import BatchOwnership, DeletionClaim
+from ..batch.ownership import BatchOwnership, AbsenceClaim
 from ..batch.query import get_batch_baseline_commit, read_batch_metadata
 from ..batch.state_refs import (
     delete_batch_state_refs,
@@ -615,7 +615,7 @@ def build_ownership_from_working_and_target_lines(
                     for index in run.source_line_numbers()
                 ]
                 deletion_claims.append(
-                    DeletionClaim(
+                    AbsenceClaim(
                         anchor_line=run.target_anchor,
                         content_lines=deletion_content,
                     )
@@ -627,7 +627,7 @@ def build_ownership_from_working_and_target_lines(
                     for index in run.source_line_numbers()
                 ]
                 deletion_claims.append(
-                    DeletionClaim(
+                    AbsenceClaim(
                         anchor_line=run.target_anchor,
                         content_lines=deletion_content,
                     )
@@ -668,7 +668,7 @@ def validate_sifted_text_file_result_from_lines(
                     f"is out of bounds (target content has {len(target_lines)} lines)"
                 )
         if not deletion_claim.content_lines:
-            raise MergeError("Sift validation failed: deletion claim has empty content")
+            raise MergeError("Sift validation failed: absence claim has empty content")
 
     try:
         reconstructed_buffer = merge_batch_from_line_sequences_as_buffer(

--- a/src/git_stage_batch/exceptions.py
+++ b/src/git_stage_batch/exceptions.py
@@ -35,7 +35,7 @@ class MergeError(Exception):
 class MissingAnchorError(MergeError):
     """Raised when an anchor line is not present in realized content.
 
-    This is a recoverable condition during discard: the deletion claim
+    This is a recoverable condition during discard: the absence claim
     is simply not applicable to the current state.
     """
     pass

--- a/tests/batch/test_batch_display.py
+++ b/tests/batch/test_batch_display.py
@@ -11,7 +11,7 @@ from git_stage_batch.batch.display import (
     annotate_with_batch_source_working_lines,
     build_display_lines_from_batch_source_lines,
 )
-from git_stage_batch.batch.ownership import BatchOwnership, DeletionClaim
+from git_stage_batch.batch.ownership import BatchOwnership, AbsenceClaim
 from git_stage_batch.core.models import HunkHeader, LineEntry, LineLevelChange
 from git_stage_batch.editor import EditorBuffer
 
@@ -66,7 +66,7 @@ class _RangeBackedDisplayOwnership:
     def __init__(
         self,
         selection: _IterationGuardedLineSelection,
-        deletions: Iterable[DeletionClaim] = (),
+        deletions: Iterable[AbsenceClaim] = (),
     ) -> None:
         self._selection = selection
         self.deletions = list(deletions)
@@ -85,7 +85,7 @@ def test_display_builder_accepts_non_list_byte_line_sequences(line_sequence):
     ownership = BatchOwnership.from_presence_lines(
         ["1,3"],
         [
-            DeletionClaim(
+            AbsenceClaim(
                 anchor_line=1,
                 content_lines=[b"deleted\n"],
             ),
@@ -145,7 +145,7 @@ def test_display_builder_uses_ranges_without_expanding_claims():
     ownership = _RangeBackedDisplayOwnership(
         _IterationGuardedLineSelection(((50, 52),)),
         [
-            DeletionClaim(
+            AbsenceClaim(
                 anchor_line=60,
                 content_lines=[b"deleted\n"],
             ),

--- a/tests/batch/test_constraint_semantics.py
+++ b/tests/batch/test_constraint_semantics.py
@@ -5,7 +5,7 @@ described in BATCHES.md.
 """
 
 
-from git_stage_batch.batch.ownership import BatchOwnership, DeletionClaim
+from git_stage_batch.batch.ownership import BatchOwnership, AbsenceClaim
 from git_stage_batch.batch.merge import merge_batch_from_line_sequences_as_buffer
 from git_stage_batch.batch.storage import _build_realized_buffer_from_lines
 from git_stage_batch.editor import EditorBuffer
@@ -46,11 +46,11 @@ def _build_realized_content_from_bytes(
         return realized.to_bytes()
 
 
-class TestDeletionClaimIdentity:
-    """Test that deletion claims are structurally anchored and independent."""
+class TestAbsenceClaimIdentity:
+    """Test that absence claims are structurally anchored and independent."""
 
     def test_two_deletion_claims_same_anchor_different_content(self):
-        """Two deletion claims at same anchor but different content are distinct.
+        """Two absence claims at same anchor but different content are distinct.
 
         This tests that anchors are part of identity, not just hints.
         Different content at the same anchor represents different constraints.
@@ -63,9 +63,9 @@ class TestDeletionClaimIdentity:
         # Batch B: removes "old_impl()"
         # These are DIFFERENT constraints even though anchor is the same
 
-        ownership_a = BatchOwnership.from_presence_lines(["1"], [DeletionClaim(anchor_line=1, content_lines=[b"debug_log()\n"])])
+        ownership_a = BatchOwnership.from_presence_lines(["1"], [AbsenceClaim(anchor_line=1, content_lines=[b"debug_log()\n"])])
 
-        ownership_b = BatchOwnership.from_presence_lines(["1"], [DeletionClaim(anchor_line=1, content_lines=[b"old_impl()\n"])])
+        ownership_b = BatchOwnership.from_presence_lines(["1"], [AbsenceClaim(anchor_line=1, content_lines=[b"old_impl()\n"])])
 
         # Applying batch A should preserve "old_impl()" even though anchor matches.
         result_a = merge_batch(batch_source, ownership_a, working)
@@ -78,14 +78,14 @@ class TestDeletionClaimIdentity:
     def test_same_deletion_content_different_anchors(self):
         """Same deletion content at different anchors are distinct constraints.
 
-        This tests that deletion claims are position-aware, not global.
+        This tests that absence claims are position-aware, not global.
         The same bytes at different structural positions are different claims.
         """
         batch_source = b"line1\nmarker\nline3\nmarker\nline5\n"
         working = b"line1\nmarker\nline3\nmarker\nline5\n"
 
         # Claim that suppresses only the first marker after line 1.
-        ownership = BatchOwnership.from_presence_lines(["1", "3", "5"], [DeletionClaim(anchor_line=1, content_lines=[b"marker\n"])])
+        ownership = BatchOwnership.from_presence_lines(["1", "3", "5"], [AbsenceClaim(anchor_line=1, content_lines=[b"marker\n"])])
 
         result = merge_batch(batch_source, ownership, working)
         lines = result.splitlines(keepends=True)
@@ -100,7 +100,7 @@ class TestDeletionClaimIdentity:
         assert marker_count == 1, "expected exactly one marker remaining"
 
     def test_deletion_claims_not_collapsed(self):
-        """Multiple deletion claims must remain structurally distinct.
+        """Multiple absence claims must remain structurally distinct.
 
         Tests that contiguous deletion runs are kept distinct rather than collapsed into
         a single claim, even if they could share an anchor.
@@ -109,7 +109,7 @@ class TestDeletionClaimIdentity:
         ownership = BatchOwnership.from_presence_lines(
             ["1", "2", "3"],
             [
-                DeletionClaim(anchor_line=1, content_lines=[b"old1\n", b"old2\n"]),
+                AbsenceClaim(anchor_line=1, content_lines=[b"old1\n", b"old2\n"]),
                 # Kept separate from the first claim even though it shares an anchor.
             ]
         )
@@ -125,7 +125,7 @@ class TestRepeatedLinesNotGloballyRemoved:
     def test_repeated_identical_lines_only_anchored_removed(self):
         """Repeated lines: only suppress at anchored position, not globally.
 
-        Deletion claims must not act as global content filters.
+        Absence claims must not act as global content filters.
         """
         batch_source = b"header\ncommon\nfooter\n"
         working = b"header\ncommon\nsection1\ncommon\nsection2\ncommon\nfooter\n"
@@ -133,7 +133,7 @@ class TestRepeatedLinesNotGloballyRemoved:
         # Suppress "common" after "header" (first occurrence only)
         ownership = BatchOwnership.from_presence_lines(
             ["1", "3"],
-            [DeletionClaim(anchor_line=1, content_lines=[b"common\n"])]
+            [AbsenceClaim(anchor_line=1, content_lines=[b"common\n"])]
         )
 
         result = merge_batch(batch_source, ownership, working)
@@ -156,7 +156,7 @@ class TestIdempotence:
         batch_source = b"line1\nline2-modified\nline3\n"
         working = b"line1\nline2\nline3\n"
 
-        ownership = BatchOwnership.from_presence_lines(["2"], [DeletionClaim(anchor_line=1, content_lines=[b"line2\n"])])
+        ownership = BatchOwnership.from_presence_lines(["2"], [AbsenceClaim(anchor_line=1, content_lines=[b"line2\n"])])
 
         # First application
         result1 = merge_batch(batch_source, ownership, working)
@@ -171,7 +171,7 @@ class TestIdempotence:
         batch_source = b"line1\nline2-modified\nline3\n"
         working = b"line1\nline2\nextra\nline3\n"
 
-        ownership = BatchOwnership.from_presence_lines(["2"], [DeletionClaim(anchor_line=1, content_lines=[b"line2\n"])])
+        ownership = BatchOwnership.from_presence_lines(["2"], [AbsenceClaim(anchor_line=1, content_lines=[b"line2\n"])])
 
         result1 = merge_batch(batch_source, ownership, working)
         result2 = merge_batch(batch_source, ownership, result1)
@@ -186,7 +186,7 @@ class TestPureRemovalBatches:
     """Test deletion-only ownership (no claimed presence lines)."""
 
     def test_deletion_only_ownership(self):
-        """Batch with only deletion claims, no presence claims.
+        """Batch with only absence claims, no presence claims.
 
         This tests that pure removals are representable.
         """
@@ -194,7 +194,7 @@ class TestPureRemovalBatches:
         working = b"line1\nline2\ndebug_log()\nline3\n"
 
         # Pure removal: just suppress debug_log, don't claim anything else
-        ownership = BatchOwnership.from_presence_lines([], [DeletionClaim(anchor_line=2, content_lines=[b"debug_log()\n"])])
+        ownership = BatchOwnership.from_presence_lines([], [AbsenceClaim(anchor_line=2, content_lines=[b"debug_log()\n"])])
 
         result = merge_batch(batch_source, ownership, working)
 
@@ -214,7 +214,7 @@ class TestBytesBasedSemantics:
         working = b"line1\n\xe9cole\nextra\nline3\n"
 
         # Claim école (line 2) and suppress "extra" (working tree insertion after école)
-        ownership = BatchOwnership.from_presence_lines(["2"], [DeletionClaim(anchor_line=2, content_lines=[b"extra\n"])])
+        ownership = BatchOwnership.from_presence_lines(["2"], [AbsenceClaim(anchor_line=2, content_lines=[b"extra\n"])])
 
         result = merge_batch(
             batch_source,
@@ -232,7 +232,7 @@ class TestBytesBasedSemantics:
         batch_source = b"line1\r\nline2-modified\r\nline3\r\n"
         working = b"line1\r\nline2\r\nline3\r\n"
 
-        ownership = BatchOwnership.from_presence_lines(["2"], [DeletionClaim(anchor_line=1, content_lines=[b"line2\r\n"])])
+        ownership = BatchOwnership.from_presence_lines(["2"], [AbsenceClaim(anchor_line=1, content_lines=[b"line2\r\n"])])
 
         result = merge_batch(batch_source, ownership, working)
 
@@ -248,7 +248,7 @@ class TestRealizedContentConstruction:
         baseline_content = b"line1\nline2\nline3\n"
         batch_source_content = b"line1\nline2-modified\nline3\n"
 
-        ownership = BatchOwnership.from_presence_lines(["2"], [DeletionClaim(anchor_line=1, content_lines=[b"line2\n"])])
+        ownership = BatchOwnership.from_presence_lines(["2"], [AbsenceClaim(anchor_line=1, content_lines=[b"line2\n"])])
 
         realized = _build_realized_content_from_bytes(
             baseline_content,
@@ -271,7 +271,7 @@ class TestRealizedContentConstruction:
         baseline_content = b"header\nold value\nfooter\n"
         batch_source_content = b"header\nnew value\nfooter\n"
 
-        ownership = BatchOwnership.from_presence_lines([], [DeletionClaim(anchor_line=2, content_lines=[b"old value\n"])],
+        ownership = BatchOwnership.from_presence_lines([], [AbsenceClaim(anchor_line=2, content_lines=[b"old value\n"])],
         )
 
         realized = _build_realized_content_from_bytes(
@@ -290,8 +290,8 @@ class TestRealizedContentConstruction:
         ownership = BatchOwnership.from_presence_lines(
             [],
             [
-                DeletionClaim(anchor_line=1, content_lines=[b"line2\n"]),
-                DeletionClaim(anchor_line=2, content_lines=[b"line3\n"]),
+                AbsenceClaim(anchor_line=1, content_lines=[b"line2\n"]),
+                AbsenceClaim(anchor_line=2, content_lines=[b"line3\n"]),
             ],
         )
 

--- a/tests/batch/test_merge.py
+++ b/tests/batch/test_merge.py
@@ -25,7 +25,7 @@ from git_stage_batch.exceptions import MergeError
 from git_stage_batch.batch.ownership import (
     BaselineReference,
     BatchOwnership,
-    DeletionClaim,
+    AbsenceClaim,
     ReplacementUnit,
 )
 from git_stage_batch.utils.text import normalize_line_sequence_endings
@@ -978,8 +978,8 @@ class TestMergeBatch:
         source = b"line1\nline2\nline3\n"
         working = b"unwanted\nline1\nline2\nline3\n"
 
-        # Create deletion claim to suppress "unwanted"
-        deletions = [DeletionClaim(anchor_line=None, content_lines=[b"unwanted\n"])]
+        # Create absence claim to suppress "unwanted"
+        deletions = [AbsenceClaim(anchor_line=None, content_lines=[b"unwanted\n"])]
 
         result = merge_batch(source, BatchOwnership([], deletions), working)
 
@@ -991,7 +991,7 @@ class TestMergeBatch:
         source = b"line1\nline2\nline3\n"
         working = b"unwanted\nline1\nline2\nline3\n"
         deletions = [
-            DeletionClaim(
+            AbsenceClaim(
                 anchor_line=None,
                 content_lines=line_sequence([b"unwanted\n"]),
             ),
@@ -1008,7 +1008,7 @@ class TestMergeBatch:
         ownership = BatchOwnership.from_presence_lines(
             [],
             [
-                DeletionClaim(
+                AbsenceClaim(
                     anchor_line=2,
                     content_lines=[b"old value\n"],
                     baseline_reference=BaselineReference(after_line=1),
@@ -1025,7 +1025,7 @@ class TestMergeBatch:
         ownership = BatchOwnership.from_presence_lines(
             [],
             [
-                DeletionClaim(
+                AbsenceClaim(
                     anchor_line=1,
                     content_lines=[b"old value\n"],
                     baseline_reference=BaselineReference(after_line=1),
@@ -1043,7 +1043,7 @@ class TestMergeBatch:
         ownership = BatchOwnership.from_presence_lines(
             ["1"],
             [
-                DeletionClaim(
+                AbsenceClaim(
                     anchor_line=None,
                     content_lines=[b"same\n"],
                     baseline_reference=BaselineReference(
@@ -1081,7 +1081,7 @@ class TestMergeBatch:
         ownership = BatchOwnership.from_presence_lines(
             ["1"],
             [
-                DeletionClaim(
+                AbsenceClaim(
                     anchor_line=5,
                     content_lines=[b"a\n"],
                     baseline_reference=BaselineReference(
@@ -1114,7 +1114,7 @@ class TestMergeBatch:
         ownership = BatchOwnership.from_presence_lines(
             [],
             [
-                DeletionClaim(
+                AbsenceClaim(
                     anchor_line=2,
                     content_lines=[b"old value\n"],
                     baseline_reference=BaselineReference(after_line=1),
@@ -1130,8 +1130,8 @@ class TestMergeBatch:
         source = b"line1\nline2\nline3\n"
         working = b"line1\nline2\nunwanted\nline3\n"
 
-        # Create deletion claim to suppress "unwanted" after line 2
-        deletions = [DeletionClaim(anchor_line=2, content_lines=[b"unwanted\n"])]
+        # Create absence claim to suppress "unwanted" after line 2
+        deletions = [AbsenceClaim(anchor_line=2, content_lines=[b"unwanted\n"])]
 
         result = merge_batch(source, BatchOwnership([], deletions), working)
 
@@ -1143,8 +1143,8 @@ class TestMergeBatch:
         source = b"line1\nline2\nline3\n"
         working = b"line1\nline2\ndifferent\nline3\n"
 
-        # Create deletion claim for content that doesn't exist
-        deletions = [DeletionClaim(anchor_line=2, content_lines=[b"nonexistent\n"])]
+        # Create absence claim for content that doesn't exist
+        deletions = [AbsenceClaim(anchor_line=2, content_lines=[b"nonexistent\n"])]
 
         result = merge_batch(source, BatchOwnership([], deletions), working)
 
@@ -1160,8 +1160,8 @@ class TestMergeBatch:
         source = b"line1\nline2\nline3\n"
         working = b"duplicate\nline1\nduplicate\nline2\nline3\n"
 
-        # Create deletion claim anchored at start-of-file
-        deletions = [DeletionClaim(anchor_line=None, content_lines=[b"duplicate\n"])]
+        # Create absence claim anchored at start-of-file
+        deletions = [AbsenceClaim(anchor_line=None, content_lines=[b"duplicate\n"])]
 
         result = merge_batch(source, BatchOwnership([], deletions), working)
 
@@ -1178,8 +1178,8 @@ class TestMergeBatch:
         source = b"line1\nline2\nline3\n"
         working = b"line1\nblock_start\nblock_end\nline2\nline3\n"
 
-        # Create deletion claim for multi-line sequence
-        deletions = [DeletionClaim(anchor_line=1, content_lines=[b"block_start\n", b"block_end\n"])]
+        # Create absence claim for multi-line sequence
+        deletions = [AbsenceClaim(anchor_line=1, content_lines=[b"block_start\n", b"block_end\n"])]
 
         result = merge_batch(source, BatchOwnership([], deletions), working)
 
@@ -1325,8 +1325,8 @@ class TestMergeBatch:
         working = b"unwanted1\nline1\nline2\nunwanted2\nline3\n"
 
         deletions = [
-            DeletionClaim(anchor_line=None, content_lines=[b"unwanted1\n"]),
-            DeletionClaim(anchor_line=2, content_lines=[b"unwanted2\n"])
+            AbsenceClaim(anchor_line=None, content_lines=[b"unwanted1\n"]),
+            AbsenceClaim(anchor_line=2, content_lines=[b"unwanted2\n"])
         ]
 
         result = merge_batch(source, BatchOwnership([], deletions), working)
@@ -1341,8 +1341,8 @@ class TestMergeBatch:
 
         # Two deletion constraints for same content (e.g., from incremental batching)
         deletions = [
-            DeletionClaim(anchor_line=None, content_lines=[b"unwanted\n"]),
-            DeletionClaim(anchor_line=2, content_lines=[b"unwanted\n"])
+            AbsenceClaim(anchor_line=None, content_lines=[b"unwanted\n"]),
+            AbsenceClaim(anchor_line=2, content_lines=[b"unwanted\n"])
         ]
 
         result = merge_batch(source, BatchOwnership([], deletions), working)
@@ -1399,7 +1399,7 @@ class TestMergeErrors:
         source = b"line1\nline2\nline3\n"
         working = b"line1\nline2\nline3\n"
 
-        deletions = [DeletionClaim(anchor_line=100, content_lines=[b"unwanted\n"])]
+        deletions = [AbsenceClaim(anchor_line=100, content_lines=[b"unwanted\n"])]
 
         with pytest.raises(MergeError, match="out of range"):
             merge_batch(source, BatchOwnership([], deletions), working)
@@ -1520,7 +1520,7 @@ class TestMergeErrors:
 
         # But the batch also includes a DELETION that depends on context from lines 7-12
         # Specifically, it wants to delete line 6 with anchor near line 7
-        deletions = [DeletionClaim(anchor_line=7, content_lines=[b"line6\n"])]
+        deletions = [AbsenceClaim(anchor_line=7, content_lines=[b"line6\n"])]
 
         # Trying to merge should detect that:
         # 1. The deletion anchor (line 7 in source_later) doesn't exist in working_early
@@ -1587,7 +1587,7 @@ parser_include = subparsers.add_parser(
         # Batch wants to:
         # 1. Delete line 4 (old set_defaults) with anchor after line 3
         # 2. Add lines 5-6 (--porcelain arg + new set_defaults)
-        deletions = [DeletionClaim(
+        deletions = [AbsenceClaim(
             anchor_line=3,
             content_lines=[b"parser_status.set_defaults(func=lambda _: commands.command_status())\n"]
         )]
@@ -1669,7 +1669,7 @@ line3_c
         claimed = ["7"]  # line2_b_MODIFIED in source
         deletions = [
             # Try to delete from Section A (anchor at line 2)
-            DeletionClaim(anchor_line=2, content_lines=[b"line1_a\n"])
+            AbsenceClaim(anchor_line=2, content_lines=[b"line1_a\n"])
         ]
 
         # This should fail because Section A doesn't exist in working tree

--- a/tests/batch/test_merge_corruption.py
+++ b/tests/batch/test_merge_corruption.py
@@ -5,7 +5,7 @@ from git_stage_batch.exceptions import MergeError
 import pytest
 
 from git_stage_batch.batch.merge import merge_batch_from_line_sequences_as_buffer
-from git_stage_batch.batch.ownership import BatchOwnership, DeletionClaim
+from git_stage_batch.batch.ownership import BatchOwnership, AbsenceClaim
 from git_stage_batch.editor import EditorBuffer
 
 
@@ -87,7 +87,7 @@ def test_merge_corruption_simplified():
 
     # Deletion: after line 6 (closing paren), delete old set_defaults
     # The old set_defaults is at line 7 in working tree
-    deletions = [DeletionClaim(
+    deletions = [AbsenceClaim(
         anchor_line=6,
         content_lines=[b"    parser_status.set_defaults(func=lambda _: status())\n"]
     )]

--- a/tests/batch/test_merge_duplication.py
+++ b/tests/batch/test_merge_duplication.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 
-from git_stage_batch.batch.ownership import DeletionClaim
+from git_stage_batch.batch.ownership import AbsenceClaim
 
 from git_stage_batch.batch.ownership import BatchOwnership
 from git_stage_batch.batch.merge import merge_batch_from_line_sequences_as_buffer
@@ -103,7 +103,7 @@ def test_merge_batch_with_deletion_suppresses_content():
 
     Scenario:
     - Batch source: A\nB\n
-    - Deletions: [DeletionClaim(anchor_line=1, content="UNWANTED")]
+    - Deletions: [AbsenceClaim(anchor_line=1, content="UNWANTED")]
       (meaning: suppress "UNWANTED" content - it's a constraint, not insertion)
     - Working tree: A\nUNWANTED\nB\n (has unwanted content)
     - Result should have the unwanted content removed
@@ -112,7 +112,7 @@ def test_merge_batch_with_deletion_suppresses_content():
     batch_source_content = b"A\nB\n"
 
     # Create a deletion constraint (suppression)
-    ownership = BatchOwnership.from_presence_lines([], [DeletionClaim(anchor_line=1, content_lines=[b"UNWANTED\n"])])
+    ownership = BatchOwnership.from_presence_lines([], [AbsenceClaim(anchor_line=1, content_lines=[b"UNWANTED\n"])])
 
     working_content = b"A\nUNWANTED\nB\n"
 

--- a/tests/batch/test_merge_validation.py
+++ b/tests/batch/test_merge_validation.py
@@ -15,7 +15,7 @@ from git_stage_batch.batch.merge import (
     _find_boundary_after_source_line,
     RealizedEntry,
 )
-from git_stage_batch.batch.ownership import BatchOwnership, DeletionClaim
+from git_stage_batch.batch.ownership import BatchOwnership, AbsenceClaim
 from git_stage_batch.editor import EditorBuffer
 from git_stage_batch.exceptions import MergeError, MissingAnchorError, AmbiguousAnchorError
 
@@ -82,7 +82,7 @@ def test_sequence_present_normalizes_both_sides():
 
 
 def test_discard_missing_anchor_skipped_gracefully():
-    """Discard should skip deletion claims when anchor is missing (not raise)."""
+    """Discard should skip absence claims when anchor is missing (not raise)."""
     batch_source = b"""line 1
 line 2
 line 3
@@ -100,13 +100,13 @@ different line 3
     # But line 2 doesn't exist in working tree (all lines different)
     ownership = BatchOwnership.from_presence_lines(
         ["2"],
-        [DeletionClaim(
+        [AbsenceClaim(
             anchor_line=2,
             content_lines=[b"old content\n"]
         )]
     )
 
-    # Should complete without error (skips deletion claim gracefully)
+    # Should complete without error (skips absence claim gracefully)
     # because anchor line 2 is not present in working tree
     result = discard_batch(batch_source, ownership, working, baseline)
 
@@ -331,7 +331,7 @@ A test project.
 
     ownership = BatchOwnership.from_presence_lines(
         ["3-4"],
-        [DeletionClaim(
+        [AbsenceClaim(
             anchor_line=2,
             content_lines=[b"A test project.\n"]
         )],
@@ -349,7 +349,7 @@ A test project for git-stage-batch.
 def test_crlf_normalization_in_discard_restoration():
     """Discard should handle CRLF in deletion content correctly.
 
-    When deletion claim content uses CRLF but the sequence check uses LF,
+    When absence claim content uses CRLF but the sequence check uses LF,
     the normalization should allow correct matching without duplication.
     """
     # Batch source with LF
@@ -364,7 +364,7 @@ def test_crlf_normalization_in_discard_restoration():
     # Claim line 2 (batch added it), deletion after line 1 with CRLF
     ownership = BatchOwnership.from_presence_lines(
         ["2"],
-        [DeletionClaim(
+        [AbsenceClaim(
             anchor_line=1,
             content_lines=[b"old content\r\n"]  # CRLF in deletion content
         )]

--- a/tests/batch/test_ownership_incremental.py
+++ b/tests/batch/test_ownership_incremental.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from git_stage_batch.batch.ownership import (
-    DeletionClaim,
+    AbsenceClaim,
     ReplacementLineRun,
     ReplacementUnit,
     derive_replacement_line_runs_from_lines,
@@ -30,7 +30,7 @@ def test_translate_lines_creates_deletion_constraints():
 
     # Should create deletion constraint for - line (suppression constraint)
     assert len(ownership.deletions) == 1
-    assert isinstance(ownership.deletions[0], DeletionClaim)
+    assert isinstance(ownership.deletions[0], AbsenceClaim)
     assert ownership.deletions[0].content_lines == [b'old_version\n']
     assert len(ownership.replacement_units) == 1
     assert ownership.replacement_units[0].presence_lines == ["1"]
@@ -170,7 +170,7 @@ def test_translate_lines_preserves_deletion_structure():
 
     ownership = translate_lines_to_batch_ownership(lines)
 
-    # Should have two separate deletion claims (not collapsed)
+    # Should have two separate absence claims (not collapsed)
     assert len(ownership.deletions) == 2
     assert ownership.deletions[0].content_lines == [b'del1\n', b'del2\n']
     assert ownership.deletions[0].anchor_line is None  # before any source line

--- a/tests/batch/test_ownership_unit_grouping.py
+++ b/tests/batch/test_ownership_unit_grouping.py
@@ -12,7 +12,7 @@ from git_stage_batch.batch.display import (
 )
 from git_stage_batch.batch.ownership import (
     BatchOwnership,
-    DeletionClaim,
+    AbsenceClaim,
     OwnershipUnit,
     OwnershipUnitKind,
     ReplacementUnit,
@@ -141,7 +141,7 @@ def test_deletion_followed_by_claimed_becomes_replacement():
     ownership = BatchOwnership.from_presence_lines(
         ["1"],
         [
-            DeletionClaim(anchor_line=None, content_lines=[b"old line 1\n", b"old line 2\n"])
+            AbsenceClaim(anchor_line=None, content_lines=[b"old line 1\n", b"old line 2\n"])
         ]
     )
 
@@ -166,7 +166,7 @@ def test_build_ownership_units_accepts_batch_source_line_sequence(line_sequence)
     ownership = BatchOwnership.from_presence_lines(
         ["1"],
         [
-            DeletionClaim(anchor_line=None, content_lines=[b"old line 1\n"])
+            AbsenceClaim(anchor_line=None, content_lines=[b"old line 1\n"])
         ],
     )
 
@@ -219,7 +219,7 @@ def test_claimed_followed_by_deletion_becomes_replacement():
     ownership = BatchOwnership.from_presence_lines(
         ["1"],
         [
-            DeletionClaim(anchor_line=1, content_lines=[b"old line 2\n"])
+            AbsenceClaim(anchor_line=1, content_lines=[b"old line 2\n"])
         ]
     )
 
@@ -252,7 +252,7 @@ def test_deletion_without_adjacent_claimed_is_deletion_only():
     ownership = BatchOwnership.from_presence_lines(
         [],
         [
-            DeletionClaim(anchor_line=1, content_lines=[b"old line 2\n"])
+            AbsenceClaim(anchor_line=1, content_lines=[b"old line 2\n"])
         ]
     )
 
@@ -355,8 +355,8 @@ def test_nearby_in_source_separated_in_display_not_coupled():
     ownership = BatchOwnership.from_presence_lines(
         ["2"],
         [
-            DeletionClaim(anchor_line=None, content_lines=[b"old line 1\n"]),
-            DeletionClaim(anchor_line=3, content_lines=[b"old line 4\n"])
+            AbsenceClaim(anchor_line=None, content_lines=[b"old line 1\n"]),
+            AbsenceClaim(anchor_line=3, content_lines=[b"old line 4\n"])
         ]
     )
 
@@ -459,7 +459,7 @@ def test_multiple_consecutive_deletions_and_claims_form_single_replacement():
     ownership = BatchOwnership.from_presence_lines(
         ["1-2"],
         [
-            DeletionClaim(anchor_line=None, content_lines=[b"old line 1\n", b"old line 2\n"])
+            AbsenceClaim(anchor_line=None, content_lines=[b"old line 1\n", b"old line 2\n"])
         ]
     )
 
@@ -492,7 +492,7 @@ def test_rebuild_does_not_promote_display_adjacency_to_explicit_metadata():
     ownership = BatchOwnership.from_presence_lines(
         ["1"],
         [
-            DeletionClaim(anchor_line=None, content_lines=[b"old line\n"])
+            AbsenceClaim(anchor_line=None, content_lines=[b"old line\n"])
         ],
     )
 
@@ -511,7 +511,7 @@ def test_explicit_replacement_unit_overrides_display_adjacency():
     ownership = BatchOwnership.from_presence_lines(
         ["1"],
         [
-            DeletionClaim(anchor_line=3, content_lines=[b"old later\n"]),
+            AbsenceClaim(anchor_line=3, content_lines=[b"old later\n"]),
         ],
         replacement_units=[
             ReplacementUnit(presence_lines=["1"], deletion_indices=[0]),
@@ -534,7 +534,7 @@ def test_explicit_replacement_unit_can_group_multiple_claimed_lines():
     ownership = BatchOwnership.from_presence_lines(
         ["1-2"],
         [
-            DeletionClaim(anchor_line=None, content_lines=[b"old one\n", b"old two\n"]),
+            AbsenceClaim(anchor_line=None, content_lines=[b"old one\n", b"old two\n"]),
         ],
         replacement_units=[
             ReplacementUnit(presence_lines=["1-2"], deletion_indices=[0]),
@@ -555,7 +555,7 @@ def test_rebuild_preserves_explicit_replacement_units():
     ownership = BatchOwnership.from_presence_lines(
         ["1-2"],
         [
-            DeletionClaim(anchor_line=None, content_lines=[b"old one\n", b"old two\n"]),
+            AbsenceClaim(anchor_line=None, content_lines=[b"old one\n", b"old two\n"]),
         ],
         replacement_units=[
             ReplacementUnit(presence_lines=["1-2"], deletion_indices=[0]),
@@ -576,11 +576,11 @@ def test_rebuild_preserves_explicit_replacement_units():
 def test_rebuild_preserves_mixed_same_anchor_deletion_order():
     """Same-anchor explicit and inferred deletions should keep stable indexes."""
     batch_source = b"new explicit\nnew inferred\nkeep\n"
-    explicit_deletion = DeletionClaim(
+    explicit_deletion = AbsenceClaim(
         anchor_line=None,
         content_lines=[b"old explicit\n"],
     )
-    inferred_deletion = DeletionClaim(
+    inferred_deletion = AbsenceClaim(
         anchor_line=None,
         content_lines=[b"old inferred\n"],
     )
@@ -608,11 +608,11 @@ def test_rebuild_preserves_mixed_same_anchor_deletion_order():
 def test_rebuild_preserves_mixed_same_anchor_order_when_explicit_is_later():
     """Later explicit replacements should not reorder earlier inferred deletions."""
     batch_source = b"new explicit\nkeep\n"
-    inferred_deletion = DeletionClaim(
+    inferred_deletion = AbsenceClaim(
         anchor_line=None,
         content_lines=[b"old inferred\n"],
     )
-    explicit_deletion = DeletionClaim(
+    explicit_deletion = AbsenceClaim(
         anchor_line=None,
         content_lines=[b"old explicit\n"],
     )

--- a/tests/batch/test_replacement.py
+++ b/tests/batch/test_replacement.py
@@ -1,6 +1,6 @@
 """Tests for replacement batch-source helpers."""
 
-from git_stage_batch.batch.ownership import BatchOwnership, DeletionClaim
+from git_stage_batch.batch.ownership import BatchOwnership, AbsenceClaim
 from git_stage_batch.batch.replacement import (
     ReplacementBatchView,
     build_replacement_batch_view_from_lines,
@@ -30,7 +30,7 @@ def test_build_replacement_batch_view_returns_named_result(line_sequence):
     ownership = BatchOwnership(
         [],
         [
-            DeletionClaim(
+            AbsenceClaim(
                 anchor_line=1,
                 content_lines=[b"old\n"],
             )

--- a/tests/batch/test_stale_source_advancement.py
+++ b/tests/batch/test_stale_source_advancement.py
@@ -7,7 +7,7 @@ import pytest
 from git_stage_batch.batch.ownership import (
     BaselineReference,
     BatchOwnership,
-    DeletionClaim,
+    AbsenceClaim,
     ReplacementUnit,
     _advance_source_lines_preserving_existing_presence,
     _remap_batch_ownership_with_lineage,
@@ -187,7 +187,7 @@ def test_remap_claimed_lines_accepts_non_list_line_sequences(line_sequence):
 
 
 def test_remap_deletion_anchors_to_new_source():
-    """Test remapping of deletion claim anchors from old source to new source."""
+    """Test remapping of absence claim anchors from old source to new source."""
     old_source = b"line one\nline two\nline three\n"
     new_source = b"new first line\nline one\nline two\nline three\n"
 
@@ -195,7 +195,7 @@ def test_remap_deletion_anchors_to_new_source():
     old_ownership = BatchOwnership.from_presence_lines(
         [],
         [
-            DeletionClaim(anchor_line=2, content_lines=[b"deleted line\n"])
+            AbsenceClaim(anchor_line=2, content_lines=[b"deleted line\n"])
         ]
     )
 
@@ -220,7 +220,7 @@ def test_remap_start_of_file_deletion_anchor():
     old_ownership = BatchOwnership.from_presence_lines(
         [],
         [
-            DeletionClaim(anchor_line=None, content_lines=[b"deleted at start\n"])
+            AbsenceClaim(anchor_line=None, content_lines=[b"deleted at start\n"])
         ]
     )
 
@@ -262,7 +262,7 @@ def test_remap_fails_when_anchor_removed_in_new_source():
     old_ownership = BatchOwnership.from_presence_lines(
         [],
         [
-            DeletionClaim(anchor_line=2, content_lines=[b"deleted\n"])
+            AbsenceClaim(anchor_line=2, content_lines=[b"deleted\n"])
         ]
     )
 
@@ -304,7 +304,7 @@ def test_remap_preserves_deletion_content():
     old_ownership = BatchOwnership.from_presence_lines(
         [],
         [
-            DeletionClaim(anchor_line=1, content_lines=deletion_content)
+            AbsenceClaim(anchor_line=1, content_lines=deletion_content)
         ]
     )
 
@@ -326,7 +326,7 @@ def test_remap_preserves_explicit_replacement_units():
     old_ownership = BatchOwnership.from_presence_lines(
         ["1"],
         [
-            DeletionClaim(anchor_line=2, content_lines=[b"old value\n"]),
+            AbsenceClaim(anchor_line=2, content_lines=[b"old value\n"]),
         ],
         replacement_units=[
             ReplacementUnit(presence_lines=["1"], deletion_indices=[0]),
@@ -446,8 +446,8 @@ def test_source_lineage_remaps_guarded_presence_ranges():
 
 
 def test_merge_coalesces_overlapping_replacement_units_after_deduplication():
-    """Deduplicated deletion claims should keep replacement metadata disjoint."""
-    deletion = DeletionClaim(anchor_line=None, content_lines=[b"old value\n"])
+    """Deduplicated absence claims should keep replacement metadata disjoint."""
+    deletion = AbsenceClaim(anchor_line=None, content_lines=[b"old value\n"])
     existing = BatchOwnership.from_presence_lines(
         ["1"],
         [deletion],
@@ -458,7 +458,7 @@ def test_merge_coalesces_overlapping_replacement_units_after_deduplication():
     new = BatchOwnership.from_presence_lines(
         ["2"],
         [
-            DeletionClaim(anchor_line=None, content_lines=[b"old value\n"]),
+            AbsenceClaim(anchor_line=None, content_lines=[b"old value\n"]),
         ],
         replacement_units=[
             ReplacementUnit(presence_lines=["2"], deletion_indices=[0]),
@@ -478,7 +478,7 @@ def test_merge_deduplicated_deletions_keeps_stronger_baseline_reference():
     """Deduplicated deletions should keep baseline metadata from new claims."""
     existing = BatchOwnership.from_presence_lines(
         [],
-        [DeletionClaim(anchor_line=1, content_lines=[b"old value\n"])],
+        [AbsenceClaim(anchor_line=1, content_lines=[b"old value\n"])],
     )
     reference = BaselineReference(
         after_line=1,
@@ -490,7 +490,7 @@ def test_merge_deduplicated_deletions_keeps_stronger_baseline_reference():
     new = BatchOwnership.from_presence_lines(
         [],
         [
-            DeletionClaim(
+            AbsenceClaim(
                 anchor_line=1,
                 content_lines=[b"old value\n"],
                 baseline_reference=reference,
@@ -501,7 +501,7 @@ def test_merge_deduplicated_deletions_keeps_stronger_baseline_reference():
     merged = merge_batch_ownership(existing, new)
 
     assert merged.deletions == [
-        DeletionClaim(
+        AbsenceClaim(
             anchor_line=1,
             content_lines=[b"old value\n"],
             baseline_reference=reference,
@@ -514,8 +514,8 @@ def test_merge_ignores_boolean_replacement_unit_deletion_indices():
     new = BatchOwnership.from_presence_lines(
         ["1"],
         [
-            DeletionClaim(anchor_line=None, content_lines=[b"old one\n"]),
-            DeletionClaim(anchor_line=None, content_lines=[b"old two\n"]),
+            AbsenceClaim(anchor_line=None, content_lines=[b"old one\n"]),
+            AbsenceClaim(anchor_line=None, content_lines=[b"old two\n"]),
         ],
         replacement_units=[
             ReplacementUnit(presence_lines=["1"], deletion_indices=[True]),

--- a/tests/batch/test_storage.py
+++ b/tests/batch/test_storage.py
@@ -13,7 +13,7 @@ from git_stage_batch.batch.storage import add_file_to_batch, read_file_from_batc
 from git_stage_batch.batch.ownership import (
     BaselineReference,
     BatchOwnership,
-    DeletionClaim,
+    AbsenceClaim,
     ReplacementUnit,
     detach_batch_ownership,
 )
@@ -95,7 +95,7 @@ def test_add_file_to_batch_persists_replacement_units(temp_git_repo):
     ownership = BatchOwnership.from_presence_lines(
         ["1"],
         [
-            DeletionClaim(anchor_line=None, content_lines=[b"old\n"]),
+            AbsenceClaim(anchor_line=None, content_lines=[b"old\n"]),
         ],
         replacement_units=[
             ReplacementUnit(presence_lines=["1"], deletion_indices=[0]),
@@ -119,11 +119,11 @@ def test_deletion_claim_metadata_accepts_non_list_content_lines(
     temp_git_repo,
     line_sequence,
 ):
-    """Deletion claim metadata only requires indexed content lines."""
+    """Absence claim metadata only requires indexed content lines."""
     ownership = BatchOwnership.from_presence_lines(
         [],
         [
-            DeletionClaim(
+            AbsenceClaim(
                 anchor_line=None,
                 content_lines=line_sequence([b"old one\n", b"old two\n"]),
             ),
@@ -142,7 +142,7 @@ def test_batch_ownership_metadata_acquisition_scopes_deletion_buffers(temp_git_r
     ownership = BatchOwnership.from_presence_lines(
         [],
         [
-            DeletionClaim(
+            AbsenceClaim(
                 anchor_line=None,
                 content_lines=[b"old one\n", b"old two\n"],
             ),
@@ -165,7 +165,7 @@ def test_detach_batch_ownership_keeps_acquired_deletion_content(temp_git_repo):
     ownership = BatchOwnership.from_presence_lines(
         ["1"],
         [
-            DeletionClaim(
+            AbsenceClaim(
                 anchor_line=None,
                 content_lines=[b"old one\n", b"old two\n"],
             ),
@@ -253,7 +253,7 @@ def test_add_file_to_batch_persists_baseline_references(temp_git_repo):
     ownership = BatchOwnership.from_presence_lines(
         ["2"],
         [
-            DeletionClaim(
+            AbsenceClaim(
                 anchor_line=1,
                 content_lines=[b"old line\n"],
                 baseline_reference=deletion_reference,
@@ -295,8 +295,8 @@ def test_boolean_replacement_unit_indices_are_omitted_from_metadata(temp_git_rep
     ownership = BatchOwnership.from_presence_lines(
         ["1"],
         [
-            DeletionClaim(anchor_line=None, content_lines=[b"old one\n"]),
-            DeletionClaim(anchor_line=None, content_lines=[b"old two\n"]),
+            AbsenceClaim(anchor_line=None, content_lines=[b"old one\n"]),
+            AbsenceClaim(anchor_line=None, content_lines=[b"old two\n"]),
         ],
         replacement_units=[
             ReplacementUnit(presence_lines=["1"], deletion_indices=[True]),
@@ -343,7 +343,7 @@ def test_add_file_to_batch_marks_whole_deleted_text_file(temp_git_repo):
     gone_file.unlink()
     ownership = BatchOwnership.from_presence_lines(
         [],
-        [DeletionClaim(anchor_line=None, content_lines=[b"gone\n"])],
+        [AbsenceClaim(anchor_line=None, content_lines=[b"gone\n"])],
     )
     add_file_to_batch("test-batch", "gone.txt", ownership)
 

--- a/tests/commands/test_apply_from.py
+++ b/tests/commands/test_apply_from.py
@@ -6,7 +6,7 @@ from git_stage_batch.commands.start import command_start
 from git_stage_batch.commands.include import command_include_to_batch
 from git_stage_batch.batch.ownership import BatchOwnership
 from git_stage_batch.batch.storage import add_file_to_batch
-from git_stage_batch.batch.ownership import DeletionClaim
+from git_stage_batch.batch.ownership import AbsenceClaim
 
 import subprocess
 
@@ -272,7 +272,7 @@ class TestCommandApplyFromBatch:
         subprocess.run(["git", "add", "file.txt"], check=True, cwd=temp_git_repo, capture_output=True)
         subprocess.run(["git", "commit", "-m", "New state for batch"], check=True, cwd=temp_git_repo, capture_output=True)
 
-        ownership = BatchOwnership.from_presence_lines(["1"], [DeletionClaim(anchor_line=None, content_lines=[b"old line\n"])])
+        ownership = BatchOwnership.from_presence_lines(["1"], [AbsenceClaim(anchor_line=None, content_lines=[b"old line\n"])])
         add_file_to_batch("replacement-batch", "file.txt", ownership, "100644")
 
         # Reset working tree to old state
@@ -307,7 +307,7 @@ class TestCommandApplyFromBatch:
         subprocess.run(["git", "add", "file.txt"], check=True, cwd=temp_git_repo, capture_output=True)
         subprocess.run(["git", "commit", "-m", "New state"], check=True, cwd=temp_git_repo, capture_output=True)
 
-        ownership = BatchOwnership.from_presence_lines(["1"], [DeletionClaim(anchor_line=None, content_lines=[b"old line\n"])])
+        ownership = BatchOwnership.from_presence_lines(["1"], [AbsenceClaim(anchor_line=None, content_lines=[b"old line\n"])])
         add_file_to_batch("atomic-batch", "file.txt", ownership, "100644")
 
         # Reset to old state

--- a/tests/commands/test_file_review.py
+++ b/tests/commands/test_file_review.py
@@ -8,7 +8,7 @@ import subprocess
 import pytest
 
 from git_stage_batch.batch import create_batch
-from git_stage_batch.batch.ownership import BatchOwnership, DeletionClaim, ReplacementUnit
+from git_stage_batch.batch.ownership import BatchOwnership, AbsenceClaim, ReplacementUnit
 from git_stage_batch.batch.query import read_batch_metadata
 from git_stage_batch.batch.storage import add_file_to_batch
 from git_stage_batch.commands.apply_from import command_apply_from_batch
@@ -2240,7 +2240,7 @@ def test_batch_review_does_not_suggest_partial_non_adjacent_atomic_replacement(
         BatchOwnership.from_presence_lines(
             ["1"],
             [
-                DeletionClaim(anchor_line=3, content_lines=[b"old later\n"]),
+                AbsenceClaim(anchor_line=3, content_lines=[b"old later\n"]),
             ],
             replacement_units=[
                 ReplacementUnit(presence_lines=["1"], deletion_indices=[0]),

--- a/tests/commands/test_reset.py
+++ b/tests/commands/test_reset.py
@@ -7,7 +7,7 @@ import pytest
 import git_stage_batch.commands.reset as reset_module
 import git_stage_batch.commands.show_from as show_from_module
 import git_stage_batch.data.hunk_tracking as hunk_tracking_module
-from git_stage_batch.batch.ownership import BatchOwnership, DeletionClaim
+from git_stage_batch.batch.ownership import BatchOwnership, AbsenceClaim
 from git_stage_batch.batch.query import read_batch_metadata
 from git_stage_batch.batch.storage import add_file_to_batch, read_file_from_batch
 from git_stage_batch.commands.again import command_again
@@ -369,7 +369,7 @@ class TestResetFromBatch:
             BatchOwnership.from_presence_lines(
                 ["1", "2"],
                 [
-                    DeletionClaim(
+                    AbsenceClaim(
                         anchor_line=5,
                         content_lines=[b"removed\n"],
                     ),
@@ -681,7 +681,7 @@ class TestResetFromBatch:
             BatchOwnership.from_presence_lines(
                 ["1", "2"],
                 [
-                    DeletionClaim(
+                    AbsenceClaim(
                         anchor_line=None,
                         content_lines=[b"line 1\n"],
                     ),
@@ -765,7 +765,7 @@ class TestResetFromBatch:
             BatchOwnership.from_presence_lines(
                 ["1"],
                 [
-                    DeletionClaim(
+                    AbsenceClaim(
                         anchor_line=None,
                         content_lines=[b"line 1\n"],
                     ),
@@ -850,7 +850,7 @@ class TestResetFromBatch:
 
         # Manually create ownership with replacement: claim line 1, delete original line 1
         # The deletion is anchored at line 0 (start of file) to be spatially close to line 1
-        ownership = BatchOwnership.from_presence_lines(["1"], [DeletionClaim(anchor_line=None, content_lines=[b"line 1\n"])])
+        ownership = BatchOwnership.from_presence_lines(["1"], [AbsenceClaim(anchor_line=None, content_lines=[b"line 1\n"])])
         add_file_to_batch("mybatch", "test.py", ownership, "100644")
 
         # Verify initial ownership has both claimed line and deletion
@@ -889,7 +889,7 @@ class TestResetFromBatch:
         fetch_next_change()
 
         # Create replacement: deletion + claimed line
-        ownership = BatchOwnership.from_presence_lines(["1"], [DeletionClaim(anchor_line=None, content_lines=[b"line 1\n"])])
+        ownership = BatchOwnership.from_presence_lines(["1"], [AbsenceClaim(anchor_line=None, content_lines=[b"line 1\n"])])
         add_file_to_batch("mybatch", "test.py", ownership, "100644")
 
         # Attempting to select only display ID 1 (deletion) should error
@@ -913,7 +913,7 @@ class TestResetFromBatch:
         command_new_batch("mybatch", "test batch")
         command_start()
         fetch_next_change()
-        ownership = BatchOwnership.from_presence_lines(["1"], [DeletionClaim(anchor_line=None, content_lines=[b"line 1\n"])])
+        ownership = BatchOwnership.from_presence_lines(["1"], [AbsenceClaim(anchor_line=None, content_lines=[b"line 1\n"])])
         add_file_to_batch("mybatch", "test.py", ownership, "100644")
 
         command_show_from_batch("mybatch", file="test.py", page="all")
@@ -925,7 +925,7 @@ class TestResetFromBatch:
         assert "Use: --line 1-2" in exc_info.value.message
 
     def test_reset_presence_only_keeps_unrelated_deletions(self, temp_git_repo):
-        """Test that resetting presence-only lines preserves unrelated deletion claims."""
+        """Test that resetting presence-only lines preserves unrelated absence claims."""
 
         # Create a file with enough lines to test distant anchoring
         test_file = temp_git_repo / "test.py"
@@ -946,7 +946,7 @@ class TestResetFromBatch:
         # - deletion anchored after line 6
         # Display order: claimed1, claimed3, claimed5, deletion-at-6
         # This keeps claimed3 separate from the deletion.
-        ownership = BatchOwnership.from_presence_lines(["1", "3", "5"], [DeletionClaim(anchor_line=6, content_lines=[b"debug_log()\n"])])
+        ownership = BatchOwnership.from_presence_lines(["1", "3", "5"], [AbsenceClaim(anchor_line=6, content_lines=[b"debug_log()\n"])])
         add_file_to_batch("mybatch", "test.py", ownership, "100644")
 
         # Display structure (display adjacency grouping):
@@ -989,7 +989,7 @@ class TestResetFromBatch:
         # Create ownership with:
         # - Replacement unit: deletion + claimed line 1
         # - Presence-only: claimed line 2
-        ownership = BatchOwnership.from_presence_lines(["1", "2"], [DeletionClaim(anchor_line=None, content_lines=[b"line 1\n"])])
+        ownership = BatchOwnership.from_presence_lines(["1", "2"], [AbsenceClaim(anchor_line=None, content_lines=[b"line 1\n"])])
         add_file_to_batch("mybatch", "test.py", ownership, "100644")
 
         # Display structure:

--- a/tests/commands/test_show_from.py
+++ b/tests/commands/test_show_from.py
@@ -5,7 +5,7 @@ from git_stage_batch.commands.include import command_include_to_batch
 from git_stage_batch.commands.show import command_show
 from git_stage_batch.batch.ownership import BatchOwnership
 from git_stage_batch.batch.storage import add_file_to_batch
-from git_stage_batch.batch.ownership import DeletionClaim
+from git_stage_batch.batch.ownership import AbsenceClaim
 from git_stage_batch.data.hunk_tracking import render_batch_file_display
 import git_stage_batch.batch.merge as merge_module
 import git_stage_batch.batch.display as display_module
@@ -223,7 +223,7 @@ class TestCommandShowFromBatch:
         ownership = BatchOwnership.from_presence_lines(
             ["1"],
             [
-                DeletionClaim(anchor_line=None, content_lines=[b"old one\n", b"old two\n"])
+                AbsenceClaim(anchor_line=None, content_lines=[b"old one\n", b"old two\n"])
             ],
         )
         add_file_to_batch("replacement-batch", "file.txt", ownership, "100644")
@@ -262,7 +262,7 @@ class TestCommandShowFromBatch:
         ownership = BatchOwnership.from_presence_lines(
             ["1"],
             [
-                DeletionClaim(anchor_line=None, content_lines=[b"old one\n", b"old two\n"])
+                AbsenceClaim(anchor_line=None, content_lines=[b"old one\n", b"old two\n"])
             ],
         )
         add_file_to_batch("display-lines-batch", "file.txt", ownership, "100644")
@@ -295,7 +295,7 @@ class TestCommandShowFromBatch:
             BatchOwnership.from_presence_lines(
                 ["1"],
                 [
-                    DeletionClaim(
+                    AbsenceClaim(
                         anchor_line=None,
                         content_lines=[b"old one\n", b"old two\n"],
                     )

--- a/tests/commands/test_sift.py
+++ b/tests/commands/test_sift.py
@@ -6,7 +6,7 @@ import subprocess
 import pytest
 
 from git_stage_batch.batch.validation import batch_exists
-from git_stage_batch.batch.ownership import BatchOwnership, DeletionClaim
+from git_stage_batch.batch.ownership import BatchOwnership, AbsenceClaim
 from git_stage_batch.batch.state_refs import get_batch_content_ref_name
 from git_stage_batch.commands.new import command_new_batch
 from git_stage_batch.commands.start import command_start
@@ -108,7 +108,7 @@ def test_validate_sifted_result_accepts_non_list_line_sequences(line_sequence):
     ownership = BatchOwnership.from_presence_lines(
         ["2"],
         [
-            DeletionClaim(
+            AbsenceClaim(
                 anchor_line=1,
                 content_lines=[b"old\n"],
             ),
@@ -489,12 +489,12 @@ class TestSiftValidationStrength:
     """
 
     def test_claimed_lines_in_bounds_but_deletions_wrong(self, temp_git_repo):
-        """Test that validation catches wrong deletion claims.
+        """Test that validation catches wrong absence claims.
 
         This test verifies that the semantic validation (level C) catches cases
-        where deletion claims are structurally valid but semantically incorrect.
+        where absence claims are structurally valid but semantically incorrect.
 
-        We create a scenario where sift would derive ownership with deletion claims,
+        We create a scenario where sift would derive ownership with absence claims,
         then verify the validation works by checking a normal sift operation succeeds.
         (A more sophisticated test would inject corrupted ownership, but that requires
         mocking or bypassing the derivation logic.)

--- a/tests/functional/test_stale_batch_source_advancement.py
+++ b/tests/functional/test_stale_batch_source_advancement.py
@@ -213,7 +213,7 @@ def test_first_discard_with_stale_source_succeeds(functional_repo):
 
 
 def test_deletion_anchors_remapped_correctly(functional_repo):
-    """Test that deletion claim anchors are correctly remapped when source advances."""
+    """Test that absence claim anchors are correctly remapped when source advances."""
     test_file = functional_repo / "test.py"
     test_file.write_text("line 1\nline 2\nline 3\nline 4\n")
 


### PR DESCRIPTION
Batch ownership records two kinds of constraints: source lines that must be
present after a batch is applied, and removed baseline content that must stay
absent. The latter is stored in existing batch metadata under the `deletions`
key because older batches already use that file format.

On main, the Python model for the absence constraint is still named
`DeletionClaim`. That name describes the diff row that created the record, not
the durable rule used during merge, discard, and batch application.

This pull request renames the Python dataclass and source imports to
`AbsenceClaim`, updates nearby comments, messages, and tests to use the new
name, and updates the batch docs wording. It intentionally leaves stored batch
metadata unchanged: `deletions`, `after_source_line`, `blob`,
`baseline_reference`, and replacement-unit `deletion_indices` keep their current
names.

Commit split:
- `batch: Rename stored deletion constraint type`
- `tests: Use renamed absence claim type`
- `docs: Rename batch absence claim wording`

Verification:
- `rg -n "DeletionClaim|deletion claim|deletion claims|Deletion claim|Deletion claims|a AbsenceClaim" src tests docs README*`
- `git diff --check main..HEAD`
- `PYTHONPATH=src uv run pytest tests/batch/test_storage.py tests/batch/test_merge.py tests/batch/test_ownership_incremental.py tests/batch/test_ownership_unit_grouping.py tests/batch/test_constraint_semantics.py tests/commands/test_sift.py tests/commands/test_reset.py`
- `PYTHONPATH=src uv run pytest -n auto`
