### PR TITLE
Normalize text deletions into staging sessions

### DIFF
--- a/assets/claude-skills/commit-unstaged-changes/SKILL.md
+++ b/assets/claude-skills/commit-unstaged-changes/SKILL.md
@@ -186,8 +186,8 @@ not count as coupling.
 3. If `check-unstaged` fails, stop and tell the user this skill only handles
    **unstaged** changes. Do not commit the staged set, and do not use
    `git-stage-batch` to add more changes on top of it. If it succeeds with a
-   staged-rename notice, continue; `git-stage-batch start` will normalize
-   those start-time renames into workflow content.
+   staged-deletion and/or start-time rename notice, continue; `start`
+   normalizes those file-level states into workflow content.
 4. Check for repository-specific commit guidance before planning messages.
    Read `CONTRIBUTING.md` when present, and inspect `.git/hooks/commit-msg`
    when present, so commit prefixes, body format, trailers, and validation
@@ -503,8 +503,14 @@ flag.
 Use the non-interactive subcommands rather than interactive mode.
 Before starting a `git-stage-batch` session, run
 `git-stage-batch check-unstaged`. Do not start the session if that command
-fails. A passing staged-rename notice is allowed because `start` will present
-those renames as workflow content.
+fails. A passing staged-deletion and/or start-time rename notice is allowed;
+`start` presents those file-level states as workflow content alongside the
+remaining unstaged work.
+
+Treat that allowance narrowly. The staging area is allowed here only as an
+intent channel for file-level states that the workflow cannot otherwise infer
+reliably. Do not pre-stage ordinary additions, modifications, or mixed content
+to steer the split.
 
 ### Start a pass
 
@@ -616,7 +622,8 @@ For each commit:
 
 1. Run `git-stage-batch check-unstaged`.
 2. If it fails, stop and tell the user this skill only handles unstaged
-   changes, except for staged renames that pass this check.
+   changes, except for staged text deletions and start-time renames that pass
+   this check.
 3. Otherwise, if no session is active, run `git-stage-batch start`.
 4. Inspect each selected hunk with `show`. Read the changed lines and
    classify each one by which concern it serves.

--- a/assets/codex-skills/commit-unstaged-changes/SKILL.md
+++ b/assets/codex-skills/commit-unstaged-changes/SKILL.md
@@ -187,8 +187,8 @@ not count as coupling.
 3. If `check-unstaged` fails, stop and tell the user this skill only handles
    **unstaged** changes. Do not commit the staged set, and do not use
    `git-stage-batch` to add more changes on top of it. If it succeeds with a
-   staged-rename notice, continue; `git-stage-batch start` will normalize
-   those start-time renames into workflow content.
+   staged-deletion and/or start-time rename notice, continue; `start`
+   normalizes those file-level states into workflow content.
 4. If a required command fails because `.git` is read-only or a write under
    `.git` is blocked, immediately retry it with escalated permissions. Do not
    keep probing the repository with more read-only commands once the sandbox
@@ -683,8 +683,14 @@ pushing the problem back to the user.
 Use the non-interactive subcommands rather than interactive mode.
 Before starting a `git-stage-batch` session, run
 `git-stage-batch check-unstaged`. Do not start the session if that command
-fails. A passing staged-rename notice is allowed because `start` will present
-those renames as workflow content.
+fails. A passing staged-deletion and/or start-time rename notice is allowed;
+`start` presents those file-level states as workflow content alongside the
+remaining unstaged work.
+
+Treat that allowance narrowly. The staging area is allowed here only as an
+intent channel for file-level states that the workflow cannot otherwise infer
+reliably. Do not pre-stage ordinary additions, modifications, or mixed content
+to steer the split.
 
 ### Start a pass
 
@@ -856,7 +862,8 @@ For each commit:
 
 1. Run `git-stage-batch check-unstaged`.
 2. If it fails, stop and tell the user this skill only handles unstaged
-   changes, except for staged renames that pass this check.
+   changes, except for staged text deletions and start-time renames that pass
+   this check.
 3. Otherwise, if no session is active, run `git-stage-batch start`.
 4. Inspect each selected hunk with `show`. Read the changed lines and
    classify each one by which concern it serves. Record whether each line is
@@ -1333,9 +1340,9 @@ The program has Spanish translation but lacks French.
 
 ## Safety Checks
 
-- Do not commit pre-existing staged changes, except staged renames that pass
-  `git-stage-batch check-unstaged` and are then deliberately staged through the
-  `git-stage-batch` workflow.
+- Do not commit pre-existing staged changes directly. Staged text deletions
+  and start-time renames that pass `git-stage-batch check-unstaged` must be
+  handled through the `git-stage-batch` workflow before they are committed.
 - Do not fold unrelated refactors, cleanup, or drive-by formatting into a
   feature commit just because they are adjacent in the diff.
 - Do not try to simplify the story by broadening the commit. When the rules

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -12,9 +12,10 @@ Check whether the current index is suitable for an unstaged-only workflow.
 ❯ git-stage-batch check-unstaged
 ```
 
-Exits successfully when the index is clean, or when the only staged changes
-are renames that `start` can normalize into workflow content. Exits with code
-2 when other staged changes are present.
+Exits successfully when the index is clean, or when every staged change is a
+start-time file-level intent that `start` can normalize into workflow content:
+regular text deletions and renames. These deletion and rename records may be
+mixed. Exits with code 2 when other staged changes are present.
 
 ---
 
@@ -40,9 +41,16 @@ Resets state if a session is already in progress.
 
 Live session diffs render renames as atomic `old -> new` choices. A selected
 rename can be included, skipped, or discarded with the rest of the workflow.
-At session start, staged renames are temporarily normalized into that same
-live workflow; if a normalized start-time rename is left untouched, `stop` or
-`abort` restores the original staged rename.
+At session start, staged renames and regular text deletions are temporarily
+normalized into that same live workflow; if a normalized start-time change is
+left untouched, `stop` or `abort` restores the original staged change.
+
+Deleted text files are handled in two steps. First, the deleted lines are
+shown as normal line-level changes, so you can include, skip, or discard only
+part of the content deletion. If the staged/index version becomes an empty
+file while the working-tree path is still absent, the path removal is shown as
+a separate text-file deletion change. Including that second change removes the
+path from the index; discarding it restores the empty file.
 
 ---
 

--- a/src/git_stage_batch/cli/argument_parser.py
+++ b/src/git_stage_batch/cli/argument_parser.py
@@ -26,7 +26,11 @@ from ..data.undo import undo_checkpoint
 from ..exceptions import CommandError
 from ..i18n import _, ngettext
 from ..utils.command import run_command
-from ..utils.file_patterns import list_changed_files, resolve_gitignore_style_patterns
+from ..utils.file_patterns import (
+    list_changed_files,
+    list_staged_files,
+    resolve_gitignore_style_patterns,
+)
 from ..utils.git import run_git_command
 from .completion import command_complete_files
 
@@ -570,13 +574,18 @@ def _discard_to_batch_each_resolved_file(
 def _resolve_live_file_scope(
     file_arg: FileArgument,
     file_patterns: list[str] | None,
+    *,
+    include_staged: bool = False,
 ) -> FileScope:
     """Resolve single-file or pattern-based live file scope."""
     resolved_patterns = _resolve_file_patterns(file_arg, file_patterns)
     if resolved_patterns is None:
         return FileScope.implicit() if file_arg is None else FileScope.explicit("")
 
-    candidate_files = list(dict.fromkeys([*list_changed_files(), *list_untracked_files()]))
+    candidate_files = [*list_changed_files(), *list_untracked_files()]
+    if include_staged:
+        candidate_files.extend(list_staged_files())
+    candidate_files = list(dict.fromkeys(candidate_files))
     resolved_files, display_patterns = _resolve_file_argument_patterns(
         candidate_files,
         file_arg,
@@ -1061,7 +1070,11 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
                 and args.from_batch is None
                 and args.to_batch is None
             ):
-                resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
+                resolved_live_scope = _resolve_live_file_scope(
+                    args.file,
+                    args.file_patterns,
+                    include_staged=True,
+                )
                 if resolved_live_scope.is_implicit:
                     raise CommandError(
                         _("`include --as` requires `--file` or `--line` and does not support `--to`.")

--- a/src/git_stage_batch/commands/check_unstaged.py
+++ b/src/git_stage_batch/commands/check_unstaged.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import sys
 
-from ..data.staged_renames import list_staged_change_records, staged_changes_are_only_normalizable_renames
+from ..data.staged_renames import (
+    list_staged_change_records,
+    staged_changes_are_only_normalizable_start_time_changes,
+)
 from ..exceptions import CommandError
 from ..i18n import _, ngettext
 from ..utils.git import require_git_repository
@@ -19,21 +22,55 @@ def command_check_unstaged() -> None:
         print(_("Index is clean for an unstaged-only workflow."), file=sys.stderr)
         return
 
-    if staged_changes_are_only_normalizable_renames():
-        rename_count = len(staged_records)
+    if staged_changes_are_only_normalizable_start_time_changes():
+        deletion_count = sum(
+            1
+            for record in staged_records
+            if record.status == "D" and len(record.paths) == 1
+        )
+        rename_count = len(staged_records) - deletion_count
+        if deletion_count and rename_count:
+            deletion_text = ngettext(
+                "{count} staged deletion",
+                "{count} staged deletions",
+                deletion_count,
+            ).format(count=deletion_count)
+            rename_text = ngettext(
+                "{count} staged rename",
+                "{count} staged renames",
+                rename_count,
+            ).format(count=rename_count)
+            print(
+                _(
+                    "Index contains {deletions} and {renames} that start "
+                    "will treat as workflow content."
+                ).format(deletions=deletion_text, renames=rename_text),
+                file=sys.stderr,
+            )
+            return
+        if rename_count:
+            print(
+                ngettext(
+                    "Index contains {count} staged rename that start will treat as workflow content.",
+                    "Index contains {count} staged renames that start will treat as workflow content.",
+                    rename_count,
+                ).format(count=rename_count),
+                file=sys.stderr,
+            )
+            return
         print(
             ngettext(
-                "Index contains {count} staged rename that start will treat as workflow content.",
-                "Index contains {count} staged renames that start will treat as workflow content.",
-                rename_count,
-            ).format(count=rename_count),
+                "Index contains {count} staged deletion that start will treat as workflow content.",
+                "Index contains {count} staged deletions that start will treat as workflow content.",
+                deletion_count,
+            ).format(count=deletion_count),
             file=sys.stderr,
         )
         return
 
     raise CommandError(
         _(
-            "Index contains staged changes outside start-time renames. "
+            "Index contains staged changes outside start-time renames or deletions. "
             "Commit, stash, or unstage them before using the unstaged-only workflow."
         ),
         exit_code=2,

--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -48,9 +48,10 @@ from ..core.hashing import (
     compute_gitlink_change_hash,
     compute_rename_change_hash,
     compute_stable_hunk_hash_from_lines,
+    compute_text_file_deletion_hash,
 )
 from ..core.line_selection import parse_line_selection
-from ..core.models import BinaryFileChange, GitlinkChange, RenameChange
+from ..core.models import BinaryFileChange, GitlinkChange, RenameChange, TextFileDeletionChange
 from ..core.text_lifecycle import TextFileChangeType, detect_empty_text_lifecycle_change
 from ..data.hunk_tracking import (
     SelectedChangeKind,
@@ -69,6 +70,7 @@ from ..data.hunk_tracking import (
     render_binary_file_change,
     render_gitlink_change,
     render_rename_change,
+    render_text_deletion_change,
     require_selected_hunk,
     restore_selected_change_state,
     snapshot_selected_change_state,
@@ -231,6 +233,25 @@ def _discard_rename_change(rename_change: RenameChange) -> None:
         )
 
 
+def _discard_text_deletion_change(deletion_change: TextFileDeletionChange) -> None:
+    """Restore a whole-text-file path deletion from the current index."""
+    file_path = deletion_change.path()
+    snapshot_file_if_untracked(file_path)
+
+    restore_result = run_git_command(
+        ["checkout", "--", file_path],
+        check=False,
+        requires_index_lock=True,
+    )
+    if restore_result.returncode != 0:
+        exit_with_error(
+            _("Failed to restore deleted file {file}: {error}").format(
+                file=file_path,
+                error=restore_result.stderr,
+            )
+        )
+
+
 @dataclass(frozen=True)
 class _CollectedTextFileDiscards:
     inputs_by_file: dict[str, _TextFileDiscardInput]
@@ -267,10 +288,10 @@ def _buffer_ends_with_lf(buffer: EditorBuffer) -> bool:
     return bool(last_chunk) and last_chunk.endswith(b"\n")
 
 
-def _path_contains_only_whitespace(path: Path) -> bool:
+def _path_is_empty(path: Path) -> bool:
     with path.open("rb") as file_handle:
         while chunk := file_handle.read(1024 * 1024):
-            if chunk.strip():
+            if chunk:
                 return False
     return True
 
@@ -352,6 +373,20 @@ def command_discard(
                     ),
                     file=sys.stderr,
                 )
+
+            finish_selected_change_action(
+                quiet=quiet,
+                auto_advance=auto_advance,
+            )
+            return
+
+        if isinstance(item, TextFileDeletionChange):
+            _discard_text_deletion_change(item)
+            append_lines_to_file(get_block_list_file_path(), [patch_hash])
+            record_hunk_discarded(patch_hash)
+
+            if not quiet:
+                print(_("✓ Text file deletion discarded: {file}").format(file=item.path()), file=sys.stderr)
 
             finish_selected_change_action(
                 quiet=quiet,
@@ -459,7 +494,7 @@ def command_discard(
         if is_new_file:
             absolute_path = get_git_repository_root_path() / filename
             if absolute_path.exists():
-                if _path_contains_only_whitespace(absolute_path):
+                if _path_is_empty(absolute_path):
                     absolute_path.unlink()
 
         # Add hash to blocklist
@@ -573,6 +608,20 @@ def command_discard_file(
         blocklist_path = get_block_list_file_path()
         blocked_hashes = read_text_file_line_set(blocklist_path)
 
+        deletion_change = render_text_deletion_change(target_file)
+        if deletion_change is not None:
+            patch_hash = compute_text_file_deletion_hash(deletion_change)
+            _discard_text_deletion_change(deletion_change)
+            if patch_hash not in blocked_hashes:
+                append_lines_to_file(blocklist_path, [patch_hash])
+                record_hunk_discarded(patch_hash)
+            print(
+                _("✓ Text file deletion discarded: {file}").format(file=target_file),
+                file=sys.stderr,
+            )
+            finish_selected_change_action(quiet=False, auto_advance=auto_advance)
+            return
+
         gitlink_change = render_gitlink_change(target_file)
         if gitlink_change is not None:
             patch_hash = compute_gitlink_change_hash(gitlink_change)
@@ -619,6 +668,15 @@ def command_discard_file(
                         continue
 
                     patch_hash = compute_rename_change_hash(patch)
+                    if patch_hash not in blocked_hashes:
+                        hashes_to_block.append(patch_hash)
+                    continue
+
+                if isinstance(patch, TextFileDeletionChange):
+                    if patch.path() != target_file:
+                        continue
+
+                    patch_hash = compute_text_file_deletion_hash(patch)
                     if patch_hash not in blocked_hashes:
                         hashes_to_block.append(patch_hash)
                     continue
@@ -874,6 +932,26 @@ def command_discard_to_batch(
             selected_change = load_selected_change()
             if isinstance(selected_change, BinaryFileChange):
                 saved_hunks = _command_discard_binary_to_batch(
+                    batch_name,
+                    selected_change,
+                    quiet=quiet,
+                    auto_advance=auto_advance,
+                )
+            else:
+                saved_hunks = _command_discard_hunk_to_batch(
+                    batch_name,
+                    file_only=False,
+                    quiet=quiet,
+                    auto_advance=auto_advance,
+                )
+        elif (
+            file is None
+            and line_ids is None
+            and read_selected_change_kind() == SelectedChangeKind.DELETION
+        ):
+            selected_change = load_selected_change()
+            if isinstance(selected_change, TextFileDeletionChange):
+                saved_hunks = _command_discard_text_deletion_to_batch(
                     batch_name,
                     selected_change,
                     quiet=quiet,
@@ -1324,6 +1402,45 @@ def _command_discard_binary_to_batch(
     return 1
 
 
+def _command_discard_text_deletion_to_batch(
+    batch_name: str,
+    deletion_change: TextFileDeletionChange,
+    *,
+    quiet: bool = False,
+    advance: bool = True,
+    auto_advance: bool | None = None,
+) -> int:
+    """Save one whole-text-file deletion to a batch, then restore it locally."""
+    file_path = deletion_change.path()
+    patch_hash = compute_text_file_deletion_hash(deletion_change)
+
+    snapshot_file_if_untracked(file_path)
+    add_file_to_batch(
+        batch_name,
+        file_path,
+        BatchOwnership([], []),
+        _detect_file_mode(file_path),
+        change_type=TextFileChangeType.DELETED.value,
+    )
+    _discard_text_deletion_change(deletion_change)
+
+    append_lines_to_file(get_block_list_file_path(), [patch_hash])
+    record_hunk_discarded(patch_hash)
+
+    if not quiet:
+        print(
+            _("Discarded text file deletion '{file}' to batch '{batch}'").format(
+                file=file_path,
+                batch=batch_name,
+            ),
+            file=sys.stderr,
+        )
+
+    if advance:
+        finish_selected_change_action(quiet=quiet, auto_advance=auto_advance)
+    return 1
+
+
 def _prepare_text_file_discard_to_batch(
     batch_name: str,
     discard_input: _TextFileDiscardInput,
@@ -1387,6 +1504,9 @@ def _collect_text_file_discard_inputs(
     ) as patches:
         for patch in patches:
             if isinstance(patch, RenameChange):
+                continue
+
+            if isinstance(patch, TextFileDeletionChange):
                 continue
 
             if isinstance(patch, GitlinkChange):
@@ -1610,6 +1730,16 @@ def _command_discard_file_to_batch(
     if not batch_exists(batch_name):
         create_batch(batch_name, "Auto-created")
 
+    deletion_change = render_text_deletion_change(file_path)
+    if deletion_change is not None:
+        return _command_discard_text_deletion_to_batch(
+            batch_name,
+            deletion_change,
+            quiet=quiet,
+            advance=advance,
+            auto_advance=auto_advance,
+        )
+
     binary_change = render_binary_file_change(file_path)
     if binary_change is not None:
         return _command_discard_binary_to_batch(
@@ -1643,6 +1773,9 @@ def _command_discard_file_to_batch(
         ) as patches:
             for patch in patches:
                 if isinstance(patch, RenameChange):
+                    continue
+
+                if isinstance(patch, TextFileDeletionChange):
                     continue
 
                 if isinstance(patch, GitlinkChange):
@@ -2020,6 +2153,13 @@ def _command_discard_hunk_to_batch(
             quiet=quiet,
             auto_advance=auto_advance,
         )
+    if isinstance(selected_item, TextFileDeletionChange):
+        return _command_discard_text_deletion_to_batch(
+            batch_name,
+            selected_item,
+            quiet=quiet,
+            auto_advance=auto_advance,
+        )
 
     # Get the file path and hash from currently cached hunk
     patch_hash = read_text_file_contents(get_selected_hunk_hash_file_path()).strip()
@@ -2068,6 +2208,9 @@ def _command_discard_text_hunk_to_batch(
             ) as patches:
                 for patch in patches:
                     if isinstance(patch, RenameChange):
+                        continue
+
+                    if isinstance(patch, TextFileDeletionChange):
                         continue
 
                     if isinstance(patch, GitlinkChange):
@@ -2201,7 +2344,7 @@ def _command_discard_text_hunk_to_batch(
                 git_remove_paths([file_path], cached=True, quiet=True, check=False)
             elif is_new_file:
                 # New file: only remove if it's empty after reverse patches
-                if _path_contains_only_whitespace(absolute_path):
+                if _path_is_empty(absolute_path):
                     absolute_path.unlink()
                     git_remove_paths([file_path], cached=True, quiet=True, check=False)
             # else: file still exists with content (reverted to HEAD state), leave it alone

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -843,6 +843,39 @@ def command_include_file(
     return hunks_staged
 
 
+def _file_has_staged_changes(file_path: str) -> bool:
+    """Return whether the index version of a path differs from HEAD."""
+    result = run_git_command(
+        [
+            "diff",
+            "--cached",
+            "--quiet",
+            "--no-renames",
+            "--",
+            file_path,
+        ],
+        check=False,
+        requires_index_lock=False,
+    )
+    return result.returncode == 1
+
+
+def _file_has_unstaged_changes(file_path: str) -> bool:
+    """Return whether the working tree version of a path differs from the index."""
+    result = run_git_command(
+        [
+            "diff",
+            "--quiet",
+            "--no-renames",
+            "--",
+            file_path,
+        ],
+        check=False,
+        requires_index_lock=False,
+    )
+    return result.returncode == 1
+
+
 def command_include_file_as(
     replacement_text: str | ReplacementPayload,
     file: str | None = None,
@@ -885,9 +918,11 @@ def command_include_file_as(
 
         if preserve_selected_state:
             line_changes = cache_unstaged_file_as_single_hunk(target_file)
-            if line_changes is None:
+            if line_changes is None and not _file_has_staged_changes(target_file):
                 exit_with_error(_("No changes in file '{file}'.").format(file=target_file))
         else:
+            if not _file_has_unstaged_changes(target_file):
+                exit_with_error(_("No changes in file '{file}'.").format(file=target_file))
             line_changes = load_line_changes_from_state()
             if line_changes is None or line_changes.path != target_file:
                 line_changes = cache_unstaged_file_as_single_hunk(target_file)

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -41,6 +41,7 @@ from ..core.hashing import (
     compute_gitlink_change_hash,
     compute_rename_change_hash,
     compute_stable_hunk_hash_from_lines,
+    compute_text_file_deletion_hash,
 )
 from ..core.line_selection import (
     format_line_ids,
@@ -48,8 +49,8 @@ from ..core.line_selection import (
     read_line_ids_file,
     write_line_ids_file,
 )
-from ..core.models import BinaryFileChange, GitlinkChange, RenameChange
-from ..core.text_lifecycle import detect_empty_text_lifecycle_change
+from ..core.models import BinaryFileChange, GitlinkChange, RenameChange, TextFileDeletionChange
+from ..core.text_lifecycle import TextFileChangeType, detect_empty_text_lifecycle_change
 from ..data.hunk_tracking import (
     SelectedChangeKind,
     apply_line_level_batch_filter_to_cached_hunk,
@@ -65,11 +66,13 @@ from ..data.hunk_tracking import (
     record_gitlink_hunk_skipped,
     record_hunk_included,
     record_hunk_skipped,
+    record_text_deletion_hunk_skipped,
     refuse_bare_action_after_auto_advance_disabled,
     refuse_bare_action_after_file_list,
     render_unstaged_file_as_single_hunk,
     render_binary_file_change,
     render_gitlink_change,
+    render_text_deletion_change,
     require_selected_hunk,
     restore_selected_change_state,
     snapshot_selected_change_state,
@@ -93,7 +96,6 @@ from ..data.session import require_session_started, snapshot_file_if_untracked
 from ..data.undo import undo_checkpoint
 from ..editor import (
     EditorBuffer,
-    buffer_byte_count,
     buffer_matches,
     load_git_object_as_buffer,
     load_working_tree_file_as_buffer,
@@ -199,6 +201,22 @@ def _stage_rename_change(rename_change: RenameChange) -> None:
             ),
         ]
     )
+
+
+def _stage_text_deletion_change(deletion_change: TextFileDeletionChange) -> None:
+    """Stage a whole-text-file deletion in the index."""
+    result = git_update_index(
+        file_path=deletion_change.path(),
+        force_remove=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        exit_with_error(
+            _("Failed to stage deletion for {file}: {error}").format(
+                file=deletion_change.path(),
+                error=result.stderr,
+            )
+        )
 
 
 class TransientIncludeFailureReason(Enum):
@@ -465,23 +483,12 @@ def _try_build_index_content_via_transient_batch(
 
 def _stage_live_line_target_buffer(file_path: str, target_buffer: EditorBuffer) -> None:
     """Stage the result of live line-level include."""
-    full_path = get_git_repository_root_path() / file_path
-    if buffer_byte_count(target_buffer) == 0 and not os.path.lexists(full_path):
-        result = git_update_index(
-            file_path=file_path,
-            force_remove=True,
-            check=False,
-        )
-        if result.returncode != 0:
-            exit_with_error(
-                _("Failed to stage deletion for {file}: {error}").format(
-                    file=file_path,
-                    error=result.stderr,
-                )
-            )
-        return
-
     update_index_with_blob_buffer(file_path, target_buffer)
+
+
+def _patch_is_text_file_path_deletion(patch_lines: Sequence[bytes]) -> bool:
+    """Return whether patch lines describe deletion of the file path itself."""
+    return any(line.rstrip(b"\n") == b"+++ /dev/null" for line in patch_lines)
 
 
 def _transient_include_failure_message(
@@ -581,6 +588,22 @@ def command_include(
             )
             return
 
+        if isinstance(item, TextFileDeletionChange):
+            _stage_text_deletion_change(item)
+            record_hunk_included(patch_hash)
+
+            if not quiet:
+                print(
+                    _("✓ Text file deletion staged: {file}").format(file=item.path()),
+                    file=sys.stderr,
+                )
+
+            finish_selected_change_action(
+                quiet=quiet,
+                auto_advance=auto_advance,
+            )
+            return
+
         if isinstance(item, GitlinkChange):
             result = _update_index_for_gitlink_change(item)
             if result.returncode != 0:
@@ -634,12 +657,17 @@ def command_include(
         filename = item.path
 
         with EditorBuffer.from_path(get_selected_hunk_patch_file_path()) as patch_buffer:
-            apply_result = git_apply_to_index(
-                patch_buffer.byte_chunks(),
-                check=False,
-            )
+            if _patch_is_text_file_path_deletion(patch_buffer):
+                with EditorBuffer.from_bytes(b"") as empty_buffer:
+                    update_index_with_blob_buffer(filename, empty_buffer)
+                apply_result = None
+            else:
+                apply_result = git_apply_to_index(
+                    patch_buffer.byte_chunks(),
+                    check=False,
+                )
 
-        if apply_result.returncode != 0:
+        if apply_result is not None and apply_result.returncode != 0:
             print(_("Failed to apply hunk: {error}").format(error=apply_result.stderr), file=sys.stderr)
             return
 
@@ -745,6 +773,15 @@ def command_include_file(
                     staged_rename_pairs.add((patch.old_path, patch.new_path))
                     continue
 
+                if isinstance(patch, TextFileDeletionChange):
+                    if patch.path() != target_file:
+                        continue
+
+                    _stage_text_deletion_change(patch)
+                    record_hunk_included(compute_text_file_deletion_hash(patch))
+                    hunks_staged += 1
+                    continue
+
                 if isinstance(patch, GitlinkChange):
                     if patch.path() == target_file:
                         result = _update_index_for_gitlink_change(patch)
@@ -797,8 +834,13 @@ def command_include_file(
                     hunks_staged += 1
                     continue
 
-                apply_result = git_apply_to_index(patch.lines, check=False)
-                if apply_result.returncode == 0:
+                if _patch_is_text_file_path_deletion(patch.lines):
+                    with EditorBuffer.from_bytes(b"") as empty_buffer:
+                        update_index_with_blob_buffer(target_file, empty_buffer)
+                    apply_result = None
+                else:
+                    apply_result = git_apply_to_index(patch.lines, check=False)
+                if apply_result is None or apply_result.returncode == 0:
                     # Record for progress tracking
                     record_hunk_included(patch_hash)
 
@@ -1663,6 +1705,28 @@ def command_include_to_batch(
         elif (
             file is None
             and line_ids is None
+            and read_selected_change_kind() == SelectedChangeKind.DELETION
+        ):
+            selected_change = load_selected_change()
+            if isinstance(selected_change, TextFileDeletionChange):
+                _command_include_text_deletion_to_batch(
+                    batch_name,
+                    selected_change,
+                    quiet=quiet,
+                    auto_advance=auto_advance,
+                )
+                return
+            else:
+                _command_include_hunk_to_batch(
+                    batch_name,
+                    file_only=False,
+                    quiet=quiet,
+                    auto_advance=auto_advance,
+                )
+                return
+        elif (
+            file is None
+            and line_ids is None
             and read_selected_change_kind() == SelectedChangeKind.BINARY
         ):
             selected_change = load_selected_change()
@@ -1770,6 +1834,39 @@ def _save_empty_text_lifecycle_to_batch(
     return change_type.value
 
 
+def _command_include_text_deletion_to_batch(
+    batch_name: str,
+    deletion_change: TextFileDeletionChange,
+    *,
+    quiet: bool = False,
+    auto_advance: bool | None = None,
+) -> None:
+    """Save one whole-text-file deletion to a batch and mark it processed."""
+    file_path = deletion_change.path()
+    patch_hash = compute_text_file_deletion_hash(deletion_change)
+
+    add_file_to_batch(
+        batch_name,
+        file_path,
+        BatchOwnership([], []),
+        _detect_file_mode(file_path),
+        change_type=TextFileChangeType.DELETED.value,
+    )
+    append_lines_to_file(get_block_list_file_path(), [patch_hash])
+    record_text_deletion_hunk_skipped(deletion_change, patch_hash)
+
+    if not quiet:
+        print(
+            _("Included text file deletion '{file}' to batch '{batch}'").format(
+                file=file_path,
+                batch=batch_name,
+            ),
+            file=sys.stderr,
+        )
+
+    finish_selected_change_action(quiet=quiet, auto_advance=auto_advance)
+
+
 def _command_include_binary_to_batch(
     batch_name: str,
     binary_change: BinaryFileChange,
@@ -1842,6 +1939,16 @@ def _command_include_file_to_batch(
     if not batch_exists(batch_name):
         create_batch(batch_name, "Auto-created")
 
+    deletion_change = render_text_deletion_change(file_path)
+    if deletion_change is not None:
+        _command_include_text_deletion_to_batch(
+            batch_name,
+            deletion_change,
+            quiet=quiet,
+            auto_advance=auto_advance,
+        )
+        return
+
     binary_change = render_binary_file_change(file_path)
     if binary_change is not None:
         _command_include_binary_to_batch(
@@ -1875,7 +1982,7 @@ def _command_include_file_to_batch(
         )
     ) as patches:
         for patch in patches:
-            if isinstance(patch, RenameChange):
+            if isinstance(patch, (RenameChange, TextFileDeletionChange)):
                 continue
             hunk_lines = build_line_changes_from_patch_lines(
                 patch.lines,
@@ -2154,6 +2261,18 @@ def _command_include_hunk_to_batch(
             if isinstance(patch, RenameChange):
                 continue
 
+            if isinstance(patch, TextFileDeletionChange):
+                patch_hash = compute_text_file_deletion_hash(patch)
+                if patch_hash not in blocked_hashes:
+                    _command_include_text_deletion_to_batch(
+                        batch_name,
+                        patch,
+                        quiet=quiet,
+                        auto_advance=auto_advance,
+                    )
+                    return
+                continue
+
             if isinstance(patch, GitlinkChange):
                 patch_hash = compute_gitlink_change_hash(patch)
                 if patch_hash not in blocked_hashes:
@@ -2214,7 +2333,7 @@ def _command_include_hunk_to_batch(
             )
         ) as patches:
             for patch in patches:
-                if isinstance(patch, RenameChange):
+                if isinstance(patch, (RenameChange, TextFileDeletionChange)):
                     continue
 
                 if patch.new_path != file_path:

--- a/src/git_stage_batch/commands/show.py
+++ b/src/git_stage_batch/commands/show.py
@@ -13,8 +13,9 @@ from ..core.hashing import (
     compute_gitlink_change_hash,
     compute_rename_change_hash,
     compute_stable_hunk_hash_from_lines,
+    compute_text_file_deletion_hash,
 )
-from ..core.models import BinaryFileChange, GitlinkChange, RenameChange
+from ..core.models import BinaryFileChange, GitlinkChange, RenameChange, TextFileDeletionChange
 from ..data.hunk_tracking import (
     SelectedChangeKind,
     apply_line_level_batch_filter_to_cached_hunk,
@@ -22,16 +23,19 @@ from ..data.hunk_tracking import (
     cache_file_as_single_hunk,
     cache_gitlink_change,
     cache_rename_change,
+    cache_text_deletion_change,
     clear_selected_change_state_files,
     get_selected_change_file_path,
     mark_selected_change_cleared_by_file_list,
     render_binary_file_change,
     render_gitlink_change,
     render_rename_change,
+    render_text_deletion_change,
     render_file_as_single_hunk,
     restore_selected_change_state,
     snapshot_selected_change_state,
     stream_live_git_diff,
+    text_deletion_change_is_batched,
     write_selected_hunk_patch_lines,
     write_selected_change_kind,
 )
@@ -49,6 +53,7 @@ from ..output import (
     print_gitlink_change,
     print_line_level_changes,
     print_rename_change,
+    print_text_file_deletion_change,
 )
 from ..output.file_review import (
     build_file_review_model,
@@ -62,6 +67,7 @@ from ..output.file_review_list import (
     make_file_review_list_entry,
     make_gitlink_file_review_list_entry,
     make_rename_file_review_list_entry,
+    make_text_deletion_file_review_list_entry,
     print_file_review_list,
 )
 from ..utils.file_io import (
@@ -98,6 +104,10 @@ def command_show_file_list(files: list[str], *, selectable: bool = True) -> None
         line_changes = render_file_as_single_hunk(file_path)
         if line_changes is not None:
             entries.append(make_file_review_list_entry(line_changes))
+            continue
+        deletion_change = render_text_deletion_change(file_path)
+        if deletion_change is not None and not text_deletion_change_is_batched(deletion_change):
+            entries.append(make_text_deletion_file_review_list_entry(deletion_change))
             continue
         binary_change = render_binary_file_change(file_path)
         if binary_change is not None:
@@ -164,17 +174,34 @@ def command_show(
             target_file = file
 
         preview_lines = render_file_as_single_hunk(target_file)
-        binary_change = render_binary_file_change(target_file) if preview_lines is None else None
+        deletion_change = render_text_deletion_change(target_file) if preview_lines is None else None
+        if deletion_change is not None and text_deletion_change_is_batched(deletion_change):
+            deletion_change = None
+        binary_change = (
+            render_binary_file_change(target_file)
+            if preview_lines is None and deletion_change is None else
+            None
+        )
         gitlink_change = (
             render_gitlink_change(target_file)
-            if preview_lines is None and binary_change is None else
+            if preview_lines is None and deletion_change is None and binary_change is None else
             None
         )
         rename_change = (
             render_rename_change(target_file)
-            if preview_lines is None and binary_change is None and gitlink_change is None else
+            if preview_lines is None and deletion_change is None and binary_change is None and gitlink_change is None else
             None
         )
+        if deletion_change is not None:
+            if page is not None:
+                exit_with_error(_("File review pages are only available for text changes."))
+            if selectable:
+                clear_last_file_review_state()
+                cache_text_deletion_change(deletion_change)
+            if porcelain:
+                return
+            print_text_file_deletion_change(deletion_change)
+            return
         if rename_change is not None:
             if page is not None:
                 exit_with_error(_("File review pages are only available for text changes."))
@@ -308,6 +335,17 @@ def command_show(
                             clear_last_file_review_state()
                         if not porcelain:
                             print_rename_change(patch)
+                        return
+                    continue
+
+                if isinstance(patch, TextFileDeletionChange):
+                    deletion_hash = compute_text_file_deletion_hash(patch)
+                    if deletion_hash not in blocked_hashes and not text_deletion_change_is_batched(patch):
+                        cache_text_deletion_change(patch)
+                        if selectable:
+                            clear_last_file_review_state()
+                        if not porcelain:
+                            print_text_file_deletion_change(patch)
                         return
                     continue
 

--- a/src/git_stage_batch/commands/skip.py
+++ b/src/git_stage_batch/commands/skip.py
@@ -12,6 +12,7 @@ from ..core.hashing import (
     compute_gitlink_change_hash,
     compute_rename_change_hash,
     compute_stable_hunk_hash_from_lines,
+    compute_text_file_deletion_hash,
 )
 from ..core.line_selection import (
     parse_line_selection,
@@ -19,7 +20,7 @@ from ..core.line_selection import (
     write_line_ids_file,
 )
 from ..batch.selection import require_line_selection_in_view
-from ..core.models import BinaryFileChange, GitlinkChange, RenameChange
+from ..core.models import BinaryFileChange, GitlinkChange, RenameChange, TextFileDeletionChange
 from ..data.hunk_tracking import (
     SelectedChangeKind,
     fetch_next_change,
@@ -31,6 +32,7 @@ from ..data.hunk_tracking import (
     record_gitlink_hunk_skipped,
     record_hunk_skipped,
     record_rename_hunk_skipped,
+    record_text_deletion_hunk_skipped,
     refuse_bare_action_after_auto_advance_disabled,
     refuse_bare_action_after_file_list,
     require_selected_hunk,
@@ -117,6 +119,20 @@ def command_skip(
                     ),
                     file=sys.stderr,
                 )
+
+            finish_selected_change_action(
+                quiet=quiet,
+                auto_advance=auto_advance,
+            )
+            return
+
+        if isinstance(item, TextFileDeletionChange):
+            blocklist_path = get_block_list_file_path()
+            append_lines_to_file(blocklist_path, [patch_hash])
+            record_text_deletion_hunk_skipped(item, patch_hash)
+
+            if not quiet:
+                print(_("✓ Text file deletion skipped: {file}").format(file=item.path()), file=sys.stderr)
 
             finish_selected_change_action(
                 quiet=quiet,
@@ -252,6 +268,20 @@ def command_skip_file(
                     append_lines_to_file(blocklist_path, [patch_hash])
                     blocked_hashes.add(patch_hash)
                     record_rename_hunk_skipped(patch, patch_hash)
+                    hunks_skipped += 1
+                    continue
+
+                if isinstance(patch, TextFileDeletionChange):
+                    if patch.path() != target_file:
+                        continue
+
+                    patch_hash = compute_text_file_deletion_hash(patch)
+                    if patch_hash in blocked_hashes:
+                        continue
+
+                    append_lines_to_file(blocklist_path, [patch_hash])
+                    blocked_hashes.add(patch_hash)
+                    record_text_deletion_hunk_skipped(patch, patch_hash)
                     hunks_skipped += 1
                     continue
 

--- a/src/git_stage_batch/commands/start.py
+++ b/src/git_stage_batch/commands/start.py
@@ -9,7 +9,7 @@ from ..data.auto_advance import DEFAULT_AUTO_ADVANCE, write_auto_advance_default
 from ..data.hunk_tracking import clear_selected_change_state_files, fetch_next_change, show_selected_change
 from ..data.file_tracking import auto_add_untracked_files
 from ..data.session import initialize_abort_state
-from ..data.staged_renames import normalize_start_time_staged_renames
+from ..data.staged_renames import normalize_start_time_staged_deletions, normalize_start_time_staged_renames
 from ..exceptions import CommandError, NoMoreHunks
 from ..i18n import _
 from ..utils.file_io import write_text_file_contents
@@ -45,11 +45,12 @@ def command_start(
     # Initialize abort state for new session
     initialize_abort_state()
 
-    # Staged renames are already in the index, so a plain worktree-vs-index
-    # pass would otherwise never offer them as workflow choices. Preserve the
-    # exact start state in abort metadata first, then expose rename pairs as
-    # unstaged rename choices for this session.
+    # Staged renames and text deletions are already in the index, so a plain
+    # worktree-vs-index pass would otherwise never offer them as workflow
+    # choices. Preserve the exact start state in abort metadata first, then
+    # expose those staged entries as unstaged choices for this session.
     normalize_start_time_staged_renames()
+    normalize_start_time_staged_deletions()
 
     write_auto_advance_default(
         DEFAULT_AUTO_ADVANCE

--- a/src/git_stage_batch/commands/status.py
+++ b/src/git_stage_batch/commands/status.py
@@ -14,9 +14,10 @@ from ..core.hashing import (
     compute_gitlink_change_hash,
     compute_rename_change_hash,
     compute_stable_hunk_hash_from_lines,
+    compute_text_file_deletion_hash,
 )
 from ..core.diff_parser import acquire_unified_diff
-from ..core.models import BinaryFileChange, GitlinkChange, RenameChange
+from ..core.models import BinaryFileChange, GitlinkChange, RenameChange, TextFileDeletionChange
 from ..data.file_review_state import (
     FileReviewAction,
     ReviewSource,
@@ -33,6 +34,7 @@ from ..data.hunk_tracking import (
     load_selected_binary_file,
     load_selected_gitlink_change,
     load_selected_rename_change,
+    load_selected_text_deletion_change,
     mark_selected_change_cleared_by_stale_batch_selection,
     read_selected_change_kind,
     rename_change_is_stale,
@@ -40,6 +42,8 @@ from ..data.hunk_tracking import (
     selected_batch_binary_file_for_batch,
     snapshots_are_stale,
     stream_live_git_diff,
+    text_deletion_change_is_batched,
+    text_deletion_change_is_stale,
 )
 from ..data.line_state import load_line_changes_from_state
 from ..data.session import get_iteration_count
@@ -127,6 +131,11 @@ def estimate_remaining_hunks() -> int:
                     ):
                         remaining += 1
                     continue
+                elif isinstance(patch, TextFileDeletionChange):
+                    if text_deletion_change_is_batched(patch):
+                        continue
+                    hunk_hash = compute_text_file_deletion_hash(patch)
+                    file_path = patch.path()
                 elif isinstance(patch, GitlinkChange):
                     hunk_hash = compute_gitlink_change_hash(patch)
                     file_path = patch.path()
@@ -165,6 +174,7 @@ def _selected_kind_label(selected_kind: str | None) -> str:
         SelectedChangeKind.FILE.value: _("Current file review:"),
         SelectedChangeKind.BATCH_FILE.value: _("Current batch file review:"),
         SelectedChangeKind.RENAME.value: _("Current rename:"),
+        SelectedChangeKind.DELETION.value: _("Current text file deletion:"),
         SelectedChangeKind.BINARY.value: _("Current binary file:"),
         SelectedChangeKind.BATCH_BINARY.value: _("Current batch binary file:"),
         SelectedChangeKind.GITLINK.value: _("Current submodule pointer:"),
@@ -240,6 +250,20 @@ def _read_selected_change_summary() -> tuple[bool, dict | None]:
             "change_type": "renamed",
             "old_path": rename_change.old_path,
             "new_path": rename_change.new_path,
+        }
+
+    if selected_kind == SelectedChangeKind.DELETION:
+        deletion_change = load_selected_text_deletion_change()
+        if deletion_change is None:
+            return False, None
+        if text_deletion_change_is_stale(deletion_change):
+            return False, None
+        return True, {
+            "kind": selected_kind.value,
+            "file": deletion_change.path(),
+            "line": None,
+            "ids": [],
+            "change_type": "deleted",
         }
 
     if selected_kind in (SelectedChangeKind.GITLINK, SelectedChangeKind.BATCH_GITLINK):

--- a/src/git_stage_batch/commands/stop.py
+++ b/src/git_stage_batch/commands/stop.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sys
 
-from ..data.staged_renames import restore_unstaged_start_time_renames
+from ..data.staged_renames import restore_unstaged_start_time_deletions, restore_unstaged_start_time_renames
 from ..data.session import clear_session_state
 from ..i18n import _
 from ..utils.file_io import read_file_paths_file
@@ -35,6 +35,7 @@ def command_stop() -> None:
             git_reset_paths([file_path], check=False)
 
     restore_unstaged_start_time_renames()
+    restore_unstaged_start_time_deletions()
 
     # Clear all session state (preserves batches and batch-sources)
     clear_session_state()

--- a/src/git_stage_batch/core/diff_parser.py
+++ b/src/git_stage_batch/core/diff_parser.py
@@ -15,6 +15,7 @@ from .models import (
     LineEntry,
     RenameChange,
     SingleHunkPatch,
+    TextFileDeletionChange,
 )
 from ..editor import (
     EditorBuffer,
@@ -32,7 +33,7 @@ from ..utils.paths import get_index_snapshot_file_path, get_working_tree_snapsho
 
 # Type for annotator hooks that enrich LineLevelChange with additional metadata
 LineLevelChangeAnnotator = Callable[[str, LineLevelChange], LineLevelChange]
-UnifiedDiffItem = Union[SingleHunkPatch, BinaryFileChange, GitlinkChange, RenameChange]
+UnifiedDiffItem = Union[SingleHunkPatch, BinaryFileChange, GitlinkChange, RenameChange, TextFileDeletionChange]
 
 
 HUNK_HEADER_PATTERN = re.compile(r"^@@\s+-(\d+)(?:,(\d+))?\s+\+(\d+)(?:,(\d+))?\s+@@")
@@ -62,6 +63,11 @@ def _metadata_indicates_rename(metadata_lines: list[bytes]) -> bool:
     has_rename_from = any(line.startswith(b"rename from ") for line in metadata_lines)
     has_rename_to = any(line.startswith(b"rename to ") for line in metadata_lines)
     return has_rename_from and has_rename_to
+
+
+def _metadata_indicates_deleted_file(metadata_lines: list[bytes]) -> bool:
+    """Return whether diff metadata describes a deleted file."""
+    return any(line.startswith(b"deleted file mode ") for line in metadata_lines)
 
 
 def _gitlink_oids_from_index(metadata_lines: list[bytes]) -> tuple[str | None, str | None]:
@@ -375,6 +381,7 @@ class _UnifiedDiffParserBuildContext:
 
                     is_gitlink = _metadata_indicates_gitlink(metadata_lines)
                     is_rename = _metadata_indicates_rename(metadata_lines)
+                    is_deleted_file = _metadata_indicates_deleted_file(metadata_lines)
                     index_old_oid, index_new_oid = _gitlink_oids_from_index(metadata_lines)
 
                     # Handle files without unified diff hunks
@@ -427,6 +434,10 @@ class _UnifiedDiffParserBuildContext:
                             continue
 
                         if is_rename:
+                            continue
+
+                        if is_deleted_file:
+                            yield TextFileDeletionChange(old_path=old_path)
                             continue
 
                         # Check if this is an empty new file (new file with no content)
@@ -552,6 +563,8 @@ class _UnifiedDiffParserBuildContext:
                                     b"@@ -0,0 +0,0 @@\n",
                                 ],
                             )
+                        elif is_deleted_file:
+                            yield TextFileDeletionChange(old_path=old_path)
         finally:
             close = getattr(line_iter, "close", None)
             if close is not None:

--- a/src/git_stage_batch/core/hashing.py
+++ b/src/git_stage_batch/core/hashing.py
@@ -7,7 +7,7 @@ from collections.abc import Iterable
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from .models import BinaryFileChange, GitlinkChange, RenameChange
+    from .models import BinaryFileChange, GitlinkChange, RenameChange, TextFileDeletionChange
 
 
 def compute_stable_hunk_hash_from_lines(patch_lines: Iterable[bytes]) -> str:
@@ -115,5 +115,15 @@ def compute_rename_change_hash(rename_change: RenameChange) -> str:
         "rename",
         rename_change.old_path,
         rename_change.new_path,
+    ]
+    return hashlib.sha256("\0".join(parts).encode("utf-8")).hexdigest()
+
+
+def compute_text_file_deletion_hash(deletion_change: TextFileDeletionChange) -> str:
+    """Compute a stable identity hash for an atomic text file deletion."""
+    parts = [
+        "text-deletion",
+        deletion_change.old_path,
+        deletion_change.new_path,
     ]
     return hashlib.sha256("\0".join(parts).encode("utf-8")).hexdigest()

--- a/src/git_stage_batch/core/models.py
+++ b/src/git_stage_batch/core/models.py
@@ -84,6 +84,17 @@ class RenameChange:
         return self.new_path
 
 
+@dataclass(frozen=True)
+class TextFileDeletionChange:
+    """Represents an atomic whole-text-file deletion."""
+    old_path: str
+    new_path: str = "/dev/null"
+
+    def path(self) -> str:
+        """Return the repository path that identifies the deleted file."""
+        return self.old_path
+
+
 @dataclass
 class GitlinkChange:
     """Represents a change to a gitlink/submodule pointer.

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -32,6 +32,7 @@ from ..core.hashing import (
     compute_gitlink_change_hash,
     compute_rename_change_hash,
     compute_stable_hunk_hash_from_lines,
+    compute_text_file_deletion_hash,
 )
 from ..core.models import (
     BinaryFileChange,
@@ -42,6 +43,7 @@ from ..core.models import (
     RenameChange,
     RenderedBatchDisplay,
     ReviewActionGroup,
+    TextFileDeletionChange,
 )
 from ..core.text_lifecycle import detect_empty_text_lifecycle_change
 from ..core.diff_parser import (
@@ -65,6 +67,7 @@ from ..output import (
     print_binary_file_change,
     print_gitlink_change,
     print_rename_change,
+    print_text_file_deletion_change,
 )
 from .consumed_selections import read_consumed_file_metadata
 from .auto_advance import resolve_auto_advance
@@ -92,6 +95,7 @@ from ..utils.paths import (
     get_selected_binary_file_json_path,
     get_selected_gitlink_file_json_path,
     get_selected_rename_file_json_path,
+    get_selected_text_deletion_file_json_path,
     get_selected_hunk_hash_file_path,
     get_selected_hunk_patch_file_path,
     get_line_changes_json_file_path,
@@ -112,6 +116,7 @@ class SelectedChangeKind(str, Enum):
     HUNK = "hunk"
     FILE = "file"
     RENAME = "rename"
+    DELETION = "deletion"
     BINARY = "binary"
     GITLINK = "submodule"
     BATCH_FILE = "batch-file"
@@ -188,6 +193,7 @@ def _selected_change_state_paths():
         "kind": get_selected_change_kind_file_path(),
         "line_state": get_line_changes_json_file_path(),
         "rename": get_selected_rename_file_json_path(),
+        "text_deletion": get_selected_text_deletion_file_json_path(),
         "binary": get_selected_binary_file_json_path(),
         "gitlink": get_selected_gitlink_file_json_path(),
         "index_snapshot": get_index_snapshot_file_path(),
@@ -536,6 +542,36 @@ def load_selected_rename_change() -> Optional[RenameChange]:
         return None
 
 
+def _read_selected_text_deletion_data() -> dict | None:
+    """Read cached text deletion selection data, if structurally valid."""
+    deletion_path = get_selected_text_deletion_file_json_path()
+    if not deletion_path.exists():
+        return None
+    try:
+        deletion_data = json.loads(read_text_file_contents(deletion_path))
+    except json.JSONDecodeError:
+        return None
+    return deletion_data if isinstance(deletion_data, dict) else None
+
+
+def load_selected_text_deletion_change() -> Optional[TextFileDeletionChange]:
+    """Load the currently cached text file deletion change."""
+    if read_selected_change_kind() != SelectedChangeKind.DELETION:
+        return None
+
+    deletion_data = _read_selected_text_deletion_data()
+    if deletion_data is None:
+        return None
+
+    try:
+        return TextFileDeletionChange(
+            old_path=deletion_data["old_path"],
+            new_path=deletion_data.get("new_path", "/dev/null"),
+        )
+    except KeyError:
+        return None
+
+
 def compute_batch_binary_fingerprint(
     batch_name: str,
     file_path: str,
@@ -591,6 +627,7 @@ def cache_binary_file_change(
     get_selected_hunk_patch_file_path().unlink(missing_ok=True)
     get_line_changes_json_file_path().unlink(missing_ok=True)
     get_selected_rename_file_json_path().unlink(missing_ok=True)
+    get_selected_text_deletion_file_json_path().unlink(missing_ok=True)
     get_index_snapshot_file_path().unlink(missing_ok=True)
     get_working_tree_snapshot_file_path().unlink(missing_ok=True)
     get_processed_include_ids_file_path().unlink(missing_ok=True)
@@ -635,6 +672,7 @@ def cache_gitlink_change(
     get_line_changes_json_file_path().unlink(missing_ok=True)
     get_selected_rename_file_json_path().unlink(missing_ok=True)
     get_selected_binary_file_json_path().unlink(missing_ok=True)
+    get_selected_text_deletion_file_json_path().unlink(missing_ok=True)
     get_index_snapshot_file_path().unlink(missing_ok=True)
     get_working_tree_snapshot_file_path().unlink(missing_ok=True)
     get_processed_include_ids_file_path().unlink(missing_ok=True)
@@ -660,6 +698,7 @@ def cache_rename_change(rename_change: RenameChange) -> None:
     get_line_changes_json_file_path().unlink(missing_ok=True)
     get_selected_binary_file_json_path().unlink(missing_ok=True)
     get_selected_gitlink_file_json_path().unlink(missing_ok=True)
+    get_selected_text_deletion_file_json_path().unlink(missing_ok=True)
     get_index_snapshot_file_path().unlink(missing_ok=True)
     get_working_tree_snapshot_file_path().unlink(missing_ok=True)
     get_processed_include_ids_file_path().unlink(missing_ok=True)
@@ -673,6 +712,33 @@ def cache_rename_change(rename_change: RenameChange) -> None:
         compute_rename_change_hash(rename_change),
     )
     write_selected_change_kind(SelectedChangeKind.RENAME)
+
+
+def cache_text_deletion_change(deletion_change: TextFileDeletionChange) -> None:
+    """Cache a whole-text-file deletion as the current selected change."""
+    deletion_data = {
+        "old_path": deletion_change.old_path,
+        "new_path": deletion_change.new_path,
+    }
+    get_selected_hunk_patch_file_path().unlink(missing_ok=True)
+    get_line_changes_json_file_path().unlink(missing_ok=True)
+    get_selected_binary_file_json_path().unlink(missing_ok=True)
+    get_selected_gitlink_file_json_path().unlink(missing_ok=True)
+    get_selected_rename_file_json_path().unlink(missing_ok=True)
+    get_index_snapshot_file_path().unlink(missing_ok=True)
+    get_working_tree_snapshot_file_path().unlink(missing_ok=True)
+    get_processed_include_ids_file_path().unlink(missing_ok=True)
+    get_processed_skip_ids_file_path().unlink(missing_ok=True)
+    write_text_file_contents(
+        get_selected_text_deletion_file_json_path(),
+        json.dumps(deletion_data, ensure_ascii=False, indent=0),
+    )
+    write_text_file_contents(
+        get_selected_hunk_hash_file_path(),
+        compute_text_file_deletion_hash(deletion_change),
+    )
+    write_snapshots_for_selected_file_path(deletion_change.path())
+    write_selected_change_kind(SelectedChangeKind.DELETION)
 
 
 def selected_batch_binary_matches_batch(batch_name: str) -> bool:
@@ -897,11 +963,26 @@ def rename_change_is_stale(rename_change: RenameChange) -> bool:
     )
 
 
+def text_deletion_change_is_stale(deletion_change: TextFileDeletionChange) -> bool:
+    """Return whether a cached text deletion selection no longer matches Git state."""
+    if snapshots_are_stale(deletion_change.path()):
+        return True
+    current_change = render_text_deletion_change(deletion_change.path())
+    if current_change is None:
+        return True
+    return (
+        current_change.old_path != deletion_change.old_path
+        or current_change.new_path != deletion_change.new_path
+    )
+
+
 def write_selected_change_kind(kind: SelectedChangeKind) -> None:
     """Persist the kind of selected change cached in session state."""
     get_selected_change_clear_reason_file_path().unlink(missing_ok=True)
     if kind != SelectedChangeKind.RENAME:
         get_selected_rename_file_json_path().unlink(missing_ok=True)
+    if kind != SelectedChangeKind.DELETION:
+        get_selected_text_deletion_file_json_path().unlink(missing_ok=True)
     if kind not in (SelectedChangeKind.BINARY, SelectedChangeKind.BATCH_BINARY):
         get_selected_binary_file_json_path().unlink(missing_ok=True)
     if kind not in (SelectedChangeKind.GITLINK, SelectedChangeKind.BATCH_GITLINK):
@@ -925,7 +1006,7 @@ def read_selected_change_kind() -> Optional[SelectedChangeKind]:
         return None
 
 
-def load_selected_change() -> Optional[Union[LineLevelChange, BinaryFileChange, GitlinkChange, RenameChange]]:
+def load_selected_change() -> Optional[Union[LineLevelChange, BinaryFileChange, GitlinkChange, RenameChange, TextFileDeletionChange]]:
     """Load the currently cached selected change, if any."""
     selected_kind = read_selected_change_kind()
     rename_change = load_selected_rename_change()
@@ -938,6 +1019,17 @@ def load_selected_change() -> Optional[Union[LineLevelChange, BinaryFileChange, 
                 ).format(old=rename_change.old_path, new=rename_change.new_path)
             )
         return rename_change
+
+    deletion_change = load_selected_text_deletion_change()
+    if deletion_change is not None:
+        if selected_kind == SelectedChangeKind.DELETION and text_deletion_change_is_stale(deletion_change):
+            raise CommandError(
+                _(
+                    "Selected text file deletion no longer matches the working tree: {file}.\n"
+                    "Run 'show' again before using a pathless action."
+                ).format(file=deletion_change.path())
+            )
+        return deletion_change
 
     gitlink_change = load_selected_gitlink_change()
     if gitlink_change is not None:
@@ -986,6 +1078,10 @@ def get_selected_change_file_path() -> Optional[str]:
     rename_change = load_selected_rename_change()
     if rename_change is not None:
         return rename_change.path()
+
+    deletion_change = load_selected_text_deletion_change()
+    if deletion_change is not None:
+        return deletion_change.path()
 
     gitlink_change = load_selected_gitlink_change()
     if gitlink_change is not None:
@@ -1059,6 +1155,11 @@ def _empty_text_lifecycle_change_is_batched(file_path: str) -> bool:
         if file_meta is not None and file_meta.get("change_type") == change_type:
             return True
     return False
+
+
+def text_deletion_change_is_batched(deletion_change: TextFileDeletionChange) -> bool:
+    """Return whether a whole-text-file deletion is already represented in a batch."""
+    return _empty_text_lifecycle_change_is_batched(deletion_change.path())
 
 
 def _filter_consumed_replacement_masks(
@@ -1727,6 +1828,25 @@ def render_rename_change(file_path: str) -> Optional[RenameChange]:
     return None
 
 
+def render_text_deletion_change(file_path: str) -> Optional[TextFileDeletionChange]:
+    """Render a whole-text-file deletion for file-scoped display without caching state."""
+    try:
+        with acquire_unified_diff(
+            stream_live_git_diff(
+                full_index=True,
+                ignore_submodules="none",
+                submodule_format="short",
+                paths=[file_path],
+            )
+        ) as patches:
+            for item in patches:
+                if isinstance(item, TextFileDeletionChange):
+                    return item
+    except subprocess.CalledProcessError:
+        return None
+    return None
+
+
 def render_unstaged_file_as_single_hunk(file_path: str) -> Optional[LineLevelChange]:
     """Render the remaining unstaged changes for a file as a single hunk."""
     auto_add_untracked_files([file_path])
@@ -1847,7 +1967,7 @@ def _build_combined_file_line_changes(
     previous_new_end = None
 
     for single_hunk in patches:
-        if isinstance(single_hunk, (BinaryFileChange, GitlinkChange, RenameChange)):
+        if isinstance(single_hunk, (BinaryFileChange, GitlinkChange, RenameChange, TextFileDeletionChange)):
             continue
 
         line_changes = build_line_changes_from_patch_lines(single_hunk.lines)
@@ -1923,7 +2043,7 @@ def _build_combined_file_line_changes(
     )
 
 
-def fetch_next_change() -> Union[LineLevelChange, BinaryFileChange, GitlinkChange, RenameChange]:
+def fetch_next_change() -> Union[LineLevelChange, BinaryFileChange, GitlinkChange, RenameChange, TextFileDeletionChange]:
     """Find the next hunk or binary file that isn't blocked and cache it as selected.
 
     Returns:
@@ -1961,6 +2081,17 @@ def fetch_next_change() -> Union[LineLevelChange, BinaryFileChange, GitlinkChang
                         continue
 
                     cache_rename_change(item)
+                    return item
+
+                if isinstance(item, TextFileDeletionChange):
+                    deletion_hash = compute_text_file_deletion_hash(item)
+                    if deletion_hash in blocked_hashes or text_deletion_change_is_batched(item):
+                        continue
+
+                    if is_path_blocked(item.path(), blocked_files):
+                        continue
+
+                    cache_text_deletion_change(item)
                     return item
 
                 if isinstance(item, GitlinkChange):
@@ -2059,6 +2190,11 @@ def show_selected_change() -> None:
         print_rename_change(rename_change)
         return
 
+    deletion_change = load_selected_text_deletion_change()
+    if deletion_change is not None:
+        print_text_file_deletion_change(deletion_change)
+        return
+
     gitlink_change = load_selected_gitlink_change()
     if gitlink_change is not None:
         print_gitlink_change(gitlink_change)
@@ -2089,6 +2225,11 @@ def advance_to_and_show_next_change() -> None:
     rename_change = load_selected_rename_change()
     if rename_change is not None:
         print_rename_change(rename_change)
+        return
+
+    deletion_change = load_selected_text_deletion_change()
+    if deletion_change is not None:
+        print_text_file_deletion_change(deletion_change)
         return
 
     gitlink_change = load_selected_gitlink_change()
@@ -2290,6 +2431,14 @@ def recalculate_selected_hunk_for_file(
                     print_rename_change(single_hunk)
                     return
 
+                if isinstance(single_hunk, TextFileDeletionChange):
+                    deletion_hash = compute_text_file_deletion_hash(single_hunk)
+                    if deletion_hash in blocked_hashes or text_deletion_change_is_batched(single_hunk):
+                        continue
+                    cache_text_deletion_change(single_hunk)
+                    print_text_file_deletion_change(single_hunk)
+                    return
+
                 if isinstance(single_hunk, GitlinkChange):
                     gitlink_hash = compute_gitlink_change_hash(single_hunk)
                     if gitlink_hash in blocked_hashes:
@@ -2455,6 +2604,22 @@ def record_rename_hunk_skipped(rename_change: RenameChange, hunk_hash: str) -> N
         "type": "rename",
         "old_path": rename_change.old_path,
         "new_path": rename_change.new_path,
+    }
+
+    jsonl_path = get_skipped_hunks_jsonl_file_path()
+    with jsonl_path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(metadata) + "\n")
+
+
+def record_text_deletion_hunk_skipped(deletion_change: TextFileDeletionChange, hunk_hash: str) -> None:
+    """Record that a whole-text-file deletion was skipped with file-level metadata."""
+    metadata = {
+        "hash": hunk_hash,
+        "file": deletion_change.path(),
+        "line": None,
+        "ids": [],
+        "type": "text-deletion",
+        "change_type": "deleted",
     }
 
     jsonl_path = get_skipped_hunks_jsonl_file_path()

--- a/src/git_stage_batch/data/staged_renames.py
+++ b/src/git_stage_batch/data/staged_renames.py
@@ -3,12 +3,23 @@
 from __future__ import annotations
 
 import json
+import os
 from dataclasses import dataclass
 
 from ..utils.file_io import read_text_file_contents, write_text_file_contents
-from ..utils.git import GitIndexEntryUpdate, git_reset_paths, git_update_index_entries, run_git_command
+from ..utils.git import (
+    GitIndexEntryUpdate,
+    get_git_repository_root_path,
+    git_reset_paths,
+    git_update_index_entries,
+    run_git_command,
+)
 from ..utils.journal import log_journal
-from ..utils.paths import get_abort_head_file_path, get_staged_renames_file_path
+from ..utils.paths import (
+    get_abort_head_file_path,
+    get_staged_deletions_file_path,
+    get_staged_renames_file_path,
+)
 
 
 @dataclass(frozen=True)
@@ -27,6 +38,15 @@ class StagedRename:
     new_path: str
     new_mode: str
     new_blob: str
+
+
+@dataclass(frozen=True)
+class StagedDeletion:
+    """A start-time staged text deletion and its original HEAD entry."""
+
+    path: str
+    old_mode: str
+    old_blob: str
 
 
 def _parse_name_status_z(data: bytes) -> list[StagedChangeRecord]:
@@ -90,6 +110,94 @@ def list_normalizable_staged_renames() -> list[StagedRename]:
     return staged_renames
 
 
+def _head_entry_for_path(file_path: str) -> tuple[str, str] | None:
+    result = run_git_command(
+        ["ls-tree", "-z", "HEAD", "--", file_path],
+        check=False,
+        text_output=False,
+        requires_index_lock=False,
+    )
+    if result.returncode != 0:
+        return None
+
+    for record in result.stdout.split(b"\0"):
+        if not record:
+            continue
+        try:
+            metadata, path_bytes = record.split(b"\t", 1)
+        except ValueError:
+            continue
+        if path_bytes.decode("utf-8", errors="surrogateescape") != file_path:
+            continue
+        parts = metadata.split()
+        if len(parts) < 3 or parts[1] != b"blob":
+            continue
+        return (
+            parts[0].decode("ascii", errors="replace"),
+            parts[2].decode("ascii", errors="replace"),
+        )
+    return None
+
+
+def _staged_deletion_is_text(file_path: str) -> bool:
+    result = run_git_command(
+        ["diff", "--cached", "--numstat", "-z", "--", file_path],
+        check=False,
+        text_output=False,
+        requires_index_lock=False,
+    )
+    if result.returncode != 0 or not result.stdout:
+        return False
+
+    record = result.stdout.split(b"\0", 1)[0]
+    parts = record.split(b"\t", 2)
+    return len(parts) == 3 and parts[0] != b"-" and parts[1] != b"-"
+
+
+def list_normalizable_staged_deletions() -> list[StagedDeletion]:
+    """Return start-time staged text deletions that can be normalized."""
+    repo_root = get_git_repository_root_path()
+    staged_deletions: list[StagedDeletion] = []
+    for record in list_staged_change_records():
+        if record.status != "D" or len(record.paths) != 1:
+            continue
+        file_path = record.paths[0]
+        if os.path.lexists(repo_root / file_path):
+            continue
+        if not _staged_deletion_is_text(file_path):
+            continue
+        entry = _head_entry_for_path(file_path)
+        if entry is None:
+            continue
+        old_mode, old_blob = entry
+        if old_mode not in {"100644", "100755"}:
+            continue
+        staged_deletions.append(
+            StagedDeletion(
+                path=file_path,
+                old_mode=old_mode,
+                old_blob=old_blob,
+            )
+        )
+
+    return staged_deletions
+
+
+def staged_changes_are_only_normalizable_start_time_changes() -> bool:
+    """Return whether all staged changes are start-time changes start can normalize."""
+    records = list_staged_change_records()
+    if not records:
+        return False
+    rename_records = [record for record in records if record.status.startswith("R") and len(record.paths) == 2]
+    deletion_records = [record for record in records if record.status == "D" and len(record.paths) == 1]
+    if len(rename_records) + len(deletion_records) != len(records):
+        return False
+    return (
+        len(list_normalizable_staged_renames()) == len(rename_records)
+        and len(list_normalizable_staged_deletions()) == len(deletion_records)
+    )
+
+
 def staged_changes_are_only_normalizable_renames() -> bool:
     """Return whether all staged changes are renames start can normalize."""
     records = list_staged_change_records()
@@ -146,6 +254,21 @@ def _serialize_renames(renames: list[StagedRename]) -> str:
     )
 
 
+def _serialize_deletions(deletions: list[StagedDeletion]) -> str:
+    return json.dumps(
+        [
+            {
+                "path": deletion.path,
+                "old_mode": deletion.old_mode,
+                "old_blob": deletion.old_blob,
+            }
+            for deletion in deletions
+        ],
+        ensure_ascii=False,
+        indent=0,
+    )
+
+
 def read_staged_renames() -> list[StagedRename]:
     """Read start-time staged rename metadata."""
     path = get_staged_renames_file_path()
@@ -180,6 +303,38 @@ def read_staged_renames() -> list[StagedRename]:
     return renames
 
 
+def read_staged_deletions() -> list[StagedDeletion]:
+    """Read start-time staged text deletion metadata."""
+    path = get_staged_deletions_file_path()
+    if not path.exists():
+        return []
+
+    try:
+        data = json.loads(read_text_file_contents(path))
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(data, list):
+        return []
+
+    deletions: list[StagedDeletion] = []
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        file_path = item.get("path")
+        old_mode = item.get("old_mode")
+        old_blob = item.get("old_blob")
+        if not all(isinstance(value, str) for value in (file_path, old_mode, old_blob)):
+            continue
+        deletions.append(
+            StagedDeletion(
+                path=file_path,
+                old_mode=old_mode,
+                old_blob=old_blob,
+            )
+        )
+    return deletions
+
+
 def normalize_start_time_staged_renames() -> list[StagedRename]:
     """Move staged renames into the unstaged workflow for the active session.
 
@@ -211,6 +366,29 @@ def normalize_start_time_staged_renames() -> list[StagedRename]:
     )
     git_reset_paths(list(dict.fromkeys(paths)), check=False)
     return staged_renames
+
+
+def normalize_start_time_staged_deletions() -> list[StagedDeletion]:
+    """Move staged text deletions into the unstaged workflow for the active session."""
+    staged_deletions = list_normalizable_staged_deletions()
+    if not staged_deletions:
+        return []
+
+    write_text_file_contents(get_staged_deletions_file_path(), _serialize_deletions(staged_deletions))
+
+    log_journal(
+        "session_normalizing_staged_deletions",
+        deletions=[
+            {
+                "path": deletion.path,
+                "old_mode": deletion.old_mode,
+                "old_blob": deletion.old_blob,
+            }
+            for deletion in staged_deletions
+        ],
+    )
+    git_reset_paths(list(dict.fromkeys(deletion.path for deletion in staged_deletions)), check=False)
+    return staged_deletions
 
 
 def _paths_have_cached_diff(paths: list[str]) -> bool:
@@ -277,6 +455,42 @@ def restore_unstaged_start_time_renames() -> list[StagedRename]:
                     "new_blob": rename.new_blob,
                 }
                 for rename in restored
+            ],
+        )
+
+    return restored
+
+
+def restore_unstaged_start_time_deletions() -> list[StagedDeletion]:
+    """Restore normalized start-time deletions that were not changed by the user."""
+    deletions = read_staged_deletions()
+    if not deletions:
+        return []
+
+    repo_root = get_git_repository_root_path()
+    restored: list[StagedDeletion] = []
+    updates: list[GitIndexEntryUpdate] = []
+    for deletion in deletions:
+        if os.path.lexists(repo_root / deletion.path):
+            continue
+        if _paths_have_cached_diff([deletion.path]):
+            continue
+        if _head_changed_since_session_start([deletion.path]):
+            continue
+        updates.append(GitIndexEntryUpdate(file_path=deletion.path, force_remove=True))
+        restored.append(deletion)
+
+    if updates:
+        git_update_index_entries(updates)
+        log_journal(
+            "session_restored_unstaged_start_deletions",
+            deletions=[
+                {
+                    "path": deletion.path,
+                    "old_mode": deletion.old_mode,
+                    "old_blob": deletion.old_blob,
+                }
+                for deletion in restored
             ],
         )
 

--- a/src/git_stage_batch/output/__init__.py
+++ b/src/git_stage_batch/output/__init__.py
@@ -7,6 +7,7 @@ from .patch import (
     print_colored_patch,
     print_gitlink_change,
     print_rename_change,
+    print_text_file_deletion_change,
 )
 
 __all__ = [
@@ -19,4 +20,5 @@ __all__ = [
     "print_colored_patch",
     "print_gitlink_change",
     "print_rename_change",
+    "print_text_file_deletion_change",
 ]

--- a/src/git_stage_batch/output/file_review_list.py
+++ b/src/git_stage_batch/output/file_review_list.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import shlex
 from dataclasses import dataclass
 
-from ..core.models import BinaryFileChange, GitlinkChange, LineLevelChange, RenameChange
+from ..core.models import BinaryFileChange, GitlinkChange, LineLevelChange, RenameChange, TextFileDeletionChange
 from ..i18n import _
 from .file_review import build_file_review_model
 
@@ -22,6 +22,7 @@ class FileReviewListEntry:
     page_count: int
     binary_change_type: str | None = None
     gitlink_change_type: str | None = None
+    text_deletion: bool = False
     rename_old_path: str | None = None
     rename_new_path: str | None = None
 
@@ -91,6 +92,19 @@ def make_rename_file_review_list_entry(rename_change: RenameChange) -> FileRevie
     )
 
 
+def make_text_deletion_file_review_list_entry(deletion_change: TextFileDeletionChange) -> FileReviewListEntry:
+    """Build a list entry from a whole-text-file deletion."""
+    return FileReviewListEntry(
+        path=deletion_change.path(),
+        change_count=1,
+        changed_line_count=0,
+        addition_count=0,
+        deletion_count=0,
+        page_count=1,
+        text_deletion=True,
+    )
+
+
 def print_file_review_list(
     *,
     source_label: str,
@@ -119,6 +133,13 @@ def print_file_review_list(
                 f"{index}. {entry.path.ljust(path_width)}  "
                 f"{entry.change_count} {change_word} · "
                 f"submodule pointer {entry.gitlink_change_type} · "
+                f"{entry.page_count} {page_word}"
+            )
+        elif entry.text_deletion:
+            print(
+                f"{index}. {entry.path.ljust(path_width)}  "
+                f"{entry.change_count} {change_word} · "
+                f"text file deleted · "
                 f"{entry.page_count} {page_word}"
             )
         elif entry.rename_old_path is not None and entry.rename_new_path is not None:

--- a/src/git_stage_batch/output/patch.py
+++ b/src/git_stage_batch/output/patch.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 from .colors import Colors
 
 if TYPE_CHECKING:
-    from ..core.models import BinaryFileChange, GitlinkChange, RenameChange
+    from ..core.models import BinaryFileChange, GitlinkChange, RenameChange, TextFileDeletionChange
 
 
 def print_colored_patch(patch_text: str) -> None:
@@ -95,6 +95,17 @@ def print_rename_change(rename_change: RenameChange) -> None:
         f"{bold}{rename_change.new_path}{reset} :: "
         f"{color}Renamed file{reset}"
     )
+
+
+def print_text_file_deletion_change(deletion_change: TextFileDeletionChange) -> None:
+    """Print a whole-text-file deletion as an atomic path change."""
+    use_color = Colors.enabled()
+
+    reset = Colors.RESET if use_color else ""
+    bold = Colors.BOLD if use_color else ""
+    color = Colors.RED if use_color else ""
+
+    print(f"{bold}{deletion_change.path()}{reset} :: {color}Deleted text file{reset}")
 
 
 def _short_oid(oid: str | None) -> str:

--- a/src/git_stage_batch/utils/file_patterns.py
+++ b/src/git_stage_batch/utils/file_patterns.py
@@ -95,23 +95,8 @@ def resolve_gitignore_style_patterns(
     return [candidate for candidate in normalized_candidates if resolved_status.get(candidate, False)]
 
 
-def list_changed_files() -> list[str]:
-    """List repository-relative paths participating in the working-tree diff."""
-    result = run_git_command(
-        [
-            "-c",
-            "diff.ignoreSubmodules=none",
-            "diff",
-            "--ignore-submodules=none",
-            "--find-renames",
-            "--name-status",
-            "-z",
-        ],
-        text_output=False,
-        requires_index_lock=False,
-    )
-
-    fields = result.stdout.split(b"\0")
+def _paths_from_name_status_z(output: bytes) -> list[str]:
+    fields = output.split(b"\0")
     changed_paths: list[str] = []
     index = 0
     while index < len(fields):
@@ -131,3 +116,42 @@ def list_changed_files() -> list[str]:
                 changed_paths.append(_normalize_path(path.decode("utf-8")))
 
     return list(dict.fromkeys(changed_paths))
+
+
+def list_changed_files() -> list[str]:
+    """List repository-relative paths participating in the working-tree diff."""
+    result = run_git_command(
+        [
+            "-c",
+            "diff.ignoreSubmodules=none",
+            "diff",
+            "--ignore-submodules=none",
+            "--find-renames",
+            "--name-status",
+            "-z",
+        ],
+        text_output=False,
+        requires_index_lock=False,
+    )
+
+    return _paths_from_name_status_z(result.stdout)
+
+
+def list_staged_files() -> list[str]:
+    """List repository-relative paths participating in the index diff."""
+    result = run_git_command(
+        [
+            "-c",
+            "diff.ignoreSubmodules=none",
+            "diff",
+            "--cached",
+            "--ignore-submodules=none",
+            "--find-renames",
+            "--name-status",
+            "-z",
+        ],
+        text_output=False,
+        requires_index_lock=False,
+    )
+
+    return _paths_from_name_status_z(result.stdout)

--- a/src/git_stage_batch/utils/git.py
+++ b/src/git_stage_batch/utils/git.py
@@ -111,8 +111,46 @@ def _prepare_git_command_environment(
 ) -> dict[str, str] | None:
     if requires_index_lock:
         wait_for_git_index_lock(cwd=cwd, env=env)
+    return _git_command_environment(requires_index_lock=requires_index_lock, env=env)
+
+
+def _git_command_environment(
+    *,
+    requires_index_lock: bool,
+    env: dict[str, str] | None,
+) -> dict[str, str] | None:
+    if requires_index_lock:
         return env
     return _git_environment_with_optional_locks_disabled(env)
+
+
+def _index_lock_error_text(stream: str | bytes | None) -> str:
+    if stream is None:
+        return ""
+    if isinstance(stream, bytes):
+        return stream.decode("utf-8", errors="replace")
+    return stream
+
+
+def _is_git_index_lock_error(result: subprocess.CompletedProcess) -> bool:
+    stderr_text = _index_lock_error_text(result.stderr).lower()
+    return "index.lock" in stderr_text and (
+        "file exists" in stderr_text
+        or "unable to create" in stderr_text
+    )
+
+
+def _raise_git_command_error(result: subprocess.CompletedProcess) -> None:
+    raise subprocess.CalledProcessError(
+        result.returncode,
+        result.args,
+        output=result.stdout,
+        stderr=result.stderr,
+    )
+
+
+def _remaining_index_lock_wait_seconds(deadline: float) -> float:
+    return max(0.0, deadline - time.monotonic())
 
 
 def stream_git_command(
@@ -308,20 +346,58 @@ def run_git_command(
     Raises:
         subprocess.CalledProcessError: If check=True and command fails
     """
-    return run_command(
-        ["git", *arguments],
-        stdin_chunks,
-        check=check,
-        text_output=text_output,
-        cwd=cwd,
-        env=_prepare_git_command_environment(
-            requires_index_lock=requires_index_lock,
+    command = ["git", *arguments]
+    reusable_stdin_chunks = (
+        list(stdin_chunks)
+        if requires_index_lock and stdin_chunks is not None
+        else stdin_chunks
+    )
+    retry_deadline = (
+        time.monotonic() + _INDEX_LOCK_WAIT_SECONDS
+        if requires_index_lock
+        else None
+    )
+
+    if retry_deadline is not None:
+        wait_for_git_index_lock(
             cwd=cwd,
             env=env,
-        ),
-        capture_stdout=capture_stdout,
-        capture_stderr=capture_stderr,
-    )
+            timeout_seconds=_remaining_index_lock_wait_seconds(retry_deadline),
+        )
+
+    while True:
+        result = run_command(
+            command,
+            reusable_stdin_chunks,
+            check=False,
+            text_output=text_output,
+            cwd=cwd,
+            env=_git_command_environment(
+                requires_index_lock=requires_index_lock,
+                env=env,
+            ),
+            capture_stdout=capture_stdout,
+            capture_stderr=capture_stderr,
+        )
+        if not (
+            retry_deadline is not None
+            and result.returncode != 0
+            and _is_git_index_lock_error(result)
+        ):
+            break
+
+        remaining_seconds = _remaining_index_lock_wait_seconds(retry_deadline)
+        if remaining_seconds <= 0:
+            break
+        wait_for_git_index_lock(
+            cwd=cwd,
+            env=env,
+            timeout_seconds=remaining_seconds,
+        )
+
+    if check and result.returncode != 0:
+        _raise_git_command_error(result)
+    return result
 
 
 @contextmanager

--- a/src/git_stage_batch/utils/paths.py
+++ b/src/git_stage_batch/utils/paths.py
@@ -215,6 +215,11 @@ def get_selected_rename_file_json_path() -> Path:
     return get_selected_state_directory_path() / "rename-file.json"
 
 
+def get_selected_text_deletion_file_json_path() -> Path:
+    """Get the path to the selected text deletion JSON file."""
+    return get_selected_state_directory_path() / "text-deletion-file.json"
+
+
 def get_abort_head_file_path() -> Path:
     """Get the path to the abort HEAD file for session restoration.
 
@@ -254,6 +259,11 @@ def get_abort_snapshot_list_file_path() -> Path:
 def get_staged_renames_file_path() -> Path:
     """Get the path to start-time staged rename metadata."""
     return get_abort_state_directory_path() / "staged-renames.json"
+
+
+def get_staged_deletions_file_path() -> Path:
+    """Get the path to start-time staged text deletion metadata."""
+    return get_abort_state_directory_path() / "staged-deletions.json"
 
 
 def get_session_batch_sources_file_path() -> Path:

--- a/tests/cli/test_argument_parser.py
+++ b/tests/cli/test_argument_parser.py
@@ -25,10 +25,11 @@ class _UnreadableStdin:
     buffer = _Buffer()
 
 
-def _mock_live_file_candidates(monkeypatch, changed, untracked=()):
+def _mock_live_file_candidates(monkeypatch, changed, untracked=(), staged=()):
     """Provide deterministic live file candidates for parser scope resolution."""
     monkeypatch.setattr(argument_parser, "list_changed_files", lambda: list(changed))
     monkeypatch.setattr(argument_parser, "list_untracked_files", lambda: list(untracked))
+    monkeypatch.setattr(argument_parser, "list_staged_files", lambda: list(staged))
 
 
 def test_build_manpath_with_existing_environment(monkeypatch):
@@ -791,6 +792,26 @@ def test_parse_command_line_include_with_file_and_as_stdin_dispatches_file_repla
     args.func(args)
     mock_command.assert_called_once_with(
         "replacement\n",
+        file="path.txt",
+        auto_advance=None,
+    )
+
+
+def test_parse_command_line_include_file_as_can_resolve_staged_file(monkeypatch):
+    """Include --file --as should accept already-staged paths."""
+    mock_command = Mock()
+    monkeypatch.setattr(argument_parser.commands, "command_include_file_as", mock_command)
+    _mock_live_file_candidates(monkeypatch, [], staged=["path.txt"])
+
+    args = parse_command_line(
+        ["include", "--file", "path.txt", "--as", "replacement"],
+        quiet=True,
+    )
+
+    assert args is not None
+    args.func(args)
+    mock_command.assert_called_once_with(
+        "replacement",
         file="path.txt",
         auto_advance=None,
     )

--- a/tests/commands/test_discard.py
+++ b/tests/commands/test_discard.py
@@ -24,6 +24,7 @@ import pytest
 from git_stage_batch.commands.discard import command_discard, command_discard_line, command_discard_line_as_to_batch
 from git_stage_batch.commands.include import command_include
 from git_stage_batch.commands.start import command_start
+from git_stage_batch.core.models import TextFileDeletionChange
 from git_stage_batch.exceptions import CommandError
 
 
@@ -488,6 +489,34 @@ class TestCommandDiscardLine:
         # Try to discard - should fail because file doesn't exist
         with pytest.raises(CommandError):
             command_discard_line("1")
+
+    def test_discard_path_removal_keeps_empty_file_after_deleted_lines_staged(self, temp_git_repo):
+        """Discarding the second deletion prompt should restore the empty index file."""
+        test_file = temp_git_repo / "test.txt"
+        test_file.write_text("content\n")
+        subprocess.run(["git", "add", "test.txt"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add test.txt"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        test_file.unlink()
+
+        command_start(quiet=True)
+        command_include(quiet=True)
+
+        selected_change = load_selected_change()
+        assert isinstance(selected_change, TextFileDeletionChange)
+
+        command_discard(quiet=True)
+
+        assert test_file.exists()
+        assert test_file.read_text() == ""
+        cached = subprocess.run(
+            ["git", "diff", "--cached", "--name-status", "--", "test.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+            text=True,
+        )
+        assert cached.stdout.strip() == "M\ttest.txt"
 
     def test_discard_line_rejects_mixed_valid_and_invalid_ids(self, temp_git_repo):
         """discard --line should reject the selection when any ID is stale."""

--- a/tests/commands/test_file_scoped_operations.py
+++ b/tests/commands/test_file_scoped_operations.py
@@ -1300,6 +1300,27 @@ class TestExplicitFilePath:
         result = run_git_command(["diff", "gamma.txt"])
         assert "gamma2-modified" in result.stdout
 
+    def test_include_file_as_can_replace_already_staged_new_file(self, multi_file_repo):
+        """Full-file replacement should work after a new file is already staged."""
+        (multi_file_repo / "new.txt").write_text("alpha\nbeta\n")
+        command_start()
+
+        command_include_file(file="new.txt")
+        command_include_file_as("replacement\n", file="new.txt")
+
+        staged_content = run_git_command(["show", ":new.txt"]).stdout
+        assert staged_content == "replacement\n"
+        assert (multi_file_repo / "new.txt").read_text() == "alpha\nbeta\n"
+
+    def test_include_file_as_shorthand_requires_unstaged_selected_file(self, multi_file_repo):
+        """Pathless full-file replacement should not target staged-only state."""
+        command_start()
+
+        command_include_file(file="alpha.txt", advance=False)
+
+        with pytest.raises(CommandError, match="No changes in file 'alpha.txt'"):
+            command_include_file_as("replacement\n", file="")
+
     def test_include_file_line_as_with_explicit_path(self, multi_file_repo):
         """Include --file PATH --line IDS --as should preserve selected position."""
         command_start()

--- a/tests/commands/test_include.py
+++ b/tests/commands/test_include.py
@@ -17,6 +17,7 @@ from git_stage_batch.commands.include import (
 )
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.commands.show import command_show
+from git_stage_batch.core.models import TextFileDeletionChange
 from git_stage_batch.data.hunk_tracking import (
     fetch_next_change,
     load_selected_change,
@@ -672,7 +673,7 @@ class TestCommandIncludeLine:
         assert result.stdout == "keep1\nkeep2\n"
 
     def test_include_line_stages_full_file_deletion(self, temp_git_repo):
-        """Full-file deletion selections should remove the path from the index."""
+        """Full-file deletion selections should stage empty content before path removal."""
         test_file = temp_git_repo / "test.txt"
         test_file.write_text("remove1\nremove2\n")
         subprocess.run(["git", "add", "test.txt"], check=True, cwd=temp_git_repo, capture_output=True)
@@ -692,7 +693,16 @@ class TestCommandIncludeLine:
             capture_output=True,
             text=True,
         )
-        assert status.stdout == "D  test.txt\n"
+        assert status.stdout == "MD test.txt\n"
+
+        index_content = subprocess.run(
+            ["git", "show", ":test.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+            text=True,
+        )
+        assert index_content.stdout == ""
 
         index_entry = subprocess.run(
             ["git", "ls-files", "-s", "--", "test.txt"],
@@ -701,7 +711,21 @@ class TestCommandIncludeLine:
             capture_output=True,
             text=True,
         )
-        assert index_entry.stdout == ""
+        assert "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391" in index_entry.stdout
+
+        selected_change = load_selected_change()
+        assert isinstance(selected_change, TextFileDeletionChange)
+
+        command_include(quiet=True)
+
+        final_status = subprocess.run(
+            ["git", "status", "--short", "--", "test.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+            text=True,
+        )
+        assert final_status.stdout == "D  test.txt\n"
 
     def test_include_line_as_replaces_staged_content_and_masks_hunk(self, temp_git_repo):
         """Test include --line --as stages replacement text and hides the line."""

--- a/tests/commands/test_staged_renames.py
+++ b/tests/commands/test_staged_renames.py
@@ -9,10 +9,10 @@ from git_stage_batch.commands.check_unstaged import command_check_unstaged
 from git_stage_batch.commands.include import command_include
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.commands.stop import command_stop
-from git_stage_batch.core.models import RenameChange
+from git_stage_batch.core.models import LineLevelChange, RenameChange, TextFileDeletionChange
 from git_stage_batch.data.hunk_tracking import load_selected_change, show_selected_change
 from git_stage_batch.exceptions import CommandError
-from git_stage_batch.utils.paths import get_staged_renames_file_path
+from git_stage_batch.utils.paths import get_staged_deletions_file_path, get_staged_renames_file_path
 
 
 @pytest.fixture
@@ -36,6 +36,11 @@ def rename_repo(tmp_path, monkeypatch):
 def _stage_rename(repo, *, new_content: str = "line 1\nline 2\n") -> None:
     (repo / "old.txt").rename(repo / "new.txt")
     (repo / "new.txt").write_text(new_content)
+    subprocess.run(["git", "add", "-A"], check=True, cwd=repo, capture_output=True)
+
+
+def _stage_deletion(repo, file_path: str = "old.txt") -> None:
+    (repo / file_path).unlink()
     subprocess.run(["git", "add", "-A"], check=True, cwd=repo, capture_output=True)
 
 
@@ -100,6 +105,38 @@ def test_start_exposes_unstaged_rename_as_rename_selection(rename_repo):
     assert selected_change.new_path == "new.txt"
 
 
+def test_start_exposes_staged_deletion_as_deleted_line_selection(rename_repo):
+    _stage_deletion(rename_repo)
+
+    command_start(quiet=True)
+
+    assert get_staged_deletions_file_path().exists()
+    assert _cached_name_status(rename_repo) == ""
+    assert _uncached_name_status(rename_repo).strip() == "D\told.txt"
+    selected_change = load_selected_change()
+    assert isinstance(selected_change, LineLevelChange)
+    assert selected_change.path == "old.txt"
+    assert {line.kind for line in selected_change.lines if line.id is not None} == {"-"}
+
+
+def test_include_staged_deletion_lines_then_path_removal(rename_repo):
+    _stage_deletion(rename_repo)
+
+    command_start(quiet=True)
+    command_include(quiet=True)
+
+    assert _cached_name_status(rename_repo).strip() == "M\told.txt"
+    assert _index_content(rename_repo, "old.txt") == ""
+    assert _uncached_name_status(rename_repo).strip() == "D\told.txt"
+    selected_change = load_selected_change()
+    assert isinstance(selected_change, TextFileDeletionChange)
+    assert selected_change.path() == "old.txt"
+
+    command_include(quiet=True)
+
+    assert _cached_name_status(rename_repo).strip() == "D\told.txt"
+
+
 def test_include_selected_rename_stages_rename_only_and_leaves_edits_unstaged(rename_repo):
     _rename_without_staging(rename_repo, new_content="line 1\nline 2\nline 3\n")
 
@@ -118,6 +155,15 @@ def test_stop_restores_untouched_start_time_staged_rename(rename_repo):
     command_stop()
 
     assert _cached_name_status(rename_repo).strip() == "R100\told.txt\tnew.txt"
+
+
+def test_stop_restores_untouched_start_time_staged_deletion(rename_repo):
+    _stage_deletion(rename_repo)
+
+    command_start(quiet=True)
+    command_stop()
+
+    assert _cached_name_status(rename_repo).strip() == "D\told.txt"
 
 
 def test_stop_preserves_staged_rename_content_after_workflow_use(rename_repo):
@@ -153,12 +199,34 @@ def test_abort_restores_start_time_staged_rename(rename_repo):
     assert _cached_name_status(rename_repo).strip() == "R100\told.txt\tnew.txt"
 
 
+def test_abort_restores_start_time_staged_deletion(rename_repo):
+    _stage_deletion(rename_repo)
+
+    command_start(quiet=True)
+    command_abort()
+
+    assert _cached_name_status(rename_repo).strip() == "D\told.txt"
+
+
 def test_check_unstaged_allows_clean_index(rename_repo):
     command_check_unstaged()
 
 
 def test_check_unstaged_allows_staged_rename(rename_repo):
     _stage_rename(rename_repo)
+
+    command_check_unstaged()
+
+
+def test_check_unstaged_allows_staged_deletion(rename_repo):
+    _stage_deletion(rename_repo)
+
+    command_check_unstaged()
+
+
+def test_check_unstaged_allows_staged_deletion_mixed_with_rename(rename_repo):
+    _stage_rename(rename_repo)
+    _stage_deletion(rename_repo, "other.txt")
 
     command_check_unstaged()
 

--- a/tests/core/test_diff_parser_edge_cases.py
+++ b/tests/core/test_diff_parser_edge_cases.py
@@ -8,7 +8,13 @@ Tests for handling:
 - Mixed scenarios
 """
 
-from git_stage_batch.core.models import BinaryFileChange, GitlinkChange, RenameChange, SingleHunkPatch
+from git_stage_batch.core.models import (
+    BinaryFileChange,
+    GitlinkChange,
+    RenameChange,
+    SingleHunkPatch,
+    TextFileDeletionChange,
+)
 
 from tests.diff_parser_helpers import collect_unified_diff
 
@@ -36,10 +42,11 @@ index abc1234..def5678 100644
 """
         patches = list(collect_unified_diff(diff.splitlines(keepends=True)))
 
-        # Should parse the normal.txt patch (empty.txt has no hunks)
-        assert len(patches) == 1
-        assert patches[0].new_path == "normal.txt"
-        assert len(patches[0].lines) == 7  # ---, +++, @@, 4 body lines
+        assert len(patches) == 2
+        assert isinstance(patches[0], TextFileDeletionChange)
+        assert patches[0].path() == "empty.txt"
+        assert patches[1].new_path == "normal.txt"
+        assert len(patches[1].lines) == 7  # ---, +++, @@, 4 body lines
 
     def test_deleted_empty_file_followed_by_new_file(self):
         """Deleted empty file followed by a new file."""
@@ -61,9 +68,11 @@ index 0000000..83db48f
 """
         patches = list(collect_unified_diff(diff.splitlines(keepends=True)))
 
-        assert len(patches) == 1
-        assert patches[0].new_path == "new.txt"
-        assert patches[0].old_path == "new.txt"
+        assert len(patches) == 2
+        assert isinstance(patches[0], TextFileDeletionChange)
+        assert patches[0].path() == "deleted.txt"
+        assert patches[1].new_path == "new.txt"
+        assert patches[1].old_path == "new.txt"
 
     def test_multiple_deleted_empty_files(self):
         """Multiple deleted empty files in sequence."""
@@ -88,9 +97,12 @@ index abc1234..def5678 100644
 """
         patches = list(collect_unified_diff(diff.splitlines(keepends=True)))
 
-        # Should only parse normal.txt (the empty files have no hunks)
-        assert len(patches) == 1
-        assert patches[0].new_path == "normal.txt"
+        assert len(patches) == 3
+        assert isinstance(patches[0], TextFileDeletionChange)
+        assert patches[0].path() == "empty1.txt"
+        assert isinstance(patches[1], TextFileDeletionChange)
+        assert patches[1].path() == "empty2.txt"
+        assert patches[2].new_path == "normal.txt"
 
 
 class TestNewEmptyFiles:
@@ -539,21 +551,23 @@ index ghi789..jkl012 100644
 
         patches = list(collect_unified_diff(diff.splitlines(keepends=True)))
 
-        # Should parse files with hunks plus binary file, rename, and empty new file
-        # Expected: new_empty.txt (empty), image.png (binary), old->new rename, normal1.txt, normal2.txt
-        assert len(patches) == 5
-        assert isinstance(patches[0], SingleHunkPatch)
-        assert patches[0].new_path == "new_empty.txt"
-        assert isinstance(patches[1], BinaryFileChange)
-        assert patches[1].new_path == "image.png"
-        assert patches[1].change_type == "added"
-        assert isinstance(patches[2], RenameChange)
-        assert patches[2].old_path == "old.txt"
-        assert patches[2].new_path == "new.txt"
-        assert isinstance(patches[3], SingleHunkPatch)
-        assert patches[3].new_path == "normal1.txt"
+        # Expected: deleted_empty.txt (deletion), new_empty.txt (empty),
+        # image.png (binary), old->new rename, normal1.txt, normal2.txt
+        assert len(patches) == 6
+        assert isinstance(patches[0], TextFileDeletionChange)
+        assert patches[0].path() == "deleted_empty.txt"
+        assert isinstance(patches[1], SingleHunkPatch)
+        assert patches[1].new_path == "new_empty.txt"
+        assert isinstance(patches[2], BinaryFileChange)
+        assert patches[2].new_path == "image.png"
+        assert patches[2].change_type == "added"
+        assert isinstance(patches[3], RenameChange)
+        assert patches[3].old_path == "old.txt"
+        assert patches[3].new_path == "new.txt"
         assert isinstance(patches[4], SingleHunkPatch)
-        assert patches[4].new_path == "normal2.txt"
+        assert patches[4].new_path == "normal1.txt"
+        assert isinstance(patches[5], SingleHunkPatch)
+        assert patches[5].new_path == "normal2.txt"
 
     def test_intent_to_add_files(self):
         """Files added with git add -N (intent-to-add)."""
@@ -584,11 +598,11 @@ index 0000000..7654321
 """
         patches = list(collect_unified_diff(diff.splitlines(keepends=True)))
 
-        # Should parse both file_a.py and file_b.py
-        # The deleted_intent.py has no hunks
-        assert len(patches) == 2
+        assert len(patches) == 3
         assert patches[0].new_path == "file_a.py"
-        assert patches[1].new_path == "file_b.py"
+        assert isinstance(patches[1], TextFileDeletionChange)
+        assert patches[1].path() == "deleted_intent.py"
+        assert patches[2].new_path == "file_b.py"
 
 
 class TestStreamingBehavior:

--- a/tests/utils/test_git.py
+++ b/tests/utils/test_git.py
@@ -95,7 +95,7 @@ class TestRunGitCommand:
         calls = []
         command_env = {"CUSTOM": "1"}
 
-        def fake_wait(*, cwd, env):
+        def fake_wait(*, cwd, env, **_kwargs):
             calls.append(("wait", cwd, env))
 
         def fake_run_command(arguments, stdin_chunks=None, **kwargs):
@@ -110,6 +110,70 @@ class TestRunGitCommand:
         assert calls[0] == ("wait", "/repo", command_env)
         assert calls[1][0] == "run"
         assert calls[1][3]["env"] is command_env
+
+    def test_retries_transient_index_lock_error(self, monkeypatch):
+        """Index-writing commands should retry when Git loses the lock race."""
+        calls = []
+
+        def fake_wait(*, cwd, env, timeout_seconds, **_kwargs):
+            calls.append(("wait", cwd, env, timeout_seconds))
+
+        def fake_run_command(arguments, stdin_chunks=None, **kwargs):
+            calls.append(("run", arguments, stdin_chunks, kwargs))
+            if len([call for call in calls if call[0] == "run"]) == 1:
+                return subprocess.CompletedProcess(
+                    arguments,
+                    128,
+                    stdout="",
+                    stderr="fatal: Unable to create '/repo/.git/index.lock': File exists.\n",
+                )
+            return subprocess.CompletedProcess(arguments, 0, stdout="ok\n", stderr="")
+
+        monkeypatch.setattr(git_utils, "wait_for_git_index_lock", fake_wait)
+        monkeypatch.setattr(git_utils, "run_command", fake_run_command)
+
+        result = run_git_command(["apply", "--cached"], check=False, cwd="/repo")
+
+        assert result.returncode == 0
+        assert result.stdout == "ok\n"
+        assert [call[0] for call in calls] == ["wait", "run", "wait", "run"]
+
+    def test_retries_index_lock_error_with_reusable_stdin(self, monkeypatch):
+        """Retried index-writing commands must resend stdin chunks."""
+        seen_stdin = []
+
+        def fake_wait(**_kwargs):
+            pass
+
+        def fake_run_command(arguments, stdin_chunks=None, **_kwargs):
+            seen_stdin.append(list(stdin_chunks or []))
+            if len(seen_stdin) == 1:
+                return subprocess.CompletedProcess(
+                    arguments,
+                    128,
+                    stdout="",
+                    stderr="fatal: Unable to create '/repo/.git/index.lock': File exists.\n",
+                )
+            return subprocess.CompletedProcess(arguments, 0, stdout="", stderr="")
+
+        def patch_chunks():
+            yield b"diff --git a/file.txt b/file.txt\n"
+            yield b"+new line\n"
+
+        monkeypatch.setattr(git_utils, "wait_for_git_index_lock", fake_wait)
+        monkeypatch.setattr(git_utils, "run_command", fake_run_command)
+
+        result = run_git_command(
+            ["apply", "--cached"],
+            stdin_chunks=patch_chunks(),
+            check=False,
+        )
+
+        assert result.returncode == 0
+        assert seen_stdin == [
+            [b"diff --git a/file.txt b/file.txt\n", b"+new line\n"],
+            [b"diff --git a/file.txt b/file.txt\n", b"+new line\n"],
+        ]
 
     def test_disables_optional_locks_for_read_only_commands(self, monkeypatch):
         """Read-only commands should opt out of Git's optional index refresh locks."""


### PR DESCRIPTION
Users deleting a text file cannot choose deleted lines separately from path removal when a full content deletion collapses into a file deletion. Staged text deletions at session start also need to enter the staging-session flow instead of staying as hidden staged state.

This PR makes text file removal a first-class staging-session change. Deleted content is still reviewed as line hunks first. When the index holds an empty file and the working-tree path is absent, the workflow then asks separately whether to stage the path removal. That lets users keep only some deleted lines, keep an empty file, or remove the file as a separate choice.

The series updates include, discard, show, skip, status, start, stop, check_unstaged, diff/storage helpers, docs, tests, and packaged assistant guidance.

Verification:
- uv run ruff check src/git_stage_batch tests/commands/test_include.py tests/commands/test_discard.py tests/commands/test_staged_renames.py tests/core/test_diff_parser_edge_cases.py
- python -m compileall -q src/git_stage_batch
- git diff --check origin/main..HEAD
- PYTHONPATH=src uv run pytest tests/commands/test_include.py tests/commands/test_discard.py tests/commands/test_staged_renames.py tests/core/test_diff_parser.py tests/core/test_diff_parser_edge_cases.py tests/commands/test_show.py tests/commands/test_status.py (172 passed)
- PYTHONPATH=src uv run pytest tests/core/test_text_lifecycle.py tests/batch/test_storage.py tests/commands/test_include_to.py tests/commands/test_include_from.py tests/commands/test_discard_empty_file.py tests/commands/test_discard_file_to_batch.py tests/commands/test_skip.py (84 passed)