### PR TITLE
batch: Reject colon in batch names

### DIFF
--- a/src/git_stage_batch/batch/validation.py
+++ b/src/git_stage_batch/batch/validation.py
@@ -14,7 +14,7 @@ def validate_batch_name(name: str) -> None:
         exit_with_error(_("Batch name cannot be empty"))
 
     # Check for invalid characters
-    invalid_chars = ['/', '\\', '..', ' ', '\t', '\n', '\r']
+    invalid_chars = ['/', '\\', '..', ':', ' ', '\t', '\n', '\r']
     for char in invalid_chars:
         if char in name:
             exit_with_error(_("Batch name cannot contain: {char}").format(char=repr(char)))

--- a/tests/batch/test_validation.py
+++ b/tests/batch/test_validation.py
@@ -62,6 +62,13 @@ def test_validate_batch_name_with_dotdot(temp_git_repo):
     assert "cannot contain" in exc_info.value.message
 
 
+def test_validate_batch_name_with_colon(temp_git_repo):
+    """Test that batch name with colon fails validation."""
+    with pytest.raises(CommandError) as exc_info:
+        validate_batch_name("cleanup:apply")
+    assert "cannot contain" in exc_info.value.message
+
+
 def test_validate_batch_name_with_space(temp_git_repo):
     """Test that batch name with space fails validation."""
     with pytest.raises(CommandError) as exc_info:


### PR DESCRIPTION
Batch names are user-provided labels that git-stage-batch stores and looks
up through git refs.

Git ref names cannot contain ':'. Batch validation already rejects other
characters that cannot safely appear in those refs, but it still accepts a
colon before trying to create or read the batch.

This pull request rejects ':' during batch name validation and adds direct
coverage for that rule.

With the implementation and validation coverage in place, batch creation
fails before git-stage-batch tries to use a name that Git refs cannot store.
