### PR TITLE
Allow staged-only include replacements

### DIFF
--- a/src/git_stage_batch/cli/argument_parser.py
+++ b/src/git_stage_batch/cli/argument_parser.py
@@ -26,7 +26,11 @@ from ..data.undo import undo_checkpoint
 from ..exceptions import CommandError
 from ..i18n import _, ngettext
 from ..utils.command import run_command
-from ..utils.file_patterns import list_changed_files, resolve_gitignore_style_patterns
+from ..utils.file_patterns import (
+    list_changed_files,
+    list_staged_files,
+    resolve_gitignore_style_patterns,
+)
 from ..utils.git import run_git_command
 from .completion import command_complete_files
 
@@ -570,13 +574,18 @@ def _discard_to_batch_each_resolved_file(
 def _resolve_live_file_scope(
     file_arg: FileArgument,
     file_patterns: list[str] | None,
+    *,
+    include_staged: bool = False,
 ) -> FileScope:
     """Resolve single-file or pattern-based live file scope."""
     resolved_patterns = _resolve_file_patterns(file_arg, file_patterns)
     if resolved_patterns is None:
         return FileScope.implicit() if file_arg is None else FileScope.explicit("")
 
-    candidate_files = list(dict.fromkeys([*list_changed_files(), *list_untracked_files()]))
+    candidate_files = [*list_changed_files(), *list_untracked_files()]
+    if include_staged:
+        candidate_files.extend(list_staged_files())
+    candidate_files = list(dict.fromkeys(candidate_files))
     resolved_files, display_patterns = _resolve_file_argument_patterns(
         candidate_files,
         file_arg,
@@ -1061,7 +1070,11 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
                 and args.from_batch is None
                 and args.to_batch is None
             ):
-                resolved_live_scope = _resolve_live_file_scope(args.file, args.file_patterns)
+                resolved_live_scope = _resolve_live_file_scope(
+                    args.file,
+                    args.file_patterns,
+                    include_staged=True,
+                )
                 if resolved_live_scope.is_implicit:
                     raise CommandError(
                         _("`include --as` requires `--file` or `--line` and does not support `--to`.")

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -843,6 +843,39 @@ def command_include_file(
     return hunks_staged
 
 
+def _file_has_staged_changes(file_path: str) -> bool:
+    """Return whether the index version of a path differs from HEAD."""
+    result = run_git_command(
+        [
+            "diff",
+            "--cached",
+            "--quiet",
+            "--no-renames",
+            "--",
+            file_path,
+        ],
+        check=False,
+        requires_index_lock=False,
+    )
+    return result.returncode == 1
+
+
+def _file_has_unstaged_changes(file_path: str) -> bool:
+    """Return whether the working tree version of a path differs from the index."""
+    result = run_git_command(
+        [
+            "diff",
+            "--quiet",
+            "--no-renames",
+            "--",
+            file_path,
+        ],
+        check=False,
+        requires_index_lock=False,
+    )
+    return result.returncode == 1
+
+
 def command_include_file_as(
     replacement_text: str | ReplacementPayload,
     file: str | None = None,
@@ -885,9 +918,11 @@ def command_include_file_as(
 
         if preserve_selected_state:
             line_changes = cache_unstaged_file_as_single_hunk(target_file)
-            if line_changes is None:
+            if line_changes is None and not _file_has_staged_changes(target_file):
                 exit_with_error(_("No changes in file '{file}'.").format(file=target_file))
         else:
+            if not _file_has_unstaged_changes(target_file):
+                exit_with_error(_("No changes in file '{file}'.").format(file=target_file))
             line_changes = load_line_changes_from_state()
             if line_changes is None or line_changes.path != target_file:
                 line_changes = cache_unstaged_file_as_single_hunk(target_file)

--- a/src/git_stage_batch/utils/file_patterns.py
+++ b/src/git_stage_batch/utils/file_patterns.py
@@ -95,23 +95,8 @@ def resolve_gitignore_style_patterns(
     return [candidate for candidate in normalized_candidates if resolved_status.get(candidate, False)]
 
 
-def list_changed_files() -> list[str]:
-    """List repository-relative paths participating in the working-tree diff."""
-    result = run_git_command(
-        [
-            "-c",
-            "diff.ignoreSubmodules=none",
-            "diff",
-            "--ignore-submodules=none",
-            "--find-renames",
-            "--name-status",
-            "-z",
-        ],
-        text_output=False,
-        requires_index_lock=False,
-    )
-
-    fields = result.stdout.split(b"\0")
+def _paths_from_name_status_z(output: bytes) -> list[str]:
+    fields = output.split(b"\0")
     changed_paths: list[str] = []
     index = 0
     while index < len(fields):
@@ -131,3 +116,42 @@ def list_changed_files() -> list[str]:
                 changed_paths.append(_normalize_path(path.decode("utf-8")))
 
     return list(dict.fromkeys(changed_paths))
+
+
+def list_changed_files() -> list[str]:
+    """List repository-relative paths participating in the working-tree diff."""
+    result = run_git_command(
+        [
+            "-c",
+            "diff.ignoreSubmodules=none",
+            "diff",
+            "--ignore-submodules=none",
+            "--find-renames",
+            "--name-status",
+            "-z",
+        ],
+        text_output=False,
+        requires_index_lock=False,
+    )
+
+    return _paths_from_name_status_z(result.stdout)
+
+
+def list_staged_files() -> list[str]:
+    """List repository-relative paths participating in the index diff."""
+    result = run_git_command(
+        [
+            "-c",
+            "diff.ignoreSubmodules=none",
+            "diff",
+            "--cached",
+            "--ignore-submodules=none",
+            "--find-renames",
+            "--name-status",
+            "-z",
+        ],
+        text_output=False,
+        requires_index_lock=False,
+    )
+
+    return _paths_from_name_status_z(result.stdout)

--- a/tests/cli/test_argument_parser.py
+++ b/tests/cli/test_argument_parser.py
@@ -25,10 +25,11 @@ class _UnreadableStdin:
     buffer = _Buffer()
 
 
-def _mock_live_file_candidates(monkeypatch, changed, untracked=()):
+def _mock_live_file_candidates(monkeypatch, changed, untracked=(), staged=()):
     """Provide deterministic live file candidates for parser scope resolution."""
     monkeypatch.setattr(argument_parser, "list_changed_files", lambda: list(changed))
     monkeypatch.setattr(argument_parser, "list_untracked_files", lambda: list(untracked))
+    monkeypatch.setattr(argument_parser, "list_staged_files", lambda: list(staged))
 
 
 def test_build_manpath_with_existing_environment(monkeypatch):
@@ -791,6 +792,26 @@ def test_parse_command_line_include_with_file_and_as_stdin_dispatches_file_repla
     args.func(args)
     mock_command.assert_called_once_with(
         "replacement\n",
+        file="path.txt",
+        auto_advance=None,
+    )
+
+
+def test_parse_command_line_include_file_as_can_resolve_staged_file(monkeypatch):
+    """Include --file --as should accept already-staged paths."""
+    mock_command = Mock()
+    monkeypatch.setattr(argument_parser.commands, "command_include_file_as", mock_command)
+    _mock_live_file_candidates(monkeypatch, [], staged=["path.txt"])
+
+    args = parse_command_line(
+        ["include", "--file", "path.txt", "--as", "replacement"],
+        quiet=True,
+    )
+
+    assert args is not None
+    args.func(args)
+    mock_command.assert_called_once_with(
+        "replacement",
         file="path.txt",
         auto_advance=None,
     )

--- a/tests/commands/test_file_scoped_operations.py
+++ b/tests/commands/test_file_scoped_operations.py
@@ -1300,6 +1300,27 @@ class TestExplicitFilePath:
         result = run_git_command(["diff", "gamma.txt"])
         assert "gamma2-modified" in result.stdout
 
+    def test_include_file_as_can_replace_already_staged_new_file(self, multi_file_repo):
+        """Full-file replacement should work after a new file is already staged."""
+        (multi_file_repo / "new.txt").write_text("alpha\nbeta\n")
+        command_start()
+
+        command_include_file(file="new.txt")
+        command_include_file_as("replacement\n", file="new.txt")
+
+        staged_content = run_git_command(["show", ":new.txt"]).stdout
+        assert staged_content == "replacement\n"
+        assert (multi_file_repo / "new.txt").read_text() == "alpha\nbeta\n"
+
+    def test_include_file_as_shorthand_requires_unstaged_selected_file(self, multi_file_repo):
+        """Pathless full-file replacement should not target staged-only state."""
+        command_start()
+
+        command_include_file(file="alpha.txt", advance=False)
+
+        with pytest.raises(CommandError, match="No changes in file 'alpha.txt'"):
+            command_include_file_as("replacement\n", file="")
+
     def test_include_file_line_as_with_explicit_path(self, multi_file_repo):
         """Include --file PATH --line IDS --as should preserve selected position."""
         command_start()


### PR DESCRIPTION
The file-pattern helper can resolve changed files for live workflows, and include supports replacement text for selected file-scoped content.

Users cannot apply explicit replacement content to files that only have staged changes. Those paths are invisible to the live changed-file resolver, so include --file --as cannot target them even when the staged-only change is the exact content being curated.

This PR addresses that by teaching file pattern resolution about staged diff paths and by allowing include --file --as to operate on an explicit staged-only path. It keeps unstaged path handling on the existing live workflow and adds focused CLI and command coverage.

Verification:
- All checks passed!
- ============================= test session starts ==============================
platform linux -- Python 3.10.18, pytest-9.0.3, pluggy-1.6.0
rootdir: /var/srv/sources/github/git-stage-batch
configfile: pyproject.toml
plugins: xdist-3.8.0
created: 8/8 workers
8 workers [219 items]

........................................................................ [ 32%]
........................................................................ [ 65%]
........................................................................ [ 98%]
...                                                                      [100%]
============================= 219 passed in 4.85s ============================== (219 passed)