### PR TITLE
architecture: Move TUI review actions behind owners

### DIFF
--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -7,14 +7,11 @@ import os
 from pathlib import Path
 import sys
 from contextlib import ExitStack
-from dataclasses import dataclass
 
 from ..batch.operations import create_batch
 from ..batch.storage import (
-    BatchFileUpdate,
     add_binary_file_to_batch,
     add_file_to_batch,
-    add_files_to_batch,
 )
 from ..batch.display import annotate_with_batch_source
 from ..batch.ownership import (
@@ -68,7 +65,7 @@ from ..data.file_change_display import (
     render_text_deletion_change,
 )
 from ..data.file_hunk_display import cache_unstaged_file_as_single_hunk
-from ..data.file_modes import detect_file_mode, detect_file_mode_from_root
+from ..data.file_modes import detect_file_mode
 from ..data.file_review.records import FileReviewAction, ReviewSource
 from ..data.file_review.state import (
     clear_last_file_review_state_if_file_matches,
@@ -81,8 +78,8 @@ from ..data.file_review.state import (
 from ..data.file_tracking import auto_add_untracked_files
 from ..data.line_state import load_line_changes_from_state
 from ..data.live_diff import stream_live_git_diff
-from ..data.progress import record_hunk_discarded, record_hunks_discarded
-from ..data.session import require_session_started, snapshot_file_if_untracked, snapshot_files_if_untracked
+from ..data.progress import record_hunk_discarded
+from ..data.session import require_session_started, snapshot_file_if_untracked
 from ..data.undo import undo_checkpoint
 from ..core.buffer import (
     LineBuffer,
@@ -132,41 +129,6 @@ from .selection.selected_change_discarding import (
     discard_text_deletion_change,
 )
 from .selection.action_completion import finish_selected_change_action
-
-
-@dataclass(frozen=True)
-class _PreparedPatchDiscard:
-    patch_lines: Sequence[bytes]
-    patch_hash: str
-
-
-@dataclass
-class _TextFileDiscardInput:
-    file_path: str
-    file_mode: str
-    all_lines_to_batch: list
-    patches_to_discard: list[_PreparedPatchDiscard]
-
-
-@dataclass(frozen=True)
-class _CollectedTextFileDiscards:
-    inputs_by_file: dict[str, _TextFileDiscardInput]
-    files_with_text_patches: set[str]
-
-
-@dataclass(frozen=True)
-class _PreparedTextFileDiscardToBatch:
-    file_path: str
-    file_mode: str
-    ownership: BatchOwnership
-    batch_source_commit: str | None
-    patches_to_discard: list[_PreparedPatchDiscard]
-
-
-@dataclass(frozen=True)
-class DiscardFilesToBatchResult:
-    discarded_hunks: int
-    discarded_files: list[str]
 
 
 def command_discard(
@@ -1054,278 +1016,6 @@ def _command_discard_text_deletion_to_batch(
     if advance:
         finish_selected_change_action(quiet=quiet, auto_advance=auto_advance)
     return 1
-
-
-def _prepare_text_file_discard_to_batch(
-    batch_name: str,
-    discard_input: _TextFileDiscardInput,
-    *,
-    metadata: dict,
-    ownership_stack: ExitStack,
-) -> _PreparedTextFileDiscardToBatch | None:
-    """Prepare one normal text file discard without publishing batch state."""
-    if not discard_input.all_lines_to_batch:
-        return None
-
-    file_path = discard_input.file_path
-    file_metadata = metadata.get("files", {}).get(file_path)
-
-    try:
-        update = ownership_stack.enter_context(
-            acquire_batch_ownership_update_for_selection(
-                batch_name=batch_name,
-                file_path=file_path,
-                file_metadata=file_metadata,
-                selected_lines=discard_input.all_lines_to_batch,
-            )
-        )
-    except ValueError as e:
-        exit_with_error(
-            _("Cannot discard file to batch: batch source is stale and remapping failed.\n"
-              "File: {file}\n"
-              "Batch: {batch}\n"
-              "Error: {error}").format(file=file_path, batch=batch_name, error=str(e))
-        )
-
-    return _PreparedTextFileDiscardToBatch(
-        file_path=file_path,
-        file_mode=discard_input.file_mode,
-        ownership=update.ownership_after,
-        batch_source_commit=update.batch_source_commit,
-        patches_to_discard=discard_input.patches_to_discard,
-    )
-
-
-def _collect_text_file_discard_inputs(
-    files: list[str],
-    *,
-    blocked_hashes: set[str],
-    patch_stack: ExitStack,
-) -> _CollectedTextFileDiscards:
-    """Collect normal text file discard inputs from one Git diff."""
-    if not files:
-        return _CollectedTextFileDiscards(inputs_by_file={}, files_with_text_patches=set())
-
-    repo_root = get_git_repository_root_path()
-    inputs_by_file: dict[str, _TextFileDiscardInput] = {}
-    files_with_text_patches: set[str] = set()
-
-    with acquire_unified_diff(
-        stream_live_git_diff(
-            base="HEAD",
-            context_lines=get_context_lines(),
-            paths=files,
-        )
-    ) as patches:
-        for patch in patches:
-            if isinstance(patch, RenameChange):
-                continue
-
-            if isinstance(patch, TextFileDeletionChange):
-                continue
-
-            if isinstance(patch, GitlinkChange):
-                exit_with_error(_("Discarding submodule pointer changes to a batch is not supported yet."))
-
-            if isinstance(patch, BinaryFileChange):
-                continue
-
-            file_path = patch.new_path if patch.new_path != "/dev/null" else patch.old_path
-            files_with_text_patches.add(file_path)
-
-            patch_hash = compute_stable_hunk_hash_from_lines(patch.lines)
-            if patch_hash in blocked_hashes:
-                continue
-
-            hunk_lines = build_line_changes_from_patch_lines(
-                patch.lines,
-                annotator=annotate_with_batch_source,
-            )
-            discard_input = inputs_by_file.get(file_path)
-            if discard_input is None:
-                discard_input = _TextFileDiscardInput(
-                    file_path=file_path,
-                    file_mode=detect_file_mode_from_root(repo_root, file_path),
-                    all_lines_to_batch=[],
-                    patches_to_discard=[],
-                )
-                inputs_by_file[file_path] = discard_input
-            discard_input.all_lines_to_batch.extend(hunk_lines.lines)
-            discard_input.patches_to_discard.append(
-                _PreparedPatchDiscard(
-                    patch_lines=patch_stack.enter_context(
-                        LineBuffer.from_chunks(patch.lines)
-                    ),
-                    patch_hash=patch_hash,
-                )
-            )
-            blocked_hashes.add(patch_hash)
-
-    return _CollectedTextFileDiscards(
-        inputs_by_file=inputs_by_file,
-        files_with_text_patches=files_with_text_patches,
-    )
-
-
-def _run_reverse_apply_for_prepared_discards(
-    prepared_discards: list[_PreparedTextFileDiscardToBatch],
-    *,
-    check_only: bool = False,
-) -> None:
-    def patch_chunks():
-        for prepared in prepared_discards:
-            for patch in prepared.patches_to_discard:
-                yield from patch.patch_lines
-
-    apply_result = git_apply_to_worktree(
-        patch_chunks(),
-        reverse=True,
-        unidiff_zero=True,
-        check_only=check_only,
-        check=False,
-    )
-
-    if apply_result.returncode != 0:
-        exit_with_error(_("Failed to discard changes from file: {err}").format(err=apply_result.stderr))
-
-
-def _discard_prepared_text_files_to_batch(
-    batch_name: str,
-    prepared_discards: list[_PreparedTextFileDiscardToBatch],
-) -> DiscardFilesToBatchResult:
-    """Publish prepared text file discards once, then update the worktree."""
-    if not prepared_discards:
-        return DiscardFilesToBatchResult(discarded_hunks=0, discarded_files=[])
-
-    snapshot_files_if_untracked([prepared.file_path for prepared in prepared_discards])
-
-    _run_reverse_apply_for_prepared_discards(prepared_discards, check_only=True)
-    add_files_to_batch(
-        batch_name,
-        [
-            BatchFileUpdate(
-                file_path=prepared.file_path,
-                ownership=prepared.ownership,
-                file_mode=prepared.file_mode,
-                batch_source_commit=prepared.batch_source_commit,
-            )
-            for prepared in prepared_discards
-        ],
-    )
-    _run_reverse_apply_for_prepared_discards(prepared_discards)
-
-    repo_root = get_git_repository_root_path()
-    for prepared in prepared_discards:
-        full_path = repo_root / prepared.file_path
-        if not full_path.exists():
-            git_remove_paths([prepared.file_path], cached=True, quiet=True, check=False)
-
-    hunk_hashes = [
-        patch.patch_hash
-        for prepared in prepared_discards
-        for patch in prepared.patches_to_discard
-    ]
-    record_hunks_discarded(hunk_hashes)
-
-    return DiscardFilesToBatchResult(
-        discarded_hunks=len(hunk_hashes),
-        discarded_files=[
-            prepared.file_path
-            for prepared in prepared_discards
-            if prepared.patches_to_discard
-        ],
-    )
-
-
-def command_discard_files_to_batch(
-    batch_name: str,
-    files: list[str],
-    *,
-    quiet: bool = False,
-    advance: bool = True,
-    auto_advance: bool | None = None,
-) -> DiscardFilesToBatchResult:
-    """Save resolved text files to a batch with one batch publication."""
-    require_git_repository()
-    ensure_state_directory_exists()
-
-    if not files:
-        return DiscardFilesToBatchResult(discarded_hunks=0, discarded_files=[])
-    auto_add_untracked_files(files)
-    if not batch_exists(batch_name):
-        create_batch(batch_name, "Auto-created")
-
-    blocklist_path = get_block_list_file_path()
-    blocked_hashes = read_text_file_line_set(blocklist_path)
-    prepared_discards: list[_PreparedTextFileDiscardToBatch] = []
-    ownership_stack = ExitStack()
-    patch_stack = ExitStack()
-    total_hunks = 0
-    discarded_files: list[str] = []
-
-    def flush_prepared() -> None:
-        nonlocal metadata, total_hunks
-        nonlocal discarded_files, ownership_stack, prepared_discards
-        with ownership_stack:
-            result = _discard_prepared_text_files_to_batch(batch_name, prepared_discards)
-        if result.discarded_hunks:
-            total_hunks += result.discarded_hunks
-            discarded_files.extend(result.discarded_files)
-            metadata = read_batch_metadata(batch_name)
-        prepared_discards = []
-        ownership_stack = ExitStack()
-
-    try:
-        metadata = read_batch_metadata(batch_name)
-        collected_discards = _collect_text_file_discard_inputs(
-            files,
-            blocked_hashes=blocked_hashes,
-            patch_stack=patch_stack,
-        )
-
-        for file_path in files:
-            log_journal("discard_file_to_batch_start", batch_name=batch_name, file_path=file_path, quiet=quiet)
-            discard_input = collected_discards.inputs_by_file.get(file_path)
-            if discard_input is None and file_path in collected_discards.files_with_text_patches:
-                continue
-
-            prepared = _prepare_text_file_discard_to_batch(
-                batch_name,
-                discard_input,
-                metadata=metadata,
-                ownership_stack=ownership_stack,
-            ) if discard_input is not None else None
-            if prepared is None:
-                flush_prepared()
-                discarded_hunks = command_discard_to_batch(
-                    batch_name,
-                    file=file_path,
-                    quiet=True,
-                    advance=False,
-                    auto_advance=auto_advance,
-                )
-                if discarded_hunks > 0:
-                    total_hunks += discarded_hunks
-                    discarded_files.append(file_path)
-                    metadata = read_batch_metadata(batch_name)
-                    blocked_hashes = read_text_file_line_set(blocklist_path)
-                continue
-
-            prepared_discards.append(prepared)
-            log_journal("discard_file_to_batch_end", batch_name=batch_name, file_path=file_path)
-
-        flush_prepared()
-    finally:
-        ownership_stack.close()
-        patch_stack.close()
-
-    if advance:
-        finish_selected_change_action(quiet=quiet, auto_advance=auto_advance)
-
-    return DiscardFilesToBatchResult(
-        discarded_hunks=total_hunks,
-        discarded_files=discarded_files,
-    )
 
 
 def _command_discard_file_to_batch(

--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -139,6 +139,7 @@ from ..utils.paths import (
 )
 from .selection import replacement_selection
 from .selection import discard_file_selection as _discard_file_selection
+from .selection import discard_line_selection as _discard_line_selection
 from .selection.selected_hunk_refresh import (
     recalculate_selected_hunk_for_command,
     refresh_selected_hunk_after_line_action,
@@ -676,52 +677,19 @@ def command_discard_line(
     if file is not None:
         operation_parts.extend(["--file", file])
     with undo_checkpoint(" ".join(operation_parts)):
-        if file is None:
-            require_selected_hunk()
-            line_changes = load_line_changes_from_state()
-        else:
-            if file == "":
-                target_file = get_selected_change_file_path()
-                if target_file is None:
-                    exit_with_error(_("No selected hunk. Run 'show' first or specify file path."))
-            else:
-                target_file = file
-
-            line_changes = _discard_file_selection.load_explicit_file_selection(target_file)
-
-        requested_ids = parse_line_selection(line_id_specification)
-        require_line_selection_in_view(
-            line_changes,
-            set(requested_ids),
-            line_id_specification=line_id_specification,
+        file_path = _discard_line_selection.discard_worktree_line_selection(
+            line_id_specification,
+            file=file,
         )
-
-        working_file_path = get_git_repository_root_path() / line_changes.path
-        if not os.path.lexists(working_file_path):
-            exit_with_error(_("File not found in working tree: {file}").format(file=line_changes.path))
-
-        with load_working_tree_file_as_buffer(line_changes.path) as working_lines:
-            target_working_buffer = build_target_working_tree_buffer_from_lines(
-                line_changes,
-                set(requested_ids),
-                working_lines,
-                working_has_trailing_newline=buffer_ends_with_lf(working_lines),
-            )
-
-        # Write back to working tree
-        with target_working_buffer:
-            write_buffer_to_path(working_file_path, target_working_buffer)
-
-        # After modifying working tree, recalculate hunk for the SAME file
         print(
             _("✓ Discarded line(s): {lines} from {file}").format(
                 lines=line_id_specification,
-                file=line_changes.path,
+                file=file_path,
             ),
             file=sys.stderr,
         )
         refresh_selected_hunk_after_line_action(
-            line_changes.path,
+            file_path,
             auto_advance=auto_advance,
         )
         finish_review_scoped_line_action(review_state)

--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -128,6 +128,7 @@ from .selection import discard_file_selection as _discard_file_selection
 from .selection import discard_line_selection as _discard_line_selection
 from .selection import discard_line_replacement as _discard_line_replacement
 from .selection import batch_line_selection as _batch_line_selection
+from .selection import batch_line_updates as _batch_line_updates
 from .selection.selected_hunk_refresh import (
     recalculate_selected_hunk_for_command,
     refresh_selected_hunk_after_line_action,
@@ -1649,51 +1650,19 @@ def _command_discard_file_lines_to_batch(
             print(_("No lines match the specified IDs in file '{file}'.").format(file=file_path), file=sys.stderr)
         return 0
 
-    # Auto-create batch if it doesn't exist
-    if not batch_exists(batch_name):
-        create_batch(batch_name, "Auto-created")
-
-    file_mode = detect_file_mode(file_path)
-
-    # Prepare batch ownership update (handles stale source, translation, merge)
-
-    metadata = read_batch_metadata(batch_name)
-    file_metadata = metadata.get("files", {}).get(file_path)
     replacement_line_runs = (
         _discard_line_replacement.derive_live_replacement_line_runs(file_path)
     )
 
-    with ExitStack() as ownership_stack:
-        try:
-            update = ownership_stack.enter_context(
-                acquire_batch_ownership_update_for_selection(
-                    batch_name=batch_name,
-                    file_path=file_path,
-                    file_metadata=file_metadata,
-                    selected_lines=selection.selected_lines,
-                    hunk_lines=line_changes.lines,
-                    replacement_line_runs=replacement_line_runs,
-                )
-            )
-        except ValueError as e:
-            exit_with_error(
-                _("Cannot discard lines to batch: batch source is stale and remapping failed.\n"
-                  "File: {file}\n"
-                  "Batch: {batch}\n"
-                  "Error: {error}").format(file=file_path, batch=batch_name, error=str(e))
-            )
-
-        # Snapshot file before modifying
-        snapshot_file_if_untracked(file_path)
-
-        # Save to batch
-        add_file_to_batch(
-            batch_name,
-            file_path,
-            update.ownership_after,
-            file_mode,
-            batch_source_commit=update.batch_source_commit,
-        )
+    _batch_line_updates.add_selected_lines_to_batch(
+        batch_name=batch_name,
+        file_path=file_path,
+        selected_lines=selection.selected_lines,
+        stale_source_action=_("Cannot discard lines to batch"),
+        hunk_lines=line_changes.lines,
+        replacement_line_runs=replacement_line_runs,
+        snapshot_untracked=True,
+    )
 
     # Now discard selected lines from working tree
     working_file_path = get_git_repository_root_path() / file_path
@@ -1746,55 +1715,26 @@ def _command_discard_lines_to_batch(
     if not selection.selected_lines:
         exit_with_error(_("No matching lines found for selection: {ids}").format(ids=line_id_specification))
 
-    # Auto-create batch if it doesn't exist
-    if not batch_exists(batch_name):
-        create_batch(batch_name, "Auto-created")
-
-    # Prepare batch ownership update (handles stale source, translation, merge)
-
-    metadata = read_batch_metadata(batch_name)
-    file_metadata = metadata.get("files", {}).get(line_changes.path)
     replacement_line_runs = (
         _discard_line_replacement.derive_live_replacement_line_runs(
             line_changes.path
         )
     )
 
-    file_mode = detect_file_mode(line_changes.path)
-
-    with ExitStack() as ownership_stack:
-        try:
-            update = ownership_stack.enter_context(
-                acquire_batch_ownership_update_for_selection(
-                    batch_name=batch_name,
-                    file_path=line_changes.path,
-                    file_metadata=file_metadata,
-                    selected_lines=selection.selected_lines,
-                    hunk_lines=line_changes.lines,
-                    replacement_line_runs=replacement_line_runs,
-                )
-            )
-        except ValueError as e:
-            exit_with_error(
-                _("Cannot discard lines to batch: batch source is stale and remapping failed.\n"
-                  "File: {file}\n"
-                  "Batch: {batch}\n"
-                  "Error: {error}").format(file=line_changes.path, batch=batch_name, error=str(e))
-            )
-
-        # add_file_to_batch creates the batch source commit from this snapshot.
-        snapshot_file_if_untracked(line_changes.path)
-
-        log_journal("discard_lines_to_batch_before_add", batch_name=batch_name, file_path=line_changes.path)
-
-        # Save to batch using batch source model
-        add_file_to_batch(
-            batch_name,
-            line_changes.path,
-            update.ownership_after,
-            file_mode,
-            batch_source_commit=update.batch_source_commit,
-        )
+    _batch_line_updates.add_selected_lines_to_batch(
+        batch_name=batch_name,
+        file_path=line_changes.path,
+        selected_lines=selection.selected_lines,
+        stale_source_action=_("Cannot discard lines to batch"),
+        hunk_lines=line_changes.lines,
+        replacement_line_runs=replacement_line_runs,
+        snapshot_untracked=True,
+        before_add=lambda: log_journal(
+            "discard_lines_to_batch_before_add",
+            batch_name=batch_name,
+            file_path=line_changes.path,
+        ),
+    )
 
     log_journal("discard_lines_to_batch_after_add", batch_name=batch_name, file_path=line_changes.path)
 

--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -10,13 +10,9 @@ from contextlib import ExitStack
 
 from ..batch.operations import create_batch
 from ..batch.storage import (
-    add_binary_file_to_batch,
     add_file_to_batch,
 )
 from ..batch.display import annotate_with_batch_source
-from ..batch.ownership import (
-    BatchOwnership,
-)
 from ..core.replacement import (
     ReplacementPayload,
     coerce_replacement_payload,
@@ -38,8 +34,6 @@ from ..core.hashing import (
     compute_text_file_deletion_hash,
 )
 from ..core.models import BinaryFileChange, GitlinkChange, RenameChange, TextFileDeletionChange
-from ..core.text_lifecycle import TextFileChangeType
-from ..data.text_lifecycle_detection import detect_empty_text_lifecycle_change
 from ..data.hunk_tracking import (
     fetch_next_change,
 )
@@ -59,7 +53,6 @@ from ..data.selected_change.clear_reasons import (
     refuse_bare_action_after_file_list,
 )
 from ..data.file_change_display import (
-    render_binary_file_change,
     render_gitlink_change,
     render_rename_change,
     render_text_deletion_change,
@@ -119,6 +112,11 @@ from .selection import discard_line_selection as _discard_line_selection
 from .selection import discard_line_replacement as _discard_line_replacement
 from .selection import batch_line_selection as _batch_line_selection
 from .selection import batch_line_updates as _batch_line_updates
+from .file_scope.discard_file_to_batch import (
+    discard_binary_to_batch,
+    discard_file_to_batch,
+    discard_text_deletion_to_batch,
+)
 from .selection.selected_hunk_refresh import (
     recalculate_selected_hunk_for_command,
     refresh_selected_hunk_after_line_action,
@@ -712,7 +710,7 @@ def command_discard_to_batch(
         ):
             selected_change = load_selected_change()
             if isinstance(selected_change, BinaryFileChange):
-                saved_hunks = _command_discard_binary_to_batch(
+                saved_hunks = discard_binary_to_batch(
                     batch_name,
                     selected_change,
                     quiet=quiet,
@@ -732,7 +730,7 @@ def command_discard_to_batch(
         ):
             selected_change = load_selected_change()
             if isinstance(selected_change, TextFileDeletionChange):
-                saved_hunks = _command_discard_text_deletion_to_batch(
+                saved_hunks = discard_text_deletion_to_batch(
                     batch_name,
                     selected_change,
                     quiet=quiet,
@@ -759,7 +757,7 @@ def command_discard_to_batch(
 
             if line_ids is None:
                 # --file without --line: discard entire file
-                saved_hunks = _command_discard_file_to_batch(
+                saved_hunks = discard_file_to_batch(
                     batch_name,
                     target_file,
                     quiet=quiet,
@@ -924,297 +922,6 @@ def _command_discard_lines_to_batch_as(
         replacement.file_path,
         auto_advance=auto_advance,
     )
-
-
-def _discard_binary_change_from_working_tree(binary_change: BinaryFileChange) -> None:
-    """Discard one live binary change from the working tree."""
-    file_path = binary_change.new_path if binary_change.new_path != "/dev/null" else binary_change.old_path
-    absolute_path = get_git_repository_root_path() / file_path
-
-    if binary_change.is_new_file():
-        if absolute_path.exists():
-            absolute_path.unlink()
-        git_remove_paths([file_path], cached=True, quiet=True, check=False)
-        return
-
-    result = git_checkout_paths("HEAD", [file_path], check=False)
-    if result.returncode != 0:
-        exit_with_error(_("Failed to restore binary file: {error}").format(error=result.stderr))
-
-
-def _command_discard_binary_to_batch(
-    batch_name: str,
-    binary_change: BinaryFileChange,
-    *,
-    quiet: bool = False,
-    advance: bool = True,
-    auto_advance: bool | None = None,
-) -> int:
-    """Save one binary change to a batch, then discard it from the working tree."""
-    file_path = binary_change.new_path if binary_change.new_path != "/dev/null" else binary_change.old_path
-    patch_hash = compute_binary_file_hash(binary_change)
-
-    snapshot_file_if_untracked(file_path)
-    add_binary_file_to_batch(
-        batch_name,
-        binary_change,
-        file_mode=detect_file_mode(file_path),
-    )
-    _discard_binary_change_from_working_tree(binary_change)
-
-    append_lines_to_file(get_block_list_file_path(), [patch_hash])
-    record_hunk_discarded(patch_hash)
-
-    if not quiet:
-        print(
-            _("Discarded binary file '{file}' to batch '{batch}'").format(
-                file=file_path,
-                batch=batch_name,
-            ),
-            file=sys.stderr,
-        )
-
-    if advance:
-        finish_selected_change_action(quiet=quiet, auto_advance=auto_advance)
-    return 1
-
-
-def _command_discard_text_deletion_to_batch(
-    batch_name: str,
-    deletion_change: TextFileDeletionChange,
-    *,
-    quiet: bool = False,
-    advance: bool = True,
-    auto_advance: bool | None = None,
-) -> int:
-    """Save one whole-text-file deletion to a batch, then restore it locally."""
-    file_path = deletion_change.path()
-    patch_hash = compute_text_file_deletion_hash(deletion_change)
-
-    snapshot_file_if_untracked(file_path)
-    add_file_to_batch(
-        batch_name,
-        file_path,
-        BatchOwnership([], []),
-        detect_file_mode(file_path),
-        change_type=TextFileChangeType.DELETED.value,
-    )
-    discard_text_deletion_change(deletion_change)
-
-    append_lines_to_file(get_block_list_file_path(), [patch_hash])
-    record_hunk_discarded(patch_hash)
-
-    if not quiet:
-        print(
-            _("Discarded text file deletion '{file}' to batch '{batch}'").format(
-                file=file_path,
-                batch=batch_name,
-            ),
-            file=sys.stderr,
-        )
-
-    if advance:
-        finish_selected_change_action(quiet=quiet, auto_advance=auto_advance)
-    return 1
-
-
-def _command_discard_file_to_batch(
-    batch_name: str,
-    file_path: str,
-    *,
-    quiet: bool = False,
-    advance: bool = True,
-    auto_advance: bool | None = None,
-) -> int:
-    """Discard entire file to batch (internal helper for file-scoped operations)."""
-    auto_add_untracked_files([file_path])
-
-    log_journal("discard_file_to_batch_start", batch_name=batch_name, file_path=file_path, quiet=quiet)
-
-    # Auto-create batch if it doesn't exist
-    if not batch_exists(batch_name):
-        create_batch(batch_name, "Auto-created")
-
-    deletion_change = render_text_deletion_change(file_path)
-    if deletion_change is not None:
-        return _command_discard_text_deletion_to_batch(
-            batch_name,
-            deletion_change,
-            quiet=quiet,
-            advance=advance,
-            auto_advance=auto_advance,
-        )
-
-    binary_change = render_binary_file_change(file_path)
-    if binary_change is not None:
-        return _command_discard_binary_to_batch(
-            batch_name,
-            binary_change,
-            quiet=quiet,
-            advance=advance,
-            auto_advance=auto_advance,
-        )
-    if render_gitlink_change(file_path) is not None:
-        exit_with_error(_("Discarding submodule pointer changes to a batch is not supported yet."))
-
-    # Load blocklist
-    blocklist_path = get_block_list_file_path()
-    blocked_hashes = read_text_file_line_set(blocklist_path)
-
-    # Detect file mode
-    file_mode = detect_file_mode(file_path)
-
-    with ExitStack() as patch_stack:
-        # Collect ALL hunks from this file (live working tree state)
-        all_lines_to_batch = []
-        patches_to_discard = []
-
-        with acquire_unified_diff(
-            stream_live_git_diff(
-                base="HEAD",
-                context_lines=get_context_lines(),
-                paths=[file_path],
-            )
-        ) as patches:
-            for patch in patches:
-                if isinstance(patch, RenameChange):
-                    continue
-
-                if isinstance(patch, TextFileDeletionChange):
-                    continue
-
-                if isinstance(patch, GitlinkChange):
-                    exit_with_error(_("Discarding submodule pointer changes to a batch is not supported yet."))
-                if isinstance(patch, BinaryFileChange):
-                    continue
-
-                patch_hash = compute_stable_hunk_hash_from_lines(patch.lines)
-
-                if patch_hash in blocked_hashes:
-                    continue
-
-                # Parse hunk to get lines
-                hunk_lines = build_line_changes_from_patch_lines(
-                    patch.lines,
-                    annotator=annotate_with_batch_source,
-                )
-                all_lines_to_batch.extend(hunk_lines.lines)
-                patches_to_discard.append((
-                    patch_stack.enter_context(LineBuffer.from_chunks(patch.lines)),
-                    patch_hash,
-                ))
-
-        if not all_lines_to_batch:
-            # Special case: empty text lifecycle changes have no hunk body.
-            repo_root = get_git_repository_root_path()
-            full_path = repo_root / file_path
-            lifecycle_change_type = detect_empty_text_lifecycle_change(file_path)
-            if lifecycle_change_type is not None:
-                snapshot_file_if_untracked(file_path)
-                add_file_to_batch(
-                    batch_name,
-                    file_path,
-                    BatchOwnership([], []),
-                    file_mode,
-                    change_type=lifecycle_change_type,
-                )
-
-                if lifecycle_change_type == TextFileChangeType.ADDED:
-                    # Delete from working tree
-                    full_path.unlink()
-
-                    # Remove from index if present (from intent-to-add)
-                    git_remove_paths([file_path], cached=True, quiet=True, check=False)
-                else:
-                    git_checkout_paths("HEAD", [file_path], check=False)
-
-                if not quiet:
-                    print(_("Discarded file '{file}' to batch '{batch}'").format(file=file_path, batch=batch_name), file=sys.stderr)
-
-                log_journal("discard_file_to_batch_end", batch_name=batch_name, file_path=file_path)
-                return 1
-
-            if not quiet:
-                print(_("No changes in file '{file}' to discard.").format(file=file_path), file=sys.stderr)
-            return 0
-
-        # Prepare batch ownership update (handles stale source, translation, merge)
-
-        metadata = read_batch_metadata(batch_name)
-        file_metadata = metadata.get("files", {}).get(file_path)
-
-        with ExitStack() as ownership_stack:
-            try:
-                update = ownership_stack.enter_context(
-                    acquire_batch_ownership_update_for_selection(
-                        batch_name=batch_name,
-                        file_path=file_path,
-                        file_metadata=file_metadata,
-                        selected_lines=all_lines_to_batch,
-                    )
-                )
-            except ValueError as e:
-                exit_with_error(
-                    _("Cannot discard file to batch: batch source is stale and remapping failed.\n"
-                      "File: {file}\n"
-                      "Batch: {batch}\n"
-                      "Error: {error}").format(file=file_path, batch=batch_name, error=str(e))
-                )
-
-            # Snapshot file before modifying
-            snapshot_file_if_untracked(file_path)
-
-            # Save to batch
-            add_file_to_batch(
-                batch_name,
-                file_path,
-                update.ownership_after,
-                file_mode,
-                batch_source_commit=update.batch_source_commit,
-            )
-
-        # Record hunks as discarded for progress tracking
-        for _patch_lines, patch_hash in patches_to_discard:
-            record_hunk_discarded(patch_hash)
-
-        # Discard from working tree (reverse patches)
-        for patch_lines_item, patch_hash in patches_to_discard:
-            log_journal(
-                "discard_file_to_batch_before_git_apply",
-                batch_name=batch_name,
-                patch_hash=patch_hash,
-                file_path=file_path,
-                patch_line_count=len(patch_lines_item),
-            )
-
-            apply_result = git_apply_to_worktree(
-                patch_lines_item,
-                reverse=True,
-                unidiff_zero=True,
-                check=False,
-            )
-
-            if apply_result.returncode != 0:
-                exit_with_error(_("Failed to discard changes from file: {err}").format(err=apply_result.stderr))
-
-            log_journal("discard_file_to_batch_after_git_apply", batch_name=batch_name, patch_hash=patch_hash, exit_code=apply_result.returncode)
-
-        # If file was deleted from working tree, remove from index too
-        repo_root = get_git_repository_root_path()
-        full_path = repo_root / file_path
-        if not full_path.exists():
-            # File was deleted by git apply --reverse, remove from index
-            git_remove_paths([file_path], cached=True, quiet=True, check=False)
-
-        if not quiet:
-            print(_("Discarded file '{file}' to batch '{batch}'").format(file=file_path, batch=batch_name), file=sys.stderr)
-
-        log_journal("discard_file_to_batch_end", batch_name=batch_name, file_path=file_path)
-
-        # Show next hunk
-        if advance:
-            finish_selected_change_action(quiet=quiet, auto_advance=auto_advance)
-        return len(patches_to_discard)
 
 
 def _command_discard_file_lines_to_batch(
@@ -1391,14 +1098,14 @@ def _command_discard_hunk_to_batch(
     if isinstance(selected_item, GitlinkChange):
         exit_with_error(_("Discarding submodule pointer changes to a batch is not supported yet."))
     if isinstance(selected_item, BinaryFileChange):
-        return _command_discard_binary_to_batch(
+        return discard_binary_to_batch(
             batch_name,
             selected_item,
             quiet=quiet,
             auto_advance=auto_advance,
         )
     if isinstance(selected_item, TextFileDeletionChange):
-        return _command_discard_text_deletion_to_batch(
+        return discard_text_deletion_to_batch(
             batch_name,
             selected_item,
             quiet=quiet,

--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -29,7 +29,6 @@ from ..core.replacement import (
     coerce_replacement_payload,
 )
 from ..batch.query import read_batch_metadata
-from ..batch.selection import require_line_selection_in_view
 from ..batch.source_refresh import acquire_batch_ownership_update_for_selection
 from ..batch.source_refresh import refresh_selected_lines_against_source_lines
 from ..batch.validation import batch_exists
@@ -46,7 +45,6 @@ from ..core.hashing import (
     compute_stable_hunk_hash_from_lines,
     compute_text_file_deletion_hash,
 )
-from ..core.line_selection import parse_line_selection
 from ..core.models import BinaryFileChange, GitlinkChange, RenameChange, TextFileDeletionChange
 from ..core.text_lifecycle import TextFileChangeType
 from ..data.text_lifecycle_detection import detect_empty_text_lifecycle_change
@@ -129,6 +127,7 @@ from ..utils.paths import (
 from .selection import discard_file_selection as _discard_file_selection
 from .selection import discard_line_selection as _discard_line_selection
 from .selection import discard_line_replacement as _discard_line_replacement
+from .selection import batch_line_selection as _batch_line_selection
 from .selection.selected_hunk_refresh import (
     recalculate_selected_hunk_for_command,
     refresh_selected_hunk_after_line_action,
@@ -1640,15 +1639,12 @@ def _command_discard_file_lines_to_batch(
     line_changes = annotate_with_batch_source(file_path, cached_lines)
 
     # Parse line IDs and filter to selected lines
-    requested_ids = set(parse_line_selection(line_id_specification))
-    require_line_selection_in_view(
+    selection = _batch_line_selection.select_lines_for_batch_action(
         line_changes,
-        requested_ids,
-        line_id_specification=line_id_specification,
+        line_id_specification,
     )
-    selected_lines = [line for line in line_changes.lines if line.id in requested_ids]
 
-    if not selected_lines:
+    if not selection.selected_lines:
         if not quiet:
             print(_("No lines match the specified IDs in file '{file}'.").format(file=file_path), file=sys.stderr)
         return 0
@@ -1674,7 +1670,7 @@ def _command_discard_file_lines_to_batch(
                     batch_name=batch_name,
                     file_path=file_path,
                     file_metadata=file_metadata,
-                    selected_lines=selected_lines,
+                    selected_lines=selection.selected_lines,
                     hunk_lines=line_changes.lines,
                     replacement_line_runs=replacement_line_runs,
                 )
@@ -1707,7 +1703,7 @@ def _command_discard_file_lines_to_batch(
     with load_working_tree_file_as_buffer(file_path) as working_lines:
         target_working_buffer = build_target_working_tree_buffer_from_lines(
             line_changes,
-            requested_ids,
+            selection.requested_ids,
             working_lines,
             working_has_trailing_newline=buffer_ends_with_lf(working_lines),
         )
@@ -1740,17 +1736,14 @@ def _command_discard_lines_to_batch(
 
     require_selected_hunk()
 
-    requested_ids = set(parse_line_selection(line_id_specification))
     line_changes = load_line_changes_from_state()
-    require_line_selection_in_view(
+    selection = _batch_line_selection.select_lines_for_batch_action(
         line_changes,
-        requested_ids,
-        line_id_specification=line_id_specification,
+        line_id_specification,
     )
 
     # Filter to requested display line IDs
-    selected_lines = [line for line in line_changes.lines if line.id in requested_ids]
-    if not selected_lines:
+    if not selection.selected_lines:
         exit_with_error(_("No matching lines found for selection: {ids}").format(ids=line_id_specification))
 
     # Auto-create batch if it doesn't exist
@@ -1776,7 +1769,7 @@ def _command_discard_lines_to_batch(
                     batch_name=batch_name,
                     file_path=line_changes.path,
                     file_metadata=file_metadata,
-                    selected_lines=selected_lines,
+                    selected_lines=selection.selected_lines,
                     hunk_lines=line_changes.lines,
                     replacement_line_runs=replacement_line_runs,
                 )
@@ -1813,7 +1806,7 @@ def _command_discard_lines_to_batch(
     with load_working_tree_file_as_buffer(line_changes.path) as working_lines:
         target_working_buffer = build_target_working_tree_buffer_from_lines(
             line_changes,
-            requested_ids,
+            selection.requested_ids,
             working_lines,
             working_has_trailing_newline=buffer_ends_with_lf(working_lines),
         )

--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -16,14 +16,10 @@ from ..batch.storage import (
     add_file_to_batch,
     add_files_to_batch,
 )
-from ..batch.display import (
-    annotate_with_batch_source,
-    annotate_with_batch_source_working_lines,
-)
+from ..batch.display import annotate_with_batch_source
 from ..batch.ownership import (
     BatchOwnership,
     remap_batch_ownership_with_lineage,
-    derive_replacement_line_runs_from_lines,
     merge_batch_ownership,
     translate_lines_to_batch_ownership,
 )
@@ -78,10 +74,7 @@ from ..data.file_change_display import (
     render_rename_change,
     render_text_deletion_change,
 )
-from ..data.file_hunk_display import (
-    build_file_hunk_from_buffer,
-    cache_unstaged_file_as_single_hunk,
-)
+from ..data.file_hunk_display import cache_unstaged_file_as_single_hunk
 from ..data.file_modes import detect_file_mode, detect_file_mode_from_root
 from ..data.file_review.records import FileReviewAction, ReviewSource
 from ..data.file_review.state import (
@@ -106,15 +99,11 @@ from ..core.buffer import (
 )
 from ..utils.repository_buffers import (
     load_git_object_as_buffer,
-    load_git_object_as_buffer_or_empty,
     load_working_tree_file_as_buffer,
 )
 from ..exceptions import CommandError, exit_with_error, NoMoreHunks
 from ..i18n import _, ngettext
-from ..staging.operations import (
-    build_target_working_tree_buffer_from_lines,
-    build_target_working_tree_buffer_with_replaced_lines,
-)
+from ..staging.operations import build_target_working_tree_buffer_from_lines
 from ..utils.file_io import (
     append_lines_to_file,
     path_is_empty,
@@ -137,9 +126,9 @@ from ..utils.paths import (
     get_selected_hunk_hash_file_path,
     get_selected_hunk_patch_file_path,
 )
-from .selection import replacement_selection
 from .selection import discard_file_selection as _discard_file_selection
 from .selection import discard_line_selection as _discard_line_selection
+from .selection import discard_line_replacement as _discard_line_replacement
 from .selection.selected_hunk_refresh import (
     recalculate_selected_hunk_for_command,
     refresh_selected_hunk_after_line_action,
@@ -928,18 +917,6 @@ def command_discard_line_as_to_batch(
         finish_review_scoped_line_action(review_state, file_path=target_file)
 
 
-def _derive_live_replacement_line_runs(file_path: str):
-    """Derive file-level replacement runs for the current live file state."""
-    with (
-        load_git_object_as_buffer_or_empty(f"HEAD:{file_path}") as baseline_lines,
-        load_working_tree_file_as_buffer(file_path) as working_lines,
-    ):
-        return derive_replacement_line_runs_from_lines(
-            old_file_lines=baseline_lines,
-            new_file_lines=working_lines,
-        )
-
-
 def _command_discard_lines_to_batch_as(
     batch_name: str,
     line_id_specification: str,
@@ -950,66 +927,19 @@ def _command_discard_lines_to_batch_as(
     auto_advance: bool | None = None,
 ) -> None:
     """Persist replacement text to batch and discard original selected lines."""
-    line_changes = load_line_changes_from_state()
-    requested_ids = set(parse_line_selection(line_id_specification))
-    require_line_selection_in_view(
-        line_changes,
-        requested_ids,
-        line_id_specification=line_id_specification,
-    )
-    effective_ids = replacement_selection.expand_replacement_selection_ids(
-        line_changes,
-        requested_ids,
-    )
-
-    if not batch_exists(batch_name):
-        create_batch(batch_name, "Auto-created")
-
-    selected_lines = [line for line in line_changes.lines if line.id in effective_ids]
-    if not selected_lines:
-        exit_with_error(_("No matching lines found for selection: {ids}").format(ids=line_id_specification))
-
-    working_file_path = get_git_repository_root_path() / line_changes.path
-    if not os.path.lexists(working_file_path):
-        exit_with_error(_("File not found in working tree: {file}").format(file=line_changes.path))
-
-    replacement_payload = coerce_replacement_payload(replacement_text)
-    try:
-        with load_working_tree_file_as_buffer(line_changes.path) as working_lines:
-            rewritten_working_buffer = (
-                build_target_working_tree_buffer_with_replaced_lines(
-                    line_changes,
-                    effective_ids,
-                    replacement_payload,
-                    working_lines,
-                    working_has_trailing_newline=buffer_ends_with_lf(working_lines),
-                    trim_unchanged_edge_anchors=not no_edge_overlap,
-                )
-            )
-    except ValueError as e:
-        exit_with_error(str(e))
-
     target_working_buffer: LineBuffer | None = None
+    replacement = None
     try:
-        with rewritten_working_buffer as rewritten_working_lines:
-            rewritten_cached_lines = build_file_hunk_from_buffer(
-                line_changes.path,
-                rewritten_working_lines,
-            )
-            if rewritten_cached_lines is None:
-                exit_with_error(_("No changes in file '{file}'.").format(file=line_changes.path))
-            rewritten_line_changes = annotate_with_batch_source_working_lines(
-                line_changes.path,
-                rewritten_cached_lines,
-                rewritten_working_lines,
-            )
-            rewritten_selected_lines = _select_rewritten_replacement_lines(
-                selected_lines,
-                rewritten_line_changes,
-            )
+        with _discard_line_replacement.prepare_discard_line_replacement_selection(
+            line_id_specification,
+            replacement_text,
+            no_edge_overlap=no_edge_overlap,
+        ) as replacement:
+            if not batch_exists(batch_name):
+                create_batch(batch_name, "Auto-created")
 
             metadata = read_batch_metadata(batch_name)
-            file_metadata = metadata.get("files", {}).get(line_changes.path)
+            file_metadata = metadata.get("files", {}).get(replacement.file_path)
             batch_source_commit = None
 
             with ExitStack() as ownership_stack:
@@ -1018,9 +948,9 @@ def _command_discard_lines_to_batch_as(
                         update = ownership_stack.enter_context(
                             acquire_batch_ownership_update_for_selection(
                                 batch_name=batch_name,
-                                file_path=line_changes.path,
+                                file_path=replacement.file_path,
                                 file_metadata=None,
-                                selected_lines=rewritten_selected_lines,
+                                selected_lines=replacement.rewritten_selected_lines,
                             )
                         )
                         ownership = update.ownership_after
@@ -1031,12 +961,12 @@ def _command_discard_lines_to_batch_as(
                             BatchOwnership.acquire_for_metadata_dict(file_metadata)
                         )
                         old_source_buffer = load_git_object_as_buffer(
-                            f"{current_batch_source}:{line_changes.path}"
+                            f"{current_batch_source}:{replacement.file_path}"
                         )
                         if old_source_buffer is None:
                             exit_with_error(
                                 _("Cannot discard lines to batch: failed to read batch source for '{file}'.").format(
-                                    file=line_changes.path
+                                    file=replacement.file_path
                                 )
                             )
 
@@ -1044,7 +974,7 @@ def _command_discard_lines_to_batch_as(
                             old_source_buffer as old_source_lines,
                             advance_source_lines_preserving_existing_presence(
                                 old_lines=old_source_lines,
-                                working_lines=rewritten_working_lines,
+                                working_lines=replacement.rewritten_working_lines,
                                 ownership=existing_ownership,
                             ) as source_with_provenance,
                         ):
@@ -1053,7 +983,7 @@ def _command_discard_lines_to_batch_as(
                                 lineage=source_with_provenance.lineage,
                             )
                             refreshed_selected_lines = refresh_selected_lines_against_source_lines(
-                                rewritten_selected_lines,
+                                replacement.rewritten_selected_lines,
                                 source_lines=source_with_provenance.source_buffer,
                                 working_lines=(),
                                 lineage=source_with_provenance.lineage,
@@ -1066,48 +996,44 @@ def _command_discard_lines_to_batch_as(
                                 new_ownership,
                             )
                             batch_source_commit = create_batch_source_commit(
-                                line_changes.path,
+                                replacement.file_path,
                                 file_buffer_override=source_with_provenance.source_buffer,
                             )
                             batch_sources = load_session_batch_sources()
-                            batch_sources[line_changes.path] = batch_source_commit
+                            batch_sources[replacement.file_path] = batch_source_commit
                             save_session_batch_sources(batch_sources)
                 except ValueError as e:
                     exit_with_error(
                         _("Cannot discard lines to batch: batch source is stale and remapping failed.\n"
                           "File: {file}\n"
                           "Batch: {batch}\n"
-                          "Error: {error}").format(file=line_changes.path, batch=batch_name, error=str(e))
+                          "Error: {error}").format(file=replacement.file_path, batch=batch_name, error=str(e))
                     )
 
-                file_mode = detect_file_mode(line_changes.path)
+                file_mode = detect_file_mode(replacement.file_path)
 
                 if batch_source_commit is None:
                     batch_source_commit = create_batch_source_commit(
-                        line_changes.path,
-                        file_buffer_override=rewritten_working_lines,
+                        replacement.file_path,
+                        file_buffer_override=replacement.rewritten_working_lines,
                     )
                     batch_sources = load_session_batch_sources()
-                    batch_sources[line_changes.path] = batch_source_commit
+                    batch_sources[replacement.file_path] = batch_source_commit
                     save_session_batch_sources(batch_sources)
 
-                snapshot_file_if_untracked(line_changes.path)
+                snapshot_file_if_untracked(replacement.file_path)
                 add_file_to_batch(
                     batch_name,
-                    line_changes.path,
+                    replacement.file_path,
                     ownership,
                     file_mode,
                     batch_source_commit=batch_source_commit,
                 )
 
-            rewritten_selected_ids = {
-                line.id for line in rewritten_selected_lines if line.id is not None
-            }
-            target_working_buffer = build_target_working_tree_buffer_from_lines(
-                rewritten_line_changes,
-                rewritten_selected_ids,
-                rewritten_working_lines,
-                working_has_trailing_newline=buffer_ends_with_lf(rewritten_working_lines),
+            target_working_buffer = (
+                _discard_line_replacement.build_discard_line_replacement_target_buffer(
+                    replacement
+                )
             )
 
     except Exception:
@@ -1116,8 +1042,9 @@ def _command_discard_lines_to_batch_as(
         raise
 
     assert target_working_buffer is not None
+    assert replacement is not None
     with target_working_buffer:
-        write_buffer_to_path(working_file_path, target_working_buffer)
+        write_buffer_to_path(replacement.working_file_path, target_working_buffer)
 
     if not quiet:
         print(
@@ -1128,43 +1055,10 @@ def _command_discard_lines_to_batch_as(
             file=sys.stderr,
         )
 
-    recalculate_selected_hunk_for_command(line_changes.path, auto_advance=auto_advance)
-
-
-def _select_rewritten_replacement_lines(
-    original_selected_lines: list,
-    rewritten_line_changes,
-) -> list:
-    """Find the rewritten changed span that overlaps the original selection."""
-    original_old_lines = {
-        line.old_line_number
-        for line in original_selected_lines
-        if line.old_line_number is not None
-    }
-    original_new_lines = {
-        line.new_line_number
-        for line in original_selected_lines
-        if line.new_line_number is not None
-    }
-
-    matching_indices = [
-        index
-        for index, line in enumerate(rewritten_line_changes.lines)
-        if line.kind != " " and (
-            line.old_line_number in original_old_lines
-            or line.new_line_number in original_new_lines
-        )
-    ]
-    if matching_indices:
-        start_index = min(matching_indices)
-        end_index = max(matching_indices)
-        return [
-            line
-            for line in rewritten_line_changes.lines[start_index:end_index + 1]
-            if line.kind != " "
-        ]
-
-    exit_with_error(_("Replacement selection could not be located after rewriting the file."))
+    recalculate_selected_hunk_for_command(
+        replacement.file_path,
+        auto_advance=auto_advance,
+    )
 
 
 def _discard_binary_change_from_working_tree(binary_change: BinaryFileChange) -> None:
@@ -1769,7 +1663,9 @@ def _command_discard_file_lines_to_batch(
 
     metadata = read_batch_metadata(batch_name)
     file_metadata = metadata.get("files", {}).get(file_path)
-    replacement_line_runs = _derive_live_replacement_line_runs(file_path)
+    replacement_line_runs = (
+        _discard_line_replacement.derive_live_replacement_line_runs(file_path)
+    )
 
     with ExitStack() as ownership_stack:
         try:
@@ -1865,7 +1761,11 @@ def _command_discard_lines_to_batch(
 
     metadata = read_batch_metadata(batch_name)
     file_metadata = metadata.get("files", {}).get(line_changes.path)
-    replacement_line_runs = _derive_live_replacement_line_runs(line_changes.path)
+    replacement_line_runs = (
+        _discard_line_replacement.derive_live_replacement_line_runs(
+            line_changes.path
+        )
+    )
 
     file_mode = detect_file_mode(line_changes.path)
 

--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -19,18 +19,13 @@ from ..batch.storage import (
 from ..batch.display import annotate_with_batch_source
 from ..batch.ownership import (
     BatchOwnership,
-    remap_batch_ownership_with_lineage,
-    merge_batch_ownership,
-    translate_lines_to_batch_ownership,
 )
-from ..batch.source_advancement import advance_source_lines_preserving_existing_presence
 from ..core.replacement import (
     ReplacementPayload,
     coerce_replacement_payload,
 )
 from ..batch.query import read_batch_metadata
 from ..batch.source_refresh import acquire_batch_ownership_update_for_selection
-from ..batch.source_refresh import refresh_selected_lines_against_source_lines
 from ..batch.validation import batch_exists
 from ..core.diff_parser import (
     acquire_unified_diff,
@@ -87,7 +82,6 @@ from ..data.file_tracking import auto_add_untracked_files
 from ..data.line_state import load_line_changes_from_state
 from ..data.live_diff import stream_live_git_diff
 from ..data.progress import record_hunk_discarded, record_hunks_discarded
-from ..data.batch_sources import create_batch_source_commit, load_session_batch_sources, save_session_batch_sources
 from ..data.session import require_session_started, snapshot_file_if_untracked, snapshot_files_if_untracked
 from ..data.undo import undo_checkpoint
 from ..core.buffer import (
@@ -96,7 +90,6 @@ from ..core.buffer import (
     write_buffer_to_path,
 )
 from ..utils.repository_buffers import (
-    load_git_object_as_buffer,
     load_working_tree_file_as_buffer,
 )
 from ..exceptions import CommandError, exit_with_error, NoMoreHunks
@@ -935,100 +928,10 @@ def _command_discard_lines_to_batch_as(
             replacement_text,
             no_edge_overlap=no_edge_overlap,
         ) as replacement:
-            if not batch_exists(batch_name):
-                create_batch(batch_name, "Auto-created")
-
-            metadata = read_batch_metadata(batch_name)
-            file_metadata = metadata.get("files", {}).get(replacement.file_path)
-            batch_source_commit = None
-
-            with ExitStack() as ownership_stack:
-                try:
-                    if file_metadata is None:
-                        update = ownership_stack.enter_context(
-                            acquire_batch_ownership_update_for_selection(
-                                batch_name=batch_name,
-                                file_path=replacement.file_path,
-                                file_metadata=None,
-                                selected_lines=replacement.rewritten_selected_lines,
-                            )
-                        )
-                        ownership = update.ownership_after
-                        batch_source_commit = update.batch_source_commit
-                    else:
-                        current_batch_source = file_metadata.get("batch_source_commit")
-                        existing_ownership = ownership_stack.enter_context(
-                            BatchOwnership.acquire_for_metadata_dict(file_metadata)
-                        )
-                        old_source_buffer = load_git_object_as_buffer(
-                            f"{current_batch_source}:{replacement.file_path}"
-                        )
-                        if old_source_buffer is None:
-                            exit_with_error(
-                                _("Cannot discard lines to batch: failed to read batch source for '{file}'.").format(
-                                    file=replacement.file_path
-                                )
-                            )
-
-                        with (
-                            old_source_buffer as old_source_lines,
-                            advance_source_lines_preserving_existing_presence(
-                                old_lines=old_source_lines,
-                                working_lines=replacement.rewritten_working_lines,
-                                ownership=existing_ownership,
-                            ) as source_with_provenance,
-                        ):
-                            remapped_existing_ownership = remap_batch_ownership_with_lineage(
-                                ownership=existing_ownership,
-                                lineage=source_with_provenance.lineage,
-                            )
-                            refreshed_selected_lines = refresh_selected_lines_against_source_lines(
-                                replacement.rewritten_selected_lines,
-                                source_lines=source_with_provenance.source_buffer,
-                                working_lines=(),
-                                lineage=source_with_provenance.lineage,
-                            )
-                            new_ownership = translate_lines_to_batch_ownership(
-                                refreshed_selected_lines
-                            )
-                            ownership = merge_batch_ownership(
-                                remapped_existing_ownership,
-                                new_ownership,
-                            )
-                            batch_source_commit = create_batch_source_commit(
-                                replacement.file_path,
-                                file_buffer_override=source_with_provenance.source_buffer,
-                            )
-                            batch_sources = load_session_batch_sources()
-                            batch_sources[replacement.file_path] = batch_source_commit
-                            save_session_batch_sources(batch_sources)
-                except ValueError as e:
-                    exit_with_error(
-                        _("Cannot discard lines to batch: batch source is stale and remapping failed.\n"
-                          "File: {file}\n"
-                          "Batch: {batch}\n"
-                          "Error: {error}").format(file=replacement.file_path, batch=batch_name, error=str(e))
-                    )
-
-                file_mode = detect_file_mode(replacement.file_path)
-
-                if batch_source_commit is None:
-                    batch_source_commit = create_batch_source_commit(
-                        replacement.file_path,
-                        file_buffer_override=replacement.rewritten_working_lines,
-                    )
-                    batch_sources = load_session_batch_sources()
-                    batch_sources[replacement.file_path] = batch_source_commit
-                    save_session_batch_sources(batch_sources)
-
-                snapshot_file_if_untracked(replacement.file_path)
-                add_file_to_batch(
-                    batch_name,
-                    replacement.file_path,
-                    ownership,
-                    file_mode,
-                    batch_source_commit=batch_source_commit,
-                )
+            _discard_line_replacement.add_discard_line_replacement_to_batch(
+                batch_name,
+                replacement,
+            )
 
             target_working_buffer = (
                 _discard_line_replacement.build_discard_line_replacement_target_buffer(

--- a/src/git_stage_batch/commands/file_scope/discard_file_to_batch.py
+++ b/src/git_stage_batch/commands/file_scope/discard_file_to_batch.py
@@ -1,0 +1,336 @@
+"""Single-file discard-to-batch support."""
+
+from __future__ import annotations
+
+from contextlib import ExitStack
+import sys
+
+from ...batch.display import annotate_with_batch_source
+from ...batch.operations import create_batch
+from ...batch.ownership import BatchOwnership
+from ...batch.query import read_batch_metadata
+from ...batch.source_refresh import acquire_batch_ownership_update_for_selection
+from ...batch.storage import add_binary_file_to_batch, add_file_to_batch
+from ...batch.validation import batch_exists
+from ...core.buffer import LineBuffer
+from ...core.diff_parser import acquire_unified_diff, build_line_changes_from_patch_lines
+from ...core.hashing import (
+    compute_binary_file_hash,
+    compute_stable_hunk_hash_from_lines,
+    compute_text_file_deletion_hash,
+)
+from ...core.models import BinaryFileChange, GitlinkChange, RenameChange, TextFileDeletionChange
+from ...core.text_lifecycle import TextFileChangeType
+from ...data.file_change_display import (
+    render_binary_file_change,
+    render_gitlink_change,
+    render_text_deletion_change,
+)
+from ...data.file_modes import detect_file_mode
+from ...data.file_tracking import auto_add_untracked_files
+from ...data.live_diff import stream_live_git_diff
+from ...data.progress import record_hunk_discarded
+from ...data.session import snapshot_file_if_untracked
+from ...data.text_lifecycle_detection import detect_empty_text_lifecycle_change
+from ...exceptions import exit_with_error
+from ...i18n import _
+from ...utils.file_io import append_lines_to_file, read_text_file_line_set
+from ...utils.git import (
+    get_git_repository_root_path,
+    git_apply_to_worktree,
+    git_checkout_paths,
+    git_remove_paths,
+)
+from ...utils.journal import log_journal
+from ...utils.paths import get_block_list_file_path, get_context_lines
+from ..selection.action_completion import finish_selected_change_action
+from ..selection.selected_change_discarding import discard_text_deletion_change
+
+
+def _discard_binary_change_from_working_tree(binary_change: BinaryFileChange) -> None:
+    """Discard one live binary change from the working tree."""
+    file_path = binary_change.new_path if binary_change.new_path != "/dev/null" else binary_change.old_path
+    absolute_path = get_git_repository_root_path() / file_path
+
+    if binary_change.is_new_file():
+        if absolute_path.exists():
+            absolute_path.unlink()
+        git_remove_paths([file_path], cached=True, quiet=True, check=False)
+        return
+
+    result = git_checkout_paths("HEAD", [file_path], check=False)
+    if result.returncode != 0:
+        exit_with_error(_("Failed to restore binary file: {error}").format(error=result.stderr))
+
+
+def discard_binary_to_batch(
+    batch_name: str,
+    binary_change: BinaryFileChange,
+    *,
+    quiet: bool = False,
+    advance: bool = True,
+    auto_advance: bool | None = None,
+) -> int:
+    """Save one binary change to a batch, then discard it from the working tree."""
+    file_path = binary_change.new_path if binary_change.new_path != "/dev/null" else binary_change.old_path
+    patch_hash = compute_binary_file_hash(binary_change)
+
+    snapshot_file_if_untracked(file_path)
+    add_binary_file_to_batch(
+        batch_name,
+        binary_change,
+        file_mode=detect_file_mode(file_path),
+    )
+    _discard_binary_change_from_working_tree(binary_change)
+
+    append_lines_to_file(get_block_list_file_path(), [patch_hash])
+    record_hunk_discarded(patch_hash)
+
+    if not quiet:
+        print(
+            _("Discarded binary file '{file}' to batch '{batch}'").format(
+                file=file_path,
+                batch=batch_name,
+            ),
+            file=sys.stderr,
+        )
+
+    if advance:
+        finish_selected_change_action(quiet=quiet, auto_advance=auto_advance)
+    return 1
+
+
+def discard_text_deletion_to_batch(
+    batch_name: str,
+    deletion_change: TextFileDeletionChange,
+    *,
+    quiet: bool = False,
+    advance: bool = True,
+    auto_advance: bool | None = None,
+) -> int:
+    """Save one whole-text-file deletion to a batch, then restore it locally."""
+    file_path = deletion_change.path()
+    patch_hash = compute_text_file_deletion_hash(deletion_change)
+
+    snapshot_file_if_untracked(file_path)
+    add_file_to_batch(
+        batch_name,
+        file_path,
+        BatchOwnership([], []),
+        detect_file_mode(file_path),
+        change_type=TextFileChangeType.DELETED.value,
+    )
+    discard_text_deletion_change(deletion_change)
+
+    append_lines_to_file(get_block_list_file_path(), [patch_hash])
+    record_hunk_discarded(patch_hash)
+
+    if not quiet:
+        print(
+            _("Discarded text file deletion '{file}' to batch '{batch}'").format(
+                file=file_path,
+                batch=batch_name,
+            ),
+            file=sys.stderr,
+        )
+
+    if advance:
+        finish_selected_change_action(quiet=quiet, auto_advance=auto_advance)
+    return 1
+
+
+def discard_file_to_batch(
+    batch_name: str,
+    file_path: str,
+    *,
+    quiet: bool = False,
+    advance: bool = True,
+    auto_advance: bool | None = None,
+) -> int:
+    """Discard one file to a batch."""
+    auto_add_untracked_files([file_path])
+
+    log_journal("discard_file_to_batch_start", batch_name=batch_name, file_path=file_path, quiet=quiet)
+
+    if not batch_exists(batch_name):
+        create_batch(batch_name, "Auto-created")
+
+    deletion_change = render_text_deletion_change(file_path)
+    if deletion_change is not None:
+        return discard_text_deletion_to_batch(
+            batch_name,
+            deletion_change,
+            quiet=quiet,
+            advance=advance,
+            auto_advance=auto_advance,
+        )
+
+    binary_change = render_binary_file_change(file_path)
+    if binary_change is not None:
+        return discard_binary_to_batch(
+            batch_name,
+            binary_change,
+            quiet=quiet,
+            advance=advance,
+            auto_advance=auto_advance,
+        )
+    if render_gitlink_change(file_path) is not None:
+        exit_with_error(_("Discarding submodule pointer changes to a batch is not supported yet."))
+
+    blocklist_path = get_block_list_file_path()
+    blocked_hashes = read_text_file_line_set(blocklist_path)
+    file_mode = detect_file_mode(file_path)
+
+    with ExitStack() as patch_stack:
+        all_lines_to_batch = []
+        patches_to_discard = []
+
+        with acquire_unified_diff(
+            stream_live_git_diff(
+                base="HEAD",
+                context_lines=get_context_lines(),
+                paths=[file_path],
+            )
+        ) as patches:
+            for patch in patches:
+                if isinstance(patch, RenameChange):
+                    continue
+
+                if isinstance(patch, TextFileDeletionChange):
+                    continue
+
+                if isinstance(patch, GitlinkChange):
+                    exit_with_error(_("Discarding submodule pointer changes to a batch is not supported yet."))
+                if isinstance(patch, BinaryFileChange):
+                    continue
+
+                patch_hash = compute_stable_hunk_hash_from_lines(patch.lines)
+
+                if patch_hash in blocked_hashes:
+                    continue
+
+                hunk_lines = build_line_changes_from_patch_lines(
+                    patch.lines,
+                    annotator=annotate_with_batch_source,
+                )
+                all_lines_to_batch.extend(hunk_lines.lines)
+                patches_to_discard.append((
+                    patch_stack.enter_context(LineBuffer.from_chunks(patch.lines)),
+                    patch_hash,
+                ))
+
+        if not all_lines_to_batch:
+            repo_root = get_git_repository_root_path()
+            full_path = repo_root / file_path
+            lifecycle_change_type = detect_empty_text_lifecycle_change(file_path)
+            if lifecycle_change_type is not None:
+                snapshot_file_if_untracked(file_path)
+                add_file_to_batch(
+                    batch_name,
+                    file_path,
+                    BatchOwnership([], []),
+                    file_mode,
+                    change_type=lifecycle_change_type,
+                )
+
+                if lifecycle_change_type == TextFileChangeType.ADDED:
+                    full_path.unlink()
+                    git_remove_paths([file_path], cached=True, quiet=True, check=False)
+                else:
+                    git_checkout_paths("HEAD", [file_path], check=False)
+
+                if not quiet:
+                    print(
+                        _("Discarded file '{file}' to batch '{batch}'").format(
+                            file=file_path,
+                            batch=batch_name,
+                        ),
+                        file=sys.stderr,
+                    )
+
+                log_journal("discard_file_to_batch_end", batch_name=batch_name, file_path=file_path)
+                return 1
+
+            if not quiet:
+                print(_("No changes in file '{file}' to discard.").format(file=file_path), file=sys.stderr)
+            return 0
+
+        metadata = read_batch_metadata(batch_name)
+        file_metadata = metadata.get("files", {}).get(file_path)
+
+        with ExitStack() as ownership_stack:
+            try:
+                update = ownership_stack.enter_context(
+                    acquire_batch_ownership_update_for_selection(
+                        batch_name=batch_name,
+                        file_path=file_path,
+                        file_metadata=file_metadata,
+                        selected_lines=all_lines_to_batch,
+                    )
+                )
+            except ValueError as e:
+                exit_with_error(
+                    _("Cannot discard file to batch: batch source is stale and remapping failed.\n"
+                      "File: {file}\n"
+                      "Batch: {batch}\n"
+                      "Error: {error}").format(file=file_path, batch=batch_name, error=str(e))
+                )
+
+            snapshot_file_if_untracked(file_path)
+
+            add_file_to_batch(
+                batch_name,
+                file_path,
+                update.ownership_after,
+                file_mode,
+                batch_source_commit=update.batch_source_commit,
+            )
+
+        for _patch_lines, patch_hash in patches_to_discard:
+            record_hunk_discarded(patch_hash)
+
+        for patch_lines_item, patch_hash in patches_to_discard:
+            log_journal(
+                "discard_file_to_batch_before_git_apply",
+                batch_name=batch_name,
+                patch_hash=patch_hash,
+                file_path=file_path,
+                patch_line_count=len(patch_lines_item),
+            )
+
+            apply_result = git_apply_to_worktree(
+                patch_lines_item,
+                reverse=True,
+                unidiff_zero=True,
+                check=False,
+            )
+
+            if apply_result.returncode != 0:
+                exit_with_error(_("Failed to discard changes from file: {err}").format(err=apply_result.stderr))
+
+            log_journal(
+                "discard_file_to_batch_after_git_apply",
+                batch_name=batch_name,
+                patch_hash=patch_hash,
+                exit_code=apply_result.returncode,
+            )
+
+        repo_root = get_git_repository_root_path()
+        full_path = repo_root / file_path
+        if not full_path.exists():
+            git_remove_paths([file_path], cached=True, quiet=True, check=False)
+
+        if not quiet:
+            print(
+                _("Discarded file '{file}' to batch '{batch}'").format(
+                    file=file_path,
+                    batch=batch_name,
+                ),
+                file=sys.stderr,
+            )
+
+        log_journal("discard_file_to_batch_end", batch_name=batch_name, file_path=file_path)
+
+        if advance:
+            finish_selected_change_action(quiet=quiet, auto_advance=auto_advance)
+        return len(patches_to_discard)

--- a/src/git_stage_batch/commands/file_scope/discard_to_batch.py
+++ b/src/git_stage_batch/commands/file_scope/discard_to_batch.py
@@ -85,6 +85,78 @@ class DiscardFilesToBatchResult:
     discarded_files: list[str]
 
 
+class _DiscardFilesToBatchSession:
+    """Mutable publication state for one multi-file discard-to-batch action."""
+
+    def __init__(self, batch_name: str, metadata: dict) -> None:
+        self._batch_name = batch_name
+        self._metadata = metadata
+        self._ownership_stack = ExitStack()
+        self._prepared_discards: list[_PreparedTextFileDiscardToBatch] = []
+        self._discarded_hunks = 0
+        self._discarded_files: list[str] = []
+
+    @property
+    def discarded_hunks(self) -> int:
+        """Return the total discarded hunk count."""
+        return self._discarded_hunks
+
+    @property
+    def discarded_files(self) -> list[str]:
+        """Return files that produced discarded hunks."""
+        return self._discarded_files
+
+    def close(self) -> None:
+        """Release any pending batch ownership update contexts."""
+        self._ownership_stack.close()
+
+    def prepare_text_file(self, discard_input: _TextFileDiscardInput) -> bool:
+        """Stage one text file for a later batch publication flush."""
+        prepared = _prepare_text_file_discard_to_batch(
+            self._batch_name,
+            discard_input,
+            metadata=self._metadata,
+            ownership_stack=self._ownership_stack,
+        )
+        if prepared is None:
+            return False
+        self._prepared_discards.append(prepared)
+        return True
+
+    def flush(self) -> None:
+        """Publish any pending prepared text file discards."""
+        ownership_stack = self._ownership_stack
+        prepared_discards = self._prepared_discards
+        self._ownership_stack = ExitStack()
+        self._prepared_discards = []
+
+        with ownership_stack:
+            result = _discard_prepared_text_files_to_batch(
+                self._batch_name,
+                prepared_discards,
+            )
+        self._record_result(result)
+
+    def record_single_file_discard(self, file_path: str, discarded_hunks: int) -> bool:
+        """Record fallback single-file command output."""
+        if discarded_hunks <= 0:
+            return False
+        self._record_result(
+            DiscardFilesToBatchResult(
+                discarded_hunks=discarded_hunks,
+                discarded_files=[file_path],
+            )
+        )
+        return True
+
+    def _record_result(self, result: DiscardFilesToBatchResult) -> None:
+        if result.discarded_hunks <= 0:
+            return
+        self._discarded_hunks += result.discarded_hunks
+        self._discarded_files.extend(result.discarded_files)
+        self._metadata = read_batch_metadata(self._batch_name)
+
+
 def _prepare_text_file_discard_to_batch(
     batch_name: str,
     discard_input: _TextFileDiscardInput,
@@ -297,29 +369,13 @@ def discard_files_to_batch(
 
     blocklist_path = get_block_list_file_path()
     blocked_hashes = read_text_file_line_set(blocklist_path)
-    prepared_discards: list[_PreparedTextFileDiscardToBatch] = []
-    ownership_stack = ExitStack()
+    session = _DiscardFilesToBatchSession(
+        batch_name=batch_name,
+        metadata=read_batch_metadata(batch_name),
+    )
     patch_stack = ExitStack()
-    total_hunks = 0
-    discarded_files: list[str] = []
-
-    def flush_prepared() -> None:
-        nonlocal metadata, total_hunks
-        nonlocal discarded_files, ownership_stack, prepared_discards
-        with ownership_stack:
-            result = _discard_prepared_text_files_to_batch(
-                batch_name,
-                prepared_discards,
-            )
-        if result.discarded_hunks:
-            total_hunks += result.discarded_hunks
-            discarded_files.extend(result.discarded_files)
-            metadata = read_batch_metadata(batch_name)
-        prepared_discards = []
-        ownership_stack = ExitStack()
 
     try:
-        metadata = read_batch_metadata(batch_name)
         collected_discards = _collect_text_file_discard_inputs(
             files,
             blocked_hashes=blocked_hashes,
@@ -340,17 +396,8 @@ def discard_files_to_batch(
             ):
                 continue
 
-            prepared = (
-                _prepare_text_file_discard_to_batch(
-                    batch_name,
-                    discard_input,
-                    metadata=metadata,
-                    ownership_stack=ownership_stack,
-                )
-                if discard_input is not None else None
-            )
-            if prepared is None:
-                flush_prepared()
+            if discard_input is None or not session.prepare_text_file(discard_input):
+                session.flush()
                 discarded_hunks = command_discard_to_batch(
                     batch_name,
                     file=file_path,
@@ -358,29 +405,25 @@ def discard_files_to_batch(
                     advance=False,
                     auto_advance=auto_advance,
                 )
-                if discarded_hunks > 0:
-                    total_hunks += discarded_hunks
-                    discarded_files.append(file_path)
-                    metadata = read_batch_metadata(batch_name)
+                if session.record_single_file_discard(file_path, discarded_hunks):
                     blocked_hashes = read_text_file_line_set(blocklist_path)
                 continue
 
-            prepared_discards.append(prepared)
             log_journal(
                 "discard_file_to_batch_end",
                 batch_name=batch_name,
                 file_path=file_path,
             )
 
-        flush_prepared()
+        session.flush()
     finally:
-        ownership_stack.close()
+        session.close()
         patch_stack.close()
 
     if advance:
         finish_selected_change_action(quiet=quiet, auto_advance=auto_advance)
 
     return DiscardFilesToBatchResult(
-        discarded_hunks=total_hunks,
-        discarded_files=discarded_files,
+        discarded_hunks=session.discarded_hunks,
+        discarded_files=session.discarded_files,
     )

--- a/src/git_stage_batch/commands/file_scope/discard_to_batch.py
+++ b/src/git_stage_batch/commands/file_scope/discard_to_batch.py
@@ -41,7 +41,7 @@ from ..selection.action_completion import finish_selected_change_action
 
 
 @dataclass(frozen=True)
-class PreparedPatchDiscard:
+class _PreparedPatchDiscard:
     """One patch scheduled for reverse application."""
 
     patch_lines: Sequence[bytes]
@@ -49,32 +49,32 @@ class PreparedPatchDiscard:
 
 
 @dataclass
-class TextFileDiscardInput:
+class _TextFileDiscardInput:
     """Collected text hunks for one file-scope discard."""
 
     file_path: str
     file_mode: str
     all_lines_to_batch: list
-    patches_to_discard: list[PreparedPatchDiscard]
+    patches_to_discard: list[_PreparedPatchDiscard]
 
 
 @dataclass(frozen=True)
-class CollectedTextFileDiscards:
+class _CollectedTextFileDiscards:
     """Collected text-file discard inputs from one live diff."""
 
-    inputs_by_file: dict[str, TextFileDiscardInput]
+    inputs_by_file: dict[str, _TextFileDiscardInput]
     files_with_text_patches: set[str]
 
 
 @dataclass(frozen=True)
-class PreparedTextFileDiscardToBatch:
+class _PreparedTextFileDiscardToBatch:
     """Prepared text-file discard that can be published atomically."""
 
     file_path: str
     file_mode: str
     ownership: object
     batch_source_commit: str | None
-    patches_to_discard: list[PreparedPatchDiscard]
+    patches_to_discard: list[_PreparedPatchDiscard]
 
 
 @dataclass(frozen=True)
@@ -87,11 +87,11 @@ class DiscardFilesToBatchResult:
 
 def _prepare_text_file_discard_to_batch(
     batch_name: str,
-    discard_input: TextFileDiscardInput,
+    discard_input: _TextFileDiscardInput,
     *,
     metadata: dict,
     ownership_stack: ExitStack,
-) -> PreparedTextFileDiscardToBatch | None:
+) -> _PreparedTextFileDiscardToBatch | None:
     """Prepare one normal text file discard without publishing batch state."""
     if not discard_input.all_lines_to_batch:
         return None
@@ -118,7 +118,7 @@ def _prepare_text_file_discard_to_batch(
             ).format(file=file_path, batch=batch_name, error=str(e))
         )
 
-    return PreparedTextFileDiscardToBatch(
+    return _PreparedTextFileDiscardToBatch(
         file_path=file_path,
         file_mode=discard_input.file_mode,
         ownership=update.ownership_after,
@@ -132,16 +132,16 @@ def _collect_text_file_discard_inputs(
     *,
     blocked_hashes: set[str],
     patch_stack: ExitStack,
-) -> CollectedTextFileDiscards:
+) -> _CollectedTextFileDiscards:
     """Collect normal text file discard inputs from one Git diff."""
     if not files:
-        return CollectedTextFileDiscards(
+        return _CollectedTextFileDiscards(
             inputs_by_file={},
             files_with_text_patches=set(),
         )
 
     repo_root = get_git_repository_root_path()
-    inputs_by_file: dict[str, TextFileDiscardInput] = {}
+    inputs_by_file: dict[str, _TextFileDiscardInput] = {}
     files_with_text_patches: set[str] = set()
 
     with acquire_unified_diff(
@@ -179,7 +179,7 @@ def _collect_text_file_discard_inputs(
             )
             discard_input = inputs_by_file.get(file_path)
             if discard_input is None:
-                discard_input = TextFileDiscardInput(
+                discard_input = _TextFileDiscardInput(
                     file_path=file_path,
                     file_mode=detect_file_mode_from_root(repo_root, file_path),
                     all_lines_to_batch=[],
@@ -188,7 +188,7 @@ def _collect_text_file_discard_inputs(
                 inputs_by_file[file_path] = discard_input
             discard_input.all_lines_to_batch.extend(hunk_lines.lines)
             discard_input.patches_to_discard.append(
-                PreparedPatchDiscard(
+                _PreparedPatchDiscard(
                     patch_lines=patch_stack.enter_context(
                         LineBuffer.from_chunks(patch.lines)
                     ),
@@ -197,14 +197,14 @@ def _collect_text_file_discard_inputs(
             )
             blocked_hashes.add(patch_hash)
 
-    return CollectedTextFileDiscards(
+    return _CollectedTextFileDiscards(
         inputs_by_file=inputs_by_file,
         files_with_text_patches=files_with_text_patches,
     )
 
 
 def _run_reverse_apply_for_prepared_discards(
-    prepared_discards: list[PreparedTextFileDiscardToBatch],
+    prepared_discards: list[_PreparedTextFileDiscardToBatch],
     *,
     check_only: bool = False,
 ) -> None:
@@ -231,7 +231,7 @@ def _run_reverse_apply_for_prepared_discards(
 
 def _discard_prepared_text_files_to_batch(
     batch_name: str,
-    prepared_discards: list[PreparedTextFileDiscardToBatch],
+    prepared_discards: list[_PreparedTextFileDiscardToBatch],
 ) -> DiscardFilesToBatchResult:
     """Publish prepared text file discards once, then update the worktree."""
     if not prepared_discards:
@@ -297,7 +297,7 @@ def discard_files_to_batch(
 
     blocklist_path = get_block_list_file_path()
     blocked_hashes = read_text_file_line_set(blocklist_path)
-    prepared_discards: list[PreparedTextFileDiscardToBatch] = []
+    prepared_discards: list[_PreparedTextFileDiscardToBatch] = []
     ownership_stack = ExitStack()
     patch_stack = ExitStack()
     total_hunks = 0

--- a/src/git_stage_batch/commands/file_scope/discard_to_batch.py
+++ b/src/git_stage_batch/commands/file_scope/discard_to_batch.py
@@ -1,0 +1,386 @@
+"""Multi-file discard-to-batch command support."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from contextlib import ExitStack
+from dataclasses import dataclass
+
+from ...batch.display import annotate_with_batch_source
+from ...batch.operations import create_batch
+from ...batch.query import read_batch_metadata
+from ...batch.source_refresh import acquire_batch_ownership_update_for_selection
+from ...batch.storage import BatchFileUpdate, add_files_to_batch
+from ...batch.validation import batch_exists
+from ...core.buffer import LineBuffer
+from ...core.diff_parser import acquire_unified_diff, build_line_changes_from_patch_lines
+from ...core.hashing import compute_stable_hunk_hash_from_lines
+from ...core.models import BinaryFileChange, GitlinkChange, RenameChange, TextFileDeletionChange
+from ...data.file_modes import detect_file_mode_from_root
+from ...data.file_tracking import auto_add_untracked_files
+from ...data.live_diff import stream_live_git_diff
+from ...data.progress import record_hunks_discarded
+from ...data.session import snapshot_files_if_untracked
+from ...exceptions import exit_with_error
+from ...i18n import _
+from ...utils.file_io import read_text_file_line_set
+from ...utils.git import (
+    get_git_repository_root_path,
+    git_apply_to_worktree,
+    git_remove_paths,
+    require_git_repository,
+)
+from ...utils.journal import log_journal
+from ...utils.paths import (
+    ensure_state_directory_exists,
+    get_block_list_file_path,
+    get_context_lines,
+)
+from ..discard import command_discard_to_batch
+from ..selection.action_completion import finish_selected_change_action
+
+
+@dataclass(frozen=True)
+class PreparedPatchDiscard:
+    """One patch scheduled for reverse application."""
+
+    patch_lines: Sequence[bytes]
+    patch_hash: str
+
+
+@dataclass
+class TextFileDiscardInput:
+    """Collected text hunks for one file-scope discard."""
+
+    file_path: str
+    file_mode: str
+    all_lines_to_batch: list
+    patches_to_discard: list[PreparedPatchDiscard]
+
+
+@dataclass(frozen=True)
+class CollectedTextFileDiscards:
+    """Collected text-file discard inputs from one live diff."""
+
+    inputs_by_file: dict[str, TextFileDiscardInput]
+    files_with_text_patches: set[str]
+
+
+@dataclass(frozen=True)
+class PreparedTextFileDiscardToBatch:
+    """Prepared text-file discard that can be published atomically."""
+
+    file_path: str
+    file_mode: str
+    ownership: object
+    batch_source_commit: str | None
+    patches_to_discard: list[PreparedPatchDiscard]
+
+
+@dataclass(frozen=True)
+class DiscardFilesToBatchResult:
+    """Aggregate result for multi-file discard-to-batch actions."""
+
+    discarded_hunks: int
+    discarded_files: list[str]
+
+
+def _prepare_text_file_discard_to_batch(
+    batch_name: str,
+    discard_input: TextFileDiscardInput,
+    *,
+    metadata: dict,
+    ownership_stack: ExitStack,
+) -> PreparedTextFileDiscardToBatch | None:
+    """Prepare one normal text file discard without publishing batch state."""
+    if not discard_input.all_lines_to_batch:
+        return None
+
+    file_path = discard_input.file_path
+    file_metadata = metadata.get("files", {}).get(file_path)
+
+    try:
+        update = ownership_stack.enter_context(
+            acquire_batch_ownership_update_for_selection(
+                batch_name=batch_name,
+                file_path=file_path,
+                file_metadata=file_metadata,
+                selected_lines=discard_input.all_lines_to_batch,
+            )
+        )
+    except ValueError as e:
+        exit_with_error(
+            _(
+                "Cannot discard file to batch: batch source is stale and remapping failed.\n"
+                "File: {file}\n"
+                "Batch: {batch}\n"
+                "Error: {error}"
+            ).format(file=file_path, batch=batch_name, error=str(e))
+        )
+
+    return PreparedTextFileDiscardToBatch(
+        file_path=file_path,
+        file_mode=discard_input.file_mode,
+        ownership=update.ownership_after,
+        batch_source_commit=update.batch_source_commit,
+        patches_to_discard=discard_input.patches_to_discard,
+    )
+
+
+def _collect_text_file_discard_inputs(
+    files: list[str],
+    *,
+    blocked_hashes: set[str],
+    patch_stack: ExitStack,
+) -> CollectedTextFileDiscards:
+    """Collect normal text file discard inputs from one Git diff."""
+    if not files:
+        return CollectedTextFileDiscards(
+            inputs_by_file={},
+            files_with_text_patches=set(),
+        )
+
+    repo_root = get_git_repository_root_path()
+    inputs_by_file: dict[str, TextFileDiscardInput] = {}
+    files_with_text_patches: set[str] = set()
+
+    with acquire_unified_diff(
+        stream_live_git_diff(
+            base="HEAD",
+            context_lines=get_context_lines(),
+            paths=files,
+        )
+    ) as patches:
+        for patch in patches:
+            if isinstance(patch, RenameChange):
+                continue
+
+            if isinstance(patch, TextFileDeletionChange):
+                continue
+
+            if isinstance(patch, GitlinkChange):
+                exit_with_error(
+                    _("Discarding submodule pointer changes to a batch is not supported yet.")
+                )
+
+            if isinstance(patch, BinaryFileChange):
+                continue
+
+            file_path = patch.new_path if patch.new_path != "/dev/null" else patch.old_path
+            files_with_text_patches.add(file_path)
+
+            patch_hash = compute_stable_hunk_hash_from_lines(patch.lines)
+            if patch_hash in blocked_hashes:
+                continue
+
+            hunk_lines = build_line_changes_from_patch_lines(
+                patch.lines,
+                annotator=annotate_with_batch_source,
+            )
+            discard_input = inputs_by_file.get(file_path)
+            if discard_input is None:
+                discard_input = TextFileDiscardInput(
+                    file_path=file_path,
+                    file_mode=detect_file_mode_from_root(repo_root, file_path),
+                    all_lines_to_batch=[],
+                    patches_to_discard=[],
+                )
+                inputs_by_file[file_path] = discard_input
+            discard_input.all_lines_to_batch.extend(hunk_lines.lines)
+            discard_input.patches_to_discard.append(
+                PreparedPatchDiscard(
+                    patch_lines=patch_stack.enter_context(
+                        LineBuffer.from_chunks(patch.lines)
+                    ),
+                    patch_hash=patch_hash,
+                )
+            )
+            blocked_hashes.add(patch_hash)
+
+    return CollectedTextFileDiscards(
+        inputs_by_file=inputs_by_file,
+        files_with_text_patches=files_with_text_patches,
+    )
+
+
+def _run_reverse_apply_for_prepared_discards(
+    prepared_discards: list[PreparedTextFileDiscardToBatch],
+    *,
+    check_only: bool = False,
+) -> None:
+    def patch_chunks():
+        for prepared in prepared_discards:
+            for patch in prepared.patches_to_discard:
+                yield from patch.patch_lines
+
+    apply_result = git_apply_to_worktree(
+        patch_chunks(),
+        reverse=True,
+        unidiff_zero=True,
+        check_only=check_only,
+        check=False,
+    )
+
+    if apply_result.returncode != 0:
+        exit_with_error(
+            _("Failed to discard changes from file: {err}").format(
+                err=apply_result.stderr
+            )
+        )
+
+
+def _discard_prepared_text_files_to_batch(
+    batch_name: str,
+    prepared_discards: list[PreparedTextFileDiscardToBatch],
+) -> DiscardFilesToBatchResult:
+    """Publish prepared text file discards once, then update the worktree."""
+    if not prepared_discards:
+        return DiscardFilesToBatchResult(discarded_hunks=0, discarded_files=[])
+
+    snapshot_files_if_untracked([prepared.file_path for prepared in prepared_discards])
+
+    _run_reverse_apply_for_prepared_discards(prepared_discards, check_only=True)
+    add_files_to_batch(
+        batch_name,
+        [
+            BatchFileUpdate(
+                file_path=prepared.file_path,
+                ownership=prepared.ownership,
+                file_mode=prepared.file_mode,
+                batch_source_commit=prepared.batch_source_commit,
+            )
+            for prepared in prepared_discards
+        ],
+    )
+    _run_reverse_apply_for_prepared_discards(prepared_discards)
+
+    repo_root = get_git_repository_root_path()
+    for prepared in prepared_discards:
+        full_path = repo_root / prepared.file_path
+        if not full_path.exists():
+            git_remove_paths([prepared.file_path], cached=True, quiet=True, check=False)
+
+    hunk_hashes = [
+        patch.patch_hash
+        for prepared in prepared_discards
+        for patch in prepared.patches_to_discard
+    ]
+    record_hunks_discarded(hunk_hashes)
+
+    return DiscardFilesToBatchResult(
+        discarded_hunks=len(hunk_hashes),
+        discarded_files=[
+            prepared.file_path
+            for prepared in prepared_discards
+            if prepared.patches_to_discard
+        ],
+    )
+
+
+def command_discard_files_to_batch(
+    batch_name: str,
+    files: list[str],
+    *,
+    quiet: bool = False,
+    advance: bool = True,
+    auto_advance: bool | None = None,
+) -> DiscardFilesToBatchResult:
+    """Save resolved text files to a batch with one batch publication."""
+    require_git_repository()
+    ensure_state_directory_exists()
+
+    if not files:
+        return DiscardFilesToBatchResult(discarded_hunks=0, discarded_files=[])
+    auto_add_untracked_files(files)
+    if not batch_exists(batch_name):
+        create_batch(batch_name, "Auto-created")
+
+    blocklist_path = get_block_list_file_path()
+    blocked_hashes = read_text_file_line_set(blocklist_path)
+    prepared_discards: list[PreparedTextFileDiscardToBatch] = []
+    ownership_stack = ExitStack()
+    patch_stack = ExitStack()
+    total_hunks = 0
+    discarded_files: list[str] = []
+
+    def flush_prepared() -> None:
+        nonlocal metadata, total_hunks
+        nonlocal discarded_files, ownership_stack, prepared_discards
+        with ownership_stack:
+            result = _discard_prepared_text_files_to_batch(
+                batch_name,
+                prepared_discards,
+            )
+        if result.discarded_hunks:
+            total_hunks += result.discarded_hunks
+            discarded_files.extend(result.discarded_files)
+            metadata = read_batch_metadata(batch_name)
+        prepared_discards = []
+        ownership_stack = ExitStack()
+
+    try:
+        metadata = read_batch_metadata(batch_name)
+        collected_discards = _collect_text_file_discard_inputs(
+            files,
+            blocked_hashes=blocked_hashes,
+            patch_stack=patch_stack,
+        )
+
+        for file_path in files:
+            log_journal(
+                "discard_file_to_batch_start",
+                batch_name=batch_name,
+                file_path=file_path,
+                quiet=quiet,
+            )
+            discard_input = collected_discards.inputs_by_file.get(file_path)
+            if (
+                discard_input is None
+                and file_path in collected_discards.files_with_text_patches
+            ):
+                continue
+
+            prepared = (
+                _prepare_text_file_discard_to_batch(
+                    batch_name,
+                    discard_input,
+                    metadata=metadata,
+                    ownership_stack=ownership_stack,
+                )
+                if discard_input is not None else None
+            )
+            if prepared is None:
+                flush_prepared()
+                discarded_hunks = command_discard_to_batch(
+                    batch_name,
+                    file=file_path,
+                    quiet=True,
+                    advance=False,
+                    auto_advance=auto_advance,
+                )
+                if discarded_hunks > 0:
+                    total_hunks += discarded_hunks
+                    discarded_files.append(file_path)
+                    metadata = read_batch_metadata(batch_name)
+                    blocked_hashes = read_text_file_line_set(blocklist_path)
+                continue
+
+            prepared_discards.append(prepared)
+            log_journal(
+                "discard_file_to_batch_end",
+                batch_name=batch_name,
+                file_path=file_path,
+            )
+
+        flush_prepared()
+    finally:
+        ownership_stack.close()
+        patch_stack.close()
+
+    if advance:
+        finish_selected_change_action(quiet=quiet, auto_advance=auto_advance)
+
+    return DiscardFilesToBatchResult(
+        discarded_hunks=total_hunks,
+        discarded_files=discarded_files,
+    )

--- a/src/git_stage_batch/commands/file_scope/discard_to_batch.py
+++ b/src/git_stage_batch/commands/file_scope/discard_to_batch.py
@@ -277,7 +277,7 @@ def _discard_prepared_text_files_to_batch(
     )
 
 
-def command_discard_files_to_batch(
+def discard_files_to_batch(
     batch_name: str,
     files: list[str],
     *,

--- a/src/git_stage_batch/commands/file_scope/discard_to_batch.py
+++ b/src/git_stage_batch/commands/file_scope/discard_to_batch.py
@@ -36,8 +36,8 @@ from ...utils.paths import (
     get_block_list_file_path,
     get_context_lines,
 )
-from ..discard import command_discard_to_batch
 from ..selection.action_completion import finish_selected_change_action
+from .discard_file_to_batch import discard_file_to_batch
 
 
 @dataclass(frozen=True)
@@ -398,9 +398,9 @@ def discard_files_to_batch(
 
             if discard_input is None or not session.prepare_text_file(discard_input):
                 session.flush()
-                discarded_hunks = command_discard_to_batch(
+                discarded_hunks = discard_file_to_batch(
                     batch_name,
-                    file=file_path,
+                    file_path,
                     quiet=True,
                     advance=False,
                     auto_advance=auto_advance,

--- a/src/git_stage_batch/commands/file_scope/multi_file_actions.py
+++ b/src/git_stage_batch/commands/file_scope/multi_file_actions.py
@@ -12,7 +12,7 @@ from ...data.hunk_tracking import select_next_change_after_action
 from ...data.undo import undo_checkpoint
 from ...exceptions import CommandError
 from ...i18n import _, ngettext
-from .discard_to_batch import command_discard_files_to_batch
+from .discard_to_batch import discard_files_to_batch
 from ..include import command_include_file
 from ..selection.selected_change_display import show_selected_change
 from ..skip import command_skip_file
@@ -178,7 +178,7 @@ def discard_to_batch_each_resolved_file(
     """Save a multi-file live scope to a batch and report one aggregate summary."""
     operation = f"discard --to {shlex.quote(batch_name)}"
     with _multi_file_undo_checkpoint(operation, files, worktree_paths=files):
-        result = command_discard_files_to_batch(
+        result = discard_files_to_batch(
             batch_name,
             list(files),
             quiet=True,

--- a/src/git_stage_batch/commands/file_scope/multi_file_actions.py
+++ b/src/git_stage_batch/commands/file_scope/multi_file_actions.py
@@ -12,7 +12,7 @@ from ...data.hunk_tracking import select_next_change_after_action
 from ...data.undo import undo_checkpoint
 from ...exceptions import CommandError
 from ...i18n import _, ngettext
-from ..discard import command_discard_files_to_batch
+from .discard_to_batch import command_discard_files_to_batch
 from ..include import command_include_file
 from ..selection.selected_change_display import show_selected_change
 from ..skip import command_skip_file

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -140,6 +140,7 @@ from ..utils.paths import (
     get_working_tree_snapshot_file_path,
 )
 from .selection import include_line_selection as _include_line_selection
+from .selection import include_file_selection as _include_file_selection
 from .selection import include_line_replacement as _include_line_replacement
 from .selection import replacement_selection
 from .selection import batch_line_selection as _batch_line_selection
@@ -1386,23 +1387,7 @@ def _command_include_file_lines_to_batch(
     auto_advance: bool | None = None,
 ) -> None:
     """Include specific lines from a file to batch (file-scoped with line IDs)."""
-    if render_gitlink_change(file_path) is not None:
-        exit_with_error(
-            _("Cannot use --lines with submodule pointers. Include the whole pointer instead.")
-        )
-
-    reuse_selected_file_view = (
-        read_selected_change_kind() == SelectedChangeKind.FILE
-        and get_selected_change_file_path() == file_path
-    )
-    if reuse_selected_file_view:
-        cached_lines = load_line_changes_from_state()
-    else:
-        cached_lines = cache_unstaged_file_as_single_hunk(file_path)
-
-    if cached_lines is None:
-        exit_with_error(_("No changes in file '{file}'.").format(file=file_path))
-
+    cached_lines = _include_file_selection.load_explicit_file_selection(file_path)
     # Annotate with batch source line numbers
     line_changes = annotate_with_batch_source(file_path, cached_lines)
     _include_line_selection.record_baseline_references_for_additions(line_changes)

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -143,6 +143,7 @@ from .selection import include_line_selection as _include_line_selection
 from .selection import include_line_replacement as _include_line_replacement
 from .selection import replacement_selection
 from .selection import batch_line_selection as _batch_line_selection
+from .selection import batch_line_updates as _batch_line_updates
 from .selection.selected_hunk_refresh import (
     recalculate_selected_hunk_for_command,
     refresh_selected_hunk_after_line_action,
@@ -1417,45 +1418,13 @@ def _command_include_file_lines_to_batch(
             print(_("No lines match the specified IDs in file '{file}'.").format(file=file_path), file=sys.stderr)
         return
 
-    # Auto-create batch if it doesn't exist
-    if not batch_exists(batch_name):
-        create_batch(batch_name, "Auto-created")
-
-    file_mode = detect_file_mode(file_path)
-
-    # Prepare batch ownership update (handles stale source, translation, merge)
-
-    metadata = read_batch_metadata(batch_name)
-    file_metadata = metadata.get("files", {}).get(file_path)
-
-    with ExitStack() as ownership_stack:
-        try:
-            update = ownership_stack.enter_context(
-                acquire_batch_ownership_update_for_selection(
-                    batch_name=batch_name,
-                    file_path=file_path,
-                    file_metadata=file_metadata,
-                    selected_lines=selection.selected_lines,
-                )
-            )
-        except ValueError as e:
-            exit_with_error(
-                _("Cannot include lines to batch: batch source is stale and remapping failed.\n"
-                  "File: {file}\nBatch: {batch}\nError: {error}").format(
-                    file=file_path, batch=batch_name, error=str(e))
-            )
-
-        # Snapshot file before modifying
-        snapshot_file_if_untracked(file_path)
-
-        # Save to batch
-        add_file_to_batch(
-            batch_name,
-            file_path,
-            update.ownership_after,
-            file_mode,
-            batch_source_commit=update.batch_source_commit,
-        )
+    _batch_line_updates.add_selected_lines_to_batch(
+        batch_name=batch_name,
+        file_path=file_path,
+        selected_lines=selection.selected_lines,
+        stale_source_action=_("Cannot include lines to batch"),
+        snapshot_untracked=True,
+    )
 
     if not quiet:
         print(_("Included line(s) from file '{file}' to batch '{batch}': {lines}").format(
@@ -1489,42 +1458,12 @@ def _command_include_lines_to_batch(
     if not selection.selected_lines:
         exit_with_error(_("No matching lines found for selection: {ids}").format(ids=line_id_specification))
 
-    # Auto-create batch if it doesn't exist
-    if not batch_exists(batch_name):
-        create_batch(batch_name, "Auto-created")
-
-    # Prepare batch ownership update (handles stale source, translation, merge)
-
-    metadata = read_batch_metadata(batch_name)
-    file_metadata = metadata.get("files", {}).get(line_changes.path)
-
-    file_mode = detect_file_mode(line_changes.path)
-
-    with ExitStack() as ownership_stack:
-        try:
-            update = ownership_stack.enter_context(
-                acquire_batch_ownership_update_for_selection(
-                    batch_name=batch_name,
-                    file_path=line_changes.path,
-                    file_metadata=file_metadata,
-                    selected_lines=selection.selected_lines,
-                )
-            )
-        except ValueError as e:
-            exit_with_error(
-                _("Cannot include lines to batch: batch source is stale and remapping failed.\n"
-                  "File: {file}\nBatch: {batch}\nError: {error}").format(
-                    file=line_changes.path, batch=batch_name, error=str(e))
-            )
-
-        # Save to batch using batch source model
-        add_file_to_batch(
-            batch_name,
-            line_changes.path,
-            update.ownership_after,
-            file_mode,
-            batch_source_commit=update.batch_source_commit,
-        )
+    _batch_line_updates.add_selected_lines_to_batch(
+        batch_name=batch_name,
+        file_path=line_changes.path,
+        selected_lines=selection.selected_lines,
+        stale_source_action=_("Cannot include lines to batch"),
+    )
 
     if not quiet:
         print(_("✓ Included line(s) to batch '{name}': {lines}").format(name=batch_name, lines=line_id_specification), file=sys.stderr)

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -142,6 +142,7 @@ from ..utils.paths import (
 from .selection import include_line_selection as _include_line_selection
 from .selection import include_line_replacement as _include_line_replacement
 from .selection import replacement_selection
+from .selection import batch_line_selection as _batch_line_selection
 from .selection.selected_hunk_refresh import (
     recalculate_selected_hunk_for_command,
     refresh_selected_hunk_after_line_action,
@@ -1406,15 +1407,12 @@ def _command_include_file_lines_to_batch(
     _include_line_selection.record_baseline_references_for_additions(line_changes)
 
     # Parse line IDs and filter to selected lines
-    requested_ids = set(parse_line_selection(line_id_specification))
-    require_line_selection_in_view(
+    selection = _batch_line_selection.select_lines_for_batch_action(
         line_changes,
-        requested_ids,
-        line_id_specification=line_id_specification,
+        line_id_specification,
     )
-    selected_lines = [line for line in line_changes.lines if line.id in requested_ids]
 
-    if not selected_lines:
+    if not selection.selected_lines:
         if not quiet:
             print(_("No lines match the specified IDs in file '{file}'.").format(file=file_path), file=sys.stderr)
         return
@@ -1437,7 +1435,7 @@ def _command_include_file_lines_to_batch(
                     batch_name=batch_name,
                     file_path=file_path,
                     file_metadata=file_metadata,
-                    selected_lines=selected_lines,
+                    selected_lines=selection.selected_lines,
                 )
             )
         except ValueError as e:
@@ -1480,18 +1478,15 @@ def _command_include_lines_to_batch(
 
     require_selected_hunk()
 
-    requested_ids = set(parse_line_selection(line_id_specification))
     line_changes = load_line_changes_from_state()
     _include_line_selection.record_baseline_references_for_additions(line_changes)
-    require_line_selection_in_view(
+    selection = _batch_line_selection.select_lines_for_batch_action(
         line_changes,
-        requested_ids,
-        line_id_specification=line_id_specification,
+        line_id_specification,
     )
 
     # Filter to requested display line IDs
-    selected_lines = [line for line in line_changes.lines if line.id in requested_ids]
-    if not selected_lines:
+    if not selection.selected_lines:
         exit_with_error(_("No matching lines found for selection: {ids}").format(ids=line_id_specification))
 
     # Auto-create batch if it doesn't exist
@@ -1512,7 +1507,7 @@ def _command_include_lines_to_batch(
                     batch_name=batch_name,
                     file_path=line_changes.path,
                     file_metadata=file_metadata,
-                    selected_lines=selected_lines,
+                    selected_lines=selection.selected_lines,
                 )
             )
         except ValueError as e:

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -613,53 +613,11 @@ def command_include_line(
         operation_parts.extend(["--file", file])
 
     with undo_checkpoint(" ".join(operation_parts)), ExitStack() as selected_state_stack:
-        preserve_selected_state = False
-        saved_selected_state = None
-
-        if file is None:
-            require_selected_hunk()
-            line_changes = load_line_changes_from_state()
-            line_changes = (
-                _include_line_selection.annotate_line_changes_with_working_tree_source(
-                    line_changes
-                )
-            )
-        else:
-            if file == "":
-                target_file = get_selected_change_file_path()
-                if target_file is None:
-                    exit_with_error(_("No selected hunk. Run 'show' first or specify file path."))
-            else:
-                target_file = file
-            auto_add_untracked_files([target_file])
-            selected_file_view_targets_file = (
-                _include_line_selection.selected_file_view_targets(target_file)
-            )
-            reuse_selected_file_view = (
-                _include_line_selection.selected_file_view_is_fresh_for(target_file)
-            )
-            if reuse_selected_file_view:
-                line_changes = load_line_changes_from_state()
-                line_changes = (
-                    _include_line_selection.annotate_line_changes_with_working_tree_source(
-                        line_changes
-                    )
-                )
-            else:
-                if file != "" and not selected_file_view_targets_file:
-                    preserve_selected_state = True
-                    saved_selected_state = selected_state_stack.enter_context(
-                        snapshot_selected_change_state()
-                    )
-
-                line_changes = cache_unstaged_file_as_single_hunk(target_file)
-                if line_changes is None:
-                    exit_with_error(_("No changes in file '{file}'.").format(file=target_file))
-                line_changes = (
-                    _include_line_selection.annotate_line_changes_with_working_tree_source(
-                        line_changes
-                    )
-                )
+        selection_context = _include_line_selection.load_include_line_selection_context(
+            file,
+            selected_state_stack,
+        )
+        line_changes = selection_context.line_changes
 
         requested_ids = parse_line_selection(line_id_specification)
         require_line_selection_in_view(
@@ -667,7 +625,7 @@ def command_include_line(
             set(requested_ids),
             line_id_specification=line_id_specification,
         )
-        if preserve_selected_state or (file is not None and not reuse_selected_file_view):
+        if selection_context.reset_processed_include_ids:
             already_included_ids = set()
         else:
             already_included_ids = set(read_line_ids_file(get_processed_include_ids_file_path()))
@@ -764,9 +722,9 @@ def command_include_line(
                 target_index_buffer,
             )
 
-        if preserve_selected_state:
-            assert saved_selected_state is not None
-            restore_selected_change_state(saved_selected_state)
+        if selection_context.preserve_selected_state:
+            assert selection_context.saved_selected_state is not None
+            restore_selected_change_state(selection_context.saved_selected_state)
         else:
             # Update processed include IDs only when the selected display remains
             # current for incremental line inclusion.
@@ -783,7 +741,7 @@ def command_include_line(
                 auto_advance=auto_advance,
             )
         finish_review_scoped_line_action(review_state, file_path=line_changes.path)
-    if preserve_selected_state:
+    if selection_context.preserve_selected_state:
         print(
             _("✓ Included line(s): {lines} from {file}").format(
                 lines=line_id_specification,

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -38,7 +38,6 @@ from ..core.hashing import (
     compute_text_file_deletion_hash,
 )
 from ..core.line_selection import (
-    format_line_ids,
     parse_line_selection,
     read_line_ids_file,
     write_line_ids_file,
@@ -108,7 +107,6 @@ from ..core.buffer import (
 )
 from ..utils.repository_buffers import (
     load_git_object_as_buffer,
-    load_working_tree_file_as_buffer,
 )
 from ..exceptions import NoMoreHunks, exit_with_error
 from ..i18n import _, ngettext
@@ -787,60 +785,22 @@ def command_include_line_as(
     if file is not None:
         operation_parts.extend(["--file", file])
 
+    replacement_file_context = None
     with undo_checkpoint(" ".join(operation_parts)), ExitStack() as selected_state_stack:
-        preserve_selected_state = False
-        saved_selected_state = None
-
         if file is None:
-            require_selected_hunk()
-            line_changes = load_line_changes_from_state()
-            replacement_line_changes = line_changes
-            replacement_line_id_specification = line_id_specification
-            replacement_base_buffer = None
-            replacement_source_buffer = None
-            selected_change_kind = read_selected_change_kind()
-            requested_ids = set(parse_line_selection(line_id_specification))
-            if selected_change_kind == SelectedChangeKind.FILE:
-                require_line_selection_in_view(
-                    line_changes,
-                    requested_ids,
-                    line_id_specification=line_id_specification,
+            replacement_context = (
+                _include_line_replacement.prepare_pathless_include_line_replacement(
+                    line_id_specification
                 )
-                translated_replacement = (
-                    _include_line_replacement.translate_file_view_replacement_to_unstaged_diff(
-                        line_changes,
-                        requested_ids,
-                    )
-                )
-                if translated_replacement is not None:
-                    replacement_line_changes, replacement_ids = translated_replacement
-                    replacement_line_id_specification = format_line_ids(
-                        sorted(replacement_ids)
-                    )
-                    replacement_base_buffer = load_git_object_as_buffer(
-                        f":{line_changes.path}"
-                    )
-                    if replacement_base_buffer is None:
-                        replacement_base_buffer = LineBuffer.from_bytes(b"")
-                    replacement_source_buffer = load_working_tree_file_as_buffer(
-                        line_changes.path
-                    )
-            if replacement_base_buffer is None:
-                replacement_base_buffer = LineBuffer.from_path(
-                    get_index_snapshot_file_path()
-                )
-            if replacement_source_buffer is None:
-                replacement_source_buffer = LineBuffer.from_path(
-                    get_working_tree_snapshot_file_path()
-                )
-
+            )
+            line_changes = replacement_context.display_line_changes
             with (
-                replacement_base_buffer as hunk_base_lines,
-                replacement_source_buffer as hunk_source_lines,
+                replacement_context.base_buffer as hunk_base_lines,
+                replacement_context.source_buffer as hunk_source_lines,
             ):
                 _include_line_replacement.apply_include_line_replacement(
-                    replacement_line_changes,
-                    line_id_specification=replacement_line_id_specification,
+                    replacement_context.replacement_line_changes,
+                    line_id_specification=replacement_context.line_id_specification,
                     replacement_text=replacement_text,
                     hunk_base_lines=hunk_base_lines,
                     hunk_source_lines=hunk_source_lines,
@@ -861,47 +821,18 @@ def command_include_line_as(
             )
             finish_review_scoped_line_action(review_state, file_path=line_changes.path)
         else:
-            if file == "":
-                target_file = get_selected_change_file_path()
-                if target_file is None:
-                    exit_with_error(_("No selected hunk. Run 'show' first or specify file path."))
-                preserve_selected_state = False
-            else:
-                target_file = file
-            selected_file_view_targets_file = (
-                _include_line_selection.selected_file_view_targets(target_file)
-            )
-            reuse_selected_file_view = (
-                _include_line_selection.selected_file_view_is_fresh_for(target_file)
-            )
-            if reuse_selected_file_view:
-                cached_lines = load_line_changes_from_state()
-                if cached_lines is None:
-                    exit_with_error(_("No changes in file '{file}'.").format(file=target_file))
-                annotated_changes = annotate_with_batch_source(target_file, cached_lines)
-            else:
-                if file != "" and not selected_file_view_targets_file:
-                    preserve_selected_state = True
-                saved_selected_state = (
-                    selected_state_stack.enter_context(snapshot_selected_change_state())
-                    if preserve_selected_state else None
+            replacement_file_context = (
+                _include_line_replacement.prepare_file_include_line_replacement(
+                    file,
+                    selected_state_stack,
                 )
-
-                cached_lines = cache_unstaged_file_as_single_hunk(target_file)
-                if cached_lines is None:
-                    exit_with_error(_("No changes in file '{file}'.").format(file=target_file))
-
-                annotated_changes = annotate_with_batch_source(target_file, cached_lines)
-            hunk_base_buffer = load_git_object_as_buffer(f":{target_file}")
-            if hunk_base_buffer is None:
-                hunk_base_buffer = LineBuffer.from_bytes(b"")
-
+            )
             with (
-                hunk_base_buffer as hunk_base_lines,
-                load_working_tree_file_as_buffer(target_file) as hunk_source_lines,
+                replacement_file_context.base_buffer as hunk_base_lines,
+                replacement_file_context.source_buffer as hunk_source_lines,
             ):
                 _include_line_replacement.apply_include_line_replacement(
-                    annotated_changes,
+                    replacement_file_context.line_changes,
                     line_id_specification=line_id_specification,
                     replacement_text=replacement_text,
                     hunk_base_lines=hunk_base_lines,
@@ -909,29 +840,37 @@ def command_include_line_as(
                     trim_unchanged_edge_anchors=not no_edge_overlap,
                 )
 
-            if preserve_selected_state:
-                assert saved_selected_state is not None
-                restore_selected_change_state(saved_selected_state)
+            if replacement_file_context.preserve_selected_state:
+                assert replacement_file_context.saved_selected_state is not None
+                restore_selected_change_state(
+                    replacement_file_context.saved_selected_state
+                )
             else:
                 write_line_ids_file(get_processed_include_ids_file_path(), set())
                 print(
                     _("✓ Included line(s) as replacement: {lines} from {file}").format(
                         lines=line_id_specification,
-                        file=target_file,
+                        file=replacement_file_context.target_file,
                     ),
                     file=sys.stderr,
                 )
                 refresh_selected_hunk_after_line_action(
-                    target_file,
+                    replacement_file_context.target_file,
                     auto_advance=auto_advance,
                 )
-            finish_review_scoped_line_action(review_state, file_path=target_file)
+            finish_review_scoped_line_action(
+                review_state,
+                file_path=replacement_file_context.target_file,
+            )
 
-    if preserve_selected_state:
+    if (
+        replacement_file_context is not None
+        and replacement_file_context.preserve_selected_state
+    ):
         print(
             _("✓ Included line(s) as replacement: {lines} from {file}").format(
                 lines=line_id_specification,
-                file=target_file,
+                file=replacement_file_context.target_file,
             ),
             file=sys.stderr,
         )

--- a/src/git_stage_batch/commands/selection/batch_line_selection.py
+++ b/src/git_stage_batch/commands/selection/batch_line_selection.py
@@ -1,0 +1,35 @@
+"""Batch line-selection support for command implementations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ...batch.selection import require_line_selection_in_view
+from ...core.line_selection import parse_line_selection
+
+
+@dataclass(frozen=True)
+class BatchLineSelection:
+    """Line IDs and matching changed lines selected for a batch action."""
+
+    requested_ids: set[int]
+    selected_lines: list
+
+
+def select_lines_for_batch_action(
+    line_changes,
+    line_id_specification: str,
+) -> BatchLineSelection:
+    """Validate line IDs against a view and return matching changed lines."""
+    requested_ids = set(parse_line_selection(line_id_specification))
+    require_line_selection_in_view(
+        line_changes,
+        requested_ids,
+        line_id_specification=line_id_specification,
+    )
+    return BatchLineSelection(
+        requested_ids=requested_ids,
+        selected_lines=[
+            line for line in line_changes.lines if line.id in requested_ids
+        ],
+    )

--- a/src/git_stage_batch/commands/selection/batch_line_updates.py
+++ b/src/git_stage_batch/commands/selection/batch_line_updates.py
@@ -1,0 +1,75 @@
+"""Batch updates for selected line ownership."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from contextlib import ExitStack
+
+from ...batch.operations import create_batch
+from ...batch.query import read_batch_metadata
+from ...batch.source_refresh import acquire_batch_ownership_update_for_selection
+from ...batch.storage import add_file_to_batch
+from ...batch.validation import batch_exists
+from ...data.file_modes import detect_file_mode
+from ...data.session import snapshot_file_if_untracked
+from ...exceptions import exit_with_error
+from ...i18n import _
+
+
+def add_selected_lines_to_batch(
+    *,
+    batch_name: str,
+    file_path: str,
+    selected_lines: Sequence,
+    stale_source_action: str,
+    hunk_lines: Sequence | None = None,
+    replacement_line_runs=None,
+    snapshot_untracked: bool = False,
+    before_add: Callable[[], None] | None = None,
+) -> None:
+    """Persist selected lines into batch ownership for one file."""
+    if not batch_exists(batch_name):
+        create_batch(batch_name, "Auto-created")
+
+    file_mode = detect_file_mode(file_path)
+    metadata = read_batch_metadata(batch_name)
+    file_metadata = metadata.get("files", {}).get(file_path)
+
+    with ExitStack() as ownership_stack:
+        try:
+            update = ownership_stack.enter_context(
+                acquire_batch_ownership_update_for_selection(
+                    batch_name=batch_name,
+                    file_path=file_path,
+                    file_metadata=file_metadata,
+                    selected_lines=selected_lines,
+                    hunk_lines=hunk_lines,
+                    replacement_line_runs=replacement_line_runs,
+                )
+            )
+        except ValueError as e:
+            exit_with_error(
+                _(
+                    "{action}: batch source is stale and remapping failed.\n"
+                    "File: {file}\n"
+                    "Batch: {batch}\n"
+                    "Error: {error}"
+                ).format(
+                    action=stale_source_action,
+                    file=file_path,
+                    batch=batch_name,
+                    error=str(e),
+                )
+            )
+
+        if snapshot_untracked:
+            snapshot_file_if_untracked(file_path)
+        if before_add is not None:
+            before_add()
+        add_file_to_batch(
+            batch_name,
+            file_path,
+            update.ownership_after,
+            file_mode,
+            batch_source_commit=update.batch_source_commit,
+        )

--- a/src/git_stage_batch/commands/selection/discard_line_replacement.py
+++ b/src/git_stage_batch/commands/selection/discard_line_replacement.py
@@ -3,26 +3,47 @@
 from __future__ import annotations
 
 from collections.abc import Iterator, Sequence
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
 import os
 from pathlib import Path
 
 from ...batch.display import annotate_with_batch_source_working_lines
+from ...batch.operations import create_batch
 from ...batch.ownership import (
+    BatchOwnership,
     ReplacementLineRun,
     derive_replacement_line_runs_from_lines,
+    merge_batch_ownership,
+    remap_batch_ownership_with_lineage,
+    translate_lines_to_batch_ownership,
 )
+from ...batch.query import read_batch_metadata
 from ...batch.selection import require_line_selection_in_view
+from ...batch.source_advancement import advance_source_lines_preserving_existing_presence
+from ...batch.source_refresh import (
+    acquire_batch_ownership_update_for_selection,
+    refresh_selected_lines_against_source_lines,
+)
+from ...batch.storage import add_file_to_batch
+from ...batch.validation import batch_exists
 from ...core.buffer import LineBuffer, buffer_ends_with_lf
 from ...core.line_selection import parse_line_selection
 from ...core.replacement import ReplacementPayload, coerce_replacement_payload
+from ...data.batch_sources import (
+    create_batch_source_commit,
+    load_session_batch_sources,
+    save_session_batch_sources,
+)
+from ...data.file_modes import detect_file_mode
 from ...data.file_hunk_display import build_file_hunk_from_buffer
 from ...data.line_state import load_line_changes_from_state
 from ...utils.repository_buffers import (
+    load_git_object_as_buffer,
     load_git_object_as_buffer_or_empty,
     load_working_tree_file_as_buffer,
 )
+from ...data.session import snapshot_file_if_untracked
 from ...exceptions import exit_with_error
 from ...i18n import _
 from ...staging.operations import (
@@ -158,6 +179,122 @@ def build_discard_line_replacement_target_buffer(
             selection.rewritten_working_lines
         ),
     )
+
+
+def add_discard_line_replacement_to_batch(
+    batch_name: str,
+    selection: DiscardLineReplacementSelection,
+) -> None:
+    """Persist a rewritten discard replacement selection to a batch."""
+    if not batch_exists(batch_name):
+        create_batch(batch_name, "Auto-created")
+
+    metadata = read_batch_metadata(batch_name)
+    file_metadata = metadata.get("files", {}).get(selection.file_path)
+    batch_source_commit = None
+
+    with ExitStack() as ownership_stack:
+        try:
+            if file_metadata is None:
+                update = ownership_stack.enter_context(
+                    acquire_batch_ownership_update_for_selection(
+                        batch_name=batch_name,
+                        file_path=selection.file_path,
+                        file_metadata=None,
+                        selected_lines=selection.rewritten_selected_lines,
+                    )
+                )
+                ownership = update.ownership_after
+                batch_source_commit = update.batch_source_commit
+            else:
+                ownership, batch_source_commit = _merge_replacement_with_batch(
+                    selection,
+                    file_metadata=file_metadata,
+                    ownership_stack=ownership_stack,
+                )
+        except ValueError as e:
+            exit_with_error(
+                _(
+                    "Cannot discard lines to batch: batch source is stale and remapping failed.\n"
+                    "File: {file}\n"
+                    "Batch: {batch}\n"
+                    "Error: {error}"
+                ).format(file=selection.file_path, batch=batch_name, error=str(e))
+            )
+
+        if batch_source_commit is None:
+            batch_source_commit = create_batch_source_commit(
+                selection.file_path,
+                file_buffer_override=selection.rewritten_working_lines,
+            )
+            _record_session_batch_source(selection.file_path, batch_source_commit)
+
+        snapshot_file_if_untracked(selection.file_path)
+        add_file_to_batch(
+            batch_name,
+            selection.file_path,
+            ownership,
+            detect_file_mode(selection.file_path),
+            batch_source_commit=batch_source_commit,
+        )
+
+
+def _merge_replacement_with_batch(
+    selection: DiscardLineReplacementSelection,
+    *,
+    file_metadata: dict,
+    ownership_stack: ExitStack,
+):
+    current_batch_source = file_metadata.get("batch_source_commit")
+    existing_ownership = ownership_stack.enter_context(
+        BatchOwnership.acquire_for_metadata_dict(file_metadata)
+    )
+    old_source_buffer = load_git_object_as_buffer(
+        f"{current_batch_source}:{selection.file_path}"
+    )
+    if old_source_buffer is None:
+        exit_with_error(
+            _(
+                "Cannot discard lines to batch: failed to read batch source for '{file}'."
+            ).format(file=selection.file_path)
+        )
+
+    with (
+        old_source_buffer as old_source_lines,
+        advance_source_lines_preserving_existing_presence(
+            old_lines=old_source_lines,
+            working_lines=selection.rewritten_working_lines,
+            ownership=existing_ownership,
+        ) as source_with_provenance,
+    ):
+        remapped_existing_ownership = remap_batch_ownership_with_lineage(
+            ownership=existing_ownership,
+            lineage=source_with_provenance.lineage,
+        )
+        refreshed_selected_lines = refresh_selected_lines_against_source_lines(
+            selection.rewritten_selected_lines,
+            source_lines=source_with_provenance.source_buffer,
+            working_lines=(),
+            lineage=source_with_provenance.lineage,
+        )
+        new_ownership = translate_lines_to_batch_ownership(
+            refreshed_selected_lines
+        )
+        batch_source_commit = create_batch_source_commit(
+            selection.file_path,
+            file_buffer_override=source_with_provenance.source_buffer,
+        )
+        _record_session_batch_source(selection.file_path, batch_source_commit)
+        return (
+            merge_batch_ownership(remapped_existing_ownership, new_ownership),
+            batch_source_commit,
+        )
+
+
+def _record_session_batch_source(file_path: str, batch_source_commit: str) -> None:
+    batch_sources = load_session_batch_sources()
+    batch_sources[file_path] = batch_source_commit
+    save_session_batch_sources(batch_sources)
 
 
 def _select_rewritten_replacement_lines(

--- a/src/git_stage_batch/commands/selection/discard_line_replacement.py
+++ b/src/git_stage_batch/commands/selection/discard_line_replacement.py
@@ -1,0 +1,198 @@
+"""Line-replacement support for discard commands."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass
+import os
+from pathlib import Path
+
+from ...batch.display import annotate_with_batch_source_working_lines
+from ...batch.ownership import (
+    ReplacementLineRun,
+    derive_replacement_line_runs_from_lines,
+)
+from ...batch.selection import require_line_selection_in_view
+from ...core.buffer import LineBuffer, buffer_ends_with_lf
+from ...core.line_selection import parse_line_selection
+from ...core.replacement import ReplacementPayload, coerce_replacement_payload
+from ...data.file_hunk_display import build_file_hunk_from_buffer
+from ...data.line_state import load_line_changes_from_state
+from ...utils.repository_buffers import (
+    load_git_object_as_buffer_or_empty,
+    load_working_tree_file_as_buffer,
+)
+from ...exceptions import exit_with_error
+from ...i18n import _
+from ...staging.operations import (
+    build_target_working_tree_buffer_from_lines,
+    build_target_working_tree_buffer_with_replaced_lines,
+)
+from ...utils.git import get_git_repository_root_path
+from . import replacement_selection
+
+
+@dataclass(frozen=True)
+class DiscardLineReplacementSelection:
+    """Prepared replacement selection for discard-to-batch."""
+
+    line_changes: object
+    file_path: str
+    working_file_path: Path
+    selected_lines: list
+    rewritten_line_changes: object
+    rewritten_selected_lines: list
+    rewritten_working_lines: Sequence[bytes]
+
+
+def derive_live_replacement_line_runs(file_path: str) -> list[ReplacementLineRun]:
+    """Derive file-level replacement runs for the current live file state."""
+    with (
+        load_git_object_as_buffer_or_empty(f"HEAD:{file_path}") as baseline_lines,
+        load_working_tree_file_as_buffer(file_path) as working_lines,
+    ):
+        return derive_replacement_line_runs_from_lines(
+            old_file_lines=baseline_lines,
+            new_file_lines=working_lines,
+        )
+
+
+@contextmanager
+def prepare_discard_line_replacement_selection(
+    line_id_specification: str,
+    replacement_text: str | ReplacementPayload,
+    *,
+    no_edge_overlap: bool = False,
+) -> Iterator[DiscardLineReplacementSelection]:
+    """Prepare rewritten line selection state for discard-to-batch."""
+    line_changes = load_line_changes_from_state()
+    requested_ids = set(parse_line_selection(line_id_specification))
+    require_line_selection_in_view(
+        line_changes,
+        requested_ids,
+        line_id_specification=line_id_specification,
+    )
+    effective_ids = replacement_selection.expand_replacement_selection_ids(
+        line_changes,
+        requested_ids,
+    )
+
+    selected_lines = [
+        line for line in line_changes.lines if line.id in effective_ids
+    ]
+    if not selected_lines:
+        exit_with_error(
+            _("No matching lines found for selection: {ids}").format(
+                ids=line_id_specification
+            )
+        )
+
+    working_file_path = get_git_repository_root_path() / line_changes.path
+    if not os.path.lexists(working_file_path):
+        exit_with_error(
+            _("File not found in working tree: {file}").format(
+                file=line_changes.path
+            )
+        )
+
+    replacement_payload = coerce_replacement_payload(replacement_text)
+    try:
+        with load_working_tree_file_as_buffer(line_changes.path) as working_lines:
+            rewritten_working_buffer = (
+                build_target_working_tree_buffer_with_replaced_lines(
+                    line_changes,
+                    effective_ids,
+                    replacement_payload,
+                    working_lines,
+                    working_has_trailing_newline=buffer_ends_with_lf(
+                        working_lines
+                    ),
+                    trim_unchanged_edge_anchors=not no_edge_overlap,
+                )
+            )
+    except ValueError as error:
+        exit_with_error(str(error))
+
+    with rewritten_working_buffer as rewritten_working_lines:
+        rewritten_cached_lines = build_file_hunk_from_buffer(
+            line_changes.path,
+            rewritten_working_lines,
+        )
+        if rewritten_cached_lines is None:
+            exit_with_error(
+                _("No changes in file '{file}'.").format(file=line_changes.path)
+            )
+        rewritten_line_changes = annotate_with_batch_source_working_lines(
+            line_changes.path,
+            rewritten_cached_lines,
+            rewritten_working_lines,
+        )
+        rewritten_selected_lines = _select_rewritten_replacement_lines(
+            selected_lines,
+            rewritten_line_changes,
+        )
+        yield DiscardLineReplacementSelection(
+            line_changes=line_changes,
+            file_path=line_changes.path,
+            working_file_path=working_file_path,
+            selected_lines=selected_lines,
+            rewritten_line_changes=rewritten_line_changes,
+            rewritten_selected_lines=rewritten_selected_lines,
+            rewritten_working_lines=rewritten_working_lines,
+        )
+
+
+def build_discard_line_replacement_target_buffer(
+    selection: DiscardLineReplacementSelection,
+) -> LineBuffer:
+    """Return the worktree buffer after removing rewritten replacement lines."""
+    rewritten_selected_ids = {
+        line.id for line in selection.rewritten_selected_lines if line.id is not None
+    }
+    return build_target_working_tree_buffer_from_lines(
+        selection.rewritten_line_changes,
+        rewritten_selected_ids,
+        selection.rewritten_working_lines,
+        working_has_trailing_newline=buffer_ends_with_lf(
+            selection.rewritten_working_lines
+        ),
+    )
+
+
+def _select_rewritten_replacement_lines(
+    original_selected_lines: list,
+    rewritten_line_changes,
+) -> list:
+    """Find the rewritten changed span that overlaps the original selection."""
+    original_old_lines = {
+        line.old_line_number
+        for line in original_selected_lines
+        if line.old_line_number is not None
+    }
+    original_new_lines = {
+        line.new_line_number
+        for line in original_selected_lines
+        if line.new_line_number is not None
+    }
+
+    matching_indices = [
+        index
+        for index, line in enumerate(rewritten_line_changes.lines)
+        if line.kind != " " and (
+            line.old_line_number in original_old_lines
+            or line.new_line_number in original_new_lines
+        )
+    ]
+    if matching_indices:
+        start_index = min(matching_indices)
+        end_index = max(matching_indices)
+        return [
+            line
+            for line in rewritten_line_changes.lines[start_index:end_index + 1]
+            if line.kind != " "
+        ]
+
+    exit_with_error(
+        _("Replacement selection could not be located after rewriting the file.")
+    )

--- a/src/git_stage_batch/commands/selection/discard_line_selection.py
+++ b/src/git_stage_batch/commands/selection/discard_line_selection.py
@@ -1,0 +1,70 @@
+"""Line-selection support for discard commands."""
+
+from __future__ import annotations
+
+import os
+
+from ...batch.selection import require_line_selection_in_view
+from ...core.buffer import buffer_ends_with_lf, write_buffer_to_path
+from ...core.line_selection import parse_line_selection
+from ...data.line_state import load_line_changes_from_state
+from ...utils.repository_buffers import load_working_tree_file_as_buffer
+from ...data.selected_change.loading import require_selected_hunk
+from ...data.selected_change.paths import get_selected_change_file_path
+from ...exceptions import exit_with_error
+from ...i18n import _
+from ...staging.operations import build_target_working_tree_buffer_from_lines
+from ...utils.git import get_git_repository_root_path
+from . import discard_file_selection as _discard_file_selection
+
+
+def discard_worktree_line_selection(
+    line_id_specification: str,
+    *,
+    file: str | None = None,
+) -> str:
+    """Discard selected line IDs from the working tree."""
+    if file is None:
+        require_selected_hunk()
+        line_changes = load_line_changes_from_state()
+    else:
+        if file == "":
+            target_file = get_selected_change_file_path()
+            if target_file is None:
+                exit_with_error(
+                    _("No selected hunk. Run 'show' first or specify file path.")
+                )
+        else:
+            target_file = file
+
+        line_changes = _discard_file_selection.load_explicit_file_selection(
+            target_file
+        )
+
+    requested_ids = parse_line_selection(line_id_specification)
+    require_line_selection_in_view(
+        line_changes,
+        set(requested_ids),
+        line_id_specification=line_id_specification,
+    )
+
+    working_file_path = get_git_repository_root_path() / line_changes.path
+    if not os.path.lexists(working_file_path):
+        exit_with_error(
+            _("File not found in working tree: {file}").format(
+                file=line_changes.path
+            )
+        )
+
+    with load_working_tree_file_as_buffer(line_changes.path) as working_lines:
+        target_working_buffer = build_target_working_tree_buffer_from_lines(
+            line_changes,
+            set(requested_ids),
+            working_lines,
+            working_has_trailing_newline=buffer_ends_with_lf(working_lines),
+        )
+
+    with target_working_buffer:
+        write_buffer_to_path(working_file_path, target_working_buffer)
+
+    return line_changes.path

--- a/src/git_stage_batch/commands/selection/include_file_selection.py
+++ b/src/git_stage_batch/commands/selection/include_file_selection.py
@@ -1,0 +1,27 @@
+"""File-scoped selection loading for include commands."""
+
+from __future__ import annotations
+
+from ...data.file_change_display import render_gitlink_change
+from ...data.file_hunk_display import cache_unstaged_file_as_single_hunk
+from ...data.line_state import load_line_changes_from_state
+from ...exceptions import exit_with_error
+from ...i18n import _
+from .include_line_selection import selected_file_view_targets
+
+
+def load_explicit_file_selection(file_path: str):
+    """Return the active file-scoped view for an explicit include target."""
+    if render_gitlink_change(file_path) is not None:
+        exit_with_error(
+            _("Cannot use --lines with submodule pointers. Include the whole pointer instead.")
+        )
+
+    if selected_file_view_targets(file_path):
+        line_changes = load_line_changes_from_state()
+    else:
+        line_changes = cache_unstaged_file_as_single_hunk(file_path)
+
+    if line_changes is None:
+        exit_with_error(_("No changes in file '{file}'.").format(file=file_path))
+    return line_changes

--- a/src/git_stage_batch/commands/selection/include_line_replacement.py
+++ b/src/git_stage_batch/commands/selection/include_line_replacement.py
@@ -3,21 +3,65 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from dataclasses import dataclass
 
+from ...batch.display import annotate_with_batch_source
 from ...batch.selection import require_line_selection_in_view
 from ...core.buffer import LineBuffer
-from ...core.line_selection import parse_line_selection
+from ...core.line_selection import format_line_ids, parse_line_selection
 from ...core.replacement import ReplacementPayload, coerce_replacement_payload
 from ...data.consumed_selections import record_consumed_selection
-from ...data.file_hunk_display import render_unstaged_file_as_single_hunk
+from ...data.file_hunk_display import (
+    cache_unstaged_file_as_single_hunk,
+    render_unstaged_file_as_single_hunk,
+)
+from ...data.line_state import load_line_changes_from_state
+from ...utils.repository_buffers import (
+    load_git_object_as_buffer_or_empty,
+    load_working_tree_file_as_buffer,
+)
+from ...data.selected_change.loading import require_selected_hunk
+from ...data.selected_change.paths import get_selected_change_file_path
+from ...data.selected_change.store import (
+    SelectedChangeKind,
+    read_selected_change_kind,
+    snapshot_selected_change_state,
+)
 from ...exceptions import exit_with_error
 from ...i18n import _
 from ...staging.operations import (
     build_target_index_buffer_with_replaced_lines,
     update_index_with_blob_buffer,
 )
+from ...utils.paths import (
+    get_index_snapshot_file_path,
+    get_working_tree_snapshot_file_path,
+)
 from . import include_line_selection as _include_line_selection
 from . import replacement_selection
+
+
+@dataclass(frozen=True)
+class IncludeLineReplacementSelection:
+    """Prepared pathless include replacement selection."""
+
+    display_line_changes: object
+    replacement_line_changes: object
+    line_id_specification: str
+    base_buffer: LineBuffer
+    source_buffer: LineBuffer
+
+
+@dataclass(frozen=True)
+class IncludeLineReplacementFileSelection:
+    """Prepared file-scoped include replacement selection."""
+
+    target_file: str
+    line_changes: object
+    base_buffer: LineBuffer
+    source_buffer: LineBuffer
+    preserve_selected_state: bool = False
+    saved_selected_state: object | None = None
 
 
 def apply_include_line_replacement(
@@ -78,6 +122,99 @@ def apply_include_line_replacement(
                 if line.kind == "+"
             ],
         },
+    )
+
+
+def prepare_pathless_include_line_replacement(
+    line_id_specification: str,
+) -> IncludeLineReplacementSelection:
+    """Prepare replacement context for include --line --as."""
+    require_selected_hunk()
+    line_changes = load_line_changes_from_state()
+    replacement_line_changes = line_changes
+    replacement_line_id_specification = line_id_specification
+    replacement_base_buffer = None
+    replacement_source_buffer = None
+    selected_change_kind = read_selected_change_kind()
+    requested_ids = set(parse_line_selection(line_id_specification))
+    if selected_change_kind == SelectedChangeKind.FILE:
+        require_line_selection_in_view(
+            line_changes,
+            requested_ids,
+            line_id_specification=line_id_specification,
+        )
+        translated_replacement = translate_file_view_replacement_to_unstaged_diff(
+            line_changes,
+            requested_ids,
+        )
+        if translated_replacement is not None:
+            replacement_line_changes, replacement_ids = translated_replacement
+            replacement_line_id_specification = format_line_ids(sorted(replacement_ids))
+            replacement_base_buffer = load_git_object_as_buffer_or_empty(
+                f":{line_changes.path}"
+            )
+            replacement_source_buffer = load_working_tree_file_as_buffer(
+                line_changes.path
+            )
+    if replacement_base_buffer is None:
+        replacement_base_buffer = LineBuffer.from_path(get_index_snapshot_file_path())
+    if replacement_source_buffer is None:
+        replacement_source_buffer = LineBuffer.from_path(
+            get_working_tree_snapshot_file_path()
+        )
+
+    return IncludeLineReplacementSelection(
+        display_line_changes=line_changes,
+        replacement_line_changes=replacement_line_changes,
+        line_id_specification=replacement_line_id_specification,
+        base_buffer=replacement_base_buffer,
+        source_buffer=replacement_source_buffer,
+    )
+
+
+def prepare_file_include_line_replacement(
+    file: str,
+    selected_state_stack,
+) -> IncludeLineReplacementFileSelection:
+    """Prepare replacement context for include --line --as --file."""
+    preserve_selected_state = False
+    saved_selected_state = None
+
+    if file == "":
+        target_file = get_selected_change_file_path()
+        if target_file is None:
+            exit_with_error(_("No selected hunk. Run 'show' first or specify file path."))
+    else:
+        target_file = file
+
+    selected_file_view_targets_file = _include_line_selection.selected_file_view_targets(
+        target_file
+    )
+    reuse_selected_file_view = _include_line_selection.selected_file_view_is_fresh_for(
+        target_file
+    )
+    if reuse_selected_file_view:
+        cached_lines = load_line_changes_from_state()
+        if cached_lines is None:
+            exit_with_error(_("No changes in file '{file}'.").format(file=target_file))
+    else:
+        if file != "" and not selected_file_view_targets_file:
+            preserve_selected_state = True
+            saved_selected_state = selected_state_stack.enter_context(
+                snapshot_selected_change_state()
+            )
+
+        cached_lines = cache_unstaged_file_as_single_hunk(target_file)
+        if cached_lines is None:
+            exit_with_error(_("No changes in file '{file}'.").format(file=target_file))
+
+    return IncludeLineReplacementFileSelection(
+        target_file=target_file,
+        line_changes=annotate_with_batch_source(target_file, cached_lines),
+        base_buffer=load_git_object_as_buffer_or_empty(f":{target_file}"),
+        source_buffer=load_working_tree_file_as_buffer(target_file),
+        preserve_selected_state=preserve_selected_state,
+        saved_selected_state=saved_selected_state,
     )
 
 

--- a/src/git_stage_batch/commands/selection/include_line_selection.py
+++ b/src/git_stage_batch/commands/selection/include_line_selection.py
@@ -19,14 +19,23 @@ from ...batch.storage import add_file_to_batch
 from ...batch.validation import batch_exists
 from ...core.buffer import LineBuffer, buffer_matches
 from ...data.batch_sources import create_batch_source_commit
+from ...data.file_hunk_display import cache_unstaged_file_as_single_hunk
 from ...data.file_modes import detect_file_mode
+from ...data.file_tracking import auto_add_untracked_files
+from ...data.line_state import load_line_changes_from_state
 from ...utils.repository_buffers import (
     load_git_object_as_buffer,
     load_working_tree_file_as_buffer,
 )
+from ...data.selected_change.loading import require_selected_hunk
 from ...data.selected_change.paths import get_selected_change_file_path
-from ...data.selected_change.store import SelectedChangeKind, read_selected_change_kind
+from ...data.selected_change.store import (
+    SelectedChangeKind,
+    read_selected_change_kind,
+    snapshot_selected_change_state,
+)
 from ...data.selected_change.snapshots import snapshots_are_stale
+from ...exceptions import exit_with_error
 from ...i18n import _
 from ...staging.operations import update_index_with_blob_buffer
 from ...utils.paths import get_session_batch_sources_file_path
@@ -66,6 +75,16 @@ class TransientIncludeResult:
         detail: str | None = None,
     ) -> TransientIncludeResult:
         return cls(buffer=None, failure_reason=reason, failure_detail=detail)
+
+
+@dataclass(frozen=True)
+class IncludeLineSelectionContext:
+    """Resolved selected-line view for a live include action."""
+
+    line_changes: object
+    preserve_selected_state: bool = False
+    saved_selected_state: object | None = None
+    reset_processed_include_ids: bool = False
 
 
 def record_baseline_references_for_additions(line_changes) -> None:
@@ -138,6 +157,53 @@ def selected_file_view_is_fresh_for(target_file: str) -> bool:
     return (
         selected_file_view_targets(target_file)
         and not snapshots_are_stale(target_file)
+    )
+
+
+def load_include_line_selection_context(
+    file: str | None,
+    selected_state_stack,
+) -> IncludeLineSelectionContext:
+    """Resolve the selected line view for include --line."""
+    if file is None:
+        require_selected_hunk()
+        return IncludeLineSelectionContext(
+            line_changes=annotate_line_changes_with_working_tree_source(
+                load_line_changes_from_state()
+            )
+        )
+
+    if file == "":
+        target_file = get_selected_change_file_path()
+        if target_file is None:
+            exit_with_error(_("No selected hunk. Run 'show' first or specify file path."))
+    else:
+        target_file = file
+
+    auto_add_untracked_files([target_file])
+    selected_file_view_targets_file = selected_file_view_targets(target_file)
+    reuse_selected_file_view = selected_file_view_is_fresh_for(target_file)
+    preserve_selected_state = False
+    saved_selected_state = None
+
+    if reuse_selected_file_view:
+        line_changes = load_line_changes_from_state()
+    else:
+        if file != "" and not selected_file_view_targets_file:
+            preserve_selected_state = True
+            saved_selected_state = selected_state_stack.enter_context(
+                snapshot_selected_change_state()
+            )
+
+        line_changes = cache_unstaged_file_as_single_hunk(target_file)
+        if line_changes is None:
+            exit_with_error(_("No changes in file '{file}'.").format(file=target_file))
+
+    return IncludeLineSelectionContext(
+        line_changes=annotate_line_changes_with_working_tree_source(line_changes),
+        preserve_selected_state=preserve_selected_state,
+        saved_selected_state=saved_selected_state,
+        reset_processed_include_ids=not reuse_selected_file_view,
     )
 
 

--- a/src/git_stage_batch/tui/action_dispatch.py
+++ b/src/git_stage_batch/tui/action_dispatch.py
@@ -1,0 +1,178 @@
+"""Action dispatch for interactive mode."""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from typing import Callable
+
+from ..data.file_tracking import auto_add_untracked_files
+from ..data.hunk_tracking import fetch_next_change
+from ..exceptions import BypassRefresh, QuitInteractive
+from ..i18n import _
+from ..utils.paths import get_selected_hunk_hash_file_path
+from .asset_menu import handle_asset_menu
+from .batch_menu import handle_batch_menu
+from .cli_escape import handle_cli_escape
+from .file_review import handle_current_file_review, handle_file_browser
+from .file_selection_menu import handle_file_selection_menu
+from .fixup_menu import handle_fixup_menu
+from .flow import FlowState, LocationRole
+from .flow_actions import handle_flow_action
+from .help_display import print_help
+from .hunk_actions import (
+    handle_hunk_discard,
+    handle_hunk_include,
+    handle_hunk_skip,
+)
+from .line_selection_menu import handle_line_selection_menu
+from .session_quit import handle_quit
+from .shell_command import handle_shell_command
+
+
+@dataclass
+class ActionHandler:
+    """Configuration for an interactive action."""
+
+    needs_hunk: bool
+    handler: Callable[[FlowState], None]
+
+
+def _handle_again(flow_state: FlowState) -> None:
+    """Handle again action - restart from first hunk."""
+    hunk_hash_file = get_selected_hunk_hash_file_path()
+    if hunk_hash_file.exists():
+        hunk_hash_file.unlink()
+
+    auto_add_untracked_files()
+    fetch_next_change()
+
+
+def _handle_undo(flow_state: FlowState) -> None:
+    """Handle undo action."""
+    from ..commands.undo import command_undo
+
+    command_undo()
+
+
+def _handle_redo(flow_state: FlowState) -> None:
+    """Handle redo action."""
+    from ..commands.redo import command_redo
+
+    command_redo()
+
+
+def _handle_status(flow_state: FlowState) -> None:
+    """Handle status drawer."""
+    from ..commands.status import command_status
+
+    command_status()
+    raise BypassRefresh()
+
+
+def _handle_assets(flow_state: FlowState) -> None:
+    """Handle bundled assistant asset installation."""
+    handle_asset_menu()
+    raise BypassRefresh()
+
+
+def _handle_line_selection(flow_state: FlowState) -> None:
+    """Handle line selection submenu."""
+    handle_line_selection_menu(flow_state)
+
+
+def _handle_file_selection(flow_state: FlowState) -> None:
+    """Handle file selection submenu."""
+    handle_file_selection_menu(flow_state)
+
+
+def _handle_file_review(flow_state: FlowState) -> None:
+    """Handle current-file review browser."""
+    handle_current_file_review(flow_state)
+
+
+def _handle_file_browser(flow_state: FlowState) -> None:
+    """Handle review file chooser."""
+    handle_file_browser(flow_state)
+
+
+def _handle_fixup(flow_state: FlowState) -> None:
+    """Handle fixup submenu."""
+    if flow_state.source.role is LocationRole.BATCH:
+        print(
+            _("Suggest-fixup is not available when pulling from a batch."),
+            file=sys.stderr,
+        )
+        raise BypassRefresh()
+    handle_fixup_menu()
+
+
+def _handle_quit(flow_state: FlowState) -> None:
+    """Handle quit action."""
+    handle_quit(stop_session=flow_state.stop_session_on_quit)
+    raise QuitInteractive()
+
+
+def _handle_batch(flow_state: FlowState) -> None:
+    """Handle batch management submenu."""
+    handle_batch_menu()
+
+
+def _handle_help(flow_state: FlowState) -> None:
+    """Handle help action."""
+    print_help()
+    raise BypassRefresh()
+
+
+ACTION_HANDLERS = {
+    "i": ActionHandler(needs_hunk=True, handler=handle_hunk_include),
+    "s": ActionHandler(needs_hunk=True, handler=handle_hunk_skip),
+    "d": ActionHandler(needs_hunk=True, handler=handle_hunk_discard),
+    "l": ActionHandler(needs_hunk=True, handler=_handle_line_selection),
+    "f": ActionHandler(needs_hunk=True, handler=_handle_file_selection),
+    "v": ActionHandler(needs_hunk=True, handler=_handle_file_review),
+    "o": ActionHandler(needs_hunk=False, handler=_handle_file_browser),
+    "x": ActionHandler(needs_hunk=True, handler=_handle_fixup),
+    "a": ActionHandler(needs_hunk=False, handler=_handle_again),
+    "u": ActionHandler(needs_hunk=False, handler=_handle_undo),
+    "U": ActionHandler(needs_hunk=False, handler=_handle_redo),
+    "S": ActionHandler(needs_hunk=False, handler=_handle_status),
+    "A": ActionHandler(needs_hunk=False, handler=_handle_assets),
+    "b": ActionHandler(needs_hunk=False, handler=_handle_batch),
+    "?": ActionHandler(needs_hunk=False, handler=_handle_help),
+    "q": ActionHandler(needs_hunk=False, handler=_handle_quit),
+}
+
+
+def dispatch_action(
+    action: str,
+    has_hunk: bool,
+    use_color: bool,
+    flow_state: FlowState,
+) -> None:
+    """
+    Dispatch an action to its handler.
+
+    Raises QuitInteractive to exit or BypassRefresh to skip display update.
+    """
+    if action.startswith("!"):
+        handle_shell_command(action)
+        return
+
+    if action == "":
+        return
+
+    if handle_flow_action(action, flow_state):
+        return
+
+    handler_config = ACTION_HANDLERS.get(action)
+
+    if handler_config is not None:
+        if handler_config.needs_hunk and not has_hunk:
+            print(_("No changes to process"), file=sys.stderr)
+            raise BypassRefresh()
+
+        handler_config.handler(flow_state)
+        return
+
+    handle_cli_escape(action, print_help=print_help)

--- a/src/git_stage_batch/tui/action_dispatch.py
+++ b/src/git_stage_batch/tui/action_dispatch.py
@@ -6,11 +6,9 @@ import sys
 from dataclasses import dataclass
 from typing import Callable
 
-from ..data.file_tracking import auto_add_untracked_files
-from ..data.hunk_tracking import fetch_next_change
 from ..exceptions import BypassRefresh, QuitInteractive
 from ..i18n import _
-from ..utils.paths import get_selected_hunk_hash_file_path
+from .again_action import handle_again
 from .asset_menu import handle_asset_menu
 from .batch_menu import handle_batch_menu
 from .cli_escape import handle_cli_escape
@@ -38,16 +36,6 @@ class ActionHandler:
 
     needs_hunk: bool
     handler: Callable[[FlowState], None]
-
-
-def _handle_again(flow_state: FlowState) -> None:
-    """Handle again action - restart from first hunk."""
-    hunk_hash_file = get_selected_hunk_hash_file_path()
-    if hunk_hash_file.exists():
-        hunk_hash_file.unlink()
-
-    auto_add_untracked_files()
-    fetch_next_change()
 
 
 def _handle_assets(flow_state: FlowState) -> None:
@@ -113,7 +101,7 @@ ACTION_HANDLERS = {
     "v": ActionHandler(needs_hunk=True, handler=_handle_file_review),
     "o": ActionHandler(needs_hunk=False, handler=_handle_file_browser),
     "x": ActionHandler(needs_hunk=True, handler=_handle_fixup),
-    "a": ActionHandler(needs_hunk=False, handler=_handle_again),
+    "a": ActionHandler(needs_hunk=False, handler=handle_again),
     "u": ActionHandler(needs_hunk=False, handler=handle_undo),
     "U": ActionHandler(needs_hunk=False, handler=handle_redo),
     "S": ActionHandler(needs_hunk=False, handler=handle_status),

--- a/src/git_stage_batch/tui/action_dispatch.py
+++ b/src/git_stage_batch/tui/action_dispatch.py
@@ -29,6 +29,7 @@ from .hunk_actions import (
 from .line_selection_menu import handle_line_selection_menu
 from .session_quit import handle_quit
 from .shell_command import handle_shell_command
+from .status_action import handle_status
 
 
 @dataclass
@@ -47,14 +48,6 @@ def _handle_again(flow_state: FlowState) -> None:
 
     auto_add_untracked_files()
     fetch_next_change()
-
-
-def _handle_status(flow_state: FlowState) -> None:
-    """Handle status drawer."""
-    from ..commands.status import command_status
-
-    command_status()
-    raise BypassRefresh()
 
 
 def _handle_assets(flow_state: FlowState) -> None:
@@ -123,7 +116,7 @@ ACTION_HANDLERS = {
     "a": ActionHandler(needs_hunk=False, handler=_handle_again),
     "u": ActionHandler(needs_hunk=False, handler=handle_undo),
     "U": ActionHandler(needs_hunk=False, handler=handle_redo),
-    "S": ActionHandler(needs_hunk=False, handler=_handle_status),
+    "S": ActionHandler(needs_hunk=False, handler=handle_status),
     "A": ActionHandler(needs_hunk=False, handler=_handle_assets),
     "b": ActionHandler(needs_hunk=False, handler=_handle_batch),
     "?": ActionHandler(needs_hunk=False, handler=_handle_help),

--- a/src/git_stage_batch/tui/action_dispatch.py
+++ b/src/git_stage_batch/tui/action_dispatch.py
@@ -20,6 +20,7 @@ from .fixup_menu import handle_fixup_menu
 from .flow import FlowState, LocationRole
 from .flow_actions import handle_flow_action
 from .help_display import print_help
+from .history_actions import handle_redo, handle_undo
 from .hunk_actions import (
     handle_hunk_discard,
     handle_hunk_include,
@@ -46,20 +47,6 @@ def _handle_again(flow_state: FlowState) -> None:
 
     auto_add_untracked_files()
     fetch_next_change()
-
-
-def _handle_undo(flow_state: FlowState) -> None:
-    """Handle undo action."""
-    from ..commands.undo import command_undo
-
-    command_undo()
-
-
-def _handle_redo(flow_state: FlowState) -> None:
-    """Handle redo action."""
-    from ..commands.redo import command_redo
-
-    command_redo()
 
 
 def _handle_status(flow_state: FlowState) -> None:
@@ -134,8 +121,8 @@ ACTION_HANDLERS = {
     "o": ActionHandler(needs_hunk=False, handler=_handle_file_browser),
     "x": ActionHandler(needs_hunk=True, handler=_handle_fixup),
     "a": ActionHandler(needs_hunk=False, handler=_handle_again),
-    "u": ActionHandler(needs_hunk=False, handler=_handle_undo),
-    "U": ActionHandler(needs_hunk=False, handler=_handle_redo),
+    "u": ActionHandler(needs_hunk=False, handler=handle_undo),
+    "U": ActionHandler(needs_hunk=False, handler=handle_redo),
     "S": ActionHandler(needs_hunk=False, handler=_handle_status),
     "A": ActionHandler(needs_hunk=False, handler=_handle_assets),
     "b": ActionHandler(needs_hunk=False, handler=_handle_batch),

--- a/src/git_stage_batch/tui/again_action.py
+++ b/src/git_stage_batch/tui/again_action.py
@@ -1,0 +1,11 @@
+"""Again action for interactive mode."""
+
+from __future__ import annotations
+
+from ..commands.again import command_again
+from .flow import FlowState
+
+
+def handle_again(flow_state: FlowState) -> None:
+    """Handle again action."""
+    command_again(quiet=True)

--- a/src/git_stage_batch/tui/cli_escape.py
+++ b/src/git_stage_batch/tui/cli_escape.py
@@ -1,0 +1,33 @@
+"""CLI command escape for interactive mode."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+import shlex
+
+from ..cli.argument_parser import parse_command_line
+from ..cli.execution import execute_non_interactive_args
+from ..exceptions import BypassRefresh
+from ..i18n import _
+
+
+def handle_cli_escape(action: str, *, print_help: Callable[[], None]) -> None:
+    """Handle arbitrary CLI command as an interactive escape hatch."""
+    try:
+        args_list = shlex.split(action)
+        args = parse_command_line(args_list, quiet=False)
+
+        if args is not None:
+            if (
+                getattr(args, "interactive_flag", False)
+                or getattr(args, "interactive_command", False)
+            ):
+                print(_("\nAlready in interactive mode."))
+            else:
+                execute_non_interactive_args(args)
+        else:
+            print(_("\nUnknown command: '{cmd}'").format(cmd=action))
+            print_help()
+    except Exception as error:
+        print(_("\nError executing command: {error}").format(error=error))
+    raise BypassRefresh()

--- a/src/git_stage_batch/tui/file_review/__init__.py
+++ b/src/git_stage_batch/tui/file_review/__init__.py
@@ -12,6 +12,11 @@ from ...data.file_tracking import list_untracked_files
 from ...exceptions import BypassRefresh, CommandError
 from ...i18n import _
 from ...utils.file_patterns import list_changed_files, resolve_gitignore_style_patterns
+from .batch_actions import (
+    apply_batch_file_action,
+    apply_batch_line_action,
+    apply_batch_replacement_action,
+)
 from .candidates import browse_candidates
 from .display import render_file_review
 from ..flow import FlowState, LocationRole
@@ -429,7 +434,7 @@ def _apply_marked_file_action(
 
             state = FileReviewSessionState(flow_state=flow_state, file_path=path)
             if flow_state.source.role is LocationRole.BATCH:
-                _apply_batch_file_action(state, action)
+                apply_batch_file_action(state, action)
             else:
                 _apply_live_file_action(state, action)
         except CommandError as e:
@@ -461,7 +466,7 @@ def _apply_replacement_action(state: FileReviewSessionState) -> None:
 
     try:
         if state.flow_state.source.role is LocationRole.BATCH:
-            _apply_batch_replacement_action(state, line_ids, replacement_text)
+            apply_batch_replacement_action(state, line_ids, replacement_text)
         else:
             _apply_live_replacement_action(state, line_ids, replacement_text)
     except CommandError as e:
@@ -486,7 +491,7 @@ def _apply_line_action(state: FileReviewSessionState, action: str) -> None:
 
     try:
         if state.flow_state.source.role is LocationRole.BATCH:
-            _apply_batch_line_action(state, action, line_ids)
+            apply_batch_line_action(state, action, line_ids)
         else:
             _apply_live_line_action(state, action, line_ids)
     except CommandError as e:
@@ -507,7 +512,7 @@ def _apply_file_action(state: FileReviewSessionState, action: str) -> None:
 
     try:
         if state.flow_state.source.role is LocationRole.BATCH:
-            _apply_batch_file_action(state, action)
+            apply_batch_file_action(state, action)
         else:
             _apply_live_file_action(state, action)
     except CommandError as e:
@@ -746,84 +751,6 @@ def _apply_live_file_action(state: FileReviewSessionState, action: str) -> None:
     from ...commands.discard import command_discard_file
 
     command_discard_file(state.file_path, auto_advance=False)
-
-
-def _apply_batch_line_action(
-    state: FileReviewSessionState,
-    action: str,
-    line_ids: str,
-) -> None:
-    if state.flow_state.target.role is not LocationRole.STAGING_AREA:
-        print(
-            _("Batch-to-batch transfers not yet supported. Target must be staging."),
-            file=sys.stderr,
-        )
-        return
-
-    if action == "i":
-        from ...commands.include_from import command_include_from_batch
-
-        command_include_from_batch(
-            state.flow_state.source.batch_name,
-            line_ids=line_ids,
-            file=state.file_path,
-        )
-        return
-
-    from ...commands.discard_from import command_discard_from_batch
-
-    command_discard_from_batch(
-        state.flow_state.source.batch_name,
-        line_ids=line_ids,
-        file=state.file_path,
-    )
-
-
-def _apply_batch_replacement_action(
-    state: FileReviewSessionState,
-    line_ids: str,
-    replacement_text: str,
-) -> None:
-    if state.flow_state.target.role is not LocationRole.STAGING_AREA:
-        print(
-            _("Batch-to-batch transfers not yet supported. Target must be staging."),
-            file=sys.stderr,
-        )
-        return
-
-    from ...commands.include_from import command_include_from_batch
-
-    command_include_from_batch(
-        state.flow_state.source.batch_name,
-        line_ids=line_ids,
-        file=state.file_path,
-        replacement_text=replacement_text,
-    )
-
-
-def _apply_batch_file_action(state: FileReviewSessionState, action: str) -> None:
-    if state.flow_state.target.role is not LocationRole.STAGING_AREA:
-        print(
-            _("Batch-to-batch transfers not yet supported. Target must be staging."),
-            file=sys.stderr,
-        )
-        return
-
-    if action == "I":
-        from ...commands.include_from import command_include_from_batch
-
-        command_include_from_batch(
-            state.flow_state.source.batch_name,
-            file=state.file_path,
-        )
-        return
-
-    from ...commands.discard_from import command_discard_from_batch
-
-    command_discard_from_batch(
-        state.flow_state.source.batch_name,
-        file=state.file_path,
-    )
 
 
 def _print_review_help(flow_state: FlowState) -> None:

--- a/src/git_stage_batch/tui/file_review/__init__.py
+++ b/src/git_stage_batch/tui/file_review/__init__.py
@@ -9,11 +9,10 @@ from ...batch.query import read_batch_metadata
 from ...data.file_review.state import read_last_file_review_state
 from ...data.line_state import load_line_changes_from_state
 from ...data.file_tracking import list_untracked_files
-from ...data.progress import get_hunk_counts
 from ...exceptions import BypassRefresh, CommandError
 from ...i18n import _
 from ...utils.file_patterns import list_changed_files, resolve_gitignore_style_patterns
-from ..display import print_status_bar
+from .display import render_file_review
 from ..flow import FlowState, LocationRole
 from ..prompts import (
     confirm_destructive_operation,
@@ -88,7 +87,11 @@ def handle_file_browser(flow_state: FlowState) -> None:
 
 def _review_loop(state: FileReviewSessionState) -> None:
     while True:
-        if not _render_review(state):
+        if not render_file_review(
+            state.flow_state,
+            file_path=state.file_path,
+            page_spec=state.page_spec,
+        ):
             return
 
         action = _prompt_review_action(state.flow_state)
@@ -134,35 +137,6 @@ def _review_loop(state: FileReviewSessionState) -> None:
             continue
 
         print(_("Unknown review action: {action}").format(action=action))
-
-
-def _render_review(state: FileReviewSessionState) -> bool:
-    print()
-    print_status_bar(get_hunk_counts(), state.flow_state)
-    print()
-
-    try:
-        if state.flow_state.source.role is LocationRole.BATCH:
-            from ...commands.show_from import command_show_from_batch
-
-            command_show_from_batch(
-                state.flow_state.source.batch_name,
-                file=state.file_path,
-                page=state.page_spec,
-                selectable=True,
-            )
-        else:
-            from ...commands.show import command_show
-
-            command_show(
-                file=state.file_path,
-                page=state.page_spec,
-                selectable=True,
-            )
-    except CommandError as e:
-        print(e.message, file=sys.stderr)
-        return False
-    return True
 
 
 def _prompt_review_action(flow_state: FlowState) -> str:

--- a/src/git_stage_batch/tui/file_review/__init__.py
+++ b/src/git_stage_batch/tui/file_review/__init__.py
@@ -20,6 +20,11 @@ from .batch_actions import (
 from .block_actions import block_review_file, unblock_review_file
 from .candidates import browse_candidates
 from .display import render_file_review
+from .fixup_actions import (
+    clear_file_review_fixup_state,
+    read_last_fixup_commit_hash,
+    suggest_fixup_for_lines,
+)
 from .live_actions import (
     apply_live_file_action,
     apply_live_line_action,
@@ -556,16 +561,10 @@ def _apply_fixup_action(state: FileReviewSessionState) -> None:
     if not line_ids:
         return
 
-    from ...commands.suggest_fixup import command_suggest_fixup_line
-    from ...data.suggest_fixup_state import (
-        clear_suggest_fixup_state,
-        read_suggest_fixup_state,
-    )
-
     use_color = sys.stdout.isatty()
 
     try:
-        command_suggest_fixup_line(line_ids, file=state.file_path)
+        suggest_fixup_for_lines(line_ids, file_path=state.file_path)
     except CommandError as e:
         print(e.message, file=sys.stderr)
         return
@@ -575,9 +574,8 @@ def _apply_fixup_action(state: FileReviewSessionState) -> None:
         action = prompt_fixup_action(use_color=use_color)
 
         if action == "y":
-            fixup_state = read_suggest_fixup_state()
-            if fixup_state and fixup_state.get("last_shown_commit"):
-                commit_hash = fixup_state["last_shown_commit"][:7]
+            commit_hash = read_last_fixup_commit_hash()
+            if commit_hash is not None:
                 print()
                 print(_("Create fixup commit with:"))
                 print(f"  git commit --fixup={commit_hash}")
@@ -585,20 +583,24 @@ def _apply_fixup_action(state: FileReviewSessionState) -> None:
             return
         if action == "n":
             try:
-                command_suggest_fixup_line(line_ids, file=state.file_path)
+                suggest_fixup_for_lines(line_ids, file_path=state.file_path)
             except CommandError as e:
                 print(e.message, file=sys.stderr)
                 return
             continue
         if action == "r":
             try:
-                command_suggest_fixup_line(line_ids, file=state.file_path, reset=True)
+                suggest_fixup_for_lines(
+                    line_ids,
+                    file_path=state.file_path,
+                    reset=True,
+                )
             except CommandError as e:
                 print(e.message, file=sys.stderr)
                 return
             continue
         if action == "q":
-            clear_suggest_fixup_state()
+            clear_file_review_fixup_state()
             print(_("\nCanceled."))
             return
 

--- a/src/git_stage_batch/tui/file_review/__init__.py
+++ b/src/git_stage_batch/tui/file_review/__init__.py
@@ -34,6 +34,7 @@ from .prompts import (
     print_review_help,
     prompt_review_action,
 )
+from .session import FileReviewSessionState
 from ..flow import FlowState, LocationRole
 from ..prompts import (
     confirm_destructive_operation,
@@ -41,15 +42,6 @@ from ..prompts import (
     prompt_line_ids,
     wrap_prompt_for_readline,
 )
-
-
-@dataclass
-class FileReviewSessionState:
-    """State for one interactive file review session."""
-
-    flow_state: FlowState
-    file_path: str
-    page_spec: str | None = None
 
 
 @dataclass(frozen=True)

--- a/src/git_stage_batch/tui/file_review/__init__.py
+++ b/src/git_stage_batch/tui/file_review/__init__.py
@@ -12,10 +12,13 @@ from ...data.file_tracking import list_untracked_files
 from ...exceptions import BypassRefresh, CommandError
 from ...i18n import _
 from ...utils.file_patterns import list_changed_files, resolve_gitignore_style_patterns
+from .action_router import (
+    apply_file_action,
+    apply_line_action,
+    apply_replacement_action,
+)
 from .batch_actions import (
     apply_batch_file_action,
-    apply_batch_line_action,
-    apply_batch_replacement_action,
 )
 from .block_actions import block_review_file, unblock_review_file
 from .candidates import browse_candidates
@@ -25,11 +28,7 @@ from .fixup_actions import (
     read_last_fixup_commit_hash,
     suggest_fixup_for_lines,
 )
-from .live_actions import (
-    apply_live_file_action,
-    apply_live_line_action,
-    apply_live_replacement_action,
-)
+from .live_actions import apply_live_file_action
 from .prompts import (
     normalize_review_action,
     print_review_help,
@@ -140,10 +139,10 @@ def _review_loop(state: FileReviewSessionState) -> None:
                 state.page_spec = None
             continue
         if normalized in {"i", "s", "d"}:
-            _apply_line_action(state, normalized)
+            apply_line_action(state, normalized)
             continue
         if normalized == "r":
-            _apply_replacement_action(state)
+            apply_replacement_action(state)
             continue
         if normalized == "x":
             _apply_fixup_action(state)
@@ -152,7 +151,7 @@ def _review_loop(state: FileReviewSessionState) -> None:
             browse_candidates(state)
             continue
         if normalized in {"I", "S", "D"}:
-            _apply_file_action(state, normalized)
+            apply_file_action(state, normalized)
             continue
         if normalized in {"B", "U"}:
             _apply_block_action(state, normalized)
@@ -197,18 +196,6 @@ def _previous_page_spec() -> str | None:
         return review_state.page_spec
 
     return str(current_page - 1)
-
-
-def _prompt_replacement_text() -> str | None:
-    try:
-        value = input(
-            wrap_prompt_for_readline(_("Replacement text (empty cancels): "))
-        )
-    except (KeyboardInterrupt, EOFError):
-        return None
-    if value == "":
-        return None
-    return value
 
 
 def _prompt_block_local_only() -> bool | None:
@@ -399,70 +386,6 @@ def _normalize_marked_file_action(raw_action: str) -> str | None:
     if lowered in {"d", "discard"}:
         return "D"
     return None
-
-
-def _apply_replacement_action(state: FileReviewSessionState) -> None:
-    line_ids = prompt_line_ids()
-    if not line_ids:
-        return
-
-    replacement_text = _prompt_replacement_text()
-    if replacement_text is None:
-        return
-
-    try:
-        if state.flow_state.source.role is LocationRole.BATCH:
-            apply_batch_replacement_action(state, line_ids, replacement_text)
-        else:
-            apply_live_replacement_action(state, line_ids, replacement_text)
-    except CommandError as e:
-        print(e.message, file=sys.stderr)
-
-
-def _apply_line_action(state: FileReviewSessionState, action: str) -> None:
-    if action == "s" and state.flow_state.source.role is LocationRole.BATCH:
-        print(_("Skip is not available when pulling from a batch."), file=sys.stderr)
-        return
-
-    line_ids = prompt_line_ids()
-    if not line_ids:
-        return
-
-    if action == "d" and state.flow_state.source.role is LocationRole.WORKING_TREE:
-        if not confirm_destructive_operation(
-            "discard",
-            _("This will discard the selected lines from your working tree."),
-        ):
-            return
-
-    try:
-        if state.flow_state.source.role is LocationRole.BATCH:
-            apply_batch_line_action(state, action, line_ids)
-        else:
-            apply_live_line_action(state, action, line_ids)
-    except CommandError as e:
-        print(e.message, file=sys.stderr)
-
-
-def _apply_file_action(state: FileReviewSessionState, action: str) -> None:
-    if action == "S" and state.flow_state.source.role is LocationRole.BATCH:
-        print(_("Skip is not available when pulling from a batch."), file=sys.stderr)
-        return
-
-    if action == "D" and state.flow_state.source.role is LocationRole.WORKING_TREE:
-        if not confirm_destructive_operation(
-            "discard",
-            _("This will discard the reviewed file from your working tree."),
-        ):
-            return
-
-    try:
-        if state.flow_state.source.role is LocationRole.BATCH:
-            apply_batch_file_action(state, action)
-        else:
-            apply_live_file_action(state, action)
-    except CommandError as e:
-        print(e.message, file=sys.stderr)
 
 
 def _apply_block_action(state: FileReviewSessionState, action: str) -> None:

--- a/src/git_stage_batch/tui/file_review/__init__.py
+++ b/src/git_stage_batch/tui/file_review/__init__.py
@@ -19,6 +19,11 @@ from .batch_actions import (
 )
 from .candidates import browse_candidates
 from .display import render_file_review
+from .live_actions import (
+    apply_live_file_action,
+    apply_live_line_action,
+    apply_live_replacement_action,
+)
 from ..flow import FlowState, LocationRole
 from ..prompts import (
     confirm_destructive_operation,
@@ -436,7 +441,7 @@ def _apply_marked_file_action(
             if flow_state.source.role is LocationRole.BATCH:
                 apply_batch_file_action(state, action)
             else:
-                _apply_live_file_action(state, action)
+                apply_live_file_action(state, action)
         except CommandError as e:
             print(e.message, file=sys.stderr)
 
@@ -468,7 +473,7 @@ def _apply_replacement_action(state: FileReviewSessionState) -> None:
         if state.flow_state.source.role is LocationRole.BATCH:
             apply_batch_replacement_action(state, line_ids, replacement_text)
         else:
-            _apply_live_replacement_action(state, line_ids, replacement_text)
+            apply_live_replacement_action(state, line_ids, replacement_text)
     except CommandError as e:
         print(e.message, file=sys.stderr)
 
@@ -493,7 +498,7 @@ def _apply_line_action(state: FileReviewSessionState, action: str) -> None:
         if state.flow_state.source.role is LocationRole.BATCH:
             apply_batch_line_action(state, action, line_ids)
         else:
-            _apply_live_line_action(state, action, line_ids)
+            apply_live_line_action(state, action, line_ids)
     except CommandError as e:
         print(e.message, file=sys.stderr)
 
@@ -514,7 +519,7 @@ def _apply_file_action(state: FileReviewSessionState, action: str) -> None:
         if state.flow_state.source.role is LocationRole.BATCH:
             apply_batch_file_action(state, action)
         else:
-            _apply_live_file_action(state, action)
+            apply_live_file_action(state, action)
     except CommandError as e:
         print(e.message, file=sys.stderr)
 
@@ -603,154 +608,6 @@ def _apply_fixup_action(state: FileReviewSessionState) -> None:
             return
 
         print(_("Unknown action: {action}").format(action=action))
-
-
-def _apply_live_line_action(
-    state: FileReviewSessionState,
-    action: str,
-    line_ids: str,
-) -> None:
-    if action == "i":
-        if state.flow_state.target.role is LocationRole.BATCH:
-            from ...commands.include import command_include_to_batch
-
-            command_include_to_batch(
-                state.flow_state.target.batch_name,
-                line_ids=line_ids,
-                file=state.file_path,
-                quiet=True,
-                auto_advance=False,
-            )
-            return
-
-        from ...commands.include import command_include_line
-
-        command_include_line(line_ids, file=state.file_path, auto_advance=False)
-        return
-
-    if action == "s":
-        if state.flow_state.target.role is LocationRole.BATCH:
-            from ...commands.include import command_include_to_batch
-
-            command_include_to_batch(
-                state.flow_state.target.batch_name,
-                line_ids=line_ids,
-                file=state.file_path,
-                quiet=True,
-                auto_advance=False,
-            )
-            return
-
-        from ...commands.skip import command_skip_line
-
-        command_skip_line(line_ids, file=state.file_path, auto_advance=False)
-        return
-
-    if state.flow_state.target.role is LocationRole.BATCH:
-        from ...commands.discard import command_discard_to_batch
-
-        command_discard_to_batch(
-            state.flow_state.target.batch_name,
-            line_ids=line_ids,
-            file=state.file_path,
-            quiet=True,
-            auto_advance=False,
-        )
-        return
-
-    from ...commands.discard import command_discard_line
-
-    command_discard_line(line_ids, file=state.file_path, auto_advance=False)
-
-
-def _apply_live_replacement_action(
-    state: FileReviewSessionState,
-    line_ids: str,
-    replacement_text: str,
-) -> None:
-    if state.flow_state.target.role is LocationRole.BATCH:
-        from ...commands.discard import command_discard_line_as_to_batch
-
-        command_discard_line_as_to_batch(
-            state.flow_state.target.batch_name,
-            line_ids,
-            replacement_text,
-            file=state.file_path,
-            quiet=True,
-            auto_advance=False,
-        )
-        return
-
-    from ...commands.include import command_include_line_as
-
-    command_include_line_as(
-        line_ids,
-        replacement_text,
-        file=state.file_path,
-        auto_advance=False,
-    )
-
-
-def _apply_live_file_action(state: FileReviewSessionState, action: str) -> None:
-    if action == "I":
-        if state.flow_state.target.role is LocationRole.BATCH:
-            from ...commands.include import command_include_to_batch
-
-            command_include_to_batch(
-                state.flow_state.target.batch_name,
-                file=state.file_path,
-                quiet=True,
-                auto_advance=False,
-            )
-            return
-
-        from ...commands.include import command_include_file
-
-        command_include_file(
-            state.file_path,
-            quiet=True,
-            advance=False,
-            auto_advance=False,
-        )
-        return
-
-    if action == "S":
-        if state.flow_state.target.role is LocationRole.BATCH:
-            from ...commands.include import command_include_to_batch
-
-            command_include_to_batch(
-                state.flow_state.target.batch_name,
-                file=state.file_path,
-                quiet=True,
-                auto_advance=False,
-            )
-            return
-
-        from ...commands.skip import command_skip_file
-
-        command_skip_file(
-            state.file_path,
-            quiet=True,
-            advance=False,
-            auto_advance=False,
-        )
-        return
-
-    if state.flow_state.target.role is LocationRole.BATCH:
-        from ...commands.discard import command_discard_to_batch
-
-        command_discard_to_batch(
-            state.flow_state.target.batch_name,
-            file=state.file_path,
-            quiet=True,
-            advance=False,
-            auto_advance=False,
-        )
-        return
-
-    from ...commands.discard import command_discard_file
-
-    command_discard_file(state.file_path, auto_advance=False)
 
 
 def _print_review_help(flow_state: FlowState) -> None:

--- a/src/git_stage_batch/tui/file_review/__init__.py
+++ b/src/git_stage_batch/tui/file_review/__init__.py
@@ -30,6 +30,11 @@ from .live_actions import (
     apply_live_line_action,
     apply_live_replacement_action,
 )
+from .prompts import (
+    normalize_review_action,
+    print_review_help,
+    prompt_review_action,
+)
 from ..flow import FlowState, LocationRole
 from ..prompts import (
     confirm_destructive_operation,
@@ -111,13 +116,13 @@ def _review_loop(state: FileReviewSessionState) -> None:
         ):
             return
 
-        action = _prompt_review_action(state.flow_state)
-        normalized = _normalize_review_action(action)
+        action = prompt_review_action(state.flow_state)
+        normalized = normalize_review_action(action)
 
         if normalized in {"q", "back", "quit"}:
             return
         if normalized in {"?", "help"}:
-            _print_review_help(state.flow_state)
+            print_review_help(state.flow_state)
             continue
         if normalized in {"g", "page"}:
             state.page_spec = _prompt_page_spec()
@@ -154,74 +159,6 @@ def _review_loop(state: FileReviewSessionState) -> None:
             continue
 
         print(_("Unknown review action: {action}").format(action=action))
-
-
-def _prompt_review_action(flow_state: FlowState) -> str:
-    print()
-    if flow_state.source.role is LocationRole.BATCH:
-        print(
-            _(
-                "Review action: [i]nclude lines [d]iscard lines "
-                "[r]eplace lines [I]include file [D]discard file "
-                "[B]block [U]unblock [c]andidates [n]next [p]prev [g]page "
-                "[o]open [q]back [?]help"
-            )
-        )
-    else:
-        print(
-            _(
-                "Review action: [i]nclude lines [s]kip lines [d]iscard lines "
-                "[r]eplace lines [I]include file [S]skip file [D]discard file "
-                "[B]block [U]unblock [x]fixup lines [n]next [p]prev [g]page "
-                "[o]open [q]back [?]help"
-            )
-        )
-
-    try:
-        return input(wrap_prompt_for_readline(_("Action: "))).strip()
-    except (KeyboardInterrupt, EOFError):
-        return "q"
-
-
-def _normalize_review_action(action: str) -> str:
-    if action in {"I", "S", "D", "B", "U"}:
-        return action
-
-    lowered = action.lower()
-    word_to_action = {
-        "include": "i",
-        "skip": "s",
-        "discard": "d",
-        "replace": "r",
-        "include-file": "I",
-        "include file": "I",
-        "skip-file": "S",
-        "skip file": "S",
-        "discard-file": "D",
-        "discard file": "D",
-        "block": "B",
-        "block-file": "B",
-        "block file": "B",
-        "unblock": "U",
-        "unblock-file": "U",
-        "unblock file": "U",
-        "fixup": "x",
-        "fixup-lines": "x",
-        "fixup lines": "x",
-        "candidates": "c",
-        "candidate": "c",
-        "next": "n",
-        "prev": "p",
-        "previous": "p",
-        "page": "g",
-        "goto": "g",
-        "open": "o",
-        "files": "o",
-        "back": "q",
-        "quit": "q",
-        "help": "?",
-    }
-    return word_to_action.get(lowered, lowered)
 
 
 def _prompt_page_spec() -> str | None:
@@ -605,28 +542,3 @@ def _apply_fixup_action(state: FileReviewSessionState) -> None:
             return
 
         print(_("Unknown action: {action}").format(action=action))
-
-
-def _print_review_help(flow_state: FlowState) -> None:
-    print()
-    print(_("File Review Commands:"))
-    print(_("  i, include       Include selected file-review line IDs"))
-    if flow_state.source.role is not LocationRole.BATCH:
-        print(_("  s, skip          Skip selected file-review line IDs"))
-    print(_("  d, discard       Discard selected file-review line IDs"))
-    print(_("  r, replace       Replace selected line IDs through current flow"))
-    if flow_state.source.role is not LocationRole.BATCH:
-        print(_("  x, fixup         Suggest fixup commits for selected line IDs"))
-    if flow_state.source.role is LocationRole.BATCH:
-        print(_("  c, candidates    Preview or execute batch candidates"))
-    print(_("  I                Include the reviewed file"))
-    if flow_state.source.role is not LocationRole.BATCH:
-        print(_("  S                Skip the reviewed file"))
-    print(_("  D                Discard the reviewed file"))
-    print(_("  B                Block the reviewed file"))
-    print(_("  U                Unblock the reviewed file"))
-    print(_("  n, next          Show the next file review page"))
-    print(_("  p, prev          Show the previous file review page"))
-    print(_("  g, page          Show a page or page range"))
-    print(_("  o, open          Choose another reviewable file"))
-    print(_("  q, back          Return to hunk review"))

--- a/src/git_stage_batch/tui/file_review/__init__.py
+++ b/src/git_stage_batch/tui/file_review/__init__.py
@@ -12,6 +12,7 @@ from ...data.file_tracking import list_untracked_files
 from ...exceptions import BypassRefresh, CommandError
 from ...i18n import _
 from ...utils.file_patterns import list_changed_files, resolve_gitignore_style_patterns
+from .candidates import browse_candidates
 from .display import render_file_review
 from ..flow import FlowState, LocationRole
 from ..prompts import (
@@ -127,7 +128,7 @@ def _review_loop(state: FileReviewSessionState) -> None:
             _apply_fixup_action(state)
             continue
         if normalized == "c":
-            _browse_candidates(state)
+            browse_candidates(state)
             continue
         if normalized in {"I", "S", "D"}:
             _apply_file_action(state, normalized)
@@ -447,119 +448,6 @@ def _normalize_marked_file_action(raw_action: str) -> str | None:
     if lowered in {"d", "discard"}:
         return "D"
     return None
-
-
-def _browse_candidates(state: FileReviewSessionState) -> None:
-    if state.flow_state.source.role is not LocationRole.BATCH:
-        print(_("Candidate browsing is only available when pulling from a batch."), file=sys.stderr)
-        return
-
-    operation = _prompt_candidate_operation()
-    if operation is None:
-        return
-
-    batch_name = state.flow_state.source.batch_name
-    selector = f"{batch_name}:{operation}"
-
-    try:
-        from ...commands.show_from import command_show_from_batch
-
-        command_show_from_batch(selector, file=state.file_path)
-    except CommandError as e:
-        print(e.message, file=sys.stderr)
-        return
-
-    while True:
-        choice = _prompt_candidate_action()
-        if choice is None:
-            return
-
-        if choice.isdigit():
-            _preview_candidate(batch_name, operation, int(choice), state.file_path)
-            continue
-        if choice.startswith("e "):
-            ordinal_text = choice[2:].strip()
-            if not ordinal_text.isdigit():
-                print(_("Invalid candidate selection."), file=sys.stderr)
-                continue
-            _execute_candidate(batch_name, operation, int(ordinal_text), state.file_path)
-            return
-
-        print(_("Invalid candidate selection."), file=sys.stderr)
-
-
-def _prompt_candidate_operation() -> str | None:
-    try:
-        choice = input(
-            wrap_prompt_for_readline(
-                _("Candidate operation [i]nclude, [a]pply, or q: ")
-            )
-        ).strip().lower()
-    except (KeyboardInterrupt, EOFError):
-        return None
-
-    if choice in {"q", "quit", "cancel"}:
-        return None
-    if choice in {"i", "include"}:
-        return "include"
-    if choice in {"a", "apply"}:
-        return "apply"
-
-    print(_("Invalid candidate operation."), file=sys.stderr)
-    return None
-
-
-def _prompt_candidate_action() -> str | None:
-    try:
-        choice = input(
-            wrap_prompt_for_readline(
-                _("Candidate number to preview, e N to execute, or q: ")
-            )
-        ).strip().lower()
-    except (KeyboardInterrupt, EOFError):
-        return None
-
-    if choice in {"q", "quit", "back"}:
-        return None
-    return choice
-
-
-def _preview_candidate(
-    batch_name: str,
-    operation: str,
-    ordinal: int,
-    file_path: str,
-) -> None:
-    from ...commands.show_from import command_show_from_batch
-
-    try:
-        command_show_from_batch(
-            f"{batch_name}:{operation}:{ordinal}",
-            file=file_path,
-        )
-    except CommandError as e:
-        print(e.message, file=sys.stderr)
-
-
-def _execute_candidate(
-    batch_name: str,
-    operation: str,
-    ordinal: int,
-    file_path: str,
-) -> None:
-    selector = f"{batch_name}:{operation}:{ordinal}"
-    try:
-        if operation == "include":
-            from ...commands.include_from import command_include_from_batch
-
-            command_include_from_batch(selector, file=file_path)
-            return
-
-        from ...commands.apply_from import command_apply_from_batch
-
-        command_apply_from_batch(selector, file=file_path)
-    except CommandError as e:
-        print(e.message, file=sys.stderr)
 
 
 def _apply_replacement_action(state: FileReviewSessionState) -> None:

--- a/src/git_stage_batch/tui/file_review/__init__.py
+++ b/src/git_stage_batch/tui/file_review/__init__.py
@@ -17,6 +17,7 @@ from .batch_actions import (
     apply_batch_line_action,
     apply_batch_replacement_action,
 )
+from .block_actions import block_review_file, unblock_review_file
 from .candidates import browse_candidates
 from .display import render_file_review
 from .live_actions import (
@@ -432,9 +433,7 @@ def _apply_marked_file_action(
     for path in sorted(marked_paths):
         try:
             if action == "B":
-                from ...commands.block_file import command_block_file
-
-                command_block_file(path, local_only=local_only)
+                block_review_file(path, local_only=local_only)
                 continue
 
             state = FileReviewSessionState(flow_state=flow_state, file_path=path)
@@ -537,17 +536,13 @@ def _apply_block_action(state: FileReviewSessionState, action: str) -> None:
             return
 
         try:
-            from ...commands.block_file import command_block_file
-
-            command_block_file(state.file_path, local_only=local_only)
+            block_review_file(state.file_path, local_only=local_only)
         except CommandError as e:
             print(e.message, file=sys.stderr)
         return
 
     try:
-        from ...commands.unblock_file import command_unblock_file
-
-        command_unblock_file(state.file_path)
+        unblock_review_file(state.file_path)
     except CommandError as e:
         print(e.message, file=sys.stderr)
 

--- a/src/git_stage_batch/tui/file_review/action_router.py
+++ b/src/git_stage_batch/tui/file_review/action_router.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import sys
-from typing import Protocol
 
 from ...exceptions import CommandError
 from ...i18n import _
@@ -17,7 +16,8 @@ from .live_actions import (
     apply_live_line_action,
     apply_live_replacement_action,
 )
-from ..flow import FlowState, LocationRole
+from .session import FileReviewSessionState
+from ..flow import LocationRole
 from ..prompts import (
     confirm_destructive_operation,
     prompt_line_ids,
@@ -25,14 +25,7 @@ from ..prompts import (
 )
 
 
-class FileReviewActionState(Protocol):
-    """State needed to route standard reviewed-file actions."""
-
-    flow_state: FlowState
-    file_path: str
-
-
-def apply_replacement_action(state: FileReviewActionState) -> None:
+def apply_replacement_action(state: FileReviewSessionState) -> None:
     """Prompt for replacement text and route the replacement action."""
     line_ids = prompt_line_ids()
     if not line_ids:
@@ -51,7 +44,7 @@ def apply_replacement_action(state: FileReviewActionState) -> None:
         print(e.message, file=sys.stderr)
 
 
-def apply_line_action(state: FileReviewActionState, action: str) -> None:
+def apply_line_action(state: FileReviewSessionState, action: str) -> None:
     """Prompt for line IDs and route the line action."""
     if action == "s" and state.flow_state.source.role is LocationRole.BATCH:
         print(_("Skip is not available when pulling from a batch."), file=sys.stderr)
@@ -77,7 +70,7 @@ def apply_line_action(state: FileReviewActionState, action: str) -> None:
         print(e.message, file=sys.stderr)
 
 
-def apply_file_action(state: FileReviewActionState, action: str) -> None:
+def apply_file_action(state: FileReviewSessionState, action: str) -> None:
     """Route a whole-file action for the reviewed file."""
     if action == "S" and state.flow_state.source.role is LocationRole.BATCH:
         print(_("Skip is not available when pulling from a batch."), file=sys.stderr)

--- a/src/git_stage_batch/tui/file_review/action_router.py
+++ b/src/git_stage_batch/tui/file_review/action_router.py
@@ -1,0 +1,111 @@
+"""Line, file, and replacement action routing for file review."""
+
+from __future__ import annotations
+
+import sys
+from typing import Protocol
+
+from ...exceptions import CommandError
+from ...i18n import _
+from .batch_actions import (
+    apply_batch_file_action,
+    apply_batch_line_action,
+    apply_batch_replacement_action,
+)
+from .live_actions import (
+    apply_live_file_action,
+    apply_live_line_action,
+    apply_live_replacement_action,
+)
+from ..flow import FlowState, LocationRole
+from ..prompts import (
+    confirm_destructive_operation,
+    prompt_line_ids,
+    wrap_prompt_for_readline,
+)
+
+
+class FileReviewActionState(Protocol):
+    """State needed to route standard reviewed-file actions."""
+
+    flow_state: FlowState
+    file_path: str
+
+
+def apply_replacement_action(state: FileReviewActionState) -> None:
+    """Prompt for replacement text and route the replacement action."""
+    line_ids = prompt_line_ids()
+    if not line_ids:
+        return
+
+    replacement_text = _prompt_replacement_text()
+    if replacement_text is None:
+        return
+
+    try:
+        if state.flow_state.source.role is LocationRole.BATCH:
+            apply_batch_replacement_action(state, line_ids, replacement_text)
+        else:
+            apply_live_replacement_action(state, line_ids, replacement_text)
+    except CommandError as e:
+        print(e.message, file=sys.stderr)
+
+
+def apply_line_action(state: FileReviewActionState, action: str) -> None:
+    """Prompt for line IDs and route the line action."""
+    if action == "s" and state.flow_state.source.role is LocationRole.BATCH:
+        print(_("Skip is not available when pulling from a batch."), file=sys.stderr)
+        return
+
+    line_ids = prompt_line_ids()
+    if not line_ids:
+        return
+
+    if action == "d" and state.flow_state.source.role is LocationRole.WORKING_TREE:
+        if not confirm_destructive_operation(
+            "discard",
+            _("This will discard the selected lines from your working tree."),
+        ):
+            return
+
+    try:
+        if state.flow_state.source.role is LocationRole.BATCH:
+            apply_batch_line_action(state, action, line_ids)
+        else:
+            apply_live_line_action(state, action, line_ids)
+    except CommandError as e:
+        print(e.message, file=sys.stderr)
+
+
+def apply_file_action(state: FileReviewActionState, action: str) -> None:
+    """Route a whole-file action for the reviewed file."""
+    if action == "S" and state.flow_state.source.role is LocationRole.BATCH:
+        print(_("Skip is not available when pulling from a batch."), file=sys.stderr)
+        return
+
+    if action == "D" and state.flow_state.source.role is LocationRole.WORKING_TREE:
+        if not confirm_destructive_operation(
+            "discard",
+            _("This will discard the reviewed file from your working tree."),
+        ):
+            return
+
+    try:
+        if state.flow_state.source.role is LocationRole.BATCH:
+            apply_batch_file_action(state, action)
+        else:
+            apply_live_file_action(state, action)
+    except CommandError as e:
+        print(e.message, file=sys.stderr)
+
+
+def _prompt_replacement_text() -> str | None:
+    try:
+        value = input(
+            wrap_prompt_for_readline(_("Replacement text (empty cancels): "))
+        )
+    except (KeyboardInterrupt, EOFError):
+        return None
+    if value == "":
+        return None
+    return value

--- a/src/git_stage_batch/tui/file_review/batch_actions.py
+++ b/src/git_stage_batch/tui/file_review/batch_actions.py
@@ -1,0 +1,98 @@
+"""Batch-source action execution for file review."""
+
+from __future__ import annotations
+
+import sys
+from typing import Protocol
+
+from ...i18n import _
+from ..flow import FlowState, LocationRole
+
+
+class FileReviewBatchActionState(Protocol):
+    """State needed to apply actions from a reviewed batch file."""
+
+    flow_state: FlowState
+    file_path: str
+
+
+def apply_batch_line_action(
+    state: FileReviewBatchActionState,
+    action: str,
+    line_ids: str,
+) -> None:
+    """Apply a line action from a batch-backed file review."""
+    if state.flow_state.target.role is not LocationRole.STAGING_AREA:
+        _print_batch_to_batch_error()
+        return
+
+    if action == "i":
+        from ...commands.include_from import command_include_from_batch
+
+        command_include_from_batch(
+            state.flow_state.source.batch_name,
+            line_ids=line_ids,
+            file=state.file_path,
+        )
+        return
+
+    from ...commands.discard_from import command_discard_from_batch
+
+    command_discard_from_batch(
+        state.flow_state.source.batch_name,
+        line_ids=line_ids,
+        file=state.file_path,
+    )
+
+
+def apply_batch_replacement_action(
+    state: FileReviewBatchActionState,
+    line_ids: str,
+    replacement_text: str,
+) -> None:
+    """Apply a replacement action from a batch-backed file review."""
+    if state.flow_state.target.role is not LocationRole.STAGING_AREA:
+        _print_batch_to_batch_error()
+        return
+
+    from ...commands.include_from import command_include_from_batch
+
+    command_include_from_batch(
+        state.flow_state.source.batch_name,
+        line_ids=line_ids,
+        file=state.file_path,
+        replacement_text=replacement_text,
+    )
+
+
+def apply_batch_file_action(
+    state: FileReviewBatchActionState,
+    action: str,
+) -> None:
+    """Apply a whole-file action from a batch-backed file review."""
+    if state.flow_state.target.role is not LocationRole.STAGING_AREA:
+        _print_batch_to_batch_error()
+        return
+
+    if action == "I":
+        from ...commands.include_from import command_include_from_batch
+
+        command_include_from_batch(
+            state.flow_state.source.batch_name,
+            file=state.file_path,
+        )
+        return
+
+    from ...commands.discard_from import command_discard_from_batch
+
+    command_discard_from_batch(
+        state.flow_state.source.batch_name,
+        file=state.file_path,
+    )
+
+
+def _print_batch_to_batch_error() -> None:
+    print(
+        _("Batch-to-batch transfers not yet supported. Target must be staging."),
+        file=sys.stderr,
+    )

--- a/src/git_stage_batch/tui/file_review/batch_actions.py
+++ b/src/git_stage_batch/tui/file_review/batch_actions.py
@@ -3,21 +3,14 @@
 from __future__ import annotations
 
 import sys
-from typing import Protocol
 
 from ...i18n import _
-from ..flow import FlowState, LocationRole
-
-
-class FileReviewBatchActionState(Protocol):
-    """State needed to apply actions from a reviewed batch file."""
-
-    flow_state: FlowState
-    file_path: str
+from .session import FileReviewSessionState
+from ..flow import LocationRole
 
 
 def apply_batch_line_action(
-    state: FileReviewBatchActionState,
+    state: FileReviewSessionState,
     action: str,
     line_ids: str,
 ) -> None:
@@ -46,7 +39,7 @@ def apply_batch_line_action(
 
 
 def apply_batch_replacement_action(
-    state: FileReviewBatchActionState,
+    state: FileReviewSessionState,
     line_ids: str,
     replacement_text: str,
 ) -> None:
@@ -66,7 +59,7 @@ def apply_batch_replacement_action(
 
 
 def apply_batch_file_action(
-    state: FileReviewBatchActionState,
+    state: FileReviewSessionState,
     action: str,
 ) -> None:
     """Apply a whole-file action from a batch-backed file review."""

--- a/src/git_stage_batch/tui/file_review/block_actions.py
+++ b/src/git_stage_batch/tui/file_review/block_actions.py
@@ -1,0 +1,17 @@
+"""Block action command execution for file review."""
+
+from __future__ import annotations
+
+
+def block_review_file(file_path: str, *, local_only: bool) -> None:
+    """Block a reviewed file from future review."""
+    from ...commands.block_file import command_block_file
+
+    command_block_file(file_path, local_only=local_only)
+
+
+def unblock_review_file(file_path: str) -> None:
+    """Remove a reviewed file from ignore state."""
+    from ...commands.unblock_file import command_unblock_file
+
+    command_unblock_file(file_path)

--- a/src/git_stage_batch/tui/file_review/candidates.py
+++ b/src/git_stage_batch/tui/file_review/candidates.py
@@ -1,0 +1,135 @@
+"""Candidate browser for batch-backed file review."""
+
+from __future__ import annotations
+
+import sys
+from typing import Protocol
+
+from ...exceptions import CommandError
+from ...i18n import _
+from ..flow import FlowState, LocationRole
+from ..prompts import wrap_prompt_for_readline
+
+
+class FileReviewCandidateState(Protocol):
+    """State needed to browse candidates for one reviewed file."""
+
+    flow_state: FlowState
+    file_path: str
+
+
+def browse_candidates(state: FileReviewCandidateState) -> None:
+    """Preview or execute candidate operations for a reviewed batch file."""
+    if state.flow_state.source.role is not LocationRole.BATCH:
+        print(
+            _("Candidate browsing is only available when pulling from a batch."),
+            file=sys.stderr,
+        )
+        return
+
+    operation = _prompt_candidate_operation()
+    if operation is None:
+        return
+
+    batch_name = state.flow_state.source.batch_name
+    selector = f"{batch_name}:{operation}"
+
+    try:
+        from ...commands.show_from import command_show_from_batch
+
+        command_show_from_batch(selector, file=state.file_path)
+    except CommandError as e:
+        print(e.message, file=sys.stderr)
+        return
+
+    while True:
+        choice = _prompt_candidate_action()
+        if choice is None:
+            return
+
+        if choice.isdigit():
+            _preview_candidate(batch_name, operation, int(choice), state.file_path)
+            continue
+        if choice.startswith("e "):
+            ordinal_text = choice[2:].strip()
+            if not ordinal_text.isdigit():
+                print(_("Invalid candidate selection."), file=sys.stderr)
+                continue
+            _execute_candidate(batch_name, operation, int(ordinal_text), state.file_path)
+            return
+
+        print(_("Invalid candidate selection."), file=sys.stderr)
+
+
+def _prompt_candidate_operation() -> str | None:
+    try:
+        choice = input(
+            wrap_prompt_for_readline(
+                _("Candidate operation [i]nclude, [a]pply, or q: ")
+            )
+        ).strip().lower()
+    except (KeyboardInterrupt, EOFError):
+        return None
+
+    if choice in {"q", "quit", "cancel"}:
+        return None
+    if choice in {"i", "include"}:
+        return "include"
+    if choice in {"a", "apply"}:
+        return "apply"
+
+    print(_("Invalid candidate operation."), file=sys.stderr)
+    return None
+
+
+def _prompt_candidate_action() -> str | None:
+    try:
+        choice = input(
+            wrap_prompt_for_readline(
+                _("Candidate number to preview, e N to execute, or q: ")
+            )
+        ).strip().lower()
+    except (KeyboardInterrupt, EOFError):
+        return None
+
+    if choice in {"q", "quit", "back"}:
+        return None
+    return choice
+
+
+def _preview_candidate(
+    batch_name: str,
+    operation: str,
+    ordinal: int,
+    file_path: str,
+) -> None:
+    from ...commands.show_from import command_show_from_batch
+
+    try:
+        command_show_from_batch(
+            f"{batch_name}:{operation}:{ordinal}",
+            file=file_path,
+        )
+    except CommandError as e:
+        print(e.message, file=sys.stderr)
+
+
+def _execute_candidate(
+    batch_name: str,
+    operation: str,
+    ordinal: int,
+    file_path: str,
+) -> None:
+    selector = f"{batch_name}:{operation}:{ordinal}"
+    try:
+        if operation == "include":
+            from ...commands.include_from import command_include_from_batch
+
+            command_include_from_batch(selector, file=file_path)
+            return
+
+        from ...commands.apply_from import command_apply_from_batch
+
+        command_apply_from_batch(selector, file=file_path)
+    except CommandError as e:
+        print(e.message, file=sys.stderr)

--- a/src/git_stage_batch/tui/file_review/candidates.py
+++ b/src/git_stage_batch/tui/file_review/candidates.py
@@ -3,22 +3,15 @@
 from __future__ import annotations
 
 import sys
-from typing import Protocol
 
 from ...exceptions import CommandError
 from ...i18n import _
-from ..flow import FlowState, LocationRole
+from .session import FileReviewSessionState
+from ..flow import LocationRole
 from ..prompts import wrap_prompt_for_readline
 
 
-class FileReviewCandidateState(Protocol):
-    """State needed to browse candidates for one reviewed file."""
-
-    flow_state: FlowState
-    file_path: str
-
-
-def browse_candidates(state: FileReviewCandidateState) -> None:
+def browse_candidates(state: FileReviewSessionState) -> None:
     """Preview or execute candidate operations for a reviewed batch file."""
     if state.flow_state.source.role is not LocationRole.BATCH:
         print(

--- a/src/git_stage_batch/tui/file_review/display.py
+++ b/src/git_stage_batch/tui/file_review/display.py
@@ -1,0 +1,45 @@
+"""File review display rendering for interactive mode."""
+
+from __future__ import annotations
+
+import sys
+
+from ...data.progress import get_hunk_counts
+from ...exceptions import CommandError
+from ..display import print_status_bar
+from ..flow import FlowState, LocationRole
+
+
+def render_file_review(
+    flow_state: FlowState,
+    *,
+    file_path: str,
+    page_spec: str | None,
+) -> bool:
+    """Render the reviewed file for the current interactive source."""
+    print()
+    print_status_bar(get_hunk_counts(), flow_state)
+    print()
+
+    try:
+        if flow_state.source.role is LocationRole.BATCH:
+            from ...commands.show_from import command_show_from_batch
+
+            command_show_from_batch(
+                flow_state.source.batch_name,
+                file=file_path,
+                page=page_spec,
+                selectable=True,
+            )
+        else:
+            from ...commands.show import command_show
+
+            command_show(
+                file=file_path,
+                page=page_spec,
+                selectable=True,
+            )
+    except CommandError as e:
+        print(e.message, file=sys.stderr)
+        return False
+    return True

--- a/src/git_stage_batch/tui/file_review/fixup_actions.py
+++ b/src/git_stage_batch/tui/file_review/fixup_actions.py
@@ -1,0 +1,36 @@
+"""Suggest-fixup command helpers for file review."""
+
+from __future__ import annotations
+
+
+def suggest_fixup_for_lines(
+    line_ids: str,
+    *,
+    file_path: str,
+    reset: bool = False,
+) -> None:
+    """Show a suggest-fixup candidate for reviewed line IDs."""
+    from ...commands.suggest_fixup import command_suggest_fixup_line
+
+    if reset:
+        command_suggest_fixup_line(line_ids, file=file_path, reset=True)
+        return
+
+    command_suggest_fixup_line(line_ids, file=file_path)
+
+
+def read_last_fixup_commit_hash() -> str | None:
+    """Return the last shown fixup commit hash for review display."""
+    from ...data.suggest_fixup_state import read_suggest_fixup_state
+
+    fixup_state = read_suggest_fixup_state()
+    if fixup_state and fixup_state.get("last_shown_commit"):
+        return fixup_state["last_shown_commit"][:7]
+    return None
+
+
+def clear_file_review_fixup_state() -> None:
+    """Clear persisted suggest-fixup selection state."""
+    from ...data.suggest_fixup_state import clear_suggest_fixup_state
+
+    clear_suggest_fixup_state()

--- a/src/git_stage_batch/tui/file_review/live_actions.py
+++ b/src/git_stage_batch/tui/file_review/live_actions.py
@@ -2,20 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Protocol
-
-from ..flow import FlowState, LocationRole
-
-
-class FileReviewLiveActionState(Protocol):
-    """State needed to apply actions from a reviewed working-tree file."""
-
-    flow_state: FlowState
-    file_path: str
+from .session import FileReviewSessionState
+from ..flow import LocationRole
 
 
 def apply_live_line_action(
-    state: FileReviewLiveActionState,
+    state: FileReviewSessionState,
     action: str,
     line_ids: str,
 ) -> None:
@@ -74,7 +66,7 @@ def apply_live_line_action(
 
 
 def apply_live_replacement_action(
-    state: FileReviewLiveActionState,
+    state: FileReviewSessionState,
     line_ids: str,
     replacement_text: str,
 ) -> None:
@@ -103,7 +95,7 @@ def apply_live_replacement_action(
 
 
 def apply_live_file_action(
-    state: FileReviewLiveActionState,
+    state: FileReviewSessionState,
     action: str,
 ) -> None:
     """Apply a whole-file action from a working-tree file review."""

--- a/src/git_stage_batch/tui/file_review/live_actions.py
+++ b/src/git_stage_batch/tui/file_review/live_actions.py
@@ -1,0 +1,168 @@
+"""Working-tree action execution for file review."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from ..flow import FlowState, LocationRole
+
+
+class FileReviewLiveActionState(Protocol):
+    """State needed to apply actions from a reviewed working-tree file."""
+
+    flow_state: FlowState
+    file_path: str
+
+
+def apply_live_line_action(
+    state: FileReviewLiveActionState,
+    action: str,
+    line_ids: str,
+) -> None:
+    """Apply a line action from a working-tree file review."""
+    if action == "i":
+        if state.flow_state.target.role is LocationRole.BATCH:
+            from ...commands.include import command_include_to_batch
+
+            command_include_to_batch(
+                state.flow_state.target.batch_name,
+                line_ids=line_ids,
+                file=state.file_path,
+                quiet=True,
+                auto_advance=False,
+            )
+            return
+
+        from ...commands.include import command_include_line
+
+        command_include_line(line_ids, file=state.file_path, auto_advance=False)
+        return
+
+    if action == "s":
+        if state.flow_state.target.role is LocationRole.BATCH:
+            from ...commands.include import command_include_to_batch
+
+            command_include_to_batch(
+                state.flow_state.target.batch_name,
+                line_ids=line_ids,
+                file=state.file_path,
+                quiet=True,
+                auto_advance=False,
+            )
+            return
+
+        from ...commands.skip import command_skip_line
+
+        command_skip_line(line_ids, file=state.file_path, auto_advance=False)
+        return
+
+    if state.flow_state.target.role is LocationRole.BATCH:
+        from ...commands.discard import command_discard_to_batch
+
+        command_discard_to_batch(
+            state.flow_state.target.batch_name,
+            line_ids=line_ids,
+            file=state.file_path,
+            quiet=True,
+            auto_advance=False,
+        )
+        return
+
+    from ...commands.discard import command_discard_line
+
+    command_discard_line(line_ids, file=state.file_path, auto_advance=False)
+
+
+def apply_live_replacement_action(
+    state: FileReviewLiveActionState,
+    line_ids: str,
+    replacement_text: str,
+) -> None:
+    """Apply a replacement action from a working-tree file review."""
+    if state.flow_state.target.role is LocationRole.BATCH:
+        from ...commands.discard import command_discard_line_as_to_batch
+
+        command_discard_line_as_to_batch(
+            state.flow_state.target.batch_name,
+            line_ids,
+            replacement_text,
+            file=state.file_path,
+            quiet=True,
+            auto_advance=False,
+        )
+        return
+
+    from ...commands.include import command_include_line_as
+
+    command_include_line_as(
+        line_ids,
+        replacement_text,
+        file=state.file_path,
+        auto_advance=False,
+    )
+
+
+def apply_live_file_action(
+    state: FileReviewLiveActionState,
+    action: str,
+) -> None:
+    """Apply a whole-file action from a working-tree file review."""
+    if action == "I":
+        if state.flow_state.target.role is LocationRole.BATCH:
+            from ...commands.include import command_include_to_batch
+
+            command_include_to_batch(
+                state.flow_state.target.batch_name,
+                file=state.file_path,
+                quiet=True,
+                auto_advance=False,
+            )
+            return
+
+        from ...commands.include import command_include_file
+
+        command_include_file(
+            state.file_path,
+            quiet=True,
+            advance=False,
+            auto_advance=False,
+        )
+        return
+
+    if action == "S":
+        if state.flow_state.target.role is LocationRole.BATCH:
+            from ...commands.include import command_include_to_batch
+
+            command_include_to_batch(
+                state.flow_state.target.batch_name,
+                file=state.file_path,
+                quiet=True,
+                auto_advance=False,
+            )
+            return
+
+        from ...commands.skip import command_skip_file
+
+        command_skip_file(
+            state.file_path,
+            quiet=True,
+            advance=False,
+            auto_advance=False,
+        )
+        return
+
+    if state.flow_state.target.role is LocationRole.BATCH:
+        from ...commands.discard import command_discard_to_batch
+
+        command_discard_to_batch(
+            state.flow_state.target.batch_name,
+            file=state.file_path,
+            quiet=True,
+            advance=False,
+            auto_advance=False,
+        )
+        return
+
+    from ...commands.discard import command_discard_file
+
+    command_discard_file(state.file_path, auto_advance=False)

--- a/src/git_stage_batch/tui/file_review/prompts.py
+++ b/src/git_stage_batch/tui/file_review/prompts.py
@@ -1,0 +1,103 @@
+"""Prompt text and action parsing for file review."""
+
+from __future__ import annotations
+
+from ...i18n import _
+from ..flow import FlowState, LocationRole
+from ..prompts import wrap_prompt_for_readline
+
+
+def prompt_review_action(flow_state: FlowState) -> str:
+    """Prompt for the next reviewed-file action."""
+    print()
+    if flow_state.source.role is LocationRole.BATCH:
+        print(
+            _(
+                "Review action: [i]nclude lines [d]iscard lines "
+                "[r]eplace lines [I]include file [D]discard file "
+                "[B]block [U]unblock [c]andidates [n]next [p]prev [g]page "
+                "[o]open [q]back [?]help"
+            )
+        )
+    else:
+        print(
+            _(
+                "Review action: [i]nclude lines [s]kip lines [d]iscard lines "
+                "[r]eplace lines [I]include file [S]skip file [D]discard file "
+                "[B]block [U]unblock [x]fixup lines [n]next [p]prev [g]page "
+                "[o]open [q]back [?]help"
+            )
+        )
+
+    try:
+        return input(wrap_prompt_for_readline(_("Action: "))).strip()
+    except (KeyboardInterrupt, EOFError):
+        return "q"
+
+
+def normalize_review_action(action: str) -> str:
+    """Return the canonical action key for a file-review action."""
+    if action in {"I", "S", "D", "B", "U"}:
+        return action
+
+    lowered = action.lower()
+    word_to_action = {
+        "include": "i",
+        "skip": "s",
+        "discard": "d",
+        "replace": "r",
+        "include-file": "I",
+        "include file": "I",
+        "skip-file": "S",
+        "skip file": "S",
+        "discard-file": "D",
+        "discard file": "D",
+        "block": "B",
+        "block-file": "B",
+        "block file": "B",
+        "unblock": "U",
+        "unblock-file": "U",
+        "unblock file": "U",
+        "fixup": "x",
+        "fixup-lines": "x",
+        "fixup lines": "x",
+        "candidates": "c",
+        "candidate": "c",
+        "next": "n",
+        "prev": "p",
+        "previous": "p",
+        "page": "g",
+        "goto": "g",
+        "open": "o",
+        "files": "o",
+        "back": "q",
+        "quit": "q",
+        "help": "?",
+    }
+    return word_to_action.get(lowered, lowered)
+
+
+def print_review_help(flow_state: FlowState) -> None:
+    """Print file-review help text for the current source."""
+    print()
+    print(_("File Review Commands:"))
+    print(_("  i, include       Include selected file-review line IDs"))
+    if flow_state.source.role is not LocationRole.BATCH:
+        print(_("  s, skip          Skip selected file-review line IDs"))
+    print(_("  d, discard       Discard selected file-review line IDs"))
+    print(_("  r, replace       Replace selected line IDs through current flow"))
+    if flow_state.source.role is not LocationRole.BATCH:
+        print(_("  x, fixup         Suggest fixup commits for selected line IDs"))
+    if flow_state.source.role is LocationRole.BATCH:
+        print(_("  c, candidates    Preview or execute batch candidates"))
+    print(_("  I                Include the reviewed file"))
+    if flow_state.source.role is not LocationRole.BATCH:
+        print(_("  S                Skip the reviewed file"))
+    print(_("  D                Discard the reviewed file"))
+    print(_("  B                Block the reviewed file"))
+    print(_("  U                Unblock the reviewed file"))
+    print(_("  n, next          Show the next file review page"))
+    print(_("  p, prev          Show the previous file review page"))
+    print(_("  g, page          Show a page or page range"))
+    print(_("  o, open          Choose another reviewable file"))
+    print(_("  q, back          Return to hunk review"))

--- a/src/git_stage_batch/tui/file_review/session.py
+++ b/src/git_stage_batch/tui/file_review/session.py
@@ -1,0 +1,16 @@
+"""Session state for TUI file review."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..flow import FlowState
+
+
+@dataclass
+class FileReviewSessionState:
+    """State for one interactive file review session."""
+
+    flow_state: FlowState
+    file_path: str
+    page_spec: str | None = None

--- a/src/git_stage_batch/tui/fixup_menu.py
+++ b/src/git_stage_batch/tui/fixup_menu.py
@@ -1,0 +1,69 @@
+"""Suggest-fixup submenu for interactive mode."""
+
+from __future__ import annotations
+
+from ..commands.suggest_fixup import command_suggest_fixup
+from ..data.line_state import load_line_changes_from_state
+from ..data.suggest_fixup_state import (
+    clear_suggest_fixup_state,
+    read_suggest_fixup_state,
+)
+from ..exceptions import CommandError
+from ..i18n import _
+from ..output.colors import Colors
+from .prompts import prompt_fixup_action
+
+
+def handle_fixup_menu() -> None:
+    """
+    Handle suggest-fixup submenu for iterative candidate selection.
+
+    Displays fixup candidates one at a time, prompting user to accept,
+    move to next, reset, or cancel. Maintains iteration state across
+    invocations within the same hunk context.
+    """
+    use_color = Colors.enabled()
+    line_changes = load_line_changes_from_state()
+    if line_changes is None:
+        return
+
+    try:
+        command_suggest_fixup()
+    except CommandError as error:
+        print(f"\n{error.message}")
+        return
+
+    while True:
+        print()
+        action = prompt_fixup_action(use_color=use_color)
+
+        if action == "y":
+            state = read_suggest_fixup_state()
+            if state and state.get("last_shown_commit"):
+                commit_hash = state["last_shown_commit"][:7]
+                print()
+                print(_("Create fixup commit with:"))
+                if use_color:
+                    print(f"  {Colors.BOLD}git commit --fixup={commit_hash}{Colors.RESET}")
+                else:
+                    print(f"  git commit --fixup={commit_hash}")
+                print()
+            break
+        elif action == "n":
+            try:
+                command_suggest_fixup()
+            except CommandError as error:
+                print(f"\n{error.message}")
+                break
+        elif action == "r":
+            try:
+                command_suggest_fixup(reset=True)
+            except CommandError as error:
+                print(f"\n{error.message}")
+                break
+        elif action == "q":
+            clear_suggest_fixup_state()
+            print(_("\nCanceled."))
+            break
+        else:
+            print(_("\nUnknown action: '{action}'").format(action=action))

--- a/src/git_stage_batch/tui/flow_actions.py
+++ b/src/git_stage_batch/tui/flow_actions.py
@@ -1,0 +1,31 @@
+"""Flow selection actions for interactive mode."""
+
+from __future__ import annotations
+
+from .flow import FlowLocation, FlowState, LocationRole
+from .flow_menu import handle_from_menu, handle_to_menu
+
+
+def handle_flow_action(action: str, flow_state: FlowState) -> bool:
+    """Apply source or target flow actions, returning whether one matched."""
+    if action.startswith("<"):
+        if len(action) > 1:
+            batch_name = action[1:]
+            flow_state.source = FlowLocation.for_batch(batch_name)
+            if flow_state.target.role is LocationRole.BATCH:
+                flow_state.target = FlowLocation.STAGING_AREA
+        else:
+            handle_from_menu(flow_state)
+        return True
+
+    if action.startswith(">"):
+        if len(action) > 1:
+            batch_name = action[1:]
+            flow_state.target = FlowLocation.for_batch(batch_name)
+            if flow_state.source.role is LocationRole.BATCH:
+                flow_state.source = FlowLocation.WORKING_TREE
+        else:
+            handle_to_menu(flow_state)
+        return True
+
+    return False

--- a/src/git_stage_batch/tui/help_display.py
+++ b/src/git_stage_batch/tui/help_display.py
@@ -1,0 +1,40 @@
+"""Help display for interactive mode."""
+
+from __future__ import annotations
+
+from ..i18n import _
+from ..output.colors import Colors
+
+
+def print_help() -> None:
+    """Print help text for interactive mode."""
+    use_color = Colors.enabled()
+
+    print()
+    header = _("Interactive Mode Commands:")
+    if use_color:
+        print(f"{Colors.BOLD}{header}{Colors.RESET}")
+    else:
+        print(header)
+
+    print()
+    print(_("Primary actions:"))
+    print(_("  i, include   - Stage this hunk to the index"))
+    print(_("  s, skip      - Skip this hunk for now"))
+    print(_("  d, discard   - Remove this hunk from working tree (DESTRUCTIVE)"))
+    print(_("  q, quit      - Exit interactive mode"))
+    print()
+    print(_("More options:"))
+    print(_("  a, again     - Clear state and start fresh pass through skipped hunks"))
+    print(_("  u, undo      - Undo the most recent operation"))
+    print(_("  U, redo      - Redo the most recently undone operation"))
+    print(_("  S, status    - Show session status"))
+    print(_("  A, assets    - Install bundled assistant assets"))
+    print(_("  l, lines     - Select specific lines from this hunk"))
+    print(_("  f, file      - Include or skip all hunks in this file"))
+    print(_("  v, view      - Review this whole file with page selection"))
+    print(_("  o, open      - Choose a file to review"))
+    print(_("  x, fixup     - Suggest which commit to fixup (iterative)"))
+    print(_("  !<cmd>       - Run shell command (e.g., !git log, or just ! to prompt)"))
+    print(_("  ?, help      - Show this help message"))
+    print()

--- a/src/git_stage_batch/tui/history_actions.py
+++ b/src/git_stage_batch/tui/history_actions.py
@@ -1,0 +1,17 @@
+"""Undo and redo actions for interactive mode."""
+
+from __future__ import annotations
+
+from ..commands.redo import command_redo
+from ..commands.undo import command_undo
+from .flow import FlowState
+
+
+def handle_redo(flow_state: FlowState) -> None:
+    """Handle redo action."""
+    command_redo()
+
+
+def handle_undo(flow_state: FlowState) -> None:
+    """Handle undo action."""
+    command_undo()

--- a/src/git_stage_batch/tui/interactive.py
+++ b/src/git_stage_batch/tui/interactive.py
@@ -31,6 +31,7 @@ from .file_review import handle_current_file_review, handle_file_browser
 from .fixup_menu import handle_fixup_menu
 from .flow import FlowLocation, LocationRole, FlowState
 from .flow_actions import handle_flow_action
+from .help_display import print_help
 from .hunk_actions import (
     handle_hunk_discard,
     handle_hunk_include,
@@ -347,37 +348,3 @@ def handle_quit(*, stop_session: bool = True) -> None:
     else:  # cancel
         # Return to main loop (don't exit)
         return
-
-
-def print_help() -> None:
-    """Print help text for interactive mode."""
-    use_color = Colors.enabled()
-
-    print()
-    header = _("Interactive Mode Commands:")
-    if use_color:
-        print(f"{Colors.BOLD}{header}{Colors.RESET}")
-    else:
-        print(header)
-
-    print()
-    print(_("Primary actions:"))
-    print(_("  i, include   - Stage this hunk to the index"))
-    print(_("  s, skip      - Skip this hunk for now"))
-    print(_("  d, discard   - Remove this hunk from working tree (DESTRUCTIVE)"))
-    print(_("  q, quit      - Exit interactive mode"))
-    print()
-    print(_("More options:"))
-    print(_("  a, again     - Clear state and start fresh pass through skipped hunks"))
-    print(_("  u, undo      - Undo the most recent operation"))
-    print(_("  U, redo      - Redo the most recently undone operation"))
-    print(_("  S, status    - Show session status"))
-    print(_("  A, assets    - Install bundled assistant assets"))
-    print(_("  l, lines     - Select specific lines from this hunk"))
-    print(_("  f, file      - Include or skip all hunks in this file"))
-    print(_("  v, view      - Review this whole file with page selection"))
-    print(_("  o, open      - Choose a file to review"))
-    print(_("  x, fixup     - Suggest which commit to fixup (iterative)"))
-    print(_("  !<cmd>       - Run shell command (e.g., !git log, or just ! to prompt)"))
-    print(_("  ?, help      - Show this help message"))
-    print()

--- a/src/git_stage_batch/tui/interactive.py
+++ b/src/git_stage_batch/tui/interactive.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import shlex
-import subprocess
 import sys
 from dataclasses import dataclass
 from typing import Callable
@@ -18,7 +17,7 @@ from ..i18n import _
 from ..output.colors import Colors
 from ..output.hunk import print_line_level_changes
 from ..utils.file_io import read_text_file_contents, write_text_file_contents
-from ..utils.git import get_git_repository_root_path, run_git_command
+from ..utils.git import run_git_command
 from ..utils.paths import (
     get_selected_hunk_hash_file_path,
     get_start_head_file_path,
@@ -41,8 +40,8 @@ from .line_selection_menu import handle_line_selection_menu
 from .prompts import (
     prompt_action,
     prompt_quit_session,
-    prompt_shell_command,
 )
+from .shell_command import handle_shell_command
 
 
 @dataclass
@@ -126,30 +125,6 @@ def _handle_quit(flow_state: FlowState) -> None:
     raise QuitInteractive()
 
 
-def _handle_shell(action: str) -> None:
-    """Handle shell command execution."""
-    if len(action) > 1:
-        command = action[1:].strip()
-    else:
-        command = prompt_shell_command()
-
-    if command:
-        result = subprocess.run(
-            command,
-            shell=True,
-            cwd=get_git_repository_root_path(),
-        )
-        if result.returncode != 0:
-            print(_("Command exited with status {}").format(result.returncode))
-
-        try:
-            input(_("\nPress Enter to continue..."))
-        except (KeyboardInterrupt, EOFError):
-            pass
-    else:
-        print(_("No command entered"))
-
-
 def _handle_batch(flow_state: FlowState) -> None:
     """Handle batch management submenu."""
     handle_batch_menu()
@@ -219,7 +194,7 @@ def _dispatch_action(
     Raises QuitInteractive to exit or BypassRefresh to skip display update.
     """
     if action.startswith("!"):
-        _handle_shell(action)
+        handle_shell_command(action)
         return
 
     if action == "":

--- a/src/git_stage_batch/tui/interactive.py
+++ b/src/git_stage_batch/tui/interactive.py
@@ -15,7 +15,7 @@ from ..exceptions import BypassRefresh, CommandError, QuitInteractive
 from ..i18n import _
 from ..output.colors import Colors
 from ..output.hunk import print_line_level_changes
-from ..utils.file_io import read_text_file_contents, write_text_file_contents
+from ..utils.file_io import write_text_file_contents
 from ..utils.git import run_git_command
 from ..utils.paths import (
     get_selected_hunk_hash_file_path,
@@ -40,8 +40,8 @@ from .hunk_actions import (
 from .line_selection_menu import handle_line_selection_menu
 from .prompts import (
     prompt_action,
-    prompt_quit_session,
 )
+from .session_quit import handle_quit
 from .shell_command import handle_shell_command
 
 
@@ -296,55 +296,3 @@ def start_interactive_mode() -> None:
             should_refresh = False
         except QuitInteractive:
             break
-
-
-def handle_quit(*, stop_session: bool = True) -> None:
-    """
-    Handle quit action with smart quit logic.
-
-    Checks if any changes were made (HEAD, index tree, or discards).
-    If no changes, silently stops. If changes exist, prompts user.
-    """
-    from ..commands.stop import command_stop
-    from ..commands.abort import command_abort
-
-    print()  # Move to new line after Action: prompt
-
-    # Check if any changes were made
-    start_head_file = get_start_head_file_path()
-    start_index_tree_file = get_start_index_tree_file_path()
-
-    if not start_head_file.exists() or not start_index_tree_file.exists():
-        # No start state recorded, just stop
-        if stop_session:
-            command_stop()
-        return
-
-    start_head = read_text_file_contents(start_head_file).strip()
-    start_index_tree = read_text_file_contents(start_index_tree_file).strip()
-
-    # Check selected state
-    selected_head = run_git_command(["rev-parse", "HEAD"], requires_index_lock=False).stdout.strip()
-    selected_index_tree = run_git_command(["write-tree"], requires_index_lock=False).stdout.strip()
-
-    # Check if any discards happened
-    stats = get_hunk_counts()
-    has_discards = stats.get("discarded", 0) > 0
-
-    # If nothing changed, silently stop
-    if selected_head == start_head and selected_index_tree == start_index_tree and not has_discards:
-        if stop_session:
-            command_stop()
-        return
-
-    # Changes exist, prompt user
-    choice = prompt_quit_session()
-
-    if choice == "keep":
-        if stop_session:
-            command_stop()
-    elif choice == "undo":
-        command_abort()
-    else:  # cancel
-        # Return to main loop (don't exit)
-        return

--- a/src/git_stage_batch/tui/interactive.py
+++ b/src/git_stage_batch/tui/interactive.py
@@ -29,6 +29,7 @@ from .batch_menu import handle_batch_menu
 from .display import print_status_bar
 from .file_selection_menu import handle_file_selection_menu
 from .file_review import handle_current_file_review, handle_file_browser
+from .fixup_menu import handle_fixup_menu
 from .flow import FlowLocation, LocationRole, FlowState
 from .flow_menu import handle_from_menu, handle_to_menu
 from .hunk_actions import (
@@ -39,7 +40,6 @@ from .hunk_actions import (
 from .line_selection_menu import handle_line_selection_menu
 from .prompts import (
     prompt_action,
-    prompt_fixup_action,
     prompt_quit_session,
     prompt_shell_command,
 )
@@ -117,7 +117,7 @@ def _handle_fixup(flow_state: FlowState) -> None:
         # Fixup doesn't make sense when pulling from batch
         print(_("Suggest-fixup is not available when pulling from a batch."), file=sys.stderr)
         raise BypassRefresh()
-    handle_fixup_selection()
+    handle_fixup_menu()
 
 
 def _handle_quit(flow_state: FlowState) -> None:
@@ -368,74 +368,6 @@ def start_interactive_mode() -> None:
             should_refresh = False
         except QuitInteractive:
             break
-
-
-def handle_fixup_selection() -> None:
-    """
-    Handle suggest-fixup submenu for iterative candidate selection.
-
-    Displays fixup candidates one at a time, prompting user to accept,
-    move to next, reset, or cancel. Maintains iteration state across
-    invocations within the same hunk context.
-    """
-    from ..commands.suggest_fixup import command_suggest_fixup
-    from ..data.suggest_fixup_state import (
-        clear_suggest_fixup_state,
-        read_suggest_fixup_state,
-    )
-
-    use_color = Colors.enabled()
-    line_changes = load_line_changes_from_state()
-    if line_changes is None:
-        return
-
-    # Show initial candidate
-    try:
-        command_suggest_fixup()
-    except CommandError as e:
-        # No candidates found or other error
-        print(f"\n{e.message}")
-        return
-
-    # Interactive loop for fixup candidate selection
-    while True:
-        print()
-        action = prompt_fixup_action(use_color=use_color)
-
-        if action == "y":
-            # Accept - show how to create fixup commit
-            state = read_suggest_fixup_state()
-            if state and state.get("last_shown_commit"):
-                commit_hash = state["last_shown_commit"][:7]
-                print()
-                print(_("Create fixup commit with:"))
-                if use_color:
-                    print(f"  {Colors.BOLD}git commit --fixup={commit_hash}{Colors.RESET}")
-                else:
-                    print(f"  git commit --fixup={commit_hash}")
-                print()
-            break
-        elif action == "n":
-            # Next candidate
-            try:
-                command_suggest_fixup()
-            except CommandError as e:
-                print(f"\n{e.message}")
-                break
-        elif action == "r":
-            # Reset iteration
-            try:
-                command_suggest_fixup(reset=True)
-            except CommandError as e:
-                print(f"\n{e.message}")
-                break
-        elif action == "q":
-            # Cancel - abort and exit submenu
-            clear_suggest_fixup_state()
-            print(_("\nCanceled."))
-            break
-        else:
-            print(_("\nUnknown action: '{action}'").format(action=action))
 
 
 def handle_quit(*, stop_session: bool = True) -> None:

--- a/src/git_stage_batch/tui/interactive.py
+++ b/src/git_stage_batch/tui/interactive.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import shlex
 import sys
 from dataclasses import dataclass
 from typing import Callable
@@ -25,6 +24,7 @@ from ..utils.paths import (
 )
 from .asset_menu import handle_asset_menu
 from .batch_menu import handle_batch_menu
+from .cli_escape import handle_cli_escape
 from .display import print_status_bar
 from .file_selection_menu import handle_file_selection_menu
 from .file_review import handle_current_file_review, handle_file_browser
@@ -136,31 +136,6 @@ def _handle_help(flow_state: FlowState) -> None:
     raise BypassRefresh()
 
 
-def _handle_cli_command(action: str) -> None:
-    """Handle arbitrary CLI command as escape hatch."""
-    try:
-        from ..cli.argument_parser import parse_command_line
-        from ..cli.execution import execute_non_interactive_args
-
-        args_list = shlex.split(action)
-        args = parse_command_line(args_list, quiet=False)
-
-        if args is not None:
-            if (
-                getattr(args, "interactive_flag", False)
-                or getattr(args, "interactive_command", False)
-            ):
-                print(_("\nAlready in interactive mode."))
-            else:
-                execute_non_interactive_args(args)
-        else:
-            print(_("\nUnknown command: '{cmd}'").format(cmd=action))
-            print_help()
-    except Exception as e:
-        print(_("\nError executing command: {error}").format(error=e))
-    raise BypassRefresh()
-
-
 # Map of actions to their handlers
 ACTION_HANDLERS = {
     "i": ActionHandler(needs_hunk=True, handler=handle_hunk_include),
@@ -236,7 +211,7 @@ def _dispatch_action(
         handler_config.handler(flow_state)
         return
 
-    _handle_cli_command(action)
+    handle_cli_escape(action, print_help=print_help)
 
 
 def start_interactive_mode() -> None:

--- a/src/git_stage_batch/tui/interactive.py
+++ b/src/git_stage_batch/tui/interactive.py
@@ -30,7 +30,7 @@ from .file_selection_menu import handle_file_selection_menu
 from .file_review import handle_current_file_review, handle_file_browser
 from .fixup_menu import handle_fixup_menu
 from .flow import FlowLocation, LocationRole, FlowState
-from .flow_menu import handle_from_menu, handle_to_menu
+from .flow_actions import handle_flow_action
 from .hunk_actions import (
     handle_hunk_discard,
     handle_hunk_include,
@@ -175,31 +175,8 @@ def _dispatch_action(
     if action == "":
         return
 
-    # Handle flow actions specially - they modify flow_state in place
-    if action.startswith("<"):
-        if len(action) > 1:
-            # Direct batch selection: <batch-name
-            batch_name = action[1:]
-            flow_state.source = FlowLocation.for_batch(batch_name)
-            # Prevent batch-to-batch state
-            if flow_state.target.role is LocationRole.BATCH:
-                flow_state.target = FlowLocation.STAGING_AREA
-        else:
-            # Show menu
-            handle_from_menu(flow_state)
-        return  # Refresh display after flow change
-    elif action.startswith(">"):
-        if len(action) > 1:
-            # Direct batch selection: >batch-name
-            batch_name = action[1:]
-            flow_state.target = FlowLocation.for_batch(batch_name)
-            # Prevent batch-to-batch state
-            if flow_state.source.role is LocationRole.BATCH:
-                flow_state.source = FlowLocation.WORKING_TREE
-        else:
-            # Show menu
-            handle_to_menu(flow_state)
-        return  # Refresh display after flow change
+    if handle_flow_action(action, flow_state):
+        return
 
     handler_config = ACTION_HANDLERS.get(action)
 

--- a/src/git_stage_batch/tui/interactive.py
+++ b/src/git_stage_batch/tui/interactive.py
@@ -3,11 +3,7 @@
 from __future__ import annotations
 
 import sys
-from dataclasses import dataclass
-from typing import Callable
 from ..data.selected_change.batch_file_cache import cache_batch_as_single_hunk
-from ..data.file_tracking import auto_add_untracked_files
-from ..data.hunk_tracking import fetch_next_change
 from ..data.progress import get_hunk_counts
 from ..data.line_state import load_line_changes_from_state
 from ..data.session import session_is_active
@@ -18,178 +14,15 @@ from ..output.hunk import print_line_level_changes
 from ..utils.file_io import write_text_file_contents
 from ..utils.git import run_git_command
 from ..utils.paths import (
-    get_selected_hunk_hash_file_path,
     get_start_head_file_path,
     get_start_index_tree_file_path,
 )
-from .asset_menu import handle_asset_menu
-from .batch_menu import handle_batch_menu
-from .cli_escape import handle_cli_escape
+from .action_dispatch import dispatch_action
 from .display import print_status_bar
-from .file_selection_menu import handle_file_selection_menu
-from .file_review import handle_current_file_review, handle_file_browser
-from .fixup_menu import handle_fixup_menu
 from .flow import FlowLocation, LocationRole, FlowState
-from .flow_actions import handle_flow_action
-from .help_display import print_help
-from .hunk_actions import (
-    handle_hunk_discard,
-    handle_hunk_include,
-    handle_hunk_skip,
-)
-from .line_selection_menu import handle_line_selection_menu
 from .prompts import (
     prompt_action,
 )
-from .session_quit import handle_quit
-from .shell_command import handle_shell_command
-
-
-@dataclass
-class ActionHandler:
-    """Configuration for an interactive action."""
-    needs_hunk: bool
-    handler: Callable[[FlowState], None]
-
-
-def _handle_again(flow_state: FlowState) -> None:
-    """Handle again action - restart from first hunk."""
-    # Clear selected hunk position to restart from beginning
-    # Don't use command_again() as it destroys abort state and start state
-    hunk_hash_file = get_selected_hunk_hash_file_path()
-    if hunk_hash_file.exists():
-        hunk_hash_file.unlink()
-
-    # Re-scan for untracked files
-    auto_add_untracked_files()
-
-    fetch_next_change()
-
-
-def _handle_undo(flow_state: FlowState) -> None:
-    """Handle undo action."""
-    from ..commands.undo import command_undo
-    command_undo()
-
-
-def _handle_redo(flow_state: FlowState) -> None:
-    """Handle redo action."""
-    from ..commands.redo import command_redo
-    command_redo()
-
-
-def _handle_status(flow_state: FlowState) -> None:
-    """Handle status drawer."""
-    from ..commands.status import command_status
-    command_status()
-    raise BypassRefresh()
-
-
-def _handle_assets(flow_state: FlowState) -> None:
-    """Handle bundled assistant asset installation."""
-    handle_asset_menu()
-    raise BypassRefresh()
-
-
-def _handle_line_selection(flow_state: FlowState) -> None:
-    """Handle line selection submenu."""
-    handle_line_selection_menu(flow_state)
-
-
-def _handle_file_selection(flow_state: FlowState) -> None:
-    """Handle file selection submenu."""
-    handle_file_selection_menu(flow_state)
-
-
-def _handle_file_review(flow_state: FlowState) -> None:
-    """Handle current-file review browser."""
-    handle_current_file_review(flow_state)
-
-
-def _handle_file_browser(flow_state: FlowState) -> None:
-    """Handle review file chooser."""
-    handle_file_browser(flow_state)
-
-
-def _handle_fixup(flow_state: FlowState) -> None:
-    """Handle fixup submenu."""
-    if flow_state.source.role is LocationRole.BATCH:
-        # Fixup doesn't make sense when pulling from batch
-        print(_("Suggest-fixup is not available when pulling from a batch."), file=sys.stderr)
-        raise BypassRefresh()
-    handle_fixup_menu()
-
-
-def _handle_quit(flow_state: FlowState) -> None:
-    """Handle quit action."""
-    handle_quit(stop_session=flow_state.stop_session_on_quit)
-    raise QuitInteractive()
-
-
-def _handle_batch(flow_state: FlowState) -> None:
-    """Handle batch management submenu."""
-    handle_batch_menu()
-
-
-def _handle_help(flow_state: FlowState) -> None:
-    """Handle help action."""
-    print_help()
-    raise BypassRefresh()
-
-
-# Map of actions to their handlers
-ACTION_HANDLERS = {
-    "i": ActionHandler(needs_hunk=True, handler=handle_hunk_include),
-    "s": ActionHandler(needs_hunk=True, handler=handle_hunk_skip),
-    "d": ActionHandler(needs_hunk=True, handler=handle_hunk_discard),
-    "l": ActionHandler(needs_hunk=True, handler=_handle_line_selection),
-    "f": ActionHandler(needs_hunk=True, handler=_handle_file_selection),
-    "v": ActionHandler(needs_hunk=True, handler=_handle_file_review),
-    "o": ActionHandler(needs_hunk=False, handler=_handle_file_browser),
-    "x": ActionHandler(needs_hunk=True, handler=_handle_fixup),
-    "a": ActionHandler(needs_hunk=False, handler=_handle_again),
-    "u": ActionHandler(needs_hunk=False, handler=_handle_undo),
-    "U": ActionHandler(needs_hunk=False, handler=_handle_redo),
-    "S": ActionHandler(needs_hunk=False, handler=_handle_status),
-    "A": ActionHandler(needs_hunk=False, handler=_handle_assets),
-    "b": ActionHandler(needs_hunk=False, handler=_handle_batch),
-    "?": ActionHandler(needs_hunk=False, handler=_handle_help),
-    "q": ActionHandler(needs_hunk=False, handler=_handle_quit),
-}
-
-
-def _dispatch_action(
-    action: str,
-    has_hunk: bool,
-    use_color: bool,
-    flow_state: FlowState
-) -> None:
-    """
-    Dispatch an action to its handler.
-
-    Raises QuitInteractive to exit or BypassRefresh to skip display update.
-    """
-    if action.startswith("!"):
-        handle_shell_command(action)
-        return
-
-    if action == "":
-        return
-
-    if handle_flow_action(action, flow_state):
-        return
-
-    handler_config = ACTION_HANDLERS.get(action)
-
-    if handler_config is not None:
-        if handler_config.needs_hunk and not has_hunk:
-            print(_("No changes to process"), file=sys.stderr)
-            raise BypassRefresh()
-
-        handler_config.handler(flow_state)
-        return
-
-    handle_cli_escape(action, print_help=print_help)
 
 
 def start_interactive_mode() -> None:
@@ -285,7 +118,7 @@ def start_interactive_mode() -> None:
         )
 
         try:
-            _dispatch_action(
+            dispatch_action(
                 action,
                 has_hunk=(line_changes is not None),
                 use_color=use_color,

--- a/src/git_stage_batch/tui/session_quit.py
+++ b/src/git_stage_batch/tui/session_quit.py
@@ -1,0 +1,64 @@
+"""Smart quit handling for interactive mode."""
+
+from __future__ import annotations
+
+from ..commands.abort import command_abort
+from ..commands.stop import command_stop
+from ..data.progress import get_hunk_counts
+from ..utils.file_io import read_text_file_contents
+from ..utils.git import run_git_command
+from ..utils.paths import (
+    get_start_head_file_path,
+    get_start_index_tree_file_path,
+)
+from .prompts import prompt_quit_session
+
+
+def handle_quit(*, stop_session: bool = True) -> None:
+    """
+    Handle quit action with smart quit logic.
+
+    Checks if any changes were made (HEAD, index tree, or discards).
+    If no changes, silently stops. If changes exist, prompts user.
+    """
+    print()
+
+    start_head_file = get_start_head_file_path()
+    start_index_tree_file = get_start_index_tree_file_path()
+
+    if not start_head_file.exists() or not start_index_tree_file.exists():
+        if stop_session:
+            command_stop()
+        return
+
+    start_head = read_text_file_contents(start_head_file).strip()
+    start_index_tree = read_text_file_contents(start_index_tree_file).strip()
+
+    selected_head = run_git_command(
+        ["rev-parse", "HEAD"],
+        requires_index_lock=False,
+    ).stdout.strip()
+    selected_index_tree = run_git_command(
+        ["write-tree"],
+        requires_index_lock=False,
+    ).stdout.strip()
+
+    stats = get_hunk_counts()
+    has_discards = stats.get("discarded", 0) > 0
+
+    if (
+        selected_head == start_head
+        and selected_index_tree == start_index_tree
+        and not has_discards
+    ):
+        if stop_session:
+            command_stop()
+        return
+
+    choice = prompt_quit_session()
+
+    if choice == "keep":
+        if stop_session:
+            command_stop()
+    elif choice == "undo":
+        command_abort()

--- a/src/git_stage_batch/tui/shell_command.py
+++ b/src/git_stage_batch/tui/shell_command.py
@@ -1,0 +1,33 @@
+"""Shell command escape for interactive mode."""
+
+from __future__ import annotations
+
+import subprocess
+
+from ..i18n import _
+from ..utils.git import get_git_repository_root_path
+from .prompts import prompt_shell_command
+
+
+def handle_shell_command(action: str) -> None:
+    """Handle shell command execution."""
+    if len(action) > 1:
+        command = action[1:].strip()
+    else:
+        command = prompt_shell_command()
+
+    if command:
+        result = subprocess.run(
+            command,
+            shell=True,
+            cwd=get_git_repository_root_path(),
+        )
+        if result.returncode != 0:
+            print(_("Command exited with status {}").format(result.returncode))
+
+        try:
+            input(_("\nPress Enter to continue..."))
+        except (KeyboardInterrupt, EOFError):
+            pass
+    else:
+        print(_("No command entered"))

--- a/src/git_stage_batch/tui/status_action.py
+++ b/src/git_stage_batch/tui/status_action.py
@@ -1,0 +1,14 @@
+"""Status action for interactive mode."""
+
+from __future__ import annotations
+
+from ..exceptions import BypassRefresh
+from .flow import FlowState
+
+
+def handle_status(flow_state: FlowState) -> None:
+    """Handle status drawer."""
+    from ..commands.status import command_status
+
+    command_status()
+    raise BypassRefresh()

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -1489,6 +1489,56 @@ def test_file_scope_discard_to_batch_owns_multi_file_pipeline():
     assert helper_imports <= helper_imported_names
 
 
+def test_file_scope_single_file_discard_to_batch_breaks_command_import_cycle():
+    """File-scope fallback support should not depend on discard.py."""
+    discard_path = SRC_ROOT / "commands" / "discard.py"
+    multi_file_helper_path = (
+        SRC_ROOT / "commands" / "file_scope" / "discard_to_batch.py"
+    )
+    single_file_helper = __import__(
+        "git_stage_batch.commands.file_scope.discard_file_to_batch",
+        fromlist=["discard_file_to_batch"],
+    )
+    support_names = {
+        "discard_binary_to_batch",
+        "discard_file_to_batch",
+        "discard_text_deletion_to_batch",
+    }
+    old_command_helper_names = {
+        "_command_discard_binary_to_batch",
+        "_command_discard_file_to_batch",
+        "_command_discard_text_deletion_to_batch",
+    }
+
+    discard_tree = ast.parse(discard_path.read_text(), filename=str(discard_path))
+    discard_names = {
+        node.name
+        for node in ast.walk(discard_tree)
+        if isinstance(node, ast.ClassDef | ast.FunctionDef)
+    }
+    discard_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(discard_path)
+    }
+    multi_file_helper_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(multi_file_helper_path)
+    }
+
+    assert support_names <= vars(single_file_helper).keys()
+    assert old_command_helper_names.isdisjoint(vars(single_file_helper).keys())
+    assert old_command_helper_names.isdisjoint(discard_names)
+    assert (
+        "git_stage_batch.commands.file_scope.discard_file_to_batch"
+        in discard_imports
+    )
+    assert (
+        "git_stage_batch.commands.file_scope.discard_file_to_batch"
+        in multi_file_helper_imports
+    )
+    assert "git_stage_batch.commands.discard" not in multi_file_helper_imports
+
+
 def test_argument_parser_uses_file_scope_resolver_module():
     """Parser branches should not own repository file-scope resolution."""
     parser_path = SRC_ROOT / "cli" / "argument_parser.py"

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -1721,6 +1721,47 @@ def test_tui_history_actions_own_undo_redo_actions():
         assert imported_module in history_actions_imports
 
 
+def test_tui_again_action_owns_iteration_restart():
+    """TUI again action should live in the again action adapter."""
+    interactive_path = SRC_ROOT / "tui" / "interactive.py"
+    action_dispatch_path = SRC_ROOT / "tui" / "action_dispatch.py"
+    again_action_path = SRC_ROOT / "tui" / "again_action.py"
+    action_dispatch = __import__(
+        "git_stage_batch.tui.action_dispatch",
+        fromlist=["action_dispatch"],
+    )
+    again_action = __import__(
+        "git_stage_batch.tui.again_action",
+        fromlist=["again_action"],
+    )
+    interactive_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(interactive_path)
+    }
+    action_dispatch_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(action_dispatch_path)
+    }
+    again_action_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(again_action_path)
+    }
+    old_dispatch_imports = {
+        "git_stage_batch.data.file_tracking",
+        "git_stage_batch.data.hunk_tracking",
+        "git_stage_batch.utils.paths",
+    }
+
+    assert "handle_again" in vars(again_action)
+    assert "_handle_again" not in vars(action_dispatch)
+    assert "git_stage_batch.tui.action_dispatch" in interactive_imports
+    assert "git_stage_batch.tui.again_action" in action_dispatch_imports
+    assert "git_stage_batch.commands.again" not in interactive_imports
+    assert "git_stage_batch.commands.again" not in action_dispatch_imports
+    assert action_dispatch_imports.isdisjoint(old_dispatch_imports)
+    assert "git_stage_batch.commands.again" in again_action_imports
+
+
 def test_tui_status_action_owns_status_command():
     """TUI status action should live in the status action adapter."""
     interactive_path = SRC_ROOT / "tui" / "interactive.py"

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -2081,10 +2081,17 @@ def test_tui_line_selection_menu_owns_line_actions():
 def test_tui_file_review_state_name_does_not_shadow_persisted_state():
     """TUI review state should not reuse the persisted file-review state name."""
     review_path = SRC_ROOT / "tui" / "file_review" / "__init__.py"
-    tree = ast.parse(review_path.read_text(), filename=str(review_path))
-    class_names = {
+    session_path = SRC_ROOT / "tui" / "file_review" / "session.py"
+    review_tree = ast.parse(review_path.read_text(), filename=str(review_path))
+    session_tree = ast.parse(session_path.read_text(), filename=str(session_path))
+    review_class_names = {
         node.name
-        for node in tree.body
+        for node in review_tree.body
+        if isinstance(node, ast.ClassDef)
+    }
+    session_class_names = {
+        node.name
+        for node in session_tree.body
         if isinstance(node, ast.ClassDef)
     }
     imported_state_names = set()
@@ -2104,8 +2111,10 @@ def test_tui_file_review_state_name_does_not_shadow_persisted_state():
 
     assert "FileReviewState" in vars(records)
     assert "FileReviewState" not in vars(persisted_state)
-    assert "FileReviewSessionState" in class_names
-    assert "FileReviewState" not in class_names
+    assert "FileReviewSessionState" in session_class_names
+    assert "FileReviewSessionState" in review_class_names | session_class_names
+    assert "FileReviewState" not in review_class_names
+    assert "FileReviewState" not in session_class_names
     assert "FileReviewState" not in imported_state_names
 
 

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -1404,6 +1404,65 @@ def test_argument_parser_delegates_multi_file_action_flow():
     )
 
 
+def test_file_scope_discard_to_batch_owns_multi_file_pipeline():
+    """Multi-file discard-to-batch support should stay out of discard.py."""
+    discard_path = SRC_ROOT / "commands" / "discard.py"
+    multi_file_actions_path = (
+        SRC_ROOT / "commands" / "file_scope" / "multi_file_actions.py"
+    )
+    helper_path = SRC_ROOT / "commands" / "file_scope" / "discard_to_batch.py"
+    helper = __import__(
+        "git_stage_batch.commands.file_scope.discard_to_batch",
+        fromlist=["discard_to_batch"],
+    )
+    public_names = {
+        "DiscardFilesToBatchResult",
+        "command_discard_files_to_batch",
+    }
+    moved_names = {
+        "CollectedTextFileDiscards",
+        "DiscardFilesToBatchResult",
+        "PreparedPatchDiscard",
+        "PreparedTextFileDiscardToBatch",
+        "TextFileDiscardInput",
+        "_collect_text_file_discard_inputs",
+        "_discard_prepared_text_files_to_batch",
+        "_prepare_text_file_discard_to_batch",
+        "_run_reverse_apply_for_prepared_discards",
+        "command_discard_files_to_batch",
+    }
+    helper_imports = {
+        "BatchFileUpdate",
+        "add_files_to_batch",
+        "detect_file_mode_from_root",
+        "record_hunks_discarded",
+        "snapshot_files_if_untracked",
+    }
+
+    assert public_names <= vars(helper).keys()
+
+    discard_tree = ast.parse(discard_path.read_text(), filename=str(discard_path))
+    discard_names = {
+        node.name
+        for node in ast.walk(discard_tree)
+        if isinstance(node, ast.ClassDef | ast.FunctionDef)
+    }
+    multi_file_action_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(multi_file_actions_path)
+    }
+    helper_imported_names = set()
+    for _imported_module, node in _import_from_nodes(helper_path):
+        helper_imported_names |= {alias.name for alias in node.names}
+
+    assert moved_names.isdisjoint(discard_names)
+    assert (
+        "git_stage_batch.commands.file_scope.discard_to_batch"
+        in multi_file_action_imports
+    )
+    assert helper_imports <= helper_imported_names
+
+
 def test_argument_parser_uses_file_scope_resolver_module():
     """Parser branches should not own repository file-scope resolution."""
     parser_path = SRC_ROOT / "cli" / "argument_parser.py"
@@ -3666,10 +3725,11 @@ def test_batch_file_mode_detection_stays_in_data_module():
     )
     expected_imports = {
         SRC_ROOT / "commands" / "include.py": {"detect_file_mode"},
-        SRC_ROOT / "commands" / "discard.py": {
-            "detect_file_mode",
-            "detect_file_mode_from_root",
-        },
+        SRC_ROOT / "commands" / "discard.py": {"detect_file_mode"},
+        SRC_ROOT
+        / "commands"
+        / "file_scope"
+        / "discard_to_batch.py": {"detect_file_mode_from_root"},
     }
     forbidden_helpers = {
         "_detect_file_mode",

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -1676,6 +1676,51 @@ def test_tui_hunk_actions_own_direct_hunk_commands():
     assert hunk_command_names <= hunk_actions_imported_names
 
 
+def test_tui_history_actions_own_undo_redo_actions():
+    """TUI history actions should live in the history action adapter."""
+    interactive_path = SRC_ROOT / "tui" / "interactive.py"
+    action_dispatch_path = SRC_ROOT / "tui" / "action_dispatch.py"
+    history_actions_path = SRC_ROOT / "tui" / "history_actions.py"
+    action_dispatch = __import__(
+        "git_stage_batch.tui.action_dispatch",
+        fromlist=["action_dispatch"],
+    )
+    history_actions = __import__(
+        "git_stage_batch.tui.history_actions",
+        fromlist=["history_actions"],
+    )
+    interactive_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(interactive_path)
+    }
+    action_dispatch_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(action_dispatch_path)
+    }
+    history_actions_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(history_actions_path)
+    }
+    old_dispatch_names = {
+        "_handle_redo",
+        "_handle_undo",
+    }
+    command_modules = {
+        "git_stage_batch.commands.redo",
+        "git_stage_batch.commands.undo",
+    }
+
+    assert {"handle_redo", "handle_undo"} <= vars(history_actions).keys()
+    assert old_dispatch_names.isdisjoint(vars(action_dispatch))
+    assert "git_stage_batch.tui.action_dispatch" in interactive_imports
+    assert "git_stage_batch.tui.history_actions" in action_dispatch_imports
+
+    for imported_module in command_modules:
+        assert imported_module not in interactive_imports
+        assert imported_module not in action_dispatch_imports
+        assert imported_module in history_actions_imports
+
+
 def test_tui_fixup_menu_owns_suggest_fixup_submenu():
     """TUI suggest-fixup selection should live in the fixup menu."""
     interactive_path = SRC_ROOT / "tui" / "interactive.py"

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -4055,6 +4055,65 @@ def test_discard_line_selection_stays_in_command_helper():
     assert helper_imports <= helper_imported_names
 
 
+def test_discard_line_replacement_stays_in_command_helper():
+    """Discard line-replacement support should stay out of the command entrypoint."""
+    discard_path = SRC_ROOT / "commands" / "discard.py"
+    helper_path = (
+        SRC_ROOT / "commands" / "selection" / "discard_line_replacement.py"
+    )
+    helper = __import__(
+        "git_stage_batch.commands.selection.discard_line_replacement",
+        fromlist=["discard_line_replacement"],
+    )
+    public_names = {
+        "DiscardLineReplacementSelection",
+        "build_discard_line_replacement_target_buffer",
+        "derive_live_replacement_line_runs",
+        "prepare_discard_line_replacement_selection",
+    }
+    old_discard_names = {
+        "_derive_live_replacement_line_runs",
+        "_select_rewritten_replacement_lines",
+    }
+    helper_imports = {
+        "annotate_with_batch_source_working_lines",
+        "build_file_hunk_from_buffer",
+        "build_target_working_tree_buffer_from_lines",
+        "build_target_working_tree_buffer_with_replaced_lines",
+        "coerce_replacement_payload",
+        "derive_replacement_line_runs_from_lines",
+        "load_git_object_as_buffer_or_empty",
+        "load_line_changes_from_state",
+        "load_working_tree_file_as_buffer",
+        "parse_line_selection",
+        "replacement_selection",
+        "require_line_selection_in_view",
+    }
+
+    assert public_names <= vars(helper).keys()
+
+    discard_tree = ast.parse(discard_path.read_text(), filename=str(discard_path))
+    discard_helpers = {
+        node.name for node in ast.walk(discard_tree) if isinstance(node, ast.FunctionDef)
+    }
+    discard_imports_helper = False
+
+    for imported_module, node in _import_from_nodes(discard_path):
+        if imported_module != "git_stage_batch.commands.selection":
+            continue
+        imported_names = {alias.name for alias in node.names}
+        if "discard_line_replacement" in imported_names:
+            discard_imports_helper = True
+
+    helper_imported_names = set()
+    for _imported_module, node in _import_from_nodes(helper_path):
+        helper_imported_names |= {alias.name for alias in node.names}
+
+    assert old_discard_names.isdisjoint(discard_helpers)
+    assert discard_imports_helper
+    assert helper_imports <= helper_imported_names
+
+
 def test_discard_uses_file_io_path_empty_helper():
     """Discard should use file I/O utilities for generic path byte checks."""
     discard_path = SRC_ROOT / "commands" / "discard.py"
@@ -4302,6 +4361,9 @@ def test_replacement_selection_stays_in_command_helper():
     """Include and discard should use the replacement-selection helper module."""
     include_path = SRC_ROOT / "commands" / "include.py"
     discard_path = SRC_ROOT / "commands" / "discard.py"
+    discard_replacement_path = (
+        SRC_ROOT / "commands" / "selection" / "discard_line_replacement.py"
+    )
     helper = __import__(
         "git_stage_batch.commands.selection.replacement_selection",
         fromlist=["replacement_selection"],
@@ -4322,9 +4384,9 @@ def test_replacement_selection_stays_in_command_helper():
         "_derive_replacement_line_runs",
         "_expand_replacement_selection_ids",
     }
-    command_paths = (
+    helper_user_paths = (
         include_path,
-        discard_path,
+        discard_replacement_path,
     )
     violations = []
 
@@ -4334,7 +4396,7 @@ def test_replacement_selection_stays_in_command_helper():
     for old_name in old_include_names:
         assert f"def {old_name}" not in include_path.read_text()
 
-    for command_path in command_paths:
+    for command_path in helper_user_paths:
         imports = _import_from_nodes(command_path)
         imports_helper_namespace = False
 
@@ -4352,11 +4414,12 @@ def test_replacement_selection_stays_in_command_helper():
                     f"{relative_path}:{node.lineno} imports replacement names directly"
                 )
 
-            if command_path == discard_path and imported_module == "git_stage_batch.commands.include":
-                relative_path = command_path.relative_to(REPO_ROOT)
-                violations.append(f"{relative_path}:{node.lineno} imports include")
-
         assert imports_helper_namespace
+
+    for imported_module, node in _import_from_nodes(discard_path):
+        if imported_module == "git_stage_batch.commands.include":
+            relative_path = discard_path.relative_to(REPO_ROOT)
+            violations.append(f"{relative_path}:{node.lineno} imports include")
 
     assert violations == []
 

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -2109,13 +2109,59 @@ def test_tui_file_review_state_name_does_not_shadow_persisted_state():
             continue
         imported_state_names |= {alias.name for alias in node.names}
 
+    review_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(review_path)
+    }
+
     assert "FileReviewState" in vars(records)
     assert "FileReviewState" not in vars(persisted_state)
     assert "FileReviewSessionState" in session_class_names
-    assert "FileReviewSessionState" in review_class_names | session_class_names
+    assert "FileReviewSessionState" not in review_class_names
+    assert "git_stage_batch.tui.file_review.session" in review_imports
     assert "FileReviewState" not in review_class_names
     assert "FileReviewState" not in session_class_names
     assert "FileReviewState" not in imported_state_names
+
+
+def test_tui_file_review_modules_share_session_state():
+    """TUI file review modules should use the shared session state."""
+    owner_import = "git_stage_batch.tui.file_review.session"
+    reviewed_paths = {
+        SRC_ROOT / "tui" / "file_review" / "__init__.py": {
+            "FileReviewActionState",
+            "FileReviewBatchActionState",
+            "FileReviewCandidateState",
+            "FileReviewLiveActionState",
+        },
+        SRC_ROOT / "tui" / "file_review" / "action_router.py": {
+            "FileReviewActionState",
+        },
+        SRC_ROOT / "tui" / "file_review" / "batch_actions.py": {
+            "FileReviewBatchActionState",
+        },
+        SRC_ROOT / "tui" / "file_review" / "candidates.py": {
+            "FileReviewCandidateState",
+        },
+        SRC_ROOT / "tui" / "file_review" / "live_actions.py": {
+            "FileReviewLiveActionState",
+        },
+    }
+
+    for path, old_names in reviewed_paths.items():
+        tree = ast.parse(path.read_text(), filename=str(path))
+        class_names = {
+            node.name
+            for node in tree.body
+            if isinstance(node, ast.ClassDef)
+        }
+        imported_modules = {
+            imported_module
+            for imported_module, _node in _import_from_nodes(path)
+        }
+
+        assert old_names.isdisjoint(class_names)
+        assert owner_import in imported_modules
 
 
 def test_tui_file_review_display_owns_review_rendering():

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -4000,6 +4000,61 @@ def test_discard_file_selection_stays_in_command_helper():
     assert helper_imports <= helper_imported_names
 
 
+def test_discard_line_selection_stays_in_command_helper():
+    """Discard line-selection editing should stay out of the command entrypoint."""
+    discard_path = SRC_ROOT / "commands" / "discard.py"
+    helper_path = (
+        SRC_ROOT / "commands" / "selection" / "discard_line_selection.py"
+    )
+    helper = __import__(
+        "git_stage_batch.commands.selection.discard_line_selection",
+        fromlist=["discard_line_selection"],
+    )
+    public_names = {"discard_worktree_line_selection"}
+    command_level_names = {
+        "build_target_working_tree_buffer_from_lines",
+        "load_working_tree_file_as_buffer",
+        "parse_line_selection",
+        "require_line_selection_in_view",
+        "write_buffer_to_path",
+    }
+    helper_imports = command_level_names | {
+        "buffer_ends_with_lf",
+        "get_git_repository_root_path",
+        "get_selected_change_file_path",
+        "load_line_changes_from_state",
+        "require_selected_hunk",
+    }
+
+    assert public_names <= vars(helper).keys()
+
+    discard_tree = ast.parse(discard_path.read_text(), filename=str(discard_path))
+    command_discard_line = next(
+        node
+        for node in ast.walk(discard_tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "command_discard_line"
+    )
+    command_names = {
+        node.id for node in ast.walk(command_discard_line) if isinstance(node, ast.Name)
+    }
+    discard_imports_helper = False
+
+    for imported_module, node in _import_from_nodes(discard_path):
+        if imported_module != "git_stage_batch.commands.selection":
+            continue
+        imported_names = {alias.name for alias in node.names}
+        if "discard_line_selection" in imported_names:
+            discard_imports_helper = True
+
+    helper_imported_names = set()
+    for _imported_module, node in _import_from_nodes(helper_path):
+        helper_imported_names |= {alias.name for alias in node.names}
+
+    assert command_level_names.isdisjoint(command_names)
+    assert discard_imports_helper
+    assert helper_imports <= helper_imported_names
+
+
 def test_discard_uses_file_io_path_empty_helper():
     """Discard should use file I/O utilities for generic path byte checks."""
     discard_path = SRC_ROOT / "commands" / "discard.py"

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -1420,16 +1420,24 @@ def test_file_scope_discard_to_batch_owns_multi_file_pipeline():
         "discard_files_to_batch",
     }
     moved_names = {
-        "CollectedTextFileDiscards",
         "DiscardFilesToBatchResult",
-        "PreparedPatchDiscard",
-        "PreparedTextFileDiscardToBatch",
-        "TextFileDiscardInput",
         "_collect_text_file_discard_inputs",
         "_discard_prepared_text_files_to_batch",
         "_prepare_text_file_discard_to_batch",
         "_run_reverse_apply_for_prepared_discards",
         "discard_files_to_batch",
+    }
+    internal_record_names = {
+        "_CollectedTextFileDiscards",
+        "_PreparedPatchDiscard",
+        "_PreparedTextFileDiscardToBatch",
+        "_TextFileDiscardInput",
+    }
+    old_public_record_names = {
+        "CollectedTextFileDiscards",
+        "PreparedPatchDiscard",
+        "PreparedTextFileDiscardToBatch",
+        "TextFileDiscardInput",
     }
     helper_imports = {
         "BatchFileUpdate",
@@ -1440,6 +1448,8 @@ def test_file_scope_discard_to_batch_owns_multi_file_pipeline():
     }
 
     assert public_names <= vars(helper).keys()
+    assert internal_record_names <= vars(helper).keys()
+    assert old_public_record_names.isdisjoint(vars(helper).keys())
 
     discard_tree = ast.parse(discard_path.read_text(), filename=str(discard_path))
     discard_names = {

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -4177,6 +4177,77 @@ def test_batch_line_selection_stays_in_command_helper():
     assert command_level_names <= helper_imported_names
 
 
+def test_batch_line_updates_stays_in_command_helper():
+    """Batch line updates should live in command selection support."""
+    include_path = SRC_ROOT / "commands" / "include.py"
+    discard_path = SRC_ROOT / "commands" / "discard.py"
+    helper_path = (
+        SRC_ROOT / "commands" / "selection" / "batch_line_updates.py"
+    )
+    helper = __import__(
+        "git_stage_batch.commands.selection.batch_line_updates",
+        fromlist=["batch_line_updates"],
+    )
+    public_names = {
+        "add_selected_lines_to_batch",
+    }
+    moved_names = {
+        "acquire_batch_ownership_update_for_selection",
+        "add_file_to_batch",
+        "batch_exists",
+        "create_batch",
+        "detect_file_mode",
+        "read_batch_metadata",
+        "snapshot_file_if_untracked",
+    }
+    guarded_functions = {
+        include_path: {
+            "_command_include_file_lines_to_batch",
+            "_command_include_lines_to_batch",
+        },
+        discard_path: {
+            "_command_discard_file_lines_to_batch",
+            "_command_discard_lines_to_batch",
+        },
+    }
+
+    assert public_names <= vars(helper).keys()
+
+    for path, function_names in guarded_functions.items():
+        tree = ast.parse(path.read_text(), filename=str(path))
+        functions = {
+            node.name: node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef)
+        }
+        imports_helper = False
+
+        for imported_module, node in _import_from_nodes(path):
+            if imported_module != "git_stage_batch.commands.selection":
+                continue
+            imported_names = {alias.name for alias in node.names}
+            if "batch_line_updates" in imported_names:
+                imports_helper = True
+
+        assert imports_helper
+        for function_name in function_names:
+            function = functions[function_name]
+            function_names_used = {
+                node.id for node in ast.walk(function) if isinstance(node, ast.Name)
+            }
+            attribute_names_used = {
+                node.attr for node in ast.walk(function) if isinstance(node, ast.Attribute)
+            }
+            assert "add_selected_lines_to_batch" in attribute_names_used
+            assert moved_names.isdisjoint(function_names_used)
+
+    helper_imported_names = set()
+    for _imported_module, node in _import_from_nodes(helper_path):
+        helper_imported_names |= {alias.name for alias in node.names}
+
+    assert moved_names <= helper_imported_names
+
+
 def test_discard_uses_file_io_path_empty_helper():
     """Discard should use file I/O utilities for generic path byte checks."""
     discard_path = SRC_ROOT / "commands" / "discard.py"

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -1721,6 +1721,41 @@ def test_tui_history_actions_own_undo_redo_actions():
         assert imported_module in history_actions_imports
 
 
+def test_tui_status_action_owns_status_command():
+    """TUI status action should live in the status action adapter."""
+    interactive_path = SRC_ROOT / "tui" / "interactive.py"
+    action_dispatch_path = SRC_ROOT / "tui" / "action_dispatch.py"
+    status_action_path = SRC_ROOT / "tui" / "status_action.py"
+    action_dispatch = __import__(
+        "git_stage_batch.tui.action_dispatch",
+        fromlist=["action_dispatch"],
+    )
+    status_action = __import__(
+        "git_stage_batch.tui.status_action",
+        fromlist=["status_action"],
+    )
+    interactive_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(interactive_path)
+    }
+    action_dispatch_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(action_dispatch_path)
+    }
+    status_action_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(status_action_path)
+    }
+
+    assert "handle_status" in vars(status_action)
+    assert "_handle_status" not in vars(action_dispatch)
+    assert "git_stage_batch.tui.action_dispatch" in interactive_imports
+    assert "git_stage_batch.tui.status_action" in action_dispatch_imports
+    assert "git_stage_batch.commands.status" not in interactive_imports
+    assert "git_stage_batch.commands.status" not in action_dispatch_imports
+    assert "git_stage_batch.commands.status" in status_action_imports
+
+
 def test_tui_fixup_menu_owns_suggest_fixup_submenu():
     """TUI suggest-fixup selection should live in the fixup menu."""
     interactive_path = SRC_ROOT / "tui" / "interactive.py"

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -1577,6 +1577,54 @@ def test_tui_flow_menu_owns_batch_selection_menus():
     assert "git_stage_batch.commands.new" in flow_menu_imports
 
 
+def test_tui_hunk_actions_own_direct_hunk_commands():
+    """TUI direct hunk actions should live in the hunk actions adapter."""
+    interactive_path = SRC_ROOT / "tui" / "interactive.py"
+    hunk_actions_path = SRC_ROOT / "tui" / "hunk_actions.py"
+    interactive = __import__(
+        "git_stage_batch.tui.interactive",
+        fromlist=["interactive"],
+    )
+    hunk_actions = __import__(
+        "git_stage_batch.tui.hunk_actions",
+        fromlist=["hunk_actions"],
+    )
+    interactive_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(interactive_path)
+    }
+    interactive_imported_names = set()
+    hunk_actions_imported_names = set()
+    hunk_action_names = {
+        "handle_hunk_discard",
+        "handle_hunk_include",
+        "handle_hunk_skip",
+    }
+    hunk_command_names = {
+        "command_discard",
+        "command_discard_from_batch",
+        "command_discard_to_batch",
+        "command_include",
+        "command_include_from_batch",
+        "command_include_to_batch",
+        "command_skip",
+    }
+
+    for _imported_module, node in _import_from_nodes(interactive_path):
+        interactive_imported_names |= {alias.name for alias in node.names}
+
+    for _imported_module, node in _import_from_nodes(hunk_actions_path):
+        hunk_actions_imported_names |= {alias.name for alias in node.names}
+
+    assert hunk_action_names <= vars(hunk_actions).keys()
+    assert "_handle_include" not in vars(interactive)
+    assert "_handle_skip" not in vars(interactive)
+    assert "_handle_discard" not in vars(interactive)
+    assert "git_stage_batch.tui.hunk_actions" in interactive_imports
+    assert hunk_command_names.isdisjoint(interactive_imported_names)
+    assert hunk_command_names <= hunk_actions_imported_names
+
+
 def test_tui_file_selection_menu_owns_whole_file_actions():
     """TUI whole-file selection should live in the file selection menu."""
     interactive_path = SRC_ROOT / "tui" / "interactive.py"

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -1625,6 +1625,44 @@ def test_tui_hunk_actions_own_direct_hunk_commands():
     assert hunk_command_names <= hunk_actions_imported_names
 
 
+def test_tui_fixup_menu_owns_suggest_fixup_submenu():
+    """TUI suggest-fixup selection should live in the fixup menu."""
+    interactive_path = SRC_ROOT / "tui" / "interactive.py"
+    fixup_menu_path = SRC_ROOT / "tui" / "fixup_menu.py"
+    interactive = __import__(
+        "git_stage_batch.tui.interactive",
+        fromlist=["interactive"],
+    )
+    fixup_menu = __import__(
+        "git_stage_batch.tui.fixup_menu",
+        fromlist=["fixup_menu"],
+    )
+    interactive_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(interactive_path)
+    }
+    interactive_imported_names = set()
+    fixup_menu_imported_names = set()
+    fixup_menu_names = {
+        "clear_suggest_fixup_state",
+        "command_suggest_fixup",
+        "prompt_fixup_action",
+        "read_suggest_fixup_state",
+    }
+
+    for _imported_module, node in _import_from_nodes(interactive_path):
+        interactive_imported_names |= {alias.name for alias in node.names}
+
+    for _imported_module, node in _import_from_nodes(fixup_menu_path):
+        fixup_menu_imported_names |= {alias.name for alias in node.names}
+
+    assert "handle_fixup_menu" in vars(fixup_menu)
+    assert "handle_fixup_selection" not in vars(interactive)
+    assert "git_stage_batch.tui.fixup_menu" in interactive_imports
+    assert fixup_menu_names.isdisjoint(interactive_imported_names)
+    assert fixup_menu_names <= fixup_menu_imported_names
+
+
 def test_tui_file_selection_menu_owns_whole_file_actions():
     """TUI whole-file selection should live in the file selection menu."""
     interactive_path = SRC_ROOT / "tui" / "interactive.py"

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -1717,6 +1717,54 @@ def test_tui_shell_command_owns_shell_escape():
     assert shell_command_names <= shell_command_imported_names
 
 
+def test_tui_cli_escape_owns_command_fallback():
+    """TUI CLI command fallback should live in the CLI escape adapter."""
+    interactive_path = SRC_ROOT / "tui" / "interactive.py"
+    cli_escape_path = SRC_ROOT / "tui" / "cli_escape.py"
+    interactive = __import__(
+        "git_stage_batch.tui.interactive",
+        fromlist=["interactive"],
+    )
+    cli_escape = __import__(
+        "git_stage_batch.tui.cli_escape",
+        fromlist=["cli_escape"],
+    )
+    interactive_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(interactive_path)
+    }
+    interactive_imported_names = set()
+    cli_escape_imported_names = set()
+    interactive_plain_imports = set()
+    cli_escape_plain_imports = set()
+    cli_escape_names = {
+        "execute_non_interactive_args",
+        "parse_command_line",
+    }
+
+    for node in ast.walk(ast.parse(interactive_path.read_text())):
+        if isinstance(node, ast.Import):
+            interactive_plain_imports |= {alias.name for alias in node.names}
+
+    for node in ast.walk(ast.parse(cli_escape_path.read_text())):
+        if isinstance(node, ast.Import):
+            cli_escape_plain_imports |= {alias.name for alias in node.names}
+
+    for _imported_module, node in _import_from_nodes(interactive_path):
+        interactive_imported_names |= {alias.name for alias in node.names}
+
+    for _imported_module, node in _import_from_nodes(cli_escape_path):
+        cli_escape_imported_names |= {alias.name for alias in node.names}
+
+    assert "handle_cli_escape" in vars(cli_escape)
+    assert "_handle_cli_command" not in vars(interactive)
+    assert "git_stage_batch.tui.cli_escape" in interactive_imports
+    assert "shlex" not in interactive_plain_imports
+    assert "shlex" in cli_escape_plain_imports
+    assert cli_escape_names.isdisjoint(interactive_imported_names)
+    assert cli_escape_names <= cli_escape_imported_names
+
+
 def test_tui_file_selection_menu_owns_whole_file_actions():
     """TUI whole-file selection should live in the file selection menu."""
     interactive_path = SRC_ROOT / "tui" / "interactive.py"

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -2224,6 +2224,47 @@ def test_tui_file_review_batch_actions_own_batch_transfers():
     assert "git_stage_batch.commands.include_from" in batch_action_imports
 
 
+def test_tui_file_review_live_actions_own_live_transfers():
+    """TUI file review live actions should own live transfer commands."""
+    review_path = SRC_ROOT / "tui" / "file_review" / "__init__.py"
+    live_actions_path = SRC_ROOT / "tui" / "file_review" / "live_actions.py"
+    review = __import__(
+        "git_stage_batch.tui.file_review",
+        fromlist=["file_review"],
+    )
+    live_actions = __import__(
+        "git_stage_batch.tui.file_review.live_actions",
+        fromlist=["live_actions"],
+    )
+    review_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(review_path)
+    }
+    live_action_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(live_actions_path)
+    }
+    old_review_names = {
+        "_apply_live_file_action",
+        "_apply_live_line_action",
+        "_apply_live_replacement_action",
+    }
+
+    assert {
+        "apply_live_file_action",
+        "apply_live_line_action",
+        "apply_live_replacement_action",
+    } <= vars(live_actions).keys()
+    assert old_review_names.isdisjoint(vars(review))
+    assert "git_stage_batch.tui.file_review.live_actions" in review_imports
+    assert "git_stage_batch.commands.discard" not in review_imports
+    assert "git_stage_batch.commands.include" not in review_imports
+    assert "git_stage_batch.commands.skip" not in review_imports
+    assert "git_stage_batch.commands.discard" in live_action_imports
+    assert "git_stage_batch.commands.include" in live_action_imports
+    assert "git_stage_batch.commands.skip" in live_action_imports
+
+
 def test_commands_do_not_import_tui():
     """Command modules should not launch or depend on TUI modules."""
     violations = []

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -1433,6 +1433,9 @@ def test_file_scope_discard_to_batch_owns_multi_file_pipeline():
         "_PreparedTextFileDiscardToBatch",
         "_TextFileDiscardInput",
     }
+    internal_state_names = {
+        "_DiscardFilesToBatchSession",
+    }
     old_public_record_names = {
         "CollectedTextFileDiscards",
         "PreparedPatchDiscard",
@@ -1449,13 +1452,25 @@ def test_file_scope_discard_to_batch_owns_multi_file_pipeline():
 
     assert public_names <= vars(helper).keys()
     assert internal_record_names <= vars(helper).keys()
+    assert internal_state_names <= vars(helper).keys()
     assert old_public_record_names.isdisjoint(vars(helper).keys())
 
     discard_tree = ast.parse(discard_path.read_text(), filename=str(discard_path))
+    helper_tree = ast.parse(helper_path.read_text(), filename=str(helper_path))
     discard_names = {
         node.name
         for node in ast.walk(discard_tree)
         if isinstance(node, ast.ClassDef | ast.FunctionDef)
+    }
+    discard_files_to_batch_def = next(
+        node
+        for node in ast.walk(helper_tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "discard_files_to_batch"
+    )
+    nested_helper_names = {
+        node.name
+        for node in ast.walk(discard_files_to_batch_def)
+        if isinstance(node, ast.FunctionDef) and node is not discard_files_to_batch_def
     }
     multi_file_action_imports = {
         imported_module
@@ -1466,6 +1481,7 @@ def test_file_scope_discard_to_batch_owns_multi_file_pipeline():
         helper_imported_names |= {alias.name for alias in node.names}
 
     assert moved_names.isdisjoint(discard_names)
+    assert nested_helper_names == set()
     assert (
         "git_stage_batch.commands.file_scope.discard_to_batch"
         in multi_file_action_imports

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -2362,6 +2362,48 @@ def test_tui_file_review_prompts_own_action_vocabulary():
     assert "Review action:" in prompt_text
 
 
+def test_tui_file_review_action_router_owns_standard_actions():
+    """TUI file review action router should own standard action gates."""
+    review_path = SRC_ROOT / "tui" / "file_review" / "__init__.py"
+    router_path = SRC_ROOT / "tui" / "file_review" / "action_router.py"
+    review = __import__(
+        "git_stage_batch.tui.file_review",
+        fromlist=["file_review"],
+    )
+    router = __import__(
+        "git_stage_batch.tui.file_review.action_router",
+        fromlist=["action_router"],
+    )
+    review_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(review_path)
+    }
+    router_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(router_path)
+    }
+    old_review_names = {
+        "_apply_file_action",
+        "_apply_line_action",
+        "_apply_replacement_action",
+        "_prompt_replacement_text",
+    }
+    review_text = review_path.read_text()
+    router_text = router_path.read_text()
+
+    assert {
+        "apply_file_action",
+        "apply_line_action",
+        "apply_replacement_action",
+    } <= vars(router).keys()
+    assert old_review_names.isdisjoint(vars(review))
+    assert "git_stage_batch.tui.file_review.action_router" in review_imports
+    assert "git_stage_batch.tui.file_review.batch_actions" in router_imports
+    assert "git_stage_batch.tui.file_review.live_actions" in router_imports
+    assert "Replacement text (empty cancels):" not in review_text
+    assert "Replacement text (empty cancels):" in router_text
+
+
 def test_commands_do_not_import_tui():
     """Command modules should not launch or depend on TUI modules."""
     violations = []

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -1452,12 +1452,17 @@ def test_cli_dispatch_delegates_noninteractive_execution():
 def test_tui_cli_escape_does_not_import_dispatch():
     """TUI command escape should execute parsed args without importing launcher dispatch."""
     interactive_path = SRC_ROOT / "tui" / "interactive.py"
+    action_dispatch_path = SRC_ROOT / "tui" / "action_dispatch.py"
     cli_escape_path = SRC_ROOT / "tui" / "cli_escape.py"
     execution_path = SRC_ROOT / "cli" / "execution.py"
     dispatch_path = SRC_ROOT / "cli" / "dispatch.py"
     interactive_imports = {
         imported_module
         for imported_module, _node in _import_from_nodes(interactive_path)
+    }
+    action_dispatch_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(action_dispatch_path)
     }
     cli_escape_imports = {
         imported_module
@@ -1472,7 +1477,8 @@ def test_tui_cli_escape_does_not_import_dispatch():
         for imported_module, _node in _import_from_nodes(dispatch_path)
     }
 
-    assert "git_stage_batch.tui.cli_escape" in interactive_imports
+    assert "git_stage_batch.tui.action_dispatch" in interactive_imports
+    assert "git_stage_batch.tui.cli_escape" in action_dispatch_imports
     assert "git_stage_batch.cli.argument_parser" in cli_escape_imports
     assert "git_stage_batch.cli.execution" in cli_escape_imports
     assert "git_stage_batch.cli.dispatch" not in cli_escape_imports
@@ -1483,6 +1489,7 @@ def test_tui_cli_escape_does_not_import_dispatch():
 def test_tui_batch_menu_owns_batch_management_actions():
     """TUI batch management should live in the batch menu adapter."""
     interactive_path = SRC_ROOT / "tui" / "interactive.py"
+    action_dispatch_path = SRC_ROOT / "tui" / "action_dispatch.py"
     batch_menu_path = SRC_ROOT / "tui" / "batch_menu.py"
     interactive = __import__(
         "git_stage_batch.tui.interactive",
@@ -1495,6 +1502,10 @@ def test_tui_batch_menu_owns_batch_management_actions():
     interactive_imports = {
         imported_module
         for imported_module, _node in _import_from_nodes(interactive_path)
+    }
+    action_dispatch_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(action_dispatch_path)
     }
     batch_menu_imports = {
         imported_module
@@ -1517,16 +1528,19 @@ def test_tui_batch_menu_owns_batch_management_actions():
 
     assert "handle_batch_menu" in vars(batch_menu)
     assert moved_names.isdisjoint(vars(interactive))
-    assert "git_stage_batch.tui.batch_menu" in interactive_imports
+    assert "git_stage_batch.tui.action_dispatch" in interactive_imports
+    assert "git_stage_batch.tui.batch_menu" in action_dispatch_imports
 
     for imported_module in menu_command_modules:
         assert imported_module not in interactive_imports
+        assert imported_module not in action_dispatch_imports
         assert imported_module in batch_menu_imports
 
 
 def test_tui_asset_menu_owns_install_assets_action():
     """TUI asset installation should live in the asset menu adapter."""
     interactive_path = SRC_ROOT / "tui" / "interactive.py"
+    action_dispatch_path = SRC_ROOT / "tui" / "action_dispatch.py"
     asset_menu_path = SRC_ROOT / "tui" / "asset_menu.py"
     interactive = __import__(
         "git_stage_batch.tui.interactive",
@@ -1540,6 +1554,10 @@ def test_tui_asset_menu_owns_install_assets_action():
         imported_module
         for imported_module, _node in _import_from_nodes(interactive_path)
     }
+    action_dispatch_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(action_dispatch_path)
+    }
     asset_menu_imports = {
         imported_module
         for imported_module, _node in _import_from_nodes(asset_menu_path)
@@ -1547,14 +1565,17 @@ def test_tui_asset_menu_owns_install_assets_action():
 
     assert "handle_asset_menu" in vars(asset_menu)
     assert "handle_install_assets" not in vars(interactive)
-    assert "git_stage_batch.tui.asset_menu" in interactive_imports
+    assert "git_stage_batch.tui.action_dispatch" in interactive_imports
+    assert "git_stage_batch.tui.asset_menu" in action_dispatch_imports
     assert "git_stage_batch.commands.install_assets" not in interactive_imports
+    assert "git_stage_batch.commands.install_assets" not in action_dispatch_imports
     assert "git_stage_batch.commands.install_assets" in asset_menu_imports
 
 
 def test_tui_flow_menu_owns_batch_selection_menus():
     """TUI flow selection should live in the flow menu adapter."""
     interactive_path = SRC_ROOT / "tui" / "interactive.py"
+    action_dispatch_path = SRC_ROOT / "tui" / "action_dispatch.py"
     flow_actions_path = SRC_ROOT / "tui" / "flow_actions.py"
     flow_menu_path = SRC_ROOT / "tui" / "flow_menu.py"
     interactive = __import__(
@@ -1573,6 +1594,10 @@ def test_tui_flow_menu_owns_batch_selection_menus():
         imported_module
         for imported_module, _node in _import_from_nodes(interactive_path)
     }
+    action_dispatch_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(action_dispatch_path)
+    }
     flow_actions_imports = {
         imported_module
         for imported_module, _node in _import_from_nodes(flow_actions_path)
@@ -1586,10 +1611,13 @@ def test_tui_flow_menu_owns_batch_selection_menus():
     assert {"handle_from_menu", "handle_to_menu"} <= vars(flow_menu).keys()
     assert "_handle_from" not in vars(interactive)
     assert "_handle_to" not in vars(interactive)
-    assert "git_stage_batch.tui.flow_actions" in interactive_imports
+    assert "git_stage_batch.tui.action_dispatch" in interactive_imports
+    assert "git_stage_batch.tui.flow_actions" in action_dispatch_imports
     assert "git_stage_batch.tui.flow_menu" in flow_actions_imports
     assert "git_stage_batch.batch.query" not in interactive_imports
+    assert "git_stage_batch.batch.query" not in action_dispatch_imports
     assert "git_stage_batch.commands.new" not in interactive_imports
+    assert "git_stage_batch.commands.new" not in action_dispatch_imports
     assert "git_stage_batch.batch.query" in flow_menu_imports
     assert "git_stage_batch.commands.new" in flow_menu_imports
 
@@ -1597,6 +1625,7 @@ def test_tui_flow_menu_owns_batch_selection_menus():
 def test_tui_hunk_actions_own_direct_hunk_commands():
     """TUI direct hunk actions should live in the hunk actions adapter."""
     interactive_path = SRC_ROOT / "tui" / "interactive.py"
+    action_dispatch_path = SRC_ROOT / "tui" / "action_dispatch.py"
     hunk_actions_path = SRC_ROOT / "tui" / "hunk_actions.py"
     interactive = __import__(
         "git_stage_batch.tui.interactive",
@@ -1611,6 +1640,10 @@ def test_tui_hunk_actions_own_direct_hunk_commands():
         for imported_module, _node in _import_from_nodes(interactive_path)
     }
     interactive_imported_names = set()
+    action_dispatch_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(action_dispatch_path)
+    }
     hunk_actions_imported_names = set()
     hunk_action_names = {
         "handle_hunk_discard",
@@ -1637,7 +1670,8 @@ def test_tui_hunk_actions_own_direct_hunk_commands():
     assert "_handle_include" not in vars(interactive)
     assert "_handle_skip" not in vars(interactive)
     assert "_handle_discard" not in vars(interactive)
-    assert "git_stage_batch.tui.hunk_actions" in interactive_imports
+    assert "git_stage_batch.tui.action_dispatch" in interactive_imports
+    assert "git_stage_batch.tui.hunk_actions" in action_dispatch_imports
     assert hunk_command_names.isdisjoint(interactive_imported_names)
     assert hunk_command_names <= hunk_actions_imported_names
 
@@ -1645,6 +1679,7 @@ def test_tui_hunk_actions_own_direct_hunk_commands():
 def test_tui_fixup_menu_owns_suggest_fixup_submenu():
     """TUI suggest-fixup selection should live in the fixup menu."""
     interactive_path = SRC_ROOT / "tui" / "interactive.py"
+    action_dispatch_path = SRC_ROOT / "tui" / "action_dispatch.py"
     fixup_menu_path = SRC_ROOT / "tui" / "fixup_menu.py"
     interactive = __import__(
         "git_stage_batch.tui.interactive",
@@ -1659,6 +1694,10 @@ def test_tui_fixup_menu_owns_suggest_fixup_submenu():
         for imported_module, _node in _import_from_nodes(interactive_path)
     }
     interactive_imported_names = set()
+    action_dispatch_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(action_dispatch_path)
+    }
     fixup_menu_imported_names = set()
     fixup_menu_names = {
         "clear_suggest_fixup_state",
@@ -1675,7 +1714,8 @@ def test_tui_fixup_menu_owns_suggest_fixup_submenu():
 
     assert "handle_fixup_menu" in vars(fixup_menu)
     assert "handle_fixup_selection" not in vars(interactive)
-    assert "git_stage_batch.tui.fixup_menu" in interactive_imports
+    assert "git_stage_batch.tui.action_dispatch" in interactive_imports
+    assert "git_stage_batch.tui.fixup_menu" in action_dispatch_imports
     assert fixup_menu_names.isdisjoint(interactive_imported_names)
     assert fixup_menu_names <= fixup_menu_imported_names
 
@@ -1683,6 +1723,7 @@ def test_tui_fixup_menu_owns_suggest_fixup_submenu():
 def test_tui_shell_command_owns_shell_escape():
     """TUI shell escapes should live in the shell command adapter."""
     interactive_path = SRC_ROOT / "tui" / "interactive.py"
+    action_dispatch_path = SRC_ROOT / "tui" / "action_dispatch.py"
     shell_command_path = SRC_ROOT / "tui" / "shell_command.py"
     interactive = __import__(
         "git_stage_batch.tui.interactive",
@@ -1697,6 +1738,10 @@ def test_tui_shell_command_owns_shell_escape():
         for imported_module, _node in _import_from_nodes(interactive_path)
     }
     interactive_imported_names = set()
+    action_dispatch_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(action_dispatch_path)
+    }
     shell_command_imported_names = set()
     interactive_plain_imports = set()
     shell_command_plain_imports = set()
@@ -1721,7 +1766,8 @@ def test_tui_shell_command_owns_shell_escape():
 
     assert "handle_shell_command" in vars(shell_command)
     assert "_handle_shell" not in vars(interactive)
-    assert "git_stage_batch.tui.shell_command" in interactive_imports
+    assert "git_stage_batch.tui.action_dispatch" in interactive_imports
+    assert "git_stage_batch.tui.shell_command" in action_dispatch_imports
     assert "subprocess" not in interactive_plain_imports
     assert "subprocess" in shell_command_plain_imports
     assert shell_command_names.isdisjoint(interactive_imported_names)
@@ -1731,6 +1777,7 @@ def test_tui_shell_command_owns_shell_escape():
 def test_tui_cli_escape_owns_command_fallback():
     """TUI CLI command fallback should live in the CLI escape adapter."""
     interactive_path = SRC_ROOT / "tui" / "interactive.py"
+    action_dispatch_path = SRC_ROOT / "tui" / "action_dispatch.py"
     cli_escape_path = SRC_ROOT / "tui" / "cli_escape.py"
     interactive = __import__(
         "git_stage_batch.tui.interactive",
@@ -1745,6 +1792,10 @@ def test_tui_cli_escape_owns_command_fallback():
         for imported_module, _node in _import_from_nodes(interactive_path)
     }
     interactive_imported_names = set()
+    action_dispatch_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(action_dispatch_path)
+    }
     cli_escape_imported_names = set()
     interactive_plain_imports = set()
     cli_escape_plain_imports = set()
@@ -1769,7 +1820,8 @@ def test_tui_cli_escape_owns_command_fallback():
 
     assert "handle_cli_escape" in vars(cli_escape)
     assert "_handle_cli_command" not in vars(interactive)
-    assert "git_stage_batch.tui.cli_escape" in interactive_imports
+    assert "git_stage_batch.tui.action_dispatch" in interactive_imports
+    assert "git_stage_batch.tui.cli_escape" in action_dispatch_imports
     assert "shlex" not in interactive_plain_imports
     assert "shlex" in cli_escape_plain_imports
     assert cli_escape_names.isdisjoint(interactive_imported_names)
@@ -1779,6 +1831,7 @@ def test_tui_cli_escape_owns_command_fallback():
 def test_tui_session_quit_owns_smart_quit_actions():
     """TUI smart quit handling should live in the session quit adapter."""
     interactive_path = SRC_ROOT / "tui" / "interactive.py"
+    action_dispatch_path = SRC_ROOT / "tui" / "action_dispatch.py"
     session_quit_path = SRC_ROOT / "tui" / "session_quit.py"
     interactive = __import__(
         "git_stage_batch.tui.interactive",
@@ -1793,6 +1846,10 @@ def test_tui_session_quit_owns_smart_quit_actions():
         for imported_module, _node in _import_from_nodes(interactive_path)
     }
     interactive_imported_names = set()
+    action_dispatch_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(action_dispatch_path)
+    }
     session_quit_imported_names = set()
     session_quit_names = {
         "command_abort",
@@ -1808,7 +1865,8 @@ def test_tui_session_quit_owns_smart_quit_actions():
         session_quit_imported_names |= {alias.name for alias in node.names}
 
     assert "handle_quit" in vars(session_quit)
-    assert "git_stage_batch.tui.session_quit" in interactive_imports
+    assert "git_stage_batch.tui.action_dispatch" in interactive_imports
+    assert "git_stage_batch.tui.session_quit" in action_dispatch_imports
     assert session_quit_names.isdisjoint(interactive_imported_names)
     assert session_quit_names <= session_quit_imported_names
 
@@ -1816,6 +1874,7 @@ def test_tui_session_quit_owns_smart_quit_actions():
 def test_tui_file_selection_menu_owns_whole_file_actions():
     """TUI whole-file selection should live in the file selection menu."""
     interactive_path = SRC_ROOT / "tui" / "interactive.py"
+    action_dispatch_path = SRC_ROOT / "tui" / "action_dispatch.py"
     file_menu_path = SRC_ROOT / "tui" / "file_selection_menu.py"
     interactive = __import__(
         "git_stage_batch.tui.interactive",
@@ -1830,6 +1889,10 @@ def test_tui_file_selection_menu_owns_whole_file_actions():
         for imported_module, _node in _import_from_nodes(interactive_path)
     }
     interactive_imported_names = set()
+    action_dispatch_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(action_dispatch_path)
+    }
     file_menu_imported_names = set()
     whole_file_command_names = {
         "command_discard_file",
@@ -1845,7 +1908,8 @@ def test_tui_file_selection_menu_owns_whole_file_actions():
 
     assert "handle_file_selection_menu" in vars(file_menu)
     assert "handle_file_selection" not in vars(interactive)
-    assert "git_stage_batch.tui.file_selection_menu" in interactive_imports
+    assert "git_stage_batch.tui.action_dispatch" in interactive_imports
+    assert "git_stage_batch.tui.file_selection_menu" in action_dispatch_imports
     assert whole_file_command_names.isdisjoint(interactive_imported_names)
     assert whole_file_command_names <= file_menu_imported_names
 
@@ -1853,6 +1917,7 @@ def test_tui_file_selection_menu_owns_whole_file_actions():
 def test_tui_line_selection_menu_owns_line_actions():
     """TUI line selection should live in the line selection menu."""
     interactive_path = SRC_ROOT / "tui" / "interactive.py"
+    action_dispatch_path = SRC_ROOT / "tui" / "action_dispatch.py"
     line_menu_path = SRC_ROOT / "tui" / "line_selection_menu.py"
     interactive = __import__(
         "git_stage_batch.tui.interactive",
@@ -1867,6 +1932,10 @@ def test_tui_line_selection_menu_owns_line_actions():
         for imported_module, _node in _import_from_nodes(interactive_path)
     }
     interactive_imported_names = set()
+    action_dispatch_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(action_dispatch_path)
+    }
     line_menu_imported_names = set()
     line_command_names = {
         "command_discard_line",
@@ -1882,7 +1951,8 @@ def test_tui_line_selection_menu_owns_line_actions():
 
     assert "handle_line_selection_menu" in vars(line_menu)
     assert "handle_line_selection" not in vars(interactive)
-    assert "git_stage_batch.tui.line_selection_menu" in interactive_imports
+    assert "git_stage_batch.tui.action_dispatch" in interactive_imports
+    assert "git_stage_batch.tui.line_selection_menu" in action_dispatch_imports
     assert line_command_names.isdisjoint(interactive_imported_names)
     assert line_command_names <= line_menu_imported_names
 

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -1776,6 +1776,43 @@ def test_tui_cli_escape_owns_command_fallback():
     assert cli_escape_names <= cli_escape_imported_names
 
 
+def test_tui_session_quit_owns_smart_quit_actions():
+    """TUI smart quit handling should live in the session quit adapter."""
+    interactive_path = SRC_ROOT / "tui" / "interactive.py"
+    session_quit_path = SRC_ROOT / "tui" / "session_quit.py"
+    interactive = __import__(
+        "git_stage_batch.tui.interactive",
+        fromlist=["interactive"],
+    )
+    session_quit = __import__(
+        "git_stage_batch.tui.session_quit",
+        fromlist=["session_quit"],
+    )
+    interactive_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(interactive_path)
+    }
+    interactive_imported_names = set()
+    session_quit_imported_names = set()
+    session_quit_names = {
+        "command_abort",
+        "command_stop",
+        "prompt_quit_session",
+        "read_text_file_contents",
+    }
+
+    for _imported_module, node in _import_from_nodes(interactive_path):
+        interactive_imported_names |= {alias.name for alias in node.names}
+
+    for _imported_module, node in _import_from_nodes(session_quit_path):
+        session_quit_imported_names |= {alias.name for alias in node.names}
+
+    assert "handle_quit" in vars(session_quit)
+    assert "git_stage_batch.tui.session_quit" in interactive_imports
+    assert session_quit_names.isdisjoint(interactive_imported_names)
+    assert session_quit_names <= session_quit_imported_names
+
+
 def test_tui_file_selection_menu_owns_whole_file_actions():
     """TUI whole-file selection should live in the file selection menu."""
     interactive_path = SRC_ROOT / "tui" / "interactive.py"

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -1663,6 +1663,54 @@ def test_tui_fixup_menu_owns_suggest_fixup_submenu():
     assert fixup_menu_names <= fixup_menu_imported_names
 
 
+def test_tui_shell_command_owns_shell_escape():
+    """TUI shell escapes should live in the shell command adapter."""
+    interactive_path = SRC_ROOT / "tui" / "interactive.py"
+    shell_command_path = SRC_ROOT / "tui" / "shell_command.py"
+    interactive = __import__(
+        "git_stage_batch.tui.interactive",
+        fromlist=["interactive"],
+    )
+    shell_command = __import__(
+        "git_stage_batch.tui.shell_command",
+        fromlist=["shell_command"],
+    )
+    interactive_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(interactive_path)
+    }
+    interactive_imported_names = set()
+    shell_command_imported_names = set()
+    interactive_plain_imports = set()
+    shell_command_plain_imports = set()
+    shell_command_names = {
+        "get_git_repository_root_path",
+        "prompt_shell_command",
+    }
+
+    for node in ast.walk(ast.parse(interactive_path.read_text())):
+        if isinstance(node, ast.Import):
+            interactive_plain_imports |= {alias.name for alias in node.names}
+
+    for node in ast.walk(ast.parse(shell_command_path.read_text())):
+        if isinstance(node, ast.Import):
+            shell_command_plain_imports |= {alias.name for alias in node.names}
+
+    for _imported_module, node in _import_from_nodes(interactive_path):
+        interactive_imported_names |= {alias.name for alias in node.names}
+
+    for _imported_module, node in _import_from_nodes(shell_command_path):
+        shell_command_imported_names |= {alias.name for alias in node.names}
+
+    assert "handle_shell_command" in vars(shell_command)
+    assert "_handle_shell" not in vars(interactive)
+    assert "git_stage_batch.tui.shell_command" in interactive_imports
+    assert "subprocess" not in interactive_plain_imports
+    assert "subprocess" in shell_command_plain_imports
+    assert shell_command_names.isdisjoint(interactive_imported_names)
+    assert shell_command_names <= shell_command_imported_names
+
+
 def test_tui_file_selection_menu_owns_whole_file_actions():
     """TUI whole-file selection should live in the file selection menu."""
     interactive_path = SRC_ROOT / "tui" / "interactive.py"

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -1452,11 +1452,16 @@ def test_cli_dispatch_delegates_noninteractive_execution():
 def test_tui_cli_escape_does_not_import_dispatch():
     """TUI command escape should execute parsed args without importing launcher dispatch."""
     interactive_path = SRC_ROOT / "tui" / "interactive.py"
+    cli_escape_path = SRC_ROOT / "tui" / "cli_escape.py"
     execution_path = SRC_ROOT / "cli" / "execution.py"
     dispatch_path = SRC_ROOT / "cli" / "dispatch.py"
     interactive_imports = {
         imported_module
         for imported_module, _node in _import_from_nodes(interactive_path)
+    }
+    cli_escape_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(cli_escape_path)
     }
     execution_imports = {
         imported_module
@@ -1467,9 +1472,10 @@ def test_tui_cli_escape_does_not_import_dispatch():
         for imported_module, _node in _import_from_nodes(dispatch_path)
     }
 
-    assert "git_stage_batch.cli.argument_parser" in interactive_imports
-    assert "git_stage_batch.cli.execution" in interactive_imports
-    assert "git_stage_batch.cli.dispatch" not in interactive_imports
+    assert "git_stage_batch.tui.cli_escape" in interactive_imports
+    assert "git_stage_batch.cli.argument_parser" in cli_escape_imports
+    assert "git_stage_batch.cli.execution" in cli_escape_imports
+    assert "git_stage_batch.cli.dispatch" not in cli_escape_imports
     assert "git_stage_batch.tui.interactive" not in execution_imports
     assert "git_stage_batch.tui.interactive" in dispatch_imports
 

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -1417,7 +1417,7 @@ def test_file_scope_discard_to_batch_owns_multi_file_pipeline():
     )
     public_names = {
         "DiscardFilesToBatchResult",
-        "command_discard_files_to_batch",
+        "discard_files_to_batch",
     }
     moved_names = {
         "CollectedTextFileDiscards",
@@ -1429,7 +1429,7 @@ def test_file_scope_discard_to_batch_owns_multi_file_pipeline():
         "_discard_prepared_text_files_to_batch",
         "_prepare_text_file_discard_to_batch",
         "_run_reverse_apply_for_prepared_discards",
-        "command_discard_files_to_batch",
+        "discard_files_to_batch",
     }
     helper_imports = {
         "BatchFileUpdate",

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -3799,15 +3799,20 @@ def test_include_selected_change_staging_stays_in_command_helper():
 def test_include_line_selection_stays_in_command_helper():
     """Include line-selection support should stay out of the command entrypoint."""
     include_path = SRC_ROOT / "commands" / "include.py"
+    helper_path = (
+        SRC_ROOT / "commands" / "selection" / "include_line_selection.py"
+    )
     helper = __import__(
         "git_stage_batch.commands.selection.include_line_selection",
         fromlist=["include_line_selection"],
     )
     public_names = {
+        "IncludeLineSelectionContext",
         "TransientIncludeFailureReason",
         "TransientIncludeResult",
         "annotate_line_changes_with_working_tree_source",
         "line_sequence_ends_with_lf",
+        "load_include_line_selection_context",
         "record_baseline_references_for_additions",
         "selected_file_view_is_fresh_for",
         "selected_file_view_targets",
@@ -3820,6 +3825,7 @@ def test_include_line_selection_stays_in_command_helper():
         "TransientIncludeResult",
         "_annotate_line_changes_with_working_tree_source",
         "_line_sequence_ends_with_lf",
+        "_load_include_line_selection_context",
         "_record_baseline_references_for_additions",
         "_restore_session_batch_sources_file",
         "_selected_file_view_is_fresh_for",
@@ -3828,6 +3834,23 @@ def test_include_line_selection_stays_in_command_helper():
         "_stage_live_line_target_buffer",
         "_transient_include_failure_message",
         "_try_build_index_content_via_transient_batch",
+    }
+    line_selection_resolution_names = {
+        "annotate_line_changes_with_working_tree_source",
+        "auto_add_untracked_files",
+        "cache_unstaged_file_as_single_hunk",
+        "load_line_changes_from_state",
+        "require_selected_hunk",
+        "selected_file_view_is_fresh_for",
+        "selected_file_view_targets",
+        "snapshot_selected_change_state",
+    }
+    helper_imports = {
+        "auto_add_untracked_files",
+        "cache_unstaged_file_as_single_hunk",
+        "load_line_changes_from_state",
+        "require_selected_hunk",
+        "snapshot_selected_change_state",
     }
     include_imports_helper = False
 
@@ -3839,6 +3862,11 @@ def test_include_line_selection_stays_in_command_helper():
         for node in ast.walk(tree)
         if isinstance(node, ast.ClassDef | ast.FunctionDef)
     }
+    include_functions = {
+        node.name: node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef)
+    }
 
     for imported_module, node in _import_from_nodes(include_path):
         if imported_module != "git_stage_batch.commands.selection":
@@ -3847,8 +3875,19 @@ def test_include_line_selection_stays_in_command_helper():
         if "include_line_selection" in imported_names:
             include_imports_helper = True
 
+    command_include_line_names = {
+        node.id
+        for node in ast.walk(include_functions["command_include_line"])
+        if isinstance(node, ast.Name)
+    }
+    helper_imported_names = set()
+    for _imported_module, node in _import_from_nodes(helper_path):
+        helper_imported_names |= {alias.name for alias in node.names}
+
     assert old_include_names.isdisjoint(include_names)
     assert include_imports_helper
+    assert line_selection_resolution_names.isdisjoint(command_include_line_names)
+    assert helper_imports <= helper_imported_names
 
 
 def test_include_line_replacement_stays_in_command_helper():

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -2322,6 +2322,46 @@ def test_tui_file_review_fixup_actions_own_line_fixups():
     assert "git_stage_batch.data.suggest_fixup_state" in fixup_action_imports
 
 
+def test_tui_file_review_prompts_own_action_vocabulary():
+    """TUI file review prompts should own action text and parsing."""
+    review_path = SRC_ROOT / "tui" / "file_review" / "__init__.py"
+    prompts_path = SRC_ROOT / "tui" / "file_review" / "prompts.py"
+    review = __import__(
+        "git_stage_batch.tui.file_review",
+        fromlist=["file_review"],
+    )
+    prompts = __import__(
+        "git_stage_batch.tui.file_review.prompts",
+        fromlist=["prompts"],
+    )
+    review_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(review_path)
+    }
+    prompt_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(prompts_path)
+    }
+    old_review_names = {
+        "_normalize_review_action",
+        "_print_review_help",
+        "_prompt_review_action",
+    }
+    prompt_text = prompts_path.read_text()
+    review_text = review_path.read_text()
+
+    assert {
+        "normalize_review_action",
+        "print_review_help",
+        "prompt_review_action",
+    } <= vars(prompts).keys()
+    assert old_review_names.isdisjoint(vars(review))
+    assert "git_stage_batch.tui.file_review.prompts" in review_imports
+    assert "git_stage_batch.tui.prompts" in prompt_imports
+    assert "Review action:" not in review_text
+    assert "Review action:" in prompt_text
+
+
 def test_commands_do_not_import_tui():
     """Command modules should not launch or depend on TUI modules."""
     violations = []

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -2109,6 +2109,44 @@ def test_tui_file_review_state_name_does_not_shadow_persisted_state():
     assert "FileReviewState" not in imported_state_names
 
 
+def test_tui_file_review_display_owns_review_rendering():
+    """TUI file review display should own reviewed-file rendering."""
+    review_path = SRC_ROOT / "tui" / "file_review" / "__init__.py"
+    display_path = SRC_ROOT / "tui" / "file_review" / "display.py"
+    review = __import__(
+        "git_stage_batch.tui.file_review",
+        fromlist=["file_review"],
+    )
+    display = __import__(
+        "git_stage_batch.tui.file_review.display",
+        fromlist=["display"],
+    )
+    review_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(review_path)
+    }
+    display_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(display_path)
+    }
+    old_review_names = {
+        "_render_review",
+        "get_hunk_counts",
+        "print_status_bar",
+    }
+
+    assert "render_file_review" in vars(display)
+    assert old_review_names.isdisjoint(vars(review))
+    assert "git_stage_batch.tui.file_review.display" in review_imports
+    assert "git_stage_batch.commands.show" not in review_imports
+    assert "git_stage_batch.data.progress" not in review_imports
+    assert "git_stage_batch.tui.display" not in review_imports
+    assert "git_stage_batch.commands.show" in display_imports
+    assert "git_stage_batch.commands.show_from" in display_imports
+    assert "git_stage_batch.data.progress" in display_imports
+    assert "git_stage_batch.tui.display" in display_imports
+
+
 def test_commands_do_not_import_tui():
     """Command modules should not launch or depend on TUI modules."""
     violations = []

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -2628,9 +2628,10 @@ def test_selected_line_source_refresh_uses_public_api():
         "_refresh_selected_lines_against_source_lines",
     }
     expected_imports = {
-        SRC_ROOT / "commands" / "discard.py": {
-            "refresh_selected_lines_against_source_lines",
-        },
+        SRC_ROOT
+        / "commands"
+        / "selection"
+        / "discard_line_replacement.py": {"refresh_selected_lines_against_source_lines"},
         SRC_ROOT / "data" / "consumed_selections.py": public_names,
     }
     violations = []
@@ -2734,7 +2735,10 @@ def test_batch_ownership_uses_public_lineage_remapping():
         "BatchSourceAdvanceResult",
     }
     expected_imports = {
-        SRC_ROOT / "commands" / "discard.py": public_names,
+        SRC_ROOT
+        / "commands"
+        / "selection"
+        / "discard_line_replacement.py": public_names,
         SRC_ROOT / "batch" / "source_advancement.py": public_names,
     }
     violations = []
@@ -2792,7 +2796,10 @@ def test_batch_source_advancement_uses_public_entry_helpers():
         "_advance_batch_source_for_file_with_provenance",
     }
     expected_imports = {
-        SRC_ROOT / "commands" / "discard.py": {
+        SRC_ROOT
+        / "commands"
+        / "selection"
+        / "discard_line_replacement.py": {
             "advance_source_lines_preserving_existing_presence",
         },
         SRC_ROOT / "batch" / "source_refresh.py": {
@@ -4215,27 +4222,57 @@ def test_discard_line_replacement_stays_in_command_helper():
     )
     public_names = {
         "DiscardLineReplacementSelection",
+        "add_discard_line_replacement_to_batch",
         "build_discard_line_replacement_target_buffer",
         "derive_live_replacement_line_runs",
         "prepare_discard_line_replacement_selection",
     }
     old_discard_names = {
+        "_add_discard_line_replacement_to_batch",
         "_derive_live_replacement_line_runs",
         "_select_rewritten_replacement_lines",
     }
     helper_imports = {
+        "BatchOwnership",
+        "acquire_batch_ownership_update_for_selection",
+        "add_file_to_batch",
+        "advance_source_lines_preserving_existing_presence",
         "annotate_with_batch_source_working_lines",
+        "batch_exists",
         "build_file_hunk_from_buffer",
         "build_target_working_tree_buffer_from_lines",
         "build_target_working_tree_buffer_with_replaced_lines",
         "coerce_replacement_payload",
+        "create_batch",
+        "create_batch_source_commit",
+        "detect_file_mode",
         "derive_replacement_line_runs_from_lines",
+        "load_git_object_as_buffer",
         "load_git_object_as_buffer_or_empty",
         "load_line_changes_from_state",
+        "load_session_batch_sources",
         "load_working_tree_file_as_buffer",
+        "merge_batch_ownership",
         "parse_line_selection",
+        "read_batch_metadata",
+        "refresh_selected_lines_against_source_lines",
         "replacement_selection",
+        "remap_batch_ownership_with_lineage",
         "require_line_selection_in_view",
+        "save_session_batch_sources",
+        "snapshot_file_if_untracked",
+        "translate_lines_to_batch_ownership",
+    }
+    moved_batch_update_names = {
+        "advance_source_lines_preserving_existing_presence",
+        "create_batch_source_commit",
+        "load_git_object_as_buffer",
+        "load_session_batch_sources",
+        "merge_batch_ownership",
+        "refresh_selected_lines_against_source_lines",
+        "remap_batch_ownership_with_lineage",
+        "save_session_batch_sources",
+        "translate_lines_to_batch_ownership",
     }
 
     assert public_names <= vars(helper).keys()
@@ -4243,6 +4280,11 @@ def test_discard_line_replacement_stays_in_command_helper():
     discard_tree = ast.parse(discard_path.read_text(), filename=str(discard_path))
     discard_helpers = {
         node.name for node in ast.walk(discard_tree) if isinstance(node, ast.FunctionDef)
+    }
+    discard_functions = {
+        node.name: node
+        for node in ast.walk(discard_tree)
+        if isinstance(node, ast.FunctionDef)
     }
     discard_imports_helper = False
 
@@ -4256,8 +4298,14 @@ def test_discard_line_replacement_stays_in_command_helper():
     helper_imported_names = set()
     for _imported_module, node in _import_from_nodes(helper_path):
         helper_imported_names |= {alias.name for alias in node.names}
+    command_update_names = {
+        node.id
+        for node in ast.walk(discard_functions["_command_discard_lines_to_batch_as"])
+        if isinstance(node, ast.Name)
+    }
 
     assert old_discard_names.isdisjoint(discard_helpers)
+    assert moved_batch_update_names.isdisjoint(command_update_names)
     assert discard_imports_helper
     assert helper_imports <= helper_imported_names
 

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -2147,6 +2147,44 @@ def test_tui_file_review_display_owns_review_rendering():
     assert "git_stage_batch.tui.display" in display_imports
 
 
+def test_tui_file_review_candidates_own_candidate_browser():
+    """TUI file review candidates should own batch candidate browsing."""
+    review_path = SRC_ROOT / "tui" / "file_review" / "__init__.py"
+    candidates_path = SRC_ROOT / "tui" / "file_review" / "candidates.py"
+    review = __import__(
+        "git_stage_batch.tui.file_review",
+        fromlist=["file_review"],
+    )
+    candidates = __import__(
+        "git_stage_batch.tui.file_review.candidates",
+        fromlist=["candidates"],
+    )
+    review_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(review_path)
+    }
+    candidate_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(candidates_path)
+    }
+    old_review_names = {
+        "_browse_candidates",
+        "_execute_candidate",
+        "_preview_candidate",
+        "_prompt_candidate_action",
+        "_prompt_candidate_operation",
+    }
+
+    assert "browse_candidates" in vars(candidates)
+    assert old_review_names.isdisjoint(vars(review))
+    assert "git_stage_batch.tui.file_review.candidates" in review_imports
+    assert "git_stage_batch.commands.apply_from" not in review_imports
+    assert "git_stage_batch.commands.show_from" not in review_imports
+    assert "git_stage_batch.commands.apply_from" in candidate_imports
+    assert "git_stage_batch.commands.include_from" in candidate_imports
+    assert "git_stage_batch.commands.show_from" in candidate_imports
+
+
 def test_commands_do_not_import_tui():
     """Command modules should not launch or depend on TUI modules."""
     violations = []

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -2293,6 +2293,35 @@ def test_tui_file_review_block_actions_own_block_commands():
     assert "git_stage_batch.commands.unblock_file" in block_action_imports
 
 
+def test_tui_file_review_fixup_actions_own_line_fixups():
+    """TUI file review fixup actions should own line-fixup command calls."""
+    review_path = SRC_ROOT / "tui" / "file_review" / "__init__.py"
+    fixup_actions_path = SRC_ROOT / "tui" / "file_review" / "fixup_actions.py"
+    fixup_actions = __import__(
+        "git_stage_batch.tui.file_review.fixup_actions",
+        fromlist=["fixup_actions"],
+    )
+    review_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(review_path)
+    }
+    fixup_action_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(fixup_actions_path)
+    }
+
+    assert {
+        "clear_file_review_fixup_state",
+        "read_last_fixup_commit_hash",
+        "suggest_fixup_for_lines",
+    } <= vars(fixup_actions).keys()
+    assert "git_stage_batch.tui.file_review.fixup_actions" in review_imports
+    assert "git_stage_batch.commands.suggest_fixup" not in review_imports
+    assert "git_stage_batch.data.suggest_fixup_state" not in review_imports
+    assert "git_stage_batch.commands.suggest_fixup" in fixup_action_imports
+    assert "git_stage_batch.data.suggest_fixup_state" in fixup_action_imports
+
+
 def test_commands_do_not_import_tui():
     """Command modules should not launch or depend on TUI modules."""
     violations = []

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -1832,7 +1832,7 @@ def test_suggest_fixup_state_stays_in_data_layer():
     command_path = SRC_ROOT / "commands" / "suggest_fixup.py"
     data_path = SRC_ROOT / "data" / "suggest_fixup_state.py"
     tui_paths = (
-        SRC_ROOT / "tui" / "interactive.py",
+        SRC_ROOT / "tui" / "fixup_menu.py",
         SRC_ROOT / "tui" / "file_review" / "__init__.py",
     )
     command_imports = {

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -2185,6 +2185,45 @@ def test_tui_file_review_candidates_own_candidate_browser():
     assert "git_stage_batch.commands.show_from" in candidate_imports
 
 
+def test_tui_file_review_batch_actions_own_batch_transfers():
+    """TUI file review batch actions should own batch transfer commands."""
+    review_path = SRC_ROOT / "tui" / "file_review" / "__init__.py"
+    batch_actions_path = SRC_ROOT / "tui" / "file_review" / "batch_actions.py"
+    review = __import__(
+        "git_stage_batch.tui.file_review",
+        fromlist=["file_review"],
+    )
+    batch_actions = __import__(
+        "git_stage_batch.tui.file_review.batch_actions",
+        fromlist=["batch_actions"],
+    )
+    review_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(review_path)
+    }
+    batch_action_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(batch_actions_path)
+    }
+    old_review_names = {
+        "_apply_batch_file_action",
+        "_apply_batch_line_action",
+        "_apply_batch_replacement_action",
+    }
+
+    assert {
+        "apply_batch_file_action",
+        "apply_batch_line_action",
+        "apply_batch_replacement_action",
+    } <= vars(batch_actions).keys()
+    assert old_review_names.isdisjoint(vars(review))
+    assert "git_stage_batch.tui.file_review.batch_actions" in review_imports
+    assert "git_stage_batch.commands.discard_from" not in review_imports
+    assert "git_stage_batch.commands.include_from" not in review_imports
+    assert "git_stage_batch.commands.discard_from" in batch_action_imports
+    assert "git_stage_batch.commands.include_from" in batch_action_imports
+
+
 def test_commands_do_not_import_tui():
     """Command modules should not launch or depend on TUI modules."""
     violations = []

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -2265,6 +2265,34 @@ def test_tui_file_review_live_actions_own_live_transfers():
     assert "git_stage_batch.commands.skip" in live_action_imports
 
 
+def test_tui_file_review_block_actions_own_block_commands():
+    """TUI file review block actions should own block command calls."""
+    review_path = SRC_ROOT / "tui" / "file_review" / "__init__.py"
+    block_actions_path = SRC_ROOT / "tui" / "file_review" / "block_actions.py"
+    block_actions = __import__(
+        "git_stage_batch.tui.file_review.block_actions",
+        fromlist=["block_actions"],
+    )
+    review_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(review_path)
+    }
+    block_action_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(block_actions_path)
+    }
+
+    assert {
+        "block_review_file",
+        "unblock_review_file",
+    } <= vars(block_actions).keys()
+    assert "git_stage_batch.tui.file_review.block_actions" in review_imports
+    assert "git_stage_batch.commands.block_file" not in review_imports
+    assert "git_stage_batch.commands.unblock_file" not in review_imports
+    assert "git_stage_batch.commands.block_file" in block_action_imports
+    assert "git_stage_batch.commands.unblock_file" in block_action_imports
+
+
 def test_commands_do_not_import_tui():
     """Command modules should not launch or depend on TUI modules."""
     violations = []

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -4114,6 +4114,69 @@ def test_discard_line_replacement_stays_in_command_helper():
     assert helper_imports <= helper_imported_names
 
 
+def test_batch_line_selection_stays_in_command_helper():
+    """Batch line-selection validation should live in command selection support."""
+    include_path = SRC_ROOT / "commands" / "include.py"
+    discard_path = SRC_ROOT / "commands" / "discard.py"
+    helper_path = (
+        SRC_ROOT / "commands" / "selection" / "batch_line_selection.py"
+    )
+    helper = __import__(
+        "git_stage_batch.commands.selection.batch_line_selection",
+        fromlist=["batch_line_selection"],
+    )
+    public_names = {
+        "BatchLineSelection",
+        "select_lines_for_batch_action",
+    }
+    command_level_names = {
+        "parse_line_selection",
+        "require_line_selection_in_view",
+    }
+    guarded_functions = {
+        include_path: {
+            "_command_include_file_lines_to_batch",
+            "_command_include_lines_to_batch",
+        },
+        discard_path: {
+            "_command_discard_file_lines_to_batch",
+            "_command_discard_lines_to_batch",
+        },
+    }
+
+    assert public_names <= vars(helper).keys()
+
+    for path, function_names in guarded_functions.items():
+        tree = ast.parse(path.read_text(), filename=str(path))
+        functions = {
+            node.name: node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef)
+        }
+        imports_helper = False
+
+        for imported_module, node in _import_from_nodes(path):
+            if imported_module != "git_stage_batch.commands.selection":
+                continue
+            imported_names = {alias.name for alias in node.names}
+            if "batch_line_selection" in imported_names:
+                imports_helper = True
+
+        assert imports_helper
+        for function_name in function_names:
+            function = functions[function_name]
+            function_names_used = {
+                node.id for node in ast.walk(function) if isinstance(node, ast.Name)
+            }
+            assert command_level_names.isdisjoint(function_names_used)
+
+    helper_imported_names = set()
+    for _imported_module, node in _import_from_nodes(helper_path):
+        helper_imported_names |= {alias.name for alias in node.names}
+
+    assert command_level_names <= helper_imported_names
+
+
 def test_discard_uses_file_io_path_empty_helper():
     """Discard should use file I/O utilities for generic path byte checks."""
     discard_path = SRC_ROOT / "commands" / "discard.py"

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -2394,9 +2394,14 @@ def test_suggest_fixup_state_stays_in_data_layer():
     """Suggest-fixup state persistence should stay below command and TUI flows."""
     command_path = SRC_ROOT / "commands" / "suggest_fixup.py"
     data_path = SRC_ROOT / "data" / "suggest_fixup_state.py"
-    tui_paths = (
+    tui_command_paths = (
         SRC_ROOT / "tui" / "fixup_menu.py",
         SRC_ROOT / "tui" / "file_review" / "__init__.py",
+        SRC_ROOT / "tui" / "file_review" / "fixup_actions.py",
+    )
+    tui_state_paths = (
+        SRC_ROOT / "tui" / "fixup_menu.py",
+        SRC_ROOT / "tui" / "file_review" / "fixup_actions.py",
     )
     command_imports = {
         imported_module
@@ -2418,11 +2423,13 @@ def test_suggest_fixup_state_stays_in_data_layer():
     }
     violations = []
 
-    for tui_path in tui_paths:
+    for tui_path in tui_state_paths:
         imports = _import_from_nodes(tui_path)
         imported_modules = {imported_module for imported_module, _node in imports}
         assert "git_stage_batch.data.suggest_fixup_state" in imported_modules
 
+    for tui_path in tui_command_paths:
+        imports = _import_from_nodes(tui_path)
         for imported_module, node in imports:
             if imported_module != "git_stage_batch.commands.suggest_fixup":
                 continue

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -4000,6 +4000,61 @@ def test_discard_file_selection_stays_in_command_helper():
     assert helper_imports <= helper_imported_names
 
 
+def test_include_file_selection_stays_in_command_helper():
+    """Include file selection should stay out of the command entrypoint."""
+    include_path = SRC_ROOT / "commands" / "include.py"
+    helper_path = (
+        SRC_ROOT / "commands" / "selection" / "include_file_selection.py"
+    )
+    helper = __import__(
+        "git_stage_batch.commands.selection.include_file_selection",
+        fromlist=["include_file_selection"],
+    )
+    public_names = {"load_explicit_file_selection"}
+    helper_imports = {
+        "cache_unstaged_file_as_single_hunk",
+        "load_line_changes_from_state",
+        "render_gitlink_change",
+        "selected_file_view_targets",
+    }
+
+    assert public_names <= vars(helper).keys()
+
+    tree = ast.parse(include_path.read_text(), filename=str(include_path))
+    functions = {
+        node.name: node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef)
+    }
+    include_imports_helper = False
+
+    for imported_module, node in _import_from_nodes(include_path):
+        if imported_module != "git_stage_batch.commands.selection":
+            continue
+        imported_names = {alias.name for alias in node.names}
+        if "include_file_selection" in imported_names:
+            include_imports_helper = True
+
+    line_function_names = {
+        node.id
+        for node in ast.walk(functions["_command_include_file_lines_to_batch"])
+        if isinstance(node, ast.Name)
+    }
+    line_function_attributes = {
+        node.attr
+        for node in ast.walk(functions["_command_include_file_lines_to_batch"])
+        if isinstance(node, ast.Attribute)
+    }
+    helper_imported_names = set()
+    for _imported_module, node in _import_from_nodes(helper_path):
+        helper_imported_names |= {alias.name for alias in node.names}
+
+    assert include_imports_helper
+    assert "load_explicit_file_selection" in line_function_attributes
+    assert helper_imports.isdisjoint(line_function_names)
+    assert helper_imports <= helper_imported_names
+
+
 def test_discard_line_selection_stays_in_command_helper():
     """Discard line-selection editing should stay out of the command entrypoint."""
     discard_path = SRC_ROOT / "commands" / "discard.py"

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -3901,21 +3901,55 @@ def test_include_line_replacement_stays_in_command_helper():
         fromlist=["include_line_replacement"],
     )
     public_names = {
+        "IncludeLineReplacementFileSelection",
+        "IncludeLineReplacementSelection",
         "apply_include_line_replacement",
+        "prepare_file_include_line_replacement",
+        "prepare_pathless_include_line_replacement",
         "translate_file_view_replacement_to_unstaged_diff",
     }
     old_include_names = {
         "_apply_include_line_replacement",
         "_line_identity_for_live_replacement",
+        "_prepare_file_include_line_replacement",
+        "_prepare_pathless_include_line_replacement",
         "_translate_file_view_replacement_to_unstaged_diff",
     }
     helper_imports = {
+        "SelectedChangeKind",
+        "annotate_with_batch_source",
         "build_target_index_buffer_with_replaced_lines",
+        "cache_unstaged_file_as_single_hunk",
+        "format_line_ids",
+        "get_index_snapshot_file_path",
+        "get_selected_change_file_path",
+        "get_working_tree_snapshot_file_path",
+        "load_git_object_as_buffer_or_empty",
+        "load_line_changes_from_state",
+        "load_working_tree_file_as_buffer",
         "parse_line_selection",
+        "read_selected_change_kind",
         "record_consumed_selection",
         "render_unstaged_file_as_single_hunk",
         "require_line_selection_in_view",
+        "require_selected_hunk",
+        "snapshot_selected_change_state",
         "update_index_with_blob_buffer",
+    }
+    replacement_context_names = {
+        "annotate_with_batch_source",
+        "cache_unstaged_file_as_single_hunk",
+        "format_line_ids",
+        "get_index_snapshot_file_path",
+        "get_selected_change_file_path",
+        "get_working_tree_snapshot_file_path",
+        "load_git_object_as_buffer",
+        "load_line_changes_from_state",
+        "load_working_tree_file_as_buffer",
+        "require_selected_hunk",
+        "selected_file_view_is_fresh_for",
+        "selected_file_view_targets",
+        "snapshot_selected_change_state",
     }
 
     assert public_names <= vars(helper).keys()
@@ -3925,6 +3959,11 @@ def test_include_line_replacement_stays_in_command_helper():
         node.name
         for node in ast.walk(include_tree)
         if isinstance(node, ast.ClassDef | ast.FunctionDef)
+    }
+    include_functions = {
+        node.name: node
+        for node in ast.walk(include_tree)
+        if isinstance(node, ast.FunctionDef)
     }
     include_imports_helper = False
 
@@ -3939,8 +3978,23 @@ def test_include_line_replacement_stays_in_command_helper():
     for _imported_module, node in _import_from_nodes(helper_path):
         helper_imported_names |= {alias.name for alias in node.names}
 
+    command_line_as_names = {
+        node.id
+        for node in ast.walk(include_functions["command_include_line_as"])
+        if isinstance(node, ast.Name)
+    }
+    command_line_as_attributes = {
+        node.attr
+        for node in ast.walk(include_functions["command_include_line_as"])
+        if isinstance(node, ast.Attribute)
+    }
+
     assert old_include_names.isdisjoint(include_names)
     assert include_imports_helper
+    assert "prepare_file_include_line_replacement" in command_line_as_attributes
+    assert "prepare_pathless_include_line_replacement" in command_line_as_attributes
+    assert replacement_context_names.isdisjoint(command_line_as_names)
+    assert replacement_context_names.isdisjoint(command_line_as_attributes)
     assert helper_imports <= helper_imported_names
 
 

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -1555,10 +1555,15 @@ def test_tui_asset_menu_owns_install_assets_action():
 def test_tui_flow_menu_owns_batch_selection_menus():
     """TUI flow selection should live in the flow menu adapter."""
     interactive_path = SRC_ROOT / "tui" / "interactive.py"
+    flow_actions_path = SRC_ROOT / "tui" / "flow_actions.py"
     flow_menu_path = SRC_ROOT / "tui" / "flow_menu.py"
     interactive = __import__(
         "git_stage_batch.tui.interactive",
         fromlist=["interactive"],
+    )
+    flow_actions = __import__(
+        "git_stage_batch.tui.flow_actions",
+        fromlist=["flow_actions"],
     )
     flow_menu = __import__(
         "git_stage_batch.tui.flow_menu",
@@ -1568,15 +1573,21 @@ def test_tui_flow_menu_owns_batch_selection_menus():
         imported_module
         for imported_module, _node in _import_from_nodes(interactive_path)
     }
+    flow_actions_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(flow_actions_path)
+    }
     flow_menu_imports = {
         imported_module
         for imported_module, _node in _import_from_nodes(flow_menu_path)
     }
 
+    assert "handle_flow_action" in vars(flow_actions)
     assert {"handle_from_menu", "handle_to_menu"} <= vars(flow_menu).keys()
     assert "_handle_from" not in vars(interactive)
     assert "_handle_to" not in vars(interactive)
-    assert "git_stage_batch.tui.flow_menu" in interactive_imports
+    assert "git_stage_batch.tui.flow_actions" in interactive_imports
+    assert "git_stage_batch.tui.flow_menu" in flow_actions_imports
     assert "git_stage_batch.batch.query" not in interactive_imports
     assert "git_stage_batch.commands.new" not in interactive_imports
     assert "git_stage_batch.batch.query" in flow_menu_imports

--- a/tests/commands/test_discard.py
+++ b/tests/commands/test_discard.py
@@ -832,7 +832,10 @@ class TestCommandDiscardToBatch:
         command_start()
         fetch_next_change()
 
-        with patch("git_stage_batch.commands.discard.add_file_to_batch", side_effect=RuntimeError("boom")):
+        with patch(
+            "git_stage_batch.commands.selection.discard_line_replacement.add_file_to_batch",
+            side_effect=RuntimeError("boom"),
+        ):
             with pytest.raises(RuntimeError, match="boom"):
                 command_discard_line_as_to_batch(
                     "feature-batch",

--- a/tests/commands/test_file_scope_actions.py
+++ b/tests/commands/test_file_scope_actions.py
@@ -197,7 +197,7 @@ def test_discard_to_batch_each_resolved_file_reports_batch_result(
 
     monkeypatch.setattr(
         multi_file_actions,
-        "command_discard_files_to_batch",
+        "discard_files_to_batch",
         fake_discard_files_to_batch,
     )
     monkeypatch.setattr(

--- a/tests/tui/test_cli_escape.py
+++ b/tests/tui/test_cli_escape.py
@@ -1,0 +1,32 @@
+"""Tests for the TUI CLI command escape."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+
+from git_stage_batch.exceptions import BypassRefresh
+from git_stage_batch.tui.cli_escape import handle_cli_escape
+
+
+def test_handle_cli_escape_executes_parsed_args():
+    """Test parsed CLI args execute through the escape adapter."""
+    args = SimpleNamespace(
+        interactive_flag=False,
+        interactive_command=False,
+    )
+    print_help = Mock()
+
+    with patch(
+        "git_stage_batch.tui.cli_escape.parse_command_line",
+        return_value=args,
+    ) as mock_parse:
+        with patch(
+            "git_stage_batch.tui.cli_escape.execute_non_interactive_args"
+        ) as mock_execute:
+            with pytest.raises(BypassRefresh):
+                handle_cli_escape("status", print_help=print_help)
+
+    mock_parse.assert_called_once_with(["status"], quiet=False)
+    mock_execute.assert_called_once_with(args)
+    print_help.assert_not_called()

--- a/tests/tui/test_file_review.py
+++ b/tests/tui/test_file_review.py
@@ -46,7 +46,7 @@ class TestHandleCurrentFileReview:
             return_value=_line_changes("test.txt"),
         ):
             with patch(
-                "git_stage_batch.tui.file_review.get_hunk_counts",
+                "git_stage_batch.tui.file_review.display.get_hunk_counts",
                 return_value={},
             ):
                 with patch(
@@ -74,7 +74,7 @@ class TestHandleCurrentFileReview:
             return_value=_line_changes("test.txt"),
         ):
             with patch(
-                "git_stage_batch.tui.file_review.get_hunk_counts",
+                "git_stage_batch.tui.file_review.display.get_hunk_counts",
                 return_value={},
             ):
                 with patch("git_stage_batch.commands.show.command_show") as mock_show:
@@ -101,7 +101,7 @@ class TestHandleCurrentFileReview:
             return_value=_line_changes("test.txt"),
         ):
             with patch(
-                "git_stage_batch.tui.file_review.get_hunk_counts",
+                "git_stage_batch.tui.file_review.display.get_hunk_counts",
                 return_value={},
             ):
                 with patch("git_stage_batch.commands.show.command_show") as mock_show:
@@ -128,7 +128,7 @@ class TestHandleCurrentFileReview:
             return_value=_line_changes("test.txt"),
         ):
             with patch(
-                "git_stage_batch.tui.file_review.get_hunk_counts",
+                "git_stage_batch.tui.file_review.display.get_hunk_counts",
                 return_value={},
             ):
                 with patch("git_stage_batch.commands.show.command_show") as mock_show:
@@ -159,7 +159,7 @@ class TestHandleCurrentFileReview:
             return_value=_line_changes("test.txt"),
         ):
             with patch(
-                "git_stage_batch.tui.file_review.get_hunk_counts",
+                "git_stage_batch.tui.file_review.display.get_hunk_counts",
                 return_value={},
             ):
                 with patch("git_stage_batch.commands.show.command_show"):
@@ -188,7 +188,7 @@ class TestHandleCurrentFileReview:
             return_value=_line_changes("test.txt"),
         ):
             with patch(
-                "git_stage_batch.tui.file_review.get_hunk_counts",
+                "git_stage_batch.tui.file_review.display.get_hunk_counts",
                 return_value={},
             ):
                 with patch("git_stage_batch.commands.show.command_show"):
@@ -221,7 +221,7 @@ class TestHandleCurrentFileReview:
             return_value=_line_changes("test.txt"),
         ):
             with patch(
-                "git_stage_batch.tui.file_review.get_hunk_counts",
+                "git_stage_batch.tui.file_review.display.get_hunk_counts",
                 return_value={},
             ):
                 with patch("git_stage_batch.commands.show.command_show"):
@@ -254,7 +254,7 @@ class TestHandleCurrentFileReview:
             return_value=_line_changes("test.txt"),
         ):
             with patch(
-                "git_stage_batch.tui.file_review.get_hunk_counts",
+                "git_stage_batch.tui.file_review.display.get_hunk_counts",
                 return_value={},
             ):
                 with patch("git_stage_batch.commands.show.command_show"):
@@ -279,7 +279,7 @@ class TestHandleCurrentFileReview:
             return_value=_line_changes("test.txt"),
         ):
             with patch(
-                "git_stage_batch.tui.file_review.get_hunk_counts",
+                "git_stage_batch.tui.file_review.display.get_hunk_counts",
                 return_value={},
             ):
                 with patch("git_stage_batch.commands.show.command_show"):
@@ -314,7 +314,7 @@ class TestHandleCurrentFileReview:
             return_value=_line_changes("test.txt"),
         ):
             with patch(
-                "git_stage_batch.tui.file_review.get_hunk_counts",
+                "git_stage_batch.tui.file_review.display.get_hunk_counts",
                 return_value={},
             ):
                 with patch("git_stage_batch.commands.show.command_show"):
@@ -344,7 +344,7 @@ class TestHandleCurrentFileReview:
             return_value=_line_changes("test.txt"),
         ):
             with patch(
-                "git_stage_batch.tui.file_review.get_hunk_counts",
+                "git_stage_batch.tui.file_review.display.get_hunk_counts",
                 return_value={},
             ):
                 with patch("git_stage_batch.commands.show.command_show"):
@@ -373,7 +373,7 @@ class TestHandleCurrentFileReview:
             return_value=_line_changes("test.txt"),
         ):
             with patch(
-                "git_stage_batch.tui.file_review.get_hunk_counts",
+                "git_stage_batch.tui.file_review.display.get_hunk_counts",
                 return_value={},
             ):
                 with patch("git_stage_batch.commands.show.command_show"):
@@ -402,7 +402,7 @@ class TestHandleCurrentFileReview:
             return_value=_line_changes("test.txt"),
         ):
             with patch(
-                "git_stage_batch.tui.file_review.get_hunk_counts",
+                "git_stage_batch.tui.file_review.display.get_hunk_counts",
                 return_value={},
             ):
                 with patch("git_stage_batch.commands.show.command_show"):
@@ -431,7 +431,7 @@ class TestHandleCurrentFileReview:
             return_value=_line_changes("test.txt"),
         ):
             with patch(
-                "git_stage_batch.tui.file_review.get_hunk_counts",
+                "git_stage_batch.tui.file_review.display.get_hunk_counts",
                 return_value={},
             ):
                 with patch("git_stage_batch.commands.show.command_show"):
@@ -456,7 +456,7 @@ class TestHandleCurrentFileReview:
             return_value=_line_changes("test.txt"),
         ):
             with patch(
-                "git_stage_batch.tui.file_review.get_hunk_counts",
+                "git_stage_batch.tui.file_review.display.get_hunk_counts",
                 return_value={},
             ):
                 with patch(
@@ -485,7 +485,7 @@ class TestHandleCurrentFileReview:
             return_value=_line_changes("test.txt"),
         ):
             with patch(
-                "git_stage_batch.tui.file_review.get_hunk_counts",
+                "git_stage_batch.tui.file_review.display.get_hunk_counts",
                 return_value={},
             ):
                 with patch("git_stage_batch.commands.show_from.command_show_from_batch"):
@@ -507,7 +507,7 @@ class TestHandleCurrentFileReview:
             return_value=_line_changes("test.txt"),
         ):
             with patch(
-                "git_stage_batch.tui.file_review.get_hunk_counts",
+                "git_stage_batch.tui.file_review.display.get_hunk_counts",
                 return_value={},
             ):
                 with patch("git_stage_batch.commands.show_from.command_show_from_batch"):
@@ -533,7 +533,7 @@ class TestHandleCurrentFileReview:
             return_value=_line_changes("test.txt"),
         ):
             with patch(
-                "git_stage_batch.tui.file_review.get_hunk_counts",
+                "git_stage_batch.tui.file_review.display.get_hunk_counts",
                 return_value={},
             ):
                 with patch("git_stage_batch.commands.show_from.command_show_from_batch"):
@@ -566,7 +566,7 @@ class TestHandleCurrentFileReview:
             return_value=_line_changes("test.txt"),
         ):
             with patch(
-                "git_stage_batch.tui.file_review.get_hunk_counts",
+                "git_stage_batch.tui.file_review.display.get_hunk_counts",
                 return_value={},
             ):
                 with patch("git_stage_batch.commands.show_from.command_show_from_batch") as mock_show:
@@ -603,7 +603,7 @@ class TestHandleCurrentFileReview:
             return_value=_line_changes("test.txt"),
         ):
             with patch(
-                "git_stage_batch.tui.file_review.get_hunk_counts",
+                "git_stage_batch.tui.file_review.display.get_hunk_counts",
                 return_value={},
             ):
                 with patch("git_stage_batch.commands.show_from.command_show_from_batch") as mock_show:
@@ -637,7 +637,7 @@ class TestHandleCurrentFileReview:
             return_value=_line_changes("test.txt"),
         ):
             with patch(
-                "git_stage_batch.tui.file_review.get_hunk_counts",
+                "git_stage_batch.tui.file_review.display.get_hunk_counts",
                 return_value={},
             ):
                 with patch("git_stage_batch.commands.show_from.command_show_from_batch"):
@@ -666,7 +666,7 @@ class TestHandleCurrentFileReview:
             return_value=_line_changes("first.txt"),
         ):
             with patch(
-                "git_stage_batch.tui.file_review.get_hunk_counts",
+                "git_stage_batch.tui.file_review.display.get_hunk_counts",
                 return_value={},
             ):
                 with patch(
@@ -703,7 +703,7 @@ class TestHandleFileBrowser:
             ],
         ):
             with patch(
-                "git_stage_batch.tui.file_review.get_hunk_counts",
+                "git_stage_batch.tui.file_review.display.get_hunk_counts",
                 return_value={},
             ):
                 with patch("git_stage_batch.commands.show.command_show") as mock_show:
@@ -740,7 +740,7 @@ class TestHandleFileBrowser:
             side_effect=list_entries,
         ) as mock_list:
             with patch(
-                "git_stage_batch.tui.file_review.get_hunk_counts",
+                "git_stage_batch.tui.file_review.display.get_hunk_counts",
                 return_value={},
             ):
                 with patch("git_stage_batch.commands.show.command_show") as mock_show:

--- a/tests/tui/test_fixup_menu.py
+++ b/tests/tui/test_fixup_menu.py
@@ -1,0 +1,48 @@
+"""Tests for the TUI fixup submenu."""
+
+from unittest.mock import patch
+
+from git_stage_batch.core.models import HunkHeader, LineEntry, LineLevelChange
+from git_stage_batch.tui.fixup_menu import handle_fixup_menu
+
+
+def _line_changes() -> LineLevelChange:
+    header = HunkHeader(old_start=1, old_len=1, new_start=1, new_len=1)
+    return LineLevelChange(
+        path="test.txt",
+        header=header,
+        lines=[
+            LineEntry(
+                id=1,
+                kind="+",
+                old_line_number=None,
+                new_line_number=1,
+                text_bytes=b"test\n",
+                text="test\n",
+            ),
+        ],
+    )
+
+
+def test_handle_fixup_menu_cancel_clears_state(capsys):
+    """Test canceling the fixup menu clears persisted iteration state."""
+    with patch("git_stage_batch.tui.fixup_menu.Colors.enabled", return_value=False):
+        with patch(
+            "git_stage_batch.tui.fixup_menu.load_line_changes_from_state",
+            return_value=_line_changes(),
+        ):
+            with patch(
+                "git_stage_batch.tui.fixup_menu.command_suggest_fixup"
+            ) as mock_fixup:
+                with patch(
+                    "git_stage_batch.tui.fixup_menu.prompt_fixup_action",
+                    return_value="q",
+                ):
+                    with patch(
+                        "git_stage_batch.tui.fixup_menu.clear_suggest_fixup_state"
+                    ) as mock_clear:
+                        handle_fixup_menu()
+
+    mock_fixup.assert_called_once_with()
+    mock_clear.assert_called_once_with()
+    assert "Canceled." in capsys.readouterr().out

--- a/tests/tui/test_flow_actions.py
+++ b/tests/tui/test_flow_actions.py
@@ -1,0 +1,32 @@
+"""Tests for TUI flow shortcut actions."""
+
+from git_stage_batch.tui.flow import FlowLocation, FlowState
+from git_stage_batch.tui.flow_actions import handle_flow_action
+
+
+def test_handle_flow_action_selects_batch_source_and_resets_batch_target():
+    """Test source batch shortcuts prevent batch-to-batch flow."""
+    flow_state = FlowState(
+        source=FlowLocation.WORKING_TREE,
+        target=FlowLocation.for_batch("target"),
+    )
+
+    handled = handle_flow_action("<source", flow_state)
+
+    assert handled is True
+    assert flow_state.source == FlowLocation.for_batch("source")
+    assert flow_state.target == FlowLocation.STAGING_AREA
+
+
+def test_handle_flow_action_selects_batch_target_and_resets_batch_source():
+    """Test target batch shortcuts prevent batch-to-batch flow."""
+    flow_state = FlowState(
+        source=FlowLocation.for_batch("source"),
+        target=FlowLocation.STAGING_AREA,
+    )
+
+    handled = handle_flow_action(">target", flow_state)
+
+    assert handled is True
+    assert flow_state.source == FlowLocation.WORKING_TREE
+    assert flow_state.target == FlowLocation.for_batch("target")

--- a/tests/tui/test_interactive.py
+++ b/tests/tui/test_interactive.py
@@ -20,13 +20,13 @@ from git_stage_batch.tui.flow import FlowLocation, FlowState
 from git_stage_batch.tui.interactive import (
     ACTION_HANDLERS,
     _dispatch_action,
-    handle_quit,
     start_interactive_mode,
 )
 from git_stage_batch.tui.asset_menu import handle_asset_menu
 from git_stage_batch.tui.file_selection_menu import handle_file_selection_menu
 from git_stage_batch.tui.help_display import print_help
 from git_stage_batch.tui.line_selection_menu import handle_line_selection_menu
+from git_stage_batch.tui.session_quit import handle_quit
 
 
 @pytest.fixture
@@ -220,7 +220,7 @@ class TestHandleQuit:
 
     def test_handle_quit_no_start_state(self, temp_git_repo):
         """Test quit when no start state exists."""
-        with patch("git_stage_batch.commands.stop.command_stop") as mock_stop:
+        with patch("git_stage_batch.tui.session_quit.command_stop") as mock_stop:
             handle_quit()
             mock_stop.assert_called_once()
 
@@ -238,8 +238,8 @@ class TestHandleQuit:
         write_text_file_contents(get_start_index_tree_file_path(), index_tree)
 
         # Quit should call stop without prompting
-        with patch("git_stage_batch.commands.stop.command_stop") as mock_stop:
-            with patch("git_stage_batch.tui.interactive.prompt_quit_session") as mock_prompt:
+        with patch("git_stage_batch.tui.session_quit.command_stop") as mock_stop:
+            with patch("git_stage_batch.tui.session_quit.prompt_quit_session") as mock_prompt:
                 handle_quit()
                 mock_stop.assert_called_once()
                 mock_prompt.assert_not_called()
@@ -254,8 +254,8 @@ class TestHandleQuit:
         write_text_file_contents(get_start_head_file_path(), head)
         write_text_file_contents(get_start_index_tree_file_path(), index_tree)
 
-        with patch("git_stage_batch.commands.stop.command_stop") as mock_stop:
-            with patch("git_stage_batch.tui.interactive.prompt_quit_session") as mock_prompt:
+        with patch("git_stage_batch.tui.session_quit.command_stop") as mock_stop:
+            with patch("git_stage_batch.tui.session_quit.prompt_quit_session") as mock_prompt:
                 handle_quit(stop_session=False)
                 mock_stop.assert_not_called()
                 mock_prompt.assert_not_called()
@@ -277,9 +277,9 @@ class TestHandleQuit:
         subprocess.run(["git", "add", "test.txt"], check=True, cwd=temp_git_repo, capture_output=True)
 
         # Quit with "keep" choice
-        with patch("git_stage_batch.tui.interactive.prompt_quit_session", return_value="keep"):
-            with patch("git_stage_batch.commands.stop.command_stop") as mock_stop:
-                with patch("git_stage_batch.commands.abort.command_abort") as mock_abort:
+        with patch("git_stage_batch.tui.session_quit.prompt_quit_session", return_value="keep"):
+            with patch("git_stage_batch.tui.session_quit.command_stop") as mock_stop:
+                with patch("git_stage_batch.tui.session_quit.command_abort") as mock_abort:
                     handle_quit()
                     mock_stop.assert_called_once()
                     mock_abort.assert_not_called()
@@ -297,9 +297,9 @@ class TestHandleQuit:
         (temp_git_repo / "test.txt").write_text("new file\n")
         subprocess.run(["git", "add", "test.txt"], check=True, cwd=temp_git_repo, capture_output=True)
 
-        with patch("git_stage_batch.tui.interactive.prompt_quit_session", return_value="keep"):
-            with patch("git_stage_batch.commands.stop.command_stop") as mock_stop:
-                with patch("git_stage_batch.commands.abort.command_abort") as mock_abort:
+        with patch("git_stage_batch.tui.session_quit.prompt_quit_session", return_value="keep"):
+            with patch("git_stage_batch.tui.session_quit.command_stop") as mock_stop:
+                with patch("git_stage_batch.tui.session_quit.command_abort") as mock_abort:
                     handle_quit(stop_session=False)
                     mock_stop.assert_not_called()
                     mock_abort.assert_not_called()
@@ -321,9 +321,9 @@ class TestHandleQuit:
         subprocess.run(["git", "add", "test.txt"], check=True, cwd=temp_git_repo, capture_output=True)
 
         # Quit with "undo" choice
-        with patch("git_stage_batch.tui.interactive.prompt_quit_session", return_value="undo"):
-            with patch("git_stage_batch.commands.stop.command_stop") as mock_stop:
-                with patch("git_stage_batch.commands.abort.command_abort") as mock_abort:
+        with patch("git_stage_batch.tui.session_quit.prompt_quit_session", return_value="undo"):
+            with patch("git_stage_batch.tui.session_quit.command_stop") as mock_stop:
+                with patch("git_stage_batch.tui.session_quit.command_abort") as mock_abort:
                     handle_quit()
                     mock_stop.assert_not_called()
                     mock_abort.assert_called_once()
@@ -345,9 +345,9 @@ class TestHandleQuit:
         subprocess.run(["git", "add", "test.txt"], check=True, cwd=temp_git_repo, capture_output=True)
 
         # Quit with "cancel" choice
-        with patch("git_stage_batch.tui.interactive.prompt_quit_session", return_value="cancel"):
-            with patch("git_stage_batch.commands.stop.command_stop") as mock_stop:
-                with patch("git_stage_batch.commands.abort.command_abort") as mock_abort:
+        with patch("git_stage_batch.tui.session_quit.prompt_quit_session", return_value="cancel"):
+            with patch("git_stage_batch.tui.session_quit.command_stop") as mock_stop:
+                with patch("git_stage_batch.tui.session_quit.command_abort") as mock_abort:
                     handle_quit()
                     # Neither should be called on cancel
                     mock_stop.assert_not_called()
@@ -531,7 +531,7 @@ class TestDegradedMode:
         """Test that interactive mode starts when no changes exist."""
         # Repo has no changes - should start without error
         with patch("git_stage_batch.tui.interactive.prompt_action", return_value="q"):
-            with patch("git_stage_batch.tui.interactive.handle_quit"):
+            with patch("git_stage_batch.tui.action_dispatch.handle_quit"):
                 start_interactive_mode()
 
         captured = capsys.readouterr()
@@ -553,7 +553,7 @@ class TestDegradedMode:
         """Test that help action works in degraded mode."""
         # No changes, try help action
         with patch("git_stage_batch.tui.interactive.prompt_action", side_effect=["?", "q"]):
-            with patch("git_stage_batch.tui.interactive.handle_quit"):
+            with patch("git_stage_batch.tui.action_dispatch.handle_quit"):
                 start_interactive_mode()
 
         captured = capsys.readouterr()
@@ -563,7 +563,7 @@ class TestDegradedMode:
         """Test that hunk-based actions show error in degraded mode."""
         # No changes, try include action
         with patch("git_stage_batch.tui.interactive.prompt_action", side_effect=["i", "q"]):
-            with patch("git_stage_batch.tui.interactive.handle_quit"):
+            with patch("git_stage_batch.tui.action_dispatch.handle_quit"):
                 start_interactive_mode()
 
         captured = capsys.readouterr()
@@ -573,7 +573,7 @@ class TestDegradedMode:
         """Test that shell commands work in degraded mode."""
         # No changes, run shell command
         with patch("git_stage_batch.tui.interactive.prompt_action", side_effect=["!echo test", "q"]):
-            with patch("git_stage_batch.tui.interactive.handle_quit"):
+            with patch("git_stage_batch.tui.action_dispatch.handle_quit"):
                 with patch("builtins.input"):  # Mock the "Press Enter" prompt
                     start_interactive_mode()
 
@@ -584,7 +584,7 @@ class TestDegradedMode:
         """Test that quit works in degraded mode."""
         # No changes, quit immediately
         with patch("git_stage_batch.tui.interactive.prompt_action", return_value="q"):
-            with patch("git_stage_batch.tui.interactive.handle_quit") as mock_quit:
+            with patch("git_stage_batch.tui.action_dispatch.handle_quit") as mock_quit:
                 start_interactive_mode()
                 mock_quit.assert_called_once()
 
@@ -599,7 +599,7 @@ class TestBatchSubmenu:
                 with patch("git_stage_batch.tui.batch_menu.read_batch_metadata", return_value={"note": "", "created_at": ""}):
                     with patch("builtins.input", side_effect=["c", "my-batch", "my note", KeyboardInterrupt]):
                         with patch("git_stage_batch.tui.batch_menu.command_new_batch") as mock_new:
-                            with patch("git_stage_batch.tui.interactive.handle_quit"):
+                            with patch("git_stage_batch.tui.action_dispatch.handle_quit"):
                                 start_interactive_mode()
                                 mock_new.assert_called_once_with(batch_name="my-batch", note="my note")
 
@@ -610,7 +610,7 @@ class TestBatchSubmenu:
                 with patch("git_stage_batch.tui.batch_menu.read_batch_metadata", return_value={"note": "", "created_at": ""}):
                     with patch("builtins.input", side_effect=["c", "my-batch", "", KeyboardInterrupt]):
                         with patch("git_stage_batch.tui.batch_menu.command_new_batch") as mock_new:
-                            with patch("git_stage_batch.tui.interactive.handle_quit"):
+                            with patch("git_stage_batch.tui.action_dispatch.handle_quit"):
                                 start_interactive_mode()
                                 mock_new.assert_called_once_with(batch_name="my-batch", note=None)
 
@@ -621,7 +621,7 @@ class TestBatchSubmenu:
                 with patch("git_stage_batch.tui.batch_menu.read_batch_metadata", return_value={"note": "", "created_at": ""}):
                     with patch("builtins.input", side_effect=["c", "", KeyboardInterrupt]):
                         with patch("git_stage_batch.tui.batch_menu.command_new_batch") as mock_new:
-                            with patch("git_stage_batch.tui.interactive.handle_quit"):
+                            with patch("git_stage_batch.tui.action_dispatch.handle_quit"):
                                 start_interactive_mode()
                                 mock_new.assert_not_called()
 
@@ -632,7 +632,7 @@ class TestBatchSubmenu:
                 with patch("git_stage_batch.tui.batch_menu.read_batch_metadata", return_value={"note": "old note", "created_at": ""}):
                     with patch("builtins.input", side_effect=["e", "1", "new note", KeyboardInterrupt]):
                         with patch("git_stage_batch.tui.batch_menu.command_annotate_batch") as mock_annotate:
-                            with patch("git_stage_batch.tui.interactive.handle_quit"):
+                            with patch("git_stage_batch.tui.action_dispatch.handle_quit"):
                                 start_interactive_mode()
                                 mock_annotate.assert_called_once_with("test-batch", "new note")
 
@@ -643,7 +643,7 @@ class TestBatchSubmenu:
                 with patch("git_stage_batch.tui.batch_menu.read_batch_metadata", return_value={"note": "some note", "created_at": ""}):
                     with patch("builtins.input", side_effect=["d", "1", KeyboardInterrupt]):
                         with patch("git_stage_batch.tui.batch_menu.command_drop_batch") as mock_drop:
-                            with patch("git_stage_batch.tui.interactive.handle_quit"):
+                            with patch("git_stage_batch.tui.action_dispatch.handle_quit"):
                                 start_interactive_mode()
                                 mock_drop.assert_called_once_with("test-batch")
 
@@ -654,7 +654,7 @@ class TestBatchSubmenu:
                 with patch("git_stage_batch.tui.batch_menu.read_batch_metadata", return_value={"note": "some note", "created_at": ""}):
                     with patch("builtins.input", side_effect=["a", "1", KeyboardInterrupt]):
                         with patch("git_stage_batch.tui.batch_menu.command_apply_from_batch") as mock_apply:
-                            with patch("git_stage_batch.tui.interactive.handle_quit"):
+                            with patch("git_stage_batch.tui.action_dispatch.handle_quit"):
                                 start_interactive_mode()
                                 mock_apply.assert_called_once_with("test-batch")
 
@@ -665,7 +665,7 @@ class TestBatchSubmenu:
                 with patch("git_stage_batch.tui.batch_menu.read_batch_metadata", return_value={"note": "some note", "created_at": ""}):
                     with patch("builtins.input", side_effect=["s", "", KeyboardInterrupt]):
                         with patch("git_stage_batch.tui.batch_menu.command_sift_batch") as mock_sift:
-                            with patch("git_stage_batch.tui.interactive.handle_quit"):
+                            with patch("git_stage_batch.tui.action_dispatch.handle_quit"):
                                 start_interactive_mode()
                                 mock_sift.assert_called_once_with("test-batch", "test-batch")
 
@@ -676,7 +676,7 @@ class TestBatchSubmenu:
                 with patch("git_stage_batch.tui.batch_menu.read_batch_metadata", return_value={"note": "", "created_at": ""}):
                     with patch("builtins.input", side_effect=["s", "2", "filtered", KeyboardInterrupt]):
                         with patch("git_stage_batch.tui.batch_menu.command_sift_batch") as mock_sift:
-                            with patch("git_stage_batch.tui.interactive.handle_quit"):
+                            with patch("git_stage_batch.tui.action_dispatch.handle_quit"):
                                 start_interactive_mode()
                                 mock_sift.assert_called_once_with("second", "filtered")
 
@@ -691,7 +691,7 @@ class TestBatchSubmenu:
                 with patch("git_stage_batch.tui.batch_menu.read_batch_metadata", return_value={"note": "my note", "created_at": ""}):
                     with patch("builtins.input", side_effect=["my-batch", "my note", KeyboardInterrupt]):
                         with patch("git_stage_batch.tui.batch_menu.command_new_batch") as mock_new:
-                            with patch("git_stage_batch.tui.interactive.handle_quit"):
+                            with patch("git_stage_batch.tui.action_dispatch.handle_quit"):
                                 start_interactive_mode()
                                 captured = capsys.readouterr()
                                 assert "No batches found. Create one now." in captured.out
@@ -704,7 +704,7 @@ class TestBatchSubmenu:
                 with patch("git_stage_batch.tui.batch_menu.read_batch_metadata", return_value={"note": "note", "created_at": ""}):
                     with patch("builtins.input", side_effect=["e", "999", KeyboardInterrupt]):
                         with patch("git_stage_batch.tui.batch_menu.command_annotate_batch") as mock_annotate:
-                            with patch("git_stage_batch.tui.interactive.handle_quit"):
+                            with patch("git_stage_batch.tui.action_dispatch.handle_quit"):
                                 start_interactive_mode()
                                 mock_annotate.assert_not_called()
                                 captured = capsys.readouterr()
@@ -714,7 +714,7 @@ class TestBatchSubmenu:
         """Test cancelling batch submenu."""
         with patch("git_stage_batch.tui.interactive.prompt_action", side_effect=["b", "q"]):
             with patch("builtins.input", side_effect=KeyboardInterrupt):
-                with patch("git_stage_batch.tui.interactive.handle_quit"):
+                with patch("git_stage_batch.tui.action_dispatch.handle_quit"):
                     start_interactive_mode()
                     # Should not raise, just return to main menu
 
@@ -724,7 +724,7 @@ class TestBatchSubmenu:
             with patch("git_stage_batch.tui.batch_menu.list_batch_names", return_value=["existing-batch"]):
                 with patch("git_stage_batch.tui.batch_menu.read_batch_metadata", return_value={"note": "", "created_at": ""}):
                     with patch("builtins.input", side_effect=["x", KeyboardInterrupt]):
-                        with patch("git_stage_batch.tui.interactive.handle_quit"):
+                        with patch("git_stage_batch.tui.action_dispatch.handle_quit"):
                             start_interactive_mode()
                             captured = capsys.readouterr()
                             assert "Unknown action" in captured.out
@@ -736,7 +736,7 @@ class TestBatchSubmenu:
                 with patch("git_stage_batch.tui.batch_menu.read_batch_metadata", return_value={"note": "note", "created_at": ""}):
                     with patch("builtins.input", side_effect=["d", "second-batch", KeyboardInterrupt]):
                         with patch("git_stage_batch.tui.batch_menu.command_drop_batch") as mock_drop:
-                            with patch("git_stage_batch.tui.interactive.handle_quit"):
+                            with patch("git_stage_batch.tui.action_dispatch.handle_quit"):
                                 start_interactive_mode()
                                 mock_drop.assert_called_once_with("second-batch")
 
@@ -748,7 +748,7 @@ class TestBatchSubmenu:
                     # Only "e" and "new note" in input - no batch selection prompt
                     with patch("builtins.input", side_effect=["e", "new note", KeyboardInterrupt]):
                         with patch("git_stage_batch.tui.batch_menu.command_annotate_batch") as mock_annotate:
-                            with patch("git_stage_batch.tui.interactive.handle_quit"):
+                            with patch("git_stage_batch.tui.action_dispatch.handle_quit"):
                                 start_interactive_mode()
                                 mock_annotate.assert_called_once_with("only-batch", "new note")
 
@@ -760,7 +760,7 @@ class TestBatchSubmenu:
                     # Only "d" in input - no batch selection prompt
                     with patch("builtins.input", side_effect=["d", KeyboardInterrupt]):
                         with patch("git_stage_batch.tui.batch_menu.command_drop_batch") as mock_drop:
-                            with patch("git_stage_batch.tui.interactive.handle_quit"):
+                            with patch("git_stage_batch.tui.action_dispatch.handle_quit"):
                                 start_interactive_mode()
                                 mock_drop.assert_called_once_with("only-batch")
 
@@ -772,7 +772,7 @@ class TestBatchSubmenu:
                     # Apply always prompts, even with one batch
                     with patch("builtins.input", side_effect=["a", "1", KeyboardInterrupt]):
                         with patch("git_stage_batch.tui.batch_menu.command_apply_from_batch") as mock_apply:
-                            with patch("git_stage_batch.tui.interactive.handle_quit"):
+                            with patch("git_stage_batch.tui.action_dispatch.handle_quit"):
                                 start_interactive_mode()
                                 mock_apply.assert_called_once_with("first")
 
@@ -785,7 +785,7 @@ class TestFlowMenus:
             with patch("git_stage_batch.tui.flow_menu.list_batch_names", return_value=["test-batch"]):
                 with patch("git_stage_batch.tui.flow_menu.read_batch_metadata", return_value={"note": "note", "created_at": ""}):
                     with patch("builtins.input", side_effect=["1", KeyboardInterrupt]):
-                        with patch("git_stage_batch.tui.interactive.handle_quit"):
+                        with patch("git_stage_batch.tui.action_dispatch.handle_quit"):
                             start_interactive_mode()
                             # Should not raise, flow changed to working tree
 
@@ -795,7 +795,7 @@ class TestFlowMenus:
             with patch("git_stage_batch.tui.flow_menu.list_batch_names", return_value=["my-batch", "other-batch"]):
                 with patch("git_stage_batch.tui.flow_menu.read_batch_metadata", return_value={"note": "note", "created_at": ""}):
                     with patch("builtins.input", side_effect=["2", KeyboardInterrupt]):
-                        with patch("git_stage_batch.tui.interactive.handle_quit"):
+                        with patch("git_stage_batch.tui.action_dispatch.handle_quit"):
                             start_interactive_mode()
                             # Should not raise, flow changed to batch
 
@@ -805,7 +805,7 @@ class TestFlowMenus:
             with patch("git_stage_batch.tui.flow_menu.list_batch_names", return_value=["test-batch"]):
                 with patch("git_stage_batch.tui.flow_menu.read_batch_metadata", return_value={"note": "", "created_at": ""}):
                     with patch("builtins.input", side_effect=[KeyboardInterrupt, KeyboardInterrupt]):
-                        with patch("git_stage_batch.tui.interactive.handle_quit"):
+                        with patch("git_stage_batch.tui.action_dispatch.handle_quit"):
                             start_interactive_mode()
                             # Should not raise, source unchanged
 
@@ -815,7 +815,7 @@ class TestFlowMenus:
             with patch("git_stage_batch.tui.flow_menu.list_batch_names", return_value=["test-batch"]):
                 with patch("git_stage_batch.tui.flow_menu.read_batch_metadata", return_value={"note": "", "created_at": ""}):
                     with patch("builtins.input", side_effect=["1", KeyboardInterrupt]):
-                        with patch("git_stage_batch.tui.interactive.handle_quit"):
+                        with patch("git_stage_batch.tui.action_dispatch.handle_quit"):
                             start_interactive_mode()
                             # Should not raise, target changed to staging
 
@@ -825,7 +825,7 @@ class TestFlowMenus:
             with patch("git_stage_batch.tui.flow_menu.list_batch_names", return_value=["batch1", "batch2"]):
                 with patch("git_stage_batch.tui.flow_menu.read_batch_metadata", return_value={"note": "test note", "created_at": ""}):
                     with patch("builtins.input", side_effect=["2", KeyboardInterrupt]):
-                        with patch("git_stage_batch.tui.interactive.handle_quit"):
+                        with patch("git_stage_batch.tui.action_dispatch.handle_quit"):
                             start_interactive_mode()
                             # Should not raise, target changed to batch1
 
@@ -837,7 +837,7 @@ class TestFlowMenus:
                     # Select "New Batch..." option (3), then provide batch ID and note
                     with patch("builtins.input", side_effect=["3", "new-batch", "my note", KeyboardInterrupt]):
                         with patch("git_stage_batch.tui.flow_menu.command_new_batch") as mock_new:
-                            with patch("git_stage_batch.tui.interactive.handle_quit"):
+                            with patch("git_stage_batch.tui.action_dispatch.handle_quit"):
                                 start_interactive_mode()
                                 mock_new.assert_called_once_with(batch_name="new-batch", note="my note")
 
@@ -849,7 +849,7 @@ class TestFlowMenus:
                     # Select "New Batch..." option (2 when no batches), then provide batch ID with no note
                     with patch("builtins.input", side_effect=["2", "new-batch", "", KeyboardInterrupt]):
                         with patch("git_stage_batch.tui.flow_menu.command_new_batch") as mock_new:
-                            with patch("git_stage_batch.tui.interactive.handle_quit"):
+                            with patch("git_stage_batch.tui.action_dispatch.handle_quit"):
                                 start_interactive_mode()
                                 mock_new.assert_called_once_with(batch_name="new-batch", note=None)
 
@@ -861,20 +861,20 @@ class TestFlowMenus:
                     # Select "New Batch...", then cancel with empty batch ID
                     with patch("builtins.input", side_effect=["2", "", KeyboardInterrupt]):
                         with patch("git_stage_batch.tui.flow_menu.command_new_batch") as mock_new:
-                            with patch("git_stage_batch.tui.interactive.handle_quit"):
+                            with patch("git_stage_batch.tui.action_dispatch.handle_quit"):
                                 start_interactive_mode()
                                 mock_new.assert_not_called()
 
     def test_direct_source_batch_shortcut(self, temp_git_repo):
         """Test direct source selection with <batch-name shortcut."""
         with patch("git_stage_batch.tui.interactive.prompt_action", side_effect=["<my-batch", "q"]):
-            with patch("git_stage_batch.tui.interactive.handle_quit"):
+            with patch("git_stage_batch.tui.action_dispatch.handle_quit"):
                 start_interactive_mode()
                 # Should set source to my-batch without showing menu
 
     def test_direct_target_batch_shortcut(self, temp_git_repo):
         """Test direct target selection with >batch-name shortcut."""
         with patch("git_stage_batch.tui.interactive.prompt_action", side_effect=[">ci", "q"]):
-            with patch("git_stage_batch.tui.interactive.handle_quit"):
+            with patch("git_stage_batch.tui.action_dispatch.handle_quit"):
                 start_interactive_mode()
                 # Should set target to ci batch without showing menu

--- a/tests/tui/test_interactive.py
+++ b/tests/tui/test_interactive.py
@@ -21,11 +21,11 @@ from git_stage_batch.tui.interactive import (
     ACTION_HANDLERS,
     _dispatch_action,
     handle_quit,
-    print_help,
     start_interactive_mode,
 )
 from git_stage_batch.tui.asset_menu import handle_asset_menu
 from git_stage_batch.tui.file_selection_menu import handle_file_selection_menu
+from git_stage_batch.tui.help_display import print_help
 from git_stage_batch.tui.line_selection_menu import handle_line_selection_menu
 
 

--- a/tests/tui/test_interactive.py
+++ b/tests/tui/test_interactive.py
@@ -95,6 +95,40 @@ class TestActionHandlers:
 
         assert handler.needs_hunk is False
 
+    def test_undo_action_dispatches_history_action(self):
+        """Test undo action routes through the history action adapter."""
+        flow_state = FlowState(
+            source=FlowLocation.WORKING_TREE,
+            target=FlowLocation.STAGING_AREA,
+        )
+
+        with patch("git_stage_batch.tui.history_actions.command_undo") as mock_undo:
+            dispatch_action(
+                "u",
+                has_hunk=False,
+                use_color=False,
+                flow_state=flow_state,
+            )
+
+        mock_undo.assert_called_once_with()
+
+    def test_redo_action_dispatches_history_action(self):
+        """Test redo action routes through the history action adapter."""
+        flow_state = FlowState(
+            source=FlowLocation.WORKING_TREE,
+            target=FlowLocation.STAGING_AREA,
+        )
+
+        with patch("git_stage_batch.tui.history_actions.command_redo") as mock_redo:
+            dispatch_action(
+                "U",
+                has_hunk=False,
+                use_color=False,
+                flow_state=flow_state,
+            )
+
+        mock_redo.assert_called_once_with()
+
     def test_assets_action_registered(self):
         """Test asset installation is available without a selected hunk."""
         handler = ACTION_HANDLERS["A"]

--- a/tests/tui/test_interactive.py
+++ b/tests/tui/test_interactive.py
@@ -16,10 +16,9 @@ from unittest.mock import patch
 import pytest
 
 from git_stage_batch.exceptions import BypassRefresh
+from git_stage_batch.tui.action_dispatch import ACTION_HANDLERS, dispatch_action
 from git_stage_batch.tui.flow import FlowLocation, FlowState
 from git_stage_batch.tui.interactive import (
-    ACTION_HANDLERS,
-    _dispatch_action,
     start_interactive_mode,
 )
 from git_stage_batch.tui.asset_menu import handle_asset_menu
@@ -110,7 +109,7 @@ class TestActionHandlers:
         )
 
         with patch("git_stage_batch.tui.hunk_actions.command_include") as mock_include:
-            _dispatch_action(
+            dispatch_action(
                 "i",
                 has_hunk=True,
                 use_color=False,
@@ -127,7 +126,7 @@ class TestActionHandlers:
         )
 
         with patch("git_stage_batch.tui.hunk_actions.command_skip") as mock_skip:
-            _dispatch_action(
+            dispatch_action(
                 "s",
                 has_hunk=True,
                 use_color=False,
@@ -150,7 +149,7 @@ class TestActionHandlers:
             with patch(
                 "git_stage_batch.tui.hunk_actions.command_discard"
             ) as mock_discard:
-                _dispatch_action(
+                dispatch_action(
                     "d",
                     has_hunk=True,
                     use_color=False,
@@ -172,7 +171,7 @@ class TestActionHandlers:
 
         with patch("git_stage_batch.commands.status.command_status") as mock_status:
             with pytest.raises(BypassRefresh):
-                _dispatch_action(
+                dispatch_action(
                     "S",
                     has_hunk=False,
                     use_color=False,
@@ -191,7 +190,7 @@ class TestActionHandlers:
         with patch("builtins.input", side_effect=["codex-skills", "commit-*", "yes"]):
             with patch("git_stage_batch.tui.asset_menu.command_install_assets") as mock_install:
                 with pytest.raises(BypassRefresh):
-                    _dispatch_action(
+                    dispatch_action(
                         "A",
                         has_hunk=False,
                         use_color=False,

--- a/tests/tui/test_interactive.py
+++ b/tests/tui/test_interactive.py
@@ -95,6 +95,23 @@ class TestActionHandlers:
 
         assert handler.needs_hunk is False
 
+    def test_again_action_dispatches_again_action(self):
+        """Test again action routes through the again action adapter."""
+        flow_state = FlowState(
+            source=FlowLocation.WORKING_TREE,
+            target=FlowLocation.STAGING_AREA,
+        )
+
+        with patch("git_stage_batch.tui.again_action.command_again") as mock_again:
+            dispatch_action(
+                "a",
+                has_hunk=False,
+                use_color=False,
+                flow_state=flow_state,
+            )
+
+        mock_again.assert_called_once_with(quiet=True)
+
     def test_undo_action_dispatches_history_action(self):
         """Test undo action routes through the history action adapter."""
         flow_state = FlowState(

--- a/tests/tui/test_shell_command.py
+++ b/tests/tui/test_shell_command.py
@@ -1,0 +1,29 @@
+"""Tests for the TUI shell command escape."""
+
+from pathlib import Path
+from subprocess import CompletedProcess
+from unittest.mock import patch
+
+from git_stage_batch.tui.shell_command import handle_shell_command
+
+
+def test_handle_shell_command_runs_in_repository_root():
+    """Test shell commands execute from the repository root."""
+    repo_root = Path("/tmp/repo")
+
+    with patch(
+        "git_stage_batch.tui.shell_command.get_git_repository_root_path",
+        return_value=repo_root,
+    ):
+        with patch(
+            "git_stage_batch.tui.shell_command.subprocess.run",
+            return_value=CompletedProcess(args="echo test", returncode=0),
+        ) as mock_run:
+            with patch("builtins.input", return_value=""):
+                handle_shell_command("!echo test")
+
+    mock_run.assert_called_once_with(
+        "echo test",
+        shell=True,
+        cwd=repo_root,
+    )


### PR DESCRIPTION
TUI hunk dispatch now has a dedicated owner, while the file-review browser
still coordinates fixup, block, line, page, and command-escape behavior
directly.

The interactive browser has too many command responsibilities, making it
hard to tell which code owns review navigation and which code owns user
actions.

This PR moves TUI review actions, fixup helpers, block actions, command
escapes, and file-scope fallbacks into focused action modules.

The next PR will apply the same ownership pressure to selection and file-
scope batching paths.

Test plan: .venv/bin/python -m pytest -n auto passed on the final stack tip
  before landing; each PR branch is rebased without code changes before
  merge.
