### PR TITLE
Allow presence-only review lines to be selected by range

### DIFF
--- a/src/git_stage_batch/batch/selection.py
+++ b/src/git_stage_batch/batch/selection.py
@@ -359,14 +359,14 @@ def translate_batch_file_gutter_ids_to_selection_ids(
         return None, None
 
     from ..data.file_review_state import (
-        fresh_batch_review_selection_groups_for_action,
+        fresh_batch_review_selections_for_action,
         validate_review_scoped_line_selection,
     )
     from ..data.hunk_tracking import render_batch_file_display
 
-    review_groups = fresh_batch_review_selection_groups_for_action(batch_name, file_path, action)
-    if review_groups is not None:
-        validate_review_scoped_line_selection(selected_ids, review_groups)
+    review_selections = fresh_batch_review_selections_for_action(batch_name, file_path, action)
+    if review_selections is not None:
+        validate_review_scoped_line_selection(selected_ids, review_selections)
 
     rendered = render_batch_file_display(batch_name, file_path)
     if rendered is None:
@@ -374,7 +374,7 @@ def translate_batch_file_gutter_ids_to_selection_ids(
 
     display_id_map = (
         rendered.review_gutter_to_selection_id or rendered.gutter_to_selection_id
-        if review_groups is not None else
+        if review_selections is not None else
         rendered.gutter_to_selection_id
     )
     rendered_for_messages = (
@@ -386,7 +386,7 @@ def translate_batch_file_gutter_ids_to_selection_ids(
                 for gutter_id, selection_id in display_id_map.items()
             },
         )
-        if review_groups is not None else
+        if review_selections is not None else
         rendered
     )
     selection_ids: set[int] = set()

--- a/src/git_stage_batch/commands/reset.py
+++ b/src/git_stage_batch/commands/reset.py
@@ -42,7 +42,7 @@ from ..i18n import _
 from ..data.file_review_state import (
     FileReviewAction,
     ReviewSource,
-    fresh_batch_review_selection_groups_for_action,
+    fresh_batch_review_selections_for_action,
     read_last_file_review_state,
     resolve_batch_source_action_scope,
     validate_review_scoped_line_selection,
@@ -251,14 +251,14 @@ def _translate_reset_line_ids_to_selection_ids(
     if is_batch_submodule_pointer(files[file_path]):
         refuse_batch_submodule_pointer_lines(_("Reset"))
 
-    review_groups = fresh_batch_review_selection_groups_for_action(
+    review_selections = fresh_batch_review_selections_for_action(
         batch_name,
         file_path,
         FileReviewAction.RESET_FROM_BATCH,
     )
-    if review_groups is None:
+    if review_selections is None:
         return selected_ids
-    validate_review_scoped_line_selection(selected_ids.to_set(), review_groups)
+    validate_review_scoped_line_selection(selected_ids, review_selections)
 
     rendered = render_batch_file_display(batch_name, file_path)
     if rendered is None:

--- a/src/git_stage_batch/commands/status.py
+++ b/src/git_stage_batch/commands/status.py
@@ -21,7 +21,7 @@ from ..data.file_review_state import (
     ReviewSource,
     read_last_file_review_state,
     selected_change_matches_review_state,
-    shown_complete_review_selection_groups,
+    shown_review_selections_for_action,
 )
 from ..data.hunk_tracking import (
     SelectedChangeKind,
@@ -167,11 +167,11 @@ def _read_batch_review_display_ids(file_path: str) -> list[int]:
 
     return sorted({
         display_id
-        for group in shown_complete_review_selection_groups(
+        for selection in shown_review_selections_for_action(
             review_state,
             FileReviewAction.INCLUDE_FROM_BATCH,
         )
-        for display_id in group
+        for display_id in selection.display_ids
     })
 
 
@@ -194,11 +194,11 @@ def _read_live_review_display_ids(file_path: str) -> list[int] | None:
 
     return sorted({
         display_id
-        for group in shown_complete_review_selection_groups(
+        for selection in shown_review_selections_for_action(
             review_state,
             FileReviewAction.INCLUDE,
         )
-        for display_id in group
+        for display_id in selection.display_ids
     })
 
 

--- a/src/git_stage_batch/data/file_review_state.py
+++ b/src/git_stage_batch/data/file_review_state.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import shlex
+from collections.abc import Iterable
 from dataclasses import asdict, dataclass
 from enum import Enum
 from hashlib import sha256
@@ -11,7 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from ..core.actionable_changes import ActionableSelectionReason
-from ..core.line_selection import parse_line_selection
+from ..core.line_selection import LineRanges, LineSelection, parse_line_selection_ranges
 from ..core.models import ReviewActionGroup
 from ..data.line_state import convert_line_changes_to_serializable_dict, load_line_changes_from_state
 from ..editor import EditorBuffer
@@ -50,7 +51,7 @@ class FileReviewAction(str, Enum):
 
 @dataclass(frozen=True)
 class FileReviewSelectionState:
-    """One complete actionable selection shown by a file review."""
+    """One actionable selection shown by a file review."""
 
     display_ids: tuple[int, ...]
     selection_ids: tuple[int, ...]
@@ -59,6 +60,7 @@ class FileReviewSelectionState:
     last_page: int
     reason: ActionableSelectionReason
     actions: tuple[FileReviewAction, ...]
+    is_splittable: bool = False
 
 
 @dataclass(frozen=True)
@@ -209,6 +211,7 @@ def read_last_file_review_state() -> FileReviewState | None:
                 last_page=selection["last_page"],
                 reason=ActionableSelectionReason(selection["reason"]),
                 actions=tuple(FileReviewAction(action) for action in selection["actions"]),
+                is_splittable=bool(selection["is_splittable"]),
             )
             for selection in data.get("selections", [])
         )
@@ -514,11 +517,27 @@ def _format_pages(pages: set[int]) -> str:
     return format_line_ids(sorted(pages))
 
 
-def shown_complete_review_selection_groups(
+def _format_line_ranges(selection: LineRanges) -> str:
+    return selection.to_line_spec()
+
+
+def _coerce_line_ranges(selection: LineSelection | Iterable[int]) -> LineRanges:
+    if isinstance(selection, LineRanges):
+        return selection
+    return LineRanges.from_lines(selection)
+
+
+@dataclass(frozen=True)
+class _ReviewValidationGroup:
+    display_ids: LineRanges
+    is_splittable: bool
+
+
+def shown_review_selections_for_action(
     review_state: FileReviewState,
     action: FileReviewAction | str,
-) -> list[set[int]]:
-    """Return complete actionable display-ID groups from shown review pages."""
+) -> list[FileReviewSelectionState]:
+    """Return actionable selections fully contained by the shown review pages."""
     review_action = _coerce_review_action(action)
     shown_pages = (
         set(range(1, review_state.page_count + 1))
@@ -526,19 +545,19 @@ def shown_complete_review_selection_groups(
         set(review_state.shown_pages)
     )
     return [
-        set(selection.display_ids)
+        selection
         for selection in review_state.selections
         if review_action in selection.actions
         and set(range(selection.first_page, selection.last_page + 1)).issubset(shown_pages)
     ]
 
 
-def fresh_batch_review_selection_groups_for_action(
+def fresh_batch_review_selections_for_action(
     batch_name: str,
     file_path: str,
     action: FileReviewAction | str,
-) -> list[set[int]] | None:
-    """Return shown review groups for a fresh matching batch review, if one is active."""
+) -> list[FileReviewSelectionState] | None:
+    """Return shown review selections for a fresh matching batch review, if one is active."""
     review_state = read_last_file_review_state()
     if review_state is None:
         return None
@@ -564,19 +583,7 @@ def fresh_batch_review_selection_groups_for_action(
             )
         )
 
-    return shown_complete_review_selection_groups(review_state, action)
-
-
-def fresh_batch_review_display_ids_for_action(
-    batch_name: str,
-    file_path: str,
-    action: FileReviewAction | str,
-) -> set[int] | None:
-    """Return shown display IDs for a fresh matching batch review, if one is active."""
-    groups = fresh_batch_review_selection_groups_for_action(batch_name, file_path, action)
-    if groups is None:
-        return None
-    return {display_id for group in groups for display_id in group}
+    return shown_review_selections_for_action(review_state, action)
 
 
 def _print_stale_or_mismatched_file_review_help(action: str, review_state: FileReviewState) -> None:
@@ -967,50 +974,69 @@ def resolve_live_line_action_scope(
 
 
 def validate_review_scoped_line_selection(
-    requested_ids: set[int],
-    valid_selection_groups: list[set[int]],
+    requested_ids: LineSelection | Iterable[int],
+    valid_selections: Iterable[FileReviewSelectionState],
 ) -> None:
     """Validate a union of complete actionable review selections."""
-    groups = [set(group) for group in valid_selection_groups if group]
+    requested_ranges = _coerce_line_ranges(requested_ids)
+    groups: list[_ReviewValidationGroup] = []
+    for selection in valid_selections:
+        display_ids = LineRanges.from_lines(selection.display_ids)
+        if display_ids:
+            groups.append(
+                _ReviewValidationGroup(
+                    display_ids=display_ids,
+                    is_splittable=selection.is_splittable,
+                )
+            )
 
-    def can_cover(remaining_ids: frozenset[int]) -> bool:
+    def can_cover(remaining_ids: LineRanges) -> bool:
         if not remaining_ids:
             return True
-        first_id = min(remaining_ids)
+        first_id = remaining_ids.first()
+        if first_id is None:
+            return True
         for group in groups:
-            if first_id not in group:
+            if first_id not in group.display_ids:
                 continue
-            if not group.issubset(remaining_ids):
+            if group.is_splittable:
+                selected_from_group = remaining_ids.intersection(group.display_ids)
+                if can_cover(remaining_ids.difference(selected_from_group)):
+                    return True
                 continue
-            if can_cover(frozenset(remaining_ids - group)):
+            if group.display_ids.difference(remaining_ids):
+                continue
+            if can_cover(remaining_ids.difference(group.display_ids)):
                 return True
         return False
 
-    if can_cover(frozenset(requested_ids)):
+    if can_cover(requested_ranges):
         return
 
-    matched_ids = {
-        display_id
-        for group in groups
-        if group.issubset(requested_ids)
-        for display_id in group
-    }
-
-    outside_ids = requested_ids - matched_ids
+    matched_ids = LineRanges.empty()
     for group in groups:
-        overlap = outside_ids & group
-        if overlap and overlap != group:
+        if group.is_splittable:
+            matched_ids = matched_ids.union(requested_ranges.intersection(group.display_ids))
+        elif not group.display_ids.difference(requested_ranges):
+            matched_ids = matched_ids.union(group.display_ids)
+
+    outside_ids = requested_ranges.difference(matched_ids)
+    for group in groups:
+        if group.is_splittable:
+            continue
+        overlap = outside_ids.intersection(group.display_ids)
+        if overlap and overlap != group.display_ids:
             raise CommandError(
                 _("Line selection #{requested} only partly selects a reviewed change.\nUse: --line {required}").format(
-                    requested=_format_pages(requested_ids),
-                    required=_format_pages(group),
+                    requested=_format_line_ranges(requested_ranges),
+                    required=_format_line_ranges(group.display_ids),
                 )
             )
 
     if outside_ids:
         raise CommandError(
             _("Line selection #{ids} is not valid from the current file review.").format(
-                ids=_format_pages(outside_ids),
+                ids=_format_line_ranges(outside_ids),
             )
         )
 
@@ -1065,10 +1091,10 @@ def validate_pathless_review_line_action(
         raise CommandError("\n".join(lines))
 
     try:
-        requested_ids = set(parse_line_selection(line_id_specification))
+        requested_ids = parse_line_selection_ranges(line_id_specification)
     except ValueError as error:
         raise CommandError(str(error)) from error
 
-    valid_groups = shown_complete_review_selection_groups(review_state, review_action)
-    validate_review_scoped_line_selection(requested_ids, valid_groups)
+    valid_selections = shown_review_selections_for_action(review_state, review_action)
+    validate_review_scoped_line_selection(requested_ids, valid_selections)
     return review_state

--- a/src/git_stage_batch/output/file_review.py
+++ b/src/git_stage_batch/output/file_review.py
@@ -754,6 +754,48 @@ def _change_index_containing_review_display_ids(
     return 0
 
 
+def _selection_ids_for_display_ids(
+    model: FileReviewModel,
+    display_ids: tuple[int, ...],
+) -> tuple[int, ...]:
+    """Translate review display IDs back to line-selection IDs."""
+    if model.display_id_by_selection_id is None:
+        return display_ids
+    selection_id_by_display_id = {
+        display_id: selection_id
+        for selection_id, display_id in model.display_id_by_selection_id.items()
+    }
+    return tuple(
+        selection_id_by_display_id[display_id]
+        for display_id in display_ids
+        if display_id in selection_id_by_display_id
+    )
+
+
+def _display_ids_for_change_pages(
+    model: FileReviewModel,
+    change: ReviewChange,
+    shown_pages: tuple[int, ...],
+) -> tuple[int, ...]:
+    """Return the display IDs from one visual change on the shown pages."""
+    display_ids: list[int] = []
+    seen_display_ids: set[int] = set()
+    for page_number in shown_pages:
+        page = model.pages[page_number - 1]
+        for fragment in page.changes:
+            if fragment.change.index != change.index:
+                continue
+            for display_id in _display_ids_for_rows(
+                fragment.rows,
+                model.display_id_by_selection_id,
+            ):
+                if display_id in seen_display_ids:
+                    continue
+                display_ids.append(display_id)
+                seen_display_ids.add(display_id)
+    return tuple(display_ids)
+
+
 def _supplemental_batch_review_selections(
     model: FileReviewModel,
     *,

--- a/src/git_stage_batch/output/file_review.py
+++ b/src/git_stage_batch/output/file_review.py
@@ -193,17 +193,18 @@ def _reason_for_selection_ids(
     selection_ids: tuple[int, ...],
 ) -> ActionableSelectionReason:
     selected_id_set = set(selection_ids)
-    changed_kinds = {
-        line.kind
-        for line in line_changes.lines
-        if line.id in selected_id_set
-        and line.kind in ("+", "-")
-    }
-    return (
-        ActionableSelectionReason.REPLACEMENT
-        if {"-", "+"}.issubset(changed_kinds)
-        else ActionableSelectionReason.SIMPLE
-    )
+    saw_addition = False
+    saw_deletion = False
+    for line in line_changes.lines:
+        if line.id not in selected_id_set or line.kind not in ("+", "-"):
+            continue
+        if line.kind == "+":
+            saw_addition = True
+        else:
+            saw_deletion = True
+        if saw_addition and saw_deletion:
+            return ActionableSelectionReason.REPLACEMENT
+    return ActionableSelectionReason.SIMPLE
 
 
 def _actionable_selections_from_selection_groups(

--- a/src/git_stage_batch/output/file_review.py
+++ b/src/git_stage_batch/output/file_review.py
@@ -170,6 +170,17 @@ def _partly_selects_ownership_group(
     )
 
 
+def _change_is_presence_only(change: ReviewChange) -> bool:
+    saw_changed_row = False
+    for row in change.rows:
+        if row.kind not in ("+", "-") or row.id is None:
+            continue
+        saw_changed_row = True
+        if row.kind != "+":
+            return False
+    return saw_changed_row
+
+
 def _coerce_actionable_reason(reason: str) -> ActionableSelectionReason:
     try:
         return ActionableSelectionReason(reason)

--- a/src/git_stage_batch/output/file_review.py
+++ b/src/git_stage_batch/output/file_review.py
@@ -796,6 +796,48 @@ def _display_ids_for_change_pages(
     return tuple(display_ids)
 
 
+def _shown_line_action_selections(
+    model: FileReviewModel,
+    shown_pages: tuple[int, ...],
+    *,
+    source: ReviewSource,
+) -> list[ActionableSelection]:
+    """Return line-action selections fully contained by the shown pages."""
+    shown_page_set = set(shown_pages)
+    selections: list[ActionableSelection] = []
+    for change in model.changes:
+        if not change.display_ids:
+            continue
+        can_split_presence = (
+            source != ReviewSource.BATCH
+            and _change_is_presence_only(change)
+        )
+        display_ids = (
+            _display_ids_for_change_pages(model, change, shown_pages)
+            if can_split_presence else
+            change.display_ids
+        )
+        if not display_ids:
+            continue
+        pages = _pages_containing_review_display_ids(model, display_ids)
+        if not pages or not set(pages).issubset(shown_page_set):
+            continue
+        selections.append(
+            ActionableSelection(
+                display_ids=display_ids,
+                selection_ids=(
+                    _selection_ids_for_display_ids(model, display_ids)
+                    if can_split_presence else
+                    change.selection_ids
+                ),
+                reason=change.reason,
+                note=change.note,
+                actions=change.actions,
+            )
+        )
+    return selections
+
+
 def _supplemental_batch_review_selections(
     model: FileReviewModel,
     *,

--- a/src/git_stage_batch/output/file_review.py
+++ b/src/git_stage_batch/output/file_review.py
@@ -1049,7 +1049,6 @@ def print_file_review(
 ) -> None:
     """Print a page-aware file review."""
     page_count = len(model.pages)
-    shown_page_set = set(shown_pages)
     shown_fragments = [
         fragment
         for page in shown_pages
@@ -1072,12 +1071,11 @@ def print_file_review(
             seen_display_ids.add(display_id)
     shown_line_spec = _line_spec_for_display_ids(tuple(shown_display_ids))
     shown_change_spec = _change_spec_for_fragments(shown_fragments)
-    complete_changes = [
-        change
-        for change in shown_changes
-        if change.display_ids
-        if set(range(change.first_page, change.last_page + 1)).issubset(shown_page_set)
-    ]
+    complete_line_action_selections = _shown_line_action_selections(
+        model,
+        shown_pages,
+        source=source,
+    )
 
     _print_header(
         model.line_changes.path,
@@ -1148,7 +1146,7 @@ def print_file_review(
         page_count=page_count,
         shown_change_spec=shown_change_spec,
         shown_line_spec=shown_line_spec,
-        complete_changes=complete_changes,
+        complete_line_action_selections=complete_line_action_selections,
         total_changes=len(model.changes),
         page_spec=page_spec,
         command_source_args=command_source_args,
@@ -1157,9 +1155,16 @@ def print_file_review(
     )
 
 
-def _change_supports_action(change: ReviewChange, action: FileReviewAction) -> bool:
-    """Return whether a rendered review change supports an action."""
-    return not change.actions or action.value in change.actions
+def _selection_supports_action(selection: ActionableSelection, action: FileReviewAction) -> bool:
+    """Return whether a line-action selection supports an action."""
+    return not selection.actions or action.value in selection.actions
+
+
+def _line_spec_for_selections(selections: list[ActionableSelection]) -> str:
+    display_ids: list[int] = []
+    for selection in selections:
+        display_ids.extend(selection.display_ids)
+    return format_line_ids(display_ids)
 
 
 def _review_change_heading_action(change: ReviewChange) -> str:
@@ -1355,7 +1360,7 @@ def _print_footer(
     page_count: int,
     shown_change_spec: str,
     shown_line_spec: str,
-    complete_changes: list[ReviewChange],
+    complete_line_action_selections: list[ActionableSelection],
     total_changes: int,
     page_spec: str,
     command_source_args: str,
@@ -1379,19 +1384,19 @@ def _print_footer(
         if source == ReviewSource.BATCH else
         FileReviewAction.INCLUDE
     )
-    primary_changes = [
-        change
-        for change in complete_changes
-        if _change_supports_action(change, primary_action)
+    primary_selections = [
+        selection
+        for selection in complete_line_action_selections
+        if _selection_supports_action(selection, primary_action)
     ]
-    reset_changes = [
-        change
-        for change in complete_changes
-        if _change_supports_action(change, FileReviewAction.RESET_FROM_BATCH)
+    reset_selections = [
+        selection
+        for selection in complete_line_action_selections
+        if _selection_supports_action(selection, FileReviewAction.RESET_FROM_BATCH)
     ]
 
-    if primary_changes:
-        combined_selection = ",".join(format_line_ids(list(change.display_ids)) for change in primary_changes)
+    if primary_selections:
+        combined_selection = _line_spec_for_selections(primary_selections)
         include_line_command = (
             _line_action_command("include", review_state, line_spec=combined_selection, pathless_line=True)
             if review_state is not None else
@@ -1426,8 +1431,8 @@ def _print_footer(
                 discard_line_command or f"git-stage-batch discard{command_source_args} --line {combined_selection}",
             )
         )
-        if source == ReviewSource.BATCH and reset_changes:
-            reset_selection = ",".join(format_line_ids(list(change.display_ids)) for change in reset_changes)
+        if source == ReviewSource.BATCH and reset_selections:
+            reset_selection = _line_spec_for_selections(reset_selections)
             reset_line_command = _line_action_command(
                 FileReviewAction.RESET_FROM_BATCH,
                 review_state,
@@ -1440,8 +1445,8 @@ def _print_footer(
                     reset_line_command or f"git-stage-batch reset{command_source_args} --line {reset_selection}",
                 )
             )
-    elif reset_changes:
-        reset_selection = ",".join(format_line_ids(list(change.display_ids)) for change in reset_changes)
+    elif reset_selections:
+        reset_selection = _line_spec_for_selections(reset_selections)
         reset_line_command = _line_action_command(
             FileReviewAction.RESET_FROM_BATCH,
             review_state,

--- a/src/git_stage_batch/output/file_review.py
+++ b/src/git_stage_batch/output/file_review.py
@@ -854,7 +854,7 @@ def make_file_review_state(
     """Create persisted review state from a rendered page selection."""
     page_count = len(model.pages)
     shown_page_set = set(shown_pages)
-    selection_actions = (
+    default_actions = (
         (
             FileReviewAction.INCLUDE_FROM_BATCH,
             FileReviewAction.DISCARD_FROM_BATCH,
@@ -874,22 +874,47 @@ def make_file_review_state(
     for change in model.changes:
         if not change.display_ids:
             continue
-        if visible_display_ids is not None and not set(change.display_ids).issubset(visible_display_ids):
+        is_splittable = (
+            source != ReviewSource.BATCH
+            and _change_is_presence_only(change)
+        )
+        display_ids = (
+            _display_ids_for_change_pages(model, change, shown_pages)
+            if is_splittable else
+            change.display_ids
+        )
+        if not display_ids:
             continue
-        change_actions = (
+        if visible_display_ids is not None and not set(display_ids).issubset(visible_display_ids):
+            continue
+        pages = _pages_containing_review_display_ids(
+            model,
+            display_ids,
+        )
+        if not pages:
+            continue
+        selection_actions = (
             tuple(FileReviewAction(action) for action in change.actions)
             if change.actions else
-            selection_actions
+            default_actions
         )
         selections.append(
             FileReviewSelectionState(
-                display_ids=change.display_ids,
-                selection_ids=change.selection_ids,
-                change_index=change.index,
-                first_page=change.first_page,
-                last_page=change.last_page,
+                display_ids=display_ids,
+                selection_ids=(
+                    _selection_ids_for_display_ids(model, display_ids)
+                    if is_splittable else
+                    change.selection_ids
+                ),
+                change_index=_change_index_containing_review_display_ids(
+                    model,
+                    display_ids,
+                ),
+                first_page=pages[0],
+                last_page=pages[-1],
                 reason=change.reason,
-                actions=change_actions,
+                actions=selection_actions,
+                is_splittable=is_splittable,
             )
         )
     if source == ReviewSource.BATCH and review_action_groups is not None:

--- a/tests/commands/test_file_review.py
+++ b/tests/commands/test_file_review.py
@@ -2121,7 +2121,7 @@ def test_file_review_multiline_note_is_part_of_header(capsys):
     assert "Note:\n    first line\n    second line\n" in captured.out
 
 
-def test_oversized_review_change_splits_without_partial_actions(capsys, monkeypatch):
+def test_presence_only_review_keeps_visual_group_with_page_local_actions(capsys, monkeypatch):
     from git_stage_batch.output import file_review
 
     lines = [
@@ -2144,6 +2144,7 @@ def test_oversized_review_change_splits_without_partial_actions(capsys, monkeypa
 
     model = build_file_review_model(line_changes)
 
+    assert len(model.changes) == 1
     assert len(model.pages) == 2
     assert model.changes[0].first_page == 1
     assert model.changes[0].last_page == 2
@@ -2159,8 +2160,8 @@ def test_oversized_review_change_splits_without_partial_actions(capsys, monkeypa
     captured = capsys.readouterr()
     assert "file.txt  ·  working tree  ·  page 1/2  ·  change 1/1  ·  lines 1–4" in captured.out
     assert "Change 1/1   lines 1–4   4-line partial group" in captured.out
-    assert "No complete change is actionable from this page." in captured.out
-    assert "git-stage-batch include --line" not in captured.out
+    assert "No complete change is actionable from this page." not in captured.out
+    assert "git-stage-batch include --line 1-4" in captured.out
 
 
 def test_batch_review_model_splits_visible_runs_around_hidden_rows(capsys):

--- a/tests/commands/test_file_review.py
+++ b/tests/commands/test_file_review.py
@@ -31,7 +31,7 @@ from git_stage_batch.data.file_review_state import (
     FileReviewAction,
     ReviewSource,
     read_last_file_review_state,
-    shown_complete_review_selection_groups,
+    shown_review_selections_for_action,
 )
 from git_stage_batch.data.hunk_tracking import (
     SelectedChangeKind,
@@ -2323,14 +2323,20 @@ def test_batch_review_preserves_mergeable_change_next_to_reset_only_change():
         review_action_groups=review_action_groups,
     )
 
-    assert shown_complete_review_selection_groups(
-        review_state,
-        FileReviewAction.INCLUDE_FROM_BATCH,
-    ) == [{1}]
-    assert shown_complete_review_selection_groups(
-        review_state,
-        FileReviewAction.RESET_FROM_BATCH,
-    ) == [{1}, {2}]
+    assert [
+        selection.display_ids
+        for selection in shown_review_selections_for_action(
+            review_state,
+            FileReviewAction.INCLUDE_FROM_BATCH,
+        )
+    ] == [(1,)]
+    assert [
+        selection.display_ids
+        for selection in shown_review_selections_for_action(
+            review_state,
+            FileReviewAction.RESET_FROM_BATCH,
+        )
+    ] == [(1,), (2,)]
 
 
 def test_show_from_batch_line_after_review_uses_review_id_space(

--- a/tests/commands/test_file_review.py
+++ b/tests/commands/test_file_review.py
@@ -951,6 +951,46 @@ def test_pathless_include_line_rejects_partial_replacement_selection(paged_file_
         command_include_line(partial_id)
 
 
+def test_pathless_include_line_accepts_visible_presence_subset_from_review(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    from git_stage_batch.output import file_review
+
+    monkeypatch.chdir(tmp_path)
+    subprocess.run(["git", "init"], check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], check=True)
+    (tmp_path / "README.md").write_text("base\n")
+    subprocess.run(["git", "add", "README.md"], check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "Initial"], check=True, capture_output=True)
+
+    added_lines = [f"line {index}\n" for index in range(1, 13)]
+    (tmp_path / "new.txt").write_text("".join(added_lines))
+    command_start(quiet=True)
+    monkeypatch.setattr(file_review, "_body_budget", lambda: 6)
+
+    command_show(file="new.txt", page="1")
+    captured = capsys.readouterr()
+    assert "change 1/1" in captured.out
+    state = read_last_file_review_state()
+    assert state is not None
+    assert len(state.selections) == 1
+    assert state.selections[0].display_ids == (1, 2, 3, 4)
+    assert state.selections[0].is_splittable is True
+
+    command_include_line("1-3")
+
+    result = subprocess.run(
+        ["git", "show", ":new.txt"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert result.stdout == "".join(added_lines[:3])
+
+
 def test_pathless_include_line_rejects_unshown_change(paged_file_repo, monkeypatch, capsys):
     _force_one_change_per_page(monkeypatch)
     command_show(file="file.txt", page="1")


### PR DESCRIPTION
File reviews record the display IDs, selection IDs, pages, and allowed
actions for each review selection. Review-scoped line commands use that
state to decide whether a requested --line range matches what was shown in
the latest review.

Presence-only additions should be decomposable because each added line has
no paired deletion that must travel with it. The existing state model treats
those additions like replacement and reset selections, where splitting the
recorded group would leave one side of an atomic change behind. Users
therefore cannot act on only the added lines visible on one review page
with ordinary --line workflows.

This pull request addresses that by marking review selections as
splittable, preserving atomic validation for replacements and resets, and
recording page-local selections for visible presence-only additions. The
file-review footer now suggests line commands for those visible ranges, so
users can include subsets of long added runs without using replacement text.

Focused validation passed with:

`uv run pytest tests/commands/test_file_review.py -k 'presence_only or pathless_include_line_accepts_visible_presence_subset_from_review or batch_review_preserves_mergeable_change_next_to_reset_only_change'`
