### PR TITLE
git: Extend index lock wait

### DIFF
--- a/src/git_stage_batch/utils/git.py
+++ b/src/git_stage_batch/utils/git.py
@@ -21,7 +21,7 @@ from .text import bytes_to_lines
 
 _GIT_REPOSITORY_ROOT_CACHE: dict[Path, Path] = {}
 _GIT_DIRECTORY_CACHE: dict[Path, Path] = {}
-_INDEX_LOCK_WAIT_SECONDS = 2.0
+_INDEX_LOCK_WAIT_SECONDS = 20.0
 _INDEX_LOCK_POLL_SECONDS = 0.05
 
 


### PR DESCRIPTION
The git command helpers serialize operations that need the index lock, and commands that stage, reset, or inspect the index rely on that shared path.

Short lock waits can fail during otherwise valid workflows when another git process still owns the index briefly. The failure mode looks like a staging error even though waiting a little longer would let the operation continue.

This PR extends the index lock wait window from two seconds to twenty seconds so git-stage-batch tolerates ordinary short-lived contention without changing command behavior once the lock is acquired.