### PR TITLE
reset/display: Store selectable line IDs as ranges

### DIFF
--- a/src/git_stage_batch/batch/ownership.py
+++ b/src/git_stage_batch/batch/ownership.py
@@ -10,7 +10,6 @@ from hashlib import sha256
 from ..core.line_selection import (
     LineRanges,
     LineSelection,
-    format_line_ids,
 )
 from ..core.models import LineEntry
 from ..data.batch_sources import create_batch_source_commit
@@ -1643,7 +1642,7 @@ class OwnershipUnit:
 
     Attributes:
         kind: Type of ownership unit
-        claimed_source_lines: Set of batch source line numbers owned by this unit
+        claimed_source_lines: Batch source line numbers owned by this unit
         deletion_claims: Absence claims that are part of this unit
         display_line_ids: Display line IDs that map to this unit (from reconstructed display)
         is_atomic: If True, partial removal is not allowed
@@ -1651,9 +1650,9 @@ class OwnershipUnit:
         preserves_replacement_unit: True when this unit came from persisted replacement metadata
     """
     kind: OwnershipUnitKind
-    claimed_source_lines: set[int]
+    claimed_source_lines: LineRanges
     deletion_claims: list[AbsenceClaim]
-    display_line_ids: set[int]
+    display_line_ids: LineRanges
     is_atomic: bool = False
     atomic_reason: str | None = None
     preserves_replacement_unit: bool = False
@@ -1808,9 +1807,9 @@ def build_ownership_units_from_display_lines(
                 # One unit per line allows independent reset
                 units.append(OwnershipUnit(
                     kind=OwnershipUnitKind.PRESENCE_ONLY,
-                    claimed_source_lines={claimed_source_line},
+                    claimed_source_lines=LineRanges.from_lines([claimed_source_line]),
                     deletion_claims=[],
-                    display_line_ids={claimed_display_id},
+                    display_line_ids=LineRanges.from_lines([claimed_display_id]),
                     is_atomic=False,
                     atomic_reason=None
                 ))
@@ -1823,18 +1822,16 @@ def build_ownership_units_from_display_lines(
 
 def _ownership_unit_display_order_key(unit: OwnershipUnit) -> int:
     """Return the first visible display line covered by a semantic unit."""
-    if not unit.display_line_ids:
-        return 10**12
-    return min(unit.display_line_ids)
+    return unit.display_line_ids.first() or 10**12
 
 
 def _build_explicit_replacement_units_from_display_lines(
     ownership: BatchOwnership,
     display_lines: list[dict],
-) -> tuple[list[OwnershipUnit], set[int], set[int]]:
+) -> tuple[list[OwnershipUnit], LineRanges, set[int]]:
     """Build units from persisted replacement metadata."""
     units: list[OwnershipUnit] = []
-    consumed_claimed_lines: set[int] = set()
+    consumed_claimed_lines = LineRanges.empty()
     consumed_deletion_indices: set[int] = set()
 
     replacement_units = _normalize_replacement_units(
@@ -1845,10 +1842,10 @@ def _build_explicit_replacement_units_from_display_lines(
         return units, consumed_claimed_lines, consumed_deletion_indices
 
     for replacement_unit in replacement_units:
-        claimed_source_lines = _parse_line_ranges(replacement_unit.presence_lines).to_set()
+        claimed_source_lines = _parse_line_ranges(replacement_unit.presence_lines)
         deletion_indices = set(replacement_unit.deletion_indices)
-        claimed_display_ids: set[int] = set()
-        deletion_display_ids: set[int] = set()
+        claimed_display_id_builder = _LineRangeBuilder()
+        deletion_display_id_builder = _LineRangeBuilder()
 
         for display_line in display_lines:
             display_id = display_line.get("id")
@@ -1859,13 +1856,15 @@ def _build_explicit_replacement_units_from_display_lines(
                 display_line["type"] == "claimed"
                 and display_line["source_line"] in claimed_source_lines
             ):
-                claimed_display_ids.add(display_id)
+                claimed_display_id_builder.add_line(display_id)
             elif (
                 display_line["type"] == "deletion"
                 and display_line["deletion_index"] in deletion_indices
             ):
-                deletion_display_ids.add(display_id)
+                deletion_display_id_builder.add_line(display_id)
 
+        claimed_display_ids = claimed_display_id_builder.finish()
+        deletion_display_ids = deletion_display_id_builder.finish()
         if not claimed_display_ids or not deletion_display_ids:
             continue
 
@@ -1877,12 +1876,12 @@ def _build_explicit_replacement_units_from_display_lines(
             kind=OwnershipUnitKind.REPLACEMENT,
             claimed_source_lines=claimed_source_lines,
             deletion_claims=deletion_claims,
-            display_line_ids=claimed_display_ids | deletion_display_ids,
+            display_line_ids=claimed_display_ids.union(deletion_display_ids),
             is_atomic=True,
             atomic_reason="explicit_replacement",
             preserves_replacement_unit=True,
         ))
-        consumed_claimed_lines.update(claimed_source_lines)
+        consumed_claimed_lines = consumed_claimed_lines.union(claimed_source_lines)
         consumed_deletion_indices.update(deletion_indices)
 
     return units, consumed_claimed_lines, consumed_deletion_indices
@@ -1890,7 +1889,7 @@ def _build_explicit_replacement_units_from_display_lines(
 
 def _display_line_is_consumed(
     display_line: dict,
-    consumed_claimed_lines: set[int],
+    consumed_claimed_lines: LineSelection,
     consumed_deletion_indices: set[int],
 ) -> bool:
     """Return True when a display line is already covered by an explicit unit."""
@@ -1905,7 +1904,7 @@ def _collect_display_run(
     display_lines: list,
     start_index: int,
     expected_type: str,
-    consumed_claimed_lines: set[int],
+    consumed_claimed_lines: LineSelection,
     consumed_deletion_indices: set[int],
 ) -> dict:
     """Collect a consecutive run of display lines of the same type.
@@ -1975,9 +1974,11 @@ def _build_replacement_unit(
 
     return OwnershipUnit(
         kind=OwnershipUnitKind.REPLACEMENT,
-        claimed_source_lines=set(claimed_run["source_lines"]),
+        claimed_source_lines=LineRanges.from_lines(claimed_run["source_lines"]),
         deletion_claims=deletion_claims,
-        display_line_ids=set(deletion_run["display_ids"] + claimed_run["display_ids"]),
+        display_line_ids=LineRanges.from_lines(
+            [*deletion_run["display_ids"], *claimed_run["display_ids"]]
+        ),
         is_atomic=True,
         atomic_reason="display_adjacency"
     )
@@ -2003,9 +2004,9 @@ def _build_deletion_only_unit(
 
     return OwnershipUnit(
         kind=OwnershipUnitKind.DELETION_ONLY,
-        claimed_source_lines=set(),
+        claimed_source_lines=LineRanges.empty(),
         deletion_claims=deletion_claims,
-        display_line_ids=set(deletion_run["display_ids"]),
+        display_line_ids=LineRanges.from_lines(deletion_run["display_ids"]),
         is_atomic=True,
         atomic_reason="deletion_only"
     )
@@ -2053,7 +2054,7 @@ def validate_ownership_units(units: list[OwnershipUnit]) -> None:
 
 def select_ownership_units_by_display_ids(
     units: list[OwnershipUnit],
-    selected_display_ids: set[int]
+    selected_display_ids: LineSelection | Iterable[int],
 ) -> list[OwnershipUnit]:
     """Select ownership units that match the given display line IDs.
 
@@ -2070,10 +2071,15 @@ def select_ownership_units_by_display_ids(
         MergeError: If atomic unit is partially selected
     """
     selected = []
+    selected_display_ranges = (
+        selected_display_ids
+        if isinstance(selected_display_ids, LineRanges)
+        else LineRanges.from_lines(selected_display_ids)
+    )
 
     for unit in units:
         # Check if any display IDs from this unit are selected
-        intersection = unit.display_line_ids & selected_display_ids
+        intersection = unit.display_line_ids.intersection(selected_display_ranges)
 
         if not intersection:
             # Not selected - skip it
@@ -2084,8 +2090,8 @@ def select_ownership_units_by_display_ids(
                 _("Cannot select only part of this change.\n"
                   "Select all related lines together: {required_ids}\n"
                   "You selected: {selected_ids}").format(
-                    required_ids=format_line_ids(sorted(unit.display_line_ids)),
-                    selected_ids=format_line_ids(sorted(intersection))
+                    required_ids=unit.display_line_ids.to_line_spec(),
+                    selected_ids=intersection.to_line_spec()
                 ),
                 required_selection_ids=unit.display_line_ids,
                 unit_kind=unit.kind.value
@@ -2099,7 +2105,7 @@ def select_ownership_units_by_display_ids(
 
 def filter_ownership_units_by_display_ids(
     units: list[OwnershipUnit],
-    selected_display_ids: set[int]
+    selected_display_ids: LineSelection | Iterable[int],
 ) -> tuple[list[OwnershipUnit], list[OwnershipUnit]]:
     """Filter ownership units, removing those that match display line IDs.
 
@@ -2131,12 +2137,12 @@ def rebuild_ownership_from_units(units: list[OwnershipUnit]) -> BatchOwnership:
     Returns:
         New BatchOwnership with combined ownership from all units
     """
-    all_presence_lines = set()
+    all_presence_lines = LineRanges.empty()
     all_deletions = []
     replacement_units: list[ReplacementUnit] = []
 
     for unit in units:
-        all_presence_lines.update(unit.claimed_source_lines)
+        all_presence_lines = all_presence_lines.union(unit.claimed_source_lines)
         deletion_indices = []
         for deletion in unit.deletion_claims:
             all_deletions.append(deletion)

--- a/src/git_stage_batch/batch/selection.py
+++ b/src/git_stage_batch/batch/selection.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator, Sequence
+from collections.abc import Iterable, Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import replace
 from typing import TYPE_CHECKING, Optional
@@ -14,7 +14,7 @@ from .ownership import (
     validate_ownership_units,
     rebuild_ownership_from_units,
 )
-from ..core.line_selection import parse_line_selection
+from ..core.line_selection import LineRanges, LineSelection, parse_line_selection
 from ..exceptions import exit_with_error
 from ..i18n import _
 from ..utils.file_patterns import resolve_gitignore_style_patterns
@@ -62,15 +62,25 @@ def missing_requested_display_ids(
 
 
 def require_display_ids_available(
-    requested_ids: set[int],
-    available_ids: set[int],
+    requested_ids: LineSelection | Iterable[int],
+    available_ids: LineSelection | Iterable[int],
     *,
     line_id_specification: str,
     file_path: str,
     review_command: str | None = None,
 ) -> None:
     """Reject a line selection if any requested display ID is unavailable."""
-    if requested_ids - available_ids:
+    requested_ranges = (
+        requested_ids
+        if isinstance(requested_ids, LineRanges)
+        else LineRanges.from_lines(requested_ids)
+    )
+    available_ranges = (
+        available_ids
+        if isinstance(available_ids, LineRanges)
+        else LineRanges.from_lines(available_ids)
+    )
+    if requested_ranges.difference(available_ranges):
         exit_with_error(
             line_selection_not_valid_message(
                 line_id_specification=line_id_specification,

--- a/src/git_stage_batch/commands/reset.py
+++ b/src/git_stage_batch/commands/reset.py
@@ -8,7 +8,7 @@ import sys
 from collections.abc import Sequence
 from contextlib import AbstractContextManager
 
-from ..core.line_selection import format_line_ids
+from ..core.line_selection import LineRanges, format_line_ids
 from ..batch.operations import create_batch
 from ..batch.ownership import (
     BatchOwnership,
@@ -569,11 +569,11 @@ def _partition_line_ownership_units(
         ownership,
         batch_source_lines,
     )
-    available_ids = {
-        display_id
+    available_ids = LineRanges.from_ranges(
+        display_id_range
         for unit in units
-        for display_id in unit.display_line_ids
-    }
+        for display_id_range in unit.display_line_ids.ranges()
+    )
     require_display_ids_available(
         selected_line_ids,
         available_ids,

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -54,7 +54,7 @@ from ..editor import (
     load_working_tree_file_as_buffer,
     write_buffer_to_path,
 )
-from ..core.line_selection import write_line_ids_file
+from ..core.line_selection import LineRanges, write_line_ids_file
 from ..exceptions import CommandError, MergeError, NoMoreHunks, exit_with_error
 from ..i18n import _, ngettext
 from ..output import print_line_level_changes, print_binary_file_change, print_gitlink_change
@@ -1215,11 +1215,11 @@ def _render_batch_file_display_from_ownership(
         for entry in line_entries
         if entry.id is not None
     ]
-    resettable_ids = {
-        line_id
+    resettable_ids = LineRanges.from_ranges(
+        display_id_range
         for unit in units
-        for line_id in unit.display_line_ids
-    }
+        for display_id_range in unit.display_line_ids.ranges()
+    )
     review_gutter_to_selection_id = {}
     review_selection_id_to_gutter = {}
     review_gutter_num = 1
@@ -1243,7 +1243,7 @@ def _render_batch_file_display_from_ownership(
             continue
 
         actions = [_BATCH_RESET_REVIEW_ACTION]
-        if unit.display_line_ids.issubset(mergeable_ids):
+        if unit.display_line_ids.intersection(mergeable_ids) == unit.display_line_ids:
             actionable_selection_groups.append(ordered_group)
             actions = [
                 *_BATCH_MERGE_REVIEW_ACTIONS,

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -1044,7 +1044,8 @@ def _render_batch_file_display_from_ownership(
     if batch_source_buffer is None:
         return None
 
-    mergeable_ids = set()
+    mergeable_id_range_parts: list[tuple[int, int]] = []
+    mergeable_id_ranges = LineRanges.empty()
     units = []
 
     with batch_source_buffer as batch_source_lines:
@@ -1085,10 +1086,12 @@ def _render_batch_file_display_from_ownership(
                                 source_to_working_mapping=source_to_working_mapping,
                             ):
                                 continue
-                            mergeable_ids.update(unit.display_line_ids)
+                            mergeable_id_range_parts.extend(unit.display_line_ids.ranges())
                         except (MergeError, ValueError, KeyError, Exception):
                             # Unit not mergeable - exclude all its lines
                             pass
+
+                    mergeable_id_ranges = LineRanges.from_ranges(mergeable_id_range_parts)
 
     if not display_lines:
         change_type = file_meta.get("change_type", "modified")
@@ -1205,7 +1208,7 @@ def _render_batch_file_display_from_ownership(
     selection_id_to_gutter = {}
     gutter_num = 1
     for entry in line_entries:
-        if entry.id is not None and entry.id in mergeable_ids:
+        if entry.id is not None and entry.id in mergeable_id_ranges:
             gutter_to_selection_id[gutter_num] = entry.id
             selection_id_to_gutter[entry.id] = gutter_num
             gutter_num += 1
@@ -1243,7 +1246,7 @@ def _render_batch_file_display_from_ownership(
             continue
 
         actions = [_BATCH_RESET_REVIEW_ACTION]
-        if unit.display_line_ids.intersection(mergeable_ids) == unit.display_line_ids:
+        if unit.display_line_ids.intersection(mergeable_id_ranges) == unit.display_line_ids:
             actionable_selection_groups.append(ordered_group)
             actions = [
                 *_BATCH_MERGE_REVIEW_ACTIONS,

--- a/src/git_stage_batch/exceptions.py
+++ b/src/git_stage_batch/exceptions.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
+
 
 class CommandError(Exception):
     """Raised when a command fails and needs to exit with an error code."""
@@ -57,10 +59,15 @@ class AtomicUnitError(MergeError):
     or not at all. Partial selection would produce inconsistent ownership.
 
     Attributes:
-        required_selection_ids: Set of selection IDs that must be selected together
+        required_selection_ids: Selection IDs that must be selected together
         unit_kind: Kind of unit (for error messages)
     """
-    def __init__(self, message: str, required_selection_ids: set[int] | None = None, unit_kind: str | None = None):
+    def __init__(
+        self,
+        message: str,
+        required_selection_ids: Iterable[int] | None = None,
+        unit_kind: str | None = None,
+    ):
         super().__init__(message)
         self.required_selection_ids = required_selection_ids
         self.unit_kind = unit_kind

--- a/tests/batch/test_ownership_unit_grouping.py
+++ b/tests/batch/test_ownership_unit_grouping.py
@@ -7,6 +7,8 @@ display order, not source-line proximity.
 
 from __future__ import annotations
 
+import pytest
+
 from git_stage_batch.batch.display import (
     build_display_lines_from_batch_source_lines,
 )
@@ -18,8 +20,11 @@ from git_stage_batch.batch.ownership import (
     ReplacementUnit,
     build_ownership_units_from_batch_source_lines,
     rebuild_ownership_from_units,
+    select_ownership_units_by_display_ids,
 )
 from git_stage_batch.batch.selection import acquire_batch_ownership_for_display_ids_from_lines
+from git_stage_batch.core.line_selection import LineRanges
+from git_stage_batch.exceptions import AtomicUnitError
 
 
 def _source_lines(content: bytes) -> list[bytes]:
@@ -290,6 +295,8 @@ def test_claimed_without_adjacent_deletion_is_presence_only():
     assert units[0].kind == OwnershipUnitKind.PRESENCE_ONLY
     assert units[0].is_atomic is False
     assert units[0].atomic_reason is None
+    assert type(units[0].claimed_source_lines) is LineRanges
+    assert type(units[0].display_line_ids) is LineRanges
     assert units[0].claimed_source_lines == {2}
     assert units[0].deletion_claims == []
 
@@ -545,8 +552,36 @@ def test_explicit_replacement_unit_can_group_multiple_claimed_lines():
 
     assert len(units) == 1
     assert units[0].kind == OwnershipUnitKind.REPLACEMENT
+    assert type(units[0].claimed_source_lines) is LineRanges
+    assert type(units[0].display_line_ids) is LineRanges
     assert units[0].claimed_source_lines == {1, 2}
     assert units[0].display_line_ids == {1, 2, 3, 4}
+
+
+def test_partial_atomic_selection_reports_range_backed_display_ids():
+    """Atomic selection errors should format IDs without a set-only contract."""
+    batch_source = b"new one\nnew two\nkeep\n"
+    ownership = BatchOwnership.from_presence_lines(
+        ["1-2"],
+        [
+            AbsenceClaim(anchor_line=None, content_lines=[b"old one\n", b"old two\n"]),
+        ],
+        replacement_units=[
+            ReplacementUnit(presence_lines=["1-2"], deletion_indices=[0]),
+        ],
+    )
+
+    units = _ownership_units_for_source(ownership, batch_source)
+
+    with pytest.raises(AtomicUnitError) as error:
+        select_ownership_units_by_display_ids(
+            units,
+            LineRanges.from_ranges([(1, 1)]),
+        )
+
+    assert "Select all related lines together: 1-4" in str(error.value)
+    assert "You selected: 1" in str(error.value)
+    assert type(error.value.required_selection_ids) is LineRanges
 
 
 def test_rebuild_preserves_explicit_replacement_units():

--- a/tests/batch/test_selection.py
+++ b/tests/batch/test_selection.py
@@ -1,0 +1,30 @@
+"""Tests for shared batch selection helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from git_stage_batch.batch.selection import require_display_ids_available
+from git_stage_batch.core.line_selection import LineRanges
+from git_stage_batch.exceptions import CommandError
+
+
+def test_require_display_ids_available_accepts_range_selections():
+    """Availability validation should compare display ID ranges directly."""
+    require_display_ids_available(
+        LineRanges.from_ranges([(2, 3)]),
+        LineRanges.from_ranges([(1, 4)]),
+        line_id_specification="2-3",
+        file_path="test.py",
+    )
+
+
+def test_require_display_ids_available_rejects_missing_range_ids():
+    """Unavailable range-selected display IDs should still be rejected."""
+    with pytest.raises(CommandError):
+        require_display_ids_available(
+            LineRanges.from_ranges([(2, 5)]),
+            LineRanges.from_ranges([(1, 4)]),
+            line_id_specification="2-5",
+            file_path="test.py",
+        )

--- a/tests/commands/test_reset.py
+++ b/tests/commands/test_reset.py
@@ -16,7 +16,7 @@ from git_stage_batch.commands.new import command_new_batch
 from git_stage_batch.commands.reset import command_reset_from_batch
 from git_stage_batch.commands.show_from import command_show_from_batch
 from git_stage_batch.commands.start import command_start
-from git_stage_batch.core.line_selection import parse_line_selection
+from git_stage_batch.core.line_selection import LineRanges, parse_line_selection
 from git_stage_batch.core.models import RenderedBatchDisplay, ReviewActionGroup
 from git_stage_batch.data.batch_sources import create_batch_source_commit, save_session_batch_sources
 from git_stage_batch.data.hunk_tracking import fetch_next_change, render_batch_file_display
@@ -87,6 +87,34 @@ def test_reset_partition_accepts_non_list_line_sequences(line_sequence):
     assert remaining_units == []
     assert len(removed_units) == 1
     assert removed_units[0].claimed_source_lines == {2}
+
+
+def test_reset_partition_validates_available_ids_as_ranges(line_sequence, monkeypatch):
+    """Reset availability checks should consume range-backed display IDs."""
+    ownership = BatchOwnership.from_presence_lines(["1,3"], [])
+    source_lines = line_sequence([b"line1\n", b"line2\n", b"line3\n"])
+    seen_available_ids = []
+    original_require_available = reset_module.require_display_ids_available
+
+    def capture_require_available(requested_ids, available_ids, **kwargs):
+        seen_available_ids.append(available_ids)
+        return original_require_available(requested_ids, available_ids, **kwargs)
+
+    monkeypatch.setattr(
+        reset_module,
+        "require_display_ids_available",
+        capture_require_available,
+    )
+
+    reset_module._partition_line_ownership_units(
+        ownership,
+        source_lines,
+        {2},
+        batch_name="mybatch",
+        file_path="test.py",
+    )
+
+    assert seen_available_ids == [LineRanges.from_ranges([(1, 2)])]
 
 
 @pytest.fixture

--- a/tests/commands/test_show_from.py
+++ b/tests/commands/test_show_from.py
@@ -18,6 +18,7 @@ import pytest
 
 from git_stage_batch.batch import create_batch
 from git_stage_batch.commands.show_from import command_show_from_batch
+from git_stage_batch.core.line_selection import LineRanges
 from git_stage_batch.data.session import initialize_abort_state
 from git_stage_batch.exceptions import CommandError
 from git_stage_batch.utils.paths import ensure_state_directory_exists
@@ -401,6 +402,37 @@ class TestCommandShowFromBatch:
         assert rendered is not None
         assert len(rendered.review_action_groups) == 2
         assert calls == ["hunk"]
+
+    def test_show_from_keeps_mergeable_display_ids_range_backed(self, temp_git_repo, monkeypatch):
+        """Rendering should not compare each unit with a set of mergeable IDs."""
+
+        (temp_git_repo / "file.txt").write_text("one\nkeep\ntwo\nend\n")
+        subprocess.run(["git", "add", "file.txt"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add file"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        create_batch("multi-unit-batch")
+        add_file_to_batch(
+            "multi-unit-batch",
+            "file.txt",
+            BatchOwnership.from_presence_lines(["1,3"], []),
+            "100644",
+        )
+
+        original_intersection = LineRanges.intersection
+        set_backed_intersections = []
+
+        def track_intersection(self, other):
+            if isinstance(other, set):
+                set_backed_intersections.append(other)
+            return original_intersection(self, other)
+
+        monkeypatch.setattr(LineRanges, "intersection", track_intersection)
+
+        rendered = render_batch_file_display("multi-unit-batch", "file.txt")
+
+        assert rendered is not None
+        assert len(rendered.review_action_groups) == 2
+        assert set_backed_intersections == []
 
     def test_show_from_multi_file_list_renders_each_file_once(self, temp_git_repo, monkeypatch, capsys):
         """Showing a multi-file batch file list should render each file once."""


### PR DESCRIPTION
## Summary

The reset and review flows rebuild a rendered file view from batch metadata before deciding which numbered lines can be reset, applied, or shown as a single related change. That metadata includes the batch-source line numbers for selected lines, the rendered line IDs shown to users, and records for content that must stay absent from the result.

Before this PR, those reset/display units stored the selected source-line IDs and rendered display IDs in Python sets. Reset also rebuilt a set of all available display IDs, and review rendering kept mergeable display IDs as a set before asking each unit whether all its displayed lines were mergeable. For large contiguous selections, those paths allocated one Python integer per line even when a range was enough.

This PR moves the unit source/display IDs to `LineRanges`, the existing range-selection helper. It also validates reset's available display IDs from unit ranges and keeps review-render mergeable IDs as one range selection after mergeability probing, so per-unit action checks do not rebuild ranges from a full set.

The public display renderer is still displayed-line-scale, and presence-only reset units are still one unit per selected line. Those larger reset/display steps remain separate work; this PR only removes the obvious set-backed selection storage and per-unit mergeability reconversion addressed by this range-backed step.

## Tests

- `PYTHONPATH=src uv run pytest tests/commands/test_show_from.py::TestCommandShowFromBatch::test_show_from_keeps_mergeable_display_ids_range_backed tests/commands/test_show_from.py::TestCommandShowFromBatch::test_show_from_reuses_line_mapping_across_mergeability_probes tests/batch/test_ownership_unit_grouping.py tests/batch/test_selection.py tests/commands/test_reset.py`
- `PYTHONPATH=src uv run pytest -n auto`