### PR TITLE
Store absence content with editor ranges

### DIFF
--- a/src/git_stage_batch/batch/ownership.py
+++ b/src/git_stage_batch/batch/ownership.py
@@ -407,7 +407,7 @@ class BatchOwnership:
     def acquire_for_metadata_dict(
         cls,
         data: dict,
-    ) -> _BatchOwnershipBuildContext:
+    ) -> _AcquiredBatchOwnership:
         """Acquire ownership for metadata with buffered deletion blobs."""
         deletion_metadata = data.get("deletions", [])
         presence_metadata = data.get("presence_claims", [])
@@ -437,7 +437,7 @@ class BatchOwnership:
                 buffer.close()
             raise
 
-        return _BatchOwnershipBuildContext(
+        return _AcquiredBatchOwnership(
             ownership=ownership,
             buffers=buffers,
         )
@@ -485,7 +485,7 @@ class BatchOwnership:
 
 
 @dataclass
-class _BatchOwnershipBuildContext:
+class _AcquiredBatchOwnership:
     """Own buffers borrowed by a scoped BatchOwnership value."""
 
     ownership: BatchOwnership

--- a/src/git_stage_batch/batch/ownership.py
+++ b/src/git_stage_batch/batch/ownership.py
@@ -15,6 +15,7 @@ from ..core.line_selection import (
 from ..core.models import LineEntry
 from ..data.batch_sources import create_batch_source_commit
 from ..editor import (
+    Editor,
     EditorBuffer,
     buffer_byte_chunks,
     load_git_blob_as_buffer,
@@ -486,7 +487,7 @@ class BatchOwnership:
 
 @dataclass
 class _AcquiredBatchOwnership:
-    """Own buffers borrowed by a scoped BatchOwnership value."""
+    """Own buffers used by a scoped BatchOwnership value."""
 
     ownership: BatchOwnership
     buffers: list[EditorBuffer]
@@ -516,31 +517,47 @@ class ResolvedBatchOwnership:
     deletion_claims: list[AbsenceClaim]  # Separate constraints, not collapsed
 
 
-def detach_batch_ownership(ownership: BatchOwnership) -> BatchOwnership:
-    """Return ownership whose deletion content no longer borrows buffers."""
-    return BatchOwnership(
-        presence_claims=[
-            PresenceClaim(
-                source_lines=claim.source_lines[:],
-                baseline_references=dict(claim.baseline_references),
+def acquire_detached_batch_ownership(
+    ownership: BatchOwnership,
+) -> _AcquiredBatchOwnership:
+    """Acquire an ownership copy with independent absence content buffers."""
+    buffers: list[EditorBuffer] = []
+    deletions: list[AbsenceClaim] = []
+    try:
+        for deletion in ownership.deletions:
+            content_lines = _copy_absence_content(deletion.content_lines)
+            buffers.append(content_lines)
+            deletions.append(
+                AbsenceClaim(
+                    anchor_line=deletion.anchor_line,
+                    content_lines=content_lines,
+                    baseline_reference=deletion.baseline_reference,
+                )
             )
-            for claim in ownership.presence_claims
-        ],
-        deletions=[
-            AbsenceClaim(
-                anchor_line=deletion.anchor_line,
-                content_lines=list(deletion.content_lines),
-                baseline_reference=deletion.baseline_reference,
-            )
-            for deletion in ownership.deletions
-        ],
-        replacement_units=[
-            ReplacementUnit(
-                presence_lines=unit.presence_lines[:],
-                deletion_indices=unit.deletion_indices[:],
-            )
-            for unit in ownership.replacement_units
-        ],
+    except Exception:
+        for buffer in buffers:
+            buffer.close()
+        raise
+
+    return _AcquiredBatchOwnership(
+        ownership=BatchOwnership(
+            presence_claims=[
+                PresenceClaim(
+                    source_lines=claim.source_lines[:],
+                    baseline_references=dict(claim.baseline_references),
+                )
+                for claim in ownership.presence_claims
+            ],
+            deletions=deletions,
+            replacement_units=[
+                ReplacementUnit(
+                    presence_lines=unit.presence_lines[:],
+                    deletion_indices=unit.deletion_indices[:],
+                )
+                for unit in ownership.replacement_units
+            ],
+        ),
+        buffers=buffers,
     )
 
 
@@ -585,28 +602,26 @@ class BatchSourceAdvanceResult:
 
 
 @dataclass(frozen=True, slots=True)
-class _DeletionSignature:
+class _AbsenceSignature:
     anchor_line: int | None
     content_digest: str
     byte_count: int
     line_count: int
 
 
-def _deletion_signature(deletion: AbsenceClaim) -> _DeletionSignature:
+def _absence_signature(claim: AbsenceClaim) -> _AbsenceSignature:
     """Return a stable signature for an absence claim."""
     digest = sha256()
     byte_count = 0
-    line_count = 0
-    for line in deletion.content_lines:
-        digest.update(line)
-        byte_count += len(line)
-        line_count += 1
+    for chunk in buffer_byte_chunks(claim.content_lines):
+        digest.update(chunk)
+        byte_count += len(chunk)
 
-    return _DeletionSignature(
-        anchor_line=deletion.anchor_line,
+    return _AbsenceSignature(
+        anchor_line=claim.anchor_line,
         content_digest=digest.hexdigest(),
         byte_count=byte_count,
-        line_count=line_count,
+        line_count=len(claim.content_lines),
     )
 
 
@@ -839,7 +854,7 @@ def merge_batch_ownership(existing: BatchOwnership, new: BatchOwnership) -> Batc
     # When batch source advances and ownership is remapped, the same deletion can appear
     # in both existing (remapped) and new (from current diff). We need to deduplicate.
     combined_deletions = []
-    deletion_index_by_signature: dict[_DeletionSignature, int] = {}
+    deletion_index_by_signature: dict[_AbsenceSignature, int] = {}
     existing_deletion_index_map: dict[int, int] = {}
     new_deletion_index_map: dict[int, int] = {}
 
@@ -848,7 +863,7 @@ def merge_batch_ownership(existing: BatchOwnership, new: BatchOwnership) -> Batc
         + [("new", index, deletion) for index, deletion in enumerate(new.deletions)]
     ):
         # Create a signature for this deletion: anchor + content
-        signature = _deletion_signature(deletion)
+        signature = _absence_signature(deletion)
 
         if signature not in deletion_index_by_signature:
             deletion_index_by_signature[signature] = len(combined_deletions)
@@ -947,15 +962,17 @@ def translate_lines_to_batch_ownership(selected_lines: list) -> BatchOwnership:
     # Context/addition lines exist in batch source → presence claims
     # Deletion lines don't exist in batch source → absence claims (suppression)
 
+    content_view = _LineEntryContentSequence(selected_lines)
     claimed_source_lines = _LineRangeBuilder()
     presence_baseline_references: dict[int, BaselineReference] = {}
-    deletion_claims: list[AbsenceClaim] = []
+    absence_claims: list[AbsenceClaim] = []
     replacement_units: list[ReplacementUnit] = []
 
     # Track current deletion run
-    current_deletion_anchor: int | None = None
-    current_deletion_baseline_reference: BaselineReference | None = None
-    current_deletion_lines: list[bytes] = []
+    current_absence_anchor: int | None = None
+    current_absence_baseline_reference: BaselineReference | None = None
+    current_absence_start: int | None = None
+    current_absence_stop: int | None = None
     active_replacement_unit: _ReplacementUnitBuilder | None = None
 
     def finish_replacement_unit(
@@ -964,30 +981,39 @@ def translate_lines_to_batch_ownership(selected_lines: list) -> BatchOwnership:
         if builder is not None:
             replacement_units.append(builder.finish())
 
-    def flush_deletion_run() -> list[int]:
+    def flush_absence_run() -> list[int]:
         """Finalize current deletion run as an AbsenceClaim."""
-        nonlocal current_deletion_anchor
-        nonlocal current_deletion_baseline_reference
-        nonlocal current_deletion_lines
-        if current_deletion_lines:
-            deletion_claims.append(
-                AbsenceClaim(
-                    anchor_line=current_deletion_anchor,
-                    content_lines=current_deletion_lines[:],
-                    baseline_reference=current_deletion_baseline_reference,
-                )
-            )
-            deletion_index = len(deletion_claims) - 1
-            current_deletion_lines = []
-            current_deletion_baseline_reference = None
-            return [deletion_index]
-        return []
+        nonlocal current_absence_anchor
+        nonlocal current_absence_baseline_reference
+        nonlocal current_absence_start
+        nonlocal current_absence_stop
+        if current_absence_start is None or current_absence_stop is None:
+            return []
 
-    for line in selected_lines:
+        content_lines = _build_absence_content_from_range(
+            content_view,
+            current_absence_start,
+            current_absence_stop,
+        )
+        absence_claims.append(
+            AbsenceClaim(
+                anchor_line=current_absence_anchor,
+                content_lines=content_lines,
+                baseline_reference=current_absence_baseline_reference,
+            )
+        )
+        absence_index = len(absence_claims) - 1
+        current_absence_start = None
+        current_absence_stop = None
+        current_absence_anchor = None
+        current_absence_baseline_reference = None
+        return [absence_index]
+
+    for index, line in enumerate(selected_lines):
         if line.kind in (' ', '+'):
             # Context or addition: exists in batch source (working tree)
             # Flush any pending deletion run
-            flushed_deletion_indices = flush_deletion_run()
+            flushed_deletion_indices = flush_absence_run()
 
             if line.source_line is None:
                 raise ValueError(
@@ -1020,7 +1046,7 @@ def translate_lines_to_batch_ownership(selected_lines: list) -> BatchOwnership:
                 active_replacement_unit = None
 
             # Update anchor for next deletion run
-            current_deletion_anchor = line.source_line
+            current_absence_anchor = line.source_line
 
         elif line.kind == '-':
             finish_replacement_unit(active_replacement_unit)
@@ -1029,20 +1055,21 @@ def translate_lines_to_batch_ownership(selected_lines: list) -> BatchOwnership:
             # Anchor each deletion run at its first deleted line. A None anchor
             # means the run starts before the first source line and must not be
             # overwritten by later deleted lines in the same run.
-            if not current_deletion_lines:
-                current_deletion_anchor = line.source_line
+            if current_absence_start is None:
+                current_absence_start = index
+                current_absence_anchor = line.source_line
                 if line.old_line_number is not None:
-                    current_deletion_baseline_reference = BaselineReference(
+                    current_absence_baseline_reference = BaselineReference(
                         after_line=(
                             line.old_line_number - 1
                             if line.old_line_number > 1 else
                             None
                         )
                     )
-            current_deletion_lines.append(_line_entry_content(line))
+            current_absence_stop = index + 1
 
     # Flush any final deletion run
-    flush_deletion_run()
+    flush_absence_run()
     finish_replacement_unit(active_replacement_unit)
 
     return BatchOwnership(
@@ -1050,10 +1077,10 @@ def translate_lines_to_batch_ownership(selected_lines: list) -> BatchOwnership:
             claimed_source_lines.finish(),
             presence_baseline_references,
         ),
-        deletions=deletion_claims,
+        deletions=absence_claims,
         replacement_units=_normalize_replacement_units(
             replacement_units,
-            deletion_count=len(deletion_claims),
+            deletion_count=len(absence_claims),
         ),
     )
 
@@ -1070,35 +1097,81 @@ def _line_entry_content(line: LineEntry) -> bytes:
     return line.text_bytes + (b"\n" if line.has_trailing_newline else b"")
 
 
-def _baseline_reference_for_deletion_run(
-    deletion_lines: list[LineEntry],
-    old_line_content: dict[int, bytes],
-) -> BaselineReference | None:
-    old_line_numbers = [
-        line.old_line_number
-        for line in deletion_lines
-        if line.old_line_number is not None
-    ]
-    if not old_line_numbers:
-        return None
+class _LineEntryContentSequence(Sequence[bytes]):
+    """Lazy byte-line view over LineEntry content."""
 
-    first_old_line = min(old_line_numbers)
-    last_old_line = max(old_line_numbers)
-    after_line = first_old_line - 1 if first_old_line > 1 else None
-    before_line = last_old_line + 1
-    before_content = old_line_content.get(before_line)
-    return BaselineReference(
-        after_line=after_line,
-        after_content=(
-            old_line_content.get(after_line)
-            if after_line is not None else
-            None
-        ),
-        has_after_line=True,
-        before_line=before_line if before_content is not None else None,
-        before_content=before_content,
-        has_before_line=before_content is not None,
-    )
+    def __init__(self, lines: Sequence[LineEntry]) -> None:
+        self._lines = lines
+
+    def __len__(self) -> int:
+        return len(self._lines)
+
+    def __getitem__(self, index: int | slice) -> bytes | Sequence[bytes]:
+        if isinstance(index, slice):
+            return _LineEntryContentSequence(self._lines[index])
+
+        return _line_entry_content(self._lines[index])
+
+
+class _AbsenceContentBuilder:
+    """Build absence content as an EditorBuffer from appended line ranges."""
+
+    def __init__(self) -> None:
+        self._editor: Editor | None = Editor(())
+
+    def __enter__(self) -> _AbsenceContentBuilder:
+        self._check_open()
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        self.close()
+
+    def append_line_range(
+        self,
+        lines: Sequence[bytes],
+        start: int,
+        end: int,
+    ) -> None:
+        editor = self._check_open()
+        editor.append_line_range(lines, start, end)
+
+    def finish(self) -> EditorBuffer:
+        editor = self._check_open()
+        try:
+            return EditorBuffer.from_chunks(editor.line_chunks())
+        finally:
+            self.close()
+
+    def close(self) -> None:
+        editor = self._editor
+        if editor is None:
+            return
+
+        self._editor = None
+        editor.close()
+
+    def _check_open(self) -> Editor:
+        editor = self._editor
+        if editor is None:
+            raise RuntimeError("absence content builder is closed")
+
+        return editor
+
+
+def _copy_absence_content(content_lines: Sequence[bytes]) -> EditorBuffer:
+    if isinstance(content_lines, EditorBuffer):
+        return EditorBuffer.from_chunks(buffer_byte_chunks(content_lines))
+    return _build_absence_content_from_range(content_lines, 0, len(content_lines))
+
+
+def _build_absence_content_from_range(
+    content_lines: Sequence[bytes],
+    start: int,
+    end: int,
+) -> EditorBuffer:
+    with _AbsenceContentBuilder() as builder:
+        builder.append_line_range(content_lines, start, end)
+        return builder.finish()
 
 
 def _baseline_reference_for_old_line_range(
@@ -1186,13 +1259,13 @@ def _scan_hunk_line_range(
     )
 
 
-def _hunk_lines_in_range(
+def _hunk_line_indexes_in_range(
     hunk_lines: list[LineEntry],
     scan: _HunkLineRangeScan,
     *,
     kind: str,
     line_number_attr: str,
-) -> Iterable[LineEntry]:
+) -> Iterable[int]:
     for index in range(scan.start_index, scan.stop_index):
         line = hunk_lines[index]
         line_number = getattr(line, line_number_attr)
@@ -1201,7 +1274,36 @@ def _hunk_lines_in_range(
             and line_number is not None
             and scan.start <= line_number <= scan.end
         ):
-            yield line
+            yield index
+
+
+def _hunk_line_index_ranges_in_range(
+    hunk_lines: list[LineEntry],
+    scan: _HunkLineRangeScan,
+    *,
+    kind: str,
+    line_number_attr: str,
+) -> Iterable[tuple[int, int]]:
+    pending_start: int | None = None
+    pending_stop: int | None = None
+
+    for index in _hunk_line_indexes_in_range(
+        hunk_lines,
+        scan,
+        kind=kind,
+        line_number_attr=line_number_attr,
+    ):
+        if pending_stop == index:
+            pending_stop = index + 1
+            continue
+
+        if pending_start is not None and pending_stop is not None:
+            yield pending_start, pending_stop
+        pending_start = index
+        pending_stop = index + 1
+
+    if pending_start is not None and pending_stop is not None:
+        yield pending_start, pending_stop
 
 
 def translate_hunk_selection_to_batch_ownership(
@@ -1224,31 +1326,39 @@ def translate_hunk_selection_to_batch_ownership(
     """
     claimed_source_lines = _LineRangeBuilder()
     presence_baseline_references: dict[int, BaselineReference] = {}
-    deletion_claims: list[AbsenceClaim] = []
+    absence_claims: list[AbsenceClaim] = []
     replacement_units: list[ReplacementUnit] = []
     old_line_content = _old_line_content_by_number(hunk_lines)
+    hunk_content_view = _LineEntryContentSequence(hunk_lines)
     consumed_replacement_ids: set[int] = set()
 
     def add_replacement_unit(
-        selected_old_lines: Iterable[LineEntry],
+        selected_old_ranges: Iterable[tuple[int, int]],
         selected_new_lines: Iterable[LineEntry],
         *,
         old_start: int,
         old_end: int,
     ) -> None:
-        deletion_content: list[bytes] = []
         deletion_anchor: int | None = None
         old_line_seen = False
         selected_source_lines = _LineRangeBuilder()
         consumed_ids: list[int] = []
+        with _AbsenceContentBuilder() as builder:
+            for range_start, range_stop in selected_old_ranges:
+                if not old_line_seen:
+                    deletion_anchor = hunk_lines[range_start].source_line
+                    old_line_seen = True
+                builder.append_line_range(
+                    hunk_content_view,
+                    range_start,
+                    range_stop,
+                )
+                for index in range(range_start, range_stop):
+                    old_line = hunk_lines[index]
+                    if old_line.id is not None:
+                        consumed_ids.append(old_line.id)
 
-        for old_line in selected_old_lines:
-            if not old_line_seen:
-                deletion_anchor = old_line.source_line
-                old_line_seen = True
-            deletion_content.append(_line_entry_content(old_line))
-            if old_line.id is not None:
-                consumed_ids.append(old_line.id)
+            content_lines = builder.finish()
 
         for new_line in selected_new_lines:
             if new_line.source_line is None:
@@ -1272,10 +1382,10 @@ def translate_hunk_selection_to_batch_ownership(
                     has_before_line=new_line.has_baseline_reference_before,
                 )
 
-        deletion_claims.append(
+        absence_claims.append(
             AbsenceClaim(
                 anchor_line=deletion_anchor,
-                content_lines=deletion_content,
+                content_lines=content_lines,
                 baseline_reference=_baseline_reference_for_old_line_range(
                     old_start,
                     old_end,
@@ -1286,7 +1396,7 @@ def translate_hunk_selection_to_batch_ownership(
         replacement_units.append(
             ReplacementUnit(
                 presence_lines=selected_source_lines.finish().to_range_strings(),
-                deletion_indices=[len(deletion_claims) - 1],
+                deletion_indices=[len(absence_claims) - 1],
             )
         )
         consumed_replacement_ids.update(consumed_ids)
@@ -1320,19 +1430,21 @@ def translate_hunk_selection_to_batch_ownership(
             continue
 
         if old_scan.count == new_scan.count:
-            old_lines = _hunk_lines_in_range(
+            old_indexes = _hunk_line_indexes_in_range(
                 hunk_lines,
                 old_scan,
                 kind="-",
                 line_number_attr="old_line_number",
             )
-            new_lines = _hunk_lines_in_range(
+            new_indexes = _hunk_line_indexes_in_range(
                 hunk_lines,
                 new_scan,
                 kind="+",
                 line_number_attr="new_line_number",
             )
-            for old_line, new_line in zip(old_lines, new_lines):
+            for old_index, new_index in zip(old_indexes, new_indexes):
+                old_line = hunk_lines[old_index]
+                new_line = hunk_lines[new_index]
                 old_selected = (
                     old_line.id is not None
                     and old_line.id in selected_display_ids
@@ -1345,7 +1457,7 @@ def translate_hunk_selection_to_batch_ownership(
                     if old_line.old_line_number is None:
                         continue
                     add_replacement_unit(
-                        (old_line,),
+                        ((old_index, old_index + 1),),
                         (new_line,),
                         old_start=old_line.old_line_number,
                         old_end=old_line.old_line_number,
@@ -1354,25 +1466,30 @@ def translate_hunk_selection_to_batch_ownership(
 
         if old_scan.fully_selected and new_scan.fully_selected:
             add_replacement_unit(
-                _hunk_lines_in_range(
+                _hunk_line_index_ranges_in_range(
                     hunk_lines,
                     old_scan,
                     kind="-",
                     line_number_attr="old_line_number",
                 ),
-                _hunk_lines_in_range(
-                    hunk_lines,
-                    new_scan,
-                    kind="+",
-                    line_number_attr="new_line_number",
+                (
+                    hunk_lines[index]
+                    for index in _hunk_line_indexes_in_range(
+                        hunk_lines,
+                        new_scan,
+                        kind="+",
+                        line_number_attr="new_line_number",
+                    )
                 ),
                 old_start=replacement_run.old_start,
                 old_end=replacement_run.old_end,
             )
 
-    current_deletion_anchor: int | None = None
-    current_deletion_lines: list[bytes] = []
-    current_deletion_hunk_lines: list[LineEntry] = []
+    current_absence_anchor: int | None = None
+    current_absence_start: int | None = None
+    current_absence_stop: int | None = None
+    current_absence_old_start: int | None = None
+    current_absence_old_end: int | None = None
     active_replacement_unit: _ReplacementUnitBuilder | None = None
 
     def finish_replacement_unit(
@@ -1381,29 +1498,47 @@ def translate_hunk_selection_to_batch_ownership(
         if builder is not None:
             replacement_units.append(builder.finish())
 
-    def flush_deletion_run() -> list[int]:
-        nonlocal current_deletion_anchor
-        nonlocal current_deletion_lines
-        nonlocal current_deletion_hunk_lines
-        if not current_deletion_lines:
+    def flush_absence_run() -> list[int]:
+        nonlocal current_absence_anchor
+        nonlocal current_absence_start
+        nonlocal current_absence_stop
+        nonlocal current_absence_old_start
+        nonlocal current_absence_old_end
+        if current_absence_start is None or current_absence_stop is None:
             return []
 
-        deletion_claims.append(
+        baseline_reference = (
+            _baseline_reference_for_old_line_range(
+                current_absence_old_start,
+                current_absence_old_end,
+                old_line_content,
+            )
+            if (
+                current_absence_old_start is not None
+                and current_absence_old_end is not None
+            )
+            else None
+        )
+        absence_claims.append(
             AbsenceClaim(
-                anchor_line=current_deletion_anchor,
-                content_lines=current_deletion_lines[:],
-                baseline_reference=_baseline_reference_for_deletion_run(
-                    current_deletion_hunk_lines,
-                    old_line_content,
+                anchor_line=current_absence_anchor,
+                content_lines=_build_absence_content_from_range(
+                    hunk_content_view,
+                    current_absence_start,
+                    current_absence_stop,
                 ),
+                baseline_reference=baseline_reference,
             )
         )
-        deletion_index = len(deletion_claims) - 1
-        current_deletion_lines = []
-        current_deletion_hunk_lines = []
-        return [deletion_index]
+        absence_index = len(absence_claims) - 1
+        current_absence_anchor = None
+        current_absence_start = None
+        current_absence_stop = None
+        current_absence_old_start = None
+        current_absence_old_end = None
+        return [absence_index]
 
-    for line in hunk_lines:
+    for index, line in enumerate(hunk_lines):
         is_selected = (
             line.id is not None
             and line.id in selected_display_ids
@@ -1411,7 +1546,7 @@ def translate_hunk_selection_to_batch_ownership(
         )
 
         if line.kind in {" ", "+"}:
-            flushed_deletion_indices = flush_deletion_run()
+            flushed_deletion_indices = flush_absence_run()
 
             if is_selected:
                 if line.source_line is None:
@@ -1449,24 +1584,28 @@ def translate_hunk_selection_to_batch_ownership(
                 active_replacement_unit = None
 
             if line.source_line is not None:
-                current_deletion_anchor = line.source_line
+                current_absence_anchor = line.source_line
             continue
 
         if line.kind == "-":
             if not is_selected:
-                flush_deletion_run()
+                flush_absence_run()
                 finish_replacement_unit(active_replacement_unit)
                 active_replacement_unit = None
                 continue
 
             finish_replacement_unit(active_replacement_unit)
             active_replacement_unit = None
-            if not current_deletion_lines:
-                current_deletion_anchor = line.source_line
-            current_deletion_lines.append(_line_entry_content(line))
-            current_deletion_hunk_lines.append(line)
+            if current_absence_start is None:
+                current_absence_anchor = line.source_line
+                current_absence_start = index
+            current_absence_stop = index + 1
+            if line.old_line_number is not None:
+                if current_absence_old_start is None:
+                    current_absence_old_start = line.old_line_number
+                current_absence_old_end = line.old_line_number
 
-    flush_deletion_run()
+    flush_absence_run()
     finish_replacement_unit(active_replacement_unit)
 
     return BatchOwnership(
@@ -1474,10 +1613,10 @@ def translate_hunk_selection_to_batch_ownership(
             claimed_source_lines.finish(),
             presence_baseline_references,
         ),
-        deletions=deletion_claims,
+        deletions=absence_claims,
         replacement_units=_normalize_replacement_units(
             replacement_units,
-            deletion_count=len(deletion_claims),
+            deletion_count=len(absence_claims),
         ),
     )
 

--- a/src/git_stage_batch/commands/reset.py
+++ b/src/git_stage_batch/commands/reset.py
@@ -6,13 +6,14 @@ import json
 import shlex
 import sys
 from collections.abc import Sequence
+from contextlib import AbstractContextManager
 
 from ..core.line_selection import format_line_ids
 from ..batch.operations import create_batch
 from ..batch.ownership import (
     BatchOwnership,
+    acquire_detached_batch_ownership,
     build_ownership_units_from_batch_source_lines,
-    detach_batch_ownership,
     filter_ownership_units_by_display_ids,
     merge_batch_ownership,
     rebuild_ownership_from_units,
@@ -320,9 +321,18 @@ def _move_claims_between_batches(
             return
 
         file_path = list(files.keys())[0]
-        selected_ownership = _select_line_ownership_for_file(source_batch, file_path, selected_ids)
-        _add_ownership_to_destination(dest_batch, file_path, source_metadata["files"][file_path], selected_ownership)
-        _reset_line_claims_for_file(source_batch, file_path, selected_ids)
+        with _acquire_line_ownership_for_file(
+            source_batch,
+            file_path,
+            selected_ids,
+        ) as selected_ownership:
+            _add_ownership_to_destination(
+                dest_batch,
+                file_path,
+                source_metadata["files"][file_path],
+                selected_ownership,
+            )
+            _reset_line_claims_for_file(source_batch, file_path, selected_ids)
         return
 
     for file_path, file_meta in files.items():
@@ -509,12 +519,12 @@ def _reset_line_claims_for_file(
             )
 
 
-def _select_line_ownership_for_file(
+def _acquire_line_ownership_for_file(
     batch_name: str,
     file_path: str,
     lines_to_select: set[int],
-) -> BatchOwnership:
-    """Build ownership for selected display line IDs from one batch file."""
+) -> AbstractContextManager[BatchOwnership]:
+    """Acquire ownership for selected display line IDs from one batch file."""
     metadata = read_batch_metadata(batch_name)
 
     if metadata["files"][file_path].get("file_type") == "binary":
@@ -540,7 +550,9 @@ def _select_line_ownership_for_file(
             file_path=file_path,
         )
         validate_ownership_units(selected_units)
-        return detach_batch_ownership(rebuild_ownership_from_units(selected_units))
+        return acquire_detached_batch_ownership(
+            rebuild_ownership_from_units(selected_units)
+        )
 
 
 def _partition_line_ownership_units(

--- a/src/git_stage_batch/commands/sift.py
+++ b/src/git_stage_batch/commands/sift.py
@@ -33,7 +33,7 @@ from ..batch.merge import merge_batch_from_line_sequences_as_buffer
 from ..exceptions import MergeError
 from ..batch.metadata_validation import read_validated_batch_metadata
 from ..batch.operations import create_batch, delete_batch
-from ..batch.ownership import BatchOwnership, AbsenceClaim
+from ..batch.ownership import BatchOwnership, AbsenceClaim, _AbsenceContentBuilder
 from ..batch.query import get_batch_baseline_commit, read_batch_metadata
 from ..batch.state_refs import (
     delete_batch_state_refs,
@@ -604,32 +604,44 @@ def build_ownership_from_working_and_target_lines(
     claimed_ranges: list[tuple[int, int]] = []
     deletion_claims = []
 
+    def build_absence_claim(
+        *,
+        anchor_line: int | None,
+        source_start: int,
+        source_end: int,
+    ) -> AbsenceClaim:
+        with _AbsenceContentBuilder() as builder:
+            builder.append_line_range(
+                working_lines,
+                source_start - 1,
+                source_end,
+            )
+            content_lines = builder.finish()
+        return AbsenceClaim(
+            anchor_line=anchor_line,
+            content_lines=content_lines,
+        )
+
     for run in semantic_runs:
         if run.kind == SemanticChangeKind.PRESENCE:
             if run.target_start is not None and run.target_end is not None:
                 claimed_ranges.append((run.target_start, run.target_end))
         elif run.kind == SemanticChangeKind.DELETION:
             if run.source_start is not None and run.source_end is not None:
-                deletion_content = [
-                    working_lines[index - 1]
-                    for index in run.source_line_numbers()
-                ]
                 deletion_claims.append(
-                    AbsenceClaim(
+                    build_absence_claim(
                         anchor_line=run.target_anchor,
-                        content_lines=deletion_content,
+                        source_start=run.source_start,
+                        source_end=run.source_end,
                     )
                 )
         elif run.kind == SemanticChangeKind.REPLACEMENT:
             if run.source_start is not None and run.source_end is not None:
-                deletion_content = [
-                    working_lines[index - 1]
-                    for index in run.source_line_numbers()
-                ]
                 deletion_claims.append(
-                    AbsenceClaim(
+                    build_absence_claim(
                         anchor_line=run.target_anchor,
-                        content_lines=deletion_content,
+                        source_start=run.source_start,
+                        source_end=run.source_end,
                     )
                 )
             if run.target_start is not None and run.target_end is not None:

--- a/tests/batch/test_ownership_incremental.py
+++ b/tests/batch/test_ownership_incremental.py
@@ -12,6 +12,7 @@ from git_stage_batch.batch.ownership import (
 )
 from git_stage_batch.core.line_selection import LineRanges
 from git_stage_batch.core.models import LineEntry
+from git_stage_batch.editor import EditorBuffer
 
 
 def test_translate_lines_creates_deletion_constraints():
@@ -31,7 +32,8 @@ def test_translate_lines_creates_deletion_constraints():
     # Should create deletion constraint for - line (suppression constraint)
     assert len(ownership.deletions) == 1
     assert isinstance(ownership.deletions[0], AbsenceClaim)
-    assert ownership.deletions[0].content_lines == [b'old_version\n']
+    assert isinstance(ownership.deletions[0].content_lines, EditorBuffer)
+    assert list(ownership.deletions[0].content_lines) == [b'old_version\n']
     assert len(ownership.replacement_units) == 1
     assert ownership.replacement_units[0].presence_lines == ["1"]
     assert ownership.replacement_units[0].deletion_indices == [0]
@@ -86,6 +88,31 @@ def test_translate_lines_builds_selected_ranges_without_line_sets(monkeypatch):
     assert ownership.replacement_units == [
         ReplacementUnit(presence_lines=["1-1000"], deletion_indices=[0]),
     ]
+
+
+def test_translate_lines_stores_large_deletion_as_editor_buffer():
+    """Large selected deletions should keep absence content buffer-backed."""
+    lines = [
+        LineEntry(
+            id=index + 1,
+            kind='-',
+            old_line_number=index + 1,
+            new_line_number=None,
+            text_bytes=f'old {index}'.encode(),
+            text=f'old {index}',
+            source_line=None if index == 0 else index,
+        )
+        for index in range(1000)
+    ]
+
+    ownership = translate_lines_to_batch_ownership(lines)
+
+    assert len(ownership.deletions) == 1
+    content_lines = ownership.deletions[0].content_lines
+    assert isinstance(content_lines, EditorBuffer)
+    assert len(content_lines) == 1000
+    assert content_lines[0] == b'old 0\n'
+    assert content_lines[999] == b'old 999\n'
 
 
 def test_derive_replacement_line_runs_accepts_non_list_sequences(line_sequence):
@@ -172,9 +199,11 @@ def test_translate_lines_preserves_deletion_structure():
 
     # Should have two separate absence claims (not collapsed)
     assert len(ownership.deletions) == 2
-    assert ownership.deletions[0].content_lines == [b'del1\n', b'del2\n']
+    assert isinstance(ownership.deletions[0].content_lines, EditorBuffer)
+    assert list(ownership.deletions[0].content_lines) == [b'del1\n', b'del2\n']
     assert ownership.deletions[0].anchor_line is None  # before any source line
-    assert ownership.deletions[1].content_lines == [b'del3\n']
+    assert isinstance(ownership.deletions[1].content_lines, EditorBuffer)
+    assert list(ownership.deletions[1].content_lines) == [b'del3\n']
     assert ownership.deletions[1].anchor_line == 1  # after source line 1
     assert ownership.replacement_units == []
 
@@ -192,7 +221,11 @@ def test_translate_lines_keeps_file_start_anchor_for_deletion_run():
 
     assert len(ownership.deletions) == 1
     assert ownership.deletions[0].anchor_line is None
-    assert ownership.deletions[0].content_lines == [b'first\n', b'second\n']
+    assert isinstance(ownership.deletions[0].content_lines, EditorBuffer)
+    assert list(ownership.deletions[0].content_lines) == [
+        b'first\n',
+        b'second\n',
+    ]
 
 
 def test_translate_hunk_selection_uses_full_hunk_boundaries():
@@ -219,7 +252,8 @@ def test_translate_hunk_selection_uses_full_hunk_boundaries():
 
     assert ownership.presence_line_set() == {1}
     assert len(ownership.deletions) == 1
-    assert ownership.deletions[0].content_lines == [b'a\n']
+    assert isinstance(ownership.deletions[0].content_lines, EditorBuffer)
+    assert list(ownership.deletions[0].content_lines) == [b'a\n']
     assert ownership.deletions[0].baseline_reference.after_line == 1
     assert ownership.deletions[0].baseline_reference.after_content == b'same'
     assert ownership.deletions[0].baseline_reference.before_line == 3
@@ -258,7 +292,8 @@ def test_translate_hunk_selection_uses_file_derived_replacement_runs():
 
     assert ownership.presence_line_set() == {1}
     assert len(ownership.deletions) == 1
-    assert ownership.deletions[0].content_lines == [b'a\n']
+    assert isinstance(ownership.deletions[0].content_lines, EditorBuffer)
+    assert list(ownership.deletions[0].content_lines) == [b'a\n']
     assert ownership.replacement_units == [
         ReplacementUnit(presence_lines=["1"], deletion_indices=[0]),
     ]
@@ -290,7 +325,8 @@ def test_translate_hunk_selection_keeps_one_to_many_replacement_atomic():
 
     assert ownership.presence_line_set() == {1, 2}
     assert len(ownership.deletions) == 1
-    assert ownership.deletions[0].content_lines == [b'old\n']
+    assert isinstance(ownership.deletions[0].content_lines, EditorBuffer)
+    assert list(ownership.deletions[0].content_lines) == [b'old\n']
     assert ownership.replacement_units == [
         ReplacementUnit(presence_lines=["1-2"], deletion_indices=[0]),
     ]
@@ -340,8 +376,59 @@ def test_translate_hunk_selection_scans_replacement_ranges(monkeypatch):
     )
 
     assert ownership.presence_claims[0].source_lines == ["1-1000"]
+    assert isinstance(ownership.deletions[0].content_lines, EditorBuffer)
     assert ownership.replacement_units == [
         ReplacementUnit(presence_lines=["1-1000"], deletion_indices=[0]),
+    ]
+
+
+def test_translate_hunk_selection_stores_large_replacement_absence_buffer():
+    """Large replacement deletions should keep absence content buffer-backed."""
+    lines = [
+        *[
+            LineEntry(
+                id=index + 1,
+                kind='-',
+                old_line_number=index + 1,
+                new_line_number=None,
+                text_bytes=f'old {index}'.encode(),
+                text=f'old {index}',
+                source_line=None if index == 0 else index,
+            )
+            for index in range(1000)
+        ],
+        LineEntry(
+            id=1001,
+            kind='+',
+            old_line_number=None,
+            new_line_number=1,
+            text_bytes=b'new\n',
+            text='new',
+            source_line=1,
+        ),
+    ]
+
+    ownership = translate_hunk_selection_to_batch_ownership(
+        lines,
+        {line.id for line in lines if line.id is not None},
+        replacement_line_runs=[
+            ReplacementLineRun(
+                old_start=1,
+                old_end=1000,
+                new_start=1,
+                new_end=1,
+            ),
+        ],
+    )
+
+    assert len(ownership.deletions) == 1
+    content_lines = ownership.deletions[0].content_lines
+    assert isinstance(content_lines, EditorBuffer)
+    assert len(content_lines) == 1000
+    assert content_lines[0] == b'old 0\n'
+    assert content_lines[999] == b'old 999\n'
+    assert ownership.replacement_units == [
+        ReplacementUnit(presence_lines=["1"], deletion_indices=[0]),
     ]
 
 

--- a/tests/batch/test_stale_source_advancement.py
+++ b/tests/batch/test_stale_source_advancement.py
@@ -209,7 +209,7 @@ def test_remap_deletion_anchors_to_new_source():
     # Anchor at line 2 in old source should map to line 3 in new source
     assert len(new_ownership.deletions) == 1
     assert new_ownership.deletions[0].anchor_line == 3
-    assert new_ownership.deletions[0].content_lines == [b"deleted line\n"]
+    assert list(new_ownership.deletions[0].content_lines) == [b"deleted line\n"]
 
 
 def test_remap_start_of_file_deletion_anchor():
@@ -299,12 +299,12 @@ def test_remap_preserves_deletion_content():
     old_source = b"line one\nline two\n"
     new_source = b"prefix\nline one\nline two\n"
 
-    deletion_content = [b"deleted line 1\n", b"deleted line 2\n"]
+    absence_content = [b"deleted line 1\n", b"deleted line 2\n"]
 
     old_ownership = BatchOwnership.from_presence_lines(
         [],
         [
-            AbsenceClaim(anchor_line=1, content_lines=deletion_content)
+            AbsenceClaim(anchor_line=1, content_lines=absence_content)
         ]
     )
 
@@ -315,7 +315,7 @@ def test_remap_preserves_deletion_content():
     )
 
     # Content should be preserved exactly
-    assert new_ownership.deletions[0].content_lines == deletion_content
+    assert list(new_ownership.deletions[0].content_lines) == absence_content
 
 
 def test_remap_preserves_explicit_replacement_units():

--- a/tests/batch/test_storage.py
+++ b/tests/batch/test_storage.py
@@ -15,8 +15,12 @@ from git_stage_batch.batch.ownership import (
     BatchOwnership,
     AbsenceClaim,
     ReplacementUnit,
-    detach_batch_ownership,
+    _AbsenceContentBuilder,
+    _absence_signature,
+    acquire_detached_batch_ownership,
+    merge_batch_ownership,
 )
+import git_stage_batch.batch.ownership as ownership_module
 from git_stage_batch.data.session import initialize_abort_state
 from git_stage_batch.editor import EditorBuffer
 from git_stage_batch.utils.git import create_git_blob
@@ -137,6 +141,26 @@ def test_deletion_claim_metadata_accepts_non_list_content_lines(
             b"old two\n",
         ]
 
+
+def test_absence_claim_metadata_keeps_deletions_key(temp_git_repo):
+    """Serialized metadata should keep the compatible deletions key."""
+    with EditorBuffer.from_chunks([b"old\n"]) as content:
+        ownership = BatchOwnership.from_presence_lines(
+            [],
+            [
+                AbsenceClaim(
+                    anchor_line=None,
+                    content_lines=content,
+                ),
+            ],
+        )
+        metadata = ownership.to_metadata_dict()
+
+    assert "deletions" in metadata
+    assert "absence_claims" not in metadata
+    assert metadata["deletions"][0]["after_source_line"] is None
+
+
 def test_batch_ownership_metadata_acquisition_scopes_deletion_buffers(temp_git_repo):
     """Acquired ownership should keep deletion content usable only inside."""
     ownership = BatchOwnership.from_presence_lines(
@@ -160,8 +184,8 @@ def test_batch_ownership_metadata_acquisition_scopes_deletion_buffers(temp_git_r
         content_lines[0]
 
 
-def test_detach_batch_ownership_keeps_acquired_deletion_content(temp_git_repo):
-    """Detached ownership should keep acquired deletion content after scope."""
+def test_acquire_detached_batch_ownership_keeps_copied_content(temp_git_repo):
+    """Detached ownership should keep copied absence content after scope."""
     ownership = BatchOwnership.from_presence_lines(
         ["1"],
         [
@@ -177,21 +201,117 @@ def test_detach_batch_ownership_keeps_acquired_deletion_content(temp_git_repo):
     metadata = ownership.to_metadata_dict()
 
     with BatchOwnership.acquire_for_metadata_dict(metadata) as scoped_ownership:
-        detached = detach_batch_ownership(scoped_ownership)
+        detached_context = acquire_detached_batch_ownership(scoped_ownership)
         content_lines = scoped_ownership.deletions[0].content_lines
         assert isinstance(content_lines, EditorBuffer)
 
     with pytest.raises(ValueError, match="buffer is closed"):
         content_lines[0]
 
-    assert detached.deletions[0].content_lines == [
-        b"old one\n",
-        b"old two\n",
-    ]
-    assert detached.presence_line_set() == {1}
-    assert detached.replacement_units == [
-        ReplacementUnit(presence_lines=["1"], deletion_indices=[0]),
-    ]
+    with detached_context as detached:
+        detached_content = detached.deletions[0].content_lines
+        assert isinstance(detached_content, EditorBuffer)
+        assert list(detached_content) == [
+            b"old one\n",
+            b"old two\n",
+        ]
+        assert detached.presence_line_set() == {1}
+        assert detached.replacement_units == [
+            ReplacementUnit(presence_lines=["1"], deletion_indices=[0]),
+        ]
+
+    with pytest.raises(ValueError, match="buffer is closed"):
+        detached_content.to_bytes()
+
+
+def test_acquire_detached_batch_ownership_streams_buffer_content(monkeypatch):
+    """Detached absence content should copy buffer bytes without line indexing."""
+    def fail_getitem(self, index):
+        raise AssertionError("detach should stream byte chunks")
+
+    with EditorBuffer.from_chunks([b"old one\n", b"old two\n"]) as content:
+        monkeypatch.setattr(EditorBuffer, "__getitem__", fail_getitem)
+        detached_context = acquire_detached_batch_ownership(
+            BatchOwnership.from_presence_lines(
+                [],
+                [AbsenceClaim(anchor_line=None, content_lines=content)],
+            )
+        )
+
+    with detached_context as detached:
+        detached_content = detached.deletions[0].content_lines
+        assert isinstance(detached_content, EditorBuffer)
+        assert detached_content.to_bytes() == b"old one\nold two\n"
+
+    with pytest.raises(ValueError, match="buffer is closed"):
+        detached_content.to_bytes()
+
+
+def test_absence_signature_streams_editor_buffer_chunks(monkeypatch):
+    """Absence signatures should hash buffer chunks without line indexing."""
+    def fail_getitem(self, index):
+        raise AssertionError("absence signature should stream byte chunks")
+
+    with (
+        EditorBuffer.from_chunks([b"old one\n", b"old two\n"]) as left_content,
+        EditorBuffer.from_chunks([b"old one\n", b"old two\n"]) as right_content,
+    ):
+        monkeypatch.setattr(EditorBuffer, "__getitem__", fail_getitem)
+        left_claim = AbsenceClaim(anchor_line=None, content_lines=left_content)
+        right_claim = AbsenceClaim(anchor_line=None, content_lines=right_content)
+
+        signature = _absence_signature(left_claim)
+        merged = merge_batch_ownership(
+            BatchOwnership.from_presence_lines([], [left_claim]),
+            BatchOwnership.from_presence_lines([], [right_claim]),
+        )
+
+        assert signature.byte_count == len(b"old one\nold two\n")
+        assert signature.line_count == 2
+        assert len(merged.deletions) == 1
+
+
+def test_absence_content_builder_closes_editor_on_finish(monkeypatch):
+    """Finishing absence content should close the temporary editor."""
+    close_count = 0
+    original_close = ownership_module.Editor.close
+
+    def count_close(self):
+        nonlocal close_count
+        close_count += 1
+        original_close(self)
+
+    monkeypatch.setattr(ownership_module.Editor, "close", count_close)
+
+    with _AbsenceContentBuilder() as builder:
+        builder.append_line_range([b"old\n"], 0, 1)
+        content = builder.finish()
+
+    try:
+        assert content.to_bytes() == b"old\n"
+    finally:
+        content.close()
+    assert close_count == 1
+
+
+def test_absence_content_builder_closes_editor_on_exception(monkeypatch):
+    """Failing absence construction should close the temporary editor."""
+    close_count = 0
+    original_close = ownership_module.Editor.close
+
+    def count_close(self):
+        nonlocal close_count
+        close_count += 1
+        original_close(self)
+
+    monkeypatch.setattr(ownership_module.Editor, "close", count_close)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        with _AbsenceContentBuilder() as builder:
+            builder.append_line_range([b"old\n"], 0, 1)
+            raise RuntimeError("boom")
+
+    assert close_count == 1
 
 
 def test_legacy_claimed_lines_metadata_loads_as_presence_claims(temp_git_repo):

--- a/tests/commands/test_sift.py
+++ b/tests/commands/test_sift.py
@@ -7,6 +7,7 @@ import pytest
 
 from git_stage_batch.batch.validation import batch_exists
 from git_stage_batch.batch.ownership import BatchOwnership, AbsenceClaim
+from git_stage_batch.editor import EditorBuffer
 from git_stage_batch.batch.state_refs import get_batch_content_ref_name
 from git_stage_batch.commands.new import command_new_batch
 from git_stage_batch.commands.start import command_start
@@ -71,7 +72,8 @@ def test_build_sift_ownership_accepts_non_list_line_sequences(line_sequence):
     resolved = ownership.resolve()
     assert resolved.presence_line_set == {2}
     assert len(resolved.deletion_claims) == 1
-    assert resolved.deletion_claims[0].content_lines == [b"old\n"]
+    assert isinstance(resolved.deletion_claims[0].content_lines, EditorBuffer)
+    assert list(resolved.deletion_claims[0].content_lines) == [b"old\n"]
 
 
 def test_build_sift_ownership_consumes_target_ranges(monkeypatch):


### PR DESCRIPTION
Absence claims record the exact removed baseline bytes that must stay out of the realized result when a batch is merged, applied, or discarded. Stored batch metadata already writes those bytes through chunk streams and reads saved absence blobs back as `EditorBuffer` instances.

On main, newly created absence claims still keep selected deletion payloads in fresh Python lists. The display-line translator, current-hunk translator, sift ownership builder, detached ownership copies, and signature calculation can all walk or retain one bytes object per removed line before the same data is written as batch metadata.

This pull request first renames the metadata acquisition wrapper to `_AcquiredBatchOwnership` so the scoped buffer owner is explicit. `BatchOwnership` remains a plain data value: it is not a context manager and it does not provide `close()`. Metadata-loaded buffers are still closed by the acquisition wrapper.

The storage change adds a lazy `LineEntry` content view and an editor-backed absence content builder. The interactive ownership translators and sift use that builder to append contiguous source ranges and finish them as `EditorBuffer` content. `acquire_detached_batch_ownership()` returns a scoped owner for copied absence buffers, and absence signatures stream byte chunks instead of materializing line lists.

The metadata format is intentionally unchanged. Serialized records still use `deletions`, `after_source_line`, `blob`, `baseline_reference`, and replacement-unit `deletion_indices` for compatibility with existing batches.

Commit split:
- `ownership: Rename acquired ownership wrapper`
- `ownership: Store absence content with editor ranges`
- `tests: Add editor-backed absence content tests`
- `sift: Build absence content with editor ranges`
- `tests: Add sift absence content buffer assertion`

Verification:
- `git diff --check origin/main..HEAD`
- no matches from `rg -n "detach_batch_ownership|_select_line_ownership_for_file|_BatchOwnershipBuildContext|BatchOwnership\.close\(|AbsenceClaim.*close|\.deletions\[[^]]+\]\.close\(" src tests`
- `PYTHONPATH=src uv run pytest tests/batch/test_storage.py tests/commands/test_reset.py tests/batch/test_ownership_incremental.py tests/commands/test_sift.py`
- `PYTHONPATH=src uv run pytest -n auto`