### PR TITLE
architecture: Isolate selected-change state storage

### DIFF
--- a/src/git_stage_batch/batch/file_display.py
+++ b/src/git_stage_batch/batch/file_display.py
@@ -1,0 +1,346 @@
+"""Batch file display rendering without selected-state mutation."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from . import display as batch_display
+from . import merge as batch_merge
+from .match import match_lines
+from .ownership import (
+    BatchOwnership,
+    build_ownership_units_from_display_lines,
+    rebuild_ownership_from_units,
+    validate_ownership_units,
+)
+from .query import read_batch_metadata
+from ..core.line_selection import LineRanges
+from ..core.models import (
+    HunkHeader,
+    LineEntry,
+    LineLevelChange,
+    RenderedBatchDisplay,
+    ReviewActionGroup,
+)
+from ..editor import load_git_object_as_buffer, load_working_tree_file_as_buffer
+from ..exceptions import MergeError
+from ..utils.paths import get_context_lines
+from ..utils.text import normalize_line_sequence_endings
+
+
+_BATCH_MERGE_REVIEW_ACTIONS = (
+    "include-from-batch",
+    "discard-from-batch",
+    "apply-from-batch",
+)
+_BATCH_RESET_REVIEW_ACTION = "reset-from-batch"
+
+
+def render_batch_file_display(
+    batch_name: str,
+    file_path: str,
+    metadata: dict | None = None,
+    *,
+    probe_mergeability: bool = True,
+) -> Optional['RenderedBatchDisplay']:
+    """Pure function to render batch file display with gutter ID translation.
+
+    This is a side-effect-free helper that:
+    - Reads batch metadata
+    - Reads batch source content
+    - Reads current working tree content
+    - Probes individual line mergeability
+    - Builds LineLevelChange with original selection IDs
+    - Builds gutter ID mappings
+
+    It does not:
+    - Write cache files
+    - Mutate selected hunk state
+    - Compute patch hashes
+
+    Args:
+        batch_name: Name of the batch
+        file_path: Specific file to render
+        probe_mergeability: If True, compute which batch lines are currently
+            mergeable. Multi-file navigational previews can set this to False
+            because they do not cache or act on individual lines.
+
+    Returns:
+        RenderedBatchDisplay with line changes and gutter ID translation, or None if file not found.
+    """
+    # Read batch metadata
+    if metadata is None:
+        metadata = read_batch_metadata(batch_name)
+    files = metadata.get("files", {})
+
+    if not files or file_path not in files:
+        return None
+
+    file_meta = files[file_path]
+
+    # Get batch source commit and ownership
+    batch_source_commit = file_meta["batch_source_commit"]
+    with BatchOwnership.acquire_for_metadata_dict(file_meta) as ownership:
+        return _render_batch_file_display_from_ownership(
+            batch_source_commit=batch_source_commit,
+            file_path=file_path,
+            file_meta=file_meta,
+            ownership=ownership,
+            probe_mergeability=probe_mergeability,
+        )
+
+
+def _render_batch_file_display_from_ownership(
+    *,
+    batch_source_commit: str,
+    file_path: str,
+    file_meta: dict,
+    ownership: BatchOwnership,
+    probe_mergeability: bool,
+) -> Optional['RenderedBatchDisplay']:
+    """Render batch file display from already-acquired ownership metadata."""
+
+    batch_source_buffer = load_git_object_as_buffer(
+        f"{batch_source_commit}:{file_path}"
+    )
+    if batch_source_buffer is None:
+        return None
+
+    mergeable_id_range_parts: list[tuple[int, int]] = []
+    mergeable_id_ranges = LineRanges.empty()
+    units = []
+
+    with batch_source_buffer as batch_source_lines:
+        # Build display lines (already has correct line IDs matching ownership)
+        display_lines = batch_display.build_display_lines_from_batch_source_lines(
+            batch_source_lines,
+            ownership,
+            context_lines=get_context_lines(),
+        )
+
+        if probe_mergeability and display_lines:
+            source_match_lines = normalize_line_sequence_endings(batch_source_lines)
+            working_tree_buffer = load_working_tree_file_as_buffer(file_path)
+            with working_tree_buffer as working_tree_lines:
+                working_match_lines = normalize_line_sequence_endings(working_tree_lines)
+                with match_lines(
+                    source_match_lines,
+                    working_match_lines,
+                ) as source_to_working_mapping:
+
+                    units = build_ownership_units_from_display_lines(
+                        ownership,
+                        display_lines,
+                    )
+
+                    # Check each ownership unit once. All lines in an atomic unit
+                    # share the same mergeability result.
+                    for unit in units:
+                        try:
+                            validate_ownership_units([unit])
+                            ownership_for_unit = rebuild_ownership_from_units([unit])
+                            if ownership_for_unit.is_empty():
+                                continue
+                            if not batch_merge.can_merge_batch_from_line_sequences(
+                                source_match_lines,
+                                ownership_for_unit,
+                                working_match_lines,
+                                source_to_working_mapping=source_to_working_mapping,
+                            ):
+                                continue
+                            mergeable_id_range_parts.extend(unit.display_line_ids.ranges())
+                        except (MergeError, ValueError, KeyError, Exception):
+                            # Unit not mergeable - exclude all its lines
+                            pass
+
+                    mergeable_id_ranges = LineRanges.from_ranges(mergeable_id_range_parts)
+
+    if not display_lines:
+        change_type = file_meta.get("change_type", "modified")
+        if change_type in {"added", "deleted"}:
+            marker_kind = "+" if change_type == "added" else "-"
+            line_changes = LineLevelChange(
+                path=file_path,
+                header=HunkHeader(
+                    old_start=0 if change_type == "added" else 1,
+                    old_len=0 if change_type == "added" else 1,
+                    new_start=1 if change_type == "added" else 0,
+                    new_len=1 if change_type == "added" else 0,
+                ),
+                lines=[
+                    LineEntry(
+                        id=1,
+                        kind=marker_kind,
+                        old_line_number=1 if change_type == "deleted" else None,
+                        new_line_number=1 if change_type == "added" else None,
+                        text_bytes=b"<empty file>",
+                        source_line=None,
+                    )
+                ],
+            )
+            return RenderedBatchDisplay(
+                line_changes=line_changes,
+                gutter_to_selection_id={},
+                selection_id_to_gutter={},
+                actionable_selection_groups=(),
+            )
+        return None
+
+    # Keep original selection IDs; mergeability is stored separately.
+    line_entries = []
+    new_line_num = 1
+
+    for display_line in display_lines:
+        line_id = display_line["id"]  # Keep original selection ID
+        content = display_line["content"]
+
+        # Convert string content to bytes (encode as UTF-8)
+        content_bytes = content.encode('utf-8')
+        # Strip only the newline terminator, preserve \r
+        text_bytes = content_bytes.rstrip(b'\n')
+        has_trailing_newline = content_bytes.endswith(b'\n')
+
+        if display_line["type"] == "claimed":
+            # Claimed line from batch source
+            source_line = display_line["source_line"]
+            line_entries.append(LineEntry(
+                id=line_id,
+                kind="+",
+                old_line_number=None,
+                new_line_number=new_line_num,
+                text_bytes=text_bytes,
+                source_line=source_line,
+                has_trailing_newline=has_trailing_newline,
+            ))
+            new_line_num += 1
+        elif display_line["type"] == "deletion":
+            # Deletion (suppression constraint - show as deletion for display)
+            line_entries.append(LineEntry(
+                id=line_id,
+                kind="-",
+                old_line_number=None,  # Not from old file (it's a constraint)
+                new_line_number=None,
+                text_bytes=text_bytes,
+                source_line=None,
+                has_trailing_newline=has_trailing_newline,
+            ))
+        elif display_line["type"] == "context":
+            line_entries.append(LineEntry(
+                id=None,
+                kind=" ",
+                old_line_number=None,
+                new_line_number=new_line_num,
+                text_bytes=text_bytes,
+                source_line=display_line["source_line"],
+                has_trailing_newline=has_trailing_newline,
+            ))
+            new_line_num += 1
+        elif display_line["type"] == "gap":
+            line_entries.append(LineEntry(
+                id=None,
+                kind=" ",
+                old_line_number=None,
+                new_line_number=None,
+                text_bytes=text_bytes,
+                source_line=None,
+                has_trailing_newline=has_trailing_newline,
+            ))
+
+    # Compute header based on actual line types
+    addition_count = sum(1 for e in line_entries if e.kind == "+")
+    deletion_count = sum(1 for e in line_entries if e.kind == "-")
+
+    # Create hunk header
+    header = HunkHeader(
+        old_start=0 if deletion_count == 0 else 1,
+        old_len=deletion_count,
+        new_start=0 if addition_count == 0 else 1,
+        new_len=addition_count
+    )
+
+    line_changes = LineLevelChange(
+        path=file_path,
+        header=header,
+        lines=line_entries
+    )
+
+    # Build gutter ID mappings
+    # Only mergeable lines get consecutive gutter IDs (1, 2, 3...)
+    gutter_to_selection_id = {}
+    selection_id_to_gutter = {}
+    gutter_num = 1
+    for entry in line_entries:
+        if entry.id is not None and entry.id in mergeable_id_ranges:
+            gutter_to_selection_id[gutter_num] = entry.id
+            selection_id_to_gutter[entry.id] = gutter_num
+            gutter_num += 1
+
+    line_id_display_order = [
+        entry.id
+        for entry in line_entries
+        if entry.id is not None
+    ]
+    resettable_ids = LineRanges.from_ranges(
+        display_id_range
+        for unit in units
+        for display_id_range in unit.display_line_ids.ranges()
+    )
+    review_gutter_to_selection_id = {}
+    review_selection_id_to_gutter = {}
+    review_gutter_num = 1
+    for entry in line_entries:
+        if entry.id is not None and entry.id in resettable_ids:
+            review_gutter_to_selection_id[review_gutter_num] = entry.id
+            review_selection_id_to_gutter[entry.id] = review_gutter_num
+            review_gutter_num += 1
+
+    actionable_selection_groups = []
+    review_action_groups = []
+    for unit in units:
+        if not unit.display_line_ids:
+            continue
+        ordered_group = tuple(
+            line_id
+            for line_id in line_id_display_order
+            if line_id in unit.display_line_ids
+        )
+        if len(ordered_group) != len(unit.display_line_ids):
+            continue
+
+        actions = [_BATCH_RESET_REVIEW_ACTION]
+        if unit.display_line_ids.intersection(mergeable_id_ranges) == unit.display_line_ids:
+            actionable_selection_groups.append(ordered_group)
+            actions = [
+                *_BATCH_MERGE_REVIEW_ACTIONS,
+                _BATCH_RESET_REVIEW_ACTION,
+            ]
+
+        review_display_ids = tuple(
+            review_selection_id_to_gutter[line_id]
+            for line_id in ordered_group
+            if line_id in review_selection_id_to_gutter
+        )
+        if len(review_display_ids) == len(ordered_group):
+            if unit.kind.value == "replacement":
+                reason = "replacement"
+            elif unit.kind.value == "deletion_only":
+                reason = "structural-run"
+            else:
+                reason = "simple"
+            review_action_groups.append(
+                ReviewActionGroup(
+                    display_ids=review_display_ids,
+                    selection_ids=ordered_group,
+                    actions=tuple(actions),
+                    reason=reason,
+                )
+            )
+    return RenderedBatchDisplay(
+        line_changes=line_changes,
+        gutter_to_selection_id=gutter_to_selection_id,
+        selection_id_to_gutter=selection_id_to_gutter,
+        actionable_selection_groups=tuple(actionable_selection_groups),
+        review_gutter_to_selection_id=review_gutter_to_selection_id,
+        review_selection_id_to_gutter=review_selection_id_to_gutter,
+        review_action_groups=tuple(review_action_groups),
+    )

--- a/src/git_stage_batch/batch/operation_candidates.py
+++ b/src/git_stage_batch/batch/operation_candidates.py
@@ -21,7 +21,7 @@ from .merge import (
     enumerate_merge_batch_candidates_from_line_sequences,
     merge_batch_from_line_sequences_as_buffer,
 )
-from .replacement import ReplacementPayload
+from ..core.replacement import ReplacementPayload
 
 
 CandidateOperation = Literal["apply", "include"]

--- a/src/git_stage_batch/batch/replacement.py
+++ b/src/git_stage_batch/batch/replacement.py
@@ -6,49 +6,26 @@ from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 
 from ..core.line_selection import format_line_ids
+from ..core.replacement import (
+    ReplacementPayload,
+    ReplacementText,
+    coerce_replacement_payload,
+    replacement_line_bodies,
+    replacement_line_chunks,
+)
 from ..editor import EditorBuffer
-from ..utils.text import bytes_to_lines
 from .ownership import BatchOwnership, AbsenceClaim, ReplacementUnit
 
 
-@dataclass(frozen=True, slots=True)
-class ReplacementPayload:
-    """Exact replacement bytes plus optional argv display text."""
-
-    data: bytes
-    display_text: str | None = None
-    exact: bool = True
-
-    @classmethod
-    def from_text(cls, text: str, *, exact: bool = True) -> "ReplacementPayload":
-        return cls(
-            text.encode("utf-8", errors="surrogateescape"),
-            display_text=text,
-            exact=exact,
-        )
-
-    @property
-    def has_trailing_lf(self) -> bool:
-        return self.data.endswith(b"\n")
-
-    def as_text(self) -> str:
-        return self.data.decode("utf-8", errors="surrogateescape")
-
-
-class ReplacementText(str):
-    """String-compatible replacement value carrying exact source bytes."""
-
-    def __new__(
-        cls,
-        text: str,
-        *,
-        data: bytes | None = None,
-        exact: bool = True,
-    ) -> "ReplacementText":
-        obj = str.__new__(cls, text)
-        obj.data = text.encode("utf-8", errors="surrogateescape") if data is None else data
-        obj.exact = exact
-        return obj
+__all__ = [
+    "ReplacementBatchView",
+    "ReplacementPayload",
+    "ReplacementText",
+    "build_replacement_batch_view_from_lines",
+    "coerce_replacement_payload",
+    "replacement_line_bodies",
+    "replacement_line_chunks",
+]
 
 
 @dataclass(slots=True)
@@ -207,42 +184,3 @@ def _replacement_source_chunks(
 
     for line_index in range(suffix_start, len(source_lines)):
         yield source_lines[line_index]
-
-
-def coerce_replacement_payload(
-    replacement: str | bytes | ReplacementPayload,
-) -> ReplacementPayload:
-    """Return exact replacement bytes for legacy str callers and new payloads."""
-    if isinstance(replacement, ReplacementPayload):
-        return replacement
-    if isinstance(replacement, ReplacementText):
-        return ReplacementPayload(
-            replacement.data,
-            display_text=str(replacement) if not replacement.exact else None,
-            exact=replacement.exact,
-        )
-    if isinstance(replacement, bytes):
-        return ReplacementPayload(replacement)
-    # Plain str is the legacy command-internal API. Preserve its historical
-    # line-oriented behavior; CLI --as-stdin uses ReplacementText for exact bytes.
-    return ReplacementPayload.from_text(replacement, exact=False)
-
-
-def replacement_line_chunks(payload: ReplacementPayload) -> list[bytes]:
-    """Split replacement bytes into exact line chunks."""
-    if not payload.exact:
-        return [line + b"\n" for line in payload.data.splitlines()]
-    return list(bytes_to_lines([payload.data]))
-
-
-def replacement_line_bodies(payload: ReplacementPayload) -> list[bytes]:
-    """Return editor line bodies while preserving CRLF as body CR bytes."""
-    if not payload.exact:
-        return payload.data.splitlines()
-    bodies: list[bytes] = []
-    for line in replacement_line_chunks(payload):
-        if line.endswith(b"\n"):
-            bodies.append(line[:-1])
-        else:
-            bodies.append(line)
-    return bodies

--- a/src/git_stage_batch/batch/selection.py
+++ b/src/git_stage_batch/batch/selection.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
     from ..exceptions import AtomicUnitError
     from ..core.models import LineLevelChange
     from ..core.models import RenderedBatchDisplay
-    from ..data.file_review_state import FileReviewAction
+    from ..data.file_review.state import FileReviewAction
 
 
 def _default_live_file_review_command(file_path: str) -> str:
@@ -358,7 +358,7 @@ def translate_batch_file_gutter_ids_to_selection_ids(
     if selected_ids is None:
         return None, None
 
-    from ..data.file_review_state import (
+    from ..data.file_review.state import (
         fresh_batch_review_selections_for_action,
         validate_review_scoped_line_selection,
     )

--- a/src/git_stage_batch/cli/argument_parser.py
+++ b/src/git_stage_batch/cli/argument_parser.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from .. import __version__
 from ..batch.validation import batch_exists
 from ..batch.source_selector import batch_name_for_source_lookup
-from ..batch.replacement import ReplacementText
+from ..core.replacement import ReplacementText
 from .. import commands
 from ..batch.query import read_batch_metadata
 from ..data.file_tracking import list_untracked_files

--- a/src/git_stage_batch/commands/apply_from.py
+++ b/src/git_stage_batch/commands/apply_from.py
@@ -40,7 +40,7 @@ from ..core.text_lifecycle import (
     normalized_text_change_type,
     selected_text_target_change_type,
 )
-from ..data.file_review_state import (
+from ..data.file_review.state import (
     FileReviewAction,
     finish_review_scoped_line_action,
     resolve_batch_source_action_scope,

--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -54,6 +54,7 @@ from ..core.line_selection import parse_line_selection
 from ..core.models import BinaryFileChange, GitlinkChange, RenameChange, TextFileDeletionChange
 from ..core.text_lifecycle import TextFileChangeType, detect_empty_text_lifecycle_change
 from ..data.hunk_tracking import (
+    RecalculateSelectedHunkResult,
     SelectedChangeKind,
     build_file_hunk_from_buffer,
     cache_unstaged_file_as_single_hunk,
@@ -131,6 +132,21 @@ from ..utils.paths import (
 from .include import (
     _expand_replacement_selection_ids,
 )
+
+
+def _recalculate_selected_hunk_for_file(
+    file_path: str,
+    *,
+    auto_advance: bool | None = None,
+) -> None:
+    result = recalculate_selected_hunk_for_file(
+        file_path,
+        auto_advance=auto_advance,
+    )
+    if result == RecalculateSelectedHunkResult.SHOW_NEXT_CHANGE:
+        from .show import command_show
+
+        command_show()
 
 
 @dataclass(frozen=True)
@@ -766,7 +782,7 @@ def command_discard_file_as(
             assert saved_selected_state is not None
             restore_selected_change_state(saved_selected_state)
         else:
-            recalculate_selected_hunk_for_file(
+            _recalculate_selected_hunk_for_file(
                 line_changes.path,
                 auto_advance=auto_advance,
             )
@@ -851,7 +867,7 @@ def command_discard_line(
             file=sys.stderr,
         )
         print_remaining_line_changes_header(line_changes.path)
-        recalculate_selected_hunk_for_file(
+        _recalculate_selected_hunk_for_file(
             line_changes.path,
             auto_advance=auto_advance,
         )
@@ -1288,7 +1304,7 @@ def _command_discard_lines_to_batch_as(
             file=sys.stderr,
         )
 
-    recalculate_selected_hunk_for_file(line_changes.path, auto_advance=auto_advance)
+    _recalculate_selected_hunk_for_file(line_changes.path, auto_advance=auto_advance)
 
 
 def _select_rewritten_replacement_lines(
@@ -2110,7 +2126,7 @@ def _command_discard_lines_to_batch(
         print(_("✓ Discarded line(s) to batch '{name}': {lines}").format(name=batch_name, lines=line_id_specification), file=sys.stderr)
 
     # After modifying working tree, recalculate and show the updated hunk for this file
-    recalculate_selected_hunk_for_file(line_changes.path, auto_advance=auto_advance)
+    _recalculate_selected_hunk_for_file(line_changes.path, auto_advance=auto_advance)
 
     log_journal("discard_lines_to_batch_success", batch_name=batch_name, line_ids=line_id_specification, file_path=line_changes.path)
     return 1

--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -29,7 +29,7 @@ from ..batch.ownership import (
     merge_batch_ownership,
     translate_lines_to_batch_ownership,
 )
-from ..batch.replacement import (
+from ..core.replacement import (
     ReplacementPayload,
     coerce_replacement_payload,
 )

--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -54,7 +54,6 @@ from ..core.line_selection import parse_line_selection
 from ..core.models import BinaryFileChange, GitlinkChange, RenameChange, TextFileDeletionChange
 from ..core.text_lifecycle import TextFileChangeType, detect_empty_text_lifecycle_change
 from ..data.hunk_tracking import (
-    RecalculateSelectedHunkResult,
     SelectedChangeKind,
     build_file_hunk_from_buffer,
     cache_unstaged_file_as_single_hunk,
@@ -63,7 +62,6 @@ from ..data.hunk_tracking import (
     get_selected_change_file_path,
     load_selected_change,
     read_selected_change_kind,
-    recalculate_selected_hunk_for_file,
     record_hunk_discarded,
     record_hunks_discarded,
     refuse_bare_action_after_auto_advance_disabled,
@@ -132,21 +130,7 @@ from ..utils.paths import (
 from .include import (
     _expand_replacement_selection_ids,
 )
-
-
-def _recalculate_selected_hunk_for_file(
-    file_path: str,
-    *,
-    auto_advance: bool | None = None,
-) -> None:
-    result = recalculate_selected_hunk_for_file(
-        file_path,
-        auto_advance=auto_advance,
-    )
-    if result == RecalculateSelectedHunkResult.SHOW_NEXT_CHANGE:
-        from .show import command_show
-
-        command_show()
+from .selection.selected_hunk_refresh import recalculate_selected_hunk_for_command
 
 
 @dataclass(frozen=True)
@@ -782,7 +766,7 @@ def command_discard_file_as(
             assert saved_selected_state is not None
             restore_selected_change_state(saved_selected_state)
         else:
-            _recalculate_selected_hunk_for_file(
+            recalculate_selected_hunk_for_command(
                 line_changes.path,
                 auto_advance=auto_advance,
             )
@@ -867,7 +851,7 @@ def command_discard_line(
             file=sys.stderr,
         )
         print_remaining_line_changes_header(line_changes.path)
-        _recalculate_selected_hunk_for_file(
+        recalculate_selected_hunk_for_command(
             line_changes.path,
             auto_advance=auto_advance,
         )
@@ -1304,7 +1288,7 @@ def _command_discard_lines_to_batch_as(
             file=sys.stderr,
         )
 
-    _recalculate_selected_hunk_for_file(line_changes.path, auto_advance=auto_advance)
+    recalculate_selected_hunk_for_command(line_changes.path, auto_advance=auto_advance)
 
 
 def _select_rewritten_replacement_lines(
@@ -2126,7 +2110,7 @@ def _command_discard_lines_to_batch(
         print(_("✓ Discarded line(s) to batch '{name}': {lines}").format(name=batch_name, lines=line_id_specification), file=sys.stderr)
 
     # After modifying working tree, recalculate and show the updated hunk for this file
-    _recalculate_selected_hunk_for_file(line_changes.path, auto_advance=auto_advance)
+    recalculate_selected_hunk_for_command(line_changes.path, auto_advance=auto_advance)
 
     log_journal("discard_lines_to_batch_success", batch_name=batch_name, line_ids=line_id_specification, file_path=line_changes.path)
     return 1

--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -99,7 +99,6 @@ from ..editor import (
 )
 from ..exceptions import CommandError, exit_with_error, NoMoreHunks
 from ..i18n import _, ngettext
-from ..output import print_remaining_line_changes_header
 from ..staging.operations import (
     build_target_working_tree_buffer_from_lines,
     build_target_working_tree_buffer_with_replaced_lines,
@@ -130,7 +129,10 @@ from ..utils.paths import (
 from .include import (
     _expand_replacement_selection_ids,
 )
-from .selection.selected_hunk_refresh import recalculate_selected_hunk_for_command
+from .selection.selected_hunk_refresh import (
+    recalculate_selected_hunk_for_command,
+    refresh_selected_hunk_after_line_action,
+)
 
 
 @dataclass(frozen=True)
@@ -850,8 +852,7 @@ def command_discard_line(
             ),
             file=sys.stderr,
         )
-        print_remaining_line_changes_header(line_changes.path)
-        recalculate_selected_hunk_for_command(
+        refresh_selected_hunk_after_line_action(
             line_changes.path,
             auto_advance=auto_advance,
         )

--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -76,7 +76,7 @@ from ..data.hunk_tracking import (
     snapshot_selected_change_state,
     stream_live_git_diff,
 )
-from ..data.file_review_state import (
+from ..data.file_review.state import (
     FileReviewAction,
     clear_last_file_review_state_if_file_matches,
     finish_review_scoped_line_action,

--- a/src/git_stage_batch/commands/discard_from.py
+++ b/src/git_stage_batch/commands/discard_from.py
@@ -30,7 +30,7 @@ from ..core.text_lifecycle import (
     normalized_text_change_type,
     selected_text_discard_change_type,
 )
-from ..data.file_review_state import (
+from ..data.file_review.state import (
     FileReviewAction,
     resolve_batch_source_action_scope,
 )

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -79,7 +79,7 @@ from ..data.hunk_tracking import (
     snapshots_are_stale,
     stream_live_git_diff,
 )
-from ..data.file_review_state import (
+from ..data.file_review.state import (
     FileReviewAction,
     clear_last_file_review_state_if_file_matches,
     finish_review_scoped_line_action,

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -135,7 +135,10 @@ from ..utils.paths import (
     get_session_batch_sources_file_path,
     get_working_tree_snapshot_file_path,
 )
-from .selection.selected_hunk_refresh import recalculate_selected_hunk_for_command
+from .selection.selected_hunk_refresh import (
+    recalculate_selected_hunk_for_command,
+    refresh_selected_hunk_after_line_action,
+)
 
 
 def _update_index_for_gitlink_change(gitlink_change: GitlinkChange):
@@ -1160,8 +1163,7 @@ def command_include_line(
                 ),
                 file=sys.stderr,
             )
-            print_remaining_line_changes_header(line_changes.path)
-            recalculate_selected_hunk_for_command(
+            refresh_selected_hunk_after_line_action(
                 line_changes.path,
                 auto_advance=auto_advance,
             )

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -52,7 +52,6 @@ from ..core.line_selection import (
 from ..core.models import BinaryFileChange, GitlinkChange, RenameChange, TextFileDeletionChange
 from ..core.text_lifecycle import TextFileChangeType, detect_empty_text_lifecycle_change
 from ..data.hunk_tracking import (
-    RecalculateSelectedHunkResult,
     SelectedChangeKind,
     apply_line_level_batch_filter_to_cached_hunk,
     cache_unstaged_file_as_single_hunk,
@@ -62,7 +61,6 @@ from ..data.hunk_tracking import (
     get_selected_change_file_path,
     load_selected_change,
     read_selected_change_kind,
-    recalculate_selected_hunk_for_file,
     record_binary_hunk_skipped,
     record_gitlink_hunk_skipped,
     record_hunk_included,
@@ -137,21 +135,7 @@ from ..utils.paths import (
     get_session_batch_sources_file_path,
     get_working_tree_snapshot_file_path,
 )
-
-
-def _recalculate_selected_hunk_for_file(
-    file_path: str,
-    *,
-    auto_advance: bool | None = None,
-) -> None:
-    result = recalculate_selected_hunk_for_file(
-        file_path,
-        auto_advance=auto_advance,
-    )
-    if result == RecalculateSelectedHunkResult.SHOW_NEXT_CHANGE:
-        from .show import command_show
-
-        command_show()
+from .selection.selected_hunk_refresh import recalculate_selected_hunk_for_command
 
 
 def _update_index_for_gitlink_change(gitlink_change: GitlinkChange):
@@ -995,7 +979,7 @@ def command_include_file_as(
             restore_selected_change_state(saved_selected_state)
         else:
             write_line_ids_file(get_processed_include_ids_file_path(), set())
-            _recalculate_selected_hunk_for_file(
+            recalculate_selected_hunk_for_command(
                 target_file,
                 auto_advance=auto_advance,
             )
@@ -1177,7 +1161,7 @@ def command_include_line(
                 file=sys.stderr,
             )
             print_remaining_line_changes_header(line_changes.path)
-            _recalculate_selected_hunk_for_file(
+            recalculate_selected_hunk_for_command(
                 line_changes.path,
                 auto_advance=auto_advance,
             )
@@ -1562,7 +1546,7 @@ def command_include_line_as(
                 file=sys.stderr,
             )
             print_remaining_line_changes_header(line_changes.path)
-            _recalculate_selected_hunk_for_file(
+            recalculate_selected_hunk_for_command(
                 line_changes.path,
                 auto_advance=auto_advance,
             )
@@ -1625,7 +1609,7 @@ def command_include_line_as(
                     file=sys.stderr,
                 )
                 print_remaining_line_changes_header(target_file)
-                _recalculate_selected_hunk_for_file(
+                recalculate_selected_hunk_for_command(
                     target_file,
                     auto_advance=auto_advance,
                 )
@@ -2217,7 +2201,7 @@ def _command_include_lines_to_batch(
         print(_("✓ Included line(s) to batch '{name}': {lines}").format(name=batch_name, lines=line_id_specification), file=sys.stderr)
 
     # Recalculate and show the updated hunk for this file with batched lines filtered out
-    _recalculate_selected_hunk_for_file(line_changes.path, auto_advance=auto_advance)
+    recalculate_selected_hunk_for_command(line_changes.path, auto_advance=auto_advance)
 
 
 def _filter_selected_hunk_excluding_batched_lines(

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -21,7 +21,7 @@ from ..batch.ownership import (
     derive_replacement_line_runs_from_lines,
     translate_hunk_selection_to_batch_ownership,
 )
-from ..batch.replacement import (
+from ..core.replacement import (
     ReplacementPayload,
     coerce_replacement_payload,
 )

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -1547,8 +1547,7 @@ def command_include_line_as(
                 ),
                 file=sys.stderr,
             )
-            print_remaining_line_changes_header(line_changes.path)
-            recalculate_selected_hunk_for_command(
+            refresh_selected_hunk_after_line_action(
                 line_changes.path,
                 auto_advance=auto_advance,
             )

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -101,7 +101,7 @@ from ..editor import (
 )
 from ..exceptions import NoMoreHunks, exit_with_error
 from ..i18n import _, ngettext
-from ..output import print_line_level_changes, print_remaining_line_changes_header
+from ..output import print_line_level_changes
 from ..staging.operations import (
     build_target_index_buffer_from_lines,
     build_target_index_buffer_with_replaced_lines,
@@ -1609,8 +1609,7 @@ def command_include_line_as(
                     ),
                     file=sys.stderr,
                 )
-                print_remaining_line_changes_header(target_file)
-                recalculate_selected_hunk_for_command(
+                refresh_selected_hunk_after_line_action(
                     target_file,
                     auto_advance=auto_advance,
                 )

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -52,6 +52,7 @@ from ..core.line_selection import (
 from ..core.models import BinaryFileChange, GitlinkChange, RenameChange, TextFileDeletionChange
 from ..core.text_lifecycle import TextFileChangeType, detect_empty_text_lifecycle_change
 from ..data.hunk_tracking import (
+    RecalculateSelectedHunkResult,
     SelectedChangeKind,
     apply_line_level_batch_filter_to_cached_hunk,
     cache_unstaged_file_as_single_hunk,
@@ -136,6 +137,21 @@ from ..utils.paths import (
     get_session_batch_sources_file_path,
     get_working_tree_snapshot_file_path,
 )
+
+
+def _recalculate_selected_hunk_for_file(
+    file_path: str,
+    *,
+    auto_advance: bool | None = None,
+) -> None:
+    result = recalculate_selected_hunk_for_file(
+        file_path,
+        auto_advance=auto_advance,
+    )
+    if result == RecalculateSelectedHunkResult.SHOW_NEXT_CHANGE:
+        from .show import command_show
+
+        command_show()
 
 
 def _update_index_for_gitlink_change(gitlink_change: GitlinkChange):
@@ -979,7 +995,7 @@ def command_include_file_as(
             restore_selected_change_state(saved_selected_state)
         else:
             write_line_ids_file(get_processed_include_ids_file_path(), set())
-            recalculate_selected_hunk_for_file(
+            _recalculate_selected_hunk_for_file(
                 target_file,
                 auto_advance=auto_advance,
             )
@@ -1161,7 +1177,7 @@ def command_include_line(
                 file=sys.stderr,
             )
             print_remaining_line_changes_header(line_changes.path)
-            recalculate_selected_hunk_for_file(
+            _recalculate_selected_hunk_for_file(
                 line_changes.path,
                 auto_advance=auto_advance,
             )
@@ -1546,7 +1562,7 @@ def command_include_line_as(
                 file=sys.stderr,
             )
             print_remaining_line_changes_header(line_changes.path)
-            recalculate_selected_hunk_for_file(
+            _recalculate_selected_hunk_for_file(
                 line_changes.path,
                 auto_advance=auto_advance,
             )
@@ -1609,7 +1625,7 @@ def command_include_line_as(
                     file=sys.stderr,
                 )
                 print_remaining_line_changes_header(target_file)
-                recalculate_selected_hunk_for_file(
+                _recalculate_selected_hunk_for_file(
                     target_file,
                     auto_advance=auto_advance,
                 )
@@ -2201,7 +2217,7 @@ def _command_include_lines_to_batch(
         print(_("✓ Included line(s) to batch '{name}': {lines}").format(name=batch_name, lines=line_id_specification), file=sys.stderr)
 
     # Recalculate and show the updated hunk for this file with batched lines filtered out
-    recalculate_selected_hunk_for_file(line_changes.path, auto_advance=auto_advance)
+    _recalculate_selected_hunk_for_file(line_changes.path, auto_advance=auto_advance)
 
 
 def _filter_selected_hunk_excluding_batched_lines(

--- a/src/git_stage_batch/commands/include_from.py
+++ b/src/git_stage_batch/commands/include_from.py
@@ -46,7 +46,7 @@ from ..core.text_lifecycle import (
     normalized_text_change_type,
     selected_text_target_change_type,
 )
-from ..data.file_review_state import (
+from ..data.file_review.state import (
     FileReviewAction,
     finish_review_scoped_line_action,
     resolve_batch_source_action_scope,

--- a/src/git_stage_batch/commands/include_from.py
+++ b/src/git_stage_batch/commands/include_from.py
@@ -17,9 +17,9 @@ from ..batch.operation_candidates import (
     load_candidate_preview_state,
 )
 from ..batch.query import get_batch_commit_sha
-from ..batch.replacement import (
+from ..batch.replacement import build_replacement_batch_view_from_lines
+from ..core.replacement import (
     ReplacementPayload,
-    build_replacement_batch_view_from_lines,
     coerce_replacement_payload,
 )
 from ..batch.selection import (

--- a/src/git_stage_batch/commands/reset.py
+++ b/src/git_stage_batch/commands/reset.py
@@ -40,7 +40,7 @@ from ..batch.source_selector import require_plain_batch_name
 from ..batch.validation import batch_exists, validate_batch_name
 from ..exceptions import MergeError, exit_with_error
 from ..i18n import _
-from ..data.file_review_state import (
+from ..data.file_review.state import (
     FileReviewAction,
     ReviewSource,
     fresh_batch_review_selections_for_action,

--- a/src/git_stage_batch/commands/selection/__init__.py
+++ b/src/git_stage_batch/commands/selection/__init__.py
@@ -1,0 +1,1 @@
+"""Command-layer selection support helpers."""

--- a/src/git_stage_batch/commands/selection/selected_hunk_refresh.py
+++ b/src/git_stage_batch/commands/selection/selected_hunk_refresh.py
@@ -6,6 +6,7 @@ from ...data.hunk_tracking import (
     RecalculateSelectedHunkResult,
     recalculate_selected_hunk_for_file,
 )
+from ...output import print_remaining_line_changes_header
 
 
 def recalculate_selected_hunk_for_command(
@@ -22,3 +23,16 @@ def recalculate_selected_hunk_for_command(
         from ..show import command_show
 
         command_show()
+
+
+def refresh_selected_hunk_after_line_action(
+    file_path: str,
+    *,
+    auto_advance: bool | None = None,
+) -> None:
+    """Print the line-action boundary and refresh selected hunk state."""
+    print_remaining_line_changes_header(file_path)
+    recalculate_selected_hunk_for_command(
+        file_path,
+        auto_advance=auto_advance,
+    )

--- a/src/git_stage_batch/commands/selection/selected_hunk_refresh.py
+++ b/src/git_stage_batch/commands/selection/selected_hunk_refresh.py
@@ -1,0 +1,24 @@
+"""Command-layer selected hunk refresh helpers."""
+
+from __future__ import annotations
+
+from ...data.hunk_tracking import (
+    RecalculateSelectedHunkResult,
+    recalculate_selected_hunk_for_file,
+)
+
+
+def recalculate_selected_hunk_for_command(
+    file_path: str,
+    *,
+    auto_advance: bool | None = None,
+) -> None:
+    """Refresh selected hunk state and perform command-layer follow-up display."""
+    result = recalculate_selected_hunk_for_file(
+        file_path,
+        auto_advance=auto_advance,
+    )
+    if result == RecalculateSelectedHunkResult.SHOW_NEXT_CHANGE:
+        from ..show import command_show
+
+        command_show()

--- a/src/git_stage_batch/commands/show.py
+++ b/src/git_stage_batch/commands/show.py
@@ -39,7 +39,7 @@ from ..data.hunk_tracking import (
     write_selected_hunk_patch_lines,
     write_selected_change_kind,
 )
-from ..data.file_review_state import (
+from ..data.file_review.state import (
     clear_last_file_review_state,
     ReviewSource,
     write_last_file_review_state,

--- a/src/git_stage_batch/commands/show.py
+++ b/src/git_stage_batch/commands/show.py
@@ -7,7 +7,6 @@ import sys
 
 from ..batch.display import annotate_with_batch_source
 from ..core.diff_parser import acquire_unified_diff, build_line_changes_from_patch_lines
-from ..core.diff_parser import write_snapshots_for_selected_file_path
 from ..core.hashing import (
     compute_binary_file_hash,
     compute_gitlink_change_hash,
@@ -46,6 +45,7 @@ from ..data.file_review.state import (
 )
 from ..data.line_state import convert_line_changes_to_serializable_dict, load_line_changes_from_state
 from ..data.session import require_session_started
+from ..data.selected_change.snapshots import write_snapshots_for_selected_file_path
 from ..exceptions import exit_with_error
 from ..i18n import _
 from ..output import (

--- a/src/git_stage_batch/commands/show_from.py
+++ b/src/git_stage_batch/commands/show_from.py
@@ -50,7 +50,7 @@ from ..data.hunk_tracking import (
     mark_selected_change_cleared_by_file_list,
     render_batch_file_display,
 )
-from ..data.file_review_state import (
+from ..data.file_review.state import (
     FileReviewAction,
     ReviewSource,
     clear_last_file_review_state,

--- a/src/git_stage_batch/commands/show_from.py
+++ b/src/git_stage_batch/commands/show_from.py
@@ -20,9 +20,9 @@ from ..batch.operation_candidates import (
     render_candidate_buffer_diff,
     save_candidate_preview_state,
 )
-from ..batch.replacement import (
+from ..batch.replacement import build_replacement_batch_view_from_lines
+from ..core.replacement import (
     ReplacementPayload,
-    build_replacement_batch_view_from_lines,
     coerce_replacement_payload,
 )
 from ..batch.selection import (

--- a/src/git_stage_batch/commands/skip.py
+++ b/src/git_stage_batch/commands/skip.py
@@ -38,7 +38,7 @@ from ..data.hunk_tracking import (
     require_selected_hunk,
     stream_live_git_diff,
 )
-from ..data.file_review_state import (
+from ..data.file_review.state import (
     FileReviewAction,
     finish_review_scoped_line_action,
     refuse_ambiguous_bare_action_after_partial_file_review,

--- a/src/git_stage_batch/commands/status.py
+++ b/src/git_stage_batch/commands/status.py
@@ -18,7 +18,7 @@ from ..core.hashing import (
 )
 from ..core.diff_parser import acquire_unified_diff
 from ..core.models import BinaryFileChange, GitlinkChange, RenameChange, TextFileDeletionChange
-from ..data.file_review_state import (
+from ..data.file_review.state import (
     FileReviewAction,
     ReviewSource,
     read_last_file_review_state,

--- a/src/git_stage_batch/commands/suggest_fixup.py
+++ b/src/git_stage_batch/commands/suggest_fixup.py
@@ -8,7 +8,7 @@ import sys
 from typing import Any
 
 from ..core.line_selection import parse_line_selection
-from ..data.file_review_state import compute_current_file_review_diff_fingerprint
+from ..data.file_review.state import compute_current_file_review_diff_fingerprint
 from ..data.hunk_tracking import (
     get_selected_change_file_path,
     render_file_as_single_hunk,

--- a/src/git_stage_batch/core/diff_parser.py
+++ b/src/git_stage_batch/core/diff_parser.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import re
 from collections.abc import Callable
-from contextlib import ExitStack
 from typing import Iterable, Iterator, Union
 
 from .models import (
@@ -17,18 +16,9 @@ from .models import (
     SingleHunkPatch,
     TextFileDeletionChange,
 )
-from ..editor import (
-    EditorBuffer,
-    buffer_byte_count,
-    buffer_preview,
-    load_git_object_as_buffer,
-    write_buffer_to_path,
-)
+from ..editor import EditorBuffer
 from ..exceptions import exit_with_error
 from ..i18n import _
-from ..utils.git import get_git_repository_root_path
-from ..utils.journal import log_journal
-from ..utils.paths import get_index_snapshot_file_path, get_working_tree_snapshot_file_path
 
 
 # Type for annotator hooks that enrich LineLevelChange with additional metadata
@@ -574,78 +564,6 @@ class _UnifiedDiffParserBuildContext:
 def acquire_unified_diff(lines: Iterable[bytes]) -> _UnifiedDiffParserBuildContext:
     """Acquire a scoped unified diff parser with parser-owned hunk buffers."""
     return _UnifiedDiffParserBuildContext(lines)
-
-
-def write_snapshots_for_selected_file_path(file_path: str) -> None:
-    """Write snapshots of the file from both the index and working tree."""
-    with ExitStack() as stack:
-        index_version = load_git_object_as_buffer(f":{file_path}")
-        if index_version is None:
-            index_version = EditorBuffer.from_bytes(b"")
-        stack.enter_context(index_version)
-
-        repo_root = get_git_repository_root_path()
-        file_full_path = repo_root / file_path
-        if file_full_path.exists():
-            working_tree_version = EditorBuffer.from_path(file_full_path)
-        else:
-            working_tree_version = EditorBuffer.from_bytes(b"")
-        stack.enter_context(working_tree_version)
-
-        # When index is empty but working tree has content, check if file exists in HEAD.
-        # For new files (not in HEAD), use empty index snapshot.
-        # For existing files with intent-to-add applied, use HEAD content.
-        if buffer_byte_count(index_version) == 0 and buffer_byte_count(working_tree_version) > 0:
-            head_version = load_git_object_as_buffer(f"HEAD:{file_path}")
-            if head_version is not None:
-                if buffer_byte_count(head_version) > 0:
-                    index_version = stack.enter_context(head_version)
-                else:
-                    head_version.close()
-
-        write_buffer_to_path(get_index_snapshot_file_path(), index_version)
-        write_buffer_to_path(get_working_tree_snapshot_file_path(), working_tree_version)
-
-        log_journal(
-            "write_snapshots_for_selected_file",
-            file_path=file_path,
-            index_len=buffer_byte_count(index_version),
-            index_lines=_buffer_line_count(index_version),
-            index_preview=(
-                buffer_preview(index_version)
-                if buffer_byte_count(index_version) > 0 else
-                "(empty)"
-            ),
-            working_tree_len=buffer_byte_count(working_tree_version),
-            working_tree_lines=_buffer_line_count(working_tree_version),
-        )
-
-
-def _buffer_line_count(buffer: EditorBuffer) -> int:
-    """Return a line count for journal metadata without materializing content."""
-    line_breaks = 0
-    seen_data = False
-    pending_cr = False
-    last_byte: int | None = None
-
-    for chunk in buffer.byte_chunks():
-        if not chunk:
-            continue
-
-        seen_data = True
-        chunk_breaks = chunk.count(b"\n") + chunk.count(b"\r") - chunk.count(b"\r\n")
-        if pending_cr and chunk.startswith(b"\n"):
-            chunk_breaks -= 1
-
-        line_breaks += chunk_breaks
-        pending_cr = chunk.endswith(b"\r")
-        last_byte = chunk[-1]
-
-    if not seen_data:
-        return 0
-    if last_byte in (ord("\n"), ord("\r")):
-        return line_breaks
-    return line_breaks + 1
 
 
 def build_line_changes_from_patch_lines(

--- a/src/git_stage_batch/core/replacement.py
+++ b/src/git_stage_batch/core/replacement.py
@@ -1,0 +1,86 @@
+"""Neutral replacement text payloads and byte-line helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..utils.text import bytes_to_lines
+
+
+@dataclass(frozen=True, slots=True)
+class ReplacementPayload:
+    """Exact replacement bytes plus optional argv display text."""
+
+    data: bytes
+    display_text: str | None = None
+    exact: bool = True
+
+    @classmethod
+    def from_text(cls, text: str, *, exact: bool = True) -> "ReplacementPayload":
+        return cls(
+            text.encode("utf-8", errors="surrogateescape"),
+            display_text=text,
+            exact=exact,
+        )
+
+    @property
+    def has_trailing_lf(self) -> bool:
+        return self.data.endswith(b"\n")
+
+    def as_text(self) -> str:
+        return self.data.decode("utf-8", errors="surrogateescape")
+
+
+class ReplacementText(str):
+    """String-compatible replacement value carrying exact source bytes."""
+
+    def __new__(
+        cls,
+        text: str,
+        *,
+        data: bytes | None = None,
+        exact: bool = True,
+    ) -> "ReplacementText":
+        obj = str.__new__(cls, text)
+        obj.data = text.encode("utf-8", errors="surrogateescape") if data is None else data
+        obj.exact = exact
+        return obj
+
+
+def coerce_replacement_payload(
+    replacement: str | bytes | ReplacementPayload,
+) -> ReplacementPayload:
+    """Return exact replacement bytes for legacy str callers and new payloads."""
+    if isinstance(replacement, ReplacementPayload):
+        return replacement
+    if isinstance(replacement, ReplacementText):
+        return ReplacementPayload(
+            replacement.data,
+            display_text=str(replacement) if not replacement.exact else None,
+            exact=replacement.exact,
+        )
+    if isinstance(replacement, bytes):
+        return ReplacementPayload(replacement)
+    # Plain str is the legacy command-internal API. Preserve its historical
+    # line-oriented behavior; CLI --as-stdin uses ReplacementText for exact bytes.
+    return ReplacementPayload.from_text(replacement, exact=False)
+
+
+def replacement_line_chunks(payload: ReplacementPayload) -> list[bytes]:
+    """Split replacement bytes into exact line chunks."""
+    if not payload.exact:
+        return [line + b"\n" for line in payload.data.splitlines()]
+    return list(bytes_to_lines([payload.data]))
+
+
+def replacement_line_bodies(payload: ReplacementPayload) -> list[bytes]:
+    """Return editor line bodies while preserving CRLF as body CR bytes."""
+    if not payload.exact:
+        return payload.data.splitlines()
+    bodies: list[bytes] = []
+    for line in replacement_line_chunks(payload):
+        if line.endswith(b"\n"):
+            bodies.append(line[:-1])
+        else:
+            bodies.append(line)
+    return bodies

--- a/src/git_stage_batch/data/__init__.py
+++ b/src/git_stage_batch/data/__init__.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 from .batch_refs import restore_batch_refs, snapshot_batch_refs
 from .file_tracking import auto_add_untracked_files
-from .hunk_tracking import (
+from .progress import (
     format_id_range,
+    get_file_progress,
+    get_hunk_counts,
     record_hunk_discarded,
     record_hunk_included,
     record_hunk_skipped,
 )
-from .progress import get_file_progress, get_hunk_counts
 
 __all__ = [
     "auto_add_untracked_files",

--- a/src/git_stage_batch/data/batch_selected_changes.py
+++ b/src/git_stage_batch/data/batch_selected_changes.py
@@ -1,0 +1,138 @@
+"""Selected atomic batch changes and stale-selection validation."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from hashlib import sha256
+
+from ..batch.query import get_batch_commit_sha
+from ..exceptions import exit_with_error
+from ..i18n import _
+from ..utils.git import run_git_command
+from .selected_change.lifecycle import clear_selected_change_state_files
+from .selected_change.store import (
+    SelectedChangeKind,
+    load_selected_binary_file,
+    mark_selected_change_cleared_by_stale_batch_selection,
+    read_selected_binary_data,
+    read_selected_change_kind,
+)
+
+
+def compute_batch_binary_fingerprint(
+    batch_name: str,
+    file_path: str,
+    file_meta: Mapping[str, object],
+) -> str:
+    """Return a stable identity for the current binary content stored in a batch."""
+    batch_blob = None
+    if file_meta.get("change_type") != "deleted":
+        batch_commit = get_batch_commit_sha(batch_name)
+        if batch_commit is not None:
+            blob_result = run_git_command(
+                ["rev-parse", "--verify", f"{batch_commit}:{file_path}"],
+                check=False,
+                requires_index_lock=False,
+            )
+            if blob_result.returncode == 0:
+                batch_blob = blob_result.stdout.strip()
+
+    payload = {
+        "file_path": file_path,
+        "file_type": file_meta.get("file_type"),
+        "change_type": file_meta.get("change_type"),
+        "mode": file_meta.get("mode"),
+        "batch_source_commit": file_meta.get("batch_source_commit"),
+        "batch_blob": batch_blob,
+    }
+    data = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return sha256(data.encode("utf-8", errors="surrogateescape")).hexdigest()
+
+
+def selected_batch_binary_matches_batch(batch_name: str) -> bool:
+    """Return whether the cached batch-binary selection came from this batch."""
+    if read_selected_change_kind() != SelectedChangeKind.BATCH_BINARY:
+        return False
+    binary_data = read_selected_binary_data()
+    if binary_data is None:
+        return False
+    return binary_data.get("batch_name") == batch_name
+
+
+def selected_batch_binary_batch_name() -> str | None:
+    """Return the source batch name for the cached batch-binary selection."""
+    if read_selected_change_kind() != SelectedChangeKind.BATCH_BINARY:
+        return None
+    binary_data = read_selected_binary_data()
+    if binary_data is None:
+        return None
+    batch_name = binary_data.get("batch_name")
+    return batch_name if isinstance(batch_name, str) else None
+
+
+def selected_batch_binary_file_for_batch(
+    batch_name: str,
+    all_files: Mapping[str, dict],
+) -> str | None:
+    """Return the selected batch-binary file if it still exists in batch metadata."""
+    if not selected_batch_binary_matches_batch(batch_name):
+        return None
+
+    binary_file = load_selected_binary_file()
+    if binary_file is None:
+        return None
+
+    file_path = binary_file.new_path if binary_file.new_path != "/dev/null" else binary_file.old_path
+    file_meta = all_files.get(file_path)
+    if file_meta is None:
+        return None
+    if file_meta.get("file_type") != "binary":
+        return None
+    if file_meta.get("change_type") != binary_file.change_type:
+        return None
+
+    binary_data = read_selected_binary_data()
+    if binary_data is None:
+        return None
+    cached_fingerprint = binary_data.get("batch_binary_fingerprint")
+    if not isinstance(cached_fingerprint, str):
+        return None
+    current_fingerprint = compute_batch_binary_fingerprint(batch_name, file_path, file_meta)
+    if current_fingerprint != cached_fingerprint:
+        return None
+
+    return file_path
+
+
+def require_current_selected_batch_binary_file_for_batch(
+    batch_name: str,
+    all_files: Mapping[str, dict],
+) -> str | None:
+    """Return selected batch-binary file for this batch, or refuse if it went stale."""
+    if not selected_batch_binary_matches_batch(batch_name):
+        return None
+
+    selected_file = selected_batch_binary_file_for_batch(batch_name, all_files)
+    if selected_file is not None:
+        return selected_file
+
+    binary_file = load_selected_binary_file()
+    file_path = (
+        binary_file.new_path
+        if binary_file is not None and binary_file.new_path != "/dev/null" else
+        binary_file.old_path
+        if binary_file is not None else
+        "the selected batch binary"
+    )
+    clear_selected_change_state_files()
+    mark_selected_change_cleared_by_stale_batch_selection(
+        batch_name=batch_name,
+        file_path=file_path,
+    )
+    exit_with_error(
+        _(
+            "The selected batch binary no longer matches batch '{name}'.\n"
+            "Show the batch again before using a pathless batch action."
+        ).format(name=batch_name)
+    )

--- a/src/git_stage_batch/data/file_review/__init__.py
+++ b/src/git_stage_batch/data/file_review/__init__.py
@@ -1,0 +1,1 @@
+"""File review persistence and validation state."""

--- a/src/git_stage_batch/data/file_review/state.py
+++ b/src/git_stage_batch/data/file_review/state.py
@@ -11,20 +11,20 @@ from hashlib import sha256
 from pathlib import Path
 from typing import Any
 
-from ..core.actionable_changes import ActionableSelectionReason
-from ..core.line_selection import LineRanges, LineSelection, parse_line_selection_ranges
-from ..core.models import ReviewActionGroup
-from ..data.line_state import convert_line_changes_to_serializable_dict, load_line_changes_from_state
-from ..editor import EditorBuffer
-from ..exceptions import CommandError
-from ..i18n import _
-from ..utils.file_io import read_text_file_contents, write_text_file_contents
-from ..utils.paths import (
+from ...core.actionable_changes import ActionableSelectionReason
+from ...core.line_selection import LineRanges, LineSelection, parse_line_selection_ranges
+from ...core.models import ReviewActionGroup
+from ..line_state import convert_line_changes_to_serializable_dict, load_line_changes_from_state
+from ...editor import EditorBuffer
+from ...exceptions import CommandError
+from ...i18n import _
+from ...utils.file_io import read_text_file_contents, write_text_file_contents
+from ...utils.paths import (
     get_index_snapshot_file_path,
     get_last_file_review_state_file_path,
     get_working_tree_snapshot_file_path,
 )
-from .hunk_tracking import SelectedChangeKind, get_selected_change_file_path, read_selected_change_kind
+from ..hunk_tracking import SelectedChangeKind, get_selected_change_file_path, read_selected_change_kind
 
 
 class ReviewSource(str, Enum):
@@ -292,7 +292,7 @@ def resolve_batch_source_action_scope(
     extra_action_parts: tuple[str, ...] = (),
 ) -> ActionScopeResolution:
     """Resolve pathless and implicit-file batch actions against the last batch review."""
-    from .hunk_tracking import (
+    from ..hunk_tracking import (
         refuse_bare_action_after_file_list,
         refuse_bare_action_after_stale_batch_selection,
     )
@@ -402,7 +402,7 @@ def selected_change_matches_review_state(review_state: FileReviewState) -> bool:
     gutter_to_selection_id = None
     line_changes = None
     if review_state.source == ReviewSource.BATCH and review_state.batch_name is not None:
-        from .hunk_tracking import render_batch_file_display
+        from ..hunk_tracking import render_batch_file_display
 
         rendered = render_batch_file_display(review_state.batch_name, review_state.file_path)
         if rendered is None:
@@ -415,7 +415,7 @@ def selected_change_matches_review_state(review_state: FileReviewState) -> bool:
         review_action_groups = rendered.review_action_groups or None
         line_changes = rendered.line_changes
     else:
-        from .hunk_tracking import snapshots_are_stale
+        from ..hunk_tracking import snapshots_are_stale
 
         if snapshots_are_stale(review_state.file_path):
             return False
@@ -450,7 +450,7 @@ def selected_batch_review_matches_reset_state(review_state: FileReviewState) -> 
     if get_selected_change_file_path() != review_state.file_path:
         return False
 
-    from .hunk_tracking import render_batch_file_display
+    from ..hunk_tracking import render_batch_file_display
 
     rendered = render_batch_file_display(review_state.batch_name, review_state.file_path)
     if rendered is None:
@@ -512,7 +512,7 @@ def _review_state_matches_action(
 
 
 def _format_pages(pages: set[int]) -> str:
-    from ..core.line_selection import format_line_ids
+    from ...core.line_selection import format_line_ids
 
     return format_line_ids(sorted(pages))
 
@@ -826,7 +826,7 @@ def validate_implicit_live_to_batch_file_action(
     use that explicit file path. The boolean is true when the caller should stop
     after a live-action guard handled the request.
     """
-    from .hunk_tracking import (
+    from ..hunk_tracking import (
         refuse_bare_action_after_auto_advance_disabled,
         refuse_bare_action_after_file_list,
     )
@@ -875,7 +875,7 @@ def resolve_live_to_batch_action_scope(
     file: str | None,
 ) -> ActionScopeResolution:
     """Resolve pathless and implicit-file live-to-batch actions against live reviews."""
-    from .hunk_tracking import (
+    from ..hunk_tracking import (
         refuse_bare_action_after_auto_advance_disabled,
         refuse_bare_action_after_file_list,
     )
@@ -938,7 +938,7 @@ def resolve_live_line_action_scope(
     validate_pathless_before_live_guard: bool = False,
 ) -> ActionScopeResolution:
     """Validate a pathless or implicit-file live line action against review state."""
-    from .hunk_tracking import (
+    from ..hunk_tracking import (
         refuse_bare_action_after_auto_advance_disabled,
         refuse_bare_action_after_file_list,
     )

--- a/src/git_stage_batch/data/file_review/state.py
+++ b/src/git_stage_batch/data/file_review/state.py
@@ -24,7 +24,7 @@ from ...utils.paths import (
     get_last_file_review_state_file_path,
     get_working_tree_snapshot_file_path,
 )
-from ..hunk_tracking import SelectedChangeKind, get_selected_change_file_path, read_selected_change_kind
+from ..selected_change.store import SelectedChangeKind, read_selected_change_kind
 
 
 class ReviewSource(str, Enum):
@@ -124,6 +124,12 @@ def _hash_file(path: Path) -> str | None:
         for chunk in buffer.byte_chunks():
             digest.update(chunk)
     return digest.hexdigest()
+
+
+def _get_selected_change_file_path() -> str | None:
+    from ..selected_change.store import get_selected_change_file_path
+
+    return get_selected_change_file_path()
 
 
 def fingerprint_selected_file_view(
@@ -292,7 +298,7 @@ def resolve_batch_source_action_scope(
     extra_action_parts: tuple[str, ...] = (),
 ) -> ActionScopeResolution:
     """Resolve pathless and implicit-file batch actions against the last batch review."""
-    from ..hunk_tracking import (
+    from ..selected_change.store import (
         refuse_bare_action_after_file_list,
         refuse_bare_action_after_stale_batch_selection,
     )
@@ -395,7 +401,7 @@ def selected_change_matches_review_state(review_state: FileReviewState) -> bool:
     selected_kind = read_selected_change_kind()
     if not selected_change_kind_matches_review_source(selected_kind, review_state):
         return False
-    if get_selected_change_file_path() != review_state.file_path:
+    if _get_selected_change_file_path() != review_state.file_path:
         return False
     if selected_kind is None:
         return False
@@ -447,7 +453,7 @@ def selected_batch_review_matches_reset_state(review_state: FileReviewState) -> 
         return False
     if not selected_change_kind_matches_review_source(selected_kind, review_state):
         return False
-    if get_selected_change_file_path() != review_state.file_path:
+    if _get_selected_change_file_path() != review_state.file_path:
         return False
 
     from ..hunk_tracking import render_batch_file_display
@@ -702,7 +708,7 @@ def refuse_live_action_for_batch_selection(action: FileReviewAction | str) -> bo
             )
         raise CommandError("\n".join(lines))
 
-    file_path = get_selected_change_file_path() or _("the selected file")
+    file_path = _get_selected_change_file_path() or _("the selected file")
     raise CommandError(
         _(
             "The selected file view for {file} came from a batch, not the live working tree.\n"
@@ -826,7 +832,7 @@ def validate_implicit_live_to_batch_file_action(
     use that explicit file path. The boolean is true when the caller should stop
     after a live-action guard handled the request.
     """
-    from ..hunk_tracking import (
+    from ..selected_change.store import (
         refuse_bare_action_after_auto_advance_disabled,
         refuse_bare_action_after_file_list,
     )
@@ -875,7 +881,7 @@ def resolve_live_to_batch_action_scope(
     file: str | None,
 ) -> ActionScopeResolution:
     """Resolve pathless and implicit-file live-to-batch actions against live reviews."""
-    from ..hunk_tracking import (
+    from ..selected_change.store import (
         refuse_bare_action_after_auto_advance_disabled,
         refuse_bare_action_after_file_list,
     )
@@ -938,7 +944,7 @@ def resolve_live_line_action_scope(
     validate_pathless_before_live_guard: bool = False,
 ) -> ActionScopeResolution:
     """Validate a pathless or implicit-file live line action against review state."""
-    from ..hunk_tracking import (
+    from ..selected_change.store import (
         refuse_bare_action_after_auto_advance_disabled,
         refuse_bare_action_after_file_list,
     )

--- a/src/git_stage_batch/data/file_review/state.py
+++ b/src/git_stage_batch/data/file_review/state.py
@@ -26,6 +26,7 @@ from ...utils.paths import (
 )
 from ...batch import file_display
 from ..selected_change.store import SelectedChangeKind, read_selected_change_kind
+from ..selected_change.snapshots import snapshots_are_stale
 
 
 class ReviewSource(str, Enum):
@@ -423,8 +424,6 @@ def selected_change_matches_review_state(review_state: FileReviewState) -> bool:
         review_action_groups = rendered.review_action_groups or None
         line_changes = rendered.line_changes
     else:
-        from ..hunk_tracking import snapshots_are_stale
-
         if snapshots_are_stale(review_state.file_path):
             return False
         actionable_selection_groups = None

--- a/src/git_stage_batch/data/file_review/state.py
+++ b/src/git_stage_batch/data/file_review/state.py
@@ -24,6 +24,7 @@ from ...utils.paths import (
     get_last_file_review_state_file_path,
     get_working_tree_snapshot_file_path,
 )
+from ...batch import file_display
 from ..selected_change.store import SelectedChangeKind, read_selected_change_kind
 
 
@@ -408,9 +409,10 @@ def selected_change_matches_review_state(review_state: FileReviewState) -> bool:
     gutter_to_selection_id = None
     line_changes = None
     if review_state.source == ReviewSource.BATCH and review_state.batch_name is not None:
-        from ..hunk_tracking import render_batch_file_display
-
-        rendered = render_batch_file_display(review_state.batch_name, review_state.file_path)
+        rendered = file_display.render_batch_file_display(
+            review_state.batch_name,
+            review_state.file_path,
+        )
         if rendered is None:
             return False
         gutter_to_selection_id = (
@@ -456,9 +458,10 @@ def selected_batch_review_matches_reset_state(review_state: FileReviewState) -> 
     if _get_selected_change_file_path() != review_state.file_path:
         return False
 
-    from ..hunk_tracking import render_batch_file_display
-
-    rendered = render_batch_file_display(review_state.batch_name, review_state.file_path)
+    rendered = file_display.render_batch_file_display(
+        review_state.batch_name,
+        review_state.file_path,
+    )
     if rendered is None:
         return False
     if (

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -6,7 +6,6 @@ import json
 import tempfile
 import subprocess
 import sys
-from contextlib import ExitStack
 from hashlib import sha256
 from typing import Generator, Mapping, Optional, Union
 
@@ -37,7 +36,6 @@ from ..core.diff_parser import (
 )
 from ..editor import (
     EditorBuffer,
-    buffer_matches,
     load_git_object_as_buffer,
 )
 from ..core.line_selection import write_line_ids_file
@@ -66,7 +64,10 @@ from .progress import (
     record_rename_hunk_skipped as record_rename_hunk_skipped,
     record_text_deletion_hunk_skipped as record_text_deletion_hunk_skipped,
 )
-from .selected_change.snapshots import write_snapshots_for_selected_file_path
+from .selected_change.snapshots import (
+    snapshots_are_stale as snapshots_are_stale,
+    write_snapshots_for_selected_file_path,
+)
 from ..utils.file_io import (
     is_path_blocked,
     read_file_paths_file,
@@ -75,7 +76,6 @@ from ..utils.file_io import (
     write_text_file_contents,
 )
 from ..utils.git import (
-    get_git_repository_root_path,
     run_git_command,
     stream_git_command,
     stream_git_diff,
@@ -1355,53 +1355,6 @@ def select_next_change_after_action(
     return False
 
 
-
-
-def snapshots_are_stale(file_path: str) -> bool:
-    """Check if cached snapshots are stale (file changed since snapshots taken).
-
-    Args:
-        file_path: Repository-relative path to check
-
-    Returns:
-        True if the file has been committed or otherwise changed such that
-        the cached hunk no longer applies
-    """
-    snapshot_base_path = get_index_snapshot_file_path()
-    snapshot_new_path = get_working_tree_snapshot_file_path()
-
-    # Missing snapshots means state is incomplete/stale
-    if not snapshot_base_path.exists() or not snapshot_new_path.exists():
-        return True
-
-    try:
-        with ExitStack() as stack:
-            cached_index_content = stack.enter_context(
-                EditorBuffer.from_path(snapshot_base_path)
-            )
-            cached_worktree_content = stack.enter_context(
-                EditorBuffer.from_path(snapshot_new_path)
-            )
-
-            selected_index_content = load_git_object_as_buffer(f":{file_path}")
-            if selected_index_content is None:
-                selected_index_content = EditorBuffer.from_bytes(b"")
-            stack.enter_context(selected_index_content)
-
-            repo_root = get_git_repository_root_path()
-            file_full_path = repo_root / file_path
-            if file_full_path.exists():
-                selected_worktree_content = EditorBuffer.from_path(file_full_path)
-            else:
-                selected_worktree_content = EditorBuffer.from_bytes(b"")
-            stack.enter_context(selected_worktree_content)
-
-            return (
-                not buffer_matches(cached_index_content, selected_index_content)
-                or not buffer_matches(cached_worktree_content, selected_worktree_content)
-            )
-    except Exception:
-        return True  # Error reading means state is stale
 
 
 def require_selected_hunk() -> None:

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -237,7 +237,7 @@ def restore_selected_change_state(snapshot: SelectedChangeStateSnapshot) -> None
 
 def clear_selected_change_state_files() -> None:
     """Clear all cached selected hunk state files."""
-    from .file_review_state import clear_last_file_review_state
+    from .file_review.state import clear_last_file_review_state
 
     for path in _selected_change_state_paths().values():
         path.unlink(missing_ok=True)

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -65,6 +65,17 @@ from ..output import (
 from .consumed_selections import read_consumed_file_metadata
 from .auto_advance import resolve_auto_advance
 from .file_tracking import auto_add_untracked_files
+from .progress import (
+    format_id_range as format_id_range,
+    record_binary_hunk_skipped as record_binary_hunk_skipped,
+    record_gitlink_hunk_skipped as record_gitlink_hunk_skipped,
+    record_hunk_discarded as record_hunk_discarded,
+    record_hunk_included as record_hunk_included,
+    record_hunk_skipped as record_hunk_skipped,
+    record_hunks_discarded as record_hunks_discarded,
+    record_rename_hunk_skipped as record_rename_hunk_skipped,
+    record_text_deletion_hunk_skipped as record_text_deletion_hunk_skipped,
+)
 from .selected_change.snapshots import write_snapshots_for_selected_file_path
 from ..utils.file_io import (
     is_path_blocked,
@@ -87,9 +98,6 @@ from ..utils.paths import (
     get_selected_hunk_hash_file_path,
     get_selected_hunk_patch_file_path,
     get_line_changes_json_file_path,
-    get_discarded_hunks_file_path,
-    get_included_hunks_file_path,
-    get_skipped_hunks_jsonl_file_path,
     get_index_snapshot_file_path,
     get_processed_include_ids_file_path,
     get_processed_skip_ids_file_path,
@@ -1886,157 +1894,3 @@ def recalculate_selected_hunk_for_file(
         command_show()
     else:
         mark_selected_change_cleared_by_auto_advance_disabled()
-
-def record_hunk_included(hunk_hash: str) -> None:
-    """Record that a hunk was included (staged)."""
-    included_path = get_included_hunks_file_path()
-    existing = read_text_file_line_set(included_path)
-    existing.add(hunk_hash)
-    write_text_file_contents(included_path, "\n".join(sorted(existing)) + "\n" if existing else "")
-
-
-def record_hunk_discarded(hunk_hash: str) -> None:
-    """Record that a hunk was discarded (removed from working tree)."""
-    record_hunks_discarded([hunk_hash])
-
-
-def record_hunks_discarded(hunk_hashes: list[str]) -> None:
-    """Record that hunks were discarded (removed from working tree)."""
-    new_hashes = {hunk_hash for hunk_hash in hunk_hashes if hunk_hash}
-    if not new_hashes:
-        return
-    discarded_path = get_discarded_hunks_file_path()
-    existing = read_text_file_line_set(discarded_path)
-    existing.update(new_hashes)
-    write_text_file_contents(discarded_path, "\n".join(sorted(existing)) + "\n" if existing else "")
-
-
-def record_hunk_skipped(line_changes: LineLevelChange, hunk_hash: str) -> None:
-    """Record that a hunk was skipped with metadata for display.
-
-    Args:
-        line_changes: Current hunk's lines
-        hunk_hash: SHA-1 hash of the hunk
-    """
-    # Extract first changed line number for display
-    first_changed_line = None
-    for entry in line_changes.lines:
-        if entry.kind != " ":  # Not context
-            first_changed_line = entry.old_line_number or entry.new_line_number
-            break
-
-    # Build metadata object
-    metadata = {
-        "hash": hunk_hash,
-        "file": line_changes.path,
-        "line": first_changed_line or 0,
-        "ids": line_changes.changed_line_ids()
-    }
-
-    # Append to JSONL file
-    jsonl_path = get_skipped_hunks_jsonl_file_path()
-    with jsonl_path.open("a", encoding="utf-8") as f:
-        f.write(json.dumps(metadata) + "\n")
-
-
-def record_binary_hunk_skipped(binary_change: BinaryFileChange, hunk_hash: str) -> None:
-    """Record that a binary change was skipped with file-level metadata."""
-    file_path = binary_change.new_path if binary_change.new_path != "/dev/null" else binary_change.old_path
-    metadata = {
-        "hash": hunk_hash,
-        "file": file_path,
-        "line": None,
-        "ids": [],
-        "change_type": binary_change.change_type,
-    }
-
-    jsonl_path = get_skipped_hunks_jsonl_file_path()
-    with jsonl_path.open("a", encoding="utf-8") as f:
-        f.write(json.dumps(metadata) + "\n")
-
-
-def record_gitlink_hunk_skipped(gitlink_change: GitlinkChange, hunk_hash: str) -> None:
-    """Record that a gitlink change was skipped with file-level metadata."""
-    metadata = {
-        "hash": hunk_hash,
-        "file": gitlink_change.path(),
-        "line": None,
-        "ids": [],
-        "type": "submodule",
-        "change_type": gitlink_change.change_type,
-        "old_oid": gitlink_change.old_oid,
-        "new_oid": gitlink_change.new_oid,
-    }
-
-    jsonl_path = get_skipped_hunks_jsonl_file_path()
-    with jsonl_path.open("a", encoding="utf-8") as f:
-        f.write(json.dumps(metadata) + "\n")
-
-
-def record_rename_hunk_skipped(rename_change: RenameChange, hunk_hash: str) -> None:
-    """Record that a rename change was skipped with file-level metadata."""
-    metadata = {
-        "hash": hunk_hash,
-        "file": rename_change.new_path,
-        "line": None,
-        "ids": [],
-        "type": "rename",
-        "old_path": rename_change.old_path,
-        "new_path": rename_change.new_path,
-    }
-
-    jsonl_path = get_skipped_hunks_jsonl_file_path()
-    with jsonl_path.open("a", encoding="utf-8") as f:
-        f.write(json.dumps(metadata) + "\n")
-
-
-def record_text_deletion_hunk_skipped(deletion_change: TextFileDeletionChange, hunk_hash: str) -> None:
-    """Record that a whole-text-file deletion was skipped with file-level metadata."""
-    metadata = {
-        "hash": hunk_hash,
-        "file": deletion_change.path(),
-        "line": None,
-        "ids": [],
-        "type": "text-deletion",
-        "change_type": "deleted",
-    }
-
-    jsonl_path = get_skipped_hunks_jsonl_file_path()
-    with jsonl_path.open("a", encoding="utf-8") as f:
-        f.write(json.dumps(metadata) + "\n")
-
-
-def format_id_range(ids: list[int]) -> str:
-    """Format list of IDs as compact range string (e.g., '1-5,7,9-11').
-
-    Args:
-        ids: List of integer IDs
-
-    Returns:
-        Compact range string
-    """
-    if not ids:
-        return ""
-
-    ids = sorted(ids)
-    ranges = []
-    start = ids[0]
-    end = ids[0]
-
-    for i in range(1, len(ids)):
-        if ids[i] == end + 1:
-            end = ids[i]
-        else:
-            if start == end:
-                ranges.append(str(start))
-            else:
-                ranges.append(f"{start}-{end}")
-            start = end = ids[i]
-
-    # Add final range
-    if start == end:
-        ranges.append(str(start))
-    else:
-        ranges.append(f"{start}-{end}")
-
-    return ",".join(ranges)

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -11,16 +11,7 @@ from hashlib import sha256
 from typing import Generator, Mapping, Optional, Union
 
 from ..batch.attribution import build_file_attribution, filter_owned_diff_fragments
-from ..batch import display as batch_display
-from ..batch import merge as batch_merge
 from ..batch.display import annotate_with_batch_source
-from ..batch.match import match_lines
-from ..batch.ownership import (
-    BatchOwnership,
-    build_ownership_units_from_display_lines,
-    rebuild_ownership_from_units,
-    validate_ownership_units,
-)
 from ..batch.query import get_batch_commit_sha, list_batch_names, read_batch_metadata
 from ..core.hashing import (
     compute_binary_file_hash,
@@ -37,7 +28,6 @@ from ..core.models import (
     LineEntry,
     RenameChange,
     RenderedBatchDisplay,
-    ReviewActionGroup,
     TextFileDeletionChange,
 )
 from ..core.text_lifecycle import detect_empty_text_lifecycle_change
@@ -49,11 +39,10 @@ from ..editor import (
     EditorBuffer,
     buffer_matches,
     load_git_object_as_buffer,
-    load_working_tree_file_as_buffer,
 )
-from ..core.line_selection import LineRanges, write_line_ids_file
+from ..core.line_selection import write_line_ids_file
 from ..core.line_identity import preserve_line_ids_from_previous_view
-from ..exceptions import CommandError, MergeError, NoMoreHunks, exit_with_error
+from ..exceptions import CommandError, NoMoreHunks, exit_with_error
 from ..i18n import _, ngettext
 from ..output import (
     print_line_level_changes,
@@ -64,6 +53,7 @@ from ..output import (
 )
 from .consumed_selections import read_consumed_file_metadata
 from .auto_advance import resolve_auto_advance
+from ..batch.file_display import render_batch_file_display as render_batch_file_display
 from .file_tracking import auto_add_untracked_files
 from .progress import (
     format_id_range as format_id_range,
@@ -90,7 +80,7 @@ from ..utils.git import (
     stream_git_command,
     stream_git_diff,
 )
-from ..utils.text import bytes_to_lines, normalize_line_sequence_endings
+from ..utils.text import bytes_to_lines
 from ..utils.paths import (
     get_block_list_file_path,
     get_blocked_files_file_path,
@@ -607,314 +597,6 @@ def _filter_consumed_replacement_masks(
     )
 
 
-def render_batch_file_display(
-    batch_name: str,
-    file_path: str,
-    metadata: dict | None = None,
-    *,
-    probe_mergeability: bool = True,
-) -> Optional['RenderedBatchDisplay']:
-    """Pure function to render batch file display with gutter ID translation.
-
-    This is a side-effect-free helper that:
-    - Reads batch metadata
-    - Reads batch source content
-    - Reads current working tree content
-    - Probes individual line mergeability
-    - Builds LineLevelChange with original selection IDs
-    - Builds gutter ID mappings
-
-    It does not:
-    - Write cache files
-    - Mutate selected hunk state
-    - Compute patch hashes
-
-    Args:
-        batch_name: Name of the batch
-        file_path: Specific file to render
-        probe_mergeability: If True, compute which batch lines are currently
-            mergeable. Multi-file navigational previews can set this to False
-            because they do not cache or act on individual lines.
-
-    Returns:
-        RenderedBatchDisplay with line changes and gutter ID translation, or None if file not found.
-    """
-    # Read batch metadata
-    if metadata is None:
-        metadata = read_batch_metadata(batch_name)
-    files = metadata.get("files", {})
-
-    if not files or file_path not in files:
-        return None
-
-    file_meta = files[file_path]
-
-    # Get batch source commit and ownership
-    batch_source_commit = file_meta["batch_source_commit"]
-    with BatchOwnership.acquire_for_metadata_dict(file_meta) as ownership:
-        return _render_batch_file_display_from_ownership(
-            batch_source_commit=batch_source_commit,
-            file_path=file_path,
-            file_meta=file_meta,
-            ownership=ownership,
-            probe_mergeability=probe_mergeability,
-        )
-
-
-def _render_batch_file_display_from_ownership(
-    *,
-    batch_source_commit: str,
-    file_path: str,
-    file_meta: dict,
-    ownership: BatchOwnership,
-    probe_mergeability: bool,
-) -> Optional['RenderedBatchDisplay']:
-    """Render batch file display from already-acquired ownership metadata."""
-
-    batch_source_buffer = load_git_object_as_buffer(
-        f"{batch_source_commit}:{file_path}"
-    )
-    if batch_source_buffer is None:
-        return None
-
-    mergeable_id_range_parts: list[tuple[int, int]] = []
-    mergeable_id_ranges = LineRanges.empty()
-    units = []
-
-    with batch_source_buffer as batch_source_lines:
-        # Build display lines (already has correct line IDs matching ownership)
-        display_lines = batch_display.build_display_lines_from_batch_source_lines(
-            batch_source_lines,
-            ownership,
-            context_lines=get_context_lines(),
-        )
-
-        if probe_mergeability and display_lines:
-            source_match_lines = normalize_line_sequence_endings(batch_source_lines)
-            working_tree_buffer = load_working_tree_file_as_buffer(file_path)
-            with working_tree_buffer as working_tree_lines:
-                working_match_lines = normalize_line_sequence_endings(working_tree_lines)
-                with match_lines(
-                    source_match_lines,
-                    working_match_lines,
-                ) as source_to_working_mapping:
-
-                    units = build_ownership_units_from_display_lines(
-                        ownership,
-                        display_lines,
-                    )
-
-                    # Check each ownership unit once. All lines in an atomic unit
-                    # share the same mergeability result.
-                    for unit in units:
-                        try:
-                            validate_ownership_units([unit])
-                            ownership_for_unit = rebuild_ownership_from_units([unit])
-                            if ownership_for_unit.is_empty():
-                                continue
-                            if not batch_merge.can_merge_batch_from_line_sequences(
-                                source_match_lines,
-                                ownership_for_unit,
-                                working_match_lines,
-                                source_to_working_mapping=source_to_working_mapping,
-                            ):
-                                continue
-                            mergeable_id_range_parts.extend(unit.display_line_ids.ranges())
-                        except (MergeError, ValueError, KeyError, Exception):
-                            # Unit not mergeable - exclude all its lines
-                            pass
-
-                    mergeable_id_ranges = LineRanges.from_ranges(mergeable_id_range_parts)
-
-    if not display_lines:
-        change_type = file_meta.get("change_type", "modified")
-        if change_type in {"added", "deleted"}:
-            marker_kind = "+" if change_type == "added" else "-"
-            line_changes = LineLevelChange(
-                path=file_path,
-                header=HunkHeader(
-                    old_start=0 if change_type == "added" else 1,
-                    old_len=0 if change_type == "added" else 1,
-                    new_start=1 if change_type == "added" else 0,
-                    new_len=1 if change_type == "added" else 0,
-                ),
-                lines=[
-                    LineEntry(
-                        id=1,
-                        kind=marker_kind,
-                        old_line_number=1 if change_type == "deleted" else None,
-                        new_line_number=1 if change_type == "added" else None,
-                        text_bytes=b"<empty file>",
-                        source_line=None,
-                    )
-                ],
-            )
-            return RenderedBatchDisplay(
-                line_changes=line_changes,
-                gutter_to_selection_id={},
-                selection_id_to_gutter={},
-                actionable_selection_groups=(),
-            )
-        return None
-
-    # Keep original selection IDs; mergeability is stored separately.
-    line_entries = []
-    new_line_num = 1
-
-    for display_line in display_lines:
-        line_id = display_line["id"]  # Keep original selection ID
-        content = display_line["content"]
-
-        # Convert string content to bytes (encode as UTF-8)
-        content_bytes = content.encode('utf-8')
-        # Strip only the newline terminator, preserve \r
-        text_bytes = content_bytes.rstrip(b'\n')
-        has_trailing_newline = content_bytes.endswith(b'\n')
-
-        if display_line["type"] == "claimed":
-            # Claimed line from batch source
-            source_line = display_line["source_line"]
-            line_entries.append(LineEntry(
-                id=line_id,
-                kind="+",
-                old_line_number=None,
-                new_line_number=new_line_num,
-                text_bytes=text_bytes,
-                source_line=source_line,
-                has_trailing_newline=has_trailing_newline,
-            ))
-            new_line_num += 1
-        elif display_line["type"] == "deletion":
-            # Deletion (suppression constraint - show as deletion for display)
-            line_entries.append(LineEntry(
-                id=line_id,
-                kind="-",
-                old_line_number=None,  # Not from old file (it's a constraint)
-                new_line_number=None,
-                text_bytes=text_bytes,
-                source_line=None,
-                has_trailing_newline=has_trailing_newline,
-            ))
-        elif display_line["type"] == "context":
-            line_entries.append(LineEntry(
-                id=None,
-                kind=" ",
-                old_line_number=None,
-                new_line_number=new_line_num,
-                text_bytes=text_bytes,
-                source_line=display_line["source_line"],
-                has_trailing_newline=has_trailing_newline,
-            ))
-            new_line_num += 1
-        elif display_line["type"] == "gap":
-            line_entries.append(LineEntry(
-                id=None,
-                kind=" ",
-                old_line_number=None,
-                new_line_number=None,
-                text_bytes=text_bytes,
-                source_line=None,
-                has_trailing_newline=has_trailing_newline,
-            ))
-
-    # Compute header based on actual line types
-    addition_count = sum(1 for e in line_entries if e.kind == "+")
-    deletion_count = sum(1 for e in line_entries if e.kind == "-")
-
-    # Create hunk header
-    header = HunkHeader(
-        old_start=0 if deletion_count == 0 else 1,
-        old_len=deletion_count,
-        new_start=0 if addition_count == 0 else 1,
-        new_len=addition_count
-    )
-
-    line_changes = LineLevelChange(
-        path=file_path,
-        header=header,
-        lines=line_entries
-    )
-
-    # Build gutter ID mappings
-    # Only mergeable lines get consecutive gutter IDs (1, 2, 3...)
-    gutter_to_selection_id = {}
-    selection_id_to_gutter = {}
-    gutter_num = 1
-    for entry in line_entries:
-        if entry.id is not None and entry.id in mergeable_id_ranges:
-            gutter_to_selection_id[gutter_num] = entry.id
-            selection_id_to_gutter[entry.id] = gutter_num
-            gutter_num += 1
-
-    line_id_display_order = [
-        entry.id
-        for entry in line_entries
-        if entry.id is not None
-    ]
-    resettable_ids = LineRanges.from_ranges(
-        display_id_range
-        for unit in units
-        for display_id_range in unit.display_line_ids.ranges()
-    )
-    review_gutter_to_selection_id = {}
-    review_selection_id_to_gutter = {}
-    review_gutter_num = 1
-    for entry in line_entries:
-        if entry.id is not None and entry.id in resettable_ids:
-            review_gutter_to_selection_id[review_gutter_num] = entry.id
-            review_selection_id_to_gutter[entry.id] = review_gutter_num
-            review_gutter_num += 1
-
-    actionable_selection_groups = []
-    review_action_groups = []
-    for unit in units:
-        if not unit.display_line_ids:
-            continue
-        ordered_group = tuple(
-            line_id
-            for line_id in line_id_display_order
-            if line_id in unit.display_line_ids
-        )
-        if len(ordered_group) != len(unit.display_line_ids):
-            continue
-
-        actions = [_BATCH_RESET_REVIEW_ACTION]
-        if unit.display_line_ids.intersection(mergeable_id_ranges) == unit.display_line_ids:
-            actionable_selection_groups.append(ordered_group)
-            actions = [
-                *_BATCH_MERGE_REVIEW_ACTIONS,
-                _BATCH_RESET_REVIEW_ACTION,
-            ]
-
-        review_display_ids = tuple(
-            review_selection_id_to_gutter[line_id]
-            for line_id in ordered_group
-            if line_id in review_selection_id_to_gutter
-        )
-        if len(review_display_ids) == len(ordered_group):
-            if unit.kind.value == "replacement":
-                reason = "replacement"
-            elif unit.kind.value == "deletion_only":
-                reason = "structural-run"
-            else:
-                reason = "simple"
-            review_action_groups.append(
-                ReviewActionGroup(
-                    display_ids=review_display_ids,
-                    selection_ids=ordered_group,
-                    actions=tuple(actions),
-                    reason=reason,
-                )
-            )
-    return RenderedBatchDisplay(
-        line_changes=line_changes,
-        gutter_to_selection_id=gutter_to_selection_id,
-        selection_id_to_gutter=selection_id_to_gutter,
-        actionable_selection_groups=tuple(actionable_selection_groups),
-        review_gutter_to_selection_id=review_gutter_to_selection_id,
-        review_selection_id_to_gutter=review_selection_id_to_gutter,
-        review_action_groups=tuple(review_action_groups),
-    )
 
 
 def cache_batch_as_single_hunk(
@@ -1671,6 +1353,8 @@ def select_next_change_after_action(
     clear_selected_change_state_files()
     mark_selected_change_cleared_by_auto_advance_disabled()
     return False
+
+
 
 
 def snapshots_are_stale(file_path: str) -> bool:

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -3,16 +3,11 @@
 from __future__ import annotations
 
 import json
-import shutil
 import tempfile
 import subprocess
 import sys
-from collections.abc import Sequence
 from contextlib import ExitStack
-from dataclasses import dataclass
-from enum import Enum
 from hashlib import sha256
-from pathlib import Path
 from typing import Generator, Mapping, Optional, Union
 
 from ..batch.attribution import build_file_attribution, filter_owned_diff_fragments
@@ -55,7 +50,6 @@ from ..editor import (
     buffer_matches,
     load_git_object_as_buffer,
     load_working_tree_file_as_buffer,
-    write_buffer_to_path,
 )
 from ..core.line_selection import LineRanges, write_line_ids_file
 from ..core.line_identity import preserve_line_ids_from_previous_view
@@ -90,38 +84,51 @@ from ..utils.paths import (
     get_block_list_file_path,
     get_blocked_files_file_path,
     get_context_lines,
-    get_selected_change_clear_reason_file_path,
-    get_selected_change_kind_file_path,
-    get_selected_binary_file_json_path,
-    get_selected_gitlink_file_json_path,
-    get_selected_rename_file_json_path,
-    get_selected_text_deletion_file_json_path,
     get_selected_hunk_hash_file_path,
     get_selected_hunk_patch_file_path,
     get_line_changes_json_file_path,
     get_discarded_hunks_file_path,
     get_included_hunks_file_path,
+    get_skipped_hunks_jsonl_file_path,
     get_index_snapshot_file_path,
     get_processed_include_ids_file_path,
     get_processed_skip_ids_file_path,
-    get_skipped_hunks_jsonl_file_path,
     get_working_tree_snapshot_file_path,
 )
 from .line_state import convert_line_changes_to_serializable_dict, load_line_changes_from_state
-
-
-class SelectedChangeKind(str, Enum):
-    """Kinds of selected changes cached in session state."""
-
-    HUNK = "hunk"
-    FILE = "file"
-    RENAME = "rename"
-    DELETION = "deletion"
-    BINARY = "binary"
-    GITLINK = "submodule"
-    BATCH_FILE = "batch-file"
-    BATCH_BINARY = "batch-binary"
-    BATCH_GITLINK = "batch-submodule"
+from .selected_change.store import (
+    SelectedChangeClearReason as SelectedChangeClearReason,
+    SelectedChangeKind,
+    SelectedChangeStateSnapshot as SelectedChangeStateSnapshot,
+    cache_binary_file_change,
+    cache_gitlink_change,
+    cache_rename_change,
+    cache_text_deletion_change,
+    clear_selected_change_persistence_files,
+    get_selected_change_file_path as get_selected_change_file_path,
+    load_line_changes_from_patch_path as _load_line_changes_from_patch_path,
+    load_selected_binary_file,
+    load_selected_gitlink_change,
+    load_selected_rename_change,
+    load_selected_text_deletion_change,
+    mark_selected_change_cleared_by_auto_advance_disabled,
+    mark_selected_change_cleared_by_file_list as mark_selected_change_cleared_by_file_list,
+    mark_selected_change_cleared_by_stale_batch_selection,
+    read_selected_binary_data as _read_selected_binary_data,
+    read_selected_change_kind,
+    read_selected_gitlink_data as _read_selected_gitlink_data,
+    refuse_bare_action_after_auto_advance_disabled as refuse_bare_action_after_auto_advance_disabled,
+    refuse_bare_action_after_file_list as refuse_bare_action_after_file_list,
+    refuse_bare_action_after_stale_batch_selection as refuse_bare_action_after_stale_batch_selection,
+    restore_selected_change_state as restore_selected_change_state,
+    selected_change_was_cleared_by_auto_advance_disabled as selected_change_was_cleared_by_auto_advance_disabled,
+    selected_change_was_cleared_by_file_list as selected_change_was_cleared_by_file_list,
+    selected_change_was_cleared_by_stale_batch_selection as selected_change_was_cleared_by_stale_batch_selection,
+    snapshot_selected_change_state as snapshot_selected_change_state,
+    write_line_changes_state as _write_line_changes_state,
+    write_selected_change_kind,
+    write_selected_hunk_patch_lines,
+)
 
 
 _BATCH_MERGE_REVIEW_ACTIONS = (
@@ -138,438 +145,12 @@ def stream_live_git_diff(**kwargs):
     return stream_git_diff(**kwargs)
 
 
-@dataclass
-class SelectedChangeStateSnapshot:
-    """Temporary file copy of selected change state."""
-
-    paths: dict[str, Path | None]
-    temporary_directory: tempfile.TemporaryDirectory
-
-    def close(self) -> None:
-        self.temporary_directory.cleanup()
-
-    def __enter__(self) -> SelectedChangeStateSnapshot:
-        return self
-
-    def __exit__(self, exc_type, exc, traceback) -> None:
-        self.close()
-
-
-def write_selected_hunk_patch_lines(patch_lines: Sequence[bytes]) -> None:
-    with EditorBuffer.from_chunks(iter(patch_lines)) as patch_buffer:
-        write_buffer_to_path(get_selected_hunk_patch_file_path(), patch_buffer)
-
-
-def _write_line_changes_state(line_changes: LineLevelChange) -> None:
-    write_text_file_contents(
-        get_line_changes_json_file_path(),
-        json.dumps(
-            convert_line_changes_to_serializable_dict(line_changes),
-            ensure_ascii=False,
-            indent=0,
-        ),
-    )
-
-
-def _load_line_changes_from_patch_path(patch_path: Path) -> LineLevelChange:
-    with EditorBuffer.from_path(patch_path) as patch_lines:
-        return build_line_changes_from_patch_lines(patch_lines)
-
-
-class SelectedChangeClearReason(str, Enum):
-    """Reasons selected change state was intentionally cleared."""
-
-    AUTO_ADVANCE_DISABLED = "auto-advance-disabled"
-    FILE_LIST = "file-list"
-    STALE_BATCH_SELECTION = "stale-batch-selection"
-
-
-def _selected_change_state_paths():
-    """Return files that make up the cached selected change state."""
-    return {
-        "patch": get_selected_hunk_patch_file_path(),
-        "hash": get_selected_hunk_hash_file_path(),
-        "clear_reason": get_selected_change_clear_reason_file_path(),
-        "kind": get_selected_change_kind_file_path(),
-        "line_state": get_line_changes_json_file_path(),
-        "rename": get_selected_rename_file_json_path(),
-        "text_deletion": get_selected_text_deletion_file_json_path(),
-        "binary": get_selected_binary_file_json_path(),
-        "gitlink": get_selected_gitlink_file_json_path(),
-        "index_snapshot": get_index_snapshot_file_path(),
-        "working_snapshot": get_working_tree_snapshot_file_path(),
-        "processed_include_ids": get_processed_include_ids_file_path(),
-        "processed_skip_ids": get_processed_skip_ids_file_path(),
-    }
-
-
-def snapshot_selected_change_state() -> SelectedChangeStateSnapshot:
-    """Capture the current selected change cache."""
-    temporary_directory = tempfile.TemporaryDirectory()
-    snapshot_root = Path(temporary_directory.name)
-    snapshot_paths: dict[str, Path | None] = {}
-
-    for name, path in _selected_change_state_paths().items():
-        if not path.exists():
-            snapshot_paths[name] = None
-            continue
-
-        snapshot_path = snapshot_root / name
-        shutil.copyfile(path, snapshot_path)
-        snapshot_paths[name] = snapshot_path
-
-    return SelectedChangeStateSnapshot(
-        paths=snapshot_paths,
-        temporary_directory=temporary_directory,
-    )
-
-
-def restore_selected_change_state(snapshot: SelectedChangeStateSnapshot) -> None:
-    """Restore a previously captured selected change cache."""
-    for name, path in _selected_change_state_paths().items():
-        snapshot_path = snapshot.paths.get(name)
-        if snapshot_path is None:
-            path.unlink(missing_ok=True)
-        else:
-            path.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copyfile(snapshot_path, path)
-
-
 def clear_selected_change_state_files() -> None:
-    """Clear all cached selected hunk state files."""
+    """Clear selected change state and dependent file-review state."""
     from .file_review.state import clear_last_file_review_state
 
-    for path in _selected_change_state_paths().values():
-        path.unlink(missing_ok=True)
+    clear_selected_change_persistence_files()
     clear_last_file_review_state()
-    # processed_batch_ids is global state (union of all batches), not per-hunk state
-
-
-def mark_selected_change_cleared_by_file_list(
-    *,
-    source: str,
-    batch_name: str | None = None,
-) -> None:
-    """Record that a navigational file list intentionally cleared selection."""
-    _write_selected_change_clear_reason(
-        reason=SelectedChangeClearReason.FILE_LIST,
-        source=source,
-        batch_name=batch_name,
-    )
-
-
-def mark_selected_change_cleared_by_stale_batch_selection(
-    *,
-    batch_name: str,
-    file_path: str,
-) -> None:
-    """Record that a batch mutation invalidated the selected batch file."""
-    _write_selected_change_clear_reason(
-        reason=SelectedChangeClearReason.STALE_BATCH_SELECTION,
-        source="batch",
-        batch_name=batch_name,
-        file_path=file_path,
-    )
-
-
-def mark_selected_change_cleared_by_auto_advance_disabled() -> None:
-    """Record that an action left the next change unselected."""
-    _write_selected_change_clear_reason(
-        reason=SelectedChangeClearReason.AUTO_ADVANCE_DISABLED,
-        source="auto-advance",
-    )
-
-
-def _write_selected_change_clear_reason(
-    *,
-    reason: SelectedChangeClearReason,
-    source: str,
-    batch_name: str | None = None,
-    file_path: str | None = None,
-) -> None:
-    """Write a structured selected-change clear marker."""
-    write_text_file_contents(
-        get_selected_change_clear_reason_file_path(),
-        json.dumps(
-            {
-                "reason": reason.value,
-                "source": source,
-                "batch_name": batch_name,
-                "file_path": file_path,
-            },
-            ensure_ascii=False,
-            indent=0,
-        ),
-    )
-
-
-def _read_selected_change_clear_reason() -> dict[str, str | None] | None:
-    """Return the structured clear marker, tolerating legacy plain-text state."""
-    raw_reason = read_text_file_contents(get_selected_change_clear_reason_file_path()).strip()
-    if not raw_reason:
-        return None
-    if raw_reason == SelectedChangeClearReason.FILE_LIST.value:
-        return {
-            "reason": SelectedChangeClearReason.FILE_LIST.value,
-            "source": None,
-            "batch_name": None,
-        }
-    try:
-        data = json.loads(raw_reason)
-    except json.JSONDecodeError:
-        return None
-    if not isinstance(data, dict):
-        return None
-    reason = data.get("reason")
-    if reason not in {item.value for item in SelectedChangeClearReason}:
-        return None
-    return {
-        "reason": reason,
-        "source": data.get("source") if isinstance(data.get("source"), str) else None,
-        "batch_name": data.get("batch_name") if isinstance(data.get("batch_name"), str) else None,
-        "file_path": data.get("file_path") if isinstance(data.get("file_path"), str) else None,
-    }
-
-
-def selected_change_was_cleared_by_file_list(
-    *,
-    source: str | None = None,
-    batch_name: str | None = None,
-) -> bool:
-    """Return whether the current empty selection came from a file list."""
-    if read_selected_change_kind() is not None:
-        return False
-    marker = _read_selected_change_clear_reason()
-    if marker is None:
-        return False
-    if marker["reason"] != SelectedChangeClearReason.FILE_LIST.value:
-        return False
-    marker_source = marker["source"]
-    marker_batch_name = marker["batch_name"]
-    if source is not None and marker_source != source:
-        return False
-    if batch_name is not None and marker_batch_name != batch_name:
-        return False
-    return True
-
-
-def selected_change_was_cleared_by_stale_batch_selection(
-    *,
-    batch_name: str | None = None,
-) -> bool:
-    """Return whether the current empty selection is a stale batch selection."""
-    if read_selected_change_kind() is not None:
-        return False
-    marker = _read_selected_change_clear_reason()
-    if marker is None:
-        return False
-    if marker["reason"] != SelectedChangeClearReason.STALE_BATCH_SELECTION.value:
-        return False
-    if batch_name is not None and marker["batch_name"] != batch_name:
-        return False
-    return True
-
-
-def selected_change_was_cleared_by_auto_advance_disabled() -> bool:
-    """Return whether the current empty selection needs an explicit show."""
-    if read_selected_change_kind() is not None:
-        return False
-    marker = _read_selected_change_clear_reason()
-    if marker is None:
-        return False
-    return marker["reason"] == SelectedChangeClearReason.AUTO_ADVANCE_DISABLED.value
-
-
-def refuse_bare_action_after_file_list(
-    action_command: str,
-    *,
-    open_command: str = "git-stage-batch show --file PATH",
-    source: str | None = None,
-    batch_name: str | None = None,
-) -> None:
-    """Refuse a bare action after a navigational file list cleared selection."""
-    if not selected_change_was_cleared_by_file_list(source=source, batch_name=batch_name):
-        return
-    raise CommandError(
-        _(
-            "No selected change.\n"
-            "The last command only showed files; it did not choose one for follow-up actions.\n\n"
-            "Run:\n"
-            "  git-stage-batch show\n"
-            "or choose a file with:\n"
-            "  {open_command}\n"
-            "before running:\n"
-            "  git-stage-batch {action}"
-        ).format(open_command=open_command, action=action_command)
-    )
-
-
-def refuse_bare_action_after_auto_advance_disabled(action_command: str) -> None:
-    """Refuse a bare action after a command declined to select the next hunk."""
-    if not selected_change_was_cleared_by_auto_advance_disabled():
-        return
-    raise CommandError(
-        _(
-            "No selected change.\n"
-            "The previous command did not choose the next hunk because automatic "
-            "advancement is disabled.\n\n"
-            "Run:\n"
-            "  git-stage-batch show\n"
-            "before running:\n"
-            "  git-stage-batch {action}"
-        ).format(action=action_command)
-    )
-
-
-def refuse_bare_action_after_stale_batch_selection(
-    action_command: str,
-    *,
-    batch_name: str,
-) -> None:
-    """Refuse a bare batch action after the selected batch file went stale."""
-    if not selected_change_was_cleared_by_stale_batch_selection(batch_name=batch_name):
-        return
-
-    marker = _read_selected_change_clear_reason() or {}
-    file_path = marker.get("file_path") or "the previously selected file"
-    raise CommandError(
-        _(
-            "No selected change.\n"
-            "The selected batch file '{file}' was changed or removed from batch '{batch}'.\n\n"
-            "Open a current batch file with:\n"
-            "  git-stage-batch show --from {batch} --file PATH\n"
-            "before running:\n"
-            "  git-stage-batch {action}"
-        ).format(file=file_path, batch=batch_name, action=action_command)
-    )
-
-
-def _read_selected_binary_data() -> dict | None:
-    """Read cached binary selection data, if structurally valid."""
-    binary_path = get_selected_binary_file_json_path()
-    if not binary_path.exists():
-        return None
-    try:
-        binary_data = json.loads(read_text_file_contents(binary_path))
-    except json.JSONDecodeError:
-        return None
-    return binary_data if isinstance(binary_data, dict) else None
-
-
-def load_selected_binary_file() -> Optional[BinaryFileChange]:
-    """Load the currently cached binary file.
-
-    Returns:
-        BinaryFileChange if a binary file is cached, None otherwise
-    """
-    if read_selected_change_kind() not in (SelectedChangeKind.BINARY, SelectedChangeKind.BATCH_BINARY):
-        return None
-
-    binary_data = _read_selected_binary_data()
-    if binary_data is None:
-        return None
-
-    try:
-        return BinaryFileChange(
-            old_path=binary_data["old_path"],
-            new_path=binary_data["new_path"],
-            change_type=binary_data["change_type"]
-        )
-    except KeyError:
-        return None
-
-
-def _read_selected_gitlink_data() -> dict | None:
-    """Read cached gitlink selection data, if structurally valid."""
-    gitlink_path = get_selected_gitlink_file_json_path()
-    if not gitlink_path.exists():
-        return None
-    try:
-        gitlink_data = json.loads(read_text_file_contents(gitlink_path))
-    except json.JSONDecodeError:
-        return None
-    return gitlink_data if isinstance(gitlink_data, dict) else None
-
-
-def load_selected_gitlink_change() -> Optional[GitlinkChange]:
-    """Load the currently cached gitlink change."""
-    if read_selected_change_kind() not in (SelectedChangeKind.GITLINK, SelectedChangeKind.BATCH_GITLINK):
-        return None
-
-    gitlink_data = _read_selected_gitlink_data()
-    if gitlink_data is None:
-        return None
-
-    try:
-        return GitlinkChange(
-            old_path=gitlink_data["old_path"],
-            new_path=gitlink_data["new_path"],
-            old_oid=gitlink_data.get("old_oid"),
-            new_oid=gitlink_data.get("new_oid"),
-            change_type=gitlink_data["change_type"],
-        )
-    except KeyError:
-        return None
-
-
-def _read_selected_rename_data() -> dict | None:
-    """Read cached rename selection data, if structurally valid."""
-    rename_path = get_selected_rename_file_json_path()
-    if not rename_path.exists():
-        return None
-    try:
-        rename_data = json.loads(read_text_file_contents(rename_path))
-    except json.JSONDecodeError:
-        return None
-    return rename_data if isinstance(rename_data, dict) else None
-
-
-def load_selected_rename_change() -> Optional[RenameChange]:
-    """Load the currently cached rename change."""
-    if read_selected_change_kind() != SelectedChangeKind.RENAME:
-        return None
-
-    rename_data = _read_selected_rename_data()
-    if rename_data is None:
-        return None
-
-    try:
-        return RenameChange(
-            old_path=rename_data["old_path"],
-            new_path=rename_data["new_path"],
-        )
-    except KeyError:
-        return None
-
-
-def _read_selected_text_deletion_data() -> dict | None:
-    """Read cached text deletion selection data, if structurally valid."""
-    deletion_path = get_selected_text_deletion_file_json_path()
-    if not deletion_path.exists():
-        return None
-    try:
-        deletion_data = json.loads(read_text_file_contents(deletion_path))
-    except json.JSONDecodeError:
-        return None
-    return deletion_data if isinstance(deletion_data, dict) else None
-
-
-def load_selected_text_deletion_change() -> Optional[TextFileDeletionChange]:
-    """Load the currently cached text file deletion change."""
-    if read_selected_change_kind() != SelectedChangeKind.DELETION:
-        return None
-
-    deletion_data = _read_selected_text_deletion_data()
-    if deletion_data is None:
-        return None
-
-    try:
-        return TextFileDeletionChange(
-            old_path=deletion_data["old_path"],
-            new_path=deletion_data.get("new_path", "/dev/null"),
-        )
-    except KeyError:
-        return None
 
 
 def compute_batch_binary_fingerprint(
@@ -600,145 +181,6 @@ def compute_batch_binary_fingerprint(
     }
     data = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
     return sha256(data.encode("utf-8", errors="surrogateescape")).hexdigest()
-
-
-def cache_binary_file_change(
-    binary_change: BinaryFileChange,
-    *,
-    kind: SelectedChangeKind = SelectedChangeKind.BINARY,
-    batch_name: str | None = None,
-    batch_binary_fingerprint: str | None = None,
-) -> None:
-    """Cache a binary file change as the current selected change."""
-    if kind not in (SelectedChangeKind.BINARY, SelectedChangeKind.BATCH_BINARY):
-        raise ValueError("binary selections must use a binary selected-change kind")
-    file_path = binary_change.new_path if binary_change.new_path != "/dev/null" else binary_change.old_path
-    binary_data = {
-        "old_path": binary_change.old_path,
-        "new_path": binary_change.new_path,
-        "change_type": binary_change.change_type,
-        "batch_name": batch_name if kind == SelectedChangeKind.BATCH_BINARY else None,
-        "batch_binary_fingerprint": (
-            batch_binary_fingerprint
-            if kind == SelectedChangeKind.BATCH_BINARY else
-            None
-        ),
-    }
-    get_selected_hunk_patch_file_path().unlink(missing_ok=True)
-    get_line_changes_json_file_path().unlink(missing_ok=True)
-    get_selected_rename_file_json_path().unlink(missing_ok=True)
-    get_selected_text_deletion_file_json_path().unlink(missing_ok=True)
-    get_index_snapshot_file_path().unlink(missing_ok=True)
-    get_working_tree_snapshot_file_path().unlink(missing_ok=True)
-    get_processed_include_ids_file_path().unlink(missing_ok=True)
-    get_processed_skip_ids_file_path().unlink(missing_ok=True)
-    write_text_file_contents(
-        get_selected_binary_file_json_path(),
-        json.dumps(binary_data, ensure_ascii=False, indent=0),
-    )
-    write_text_file_contents(
-        get_selected_hunk_hash_file_path(),
-        compute_binary_file_hash(binary_change),
-    )
-    if kind == SelectedChangeKind.BINARY:
-        write_snapshots_for_selected_file_path(file_path)
-    write_selected_change_kind(kind)
-
-
-def cache_gitlink_change(
-    gitlink_change: GitlinkChange,
-    *,
-    kind: SelectedChangeKind = SelectedChangeKind.GITLINK,
-    batch_name: str | None = None,
-    batch_gitlink_fingerprint: str | None = None,
-) -> None:
-    """Cache a gitlink change as the current selected change."""
-    if kind not in (SelectedChangeKind.GITLINK, SelectedChangeKind.BATCH_GITLINK):
-        raise ValueError("gitlink selections must use a gitlink selected-change kind")
-    gitlink_data = {
-        "old_path": gitlink_change.old_path,
-        "new_path": gitlink_change.new_path,
-        "old_oid": gitlink_change.old_oid,
-        "new_oid": gitlink_change.new_oid,
-        "change_type": gitlink_change.change_type,
-        "batch_name": batch_name if kind == SelectedChangeKind.BATCH_GITLINK else None,
-        "batch_gitlink_fingerprint": (
-            batch_gitlink_fingerprint
-            if kind == SelectedChangeKind.BATCH_GITLINK else
-            None
-        ),
-    }
-    get_selected_hunk_patch_file_path().unlink(missing_ok=True)
-    get_line_changes_json_file_path().unlink(missing_ok=True)
-    get_selected_rename_file_json_path().unlink(missing_ok=True)
-    get_selected_binary_file_json_path().unlink(missing_ok=True)
-    get_selected_text_deletion_file_json_path().unlink(missing_ok=True)
-    get_index_snapshot_file_path().unlink(missing_ok=True)
-    get_working_tree_snapshot_file_path().unlink(missing_ok=True)
-    get_processed_include_ids_file_path().unlink(missing_ok=True)
-    get_processed_skip_ids_file_path().unlink(missing_ok=True)
-    write_text_file_contents(
-        get_selected_gitlink_file_json_path(),
-        json.dumps(gitlink_data, ensure_ascii=False, indent=0),
-    )
-    write_text_file_contents(
-        get_selected_hunk_hash_file_path(),
-        compute_gitlink_change_hash(gitlink_change),
-    )
-    write_selected_change_kind(kind)
-
-
-def cache_rename_change(rename_change: RenameChange) -> None:
-    """Cache a rename change as the current selected change."""
-    rename_data = {
-        "old_path": rename_change.old_path,
-        "new_path": rename_change.new_path,
-    }
-    get_selected_hunk_patch_file_path().unlink(missing_ok=True)
-    get_line_changes_json_file_path().unlink(missing_ok=True)
-    get_selected_binary_file_json_path().unlink(missing_ok=True)
-    get_selected_gitlink_file_json_path().unlink(missing_ok=True)
-    get_selected_text_deletion_file_json_path().unlink(missing_ok=True)
-    get_index_snapshot_file_path().unlink(missing_ok=True)
-    get_working_tree_snapshot_file_path().unlink(missing_ok=True)
-    get_processed_include_ids_file_path().unlink(missing_ok=True)
-    get_processed_skip_ids_file_path().unlink(missing_ok=True)
-    write_text_file_contents(
-        get_selected_rename_file_json_path(),
-        json.dumps(rename_data, ensure_ascii=False, indent=0),
-    )
-    write_text_file_contents(
-        get_selected_hunk_hash_file_path(),
-        compute_rename_change_hash(rename_change),
-    )
-    write_selected_change_kind(SelectedChangeKind.RENAME)
-
-
-def cache_text_deletion_change(deletion_change: TextFileDeletionChange) -> None:
-    """Cache a whole-text-file deletion as the current selected change."""
-    deletion_data = {
-        "old_path": deletion_change.old_path,
-        "new_path": deletion_change.new_path,
-    }
-    get_selected_hunk_patch_file_path().unlink(missing_ok=True)
-    get_line_changes_json_file_path().unlink(missing_ok=True)
-    get_selected_binary_file_json_path().unlink(missing_ok=True)
-    get_selected_gitlink_file_json_path().unlink(missing_ok=True)
-    get_selected_rename_file_json_path().unlink(missing_ok=True)
-    get_index_snapshot_file_path().unlink(missing_ok=True)
-    get_working_tree_snapshot_file_path().unlink(missing_ok=True)
-    get_processed_include_ids_file_path().unlink(missing_ok=True)
-    get_processed_skip_ids_file_path().unlink(missing_ok=True)
-    write_text_file_contents(
-        get_selected_text_deletion_file_json_path(),
-        json.dumps(deletion_data, ensure_ascii=False, indent=0),
-    )
-    write_text_file_contents(
-        get_selected_hunk_hash_file_path(),
-        compute_text_file_deletion_hash(deletion_change),
-    )
-    write_snapshots_for_selected_file_path(deletion_change.path())
-    write_selected_change_kind(SelectedChangeKind.DELETION)
 
 
 def selected_batch_binary_matches_batch(batch_name: str) -> bool:
@@ -976,36 +418,6 @@ def text_deletion_change_is_stale(deletion_change: TextFileDeletionChange) -> bo
     )
 
 
-def write_selected_change_kind(kind: SelectedChangeKind) -> None:
-    """Persist the kind of selected change cached in session state."""
-    get_selected_change_clear_reason_file_path().unlink(missing_ok=True)
-    if kind != SelectedChangeKind.RENAME:
-        get_selected_rename_file_json_path().unlink(missing_ok=True)
-    if kind != SelectedChangeKind.DELETION:
-        get_selected_text_deletion_file_json_path().unlink(missing_ok=True)
-    if kind not in (SelectedChangeKind.BINARY, SelectedChangeKind.BATCH_BINARY):
-        get_selected_binary_file_json_path().unlink(missing_ok=True)
-    if kind not in (SelectedChangeKind.GITLINK, SelectedChangeKind.BATCH_GITLINK):
-        get_selected_gitlink_file_json_path().unlink(missing_ok=True)
-    write_text_file_contents(get_selected_change_kind_file_path(), kind)
-
-
-def read_selected_change_kind() -> Optional[SelectedChangeKind]:
-    """Return the kind of selected change cached in session state."""
-    path = get_selected_change_kind_file_path()
-    if not path.exists():
-        return None
-
-    raw_kind = read_text_file_contents(path).strip()
-    if not raw_kind:
-        return None
-
-    try:
-        return SelectedChangeKind(raw_kind)
-    except ValueError:
-        return None
-
-
 def load_selected_change() -> Optional[Union[LineLevelChange, BinaryFileChange, GitlinkChange, RenameChange, TextFileDeletionChange]]:
     """Load the currently cached selected change, if any."""
     selected_kind = read_selected_change_kind()
@@ -1065,38 +477,6 @@ def load_selected_change() -> Optional[Union[LineLevelChange, BinaryFileChange, 
         return line_changes
 
     return _load_line_changes_from_patch_path(patch_path)
-
-
-def get_selected_change_file_path() -> Optional[str]:
-    """Return the file path for the currently cached selected change.
-
-    The selected patch/binary cache is the source of truth for pathless
-    file-scoped commands because it is what navigation just displayed.
-    selected-lines.json is derived state and may lag after display/navigation
-    edge cases.
-    """
-    rename_change = load_selected_rename_change()
-    if rename_change is not None:
-        return rename_change.path()
-
-    deletion_change = load_selected_text_deletion_change()
-    if deletion_change is not None:
-        return deletion_change.path()
-
-    gitlink_change = load_selected_gitlink_change()
-    if gitlink_change is not None:
-        return gitlink_change.path()
-
-    binary_file = load_selected_binary_file()
-    if binary_file is not None:
-        return binary_file.new_path if binary_file.new_path != "/dev/null" else binary_file.old_path
-
-    patch_path = get_selected_hunk_patch_file_path()
-    if not patch_path.exists():
-        return None
-
-    line_changes = _load_line_changes_from_patch_path(patch_path)
-    return line_changes.path
 
 
 def apply_line_level_batch_filter_to_cached_hunk() -> bool:
@@ -2506,7 +1886,6 @@ def recalculate_selected_hunk_for_file(
         command_show()
     else:
         mark_selected_change_cleared_by_auto_advance_disabled()
-
 
 def record_hunk_included(hunk_hash: str) -> None:
     """Record that a hunk was included (staged)."""

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -6,6 +6,7 @@ import json
 import tempfile
 import subprocess
 import sys
+from enum import Enum
 from hashlib import sha256
 from typing import Generator, Mapping, Optional, Union
 
@@ -127,6 +128,14 @@ from .selected_change.store import (
     write_selected_change_kind,
     write_selected_hunk_patch_lines,
 )
+
+
+class RecalculateSelectedHunkResult(str, Enum):
+    """Outcome from refreshing the selected hunk for one file."""
+
+    RECALCULATED = "recalculated"
+    CLEARED = "cleared"
+    SHOW_NEXT_CHANGE = "show-next-change"
 
 
 _BATCH_MERGE_REVIEW_ACTIONS = (
@@ -1382,7 +1391,7 @@ def recalculate_selected_hunk_for_file(
     file_path: str,
     *,
     auto_advance: bool | None = None,
-) -> None:
+) -> RecalculateSelectedHunkResult:
     """Recalculate the selected hunk for a specific file after modifications.
 
     After discard --line or include --line changes the working tree or index,
@@ -1406,10 +1415,11 @@ def recalculate_selected_hunk_for_file(
             clear_selected_change_state_files()
             if resolve_auto_advance(auto_advance):
                 from ..commands.show import command_show
+
                 command_show()
-            else:
-                mark_selected_change_cleared_by_auto_advance_disabled()
-            return
+                return RecalculateSelectedHunkResult.RECALCULATED
+            mark_selected_change_cleared_by_auto_advance_disabled()
+            return RecalculateSelectedHunkResult.CLEARED
 
         line_changes = preserve_line_ids_from_previous_view(
             previous_line_changes,
@@ -1421,15 +1431,16 @@ def recalculate_selected_hunk_for_file(
             clear_selected_change_state_files()
             if resolve_auto_advance(auto_advance):
                 from ..commands.show import command_show
+
                 command_show()
-            else:
-                mark_selected_change_cleared_by_auto_advance_disabled()
-            return
+                return RecalculateSelectedHunkResult.RECALCULATED
+            mark_selected_change_cleared_by_auto_advance_disabled()
+            return RecalculateSelectedHunkResult.CLEARED
 
         line_changes = load_line_changes_from_state()
         if line_changes is not None:
             print_line_level_changes(line_changes)
-        return
+        return RecalculateSelectedHunkResult.RECALCULATED
 
     # Load blocklist
     blocked_hashes = read_text_file_line_set(get_block_list_file_path())
@@ -1454,7 +1465,7 @@ def recalculate_selected_hunk_for_file(
                         continue
                     cache_rename_change(single_hunk)
                     print_rename_change(single_hunk)
-                    return
+                    return RecalculateSelectedHunkResult.RECALCULATED
 
                 if isinstance(single_hunk, TextFileDeletionChange):
                     deletion_hash = compute_text_file_deletion_hash(single_hunk)
@@ -1462,7 +1473,7 @@ def recalculate_selected_hunk_for_file(
                         continue
                     cache_text_deletion_change(single_hunk)
                     print_text_file_deletion_change(single_hunk)
-                    return
+                    return RecalculateSelectedHunkResult.RECALCULATED
 
                 if isinstance(single_hunk, GitlinkChange):
                     gitlink_hash = compute_gitlink_change_hash(single_hunk)
@@ -1470,7 +1481,7 @@ def recalculate_selected_hunk_for_file(
                         continue
                     cache_gitlink_change(single_hunk)
                     print_gitlink_change(single_hunk)
-                    return
+                    return RecalculateSelectedHunkResult.RECALCULATED
 
                 if isinstance(single_hunk, BinaryFileChange):
                     continue
@@ -1510,24 +1521,25 @@ def recalculate_selected_hunk_for_file(
                     # All lines were batched, clear the hunk
                     clear_selected_change_state_files()
                     print(_("No more lines in this hunk."), file=sys.stderr)
-                    return
+                    return RecalculateSelectedHunkResult.CLEARED
 
                 # Display filtered hunk
                 line_changes = load_line_changes_from_state()
                 if line_changes is not None:
                     print_line_level_changes(line_changes)
-                return
+                return RecalculateSelectedHunkResult.RECALCULATED
     except subprocess.CalledProcessError:
         # Git diff failed (e.g., no changes)
         clear_selected_change_state_files()
         print(_("No pending hunks."), file=sys.stderr)
-        return
+        return RecalculateSelectedHunkResult.CLEARED
 
     # No more hunks for this file, advance to next file
     clear_selected_change_state_files()
-    # Import here to avoid circular dependency
     if resolve_auto_advance(auto_advance):
         from ..commands.show import command_show
+
         command_show()
-    else:
-        mark_selected_change_cleared_by_auto_advance_disabled()
+        return RecalculateSelectedHunkResult.RECALCULATED
+    mark_selected_change_cleared_by_auto_advance_disabled()
+    return RecalculateSelectedHunkResult.CLEARED

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -49,7 +49,6 @@ from ..core.text_lifecycle import detect_empty_text_lifecycle_change
 from ..core.diff_parser import (
     acquire_unified_diff,
     build_line_changes_from_patch_lines,
-    write_snapshots_for_selected_file_path,
 )
 from ..editor import (
     EditorBuffer,
@@ -72,6 +71,7 @@ from ..output import (
 from .consumed_selections import read_consumed_file_metadata
 from .auto_advance import resolve_auto_advance
 from .file_tracking import auto_add_untracked_files
+from .selected_change.snapshots import write_snapshots_for_selected_file_path
 from ..utils.file_io import (
     is_path_blocked,
     read_file_paths_file,

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -95,6 +95,7 @@ from ..utils.paths import (
     get_working_tree_snapshot_file_path,
 )
 from .line_state import convert_line_changes_to_serializable_dict, load_line_changes_from_state
+from .selected_change.lifecycle import clear_selected_change_state_files as clear_selected_change_state_files
 from .selected_change.store import (
     SelectedChangeClearReason as SelectedChangeClearReason,
     SelectedChangeKind,
@@ -103,7 +104,6 @@ from .selected_change.store import (
     cache_gitlink_change,
     cache_rename_change,
     cache_text_deletion_change,
-    clear_selected_change_persistence_files,
     get_selected_change_file_path as get_selected_change_file_path,
     load_line_changes_from_patch_path as _load_line_changes_from_patch_path,
     load_selected_binary_file,
@@ -150,14 +150,6 @@ def stream_live_git_diff(**kwargs):
     """Stream actionable live changes with rename detection enabled."""
     kwargs.setdefault("find_renames", True)
     return stream_git_diff(**kwargs)
-
-
-def clear_selected_change_state_files() -> None:
-    """Clear selected change state and dependent file-review state."""
-    from .file_review.state import clear_last_file_review_state
-
-    clear_selected_change_persistence_files()
-    clear_last_file_review_state()
 
 
 def compute_batch_binary_fingerprint(

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -1414,10 +1414,7 @@ def recalculate_selected_hunk_for_file(
         if line_changes is None:
             clear_selected_change_state_files()
             if resolve_auto_advance(auto_advance):
-                from ..commands.show import command_show
-
-                command_show()
-                return RecalculateSelectedHunkResult.RECALCULATED
+                return RecalculateSelectedHunkResult.SHOW_NEXT_CHANGE
             mark_selected_change_cleared_by_auto_advance_disabled()
             return RecalculateSelectedHunkResult.CLEARED
 
@@ -1430,10 +1427,7 @@ def recalculate_selected_hunk_for_file(
         if apply_line_level_batch_filter_to_cached_hunk():
             clear_selected_change_state_files()
             if resolve_auto_advance(auto_advance):
-                from ..commands.show import command_show
-
-                command_show()
-                return RecalculateSelectedHunkResult.RECALCULATED
+                return RecalculateSelectedHunkResult.SHOW_NEXT_CHANGE
             mark_selected_change_cleared_by_auto_advance_disabled()
             return RecalculateSelectedHunkResult.CLEARED
 
@@ -1537,9 +1531,6 @@ def recalculate_selected_hunk_for_file(
     # No more hunks for this file, advance to next file
     clear_selected_change_state_files()
     if resolve_auto_advance(auto_advance):
-        from ..commands.show import command_show
-
-        command_show()
-        return RecalculateSelectedHunkResult.RECALCULATED
+        return RecalculateSelectedHunkResult.SHOW_NEXT_CHANGE
     mark_selected_change_cleared_by_auto_advance_disabled()
     return RecalculateSelectedHunkResult.CLEARED

--- a/src/git_stage_batch/data/progress.py
+++ b/src/git_stage_batch/data/progress.py
@@ -27,6 +27,22 @@ def record_hunk_included(hunk_hash: str) -> None:
     write_text_file_contents(included_path, "\n".join(sorted(existing)) + "\n" if existing else "")
 
 
+def record_hunk_discarded(hunk_hash: str) -> None:
+    """Record that a hunk was discarded (removed from working tree)."""
+    record_hunks_discarded([hunk_hash])
+
+
+def record_hunks_discarded(hunk_hashes: list[str]) -> None:
+    """Record that hunks were discarded (removed from working tree)."""
+    new_hashes = {hunk_hash for hunk_hash in hunk_hashes if hunk_hash}
+    if not new_hashes:
+        return
+    discarded_path = get_discarded_hunks_file_path()
+    existing = read_text_file_line_set(discarded_path)
+    existing.update(new_hashes)
+    write_text_file_contents(discarded_path, "\n".join(sorted(existing)) + "\n" if existing else "")
+
+
 def get_hunk_counts() -> dict[str, int]:
     """Get counts of hunks in various states.
 

--- a/src/git_stage_batch/data/progress.py
+++ b/src/git_stage_batch/data/progress.py
@@ -6,6 +6,7 @@ import json
 
 from ..core.models import (
     BinaryFileChange,
+    GitlinkChange,
     LineLevelChange,
 )
 from ..utils.file_io import (
@@ -73,6 +74,21 @@ def record_binary_hunk_skipped(binary_change: BinaryFileChange, hunk_hash: str) 
         "line": None,
         "ids": [],
         "change_type": binary_change.change_type,
+    }
+    _append_skipped_hunk_metadata(metadata)
+
+
+def record_gitlink_hunk_skipped(gitlink_change: GitlinkChange, hunk_hash: str) -> None:
+    """Record that a gitlink change was skipped with file-level metadata."""
+    metadata = {
+        "hash": hunk_hash,
+        "file": gitlink_change.path(),
+        "line": None,
+        "ids": [],
+        "type": "submodule",
+        "change_type": gitlink_change.change_type,
+        "old_oid": gitlink_change.old_oid,
+        "new_oid": gitlink_change.new_oid,
     }
     _append_skipped_hunk_metadata(metadata)
 

--- a/src/git_stage_batch/data/progress.py
+++ b/src/git_stage_batch/data/progress.py
@@ -9,6 +9,7 @@ from ..core.models import (
     GitlinkChange,
     LineLevelChange,
     RenameChange,
+    TextFileDeletionChange,
 )
 from ..utils.file_io import (
     count_nonblank_text_file_lines,
@@ -104,6 +105,22 @@ def record_rename_hunk_skipped(rename_change: RenameChange, hunk_hash: str) -> N
         "type": "rename",
         "old_path": rename_change.old_path,
         "new_path": rename_change.new_path,
+    }
+    _append_skipped_hunk_metadata(metadata)
+
+
+def record_text_deletion_hunk_skipped(
+    deletion_change: TextFileDeletionChange,
+    hunk_hash: str,
+) -> None:
+    """Record that a whole-text-file deletion was skipped with file-level metadata."""
+    metadata = {
+        "hash": hunk_hash,
+        "file": deletion_change.path(),
+        "line": None,
+        "ids": [],
+        "type": "text-deletion",
+        "change_type": "deleted",
     }
     _append_skipped_hunk_metadata(metadata)
 

--- a/src/git_stage_batch/data/progress.py
+++ b/src/git_stage_batch/data/progress.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 
+from ..core.models import LineLevelChange
 from ..utils.file_io import (
     count_nonblank_text_file_lines,
     read_text_file_contents,
@@ -41,6 +42,29 @@ def record_hunks_discarded(hunk_hashes: list[str]) -> None:
     existing = read_text_file_line_set(discarded_path)
     existing.update(new_hashes)
     write_text_file_contents(discarded_path, "\n".join(sorted(existing)) + "\n" if existing else "")
+
+
+def record_hunk_skipped(line_changes: LineLevelChange, hunk_hash: str) -> None:
+    """Record that a hunk was skipped with metadata for display."""
+    first_changed_line = None
+    for entry in line_changes.lines:
+        if entry.kind != " ":
+            first_changed_line = entry.old_line_number or entry.new_line_number
+            break
+
+    metadata = {
+        "hash": hunk_hash,
+        "file": line_changes.path,
+        "line": first_changed_line or 0,
+        "ids": line_changes.changed_line_ids(),
+    }
+    _append_skipped_hunk_metadata(metadata)
+
+
+def _append_skipped_hunk_metadata(metadata: dict) -> None:
+    jsonl_path = get_skipped_hunks_jsonl_file_path()
+    with jsonl_path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(metadata) + "\n")
 
 
 def get_hunk_counts() -> dict[str, int]:

--- a/src/git_stage_batch/data/progress.py
+++ b/src/git_stage_batch/data/progress.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import json
 
-from ..core.models import LineLevelChange
+from ..core.models import (
+    BinaryFileChange,
+    LineLevelChange,
+)
 from ..utils.file_io import (
     count_nonblank_text_file_lines,
     read_text_file_contents,
@@ -57,6 +60,19 @@ def record_hunk_skipped(line_changes: LineLevelChange, hunk_hash: str) -> None:
         "file": line_changes.path,
         "line": first_changed_line or 0,
         "ids": line_changes.changed_line_ids(),
+    }
+    _append_skipped_hunk_metadata(metadata)
+
+
+def record_binary_hunk_skipped(binary_change: BinaryFileChange, hunk_hash: str) -> None:
+    """Record that a binary change was skipped with file-level metadata."""
+    file_path = binary_change.new_path if binary_change.new_path != "/dev/null" else binary_change.old_path
+    metadata = {
+        "hash": hunk_hash,
+        "file": file_path,
+        "line": None,
+        "ids": [],
+        "change_type": binary_change.change_type,
     }
     _append_skipped_hunk_metadata(metadata)
 

--- a/src/git_stage_batch/data/progress.py
+++ b/src/git_stage_batch/data/progress.py
@@ -131,6 +131,34 @@ def _append_skipped_hunk_metadata(metadata: dict) -> None:
         f.write(json.dumps(metadata) + "\n")
 
 
+def format_id_range(ids: list[int]) -> str:
+    """Format list of IDs as compact range string (e.g., '1-5,7,9-11')."""
+    if not ids:
+        return ""
+
+    ids = sorted(ids)
+    ranges = []
+    start = ids[0]
+    end = ids[0]
+
+    for i in range(1, len(ids)):
+        if ids[i] == end + 1:
+            end = ids[i]
+        else:
+            if start == end:
+                ranges.append(str(start))
+            else:
+                ranges.append(f"{start}-{end}")
+            start = end = ids[i]
+
+    if start == end:
+        ranges.append(str(start))
+    else:
+        ranges.append(f"{start}-{end}")
+
+    return ",".join(ranges)
+
+
 def get_hunk_counts() -> dict[str, int]:
     """Get counts of hunks in various states.
 

--- a/src/git_stage_batch/data/progress.py
+++ b/src/git_stage_batch/data/progress.py
@@ -8,6 +8,7 @@ from ..core.models import (
     BinaryFileChange,
     GitlinkChange,
     LineLevelChange,
+    RenameChange,
 )
 from ..utils.file_io import (
     count_nonblank_text_file_lines,
@@ -89,6 +90,20 @@ def record_gitlink_hunk_skipped(gitlink_change: GitlinkChange, hunk_hash: str) -
         "change_type": gitlink_change.change_type,
         "old_oid": gitlink_change.old_oid,
         "new_oid": gitlink_change.new_oid,
+    }
+    _append_skipped_hunk_metadata(metadata)
+
+
+def record_rename_hunk_skipped(rename_change: RenameChange, hunk_hash: str) -> None:
+    """Record that a rename change was skipped with file-level metadata."""
+    metadata = {
+        "hash": hunk_hash,
+        "file": rename_change.new_path,
+        "line": None,
+        "ids": [],
+        "type": "rename",
+        "old_path": rename_change.old_path,
+        "new_path": rename_change.new_path,
     }
     _append_skipped_hunk_metadata(metadata)
 

--- a/src/git_stage_batch/data/progress.py
+++ b/src/git_stage_batch/data/progress.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 import json
 
-from ..utils.file_io import count_nonblank_text_file_lines, read_text_file_contents
+from ..utils.file_io import (
+    count_nonblank_text_file_lines,
+    read_text_file_contents,
+    read_text_file_line_set,
+    write_text_file_contents,
+)
 from ..utils.git import run_git_command
 from ..utils.paths import (
     get_line_changes_json_file_path,
@@ -12,6 +17,14 @@ from ..utils.paths import (
     get_included_hunks_file_path,
     get_skipped_hunks_jsonl_file_path,
 )
+
+
+def record_hunk_included(hunk_hash: str) -> None:
+    """Record that a hunk was included (staged)."""
+    included_path = get_included_hunks_file_path()
+    existing = read_text_file_line_set(included_path)
+    existing.add(hunk_hash)
+    write_text_file_contents(included_path, "\n".join(sorted(existing)) + "\n" if existing else "")
 
 
 def get_hunk_counts() -> dict[str, int]:

--- a/src/git_stage_batch/data/selected_change/__init__.py
+++ b/src/git_stage_batch/data/selected_change/__init__.py
@@ -1,0 +1,3 @@
+"""Selected-change state helpers."""
+
+from __future__ import annotations

--- a/src/git_stage_batch/data/selected_change/lifecycle.py
+++ b/src/git_stage_batch/data/selected_change/lifecycle.py
@@ -1,0 +1,13 @@
+"""Selected-change lifecycle helpers shared by command workflows."""
+
+from __future__ import annotations
+
+from .store import clear_selected_change_persistence_files
+
+
+def clear_selected_change_state_files() -> None:
+    """Clear selected change state and dependent file-review state."""
+    from ..file_review.state import clear_last_file_review_state
+
+    clear_selected_change_persistence_files()
+    clear_last_file_review_state()

--- a/src/git_stage_batch/data/selected_change/snapshots.py
+++ b/src/git_stage_batch/data/selected_change/snapshots.py
@@ -1,0 +1,88 @@
+"""Snapshot persistence for the currently selected file."""
+
+from __future__ import annotations
+
+from contextlib import ExitStack
+
+from ...editor import (
+    EditorBuffer,
+    buffer_byte_count,
+    buffer_preview,
+    load_git_object_as_buffer,
+    write_buffer_to_path,
+)
+from ...utils.git import get_git_repository_root_path
+from ...utils.journal import log_journal
+from ...utils.paths import get_index_snapshot_file_path, get_working_tree_snapshot_file_path
+
+
+def write_snapshots_for_selected_file_path(file_path: str) -> None:
+    """Write snapshots of the file from both the index and working tree."""
+    with ExitStack() as stack:
+        index_version = load_git_object_as_buffer(f":{file_path}")
+        if index_version is None:
+            index_version = EditorBuffer.from_bytes(b"")
+        stack.enter_context(index_version)
+
+        repo_root = get_git_repository_root_path()
+        file_full_path = repo_root / file_path
+        if file_full_path.exists():
+            working_tree_version = EditorBuffer.from_path(file_full_path)
+        else:
+            working_tree_version = EditorBuffer.from_bytes(b"")
+        stack.enter_context(working_tree_version)
+
+        # When index is empty but working tree has content, check if file exists in HEAD.
+        # For new files (not in HEAD), use empty index snapshot.
+        # For existing files with intent-to-add applied, use HEAD content.
+        if buffer_byte_count(index_version) == 0 and buffer_byte_count(working_tree_version) > 0:
+            head_version = load_git_object_as_buffer(f"HEAD:{file_path}")
+            if head_version is not None:
+                if buffer_byte_count(head_version) > 0:
+                    index_version = stack.enter_context(head_version)
+                else:
+                    head_version.close()
+
+        write_buffer_to_path(get_index_snapshot_file_path(), index_version)
+        write_buffer_to_path(get_working_tree_snapshot_file_path(), working_tree_version)
+
+        log_journal(
+            "write_snapshots_for_selected_file",
+            file_path=file_path,
+            index_len=buffer_byte_count(index_version),
+            index_lines=_buffer_line_count(index_version),
+            index_preview=(
+                buffer_preview(index_version)
+                if buffer_byte_count(index_version) > 0 else
+                "(empty)"
+            ),
+            working_tree_len=buffer_byte_count(working_tree_version),
+            working_tree_lines=_buffer_line_count(working_tree_version),
+        )
+
+
+def _buffer_line_count(buffer: EditorBuffer) -> int:
+    """Return a line count for journal metadata without materializing content."""
+    line_breaks = 0
+    seen_data = False
+    pending_cr = False
+    last_byte: int | None = None
+
+    for chunk in buffer.byte_chunks():
+        if not chunk:
+            continue
+
+        seen_data = True
+        chunk_breaks = chunk.count(b"\n") + chunk.count(b"\r") - chunk.count(b"\r\n")
+        if pending_cr and chunk.startswith(b"\n"):
+            chunk_breaks -= 1
+
+        line_breaks += chunk_breaks
+        pending_cr = chunk.endswith(b"\r")
+        last_byte = chunk[-1]
+
+    if not seen_data:
+        return 0
+    if last_byte in (ord("\n"), ord("\r")):
+        return line_breaks
+    return line_breaks + 1

--- a/src/git_stage_batch/data/selected_change/snapshots.py
+++ b/src/git_stage_batch/data/selected_change/snapshots.py
@@ -6,6 +6,7 @@ from contextlib import ExitStack
 
 from ...editor import (
     EditorBuffer,
+    buffer_matches,
     buffer_byte_count,
     buffer_preview,
     load_git_object_as_buffer,
@@ -86,3 +87,50 @@ def _buffer_line_count(buffer: EditorBuffer) -> int:
     if last_byte in (ord("\n"), ord("\r")):
         return line_breaks
     return line_breaks + 1
+
+
+def snapshots_are_stale(file_path: str) -> bool:
+    """Check if cached snapshots are stale (file changed since snapshots taken).
+
+    Args:
+        file_path: Repository-relative path to check
+
+    Returns:
+        True if the file has been committed or otherwise changed such that
+        the cached hunk no longer applies
+    """
+    snapshot_base_path = get_index_snapshot_file_path()
+    snapshot_new_path = get_working_tree_snapshot_file_path()
+
+    # Missing snapshots means state is incomplete/stale
+    if not snapshot_base_path.exists() or not snapshot_new_path.exists():
+        return True
+
+    try:
+        with ExitStack() as stack:
+            cached_index_content = stack.enter_context(
+                EditorBuffer.from_path(snapshot_base_path)
+            )
+            cached_worktree_content = stack.enter_context(
+                EditorBuffer.from_path(snapshot_new_path)
+            )
+
+            selected_index_content = load_git_object_as_buffer(f":{file_path}")
+            if selected_index_content is None:
+                selected_index_content = EditorBuffer.from_bytes(b"")
+            stack.enter_context(selected_index_content)
+
+            repo_root = get_git_repository_root_path()
+            file_full_path = repo_root / file_path
+            if file_full_path.exists():
+                selected_worktree_content = EditorBuffer.from_path(file_full_path)
+            else:
+                selected_worktree_content = EditorBuffer.from_bytes(b"")
+            stack.enter_context(selected_worktree_content)
+
+            return (
+                not buffer_matches(cached_index_content, selected_index_content)
+                or not buffer_matches(cached_worktree_content, selected_worktree_content)
+            )
+    except Exception:
+        return True  # Error reading means state is stale

--- a/src/git_stage_batch/data/selected_change/store.py
+++ b/src/git_stage_batch/data/selected_change/store.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 import shutil
 import tempfile
-
 from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import Enum
@@ -30,13 +29,13 @@ from ...exceptions import CommandError
 from ...i18n import _
 from ...utils.file_io import read_text_file_contents, write_text_file_contents
 from ...utils.paths import (
-    get_selected_change_clear_reason_file_path,
-    get_selected_change_kind_file_path,
     get_index_snapshot_file_path,
     get_line_changes_json_file_path,
     get_processed_include_ids_file_path,
     get_processed_skip_ids_file_path,
     get_selected_binary_file_json_path,
+    get_selected_change_clear_reason_file_path,
+    get_selected_change_kind_file_path,
     get_selected_gitlink_file_json_path,
     get_selected_hunk_hash_file_path,
     get_selected_hunk_patch_file_path,
@@ -61,6 +60,7 @@ class SelectedChangeKind(str, Enum):
     BATCH_BINARY = "batch-binary"
     BATCH_GITLINK = "batch-submodule"
 
+
 class SelectedChangeClearReason(str, Enum):
     """Reasons selected change state was intentionally cleared."""
 
@@ -68,6 +68,8 @@ class SelectedChangeClearReason(str, Enum):
     FILE_LIST = "file-list"
     STALE_BATCH_SELECTION = "stale-batch-selection"
 
+
+@dataclass
 class SelectedChangeStateSnapshot:
     """Temporary file copy of selected change state."""
 
@@ -83,9 +85,11 @@ class SelectedChangeStateSnapshot:
     def __exit__(self, exc_type, exc, traceback) -> None:
         self.close()
 
+
 def write_selected_hunk_patch_lines(patch_lines: Sequence[bytes]) -> None:
     with EditorBuffer.from_chunks(iter(patch_lines)) as patch_buffer:
         write_buffer_to_path(get_selected_hunk_patch_file_path(), patch_buffer)
+
 
 def write_line_changes_state(line_changes: LineLevelChange) -> None:
     write_text_file_contents(
@@ -97,9 +101,11 @@ def write_line_changes_state(line_changes: LineLevelChange) -> None:
         ),
     )
 
+
 def load_line_changes_from_patch_path(patch_path: Path) -> LineLevelChange:
     with EditorBuffer.from_path(patch_path) as patch_lines:
         return build_line_changes_from_patch_lines(patch_lines)
+
 
 def _selected_change_state_paths():
     """Return files that make up the cached selected change state."""
@@ -140,6 +146,7 @@ def snapshot_selected_change_state() -> SelectedChangeStateSnapshot:
         temporary_directory=temporary_directory,
     )
 
+
 def restore_selected_change_state(snapshot: SelectedChangeStateSnapshot) -> None:
     """Restore a previously captured selected change cache."""
     for name, path in _selected_change_state_paths().items():
@@ -150,10 +157,13 @@ def restore_selected_change_state(snapshot: SelectedChangeStateSnapshot) -> None
             path.parent.mkdir(parents=True, exist_ok=True)
             shutil.copyfile(snapshot_path, path)
 
+
 def clear_selected_change_persistence_files() -> None:
     """Clear cached selected change state files."""
     for path in _selected_change_state_paths().values():
         path.unlink(missing_ok=True)
+    # processed_batch_ids is global state (union of all batches), not per-hunk state
+
 
 def _clear_selected_line_payload_files() -> None:
     """Clear selected line/hunk state before storing an atomic file selection."""
@@ -163,6 +173,7 @@ def _clear_selected_line_payload_files() -> None:
     get_working_tree_snapshot_file_path().unlink(missing_ok=True)
     get_processed_include_ids_file_path().unlink(missing_ok=True)
     get_processed_skip_ids_file_path().unlink(missing_ok=True)
+
 
 def read_selected_binary_data() -> dict | None:
     """Read cached binary selection data, if structurally valid."""
@@ -174,6 +185,7 @@ def read_selected_binary_data() -> dict | None:
     except json.JSONDecodeError:
         return None
     return binary_data if isinstance(binary_data, dict) else None
+
 
 def load_selected_binary_file() -> BinaryFileChange | None:
     """Load the currently cached binary file."""
@@ -193,6 +205,7 @@ def load_selected_binary_file() -> BinaryFileChange | None:
     except KeyError:
         return None
 
+
 def read_selected_gitlink_data() -> dict | None:
     """Read cached gitlink selection data, if structurally valid."""
     gitlink_path = get_selected_gitlink_file_json_path()
@@ -203,6 +216,7 @@ def read_selected_gitlink_data() -> dict | None:
     except json.JSONDecodeError:
         return None
     return gitlink_data if isinstance(gitlink_data, dict) else None
+
 
 def load_selected_gitlink_change() -> GitlinkChange | None:
     """Load the currently cached gitlink change."""
@@ -224,6 +238,7 @@ def load_selected_gitlink_change() -> GitlinkChange | None:
     except KeyError:
         return None
 
+
 def read_selected_rename_data() -> dict | None:
     """Read cached rename selection data, if structurally valid."""
     rename_path = get_selected_rename_file_json_path()
@@ -234,6 +249,7 @@ def read_selected_rename_data() -> dict | None:
     except json.JSONDecodeError:
         return None
     return rename_data if isinstance(rename_data, dict) else None
+
 
 def load_selected_rename_change() -> RenameChange | None:
     """Load the currently cached rename change."""
@@ -252,6 +268,7 @@ def load_selected_rename_change() -> RenameChange | None:
     except KeyError:
         return None
 
+
 def read_selected_text_deletion_data() -> dict | None:
     """Read cached text deletion selection data, if structurally valid."""
     deletion_path = get_selected_text_deletion_file_json_path()
@@ -262,6 +279,7 @@ def read_selected_text_deletion_data() -> dict | None:
     except json.JSONDecodeError:
         return None
     return deletion_data if isinstance(deletion_data, dict) else None
+
 
 def load_selected_text_deletion_change() -> TextFileDeletionChange | None:
     """Load the currently cached text file deletion change."""
@@ -279,6 +297,7 @@ def load_selected_text_deletion_change() -> TextFileDeletionChange | None:
         )
     except KeyError:
         return None
+
 
 def cache_binary_file_change(
     binary_change: BinaryFileChange,
@@ -315,6 +334,7 @@ def cache_binary_file_change(
         write_snapshots_for_selected_file_path(file_path)
     write_selected_change_kind(kind)
 
+
 def cache_gitlink_change(
     gitlink_change: GitlinkChange,
     *,
@@ -349,6 +369,7 @@ def cache_gitlink_change(
     )
     write_selected_change_kind(kind)
 
+
 def cache_rename_change(rename_change: RenameChange) -> None:
     """Cache a rename change as the current selected change."""
     rename_data = {
@@ -365,6 +386,7 @@ def cache_rename_change(rename_change: RenameChange) -> None:
         compute_rename_change_hash(rename_change),
     )
     write_selected_change_kind(SelectedChangeKind.RENAME)
+
 
 def cache_text_deletion_change(deletion_change: TextFileDeletionChange) -> None:
     """Cache a whole-text-file deletion as the current selected change."""
@@ -383,6 +405,7 @@ def cache_text_deletion_change(deletion_change: TextFileDeletionChange) -> None:
     )
     write_snapshots_for_selected_file_path(deletion_change.path())
     write_selected_change_kind(SelectedChangeKind.DELETION)
+
 
 def get_selected_change_file_path() -> str | None:
     """Return the file path for the currently cached selected change."""
@@ -409,6 +432,7 @@ def get_selected_change_file_path() -> str | None:
     line_changes = load_line_changes_from_patch_path(patch_path)
     return line_changes.path
 
+
 def mark_selected_change_cleared_by_file_list(
     *,
     source: str,
@@ -420,6 +444,7 @@ def mark_selected_change_cleared_by_file_list(
         source=source,
         batch_name=batch_name,
     )
+
 
 def mark_selected_change_cleared_by_stale_batch_selection(
     *,
@@ -433,6 +458,15 @@ def mark_selected_change_cleared_by_stale_batch_selection(
         batch_name=batch_name,
         file_path=file_path,
     )
+
+
+def mark_selected_change_cleared_by_auto_advance_disabled() -> None:
+    """Record that an action left the next change unselected."""
+    _write_selected_change_clear_reason(
+        reason=SelectedChangeClearReason.AUTO_ADVANCE_DISABLED,
+        source="auto-advance",
+    )
+
 
 def _write_selected_change_clear_reason(
     *,
@@ -455,6 +489,7 @@ def _write_selected_change_clear_reason(
             indent=0,
         ),
     )
+
 
 def _read_selected_change_clear_reason() -> dict[str, str | None] | None:
     """Return the structured clear marker, tolerating legacy plain-text state."""
@@ -483,6 +518,7 @@ def _read_selected_change_clear_reason() -> dict[str, str | None] | None:
         "file_path": data.get("file_path") if isinstance(data.get("file_path"), str) else None,
     }
 
+
 def selected_change_was_cleared_by_file_list(
     *,
     source: str | None = None,
@@ -504,6 +540,7 @@ def selected_change_was_cleared_by_file_list(
         return False
     return True
 
+
 def selected_change_was_cleared_by_stale_batch_selection(
     *,
     batch_name: str | None = None,
@@ -519,6 +556,17 @@ def selected_change_was_cleared_by_stale_batch_selection(
     if batch_name is not None and marker["batch_name"] != batch_name:
         return False
     return True
+
+
+def selected_change_was_cleared_by_auto_advance_disabled() -> bool:
+    """Return whether the current empty selection needs an explicit show."""
+    if read_selected_change_kind() is not None:
+        return False
+    marker = _read_selected_change_clear_reason()
+    if marker is None:
+        return False
+    return marker["reason"] == SelectedChangeClearReason.AUTO_ADVANCE_DISABLED.value
+
 
 def refuse_bare_action_after_file_list(
     action_command: str,
@@ -543,6 +591,24 @@ def refuse_bare_action_after_file_list(
         ).format(open_command=open_command, action=action_command)
     )
 
+
+def refuse_bare_action_after_auto_advance_disabled(action_command: str) -> None:
+    """Refuse a bare action after a command declined to select the next hunk."""
+    if not selected_change_was_cleared_by_auto_advance_disabled():
+        return
+    raise CommandError(
+        _(
+            "No selected change.\n"
+            "The previous command did not choose the next hunk because automatic "
+            "advancement is disabled.\n\n"
+            "Run:\n"
+            "  git-stage-batch show\n"
+            "before running:\n"
+            "  git-stage-batch {action}"
+        ).format(action=action_command)
+    )
+
+
 def refuse_bare_action_after_stale_batch_selection(
     action_command: str,
     *,
@@ -564,6 +630,7 @@ def refuse_bare_action_after_stale_batch_selection(
             "  git-stage-batch {action}"
         ).format(file=file_path, batch=batch_name, action=action_command)
     )
+
 
 def write_selected_change_kind(kind: SelectedChangeKind) -> None:
     """Persist the kind of selected change cached in session state."""

--- a/src/git_stage_batch/data/selected_change/store.py
+++ b/src/git_stage_batch/data/selected_change/store.py
@@ -13,10 +13,12 @@ from pathlib import Path
 
 from ...core.diff_parser import build_line_changes_from_patch_lines
 from ...core.hashing import (
+    compute_binary_file_hash,
     compute_rename_change_hash,
     compute_text_file_deletion_hash,
 )
 from ...core.models import (
+    BinaryFileChange,
     LineLevelChange,
     RenameChange,
     TextFileDeletionChange,
@@ -30,6 +32,7 @@ from ...utils.paths import (
     get_line_changes_json_file_path,
     get_processed_include_ids_file_path,
     get_processed_skip_ids_file_path,
+    get_selected_binary_file_json_path,
     get_selected_hunk_hash_file_path,
     get_selected_hunk_patch_file_path,
     get_selected_rename_file_json_path,
@@ -96,6 +99,7 @@ def _selected_change_state_paths():
         "line_state": get_line_changes_json_file_path(),
         "rename": get_selected_rename_file_json_path(),
         "text_deletion": get_selected_text_deletion_file_json_path(),
+        "binary": get_selected_binary_file_json_path(),
         "index_snapshot": get_index_snapshot_file_path(),
         "working_snapshot": get_working_tree_snapshot_file_path(),
         "processed_include_ids": get_processed_include_ids_file_path(),
@@ -146,6 +150,35 @@ def _clear_selected_line_payload_files() -> None:
     get_working_tree_snapshot_file_path().unlink(missing_ok=True)
     get_processed_include_ids_file_path().unlink(missing_ok=True)
     get_processed_skip_ids_file_path().unlink(missing_ok=True)
+
+def read_selected_binary_data() -> dict | None:
+    """Read cached binary selection data, if structurally valid."""
+    binary_path = get_selected_binary_file_json_path()
+    if not binary_path.exists():
+        return None
+    try:
+        binary_data = json.loads(read_text_file_contents(binary_path))
+    except json.JSONDecodeError:
+        return None
+    return binary_data if isinstance(binary_data, dict) else None
+
+def load_selected_binary_file() -> BinaryFileChange | None:
+    """Load the currently cached binary file."""
+    if read_selected_change_kind() not in (SelectedChangeKind.BINARY, SelectedChangeKind.BATCH_BINARY):
+        return None
+
+    binary_data = read_selected_binary_data()
+    if binary_data is None:
+        return None
+
+    try:
+        return BinaryFileChange(
+            old_path=binary_data["old_path"],
+            new_path=binary_data["new_path"],
+            change_type=binary_data["change_type"],
+        )
+    except KeyError:
+        return None
 
 def read_selected_rename_data() -> dict | None:
     """Read cached rename selection data, if structurally valid."""
@@ -203,6 +236,41 @@ def load_selected_text_deletion_change() -> TextFileDeletionChange | None:
     except KeyError:
         return None
 
+def cache_binary_file_change(
+    binary_change: BinaryFileChange,
+    *,
+    kind: SelectedChangeKind = SelectedChangeKind.BINARY,
+    batch_name: str | None = None,
+    batch_binary_fingerprint: str | None = None,
+) -> None:
+    """Cache a binary file change as the current selected change."""
+    if kind not in (SelectedChangeKind.BINARY, SelectedChangeKind.BATCH_BINARY):
+        raise ValueError("binary selections must use a binary selected-change kind")
+    file_path = binary_change.new_path if binary_change.new_path != "/dev/null" else binary_change.old_path
+    binary_data = {
+        "old_path": binary_change.old_path,
+        "new_path": binary_change.new_path,
+        "change_type": binary_change.change_type,
+        "batch_name": batch_name if kind == SelectedChangeKind.BATCH_BINARY else None,
+        "batch_binary_fingerprint": (
+            batch_binary_fingerprint
+            if kind == SelectedChangeKind.BATCH_BINARY else
+            None
+        ),
+    }
+    _clear_selected_line_payload_files()
+    write_text_file_contents(
+        get_selected_binary_file_json_path(),
+        json.dumps(binary_data, ensure_ascii=False, indent=0),
+    )
+    write_text_file_contents(
+        get_selected_hunk_hash_file_path(),
+        compute_binary_file_hash(binary_change),
+    )
+    if kind == SelectedChangeKind.BINARY:
+        write_snapshots_for_selected_file_path(file_path)
+    write_selected_change_kind(kind)
+
 def cache_rename_change(rename_change: RenameChange) -> None:
     """Cache a rename change as the current selected change."""
     rename_data = {
@@ -245,6 +313,8 @@ def write_selected_change_kind(kind: SelectedChangeKind) -> None:
         get_selected_rename_file_json_path().unlink(missing_ok=True)
     if kind != SelectedChangeKind.DELETION:
         get_selected_text_deletion_file_json_path().unlink(missing_ok=True)
+    if kind not in (SelectedChangeKind.BINARY, SelectedChangeKind.BATCH_BINARY):
+        get_selected_binary_file_json_path().unlink(missing_ok=True)
     write_text_file_contents(get_selected_change_kind_file_path(), kind)
 
 

--- a/src/git_stage_batch/data/selected_change/store.py
+++ b/src/git_stage_batch/data/selected_change/store.py
@@ -421,6 +421,19 @@ def mark_selected_change_cleared_by_file_list(
         batch_name=batch_name,
     )
 
+def mark_selected_change_cleared_by_stale_batch_selection(
+    *,
+    batch_name: str,
+    file_path: str,
+) -> None:
+    """Record that a batch mutation invalidated the selected batch file."""
+    _write_selected_change_clear_reason(
+        reason=SelectedChangeClearReason.STALE_BATCH_SELECTION,
+        source="batch",
+        batch_name=batch_name,
+        file_path=file_path,
+    )
+
 def _write_selected_change_clear_reason(
     *,
     reason: SelectedChangeClearReason,
@@ -491,6 +504,22 @@ def selected_change_was_cleared_by_file_list(
         return False
     return True
 
+def selected_change_was_cleared_by_stale_batch_selection(
+    *,
+    batch_name: str | None = None,
+) -> bool:
+    """Return whether the current empty selection is a stale batch selection."""
+    if read_selected_change_kind() is not None:
+        return False
+    marker = _read_selected_change_clear_reason()
+    if marker is None:
+        return False
+    if marker["reason"] != SelectedChangeClearReason.STALE_BATCH_SELECTION.value:
+        return False
+    if batch_name is not None and marker["batch_name"] != batch_name:
+        return False
+    return True
+
 def refuse_bare_action_after_file_list(
     action_command: str,
     *,
@@ -512,6 +541,28 @@ def refuse_bare_action_after_file_list(
             "before running:\n"
             "  git-stage-batch {action}"
         ).format(open_command=open_command, action=action_command)
+    )
+
+def refuse_bare_action_after_stale_batch_selection(
+    action_command: str,
+    *,
+    batch_name: str,
+) -> None:
+    """Refuse a bare batch action after the selected batch file went stale."""
+    if not selected_change_was_cleared_by_stale_batch_selection(batch_name=batch_name):
+        return
+
+    marker = _read_selected_change_clear_reason() or {}
+    file_path = marker.get("file_path") or "the previously selected file"
+    raise CommandError(
+        _(
+            "No selected change.\n"
+            "The selected batch file '{file}' was changed or removed from batch '{batch}'.\n\n"
+            "Open a current batch file with:\n"
+            "  git-stage-batch show --from {batch} --file PATH\n"
+            "before running:\n"
+            "  git-stage-batch {action}"
+        ).format(file=file_path, batch=batch_name, action=action_command)
     )
 
 def write_selected_change_kind(kind: SelectedChangeKind) -> None:

--- a/src/git_stage_batch/data/selected_change/store.py
+++ b/src/git_stage_batch/data/selected_change/store.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import json
+import shutil
+import tempfile
 
 from collections.abc import Sequence
+from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 
@@ -15,8 +18,13 @@ from ...utils.file_io import read_text_file_contents, write_text_file_contents
 from ...utils.paths import (
     get_selected_change_clear_reason_file_path,
     get_selected_change_kind_file_path,
+    get_index_snapshot_file_path,
     get_line_changes_json_file_path,
+    get_processed_include_ids_file_path,
+    get_processed_skip_ids_file_path,
+    get_selected_hunk_hash_file_path,
     get_selected_hunk_patch_file_path,
+    get_working_tree_snapshot_file_path,
 )
 from ..line_state import convert_line_changes_to_serializable_dict
 
@@ -33,6 +41,21 @@ class SelectedChangeKind(str, Enum):
     BATCH_FILE = "batch-file"
     BATCH_BINARY = "batch-binary"
     BATCH_GITLINK = "batch-submodule"
+
+class SelectedChangeStateSnapshot:
+    """Temporary file copy of selected change state."""
+
+    paths: dict[str, Path | None]
+    temporary_directory: tempfile.TemporaryDirectory
+
+    def close(self) -> None:
+        self.temporary_directory.cleanup()
+
+    def __enter__(self) -> SelectedChangeStateSnapshot:
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        self.close()
 
 def write_selected_hunk_patch_lines(patch_lines: Sequence[bytes]) -> None:
     with EditorBuffer.from_chunks(iter(patch_lines)) as patch_buffer:
@@ -51,6 +74,56 @@ def write_line_changes_state(line_changes: LineLevelChange) -> None:
 def load_line_changes_from_patch_path(patch_path: Path) -> LineLevelChange:
     with EditorBuffer.from_path(patch_path) as patch_lines:
         return build_line_changes_from_patch_lines(patch_lines)
+
+def _selected_change_state_paths():
+    """Return files that make up the cached selected change state."""
+    return {
+        "patch": get_selected_hunk_patch_file_path(),
+        "hash": get_selected_hunk_hash_file_path(),
+        "clear_reason": get_selected_change_clear_reason_file_path(),
+        "kind": get_selected_change_kind_file_path(),
+        "line_state": get_line_changes_json_file_path(),
+        "index_snapshot": get_index_snapshot_file_path(),
+        "working_snapshot": get_working_tree_snapshot_file_path(),
+        "processed_include_ids": get_processed_include_ids_file_path(),
+        "processed_skip_ids": get_processed_skip_ids_file_path(),
+    }
+
+
+def snapshot_selected_change_state() -> SelectedChangeStateSnapshot:
+    """Capture the current selected change cache."""
+    temporary_directory = tempfile.TemporaryDirectory()
+    snapshot_root = Path(temporary_directory.name)
+    snapshot_paths: dict[str, Path | None] = {}
+
+    for name, path in _selected_change_state_paths().items():
+        if not path.exists():
+            snapshot_paths[name] = None
+            continue
+
+        snapshot_path = snapshot_root / name
+        shutil.copyfile(path, snapshot_path)
+        snapshot_paths[name] = snapshot_path
+
+    return SelectedChangeStateSnapshot(
+        paths=snapshot_paths,
+        temporary_directory=temporary_directory,
+    )
+
+def restore_selected_change_state(snapshot: SelectedChangeStateSnapshot) -> None:
+    """Restore a previously captured selected change cache."""
+    for name, path in _selected_change_state_paths().items():
+        snapshot_path = snapshot.paths.get(name)
+        if snapshot_path is None:
+            path.unlink(missing_ok=True)
+        else:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(snapshot_path, path)
+
+def clear_selected_change_persistence_files() -> None:
+    """Clear cached selected change state files."""
+    for path in _selected_change_state_paths().values():
+        path.unlink(missing_ok=True)
 
 def write_selected_change_kind(kind: SelectedChangeKind) -> None:
     """Persist the kind of selected change cached in session state."""

--- a/src/git_stage_batch/data/selected_change/store.py
+++ b/src/git_stage_batch/data/selected_change/store.py
@@ -2,13 +2,23 @@
 
 from __future__ import annotations
 
-from enum import Enum
+import json
 
+from collections.abc import Sequence
+from enum import Enum
+from pathlib import Path
+
+from ...core.diff_parser import build_line_changes_from_patch_lines
+from ...core.models import LineLevelChange
+from ...editor import EditorBuffer, write_buffer_to_path
 from ...utils.file_io import read_text_file_contents, write_text_file_contents
 from ...utils.paths import (
     get_selected_change_clear_reason_file_path,
     get_selected_change_kind_file_path,
+    get_line_changes_json_file_path,
+    get_selected_hunk_patch_file_path,
 )
+from ..line_state import convert_line_changes_to_serializable_dict
 
 
 class SelectedChangeKind(str, Enum):
@@ -23,6 +33,24 @@ class SelectedChangeKind(str, Enum):
     BATCH_FILE = "batch-file"
     BATCH_BINARY = "batch-binary"
     BATCH_GITLINK = "batch-submodule"
+
+def write_selected_hunk_patch_lines(patch_lines: Sequence[bytes]) -> None:
+    with EditorBuffer.from_chunks(iter(patch_lines)) as patch_buffer:
+        write_buffer_to_path(get_selected_hunk_patch_file_path(), patch_buffer)
+
+def write_line_changes_state(line_changes: LineLevelChange) -> None:
+    write_text_file_contents(
+        get_line_changes_json_file_path(),
+        json.dumps(
+            convert_line_changes_to_serializable_dict(line_changes),
+            ensure_ascii=False,
+            indent=0,
+        ),
+    )
+
+def load_line_changes_from_patch_path(patch_path: Path) -> LineLevelChange:
+    with EditorBuffer.from_path(patch_path) as patch_lines:
+        return build_line_changes_from_patch_lines(patch_lines)
 
 def write_selected_change_kind(kind: SelectedChangeKind) -> None:
     """Persist the kind of selected change cached in session state."""

--- a/src/git_stage_batch/data/selected_change/store.py
+++ b/src/git_stage_batch/data/selected_change/store.py
@@ -12,10 +12,14 @@ from enum import Enum
 from pathlib import Path
 
 from ...core.diff_parser import build_line_changes_from_patch_lines
-from ...core.hashing import compute_rename_change_hash
+from ...core.hashing import (
+    compute_rename_change_hash,
+    compute_text_file_deletion_hash,
+)
 from ...core.models import (
     LineLevelChange,
     RenameChange,
+    TextFileDeletionChange,
 )
 from ...editor import EditorBuffer, write_buffer_to_path
 from ...utils.file_io import read_text_file_contents, write_text_file_contents
@@ -29,9 +33,11 @@ from ...utils.paths import (
     get_selected_hunk_hash_file_path,
     get_selected_hunk_patch_file_path,
     get_selected_rename_file_json_path,
+    get_selected_text_deletion_file_json_path,
     get_working_tree_snapshot_file_path,
 )
 from ..line_state import convert_line_changes_to_serializable_dict
+from .snapshots import write_snapshots_for_selected_file_path
 
 
 class SelectedChangeKind(str, Enum):
@@ -89,6 +95,7 @@ def _selected_change_state_paths():
         "kind": get_selected_change_kind_file_path(),
         "line_state": get_line_changes_json_file_path(),
         "rename": get_selected_rename_file_json_path(),
+        "text_deletion": get_selected_text_deletion_file_json_path(),
         "index_snapshot": get_index_snapshot_file_path(),
         "working_snapshot": get_working_tree_snapshot_file_path(),
         "processed_include_ids": get_processed_include_ids_file_path(),
@@ -168,6 +175,34 @@ def load_selected_rename_change() -> RenameChange | None:
     except KeyError:
         return None
 
+def read_selected_text_deletion_data() -> dict | None:
+    """Read cached text deletion selection data, if structurally valid."""
+    deletion_path = get_selected_text_deletion_file_json_path()
+    if not deletion_path.exists():
+        return None
+    try:
+        deletion_data = json.loads(read_text_file_contents(deletion_path))
+    except json.JSONDecodeError:
+        return None
+    return deletion_data if isinstance(deletion_data, dict) else None
+
+def load_selected_text_deletion_change() -> TextFileDeletionChange | None:
+    """Load the currently cached text file deletion change."""
+    if read_selected_change_kind() != SelectedChangeKind.DELETION:
+        return None
+
+    deletion_data = read_selected_text_deletion_data()
+    if deletion_data is None:
+        return None
+
+    try:
+        return TextFileDeletionChange(
+            old_path=deletion_data["old_path"],
+            new_path=deletion_data.get("new_path", "/dev/null"),
+        )
+    except KeyError:
+        return None
+
 def cache_rename_change(rename_change: RenameChange) -> None:
     """Cache a rename change as the current selected change."""
     rename_data = {
@@ -185,11 +220,31 @@ def cache_rename_change(rename_change: RenameChange) -> None:
     )
     write_selected_change_kind(SelectedChangeKind.RENAME)
 
+def cache_text_deletion_change(deletion_change: TextFileDeletionChange) -> None:
+    """Cache a whole-text-file deletion as the current selected change."""
+    deletion_data = {
+        "old_path": deletion_change.old_path,
+        "new_path": deletion_change.new_path,
+    }
+    _clear_selected_line_payload_files()
+    write_text_file_contents(
+        get_selected_text_deletion_file_json_path(),
+        json.dumps(deletion_data, ensure_ascii=False, indent=0),
+    )
+    write_text_file_contents(
+        get_selected_hunk_hash_file_path(),
+        compute_text_file_deletion_hash(deletion_change),
+    )
+    write_snapshots_for_selected_file_path(deletion_change.path())
+    write_selected_change_kind(SelectedChangeKind.DELETION)
+
 def write_selected_change_kind(kind: SelectedChangeKind) -> None:
     """Persist the kind of selected change cached in session state."""
     get_selected_change_clear_reason_file_path().unlink(missing_ok=True)
     if kind != SelectedChangeKind.RENAME:
         get_selected_rename_file_json_path().unlink(missing_ok=True)
+    if kind != SelectedChangeKind.DELETION:
+        get_selected_text_deletion_file_json_path().unlink(missing_ok=True)
     write_text_file_contents(get_selected_change_kind_file_path(), kind)
 
 

--- a/src/git_stage_batch/data/selected_change/store.py
+++ b/src/git_stage_batch/data/selected_change/store.py
@@ -14,11 +14,13 @@ from pathlib import Path
 from ...core.diff_parser import build_line_changes_from_patch_lines
 from ...core.hashing import (
     compute_binary_file_hash,
+    compute_gitlink_change_hash,
     compute_rename_change_hash,
     compute_text_file_deletion_hash,
 )
 from ...core.models import (
     BinaryFileChange,
+    GitlinkChange,
     LineLevelChange,
     RenameChange,
     TextFileDeletionChange,
@@ -33,6 +35,7 @@ from ...utils.paths import (
     get_processed_include_ids_file_path,
     get_processed_skip_ids_file_path,
     get_selected_binary_file_json_path,
+    get_selected_gitlink_file_json_path,
     get_selected_hunk_hash_file_path,
     get_selected_hunk_patch_file_path,
     get_selected_rename_file_json_path,
@@ -100,6 +103,7 @@ def _selected_change_state_paths():
         "rename": get_selected_rename_file_json_path(),
         "text_deletion": get_selected_text_deletion_file_json_path(),
         "binary": get_selected_binary_file_json_path(),
+        "gitlink": get_selected_gitlink_file_json_path(),
         "index_snapshot": get_index_snapshot_file_path(),
         "working_snapshot": get_working_tree_snapshot_file_path(),
         "processed_include_ids": get_processed_include_ids_file_path(),
@@ -176,6 +180,37 @@ def load_selected_binary_file() -> BinaryFileChange | None:
             old_path=binary_data["old_path"],
             new_path=binary_data["new_path"],
             change_type=binary_data["change_type"],
+        )
+    except KeyError:
+        return None
+
+def read_selected_gitlink_data() -> dict | None:
+    """Read cached gitlink selection data, if structurally valid."""
+    gitlink_path = get_selected_gitlink_file_json_path()
+    if not gitlink_path.exists():
+        return None
+    try:
+        gitlink_data = json.loads(read_text_file_contents(gitlink_path))
+    except json.JSONDecodeError:
+        return None
+    return gitlink_data if isinstance(gitlink_data, dict) else None
+
+def load_selected_gitlink_change() -> GitlinkChange | None:
+    """Load the currently cached gitlink change."""
+    if read_selected_change_kind() not in (SelectedChangeKind.GITLINK, SelectedChangeKind.BATCH_GITLINK):
+        return None
+
+    gitlink_data = read_selected_gitlink_data()
+    if gitlink_data is None:
+        return None
+
+    try:
+        return GitlinkChange(
+            old_path=gitlink_data["old_path"],
+            new_path=gitlink_data["new_path"],
+            old_oid=gitlink_data.get("old_oid"),
+            new_oid=gitlink_data.get("new_oid"),
+            change_type=gitlink_data["change_type"],
         )
     except KeyError:
         return None
@@ -271,6 +306,40 @@ def cache_binary_file_change(
         write_snapshots_for_selected_file_path(file_path)
     write_selected_change_kind(kind)
 
+def cache_gitlink_change(
+    gitlink_change: GitlinkChange,
+    *,
+    kind: SelectedChangeKind = SelectedChangeKind.GITLINK,
+    batch_name: str | None = None,
+    batch_gitlink_fingerprint: str | None = None,
+) -> None:
+    """Cache a gitlink change as the current selected change."""
+    if kind not in (SelectedChangeKind.GITLINK, SelectedChangeKind.BATCH_GITLINK):
+        raise ValueError("gitlink selections must use a gitlink selected-change kind")
+    gitlink_data = {
+        "old_path": gitlink_change.old_path,
+        "new_path": gitlink_change.new_path,
+        "old_oid": gitlink_change.old_oid,
+        "new_oid": gitlink_change.new_oid,
+        "change_type": gitlink_change.change_type,
+        "batch_name": batch_name if kind == SelectedChangeKind.BATCH_GITLINK else None,
+        "batch_gitlink_fingerprint": (
+            batch_gitlink_fingerprint
+            if kind == SelectedChangeKind.BATCH_GITLINK else
+            None
+        ),
+    }
+    _clear_selected_line_payload_files()
+    write_text_file_contents(
+        get_selected_gitlink_file_json_path(),
+        json.dumps(gitlink_data, ensure_ascii=False, indent=0),
+    )
+    write_text_file_contents(
+        get_selected_hunk_hash_file_path(),
+        compute_gitlink_change_hash(gitlink_change),
+    )
+    write_selected_change_kind(kind)
+
 def cache_rename_change(rename_change: RenameChange) -> None:
     """Cache a rename change as the current selected change."""
     rename_data = {
@@ -315,6 +384,8 @@ def write_selected_change_kind(kind: SelectedChangeKind) -> None:
         get_selected_text_deletion_file_json_path().unlink(missing_ok=True)
     if kind not in (SelectedChangeKind.BINARY, SelectedChangeKind.BATCH_BINARY):
         get_selected_binary_file_json_path().unlink(missing_ok=True)
+    if kind not in (SelectedChangeKind.GITLINK, SelectedChangeKind.BATCH_GITLINK):
+        get_selected_gitlink_file_json_path().unlink(missing_ok=True)
     write_text_file_contents(get_selected_change_kind_file_path(), kind)
 
 

--- a/src/git_stage_batch/data/selected_change/store.py
+++ b/src/git_stage_batch/data/selected_change/store.py
@@ -375,6 +375,31 @@ def cache_text_deletion_change(deletion_change: TextFileDeletionChange) -> None:
     write_snapshots_for_selected_file_path(deletion_change.path())
     write_selected_change_kind(SelectedChangeKind.DELETION)
 
+def get_selected_change_file_path() -> str | None:
+    """Return the file path for the currently cached selected change."""
+    rename_change = load_selected_rename_change()
+    if rename_change is not None:
+        return rename_change.path()
+
+    deletion_change = load_selected_text_deletion_change()
+    if deletion_change is not None:
+        return deletion_change.path()
+
+    gitlink_change = load_selected_gitlink_change()
+    if gitlink_change is not None:
+        return gitlink_change.path()
+
+    binary_file = load_selected_binary_file()
+    if binary_file is not None:
+        return binary_file.new_path if binary_file.new_path != "/dev/null" else binary_file.old_path
+
+    patch_path = get_selected_hunk_patch_file_path()
+    if not patch_path.exists():
+        return None
+
+    line_changes = load_line_changes_from_patch_path(patch_path)
+    return line_changes.path
+
 def write_selected_change_kind(kind: SelectedChangeKind) -> None:
     """Persist the kind of selected change cached in session state."""
     get_selected_change_clear_reason_file_path().unlink(missing_ok=True)

--- a/src/git_stage_batch/data/selected_change/store.py
+++ b/src/git_stage_batch/data/selected_change/store.py
@@ -12,7 +12,11 @@ from enum import Enum
 from pathlib import Path
 
 from ...core.diff_parser import build_line_changes_from_patch_lines
-from ...core.models import LineLevelChange
+from ...core.hashing import compute_rename_change_hash
+from ...core.models import (
+    LineLevelChange,
+    RenameChange,
+)
 from ...editor import EditorBuffer, write_buffer_to_path
 from ...utils.file_io import read_text_file_contents, write_text_file_contents
 from ...utils.paths import (
@@ -24,6 +28,7 @@ from ...utils.paths import (
     get_processed_skip_ids_file_path,
     get_selected_hunk_hash_file_path,
     get_selected_hunk_patch_file_path,
+    get_selected_rename_file_json_path,
     get_working_tree_snapshot_file_path,
 )
 from ..line_state import convert_line_changes_to_serializable_dict
@@ -83,6 +88,7 @@ def _selected_change_state_paths():
         "clear_reason": get_selected_change_clear_reason_file_path(),
         "kind": get_selected_change_kind_file_path(),
         "line_state": get_line_changes_json_file_path(),
+        "rename": get_selected_rename_file_json_path(),
         "index_snapshot": get_index_snapshot_file_path(),
         "working_snapshot": get_working_tree_snapshot_file_path(),
         "processed_include_ids": get_processed_include_ids_file_path(),
@@ -125,9 +131,65 @@ def clear_selected_change_persistence_files() -> None:
     for path in _selected_change_state_paths().values():
         path.unlink(missing_ok=True)
 
+def _clear_selected_line_payload_files() -> None:
+    """Clear selected line/hunk state before storing an atomic file selection."""
+    get_selected_hunk_patch_file_path().unlink(missing_ok=True)
+    get_line_changes_json_file_path().unlink(missing_ok=True)
+    get_index_snapshot_file_path().unlink(missing_ok=True)
+    get_working_tree_snapshot_file_path().unlink(missing_ok=True)
+    get_processed_include_ids_file_path().unlink(missing_ok=True)
+    get_processed_skip_ids_file_path().unlink(missing_ok=True)
+
+def read_selected_rename_data() -> dict | None:
+    """Read cached rename selection data, if structurally valid."""
+    rename_path = get_selected_rename_file_json_path()
+    if not rename_path.exists():
+        return None
+    try:
+        rename_data = json.loads(read_text_file_contents(rename_path))
+    except json.JSONDecodeError:
+        return None
+    return rename_data if isinstance(rename_data, dict) else None
+
+def load_selected_rename_change() -> RenameChange | None:
+    """Load the currently cached rename change."""
+    if read_selected_change_kind() != SelectedChangeKind.RENAME:
+        return None
+
+    rename_data = read_selected_rename_data()
+    if rename_data is None:
+        return None
+
+    try:
+        return RenameChange(
+            old_path=rename_data["old_path"],
+            new_path=rename_data["new_path"],
+        )
+    except KeyError:
+        return None
+
+def cache_rename_change(rename_change: RenameChange) -> None:
+    """Cache a rename change as the current selected change."""
+    rename_data = {
+        "old_path": rename_change.old_path,
+        "new_path": rename_change.new_path,
+    }
+    _clear_selected_line_payload_files()
+    write_text_file_contents(
+        get_selected_rename_file_json_path(),
+        json.dumps(rename_data, ensure_ascii=False, indent=0),
+    )
+    write_text_file_contents(
+        get_selected_hunk_hash_file_path(),
+        compute_rename_change_hash(rename_change),
+    )
+    write_selected_change_kind(SelectedChangeKind.RENAME)
+
 def write_selected_change_kind(kind: SelectedChangeKind) -> None:
     """Persist the kind of selected change cached in session state."""
     get_selected_change_clear_reason_file_path().unlink(missing_ok=True)
+    if kind != SelectedChangeKind.RENAME:
+        get_selected_rename_file_json_path().unlink(missing_ok=True)
     write_text_file_contents(get_selected_change_kind_file_path(), kind)
 
 

--- a/src/git_stage_batch/data/selected_change/store.py
+++ b/src/git_stage_batch/data/selected_change/store.py
@@ -26,6 +26,8 @@ from ...core.models import (
     TextFileDeletionChange,
 )
 from ...editor import EditorBuffer, write_buffer_to_path
+from ...exceptions import CommandError
+from ...i18n import _
 from ...utils.file_io import read_text_file_contents, write_text_file_contents
 from ...utils.paths import (
     get_selected_change_clear_reason_file_path,
@@ -58,6 +60,13 @@ class SelectedChangeKind(str, Enum):
     BATCH_FILE = "batch-file"
     BATCH_BINARY = "batch-binary"
     BATCH_GITLINK = "batch-submodule"
+
+class SelectedChangeClearReason(str, Enum):
+    """Reasons selected change state was intentionally cleared."""
+
+    AUTO_ADVANCE_DISABLED = "auto-advance-disabled"
+    FILE_LIST = "file-list"
+    STALE_BATCH_SELECTION = "stale-batch-selection"
 
 class SelectedChangeStateSnapshot:
     """Temporary file copy of selected change state."""
@@ -399,6 +408,111 @@ def get_selected_change_file_path() -> str | None:
 
     line_changes = load_line_changes_from_patch_path(patch_path)
     return line_changes.path
+
+def mark_selected_change_cleared_by_file_list(
+    *,
+    source: str,
+    batch_name: str | None = None,
+) -> None:
+    """Record that a navigational file list intentionally cleared selection."""
+    _write_selected_change_clear_reason(
+        reason=SelectedChangeClearReason.FILE_LIST,
+        source=source,
+        batch_name=batch_name,
+    )
+
+def _write_selected_change_clear_reason(
+    *,
+    reason: SelectedChangeClearReason,
+    source: str,
+    batch_name: str | None = None,
+    file_path: str | None = None,
+) -> None:
+    """Write a structured selected-change clear marker."""
+    write_text_file_contents(
+        get_selected_change_clear_reason_file_path(),
+        json.dumps(
+            {
+                "reason": reason.value,
+                "source": source,
+                "batch_name": batch_name,
+                "file_path": file_path,
+            },
+            ensure_ascii=False,
+            indent=0,
+        ),
+    )
+
+def _read_selected_change_clear_reason() -> dict[str, str | None] | None:
+    """Return the structured clear marker, tolerating legacy plain-text state."""
+    raw_reason = read_text_file_contents(get_selected_change_clear_reason_file_path()).strip()
+    if not raw_reason:
+        return None
+    if raw_reason == SelectedChangeClearReason.FILE_LIST.value:
+        return {
+            "reason": SelectedChangeClearReason.FILE_LIST.value,
+            "source": None,
+            "batch_name": None,
+        }
+    try:
+        data = json.loads(raw_reason)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    reason = data.get("reason")
+    if reason not in {item.value for item in SelectedChangeClearReason}:
+        return None
+    return {
+        "reason": reason,
+        "source": data.get("source") if isinstance(data.get("source"), str) else None,
+        "batch_name": data.get("batch_name") if isinstance(data.get("batch_name"), str) else None,
+        "file_path": data.get("file_path") if isinstance(data.get("file_path"), str) else None,
+    }
+
+def selected_change_was_cleared_by_file_list(
+    *,
+    source: str | None = None,
+    batch_name: str | None = None,
+) -> bool:
+    """Return whether the current empty selection came from a file list."""
+    if read_selected_change_kind() is not None:
+        return False
+    marker = _read_selected_change_clear_reason()
+    if marker is None:
+        return False
+    if marker["reason"] != SelectedChangeClearReason.FILE_LIST.value:
+        return False
+    marker_source = marker["source"]
+    marker_batch_name = marker["batch_name"]
+    if source is not None and marker_source != source:
+        return False
+    if batch_name is not None and marker_batch_name != batch_name:
+        return False
+    return True
+
+def refuse_bare_action_after_file_list(
+    action_command: str,
+    *,
+    open_command: str = "git-stage-batch show --file PATH",
+    source: str | None = None,
+    batch_name: str | None = None,
+) -> None:
+    """Refuse a bare action after a navigational file list cleared selection."""
+    if not selected_change_was_cleared_by_file_list(source=source, batch_name=batch_name):
+        return
+    raise CommandError(
+        _(
+            "No selected change.\n"
+            "The last command only showed files; it did not choose one for follow-up actions.\n\n"
+            "Run:\n"
+            "  git-stage-batch show\n"
+            "or choose a file with:\n"
+            "  {open_command}\n"
+            "before running:\n"
+            "  git-stage-batch {action}"
+        ).format(open_command=open_command, action=action_command)
+    )
 
 def write_selected_change_kind(kind: SelectedChangeKind) -> None:
     """Persist the kind of selected change cached in session state."""

--- a/src/git_stage_batch/data/selected_change/store.py
+++ b/src/git_stage_batch/data/selected_change/store.py
@@ -1,0 +1,46 @@
+"""Selected-change state file persistence."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from ...utils.file_io import read_text_file_contents, write_text_file_contents
+from ...utils.paths import (
+    get_selected_change_clear_reason_file_path,
+    get_selected_change_kind_file_path,
+)
+
+
+class SelectedChangeKind(str, Enum):
+    """Kinds of selected changes cached in session state."""
+
+    HUNK = "hunk"
+    FILE = "file"
+    RENAME = "rename"
+    DELETION = "deletion"
+    BINARY = "binary"
+    GITLINK = "submodule"
+    BATCH_FILE = "batch-file"
+    BATCH_BINARY = "batch-binary"
+    BATCH_GITLINK = "batch-submodule"
+
+def write_selected_change_kind(kind: SelectedChangeKind) -> None:
+    """Persist the kind of selected change cached in session state."""
+    get_selected_change_clear_reason_file_path().unlink(missing_ok=True)
+    write_text_file_contents(get_selected_change_kind_file_path(), kind)
+
+
+def read_selected_change_kind() -> SelectedChangeKind | None:
+    """Return the kind of selected change cached in session state."""
+    path = get_selected_change_kind_file_path()
+    if not path.exists():
+        return None
+
+    raw_kind = read_text_file_contents(path).strip()
+    if not raw_kind:
+        return None
+
+    try:
+        return SelectedChangeKind(raw_kind)
+    except ValueError:
+        return None

--- a/src/git_stage_batch/output/file_review.py
+++ b/src/git_stage_batch/output/file_review.py
@@ -24,7 +24,7 @@ from ..data.file_review.state import (
     fingerprint_selected_file_view,
     _line_action_command,
 )
-from ..data.hunk_tracking import SelectedChangeKind
+from ..data.selected_change.store import SelectedChangeKind
 from ..exceptions import CommandError
 from ..i18n import _
 from .colors import Colors

--- a/src/git_stage_batch/output/file_review.py
+++ b/src/git_stage_batch/output/file_review.py
@@ -15,7 +15,7 @@ from ..core.actionable_changes import (
 )
 from ..core.line_selection import format_line_ids, parse_positive_selection
 from ..core.models import HunkHeader, LineEntry, LineLevelChange, ReviewActionGroup
-from ..data.file_review_state import (
+from ..data.file_review.state import (
     FileReviewAction,
     FileReviewState,
     FileReviewSelectionState,

--- a/src/git_stage_batch/staging/operations.py
+++ b/src/git_stage_batch/staging/operations.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Iterator, Sequence
 
 from ..core.models import LineEntry, LineLevelChange
-from ..batch.replacement import (
+from ..core.replacement import (
     ReplacementPayload,
     coerce_replacement_payload,
     replacement_line_bodies,

--- a/src/git_stage_batch/tui/file_review.py
+++ b/src/git_stage_batch/tui/file_review.py
@@ -6,7 +6,7 @@ import sys
 from dataclasses import dataclass
 
 from ..batch.query import read_batch_metadata
-from ..data.file_review_state import read_last_file_review_state
+from ..data.file_review.state import read_last_file_review_state
 from ..data.line_state import load_line_changes_from_state
 from ..data.file_tracking import list_untracked_files
 from ..data.progress import get_hunk_counts

--- a/src/git_stage_batch/tui/file_review/__init__.py
+++ b/src/git_stage_batch/tui/file_review/__init__.py
@@ -5,17 +5,17 @@ from __future__ import annotations
 import sys
 from dataclasses import dataclass
 
-from ..batch.query import read_batch_metadata
-from ..data.file_review.state import read_last_file_review_state
-from ..data.line_state import load_line_changes_from_state
-from ..data.file_tracking import list_untracked_files
-from ..data.progress import get_hunk_counts
-from ..exceptions import BypassRefresh, CommandError
-from ..i18n import _
-from ..utils.file_patterns import list_changed_files, resolve_gitignore_style_patterns
-from .display import print_status_bar
-from .flow import FlowState, LocationRole
-from .prompts import (
+from ...batch.query import read_batch_metadata
+from ...data.file_review.state import read_last_file_review_state
+from ...data.line_state import load_line_changes_from_state
+from ...data.file_tracking import list_untracked_files
+from ...data.progress import get_hunk_counts
+from ...exceptions import BypassRefresh, CommandError
+from ...i18n import _
+from ...utils.file_patterns import list_changed_files, resolve_gitignore_style_patterns
+from ..display import print_status_bar
+from ..flow import FlowState, LocationRole
+from ..prompts import (
     confirm_destructive_operation,
     prompt_fixup_action,
     prompt_line_ids,
@@ -141,7 +141,7 @@ def _render_review(state: FileReviewState) -> bool:
 
     try:
         if state.flow_state.source.role is LocationRole.BATCH:
-            from ..commands.show_from import command_show_from_batch
+            from ...commands.show_from import command_show_from_batch
 
             command_show_from_batch(
                 state.flow_state.source.batch_name,
@@ -150,7 +150,7 @@ def _render_review(state: FileReviewState) -> bool:
                 selectable=True,
             )
         else:
-            from ..commands.show import command_show
+            from ...commands.show import command_show
 
             command_show(
                 file=state.file_path,
@@ -445,7 +445,7 @@ def _apply_marked_file_action(
     for path in sorted(marked_paths):
         try:
             if action == "B":
-                from ..commands.block_file import command_block_file
+                from ...commands.block_file import command_block_file
 
                 command_block_file(path, local_only=local_only)
                 continue
@@ -486,7 +486,7 @@ def _browse_candidates(state: FileReviewState) -> None:
     selector = f"{batch_name}:{operation}"
 
     try:
-        from ..commands.show_from import command_show_from_batch
+        from ...commands.show_from import command_show_from_batch
 
         command_show_from_batch(selector, file=state.file_path)
     except CommandError as e:
@@ -554,7 +554,7 @@ def _preview_candidate(
     ordinal: int,
     file_path: str,
 ) -> None:
-    from ..commands.show_from import command_show_from_batch
+    from ...commands.show_from import command_show_from_batch
 
     try:
         command_show_from_batch(
@@ -574,12 +574,12 @@ def _execute_candidate(
     selector = f"{batch_name}:{operation}:{ordinal}"
     try:
         if operation == "include":
-            from ..commands.include_from import command_include_from_batch
+            from ...commands.include_from import command_include_from_batch
 
             command_include_from_batch(selector, file=file_path)
             return
 
-        from ..commands.apply_from import command_apply_from_batch
+        from ...commands.apply_from import command_apply_from_batch
 
         command_apply_from_batch(selector, file=file_path)
     except CommandError as e:
@@ -663,7 +663,7 @@ def _apply_block_action(state: FileReviewState, action: str) -> None:
             return
 
         try:
-            from ..commands.block_file import command_block_file
+            from ...commands.block_file import command_block_file
 
             command_block_file(state.file_path, local_only=local_only)
         except CommandError as e:
@@ -671,7 +671,7 @@ def _apply_block_action(state: FileReviewState, action: str) -> None:
         return
 
     try:
-        from ..commands.unblock_file import command_unblock_file
+        from ...commands.unblock_file import command_unblock_file
 
         command_unblock_file(state.file_path)
     except CommandError as e:
@@ -687,7 +687,7 @@ def _apply_fixup_action(state: FileReviewState) -> None:
     if not line_ids:
         return
 
-    from ..commands.suggest_fixup import (
+    from ...commands.suggest_fixup import (
         _load_suggest_fixup_state,
         _reset_suggest_fixup_state,
         command_suggest_fixup_line,
@@ -743,7 +743,7 @@ def _apply_live_line_action(
 ) -> None:
     if action == "i":
         if state.flow_state.target.role is LocationRole.BATCH:
-            from ..commands.include import command_include_to_batch
+            from ...commands.include import command_include_to_batch
 
             command_include_to_batch(
                 state.flow_state.target.batch_name,
@@ -754,14 +754,14 @@ def _apply_live_line_action(
             )
             return
 
-        from ..commands.include import command_include_line
+        from ...commands.include import command_include_line
 
         command_include_line(line_ids, file=state.file_path, auto_advance=False)
         return
 
     if action == "s":
         if state.flow_state.target.role is LocationRole.BATCH:
-            from ..commands.include import command_include_to_batch
+            from ...commands.include import command_include_to_batch
 
             command_include_to_batch(
                 state.flow_state.target.batch_name,
@@ -772,13 +772,13 @@ def _apply_live_line_action(
             )
             return
 
-        from ..commands.skip import command_skip_line
+        from ...commands.skip import command_skip_line
 
         command_skip_line(line_ids, file=state.file_path, auto_advance=False)
         return
 
     if state.flow_state.target.role is LocationRole.BATCH:
-        from ..commands.discard import command_discard_to_batch
+        from ...commands.discard import command_discard_to_batch
 
         command_discard_to_batch(
             state.flow_state.target.batch_name,
@@ -789,7 +789,7 @@ def _apply_live_line_action(
         )
         return
 
-    from ..commands.discard import command_discard_line
+    from ...commands.discard import command_discard_line
 
     command_discard_line(line_ids, file=state.file_path, auto_advance=False)
 
@@ -800,7 +800,7 @@ def _apply_live_replacement_action(
     replacement_text: str,
 ) -> None:
     if state.flow_state.target.role is LocationRole.BATCH:
-        from ..commands.discard import command_discard_line_as_to_batch
+        from ...commands.discard import command_discard_line_as_to_batch
 
         command_discard_line_as_to_batch(
             state.flow_state.target.batch_name,
@@ -812,7 +812,7 @@ def _apply_live_replacement_action(
         )
         return
 
-    from ..commands.include import command_include_line_as
+    from ...commands.include import command_include_line_as
 
     command_include_line_as(
         line_ids,
@@ -825,7 +825,7 @@ def _apply_live_replacement_action(
 def _apply_live_file_action(state: FileReviewState, action: str) -> None:
     if action == "I":
         if state.flow_state.target.role is LocationRole.BATCH:
-            from ..commands.include import command_include_to_batch
+            from ...commands.include import command_include_to_batch
 
             command_include_to_batch(
                 state.flow_state.target.batch_name,
@@ -835,7 +835,7 @@ def _apply_live_file_action(state: FileReviewState, action: str) -> None:
             )
             return
 
-        from ..commands.include import command_include_file
+        from ...commands.include import command_include_file
 
         command_include_file(
             state.file_path,
@@ -847,7 +847,7 @@ def _apply_live_file_action(state: FileReviewState, action: str) -> None:
 
     if action == "S":
         if state.flow_state.target.role is LocationRole.BATCH:
-            from ..commands.include import command_include_to_batch
+            from ...commands.include import command_include_to_batch
 
             command_include_to_batch(
                 state.flow_state.target.batch_name,
@@ -857,7 +857,7 @@ def _apply_live_file_action(state: FileReviewState, action: str) -> None:
             )
             return
 
-        from ..commands.skip import command_skip_file
+        from ...commands.skip import command_skip_file
 
         command_skip_file(
             state.file_path,
@@ -868,7 +868,7 @@ def _apply_live_file_action(state: FileReviewState, action: str) -> None:
         return
 
     if state.flow_state.target.role is LocationRole.BATCH:
-        from ..commands.discard import command_discard_to_batch
+        from ...commands.discard import command_discard_to_batch
 
         command_discard_to_batch(
             state.flow_state.target.batch_name,
@@ -879,7 +879,7 @@ def _apply_live_file_action(state: FileReviewState, action: str) -> None:
         )
         return
 
-    from ..commands.discard import command_discard_file
+    from ...commands.discard import command_discard_file
 
     command_discard_file(state.file_path, auto_advance=False)
 
@@ -897,7 +897,7 @@ def _apply_batch_line_action(
         return
 
     if action == "i":
-        from ..commands.include_from import command_include_from_batch
+        from ...commands.include_from import command_include_from_batch
 
         command_include_from_batch(
             state.flow_state.source.batch_name,
@@ -906,7 +906,7 @@ def _apply_batch_line_action(
         )
         return
 
-    from ..commands.discard_from import command_discard_from_batch
+    from ...commands.discard_from import command_discard_from_batch
 
     command_discard_from_batch(
         state.flow_state.source.batch_name,
@@ -927,7 +927,7 @@ def _apply_batch_replacement_action(
         )
         return
 
-    from ..commands.include_from import command_include_from_batch
+    from ...commands.include_from import command_include_from_batch
 
     command_include_from_batch(
         state.flow_state.source.batch_name,
@@ -946,7 +946,7 @@ def _apply_batch_file_action(state: FileReviewState, action: str) -> None:
         return
 
     if action == "I":
-        from ..commands.include_from import command_include_from_batch
+        from ...commands.include_from import command_include_from_batch
 
         command_include_from_batch(
             state.flow_state.source.batch_name,
@@ -954,7 +954,7 @@ def _apply_batch_file_action(state: FileReviewState, action: str) -> None:
         )
         return
 
-    from ..commands.discard_from import command_discard_from_batch
+    from ...commands.discard_from import command_discard_from_batch
 
     command_discard_from_batch(
         state.flow_state.source.batch_name,

--- a/src/git_stage_batch/utils/journal.py
+++ b/src/git_stage_batch/utils/journal.py
@@ -13,9 +13,21 @@ from .git import run_git_command
 from .paths import get_state_directory_path
 
 
+GLOBAL_JOURNAL_PATH_ENV = "GIT_STAGE_BATCH_GLOBAL_JOURNAL_PATH"
+DEFAULT_GLOBAL_JOURNAL_PATH = Path("/var/tmp/git-stage-batch-journal.jsonl")
+
+
 def _get_journal_path() -> Path:
     """Get path to journal file."""
     return get_state_directory_path() / "journal.jsonl"
+
+
+def _get_global_journal_path() -> Path:
+    """Get path to the cross-repository debug journal file."""
+    override = os.environ.get(GLOBAL_JOURNAL_PATH_ENV)
+    if override:
+        return Path(override)
+    return DEFAULT_GLOBAL_JOURNAL_PATH
 
 
 def _get_index_state(file_path: str | None = None) -> dict[str, Any]:
@@ -54,8 +66,10 @@ def log_journal(operation: str, **kwargs: Any) -> None:
     (cleared by abort, preserved by again)
 
     If GIT_STAGE_BATCH_DEBUG environment variable is set, also writes to
-    global journal: /var/tmp/git-stage-batch-journal.jsonl (persists across
-    sessions and repositories, useful for debugging).
+    global journal: /var/tmp/git-stage-batch-journal.jsonl by default
+    (persists across sessions and repositories, useful for debugging).
+    Tests and callers can override the global path with
+    GIT_STAGE_BATCH_GLOBAL_JOURNAL_PATH.
 
     Args:
         operation: Name of the operation
@@ -96,7 +110,8 @@ def log_journal(operation: str, **kwargs: Any) -> None:
             except Exception:
                 pass
 
-            global_journal_path = Path("/var/tmp/git-stage-batch-journal.jsonl")
+            global_journal_path = _get_global_journal_path()
+            global_journal_path.parent.mkdir(parents=True, exist_ok=True)
             global_entry = {
                 "repo": repo_path,
                 **entry

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -108,3 +108,15 @@ def test_selected_change_store_stays_below_orchestration_state():
 
     assert "git_stage_batch.data.hunk_tracking" not in imported_modules
     assert "git_stage_batch.data.file_review.state" not in imported_modules
+
+
+def test_batch_file_display_stays_below_hunk_navigation():
+    """Batch file rendering should not depend on selected-change orchestration."""
+    renderer_path = SRC_ROOT / "batch" / "file_display.py"
+    imported_modules = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(renderer_path)
+    }
+
+    assert "git_stage_batch.data.hunk_tracking" not in imported_modules
+    assert "git_stage_batch.data.file_review.state" not in imported_modules

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -96,3 +96,15 @@ def test_diff_parser_does_not_import_snapshot_runtime_io():
         ),
         "write_snapshots_for_selected_file_path",
     )
+
+
+def test_selected_change_store_stays_below_orchestration_state():
+    """Selected-change persistence should stay below orchestration state."""
+    store_path = SRC_ROOT / "data" / "selected_change" / "store.py"
+    imported_modules = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(store_path)
+    }
+
+    assert "git_stage_batch.data.hunk_tracking" not in imported_modules
+    assert "git_stage_batch.data.file_review.state" not in imported_modules

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -145,9 +145,10 @@ def test_file_review_output_does_not_import_hunk_navigation():
 
 
 def test_recalc_handoff_stays_in_command_helper():
-    """Include command should use the command refresh handoff."""
+    """Include and discard commands should use the command refresh handoff."""
     command_paths = (
         SRC_ROOT / "commands" / "include.py",
+        SRC_ROOT / "commands" / "discard.py",
     )
     forbidden_names = {
         "RecalculateSelectedHunkResult",

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -144,6 +144,38 @@ def test_file_review_output_does_not_import_hunk_navigation():
     assert "git_stage_batch.data.hunk_tracking" not in imported_modules
 
 
+def test_recalc_handoff_stays_in_command_helper():
+    """Include command should use the command refresh handoff."""
+    command_paths = (
+        SRC_ROOT / "commands" / "include.py",
+    )
+    forbidden_names = {
+        "RecalculateSelectedHunkResult",
+        "recalculate_selected_hunk_for_file",
+    }
+    violations = []
+
+    for command_path in command_paths:
+        imported_modules = {
+            imported_module
+            for imported_module, _node in _import_from_nodes(command_path)
+        }
+        assert "git_stage_batch.commands.selection.selected_hunk_refresh" in imported_modules
+
+        for imported_module, node in _import_from_nodes(command_path):
+            if imported_module != "git_stage_batch.data.hunk_tracking":
+                continue
+
+            imported_names = {alias.name for alias in node.names}
+            disallowed_names = imported_names & forbidden_names
+            if disallowed_names:
+                relative_path = command_path.relative_to(REPO_ROOT)
+                names = ", ".join(sorted(disallowed_names))
+                violations.append(f"{relative_path}:{node.lineno} imports {names}")
+
+    assert violations == []
+
+
 def test_hunk_tracking_does_not_import_show_command():
     """Hunk navigation state should not depend on the show command."""
     hunk_tracking_path = SRC_ROOT / "data" / "hunk_tracking.py"

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -131,3 +131,14 @@ def test_file_review_state_does_not_import_hunk_navigation():
     }
 
     assert "git_stage_batch.data.hunk_tracking" not in imported_modules
+
+
+def test_file_review_output_does_not_import_hunk_navigation():
+    """File-review output should not depend on hunk navigation."""
+    review_output_path = SRC_ROOT / "output" / "file_review.py"
+    imported_modules = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(review_output_path)
+    }
+
+    assert "git_stage_batch.data.hunk_tracking" not in imported_modules

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -142,3 +142,14 @@ def test_file_review_output_does_not_import_hunk_navigation():
     }
 
     assert "git_stage_batch.data.hunk_tracking" not in imported_modules
+
+
+def test_hunk_tracking_does_not_import_show_command():
+    """Hunk navigation state should not depend on the show command."""
+    hunk_tracking_path = SRC_ROOT / "data" / "hunk_tracking.py"
+    imported_modules = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(hunk_tracking_path)
+    }
+
+    assert "git_stage_batch.commands.show" not in imported_modules

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -178,9 +178,10 @@ def test_recalc_handoff_stays_in_command_helper():
 
 
 def test_line_action_refresh_header_stays_in_command_helper():
-    """Include line actions should use the command refresh helper."""
+    """Include and discard line actions should use the command refresh helper."""
     command_paths = (
         SRC_ROOT / "commands" / "include.py",
+        SRC_ROOT / "commands" / "discard.py",
     )
     violations = []
 

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -120,3 +120,14 @@ def test_batch_file_display_stays_below_hunk_navigation():
 
     assert "git_stage_batch.data.hunk_tracking" not in imported_modules
     assert "git_stage_batch.data.file_review.state" not in imported_modules
+
+
+def test_file_review_state_does_not_import_hunk_navigation():
+    """File-review safety state should not depend on hunk navigation."""
+    review_state_path = SRC_ROOT / "data" / "file_review" / "state.py"
+    imported_modules = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(review_state_path)
+    }
+
+    assert "git_stage_batch.data.hunk_tracking" not in imported_modules

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -177,6 +177,38 @@ def test_recalc_handoff_stays_in_command_helper():
     assert violations == []
 
 
+def test_line_action_refresh_header_stays_in_command_helper():
+    """Include line actions should use the command refresh helper."""
+    command_paths = (
+        SRC_ROOT / "commands" / "include.py",
+    )
+    violations = []
+
+    for command_path in command_paths:
+        imports = _import_from_nodes(command_path)
+        imports_refresh_helper = False
+        for imported_module, node in imports:
+            imported_names = {alias.name for alias in node.names}
+            if (
+                imported_module == "git_stage_batch.commands.selection.selected_hunk_refresh"
+                and "refresh_selected_hunk_after_line_action" in imported_names
+            ):
+                imports_refresh_helper = True
+
+            if imported_module != "git_stage_batch.output":
+                continue
+            if "print_remaining_line_changes_header" in imported_names:
+                relative_path = command_path.relative_to(REPO_ROOT)
+                violations.append(
+                    f"{relative_path}:{node.lineno} imports "
+                    "print_remaining_line_changes_header"
+                )
+
+        assert imports_refresh_helper
+
+    assert violations == []
+
+
 def test_hunk_tracking_does_not_import_show_command():
     """Hunk navigation state should not depend on the show command."""
     hunk_tracking_path = SRC_ROOT / "data" / "hunk_tracking.py"

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -1,0 +1,77 @@
+"""Import-boundary checks for architecture-sensitive package seams."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC_ROOT = REPO_ROOT / "src" / "git_stage_batch"
+
+
+def _module_name_for_path(path: Path) -> str:
+    relative_path = path.relative_to(SRC_ROOT).with_suffix("")
+    return ".".join(("git_stage_batch", *relative_path.parts))
+
+
+def _resolve_import_from_module(
+    *,
+    current_module: str,
+    level: int,
+    module: str | None,
+) -> str | None:
+    if level == 0:
+        return module
+
+    current_package = current_module.split(".")[:-1]
+    if level - 1 > len(current_package):
+        return None
+
+    base_package = current_package[: len(current_package) - (level - 1)]
+    if module:
+        return ".".join((*base_package, *module.split(".")))
+    return ".".join(base_package)
+
+
+def _import_from_nodes(path: Path) -> list[tuple[str | None, ast.ImportFrom]]:
+    current_module = _module_name_for_path(path)
+    tree = ast.parse(path.read_text(), filename=str(path))
+    nodes = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            nodes.append((
+                _resolve_import_from_module(
+                    current_module=current_module,
+                    level=node.level,
+                    module=node.module,
+                ),
+                node,
+            ))
+    return nodes
+
+
+def test_replacement_payload_imports_use_core_boundary():
+    """Non-batch code should not depend on batch replacement for neutral payloads."""
+    neutral_names = {
+        "ReplacementPayload",
+        "ReplacementText",
+        "coerce_replacement_payload",
+        "replacement_line_bodies",
+        "replacement_line_chunks",
+    }
+    violations = []
+
+    for path in SRC_ROOT.rglob("*.py"):
+        for imported_module, node in _import_from_nodes(path):
+            if imported_module != "git_stage_batch.batch.replacement":
+                continue
+
+            imported_names = {alias.name for alias in node.names}
+            disallowed_names = imported_names & neutral_names
+            if disallowed_names:
+                relative_path = path.relative_to(REPO_ROOT)
+                names = ", ".join(sorted(disallowed_names))
+                violations.append(f"{relative_path}:{node.lineno} imports {names}")
+
+    assert violations == []

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -75,3 +75,24 @@ def test_replacement_payload_imports_use_core_boundary():
                 violations.append(f"{relative_path}:{node.lineno} imports {names}")
 
     assert violations == []
+
+
+def test_diff_parser_does_not_import_snapshot_runtime_io():
+    """Diff parsing should not own selected-file snapshot persistence."""
+    diff_parser_path = SRC_ROOT / "core" / "diff_parser.py"
+    imported_modules = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(diff_parser_path)
+    }
+
+    assert "git_stage_batch.data.selected_change.snapshots" not in imported_modules
+    assert "git_stage_batch.utils.git" not in imported_modules
+    assert "git_stage_batch.utils.journal" not in imported_modules
+    assert "git_stage_batch.utils.paths" not in imported_modules
+    assert not hasattr(
+        __import__(
+            "git_stage_batch.core.diff_parser",
+            fromlist=["write_snapshots_for_selected_file_path"],
+        ),
+        "write_snapshots_for_selected_file_path",
+    )

--- a/tests/batch/test_replacement.py
+++ b/tests/batch/test_replacement.py
@@ -2,9 +2,11 @@
 
 from git_stage_batch.batch.ownership import BatchOwnership, AbsenceClaim
 from git_stage_batch.batch.replacement import (
-    ReplacementText,
     ReplacementBatchView,
     build_replacement_batch_view_from_lines,
+)
+from git_stage_batch.core.replacement import (
+    ReplacementText,
     coerce_replacement_payload,
     replacement_line_chunks,
 )

--- a/tests/commands/test_again.py
+++ b/tests/commands/test_again.py
@@ -5,7 +5,7 @@ from git_stage_batch.core.line_selection import parse_line_selection
 from git_stage_batch.commands.discard import command_discard_to_batch
 from git_stage_batch.commands.include import command_include
 from git_stage_batch.commands.show import command_show, command_show_file_list
-from git_stage_batch.data.file_review_state import read_last_file_review_state
+from git_stage_batch.data.file_review.state import read_last_file_review_state
 from git_stage_batch.data.hunk_tracking import (
     SelectedChangeKind,
     fetch_next_change,

--- a/tests/commands/test_discard.py
+++ b/tests/commands/test_discard.py
@@ -228,6 +228,42 @@ class TestCommandDiscard:
         with pytest.raises(CommandError, match="automatic advancement is disabled"):
             command_discard(quiet=True)
 
+    def test_discard_line_auto_advance_after_file_is_exhausted(
+        self,
+        temp_git_repo,
+    ):
+        """Line discard should show the next file after current-file refresh ends."""
+        file1 = temp_git_repo / "file1.txt"
+        file2 = temp_git_repo / "file2.txt"
+        file1.write_text("base 1\n")
+        file2.write_text("base 2\n")
+        subprocess.run(
+            ["git", "add", "file1.txt", "file2.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add files"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+
+        file1.write_text("base 1\nselected\n")
+        file2.write_text("base 2\nnext\n")
+        command_start(quiet=True)
+
+        first_change = load_line_changes_from_state()
+        assert first_change is not None
+        assert first_change.path == "file1.txt"
+
+        command_discard_line("1", auto_advance=True)
+
+        next_change = load_line_changes_from_state()
+        assert next_change is not None
+        assert next_change.path == "file2.txt"
+
     def test_discard_all_hunks_processed(self, temp_git_repo, capsys):
         """Test discard when all hunks have been processed."""
         # Modify README before starting

--- a/tests/commands/test_file_review.py
+++ b/tests/commands/test_file_review.py
@@ -28,7 +28,7 @@ from git_stage_batch.commands.include import command_include_to_batch
 from git_stage_batch.commands.suggest_fixup import command_suggest_fixup
 from git_stage_batch.core.actionable_changes import ActionableSelectionReason
 import git_stage_batch.data.hunk_tracking as hunk_tracking_module
-from git_stage_batch.data.file_review_state import (
+from git_stage_batch.data.file_review.state import (
     FileReviewAction,
     ReviewSource,
     read_last_file_review_state,

--- a/tests/commands/test_file_review.py
+++ b/tests/commands/test_file_review.py
@@ -27,6 +27,7 @@ from git_stage_batch.commands.stop import command_stop
 from git_stage_batch.commands.include import command_include_to_batch
 from git_stage_batch.commands.suggest_fixup import command_suggest_fixup
 from git_stage_batch.core.actionable_changes import ActionableSelectionReason
+import git_stage_batch.batch.file_display as file_display_module
 import git_stage_batch.data.hunk_tracking as hunk_tracking_module
 from git_stage_batch.data.file_review.state import (
     FileReviewAction,
@@ -1868,7 +1869,7 @@ def test_pathless_include_from_batch_refuses_when_rerendered_batch_diff_changes(
     assert state is not None
     line_spec = format_line_ids(list(state.selections[0].display_ids))
 
-    original_render = hunk_tracking_module.render_batch_file_display
+    original_render = file_display_module.render_batch_file_display
 
     def changed_render(batch_name, file_path, metadata=None):
         rendered = original_render(batch_name, file_path, metadata=metadata)
@@ -1890,7 +1891,7 @@ def test_pathless_include_from_batch_refuses_when_rerendered_batch_diff_changes(
             selection_id_to_gutter=rendered.selection_id_to_gutter,
         )
 
-    monkeypatch.setattr(hunk_tracking_module, "render_batch_file_display", changed_render)
+    monkeypatch.setattr(file_display_module, "render_batch_file_display", changed_render)
 
     with pytest.raises(CommandError, match="no longer matches"):
         command_include_from_batch("cleanup", line_ids=line_spec)
@@ -2559,6 +2560,7 @@ def test_show_from_batch_line_after_review_uses_review_id_space(
         )
 
     monkeypatch.setattr(show_from_module, "render_batch_file_display", render_with_review_only_first_line)
+    monkeypatch.setattr(file_display_module, "render_batch_file_display", render_with_review_only_first_line)
     monkeypatch.setattr(hunk_tracking_module, "render_batch_file_display", render_with_review_only_first_line)
 
     command_show_from_batch("manual", file="file.txt", page="all")
@@ -2652,6 +2654,7 @@ def test_show_from_batch_line_without_review_uses_printed_review_id_space(
         )
 
     monkeypatch.setattr(show_from_module, "render_batch_file_display", render_with_review_only_second_line)
+    monkeypatch.setattr(file_display_module, "render_batch_file_display", render_with_review_only_second_line)
     monkeypatch.setattr(hunk_tracking_module, "render_batch_file_display", render_with_review_only_second_line)
 
     command_show_from_batch("manual", file="file.txt", line_ids="2")

--- a/tests/commands/test_include.py
+++ b/tests/commands/test_include.py
@@ -225,6 +225,42 @@ class TestCommandInclude:
 class TestCommandIncludeLine:
     """Tests for command_include_line."""
 
+    def test_include_line_auto_advance_after_file_is_exhausted(
+        self,
+        temp_git_repo,
+    ):
+        """Line include should show the next file after current-file refresh ends."""
+        file1 = temp_git_repo / "file1.txt"
+        file2 = temp_git_repo / "file2.txt"
+        file1.write_text("base 1\n")
+        file2.write_text("base 2\n")
+        subprocess.run(
+            ["git", "add", "file1.txt", "file2.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add files"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+
+        file1.write_text("base 1\nselected\n")
+        file2.write_text("base 2\nnext\n")
+        command_start(quiet=True)
+
+        first_change = load_line_changes_from_state()
+        assert first_change is not None
+        assert first_change.path == "file1.txt"
+
+        command_include_line("1", auto_advance=True)
+
+        next_change = load_line_changes_from_state()
+        assert next_change is not None
+        assert next_change.path == "file2.txt"
+
     def test_include_line_symlink_reads_link_target_not_referent(
         self,
         temp_git_repo,

--- a/tests/commands/test_reset.py
+++ b/tests/commands/test_reset.py
@@ -6,7 +6,7 @@ import pytest
 
 import git_stage_batch.commands.reset as reset_module
 import git_stage_batch.commands.show_from as show_from_module
-import git_stage_batch.data.hunk_tracking as hunk_tracking_module
+import git_stage_batch.batch.file_display as file_display_module
 from git_stage_batch.batch.ownership import BatchOwnership, AbsenceClaim
 from git_stage_batch.batch.query import read_batch_metadata
 from git_stage_batch.batch.storage import add_file_to_batch, read_file_from_batch
@@ -19,7 +19,8 @@ from git_stage_batch.commands.start import command_start
 from git_stage_batch.core.line_selection import LineRanges, parse_line_selection
 from git_stage_batch.core.models import RenderedBatchDisplay, ReviewActionGroup
 from git_stage_batch.data.batch_sources import create_batch_source_commit, save_session_batch_sources
-from git_stage_batch.data.hunk_tracking import fetch_next_change, render_batch_file_display
+from git_stage_batch.batch.file_display import render_batch_file_display
+from git_stage_batch.data.hunk_tracking import fetch_next_change
 from git_stage_batch.editor import EditorBuffer
 from git_stage_batch.exceptions import CommandError, NoMoreHunks
 
@@ -298,7 +299,7 @@ class TestResetFromBatch:
 
         monkeypatch.setattr(reset_module, "render_batch_file_display", render_with_shifted_gutter)
         monkeypatch.setattr(show_from_module, "render_batch_file_display", render_with_shifted_gutter)
-        monkeypatch.setattr(hunk_tracking_module, "render_batch_file_display", render_with_shifted_gutter)
+        monkeypatch.setattr(file_display_module, "render_batch_file_display", render_with_shifted_gutter)
 
         command_show_from_batch("mybatch", file="test.py", page="all")
 
@@ -345,7 +346,7 @@ class TestResetFromBatch:
 
         monkeypatch.setattr(reset_module, "render_batch_file_display", render_with_shifted_gutter)
         monkeypatch.setattr(show_from_module, "render_batch_file_display", render_with_shifted_gutter)
-        monkeypatch.setattr(hunk_tracking_module, "render_batch_file_display", render_with_shifted_gutter)
+        monkeypatch.setattr(file_display_module, "render_batch_file_display", render_with_shifted_gutter)
 
         command_show_from_batch("mybatch", file="test.py", page="all")
 
@@ -408,11 +409,11 @@ class TestResetFromBatch:
 
         monkeypatch.setattr(reset_module, "render_batch_file_display", render_with_shifted_gutter)
         monkeypatch.setattr(show_from_module, "render_batch_file_display", render_with_shifted_gutter)
-        monkeypatch.setattr(hunk_tracking_module, "render_batch_file_display", render_with_shifted_gutter)
+        monkeypatch.setattr(file_display_module, "render_batch_file_display", render_with_shifted_gutter)
 
         command_show_from_batch("mybatch", file="test.py", page="all")
 
-        monkeypatch.setattr(hunk_tracking_module, "render_batch_file_display", render_with_raw_gutter)
+        monkeypatch.setattr(file_display_module, "render_batch_file_display", render_with_raw_gutter)
 
         with pytest.raises(CommandError, match="no longer matches"):
             command_reset_from_batch("mybatch", line_ids="1", file="test.py")

--- a/tests/commands/test_selection_refresh.py
+++ b/tests/commands/test_selection_refresh.py
@@ -1,0 +1,55 @@
+import git_stage_batch.commands.selection.selected_hunk_refresh as selected_hunk_refresh
+from git_stage_batch.data.hunk_tracking import RecalculateSelectedHunkResult
+
+
+def test_recalculate_selected_hunk_for_command_delegates_without_show(monkeypatch):
+    calls = []
+    show_calls = []
+
+    def fake_recalculate(file_path, *, auto_advance=None):
+        calls.append((file_path, auto_advance))
+        return RecalculateSelectedHunkResult.RECALCULATED
+
+    monkeypatch.setattr(
+        selected_hunk_refresh,
+        "recalculate_selected_hunk_for_file",
+        fake_recalculate,
+    )
+    monkeypatch.setattr(
+        "git_stage_batch.commands.show.command_show",
+        lambda: show_calls.append(True),
+    )
+
+    selected_hunk_refresh.recalculate_selected_hunk_for_command(
+        "file.txt",
+        auto_advance=False,
+    )
+
+    assert calls == [("file.txt", False)]
+    assert show_calls == []
+
+
+def test_recalculate_selected_hunk_for_command_shows_next_change(monkeypatch):
+    show_calls = []
+
+    def fake_recalculate(file_path, *, auto_advance=None):
+        assert file_path == "file.txt"
+        assert auto_advance is True
+        return RecalculateSelectedHunkResult.SHOW_NEXT_CHANGE
+
+    monkeypatch.setattr(
+        selected_hunk_refresh,
+        "recalculate_selected_hunk_for_file",
+        fake_recalculate,
+    )
+    monkeypatch.setattr(
+        "git_stage_batch.commands.show.command_show",
+        lambda: show_calls.append(True),
+    )
+
+    selected_hunk_refresh.recalculate_selected_hunk_for_command(
+        "file.txt",
+        auto_advance=True,
+    )
+
+    assert show_calls == [True]

--- a/tests/commands/test_selection_refresh.py
+++ b/tests/commands/test_selection_refresh.py
@@ -53,3 +53,32 @@ def test_recalculate_selected_hunk_for_command_shows_next_change(monkeypatch):
     )
 
     assert show_calls == [True]
+
+
+def test_refresh_selected_hunk_after_line_action_prints_header_before_refresh(
+    monkeypatch,
+):
+    calls = []
+
+    monkeypatch.setattr(
+        selected_hunk_refresh,
+        "print_remaining_line_changes_header",
+        lambda file_path: calls.append(("header", file_path)),
+    )
+    monkeypatch.setattr(
+        selected_hunk_refresh,
+        "recalculate_selected_hunk_for_command",
+        lambda file_path, *, auto_advance=None: calls.append(
+            ("refresh", file_path, auto_advance)
+        ),
+    )
+
+    selected_hunk_refresh.refresh_selected_hunk_after_line_action(
+        "file.txt",
+        auto_advance=True,
+    )
+
+    assert calls == [
+        ("header", "file.txt"),
+        ("refresh", "file.txt", True),
+    ]

--- a/tests/commands/test_show_from.py
+++ b/tests/commands/test_show_from.py
@@ -6,9 +6,10 @@ from git_stage_batch.commands.show import command_show
 from git_stage_batch.batch.ownership import BatchOwnership
 from git_stage_batch.batch.storage import add_file_to_batch
 from git_stage_batch.batch.ownership import AbsenceClaim
-from git_stage_batch.data.hunk_tracking import render_batch_file_display
+from git_stage_batch.batch.file_display import render_batch_file_display
 import git_stage_batch.batch.merge as merge_module
 import git_stage_batch.batch.display as display_module
+import git_stage_batch.batch.file_display as file_display
 import git_stage_batch.data.hunk_tracking as hunk_tracking
 import git_stage_batch.commands.show_from as show_from_module
 
@@ -341,22 +342,14 @@ class TestCommandShowFromBatch:
         command_start()
         command_include_to_batch("preview-batch", quiet=True)
 
-        original_load_git_object_as_buffer = hunk_tracking.load_git_object_as_buffer
+        original_load_git_object_as_buffer = file_display.load_git_object_as_buffer
         loaded_revisions = []
 
         def tracking_load_git_object_as_buffer(revision_path):
             loaded_revisions.append(revision_path)
             return original_load_git_object_as_buffer(revision_path)
 
-        original_run_git_command = hunk_tracking.run_git_command
-
-        def rejecting_show_run_git_command(arguments, *args, **kwargs):
-            if arguments and arguments[0] == "show":
-                raise AssertionError("batch source content should be streamed")
-            return original_run_git_command(arguments, *args, **kwargs)
-
-        monkeypatch.setattr(hunk_tracking, "load_git_object_as_buffer", tracking_load_git_object_as_buffer)
-        monkeypatch.setattr(hunk_tracking, "run_git_command", rejecting_show_run_git_command)
+        monkeypatch.setattr(file_display, "load_git_object_as_buffer", tracking_load_git_object_as_buffer)
 
         rendered = render_batch_file_display(
             "preview-batch",
@@ -382,26 +375,26 @@ class TestCommandShowFromBatch:
             "100644",
         )
 
-        original_hunk_match_lines = hunk_tracking.match_lines
+        original_renderer_match_lines = file_display.match_lines
         original_merge_match_lines = merge_module.match_lines
         calls = []
 
-        def counting_hunk_match_lines(*args, **kwargs):
-            calls.append("hunk")
-            return original_hunk_match_lines(*args, **kwargs)
+        def counting_renderer_match_lines(*args, **kwargs):
+            calls.append("renderer")
+            return original_renderer_match_lines(*args, **kwargs)
 
         def counting_merge_match_lines(*args, **kwargs):
             calls.append("merge")
             return original_merge_match_lines(*args, **kwargs)
 
-        monkeypatch.setattr(hunk_tracking, "match_lines", counting_hunk_match_lines)
+        monkeypatch.setattr(file_display, "match_lines", counting_renderer_match_lines)
         monkeypatch.setattr(merge_module, "match_lines", counting_merge_match_lines)
 
         rendered = render_batch_file_display("multi-unit-batch", "file.txt")
 
         assert rendered is not None
         assert len(rendered.review_action_groups) == 2
-        assert calls == ["hunk"]
+        assert calls == ["renderer"]
 
     def test_show_from_keeps_mergeable_display_ids_range_backed(self, temp_git_repo, monkeypatch):
         """Rendering should not compare each unit with a set of mergeable IDs."""
@@ -450,7 +443,7 @@ class TestCommandShowFromBatch:
         command_include_to_batch("multi-file-batch", quiet=True, file="file2.txt")
         capsys.readouterr()
 
-        original_render = hunk_tracking.render_batch_file_display
+        original_render = file_display.render_batch_file_display
         rendered_files = []
         probe_flags = []
 

--- a/tests/commands/test_status.py
+++ b/tests/commands/test_status.py
@@ -24,7 +24,7 @@ from git_stage_batch.commands.skip import command_skip, command_skip_file
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.commands.status import command_status
 from git_stage_batch.core.line_selection import format_line_ids
-from git_stage_batch.data.file_review_state import read_last_file_review_state
+from git_stage_batch.data.file_review.state import read_last_file_review_state
 from git_stage_batch.exceptions import CommandError
 
 

--- a/tests/core/test_diff_parser.py
+++ b/tests/core/test_diff_parser.py
@@ -1,21 +1,14 @@
 """Tests for unified diff parser."""
 
-from git_stage_batch.utils.paths import ensure_state_directory_exists
-
-import subprocess
-
 import pytest
 
 from git_stage_batch.core.diff_parser import (
     acquire_unified_diff,
     build_line_changes_from_patch_lines,
-    write_snapshots_for_selected_file_path,
 )
 from git_stage_batch.core.models import SingleHunkPatch
 from git_stage_batch.editor import EditorBuffer
 from tests.diff_parser_helpers import collect_unified_diff
-from git_stage_batch.utils.file_io import read_text_file_contents
-from git_stage_batch.utils.paths import get_index_snapshot_file_path, get_working_tree_snapshot_file_path
 
 
 def _two_hunk_diff_lines() -> list[bytes]:
@@ -333,163 +326,3 @@ class TestBuildLineLevelChangeFromPatchText:
         )
 
         assert line_changes_from_lines == line_changes_from_list
-
-
-class TestWriteSnapshotsForCurrentFilePath:
-    """Tests for write_snapshots_for_selected_file_path with intent-to-add entries."""
-
-    @pytest.fixture
-    def temp_git_repo(self, tmp_path, monkeypatch):
-        """Create a temporary git repository."""
-        monkeypatch.chdir(tmp_path)
-        subprocess.run(["git", "init"], check=True, capture_output=True)
-        subprocess.run(["git", "config", "user.name", "Test User"], check=True, capture_output=True)
-        subprocess.run(["git", "config", "user.email", "test@example.com"], check=True, capture_output=True)
-
-        # Create initial commit
-        (tmp_path / "README.md").write_text("# Test\n")
-        subprocess.run(["git", "add", "README.md"], check=True, capture_output=True)
-        subprocess.run(["git", "commit", "-m", "Initial commit"], check=True, capture_output=True)
-
-        # Ensure state directory exists
-        ensure_state_directory_exists()
-
-        return tmp_path
-
-    def test_intent_to_add_tracked_file_uses_head_content(self, temp_git_repo):
-        """When a tracked file has intent-to-add entry, index snapshot should use HEAD content."""
-        # Create and commit a file
-        test_file = temp_git_repo / "tracked.py"
-        original_content = '''"""Module docstring."""
-
-def original_function():
-    """Original implementation."""
-    return "original"
-'''
-        test_file.write_text(original_content)
-        subprocess.run(["git", "add", "tracked.py"], cwd=temp_git_repo, check=True, capture_output=True)
-        subprocess.run(["git", "commit", "-m", "Add tracked file"], cwd=temp_git_repo, check=True, capture_output=True)
-
-        # Modify the file in working tree
-        modified_content = '''"""Module docstring."""
-
-def original_function():
-    """Modified implementation."""
-    return "modified"
-
-def new_function():
-    """New function."""
-    return "new"
-'''
-        test_file.write_text(modified_content)
-
-        # Simulate intent-to-add by removing from cache and re-adding with -N
-        # This creates an empty blob (e69de29...) in the index
-        subprocess.run(["git", "rm", "--cached", "tracked.py"], cwd=temp_git_repo, check=True, capture_output=True)
-        subprocess.run(["git", "add", "-N", "tracked.py"], cwd=temp_git_repo, check=True, capture_output=True)
-
-        # Verify we have an empty blob in index
-        ls_result = subprocess.run(
-            ["git", "ls-files", "--stage", "tracked.py"],
-            cwd=temp_git_repo,
-            check=True,
-            capture_output=True,
-            text=True
-        )
-        assert "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391" in ls_result.stdout, "Should have empty blob in index"
-
-        # Verify git show :file returns empty content.
-        show_result = subprocess.run(
-            ["git", "show", ":tracked.py"],
-            cwd=temp_git_repo,
-            check=True,
-            capture_output=True,
-            text=True
-        )
-        assert show_result.stdout == "", "Index should return empty content for intent-to-add"
-
-        # Call write_snapshots_for_selected_file_path
-        write_snapshots_for_selected_file_path("tracked.py")
-
-        # Read the index snapshot
-        index_snapshot_path = get_index_snapshot_file_path()
-        index_snapshot_content = read_text_file_contents(index_snapshot_path)
-
-        # The fix: index snapshot should contain HEAD content, not empty
-        assert index_snapshot_content == original_content, (
-            "Index snapshot should contain HEAD content for intent-to-add tracked file, "
-            "not empty content"
-        )
-
-        # Verify working tree snapshot has the modified content
-        working_tree_snapshot_path = get_working_tree_snapshot_file_path()
-        working_tree_snapshot_content = read_text_file_contents(working_tree_snapshot_path)
-        assert working_tree_snapshot_content == modified_content
-
-    def test_intent_to_add_new_file_keeps_empty_index(self, temp_git_repo):
-        """New files with intent-to-add should keep empty index snapshot."""
-        # Create a new file (not in HEAD)
-        test_file = temp_git_repo / "newfile.py"
-        new_content = '''"""New file."""
-
-def new_function():
-    return "new"
-'''
-        test_file.write_text(new_content)
-
-        # Add with intent-to-add
-        subprocess.run(["git", "add", "-N", "newfile.py"], cwd=temp_git_repo, check=True, capture_output=True)
-
-        # Verify file is not in HEAD
-        head_check = subprocess.run(
-            ["git", "cat-file", "-e", "HEAD:newfile.py"],
-            cwd=temp_git_repo,
-            capture_output=True
-        )
-        assert head_check.returncode != 0, "New file should not exist in HEAD"
-
-        # Call write_snapshots_for_selected_file_path
-        write_snapshots_for_selected_file_path("newfile.py")
-
-        # Read the index snapshot
-        index_snapshot_path = get_index_snapshot_file_path()
-        index_snapshot_content = read_text_file_contents(index_snapshot_path)
-
-        # New files should have empty index snapshot (no fallback to HEAD)
-        assert index_snapshot_content == "", "New file should have empty index snapshot"
-
-        # Verify working tree snapshot has the content
-        working_tree_snapshot_path = get_working_tree_snapshot_file_path()
-        working_tree_snapshot_content = read_text_file_contents(working_tree_snapshot_path)
-        assert working_tree_snapshot_content == new_content
-
-    def test_normal_tracked_file_uses_index_content(self, temp_git_repo):
-        """Normal tracked files should use index content (no fallback)."""
-        # Create and commit a file
-        test_file = temp_git_repo / "normal.py"
-        original_content = "original content\n"
-        test_file.write_text(original_content)
-        subprocess.run(["git", "add", "normal.py"], cwd=temp_git_repo, check=True, capture_output=True)
-        subprocess.run(["git", "commit", "-m", "Add normal file"], cwd=temp_git_repo, check=True, capture_output=True)
-
-        # Modify and stage
-        staged_content = "staged content\n"
-        test_file.write_text(staged_content)
-        subprocess.run(["git", "add", "normal.py"], cwd=temp_git_repo, check=True, capture_output=True)
-
-        # Further modify in working tree
-        working_content = "working tree content\n"
-        test_file.write_text(working_content)
-
-        # Call write_snapshots_for_selected_file_path
-        write_snapshots_for_selected_file_path("normal.py")
-
-        # Index snapshot should have staged content
-        index_snapshot_path = get_index_snapshot_file_path()
-        index_snapshot_content = read_text_file_contents(index_snapshot_path)
-        assert index_snapshot_content == staged_content
-
-        # Working tree snapshot should have working content
-        working_tree_snapshot_path = get_working_tree_snapshot_file_path()
-        working_tree_snapshot_content = read_text_file_contents(working_tree_snapshot_path)
-        assert working_tree_snapshot_content == working_content

--- a/tests/data/test_hunk_tracking.py
+++ b/tests/data/test_hunk_tracking.py
@@ -20,6 +20,7 @@ import pytest
 from git_stage_batch.commands.again import command_again
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.data.hunk_tracking import (
+    RecalculateSelectedHunkResult,
     advance_to_next_change,
     apply_line_level_batch_filter_to_cached_hunk,
     build_file_hunk_from_buffer,
@@ -580,6 +581,40 @@ class TestRecalculateCurrentHunkForFile:
 
         output = captured.getvalue()
         assert "No pending hunks" in output or not get_selected_hunk_patch_file_path().exists()
+
+    def test_reports_next_change_when_file_is_exhausted(self, temp_git_repo):
+        """Recalculation should not call the show command for the next file."""
+        file1 = temp_git_repo / "file1.txt"
+        file2 = temp_git_repo / "file2.txt"
+        file1.write_text("base 1\n")
+        file2.write_text("base 2\n")
+        subprocess.run(
+            ["git", "add", "file1.txt", "file2.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add files"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+
+        file1.write_text("base 1\nselected\n")
+        file2.write_text("base 2\nnext\n")
+        selected = fetch_next_change()
+        assert selected.path == "file1.txt"
+
+        file1.write_text("base 1\n")
+
+        result = recalculate_selected_hunk_for_file(
+            "file1.txt",
+            auto_advance=True,
+        )
+
+        assert result is RecalculateSelectedHunkResult.SHOW_NEXT_CHANGE
+        assert not get_selected_hunk_patch_file_path().exists()
 
 
 class TestRecordHunkFunctions:

--- a/tests/data/test_selected_snapshots.py
+++ b/tests/data/test_selected_snapshots.py
@@ -1,0 +1,156 @@
+"""Tests for selected-file snapshot persistence."""
+
+import subprocess
+
+import pytest
+
+from git_stage_batch.data.selected_change.snapshots import write_snapshots_for_selected_file_path
+from git_stage_batch.utils.file_io import read_text_file_contents
+from git_stage_batch.utils.paths import (
+    ensure_state_directory_exists,
+    get_index_snapshot_file_path,
+    get_working_tree_snapshot_file_path,
+)
+
+
+class TestWriteSnapshotsForCurrentFilePath:
+    """Tests for write_snapshots_for_selected_file_path with intent-to-add entries."""
+
+    @pytest.fixture
+    def temp_git_repo(self, tmp_path, monkeypatch):
+        """Create a temporary git repository."""
+        monkeypatch.chdir(tmp_path)
+        subprocess.run(["git", "init"], check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.name", "Test User"], check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.email", "test@example.com"], check=True, capture_output=True)
+
+        # Create initial commit
+        (tmp_path / "README.md").write_text("# Test\n")
+        subprocess.run(["git", "add", "README.md"], check=True, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Initial commit"], check=True, capture_output=True)
+
+        # Ensure state directory exists
+        ensure_state_directory_exists()
+
+        return tmp_path
+
+    def test_intent_to_add_tracked_file_uses_head_content(self, temp_git_repo):
+        """When a tracked file has intent-to-add entry, index snapshot should use HEAD content."""
+        # Create and commit a file
+        test_file = temp_git_repo / "tracked.py"
+        original_content = '''"""Module docstring."""
+
+def original_function():
+    """Original implementation."""
+    return "original"
+'''
+        test_file.write_text(original_content)
+        subprocess.run(["git", "add", "tracked.py"], cwd=temp_git_repo, check=True, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add tracked file"], cwd=temp_git_repo, check=True, capture_output=True)
+
+        # Modify the file in working tree
+        modified_content = '''"""Module docstring."""
+
+def original_function():
+    """Modified implementation."""
+    return "modified"
+
+def new_function():
+    """New function."""
+    return "new"
+'''
+        test_file.write_text(modified_content)
+
+        # Simulate intent-to-add by removing from cache and re-adding with -N.
+        # This creates an empty blob (e69de29...) in the index.
+        subprocess.run(["git", "rm", "--cached", "tracked.py"], cwd=temp_git_repo, check=True, capture_output=True)
+        subprocess.run(["git", "add", "-N", "tracked.py"], cwd=temp_git_repo, check=True, capture_output=True)
+
+        # Verify we have an empty blob in index.
+        ls_result = subprocess.run(
+            ["git", "ls-files", "--stage", "tracked.py"],
+            cwd=temp_git_repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        assert "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391" in ls_result.stdout, "Should have empty blob in index"
+
+        # Verify git show :file returns empty content.
+        show_result = subprocess.run(
+            ["git", "show", ":tracked.py"],
+            cwd=temp_git_repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        assert show_result.stdout == "", "Index should return empty content for intent-to-add"
+
+        write_snapshots_for_selected_file_path("tracked.py")
+
+        index_snapshot_path = get_index_snapshot_file_path()
+        index_snapshot_content = read_text_file_contents(index_snapshot_path)
+
+        assert index_snapshot_content == original_content, (
+            "Index snapshot should contain HEAD content for intent-to-add tracked file, "
+            "not empty content"
+        )
+
+        working_tree_snapshot_path = get_working_tree_snapshot_file_path()
+        working_tree_snapshot_content = read_text_file_contents(working_tree_snapshot_path)
+        assert working_tree_snapshot_content == modified_content
+
+    def test_intent_to_add_new_file_keeps_empty_index(self, temp_git_repo):
+        """New files with intent-to-add should keep empty index snapshot."""
+        test_file = temp_git_repo / "newfile.py"
+        new_content = '''"""New file."""
+
+def new_function():
+    return "new"
+'''
+        test_file.write_text(new_content)
+
+        subprocess.run(["git", "add", "-N", "newfile.py"], cwd=temp_git_repo, check=True, capture_output=True)
+
+        head_check = subprocess.run(
+            ["git", "cat-file", "-e", "HEAD:newfile.py"],
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        assert head_check.returncode != 0, "New file should not exist in HEAD"
+
+        write_snapshots_for_selected_file_path("newfile.py")
+
+        index_snapshot_path = get_index_snapshot_file_path()
+        index_snapshot_content = read_text_file_contents(index_snapshot_path)
+
+        assert index_snapshot_content == "", "New file should have empty index snapshot"
+
+        working_tree_snapshot_path = get_working_tree_snapshot_file_path()
+        working_tree_snapshot_content = read_text_file_contents(working_tree_snapshot_path)
+        assert working_tree_snapshot_content == new_content
+
+    def test_normal_tracked_file_uses_index_content(self, temp_git_repo):
+        """Normal tracked files should use index content without fallback."""
+        test_file = temp_git_repo / "normal.py"
+        original_content = "original content\n"
+        test_file.write_text(original_content)
+        subprocess.run(["git", "add", "normal.py"], cwd=temp_git_repo, check=True, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add normal file"], cwd=temp_git_repo, check=True, capture_output=True)
+
+        staged_content = "staged content\n"
+        test_file.write_text(staged_content)
+        subprocess.run(["git", "add", "normal.py"], cwd=temp_git_repo, check=True, capture_output=True)
+
+        working_content = "working tree content\n"
+        test_file.write_text(working_content)
+
+        write_snapshots_for_selected_file_path("normal.py")
+
+        index_snapshot_path = get_index_snapshot_file_path()
+        index_snapshot_content = read_text_file_contents(index_snapshot_path)
+        assert index_snapshot_content == staged_content
+
+        working_tree_snapshot_path = get_working_tree_snapshot_file_path()
+        working_tree_snapshot_content = read_text_file_contents(working_tree_snapshot_path)
+        assert working_tree_snapshot_content == working_content

--- a/tests/utils/test_journal.py
+++ b/tests/utils/test_journal.py
@@ -4,12 +4,11 @@ from git_stage_batch.utils.paths import ensure_state_directory_exists
 
 import json
 import subprocess
-from pathlib import Path
 
 import pytest
 
 from git_stage_batch.commands.start import command_start
-from git_stage_batch.utils.journal import log_journal
+from git_stage_batch.utils.journal import GLOBAL_JOURNAL_PATH_ENV, log_journal
 from git_stage_batch.utils.paths import get_state_directory_path
 
 
@@ -27,6 +26,14 @@ def temp_git_repo(tmp_path, monkeypatch):
     subprocess.run(["git", "commit", "-m", "initial"], check=True, capture_output=True)
 
     return tmp_path
+
+
+@pytest.fixture
+def global_journal_path(tmp_path, monkeypatch):
+    """Provide an isolated global journal path for tests."""
+    path = tmp_path / "journals" / "global.jsonl"
+    monkeypatch.setenv(GLOBAL_JOURNAL_PATH_ENV, str(path))
+    return path
 
 
 class TestJournal:
@@ -55,17 +62,16 @@ class TestJournal:
             assert "timestamp" in entry
             assert "operation" in entry
 
-    def test_journal_global_only_with_debug_env(self, temp_git_repo, monkeypatch):
+    def test_journal_global_only_with_debug_env(
+        self,
+        temp_git_repo,
+        monkeypatch,
+        global_journal_path,
+    ):
         """Test that global journal only logs when GIT_STAGE_BATCH_DEBUG is set."""
-
-        global_journal_path = Path("/var/tmp/git-stage-batch-journal.jsonl")
 
         # Ensure state directory exists
         ensure_state_directory_exists()
-
-        # Clear any existing global journal
-        if global_journal_path.exists():
-            global_journal_path.unlink()
 
         # Without debug env var, global journal is not created.
         monkeypatch.delenv("GIT_STAGE_BATCH_DEBUG", raising=False)
@@ -79,10 +85,6 @@ class TestJournal:
         # Test 2: With debug env var, should create global journal
         monkeypatch.setenv("GIT_STAGE_BATCH_DEBUG", "1")
 
-        # Clear global journal again
-        if global_journal_path.exists():
-            global_journal_path.unlink()
-
         log_journal("test_operation_with_debug", test=True)
 
         # Global journal should now exist and have content
@@ -90,10 +92,6 @@ class TestJournal:
 
         content = global_journal_path.read_text()
         assert "test_operation_with_debug" in content
-
-        # Clean up
-        if global_journal_path.exists():
-            global_journal_path.unlink()
 
     def test_journal_entries_have_required_fields(self, temp_git_repo):
         """Test that journal entries have all required fields."""
@@ -125,15 +123,14 @@ class TestJournal:
         # Stack should be a list
         assert isinstance(entry["stack"], list)
 
-    def test_journal_global_includes_repo_path(self, temp_git_repo, monkeypatch):
+    def test_journal_global_includes_repo_path(
+        self,
+        temp_git_repo,
+        monkeypatch,
+        global_journal_path,
+    ):
         """Test that global journal entries include repo path."""
         monkeypatch.setenv("GIT_STAGE_BATCH_DEBUG", "1")
-
-        global_journal_path = Path("/var/tmp/git-stage-batch-journal.jsonl")
-
-        # Clear existing
-        if global_journal_path.exists():
-            global_journal_path.unlink()
 
         log_journal("test_repo_path", test=True)
 
@@ -147,9 +144,6 @@ class TestJournal:
         assert "repo" in entry
         assert entry["repo"] is not None
         assert str(temp_git_repo) in entry["repo"]
-
-        # Clean up
-        global_journal_path.unlink()
 
     def test_journal_logging_never_breaks_operations(self, temp_git_repo, monkeypatch):
         """Test that journal logging failures don't break operations."""


### PR DESCRIPTION
Selected-change persistence sits behind hunk navigation and file-review
helpers, while progress, binary, gitlink, and clear-marker state are still
spread across the navigation-oriented modules.

The project does not have one obvious owner for selected-change workflow
state. That makes unrelated batch and command code depend on hunk navigation
when they only need persistence, fingerprinting, or stale-selection checks.

This PR begins isolating selected-change state by moving file-review state,
selected snapshots, progress records, payload caches, and batch-selection
helpers behind focused data and batch modules.

The next PR will route remaining selected-change callers through those new
owners and hide the broad hunk-navigation facade left behind by this split.

Test plan: .venv/bin/python -m pytest -n auto passed on the final stack tip.
