### PR TITLE
state: Preserve sparse line IDs during refresh

### DIFF
--- a/src/git_stage_batch/batch/attribution.py
+++ b/src/git_stage_batch/batch/attribution.py
@@ -12,7 +12,6 @@ from collections.abc import Iterable, Sequence
 from contextlib import ExitStack
 import hashlib
 from dataclasses import dataclass
-from dataclasses import replace
 from enum import Enum
 
 from ..batch.match import LineMapping, match_lines
@@ -939,18 +938,13 @@ def filter_owned_diff_fragments(
     """Filter displayed diff fragments that correspond to owned units."""
     display_to_unit = project_attribution_to_diff(attribution, line_changes)
     filtered_lines = []
-    new_id = 1
 
     for idx, line_entry in enumerate(line_changes.lines):
         attr_unit = display_to_unit.get(idx)
         if attr_unit and attr_unit.owning_batches:
             continue
 
-        filtered_lines.append(
-            replace(line_entry, id=new_id if line_entry.kind != " " else None)
-        )
-        if line_entry.kind != " ":
-            new_id += 1
+        filtered_lines.append(line_entry)
 
     # Skip only if we had changes but they were all filtered out
     # Don't skip empty files (which have no lines to begin with)

--- a/src/git_stage_batch/core/line_identity.py
+++ b/src/git_stage_batch/core/line_identity.py
@@ -1,0 +1,96 @@
+"""Best-effort helpers for preserving user-facing line IDs."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from difflib import SequenceMatcher
+
+from .models import LineEntry, LineLevelChange
+
+
+def _changed_line_entries(
+    line_changes: LineLevelChange,
+) -> list[tuple[int, LineEntry]]:
+    return [
+        (index, line)
+        for index, line in enumerate(line_changes.lines)
+        if line.kind in ("+", "-") and line.id is not None
+    ]
+
+
+def _line_signature(line: LineEntry) -> tuple[str, bytes, bool]:
+    return (line.kind, line.text_bytes, line.has_trailing_newline)
+
+
+def preserve_line_ids_from_previous_view(
+    previous: LineLevelChange | None,
+    current: LineLevelChange,
+) -> LineLevelChange:
+    """Carry unchanged line IDs from a previous view into a refreshed view.
+
+    This is intentionally best-effort. It only preserves IDs for equal changed
+    line runs that can be aligned by kind/content/order. New or unmatched rows
+    receive IDs after the previous maximum so old holes stay empty.
+    """
+    if previous is None or previous.path != current.path:
+        return current
+
+    previous_entries = _changed_line_entries(previous)
+    current_entries = _changed_line_entries(current)
+    if not previous_entries or not current_entries:
+        return current
+
+    previous_signatures = [_line_signature(line) for _index, line in previous_entries]
+    current_signatures = [_line_signature(line) for _index, line in current_entries]
+    matcher = SequenceMatcher(
+        None,
+        previous_signatures,
+        current_signatures,
+        autojunk=False,
+    )
+
+    id_by_current_index: dict[int, int] = {}
+    used_ids: set[int] = set()
+    for tag, previous_start, previous_end, current_start, current_end in matcher.get_opcodes():
+        if tag != "equal":
+            continue
+        length = min(previous_end - previous_start, current_end - current_start)
+        for offset in range(length):
+            previous_line = previous_entries[previous_start + offset][1]
+            current_index = current_entries[current_start + offset][0]
+            if previous_line.id is None or previous_line.id in used_ids:
+                continue
+            id_by_current_index[current_index] = previous_line.id
+            used_ids.add(previous_line.id)
+
+    previous_ids = [
+        line.id
+        for _index, line in previous_entries
+        if line.id is not None
+    ]
+    next_id = max(previous_ids, default=0) + 1
+
+    changed = False
+    remapped_lines: list[LineEntry] = []
+    for index, line in enumerate(current.lines):
+        if line.kind not in ("+", "-") or line.id is None:
+            remapped_lines.append(line)
+            continue
+
+        replacement_id = id_by_current_index.get(index)
+        if replacement_id is None:
+            while next_id in used_ids:
+                next_id += 1
+            replacement_id = next_id
+            used_ids.add(replacement_id)
+            next_id += 1
+
+        if line.id == replacement_id:
+            remapped_lines.append(line)
+        else:
+            remapped_lines.append(replace(line, id=replacement_id))
+            changed = True
+
+    if not changed:
+        return current
+    return replace(current, lines=remapped_lines)

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -55,6 +55,7 @@ from ..editor import (
     write_buffer_to_path,
 )
 from ..core.line_selection import LineRanges, write_line_ids_file
+from ..core.line_identity import preserve_line_ids_from_previous_view
 from ..exceptions import CommandError, MergeError, NoMoreHunks, exit_with_error
 from ..i18n import _, ngettext
 from ..output import print_line_level_changes, print_binary_file_change, print_gitlink_change
@@ -137,6 +138,17 @@ class SelectedChangeStateSnapshot:
 def write_selected_hunk_patch_lines(patch_lines: Sequence[bytes]) -> None:
     with EditorBuffer.from_chunks(iter(patch_lines)) as patch_buffer:
         write_buffer_to_path(get_selected_hunk_patch_file_path(), patch_buffer)
+
+
+def _write_line_changes_state(line_changes: LineLevelChange) -> None:
+    write_text_file_contents(
+        get_line_changes_json_file_path(),
+        json.dumps(
+            convert_line_changes_to_serializable_dict(line_changes),
+            ensure_ascii=False,
+            indent=0,
+        ),
+    )
 
 
 def _load_line_changes_from_patch_path(patch_path: Path) -> LineLevelChange:
@@ -992,23 +1004,14 @@ def _filter_consumed_replacement_masks(
 
     flush_changed_run()
 
-    new_id = 1
-    renumbered_lines = []
-    for line_entry in filtered_lines:
-        renumbered_lines.append(
-            replace(line_entry, id=new_id if line_entry.kind != " " else None)
-        )
-        if line_entry.kind != " ":
-            new_id += 1
-
-    has_changes_after_filter = any(line.kind in ("+", "-") for line in renumbered_lines)
+    has_changes_after_filter = any(line.kind in ("+", "-") for line in filtered_lines)
     if not has_changes_after_filter:
         return None
 
     return LineLevelChange(
         path=line_changes.path,
         header=line_changes.header,
-        lines=renumbered_lines,
+        lines=filtered_lines,
     )
 
 
@@ -2067,6 +2070,9 @@ def recalculate_selected_hunk_for_file(
         file_path: Repository-relative path to recalculate hunk for
     """
     selected_kind = read_selected_change_kind()
+    previous_line_changes = load_line_changes_from_state()
+    if previous_line_changes is not None and previous_line_changes.path != file_path:
+        previous_line_changes = None
 
     # Clear processed IDs since old line numbers don't apply to fresh hunk
     write_line_ids_file(get_processed_include_ids_file_path(), set())
@@ -2082,6 +2088,12 @@ def recalculate_selected_hunk_for_file(
             else:
                 mark_selected_change_cleared_by_auto_advance_disabled()
             return
+
+        line_changes = preserve_line_ids_from_previous_view(
+            previous_line_changes,
+            line_changes,
+        )
+        _write_line_changes_state(line_changes)
 
         if apply_line_level_batch_filter_to_cached_hunk():
             clear_selected_change_state_files()
@@ -2138,9 +2150,11 @@ def recalculate_selected_hunk_for_file(
                     single_hunk.lines,
                     annotator=annotate_with_batch_source,
                 )
-                write_text_file_contents(get_line_changes_json_file_path(),
-                                        json.dumps(convert_line_changes_to_serializable_dict(line_changes),
-                                                  ensure_ascii=False, indent=0))
+                line_changes = preserve_line_ids_from_previous_view(
+                    previous_line_changes,
+                    line_changes,
+                )
+                _write_line_changes_state(line_changes)
                 write_snapshots_for_selected_file_path(line_changes.path)
 
                 # Apply batch filter to exclude batched lines

--- a/tests/commands/test_discard.py
+++ b/tests/commands/test_discard.py
@@ -15,6 +15,7 @@ from git_stage_batch.data.hunk_tracking import (
     recalculate_selected_hunk_for_file,
     selected_change_was_cleared_by_auto_advance_disabled,
 )
+from git_stage_batch.data.line_state import load_line_changes_from_state
 
 import subprocess
 
@@ -123,6 +124,30 @@ class TestCommandDiscard:
             text=True,
         )
         assert "+added" not in diff_result.stdout
+
+    def test_discard_lines_to_batch_preserves_later_line_ids(self, temp_git_repo):
+        """Saving and removing a middle line leaves later line IDs sparse."""
+        readme = temp_git_repo / "README.md"
+        readme.write_text("# Test\nLine 1\nLine 2\nLine 3\nLine 4\n")
+
+        command_start()
+        fetch_next_change()
+
+        command_discard_to_batch("stable-ids", line_ids="2", quiet=True)
+
+        line_changes = load_line_changes_from_state()
+        assert line_changes is not None
+        changed_lines = [
+            line
+            for line in line_changes.lines
+            if line.kind in ("+", "-") and line.id is not None
+        ]
+        assert [line.id for line in changed_lines] == [1, 3, 4]
+        assert [line.display_text() for line in changed_lines] == [
+            "Line 1",
+            "Line 3",
+            "Line 4",
+        ]
 
     def test_discard_no_changes(self, temp_git_repo, capsys):
         """Test discard when no more hunks remain."""
@@ -665,8 +690,8 @@ class TestCommandDiscardToBatch:
         # Recalculate hunk after first discard
         recalculate_selected_hunk_for_file("README.md")
 
-        # Discard line 2 (now line 1 in the renumbered hunk)
-        command_discard_to_batch("accum-batch", line_ids="1")
+        # Discard line 2 using its preserved sparse ID.
+        command_discard_to_batch("accum-batch", line_ids="2")
 
         # Verify batch contains both lines
         content = read_file_from_batch("accum-batch", "README.md")

--- a/tests/commands/test_file_review.py
+++ b/tests/commands/test_file_review.py
@@ -661,9 +661,11 @@ def test_pathless_include_to_batch_line_filters_file_review_selection(
 
     filtered = load_line_changes_from_state()
     assert filtered is not None
-    assert [line.display_text() for line in filtered.lines if line.id is not None] == ["Y"]
+    filtered_lines = [line for line in filtered.lines if line.id is not None]
+    assert [line.display_text() for line in filtered_lines] == ["Y"]
+    assert [line.id for line in filtered_lines] == [2]
 
-    command_include_to_batch("second", line_ids="1", quiet=True)
+    command_include_to_batch("second", line_ids="2", quiet=True)
 
     first_metadata = read_batch_metadata("first")
     second_metadata = read_batch_metadata("second")

--- a/tests/commands/test_file_scoped_operations.py
+++ b/tests/commands/test_file_scoped_operations.py
@@ -350,13 +350,13 @@ class TestShowFileFlag:
         assert line_changes is not None
         remaining_ids = [line.id for line in line_changes.lines if line.id is not None]
         remaining_texts = [line.display_text() for line in line_changes.lines if line.id is not None]
-        assert remaining_ids == [1, 2]
+        assert remaining_ids == [6, 7]
         assert remaining_texts == [
             "from old_beta import helper",
             "from new_beta import helper",
         ]
 
-        command_include_line("1,2", file="module.py")
+        command_include_line(",".join(str(line_id) for line_id in remaining_ids), file="module.py")
 
         result = run_git_command(["show", ":module.py"])
         assert result.stdout == "".join(rewritten)

--- a/tests/commands/test_include.py
+++ b/tests/commands/test_include.py
@@ -514,8 +514,8 @@ class TestCommandIncludeLine:
         # Include line 2 (which adds line1)
         command_include_line("2")
 
-        # Include line 3 (which adds line2) after recalculation
-        command_include_line("2")
+        # Include line 3 (which adds line2) using its preserved sparse ID.
+        command_include_line("3")
 
         # Check staged content
         result = subprocess.run(

--- a/tests/commands/test_include_to.py
+++ b/tests/commands/test_include_to.py
@@ -62,9 +62,9 @@ class TestCommandIncludeToBatch:
         filtered_lines = load_line_changes_from_state()
         changed_lines = [line for line in filtered_lines.lines if line.kind != " "]
         assert len(changed_lines) == 2
-        # Line IDs should be renumbered: was [1,2,3], after filtering [1] should be [1,2]
-        assert changed_lines[0].id == 1
-        assert changed_lines[1].id == 2
+        # Remaining line IDs are left sparse so later references do not shift.
+        assert changed_lines[0].id == 2
+        assert changed_lines[1].id == 3
 
     def test_include_lines_to_batch_displays_filtered_hunk_once(self, temp_git_repo, capsys):
         """Line-level include to batch prints the remaining hunk only once."""
@@ -265,8 +265,8 @@ class TestCommandIncludeToBatch:
         # Include line 1
         command_include_to_batch("accum-batch", line_ids="1")
 
-        # Include line 3 (line 2 in filtered view)
-        command_include_to_batch("accum-batch", line_ids="2")
+        # Include line 3 using its preserved sparse ID.
+        command_include_to_batch("accum-batch", line_ids="3")
 
         # Verify batch contains both lines
         content = read_file_from_batch("accum-batch", "README.md")


### PR DESCRIPTION
Line-level selection views currently rebuild IDs from refreshed diffs after include, discard, and batch-filter operations.

Users can lose their place when an earlier selected row disappears because later rows receive lower IDs even though those rows remain unchanged.

The PR addresses that by adding a conservative same-file remapping helper, applying it during live view recalculation, and leaving filtered rows with their original IDs. New unmatched rows receive IDs after the previous maximum so old holes stay empty.

Tests cover include, discard, file-review, and file-scoped follow-up selections that use the displayed sparse IDs.

Verification:
- `uv run pytest -n auto -q`