### PR TITLE
batch: Fix stale session source reuse after discard --to in same session

### DIFF
--- a/src/git_stage_batch/batch/source_refresh.py
+++ b/src/git_stage_batch/batch/source_refresh.py
@@ -12,7 +12,12 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 
 from ..core.models import LineEntry
-from ..data.batch_sources import load_session_batch_sources, save_session_batch_sources
+from ..data.batch_sources import (
+    create_batch_source_commit,
+    load_session_batch_sources,
+    save_session_batch_sources,
+)
+from ..editor import load_git_object_as_buffer, load_working_tree_file_as_buffer
 from .lineage import _BatchSourceLineage
 from .match import match_lines
 from .ownership import (
@@ -99,7 +104,23 @@ def ensure_batch_source_current_for_selection(
     Raises:
         ValueError: If stale source remapping fails
     """
-    # Detect if source is stale
+    if current_batch_source_commit is None:
+        cached_source_result = _prepare_initial_cached_source_for_selection(
+            file_path,
+            selected_lines,
+        )
+        if cached_source_result is not None:
+            batch_source_commit, prepared_selected_lines, source_was_advanced = (
+                cached_source_result
+            )
+            return RefreshedBatchSelection(
+                batch_source_commit=batch_source_commit,
+                ownership=existing_ownership,
+                selected_lines=prepared_selected_lines,
+                source_was_advanced=source_was_advanced,
+            )
+
+    # Detect if source is stale.
     is_stale = detect_stale_batch_source_for_selection(selected_lines)
 
     if is_stale and current_batch_source_commit and existing_ownership:
@@ -152,6 +173,7 @@ def ensure_batch_source_current_for_selection(
             selected_lines=reannotated_lines,
             source_was_advanced=False
         )
+
     else:
         # Source is current - no changes needed
         return RefreshedBatchSelection(
@@ -160,6 +182,80 @@ def ensure_batch_source_current_for_selection(
             selected_lines=selected_lines,
             source_was_advanced=False
         )
+
+
+def _line_entry_content(line: LineEntry) -> bytes:
+    return line.text_bytes + (b"\n" if line.has_trailing_newline else b"")
+
+
+def _selected_lines_fit_source(
+    selected_lines: list,
+    source_lines: Sequence[bytes],
+) -> bool:
+    """Return whether selected presence lines can be claimed from source bytes."""
+    if detect_stale_batch_source_for_selection(selected_lines):
+        return False
+
+    for line in selected_lines:
+        if line.kind not in (" ", "+"):
+            continue
+        if line.source_line is None:
+            return False
+
+        source_index = line.source_line - 1
+        if source_index < 0 or source_index >= len(source_lines):
+            return False
+        if source_lines[source_index] != _line_entry_content(line):
+            return False
+
+    return True
+
+
+def _cache_session_source(file_path: str, batch_source_commit: str) -> None:
+    batch_sources = load_session_batch_sources()
+    batch_sources[file_path] = batch_source_commit
+    save_session_batch_sources(batch_sources)
+
+
+def _create_current_working_source_for_selection(
+    file_path: str,
+    selected_lines: list,
+) -> tuple[str, list]:
+    with load_working_tree_file_as_buffer(file_path) as working_lines:
+        batch_source_commit = create_batch_source_commit(
+            file_path,
+            file_buffer_override=working_lines,
+        )
+    _cache_session_source(file_path, batch_source_commit)
+    return (
+        batch_source_commit,
+        _refresh_selected_lines_against_new_source(selected_lines),
+    )
+
+
+def _prepare_initial_cached_source_for_selection(
+    file_path: str,
+    selected_lines: list,
+) -> tuple[str, list, bool] | None:
+    batch_source_commit = load_session_batch_sources().get(file_path)
+    if not batch_source_commit:
+        return None
+
+    source_buffer = load_git_object_as_buffer(f"{batch_source_commit}:{file_path}")
+    if source_buffer is None:
+        raise ValueError(
+            f"Cannot read cached batch source for {file_path} at "
+            f"{batch_source_commit}"
+        )
+
+    with source_buffer as source_lines:
+        if _selected_lines_fit_source(selected_lines, source_lines):
+            return batch_source_commit, selected_lines, False
+
+    new_batch_source_commit, reannotated_lines = (
+        _create_current_working_source_for_selection(file_path, selected_lines)
+    )
+    return new_batch_source_commit, reannotated_lines, True
 
 
 def _refresh_selected_lines_against_new_source(selected_lines: list) -> list:

--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -1592,6 +1592,7 @@ def _command_discard_file_to_batch(
                 file_path,
                 update.ownership_after,
                 file_mode,
+                batch_source_commit=update.batch_source_commit,
             )
 
         # Record hunks as discarded for progress tracking
@@ -1705,6 +1706,7 @@ def _command_discard_file_lines_to_batch(
             file_path,
             update.ownership_after,
             file_mode,
+            batch_source_commit=update.batch_source_commit,
         )
 
     # Now discard selected lines from working tree
@@ -1801,6 +1803,7 @@ def _command_discard_lines_to_batch(
             line_changes.path,
             update.ownership_after,
             file_mode,
+            batch_source_commit=update.batch_source_commit,
         )
 
     log_journal("discard_lines_to_batch_after_add", batch_name=batch_name, file_path=line_changes.path)
@@ -1967,7 +1970,13 @@ def _command_discard_text_hunk_to_batch(
             log_journal("discard_hunk_to_batch_before_add", batch_name=batch_name, file_path=file_path, num_patches=len(patches_to_discard))
 
             # Save to batch using batch source model (once, with all accumulated data)
-            add_file_to_batch(batch_name, file_path, update.ownership_after, file_mode)
+            add_file_to_batch(
+                batch_name,
+                file_path,
+                update.ownership_after,
+                file_mode,
+                batch_source_commit=update.batch_source_commit,
+            )
 
         log_journal("discard_hunk_to_batch_after_add", batch_name=batch_name, file_path=file_path)
 

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -1663,7 +1663,13 @@ def _command_include_file_to_batch(
         snapshot_file_if_untracked(file_path)
 
         # Save to batch
-        add_file_to_batch(batch_name, file_path, update.ownership_after, file_mode)
+        add_file_to_batch(
+            batch_name,
+            file_path,
+            update.ownership_after,
+            file_mode,
+            batch_source_commit=update.batch_source_commit,
+        )
 
     if not quiet:
         print(_("Included file '{file}' to batch '{batch}'").format(file=file_path, batch=batch_name), file=sys.stderr)
@@ -1747,7 +1753,13 @@ def _command_include_file_lines_to_batch(
         snapshot_file_if_untracked(file_path)
 
         # Save to batch
-        add_file_to_batch(batch_name, file_path, update.ownership_after, file_mode)
+        add_file_to_batch(
+            batch_name,
+            file_path,
+            update.ownership_after,
+            file_mode,
+            batch_source_commit=update.batch_source_commit,
+        )
 
     if not quiet:
         print(_("Included line(s) from file '{file}' to batch '{batch}': {lines}").format(
@@ -1818,6 +1830,7 @@ def _command_include_lines_to_batch(
             line_changes.path,
             update.ownership_after,
             file_mode,
+            batch_source_commit=update.batch_source_commit,
         )
 
     if not quiet:
@@ -1987,7 +2000,13 @@ def _command_include_hunk_to_batch(
             )
 
         # Save to batch using batch source model (once, with all accumulated data)
-        add_file_to_batch(batch_name, file_path, update.ownership_after, file_mode)
+        add_file_to_batch(
+            batch_name,
+            file_path,
+            update.ownership_after,
+            file_mode,
+            batch_source_commit=update.batch_source_commit,
+        )
 
     # Mark hunks as processed
     for hunk_lines, patch_hash in processed_hunks:

--- a/tests/functional/test_stale_batch_source_advancement.py
+++ b/tests/functional/test_stale_batch_source_advancement.py
@@ -6,7 +6,10 @@ import subprocess
 
 
 from git_stage_batch.batch.query import read_batch_metadata
+from git_stage_batch.batch.query import get_batch_commit_sha
+from git_stage_batch.commands.again import command_again
 from git_stage_batch.commands.discard import command_discard_to_batch
+from git_stage_batch.commands.include import command_include_to_batch
 from git_stage_batch.commands.start import command_start
 
 
@@ -15,6 +18,15 @@ def _presence_source_lines(file_metadata: dict) -> list[str]:
     for claim in file_metadata.get("presence_claims", []):
         lines.extend(claim.get("source_lines", []))
     return lines
+
+
+def _show_file(commit: str, path: str) -> str:
+    return subprocess.run(
+        ["git", "show", f"{commit}:{path}"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
 
 
 def test_stale_source_advancement_on_discard(functional_repo):
@@ -65,6 +77,38 @@ def test_stale_source_advancement_on_discard(functional_repo):
     # Verify ownership was preserved and extended
     # Should now claim all 5 lines
     assert "1-5" in ",".join(_presence_source_lines(metadata["files"]["test.py"]))
+
+
+def test_again_include_to_new_batch_does_not_reuse_stale_session_source(functional_repo):
+    """A bridge repair after again must not save bytes from an older batch source."""
+    test_file = functional_repo / "api.py"
+    test_file.write_text('def api():\n    return "base"\n')
+
+    subprocess.run(["git", "add", "api.py"], check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "Add api"], check=True, capture_output=True)
+
+    test_file.write_text('def api():\n    return "layer3"\n')
+
+    command_start()
+    command_discard_to_batch(batch_name="layer3", file="api.py", quiet=True)
+
+    test_file.write_text('def api():\n    return "bridge"\n')
+
+    command_again(quiet=True)
+    command_include_to_batch(batch_name="repair", quiet=True)
+
+    metadata = read_batch_metadata("repair")
+    file_metadata = metadata["files"]["api.py"]
+    source_content = _show_file(file_metadata["batch_source_commit"], "api.py")
+
+    batch_commit = get_batch_commit_sha("repair")
+    assert batch_commit is not None
+    realized_content = _show_file(batch_commit, "api.py")
+
+    assert 'return "bridge"' in source_content
+    assert 'return "layer3"' not in source_content
+    assert 'return "bridge"' in realized_content
+    assert 'return "layer3"' not in realized_content
 
 
 def test_stale_discard_preserves_previously_discarded_claimed_lines(functional_repo):


### PR DESCRIPTION
The stale-source repair path in source_refresh.py handles two cases:
when an existing batch source is outdated relative to new working tree
content it advances the source commit, and when there is no batch
source at all it falls through to let add_file_to_batch create one
from the session cache.

A gap exists when the session cache holds a source commit from an
earlier operation on a file — after discard --to captures layer
content, for example — and a later include --to targets a new batch
for a different logical state of that file. With no existing batch
source for the new batch, the repair path takes the "no source"
branch and defers to add_file_to_batch, which reads the now-stale
session entry. The new batch inherits the wrong source, misidentifying
which file bytes it contains. Concretely, a bridge repair batch
created with again + include --to captures the pre-repair file bytes
instead of the post-edit bytes, and the subsequent discard --from
silently does nothing.

This series fixes the bug by teaching source_refresh to detect the
case where no batch source exists yet but the session cache already
has an entry for the file. A new helper verifies that the cached
source matches the current working tree content for the selected
lines; when it does not, it creates a fresh source from the working
tree and updates the session cache. The discard and include commands
are then updated to forward the resolved commit from
PreparedBatchUpdate into add_file_to_batch explicitly, rather than
letting the storage layer fall back to the session cache a second
time. A functional test covers the end-to-end scenario: discard --to
on api.py, manual edit to bridge state, again, include --to repair,
asserting the repair batch source and realized content both contain
the bridge-state bytes.