### PR TITLE
show: Frame ambiguous candidate previews

### DIFF
--- a/src/git_stage_batch/batch/merge.py
+++ b/src/git_stage_batch/batch/merge.py
@@ -63,6 +63,7 @@ class MergeCandidate:
     target_after_line: int | None
     target_before_line: int | None
     explanation: str
+    ambiguity_target_line_range: tuple[int, int] | None = None
 
     @property
     def resolution(self) -> MergeResolution:
@@ -2032,6 +2033,22 @@ class _PresenceChoice:
     target_before_line: int | None
 
 
+def _presence_ambiguity_target_line_range(
+    choices: Sequence[_PresenceChoice],
+    target_line_count: int,
+) -> tuple[int, int] | None:
+    """Return existing target lines spanning compatible insertion gaps."""
+    if target_line_count == 0:
+        return None
+
+    positions = [choice.gap_index for choice in choices]
+    start = max(1, min(positions))
+    end = min(target_line_count, max(positions) + 1)
+    if start > end:
+        return None
+    return start, end
+
+
 def _absence_choices_for_claim(
     entries: Sequence[RealizedEntry],
     anchor_line: int | None,
@@ -2901,6 +2918,10 @@ def _enumerate_merge_batch_candidates_acquired(
             valid_choices.append(choice)
         if len(valid_choices) > 1:
             count = len(valid_choices)
+            ambiguity_target_line_range = _presence_ambiguity_target_line_range(
+                valid_choices,
+                len(working_lines),
+            )
             candidates = []
             for ordinal, choice in enumerate(valid_choices, start=1):
                 summary = _(
@@ -2927,6 +2948,7 @@ def _enumerate_merge_batch_candidates_acquired(
                         target_after_line=choice.target_after_line,
                         target_before_line=choice.target_before_line,
                         explanation=_("surrounding source context has multiple compatible placements"),
+                        ambiguity_target_line_range=ambiguity_target_line_range,
                     )
                 )
             return MergeCandidateSet(tuple(candidates))
@@ -3001,6 +3023,10 @@ def _enumerate_merge_batch_candidates_acquired(
             return MergeCandidateSet(())
 
         count = len(valid_choices)
+        ambiguity_target_line_range = (
+            min(choice.position + 1 for choice in valid_choices),
+            max(choice.position + len(forbidden_sequence) for choice in valid_choices),
+        )
         candidates: list[MergeCandidate] = []
         for ordinal, choice in enumerate(valid_choices, start=1):
             target_start = choice.position + 1
@@ -3033,6 +3059,7 @@ def _enumerate_merge_batch_candidates_acquired(
                     target_after_line=choice.target_after_line,
                     target_before_line=choice.target_before_line,
                     explanation=_("deletion anchor has multiple compatible target placements"),
+                    ambiguity_target_line_range=ambiguity_target_line_range,
                 )
             )
         return MergeCandidateSet(tuple(candidates))

--- a/src/git_stage_batch/batch/operation_candidates.py
+++ b/src/git_stage_batch/batch/operation_candidates.py
@@ -50,6 +50,7 @@ class TargetCandidatePreview:
     resolution_count: int
     summary: str
     explanation: str
+    ambiguity_target_line_range: tuple[int, int] | None
 
     def close(self) -> None:
         self.before_buffer.close()
@@ -313,6 +314,9 @@ def _materialize_target_candidate(
         resolution_count=1 if candidate is None else candidate.count,
         summary="unambiguous" if candidate is None else candidate.summary,
         explanation="" if candidate is None else candidate.explanation,
+        ambiguity_target_line_range=(
+            None if candidate is None else candidate.ambiguity_target_line_range
+        ),
     )
 
 

--- a/src/git_stage_batch/commands/apply_from.py
+++ b/src/git_stage_batch/commands/apply_from.py
@@ -279,14 +279,14 @@ def _execute_apply_candidate(
                     target.after_buffer,
                 )
                 print(
-                    _("Applying apply candidate {ordinal} of {count} for batch '{batch}':").format(
+                    _("Applying candidate {ordinal} of {count} from batch '{batch}':").format(
                         ordinal=preview.ordinal,
                         count=preview.count,
                         batch=batch_name,
                     ),
                     file=sys.stderr,
                 )
-                print(f"  {file_path}: {target.summary}", file=sys.stderr)
+                print(f"  {file_path}: {_('Working tree')}", file=sys.stderr)
                 operation_parts = ["apply", "--from", raw_selector, "--file", file_path]
                 with undo_checkpoint(" ".join(operation_parts), worktree_paths=[file_path]):
                     snapshot_file_if_untracked(file_path)

--- a/src/git_stage_batch/commands/include_from.py
+++ b/src/git_stage_batch/commands/include_from.py
@@ -357,8 +357,8 @@ def _execute_include_candidate(
                     file=sys.stderr,
                 )
                 print(f"  {file_path}:", file=sys.stderr)
-                print(f"    index: {index_target.summary}", file=sys.stderr)
-                print(f"    working tree: {worktree_target.summary}", file=sys.stderr)
+                print(f"    {_('Index')}", file=sys.stderr)
+                print(f"    {_('Working tree')}", file=sys.stderr)
                 operation_parts = ["include", "--from", raw_selector, "--file", file_path]
                 with undo_checkpoint(" ".join(operation_parts), worktree_paths=[file_path]):
                     snapshot_file_if_untracked(file_path)

--- a/src/git_stage_batch/commands/show_from.py
+++ b/src/git_stage_batch/commands/show_from.py
@@ -38,6 +38,7 @@ from ..core.text_lifecycle import (
     mode_for_text_materialization,
     normalized_text_change_type,
 )
+from ..core.diff_parser import build_line_changes_from_patch_lines
 from ..data.hunk_tracking import (
     SelectedChangeKind,
     cache_binary_file_change,
@@ -55,7 +56,12 @@ from ..data.file_review_state import (
     clear_last_file_review_state,
     write_last_file_review_state,
 )
-from ..output import print_binary_file_change, print_gitlink_change, print_line_level_changes
+from ..output import (
+    Colors,
+    print_binary_file_change,
+    print_gitlink_change,
+    print_line_level_changes,
+)
 from ..output.file_review import (
     build_file_review_model,
     make_file_review_state,
@@ -81,10 +87,11 @@ from ..utils.git import get_git_repository_root_path, require_git_repository
 from ..utils.paths import get_context_lines
 
 
-_CANDIDATE_OVERVIEW_CONTEXT_LINES = 1
-_CANDIDATE_OVERVIEW_MAX_LINES = 5
+_CANDIDATE_OVERVIEW_CONTEXT_LINES = 2
+_CANDIDATE_OVERVIEW_MAX_LINES = 9
 _CANDIDATE_OVERVIEW_MAX_LINE_WIDTH = 64
 _CANDIDATE_OVERVIEW_MAX_CANDIDATES = 10
+_CANDIDATE_GUTTER_SEPARATOR = "│"
 
 
 def _batch_source_args(batch_name: str) -> str:
@@ -163,11 +170,153 @@ def _show_candidate_command(preview: OperationCandidatePreview, ordinal: int | N
     )
 
 
+def _execute_candidate_command(preview: OperationCandidatePreview) -> str:
+    return "git-stage-batch {command} --from {selector} --file {file}".format(
+        command=preview.operation,
+        selector=_candidate_selector_text(
+            preview.batch_name,
+            preview.operation,
+            preview.ordinal,
+        ),
+        file=shlex.quote(preview.file_path),
+    )
+
+
+def _candidate_overview_subject(
+    previews: tuple[OperationCandidatePreview, ...],
+) -> tuple[str, str]:
+    ambiguous_targets: list[str] = []
+    for target_name in ("worktree", "index"):
+        for preview in previews:
+            target = next(
+                (target for target in preview.targets if target.target == target_name),
+                None,
+            )
+            if target is not None and target.resolution_count > 1:
+                ambiguous_targets.append(target_name)
+                break
+
+    if not ambiguous_targets:
+        ambiguous_targets = [
+            target_name
+            for target_name in ("worktree", "index")
+            if any(
+                target.target == target_name
+                for preview in previews
+                for target in preview.targets
+            )
+        ]
+
+    labels = [
+        _("working tree") if target_name == "worktree" else _("index")
+        for target_name in ambiguous_targets
+    ]
+    if len(labels) == 1:
+        return labels[0], _("has")
+    if len(labels) == 2:
+        return _("{first} and {second}").format(
+            first=labels[0],
+            second=labels[1],
+        ), _("have")
+    return _("target files"), _("have")
+
+
+def _candidate_choice_count(count: int) -> str:
+    if count == 1:
+        return _("1 choice")
+    return _("{count} choices").format(count=count)
+
+
+def _candidate_operation_past_tense(operation: str) -> str:
+    if operation == "include":
+        return _("included")
+    return _("applied")
+
+
+def _print_candidate_rule() -> None:
+    rule = "─" * 78
+    if Colors.enabled():
+        print(f"{Colors.GRAY}{rule}{Colors.RESET}")
+    else:
+        print(rule)
+
+
+def _print_candidate_header(status: str, *, note: str | None) -> None:
+    if Colors.enabled():
+        print(f"{Colors.BOLD}{status}{Colors.RESET}")
+    else:
+        print(status)
+    if note:
+        if Colors.enabled():
+            print(f"{Colors.GRAY}{_('Note: {note}').format(note=note)}{Colors.RESET}")
+        else:
+            print(_("Note: {note}").format(note=note))
+    _print_candidate_rule()
+
+
+def _print_candidate_overview_header(
+    first: OperationCandidatePreview,
+    *,
+    note: str | None,
+) -> None:
+    status = "  ·  ".join(
+        (
+            first.file_path,
+            first.batch_name,
+            _("{operation} candidates").format(operation=first.operation),
+            _candidate_choice_count(first.count),
+        )
+    )
+    _print_candidate_header(status, note=note)
+
+
+def _print_candidate_detail_header(
+    preview: OperationCandidatePreview,
+    *,
+    note: str | None,
+) -> None:
+    status = "  ·  ".join(
+        (
+            preview.file_path,
+            preview.batch_name,
+            _("{operation} candidate {ordinal}/{count}").format(
+                operation=preview.operation,
+                ordinal=preview.ordinal,
+                count=preview.count,
+            ),
+        )
+    )
+    _print_candidate_header(status, note=note)
+
+
 @dataclass(frozen=True)
 class _CandidateTargetSummary:
     label: str
     title: str
-    lines: tuple[str, ...]
+    lines: tuple["_CandidateSnippetLine", ...]
+    ambiguity_line_range: tuple[int, int] | None = None
+
+
+@dataclass(frozen=True)
+class _AmbiguityBlockContext:
+    relation: str
+    line_range: tuple[int, int]
+    description: str
+
+
+@dataclass(frozen=True)
+class _CandidateSnippetLine:
+    line_number: int | None
+    marker: str
+    text: str
+    highlight: bool = False
+
+    def plain(self, *, width: int) -> str:
+        line_number = " " * width if self.line_number is None else f"{self.line_number:>{width}}"
+        return (
+            f"{line_number}{_CANDIDATE_GUTTER_SEPARATOR} "
+            f"{self.marker}{_shorten_overview_text(self.text)}"
+        )
 
 
 def _decode_overview_lines(buffer: EditorBuffer) -> list[str]:
@@ -193,6 +342,76 @@ def _summarize_overview_lines(lines: list[str]) -> str:
             return f'"{text}"'
         return _("an empty line")
     return _("{count} lines").format(count=len(lines))
+
+
+def _summarize_ambiguity_block(lines: list[str]) -> str:
+    if not lines:
+        return _("ambiguous block")
+    if len(lines) == 1:
+        text = _shorten_overview_text(lines[0], 36)
+        if text:
+            return f'"{text}"'
+        return _("an empty line")
+
+    first = _shorten_overview_text(lines[0], 24)
+    last = _shorten_overview_text(lines[-1], 24)
+    if first and last:
+        return f'"{first} … {last}"'
+    return _("{count} lines").format(count=len(lines))
+
+
+def _delete_ambiguity_block_context(
+    before_lines: list[str],
+    before_start: int,
+    before_end: int,
+    ambiguity_target_line_range: tuple[int, int] | None,
+) -> _AmbiguityBlockContext | None:
+    if ambiguity_target_line_range is None:
+        return None
+
+    removed_lines = before_lines[before_start:before_end]
+    removed_len = len(removed_lines)
+    if removed_len == 0:
+        return None
+
+    span_start, span_end = ambiguity_target_line_range
+    current_start = before_start + 1
+    current_end = before_end
+    if current_start < span_start or current_end > span_end:
+        return None
+
+    if current_start == span_start and current_end < span_end:
+        block_start = current_end + 1
+        block_end = span_end
+        alternate_start = span_end - removed_len + 1
+        if (
+            alternate_start >= block_start
+            and before_lines[alternate_start - 1:span_end] == removed_lines
+        ):
+            block_end = alternate_start - 1
+        relation = "before"
+    elif current_end == span_end and current_start > span_start:
+        block_start = span_start
+        block_end = current_start - 1
+        alternate_end = span_start + removed_len - 1
+        if (
+            alternate_end <= block_end
+            and before_lines[span_start - 1:alternate_end] == removed_lines
+        ):
+            block_start = alternate_end + 1
+        relation = "after"
+    else:
+        return None
+
+    if block_start > block_end:
+        return None
+
+    block_lines = before_lines[block_start - 1:block_end]
+    return _AmbiguityBlockContext(
+        relation=relation,
+        line_range=(block_start, block_end),
+        description=_summarize_ambiguity_block(block_lines),
+    )
 
 
 def _first_changed_opcode(
@@ -239,40 +458,199 @@ def _overview_action_title(
     before_end: int,
     after_start: int,
     after_end: int,
+    ambiguity_context: _AmbiguityBlockContext | None,
 ) -> str:
     removed = before_lines[before_start:before_end]
     added = after_lines[after_start:after_end]
     changed = removed or added
-    nearby = _nearby_context_summary(before_lines, before_start, before_end, changed)
+    placement = ""
+    if ambiguity_context is not None:
+        if ambiguity_context.relation == "before":
+            placement = _(" before {block}").format(
+                block=ambiguity_context.description,
+            )
+        elif ambiguity_context.relation == "after":
+            placement = _(" after {block}").format(
+                block=ambiguity_context.description,
+            )
+    if not placement:
+        placement = _nearby_context_summary(before_lines, before_start, before_end, changed)
 
     if tag == "delete":
-        return _("Remove {text}{nearby}").format(
+        return _("Remove {text}{placement}").format(
             text=_summarize_overview_lines(removed),
-            nearby=nearby,
+            placement=placement,
         )
     if tag == "insert":
-        return _("Add {text}{nearby}").format(
+        return _("Add {text}{placement}").format(
             text=_summarize_overview_lines(added),
-            nearby=nearby,
+            placement=placement,
         )
-    return _("Replace {old} with {new}{nearby}").format(
+    return _("Replace {old} with {new}{placement}").format(
         old=_summarize_overview_lines(removed),
         new=_summarize_overview_lines(added),
-        nearby=nearby,
+        placement=placement,
     )
 
 
 def _append_overview_line(
-    lines: list[str],
+    lines: list[_CandidateSnippetLine],
     *,
     line_number: int,
-    width: int,
     marker: str,
     text: str,
+    highlight: bool = False,
 ) -> None:
-    lines.append(
-        f"{line_number:>{width}} {marker}{_shorten_overview_text(text)}"
+    lines.append(_CandidateSnippetLine(line_number, marker, text, highlight))
+
+
+def _snippet_line_width(lines: tuple[_CandidateSnippetLine, ...]) -> int:
+    numbered_lines = [line for line in lines if line.line_number is not None]
+    if not numbered_lines:
+        return 1
+    return max(len(str(line.line_number)) for line in numbered_lines)
+
+
+def _style_candidate_snippet_line(line: _CandidateSnippetLine, *, width: int) -> str:
+    plain = line.plain(width=width)
+    if not Colors.enabled():
+        return plain
+
+    line_number = " " * width if line.line_number is None else f"{line.line_number:>{width}}"
+    gutter = f"{line_number}{_CANDIDATE_GUTTER_SEPARATOR} "
+    body = f"{line.marker}{_shorten_overview_text(line.text)}"
+    if line.highlight:
+        return f"{Colors.GRAY}{gutter}{Colors.RESET}{Colors.REVERSE}{Colors.GRAY}{body}{Colors.RESET}"
+    if line.marker == "+":
+        return f"{Colors.GRAY}{gutter}{Colors.RESET}{Colors.GREEN}{body}{Colors.RESET}"
+    if line.marker == "-":
+        return f"{Colors.GRAY}{gutter}{Colors.RESET}{Colors.RED}{body}{Colors.RESET}"
+    return f"{Colors.GRAY}{gutter}{Colors.RESET}{body}"
+
+
+def _plain_candidate_snippet_lines(
+    lines: tuple[_CandidateSnippetLine, ...],
+) -> tuple[str, ...]:
+    width = _snippet_line_width(lines)
+    return tuple(line.plain(width=width) for line in lines)
+
+
+def _line_in_range(
+    line_number: int | None,
+    line_range: tuple[int, int] | None,
+) -> bool:
+    if line_number is None or line_range is None:
+        return False
+    start, end = line_range
+    return start <= line_number <= end
+
+
+def _candidate_diff_hunks(diff_text: str) -> tuple[tuple[bytes, ...], ...]:
+    headers: list[bytes] = []
+    current_hunk: list[bytes] = []
+    hunks: list[tuple[bytes, ...]] = []
+    for line in diff_text.splitlines(keepends=True):
+        line_bytes = line.encode("utf-8", errors="surrogateescape")
+        if line_bytes.startswith((b"--- ", b"+++ ")):
+            headers.append(line_bytes)
+            continue
+        if line_bytes.startswith(b"@@ "):
+            if current_hunk:
+                hunks.append(tuple(headers + current_hunk))
+            current_hunk = [line_bytes]
+            continue
+        if current_hunk:
+            current_hunk.append(line_bytes)
+
+    if current_hunk:
+        hunks.append(tuple(headers + current_hunk))
+    return tuple(hunks)
+
+
+def _candidate_line_number(line) -> int | None:
+    if line.kind == "+":
+        return line.new_line_number
+    return line.old_line_number if line.old_line_number is not None else line.new_line_number
+
+
+def _print_candidate_line_changes(
+    line_changes,
+    *,
+    ambiguity_target_line_range: tuple[int, int] | None,
+) -> None:
+    use_color = Colors.enabled()
+    header = line_changes.header
+    header_part = f"@@ -{header.old_start},{header.old_len} +{header.new_start},{header.new_len} @@"
+    if use_color:
+        print(f"{Colors.BOLD}{line_changes.path}{Colors.RESET} :: {Colors.CYAN}{header_part}{Colors.RESET}")
+    else:
+        print(f"{line_changes.path} :: {header_part}")
+
+    line_numbers = [
+        line_number
+        for line_number in (_candidate_line_number(line) for line in line_changes.lines)
+        if line_number is not None
+    ]
+    width = max((len(str(line_number)) for line_number in line_numbers), default=1)
+
+    for line in line_changes.lines:
+        line_number = _candidate_line_number(line)
+        gutter_number = " " * width if line_number is None else f"{line_number:>{width}}"
+        gutter = f"{gutter_number}{_CANDIDATE_GUTTER_SEPARATOR} "
+        body = f"{line.kind}{line.display_text()}"
+
+        if not use_color:
+            print(f"{gutter}{body}")
+            continue
+
+        styled_gutter = f"{Colors.GRAY}{gutter}{Colors.RESET}"
+        if line.kind == "+":
+            print(f"{styled_gutter}{Colors.GREEN}{body}{Colors.RESET}")
+        elif line.kind == "-":
+            print(f"{styled_gutter}{Colors.RED}{body}{Colors.RESET}")
+        elif _line_in_range(line_number, ambiguity_target_line_range):
+            print(f"{styled_gutter}{Colors.REVERSE}{Colors.GRAY}{body}{Colors.RESET}")
+        else:
+            print(f"{styled_gutter}{body}")
+
+
+def _print_candidate_buffer_diff(
+    file_path: str,
+    before_buffer: EditorBuffer,
+    after_buffer: EditorBuffer,
+    *,
+    context_lines: int,
+    ambiguity_target_line_range: tuple[int, int] | None,
+    leading_blank: bool = False,
+) -> bool:
+    diff_text = render_candidate_buffer_diff(
+        file_path,
+        before_buffer,
+        after_buffer,
+        label_before="a",
+        label_after="b",
+        context_lines=context_lines,
     )
+    if not diff_text:
+        return False
+
+    if leading_blank:
+        print()
+
+    hunks = _candidate_diff_hunks(diff_text)
+    if not hunks:
+        print(diff_text, end="" if diff_text.endswith("\n") else "\n")
+        return True
+
+    for index, hunk in enumerate(hunks):
+        if index:
+            print()
+        line_changes = build_line_changes_from_patch_lines(hunk)
+        _print_candidate_line_changes(
+            line_changes,
+            ambiguity_target_line_range=ambiguity_target_line_range,
+        )
+    return True
 
 
 def _overview_snippet_lines(
@@ -282,9 +660,9 @@ def _overview_snippet_lines(
     before_end: int,
     after_start: int,
     after_end: int,
-) -> tuple[str, ...]:
-    width = max(len(str(max(len(before_lines), len(after_lines), 1))), 1)
-    lines: list[str] = []
+    ambiguity_target_line_range: tuple[int, int] | None,
+) -> tuple[_CandidateSnippetLine, ...]:
+    lines: list[_CandidateSnippetLine] = []
 
     context_start = max(0, before_start - _CANDIDATE_OVERVIEW_CONTEXT_LINES)
     context_end = min(len(before_lines), before_end + _CANDIDATE_OVERVIEW_CONTEXT_LINES)
@@ -293,16 +671,15 @@ def _overview_snippet_lines(
         _append_overview_line(
             lines,
             line_number=index + 1,
-            width=width,
             marker=" ",
             text=before_lines[index],
+            highlight=_line_in_range(index + 1, ambiguity_target_line_range),
         )
 
     for index in range(before_start, before_end):
         _append_overview_line(
             lines,
             line_number=index + 1,
-            width=width,
             marker="-",
             text=before_lines[index],
         )
@@ -311,7 +688,6 @@ def _overview_snippet_lines(
         _append_overview_line(
             lines,
             line_number=index + 1,
-            width=width,
             marker="+",
             text=after_lines[index],
         )
@@ -320,13 +696,16 @@ def _overview_snippet_lines(
         _append_overview_line(
             lines,
             line_number=index + 1,
-            width=width,
             marker=" ",
             text=before_lines[index],
+            highlight=_line_in_range(index + 1, ambiguity_target_line_range),
         )
 
     if len(lines) > _CANDIDATE_OVERVIEW_MAX_LINES:
-        return tuple(lines[:_CANDIDATE_OVERVIEW_MAX_LINES] + ["..."])
+        return tuple(
+            lines[:_CANDIDATE_OVERVIEW_MAX_LINES]
+            + [_CandidateSnippetLine(None, " ", "...")]
+        )
     return tuple(lines)
 
 
@@ -339,6 +718,19 @@ def _summarize_candidate_target(target) -> _CandidateTargetSummary:
         return _CandidateTargetSummary(label=label, title=_("No text changes"), lines=())
 
     tag, before_start, before_end, after_start, after_end = opcode
+    ambiguity_context = (
+        _delete_ambiguity_block_context(
+            before_lines,
+            before_start,
+            before_end,
+            target.ambiguity_target_line_range,
+        )
+        if tag == "delete"
+        else None
+    )
+    ambiguity_line_range = (
+        None if ambiguity_context is None else ambiguity_context.line_range
+    )
     return _CandidateTargetSummary(
         label=label,
         title=_overview_action_title(
@@ -349,6 +741,7 @@ def _summarize_candidate_target(target) -> _CandidateTargetSummary:
             before_end,
             after_start,
             after_end,
+            ambiguity_context,
         ),
         lines=_overview_snippet_lines(
             before_lines,
@@ -357,14 +750,84 @@ def _summarize_candidate_target(target) -> _CandidateTargetSummary:
             before_end,
             after_start,
             after_end,
+            ambiguity_line_range,
         ),
+        ambiguity_line_range=ambiguity_line_range,
     )
+
+
+def _candidate_summary_key(summary: _CandidateTargetSummary) -> tuple[str, tuple[str, ...]]:
+    return summary.title, _plain_candidate_snippet_lines(summary.lines)
+
+
+def _common_candidate_target_indexes(
+    previews: tuple[OperationCandidatePreview, ...],
+    candidate_summaries: list[list[_CandidateTargetSummary]],
+) -> tuple[int, ...]:
+    if not previews or not previews[0].targets:
+        return ()
+
+    common_indexes: list[int] = []
+    for target_index, first_target in enumerate(previews[0].targets):
+        if first_target.resolution_count > 1:
+            continue
+        first_summary = candidate_summaries[0][target_index]
+        first_key = _candidate_summary_key(first_summary)
+        is_common = True
+        for preview, summaries in zip(previews[1:], candidate_summaries[1:]):
+            if target_index >= len(preview.targets):
+                is_common = False
+                break
+            target = preview.targets[target_index]
+            if target.target != first_target.target or target.resolution_count > 1:
+                is_common = False
+                break
+            if _candidate_summary_key(summaries[target_index]) != first_key:
+                is_common = False
+                break
+        if is_common:
+            common_indexes.append(target_index)
+    return tuple(common_indexes)
+
+
+def _print_candidate_summary_block(
+    summary: _CandidateTargetSummary,
+    *,
+    indent: str,
+) -> None:
+    width = _snippet_line_width(summary.lines)
+    for line in summary.lines:
+        print(f"{indent}{_style_candidate_snippet_line(line, width=width)}")
+
+
+def _print_common_candidate_target_blocks(
+    previews: tuple[OperationCandidatePreview, ...],
+    candidate_summaries: list[list[_CandidateTargetSummary]],
+    common_target_indexes: tuple[int, ...],
+) -> None:
+    if not common_target_indexes:
+        return
+
+    first_summaries = candidate_summaries[0]
+    for target_index in common_target_indexes:
+        target = previews[0].targets[target_index]
+        summary = first_summaries[target_index]
+        label = _("Index") if target.target == "index" else _("Working tree")
+        print(
+            _("{target} update, same for all candidates: {summary}").format(
+                target=label,
+                summary=summary.title,
+            )
+        )
+        _print_candidate_summary_block(summary, indent="   ")
+        print()
 
 
 def _render_operation_candidate_overview(
     previews: tuple[OperationCandidatePreview, ...],
     *,
     porcelain: bool,
+    note: str | None = None,
 ) -> tuple[OperationCandidatePreview, ...]:
     first = previews[0]
     candidate_summaries = [
@@ -407,22 +870,14 @@ def _render_operation_candidate_overview(
                             )
                         ),
                         "execute": (
-                            "git-stage-batch {command} --from {selector} --file {file}".format(
-                                command=preview.operation,
-                                selector=_candidate_selector_text(
-                                    preview.batch_name,
-                                    preview.operation,
-                                    preview.ordinal,
-                                ),
-                                file=shlex.quote(preview.file_path),
-                            )
+                            _execute_candidate_command(preview)
                         ),
                     },
                     "targets": [
                         {
                             "target": target.target,
                             "summary": summary.title,
-                            "context": list(summary.lines),
+                            "context": list(_plain_candidate_snippet_lines(summary.lines)),
                         }
                         for target, summary in zip(preview.targets, summaries)
                     ],
@@ -432,53 +887,53 @@ def _render_operation_candidate_overview(
         }, sort_keys=True))
         return previews
 
-    operation = first.operation.capitalize()
+    targets, verb = _candidate_overview_subject(previews)
+    _print_candidate_overview_header(
+        first,
+        note=note,
+    )
     print(
-        _("{operation} candidates for batch '{batch}' in {file}.").format(
-            operation=operation,
-            batch=first.batch_name,
-            file=first.file_path,
+        _("The {targets} {verb} changed in an ambiguous way since this batch was created.").format(
+            targets=targets,
+            verb=verb,
         )
     )
-    print(_("Candidates: {count}").format(count=len(previews)))
-    print(_("No changes applied."))
+    print(
+        _("The batch can be {operation} in more than one way:").format(
+            operation=_candidate_operation_past_tense(first.operation),
+        )
+    )
     print()
 
     shown_previews = previews[:_CANDIDATE_OVERVIEW_MAX_CANDIDATES]
     shown_summaries = candidate_summaries[:_CANDIDATE_OVERVIEW_MAX_CANDIDATES]
+    common_target_indexes = _common_candidate_target_indexes(previews, candidate_summaries)
+
     for preview, summaries in zip(shown_previews, shown_summaries):
-        if len(summaries) == 1:
-            summary = summaries[0]
-            print(f"{preview.ordinal}. {summary.label}: {summary.title}")
-            for line in summary.lines:
-                print(f"   {line}")
+        visible_summaries = [
+            (target, summary)
+            for target_index, (target, summary) in enumerate(zip(preview.targets, summaries))
+            if target_index not in common_target_indexes
+        ]
+        candidate_header = _("Candidate {ordinal}/{count}").format(
+            ordinal=preview.ordinal,
+            count=preview.count,
+        )
+        if len(visible_summaries) == 1:
+            _target, summary = visible_summaries[0]
+            print(f"{candidate_header}   {summary.title}")
+            _print_candidate_summary_block(summary, indent="   ")
         else:
-            print(f"{preview.ordinal}.")
-            for summary in summaries:
-                print(f"   {summary.label}: {summary.title}")
-                for line in summary.lines:
-                    print(f"      {line}")
-        print(
-            "   show: git-stage-batch show --from {selector} --file {file}".format(
-                selector=_candidate_selector_text(
-                    preview.batch_name,
-                    preview.operation,
-                    preview.ordinal,
-                ),
-                file=shlex.quote(preview.file_path),
-            )
-        )
-        print(
-            "   {command}: git-stage-batch {command} --from {selector} --file {file}".format(
-                command=preview.operation,
-                selector=_candidate_selector_text(
-                    preview.batch_name,
-                    preview.operation,
-                    preview.ordinal,
-                ),
-                file=shlex.quote(preview.file_path),
-            )
-        )
+            print(candidate_header)
+            for target, summary in visible_summaries:
+                label = _("Index") if target.target == "index" else _("Working tree")
+                print(f"   {label}: {summary.title}")
+                _print_candidate_summary_block(summary, indent="      ")
+        action = _("Apply") if preview.operation == "apply" else _("Include")
+        print(f"   {_('Preview this candidate:')}")
+        print(f"     {_show_candidate_command(preview, preview.ordinal)}")
+        print(f"   {_('{action} this candidate:').format(action=action)}")
+        print(f"     {_execute_candidate_command(preview)}")
         print()
 
     if len(previews) > len(shown_previews):
@@ -489,6 +944,12 @@ def _render_operation_candidate_overview(
                 selector=_candidate_selector_text(first.batch_name, first.operation),
             )
         )
+        print()
+    _print_common_candidate_target_blocks(
+        previews,
+        candidate_summaries,
+        common_target_indexes,
+    )
     return tuple(shown_previews)
 
 
@@ -496,6 +957,7 @@ def _render_operation_candidate(
     preview: OperationCandidatePreview,
     *,
     porcelain: bool,
+    note: str | None,
 ) -> None:
     if porcelain:
         print(json.dumps({
@@ -524,81 +986,54 @@ def _render_operation_candidate(
         }, sort_keys=True))
         return
 
-    print(
-        _("{operation} candidate {ordinal} of {count} for batch '{batch}'.").format(
-            operation=preview.operation.capitalize(),
-            ordinal=preview.ordinal,
-            count=preview.count,
-            batch=preview.batch_name,
-        ),
-        file=sys.stderr,
-    )
-    print(_("No changes applied."), file=sys.stderr)
-    print("", file=sys.stderr)
-    print(preview.file_path, file=sys.stderr)
-    print(
-        _("Candidate {ordinal} of {count}").format(
-            ordinal=preview.ordinal,
-            count=preview.count,
-        ),
-        file=sys.stderr,
-    )
+    _print_candidate_detail_header(preview, note=note)
 
     context_lines = get_context_lines()
-    for target in preview.targets:
-        if len(preview.targets) > 1:
+    for target_index, target in enumerate(preview.targets):
+        summary = _summarize_candidate_target(target)
+        has_multiple_targets = len(preview.targets) > 1
+        if has_multiple_targets:
+            if target_index > 0:
+                print()
+            target_label = _("Index") if target.target == "index" else _("Working tree")
             print(
-                _("{target} result:").format(
-                    target="Index" if target.target == "index" else "Working-tree"
+                _("{target} update: {summary}").format(
+                    target=target_label,
+                    summary=summary.title,
                 ),
-                file=sys.stderr,
             )
-        if target.summary:
-            print(_("Plan: {summary}").format(summary=target.summary), file=sys.stderr)
-        if target.explanation:
-            print(_("Reason: {reason}").format(reason=target.explanation), file=sys.stderr)
-        diff_text = render_candidate_buffer_diff(
+        else:
+            print(summary.title)
+        _print_candidate_buffer_diff(
             preview.file_path,
             target.before_buffer,
             target.after_buffer,
-            label_before=target.target,
-            label_after=f"{target.target}-candidate",
             context_lines=context_lines,
+            ambiguity_target_line_range=summary.ambiguity_line_range,
+            leading_blank=not has_multiple_targets,
         )
-        if diff_text:
-            print(diff_text, end="" if diff_text.endswith("\n") else "\n")
 
-    print("", file=sys.stderr)
-    execute_command = (
-        "apply" if preview.operation == "apply" else "include"
-    )
+    print()
     action = _("Apply") if preview.operation == "apply" else _("Include")
     print(
-        _("{action} this candidate:\n  git-stage-batch {command} --from {selector} --file {file}").format(
+        _("{action} this candidate:\n  {command}").format(
             action=action,
-            command=execute_command,
-            selector=_candidate_selector_text(
-                preview.batch_name,
-                preview.operation,
-                preview.ordinal,
-            ),
-            file=shlex.quote(preview.file_path),
+            command=_execute_candidate_command(preview),
         ),
-        file=sys.stderr,
     )
-    print("", file=sys.stderr)
-    print(_("Review candidates:"), file=sys.stderr)
+    print()
+    print(_("Review candidates:"))
     print(_("  overview: {command}").format(
         command=_show_candidate_command(preview),
-    ), file=sys.stderr)
+    ))
     if preview.ordinal > 1:
         print(_("  previous: {command}").format(
             command=_show_candidate_command(preview, preview.ordinal - 1),
-        ), file=sys.stderr)
+        ))
     if preview.ordinal < preview.count:
         print(_("  next: {command}").format(
             command=_show_candidate_command(preview, preview.ordinal + 1),
-        ), file=sys.stderr)
+        ))
 
 
 def _resolve_candidate_ordinal(
@@ -892,6 +1327,7 @@ def command_show_from_batch(
                 reviewed_previews = _render_operation_candidate_overview(
                     previews,
                     porcelain=porcelain,
+                    note=metadata.get("note") or None,
                 )
                 for preview in reviewed_previews:
                     save_candidate_preview_state(preview)
@@ -905,6 +1341,7 @@ def command_show_from_batch(
             _render_operation_candidate(
                 preview,
                 porcelain=porcelain,
+                note=metadata.get("note") or None,
             )
             save_candidate_preview_state(preview)
         finally:

--- a/src/git_stage_batch/output/colors.py
+++ b/src/git_stage_batch/output/colors.py
@@ -9,6 +9,7 @@ class Colors:
     """ANSI color codes for terminal output."""
     RESET = "\033[0m"
     BOLD = "\033[1m"
+    REVERSE = "\033[7m"
     RED = "\033[31m"
     GREEN = "\033[32m"
     CYAN = "\033[36m"

--- a/tests/commands/test_candidate_previews.py
+++ b/tests/commands/test_candidate_previews.py
@@ -470,6 +470,7 @@ def test_include_candidate_can_run_from_overview(temp_git_repo, capsys):
 
     captured = capsys.readouterr()
     assert "Included candidate 2 of 2 from batch 'ambiguous'" in captured.err
+    assert "delete target line" not in captured.err
     assert (temp_git_repo / "file.txt").read_text() == "a\ninsert\nx\nmid\nb\n"
     assert not _candidate_state_has_file("ambiguous", "file.txt")
 

--- a/tests/commands/test_candidate_previews.py
+++ b/tests/commands/test_candidate_previews.py
@@ -2,6 +2,7 @@
 
 import json
 import subprocess
+from types import SimpleNamespace
 
 import pytest
 
@@ -58,7 +59,7 @@ def temp_git_repo(tmp_path, monkeypatch):
     return repo
 
 
-def _create_displaced_absence_batch(repo):
+def _create_displaced_absence_batch(repo, note=None):
     (repo / "file.txt").write_text("a\nb\n")
     subprocess.run(["git", "add", "file.txt"], check=True, cwd=repo, capture_output=True)
     subprocess.run(
@@ -68,7 +69,10 @@ def _create_displaced_absence_batch(repo):
         capture_output=True,
     )
     initialize_abort_state()
-    create_batch("ambiguous")
+    if note is None:
+        create_batch("ambiguous")
+    else:
+        create_batch("ambiguous", note)
     add_file_to_batch(
         "ambiguous",
         "file.txt",
@@ -130,15 +134,88 @@ def test_show_candidate_set_lists_context_and_commands(temp_git_repo, capsys):
     command_show_from_batch("ambiguous:apply", file="file.txt")
 
     captured = capsys.readouterr()
-    assert "Apply candidates for batch 'ambiguous' in file.txt." in captured.out
-    assert "Candidates: 2" in captured.out
-    assert '1. Working tree: Remove "x" near "insert"' in captured.out
-    assert '2. Working tree: Remove "x" near "mid"' in captured.out
-    assert "3 -x" in captured.out
-    assert "5 -x" in captured.out
-    assert "show: git-stage-batch show --from ambiguous:apply:1 --file file.txt" in captured.out
-    assert "apply: git-stage-batch apply --from ambiguous:apply:1 --file file.txt" in captured.out
+    assert "file.txt  ·  ambiguous  ·  apply candidates  ·  2 choices" in captured.out
+    assert (
+        "The working tree has changed in an ambiguous way since this batch was created."
+        in captured.out
+    )
+    assert "The batch can be applied in more than one way:" in captured.out
+    assert "Note:" not in captured.out
+    assert 'Candidate 1/2   Remove "x" before "mid"' in captured.out
+    assert 'Candidate 2/2   Remove "x" after "mid"' in captured.out
+    assert "Working tree:" not in captured.out
+    assert "3│ -x" in captured.out
+    assert "5│ -x" in captured.out
+    assert "Preview this candidate:\n     git-stage-batch show --from ambiguous:apply:1 --file file.txt" in captured.out
+    assert "Apply this candidate:\n     git-stage-batch apply --from ambiguous:apply:1 --file file.txt" in captured.out
     assert "Apply candidate 1 of 2 for batch 'ambiguous'." not in captured.err
+
+
+def test_multiline_ambiguous_block_summary_uses_ellipsis():
+    """Candidate summaries should name a multi-line block by its endpoints."""
+    assert show_from_module._summarize_ambiguity_block(
+        ["vanilla extract", "nutmeg"],
+    ) == '"vanilla extract … nutmeg"'
+
+
+def test_candidate_overview_subject_names_only_ambiguous_targets():
+    """The overview prose should mention only targets with multiple resolutions."""
+    preview = SimpleNamespace(
+        targets=(
+            SimpleNamespace(target="index", resolution_count=1),
+            SimpleNamespace(target="worktree", resolution_count=2),
+        ),
+    )
+    assert show_from_module._candidate_overview_subject((preview,)) == (
+        "working tree",
+        "has",
+    )
+
+    preview = SimpleNamespace(
+        targets=(
+            SimpleNamespace(target="index", resolution_count=2),
+            SimpleNamespace(target="worktree", resolution_count=1),
+        ),
+    )
+    assert show_from_module._candidate_overview_subject((preview,)) == (
+        "index",
+        "has",
+    )
+
+    preview = SimpleNamespace(
+        targets=(
+            SimpleNamespace(target="index", resolution_count=2),
+            SimpleNamespace(target="worktree", resolution_count=2),
+        ),
+    )
+    assert show_from_module._candidate_overview_subject((preview,)) == (
+        "working tree and index",
+        "have",
+    )
+
+
+def test_show_candidate_set_highlights_candidate_regions_when_colored(
+    temp_git_repo,
+    capsys,
+    monkeypatch,
+):
+    """Candidate summaries should visually mark the chosen ambiguous region."""
+    _create_displaced_absence_batch(temp_git_repo)
+    monkeypatch.setattr(
+        show_from_module.Colors,
+        "enabled",
+        staticmethod(lambda: True),
+    )
+
+    command_show_from_batch("ambiguous:apply", file="file.txt")
+
+    captured = capsys.readouterr()
+    assert show_from_module.Colors.REVERSE in captured.out
+    assert show_from_module.Colors.GRAY in captured.out
+    assert show_from_module.Colors.RED in captured.out
+    assert f"{show_from_module.Colors.REVERSE}{show_from_module.Colors.RED}" not in captured.out
+    assert f"{show_from_module.Colors.REVERSE}{show_from_module.Colors.GRAY}" in captured.out
+    assert "3│ " in captured.out
 
 
 def test_apply_candidate_can_run_from_overview(temp_git_repo, capsys):
@@ -230,18 +307,94 @@ def test_numbered_show_candidate_records_its_own_preview(temp_git_repo, capsys):
 
     command_show_from_batch("ambiguous:apply:1", file="file.txt")
     first_preview = capsys.readouterr()
-    assert "overview: git-stage-batch show --from ambiguous:apply --file file.txt" in first_preview.err
-    assert "next: git-stage-batch show --from ambiguous:apply:2 --file file.txt" in first_preview.err
+    assert first_preview.out.startswith(
+        "file.txt  ·  ambiguous  ·  apply candidate 1/2\n"
+    )
+    assert "Preview apply candidate 1 of 2 for batch 'ambiguous'." not in first_preview.out
+    assert "Note:" not in first_preview.out
+    assert "No changes applied." not in first_preview.out
+    assert "\nfile.txt\nCandidate 1 of 2\n" not in first_preview.out
+    assert 'Remove "x" before "mid"' in first_preview.out
+    assert "─\nRemove" in first_preview.out
+    assert 'Remove "x" before "mid"\n\nfile.txt ::' in first_preview.out
+    assert "Working tree:" not in first_preview.out
+    assert "Plan: delete target line" not in first_preview.out
+    assert "file.txt :: @@ -1,6 +1,5 @@" in first_preview.out
+    assert "3│ -x" in first_preview.out
+    assert "--- a/file.txt" not in first_preview.out
+    assert "overview: git-stage-batch show --from ambiguous:apply --file file.txt" in first_preview.out
+    assert "next: git-stage-batch show --from ambiguous:apply:2 --file file.txt" in first_preview.out
     command_show_from_batch("ambiguous:apply:2", file="file.txt")
     second_preview = capsys.readouterr()
-    assert "overview: git-stage-batch show --from ambiguous:apply --file file.txt" in second_preview.err
-    assert "previous: git-stage-batch show --from ambiguous:apply:1 --file file.txt" in second_preview.err
+    assert "overview: git-stage-batch show --from ambiguous:apply --file file.txt" in second_preview.out
+    assert "previous: git-stage-batch show --from ambiguous:apply:1 --file file.txt" in second_preview.out
 
     command_apply_from_batch("ambiguous:apply:1", file="file.txt")
 
     captured = capsys.readouterr()
     assert "Applied candidate 1 of 2 from batch 'ambiguous'" in captured.err
     assert (temp_git_repo / "file.txt").read_text() == "a\ninsert\nmid\nx\nb\n"
+
+
+def test_numbered_show_candidate_header_preserves_batch_note(temp_git_repo, capsys):
+    """Numbered candidate previews should keep the same framed header as overview."""
+    _create_displaced_absence_batch(temp_git_repo, note="Auto-created")
+
+    command_show_from_batch("ambiguous:apply:1", file="file.txt")
+
+    captured = capsys.readouterr()
+    assert captured.out.startswith(
+        "file.txt  ·  ambiguous  ·  apply candidate 1/2\n"
+        "Note: Auto-created\n"
+    )
+    assert "Preview apply candidate" not in captured.out
+    assert "─\nRemove" in captured.out
+
+
+def test_numbered_show_candidate_keeps_diff_colors_when_colored(
+    temp_git_repo,
+    capsys,
+    monkeypatch,
+):
+    """Candidate diffs should use normal red/green diff colors."""
+    _create_displaced_absence_batch(temp_git_repo)
+    monkeypatch.setattr(
+        show_from_module.Colors,
+        "enabled",
+        staticmethod(lambda: True),
+    )
+
+    command_show_from_batch("ambiguous:apply:1", file="file.txt")
+
+    captured = capsys.readouterr()
+    assert show_from_module.Colors.REVERSE in captured.out
+    assert show_from_module.Colors.RED in captured.out
+    assert f"{show_from_module.Colors.REVERSE}{show_from_module.Colors.RED}" not in captured.out
+    assert f"{show_from_module.Colors.REVERSE}{show_from_module.Colors.GRAY}" in captured.out
+
+
+def test_numbered_include_candidate_separates_target_sections(
+    temp_git_repo,
+    capsys,
+):
+    """Numbered include previews should not duplicate target labels."""
+    _create_displaced_absence_batch(temp_git_repo)
+
+    command_show_from_batch("ambiguous:include:2", file="file.txt")
+
+    captured = capsys.readouterr()
+    assert captured.out.startswith(
+        "file.txt  ·  ambiguous  ·  include candidate 2/2\n"
+    )
+    assert "Preview include candidate" not in captured.out
+    assert "Index update: No text changes\n\nWorking tree update: Remove" in captured.out
+    assert "Working tree update:\nRemove" not in captured.out
+    assert "Working tree update: Remove" in captured.out
+    assert "\n\n\nWorking tree update:" not in captured.out
+    assert "Index result:" not in captured.out
+    assert "Working-tree result:" not in captured.out
+    assert "Index: Remove" not in captured.out
+    assert "Working tree: Remove" not in captured.out
 
 
 def test_apply_candidate_rejects_changed_materialized_result(
@@ -296,7 +449,20 @@ def test_include_candidate_can_run_from_overview(temp_git_repo, capsys):
 
     command_show_from_batch("ambiguous:include", file="file.txt")
     overview = capsys.readouterr()
-    assert "include: git-stage-batch include --from ambiguous:include:2 --file file.txt" in overview.out
+    assert "file.txt  ·  ambiguous  ·  include candidates  ·  2 choices" in overview.out
+    assert (
+        "The working tree has changed in an ambiguous way since this batch was created."
+        in overview.out
+    )
+    assert "The batch can be included in more than one way:" in overview.out
+    assert "Note:" not in overview.out
+    assert "Index update, same for all candidates:" in overview.out
+    assert 'Candidate 1/2   Remove "x" before "mid"' in overview.out
+    assert 'Candidate 2/2   Remove "x" after "mid"' in overview.out
+    assert overview.out.index("Candidate 1/2") < overview.out.index("Index update")
+    assert "Candidate 1/2   Working tree:" not in overview.out
+    assert "Candidate 2/2   Working tree:" not in overview.out
+    assert "Include this candidate:\n     git-stage-batch include --from ambiguous:include:2 --file file.txt" in overview.out
     assert _candidate_state_has_file("ambiguous", "file.txt")
 
     command_include_from_batch("ambiguous:include:2", file="file.txt")

--- a/tests/commands/test_candidate_previews.py
+++ b/tests/commands/test_candidate_previews.py
@@ -230,6 +230,7 @@ def test_apply_candidate_can_run_from_overview(temp_git_repo, capsys):
 
     captured = capsys.readouterr()
     assert "Applied candidate 1 of 2 from batch 'ambiguous'" in captured.err
+    assert "delete target line" not in captured.err
     assert (temp_git_repo / "file.txt").read_text() == "a\ninsert\nmid\nx\nb\n"
     assert not _candidate_state_has_file("ambiguous", "file.txt")
 


### PR DESCRIPTION
Candidate preview plumbing already enumerates possible apply and include
resolutions and requires users to review a candidate before execution.

Users deciding between ambiguous placements need to understand which
unchanged block makes those placements differ. The previous candidate views
exposed internal target-line summaries, uncolored diffs, inconsistent headers,
and repeated target labels, making that comparison harder than the normal
batch review flow.

This PR addresses that by carrying ambiguity spans through merge candidates
and rendering candidate overview and detail views with the batch-review frame,
red and green diff color, reverse-gray ambiguity context, concise placement
titles, and operation-specific prose.

It also trims apply and include execution status so those commands confirm the
affected targets instead of repeating internal merge summaries after the user
has selected a candidate.

Validation:

- `PYTHONPATH=src uv run pytest tests/batch/test_merge.py tests/commands/test_candidate_previews.py tests/commands/test_show_from.py`
- `PYTHONPATH=src uv run ruff check src/git_stage_batch/batch/merge.py src/git_stage_batch/batch/operation_candidates.py src/git_stage_batch/commands/show_from.py src/git_stage_batch/commands/apply_from.py src/git_stage_batch/commands/include_from.py src/git_stage_batch/output/colors.py tests/commands/test_candidate_previews.py`
