### PR TITLE
core: Handle metadata-less submodule diffs

### DIFF
--- a/src/git_stage_batch/core/diff_parser.py
+++ b/src/git_stage_batch/core/diff_parser.py
@@ -37,7 +37,7 @@ UnifiedDiffItem = Union[SingleHunkPatch, BinaryFileChange, GitlinkChange, Rename
 
 HUNK_HEADER_PATTERN = re.compile(r"^@@\s+-(\d+)(?:,(\d+))?\s+\+(\d+)(?:,(\d+))?\s+@@")
 INDEX_LINE_PATTERN = re.compile(br"^index ([0-9a-f]+)\.\.([0-9a-f]+)(?: ([0-7]+))?$")
-SUBPROJECT_COMMIT_PATTERN = re.compile(br"^([+-])Subproject commit ([0-9a-f]+)$")
+SUBPROJECT_COMMIT_PATTERN = re.compile(br"^([+-])Subproject commit ([0-9a-f]+)(?:-[^\s]+)?$")
 NULL_OBJECT_PREFIX = "0" * 7
 
 
@@ -466,6 +466,8 @@ class _UnifiedDiffParserBuildContext:
                         hunk_old_oid, hunk_new_oid = _consume_gitlink_hunks(next_line, peek_line)
                         old_oid = hunk_old_oid or _non_null_git_oid(index_old_oid)
                         new_oid = hunk_new_oid or _non_null_git_oid(index_new_oid)
+                        if old_oid is not None and old_oid == new_oid:
+                            continue
                         yield GitlinkChange(
                             old_path=_gitlink_old_path(old_path, old_oid or index_old_oid),
                             new_path=_gitlink_new_path(new_path, new_oid or index_new_oid),
@@ -509,6 +511,8 @@ class _UnifiedDiffParserBuildContext:
                             )
                         if subproject_oids is not None:
                             old_oid, new_oid = subproject_oids
+                            if old_oid is not None and old_oid == new_oid:
+                                continue
                             yield GitlinkChange(
                                 old_path=_gitlink_old_path(old_path, old_oid),
                                 new_path=_gitlink_new_path(new_path, new_oid),

--- a/src/git_stage_batch/core/diff_parser.py
+++ b/src/git_stage_batch/core/diff_parser.py
@@ -37,7 +37,7 @@ UnifiedDiffItem = Union[SingleHunkPatch, BinaryFileChange, GitlinkChange, Rename
 
 HUNK_HEADER_PATTERN = re.compile(r"^@@\s+-(\d+)(?:,(\d+))?\s+\+(\d+)(?:,(\d+))?\s+@@")
 INDEX_LINE_PATTERN = re.compile(br"^index ([0-9a-f]+)\.\.([0-9a-f]+)(?: ([0-7]+))?$")
-SUBPROJECT_COMMIT_PATTERN = re.compile(br"^[+-]Subproject commit ([0-9a-f]+)")
+SUBPROJECT_COMMIT_PATTERN = re.compile(br"^([+-])Subproject commit ([0-9a-f]+)$")
 NULL_OBJECT_PREFIX = "0" * 7
 
 
@@ -131,15 +131,45 @@ def _consume_gitlink_hunks(
             break
 
         next_line()
-        if next_l_stripped.startswith(b"-Subproject commit "):
-            match = SUBPROJECT_COMMIT_PATTERN.match(next_l_stripped)
-            if match is not None:
-                old_oid = match.group(1).decode("ascii")
-        elif next_l_stripped.startswith(b"+Subproject commit "):
-            match = SUBPROJECT_COMMIT_PATTERN.match(next_l_stripped)
-            if match is not None:
-                new_oid = match.group(1).decode("ascii")
+        match = SUBPROJECT_COMMIT_PATTERN.match(next_l_stripped)
+        if match is not None:
+            oid = match.group(2).decode("ascii")
+            if match.group(1) == b"-":
+                old_oid = oid
+            else:
+                new_oid = oid
 
+    return old_oid, new_oid
+
+
+def _gitlink_oids_from_subproject_commit_patch(
+    patch_lines: Iterable[bytes],
+) -> tuple[str | None, str | None] | None:
+    """Return gitlink oids when a patch only changes Subproject commit lines."""
+    old_oid = None
+    new_oid = None
+    changed_line_count = 0
+
+    for line in patch_lines:
+        stripped = line.rstrip(b"\n")
+        if stripped.startswith((b"--- ", b"+++ ", b"@@ ", b"\\ ")):
+            continue
+        if not stripped or stripped[0:1] not in (b"+", b"-"):
+            continue
+
+        changed_line_count += 1
+        match = SUBPROJECT_COMMIT_PATTERN.match(stripped)
+        if match is None:
+            return None
+
+        oid = match.group(2).decode("ascii")
+        if match.group(1) == b"-":
+            old_oid = oid
+        else:
+            new_oid = oid
+
+    if changed_line_count == 0:
+        return None
     return old_oid, new_oid
 
 
@@ -466,15 +496,37 @@ class _UnifiedDiffParserBuildContext:
                         # Consume the hunk header
                         next_line()
 
+                        patch_lines: Iterable[bytes] = hunk_line_chunks(
+                            old_file_line,
+                            new_file_line,
+                            hunk_header_stripped,
+                        )
+                        subproject_oids = None
+                        if not is_gitlink and not metadata_lines:
+                            patch_lines = list(patch_lines)
+                            subproject_oids = _gitlink_oids_from_subproject_commit_patch(
+                                patch_lines
+                            )
+                        if subproject_oids is not None:
+                            old_oid, new_oid = subproject_oids
+                            yield GitlinkChange(
+                                old_path=_gitlink_old_path(old_path, old_oid),
+                                new_path=_gitlink_new_path(new_path, new_oid),
+                                old_oid=old_oid,
+                                new_oid=new_oid,
+                                change_type=_gitlink_change_type(
+                                    metadata_lines,
+                                    old_oid,
+                                    new_oid,
+                                ),
+                            )
+                            continue
+
                         # Yield this hunk immediately
                         yield self._build_single_hunk_patch(
                             old_path=old_path,
                             new_path=new_path,
-                            lines=hunk_line_chunks(
-                                old_file_line,
-                                new_file_line,
-                                hunk_header_stripped,
-                            ),
+                            lines=patch_lines,
                         )
 
                     # If we got --- and +++ but no hunks, check if it's an empty new file

--- a/tests/commands/test_submodule_pointers.py
+++ b/tests/commands/test_submodule_pointers.py
@@ -126,6 +126,38 @@ def untracked_submodule_pointer_repo(tmp_path: Path, monkeypatch: pytest.MonkeyP
 
 
 @pytest.fixture
+def dirty_only_submodule_with_file_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Create a superproject with a file edit and a dirty submodule worktree."""
+    repo = tmp_path / "repo"
+    submodule = repo / "sub"
+    repo.mkdir()
+
+    _run(["git", "init"], cwd=repo)
+    _configure_identity(repo)
+
+    (repo / "README.md").write_text("base\n")
+    _run(["git", "add", "README.md"], cwd=repo)
+    _run(["git", "commit", "-m", "Add readme"], cwd=repo)
+
+    submodule.mkdir()
+    _run(["git", "init"], cwd=submodule)
+    _configure_identity(submodule)
+    (submodule / "file.txt").write_text("sub\n")
+    _run(["git", "add", "file.txt"], cwd=submodule)
+    _run(["git", "commit", "-m", "Add sub file"], cwd=submodule)
+    sub_oid = _git_stdout(["rev-parse", "HEAD"], cwd=submodule)
+
+    _run(["git", "update-index", "--add", "--cacheinfo", "160000", sub_oid, "sub"], cwd=repo)
+    _run(["git", "commit", "-m", "Add submodule pointer"], cwd=repo)
+
+    (repo / "README.md").write_text("base\nchange\n")
+    (submodule / "dirty.txt").write_text("dirty\n")
+    monkeypatch.chdir(repo)
+
+    return repo
+
+
+@pytest.fixture
 def deleted_submodule_pointer_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, str]:
     """Create a superproject with a deleted submodule pointer."""
     repo = tmp_path / "repo"
@@ -201,6 +233,23 @@ def test_start_auto_adds_untracked_submodule_pointer(
     assert get_selected_change_file_path() == "sub"
     assert _git_stdout(["ls-files", "--stage", "--", "sub"], cwd=repo) == (
         f"160000 {EMPTY_BLOB_HASH} 0\tsub"
+    )
+
+
+def test_include_file_auto_advance_ignores_dirty_only_submodule(
+    dirty_only_submodule_with_file_repo: Path,
+) -> None:
+    """File include should not crash when the next diff is a dirty submodule."""
+    repo = dirty_only_submodule_with_file_repo
+
+    command_start(quiet=True)
+    command_include_file("README.md", quiet=True)
+
+    assert "+change" in _git_stdout(["diff", "--cached", "--", "README.md"], cwd=repo)
+    assert read_selected_change_kind() is None
+    assert "Subproject commit" in _git_stdout(
+        ["diff", "--ignore-submodules=none", "--submodule=short", "--", "sub"],
+        cwd=repo,
     )
 
 

--- a/tests/core/test_diff_parser_edge_cases.py
+++ b/tests/core/test_diff_parser_edge_cases.py
@@ -351,6 +351,29 @@ index abc1234..def5678 100644
         assert patches[0].change_type == "modified"
         assert isinstance(patches[1], SingleHunkPatch)
 
+    def test_metadata_less_gitlink_pointer_change_is_atomic(self):
+        """Subproject commit hunks without metadata still avoid line snapshots."""
+        old_oid = b"1111111111111111111111111111111111111111"
+        new_oid = b"2222222222222222222222222222222222222222"
+        diff = b"""\
+diff --git a/sub b/sub
+--- a/sub
++++ b/sub
+@@ -1 +1 @@
+-Subproject commit """ + old_oid + b"""
++Subproject commit """ + new_oid + b"""
+"""
+
+        patches = list(collect_unified_diff(diff.splitlines(keepends=True)))
+
+        assert len(patches) == 1
+        assert isinstance(patches[0], GitlinkChange)
+        assert patches[0].old_path == "sub"
+        assert patches[0].new_path == "sub"
+        assert patches[0].old_oid == old_oid.decode("ascii")
+        assert patches[0].new_oid == new_oid.decode("ascii")
+        assert patches[0].change_type == "modified"
+
 
 class TestRenamedFiles:
     """Test parsing diffs with renamed files."""

--- a/tests/core/test_diff_parser_edge_cases.py
+++ b/tests/core/test_diff_parser_edge_cases.py
@@ -351,6 +351,31 @@ index abc1234..def5678 100644
         assert patches[0].change_type == "modified"
         assert isinstance(patches[1], SingleHunkPatch)
 
+    def test_dirty_only_gitlink_without_metadata_is_skipped(self):
+        """Dirty-only submodule worktrees are not stageable pointer changes."""
+        oid = b"1111111111111111111111111111111111111111"
+        diff = b"""\
+diff --git a/sub b/sub
+--- a/sub
++++ b/sub
+@@ -1 +1 @@
+-Subproject commit """ + oid + b"""
++Subproject commit """ + oid + b"""-dirty
+diff --git a/text.txt b/text.txt
+index abc1234..def5678 100644
+--- a/text.txt
++++ b/text.txt
+@@ -1 +1,2 @@
+ line
++next
+"""
+
+        patches = list(collect_unified_diff(diff.splitlines(keepends=True)))
+
+        assert len(patches) == 1
+        assert isinstance(patches[0], SingleHunkPatch)
+        assert patches[0].new_path == "text.txt"
+
     def test_metadata_less_gitlink_pointer_change_is_atomic(self):
         """Subproject commit hunks without metadata still avoid line snapshots."""
         old_oid = b"1111111111111111111111111111111111111111"


### PR DESCRIPTION
The diff parser recognizes submodule pointer changes when gitlink metadata
marks a path as mode 160000, and the command tests cover the existing
submodule pointer workflows.

Some git diff output reports submodule pointer changes as metadata-less
Subproject commit hunks. Git can also append dirty status to that line when
the submodule worktree has local changes but the recorded object id is
unchanged, which can leave users with a selection that cannot update the
superproject index.

This PR parses metadata-less Subproject commit hunks as atomic submodule
pointer changes, filters dirty-only unchanged submodule diffs, and covers the
parser and file-include auto-advance paths.

Validation:

`uv run pytest tests/core/test_diff_parser_edge_cases.py tests/commands/test_submodule_pointers.py`
