### PR TITLE
docs: Add AI assistant onboarding guides and clarify history behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,25 @@ git-stage-batch status
 git-stage-batch again
 ```
 
+### AI Assistant Quick Start
+
+```bash
+# Install the command
+python -m pipx install git-stage-batch
+
+# Install Claude Code commit skills into this repository
+git-stage-batch install-assets claude-skills --filter 'commit-*'
+
+# Keep the local Claude assets out of reviews
+git-stage-batch block-file --local-only .claude/
+
+# Ask Claude Code to split and commit the unstaged work
+claude "/commit-unstaged-changes"
+```
+
+Omit `--filter` when installing Claude skills if you also want the larger
+`/decompose-and-commit-unstaged-changes` workflow.
+
 ## Example Workflow
 
 ```bash

--- a/docs/ai-assistants.md
+++ b/docs/ai-assistants.md
@@ -43,6 +43,11 @@ The bundled Claude skills currently include:
 - `decompose-and-commit-unstaged-changes` for peeling larger unstaged work into
   concern batches and rebuilding a fine-grained commit series
 
+The regular commit skills stage the current working tree into new commits. The
+decomposition skill may rewrite commits it just created while polishing a local
+draft series, but it is not intended to rewrite shared or protected branch
+history.
+
 Create or update `CLAUDE.md` in your repository root:
 
 ```markdown

--- a/docs/ai-assistants.md
+++ b/docs/ai-assistants.md
@@ -23,6 +23,19 @@ git-stage-batch install-assets claude-skills --filter 'commit-*'
 Omit `--filter` to install all bundled Claude skills.
 Use `--force` to replace an existing repo-local copy.
 
+For a new environment, a minimal Claude setup looks like:
+
+```bash
+python -m pipx install git-stage-batch
+git-stage-batch install-assets claude-skills --filter 'commit-*'
+git-stage-batch block-file --local-only .claude/
+claude "/commit-unstaged-changes"
+```
+
+The `block-file --local-only` line is useful when the Claude assets should
+remain local. It keeps `.claude/` out of future reviews without adding it to
+the project `.gitignore`.
+
 The bundled Claude skills currently include:
 
 - `commit-staged-changes` for turning the current staged index into one commit

--- a/docs/batches.md
+++ b/docs/batches.md
@@ -834,9 +834,14 @@ They operate at different levels of the workflow.
 
 ### Do batches modify my Git history?
 
-No.
+Not by themselves.
 
-Batches are stored separately from your commit history. They only affect how you prepare commits.
+Batches are stored separately from your commit history. The normal workflow uses
+them to prepare commits without rewriting existing history.
+
+Assistant decomposition workflows can use batches while rebuilding a local
+draft series, and may polish commits they just created before the series is
+shared. That is different from modifying protected branch history.
 
 Once a batch is included and committed, the batch itself can be dropped.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -522,7 +522,12 @@ When run without a selected hunk, you can specify the file path:
 
 ```
 ❯ git-stage-batch block-file path/to/file.txt
+❯ git-stage-batch block-file --local-only .claude/
 ```
+
+Use `--local-only` to write the ignore entry to `.git/info/exclude` instead
+of `.gitignore`, which is useful for personal assistant assets or other
+machine-local files.
 
 Useful for build artifacts, IDE files, or other generated content.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -215,6 +215,34 @@ Similar to `git add -p` but **more granular and flexible**:
 See [batch operations](batches.md) for advanced patch-series organization.
 See [commands reference](commands.md) for the `--as` contiguous-range rules.
 
+### AI Assistant Quick Start
+
+For Claude Code, install the tool and the bundled commit skills in the
+repository where the assistant will work:
+
+```
+❯ python -m pipx install git-stage-batch
+❯ git-stage-batch install-assets claude-skills --filter 'commit-*'
+```
+
+If you want the Claude assets to stay local, keep them out of reviews without
+changing the project `.gitignore`:
+
+```
+❯ git-stage-batch block-file --local-only .claude/
+```
+
+Then ask Claude Code to split and commit the current unstaged work:
+
+```
+❯ claude "/commit-unstaged-changes"
+```
+
+Omit `--filter` when installing Claude skills if you also want the larger
+`/decompose-and-commit-unstaged-changes` workflow. See the
+[AI assistant guide](ai-assistants.md) for Codex setup and fuller assistant
+configuration.
+
 ## Example Workflow
 
 <div class="workflow-showcase">

--- a/docs/index.md
+++ b/docs/index.md
@@ -342,13 +342,18 @@ Automatically detects and clears cached state when files are committed or modifi
 
 ### Is this rewriting Git history?
 
-No.
+Usually no.
 
 git-stage-batch is intended for organizing draft patch sets before they are committed or shared. It helps you turn a messy working tree into a clean sequence of logical commits.
 
-It does not rewrite existing commits, and it is not meant to modify the history of shared or protected branches.
+The normal workflow stages selected working-tree changes into new commits
+rather than rewriting existing commits. Assistant decomposition workflows may
+polish commits they have just created while rebuilding a local series, but
+that rewriting is limited to fresh draft history.
 
-Think of it as helping you prepare commits before they become part of history, not changing history afterward.
+It is not meant to modify shared history or protected branches. Think of it as
+helping you prepare commits before they become part of reviewable project
+history, with any assistant-side polishing confined to local draft commits.
 
 ### When should I use this?
 


### PR DESCRIPTION
The project website, command reference, and README each provide useful
information about git-stage-batch features, but none of them offers a
copy-paste path from zero to a working AI assistant commit workflow. Users
setting up a new environment have to piece together installation steps,
skill filtering, and local-only asset management from separate reference
sections. Additionally, FAQ answers categorically deny any history
rewriting, which contradicts the behavior users observe when using the
assistant decomposition skill.

This series adds quick-start guides and corrects the history documentation:

- Document the block-file --local-only flag in the command reference so
  users know how to exclude machine-local files like .claude/ without
  modifying the shared .gitignore

- Add quick-start sections to the website landing page, AI assistant
  guide, and project README with a four-step sequence covering pipx
  installation, skill filtering, local-only file blocking, and Claude
  invocation

- Update FAQ answers on the batches and landing pages to distinguish
  normal batch usage (no history rewriting) from assistant decomposition
  workflows (may rewrite its own draft commits)