### PR TITLE
show: Add non-advancing previews

### DIFF
--- a/completions/git-stage-batch
+++ b/completions/git-stage-batch
@@ -88,7 +88,7 @@ _git_stage_batch()
                     return
                     ;;
             esac
-            COMPREPLY=($(compgen -W "--porcelain --from --file --files --line --page --pages --as --as-stdin" -- "$cur"))
+            COMPREPLY=($(compgen -W "--porcelain --no-advance --from --file --files --line --page --pages --as --as-stdin" -- "$cur"))
             ;;
         include)
             case "$prev" in

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -55,6 +55,11 @@ Display the cached "selected" hunk, one file review, or a matched-files list.
 ❯ git-stage-batch show
 ```
 
+**Peek at the next hunk without selecting it:**
+```
+❯ git-stage-batch show --no-advance
+```
+
 **Show all changes from selected hunk's file:**
 ```
 ❯ git-stage-batch show --file
@@ -134,6 +139,7 @@ actions, but not `--line`.
   - Requires `--file`, or `--files` resolving to exactly one changed file
   - Cannot be combined with `--line`, multiple resolved `--files` matches, or `--porcelain`
 - `--porcelain`: Exit silently with status code only (no output)
+- `--no-advance`: Preview without selecting the shown change for later actions. This does not use the session's `start --no-auto-advance` default.
 - `--from BATCH`: Show changes from a batch instead of live file-vs-HEAD changes
 - `--as TEXT`, `--as-stdin`: With `--from BATCH --line IDS`, preview the same replacement batch view used by `include --from BATCH --line IDS --as ...` without mutating anything
 

--- a/man/git-stage-batch-show.1.in
+++ b/man/git-stage-batch-show.1.in
@@ -8,6 +8,7 @@ git-stage-batch-show \- show the selected hunk or a file review
 [\fB\-\-line\fR \fIIDS\fR]
 [\fB\-\-page\fR \fIPAGES\fR]
 [\fB\-\-porcelain\fR]
+[\fB\-\-no\-advance\fR]
 [\fB\-\-as\fR \fITEXT\fR | \fB\-\-as\-stdin\fR]
 .SH DESCRIPTION
 .B show
@@ -53,6 +54,10 @@ or
 .TP
 .B \-\-porcelain
 Exit silently with status code 0 when a hunk exists and 1 when no hunk exists.
+.TP
+.B \-\-no\-advance
+Preview without selecting the shown change for later actions. This option does
+not read the session's automatic-advance preference.
 .TP
 .BI "\-\-as " TEXT
 With

--- a/src/git_stage_batch/cli/argument_parser.py
+++ b/src/git_stage_batch/cli/argument_parser.py
@@ -821,6 +821,19 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
         help=_("Output JSON for scripting instead of human-readable text"),
     )
     parser_show.add_argument(
+        "--no-advance",
+        dest="advance",
+        action="store_false",
+        default=True,
+        help=_("Preview without selecting the shown change for later actions"),
+    )
+    parser_show.add_argument(
+        "--no-auto-advance",
+        dest="advance",
+        action="store_false",
+        help=argparse.SUPPRESS,
+    )
+    parser_show.add_argument(
         "--as",
         dest="as_text",
         metavar="TEXT",
@@ -871,6 +884,8 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
             show_kwargs = {"page": args.page}
             if args.porcelain:
                 show_kwargs["porcelain"] = args.porcelain
+            if not args.advance:
+                show_kwargs["selectable"] = False
             if replacement_text is not None:
                 show_kwargs["replacement_text"] = replacement_text
             if resolved_file_scope.is_multiple:
@@ -898,15 +913,29 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
             if resolved_file_scope.is_multiple:
                 if args.line_ids:
                     raise CommandError(_("Cannot use --lines with multiple files."))
-                commands.command_show_file_list(list(resolved_file_scope.files))
+                show_list_kwargs = {}
+                if not args.advance:
+                    show_list_kwargs["selectable"] = False
+                commands.command_show_file_list(
+                    list(resolved_file_scope.files),
+                    **show_list_kwargs,
+                )
             else:
+                show_kwargs = {
+                    "file": resolved_file_scope.optional_file(),
+                    "page": args.page,
+                    "porcelain": args.porcelain,
+                }
+                if not args.advance:
+                    show_kwargs["selectable"] = False
                 commands.command_show(
-                    file=resolved_file_scope.optional_file(),
-                    page=args.page,
-                    porcelain=args.porcelain,
+                    **show_kwargs,
                 )
             return
-        commands.command_show(porcelain=args.porcelain)
+        show_kwargs = {"porcelain": args.porcelain}
+        if not args.advance:
+            show_kwargs["selectable"] = False
+        commands.command_show(**show_kwargs)
 
     parser_show.set_defaults(func=dispatch_show)
 

--- a/src/git_stage_batch/commands/show.py
+++ b/src/git_stage_batch/commands/show.py
@@ -86,7 +86,7 @@ def _load_previous_selection_for_review():
         return None
 
 
-def command_show_file_list(files: list[str]) -> None:
+def command_show_file_list(files: list[str], *, selectable: bool = True) -> None:
     """Show a navigational file list for multiple live file reviews."""
     require_git_repository()
     require_session_started()
@@ -118,8 +118,9 @@ def command_show_file_list(files: list[str]) -> None:
         print(_("No reviewable changes in matched files."), file=sys.stderr)
         return
 
-    clear_selected_change_state_files()
-    mark_selected_change_cleared_by_file_list(source=ReviewSource.FILE_VS_HEAD.value)
+    if selectable:
+        clear_selected_change_state_files()
+        mark_selected_change_cleared_by_file_list(source=ReviewSource.FILE_VS_HEAD.value)
 
     print_file_review_list(
         source_label=_("Changes: file vs HEAD"),
@@ -263,97 +264,126 @@ def command_show(
                     ),
                 )
             else:
-                print_line_level_changes(file_lines, gutter_to_selection_id={})
+                if page is not None:
+                    review_model = build_file_review_model(file_lines, gutter_to_selection_id={})
+                    shown_pages = resolve_default_review_pages(
+                        review_model,
+                        requested_page_spec=page,
+                        previous_selection=previous_selection,
+                    )
+                    page_spec = normalize_page_spec(shown_pages, len(review_model.pages))
+                    print_file_review(
+                        review_model,
+                        shown_pages=shown_pages,
+                        source_label=_("Changes: file vs HEAD"),
+                        page_spec=page_spec,
+                        source=ReviewSource.FILE_VS_HEAD,
+                    )
+                else:
+                    print_line_level_changes(file_lines, gutter_to_selection_id={})
         return
 
-    # Hunk-scoped operation (selected behavior)
-    # Load blocklist
-    blocklist_path = get_block_list_file_path()
-    blocked_hashes = read_text_file_line_set(blocklist_path)
+    preview_state = snapshot_selected_change_state() if not selectable else None
+    try:
+        # Hunk-scoped operation (selected behavior)
+        # Load blocklist
+        blocklist_path = get_block_list_file_path()
+        blocked_hashes = read_text_file_line_set(blocklist_path)
 
-    # Stream diff and show first unblocked hunk
-    with acquire_unified_diff(
-        stream_live_git_diff(
-            context_lines=get_context_lines(),
-            full_index=True,
-            ignore_submodules="none",
-            submodule_format="short",
-        )
-    ) as patches:
-        for patch in patches:
-            if isinstance(patch, RenameChange):
-                rename_hash = compute_rename_change_hash(patch)
-                if rename_hash not in blocked_hashes:
-                    cache_rename_change(patch)
-                    clear_last_file_review_state()
-                    if not porcelain:
-                        print_rename_change(patch)
-                    return
-                continue
-
-            if isinstance(patch, GitlinkChange):
-                gitlink_hash = compute_gitlink_change_hash(patch)
-                if gitlink_hash not in blocked_hashes:
-                    cache_gitlink_change(patch)
-                    clear_last_file_review_state()
-                    if not porcelain:
-                        print_gitlink_change(patch)
-                    return
-                continue
-
-            if isinstance(patch, BinaryFileChange):
-                binary_hash = compute_binary_file_hash(patch)
-                if binary_hash not in blocked_hashes:
-                    cache_binary_file_change(patch)
-                    clear_last_file_review_state()
-                    if not porcelain:
-                        print_binary_file_change(patch)
-                    return
-                continue
-
-            if patch.old_path != patch.new_path:
-                rename_hash = compute_rename_change_hash(
-                    RenameChange(old_path=patch.old_path, new_path=patch.new_path)
-                )
-                if rename_hash in blocked_hashes:
+        # Stream diff and show first unblocked hunk
+        with acquire_unified_diff(
+            stream_live_git_diff(
+                context_lines=get_context_lines(),
+                full_index=True,
+                ignore_submodules="none",
+                submodule_format="short",
+            )
+        ) as patches:
+            for patch in patches:
+                if isinstance(patch, RenameChange):
+                    rename_hash = compute_rename_change_hash(patch)
+                    if rename_hash not in blocked_hashes:
+                        cache_rename_change(patch)
+                        if selectable:
+                            clear_last_file_review_state()
+                        if not porcelain:
+                            print_rename_change(patch)
+                        return
                     continue
 
-            patch_hash = compute_stable_hunk_hash_from_lines(patch.lines)
-            if patch_hash not in blocked_hashes:
-                with snapshot_selected_change_state() as previous_selected_state:
-                    # Cache selected hunk bytes exactly; display text is derived from parsed lines.
-                    write_selected_hunk_patch_lines(patch.lines)
-                    write_text_file_contents(get_selected_hunk_hash_file_path(), patch_hash)
-                    write_selected_change_kind(SelectedChangeKind.HUNK)
+                if isinstance(patch, GitlinkChange):
+                    gitlink_hash = compute_gitlink_change_hash(patch)
+                    if gitlink_hash not in blocked_hashes:
+                        cache_gitlink_change(patch)
+                        if selectable:
+                            clear_last_file_review_state()
+                        if not porcelain:
+                            print_gitlink_change(patch)
+                        return
+                    continue
 
-                    # Parse and cache line_changes for batch filtering
-                    line_changes = build_line_changes_from_patch_lines(
-                        patch.lines,
-                        annotator=annotate_with_batch_source,
+                if isinstance(patch, BinaryFileChange):
+                    binary_hash = compute_binary_file_hash(patch)
+                    if binary_hash not in blocked_hashes:
+                        cache_binary_file_change(patch)
+                        if selectable:
+                            clear_last_file_review_state()
+                        if not porcelain:
+                            print_binary_file_change(patch)
+                        return
+                    continue
+
+                if patch.old_path != patch.new_path:
+                    rename_hash = compute_rename_change_hash(
+                        RenameChange(old_path=patch.old_path, new_path=patch.new_path)
                     )
-                    write_text_file_contents(get_line_changes_json_file_path(),
-                                            json.dumps(convert_line_changes_to_serializable_dict(line_changes),
-                                                      ensure_ascii=False, indent=0))
-                    write_snapshots_for_selected_file_path(line_changes.path)
-
-                    # Apply line-level batch filtering
-                    if apply_line_level_batch_filter_to_cached_hunk():
-                        # All lines in this hunk are batched, skip to next
-                        restore_selected_change_state(previous_selected_state)
+                    if rename_hash in blocked_hashes:
                         continue
 
-                clear_last_file_review_state()
+                patch_hash = compute_stable_hunk_hash_from_lines(patch.lines)
+                if patch_hash not in blocked_hashes:
+                    with snapshot_selected_change_state() as previous_selected_state:
+                        # Cache selected hunk bytes exactly; display text is derived from parsed lines.
+                        write_selected_hunk_patch_lines(patch.lines)
+                        write_text_file_contents(get_selected_hunk_hash_file_path(), patch_hash)
+                        write_selected_change_kind(SelectedChangeKind.HUNK)
 
-                # Display this unprocessed hunk (unless porcelain mode)
-                if not porcelain:
-                    line_changes = load_line_changes_from_state()
-                    if line_changes is not None:
-                        print_line_level_changes(line_changes)
-                return
+                        # Parse and cache line_changes for batch filtering
+                        line_changes = build_line_changes_from_patch_lines(
+                            patch.lines,
+                            annotator=annotate_with_batch_source,
+                        )
+                        write_text_file_contents(get_line_changes_json_file_path(),
+                                                json.dumps(convert_line_changes_to_serializable_dict(line_changes),
+                                                          ensure_ascii=False, indent=0))
+                        write_snapshots_for_selected_file_path(line_changes.path)
 
-    # Either no changes or all hunks are blocked
-    if porcelain:
-        # Exit with code 1 for scripts
-        sys.exit(1)
-    else:
-        print(_("No more hunks to process."), file=sys.stderr)
+                        # Apply line-level batch filtering
+                        if apply_line_level_batch_filter_to_cached_hunk():
+                            # All lines in this hunk are batched, skip to next
+                            restore_selected_change_state(previous_selected_state)
+                            continue
+
+                    if selectable:
+                        clear_last_file_review_state()
+
+                    # Display this unprocessed hunk (unless porcelain mode)
+                    if not porcelain:
+                        line_changes = load_line_changes_from_state()
+                        if line_changes is not None:
+                            print_line_level_changes(
+                                line_changes,
+                                gutter_to_selection_id=None if selectable else {},
+                            )
+                    return
+
+        # Either no changes or all hunks are blocked
+        if porcelain:
+            # Exit with code 1 for scripts
+            sys.exit(1)
+        else:
+            print(_("No more hunks to process."), file=sys.stderr)
+    finally:
+        if preview_state is not None:
+            restore_selected_change_state(preview_state)
+            preview_state.close()

--- a/tests/cli/test_argument_parser.py
+++ b/tests/cli/test_argument_parser.py
@@ -351,6 +351,19 @@ def test_parse_command_line_alias_help_uses_canonical_command_manpage(monkeypatc
     assert calls == ["stage-batch-include"]
 
 
+def test_show_help_hides_no_auto_advance_alias(monkeypatch, capsys):
+    """The muscle-memory alias should parse without being advertised."""
+    monkeypatch.setattr(argument_parser, "_show_git_stage_batch_help", lambda _topic: False)
+
+    with pytest.raises(SystemExit) as exc_info:
+        parse_command_line(["show", "--help"], quiet=True)
+
+    captured = capsys.readouterr()
+    assert exc_info.value.code == 0
+    assert "--no-advance" in captured.out
+    assert "--no-auto-advance" not in captured.out
+
+
 def test_parse_command_line_invalid_arg():
     """Test parsing invalid argument returns None."""
     parse_command_line(["--invalid-arg"], quiet=True)
@@ -440,6 +453,29 @@ def test_parse_command_line_show():
     assert callable(args.func)
 
 
+def test_parse_command_line_show_no_advance_peeks_without_selecting(monkeypatch):
+    mock_command = Mock()
+    monkeypatch.setattr(argument_parser.commands, "command_show", mock_command)
+
+    args = parse_command_line(["show", "--no-advance"], quiet=True)
+
+    assert args is not None
+    args.func(args)
+    mock_command.assert_called_once_with(porcelain=False, selectable=False)
+
+
+def test_parse_command_line_show_no_auto_advance_is_show_local(monkeypatch):
+    mock_command = Mock()
+    monkeypatch.setattr(argument_parser.commands, "command_show", mock_command)
+
+    args = parse_command_line(["show", "--no-auto-advance"], quiet=True)
+
+    assert args is not None
+    assert args.advance is False
+    args.func(args)
+    mock_command.assert_called_once_with(porcelain=False, selectable=False)
+
+
 def test_show_page_requires_file():
     args = parse_command_line(["show", "--page", "2"], quiet=True)
     assert args is not None
@@ -465,6 +501,49 @@ def test_show_page_accepts_single_files_match(monkeypatch):
     assert args is not None
     args.func(args)
     mock_command.assert_called_once_with(file="src/parser.py", page="2", porcelain=False)
+
+
+def test_show_file_no_advance_peeks_without_selecting(monkeypatch):
+    mock_command = Mock()
+    monkeypatch.setattr(argument_parser.commands, "command_show", mock_command)
+    _mock_live_file_candidates(monkeypatch, ["src/parser.py"])
+
+    args = parse_command_line(["show", "--file", "src/parser.py", "--no-advance"], quiet=True)
+
+    assert args is not None
+    args.func(args)
+    mock_command.assert_called_once_with(
+        file="src/parser.py",
+        page=None,
+        porcelain=False,
+        selectable=False,
+    )
+
+
+def test_show_from_no_advance_peeks_without_selecting(monkeypatch):
+    mock_command = Mock()
+    monkeypatch.setattr(argument_parser.commands, "command_show_from_batch", mock_command)
+    monkeypatch.setattr(argument_parser, "batch_exists", lambda name: True)
+    monkeypatch.setattr(
+        argument_parser,
+        "read_batch_metadata",
+        lambda name: {"files": {"src/parser.py": {}}},
+    )
+
+    args = parse_command_line(
+        ["show", "--from", "batch", "--file", "src/parser.py", "--no-advance"],
+        quiet=True,
+    )
+
+    assert args is not None
+    args.func(args)
+    mock_command.assert_called_once_with(
+        "batch",
+        None,
+        "src/parser.py",
+        page=None,
+        selectable=False,
+    )
 
 
 def test_show_page_accepts_single_file_pattern_match(monkeypatch):

--- a/tests/commands/test_file_review.py
+++ b/tests/commands/test_file_review.py
@@ -249,6 +249,23 @@ def test_non_selectable_live_preview_preserves_partial_review_guard(
         command_include(quiet=True)
 
 
+def test_non_selectable_live_preview_honors_requested_page(
+    paged_file_repo,
+    monkeypatch,
+    capsys,
+):
+    _force_one_change_per_page(monkeypatch)
+
+    command_show(file="file.txt", page="2", selectable=False)
+
+    captured = capsys.readouterr()
+    assert "page 2/3" in captured.out
+    assert "Change 2/3" in captured.out
+    assert "Change 1/3" not in captured.out
+    assert "[#" not in captured.out
+    assert read_last_file_review_state() is None
+
+
 def test_non_selectable_batch_preview_preserves_partial_review_guard(
     paged_file_repo,
     monkeypatch,

--- a/tests/commands/test_show.py
+++ b/tests/commands/test_show.py
@@ -213,6 +213,51 @@ class TestCommandShow:
         cached_hash = get_selected_hunk_hash_file_path().read_text()
         assert cached_hash == expected_hash
 
+    def test_show_no_advance_preserves_previous_selection(self, temp_git_repo, capsys):
+        """A non-selecting hunk preview should restore the prior selection."""
+        file1 = temp_git_repo / "file1.txt"
+        file2 = temp_git_repo / "file2.txt"
+        file1.write_text("one\n")
+        file2.write_text("two\n")
+        subprocess.run(["git", "add", "file1.txt", "file2.txt"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add files"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        file1.write_text("one changed\n")
+        file2.write_text("two changed\n")
+
+        command_start()
+        capsys.readouterr()
+        command_show(file="file2.txt")
+        capsys.readouterr()
+        assert get_selected_change_file_path() == "file2.txt"
+
+        command_show(selectable=False)
+
+        captured = capsys.readouterr()
+        assert "file1.txt" in captured.out
+        assert "[#1]" not in captured.out
+        assert get_selected_change_file_path() == "file2.txt"
+
+        cached = load_line_changes_from_state()
+        assert cached is not None
+        assert cached.path == "file2.txt"
+
+    def test_show_no_advance_leaves_empty_selection_empty(self, temp_git_repo, capsys):
+        """A non-selecting hunk preview should not create a selected change."""
+        readme = temp_git_repo / "README.md"
+        readme.write_text("# Test\nModified\n")
+
+        ensure_state_directory_exists()
+        initialize_abort_state()
+
+        command_show(selectable=False)
+
+        captured = capsys.readouterr()
+        assert "README.md" in captured.out
+        assert "[#1]" not in captured.out
+        assert get_selected_change_file_path() is None
+        assert not get_selected_hunk_patch_file_path().exists()
+
     def test_show_porcelain_with_hunk(self, temp_git_repo, capsys):
         """Test that show --porcelain exits 0 with no output when hunk exists."""
 


### PR DESCRIPTION
The show command can display selected hunks, file reviews, matched-file lists, and batch previews. Those displays also serve as the selected change for later pathless actions.

Users who want to inspect a change without changing session state have no public preview mode. Reusing the action-oriented auto-advance spelling as the advertised form would make the behavior look connected to the session preference.

This pull request addresses that by adding a show-local --no-advance flag, keeping --no-auto-advance as a hidden compatibility alias, and preserving non-selecting hunk and file-review state. It also updates the man page, completion, command reference, and focused coverage.

Verification:
- PYTHONPATH=src uv run pytest tests/commands/test_show.py tests/commands/test_file_review.py tests/cli/test_argument_parser.py
- PYTHONPATH=src uv run ruff check src/git_stage_batch/commands/show.py src/git_stage_batch/cli/argument_parser.py tests/commands/test_show.py tests/commands/test_file_review.py tests/cli/test_argument_parser.py