### PR TITLE
project: Tune release tweet threads for X ranking

### DIFF
--- a/.claude/skills/release-tweet-thread/SKILL.md
+++ b/.claude/skills/release-tweet-thread/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: release-tweet-thread
-description: Draft a copy-paste tweet thread announcing the latest release.
+description: Draft an algorithm-optimized tweet thread announcing the latest release.
 whenToUse: Use this when the user wants to announce a release on X/Twitter or draft social media posts about a release.
 allowed-tools: Bash(git *), Bash(gh *), Read
 user-invocable: true
 ---
 
-Your task is to draft a tweet thread announcing the latest release of this project.
+Your task is to draft a tweet thread announcing the latest release of this project,
+optimized for the X recommendation algorithm's ranking signals.
 
 ## Workflow
 
@@ -19,11 +20,11 @@ Your task is to draft a tweet thread announcing the latest release of this proje
 
 Write 2-4 tweets. Each tweet must be under 280 characters.
 
-**Tweet 1:** Lead with the release announcement. Mention the project name, version, and the single most compelling change. Include a link to the GitHub release page.
+**Tweet 1 (hook):** Lead with a concrete before/after or a surprising result — something that makes people stop scrolling (dwell time is a ranking signal). Mention the project name and version. Include a link to the GitHub release page.
 
-**Tweet 2-3:** One highlight per tweet. Keep them concrete — what can users do now that they could not before? Avoid jargon. Use short sentences.
+**Tweet 2-3 (highlights):** One highlight per tweet. Keep them concrete — what can users do now that they could not before? Avoid jargon. Use short sentences. Where possible, suggest including a short demo video or screenshot — media activates dedicated ranking signals (video quality views, photo expand) that plain text does not.
 
-**Tweet 4 (optional):** Call to action — install command (`pip install git-stage-batch`), link to docs, or invitation to try it.
+**Final tweet (engagement close):** End with a genuine question that invites replies — reply probability is one of the highest-weighted ranking signals. Good patterns: ask what feature users want next, ask about their current workflow pain point, or pose a "how do you handle X?" question. Pair with a low-friction call to action (install command, link to docs).
 
 ## Output format
 
@@ -39,9 +40,14 @@ Present each tweet in a clearly numbered, copy-paste-ready block. Use a visual s
 
 After the thread, show the character count for each tweet so the user can verify they fit.
 
+If any tweet would benefit from an attached image or video, note that below the thread with a brief description of what to capture (e.g., "Attach: 15-second terminal recording of the new `--hierarchical` flag").
+
 ## Guidelines
 
 - Do not use hashtags unless the user asks for them.
 - Do not use emoji unless the user asks for them.
 - Write in a direct, conversational tone — not marketing speak.
 - If the release is small (one fix, one feature), two tweets are enough. Do not pad.
+- Keep the thread short. The algorithm applies author diversity decay — each additional tweet from the same author in a feed session scores lower than the previous one. A tight 2-3 tweet thread outperforms a padded 5-tweet thread.
+- Write for shareability. Tweets that get reposted, bookmarked, or shared via DM each activate separate weighted ranking signals. Practical tips and concrete results are more shareable than vague announcements.
+- Avoid anything that could trigger mute/block/not-interested signals — no clickbait, no "like and repost" begging, no generic filler.


### PR DESCRIPTION
The release tweet thread skill drafts copy-paste social posts from the latest GitHub release and the commits behind it.

Users announcing releases on X need posts that fit how the platform ranks replies, media interactions, dwell time, and sharing signals. A plain release summary can miss those signals even when the release notes are accurate.

This commit addresses that by steering the skill toward hook-driven openings, media suggestions, reply-focused closing questions, shorter threads, and guidance that avoids low-quality engagement patterns.