### PR TITLE
Add reviewed choices for ambiguous batches

### DIFF
--- a/completions/git-stage-batch
+++ b/completions/git-stage-batch
@@ -83,12 +83,12 @@ _git_stage_batch()
                     __git_stage_batch_set_nospace_for_dirs
                     return
                     ;;
-                --line|--page|--pages)
+                --line|--page|--pages|--as)
                     # Line IDs - no completion
                     return
                     ;;
             esac
-            COMPREPLY=($(compgen -W "--porcelain --from --file --files --line --page --pages" -- "$cur"))
+            COMPREPLY=($(compgen -W "--porcelain --from --file --files --line --page --pages --as --as-stdin" -- "$cur"))
             ;;
         include)
             case "$prev" in

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -62,6 +62,7 @@ Display the cached "selected" hunk, one file review, or a matched-files list.
 ```bash
 ❯ git-stage-batch show --from cleanup-ui
 ❯ git-stage-batch show --from cleanup-ui --file src/config.py --page 2
+❯ git-stage-batch show --from cleanup-ui --file src/config.py --line 3-5 --as "replacement"
 ```
 
 When `--file` is used, `show` displays a structured file review with global line IDs, page orientation, and exact follow-up commands. By default, large file reviews are bounded to the first relevant page. Use `--page all` or `--pages all` to review the whole file.
@@ -71,6 +72,32 @@ When only part of a file review has been shown, unqualified actions such as `inc
 When `--files` resolves to multiple files, `show` prints a matched-files list with per-file change counts, changed-line counts, review page counts, and exact `show --file PATH` commands. This list is navigational: it does not select a hidden file for later bare actions.
 
 For multi-file batches, `show --from BATCH` uses the same matched-files list and repeats `--from BATCH` in the suggested open commands.
+
+When an `apply --from BATCH` or `include --from BATCH` operation cannot safely
+choose between multiple structural placements, the mutating command refuses
+without changing the working tree or index and points to operation-specific
+candidate previews. Candidate selectors use `BATCH:apply`, `BATCH:apply:N`,
+`BATCH:include`, or `BATCH:include:N`. `BATCH:apply` and `BATCH:include`
+show a compact candidate overview with local context and exact commands.
+Append `:N` to show the full diff for one numbered candidate. Bare numeric
+selectors such as
+`BATCH:2` are invalid because apply and include can have different candidate
+spaces.
+
+```bash
+❯ git-stage-batch show --from cleanup-ui:apply --file src/config.py
+❯ git-stage-batch show --from cleanup-ui:apply:2 --file src/config.py
+❯ git-stage-batch apply --from cleanup-ui:apply:2 --file src/config.py
+
+❯ git-stage-batch show --from cleanup-ui:include --file src/config.py
+❯ git-stage-batch show --from cleanup-ui:include:2 --file src/config.py
+❯ git-stage-batch include --from cleanup-ui:include:2 --file src/config.py
+```
+
+Candidate execution requires a matching prior preview for the same file and
+selector. A candidate overview counts as review for the candidates it shows,
+so users can run a listed apply or include command directly from that summary.
+Re-preview after editing the target file or changing the index.
 
 Submodule pointer changes are shown as atomic entries. They support whole-entry
 actions, but not `--line`.
@@ -88,6 +115,7 @@ actions, but not `--line`.
   - Cannot be combined with `--line`, multiple resolved `--files` matches, or `--porcelain`
 - `--porcelain`: Exit silently with status code only (no output)
 - `--from BATCH`: Show changes from a batch instead of live file-vs-HEAD changes
+- `--as TEXT`, `--as-stdin`: With `--from BATCH --line IDS`, preview the same replacement batch view used by `include --from BATCH --line IDS --as ...` without mutating anything
 
 When `--files` resolves to one file, `show` opens that single file review directly. When it resolves to multiple files, open one listed file with `show --file PATH` before using pathless `--line` actions.
 
@@ -588,6 +616,10 @@ use `--as-stdin` instead of shell command substitution. For example:
 
 Unlike `--as "$(cat replacement.txt)"`, `--as-stdin` preserves trailing
 newlines exactly.
+
+For saved batches, `show --from BATCH --file PATH --line IDS --as TEXT` previews
+the replacement batch view without staging or writing it. The corresponding
+mutating command is `include --from BATCH --file PATH --line IDS --as TEXT`.
 
 These replacement workflows require one contiguous selected line-ID span.
 Selections such as `1-4` or `2,3,4` are accepted because they resolve to one

--- a/man/git-stage-batch-apply.1.in
+++ b/man/git-stage-batch-apply.1.in
@@ -15,6 +15,15 @@ batch remains available after the command.
 .BI "\-\-from " BATCH
 Apply changes from
 .IR BATCH .
+To apply a reviewed ambiguity resolution, use
+.IR BATCH :apply: N
+with
+.BR \-\-file .
+The
+.IR BATCH :include: N
+selector belongs to
+.B include
+and is rejected here.
 .TP
 .BI "\-\-line, \-\-lines " IDS
 Apply only specific displayed line IDs.
@@ -27,6 +36,22 @@ is omitted, use the selected batch file when available.
 .TP
 .BI "\-\-files " PATTERN "..."
 Apply batch files matched by gitignore-style patterns.
+.SH CANDIDATES
+If a plain
+.B apply --from
+operation finds multiple safe structural placements, it refuses without
+changing the working tree and points to
+.B show --from
+.IR BATCH :apply .
+Review the candidate overview, or preview a numbered candidate, then apply
+that same reviewed candidate:
+.RS
+.nf
+git-stage-batch show --from cleanup:apply --file src/app.py
+git-stage-batch show --from cleanup:apply:2 --file src/app.py
+git-stage-batch apply --from cleanup:apply:2 --file src/app.py
+.fi
+.RE
 .SH SEE ALSO
 .BR git-stage-batch (1),
 .BR git-stage-batch-include (1),

--- a/man/git-stage-batch-include.1.in
+++ b/man/git-stage-batch-include.1.in
@@ -36,6 +36,15 @@ Operate on all changed files matched by gitignore-style patterns.
 .BI "\-\-from " BATCH
 Stage changes from
 .IR BATCH .
+To include a reviewed ambiguity resolution, use
+.IR BATCH :include: N
+with
+.BR \-\-file .
+The
+.IR BATCH :apply: N
+selector belongs to
+.B apply
+and is rejected here.
 .TP
 .BI "\-\-to " BATCH
 Save selected live changes to
@@ -69,9 +78,20 @@ git-stage-batch include --line 1,3,5-7
 git-stage-batch include --file src/app.py
 git-stage-batch include --to cleanup --files 'src/**'
 git-stage-batch include --from cleanup --file src/app.py
+git-stage-batch show --from cleanup:include:2 --file src/app.py
+git-stage-batch include --from cleanup:include:2 --file src/app.py
 some-command | git-stage-batch include --line 1-3 --as-stdin
 .fi
 .RE
+.SH CANDIDATES
+If a plain
+.B include --from
+operation finds multiple safe structural placements, it refuses without
+changing either the index or working tree and points to
+.B show --from
+.IR BATCH :include .
+Review the candidate overview, or preview a numbered candidate, then include
+that same reviewed candidate.
 .SH SEE ALSO
 .BR git-stage-batch (1),
 .BR git-stage-batch-show (1),

--- a/man/git-stage-batch-show.1.in
+++ b/man/git-stage-batch-show.1.in
@@ -8,6 +8,7 @@ git-stage-batch-show \- show the selected hunk or a file review
 [\fB\-\-line\fR \fIIDS\fR]
 [\fB\-\-page\fR \fIPAGES\fR]
 [\fB\-\-porcelain\fR]
+[\fB\-\-as\fR \fITEXT\fR | \fB\-\-as\-stdin\fR]
 .SH DESCRIPTION
 .B show
 prints the currently selected hunk. It can also open a page-aware review for
@@ -17,6 +18,14 @@ one file, list matching files, or show changes stored in a batch.
 .BI "\-\-from " BATCH
 Show changes from
 .IR BATCH .
+Candidate previews use
+.IR BATCH :apply ,
+.IR BATCH :apply: N ,
+.IR BATCH :include ,
+or
+.IR BATCH :include: N .
+The unnumbered apply and include forms print a compact overview of available
+candidates. Numbered forms show the full diff for one candidate.
 .TP
 .B \-\-file
 .RI [ PATH ]
@@ -44,12 +53,26 @@ or
 .TP
 .B \-\-porcelain
 Exit silently with status code 0 when a hunk exists and 1 when no hunk exists.
+.TP
+.BI "\-\-as " TEXT
+With
+.BR "\-\-from " BATCH
+and
+.BR "\-\-line " IDS ,
+preview the replacement batch view that
+.B include --from --as
+would use, without mutating the index or working tree.
+.TP
+.B \-\-as\-stdin
+Read replacement preview text from standard input exactly.
 .SH EXAMPLES
 .RS
 .nf
 git-stage-batch show
 git-stage-batch show --file src/app.py --page 2
 git-stage-batch show --from cleanup --files 'src/**' '!src/vendor/**'
+git-stage-batch show --from cleanup:apply --file src/app.py
+git-stage-batch show --from cleanup:include:2 --file src/app.py
 .fi
 .RE
 .SH SEE ALSO

--- a/src/git_stage_batch/batch/match.py
+++ b/src/git_stage_batch/batch/match.py
@@ -111,6 +111,15 @@ class LineMapping:
             raise ValueError("line mapping is closed")
 
 
+@dataclass(frozen=True)
+class TargetGap:
+    """A concrete gap between target lines."""
+
+    gap_index: int
+    target_after_line: int | None
+    target_before_line: int | None
+
+
 def _close_vector(vector: IntVector) -> None:
     close = getattr(vector, "close", None)
     if close is not None:
@@ -702,3 +711,69 @@ def match_lines(
         as_acquirable_line_sequence(source_lines),
         as_acquirable_line_sequence(target_lines),
     )
+
+
+def iter_exact_sequence_occurrences(
+    lines: Sequence[bytes],
+    sequence: Sequence[bytes],
+    *,
+    start: int = 0,
+    end: int | None = None,
+    max_results: int | None = None,
+) -> Iterator[int]:
+    """Yield exact sequence start offsets in ascending order."""
+    if end is None:
+        end = len(lines)
+    start = max(start, 0)
+    end = min(end, len(lines))
+    if not sequence:
+        return
+    if start > end:
+        return
+
+    result_count = 0
+    sequence_length = len(sequence)
+    last_start = end - sequence_length
+    for index in range(start, last_start + 1):
+        if all(lines[index + offset] == sequence[offset] for offset in range(sequence_length)):
+            yield index
+            result_count += 1
+            if max_results is not None and result_count >= max_results:
+                return
+
+
+def iter_exact_context_gaps(
+    target_lines: Sequence[bytes],
+    *,
+    left_context: Sequence[bytes],
+    right_context: Sequence[bytes],
+    start_gap: int,
+    end_gap: int,
+    max_results: int | None = None,
+) -> Iterator[TargetGap]:
+    """Yield target gaps whose surrounding context matches exactly."""
+    start_gap = max(start_gap, 0)
+    end_gap = min(end_gap, len(target_lines))
+    if start_gap > end_gap:
+        return
+
+    result_count = 0
+    left_count = len(left_context)
+    right_count = len(right_context)
+    for gap_index in range(start_gap, end_gap + 1):
+        if gap_index < left_count:
+            continue
+        if gap_index + right_count > len(target_lines):
+            continue
+        if left_count and tuple(target_lines[gap_index - left_count:gap_index]) != tuple(left_context):
+            continue
+        if right_count and tuple(target_lines[gap_index:gap_index + right_count]) != tuple(right_context):
+            continue
+        yield TargetGap(
+            gap_index=gap_index,
+            target_after_line=None if gap_index == 0 else gap_index,
+            target_before_line=None if gap_index == len(target_lines) else gap_index + 1,
+        )
+        result_count += 1
+        if max_results is not None and result_count >= max_results:
+            return

--- a/src/git_stage_batch/batch/merge.py
+++ b/src/git_stage_batch/batch/merge.py
@@ -1716,6 +1716,7 @@ def _satisfy_constraints(
     *,
     strict: bool = True,
     source_to_working_mapping: LineMapping | None = None,
+    resolution: MergeResolution | None = None,
 ) -> _RealizedEntries:
     """Apply presence and absence constraints until claimed lines survive."""
     realized_entries = _apply_presence_constraints(
@@ -1723,13 +1724,15 @@ def _satisfy_constraints(
         working_lines,
         presence_line_set,
         source_to_working_mapping=source_to_working_mapping,
+        resolution=resolution,
     )
 
     try:
         updated_entries = _apply_absence_constraints(
             realized_entries,
             deletion_claims,
-            strict=strict
+            strict=strict,
+            resolution=resolution,
         )
         if updated_entries is not realized_entries:
             realized_entries.close()
@@ -1744,7 +1747,8 @@ def _satisfy_constraints(
             updated_entries = _apply_presence_constraints(
                 source_lines,
                 current_lines,
-                presence_line_set
+                presence_line_set,
+                resolution=resolution,
             )
         finally:
             previous_entries.close()
@@ -1753,7 +1757,8 @@ def _satisfy_constraints(
         updated_entries = _apply_absence_constraints(
             realized_entries,
             deletion_claims,
-            strict=strict
+            strict=strict,
+            resolution=resolution,
         )
         if updated_entries is not realized_entries:
             realized_entries.close()

--- a/src/git_stage_batch/batch/merge.py
+++ b/src/git_stage_batch/batch/merge.py
@@ -2679,6 +2679,7 @@ def merge_batch_from_line_sequences_as_buffer(
     working_lines: Sequence[bytes],
     *,
     source_to_working_mapping: LineMapping | None = None,
+    resolution: MergeResolution | None = None,
 ) -> EditorBuffer:
     """Merge line sequences and return a buffer with destination line endings."""
     result_line_ending = _merge_result_line_ending_from_lines(
@@ -2694,6 +2695,7 @@ def merge_batch_from_line_sequences_as_buffer(
                 ownership,
                 normalized_working_lines,
                 source_to_working_mapping=source_to_working_mapping,
+                resolution=resolution,
             ),
             result_line_ending,
         )
@@ -2706,6 +2708,7 @@ def can_merge_batch_from_line_sequences(
     working_lines: Sequence[bytes],
     *,
     source_to_working_mapping: LineMapping | None = None,
+    resolution: MergeResolution | None = None,
 ) -> bool:
     """Return whether a normalized line merge can be applied."""
     normalized_source_lines = normalize_line_sequence_endings(source_lines)
@@ -2716,6 +2719,7 @@ def can_merge_batch_from_line_sequences(
             ownership,
             normalized_working_lines,
             source_to_working_mapping=source_to_working_mapping,
+            resolution=resolution,
         ):
             pass
     except MergeError:
@@ -2729,6 +2733,7 @@ def _merge_batch_line_chunks(
     working_lines: AcquirableLineSequence[Any],
     *,
     source_to_working_mapping: LineMapping | None = None,
+    resolution: MergeResolution | None = None,
 ) -> Iterator[bytes]:
     """Merge normalized byte-line sequences and yield normalized chunks."""
     with (
@@ -2740,6 +2745,7 @@ def _merge_batch_line_chunks(
             ownership,
             acquired_working_lines,
             source_to_working_mapping=source_to_working_mapping,
+            resolution=resolution,
         )
 
 
@@ -2749,6 +2755,7 @@ def _merge_batch_acquired_line_chunks(
     working_lines: Sequence[bytes],
     *,
     source_to_working_mapping: LineMapping | None = None,
+    resolution: MergeResolution | None = None,
 ) -> Iterator[bytes]:
     """Merge acquired normalized line sequences and yield normalized chunks."""
     resolved = ownership.resolve()
@@ -2772,13 +2779,17 @@ def _merge_batch_acquired_line_chunks(
         owned_mapping = match_lines(source_lines, working_lines)
         mapping = owned_mapping
     try:
-        _check_structural_validity(
-            mapping,
-            presence_line_set,
-            deletion_claims,
-            source_lines,
-            working_lines
-        )
+        try:
+            _check_structural_validity(
+                mapping,
+                presence_line_set,
+                deletion_claims,
+                source_lines,
+                working_lines
+            )
+        except MergeError:
+            if resolution is None:
+                raise
 
         realized_entries = _satisfy_constraints(
             source_lines,
@@ -2786,6 +2797,7 @@ def _merge_batch_acquired_line_chunks(
             presence_line_set,
             deletion_claims,
             source_to_working_mapping=mapping,
+            resolution=resolution,
         )
     except MergeError:
         fallback_chunks = _try_apply_baseline_replacement_units(

--- a/src/git_stage_batch/batch/merge.py
+++ b/src/git_stage_batch/batch/merge.py
@@ -1965,6 +1965,64 @@ class _PresenceChoice:
     target_before_line: int | None
 
 
+def _absence_choices_for_claim(
+    entries: Sequence[RealizedEntry],
+    anchor_line: int | None,
+    forbidden_sequence: Sequence[bytes],
+    *,
+    max_results: int | None = None,
+) -> tuple[_AbsenceChoice, ...]:
+    """Return concrete exact-removal choices for one absence claim."""
+    positions: list[tuple[int, str]] = []
+    seen: set[int] = set()
+
+    def add_position(position: int, explanation: str) -> None:
+        if position in seen:
+            return
+        if not _sequence_matches_at_position(entries, position, list(forbidden_sequence)):
+            return
+        seen.add(position)
+        positions.append((position, explanation))
+
+    for boundary in _boundary_choices_after_source_line(entries, anchor_line):
+        add_position(boundary, _("deletion content appears at the anchored boundary"))
+        after_claimed = _position_after_claimed_insertions_at_boundary(entries, boundary)
+        if after_claimed != boundary:
+            add_position(
+                after_claimed,
+                _("deletion content appears after claimed insertions at the anchored boundary"),
+            )
+
+    if len(positions) <= 1:
+        for position in iter_sequence_occurrences_nearby(
+            entries,
+            _boundary_choices_after_source_line(entries, anchor_line)[0],
+            forbidden_sequence,
+            window=20,
+            max_results=(max_results or _MERGE_CANDIDATE_CAP) + 1,
+        ):
+            add_position(position, _("deletion content appears nearby"))
+
+    positions.sort(key=lambda item: item[0])
+    if max_results is not None:
+        positions = positions[:max_results]
+
+    choices = []
+    for index, (position, explanation) in enumerate(positions, start=1):
+        after_line = None if position == 0 else position
+        before_line = None if position + len(forbidden_sequence) >= len(entries) else position + 1
+        choices.append(
+            _AbsenceChoice(
+                choice_index=index,
+                position=position,
+                target_after_line=after_line,
+                target_before_line=before_line,
+                explanation=explanation,
+            )
+        )
+    return tuple(choices)
+
+
 def _sequence_matches_at_position(
     entries: Sequence[RealizedEntry],
     position: int,

--- a/src/git_stage_batch/batch/merge.py
+++ b/src/git_stage_batch/batch/merge.py
@@ -1591,7 +1591,8 @@ def _apply_absence_constraints(
     entries: Sequence[RealizedEntry],
     deletion_claims: list['AbsenceClaim'],
     *,
-    strict: bool = True
+    strict: bool = True,
+    resolution: MergeResolution | None = None,
 ) -> _RealizedEntries:
     """Apply absence constraints with boundary enforcement.
 
@@ -1634,8 +1635,32 @@ def _apply_absence_constraints(
 
     suppress_fn = _suppress_at_boundary_strict if strict else _suppress_at_boundary_for_realization
 
-    for claim in deletion_claims:
+    for claim_index, claim in enumerate(deletion_claims):
         if not claim.content_lines:
+            continue
+
+        forbidden_sequence = [
+            normalize_line_endings(line)
+            for line in claim.content_lines
+        ]
+
+        ambiguity_key = _absence_ambiguity_key(
+            claim_index,
+            claim.anchor_line,
+            forbidden_sequence,
+        )
+
+        if resolution is not None and ambiguity_key in resolution.decisions:
+            old_result = result
+            result = _suppress_absence_with_resolution(
+                result,
+                claim.anchor_line,
+                forbidden_sequence,
+                ambiguity_key,
+                resolution,
+            )
+            if result is not old_result and old_result is not entries:
+                old_result.close()
             continue
 
         # Find boundary (fails if ambiguous or missing - appropriate for both modes)
@@ -1645,12 +1670,6 @@ def _apply_absence_constraints(
             if strict:
                 raise
             boundary = _find_realization_fallback_boundary(result, claim.anchor_line)
-
-        # Normalize deletion content for comparison
-        forbidden_sequence = [
-            normalize_line_endings(line)
-            for line in claim.content_lines
-        ]
 
         old_result = result
         result = suppress_fn(result, boundary, forbidden_sequence)

--- a/src/git_stage_batch/batch/merge.py
+++ b/src/git_stage_batch/batch/merge.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 from array import array
 from bisect import bisect_right
-from collections.abc import Iterable, Iterator, Sequence
+from collections.abc import Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass, field
 from enum import Enum, auto
+import hashlib
 from typing import TYPE_CHECKING, Any
 
-from .match import LineMapping, match_lines
+from .match import LineMapping, iter_exact_context_gaps, match_lines
 from ..core.line_selection import LineRanges, LineSelection
 from ..editor import (
     Editor,
@@ -29,6 +30,52 @@ from ..utils.text import (
 
 if TYPE_CHECKING:
     from .ownership import BatchOwnership, AbsenceClaim
+
+
+_MERGE_CANDIDATE_CAP = 50
+
+
+@dataclass(frozen=True)
+class MergeResolutionDecision:
+    """One selected merge ambiguity decision."""
+
+    ambiguity_key: str
+    choice_index: int
+    choice_label: str
+
+
+@dataclass(frozen=True)
+class MergeResolution:
+    """Concrete ambiguity decisions used to materialize a merge candidate."""
+
+    decisions: Mapping[str, int]
+
+
+@dataclass(frozen=True)
+class MergeCandidate:
+    """One complete target-level merge candidate."""
+
+    ordinal: int
+    count: int
+    decisions: tuple[MergeResolutionDecision, ...]
+    summary: str
+    source_line_range: tuple[int, int] | None
+    target_after_line: int | None
+    target_before_line: int | None
+    explanation: str
+
+    @property
+    def resolution(self) -> MergeResolution:
+        return MergeResolution(
+            {decision.ambiguity_key: decision.choice_index for decision in self.decisions}
+        )
+
+
+@dataclass(frozen=True)
+class MergeCandidateSet:
+    """Merge candidates for one target."""
+
+    candidates: tuple[MergeCandidate, ...]
 
 
 class RegionKind(Enum):

--- a/src/git_stage_batch/batch/merge.py
+++ b/src/git_stage_batch/batch/merge.py
@@ -1828,6 +1828,37 @@ def _find_boundary_after_source_line(
     return matching_indices[0] + 1
 
 
+def _boundary_choices_after_source_line(
+    entries: Sequence[RealizedEntry],
+    source_line: int | None,
+) -> tuple[int, ...]:
+    """Return all concrete boundary positions after a source line."""
+    if source_line is None:
+        return (0,)
+
+    matching_indices: list[int] = []
+    if isinstance(entries, _RealizedEntries):
+        for run in entries.provenance_runs():
+            if run.source_start == 0:
+                continue
+            run_length = run.dest_end - run.dest_start
+            if not run.source_start <= source_line < run.source_start + run_length:
+                continue
+            matching_indices.append(run.dest_start + (source_line - run.source_start))
+    else:
+        for index in range(len(entries)):
+            if _entry_source_line_at(entries, index) == source_line:
+                matching_indices.append(index)
+
+    if not matching_indices:
+        raise MissingAnchorError(
+            _("Cannot locate anchor boundary after source line {line}: "
+              "anchor not present in realized content").format(line=source_line)
+        )
+
+    return tuple(index + 1 for index in matching_indices)
+
+
 def _presence_ambiguity_key(
     run_start: int,
     run_end: int,

--- a/src/git_stage_batch/batch/merge.py
+++ b/src/git_stage_batch/batch/merge.py
@@ -2828,7 +2828,12 @@ def enumerate_merge_batch_candidates_from_line_sequences(
     *,
     max_candidates: int = _MERGE_CANDIDATE_CAP,
 ) -> MergeCandidateSet:
-    """Enumerate safe merge candidates for an otherwise-refused merge."""
+    """Enumerate safe merge candidates for an otherwise-refused merge.
+
+    The normal merge path remains ambiguity-intolerant. This helper first
+    verifies that the ordinary merge refuses, then enumerates supported
+    ambiguity choices one at a time.
+    """
     normalized_source_lines = normalize_line_sequence_endings(source_lines)
     normalized_working_lines = normalize_line_sequence_endings(working_lines)
     with (
@@ -2863,6 +2868,7 @@ def _enumerate_merge_batch_candidates_acquired(
 ) -> MergeCandidateSet:
     resolved = ownership.resolve()
     presence_line_set = resolved.presence_line_set
+    deletion_claims = resolved.deletion_claims
 
     presence_mapping = match_lines(source_lines, working_lines)
     try:
@@ -2925,7 +2931,113 @@ def _enumerate_merge_batch_candidates_acquired(
                 )
             return MergeCandidateSet(tuple(candidates))
 
-    return MergeCandidateSet(())
+    if not deletion_claims:
+        return MergeCandidateSet(())
+
+    if len([claim for claim in deletion_claims if claim.content_lines]) != 1:
+        raise MergeError(_("Batch was created from a different version of the file"))
+
+    owned_mapping = match_lines(source_lines, working_lines)
+    try:
+        _check_structural_validity(
+            owned_mapping,
+            presence_line_set,
+            deletion_claims,
+            source_lines,
+            working_lines,
+        )
+        realized_entries = _apply_presence_constraints(
+            source_lines,
+            working_lines,
+            presence_line_set,
+            source_to_working_mapping=owned_mapping,
+        )
+    finally:
+        owned_mapping.close()
+
+    try:
+        enumerable_claims = [
+            (index, claim)
+            for index, claim in enumerate(deletion_claims)
+            if claim.content_lines
+        ]
+        claim_index, claim = enumerable_claims[0]
+        forbidden_sequence = [
+            normalize_line_endings(line)
+            for line in claim.content_lines
+        ]
+        ambiguity_key = _absence_ambiguity_key(
+            claim_index,
+            claim.anchor_line,
+            forbidden_sequence,
+        )
+        choices = _absence_choices_for_claim(
+            realized_entries,
+            claim.anchor_line,
+            forbidden_sequence,
+            max_results=max_candidates + 1,
+        )
+        if len(choices) > max_candidates:
+            raise MergeError(_("Too many merge candidates to preview safely"))
+        if len(choices) <= 1:
+            return MergeCandidateSet(())
+
+        valid_choices: list[_AbsenceChoice] = []
+        for choice in choices:
+            resolution = MergeResolution({ambiguity_key: choice.choice_index})
+            try:
+                for _chunk in _merge_batch_acquired_line_chunks(
+                    source_lines,
+                    ownership,
+                    working_lines,
+                    resolution=resolution,
+                ):
+                    pass
+            except MergeError:
+                continue
+            valid_choices.append(choice)
+
+        if len(valid_choices) <= 1:
+            return MergeCandidateSet(())
+
+        count = len(valid_choices)
+        candidates: list[MergeCandidate] = []
+        for ordinal, choice in enumerate(valid_choices, start=1):
+            target_start = choice.position + 1
+            target_end = choice.position + len(forbidden_sequence)
+            summary = (
+                _("delete target lines {start}-{end}").format(
+                    start=target_start,
+                    end=target_end,
+                )
+                if target_start != target_end
+                else _("delete target line {line}").format(line=target_start)
+            )
+            candidates.append(
+                MergeCandidate(
+                    ordinal=ordinal,
+                    count=count,
+                    decisions=(
+                        MergeResolutionDecision(
+                            ambiguity_key=ambiguity_key,
+                            choice_index=choice.choice_index,
+                            choice_label=summary,
+                        ),
+                    ),
+                    summary=summary,
+                    source_line_range=(
+                        (claim.anchor_line, claim.anchor_line)
+                        if claim.anchor_line is not None
+                        else None
+                    ),
+                    target_after_line=choice.target_after_line,
+                    target_before_line=choice.target_before_line,
+                    explanation=_("deletion anchor has multiple compatible target placements"),
+                )
+            )
+        return MergeCandidateSet(tuple(candidates))
+    finally:
+        realized_entries.close()
 
 
 def discard_batch_from_line_sequences_as_buffer(

--- a/src/git_stage_batch/batch/merge.py
+++ b/src/git_stage_batch/batch/merge.py
@@ -1828,6 +1828,93 @@ def _find_boundary_after_source_line(
     return matching_indices[0] + 1
 
 
+def _presence_ambiguity_key(
+    run_start: int,
+    run_end: int,
+    claimed_run: Sequence[bytes],
+    before_source_line: int,
+    after_source_line: int,
+) -> str:
+    digest = hashlib.sha256(b"".join(claimed_run)).hexdigest()[:12]
+    return (
+        f"presence:{run_start}-{run_end}:claimed:{digest}:"
+        f"between:{before_source_line}-{after_source_line}"
+    )
+
+
+def _presence_choices_for_missing_claimed_run(
+    source_lines: Sequence[bytes],
+    working_lines: Sequence[bytes],
+    presence_line_set: LineSelection,
+    mapping: LineMapping,
+    *,
+    max_results: int,
+) -> tuple[str | None, tuple[_PresenceChoice, ...]]:
+    missing_claimed = _mapped_missing_source_lines(
+        presence_line_set,
+        len(source_lines),
+        mapping,
+    )
+    ranges = list(missing_claimed.ranges())
+    if len(ranges) != 1:
+        return None, ()
+
+    run_start, run_end = ranges[0]
+    before_source_line = run_start - 1
+    after_source_line = run_end + 1
+    if before_source_line < 1 or after_source_line > len(source_lines):
+        return None, ()
+    before_target_line = mapping.get_target_line_from_source_line(before_source_line)
+    after_target_line = mapping.get_target_line_from_source_line(after_source_line)
+    if before_target_line is None or after_target_line is None:
+        return None, ()
+    if before_target_line >= after_target_line:
+        return None, ()
+
+    left_context = (bytes(source_lines[before_source_line - 1]),)
+    right_context = (bytes(source_lines[after_source_line - 1]),)
+    claimed_run = tuple(bytes(source_lines[index]) for index in range(run_start - 1, run_end))
+    key = _presence_ambiguity_key(
+        run_start,
+        run_end,
+        claimed_run,
+        before_source_line,
+        after_source_line,
+    )
+    choices: list[_PresenceChoice] = []
+    for gap in iter_exact_context_gaps(
+        working_lines,
+        left_context=left_context,
+        right_context=right_context,
+        start_gap=before_target_line,
+        end_gap=after_target_line - 1,
+        max_results=max_results,
+    ):
+        if _line_slice_equals(working_lines, gap.gap_index, claimed_run):
+            continue
+        choices.append(
+            _PresenceChoice(
+                choice_index=len(choices) + 1,
+                gap_index=gap.gap_index,
+                run_start=run_start,
+                run_end=run_end,
+                target_after_line=gap.target_after_line,
+                target_before_line=gap.target_before_line,
+            )
+        )
+    return key, tuple(choices)
+
+
+@dataclass(frozen=True)
+class _PresenceChoice:
+    choice_index: int
+    gap_index: int
+    run_start: int
+    run_end: int
+    target_after_line: int | None
+    target_before_line: int | None
+
+
 def _sequence_matches_at_position(
     entries: Sequence[RealizedEntry],
     position: int,

--- a/src/git_stage_batch/batch/merge.py
+++ b/src/git_stage_batch/batch/merge.py
@@ -1965,6 +1965,25 @@ def _find_sequence_nearby(
     return None
 
 
+def iter_sequence_occurrences_nearby(
+    entries: Sequence[RealizedEntry],
+    position: int,
+    sequence: Sequence[bytes],
+    *,
+    window: int,
+    max_results: int,
+) -> Iterator[int]:
+    """Yield exact nearby sequence positions after a boundary."""
+    search_end = min(position + window, len(entries) - len(sequence) + 1)
+    result_count = 0
+    for check_pos in range(position + 1, search_end):
+        if _sequence_matches_at_position(entries, check_pos, list(sequence)):
+            yield check_pos
+            result_count += 1
+            if result_count >= max_results:
+                return
+
+
 def _remove_sequence_at_position(
     entries: Sequence[RealizedEntry],
     position: int,

--- a/src/git_stage_batch/batch/merge.py
+++ b/src/git_stage_batch/batch/merge.py
@@ -2023,6 +2023,28 @@ def _absence_choices_for_claim(
     return tuple(choices)
 
 
+def _suppress_absence_with_resolution(
+    entries: Sequence[RealizedEntry],
+    anchor_line: int | None,
+    forbidden_sequence: list[bytes],
+    ambiguity_key: str,
+    resolution: MergeResolution,
+) -> _RealizedEntries:
+    choice_index = resolution.decisions.get(ambiguity_key)
+    if choice_index is None:
+        raise MergeError(_("Missing merge resolution for {key}").format(key=ambiguity_key))
+    choices = _absence_choices_for_claim(
+        entries,
+        anchor_line,
+        forbidden_sequence,
+        max_results=_MERGE_CANDIDATE_CAP + 1,
+    )
+    for choice in choices:
+        if choice.choice_index == choice_index:
+            return _remove_sequence_at_position(entries, choice.position, forbidden_sequence)
+    raise MergeError(_("Selected merge resolution is no longer valid"))
+
+
 def _sequence_matches_at_position(
     entries: Sequence[RealizedEntry],
     position: int,

--- a/src/git_stage_batch/batch/merge.py
+++ b/src/git_stage_batch/batch/merge.py
@@ -1947,6 +1947,15 @@ def _presence_choices_for_missing_claimed_run(
 
 
 @dataclass(frozen=True)
+class _AbsenceChoice:
+    choice_index: int
+    position: int
+    target_after_line: int | None
+    target_before_line: int | None
+    explanation: str
+
+
+@dataclass(frozen=True)
 class _PresenceChoice:
     choice_index: int
     gap_index: int

--- a/src/git_stage_batch/batch/merge.py
+++ b/src/git_stage_batch/batch/merge.py
@@ -2821,6 +2821,113 @@ def _merge_batch_acquired_line_chunks(
         realized_entries.close()
 
 
+def enumerate_merge_batch_candidates_from_line_sequences(
+    source_lines: Sequence[bytes],
+    ownership: 'BatchOwnership',
+    working_lines: Sequence[bytes],
+    *,
+    max_candidates: int = _MERGE_CANDIDATE_CAP,
+) -> MergeCandidateSet:
+    """Enumerate safe merge candidates for an otherwise-refused merge."""
+    normalized_source_lines = normalize_line_sequence_endings(source_lines)
+    normalized_working_lines = normalize_line_sequence_endings(working_lines)
+    with (
+        normalized_source_lines.acquire_lines() as acquired_source_lines,
+        normalized_working_lines.acquire_lines() as acquired_working_lines,
+    ):
+        try:
+            for _chunk in _merge_batch_acquired_line_chunks(
+                acquired_source_lines,
+                ownership,
+                acquired_working_lines,
+            ):
+                pass
+            return MergeCandidateSet(())
+        except MergeError:
+            pass
+
+        return _enumerate_merge_batch_candidates_acquired(
+            acquired_source_lines,
+            ownership,
+            acquired_working_lines,
+            max_candidates=max_candidates,
+        )
+
+
+def _enumerate_merge_batch_candidates_acquired(
+    source_lines: Sequence[bytes],
+    ownership: 'BatchOwnership',
+    working_lines: Sequence[bytes],
+    *,
+    max_candidates: int,
+) -> MergeCandidateSet:
+    resolved = ownership.resolve()
+    presence_line_set = resolved.presence_line_set
+
+    presence_mapping = match_lines(source_lines, working_lines)
+    try:
+        presence_key, presence_choices = _presence_choices_for_missing_claimed_run(
+            source_lines,
+            working_lines,
+            presence_line_set,
+            presence_mapping,
+            max_results=max_candidates + 1,
+        )
+    finally:
+        presence_mapping.close()
+
+    if presence_key is not None and len(presence_choices) > max_candidates:
+        raise MergeError(_("Too many merge candidates to preview safely"))
+    if presence_key is not None and len(presence_choices) > 1:
+        valid_choices: list[_PresenceChoice] = []
+        for choice in presence_choices:
+            resolution = MergeResolution({presence_key: choice.choice_index})
+            try:
+                for _chunk in _merge_batch_acquired_line_chunks(
+                    source_lines,
+                    ownership,
+                    working_lines,
+                    resolution=resolution,
+                ):
+                    pass
+            except MergeError:
+                continue
+            valid_choices.append(choice)
+        if len(valid_choices) > 1:
+            count = len(valid_choices)
+            candidates = []
+            for ordinal, choice in enumerate(valid_choices, start=1):
+                summary = _(
+                    "insert source lines {start}-{end} after target line {after}, before target line {before}"
+                ).format(
+                    start=choice.run_start,
+                    end=choice.run_end,
+                    after=choice.target_after_line or "start",
+                    before=choice.target_before_line or "end",
+                )
+                candidates.append(
+                    MergeCandidate(
+                        ordinal=ordinal,
+                        count=count,
+                        decisions=(
+                            MergeResolutionDecision(
+                                ambiguity_key=presence_key,
+                                choice_index=choice.choice_index,
+                                choice_label=summary,
+                            ),
+                        ),
+                        summary=summary,
+                        source_line_range=(choice.run_start, choice.run_end),
+                        target_after_line=choice.target_after_line,
+                        target_before_line=choice.target_before_line,
+                        explanation=_("surrounding source context has multiple compatible placements"),
+                    )
+                )
+            return MergeCandidateSet(tuple(candidates))
+
+    return MergeCandidateSet(())
+
+
 def discard_batch_from_line_sequences_as_buffer(
     source_lines: Sequence[bytes],
     ownership: 'BatchOwnership',

--- a/src/git_stage_batch/batch/merge.py
+++ b/src/git_stage_batch/batch/merge.py
@@ -1859,6 +1859,16 @@ def _boundary_choices_after_source_line(
     return tuple(index + 1 for index in matching_indices)
 
 
+def _absence_ambiguity_key(
+    claim_index: int,
+    anchor_line: int | None,
+    forbidden_sequence: Sequence[bytes],
+) -> str:
+    anchor = "start" if anchor_line is None else str(anchor_line)
+    digest = hashlib.sha256(b"".join(forbidden_sequence)).hexdigest()[:12]
+    return f"absence:{claim_index}:{anchor}:{digest}"
+
+
 def _presence_ambiguity_key(
     run_start: int,
     run_end: int,

--- a/src/git_stage_batch/batch/merge.py
+++ b/src/git_stage_batch/batch/merge.py
@@ -1309,6 +1309,7 @@ def _apply_presence_constraints(
     presence_line_set: LineSelection,
     *,
     source_to_working_mapping: LineMapping | None = None,
+    resolution: MergeResolution | None = None,
 ) -> _RealizedEntries:
     """Apply presence constraints: ensure all claimed lines exist in result.
 
@@ -1336,6 +1337,7 @@ def _apply_presence_constraints(
             working_lines,
             presence_line_set,
             mapping,
+            resolution=resolution,
         )
     finally:
         if owned_mapping is not None:
@@ -1452,6 +1454,8 @@ def _apply_presence_constraints_with_mapping(
     working_lines: Sequence[bytes],
     presence_line_set: LineSelection,
     mapping: LineMapping,
+    *,
+    resolution: MergeResolution | None = None,
 ) -> _RealizedEntries:
     """Apply presence constraints using an existing source-to-working mapping."""
 
@@ -1484,6 +1488,45 @@ def _apply_presence_constraints_with_mapping(
             presence_line_set,
         )
         return result
+
+    if resolution is not None:
+        presence_key, presence_choices = _presence_choices_for_missing_claimed_run(
+            source_lines,
+            working_lines,
+            presence_line_set,
+            mapping,
+            max_results=_MERGE_CANDIDATE_CAP + 1,
+        )
+        if presence_key is not None and presence_key in resolution.decisions:
+            selected_choice_index = resolution.decisions[presence_key]
+            for choice in presence_choices:
+                if choice.choice_index == selected_choice_index:
+                    result = _RealizedEntries()
+                    _append_working_range_with_mapping(
+                        result,
+                        working_lines,
+                        mapping,
+                        0,
+                        choice.gap_index,
+                        presence_line_set,
+                    )
+                    result.append_line_range_from(
+                        source_lines,
+                        choice.run_start - 1,
+                        choice.run_end,
+                        source_line_start=choice.run_start,
+                        is_claimed=True,
+                    )
+                    _append_working_range_with_mapping(
+                        result,
+                        working_lines,
+                        mapping,
+                        choice.gap_index,
+                        len(working_lines),
+                        presence_line_set,
+                    )
+                    return result
+            raise MergeError(_("Selected merge resolution is no longer valid"))
 
     result = _RealizedEntries()
     working_idx = 0

--- a/src/git_stage_batch/batch/operation_candidates.py
+++ b/src/git_stage_batch/batch/operation_candidates.py
@@ -1,0 +1,353 @@
+"""Operation-level candidate planning and state for batch apply/include."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from itertools import product
+from typing import Literal
+
+from .merge import (
+    MergeError,
+    MergeCandidate,
+    MergeResolution,
+    enumerate_merge_batch_candidates_from_line_sequences,
+    merge_batch_from_line_sequences_as_buffer,
+)
+from .replacement import ReplacementPayload
+from ..editor import EditorBuffer
+from ..exceptions import AtomicUnitError
+
+
+CandidateOperation = Literal["apply", "include"]
+CandidateTarget = Literal["index", "worktree"]
+MAX_OPERATION_CANDIDATES = 50
+ALGORITHM_VERSION = 1
+
+
+class CandidateEnumerationLimitError(ValueError):
+    """Raised when a candidate set is too large to preview safely."""
+
+
+@dataclass
+class TargetCandidatePreview:
+    """Materialized candidate result for one target."""
+
+    target: CandidateTarget
+    file_path: str
+    before_buffer: EditorBuffer
+    after_buffer: EditorBuffer
+    resolution: MergeResolution | None
+    resolution_ordinal: int
+    resolution_count: int
+    summary: str
+    explanation: str
+
+    def close(self) -> None:
+        self.before_buffer.close()
+        self.after_buffer.close()
+
+
+@dataclass
+class OperationCandidatePreview:
+    """Materialized preview for one complete operation candidate."""
+
+    operation: CandidateOperation
+    batch_name: str
+    file_path: str
+    ordinal: int
+    count: int
+    candidate_id: str
+    targets: tuple[TargetCandidatePreview, ...]
+    batch_fingerprint: str
+    target_fingerprints: dict[str, str]
+    scope_fingerprint: str
+
+    def close(self) -> None:
+        for target in self.targets:
+            target.close()
+
+
+def _buffer_bytes(buffer: EditorBuffer) -> bytes:
+    return buffer.to_bytes()
+
+
+def _hash_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _target_fingerprint(target: CandidateTarget, file_path: str, buffer: EditorBuffer) -> str:
+    return _hash_bytes(
+        b"\0".join(
+            [
+                target.encode(),
+                file_path.encode("utf-8", errors="surrogateescape"),
+                _buffer_bytes(buffer),
+            ]
+        )
+    )
+
+
+def _candidate_id(
+    *,
+    operation: CandidateOperation,
+    batch_name: str,
+    file_path: str,
+    scope_fingerprint: str,
+    batch_fingerprint: str,
+    target_fingerprints: dict[str, str],
+    targets: tuple[TargetCandidatePreview, ...],
+) -> str:
+    payload = {
+        "algorithm_version": ALGORITHM_VERSION,
+        "operation": operation,
+        "batch_name": batch_name,
+        "file": file_path,
+        "scope": scope_fingerprint,
+        "batch_fingerprint": batch_fingerprint,
+        "targets": target_fingerprints,
+        "decisions": [
+            [
+                target.target,
+                None if target.resolution is None else sorted(target.resolution.decisions.items()),
+            ]
+            for target in targets
+        ],
+    }
+    return hashlib.sha256(json.dumps(payload, sort_keys=True).encode()).hexdigest()[:12]
+
+
+def _scope_fingerprint(
+    *,
+    operation: CandidateOperation,
+    batch_name: str,
+    file_path: str,
+    selection_ids: set[int] | None,
+    replacement_payload: ReplacementPayload | None = None,
+) -> str:
+    payload = {
+        "operation": operation,
+        "batch": batch_name,
+        "file": file_path,
+        "selection_ids": sorted(selection_ids) if selection_ids is not None else None,
+        "replacement": (
+            _hash_bytes(replacement_payload.data)
+            if replacement_payload is not None
+            else None
+        ),
+    }
+    return hashlib.sha256(json.dumps(payload, sort_keys=True).encode()).hexdigest()
+
+
+def _batch_fingerprint(batch_name: str, file_path: str, source_buffer: EditorBuffer) -> str:
+    return _hash_bytes(
+        b"\0".join(
+            [
+                batch_name.encode("utf-8", errors="surrogateescape"),
+                file_path.encode("utf-8", errors="surrogateescape"),
+                _buffer_bytes(source_buffer),
+            ]
+        )
+    )
+
+
+def _merge_candidates_or_unambiguous(
+    source_lines: EditorBuffer,
+    ownership,
+    target_lines: EditorBuffer,
+) -> tuple[MergeCandidate | None, ...]:
+    try:
+        with merge_batch_from_line_sequences_as_buffer(
+            source_lines,
+            ownership,
+            target_lines,
+        ) as _buffer:
+            pass
+        return (None,)
+    except AtomicUnitError:
+        raise
+    except MergeError:
+        pass
+
+    candidate_set = enumerate_merge_batch_candidates_from_line_sequences(
+        source_lines,
+        ownership,
+        target_lines,
+        max_candidates=MAX_OPERATION_CANDIDATES,
+    )
+    if candidate_set.candidates:
+        return candidate_set.candidates
+    raise MergeError("Batch was created from a different version of the file")
+
+
+def _materialize_target_candidate(
+    *,
+    target: CandidateTarget,
+    file_path: str,
+    source_lines: EditorBuffer,
+    ownership,
+    before_lines: EditorBuffer,
+    candidate: MergeCandidate | None,
+) -> TargetCandidatePreview:
+    before_copy = EditorBuffer.from_bytes(before_lines.to_bytes())
+    after = merge_batch_from_line_sequences_as_buffer(
+        source_lines,
+        ownership,
+        before_lines,
+        resolution=None if candidate is None else candidate.resolution,
+    )
+    return TargetCandidatePreview(
+        target=target,
+        file_path=file_path,
+        before_buffer=before_copy,
+        after_buffer=after,
+        resolution=None if candidate is None else candidate.resolution,
+        resolution_ordinal=1 if candidate is None else candidate.ordinal,
+        resolution_count=1 if candidate is None else candidate.count,
+        summary="unambiguous" if candidate is None else candidate.summary,
+        explanation="" if candidate is None else candidate.explanation,
+    )
+
+
+def build_apply_candidate_previews(
+    *,
+    batch_name: str,
+    file_path: str,
+    source_lines: EditorBuffer,
+    ownership,
+    worktree_lines: EditorBuffer,
+    selection_ids: set[int] | None,
+) -> tuple[OperationCandidatePreview, ...]:
+    """Return apply candidates for a single file, or an empty tuple."""
+    merge_candidates = _merge_candidates_or_unambiguous(
+        source_lines,
+        ownership,
+        worktree_lines,
+    )
+    if merge_candidates == (None,):
+        return ()
+
+    batch_fingerprint = _batch_fingerprint(batch_name, file_path, source_lines)
+    scope_fingerprint = _scope_fingerprint(
+        operation="apply",
+        batch_name=batch_name,
+        file_path=file_path,
+        selection_ids=selection_ids,
+    )
+    count = len(merge_candidates)
+    previews: list[OperationCandidatePreview] = []
+    for ordinal, merge_candidate in enumerate(merge_candidates, start=1):
+        target_preview = _materialize_target_candidate(
+            target="worktree",
+            file_path=file_path,
+            source_lines=source_lines,
+            ownership=ownership,
+            before_lines=worktree_lines,
+            candidate=merge_candidate,
+        )
+        target_fingerprints = {
+            "worktree": _target_fingerprint("worktree", file_path, target_preview.before_buffer)
+        }
+        targets = (target_preview,)
+        preview = OperationCandidatePreview(
+            operation="apply",
+            batch_name=batch_name,
+            file_path=file_path,
+            ordinal=ordinal,
+            count=count,
+            candidate_id="",
+            targets=targets,
+            batch_fingerprint=batch_fingerprint,
+            target_fingerprints=target_fingerprints,
+            scope_fingerprint=scope_fingerprint,
+        )
+        preview.candidate_id = _candidate_id(
+            operation="apply",
+            batch_name=batch_name,
+            file_path=file_path,
+            scope_fingerprint=scope_fingerprint,
+            batch_fingerprint=batch_fingerprint,
+            target_fingerprints=target_fingerprints,
+            targets=targets,
+        )
+        previews.append(preview)
+    return tuple(previews)
+
+
+def build_include_candidate_previews(
+    *,
+    batch_name: str,
+    file_path: str,
+    source_lines: EditorBuffer,
+    ownership,
+    index_lines: EditorBuffer,
+    worktree_lines: EditorBuffer,
+    selection_ids: set[int] | None,
+    replacement_payload: ReplacementPayload | None = None,
+) -> tuple[OperationCandidatePreview, ...]:
+    """Return include candidates for a single file, or an empty tuple."""
+    index_candidates = _merge_candidates_or_unambiguous(source_lines, ownership, index_lines)
+    worktree_candidates = _merge_candidates_or_unambiguous(source_lines, ownership, worktree_lines)
+    if index_candidates == (None,) and worktree_candidates == (None,):
+        return ()
+
+    products = list(product(index_candidates, worktree_candidates))
+    if len(products) > MAX_OPERATION_CANDIDATES:
+        raise CandidateEnumerationLimitError("too many include candidates to preview safely")
+
+    batch_fingerprint = _batch_fingerprint(batch_name, file_path, source_lines)
+    scope_fingerprint = _scope_fingerprint(
+        operation="include",
+        batch_name=batch_name,
+        file_path=file_path,
+        selection_ids=selection_ids,
+        replacement_payload=replacement_payload,
+    )
+    count = len(products)
+    previews: list[OperationCandidatePreview] = []
+    for ordinal, (index_candidate, worktree_candidate) in enumerate(products, start=1):
+        index_preview = _materialize_target_candidate(
+            target="index",
+            file_path=file_path,
+            source_lines=source_lines,
+            ownership=ownership,
+            before_lines=index_lines,
+            candidate=index_candidate,
+        )
+        worktree_preview = _materialize_target_candidate(
+            target="worktree",
+            file_path=file_path,
+            source_lines=source_lines,
+            ownership=ownership,
+            before_lines=worktree_lines,
+            candidate=worktree_candidate,
+        )
+        targets = (index_preview, worktree_preview)
+        target_fingerprints = {
+            "index": _target_fingerprint("index", file_path, index_preview.before_buffer),
+            "worktree": _target_fingerprint("worktree", file_path, worktree_preview.before_buffer),
+        }
+        preview = OperationCandidatePreview(
+            operation="include",
+            batch_name=batch_name,
+            file_path=file_path,
+            ordinal=ordinal,
+            count=count,
+            candidate_id="",
+            targets=targets,
+            batch_fingerprint=batch_fingerprint,
+            target_fingerprints=target_fingerprints,
+            scope_fingerprint=scope_fingerprint,
+        )
+        preview.candidate_id = _candidate_id(
+            operation="include",
+            batch_name=batch_name,
+            file_path=file_path,
+            scope_fingerprint=scope_fingerprint,
+            batch_fingerprint=batch_fingerprint,
+            target_fingerprints=target_fingerprints,
+            targets=targets,
+        )
+        previews.append(preview)
+    return tuple(previews)

--- a/src/git_stage_batch/batch/operation_candidates.py
+++ b/src/git_stage_batch/batch/operation_candidates.py
@@ -6,6 +6,7 @@ import difflib
 import hashlib
 import json
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from itertools import product
 from typing import Literal
 
@@ -19,6 +20,7 @@ from .merge import (
 from .replacement import ReplacementPayload
 from ..editor import EditorBuffer
 from ..exceptions import AtomicUnitError
+from ..utils.paths import get_batch_candidate_state_file_path
 
 
 CandidateOperation = Literal["apply", "include"]
@@ -375,3 +377,84 @@ def render_candidate_buffer_diff(
             n=context_lines,
         )
     )
+
+
+def _load_state() -> dict:
+    path = get_batch_candidate_state_file_path()
+    if not path.exists():
+        return {"schema_version": 1, "algorithm_version": ALGORITHM_VERSION, "scopes": {}}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {"schema_version": 1, "algorithm_version": ALGORITHM_VERSION, "scopes": {}}
+    if data.get("schema_version") != 1:
+        return {"schema_version": 1, "algorithm_version": ALGORITHM_VERSION, "scopes": {}}
+    data.setdefault("scopes", {})
+    return data
+
+
+def _save_state(data: dict) -> None:
+    path = get_batch_candidate_state_file_path()
+    path.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def clear_candidate_preview_state_for_file(*, batch_name: str, file_path: str) -> None:
+    """Remove saved candidate previews for one batch file."""
+    data = _load_state()
+    scopes = data.get("scopes", {})
+    matching_keys = [
+        key
+        for key, scope in scopes.items()
+        if scope.get("batch_name") == batch_name and scope.get("file") == file_path
+    ]
+    if not matching_keys:
+        return
+
+    for key in matching_keys:
+        del scopes[key]
+
+    if scopes:
+        _save_state(data)
+        return
+
+    get_batch_candidate_state_file_path().unlink(missing_ok=True)
+
+
+def candidate_preview_scope_key(preview: OperationCandidatePreview) -> str:
+    payload = {
+        "algorithm_version": ALGORITHM_VERSION,
+        "operation": preview.operation,
+        "batch": preview.batch_name,
+        "file": preview.file_path,
+        "scope": preview.scope_fingerprint,
+    }
+    digest = hashlib.sha256(json.dumps(payload, sort_keys=True).encode()).hexdigest()
+    return f"{preview.operation}:{preview.batch_name}:{preview.file_path}:{digest}"
+
+
+def save_candidate_preview_state(preview: OperationCandidatePreview) -> None:
+    data = _load_state()
+    data["algorithm_version"] = ALGORITHM_VERSION
+    scope = data["scopes"].setdefault(candidate_preview_scope_key(preview), {})
+    scope.update({
+        "batch_name": preview.batch_name,
+        "operation": preview.operation,
+        "file": preview.file_path,
+        "batch_fingerprint": preview.batch_fingerprint,
+        "scope_fingerprint": preview.scope_fingerprint,
+        "candidate_count": preview.count,
+    })
+    scope.setdefault("previews", {})[str(preview.ordinal)] = {
+        "ordinal": preview.ordinal,
+        "candidate_id": preview.candidate_id,
+        "target_fingerprints": preview.target_fingerprints,
+        "shown_at": datetime.now(timezone.utc).isoformat(),
+    }
+    _save_state(data)
+
+
+def load_candidate_preview_state(preview: OperationCandidatePreview) -> dict | None:
+    scope = _load_state().get("scopes", {}).get(candidate_preview_scope_key(preview))
+    if scope is None:
+        return None
+    return scope.get("previews", {}).get(str(preview.ordinal))

--- a/src/git_stage_batch/batch/operation_candidates.py
+++ b/src/git_stage_batch/batch/operation_candidates.py
@@ -10,6 +10,10 @@ from datetime import datetime, timezone
 from itertools import product
 from typing import Literal
 
+from ..core.text_lifecycle import selected_text_target_change_type
+from ..editor import EditorBuffer, buffer_byte_chunks
+from ..exceptions import AtomicUnitError
+from ..utils.paths import get_batch_candidate_state_file_path
 from .merge import (
     MergeError,
     MergeCandidate,
@@ -18,15 +22,12 @@ from .merge import (
     merge_batch_from_line_sequences_as_buffer,
 )
 from .replacement import ReplacementPayload
-from ..editor import EditorBuffer
-from ..exceptions import AtomicUnitError
-from ..utils.paths import get_batch_candidate_state_file_path
 
 
 CandidateOperation = Literal["apply", "include"]
 CandidateTarget = Literal["index", "worktree"]
 MAX_OPERATION_CANDIDATES = 50
-ALGORITHM_VERSION = 1
+ALGORITHM_VERSION = 2
 
 
 class CandidateEnumerationLimitError(ValueError):
@@ -41,6 +42,9 @@ class TargetCandidatePreview:
     file_path: str
     before_buffer: EditorBuffer
     after_buffer: EditorBuffer
+    file_mode: str | None
+    change_type: str
+    destination_exists: bool
     resolution: MergeResolution | None
     resolution_ordinal: int
     resolution_count: int
@@ -65,6 +69,7 @@ class OperationCandidatePreview:
     targets: tuple[TargetCandidatePreview, ...]
     batch_fingerprint: str
     target_fingerprints: dict[str, str]
+    target_result_fingerprints: dict[str, str]
     scope_fingerprint: str
 
     def close(self) -> None:
@@ -72,24 +77,101 @@ class OperationCandidatePreview:
             target.close()
 
 
-def _buffer_bytes(buffer: EditorBuffer) -> bytes:
-    return buffer.to_bytes()
-
-
 def _hash_bytes(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
 
 
+def _buffer_fingerprint(buffer) -> str:
+    digest = hashlib.sha256()
+    for chunk in buffer_byte_chunks(buffer):
+        digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _json_fingerprint(payload) -> str:
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+
+
 def _target_fingerprint(target: CandidateTarget, file_path: str, buffer: EditorBuffer) -> str:
-    return _hash_bytes(
-        b"\0".join(
-            [
-                target.encode(),
-                file_path.encode("utf-8", errors="surrogateescape"),
-                _buffer_bytes(buffer),
-            ]
-        )
-    )
+    return _json_fingerprint({
+        "target": target,
+        "file": file_path,
+        "buffer": _buffer_fingerprint(buffer),
+    })
+
+
+def _target_result_fingerprint(target: TargetCandidatePreview) -> str:
+    return _json_fingerprint({
+        "target": target.target,
+        "file": target.file_path,
+        "before": _buffer_fingerprint(target.before_buffer),
+        "after": _buffer_fingerprint(target.after_buffer),
+        "file_mode": target.file_mode,
+        "change_type": target.change_type,
+        "destination_exists": target.destination_exists,
+    })
+
+
+def _baseline_reference_payload(reference) -> dict | None:
+    if reference is None:
+        return None
+    return {
+        "after_line": reference.after_line,
+        "after_content": (
+            None if reference.after_content is None else _hash_bytes(reference.after_content)
+        ),
+        "has_after_line": reference.has_after_line,
+        "before_line": reference.before_line,
+        "before_content": (
+            None if reference.before_content is None else _hash_bytes(reference.before_content)
+        ),
+        "has_before_line": reference.has_before_line,
+    }
+
+
+def _absence_claim_payload(claim) -> dict:
+    return {
+        "anchor_line": claim.anchor_line,
+        "content": _buffer_fingerprint(claim.content_lines),
+        "line_count": len(claim.content_lines),
+        "baseline_reference": _baseline_reference_payload(claim.baseline_reference),
+    }
+
+
+def _presence_claim_payload(claim) -> dict:
+    return {
+        "source_lines": claim.source_lines,
+        "baseline_references": [
+            [line, _baseline_reference_payload(reference)]
+            for line, reference in sorted(claim.baseline_references.items())
+        ],
+    }
+
+
+def _replacement_unit_payload(unit) -> dict:
+    return {
+        "presence_lines": unit.presence_lines,
+        "deletion_indices": unit.deletion_indices,
+    }
+
+
+def _ownership_fingerprint(ownership) -> str:
+    return _json_fingerprint({
+        "presence_claims": [
+            _presence_claim_payload(claim)
+            for claim in ownership.presence_claims
+        ],
+        "deletions": [
+            _absence_claim_payload(claim)
+            for claim in ownership.deletions
+        ],
+        "replacement_units": [
+            _replacement_unit_payload(unit)
+            for unit in ownership.replacement_units
+        ],
+    })
 
 
 def _candidate_id(
@@ -100,6 +182,7 @@ def _candidate_id(
     scope_fingerprint: str,
     batch_fingerprint: str,
     target_fingerprints: dict[str, str],
+    target_result_fingerprints: dict[str, str],
     targets: tuple[TargetCandidatePreview, ...],
 ) -> str:
     payload = {
@@ -110,6 +193,7 @@ def _candidate_id(
         "scope": scope_fingerprint,
         "batch_fingerprint": batch_fingerprint,
         "targets": target_fingerprints,
+        "target_results": target_result_fingerprints,
         "decisions": [
             [
                 target.target,
@@ -143,16 +227,24 @@ def _scope_fingerprint(
     return hashlib.sha256(json.dumps(payload, sort_keys=True).encode()).hexdigest()
 
 
-def _batch_fingerprint(batch_name: str, file_path: str, source_buffer: EditorBuffer) -> str:
-    return _hash_bytes(
-        b"\0".join(
-            [
-                batch_name.encode("utf-8", errors="surrogateescape"),
-                file_path.encode("utf-8", errors="surrogateescape"),
-                _buffer_bytes(source_buffer),
-            ]
-        )
-    )
+def _batch_fingerprint(
+    *,
+    batch_name: str,
+    file_path: str,
+    source_buffer: EditorBuffer,
+    ownership,
+    batch_source_commit: str,
+    file_meta: dict,
+) -> str:
+    return _json_fingerprint({
+        "algorithm_version": ALGORITHM_VERSION,
+        "batch_name": batch_name,
+        "file": file_path,
+        "batch_source_commit": batch_source_commit,
+        "source": _buffer_fingerprint(source_buffer),
+        "file_metadata": file_meta,
+        "ownership": _ownership_fingerprint(ownership),
+    })
 
 
 def _merge_candidates_or_unambiguous(
@@ -192,6 +284,10 @@ def _materialize_target_candidate(
     ownership,
     before_lines: EditorBuffer,
     candidate: MergeCandidate | None,
+    file_mode: str | None,
+    text_change_type,
+    destination_exists: bool,
+    selected_ids: set[int] | None,
 ) -> TargetCandidatePreview:
     before_copy = EditorBuffer.from_bytes(before_lines.to_bytes())
     after = merge_batch_from_line_sequences_as_buffer(
@@ -205,6 +301,13 @@ def _materialize_target_candidate(
         file_path=file_path,
         before_buffer=before_copy,
         after_buffer=after,
+        file_mode=file_mode,
+        change_type=selected_text_target_change_type(
+            text_change_type,
+            selected_ids,
+            after,
+        ).value,
+        destination_exists=destination_exists,
         resolution=None if candidate is None else candidate.resolution,
         resolution_ordinal=1 if candidate is None else candidate.ordinal,
         resolution_count=1 if candidate is None else candidate.count,
@@ -220,6 +323,12 @@ def build_apply_candidate_previews(
     source_lines: EditorBuffer,
     ownership,
     worktree_lines: EditorBuffer,
+    batch_source_commit: str,
+    file_meta: dict,
+    text_change_type,
+    worktree_file_mode: str | None,
+    worktree_exists: bool,
+    selected_ids: set[int] | None,
     selection_ids: set[int] | None,
 ) -> tuple[OperationCandidatePreview, ...]:
     """Return apply candidates for a single file, or an empty tuple."""
@@ -231,7 +340,14 @@ def build_apply_candidate_previews(
     if merge_candidates == (None,):
         return ()
 
-    batch_fingerprint = _batch_fingerprint(batch_name, file_path, source_lines)
+    batch_fingerprint = _batch_fingerprint(
+        batch_name=batch_name,
+        file_path=file_path,
+        source_buffer=source_lines,
+        ownership=ownership,
+        batch_source_commit=batch_source_commit,
+        file_meta=file_meta,
+    )
     scope_fingerprint = _scope_fingerprint(
         operation="apply",
         batch_name=batch_name,
@@ -248,9 +364,16 @@ def build_apply_candidate_previews(
             ownership=ownership,
             before_lines=worktree_lines,
             candidate=merge_candidate,
+            file_mode=worktree_file_mode,
+            text_change_type=text_change_type,
+            destination_exists=worktree_exists,
+            selected_ids=selected_ids,
         )
         target_fingerprints = {
             "worktree": _target_fingerprint("worktree", file_path, target_preview.before_buffer)
+        }
+        target_result_fingerprints = {
+            "worktree": _target_result_fingerprint(target_preview)
         }
         targets = (target_preview,)
         preview = OperationCandidatePreview(
@@ -263,6 +386,7 @@ def build_apply_candidate_previews(
             targets=targets,
             batch_fingerprint=batch_fingerprint,
             target_fingerprints=target_fingerprints,
+            target_result_fingerprints=target_result_fingerprints,
             scope_fingerprint=scope_fingerprint,
         )
         preview.candidate_id = _candidate_id(
@@ -272,6 +396,7 @@ def build_apply_candidate_previews(
             scope_fingerprint=scope_fingerprint,
             batch_fingerprint=batch_fingerprint,
             target_fingerprints=target_fingerprints,
+            target_result_fingerprints=target_result_fingerprints,
             targets=targets,
         )
         previews.append(preview)
@@ -286,6 +411,14 @@ def build_include_candidate_previews(
     ownership,
     index_lines: EditorBuffer,
     worktree_lines: EditorBuffer,
+    batch_source_commit: str,
+    file_meta: dict,
+    text_change_type,
+    index_file_mode: str | None,
+    worktree_file_mode: str | None,
+    index_exists: bool,
+    worktree_exists: bool,
+    selected_ids: set[int] | None,
     selection_ids: set[int] | None,
     replacement_payload: ReplacementPayload | None = None,
 ) -> tuple[OperationCandidatePreview, ...]:
@@ -299,7 +432,14 @@ def build_include_candidate_previews(
     if len(products) > MAX_OPERATION_CANDIDATES:
         raise CandidateEnumerationLimitError("too many include candidates to preview safely")
 
-    batch_fingerprint = _batch_fingerprint(batch_name, file_path, source_lines)
+    batch_fingerprint = _batch_fingerprint(
+        batch_name=batch_name,
+        file_path=file_path,
+        source_buffer=source_lines,
+        ownership=ownership,
+        batch_source_commit=batch_source_commit,
+        file_meta=file_meta,
+    )
     scope_fingerprint = _scope_fingerprint(
         operation="include",
         batch_name=batch_name,
@@ -317,6 +457,10 @@ def build_include_candidate_previews(
             ownership=ownership,
             before_lines=index_lines,
             candidate=index_candidate,
+            file_mode=index_file_mode,
+            text_change_type=text_change_type,
+            destination_exists=index_exists,
+            selected_ids=selected_ids,
         )
         worktree_preview = _materialize_target_candidate(
             target="worktree",
@@ -325,11 +469,19 @@ def build_include_candidate_previews(
             ownership=ownership,
             before_lines=worktree_lines,
             candidate=worktree_candidate,
+            file_mode=worktree_file_mode,
+            text_change_type=text_change_type,
+            destination_exists=worktree_exists,
+            selected_ids=selected_ids,
         )
         targets = (index_preview, worktree_preview)
         target_fingerprints = {
             "index": _target_fingerprint("index", file_path, index_preview.before_buffer),
             "worktree": _target_fingerprint("worktree", file_path, worktree_preview.before_buffer),
+        }
+        target_result_fingerprints = {
+            "index": _target_result_fingerprint(index_preview),
+            "worktree": _target_result_fingerprint(worktree_preview),
         }
         preview = OperationCandidatePreview(
             operation="include",
@@ -341,6 +493,7 @@ def build_include_candidate_previews(
             targets=targets,
             batch_fingerprint=batch_fingerprint,
             target_fingerprints=target_fingerprints,
+            target_result_fingerprints=target_result_fingerprints,
             scope_fingerprint=scope_fingerprint,
         )
         preview.candidate_id = _candidate_id(
@@ -350,6 +503,7 @@ def build_include_candidate_previews(
             scope_fingerprint=scope_fingerprint,
             batch_fingerprint=batch_fingerprint,
             target_fingerprints=target_fingerprints,
+            target_result_fingerprints=target_result_fingerprints,
             targets=targets,
         )
         previews.append(preview)
@@ -388,6 +542,8 @@ def _load_state() -> dict:
     except (OSError, json.JSONDecodeError):
         return {"schema_version": 1, "algorithm_version": ALGORITHM_VERSION, "scopes": {}}
     if data.get("schema_version") != 1:
+        return {"schema_version": 1, "algorithm_version": ALGORITHM_VERSION, "scopes": {}}
+    if data.get("algorithm_version") != ALGORITHM_VERSION:
         return {"schema_version": 1, "algorithm_version": ALGORITHM_VERSION, "scopes": {}}
     data.setdefault("scopes", {})
     return data
@@ -448,6 +604,7 @@ def save_candidate_preview_state(preview: OperationCandidatePreview) -> None:
         "ordinal": preview.ordinal,
         "candidate_id": preview.candidate_id,
         "target_fingerprints": preview.target_fingerprints,
+        "target_result_fingerprints": preview.target_result_fingerprints,
         "shown_at": datetime.now(timezone.utc).isoformat(),
     }
     _save_state(data)

--- a/src/git_stage_batch/batch/operation_candidates.py
+++ b/src/git_stage_batch/batch/operation_candidates.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import difflib
 import hashlib
 import json
 from dataclasses import dataclass
@@ -351,3 +352,26 @@ def build_include_candidate_previews(
         )
         previews.append(preview)
     return tuple(previews)
+
+
+def render_candidate_buffer_diff(
+    file_path: str,
+    before_buffer: EditorBuffer,
+    after_buffer: EditorBuffer,
+    *,
+    label_before: str,
+    label_after: str,
+    context_lines: int,
+) -> str:
+    """Render a unified diff between two candidate buffers."""
+    before_text = before_buffer.to_bytes().decode("utf-8", errors="surrogateescape")
+    after_text = after_buffer.to_bytes().decode("utf-8", errors="surrogateescape")
+    return "".join(
+        difflib.unified_diff(
+            before_text.splitlines(keepends=True),
+            after_text.splitlines(keepends=True),
+            fromfile=f"{label_before}/{file_path}",
+            tofile=f"{label_after}/{file_path}",
+            n=context_lines,
+        )
+    )

--- a/src/git_stage_batch/batch/source_selector.py
+++ b/src/git_stage_batch/batch/source_selector.py
@@ -1,0 +1,115 @@
+"""Parsing helpers for batch source selectors."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Literal
+
+from .validation import validate_batch_name
+from ..exceptions import CommandError
+from ..i18n import _
+
+
+CandidateOperation = Literal["apply", "include"]
+
+_SELECTOR_RE = re.compile(
+    r"^(?P<batch>[^:]+):(?P<operation>apply|include)(?::(?P<ordinal>[1-9][0-9]*))?$"
+)
+
+
+@dataclass(frozen=True)
+class BatchSourceSelector:
+    """A parsed batch selector with optional candidate preview information."""
+
+    batch_name: str
+    candidate_operation: CandidateOperation | None = None
+    candidate_ordinal: int | None = None
+
+    @property
+    def is_candidate_selector(self) -> bool:
+        return self.candidate_operation is not None
+
+
+def _invalid_selector(value: str) -> CommandError:
+    return CommandError(
+        _(
+            "Invalid batch selector '{selector}'. Candidate selectors use "
+            "'BATCH:apply', 'BATCH:apply:N', 'BATCH:include', or 'BATCH:include:N'."
+        ).format(selector=value)
+    )
+
+
+def parse_batch_source_selector(value: str) -> BatchSourceSelector:
+    """Parse a batch name or operation candidate selector."""
+    if ":" not in value:
+        validate_batch_name(value)
+        return BatchSourceSelector(batch_name=value)
+
+    match = _SELECTOR_RE.fullmatch(value)
+    if match is None:
+        raise _invalid_selector(value)
+
+    batch_name = match.group("batch")
+    validate_batch_name(batch_name)
+    ordinal_text = match.group("ordinal")
+    return BatchSourceSelector(
+        batch_name=batch_name,
+        candidate_operation=match.group("operation"),  # type: ignore[arg-type]
+        candidate_ordinal=int(ordinal_text) if ordinal_text is not None else None,
+    )
+
+
+def format_batch_source_selector(selector: BatchSourceSelector) -> str:
+    """Format a parsed selector back into user-facing syntax."""
+    if selector.candidate_operation is None:
+        return selector.batch_name
+    if selector.candidate_ordinal is None:
+        return f"{selector.batch_name}:{selector.candidate_operation}"
+    return (
+        f"{selector.batch_name}:{selector.candidate_operation}:"
+        f"{selector.candidate_ordinal}"
+    )
+
+
+def batch_name_for_source_lookup(value: str) -> str:
+    """Return the underlying batch name for early metadata/scope lookup."""
+    return parse_batch_source_selector(value).batch_name
+
+
+def require_plain_batch_name(value: str, command_name: str) -> str:
+    """Reject candidate selectors where a command expects a batch object name."""
+    selector = parse_batch_source_selector(value)
+    if selector.candidate_operation is not None:
+        raise CommandError(
+            _(
+                "'{selector}' is a candidate selector, not a batch name.\n"
+                "Use '{batch}' for batch management commands."
+            ).format(selector=value, batch=selector.batch_name)
+        )
+    return selector.batch_name
+
+
+def require_candidate_operation(
+    selector: BatchSourceSelector,
+    expected: CandidateOperation,
+    *,
+    raw_value: str | None = None,
+    file: str | None = None,
+) -> None:
+    """Reject a selector for the opposite operation."""
+    actual = selector.candidate_operation
+    if actual is None or actual == expected:
+        return
+
+    display = raw_value or format_batch_source_selector(selector)
+    message = _(
+        "'{selector}' is an {actual} candidate, not an {expected} candidate.\n"
+        "No changes applied."
+    ).format(selector=display, actual=actual, expected=expected)
+    if file:
+        message += _(
+            "\n\nPreview {expected} candidates with:\n"
+            "  git-stage-batch show --from {batch}:{expected} --file {file}"
+        ).format(expected=expected, batch=selector.batch_name, file=file)
+    raise CommandError(message)

--- a/src/git_stage_batch/cli/argument_parser.py
+++ b/src/git_stage_batch/cli/argument_parser.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 from .. import __version__
 from ..batch.validation import batch_exists
+from ..batch.source_selector import batch_name_for_source_lookup
 from ..batch.replacement import ReplacementText
 from .. import commands
 from ..batch.query import read_batch_metadata
@@ -489,18 +490,19 @@ def _resolve_batch_file_scope(
     file_patterns: list[str] | None,
 ) -> FileScope:
     """Resolve single-file or pattern-based batch file scope."""
+    lookup_batch_name = batch_name_for_source_lookup(batch_name)
     _validate_file_inputs(file_arg, file_patterns)
     if file_patterns is None:
         return FileScope.implicit() if file_arg is None else FileScope.explicit(file_arg)
-    if not batch_exists(batch_name):
-        raise CommandError(_("Batch '{name}' does not exist").format(name=batch_name))
+    if not batch_exists(lookup_batch_name):
+        raise CommandError(_("Batch '{name}' does not exist").format(name=lookup_batch_name))
 
-    metadata = read_batch_metadata(batch_name)
+    metadata = read_batch_metadata(lookup_batch_name)
     resolved_files = resolve_gitignore_style_patterns(metadata.get("files", {}).keys(), file_patterns)
     if not resolved_files:
         raise CommandError(
             _("No files in batch '{name}' matched: {patterns}").format(
-                name=batch_name,
+                name=lookup_batch_name,
                 patterns=", ".join(file_patterns),
             )
         )
@@ -706,13 +708,15 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
             else _resolve_live_file_scope(args.file, args.file_patterns)
         )
         if args.page is not None:
-            if args.from_batch and not batch_exists(args.from_batch):
-                raise CommandError(_("Batch '{name}' does not exist").format(name=args.from_batch))
+            lookup_batch = batch_name_for_source_lookup(args.from_batch) if args.from_batch else None
+            if lookup_batch and not batch_exists(lookup_batch):
+                raise CommandError(_("Batch '{name}' does not exist").format(name=lookup_batch))
             if resolved_file_scope.is_implicit:
                 if not (
                     args.from_batch
-                    and batch_exists(args.from_batch)
-                    and len(read_batch_metadata(args.from_batch).get("files", {})) == 1
+                    and lookup_batch is not None
+                    and batch_exists(lookup_batch)
+                    and len(read_batch_metadata(lookup_batch).get("files", {})) == 1
                 ):
                     raise CommandError(
                         _(

--- a/src/git_stage_batch/cli/argument_parser.py
+++ b/src/git_stage_batch/cli/argument_parser.py
@@ -701,7 +701,24 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
         action="store_true",
         help=_("Output JSON for scripting instead of human-readable text"),
     )
+    parser_show.add_argument(
+        "--as",
+        dest="as_text",
+        metavar="TEXT",
+        help=_("Preview selected batch lines as replacement text"),
+    )
+    parser_show.add_argument(
+        "--as-stdin",
+        dest="as_stdin",
+        action="store_true",
+        help=_("Read replacement preview text from standard input exactly"),
+    )
     def dispatch_show(args: argparse.Namespace) -> None:
+        replacement_requested = args.as_text is not None or args.as_stdin
+        if replacement_requested and not args.from_batch:
+            raise CommandError(_("`show --as` requires `--from`."))
+        if args.as_text is not None and args.as_stdin:
+            raise CommandError(_("Cannot use `--as` and `--as-stdin` together."))
         resolved_file_scope = (
             _resolve_batch_file_scope(args.from_batch, args.file, args.file_patterns)
             if args.from_batch
@@ -731,21 +748,29 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
             if args.porcelain:
                 raise CommandError(_("Cannot use `show --page` with `--porcelain`."))
         if args.from_batch:
+            replacement_text = _resolve_replacement_text(args) if replacement_requested else None
+            show_kwargs = {"page": args.page}
+            if args.porcelain:
+                show_kwargs["porcelain"] = args.porcelain
+            if replacement_text is not None:
+                show_kwargs["replacement_text"] = replacement_text
             if resolved_file_scope.is_multiple:
                 if args.line_ids:
                     raise CommandError(_("Cannot use --lines with multiple files."))
+                if replacement_requested:
+                    raise CommandError(_("`show --as` requires exactly one resolved file."))
                 commands.command_show_from_batch(
                     args.from_batch,
                     args.line_ids,
                     patterns=args.file_patterns,
-                    page=args.page,
+                    **show_kwargs,
                 )
             else:
                 commands.command_show_from_batch(
                     args.from_batch,
                     args.line_ids,
                     resolved_file_scope.optional_file(),
-                    page=args.page,
+                    **show_kwargs,
                 )
             return
         if args.line_ids or not resolved_file_scope.is_implicit:

--- a/src/git_stage_batch/commands/annotate.py
+++ b/src/git_stage_batch/commands/annotate.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from ..batch import update_batch_note
+from ..batch.source_selector import require_plain_batch_name
 import sys
 from ..data.undo import undo_checkpoint
 from ..i18n import _
@@ -12,6 +13,7 @@ from ..utils.git import require_git_repository
 def command_annotate_batch(batch_name: str, note: str) -> None:
     """Add or update batch description."""
     require_git_repository()
+    batch_name = require_plain_batch_name(batch_name, "annotate")
     with undo_checkpoint(f"annotate {batch_name}"):
         update_batch_note(batch_name, note)
     print(_("✓ Updated note for batch '{name}'").format(name=batch_name), file=sys.stderr)

--- a/src/git_stage_batch/commands/apply_from.py
+++ b/src/git_stage_batch/commands/apply_from.py
@@ -4,10 +4,17 @@ from __future__ import annotations
 
 import os
 import sys
+from dataclasses import dataclass
 from typing import Optional
 
 from ..batch.merge import merge_batch_from_line_sequences_as_buffer
 from ..batch.metadata_validation import read_validated_batch_metadata
+from ..batch.operation_candidates import (
+    CandidateEnumerationLimitError,
+    build_apply_candidate_previews,
+    clear_candidate_preview_state_for_file,
+    load_candidate_preview_state,
+)
 from ..batch.query import get_batch_commit_sha
 from ..batch.selection import (
     acquire_batch_ownership_for_display_ids_from_lines,
@@ -22,6 +29,10 @@ from ..batch.submodule_pointer import (
     is_batch_submodule_pointer,
     refuse_batch_submodule_pointer_lines,
 )
+from ..batch.source_selector import (
+    parse_batch_source_selector,
+    require_candidate_operation,
+)
 from ..batch.validation import batch_exists
 from ..core.text_lifecycle import (
     TextFileChangeType,
@@ -31,6 +42,7 @@ from ..core.text_lifecycle import (
 )
 from ..data.file_review_state import (
     FileReviewAction,
+    finish_review_scoped_line_action,
     resolve_batch_source_action_scope,
 )
 from ..data.hunk_tracking import (
@@ -49,50 +61,95 @@ from ..i18n import _
 from ..utils.git import get_git_repository_root_path, require_git_repository
 
 
-def _apply_binary_file_from_batch(batch_name: str, file_path: str, file_meta: dict) -> None:
-    """Apply binary file from batch to working tree.
+@dataclass
+class _ApplyTextPlan:
+    file_path: str
+    buffer: EditorBuffer | None
+    file_mode: str | None
+    change_type: str
 
-    Binary files are atomic units - whole file replacements stored in batch commit tree.
-    This function reads the file from the batch commit tree and writes it to the working tree,
-    or deletes the working tree file if the batch represents a deletion.
+    def close(self) -> None:
+        if self.buffer is not None:
+            self.buffer.close()
 
-    Args:
-        batch_name: Name of batch containing binary file
-        file_path: Path to binary file
-        file_meta: File metadata from batch
 
-    Raises:
-        RuntimeError: If batch commit not found or file cannot be read
-    """
-    repo_root = get_git_repository_root_path()
-    full_path = repo_root / file_path
+@dataclass
+class _ApplyBinaryPlan:
+    file_path: str
+    file_meta: dict
+    buffer: EditorBuffer | None
 
-    # Get batch commit SHA (canonical state for binaries)
+    def close(self) -> None:
+        if self.buffer is not None:
+            self.buffer.close()
+
+
+@dataclass(frozen=True)
+class _ApplySubmodulePlan:
+    file_path: str
+    file_meta: dict
+
+    def close(self) -> None:
+        return None
+
+
+@dataclass(frozen=True)
+class _ApplyCandidateCount:
+    count: int = 0
+    too_many: bool = False
+    error: str | None = None
+
+
+def _read_binary_file_from_batch(
+    batch_name: str,
+    file_path: str,
+    file_meta: dict,
+) -> EditorBuffer | None:
+    """Read one binary batch target, or return None for a stored deletion."""
     batch_commit = get_batch_commit_sha(batch_name)
     if not batch_commit:
         raise RuntimeError(f"Batch commit not found for batch '{batch_name}'")
 
     change_type = file_meta.get("change_type", "modified")
     if change_type == "deleted":
-        if os.path.lexists(full_path):
-            full_path.unlink()
-            print(_("✓ Deleted binary file: {file}").format(file=file_path), file=sys.stderr)
-        return
+        return None
 
-    # Read file from batch commit tree
     batch_buffer = load_git_object_as_buffer(f"{batch_commit}:{file_path}")
     if batch_buffer is None:
         raise RuntimeError(
             f"Binary file metadata for {file_path} says {change_type}, "
             "but the batch content is missing"
         )
+    return batch_buffer
 
-    with batch_buffer:
-        write_buffer_to_working_tree_path(
-            full_path,
-            batch_buffer,
-            mode=str(file_meta.get("mode", "100644")),
+
+def _write_binary_file_from_batch(
+    file_path: str,
+    file_meta: dict,
+    buffer: EditorBuffer | None,
+) -> None:
+    """Write one binary batch target into the working tree."""
+    repo_root = get_git_repository_root_path()
+    full_path = repo_root / file_path
+    change_type = file_meta.get("change_type", "modified")
+
+    if change_type == "deleted":
+        if os.path.lexists(full_path):
+            full_path.unlink()
+            print(_("✓ Deleted binary file: {file}").format(file=file_path), file=sys.stderr)
+        return
+
+    if buffer is None:
+        raise RuntimeError(
+            f"Binary file metadata for {file_path} says {change_type}, "
+            "but the batch content is missing"
         )
+
+    write_buffer_to_working_tree_path(
+        full_path,
+        buffer,
+        mode=str(file_meta.get("mode", "100644")),
+    )
 
     if change_type == "added":
         print(_("✓ Applied new binary file: {file}").format(file=file_path), file=sys.stderr)
@@ -121,6 +178,201 @@ def _write_text_file_from_batch(
     write_buffer_to_working_tree_path(full_path, buffer, mode=file_mode)
 
 
+def _close_apply_plans(plans) -> None:
+    for plan in plans:
+        plan.close()
+
+
+def _execute_apply_candidate(
+    *,
+    batch_name: str,
+    raw_selector: str,
+    ordinal: int,
+    files: dict,
+    selected_ids: set[int] | None,
+    selection_ids_to_apply: set[int] | None,
+) -> None:
+    """Recompute and apply one previewed apply candidate."""
+    if len(files) != 1:
+        exit_with_error(_("Candidate execution requires exactly one file."))
+    file_path, file_meta = next(iter(files.items()))
+    if file_meta.get("file_type") == "binary" or is_batch_submodule_pointer(file_meta):
+        exit_with_error(_("Candidate execution is only available for text batch entries."))
+
+    batch_source_commit = file_meta["batch_source_commit"]
+    batch_source_buffer = load_git_object_as_buffer(f"{batch_source_commit}:{file_path}")
+    if batch_source_buffer is None:
+        exit_with_error(_("Batch source content is missing for {file}.").format(file=file_path))
+
+    repo_root = get_git_repository_root_path()
+    full_path = repo_root / file_path
+    working_exists = os.path.lexists(full_path)
+    file_mode = mode_for_text_materialization(
+        str(file_meta.get("mode", "100644")),
+        selected_ids,
+        destination_exists=working_exists,
+    )
+    text_change_type = normalized_text_change_type(file_meta.get("change_type"))
+
+    with (
+        batch_source_buffer as batch_source_lines,
+        load_working_tree_file_as_buffer(file_path) as working_lines,
+    ):
+        with acquire_batch_ownership_for_display_ids_from_lines(
+            file_meta,
+            batch_source_lines,
+            selection_ids_to_apply,
+        ) as ownership:
+            try:
+                previews = build_apply_candidate_previews(
+                    batch_name=batch_name,
+                    file_path=file_path,
+                    source_lines=batch_source_lines,
+                    ownership=ownership,
+                    worktree_lines=working_lines,
+                    batch_source_commit=batch_source_commit,
+                    file_meta=file_meta,
+                    text_change_type=text_change_type,
+                    worktree_file_mode=file_mode,
+                    worktree_exists=working_exists,
+                    selected_ids=selected_ids,
+                    selection_ids=selection_ids_to_apply,
+                )
+            except MergeError as e:
+                exit_with_error(str(e))
+
+            if ordinal < 1 or ordinal > len(previews):
+                for preview in previews:
+                    preview.close()
+                exit_with_error(
+                    _("Batch '{batch}' has {count} apply candidates for {file}; candidate {ordinal} does not exist.").format(
+                        batch=batch_name,
+                        count=len(previews),
+                        file=file_path,
+                        ordinal=ordinal,
+                    )
+                )
+
+            preview = previews[ordinal - 1]
+            try:
+                state = load_candidate_preview_state(preview)
+                if (
+                    state is None
+                    or state.get("ordinal") != ordinal
+                    or state.get("candidate_id") != preview.candidate_id
+                    or state.get("target_fingerprints") != preview.target_fingerprints
+                    or state.get("target_result_fingerprints") != preview.target_result_fingerprints
+                ):
+                    exit_with_error(
+                        _(
+                            "Candidate selector '{selector}' has not been previewed for {file}.\n"
+                            "No changes applied.\n\n"
+                            "Preview it first with:\n"
+                            "  git-stage-batch show --from {selector} --file {file}"
+                        ).format(selector=raw_selector, file=file_path)
+                    )
+
+                target = preview.targets[0]
+                effective_change_type = selected_text_target_change_type(
+                    text_change_type,
+                    selected_ids,
+                    target.after_buffer,
+                )
+                print(
+                    _("Applying apply candidate {ordinal} of {count} for batch '{batch}':").format(
+                        ordinal=preview.ordinal,
+                        count=preview.count,
+                        batch=batch_name,
+                    ),
+                    file=sys.stderr,
+                )
+                print(f"  {file_path}: {target.summary}", file=sys.stderr)
+                operation_parts = ["apply", "--from", raw_selector, "--file", file_path]
+                with undo_checkpoint(" ".join(operation_parts), worktree_paths=[file_path]):
+                    snapshot_file_if_untracked(file_path)
+                    _write_text_file_from_batch(
+                        file_path,
+                        target.after_buffer,
+                        file_mode,
+                        effective_change_type,
+                    )
+                clear_candidate_preview_state_for_file(
+                    batch_name=batch_name,
+                    file_path=file_path,
+                )
+                print(
+                    _("✓ Applied candidate {ordinal} of {count} from batch '{batch}' to working tree").format(
+                        ordinal=preview.ordinal,
+                        count=preview.count,
+                        batch=batch_name,
+                    ),
+                    file=sys.stderr,
+                )
+            finally:
+                for candidate in previews:
+                    candidate.close()
+
+
+def _apply_candidate_count_for_file(
+    *,
+    batch_name: str,
+    file_path: str,
+    file_meta: dict,
+    selection_ids_to_apply: set[int] | None,
+) -> _ApplyCandidateCount:
+    if file_meta.get("file_type") == "binary" or is_batch_submodule_pointer(file_meta):
+        return _ApplyCandidateCount()
+    batch_source_commit = file_meta.get("batch_source_commit")
+    if not batch_source_commit:
+        return _ApplyCandidateCount()
+    batch_source_buffer = load_git_object_as_buffer(f"{batch_source_commit}:{file_path}")
+    if batch_source_buffer is None:
+        return _ApplyCandidateCount()
+    repo_root = get_git_repository_root_path()
+    full_path = repo_root / file_path
+    working_exists = os.path.lexists(full_path)
+    file_mode = mode_for_text_materialization(
+        str(file_meta.get("mode", "100644")),
+        selection_ids_to_apply,
+        destination_exists=working_exists,
+    )
+    text_change_type = normalized_text_change_type(file_meta.get("change_type"))
+    try:
+        with (
+            batch_source_buffer as batch_source_lines,
+            load_working_tree_file_as_buffer(file_path) as working_lines,
+        ):
+            with acquire_batch_ownership_for_display_ids_from_lines(
+                file_meta,
+                batch_source_lines,
+                selection_ids_to_apply,
+            ) as ownership:
+                previews = build_apply_candidate_previews(
+                    batch_name=batch_name,
+                    file_path=file_path,
+                    source_lines=batch_source_lines,
+                    ownership=ownership,
+                    worktree_lines=working_lines,
+                    batch_source_commit=batch_source_commit,
+                    file_meta=file_meta,
+                    text_change_type=text_change_type,
+                    worktree_file_mode=file_mode,
+                    worktree_exists=working_exists,
+                    selected_ids=selection_ids_to_apply,
+                    selection_ids=selection_ids_to_apply,
+                )
+                count = len(previews)
+                for preview in previews:
+                    preview.close()
+                return _ApplyCandidateCount(count=count)
+    except CandidateEnumerationLimitError as e:
+        return _ApplyCandidateCount(too_many=True, error=str(e))
+    except MergeError:
+        return _ApplyCandidateCount()
+    except Exception as e:
+        return _ApplyCandidateCount(error=str(e))
+
+
 def command_apply_from_batch(
     batch_name: str,
     line_ids: Optional[str] = None,
@@ -137,6 +389,25 @@ def command_apply_from_batch(
         patterns: Optional gitignore-style file patterns to filter batch files.
     """
     require_git_repository()
+    raw_selector = batch_name
+    selector = parse_batch_source_selector(batch_name)
+    require_candidate_operation(selector, "apply", raw_value=raw_selector, file=file)
+    if selector.candidate_operation == "apply" and selector.candidate_ordinal is None:
+        exit_with_error(
+            _(
+                "'{selector}' names the apply candidate preview set.\n"
+                "Use 'git-stage-batch show --from {selector}' to preview candidates, "
+                "or use '{batch}:apply:N' to apply a candidate."
+            ).format(selector=raw_selector, batch=selector.batch_name)
+        )
+    if selector.candidate_ordinal is not None and file is None:
+        exit_with_error(
+            _(
+                "Candidate selector '{selector}' requires --file in this implementation.\n"
+                "No changes applied."
+            ).format(selector=raw_selector)
+        )
+    batch_name = selector.batch_name
     scope_resolution = resolve_batch_source_action_scope(
         FileReviewAction.APPLY_FROM_BATCH,
         command_name="apply",
@@ -191,105 +462,212 @@ def command_apply_from_batch(
             selected_ids,
             FileReviewAction.APPLY_FROM_BATCH,
         )
-    operation_parts = ["apply", "--from", batch_name]
+    operation_parts = ["apply", "--from", raw_selector]
     if line_ids is not None:
         operation_parts.extend(["--line", line_ids])
     if file is not None:
         operation_parts.extend(["--file", file])
-    with undo_checkpoint(" ".join(operation_parts), worktree_paths=list(files)):
-        # Apply all files in batch
-        repo_root = get_git_repository_root_path()
-        failed_files = []
+    if selector.candidate_ordinal is not None:
+        _execute_apply_candidate(
+            batch_name=batch_name,
+            raw_selector=raw_selector,
+            ordinal=selector.candidate_ordinal,
+            files=files,
+            selected_ids=selected_ids,
+            selection_ids_to_apply=selection_ids_to_apply,
+        )
+        return
 
-        for file_path, file_meta in files.items():
-            try:
-                # Binary files are atomic units - handle separately without ownership/merge logic
-                if file_meta.get("file_type") == "binary":
-                    snapshot_file_if_untracked(file_path)
-                    _apply_binary_file_from_batch(batch_name, file_path, file_meta)
-                    continue
-                if is_batch_submodule_pointer(file_meta):
-                    apply_submodule_pointer_from_batch(file_path, file_meta)
-                    continue
+    repo_root = get_git_repository_root_path()
+    failed_files = []
+    candidate_counts: dict[str, _ApplyCandidateCount] = {}
+    apply_plans = []
 
-                # Snapshot file before modifying
-                snapshot_file_if_untracked(file_path)
+    for file_path, file_meta in files.items():
+        try:
+            # Binary files are atomic units - handle separately without ownership/merge logic
+            if file_meta.get("file_type") == "binary":
+                batch_buffer = _read_binary_file_from_batch(batch_name, file_path, file_meta)
+                apply_plans.append(_ApplyBinaryPlan(file_path, file_meta, batch_buffer))
+                continue
+            if is_batch_submodule_pointer(file_meta):
+                apply_plans.append(_ApplySubmodulePlan(file_path, file_meta))
+                continue
 
-                text_change_type = normalized_text_change_type(file_meta.get("change_type"))
+            text_change_type = normalized_text_change_type(file_meta.get("change_type"))
 
-                full_path = repo_root / file_path
-                working_exists = os.path.lexists(full_path)
+            full_path = repo_root / file_path
+            working_exists = os.path.lexists(full_path)
 
-                file_mode = mode_for_text_materialization(
-                    str(file_meta.get("mode", "100644")),
-                    selected_ids,
-                    destination_exists=working_exists,
+            file_mode = mode_for_text_materialization(
+                str(file_meta.get("mode", "100644")),
+                selected_ids,
+                destination_exists=working_exists,
+            )
+            if selected_ids is None and text_change_type == TextFileChangeType.DELETED:
+                apply_plans.append(
+                    _ApplyTextPlan(file_path, None, file_mode, text_change_type)
                 )
-                if selected_ids is None and text_change_type == TextFileChangeType.DELETED:
-                    _write_text_file_from_batch(file_path, None, file_mode, text_change_type)
-                    continue
+                continue
 
-                batch_source_commit = file_meta["batch_source_commit"]
-                batch_source_buffer = load_git_object_as_buffer(
-                    f"{batch_source_commit}:{file_path}"
-                )
-                if batch_source_buffer is None:
-                    failed_files.append(file_path)
-                    continue
+            batch_source_commit = file_meta["batch_source_commit"]
+            batch_source_buffer = load_git_object_as_buffer(
+                f"{batch_source_commit}:{file_path}"
+            )
+            if batch_source_buffer is None:
+                failed_files.append(file_path)
+                continue
 
-                with (
-                    batch_source_buffer as batch_source_lines,
-                    load_working_tree_file_as_buffer(file_path) as working_lines,
-                ):
-                    try:
-                        with acquire_batch_ownership_for_display_ids_from_lines(
-                            file_meta,
-                            batch_source_lines,
-                            selection_ids_to_apply,
-                        ) as ownership:
-                            if ownership.is_empty():
-                                if selected_ids is None and text_change_type == TextFileChangeType.ADDED:
-                                    merged_buffer = EditorBuffer.from_bytes(b"")
-                                else:
-                                    continue
+            with (
+                batch_source_buffer as batch_source_lines,
+                load_working_tree_file_as_buffer(file_path) as working_lines,
+            ):
+                try:
+                    with acquire_batch_ownership_for_display_ids_from_lines(
+                        file_meta,
+                        batch_source_lines,
+                        selection_ids_to_apply,
+                    ) as ownership:
+                        if ownership.is_empty():
+                            if selected_ids is None and text_change_type == TextFileChangeType.ADDED:
+                                merged_buffer = EditorBuffer.from_bytes(b"")
                             else:
-                                merged_buffer = merge_batch_from_line_sequences_as_buffer(
-                                    batch_source_lines,
-                                    ownership,
-                                    working_lines,
-                                )
-                    except AtomicUnitError as e:
-                        if rendered:
-                            translate_atomic_unit_error_to_gutter_ids(e, rendered, "apply", batch_name)
-                        exit_with_error(_("Failed to apply batch '{name}': {error}").format(
-                            name=batch_name,
-                            error=str(e)
-                        ))
+                                continue
+                        else:
+                            merged_buffer = merge_batch_from_line_sequences_as_buffer(
+                                batch_source_lines,
+                                ownership,
+                                working_lines,
+                            )
+                except AtomicUnitError as e:
+                    if rendered:
+                        translate_atomic_unit_error_to_gutter_ids(e, rendered, "apply", batch_name)
+                    _close_apply_plans(apply_plans)
+                    exit_with_error(_("Failed to apply batch '{name}': {error}").format(
+                        name=batch_name,
+                        error=str(e)
+                    ))
 
-                with merged_buffer:
-                    effective_change_type = selected_text_target_change_type(
-                        text_change_type,
-                        selected_ids,
-                        merged_buffer,
-                    )
-                    _write_text_file_from_batch(
-                        file_path,
-                        merged_buffer,
-                        file_mode,
-                        effective_change_type,
-                    )
+            effective_change_type = selected_text_target_change_type(
+                text_change_type,
+                selected_ids,
+                merged_buffer,
+            )
+            apply_plans.append(
+                _ApplyTextPlan(file_path, merged_buffer, file_mode, effective_change_type)
+            )
 
-            except MergeError:
-                # Merge conflict - batch created from different file version
-                failed_files.append(file_path)
-            except CommandError:
-                # Re-raise user errors (e.g., partial atomic selection)
-                raise
-            except Exception as e:
-                print(_("Error applying {file}: {error}").format(file=file_path, error=str(e)), file=sys.stderr)
-                failed_files.append(file_path)
+        except MergeError:
+            # Merge conflict - batch created from different file version
+            candidate_count = _apply_candidate_count_for_file(
+                batch_name=batch_name,
+                file_path=file_path,
+                file_meta=file_meta,
+                selection_ids_to_apply=selection_ids_to_apply,
+            )
+            if candidate_count.count or candidate_count.too_many or candidate_count.error:
+                candidate_counts[file_path] = candidate_count
+            failed_files.append(file_path)
+        except CommandError:
+            # Re-raise user errors (e.g., partial atomic selection)
+            _close_apply_plans(apply_plans)
+            raise
+        except Exception as e:
+            print(_("Error applying {file}: {error}").format(file=file_path, error=str(e)), file=sys.stderr)
+            failed_files.append(file_path)
 
     if failed_files:
+        _close_apply_plans(apply_plans)
+        candidate_limit_files = [
+            file_path
+            for file_path in failed_files
+            if candidate_counts.get(file_path, _ApplyCandidateCount()).too_many
+        ]
+        if len(candidate_limit_files) == 1:
+            file_path = candidate_limit_files[0]
+            exit_with_error(
+                _(
+                    "Cannot apply batch '{batch}': {file} has too many apply "
+                    "candidates to preview safely.\n"
+                    "No changes applied.\n\n"
+                    "Use --line with a narrower selection or split the batch "
+                    "before previewing candidates."
+                ).format(batch=batch_name, file=file_path)
+            )
+        if len(candidate_limit_files) > 1:
+            exit_with_error(
+                _(
+                    "Cannot apply batch '{batch}': multiple files have too many "
+                    "apply candidates to preview safely.\n"
+                    "No changes applied.\n\n"
+                    "Use --line with narrower selections or split the batch "
+                    "before previewing candidates."
+                ).format(batch=batch_name)
+            )
+
+        candidate_error_files = [
+            file_path
+            for file_path in failed_files
+            if (
+                candidate_counts.get(file_path, _ApplyCandidateCount()).error
+                and not candidate_counts.get(file_path, _ApplyCandidateCount()).too_many
+            )
+        ]
+        if len(candidate_error_files) == 1:
+            file_path = candidate_error_files[0]
+            error = candidate_counts[file_path].error
+            exit_with_error(
+                _(
+                    "Cannot enumerate apply candidates for {file}: {error}\n"
+                    "No changes applied."
+                ).format(file=file_path, error=error)
+            )
+        if len(candidate_error_files) > 1:
+            examples = "\n".join(
+                f"  {file_path}: {candidate_counts[file_path].error}"
+                for file_path in candidate_error_files[:3]
+            )
+            exit_with_error(
+                _(
+                    "Cannot enumerate apply candidates for multiple files.\n"
+                    "No changes applied.\n\n"
+                    "{examples}"
+                ).format(examples=examples)
+            )
+
+        ambiguous_files = [
+            file_path
+            for file_path in failed_files
+            if candidate_counts.get(file_path, _ApplyCandidateCount()).count
+        ]
+        if len(ambiguous_files) == 1:
+            file_path = ambiguous_files[0]
+            exit_with_error(
+                _(
+                    "Cannot apply batch '{batch}': {file} has {count} apply candidates.\n"
+                    "No changes applied.\n\n"
+                    "Preview candidates:\n"
+                    "  git-stage-batch show --from {batch}:apply --file {file}\n\n"
+                    "Apply a reviewed candidate:\n"
+                    "  git-stage-batch apply --from {batch}:apply:N --file {file}"
+                ).format(
+                    batch=batch_name,
+                    file=file_path,
+                    count=candidate_counts[file_path].count,
+                )
+            )
+        if len(ambiguous_files) > 1:
+            examples = "\n".join(
+                f"  git-stage-batch show --from {batch_name}:apply --file {file_path}"
+                for file_path in ambiguous_files[:3]
+            )
+            exit_with_error(
+                _(
+                    "Cannot apply batch '{batch}': multiple files need apply decisions.\n"
+                    "No changes applied.\n\n"
+                    "Resolve one file at a time:\n{examples}"
+                ).format(batch=batch_name, examples=examples)
+            )
         if len(failed_files) == 1:
             # Check if there are individually mergeable lines to suggest --lines
             file_path = failed_files[0]
@@ -320,6 +698,50 @@ def command_apply_from_batch(
                     files=', '.join(failed_files)
                 )
             )
+
+    try:
+        try:
+            with undo_checkpoint(" ".join(operation_parts), worktree_paths=list(files)):
+                for plan in apply_plans:
+                    snapshot_file_if_untracked(plan.file_path)
+                    if isinstance(plan, _ApplyTextPlan):
+                        _write_text_file_from_batch(
+                            plan.file_path,
+                            plan.buffer,
+                            plan.file_mode,
+                            plan.change_type,
+                        )
+                    elif isinstance(plan, _ApplyBinaryPlan):
+                        _write_binary_file_from_batch(
+                            plan.file_path,
+                            plan.file_meta,
+                            plan.buffer,
+                        )
+                    else:
+                        apply_submodule_pointer_from_batch(plan.file_path, plan.file_meta)
+        except CommandError:
+            raise
+        except Exception:
+            if len(files) == 1:
+                file_path = next(iter(files))
+                exit_with_error(
+                    _("Batch '{batch}' contains changes to {file} that are incompatible with the current working tree. "
+                      "Use 'git-stage-batch show --from {batch}' to review the batch.").format(
+                        batch=batch_name,
+                        file=file_path,
+                    )
+                )
+            exit_with_error(
+                _("Batch '{batch}' contains changes to one or more files that are incompatible with the current working tree. "
+                  "Use 'git-stage-batch show --from {batch}' to review the batch.").format(
+                    batch=batch_name,
+                )
+            )
+    finally:
+        _close_apply_plans(apply_plans)
+
+    for file_path in files:
+        finish_review_scoped_line_action(scope_resolution.review_state, file_path=file_path)
 
     if line_ids:
         print(_("✓ Applied selected lines from batch '{name}' to working tree").format(name=batch_name), file=sys.stderr)

--- a/src/git_stage_batch/commands/discard_from.py
+++ b/src/git_stage_batch/commands/discard_from.py
@@ -9,6 +9,7 @@ from typing import Optional
 
 from ..batch.merge import discard_batch_from_line_sequences_as_buffer
 from ..batch.metadata_validation import get_validated_baseline_commit, read_validated_batch_metadata
+from ..batch.source_selector import require_plain_batch_name
 from ..batch.selection import (
     acquire_batch_ownership_for_display_ids_from_lines,
     resolve_current_batch_binary_file_scope,
@@ -139,6 +140,7 @@ def command_discard_from_batch(
         patterns: Optional gitignore-style file patterns to filter batch files.
     """
     require_git_repository()
+    batch_name = require_plain_batch_name(batch_name, "discard")
     scope_resolution = resolve_batch_source_action_scope(
         FileReviewAction.DISCARD_FROM_BATCH,
         command_name="discard",

--- a/src/git_stage_batch/commands/drop.py
+++ b/src/git_stage_batch/commands/drop.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from ..batch import delete_batch
+from ..batch.source_selector import require_plain_batch_name
 import sys
 from ..data.undo import undo_checkpoint
 from ..i18n import _
@@ -12,6 +13,7 @@ from ..utils.git import require_git_repository
 def command_drop_batch(batch_name: str) -> None:
     """Delete a batch."""
     require_git_repository()
+    batch_name = require_plain_batch_name(batch_name, "drop")
     with undo_checkpoint(f"drop {batch_name}"):
         delete_batch(batch_name)
     print(_("✓ Deleted batch '{name}'").format(name=batch_name), file=sys.stderr)

--- a/src/git_stage_batch/commands/include_from.py
+++ b/src/git_stage_batch/commands/include_from.py
@@ -2,14 +2,26 @@
 
 from __future__ import annotations
 
+from contextlib import ExitStack
 import os
 import sys
+from dataclasses import dataclass
 from typing import Optional
 
 from ..batch.merge import merge_batch_from_line_sequences_as_buffer
 from ..batch.metadata_validation import read_validated_batch_metadata
+from ..batch.operation_candidates import (
+    CandidateEnumerationLimitError,
+    build_include_candidate_previews,
+    clear_candidate_preview_state_for_file,
+    load_candidate_preview_state,
+)
 from ..batch.query import get_batch_commit_sha
-from ..batch.replacement import build_replacement_batch_view_from_lines
+from ..batch.replacement import (
+    ReplacementPayload,
+    build_replacement_batch_view_from_lines,
+    coerce_replacement_payload,
+)
 from ..batch.selection import (
     acquire_batch_ownership_for_display_ids_from_lines,
     resolve_current_batch_binary_file_scope,
@@ -23,6 +35,10 @@ from ..batch.submodule_pointer import (
     refuse_batch_submodule_pointer_lines,
     stage_submodule_pointer_from_batch,
 )
+from ..batch.source_selector import (
+    parse_batch_source_selector,
+    require_candidate_operation,
+)
 from ..batch.validation import batch_exists
 from ..core.text_lifecycle import (
     TextFileChangeType,
@@ -32,6 +48,7 @@ from ..core.text_lifecycle import (
 )
 from ..data.file_review_state import (
     FileReviewAction,
+    finish_review_scoped_line_action,
     resolve_batch_source_action_scope,
 )
 from ..data.hunk_tracking import (
@@ -61,6 +78,55 @@ from ..utils.git import (
     git_update_index,
     require_git_repository,
 )
+
+
+@dataclass
+class _IncludeTextPlan:
+    file_path: str
+    index_buffer: EditorBuffer | None
+    working_buffer: EditorBuffer | None
+    index_file_mode: str | None
+    working_file_mode: str | None
+    index_change_type: str
+    working_change_type: str
+
+    def close(self) -> None:
+        if self.index_buffer is not None:
+            self.index_buffer.close()
+        if self.working_buffer is not None and self.working_buffer is not self.index_buffer:
+            self.working_buffer.close()
+
+
+@dataclass
+class _IncludeBinaryPlan:
+    file_path: str
+    file_meta: dict
+    buffer: EditorBuffer | None
+
+    def close(self) -> None:
+        if self.buffer is not None:
+            self.buffer.close()
+
+
+@dataclass(frozen=True)
+class _IncludeSubmodulePlan:
+    file_path: str
+    file_meta: dict
+
+    def close(self) -> None:
+        return None
+
+
+def _close_include_plans(plans) -> None:
+    for plan in plans:
+        plan.close()
+
+
+@dataclass(frozen=True)
+class _IncludeCandidateCount:
+    count: int = 0
+    too_many: bool = False
+    error: str | None = None
 
 
 def _read_binary_file_from_batch(
@@ -150,6 +216,269 @@ def _write_text_file_from_batch(
     write_buffer_to_working_tree_path(full_path, buffer, mode=file_mode)
 
 
+def _execute_include_candidate(
+    *,
+    batch_name: str,
+    raw_selector: str,
+    ordinal: int,
+    files: dict,
+    selected_ids: set[int] | None,
+    selection_ids_to_include: set[int] | None,
+    replacement_payload: ReplacementPayload | None,
+) -> None:
+    """Recompute and include one previewed include candidate."""
+    if len(files) != 1:
+        exit_with_error(_("Candidate execution requires exactly one file."))
+    file_path, file_meta = next(iter(files.items()))
+    if file_meta.get("file_type") == "binary" or is_batch_submodule_pointer(file_meta):
+        exit_with_error(_("Candidate execution is only available for text batch entries."))
+
+    batch_source_commit = file_meta["batch_source_commit"]
+    batch_source_buffer = load_git_object_as_buffer(f"{batch_source_commit}:{file_path}")
+    if batch_source_buffer is None:
+        exit_with_error(_("Batch source content is missing for {file}.").format(file=file_path))
+
+    repo_root = get_git_repository_root_path()
+    full_path = repo_root / file_path
+    working_exists = os.path.lexists(full_path)
+    text_change_type = normalized_text_change_type(file_meta.get("change_type"))
+    batch_file_mode = str(file_meta.get("mode", "100644"))
+    index_buffer = load_git_object_as_buffer(f":{file_path}")
+    index_exists = index_buffer is not None
+    if index_buffer is None:
+        index_buffer = EditorBuffer.from_bytes(b"")
+    index_file_mode = mode_for_text_materialization(
+        batch_file_mode,
+        selected_ids,
+        destination_exists=index_exists,
+    )
+    working_file_mode = mode_for_text_materialization(
+        batch_file_mode,
+        selected_ids,
+        destination_exists=working_exists,
+    )
+
+    with (
+        batch_source_buffer as batch_source_lines,
+        index_buffer as index_lines,
+        load_working_tree_file_as_buffer(file_path) as working_lines,
+    ):
+        with acquire_batch_ownership_for_display_ids_from_lines(
+            file_meta,
+            batch_source_lines,
+            selection_ids_to_include,
+        ) as ownership:
+            with ExitStack() as stack:
+                source_for_candidates = batch_source_lines
+                candidate_ownership = ownership
+                if replacement_payload is not None:
+                    try:
+                        replacement_view = build_replacement_batch_view_from_lines(
+                            batch_source_lines,
+                            ownership,
+                            replacement_payload,
+                        )
+                    except ValueError as e:
+                        exit_with_error(str(e))
+                    replacement_view = stack.enter_context(replacement_view)
+                    source_for_candidates = replacement_view.source_buffer
+                    candidate_ownership = replacement_view.ownership
+                try:
+                    previews = build_include_candidate_previews(
+                        batch_name=batch_name,
+                        file_path=file_path,
+                        source_lines=source_for_candidates,
+                        ownership=candidate_ownership,
+                        index_lines=index_lines,
+                        worktree_lines=working_lines,
+                        batch_source_commit=batch_source_commit,
+                        file_meta=file_meta,
+                        text_change_type=text_change_type,
+                        index_file_mode=index_file_mode,
+                        worktree_file_mode=working_file_mode,
+                        index_exists=index_exists,
+                        worktree_exists=working_exists,
+                        selected_ids=selected_ids,
+                        selection_ids=selection_ids_to_include,
+                        replacement_payload=replacement_payload,
+                    )
+                except (MergeError, ValueError) as e:
+                    exit_with_error(str(e))
+
+            if ordinal < 1 or ordinal > len(previews):
+                for preview in previews:
+                    preview.close()
+                exit_with_error(
+                    _("Batch '{batch}' has {count} include candidates for {file}; candidate {ordinal} does not exist.").format(
+                        batch=batch_name,
+                        count=len(previews),
+                        file=file_path,
+                        ordinal=ordinal,
+                    )
+                )
+
+            preview = previews[ordinal - 1]
+            try:
+                state = load_candidate_preview_state(preview)
+                if (
+                    state is None
+                    or state.get("ordinal") != ordinal
+                    or state.get("candidate_id") != preview.candidate_id
+                    or state.get("target_fingerprints") != preview.target_fingerprints
+                    or state.get("target_result_fingerprints") != preview.target_result_fingerprints
+                ):
+                    exit_with_error(
+                        _(
+                            "Candidate selector '{selector}' has not been previewed for {file}.\n"
+                            "No changes applied.\n\n"
+                            "Preview it first with:\n"
+                            "  git-stage-batch show --from {selector} --file {file}"
+                        ).format(selector=raw_selector, file=file_path)
+                    )
+
+                index_target = next(target for target in preview.targets if target.target == "index")
+                worktree_target = next(target for target in preview.targets if target.target == "worktree")
+                index_change_type = selected_text_target_change_type(
+                    text_change_type,
+                    selected_ids,
+                    index_target.after_buffer,
+                )
+                working_change_type = selected_text_target_change_type(
+                    text_change_type,
+                    selected_ids,
+                    worktree_target.after_buffer,
+                )
+                print(
+                    _("Including candidate {ordinal} of {count} for batch '{batch}':").format(
+                        ordinal=preview.ordinal,
+                        count=preview.count,
+                        batch=batch_name,
+                    ),
+                    file=sys.stderr,
+                )
+                print(f"  {file_path}:", file=sys.stderr)
+                print(f"    index: {index_target.summary}", file=sys.stderr)
+                print(f"    working tree: {worktree_target.summary}", file=sys.stderr)
+                operation_parts = ["include", "--from", raw_selector, "--file", file_path]
+                with undo_checkpoint(" ".join(operation_parts), worktree_paths=[file_path]):
+                    snapshot_file_if_untracked(file_path)
+                    _stage_text_file_from_batch(
+                        file_path,
+                        index_target.after_buffer,
+                        index_file_mode,
+                        index_change_type,
+                    )
+                    _write_text_file_from_batch(
+                        file_path,
+                        worktree_target.after_buffer,
+                        working_file_mode,
+                        working_change_type,
+                    )
+                clear_candidate_preview_state_for_file(
+                    batch_name=batch_name,
+                    file_path=file_path,
+                )
+                print(
+                    _("✓ Included candidate {ordinal} of {count} from batch '{batch}'").format(
+                        ordinal=preview.ordinal,
+                        count=preview.count,
+                        batch=batch_name,
+                    ),
+                    file=sys.stderr,
+                )
+            finally:
+                for candidate in previews:
+                    candidate.close()
+
+
+def _include_candidate_count_for_file(
+    *,
+    batch_name: str,
+    file_path: str,
+    file_meta: dict,
+    selection_ids_to_include: set[int] | None,
+    replacement_payload: ReplacementPayload | None,
+) -> _IncludeCandidateCount:
+    if file_meta.get("file_type") == "binary" or is_batch_submodule_pointer(file_meta):
+        return _IncludeCandidateCount()
+    batch_source_commit = file_meta.get("batch_source_commit")
+    if not batch_source_commit:
+        return _IncludeCandidateCount()
+    batch_source_buffer = load_git_object_as_buffer(f"{batch_source_commit}:{file_path}")
+    if batch_source_buffer is None:
+        return _IncludeCandidateCount()
+    index_buffer = load_git_object_as_buffer(f":{file_path}")
+    index_exists = index_buffer is not None
+    if index_buffer is None:
+        index_buffer = EditorBuffer.from_bytes(b"")
+    repo_root = get_git_repository_root_path()
+    full_path = repo_root / file_path
+    working_exists = os.path.lexists(full_path)
+    text_change_type = normalized_text_change_type(file_meta.get("change_type"))
+    batch_file_mode = str(file_meta.get("mode", "100644"))
+    index_file_mode = mode_for_text_materialization(
+        batch_file_mode,
+        selection_ids_to_include,
+        destination_exists=index_exists,
+    )
+    working_file_mode = mode_for_text_materialization(
+        batch_file_mode,
+        selection_ids_to_include,
+        destination_exists=working_exists,
+    )
+    try:
+        with (
+            batch_source_buffer as batch_source_lines,
+            index_buffer as index_lines,
+            load_working_tree_file_as_buffer(file_path) as working_lines,
+        ):
+            with acquire_batch_ownership_for_display_ids_from_lines(
+                file_meta,
+                batch_source_lines,
+                selection_ids_to_include,
+            ) as ownership:
+                with ExitStack() as stack:
+                    source_for_candidates = batch_source_lines
+                    candidate_ownership = ownership
+                    if replacement_payload is not None:
+                        replacement_view = build_replacement_batch_view_from_lines(
+                            batch_source_lines,
+                            ownership,
+                            replacement_payload,
+                        )
+                        replacement_view = stack.enter_context(replacement_view)
+                        source_for_candidates = replacement_view.source_buffer
+                        candidate_ownership = replacement_view.ownership
+                    previews = build_include_candidate_previews(
+                        batch_name=batch_name,
+                        file_path=file_path,
+                        source_lines=source_for_candidates,
+                        ownership=candidate_ownership,
+                        index_lines=index_lines,
+                        worktree_lines=working_lines,
+                        batch_source_commit=batch_source_commit,
+                        file_meta=file_meta,
+                        text_change_type=text_change_type,
+                        index_file_mode=index_file_mode,
+                        worktree_file_mode=working_file_mode,
+                        index_exists=index_exists,
+                        worktree_exists=working_exists,
+                        selected_ids=selection_ids_to_include,
+                        selection_ids=selection_ids_to_include,
+                        replacement_payload=replacement_payload,
+                    )
+                count = len(previews)
+                for preview in previews:
+                    preview.close()
+                return _IncludeCandidateCount(count=count)
+    except CandidateEnumerationLimitError as e:
+        return _IncludeCandidateCount(too_many=True, error=str(e))
+    except MergeError:
+        return _IncludeCandidateCount()
+    except Exception as e:
+        return _IncludeCandidateCount(error=str(e))
+
+
 def _write_binary_file_from_batch(
     file_path: str,
     file_meta: dict,
@@ -190,7 +519,7 @@ def command_include_from_batch(
     line_ids: Optional[str] = None,
     file: Optional[str] = None,
     patterns: Optional[list[str]] = None,
-    replacement_text: Optional[str] = None,
+    replacement_text: Optional[str | ReplacementPayload] = None,
 ) -> None:
     """Stage batch changes to index and working tree using structural merge.
 
@@ -203,6 +532,25 @@ def command_include_from_batch(
         replacement_text: Optional replacement text for selected batch lines.
     """
     require_git_repository()
+    raw_selector = batch_name
+    selector = parse_batch_source_selector(batch_name)
+    require_candidate_operation(selector, "include", raw_value=raw_selector, file=file)
+    if selector.candidate_operation == "include" and selector.candidate_ordinal is None:
+        exit_with_error(
+            _(
+                "'{selector}' names the include candidate preview set.\n"
+                "Use 'git-stage-batch show --from {selector}' to preview candidates, "
+                "or use '{batch}:include:N' to include a candidate."
+            ).format(selector=raw_selector, batch=selector.batch_name)
+        )
+    if selector.candidate_ordinal is not None and file is None:
+        exit_with_error(
+            _(
+                "Candidate selector '{selector}' requires --file in this implementation.\n"
+                "No changes applied."
+            ).format(selector=raw_selector)
+        )
+    batch_name = selector.batch_name
     scope_resolution = resolve_batch_source_action_scope(
         FileReviewAction.INCLUDE_FROM_BATCH,
         command_name="include",
@@ -240,7 +588,13 @@ def command_include_from_batch(
     selected_ids = require_single_file_context_for_line_selection(
         batch_name, files, line_ids, "include"
     )
-    if replacement_text is not None and not selected_ids:
+    replacement_payload = (
+        coerce_replacement_payload(replacement_text)
+        if replacement_text is not None
+        else None
+    )
+
+    if replacement_payload is not None and not selected_ids:
         exit_with_error(_("`include --from --as` requires `--line`."))
 
     if selected_ids:
@@ -254,7 +608,7 @@ def command_include_from_batch(
     selection_ids_to_include = selected_ids
     rendered = None  # Store for error translation
     if selected_ids:
-        if replacement_text is not None:
+        if replacement_payload is not None:
             _require_contiguous_display_selection(selected_ids)
         file_path_for_render = list(files.keys())[0]  # Single file context enforced above
         selection_ids_to_include, rendered = translate_batch_file_gutter_ids_to_selection_ids(
@@ -263,166 +617,287 @@ def command_include_from_batch(
             selected_ids,
             FileReviewAction.INCLUDE_FROM_BATCH,
         )
-    operation_parts = ["include", "--from", batch_name]
+    operation_parts = ["include", "--from", raw_selector]
     if line_ids is not None:
         operation_parts.extend(["--line", line_ids])
     if file is not None:
         operation_parts.extend(["--file", file])
-    if replacement_text is not None:
-        operation_parts.extend(["--as", replacement_text])
-    with undo_checkpoint(" ".join(operation_parts), worktree_paths=list(files)):
-        # Apply all files in batch
-        repo_root = get_git_repository_root_path()
-        failed_files = []
+    if replacement_payload is not None:
+        operation_parts.extend(["--as", replacement_payload.display_text or "<stdin>"])
+    if selector.candidate_ordinal is not None:
+        _execute_include_candidate(
+            batch_name=batch_name,
+            raw_selector=raw_selector,
+            ordinal=selector.candidate_ordinal,
+            files=files,
+            selected_ids=selected_ids,
+            selection_ids_to_include=selection_ids_to_include,
+            replacement_payload=replacement_payload,
+        )
+        return
 
-        for file_path, file_meta in files.items():
-            try:
-                if file_meta.get("file_type") == "binary":
-                    batch_buffer = _read_binary_file_from_batch(batch_name, file_path, file_meta)
-                    try:
-                        snapshot_file_if_untracked(file_path)
-                        _stage_binary_file_from_batch(file_path, file_meta, batch_buffer)
-                        _write_binary_file_from_batch(file_path, file_meta, batch_buffer)
-                    finally:
-                        if batch_buffer is not None:
-                            batch_buffer.close()
-                    continue
-                if is_batch_submodule_pointer(file_meta):
-                    stage_submodule_pointer_from_batch(file_path, file_meta)
-                    continue
+    repo_root = get_git_repository_root_path()
+    failed_files = []
+    candidate_counts: dict[str, _IncludeCandidateCount] = {}
+    include_plans = []
 
-                text_change_type = normalized_text_change_type(file_meta.get("change_type"))
+    for file_path, file_meta in files.items():
+        merged_index_buffer = None
+        merged_working_buffer = None
+        try:
+            if file_meta.get("file_type") == "binary":
+                batch_buffer = _read_binary_file_from_batch(batch_name, file_path, file_meta)
+                include_plans.append(_IncludeBinaryPlan(file_path, file_meta, batch_buffer))
+                continue
+            if is_batch_submodule_pointer(file_meta):
+                include_plans.append(_IncludeSubmodulePlan(file_path, file_meta))
+                continue
 
-                index_buffer = load_git_object_as_buffer(f":{file_path}")
-                index_exists = index_buffer is not None
-                if index_buffer is None:
-                    index_buffer = EditorBuffer.from_bytes(b"")
+            text_change_type = normalized_text_change_type(file_meta.get("change_type"))
 
-                full_path = repo_root / file_path
-                working_exists = os.path.lexists(full_path)
+            index_buffer = load_git_object_as_buffer(f":{file_path}")
+            index_exists = index_buffer is not None
+            if index_buffer is None:
+                index_buffer = EditorBuffer.from_bytes(b"")
 
-                batch_file_mode = str(file_meta.get("mode", "100644"))
-                index_file_mode = mode_for_text_materialization(
-                    batch_file_mode,
-                    selected_ids,
-                    destination_exists=index_exists,
+            full_path = repo_root / file_path
+            working_exists = os.path.lexists(full_path)
+
+            batch_file_mode = str(file_meta.get("mode", "100644"))
+            index_file_mode = mode_for_text_materialization(
+                batch_file_mode,
+                selected_ids,
+                destination_exists=index_exists,
+            )
+            working_file_mode = mode_for_text_materialization(
+                batch_file_mode,
+                selected_ids,
+                destination_exists=working_exists,
+            )
+            if selected_ids is None and text_change_type == TextFileChangeType.DELETED:
+                index_buffer.close()
+                include_plans.append(
+                    _IncludeTextPlan(
+                        file_path,
+                        None,
+                        None,
+                        index_file_mode,
+                        working_file_mode,
+                        text_change_type,
+                        text_change_type,
+                    )
                 )
-                working_file_mode = mode_for_text_materialization(
-                    batch_file_mode,
-                    selected_ids,
-                    destination_exists=working_exists,
-                )
-                if selected_ids is None and text_change_type == TextFileChangeType.DELETED:
-                    index_buffer.close()
-                    snapshot_file_if_untracked(file_path)
-                    _stage_text_file_from_batch(file_path, None, index_file_mode, text_change_type)
-                    _write_text_file_from_batch(file_path, None, working_file_mode, text_change_type)
-                    continue
+                continue
 
-                batch_source_commit = file_meta["batch_source_commit"]
-                batch_source_buffer = load_git_object_as_buffer(
-                    f"{batch_source_commit}:{file_path}"
-                )
-                if batch_source_buffer is None:
-                    index_buffer.close()
-                    failed_files.append(file_path)
-                    continue
+            batch_source_commit = file_meta["batch_source_commit"]
+            batch_source_buffer = load_git_object_as_buffer(
+                f"{batch_source_commit}:{file_path}"
+            )
+            if batch_source_buffer is None:
+                index_buffer.close()
+                failed_files.append(file_path)
+                continue
 
-                with (
-                    batch_source_buffer as batch_source_lines,
-                    index_buffer as index_lines,
-                    load_working_tree_file_as_buffer(file_path) as working_lines,
-                ):
-                    try:
-                        with acquire_batch_ownership_for_display_ids_from_lines(
-                            file_meta,
-                            batch_source_lines,
-                            selection_ids_to_include,
-                        ) as ownership:
-                            if ownership.is_empty():
-                                if selected_ids is None and text_change_type == TextFileChangeType.ADDED:
-                                    merged_index_buffer = EditorBuffer.from_bytes(b"")
-                                    merged_working_buffer = EditorBuffer.from_bytes(b"")
-                                else:
-                                    continue
-                            elif replacement_text is not None:
-                                try:
-                                    replacement_view = build_replacement_batch_view_from_lines(
-                                        batch_source_lines,
-                                        ownership,
-                                        replacement_text,
-                                    )
-                                except ValueError as e:
-                                    exit_with_error(str(e))
-
-                                with replacement_view:
-                                    ownership = replacement_view.ownership
-                                    merged_index_buffer = merge_batch_from_line_sequences_as_buffer(
-                                        replacement_view.source_buffer,
-                                        ownership,
-                                        index_lines,
-                                    )
-                                    merged_working_buffer = merge_batch_from_line_sequences_as_buffer(
-                                        replacement_view.source_buffer,
-                                        ownership,
-                                        working_lines,
-                                    )
+            with (
+                batch_source_buffer as batch_source_lines,
+                index_buffer as index_lines,
+                load_working_tree_file_as_buffer(file_path) as working_lines,
+            ):
+                try:
+                    with acquire_batch_ownership_for_display_ids_from_lines(
+                        file_meta,
+                        batch_source_lines,
+                        selection_ids_to_include,
+                    ) as ownership:
+                        if ownership.is_empty():
+                            if selected_ids is None and text_change_type == TextFileChangeType.ADDED:
+                                merged_index_buffer = EditorBuffer.from_bytes(b"")
+                                merged_working_buffer = EditorBuffer.from_bytes(b"")
                             else:
-                                merged_index_buffer = merge_batch_from_line_sequences_as_buffer(
+                                continue
+                        elif replacement_payload is not None:
+                            try:
+                                replacement_view = build_replacement_batch_view_from_lines(
                                     batch_source_lines,
+                                    ownership,
+                                    replacement_payload,
+                                )
+                            except ValueError as e:
+                                _close_include_plans(include_plans)
+                                exit_with_error(str(e))
+
+                            with replacement_view:
+                                ownership = replacement_view.ownership
+                                merged_index_buffer = merge_batch_from_line_sequences_as_buffer(
+                                    replacement_view.source_buffer,
                                     ownership,
                                     index_lines,
                                 )
                                 merged_working_buffer = merge_batch_from_line_sequences_as_buffer(
-                                    batch_source_lines,
+                                    replacement_view.source_buffer,
                                     ownership,
                                     working_lines,
                                 )
-                    except AtomicUnitError as e:
-                        if rendered:
-                            translate_atomic_unit_error_to_gutter_ids(e, rendered, "include from", batch_name)
-                        exit_with_error(_("Failed to include from batch '{name}': {error}").format(
-                            name=batch_name,
-                            error=str(e)
-                        ))
+                        else:
+                            merged_index_buffer = merge_batch_from_line_sequences_as_buffer(
+                                batch_source_lines,
+                                ownership,
+                                index_lines,
+                            )
+                            merged_working_buffer = merge_batch_from_line_sequences_as_buffer(
+                                batch_source_lines,
+                                ownership,
+                                working_lines,
+                            )
+                except AtomicUnitError as e:
+                    if rendered:
+                        translate_atomic_unit_error_to_gutter_ids(e, rendered, "include from", batch_name)
+                    _close_include_plans(include_plans)
+                    exit_with_error(_("Failed to include from batch '{name}': {error}").format(
+                        name=batch_name,
+                        error=str(e)
+                    ))
 
-                snapshot_file_if_untracked(file_path)
+            index_change_type = selected_text_target_change_type(
+                text_change_type,
+                selected_ids,
+                merged_index_buffer,
+            )
+            working_change_type = selected_text_target_change_type(
+                text_change_type,
+                selected_ids,
+                merged_working_buffer,
+            )
+            include_plans.append(
+                _IncludeTextPlan(
+                    file_path,
+                    merged_index_buffer,
+                    merged_working_buffer,
+                    index_file_mode,
+                    working_file_mode,
+                    index_change_type,
+                    working_change_type,
+                )
+            )
+            merged_index_buffer = None
+            merged_working_buffer = None
 
-                with merged_index_buffer, merged_working_buffer:
-                    index_change_type = selected_text_target_change_type(
-                        text_change_type,
-                        selected_ids,
-                        merged_index_buffer,
-                    )
-                    working_change_type = selected_text_target_change_type(
-                        text_change_type,
-                        selected_ids,
-                        merged_working_buffer,
-                    )
-                    _stage_text_file_from_batch(
-                        file_path,
-                        merged_index_buffer,
-                        index_file_mode,
-                        index_change_type,
-                    )
-                    _write_text_file_from_batch(
-                        file_path,
-                        merged_working_buffer,
-                        working_file_mode,
-                        working_change_type,
-                    )
-
-            except MergeError:
-                # Merge conflict - batch created from different file version
-                failed_files.append(file_path)
-            except CommandError:
-                # Re-raise user errors (e.g., partial atomic selection)
-                raise
-            except Exception as e:
-                print(_("Error staging {file}: {error}").format(file=file_path, error=str(e)), file=sys.stderr)
-                failed_files.append(file_path)
+        except MergeError:
+            if merged_index_buffer is not None:
+                merged_index_buffer.close()
+            if merged_working_buffer is not None:
+                merged_working_buffer.close()
+            # Merge conflict - batch created from different file version
+            candidate_count = _include_candidate_count_for_file(
+                batch_name=batch_name,
+                file_path=file_path,
+                file_meta=file_meta,
+                selection_ids_to_include=selection_ids_to_include,
+                replacement_payload=replacement_payload,
+            )
+            if candidate_count.count or candidate_count.too_many or candidate_count.error:
+                candidate_counts[file_path] = candidate_count
+            failed_files.append(file_path)
+        except CommandError:
+            # Re-raise user errors (e.g., partial atomic selection)
+            _close_include_plans(include_plans)
+            raise
+        except Exception as e:
+            print(_("Error staging {file}: {error}").format(file=file_path, error=str(e)), file=sys.stderr)
+            failed_files.append(file_path)
 
     if failed_files:
+        _close_include_plans(include_plans)
+        candidate_limit_files = [
+            file_path
+            for file_path in failed_files
+            if candidate_counts.get(file_path, _IncludeCandidateCount()).too_many
+        ]
+        if len(candidate_limit_files) == 1:
+            file_path = candidate_limit_files[0]
+            exit_with_error(
+                _(
+                    "Cannot include batch '{batch}': {file} has too many include "
+                    "candidates to preview safely.\n"
+                    "No changes applied.\n\n"
+                    "Use --line with a narrower selection or split the batch "
+                    "before previewing candidates."
+                ).format(batch=batch_name, file=file_path)
+            )
+        if len(candidate_limit_files) > 1:
+            exit_with_error(
+                _(
+                    "Cannot include batch '{batch}': multiple files have too many "
+                    "include candidates to preview safely.\n"
+                    "No changes applied.\n\n"
+                    "Use --line with narrower selections or split the batch "
+                    "before previewing candidates."
+                ).format(batch=batch_name)
+            )
+
+        candidate_error_files = [
+            file_path
+            for file_path in failed_files
+            if (
+                candidate_counts.get(file_path, _IncludeCandidateCount()).error
+                and not candidate_counts.get(file_path, _IncludeCandidateCount()).too_many
+            )
+        ]
+        if len(candidate_error_files) == 1:
+            file_path = candidate_error_files[0]
+            error = candidate_counts[file_path].error
+            exit_with_error(
+                _(
+                    "Cannot enumerate include candidates for {file}: {error}\n"
+                    "No changes applied."
+                ).format(file=file_path, error=error)
+            )
+        if len(candidate_error_files) > 1:
+            examples = "\n".join(
+                f"  {file_path}: {candidate_counts[file_path].error}"
+                for file_path in candidate_error_files[:3]
+            )
+            exit_with_error(
+                _(
+                    "Cannot enumerate include candidates for multiple files.\n"
+                    "No changes applied.\n\n"
+                    "{examples}"
+                ).format(examples=examples)
+            )
+
+        ambiguous_files = [
+            file_path
+            for file_path in failed_files
+            if candidate_counts.get(file_path, _IncludeCandidateCount()).count
+        ]
+        if len(ambiguous_files) == 1:
+            file_path = ambiguous_files[0]
+            exit_with_error(
+                _(
+                    "Cannot include batch '{batch}': {file} has {count} include candidates.\n"
+                    "No changes applied.\n\n"
+                    "Preview candidates:\n"
+                    "  git-stage-batch show --from {batch}:include --file {file}\n\n"
+                    "Include a reviewed candidate:\n"
+                    "  git-stage-batch include --from {batch}:include:N --file {file}"
+                ).format(
+                    batch=batch_name,
+                    file=file_path,
+                    count=candidate_counts[file_path].count,
+                )
+            )
+        if len(ambiguous_files) > 1:
+            examples = "\n".join(
+                f"  git-stage-batch show --from {batch_name}:include --file {file_path}"
+                for file_path in ambiguous_files[:3]
+            )
+            exit_with_error(
+                _(
+                    "Cannot include batch '{batch}': multiple files need include decisions.\n"
+                    "No changes applied.\n\n"
+                    "Resolve one file at a time:\n{examples}"
+                ).format(batch=batch_name, examples=examples)
+            )
         if len(failed_files) == 1:
             # Check if there are individually mergeable lines to suggest --lines
             file_path = failed_files[0]
@@ -454,7 +929,54 @@ def command_include_from_batch(
                 )
             )
 
-    if replacement_text is not None and line_ids:
+    try:
+        try:
+            with undo_checkpoint(" ".join(operation_parts), worktree_paths=list(files)):
+                for plan in include_plans:
+                    snapshot_file_if_untracked(plan.file_path)
+                    if isinstance(plan, _IncludeTextPlan):
+                        _stage_text_file_from_batch(
+                            plan.file_path,
+                            plan.index_buffer,
+                            plan.index_file_mode,
+                            plan.index_change_type,
+                        )
+                        _write_text_file_from_batch(
+                            plan.file_path,
+                            plan.working_buffer,
+                            plan.working_file_mode,
+                            plan.working_change_type,
+                        )
+                    elif isinstance(plan, _IncludeBinaryPlan):
+                        _stage_binary_file_from_batch(plan.file_path, plan.file_meta, plan.buffer)
+                        _write_binary_file_from_batch(plan.file_path, plan.file_meta, plan.buffer)
+                    else:
+                        stage_submodule_pointer_from_batch(plan.file_path, plan.file_meta)
+        except CommandError:
+            raise
+        except Exception:
+            if len(files) == 1:
+                file_path = next(iter(files))
+                exit_with_error(
+                    _("Batch '{batch}' contains changes to {file} that are incompatible with the current working tree. "
+                      "Use 'git-stage-batch show --from {batch}' to review the batch.").format(
+                        batch=batch_name,
+                        file=file_path,
+                    )
+                )
+            exit_with_error(
+                _("Batch '{batch}' contains changes to one or more files that are incompatible with the current working tree. "
+                  "Use 'git-stage-batch show --from {batch}' to review the batch.").format(
+                    batch=batch_name,
+                )
+            )
+    finally:
+        _close_include_plans(include_plans)
+
+    for file_path in files:
+        finish_review_scoped_line_action(scope_resolution.review_state, file_path=file_path)
+
+    if replacement_payload is not None and line_ids:
         print(
             _("✓ Staged selected lines as replacement from batch '{name}'").format(name=batch_name),
             file=sys.stderr,

--- a/src/git_stage_batch/commands/new.py
+++ b/src/git_stage_batch/commands/new.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from ..batch import create_batch
+from ..batch.source_selector import require_plain_batch_name
 import sys
 from ..data.undo import undo_checkpoint
 from ..i18n import _
@@ -12,6 +13,7 @@ from ..utils.git import require_git_repository
 def command_new_batch(batch_name: str, note: str = "") -> None:
     """Create a new batch."""
     require_git_repository()
+    batch_name = require_plain_batch_name(batch_name, "new")
     with undo_checkpoint(f"new {batch_name}"):
         create_batch(batch_name, note)
     print(_("✓ Created batch '{name}'").format(name=batch_name), file=sys.stderr)

--- a/src/git_stage_batch/commands/reset.py
+++ b/src/git_stage_batch/commands/reset.py
@@ -36,6 +36,7 @@ from ..batch.submodule_pointer import (
     refuse_batch_submodule_pointer_lines,
 )
 from ..batch.state_refs import sync_batch_state_refs
+from ..batch.source_selector import require_plain_batch_name
 from ..batch.validation import batch_exists, validate_batch_name
 from ..exceptions import MergeError, exit_with_error
 from ..i18n import _
@@ -86,6 +87,7 @@ def command_reset_from_batch(
     """
     require_git_repository()
     ensure_state_directory_exists()
+    batch_name = require_plain_batch_name(batch_name, "reset")
     validate_batch_name(batch_name)
     extra_action_parts = ()
     if to_batch is not None:

--- a/src/git_stage_batch/commands/show_from.py
+++ b/src/git_stage_batch/commands/show_from.py
@@ -2,16 +2,42 @@
 
 from __future__ import annotations
 
+import difflib
+import json
+import os
 import shlex
 import sys
+from contextlib import ExitStack
+from dataclasses import dataclass
 from typing import Optional
 
+from ..batch.merge import MergeError
 from ..batch.metadata_validation import read_validated_batch_metadata
+from ..batch.operation_candidates import (
+    OperationCandidatePreview,
+    build_apply_candidate_previews,
+    build_include_candidate_previews,
+    render_candidate_buffer_diff,
+    save_candidate_preview_state,
+)
+from ..batch.replacement import (
+    ReplacementPayload,
+    build_replacement_batch_view_from_lines,
+    coerce_replacement_payload,
+)
 from ..batch.selection import (
+    acquire_batch_ownership_for_display_ids_from_lines,
     resolve_batch_file_scope,
     require_single_file_context_for_line_selection,
+    translate_batch_file_gutter_ids_to_selection_ids,
 )
+from ..batch.source_selector import parse_batch_source_selector
+from ..batch.submodule_pointer import is_batch_submodule_pointer
 from ..batch.validation import batch_exists
+from ..core.text_lifecycle import (
+    mode_for_text_materialization,
+    normalized_text_change_type,
+)
 from ..data.hunk_tracking import (
     SelectedChangeKind,
     cache_binary_file_change,
@@ -24,6 +50,7 @@ from ..data.hunk_tracking import (
     render_batch_file_display,
 )
 from ..data.file_review_state import (
+    FileReviewAction,
     ReviewSource,
     clear_last_file_review_state,
     write_last_file_review_state,
@@ -42,10 +69,22 @@ from ..output.file_review_list import (
     make_gitlink_file_review_list_entry,
     print_file_review_list,
 )
-from ..exceptions import exit_with_error, BatchMetadataError
+from ..editor import (
+    EditorBuffer,
+    load_git_object_as_buffer,
+    load_working_tree_file_as_buffer,
+)
+from ..exceptions import exit_with_error, BatchMetadataError, CommandError
 from ..i18n import _
 from ..core.models import BinaryFileChange, GitlinkChange, LineLevelChange
-from ..utils.git import require_git_repository
+from ..utils.git import get_git_repository_root_path, require_git_repository
+from ..utils.paths import get_context_lines
+
+
+_CANDIDATE_OVERVIEW_CONTEXT_LINES = 1
+_CANDIDATE_OVERVIEW_MAX_LINES = 5
+_CANDIDATE_OVERVIEW_MAX_LINE_WIDTH = 64
+_CANDIDATE_OVERVIEW_MAX_CANDIDATES = 10
 
 
 def _batch_source_args(batch_name: str) -> str:
@@ -95,6 +134,684 @@ def _shown_pages_for_display_ids(review_model, display_ids: set[int]) -> tuple[i
     )
 
 
+def _require_contiguous_display_selection(selected_ids: set[int]) -> None:
+    if not selected_ids:
+        return
+    selected_range = list(range(min(selected_ids), max(selected_ids) + 1))
+    if sorted(selected_ids) != selected_range:
+        exit_with_error(_("Replacement selection must be one contiguous line range."))
+
+
+def _candidate_selector_text(
+    batch_name: str,
+    operation: str,
+    ordinal: int | None = None,
+) -> str:
+    if ordinal is None:
+        return f"{batch_name}:{operation}"
+    return f"{batch_name}:{operation}:{ordinal}"
+
+
+def _show_candidate_command(preview: OperationCandidatePreview, ordinal: int | None = None) -> str:
+    return "git-stage-batch show --from {selector} --file {file}".format(
+        selector=_candidate_selector_text(
+            preview.batch_name,
+            preview.operation,
+            ordinal,
+        ),
+        file=shlex.quote(preview.file_path),
+    )
+
+
+@dataclass(frozen=True)
+class _CandidateTargetSummary:
+    label: str
+    title: str
+    lines: tuple[str, ...]
+
+
+def _decode_overview_lines(buffer: EditorBuffer) -> list[str]:
+    text = buffer.to_bytes().decode("utf-8", errors="surrogateescape")
+    return text.splitlines()
+
+
+def _shorten_overview_text(text: str, max_width: int = _CANDIDATE_OVERVIEW_MAX_LINE_WIDTH) -> str:
+    compact = text.strip()
+    if len(compact) <= max_width:
+        return compact
+    if max_width <= 3:
+        return compact[:max_width]
+    return compact[: max_width - 3] + "..."
+
+
+def _summarize_overview_lines(lines: list[str]) -> str:
+    if not lines:
+        return _("nothing")
+    if len(lines) == 1:
+        text = _shorten_overview_text(lines[0], 36)
+        if text:
+            return f'"{text}"'
+        return _("an empty line")
+    return _("{count} lines").format(count=len(lines))
+
+
+def _first_changed_opcode(
+    before_lines: list[str],
+    after_lines: list[str],
+) -> tuple[str, int, int, int, int] | None:
+    matcher = difflib.SequenceMatcher(a=before_lines, b=after_lines, autojunk=False)
+    for tag, before_start, before_end, after_start, after_end in matcher.get_opcodes():
+        if tag != "equal":
+            return tag, before_start, before_end, after_start, after_end
+    return None
+
+
+def _nearby_context_summary(
+    before_lines: list[str],
+    before_start: int,
+    before_end: int,
+    changed_lines: list[str],
+) -> str:
+    changed_text = {line.strip() for line in changed_lines if line.strip()}
+    candidates = []
+    if before_start > 0:
+        candidates.append(before_lines[before_start - 1])
+    if before_end < len(before_lines):
+        candidates.append(before_lines[before_end])
+
+    for line in candidates:
+        text = _shorten_overview_text(line, 36)
+        if text and text not in changed_text:
+            return _(' near "{context}"').format(context=text)
+
+    for line in candidates:
+        text = _shorten_overview_text(line, 36)
+        if text:
+            return _(' near "{context}"').format(context=text)
+    return ""
+
+
+def _overview_action_title(
+    tag: str,
+    before_lines: list[str],
+    after_lines: list[str],
+    before_start: int,
+    before_end: int,
+    after_start: int,
+    after_end: int,
+) -> str:
+    removed = before_lines[before_start:before_end]
+    added = after_lines[after_start:after_end]
+    changed = removed or added
+    nearby = _nearby_context_summary(before_lines, before_start, before_end, changed)
+
+    if tag == "delete":
+        return _("Remove {text}{nearby}").format(
+            text=_summarize_overview_lines(removed),
+            nearby=nearby,
+        )
+    if tag == "insert":
+        return _("Add {text}{nearby}").format(
+            text=_summarize_overview_lines(added),
+            nearby=nearby,
+        )
+    return _("Replace {old} with {new}{nearby}").format(
+        old=_summarize_overview_lines(removed),
+        new=_summarize_overview_lines(added),
+        nearby=nearby,
+    )
+
+
+def _append_overview_line(
+    lines: list[str],
+    *,
+    line_number: int,
+    width: int,
+    marker: str,
+    text: str,
+) -> None:
+    lines.append(
+        f"{line_number:>{width}} {marker}{_shorten_overview_text(text)}"
+    )
+
+
+def _overview_snippet_lines(
+    before_lines: list[str],
+    after_lines: list[str],
+    before_start: int,
+    before_end: int,
+    after_start: int,
+    after_end: int,
+) -> tuple[str, ...]:
+    width = max(len(str(max(len(before_lines), len(after_lines), 1))), 1)
+    lines: list[str] = []
+
+    context_start = max(0, before_start - _CANDIDATE_OVERVIEW_CONTEXT_LINES)
+    context_end = min(len(before_lines), before_end + _CANDIDATE_OVERVIEW_CONTEXT_LINES)
+
+    for index in range(context_start, before_start):
+        _append_overview_line(
+            lines,
+            line_number=index + 1,
+            width=width,
+            marker=" ",
+            text=before_lines[index],
+        )
+
+    for index in range(before_start, before_end):
+        _append_overview_line(
+            lines,
+            line_number=index + 1,
+            width=width,
+            marker="-",
+            text=before_lines[index],
+        )
+
+    for index in range(after_start, after_end):
+        _append_overview_line(
+            lines,
+            line_number=index + 1,
+            width=width,
+            marker="+",
+            text=after_lines[index],
+        )
+
+    for index in range(before_end, context_end):
+        _append_overview_line(
+            lines,
+            line_number=index + 1,
+            width=width,
+            marker=" ",
+            text=before_lines[index],
+        )
+
+    if len(lines) > _CANDIDATE_OVERVIEW_MAX_LINES:
+        return tuple(lines[:_CANDIDATE_OVERVIEW_MAX_LINES] + ["..."])
+    return tuple(lines)
+
+
+def _summarize_candidate_target(target) -> _CandidateTargetSummary:
+    before_lines = _decode_overview_lines(target.before_buffer)
+    after_lines = _decode_overview_lines(target.after_buffer)
+    opcode = _first_changed_opcode(before_lines, after_lines)
+    label = _("Index") if target.target == "index" else _("Working tree")
+    if opcode is None:
+        return _CandidateTargetSummary(label=label, title=_("No text changes"), lines=())
+
+    tag, before_start, before_end, after_start, after_end = opcode
+    return _CandidateTargetSummary(
+        label=label,
+        title=_overview_action_title(
+            tag,
+            before_lines,
+            after_lines,
+            before_start,
+            before_end,
+            after_start,
+            after_end,
+        ),
+        lines=_overview_snippet_lines(
+            before_lines,
+            after_lines,
+            before_start,
+            before_end,
+            after_start,
+            after_end,
+        ),
+    )
+
+
+def _render_operation_candidate_overview(
+    previews: tuple[OperationCandidatePreview, ...],
+    *,
+    porcelain: bool,
+) -> tuple[OperationCandidatePreview, ...]:
+    first = previews[0]
+    candidate_summaries = [
+        [
+            _summarize_candidate_target(target)
+            for target in preview.targets
+        ]
+        for preview in previews
+    ]
+
+    if porcelain:
+        print(json.dumps({
+            "status": "candidates",
+            "changed": False,
+            "batch": first.batch_name,
+            "selector": {
+                "operation": first.operation,
+                "count": len(previews),
+            },
+            "scope": {
+                "file": first.file_path,
+            },
+            "candidates": [
+                {
+                    "ordinal": preview.ordinal,
+                    "selector": _candidate_selector_text(
+                        preview.batch_name,
+                        preview.operation,
+                        preview.ordinal,
+                    ),
+                    "commands": {
+                        "preview": (
+                            "git-stage-batch show --from {selector} --file {file}".format(
+                                selector=_candidate_selector_text(
+                                    preview.batch_name,
+                                    preview.operation,
+                                    preview.ordinal,
+                                ),
+                                file=shlex.quote(preview.file_path),
+                            )
+                        ),
+                        "execute": (
+                            "git-stage-batch {command} --from {selector} --file {file}".format(
+                                command=preview.operation,
+                                selector=_candidate_selector_text(
+                                    preview.batch_name,
+                                    preview.operation,
+                                    preview.ordinal,
+                                ),
+                                file=shlex.quote(preview.file_path),
+                            )
+                        ),
+                    },
+                    "targets": [
+                        {
+                            "target": target.target,
+                            "summary": summary.title,
+                            "context": list(summary.lines),
+                        }
+                        for target, summary in zip(preview.targets, summaries)
+                    ],
+                }
+                for preview, summaries in zip(previews, candidate_summaries)
+            ],
+        }, sort_keys=True))
+        return previews
+
+    operation = first.operation.capitalize()
+    print(
+        _("{operation} candidates for batch '{batch}' in {file}.").format(
+            operation=operation,
+            batch=first.batch_name,
+            file=first.file_path,
+        )
+    )
+    print(_("Candidates: {count}").format(count=len(previews)))
+    print(_("No changes applied."))
+    print()
+
+    shown_previews = previews[:_CANDIDATE_OVERVIEW_MAX_CANDIDATES]
+    shown_summaries = candidate_summaries[:_CANDIDATE_OVERVIEW_MAX_CANDIDATES]
+    for preview, summaries in zip(shown_previews, shown_summaries):
+        if len(summaries) == 1:
+            summary = summaries[0]
+            print(f"{preview.ordinal}. {summary.label}: {summary.title}")
+            for line in summary.lines:
+                print(f"   {line}")
+        else:
+            print(f"{preview.ordinal}.")
+            for summary in summaries:
+                print(f"   {summary.label}: {summary.title}")
+                for line in summary.lines:
+                    print(f"      {line}")
+        print(
+            "   show: git-stage-batch show --from {selector} --file {file}".format(
+                selector=_candidate_selector_text(
+                    preview.batch_name,
+                    preview.operation,
+                    preview.ordinal,
+                ),
+                file=shlex.quote(preview.file_path),
+            )
+        )
+        print(
+            "   {command}: git-stage-batch {command} --from {selector} --file {file}".format(
+                command=preview.operation,
+                selector=_candidate_selector_text(
+                    preview.batch_name,
+                    preview.operation,
+                    preview.ordinal,
+                ),
+                file=shlex.quote(preview.file_path),
+            )
+        )
+        print()
+
+    if len(previews) > len(shown_previews):
+        remaining = len(previews) - len(shown_previews)
+        print(
+            _("... {count} more candidates. Preview another candidate with {selector}:N.").format(
+                count=remaining,
+                selector=_candidate_selector_text(first.batch_name, first.operation),
+            )
+        )
+    return tuple(shown_previews)
+
+
+def _render_operation_candidate(
+    preview: OperationCandidatePreview,
+    *,
+    porcelain: bool,
+) -> None:
+    if porcelain:
+        print(json.dumps({
+            "status": "candidate",
+            "changed": False,
+            "batch": preview.batch_name,
+            "selector": {
+                "operation": preview.operation,
+                "ordinal": preview.ordinal,
+                "count": preview.count,
+                "id": preview.candidate_id,
+            },
+            "scope": {
+                "file": preview.file_path,
+            },
+            "targets": [
+                {
+                    "target": target.target,
+                    "file": target.file_path,
+                    "summary": target.summary,
+                    "resolution_ordinal": target.resolution_ordinal,
+                    "resolution_count": target.resolution_count,
+                }
+                for target in preview.targets
+            ],
+        }, sort_keys=True))
+        return
+
+    print(
+        _("{operation} candidate {ordinal} of {count} for batch '{batch}'.").format(
+            operation=preview.operation.capitalize(),
+            ordinal=preview.ordinal,
+            count=preview.count,
+            batch=preview.batch_name,
+        ),
+        file=sys.stderr,
+    )
+    print(_("No changes applied."), file=sys.stderr)
+    print("", file=sys.stderr)
+    print(preview.file_path, file=sys.stderr)
+    print(
+        _("Candidate {ordinal} of {count}").format(
+            ordinal=preview.ordinal,
+            count=preview.count,
+        ),
+        file=sys.stderr,
+    )
+
+    context_lines = get_context_lines()
+    for target in preview.targets:
+        if len(preview.targets) > 1:
+            print(
+                _("{target} result:").format(
+                    target="Index" if target.target == "index" else "Working-tree"
+                ),
+                file=sys.stderr,
+            )
+        if target.summary:
+            print(_("Plan: {summary}").format(summary=target.summary), file=sys.stderr)
+        if target.explanation:
+            print(_("Reason: {reason}").format(reason=target.explanation), file=sys.stderr)
+        diff_text = render_candidate_buffer_diff(
+            preview.file_path,
+            target.before_buffer,
+            target.after_buffer,
+            label_before=target.target,
+            label_after=f"{target.target}-candidate",
+            context_lines=context_lines,
+        )
+        if diff_text:
+            print(diff_text, end="" if diff_text.endswith("\n") else "\n")
+
+    print("", file=sys.stderr)
+    execute_command = (
+        "apply" if preview.operation == "apply" else "include"
+    )
+    action = _("Apply") if preview.operation == "apply" else _("Include")
+    print(
+        _("{action} this candidate:\n  git-stage-batch {command} --from {selector} --file {file}").format(
+            action=action,
+            command=execute_command,
+            selector=_candidate_selector_text(
+                preview.batch_name,
+                preview.operation,
+                preview.ordinal,
+            ),
+            file=shlex.quote(preview.file_path),
+        ),
+        file=sys.stderr,
+    )
+    print("", file=sys.stderr)
+    print(_("Review candidates:"), file=sys.stderr)
+    print(_("  overview: {command}").format(
+        command=_show_candidate_command(preview),
+    ), file=sys.stderr)
+    if preview.ordinal > 1:
+        print(_("  previous: {command}").format(
+            command=_show_candidate_command(preview, preview.ordinal - 1),
+        ), file=sys.stderr)
+    if preview.ordinal < preview.count:
+        print(_("  next: {command}").format(
+            command=_show_candidate_command(preview, preview.ordinal + 1),
+        ), file=sys.stderr)
+
+
+def _resolve_candidate_ordinal(
+    previews: tuple[OperationCandidatePreview, ...],
+    *,
+    explicit_ordinal: int,
+) -> OperationCandidatePreview:
+    if not previews:
+        raise CommandError(_("No candidates available."))
+    first = previews[0]
+    ordinal = explicit_ordinal
+
+    if ordinal > len(previews):
+        raise CommandError(
+            _("Batch '{batch}' has {count} {operation} candidates for {file}; candidate {ordinal} does not exist.").format(
+                batch=first.batch_name,
+                count=len(previews),
+                operation=first.operation,
+                file=first.file_path,
+                ordinal=ordinal,
+            )
+        )
+    if ordinal < 1:
+        raise CommandError(_("Candidate ordinal must be at least 1."))
+    return previews[ordinal - 1]
+
+
+def _preview_replacement_batch_view(
+    batch_name: str,
+    metadata: dict,
+    files: dict,
+    line_ids: str,
+    file_path: str,
+    selected_ids: set[int],
+    replacement_text: str | ReplacementPayload,
+) -> None:
+    file_meta = files[file_path]
+    if file_meta.get("file_type") == "binary":
+        exit_with_error(_("Cannot preview replacement text for binary files."))
+    if is_batch_submodule_pointer(file_meta):
+        exit_with_error(_("Cannot preview replacement text for submodule pointers."))
+
+    _require_contiguous_display_selection(selected_ids)
+    batch_source_commit = file_meta["batch_source_commit"]
+    batch_source_buffer = load_git_object_as_buffer(f"{batch_source_commit}:{file_path}")
+    if batch_source_buffer is None:
+        exit_with_error(_("Batch source content is missing for {file}.").format(file=file_path))
+
+    with batch_source_buffer as batch_source_lines:
+        selection_ids, _rendered = translate_batch_file_gutter_ids_to_selection_ids(
+            batch_name,
+            file_path,
+            selected_ids,
+            # Replacement preview is include-shaped because it previews include --from --as.
+            FileReviewAction.INCLUDE_FROM_BATCH,
+        )
+        with acquire_batch_ownership_for_display_ids_from_lines(
+            file_meta,
+            batch_source_lines,
+            selection_ids,
+        ) as ownership:
+            try:
+                replacement_view = build_replacement_batch_view_from_lines(
+                    batch_source_lines,
+                    ownership,
+                    coerce_replacement_payload(replacement_text),
+                )
+            except ValueError as e:
+                exit_with_error(str(e))
+            with replacement_view:
+                before = EditorBuffer.from_bytes(batch_source_buffer.to_bytes())
+                try:
+                    diff_text = render_candidate_buffer_diff(
+                        file_path,
+                        before,
+                        replacement_view.source_buffer,
+                        label_before="batch",
+                        label_after="replacement-preview",
+                        context_lines=get_context_lines(),
+                    )
+                    if diff_text:
+                        print(diff_text, end="" if diff_text.endswith("\n") else "\n")
+                finally:
+                    before.close()
+
+
+def _build_candidate_previews(
+    *,
+    selector,
+    metadata: dict,
+    files: dict,
+    file_path: str,
+    selected_ids: set[int] | None,
+    replacement_text: str | ReplacementPayload | None,
+) -> tuple[OperationCandidatePreview, ...]:
+    file_meta = files[file_path]
+    if file_meta.get("file_type") == "binary" or is_batch_submodule_pointer(file_meta):
+        exit_with_error(_("Candidate preview is only available for text batch entries."))
+
+    batch_source_commit = file_meta["batch_source_commit"]
+    batch_source_buffer = load_git_object_as_buffer(f"{batch_source_commit}:{file_path}")
+    if batch_source_buffer is None:
+        exit_with_error(_("Batch source content is missing for {file}.").format(file=file_path))
+
+    repo_root = get_git_repository_root_path()
+    full_path = repo_root / file_path
+    working_exists = os.path.lexists(full_path)
+    text_change_type = normalized_text_change_type(file_meta.get("change_type"))
+    batch_file_mode = str(file_meta.get("mode", "100644"))
+
+    with batch_source_buffer as batch_source_lines:
+        selection_ids_to_apply = selected_ids
+        if selected_ids:
+            action = (
+                FileReviewAction.APPLY_FROM_BATCH
+                if selector.candidate_operation == "apply"
+                else FileReviewAction.INCLUDE_FROM_BATCH
+            )
+            selection_ids_to_apply, _rendered = translate_batch_file_gutter_ids_to_selection_ids(
+                selector.batch_name,
+                file_path,
+                selected_ids,
+                action,
+            )
+
+        with acquire_batch_ownership_for_display_ids_from_lines(
+            file_meta,
+            batch_source_lines,
+            selection_ids_to_apply,
+        ) as ownership:
+            with ExitStack() as stack:
+                source_for_candidates = batch_source_lines
+                candidate_ownership = ownership
+                replacement_payload = None
+                if replacement_text is not None:
+                    if selector.candidate_operation == "apply":
+                        exit_with_error(_("Replacement preview is not valid for apply candidates."))
+                    if not selected_ids:
+                        exit_with_error(_("`show --from --as` requires `--line`."))
+                    _require_contiguous_display_selection(selected_ids)
+                    replacement_payload = coerce_replacement_payload(replacement_text)
+                    try:
+                        replacement_view = build_replacement_batch_view_from_lines(
+                            batch_source_lines,
+                            ownership,
+                            replacement_payload,
+                        )
+                    except ValueError as e:
+                        exit_with_error(str(e))
+                    replacement_view = stack.enter_context(replacement_view)
+                    source_for_candidates = replacement_view.source_buffer
+                    candidate_ownership = replacement_view.ownership
+
+                if selector.candidate_operation == "apply":
+                    worktree_file_mode = mode_for_text_materialization(
+                        batch_file_mode,
+                        selected_ids,
+                        destination_exists=working_exists,
+                    )
+                    with load_working_tree_file_as_buffer(file_path) as working_lines:
+                        return build_apply_candidate_previews(
+                            batch_name=selector.batch_name,
+                            file_path=file_path,
+                            source_lines=source_for_candidates,
+                            ownership=candidate_ownership,
+                            worktree_lines=working_lines,
+                            batch_source_commit=batch_source_commit,
+                            file_meta=file_meta,
+                            text_change_type=text_change_type,
+                            worktree_file_mode=worktree_file_mode,
+                            worktree_exists=working_exists,
+                            selected_ids=selected_ids,
+                            selection_ids=selection_ids_to_apply,
+                        )
+
+                index_buffer = load_git_object_as_buffer(f":{file_path}")
+                index_exists = index_buffer is not None
+                if index_buffer is None:
+                    index_buffer = EditorBuffer.from_bytes(b"")
+                index_file_mode = mode_for_text_materialization(
+                    batch_file_mode,
+                    selected_ids,
+                    destination_exists=index_exists,
+                )
+                worktree_file_mode = mode_for_text_materialization(
+                    batch_file_mode,
+                    selected_ids,
+                    destination_exists=working_exists,
+                )
+                with (
+                    index_buffer as index_lines,
+                    load_working_tree_file_as_buffer(file_path) as working_lines,
+                ):
+                    return build_include_candidate_previews(
+                        batch_name=selector.batch_name,
+                        file_path=file_path,
+                        source_lines=source_for_candidates,
+                        ownership=candidate_ownership,
+                        index_lines=index_lines,
+                        worktree_lines=working_lines,
+                        batch_source_commit=batch_source_commit,
+                        file_meta=file_meta,
+                        text_change_type=text_change_type,
+                        index_file_mode=index_file_mode,
+                        worktree_file_mode=worktree_file_mode,
+                        index_exists=index_exists,
+                        worktree_exists=working_exists,
+                        selected_ids=selected_ids,
+                        selection_ids=selection_ids_to_apply,
+                        replacement_payload=replacement_payload,
+                    )
+
+
 def command_show_from_batch(
     batch_name: str,
     line_ids: Optional[str] = None,
@@ -102,6 +819,8 @@ def command_show_from_batch(
     patterns: Optional[list[str]] = None,
     selectable: bool = True,
     page: str | None = None,
+    porcelain: bool = False,
+    replacement_text: str | ReplacementPayload | None = None,
 ) -> None:
     """Show changes from a batch.
 
@@ -115,6 +834,11 @@ def command_show_from_batch(
         page: Optional file-review page selection.
     """
     require_git_repository()
+    selector = parse_batch_source_selector(batch_name)
+    batch_name = selector.batch_name
+
+    if selector.candidate_operation is not None and page is not None:
+        exit_with_error(_("Candidate preview does not support --page."))
 
     # Check if batch exists
     if not batch_exists(batch_name):
@@ -135,6 +859,77 @@ def command_show_from_batch(
     selected_ids = require_single_file_context_for_line_selection(
         batch_name, files, line_ids, "show"
     )
+
+    if selector.candidate_operation is not None:
+        if patterns is not None or len(files) != 1:
+            exit_with_error(_("Candidate preview requires exactly one file."))
+        file_path = list(files.keys())[0]
+        try:
+            previews = _build_candidate_previews(
+                selector=selector,
+                metadata=metadata,
+                files=files,
+                file_path=file_path,
+                selected_ids=selected_ids,
+                replacement_text=replacement_text,
+            )
+        except ValueError as e:
+            exit_with_error(str(e))
+        except MergeError as e:
+            exit_with_error(str(e))
+
+        if not previews:
+            exit_with_error(
+                _("Batch '{batch}' has no {operation} candidates for {file}.").format(
+                    batch=batch_name,
+                    operation=selector.candidate_operation,
+                    file=file_path,
+                )
+            )
+
+        if selector.candidate_ordinal is None:
+            try:
+                reviewed_previews = _render_operation_candidate_overview(
+                    previews,
+                    porcelain=porcelain,
+                )
+                for preview in reviewed_previews:
+                    save_candidate_preview_state(preview)
+            finally:
+                for candidate in previews:
+                    candidate.close()
+            return
+
+        preview = _resolve_candidate_ordinal(previews, explicit_ordinal=selector.candidate_ordinal)
+        try:
+            _render_operation_candidate(
+                preview,
+                porcelain=porcelain,
+            )
+            save_candidate_preview_state(preview)
+        finally:
+            for candidate in previews:
+                candidate.close()
+        return
+
+    if porcelain:
+        exit_with_error(_("--porcelain is only supported for candidate preview in `show --from`."))
+    if replacement_text is not None:
+        if not line_ids:
+            exit_with_error(_("`show --from --as` requires `--line`."))
+        if len(files) != 1:
+            exit_with_error(_("`show --from --as` requires exactly one file."))
+        file_path = list(files.keys())[0]
+        _preview_replacement_batch_view(
+            batch_name,
+            metadata,
+            files,
+            line_ids,
+            file_path,
+            selected_ids,
+            replacement_text,
+        )
+        return
 
     if len(files) == 1:
         # Show specific file from batch

--- a/src/git_stage_batch/commands/sift.py
+++ b/src/git_stage_batch/commands/sift.py
@@ -47,6 +47,7 @@ from ..batch.storage import (
     _update_batch_commit,
 )
 from ..batch.validation import batch_exists, validate_batch_name
+from ..batch.source_selector import require_plain_batch_name
 from ..core.line_selection import LineRanges
 from ..core.models import BinaryFileChange
 from ..core.text_lifecycle import (
@@ -183,6 +184,8 @@ def add_sifted_text_file_to_batch(
 def command_sift_batch(source_batch: str, dest_batch: str) -> None:
     """Sift a batch to remove portions already present at tip."""
     require_git_repository()
+    source_batch = require_plain_batch_name(source_batch, "sift")
+    dest_batch = require_plain_batch_name(dest_batch, "sift")
     validate_batch_name(source_batch)
     validate_batch_name(dest_batch)
 

--- a/src/git_stage_batch/exceptions.py
+++ b/src/git_stage_batch/exceptions.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Literal
 
 
 class CommandError(Exception):
@@ -32,6 +34,48 @@ class BypassRefresh(Exception):
 class MergeError(Exception):
     """Raised when batch merge fails due to structural ambiguity."""
     pass
+
+
+@dataclass(frozen=True)
+class MergeAmbiguityChoice:
+    """One concrete merge ambiguity choice."""
+
+    choice_index: int
+    target_after_line: int | None
+    target_before_line: int | None
+    explanation: str
+
+
+@dataclass(frozen=True)
+class MergeAmbiguity:
+    """An enumerable merge ambiguity."""
+
+    key: str
+    kind: Literal[
+        "missing_claimed_run_placement",
+        "ambiguous_absence_boundary",
+        "replacement_region_placement",
+    ]
+    source_line_range: tuple[int, int] | None
+    choices: tuple[MergeAmbiguityChoice, ...]
+
+
+@dataclass(frozen=True)
+class MergeAmbiguitySet:
+    """A collection of merge ambiguities for one target."""
+
+    file_path: str | None
+    source_line_count: int
+    target_line_count: int
+    ambiguities: tuple[MergeAmbiguity, ...]
+
+
+class MergeAmbiguityError(MergeError):
+    """Raised when a merge refusal has enumerable candidate choices."""
+
+    def __init__(self, ambiguity: MergeAmbiguitySet):
+        self.ambiguity = ambiguity
+        super().__init__("Merge has enumerable ambiguity")
 
 
 class MissingAnchorError(MergeError):

--- a/src/git_stage_batch/utils/paths.py
+++ b/src/git_stage_batch/utils/paths.py
@@ -85,6 +85,18 @@ def get_fixup_state_directory_path() -> Path:
     return path
 
 
+def get_candidate_state_directory_path() -> Path:
+    """Get the directory containing batch candidate iteration state."""
+    path = get_session_directory_path() / "candidates"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def get_batch_candidate_state_file_path() -> Path:
+    """Get the path to the batch candidate state file."""
+    return get_candidate_state_directory_path() / "state.json"
+
+
 def get_processed_include_ids_file_path() -> Path:
     """Get the path to the processed include IDs file.
 

--- a/tests/batch/test_merge.py
+++ b/tests/batch/test_merge.py
@@ -17,6 +17,7 @@ from git_stage_batch.batch.merge import (
     _try_apply_baseline_replacement_units,
     can_merge_batch_from_line_sequences,
     discard_batch_from_line_sequences_as_buffer,
+    enumerate_merge_batch_candidates_from_line_sequences,
     merge_batch_from_line_sequences_as_buffer,
     _satisfy_constraints,
 )
@@ -1318,6 +1319,27 @@ class TestMergeBatch:
         result = merge_batch(source, BatchOwnership.from_presence_lines(claimed, []), working)
 
         assert result == b"line1\nline2\nline3\nline4\nline5\n"
+
+    def test_enumerates_displaced_absence_candidates(self):
+        """Ambiguous nearby deletion content can be previewed as candidates."""
+        source = [b"a\n", b"b\n"]
+        working = [b"a\n", b"insert\n", b"x\n", b"x\n", b"b\n"]
+        ownership = BatchOwnership(
+            [],
+            [AbsenceClaim(anchor_line=1, content_lines=[b"x\n"])],
+        )
+
+        candidate_set = enumerate_merge_batch_candidates_from_line_sequences(
+            source,
+            ownership,
+            working,
+            max_candidates=10,
+        )
+
+        assert [candidate.summary for candidate in candidate_set.candidates] == [
+            "delete target line 3",
+            "delete target line 4",
+        ]
 
     def test_merge_multiple_deletions(self):
         """Test merge with multiple deletion constraints at different positions."""

--- a/tests/batch/test_source_selector.py
+++ b/tests/batch/test_source_selector.py
@@ -1,0 +1,46 @@
+import pytest
+
+from git_stage_batch.batch.source_selector import (
+    BatchSourceSelector,
+    parse_batch_source_selector,
+)
+from git_stage_batch.exceptions import CommandError
+
+
+def test_parse_plain_batch_selector():
+    assert parse_batch_source_selector("cleanup") == BatchSourceSelector("cleanup")
+
+
+@pytest.mark.parametrize(
+    ("raw", "operation", "ordinal"),
+    [
+        ("cleanup:apply", "apply", None),
+        ("cleanup:apply:2", "apply", 2),
+        ("cleanup:include", "include", None),
+        ("cleanup:include:2", "include", 2),
+    ],
+)
+def test_parse_candidate_selectors(raw, operation, ordinal):
+    assert parse_batch_source_selector(raw) == BatchSourceSelector(
+        "cleanup",
+        operation,
+        ordinal,
+    )
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "cleanup:0",
+        "cleanup:1",
+        "cleanup:apply:0",
+        "cleanup:include:0",
+        "cleanup:apply:-1",
+        "cleanup:include:foo",
+        "cleanup::apply:1",
+        "cleanup:1:apply",
+    ],
+)
+def test_reject_invalid_candidate_selectors(raw):
+    with pytest.raises(CommandError):
+        parse_batch_source_selector(raw)

--- a/tests/cli/test_argument_parser.py
+++ b/tests/cli/test_argument_parser.py
@@ -415,6 +415,7 @@ def test_show_page_accepts_single_files_match(monkeypatch):
     mock_command = Mock()
     monkeypatch.setattr(argument_parser.commands, "command_show", mock_command)
     monkeypatch.setattr(argument_parser, "list_changed_files", lambda: ["src/parser.py", "notes.txt"])
+    monkeypatch.setattr(argument_parser, "list_untracked_files", lambda: [])
 
     args = parse_command_line(["show", "--files", "*.py", "--page", "2"], quiet=True)
 
@@ -425,6 +426,7 @@ def test_show_page_accepts_single_files_match(monkeypatch):
 
 def test_show_page_rejects_multiple_files_matches(monkeypatch):
     monkeypatch.setattr(argument_parser, "list_changed_files", lambda: ["foo.py", "bar.py"])
+    monkeypatch.setattr(argument_parser, "list_untracked_files", lambda: [])
 
     args = parse_command_line(["show", "--files", "*.py", "--page", "2"], quiet=True)
 
@@ -1009,6 +1011,7 @@ def test_parse_command_line_show_with_files_uses_file_list(monkeypatch):
     mock_command = Mock()
     monkeypatch.setattr(argument_parser.commands, "command_show_file_list", mock_command)
     monkeypatch.setattr(argument_parser, "list_changed_files", lambda: ["foo.py", "bar.py", "notes.txt"])
+    monkeypatch.setattr(argument_parser, "list_untracked_files", lambda: [])
 
     args = parse_command_line(["show", "--files", "*.py"], quiet=True)
 
@@ -1020,6 +1023,7 @@ def test_parse_command_line_show_with_files_uses_file_list(monkeypatch):
 def test_parse_command_line_show_with_files_raises_command_error_for_no_matches(monkeypatch):
     """Show should report unmatched --files patterns without a traceback."""
     monkeypatch.setattr(argument_parser, "list_changed_files", lambda: ["foo.py", "bar.py"])
+    monkeypatch.setattr(argument_parser, "list_untracked_files", lambda: [])
 
     args = parse_command_line(["show", "--files", "*.md"], quiet=True)
 

--- a/tests/commands/test_candidate_previews.py
+++ b/tests/commands/test_candidate_previews.py
@@ -1,0 +1,367 @@
+"""Tests for reviewed batch candidate choices."""
+
+import json
+import subprocess
+
+import pytest
+
+import git_stage_batch.batch.operation_candidates as operation_candidates
+import git_stage_batch.commands.apply_from as apply_from_module
+import git_stage_batch.commands.include_from as include_from_module
+import git_stage_batch.commands.show_from as show_from_module
+from git_stage_batch.batch import create_batch
+from git_stage_batch.batch.ownership import AbsenceClaim, BatchOwnership
+from git_stage_batch.batch.storage import add_file_to_batch
+from git_stage_batch.commands.apply_from import command_apply_from_batch
+from git_stage_batch.commands.include_from import command_include_from_batch
+from git_stage_batch.commands.show_from import command_show_from_batch
+from git_stage_batch.data.session import initialize_abort_state
+from git_stage_batch.editor import EditorBuffer
+from git_stage_batch.exceptions import CommandError
+from git_stage_batch.utils.paths import (
+    ensure_state_directory_exists,
+    get_batch_candidate_state_file_path,
+)
+
+
+@pytest.fixture
+def temp_git_repo(tmp_path, monkeypatch):
+    """Create a temporary git repository for candidate preview tests."""
+    repo = tmp_path / "test_repo"
+    repo.mkdir()
+    monkeypatch.chdir(repo)
+
+    subprocess.run(["git", "init"], check=True, cwd=repo, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"],
+        check=True,
+        cwd=repo,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        check=True,
+        cwd=repo,
+        capture_output=True,
+    )
+    (repo / "README.md").write_text("# Test\n")
+    subprocess.run(["git", "add", "README.md"], check=True, cwd=repo, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "Initial commit"],
+        check=True,
+        cwd=repo,
+        capture_output=True,
+    )
+
+    ensure_state_directory_exists()
+    initialize_abort_state()
+    return repo
+
+
+def _create_displaced_absence_batch(repo):
+    (repo / "file.txt").write_text("a\nb\n")
+    subprocess.run(["git", "add", "file.txt"], check=True, cwd=repo, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "Add source file"],
+        check=True,
+        cwd=repo,
+        capture_output=True,
+    )
+    initialize_abort_state()
+    create_batch("ambiguous")
+    add_file_to_batch(
+        "ambiguous",
+        "file.txt",
+        BatchOwnership(
+            [],
+            [AbsenceClaim(anchor_line=1, content_lines=[b"x\n"])],
+        ),
+        "100644",
+    )
+    (repo / "file.txt").write_text("a\ninsert\nx\nmid\nx\nb\n")
+
+
+def _create_displaced_absence_block_batch(repo):
+    (repo / "file.txt").write_text("a\nb\n")
+    subprocess.run(["git", "add", "file.txt"], check=True, cwd=repo, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "Add source file"],
+        check=True,
+        cwd=repo,
+        capture_output=True,
+    )
+    initialize_abort_state()
+    create_batch("ambiguous-lines")
+    add_file_to_batch(
+        "ambiguous-lines",
+        "file.txt",
+        BatchOwnership(
+            [],
+            [
+                AbsenceClaim(
+                    anchor_line=1,
+                    content_lines=[b"x\n", b"y\n", b"z\n"],
+                )
+            ],
+        ),
+        "100644",
+    )
+    (repo / "file.txt").write_text(
+        "a\ninsert\nx\ny\nz\nmid\nx\ny\nz\nb\n"
+    )
+
+
+def _candidate_state_has_file(batch_name, file_path):
+    state_path = get_batch_candidate_state_file_path()
+    if not state_path.exists():
+        return False
+
+    data = json.loads(state_path.read_text(encoding="utf-8"))
+    return any(
+        scope.get("batch_name") == batch_name and scope.get("file") == file_path
+        for scope in data.get("scopes", {}).values()
+    )
+
+
+def test_show_candidate_set_lists_context_and_commands(temp_git_repo, capsys):
+    """Unnumbered candidate selectors should list choices without a full diff."""
+    _create_displaced_absence_batch(temp_git_repo)
+
+    command_show_from_batch("ambiguous:apply", file="file.txt")
+
+    captured = capsys.readouterr()
+    assert "Apply candidates for batch 'ambiguous' in file.txt." in captured.out
+    assert "Candidates: 2" in captured.out
+    assert '1. Working tree: Remove "x" near "insert"' in captured.out
+    assert '2. Working tree: Remove "x" near "mid"' in captured.out
+    assert "3 -x" in captured.out
+    assert "5 -x" in captured.out
+    assert "show: git-stage-batch show --from ambiguous:apply:1 --file file.txt" in captured.out
+    assert "apply: git-stage-batch apply --from ambiguous:apply:1 --file file.txt" in captured.out
+    assert "Apply candidate 1 of 2 for batch 'ambiguous'." not in captured.err
+
+
+def test_apply_candidate_can_run_from_overview(temp_git_repo, capsys):
+    """The candidate overview should count as review for shown candidates."""
+    _create_displaced_absence_batch(temp_git_repo)
+
+    command_show_from_batch("ambiguous:apply", file="file.txt")
+    capsys.readouterr()
+    assert _candidate_state_has_file("ambiguous", "file.txt")
+
+    command_apply_from_batch("ambiguous:apply:1", file="file.txt")
+
+    captured = capsys.readouterr()
+    assert "Applied candidate 1 of 2 from batch 'ambiguous'" in captured.err
+    assert (temp_git_repo / "file.txt").read_text() == "a\ninsert\nmid\nx\nb\n"
+    assert not _candidate_state_has_file("ambiguous", "file.txt")
+
+
+def test_candidate_preview_allows_equivalent_line_selection_spelling(
+    temp_git_repo,
+    capsys,
+    monkeypatch,
+):
+    """Equivalent --line spellings should authorize the same selected lines."""
+    _create_displaced_absence_block_batch(temp_git_repo)
+
+    def resolve_selected_lines(batch_name, file_path, selected_ids, action):
+        return set(selected_ids), None
+
+    monkeypatch.setattr(
+        show_from_module,
+        "translate_batch_file_gutter_ids_to_selection_ids",
+        resolve_selected_lines,
+    )
+    monkeypatch.setattr(
+        apply_from_module,
+        "translate_batch_file_gutter_ids_to_selection_ids",
+        resolve_selected_lines,
+    )
+
+    command_show_from_batch(
+        "ambiguous-lines:apply:1",
+        line_ids="1-3",
+        file="file.txt",
+    )
+    capsys.readouterr()
+
+    command_apply_from_batch(
+        "ambiguous-lines:apply:1",
+        line_ids="1,2,3",
+        file="file.txt",
+    )
+
+    captured = capsys.readouterr()
+    assert "Applied candidate 1 of 2 from batch 'ambiguous-lines'" in captured.err
+    assert (temp_git_repo / "file.txt").read_text() == (
+        "a\ninsert\nmid\nx\ny\nz\nb\n"
+    )
+
+
+def test_apply_from_reports_candidate_enumeration_error(
+    temp_git_repo,
+    monkeypatch,
+):
+    """Candidate-count failures should not look like missing candidates."""
+    _create_displaced_absence_batch(temp_git_repo)
+
+    def fail_count(*args, **kwargs):
+        raise RuntimeError("metadata drift")
+
+    monkeypatch.setattr(
+        apply_from_module,
+        "build_apply_candidate_previews",
+        fail_count,
+    )
+
+    with pytest.raises(CommandError) as exc_info:
+        command_apply_from_batch("ambiguous", file="file.txt")
+
+    assert "Cannot enumerate apply candidates for file.txt: metadata drift" in (
+        exc_info.value.message
+    )
+    assert (temp_git_repo / "file.txt").read_text() == "a\ninsert\nx\nmid\nx\nb\n"
+
+
+def test_numbered_show_candidate_records_its_own_preview(temp_git_repo, capsys):
+    """A later numbered preview should not replace an earlier reviewed choice."""
+    _create_displaced_absence_batch(temp_git_repo)
+
+    command_show_from_batch("ambiguous:apply:1", file="file.txt")
+    first_preview = capsys.readouterr()
+    assert "overview: git-stage-batch show --from ambiguous:apply --file file.txt" in first_preview.err
+    assert "next: git-stage-batch show --from ambiguous:apply:2 --file file.txt" in first_preview.err
+    command_show_from_batch("ambiguous:apply:2", file="file.txt")
+    second_preview = capsys.readouterr()
+    assert "overview: git-stage-batch show --from ambiguous:apply --file file.txt" in second_preview.err
+    assert "previous: git-stage-batch show --from ambiguous:apply:1 --file file.txt" in second_preview.err
+
+    command_apply_from_batch("ambiguous:apply:1", file="file.txt")
+
+    captured = capsys.readouterr()
+    assert "Applied candidate 1 of 2 from batch 'ambiguous'" in captured.err
+    assert (temp_git_repo / "file.txt").read_text() == "a\ninsert\nmid\nx\nb\n"
+
+
+def test_apply_candidate_rejects_changed_materialized_result(
+    temp_git_repo,
+    capsys,
+    monkeypatch,
+):
+    """A reviewed apply candidate should not execute a different result."""
+    _create_displaced_absence_batch(temp_git_repo)
+
+    command_show_from_batch("ambiguous:apply:1", file="file.txt")
+    capsys.readouterr()
+
+    original_merge = operation_candidates.merge_batch_from_line_sequences_as_buffer
+
+    def changed_result(*args, **kwargs):
+        result = original_merge(*args, **kwargs)
+        if kwargs.get("resolution") is None:
+            return result
+        try:
+            changed = result.to_bytes().replace(b"insert\n", b"drifted\n", 1)
+        finally:
+            result.close()
+        return EditorBuffer.from_bytes(changed)
+
+    monkeypatch.setattr(
+        operation_candidates,
+        "merge_batch_from_line_sequences_as_buffer",
+        changed_result,
+    )
+
+    with pytest.raises(CommandError) as exc_info:
+        command_apply_from_batch("ambiguous:apply:1", file="file.txt")
+
+    assert "has not been previewed" in exc_info.value.message
+    assert (temp_git_repo / "file.txt").read_text() == "a\ninsert\nx\nmid\nx\nb\n"
+
+
+def test_show_candidate_rejects_unknown_choice(temp_git_repo):
+    """Operation candidate selectors should reject ordinals outside the set."""
+    _create_displaced_absence_batch(temp_git_repo)
+
+    with pytest.raises(CommandError) as exc_info:
+        command_show_from_batch("ambiguous:apply:3", file="file.txt")
+
+    assert "candidate 3 does not exist" in exc_info.value.message
+
+
+def test_include_candidate_can_run_from_overview(temp_git_repo, capsys):
+    """Include candidates should also be executable after the overview."""
+    _create_displaced_absence_batch(temp_git_repo)
+
+    command_show_from_batch("ambiguous:include", file="file.txt")
+    overview = capsys.readouterr()
+    assert "include: git-stage-batch include --from ambiguous:include:2 --file file.txt" in overview.out
+    assert _candidate_state_has_file("ambiguous", "file.txt")
+
+    command_include_from_batch("ambiguous:include:2", file="file.txt")
+
+    captured = capsys.readouterr()
+    assert "Included candidate 2 of 2 from batch 'ambiguous'" in captured.err
+    assert (temp_git_repo / "file.txt").read_text() == "a\ninsert\nx\nmid\nb\n"
+    assert not _candidate_state_has_file("ambiguous", "file.txt")
+
+
+def test_include_from_reports_candidate_limit(temp_git_repo, monkeypatch):
+    """Candidate-count limits should not look like missing candidates."""
+    _create_displaced_absence_batch(temp_git_repo)
+
+    def fail_count(*args, **kwargs):
+        raise operation_candidates.CandidateEnumerationLimitError(
+            "too many include candidates to preview safely"
+        )
+
+    monkeypatch.setattr(
+        include_from_module,
+        "build_include_candidate_previews",
+        fail_count,
+    )
+
+    with pytest.raises(CommandError) as exc_info:
+        command_include_from_batch("ambiguous", file="file.txt")
+
+    assert "file.txt has too many include candidates to preview safely" in (
+        exc_info.value.message
+    )
+    assert (temp_git_repo / "file.txt").read_text() == "a\ninsert\nx\nmid\nx\nb\n"
+
+
+def test_include_candidate_rejects_changed_materialized_result(
+    temp_git_repo,
+    capsys,
+    monkeypatch,
+):
+    """A reviewed include candidate should not execute a different result."""
+    _create_displaced_absence_batch(temp_git_repo)
+
+    command_show_from_batch("ambiguous:include:2", file="file.txt")
+    capsys.readouterr()
+
+    original_merge = operation_candidates.merge_batch_from_line_sequences_as_buffer
+
+    def changed_result(*args, **kwargs):
+        result = original_merge(*args, **kwargs)
+        if kwargs.get("resolution") is None:
+            return result
+        try:
+            changed = result.to_bytes().replace(b"mid\n", b"drifted\n", 1)
+        finally:
+            result.close()
+        return EditorBuffer.from_bytes(changed)
+
+    monkeypatch.setattr(
+        operation_candidates,
+        "merge_batch_from_line_sequences_as_buffer",
+        changed_result,
+    )
+
+    with pytest.raises(CommandError) as exc_info:
+        command_include_from_batch("ambiguous:include:2", file="file.txt")
+
+    assert "has not been previewed" in exc_info.value.message
+    assert (temp_git_repo / "file.txt").read_text() == "a\ninsert\nx\nmid\nx\nb\n"


### PR DESCRIPTION
The `git-stage-batch apply --from` and `git-stage-batch include --from`
workflows are intentionally conservative. When saved batch lines can fit in
more than one place, the command refuses instead of picking a location
silently.

That keeps files safe, but it also leaves users and AI assistants to inspect
the saved batch text with `git-stage-batch show --from` and merge it by hand.
This pull request adds a reviewed choice workflow for those cases.

When `git-stage-batch apply --from` or `git-stage-batch include --from` hits
ambiguity, it points to `git-stage-batch show --from BATCH:apply` or
`git-stage-batch show --from BATCH:include`. That command prints a compact
overview of candidate choices with nearby context and exact follow-up
commands. The overview counts as review for the candidates it lists, so a
user can run a listed command such as
`git-stage-batch apply --from BATCH:apply:2 --file PATH` directly from the
summary.

Users who want the full diff for one choice can still run a command such as
`git-stage-batch show --from BATCH:apply:2 --file PATH` before executing it.
When review is scoped with `--line`, validation uses the resolved selected
batch lines, so equivalent spellings such as `--line 1-3` and
`--line 1,2,3` share the same reviewed scope.

Before execution, `git-stage-batch apply --from` and
`git-stage-batch include --from` rebuild the same candidate and compare hashes
for the reviewed batch operation, the target contents before review, and the
previewed target result. If the batch, working tree, or index changes in a way
that would change the result, the command asks for another review instead of
applying a stale choice. After a reviewed candidate is applied or included,
saved choices for that batch file are cleared so the session does not keep
authorization records for a file that just changed.

The series also reports candidate enumeration failures separately from files
with no available candidates, and updates parser guards, man pages, bash
completion, and the command guide for the candidate selector syntax.
