### PR TITLE
git: Override whitespace configuration in apply calls

### DIFF
--- a/src/git_stage_batch/utils/git.py
+++ b/src/git_stage_batch/utils/git.py
@@ -485,7 +485,7 @@ def git_apply_to_index(
 ) -> subprocess.CompletedProcess:
     """Apply patch chunks to the index."""
     return run_git_command(
-        ["apply", "--cached"],
+        ["apply", "--cached", "--whitespace=nowarn"],
         stdin_chunks=patch_chunks,
         check=check,
         requires_index_lock=True,
@@ -501,7 +501,7 @@ def git_apply_to_worktree(
     check: bool = True,
 ) -> subprocess.CompletedProcess:
     """Apply patch chunks to the working tree without writing the index."""
-    arguments = ["apply"]
+    arguments = ["apply", "--whitespace=nowarn"]
     if reverse:
         arguments.append("--reverse")
     if unidiff_zero:

--- a/tests/commands/test_include_file.py
+++ b/tests/commands/test_include_file.py
@@ -119,6 +119,41 @@ class TestCommandIncludeFile:
         )
         assert "file2.txt" in result.stdout
 
+    def test_include_file_preserves_trailing_whitespace_with_apply_fix_config(
+        self,
+        temp_git_repo,
+        capsys,
+    ):
+        """File include should not inherit a whitespace-fixing git apply config."""
+        fixture = temp_git_repo / "fixture.patch"
+        fixture.write_bytes(b"base\n")
+        subprocess.run(["git", "add", "fixture.patch"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Add fixture"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "config", "apply.whitespace", "fix"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        expected = b"line with space \n-- \nno newline"
+        fixture.write_bytes(expected)
+
+        command_start()
+        command_include_file(file="fixture.patch")
+
+        staged = subprocess.run(
+            ["git", "show", ":fixture.patch"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        ).stdout
+        assert staged == expected
+
     def test_include_file_refreshes_untracked_path_after_external_unstage(
         self,
         temp_git_repo,


### PR DESCRIPTION
The git_apply_to_index() and git_apply_to_worktree() helpers pass patch
content to git-apply without specifying a whitespace handling policy.
They rely on the user's default git configuration.

Git's apply command respects the user's apply.whitespace configuration
setting. When that setting is set to fix, git-apply silently strips
trailing whitespace from patch content before writing the result.
Because git-stage-batch relies on git-apply to transfer hunks between
the index and working tree, a whitespace-fixing configuration causes the
staged result to diverge from the working-tree file. Trailing whitespace
the user intentionally wrote gets dropped without notice during staging.

This PR adds --whitespace=nowarn to both apply helpers so that patch
content is transferred exactly as provided, and adds a test that verifies
trailing whitespace survives the staging round-trip even when
apply.whitespace is set to fix.

Validation:

`uv run pytest tests/commands/test_include_file.py -k whitespace`