### PR TITLE
replacement: Preserve text supplied through --as

### DIFF
--- a/src/git_stage_batch/batch/replacement.py
+++ b/src/git_stage_batch/batch/replacement.py
@@ -7,7 +7,48 @@ from dataclasses import dataclass
 
 from ..core.line_selection import format_line_ids
 from ..editor import EditorBuffer
+from ..utils.text import bytes_to_lines
 from .ownership import BatchOwnership, AbsenceClaim, ReplacementUnit
+
+
+@dataclass(frozen=True, slots=True)
+class ReplacementPayload:
+    """Exact replacement bytes plus optional argv display text."""
+
+    data: bytes
+    display_text: str | None = None
+    exact: bool = True
+
+    @classmethod
+    def from_text(cls, text: str, *, exact: bool = True) -> "ReplacementPayload":
+        return cls(
+            text.encode("utf-8", errors="surrogateescape"),
+            display_text=text,
+            exact=exact,
+        )
+
+    @property
+    def has_trailing_lf(self) -> bool:
+        return self.data.endswith(b"\n")
+
+    def as_text(self) -> str:
+        return self.data.decode("utf-8", errors="surrogateescape")
+
+
+class ReplacementText(str):
+    """String-compatible replacement value carrying exact source bytes."""
+
+    def __new__(
+        cls,
+        text: str,
+        *,
+        data: bytes | None = None,
+        exact: bool = True,
+    ) -> "ReplacementText":
+        obj = str.__new__(cls, text)
+        obj.data = text.encode("utf-8", errors="surrogateescape") if data is None else data
+        obj.exact = exact
+        return obj
 
 
 @dataclass(slots=True)
@@ -38,12 +79,12 @@ def _format_presence_lines(line_numbers: list[int]) -> list[str]:
 def build_replacement_batch_view_from_lines(
     source_lines: Sequence[bytes],
     ownership: BatchOwnership,
-    replacement_text: str,
+    replacement_text: str | ReplacementPayload,
 ) -> ReplacementBatchView:
     """Build replacement source content from an indexed byte-line sequence."""
     claimed_source_lines = sorted(ownership.presence_line_set())
-    replacement_bytes = replacement_text.encode("utf-8", errors="surrogateescape")
-    replacement_lines = [line + b"\n" for line in replacement_bytes.splitlines()]
+    payload = coerce_replacement_payload(replacement_text)
+    replacement_lines = replacement_line_chunks(payload)
 
     if claimed_source_lines:
         expected_claimed = list(range(claimed_source_lines[0], claimed_source_lines[-1] + 1))
@@ -166,3 +207,42 @@ def _replacement_source_chunks(
 
     for line_index in range(suffix_start, len(source_lines)):
         yield source_lines[line_index]
+
+
+def coerce_replacement_payload(
+    replacement: str | bytes | ReplacementPayload,
+) -> ReplacementPayload:
+    """Return exact replacement bytes for legacy str callers and new payloads."""
+    if isinstance(replacement, ReplacementPayload):
+        return replacement
+    if isinstance(replacement, ReplacementText):
+        return ReplacementPayload(
+            replacement.data,
+            display_text=str(replacement) if not replacement.exact else None,
+            exact=replacement.exact,
+        )
+    if isinstance(replacement, bytes):
+        return ReplacementPayload(replacement)
+    # Plain str is the legacy command-internal API. Preserve its historical
+    # line-oriented behavior; CLI --as-stdin uses ReplacementText for exact bytes.
+    return ReplacementPayload.from_text(replacement, exact=False)
+
+
+def replacement_line_chunks(payload: ReplacementPayload) -> list[bytes]:
+    """Split replacement bytes into exact line chunks."""
+    if not payload.exact:
+        return [line + b"\n" for line in payload.data.splitlines()]
+    return list(bytes_to_lines([payload.data]))
+
+
+def replacement_line_bodies(payload: ReplacementPayload) -> list[bytes]:
+    """Return editor line bodies while preserving CRLF as body CR bytes."""
+    if not payload.exact:
+        return payload.data.splitlines()
+    bodies: list[bytes] = []
+    for line in replacement_line_chunks(payload):
+        if line.endswith(b"\n"):
+            bodies.append(line[:-1])
+        else:
+            bodies.append(line)
+    return bodies

--- a/src/git_stage_batch/cli/argument_parser.py
+++ b/src/git_stage_batch/cli/argument_parser.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 from .. import __version__
 from ..batch.validation import batch_exists
+from ..batch.replacement import ReplacementText
 from .. import commands
 from ..batch.query import read_batch_metadata
 from ..data.file_tracking import list_untracked_files
@@ -511,8 +512,16 @@ def _resolve_replacement_text(args: argparse.Namespace) -> str | None:
     if getattr(args, "as_text", None) is not None and getattr(args, "as_stdin", False):
         raise CommandError(_("Cannot use `--as` and `--as-stdin` together."))
     if getattr(args, "as_stdin", False):
-        return sys.stdin.buffer.read().decode("utf-8", errors="surrogateescape")
-    return getattr(args, "as_text", None)
+        data = sys.stdin.buffer.read()
+        return ReplacementText(
+            data.decode("utf-8", errors="surrogateescape"),
+            data=data,
+            exact=True,
+        )
+    as_text = getattr(args, "as_text", None)
+    if as_text is not None:
+        return ReplacementText(as_text, exact=True)
+    return None
 
 
 def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Namespace | None:

--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -28,6 +28,10 @@ from ..batch.ownership import (
     merge_batch_ownership,
     translate_lines_to_batch_ownership,
 )
+from ..batch.replacement import (
+    ReplacementPayload,
+    coerce_replacement_payload,
+)
 from ..batch.query import read_batch_metadata
 from ..batch.selection import require_line_selection_in_view
 from ..batch.source_refresh import acquire_batch_ownership_update_for_selection
@@ -551,7 +555,7 @@ def command_discard_file(
 
 
 def command_discard_file_as(
-    replacement_text: str,
+    replacement_text: str | ReplacementPayload,
     file: str | None = None,
     *,
     auto_advance: bool | None = None,
@@ -568,7 +572,8 @@ def command_discard_file_as(
         refuse_bare_action_after_file_list("discard --file --as")
         refuse_bare_action_after_auto_advance_disabled("discard --file --as")
 
-    operation_parts = ["discard", "--as", replacement_text]
+    replacement_payload = coerce_replacement_payload(replacement_text)
+    operation_parts = ["discard", "--as", replacement_payload.display_text or "<stdin>"]
     if file is not None:
         operation_parts.extend(["--file", file])
 
@@ -592,7 +597,8 @@ def command_discard_file_as(
 
         absolute_path = get_git_repository_root_path() / target_file
         absolute_path.parent.mkdir(parents=True, exist_ok=True)
-        absolute_path.write_text(replacement_text, encoding="utf-8", errors="surrogateescape")
+        absolute_path.parent.mkdir(parents=True, exist_ok=True)
+        absolute_path.write_bytes(replacement_payload.data)
 
         if preserve_selected_state:
             assert saved_selected_state is not None

--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -821,7 +821,7 @@ def command_discard_to_batch(
 def command_discard_line_as_to_batch(
     batch_name: str,
     line_id_specification: str,
-    replacement_text: str,
+    replacement_text: str | ReplacementPayload,
     file: str | None = None,
     *,
     no_edge_overlap: bool = False,
@@ -843,11 +843,12 @@ def command_discard_line_as_to_batch(
         return
     review_state = scope_resolution.review_state
 
+    replacement_payload = coerce_replacement_payload(replacement_text)
     operation_parts = [
         "discard",
         "--to", batch_name,
         "--line", line_id_specification,
-        "--as", replacement_text,
+        "--as", replacement_payload.display_text or "<stdin>",
     ]
     if no_edge_overlap:
         operation_parts.append("--no-edge-overlap")
@@ -895,7 +896,7 @@ def command_discard_line_as_to_batch(
 def _command_discard_lines_to_batch_as(
     batch_name: str,
     line_id_specification: str,
-    replacement_text: str,
+    replacement_text: str | ReplacementPayload,
     *,
     no_edge_overlap: bool = False,
     quiet: bool = False,
@@ -922,13 +923,14 @@ def _command_discard_lines_to_batch_as(
     if not os.path.lexists(working_file_path):
         exit_with_error(_("File not found in working tree: {file}").format(file=line_changes.path))
 
+    replacement_payload = coerce_replacement_payload(replacement_text)
     try:
         with load_working_tree_file_as_buffer(line_changes.path) as working_lines:
             rewritten_working_buffer = (
                 build_target_working_tree_buffer_with_replaced_lines(
                     line_changes,
                     effective_ids,
-                    replacement_text,
+                    replacement_payload,
                     working_lines,
                     working_has_trailing_newline=_buffer_ends_with_lf(working_lines),
                     trim_unchanged_edge_anchors=not no_edge_overlap,

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -1155,7 +1155,7 @@ def _apply_include_line_replacement(
     line_changes,
     *,
     line_id_specification: str,
-    replacement_text: str,
+    replacement_text: str | ReplacementPayload,
     hunk_base_lines: Sequence[bytes],
     hunk_source_lines: EditorBuffer,
     trim_unchanged_edge_anchors: bool,
@@ -1173,11 +1173,12 @@ def _apply_include_line_replacement(
     if not selected_lines:
         exit_with_error(_("No matching lines found for selection: {ids}").format(ids=line_id_specification))
 
+    replacement_payload = coerce_replacement_payload(replacement_text)
     try:
         target_index_buffer = build_target_index_buffer_with_replaced_lines(
             line_changes,
             effective_ids,
-            replacement_text,
+            replacement_payload,
             hunk_base_lines,
             base_has_trailing_newline=_line_sequence_ends_with_lf(hunk_base_lines),
             trim_unchanged_edge_anchors=trim_unchanged_edge_anchors,
@@ -1192,7 +1193,7 @@ def _apply_include_line_replacement(
         source_buffer=hunk_source_lines,
         selected_lines=selected_lines,
         replacement_mask={
-            "deleted_lines": replacement_text.splitlines(),
+            "deleted_lines": replacement_payload.as_text().splitlines(),
             "added_lines": [line.display_text() for line in selected_lines if line.kind == "+"],
         },
     )
@@ -1200,7 +1201,7 @@ def _apply_include_line_replacement(
 
 def command_include_line_as(
     line_id_specification: str,
-    replacement_text: str,
+    replacement_text: str | ReplacementPayload,
     file: str | None = None,
     *,
     no_edge_overlap: bool = False,
@@ -1221,7 +1222,14 @@ def command_include_line_as(
         return
     review_state = scope_resolution.review_state
 
-    operation_parts = ["include", "--line", line_id_specification, "--as", replacement_text]
+    replacement_payload = coerce_replacement_payload(replacement_text)
+    operation_parts = [
+        "include",
+        "--line",
+        line_id_specification,
+        "--as",
+        replacement_payload.display_text or "<stdin>",
+    ]
     if no_edge_overlap:
         operation_parts.append("--no-edge-overlap")
     if file is not None:

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -24,6 +24,10 @@ from ..batch.ownership import (
     derive_replacement_line_runs_from_lines,
     translate_hunk_selection_to_batch_ownership,
 )
+from ..batch.replacement import (
+    ReplacementPayload,
+    coerce_replacement_payload,
+)
 from ..batch.query import read_batch_metadata
 from ..batch.selection import (
     line_selection_not_valid_message,
@@ -752,7 +756,7 @@ def command_include_file(
 
 
 def command_include_file_as(
-    replacement_text: str,
+    replacement_text: str | ReplacementPayload,
     file: str | None = None,
     *,
     auto_advance: bool | None = None,
@@ -769,7 +773,9 @@ def command_include_file_as(
         refuse_bare_action_after_file_list("include --file --as")
         refuse_bare_action_after_auto_advance_disabled("include --file --as")
 
-    operation_parts = ["include", "--as", replacement_text]
+    replacement_payload = coerce_replacement_payload(replacement_text)
+    operation_text = replacement_payload.display_text
+    operation_parts = ["include", "--as", operation_text or "<stdin>"]
     if file is not None:
         operation_parts.extend(["--file", file])
 
@@ -800,9 +806,7 @@ def command_include_file_as(
                 if line_changes is None:
                     exit_with_error(_("No changes in file '{file}'.").format(file=target_file))
 
-        with EditorBuffer.from_bytes(
-            replacement_text.encode("utf-8", errors="surrogateescape")
-        ) as replacement_buffer:
+        with EditorBuffer.from_bytes(replacement_payload.data) as replacement_buffer:
             update_index_with_blob_buffer(target_file, replacement_buffer)
 
         if preserve_selected_state:

--- a/src/git_stage_batch/staging/operations.py
+++ b/src/git_stage_batch/staging/operations.py
@@ -5,6 +5,11 @@ from __future__ import annotations
 from collections.abc import Iterator, Sequence
 
 from ..core.models import LineEntry, LineLevelChange
+from ..batch.replacement import (
+    ReplacementPayload,
+    coerce_replacement_payload,
+    replacement_line_bodies,
+)
 from ..editor import (
     EditorBuffer,
     buffer_byte_count,
@@ -179,7 +184,7 @@ def build_target_index_buffer_from_lines(
 def build_target_index_buffer_with_replaced_lines(
     line_changes: LineLevelChange,
     replace_ids: set[int],
-    replacement_text: str,
+    replacement_text: str | ReplacementPayload,
     base_lines: Sequence[bytes],
     *,
     base_has_trailing_newline: bool,
@@ -224,8 +229,8 @@ def build_target_index_buffer_with_replaced_lines(
     if selected_ids != expected_range:
         raise ValueError("Replacement selection must be one contiguous line range")
 
-    replacement_bytes = replacement_text.encode("utf-8", errors="surrogateescape")
-    replacement_lines = replacement_bytes.splitlines()
+    replacement_payload = coerce_replacement_payload(replacement_text)
+    replacement_lines = replacement_line_bodies(replacement_payload)
     base_line_count = len(base_lines)
     selected_indices = [
         index
@@ -313,10 +318,14 @@ def build_target_index_buffer_with_replaced_lines(
                 "or pass --no-edge-overlap to keep the edge-overlap text."
             )
 
-    trailing_newline = (
-        replacement_text.endswith("\n")
-        or base_has_trailing_newline
-    )
+    if replacement_payload.exact:
+        trailing_newline = (
+            replacement_payload.has_trailing_lf
+            if replace_end == base_line_count
+            else base_has_trailing_newline
+        )
+    else:
+        trailing_newline = replacement_payload.has_trailing_lf or base_has_trailing_newline
     return edit_lines_as_buffer(
         base_lines,
         replacement_lines,

--- a/src/git_stage_batch/staging/operations.py
+++ b/src/git_stage_batch/staging/operations.py
@@ -427,7 +427,7 @@ def build_target_working_tree_buffer_from_lines(
 def build_target_working_tree_buffer_with_replaced_lines(
     line_changes: LineLevelChange,
     replace_ids: set[int],
-    replacement_text: str,
+    replacement_text: str | ReplacementPayload,
     working_lines: Sequence[bytes],
     *,
     working_has_trailing_newline: bool,
@@ -473,8 +473,8 @@ def build_target_working_tree_buffer_with_replaced_lines(
         raise ValueError("Replacement selection must be one contiguous line range")
 
     working_line_count = len(working_lines)
-    replacement_bytes = replacement_text.encode("utf-8", errors="surrogateescape")
-    replacement_lines = replacement_bytes.splitlines()
+    replacement_payload = coerce_replacement_payload(replacement_text)
+    replacement_lines = replacement_line_bodies(replacement_payload)
     selected_indices = [
         index
         for index, line in enumerate(line_changes.lines)
@@ -561,10 +561,14 @@ def build_target_working_tree_buffer_with_replaced_lines(
                 "or pass --no-edge-overlap to keep the edge-overlap text."
             )
 
-    trailing_newline = (
-        replacement_text.endswith("\n")
-        or working_has_trailing_newline
-    )
+    if replacement_payload.exact:
+        trailing_newline = (
+            replacement_payload.has_trailing_lf
+            if replace_end == working_line_count
+            else working_has_trailing_newline
+        )
+    else:
+        trailing_newline = replacement_payload.has_trailing_lf or working_has_trailing_newline
     return edit_lines_as_buffer(
         working_lines,
         replacement_lines,

--- a/tests/batch/test_replacement.py
+++ b/tests/batch/test_replacement.py
@@ -2,8 +2,11 @@
 
 from git_stage_batch.batch.ownership import BatchOwnership, AbsenceClaim
 from git_stage_batch.batch.replacement import (
+    ReplacementText,
     ReplacementBatchView,
     build_replacement_batch_view_from_lines,
+    coerce_replacement_payload,
+    replacement_line_chunks,
 )
 
 
@@ -46,3 +49,15 @@ def test_build_replacement_batch_view_returns_named_result(line_sequence):
     with view:
         assert view.source_buffer.to_bytes() == b"line1\nnew\nline2\n"
         assert view.ownership.presence_line_set() == {2}
+
+
+def test_replacement_text_can_carry_exact_stdin_bytes():
+    payload = coerce_replacement_payload(
+        ReplacementText(
+            "first\r\nsecond",
+            data=b"first\r\nsecond",
+            exact=True,
+        )
+    )
+
+    assert replacement_line_chunks(payload) == [b"first\r\n", b"second"]


### PR DESCRIPTION
Line and file replacement workflows let users replace selected text by
passing --as TEXT or by piping input through --as-stdin.

That input can include trailing blank lines, CRLF line endings, or an
intentional missing final newline. If git-stage-batch splits it into
ordinary strings too early, include or discard can stage or save text that
no longer matches what the user supplied.

This pull request carries replacement text as exact bytes from CLI parsing
through include and discard, while keeping existing string callers working.

With include, discard, batch-saving, and regression coverage in place,
replacement commands now preserve the text shape users provide through --as
and --as-stdin.
