### PR TITLE
state: Auto-add untracked submodule pointers

### DIFF
--- a/src/git_stage_batch/data/file_tracking.py
+++ b/src/git_stage_batch/data/file_tracking.py
@@ -10,9 +10,15 @@ from ..utils.journal import log_journal
 from ..utils.paths import get_auto_added_files_file_path
 
 
-def _is_embedded_git_repository(file_path: str) -> bool:
-    path = get_git_repository_root_path() / file_path.rstrip("/")
-    return path.is_dir() and (path / ".git").exists()
+def _embedded_git_repository_index_path(file_path: str) -> str | None:
+    normalized_path = file_path.rstrip("/")
+    if not normalized_path:
+        return None
+
+    path = get_git_repository_root_path() / normalized_path
+    if path.is_dir() and (path / ".git").exists():
+        return normalized_path
+    return None
 
 
 def list_untracked_files(paths: Iterable[str] | None = None) -> list[str]:
@@ -50,33 +56,31 @@ def auto_add_untracked_files(paths: Iterable[str] | None = None) -> None:
     # Add untracked files even when they were recorded earlier. A user may have
     # removed the intent-to-add entry with git restore --staged during a session.
     for file_path in untracked_files:
-        if _is_embedded_git_repository(file_path):
-            log_journal("skip_auto_add_embedded_git_repository", file_path=file_path)
-            continue
+        index_path = _embedded_git_repository_index_path(file_path) or file_path
 
         # Get before state
         ls_before = run_git_command(
-            ["ls-files", "--stage", "--", file_path],
+            ["ls-files", "--stage", "--", index_path],
             check=False,
             requires_index_lock=False,
         ).stdout.strip()
 
-        result = git_add_paths([file_path], intent_to_add=True, check=False)
+        result = git_add_paths([index_path], intent_to_add=True, check=False)
         if result.returncode == 0:
-            already_recorded = file_path in auto_added_files
+            already_recorded = index_path in auto_added_files
             if not already_recorded:
-                append_file_path_to_file(auto_added_path, file_path)
-                auto_added_files.add(file_path)
+                append_file_path_to_file(auto_added_path, index_path)
+                auto_added_files.add(index_path)
 
             # Get after state
             ls_after = run_git_command(
-                ["ls-files", "--stage", "--", file_path],
+                ["ls-files", "--stage", "--", index_path],
                 check=False,
                 requires_index_lock=False,
             ).stdout.strip()
             log_journal(
                 "git_add_intent_to_add",
-                file_path=file_path,
+                file_path=index_path,
                 index_before=ls_before,
                 index_after=ls_after,
                 already_recorded=already_recorded,

--- a/tests/commands/test_submodule_pointers.py
+++ b/tests/commands/test_submodule_pointers.py
@@ -33,6 +33,8 @@ from git_stage_batch.data.hunk_tracking import (
 )
 from git_stage_batch.exceptions import CommandError
 
+EMPTY_BLOB_HASH = "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"
+
 
 @pytest.fixture
 def submodule_pointer_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, str, str]:
@@ -98,6 +100,32 @@ def added_submodule_pointer_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 
 
 @pytest.fixture
+def untracked_submodule_pointer_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, str]:
+    """Create a superproject with an untracked embedded repository."""
+    repo = tmp_path / "repo"
+    submodule = repo / "sub"
+    repo.mkdir()
+
+    _run(["git", "init"], cwd=repo)
+    _configure_identity(repo)
+    (repo / "base.txt").write_text("base\n")
+    _run(["git", "add", "base.txt"], cwd=repo)
+    _run(["git", "commit", "-m", "Add base"], cwd=repo)
+
+    submodule.mkdir()
+    _run(["git", "init"], cwd=submodule)
+    _configure_identity(submodule)
+    (submodule / "file.txt").write_text("sub\n")
+    _run(["git", "add", "file.txt"], cwd=submodule)
+    _run(["git", "commit", "-m", "Add sub file"], cwd=submodule)
+    new_oid = _git_stdout(["rev-parse", "HEAD"], cwd=submodule)
+    _run(["git", "config", "diff.ignoreSubmodules", "all"], cwd=repo)
+    monkeypatch.chdir(repo)
+
+    return repo, new_oid
+
+
+@pytest.fixture
 def deleted_submodule_pointer_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, str]:
     """Create a superproject with a deleted submodule pointer."""
     repo = tmp_path / "repo"
@@ -156,6 +184,24 @@ def test_start_shows_added_submodule_pointer(
     assert f"sub :: Submodule added at {new_oid[:12]}" in captured.out
     assert read_selected_change_kind() == SelectedChangeKind.GITLINK
     assert get_selected_change_file_path() == "sub"
+
+
+def test_start_auto_adds_untracked_submodule_pointer(
+    untracked_submodule_pointer_repo: tuple[Path, str],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """start should automatically present untracked embedded repositories."""
+    repo, new_oid = untracked_submodule_pointer_repo
+
+    command_start()
+
+    captured = capsys.readouterr()
+    assert f"sub :: Submodule added at {new_oid[:12]}" in captured.out
+    assert read_selected_change_kind() == SelectedChangeKind.GITLINK
+    assert get_selected_change_file_path() == "sub"
+    assert _git_stdout(["ls-files", "--stage", "--", "sub"], cwd=repo) == (
+        f"160000 {EMPTY_BLOB_HASH} 0\tsub"
+    )
 
 
 def test_start_shows_deleted_submodule_pointer(

--- a/tests/data/test_file_tracking.py
+++ b/tests/data/test_file_tracking.py
@@ -11,6 +11,8 @@ from git_stage_batch.utils.paths import (
     get_auto_added_files_file_path,
 )
 
+EMPTY_BLOB_HASH = "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"
+
 
 @pytest.fixture
 def temp_git_repo(tmp_path, monkeypatch):
@@ -240,8 +242,8 @@ class TestAutoAddUntrackedFiles:
         auto_added = read_file_paths_file(get_auto_added_files_file_path())
         assert "my file.txt" in auto_added
 
-    def test_auto_add_skips_untracked_embedded_git_repository(self, temp_git_repo):
-        """Test that untracked embedded repositories are not auto-added."""
+    def test_auto_add_marks_untracked_embedded_git_repository_as_gitlink(self, temp_git_repo):
+        """Test that untracked embedded repositories are auto-added as gitlinks."""
         ensure_state_directory_exists()
 
         embedded_repo = temp_git_repo / "embedded"
@@ -252,11 +254,18 @@ class TestAutoAddUntrackedFiles:
         (embedded_repo / "file.txt").write_text("content\n")
         subprocess.run(["git", "add", "file.txt"], check=True, cwd=embedded_repo, capture_output=True)
         subprocess.run(["git", "commit", "-m", "Add file"], check=True, cwd=embedded_repo, capture_output=True)
+        embedded_oid = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            check=True,
+            cwd=embedded_repo,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
 
         auto_add_untracked_files()
 
         auto_added = read_file_paths_file(get_auto_added_files_file_path())
-        assert "embedded" not in auto_added
+        assert "embedded" in auto_added
         assert "embedded/" not in auto_added
 
         result = subprocess.run(
@@ -266,4 +275,13 @@ class TestAutoAddUntrackedFiles:
             capture_output=True,
             text=True,
         )
-        assert result.stdout == ""
+        assert result.stdout.strip() == f"160000 {EMPTY_BLOB_HASH} 0\tembedded"
+
+        diff_result = subprocess.run(
+            ["git", "diff", "--ignore-submodules=none", "--submodule=short", "HEAD", "--", "embedded"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+            text=True,
+        )
+        assert f"+Subproject commit {embedded_oid}" in diff_result.stdout


### PR DESCRIPTION
The session workflow currently auto-adds untracked file paths with intent-to-add entries so new files appear in live diffs. Submodule pointer support can render mode-160000 changes once Git has an index entry to compare against the working tree.

Users who create an embedded repository before starting a session cannot review that added submodule pointer from startup. The auto-add pass skips the embedded repository, so no gitlink entry is available for the diff parser to present.

This PR addresses that by normalizing embedded repository paths to their index path before running git add -N and recording the same normalized path for session cleanup. It adds regression coverage for the lower-level auto-add marker and for start presenting an untracked embedded repository as an added submodule pointer.

Validation:
- `uv run pytest tests/data/test_file_tracking.py tests/commands/test_submodule_pointers.py tests/commands/test_abort.py tests/commands/test_stop.py`
- `uv run ruff check tests/data/test_file_tracking.py tests/commands/test_submodule_pointers.py`