### PR TITLE
project: Use importlib import mode for pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ no-build-isolation = true
 preview = true
 
 [tool.pytest.ini_options]
-addopts = ["-n", "auto"]
+addopts = ["--import-mode=importlib", "-n", "auto"]
 
 [tool.uv.extra-build-dependencies]
 git-stage-batch = [


### PR DESCRIPTION
The project uses meson-python as its build backend and pytest with xdist
for test execution. The pytest configuration in pyproject.toml sets
automatic parallelism but leaves the import mode at the default prepend
setting.

The test suite has files that share a basename across different
subdirectories (e.g. tests/commands/test_undo.py and
tests/functional/test_undo.py). Under the default prepend import mode,
pytest inserts each test directory into sys.path, so both files resolve to
the bare module name "test_undo". When xdist dispatches tests to workers,
the second file to load shadows the first, causing import errors or
silently running the wrong tests.

This commit addresses that by adding --import-mode=importlib to the pytest
addopts list. The importlib mode uses Python's own import machinery instead
of sys.path insertion, giving each test file a unique module identity
regardless of its basename.