### PR TITLE
cli: Open subcommand man pages from --help

### DIFF
--- a/man/git-stage-batch.1.in
+++ b/man/git-stage-batch.1.in
@@ -21,7 +21,7 @@ page. For example:
 .RS
 .nf
 git-stage-batch include --help
-git help stage-batch-include
+git help git-stage-batch-include
 .fi
 .RE
 .SH COMMON WORKFLOW

--- a/meson.build
+++ b/meson.build
@@ -34,7 +34,7 @@ configure_file(
   install_tag: 'runtime',
 )
 
-# Generate man pages for wheel fallback assets or system installation.
+# Generate man pages for runtime help assets and system installation.
 manpage_specs = [
   ['git-stage-batch.1.in', 'git-stage-batch.1'],
   ['git-stage-batch-abort.1.in', 'git-stage-batch-abort.1'],
@@ -69,13 +69,11 @@ foreach manpage_spec : manpage_specs
     configuration: {'VERSION': meson.project_version()},
   )
 endforeach
-if get_option('python_wheel')
-  install_data(
-    manpages,
-    install_dir: package_dir / 'assets' / 'man' / 'man1',
-    install_tag: 'python-runtime',
-  )
-endif
+install_data(
+  manpages,
+  install_dir: package_dir / 'assets' / 'man' / 'man1',
+  install_tag: 'python-runtime',
+)
 if not get_option('python_wheel')
   install_man(manpages)
 endif

--- a/src/git_stage_batch/cli/argument_parser.py
+++ b/src/git_stage_batch/cli/argument_parser.py
@@ -139,7 +139,7 @@ def _try_git_help_with_environment(
     """Run git help for a git-stage-batch topic."""
     try:
         result = run_git_command(
-            ["help", help_topic],
+            ["help", _git_help_name_for_help_topic(help_topic)],
             check=False,
             capture_stdout=False,
             env=env,
@@ -174,6 +174,11 @@ def _with_real_manpath_root(manpage_path: Path):
 def _manpage_name_for_help_topic(help_topic: str) -> str:
     """Return the man page filename for a git help topic."""
     return f"git-{help_topic}.1"
+
+
+def _git_help_name_for_help_topic(help_topic: str) -> str:
+    """Return the git help argument for a git-stage-batch topic."""
+    return _manpage_name_for_help_topic(help_topic).removesuffix(".1")
 
 
 def _show_git_stage_batch_help(help_topic: str = "stage-batch") -> bool:

--- a/tests/cli/test_argument_parser.py
+++ b/tests/cli/test_argument_parser.py
@@ -113,7 +113,7 @@ def test_show_git_stage_batch_help_uses_packaged_page_first(monkeypatch, tmp_pat
     monkeypatch.setattr(argument_parser, "run_git_command", fake_git)
 
     assert argument_parser._show_git_stage_batch_help() is True
-    assert calls[0][0] == ["help", "stage-batch"]
+    assert calls[0][0] == ["help", "git-stage-batch"]
     assert calls[0][1]["MANPATH"] == f"{manpage.parent.parent}{os.pathsep}/usr/share/man"
 
 
@@ -151,7 +151,7 @@ def test_show_git_stage_batch_help_uses_packaged_command_page(monkeypatch, tmp_p
     monkeypatch.setattr(argument_parser, "run_git_command", fake_git)
 
     assert argument_parser._show_git_stage_batch_help("stage-batch-include") is True
-    assert calls[0][0] == ["help", "stage-batch-include"]
+    assert calls[0][0] == ["help", "git-stage-batch-include"]
     assert calls[0][1]["MANPATH"] == f"{manpage.parent.parent}{os.pathsep}/usr/share/man"
 
 


### PR DESCRIPTION
The command-specific help path now has per-command topics and generated man
pages, and the wheel packages those pages as runtime help assets.

Users running `git-stage-batch include --help` can still fall back to
argparse help because Git does not resolve a synthetic topic such as
`stage-batch-include` to `git-stage-batch-include(1)`. Editable installs also
need the generated pages available as Python runtime assets so the MANPATH
fallback can see them under `uv run`.

This PR addresses that by invoking `git help` with installed man page names,
packaging the generated man pages as runtime assets for editable installs as
well as wheels, and updating the overview page's direct `git help` example.

I verified the reported command directly:

```text
uv run git-stage-batch include --help
```

Tests:
- `PYTHONPATH=src uv run ruff check src/git_stage_batch/cli/argument_parser.py tests/cli/test_argument_parser.py`
- `PYTHONPATH=src uv run pytest tests/cli/test_argument_parser.py tests/test_packaging.py`
- `PYTHONPATH=src uv run pytest tests/test_build.py`
