### PR TITLE
include: Reject partial removed replacement selections

### DIFF
--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -1115,17 +1115,17 @@ def _build_leading_replacement_addition_selection_error(
     line_changes,
     selected_ids: set[int],
 ) -> str | None:
-    """Reject include selections that would keep the removed line with the first insertion."""
+    """Reject include selections that split an inserted replacement prefix."""
     changed_run: list = []
 
     def check_run(run: list) -> str | None:
         if not run:
             return None
-        deletion_ids = {
+        deletion_ids = tuple(
             line.id
             for line in run
             if line.kind == "-" and line.id is not None
-        }
+        )
         addition_ids = tuple(
             line.id
             for line in run
@@ -1134,7 +1134,8 @@ def _build_leading_replacement_addition_selection_error(
         if not deletion_ids or not addition_ids:
             return None
 
-        selected_deletions = selected_ids & deletion_ids
+        deletion_id_set = set(deletion_ids)
+        selected_deletions = selected_ids & deletion_id_set
         selected_addition_positions = [
             index
             for index, line_id in enumerate(addition_ids)
@@ -1151,6 +1152,12 @@ def _build_leading_replacement_addition_selection_error(
                 "later inserted lines, or use --as."
             )
         if selected_deletions:
+            if selected_deletions != deletion_id_set:
+                return _(
+                    "That line selection splits the removed side of a replacement. "
+                    "Select every removed line with inserted lines, select only "
+                    "inserted lines, or use --as."
+                )
             expected_prefix = list(range(selected_addition_positions[-1] + 1))
             if selected_addition_positions != expected_prefix:
                 return _(

--- a/tests/commands/test_file_scoped_operations.py
+++ b/tests/commands/test_file_scoped_operations.py
@@ -1695,6 +1695,61 @@ class TestExplicitFilePath:
         assert staged_names == ""
         assert file_path.read_text() == "keep\nnew value 1\nnew value 2\nnew value 3\n"
 
+    def test_include_line_with_explicit_path_rejects_partial_removed_side_with_addition(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        """Inserted replacement lines should not attach to only the removed tail."""
+        repo = tmp_path / "test_repo"
+        repo.mkdir()
+        monkeypatch.chdir(repo)
+
+        subprocess.run(["git", "init"], check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.name", "Test"], check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.email", "test@test.com"], check=True, capture_output=True)
+
+        file_path = repo / "module.py"
+        file_path.write_text(
+            "def before():\n"
+            "    pass\n"
+            "\n"
+            "\n"
+            "def _bwrap_pairs(command: list[str], option: str) -> list[tuple[str, str]]:\n"
+            "    return [\n"
+            "        (command[index + 1], command[index + 2])\n"
+            "        for index, item in enumerate(command[:-2])\n"
+            "        if item == option\n"
+            "    ]\n"
+            "\n"
+            "\n"
+            "def after():\n"
+            "    pass\n"
+        )
+        subprocess.run(["git", "add", "module.py"], check=True, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Initial"], check=True, capture_output=True)
+
+        file_path.write_text(
+            "def before():\n"
+            "    pass\n"
+            "\n"
+            "\n"
+            "def test_workflow_container_version_follows_target_branch(tmp_path):\n"
+            "    assert version == 'c9s'\n"
+            "    assert version == 'c10s'\n"
+            "\n"
+            "\n"
+            "def after():\n"
+            "    pass\n"
+        )
+        command_start()
+
+        with pytest.raises(CommandError, match="removed side of a replacement"):
+            command_include_line("6-8", file="module.py")
+
+        staged_names = run_git_command(["diff", "--cached", "--name-only"]).stdout
+        assert staged_names == ""
+
     def test_include_line_with_explicit_path_rejects_partial_later_structural_run(self, tmp_path, monkeypatch):
         """Explicit file-scoped include --line should reject a partial later run."""
         repo = tmp_path / "test_repo"


### PR DESCRIPTION
File-scoped include --line validates replacement selections before staging
selected lines into the index.

Users can select inserted replacement lines together with only part of the
removed side. That lets staged replacement content attach to a stale tail of
the original block, producing an index shape that the line model does not
treat as a valid replacement boundary.

This PR addresses that by requiring any selected removal from a replacement
run to include the whole removed side before inserted lines can be staged with
it. The accompanying regression test covers the explicit file-scoped include
path.

The include path now rejects both inserted-prefix splits and removed-side
splits for explicit file-scoped line selections.
