### PR TITLE
ci: Fix 10 consistently failing CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Configure git identity
+        run: |
+          git config --global user.name "CI"
+          git config --global user.email "ci@test"
+
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y gettext
 

--- a/src/git_stage_batch/output/file_review.py
+++ b/src/git_stage_batch/output/file_review.py
@@ -989,8 +989,11 @@ def make_file_review_state(
             gutter_to_selection_id=gutter_to_selection_id,
             actionable_selection_groups=actionable_selection_groups,
             review_action_groups=review_action_groups,
+            line_changes=model.line_changes,
         ),
-        diff_fingerprint=compute_current_file_review_diff_fingerprint(model.line_changes.path),
+        diff_fingerprint=compute_current_file_review_diff_fingerprint(
+            model.line_changes.path, line_changes=model.line_changes,
+        ),
     )
 
 


### PR DESCRIPTION
The CI test suite consistently fails 10 tests in
tests/cli/test_argument_parser.py. Parallel test execution leaks
a session directory into the checkout, causing undo-checkpoint code
to call git commit-tree without a configured git identity.

The test runner has no user.name or user.email set, so
git commit-tree exits with code 128 and the argument parser
dispatch tests fail.

These commits address the failures by forwarding in-memory line
changes to fingerprint functions instead of re-reading from disk,
and by configuring git identity in the CI workflow so
git commit-tree succeeds when tests exercise undo checkpoint
paths.