### PR TITLE
batch: Replay split replacements from origins

### DIFF
--- a/src/git_stage_batch/batch/merge.py
+++ b/src/git_stage_batch/batch/merge.py
@@ -1951,6 +1951,22 @@ def _presence_ambiguity_key(
     )
 
 
+def _replacement_origin_ambiguity_key(
+    unit_index: int,
+    deletion_index: int,
+    origin,
+    claimed_lines: Sequence[int],
+    forbidden_sequence: Sequence[bytes],
+) -> str:
+    claimed = ",".join(str(line) for line in claimed_lines)
+    digest = hashlib.sha256(b"".join(forbidden_sequence)).hexdigest()[:12]
+    return (
+        f"replacement-origin:{unit_index}:delete:{deletion_index}:"
+        f"claimed:{claimed}:old:{origin.old_start}-{origin.old_end}:"
+        f"new:{origin.new_start}-{origin.new_end}:{digest}"
+    )
+
+
 def _presence_choices_for_missing_claimed_run(
     source_lines: Sequence[bytes],
     working_lines: Sequence[bytes],
@@ -2033,6 +2049,14 @@ class _PresenceChoice:
     target_before_line: int | None
 
 
+@dataclass(frozen=True)
+class _ReplacementOriginChoice:
+    choice_index: int
+    position: int
+    target_after_line: int | None
+    target_before_line: int | None
+
+
 def _presence_ambiguity_target_line_range(
     choices: Sequence[_PresenceChoice],
     target_line_count: int,
@@ -2105,6 +2129,65 @@ def _absence_choices_for_claim(
             )
         )
     return tuple(choices)
+
+
+def _replacement_origin_choices_for_unit(
+    claim: 'AbsenceClaim',
+    unit_index: int,
+    unit,
+    claimed_lines: Sequence[int],
+    working_lines: Sequence[bytes],
+    *,
+    max_results: int | None = None,
+) -> tuple[str | None, tuple[_ReplacementOriginChoice, ...]]:
+    """Return explicit target placements for an origin-tracked replacement."""
+    origin = getattr(unit, "origin", None)
+    if origin is None or not claim.content_lines:
+        return None, ()
+
+    forbidden_sequence = [
+        normalize_line_endings(line)
+        for line in claim.content_lines
+    ]
+    if not forbidden_sequence:
+        return None, ()
+    if len(forbidden_sequence) > len(working_lines):
+        return None, ()
+
+    choices: list[_ReplacementOriginChoice] = []
+    for position in range(0, len(working_lines) - len(forbidden_sequence) + 1):
+        if not _line_slice_equals(working_lines, position, forbidden_sequence):
+            continue
+        choices.append(
+            _ReplacementOriginChoice(
+                choice_index=len(choices) + 1,
+                position=position,
+                target_after_line=None if position == 0 else position,
+                target_before_line=(
+                    None
+                    if position + len(forbidden_sequence) >= len(working_lines) else
+                    position + len(forbidden_sequence) + 1
+                ),
+            )
+        )
+        if max_results is not None and len(choices) >= max_results:
+            break
+
+    if not choices:
+        return None, ()
+
+    deletion_indices = getattr(unit, "deletion_indices", [])
+    if len(deletion_indices) != 1:
+        return None, ()
+
+    key = _replacement_origin_ambiguity_key(
+        unit_index,
+        deletion_indices[0],
+        origin,
+        claimed_lines,
+        forbidden_sequence,
+    )
+    return key, tuple(choices)
 
 
 def _suppress_absence_with_resolution(
@@ -2541,6 +2624,188 @@ def _baseline_removal_edit(
     return position, position + len(forbidden_sequence), []
 
 
+def _replacement_origin_absence_bounds(
+    origin,
+    working_lines: Sequence[bytes],
+) -> tuple[int, int] | None:
+    """Return the target bounds of an original replacement parent, if provable."""
+    if origin is None or getattr(origin, "baseline_reference", None) is None:
+        return None
+    old_line_count = getattr(origin, "old_line_count", None)
+    if type(old_line_count) is not int or old_line_count <= 0:
+        return None
+
+    position = _baseline_reference_absence_position(
+        origin.baseline_reference,
+        working_lines,
+        old_line_count,
+    )
+    if position is None:
+        return None
+    return position, position + old_line_count
+
+
+def _replacement_edit_with_origin_guard(
+    claim: 'AbsenceClaim',
+    origin,
+    working_lines: Sequence[bytes],
+) -> _BaselineLineEdit | None:
+    """Return a removal edit only if it fits inside the original parent unit."""
+    removal_edit = _baseline_removal_edit(claim, working_lines)
+    if removal_edit is None:
+        return None
+
+    if origin is None:
+        return removal_edit
+
+    parent_bounds = _replacement_origin_absence_bounds(origin, working_lines)
+    if parent_bounds is None:
+        return None
+
+    start, end, replacement_lines = removal_edit
+    parent_start, parent_end = parent_bounds
+    if start < parent_start or end > parent_end:
+        return None
+    return start, end, replacement_lines
+
+
+def _replacement_edit_from_parent_offset(
+    claim: 'AbsenceClaim',
+    origin,
+    claimed_lines: Sequence[int],
+    working_lines: Sequence[bytes],
+) -> _BaselineLineEdit | None:
+    """Place an equal-size split replacement by offset inside its parent."""
+    if origin is None or not claim.content_lines:
+        return None
+
+    old_line_count = getattr(origin, "old_line_count", None)
+    new_start = getattr(origin, "new_start", None)
+    new_end = getattr(origin, "new_end", None)
+    if (
+        type(old_line_count) is not int
+        or type(new_start) is not int
+        or type(new_end) is not int
+        or old_line_count <= 0
+        or new_end < new_start
+    ):
+        return None
+
+    new_line_count = new_end - new_start + 1
+    if old_line_count != new_line_count:
+        return None
+
+    relative_offsets = [
+        claimed_line - new_start
+        for claimed_line in sorted(claimed_lines)
+    ]
+    if (
+        not relative_offsets
+        or relative_offsets[0] < 0
+        or relative_offsets[-1] >= new_line_count
+    ):
+        return None
+    if relative_offsets != list(
+        range(relative_offsets[0], relative_offsets[0] + len(relative_offsets))
+    ):
+        return None
+
+    forbidden_sequence = [
+        normalize_line_endings(line)
+        for line in claim.content_lines
+    ]
+    if len(forbidden_sequence) != len(relative_offsets):
+        return None
+
+    parent_bounds = _replacement_origin_absence_bounds(origin, working_lines)
+    if parent_bounds is None:
+        return None
+
+    parent_start, parent_end = parent_bounds
+    start = parent_start + relative_offsets[0]
+    end = start + len(forbidden_sequence)
+    if start < parent_start or end > parent_end:
+        return None
+    if not _line_slice_equals(working_lines, start, forbidden_sequence):
+        return None
+    return start, end, []
+
+
+def _replacement_edit_from_origin_resolution(
+    claim: 'AbsenceClaim',
+    unit_index: int,
+    unit,
+    claimed_lines: Sequence[int],
+    working_lines: Sequence[bytes],
+    resolution: MergeResolution | None,
+) -> _BaselineLineEdit | None:
+    """Return a replacement edit from a reviewed origin-placement choice."""
+    if resolution is None:
+        return None
+
+    key, choices = _replacement_origin_choices_for_unit(
+        claim,
+        unit_index,
+        unit,
+        claimed_lines,
+        working_lines,
+        max_results=_MERGE_CANDIDATE_CAP + 1,
+    )
+    if key is None or key not in resolution.decisions:
+        return None
+
+    choice_index = resolution.decisions[key]
+    forbidden_sequence = [
+        normalize_line_endings(line)
+        for line in claim.content_lines
+    ]
+    for choice in choices:
+        if choice.choice_index == choice_index:
+            return (
+                choice.position,
+                choice.position + len(forbidden_sequence),
+                [],
+            )
+
+    raise MergeError(_("Selected merge resolution is no longer valid"))
+
+
+def _replacement_baseline_edit(
+    claim: 'AbsenceClaim',
+    unit_index: int,
+    unit,
+    claimed_lines: Sequence[int],
+    working_lines: Sequence[bytes],
+    resolution: MergeResolution | None,
+) -> _BaselineLineEdit | None:
+    origin = getattr(unit, "origin", None)
+    offset_edit = _replacement_edit_from_parent_offset(
+        claim,
+        origin,
+        claimed_lines,
+        working_lines,
+    )
+    if offset_edit is not None:
+        return offset_edit
+
+    guarded_edit = _replacement_edit_with_origin_guard(
+        claim,
+        origin,
+        working_lines,
+    )
+    if guarded_edit is not None:
+        return guarded_edit
+
+    return _replacement_edit_from_origin_resolution(
+        claim,
+        unit_index,
+        unit,
+        claimed_lines,
+        working_lines,
+        resolution,
+    )
+
+
 def _apply_non_overlapping_baseline_edits(
     working_lines: Sequence[bytes],
     edits: list[_BaselineLineEdit],
@@ -2593,6 +2858,8 @@ def _try_apply_baseline_replacement_units(
     ownership: 'BatchOwnership',
     presence_line_set: LineSelection,
     deletion_claims: list['AbsenceClaim'],
+    *,
+    resolution: MergeResolution | None = None,
 ) -> Iterator[bytes] | None:
     """Apply baseline-coordinate edits when structural source anchors fail.
 
@@ -2620,7 +2887,7 @@ def _try_apply_baseline_replacement_units(
     unit_claimed_lines = LineRanges.empty()
     unit_deletion_indices: set[int] = set()
 
-    for unit in replacement_units:
+    for unit_index, unit in enumerate(replacement_units):
         claimed_selection = LineRanges.from_specs(unit.presence_lines)
         claimed_lines = list(claimed_selection)
         if not claimed_lines or len(unit.deletion_indices) != 1:
@@ -2635,9 +2902,13 @@ def _try_apply_baseline_replacement_units(
                 return None
             replacement_lines.append(source_lines[claimed_line - 1])
 
-        removal_edit = _baseline_removal_edit(
+        removal_edit = _replacement_baseline_edit(
             deletion_claims[deletion_index],
+            unit_index,
+            unit,
+            claimed_lines,
             working_lines,
+            resolution,
         )
         if removal_edit is None:
             return None
@@ -2688,6 +2959,152 @@ def _try_apply_baseline_replacement_units(
         return None
 
     return _apply_non_overlapping_baseline_edits(working_lines, edits)
+
+
+def _has_missing_origin_replacement_claims(
+    ownership: 'BatchOwnership',
+    presence_line_set: LineSelection,
+    source_lines: Sequence[bytes],
+    mapping: LineMapping,
+) -> bool:
+    """Return whether parent-tracked replacement lines would need placement."""
+    selected_presence = _as_line_ranges(presence_line_set)
+    for unit in getattr(ownership, "replacement_units", []):
+        if getattr(unit, "origin", None) is None:
+            continue
+        claimed_selection = LineRanges.from_specs(unit.presence_lines)
+        for claimed_line in selected_presence.intersection(claimed_selection):
+            if claimed_line < 1 or claimed_line > len(source_lines):
+                continue
+            if mapping.get_target_line_from_source_line(claimed_line) is None:
+                return True
+    return False
+
+
+def _replacement_origin_candidate_set(
+    source_lines: Sequence[bytes],
+    ownership: 'BatchOwnership',
+    working_lines: Sequence[bytes],
+    presence_line_set: LineSelection,
+    deletion_claims: list['AbsenceClaim'],
+    *,
+    max_candidates: int,
+) -> MergeCandidateSet:
+    """Enumerate reviewed placements for one unresolved split replacement."""
+    owned_mapping = match_lines(source_lines, working_lines)
+    try:
+        selected_presence = _as_line_ranges(presence_line_set)
+        unresolved: list[tuple[list[int], int, str, tuple[_ReplacementOriginChoice, ...]]] = []
+        for unit_index, unit in enumerate(getattr(ownership, "replacement_units", [])):
+            if getattr(unit, "origin", None) is None:
+                continue
+
+            claimed_selection = LineRanges.from_specs(unit.presence_lines)
+            claimed_lines = list(selected_presence.intersection(claimed_selection))
+            if not claimed_lines:
+                continue
+            if all(
+                1 <= claimed_line <= len(source_lines)
+                and owned_mapping.get_target_line_from_source_line(claimed_line) is not None
+                for claimed_line in claimed_lines
+            ):
+                continue
+            if len(unit.deletion_indices) != 1:
+                raise MergeError(_("Batch was created from a different version of the file"))
+
+            deletion_index = unit.deletion_indices[0]
+            if deletion_index < 0 or deletion_index >= len(deletion_claims):
+                raise MergeError(_("Batch was created from a different version of the file"))
+            key, choices = _replacement_origin_choices_for_unit(
+                deletion_claims[deletion_index],
+                unit_index,
+                unit,
+                claimed_lines,
+                working_lines,
+                max_results=max_candidates + 1,
+            )
+            if key is None:
+                continue
+            unresolved.append((claimed_lines, deletion_index, key, choices))
+    finally:
+        owned_mapping.close()
+
+    if not unresolved:
+        return MergeCandidateSet(())
+    if len(unresolved) > 1:
+        raise MergeError(_("Multiple split replacement placements need review"))
+
+    claimed_lines, deletion_index, key, choices = unresolved[0]
+    if len(choices) > max_candidates:
+        raise MergeError(_("Too many merge candidates to preview safely"))
+
+    valid_choices: list[_ReplacementOriginChoice] = []
+    for choice in choices:
+        resolution = MergeResolution({key: choice.choice_index})
+        try:
+            for _chunk in _merge_batch_acquired_line_chunks(
+                source_lines,
+                ownership,
+                working_lines,
+                resolution=resolution,
+            ):
+                pass
+        except MergeError:
+            continue
+        valid_choices.append(choice)
+
+    if not valid_choices:
+        return MergeCandidateSet(())
+
+    count = len(valid_choices)
+    claim = deletion_claims[deletion_index]
+    line_count = len(claim.content_lines)
+    source_start = min(claimed_lines)
+    source_end = max(claimed_lines)
+    ambiguity_target_line_range = (
+        min(choice.position + 1 for choice in valid_choices),
+        max(choice.position + line_count for choice in valid_choices),
+    )
+    candidates: list[MergeCandidate] = []
+    for ordinal, choice in enumerate(valid_choices, start=1):
+        target_start = choice.position + 1
+        target_end = choice.position + line_count
+        source_range = (
+            str(source_start)
+            if source_start == source_end else
+            f"{source_start}-{source_end}"
+        )
+        target_range = (
+            str(target_start)
+            if target_start == target_end else
+            f"{target_start}-{target_end}"
+        )
+        summary = _(
+            "replace target lines {target} with source lines {source}"
+        ).format(target=target_range, source=source_range)
+        candidates.append(
+            MergeCandidate(
+                ordinal=ordinal,
+                count=count,
+                decisions=(
+                    MergeResolutionDecision(
+                        ambiguity_key=key,
+                        choice_index=choice.choice_index,
+                        choice_label=summary,
+                    ),
+                ),
+                summary=summary,
+                source_line_range=(source_start, source_end),
+                target_after_line=choice.target_after_line,
+                target_before_line=choice.target_before_line,
+                explanation=_(
+                    "original replacement boundary is not present; "
+                    "selected replacement content has multiple compatible placements"
+                ),
+                ambiguity_target_line_range=ambiguity_target_line_range,
+            )
+        )
+    return MergeCandidateSet(tuple(candidates))
 
 
 def merge_batch_from_line_sequences_as_buffer(
@@ -2785,6 +3202,7 @@ def _merge_batch_acquired_line_chunks(
         ownership,
         presence_line_set,
         deletion_claims,
+        resolution=resolution,
     )
     if fallback_chunks is not None:
         yield from _byte_chunks(fallback_chunks)
@@ -2796,6 +3214,19 @@ def _merge_batch_acquired_line_chunks(
         owned_mapping = match_lines(source_lines, working_lines)
         mapping = owned_mapping
     try:
+        if _has_missing_origin_replacement_claims(
+            ownership,
+            presence_line_set,
+            source_lines,
+            mapping,
+        ):
+            raise MergeError(
+                _(
+                    "Cannot reliably place split replacement: original replacement "
+                    "boundary is not present"
+                )
+            )
+
         try:
             _check_structural_validity(
                 mapping,
@@ -2823,6 +3254,7 @@ def _merge_batch_acquired_line_chunks(
             ownership,
             presence_line_set,
             deletion_claims,
+            resolution=resolution,
         )
         if fallback_chunks is not None:
             yield from _byte_chunks(fallback_chunks)
@@ -2886,6 +3318,17 @@ def _enumerate_merge_batch_candidates_acquired(
     resolved = ownership.resolve()
     presence_line_set = resolved.presence_line_set
     deletion_claims = resolved.deletion_claims
+
+    replacement_candidates = _replacement_origin_candidate_set(
+        source_lines,
+        ownership,
+        working_lines,
+        presence_line_set,
+        deletion_claims,
+        max_candidates=max_candidates,
+    )
+    if replacement_candidates.candidates:
+        return replacement_candidates
 
     presence_mapping = match_lines(source_lines, working_lines)
     try:

--- a/src/git_stage_batch/batch/operation_candidates.py
+++ b/src/git_stage_batch/batch/operation_candidates.py
@@ -152,9 +152,19 @@ def _presence_claim_payload(claim) -> dict:
 
 
 def _replacement_unit_payload(unit) -> dict:
+    origin = unit.origin
     return {
         "presence_lines": unit.presence_lines,
         "deletion_indices": unit.deletion_indices,
+        "origin": None if origin is None else {
+            "old_start": origin.old_start,
+            "old_end": origin.old_end,
+            "new_start": origin.new_start,
+            "new_end": origin.new_end,
+            "baseline_reference": _baseline_reference_payload(
+                origin.baseline_reference
+            ),
+        },
     }
 
 

--- a/src/git_stage_batch/batch/ownership.py
+++ b/src/git_stage_batch/batch/ownership.py
@@ -253,6 +253,73 @@ def _deletion_reference_blob_ids(deletion_metadata: list[dict]) -> list[str]:
     ]
 
 
+def _replacement_origin_reference_blob_ids(replacement_metadata: list[dict]) -> list[str]:
+    blob_ids: list[str] = []
+    for metadata in replacement_metadata:
+        origin_metadata = metadata.get("original_unit", {})
+        if not isinstance(origin_metadata, dict):
+            continue
+        blob_ids.extend(
+            _baseline_reference_blob_ids(
+                origin_metadata.get("baseline_reference", {})
+            )
+        )
+    return blob_ids
+
+
+@dataclass
+class ReplacementUnitOrigin:
+    """Original full replacement region for a selectable replacement sub-unit.
+
+    Split replacement units may be smaller than the file-derived replacement run
+    that created them. This context records that original run so merge/discard
+    code can validate placement against the parent replacement boundary instead
+    of treating the selected sub-unit as an unrelated edit.
+    """
+
+    old_start: int
+    old_end: int
+    new_start: int
+    new_end: int
+    baseline_reference: BaselineReference | None = None
+
+    @property
+    def old_line_count(self) -> int:
+        """Return the number of baseline lines covered by the original unit."""
+        return self.old_end - self.old_start + 1
+
+    def to_dict(self) -> dict:
+        """Serialize to metadata dictionary."""
+        data = {
+            "old_start": self.old_start,
+            "old_end": self.old_end,
+            "new_start": self.new_start,
+            "new_end": self.new_end,
+        }
+        if self.baseline_reference is not None:
+            data["baseline_reference"] = self.baseline_reference.to_dict()
+        return data
+
+    @classmethod
+    def from_dict(
+        cls,
+        data: dict,
+        blob_contents: dict[str, bytes] | None = None,
+    ) -> ReplacementUnitOrigin:
+        """Deserialize from metadata dictionary."""
+        baseline_metadata = data.get("baseline_reference")
+        return cls(
+            old_start=data["old_start"],
+            old_end=data["old_end"],
+            new_start=data["new_start"],
+            new_end=data["new_end"],
+            baseline_reference=(
+                BaselineReference.from_dict(baseline_metadata, blob_contents)
+                if baseline_metadata is not None else None
+            ),
+        )
+
+
 @dataclass
 class ReplacementUnit:
     """Explicit coupling between presence claims and absence claims.
@@ -263,20 +330,33 @@ class ReplacementUnit:
 
     presence_lines: list[str]
     deletion_indices: list[int]
+    origin: ReplacementUnitOrigin | None = field(default=None, compare=False)
 
     def to_dict(self) -> dict:
         """Serialize to metadata dictionary."""
-        return {
+        data = {
             "presence_lines": self.presence_lines,
             "deletion_indices": self.deletion_indices,
         }
+        if self.origin is not None:
+            data["original_unit"] = self.origin.to_dict()
+        return data
 
     @classmethod
-    def from_dict(cls, data: dict) -> ReplacementUnit:
+    def from_dict(
+        cls,
+        data: dict,
+        blob_contents: dict[str, bytes] | None = None,
+    ) -> ReplacementUnit:
         """Deserialize from metadata dictionary."""
+        origin_metadata = data.get("original_unit")
         return cls(
             presence_lines=data.get("presence_lines", data.get("claimed_lines", [])),
             deletion_indices=data.get("deletion_indices", []),
+            origin=(
+                ReplacementUnitOrigin.from_dict(origin_metadata, blob_contents)
+                if isinstance(origin_metadata, dict) else None
+            ),
         )
 
 
@@ -411,6 +491,7 @@ class BatchOwnership:
         """Acquire ownership for metadata with buffered deletion blobs."""
         deletion_metadata = data.get("deletions", [])
         presence_metadata = data.get("presence_claims", [])
+        replacement_metadata = data.get("replacement_units", [])
         blob_buffers: dict[str, EditorBuffer] = {}
         buffers: list[EditorBuffer] = []
         try:
@@ -425,6 +506,7 @@ class BatchOwnership:
                 [
                     *_deletion_reference_blob_ids(deletion_metadata),
                     *_presence_claim_reference_blob_ids(presence_metadata),
+                    *_replacement_origin_reference_blob_ids(replacement_metadata),
                 ]
             )
             ownership = cls._from_metadata_dict(
@@ -466,7 +548,7 @@ class BatchOwnership:
             for d in deletion_metadata
         ]
         replacement_units = [
-            ReplacementUnit.from_dict(d)
+            ReplacementUnit.from_dict(d, blob_contents)
             for d in data.get("replacement_units", [])
         ]
         return cls(
@@ -552,6 +634,7 @@ def acquire_detached_batch_ownership(
                 ReplacementUnit(
                     presence_lines=unit.presence_lines[:],
                     deletion_indices=unit.deletion_indices[:],
+                    origin=unit.origin,
                 )
                 for unit in ownership.replacement_units
             ],
@@ -781,7 +864,7 @@ def _normalize_replacement_units(
     deletion_count: int,
 ) -> list[ReplacementUnit]:
     """Drop invalid references and coalesce overlapping replacement units."""
-    components: list[tuple[LineRanges, set[int]]] = []
+    components: list[tuple[LineRanges, set[int], ReplacementUnitOrigin | None]] = []
 
     for unit in replacement_units:
         claimed = _parse_line_ranges(unit.presence_lines)
@@ -792,36 +875,75 @@ def _normalize_replacement_units(
         }
         if not claimed or not deletion_indices:
             continue
+        origin = _normalize_replacement_unit_origin(unit.origin)
 
         overlapping_component_indices = [
             index
-            for index, (component_claimed, component_deletions)
+            for index, (component_claimed, component_deletions, _component_origin)
             in enumerate(components)
             if component_claimed.intersection(claimed) or component_deletions & deletion_indices
         ]
         if not overlapping_component_indices:
-            components.append((claimed, set(deletion_indices)))
+            components.append((claimed, set(deletion_indices), origin))
             continue
 
         target_index = overlapping_component_indices[0]
-        target_claimed, target_deletions = components[target_index]
+        target_claimed, target_deletions, target_origin = components[target_index]
         target_claimed = target_claimed.union(claimed)
         target_deletions.update(deletion_indices)
+        target_origin = _merge_replacement_unit_origins(target_origin, origin)
 
         for source_index in reversed(overlapping_component_indices[1:]):
-            source_claimed, source_deletions = components[source_index]
+            source_claimed, source_deletions, source_origin = components[source_index]
             target_claimed = target_claimed.union(source_claimed)
             target_deletions.update(source_deletions)
+            target_origin = _merge_replacement_unit_origins(
+                target_origin,
+                source_origin,
+            )
             del components[source_index]
-        components[target_index] = (target_claimed, target_deletions)
+        components[target_index] = (target_claimed, target_deletions, target_origin)
 
     return [
         ReplacementUnit(
             presence_lines=_format_line_set(claimed),
             deletion_indices=sorted(deletion_indices),
+            origin=origin,
         )
-        for claimed, deletion_indices in components
+        for claimed, deletion_indices, origin in components
     ]
+
+
+def _normalize_replacement_unit_origin(
+    origin: ReplacementUnitOrigin | None,
+) -> ReplacementUnitOrigin | None:
+    """Return valid original replacement context, or None."""
+    if origin is None:
+        return None
+    if (
+        type(origin.old_start) is not int
+        or type(origin.old_end) is not int
+        or type(origin.new_start) is not int
+        or type(origin.new_end) is not int
+        or origin.old_start > origin.old_end
+        or origin.new_start > origin.new_end
+    ):
+        return None
+    return origin
+
+
+def _merge_replacement_unit_origins(
+    left: ReplacementUnitOrigin | None,
+    right: ReplacementUnitOrigin | None,
+) -> ReplacementUnitOrigin | None:
+    """Keep parent context only when coalesced units agree on it."""
+    if left == right:
+        return left
+    if left is None:
+        return right
+    if right is None:
+        return left
+    return None
 
 
 def merge_batch_ownership(existing: BatchOwnership, new: BatchOwnership) -> BatchOwnership:
@@ -893,6 +1015,7 @@ def merge_batch_ownership(existing: BatchOwnership, new: BatchOwnership) -> Batc
             combined_replacement_units.append(ReplacementUnit(
                 presence_lines=unit.presence_lines,
                 deletion_indices=remapped_indices,
+                origin=unit.origin,
             ))
 
     return BatchOwnership(
@@ -1195,6 +1318,24 @@ def _baseline_reference_for_old_line_range(
     )
 
 
+def _replacement_unit_origin_for_line_run(
+    replacement_run: ReplacementLineRun,
+    old_line_content: dict[int, bytes],
+) -> ReplacementUnitOrigin:
+    """Build parent replacement context for a file-derived replacement run."""
+    return ReplacementUnitOrigin(
+        old_start=replacement_run.old_start,
+        old_end=replacement_run.old_end,
+        new_start=replacement_run.new_start,
+        new_end=replacement_run.new_end,
+        baseline_reference=_baseline_reference_for_old_line_range(
+            replacement_run.old_start,
+            replacement_run.old_end,
+            old_line_content,
+        ),
+    )
+
+
 @dataclass(frozen=True)
 class _HunkLineRangeScan:
     start: int
@@ -1337,6 +1478,7 @@ def translate_hunk_selection_to_batch_ownership(
         *,
         old_start: int,
         old_end: int,
+        origin: ReplacementUnitOrigin | None = None,
     ) -> None:
         deletion_anchor: int | None = None
         old_line_seen = False
@@ -1396,6 +1538,7 @@ def translate_hunk_selection_to_batch_ownership(
             ReplacementUnit(
                 presence_lines=selected_source_lines.finish().to_range_strings(),
                 deletion_indices=[len(absence_claims) - 1],
+                origin=origin,
             )
         )
         consumed_replacement_ids.update(consumed_ids)
@@ -1404,6 +1547,10 @@ def translate_hunk_selection_to_batch_ownership(
     new_cursor = 0
 
     for replacement_run in replacement_line_runs or []:
+        replacement_origin = _replacement_unit_origin_for_line_run(
+            replacement_run,
+            old_line_content,
+        )
         old_scan = _scan_hunk_line_range(
             hunk_lines,
             old_cursor,
@@ -1460,6 +1607,7 @@ def translate_hunk_selection_to_batch_ownership(
                         (new_line,),
                         old_start=old_line.old_line_number,
                         old_end=old_line.old_line_number,
+                        origin=replacement_origin,
                     )
             continue
 
@@ -1482,6 +1630,7 @@ def translate_hunk_selection_to_batch_ownership(
                 ),
                 old_start=replacement_run.old_start,
                 old_end=replacement_run.old_end,
+                origin=replacement_origin,
             )
 
     current_absence_anchor: int | None = None
@@ -1648,6 +1797,7 @@ class OwnershipUnit:
         is_atomic: If True, partial removal is not allowed
         atomic_reason: Explanation for why unit is atomic (for debugging/errors)
         preserves_replacement_unit: True when this unit came from persisted replacement metadata
+        replacement_origin: Original parent replacement context, when known
     """
     kind: OwnershipUnitKind
     claimed_source_lines: LineRanges
@@ -1656,6 +1806,7 @@ class OwnershipUnit:
     is_atomic: bool = False
     atomic_reason: str | None = None
     preserves_replacement_unit: bool = False
+    replacement_origin: ReplacementUnitOrigin | None = None
 
 
 def build_ownership_units_from_batch_source_lines(
@@ -1880,6 +2031,7 @@ def _build_explicit_replacement_units_from_display_lines(
             is_atomic=True,
             atomic_reason="explicit_replacement",
             preserves_replacement_unit=True,
+            replacement_origin=replacement_unit.origin,
         ))
         consumed_claimed_lines = consumed_claimed_lines.union(claimed_source_lines)
         consumed_deletion_indices.update(deletion_indices)
@@ -2151,6 +2303,7 @@ def rebuild_ownership_from_units(units: list[OwnershipUnit]) -> BatchOwnership:
             replacement_units.append(ReplacementUnit(
                 presence_lines=_format_line_set(unit.claimed_source_lines),
                 deletion_indices=deletion_indices,
+                origin=unit.replacement_origin,
             ))
 
     return BatchOwnership(
@@ -2186,6 +2339,7 @@ def _remap_replacement_units(
         remapped_units.append(ReplacementUnit(
             presence_lines=_format_line_set(new_presence_lines),
             deletion_indices=unit.deletion_indices,
+            origin=unit.origin,
         ))
 
     return _normalize_replacement_units(
@@ -2224,6 +2378,7 @@ def _remap_replacement_units_with_lineage(
                 lineage.translate_source_selection(old_presence_lines)
             ),
             deletion_indices=unit.deletion_indices,
+            origin=unit.origin,
         ))
 
     return _normalize_replacement_units(

--- a/src/git_stage_batch/batch/query.py
+++ b/src/git_stage_batch/batch/query.py
@@ -30,7 +30,7 @@ def read_batch_metadata(name: str) -> dict:
                 "batch_source_commit": str,  # Batch source SHA
                 "presence_claims": list[dict],  # [{"source_lines": ["1-5"]}]
                 "deletions": list[dict],  # [{"after_source_line": int|None, "blob": str}]
-                "replacement_units": list[dict],  # optional presence/deletion coupling
+                "replacement_units": list[dict],  # optional presence/deletion coupling plus original-unit context
                 "mode": str,  # File mode (e.g. "100644")
                 "change_type": str,  # optional text lifecycle: "added" or "deleted"
             }

--- a/src/git_stage_batch/batch/source_refresh.py
+++ b/src/git_stage_batch/batch/source_refresh.py
@@ -22,9 +22,11 @@ from .lineage import _BatchSourceLineage
 from .match import match_lines
 from .ownership import (
     BatchOwnership,
+    ReplacementLineRun,
     advance_batch_source_for_file_with_provenance,
     detect_stale_batch_source_for_selection,
     merge_batch_ownership,
+    translate_hunk_selection_to_batch_ownership,
     translate_lines_to_batch_ownership,
 )
 
@@ -372,12 +374,62 @@ def _refresh_selected_lines_against_source_lines(
         if mapping is not None:
             mapping.close()
 
+
+def _merge_refreshed_selected_lines_into_hunk(
+    hunk_lines: Sequence[LineEntry],
+    selected_lines: Sequence[LineEntry],
+) -> list[LineEntry]:
+    """Return full hunk lines with refreshed selected-line coordinates."""
+    selected_by_id = {
+        line.id: line
+        for line in selected_lines
+        if line.id is not None
+    }
+    if not selected_by_id:
+        return list(hunk_lines)
+
+    return [
+        selected_by_id.get(line.id, line)
+        if line.id is not None else
+        line
+        for line in hunk_lines
+    ]
+
+
+def _translate_selection_to_batch_ownership(
+    selected_lines: list,
+    *,
+    hunk_lines: Sequence[LineEntry] | None = None,
+    replacement_line_runs: Sequence[ReplacementLineRun] | None = None,
+) -> BatchOwnership:
+    """Translate a selection, using full-hunk replacement context when available."""
+    selected_ids = {
+        line.id
+        for line in selected_lines
+        if line.id is not None
+    }
+    if hunk_lines is not None and replacement_line_runs is not None and selected_ids:
+        return translate_hunk_selection_to_batch_ownership(
+            _merge_refreshed_selected_lines_into_hunk(
+                hunk_lines,
+                selected_lines,
+            ),
+            selected_ids,
+            replacement_line_runs=list(replacement_line_runs),
+        )
+
+    return translate_lines_to_batch_ownership(selected_lines)
+
+
 def prepare_batch_ownership_update_for_selection(
     batch_name: str,
     file_path: str,
     current_batch_source_commit: str | None,
     existing_ownership: BatchOwnership | None,
     selected_lines: list,
+    *,
+    hunk_lines: Sequence[LineEntry] | None = None,
+    replacement_line_runs: Sequence[ReplacementLineRun] | None = None,
 ) -> PreparedBatchUpdate:
     """Prepare complete ownership update for batch file, handling stale sources.
 
@@ -414,7 +466,11 @@ def prepare_batch_ownership_update_for_selection(
     )
 
     # Step 2: Translate selected lines to new ownership
-    new_ownership = translate_lines_to_batch_ownership(refreshed.selected_lines)
+    new_ownership = _translate_selection_to_batch_ownership(
+        refreshed.selected_lines,
+        hunk_lines=hunk_lines,
+        replacement_line_runs=replacement_line_runs,
+    )
 
     # Step 3: Merge with existing ownership
     if refreshed.ownership:
@@ -437,6 +493,8 @@ def acquire_batch_ownership_update_for_selection(
     file_path: str,
     file_metadata: dict | None,
     selected_lines: list,
+    hunk_lines: Sequence[LineEntry] | None = None,
+    replacement_line_runs: Sequence[ReplacementLineRun] | None = None,
 ) -> Iterator[PreparedBatchUpdate]:
     """Acquire existing ownership metadata while preparing a batch update.
 
@@ -450,6 +508,8 @@ def acquire_batch_ownership_update_for_selection(
             current_batch_source_commit=None,
             existing_ownership=None,
             selected_lines=selected_lines,
+            hunk_lines=hunk_lines,
+            replacement_line_runs=replacement_line_runs,
         )
         return
 
@@ -460,4 +520,6 @@ def acquire_batch_ownership_update_for_selection(
             current_batch_source_commit=file_metadata.get("batch_source_commit"),
             existing_ownership=existing_ownership,
             selected_lines=selected_lines,
+            hunk_lines=hunk_lines,
+            replacement_line_runs=replacement_line_runs,
         )

--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -25,6 +25,7 @@ from ..batch.ownership import (
     BatchOwnership,
     _advance_source_lines_preserving_existing_presence,
     _remap_batch_ownership_with_lineage,
+    derive_replacement_line_runs_from_lines,
     merge_batch_ownership,
     translate_lines_to_batch_ownership,
 )
@@ -91,6 +92,7 @@ from ..data.undo import undo_checkpoint
 from ..editor import (
     EditorBuffer,
     load_git_object_as_buffer,
+    load_git_object_as_buffer_or_empty,
     load_working_tree_file_as_buffer,
     write_buffer_to_path,
 )
@@ -1011,6 +1013,18 @@ def command_discard_line_as_to_batch(
         finish_review_scoped_line_action(review_state, file_path=target_file)
 
 
+def _derive_live_replacement_line_runs(file_path: str):
+    """Derive file-level replacement runs for the current live file state."""
+    with (
+        load_git_object_as_buffer_or_empty(f"HEAD:{file_path}") as baseline_lines,
+        load_working_tree_file_as_buffer(file_path) as working_lines,
+    ):
+        return derive_replacement_line_runs_from_lines(
+            old_file_lines=baseline_lines,
+            new_file_lines=working_lines,
+        )
+
+
 def _command_discard_lines_to_batch_as(
     batch_name: str,
     line_id_specification: str,
@@ -1804,6 +1818,7 @@ def _command_discard_file_lines_to_batch(
 
     metadata = read_batch_metadata(batch_name)
     file_metadata = metadata.get("files", {}).get(file_path)
+    replacement_line_runs = _derive_live_replacement_line_runs(file_path)
 
     with ExitStack() as ownership_stack:
         try:
@@ -1813,6 +1828,8 @@ def _command_discard_file_lines_to_batch(
                     file_path=file_path,
                     file_metadata=file_metadata,
                     selected_lines=selected_lines,
+                    hunk_lines=line_changes.lines,
+                    replacement_line_runs=replacement_line_runs,
                 )
             )
         except ValueError as e:
@@ -1897,6 +1914,7 @@ def _command_discard_lines_to_batch(
 
     metadata = read_batch_metadata(batch_name)
     file_metadata = metadata.get("files", {}).get(line_changes.path)
+    replacement_line_runs = _derive_live_replacement_line_runs(line_changes.path)
 
     file_mode = _detect_file_mode(line_changes.path)
 
@@ -1908,6 +1926,8 @@ def _command_discard_lines_to_batch(
                     file_path=line_changes.path,
                     file_metadata=file_metadata,
                     selected_lines=selected_lines,
+                    hunk_lines=line_changes.lines,
+                    replacement_line_runs=replacement_line_runs,
                 )
             )
         except ValueError as e:

--- a/tests/batch/test_merge.py
+++ b/tests/batch/test_merge.py
@@ -28,6 +28,7 @@ from git_stage_batch.batch.ownership import (
     BatchOwnership,
     AbsenceClaim,
     ReplacementUnit,
+    ReplacementUnitOrigin,
 )
 from git_stage_batch.utils.text import normalize_line_sequence_endings
 
@@ -84,6 +85,7 @@ def merge_batch(
     working_content: bytes,
     *,
     source_to_working_mapping=None,
+    resolution=None,
 ) -> bytes:
     """Return merged bytes through the buffer-returning production API."""
     with (
@@ -94,6 +96,7 @@ def merge_batch(
             ownership,
             working_lines,
             source_to_working_mapping=source_to_working_mapping,
+            resolution=resolution,
         ) as buffer,
     ):
         return buffer.to_bytes()
@@ -1074,6 +1077,261 @@ class TestMergeBatch:
         result = merge_batch(source, ownership, source)
 
         assert result == source
+
+    def test_split_replacement_origin_places_subunit_inside_parent_boundary(self):
+        """Parent replacement context constrains exact split-unit reapply."""
+        source = b"head\nnew1\nnew2\ntail\n"
+        working = b"head\nold1\nold2\ntail\n"
+        ownership = BatchOwnership.from_presence_lines(
+            ["3"],
+            [
+                AbsenceClaim(
+                    anchor_line=2,
+                    content_lines=[b"old2\n"],
+                    baseline_reference=BaselineReference(
+                        after_line=2,
+                        after_content=b"old1",
+                        before_line=4,
+                        before_content=b"tail",
+                        has_before_line=True,
+                    ),
+                )
+            ],
+            baseline_references={
+                3: BaselineReference(
+                    after_line=2,
+                    after_content=b"old1",
+                    before_line=4,
+                    before_content=b"tail",
+                    has_before_line=True,
+                )
+            },
+            replacement_units=[
+                ReplacementUnit(
+                    presence_lines=["3"],
+                    deletion_indices=[0],
+                    origin=ReplacementUnitOrigin(
+                        old_start=2,
+                        old_end=3,
+                        new_start=2,
+                        new_end=3,
+                        baseline_reference=BaselineReference(
+                            after_line=1,
+                            after_content=b"head",
+                            before_line=4,
+                            before_content=b"tail",
+                            has_before_line=True,
+                        ),
+                    ),
+                )
+            ],
+        )
+
+        result = merge_batch(source, ownership, working)
+
+        assert result == b"head\nold1\nnew2\ntail\n"
+
+    def test_split_replacement_origin_places_subunit_in_hybrid_parent(self):
+        """Split units should reapply where unselected sibling lines remain new."""
+        source = b"head\nnew1\nnew2\ntail\n"
+        working = b"head\nnew1\nold2\ntail\n"
+        ownership = BatchOwnership.from_presence_lines(
+            ["3"],
+            [
+                AbsenceClaim(
+                    anchor_line=2,
+                    content_lines=[b"old2\n"],
+                    baseline_reference=BaselineReference(
+                        after_line=2,
+                        after_content=b"old1",
+                        before_line=4,
+                        before_content=b"tail",
+                        has_before_line=True,
+                    ),
+                )
+            ],
+            baseline_references={
+                3: BaselineReference(
+                    after_line=2,
+                    after_content=b"old1",
+                    before_line=4,
+                    before_content=b"tail",
+                    has_before_line=True,
+                )
+            },
+            replacement_units=[
+                ReplacementUnit(
+                    presence_lines=["3"],
+                    deletion_indices=[0],
+                    origin=ReplacementUnitOrigin(
+                        old_start=2,
+                        old_end=3,
+                        new_start=2,
+                        new_end=3,
+                        baseline_reference=BaselineReference(
+                            after_line=1,
+                            after_content=b"head",
+                            before_line=4,
+                            before_content=b"tail",
+                            has_before_line=True,
+                        ),
+                    ),
+                )
+            ],
+        )
+
+        result = merge_batch(source, ownership, working)
+
+        assert result == b"head\nnew1\nnew2\ntail\n"
+
+    def test_split_replacement_origin_refuses_missing_parent_boundary(self):
+        """Split replacement units should fail rather than guess a new location."""
+        source = b"head\nnew1\nnew2\ntail\n"
+        working = b"head\nold2\ntail\n"
+        ownership = BatchOwnership.from_presence_lines(
+            ["3"],
+            [
+                AbsenceClaim(
+                    anchor_line=2,
+                    content_lines=[b"old2\n"],
+                    baseline_reference=BaselineReference(
+                        after_line=2,
+                        after_content=b"old1",
+                        before_line=4,
+                        before_content=b"tail",
+                        has_before_line=True,
+                    ),
+                )
+            ],
+            baseline_references={
+                3: BaselineReference(
+                    after_line=2,
+                    after_content=b"old1",
+                    before_line=4,
+                    before_content=b"tail",
+                    has_before_line=True,
+                )
+            },
+            replacement_units=[
+                ReplacementUnit(
+                    presence_lines=["3"],
+                    deletion_indices=[0],
+                    origin=ReplacementUnitOrigin(
+                        old_start=2,
+                        old_end=3,
+                        new_start=2,
+                        new_end=3,
+                        baseline_reference=BaselineReference(
+                            after_line=1,
+                            after_content=b"head",
+                            before_line=4,
+                            before_content=b"tail",
+                            has_before_line=True,
+                        ),
+                    ),
+                )
+            ],
+        )
+
+        with pytest.raises(MergeError, match="original replacement boundary"):
+            merge_batch(source, ownership, working)
+
+        candidate_set = enumerate_merge_batch_candidates_from_line_sequences(
+            source.splitlines(keepends=True),
+            ownership,
+            working.splitlines(keepends=True),
+            max_candidates=10,
+        )
+
+        assert [candidate.summary for candidate in candidate_set.candidates] == [
+            "replace target lines 2 with source lines 3",
+        ]
+
+        result = merge_batch(
+            source,
+            ownership,
+            working,
+            resolution=candidate_set.candidates[0].resolution,
+        )
+
+        assert result == b"head\nnew2\ntail\n"
+
+    def test_split_replacement_origin_enumerates_ambiguous_placements(self):
+        """Missing parent context should use reviewed candidates, not guessing."""
+        source = b"head\nnew1\nnew2\ntail\n"
+        working = b"head\nold2\nmid\nold2\ntail\n"
+        ownership = BatchOwnership.from_presence_lines(
+            ["3"],
+            [
+                AbsenceClaim(
+                    anchor_line=2,
+                    content_lines=[b"old2\n"],
+                    baseline_reference=BaselineReference(
+                        after_line=2,
+                        after_content=b"old1",
+                        before_line=4,
+                        before_content=b"tail",
+                        has_before_line=True,
+                    ),
+                )
+            ],
+            baseline_references={
+                3: BaselineReference(
+                    after_line=2,
+                    after_content=b"old1",
+                    before_line=4,
+                    before_content=b"tail",
+                    has_before_line=True,
+                )
+            },
+            replacement_units=[
+                ReplacementUnit(
+                    presence_lines=["3"],
+                    deletion_indices=[0],
+                    origin=ReplacementUnitOrigin(
+                        old_start=2,
+                        old_end=3,
+                        new_start=2,
+                        new_end=3,
+                        baseline_reference=BaselineReference(
+                            after_line=1,
+                            after_content=b"head",
+                            before_line=4,
+                            before_content=b"tail",
+                            has_before_line=True,
+                        ),
+                    ),
+                )
+            ],
+        )
+
+        with pytest.raises(MergeError, match="original replacement boundary"):
+            merge_batch(source, ownership, working)
+
+        candidate_set = enumerate_merge_batch_candidates_from_line_sequences(
+            source.splitlines(keepends=True),
+            ownership,
+            working.splitlines(keepends=True),
+            max_candidates=10,
+        )
+
+        assert [candidate.summary for candidate in candidate_set.candidates] == [
+            "replace target lines 2 with source lines 3",
+            "replace target lines 4 with source lines 3",
+        ]
+        first, second = candidate_set.candidates
+        assert merge_batch(
+            source,
+            ownership,
+            working,
+            resolution=first.resolution,
+        ) == b"head\nnew2\nmid\nold2\ntail\n"
+        assert merge_batch(
+            source,
+            ownership,
+            working,
+            resolution=second.resolution,
+        ) == b"head\nold2\nmid\nnew2\ntail\n"
 
     def test_baseline_referenced_independent_presence_and_absence(self):
         """Independent baseline-coordinate insertions and removals can compose."""

--- a/tests/batch/test_ownership_incremental.py
+++ b/tests/batch/test_ownership_incremental.py
@@ -6,6 +6,7 @@ from git_stage_batch.batch.ownership import (
     AbsenceClaim,
     ReplacementLineRun,
     ReplacementUnit,
+    ReplacementUnitOrigin,
     derive_replacement_line_runs_from_lines,
     translate_hunk_selection_to_batch_ownership,
     translate_lines_to_batch_ownership,
@@ -297,6 +298,55 @@ def test_translate_hunk_selection_uses_file_derived_replacement_runs():
     assert ownership.replacement_units == [
         ReplacementUnit(presence_lines=["1"], deletion_indices=[0]),
     ]
+    origin = ownership.replacement_units[0].origin
+    assert origin == ReplacementUnitOrigin(
+        old_start=1,
+        old_end=2,
+        new_start=1,
+        new_end=2,
+        baseline_reference=origin.baseline_reference,
+    )
+
+
+def test_translate_hunk_selection_records_parent_origin_for_split_replacement():
+    """Split replacement sub-units should remember their full parent run."""
+    lines = [
+        LineEntry(id=1, kind='-', old_line_number=1, new_line_number=None,
+                  text_bytes=b'a', text='a', source_line=None),
+        LineEntry(id=2, kind='-', old_line_number=2, new_line_number=None,
+                  text_bytes=b'b', text='b', source_line=1),
+        LineEntry(id=3, kind='+', old_line_number=None, new_line_number=1,
+                  text_bytes=b'A', text='A', source_line=1),
+        LineEntry(id=4, kind='+', old_line_number=None, new_line_number=2,
+                  text_bytes=b'B', text='B', source_line=2),
+        LineEntry(id=None, kind=' ', old_line_number=3, new_line_number=3,
+                  text_bytes=b'c', text='c', source_line=3),
+    ]
+
+    ownership = translate_hunk_selection_to_batch_ownership(
+        lines,
+        {1, 3},
+        replacement_line_runs=[
+            ReplacementLineRun(
+                old_start=1,
+                old_end=2,
+                new_start=1,
+                new_end=2,
+            ),
+        ],
+    )
+
+    origin = ownership.replacement_units[0].origin
+    assert origin is not None
+    assert (origin.old_start, origin.old_end) == (1, 2)
+    assert (origin.new_start, origin.new_end) == (1, 2)
+    assert origin.baseline_reference.after_line is None
+    assert origin.baseline_reference.before_line == 3
+    assert origin.baseline_reference.before_content == b'c'
+
+    selected_reference = ownership.deletions[0].baseline_reference
+    assert selected_reference.before_line == 2
+    assert selected_reference.before_content == b'b'
 
 
 def test_translate_hunk_selection_keeps_one_to_many_replacement_atomic():

--- a/tests/batch/test_ownership_unit_grouping.py
+++ b/tests/batch/test_ownership_unit_grouping.py
@@ -15,9 +15,11 @@ from git_stage_batch.batch.display import (
 from git_stage_batch.batch.ownership import (
     BatchOwnership,
     AbsenceClaim,
+    BaselineReference,
     OwnershipUnit,
     OwnershipUnitKind,
     ReplacementUnit,
+    ReplacementUnitOrigin,
     build_ownership_units_from_batch_source_lines,
     rebuild_ownership_from_units,
     select_ownership_units_by_display_ids,
@@ -587,13 +589,24 @@ def test_partial_atomic_selection_reports_range_backed_display_ids():
 def test_rebuild_preserves_explicit_replacement_units():
     """Filtering/rebuilding ownership should persist replacement couplings."""
     batch_source = b"new one\nnew two\nkeep\n"
+    origin = ReplacementUnitOrigin(
+        old_start=1,
+        old_end=2,
+        new_start=1,
+        new_end=2,
+        baseline_reference=BaselineReference(after_line=None),
+    )
     ownership = BatchOwnership.from_presence_lines(
         ["1-2"],
         [
             AbsenceClaim(anchor_line=None, content_lines=[b"old one\n", b"old two\n"]),
         ],
         replacement_units=[
-            ReplacementUnit(presence_lines=["1-2"], deletion_indices=[0]),
+            ReplacementUnit(
+                presence_lines=["1-2"],
+                deletion_indices=[0],
+                origin=origin,
+            ),
         ],
     )
 
@@ -606,6 +619,7 @@ def test_rebuild_preserves_explicit_replacement_units():
     assert rebuilt.replacement_units == [
         ReplacementUnit(presence_lines=["1-2"], deletion_indices=[0]),
     ]
+    assert rebuilt.replacement_units[0].origin == origin
 
 
 def test_rebuild_preserves_mixed_same_anchor_deletion_order():

--- a/tests/batch/test_storage.py
+++ b/tests/batch/test_storage.py
@@ -15,6 +15,7 @@ from git_stage_batch.batch.ownership import (
     BatchOwnership,
     AbsenceClaim,
     ReplacementUnit,
+    ReplacementUnitOrigin,
     _AbsenceContentBuilder,
     _absence_signature,
     acquire_detached_batch_ownership,
@@ -395,6 +396,46 @@ def test_add_file_to_batch_persists_baseline_references(temp_git_repo):
     with BatchOwnership.acquire_for_metadata_dict(file_meta) as round_tripped:
         assert round_tripped.presence_baseline_references()[2] == presence_reference
         assert round_tripped.deletions[0].baseline_reference == deletion_reference
+
+
+def test_replacement_unit_origin_round_trips_metadata(temp_git_repo):
+    """Original replacement parent context should survive metadata loading."""
+    origin_reference = BaselineReference(
+        after_line=1,
+        after_content=b"before",
+        before_line=4,
+        before_content=b"after",
+        has_before_line=True,
+    )
+    origin = ReplacementUnitOrigin(
+        old_start=2,
+        old_end=3,
+        new_start=2,
+        new_end=3,
+        baseline_reference=origin_reference,
+    )
+    old_blob = create_git_blob([b"old\n"])
+
+    with BatchOwnership.acquire_for_metadata_dict({
+        "presence_claims": [{"source_lines": ["2"]}],
+        "deletions": [
+            {
+                "after_source_line": 1,
+                "blob": old_blob,
+            }
+        ],
+        "replacement_units": [
+            ReplacementUnit(
+                presence_lines=["2"],
+                deletion_indices=[0],
+                origin=origin,
+            ).to_dict()
+        ],
+    }) as ownership:
+        round_tripped_origin = ownership.replacement_units[0].origin
+        assert round_tripped_origin == origin
+        assert round_tripped_origin.baseline_reference.after_content == b"before"
+        assert round_tripped_origin.baseline_reference.before_content == b"after"
 
 
 def test_empty_replacement_units_are_omitted_from_metadata():

--- a/tests/commands/test_candidate_previews.py
+++ b/tests/commands/test_candidate_previews.py
@@ -11,7 +11,13 @@ import git_stage_batch.commands.apply_from as apply_from_module
 import git_stage_batch.commands.include_from as include_from_module
 import git_stage_batch.commands.show_from as show_from_module
 from git_stage_batch.batch import create_batch
-from git_stage_batch.batch.ownership import AbsenceClaim, BatchOwnership
+from git_stage_batch.batch.ownership import (
+    AbsenceClaim,
+    BaselineReference,
+    BatchOwnership,
+    ReplacementUnit,
+    ReplacementUnitOrigin,
+)
 from git_stage_batch.batch.storage import add_file_to_batch
 from git_stage_batch.commands.apply_from import command_apply_from_batch
 from git_stage_batch.commands.include_from import command_include_from_batch
@@ -113,6 +119,69 @@ def _create_displaced_absence_block_batch(repo):
     (repo / "file.txt").write_text(
         "a\ninsert\nx\ny\nz\nmid\nx\ny\nz\nb\n"
     )
+
+
+def _create_split_replacement_origin_batch(repo):
+    (repo / "file.txt").write_text("head\nnew1\nnew2\ntail\n")
+    subprocess.run(["git", "add", "file.txt"], check=True, cwd=repo, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "Add split replacement source file"],
+        check=True,
+        cwd=repo,
+        capture_output=True,
+    )
+    initialize_abort_state()
+    create_batch("split-origin")
+    add_file_to_batch(
+        "split-origin",
+        "file.txt",
+        BatchOwnership.from_presence_lines(
+            ["3"],
+            [
+                AbsenceClaim(
+                    anchor_line=2,
+                    content_lines=[b"old2\n"],
+                    baseline_reference=BaselineReference(
+                        after_line=2,
+                        after_content=b"old1",
+                        before_line=4,
+                        before_content=b"tail",
+                        has_before_line=True,
+                    ),
+                )
+            ],
+            baseline_references={
+                3: BaselineReference(
+                    after_line=2,
+                    after_content=b"old1",
+                    before_line=4,
+                    before_content=b"tail",
+                    has_before_line=True,
+                )
+            },
+            replacement_units=[
+                ReplacementUnit(
+                    presence_lines=["3"],
+                    deletion_indices=[0],
+                    origin=ReplacementUnitOrigin(
+                        old_start=2,
+                        old_end=3,
+                        new_start=2,
+                        new_end=3,
+                        baseline_reference=BaselineReference(
+                            after_line=1,
+                            after_content=b"head",
+                            before_line=4,
+                            before_content=b"tail",
+                            has_before_line=True,
+                        ),
+                    ),
+                )
+            ],
+        ),
+        "100644",
+    )
+    (repo / "file.txt").write_text("head\nold2\nmid\nold2\ntail\n")
 
 
 def _candidate_state_has_file(batch_name, file_path):
@@ -233,6 +302,36 @@ def test_apply_candidate_can_run_from_overview(temp_git_repo, capsys):
     assert "delete target line" not in captured.err
     assert (temp_git_repo / "file.txt").read_text() == "a\ninsert\nmid\nx\nb\n"
     assert not _candidate_state_has_file("ambiguous", "file.txt")
+
+
+def test_split_replacement_origin_uses_apply_candidates(temp_git_repo, capsys):
+    """Unprovable split replacement placement should use reviewed candidates."""
+    _create_split_replacement_origin_batch(temp_git_repo)
+
+    with pytest.raises(CommandError) as exc_info:
+        command_apply_from_batch("split-origin")
+
+    assert "file.txt has 2 apply candidates" in exc_info.value.message
+    assert "git-stage-batch show --from split-origin:apply --file file.txt" in (
+        exc_info.value.message
+    )
+
+    command_show_from_batch("split-origin:apply", file="file.txt")
+
+    overview = capsys.readouterr()
+    assert "file.txt  ·  split-origin  ·  apply candidates  ·  2 choices" in (
+        overview.out
+    )
+    assert "Candidate 1/2" in overview.out
+    assert "Candidate 2/2" in overview.out
+    assert _candidate_state_has_file("split-origin", "file.txt")
+
+    command_apply_from_batch("split-origin:apply:2", file="file.txt")
+
+    captured = capsys.readouterr()
+    assert "Applied candidate 2 of 2 from batch 'split-origin'" in captured.err
+    assert (temp_git_repo / "file.txt").read_text() == "head\nold2\nmid\nnew2\ntail\n"
+    assert not _candidate_state_has_file("split-origin", "file.txt")
 
 
 def test_candidate_preview_allows_equivalent_line_selection_spelling(

--- a/tests/commands/test_discard.py
+++ b/tests/commands/test_discard.py
@@ -724,6 +724,15 @@ class TestCommandDiscardToBatch:
         assert captured.out.count("file.txt ::") == 1
         assert file_path.read_text() == "a\nB\n"
 
+        metadata = read_batch_metadata("test")
+        replacement_unit = metadata["files"]["file.txt"]["replacement_units"][0]
+        assert replacement_unit["presence_lines"] == ["1"]
+        assert replacement_unit["deletion_indices"] == [0]
+        assert replacement_unit["original_unit"]["old_start"] == 1
+        assert replacement_unit["original_unit"]["old_end"] == 2
+        assert replacement_unit["original_unit"]["new_start"] == 1
+        assert replacement_unit["original_unit"]["new_end"] == 2
+
         command_apply_from_batch("test")
 
         assert file_path.read_text() == "A\nB\n"


### PR DESCRIPTION
Batch ownership records explicit replacement units as a coupling between
presence claims and deletion claims. When a replacement unit is split into
smaller selectable pieces, the program loses the larger file-derived
replacement run that produced those pieces.

Without that parent context, later merge logic has no durable boundary to
distinguish the selected slice from unrelated matching content. Users who
split a replacement and then reapply it after the surrounding file has
diverged get weaker source anchors or outright rejections for cases that
could be reviewed safely.

This PR addresses that by preserving the original replacement run as unit
metadata, carrying it through ownership transforms and source refresh,
then using it during merge replay to place equal-size split replacements
inside proven parent boundaries. When the parent boundary is no longer
present, the existing merge candidate machinery exposes reviewed placement
choices.

Line-level discard completes the code path by deriving live file-level
replacement runs and passing the current hunk into the refreshed ownership
update, so batches created through normal discard workflows carry the
context needed by replay.