### PR TITLE
Keep small buffers on heap

### DIFF
--- a/src/git_stage_batch/editor/buffer.py
+++ b/src/git_stage_batch/editor/buffer.py
@@ -7,10 +7,13 @@ from contextlib import nullcontext
 import mmap
 import os
 from pathlib import Path
-import tempfile
 from typing import Any, BinaryIO, Generic, Iterator, TypeVar, overload
 
-from ..utils.mapped_storage import ChunkedMappedRecordVector
+from ..utils.mapped_storage import (
+    ChunkedMappedRecordVector,
+    byte_storage_from_chunks,
+    byte_storage_from_path,
+)
 
 
 _DEFAULT_CHUNK_SIZE = 1024 * 1024
@@ -66,20 +69,8 @@ class EditorBuffer(Sequence[bytes]):
     @classmethod
     def from_path(cls, path: str | Path) -> EditorBuffer:
         """Create a buffer from a file using mmap when possible."""
-        file_path = Path(path)
-        file_handle = file_path.open("rb")
-        try:
-            if file_path.stat().st_size == 0:
-                file_handle.close()
-                return cls(b"")
-
-            return cls(
-                mmap.mmap(file_handle.fileno(), 0, access=mmap.ACCESS_READ),
-                file_handle=file_handle,
-            )
-        except Exception:
-            file_handle.close()
-            raise
+        data, file_handle = byte_storage_from_path(path)
+        return cls(data, file_handle=file_handle)
 
     @classmethod
     def from_chunks(
@@ -88,32 +79,12 @@ class EditorBuffer(Sequence[bytes]):
         *,
         spool_dir: str | Path | None = None,
     ) -> EditorBuffer:
-        """Create a buffer from generated chunks via a temporary file."""
-        file_handle = tempfile.TemporaryFile(
-            dir=None if spool_dir is None else Path(spool_dir)
+        """Create a buffer from generated chunks."""
+        data, file_handle = byte_storage_from_chunks(
+            chunks,
+            spool_dir=spool_dir,
         )
-        byte_count = 0
-        try:
-            for chunk in chunks:
-                if not isinstance(chunk, (bytes, bytearray, memoryview)):
-                    raise TypeError(
-                        f"expected bytes-like object, got {type(chunk).__name__}"
-                    )
-                byte_count += len(chunk)
-                file_handle.write(chunk)
-
-            if byte_count == 0:
-                file_handle.close()
-                return cls(b"")
-
-            file_handle.flush()
-            return cls(
-                mmap.mmap(file_handle.fileno(), 0, access=mmap.ACCESS_READ),
-                file_handle=file_handle,
-            )
-        except Exception:
-            file_handle.close()
-            raise
+        return cls(data, file_handle=file_handle)
 
     @property
     def is_mmap_backed(self) -> bool:

--- a/src/git_stage_batch/editor/buffer.py
+++ b/src/git_stage_batch/editor/buffer.py
@@ -87,8 +87,8 @@ class EditorBuffer(Sequence[bytes]):
         return cls(data, file_handle=file_handle)
 
     @property
-    def is_mmap_backed(self) -> bool:
-        """Return whether this buffer is backed by an mmap object."""
+    def uses_mapped_storage(self) -> bool:
+        """Return whether this buffer uses mapped storage."""
         return isinstance(self._data, mmap.mmap) and not self._closed
 
     @property

--- a/src/git_stage_batch/utils/mapped_storage.py
+++ b/src/git_stage_batch/utils/mapped_storage.py
@@ -1,4 +1,4 @@
-"""Tempfile-backed fixed-width storage helpers."""
+"""Fixed-width storage helpers that use mmap for larger allocations."""
 
 from __future__ import annotations
 
@@ -13,6 +13,8 @@ from typing import BinaryIO
 _UINT32_MAX = (1 << 32) - 1
 _UINT64_MAX = (1 << 64) - 1
 _FILL_CHUNK_BYTES = 1024 * 1024
+MAPPED_STORAGE_OFFLOAD_SIZE_THRESHOLD = mmap.PAGESIZE
+_StorageBuffer = bytearray | mmap.mmap
 
 
 def _normalize_width(width: int) -> int:
@@ -29,6 +31,14 @@ def _format_for_width(width: int) -> str:
     return "<I" if width == 4 else "<Q"
 
 
+def _normalize_record_format(record_format: str) -> str:
+    if not record_format:
+        raise ValueError("record format must not be empty")
+    if record_format[0] not in "@=<>!":
+        return "<" + record_format
+    return record_format
+
+
 def _max_for_width(width: int) -> int:
     return _UINT32_MAX if width == 4 else _UINT64_MAX
 
@@ -38,8 +48,39 @@ def _check_unsigned(value: int, max_value: int) -> None:
         raise OverflowError("value does not fit in unsigned storage")
 
 
+def _allocate_storage(
+    byte_count: int,
+    *,
+    spool_dir: str | Path | None = None,
+) -> tuple[_StorageBuffer | None, BinaryIO | None]:
+    if byte_count <= 0:
+        return None, None
+    if byte_count < MAPPED_STORAGE_OFFLOAD_SIZE_THRESHOLD:
+        return bytearray(byte_count), None
+
+    file_handle = tempfile.TemporaryFile(
+        dir=None if spool_dir is None else Path(spool_dir)
+    )
+    try:
+        file_handle.truncate(byte_count)
+        return mmap.mmap(file_handle.fileno(), byte_count), file_handle
+    except Exception:
+        file_handle.close()
+        raise
+
+
+def _close_storage(
+    data: _StorageBuffer | None,
+    file_handle: BinaryIO | None,
+) -> None:
+    if isinstance(data, mmap.mmap):
+        data.close()
+    if file_handle is not None:
+        file_handle.close()
+
+
 class MappedIntVector(Sequence[int]):
-    """Fixed-width unsigned integer vector backed by a temporary mmap."""
+    """Fixed-width unsigned integer vector."""
 
     def __init__(
         self,
@@ -58,18 +99,16 @@ class MappedIntVector(Sequence[int]):
         self._max_value = _max_for_width(self._width)
         self._byte_count = length * self._width
         self._file_handle: BinaryIO | None = None
-        self._mmap: mmap.mmap | None = None
+        self._data: _StorageBuffer | None = None
         self._closed = False
 
         _check_unsigned(fill, self._max_value)
-        if self._byte_count > 0:
-            self._file_handle = tempfile.TemporaryFile(
-                dir=None if spool_dir is None else Path(spool_dir)
-            )
-            self._file_handle.truncate(self._byte_count)
-            self._mmap = mmap.mmap(self._file_handle.fileno(), self._byte_count)
-            if fill != 0:
-                self.fill(fill)
+        self._data, self._file_handle = _allocate_storage(
+            self._byte_count,
+            spool_dir=spool_dir,
+        )
+        if self._data is not None and fill != 0:
+            self.fill(fill)
 
     @property
     def typecode(self) -> str:
@@ -78,7 +117,7 @@ class MappedIntVector(Sequence[int]):
 
     @property
     def byte_count(self) -> int:
-        """Return allocated mmap bytes."""
+        """Return allocated storage bytes."""
         return 0 if self._closed else self._byte_count
 
     @property
@@ -96,15 +135,15 @@ class MappedIntVector(Sequence[int]):
             return [self[item] for item in range(*index.indices(self._length))]
 
         index = self._normalize_index(index)
-        mm = self._require_mmap()
-        return self._format.unpack_from(mm, index * self._width)[0]
+        data = self._require_storage()
+        return self._format.unpack_from(data, index * self._width)[0]
 
     def __setitem__(self, index: int, value: int) -> None:
         self._require_open()
         index = self._normalize_index(index)
         _check_unsigned(value, self._max_value)
-        mm = self._require_mmap()
-        self._format.pack_into(mm, index * self._width, value)
+        data = self._require_storage()
+        self._format.pack_into(data, index * self._width, value)
 
     def fill(self, value: int) -> None:
         """Set every slot to one unsigned value."""
@@ -113,7 +152,7 @@ class MappedIntVector(Sequence[int]):
         if self._length == 0:
             return
 
-        mm = self._require_mmap()
+        data = self._require_storage()
         packed = self._format.pack(value)
         repeat = max(1, _FILL_CHUNK_BYTES // self._width)
         chunk = packed * min(self._length, repeat)
@@ -123,21 +162,18 @@ class MappedIntVector(Sequence[int]):
         while remaining:
             count = min(remaining, len(chunk) // self._width)
             byte_count = count * self._width
-            mm[offset:offset + byte_count] = chunk[:byte_count]
+            data[offset:offset + byte_count] = chunk[:byte_count]
             offset += byte_count
             remaining -= count
 
     def close(self) -> None:
-        """Close mmap and temporary file resources."""
+        """Close storage resources."""
         if self._closed:
             return
 
-        if self._mmap is not None:
-            self._mmap.close()
-            self._mmap = None
-        if self._file_handle is not None:
-            self._file_handle.close()
-            self._file_handle = None
+        _close_storage(self._data, self._file_handle)
+        self._data = None
+        self._file_handle = None
         self._closed = True
 
     def __enter__(self) -> MappedIntVector:
@@ -160,10 +196,10 @@ class MappedIntVector(Sequence[int]):
             raise IndexError(index)
         return index
 
-    def _require_mmap(self) -> mmap.mmap:
-        if self._mmap is None:
+    def _require_storage(self) -> _StorageBuffer:
+        if self._data is None:
             raise IndexError("empty vector has no storage")
-        return self._mmap
+        return self._data
 
     def _require_open(self) -> None:
         if self._closed:
@@ -171,7 +207,7 @@ class MappedIntVector(Sequence[int]):
 
 
 class MappedRecordVector(Sequence[tuple[int, ...]]):
-    """Fixed-size record vector backed by a temporary mmap."""
+    """Fixed-size record vector."""
 
     def __init__(
         self,
@@ -188,25 +224,18 @@ class MappedRecordVector(Sequence[tuple[int, ...]]):
         if length < 0 or length > capacity:
             raise ValueError("length must fit within capacity")
 
-        if not record_format:
-            raise ValueError("record format must not be empty")
-        if record_format[0] not in "@=<>!":
-            record_format = "<" + record_format
-
-        self._struct = struct.Struct(record_format)
+        self._struct = struct.Struct(_normalize_record_format(record_format))
         self._capacity = capacity
         self._length = length
         self._byte_count = capacity * self._struct.size
         self._file_handle: BinaryIO | None = None
-        self._mmap: mmap.mmap | None = None
+        self._data: _StorageBuffer | None = None
         self._closed = False
 
-        if self._byte_count > 0:
-            self._file_handle = tempfile.TemporaryFile(
-                dir=None if spool_dir is None else Path(spool_dir)
-            )
-            self._file_handle.truncate(self._byte_count)
-            self._mmap = mmap.mmap(self._file_handle.fileno(), self._byte_count)
+        self._data, self._file_handle = _allocate_storage(
+            self._byte_count,
+            spool_dir=spool_dir,
+        )
 
     @property
     def capacity(self) -> int:
@@ -221,7 +250,7 @@ class MappedRecordVector(Sequence[tuple[int, ...]]):
 
     @property
     def byte_count(self) -> int:
-        """Return allocated mmap bytes."""
+        """Return allocated storage bytes."""
         return 0 if self._closed else self._byte_count
 
     @property
@@ -239,8 +268,8 @@ class MappedRecordVector(Sequence[tuple[int, ...]]):
             return [self[item] for item in range(*index.indices(self._length))]
 
         index = self._normalize_index(index)
-        mm = self._require_mmap()
-        return self._struct.unpack_from(mm, index * self._struct.size)
+        data = self._require_storage()
+        return self._struct.unpack_from(data, index * self._struct.size)
 
     def __setitem__(self, index: int, record: Sequence[int]) -> None:
         self._require_open()
@@ -265,16 +294,13 @@ class MappedRecordVector(Sequence[tuple[int, ...]]):
             self._write_record(index, record)
 
     def close(self) -> None:
-        """Close mmap and temporary file resources."""
+        """Close storage resources."""
         if self._closed:
             return
 
-        if self._mmap is not None:
-            self._mmap.close()
-            self._mmap = None
-        if self._file_handle is not None:
-            self._file_handle.close()
-            self._file_handle = None
+        _close_storage(self._data, self._file_handle)
+        self._data = None
+        self._file_handle = None
         self._closed = True
 
     def __enter__(self) -> MappedRecordVector:
@@ -291,8 +317,8 @@ class MappedRecordVector(Sequence[tuple[int, ...]]):
             pass
 
     def _write_record(self, index: int, record: Sequence[int]) -> None:
-        mm = self._require_mmap()
-        self._struct.pack_into(mm, index * self._struct.size, *record)
+        data = self._require_storage()
+        self._struct.pack_into(data, index * self._struct.size, *record)
 
     def _normalize_index(self, index: int) -> int:
         if index < 0:
@@ -301,10 +327,10 @@ class MappedRecordVector(Sequence[tuple[int, ...]]):
             raise IndexError(index)
         return index
 
-    def _require_mmap(self) -> mmap.mmap:
-        if self._mmap is None:
+    def _require_storage(self) -> _StorageBuffer:
+        if self._data is None:
             raise IndexError("empty record vector has no storage")
-        return self._mmap
+        return self._data
 
     def _require_open(self) -> None:
         if self._closed:
@@ -409,7 +435,7 @@ class ChunkedMappedRecordVector(Sequence[tuple[int, ...]]):
 
 
 class ManagedMappedResources:
-    """Track mapped resources and byte high-water use."""
+    """Track storage resources and byte high-water use."""
 
     def __init__(self) -> None:
         self._resources: list[object] = []
@@ -434,7 +460,7 @@ class ManagedMappedResources:
         return self._total_allocated_bytes
 
     def track(self, resource: object) -> object:
-        """Track a mapped resource for deterministic cleanup."""
+        """Track a storage resource for deterministic cleanup."""
         self._require_open()
         self._resources.append(resource)
         byte_count = _resource_byte_count(resource)

--- a/src/git_stage_batch/utils/mapped_storage.py
+++ b/src/git_stage_batch/utils/mapped_storage.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from bisect import bisect_right
 from collections.abc import Sequence
 import mmap
 import struct
@@ -338,7 +339,7 @@ class MappedRecordVector(Sequence[tuple[int, ...]]):
 
 
 class ChunkedMappedRecordVector(Sequence[tuple[int, ...]]):
-    """Append-only record vector that grows by mmap-backed chunks."""
+    """Append-only record vector that grows by fixed-width chunks."""
 
     def __init__(
         self,
@@ -354,12 +355,14 @@ class ChunkedMappedRecordVector(Sequence[tuple[int, ...]]):
         self._chunk_capacity = chunk_capacity
         self._spool_dir = spool_dir
         self._chunks: list[MappedRecordVector] = []
+        self._chunk_starts: list[int] = []
+        self._next_chunk_capacity = 1
         self._length = 0
         self._closed = False
 
     @property
     def byte_count(self) -> int:
-        """Return allocated mmap bytes across chunks."""
+        """Return allocated storage bytes across chunks."""
         if self._closed:
             return 0
         return sum(chunk.byte_count for chunk in self._chunks)
@@ -379,25 +382,43 @@ class ChunkedMappedRecordVector(Sequence[tuple[int, ...]]):
             return [self[item] for item in range(*index.indices(self._length))]
 
         index = self._normalize_index(index)
-        chunk_index, record_index = divmod(index, self._chunk_capacity)
-        return self._chunks[chunk_index][record_index]
+        chunk, record_index = self._chunk_for_index(index)
+        return chunk[record_index]
 
     def append(self, record: Sequence[int]) -> int:
         """Append a record and return its zero-based index."""
         self._require_open()
-        if self._length == len(self._chunks) * self._chunk_capacity:
-            self._chunks.append(
-                MappedRecordVector(
-                    self._chunk_capacity,
-                    self._record_format,
-                    spool_dir=self._spool_dir,
-                )
-            )
+        if not self._chunks or len(self._chunks[-1]) >= self._chunks[-1].capacity:
+            self._append_chunk()
 
         index = self._length
         self._chunks[-1].append(record)
         self._length += 1
         return index
+
+    def _append_chunk(self) -> None:
+        capacity = self._next_chunk_capacity
+        self._chunk_starts.append(self._length)
+        self._chunks.append(
+            MappedRecordVector(
+                capacity,
+                self._record_format,
+                spool_dir=self._spool_dir,
+            )
+        )
+        self._next_chunk_capacity = min(
+            self._chunk_capacity,
+            max(capacity + 1, capacity * 2),
+        )
+
+    def _chunk_for_index(self, index: int) -> tuple[MappedRecordVector, int]:
+        chunk_index = bisect_right(self._chunk_starts, index) - 1
+        if chunk_index < 0:
+            raise IndexError(index)
+        return (
+            self._chunks[chunk_index],
+            index - self._chunk_starts[chunk_index],
+        )
 
     def close(self) -> None:
         """Close every allocated chunk."""
@@ -407,6 +428,7 @@ class ChunkedMappedRecordVector(Sequence[tuple[int, ...]]):
         for chunk in self._chunks:
             chunk.close()
         self._chunks.clear()
+        self._chunk_starts.clear()
         self._closed = True
 
     def __enter__(self) -> ChunkedMappedRecordVector:

--- a/src/git_stage_batch/utils/mapped_storage.py
+++ b/src/git_stage_batch/utils/mapped_storage.py
@@ -1,9 +1,9 @@
-"""Fixed-width storage helpers that use mmap for larger allocations."""
+"""Storage helpers that use mmap for larger allocations."""
 
 from __future__ import annotations
 
 from bisect import bisect_right
-from collections.abc import Sequence
+from collections.abc import Iterable, Iterator, Sequence
 import mmap
 import struct
 import tempfile
@@ -15,7 +15,114 @@ _UINT32_MAX = (1 << 32) - 1
 _UINT64_MAX = (1 << 64) - 1
 _FILL_CHUNK_BYTES = 1024 * 1024
 MAPPED_STORAGE_OFFLOAD_SIZE_THRESHOLD = mmap.PAGESIZE
+_BytesLike = bytes | bytearray | memoryview
+_ByteStorage = bytes | mmap.mmap
 _StorageBuffer = bytearray | mmap.mmap
+
+
+def should_use_mapped_storage(byte_count: int) -> bool:
+    """Return whether a byte count should use mapped storage."""
+    return byte_count >= MAPPED_STORAGE_OFFLOAD_SIZE_THRESHOLD
+
+
+def byte_storage_from_path(path: str | Path) -> tuple[_ByteStorage, BinaryIO | None]:
+    """Load path bytes using heap memory below the mapped-storage threshold."""
+    file_path = Path(path)
+    file_handle = file_path.open("rb")
+    try:
+        byte_count = file_path.stat().st_size
+        if byte_count == 0:
+            file_handle.close()
+            return b"", None
+        if not should_use_mapped_storage(byte_count):
+            data = file_handle.read()
+            file_handle.close()
+            return data, None
+
+        return (
+            mmap.mmap(file_handle.fileno(), 0, access=mmap.ACCESS_READ),
+            file_handle,
+        )
+    except Exception:
+        file_handle.close()
+        raise
+
+
+def byte_storage_from_chunks(
+    chunks: Iterable[_BytesLike],
+    *,
+    spool_dir: str | Path | None = None,
+) -> tuple[_ByteStorage, BinaryIO | None]:
+    """Build byte storage from chunks using mapped storage above the threshold."""
+    pending_chunks: list[bytes] = []
+    byte_count = 0
+    chunk_iter = iter(chunks)
+
+    for chunk in chunk_iter:
+        chunk = _validate_byte_chunk(chunk)
+        chunk_size = _chunk_byte_count(chunk)
+        if chunk_size == 0:
+            continue
+        next_byte_count = byte_count + chunk_size
+        if should_use_mapped_storage(next_byte_count):
+            return _byte_storage_from_chunk_prefix_and_remainder(
+                pending_chunks,
+                chunk,
+                chunk_iter,
+                spool_dir=spool_dir,
+            )
+
+        byte_count = next_byte_count
+        pending_chunks.append(bytes(chunk))
+
+    if byte_count == 0:
+        return b"", None
+    return b"".join(pending_chunks), None
+
+
+def _validate_byte_chunk(chunk: _BytesLike) -> _BytesLike:
+    if isinstance(chunk, bytes):
+        return chunk
+    if isinstance(chunk, (bytearray, memoryview)):
+        return chunk
+    raise TypeError(f"expected bytes-like object, got {type(chunk).__name__}")
+
+
+def _chunk_byte_count(chunk: _BytesLike) -> int:
+    if isinstance(chunk, memoryview):
+        return chunk.nbytes
+    return len(chunk)
+
+
+def _byte_storage_from_chunk_prefix_and_remainder(
+    pending_chunks: Sequence[bytes],
+    threshold_chunk: _BytesLike,
+    remaining_chunks: Iterator[_BytesLike],
+    *,
+    spool_dir: str | Path | None = None,
+) -> tuple[_ByteStorage, BinaryIO | None]:
+    file_handle = _temporary_file(spool_dir)
+    try:
+        for chunk in pending_chunks:
+            file_handle.write(chunk)
+        file_handle.write(threshold_chunk)
+        for chunk in remaining_chunks:
+            chunk = _validate_byte_chunk(chunk)
+            file_handle.write(chunk)
+        file_handle.flush()
+        return (
+            mmap.mmap(file_handle.fileno(), 0, access=mmap.ACCESS_READ),
+            file_handle,
+        )
+    except Exception:
+        file_handle.close()
+        raise
+
+
+def _temporary_file(spool_dir: str | Path | None = None) -> BinaryIO:
+    return tempfile.TemporaryFile(
+        dir=None if spool_dir is None else Path(spool_dir)
+    )
 
 
 def _normalize_width(width: int) -> int:
@@ -56,12 +163,10 @@ def _allocate_storage(
 ) -> tuple[_StorageBuffer | None, BinaryIO | None]:
     if byte_count <= 0:
         return None, None
-    if byte_count < MAPPED_STORAGE_OFFLOAD_SIZE_THRESHOLD:
+    if not should_use_mapped_storage(byte_count):
         return bytearray(byte_count), None
 
-    file_handle = tempfile.TemporaryFile(
-        dir=None if spool_dir is None else Path(spool_dir)
-    )
+    file_handle = _temporary_file(spool_dir)
     try:
         file_handle.truncate(byte_count)
         return mmap.mmap(file_handle.fileno(), byte_count), file_handle

--- a/tests/batch/test_match_storage.py
+++ b/tests/batch/test_match_storage.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+import mmap
 import os
 
 import pytest
 
+import git_stage_batch.utils.mapped_storage as mapped_storage_module
 from git_stage_batch.batch.match_storage import MatcherWorkspace
-from git_stage_batch.utils.mapped_storage import MappedIntVector, MappedRecordVector
+from git_stage_batch.utils.mapped_storage import (
+    MappedIntVector,
+    MappedRecordVector,
+)
 
 
 def _open_fd_count() -> int | None:
@@ -39,6 +44,46 @@ def test_mapped_int_vector_get_set_fill_and_close():
         vector[0]
 
 
+def test_less_than_page_mapped_int_vector_uses_heap(monkeypatch):
+    """Integer vectors smaller than one memory page should stay heap-backed."""
+    def fail_temporary_file(*args, **kwargs):
+        raise AssertionError("small vector should use heap storage")
+
+    monkeypatch.setattr(
+        mapped_storage_module.tempfile,
+        "TemporaryFile",
+        fail_temporary_file,
+    )
+
+    vector = MappedIntVector(4, width=4, fill=7)
+
+    assert vector.byte_count < mmap.PAGESIZE
+    assert list(vector) == [7, 7, 7, 7]
+
+
+def test_page_sized_mapped_int_vector_uses_mmap(monkeypatch):
+    """Page-sized integer vectors still use temporary mmap storage."""
+    calls = 0
+    original_temporary_file = mapped_storage_module.tempfile.TemporaryFile
+
+    def counting_temporary_file(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return original_temporary_file(*args, **kwargs)
+
+    monkeypatch.setattr(
+        mapped_storage_module.tempfile,
+        "TemporaryFile",
+        counting_temporary_file,
+    )
+
+    with MappedIntVector(mmap.PAGESIZE // 8, width=8, fill=3) as vector:
+        assert vector.byte_count == mmap.PAGESIZE
+        assert vector[0] == 3
+
+    assert calls == 1
+
+
 def test_mapped_int_vector_uses_64_bit_slots():
     """Mapped integer vectors store values past the 32-bit range."""
     value = (1 << 40) + 3
@@ -67,6 +112,24 @@ def test_mapped_record_vector_append_and_indexed_write():
     records.close()
     with pytest.raises(ValueError, match="closed"):
         len(records)
+
+
+def test_less_than_page_mapped_record_vector_uses_heap(monkeypatch):
+    """Record vectors smaller than one memory page should stay heap-backed."""
+    def fail_temporary_file(*args, **kwargs):
+        raise AssertionError("small record vector should use heap storage")
+
+    monkeypatch.setattr(
+        mapped_storage_module.tempfile,
+        "TemporaryFile",
+        fail_temporary_file,
+    )
+
+    records = MappedRecordVector(3, "QQ")
+    records.append((1, 2))
+
+    assert records.byte_count < mmap.PAGESIZE
+    assert records[0] == (1, 2)
 
 
 def test_mapped_record_vector_can_start_presized():

--- a/tests/batch/test_match_storage.py
+++ b/tests/batch/test_match_storage.py
@@ -10,6 +10,7 @@ import pytest
 import git_stage_batch.utils.mapped_storage as mapped_storage_module
 from git_stage_batch.batch.match_storage import MatcherWorkspace
 from git_stage_batch.utils.mapped_storage import (
+    ChunkedMappedRecordVector,
     MappedIntVector,
     MappedRecordVector,
 )
@@ -138,6 +139,30 @@ def test_mapped_record_vector_can_start_presized():
         records[0] = (10, 20)
         records[1] = (30, 40)
         assert list(records) == [(10, 20), (30, 40)]
+
+
+def test_chunked_mapped_record_vector_grows_from_small_chunks():
+    """Chunked vectors should avoid allocating the full chunk up front."""
+    records = ChunkedMappedRecordVector(
+        record_format="QQ",
+        chunk_capacity=4,
+    )
+
+    for value in range(8):
+        records.append((value, value + 10))
+
+    byte_count = records.byte_count
+
+    assert byte_count < mmap.PAGESIZE
+    assert records._chunk_starts == [0, 1, 3, 7]
+    assert records[0] == (0, 10)
+    assert records[1] == (1, 11)
+    assert records[2] == (2, 12)
+    assert records[3] == (3, 13)
+    assert records[6] == (6, 16)
+    assert records[7] == (7, 17)
+
+    records.close()
 
 
 def test_matcher_workspace_tracks_and_closes_resources():

--- a/tests/batch/test_match_storage.py
+++ b/tests/batch/test_match_storage.py
@@ -13,7 +13,16 @@ from git_stage_batch.utils.mapped_storage import (
     ChunkedMappedRecordVector,
     MappedIntVector,
     MappedRecordVector,
+    byte_storage_from_chunks,
+    byte_storage_from_path,
 )
+
+
+class _CopyFailingBytearray(bytearray):
+    """Bytearray test double that fails if converted through bytes()."""
+
+    def __bytes__(self):
+        raise AssertionError("chunk should stream without being copied")
 
 
 def _open_fd_count() -> int | None:
@@ -21,6 +30,78 @@ def _open_fd_count() -> int | None:
     if not os.path.isdir(fd_path):
         return None
     return len(os.listdir(fd_path))
+
+
+def test_byte_storage_from_path_uses_heap_below_threshold(tmp_path, monkeypatch):
+    """Small path byte storage should stay heap-backed."""
+    def fail_temporary_file(*args, **kwargs):
+        raise AssertionError("small path storage should use heap storage")
+
+    monkeypatch.setattr(
+        mapped_storage_module.tempfile,
+        "TemporaryFile",
+        fail_temporary_file,
+    )
+
+    file_path = tmp_path / "small.txt"
+    file_path.write_bytes(b"alpha\n")
+
+    data, file_handle = byte_storage_from_path(file_path)
+
+    assert file_handle is None
+    assert data == b"alpha\n"
+    assert not isinstance(data, mmap.mmap)
+
+
+def test_byte_storage_from_path_uses_mapped_storage_at_threshold(tmp_path):
+    """Page-sized path byte storage should use mapped storage."""
+    file_path = tmp_path / "page.txt"
+    file_path.write_bytes(b"x" * mmap.PAGESIZE)
+
+    data, file_handle = byte_storage_from_path(file_path)
+    try:
+        assert isinstance(data, mmap.mmap)
+        assert file_handle is not None
+        assert data[:4] == b"xxxx"
+    finally:
+        data.close()
+        assert file_handle is not None
+        file_handle.close()
+
+
+def test_byte_storage_from_chunks_copies_small_mutable_chunks():
+    """Small chunk byte storage should copy mutable chunks."""
+    chunk = bytearray(b"alpha\n")
+
+    data, file_handle = byte_storage_from_chunks([chunk])
+    chunk[:] = b"omega\n"
+
+    assert file_handle is None
+    assert data == b"alpha\n"
+
+
+def test_byte_storage_from_chunks_streams_large_chunks_without_copying():
+    """Large chunk byte storage should stream chunks directly."""
+    prefix = b"alpha\n"
+    threshold_chunk = _CopyFailingBytearray(
+        b"x" * (mmap.PAGESIZE - len(prefix))
+    )
+    remaining_chunk = _CopyFailingBytearray(b"omega\n")
+
+    data, file_handle = byte_storage_from_chunks([
+        prefix,
+        threshold_chunk,
+        remaining_chunk,
+    ])
+    try:
+        assert isinstance(data, mmap.mmap)
+        assert file_handle is not None
+        assert data[:len(prefix)] == prefix
+        assert data[-len(remaining_chunk):] == bytes(bytearray(remaining_chunk))
+    finally:
+        data.close()
+        assert file_handle is not None
+        file_handle.close()
 
 
 def test_mapped_int_vector_get_set_fill_and_close():

--- a/tests/batch/test_storage_duplication.py
+++ b/tests/batch/test_storage_duplication.py
@@ -117,7 +117,7 @@ def test_build_realized_buffer_from_lines_returns_buffer():
         ownership,
     ) as result:
         assert result.to_bytes() == b"A\r\nNEW\r\nB\r\n"
-        assert result.is_mmap_backed
+        assert result.byte_count == len(b"A\r\nNEW\r\nB\r\n")
 
 
 def test_build_realized_content_equal_block_with_unclaimed_insert():

--- a/tests/editor/test_buffer.py
+++ b/tests/editor/test_buffer.py
@@ -234,7 +234,7 @@ def test_editor_buffer_uses_heap_for_files_smaller_than_memory_page(tmp_path):
     file_path.write_bytes(b"alpha\nbeta\n")
 
     with EditorBuffer.from_path(file_path) as buffer:
-        assert buffer.is_mmap_backed is False
+        assert buffer.uses_mapped_storage is False
         assert buffer.byte_count == len(b"alpha\nbeta\n")
         assert list(buffer.byte_chunks(5)) == [b"alpha", b"\nbeta", b"\n"]
         assert buffer.to_bytes() == b"alpha\nbeta\n"
@@ -242,14 +242,14 @@ def test_editor_buffer_uses_heap_for_files_smaller_than_memory_page(tmp_path):
         assert buffer[1] == b"beta\n"
 
 
-def test_editor_buffer_is_mmap_backed_for_page_sized_files(tmp_path):
+def test_editor_buffer_uses_mapped_storage_for_page_sized_files(tmp_path):
     """Page-sized file buffers use mapped storage."""
     data = b"alpha\n" + b"x" * (mmap.PAGESIZE - len(b"alpha\n"))
     file_path = tmp_path / "buffer.txt"
     file_path.write_bytes(data)
 
     with EditorBuffer.from_path(file_path) as buffer:
-        assert buffer.is_mmap_backed is True
+        assert buffer.uses_mapped_storage is True
         assert buffer.byte_count == mmap.PAGESIZE
         assert buffer[0] == b"alpha\n"
         assert buffer[1] == b"x" * (mmap.PAGESIZE - len(b"alpha\n"))
@@ -261,7 +261,7 @@ def test_editor_buffer_skips_mapped_storage_for_empty_files(tmp_path):
     file_path.write_bytes(b"")
 
     with EditorBuffer.from_path(file_path) as buffer:
-        assert buffer.is_mmap_backed is False
+        assert buffer.uses_mapped_storage is False
         assert len(buffer) == 0
 
 
@@ -270,7 +270,7 @@ def test_editor_buffer_uses_heap_for_generated_chunks_smaller_than_page():
     chunks = iter([b"alpha\nbe", b"ta\n", memoryview(b"gamma")])
 
     with EditorBuffer.from_chunks(chunks) as buffer:
-        assert buffer.is_mmap_backed is False
+        assert buffer.uses_mapped_storage is False
         assert len(buffer) == 3
         assert buffer[0] == b"alpha\n"
         assert buffer[1] == b"beta\n"
@@ -296,7 +296,7 @@ def test_editor_buffer_spools_page_sized_generated_chunks_to_mapped_storage():
     ])
 
     with EditorBuffer.from_chunks(chunks) as buffer:
-        assert buffer.is_mmap_backed is True
+        assert buffer.uses_mapped_storage is True
         assert buffer.byte_count == mmap.PAGESIZE
         assert buffer[0] == b"alpha\n"
         assert buffer[1] == b"beta\n"
@@ -304,26 +304,26 @@ def test_editor_buffer_spools_page_sized_generated_chunks_to_mapped_storage():
 
 
 def test_editor_buffer_streams_threshold_chunk_without_copying():
-    """The chunk that reaches the mmap threshold is streamed directly."""
+    """The chunk that reaches the mapped-storage threshold streams directly."""
     prefix = b"alpha\n"
     threshold_chunk = _CopyFailingBytearray(
         b"x" * (mmap.PAGESIZE - len(prefix))
     )
 
     with EditorBuffer.from_chunks([prefix, threshold_chunk]) as buffer:
-        assert buffer.is_mmap_backed is True
+        assert buffer.uses_mapped_storage is True
         assert buffer.byte_count == mmap.PAGESIZE
         assert buffer[0] == prefix
         assert buffer[1] == bytes(bytearray(threshold_chunk))
 
 
 def test_editor_buffer_streams_remaining_large_chunks_without_copying():
-    """Chunks after the mmap threshold are streamed directly."""
+    """Chunks after the mapped-storage threshold stream directly."""
     threshold_chunk = b"x" * mmap.PAGESIZE
     remaining_chunk = _CopyFailingBytearray(b"omega\n")
 
     with EditorBuffer.from_chunks([threshold_chunk, remaining_chunk]) as buffer:
-        assert buffer.is_mmap_backed is True
+        assert buffer.uses_mapped_storage is True
         assert buffer.byte_count == mmap.PAGESIZE + len(remaining_chunk)
         assert buffer[0] == threshold_chunk + b"omega\n"
 
@@ -331,7 +331,7 @@ def test_editor_buffer_streams_remaining_large_chunks_without_copying():
 def test_editor_buffer_handles_empty_generated_chunks():
     """Empty generated buffers have no byte lines."""
     with EditorBuffer.from_chunks([]) as buffer:
-        assert buffer.is_mmap_backed is False
+        assert buffer.uses_mapped_storage is False
         assert len(buffer) == 0
 
 

--- a/tests/editor/test_buffer.py
+++ b/tests/editor/test_buffer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import mmap
 from collections.abc import Sequence
 
 import pytest
@@ -15,6 +16,13 @@ from git_stage_batch.editor import (
     buffer_preview,
     write_buffer_to_path,
 )
+
+
+class _CopyFailingBytearray(bytearray):
+    """Bytearray test double that fails if converted through bytes()."""
+
+    def __bytes__(self):
+        raise AssertionError("chunk should stream without being copied")
 
 
 def test_editor_buffer_indexes_in_memory_lines():
@@ -220,13 +228,13 @@ def test_buffer_matches_buffers():
         assert buffer_matches(left, right) is True
 
 
-def test_editor_buffer_uses_mmap_for_non_empty_files(tmp_path):
-    """Non-empty file buffers are backed by mmap."""
+def test_editor_buffer_uses_heap_for_files_smaller_than_memory_page(tmp_path):
+    """Small file buffers stay on the Python heap."""
     file_path = tmp_path / "buffer.txt"
     file_path.write_bytes(b"alpha\nbeta\n")
 
     with EditorBuffer.from_path(file_path) as buffer:
-        assert buffer.is_mmap_backed is True
+        assert buffer.is_mmap_backed is False
         assert buffer.byte_count == len(b"alpha\nbeta\n")
         assert list(buffer.byte_chunks(5)) == [b"alpha", b"\nbeta", b"\n"]
         assert buffer.to_bytes() == b"alpha\nbeta\n"
@@ -234,8 +242,21 @@ def test_editor_buffer_uses_mmap_for_non_empty_files(tmp_path):
         assert buffer[1] == b"beta\n"
 
 
-def test_editor_buffer_skips_mmap_for_empty_files(tmp_path):
-    """Empty files cannot be mmap-backed but still expose an empty buffer."""
+def test_editor_buffer_is_mmap_backed_for_page_sized_files(tmp_path):
+    """Page-sized file buffers use mapped storage."""
+    data = b"alpha\n" + b"x" * (mmap.PAGESIZE - len(b"alpha\n"))
+    file_path = tmp_path / "buffer.txt"
+    file_path.write_bytes(data)
+
+    with EditorBuffer.from_path(file_path) as buffer:
+        assert buffer.is_mmap_backed is True
+        assert buffer.byte_count == mmap.PAGESIZE
+        assert buffer[0] == b"alpha\n"
+        assert buffer[1] == b"x" * (mmap.PAGESIZE - len(b"alpha\n"))
+
+
+def test_editor_buffer_skips_mapped_storage_for_empty_files(tmp_path):
+    """Empty files do not use mapped storage but still expose an empty buffer."""
     file_path = tmp_path / "empty.txt"
     file_path.write_bytes(b"")
 
@@ -244,16 +265,67 @@ def test_editor_buffer_skips_mmap_for_empty_files(tmp_path):
         assert len(buffer) == 0
 
 
-def test_editor_buffer_spools_generated_chunks_to_mmap():
-    """Generated chunks are spooled to an mmap-backed buffer."""
+def test_editor_buffer_uses_heap_for_generated_chunks_smaller_than_page():
+    """Small generated buffers stay on the Python heap."""
     chunks = iter([b"alpha\nbe", b"ta\n", memoryview(b"gamma")])
 
     with EditorBuffer.from_chunks(chunks) as buffer:
-        assert buffer.is_mmap_backed is True
+        assert buffer.is_mmap_backed is False
         assert len(buffer) == 3
         assert buffer[0] == b"alpha\n"
         assert buffer[1] == b"beta\n"
         assert buffer[2] == b"gamma"
+
+
+def test_editor_buffer_copies_small_generated_chunks_for_heap_storage():
+    """Small mutable generated chunks are copied before storage."""
+    chunk = bytearray(b"alpha\n")
+
+    with EditorBuffer.from_chunks([chunk]) as buffer:
+        chunk[:] = b"omega\n"
+        assert buffer.to_bytes() == b"alpha\n"
+
+
+def test_editor_buffer_spools_page_sized_generated_chunks_to_mapped_storage():
+    """Page-sized generated buffers are spooled to mapped storage."""
+    prefix = b"alpha\nbeta\n"
+    chunks = iter([
+        prefix[:7],
+        prefix[7:],
+        memoryview(b"x" * (mmap.PAGESIZE - len(prefix))),
+    ])
+
+    with EditorBuffer.from_chunks(chunks) as buffer:
+        assert buffer.is_mmap_backed is True
+        assert buffer.byte_count == mmap.PAGESIZE
+        assert buffer[0] == b"alpha\n"
+        assert buffer[1] == b"beta\n"
+        assert buffer[2] == b"x" * (mmap.PAGESIZE - len(prefix))
+
+
+def test_editor_buffer_streams_threshold_chunk_without_copying():
+    """The chunk that reaches the mmap threshold is streamed directly."""
+    prefix = b"alpha\n"
+    threshold_chunk = _CopyFailingBytearray(
+        b"x" * (mmap.PAGESIZE - len(prefix))
+    )
+
+    with EditorBuffer.from_chunks([prefix, threshold_chunk]) as buffer:
+        assert buffer.is_mmap_backed is True
+        assert buffer.byte_count == mmap.PAGESIZE
+        assert buffer[0] == prefix
+        assert buffer[1] == bytes(bytearray(threshold_chunk))
+
+
+def test_editor_buffer_streams_remaining_large_chunks_without_copying():
+    """Chunks after the mmap threshold are streamed directly."""
+    threshold_chunk = b"x" * mmap.PAGESIZE
+    remaining_chunk = _CopyFailingBytearray(b"omega\n")
+
+    with EditorBuffer.from_chunks([threshold_chunk, remaining_chunk]) as buffer:
+        assert buffer.is_mmap_backed is True
+        assert buffer.byte_count == mmap.PAGESIZE + len(remaining_chunk)
+        assert buffer[0] == threshold_chunk + b"omega\n"
 
 
 def test_editor_buffer_handles_empty_generated_chunks():

--- a/tests/editor/test_git_buffer.py
+++ b/tests/editor/test_git_buffer.py
@@ -16,7 +16,7 @@ from git_stage_batch.editor import (
 from git_stage_batch.utils.git import GitTreeBlob
 
 
-def test_load_git_blob_as_buffer_spools_streamed_blob(monkeypatch):
+def test_load_git_blob_as_buffer_loads_streamed_blob(monkeypatch):
     """Git blob buffers are loaded from streamed blob chunks."""
     calls = []
 
@@ -28,7 +28,7 @@ def test_load_git_blob_as_buffer_spools_streamed_blob(monkeypatch):
 
     with load_git_blob_as_buffer("abc123") as buffer:
         assert calls == ["abc123"]
-        assert buffer.is_mmap_backed is True
+        assert buffer.is_mmap_backed is False
         assert buffer[1] == b"beta\n"
 
 
@@ -59,7 +59,7 @@ def test_load_git_tree_files_as_buffers_loads_tree_blobs(monkeypatch):
             buffer.close()
 
 
-def test_load_git_object_as_buffer_spools_streamed_output(monkeypatch):
+def test_load_git_object_as_buffer_loads_streamed_output(monkeypatch):
     """Git object buffers are loaded from streamed command output."""
     calls = []
 
@@ -71,7 +71,7 @@ def test_load_git_object_as_buffer_spools_streamed_output(monkeypatch):
 
     with load_git_object_as_buffer("HEAD:file.txt") as buffer:
         assert calls == ["HEAD:file.txt"]
-        assert buffer.is_mmap_backed is True
+        assert buffer.is_mmap_backed is False
         assert buffer[1] == b"beta\n"
 
 
@@ -115,7 +115,7 @@ def test_load_working_tree_file_as_buffer_uses_repository_root(monkeypatch, tmp_
     monkeypatch.setattr(editor_git, "get_git_repository_root_path", lambda: tmp_path)
 
     with load_working_tree_file_as_buffer("dir/file.txt") as buffer:
-        assert buffer.is_mmap_backed is True
+        assert buffer.is_mmap_backed is False
         assert buffer[0] == b"alpha\n"
         assert buffer[1] == b"beta\n"
 

--- a/tests/editor/test_git_buffer.py
+++ b/tests/editor/test_git_buffer.py
@@ -28,7 +28,7 @@ def test_load_git_blob_as_buffer_loads_streamed_blob(monkeypatch):
 
     with load_git_blob_as_buffer("abc123") as buffer:
         assert calls == ["abc123"]
-        assert buffer.is_mmap_backed is False
+        assert buffer.uses_mapped_storage is False
         assert buffer[1] == b"beta\n"
 
 
@@ -71,7 +71,7 @@ def test_load_git_object_as_buffer_loads_streamed_output(monkeypatch):
 
     with load_git_object_as_buffer("HEAD:file.txt") as buffer:
         assert calls == ["HEAD:file.txt"]
-        assert buffer.is_mmap_backed is False
+        assert buffer.uses_mapped_storage is False
         assert buffer[1] == b"beta\n"
 
 
@@ -115,7 +115,7 @@ def test_load_working_tree_file_as_buffer_uses_repository_root(monkeypatch, tmp_
     monkeypatch.setattr(editor_git, "get_git_repository_root_path", lambda: tmp_path)
 
     with load_working_tree_file_as_buffer("dir/file.txt") as buffer:
-        assert buffer.is_mmap_backed is False
+        assert buffer.uses_mapped_storage is False
         assert buffer[0] == b"alpha\n"
         assert buffer[1] == b"beta\n"
 


### PR DESCRIPTION
EditorBuffer and fixed-width storage helpers currently use mapped storage for most positive-size allocations. That is useful for larger data, but small buffers can still pay a full page of mapped storage plus temporary-file setup for only a few bytes.

This pull request introduces a shared one-page offload threshold. Fixed-width integer and record vectors use bytearray storage below one memory page and mapped storage at one page or above. Chunked record vectors grow from small chunks before reaching their configured maximum chunk size, so small line-span tables, compact run tables, and matcher scratch data avoid a large first chunk.

The byte-storage builders now live in `mapped_storage.py`, and EditorBuffer uses them for file and generated chunk content. Small files and small generated buffers stay on the Python heap. Page-sized and larger inputs use mapped storage, and generated chunks that cross the threshold are streamed through the buffer protocol instead of being converted through `bytes()` first.

Commit split:
- `storage: Keep small fixed vectors on heap`
- `tests: Add small fixed vector tests`
- `storage: Grow record chunks gradually`
- `tests: Add gradual chunk growth test`
- `storage: Add thresholded byte storage builders`
- `tests: Add byte storage builder tests`
- `editor: Build buffers through shared storage`
- `tests: Add small editor buffer tests`
- `editor: Rename mapped storage accessor`
- `tests: Update mapped storage accessor tests`

Verification:
- `git diff --check origin/main..HEAD`
- `PYTHONPATH=src uv run pytest tests/batch/test_match_storage.py tests/editor/test_buffer.py tests/editor/test_git_buffer.py tests/batch/test_storage_duplication.py`
- `PYTHONPATH=src uv run pytest -n auto`