### PR TITLE
block-file: Add --local-only, directory support, and negation unblocking

### DIFF
--- a/man/git-stage-batch-block-file.1.in
+++ b/man/git-stage-batch-block-file.1.in
@@ -1,18 +1,25 @@
 .TH GIT-STAGE-BATCH-BLOCK-FILE 1 "May 2026" "git-stage-batch @VERSION@" "User Commands"
 .SH NAME
-git-stage-batch-block-file \- permanently exclude a file from reviews
+git-stage-batch-block-file \- permanently exclude a file or directory from reviews
 .SH SYNOPSIS
 .B git-stage-batch block-file
 [\fB\-\-local\-only\fR]
 [\fIPATH\fR]
 .SH DESCRIPTION
 .B block-file
-adds a file to
+adds a file or directory to
 .BR .gitignore ,
-records it in session state, and skips all of its hunks automatically in
+records it in session state, and skips all matching hunks automatically in
 future sessions. If
 .I PATH
 is omitted, the selected hunk's file is used.
+.PP
+When
+.I PATH
+refers to a directory, it is stored with a trailing slash so that all files
+under that directory are suppressed. A bare name such as
+.B build
+is treated as a directory if one exists on disk at that path.
 .SH OPTIONS
 .TP
 .B \-\-local\-only

--- a/man/git-stage-batch-block-file.1.in
+++ b/man/git-stage-batch-block-file.1.in
@@ -3,6 +3,7 @@
 git-stage-batch-block-file \- permanently exclude a file from reviews
 .SH SYNOPSIS
 .B git-stage-batch block-file
+[\fB\-\-local\-only\fR]
 [\fIPATH\fR]
 .SH DESCRIPTION
 .B block-file
@@ -12,6 +13,14 @@ records it in session state, and skips all of its hunks automatically in
 future sessions. If
 .I PATH
 is omitted, the selected hunk's file is used.
+.SH OPTIONS
+.TP
+.B \-\-local\-only
+Write the ignore entry to
+.B .git/info/exclude
+instead of
+.BR .gitignore .
+The entry is kept out of the repository and never committed.
 .SH SEE ALSO
 .BR git-stage-batch (1),
 .BR git-stage-batch-unblock-file (1)

--- a/man/git-stage-batch-unblock-file.1.in
+++ b/man/git-stage-batch-unblock-file.1.in
@@ -8,8 +8,11 @@ git-stage-batch-unblock-file \- allow a blocked file to be reviewed again
 .B unblock-file
 removes
 .I PATH
-from the block list and removes the matching ignore entry so its hunks can be
-processed again.
+from the block list and removes the matching ignore entry from
+.B .gitignore
+and
+.B .git/info/exclude
+so its hunks can be processed again.
 .SH SEE ALSO
 .BR git-stage-batch (1),
 .BR git-stage-batch-block-file (1)

--- a/man/git-stage-batch-unblock-file.1.in
+++ b/man/git-stage-batch-unblock-file.1.in
@@ -13,6 +13,20 @@ from the block list and removes the matching ignore entry from
 and
 .B .git/info/exclude
 so its hunks can be processed again.
+.PP
+When
+.I PATH
+is not listed directly but is covered by a blocked directory entry such as
+.BR build/ ,
+.B unblock-file
+instead promotes that entry to
+.B build/**
+and appends
+.B !PATH
+as a negation. The
+.B build/**
+form leaves the directory node unexcluded so git honours the negation,
+while all other files in the directory remain ignored.
 .SH SEE ALSO
 .BR git-stage-batch (1),
 .BR git-stage-batch-block-file (1)

--- a/src/git_stage_batch/cli/argument_parser.py
+++ b/src/git_stage_batch/cli/argument_parser.py
@@ -1318,7 +1318,13 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
         default="",
         help=_("Path to the file to block (defaults to selected hunk's file)"),
     )
-    parser_block_file.set_defaults(func=lambda args: commands.command_block_file(args.file_path))
+    parser_block_file.add_argument(
+        "--local-only",
+        action="store_true",
+        default=False,
+        help=_("Add to .git/info/exclude instead of .gitignore"),
+    )
+    parser_block_file.set_defaults(func=lambda args: commands.command_block_file(args.file_path, local_only=args.local_only))
 
     # unblock-file - Remove a file from blocked list
     parser_unblock_file = _add_subcommand_parser(

--- a/src/git_stage_batch/commands/block_file.py
+++ b/src/git_stage_batch/commands/block_file.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sys
 from contextlib import nullcontext
+from pathlib import Path
 
 from ..data.hunk_tracking import advance_to_and_show_next_change
 from ..data.undo import undo_checkpoint
@@ -51,8 +52,10 @@ def command_block_file(file_path_arg: str = "", local_only: bool = False) -> Non
             exit_with_error(_("No selected hunk. Run 'show' first or specify file path."))
         file_path_arg = line_changes.path
 
-    # Resolve to repo-relative path
+    # Resolve to repo-relative path, normalizing directories to a trailing slash
     file_path = resolve_file_path_to_repo_relative(file_path_arg)
+    if file_path_arg.endswith("/") or Path(file_path_arg).is_dir():
+        file_path = file_path.rstrip("/") + "/"
     session_active = get_abort_head_file_path().exists()
     checkpoint_paths = [] if local_only else [".gitignore"]
     checkpoint = (
@@ -68,7 +71,7 @@ def command_block_file(file_path_arg: str = "", local_only: bool = False) -> Non
             add_file_to_gitignore(file_path)
 
         # Remove from index if session is active and the file is a new intent-to-add entry
-        if session_active and _is_new_intent_to_add_file(file_path):
+        if session_active and not file_path.endswith("/") and _is_new_intent_to_add_file(file_path):
             git_remove_paths([file_path], cached=True, quiet=True, ignore_unmatch=True, check=False)
             remove_file_path_from_file(get_auto_added_files_file_path(), file_path)
 

--- a/src/git_stage_batch/commands/block_file.py
+++ b/src/git_stage_batch/commands/block_file.py
@@ -11,6 +11,7 @@ from ..exceptions import NoMoreHunks, exit_with_error
 from ..i18n import _
 from ..utils.file_io import append_file_path_to_file, remove_file_path_from_file
 from ..utils.git import (
+    add_file_to_local_exclude,
     add_file_to_gitignore,
     git_remove_paths,
     require_git_repository,
@@ -38,7 +39,7 @@ def _is_new_intent_to_add_file(file_path: str) -> bool:
     return head_check.returncode != 0
 
 
-def command_block_file(file_path_arg: str = "") -> None:
+def command_block_file(file_path_arg: str = "", local_only: bool = False) -> None:
     """Permanently exclude a file by adding it to .gitignore and blocked list."""
     require_git_repository()
     ensure_state_directory_exists()
@@ -53,14 +54,18 @@ def command_block_file(file_path_arg: str = "") -> None:
     # Resolve to repo-relative path
     file_path = resolve_file_path_to_repo_relative(file_path_arg)
     session_active = get_abort_head_file_path().exists()
+    checkpoint_paths = [] if local_only else [".gitignore"]
     checkpoint = (
-        undo_checkpoint(f"block-file {file_path}", worktree_paths=[".gitignore"])
+        undo_checkpoint(f"block-file {file_path}", worktree_paths=checkpoint_paths)
         if session_active else nullcontext()
     )
 
     with checkpoint:
-        # Add to .gitignore
-        add_file_to_gitignore(file_path)
+        # Add to .git/info/exclude or .gitignore
+        if local_only:
+            add_file_to_local_exclude(file_path)
+        else:
+            add_file_to_gitignore(file_path)
 
         # Remove from index if session is active and the file is a new intent-to-add entry
         if session_active and _is_new_intent_to_add_file(file_path):

--- a/src/git_stage_batch/commands/status.py
+++ b/src/git_stage_batch/commands/status.py
@@ -43,6 +43,7 @@ from ..exceptions import CommandError
 from ..i18n import _
 from ..utils.file_io import (
     count_nonblank_text_file_lines,
+    is_path_blocked,
     stream_text_file_lines,
     read_file_paths_file,
     read_text_file_line_set,
@@ -124,7 +125,7 @@ def estimate_remaining_hunks() -> int:
                     file_path = patch.old_path if patch.old_path != "/dev/null" else patch.new_path
                 file_path = file_path.removeprefix("a/").removeprefix("b/")
 
-                if hunk_hash not in blocked_hashes and file_path not in blocked_files:
+                if hunk_hash not in blocked_hashes and not is_path_blocked(file_path, blocked_files):
                     remaining += 1
     except Exception:
         return 0

--- a/src/git_stage_batch/commands/unblock_file.py
+++ b/src/git_stage_batch/commands/unblock_file.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sys
 from contextlib import nullcontext
+from pathlib import Path
 
 from ..data.hunk_tracking import advance_to_and_show_next_change
 from ..data.undo import undo_checkpoint
@@ -41,8 +42,10 @@ def command_unblock_file(file_path_arg: str) -> None:
     if not file_path_arg:
         exit_with_error(_("File path required for unblock-file command."))
 
-    # Resolve to repo-relative path
+    # Resolve to repo-relative path, normalizing directories to a trailing slash
     file_path = resolve_file_path_to_repo_relative(file_path_arg)
+    if file_path_arg.endswith("/") or Path(file_path_arg).is_dir():
+        file_path = file_path.rstrip("/") + "/"
     session_active = get_abort_head_file_path().exists()
     checkpoint = (
         undo_checkpoint(f"unblock-file {file_path}", worktree_paths=[".gitignore"])
@@ -58,7 +61,7 @@ def command_unblock_file(file_path_arg: str) -> None:
         remove_file_path_from_file(get_blocked_files_file_path(), file_path)
 
         # Re-add new untracked files as intent-to-add if session is active
-        if session_active and _is_absent_from_head(file_path) and _is_absent_from_index(file_path):
+        if session_active and not file_path.endswith("/") and _is_absent_from_head(file_path) and _is_absent_from_index(file_path):
             result = git_add_paths([file_path], intent_to_add=True, check=False)
             if result.returncode == 0:
                 append_file_path_to_file(get_auto_added_files_file_path(), file_path)

--- a/src/git_stage_batch/commands/unblock_file.py
+++ b/src/git_stage_batch/commands/unblock_file.py
@@ -10,9 +10,13 @@ from ..data.hunk_tracking import advance_to_and_show_next_change
 from ..data.undo import undo_checkpoint
 from ..exceptions import NoMoreHunks, exit_with_error
 from ..i18n import _
-from ..utils.file_io import append_file_path_to_file, remove_file_path_from_file
+from ..utils.file_io import append_file_path_to_file, read_file_paths_file, remove_file_path_from_file
 from ..utils.git import (
+    add_file_to_gitignore,
+    add_file_to_local_exclude,
     git_add_paths,
+    promote_directory_to_glob_in_gitignore,
+    promote_directory_to_glob_in_local_exclude,
     remove_file_from_gitignore,
     remove_file_from_local_exclude,
     require_git_repository,
@@ -20,6 +24,14 @@ from ..utils.git import (
     run_git_command,
 )
 from ..utils.paths import ensure_state_directory_exists, get_abort_head_file_path, get_auto_added_files_file_path, get_blocked_files_file_path
+
+
+def _find_covering_directory(path: str, blocked_files: list[str]) -> str | None:
+    """Return the blocked directory entry that covers path, or None."""
+    for entry in blocked_files:
+        if entry.endswith("/") and path.startswith(entry):
+            return entry
+    return None
 
 
 def _is_absent_from_head(file_path: str) -> bool:
@@ -53,12 +65,28 @@ def command_unblock_file(file_path_arg: str) -> None:
     )
 
     with checkpoint:
-        # Remove from .gitignore and .git/info/exclude
+        # Try direct removal first
         removed_from_gitignore = remove_file_from_gitignore(file_path)
         removed_from_local_exclude = remove_file_from_local_exclude(file_path)
 
-        # Remove from blocked-files state
-        remove_file_path_from_file(get_blocked_files_file_path(), file_path)
+        blocked_files = read_file_paths_file(get_blocked_files_file_path())
+        directly_blocked = file_path in blocked_files
+        if directly_blocked:
+            remove_file_path_from_file(get_blocked_files_file_path(), file_path)
+
+        # If not found directly, check whether a directory entry covers this path.
+        # If so, promote dir/ to dir/** in the ignore file(s) and append a negation
+        # so git re-includes this specific file while still ignoring the rest.
+        if not removed_from_gitignore and not removed_from_local_exclude and not directly_blocked:
+            covering_dir = _find_covering_directory(file_path, blocked_files)
+            if covering_dir is not None:
+                if promote_directory_to_glob_in_gitignore(covering_dir):
+                    add_file_to_gitignore(f"!{file_path}")
+                    removed_from_gitignore = True
+                if promote_directory_to_glob_in_local_exclude(covering_dir):
+                    add_file_to_local_exclude(f"!{file_path}")
+                    removed_from_local_exclude = True
+                append_file_path_to_file(get_blocked_files_file_path(), f"!{file_path}")
 
         # Re-add new untracked files as intent-to-add if session is active
         if session_active and not file_path.endswith("/") and _is_absent_from_head(file_path) and _is_absent_from_index(file_path):

--- a/src/git_stage_batch/commands/unblock_file.py
+++ b/src/git_stage_batch/commands/unblock_file.py
@@ -13,6 +13,7 @@ from ..utils.file_io import append_file_path_to_file, remove_file_path_from_file
 from ..utils.git import (
     git_add_paths,
     remove_file_from_gitignore,
+    remove_file_from_local_exclude,
     require_git_repository,
     resolve_file_path_to_repo_relative,
     run_git_command,
@@ -49,8 +50,9 @@ def command_unblock_file(file_path_arg: str) -> None:
     )
 
     with checkpoint:
-        # Remove from .gitignore
+        # Remove from .gitignore and .git/info/exclude
         removed_from_gitignore = remove_file_from_gitignore(file_path)
+        removed_from_local_exclude = remove_file_from_local_exclude(file_path)
 
         # Remove from blocked-files state
         remove_file_path_from_file(get_blocked_files_file_path(), file_path)
@@ -61,7 +63,7 @@ def command_unblock_file(file_path_arg: str) -> None:
             if result.returncode == 0:
                 append_file_path_to_file(get_auto_added_files_file_path(), file_path)
 
-    if removed_from_gitignore:
+    if removed_from_gitignore or removed_from_local_exclude:
         print(f"Unblocked file: {file_path}", file=sys.stderr)
     else:
         print(f"Removed from blocked list: {file_path} (was not in .gitignore)", file=sys.stderr)

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -62,6 +62,7 @@ from .consumed_selections import read_consumed_file_metadata
 from .auto_advance import resolve_auto_advance
 from .file_tracking import auto_add_untracked_files
 from ..utils.file_io import (
+    is_path_blocked,
     read_file_paths_file,
     read_text_file_line_set,
     read_text_file_contents,
@@ -1825,7 +1826,7 @@ def fetch_next_change() -> Union[LineLevelChange, BinaryFileChange, GitlinkChang
                     if gitlink_hash in blocked_hashes:
                         continue
 
-                    if item.path() in blocked_files:
+                    if is_path_blocked(item.path(), blocked_files):
                         continue
 
                     cache_gitlink_change(item)
@@ -1839,7 +1840,7 @@ def fetch_next_change() -> Union[LineLevelChange, BinaryFileChange, GitlinkChang
 
                     # Determine file path for blocked files check
                     file_path = item.new_path if item.new_path != "/dev/null" else item.old_path
-                    if file_path in blocked_files:
+                    if is_path_blocked(file_path, blocked_files):
                         continue
 
                     cache_binary_file_change(item)
@@ -1857,7 +1858,7 @@ def fetch_next_change() -> Union[LineLevelChange, BinaryFileChange, GitlinkChang
                     item.lines,
                     annotator=annotate_with_batch_source,
                 )
-                if line_changes.path in blocked_files:
+                if is_path_blocked(line_changes.path, blocked_files):
                     continue
 
                 write_selected_hunk_patch_lines(item.lines)

--- a/src/git_stage_batch/utils/file_io.py
+++ b/src/git_stage_batch/utils/file_io.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Collection
 from pathlib import Path
 from typing import Iterable
 
@@ -113,6 +114,17 @@ def append_file_path_to_file(path: Path, file_path: str) -> None:
     if file_path not in existing_paths:
         existing_paths.append(file_path)
         write_file_paths_file(path, existing_paths)
+
+
+def is_path_blocked(path: str, blocked_files: Collection[str]) -> bool:
+    """Return True when path is covered by the blocked-files list.
+
+    An entry covers path if it equals path exactly, or if the entry ends
+    with '/' and path starts with that prefix (directory match).
+    """
+    if path in blocked_files:
+        return True
+    return any(path.startswith(entry) for entry in blocked_files if entry.endswith("/"))
 
 
 def remove_file_path_from_file(state_file_path: Path, file_path: str) -> None:

--- a/src/git_stage_batch/utils/file_io.py
+++ b/src/git_stage_batch/utils/file_io.py
@@ -119,9 +119,12 @@ def append_file_path_to_file(path: Path, file_path: str) -> None:
 def is_path_blocked(path: str, blocked_files: Collection[str]) -> bool:
     """Return True when path is covered by the blocked-files list.
 
+    A negation entry (!path) takes precedence over all other entries.
     An entry covers path if it equals path exactly, or if the entry ends
     with '/' and path starts with that prefix (directory match).
     """
+    if f"!{path}" in blocked_files:
+        return False
     if path in blocked_files:
         return True
     return any(path.startswith(entry) for entry in blocked_files if entry.endswith("/"))

--- a/src/git_stage_batch/utils/git.py
+++ b/src/git_stage_batch/utils/git.py
@@ -859,6 +859,15 @@ def get_gitignore_path() -> Path:
     return get_git_repository_root_path() / ".gitignore"
 
 
+def get_local_exclude_path() -> Path:
+    """Get the path to the repository's .git/info/exclude file.
+
+    Returns:
+        Path to .git/info/exclude
+    """
+    return get_git_directory_path() / "info" / "exclude"
+
+
 def read_gitignore_lines() -> list[str]:
     """Read .gitignore file, returning lines preserving original formatting.
 
@@ -931,5 +940,64 @@ def remove_file_from_gitignore(file_path: str) -> bool:
 
     if removed:
         write_gitignore_lines(lines)
+
+    return removed
+
+
+def add_file_to_local_exclude(file_path: str) -> None:
+    """Add a file path to .git/info/exclude.
+
+    Args:
+        file_path: File path to add
+    """
+    exclude_path = get_local_exclude_path()
+    exclude_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if exclude_path.exists():
+        content = read_text_file_contents(exclude_path)
+        lines = content.splitlines(keepends=True)
+    else:
+        lines = []
+
+    file_path_normalized = file_path.rstrip("\n")
+    for line in lines:
+        if line.rstrip("\n") == file_path_normalized:
+            return  # Already present
+
+    if lines and not lines[-1].endswith("\n"):
+        lines[-1] += "\n"
+
+    lines.append(f"{file_path}\n")
+    write_text_file_contents(exclude_path, "".join(lines))
+
+
+def remove_file_from_local_exclude(file_path: str) -> bool:
+    """Remove a file path from .git/info/exclude.
+
+    Args:
+        file_path: File path to remove
+
+    Returns:
+        True if removed, False if not found
+    """
+    exclude_path = get_local_exclude_path()
+    if not exclude_path.exists():
+        return False
+
+    content = read_text_file_contents(exclude_path)
+    lines = content.splitlines(keepends=True)
+    file_path_normalized = file_path.rstrip("\n")
+
+    i = 0
+    removed = False
+    while i < len(lines):
+        if lines[i].rstrip("\n") == file_path_normalized:
+            del lines[i]
+            removed = True
+            continue
+        i += 1
+
+    if removed:
+        write_text_file_contents(exclude_path, "".join(lines))
 
     return removed

--- a/src/git_stage_batch/utils/git.py
+++ b/src/git_stage_batch/utils/git.py
@@ -1001,3 +1001,56 @@ def remove_file_from_local_exclude(file_path: str) -> bool:
         write_text_file_contents(exclude_path, "".join(lines))
 
     return removed
+
+
+def promote_directory_to_glob_in_gitignore(dir_path: str) -> bool:
+    """Replace a dir/ entry with dir/** in .gitignore, enabling negation patterns.
+
+    Returns True when dir/ or dir/** is present (so negation will take effect),
+    False when the directory has no entry in .gitignore.
+    """
+    lines = read_gitignore_lines()
+    dir_entry = dir_path.rstrip("/") + "/"
+    glob_entry = dir_path.rstrip("/") + "/**"
+
+    if any(line.rstrip("\n") == glob_entry for line in lines):
+        return True  # Already promoted
+
+    found = False
+    for i, line in enumerate(lines):
+        if line.rstrip("\n") == dir_entry:
+            lines[i] = glob_entry + ("\n" if line.endswith("\n") else "")
+            found = True
+
+    if found:
+        write_gitignore_lines(lines)
+    return found
+
+
+def promote_directory_to_glob_in_local_exclude(dir_path: str) -> bool:
+    """Replace a dir/ entry with dir/** in .git/info/exclude, enabling negation patterns.
+
+    Returns True when dir/ or dir/** is present (so negation will take effect),
+    False when the directory has no entry in .git/info/exclude.
+    """
+    exclude_path = get_local_exclude_path()
+    if not exclude_path.exists():
+        return False
+
+    content = read_text_file_contents(exclude_path)
+    lines = content.splitlines(keepends=True)
+    dir_entry = dir_path.rstrip("/") + "/"
+    glob_entry = dir_path.rstrip("/") + "/**"
+
+    if any(line.rstrip("\n") == glob_entry for line in lines):
+        return True  # Already promoted
+
+    found = False
+    for i, line in enumerate(lines):
+        if line.rstrip("\n") == dir_entry:
+            lines[i] = glob_entry + ("\n" if line.endswith("\n") else "")
+            found = True
+
+    if found:
+        write_text_file_contents(exclude_path, "".join(lines))
+    return found

--- a/tests/commands/test_block_file.py
+++ b/tests/commands/test_block_file.py
@@ -223,3 +223,48 @@ class TestCommandBlockFile:
 
         exclude = get_local_exclude_path()
         assert exclude.read_text().count("dup.txt") == 1
+
+    def test_block_file_directory_with_trailing_slash(self, temp_git_repo):
+        """Test that a directory argument with trailing slash is stored as dir/."""
+        subdir = temp_git_repo / "build"
+        subdir.mkdir()
+        (subdir / "output.o").write_text("binary\n")
+
+        command_block_file("build/")
+
+        blocked = read_file_paths_file(get_blocked_files_file_path())
+        assert "build/" in blocked
+
+        gitignore = get_gitignore_path()
+        assert "build/\n" in gitignore.read_text()
+
+    def test_block_file_directory_without_trailing_slash(self, temp_git_repo):
+        """Test that a bare directory name is normalized to dir/ form."""
+        subdir = temp_git_repo / "dist"
+        subdir.mkdir()
+        (subdir / "bundle.js").write_text("code\n")
+
+        command_block_file("dist")
+
+        blocked = read_file_paths_file(get_blocked_files_file_path())
+        assert "dist/" in blocked
+        assert "dist" not in blocked
+
+    def test_block_file_directory_prefix_match(self, temp_git_repo):
+        """Test that blocking a directory suppresses files under it during a session."""
+        from git_stage_batch.commands.start import command_start
+        from git_stage_batch.utils.file_io import is_path_blocked
+
+        subdir = temp_git_repo / "generated"
+        subdir.mkdir()
+        (subdir / "foo.c").write_text("code\n")
+        (subdir / "bar.c").write_text("code\n")
+
+        command_start()
+        command_block_file("generated/")
+
+        blocked = read_file_paths_file(get_blocked_files_file_path())
+        blocked_set = set(blocked)
+        assert is_path_blocked("generated/foo.c", blocked_set)
+        assert is_path_blocked("generated/bar.c", blocked_set)
+        assert not is_path_blocked("other.c", blocked_set)

--- a/tests/commands/test_block_file.py
+++ b/tests/commands/test_block_file.py
@@ -7,7 +7,7 @@ import pytest
 from git_stage_batch.commands.block_file import command_block_file
 from git_stage_batch.exceptions import CommandError
 from git_stage_batch.utils.file_io import read_file_paths_file
-from git_stage_batch.utils.git import get_gitignore_path
+from git_stage_batch.utils.git import get_gitignore_path, get_local_exclude_path
 from git_stage_batch.utils.paths import get_blocked_files_file_path
 
 
@@ -188,3 +188,38 @@ class TestCommandBlockFile:
         gitignore = get_gitignore_path()
         content = gitignore.read_text()
         assert "src/file.txt\n" in content
+
+    def test_block_file_local_only_adds_to_exclude(self, temp_git_repo, capsys):
+        """Test that --local-only adds file to .git/info/exclude, not .gitignore."""
+        (temp_git_repo / "local.txt").write_text("local content\n")
+
+        command_block_file("local.txt", local_only=True)
+
+        exclude = get_local_exclude_path()
+        assert exclude.exists()
+        assert "local.txt\n" in exclude.read_text()
+
+        gitignore = get_gitignore_path()
+        assert not gitignore.exists() or "local.txt" not in gitignore.read_text()
+
+        captured = capsys.readouterr()
+        assert "Blocked file: local.txt" in captured.err
+
+    def test_block_file_local_only_adds_to_blocked_list(self, temp_git_repo):
+        """Test that --local-only still adds file to the blocked list."""
+        (temp_git_repo / "local.txt").write_text("local content\n")
+
+        command_block_file("local.txt", local_only=True)
+
+        blocked = read_file_paths_file(get_blocked_files_file_path())
+        assert "local.txt" in blocked
+
+    def test_block_file_local_only_no_duplicates_in_exclude(self, temp_git_repo):
+        """Test that --local-only blocking the same file twice doesn't duplicate entries."""
+        (temp_git_repo / "dup.txt").write_text("content\n")
+
+        command_block_file("dup.txt", local_only=True)
+        command_block_file("dup.txt", local_only=True)
+
+        exclude = get_local_exclude_path()
+        assert exclude.read_text().count("dup.txt") == 1

--- a/tests/commands/test_unblock_file.py
+++ b/tests/commands/test_unblock_file.py
@@ -8,7 +8,7 @@ from git_stage_batch.commands.block_file import command_block_file
 from git_stage_batch.commands.unblock_file import command_unblock_file
 from git_stage_batch.exceptions import CommandError
 from git_stage_batch.utils.file_io import append_file_path_to_file, read_file_paths_file
-from git_stage_batch.utils.git import get_gitignore_path
+from git_stage_batch.utils.git import get_gitignore_path, get_local_exclude_path
 from git_stage_batch.utils.paths import get_blocked_files_file_path
 
 
@@ -212,3 +212,42 @@ class TestCommandUnblockFile:
         # Should be removed (using relative path)
         blocked = read_file_paths_file(get_blocked_files_file_path())
         assert "file.txt" not in blocked
+
+    def test_unblock_file_removes_from_local_exclude(self, temp_git_repo, capsys):
+        """Test that unblock-file removes file from .git/info/exclude."""
+        (temp_git_repo / "local.txt").write_text("content\n")
+        command_block_file("local.txt", local_only=True)
+
+        exclude = get_local_exclude_path()
+        assert "local.txt\n" in exclude.read_text()
+
+        command_unblock_file("local.txt")
+
+        assert "local.txt" not in exclude.read_text()
+
+        blocked = read_file_paths_file(get_blocked_files_file_path())
+        assert "local.txt" not in blocked
+
+        captured = capsys.readouterr()
+        assert "Unblocked file: local.txt" in captured.err
+
+    def test_unblock_file_removes_from_both_exclude_and_gitignore(self, temp_git_repo, capsys):
+        """Test that unblock-file removes file from both ignore sources at once."""
+        (temp_git_repo / "both.txt").write_text("content\n")
+
+        # Manually add to both
+        get_gitignore_path().write_text("both.txt\n")
+        exclude = get_local_exclude_path()
+        exclude.parent.mkdir(parents=True, exist_ok=True)
+        exclude.write_text("both.txt\n")
+        append_file_path_to_file(get_blocked_files_file_path(), "both.txt")
+
+        command_unblock_file("both.txt")
+
+        assert "both.txt" not in get_gitignore_path().read_text()
+        assert "both.txt" not in exclude.read_text()
+        blocked = read_file_paths_file(get_blocked_files_file_path())
+        assert "both.txt" not in blocked
+
+        captured = capsys.readouterr()
+        assert "Unblocked file: both.txt" in captured.err

--- a/tests/commands/test_unblock_file.py
+++ b/tests/commands/test_unblock_file.py
@@ -284,3 +284,74 @@ class TestCommandUnblockFile:
 
         blocked = read_file_paths_file(get_blocked_files_file_path())
         assert "dist/" not in blocked
+
+    def test_unblock_file_via_negation_when_directory_covers_path(self, temp_git_repo, capsys):
+        """Test that unblocking a file under a blocked directory uses negation."""
+        subdir = temp_git_repo / "build"
+        subdir.mkdir()
+        (subdir / "keep.c").write_text("important\n")
+        (subdir / "discard.o").write_text("binary\n")
+
+        command_block_file("build/")
+
+        # Verify directory is blocked
+        gitignore = get_gitignore_path()
+        assert "build/\n" in gitignore.read_text()
+
+        # Unblock a specific file inside the blocked directory
+        command_unblock_file("build/keep.c")
+
+        # .gitignore should have build/** (promoted) and !build/keep.c (negation)
+        content = gitignore.read_text()
+        assert "build/**\n" in content
+        assert "!build/keep.c\n" in content
+        assert "build/\n" not in content
+
+        # Blocked list should have !build/keep.c negation
+        blocked = read_file_paths_file(get_blocked_files_file_path())
+        assert "!build/keep.c" in blocked
+        assert "build/" in blocked  # directory entry stays
+
+        captured = capsys.readouterr()
+        assert "Unblocked file: build/keep.c" in captured.err
+
+    def test_unblock_file_negation_blocks_other_files_in_directory(self, temp_git_repo):
+        """Test that unblocking one file in a directory leaves others blocked."""
+        from git_stage_batch.utils.file_io import is_path_blocked
+
+        subdir = temp_git_repo / "build"
+        subdir.mkdir()
+        (subdir / "keep.c").write_text("important\n")
+        (subdir / "discard.o").write_text("binary\n")
+
+        command_block_file("build/")
+        command_unblock_file("build/keep.c")
+
+        blocked = set(read_file_paths_file(get_blocked_files_file_path()))
+        assert not is_path_blocked("build/keep.c", blocked)
+        assert is_path_blocked("build/discard.o", blocked)
+
+    def test_unblock_file_negation_second_file_in_same_directory(self, temp_git_repo):
+        """Test that a second negation in an already-promoted directory works."""
+        subdir = temp_git_repo / "gen"
+        subdir.mkdir()
+        (subdir / "a.c").write_text("code\n")
+        (subdir / "b.c").write_text("code\n")
+        (subdir / "c.o").write_text("binary\n")
+
+        command_block_file("gen/")
+        command_unblock_file("gen/a.c")
+        command_unblock_file("gen/b.c")
+
+        gitignore = get_gitignore_path()
+        content = gitignore.read_text()
+        assert "gen/**\n" in content
+        assert content.count("gen/**") == 1  # not promoted twice
+        assert "!gen/a.c\n" in content
+        assert "!gen/b.c\n" in content
+
+        blocked = set(read_file_paths_file(get_blocked_files_file_path()))
+        from git_stage_batch.utils.file_io import is_path_blocked
+        assert not is_path_blocked("gen/a.c", blocked)
+        assert not is_path_blocked("gen/b.c", blocked)
+        assert is_path_blocked("gen/c.o", blocked)

--- a/tests/commands/test_unblock_file.py
+++ b/tests/commands/test_unblock_file.py
@@ -251,3 +251,36 @@ class TestCommandUnblockFile:
 
         captured = capsys.readouterr()
         assert "Unblocked file: both.txt" in captured.err
+
+    def test_unblock_file_directory_with_trailing_slash(self, temp_git_repo, capsys):
+        """Test that unblock-file removes a directory entry stored as dir/."""
+        subdir = temp_git_repo / "build"
+        subdir.mkdir()
+        (subdir / "out.o").write_text("binary\n")
+
+        command_block_file("build/")
+        blocked = read_file_paths_file(get_blocked_files_file_path())
+        assert "build/" in blocked
+
+        command_unblock_file("build/")
+
+        blocked = read_file_paths_file(get_blocked_files_file_path())
+        assert "build/" not in blocked
+
+        captured = capsys.readouterr()
+        assert "Unblocked file: build/" in captured.err
+
+    def test_unblock_file_directory_without_trailing_slash(self, temp_git_repo):
+        """Test that unblock-file normalizes a bare directory name to dir/ for removal."""
+        subdir = temp_git_repo / "dist"
+        subdir.mkdir()
+        (subdir / "bundle.js").write_text("code\n")
+
+        command_block_file("dist/")
+        blocked = read_file_paths_file(get_blocked_files_file_path())
+        assert "dist/" in blocked
+
+        command_unblock_file("dist")
+
+        blocked = read_file_paths_file(get_blocked_files_file_path())
+        assert "dist/" not in blocked


### PR DESCRIPTION
block-file writes per-file ignore entries to .gitignore when a user
blocks a file, and unblock-file removes them. Both commands operate on
individual file paths and always use the shared .gitignore.

Users sometimes want to block files only on their own machine without
changing the shared .gitignore. Users who block an entire directory
and later want to allow a single file inside it back through have no
way to do that — the directory entry covers the file and unblock-file
finds no individual entry to remove. block-file also does not accept
directory arguments, so users must block each file individually.

This series addresses those limitations across three groups of
commits. The first group adds a --local-only flag to block-file that
routes ignore entries to .git/info/exclude instead of .gitignore, and
extends unblock-file to search both locations when removing entries.
The second group adds directory argument support, normalizing
directory paths to trailing-slash form and using prefix matching in
is_path_blocked() so all files under a blocked directory are
recognized without expanding the directory into individual entries.
The third group adds negation unblocking: when unblock-file is given
a file covered by a directory entry, it promotes dir/ to dir/** in
the ignore file and appends !path as a negation, allowing git to
re-include the specific file while all other files in the directory
remain ignored.

The series now provides local-only blocking, directory-level
blocking, and selective unblocking within blocked directories.