### PR TITLE
include: Let ranges clarify replacements

### DIFF
--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -12,10 +12,7 @@ import sys
 import uuid
 
 from ..batch import add_binary_file_to_batch, add_file_to_batch, add_gitlink_to_batch, create_batch, delete_batch
-from ..batch.comparison import (
-    derive_display_id_run_sets_from_lines,
-    derive_replacement_display_id_run_sets_from_lines,
-)
+from ..batch.comparison import derive_display_id_run_sets_from_lines
 from ..batch.display import annotate_with_batch_source
 from ..batch.merge import merge_batch_from_line_sequences_as_buffer
 from ..batch.ownership import (
@@ -912,14 +909,15 @@ def command_include_line(
         ):
             selected_change_kind = read_selected_change_kind()
             if selected_change_kind == SelectedChangeKind.FILE:
-                partial_replacement_error = _build_partial_replacement_selection_error(
-                    line_changes,
-                    combined_include_ids,
-                    hunk_base_lines=hunk_base_lines,
-                    hunk_source_lines=hunk_source_lines,
+                leading_replacement_addition_error = (
+                    _build_leading_replacement_addition_selection_error(
+                        line_changes,
+                        combined_include_ids,
+                    )
                 )
-                if partial_replacement_error is not None:
-                    exit_with_error(partial_replacement_error)
+                if leading_replacement_addition_error is not None:
+                    exit_with_error(leading_replacement_addition_error)
+
                 partial_structural_run_error = _build_partial_structural_run_selection_error(
                     line_changes,
                     combined_include_ids,
@@ -1011,20 +1009,6 @@ def command_include_line(
         )
 
 
-def _derive_replacement_unit_display_ids(
-    line_changes,
-    *,
-    hunk_base_lines: Sequence[bytes],
-    hunk_source_lines: Sequence[bytes],
-) -> list[set[int]]:
-    """Map semantic replacement runs onto display IDs in the current selection."""
-    return derive_replacement_display_id_run_sets_from_lines(
-        line_changes,
-        source_lines=hunk_base_lines,
-        target_lines=hunk_source_lines,
-    )
-
-
 def _derive_replacement_line_runs(
     *,
     hunk_base_lines: Sequence[bytes],
@@ -1037,37 +1021,65 @@ def _derive_replacement_line_runs(
     )
 
 
-def _build_partial_replacement_selection_error(
+def _build_leading_replacement_addition_selection_error(
     line_changes,
     selected_ids: set[int],
-    *,
-    hunk_base_lines: Sequence[bytes],
-    hunk_source_lines: Sequence[bytes],
 ) -> str | None:
-    """Reject contiguous interval selections that tear a replacement unit."""
-    if len(selected_ids) <= 1:
-        return None
+    """Reject include selections that would keep the removed line with the first insertion."""
+    changed_run: list = []
 
-    sorted_ids = sorted(selected_ids)
-    is_contiguous_interval = sorted_ids == list(range(sorted_ids[0], sorted_ids[-1] + 1))
-    if not is_contiguous_interval:
-        return None
+    def check_run(run: list) -> str | None:
+        if not run:
+            return None
+        deletion_ids = {
+            line.id
+            for line in run
+            if line.kind == "-" and line.id is not None
+        }
+        addition_ids = tuple(
+            line.id
+            for line in run
+            if line.kind == "+" and line.id is not None
+        )
+        if not deletion_ids or not addition_ids:
+            return None
 
-    replacement_units = _derive_replacement_unit_display_ids(
-        line_changes,
-        hunk_base_lines=hunk_base_lines,
-        hunk_source_lines=hunk_source_lines,
-    )
-    for replacement_unit in replacement_units:
-        selected_in_unit = selected_ids & replacement_unit
-        if selected_in_unit and selected_in_unit != replacement_unit:
+        selected_deletions = selected_ids & deletion_ids
+        selected_addition_positions = [
+            index
+            for index, line_id in enumerate(addition_ids)
+            if line_id in selected_ids
+        ]
+        if not selected_addition_positions:
+            return None
+
+        selects_first_addition = selected_addition_positions[0] == 0
+        if selects_first_addition and not selected_deletions:
             return _(
-                "Contiguous line selections cannot split one replacement. "
-                "Select --lines {lines} instead, pick "
-                "individual lines one at a time, or use --as."
-            ).format(lines=format_line_ids(sorted(replacement_unit)))
+                "That line selection splits the leading edge of a replacement. "
+                "Select the removed line with the first inserted line, select only "
+                "later inserted lines, or use --as."
+            )
+        if selected_deletions:
+            expected_prefix = list(range(selected_addition_positions[-1] + 1))
+            if selected_addition_positions != expected_prefix:
+                return _(
+                    "That line selection splits the leading edge of a replacement. "
+                    "Select the removed line with a contiguous prefix of inserted "
+                    "lines, select only later inserted lines, or use --as."
+                )
+        return None
 
-    return None
+    for line in line_changes.lines:
+        if line.kind in ("+", "-") and line.id is not None:
+            changed_run.append(line)
+            continue
+        error = check_run(changed_run)
+        if error is not None:
+            return error
+        changed_run = []
+
+    return check_run(changed_run)
 
 
 def _build_partial_structural_run_selection_error(

--- a/src/git_stage_batch/output/file_review.py
+++ b/src/git_stage_batch/output/file_review.py
@@ -181,6 +181,14 @@ def _change_is_presence_only(change: ReviewChange) -> bool:
     return saw_changed_row
 
 
+def _change_is_live_splittable(change: ReviewChange) -> bool:
+    """Return whether live explicit line ranges may select part of a change."""
+    return (
+        _change_is_presence_only(change)
+        or change.reason == ActionableSelectionReason.REPLACEMENT
+    )
+
+
 def _coerce_actionable_reason(reason: str) -> ActionableSelectionReason:
     try:
         return ActionableSelectionReason(reason)
@@ -918,13 +926,14 @@ def make_file_review_state(
             continue
         is_splittable = (
             source != ReviewSource.BATCH
-            and _change_is_presence_only(change)
+            and _change_is_live_splittable(change)
         )
-        display_ids = (
-            _display_ids_for_change_pages(model, change, shown_pages)
-            if is_splittable else
-            change.display_ids
-        )
+        if is_splittable:
+            display_ids = _display_ids_for_change_pages(model, change, shown_pages)
+            if not display_ids and change.reason == ActionableSelectionReason.REPLACEMENT:
+                display_ids = change.display_ids
+        else:
+            display_ids = change.display_ids
         if not display_ids:
             continue
         if visible_display_ids is not None and not set(display_ids).issubset(visible_display_ids):

--- a/tests/batch/test_ownership_incremental.py
+++ b/tests/batch/test_ownership_incremental.py
@@ -332,6 +332,72 @@ def test_translate_hunk_selection_keeps_one_to_many_replacement_atomic():
     ]
 
 
+def test_translate_hunk_selection_uses_partial_one_to_many_selection_as_replacement():
+    """A selected deletion plus insertion prefix defines the replacement unit."""
+    lines = [
+        LineEntry(id=1, kind='-', old_line_number=1, new_line_number=None,
+                  text_bytes=b'old', text='old', source_line=None),
+        LineEntry(id=2, kind='+', old_line_number=None, new_line_number=1,
+                  text_bytes=b'new one', text='new one', source_line=1),
+        LineEntry(id=3, kind='+', old_line_number=None, new_line_number=2,
+                  text_bytes=b'new two', text='new two', source_line=2),
+        LineEntry(id=4, kind='+', old_line_number=None, new_line_number=3,
+                  text_bytes=b'new three', text='new three', source_line=3),
+    ]
+
+    ownership = translate_hunk_selection_to_batch_ownership(
+        lines,
+        {1, 2, 3},
+        replacement_line_runs=[
+            ReplacementLineRun(
+                old_start=1,
+                old_end=1,
+                new_start=1,
+                new_end=3,
+            ),
+        ],
+    )
+
+    assert ownership.presence_line_set() == {1, 2}
+    assert len(ownership.deletions) == 1
+    assert isinstance(ownership.deletions[0].content_lines, EditorBuffer)
+    assert list(ownership.deletions[0].content_lines) == [b'old\n']
+    assert ownership.replacement_units == [
+        ReplacementUnit(presence_lines=["1-2"], deletion_indices=[0]),
+    ]
+
+
+def test_translate_hunk_selection_treats_replacement_tail_as_presence_only():
+    """Selected tail insertions should not claim the replacement deletion."""
+    lines = [
+        LineEntry(id=1, kind='-', old_line_number=1, new_line_number=None,
+                  text_bytes=b'old', text='old', source_line=None),
+        LineEntry(id=2, kind='+', old_line_number=None, new_line_number=1,
+                  text_bytes=b'new one', text='new one', source_line=1),
+        LineEntry(id=3, kind='+', old_line_number=None, new_line_number=2,
+                  text_bytes=b'new two', text='new two', source_line=2),
+        LineEntry(id=4, kind='+', old_line_number=None, new_line_number=3,
+                  text_bytes=b'new three', text='new three', source_line=3),
+    ]
+
+    ownership = translate_hunk_selection_to_batch_ownership(
+        lines,
+        {3, 4},
+        replacement_line_runs=[
+            ReplacementLineRun(
+                old_start=1,
+                old_end=1,
+                new_start=1,
+                new_end=3,
+            ),
+        ],
+    )
+
+    assert ownership.presence_line_set() == {2, 3}
+    assert ownership.deletions == []
+    assert ownership.replacement_units == []
+
+
 def test_translate_hunk_selection_scans_replacement_ranges(monkeypatch):
     """File-derived replacement runs should be consumed through endpoints."""
     def fail_from_lines(cls, lines):

--- a/tests/commands/test_file_review.py
+++ b/tests/commands/test_file_review.py
@@ -26,12 +26,14 @@ from git_stage_batch.commands.start import command_start
 from git_stage_batch.commands.stop import command_stop
 from git_stage_batch.commands.include import command_include_to_batch
 from git_stage_batch.commands.suggest_fixup import command_suggest_fixup
+from git_stage_batch.core.actionable_changes import ActionableSelectionReason
 import git_stage_batch.data.hunk_tracking as hunk_tracking_module
 from git_stage_batch.data.file_review_state import (
     FileReviewAction,
     ReviewSource,
     read_last_file_review_state,
     shown_review_selections_for_action,
+    validate_pathless_review_line_action,
 )
 from git_stage_batch.data.hunk_tracking import (
     SelectedChangeKind,
@@ -96,6 +98,22 @@ def _add_second_changed_file(repo):
     subprocess.run(["git", "add", "other.txt"], check=True, capture_output=True)
     subprocess.run(["git", "commit", "-m", "Add other"], check=True, capture_output=True)
     other_file.write_text("other 1\nother changed\n")
+
+
+def _create_one_to_many_replacement_repo(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    subprocess.run(["git", "init"], check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], check=True)
+
+    file_path = tmp_path / "module.py"
+    file_path.write_text("keep\nold value\n")
+    subprocess.run(["git", "add", "module.py"], check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "Initial"], check=True, capture_output=True)
+
+    file_path.write_text("keep\nnew value 1\nnew value 2\nnew value 3\n")
+    command_start(quiet=True)
+    return file_path
 
 
 def _create_multi_file_batch(repo):
@@ -937,18 +955,76 @@ def test_file_review_footer_suggests_pathless_line_commands(paged_file_repo, mon
     assert "git-stage-batch include --file file.txt --line" not in captured.out
 
 
-def test_pathless_include_line_rejects_partial_replacement_selection(paged_file_repo, monkeypatch, capsys):
-    _force_one_change_per_page(monkeypatch)
-    command_show(file="file.txt", page="1")
+def test_pathless_include_line_accepts_replacement_prefix_range(tmp_path, monkeypatch, capsys):
+    file_path = _create_one_to_many_replacement_repo(tmp_path, monkeypatch)
+
+    command_show(file="module.py")
     captured = capsys.readouterr()
-    assert "Change 1/3   lines 1–2   2-line group" in captured.out
+    assert "Change 1/1   lines 1–4   4-line group" in captured.out
 
     state = read_last_file_review_state()
     assert state is not None
-    partial_id = str(state.selections[0].display_ids[0])
+    assert state.selections[0].is_splittable is True
+    prefix_spec = format_line_ids(list(state.selections[0].display_ids[:2]))
 
-    with pytest.raises(CommandError, match="only partly selects"):
-        command_include_line(partial_id)
+    command_include_line(prefix_spec)
+
+    staged_content = subprocess.run(
+        ["git", "show", ":module.py"],
+        check=True,
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    ).stdout
+    assert staged_content == "keep\nnew value 1\n"
+    assert file_path.read_text() == "keep\nnew value 1\nnew value 2\nnew value 3\n"
+
+
+@pytest.mark.parametrize("line_spec", ["2", "2-3"])
+def test_pathless_include_line_rejects_leading_addition_without_deletion(
+    tmp_path,
+    monkeypatch,
+    capsys,
+    line_spec,
+):
+    _create_one_to_many_replacement_repo(tmp_path, monkeypatch)
+
+    command_show(file="module.py")
+    capsys.readouterr()
+
+    with pytest.raises(CommandError, match="leading edge of a replacement"):
+        command_include_line(line_spec)
+
+
+@pytest.mark.parametrize(
+    "action",
+    [
+        FileReviewAction.INCLUDE,
+        FileReviewAction.SKIP,
+        FileReviewAction.DISCARD,
+        FileReviewAction.INCLUDE_TO_BATCH,
+        FileReviewAction.DISCARD_TO_BATCH,
+    ],
+)
+def test_live_review_line_actions_accept_replacement_subranges(
+    tmp_path,
+    monkeypatch,
+    capsys,
+    action,
+):
+    _create_one_to_many_replacement_repo(tmp_path, monkeypatch)
+    command_show(file="module.py")
+    capsys.readouterr()
+    state = read_last_file_review_state()
+    assert state is not None
+    assert state.selections[0].is_splittable is True
+    tail_spec = format_line_ids(list(state.selections[0].display_ids[2:]))
+
+    validate_pathless_review_line_action(
+        action,
+        tail_spec,
+        source=ReviewSource.FILE_VS_HEAD,
+    )
 
 
 def test_pathless_include_line_accepts_visible_presence_subset_from_review(
@@ -1001,6 +1077,30 @@ def test_pathless_include_line_rejects_unshown_change(paged_file_repo, monkeypat
 
     with pytest.raises(CommandError, match="not valid from the current file review"):
         command_include_line(unshown_spec)
+
+
+def test_partial_live_review_keeps_hidden_replacement_groups_for_page_guard(
+    paged_file_repo,
+    monkeypatch,
+    capsys,
+):
+    _force_one_change_per_page(monkeypatch)
+    command_show(file="file.txt", page="1")
+    capsys.readouterr()
+
+    state = read_last_file_review_state()
+    assert state is not None
+    assert state.shown_pages == (1,)
+    assert [selection.first_page for selection in state.selections] == [1, 2, 3]
+    assert [selection.reason for selection in state.selections] == [
+        ActionableSelectionReason.REPLACEMENT,
+        ActionableSelectionReason.REPLACEMENT,
+        ActionableSelectionReason.REPLACEMENT,
+    ]
+
+    hidden_spec = format_line_ids(list(state.selections[1].display_ids))
+    with pytest.raises(CommandError, match="not valid from the current file review"):
+        command_include_line(hidden_spec)
 
 
 def test_partial_review_line_action_keeps_stale_guard_for_followup_bare_action(

--- a/tests/commands/test_file_scoped_operations.py
+++ b/tests/commands/test_file_scoped_operations.py
@@ -68,6 +68,25 @@ def multi_file_repo(tmp_path, monkeypatch):
     return repo
 
 
+def _create_one_to_many_replacement_repo(tmp_path, monkeypatch):
+    repo = tmp_path / "test_repo"
+    repo.mkdir()
+    monkeypatch.chdir(repo)
+
+    subprocess.run(["git", "init"], check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test"], check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@test.com"], check=True, capture_output=True)
+
+    file_path = repo / "module.py"
+    file_path.write_text("keep\nold value\n")
+    subprocess.run(["git", "add", "module.py"], check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "Initial"], check=True, capture_output=True)
+
+    file_path.write_text("keep\nnew value 1\nnew value 2\nnew value 3\n")
+    command_start()
+    return repo, file_path
+
+
 class TestShowFileFlag:
     """Test show command with --file flag for displaying entire files."""
 
@@ -1618,37 +1637,63 @@ class TestExplicitFilePath:
         assert staged_content == "keep1\nkeep2\nstaged\nkeep4\n"
         assert file_path.read_text() == "keep1\nkeep2\nnew\nkeep4\n"
 
-    def test_include_line_with_explicit_path_rejects_partial_replacement_range(self, tmp_path, monkeypatch):
-        """Explicit file-scoped include --line should refuse a partial replacement range."""
-        repo = tmp_path / "test_repo"
-        repo.mkdir()
-        monkeypatch.chdir(repo)
+    def test_include_line_with_explicit_path_accepts_partial_replacement_range(self, tmp_path, monkeypatch):
+        """Explicit file-scoped include --line should let the range define the replacement."""
+        _repo, file_path = _create_one_to_many_replacement_repo(tmp_path, monkeypatch)
 
-        subprocess.run(["git", "init"], check=True, capture_output=True)
-        subprocess.run(["git", "config", "user.name", "Test"], check=True, capture_output=True)
-        subprocess.run(["git", "config", "user.email", "test@test.com"], check=True, capture_output=True)
+        command_include_line("1-2", file="module.py")
 
-        file_path = repo / "module.py"
-        file_path.write_text("keep\nold value\n")
-        subprocess.run(["git", "add", "module.py"], check=True, capture_output=True)
-        subprocess.run(["git", "commit", "-m", "Initial"], check=True, capture_output=True)
+        staged_content = run_git_command(["show", ":module.py"]).stdout
+        assert staged_content == "keep\nnew value 1\n"
+        assert file_path.read_text() == "keep\nnew value 1\nnew value 2\nnew value 3\n"
 
-        file_path.write_text("keep\nnew value 1\nnew value 2\nnew value 3\n")
+    def test_include_line_with_explicit_path_treats_replacement_tail_as_insertions(self, tmp_path, monkeypatch):
+        """Selecting only tail insertions should leave the replacement prefix unstaged."""
+        _repo, file_path = _create_one_to_many_replacement_repo(tmp_path, monkeypatch)
 
-        command_start()
+        command_include_line("3-4", file="module.py")
 
-        with pytest.raises(CommandError) as exc_info:
-            command_include_line("1-2", file="module.py")
+        staged_content = run_git_command(["show", ":module.py"]).stdout
+        assert staged_content == "keep\nold value\nnew value 2\nnew value 3\n"
+        assert file_path.read_text() == "keep\nnew value 1\nnew value 2\nnew value 3\n"
 
-        assert (
-            str(exc_info.value)
-            == "Contiguous line selections cannot split one replacement. "
-            "Select --lines 1-4 instead, pick individual "
-            "lines one at a time, or use --as."
-        )
+        unstaged_diff = run_git_command(["diff", "--", "module.py"]).stdout
+        assert "-old value" in unstaged_diff
+        assert "+new value 1" in unstaged_diff
+        assert "+new value 2" not in unstaged_diff
+        assert "+new value 3" not in unstaged_diff
 
-        result = run_git_command(["diff", "--cached", "--name-only"])
-        assert result.stdout == ""
+    def test_include_line_with_explicit_path_accepts_tail_before_replacement_prefix(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        """Tail insertions can be staged before the replacement prefix."""
+        _repo, file_path = _create_one_to_many_replacement_repo(tmp_path, monkeypatch)
+
+        command_include_line("3-4", file="module.py")
+        command_include_line("1-2", file="module.py")
+
+        staged_content = run_git_command(["show", ":module.py"]).stdout
+        assert staged_content == file_path.read_text()
+        assert file_path.read_text() == "keep\nnew value 1\nnew value 2\nnew value 3\n"
+
+    @pytest.mark.parametrize("line_spec", ["2", "2-3"])
+    def test_include_line_with_explicit_path_rejects_leading_addition_without_deletion(
+        self,
+        tmp_path,
+        monkeypatch,
+        line_spec,
+    ):
+        """The first replacement insertion should not be staged without the deletion."""
+        _repo, file_path = _create_one_to_many_replacement_repo(tmp_path, monkeypatch)
+
+        with pytest.raises(CommandError, match="leading edge of a replacement"):
+            command_include_line(line_spec, file="module.py")
+
+        staged_names = run_git_command(["diff", "--cached", "--name-only"]).stdout
+        assert staged_names == ""
+        assert file_path.read_text() == "keep\nnew value 1\nnew value 2\nnew value 3\n"
 
     def test_include_line_with_explicit_path_rejects_partial_later_structural_run(self, tmp_path, monkeypatch):
         """Explicit file-scoped include --line should reject a partial later run."""

--- a/tests/commands/test_include.py
+++ b/tests/commands/test_include.py
@@ -15,7 +15,6 @@ from git_stage_batch.commands.include import (
     command_include_line_as,
     command_include_to_batch,
 )
-from git_stage_batch.core.models import HunkHeader, LineEntry, LineLevelChange
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.commands.show import command_show
 from git_stage_batch.data.hunk_tracking import (
@@ -288,30 +287,16 @@ class TestCommandIncludeLine:
         assert blob_result.stdout == b"newtarget"
         assert mode_result.stdout.split()[0] == "120000"
 
-    def test_replacement_analysis_accepts_non_list_line_sequences(self, line_sequence):
+    def test_replacement_line_analysis_accepts_non_list_sequences(self, line_sequence):
         """Include replacement analysis can read from indexed content sequences."""
-        header = HunkHeader(1, 3, 1, 3)
-        lines = [
-            LineEntry(None, " ", 1, 1, text_bytes=b"keep", text="keep"),
-            LineEntry(1, "-", 2, None, text_bytes=b"old", text="old"),
-            LineEntry(2, "+", None, 2, text_bytes=b"new", text="new"),
-            LineEntry(None, " ", 3, 3, text_bytes=b"tail", text="tail"),
-        ]
-        line_changes = LineLevelChange(path="test.txt", header=header, lines=lines)
         base_lines = line_sequence([b"keep\r\n", b"old\r\n", b"tail\r\n"])
         source_lines = line_sequence([b"keep\r\n", b"new\r\n", b"tail\r\n"])
 
-        display_runs = include_command._derive_replacement_unit_display_ids(
-            line_changes,
-            hunk_base_lines=base_lines,
-            hunk_source_lines=source_lines,
-        )
         line_runs = include_command._derive_replacement_line_runs(
             hunk_base_lines=base_lines,
             hunk_source_lines=source_lines,
         )
 
-        assert display_runs == [{1, 2}]
         assert len(line_runs) == 1
         assert (line_runs[0].old_start, line_runs[0].old_end) == (2, 2)
         assert (line_runs[0].new_start, line_runs[0].new_end) == (2, 2)


### PR DESCRIPTION
File-scoped include and live file review group adjacent deletion and addition runs with a replacement heuristic.

That heuristic is useful, but it can overstate the relationship between a removed line and a longer inserted run. An explicit line range is the user-provided signal that clarifies which part of the group belongs to the staged replacement and which later inserted lines should remain separate.

The boundary is intentionally not strict prefix-only. A deletion plus insertion prefix, such as lines 1-2, can stage the replacement portion. A complementary tail, such as lines 3-4, can also be staged first as plain insertions. The guarded case is selecting the leading inserted line without the deletion, such as line 2 or lines 2-3, because that leaves old and replacement text together in the index.

The patch removes the whole-replacement range rejection, marks live replacement review groups as splittable, preserves hidden replacement groups for partial-review page guards, and adds an include guard for the leading-edge hybrid case. Coverage exercises command selection, pathless review include, tail-before-prefix order, ownership metadata, and the other live review actions that share replacement subrange validation.

Tests:
uv run ruff check src/git_stage_batch/commands/include.py src/git_stage_batch/output/file_review.py tests/commands/test_include.py tests/commands/test_file_review.py tests/commands/test_file_scoped_operations.py tests/batch/test_ownership_incremental.py
uv run pytest tests/batch/test_ownership_incremental.py tests/commands/test_file_scoped_operations.py tests/commands/test_file_review.py tests/commands/test_include.py
uv run pytest -n 0