### PR TITLE
cli: Add automatic hunk selection controls

### DIFF
--- a/completions/git-stage-batch
+++ b/completions/git-stage-batch
@@ -67,7 +67,10 @@ _git_stage_batch()
                     return
                     ;;
             esac
-            COMPREPLY=($(compgen -W "-U --unified" -- "$cur"))
+            COMPREPLY=($(compgen -W "-U --unified --auto-advance --no-auto-advance" -- "$cur"))
+            ;;
+        again)
+            COMPREPLY=($(compgen -W "--auto-advance --no-auto-advance" -- "$cur"))
             ;;
         show)
             case "$prev" in
@@ -107,7 +110,7 @@ _git_stage_batch()
                     return
                     ;;
             esac
-            COMPREPLY=($(compgen -W "--file --files --from --to --line --lines --as --as-stdin --no-edge-overlap" -- "$cur"))
+            COMPREPLY=($(compgen -W "--file --files --from --to --line --lines --as --as-stdin --no-edge-overlap --auto-advance --no-auto-advance" -- "$cur"))
             ;;
         skip)
             case "$prev" in
@@ -121,7 +124,7 @@ _git_stage_batch()
                     return
                     ;;
             esac
-            COMPREPLY=($(compgen -W "--file --files --line" -- "$cur"))
+            COMPREPLY=($(compgen -W "--file --files --line --auto-advance --no-auto-advance" -- "$cur"))
             ;;
         discard)
             case "$prev" in
@@ -143,7 +146,7 @@ _git_stage_batch()
                     return
                     ;;
             esac
-            COMPREPLY=($(compgen -W "--file --files --from --to --line --lines --as --as-stdin --no-edge-overlap" -- "$cur"))
+            COMPREPLY=($(compgen -W "--file --files --from --to --line --lines --as --as-stdin --no-edge-overlap --auto-advance --no-auto-advance" -- "$cur"))
             ;;
         apply)
             case "$prev" in

--- a/docs/ai-assistants.md
+++ b/docs/ai-assistants.md
@@ -49,7 +49,9 @@ automation.
    - `git-stage-batch include` (stage this hunk)
    - `git-stage-batch skip` (skip this hunk for now)
 
-   These commands automatically display the next hunk to evaluate.
+   These commands automatically display the next hunk to evaluate. Use
+   `--no-auto-advance` when the automation should stop after one action and
+   run `git-stage-batch show` explicitly before the next bare action.
 
 3. Repeatedly run these commands until all hunks relevant to the selected commit
    are processed, then commit the results.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -14,9 +14,12 @@ Find and display the first unprocessed hunk; cache as "selected".
 
 **Options:**
 - `-U N` or `--unified N`: Number of context lines in diff output (default: 3)
+- `--auto-advance`: Select the next hunk after later actions (default)
+- `--no-auto-advance`: Leave no hunk selected after later actions
 
 ```
 ❯ git-stage-batch start -U5  # Show 5 lines of context
+❯ git-stage-batch start --no-auto-advance
 ```
 
 Resets state if a session is already in progress.
@@ -111,7 +114,8 @@ fi
 
 ### `include`
 
-Stage the cached hunk (entire hunk) to the index; advance to next.
+Stage the cached hunk (entire hunk) to the index; advance to next unless
+automatic selection is disabled.
 
 ```
 ❯ git-stage-batch include
@@ -126,7 +130,8 @@ When a session is active, the bare command shows the selected hunk:
 
 ### `skip`
 
-Mark the cached hunk as skipped; advance to next.
+Mark the cached hunk as skipped; advance to next unless automatic selection is
+disabled.
 
 ```
 ❯ git-stage-batch skip
@@ -138,7 +143,8 @@ Skipped hunks can be revisited with `again`.
 
 ### `discard`
 
-Reverse-apply the cached hunk to the working tree; advance to next.
+Reverse-apply the cached hunk to the working tree; advance to next unless
+automatic selection is disabled.
 
 ```
 ❯ git-stage-batch discard
@@ -146,6 +152,26 @@ Reverse-apply the cached hunk to the working tree; advance to next.
 
 !!! warning "Destructive Operation"
     This permanently removes changes from your working tree. Use with caution.
+
+---
+
+### Automatic Hunk Selection
+
+By default, `include`, `skip`, `discard`, `include --to`, and `discard --to`
+select and display the next hunk after they finish. Add
+`--no-auto-advance` to one action when you want the command to stop with no
+hunk selected:
+
+```bash
+❯ git-stage-batch include --no-auto-advance
+❯ git-stage-batch show
+```
+
+After `--no-auto-advance`, another bare action refuses until `show` selects
+the next hunk. Use `--auto-advance` to opt back in for one command.
+
+`start` and `again` accept the same flags to set the session default for
+later actions that do not specify either flag.
 
 ---
 
@@ -244,6 +270,10 @@ Clear the blocklist and restart iteration through all hunks.
 ```
 
 Useful for making another pass after committing some changes.
+
+**Options:**
+- `--auto-advance`: Select the next hunk after later actions
+- `--no-auto-advance`: Leave no hunk selected after later actions
 
 ---
 

--- a/docs/git-stage-batch.1.in
+++ b/docs/git-stage-batch.1.in
@@ -106,10 +106,12 @@ Useful for scripts checking hunk availability without output.
 .RE
 .TP
 .B include
-Stage the cached hunk (entire hunk) to the index; advance to next.
+Stage the cached hunk (entire hunk) to the index; advance to next unless
+automatic selection is disabled.
 .TP
 .B skip
-Mark the cached hunk as skipped; advance to next.
+Mark the cached hunk as skipped; advance to next unless automatic selection
+is disabled.
 Skipped hunks can be revisited with
 .BR again .
 .TP
@@ -119,7 +121,8 @@ When a session is active, running
 with no command shows the selected hunk.
 .TP
 .B discard
-Reverse-apply the cached hunk to the working tree; advance to next.
+Reverse-apply the cached hunk to the working tree; advance to next unless
+automatic selection is disabled.
 .B WARNING:
 This permanently removes changes from your working tree.
 .TP
@@ -175,6 +178,27 @@ is included + skipped + discarded;
 .BR {total}
 is processed + remaining.
 .RE
+.SS Automatic Hunk Selection
+.PP
+By default, hunk actions select and display the next hunk after they finish.
+Use
+.B \-\-no\-auto\-advance
+on an action command to leave no hunk selected after the action completes.
+Run
+.B git-stage-batch show
+to choose and display the next hunk before running another bare action.
+.PP
+Use
+.B \-\-auto\-advance
+to opt back in for one command. The
+.B start
+and
+.B again
+commands also accept
+.B \-\-auto\-advance
+and
+.B \-\-no\-auto\-advance
+to set the session default for later actions that do not specify either flag.
 .SS Session Management
 .TP
 .B again

--- a/docs/index.md
+++ b/docs/index.md
@@ -204,6 +204,10 @@ Similar to `git add -p` but **more granular and flexible**:
 # Start fresh after committing
 ❯ git-stage-batch again   # or: a
 
+# Stop after one action instead of selecting the next hunk
+❯ git-stage-batch include --no-auto-advance
+❯ git-stage-batch show
+
 # For advanced workflows, defer changes to named batches
 ❯ git-stage-batch include --to feature-work  # Save to batch for later
 ```

--- a/src/git_stage_batch/cli/argument_parser.py
+++ b/src/git_stage_batch/cli/argument_parser.py
@@ -19,7 +19,11 @@ from ..batch.validation import batch_exists
 from .. import commands
 from ..batch.query import read_batch_metadata
 from ..data.file_tracking import list_untracked_files
-from ..data.hunk_tracking import advance_to_next_change, show_selected_change
+from ..data.hunk_tracking import (
+    advance_to_next_change,
+    select_next_change_after_action,
+    show_selected_change,
+)
 from ..data.undo import undo_checkpoint
 from ..exceptions import CommandError
 from ..i18n import _, ngettext
@@ -277,7 +281,11 @@ def _multi_file_undo_checkpoint(
     )
 
 
-def _include_each_resolved_file(files: list[str]) -> None:
+def _include_each_resolved_file(
+    files: list[str],
+    *,
+    auto_advance: bool | None = None,
+) -> None:
     """Stage a multi-file live scope and report one aggregate summary."""
     total_hunks = 0
     staged_files: list[str] = []
@@ -297,7 +305,7 @@ def _include_each_resolved_file(files: list[str]) -> None:
         print(_("No hunks staged from matched files."), file=sys.stderr)
         return
 
-    advance_to_next_change()
+    should_show_next = select_next_change_after_action(auto_advance=auto_advance)
 
     if len(staged_files) == 1:
         file_summary = staged_files[0]
@@ -316,7 +324,8 @@ def _include_each_resolved_file(files: list[str]) -> None:
         ).format(count=total_hunks, files=file_summary),
         file=sys.stderr,
     )
-    show_selected_change()
+    if should_show_next:
+        show_selected_change()
 
 
 def _skip_each_resolved_file(files: list[str]) -> None:
@@ -769,6 +778,7 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
         action="store_true",
         help=argparse.SUPPRESS,
     )
+    _add_auto_advance_arguments(parser_include)
 
     def dispatch_include(args: argparse.Namespace) -> None:
         replacement_requested = args.as_text is not None or args.as_stdin
@@ -797,6 +807,7 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
                     replacement_text,
                     file=resolved_file,
                     no_edge_overlap=args.no_edge_overlap,
+                    auto_advance=args.auto_advance,
                 )
                 return
             if (
@@ -814,7 +825,11 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
                 if resolved_live_scope.is_multiple:
                     raise CommandError(_("Cannot use --as with multiple files."))
                 replacement_text = _resolve_replacement_text(args)
-                commands.command_include_file_as(replacement_text, file=resolved_live_scope.optional_file())
+                commands.command_include_file_as(
+                    replacement_text,
+                    file=resolved_live_scope.optional_file(),
+                    auto_advance=args.auto_advance,
+                )
                 return
             raise CommandError(
                 _("`include --as` requires `--file` or `--line` and does not support `--to`.")
@@ -834,22 +849,37 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
             resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
             _run_for_each_file(
                 resolved_live_scope,
-                lambda file: commands.command_include_to_batch(args.to_batch, args.line_ids, file),
+                lambda file: commands.command_include_to_batch(
+                    args.to_batch,
+                    args.line_ids,
+                    file,
+                    auto_advance=args.auto_advance,
+                ),
                 line_ids=args.line_ids,
                 undo_operation=f"include --to {shlex.quote(args.to_batch)}",
             )
         elif args.line_ids:
             resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
             resolved_file = resolved_live_scope.require_single_file(_("Cannot use --lines with multiple files."))
-            commands.command_include_line(args.line_ids, file=resolved_file)
+            commands.command_include_line(
+                args.line_ids,
+                file=resolved_file,
+                auto_advance=args.auto_advance,
+            )
         else:
             resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
             if resolved_live_scope.is_multiple:
-                _include_each_resolved_file(list(resolved_live_scope.files))
+                _include_each_resolved_file(
+                    list(resolved_live_scope.files),
+                    auto_advance=args.auto_advance,
+                )
             elif not resolved_live_scope.is_implicit:
-                commands.command_include_file(resolved_live_scope.optional_file())
+                commands.command_include_file(
+                    resolved_live_scope.optional_file(),
+                    auto_advance=args.auto_advance,
+                )
             else:
-                commands.command_include()
+                commands.command_include(auto_advance=args.auto_advance)
 
     parser_include.set_defaults(func=dispatch_include)
 

--- a/src/git_stage_batch/cli/argument_parser.py
+++ b/src/git_stage_batch/cli/argument_parser.py
@@ -203,6 +203,24 @@ def _add_file_argument(parser: argparse.ArgumentParser, help_text: str) -> None:
     )
 
 
+def _add_auto_advance_arguments(parser: argparse.ArgumentParser) -> None:
+    """Add controls for selecting the next hunk after an action."""
+    auto_advance = parser.add_mutually_exclusive_group()
+    auto_advance.add_argument(
+        "--auto-advance",
+        dest="auto_advance",
+        action="store_true",
+        default=None,
+        help=_("Select the next hunk after the command completes"),
+    )
+    auto_advance.add_argument(
+        "--no-auto-advance",
+        dest="auto_advance",
+        action="store_false",
+        help=_("Leave no hunk selected after the command completes"),
+    )
+
+
 def _validate_file_inputs(
     file_arg: str | None,
     file_patterns: list[str] | None,
@@ -510,7 +528,13 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
         metavar="N",
         help=_("Number of context lines in diff output (default: 3)"),
     )
-    parser_start.set_defaults(func=lambda args: commands.command_start(context_lines=args.context_lines))
+    _add_auto_advance_arguments(parser_start)
+    parser_start.set_defaults(
+        func=lambda args: commands.command_start(
+            context_lines=args.context_lines,
+            auto_advance=args.auto_advance,
+        )
+    )
 
     # interactive - Start interactive hunk-by-hunk mode
     parser_interactive = subparsers.add_parser(
@@ -532,7 +556,10 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
         aliases=["a"],
         help=_("Clear state and start a fresh pass"),
     )
-    parser_again.set_defaults(func=lambda _: commands.command_again())
+    _add_auto_advance_arguments(parser_again)
+    parser_again.set_defaults(
+        func=lambda args: commands.command_again(auto_advance=args.auto_advance)
+    )
 
     # undo - Undo the most recent undoable session operation
     parser_undo = subparsers.add_parser(

--- a/src/git_stage_batch/cli/argument_parser.py
+++ b/src/git_stage_batch/cli/argument_parser.py
@@ -328,7 +328,11 @@ def _include_each_resolved_file(
         show_selected_change()
 
 
-def _skip_each_resolved_file(files: list[str]) -> None:
+def _skip_each_resolved_file(
+    files: list[str],
+    *,
+    auto_advance: bool | None = None,
+) -> None:
     """Skip a multi-file live scope and report one aggregate summary."""
     total_hunks = 0
     skipped_files: list[str] = []
@@ -348,7 +352,7 @@ def _skip_each_resolved_file(files: list[str]) -> None:
         print(_("No hunks skipped from matched files."), file=sys.stderr)
         return
 
-    advance_to_next_change()
+    should_show_next = select_next_change_after_action(auto_advance=auto_advance)
 
     if len(skipped_files) == 1:
         file_summary = skipped_files[0]
@@ -367,7 +371,8 @@ def _skip_each_resolved_file(files: list[str]) -> None:
         ).format(count=total_hunks, files=file_summary),
         file=sys.stderr,
     )
-    show_selected_change()
+    if should_show_next:
+        show_selected_change()
 
 
 def _discard_to_batch_each_resolved_file(batch_name: str, files: list[str]) -> None:
@@ -902,19 +907,30 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
           "If PATH omitted, uses selected hunk's file. "
           "Without --line, skips all hunks from the file."),
     )
+    _add_auto_advance_arguments(parser_skip)
 
     def dispatch_skip(args: argparse.Namespace) -> None:
         resolved_file_scope = _resolve_live_file_scope(args.file, args.file_patterns)
         if args.line_ids:
             resolved_file = resolved_file_scope.require_single_file(_("Cannot use --lines with multiple files."))
-            commands.command_skip_line(args.line_ids, file=resolved_file)
+            commands.command_skip_line(
+                args.line_ids,
+                file=resolved_file,
+                auto_advance=args.auto_advance,
+            )
         elif not resolved_file_scope.is_implicit:
             if resolved_file_scope.is_multiple:
-                _skip_each_resolved_file(list(resolved_file_scope.files))
+                _skip_each_resolved_file(
+                    list(resolved_file_scope.files),
+                    auto_advance=args.auto_advance,
+                )
             else:
-                commands.command_skip_file(resolved_file_scope.optional_file())
+                commands.command_skip_file(
+                    resolved_file_scope.optional_file(),
+                    auto_advance=args.auto_advance,
+                )
         else:
-            commands.command_skip()
+            commands.command_skip(auto_advance=args.auto_advance)
 
     parser_skip.set_defaults(func=dispatch_skip)
 

--- a/src/git_stage_batch/cli/argument_parser.py
+++ b/src/git_stage_batch/cli/argument_parser.py
@@ -19,11 +19,7 @@ from ..batch.validation import batch_exists
 from .. import commands
 from ..batch.query import read_batch_metadata
 from ..data.file_tracking import list_untracked_files
-from ..data.hunk_tracking import (
-    advance_to_next_change,
-    select_next_change_after_action,
-    show_selected_change,
-)
+from ..data.hunk_tracking import select_next_change_after_action, show_selected_change
 from ..data.undo import undo_checkpoint
 from ..exceptions import CommandError
 from ..i18n import _, ngettext
@@ -375,7 +371,12 @@ def _skip_each_resolved_file(
         show_selected_change()
 
 
-def _discard_to_batch_each_resolved_file(batch_name: str, files: list[str]) -> None:
+def _discard_to_batch_each_resolved_file(
+    batch_name: str,
+    files: list[str],
+    *,
+    auto_advance: bool | None = None,
+) -> None:
     """Save a multi-file live scope to a batch and report one aggregate summary."""
     total_hunks = 0
     discarded_files: list[str] = []
@@ -387,6 +388,7 @@ def _discard_to_batch_each_resolved_file(batch_name: str, files: list[str]) -> N
             files,
             quiet=True,
             advance=False,
+            auto_advance=auto_advance,
         )
         total_hunks = result.discarded_hunks
         discarded_files = result.discarded_files
@@ -395,7 +397,7 @@ def _discard_to_batch_each_resolved_file(batch_name: str, files: list[str]) -> N
         print(_("No hunks saved to batch from matched files."), file=sys.stderr)
         return
 
-    advance_to_next_change()
+    should_show_next = select_next_change_after_action(auto_advance=auto_advance)
 
     if len(discarded_files) == 1:
         file_summary = discarded_files[0]
@@ -414,7 +416,8 @@ def _discard_to_batch_each_resolved_file(batch_name: str, files: list[str]) -> N
         ).format(count=total_hunks, files=file_summary, batch=batch_name),
         file=sys.stderr,
     )
-    show_selected_change()
+    if should_show_next:
+        show_selected_change()
 
 
 def _resolve_live_file_scope(
@@ -990,6 +993,7 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
         action="store_true",
         help=argparse.SUPPRESS,
     )
+    _add_auto_advance_arguments(parser_discard)
 
     def dispatch_discard(args: argparse.Namespace) -> None:
         replacement_requested = args.as_text is not None or args.as_stdin
@@ -1006,6 +1010,7 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
                     replacement_text,
                     file=resolved_file,
                     no_edge_overlap=args.no_edge_overlap,
+                    auto_advance=args.auto_advance,
                 )
                 return
             if (
@@ -1023,7 +1028,11 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
                 if resolved_live_scope.is_multiple:
                     raise CommandError(_("Cannot use --as with multiple files."))
                 replacement_text = _resolve_replacement_text(args)
-                commands.command_discard_file_as(replacement_text, file=resolved_live_scope.optional_file())
+                commands.command_discard_file_as(
+                    replacement_text,
+                    file=resolved_live_scope.optional_file(),
+                    auto_advance=args.auto_advance,
+                )
                 return
             raise CommandError(
                 _("`discard --as` requires `--file`, or `--to` with `--line`.")
@@ -1042,11 +1051,20 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
         elif args.to_batch:
             resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
             if resolved_live_scope.is_multiple and args.line_ids is None:
-                _discard_to_batch_each_resolved_file(args.to_batch, list(resolved_live_scope.files))
+                _discard_to_batch_each_resolved_file(
+                    args.to_batch,
+                    list(resolved_live_scope.files),
+                    auto_advance=args.auto_advance,
+                )
             else:
                 _run_for_each_file(
                     resolved_live_scope,
-                    lambda file: commands.command_discard_to_batch(args.to_batch, args.line_ids, file),
+                    lambda file: commands.command_discard_to_batch(
+                        args.to_batch,
+                        args.line_ids,
+                        file,
+                        auto_advance=args.auto_advance,
+                    ),
                     line_ids=args.line_ids,
                     undo_operation=f"discard --to {shlex.quote(args.to_batch)}",
                     worktree_paths=resolved_live_scope.files,
@@ -1054,18 +1072,25 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
         elif args.line_ids:
             resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
             resolved_file = resolved_live_scope.require_single_file(_("Cannot use --lines with multiple files."))
-            commands.command_discard_line(args.line_ids, file=resolved_file)
+            commands.command_discard_line(
+                args.line_ids,
+                file=resolved_file,
+                auto_advance=args.auto_advance,
+            )
         else:
             resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
             if not resolved_live_scope.is_implicit:
                 _run_for_each_file(
                     resolved_live_scope,
-                    commands.command_discard_file,
+                    lambda file: commands.command_discard_file(
+                        file,
+                        auto_advance=args.auto_advance,
+                    ),
                     undo_operation="discard",
                     worktree_paths=resolved_live_scope.files,
                 )
             else:
-                commands.command_discard()
+                commands.command_discard(auto_advance=args.auto_advance)
 
     parser_discard.set_defaults(func=dispatch_discard)
 

--- a/src/git_stage_batch/commands/again.py
+++ b/src/git_stage_batch/commands/again.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from ..data.auto_advance import write_auto_advance_default
 from ..data.file_tracking import auto_add_untracked_files
 from ..data.hunk_tracking import fetch_next_change, show_selected_change
 from ..data.session import clear_iteration_state, require_session_started
@@ -11,7 +12,7 @@ from ..utils.git import require_git_repository
 from ..utils.paths import ensure_state_directory_exists
 
 
-def command_again(*, quiet: bool = False) -> None:
+def command_again(*, quiet: bool = False, auto_advance: bool | None = None) -> None:
     """Clear state and start a fresh pass through all hunks.
 
     This command resets the iteration-specific state (selected hunk, blocklist,
@@ -22,6 +23,9 @@ def command_again(*, quiet: bool = False) -> None:
     require_git_repository()
     require_session_started()
     ensure_state_directory_exists()
+
+    if auto_advance is not None:
+        write_auto_advance_default(auto_advance)
 
     # Clear iteration-specific state (shared logic with stop/abort)
     clear_iteration_state()

--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -48,17 +48,17 @@ from ..core.models import BinaryFileChange, GitlinkChange
 from ..core.text_lifecycle import TextFileChangeType, detect_empty_text_lifecycle_change
 from ..data.hunk_tracking import (
     SelectedChangeKind,
-    advance_to_and_show_next_change,
-    advance_to_next_change,
     build_file_hunk_from_buffer,
     cache_unstaged_file_as_single_hunk,
     fetch_next_change,
+    finish_selected_change_action,
     get_selected_change_file_path,
     load_selected_change,
     read_selected_change_kind,
     recalculate_selected_hunk_for_file,
     record_hunk_discarded,
     record_hunks_discarded,
+    refuse_bare_action_after_auto_advance_disabled,
     refuse_bare_action_after_file_list,
     render_binary_file_change,
     render_gitlink_change,
@@ -230,7 +230,11 @@ def _load_explicit_file_selection(file_path: str):
     return line_changes
 
 
-def command_discard(*, quiet: bool = False) -> None:
+def command_discard(
+    *,
+    quiet: bool = False,
+    auto_advance: bool | None = None,
+) -> None:
     """Discard the selected hunk or binary file from the working tree."""
 
     log_journal("command_discard_start", quiet=quiet)
@@ -244,9 +248,13 @@ def command_discard(*, quiet: bool = False) -> None:
     if refuse_ambiguous_bare_action_after_partial_file_review(FileReviewAction.DISCARD):
         return
     refuse_bare_action_after_file_list("discard")
+    refuse_bare_action_after_auto_advance_disabled("discard")
 
     if read_selected_change_kind() == SelectedChangeKind.FILE:
-        _command_discard_selected_file(quiet=quiet)
+        _command_discard_selected_file(
+            quiet=quiet,
+            auto_advance=auto_advance,
+        )
         return
 
     try:
@@ -280,10 +288,10 @@ def command_discard(*, quiet: bool = False) -> None:
                     file=sys.stderr,
                 )
 
-            if quiet:
-                advance_to_next_change()
-            else:
-                advance_to_and_show_next_change()
+            finish_selected_change_action(
+                quiet=quiet,
+                auto_advance=auto_advance,
+            )
             return
 
         if isinstance(item, BinaryFileChange):
@@ -328,10 +336,10 @@ def command_discard(*, quiet: bool = False) -> None:
                 change_desc = "added" if item.is_new_file() else ("deleted" if item.is_deleted_file() else "modified")
                 print(_("✓ Binary file {desc} discarded: {file}").format(desc=change_desc, file=file_path), file=sys.stderr)
 
-            if quiet:
-                advance_to_next_change()
-            else:
-                advance_to_and_show_next_change()
+            finish_selected_change_action(
+                quiet=quiet,
+                auto_advance=auto_advance,
+            )
             return
 
         # Text hunk - use git apply -R
@@ -384,13 +392,17 @@ def command_discard(*, quiet: bool = False) -> None:
         if not quiet:
             print(_("✓ Hunk discarded from {file}").format(file=filename), file=sys.stderr)
 
-        if quiet:
-            advance_to_next_change()
-        else:
-            advance_to_and_show_next_change()
+        finish_selected_change_action(
+            quiet=quiet,
+            auto_advance=auto_advance,
+        )
 
 
-def _command_discard_selected_file(*, quiet: bool = False) -> None:
+def _command_discard_selected_file(
+    *,
+    quiet: bool = False,
+    auto_advance: bool | None = None,
+) -> None:
     """Discard all changes from the currently selected file-scoped view."""
     target_file = get_selected_change_file_path()
     if target_file is None:
@@ -419,13 +431,17 @@ def _command_discard_selected_file(*, quiet: bool = False) -> None:
                 absolute_path.unlink()
 
         if quiet:
-            advance_to_next_change()
+            finish_selected_change_action(quiet=True, auto_advance=auto_advance)
         else:
             print(_("✓ File discarded: {}").format(target_file), file=sys.stderr)
-            advance_to_and_show_next_change()
+            finish_selected_change_action(quiet=False, auto_advance=auto_advance)
 
 
-def command_discard_file(file: str) -> None:
+def command_discard_file(
+    file: str,
+    *,
+    auto_advance: bool | None = None,
+) -> None:
     """Discard the entire specified file from the working tree.
 
     Args:
@@ -444,6 +460,7 @@ def command_discard_file(file: str) -> None:
         if refuse_ambiguous_bare_action_after_partial_file_review(FileReviewAction.DISCARD):
             return
         refuse_bare_action_after_file_list("discard --file")
+        refuse_bare_action_after_auto_advance_disabled("discard --file")
 
     # Determine target file
     if file == "":
@@ -485,7 +502,7 @@ def command_discard_file(file: str) -> None:
                 _("✓ Submodule pointer restored: {file}").format(file=target_file),
                 file=sys.stderr,
             )
-            advance_to_and_show_next_change()
+            finish_selected_change_action(quiet=False, auto_advance=auto_advance)
             return
 
         # Snapshot the file if it's untracked (for abort functionality)
@@ -530,10 +547,15 @@ def command_discard_file(file: str) -> None:
 
         print(_("✓ File discarded: {}").format(target_file), file=sys.stderr)
 
-        advance_to_and_show_next_change()
+        finish_selected_change_action(quiet=False, auto_advance=auto_advance)
 
 
-def command_discard_file_as(replacement_text: str, file: str | None = None) -> None:
+def command_discard_file_as(
+    replacement_text: str,
+    file: str | None = None,
+    *,
+    auto_advance: bool | None = None,
+) -> None:
     """Replace one live file-scoped working-tree file with explicit text."""
     require_git_repository()
     require_session_started()
@@ -544,6 +566,7 @@ def command_discard_file_as(replacement_text: str, file: str | None = None) -> N
         if refuse_ambiguous_bare_action_after_partial_file_review(FileReviewAction.DISCARD):
             return
         refuse_bare_action_after_file_list("discard --file --as")
+        refuse_bare_action_after_auto_advance_disabled("discard --file --as")
 
     operation_parts = ["discard", "--as", replacement_text]
     if file is not None:
@@ -575,13 +598,21 @@ def command_discard_file_as(replacement_text: str, file: str | None = None) -> N
             assert saved_selected_state is not None
             restore_selected_change_state(saved_selected_state)
         else:
-            recalculate_selected_hunk_for_file(line_changes.path)
+            recalculate_selected_hunk_for_file(
+                line_changes.path,
+                auto_advance=auto_advance,
+            )
         clear_last_file_review_state_if_file_matches(target_file)
 
     print(_("✓ Discarded file as replacement: {file}").format(file=target_file), file=sys.stderr)
 
 
-def command_discard_line(line_id_specification: str, file: str | None = None) -> None:
+def command_discard_line(
+    line_id_specification: str,
+    file: str | None = None,
+    *,
+    auto_advance: bool | None = None,
+) -> None:
     """Discard only the specified lines from the working tree.
 
     Args:
@@ -652,7 +683,10 @@ def command_discard_line(line_id_specification: str, file: str | None = None) ->
             file=sys.stderr,
         )
         print_remaining_line_changes_header(line_changes.path)
-        recalculate_selected_hunk_for_file(line_changes.path)
+        recalculate_selected_hunk_for_file(
+            line_changes.path,
+            auto_advance=auto_advance,
+        )
         finish_review_scoped_line_action(review_state)
 
 
@@ -663,6 +697,7 @@ def command_discard_to_batch(
     *,
     quiet: bool = False,
     advance: bool = True,
+    auto_advance: bool | None = None,
 ) -> int:
     """Save to batch then discard from working tree.
 
@@ -674,6 +709,7 @@ def command_discard_to_batch(
               If None, uses selected hunk (cached state).
         quiet: Suppress output
         advance: When quiet, advance the selection after discarding this file.
+        auto_advance: Whether to select the next hunk after this action.
 
     Returns:
         Number of hunks saved to the batch and discarded.
@@ -711,9 +747,19 @@ def command_discard_to_batch(
         ):
             selected_change = load_selected_change()
             if isinstance(selected_change, BinaryFileChange):
-                saved_hunks = _command_discard_binary_to_batch(batch_name, selected_change, quiet=quiet)
+                saved_hunks = _command_discard_binary_to_batch(
+                    batch_name,
+                    selected_change,
+                    quiet=quiet,
+                    auto_advance=auto_advance,
+                )
             else:
-                saved_hunks = _command_discard_hunk_to_batch(batch_name, file_only=False, quiet=quiet)
+                saved_hunks = _command_discard_hunk_to_batch(
+                    batch_name,
+                    file_only=False,
+                    quiet=quiet,
+                    auto_advance=auto_advance,
+                )
         elif file is not None:
             # File-scoped operation
 
@@ -728,17 +774,39 @@ def command_discard_to_batch(
 
             if line_ids is None:
                 # --file without --line: discard entire file
-                saved_hunks = _command_discard_file_to_batch(batch_name, target_file, quiet=quiet, advance=advance)
+                saved_hunks = _command_discard_file_to_batch(
+                    batch_name,
+                    target_file,
+                    quiet=quiet,
+                    advance=advance,
+                    auto_advance=auto_advance,
+                )
             else:
                 # --file with --line: discard specific lines from file
-                saved_hunks = _command_discard_file_lines_to_batch(batch_name, target_file, line_ids, quiet=quiet)
+                saved_hunks = _command_discard_file_lines_to_batch(
+                    batch_name,
+                    target_file,
+                    line_ids,
+                    quiet=quiet,
+                    auto_advance=auto_advance,
+                )
         else:
             # Hunk-scoped operation (selected behavior)
             if line_ids is not None:
-                saved_hunks = _command_discard_lines_to_batch(batch_name, line_ids, quiet=quiet)
+                saved_hunks = _command_discard_lines_to_batch(
+                    batch_name,
+                    line_ids,
+                    quiet=quiet,
+                    auto_advance=auto_advance,
+                )
             else:
                 # Discard entire selected hunk
-                saved_hunks = _command_discard_hunk_to_batch(batch_name, file_only=False, quiet=quiet)
+                saved_hunks = _command_discard_hunk_to_batch(
+                    batch_name,
+                    file_only=False,
+                    quiet=quiet,
+                    auto_advance=auto_advance,
+                )
     if original_file_scope in (None, "") and line_ids is not None:
         finish_review_scoped_line_action(review_state)
     return saved_hunks
@@ -752,6 +820,7 @@ def command_discard_line_as_to_batch(
     *,
     no_edge_overlap: bool = False,
     quiet: bool = False,
+    auto_advance: bool | None = None,
 ) -> None:
     """Save replacement text to batch, then discard the original selection locally."""
     require_git_repository()
@@ -803,6 +872,7 @@ def command_discard_line_as_to_batch(
                 replacement_text,
                 no_edge_overlap=no_edge_overlap,
                 quiet=quiet,
+                auto_advance=auto_advance,
             )
 
             if preserve_selected_state:
@@ -823,6 +893,7 @@ def _command_discard_lines_to_batch_as(
     *,
     no_edge_overlap: bool = False,
     quiet: bool = False,
+    auto_advance: bool | None = None,
 ) -> None:
     """Persist replacement text to batch and discard original selected lines."""
     line_changes = load_line_changes_from_state()
@@ -999,7 +1070,7 @@ def _command_discard_lines_to_batch_as(
             file=sys.stderr,
         )
 
-    recalculate_selected_hunk_for_file(line_changes.path)
+    recalculate_selected_hunk_for_file(line_changes.path, auto_advance=auto_advance)
 
 
 def _select_rewritten_replacement_lines(
@@ -1082,6 +1153,7 @@ def _command_discard_binary_to_batch(
     *,
     quiet: bool = False,
     advance: bool = True,
+    auto_advance: bool | None = None,
 ) -> int:
     """Save one binary change to a batch, then discard it from the working tree."""
     file_path = binary_change.new_path if binary_change.new_path != "/dev/null" else binary_change.old_path
@@ -1107,10 +1179,8 @@ def _command_discard_binary_to_batch(
             file=sys.stderr,
         )
 
-    if quiet and advance:
-        advance_to_next_change()
-    elif not quiet:
-        advance_to_and_show_next_change()
+    if advance:
+        finish_selected_change_action(quiet=quiet, auto_advance=auto_advance)
     return 1
 
 
@@ -1295,6 +1365,7 @@ def command_discard_files_to_batch(
     *,
     quiet: bool = False,
     advance: bool = True,
+    auto_advance: bool | None = None,
 ) -> DiscardFilesToBatchResult:
     """Save resolved text files to a batch with one batch publication."""
     require_git_repository()
@@ -1353,6 +1424,7 @@ def command_discard_files_to_batch(
                     file=file_path,
                     quiet=True,
                     advance=False,
+                    auto_advance=auto_advance,
                 )
                 if discarded_hunks > 0:
                     total_hunks += discarded_hunks
@@ -1369,10 +1441,8 @@ def command_discard_files_to_batch(
         ownership_stack.close()
         patch_stack.close()
 
-    if quiet and advance:
-        advance_to_next_change()
-    elif not quiet:
-        advance_to_and_show_next_change()
+    if advance:
+        finish_selected_change_action(quiet=quiet, auto_advance=auto_advance)
 
     return DiscardFilesToBatchResult(
         discarded_hunks=total_hunks,
@@ -1386,6 +1456,7 @@ def _command_discard_file_to_batch(
     *,
     quiet: bool = False,
     advance: bool = True,
+    auto_advance: bool | None = None,
 ) -> int:
     """Discard entire file to batch (internal helper for file-scoped operations)."""
     auto_add_untracked_files([file_path])
@@ -1398,7 +1469,13 @@ def _command_discard_file_to_batch(
 
     binary_change = render_binary_file_change(file_path)
     if binary_change is not None:
-        return _command_discard_binary_to_batch(batch_name, binary_change, quiet=quiet, advance=advance)
+        return _command_discard_binary_to_batch(
+            batch_name,
+            binary_change,
+            quiet=quiet,
+            advance=advance,
+            auto_advance=auto_advance,
+        )
     if render_gitlink_change(file_path) is not None:
         exit_with_error(_("Discarding submodule pointer changes to a batch is not supported yet."))
 
@@ -1548,14 +1625,19 @@ def _command_discard_file_to_batch(
         log_journal("discard_file_to_batch_end", batch_name=batch_name, file_path=file_path)
 
         # Show next hunk
-        if quiet and advance:
-            advance_to_next_change()
-        elif not quiet:
-            advance_to_and_show_next_change()
+        if advance:
+            finish_selected_change_action(quiet=quiet, auto_advance=auto_advance)
         return len(patches_to_discard)
 
 
-def _command_discard_file_lines_to_batch(batch_name: str, file_path: str, line_id_specification: str, *, quiet: bool = False) -> int:
+def _command_discard_file_lines_to_batch(
+    batch_name: str,
+    file_path: str,
+    line_id_specification: str,
+    *,
+    quiet: bool = False,
+    auto_advance: bool | None = None,
+) -> int:
     """Discard specific lines from a file to batch (file-scoped with line IDs)."""
 
     cached_lines = _load_explicit_file_selection(file_path)
@@ -1641,15 +1723,17 @@ def _command_discard_file_lines_to_batch(batch_name: str, file_path: str, line_i
             lines=line_id_specification
         ), file=sys.stderr)
 
-    # Show next hunk
-    if quiet:
-        advance_to_next_change()
-    else:
-        advance_to_and_show_next_change()
+    finish_selected_change_action(quiet=quiet, auto_advance=auto_advance)
     return 1
 
 
-def _command_discard_lines_to_batch(batch_name: str, line_id_specification: str, *, quiet: bool = False) -> int:
+def _command_discard_lines_to_batch(
+    batch_name: str,
+    line_id_specification: str,
+    *,
+    quiet: bool = False,
+    auto_advance: bool | None = None,
+) -> int:
     """Save specific lines to batch and discard them from working tree (internal helper)."""
 
     log_journal("discard_lines_to_batch_start", batch_name=batch_name, line_ids=line_id_specification, quiet=quiet)
@@ -1736,13 +1820,19 @@ def _command_discard_lines_to_batch(batch_name: str, line_id_specification: str,
         print(_("✓ Discarded line(s) to batch '{name}': {lines}").format(name=batch_name, lines=line_id_specification), file=sys.stderr)
 
     # After modifying working tree, recalculate and show the updated hunk for this file
-    recalculate_selected_hunk_for_file(line_changes.path)
+    recalculate_selected_hunk_for_file(line_changes.path, auto_advance=auto_advance)
 
     log_journal("discard_lines_to_batch_success", batch_name=batch_name, line_ids=line_id_specification, file_path=line_changes.path)
     return 1
 
 
-def _command_discard_hunk_to_batch(batch_name: str, file_only: bool = False, *, quiet: bool = False) -> int:
+def _command_discard_hunk_to_batch(
+    batch_name: str,
+    file_only: bool = False,
+    *,
+    quiet: bool = False,
+    auto_advance: bool | None = None,
+) -> int:
     """Save whole hunk or file to batch and discard from working tree (internal helper)."""
     log_journal("discard_hunk_to_batch_start", batch_name=batch_name, file_only=file_only, quiet=quiet)
 
@@ -1760,7 +1850,12 @@ def _command_discard_hunk_to_batch(batch_name: str, file_only: bool = False, *, 
     if isinstance(selected_item, GitlinkChange):
         exit_with_error(_("Discarding submodule pointer changes to a batch is not supported yet."))
     if isinstance(selected_item, BinaryFileChange):
-        return _command_discard_binary_to_batch(batch_name, selected_item, quiet=quiet)
+        return _command_discard_binary_to_batch(
+            batch_name,
+            selected_item,
+            quiet=quiet,
+            auto_advance=auto_advance,
+        )
 
     # Get the file path and hash from currently cached hunk
     patch_hash = read_text_file_contents(get_selected_hunk_hash_file_path()).strip()
@@ -1771,6 +1866,7 @@ def _command_discard_hunk_to_batch(batch_name: str, file_only: bool = False, *, 
             selected_patch_hash=patch_hash,
             file_only=file_only,
             quiet=quiet,
+            auto_advance=auto_advance,
         )
 
 
@@ -1781,6 +1877,7 @@ def _command_discard_text_hunk_to_batch(
     selected_patch_hash: str,
     file_only: bool,
     quiet: bool,
+    auto_advance: bool | None = None,
 ) -> int:
     """Save one cached text patch selection to a batch, then discard it."""
     line_changes = build_line_changes_from_patch_lines(
@@ -1948,8 +2045,5 @@ def _command_discard_text_hunk_to_batch(
             else:
                 print(_("✓ Hunk saved to batch '{name}' and discarded from working tree").format(name=batch_name), file=sys.stderr)
 
-        if quiet:
-            advance_to_next_change()
-        else:
-            advance_to_and_show_next_change()
+        finish_selected_change_action(quiet=quiet, auto_advance=auto_advance)
         return len(patches_to_discard)

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -50,12 +50,11 @@ from ..core.models import BinaryFileChange, GitlinkChange
 from ..core.text_lifecycle import detect_empty_text_lifecycle_change
 from ..data.hunk_tracking import (
     SelectedChangeKind,
-    advance_to_and_show_next_change,
-    advance_to_next_change,
     apply_line_level_batch_filter_to_cached_hunk,
     cache_unstaged_file_as_single_hunk,
     clear_selected_change_state_files,
     fetch_next_change,
+    finish_selected_change_action,
     get_selected_change_file_path,
     load_selected_change,
     read_selected_change_kind,
@@ -64,6 +63,7 @@ from ..data.hunk_tracking import (
     record_gitlink_hunk_skipped,
     record_hunk_included,
     record_hunk_skipped,
+    refuse_bare_action_after_auto_advance_disabled,
     refuse_bare_action_after_file_list,
     render_binary_file_change,
     render_gitlink_change,
@@ -478,7 +478,11 @@ def _transient_include_failure_message(
     ).format(lines=line_id_specification, file=file_path)
 
 
-def command_include(*, quiet: bool = False) -> None:
+def command_include(
+    *,
+    quiet: bool = False,
+    auto_advance: bool | None = None,
+) -> None:
     """Include (stage) the selected hunk or binary file."""
 
     log_journal("command_include_start", quiet=quiet)
@@ -492,9 +496,10 @@ def command_include(*, quiet: bool = False) -> None:
     if refuse_ambiguous_bare_action_after_partial_file_review(FileReviewAction.INCLUDE):
         return 0
     refuse_bare_action_after_file_list("include")
+    refuse_bare_action_after_auto_advance_disabled("include")
 
     if read_selected_change_kind() == SelectedChangeKind.FILE:
-        command_include_file("")
+        command_include_file("", auto_advance=auto_advance)
         return 0
 
     item = load_selected_change()
@@ -530,10 +535,10 @@ def command_include(*, quiet: bool = False) -> None:
                     file=sys.stderr,
                 )
 
-            if quiet:
-                advance_to_next_change()
-            else:
-                advance_to_and_show_next_change()
+            finish_selected_change_action(
+                quiet=quiet,
+                auto_advance=auto_advance,
+            )
             return
 
         if isinstance(item, BinaryFileChange):
@@ -553,10 +558,10 @@ def command_include(*, quiet: bool = False) -> None:
                 change_desc = "added" if item.is_new_file() else ("deleted" if item.is_deleted_file() else "modified")
                 print(_("✓ Binary file {desc}: {file}").format(desc=change_desc, file=file_path), file=sys.stderr)
 
-            if quiet:
-                advance_to_next_change()
-            else:
-                advance_to_and_show_next_change()
+            finish_selected_change_action(
+                quiet=quiet,
+                auto_advance=auto_advance,
+            )
             return
 
         # Extract filename for user feedback (we already have LineLevelChange in item)
@@ -578,10 +583,10 @@ def command_include(*, quiet: bool = False) -> None:
         if not quiet:
             print(_("✓ Hunk staged from {file}").format(file=filename), file=sys.stderr)
 
-        if quiet:
-            advance_to_next_change()
-        else:
-            advance_to_and_show_next_change()
+        finish_selected_change_action(
+            quiet=quiet,
+            auto_advance=auto_advance,
+        )
 
 
 def command_include_file(
@@ -589,6 +594,7 @@ def command_include_file(
     *,
     quiet: bool = False,
     advance: bool = True,
+    auto_advance: bool | None = None,
 ) -> int:
     """Include (stage) all hunks from the specified file.
 
@@ -598,6 +604,7 @@ def command_include_file(
               If explicit path, uses that file.
         quiet: Suppress per-file status output while preserving selection state.
         advance: When quiet, advance the selection after staging this file.
+        auto_advance: Whether to select the next hunk after this action.
 
     Returns:
         Number of hunks staged from the requested file.
@@ -612,6 +619,7 @@ def command_include_file(
         if refuse_ambiguous_bare_action_after_partial_file_review(FileReviewAction.INCLUDE):
             return 0
         refuse_bare_action_after_file_list("include --file")
+        refuse_bare_action_after_auto_advance_disabled("include --file")
 
     # Determine target file
     if file == "":
@@ -719,7 +727,7 @@ def command_include_file(
         return 0
 
     if quiet and advance:
-        advance_to_next_change()
+        finish_selected_change_action(quiet=True, auto_advance=auto_advance)
     if quiet:
         return hunks_staged
 
@@ -738,12 +746,17 @@ def command_include_file(
         ).format(count=hunks_staged, file=target_file)
     print(msg, file=sys.stderr)
 
-    # Advance to next file's hunk
-    advance_to_and_show_next_change()
+    if advance:
+        finish_selected_change_action(quiet=False, auto_advance=auto_advance)
     return hunks_staged
 
 
-def command_include_file_as(replacement_text: str, file: str | None = None) -> None:
+def command_include_file_as(
+    replacement_text: str,
+    file: str | None = None,
+    *,
+    auto_advance: bool | None = None,
+) -> None:
     """Stage full-file replacement text for a live file-scoped selection."""
     require_git_repository()
     require_session_started()
@@ -754,6 +767,7 @@ def command_include_file_as(replacement_text: str, file: str | None = None) -> N
         if refuse_ambiguous_bare_action_after_partial_file_review(FileReviewAction.INCLUDE):
             return
         refuse_bare_action_after_file_list("include --file --as")
+        refuse_bare_action_after_auto_advance_disabled("include --file --as")
 
     operation_parts = ["include", "--as", replacement_text]
     if file is not None:
@@ -796,13 +810,21 @@ def command_include_file_as(replacement_text: str, file: str | None = None) -> N
             restore_selected_change_state(saved_selected_state)
         else:
             write_line_ids_file(get_processed_include_ids_file_path(), set())
-            recalculate_selected_hunk_for_file(target_file)
+            recalculate_selected_hunk_for_file(
+                target_file,
+                auto_advance=auto_advance,
+            )
         clear_last_file_review_state_if_file_matches(target_file)
 
     print(_("✓ Included file as replacement: {file}").format(file=target_file), file=sys.stderr)
 
 
-def command_include_line(line_id_specification: str, file: str | None = None) -> None:
+def command_include_line(
+    line_id_specification: str,
+    file: str | None = None,
+    *,
+    auto_advance: bool | None = None,
+) -> None:
     """Stage only the specified lines to the index.
 
     Args:
@@ -969,7 +991,10 @@ def command_include_line(line_id_specification: str, file: str | None = None) ->
                 file=sys.stderr,
             )
             print_remaining_line_changes_header(line_changes.path)
-            recalculate_selected_hunk_for_file(line_changes.path)
+            recalculate_selected_hunk_for_file(
+                line_changes.path,
+                auto_advance=auto_advance,
+            )
         finish_review_scoped_line_action(review_state, file_path=line_changes.path)
     if preserve_selected_state:
         print(
@@ -1175,6 +1200,7 @@ def command_include_line_as(
     file: str | None = None,
     *,
     no_edge_overlap: bool = False,
+    auto_advance: bool | None = None,
 ) -> None:
     """Stage a replacement for one contiguous selected line span and mask it."""
     require_git_repository()
@@ -1227,7 +1253,10 @@ def command_include_line_as(
                 file=sys.stderr,
             )
             print_remaining_line_changes_header(line_changes.path)
-            recalculate_selected_hunk_for_file(line_changes.path)
+            recalculate_selected_hunk_for_file(
+                line_changes.path,
+                auto_advance=auto_advance,
+            )
             finish_review_scoped_line_action(review_state, file_path=line_changes.path)
         else:
             if file == "":
@@ -1287,7 +1316,10 @@ def command_include_line_as(
                     file=sys.stderr,
                 )
                 print_remaining_line_changes_header(target_file)
-                recalculate_selected_hunk_for_file(target_file)
+                recalculate_selected_hunk_for_file(
+                    target_file,
+                    auto_advance=auto_advance,
+                )
             finish_review_scoped_line_action(review_state, file_path=target_file)
 
     if preserve_selected_state:
@@ -1300,7 +1332,14 @@ def command_include_line_as(
         )
 
 
-def command_include_to_batch(batch_name: str, line_ids: str | None = None, file: str | None = None, *, quiet: bool = False) -> None:
+def command_include_to_batch(
+    batch_name: str,
+    line_ids: str | None = None,
+    file: str | None = None,
+    *,
+    quiet: bool = False,
+    auto_advance: bool | None = None,
+) -> None:
     """Save selected changes to batch instead of staging.
 
     Args:
@@ -1310,6 +1349,7 @@ def command_include_to_batch(batch_name: str, line_ids: str | None = None, file:
               If empty string, uses selected hunk's file.
               If None, uses selected hunk (cached state).
         quiet: Suppress output
+        auto_advance: Whether to select the next hunk after this action.
     """
     require_git_repository()
     ensure_state_directory_exists()
@@ -1338,10 +1378,20 @@ def command_include_to_batch(batch_name: str, line_ids: str | None = None, file:
         ):
             selected_change = load_selected_change()
             if isinstance(selected_change, GitlinkChange):
-                _command_include_gitlink_to_batch(batch_name, selected_change, quiet=quiet)
+                _command_include_gitlink_to_batch(
+                    batch_name,
+                    selected_change,
+                    quiet=quiet,
+                    auto_advance=auto_advance,
+                )
                 return
             else:
-                _command_include_hunk_to_batch(batch_name, file_only=False, quiet=quiet)
+                _command_include_hunk_to_batch(
+                    batch_name,
+                    file_only=False,
+                    quiet=quiet,
+                    auto_advance=auto_advance,
+                )
                 return
         elif (
             file is None
@@ -1350,10 +1400,20 @@ def command_include_to_batch(batch_name: str, line_ids: str | None = None, file:
         ):
             selected_change = load_selected_change()
             if isinstance(selected_change, BinaryFileChange):
-                _command_include_binary_to_batch(batch_name, selected_change, quiet=quiet)
+                _command_include_binary_to_batch(
+                    batch_name,
+                    selected_change,
+                    quiet=quiet,
+                    auto_advance=auto_advance,
+                )
                 return
             else:
-                _command_include_hunk_to_batch(batch_name, file_only=False, quiet=quiet)
+                _command_include_hunk_to_batch(
+                    batch_name,
+                    file_only=False,
+                    quiet=quiet,
+                    auto_advance=auto_advance,
+                )
                 return
         elif file is not None:
             # File-scoped operation
@@ -1369,17 +1429,38 @@ def command_include_to_batch(batch_name: str, line_ids: str | None = None, file:
 
             if line_ids is None:
                 # --file without --line: include entire file
-                _command_include_file_to_batch(batch_name, target_file, quiet=quiet)
+                _command_include_file_to_batch(
+                    batch_name,
+                    target_file,
+                    quiet=quiet,
+                    auto_advance=auto_advance,
+                )
             else:
                 # --file with --line: include specific lines from file
-                _command_include_file_lines_to_batch(batch_name, target_file, line_ids, quiet=quiet)
+                _command_include_file_lines_to_batch(
+                    batch_name,
+                    target_file,
+                    line_ids,
+                    quiet=quiet,
+                    auto_advance=auto_advance,
+                )
         else:
             # Hunk-scoped operation (selected behavior)
             if line_ids is not None:
-                _command_include_lines_to_batch(batch_name, line_ids, quiet=quiet)
+                _command_include_lines_to_batch(
+                    batch_name,
+                    line_ids,
+                    quiet=quiet,
+                    auto_advance=auto_advance,
+                )
             else:
                 # Include entire selected hunk
-                _command_include_hunk_to_batch(batch_name, file_only=False, quiet=quiet)
+                _command_include_hunk_to_batch(
+                    batch_name,
+                    file_only=False,
+                    quiet=quiet,
+                    auto_advance=auto_advance,
+                )
     if original_file_scope in (None, "") and line_ids is not None:
         finish_review_scoped_line_action(review_state)
 
@@ -1427,6 +1508,7 @@ def _command_include_binary_to_batch(
     binary_change: BinaryFileChange,
     *,
     quiet: bool = False,
+    auto_advance: bool | None = None,
 ) -> None:
     """Save one binary change to a batch and mark it processed."""
     file_path = binary_change.new_path if binary_change.new_path != "/dev/null" else binary_change.old_path
@@ -1449,10 +1531,7 @@ def _command_include_binary_to_batch(
             file=sys.stderr,
         )
 
-    if quiet:
-        advance_to_next_change()
-    else:
-        advance_to_and_show_next_change()
+    finish_selected_change_action(quiet=quiet, auto_advance=auto_advance)
 
 
 def _command_include_gitlink_to_batch(
@@ -1460,6 +1539,7 @@ def _command_include_gitlink_to_batch(
     gitlink_change: GitlinkChange,
     *,
     quiet: bool = False,
+    auto_advance: bool | None = None,
 ) -> None:
     """Save one submodule pointer change to a batch and mark it processed."""
     file_path = gitlink_change.path()
@@ -1478,13 +1558,16 @@ def _command_include_gitlink_to_batch(
             file=sys.stderr,
         )
 
-    if quiet:
-        advance_to_next_change()
-    else:
-        advance_to_and_show_next_change()
+    finish_selected_change_action(quiet=quiet, auto_advance=auto_advance)
 
 
-def _command_include_file_to_batch(batch_name: str, file_path: str, *, quiet: bool = False) -> None:
+def _command_include_file_to_batch(
+    batch_name: str,
+    file_path: str,
+    *,
+    quiet: bool = False,
+    auto_advance: bool | None = None,
+) -> None:
     """Include entire file to batch (internal helper for file-scoped operations)."""
     auto_add_untracked_files([file_path])
 
@@ -1494,11 +1577,21 @@ def _command_include_file_to_batch(batch_name: str, file_path: str, *, quiet: bo
 
     binary_change = render_binary_file_change(file_path)
     if binary_change is not None:
-        _command_include_binary_to_batch(batch_name, binary_change, quiet=quiet)
+        _command_include_binary_to_batch(
+            batch_name,
+            binary_change,
+            quiet=quiet,
+            auto_advance=auto_advance,
+        )
         return
     gitlink_change = render_gitlink_change(file_path)
     if gitlink_change is not None:
-        _command_include_gitlink_to_batch(batch_name, gitlink_change, quiet=quiet)
+        _command_include_gitlink_to_batch(
+            batch_name,
+            gitlink_change,
+            quiet=quiet,
+            auto_advance=auto_advance,
+        )
         return
 
     # Detect file mode
@@ -1525,10 +1618,7 @@ def _command_include_file_to_batch(batch_name: str, file_path: str, *, quiet: bo
         if _save_empty_text_lifecycle_to_batch(batch_name, file_path, file_mode) is not None:
             if not quiet:
                 print(_("Included file '{file}' to batch '{batch}'").format(file=file_path, batch=batch_name), file=sys.stderr)
-            if quiet:
-                advance_to_next_change()
-            else:
-                advance_to_and_show_next_change()
+            finish_selected_change_action(quiet=quiet, auto_advance=auto_advance)
             return
 
         if not quiet:
@@ -1566,14 +1656,17 @@ def _command_include_file_to_batch(batch_name: str, file_path: str, *, quiet: bo
     if not quiet:
         print(_("Included file '{file}' to batch '{batch}'").format(file=file_path, batch=batch_name), file=sys.stderr)
 
-    # Show next hunk
-    if quiet:
-        advance_to_next_change()
-    else:
-        advance_to_and_show_next_change()
+    finish_selected_change_action(quiet=quiet, auto_advance=auto_advance)
 
 
-def _command_include_file_lines_to_batch(batch_name: str, file_path: str, line_id_specification: str, *, quiet: bool = False) -> None:
+def _command_include_file_lines_to_batch(
+    batch_name: str,
+    file_path: str,
+    line_id_specification: str,
+    *,
+    quiet: bool = False,
+    auto_advance: bool | None = None,
+) -> None:
     """Include specific lines from a file to batch (file-scoped with line IDs)."""
     if render_gitlink_change(file_path) is not None:
         exit_with_error(
@@ -1651,14 +1744,16 @@ def _command_include_file_lines_to_batch(batch_name: str, file_path: str, line_i
             lines=line_id_specification
         ), file=sys.stderr)
 
-    # Show next hunk
-    if quiet:
-        advance_to_next_change()
-    else:
-        advance_to_and_show_next_change()
+    finish_selected_change_action(quiet=quiet, auto_advance=auto_advance)
 
 
-def _command_include_lines_to_batch(batch_name: str, line_id_specification: str, *, quiet: bool = False) -> None:
+def _command_include_lines_to_batch(
+    batch_name: str,
+    line_id_specification: str,
+    *,
+    quiet: bool = False,
+    auto_advance: bool | None = None,
+) -> None:
     """Save specific lines to batch (internal helper)."""
 
     require_selected_hunk()
@@ -1717,10 +1812,14 @@ def _command_include_lines_to_batch(batch_name: str, line_id_specification: str,
         print(_("✓ Included line(s) to batch '{name}': {lines}").format(name=batch_name, lines=line_id_specification), file=sys.stderr)
 
     # Recalculate and show the updated hunk for this file with batched lines filtered out
-    recalculate_selected_hunk_for_file(line_changes.path)
+    recalculate_selected_hunk_for_file(line_changes.path, auto_advance=auto_advance)
 
 
-def _filter_selected_hunk_excluding_batched_lines(*, quiet: bool = False) -> None:
+def _filter_selected_hunk_excluding_batched_lines(
+    *,
+    quiet: bool = False,
+    auto_advance: bool | None = None,
+) -> None:
     """Filter the selected hunk to exclude lines that have been batched and display it."""
 
     # Apply filtering
@@ -1730,10 +1829,7 @@ def _filter_selected_hunk_excluding_batched_lines(*, quiet: bool = False) -> Non
         if not quiet:
             print(_("No more lines in this hunk."), file=sys.stderr)
 
-        if quiet:
-            advance_to_next_change()
-        else:
-            advance_to_and_show_next_change()
+        finish_selected_change_action(quiet=quiet, auto_advance=auto_advance)
         return
 
     # Display filtered hunk
@@ -1743,7 +1839,13 @@ def _filter_selected_hunk_excluding_batched_lines(*, quiet: bool = False) -> Non
             print_line_level_changes(line_changes)
 
 
-def _command_include_hunk_to_batch(batch_name: str, file_only: bool = False, *, quiet: bool = False) -> None:
+def _command_include_hunk_to_batch(
+    batch_name: str,
+    file_only: bool = False,
+    *,
+    quiet: bool = False,
+    auto_advance: bool | None = None,
+) -> None:
     """Save whole hunk or file to batch (internal helper)."""
 
     # Auto-create batch if it doesn't exist
@@ -1770,14 +1872,24 @@ def _command_include_hunk_to_batch(batch_name: str, file_only: bool = False, *, 
             if isinstance(patch, GitlinkChange):
                 patch_hash = compute_gitlink_change_hash(patch)
                 if patch_hash not in blocked_hashes:
-                    _command_include_gitlink_to_batch(batch_name, patch, quiet=quiet)
+                    _command_include_gitlink_to_batch(
+                        batch_name,
+                        patch,
+                        quiet=quiet,
+                        auto_advance=auto_advance,
+                    )
                     return
                 continue
 
             if isinstance(patch, BinaryFileChange):
                 patch_hash = compute_binary_file_hash(patch)
                 if patch_hash not in blocked_hashes:
-                    _command_include_binary_to_batch(batch_name, patch, quiet=quiet)
+                    _command_include_binary_to_batch(
+                        batch_name,
+                        patch,
+                        quiet=quiet,
+                        auto_advance=auto_advance,
+                    )
                     return
                 continue
 
@@ -1885,7 +1997,4 @@ def _command_include_hunk_to_batch(batch_name: str, file_only: bool = False, *, 
         else:
             print(_("✓ Hunk saved to batch '{name}'").format(name=batch_name), file=sys.stderr)
 
-    if quiet:
-        advance_to_next_change()
-    else:
-        advance_to_and_show_next_change()
+    finish_selected_change_action(quiet=quiet, auto_advance=auto_advance)

--- a/src/git_stage_batch/commands/skip.py
+++ b/src/git_stage_batch/commands/skip.py
@@ -21,15 +21,15 @@ from ..batch.selection import require_line_selection_in_view
 from ..core.models import BinaryFileChange, GitlinkChange
 from ..data.hunk_tracking import (
     SelectedChangeKind,
-    advance_to_and_show_next_change,
-    advance_to_next_change,
     fetch_next_change,
+    finish_selected_change_action,
     get_selected_change_file_path,
     load_selected_change,
     read_selected_change_kind,
     record_binary_hunk_skipped,
     record_gitlink_hunk_skipped,
     record_hunk_skipped,
+    refuse_bare_action_after_auto_advance_disabled,
     refuse_bare_action_after_file_list,
     require_selected_hunk,
 )
@@ -65,7 +65,11 @@ from ..utils.paths import (
 )
 
 
-def command_skip(*, quiet: bool = False) -> None:
+def command_skip(
+    *,
+    quiet: bool = False,
+    auto_advance: bool | None = None,
+) -> None:
     """Skip the selected hunk or binary file without staging it."""
     log_journal("command_skip_start", quiet=quiet)
 
@@ -78,9 +82,10 @@ def command_skip(*, quiet: bool = False) -> None:
     if refuse_ambiguous_bare_action_after_partial_file_review(FileReviewAction.SKIP):
         return
     refuse_bare_action_after_file_list("skip")
+    refuse_bare_action_after_auto_advance_disabled("skip")
 
     if read_selected_change_kind() == SelectedChangeKind.FILE:
-        command_skip_file("")
+        command_skip_file("", auto_advance=auto_advance)
         return
 
     item = load_selected_change()
@@ -110,10 +115,10 @@ def command_skip(*, quiet: bool = False) -> None:
                     file=sys.stderr,
                 )
 
-            if quiet:
-                advance_to_next_change()
-            else:
-                advance_to_and_show_next_change()
+            finish_selected_change_action(
+                quiet=quiet,
+                auto_advance=auto_advance,
+            )
             return
 
         if isinstance(item, BinaryFileChange):
@@ -130,10 +135,10 @@ def command_skip(*, quiet: bool = False) -> None:
                 change_desc = "added" if item.is_new_file() else ("deleted" if item.is_deleted_file() else "modified")
                 print(_("✓ Binary file {desc} skipped: {file}").format(desc=change_desc, file=file_path), file=sys.stderr)
 
-            if quiet:
-                advance_to_next_change()
-            else:
-                advance_to_and_show_next_change()
+            finish_selected_change_action(
+                quiet=quiet,
+                auto_advance=auto_advance,
+            )
             return
 
         # Text hunk - item is LineLevelChange here
@@ -149,10 +154,10 @@ def command_skip(*, quiet: bool = False) -> None:
         if not quiet:
             print(_("✓ Hunk skipped from {file}").format(file=filename), file=sys.stderr)
 
-        if quiet:
-            advance_to_next_change()
-        else:
-            advance_to_and_show_next_change()
+        finish_selected_change_action(
+            quiet=quiet,
+            auto_advance=auto_advance,
+        )
 
 
 def command_skip_file(
@@ -160,6 +165,7 @@ def command_skip_file(
     *,
     quiet: bool = False,
     advance: bool = True,
+    auto_advance: bool | None = None,
 ) -> int:
     """Skip all remaining hunks from the specified file.
 
@@ -184,6 +190,7 @@ def command_skip_file(
         if refuse_ambiguous_bare_action_after_partial_file_review(FileReviewAction.SKIP):
             return 0
         refuse_bare_action_after_file_list("skip --file")
+        refuse_bare_action_after_auto_advance_disabled("skip --file")
 
     # Determine target file
     if file == "":
@@ -259,7 +266,7 @@ def command_skip_file(
                 hunks_skipped += 1
 
         if quiet and advance:
-            advance_to_next_change()
+            finish_selected_change_action(quiet=True, auto_advance=auto_advance)
         if quiet:
             return hunks_skipped
 
@@ -270,11 +277,17 @@ def command_skip_file(
         ).format(count=hunks_skipped, file=target_file)
         print(msg, file=sys.stderr)
 
-        advance_to_and_show_next_change()
+        if advance:
+            finish_selected_change_action(quiet=False, auto_advance=auto_advance)
         return hunks_skipped
 
 
-def command_skip_line(line_id_specification: str, file: str | None = None) -> None:
+def command_skip_line(
+    line_id_specification: str,
+    file: str | None = None,
+    *,
+    auto_advance: bool | None = None,
+) -> None:
     """Mark only the specified lines as skipped.
 
     Args:
@@ -354,7 +367,7 @@ def command_skip_line(line_id_specification: str, file: str | None = None) -> No
             if read_selected_change_kind() == SelectedChangeKind.FILE:
                 print(_("✓ Skipped line(s): {lines}").format(lines=line_id_specification), file=sys.stderr)
                 finish_review_scoped_line_action(review_state)
-                command_skip_file("")
+                command_skip_file("", auto_advance=auto_advance)
                 return
 
             patch_hash = read_text_file_contents(get_selected_hunk_hash_file_path()).strip()
@@ -363,7 +376,10 @@ def command_skip_line(line_id_specification: str, file: str | None = None) -> No
             record_hunk_skipped(line_changes, patch_hash)
             print(_("✓ Skipped line(s): {lines}").format(lines=line_id_specification), file=sys.stderr)
             finish_review_scoped_line_action(review_state)
-            advance_to_and_show_next_change()
+            finish_selected_change_action(
+                quiet=False,
+                auto_advance=auto_advance,
+            )
             return
 
         filtered_lines = [

--- a/src/git_stage_batch/commands/start.py
+++ b/src/git_stage_batch/commands/start.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Optional
 
 from .again import command_again
+from ..data.auto_advance import DEFAULT_AUTO_ADVANCE, write_auto_advance_default
 from ..data.hunk_tracking import clear_selected_change_state_files, fetch_next_change, show_selected_change
 from ..data.file_tracking import auto_add_untracked_files
 from ..data.session import initialize_abort_state
@@ -15,19 +16,25 @@ from ..utils.git import require_git_repository
 from ..utils.paths import ensure_state_directory_exists, get_context_lines_file_path, get_abort_head_file_path
 
 
-def command_start(*, context_lines: Optional[int] = None, quiet: bool = False) -> None:
+def command_start(
+    *,
+    context_lines: Optional[int] = None,
+    quiet: bool = False,
+    auto_advance: bool | None = None,
+) -> None:
     """Start a new batch staging session.
 
     Args:
         context_lines: Number of context lines to use in diffs (default: 3)
         quiet: If True, suppress "No more hunks" message when no changes exist
+        auto_advance: Whether later actions should select the next hunk
     """
     require_git_repository()
     ensure_state_directory_exists()
 
     # If session already exists, run again logic instead
     if get_abort_head_file_path().exists():
-        command_again(quiet=quiet)
+        command_again(quiet=quiet, auto_advance=auto_advance)
         return
 
     # Batch reviews may be shown outside an active session. A new session must
@@ -36,6 +43,12 @@ def command_start(*, context_lines: Optional[int] = None, quiet: bool = False) -
 
     # Initialize abort state for new session
     initialize_abort_state()
+
+    write_auto_advance_default(
+        DEFAULT_AUTO_ADVANCE
+        if auto_advance is None else
+        auto_advance
+    )
 
     # Save context lines setting if provided
     if context_lines is not None:

--- a/src/git_stage_batch/data/auto_advance.py
+++ b/src/git_stage_batch/data/auto_advance.py
@@ -1,0 +1,32 @@
+"""Session preference for selecting the next hunk after an action."""
+
+from __future__ import annotations
+
+from ..utils.file_io import read_text_file_contents, write_text_file_contents
+from ..utils.paths import get_auto_advance_config_file_path
+
+
+DEFAULT_AUTO_ADVANCE = True
+
+
+def read_auto_advance_default() -> bool:
+    """Return whether actions should select the next hunk by default."""
+    value = read_text_file_contents(get_auto_advance_config_file_path()).strip()
+    if value == "false":
+        return False
+    if value == "true":
+        return True
+    return DEFAULT_AUTO_ADVANCE
+
+
+def write_auto_advance_default(auto_advance: bool) -> None:
+    """Persist whether actions should select the next hunk by default."""
+    value = "true\n" if auto_advance else "false\n"
+    write_text_file_contents(get_auto_advance_config_file_path(), value)
+
+
+def resolve_auto_advance(auto_advance: bool | None) -> bool:
+    """Resolve a command-specific preference against the session default."""
+    if auto_advance is not None:
+        return auto_advance
+    return read_auto_advance_default()

--- a/src/git_stage_batch/data/file_review_state.py
+++ b/src/git_stage_batch/data/file_review_state.py
@@ -819,10 +819,14 @@ def validate_implicit_live_to_batch_file_action(
     use that explicit file path. The boolean is true when the caller should stop
     after a live-action guard handled the request.
     """
-    from .hunk_tracking import refuse_bare_action_after_file_list
+    from .hunk_tracking import (
+        refuse_bare_action_after_auto_advance_disabled,
+        refuse_bare_action_after_file_list,
+    )
 
     review_action = _coerce_review_action(action)
     refuse_bare_action_after_file_list(action_command)
+    refuse_bare_action_after_auto_advance_disabled(action_command)
     if line_id_specification is None:
         return ImplicitLiveToBatchFileActionResult(
             reviewed_file=resolve_review_file_for_bare_whole_file_action(
@@ -864,7 +868,10 @@ def resolve_live_to_batch_action_scope(
     file: str | None,
 ) -> ActionScopeResolution:
     """Resolve pathless and implicit-file live-to-batch actions against live reviews."""
-    from .hunk_tracking import refuse_bare_action_after_file_list
+    from .hunk_tracking import (
+        refuse_bare_action_after_auto_advance_disabled,
+        refuse_bare_action_after_file_list,
+    )
 
     review_action = _coerce_review_action(action)
     if file is None:
@@ -875,6 +882,7 @@ def resolve_live_to_batch_action_scope(
             line_ids=line_ids,
         )
         refuse_bare_action_after_file_list(action_command)
+        refuse_bare_action_after_auto_advance_disabled(action_command)
         if refuse_live_action_for_batch_selection(review_action):
             return ActionScopeResolution(file=file, should_stop=True)
         if line_ids is None:
@@ -923,13 +931,17 @@ def resolve_live_line_action_scope(
     validate_pathless_before_live_guard: bool = False,
 ) -> ActionScopeResolution:
     """Validate a pathless or implicit-file live line action against review state."""
-    from .hunk_tracking import refuse_bare_action_after_file_list
+    from .hunk_tracking import (
+        refuse_bare_action_after_auto_advance_disabled,
+        refuse_bare_action_after_file_list,
+    )
 
     if file not in (None, ""):
         return ActionScopeResolution(file=file)
 
     review_action = _coerce_review_action(action)
     refuse_bare_action_after_file_list(action_command)
+    refuse_bare_action_after_auto_advance_disabled(action_command)
 
     if file is None and validate_pathless_before_live_guard:
         review_state = validate_pathless_review_line_action(

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -59,6 +59,7 @@ from ..exceptions import CommandError, MergeError, NoMoreHunks, exit_with_error
 from ..i18n import _, ngettext
 from ..output import print_line_level_changes, print_binary_file_change, print_gitlink_change
 from .consumed_selections import read_consumed_file_metadata
+from .auto_advance import resolve_auto_advance
 from .file_tracking import auto_add_untracked_files
 from ..utils.file_io import (
     read_file_paths_file,
@@ -145,6 +146,7 @@ def _load_line_changes_from_patch_path(patch_path: Path) -> LineLevelChange:
 class SelectedChangeClearReason(str, Enum):
     """Reasons selected change state was intentionally cleared."""
 
+    AUTO_ADVANCE_DISABLED = "auto-advance-disabled"
     FILE_LIST = "file-list"
     STALE_BATCH_SELECTION = "stale-batch-selection"
 
@@ -232,6 +234,14 @@ def mark_selected_change_cleared_by_stale_batch_selection(
         source="batch",
         batch_name=batch_name,
         file_path=file_path,
+    )
+
+
+def mark_selected_change_cleared_by_auto_advance_disabled() -> None:
+    """Record that an action left the next change unselected."""
+    _write_selected_change_clear_reason(
+        reason=SelectedChangeClearReason.AUTO_ADVANCE_DISABLED,
+        source="auto-advance",
     )
 
 
@@ -325,6 +335,16 @@ def selected_change_was_cleared_by_stale_batch_selection(
     return True
 
 
+def selected_change_was_cleared_by_auto_advance_disabled() -> bool:
+    """Return whether the current empty selection needs an explicit show."""
+    if read_selected_change_kind() is not None:
+        return False
+    marker = _read_selected_change_clear_reason()
+    if marker is None:
+        return False
+    return marker["reason"] == SelectedChangeClearReason.AUTO_ADVANCE_DISABLED.value
+
+
 def refuse_bare_action_after_file_list(
     action_command: str,
     *,
@@ -346,6 +366,23 @@ def refuse_bare_action_after_file_list(
             "before running:\n"
             "  git-stage-batch {action}"
         ).format(open_command=open_command, action=action_command)
+    )
+
+
+def refuse_bare_action_after_auto_advance_disabled(action_command: str) -> None:
+    """Refuse a bare action after a command declined to select the next hunk."""
+    if not selected_change_was_cleared_by_auto_advance_disabled():
+        return
+    raise CommandError(
+        _(
+            "No selected change.\n"
+            "The previous command did not choose the next hunk because automatic "
+            "advancement is disabled.\n\n"
+            "Run:\n"
+            "  git-stage-batch show\n"
+            "before running:\n"
+            "  git-stage-batch {action}"
+        ).format(action=action_command)
     )
 
 
@@ -1914,6 +1951,39 @@ def advance_to_and_show_next_change() -> None:
         print(_("No more hunks to process."), file=sys.stderr)
 
 
+def finish_selected_change_action(
+    *,
+    quiet: bool,
+    auto_advance: bool | None = None,
+) -> None:
+    """Apply the configured selection step after a hunk action completes."""
+    if not select_next_change_after_action(auto_advance=auto_advance):
+        return
+
+    if quiet:
+        return
+
+    if read_selected_change_kind() is None:
+        print(_("No more hunks to process."), file=sys.stderr)
+        return
+
+    show_selected_change()
+
+
+def select_next_change_after_action(
+    *,
+    auto_advance: bool | None = None,
+) -> bool:
+    """Select the next hunk after an action, or leave selection empty."""
+    if resolve_auto_advance(auto_advance):
+        advance_to_next_change()
+        return True
+
+    clear_selected_change_state_files()
+    mark_selected_change_cleared_by_auto_advance_disabled()
+    return False
+
+
 def snapshots_are_stale(file_path: str) -> bool:
     """Check if cached snapshots are stale (file changed since snapshots taken).
 
@@ -1982,7 +2052,11 @@ def require_selected_hunk() -> None:
             exit_with_error(_("Cached hunk is stale (file was changed). Run 'start' or 'again' to continue."))
 
 
-def recalculate_selected_hunk_for_file(file_path: str) -> None:
+def recalculate_selected_hunk_for_file(
+    file_path: str,
+    *,
+    auto_advance: bool | None = None,
+) -> None:
     """Recalculate the selected hunk for a specific file after modifications.
 
     After discard --line or include --line changes the working tree or index,
@@ -2001,14 +2075,20 @@ def recalculate_selected_hunk_for_file(file_path: str) -> None:
         line_changes = cache_unstaged_file_as_single_hunk(file_path)
         if line_changes is None:
             clear_selected_change_state_files()
-            from ..commands.show import command_show
-            command_show()
+            if resolve_auto_advance(auto_advance):
+                from ..commands.show import command_show
+                command_show()
+            else:
+                mark_selected_change_cleared_by_auto_advance_disabled()
             return
 
         if apply_line_level_batch_filter_to_cached_hunk():
             clear_selected_change_state_files()
-            from ..commands.show import command_show
-            command_show()
+            if resolve_auto_advance(auto_advance):
+                from ..commands.show import command_show
+                command_show()
+            else:
+                mark_selected_change_cleared_by_auto_advance_disabled()
             return
 
         line_changes = load_line_changes_from_state()
@@ -2083,8 +2163,11 @@ def recalculate_selected_hunk_for_file(file_path: str) -> None:
     # No more hunks for this file, advance to next file
     clear_selected_change_state_files()
     # Import here to avoid circular dependency
-    from ..commands.show import command_show
-    command_show()
+    if resolve_auto_advance(auto_advance):
+        from ..commands.show import command_show
+        command_show()
+    else:
+        mark_selected_change_cleared_by_auto_advance_disabled()
 
 
 def record_hunk_included(hunk_hash: str) -> None:

--- a/src/git_stage_batch/tui/interactive.py
+++ b/src/git_stage_batch/tui/interactive.py
@@ -48,11 +48,15 @@ def _handle_include(flow_state: FlowState) -> None:
     if flow_state.source.role is LocationRole.WORKING_TREE:
         if flow_state.target.role is LocationRole.STAGING_AREA:
             from ..commands.include import command_include
-            command_include(quiet=True)
+            command_include(quiet=True, auto_advance=True)
         elif flow_state.target.role is LocationRole.BATCH:
             # Include to batch (via skip-to-batch)
             from ..commands.include import command_include_to_batch
-            command_include_to_batch(flow_state.target.batch_name, quiet=True)
+            command_include_to_batch(
+                flow_state.target.batch_name,
+                quiet=True,
+                auto_advance=True,
+            )
         else:
             raise ValueError(f"Unknown target role: {flow_state.target.role}")
     elif flow_state.source.role is LocationRole.BATCH:
@@ -71,11 +75,15 @@ def _handle_skip(flow_state: FlowState) -> None:
     if flow_state.source.role is LocationRole.WORKING_TREE:
         if flow_state.target.role is LocationRole.STAGING_AREA:
             from ..commands.skip import command_skip
-            command_skip(quiet=True)
+            command_skip(quiet=True, auto_advance=True)
         elif flow_state.target.role is LocationRole.BATCH:
             # Skip to batch
             from ..commands.include import command_include_to_batch
-            command_include_to_batch(flow_state.target.batch_name, quiet=True)
+            command_include_to_batch(
+                flow_state.target.batch_name,
+                quiet=True,
+                auto_advance=True,
+            )
         else:
             raise ValueError(f"Unknown target role: {flow_state.target.role}")
     elif flow_state.source.role is LocationRole.BATCH:
@@ -92,11 +100,15 @@ def _handle_discard(flow_state: FlowState) -> None:
         if flow_state.target.role is LocationRole.STAGING_AREA:
             from ..commands.discard import command_discard
             if confirm_destructive_operation("discard", _("This will remove the hunk from your working tree.")):
-                command_discard(quiet=True)
+                command_discard(quiet=True, auto_advance=True)
         elif flow_state.target.role is LocationRole.BATCH:
             # Discard to batch (save for later)
             from ..commands.discard import command_discard_to_batch
-            command_discard_to_batch(flow_state.target.batch_name, quiet=True)
+            command_discard_to_batch(
+                flow_state.target.batch_name,
+                quiet=True,
+                auto_advance=True,
+            )
         else:
             raise ValueError(f"Unknown target role: {flow_state.target.role}")
     elif flow_state.source.role is LocationRole.BATCH:
@@ -621,7 +633,7 @@ def start_interactive_mode() -> None:
     # Auto-initialize session (allow degraded mode if no changes)
     degraded_mode = False
     try:
-        command_start(quiet=True)
+        command_start(quiet=True, auto_advance=True)
     except CommandError as e:
         if e.exit_code == 2:
             degraded_mode = True
@@ -765,11 +777,16 @@ def handle_file_selection(flow_state: FlowState) -> None:
     if action_input in ("i", "include"):
         if flow_state.source.role is LocationRole.WORKING_TREE:
             if flow_state.target.role is LocationRole.STAGING_AREA:
-                command_include_file(file="")
+                command_include_file(file="", auto_advance=True)
             elif flow_state.target.role is LocationRole.BATCH:
                 # Include file to batch
                 from ..commands.include import command_include_to_batch
-                command_include_to_batch(flow_state.target.batch_name, file="", quiet=True)
+                command_include_to_batch(
+                    flow_state.target.batch_name,
+                    file="",
+                    quiet=True,
+                    auto_advance=True,
+                )
             else:
                 raise ValueError(f"Unknown target role: {flow_state.target.role}")
         elif flow_state.source.role is LocationRole.BATCH:
@@ -786,10 +803,14 @@ def handle_file_selection(flow_state: FlowState) -> None:
             print(_("Skip is not available when pulling from a batch."), file=sys.stderr)
             return
         if flow_state.target.role is LocationRole.STAGING_AREA:
-            command_skip_file()
+            command_skip_file(auto_advance=True)
         elif flow_state.target.role is LocationRole.BATCH:
             from ..commands.include import command_include_to_batch
-            command_include_to_batch(flow_state.target.batch_name, file="")
+            command_include_to_batch(
+                flow_state.target.batch_name,
+                file="",
+                auto_advance=True,
+            )
         else:
             raise ValueError(f"Unknown target role: {flow_state.target.role}")
         fetch_next_change()
@@ -797,11 +818,16 @@ def handle_file_selection(flow_state: FlowState) -> None:
         if flow_state.source.role is LocationRole.WORKING_TREE:
             if flow_state.target.role is LocationRole.STAGING_AREA:
                 if confirm_destructive_operation("discard", _("This will remove all hunks from {filename} in your working tree.").format(filename=filename)):
-                    command_discard_file(file="")
+                    command_discard_file(file="", auto_advance=True)
             elif flow_state.target.role is LocationRole.BATCH:
                 # Discard file to batch
                 from ..commands.discard import command_discard_to_batch
-                command_discard_to_batch(flow_state.target.batch_name, file="", quiet=True)
+                command_discard_to_batch(
+                    flow_state.target.batch_name,
+                    file="",
+                    quiet=True,
+                    auto_advance=True,
+                )
             else:
                 raise ValueError(f"Unknown target role: {flow_state.target.role}")
         elif flow_state.source.role is LocationRole.BATCH:
@@ -898,11 +924,16 @@ def handle_line_selection(flow_state: FlowState) -> None:
         if action == "include":
             if flow_state.source.role is LocationRole.WORKING_TREE:
                 if flow_state.target.role is LocationRole.STAGING_AREA:
-                    command_include_line(line_ids)
+                    command_include_line(line_ids, auto_advance=True)
                 elif flow_state.target.role is LocationRole.BATCH:
                     # Include lines to batch (via skip-to-batch with line IDs)
                     from ..commands.include import command_include_to_batch
-                    command_include_to_batch(flow_state.target.batch_name, line_ids=line_ids, quiet=True)
+                    command_include_to_batch(
+                        flow_state.target.batch_name,
+                        line_ids=line_ids,
+                        quiet=True,
+                        auto_advance=True,
+                    )
                 else:
                     raise ValueError(f"Unknown target role: {flow_state.target.role}")
             elif flow_state.source.role is LocationRole.BATCH:
@@ -918,21 +949,30 @@ def handle_line_selection(flow_state: FlowState) -> None:
                 print(_("Skip is not available when pulling from a batch."), file=sys.stderr)
                 return
             if flow_state.target.role is LocationRole.STAGING_AREA:
-                command_skip_line(line_ids)
+                command_skip_line(line_ids, auto_advance=True)
             elif flow_state.target.role is LocationRole.BATCH:
                 from ..commands.include import command_include_to_batch
-                command_include_to_batch(flow_state.target.batch_name, line_ids=line_ids)
+                command_include_to_batch(
+                    flow_state.target.batch_name,
+                    line_ids=line_ids,
+                    auto_advance=True,
+                )
             else:
                 raise ValueError(f"Unknown target role: {flow_state.target.role}")
         elif action == "discard":
             if flow_state.source.role is LocationRole.WORKING_TREE:
                 if flow_state.target.role is LocationRole.STAGING_AREA:
                     if confirm_destructive_operation("discard", _("This will remove lines {line_ids} from your working tree.").format(line_ids=line_ids)):
-                        command_discard_line(line_ids)
+                        command_discard_line(line_ids, auto_advance=True)
                 elif flow_state.target.role is LocationRole.BATCH:
                     # Discard lines to batch
                     from ..commands.discard import command_discard_to_batch
-                    command_discard_to_batch(flow_state.target.batch_name, line_ids=line_ids, quiet=True)
+                    command_discard_to_batch(
+                        flow_state.target.batch_name,
+                        line_ids=line_ids,
+                        quiet=True,
+                        auto_advance=True,
+                    )
                 else:
                     raise ValueError(f"Unknown target role: {flow_state.target.role}")
             elif flow_state.source.role is LocationRole.BATCH:

--- a/src/git_stage_batch/utils/paths.py
+++ b/src/git_stage_batch/utils/paths.py
@@ -66,6 +66,11 @@ def get_config_state_directory_path() -> Path:
     return path
 
 
+def get_auto_advance_config_file_path() -> Path:
+    """Get the path to the automatic hunk selection preference."""
+    return get_config_state_directory_path() / "auto-advance.txt"
+
+
 def get_abort_state_directory_path() -> Path:
     """Get the directory containing abort/recovery state."""
     path = get_session_directory_path() / "abort"

--- a/tests/cli/test_argument_parser.py
+++ b/tests/cli/test_argument_parser.py
@@ -266,6 +266,17 @@ def test_parse_command_line_start():
     assert callable(args.func)
 
 
+def test_parse_command_line_start_passes_auto_advance(monkeypatch):
+    mock_command = Mock()
+    monkeypatch.setattr(argument_parser.commands, "command_start", mock_command)
+
+    args = parse_command_line(["start", "--no-auto-advance"], quiet=True)
+
+    assert args is not None
+    args.func(args)
+    mock_command.assert_called_once_with(context_lines=None, auto_advance=False)
+
+
 def test_parse_command_line_stop():
     """Test parsing stop command."""
     args = parse_command_line(["stop"], quiet=True)
@@ -291,6 +302,17 @@ def test_parse_command_line_again_alias():
     assert args.command == "a"
     assert hasattr(args, "func")
     assert callable(args.func)
+
+
+def test_parse_command_line_again_passes_auto_advance(monkeypatch):
+    mock_command = Mock()
+    monkeypatch.setattr(argument_parser.commands, "command_again", mock_command)
+
+    args = parse_command_line(["again", "--auto-advance"], quiet=True)
+
+    assert args is not None
+    args.func(args)
+    mock_command.assert_called_once_with(auto_advance=True)
 
 
 def test_parse_command_line_show():

--- a/tests/cli/test_argument_parser.py
+++ b/tests/cli/test_argument_parser.py
@@ -847,12 +847,16 @@ def test_parse_command_line_discard_with_files_dispatches_per_file(monkeypatch):
     mock_command = Mock()
     monkeypatch.setattr(argument_parser.commands, "command_discard_file", mock_command)
     monkeypatch.setattr(argument_parser, "list_changed_files", lambda: ["foo.py", "bar.py", "notes.txt"])
+    monkeypatch.setattr(argument_parser, "list_untracked_files", lambda: [])
 
     args = parse_command_line(["discard", "--files", "*.py"], quiet=True)
 
     assert args is not None
     args.func(args)
-    assert mock_command.call_args_list == [call("foo.py"), call("bar.py")]
+    assert mock_command.call_args_list == [
+        call("foo.py", auto_advance=None),
+        call("bar.py", auto_advance=None),
+    ]
 
 
 def test_parse_command_line_discard_from_with_files_resolves_batch_scope_only(monkeypatch):
@@ -889,21 +893,22 @@ def test_parse_command_line_discard_to_with_files_uses_aggregate_dispatch(monkey
             discarded_files=["foo.py", "bar.py"],
         )
     )
-    mock_advance = Mock()
+    mock_select_next = Mock(return_value=True)
     mock_show = Mock()
     monkeypatch.setattr(argument_parser.commands, "command_discard_files_to_batch", mock_command)
-    monkeypatch.setattr(argument_parser, "advance_to_next_change", mock_advance)
+    monkeypatch.setattr(argument_parser, "select_next_change_after_action", mock_select_next)
     monkeypatch.setattr(argument_parser, "show_selected_change", mock_show)
     monkeypatch.setattr(argument_parser, "list_changed_files", lambda: ["foo.py", "bar.py", "notes.txt"])
+    monkeypatch.setattr(argument_parser, "list_untracked_files", lambda: [])
 
     args = parse_command_line(["discard", "--to", "batch", "--files", "*.py"], quiet=True)
 
     assert args is not None
     args.func(args)
     assert mock_command.call_args_list == [
-        call("batch", ["foo.py", "bar.py"], quiet=True, advance=False),
+        call("batch", ["foo.py", "bar.py"], quiet=True, advance=False, auto_advance=None),
     ]
-    mock_advance.assert_called_once_with()
+    mock_select_next.assert_called_once_with(auto_advance=None)
     mock_show.assert_called_once_with()
 
 
@@ -1078,7 +1083,11 @@ def test_parse_command_line_discard_with_file_and_as_dispatches_file_replacement
 
     assert args is not None
     args.func(args)
-    mock_command.assert_called_once_with("replacement", file="path.txt")
+    mock_command.assert_called_once_with(
+        "replacement",
+        file="path.txt",
+        auto_advance=None,
+    )
 
 
 def test_parse_command_line_discard_with_file_and_as_stdin_dispatches_file_replacement(monkeypatch):
@@ -1094,7 +1103,11 @@ def test_parse_command_line_discard_with_file_and_as_stdin_dispatches_file_repla
 
     assert args is not None
     args.func(args)
-    mock_command.assert_called_once_with("replacement\n", file="path.txt")
+    mock_command.assert_called_once_with(
+        "replacement\n",
+        file="path.txt",
+        auto_advance=None,
+    )
 
 
 def test_parse_command_line_discard_to_line_range_and_as_stdin_dispatches_replacement(monkeypatch):
@@ -1116,6 +1129,7 @@ def test_parse_command_line_discard_to_line_range_and_as_stdin_dispatches_replac
         "replacement one\nreplacement two\n",
         file="path.txt",
         no_edge_overlap=False,
+        auto_advance=None,
     )
 
 
@@ -1150,6 +1164,7 @@ def test_parse_command_line_discard_with_no_edge_overlap_dispatches_line_replace
         "replacement",
         file="path.txt",
         no_edge_overlap=True,
+        auto_advance=None,
     )
 
 
@@ -1187,7 +1202,13 @@ def test_parse_command_line_discard_with_file_and_line_dispatches_file_scope(mon
 
     assert args is not None
     args.func(args)
-    mock_command.assert_called_once_with("2-3", file="path.txt")
+    mock_command.assert_called_once_with(
+        "2-3",
+        file="path.txt",
+        auto_advance=None,
+    )
+
+
 def test_parse_command_line_discard_alias():
     """Test parsing discard command alias 'd'."""
     args = parse_command_line(["d"], quiet=True)
@@ -1195,6 +1216,17 @@ def test_parse_command_line_discard_alias():
     assert args.command == "d"
     assert hasattr(args, "func")
     assert callable(args.func)
+
+
+def test_parse_command_line_discard_passes_auto_advance(monkeypatch):
+    mock_command = Mock()
+    monkeypatch.setattr(argument_parser.commands, "command_discard", mock_command)
+
+    args = parse_command_line(["discard", "--no-auto-advance"], quiet=True)
+
+    assert args is not None
+    args.func(args)
+    mock_command.assert_called_once_with(auto_advance=False)
 
 
 def test_parse_command_line_discard_with_file():

--- a/tests/cli/test_argument_parser.py
+++ b/tests/cli/test_argument_parser.py
@@ -483,6 +483,17 @@ def test_parse_command_line_include_alias():
     assert callable(args.func)
 
 
+def test_parse_command_line_include_passes_auto_advance(monkeypatch):
+    mock_command = Mock()
+    monkeypatch.setattr(argument_parser.commands, "command_include", mock_command)
+
+    args = parse_command_line(["include", "--no-auto-advance"], quiet=True)
+
+    assert args is not None
+    args.func(args)
+    mock_command.assert_called_once_with(auto_advance=False)
+
+
 def test_parse_command_line_include_with_file():
     """Test parsing include command with --file flag."""
     args = parse_command_line(["include", "--file"], quiet=True)
@@ -537,7 +548,11 @@ def test_parse_command_line_include_with_file_and_as_dispatches_file_replacement
 
     assert args is not None
     args.func(args)
-    mock_command.assert_called_once_with("replacement", file="path.txt")
+    mock_command.assert_called_once_with(
+        "replacement",
+        file="path.txt",
+        auto_advance=None,
+    )
 
 
 def test_parse_command_line_include_with_file_and_as_stdin_dispatches_file_replacement(monkeypatch):
@@ -553,7 +568,11 @@ def test_parse_command_line_include_with_file_and_as_stdin_dispatches_file_repla
 
     assert args is not None
     args.func(args)
-    mock_command.assert_called_once_with("replacement\n", file="path.txt")
+    mock_command.assert_called_once_with(
+        "replacement\n",
+        file="path.txt",
+        auto_advance=None,
+    )
 
 
 def test_parse_command_line_include_with_line_range_and_as_stdin_dispatches_line_replacement(monkeypatch):
@@ -574,6 +593,7 @@ def test_parse_command_line_include_with_line_range_and_as_stdin_dispatches_line
         "replacement one\nreplacement two\n",
         file="path.txt",
         no_edge_overlap=False,
+        auto_advance=None,
     )
 
 
@@ -589,18 +609,23 @@ def test_parse_command_line_include_with_file_and_line_dispatches_file_scope(mon
 
     assert args is not None
     args.func(args)
-    mock_command.assert_called_once_with("2-3", file="path.txt")
+    mock_command.assert_called_once_with(
+        "2-3",
+        file="path.txt",
+        auto_advance=None,
+    )
 
 
 def test_parse_command_line_include_with_files_dispatches_per_file(monkeypatch):
     """Include should dispatch once per file resolved from --files."""
     mock_command = Mock(return_value=1)
     monkeypatch.setattr(argument_parser.commands, "command_include_file", mock_command)
-    mock_advance_to_next_change = Mock()
-    monkeypatch.setattr(argument_parser, "advance_to_next_change", mock_advance_to_next_change)
+    mock_select_next = Mock(return_value=True)
+    monkeypatch.setattr(argument_parser, "select_next_change_after_action", mock_select_next)
     mock_show_selected_change = Mock()
     monkeypatch.setattr(argument_parser, "show_selected_change", mock_show_selected_change)
     monkeypatch.setattr(argument_parser, "list_changed_files", lambda: ["foo.py", "dir/bar.py", "baz.txt"])
+    monkeypatch.setattr(argument_parser, "list_untracked_files", lambda: [])
 
     args = parse_command_line(["include", "--files", "*.py"], quiet=True)
 
@@ -611,7 +636,7 @@ def test_parse_command_line_include_with_files_dispatches_per_file(monkeypatch):
         call("foo.py", quiet=True, advance=False),
         call("dir/bar.py", quiet=True, advance=False),
     ]
-    mock_advance_to_next_change.assert_called_once_with()
+    mock_select_next.assert_called_once_with(auto_advance=None)
     mock_show_selected_change.assert_called_once_with()
 
 
@@ -680,7 +705,13 @@ def test_parse_command_line_include_with_no_edge_overlap_dispatches_line_replace
 
     assert args is not None
     args.func(args)
-    mock_command.assert_called_once_with("2-3", "replacement", file="path.txt", no_edge_overlap=True)
+    mock_command.assert_called_once_with(
+        "2-3",
+        "replacement",
+        file="path.txt",
+        no_edge_overlap=True,
+        auto_advance=None,
+    )
 
 
 def test_parse_command_line_include_rejects_no_edge_overlap_without_line_as():

--- a/tests/cli/test_argument_parser.py
+++ b/tests/cli/test_argument_parser.py
@@ -754,6 +754,17 @@ def test_parse_command_line_skip_alias():
     assert callable(args.func)
 
 
+def test_parse_command_line_skip_passes_auto_advance(monkeypatch):
+    mock_command = Mock()
+    monkeypatch.setattr(argument_parser.commands, "command_skip", mock_command)
+
+    args = parse_command_line(["skip", "--no-auto-advance"], quiet=True)
+
+    assert args is not None
+    args.func(args)
+    mock_command.assert_called_once_with(auto_advance=False)
+
+
 def test_parse_command_line_skip_with_file():
     """Test parsing skip command with --file flag."""
     args = parse_command_line(["skip", "--file"], quiet=True)
@@ -792,11 +803,12 @@ def test_parse_command_line_skip_files_dispatches_per_file(monkeypatch):
     """Skip should dispatch once per file resolved from --files."""
     mock_command = Mock(side_effect=[1, 2])
     monkeypatch.setattr(argument_parser.commands, "command_skip_file", mock_command)
-    mock_advance_to_next_change = Mock()
-    monkeypatch.setattr(argument_parser, "advance_to_next_change", mock_advance_to_next_change)
+    mock_select_next = Mock(return_value=True)
+    monkeypatch.setattr(argument_parser, "select_next_change_after_action", mock_select_next)
     mock_show_selected_change = Mock()
     monkeypatch.setattr(argument_parser, "show_selected_change", mock_show_selected_change)
     monkeypatch.setattr(argument_parser, "list_changed_files", lambda: ["foo.py", "bar.py", "notes.txt"])
+    monkeypatch.setattr(argument_parser, "list_untracked_files", lambda: [])
 
     args = parse_command_line(["skip", "--files", "*.py"], quiet=True)
 
@@ -806,13 +818,14 @@ def test_parse_command_line_skip_files_dispatches_per_file(monkeypatch):
         call("foo.py", quiet=True, advance=False),
         call("bar.py", quiet=True, advance=False),
     ]
-    mock_advance_to_next_change.assert_called_once_with()
+    mock_select_next.assert_called_once_with(auto_advance=None)
     mock_show_selected_change.assert_called_once_with()
 
 
 def test_parse_command_line_skip_rejects_lines_with_multiple_files(monkeypatch):
     """Skip should reject --line/--lines when --files resolves to multiple files."""
     monkeypatch.setattr(argument_parser, "list_changed_files", lambda: ["foo.py", "bar.py"])
+    monkeypatch.setattr(argument_parser, "list_untracked_files", lambda: [])
     args = parse_command_line(["skip", "--files", "*.py", "--lines", "1"], quiet=True)
     assert args is not None
 

--- a/tests/commands/test_discard.py
+++ b/tests/commands/test_discard.py
@@ -9,7 +9,12 @@ from git_stage_batch.batch import list_batch_files, read_batch_metadata, read_fi
 from git_stage_batch.commands.discard import command_discard_to_batch
 from git_stage_batch.batch.validation import batch_exists
 from git_stage_batch.commands.apply_from import command_apply_from_batch
-from git_stage_batch.data.hunk_tracking import fetch_next_change, recalculate_selected_hunk_for_file
+from git_stage_batch.data.hunk_tracking import (
+    fetch_next_change,
+    load_selected_change,
+    recalculate_selected_hunk_for_file,
+    selected_change_was_cleared_by_auto_advance_disabled,
+)
 
 import subprocess
 
@@ -176,6 +181,26 @@ class TestCommandDiscard:
         )
         assert "file2.txt" in result.stdout
         assert "file1.txt" not in result.stdout
+
+    def test_discard_no_auto_advance_leaves_no_selected_hunk(self, temp_git_repo):
+        """discard --no-auto-advance should leave the next hunk unselected."""
+        file1 = temp_git_repo / "file1.txt"
+        file2 = temp_git_repo / "file2.txt"
+        file1.write_text("original 1\n")
+        file2.write_text("original 2\n")
+        subprocess.run(["git", "add", "file1.txt", "file2.txt"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add files"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        file1.write_text("modified 1\n")
+        file2.write_text("modified 2\n")
+        command_start(quiet=True)
+
+        command_discard(quiet=True, auto_advance=False)
+
+        assert load_selected_change() is None
+        assert selected_change_was_cleared_by_auto_advance_disabled() is True
+        with pytest.raises(CommandError, match="automatic advancement is disabled"):
+            command_discard(quiet=True)
 
     def test_discard_all_hunks_processed(self, temp_git_repo, capsys):
         """Test discard when all hunks have been processed."""

--- a/tests/commands/test_include.py
+++ b/tests/commands/test_include.py
@@ -17,7 +17,12 @@ from git_stage_batch.commands.include import (
 )
 from git_stage_batch.core.models import HunkHeader, LineEntry, LineLevelChange
 from git_stage_batch.commands.start import command_start
-from git_stage_batch.data.hunk_tracking import fetch_next_change
+from git_stage_batch.commands.show import command_show
+from git_stage_batch.data.hunk_tracking import (
+    fetch_next_change,
+    load_selected_change,
+    selected_change_was_cleared_by_auto_advance_disabled,
+)
 from git_stage_batch.data.line_state import load_line_changes_from_state
 from git_stage_batch.exceptions import CommandError, NoMoreHunks
 from git_stage_batch.commands.again import command_again
@@ -144,6 +149,34 @@ class TestCommandInclude:
         )
         assert "file1.txt" in result.stdout
         assert "file2.txt" in result.stdout
+
+    def test_include_no_auto_advance_requires_show_before_next_action(
+        self,
+        temp_git_repo,
+    ):
+        """include --no-auto-advance should not hide-select the next hunk."""
+        file1 = temp_git_repo / "file1.txt"
+        file2 = temp_git_repo / "file2.txt"
+        file1.write_text("original 1\n")
+        file2.write_text("original 2\n")
+        subprocess.run(["git", "add", "file1.txt", "file2.txt"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add files"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        file1.write_text("modified 1\n")
+        file2.write_text("modified 2\n")
+        command_start(quiet=True)
+
+        command_include(quiet=True, auto_advance=False)
+
+        assert load_selected_change() is None
+        assert selected_change_was_cleared_by_auto_advance_disabled() is True
+        with pytest.raises(CommandError, match="automatic advancement is disabled"):
+            command_include(quiet=True)
+
+        command_show(porcelain=True)
+        next_change = load_line_changes_from_state()
+        assert next_change is not None
+        assert next_change.path == "file2.txt"
 
     def test_include_file_to_batch_uses_scoped_ownership_metadata(
         self,

--- a/tests/commands/test_skip.py
+++ b/tests/commands/test_skip.py
@@ -6,7 +6,11 @@ import pytest
 
 from git_stage_batch.commands.skip import command_skip, command_skip_line
 from git_stage_batch.commands.start import command_start
-from git_stage_batch.data.hunk_tracking import fetch_next_change
+from git_stage_batch.data.hunk_tracking import (
+    fetch_next_change,
+    load_selected_change,
+    selected_change_was_cleared_by_auto_advance_disabled,
+)
 from git_stage_batch.data.line_state import load_line_changes_from_state
 from git_stage_batch.exceptions import CommandError
 from git_stage_batch.utils.file_io import read_text_file_contents
@@ -119,6 +123,26 @@ class TestCommandSkip:
 
         # Second hunk should now be available
         # (Would normally use command_include here but we're just testing skip)
+
+    def test_skip_no_auto_advance_leaves_no_selected_hunk(self, temp_git_repo):
+        """skip --no-auto-advance should leave the next hunk unselected."""
+        file1 = temp_git_repo / "file1.txt"
+        file2 = temp_git_repo / "file2.txt"
+        file1.write_text("original 1\n")
+        file2.write_text("original 2\n")
+        subprocess.run(["git", "add", "file1.txt", "file2.txt"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add files"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        file1.write_text("modified 1\n")
+        file2.write_text("modified 2\n")
+        command_start(quiet=True)
+
+        command_skip(quiet=True, auto_advance=False)
+
+        assert load_selected_change() is None
+        assert selected_change_was_cleared_by_auto_advance_disabled() is True
+        with pytest.raises(CommandError, match="automatic advancement is disabled"):
+            command_skip(quiet=True)
 
 
 class TestCommandSkipLine:

--- a/tests/data/test_auto_advance.py
+++ b/tests/data/test_auto_advance.py
@@ -10,6 +10,12 @@ from git_stage_batch.data.auto_advance import (
     read_auto_advance_default,
     write_auto_advance_default,
 )
+from git_stage_batch.data.hunk_tracking import (
+    refuse_bare_action_after_auto_advance_disabled,
+    select_next_change_after_action,
+    selected_change_was_cleared_by_auto_advance_disabled,
+)
+from git_stage_batch.exceptions import CommandError
 from git_stage_batch.utils.file_io import write_text_file_contents
 from git_stage_batch.utils.paths import (
     ensure_state_directory_exists,
@@ -83,3 +89,11 @@ def test_again_preserves_auto_advance_default_without_override(temp_git_repo):
     command_again(quiet=True)
 
     assert read_auto_advance_default() is False
+
+
+def test_disabled_auto_advance_records_empty_selection(temp_git_repo):
+    assert select_next_change_after_action(auto_advance=False) is False
+    assert selected_change_was_cleared_by_auto_advance_disabled() is True
+
+    with pytest.raises(CommandError, match="automatic advancement is disabled"):
+        refuse_bare_action_after_auto_advance_disabled("include")

--- a/tests/data/test_auto_advance.py
+++ b/tests/data/test_auto_advance.py
@@ -1,0 +1,54 @@
+"""Tests for the automatic hunk selection preference."""
+
+import subprocess
+
+import pytest
+
+from git_stage_batch.data.auto_advance import (
+    read_auto_advance_default,
+    write_auto_advance_default,
+)
+from git_stage_batch.utils.file_io import write_text_file_contents
+from git_stage_batch.utils.paths import (
+    ensure_state_directory_exists,
+    get_auto_advance_config_file_path,
+)
+
+
+@pytest.fixture
+def temp_git_repo(tmp_path, monkeypatch):
+    """Create a temporary git repository for testing."""
+    repo = tmp_path / "test_repo"
+    repo.mkdir()
+    monkeypatch.chdir(repo)
+
+    subprocess.run(["git", "init"], check=True, cwd=repo, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], check=True, cwd=repo, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], check=True, cwd=repo, capture_output=True)
+
+    (repo / "README.md").write_text("# Test\n")
+    subprocess.run(["git", "add", "README.md"], check=True, cwd=repo, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "Initial commit"], check=True, cwd=repo, capture_output=True)
+
+    ensure_state_directory_exists()
+    return repo
+
+
+def test_auto_advance_default_is_enabled_without_config(temp_git_repo):
+    assert read_auto_advance_default() is True
+
+
+def test_auto_advance_default_round_trips(temp_git_repo):
+    write_auto_advance_default(False)
+
+    assert read_auto_advance_default() is False
+
+    write_auto_advance_default(True)
+
+    assert read_auto_advance_default() is True
+
+
+def test_auto_advance_default_ignores_unknown_config(temp_git_repo):
+    write_text_file_contents(get_auto_advance_config_file_path(), "maybe\n")
+
+    assert read_auto_advance_default() is True

--- a/tests/data/test_auto_advance.py
+++ b/tests/data/test_auto_advance.py
@@ -4,6 +4,8 @@ import subprocess
 
 import pytest
 
+from git_stage_batch.commands.again import command_again
+from git_stage_batch.commands.start import command_start
 from git_stage_batch.data.auto_advance import (
     read_auto_advance_default,
     write_auto_advance_default,
@@ -52,3 +54,32 @@ def test_auto_advance_default_ignores_unknown_config(temp_git_repo):
     write_text_file_contents(get_auto_advance_config_file_path(), "maybe\n")
 
     assert read_auto_advance_default() is True
+
+
+def test_start_initializes_auto_advance_default(temp_git_repo):
+    readme = temp_git_repo / "README.md"
+    readme.write_text("# Test\nChanged\n")
+
+    command_start(quiet=True, auto_advance=False)
+
+    assert read_auto_advance_default() is False
+
+
+def test_again_updates_auto_advance_default(temp_git_repo):
+    readme = temp_git_repo / "README.md"
+    readme.write_text("# Test\nChanged\n")
+    command_start(quiet=True, auto_advance=False)
+
+    command_again(quiet=True, auto_advance=True)
+
+    assert read_auto_advance_default() is True
+
+
+def test_again_preserves_auto_advance_default_without_override(temp_git_repo):
+    readme = temp_git_repo / "README.md"
+    readme.write_text("# Test\nChanged\n")
+    command_start(quiet=True, auto_advance=False)
+
+    command_again(quiet=True)
+
+    assert read_auto_advance_default() is False

--- a/tests/tui/test_interactive.py
+++ b/tests/tui/test_interactive.py
@@ -254,7 +254,12 @@ class TestHandleFileSelection:
                             source=FlowLocation.WORKING_TREE,
                             target=FlowLocation.for_batch("mybatch")
                         ))
-                        mock_discard.assert_called_once_with("mybatch", file="", quiet=True)
+                        mock_discard.assert_called_once_with(
+                            "mybatch",
+                            file="",
+                            quiet=True,
+                            auto_advance=True,
+                        )
 
     def test_handle_file_selection_cancel(self):
         """Test file selection with Ctrl-C."""
@@ -299,7 +304,7 @@ class TestHandleLineSelection:
                             source=FlowLocation.WORKING_TREE,
                             target=FlowLocation.STAGING_AREA
                         ))
-                        mock_include.assert_called_once_with("1")
+                        mock_include.assert_called_once_with("1", auto_advance=True)
 
     def test_handle_line_selection_no_changed_lines(self):
         """Test line selection when no changed lines exist."""


### PR DESCRIPTION
The CLI selects and displays the next hunk after include, skip, and discard finish. The interactive prompt also relies on that behavior so one action can naturally lead to the next prompt.

Users sometimes need a command to stop after one action, especially when automation wants to inspect state or choose the next step explicitly. Without a control, a later bare action can operate on the next hunk before the caller has run show.

This PR adds --auto-advance and --no-auto-advance to start, again, include, skip, and discard. start and again set the session default for later actions, while action commands can override it for one invocation. When automatic selection is disabled, a completed action clears the selected hunk and a following bare action refuses until show selects and displays the next hunk.

The PR also keeps interactive mode on its prompt-driven advancement behavior and updates tests, the man page, bash completion, and website docs.

Verification:
- PYTHONPATH=src uv run pytest tests/data/test_auto_advance.py tests/commands/test_include.py tests/commands/test_skip.py tests/commands/test_discard.py tests/cli/test_argument_parser.py tests/tui/test_interactive.py
- PYTHONPATH=src uv run ruff check src/git_stage_batch tests/data/test_auto_advance.py tests/commands/test_include.py tests/commands/test_skip.py tests/commands/test_discard.py tests/cli/test_argument_parser.py tests/tui/test_interactive.py
- bash -n completions/git-stage-batch