### PR TITLE
architecture: Route selected-change callers through stores

### DIFF
--- a/src/git_stage_batch/batch/selection.py
+++ b/src/git_stage_batch/batch/selection.py
@@ -20,7 +20,10 @@ from ..core.line_selection import (
     parse_line_selection,
     parse_line_selection_ranges,
 )
-from ..exceptions import exit_with_error
+from ..data.selected_change.store import (
+    get_selected_change_file_path,
+)
+from ..exceptions import CommandError, exit_with_error
 from ..i18n import _
 from ..utils.file_patterns import resolve_gitignore_style_patterns
 
@@ -136,9 +139,6 @@ def resolve_batch_file_scope(
         SystemExit: If file not found or no hunk selected when using ""
     """
     if file is not None:
-        # Specific file requested
-        from ..data.hunk_tracking import get_batch_file_for_line_operation, get_selected_change_file_path
-
         # If file is empty string, use selected hunk's file
         if file == "":
             file_to_use = get_selected_change_file_path()
@@ -147,7 +147,7 @@ def resolve_batch_file_scope(
         else:
             file_to_use = file
 
-        target_file = get_batch_file_for_line_operation(batch_name, file_to_use)
+        target_file = _get_batch_file_for_line_operation(batch_name, all_files, file_to_use)
         return {target_file: all_files[target_file]}
     if patterns is not None:
         resolved_files = resolve_gitignore_style_patterns(all_files.keys(), patterns)
@@ -214,6 +214,26 @@ def resolve_current_batch_binary_file_scope(
         patterns,
         line_ids,
     )
+
+
+def _get_batch_file_for_line_operation(
+    batch_name: str,
+    all_files: dict[str, dict],
+    file: str | None,
+) -> str:
+    """Determine which file in batch to operate on."""
+    files = sorted(all_files.keys())
+
+    if not files:
+        raise CommandError(f"Batch '{batch_name}' is empty")
+
+    if file is None:
+        return files[0]
+
+    if file not in all_files:
+        raise CommandError(f"File '{file}' not found in batch '{batch_name}'")
+
+    return file
 
 
 def require_single_file_context_for_line_selection(

--- a/src/git_stage_batch/batch/selection.py
+++ b/src/git_stage_batch/batch/selection.py
@@ -20,8 +20,14 @@ from ..core.line_selection import (
     parse_line_selection,
     parse_line_selection_ranges,
 )
+from ..data.batch_selected_changes import (
+    require_current_selected_batch_binary_file_for_batch,
+    require_current_selected_batch_gitlink_file_for_batch,
+)
 from ..data.selected_change.store import (
+    SelectedChangeKind,
     get_selected_change_file_path,
+    read_selected_change_kind,
 )
 from ..exceptions import CommandError, exit_with_error
 from ..i18n import _
@@ -180,13 +186,6 @@ def resolve_current_batch_atomic_file_scope(
     """
     if patterns is not None or line_ids is not None or file not in (None, ""):
         return file
-
-    from ..data.hunk_tracking import (
-        SelectedChangeKind,
-        read_selected_change_kind,
-        require_current_selected_batch_binary_file_for_batch,
-        require_current_selected_batch_gitlink_file_for_batch,
-    )
 
     selected_kind = read_selected_change_kind()
     if selected_kind == SelectedChangeKind.BATCH_BINARY:

--- a/src/git_stage_batch/batch/selection.py
+++ b/src/git_stage_batch/batch/selection.py
@@ -24,6 +24,7 @@ from ..data.batch_selected_changes import (
     require_current_selected_batch_binary_file_for_batch,
     require_current_selected_batch_gitlink_file_for_batch,
 )
+from ..data.progress import format_id_range
 from ..data.selected_change.store import (
     SelectedChangeKind,
     get_selected_change_file_path,
@@ -327,8 +328,6 @@ def translate_atomic_unit_error_to_gutter_ids(
     Raises:
         CommandError: Always exits with translated error message
     """
-    from ..data.hunk_tracking import format_id_range
-
     if error.required_selection_ids:
         # Translate required selection IDs to gutter IDs
         gutter_ids = []

--- a/src/git_stage_batch/batch/selection.py
+++ b/src/git_stage_batch/batch/selection.py
@@ -20,6 +20,7 @@ from ..core.line_selection import (
     parse_line_selection,
     parse_line_selection_ranges,
 )
+from ..batch.file_display import render_batch_file_display
 from ..data.batch_selected_changes import (
     require_current_selected_batch_binary_file_for_batch,
     require_current_selected_batch_gitlink_file_for_batch,
@@ -380,7 +381,6 @@ def translate_batch_file_gutter_ids_to_selection_ids(
         fresh_batch_review_selections_for_action,
         validate_review_scoped_line_selection,
     )
-    from ..data.hunk_tracking import render_batch_file_display
 
     review_selections = fresh_batch_review_selections_for_action(batch_name, file_path, action)
     if review_selections is not None:

--- a/src/git_stage_batch/commands/apply_from.py
+++ b/src/git_stage_batch/commands/apply_from.py
@@ -45,9 +45,7 @@ from ..data.file_review.state import (
     finish_review_scoped_line_action,
     resolve_batch_source_action_scope,
 )
-from ..data.hunk_tracking import (
-    render_batch_file_display,
-)
+from ..batch.file_display import render_batch_file_display
 from ..editor import (
     EditorBuffer,
     load_git_object_as_buffer,

--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -60,8 +60,6 @@ from ..data.hunk_tracking import (
     get_selected_change_file_path,
     load_selected_change,
     read_selected_change_kind,
-    record_hunk_discarded,
-    record_hunks_discarded,
     refuse_bare_action_after_auto_advance_disabled,
     refuse_bare_action_after_file_list,
     require_selected_hunk,
@@ -91,6 +89,7 @@ from ..data.file_review.state import (
 from ..data.file_tracking import auto_add_untracked_files
 from ..data.line_state import load_line_changes_from_state
 from ..data.live_diff import stream_live_git_diff
+from ..data.progress import record_hunk_discarded, record_hunks_discarded
 from ..data.batch_sources import create_batch_source_commit, load_session_batch_sources, save_session_batch_sources
 from ..data.session import require_session_started, snapshot_file_if_untracked, snapshot_files_if_untracked
 from ..data.undo import undo_checkpoint

--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -69,7 +69,6 @@ from ..data.hunk_tracking import (
     require_selected_hunk,
     restore_selected_change_state,
     snapshot_selected_change_state,
-    stream_live_git_diff,
 )
 from ..data.file_change_display import (
     render_binary_file_change,
@@ -89,6 +88,7 @@ from ..data.file_review.state import (
 )
 from ..data.file_tracking import auto_add_untracked_files
 from ..data.line_state import load_line_changes_from_state
+from ..data.live_diff import stream_live_git_diff
 from ..data.batch_sources import create_batch_source_commit, load_session_batch_sources, save_session_batch_sources
 from ..data.session import require_session_started, snapshot_file_if_untracked, snapshot_files_if_untracked
 from ..data.undo import undo_checkpoint

--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -66,14 +66,16 @@ from ..data.hunk_tracking import (
     record_hunks_discarded,
     refuse_bare_action_after_auto_advance_disabled,
     refuse_bare_action_after_file_list,
-    render_binary_file_change,
-    render_gitlink_change,
-    render_rename_change,
-    render_text_deletion_change,
     require_selected_hunk,
     restore_selected_change_state,
     snapshot_selected_change_state,
     stream_live_git_diff,
+)
+from ..data.file_change_display import (
+    render_binary_file_change,
+    render_gitlink_change,
+    render_rename_change,
+    render_text_deletion_change,
 )
 from ..data.file_review.state import (
     FileReviewAction,

--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -55,8 +55,6 @@ from ..core.models import BinaryFileChange, GitlinkChange, RenameChange, TextFil
 from ..core.text_lifecycle import TextFileChangeType, detect_empty_text_lifecycle_change
 from ..data.hunk_tracking import (
     SelectedChangeKind,
-    build_file_hunk_from_buffer,
-    cache_unstaged_file_as_single_hunk,
     fetch_next_change,
     finish_selected_change_action,
     get_selected_change_file_path,
@@ -75,6 +73,10 @@ from ..data.file_change_display import (
     render_gitlink_change,
     render_rename_change,
     render_text_deletion_change,
+)
+from ..data.file_hunk_display import (
+    build_file_hunk_from_buffer,
+    cache_unstaged_file_as_single_hunk,
 )
 from ..data.file_review.state import (
     FileReviewAction,

--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -54,15 +54,17 @@ from ..core.line_selection import parse_line_selection
 from ..core.models import BinaryFileChange, GitlinkChange, RenameChange, TextFileDeletionChange
 from ..core.text_lifecycle import TextFileChangeType, detect_empty_text_lifecycle_change
 from ..data.hunk_tracking import (
-    SelectedChangeKind,
     fetch_next_change,
     finish_selected_change_action,
-    get_selected_change_file_path,
     load_selected_change,
+    require_selected_hunk,
+)
+from ..data.selected_change.store import (
+    SelectedChangeKind,
+    get_selected_change_file_path,
     read_selected_change_kind,
     refuse_bare_action_after_auto_advance_disabled,
     refuse_bare_action_after_file_list,
-    require_selected_hunk,
     restore_selected_change_state,
     snapshot_selected_change_state,
 )

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -54,7 +54,6 @@ from ..core.text_lifecycle import TextFileChangeType, detect_empty_text_lifecycl
 from ..data.hunk_tracking import (
     SelectedChangeKind,
     apply_line_level_batch_filter_to_cached_hunk,
-    cache_unstaged_file_as_single_hunk,
     clear_selected_change_state_files,
     fetch_next_change,
     finish_selected_change_action,
@@ -68,7 +67,6 @@ from ..data.hunk_tracking import (
     record_text_deletion_hunk_skipped,
     refuse_bare_action_after_auto_advance_disabled,
     refuse_bare_action_after_file_list,
-    render_unstaged_file_as_single_hunk,
     require_selected_hunk,
     restore_selected_change_state,
     snapshot_selected_change_state,
@@ -78,6 +76,10 @@ from ..data.file_change_display import (
     render_binary_file_change,
     render_gitlink_change,
     render_text_deletion_change,
+)
+from ..data.file_hunk_display import (
+    cache_unstaged_file_as_single_hunk,
+    render_unstaged_file_as_single_hunk,
 )
 from ..data.file_review.state import (
     FileReviewAction,

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -73,7 +73,6 @@ from ..data.hunk_tracking import (
     restore_selected_change_state,
     snapshot_selected_change_state,
     snapshots_are_stale,
-    stream_live_git_diff,
 )
 from ..data.file_change_display import (
     render_binary_file_change,
@@ -93,6 +92,7 @@ from ..data.consumed_selections import record_consumed_selection
 from ..data.batch_sources import create_batch_source_commit
 from ..data.file_tracking import auto_add_untracked_files
 from ..data.line_state import load_line_changes_from_state
+from ..data.live_diff import stream_live_git_diff
 from ..data.session import require_session_started, snapshot_file_if_untracked
 from ..data.undo import undo_checkpoint
 from ..editor import (

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -52,16 +52,18 @@ from ..core.line_selection import (
 from ..core.models import BinaryFileChange, GitlinkChange, RenameChange, TextFileDeletionChange
 from ..core.text_lifecycle import TextFileChangeType, detect_empty_text_lifecycle_change
 from ..data.hunk_tracking import (
-    SelectedChangeKind,
     apply_line_level_batch_filter_to_cached_hunk,
     fetch_next_change,
     finish_selected_change_action,
-    get_selected_change_file_path,
     load_selected_change,
+    require_selected_hunk,
+)
+from ..data.selected_change.store import (
+    SelectedChangeKind,
+    get_selected_change_file_path,
     read_selected_change_kind,
     refuse_bare_action_after_auto_advance_disabled,
     refuse_bare_action_after_file_list,
-    require_selected_hunk,
     restore_selected_change_state,
     snapshot_selected_change_state,
 )

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -60,11 +60,6 @@ from ..data.hunk_tracking import (
     get_selected_change_file_path,
     load_selected_change,
     read_selected_change_kind,
-    record_binary_hunk_skipped,
-    record_gitlink_hunk_skipped,
-    record_hunk_included,
-    record_hunk_skipped,
-    record_text_deletion_hunk_skipped,
     refuse_bare_action_after_auto_advance_disabled,
     refuse_bare_action_after_file_list,
     require_selected_hunk,
@@ -95,6 +90,13 @@ from ..data.batch_sources import create_batch_source_commit
 from ..data.file_tracking import auto_add_untracked_files
 from ..data.line_state import load_line_changes_from_state
 from ..data.live_diff import stream_live_git_diff
+from ..data.progress import (
+    record_binary_hunk_skipped,
+    record_gitlink_hunk_skipped,
+    record_hunk_included,
+    record_hunk_skipped,
+    record_text_deletion_hunk_skipped,
+)
 from ..data.session import require_session_started, snapshot_file_if_untracked
 from ..data.undo import undo_checkpoint
 from ..editor import (

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -69,14 +69,16 @@ from ..data.hunk_tracking import (
     refuse_bare_action_after_auto_advance_disabled,
     refuse_bare_action_after_file_list,
     render_unstaged_file_as_single_hunk,
-    render_binary_file_change,
-    render_gitlink_change,
-    render_text_deletion_change,
     require_selected_hunk,
     restore_selected_change_state,
     snapshot_selected_change_state,
     snapshots_are_stale,
     stream_live_git_diff,
+)
+from ..data.file_change_display import (
+    render_binary_file_change,
+    render_gitlink_change,
+    render_text_deletion_change,
 )
 from ..data.file_review.state import (
     FileReviewAction,

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -54,7 +54,6 @@ from ..core.text_lifecycle import TextFileChangeType, detect_empty_text_lifecycl
 from ..data.hunk_tracking import (
     SelectedChangeKind,
     apply_line_level_batch_filter_to_cached_hunk,
-    clear_selected_change_state_files,
     fetch_next_change,
     finish_selected_change_action,
     get_selected_change_file_path,
@@ -65,7 +64,6 @@ from ..data.hunk_tracking import (
     require_selected_hunk,
     restore_selected_change_state,
     snapshot_selected_change_state,
-    snapshots_are_stale,
 )
 from ..data.file_change_display import (
     render_binary_file_change,
@@ -97,6 +95,8 @@ from ..data.progress import (
     record_hunk_skipped,
     record_text_deletion_hunk_skipped,
 )
+from ..data.selected_change.lifecycle import clear_selected_change_state_files
+from ..data.selected_change.snapshots import snapshots_are_stale
 from ..data.session import require_session_started, snapshot_file_if_untracked
 from ..data.undo import undo_checkpoint
 from ..editor import (

--- a/src/git_stage_batch/commands/include_from.py
+++ b/src/git_stage_batch/commands/include_from.py
@@ -51,9 +51,7 @@ from ..data.file_review.state import (
     finish_review_scoped_line_action,
     resolve_batch_source_action_scope,
 )
-from ..data.hunk_tracking import (
-    render_batch_file_display,
-)
+from ..batch.file_display import render_batch_file_display
 from ..editor import (
     EditorBuffer,
     load_git_object_as_buffer,

--- a/src/git_stage_batch/commands/reset.py
+++ b/src/git_stage_batch/commands/reset.py
@@ -40,6 +40,10 @@ from ..batch.source_selector import require_plain_batch_name
 from ..batch.validation import batch_exists, validate_batch_name
 from ..exceptions import MergeError, exit_with_error
 from ..i18n import _
+from ..data.batch_selected_changes import (
+    selected_batch_binary_matches_batch,
+    selected_batch_gitlink_matches_batch,
+)
 from ..data.file_review.state import (
     FileReviewAction,
     ReviewSource,
@@ -50,8 +54,6 @@ from ..data.file_review.state import (
 )
 from ..data.hunk_tracking import (
     render_batch_file_display,
-    selected_batch_binary_matches_batch,
-    selected_batch_gitlink_matches_batch,
 )
 from ..data.selected_change.lifecycle import clear_selected_change_state_files
 from ..data.selected_change.store import (

--- a/src/git_stage_batch/commands/reset.py
+++ b/src/git_stage_batch/commands/reset.py
@@ -49,14 +49,16 @@ from ..data.file_review.state import (
     validate_review_scoped_line_selection,
 )
 from ..data.hunk_tracking import (
-    SelectedChangeKind,
-    clear_selected_change_state_files,
-    get_selected_change_file_path,
-    mark_selected_change_cleared_by_stale_batch_selection,
-    read_selected_change_kind,
     render_batch_file_display,
     selected_batch_binary_matches_batch,
     selected_batch_gitlink_matches_batch,
+)
+from ..data.selected_change.lifecycle import clear_selected_change_state_files
+from ..data.selected_change.store import (
+    SelectedChangeKind,
+    get_selected_change_file_path,
+    mark_selected_change_cleared_by_stale_batch_selection,
+    read_selected_change_kind,
 )
 from ..data.undo import undo_checkpoint
 from ..editor import load_git_object_as_buffer

--- a/src/git_stage_batch/commands/reset.py
+++ b/src/git_stage_batch/commands/reset.py
@@ -40,6 +40,7 @@ from ..batch.source_selector import require_plain_batch_name
 from ..batch.validation import batch_exists, validate_batch_name
 from ..exceptions import MergeError, exit_with_error
 from ..i18n import _
+from ..batch.file_display import render_batch_file_display
 from ..data.batch_selected_changes import (
     selected_batch_binary_matches_batch,
     selected_batch_gitlink_matches_batch,
@@ -51,9 +52,6 @@ from ..data.file_review.state import (
     read_last_file_review_state,
     resolve_batch_source_action_scope,
     validate_review_scoped_line_selection,
-)
-from ..data.hunk_tracking import (
-    render_batch_file_display,
 )
 from ..data.selected_change.lifecycle import clear_selected_change_state_files
 from ..data.selected_change.store import (

--- a/src/git_stage_batch/commands/show.py
+++ b/src/git_stage_batch/commands/show.py
@@ -26,10 +26,6 @@ from ..data.hunk_tracking import (
     clear_selected_change_state_files,
     get_selected_change_file_path,
     mark_selected_change_cleared_by_file_list,
-    render_binary_file_change,
-    render_gitlink_change,
-    render_rename_change,
-    render_text_deletion_change,
     render_file_as_single_hunk,
     restore_selected_change_state,
     snapshot_selected_change_state,
@@ -37,6 +33,12 @@ from ..data.hunk_tracking import (
     text_deletion_change_is_batched,
     write_selected_hunk_patch_lines,
     write_selected_change_kind,
+)
+from ..data.file_change_display import (
+    render_binary_file_change,
+    render_gitlink_change,
+    render_rename_change,
+    render_text_deletion_change,
 )
 from ..data.file_review.state import (
     clear_last_file_review_state,

--- a/src/git_stage_batch/commands/show.py
+++ b/src/git_stage_batch/commands/show.py
@@ -29,7 +29,6 @@ from ..data.hunk_tracking import (
     render_file_as_single_hunk,
     restore_selected_change_state,
     snapshot_selected_change_state,
-    stream_live_git_diff,
     write_selected_hunk_patch_lines,
     write_selected_change_kind,
 )
@@ -46,6 +45,7 @@ from ..data.file_review.state import (
     write_last_file_review_state,
 )
 from ..data.line_state import convert_line_changes_to_serializable_dict, load_line_changes_from_state
+from ..data.live_diff import stream_live_git_diff
 from ..data.session import require_session_started
 from ..data.selected_change.snapshots import write_snapshots_for_selected_file_path
 from ..exceptions import exit_with_error

--- a/src/git_stage_batch/commands/show.py
+++ b/src/git_stage_batch/commands/show.py
@@ -16,8 +16,10 @@ from ..core.hashing import (
 )
 from ..core.models import BinaryFileChange, GitlinkChange, RenameChange, TextFileDeletionChange
 from ..data.hunk_tracking import (
-    SelectedChangeKind,
     apply_line_level_batch_filter_to_cached_hunk,
+)
+from ..data.selected_change.store import (
+    SelectedChangeKind,
     cache_binary_file_change,
     cache_gitlink_change,
     cache_rename_change,

--- a/src/git_stage_batch/commands/show.py
+++ b/src/git_stage_batch/commands/show.py
@@ -19,20 +19,19 @@ from ..data.hunk_tracking import (
     SelectedChangeKind,
     apply_line_level_batch_filter_to_cached_hunk,
     cache_binary_file_change,
-    cache_file_as_single_hunk,
     cache_gitlink_change,
     cache_rename_change,
     cache_text_deletion_change,
     clear_selected_change_state_files,
     get_selected_change_file_path,
     mark_selected_change_cleared_by_file_list,
-    render_file_as_single_hunk,
     restore_selected_change_state,
     snapshot_selected_change_state,
     write_selected_hunk_patch_lines,
     write_selected_change_kind,
 )
 from ..data.change_freshness import text_deletion_change_is_batched
+from ..data.file_hunk_display import cache_file_as_single_hunk, render_file_as_single_hunk
 from ..data.file_change_display import (
     render_binary_file_change,
     render_gitlink_change,

--- a/src/git_stage_batch/commands/show.py
+++ b/src/git_stage_batch/commands/show.py
@@ -30,10 +30,10 @@ from ..data.hunk_tracking import (
     restore_selected_change_state,
     snapshot_selected_change_state,
     stream_live_git_diff,
-    text_deletion_change_is_batched,
     write_selected_hunk_patch_lines,
     write_selected_change_kind,
 )
+from ..data.change_freshness import text_deletion_change_is_batched
 from ..data.file_change_display import (
     render_binary_file_change,
     render_gitlink_change,

--- a/src/git_stage_batch/commands/show.py
+++ b/src/git_stage_batch/commands/show.py
@@ -22,7 +22,6 @@ from ..data.hunk_tracking import (
     cache_gitlink_change,
     cache_rename_change,
     cache_text_deletion_change,
-    clear_selected_change_state_files,
     get_selected_change_file_path,
     mark_selected_change_cleared_by_file_list,
     restore_selected_change_state,
@@ -46,6 +45,7 @@ from ..data.file_review.state import (
 from ..data.line_state import convert_line_changes_to_serializable_dict, load_line_changes_from_state
 from ..data.live_diff import stream_live_git_diff
 from ..data.session import require_session_started
+from ..data.selected_change.lifecycle import clear_selected_change_state_files
 from ..data.selected_change.snapshots import write_snapshots_for_selected_file_path
 from ..exceptions import exit_with_error
 from ..i18n import _

--- a/src/git_stage_batch/commands/show_from.py
+++ b/src/git_stage_batch/commands/show_from.py
@@ -40,15 +40,17 @@ from ..core.text_lifecycle import (
 )
 from ..core.diff_parser import build_line_changes_from_patch_lines
 from ..data.hunk_tracking import (
+    cache_rendered_batch_file_display,
+    compute_batch_binary_fingerprint,
+    compute_batch_gitlink_fingerprint,
+    render_batch_file_display,
+)
+from ..data.selected_change.lifecycle import clear_selected_change_state_files
+from ..data.selected_change.store import (
     SelectedChangeKind,
     cache_binary_file_change,
     cache_gitlink_change,
-    cache_rendered_batch_file_display,
-    clear_selected_change_state_files,
-    compute_batch_binary_fingerprint,
-    compute_batch_gitlink_fingerprint,
     mark_selected_change_cleared_by_file_list,
-    render_batch_file_display,
 )
 from ..data.file_review.state import (
     FileReviewAction,

--- a/src/git_stage_batch/commands/show_from.py
+++ b/src/git_stage_batch/commands/show_from.py
@@ -44,9 +44,7 @@ from ..data.batch_selected_changes import (
     compute_batch_binary_fingerprint,
     compute_batch_gitlink_fingerprint,
 )
-from ..data.hunk_tracking import (
-    cache_rendered_batch_file_display,
-)
+from ..data.selected_change.batch_file_cache import cache_rendered_batch_file_display
 from ..data.selected_change.lifecycle import clear_selected_change_state_files
 from ..data.selected_change.store import (
     SelectedChangeKind,

--- a/src/git_stage_batch/commands/show_from.py
+++ b/src/git_stage_batch/commands/show_from.py
@@ -39,13 +39,13 @@ from ..core.text_lifecycle import (
     normalized_text_change_type,
 )
 from ..core.diff_parser import build_line_changes_from_patch_lines
+from ..batch.file_display import render_batch_file_display
 from ..data.batch_selected_changes import (
     compute_batch_binary_fingerprint,
     compute_batch_gitlink_fingerprint,
 )
 from ..data.hunk_tracking import (
     cache_rendered_batch_file_display,
-    render_batch_file_display,
 )
 from ..data.selected_change.lifecycle import clear_selected_change_state_files
 from ..data.selected_change.store import (

--- a/src/git_stage_batch/commands/show_from.py
+++ b/src/git_stage_batch/commands/show_from.py
@@ -39,10 +39,12 @@ from ..core.text_lifecycle import (
     normalized_text_change_type,
 )
 from ..core.diff_parser import build_line_changes_from_patch_lines
-from ..data.hunk_tracking import (
-    cache_rendered_batch_file_display,
+from ..data.batch_selected_changes import (
     compute_batch_binary_fingerprint,
     compute_batch_gitlink_fingerprint,
+)
+from ..data.hunk_tracking import (
+    cache_rendered_batch_file_display,
     render_batch_file_display,
 )
 from ..data.selected_change.lifecycle import clear_selected_change_state_files

--- a/src/git_stage_batch/commands/skip.py
+++ b/src/git_stage_batch/commands/skip.py
@@ -36,7 +36,6 @@ from ..data.hunk_tracking import (
     refuse_bare_action_after_auto_advance_disabled,
     refuse_bare_action_after_file_list,
     require_selected_hunk,
-    stream_live_git_diff,
 )
 from ..data.file_review.state import (
     FileReviewAction,
@@ -47,6 +46,7 @@ from ..data.file_review.state import (
 )
 from ..data.file_tracking import auto_add_untracked_files
 from ..data.line_state import convert_line_changes_to_serializable_dict, load_line_changes_from_state
+from ..data.live_diff import stream_live_git_diff
 from ..data.session import require_session_started
 from ..data.undo import undo_checkpoint
 from ..exceptions import NoMoreHunks, exit_with_error

--- a/src/git_stage_batch/commands/skip.py
+++ b/src/git_stage_batch/commands/skip.py
@@ -44,6 +44,10 @@ from ..data.file_review.state import (
     refuse_live_action_for_batch_selection,
     resolve_live_line_action_scope,
 )
+from ..data.file_hunk_display import (
+    cache_unstaged_file_as_single_hunk,
+    render_unstaged_file_as_single_hunk,
+)
 from ..data.file_tracking import auto_add_untracked_files
 from ..data.line_state import convert_line_changes_to_serializable_dict, load_line_changes_from_state
 from ..data.live_diff import stream_live_git_diff
@@ -389,8 +393,6 @@ def command_skip_line(
         else:
             target_file = file
         auto_add_untracked_files([target_file])
-        from ..data.hunk_tracking import cache_unstaged_file_as_single_hunk
-        from ..data.hunk_tracking import render_unstaged_file_as_single_hunk
 
         reuse_selected_file_view = (
             read_selected_change_kind() == SelectedChangeKind.FILE

--- a/src/git_stage_batch/commands/skip.py
+++ b/src/git_stage_batch/commands/skip.py
@@ -22,15 +22,17 @@ from ..core.line_selection import (
 from ..batch.selection import require_line_selection_in_view
 from ..core.models import BinaryFileChange, GitlinkChange, RenameChange, TextFileDeletionChange
 from ..data.hunk_tracking import (
-    SelectedChangeKind,
     fetch_next_change,
     finish_selected_change_action,
-    get_selected_change_file_path,
     load_selected_change,
+    require_selected_hunk,
+)
+from ..data.selected_change.store import (
+    SelectedChangeKind,
+    get_selected_change_file_path,
     read_selected_change_kind,
     refuse_bare_action_after_auto_advance_disabled,
     refuse_bare_action_after_file_list,
-    require_selected_hunk,
 )
 from ..data.file_review.state import (
     FileReviewAction,

--- a/src/git_stage_batch/commands/skip.py
+++ b/src/git_stage_batch/commands/skip.py
@@ -28,11 +28,6 @@ from ..data.hunk_tracking import (
     get_selected_change_file_path,
     load_selected_change,
     read_selected_change_kind,
-    record_binary_hunk_skipped,
-    record_gitlink_hunk_skipped,
-    record_hunk_skipped,
-    record_rename_hunk_skipped,
-    record_text_deletion_hunk_skipped,
     refuse_bare_action_after_auto_advance_disabled,
     refuse_bare_action_after_file_list,
     require_selected_hunk,
@@ -51,6 +46,13 @@ from ..data.file_hunk_display import (
 from ..data.file_tracking import auto_add_untracked_files
 from ..data.line_state import convert_line_changes_to_serializable_dict, load_line_changes_from_state
 from ..data.live_diff import stream_live_git_diff
+from ..data.progress import (
+    record_binary_hunk_skipped,
+    record_gitlink_hunk_skipped,
+    record_hunk_skipped,
+    record_rename_hunk_skipped,
+    record_text_deletion_hunk_skipped,
+)
 from ..data.session import require_session_started
 from ..data.undo import undo_checkpoint
 from ..exceptions import NoMoreHunks, exit_with_error

--- a/src/git_stage_batch/commands/start.py
+++ b/src/git_stage_batch/commands/start.py
@@ -6,7 +6,8 @@ from typing import Optional
 
 from .again import command_again
 from ..data.auto_advance import DEFAULT_AUTO_ADVANCE, write_auto_advance_default
-from ..data.hunk_tracking import clear_selected_change_state_files, fetch_next_change, show_selected_change
+from ..data.hunk_tracking import fetch_next_change, show_selected_change
+from ..data.selected_change.lifecycle import clear_selected_change_state_files
 from ..data.file_tracking import auto_add_untracked_files
 from ..data.session import initialize_abort_state
 from ..data.staged_renames import normalize_start_time_staged_deletions, normalize_start_time_staged_renames

--- a/src/git_stage_batch/commands/status.py
+++ b/src/git_stage_batch/commands/status.py
@@ -18,6 +18,10 @@ from ..core.hashing import (
 )
 from ..core.diff_parser import acquire_unified_diff
 from ..core.models import BinaryFileChange, GitlinkChange, RenameChange, TextFileDeletionChange
+from ..data.batch_selected_changes import (
+    selected_batch_binary_batch_name,
+    selected_batch_binary_file_for_batch,
+)
 from ..data.file_review.state import (
     FileReviewAction,
     ReviewSource,
@@ -30,8 +34,6 @@ from ..data.hunk_tracking import (
     format_id_range,
     gitlink_change_is_stale,
     rename_change_is_stale,
-    selected_batch_binary_batch_name,
-    selected_batch_binary_file_for_batch,
     snapshots_are_stale,
     stream_live_git_diff,
     text_deletion_change_is_batched,

--- a/src/git_stage_batch/commands/status.py
+++ b/src/git_stage_batch/commands/status.py
@@ -33,11 +33,11 @@ from ..data.hunk_tracking import (
     binary_file_change_is_stale,
     gitlink_change_is_stale,
     rename_change_is_stale,
-    stream_live_git_diff,
     text_deletion_change_is_batched,
     text_deletion_change_is_stale,
 )
 from ..data.line_state import load_line_changes_from_state
+from ..data.live_diff import stream_live_git_diff
 from ..data.progress import format_id_range
 from ..data.selected_change.lifecycle import clear_selected_change_state_files
 from ..data.selected_change.store import (

--- a/src/git_stage_batch/commands/status.py
+++ b/src/git_stage_batch/commands/status.py
@@ -33,7 +33,6 @@ from ..data.hunk_tracking import (
     binary_file_change_is_stale,
     gitlink_change_is_stale,
     rename_change_is_stale,
-    snapshots_are_stale,
     stream_live_git_diff,
     text_deletion_change_is_batched,
     text_deletion_change_is_stale,
@@ -50,6 +49,7 @@ from ..data.selected_change.store import (
     mark_selected_change_cleared_by_stale_batch_selection,
     read_selected_change_kind,
 )
+from ..data.selected_change.snapshots import snapshots_are_stale
 from ..data.session import get_iteration_count
 from ..exceptions import CommandError
 from ..i18n import _

--- a/src/git_stage_batch/commands/status.py
+++ b/src/git_stage_batch/commands/status.py
@@ -31,7 +31,6 @@ from ..data.file_review.state import (
 )
 from ..data.hunk_tracking import (
     binary_file_change_is_stale,
-    format_id_range,
     gitlink_change_is_stale,
     rename_change_is_stale,
     snapshots_are_stale,
@@ -40,6 +39,7 @@ from ..data.hunk_tracking import (
     text_deletion_change_is_stale,
 )
 from ..data.line_state import load_line_changes_from_state
+from ..data.progress import format_id_range
 from ..data.selected_change.lifecycle import clear_selected_change_state_files
 from ..data.selected_change.store import (
     SelectedChangeKind,

--- a/src/git_stage_batch/commands/status.py
+++ b/src/git_stage_batch/commands/status.py
@@ -22,19 +22,19 @@ from ..data.batch_selected_changes import (
     selected_batch_binary_batch_name,
     selected_batch_binary_file_for_batch,
 )
+from ..data.change_freshness import (
+    binary_file_change_is_stale,
+    gitlink_change_is_stale,
+    rename_change_is_stale,
+    text_deletion_change_is_batched,
+    text_deletion_change_is_stale,
+)
 from ..data.file_review.state import (
     FileReviewAction,
     ReviewSource,
     read_last_file_review_state,
     selected_change_matches_review_state,
     shown_review_selections_for_action,
-)
-from ..data.hunk_tracking import (
-    binary_file_change_is_stale,
-    gitlink_change_is_stale,
-    rename_change_is_stale,
-    text_deletion_change_is_batched,
-    text_deletion_change_is_stale,
 )
 from ..data.line_state import load_line_changes_from_state
 from ..data.live_diff import stream_live_git_diff

--- a/src/git_stage_batch/commands/status.py
+++ b/src/git_stage_batch/commands/status.py
@@ -26,17 +26,9 @@ from ..data.file_review.state import (
     shown_review_selections_for_action,
 )
 from ..data.hunk_tracking import (
-    SelectedChangeKind,
     binary_file_change_is_stale,
-    clear_selected_change_state_files,
     format_id_range,
     gitlink_change_is_stale,
-    load_selected_binary_file,
-    load_selected_gitlink_change,
-    load_selected_rename_change,
-    load_selected_text_deletion_change,
-    mark_selected_change_cleared_by_stale_batch_selection,
-    read_selected_change_kind,
     rename_change_is_stale,
     selected_batch_binary_batch_name,
     selected_batch_binary_file_for_batch,
@@ -46,6 +38,16 @@ from ..data.hunk_tracking import (
     text_deletion_change_is_stale,
 )
 from ..data.line_state import load_line_changes_from_state
+from ..data.selected_change.lifecycle import clear_selected_change_state_files
+from ..data.selected_change.store import (
+    SelectedChangeKind,
+    load_selected_binary_file,
+    load_selected_gitlink_change,
+    load_selected_rename_change,
+    load_selected_text_deletion_change,
+    mark_selected_change_cleared_by_stale_batch_selection,
+    read_selected_change_kind,
+)
 from ..data.session import get_iteration_count
 from ..exceptions import CommandError
 from ..i18n import _

--- a/src/git_stage_batch/commands/suggest_fixup.py
+++ b/src/git_stage_batch/commands/suggest_fixup.py
@@ -9,12 +9,10 @@ from typing import Any
 
 from ..core.line_selection import parse_line_selection
 from ..data.file_review.state import compute_current_file_review_diff_fingerprint
-from ..data.hunk_tracking import (
-    get_selected_change_file_path,
-    require_selected_hunk,
-)
+from ..data.hunk_tracking import require_selected_hunk
 from ..data.file_hunk_display import render_file_as_single_hunk
 from ..data.line_state import load_line_changes_from_state
+from ..data.selected_change.store import get_selected_change_file_path
 from ..data.session import require_session_started
 from ..exceptions import exit_with_error
 from ..i18n import _

--- a/src/git_stage_batch/commands/suggest_fixup.py
+++ b/src/git_stage_batch/commands/suggest_fixup.py
@@ -11,9 +11,9 @@ from ..core.line_selection import parse_line_selection
 from ..data.file_review.state import compute_current_file_review_diff_fingerprint
 from ..data.hunk_tracking import (
     get_selected_change_file_path,
-    render_file_as_single_hunk,
     require_selected_hunk,
 )
+from ..data.file_hunk_display import render_file_as_single_hunk
 from ..data.line_state import load_line_changes_from_state
 from ..data.session import require_session_started
 from ..exceptions import exit_with_error

--- a/src/git_stage_batch/data/batch_selected_changes.py
+++ b/src/git_stage_batch/data/batch_selected_changes.py
@@ -14,9 +14,11 @@ from .selected_change.lifecycle import clear_selected_change_state_files
 from .selected_change.store import (
     SelectedChangeKind,
     load_selected_binary_file,
+    load_selected_gitlink_change,
     mark_selected_change_cleared_by_stale_batch_selection,
     read_selected_binary_data,
     read_selected_change_kind,
+    read_selected_gitlink_data,
 )
 
 
@@ -133,6 +135,98 @@ def require_current_selected_batch_binary_file_for_batch(
     exit_with_error(
         _(
             "The selected batch binary no longer matches batch '{name}'.\n"
+            "Show the batch again before using a pathless batch action."
+        ).format(name=batch_name)
+    )
+
+
+def compute_batch_gitlink_fingerprint(
+    file_path: str,
+    file_meta: Mapping[str, object],
+) -> str:
+    """Return a stable identity for the current stored submodule pointer."""
+    payload = {
+        "file_path": file_path,
+        "file_type": file_meta.get("file_type"),
+        "change_type": file_meta.get("change_type"),
+        "mode": file_meta.get("mode"),
+        "old_oid": file_meta.get("old_oid"),
+        "new_oid": file_meta.get("new_oid"),
+    }
+    data = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return sha256(data.encode("utf-8", errors="surrogateescape")).hexdigest()
+
+
+def selected_batch_gitlink_matches_batch(batch_name: str) -> bool:
+    """Return whether the cached batch submodule pointer came from this batch."""
+    if read_selected_change_kind() != SelectedChangeKind.BATCH_GITLINK:
+        return False
+    gitlink_data = read_selected_gitlink_data()
+    if gitlink_data is None:
+        return False
+    return gitlink_data.get("batch_name") == batch_name
+
+
+def selected_batch_gitlink_file_for_batch(
+    batch_name: str,
+    all_files: Mapping[str, dict],
+) -> str | None:
+    """Return the selected batch submodule pointer if it is still current."""
+    if not selected_batch_gitlink_matches_batch(batch_name):
+        return None
+
+    gitlink_change = load_selected_gitlink_change()
+    if gitlink_change is None:
+        return None
+
+    file_path = gitlink_change.path()
+    file_meta = all_files.get(file_path)
+    if file_meta is None:
+        return None
+    if file_meta.get("file_type") != "gitlink":
+        return None
+    if file_meta.get("change_type") != gitlink_change.change_type:
+        return None
+    if file_meta.get("old_oid") != gitlink_change.old_oid:
+        return None
+    if file_meta.get("new_oid") != gitlink_change.new_oid:
+        return None
+
+    gitlink_data = read_selected_gitlink_data()
+    if gitlink_data is None:
+        return None
+    cached_fingerprint = gitlink_data.get("batch_gitlink_fingerprint")
+    if not isinstance(cached_fingerprint, str):
+        return None
+    current_fingerprint = compute_batch_gitlink_fingerprint(file_path, file_meta)
+    if current_fingerprint != cached_fingerprint:
+        return None
+
+    return file_path
+
+
+def require_current_selected_batch_gitlink_file_for_batch(
+    batch_name: str,
+    all_files: Mapping[str, dict],
+) -> str | None:
+    """Return selected batch submodule pointer, or refuse if it went stale."""
+    if not selected_batch_gitlink_matches_batch(batch_name):
+        return None
+
+    selected_file = selected_batch_gitlink_file_for_batch(batch_name, all_files)
+    if selected_file is not None:
+        return selected_file
+
+    gitlink_change = load_selected_gitlink_change()
+    file_path = gitlink_change.path() if gitlink_change is not None else "the selected batch submodule pointer"
+    clear_selected_change_state_files()
+    mark_selected_change_cleared_by_stale_batch_selection(
+        batch_name=batch_name,
+        file_path=file_path,
+    )
+    exit_with_error(
+        _(
+            "The selected batch submodule pointer no longer matches batch '{name}'.\n"
             "Show the batch again before using a pathless batch action."
         ).format(name=batch_name)
     )

--- a/src/git_stage_batch/data/change_freshness.py
+++ b/src/git_stage_batch/data/change_freshness.py
@@ -1,0 +1,100 @@
+"""Freshness checks for cached live file changes."""
+
+from __future__ import annotations
+
+from ..batch.query import list_batch_names, read_batch_metadata
+from ..core.models import (
+    BinaryFileChange,
+    GitlinkChange,
+    RenameChange,
+    TextFileDeletionChange,
+)
+from ..core.text_lifecycle import detect_empty_text_lifecycle_change
+from .file_change_display import (
+    render_binary_file_change,
+    render_gitlink_change,
+    render_rename_change,
+    render_text_deletion_change,
+)
+from .selected_change.snapshots import snapshots_are_stale
+
+
+def binary_file_change_is_stale(binary_change: BinaryFileChange) -> bool:
+    """Return whether a cached binary selection no longer matches repository state."""
+    file_path = (
+        binary_change.new_path
+        if binary_change.new_path != "/dev/null"
+        else binary_change.old_path
+    )
+    if snapshots_are_stale(file_path):
+        return True
+    current_change = render_binary_file_change(file_path)
+    if current_change is None:
+        return True
+    return (
+        current_change.old_path != binary_change.old_path
+        or current_change.new_path != binary_change.new_path
+        or current_change.change_type != binary_change.change_type
+    )
+
+
+def gitlink_change_is_stale(gitlink_change: GitlinkChange) -> bool:
+    """Return whether a cached gitlink selection no longer matches Git state."""
+    current_change = render_gitlink_change(gitlink_change.path())
+    if current_change is None:
+        return True
+    return (
+        current_change.old_path != gitlink_change.old_path
+        or current_change.new_path != gitlink_change.new_path
+        or current_change.old_oid != gitlink_change.old_oid
+        or current_change.new_oid != gitlink_change.new_oid
+        or current_change.change_type != gitlink_change.change_type
+    )
+
+
+def rename_change_is_stale(rename_change: RenameChange) -> bool:
+    """Return whether a cached rename selection no longer matches Git state."""
+    current_change = render_rename_change(rename_change.new_path)
+    if current_change is None:
+        current_change = render_rename_change(rename_change.old_path)
+    if current_change is None:
+        return True
+    return (
+        current_change.old_path != rename_change.old_path
+        or current_change.new_path != rename_change.new_path
+    )
+
+
+def text_deletion_change_is_stale(
+    deletion_change: TextFileDeletionChange,
+) -> bool:
+    """Return whether a cached text deletion selection no longer matches Git state."""
+    if snapshots_are_stale(deletion_change.path()):
+        return True
+    current_change = render_text_deletion_change(deletion_change.path())
+    if current_change is None:
+        return True
+    return (
+        current_change.old_path != deletion_change.old_path
+        or current_change.new_path != deletion_change.new_path
+    )
+
+
+def text_deletion_change_is_batched(
+    deletion_change: TextFileDeletionChange,
+) -> bool:
+    """Return whether a whole-text-file deletion is already represented in a batch."""
+    return empty_text_lifecycle_change_is_batched(deletion_change.path())
+
+
+def empty_text_lifecycle_change_is_batched(file_path: str) -> bool:
+    """Return whether the current empty text lifecycle diff is already batched."""
+    change_type = detect_empty_text_lifecycle_change(file_path)
+    if change_type is None:
+        return False
+
+    for batch_name in list_batch_names():
+        file_meta = read_batch_metadata(batch_name).get("files", {}).get(file_path)
+        if file_meta is not None and file_meta.get("change_type") == change_type:
+            return True
+    return False

--- a/src/git_stage_batch/data/file_change_display.py
+++ b/src/git_stage_batch/data/file_change_display.py
@@ -1,0 +1,101 @@
+"""Live file change rendering without selected-state mutation."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import Optional
+
+from ..core.diff_parser import acquire_unified_diff
+from ..core.models import (
+    BinaryFileChange,
+    GitlinkChange,
+    RenameChange,
+    TextFileDeletionChange,
+)
+from .file_tracking import auto_add_untracked_files
+from .live_diff import stream_live_git_diff
+
+
+def render_binary_file_change(file_path: str) -> Optional[BinaryFileChange]:
+    """Render a binary file change for file-scoped display without caching state."""
+    auto_add_untracked_files([file_path])
+    try:
+        with acquire_unified_diff(
+            stream_live_git_diff(
+                base="HEAD",
+                full_index=True,
+                ignore_submodules="none",
+                submodule_format="short",
+                paths=[file_path],
+            )
+        ) as patches:
+            for item in patches:
+                if isinstance(item, BinaryFileChange):
+                    return item
+    except subprocess.CalledProcessError:
+        return None
+    return None
+
+
+def render_gitlink_change(file_path: str) -> Optional[GitlinkChange]:
+    """Render a gitlink change for file-scoped display without caching state."""
+    auto_add_untracked_files([file_path])
+    try:
+        with acquire_unified_diff(
+            stream_live_git_diff(
+                base="HEAD",
+                full_index=True,
+                ignore_submodules="none",
+                submodule_format="short",
+                paths=[file_path],
+            )
+        ) as patches:
+            for item in patches:
+                if isinstance(item, GitlinkChange):
+                    return item
+    except subprocess.CalledProcessError:
+        return None
+    return None
+
+
+def render_rename_change(file_path: str) -> Optional[RenameChange]:
+    """Render a rename change involving file_path without caching state."""
+    auto_add_untracked_files([file_path])
+    try:
+        with acquire_unified_diff(
+            stream_live_git_diff(
+                full_index=True,
+                ignore_submodules="none",
+                submodule_format="short",
+            )
+        ) as patches:
+            for item in patches:
+                if (
+                    isinstance(item, RenameChange)
+                    and file_path in (item.old_path, item.new_path)
+                ):
+                    return item
+    except subprocess.CalledProcessError:
+        return None
+    return None
+
+
+def render_text_deletion_change(
+    file_path: str,
+) -> Optional[TextFileDeletionChange]:
+    """Render a whole-text-file deletion without caching state."""
+    try:
+        with acquire_unified_diff(
+            stream_live_git_diff(
+                full_index=True,
+                ignore_submodules="none",
+                submodule_format="short",
+                paths=[file_path],
+            )
+        ) as patches:
+            for item in patches:
+                if isinstance(item, TextFileDeletionChange):
+                    return item
+    except subprocess.CalledProcessError:
+        return None
+    return None

--- a/src/git_stage_batch/data/file_hunk_display.py
+++ b/src/git_stage_batch/data/file_hunk_display.py
@@ -1,0 +1,338 @@
+"""File-scoped text hunk rendering and selected-state caching."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+import os
+import json
+import subprocess
+import tempfile
+from typing import Optional
+
+from ..core.diff_parser import (
+    acquire_unified_diff,
+    build_line_changes_from_patch_lines,
+)
+from ..core.hashing import compute_stable_hunk_hash_from_lines
+from ..core.line_selection import write_line_ids_file
+from ..core.models import (
+    BinaryFileChange,
+    GitlinkChange,
+    HunkHeader,
+    LineEntry,
+    LineLevelChange,
+    RenameChange,
+    TextFileDeletionChange,
+)
+from ..editor import EditorBuffer, load_git_object_as_buffer
+from ..i18n import ngettext
+from ..utils.file_io import write_text_file_contents
+from ..utils.git import stream_git_command
+from ..utils.paths import (
+    get_context_lines,
+    get_line_changes_json_file_path,
+    get_processed_include_ids_file_path,
+    get_processed_skip_ids_file_path,
+    get_selected_hunk_hash_file_path,
+)
+from ..utils.text import bytes_to_lines
+from .file_tracking import auto_add_untracked_files
+from .line_state import convert_line_changes_to_serializable_dict
+from .live_diff import stream_live_git_diff
+from .selected_change.store import (
+    SelectedChangeKind,
+    write_selected_change_kind,
+    write_selected_hunk_patch_lines,
+)
+from .selected_change.snapshots import write_snapshots_for_selected_file_path
+
+
+def cache_file_as_single_hunk(file_path: str) -> Optional[LineLevelChange]:
+    """Cache all changes for a file as a single concatenated hunk.
+
+    Reads the CURRENT working tree state for the file and fetches ALL
+    hunks (ignoring blocklist/batches), concatenating them into one
+    LineLevelChange with continuous line IDs.
+
+    This always reflects the live working tree state, unlike regular
+    hunk caching which uses snapshots.
+
+    Args:
+        file_path: Repository-relative path to file
+
+    Returns:
+        LineLevelChange with all file changes, or None if no changes
+    """
+    try:
+        combined_line_changes = render_file_as_single_hunk(file_path)
+        return _cache_combined_file_line_changes(file_path, combined_line_changes)
+    except subprocess.CalledProcessError:
+        return None
+
+
+def cache_unstaged_file_as_single_hunk(file_path: str) -> Optional[LineLevelChange]:
+    """Cache the remaining unstaged changes for a file as a single hunk."""
+    try:
+        combined_line_changes = render_unstaged_file_as_single_hunk(file_path)
+        return _cache_combined_file_line_changes(file_path, combined_line_changes)
+    except subprocess.CalledProcessError:
+        return None
+
+
+def _cache_combined_file_line_changes(
+    file_path: str,
+    combined_line_changes: Optional[LineLevelChange],
+) -> Optional[LineLevelChange]:
+    """Persist a combined file-scoped view as the current selection."""
+    if combined_line_changes is None:
+        return None
+
+    patch_lines = [
+        f"--- a/{file_path}\n".encode("utf-8"),
+        f"+++ b/{file_path}\n".encode("utf-8"),
+        (
+            f"@@ -{combined_line_changes.header.old_start},{combined_line_changes.header.old_len} "
+            f"+{combined_line_changes.header.new_start},{combined_line_changes.header.new_len} @@\n"
+        ).encode("utf-8"),
+    ]
+    for entry in combined_line_changes.lines:
+        patch_lines.append(entry.kind.encode("utf-8") + entry.text_bytes + b"\n")
+        if not entry.has_trailing_newline:
+            patch_lines.append(b"\\ No newline at end of file\n")
+
+    patch_hash = compute_stable_hunk_hash_from_lines(patch_lines)
+
+    write_selected_hunk_patch_lines(patch_lines)
+    write_text_file_contents(get_selected_hunk_hash_file_path(), patch_hash)
+    write_selected_change_kind(SelectedChangeKind.FILE)
+    write_line_ids_file(get_processed_include_ids_file_path(), set())
+    write_line_ids_file(get_processed_skip_ids_file_path(), set())
+    write_text_file_contents(
+        get_line_changes_json_file_path(),
+        json.dumps(
+            convert_line_changes_to_serializable_dict(combined_line_changes),
+            ensure_ascii=False,
+            indent=0,
+        ),
+    )
+
+    write_snapshots_for_selected_file_path(file_path)
+
+    return combined_line_changes
+
+
+def render_file_as_single_hunk(file_path: str) -> Optional[LineLevelChange]:
+    """Render all changes for a file as a single hunk without caching state."""
+    auto_add_untracked_files([file_path])
+    with acquire_unified_diff(
+        stream_live_git_diff(
+            base="HEAD",
+            context_lines=get_context_lines(),
+            full_index=True,
+            ignore_submodules="none",
+            submodule_format="short",
+            paths=[file_path],
+        )
+    ) as patches:
+        return _build_combined_file_line_changes(
+            file_path,
+            patches,
+        )
+
+
+def render_unstaged_file_as_single_hunk(file_path: str) -> Optional[LineLevelChange]:
+    """Render the remaining unstaged changes for a file as a single hunk."""
+    auto_add_untracked_files([file_path])
+    with acquire_unified_diff(
+        stream_live_git_diff(
+            context_lines=get_context_lines(),
+            full_index=True,
+            ignore_submodules="none",
+            submodule_format="short",
+            paths=[file_path],
+        )
+    ) as patches:
+        return _build_combined_file_line_changes(
+            file_path,
+            patches,
+        )
+
+
+def build_file_hunk_from_buffer(
+    file_path: str,
+    file_buffer: EditorBuffer,
+) -> Optional[LineLevelChange]:
+    """Build a file-scoped line view for a hypothetical file buffer without writing it."""
+    head_buffer = load_git_object_as_buffer(f"HEAD:{file_path}")
+
+    with tempfile.NamedTemporaryFile(delete=False) as old_tmp:
+        if head_buffer is not None:
+            with head_buffer:
+                for chunk in head_buffer.byte_chunks():
+                    old_tmp.write(chunk)
+        old_path = old_tmp.name
+    with tempfile.NamedTemporaryFile(delete=False) as new_tmp:
+        for chunk in file_buffer.byte_chunks():
+            new_tmp.write(chunk)
+        new_path = new_tmp.name
+
+    try:
+        with acquire_unified_diff(
+            _stream_no_index_diff_lines(
+                file_path=file_path,
+                old_path=old_path,
+                new_path=new_path,
+            )
+        ) as patches:
+            return _build_combined_file_line_changes(
+                file_path,
+                patches,
+            )
+    finally:
+        try:
+            os.unlink(old_path)
+            os.unlink(new_path)
+        except OSError:
+            pass
+
+
+def _stream_no_index_diff_lines(
+    *,
+    file_path: str,
+    old_path: str,
+    new_path: str,
+) -> Generator[bytes, None, None]:
+    arguments = [
+        "diff",
+        "--no-index",
+        f"-U{get_context_lines()}",
+        "--no-color",
+        old_path,
+        new_path,
+    ]
+    stderr_chunks: list[bytes] = []
+    exit_code = 0
+
+    def stdout_chunks() -> Generator[bytes, None, None]:
+        nonlocal exit_code
+
+        try:
+            yield from stream_git_command(arguments, requires_index_lock=False)
+        except subprocess.CalledProcessError as error:
+            exit_code = error.returncode
+            stderr = error.stderr
+            if stderr is not None:
+                stderr_chunks.append(stderr.encode("utf-8", errors="replace"))
+
+    old_header = f"a{old_path}".encode("utf-8")
+    new_header = f"b{new_path}".encode("utf-8")
+    rendered_old_header = f"a/{file_path}".encode("utf-8")
+    rendered_new_header = f"b/{file_path}".encode("utf-8")
+
+    for line in bytes_to_lines(stdout_chunks()):
+        yield line.replace(old_header, rendered_old_header).replace(
+            new_header,
+            rendered_new_header,
+        )
+
+    if exit_code not in (0, 1):
+        stderr_text = b"".join(stderr_chunks).decode("utf-8", errors="replace")
+        raise subprocess.CalledProcessError(
+            exit_code,
+            arguments,
+            stderr=stderr_text,
+        )
+
+
+def _build_combined_file_line_changes(
+    file_path: str,
+    patches,
+) -> Optional[LineLevelChange]:
+    """Combine file diff hunks into one file-scoped LineLevelChange."""
+    all_line_entries = []
+    line_id_counter = 1
+    min_old_start = None
+    max_old_end = None
+    min_new_start = None
+    max_new_end = None
+    previous_old_end = None
+    previous_new_end = None
+
+    for single_hunk in patches:
+        if isinstance(
+            single_hunk,
+            (BinaryFileChange, GitlinkChange, RenameChange, TextFileDeletionChange),
+        ):
+            continue
+
+        line_changes = build_line_changes_from_patch_lines(single_hunk.lines)
+
+        if previous_old_end is not None and previous_new_end is not None:
+            omitted_old_lines = line_changes.header.old_start - previous_old_end
+            omitted_new_lines = line_changes.header.new_start - previous_new_end
+            omitted_line_count = max(omitted_old_lines, omitted_new_lines)
+            if omitted_line_count > 0:
+                gap_text = ngettext(
+                    "... {count} more line ...",
+                    "... {count} more lines ...",
+                    omitted_line_count,
+                ).format(count=omitted_line_count)
+                all_line_entries.append(
+                    LineEntry(
+                        id=None,
+                        kind=" ",
+                        old_line_number=None,
+                        new_line_number=None,
+                        text_bytes=gap_text.encode("utf-8"),
+                        source_line=None,
+                    )
+                )
+
+        if min_old_start is None:
+            min_old_start = line_changes.header.old_start
+            min_new_start = line_changes.header.new_start
+
+        max_old_end = line_changes.header.old_start + line_changes.header.old_len
+        max_new_end = line_changes.header.new_start + line_changes.header.new_len
+        previous_old_end = max_old_end
+        previous_new_end = max_new_end
+
+        for line_entry in line_changes.lines:
+            if line_entry.kind != " ":
+                new_entry = LineEntry(
+                    id=line_id_counter,
+                    kind=line_entry.kind,
+                    old_line_number=line_entry.old_line_number,
+                    new_line_number=line_entry.new_line_number,
+                    text_bytes=line_entry.text_bytes,
+                    source_line=line_entry.source_line,
+                    has_trailing_newline=line_entry.has_trailing_newline,
+                )
+                line_id_counter += 1
+            else:
+                new_entry = LineEntry(
+                    id=None,
+                    kind=line_entry.kind,
+                    old_line_number=line_entry.old_line_number,
+                    new_line_number=line_entry.new_line_number,
+                    text_bytes=line_entry.text_bytes,
+                    source_line=line_entry.source_line,
+                    has_trailing_newline=line_entry.has_trailing_newline,
+                )
+            all_line_entries.append(new_entry)
+
+    if not all_line_entries:
+        return None
+
+    combined_header = HunkHeader(
+        old_start=min_old_start,
+        old_len=max_old_end - min_old_start,
+        new_start=min_new_start,
+        new_len=max_new_end - min_new_start,
+    )
+
+    return LineLevelChange(
+        path=file_path,
+        header=combined_header,
+        lines=all_line_entries,
+    )

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -12,7 +12,7 @@ from typing import Generator, Mapping, Optional, Union
 
 from ..batch.attribution import build_file_attribution, filter_owned_diff_fragments
 from ..batch.display import annotate_with_batch_source
-from ..batch.query import get_batch_commit_sha, list_batch_names, read_batch_metadata
+from ..batch.query import list_batch_names, read_batch_metadata
 from ..core.hashing import (
     compute_binary_file_hash,
     compute_gitlink_change_hash,
@@ -77,7 +77,6 @@ from ..utils.file_io import (
     write_text_file_contents,
 )
 from ..utils.git import (
-    run_git_command,
     stream_git_command,
     stream_git_diff,
 )
@@ -95,6 +94,13 @@ from ..utils.paths import (
     get_working_tree_snapshot_file_path,
 )
 from .line_state import convert_line_changes_to_serializable_dict, load_line_changes_from_state
+from .batch_selected_changes import (
+    compute_batch_binary_fingerprint as compute_batch_binary_fingerprint,
+    require_current_selected_batch_binary_file_for_batch as require_current_selected_batch_binary_file_for_batch,
+    selected_batch_binary_batch_name as selected_batch_binary_batch_name,
+    selected_batch_binary_file_for_batch as selected_batch_binary_file_for_batch,
+    selected_batch_binary_matches_batch as selected_batch_binary_matches_batch,
+)
 from .selected_change.lifecycle import clear_selected_change_state_files as clear_selected_change_state_files
 from .selected_change.store import (
     SelectedChangeClearReason as SelectedChangeClearReason,
@@ -113,7 +119,6 @@ from .selected_change.store import (
     mark_selected_change_cleared_by_auto_advance_disabled,
     mark_selected_change_cleared_by_file_list as mark_selected_change_cleared_by_file_list,
     mark_selected_change_cleared_by_stale_batch_selection,
-    read_selected_binary_data as _read_selected_binary_data,
     read_selected_change_kind,
     read_selected_gitlink_data as _read_selected_gitlink_data,
     refuse_bare_action_after_auto_advance_disabled as refuse_bare_action_after_auto_advance_disabled,
@@ -150,124 +155,6 @@ def stream_live_git_diff(**kwargs):
     """Stream actionable live changes with rename detection enabled."""
     kwargs.setdefault("find_renames", True)
     return stream_git_diff(**kwargs)
-
-
-def compute_batch_binary_fingerprint(
-    batch_name: str,
-    file_path: str,
-    file_meta: Mapping[str, object],
-) -> str:
-    """Return a stable identity for the current binary content stored in a batch."""
-    batch_blob = None
-    if file_meta.get("change_type") != "deleted":
-        batch_commit = get_batch_commit_sha(batch_name)
-        if batch_commit is not None:
-            blob_result = run_git_command(
-                ["rev-parse", "--verify", f"{batch_commit}:{file_path}"],
-                check=False,
-                requires_index_lock=False,
-            )
-            if blob_result.returncode == 0:
-                batch_blob = blob_result.stdout.strip()
-
-    payload = {
-        "file_path": file_path,
-        "file_type": file_meta.get("file_type"),
-        "change_type": file_meta.get("change_type"),
-        "mode": file_meta.get("mode"),
-        "batch_source_commit": file_meta.get("batch_source_commit"),
-        "batch_blob": batch_blob,
-    }
-    data = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
-    return sha256(data.encode("utf-8", errors="surrogateescape")).hexdigest()
-
-
-def selected_batch_binary_matches_batch(batch_name: str) -> bool:
-    """Return whether the cached batch-binary selection came from this batch."""
-    if read_selected_change_kind() != SelectedChangeKind.BATCH_BINARY:
-        return False
-    binary_data = _read_selected_binary_data()
-    if binary_data is None:
-        return False
-    return binary_data.get("batch_name") == batch_name
-
-
-def selected_batch_binary_batch_name() -> str | None:
-    """Return the source batch name for the cached batch-binary selection."""
-    if read_selected_change_kind() != SelectedChangeKind.BATCH_BINARY:
-        return None
-    binary_data = _read_selected_binary_data()
-    if binary_data is None:
-        return None
-    batch_name = binary_data.get("batch_name")
-    return batch_name if isinstance(batch_name, str) else None
-
-
-def selected_batch_binary_file_for_batch(
-    batch_name: str,
-    all_files: Mapping[str, dict],
-) -> str | None:
-    """Return the selected batch-binary file if it still exists in batch metadata."""
-    if not selected_batch_binary_matches_batch(batch_name):
-        return None
-
-    binary_file = load_selected_binary_file()
-    if binary_file is None:
-        return None
-
-    file_path = binary_file.new_path if binary_file.new_path != "/dev/null" else binary_file.old_path
-    file_meta = all_files.get(file_path)
-    if file_meta is None:
-        return None
-    if file_meta.get("file_type") != "binary":
-        return None
-    if file_meta.get("change_type") != binary_file.change_type:
-        return None
-
-    binary_data = _read_selected_binary_data()
-    if binary_data is None:
-        return None
-    cached_fingerprint = binary_data.get("batch_binary_fingerprint")
-    if not isinstance(cached_fingerprint, str):
-        return None
-    current_fingerprint = compute_batch_binary_fingerprint(batch_name, file_path, file_meta)
-    if current_fingerprint != cached_fingerprint:
-        return None
-
-    return file_path
-
-
-def require_current_selected_batch_binary_file_for_batch(
-    batch_name: str,
-    all_files: Mapping[str, dict],
-) -> str | None:
-    """Return selected batch-binary file for this batch, or refuse if it went stale."""
-    if not selected_batch_binary_matches_batch(batch_name):
-        return None
-
-    selected_file = selected_batch_binary_file_for_batch(batch_name, all_files)
-    if selected_file is not None:
-        return selected_file
-
-    binary_file = load_selected_binary_file()
-    file_path = (
-        binary_file.new_path
-        if binary_file is not None and binary_file.new_path != "/dev/null" else
-        binary_file.old_path
-        if binary_file is not None else
-        "the selected batch binary"
-    )
-    clear_selected_change_state_files()
-    mark_selected_change_cleared_by_stale_batch_selection(
-        batch_name=batch_name,
-        file_path=file_path,
-    )
-    exit_with_error(
-        _(
-            "The selected batch binary no longer matches batch '{name}'.\n"
-            "Show the batch again before using a pathless batch action."
-        ).format(name=batch_name)
-    )
 
 
 def compute_batch_gitlink_fingerprint(

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -1,4 +1,4 @@
-"""Hunk navigation, state management, staleness detection, and progress tracking."""
+"""Hunk navigation, selected-state orchestration, and progress tracking."""
 
 from __future__ import annotations
 
@@ -152,8 +152,6 @@ _BATCH_MERGE_REVIEW_ACTIONS = (
 _BATCH_RESET_REVIEW_ACTION = "reset-from-batch"
 
 
-
-
 def load_selected_change() -> Optional[Union[LineLevelChange, BinaryFileChange, GitlinkChange, RenameChange, TextFileDeletionChange]]:
     """Load the currently cached selected change, if any."""
     selected_kind = read_selected_change_kind()
@@ -273,7 +271,6 @@ def apply_line_level_batch_filter_to_cached_hunk() -> bool:
     )
 
     return False
-
 
 
 def _filter_consumed_replacement_masks(
@@ -568,89 +565,6 @@ def render_file_as_single_hunk(file_path: str) -> Optional[LineLevelChange]:
             file_path,
             patches,
         )
-
-
-def render_binary_file_change(file_path: str) -> Optional[BinaryFileChange]:
-    """Render a binary file change for file-scoped display without caching state."""
-    auto_add_untracked_files([file_path])
-    try:
-        with acquire_unified_diff(
-            _live_diff.stream_live_git_diff(
-                base="HEAD",
-                full_index=True,
-                ignore_submodules="none",
-                submodule_format="short",
-                paths=[file_path],
-            )
-        ) as patches:
-            for item in patches:
-                if isinstance(item, BinaryFileChange):
-                    return item
-    except subprocess.CalledProcessError:
-        return None
-    return None
-
-
-def render_gitlink_change(file_path: str) -> Optional[GitlinkChange]:
-    """Render a gitlink change for file-scoped display without caching state."""
-    auto_add_untracked_files([file_path])
-    try:
-        with acquire_unified_diff(
-            _live_diff.stream_live_git_diff(
-                base="HEAD",
-                full_index=True,
-                ignore_submodules="none",
-                submodule_format="short",
-                paths=[file_path],
-            )
-        ) as patches:
-            for item in patches:
-                if isinstance(item, GitlinkChange):
-                    return item
-    except subprocess.CalledProcessError:
-        return None
-    return None
-
-
-def render_rename_change(file_path: str) -> Optional[RenameChange]:
-    """Render a rename change involving file_path without caching state."""
-    auto_add_untracked_files([file_path])
-    try:
-        with acquire_unified_diff(
-            _live_diff.stream_live_git_diff(
-                full_index=True,
-                ignore_submodules="none",
-                submodule_format="short",
-            )
-        ) as patches:
-            for item in patches:
-                if (
-                    isinstance(item, RenameChange)
-                    and file_path in (item.old_path, item.new_path)
-                ):
-                    return item
-    except subprocess.CalledProcessError:
-        return None
-    return None
-
-
-def render_text_deletion_change(file_path: str) -> Optional[TextFileDeletionChange]:
-    """Render a whole-text-file deletion for file-scoped display without caching state."""
-    try:
-        with acquire_unified_diff(
-            _live_diff.stream_live_git_diff(
-                full_index=True,
-                ignore_submodules="none",
-                submodule_format="short",
-                paths=[file_path],
-            )
-        ) as patches:
-            for item in patches:
-                if isinstance(item, TextFileDeletionChange):
-                    return item
-    except subprocess.CalledProcessError:
-        return None
-    return None
 
 
 def render_unstaged_file_as_single_hunk(file_path: str) -> Optional[LineLevelChange]:

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -6,11 +6,10 @@ import json
 import subprocess
 import sys
 from enum import Enum
-from typing import Generator, Optional, Union
+from typing import Optional, Union
 
 from ..batch.attribution import build_file_attribution, filter_owned_diff_fragments
 from ..batch.display import annotate_with_batch_source
-from ..batch.query import read_batch_metadata
 from ..core.hashing import (
     compute_binary_file_hash,
     compute_gitlink_change_hash,
@@ -24,7 +23,6 @@ from ..core.models import (
     LineLevelChange,
     LineEntry,
     RenameChange,
-    RenderedBatchDisplay,
     TextFileDeletionChange,
 )
 from ..core.diff_parser import (
@@ -44,7 +42,6 @@ from ..output import (
 )
 from .consumed_selections import read_consumed_file_metadata
 from .auto_advance import resolve_auto_advance
-from ..batch.file_display import render_batch_file_display as render_batch_file_display
 from . import change_freshness as _change_freshness
 from . import file_hunk_display as _file_hunk_display
 from . import live_diff as _live_diff
@@ -77,10 +74,8 @@ from ..utils.paths import (
     get_selected_hunk_hash_file_path,
     get_selected_hunk_patch_file_path,
     get_line_changes_json_file_path,
-    get_index_snapshot_file_path,
     get_processed_include_ids_file_path,
     get_processed_skip_ids_file_path,
-    get_working_tree_snapshot_file_path,
 )
 from .line_state import convert_line_changes_to_serializable_dict, load_line_changes_from_state
 from .batch_selected_changes import (
@@ -318,149 +313,6 @@ def _filter_consumed_replacement_masks(
         header=line_changes.header,
         lines=filtered_lines,
     )
-
-
-
-
-def cache_batch_as_single_hunk(
-    batch_name: str,
-    file_path: str | None = None,
-    metadata: dict | None = None,
-) -> Optional['RenderedBatchDisplay']:
-    """Load file from batch and cache it as a single hunk using batch source model.
-
-    Args:
-        batch_name: Name of the batch to load
-        file_path: Specific file to cache, or None for first file
-
-    Returns:
-        RenderedBatchDisplay with line changes and gutter ID translation, or None if batch is empty or file not found.
-        The gutter_to_selection_id mapping translates user-visible filtered gutter IDs (1, 2, 3...)
-        to original selection IDs for ownership selection commands.
-    """
-    # Read batch metadata
-    if metadata is None:
-        metadata = read_batch_metadata(batch_name)
-    files = metadata.get("files", {})
-
-    if not files:
-        return None
-
-    # Determine which file to use
-    if file_path is None:
-        # Default to first file (sorted order for consistency)
-        file_path = sorted(files.keys())[0]
-    elif file_path not in files:
-        # Requested file not in batch
-        raise CommandError(f"File '{file_path}' not found in batch '{batch_name}'")
-
-    # Use pure render helper (side-effect free)
-    rendered = render_batch_file_display(batch_name, file_path, metadata=metadata)
-    if rendered is None:
-        return None
-
-    cache_rendered_batch_file_display(file_path, rendered)
-    return rendered
-
-
-def cache_rendered_batch_file_display(
-    file_path: str,
-    rendered: 'RenderedBatchDisplay',
-) -> None:
-    """Cache an already rendered batch file as the selected hunk."""
-    line_changes = rendered.line_changes
-    line_entries = line_changes.lines
-    header = line_changes.header
-
-    # Compute counts for patch synthesis
-    addition_count = sum(1 for e in line_entries if e.kind == "+")
-    deletion_count = sum(1 for e in line_entries if e.kind == "-")
-
-    # Synthesize a patch for hashing and caching (preserving original bytes)
-    old_path = "/dev/null" if deletion_count == 0 and addition_count > 0 else f"a/{file_path}"
-    new_path = "/dev/null" if addition_count == 0 and deletion_count > 0 else f"b/{file_path}"
-
-    patch_lines = [
-        f"--- {old_path}\n".encode('utf-8'),
-        f"+++ {new_path}\n".encode('utf-8'),
-        f"@@ -{header.old_start},{header.old_len} +{header.new_start},{header.new_len} @@\n".encode('utf-8')
-    ]
-    for entry in line_entries:
-        patch_lines.append(entry.kind.encode('utf-8') + entry.text_bytes + b'\n')
-        if not entry.has_trailing_newline:
-            patch_lines.append(b"\\ No newline at end of file\n")
-
-    patch_hash = compute_stable_hunk_hash_from_lines(patch_lines)
-
-    # Cache the hunk bytes exactly; display strings are derived elsewhere.
-    write_selected_hunk_patch_lines(patch_lines)
-    write_text_file_contents(get_selected_hunk_hash_file_path(), patch_hash)
-    write_selected_change_kind(SelectedChangeKind.BATCH_FILE)
-
-    # Save LineLevelChange for line-level operations
-    write_text_file_contents(get_line_changes_json_file_path(),
-                            json.dumps(convert_line_changes_to_serializable_dict(line_changes),
-                                      ensure_ascii=False, indent=0))
-
-    # No snapshots for batch hunks (they don't track staleness)
-    get_index_snapshot_file_path().unlink(missing_ok=True)
-    get_working_tree_snapshot_file_path().unlink(missing_ok=True)
-
-
-def cache_batch_files_generator(
-    batch_name: str,
-    metadata: dict | None = None,
-) -> Generator['RenderedBatchDisplay', None, None]:
-    """Yield RenderedBatchDisplay for each file in batch.
-
-    Files are yielded in sorted order. Each file has line IDs
-    from original display IDs. Batch content comes from batch storage (not working tree).
-
-    Args:
-        batch_name: Name of the batch
-
-    Yields:
-        RenderedBatchDisplay for each file in batch with gutter ID translation.
-    """
-    # Read batch metadata
-    if metadata is None:
-        metadata = read_batch_metadata(batch_name)
-    files = sorted(metadata.get("files", {}).keys())
-
-    for file_path in files:
-        # Use pure render helper (side-effect free)
-        rendered = render_batch_file_display(batch_name, file_path, metadata=metadata)
-        if rendered is not None:
-            yield rendered
-
-
-def get_batch_file_for_line_operation(batch_name: str, file: str | None) -> str:
-    """Determine which file in batch to operate on.
-
-    Args:
-        batch_name: Name of batch
-        file: User-specified file path, or None for default
-
-    Returns:
-        File path to use
-
-    Raises:
-        CommandError: If batch empty or file not in batch
-    """
-    metadata = read_batch_metadata(batch_name)
-    files = sorted(metadata.get("files", {}).keys())
-
-    if not files:
-        raise CommandError(f"Batch '{batch_name}' is empty")
-
-    if file is None:
-        # Default to first file (sorted order)
-        return files[0]
-
-    if file not in files:
-        raise CommandError(f"File '{file}' not found in batch '{batch_name}'")
-
-    return file
 
 
 def fetch_next_change() -> Union[LineLevelChange, BinaryFileChange, GitlinkChange, RenameChange, TextFileDeletionChange]:

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -52,6 +52,7 @@ from ..output import (
 from .consumed_selections import read_consumed_file_metadata
 from .auto_advance import resolve_auto_advance
 from ..batch.file_display import render_batch_file_display as render_batch_file_display
+from . import live_diff as _live_diff
 from .file_tracking import auto_add_untracked_files
 from .progress import (
     format_id_range as format_id_range,
@@ -77,7 +78,6 @@ from ..utils.file_io import (
 )
 from ..utils.git import (
     stream_git_command,
-    stream_git_diff,
 )
 from ..utils.text import bytes_to_lines
 from ..utils.paths import (
@@ -151,11 +151,6 @@ _BATCH_MERGE_REVIEW_ACTIONS = (
 )
 _BATCH_RESET_REVIEW_ACTION = "reset-from-batch"
 
-
-def stream_live_git_diff(**kwargs):
-    """Stream actionable live changes with rename detection enabled."""
-    kwargs.setdefault("find_renames", True)
-    return stream_git_diff(**kwargs)
 
 
 def binary_file_change_is_stale(binary_change: BinaryFileChange) -> bool:
@@ -616,7 +611,7 @@ def render_file_as_single_hunk(file_path: str) -> Optional[LineLevelChange]:
     """Render all changes for a file as a single hunk without caching state."""
     auto_add_untracked_files([file_path])
     with acquire_unified_diff(
-        stream_live_git_diff(
+        _live_diff.stream_live_git_diff(
             base="HEAD",
             context_lines=get_context_lines(),
             full_index=True,
@@ -636,7 +631,7 @@ def render_binary_file_change(file_path: str) -> Optional[BinaryFileChange]:
     auto_add_untracked_files([file_path])
     try:
         with acquire_unified_diff(
-            stream_live_git_diff(
+            _live_diff.stream_live_git_diff(
                 base="HEAD",
                 full_index=True,
                 ignore_submodules="none",
@@ -657,7 +652,7 @@ def render_gitlink_change(file_path: str) -> Optional[GitlinkChange]:
     auto_add_untracked_files([file_path])
     try:
         with acquire_unified_diff(
-            stream_live_git_diff(
+            _live_diff.stream_live_git_diff(
                 base="HEAD",
                 full_index=True,
                 ignore_submodules="none",
@@ -678,7 +673,7 @@ def render_rename_change(file_path: str) -> Optional[RenameChange]:
     auto_add_untracked_files([file_path])
     try:
         with acquire_unified_diff(
-            stream_live_git_diff(
+            _live_diff.stream_live_git_diff(
                 full_index=True,
                 ignore_submodules="none",
                 submodule_format="short",
@@ -699,7 +694,7 @@ def render_text_deletion_change(file_path: str) -> Optional[TextFileDeletionChan
     """Render a whole-text-file deletion for file-scoped display without caching state."""
     try:
         with acquire_unified_diff(
-            stream_live_git_diff(
+            _live_diff.stream_live_git_diff(
                 full_index=True,
                 ignore_submodules="none",
                 submodule_format="short",
@@ -718,7 +713,7 @@ def render_unstaged_file_as_single_hunk(file_path: str) -> Optional[LineLevelCha
     """Render the remaining unstaged changes for a file as a single hunk."""
     auto_add_untracked_files([file_path])
     with acquire_unified_diff(
-        stream_live_git_diff(
+        _live_diff.stream_live_git_diff(
             context_lines=get_context_lines(),
             full_index=True,
             ignore_submodules="none",
@@ -928,7 +923,7 @@ def fetch_next_change() -> Union[LineLevelChange, BinaryFileChange, GitlinkChang
     # Stream git diff and parse incrementally - stops after first unblocked item found
     try:
         with acquire_unified_diff(
-            stream_live_git_diff(
+            _live_diff.stream_live_git_diff(
                 context_lines=get_context_lines(),
                 full_index=True,
                 ignore_submodules="none",
@@ -1230,7 +1225,7 @@ def recalculate_selected_hunk_for_file(
     # Stream git diff and parse incrementally - stops after first matching hunk found
     try:
         with acquire_unified_diff(
-            stream_live_git_diff(
+            _live_diff.stream_live_git_diff(
                 context_lines=get_context_lines(),
                 full_index=True,
                 ignore_submodules="none",

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import tempfile
 import subprocess
 import sys
 from enum import Enum
@@ -23,7 +22,6 @@ from ..core.models import (
     BinaryFileChange,
     GitlinkChange,
     LineLevelChange,
-    HunkHeader,
     LineEntry,
     RenameChange,
     RenderedBatchDisplay,
@@ -33,14 +31,10 @@ from ..core.diff_parser import (
     acquire_unified_diff,
     build_line_changes_from_patch_lines,
 )
-from ..editor import (
-    EditorBuffer,
-    load_git_object_as_buffer,
-)
 from ..core.line_selection import write_line_ids_file
 from ..core.line_identity import preserve_line_ids_from_previous_view
 from ..exceptions import CommandError, NoMoreHunks, exit_with_error
-from ..i18n import _, ngettext
+from ..i18n import _
 from ..output import (
     print_line_level_changes,
     print_binary_file_change,
@@ -54,7 +48,6 @@ from ..batch.file_display import render_batch_file_display as render_batch_file_
 from . import change_freshness as _change_freshness
 from . import file_hunk_display as _file_hunk_display
 from . import live_diff as _live_diff
-from .file_tracking import auto_add_untracked_files
 from .progress import (
     format_id_range as format_id_range,
     record_binary_hunk_skipped as record_binary_hunk_skipped,
@@ -77,10 +70,6 @@ from ..utils.file_io import (
     read_text_file_contents,
     write_text_file_contents,
 )
-from ..utils.git import (
-    stream_git_command,
-)
-from ..utils.text import bytes_to_lines
 from ..utils.paths import (
     get_block_list_file_path,
     get_blocked_files_file_path,
@@ -472,296 +461,6 @@ def get_batch_file_for_line_operation(batch_name: str, file: str | None) -> str:
         raise CommandError(f"File '{file}' not found in batch '{batch_name}'")
 
     return file
-
-
-def cache_file_as_single_hunk(file_path: str) -> Optional[LineLevelChange]:
-    """Cache all changes for a file as a single concatenated hunk.
-
-    Reads the CURRENT working tree state for the file and fetches ALL
-    hunks (ignoring blocklist/batches), concatenating them into one
-    LineLevelChange with continuous line IDs.
-
-    This always reflects the live working tree state, unlike regular
-    hunk caching which uses snapshots.
-
-    Args:
-        file_path: Repository-relative path to file
-
-    Returns:
-        LineLevelChange with all file changes, or None if no changes
-    """
-    try:
-        combined_line_changes = render_file_as_single_hunk(file_path)
-        return _cache_combined_file_line_changes(file_path, combined_line_changes)
-    except subprocess.CalledProcessError:
-        # Git diff failed (e.g., no changes in file)
-        return None
-
-
-def cache_unstaged_file_as_single_hunk(file_path: str) -> Optional[LineLevelChange]:
-    """Cache the remaining unstaged changes for a file as a single hunk."""
-    try:
-        combined_line_changes = render_unstaged_file_as_single_hunk(file_path)
-        return _cache_combined_file_line_changes(file_path, combined_line_changes)
-    except subprocess.CalledProcessError:
-        # Git diff failed (e.g., no changes in file)
-        return None
-
-
-def _cache_combined_file_line_changes(
-    file_path: str,
-    combined_line_changes: Optional[LineLevelChange],
-) -> Optional[LineLevelChange]:
-    """Persist a combined file-scoped view as the current selection."""
-    if combined_line_changes is None:
-        return None
-
-    # Synthesize patch bytes for caching (used for hashing/identity)
-    patch_lines = [
-        f"--- a/{file_path}\n".encode("utf-8"),
-        f"+++ b/{file_path}\n".encode("utf-8"),
-        (
-            f"@@ -{combined_line_changes.header.old_start},{combined_line_changes.header.old_len} "
-            f"+{combined_line_changes.header.new_start},{combined_line_changes.header.new_len} @@\n"
-        ).encode("utf-8"),
-    ]
-    for entry in combined_line_changes.lines:
-        patch_lines.append(entry.kind.encode("utf-8") + entry.text_bytes + b"\n")
-        if not entry.has_trailing_newline:
-            patch_lines.append(b"\\ No newline at end of file\n")
-
-    patch_hash = compute_stable_hunk_hash_from_lines(patch_lines)
-
-    # Cache the combined hunk
-    write_selected_hunk_patch_lines(patch_lines)
-    write_text_file_contents(get_selected_hunk_hash_file_path(), patch_hash)
-    write_selected_change_kind(SelectedChangeKind.FILE)
-    write_line_ids_file(get_processed_include_ids_file_path(), set())
-    write_line_ids_file(get_processed_skip_ids_file_path(), set())
-    write_text_file_contents(get_line_changes_json_file_path(),
-                            json.dumps(convert_line_changes_to_serializable_dict(combined_line_changes),
-                                      ensure_ascii=False, indent=0))
-
-    # Cache live snapshots so later line-level operations can reuse the
-    # file-scoped selection the same way they reuse ordinary selected hunks.
-    write_snapshots_for_selected_file_path(file_path)
-
-    return combined_line_changes
-
-
-def render_file_as_single_hunk(file_path: str) -> Optional[LineLevelChange]:
-    """Render all changes for a file as a single hunk without caching state."""
-    auto_add_untracked_files([file_path])
-    with acquire_unified_diff(
-        _live_diff.stream_live_git_diff(
-            base="HEAD",
-            context_lines=get_context_lines(),
-            full_index=True,
-            ignore_submodules="none",
-            submodule_format="short",
-            paths=[file_path],
-        )
-    ) as patches:
-        return _build_combined_file_line_changes(
-            file_path,
-            patches,
-        )
-
-
-def render_unstaged_file_as_single_hunk(file_path: str) -> Optional[LineLevelChange]:
-    """Render the remaining unstaged changes for a file as a single hunk."""
-    auto_add_untracked_files([file_path])
-    with acquire_unified_diff(
-        _live_diff.stream_live_git_diff(
-            context_lines=get_context_lines(),
-            full_index=True,
-            ignore_submodules="none",
-            submodule_format="short",
-            paths=[file_path],
-        )
-    ) as patches:
-        return _build_combined_file_line_changes(
-            file_path,
-            patches,
-        )
-
-
-def build_file_hunk_from_buffer(
-    file_path: str,
-    file_buffer: EditorBuffer,
-) -> Optional[LineLevelChange]:
-    """Build a file-scoped line view for a hypothetical file buffer without writing it."""
-    head_buffer = load_git_object_as_buffer(f"HEAD:{file_path}")
-
-    with tempfile.NamedTemporaryFile(delete=False) as old_tmp:
-        if head_buffer is not None:
-            with head_buffer:
-                for chunk in head_buffer.byte_chunks():
-                    old_tmp.write(chunk)
-        old_path = old_tmp.name
-    with tempfile.NamedTemporaryFile(delete=False) as new_tmp:
-        for chunk in file_buffer.byte_chunks():
-            new_tmp.write(chunk)
-        new_path = new_tmp.name
-
-    try:
-        with acquire_unified_diff(
-            _stream_no_index_diff_lines(
-                file_path=file_path,
-                old_path=old_path,
-                new_path=new_path,
-            )
-        ) as patches:
-            return _build_combined_file_line_changes(
-                file_path,
-                patches,
-            )
-    finally:
-        try:
-            import os
-            os.unlink(old_path)
-            os.unlink(new_path)
-        except OSError:
-            pass
-
-
-def _stream_no_index_diff_lines(
-    *,
-    file_path: str,
-    old_path: str,
-    new_path: str,
-) -> Generator[bytes, None, None]:
-    arguments = [
-        "diff",
-        "--no-index",
-        f"-U{get_context_lines()}",
-        "--no-color",
-        old_path,
-        new_path,
-    ]
-    stderr_chunks: list[bytes] = []
-    exit_code = 0
-
-    def stdout_chunks() -> Generator[bytes, None, None]:
-        nonlocal exit_code
-
-        try:
-            yield from stream_git_command(arguments, requires_index_lock=False)
-        except subprocess.CalledProcessError as error:
-            exit_code = error.returncode
-            stderr = error.stderr
-            if stderr is not None:
-                stderr_chunks.append(stderr.encode("utf-8", errors="replace"))
-
-    old_header = f"a{old_path}".encode("utf-8")
-    new_header = f"b{new_path}".encode("utf-8")
-    rendered_old_header = f"a/{file_path}".encode("utf-8")
-    rendered_new_header = f"b/{file_path}".encode("utf-8")
-
-    for line in bytes_to_lines(stdout_chunks()):
-        yield line.replace(old_header, rendered_old_header).replace(
-            new_header,
-            rendered_new_header,
-        )
-
-    if exit_code not in (0, 1):
-        stderr_text = b"".join(stderr_chunks).decode("utf-8", errors="replace")
-        raise subprocess.CalledProcessError(
-            exit_code,
-            arguments,
-            stderr=stderr_text,
-        )
-
-
-def _build_combined_file_line_changes(
-    file_path: str,
-    patches,
-) -> Optional[LineLevelChange]:
-    """Combine file diff hunks into one file-scoped LineLevelChange."""
-    all_line_entries = []
-    line_id_counter = 1
-    min_old_start = None
-    max_old_end = None
-    min_new_start = None
-    max_new_end = None
-    previous_old_end = None
-    previous_new_end = None
-
-    for single_hunk in patches:
-        if isinstance(single_hunk, (BinaryFileChange, GitlinkChange, RenameChange, TextFileDeletionChange)):
-            continue
-
-        line_changes = build_line_changes_from_patch_lines(single_hunk.lines)
-
-        if previous_old_end is not None and previous_new_end is not None:
-            omitted_old_lines = line_changes.header.old_start - previous_old_end
-            omitted_new_lines = line_changes.header.new_start - previous_new_end
-            omitted_line_count = max(omitted_old_lines, omitted_new_lines)
-            if omitted_line_count > 0:
-                gap_text = ngettext(
-                    "... {count} more line ...",
-                    "... {count} more lines ...",
-                    omitted_line_count,
-                ).format(count=omitted_line_count)
-                all_line_entries.append(
-                    LineEntry(
-                        id=None,
-                        kind=" ",
-                        old_line_number=None,
-                        new_line_number=None,
-                        text_bytes=gap_text.encode("utf-8"),
-                        source_line=None,
-                    )
-                )
-
-        if min_old_start is None:
-            min_old_start = line_changes.header.old_start
-            min_new_start = line_changes.header.new_start
-
-        max_old_end = line_changes.header.old_start + line_changes.header.old_len
-        max_new_end = line_changes.header.new_start + line_changes.header.new_len
-        previous_old_end = max_old_end
-        previous_new_end = max_new_end
-
-        for line_entry in line_changes.lines:
-            if line_entry.kind != " ":
-                new_entry = LineEntry(
-                    id=line_id_counter,
-                    kind=line_entry.kind,
-                    old_line_number=line_entry.old_line_number,
-                    new_line_number=line_entry.new_line_number,
-                    text_bytes=line_entry.text_bytes,
-                    source_line=line_entry.source_line,
-                    has_trailing_newline=line_entry.has_trailing_newline,
-                )
-                line_id_counter += 1
-            else:
-                new_entry = LineEntry(
-                    id=None,
-                    kind=line_entry.kind,
-                    old_line_number=line_entry.old_line_number,
-                    new_line_number=line_entry.new_line_number,
-                    text_bytes=line_entry.text_bytes,
-                    source_line=line_entry.source_line,
-                    has_trailing_newline=line_entry.has_trailing_newline,
-                )
-            all_line_entries.append(new_entry)
-
-    if not all_line_entries:
-        return None
-
-    combined_header = HunkHeader(
-        old_start=min_old_start,
-        old_len=max_old_end - min_old_start,
-        new_start=min_new_start,
-        new_len=max_new_end - min_new_start,
-    )
-
-    return LineLevelChange(
-        path=file_path,
-        header=combined_header,
-        lines=all_line_entries,
-    )
 
 
 def fetch_next_change() -> Union[LineLevelChange, BinaryFileChange, GitlinkChange, RenameChange, TextFileDeletionChange]:

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -45,17 +45,6 @@ from .auto_advance import resolve_auto_advance
 from . import change_freshness as _change_freshness
 from . import file_hunk_display as _file_hunk_display
 from . import live_diff as _live_diff
-from .progress import (
-    format_id_range as format_id_range,
-    record_binary_hunk_skipped as record_binary_hunk_skipped,
-    record_gitlink_hunk_skipped as record_gitlink_hunk_skipped,
-    record_hunk_discarded as record_hunk_discarded,
-    record_hunk_included as record_hunk_included,
-    record_hunk_skipped as record_hunk_skipped,
-    record_hunks_discarded as record_hunks_discarded,
-    record_rename_hunk_skipped as record_rename_hunk_skipped,
-    record_text_deletion_hunk_skipped as record_text_deletion_hunk_skipped,
-)
 from .selected_change.snapshots import (
     snapshots_are_stale as snapshots_are_stale,
     write_snapshots_for_selected_file_path,

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -52,6 +52,7 @@ from .consumed_selections import read_consumed_file_metadata
 from .auto_advance import resolve_auto_advance
 from ..batch.file_display import render_batch_file_display as render_batch_file_display
 from . import change_freshness as _change_freshness
+from . import file_hunk_display as _file_hunk_display
 from . import live_diff as _live_diff
 from .file_tracking import auto_add_untracked_files
 from .progress import (
@@ -1054,7 +1055,7 @@ def recalculate_selected_hunk_for_file(
     write_line_ids_file(get_processed_skip_ids_file_path(), set())
 
     if selected_kind == SelectedChangeKind.FILE:
-        line_changes = cache_unstaged_file_as_single_hunk(file_path)
+        line_changes = _file_hunk_display.cache_unstaged_file_as_single_hunk(file_path)
         if line_changes is None:
             clear_selected_change_state_files()
             if resolve_auto_advance(auto_advance):

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -7,8 +7,7 @@ import tempfile
 import subprocess
 import sys
 from enum import Enum
-from hashlib import sha256
-from typing import Generator, Mapping, Optional, Union
+from typing import Generator, Optional, Union
 
 from ..batch.attribution import build_file_attribution, filter_owned_diff_fragments
 from ..batch.display import annotate_with_batch_source
@@ -96,10 +95,14 @@ from ..utils.paths import (
 from .line_state import convert_line_changes_to_serializable_dict, load_line_changes_from_state
 from .batch_selected_changes import (
     compute_batch_binary_fingerprint as compute_batch_binary_fingerprint,
+    compute_batch_gitlink_fingerprint as compute_batch_gitlink_fingerprint,
     require_current_selected_batch_binary_file_for_batch as require_current_selected_batch_binary_file_for_batch,
+    require_current_selected_batch_gitlink_file_for_batch as require_current_selected_batch_gitlink_file_for_batch,
     selected_batch_binary_batch_name as selected_batch_binary_batch_name,
     selected_batch_binary_file_for_batch as selected_batch_binary_file_for_batch,
     selected_batch_binary_matches_batch as selected_batch_binary_matches_batch,
+    selected_batch_gitlink_file_for_batch as selected_batch_gitlink_file_for_batch,
+    selected_batch_gitlink_matches_batch as selected_batch_gitlink_matches_batch,
 )
 from .selected_change.lifecycle import clear_selected_change_state_files as clear_selected_change_state_files
 from .selected_change.store import (
@@ -118,9 +121,7 @@ from .selected_change.store import (
     load_selected_text_deletion_change,
     mark_selected_change_cleared_by_auto_advance_disabled,
     mark_selected_change_cleared_by_file_list as mark_selected_change_cleared_by_file_list,
-    mark_selected_change_cleared_by_stale_batch_selection,
     read_selected_change_kind,
-    read_selected_gitlink_data as _read_selected_gitlink_data,
     refuse_bare_action_after_auto_advance_disabled as refuse_bare_action_after_auto_advance_disabled,
     refuse_bare_action_after_file_list as refuse_bare_action_after_file_list,
     refuse_bare_action_after_stale_batch_selection as refuse_bare_action_after_stale_batch_selection,
@@ -155,98 +156,6 @@ def stream_live_git_diff(**kwargs):
     """Stream actionable live changes with rename detection enabled."""
     kwargs.setdefault("find_renames", True)
     return stream_git_diff(**kwargs)
-
-
-def compute_batch_gitlink_fingerprint(
-    file_path: str,
-    file_meta: Mapping[str, object],
-) -> str:
-    """Return a stable identity for the current stored submodule pointer."""
-    payload = {
-        "file_path": file_path,
-        "file_type": file_meta.get("file_type"),
-        "change_type": file_meta.get("change_type"),
-        "mode": file_meta.get("mode"),
-        "old_oid": file_meta.get("old_oid"),
-        "new_oid": file_meta.get("new_oid"),
-    }
-    data = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
-    return sha256(data.encode("utf-8", errors="surrogateescape")).hexdigest()
-
-
-def selected_batch_gitlink_matches_batch(batch_name: str) -> bool:
-    """Return whether the cached batch submodule pointer came from this batch."""
-    if read_selected_change_kind() != SelectedChangeKind.BATCH_GITLINK:
-        return False
-    gitlink_data = _read_selected_gitlink_data()
-    if gitlink_data is None:
-        return False
-    return gitlink_data.get("batch_name") == batch_name
-
-
-def selected_batch_gitlink_file_for_batch(
-    batch_name: str,
-    all_files: Mapping[str, dict],
-) -> str | None:
-    """Return the selected batch submodule pointer if it is still current."""
-    if not selected_batch_gitlink_matches_batch(batch_name):
-        return None
-
-    gitlink_change = load_selected_gitlink_change()
-    if gitlink_change is None:
-        return None
-
-    file_path = gitlink_change.path()
-    file_meta = all_files.get(file_path)
-    if file_meta is None:
-        return None
-    if file_meta.get("file_type") != "gitlink":
-        return None
-    if file_meta.get("change_type") != gitlink_change.change_type:
-        return None
-    if file_meta.get("old_oid") != gitlink_change.old_oid:
-        return None
-    if file_meta.get("new_oid") != gitlink_change.new_oid:
-        return None
-
-    gitlink_data = _read_selected_gitlink_data()
-    if gitlink_data is None:
-        return None
-    cached_fingerprint = gitlink_data.get("batch_gitlink_fingerprint")
-    if not isinstance(cached_fingerprint, str):
-        return None
-    current_fingerprint = compute_batch_gitlink_fingerprint(file_path, file_meta)
-    if current_fingerprint != cached_fingerprint:
-        return None
-
-    return file_path
-
-
-def require_current_selected_batch_gitlink_file_for_batch(
-    batch_name: str,
-    all_files: Mapping[str, dict],
-) -> str | None:
-    """Return selected batch submodule pointer, or refuse if it went stale."""
-    if not selected_batch_gitlink_matches_batch(batch_name):
-        return None
-
-    selected_file = selected_batch_gitlink_file_for_batch(batch_name, all_files)
-    if selected_file is not None:
-        return selected_file
-
-    gitlink_change = load_selected_gitlink_change()
-    file_path = gitlink_change.path() if gitlink_change is not None else "the selected batch submodule pointer"
-    clear_selected_change_state_files()
-    mark_selected_change_cleared_by_stale_batch_selection(
-        batch_name=batch_name,
-        file_path=file_path,
-    )
-    exit_with_error(
-        _(
-            "The selected batch submodule pointer no longer matches batch '{name}'.\n"
-            "Show the batch again before using a pathless batch action."
-        ).format(name=batch_name)
-    )
 
 
 def binary_file_change_is_stale(binary_change: BinaryFileChange) -> bool:

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -46,8 +46,8 @@ from . import change_freshness as _change_freshness
 from . import file_hunk_display as _file_hunk_display
 from . import live_diff as _live_diff
 from .selected_change.snapshots import (
-    snapshots_are_stale as snapshots_are_stale,
-    write_snapshots_for_selected_file_path,
+    snapshots_are_stale as _snapshots_are_stale,
+    write_snapshots_for_selected_file_path as _write_snapshots_for_selected_file_path,
 )
 from ..utils.file_io import (
     is_path_blocked,
@@ -78,7 +78,9 @@ from .batch_selected_changes import (
     selected_batch_gitlink_file_for_batch as selected_batch_gitlink_file_for_batch,
     selected_batch_gitlink_matches_batch as selected_batch_gitlink_matches_batch,
 )
-from .selected_change.lifecycle import clear_selected_change_state_files as clear_selected_change_state_files
+from .selected_change.lifecycle import (
+    clear_selected_change_state_files as _clear_selected_change_state_files,
+)
 from .selected_change.store import (
     SelectedChangeClearReason as SelectedChangeClearReason,
     SelectedChangeKind,
@@ -412,12 +414,12 @@ def fetch_next_change() -> Union[LineLevelChange, BinaryFileChange, GitlinkChang
                 write_text_file_contents(get_line_changes_json_file_path(),
                                          json.dumps(convert_line_changes_to_serializable_dict(line_changes),
                                                     ensure_ascii=False, indent=0))
-                write_snapshots_for_selected_file_path(line_changes.path)
+                _write_snapshots_for_selected_file_path(line_changes.path)
 
                 # Apply line-level batch filtering
                 if apply_line_level_batch_filter_to_cached_hunk():
                     # All lines were batched, skip this hunk and continue
-                    clear_selected_change_state_files()
+                    _clear_selected_change_state_files()
                     continue
 
                 # Return filtered hunk (or original if no filtering applied)
@@ -435,7 +437,7 @@ def advance_to_next_change() -> None:
 
     If no more hunks exist, clears state and returns silently.
     """
-    clear_selected_change_state_files()
+    _clear_selected_change_state_files()
     try:
         fetch_next_change()
     except NoMoreHunks:
@@ -544,7 +546,7 @@ def select_next_change_after_action(
         advance_to_next_change()
         return True
 
-    clear_selected_change_state_files()
+    _clear_selected_change_state_files()
     mark_selected_change_cleared_by_auto_advance_disabled()
     return False
 
@@ -567,8 +569,8 @@ def require_selected_hunk() -> None:
     if get_line_changes_json_file_path().exists():
         data = json.loads(read_text_file_contents(get_line_changes_json_file_path()))
         file_path = data["path"]
-        if snapshots_are_stale(file_path):
-            clear_selected_change_state_files()
+        if _snapshots_are_stale(file_path):
+            _clear_selected_change_state_files()
             exit_with_error(_("Cached hunk is stale (file was changed). Run 'start' or 'again' to continue."))
 
 
@@ -597,7 +599,7 @@ def recalculate_selected_hunk_for_file(
     if selected_kind == SelectedChangeKind.FILE:
         line_changes = _file_hunk_display.cache_unstaged_file_as_single_hunk(file_path)
         if line_changes is None:
-            clear_selected_change_state_files()
+            _clear_selected_change_state_files()
             if resolve_auto_advance(auto_advance):
                 return RecalculateSelectedHunkResult.SHOW_NEXT_CHANGE
             mark_selected_change_cleared_by_auto_advance_disabled()
@@ -610,7 +612,7 @@ def recalculate_selected_hunk_for_file(
         _write_line_changes_state(line_changes)
 
         if apply_line_level_batch_filter_to_cached_hunk():
-            clear_selected_change_state_files()
+            _clear_selected_change_state_files()
             if resolve_auto_advance(auto_advance):
                 return RecalculateSelectedHunkResult.SHOW_NEXT_CHANGE
             mark_selected_change_cleared_by_auto_advance_disabled()
@@ -698,12 +700,12 @@ def recalculate_selected_hunk_for_file(
                     line_changes,
                 )
                 _write_line_changes_state(line_changes)
-                write_snapshots_for_selected_file_path(line_changes.path)
+                _write_snapshots_for_selected_file_path(line_changes.path)
 
                 # Apply batch filter to exclude batched lines
                 if apply_line_level_batch_filter_to_cached_hunk():
                     # All lines were batched, clear the hunk
-                    clear_selected_change_state_files()
+                    _clear_selected_change_state_files()
                     print(_("No more lines in this hunk."), file=sys.stderr)
                     return RecalculateSelectedHunkResult.CLEARED
 
@@ -714,12 +716,12 @@ def recalculate_selected_hunk_for_file(
                 return RecalculateSelectedHunkResult.RECALCULATED
     except subprocess.CalledProcessError:
         # Git diff failed (e.g., no changes)
-        clear_selected_change_state_files()
+        _clear_selected_change_state_files()
         print(_("No pending hunks."), file=sys.stderr)
         return RecalculateSelectedHunkResult.CLEARED
 
     # No more hunks for this file, advance to next file
-    clear_selected_change_state_files()
+    _clear_selected_change_state_files()
     if resolve_auto_advance(auto_advance):
         return RecalculateSelectedHunkResult.SHOW_NEXT_CHANGE
     mark_selected_change_cleared_by_auto_advance_disabled()

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -67,17 +67,6 @@ from ..utils.paths import (
     get_processed_skip_ids_file_path,
 )
 from .line_state import convert_line_changes_to_serializable_dict, load_line_changes_from_state
-from .batch_selected_changes import (
-    compute_batch_binary_fingerprint as compute_batch_binary_fingerprint,
-    compute_batch_gitlink_fingerprint as compute_batch_gitlink_fingerprint,
-    require_current_selected_batch_binary_file_for_batch as require_current_selected_batch_binary_file_for_batch,
-    require_current_selected_batch_gitlink_file_for_batch as require_current_selected_batch_gitlink_file_for_batch,
-    selected_batch_binary_batch_name as selected_batch_binary_batch_name,
-    selected_batch_binary_file_for_batch as selected_batch_binary_file_for_batch,
-    selected_batch_binary_matches_batch as selected_batch_binary_matches_batch,
-    selected_batch_gitlink_file_for_batch as selected_batch_gitlink_file_for_batch,
-    selected_batch_gitlink_matches_batch as selected_batch_gitlink_matches_batch,
-)
 from .selected_change.lifecycle import (
     clear_selected_change_state_files as _clear_selected_change_state_files,
 )

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -11,7 +11,7 @@ from typing import Generator, Optional, Union
 
 from ..batch.attribution import build_file_attribution, filter_owned_diff_fragments
 from ..batch.display import annotate_with_batch_source
-from ..batch.query import list_batch_names, read_batch_metadata
+from ..batch.query import read_batch_metadata
 from ..core.hashing import (
     compute_binary_file_hash,
     compute_gitlink_change_hash,
@@ -29,7 +29,6 @@ from ..core.models import (
     RenderedBatchDisplay,
     TextFileDeletionChange,
 )
-from ..core.text_lifecycle import detect_empty_text_lifecycle_change
 from ..core.diff_parser import (
     acquire_unified_diff,
     build_line_changes_from_patch_lines,
@@ -52,6 +51,7 @@ from ..output import (
 from .consumed_selections import read_consumed_file_metadata
 from .auto_advance import resolve_auto_advance
 from ..batch.file_display import render_batch_file_display as render_batch_file_display
+from . import change_freshness as _change_freshness
 from . import live_diff as _live_diff
 from .file_tracking import auto_add_untracked_files
 from .progress import (
@@ -153,67 +153,16 @@ _BATCH_RESET_REVIEW_ACTION = "reset-from-batch"
 
 
 
-def binary_file_change_is_stale(binary_change: BinaryFileChange) -> bool:
-    """Return whether a cached binary selection no longer matches repository state."""
-    file_path = binary_change.new_path if binary_change.new_path != "/dev/null" else binary_change.old_path
-    if snapshots_are_stale(file_path):
-        return True
-    current_change = render_binary_file_change(file_path)
-    if current_change is None:
-        return True
-    return (
-        current_change.old_path != binary_change.old_path
-        or current_change.new_path != binary_change.new_path
-        or current_change.change_type != binary_change.change_type
-    )
-
-
-def gitlink_change_is_stale(gitlink_change: GitlinkChange) -> bool:
-    """Return whether a cached gitlink selection no longer matches Git state."""
-    current_change = render_gitlink_change(gitlink_change.path())
-    if current_change is None:
-        return True
-    return (
-        current_change.old_path != gitlink_change.old_path
-        or current_change.new_path != gitlink_change.new_path
-        or current_change.old_oid != gitlink_change.old_oid
-        or current_change.new_oid != gitlink_change.new_oid
-        or current_change.change_type != gitlink_change.change_type
-    )
-
-
-def rename_change_is_stale(rename_change: RenameChange) -> bool:
-    """Return whether a cached rename selection no longer matches Git state."""
-    current_change = render_rename_change(rename_change.new_path)
-    if current_change is None:
-        current_change = render_rename_change(rename_change.old_path)
-    if current_change is None:
-        return True
-    return (
-        current_change.old_path != rename_change.old_path
-        or current_change.new_path != rename_change.new_path
-    )
-
-
-def text_deletion_change_is_stale(deletion_change: TextFileDeletionChange) -> bool:
-    """Return whether a cached text deletion selection no longer matches Git state."""
-    if snapshots_are_stale(deletion_change.path()):
-        return True
-    current_change = render_text_deletion_change(deletion_change.path())
-    if current_change is None:
-        return True
-    return (
-        current_change.old_path != deletion_change.old_path
-        or current_change.new_path != deletion_change.new_path
-    )
-
 
 def load_selected_change() -> Optional[Union[LineLevelChange, BinaryFileChange, GitlinkChange, RenameChange, TextFileDeletionChange]]:
     """Load the currently cached selected change, if any."""
     selected_kind = read_selected_change_kind()
     rename_change = load_selected_rename_change()
     if rename_change is not None:
-        if selected_kind == SelectedChangeKind.RENAME and rename_change_is_stale(rename_change):
+        if (
+            selected_kind == SelectedChangeKind.RENAME
+            and _change_freshness.rename_change_is_stale(rename_change)
+        ):
             raise CommandError(
                 _(
                     "Selected rename no longer matches the working tree: {old} -> {new}.\n"
@@ -224,7 +173,10 @@ def load_selected_change() -> Optional[Union[LineLevelChange, BinaryFileChange, 
 
     deletion_change = load_selected_text_deletion_change()
     if deletion_change is not None:
-        if selected_kind == SelectedChangeKind.DELETION and text_deletion_change_is_stale(deletion_change):
+        if (
+            selected_kind == SelectedChangeKind.DELETION
+            and _change_freshness.text_deletion_change_is_stale(deletion_change)
+        ):
             raise CommandError(
                 _(
                     "Selected text file deletion no longer matches the working tree: {file}.\n"
@@ -235,7 +187,10 @@ def load_selected_change() -> Optional[Union[LineLevelChange, BinaryFileChange, 
 
     gitlink_change = load_selected_gitlink_change()
     if gitlink_change is not None:
-        if selected_kind == SelectedChangeKind.GITLINK and gitlink_change_is_stale(gitlink_change):
+        if (
+            selected_kind == SelectedChangeKind.GITLINK
+            and _change_freshness.gitlink_change_is_stale(gitlink_change)
+        ):
             raise CommandError(
                 _(
                     "Selected submodule pointer no longer matches the working tree: {file}.\n"
@@ -246,7 +201,10 @@ def load_selected_change() -> Optional[Union[LineLevelChange, BinaryFileChange, 
 
     binary_file = load_selected_binary_file()
     if binary_file is not None:
-        if selected_kind == SelectedChangeKind.BINARY and binary_file_change_is_stale(binary_file):
+        if (
+            selected_kind == SelectedChangeKind.BINARY
+            and _change_freshness.binary_file_change_is_stale(binary_file)
+        ):
             file_path = binary_file.new_path if binary_file.new_path != "/dev/null" else binary_file.old_path
             raise CommandError(
                 _(
@@ -286,7 +244,10 @@ def apply_line_level_batch_filter_to_cached_hunk() -> bool:
 
     file_path = line_changes.path
 
-    if not line_changes.lines and _empty_text_lifecycle_change_is_batched(file_path):
+    if (
+        not line_changes.lines
+        and _change_freshness.empty_text_lifecycle_change_is_batched(file_path)
+    ):
         return True
 
     # Step 1: Build file attribution (file-centric, not diff-centric)
@@ -313,23 +274,6 @@ def apply_line_level_batch_filter_to_cached_hunk() -> bool:
 
     return False
 
-
-def _empty_text_lifecycle_change_is_batched(file_path: str) -> bool:
-    """Return whether the current empty text lifecycle diff is already batched."""
-    change_type = detect_empty_text_lifecycle_change(file_path)
-    if change_type is None:
-        return False
-
-    for batch_name in list_batch_names():
-        file_meta = read_batch_metadata(batch_name).get("files", {}).get(file_path)
-        if file_meta is not None and file_meta.get("change_type") == change_type:
-            return True
-    return False
-
-
-def text_deletion_change_is_batched(deletion_change: TextFileDeletionChange) -> bool:
-    """Return whether a whole-text-file deletion is already represented in a batch."""
-    return _empty_text_lifecycle_change_is_batched(deletion_change.path())
 
 
 def _filter_consumed_replacement_masks(
@@ -947,7 +891,10 @@ def fetch_next_change() -> Union[LineLevelChange, BinaryFileChange, GitlinkChang
 
                 if isinstance(item, TextFileDeletionChange):
                     deletion_hash = compute_text_file_deletion_hash(item)
-                    if deletion_hash in blocked_hashes or text_deletion_change_is_batched(item):
+                    if (
+                        deletion_hash in blocked_hashes
+                        or _change_freshness.text_deletion_change_is_batched(item)
+                    ):
                         continue
 
                     if is_path_blocked(item.path(), blocked_files):
@@ -1246,7 +1193,12 @@ def recalculate_selected_hunk_for_file(
 
                 if isinstance(single_hunk, TextFileDeletionChange):
                     deletion_hash = compute_text_file_deletion_hash(single_hunk)
-                    if deletion_hash in blocked_hashes or text_deletion_change_is_batched(single_hunk):
+                    if (
+                        deletion_hash in blocked_hashes
+                        or _change_freshness.text_deletion_change_is_batched(
+                            single_hunk
+                        )
+                    ):
                         continue
                     cache_text_deletion_change(single_hunk)
                     print_text_file_deletion_change(single_hunk)

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -45,6 +45,7 @@ from .auto_advance import resolve_auto_advance
 from . import change_freshness as _change_freshness
 from . import file_hunk_display as _file_hunk_display
 from . import live_diff as _live_diff
+from .selected_change import store as _selected_store
 from .selected_change.snapshots import (
     snapshots_are_stale as _snapshots_are_stale,
     write_snapshots_for_selected_file_path as _write_snapshots_for_selected_file_path,
@@ -70,35 +71,6 @@ from .line_state import convert_line_changes_to_serializable_dict, load_line_cha
 from .selected_change.lifecycle import (
     clear_selected_change_state_files as _clear_selected_change_state_files,
 )
-from .selected_change.store import (
-    SelectedChangeClearReason as SelectedChangeClearReason,
-    SelectedChangeKind,
-    SelectedChangeStateSnapshot as SelectedChangeStateSnapshot,
-    cache_binary_file_change,
-    cache_gitlink_change,
-    cache_rename_change,
-    cache_text_deletion_change,
-    get_selected_change_file_path as get_selected_change_file_path,
-    load_line_changes_from_patch_path as _load_line_changes_from_patch_path,
-    load_selected_binary_file,
-    load_selected_gitlink_change,
-    load_selected_rename_change,
-    load_selected_text_deletion_change,
-    mark_selected_change_cleared_by_auto_advance_disabled,
-    mark_selected_change_cleared_by_file_list as mark_selected_change_cleared_by_file_list,
-    read_selected_change_kind,
-    refuse_bare_action_after_auto_advance_disabled as refuse_bare_action_after_auto_advance_disabled,
-    refuse_bare_action_after_file_list as refuse_bare_action_after_file_list,
-    refuse_bare_action_after_stale_batch_selection as refuse_bare_action_after_stale_batch_selection,
-    restore_selected_change_state as restore_selected_change_state,
-    selected_change_was_cleared_by_auto_advance_disabled as selected_change_was_cleared_by_auto_advance_disabled,
-    selected_change_was_cleared_by_file_list as selected_change_was_cleared_by_file_list,
-    selected_change_was_cleared_by_stale_batch_selection as selected_change_was_cleared_by_stale_batch_selection,
-    snapshot_selected_change_state as snapshot_selected_change_state,
-    write_line_changes_state as _write_line_changes_state,
-    write_selected_change_kind,
-    write_selected_hunk_patch_lines,
-)
 
 
 class RecalculateSelectedHunkResult(str, Enum):
@@ -119,11 +91,11 @@ _BATCH_RESET_REVIEW_ACTION = "reset-from-batch"
 
 def load_selected_change() -> Optional[Union[LineLevelChange, BinaryFileChange, GitlinkChange, RenameChange, TextFileDeletionChange]]:
     """Load the currently cached selected change, if any."""
-    selected_kind = read_selected_change_kind()
-    rename_change = load_selected_rename_change()
+    selected_kind = _selected_store.read_selected_change_kind()
+    rename_change = _selected_store.load_selected_rename_change()
     if rename_change is not None:
         if (
-            selected_kind == SelectedChangeKind.RENAME
+            selected_kind == _selected_store.SelectedChangeKind.RENAME
             and _change_freshness.rename_change_is_stale(rename_change)
         ):
             raise CommandError(
@@ -134,10 +106,10 @@ def load_selected_change() -> Optional[Union[LineLevelChange, BinaryFileChange, 
             )
         return rename_change
 
-    deletion_change = load_selected_text_deletion_change()
+    deletion_change = _selected_store.load_selected_text_deletion_change()
     if deletion_change is not None:
         if (
-            selected_kind == SelectedChangeKind.DELETION
+            selected_kind == _selected_store.SelectedChangeKind.DELETION
             and _change_freshness.text_deletion_change_is_stale(deletion_change)
         ):
             raise CommandError(
@@ -148,10 +120,10 @@ def load_selected_change() -> Optional[Union[LineLevelChange, BinaryFileChange, 
             )
         return deletion_change
 
-    gitlink_change = load_selected_gitlink_change()
+    gitlink_change = _selected_store.load_selected_gitlink_change()
     if gitlink_change is not None:
         if (
-            selected_kind == SelectedChangeKind.GITLINK
+            selected_kind == _selected_store.SelectedChangeKind.GITLINK
             and _change_freshness.gitlink_change_is_stale(gitlink_change)
         ):
             raise CommandError(
@@ -162,10 +134,10 @@ def load_selected_change() -> Optional[Union[LineLevelChange, BinaryFileChange, 
             )
         return gitlink_change
 
-    binary_file = load_selected_binary_file()
+    binary_file = _selected_store.load_selected_binary_file()
     if binary_file is not None:
         if (
-            selected_kind == SelectedChangeKind.BINARY
+            selected_kind == _selected_store.SelectedChangeKind.BINARY
             and _change_freshness.binary_file_change_is_stale(binary_file)
         ):
             file_path = binary_file.new_path if binary_file.new_path != "/dev/null" else binary_file.old_path
@@ -187,7 +159,7 @@ def load_selected_change() -> Optional[Union[LineLevelChange, BinaryFileChange, 
     if line_changes is not None:
         return line_changes
 
-    return _load_line_changes_from_patch_path(patch_path)
+    return _selected_store.load_line_changes_from_patch_path(patch_path)
 
 
 def apply_line_level_batch_filter_to_cached_hunk() -> bool:
@@ -332,7 +304,7 @@ def fetch_next_change() -> Union[LineLevelChange, BinaryFileChange, GitlinkChang
                     ):
                         continue
 
-                    cache_rename_change(item)
+                    _selected_store.cache_rename_change(item)
                     return item
 
                 if isinstance(item, TextFileDeletionChange):
@@ -346,7 +318,7 @@ def fetch_next_change() -> Union[LineLevelChange, BinaryFileChange, GitlinkChang
                     if is_path_blocked(item.path(), blocked_files):
                         continue
 
-                    cache_text_deletion_change(item)
+                    _selected_store.cache_text_deletion_change(item)
                     return item
 
                 if isinstance(item, GitlinkChange):
@@ -357,7 +329,7 @@ def fetch_next_change() -> Union[LineLevelChange, BinaryFileChange, GitlinkChang
                     if is_path_blocked(item.path(), blocked_files):
                         continue
 
-                    cache_gitlink_change(item)
+                    _selected_store.cache_gitlink_change(item)
                     return item
 
                 # Handle binary files
@@ -371,7 +343,7 @@ def fetch_next_change() -> Union[LineLevelChange, BinaryFileChange, GitlinkChang
                     if is_path_blocked(file_path, blocked_files):
                         continue
 
-                    cache_binary_file_change(item)
+                    _selected_store.cache_binary_file_change(item)
 
                     # Return the BinaryFileChange object directly
                     return item
@@ -396,9 +368,11 @@ def fetch_next_change() -> Union[LineLevelChange, BinaryFileChange, GitlinkChang
                 if is_path_blocked(line_changes.path, blocked_files):
                     continue
 
-                write_selected_hunk_patch_lines(item.lines)
+                _selected_store.write_selected_hunk_patch_lines(item.lines)
                 write_text_file_contents(get_selected_hunk_hash_file_path(), hunk_hash)
-                write_selected_change_kind(SelectedChangeKind.HUNK)
+                _selected_store.write_selected_change_kind(
+                    _selected_store.SelectedChangeKind.HUNK
+                )
 
                 write_text_file_contents(get_line_changes_json_file_path(),
                                          json.dumps(convert_line_changes_to_serializable_dict(line_changes),
@@ -440,23 +414,23 @@ def show_selected_change() -> None:
     This is a helper for commands that need to display the cached hunk
     without advancing (e.g., start, again).
     """
-    rename_change = load_selected_rename_change()
+    rename_change = _selected_store.load_selected_rename_change()
     if rename_change is not None:
         print_rename_change(rename_change)
         return
 
-    deletion_change = load_selected_text_deletion_change()
+    deletion_change = _selected_store.load_selected_text_deletion_change()
     if deletion_change is not None:
         print_text_file_deletion_change(deletion_change)
         return
 
-    gitlink_change = load_selected_gitlink_change()
+    gitlink_change = _selected_store.load_selected_gitlink_change()
     if gitlink_change is not None:
         print_gitlink_change(gitlink_change)
         return
 
     # Check if selected item is a binary file
-    binary_file = load_selected_binary_file()
+    binary_file = _selected_store.load_selected_binary_file()
     if binary_file is not None:
         print_binary_file_change(binary_file)
         return
@@ -464,7 +438,9 @@ def show_selected_change() -> None:
     # Otherwise, show text hunk
     patch_path = get_selected_hunk_patch_file_path()
     if patch_path.exists():
-        line_changes = _load_line_changes_from_patch_path(patch_path)
+        line_changes = _selected_store.load_line_changes_from_patch_path(
+            patch_path
+        )
         print_line_level_changes(line_changes)
 
 
@@ -477,23 +453,23 @@ def advance_to_and_show_next_change() -> None:
     """
     advance_to_next_change()
 
-    rename_change = load_selected_rename_change()
+    rename_change = _selected_store.load_selected_rename_change()
     if rename_change is not None:
         print_rename_change(rename_change)
         return
 
-    deletion_change = load_selected_text_deletion_change()
+    deletion_change = _selected_store.load_selected_text_deletion_change()
     if deletion_change is not None:
         print_text_file_deletion_change(deletion_change)
         return
 
-    gitlink_change = load_selected_gitlink_change()
+    gitlink_change = _selected_store.load_selected_gitlink_change()
     if gitlink_change is not None:
         print_gitlink_change(gitlink_change)
         return
 
     # Check if a binary file was cached
-    binary_file = load_selected_binary_file()
+    binary_file = _selected_store.load_selected_binary_file()
     if binary_file is not None:
         print_binary_file_change(binary_file)
         return
@@ -501,7 +477,9 @@ def advance_to_and_show_next_change() -> None:
     # Check if a text hunk was cached
     patch_path = get_selected_hunk_patch_file_path()
     if patch_path.exists():
-        line_changes = _load_line_changes_from_patch_path(patch_path)
+        line_changes = _selected_store.load_line_changes_from_patch_path(
+            patch_path
+        )
         print_line_level_changes(line_changes)
     else:
         print(_("No more hunks to process."), file=sys.stderr)
@@ -519,7 +497,7 @@ def finish_selected_change_action(
     if quiet:
         return
 
-    if read_selected_change_kind() is None:
+    if _selected_store.read_selected_change_kind() is None:
         print(_("No more hunks to process."), file=sys.stderr)
         return
 
@@ -536,7 +514,7 @@ def select_next_change_after_action(
         return True
 
     _clear_selected_change_state_files()
-    mark_selected_change_cleared_by_auto_advance_disabled()
+    _selected_store.mark_selected_change_cleared_by_auto_advance_disabled()
     return False
 
 
@@ -544,7 +522,10 @@ def select_next_change_after_action(
 
 def require_selected_hunk() -> None:
     """Ensure selected hunk exists and is not stale, exit with error otherwise."""
-    if read_selected_change_kind() in (SelectedChangeKind.BATCH_FILE, SelectedChangeKind.BATCH_BINARY):
+    if _selected_store.read_selected_change_kind() in (
+        _selected_store.SelectedChangeKind.BATCH_FILE,
+        _selected_store.SelectedChangeKind.BATCH_BINARY,
+    ):
         exit_with_error(
             _(
                 "Selected file came from a batch, not a live hunk. "
@@ -576,7 +557,7 @@ def recalculate_selected_hunk_for_file(
     Args:
         file_path: Repository-relative path to recalculate hunk for
     """
-    selected_kind = read_selected_change_kind()
+    selected_kind = _selected_store.read_selected_change_kind()
     previous_line_changes = load_line_changes_from_state()
     if previous_line_changes is not None and previous_line_changes.path != file_path:
         previous_line_changes = None
@@ -585,26 +566,26 @@ def recalculate_selected_hunk_for_file(
     write_line_ids_file(get_processed_include_ids_file_path(), set())
     write_line_ids_file(get_processed_skip_ids_file_path(), set())
 
-    if selected_kind == SelectedChangeKind.FILE:
+    if selected_kind == _selected_store.SelectedChangeKind.FILE:
         line_changes = _file_hunk_display.cache_unstaged_file_as_single_hunk(file_path)
         if line_changes is None:
             _clear_selected_change_state_files()
             if resolve_auto_advance(auto_advance):
                 return RecalculateSelectedHunkResult.SHOW_NEXT_CHANGE
-            mark_selected_change_cleared_by_auto_advance_disabled()
+            _selected_store.mark_selected_change_cleared_by_auto_advance_disabled()
             return RecalculateSelectedHunkResult.CLEARED
 
         line_changes = preserve_line_ids_from_previous_view(
             previous_line_changes,
             line_changes,
         )
-        _write_line_changes_state(line_changes)
+        _selected_store.write_line_changes_state(line_changes)
 
         if apply_line_level_batch_filter_to_cached_hunk():
             _clear_selected_change_state_files()
             if resolve_auto_advance(auto_advance):
                 return RecalculateSelectedHunkResult.SHOW_NEXT_CHANGE
-            mark_selected_change_cleared_by_auto_advance_disabled()
+            _selected_store.mark_selected_change_cleared_by_auto_advance_disabled()
             return RecalculateSelectedHunkResult.CLEARED
 
         line_changes = load_line_changes_from_state()
@@ -633,7 +614,7 @@ def recalculate_selected_hunk_for_file(
                     rename_hash = compute_rename_change_hash(single_hunk)
                     if rename_hash in blocked_hashes:
                         continue
-                    cache_rename_change(single_hunk)
+                    _selected_store.cache_rename_change(single_hunk)
                     print_rename_change(single_hunk)
                     return RecalculateSelectedHunkResult.RECALCULATED
 
@@ -646,7 +627,7 @@ def recalculate_selected_hunk_for_file(
                         )
                     ):
                         continue
-                    cache_text_deletion_change(single_hunk)
+                    _selected_store.cache_text_deletion_change(single_hunk)
                     print_text_file_deletion_change(single_hunk)
                     return RecalculateSelectedHunkResult.RECALCULATED
 
@@ -654,7 +635,7 @@ def recalculate_selected_hunk_for_file(
                     gitlink_hash = compute_gitlink_change_hash(single_hunk)
                     if gitlink_hash in blocked_hashes:
                         continue
-                    cache_gitlink_change(single_hunk)
+                    _selected_store.cache_gitlink_change(single_hunk)
                     print_gitlink_change(single_hunk)
                     return RecalculateSelectedHunkResult.RECALCULATED
 
@@ -676,9 +657,11 @@ def recalculate_selected_hunk_for_file(
                 if hunk_hash in blocked_hashes:
                     continue
 
-                write_selected_hunk_patch_lines(single_hunk.lines)
+                _selected_store.write_selected_hunk_patch_lines(single_hunk.lines)
                 write_text_file_contents(get_selected_hunk_hash_file_path(), hunk_hash)
-                write_selected_change_kind(SelectedChangeKind.HUNK)
+                _selected_store.write_selected_change_kind(
+                    _selected_store.SelectedChangeKind.HUNK
+                )
 
                 line_changes = build_line_changes_from_patch_lines(
                     single_hunk.lines,
@@ -688,7 +671,7 @@ def recalculate_selected_hunk_for_file(
                     previous_line_changes,
                     line_changes,
                 )
-                _write_line_changes_state(line_changes)
+                _selected_store.write_line_changes_state(line_changes)
                 _write_snapshots_for_selected_file_path(line_changes.path)
 
                 # Apply batch filter to exclude batched lines
@@ -713,5 +696,5 @@ def recalculate_selected_hunk_for_file(
     _clear_selected_change_state_files()
     if resolve_auto_advance(auto_advance):
         return RecalculateSelectedHunkResult.SHOW_NEXT_CHANGE
-    mark_selected_change_cleared_by_auto_advance_disabled()
+    _selected_store.mark_selected_change_cleared_by_auto_advance_disabled()
     return RecalculateSelectedHunkResult.CLEARED

--- a/src/git_stage_batch/data/live_diff.py
+++ b/src/git_stage_batch/data/live_diff.py
@@ -1,0 +1,11 @@
+"""Live working-tree diff streams."""
+
+from __future__ import annotations
+
+from ..utils.git import stream_git_diff
+
+
+def stream_live_git_diff(**kwargs):
+    """Stream actionable live changes with rename detection enabled."""
+    kwargs.setdefault("find_renames", True)
+    return stream_git_diff(**kwargs)

--- a/src/git_stage_batch/data/selected_change/batch_file_cache.py
+++ b/src/git_stage_batch/data/selected_change/batch_file_cache.py
@@ -1,0 +1,106 @@
+"""Selected-change caching for rendered batch file views."""
+
+from __future__ import annotations
+
+import json
+from typing import Optional
+
+from ...batch.query import read_batch_metadata
+from ...core.hashing import compute_stable_hunk_hash_from_lines
+from ...core.models import RenderedBatchDisplay
+from ...exceptions import CommandError
+from ...utils.file_io import write_text_file_contents
+from ...utils.paths import (
+    get_index_snapshot_file_path,
+    get_line_changes_json_file_path,
+    get_selected_hunk_hash_file_path,
+    get_working_tree_snapshot_file_path,
+)
+from ...batch.file_display import render_batch_file_display
+from ..line_state import convert_line_changes_to_serializable_dict
+from .store import (
+    SelectedChangeKind,
+    write_selected_change_kind,
+    write_selected_hunk_patch_lines,
+)
+
+
+def cache_batch_as_single_hunk(
+    batch_name: str,
+    file_path: str | None = None,
+    metadata: dict | None = None,
+) -> Optional[RenderedBatchDisplay]:
+    """Load one batch file and cache it as the selected hunk."""
+    if metadata is None:
+        metadata = read_batch_metadata(batch_name)
+    files = metadata.get("files", {})
+
+    if not files:
+        return None
+
+    if file_path is None:
+        file_path = sorted(files.keys())[0]
+    elif file_path not in files:
+        raise CommandError(f"File '{file_path}' not found in batch '{batch_name}'")
+
+    rendered = render_batch_file_display(batch_name, file_path, metadata=metadata)
+    if rendered is None:
+        return None
+
+    cache_rendered_batch_file_display(file_path, rendered)
+    return rendered
+
+
+def cache_rendered_batch_file_display(
+    file_path: str,
+    rendered: RenderedBatchDisplay,
+) -> None:
+    """Cache an already rendered batch file as the selected hunk."""
+    line_changes = rendered.line_changes
+    line_entries = line_changes.lines
+    header = line_changes.header
+
+    addition_count = sum(1 for entry in line_entries if entry.kind == "+")
+    deletion_count = sum(1 for entry in line_entries if entry.kind == "-")
+
+    old_path = (
+        "/dev/null"
+        if deletion_count == 0 and addition_count > 0
+        else f"a/{file_path}"
+    )
+    new_path = (
+        "/dev/null"
+        if addition_count == 0 and deletion_count > 0
+        else f"b/{file_path}"
+    )
+
+    patch_lines = [
+        f"--- {old_path}\n".encode("utf-8"),
+        f"+++ {new_path}\n".encode("utf-8"),
+        (
+            f"@@ -{header.old_start},{header.old_len} "
+            f"+{header.new_start},{header.new_len} @@\n"
+        ).encode("utf-8"),
+    ]
+    for entry in line_entries:
+        patch_lines.append(entry.kind.encode("utf-8") + entry.text_bytes + b"\n")
+        if not entry.has_trailing_newline:
+            patch_lines.append(b"\\ No newline at end of file\n")
+
+    patch_hash = compute_stable_hunk_hash_from_lines(patch_lines)
+
+    write_selected_hunk_patch_lines(patch_lines)
+    write_text_file_contents(get_selected_hunk_hash_file_path(), patch_hash)
+    write_selected_change_kind(SelectedChangeKind.BATCH_FILE)
+
+    write_text_file_contents(
+        get_line_changes_json_file_path(),
+        json.dumps(
+            convert_line_changes_to_serializable_dict(line_changes),
+            ensure_ascii=False,
+            indent=0,
+        ),
+    )
+
+    get_index_snapshot_file_path().unlink(missing_ok=True)
+    get_working_tree_snapshot_file_path().unlink(missing_ok=True)

--- a/src/git_stage_batch/tui/interactive.py
+++ b/src/git_stage_batch/tui/interactive.py
@@ -10,9 +10,8 @@ from typing import Callable
 from ..batch import query as batch_query
 from ..data.selected_change.batch_file_cache import cache_batch_as_single_hunk
 from ..data.file_tracking import auto_add_untracked_files
-from ..data.hunk_tracking import format_id_range
 from ..data.hunk_tracking import fetch_next_change
-from ..data.progress import get_hunk_counts
+from ..data.progress import format_id_range, get_hunk_counts
 from ..data.line_state import load_line_changes_from_state
 from ..exceptions import BypassRefresh, CommandError, QuitInteractive
 from ..i18n import _

--- a/src/git_stage_batch/tui/interactive.py
+++ b/src/git_stage_batch/tui/interactive.py
@@ -8,8 +8,9 @@ import sys
 from dataclasses import dataclass
 from typing import Callable
 from ..batch import query as batch_query
+from ..data.selected_change.batch_file_cache import cache_batch_as_single_hunk
 from ..data.file_tracking import auto_add_untracked_files
-from ..data.hunk_tracking import cache_batch_as_single_hunk, format_id_range
+from ..data.hunk_tracking import format_id_range
 from ..data.hunk_tracking import fetch_next_change
 from ..data.progress import get_hunk_counts
 from ..data.line_state import load_line_changes_from_state

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -188,6 +188,17 @@ def test_file_change_display_does_not_import_hunk_navigation():
     assert "git_stage_batch.data.hunk_tracking" not in imported_modules
 
 
+def test_file_hunk_display_does_not_import_hunk_navigation():
+    """File-scoped text rendering should not depend on hunk navigation."""
+    display_path = SRC_ROOT / "data" / "file_hunk_display.py"
+    imported_modules = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(display_path)
+    }
+
+    assert "git_stage_batch.data.hunk_tracking" not in imported_modules
+
+
 def test_change_freshness_does_not_import_hunk_navigation():
     """Cached change freshness checks should not depend on hunk navigation."""
     freshness_path = SRC_ROOT / "data" / "change_freshness.py"

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -188,6 +188,17 @@ def test_file_change_display_does_not_import_hunk_navigation():
     assert "git_stage_batch.data.hunk_tracking" not in imported_modules
 
 
+def test_change_freshness_does_not_import_hunk_navigation():
+    """Cached change freshness checks should not depend on hunk navigation."""
+    freshness_path = SRC_ROOT / "data" / "change_freshness.py"
+    imported_modules = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(freshness_path)
+    }
+
+    assert "git_stage_batch.data.hunk_tracking" not in imported_modules
+
+
 def test_recalc_handoff_stays_in_command_helper():
     """Include and discard commands should use the command refresh handoff."""
     command_paths = (

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -177,6 +177,17 @@ def test_selected_change_lifecycle_does_not_import_hunk_navigation():
     assert "git_stage_batch.data.hunk_tracking" not in imported_modules
 
 
+def test_file_change_display_does_not_import_hunk_navigation():
+    """Live file-change rendering should not depend on hunk navigation."""
+    display_path = SRC_ROOT / "data" / "file_change_display.py"
+    imported_modules = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(display_path)
+    }
+
+    assert "git_stage_batch.data.hunk_tracking" not in imported_modules
+
+
 def test_recalc_handoff_stays_in_command_helper():
     """Include and discard commands should use the command refresh handoff."""
     command_paths = (

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -199,6 +199,17 @@ def test_change_freshness_does_not_import_hunk_navigation():
     assert "git_stage_batch.data.hunk_tracking" not in imported_modules
 
 
+def test_status_does_not_import_hunk_navigation():
+    """Status should read focused data helpers instead of hunk navigation."""
+    status_path = SRC_ROOT / "commands" / "status.py"
+    imported_modules = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(status_path)
+    }
+
+    assert "git_stage_batch.data.hunk_tracking" not in imported_modules
+
+
 def test_recalc_handoff_stays_in_command_helper():
     """Include and discard commands should use the command refresh handoff."""
     command_paths = (

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -324,6 +324,27 @@ def test_hunk_tracking_does_not_reexport_selected_state_helpers():
     assert selected_state_names.isdisjoint(vars(hunk_tracking))
 
 
+def test_hunk_tracking_does_not_reexport_batch_selection_helpers():
+    """Batch selection helpers should not stay on hunk tracking."""
+    hunk_tracking = __import__(
+        "git_stage_batch.data.hunk_tracking",
+        fromlist=["hunk_tracking"],
+    )
+    batch_selection_names = {
+        "compute_batch_binary_fingerprint",
+        "compute_batch_gitlink_fingerprint",
+        "require_current_selected_batch_binary_file_for_batch",
+        "require_current_selected_batch_gitlink_file_for_batch",
+        "selected_batch_binary_batch_name",
+        "selected_batch_binary_file_for_batch",
+        "selected_batch_binary_matches_batch",
+        "selected_batch_gitlink_file_for_batch",
+        "selected_batch_gitlink_matches_batch",
+    }
+
+    assert batch_selection_names.isdisjoint(vars(hunk_tracking))
+
+
 def test_recalc_handoff_stays_in_command_helper():
     """Include and discard commands should use the command refresh handoff."""
     command_paths = (

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -309,6 +309,21 @@ def test_hunk_tracking_does_not_reexport_progress_helpers():
     assert progress_names.isdisjoint(vars(hunk_tracking))
 
 
+def test_hunk_tracking_does_not_reexport_selected_state_helpers():
+    """Selected-state helpers should not stay on hunk tracking."""
+    hunk_tracking = __import__(
+        "git_stage_batch.data.hunk_tracking",
+        fromlist=["hunk_tracking"],
+    )
+    selected_state_names = {
+        "clear_selected_change_state_files",
+        "snapshots_are_stale",
+        "write_snapshots_for_selected_file_path",
+    }
+
+    assert selected_state_names.isdisjoint(vars(hunk_tracking))
+
+
 def test_recalc_handoff_stays_in_command_helper():
     """Include and discard commands should use the command refresh handoff."""
     command_paths = (

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -243,6 +243,23 @@ def test_hunk_tracking_does_not_reexport_live_change_helpers():
     assert moved_names.isdisjoint(vars(hunk_tracking))
 
 
+def test_hunk_tracking_does_not_reexport_file_hunk_helpers():
+    """Moved file-scoped hunk helpers should not stay on hunk tracking."""
+    hunk_tracking = __import__(
+        "git_stage_batch.data.hunk_tracking",
+        fromlist=["hunk_tracking"],
+    )
+    moved_names = {
+        "build_file_hunk_from_buffer",
+        "cache_file_as_single_hunk",
+        "cache_unstaged_file_as_single_hunk",
+        "render_file_as_single_hunk",
+        "render_unstaged_file_as_single_hunk",
+    }
+
+    assert moved_names.isdisjoint(vars(hunk_tracking))
+
+
 def test_recalc_handoff_stays_in_command_helper():
     """Include and discard commands should use the command refresh handoff."""
     command_paths = (

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -144,6 +144,17 @@ def test_file_review_output_does_not_import_hunk_navigation():
     assert "git_stage_batch.data.hunk_tracking" not in imported_modules
 
 
+def test_batch_selection_does_not_import_hunk_navigation():
+    """Batch selection should use focused data helpers instead of hunk navigation."""
+    selection_path = SRC_ROOT / "batch" / "selection.py"
+    imported_modules = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(selection_path)
+    }
+
+    assert "git_stage_batch.data.hunk_tracking" not in imported_modules
+
+
 def test_recalc_handoff_stays_in_command_helper():
     """Include and discard commands should use the command refresh handoff."""
     command_paths = (

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -288,6 +288,27 @@ def test_hunk_tracking_does_not_reexport_batch_hunk_helpers():
     assert moved_or_removed_names.isdisjoint(vars(hunk_tracking))
 
 
+def test_hunk_tracking_does_not_reexport_progress_helpers():
+    """Progress helpers should not stay on hunk tracking."""
+    hunk_tracking = __import__(
+        "git_stage_batch.data.hunk_tracking",
+        fromlist=["hunk_tracking"],
+    )
+    progress_names = {
+        "format_id_range",
+        "record_binary_hunk_skipped",
+        "record_gitlink_hunk_skipped",
+        "record_hunk_discarded",
+        "record_hunk_included",
+        "record_hunk_skipped",
+        "record_hunks_discarded",
+        "record_rename_hunk_skipped",
+        "record_text_deletion_hunk_skipped",
+    }
+
+    assert progress_names.isdisjoint(vars(hunk_tracking))
+
+
 def test_recalc_handoff_stays_in_command_helper():
     """Include and discard commands should use the command refresh handoff."""
     command_paths = (

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -122,6 +122,17 @@ def test_batch_file_display_stays_below_hunk_navigation():
     assert "git_stage_batch.data.file_review.state" not in imported_modules
 
 
+def test_selected_change_batch_file_cache_does_not_import_hunk_navigation():
+    """Batch file selection caching should not depend on hunk navigation."""
+    cache_path = SRC_ROOT / "data" / "selected_change" / "batch_file_cache.py"
+    imported_modules = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(cache_path)
+    }
+
+    assert "git_stage_batch.data.hunk_tracking" not in imported_modules
+
+
 def test_file_review_state_does_not_import_hunk_navigation():
     """File-review safety state should not depend on hunk navigation."""
     review_state_path = SRC_ROOT / "data" / "file_review" / "state.py"
@@ -258,6 +269,23 @@ def test_hunk_tracking_does_not_reexport_file_hunk_helpers():
     }
 
     assert moved_names.isdisjoint(vars(hunk_tracking))
+
+
+def test_hunk_tracking_does_not_reexport_batch_hunk_helpers():
+    """Batch display helpers should not stay on hunk tracking."""
+    hunk_tracking = __import__(
+        "git_stage_batch.data.hunk_tracking",
+        fromlist=["hunk_tracking"],
+    )
+    moved_or_removed_names = {
+        "cache_batch_as_single_hunk",
+        "cache_batch_files_generator",
+        "cache_rendered_batch_file_display",
+        "get_batch_file_for_line_operation",
+        "render_batch_file_display",
+    }
+
+    assert moved_or_removed_names.isdisjoint(vars(hunk_tracking))
 
 
 def test_recalc_handoff_stays_in_command_helper():

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -166,6 +166,17 @@ def test_batch_selected_changes_does_not_import_hunk_navigation():
     assert "git_stage_batch.data.hunk_tracking" not in imported_modules
 
 
+def test_selected_change_lifecycle_does_not_import_hunk_navigation():
+    """Selected-change lifecycle clearing should stay independent from hunk navigation."""
+    lifecycle_path = SRC_ROOT / "data" / "selected_change" / "lifecycle.py"
+    imported_modules = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(lifecycle_path)
+    }
+
+    assert "git_stage_batch.data.hunk_tracking" not in imported_modules
+
+
 def test_recalc_handoff_stays_in_command_helper():
     """Include and discard commands should use the command refresh handoff."""
     command_paths = (

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -155,6 +155,17 @@ def test_batch_selection_does_not_import_hunk_navigation():
     assert "git_stage_batch.data.hunk_tracking" not in imported_modules
 
 
+def test_batch_selected_changes_does_not_import_hunk_navigation():
+    """Batch atomic-selection state should not depend on live hunk navigation."""
+    batch_selected_path = SRC_ROOT / "data" / "batch_selected_changes.py"
+    imported_modules = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(batch_selected_path)
+    }
+
+    assert "git_stage_batch.data.hunk_tracking" not in imported_modules
+
+
 def test_recalc_handoff_stays_in_command_helper():
     """Include and discard commands should use the command refresh handoff."""
     command_paths = (

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -210,6 +210,28 @@ def test_status_does_not_import_hunk_navigation():
     assert "git_stage_batch.data.hunk_tracking" not in imported_modules
 
 
+def test_hunk_tracking_does_not_reexport_live_change_helpers():
+    """Moved live-change helpers should not stay available from hunk tracking."""
+    hunk_tracking = __import__(
+        "git_stage_batch.data.hunk_tracking",
+        fromlist=["hunk_tracking"],
+    )
+    moved_names = {
+        "binary_file_change_is_stale",
+        "gitlink_change_is_stale",
+        "rename_change_is_stale",
+        "render_binary_file_change",
+        "render_gitlink_change",
+        "render_rename_change",
+        "render_text_deletion_change",
+        "stream_live_git_diff",
+        "text_deletion_change_is_batched",
+        "text_deletion_change_is_stale",
+    }
+
+    assert moved_names.isdisjoint(vars(hunk_tracking))
+
+
 def test_recalc_handoff_stays_in_command_helper():
     """Include and discard commands should use the command refresh handoff."""
     command_paths = (

--- a/tests/commands/test_again.py
+++ b/tests/commands/test_again.py
@@ -6,9 +6,9 @@ from git_stage_batch.commands.discard import command_discard_to_batch
 from git_stage_batch.commands.include import command_include
 from git_stage_batch.commands.show import command_show, command_show_file_list
 from git_stage_batch.data.file_review.state import read_last_file_review_state
-from git_stage_batch.data.hunk_tracking import (
+from git_stage_batch.data.hunk_tracking import fetch_next_change
+from git_stage_batch.data.selected_change.store import (
     SelectedChangeKind,
-    fetch_next_change,
     get_selected_change_file_path,
     read_selected_change_kind,
 )

--- a/tests/commands/test_binary_files.py
+++ b/tests/commands/test_binary_files.py
@@ -25,9 +25,9 @@ from git_stage_batch.commands.skip import command_skip, command_skip_file
 from git_stage_batch.commands.status import command_status
 from git_stage_batch.core.models import BinaryFileChange, LineLevelChange
 from git_stage_batch.data.file_tracking import auto_add_untracked_files
-from git_stage_batch.data.hunk_tracking import (
+from git_stage_batch.data.hunk_tracking import fetch_next_change
+from git_stage_batch.data.selected_change.store import (
     SelectedChangeKind,
-    fetch_next_change,
     get_selected_change_file_path,
     read_selected_change_kind,
 )

--- a/tests/commands/test_discard.py
+++ b/tests/commands/test_discard.py
@@ -13,9 +13,11 @@ from git_stage_batch.data.hunk_tracking import (
     fetch_next_change,
     load_selected_change,
     recalculate_selected_hunk_for_file,
-    selected_change_was_cleared_by_auto_advance_disabled,
 )
 from git_stage_batch.data.line_state import load_line_changes_from_state
+from git_stage_batch.data.selected_change.store import (
+    selected_change_was_cleared_by_auto_advance_disabled,
+)
 
 import subprocess
 

--- a/tests/commands/test_discard_from.py
+++ b/tests/commands/test_discard_from.py
@@ -8,7 +8,7 @@ import subprocess
 import pytest
 
 from git_stage_batch.batch import create_batch
-from git_stage_batch.data.hunk_tracking import render_batch_file_display
+from git_stage_batch.batch.file_display import render_batch_file_display
 from git_stage_batch.commands.discard_from import command_discard_from_batch
 from git_stage_batch.data.session import initialize_abort_state
 from git_stage_batch.exceptions import CommandError

--- a/tests/commands/test_file_review.py
+++ b/tests/commands/test_file_review.py
@@ -35,7 +35,7 @@ from git_stage_batch.data.file_review.state import (
     shown_review_selections_for_action,
     validate_pathless_review_line_action,
 )
-from git_stage_batch.data.hunk_tracking import (
+from git_stage_batch.data.selected_change.store import (
     SelectedChangeKind,
     get_selected_change_file_path,
     read_selected_change_kind,

--- a/tests/commands/test_file_review.py
+++ b/tests/commands/test_file_review.py
@@ -28,7 +28,6 @@ from git_stage_batch.commands.include import command_include_to_batch
 from git_stage_batch.commands.suggest_fixup import command_suggest_fixup
 from git_stage_batch.core.actionable_changes import ActionableSelectionReason
 import git_stage_batch.batch.file_display as file_display_module
-import git_stage_batch.data.hunk_tracking as hunk_tracking_module
 from git_stage_batch.data.file_review.state import (
     FileReviewAction,
     ReviewSource,
@@ -2561,7 +2560,6 @@ def test_show_from_batch_line_after_review_uses_review_id_space(
 
     monkeypatch.setattr(show_from_module, "render_batch_file_display", render_with_review_only_first_line)
     monkeypatch.setattr(file_display_module, "render_batch_file_display", render_with_review_only_first_line)
-    monkeypatch.setattr(hunk_tracking_module, "render_batch_file_display", render_with_review_only_first_line)
 
     command_show_from_batch("manual", file="file.txt", page="all")
     capsys.readouterr()
@@ -2655,7 +2653,6 @@ def test_show_from_batch_line_without_review_uses_printed_review_id_space(
 
     monkeypatch.setattr(show_from_module, "render_batch_file_display", render_with_review_only_second_line)
     monkeypatch.setattr(file_display_module, "render_batch_file_display", render_with_review_only_second_line)
-    monkeypatch.setattr(hunk_tracking_module, "render_batch_file_display", render_with_review_only_second_line)
 
     command_show_from_batch("manual", file="file.txt", line_ids="2")
 

--- a/tests/commands/test_file_scoped_operations.py
+++ b/tests/commands/test_file_scoped_operations.py
@@ -15,7 +15,7 @@ from git_stage_batch.utils.paths import (
     get_selected_hunk_hash_file_path,
     get_selected_hunk_patch_file_path,
 )
-from git_stage_batch.data.hunk_tracking import read_selected_change_kind
+from git_stage_batch.data.selected_change.store import read_selected_change_kind
 from git_stage_batch.data.file_hunk_display import render_unstaged_file_as_single_hunk
 from git_stage_batch.commands.skip import command_skip, command_skip_line
 from git_stage_batch.cli.argument_parser import parse_command_line

--- a/tests/commands/test_file_scoped_operations.py
+++ b/tests/commands/test_file_scoped_operations.py
@@ -15,7 +15,8 @@ from git_stage_batch.utils.paths import (
     get_selected_hunk_hash_file_path,
     get_selected_hunk_patch_file_path,
 )
-from git_stage_batch.data.hunk_tracking import read_selected_change_kind, render_unstaged_file_as_single_hunk
+from git_stage_batch.data.hunk_tracking import read_selected_change_kind
+from git_stage_batch.data.file_hunk_display import render_unstaged_file_as_single_hunk
 from git_stage_batch.commands.skip import command_skip, command_skip_line
 from git_stage_batch.cli.argument_parser import parse_command_line
 

--- a/tests/commands/test_include.py
+++ b/tests/commands/test_include.py
@@ -21,9 +21,11 @@ from git_stage_batch.core.models import TextFileDeletionChange
 from git_stage_batch.data.hunk_tracking import (
     fetch_next_change,
     load_selected_change,
-    selected_change_was_cleared_by_auto_advance_disabled,
 )
 from git_stage_batch.data.line_state import load_line_changes_from_state
+from git_stage_batch.data.selected_change.store import (
+    selected_change_was_cleared_by_auto_advance_disabled,
+)
 from git_stage_batch.exceptions import CommandError, NoMoreHunks
 from git_stage_batch.commands.again import command_again
 

--- a/tests/commands/test_include_from.py
+++ b/tests/commands/test_include_from.py
@@ -16,7 +16,7 @@ from git_stage_batch.commands.include import command_include_to_batch
 from git_stage_batch.commands.include_from import command_include_from_batch
 from git_stage_batch.commands.show_from import command_show_from_batch
 from git_stage_batch.commands.start import command_start
-from git_stage_batch.data.hunk_tracking import render_batch_file_display
+from git_stage_batch.batch.file_display import render_batch_file_display
 from git_stage_batch.data.session import initialize_abort_state
 from git_stage_batch.exceptions import CommandError
 from git_stage_batch.utils.git import run_git_command

--- a/tests/commands/test_show.py
+++ b/tests/commands/test_show.py
@@ -18,7 +18,7 @@ import pytest
 import git_stage_batch.commands.show as show_module
 from git_stage_batch.commands.show import command_show
 from git_stage_batch.commands.start import command_start
-from git_stage_batch.data.hunk_tracking import get_selected_change_file_path
+from git_stage_batch.data.selected_change.store import get_selected_change_file_path
 from git_stage_batch.data.line_state import load_line_changes_from_state
 
 

--- a/tests/commands/test_show_from.py
+++ b/tests/commands/test_show_from.py
@@ -10,7 +10,7 @@ from git_stage_batch.batch.file_display import render_batch_file_display
 import git_stage_batch.batch.merge as merge_module
 import git_stage_batch.batch.display as display_module
 import git_stage_batch.batch.file_display as file_display
-import git_stage_batch.data.hunk_tracking as hunk_tracking
+import git_stage_batch.data.selected_change.store as selected_change_store
 import git_stage_batch.commands.show_from as show_from_module
 
 import subprocess
@@ -472,7 +472,7 @@ class TestCommandShowFromBatch:
         readme.write_text("# Test\nselected\n")
         command_show()
         capsys.readouterr()
-        assert hunk_tracking.get_selected_change_file_path() == "README.md"
+        assert selected_change_store.get_selected_change_file_path() == "README.md"
 
         (temp_git_repo / "file1.txt").write_text("one\n")
         (temp_git_repo / "file2.txt").write_text("two\n")
@@ -493,4 +493,4 @@ class TestCommandShowFromBatch:
         command_show_from_batch("multi-file-batch", selectable=False)
         capsys.readouterr()
 
-        assert hunk_tracking.get_selected_change_file_path() == "README.md"
+        assert selected_change_store.get_selected_change_file_path() == "README.md"

--- a/tests/commands/test_skip.py
+++ b/tests/commands/test_skip.py
@@ -9,9 +9,11 @@ from git_stage_batch.commands.start import command_start
 from git_stage_batch.data.hunk_tracking import (
     fetch_next_change,
     load_selected_change,
-    selected_change_was_cleared_by_auto_advance_disabled,
 )
 from git_stage_batch.data.line_state import load_line_changes_from_state
+from git_stage_batch.data.selected_change.store import (
+    selected_change_was_cleared_by_auto_advance_disabled,
+)
 from git_stage_batch.exceptions import CommandError
 from git_stage_batch.utils.file_io import read_text_file_contents
 from git_stage_batch.utils.paths import get_processed_skip_ids_file_path

--- a/tests/commands/test_status.py
+++ b/tests/commands/test_status.py
@@ -8,7 +8,7 @@ from git_stage_batch.commands.include import command_include_line, command_inclu
 from git_stage_batch.commands.reset import command_reset_from_batch
 from git_stage_batch.commands.show import command_show, command_show_file_list
 from git_stage_batch.commands.show_from import command_show_from_batch
-from git_stage_batch.data.hunk_tracking import SelectedChangeKind, read_selected_change_kind
+from git_stage_batch.data.selected_change.store import SelectedChangeKind, read_selected_change_kind
 from git_stage_batch.data.session import initialize_abort_state
 from git_stage_batch.utils.paths import get_iteration_count_file_path
 from git_stage_batch.utils.paths import ensure_state_directory_exists, get_state_directory_path

--- a/tests/commands/test_submodule_pointers.py
+++ b/tests/commands/test_submodule_pointers.py
@@ -26,7 +26,7 @@ from git_stage_batch.commands.skip import command_skip
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.commands.status import command_status
 from git_stage_batch.commands.undo import command_undo
-from git_stage_batch.data.hunk_tracking import (
+from git_stage_batch.data.selected_change.store import (
     SelectedChangeKind,
     get_selected_change_file_path,
     read_selected_change_kind,

--- a/tests/commands/test_suggest_fixup.py
+++ b/tests/commands/test_suggest_fixup.py
@@ -18,7 +18,7 @@ from git_stage_batch.commands.suggest_fixup import (
 )
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.data.hunk_tracking import fetch_next_change
-from git_stage_batch.data.hunk_tracking import render_file_as_single_hunk
+from git_stage_batch.data.file_hunk_display import render_file_as_single_hunk
 from git_stage_batch.exceptions import CommandError
 from git_stage_batch.utils.paths import get_suggest_fixup_state_file_path
 

--- a/tests/data/test_auto_advance.py
+++ b/tests/data/test_auto_advance.py
@@ -11,8 +11,10 @@ from git_stage_batch.data.auto_advance import (
     write_auto_advance_default,
 )
 from git_stage_batch.data.hunk_tracking import (
-    refuse_bare_action_after_auto_advance_disabled,
     select_next_change_after_action,
+)
+from git_stage_batch.data.selected_change.store import (
+    refuse_bare_action_after_auto_advance_disabled,
     selected_change_was_cleared_by_auto_advance_disabled,
 )
 from git_stage_batch.exceptions import CommandError

--- a/tests/data/test_file_hunk_display.py
+++ b/tests/data/test_file_hunk_display.py
@@ -1,0 +1,58 @@
+"""Tests for file-scoped text hunk rendering."""
+
+import subprocess
+
+import pytest
+
+from git_stage_batch.data.file_hunk_display import build_file_hunk_from_buffer
+from git_stage_batch.editor import EditorBuffer
+from git_stage_batch.utils.paths import ensure_state_directory_exists
+
+
+@pytest.fixture
+def temp_git_repo(tmp_path, monkeypatch):
+    """Create a temporary git repository for testing."""
+    repo = tmp_path / "test_repo"
+    repo.mkdir()
+    monkeypatch.chdir(repo)
+
+    subprocess.run(["git", "init"], check=True, cwd=repo, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], check=True, cwd=repo, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], check=True, cwd=repo, capture_output=True)
+
+    (repo / "README.md").write_text("# Test\n")
+    subprocess.run(["git", "add", "README.md"], check=True, cwd=repo, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "Initial commit"], check=True, cwd=repo, capture_output=True)
+
+    ensure_state_directory_exists()
+
+    return repo
+
+
+def test_build_file_hunk_from_buffer_accepts_buffer(temp_git_repo):
+    """Hypothetical file views can read generated buffers."""
+    test_file = temp_git_repo / "test.txt"
+    test_file.write_text("line1\nline2\n")
+    subprocess.run(
+        ["git", "add", "test.txt"],
+        check=True,
+        cwd=temp_git_repo,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "Add test file"],
+        check=True,
+        cwd=temp_git_repo,
+        capture_output=True,
+    )
+
+    with EditorBuffer.from_chunks([b"line1\nchanged\n"]) as buffer:
+        line_changes = build_file_hunk_from_buffer("test.txt", buffer)
+
+    assert line_changes is not None
+    assert [line.display_text() for line in line_changes.lines if line.kind == "-"] == [
+        "line2"
+    ]
+    assert [line.display_text() for line in line_changes.lines if line.kind == "+"] == [
+        "changed"
+    ]

--- a/tests/data/test_hunk_tracking.py
+++ b/tests/data/test_hunk_tracking.py
@@ -23,11 +23,9 @@ from git_stage_batch.data.hunk_tracking import (
     RecalculateSelectedHunkResult,
     advance_to_next_change,
     apply_line_level_batch_filter_to_cached_hunk,
-    clear_selected_change_state_files,
     fetch_next_change,
     recalculate_selected_hunk_for_file,
     require_selected_hunk,
-    snapshots_are_stale,
 )
 from git_stage_batch.utils.file_io import append_lines_to_file
 from git_stage_batch.utils.paths import (
@@ -36,10 +34,8 @@ from git_stage_batch.utils.paths import (
     get_selected_hunk_hash_file_path,
     get_selected_hunk_patch_file_path,
     get_line_changes_json_file_path,
-    get_index_snapshot_file_path,
     get_processed_batch_ids_file_path,
     get_processed_include_ids_file_path,
-    get_working_tree_snapshot_file_path,
 )
 
 
@@ -63,40 +59,6 @@ def temp_git_repo(tmp_path, monkeypatch):
 
     return repo
 
-
-class TestClearCurrentHunkStateFiles:
-    """Tests for clear_selected_change_state_files()."""
-
-    def test_clears_all_state_files(self, temp_git_repo):
-        """Test that all selected hunk state files are cleared."""
-
-        # Create state files
-        get_selected_hunk_patch_file_path().write_text("patch")
-        get_selected_hunk_hash_file_path().write_text("hash")
-        get_line_changes_json_file_path().write_text("{}")
-        get_index_snapshot_file_path().write_text("index")
-        get_working_tree_snapshot_file_path().write_text("tree")
-        get_processed_include_ids_file_path().write_text("1\n2\n")
-        # processed.batch uses JSON format now and is global state (not per-hunk)
-        get_processed_batch_ids_file_path().write_text(json.dumps({"test.py": {"presence_claims": [{"source_lines": ["1", "2"]}]}}))
-
-        # Clear state
-        clear_selected_change_state_files()
-
-        # Verify per-hunk files are removed
-        assert not get_selected_hunk_patch_file_path().exists()
-        assert not get_selected_hunk_hash_file_path().exists()
-        assert not get_line_changes_json_file_path().exists()
-        assert not get_index_snapshot_file_path().exists()
-        assert not get_working_tree_snapshot_file_path().exists()
-        assert not get_processed_include_ids_file_path().exists()
-        # processed.batch is global state, so per-hunk reset leaves it intact.
-        assert get_processed_batch_ids_file_path().exists()
-
-    def test_handles_missing_files(self, temp_git_repo):
-        """Test that clearing works even when files don't exist."""
-        # Should not raise error when files don't exist
-        clear_selected_change_state_files()
 
 class TestFindAndCacheNextUnblockedHunk:
     """Tests for fetch_next_change()."""
@@ -333,70 +295,6 @@ class TestAdvanceToNextHunk:
         # State files should be cleared
         assert not get_selected_hunk_patch_file_path().exists()
         assert not get_selected_hunk_hash_file_path().exists()
-
-
-class TestSnapshotsAreStale:
-    """Tests for snapshots_are_stale()."""
-
-    def test_detects_missing_snapshots(self, temp_git_repo):
-        """Test that missing snapshots are detected as stale."""
-        # No snapshots exist yet
-        assert snapshots_are_stale("test.txt") is True
-
-    def test_detects_fresh_snapshots(self, temp_git_repo):
-        """Test that fresh snapshots are not stale."""
-        # Create a file and cache it
-        test_file = temp_git_repo / "test.txt"
-        test_file.write_text("content\n")
-        subprocess.run(["git", "add", "test.txt"], check=True, cwd=temp_git_repo, capture_output=True)
-        subprocess.run(["git", "commit", "-m", "Add file"], check=True, cwd=temp_git_repo, capture_output=True)
-
-        test_file.write_text("modified\n")
-
-        # Cache the hunk with snapshots
-        fetch_next_change()
-
-        # Snapshots should be fresh
-        assert snapshots_are_stale("test.txt") is False
-
-    def test_detects_index_change(self, temp_git_repo):
-        """Test that index changes make snapshots stale."""
-        # Create a file and cache it
-        test_file = temp_git_repo / "test.txt"
-        test_file.write_text("content\n")
-        subprocess.run(["git", "add", "test.txt"], check=True, cwd=temp_git_repo, capture_output=True)
-        subprocess.run(["git", "commit", "-m", "Add file"], check=True, cwd=temp_git_repo, capture_output=True)
-
-        test_file.write_text("modified\n")
-
-        # Cache the hunk with snapshots
-        fetch_next_change()
-
-        # Change the index
-        test_file.write_text("changed again\n")
-        subprocess.run(["git", "add", "test.txt"], check=True, cwd=temp_git_repo, capture_output=True)
-
-        # Snapshots should now be stale
-        assert snapshots_are_stale("test.txt") is True
-
-    def test_detects_working_tree_change(self, temp_git_repo):
-        """Test that working tree changes make snapshots stale."""
-        # Create a file and cache it
-        test_file = temp_git_repo / "test.txt"
-        test_file.write_text("content\n")
-        subprocess.run(["git", "add", "test.txt"], check=True, cwd=temp_git_repo, capture_output=True)
-        subprocess.run(["git", "commit", "-m", "Add file"], check=True, cwd=temp_git_repo, capture_output=True)
-
-        test_file.write_text("modified\n")
-
-        # Cache the hunk with snapshots
-        fetch_next_change()
-
-        # Change the working tree
-        test_file.write_text("different content\n")
-
-        # Snapshots should now be stale
-        assert snapshots_are_stale("test.txt") is True
 
 
 class TestRequireCurrentHunkAndCheckStale:

--- a/tests/data/test_hunk_tracking.py
+++ b/tests/data/test_hunk_tracking.py
@@ -23,7 +23,6 @@ from git_stage_batch.data.hunk_tracking import (
     RecalculateSelectedHunkResult,
     advance_to_next_change,
     apply_line_level_batch_filter_to_cached_hunk,
-    build_file_hunk_from_buffer,
     clear_selected_change_state_files,
     fetch_next_change,
     recalculate_selected_hunk_for_file,
@@ -32,7 +31,6 @@ from git_stage_batch.data.hunk_tracking import (
     require_selected_hunk,
     snapshots_are_stale,
 )
-from git_stage_batch.editor import EditorBuffer
 from git_stage_batch.utils.file_io import append_lines_to_file
 from git_stage_batch.utils.paths import (
     ensure_state_directory_exists,
@@ -103,36 +101,6 @@ class TestClearCurrentHunkStateFiles:
         """Test that clearing works even when files don't exist."""
         # Should not raise error when files don't exist
         clear_selected_change_state_files()
-
-
-def test_build_file_hunk_from_buffer_accepts_buffer(temp_git_repo):
-    """Hypothetical file views can read generated buffers."""
-    test_file = temp_git_repo / "test.txt"
-    test_file.write_text("line1\nline2\n")
-    subprocess.run(
-        ["git", "add", "test.txt"],
-        check=True,
-        cwd=temp_git_repo,
-        capture_output=True,
-    )
-    subprocess.run(
-        ["git", "commit", "-m", "Add test file"],
-        check=True,
-        cwd=temp_git_repo,
-        capture_output=True,
-    )
-
-    with EditorBuffer.from_chunks([b"line1\nchanged\n"]) as buffer:
-        line_changes = build_file_hunk_from_buffer("test.txt", buffer)
-
-    assert line_changes is not None
-    assert [line.display_text() for line in line_changes.lines if line.kind == "-"] == [
-        "line2"
-    ]
-    assert [line.display_text() for line in line_changes.lines if line.kind == "+"] == [
-        "changed"
-    ]
-
 
 class TestFindAndCacheNextUnblockedHunk:
     """Tests for fetch_next_change()."""

--- a/tests/data/test_hunk_tracking.py
+++ b/tests/data/test_hunk_tracking.py
@@ -1,4 +1,4 @@
-"""Tests for hunk navigation, state management, staleness detection, and progress tracking."""
+"""Tests for hunk navigation, state management, and staleness detection."""
 
 import json
 from git_stage_batch.core.hashing import compute_stable_hunk_hash_from_lines
@@ -26,8 +26,6 @@ from git_stage_batch.data.hunk_tracking import (
     clear_selected_change_state_files,
     fetch_next_change,
     recalculate_selected_hunk_for_file,
-    record_hunk_discarded,
-    record_hunk_included,
     require_selected_hunk,
     snapshots_are_stale,
 )
@@ -38,8 +36,6 @@ from git_stage_batch.utils.paths import (
     get_selected_hunk_hash_file_path,
     get_selected_hunk_patch_file_path,
     get_line_changes_json_file_path,
-    get_discarded_hunks_file_path,
-    get_included_hunks_file_path,
     get_index_snapshot_file_path,
     get_processed_batch_ids_file_path,
     get_processed_include_ids_file_path,
@@ -583,23 +579,3 @@ class TestRecalculateCurrentHunkForFile:
 
         assert result is RecalculateSelectedHunkResult.SHOW_NEXT_CHANGE
         assert not get_selected_hunk_patch_file_path().exists()
-
-
-class TestRecordHunkFunctions:
-    """Tests for hunk recording functions."""
-
-    def test_record_hunk_included(self, temp_git_repo):
-        """Test recording included hunk."""
-        record_hunk_included("abc123")
-
-        included_file = get_included_hunks_file_path()
-        assert included_file.exists()
-        assert "abc123" in included_file.read_text()
-
-    def test_record_hunk_discarded(self, temp_git_repo):
-        """Test recording discarded hunk."""
-        record_hunk_discarded("xyz789")
-
-        discarded_file = get_discarded_hunks_file_path()
-        assert discarded_file.exists()
-        assert "xyz789" in discarded_file.read_text()

--- a/tests/data/test_progress.py
+++ b/tests/data/test_progress.py
@@ -4,7 +4,12 @@ import subprocess
 
 import pytest
 
-from git_stage_batch.data.progress import get_file_progress, get_hunk_counts
+from git_stage_batch.data.progress import (
+    get_file_progress,
+    get_hunk_counts,
+    record_hunk_discarded,
+    record_hunk_included,
+)
 from git_stage_batch.utils.file_io import write_text_file_contents
 from git_stage_batch.utils.paths import (
     ensure_state_directory_exists,
@@ -32,6 +37,30 @@ def temp_git_repo(tmp_path, monkeypatch):
     subprocess.run(["git", "commit", "-m", "Initial commit"], check=True, cwd=repo, capture_output=True)
 
     return repo
+
+
+class TestRecordHunkFunctions:
+    """Tests for hunk recording functions."""
+
+    def test_record_hunk_included(self, temp_git_repo):
+        """Test recording included hunk."""
+        ensure_state_directory_exists()
+
+        record_hunk_included("abc123")
+
+        included_file = get_included_hunks_file_path()
+        assert included_file.exists()
+        assert "abc123" in included_file.read_text()
+
+    def test_record_hunk_discarded(self, temp_git_repo):
+        """Test recording discarded hunk."""
+        ensure_state_directory_exists()
+
+        record_hunk_discarded("xyz789")
+
+        discarded_file = get_discarded_hunks_file_path()
+        assert discarded_file.exists()
+        assert "xyz789" in discarded_file.read_text()
 
 
 class TestHunkCounts:

--- a/tests/data/test_selected_change_lifecycle.py
+++ b/tests/data/test_selected_change_lifecycle.py
@@ -1,0 +1,93 @@
+"""Tests for selected-change lifecycle state cleanup."""
+
+import json
+import subprocess
+
+import pytest
+
+from git_stage_batch.data.selected_change.lifecycle import (
+    clear_selected_change_state_files,
+)
+from git_stage_batch.utils.paths import (
+    ensure_state_directory_exists,
+    get_index_snapshot_file_path,
+    get_line_changes_json_file_path,
+    get_processed_batch_ids_file_path,
+    get_processed_include_ids_file_path,
+    get_selected_hunk_hash_file_path,
+    get_selected_hunk_patch_file_path,
+    get_working_tree_snapshot_file_path,
+)
+
+
+@pytest.fixture
+def temp_git_repo(tmp_path, monkeypatch):
+    """Create a temporary git repository."""
+    repo = tmp_path / "test_repo"
+    repo.mkdir()
+    monkeypatch.chdir(repo)
+
+    subprocess.run(["git", "init"], check=True, cwd=repo, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"],
+        check=True,
+        cwd=repo,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        check=True,
+        cwd=repo,
+        capture_output=True,
+    )
+
+    (repo / "README.md").write_text("# Test\n")
+    subprocess.run(["git", "add", "README.md"], check=True, cwd=repo, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "Initial commit"],
+        check=True,
+        cwd=repo,
+        capture_output=True,
+    )
+
+    ensure_state_directory_exists()
+
+    return repo
+
+
+class TestClearSelectedChangeStateFiles:
+    """Tests for clear_selected_change_state_files()."""
+
+    def test_clears_per_selection_state_files(self, temp_git_repo):
+        """Selected-change cleanup should leave global batch state intact."""
+        get_selected_hunk_patch_file_path().write_text("patch")
+        get_selected_hunk_hash_file_path().write_text("hash")
+        get_line_changes_json_file_path().write_text("{}")
+        get_index_snapshot_file_path().write_text("index")
+        get_working_tree_snapshot_file_path().write_text("tree")
+        get_processed_include_ids_file_path().write_text("1\n2\n")
+        get_processed_batch_ids_file_path().write_text(
+            json.dumps(
+                {
+                    "test.py": {
+                        "presence_claims": [
+                            {"source_lines": ["1", "2"]},
+                        ],
+                    },
+                }
+            )
+        )
+
+        clear_selected_change_state_files()
+
+        assert not get_selected_hunk_patch_file_path().exists()
+        assert not get_selected_hunk_hash_file_path().exists()
+        assert not get_line_changes_json_file_path().exists()
+        assert not get_index_snapshot_file_path().exists()
+        assert not get_working_tree_snapshot_file_path().exists()
+        assert not get_processed_include_ids_file_path().exists()
+        assert get_processed_batch_ids_file_path().exists()
+
+    def test_handles_missing_files(self, temp_git_repo):
+        """Selected-change cleanup should tolerate already-missing files."""
+        clear_selected_change_state_files()

--- a/tests/data/test_selected_snapshots.py
+++ b/tests/data/test_selected_snapshots.py
@@ -4,7 +4,10 @@ import subprocess
 
 import pytest
 
-from git_stage_batch.data.selected_change.snapshots import write_snapshots_for_selected_file_path
+from git_stage_batch.data.selected_change.snapshots import (
+    snapshots_are_stale,
+    write_snapshots_for_selected_file_path,
+)
 from git_stage_batch.utils.file_io import read_text_file_contents
 from git_stage_batch.utils.paths import (
     ensure_state_directory_exists,
@@ -154,3 +157,69 @@ def new_function():
         working_tree_snapshot_path = get_working_tree_snapshot_file_path()
         working_tree_snapshot_content = read_text_file_contents(working_tree_snapshot_path)
         assert working_tree_snapshot_content == working_content
+
+
+class TestSnapshotsAreStale:
+    """Tests for snapshots_are_stale()."""
+
+    @pytest.fixture
+    def temp_git_repo(self, tmp_path, monkeypatch):
+        """Create a temporary git repository."""
+        monkeypatch.chdir(tmp_path)
+        subprocess.run(["git", "init"], check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.name", "Test User"], check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.email", "test@example.com"], check=True, capture_output=True)
+
+        (tmp_path / "README.md").write_text("# Test\n")
+        subprocess.run(["git", "add", "README.md"], check=True, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Initial commit"], check=True, capture_output=True)
+
+        ensure_state_directory_exists()
+
+        return tmp_path
+
+    def test_detects_missing_snapshots(self, temp_git_repo):
+        """Missing snapshots should be considered stale."""
+        assert snapshots_are_stale("test.txt") is True
+
+    def test_detects_fresh_snapshots(self, temp_git_repo):
+        """Current index and working tree snapshots should not be stale."""
+        test_file = temp_git_repo / "test.txt"
+        test_file.write_text("content\n")
+        subprocess.run(["git", "add", "test.txt"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add file"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        test_file.write_text("modified\n")
+
+        write_snapshots_for_selected_file_path("test.txt")
+
+        assert snapshots_are_stale("test.txt") is False
+
+    def test_detects_index_change(self, temp_git_repo):
+        """Index changes should make selected-file snapshots stale."""
+        test_file = temp_git_repo / "test.txt"
+        test_file.write_text("content\n")
+        subprocess.run(["git", "add", "test.txt"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add file"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        test_file.write_text("modified\n")
+        write_snapshots_for_selected_file_path("test.txt")
+
+        test_file.write_text("changed again\n")
+        subprocess.run(["git", "add", "test.txt"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        assert snapshots_are_stale("test.txt") is True
+
+    def test_detects_working_tree_change(self, temp_git_repo):
+        """Working tree changes should make selected-file snapshots stale."""
+        test_file = temp_git_repo / "test.txt"
+        test_file.write_text("content\n")
+        subprocess.run(["git", "add", "test.txt"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Add file"], check=True, cwd=temp_git_repo, capture_output=True)
+
+        test_file.write_text("modified\n")
+        write_snapshots_for_selected_file_path("test.txt")
+
+        test_file.write_text("different content\n")
+
+        assert snapshots_are_stale("test.txt") is True


### PR DESCRIPTION
Selected-change workflow state now has focused stores for review state,
payload caches, progress records, snapshots, and batch selection helpers.

The project still exposes selected-change persistence through broad hunk-
navigation facades, so command and batch callers can depend on navigation
code when they only need stored state.

This PR routes the remaining selected-change callers through the focused
stores and hides the broad selected-change facade from hunk navigation.

The next PR will add boundary scaffolding so those narrowed ownership lines
stay visible in the test suite.

Test plan: .venv/bin/python -m pytest -n auto passed on the final stack tip
  before landing; each PR branch is rebased without code changes before
  merge.
