### PR TITLE
tests: Sync editable meson build before xdist collection

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,10 +2,45 @@
 
 from __future__ import annotations
 
+import subprocess
+import sys
 from collections.abc import Iterable, Sequence
+from pathlib import Path
 from typing import overload
 
 import pytest
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Refresh the editable Meson build before xdist workers collect tests."""
+    if getattr(config, "workerinput", None) is not None:
+        return
+
+    numprocesses = getattr(config.option, "numprocesses", None)
+    if numprocesses in (None, 0, "0"):
+        return
+
+    _sync_editable_meson_build()
+
+
+def _sync_editable_meson_build() -> None:
+    """Run the current interpreter's editable Meson build if it exists."""
+    project_root = Path(__file__).resolve().parent.parent
+    build_dir = project_root / "build" / f"cp{sys.version_info.major}{sys.version_info.minor}"
+    if not (build_dir / "build.ninja").exists():
+        return
+
+    result = subprocess.run(
+        ["ninja", "-C", str(build_dir)],
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise pytest.UsageError(
+            "failed to refresh editable Meson build before xdist collection:\n"
+            f"{result.stderr}"
+        )
 
 
 class _LineSequence(Sequence[bytes]):


### PR DESCRIPTION
The test suite uses pytest-xdist for parallel execution. When the project is installed in editable mode via meson, the build artifacts under build/cpXY/ can become stale between source edits and test runs.

When xdist spawns worker processes, each worker imports the installed package from the editable build tree. If build artifacts are stale, workers can pick up outdated bytecode or missing generated files, causing confusing test failures that do not reproduce in serial mode.

This PR addresses that by adding a pytest_configure hook in conftest.py that runs ninja on the editable build directory before xdist workers begin collecting tests. The hook only runs on the controller process and only when parallel workers are requested, so serial test runs and CI environments without an editable build directory are unaffected.