### PR TITLE
cli: Report Git startup failures without tracebacks

### DIFF
--- a/src/git_stage_batch/cli/main.py
+++ b/src/git_stage_batch/cli/main.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import subprocess
 import sys
 from contextlib import nullcontext
 
@@ -38,6 +39,19 @@ def main() -> None:
         if e.message:
             print(e.message, file=sys.stderr)
         sys.exit(e.exit_code)
+    except subprocess.CalledProcessError as e:
+        if e.stderr:
+            print(e.stderr.rstrip(), file=sys.stderr)
+        else:
+            command = " ".join(e.cmd) if isinstance(e.cmd, list) else str(e.cmd)
+            print(
+                _("Command failed with exit status {status}: {command}").format(
+                    status=e.returncode,
+                    command=command,
+                ),
+                file=sys.stderr,
+            )
+        sys.exit(e.returncode)
     except KeyboardInterrupt:
         print(_("Interrupted."), file=sys.stderr)
         sys.exit(130)


### PR DESCRIPTION
The CLI entry point already handles command-level failures and keyboard interrupts at the top level.

Git failures that happen while preparing shared session state occur before command dispatch. Users see a Python traceback instead of Git's fatal message when startup cannot resolve repository state.

This PR addresses that by catching subprocess.CalledProcessError at the CLI boundary, printing Git stderr when available, and exiting with the underlying status.

A follow-up PR will add a regression test for Git failures raised before dispatch begins.