### PR TITLE
workflow: Present renames as staging choices

### DIFF
--- a/assets/claude-skills/commit-unstaged-changes/SKILL.md
+++ b/assets/claude-skills/commit-unstaged-changes/SKILL.md
@@ -181,10 +181,13 @@ not count as coupling.
 ## Core Workflow
 
 1. Inspect the repository state with `git status --short`.
-2. Check whether the index already contains staged changes.
-3. If staged changes already exist, stop and tell the user this skill only
-   handles **unstaged** changes. Do not commit the staged set, and do not use
-   `git-stage-batch` to add more changes on top of it.
+2. Run `git-stage-batch check-unstaged` to check whether the index is
+   suitable for this unstaged-only workflow.
+3. If `check-unstaged` fails, stop and tell the user this skill only handles
+   **unstaged** changes. Do not commit the staged set, and do not use
+   `git-stage-batch` to add more changes on top of it. If it succeeds with a
+   staged-rename notice, continue; `git-stage-batch start` will normalize
+   those start-time renames into workflow content.
 4. Check for repository-specific commit guidance before planning messages.
    Read `CONTRIBUTING.md` when present, and inspect `.git/hooks/commit-msg`
    when present, so commit prefixes, body format, trailers, and validation
@@ -498,7 +501,10 @@ flag.
 ## `git-stage-batch` Workflow
 
 Use the non-interactive subcommands rather than interactive mode.
-Do not start a `git-stage-batch` session until the index is clean.
+Before starting a `git-stage-batch` session, run
+`git-stage-batch check-unstaged`. Do not start the session if that command
+fails. A passing staged-rename notice is allowed because `start` will present
+those renames as workflow content.
 
 ### Start a pass
 
@@ -608,9 +614,9 @@ not stop and restart. Run `stop` once at the very end.
 
 For each commit:
 
-1. Verify that the index does not already contain staged changes.
-2. If it does, stop and tell the user this skill only handles unstaged
-   changes.
+1. Run `git-stage-batch check-unstaged`.
+2. If it fails, stop and tell the user this skill only handles unstaged
+   changes, except for staged renames that pass this check.
 3. Otherwise, if no session is active, run `git-stage-batch start`.
 4. Inspect each selected hunk with `show`. Read the changed lines and
    classify each one by which concern it serves.

--- a/assets/codex-skills/commit-unstaged-changes/SKILL.md
+++ b/assets/codex-skills/commit-unstaged-changes/SKILL.md
@@ -182,10 +182,13 @@ not count as coupling.
 ## Core Workflow
 
 1. Inspect the repository state with `git status --short`.
-2. Check whether the index already contains staged changes.
-3. If staged changes already exist, stop and tell the user this skill only
-   handles **unstaged** changes. Do not commit the staged set, and do not use
-   `git-stage-batch` to add more changes on top of it.
+2. Run `git-stage-batch check-unstaged` to check whether the index is
+   suitable for this unstaged-only workflow.
+3. If `check-unstaged` fails, stop and tell the user this skill only handles
+   **unstaged** changes. Do not commit the staged set, and do not use
+   `git-stage-batch` to add more changes on top of it. If it succeeds with a
+   staged-rename notice, continue; `git-stage-batch start` will normalize
+   those start-time renames into workflow content.
 4. If a required command fails because `.git` is read-only or a write under
    `.git` is blocked, immediately retry it with escalated permissions. Do not
    keep probing the repository with more read-only commands once the sandbox
@@ -678,7 +681,10 @@ pushing the problem back to the user.
 ## `git-stage-batch` Workflow
 
 Use the non-interactive subcommands rather than interactive mode.
-Do not start a `git-stage-batch` session until the index is clean.
+Before starting a `git-stage-batch` session, run
+`git-stage-batch check-unstaged`. Do not start the session if that command
+fails. A passing staged-rename notice is allowed because `start` will present
+those renames as workflow content.
 
 ### Start a pass
 
@@ -848,9 +854,9 @@ Always stop the session when done.
 
 For each commit:
 
-1. Verify that the index does not already contain staged changes.
-2. If it does, stop and tell the user this skill only handles unstaged
-   changes.
+1. Run `git-stage-batch check-unstaged`.
+2. If it fails, stop and tell the user this skill only handles unstaged
+   changes, except for staged renames that pass this check.
 3. Otherwise, if no session is active, run `git-stage-batch start`.
 4. Inspect each selected hunk with `show`. Read the changed lines and
    classify each one by which concern it serves. Record whether each line is
@@ -1327,7 +1333,9 @@ The program has Spanish translation but lacks French.
 
 ## Safety Checks
 
-- Do not commit pre-existing staged changes.
+- Do not commit pre-existing staged changes, except staged renames that pass
+  `git-stage-batch check-unstaged` and are then deliberately staged through the
+  `git-stage-batch` workflow.
 - Do not fold unrelated refactors, cleanup, or drive-by formatting into a
   feature commit just because they are adjacent in the diff.
 - Do not try to simplify the story by broadening the commit. When the rules

--- a/docs/ai-assistants.md
+++ b/docs/ai-assistants.md
@@ -312,9 +312,9 @@ git commit -m "docs: Document dashboard feature"
 # AI refactors code with both rename and logic changes
 git-stage-batch start
 
-# Separate rename from logic changes using line-level
-# Hunk shows both rename and logic change
-git-stage-batch include --line 1-5    # rename only
+# Separate rename from logic changes
+# First prompt shows the structural rename
+git-stage-batch include               # rename only
 git commit -m "refactor: Rename helper_function to process_data"
 
 git-stage-batch again

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -4,6 +4,20 @@ Complete reference of all available commands.
 
 ## Core Operations
 
+### `check-unstaged`
+
+Check whether the current index is suitable for an unstaged-only workflow.
+
+```
+❯ git-stage-batch check-unstaged
+```
+
+Exits successfully when the index is clean, or when the only staged changes
+are renames that `start` can normalize into workflow content. Exits with code
+2 when other staged changes are present.
+
+---
+
 ### `start`
 
 Find and display the first unprocessed hunk; cache as "selected".

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -24,6 +24,12 @@ Find and display the first unprocessed hunk; cache as "selected".
 
 Resets state if a session is already in progress.
 
+Live session diffs render renames as atomic `old -> new` choices. A selected
+rename can be included, skipped, or discarded with the rest of the workflow.
+At session start, staged renames are temporarily normalized into that same
+live workflow; if a normalized start-time rename is left untouched, `stop` or
+`abort` restores the original staged rename.
+
 ---
 
 ### `show [--file [PATH] | --files PATTERN...]`

--- a/src/git_stage_batch/cli/argument_parser.py
+++ b/src/git_stage_batch/cli/argument_parser.py
@@ -697,6 +697,14 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
         help=_("Available commands"),
     )
 
+    # check-unstaged - Check whether the index fits an unstaged-only workflow
+    parser_check_unstaged = _add_subcommand_parser(
+        subparsers,
+        "check-unstaged",
+        help=_("Check whether the index fits an unstaged-only workflow"),
+    )
+    parser_check_unstaged.set_defaults(func=lambda _: commands.command_check_unstaged())
+
     # start - Start a new batch staging session
     parser_start = _add_subcommand_parser(
         subparsers,

--- a/src/git_stage_batch/commands/__init__.py
+++ b/src/git_stage_batch/commands/__init__.py
@@ -7,6 +7,7 @@ from .again import command_again
 from .annotate import command_annotate_batch
 from .apply_from import command_apply_from_batch
 from .block_file import command_block_file
+from .check_unstaged import command_check_unstaged
 from .discard import (
     command_discard,
     command_discard_file,
@@ -44,6 +45,7 @@ __all__ = [
     "command_annotate_batch",
     "command_apply_from_batch",
     "command_block_file",
+    "command_check_unstaged",
     "command_discard",
     "command_discard_file",
     "command_discard_file_as",

--- a/src/git_stage_batch/commands/abort.py
+++ b/src/git_stage_batch/commands/abort.py
@@ -8,6 +8,7 @@ import sys
 
 from ..data.batch_refs import restore_batch_refs
 from ..data.session import clear_session_state
+from ..data.staged_renames import read_staged_renames
 from ..exceptions import exit_with_error
 from ..i18n import _
 from ..utils.file_io import read_file_paths_file, read_text_file_contents
@@ -18,6 +19,7 @@ from ..utils.git import (
     git_reset_hard,
     git_reset_paths,
     require_git_repository,
+    run_git_command,
 )
 from ..utils.paths import (
     get_abort_head_file_path,
@@ -27,6 +29,28 @@ from ..utils.paths import (
     get_auto_added_files_file_path,
     get_abort_state_directory_path,
 )
+
+
+def _remove_normalized_rename_destinations_before_stash_apply() -> None:
+    renames = read_staged_renames()
+    if not renames:
+        return
+
+    repo_root = get_git_repository_root_path()
+    for rename in renames:
+        tracked_result = run_git_command(
+            ["ls-files", "--error-unmatch", "--", rename.new_path],
+            check=False,
+            requires_index_lock=False,
+        )
+        if tracked_result.returncode == 0:
+            continue
+
+        target_path = repo_root / rename.new_path
+        if target_path.is_dir() and not target_path.is_symlink():
+            shutil.rmtree(target_path)
+        else:
+            target_path.unlink(missing_ok=True)
 
 
 def command_abort() -> None:
@@ -55,6 +79,7 @@ def command_abort() -> None:
 
     print(_("Resetting to {}...").format(abort_head[:7]), file=sys.stderr)
     git_reset_hard(abort_head, env=env)
+    _remove_normalized_rename_destinations_before_stash_apply()
 
     # Apply original stash if it exists (with --index to restore staged state)
     if abort_stash:

--- a/src/git_stage_batch/commands/check_unstaged.py
+++ b/src/git_stage_batch/commands/check_unstaged.py
@@ -1,0 +1,40 @@
+"""Read-only checks for unstaged-only batch workflows."""
+
+from __future__ import annotations
+
+import sys
+
+from ..data.staged_renames import list_staged_change_records, staged_changes_are_only_normalizable_renames
+from ..exceptions import CommandError
+from ..i18n import _, ngettext
+from ..utils.git import require_git_repository
+
+
+def command_check_unstaged() -> None:
+    """Check whether the index is suitable for an unstaged-only workflow."""
+    require_git_repository()
+
+    staged_records = list_staged_change_records()
+    if not staged_records:
+        print(_("Index is clean for an unstaged-only workflow."), file=sys.stderr)
+        return
+
+    if staged_changes_are_only_normalizable_renames():
+        rename_count = len(staged_records)
+        print(
+            ngettext(
+                "Index contains {count} staged rename that start will treat as workflow content.",
+                "Index contains {count} staged renames that start will treat as workflow content.",
+                rename_count,
+            ).format(count=rename_count),
+            file=sys.stderr,
+        )
+        return
+
+    raise CommandError(
+        _(
+            "Index contains staged changes outside start-time renames. "
+            "Commit, stash, or unstage them before using the unstaged-only workflow."
+        ),
+        exit_code=2,
+    )

--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -45,10 +45,11 @@ from ..core.diff_parser import (
 from ..core.hashing import (
     compute_binary_file_hash,
     compute_gitlink_change_hash,
+    compute_rename_change_hash,
     compute_stable_hunk_hash_from_lines,
 )
 from ..core.line_selection import parse_line_selection
-from ..core.models import BinaryFileChange, GitlinkChange
+from ..core.models import BinaryFileChange, GitlinkChange, RenameChange
 from ..core.text_lifecycle import TextFileChangeType, detect_empty_text_lifecycle_change
 from ..data.hunk_tracking import (
     SelectedChangeKind,
@@ -66,9 +67,11 @@ from ..data.hunk_tracking import (
     refuse_bare_action_after_file_list,
     render_binary_file_change,
     render_gitlink_change,
+    render_rename_change,
     require_selected_hunk,
     restore_selected_change_state,
     snapshot_selected_change_state,
+    stream_live_git_diff,
 )
 from ..data.file_review_state import (
     FileReviewAction,
@@ -108,10 +111,10 @@ from ..utils.git import (
     git_apply_to_worktree,
     git_checkout_paths,
     git_remove_paths,
+    git_update_index,
     git_update_gitlink,
     require_git_repository,
     run_git_command,
-    stream_git_diff,
 )
 from ..utils.journal import log_journal
 from ..utils.paths import (
@@ -169,6 +172,59 @@ def _discard_gitlink_change(gitlink_change: GitlinkChange) -> None:
             _("Failed to update submodule pointer in the index for {file}: {error}").format(
                 file=file_path,
                 error=index_result.stderr,
+            )
+        )
+
+
+def _remove_worktree_path(file_path: str) -> None:
+    """Remove a working-tree path if it still exists after index cleanup."""
+    absolute_path = get_git_repository_root_path() / file_path
+    if not os.path.lexists(absolute_path):
+        return
+    if absolute_path.is_dir() and not absolute_path.is_symlink():
+        # A rename diff is file-oriented, but avoid leaving an untracked directory
+        # behind if the destination path was replaced while the prompt was open.
+        for child in sorted(absolute_path.rglob("*"), reverse=True):
+            if child.is_dir() and not child.is_symlink():
+                child.rmdir()
+            else:
+                child.unlink()
+        absolute_path.rmdir()
+        return
+    absolute_path.unlink()
+
+
+def _discard_rename_change(rename_change: RenameChange) -> None:
+    """Restore the old path and remove the renamed destination."""
+    snapshot_files_if_untracked([rename_change.new_path])
+
+    remove_result = git_remove_paths(
+        [rename_change.new_path],
+        force=True,
+        ignore_unmatch=True,
+        check=False,
+    )
+    if remove_result.returncode != 0:
+        index_result = git_update_index(
+            file_path=rename_change.new_path,
+            force_remove=True,
+            check=False,
+        )
+        if index_result.returncode != 0:
+            exit_with_error(
+                _("Failed to remove renamed path {file}: {error}").format(
+                    file=rename_change.new_path,
+                    error=index_result.stderr,
+                )
+            )
+        _remove_worktree_path(rename_change.new_path)
+
+    restore_result = git_checkout_paths("HEAD", [rename_change.old_path], check=False)
+    if restore_result.returncode != 0:
+        exit_with_error(
+            _("Failed to restore renamed source {file}: {error}").format(
+                file=rename_change.old_path,
+                error=restore_result.stderr,
             )
         )
 
@@ -281,6 +337,26 @@ def command_discard(
         patch_hash = read_text_file_contents(get_selected_hunk_hash_file_path()).strip()
 
         # Handle based on item type
+        if isinstance(item, RenameChange):
+            _discard_rename_change(item)
+            append_lines_to_file(get_block_list_file_path(), [patch_hash])
+            record_hunk_discarded(patch_hash)
+
+            if not quiet:
+                print(
+                    _("✓ Rename discarded: {old} -> {new}").format(
+                        old=item.old_path,
+                        new=item.new_path,
+                    ),
+                    file=sys.stderr,
+                )
+
+            finish_selected_change_action(
+                quiet=quiet,
+                auto_advance=auto_advance,
+            )
+            return
+
         if isinstance(item, GitlinkChange):
             _discard_gitlink_change(item)
             append_lines_to_file(get_block_list_file_path(), [patch_hash])
@@ -509,6 +585,23 @@ def command_discard_file(
             finish_selected_change_action(quiet=False, auto_advance=auto_advance)
             return
 
+        rename_change = render_rename_change(target_file)
+        if rename_change is not None:
+            patch_hash = compute_rename_change_hash(rename_change)
+            _discard_rename_change(rename_change)
+            if patch_hash not in blocked_hashes:
+                append_lines_to_file(blocklist_path, [patch_hash])
+                record_hunk_discarded(patch_hash)
+            print(
+                _("✓ Rename discarded: {old} -> {new}").format(
+                    old=rename_change.old_path,
+                    new=rename_change.new_path,
+                ),
+                file=sys.stderr,
+            )
+            finish_selected_change_action(quiet=False, auto_advance=auto_advance)
+            return
+
         # Snapshot the file if it's untracked (for abort functionality)
         snapshot_file_if_untracked(target_file)
 
@@ -516,9 +609,18 @@ def command_discard_file(
         # (git rm -f will stage the deletion, making hunks disappear from git diff)
         hashes_to_block = []
         with acquire_unified_diff(
-            stream_git_diff(context_lines=get_context_lines())
+            stream_live_git_diff(context_lines=get_context_lines())
         ) as patches:
             for patch in patches:
+                if isinstance(patch, RenameChange):
+                    if target_file not in (patch.old_path, patch.new_path):
+                        continue
+
+                    patch_hash = compute_rename_change_hash(patch)
+                    if patch_hash not in blocked_hashes:
+                        hashes_to_block.append(patch_hash)
+                    continue
+
                 if isinstance(patch, BinaryFileChange):
                     file_path = patch.new_path if patch.new_path != "/dev/null" else patch.old_path
                     if file_path != target_file:
@@ -740,6 +842,22 @@ def command_discard_to_batch(
     if file is not None:
         operation_parts.extend(["--file", file])
     with undo_checkpoint(" ".join(operation_parts)):
+        if (
+            file is None
+            and line_ids is None
+            and read_selected_change_kind() == SelectedChangeKind.RENAME
+        ):
+            selected_change = load_selected_change()
+            if isinstance(selected_change, RenameChange):
+                exit_with_error(
+                    _(
+                        "Cannot discard rename '{old} -> {new}' to a batch yet. "
+                        "Discard, skip, or stage the rename first."
+                    ).format(
+                        old=selected_change.old_path,
+                        new=selected_change.new_path,
+                    )
+                )
         if (
             file is None
             and line_ids is None
@@ -1247,13 +1365,16 @@ def _collect_text_file_discard_inputs(
     files_with_text_patches: set[str] = set()
 
     with acquire_unified_diff(
-        stream_git_diff(
+        stream_live_git_diff(
             base="HEAD",
             context_lines=get_context_lines(),
             paths=files,
         )
     ) as patches:
         for patch in patches:
+            if isinstance(patch, RenameChange):
+                continue
+
             if isinstance(patch, GitlinkChange):
                 exit_with_error(_("Discarding submodule pointer changes to a batch is not supported yet."))
 
@@ -1500,15 +1621,20 @@ def _command_discard_file_to_batch(
         patches_to_discard = []
 
         with acquire_unified_diff(
-            stream_git_diff(
+            stream_live_git_diff(
                 base="HEAD",
                 context_lines=get_context_lines(),
                 paths=[file_path],
             )
         ) as patches:
             for patch in patches:
+                if isinstance(patch, RenameChange):
+                    continue
+
                 if isinstance(patch, GitlinkChange):
                     exit_with_error(_("Discarding submodule pointer changes to a batch is not supported yet."))
+                if isinstance(patch, BinaryFileChange):
+                    continue
 
                 patch_hash = compute_stable_hunk_hash_from_lines(patch.lines)
 
@@ -1858,6 +1984,13 @@ def _command_discard_hunk_to_batch(
     except NoMoreHunks:
         print(_("No changes to process."), file=sys.stderr)
         return 0
+    if isinstance(selected_item, RenameChange):
+        exit_with_error(
+            _(
+                "Cannot discard rename '{old} -> {new}' to a batch yet. "
+                "Discard, skip, or stage the rename first."
+            ).format(old=selected_item.old_path, new=selected_item.new_path)
+        )
     if isinstance(selected_item, GitlinkChange):
         exit_with_error(_("Discarding submodule pointer changes to a batch is not supported yet."))
     if isinstance(selected_item, BinaryFileChange):
@@ -1911,11 +2044,16 @@ def _command_discard_text_hunk_to_batch(
         if file_only:
             # Collect ALL hunks from this file
             with acquire_unified_diff(
-                stream_git_diff(context_lines=get_context_lines())
+                stream_live_git_diff(context_lines=get_context_lines())
             ) as patches:
                 for patch in patches:
+                    if isinstance(patch, RenameChange):
+                        continue
+
                     if isinstance(patch, GitlinkChange):
                         exit_with_error(_("Discarding submodule pointer changes to a batch is not supported yet."))
+                    if isinstance(patch, BinaryFileChange):
+                        continue
 
                     if patch.new_path != file_path:
                         continue

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -39,6 +39,7 @@ from ..core.diff_parser import (
 from ..core.hashing import (
     compute_binary_file_hash,
     compute_gitlink_change_hash,
+    compute_rename_change_hash,
     compute_stable_hunk_hash_from_lines,
 )
 from ..core.line_selection import (
@@ -47,7 +48,7 @@ from ..core.line_selection import (
     read_line_ids_file,
     write_line_ids_file,
 )
-from ..core.models import BinaryFileChange, GitlinkChange
+from ..core.models import BinaryFileChange, GitlinkChange, RenameChange
 from ..core.text_lifecycle import detect_empty_text_lifecycle_change
 from ..data.hunk_tracking import (
     SelectedChangeKind,
@@ -73,6 +74,7 @@ from ..data.hunk_tracking import (
     restore_selected_change_state,
     snapshot_selected_change_state,
     snapshots_are_stale,
+    stream_live_git_diff,
 )
 from ..data.file_review_state import (
     FileReviewAction,
@@ -111,13 +113,14 @@ from ..utils.file_io import (
 )
 from ..utils.git import (
     get_git_repository_root_path,
+    GitIndexEntryUpdate,
     git_add_paths,
     git_apply_to_index,
     git_update_index,
+    git_update_index_entries,
     git_update_gitlink,
     require_git_repository,
     run_git_command,
-    stream_git_diff,
 )
 from ..utils.journal import log_journal
 from ..utils.paths import (
@@ -153,6 +156,48 @@ def _update_index_for_gitlink_change(gitlink_change: GitlinkChange):
         file_path=file_path,
         oid=gitlink_change.new_oid,
         check=False,
+    )
+
+
+def _index_entry_for_path(file_path: str) -> tuple[str, str] | None:
+    """Return mode and object id for the current index entry at file_path."""
+    result = run_git_command(
+        ["ls-files", "-s", "--", file_path],
+        check=False,
+        text_output=False,
+        requires_index_lock=False,
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+
+    header = result.stdout.split(b"\n", 1)[0].split(b"\t", 1)[0]
+    parts = header.split()
+    if len(parts) < 2:
+        return None
+    return parts[0].decode("ascii"), parts[1].decode("ascii")
+
+
+def _stage_rename_change(rename_change: RenameChange) -> None:
+    """Stage only the structural rename, leaving destination content edits unstaged."""
+    index_entry = _index_entry_for_path(rename_change.old_path)
+    if index_entry is None:
+        exit_with_error(
+            _("Cannot stage rename {old} -> {new}: missing baseline index entry.").format(
+                old=rename_change.old_path,
+                new=rename_change.new_path,
+            )
+        )
+
+    mode, blob_sha = index_entry
+    git_update_index_entries(
+        [
+            GitIndexEntryUpdate(file_path=rename_change.old_path, force_remove=True),
+            GitIndexEntryUpdate(
+                file_path=rename_change.new_path,
+                mode=mode,
+                blob_sha=blob_sha,
+            ),
+        ]
     )
 
 
@@ -517,6 +562,25 @@ def command_include(
         patch_hash = read_text_file_contents(get_selected_hunk_hash_file_path()).strip()
 
         # Handle based on item type
+        if isinstance(item, RenameChange):
+            _stage_rename_change(item)
+            record_hunk_included(patch_hash)
+
+            if not quiet:
+                print(
+                    _("✓ Rename staged: {old} -> {new}").format(
+                        old=item.old_path,
+                        new=item.new_path,
+                    ),
+                    file=sys.stderr,
+                )
+
+            finish_selected_change_action(
+                quiet=quiet,
+                auto_advance=auto_advance,
+            )
+            return
+
         if isinstance(item, GitlinkChange):
             result = _update_index_for_gitlink_change(item)
             if result.returncode != 0:
@@ -656,14 +720,31 @@ def command_include_file(
         # follow-up `show --files` / `include --files` passes in the same session.
         hunks_staged = 0
         submodule_pointers_staged = 0
+        renames_staged = 0
+        staged_rename_pairs: set[tuple[str, str]] = set()
         with acquire_unified_diff(
-            stream_git_diff(
+            stream_live_git_diff(
                 full_index=True,
                 ignore_submodules="none",
                 submodule_format="short",
             )
         ) as patches:
             for patch in patches:
+                if isinstance(patch, RenameChange):
+                    if target_file not in (patch.old_path, patch.new_path):
+                        continue
+
+                    _stage_rename_change(patch)
+                    result = git_add_paths([patch.new_path], check=False)
+                    if result.returncode != 0:
+                        print(_("Failed to stage renamed file: {error}").format(error=result.stderr), file=sys.stderr)
+                        break
+                    record_hunk_included(compute_rename_change_hash(patch))
+                    hunks_staged += 1
+                    renames_staged += 1
+                    staged_rename_pairs.add((patch.old_path, patch.new_path))
+                    continue
+
                 if isinstance(patch, GitlinkChange):
                     if patch.path() == target_file:
                         result = _update_index_for_gitlink_change(patch)
@@ -701,6 +782,9 @@ def command_include_file(
                 if target_file not in patch_paths:
                     continue
 
+                if (patch.old_path, patch.new_path) in staged_rename_pairs:
+                    continue
+
                 patch_hash = compute_stable_hunk_hash_from_lines(patch.lines)
 
                 if patch.old_path != patch.new_path:
@@ -734,7 +818,13 @@ def command_include_file(
         return hunks_staged
 
     # Print summary message
-    if submodule_pointers_staged == hunks_staged:
+    if renames_staged == hunks_staged:
+        msg = ngettext(
+            "✓ Staged {count} rename from {file}",
+            "✓ Staged {count} renames from {file}",
+            hunks_staged,
+        ).format(count=hunks_staged, file=target_file)
+    elif submodule_pointers_staged == hunks_staged:
         msg = ngettext(
             "✓ Staged {count} submodule pointer from {file}",
             "✓ Staged {count} submodule pointers from {file}",
@@ -1493,6 +1583,22 @@ def command_include_to_batch(
         if (
             file is None
             and line_ids is None
+            and read_selected_change_kind() == SelectedChangeKind.RENAME
+        ):
+            selected_change = load_selected_change()
+            if isinstance(selected_change, RenameChange):
+                exit_with_error(
+                    _(
+                        "Cannot include rename '{old} -> {new}' to a batch yet. "
+                        "Stage, skip, or discard the rename first."
+                    ).format(
+                        old=selected_change.old_path,
+                        new=selected_change.new_path,
+                    )
+                )
+        if (
+            file is None
+            and line_ids is None
             and read_selected_change_kind() == SelectedChangeKind.GITLINK
         ):
             selected_change = load_selected_change()
@@ -1720,13 +1826,15 @@ def _command_include_file_to_batch(
     all_lines_to_batch = []
 
     with acquire_unified_diff(
-        stream_git_diff(
+        stream_live_git_diff(
             base="HEAD",
             context_lines=get_context_lines(),
             paths=[file_path],
         )
     ) as patches:
         for patch in patches:
+            if isinstance(patch, RenameChange):
+                continue
             hunk_lines = build_line_changes_from_patch_lines(
                 patch.lines,
                 annotator=annotate_with_batch_source,
@@ -1993,7 +2101,7 @@ def _command_include_hunk_to_batch(
     selected_line_changes = None
     selected_hash = None
     with acquire_unified_diff(
-        stream_git_diff(
+        stream_live_git_diff(
             context_lines=get_context_lines(),
             full_index=True,
             ignore_submodules="none",
@@ -2001,6 +2109,9 @@ def _command_include_hunk_to_batch(
         )
     ) as patches:
         for patch in patches:
+            if isinstance(patch, RenameChange):
+                continue
+
             if isinstance(patch, GitlinkChange):
                 patch_hash = compute_gitlink_change_hash(patch)
                 if patch_hash not in blocked_hashes:
@@ -2053,7 +2164,7 @@ def _command_include_hunk_to_batch(
     if file_only:
         # Collect ALL hunks from this file
         with acquire_unified_diff(
-            stream_git_diff(
+            stream_live_git_diff(
                 context_lines=get_context_lines(),
                 full_index=True,
                 ignore_submodules="none",
@@ -2061,6 +2172,9 @@ def _command_include_hunk_to_batch(
             )
         ) as patches:
             for patch in patches:
+                if isinstance(patch, RenameChange):
+                    continue
+
                 if patch.new_path != file_path:
                     continue
 

--- a/src/git_stage_batch/commands/show.py
+++ b/src/git_stage_batch/commands/show.py
@@ -11,23 +11,27 @@ from ..core.diff_parser import write_snapshots_for_selected_file_path
 from ..core.hashing import (
     compute_binary_file_hash,
     compute_gitlink_change_hash,
+    compute_rename_change_hash,
     compute_stable_hunk_hash_from_lines,
 )
-from ..core.models import BinaryFileChange, GitlinkChange
+from ..core.models import BinaryFileChange, GitlinkChange, RenameChange
 from ..data.hunk_tracking import (
     SelectedChangeKind,
     apply_line_level_batch_filter_to_cached_hunk,
     cache_binary_file_change,
     cache_file_as_single_hunk,
     cache_gitlink_change,
+    cache_rename_change,
     clear_selected_change_state_files,
     get_selected_change_file_path,
     mark_selected_change_cleared_by_file_list,
     render_binary_file_change,
     render_gitlink_change,
+    render_rename_change,
     render_file_as_single_hunk,
     restore_selected_change_state,
     snapshot_selected_change_state,
+    stream_live_git_diff,
     write_selected_hunk_patch_lines,
     write_selected_change_kind,
 )
@@ -40,7 +44,12 @@ from ..data.line_state import convert_line_changes_to_serializable_dict, load_li
 from ..data.session import require_session_started
 from ..exceptions import exit_with_error
 from ..i18n import _
-from ..output import print_binary_file_change, print_gitlink_change, print_line_level_changes
+from ..output import (
+    print_binary_file_change,
+    print_gitlink_change,
+    print_line_level_changes,
+    print_rename_change,
+)
 from ..output.file_review import (
     build_file_review_model,
     make_file_review_state,
@@ -52,13 +61,14 @@ from ..output.file_review_list import (
     make_binary_file_review_list_entry,
     make_file_review_list_entry,
     make_gitlink_file_review_list_entry,
+    make_rename_file_review_list_entry,
     print_file_review_list,
 )
 from ..utils.file_io import (
     read_text_file_line_set,
     write_text_file_contents,
 )
-from ..utils.git import require_git_repository, stream_git_diff
+from ..utils.git import require_git_repository
 from ..utils.paths import (
     ensure_state_directory_exists,
     get_block_list_file_path,
@@ -83,6 +93,7 @@ def command_show_file_list(files: list[str]) -> None:
     ensure_state_directory_exists()
 
     entries = []
+    seen_rename_hashes: set[str] = set()
     for file_path in files:
         line_changes = render_file_as_single_hunk(file_path)
         if line_changes is not None:
@@ -95,6 +106,13 @@ def command_show_file_list(files: list[str]) -> None:
         gitlink_change = render_gitlink_change(file_path)
         if gitlink_change is not None:
             entries.append(make_gitlink_file_review_list_entry(gitlink_change))
+            continue
+        rename_change = render_rename_change(file_path)
+        if rename_change is not None:
+            rename_hash = compute_rename_change_hash(rename_change)
+            if rename_hash not in seen_rename_hashes:
+                entries.append(make_rename_file_review_list_entry(rename_change))
+                seen_rename_hashes.add(rename_hash)
 
     if not entries:
         print(_("No reviewable changes in matched files."), file=sys.stderr)
@@ -151,6 +169,21 @@ def command_show(
             if preview_lines is None and binary_change is None else
             None
         )
+        rename_change = (
+            render_rename_change(target_file)
+            if preview_lines is None and binary_change is None and gitlink_change is None else
+            None
+        )
+        if rename_change is not None:
+            if page is not None:
+                exit_with_error(_("File review pages are only available for text changes."))
+            if selectable:
+                clear_last_file_review_state()
+                cache_rename_change(rename_change)
+            if porcelain:
+                return
+            print_rename_change(rename_change)
+            return
         if gitlink_change is not None:
             if page is not None:
                 exit_with_error(_("File review pages are only available for text changes."))
@@ -240,7 +273,7 @@ def command_show(
 
     # Stream diff and show first unblocked hunk
     with acquire_unified_diff(
-        stream_git_diff(
+        stream_live_git_diff(
             context_lines=get_context_lines(),
             full_index=True,
             ignore_submodules="none",
@@ -248,6 +281,16 @@ def command_show(
         )
     ) as patches:
         for patch in patches:
+            if isinstance(patch, RenameChange):
+                rename_hash = compute_rename_change_hash(patch)
+                if rename_hash not in blocked_hashes:
+                    cache_rename_change(patch)
+                    clear_last_file_review_state()
+                    if not porcelain:
+                        print_rename_change(patch)
+                    return
+                continue
+
             if isinstance(patch, GitlinkChange):
                 gitlink_hash = compute_gitlink_change_hash(patch)
                 if gitlink_hash not in blocked_hashes:
@@ -267,6 +310,13 @@ def command_show(
                         print_binary_file_change(patch)
                     return
                 continue
+
+            if patch.old_path != patch.new_path:
+                rename_hash = compute_rename_change_hash(
+                    RenameChange(old_path=patch.old_path, new_path=patch.new_path)
+                )
+                if rename_hash in blocked_hashes:
+                    continue
 
             patch_hash = compute_stable_hunk_hash_from_lines(patch.lines)
             if patch_hash not in blocked_hashes:

--- a/src/git_stage_batch/commands/skip.py
+++ b/src/git_stage_batch/commands/skip.py
@@ -10,6 +10,7 @@ from ..core.diff_parser import acquire_unified_diff, build_line_changes_from_pat
 from ..core.hashing import (
     compute_binary_file_hash,
     compute_gitlink_change_hash,
+    compute_rename_change_hash,
     compute_stable_hunk_hash_from_lines,
 )
 from ..core.line_selection import (
@@ -18,7 +19,7 @@ from ..core.line_selection import (
     write_line_ids_file,
 )
 from ..batch.selection import require_line_selection_in_view
-from ..core.models import BinaryFileChange, GitlinkChange
+from ..core.models import BinaryFileChange, GitlinkChange, RenameChange
 from ..data.hunk_tracking import (
     SelectedChangeKind,
     fetch_next_change,
@@ -29,9 +30,11 @@ from ..data.hunk_tracking import (
     record_binary_hunk_skipped,
     record_gitlink_hunk_skipped,
     record_hunk_skipped,
+    record_rename_hunk_skipped,
     refuse_bare_action_after_auto_advance_disabled,
     refuse_bare_action_after_file_list,
     require_selected_hunk,
+    stream_live_git_diff,
 )
 from ..data.file_review_state import (
     FileReviewAction,
@@ -53,7 +56,7 @@ from ..utils.file_io import (
     read_text_file_contents,
     write_text_file_contents,
 )
-from ..utils.git import require_git_repository, stream_git_diff
+from ..utils.git import require_git_repository
 from ..utils.journal import log_journal
 from ..utils.paths import (
     ensure_state_directory_exists,
@@ -101,6 +104,26 @@ def command_skip(
         patch_hash = read_text_file_contents(get_selected_hunk_hash_file_path()).strip()
 
         # Handle based on item type
+        if isinstance(item, RenameChange):
+            blocklist_path = get_block_list_file_path()
+            append_lines_to_file(blocklist_path, [patch_hash])
+            record_rename_hunk_skipped(item, patch_hash)
+
+            if not quiet:
+                print(
+                    _("✓ Rename skipped: {old} -> {new}").format(
+                        old=item.old_path,
+                        new=item.new_path,
+                    ),
+                    file=sys.stderr,
+                )
+
+            finish_selected_change_action(
+                quiet=quiet,
+                auto_advance=auto_advance,
+            )
+            return
+
         if isinstance(item, GitlinkChange):
             blocklist_path = get_block_list_file_path()
             append_lines_to_file(blocklist_path, [patch_hash])
@@ -210,7 +233,7 @@ def command_skip_file(
 
         hunks_skipped = 0
         with acquire_unified_diff(
-            stream_git_diff(
+            stream_live_git_diff(
                 context_lines=get_context_lines(),
                 full_index=True,
                 ignore_submodules="none",
@@ -218,6 +241,20 @@ def command_skip_file(
             )
         ) as patches:
             for patch in patches:
+                if isinstance(patch, RenameChange):
+                    if target_file not in (patch.old_path, patch.new_path):
+                        continue
+
+                    patch_hash = compute_rename_change_hash(patch)
+                    if patch_hash in blocked_hashes:
+                        continue
+
+                    append_lines_to_file(blocklist_path, [patch_hash])
+                    blocked_hashes.add(patch_hash)
+                    record_rename_hunk_skipped(patch, patch_hash)
+                    hunks_skipped += 1
+                    continue
+
                 if isinstance(patch, GitlinkChange):
                     if patch.path() != target_file:
                         continue
@@ -247,7 +284,11 @@ def command_skip_file(
                     hunks_skipped += 1
                     continue
 
-                if patch.new_path != target_file:
+                patch_paths = {
+                    path for path in (patch.old_path, patch.new_path)
+                    if path != "/dev/null"
+                }
+                if target_file not in patch_paths:
                     continue
 
                 patch_hash = compute_stable_hunk_hash_from_lines(patch.lines)

--- a/src/git_stage_batch/commands/start.py
+++ b/src/git_stage_batch/commands/start.py
@@ -9,6 +9,7 @@ from ..data.auto_advance import DEFAULT_AUTO_ADVANCE, write_auto_advance_default
 from ..data.hunk_tracking import clear_selected_change_state_files, fetch_next_change, show_selected_change
 from ..data.file_tracking import auto_add_untracked_files
 from ..data.session import initialize_abort_state
+from ..data.staged_renames import normalize_start_time_staged_renames
 from ..exceptions import CommandError, NoMoreHunks
 from ..i18n import _
 from ..utils.file_io import write_text_file_contents
@@ -43,6 +44,12 @@ def command_start(
 
     # Initialize abort state for new session
     initialize_abort_state()
+
+    # Staged renames are already in the index, so a plain worktree-vs-index
+    # pass would otherwise never offer them as workflow choices. Preserve the
+    # exact start state in abort metadata first, then expose rename pairs as
+    # unstaged rename choices for this session.
+    normalize_start_time_staged_renames()
 
     write_auto_advance_default(
         DEFAULT_AUTO_ADVANCE

--- a/src/git_stage_batch/commands/status.py
+++ b/src/git_stage_batch/commands/status.py
@@ -12,10 +12,11 @@ from ..batch.query import read_batch_metadata
 from ..core.hashing import (
     compute_binary_file_hash,
     compute_gitlink_change_hash,
+    compute_rename_change_hash,
     compute_stable_hunk_hash_from_lines,
 )
 from ..core.diff_parser import acquire_unified_diff
-from ..core.models import BinaryFileChange, GitlinkChange
+from ..core.models import BinaryFileChange, GitlinkChange, RenameChange
 from ..data.file_review_state import (
     FileReviewAction,
     ReviewSource,
@@ -31,11 +32,14 @@ from ..data.hunk_tracking import (
     gitlink_change_is_stale,
     load_selected_binary_file,
     load_selected_gitlink_change,
+    load_selected_rename_change,
     mark_selected_change_cleared_by_stale_batch_selection,
     read_selected_change_kind,
+    rename_change_is_stale,
     selected_batch_binary_batch_name,
     selected_batch_binary_file_for_batch,
     snapshots_are_stale,
+    stream_live_git_diff,
 )
 from ..data.line_state import load_line_changes_from_state
 from ..data.session import get_iteration_count
@@ -48,7 +52,7 @@ from ..utils.file_io import (
     read_file_paths_file,
     read_text_file_line_set,
 )
-from ..utils.git import require_git_repository, run_git_command, stream_git_diff
+from ..utils.git import require_git_repository, run_git_command
 from ..utils.paths import (
     get_block_list_file_path,
     get_blocked_files_file_path,
@@ -106,7 +110,7 @@ def estimate_remaining_hunks() -> int:
     remaining = 0
     try:
         with acquire_unified_diff(
-            stream_git_diff(
+            stream_live_git_diff(
                 context_lines=get_context_lines(),
                 full_index=True,
                 ignore_submodules="none",
@@ -114,13 +118,28 @@ def estimate_remaining_hunks() -> int:
             )
         ) as patches:
             for patch in patches:
-                if isinstance(patch, GitlinkChange):
+                if isinstance(patch, RenameChange):
+                    hunk_hash = compute_rename_change_hash(patch)
+                    if (
+                        hunk_hash not in blocked_hashes
+                        and not is_path_blocked(patch.old_path, blocked_files)
+                        and not is_path_blocked(patch.new_path, blocked_files)
+                    ):
+                        remaining += 1
+                    continue
+                elif isinstance(patch, GitlinkChange):
                     hunk_hash = compute_gitlink_change_hash(patch)
                     file_path = patch.path()
                 elif isinstance(patch, BinaryFileChange):
                     hunk_hash = compute_binary_file_hash(patch)
                     file_path = patch.new_path if patch.new_path != "/dev/null" else patch.old_path
                 else:
+                    if patch.old_path != patch.new_path:
+                        rename_hash = compute_rename_change_hash(
+                            RenameChange(old_path=patch.old_path, new_path=patch.new_path)
+                        )
+                        if rename_hash in blocked_hashes:
+                            continue
                     hunk_hash = compute_stable_hunk_hash_from_lines(patch.lines)
                     file_path = patch.old_path if patch.old_path != "/dev/null" else patch.new_path
                 file_path = file_path.removeprefix("a/").removeprefix("b/")
@@ -145,6 +164,7 @@ def _selected_kind_label(selected_kind: str | None) -> str:
         SelectedChangeKind.HUNK.value: _("Current hunk:"),
         SelectedChangeKind.FILE.value: _("Current file review:"),
         SelectedChangeKind.BATCH_FILE.value: _("Current batch file review:"),
+        SelectedChangeKind.RENAME.value: _("Current rename:"),
         SelectedChangeKind.BINARY.value: _("Current binary file:"),
         SelectedChangeKind.BATCH_BINARY.value: _("Current batch binary file:"),
         SelectedChangeKind.GITLINK.value: _("Current submodule pointer:"),
@@ -206,6 +226,22 @@ def _read_live_review_display_ids(file_path: str) -> list[int] | None:
 def _read_selected_change_summary() -> tuple[bool, dict | None]:
     """Return whether a non-stale selected change exists and its status summary."""
     selected_kind = read_selected_change_kind()
+    if selected_kind == SelectedChangeKind.RENAME:
+        rename_change = load_selected_rename_change()
+        if rename_change is None:
+            return False, None
+        if rename_change_is_stale(rename_change):
+            return False, None
+        return True, {
+            "kind": selected_kind.value,
+            "file": rename_change.new_path,
+            "line": None,
+            "ids": [],
+            "change_type": "renamed",
+            "old_path": rename_change.old_path,
+            "new_path": rename_change.new_path,
+        }
+
     if selected_kind in (SelectedChangeKind.GITLINK, SelectedChangeKind.BATCH_GITLINK):
         gitlink_change = load_selected_gitlink_change()
         if gitlink_change is None:

--- a/src/git_stage_batch/commands/stop.py
+++ b/src/git_stage_batch/commands/stop.py
@@ -4,11 +4,21 @@ from __future__ import annotations
 
 import sys
 
+from ..data.staged_renames import restore_unstaged_start_time_renames
 from ..data.session import clear_session_state
 from ..i18n import _
 from ..utils.file_io import read_file_paths_file
-from ..utils.git import git_reset_paths, require_git_repository
+from ..utils.git import git_reset_paths, require_git_repository, run_git_command
 from ..utils.paths import get_auto_added_files_file_path
+
+
+def _path_has_staged_content(file_path: str) -> bool:
+    result = run_git_command(
+        ["diff", "--cached", "--quiet", "--no-renames", "--", file_path],
+        check=False,
+        requires_index_lock=False,
+    )
+    return result.returncode == 1
 
 
 def command_stop() -> None:
@@ -20,7 +30,11 @@ def command_stop() -> None:
     if auto_added_path.exists():
         auto_added = read_file_paths_file(auto_added_path)
         for file_path in auto_added:
+            if _path_has_staged_content(file_path):
+                continue
             git_reset_paths([file_path], check=False)
+
+    restore_unstaged_start_time_renames()
 
     # Clear all session state (preserves batches and batch-sources)
     clear_session_state()

--- a/src/git_stage_batch/core/diff_parser.py
+++ b/src/git_stage_batch/core/diff_parser.py
@@ -13,6 +13,7 @@ from .models import (
     LineLevelChange,
     HunkHeader,
     LineEntry,
+    RenameChange,
     SingleHunkPatch,
 )
 from ..editor import (
@@ -31,7 +32,7 @@ from ..utils.paths import get_index_snapshot_file_path, get_working_tree_snapsho
 
 # Type for annotator hooks that enrich LineLevelChange with additional metadata
 LineLevelChangeAnnotator = Callable[[str, LineLevelChange], LineLevelChange]
-UnifiedDiffItem = Union[SingleHunkPatch, BinaryFileChange, GitlinkChange]
+UnifiedDiffItem = Union[SingleHunkPatch, BinaryFileChange, GitlinkChange, RenameChange]
 
 
 HUNK_HEADER_PATTERN = re.compile(r"^@@\s+-(\d+)(?:,(\d+))?\s+\+(\d+)(?:,(\d+))?\s+@@")
@@ -54,6 +55,13 @@ def _metadata_indicates_gitlink(metadata_lines: list[bytes]) -> bool:
         if match is not None and match.group(3) == b"160000":
             return True
     return False
+
+
+def _metadata_indicates_rename(metadata_lines: list[bytes]) -> bool:
+    """Return whether diff metadata describes a path rename."""
+    has_rename_from = any(line.startswith(b"rename from ") for line in metadata_lines)
+    has_rename_to = any(line.startswith(b"rename to ") for line in metadata_lines)
+    return has_rename_from and has_rename_to
 
 
 def _gitlink_oids_from_index(metadata_lines: list[bytes]) -> tuple[str | None, str | None]:
@@ -336,10 +344,14 @@ class _UnifiedDiffParserBuildContext:
                             break
 
                     is_gitlink = _metadata_indicates_gitlink(metadata_lines)
+                    is_rename = _metadata_indicates_rename(metadata_lines)
                     index_old_oid, index_new_oid = _gitlink_oids_from_index(metadata_lines)
 
                     # Handle files without unified diff hunks
                     if old_file_line is None:
+                        if is_rename:
+                            yield RenameChange(old_path=old_path, new_path=new_path)
+
                         if is_gitlink:
                             yield GitlinkChange(
                                 old_path=_gitlink_old_path(old_path, index_old_oid),
@@ -384,6 +396,9 @@ class _UnifiedDiffParserBuildContext:
                             )
                             continue
 
+                        if is_rename:
+                            continue
+
                         # Check if this is an empty new file (new file with no content)
                         # Empty new files have "new file mode" and "index 0000000..e69de29" (empty blob, short hash)
                         EMPTY_BLOB_SHORT_HASH = b"e69de29"  # Short hash for empty blob
@@ -413,6 +428,9 @@ class _UnifiedDiffParserBuildContext:
                     if not plus_line_stripped.startswith(b"+++"):
                         continue
                     new_file_line = plus_line_stripped
+
+                    if is_rename:
+                        yield RenameChange(old_path=old_path, new_path=new_path)
 
                     if is_gitlink:
                         hunk_old_oid, hunk_new_oid = _consume_gitlink_hunks(next_line, peek_line)

--- a/src/git_stage_batch/core/hashing.py
+++ b/src/git_stage_batch/core/hashing.py
@@ -7,7 +7,7 @@ from collections.abc import Iterable
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from .models import BinaryFileChange, GitlinkChange
+    from .models import BinaryFileChange, GitlinkChange, RenameChange
 
 
 def compute_stable_hunk_hash_from_lines(patch_lines: Iterable[bytes]) -> str:
@@ -105,5 +105,15 @@ def compute_gitlink_change_hash(gitlink_change: GitlinkChange) -> str:
         gitlink_change.old_oid or "",
         gitlink_change.new_oid or "",
         gitlink_change.change_type,
+    ]
+    return hashlib.sha256("\0".join(parts).encode("utf-8")).hexdigest()
+
+
+def compute_rename_change_hash(rename_change: RenameChange) -> str:
+    """Compute a stable identity hash for an atomic rename change."""
+    parts = [
+        "rename",
+        rename_change.old_path,
+        rename_change.new_path,
     ]
     return hashlib.sha256("\0".join(parts).encode("utf-8")).hexdigest()

--- a/src/git_stage_batch/core/models.py
+++ b/src/git_stage_batch/core/models.py
@@ -73,6 +73,17 @@ class BinaryFileChange:
         return self.change_type == "modified"
 
 
+@dataclass(frozen=True)
+class RenameChange:
+    """Represents an atomic file rename without content ownership."""
+    old_path: str
+    new_path: str
+
+    def path(self) -> str:
+        """Return the destination path for file-scoped follow-up actions."""
+        return self.new_path
+
+
 @dataclass
 class GitlinkChange:
     """Represents a change to a gitlink/submodule pointer.

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -9,7 +9,7 @@ import subprocess
 import sys
 from collections.abc import Sequence
 from contextlib import ExitStack
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from enum import Enum
 from hashlib import sha256
 from pathlib import Path
@@ -30,6 +30,7 @@ from ..batch.query import get_batch_commit_sha, list_batch_names, read_batch_met
 from ..core.hashing import (
     compute_binary_file_hash,
     compute_gitlink_change_hash,
+    compute_rename_change_hash,
     compute_stable_hunk_hash_from_lines,
 )
 from ..core.models import (
@@ -38,6 +39,7 @@ from ..core.models import (
     LineLevelChange,
     HunkHeader,
     LineEntry,
+    RenameChange,
     RenderedBatchDisplay,
     ReviewActionGroup,
 )
@@ -58,7 +60,12 @@ from ..core.line_selection import LineRanges, write_line_ids_file
 from ..core.line_identity import preserve_line_ids_from_previous_view
 from ..exceptions import CommandError, MergeError, NoMoreHunks, exit_with_error
 from ..i18n import _, ngettext
-from ..output import print_line_level_changes, print_binary_file_change, print_gitlink_change
+from ..output import (
+    print_line_level_changes,
+    print_binary_file_change,
+    print_gitlink_change,
+    print_rename_change,
+)
 from .consumed_selections import read_consumed_file_metadata
 from .auto_advance import resolve_auto_advance
 from .file_tracking import auto_add_untracked_files
@@ -84,6 +91,7 @@ from ..utils.paths import (
     get_selected_change_kind_file_path,
     get_selected_binary_file_json_path,
     get_selected_gitlink_file_json_path,
+    get_selected_rename_file_json_path,
     get_selected_hunk_hash_file_path,
     get_selected_hunk_patch_file_path,
     get_line_changes_json_file_path,
@@ -103,6 +111,7 @@ class SelectedChangeKind(str, Enum):
 
     HUNK = "hunk"
     FILE = "file"
+    RENAME = "rename"
     BINARY = "binary"
     GITLINK = "submodule"
     BATCH_FILE = "batch-file"
@@ -116,6 +125,12 @@ _BATCH_MERGE_REVIEW_ACTIONS = (
     "apply-from-batch",
 )
 _BATCH_RESET_REVIEW_ACTION = "reset-from-batch"
+
+
+def stream_live_git_diff(**kwargs):
+    """Stream actionable live changes with rename detection enabled."""
+    kwargs.setdefault("find_renames", True)
+    return stream_git_diff(**kwargs)
 
 
 @dataclass
@@ -172,6 +187,7 @@ def _selected_change_state_paths():
         "clear_reason": get_selected_change_clear_reason_file_path(),
         "kind": get_selected_change_kind_file_path(),
         "line_state": get_line_changes_json_file_path(),
+        "rename": get_selected_rename_file_json_path(),
         "binary": get_selected_binary_file_json_path(),
         "gitlink": get_selected_gitlink_file_json_path(),
         "index_snapshot": get_index_snapshot_file_path(),
@@ -490,6 +506,36 @@ def load_selected_gitlink_change() -> Optional[GitlinkChange]:
         return None
 
 
+def _read_selected_rename_data() -> dict | None:
+    """Read cached rename selection data, if structurally valid."""
+    rename_path = get_selected_rename_file_json_path()
+    if not rename_path.exists():
+        return None
+    try:
+        rename_data = json.loads(read_text_file_contents(rename_path))
+    except json.JSONDecodeError:
+        return None
+    return rename_data if isinstance(rename_data, dict) else None
+
+
+def load_selected_rename_change() -> Optional[RenameChange]:
+    """Load the currently cached rename change."""
+    if read_selected_change_kind() != SelectedChangeKind.RENAME:
+        return None
+
+    rename_data = _read_selected_rename_data()
+    if rename_data is None:
+        return None
+
+    try:
+        return RenameChange(
+            old_path=rename_data["old_path"],
+            new_path=rename_data["new_path"],
+        )
+    except KeyError:
+        return None
+
+
 def compute_batch_binary_fingerprint(
     batch_name: str,
     file_path: str,
@@ -544,6 +590,7 @@ def cache_binary_file_change(
     }
     get_selected_hunk_patch_file_path().unlink(missing_ok=True)
     get_line_changes_json_file_path().unlink(missing_ok=True)
+    get_selected_rename_file_json_path().unlink(missing_ok=True)
     get_index_snapshot_file_path().unlink(missing_ok=True)
     get_working_tree_snapshot_file_path().unlink(missing_ok=True)
     get_processed_include_ids_file_path().unlink(missing_ok=True)
@@ -586,6 +633,7 @@ def cache_gitlink_change(
     }
     get_selected_hunk_patch_file_path().unlink(missing_ok=True)
     get_line_changes_json_file_path().unlink(missing_ok=True)
+    get_selected_rename_file_json_path().unlink(missing_ok=True)
     get_selected_binary_file_json_path().unlink(missing_ok=True)
     get_index_snapshot_file_path().unlink(missing_ok=True)
     get_working_tree_snapshot_file_path().unlink(missing_ok=True)
@@ -600,6 +648,31 @@ def cache_gitlink_change(
         compute_gitlink_change_hash(gitlink_change),
     )
     write_selected_change_kind(kind)
+
+
+def cache_rename_change(rename_change: RenameChange) -> None:
+    """Cache a rename change as the current selected change."""
+    rename_data = {
+        "old_path": rename_change.old_path,
+        "new_path": rename_change.new_path,
+    }
+    get_selected_hunk_patch_file_path().unlink(missing_ok=True)
+    get_line_changes_json_file_path().unlink(missing_ok=True)
+    get_selected_binary_file_json_path().unlink(missing_ok=True)
+    get_selected_gitlink_file_json_path().unlink(missing_ok=True)
+    get_index_snapshot_file_path().unlink(missing_ok=True)
+    get_working_tree_snapshot_file_path().unlink(missing_ok=True)
+    get_processed_include_ids_file_path().unlink(missing_ok=True)
+    get_processed_skip_ids_file_path().unlink(missing_ok=True)
+    write_text_file_contents(
+        get_selected_rename_file_json_path(),
+        json.dumps(rename_data, ensure_ascii=False, indent=0),
+    )
+    write_text_file_contents(
+        get_selected_hunk_hash_file_path(),
+        compute_rename_change_hash(rename_change),
+    )
+    write_selected_change_kind(SelectedChangeKind.RENAME)
 
 
 def selected_batch_binary_matches_batch(batch_name: str) -> bool:
@@ -811,9 +884,24 @@ def gitlink_change_is_stale(gitlink_change: GitlinkChange) -> bool:
     )
 
 
+def rename_change_is_stale(rename_change: RenameChange) -> bool:
+    """Return whether a cached rename selection no longer matches Git state."""
+    current_change = render_rename_change(rename_change.new_path)
+    if current_change is None:
+        current_change = render_rename_change(rename_change.old_path)
+    if current_change is None:
+        return True
+    return (
+        current_change.old_path != rename_change.old_path
+        or current_change.new_path != rename_change.new_path
+    )
+
+
 def write_selected_change_kind(kind: SelectedChangeKind) -> None:
     """Persist the kind of selected change cached in session state."""
     get_selected_change_clear_reason_file_path().unlink(missing_ok=True)
+    if kind != SelectedChangeKind.RENAME:
+        get_selected_rename_file_json_path().unlink(missing_ok=True)
     if kind not in (SelectedChangeKind.BINARY, SelectedChangeKind.BATCH_BINARY):
         get_selected_binary_file_json_path().unlink(missing_ok=True)
     if kind not in (SelectedChangeKind.GITLINK, SelectedChangeKind.BATCH_GITLINK):
@@ -837,9 +925,20 @@ def read_selected_change_kind() -> Optional[SelectedChangeKind]:
         return None
 
 
-def load_selected_change() -> Optional[Union[LineLevelChange, BinaryFileChange, GitlinkChange]]:
+def load_selected_change() -> Optional[Union[LineLevelChange, BinaryFileChange, GitlinkChange, RenameChange]]:
     """Load the currently cached selected change, if any."""
     selected_kind = read_selected_change_kind()
+    rename_change = load_selected_rename_change()
+    if rename_change is not None:
+        if selected_kind == SelectedChangeKind.RENAME and rename_change_is_stale(rename_change):
+            raise CommandError(
+                _(
+                    "Selected rename no longer matches the working tree: {old} -> {new}.\n"
+                    "Run 'show' again before using a pathless action."
+                ).format(old=rename_change.old_path, new=rename_change.new_path)
+            )
+        return rename_change
+
     gitlink_change = load_selected_gitlink_change()
     if gitlink_change is not None:
         if selected_kind == SelectedChangeKind.GITLINK and gitlink_change_is_stale(gitlink_change):
@@ -884,6 +983,10 @@ def get_selected_change_file_path() -> Optional[str]:
     selected-lines.json is derived state and may lag after display/navigation
     edge cases.
     """
+    rename_change = load_selected_rename_change()
+    if rename_change is not None:
+        return rename_change.path()
+
     gitlink_change = load_selected_gitlink_change()
     if gitlink_change is not None:
         return gitlink_change.path()
@@ -1545,7 +1648,7 @@ def render_file_as_single_hunk(file_path: str) -> Optional[LineLevelChange]:
     """Render all changes for a file as a single hunk without caching state."""
     auto_add_untracked_files([file_path])
     with acquire_unified_diff(
-        stream_git_diff(
+        stream_live_git_diff(
             base="HEAD",
             context_lines=get_context_lines(),
             full_index=True,
@@ -1565,7 +1668,7 @@ def render_binary_file_change(file_path: str) -> Optional[BinaryFileChange]:
     auto_add_untracked_files([file_path])
     try:
         with acquire_unified_diff(
-            stream_git_diff(
+            stream_live_git_diff(
                 base="HEAD",
                 full_index=True,
                 ignore_submodules="none",
@@ -1586,7 +1689,7 @@ def render_gitlink_change(file_path: str) -> Optional[GitlinkChange]:
     auto_add_untracked_files([file_path])
     try:
         with acquire_unified_diff(
-            stream_git_diff(
+            stream_live_git_diff(
                 base="HEAD",
                 full_index=True,
                 ignore_submodules="none",
@@ -1602,11 +1705,33 @@ def render_gitlink_change(file_path: str) -> Optional[GitlinkChange]:
     return None
 
 
+def render_rename_change(file_path: str) -> Optional[RenameChange]:
+    """Render a rename change involving file_path without caching state."""
+    auto_add_untracked_files([file_path])
+    try:
+        with acquire_unified_diff(
+            stream_live_git_diff(
+                full_index=True,
+                ignore_submodules="none",
+                submodule_format="short",
+            )
+        ) as patches:
+            for item in patches:
+                if (
+                    isinstance(item, RenameChange)
+                    and file_path in (item.old_path, item.new_path)
+                ):
+                    return item
+    except subprocess.CalledProcessError:
+        return None
+    return None
+
+
 def render_unstaged_file_as_single_hunk(file_path: str) -> Optional[LineLevelChange]:
     """Render the remaining unstaged changes for a file as a single hunk."""
     auto_add_untracked_files([file_path])
     with acquire_unified_diff(
-        stream_git_diff(
+        stream_live_git_diff(
             context_lines=get_context_lines(),
             full_index=True,
             ignore_submodules="none",
@@ -1722,7 +1847,7 @@ def _build_combined_file_line_changes(
     previous_new_end = None
 
     for single_hunk in patches:
-        if isinstance(single_hunk, (BinaryFileChange, GitlinkChange)):
+        if isinstance(single_hunk, (BinaryFileChange, GitlinkChange, RenameChange)):
             continue
 
         line_changes = build_line_changes_from_patch_lines(single_hunk.lines)
@@ -1798,7 +1923,7 @@ def _build_combined_file_line_changes(
     )
 
 
-def fetch_next_change() -> Union[LineLevelChange, BinaryFileChange, GitlinkChange]:
+def fetch_next_change() -> Union[LineLevelChange, BinaryFileChange, GitlinkChange, RenameChange]:
     """Find the next hunk or binary file that isn't blocked and cache it as selected.
 
     Returns:
@@ -1816,7 +1941,7 @@ def fetch_next_change() -> Union[LineLevelChange, BinaryFileChange, GitlinkChang
     # Stream git diff and parse incrementally - stops after first unblocked item found
     try:
         with acquire_unified_diff(
-            stream_git_diff(
+            stream_live_git_diff(
                 context_lines=get_context_lines(),
                 full_index=True,
                 ignore_submodules="none",
@@ -1824,6 +1949,20 @@ def fetch_next_change() -> Union[LineLevelChange, BinaryFileChange, GitlinkChang
             )
         ) as patches:
             for item in patches:
+                if isinstance(item, RenameChange):
+                    rename_hash = compute_rename_change_hash(item)
+                    if rename_hash in blocked_hashes:
+                        continue
+
+                    if (
+                        is_path_blocked(item.old_path, blocked_files)
+                        or is_path_blocked(item.new_path, blocked_files)
+                    ):
+                        continue
+
+                    cache_rename_change(item)
+                    return item
+
                 if isinstance(item, GitlinkChange):
                     gitlink_hash = compute_gitlink_change_hash(item)
                     if gitlink_hash in blocked_hashes:
@@ -1852,6 +1991,13 @@ def fetch_next_change() -> Union[LineLevelChange, BinaryFileChange, GitlinkChang
                     return item
 
                 # Handle text hunks (SingleHunkPatch)
+                if item.old_path != item.new_path:
+                    rename_hash = compute_rename_change_hash(
+                        RenameChange(old_path=item.old_path, new_path=item.new_path)
+                    )
+                    if rename_hash in blocked_hashes:
+                        continue
+
                 hunk_hash = compute_stable_hunk_hash_from_lines(item.lines)
                 if hunk_hash in blocked_hashes:
                     continue
@@ -1908,6 +2054,11 @@ def show_selected_change() -> None:
     This is a helper for commands that need to display the cached hunk
     without advancing (e.g., start, again).
     """
+    rename_change = load_selected_rename_change()
+    if rename_change is not None:
+        print_rename_change(rename_change)
+        return
+
     gitlink_change = load_selected_gitlink_change()
     if gitlink_change is not None:
         print_gitlink_change(gitlink_change)
@@ -1934,6 +2085,11 @@ def advance_to_and_show_next_change() -> None:
     prints a message to stderr.
     """
     advance_to_next_change()
+
+    rename_change = load_selected_rename_change()
+    if rename_change is not None:
+        print_rename_change(rename_change)
+        return
 
     gitlink_change = load_selected_gitlink_change()
     if gitlink_change is not None:
@@ -2115,7 +2271,7 @@ def recalculate_selected_hunk_for_file(
     # Stream git diff and parse incrementally - stops after first matching hunk found
     try:
         with acquire_unified_diff(
-            stream_git_diff(
+            stream_live_git_diff(
                 context_lines=get_context_lines(),
                 full_index=True,
                 ignore_submodules="none",
@@ -2125,6 +2281,14 @@ def recalculate_selected_hunk_for_file(
             for single_hunk in patches:
                 if single_hunk.old_path != file_path and single_hunk.new_path != file_path:
                     continue
+
+                if isinstance(single_hunk, RenameChange):
+                    rename_hash = compute_rename_change_hash(single_hunk)
+                    if rename_hash in blocked_hashes:
+                        continue
+                    cache_rename_change(single_hunk)
+                    print_rename_change(single_hunk)
+                    return
 
                 if isinstance(single_hunk, GitlinkChange):
                     gitlink_hash = compute_gitlink_change_hash(single_hunk)
@@ -2136,6 +2300,16 @@ def recalculate_selected_hunk_for_file(
 
                 if isinstance(single_hunk, BinaryFileChange):
                     continue
+
+                if single_hunk.old_path != single_hunk.new_path:
+                    rename_hash = compute_rename_change_hash(
+                        RenameChange(
+                            old_path=single_hunk.old_path,
+                            new_path=single_hunk.new_path,
+                        )
+                    )
+                    if rename_hash in blocked_hashes:
+                        continue
 
                 hunk_hash = compute_stable_hunk_hash_from_lines(single_hunk.lines)
 
@@ -2264,6 +2438,23 @@ def record_gitlink_hunk_skipped(gitlink_change: GitlinkChange, hunk_hash: str) -
         "change_type": gitlink_change.change_type,
         "old_oid": gitlink_change.old_oid,
         "new_oid": gitlink_change.new_oid,
+    }
+
+    jsonl_path = get_skipped_hunks_jsonl_file_path()
+    with jsonl_path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(metadata) + "\n")
+
+
+def record_rename_hunk_skipped(rename_change: RenameChange, hunk_hash: str) -> None:
+    """Record that a rename change was skipped with file-level metadata."""
+    metadata = {
+        "hash": hunk_hash,
+        "file": rename_change.new_path,
+        "line": None,
+        "ids": [],
+        "type": "rename",
+        "old_path": rename_change.old_path,
+        "new_path": rename_change.new_path,
     }
 
     jsonl_path = get_skipped_hunks_jsonl_file_path()

--- a/src/git_stage_batch/data/staged_renames.py
+++ b/src/git_stage_batch/data/staged_renames.py
@@ -1,0 +1,283 @@
+"""Session handling for staged renames normalized into the workflow."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+from ..utils.file_io import read_text_file_contents, write_text_file_contents
+from ..utils.git import GitIndexEntryUpdate, git_reset_paths, git_update_index_entries, run_git_command
+from ..utils.journal import log_journal
+from ..utils.paths import get_abort_head_file_path, get_staged_renames_file_path
+
+
+@dataclass(frozen=True)
+class StagedChangeRecord:
+    """One `git diff --name-status` record from the staged diff."""
+
+    status: str
+    paths: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class StagedRename:
+    """A start-time staged rename and its exact staged destination entry."""
+
+    old_path: str
+    new_path: str
+    new_mode: str
+    new_blob: str
+
+
+def _parse_name_status_z(data: bytes) -> list[StagedChangeRecord]:
+    """Parse `git diff --name-status -z` records."""
+    fields = data.split(b"\0")
+    if fields and fields[-1] == b"":
+        fields.pop()
+
+    records: list[StagedChangeRecord] = []
+    index = 0
+    while index < len(fields):
+        status = fields[index].decode("ascii", errors="replace")
+        index += 1
+
+        path_count = 2 if status.startswith(("R", "C")) else 1
+        if index + path_count > len(fields):
+            break
+        paths = tuple(
+            field.decode("utf-8", errors="surrogateescape")
+            for field in fields[index:index + path_count]
+        )
+        index += path_count
+        records.append(StagedChangeRecord(status=status, paths=paths))
+
+    return records
+
+
+def list_staged_change_records() -> list[StagedChangeRecord]:
+    """Return staged change records using Git's normal rename detection."""
+    result = run_git_command(
+        ["diff", "--cached", "--name-status", "-M", "-z"],
+        check=False,
+        text_output=False,
+        requires_index_lock=False,
+    )
+    if result.returncode != 0 or not result.stdout:
+        return []
+    return _parse_name_status_z(result.stdout)
+
+
+def list_normalizable_staged_renames() -> list[StagedRename]:
+    """Return start-time staged renames that can be normalized."""
+    staged_renames: list[StagedRename] = []
+    for record in list_staged_change_records():
+        if not record.status.startswith("R") or len(record.paths) != 2:
+            continue
+        old_path, new_path = record.paths
+        entry = _index_entry_for_path(new_path)
+        if entry is None:
+            continue
+        new_mode, new_blob = entry
+        staged_renames.append(
+            StagedRename(
+                old_path=old_path,
+                new_path=new_path,
+                new_mode=new_mode,
+                new_blob=new_blob,
+            )
+        )
+
+    return staged_renames
+
+
+def staged_changes_are_only_normalizable_renames() -> bool:
+    """Return whether all staged changes are renames start can normalize."""
+    records = list_staged_change_records()
+    if not records:
+        return False
+    rename_records = [record for record in records if record.status.startswith("R") and len(record.paths) == 2]
+    if len(rename_records) != len(records):
+        return False
+    return len(list_normalizable_staged_renames()) == len(rename_records)
+
+
+def _index_entry_for_path(file_path: str) -> tuple[str, str] | None:
+    result = run_git_command(
+        ["ls-files", "--stage", "-z", "--", file_path],
+        check=False,
+        text_output=False,
+        requires_index_lock=False,
+    )
+    if result.returncode != 0:
+        return None
+
+    for record in result.stdout.split(b"\0"):
+        if not record:
+            continue
+        try:
+            metadata, path_bytes = record.split(b"\t", 1)
+        except ValueError:
+            continue
+        if path_bytes.decode("utf-8", errors="surrogateescape") != file_path:
+            continue
+        parts = metadata.split()
+        if len(parts) < 3 or parts[2] != b"0":
+            continue
+        return (
+            parts[0].decode("ascii", errors="replace"),
+            parts[1].decode("ascii", errors="replace"),
+        )
+    return None
+
+
+def _serialize_renames(renames: list[StagedRename]) -> str:
+    return json.dumps(
+        [
+            {
+                "old_path": rename.old_path,
+                "new_path": rename.new_path,
+                "new_mode": rename.new_mode,
+                "new_blob": rename.new_blob,
+            }
+            for rename in renames
+        ],
+        ensure_ascii=False,
+        indent=0,
+    )
+
+
+def read_staged_renames() -> list[StagedRename]:
+    """Read start-time staged rename metadata."""
+    path = get_staged_renames_file_path()
+    if not path.exists():
+        return []
+
+    try:
+        data = json.loads(read_text_file_contents(path))
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(data, list):
+        return []
+
+    renames: list[StagedRename] = []
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        old_path = item.get("old_path")
+        new_path = item.get("new_path")
+        new_mode = item.get("new_mode")
+        new_blob = item.get("new_blob")
+        if not all(isinstance(value, str) for value in (old_path, new_path, new_mode, new_blob)):
+            continue
+        renames.append(
+            StagedRename(
+                old_path=old_path,
+                new_path=new_path,
+                new_mode=new_mode,
+                new_blob=new_blob,
+            )
+        )
+    return renames
+
+
+def normalize_start_time_staged_renames() -> list[StagedRename]:
+    """Move staged renames into the unstaged workflow for the active session.
+
+    The abort stash is created before this function runs, so abort can restore
+    the exact start state. Stop restoration uses the metadata recorded here
+    when a normalized rename was never staged during the session.
+    """
+    staged_renames = list_normalizable_staged_renames()
+    if not staged_renames:
+        return []
+
+    write_text_file_contents(get_staged_renames_file_path(), _serialize_renames(staged_renames))
+
+    paths: list[str] = []
+    for rename in staged_renames:
+        paths.extend([rename.old_path, rename.new_path])
+
+    log_journal(
+        "session_normalizing_staged_renames",
+        renames=[
+            {
+                "old_path": rename.old_path,
+                "new_path": rename.new_path,
+                "new_mode": rename.new_mode,
+                "new_blob": rename.new_blob,
+            }
+            for rename in staged_renames
+        ],
+    )
+    git_reset_paths(list(dict.fromkeys(paths)), check=False)
+    return staged_renames
+
+
+def _paths_have_cached_diff(paths: list[str]) -> bool:
+    result = run_git_command(
+        ["diff", "--cached", "--quiet", "--no-renames", "--", *paths],
+        check=False,
+        requires_index_lock=False,
+    )
+    return result.returncode == 1
+
+
+def _head_changed_since_session_start(paths: list[str]) -> bool:
+    abort_head_path = get_abort_head_file_path()
+    if not abort_head_path.exists():
+        return False
+
+    abort_head = read_text_file_contents(abort_head_path).strip()
+    if not abort_head:
+        return False
+
+    result = run_git_command(
+        ["diff", "--quiet", abort_head, "HEAD", "--", *paths],
+        check=False,
+        requires_index_lock=False,
+    )
+    return result.returncode == 1
+
+
+def restore_unstaged_start_time_renames() -> list[StagedRename]:
+    """Restore normalized start-time renames that were not staged by the user."""
+    renames = read_staged_renames()
+    if not renames:
+        return []
+
+    restored: list[StagedRename] = []
+    updates: list[GitIndexEntryUpdate] = []
+    for rename in renames:
+        paths = [rename.old_path, rename.new_path]
+        if _paths_have_cached_diff(paths):
+            continue
+        if _head_changed_since_session_start(paths):
+            continue
+        updates.extend(
+            [
+                GitIndexEntryUpdate(file_path=rename.old_path, force_remove=True),
+                GitIndexEntryUpdate(
+                    file_path=rename.new_path,
+                    mode=rename.new_mode,
+                    blob_sha=rename.new_blob,
+                ),
+            ]
+        )
+        restored.append(rename)
+
+    if updates:
+        git_update_index_entries(updates)
+        log_journal(
+            "session_restored_unstaged_start_renames",
+            renames=[
+                {
+                    "old_path": rename.old_path,
+                    "new_path": rename.new_path,
+                    "new_mode": rename.new_mode,
+                    "new_blob": rename.new_blob,
+                }
+                for rename in restored
+            ],
+        )
+
+    return restored

--- a/src/git_stage_batch/output/__init__.py
+++ b/src/git_stage_batch/output/__init__.py
@@ -2,7 +2,12 @@
 
 from .colors import Colors, format_hotkey, format_option_list
 from .hunk import print_line_level_changes, print_remaining_line_changes_header
-from .patch import print_binary_file_change, print_colored_patch, print_gitlink_change
+from .patch import (
+    print_binary_file_change,
+    print_colored_patch,
+    print_gitlink_change,
+    print_rename_change,
+)
 
 __all__ = [
     "Colors",
@@ -13,4 +18,5 @@ __all__ = [
     "print_binary_file_change",
     "print_colored_patch",
     "print_gitlink_change",
+    "print_rename_change",
 ]

--- a/src/git_stage_batch/output/file_review_list.py
+++ b/src/git_stage_batch/output/file_review_list.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import shlex
 from dataclasses import dataclass
 
-from ..core.models import BinaryFileChange, GitlinkChange, LineLevelChange
+from ..core.models import BinaryFileChange, GitlinkChange, LineLevelChange, RenameChange
 from ..i18n import _
 from .file_review import build_file_review_model
 
@@ -22,6 +22,8 @@ class FileReviewListEntry:
     page_count: int
     binary_change_type: str | None = None
     gitlink_change_type: str | None = None
+    rename_old_path: str | None = None
+    rename_new_path: str | None = None
 
 
 def make_file_review_list_entry(
@@ -75,6 +77,20 @@ def make_gitlink_file_review_list_entry(gitlink_change: GitlinkChange) -> FileRe
     )
 
 
+def make_rename_file_review_list_entry(rename_change: RenameChange) -> FileReviewListEntry:
+    """Build a list entry from a rename change."""
+    return FileReviewListEntry(
+        path=rename_change.new_path,
+        change_count=1,
+        changed_line_count=0,
+        addition_count=0,
+        deletion_count=0,
+        page_count=1,
+        rename_old_path=rename_change.old_path,
+        rename_new_path=rename_change.new_path,
+    )
+
+
 def print_file_review_list(
     *,
     source_label: str,
@@ -103,6 +119,13 @@ def print_file_review_list(
                 f"{index}. {entry.path.ljust(path_width)}  "
                 f"{entry.change_count} {change_word} · "
                 f"submodule pointer {entry.gitlink_change_type} · "
+                f"{entry.page_count} {page_word}"
+            )
+        elif entry.rename_old_path is not None and entry.rename_new_path is not None:
+            print(
+                f"{index}. {entry.path.ljust(path_width)}  "
+                f"{entry.change_count} {change_word} · "
+                f"rename {entry.rename_old_path} -> {entry.rename_new_path} · "
                 f"{entry.page_count} {page_word}"
             )
         elif entry.binary_change_type is not None:

--- a/src/git_stage_batch/output/patch.py
+++ b/src/git_stage_batch/output/patch.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 from .colors import Colors
 
 if TYPE_CHECKING:
-    from ..core.models import BinaryFileChange, GitlinkChange
+    from ..core.models import BinaryFileChange, GitlinkChange, RenameChange
 
 
 def print_colored_patch(patch_text: str) -> None:
@@ -80,6 +80,21 @@ def print_gitlink_change(gitlink_change: GitlinkChange) -> None:
     print(f"{bold}{path}{reset} :: {color}Submodule pointer modified{reset}")
     print(f"old {_short_oid(gitlink_change.old_oid)}")
     print(f"new {_short_oid(gitlink_change.new_oid)}")
+
+
+def print_rename_change(rename_change: RenameChange) -> None:
+    """Print a file rename as an atomic structural change."""
+    use_color = Colors.enabled()
+
+    reset = Colors.RESET if use_color else ""
+    bold = Colors.BOLD if use_color else ""
+    color = Colors.YELLOW if use_color else ""
+
+    print(
+        f"{bold}{rename_change.old_path}{reset} -> "
+        f"{bold}{rename_change.new_path}{reset} :: "
+        f"{color}Renamed file{reset}"
+    )
 
 
 def _short_oid(oid: str | None) -> str:

--- a/src/git_stage_batch/utils/file_patterns.py
+++ b/src/git_stage_batch/utils/file_patterns.py
@@ -96,21 +96,38 @@ def resolve_gitignore_style_patterns(
 
 
 def list_changed_files() -> list[str]:
-    """List repository-relative files currently present in the working-tree diff."""
+    """List repository-relative paths participating in the working-tree diff."""
     result = run_git_command(
         [
             "-c",
             "diff.ignoreSubmodules=none",
             "diff",
             "--ignore-submodules=none",
-            "--name-only",
+            "--find-renames",
+            "--name-status",
             "-z",
         ],
         text_output=False,
         requires_index_lock=False,
     )
-    return [
-        _normalize_path(path.decode("utf-8"))
-        for path in result.stdout.split(b"\0")
-        if path
-    ]
+
+    fields = result.stdout.split(b"\0")
+    changed_paths: list[str] = []
+    index = 0
+    while index < len(fields):
+        status_bytes = fields[index]
+        index += 1
+        if not status_bytes:
+            continue
+
+        status = status_bytes.decode("ascii", errors="replace")
+        path_count = 2 if status.startswith(("R", "C")) else 1
+        for _ in range(path_count):
+            if index >= len(fields):
+                break
+            path = fields[index]
+            index += 1
+            if path:
+                changed_paths.append(_normalize_path(path.decode("utf-8")))
+
+    return list(dict.fromkeys(changed_paths))

--- a/src/git_stage_batch/utils/git.py
+++ b/src/git_stage_batch/utils/git.py
@@ -189,6 +189,8 @@ def stream_git_diff(
     context_lines: int | None = None,
     no_color: bool = True,
     full_index: bool = False,
+    find_renames: bool = False,
+    no_renames: bool = False,
     ignore_submodules: str | None = None,
     submodule_format: str | None = None,
     paths: Iterable[str] = (),
@@ -207,6 +209,10 @@ def stream_git_diff(
         arguments.append(f"--submodule={submodule_format}")
     if full_index:
         arguments.append("--full-index")
+    if find_renames and not no_renames:
+        arguments.append("--find-renames")
+    if no_renames:
+        arguments.append("--no-renames")
     if no_color:
         arguments.append("--no-color")
     if cached:

--- a/src/git_stage_batch/utils/paths.py
+++ b/src/git_stage_batch/utils/paths.py
@@ -251,6 +251,11 @@ def get_abort_snapshot_list_file_path() -> Path:
     return get_abort_state_directory_path() / "untracked-paths.txt"
 
 
+def get_staged_renames_file_path() -> Path:
+    """Get the path to start-time staged rename metadata."""
+    return get_abort_state_directory_path() / "staged-renames.json"
+
+
 def get_session_batch_sources_file_path() -> Path:
     """Get the path to the session batch sources cache file.
 

--- a/src/git_stage_batch/utils/paths.py
+++ b/src/git_stage_batch/utils/paths.py
@@ -210,6 +210,11 @@ def get_selected_gitlink_file_json_path() -> Path:
     return get_selected_state_directory_path() / "gitlink-file.json"
 
 
+def get_selected_rename_file_json_path() -> Path:
+    """Get the path to the selected rename JSON file."""
+    return get_selected_state_directory_path() / "rename-file.json"
+
+
 def get_abort_head_file_path() -> Path:
     """Get the path to the abort HEAD file for session restoration.
 

--- a/tests/cli/test_argument_parser.py
+++ b/tests/cli/test_argument_parser.py
@@ -380,6 +380,19 @@ def test_parse_command_line_start_passes_auto_advance(monkeypatch):
     mock_command.assert_called_once_with(context_lines=None, auto_advance=False)
 
 
+def test_parse_command_line_check_unstaged(monkeypatch):
+    """check-unstaged dispatches to the unstaged-only index guard."""
+    mock_command = Mock()
+    monkeypatch.setattr(argument_parser.commands, "command_check_unstaged", mock_command)
+
+    args = parse_command_line(["check-unstaged"], quiet=True)
+
+    assert args is not None
+    assert args.command == "check-unstaged"
+    args.func(args)
+    mock_command.assert_called_once_with()
+
+
 def test_parse_command_line_stop():
     """Test parsing stop command."""
     args = parse_command_line(["stop"], quiet=True)

--- a/tests/commands/test_staged_renames.py
+++ b/tests/commands/test_staged_renames.py
@@ -1,0 +1,85 @@
+"""Tests for rename selections in live sessions."""
+
+import subprocess
+
+import pytest
+
+from git_stage_batch.commands.include import command_include
+from git_stage_batch.commands.start import command_start
+from git_stage_batch.core.models import RenameChange
+from git_stage_batch.data.hunk_tracking import load_selected_change
+
+
+@pytest.fixture
+def rename_repo(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.chdir(repo)
+
+    subprocess.run(["git", "init"], check=True, cwd=repo, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], check=True, cwd=repo, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], check=True, cwd=repo, capture_output=True)
+
+    (repo / "old.txt").write_text("line 1\nline 2\n")
+    (repo / "other.txt").write_text("original\n")
+    subprocess.run(["git", "add", "."], check=True, cwd=repo, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "Initial"], check=True, cwd=repo, capture_output=True)
+
+    return repo
+
+
+def _rename_without_staging(repo, *, new_content: str = "line 1\nline 2\n") -> None:
+    (repo / "old.txt").rename(repo / "new.txt")
+    (repo / "new.txt").write_text(new_content)
+
+
+def _cached_name_status(repo) -> str:
+    return subprocess.run(
+        ["git", "diff", "--cached", "--name-status", "-M"],
+        check=True,
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    ).stdout
+
+
+def _uncached_name_status(repo) -> str:
+    return subprocess.run(
+        ["git", "diff", "--name-status", "-M"],
+        check=True,
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    ).stdout
+
+
+def _index_content(repo, file_path: str) -> str:
+    return subprocess.run(
+        ["git", "show", f":{file_path}"],
+        check=True,
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    ).stdout
+
+
+def test_start_exposes_unstaged_rename_as_rename_selection(rename_repo):
+    _rename_without_staging(rename_repo)
+
+    command_start(quiet=True)
+
+    selected_change = load_selected_change()
+    assert isinstance(selected_change, RenameChange)
+    assert selected_change.old_path == "old.txt"
+    assert selected_change.new_path == "new.txt"
+
+
+def test_include_selected_rename_stages_rename_only_and_leaves_edits_unstaged(rename_repo):
+    _rename_without_staging(rename_repo, new_content="line 1\nline 2\nline 3\n")
+
+    command_start(quiet=True)
+    command_include(quiet=True, auto_advance=False)
+
+    assert _cached_name_status(rename_repo).strip() == "R100\told.txt\tnew.txt"
+    assert _index_content(rename_repo, "new.txt") == "line 1\nline 2\n"
+    assert _uncached_name_status(rename_repo).strip() == "M\tnew.txt"

--- a/tests/commands/test_staged_renames.py
+++ b/tests/commands/test_staged_renames.py
@@ -1,13 +1,16 @@
-"""Tests for rename selections in live sessions."""
+"""Tests for start-time staged rename normalization."""
 
 import subprocess
 
 import pytest
 
+from git_stage_batch.commands.abort import command_abort
 from git_stage_batch.commands.include import command_include
 from git_stage_batch.commands.start import command_start
+from git_stage_batch.commands.stop import command_stop
 from git_stage_batch.core.models import RenameChange
-from git_stage_batch.data.hunk_tracking import load_selected_change
+from git_stage_batch.data.hunk_tracking import load_selected_change, show_selected_change
+from git_stage_batch.utils.paths import get_staged_renames_file_path
 
 
 @pytest.fixture
@@ -26,6 +29,12 @@ def rename_repo(tmp_path, monkeypatch):
     subprocess.run(["git", "commit", "-m", "Initial"], check=True, cwd=repo, capture_output=True)
 
     return repo
+
+
+def _stage_rename(repo, *, new_content: str = "line 1\nline 2\n") -> None:
+    (repo / "old.txt").rename(repo / "new.txt")
+    (repo / "new.txt").write_text(new_content)
+    subprocess.run(["git", "add", "-A"], check=True, cwd=repo, capture_output=True)
 
 
 def _rename_without_staging(repo, *, new_content: str = "line 1\nline 2\n") -> None:
@@ -63,6 +72,21 @@ def _index_content(repo, file_path: str) -> str:
     ).stdout
 
 
+def test_start_exposes_staged_rename_as_rename_selection(rename_repo, capsys):
+    _stage_rename(rename_repo)
+
+    command_start(quiet=True)
+    show_selected_change()
+
+    assert get_staged_renames_file_path().exists()
+    assert _cached_name_status(rename_repo) == ""
+    selected_change = load_selected_change()
+    assert isinstance(selected_change, RenameChange)
+    assert selected_change.old_path == "old.txt"
+    assert selected_change.new_path == "new.txt"
+    assert "old.txt -> new.txt" in capsys.readouterr().out
+
+
 def test_start_exposes_unstaged_rename_as_rename_selection(rename_repo):
     _rename_without_staging(rename_repo)
 
@@ -83,3 +107,45 @@ def test_include_selected_rename_stages_rename_only_and_leaves_edits_unstaged(re
     assert _cached_name_status(rename_repo).strip() == "R100\told.txt\tnew.txt"
     assert _index_content(rename_repo, "new.txt") == "line 1\nline 2\n"
     assert _uncached_name_status(rename_repo).strip() == "M\tnew.txt"
+
+
+def test_stop_restores_untouched_start_time_staged_rename(rename_repo):
+    _stage_rename(rename_repo)
+
+    command_start(quiet=True)
+    command_stop()
+
+    assert _cached_name_status(rename_repo).strip() == "R100\told.txt\tnew.txt"
+
+
+def test_stop_preserves_staged_rename_content_after_workflow_use(rename_repo):
+    _stage_rename(rename_repo)
+
+    command_start(quiet=True)
+    (rename_repo / "new.txt").write_text("line 1\nline 2\nline 3\n")
+    subprocess.run(["git", "add", "-A"], check=True, cwd=rename_repo, capture_output=True)
+    command_stop()
+
+    assert _cached_name_status(rename_repo).strip().startswith("R")
+    assert _index_content(rename_repo, "new.txt") == "line 1\nline 2\nline 3\n"
+
+
+def test_stop_does_not_restore_rename_paths_changed_by_session_commit(rename_repo):
+    _stage_rename(rename_repo)
+
+    command_start(quiet=True)
+    (rename_repo / "new.txt").write_text("line 1\nline 2\nline 3\n")
+    subprocess.run(["git", "add", "-A"], check=True, cwd=rename_repo, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "Rename file"], check=True, cwd=rename_repo, capture_output=True)
+    command_stop()
+
+    assert _cached_name_status(rename_repo) == ""
+
+
+def test_abort_restores_start_time_staged_rename(rename_repo):
+    _stage_rename(rename_repo)
+
+    command_start(quiet=True)
+    command_abort()
+
+    assert _cached_name_status(rename_repo).strip() == "R100\told.txt\tnew.txt"

--- a/tests/commands/test_staged_renames.py
+++ b/tests/commands/test_staged_renames.py
@@ -5,11 +5,13 @@ import subprocess
 import pytest
 
 from git_stage_batch.commands.abort import command_abort
+from git_stage_batch.commands.check_unstaged import command_check_unstaged
 from git_stage_batch.commands.include import command_include
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.commands.stop import command_stop
 from git_stage_batch.core.models import RenameChange
 from git_stage_batch.data.hunk_tracking import load_selected_change, show_selected_change
+from git_stage_batch.exceptions import CommandError
 from git_stage_batch.utils.paths import get_staged_renames_file_path
 
 
@@ -149,3 +151,34 @@ def test_abort_restores_start_time_staged_rename(rename_repo):
     command_abort()
 
     assert _cached_name_status(rename_repo).strip() == "R100\told.txt\tnew.txt"
+
+
+def test_check_unstaged_allows_clean_index(rename_repo):
+    command_check_unstaged()
+
+
+def test_check_unstaged_allows_staged_rename(rename_repo):
+    _stage_rename(rename_repo)
+
+    command_check_unstaged()
+
+
+def test_check_unstaged_rejects_non_rename_staged_content(rename_repo):
+    (rename_repo / "other.txt").write_text("changed\n")
+    subprocess.run(["git", "add", "other.txt"], check=True, cwd=rename_repo, capture_output=True)
+
+    with pytest.raises(CommandError) as exc_info:
+        command_check_unstaged()
+
+    assert exc_info.value.exit_code == 2
+
+
+def test_check_unstaged_rejects_rename_mixed_with_other_staged_content(rename_repo):
+    _stage_rename(rename_repo)
+    (rename_repo / "other.txt").write_text("changed\n")
+    subprocess.run(["git", "add", "other.txt"], check=True, cwd=rename_repo, capture_output=True)
+
+    with pytest.raises(CommandError) as exc_info:
+        command_check_unstaged()
+
+    assert exc_info.value.exit_code == 2

--- a/tests/core/test_diff_parser_edge_cases.py
+++ b/tests/core/test_diff_parser_edge_cases.py
@@ -8,7 +8,7 @@ Tests for handling:
 - Mixed scenarios
 """
 
-from git_stage_batch.core.models import BinaryFileChange, GitlinkChange, SingleHunkPatch
+from git_stage_batch.core.models import BinaryFileChange, GitlinkChange, RenameChange, SingleHunkPatch
 
 from tests.diff_parser_helpers import collect_unified_diff
 
@@ -372,9 +372,11 @@ index abc1234..def5678 100644
 """
         patches = list(collect_unified_diff(diff.splitlines(keepends=True)))
 
-        # Should parse other.txt (renamed file has no hunks)
-        assert len(patches) == 1
-        assert patches[0].new_path == "other.txt"
+        assert len(patches) == 2
+        assert isinstance(patches[0], RenameChange)
+        assert patches[0].old_path == "old_name.txt"
+        assert patches[0].new_path == "new_name.txt"
+        assert patches[1].new_path == "other.txt"
 
     def test_renamed_file_with_changes(self):
         """Renamed file with content changes."""
@@ -394,9 +396,12 @@ index abc1234..def5678 100644
 """
         patches = list(collect_unified_diff(diff.splitlines(keepends=True)))
 
-        assert len(patches) == 1
+        assert len(patches) == 2
+        assert isinstance(patches[0], RenameChange)
         assert patches[0].old_path == "old_name.txt"
         assert patches[0].new_path == "new_name.txt"
+        assert patches[1].old_path == "old_name.txt"
+        assert patches[1].new_path == "new_name.txt"
 
 
 class TestModeChanges:
@@ -486,18 +491,21 @@ index ghi789..jkl012 100644
 
         patches = list(collect_unified_diff(diff.splitlines(keepends=True)))
 
-        # Should parse files with hunks plus binary file and empty new file
-        # Expected: new_empty.txt (empty), image.png (binary), normal1.txt, normal2.txt
-        assert len(patches) == 4
+        # Should parse files with hunks plus binary file, rename, and empty new file
+        # Expected: new_empty.txt (empty), image.png (binary), old->new rename, normal1.txt, normal2.txt
+        assert len(patches) == 5
         assert isinstance(patches[0], SingleHunkPatch)
         assert patches[0].new_path == "new_empty.txt"
         assert isinstance(patches[1], BinaryFileChange)
         assert patches[1].new_path == "image.png"
         assert patches[1].change_type == "added"
-        assert isinstance(patches[2], SingleHunkPatch)
-        assert patches[2].new_path == "normal1.txt"
+        assert isinstance(patches[2], RenameChange)
+        assert patches[2].old_path == "old.txt"
+        assert patches[2].new_path == "new.txt"
         assert isinstance(patches[3], SingleHunkPatch)
-        assert patches[3].new_path == "normal2.txt"
+        assert patches[3].new_path == "normal1.txt"
+        assert isinstance(patches[4], SingleHunkPatch)
+        assert patches[4].new_path == "normal2.txt"
 
     def test_intent_to_add_files(self):
         """Files added with git add -N (intent-to-add)."""

--- a/tests/functional/test_functional_interactive.py
+++ b/tests/functional/test_functional_interactive.py
@@ -227,7 +227,7 @@ class TestInteractiveWorkflow:
     def test_interactive_stage_incrementally(self, repo_with_changes):
         """Test staging changes incrementally across multiple hunks."""
         # Include from first hunk, skip, include from second
-        result = run_interactive("i", "s", "i", "q")
+        result = run_interactive("i", "s", "i", "q", "y")
         assert result.returncode == 0
         # Should have staged changes from two includes
         staged = get_staged_files()
@@ -502,7 +502,8 @@ class TestInteractiveMultiFile:
             "i",
             "s",
             "i",
-            "q"
+            "q",
+            "y",
         )
         assert result.returncode == 0, f"STDOUT: {result.stdout}\nSTDERR: {result.stderr}"
         # Verify command succeeded (batch may or may not have content)
@@ -534,7 +535,7 @@ class TestInteractiveMultiFile:
             file_path.write_text(f"Line 1\nLine 2\nLine {i}\n")
 
         # Navigate through multiple hunks
-        result = run_interactive("i", "s", "i", "s", "i", "s", "i", "s", "i", "q")
+        result = run_interactive("i", "s", "i", "s", "i", "s", "i", "s", "i", "q", "y")
         assert result.returncode == 0
         staged = get_staged_files()
         assert len(staged) > 0

--- a/tests/utils/test_file_patterns.py
+++ b/tests/utils/test_file_patterns.py
@@ -1,6 +1,8 @@
 """Tests for gitignore-style file pattern resolution."""
 
-from git_stage_batch.utils.file_patterns import resolve_gitignore_style_patterns
+import subprocess
+
+from git_stage_batch.utils.file_patterns import list_changed_files, resolve_gitignore_style_patterns
 
 
 def test_resolve_gitignore_style_patterns_matches_basename_anywhere():
@@ -101,3 +103,24 @@ def test_resolve_gitignore_style_patterns_returns_empty_list_for_no_matches():
     )
 
     assert resolved == []
+
+
+def test_list_changed_files_reports_rename_delete_and_add(tmp_path, monkeypatch):
+    """Changed-file discovery should expose both paths of an unstaged rename."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.chdir(repo)
+
+    subprocess.run(["git", "init"], check=True, cwd=repo, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], check=True, cwd=repo, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], check=True, cwd=repo, capture_output=True)
+
+    (repo / "old.txt").write_text("one\ntwo\n")
+    subprocess.run(["git", "add", "old.txt"], check=True, cwd=repo, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "Initial"], check=True, cwd=repo, capture_output=True)
+
+    (repo / "old.txt").rename(repo / "new.txt")
+    (repo / "new.txt").write_text("one\ntwo\nthree\n")
+    subprocess.run(["git", "add", "-N", "new.txt"], check=True, cwd=repo, capture_output=True)
+
+    assert list_changed_files() == ["old.txt", "new.txt"]


### PR DESCRIPTION
Live staging now detects rename metadata instead of forcing rename handling
through lower-level path effects. Users see an old -> new prompt for pure
renames and rename-plus-edit cases, and include, skip, and discard act on
that structural choice before later content hunks.

Sessions can normalize renames that were already staged at start time. The
session records the staged rename metadata, resets those paths for review,
and restores untouched staged renames during stop or abort.

Automation now has check-unstaged as a preflight for unstaged-only
workflows. The command accepts an index with no staged entries and staged
renames that start can normalize, while rejecting other staged content with
exit code 2.

Validation:

```sh
uv run ruff check src/git_stage_batch \
  tests/commands/test_staged_renames.py \
  tests/core/test_diff_parser_edge_cases.py \
  tests/utils/test_file_patterns.py \
  tests/cli/test_argument_parser.py \
  tests/functional/test_functional_interactive.py

uv run pytest \
  tests/commands/test_staged_renames.py \
  tests/core/test_diff_parser_edge_cases.py \
  tests/utils/test_file_patterns.py \
  tests/cli/test_argument_parser.py \
  tests/functional/test_functional_interactive.py \
  -q
```