### PR TITLE
architecture: Plan batch-source preview actions

### DIFF
--- a/src/git_stage_batch/batch/operation_candidates.py
+++ b/src/git_stage_batch/batch/operation_candidates.py
@@ -86,6 +86,13 @@ class OperationCandidatePreview:
     target_result_fingerprints: dict[str, str]
     scope_fingerprint: str
 
+    def require_target(self, target: CandidateTarget) -> TargetCandidatePreview:
+        """Return a target preview or raise when the candidate shape is invalid."""
+        for candidate_target in self.targets:
+            if candidate_target.target == target:
+                return candidate_target
+        raise KeyError(target)
+
     def close(self) -> None:
         for target in self.targets:
             target.close()

--- a/src/git_stage_batch/commands/apply_from.py
+++ b/src/git_stage_batch/commands/apply_from.py
@@ -8,8 +8,8 @@ from typing import Optional
 
 from .batch_source import action_plans as _action_plans
 from .batch_source import binary_file_actions as _binary_file_actions
+from .batch_source import candidate_materialization as _candidate_materialization
 from .batch_source import candidate_preview_counts as _candidate_preview_counts
-from .batch_source import candidate_previews as _candidate_previews
 from .batch_source import candidate_refusals as _candidate_refusals
 from .batch_source import candidate_selectors as _candidate_selectors
 from .batch_source import merge_refusals as _merge_refusals
@@ -18,7 +18,6 @@ from ..batch.binary_file_content import read_binary_file_from_batch
 from ..batch.merge import merge_batch_from_line_sequences_as_buffer
 from ..batch.metadata_validation import read_validated_batch_metadata
 from ..batch.operation_candidates import (
-    build_apply_candidate_previews,
     clear_candidate_preview_state_for_file,
 )
 from ..batch.selection import (
@@ -87,107 +86,50 @@ def _execute_apply_candidate(
     selection_ids_to_apply: set[int] | None,
 ) -> None:
     """Recompute and apply one previewed apply candidate."""
-    if len(files) != 1:
-        exit_with_error(_("Candidate execution requires exactly one file."))
-    file_path, file_meta = next(iter(files.items()))
-    if file_meta.get("file_type") == "binary" or is_batch_submodule_pointer(file_meta):
-        exit_with_error(_("Candidate execution is only available for text batch entries."))
-
-    batch_source_commit = file_meta["batch_source_commit"]
-    batch_source_buffer = load_git_object_as_buffer(f"{batch_source_commit}:{file_path}")
-    if batch_source_buffer is None:
-        exit_with_error(_("Batch source content is missing for {file}.").format(file=file_path))
-
-    repo_root = get_git_repository_root_path()
-    full_path = repo_root / file_path
-    working_exists = os.path.lexists(full_path)
-    file_mode = mode_for_text_materialization(
-        str(file_meta.get("mode", "100644")),
-        selected_ids,
-        destination_exists=working_exists,
+    materialized = _candidate_materialization.materialize_apply_candidate(
+        batch_name=batch_name,
+        raw_selector=raw_selector,
+        ordinal=ordinal,
+        files=files,
+        selected_ids=selected_ids,
+        selection_ids_to_apply=selection_ids_to_apply,
     )
-    text_change_type = normalized_text_change_type(file_meta.get("change_type"))
-
-    with (
-        batch_source_buffer as batch_source_lines,
-        load_working_tree_file_as_buffer(file_path) as working_lines,
-    ):
-        with acquire_batch_ownership_for_display_ids_from_lines(
-            file_meta,
-            batch_source_lines,
-            selection_ids_to_apply,
-        ) as ownership:
-            try:
-                previews = build_apply_candidate_previews(
-                    batch_name=batch_name,
-                    file_path=file_path,
-                    source_lines=batch_source_lines,
-                    ownership=ownership,
-                    worktree_lines=working_lines,
-                    batch_source_commit=batch_source_commit,
-                    file_meta=file_meta,
-                    text_change_type=text_change_type,
-                    worktree_file_mode=file_mode,
-                    worktree_exists=working_exists,
-                    selected_ids=selected_ids,
-                    selection_ids=selection_ids_to_apply,
-                )
-            except MergeError as e:
-                exit_with_error(str(e))
-
-            try:
-                preview = _candidate_previews.require_candidate_preview_for_ordinal(
-                    previews,
-                    ordinal,
-                    batch_name=batch_name,
-                    operation="apply",
-                    file_path=file_path,
-                )
-                _candidate_previews.require_candidate_preview_state(
-                    preview,
-                    ordinal,
-                    selector=raw_selector,
-                    file_path=file_path,
-                )
-
-                target = preview.targets[0]
-                effective_change_type = selected_text_target_change_type(
-                    text_change_type,
-                    selected_ids,
-                    target.after_buffer,
-                )
-                print(
-                    _("Applying candidate {ordinal} of {count} from batch '{batch}':").format(
-                        ordinal=preview.ordinal,
-                        count=preview.count,
-                        batch=batch_name,
-                    ),
-                    file=sys.stderr,
-                )
-                print(f"  {file_path}: {_('Working tree')}", file=sys.stderr)
-                operation_parts = ["apply", "--from", raw_selector, "--file", file_path]
-                with undo_checkpoint(" ".join(operation_parts), worktree_paths=[file_path]):
-                    snapshot_file_if_untracked(file_path)
-                    _text_file_actions.write_text_file_to_worktree(
-                        file_path,
-                        target.after_buffer,
-                        file_mode,
-                        effective_change_type,
-                    )
-                clear_candidate_preview_state_for_file(
-                    batch_name=batch_name,
-                    file_path=file_path,
-                )
-                print(
-                    _("✓ Applied candidate {ordinal} of {count} from batch '{batch}' to working tree").format(
-                        ordinal=preview.ordinal,
-                        count=preview.count,
-                        batch=batch_name,
-                    ),
-                    file=sys.stderr,
-                )
-            finally:
-                _candidate_previews.close_candidate_previews(previews)
+    try:
+        target = materialized.target
+        preview = materialized.preview
+        file_path = materialized.file_path
+        print(
+            _("Applying candidate {ordinal} of {count} from batch '{batch}':").format(
+                ordinal=preview.ordinal,
+                count=preview.count,
+                batch=batch_name,
+            ),
+            file=sys.stderr,
+        )
+        print(f"  {file_path}: {_('Working tree')}", file=sys.stderr)
+        operation_parts = ["apply", "--from", raw_selector, "--file", file_path]
+        with undo_checkpoint(" ".join(operation_parts), worktree_paths=[file_path]):
+            snapshot_file_if_untracked(file_path)
+            _text_file_actions.write_text_file_to_worktree(
+                file_path,
+                target.after_buffer,
+                materialized.file_mode,
+                target.change_type,
+            )
+        clear_candidate_preview_state_for_file(
+            batch_name=batch_name,
+            file_path=file_path,
+        )
+        print(
+            _("✓ Applied candidate {ordinal} of {count} from batch '{batch}' to working tree").format(
+                ordinal=preview.ordinal,
+                count=preview.count,
+                batch=batch_name,
+            ),
+            file=sys.stderr,
+        )
+    finally:
+        materialized.close()
 
 
 def command_apply_from_batch(

--- a/src/git_stage_batch/commands/apply_from.py
+++ b/src/git_stage_batch/commands/apply_from.py
@@ -10,6 +10,7 @@ from .batch_source import action_plans as _action_plans
 from .batch_source import binary_file_actions as _binary_file_actions
 from .batch_source import candidate_previews as _candidate_previews
 from .batch_source import candidate_refusals as _candidate_refusals
+from .batch_source import candidate_selectors as _candidate_selectors
 from .batch_source import text_file_actions as _text_file_actions
 from ..batch.binary_file_content import read_binary_file_from_batch
 from ..batch.merge import merge_batch_from_line_sequences_as_buffer
@@ -31,10 +32,6 @@ from ..batch.submodule_pointer import (
     apply_submodule_pointer_from_batch,
     is_batch_submodule_pointer,
     refuse_batch_submodule_pointer_lines,
-)
-from ..batch.source_selector import (
-    parse_batch_source_selector,
-    require_candidate_operation,
 )
 from ..batch.validation import batch_exists
 from ..core.text_lifecycle import (
@@ -284,23 +281,11 @@ def command_apply_from_batch(
     """
     require_git_repository()
     raw_selector = batch_name
-    selector = parse_batch_source_selector(batch_name)
-    require_candidate_operation(selector, "apply", raw_value=raw_selector, file=file)
-    if selector.candidate_operation == "apply" and selector.candidate_ordinal is None:
-        exit_with_error(
-            _(
-                "'{selector}' names the apply candidate preview set.\n"
-                "Use 'git-stage-batch show --from {selector}' to preview candidates, "
-                "or use '{batch}:apply:N' to apply a candidate."
-            ).format(selector=raw_selector, batch=selector.batch_name)
-        )
-    if selector.candidate_ordinal is not None and file is None:
-        exit_with_error(
-            _(
-                "Candidate selector '{selector}' requires --file in this implementation.\n"
-                "No changes applied."
-            ).format(selector=raw_selector)
-        )
+    selector = _candidate_selectors.resolve_batch_source_action_selector(
+        raw_selector,
+        "apply",
+        file=file,
+    )
     batch_name = selector.batch_name
     scope_resolution = resolve_batch_source_action_scope(
         FileReviewAction.APPLY_FROM_BATCH,

--- a/src/git_stage_batch/commands/apply_from.py
+++ b/src/git_stage_batch/commands/apply_from.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import sys
 from typing import Optional
 
@@ -14,14 +13,13 @@ from .batch_source import candidate_refusals as _candidate_refusals
 from .batch_source import candidate_selectors as _candidate_selectors
 from .batch_source import merge_refusals as _merge_refusals
 from .batch_source import text_file_actions as _text_file_actions
+from .batch_source import text_plan_builders as _text_plan_builders
 from ..batch.binary_file_content import read_binary_file_from_batch
-from ..batch.merge import merge_batch_from_line_sequences_as_buffer
 from ..batch.metadata_validation import read_validated_batch_metadata
 from ..batch.operation_candidates import (
     clear_candidate_preview_state_for_file,
 )
 from ..batch.selection import (
-    acquire_batch_ownership_for_display_ids_from_lines,
     resolve_current_batch_binary_file_scope,
     resolve_batch_file_scope,
     require_single_file_context_for_line_selection,
@@ -33,28 +31,17 @@ from ..batch.submodule_pointer import (
     refuse_batch_submodule_pointer_lines,
 )
 from ..batch.validation import batch_exists
-from ..core.text_lifecycle import (
-    TextFileChangeType,
-    mode_for_text_materialization,
-    normalized_text_change_type,
-    selected_text_target_change_type,
-)
 from ..data.file_review.records import FileReviewAction
 from ..data.file_review.state import (
     finish_review_scoped_line_action,
     resolve_batch_source_action_scope,
 )
 from ..data.file_review.batch_selection import translate_batch_file_gutter_ids_to_selection_ids
-from ..core.buffer import LineBuffer
-from ..utils.repository_buffers import (
-    load_git_object_as_buffer,
-    load_working_tree_file_as_buffer,
-)
 from ..data.session import snapshot_file_if_untracked
 from ..data.undo import undo_checkpoint
 from ..exceptions import exit_with_error, MergeError, CommandError, AtomicUnitError, BatchMetadataError
 from ..i18n import _
-from ..utils.git import get_git_repository_root_path, require_git_repository
+from ..utils.git import require_git_repository
 
 
 def _print_binary_worktree_result(
@@ -225,7 +212,6 @@ def command_apply_from_batch(
         )
         return
 
-    repo_root = get_git_repository_root_path()
     failed_files = []
     candidate_counts = {}
     apply_plans = []
@@ -253,78 +239,35 @@ def command_apply_from_batch(
                 )
                 continue
 
-            text_change_type = normalized_text_change_type(file_meta.get("change_type"))
-
-            full_path = repo_root / file_path
-            working_exists = os.path.lexists(full_path)
-
-            file_mode = mode_for_text_materialization(
-                str(file_meta.get("mode", "100644")),
-                selected_ids,
-                destination_exists=working_exists,
-            )
-            if selected_ids is None and text_change_type == TextFileChangeType.DELETED:
-                apply_plans.append(
-                    _action_plans.ApplyTextFileActionPlan(
-                        file_path,
-                        None,
-                        file_mode,
-                        text_change_type,
+            try:
+                text_plan_result = (
+                    _text_plan_builders.build_apply_text_file_action_plan(
+                        file_path=file_path,
+                        file_meta=file_meta,
+                        selected_ids=selected_ids,
+                        selection_ids_to_apply=selection_ids_to_apply,
                     )
                 )
-                continue
+            except AtomicUnitError as e:
+                if rendered:
+                    translate_atomic_unit_error_to_gutter_ids(
+                        e,
+                        rendered,
+                        "apply",
+                        batch_name,
+                    )
+                _action_plans.close_action_plans(apply_plans)
+                exit_with_error(_("Failed to apply batch '{name}': {error}").format(
+                    name=batch_name,
+                    error=str(e)
+                ))
 
-            batch_source_commit = file_meta["batch_source_commit"]
-            batch_source_buffer = load_git_object_as_buffer(
-                f"{batch_source_commit}:{file_path}"
-            )
-            if batch_source_buffer is None:
+            if text_plan_result.missing_source:
                 failed_files.append(file_path)
                 continue
-
-            with (
-                batch_source_buffer as batch_source_lines,
-                load_working_tree_file_as_buffer(file_path) as working_lines,
-            ):
-                try:
-                    with acquire_batch_ownership_for_display_ids_from_lines(
-                        file_meta,
-                        batch_source_lines,
-                        selection_ids_to_apply,
-                    ) as ownership:
-                        if ownership.is_empty():
-                            if selected_ids is None and text_change_type == TextFileChangeType.ADDED:
-                                merged_buffer = LineBuffer.from_bytes(b"")
-                            else:
-                                continue
-                        else:
-                            merged_buffer = merge_batch_from_line_sequences_as_buffer(
-                                batch_source_lines,
-                                ownership,
-                                working_lines,
-                            )
-                except AtomicUnitError as e:
-                    if rendered:
-                        translate_atomic_unit_error_to_gutter_ids(e, rendered, "apply", batch_name)
-                    _action_plans.close_action_plans(apply_plans)
-                    exit_with_error(_("Failed to apply batch '{name}': {error}").format(
-                        name=batch_name,
-                        error=str(e)
-                    ))
-
-            effective_change_type = selected_text_target_change_type(
-                text_change_type,
-                selected_ids,
-                merged_buffer,
-            )
-            apply_plans.append(
-                _action_plans.ApplyTextFileActionPlan(
-                    file_path,
-                    merged_buffer,
-                    file_mode,
-                    effective_change_type,
-                )
-            )
+            if text_plan_result.plan is None:
+                continue
+            apply_plans.append(text_plan_result.plan)
 
         except MergeError:
             # Merge conflict - batch created from different file version

--- a/src/git_stage_batch/commands/apply_from.py
+++ b/src/git_stage_batch/commands/apply_from.py
@@ -9,6 +9,7 @@ from typing import Optional
 from .batch_source import action_plans as _action_plans
 from .batch_source import binary_file_actions as _binary_file_actions
 from .batch_source import candidate_previews as _candidate_previews
+from .batch_source import candidate_refusals as _candidate_refusals
 from .batch_source import text_file_actions as _text_file_actions
 from ..batch.binary_file_content import read_binary_file_from_batch
 from ..batch.merge import merge_batch_from_line_sequences_as_buffer
@@ -493,96 +494,12 @@ def command_apply_from_batch(
 
     if failed_files:
         _action_plans.close_action_plans(apply_plans)
-        candidate_limit_files = [
-            file_path
-            for file_path in failed_files
-            if candidate_counts.get(file_path, CandidatePreviewCount()).too_many
-        ]
-        if len(candidate_limit_files) == 1:
-            file_path = candidate_limit_files[0]
-            exit_with_error(
-                _(
-                    "Cannot apply batch '{batch}': {file} has too many apply "
-                    "candidates to preview safely.\n"
-                    "No changes applied.\n\n"
-                    "Use --line with a narrower selection or split the batch "
-                    "before previewing candidates."
-                ).format(batch=batch_name, file=file_path)
-            )
-        if len(candidate_limit_files) > 1:
-            exit_with_error(
-                _(
-                    "Cannot apply batch '{batch}': multiple files have too many "
-                    "apply candidates to preview safely.\n"
-                    "No changes applied.\n\n"
-                    "Use --line with narrower selections or split the batch "
-                    "before previewing candidates."
-                ).format(batch=batch_name)
-            )
-
-        candidate_error_files = [
-            file_path
-            for file_path in failed_files
-            if (
-                candidate_counts.get(file_path, CandidatePreviewCount()).error
-                and not candidate_counts.get(file_path, CandidatePreviewCount()).too_many
-            )
-        ]
-        if len(candidate_error_files) == 1:
-            file_path = candidate_error_files[0]
-            error = candidate_counts[file_path].error
-            exit_with_error(
-                _(
-                    "Cannot enumerate apply candidates for {file}: {error}\n"
-                    "No changes applied."
-                ).format(file=file_path, error=error)
-            )
-        if len(candidate_error_files) > 1:
-            examples = "\n".join(
-                f"  {file_path}: {candidate_counts[file_path].error}"
-                for file_path in candidate_error_files[:3]
-            )
-            exit_with_error(
-                _(
-                    "Cannot enumerate apply candidates for multiple files.\n"
-                    "No changes applied.\n\n"
-                    "{examples}"
-                ).format(examples=examples)
-            )
-
-        ambiguous_files = [
-            file_path
-            for file_path in failed_files
-            if candidate_counts.get(file_path, CandidatePreviewCount()).count
-        ]
-        if len(ambiguous_files) == 1:
-            file_path = ambiguous_files[0]
-            exit_with_error(
-                _(
-                    "Cannot apply batch '{batch}': {file} has {count} apply candidates.\n"
-                    "No changes applied.\n\n"
-                    "Preview candidates:\n"
-                    "  git-stage-batch show --from {batch}:apply --file {file}\n\n"
-                    "Apply a reviewed candidate:\n"
-                    "  git-stage-batch apply --from {batch}:apply:N --file {file}"
-                ).format(
-                    batch=batch_name,
-                    file=file_path,
-                    count=candidate_counts[file_path].count,
-                )
-            )
-        if len(ambiguous_files) > 1:
-            examples = "\n".join(
-                f"  git-stage-batch show --from {batch_name}:apply --file {file_path}"
-                for file_path in ambiguous_files[:3]
-            )
-            exit_with_error(
-                _(
-                    "Cannot apply batch '{batch}': multiple files need apply decisions.\n"
-                    "No changes applied.\n\n"
-                    "Resolve one file at a time:\n{examples}"
-                ).format(batch=batch_name, examples=examples)
-            )
+        _candidate_refusals.refuse_candidate_conflicts(
+            batch_name=batch_name,
+            operation="apply",
+            failed_files=failed_files,
+            candidate_counts=candidate_counts,
+        )
         if len(failed_files) == 1:
             # Check if there are individually mergeable lines to suggest --lines
             file_path = failed_files[0]

--- a/src/git_stage_batch/commands/apply_from.py
+++ b/src/git_stage_batch/commands/apply_from.py
@@ -8,6 +8,7 @@ from typing import Optional
 
 from .batch_source import action_plans as _action_plans
 from .batch_source import binary_file_actions as _binary_file_actions
+from .batch_source import candidate_previews as _candidate_previews
 from .batch_source import text_file_actions as _text_file_actions
 from ..batch.binary_file_content import read_binary_file_from_batch
 from ..batch.merge import merge_batch_from_line_sequences_as_buffer
@@ -17,7 +18,6 @@ from ..batch.operation_candidates import (
     CandidatePreviewCount,
     build_apply_candidate_previews,
     clear_candidate_preview_state_for_file,
-    load_candidate_preview_state,
 )
 from ..batch.selection import (
     acquire_batch_ownership_for_display_ids_from_lines,
@@ -138,9 +138,12 @@ def _execute_apply_candidate(
             except MergeError as e:
                 exit_with_error(str(e))
 
-            if ordinal < 1 or ordinal > len(previews):
-                for preview in previews:
-                    preview.close()
+            preview = _candidate_previews.candidate_preview_for_ordinal(
+                previews,
+                ordinal,
+            )
+            if preview is None:
+                _candidate_previews.close_candidate_previews(previews)
                 exit_with_error(
                     _("Batch '{batch}' has {count} apply candidates for {file}; candidate {ordinal} does not exist.").format(
                         batch=batch_name,
@@ -150,15 +153,10 @@ def _execute_apply_candidate(
                     )
                 )
 
-            preview = previews[ordinal - 1]
             try:
-                state = load_candidate_preview_state(preview)
-                if (
-                    state is None
-                    or state.get("ordinal") != ordinal
-                    or state.get("candidate_id") != preview.candidate_id
-                    or state.get("target_fingerprints") != preview.target_fingerprints
-                    or state.get("target_result_fingerprints") != preview.target_result_fingerprints
+                if not _candidate_previews.candidate_preview_state_matches(
+                    preview,
+                    ordinal,
                 ):
                     exit_with_error(
                         _(
@@ -206,8 +204,7 @@ def _execute_apply_candidate(
                     file=sys.stderr,
                 )
             finally:
-                for candidate in previews:
-                    candidate.close()
+                _candidate_previews.close_candidate_previews(previews)
 
 
 def _apply_candidate_count_for_file(
@@ -259,8 +256,7 @@ def _apply_candidate_count_for_file(
                     selection_ids=selection_ids_to_apply,
                 )
                 count = len(previews)
-                for preview in previews:
-                    preview.close()
+                _candidate_previews.close_candidate_previews(previews)
                 return CandidatePreviewCount(count=count)
     except CandidateEnumerationLimitError as e:
         return CandidatePreviewCount(too_many=True, error=str(e))

--- a/src/git_stage_batch/commands/apply_from.py
+++ b/src/git_stage_batch/commands/apply_from.py
@@ -136,34 +136,20 @@ def _execute_apply_candidate(
             except MergeError as e:
                 exit_with_error(str(e))
 
-            preview = _candidate_previews.candidate_preview_for_ordinal(
-                previews,
-                ordinal,
-            )
-            if preview is None:
-                _candidate_previews.close_candidate_previews(previews)
-                exit_with_error(
-                    _("Batch '{batch}' has {count} apply candidates for {file}; candidate {ordinal} does not exist.").format(
-                        batch=batch_name,
-                        count=len(previews),
-                        file=file_path,
-                        ordinal=ordinal,
-                    )
-                )
-
             try:
-                if not _candidate_previews.candidate_preview_state_matches(
+                preview = _candidate_previews.require_candidate_preview_for_ordinal(
+                    previews,
+                    ordinal,
+                    batch_name=batch_name,
+                    operation="apply",
+                    file_path=file_path,
+                )
+                _candidate_previews.require_candidate_preview_state(
                     preview,
                     ordinal,
-                ):
-                    exit_with_error(
-                        _(
-                            "Candidate selector '{selector}' has not been previewed for {file}.\n"
-                            "No changes applied.\n\n"
-                            "Preview it first with:\n"
-                            "  git-stage-batch show --from {selector} --file {file}"
-                        ).format(selector=raw_selector, file=file_path)
-                    )
+                    selector=raw_selector,
+                    file_path=file_path,
+                )
 
                 target = preview.targets[0]
                 effective_change_type = selected_text_target_change_type(

--- a/src/git_stage_batch/commands/apply_from.py
+++ b/src/git_stage_batch/commands/apply_from.py
@@ -11,6 +11,7 @@ from .batch_source import binary_file_actions as _binary_file_actions
 from .batch_source import candidate_previews as _candidate_previews
 from .batch_source import candidate_refusals as _candidate_refusals
 from .batch_source import candidate_selectors as _candidate_selectors
+from .batch_source import merge_refusals as _merge_refusals
 from .batch_source import text_file_actions as _text_file_actions
 from ..batch.binary_file_content import read_binary_file_from_batch
 from ..batch.merge import merge_batch_from_line_sequences_as_buffer
@@ -46,7 +47,6 @@ from ..data.file_review.state import (
     resolve_batch_source_action_scope,
 )
 from ..data.file_review.batch_selection import translate_batch_file_gutter_ids_to_selection_ids
-from ..batch.file_display import render_batch_file_display
 from ..core.buffer import LineBuffer
 from ..utils.repository_buffers import (
     load_git_object_as_buffer,
@@ -485,36 +485,10 @@ def command_apply_from_batch(
             failed_files=failed_files,
             candidate_counts=candidate_counts,
         )
-        if len(failed_files) == 1:
-            # Check if there are individually mergeable lines to suggest --lines
-            file_path = failed_files[0]
-            rendered = render_batch_file_display(batch_name, file_path)
-            has_mergeable_lines = rendered and len(rendered.gutter_to_selection_id) > 0
-
-            if has_mergeable_lines:
-                error_msg = _("Batch '{batch}' contains changes to {file} that are incompatible with the current working tree. "
-                             "Use 'git-stage-batch show --from {batch}' to review the batch, "
-                             "or use '--lines' to apply only specific changes.").format(
-                    batch=batch_name,
-                    file=file_path
-                )
-            else:
-                error_msg = _("Batch '{batch}' contains changes to {file} that are incompatible with the current working tree. "
-                             "Use 'git-stage-batch show --from {batch}' to review the batch.").format(
-                    batch=batch_name,
-                    file=file_path
-                )
-            exit_with_error(error_msg)
-        else:
-            exit_with_error(
-                _("Batch '{batch}' contains changes to one or more files that are incompatible with the current working tree. "
-                  "Failed for: {files}. "
-                  "Use 'git-stage-batch show --from {batch}' to review the batch, "
-                  "or use '--lines' to apply only specific changes.").format(
-                    batch=batch_name,
-                    files=', '.join(failed_files)
-                )
-            )
+        _merge_refusals.refuse_batch_source_merge_failures(
+            batch_name=batch_name,
+            failed_files=failed_files,
+        )
 
     try:
         try:

--- a/src/git_stage_batch/commands/apply_from.py
+++ b/src/git_stage_batch/commands/apply_from.py
@@ -8,6 +8,7 @@ from typing import Optional
 
 from .batch_source import action_plans as _action_plans
 from .batch_source import binary_file_actions as _binary_file_actions
+from .batch_source import candidate_preview_counts as _candidate_preview_counts
 from .batch_source import candidate_previews as _candidate_previews
 from .batch_source import candidate_refusals as _candidate_refusals
 from .batch_source import candidate_selectors as _candidate_selectors
@@ -17,8 +18,6 @@ from ..batch.binary_file_content import read_binary_file_from_batch
 from ..batch.merge import merge_batch_from_line_sequences_as_buffer
 from ..batch.metadata_validation import read_validated_batch_metadata
 from ..batch.operation_candidates import (
-    CandidateEnumerationLimitError,
-    CandidatePreviewCount,
     build_apply_candidate_previews,
     clear_candidate_preview_state_for_file,
 )
@@ -191,65 +190,6 @@ def _execute_apply_candidate(
                 _candidate_previews.close_candidate_previews(previews)
 
 
-def _apply_candidate_count_for_file(
-    *,
-    batch_name: str,
-    file_path: str,
-    file_meta: dict,
-    selection_ids_to_apply: set[int] | None,
-) -> CandidatePreviewCount:
-    if file_meta.get("file_type") == "binary" or is_batch_submodule_pointer(file_meta):
-        return CandidatePreviewCount()
-    batch_source_commit = file_meta.get("batch_source_commit")
-    if not batch_source_commit:
-        return CandidatePreviewCount()
-    batch_source_buffer = load_git_object_as_buffer(f"{batch_source_commit}:{file_path}")
-    if batch_source_buffer is None:
-        return CandidatePreviewCount()
-    repo_root = get_git_repository_root_path()
-    full_path = repo_root / file_path
-    working_exists = os.path.lexists(full_path)
-    file_mode = mode_for_text_materialization(
-        str(file_meta.get("mode", "100644")),
-        selection_ids_to_apply,
-        destination_exists=working_exists,
-    )
-    text_change_type = normalized_text_change_type(file_meta.get("change_type"))
-    try:
-        with (
-            batch_source_buffer as batch_source_lines,
-            load_working_tree_file_as_buffer(file_path) as working_lines,
-        ):
-            with acquire_batch_ownership_for_display_ids_from_lines(
-                file_meta,
-                batch_source_lines,
-                selection_ids_to_apply,
-            ) as ownership:
-                previews = build_apply_candidate_previews(
-                    batch_name=batch_name,
-                    file_path=file_path,
-                    source_lines=batch_source_lines,
-                    ownership=ownership,
-                    worktree_lines=working_lines,
-                    batch_source_commit=batch_source_commit,
-                    file_meta=file_meta,
-                    text_change_type=text_change_type,
-                    worktree_file_mode=file_mode,
-                    worktree_exists=working_exists,
-                    selected_ids=selection_ids_to_apply,
-                    selection_ids=selection_ids_to_apply,
-                )
-                count = len(previews)
-                _candidate_previews.close_candidate_previews(previews)
-                return CandidatePreviewCount(count=count)
-    except CandidateEnumerationLimitError as e:
-        return CandidatePreviewCount(too_many=True, error=str(e))
-    except MergeError:
-        return CandidatePreviewCount()
-    except Exception as e:
-        return CandidatePreviewCount(error=str(e))
-
-
 def command_apply_from_batch(
     batch_name: str,
     line_ids: Optional[str] = None,
@@ -345,7 +285,7 @@ def command_apply_from_batch(
 
     repo_root = get_git_repository_root_path()
     failed_files = []
-    candidate_counts: dict[str, CandidatePreviewCount] = {}
+    candidate_counts = {}
     apply_plans = []
 
     for file_path, file_meta in files.items():
@@ -446,11 +386,13 @@ def command_apply_from_batch(
 
         except MergeError:
             # Merge conflict - batch created from different file version
-            candidate_count = _apply_candidate_count_for_file(
-                batch_name=batch_name,
-                file_path=file_path,
-                file_meta=file_meta,
-                selection_ids_to_apply=selection_ids_to_apply,
+            candidate_count = (
+                _candidate_preview_counts.count_apply_candidate_previews_for_file(
+                    batch_name=batch_name,
+                    file_path=file_path,
+                    file_meta=file_meta,
+                    selection_ids_to_apply=selection_ids_to_apply,
+                )
             )
             if candidate_count.count or candidate_count.too_many or candidate_count.error:
                 candidate_counts[file_path] = candidate_count

--- a/src/git_stage_batch/commands/batch_source/action_plans.py
+++ b/src/git_stage_batch/commands/batch_source/action_plans.py
@@ -55,6 +55,20 @@ class IncludeTextFileActionPlan:
 
 
 @dataclass
+class DiscardTextFileActionPlan:
+    """Deferred discard-from text file action with final worktree content."""
+
+    file_path: str
+    buffer: LineBuffer | None
+    file_mode: str | None
+    change_type: str
+
+    def close(self) -> None:
+        if self.buffer is not None:
+            self.buffer.close()
+
+
+@dataclass
 class BinaryFileActionPlan:
     """Deferred binary file action with optional stored batch content."""
 

--- a/src/git_stage_batch/commands/batch_source/candidate_inputs.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_inputs.py
@@ -1,0 +1,114 @@
+"""Input metadata helpers for batch-source candidate operations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from typing import Iterable
+
+from ...batch.submodule_pointer import is_batch_submodule_pointer
+from ...core.text_lifecycle import (
+    TextFileChangeType,
+    mode_for_text_materialization,
+    normalized_text_change_type,
+)
+from ...utils.git import get_git_repository_root_path
+
+
+@dataclass(frozen=True)
+class CandidateBatchSourceRef:
+    """Git object reference for one text candidate's batch source."""
+
+    commit: str
+    object_spec: str
+
+
+@dataclass(frozen=True)
+class CandidateWorktreeTarget:
+    """Worktree metadata needed to build text candidate previews."""
+
+    exists: bool
+    file_mode: str | None
+    text_change_type: TextFileChangeType
+
+
+@dataclass(frozen=True)
+class CandidateIndexTarget:
+    """Index metadata needed to build text candidate previews."""
+
+    exists: bool
+    file_mode: str | None
+
+
+def is_text_candidate_entry(file_meta: dict) -> bool:
+    """Return whether a batch file entry supports text candidate handling."""
+    return file_meta.get("file_type") != "binary" and not is_batch_submodule_pointer(
+        file_meta
+    )
+
+
+def candidate_batch_source_ref(
+    file_path: str,
+    file_meta: dict,
+) -> CandidateBatchSourceRef | None:
+    """Return the batch source object reference, or None when metadata lacks one."""
+    batch_source_commit = file_meta.get("batch_source_commit")
+    if not batch_source_commit:
+        return None
+    return CandidateBatchSourceRef(
+        commit=batch_source_commit,
+        object_spec=f"{batch_source_commit}:{file_path}",
+    )
+
+
+def require_candidate_batch_source_ref(
+    file_path: str,
+    file_meta: dict,
+) -> CandidateBatchSourceRef:
+    """Return the batch source object reference for validated candidate metadata."""
+    batch_source_commit = file_meta["batch_source_commit"]
+    return CandidateBatchSourceRef(
+        commit=batch_source_commit,
+        object_spec=f"{batch_source_commit}:{file_path}",
+    )
+
+
+def candidate_worktree_text_target(
+    *,
+    file_path: str,
+    file_meta: dict,
+    selected_ids: Iterable[int] | None,
+) -> CandidateWorktreeTarget:
+    """Return worktree existence, materialization mode, and text lifecycle."""
+    repo_root = get_git_repository_root_path()
+    working_exists = os.path.lexists(repo_root / file_path)
+    return CandidateWorktreeTarget(
+        exists=working_exists,
+        file_mode=mode_for_text_materialization(
+            _batch_file_mode(file_meta),
+            selected_ids,
+            destination_exists=working_exists,
+        ),
+        text_change_type=normalized_text_change_type(file_meta.get("change_type")),
+    )
+
+
+def candidate_index_text_target(
+    *,
+    file_meta: dict,
+    selected_ids: Iterable[int] | None,
+    index_exists: bool,
+) -> CandidateIndexTarget:
+    """Return index existence and materialization mode metadata."""
+    return CandidateIndexTarget(
+        exists=index_exists,
+        file_mode=mode_for_text_materialization(
+            _batch_file_mode(file_meta),
+            selected_ids,
+            destination_exists=index_exists,
+        ),
+    )
+
+
+def _batch_file_mode(file_meta: dict) -> str:
+    return str(file_meta.get("mode", "100644"))

--- a/src/git_stage_batch/commands/batch_source/candidate_materialization.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_materialization.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from contextlib import ExitStack
 from dataclasses import dataclass
-import os
 
+from . import candidate_inputs as _candidate_inputs
 from . import candidate_previews as _candidate_previews
 from ...batch.operation_candidates import (
     OperationCandidatePreview,
@@ -15,20 +15,14 @@ from ...batch.operation_candidates import (
 )
 from ...batch.replacement import build_replacement_batch_view_from_lines
 from ...batch.selection import acquire_batch_ownership_for_display_ids_from_lines
-from ...batch.submodule_pointer import is_batch_submodule_pointer
 from ...core.buffer import LineBuffer
 from ...core.replacement import ReplacementPayload
-from ...core.text_lifecycle import (
-    mode_for_text_materialization,
-    normalized_text_change_type,
-)
 from ...utils.repository_buffers import (
     load_git_object_as_buffer,
     load_working_tree_file_as_buffer,
 )
 from ...exceptions import MergeError, exit_with_error
 from ...i18n import _
-from ...utils.git import get_git_repository_root_path
 
 
 @dataclass(frozen=True)
@@ -83,27 +77,26 @@ def materialize_apply_candidate(
     if len(files) != 1:
         exit_with_error(_("Candidate execution requires exactly one file."))
     file_path, file_meta = next(iter(files.items()))
-    if file_meta.get("file_type") == "binary" or is_batch_submodule_pointer(file_meta):
+    if not _candidate_inputs.is_text_candidate_entry(file_meta):
         exit_with_error(
             _("Candidate execution is only available for text batch entries.")
         )
 
-    batch_source_commit = file_meta["batch_source_commit"]
-    batch_source_buffer = load_git_object_as_buffer(f"{batch_source_commit}:{file_path}")
+    batch_source_ref = _candidate_inputs.require_candidate_batch_source_ref(
+        file_path,
+        file_meta,
+    )
+    batch_source_buffer = load_git_object_as_buffer(batch_source_ref.object_spec)
     if batch_source_buffer is None:
         exit_with_error(
             _("Batch source content is missing for {file}.").format(file=file_path)
         )
 
-    repo_root = get_git_repository_root_path()
-    full_path = repo_root / file_path
-    working_exists = os.path.lexists(full_path)
-    file_mode = mode_for_text_materialization(
-        str(file_meta.get("mode", "100644")),
-        selected_ids,
-        destination_exists=working_exists,
+    worktree_target = _candidate_inputs.candidate_worktree_text_target(
+        file_path=file_path,
+        file_meta=file_meta,
+        selected_ids=selected_ids,
     )
-    text_change_type = normalized_text_change_type(file_meta.get("change_type"))
 
     with (
         batch_source_buffer as batch_source_lines,
@@ -121,11 +114,11 @@ def materialize_apply_candidate(
                     source_lines=batch_source_lines,
                     ownership=ownership,
                     worktree_lines=working_lines,
-                    batch_source_commit=batch_source_commit,
+                    batch_source_commit=batch_source_ref.commit,
                     file_meta=file_meta,
-                    text_change_type=text_change_type,
-                    worktree_file_mode=file_mode,
-                    worktree_exists=working_exists,
+                    text_change_type=worktree_target.text_change_type,
+                    worktree_file_mode=worktree_target.file_mode,
+                    worktree_exists=worktree_target.exists,
                     selected_ids=selected_ids,
                     selection_ids=selection_ids_to_apply,
                 )
@@ -154,7 +147,7 @@ def materialize_apply_candidate(
         preview=preview,
         previews=previews,
         file_path=file_path,
-        file_mode=file_mode,
+        file_mode=worktree_target.file_mode,
     )
 
 
@@ -172,36 +165,34 @@ def materialize_include_candidate(
     if len(files) != 1:
         exit_with_error(_("Candidate execution requires exactly one file."))
     file_path, file_meta = next(iter(files.items()))
-    if file_meta.get("file_type") == "binary" or is_batch_submodule_pointer(file_meta):
+    if not _candidate_inputs.is_text_candidate_entry(file_meta):
         exit_with_error(
             _("Candidate execution is only available for text batch entries.")
         )
 
-    batch_source_commit = file_meta["batch_source_commit"]
-    batch_source_buffer = load_git_object_as_buffer(f"{batch_source_commit}:{file_path}")
+    batch_source_ref = _candidate_inputs.require_candidate_batch_source_ref(
+        file_path,
+        file_meta,
+    )
+    batch_source_buffer = load_git_object_as_buffer(batch_source_ref.object_spec)
     if batch_source_buffer is None:
         exit_with_error(
             _("Batch source content is missing for {file}.").format(file=file_path)
         )
 
-    repo_root = get_git_repository_root_path()
-    full_path = repo_root / file_path
-    working_exists = os.path.lexists(full_path)
-    text_change_type = normalized_text_change_type(file_meta.get("change_type"))
-    batch_file_mode = str(file_meta.get("mode", "100644"))
     index_buffer = load_git_object_as_buffer(f":{file_path}")
     index_exists = index_buffer is not None
     if index_buffer is None:
         index_buffer = LineBuffer.from_bytes(b"")
-    index_file_mode = mode_for_text_materialization(
-        batch_file_mode,
-        selected_ids,
-        destination_exists=index_exists,
+    index_target = _candidate_inputs.candidate_index_text_target(
+        file_meta=file_meta,
+        selected_ids=selected_ids,
+        index_exists=index_exists,
     )
-    worktree_file_mode = mode_for_text_materialization(
-        batch_file_mode,
-        selected_ids,
-        destination_exists=working_exists,
+    worktree_target = _candidate_inputs.candidate_worktree_text_target(
+        file_path=file_path,
+        file_meta=file_meta,
+        selected_ids=selected_ids,
     )
 
     with (
@@ -237,13 +228,13 @@ def materialize_include_candidate(
                         ownership=candidate_ownership,
                         index_lines=index_lines,
                         worktree_lines=working_lines,
-                        batch_source_commit=batch_source_commit,
+                        batch_source_commit=batch_source_ref.commit,
                         file_meta=file_meta,
-                        text_change_type=text_change_type,
-                        index_file_mode=index_file_mode,
-                        worktree_file_mode=worktree_file_mode,
-                        index_exists=index_exists,
-                        worktree_exists=working_exists,
+                        text_change_type=worktree_target.text_change_type,
+                        index_file_mode=index_target.file_mode,
+                        worktree_file_mode=worktree_target.file_mode,
+                        index_exists=index_target.exists,
+                        worktree_exists=worktree_target.exists,
                         selected_ids=selected_ids,
                         selection_ids=selection_ids_to_include,
                         replacement_payload=replacement_payload,
@@ -273,6 +264,6 @@ def materialize_include_candidate(
         preview=preview,
         previews=previews,
         file_path=file_path,
-        index_file_mode=index_file_mode,
-        worktree_file_mode=worktree_file_mode,
+        index_file_mode=index_target.file_mode,
+        worktree_file_mode=worktree_target.file_mode,
     )

--- a/src/git_stage_batch/commands/batch_source/candidate_materialization.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_materialization.py
@@ -1,0 +1,131 @@
+"""Reviewed candidate materialization for batch-source action commands."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+
+from . import candidate_previews as _candidate_previews
+from ...batch.operation_candidates import (
+    OperationCandidatePreview,
+    TargetCandidatePreview,
+    build_apply_candidate_previews,
+)
+from ...batch.selection import acquire_batch_ownership_for_display_ids_from_lines
+from ...batch.submodule_pointer import is_batch_submodule_pointer
+from ...core.text_lifecycle import (
+    mode_for_text_materialization,
+    normalized_text_change_type,
+)
+from ...utils.repository_buffers import (
+    load_git_object_as_buffer,
+    load_working_tree_file_as_buffer,
+)
+from ...exceptions import MergeError, exit_with_error
+from ...i18n import _
+from ...utils.git import get_git_repository_root_path
+
+
+@dataclass(frozen=True)
+class ApplyCandidateMaterialization:
+    """Materialized apply candidate plus metadata needed by command execution."""
+
+    preview: OperationCandidatePreview
+    previews: tuple[OperationCandidatePreview, ...]
+    file_path: str
+    file_mode: str | None
+
+    @property
+    def target(self) -> TargetCandidatePreview:
+        return self.preview.targets[0]
+
+    def close(self) -> None:
+        _candidate_previews.close_candidate_previews(self.previews)
+
+
+def materialize_apply_candidate(
+    *,
+    batch_name: str,
+    raw_selector: str,
+    ordinal: int,
+    files: dict,
+    selected_ids: set[int] | None,
+    selection_ids_to_apply: set[int] | None,
+) -> ApplyCandidateMaterialization:
+    """Return the reviewed apply candidate selected by the user."""
+    if len(files) != 1:
+        exit_with_error(_("Candidate execution requires exactly one file."))
+    file_path, file_meta = next(iter(files.items()))
+    if file_meta.get("file_type") == "binary" or is_batch_submodule_pointer(file_meta):
+        exit_with_error(
+            _("Candidate execution is only available for text batch entries.")
+        )
+
+    batch_source_commit = file_meta["batch_source_commit"]
+    batch_source_buffer = load_git_object_as_buffer(f"{batch_source_commit}:{file_path}")
+    if batch_source_buffer is None:
+        exit_with_error(
+            _("Batch source content is missing for {file}.").format(file=file_path)
+        )
+
+    repo_root = get_git_repository_root_path()
+    full_path = repo_root / file_path
+    working_exists = os.path.lexists(full_path)
+    file_mode = mode_for_text_materialization(
+        str(file_meta.get("mode", "100644")),
+        selected_ids,
+        destination_exists=working_exists,
+    )
+    text_change_type = normalized_text_change_type(file_meta.get("change_type"))
+
+    with (
+        batch_source_buffer as batch_source_lines,
+        load_working_tree_file_as_buffer(file_path) as working_lines,
+    ):
+        with acquire_batch_ownership_for_display_ids_from_lines(
+            file_meta,
+            batch_source_lines,
+            selection_ids_to_apply,
+        ) as ownership:
+            try:
+                previews = build_apply_candidate_previews(
+                    batch_name=batch_name,
+                    file_path=file_path,
+                    source_lines=batch_source_lines,
+                    ownership=ownership,
+                    worktree_lines=working_lines,
+                    batch_source_commit=batch_source_commit,
+                    file_meta=file_meta,
+                    text_change_type=text_change_type,
+                    worktree_file_mode=file_mode,
+                    worktree_exists=working_exists,
+                    selected_ids=selected_ids,
+                    selection_ids=selection_ids_to_apply,
+                )
+            except MergeError as e:
+                exit_with_error(str(e))
+
+            try:
+                preview = _candidate_previews.require_candidate_preview_for_ordinal(
+                    previews,
+                    ordinal,
+                    batch_name=batch_name,
+                    operation="apply",
+                    file_path=file_path,
+                )
+                _candidate_previews.require_candidate_preview_state(
+                    preview,
+                    ordinal,
+                    selector=raw_selector,
+                    file_path=file_path,
+                )
+            except Exception:
+                _candidate_previews.close_candidate_previews(previews)
+                raise
+
+    return ApplyCandidateMaterialization(
+        preview=preview,
+        previews=previews,
+        file_path=file_path,
+        file_mode=file_mode,
+    )

--- a/src/git_stage_batch/commands/batch_source/candidate_materialization.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_materialization.py
@@ -42,7 +42,7 @@ class ApplyCandidateMaterialization:
 
     @property
     def target(self) -> TargetCandidatePreview:
-        return self.preview.targets[0]
+        return self.preview.require_target("worktree")
 
     def close(self) -> None:
         _candidate_previews.close_candidate_previews(self.previews)
@@ -60,13 +60,11 @@ class IncludeCandidateMaterialization:
 
     @property
     def index_target(self) -> TargetCandidatePreview:
-        return next(target for target in self.preview.targets if target.target == "index")
+        return self.preview.require_target("index")
 
     @property
     def worktree_target(self) -> TargetCandidatePreview:
-        return next(
-            target for target in self.preview.targets if target.target == "worktree"
-        )
+        return self.preview.require_target("worktree")
 
     def close(self) -> None:
         _candidate_previews.close_candidate_previews(self.previews)

--- a/src/git_stage_batch/commands/batch_source/candidate_materialization.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_materialization.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from contextlib import ExitStack
 from dataclasses import dataclass
 import os
 
@@ -10,9 +11,13 @@ from ...batch.operation_candidates import (
     OperationCandidatePreview,
     TargetCandidatePreview,
     build_apply_candidate_previews,
+    build_include_candidate_previews,
 )
+from ...batch.replacement import build_replacement_batch_view_from_lines
 from ...batch.selection import acquire_batch_ownership_for_display_ids_from_lines
 from ...batch.submodule_pointer import is_batch_submodule_pointer
+from ...core.buffer import LineBuffer
+from ...core.replacement import ReplacementPayload
 from ...core.text_lifecycle import (
     mode_for_text_materialization,
     normalized_text_change_type,
@@ -38,6 +43,30 @@ class ApplyCandidateMaterialization:
     @property
     def target(self) -> TargetCandidatePreview:
         return self.preview.targets[0]
+
+    def close(self) -> None:
+        _candidate_previews.close_candidate_previews(self.previews)
+
+
+@dataclass(frozen=True)
+class IncludeCandidateMaterialization:
+    """Materialized include candidate plus metadata needed by command execution."""
+
+    preview: OperationCandidatePreview
+    previews: tuple[OperationCandidatePreview, ...]
+    file_path: str
+    index_file_mode: str | None
+    worktree_file_mode: str | None
+
+    @property
+    def index_target(self) -> TargetCandidatePreview:
+        return next(target for target in self.preview.targets if target.target == "index")
+
+    @property
+    def worktree_target(self) -> TargetCandidatePreview:
+        return next(
+            target for target in self.preview.targets if target.target == "worktree"
+        )
 
     def close(self) -> None:
         _candidate_previews.close_candidate_previews(self.previews)
@@ -128,4 +157,124 @@ def materialize_apply_candidate(
         previews=previews,
         file_path=file_path,
         file_mode=file_mode,
+    )
+
+
+def materialize_include_candidate(
+    *,
+    batch_name: str,
+    raw_selector: str,
+    ordinal: int,
+    files: dict,
+    selected_ids: set[int] | None,
+    selection_ids_to_include: set[int] | None,
+    replacement_payload: ReplacementPayload | None,
+) -> IncludeCandidateMaterialization:
+    """Return the reviewed include candidate selected by the user."""
+    if len(files) != 1:
+        exit_with_error(_("Candidate execution requires exactly one file."))
+    file_path, file_meta = next(iter(files.items()))
+    if file_meta.get("file_type") == "binary" or is_batch_submodule_pointer(file_meta):
+        exit_with_error(
+            _("Candidate execution is only available for text batch entries.")
+        )
+
+    batch_source_commit = file_meta["batch_source_commit"]
+    batch_source_buffer = load_git_object_as_buffer(f"{batch_source_commit}:{file_path}")
+    if batch_source_buffer is None:
+        exit_with_error(
+            _("Batch source content is missing for {file}.").format(file=file_path)
+        )
+
+    repo_root = get_git_repository_root_path()
+    full_path = repo_root / file_path
+    working_exists = os.path.lexists(full_path)
+    text_change_type = normalized_text_change_type(file_meta.get("change_type"))
+    batch_file_mode = str(file_meta.get("mode", "100644"))
+    index_buffer = load_git_object_as_buffer(f":{file_path}")
+    index_exists = index_buffer is not None
+    if index_buffer is None:
+        index_buffer = LineBuffer.from_bytes(b"")
+    index_file_mode = mode_for_text_materialization(
+        batch_file_mode,
+        selected_ids,
+        destination_exists=index_exists,
+    )
+    worktree_file_mode = mode_for_text_materialization(
+        batch_file_mode,
+        selected_ids,
+        destination_exists=working_exists,
+    )
+
+    with (
+        batch_source_buffer as batch_source_lines,
+        index_buffer as index_lines,
+        load_working_tree_file_as_buffer(file_path) as working_lines,
+    ):
+        with acquire_batch_ownership_for_display_ids_from_lines(
+            file_meta,
+            batch_source_lines,
+            selection_ids_to_include,
+        ) as ownership:
+            with ExitStack() as stack:
+                source_for_candidates = batch_source_lines
+                candidate_ownership = ownership
+                if replacement_payload is not None:
+                    try:
+                        replacement_view = build_replacement_batch_view_from_lines(
+                            batch_source_lines,
+                            ownership,
+                            replacement_payload,
+                        )
+                    except ValueError as e:
+                        exit_with_error(str(e))
+                    replacement_view = stack.enter_context(replacement_view)
+                    source_for_candidates = replacement_view.source_buffer
+                    candidate_ownership = replacement_view.ownership
+                try:
+                    previews = build_include_candidate_previews(
+                        batch_name=batch_name,
+                        file_path=file_path,
+                        source_lines=source_for_candidates,
+                        ownership=candidate_ownership,
+                        index_lines=index_lines,
+                        worktree_lines=working_lines,
+                        batch_source_commit=batch_source_commit,
+                        file_meta=file_meta,
+                        text_change_type=text_change_type,
+                        index_file_mode=index_file_mode,
+                        worktree_file_mode=worktree_file_mode,
+                        index_exists=index_exists,
+                        worktree_exists=working_exists,
+                        selected_ids=selected_ids,
+                        selection_ids=selection_ids_to_include,
+                        replacement_payload=replacement_payload,
+                    )
+                except (MergeError, ValueError) as e:
+                    exit_with_error(str(e))
+
+            try:
+                preview = _candidate_previews.require_candidate_preview_for_ordinal(
+                    previews,
+                    ordinal,
+                    batch_name=batch_name,
+                    operation="include",
+                    file_path=file_path,
+                )
+                _candidate_previews.require_candidate_preview_state(
+                    preview,
+                    ordinal,
+                    selector=raw_selector,
+                    file_path=file_path,
+                )
+            except Exception:
+                _candidate_previews.close_candidate_previews(previews)
+                raise
+
+    return IncludeCandidateMaterialization(
+        preview=preview,
+        previews=previews,
+        file_path=file_path,
+        index_file_mode=index_file_mode,
+        worktree_file_mode=worktree_file_mode,
     )

--- a/src/git_stage_batch/commands/batch_source/candidate_preview_builders.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_preview_builders.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from contextlib import ExitStack
-import os
 from typing import Any
 
+from . import candidate_inputs as _candidate_inputs
 from ..selection import replacement_selection
 from ...batch.operation_candidates import (
     OperationCandidatePreview,
@@ -16,13 +16,8 @@ from ...batch.operation_candidates import (
 from ...batch.replacement import build_replacement_batch_view_from_lines
 from ...batch.selection import acquire_batch_ownership_for_display_ids_from_lines
 from ...batch.source_selector import BatchSourceSelector
-from ...batch.submodule_pointer import is_batch_submodule_pointer
 from ...core.buffer import LineBuffer
 from ...core.replacement import ReplacementPayload, coerce_replacement_payload
-from ...core.text_lifecycle import (
-    mode_for_text_materialization,
-    normalized_text_change_type,
-)
 from ...data.file_review.batch_selection import (
     translate_batch_file_gutter_ids_to_selection_ids,
 )
@@ -33,7 +28,6 @@ from ...utils.repository_buffers import (
 )
 from ...exceptions import exit_with_error
 from ...i18n import _
-from ...utils.git import get_git_repository_root_path
 
 
 SelectionTranslator = Callable[
@@ -59,23 +53,26 @@ def build_batch_source_candidate_previews(
         raise ValueError("Candidate preview requires a candidate selector.")
 
     file_meta = files[file_path]
-    if file_meta.get("file_type") == "binary" or is_batch_submodule_pointer(file_meta):
+    if not _candidate_inputs.is_text_candidate_entry(file_meta):
         exit_with_error(
             _("Candidate preview is only available for text batch entries.")
         )
 
-    batch_source_commit = file_meta["batch_source_commit"]
-    batch_source_buffer = load_git_object_as_buffer(f"{batch_source_commit}:{file_path}")
+    batch_source_ref = _candidate_inputs.require_candidate_batch_source_ref(
+        file_path,
+        file_meta,
+    )
+    batch_source_buffer = load_git_object_as_buffer(batch_source_ref.object_spec)
     if batch_source_buffer is None:
         exit_with_error(
             _("Batch source content is missing for {file}.").format(file=file_path)
         )
 
-    repo_root = get_git_repository_root_path()
-    full_path = repo_root / file_path
-    working_exists = os.path.lexists(full_path)
-    text_change_type = normalized_text_change_type(file_meta.get("change_type"))
-    batch_file_mode = str(file_meta.get("mode", "100644"))
+    worktree_target = _candidate_inputs.candidate_worktree_text_target(
+        file_path=file_path,
+        file_meta=file_meta,
+        selected_ids=selected_ids,
+    )
 
     with batch_source_buffer as batch_source_lines:
         selection_ids_to_apply = selected_ids
@@ -125,11 +122,6 @@ def build_batch_source_candidate_previews(
                     candidate_ownership = replacement_view.ownership
 
                 if operation == "apply":
-                    worktree_file_mode = mode_for_text_materialization(
-                        batch_file_mode,
-                        selected_ids,
-                        destination_exists=working_exists,
-                    )
                     with load_working_tree_file_as_buffer(file_path) as working_lines:
                         return build_apply_candidate_previews(
                             batch_name=selector.batch_name,
@@ -137,11 +129,11 @@ def build_batch_source_candidate_previews(
                             source_lines=source_for_candidates,
                             ownership=candidate_ownership,
                             worktree_lines=working_lines,
-                            batch_source_commit=batch_source_commit,
+                            batch_source_commit=batch_source_ref.commit,
                             file_meta=file_meta,
-                            text_change_type=text_change_type,
-                            worktree_file_mode=worktree_file_mode,
-                            worktree_exists=working_exists,
+                            text_change_type=worktree_target.text_change_type,
+                            worktree_file_mode=worktree_target.file_mode,
+                            worktree_exists=worktree_target.exists,
                             selected_ids=selected_ids,
                             selection_ids=selection_ids_to_apply,
                         )
@@ -150,15 +142,10 @@ def build_batch_source_candidate_previews(
                 index_exists = index_buffer is not None
                 if index_buffer is None:
                     index_buffer = LineBuffer.from_bytes(b"")
-                index_file_mode = mode_for_text_materialization(
-                    batch_file_mode,
-                    selected_ids,
-                    destination_exists=index_exists,
-                )
-                worktree_file_mode = mode_for_text_materialization(
-                    batch_file_mode,
-                    selected_ids,
-                    destination_exists=working_exists,
+                index_target = _candidate_inputs.candidate_index_text_target(
+                    file_meta=file_meta,
+                    selected_ids=selected_ids,
+                    index_exists=index_exists,
                 )
                 with (
                     index_buffer as index_lines,
@@ -171,13 +158,13 @@ def build_batch_source_candidate_previews(
                         ownership=candidate_ownership,
                         index_lines=index_lines,
                         worktree_lines=working_lines,
-                        batch_source_commit=batch_source_commit,
+                        batch_source_commit=batch_source_ref.commit,
                         file_meta=file_meta,
-                        text_change_type=text_change_type,
-                        index_file_mode=index_file_mode,
-                        worktree_file_mode=worktree_file_mode,
-                        index_exists=index_exists,
-                        worktree_exists=working_exists,
+                        text_change_type=worktree_target.text_change_type,
+                        index_file_mode=index_target.file_mode,
+                        worktree_file_mode=worktree_target.file_mode,
+                        index_exists=index_target.exists,
+                        worktree_exists=worktree_target.exists,
                         selected_ids=selected_ids,
                         selection_ids=selection_ids_to_apply,
                         replacement_payload=replacement_payload,

--- a/src/git_stage_batch/commands/batch_source/candidate_preview_builders.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_preview_builders.py
@@ -1,0 +1,184 @@
+"""Candidate preview builders for batch-source commands."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from contextlib import ExitStack
+import os
+from typing import Any
+
+from ..selection import replacement_selection
+from ...batch.operation_candidates import (
+    OperationCandidatePreview,
+    build_apply_candidate_previews,
+    build_include_candidate_previews,
+)
+from ...batch.replacement import build_replacement_batch_view_from_lines
+from ...batch.selection import acquire_batch_ownership_for_display_ids_from_lines
+from ...batch.source_selector import BatchSourceSelector
+from ...batch.submodule_pointer import is_batch_submodule_pointer
+from ...core.buffer import LineBuffer
+from ...core.replacement import ReplacementPayload, coerce_replacement_payload
+from ...core.text_lifecycle import (
+    mode_for_text_materialization,
+    normalized_text_change_type,
+)
+from ...data.file_review.batch_selection import (
+    translate_batch_file_gutter_ids_to_selection_ids,
+)
+from ...data.file_review.records import FileReviewAction
+from ...utils.repository_buffers import (
+    load_git_object_as_buffer,
+    load_working_tree_file_as_buffer,
+)
+from ...exceptions import exit_with_error
+from ...i18n import _
+from ...utils.git import get_git_repository_root_path
+
+
+SelectionTranslator = Callable[
+    [str, str, set[int], FileReviewAction],
+    tuple[set[int], Any],
+]
+
+
+def build_batch_source_candidate_previews(
+    *,
+    selector: BatchSourceSelector,
+    files: dict,
+    file_path: str,
+    selected_ids: set[int] | None,
+    replacement_text: str | ReplacementPayload | None,
+    translate_selection_ids: SelectionTranslator = (
+        translate_batch_file_gutter_ids_to_selection_ids
+    ),
+) -> tuple[OperationCandidatePreview, ...]:
+    """Return operation candidates for a batch-source candidate selector."""
+    operation = selector.candidate_operation
+    if operation is None:
+        raise ValueError("Candidate preview requires a candidate selector.")
+
+    file_meta = files[file_path]
+    if file_meta.get("file_type") == "binary" or is_batch_submodule_pointer(file_meta):
+        exit_with_error(
+            _("Candidate preview is only available for text batch entries.")
+        )
+
+    batch_source_commit = file_meta["batch_source_commit"]
+    batch_source_buffer = load_git_object_as_buffer(f"{batch_source_commit}:{file_path}")
+    if batch_source_buffer is None:
+        exit_with_error(
+            _("Batch source content is missing for {file}.").format(file=file_path)
+        )
+
+    repo_root = get_git_repository_root_path()
+    full_path = repo_root / file_path
+    working_exists = os.path.lexists(full_path)
+    text_change_type = normalized_text_change_type(file_meta.get("change_type"))
+    batch_file_mode = str(file_meta.get("mode", "100644"))
+
+    with batch_source_buffer as batch_source_lines:
+        selection_ids_to_apply = selected_ids
+        if selected_ids:
+            action = (
+                FileReviewAction.APPLY_FROM_BATCH
+                if operation == "apply"
+                else FileReviewAction.INCLUDE_FROM_BATCH
+            )
+            selection_ids_to_apply, _rendered = translate_selection_ids(
+                selector.batch_name,
+                file_path,
+                selected_ids,
+                action,
+            )
+
+        with acquire_batch_ownership_for_display_ids_from_lines(
+            file_meta,
+            batch_source_lines,
+            selection_ids_to_apply,
+        ) as ownership:
+            with ExitStack() as stack:
+                source_for_candidates = batch_source_lines
+                candidate_ownership = ownership
+                replacement_payload = None
+                if replacement_text is not None:
+                    if operation == "apply":
+                        exit_with_error(
+                            _("Replacement preview is not valid for apply candidates.")
+                        )
+                    if not selected_ids:
+                        exit_with_error(_("`show --from --as` requires `--line`."))
+                    replacement_selection.require_contiguous_display_selection(
+                        selected_ids,
+                    )
+                    replacement_payload = coerce_replacement_payload(replacement_text)
+                    try:
+                        replacement_view = build_replacement_batch_view_from_lines(
+                            batch_source_lines,
+                            ownership,
+                            replacement_payload,
+                        )
+                    except ValueError as e:
+                        exit_with_error(str(e))
+                    replacement_view = stack.enter_context(replacement_view)
+                    source_for_candidates = replacement_view.source_buffer
+                    candidate_ownership = replacement_view.ownership
+
+                if operation == "apply":
+                    worktree_file_mode = mode_for_text_materialization(
+                        batch_file_mode,
+                        selected_ids,
+                        destination_exists=working_exists,
+                    )
+                    with load_working_tree_file_as_buffer(file_path) as working_lines:
+                        return build_apply_candidate_previews(
+                            batch_name=selector.batch_name,
+                            file_path=file_path,
+                            source_lines=source_for_candidates,
+                            ownership=candidate_ownership,
+                            worktree_lines=working_lines,
+                            batch_source_commit=batch_source_commit,
+                            file_meta=file_meta,
+                            text_change_type=text_change_type,
+                            worktree_file_mode=worktree_file_mode,
+                            worktree_exists=working_exists,
+                            selected_ids=selected_ids,
+                            selection_ids=selection_ids_to_apply,
+                        )
+
+                index_buffer = load_git_object_as_buffer(f":{file_path}")
+                index_exists = index_buffer is not None
+                if index_buffer is None:
+                    index_buffer = LineBuffer.from_bytes(b"")
+                index_file_mode = mode_for_text_materialization(
+                    batch_file_mode,
+                    selected_ids,
+                    destination_exists=index_exists,
+                )
+                worktree_file_mode = mode_for_text_materialization(
+                    batch_file_mode,
+                    selected_ids,
+                    destination_exists=working_exists,
+                )
+                with (
+                    index_buffer as index_lines,
+                    load_working_tree_file_as_buffer(file_path) as working_lines,
+                ):
+                    return build_include_candidate_previews(
+                        batch_name=selector.batch_name,
+                        file_path=file_path,
+                        source_lines=source_for_candidates,
+                        ownership=candidate_ownership,
+                        index_lines=index_lines,
+                        worktree_lines=working_lines,
+                        batch_source_commit=batch_source_commit,
+                        file_meta=file_meta,
+                        text_change_type=text_change_type,
+                        index_file_mode=index_file_mode,
+                        worktree_file_mode=worktree_file_mode,
+                        index_exists=index_exists,
+                        worktree_exists=working_exists,
+                        selected_ids=selected_ids,
+                        selection_ids=selection_ids_to_apply,
+                        replacement_payload=replacement_payload,
+                    )

--- a/src/git_stage_batch/commands/batch_source/candidate_preview_counts.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_preview_counts.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from contextlib import ExitStack
 import os
 
 from . import candidate_previews as _candidate_previews
@@ -9,9 +10,13 @@ from ...batch.operation_candidates import (
     CandidateEnumerationLimitError,
     CandidatePreviewCount,
     build_apply_candidate_previews,
+    build_include_candidate_previews,
 )
+from ...batch.replacement import build_replacement_batch_view_from_lines
 from ...batch.selection import acquire_batch_ownership_for_display_ids_from_lines
 from ...batch.submodule_pointer import is_batch_submodule_pointer
+from ...core.buffer import LineBuffer
+from ...core.replacement import ReplacementPayload
 from ...core.text_lifecycle import (
     mode_for_text_materialization,
     normalized_text_change_type,
@@ -75,6 +80,97 @@ def count_apply_candidate_previews_for_file(
                     selected_ids=selection_ids_to_apply,
                     selection_ids=selection_ids_to_apply,
                 )
+                count = len(previews)
+                _candidate_previews.close_candidate_previews(previews)
+                return CandidatePreviewCount(count=count)
+    except CandidateEnumerationLimitError as e:
+        return CandidatePreviewCount(too_many=True, error=str(e))
+    except MergeError:
+        return CandidatePreviewCount()
+    except Exception as e:
+        return CandidatePreviewCount(error=str(e))
+
+
+def count_include_candidate_previews_for_file(
+    *,
+    batch_name: str,
+    file_path: str,
+    file_meta: dict,
+    selection_ids_to_include: set[int] | None,
+    replacement_payload: ReplacementPayload | None,
+) -> CandidatePreviewCount:
+    """Return previewable include candidate counts for one text batch file."""
+    if file_meta.get("file_type") == "binary" or is_batch_submodule_pointer(file_meta):
+        return CandidatePreviewCount()
+    batch_source_commit = file_meta.get("batch_source_commit")
+    if not batch_source_commit:
+        return CandidatePreviewCount()
+    batch_source_buffer = load_git_object_as_buffer(f"{batch_source_commit}:{file_path}")
+    if batch_source_buffer is None:
+        return CandidatePreviewCount()
+
+    index_buffer = load_git_object_as_buffer(f":{file_path}")
+    index_exists = index_buffer is not None
+    if index_buffer is None:
+        index_buffer = LineBuffer.from_bytes(b"")
+
+    repo_root = get_git_repository_root_path()
+    full_path = repo_root / file_path
+    working_exists = os.path.lexists(full_path)
+    text_change_type = normalized_text_change_type(file_meta.get("change_type"))
+    batch_file_mode = str(file_meta.get("mode", "100644"))
+    index_file_mode = mode_for_text_materialization(
+        batch_file_mode,
+        selection_ids_to_include,
+        destination_exists=index_exists,
+    )
+    working_file_mode = mode_for_text_materialization(
+        batch_file_mode,
+        selection_ids_to_include,
+        destination_exists=working_exists,
+    )
+
+    try:
+        with (
+            batch_source_buffer as batch_source_lines,
+            index_buffer as index_lines,
+            load_working_tree_file_as_buffer(file_path) as working_lines,
+        ):
+            with acquire_batch_ownership_for_display_ids_from_lines(
+                file_meta,
+                batch_source_lines,
+                selection_ids_to_include,
+            ) as ownership:
+                with ExitStack() as stack:
+                    source_for_candidates = batch_source_lines
+                    candidate_ownership = ownership
+                    if replacement_payload is not None:
+                        replacement_view = build_replacement_batch_view_from_lines(
+                            batch_source_lines,
+                            ownership,
+                            replacement_payload,
+                        )
+                        replacement_view = stack.enter_context(replacement_view)
+                        source_for_candidates = replacement_view.source_buffer
+                        candidate_ownership = replacement_view.ownership
+                    previews = build_include_candidate_previews(
+                        batch_name=batch_name,
+                        file_path=file_path,
+                        source_lines=source_for_candidates,
+                        ownership=candidate_ownership,
+                        index_lines=index_lines,
+                        worktree_lines=working_lines,
+                        batch_source_commit=batch_source_commit,
+                        file_meta=file_meta,
+                        text_change_type=text_change_type,
+                        index_file_mode=index_file_mode,
+                        worktree_file_mode=working_file_mode,
+                        index_exists=index_exists,
+                        worktree_exists=working_exists,
+                        selected_ids=selection_ids_to_include,
+                        selection_ids=selection_ids_to_include,
+                        replacement_payload=replacement_payload,
+                    )
                 count = len(previews)
                 _candidate_previews.close_candidate_previews(previews)
                 return CandidatePreviewCount(count=count)

--- a/src/git_stage_batch/commands/batch_source/candidate_preview_counts.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_preview_counts.py
@@ -1,0 +1,86 @@
+"""Candidate preview counting for batch-source action commands."""
+
+from __future__ import annotations
+
+import os
+
+from . import candidate_previews as _candidate_previews
+from ...batch.operation_candidates import (
+    CandidateEnumerationLimitError,
+    CandidatePreviewCount,
+    build_apply_candidate_previews,
+)
+from ...batch.selection import acquire_batch_ownership_for_display_ids_from_lines
+from ...batch.submodule_pointer import is_batch_submodule_pointer
+from ...core.text_lifecycle import (
+    mode_for_text_materialization,
+    normalized_text_change_type,
+)
+from ...utils.repository_buffers import (
+    load_git_object_as_buffer,
+    load_working_tree_file_as_buffer,
+)
+from ...exceptions import MergeError
+from ...utils.git import get_git_repository_root_path
+
+
+def count_apply_candidate_previews_for_file(
+    *,
+    batch_name: str,
+    file_path: str,
+    file_meta: dict,
+    selection_ids_to_apply: set[int] | None,
+) -> CandidatePreviewCount:
+    """Return previewable apply candidate counts for one text batch file."""
+    if file_meta.get("file_type") == "binary" or is_batch_submodule_pointer(file_meta):
+        return CandidatePreviewCount()
+    batch_source_commit = file_meta.get("batch_source_commit")
+    if not batch_source_commit:
+        return CandidatePreviewCount()
+    batch_source_buffer = load_git_object_as_buffer(f"{batch_source_commit}:{file_path}")
+    if batch_source_buffer is None:
+        return CandidatePreviewCount()
+
+    repo_root = get_git_repository_root_path()
+    full_path = repo_root / file_path
+    working_exists = os.path.lexists(full_path)
+    file_mode = mode_for_text_materialization(
+        str(file_meta.get("mode", "100644")),
+        selection_ids_to_apply,
+        destination_exists=working_exists,
+    )
+    text_change_type = normalized_text_change_type(file_meta.get("change_type"))
+
+    try:
+        with (
+            batch_source_buffer as batch_source_lines,
+            load_working_tree_file_as_buffer(file_path) as working_lines,
+        ):
+            with acquire_batch_ownership_for_display_ids_from_lines(
+                file_meta,
+                batch_source_lines,
+                selection_ids_to_apply,
+            ) as ownership:
+                previews = build_apply_candidate_previews(
+                    batch_name=batch_name,
+                    file_path=file_path,
+                    source_lines=batch_source_lines,
+                    ownership=ownership,
+                    worktree_lines=working_lines,
+                    batch_source_commit=batch_source_commit,
+                    file_meta=file_meta,
+                    text_change_type=text_change_type,
+                    worktree_file_mode=file_mode,
+                    worktree_exists=working_exists,
+                    selected_ids=selection_ids_to_apply,
+                    selection_ids=selection_ids_to_apply,
+                )
+                count = len(previews)
+                _candidate_previews.close_candidate_previews(previews)
+                return CandidatePreviewCount(count=count)
+    except CandidateEnumerationLimitError as e:
+        return CandidatePreviewCount(too_many=True, error=str(e))
+    except MergeError:
+        return CandidatePreviewCount()
+    except Exception as e:
+        return CandidatePreviewCount(error=str(e))

--- a/src/git_stage_batch/commands/batch_source/candidate_preview_counts.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_preview_counts.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 from contextlib import ExitStack
-import os
 
+from . import candidate_inputs as _candidate_inputs
 from . import candidate_previews as _candidate_previews
 from ...batch.operation_candidates import (
     CandidateEnumerationLimitError,
@@ -14,19 +14,13 @@ from ...batch.operation_candidates import (
 )
 from ...batch.replacement import build_replacement_batch_view_from_lines
 from ...batch.selection import acquire_batch_ownership_for_display_ids_from_lines
-from ...batch.submodule_pointer import is_batch_submodule_pointer
 from ...core.buffer import LineBuffer
 from ...core.replacement import ReplacementPayload
-from ...core.text_lifecycle import (
-    mode_for_text_materialization,
-    normalized_text_change_type,
-)
 from ...utils.repository_buffers import (
     load_git_object_as_buffer,
     load_working_tree_file_as_buffer,
 )
 from ...exceptions import MergeError
-from ...utils.git import get_git_repository_root_path
 
 
 def count_apply_candidate_previews_for_file(
@@ -37,24 +31,20 @@ def count_apply_candidate_previews_for_file(
     selection_ids_to_apply: set[int] | None,
 ) -> CandidatePreviewCount:
     """Return previewable apply candidate counts for one text batch file."""
-    if file_meta.get("file_type") == "binary" or is_batch_submodule_pointer(file_meta):
+    if not _candidate_inputs.is_text_candidate_entry(file_meta):
         return CandidatePreviewCount()
-    batch_source_commit = file_meta.get("batch_source_commit")
-    if not batch_source_commit:
+    batch_source_ref = _candidate_inputs.candidate_batch_source_ref(file_path, file_meta)
+    if batch_source_ref is None:
         return CandidatePreviewCount()
-    batch_source_buffer = load_git_object_as_buffer(f"{batch_source_commit}:{file_path}")
+    batch_source_buffer = load_git_object_as_buffer(batch_source_ref.object_spec)
     if batch_source_buffer is None:
         return CandidatePreviewCount()
 
-    repo_root = get_git_repository_root_path()
-    full_path = repo_root / file_path
-    working_exists = os.path.lexists(full_path)
-    file_mode = mode_for_text_materialization(
-        str(file_meta.get("mode", "100644")),
-        selection_ids_to_apply,
-        destination_exists=working_exists,
+    worktree_target = _candidate_inputs.candidate_worktree_text_target(
+        file_path=file_path,
+        file_meta=file_meta,
+        selected_ids=selection_ids_to_apply,
     )
-    text_change_type = normalized_text_change_type(file_meta.get("change_type"))
 
     try:
         with (
@@ -72,11 +62,11 @@ def count_apply_candidate_previews_for_file(
                     source_lines=batch_source_lines,
                     ownership=ownership,
                     worktree_lines=working_lines,
-                    batch_source_commit=batch_source_commit,
+                    batch_source_commit=batch_source_ref.commit,
                     file_meta=file_meta,
-                    text_change_type=text_change_type,
-                    worktree_file_mode=file_mode,
-                    worktree_exists=working_exists,
+                    text_change_type=worktree_target.text_change_type,
+                    worktree_file_mode=worktree_target.file_mode,
+                    worktree_exists=worktree_target.exists,
                     selected_ids=selection_ids_to_apply,
                     selection_ids=selection_ids_to_apply,
                 )
@@ -100,12 +90,12 @@ def count_include_candidate_previews_for_file(
     replacement_payload: ReplacementPayload | None,
 ) -> CandidatePreviewCount:
     """Return previewable include candidate counts for one text batch file."""
-    if file_meta.get("file_type") == "binary" or is_batch_submodule_pointer(file_meta):
+    if not _candidate_inputs.is_text_candidate_entry(file_meta):
         return CandidatePreviewCount()
-    batch_source_commit = file_meta.get("batch_source_commit")
-    if not batch_source_commit:
+    batch_source_ref = _candidate_inputs.candidate_batch_source_ref(file_path, file_meta)
+    if batch_source_ref is None:
         return CandidatePreviewCount()
-    batch_source_buffer = load_git_object_as_buffer(f"{batch_source_commit}:{file_path}")
+    batch_source_buffer = load_git_object_as_buffer(batch_source_ref.object_spec)
     if batch_source_buffer is None:
         return CandidatePreviewCount()
 
@@ -114,20 +104,15 @@ def count_include_candidate_previews_for_file(
     if index_buffer is None:
         index_buffer = LineBuffer.from_bytes(b"")
 
-    repo_root = get_git_repository_root_path()
-    full_path = repo_root / file_path
-    working_exists = os.path.lexists(full_path)
-    text_change_type = normalized_text_change_type(file_meta.get("change_type"))
-    batch_file_mode = str(file_meta.get("mode", "100644"))
-    index_file_mode = mode_for_text_materialization(
-        batch_file_mode,
-        selection_ids_to_include,
-        destination_exists=index_exists,
+    index_target = _candidate_inputs.candidate_index_text_target(
+        file_meta=file_meta,
+        selected_ids=selection_ids_to_include,
+        index_exists=index_exists,
     )
-    working_file_mode = mode_for_text_materialization(
-        batch_file_mode,
-        selection_ids_to_include,
-        destination_exists=working_exists,
+    worktree_target = _candidate_inputs.candidate_worktree_text_target(
+        file_path=file_path,
+        file_meta=file_meta,
+        selected_ids=selection_ids_to_include,
     )
 
     try:
@@ -160,13 +145,13 @@ def count_include_candidate_previews_for_file(
                         ownership=candidate_ownership,
                         index_lines=index_lines,
                         worktree_lines=working_lines,
-                        batch_source_commit=batch_source_commit,
+                        batch_source_commit=batch_source_ref.commit,
                         file_meta=file_meta,
-                        text_change_type=text_change_type,
-                        index_file_mode=index_file_mode,
-                        worktree_file_mode=working_file_mode,
-                        index_exists=index_exists,
-                        worktree_exists=working_exists,
+                        text_change_type=worktree_target.text_change_type,
+                        index_file_mode=index_target.file_mode,
+                        worktree_file_mode=worktree_target.file_mode,
+                        index_exists=index_target.exists,
+                        worktree_exists=worktree_target.exists,
                         selected_ids=selection_ids_to_include,
                         selection_ids=selection_ids_to_include,
                         replacement_payload=replacement_payload,

--- a/src/git_stage_batch/commands/batch_source/candidate_previews.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_previews.py
@@ -8,6 +8,8 @@ from ...batch.operation_candidates import (
     OperationCandidatePreview,
     load_candidate_preview_state,
 )
+from ...exceptions import CommandError
+from ...i18n import _
 
 
 def candidate_preview_for_ordinal(
@@ -18,6 +20,31 @@ def candidate_preview_for_ordinal(
     if ordinal < 1 or ordinal > len(previews):
         return None
     return previews[ordinal - 1]
+
+
+def require_candidate_preview_for_ordinal(
+    previews: Sequence[OperationCandidatePreview],
+    ordinal: int,
+    *,
+    batch_name: str,
+    operation: str,
+    file_path: str,
+) -> OperationCandidatePreview:
+    """Return the preview for a one-based ordinal or raise a command error."""
+    preview = candidate_preview_for_ordinal(previews, ordinal)
+    if preview is not None:
+        return preview
+    if ordinal < 1:
+        raise CommandError(_("Candidate ordinal must be at least 1."))
+    raise CommandError(
+        _("Batch '{batch}' has {count} {operation} candidates for {file}; candidate {ordinal} does not exist.").format(
+            batch=batch_name,
+            count=len(previews),
+            operation=operation,
+            file=file_path,
+            ordinal=ordinal,
+        )
+    )
 
 
 def candidate_preview_state_matches(
@@ -33,6 +60,26 @@ def candidate_preview_state_matches(
         and state.get("target_fingerprints") == preview.target_fingerprints
         and state.get("target_result_fingerprints")
         == preview.target_result_fingerprints
+    )
+
+
+def require_candidate_preview_state(
+    preview: OperationCandidatePreview,
+    ordinal: int,
+    *,
+    selector: str,
+    file_path: str,
+) -> None:
+    """Raise a command error when the stored preview state is stale or missing."""
+    if candidate_preview_state_matches(preview, ordinal):
+        return
+    raise CommandError(
+        _(
+            "Candidate selector '{selector}' has not been previewed for {file}.\n"
+            "No changes applied.\n\n"
+            "Preview it first with:\n"
+            "  git-stage-batch show --from {selector} --file {file}"
+        ).format(selector=selector, file=file_path)
     )
 
 

--- a/src/git_stage_batch/commands/batch_source/candidate_refusals.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_refusals.py
@@ -1,0 +1,125 @@
+"""Candidate refusal helpers for batch-source commands."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+from ...batch.operation_candidates import CandidatePreviewCount
+from ...exceptions import exit_with_error
+from ...i18n import _
+
+
+def refuse_candidate_conflicts(
+    *,
+    batch_name: str,
+    operation: str,
+    failed_files: Sequence[str],
+    candidate_counts: Mapping[str, CandidatePreviewCount],
+) -> None:
+    """Exit when merge failures have candidate preview refusal details."""
+    candidate_limit_files = [
+        file_path
+        for file_path in failed_files
+        if candidate_counts.get(file_path, CandidatePreviewCount()).too_many
+    ]
+    if len(candidate_limit_files) == 1:
+        file_path = candidate_limit_files[0]
+        exit_with_error(
+            _(
+                "Cannot {operation} batch '{batch}': {file} has too many "
+                "{operation} candidates to preview safely.\n"
+                "No changes applied.\n\n"
+                "Use --line with a narrower selection or split the batch "
+                "before previewing candidates."
+            ).format(operation=operation, batch=batch_name, file=file_path)
+        )
+    if len(candidate_limit_files) > 1:
+        exit_with_error(
+            _(
+                "Cannot {operation} batch '{batch}': multiple files have too "
+                "many {operation} candidates to preview safely.\n"
+                "No changes applied.\n\n"
+                "Use --line with narrower selections or split the batch "
+                "before previewing candidates."
+            ).format(operation=operation, batch=batch_name)
+        )
+
+    candidate_error_files = [
+        file_path
+        for file_path in failed_files
+        if (
+            candidate_counts.get(file_path, CandidatePreviewCount()).error
+            and not candidate_counts.get(file_path, CandidatePreviewCount()).too_many
+        )
+    ]
+    if len(candidate_error_files) == 1:
+        file_path = candidate_error_files[0]
+        error = candidate_counts[file_path].error
+        exit_with_error(
+            _(
+                "Cannot enumerate {operation} candidates for {file}: {error}\n"
+                "No changes applied."
+            ).format(operation=operation, file=file_path, error=error)
+        )
+    if len(candidate_error_files) > 1:
+        examples = "\n".join(
+            f"  {file_path}: {candidate_counts[file_path].error}"
+            for file_path in candidate_error_files[:3]
+        )
+        exit_with_error(
+            _(
+                "Cannot enumerate {operation} candidates for multiple files.\n"
+                "No changes applied.\n\n"
+                "{examples}"
+            ).format(operation=operation, examples=examples)
+        )
+
+    ambiguous_files = [
+        file_path
+        for file_path in failed_files
+        if candidate_counts.get(file_path, CandidatePreviewCount()).count
+    ]
+    if len(ambiguous_files) == 1:
+        file_path = ambiguous_files[0]
+        reviewed_action = _reviewed_action_label(operation)
+        exit_with_error(
+            _(
+                "Cannot {operation} batch '{batch}': {file} has {count} "
+                "{operation} candidates.\n"
+                "No changes applied.\n\n"
+                "Preview candidates:\n"
+                "  git-stage-batch show --from {batch}:{operation} --file {file}\n\n"
+                "{reviewed_action} a reviewed candidate:\n"
+                "  git-stage-batch {operation} --from {batch}:{operation}:N --file {file}"
+            ).format(
+                operation=operation,
+                batch=batch_name,
+                file=file_path,
+                count=candidate_counts[file_path].count,
+                reviewed_action=reviewed_action,
+            )
+        )
+    if len(ambiguous_files) > 1:
+        examples = "\n".join(
+            (
+                f"  git-stage-batch show --from {batch_name}:{operation} "
+                f"--file {file_path}"
+            )
+            for file_path in ambiguous_files[:3]
+        )
+        exit_with_error(
+            _(
+                "Cannot {operation} batch '{batch}': multiple files need "
+                "{operation} decisions.\n"
+                "No changes applied.\n\n"
+                "Resolve one file at a time:\n{examples}"
+            ).format(operation=operation, batch=batch_name, examples=examples)
+        )
+
+
+def _reviewed_action_label(operation: str) -> str:
+    if operation == "apply":
+        return _("Apply")
+    if operation == "include":
+        return _("Include")
+    return operation.capitalize()

--- a/src/git_stage_batch/commands/batch_source/candidate_selectors.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_selectors.py
@@ -1,0 +1,51 @@
+"""Candidate selector helpers for batch-source action commands."""
+
+from __future__ import annotations
+
+from ...batch.source_selector import (
+    BatchSourceSelector,
+    CandidateOperation,
+    parse_batch_source_selector,
+    require_candidate_operation,
+)
+from ...exceptions import exit_with_error
+from ...i18n import _
+
+
+def resolve_batch_source_action_selector(
+    raw_selector: str,
+    expected_operation: CandidateOperation,
+    *,
+    file: str | None,
+) -> BatchSourceSelector:
+    """Parse and validate a batch-source selector for an action command."""
+    selector = parse_batch_source_selector(raw_selector)
+    require_candidate_operation(
+        selector,
+        expected_operation,
+        raw_value=raw_selector,
+        file=file,
+    )
+    if (
+        selector.candidate_operation == expected_operation
+        and selector.candidate_ordinal is None
+    ):
+        exit_with_error(
+            _(
+                "'{selector}' names the {operation} candidate preview set.\n"
+                "Use 'git-stage-batch show --from {selector}' to preview candidates, "
+                "or use '{batch}:{operation}:N' to {operation} a candidate."
+            ).format(
+                selector=raw_selector,
+                batch=selector.batch_name,
+                operation=expected_operation,
+            )
+        )
+    if selector.candidate_ordinal is not None and file is None:
+        exit_with_error(
+            _(
+                "Candidate selector '{selector}' requires --file in this implementation.\n"
+                "No changes applied."
+            ).format(selector=raw_selector)
+        )
+    return selector

--- a/src/git_stage_batch/commands/batch_source/merge_refusals.py
+++ b/src/git_stage_batch/commands/batch_source/merge_refusals.py
@@ -1,0 +1,51 @@
+"""Merge refusal helpers for batch-source commands."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from ...batch.file_display import render_batch_file_display
+from ...exceptions import exit_with_error
+from ...i18n import _
+
+
+def refuse_batch_source_merge_failures(
+    *,
+    batch_name: str,
+    failed_files: Sequence[str],
+) -> None:
+    """Exit for merge failures without enumerable candidate details."""
+    if len(failed_files) == 1:
+        file_path = failed_files[0]
+        rendered = render_batch_file_display(batch_name, file_path)
+        has_mergeable_lines = (
+            rendered is not None and len(rendered.gutter_to_selection_id) > 0
+        )
+
+        if has_mergeable_lines:
+            error_msg = _(
+                "Batch '{batch}' contains changes to {file} that are "
+                "incompatible with the current working tree. "
+                "Use 'git-stage-batch show --from {batch}' to review the batch, "
+                "or use '--lines' to apply only specific changes."
+            ).format(batch=batch_name, file=file_path)
+        else:
+            error_msg = _(
+                "Batch '{batch}' contains changes to {file} that are "
+                "incompatible with the current working tree. "
+                "Use 'git-stage-batch show --from {batch}' to review the batch."
+            ).format(batch=batch_name, file=file_path)
+        exit_with_error(error_msg)
+
+    exit_with_error(
+        _(
+            "Batch '{batch}' contains changes to one or more files that are "
+            "incompatible with the current working tree. "
+            "Failed for: {files}. "
+            "Use 'git-stage-batch show --from {batch}' to review the batch, "
+            "or use '--lines' to apply only specific changes."
+        ).format(
+            batch=batch_name,
+            files=", ".join(failed_files),
+        )
+    )

--- a/src/git_stage_batch/commands/batch_source/replacement_previews.py
+++ b/src/git_stage_batch/commands/batch_source/replacement_previews.py
@@ -1,0 +1,94 @@
+"""Replacement preview rendering for batch-source commands."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from ..selection import replacement_selection
+from ...batch.operation_candidates import render_candidate_buffer_diff
+from ...batch.replacement import build_replacement_batch_view_from_lines
+from ...batch.selection import acquire_batch_ownership_for_display_ids_from_lines
+from ...batch.submodule_pointer import is_batch_submodule_pointer
+from ...core.buffer import LineBuffer
+from ...core.replacement import ReplacementPayload, coerce_replacement_payload
+from ...data.file_review.batch_selection import (
+    translate_batch_file_gutter_ids_to_selection_ids,
+)
+from ...data.file_review.records import FileReviewAction
+from ...utils.repository_buffers import load_git_object_as_buffer
+from ...exceptions import exit_with_error
+from ...i18n import _
+from ...utils.paths import get_context_lines
+
+
+SelectionTranslator = Callable[
+    [str, str, set[int], FileReviewAction],
+    tuple[set[int], Any],
+]
+
+
+def print_batch_source_replacement_preview(
+    *,
+    batch_name: str,
+    files: dict,
+    file_path: str,
+    selected_ids: set[int],
+    replacement_text: str | ReplacementPayload,
+    translate_selection_ids: SelectionTranslator = (
+        translate_batch_file_gutter_ids_to_selection_ids
+    ),
+) -> None:
+    """Print a diff preview for replacing selected batch-source lines."""
+    file_meta = files[file_path]
+    if file_meta.get("file_type") == "binary":
+        exit_with_error(_("Cannot preview replacement text for binary files."))
+    if is_batch_submodule_pointer(file_meta):
+        exit_with_error(_("Cannot preview replacement text for submodule pointers."))
+
+    replacement_selection.require_contiguous_display_selection(selected_ids)
+    batch_source_commit = file_meta["batch_source_commit"]
+    batch_source_buffer = load_git_object_as_buffer(f"{batch_source_commit}:{file_path}")
+    if batch_source_buffer is None:
+        exit_with_error(
+            _("Batch source content is missing for {file}.").format(file=file_path)
+        )
+
+    with batch_source_buffer as batch_source_lines:
+        selection_ids, _rendered = translate_selection_ids(
+            batch_name,
+            file_path,
+            selected_ids,
+            FileReviewAction.INCLUDE_FROM_BATCH,
+        )
+        with acquire_batch_ownership_for_display_ids_from_lines(
+            file_meta,
+            batch_source_lines,
+            selection_ids,
+        ) as ownership:
+            try:
+                replacement_view = build_replacement_batch_view_from_lines(
+                    batch_source_lines,
+                    ownership,
+                    coerce_replacement_payload(replacement_text),
+                )
+            except ValueError as e:
+                exit_with_error(str(e))
+            with replacement_view:
+                before = LineBuffer.from_bytes(batch_source_buffer.to_bytes())
+                try:
+                    diff_text = render_candidate_buffer_diff(
+                        file_path,
+                        before,
+                        replacement_view.source_buffer,
+                        label_before="batch",
+                        label_after="replacement-preview",
+                        context_lines=get_context_lines(),
+                    )
+                    if diff_text:
+                        print(
+                            diff_text,
+                            end="" if diff_text.endswith("\n") else "\n",
+                        )
+                finally:
+                    before.close()

--- a/src/git_stage_batch/commands/batch_source/text_plan_builders.py
+++ b/src/git_stage_batch/commands/batch_source/text_plan_builders.py
@@ -7,7 +7,10 @@ from dataclasses import dataclass
 import os
 
 from . import action_plans as _action_plans
-from ...batch.merge import merge_batch_from_line_sequences_as_buffer
+from ...batch.merge import (
+    discard_batch_from_line_sequences_as_buffer,
+    merge_batch_from_line_sequences_as_buffer,
+)
 from ...batch.replacement import build_replacement_batch_view_from_lines
 from ...batch.selection import acquire_batch_ownership_for_display_ids_from_lines
 from ...core.buffer import LineBuffer
@@ -16,8 +19,10 @@ from ...core.text_lifecycle import (
     TextFileChangeType,
     mode_for_text_materialization,
     normalized_text_change_type,
+    selected_text_discard_change_type,
     selected_text_target_change_type,
 )
+from ...data.file_modes import detect_file_mode_in_commit
 from ...utils.repository_buffers import (
     load_git_object_as_buffer,
     load_working_tree_file_as_buffer,
@@ -38,6 +43,14 @@ class IncludeTextPlanBuildResult:
     """Result of building one include-from text action plan."""
 
     plan: _action_plans.IncludeTextFileActionPlan | None = None
+    missing_source: bool = False
+
+
+@dataclass(frozen=True)
+class DiscardTextPlanBuildResult:
+    """Result of building one discard-from text action plan."""
+
+    plan: _action_plans.DiscardTextFileActionPlan | None = None
     missing_source: bool = False
 
 
@@ -248,3 +261,111 @@ def build_include_text_file_action_plan(
     except Exception:
         _close_include_merge_buffers(merged_index_buffer, merged_working_buffer)
         raise
+
+
+def build_discard_text_file_action_plan(
+    *,
+    file_path: str,
+    file_meta: dict,
+    baseline_commit: str,
+    selected_ids: set[int] | None,
+    selection_ids_to_discard: set[int] | None,
+) -> DiscardTextPlanBuildResult:
+    """Build one deferred discard-from text action plan."""
+    text_change_type = normalized_text_change_type(file_meta.get("change_type"))
+    if selected_ids is None and text_change_type in {
+        TextFileChangeType.ADDED,
+        TextFileChangeType.DELETED,
+    }:
+        return DiscardTextPlanBuildResult(
+            plan=_build_baseline_restore_text_plan(
+                file_path=file_path,
+                baseline_commit=baseline_commit,
+            )
+        )
+
+    batch_source_commit = file_meta["batch_source_commit"]
+    batch_source_buffer = load_git_object_as_buffer(
+        f"{batch_source_commit}:{file_path}"
+    )
+    if batch_source_buffer is None:
+        return DiscardTextPlanBuildResult(missing_source=True)
+
+    baseline_buffer = load_git_object_as_buffer(f"{baseline_commit}:{file_path}")
+    baseline_exists = baseline_buffer is not None
+    if baseline_buffer is None:
+        baseline_buffer = LineBuffer.from_bytes(b"")
+
+    repo_root = get_git_repository_root_path()
+    working_exists = (repo_root / file_path).exists()
+    baseline_mode = detect_file_mode_in_commit(baseline_commit, file_path)
+    restore_mode = mode_for_text_materialization(
+        baseline_mode,
+        selected_ids,
+        destination_exists=working_exists,
+    )
+
+    discarded_buffer = None
+    try:
+        with (
+            batch_source_buffer as batch_source_lines,
+            baseline_buffer as baseline_lines,
+            load_working_tree_file_as_buffer(file_path) as working_lines,
+        ):
+            with acquire_batch_ownership_for_display_ids_from_lines(
+                file_meta,
+                batch_source_lines,
+                selection_ids_to_discard,
+            ) as ownership:
+                if ownership.is_empty():
+                    return DiscardTextPlanBuildResult()
+
+                discarded_buffer = discard_batch_from_line_sequences_as_buffer(
+                    batch_source_lines,
+                    ownership,
+                    working_lines,
+                    baseline_lines,
+                )
+
+        effective_change_type = selected_text_discard_change_type(
+            text_change_type,
+            selected_ids,
+            discarded_buffer,
+            baseline_exists=baseline_exists,
+        )
+        if effective_change_type == TextFileChangeType.DELETED:
+            discarded_buffer.close()
+            discarded_buffer = None
+        plan = _action_plans.DiscardTextFileActionPlan(
+            file_path,
+            discarded_buffer,
+            restore_mode,
+            effective_change_type,
+        )
+        discarded_buffer = None
+        return DiscardTextPlanBuildResult(plan=plan)
+    except Exception:
+        if discarded_buffer is not None:
+            discarded_buffer.close()
+        raise
+
+
+def _build_baseline_restore_text_plan(
+    *,
+    file_path: str,
+    baseline_commit: str,
+) -> _action_plans.DiscardTextFileActionPlan:
+    baseline_buffer = load_git_object_as_buffer(f"{baseline_commit}:{file_path}")
+    if baseline_buffer is None:
+        return _action_plans.DiscardTextFileActionPlan(
+            file_path,
+            None,
+            None,
+            TextFileChangeType.DELETED,
+        )
+    return _action_plans.DiscardTextFileActionPlan(
+        file_path,
+        baseline_buffer,
+        detect_file_mode_in_commit(baseline_commit, file_path),
+        TextFileChangeType.MODIFIED,
+    )

--- a/src/git_stage_batch/commands/batch_source/text_plan_builders.py
+++ b/src/git_stage_batch/commands/batch_source/text_plan_builders.py
@@ -1,0 +1,101 @@
+"""Text action plan builders for batch-source commands."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+
+from . import action_plans as _action_plans
+from ...batch.merge import merge_batch_from_line_sequences_as_buffer
+from ...batch.selection import acquire_batch_ownership_for_display_ids_from_lines
+from ...core.buffer import LineBuffer
+from ...core.text_lifecycle import (
+    TextFileChangeType,
+    mode_for_text_materialization,
+    normalized_text_change_type,
+    selected_text_target_change_type,
+)
+from ...utils.repository_buffers import (
+    load_git_object_as_buffer,
+    load_working_tree_file_as_buffer,
+)
+from ...utils.git import get_git_repository_root_path
+
+
+@dataclass(frozen=True)
+class ApplyTextPlanBuildResult:
+    """Result of building one apply-from text action plan."""
+
+    plan: _action_plans.ApplyTextFileActionPlan | None = None
+    missing_source: bool = False
+
+
+def build_apply_text_file_action_plan(
+    *,
+    file_path: str,
+    file_meta: dict,
+    selected_ids: set[int] | None,
+    selection_ids_to_apply: set[int] | None,
+) -> ApplyTextPlanBuildResult:
+    """Build one deferred apply-from text action plan."""
+    text_change_type = normalized_text_change_type(file_meta.get("change_type"))
+
+    repo_root = get_git_repository_root_path()
+    working_exists = os.path.lexists(repo_root / file_path)
+
+    file_mode = mode_for_text_materialization(
+        str(file_meta.get("mode", "100644")),
+        selected_ids,
+        destination_exists=working_exists,
+    )
+    if selected_ids is None and text_change_type == TextFileChangeType.DELETED:
+        return ApplyTextPlanBuildResult(
+            plan=_action_plans.ApplyTextFileActionPlan(
+                file_path,
+                None,
+                file_mode,
+                text_change_type,
+            )
+        )
+
+    batch_source_commit = file_meta["batch_source_commit"]
+    batch_source_buffer = load_git_object_as_buffer(
+        f"{batch_source_commit}:{file_path}"
+    )
+    if batch_source_buffer is None:
+        return ApplyTextPlanBuildResult(missing_source=True)
+
+    with (
+        batch_source_buffer as batch_source_lines,
+        load_working_tree_file_as_buffer(file_path) as working_lines,
+    ):
+        with acquire_batch_ownership_for_display_ids_from_lines(
+            file_meta,
+            batch_source_lines,
+            selection_ids_to_apply,
+        ) as ownership:
+            if ownership.is_empty():
+                if selected_ids is None and text_change_type == TextFileChangeType.ADDED:
+                    merged_buffer = LineBuffer.from_bytes(b"")
+                else:
+                    return ApplyTextPlanBuildResult()
+            else:
+                merged_buffer = merge_batch_from_line_sequences_as_buffer(
+                    batch_source_lines,
+                    ownership,
+                    working_lines,
+                )
+
+    effective_change_type = selected_text_target_change_type(
+        text_change_type,
+        selected_ids,
+        merged_buffer,
+    )
+    return ApplyTextPlanBuildResult(
+        plan=_action_plans.ApplyTextFileActionPlan(
+            file_path,
+            merged_buffer,
+            file_mode,
+            effective_change_type,
+        )
+    )

--- a/src/git_stage_batch/commands/batch_source/text_plan_builders.py
+++ b/src/git_stage_batch/commands/batch_source/text_plan_builders.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+from contextlib import ExitStack
 from dataclasses import dataclass
 import os
 
 from . import action_plans as _action_plans
 from ...batch.merge import merge_batch_from_line_sequences_as_buffer
+from ...batch.replacement import build_replacement_batch_view_from_lines
 from ...batch.selection import acquire_batch_ownership_for_display_ids_from_lines
 from ...core.buffer import LineBuffer
+from ...core.replacement import ReplacementPayload
 from ...core.text_lifecycle import (
     TextFileChangeType,
     mode_for_text_materialization,
@@ -28,6 +31,24 @@ class ApplyTextPlanBuildResult:
 
     plan: _action_plans.ApplyTextFileActionPlan | None = None
     missing_source: bool = False
+
+
+@dataclass(frozen=True)
+class IncludeTextPlanBuildResult:
+    """Result of building one include-from text action plan."""
+
+    plan: _action_plans.IncludeTextFileActionPlan | None = None
+    missing_source: bool = False
+
+
+def _close_include_merge_buffers(
+    index_buffer: LineBuffer | None,
+    working_buffer: LineBuffer | None,
+) -> None:
+    if index_buffer is not None:
+        index_buffer.close()
+    if working_buffer is not None and working_buffer is not index_buffer:
+        working_buffer.close()
 
 
 def build_apply_text_file_action_plan(
@@ -99,3 +120,131 @@ def build_apply_text_file_action_plan(
             effective_change_type,
         )
     )
+
+
+def build_include_text_file_action_plan(
+    *,
+    file_path: str,
+    file_meta: dict,
+    selected_ids: set[int] | None,
+    selection_ids_to_include: set[int] | None,
+    replacement_payload: ReplacementPayload | None,
+) -> IncludeTextPlanBuildResult:
+    """Build one deferred include-from text action plan."""
+    text_change_type = normalized_text_change_type(file_meta.get("change_type"))
+
+    index_buffer = load_git_object_as_buffer(f":{file_path}")
+    index_exists = index_buffer is not None
+    if index_buffer is None:
+        index_buffer = LineBuffer.from_bytes(b"")
+
+    repo_root = get_git_repository_root_path()
+    working_exists = os.path.lexists(repo_root / file_path)
+
+    batch_file_mode = str(file_meta.get("mode", "100644"))
+    index_file_mode = mode_for_text_materialization(
+        batch_file_mode,
+        selected_ids,
+        destination_exists=index_exists,
+    )
+    working_file_mode = mode_for_text_materialization(
+        batch_file_mode,
+        selected_ids,
+        destination_exists=working_exists,
+    )
+    if selected_ids is None and text_change_type == TextFileChangeType.DELETED:
+        index_buffer.close()
+        return IncludeTextPlanBuildResult(
+            plan=_action_plans.IncludeTextFileActionPlan(
+                file_path,
+                None,
+                None,
+                index_file_mode,
+                working_file_mode,
+                text_change_type,
+                text_change_type,
+            )
+        )
+
+    batch_source_commit = file_meta["batch_source_commit"]
+    batch_source_buffer = load_git_object_as_buffer(
+        f"{batch_source_commit}:{file_path}"
+    )
+    if batch_source_buffer is None:
+        index_buffer.close()
+        return IncludeTextPlanBuildResult(missing_source=True)
+
+    merged_index_buffer = None
+    merged_working_buffer = None
+    try:
+        with (
+            batch_source_buffer as batch_source_lines,
+            index_buffer as index_lines,
+            load_working_tree_file_as_buffer(file_path) as working_lines,
+        ):
+            with acquire_batch_ownership_for_display_ids_from_lines(
+                file_meta,
+                batch_source_lines,
+                selection_ids_to_include,
+            ) as ownership:
+                if ownership.is_empty():
+                    if (
+                        selected_ids is None
+                        and text_change_type == TextFileChangeType.ADDED
+                    ):
+                        merged_index_buffer = LineBuffer.from_bytes(b"")
+                        merged_working_buffer = LineBuffer.from_bytes(b"")
+                    else:
+                        return IncludeTextPlanBuildResult()
+                else:
+                    with ExitStack() as stack:
+                        source_lines = batch_source_lines
+                        merge_ownership = ownership
+                        if replacement_payload is not None:
+                            replacement_view = stack.enter_context(
+                                build_replacement_batch_view_from_lines(
+                                    batch_source_lines,
+                                    ownership,
+                                    replacement_payload,
+                                )
+                            )
+                            source_lines = replacement_view.source_buffer
+                            merge_ownership = replacement_view.ownership
+                        merged_index_buffer = merge_batch_from_line_sequences_as_buffer(
+                            source_lines,
+                            merge_ownership,
+                            index_lines,
+                        )
+                        merged_working_buffer = (
+                            merge_batch_from_line_sequences_as_buffer(
+                                source_lines,
+                                merge_ownership,
+                                working_lines,
+                            )
+                        )
+
+        index_change_type = selected_text_target_change_type(
+            text_change_type,
+            selected_ids,
+            merged_index_buffer,
+        )
+        working_change_type = selected_text_target_change_type(
+            text_change_type,
+            selected_ids,
+            merged_working_buffer,
+        )
+        plan = _action_plans.IncludeTextFileActionPlan(
+            file_path,
+            merged_index_buffer,
+            merged_working_buffer,
+            index_file_mode,
+            working_file_mode,
+            index_change_type,
+            working_change_type,
+        )
+        merged_index_buffer = None
+        merged_working_buffer = None
+        return IncludeTextPlanBuildResult(plan=plan)
+    except Exception:
+        _close_include_merge_buffers(merged_index_buffer, merged_working_buffer)
+        raise

--- a/src/git_stage_batch/commands/discard_from.py
+++ b/src/git_stage_batch/commands/discard_from.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-import stat
 import sys
-from pathlib import Path
 from typing import Optional
 
 from ..batch.merge import discard_batch_from_line_sequences_as_buffer
@@ -38,6 +36,7 @@ from ..core.buffer import (
     LineBuffer,
     write_buffer_to_path,
 )
+from ..data.file_modes import apply_git_file_mode, detect_file_mode_in_commit
 from ..utils.repository_buffers import (
     load_git_object_as_buffer,
     load_working_tree_file_as_buffer,
@@ -46,30 +45,7 @@ from ..data.session import snapshot_file_if_untracked
 from ..data.undo import undo_checkpoint
 from ..exceptions import exit_with_error, AtomicUnitError, CommandError, MergeError, BatchMetadataError
 from ..i18n import _
-from ..utils.git import get_git_repository_root_path, require_git_repository, run_git_command
-
-
-def _baseline_file_mode(baseline_commit: str, file_path: str) -> str | None:
-    """Return file mode for a path in the baseline tree, if present."""
-    result = run_git_command(
-        ["ls-tree", baseline_commit, "--", file_path],
-        check=False,
-        requires_index_lock=False,
-    )
-    if result.returncode != 0 or not result.stdout.strip():
-        return None
-    return result.stdout.split(maxsplit=1)[0]
-
-
-def _restore_working_tree_file_mode(file_path: Path, file_mode: str | None) -> None:
-    """Restore executable bits for a working-tree file from a Git file mode."""
-    if file_mode is None:
-        return
-    current_mode = file_path.stat().st_mode
-    if file_mode == "100755":
-        file_path.chmod(current_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
-    else:
-        file_path.chmod(current_mode & ~(stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH))
+from ..utils.git import get_git_repository_root_path, require_git_repository
 
 
 def _discard_binary_file_from_batch(file_path: str, baseline_commit: str) -> None:
@@ -94,9 +70,9 @@ def _discard_binary_file_from_batch(file_path: str, baseline_commit: str) -> Non
         # File exists in baseline - restore it
         with baseline_buffer:
             write_buffer_to_path(full_path, baseline_buffer)
-        _restore_working_tree_file_mode(
+        apply_git_file_mode(
             full_path,
-            _baseline_file_mode(baseline_commit, file_path),
+            detect_file_mode_in_commit(baseline_commit, file_path),
         )
         print(_("✓ Restored binary file to baseline: {file}").format(file=file_path), file=sys.stderr)
     else:
@@ -118,9 +94,9 @@ def _discard_text_file_lifecycle_from_batch(file_path: str, baseline_commit: str
     if baseline_buffer is not None:
         with baseline_buffer:
             write_buffer_to_path(full_path, baseline_buffer)
-        _restore_working_tree_file_mode(
+        apply_git_file_mode(
             full_path,
-            _baseline_file_mode(baseline_commit, file_path),
+            detect_file_mode_in_commit(baseline_commit, file_path),
         )
     elif full_path.exists():
         full_path.unlink()
@@ -252,7 +228,7 @@ def command_discard_from_batch(
 
                 full_path = repo_root / file_path
                 working_exists = full_path.exists()
-                baseline_mode = _baseline_file_mode(baseline_commit, file_path)
+                baseline_mode = detect_file_mode_in_commit(baseline_commit, file_path)
                 restore_mode = mode_for_text_materialization(
                     baseline_mode,
                     selected_ids,
@@ -299,7 +275,7 @@ def command_discard_from_batch(
                             full_path.unlink()
                     else:
                         write_buffer_to_path(full_path, discarded_buffer)
-                        _restore_working_tree_file_mode(full_path, restore_mode)
+                        apply_git_file_mode(full_path, restore_mode)
 
             except CommandError:
                 raise

--- a/src/git_stage_batch/commands/include_from.py
+++ b/src/git_stage_batch/commands/include_from.py
@@ -9,6 +9,7 @@ from typing import Optional
 
 from .batch_source import action_plans as _action_plans
 from .batch_source import binary_file_actions as _binary_file_actions
+from .batch_source import candidate_previews as _candidate_previews
 from .batch_source import text_file_actions as _text_file_actions
 from .selection import replacement_selection
 from ..batch.binary_file_content import read_binary_file_from_batch
@@ -19,7 +20,6 @@ from ..batch.operation_candidates import (
     CandidatePreviewCount,
     build_include_candidate_previews,
     clear_candidate_preview_state_for_file,
-    load_candidate_preview_state,
 )
 from ..batch.replacement import build_replacement_batch_view_from_lines
 from ..core.replacement import (
@@ -167,9 +167,12 @@ def _execute_include_candidate(
                 except (MergeError, ValueError) as e:
                     exit_with_error(str(e))
 
-            if ordinal < 1 or ordinal > len(previews):
-                for preview in previews:
-                    preview.close()
+            preview = _candidate_previews.candidate_preview_for_ordinal(
+                previews,
+                ordinal,
+            )
+            if preview is None:
+                _candidate_previews.close_candidate_previews(previews)
                 exit_with_error(
                     _("Batch '{batch}' has {count} include candidates for {file}; candidate {ordinal} does not exist.").format(
                         batch=batch_name,
@@ -179,15 +182,10 @@ def _execute_include_candidate(
                     )
                 )
 
-            preview = previews[ordinal - 1]
             try:
-                state = load_candidate_preview_state(preview)
-                if (
-                    state is None
-                    or state.get("ordinal") != ordinal
-                    or state.get("candidate_id") != preview.candidate_id
-                    or state.get("target_fingerprints") != preview.target_fingerprints
-                    or state.get("target_result_fingerprints") != preview.target_result_fingerprints
+                if not _candidate_previews.candidate_preview_state_matches(
+                    preview,
+                    ordinal,
                 ):
                     exit_with_error(
                         _(
@@ -249,8 +247,7 @@ def _execute_include_candidate(
                     file=sys.stderr,
                 )
             finally:
-                for candidate in previews:
-                    candidate.close()
+                _candidate_previews.close_candidate_previews(previews)
 
 
 def _include_candidate_count_for_file(
@@ -330,8 +327,7 @@ def _include_candidate_count_for_file(
                         replacement_payload=replacement_payload,
                     )
                 count = len(previews)
-                for preview in previews:
-                    preview.close()
+                _candidate_previews.close_candidate_previews(previews)
                 return CandidatePreviewCount(count=count)
     except CandidateEnumerationLimitError as e:
         return CandidatePreviewCount(too_many=True, error=str(e))

--- a/src/git_stage_batch/commands/include_from.py
+++ b/src/git_stage_batch/commands/include_from.py
@@ -12,6 +12,7 @@ from .batch_source import binary_file_actions as _binary_file_actions
 from .batch_source import candidate_previews as _candidate_previews
 from .batch_source import candidate_refusals as _candidate_refusals
 from .batch_source import candidate_selectors as _candidate_selectors
+from .batch_source import merge_refusals as _merge_refusals
 from .batch_source import text_file_actions as _text_file_actions
 from .selection import replacement_selection
 from ..batch.binary_file_content import read_binary_file_from_batch
@@ -53,7 +54,6 @@ from ..data.file_review.state import (
     resolve_batch_source_action_scope,
 )
 from ..data.file_review.batch_selection import translate_batch_file_gutter_ids_to_selection_ids
-from ..batch.file_display import render_batch_file_display
 from ..core.buffer import LineBuffer
 from ..utils.repository_buffers import (
     load_git_object_as_buffer,
@@ -638,36 +638,10 @@ def command_include_from_batch(
             failed_files=failed_files,
             candidate_counts=candidate_counts,
         )
-        if len(failed_files) == 1:
-            # Check if there are individually mergeable lines to suggest --lines
-            file_path = failed_files[0]
-            rendered = render_batch_file_display(batch_name, file_path)
-            has_mergeable_lines = rendered and len(rendered.gutter_to_selection_id) > 0
-
-            if has_mergeable_lines:
-                error_msg = _("Batch '{batch}' contains changes to {file} that are incompatible with the current working tree. "
-                             "Use 'git-stage-batch show --from {batch}' to review the batch, "
-                             "or use '--lines' to apply only specific changes.").format(
-                    batch=batch_name,
-                    file=file_path
-                )
-            else:
-                error_msg = _("Batch '{batch}' contains changes to {file} that are incompatible with the current working tree. "
-                             "Use 'git-stage-batch show --from {batch}' to review the batch.").format(
-                    batch=batch_name,
-                    file=file_path
-                )
-            exit_with_error(error_msg)
-        else:
-            exit_with_error(
-                _("Batch '{batch}' contains changes to one or more files that are incompatible with the current working tree. "
-                  "Failed for: {files}. "
-                  "Use 'git-stage-batch show --from {batch}' to review the batch, "
-                  "or use '--lines' to apply only specific changes.").format(
-                    batch=batch_name,
-                    files=', '.join(failed_files)
-                )
-            )
+        _merge_refusals.refuse_batch_source_merge_failures(
+            batch_name=batch_name,
+            failed_files=failed_files,
+        )
 
     try:
         try:

--- a/src/git_stage_batch/commands/include_from.py
+++ b/src/git_stage_batch/commands/include_from.py
@@ -10,6 +10,7 @@ from typing import Optional
 from .batch_source import action_plans as _action_plans
 from .batch_source import binary_file_actions as _binary_file_actions
 from .batch_source import candidate_previews as _candidate_previews
+from .batch_source import candidate_refusals as _candidate_refusals
 from .batch_source import text_file_actions as _text_file_actions
 from .selection import replacement_selection
 from ..batch.binary_file_content import read_binary_file_from_batch
@@ -646,96 +647,12 @@ def command_include_from_batch(
 
     if failed_files:
         _action_plans.close_action_plans(include_plans)
-        candidate_limit_files = [
-            file_path
-            for file_path in failed_files
-            if candidate_counts.get(file_path, CandidatePreviewCount()).too_many
-        ]
-        if len(candidate_limit_files) == 1:
-            file_path = candidate_limit_files[0]
-            exit_with_error(
-                _(
-                    "Cannot include batch '{batch}': {file} has too many include "
-                    "candidates to preview safely.\n"
-                    "No changes applied.\n\n"
-                    "Use --line with a narrower selection or split the batch "
-                    "before previewing candidates."
-                ).format(batch=batch_name, file=file_path)
-            )
-        if len(candidate_limit_files) > 1:
-            exit_with_error(
-                _(
-                    "Cannot include batch '{batch}': multiple files have too many "
-                    "include candidates to preview safely.\n"
-                    "No changes applied.\n\n"
-                    "Use --line with narrower selections or split the batch "
-                    "before previewing candidates."
-                ).format(batch=batch_name)
-            )
-
-        candidate_error_files = [
-            file_path
-            for file_path in failed_files
-            if (
-                candidate_counts.get(file_path, CandidatePreviewCount()).error
-                and not candidate_counts.get(file_path, CandidatePreviewCount()).too_many
-            )
-        ]
-        if len(candidate_error_files) == 1:
-            file_path = candidate_error_files[0]
-            error = candidate_counts[file_path].error
-            exit_with_error(
-                _(
-                    "Cannot enumerate include candidates for {file}: {error}\n"
-                    "No changes applied."
-                ).format(file=file_path, error=error)
-            )
-        if len(candidate_error_files) > 1:
-            examples = "\n".join(
-                f"  {file_path}: {candidate_counts[file_path].error}"
-                for file_path in candidate_error_files[:3]
-            )
-            exit_with_error(
-                _(
-                    "Cannot enumerate include candidates for multiple files.\n"
-                    "No changes applied.\n\n"
-                    "{examples}"
-                ).format(examples=examples)
-            )
-
-        ambiguous_files = [
-            file_path
-            for file_path in failed_files
-            if candidate_counts.get(file_path, CandidatePreviewCount()).count
-        ]
-        if len(ambiguous_files) == 1:
-            file_path = ambiguous_files[0]
-            exit_with_error(
-                _(
-                    "Cannot include batch '{batch}': {file} has {count} include candidates.\n"
-                    "No changes applied.\n\n"
-                    "Preview candidates:\n"
-                    "  git-stage-batch show --from {batch}:include --file {file}\n\n"
-                    "Include a reviewed candidate:\n"
-                    "  git-stage-batch include --from {batch}:include:N --file {file}"
-                ).format(
-                    batch=batch_name,
-                    file=file_path,
-                    count=candidate_counts[file_path].count,
-                )
-            )
-        if len(ambiguous_files) > 1:
-            examples = "\n".join(
-                f"  git-stage-batch show --from {batch_name}:include --file {file_path}"
-                for file_path in ambiguous_files[:3]
-            )
-            exit_with_error(
-                _(
-                    "Cannot include batch '{batch}': multiple files need include decisions.\n"
-                    "No changes applied.\n\n"
-                    "Resolve one file at a time:\n{examples}"
-                ).format(batch=batch_name, examples=examples)
-            )
+        _candidate_refusals.refuse_candidate_conflicts(
+            batch_name=batch_name,
+            operation="include",
+            failed_files=failed_files,
+            candidate_counts=candidate_counts,
+        )
         if len(failed_files) == 1:
             # Check if there are individually mergeable lines to suggest --lines
             file_path = failed_files[0]

--- a/src/git_stage_batch/commands/include_from.py
+++ b/src/git_stage_batch/commands/include_from.py
@@ -165,34 +165,20 @@ def _execute_include_candidate(
                 except (MergeError, ValueError) as e:
                     exit_with_error(str(e))
 
-            preview = _candidate_previews.candidate_preview_for_ordinal(
-                previews,
-                ordinal,
-            )
-            if preview is None:
-                _candidate_previews.close_candidate_previews(previews)
-                exit_with_error(
-                    _("Batch '{batch}' has {count} include candidates for {file}; candidate {ordinal} does not exist.").format(
-                        batch=batch_name,
-                        count=len(previews),
-                        file=file_path,
-                        ordinal=ordinal,
-                    )
-                )
-
             try:
-                if not _candidate_previews.candidate_preview_state_matches(
+                preview = _candidate_previews.require_candidate_preview_for_ordinal(
+                    previews,
+                    ordinal,
+                    batch_name=batch_name,
+                    operation="include",
+                    file_path=file_path,
+                )
+                _candidate_previews.require_candidate_preview_state(
                     preview,
                     ordinal,
-                ):
-                    exit_with_error(
-                        _(
-                            "Candidate selector '{selector}' has not been previewed for {file}.\n"
-                            "No changes applied.\n\n"
-                            "Preview it first with:\n"
-                            "  git-stage-batch show --from {selector} --file {file}"
-                        ).format(selector=raw_selector, file=file_path)
-                    )
+                    selector=raw_selector,
+                    file_path=file_path,
+                )
 
                 index_target = next(target for target in preview.targets if target.target == "index")
                 worktree_target = next(target for target in preview.targets if target.target == "worktree")

--- a/src/git_stage_batch/commands/include_from.py
+++ b/src/git_stage_batch/commands/include_from.py
@@ -9,6 +9,7 @@ from typing import Optional
 
 from .batch_source import action_plans as _action_plans
 from .batch_source import binary_file_actions as _binary_file_actions
+from .batch_source import candidate_preview_counts as _candidate_preview_counts
 from .batch_source import candidate_previews as _candidate_previews
 from .batch_source import candidate_refusals as _candidate_refusals
 from .batch_source import candidate_selectors as _candidate_selectors
@@ -19,8 +20,6 @@ from ..batch.binary_file_content import read_binary_file_from_batch
 from ..batch.merge import merge_batch_from_line_sequences_as_buffer
 from ..batch.metadata_validation import read_validated_batch_metadata
 from ..batch.operation_candidates import (
-    CandidateEnumerationLimitError,
-    CandidatePreviewCount,
     build_include_candidate_previews,
     clear_candidate_preview_state_for_file,
 )
@@ -234,93 +233,6 @@ def _execute_include_candidate(
                 _candidate_previews.close_candidate_previews(previews)
 
 
-def _include_candidate_count_for_file(
-    *,
-    batch_name: str,
-    file_path: str,
-    file_meta: dict,
-    selection_ids_to_include: set[int] | None,
-    replacement_payload: ReplacementPayload | None,
-) -> CandidatePreviewCount:
-    if file_meta.get("file_type") == "binary" or is_batch_submodule_pointer(file_meta):
-        return CandidatePreviewCount()
-    batch_source_commit = file_meta.get("batch_source_commit")
-    if not batch_source_commit:
-        return CandidatePreviewCount()
-    batch_source_buffer = load_git_object_as_buffer(f"{batch_source_commit}:{file_path}")
-    if batch_source_buffer is None:
-        return CandidatePreviewCount()
-    index_buffer = load_git_object_as_buffer(f":{file_path}")
-    index_exists = index_buffer is not None
-    if index_buffer is None:
-        index_buffer = LineBuffer.from_bytes(b"")
-    repo_root = get_git_repository_root_path()
-    full_path = repo_root / file_path
-    working_exists = os.path.lexists(full_path)
-    text_change_type = normalized_text_change_type(file_meta.get("change_type"))
-    batch_file_mode = str(file_meta.get("mode", "100644"))
-    index_file_mode = mode_for_text_materialization(
-        batch_file_mode,
-        selection_ids_to_include,
-        destination_exists=index_exists,
-    )
-    working_file_mode = mode_for_text_materialization(
-        batch_file_mode,
-        selection_ids_to_include,
-        destination_exists=working_exists,
-    )
-    try:
-        with (
-            batch_source_buffer as batch_source_lines,
-            index_buffer as index_lines,
-            load_working_tree_file_as_buffer(file_path) as working_lines,
-        ):
-            with acquire_batch_ownership_for_display_ids_from_lines(
-                file_meta,
-                batch_source_lines,
-                selection_ids_to_include,
-            ) as ownership:
-                with ExitStack() as stack:
-                    source_for_candidates = batch_source_lines
-                    candidate_ownership = ownership
-                    if replacement_payload is not None:
-                        replacement_view = build_replacement_batch_view_from_lines(
-                            batch_source_lines,
-                            ownership,
-                            replacement_payload,
-                        )
-                        replacement_view = stack.enter_context(replacement_view)
-                        source_for_candidates = replacement_view.source_buffer
-                        candidate_ownership = replacement_view.ownership
-                    previews = build_include_candidate_previews(
-                        batch_name=batch_name,
-                        file_path=file_path,
-                        source_lines=source_for_candidates,
-                        ownership=candidate_ownership,
-                        index_lines=index_lines,
-                        worktree_lines=working_lines,
-                        batch_source_commit=batch_source_commit,
-                        file_meta=file_meta,
-                        text_change_type=text_change_type,
-                        index_file_mode=index_file_mode,
-                        worktree_file_mode=working_file_mode,
-                        index_exists=index_exists,
-                        worktree_exists=working_exists,
-                        selected_ids=selection_ids_to_include,
-                        selection_ids=selection_ids_to_include,
-                        replacement_payload=replacement_payload,
-                    )
-                count = len(previews)
-                _candidate_previews.close_candidate_previews(previews)
-                return CandidatePreviewCount(count=count)
-    except CandidateEnumerationLimitError as e:
-        return CandidatePreviewCount(too_many=True, error=str(e))
-    except MergeError:
-        return CandidatePreviewCount()
-    except Exception as e:
-        return CandidatePreviewCount(error=str(e))
-
-
 def command_include_from_batch(
     batch_name: str,
     line_ids: Optional[str] = None,
@@ -433,7 +345,7 @@ def command_include_from_batch(
 
     repo_root = get_git_repository_root_path()
     failed_files = []
-    candidate_counts: dict[str, CandidatePreviewCount] = {}
+    candidate_counts = {}
     include_plans = []
 
     for file_path, file_meta in files.items():
@@ -598,12 +510,14 @@ def command_include_from_batch(
             if merged_working_buffer is not None:
                 merged_working_buffer.close()
             # Merge conflict - batch created from different file version
-            candidate_count = _include_candidate_count_for_file(
-                batch_name=batch_name,
-                file_path=file_path,
-                file_meta=file_meta,
-                selection_ids_to_include=selection_ids_to_include,
-                replacement_payload=replacement_payload,
+            candidate_count = (
+                _candidate_preview_counts.count_include_candidate_previews_for_file(
+                    batch_name=batch_name,
+                    file_path=file_path,
+                    file_meta=file_meta,
+                    selection_ids_to_include=selection_ids_to_include,
+                    replacement_payload=replacement_payload,
+                )
             )
             if candidate_count.count or candidate_count.too_many or candidate_count.error:
                 candidate_counts[file_path] = candidate_count

--- a/src/git_stage_batch/commands/include_from.py
+++ b/src/git_stage_batch/commands/include_from.py
@@ -9,8 +9,8 @@ from typing import Optional
 
 from .batch_source import action_plans as _action_plans
 from .batch_source import binary_file_actions as _binary_file_actions
+from .batch_source import candidate_materialization as _candidate_materialization
 from .batch_source import candidate_preview_counts as _candidate_preview_counts
-from .batch_source import candidate_previews as _candidate_previews
 from .batch_source import candidate_refusals as _candidate_refusals
 from .batch_source import candidate_selectors as _candidate_selectors
 from .batch_source import merge_refusals as _merge_refusals
@@ -20,7 +20,6 @@ from ..batch.binary_file_content import read_binary_file_from_batch
 from ..batch.merge import merge_batch_from_line_sequences_as_buffer
 from ..batch.metadata_validation import read_validated_batch_metadata
 from ..batch.operation_candidates import (
-    build_include_candidate_previews,
     clear_candidate_preview_state_for_file,
 )
 from ..batch.replacement import build_replacement_batch_view_from_lines
@@ -86,151 +85,60 @@ def _execute_include_candidate(
     replacement_payload: ReplacementPayload | None,
 ) -> None:
     """Recompute and include one previewed include candidate."""
-    if len(files) != 1:
-        exit_with_error(_("Candidate execution requires exactly one file."))
-    file_path, file_meta = next(iter(files.items()))
-    if file_meta.get("file_type") == "binary" or is_batch_submodule_pointer(file_meta):
-        exit_with_error(_("Candidate execution is only available for text batch entries."))
-
-    batch_source_commit = file_meta["batch_source_commit"]
-    batch_source_buffer = load_git_object_as_buffer(f"{batch_source_commit}:{file_path}")
-    if batch_source_buffer is None:
-        exit_with_error(_("Batch source content is missing for {file}.").format(file=file_path))
-
-    repo_root = get_git_repository_root_path()
-    full_path = repo_root / file_path
-    working_exists = os.path.lexists(full_path)
-    text_change_type = normalized_text_change_type(file_meta.get("change_type"))
-    batch_file_mode = str(file_meta.get("mode", "100644"))
-    index_buffer = load_git_object_as_buffer(f":{file_path}")
-    index_exists = index_buffer is not None
-    if index_buffer is None:
-        index_buffer = LineBuffer.from_bytes(b"")
-    index_file_mode = mode_for_text_materialization(
-        batch_file_mode,
-        selected_ids,
-        destination_exists=index_exists,
+    materialized = _candidate_materialization.materialize_include_candidate(
+        batch_name=batch_name,
+        raw_selector=raw_selector,
+        ordinal=ordinal,
+        files=files,
+        selected_ids=selected_ids,
+        selection_ids_to_include=selection_ids_to_include,
+        replacement_payload=replacement_payload,
     )
-    working_file_mode = mode_for_text_materialization(
-        batch_file_mode,
-        selected_ids,
-        destination_exists=working_exists,
-    )
-
-    with (
-        batch_source_buffer as batch_source_lines,
-        index_buffer as index_lines,
-        load_working_tree_file_as_buffer(file_path) as working_lines,
-    ):
-        with acquire_batch_ownership_for_display_ids_from_lines(
-            file_meta,
-            batch_source_lines,
-            selection_ids_to_include,
-        ) as ownership:
-            with ExitStack() as stack:
-                source_for_candidates = batch_source_lines
-                candidate_ownership = ownership
-                if replacement_payload is not None:
-                    try:
-                        replacement_view = build_replacement_batch_view_from_lines(
-                            batch_source_lines,
-                            ownership,
-                            replacement_payload,
-                        )
-                    except ValueError as e:
-                        exit_with_error(str(e))
-                    replacement_view = stack.enter_context(replacement_view)
-                    source_for_candidates = replacement_view.source_buffer
-                    candidate_ownership = replacement_view.ownership
-                try:
-                    previews = build_include_candidate_previews(
-                        batch_name=batch_name,
-                        file_path=file_path,
-                        source_lines=source_for_candidates,
-                        ownership=candidate_ownership,
-                        index_lines=index_lines,
-                        worktree_lines=working_lines,
-                        batch_source_commit=batch_source_commit,
-                        file_meta=file_meta,
-                        text_change_type=text_change_type,
-                        index_file_mode=index_file_mode,
-                        worktree_file_mode=working_file_mode,
-                        index_exists=index_exists,
-                        worktree_exists=working_exists,
-                        selected_ids=selected_ids,
-                        selection_ids=selection_ids_to_include,
-                        replacement_payload=replacement_payload,
-                    )
-                except (MergeError, ValueError) as e:
-                    exit_with_error(str(e))
-
-            try:
-                preview = _candidate_previews.require_candidate_preview_for_ordinal(
-                    previews,
-                    ordinal,
-                    batch_name=batch_name,
-                    operation="include",
-                    file_path=file_path,
-                )
-                _candidate_previews.require_candidate_preview_state(
-                    preview,
-                    ordinal,
-                    selector=raw_selector,
-                    file_path=file_path,
-                )
-
-                index_target = next(target for target in preview.targets if target.target == "index")
-                worktree_target = next(target for target in preview.targets if target.target == "worktree")
-                index_change_type = selected_text_target_change_type(
-                    text_change_type,
-                    selected_ids,
-                    index_target.after_buffer,
-                )
-                working_change_type = selected_text_target_change_type(
-                    text_change_type,
-                    selected_ids,
-                    worktree_target.after_buffer,
-                )
-                print(
-                    _("Including candidate {ordinal} of {count} for batch '{batch}':").format(
-                        ordinal=preview.ordinal,
-                        count=preview.count,
-                        batch=batch_name,
-                    ),
-                    file=sys.stderr,
-                )
-                print(f"  {file_path}:", file=sys.stderr)
-                print(f"    {_('Index')}", file=sys.stderr)
-                print(f"    {_('Working tree')}", file=sys.stderr)
-                operation_parts = ["include", "--from", raw_selector, "--file", file_path]
-                with undo_checkpoint(" ".join(operation_parts), worktree_paths=[file_path]):
-                    snapshot_file_if_untracked(file_path)
-                    _text_file_actions.stage_text_file_to_index(
-                        file_path,
-                        index_target.after_buffer,
-                        index_file_mode,
-                        index_change_type,
-                    )
-                    _text_file_actions.write_text_file_to_worktree(
-                        file_path,
-                        worktree_target.after_buffer,
-                        working_file_mode,
-                        working_change_type,
-                    )
-                clear_candidate_preview_state_for_file(
-                    batch_name=batch_name,
-                    file_path=file_path,
-                )
-                print(
-                    _("✓ Included candidate {ordinal} of {count} from batch '{batch}'").format(
-                        ordinal=preview.ordinal,
-                        count=preview.count,
-                        batch=batch_name,
-                    ),
-                    file=sys.stderr,
-                )
-            finally:
-                _candidate_previews.close_candidate_previews(previews)
+    try:
+        preview = materialized.preview
+        file_path = materialized.file_path
+        index_target = materialized.index_target
+        worktree_target = materialized.worktree_target
+        print(
+            _("Including candidate {ordinal} of {count} for batch '{batch}':").format(
+                ordinal=preview.ordinal,
+                count=preview.count,
+                batch=batch_name,
+            ),
+            file=sys.stderr,
+        )
+        print(f"  {file_path}:", file=sys.stderr)
+        print(f"    {_('Index')}", file=sys.stderr)
+        print(f"    {_('Working tree')}", file=sys.stderr)
+        operation_parts = ["include", "--from", raw_selector, "--file", file_path]
+        with undo_checkpoint(" ".join(operation_parts), worktree_paths=[file_path]):
+            snapshot_file_if_untracked(file_path)
+            _text_file_actions.stage_text_file_to_index(
+                file_path,
+                index_target.after_buffer,
+                materialized.index_file_mode,
+                index_target.change_type,
+            )
+            _text_file_actions.write_text_file_to_worktree(
+                file_path,
+                worktree_target.after_buffer,
+                materialized.worktree_file_mode,
+                worktree_target.change_type,
+            )
+        clear_candidate_preview_state_for_file(
+            batch_name=batch_name,
+            file_path=file_path,
+        )
+        print(
+            _("✓ Included candidate {ordinal} of {count} from batch '{batch}'").format(
+                ordinal=preview.ordinal,
+                count=preview.count,
+                batch=batch_name,
+            ),
+            file=sys.stderr,
+        )
+    finally:
+        materialized.close()
 
 
 def command_include_from_batch(

--- a/src/git_stage_batch/commands/include_from.py
+++ b/src/git_stage_batch/commands/include_from.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from contextlib import ExitStack
-import os
 import sys
 from typing import Optional
 
@@ -14,21 +12,19 @@ from .batch_source import candidate_preview_counts as _candidate_preview_counts
 from .batch_source import candidate_refusals as _candidate_refusals
 from .batch_source import candidate_selectors as _candidate_selectors
 from .batch_source import merge_refusals as _merge_refusals
+from .batch_source import text_plan_builders as _text_plan_builders
 from .batch_source import text_file_actions as _text_file_actions
 from .selection import replacement_selection
 from ..batch.binary_file_content import read_binary_file_from_batch
-from ..batch.merge import merge_batch_from_line_sequences_as_buffer
 from ..batch.metadata_validation import read_validated_batch_metadata
 from ..batch.operation_candidates import (
     clear_candidate_preview_state_for_file,
 )
-from ..batch.replacement import build_replacement_batch_view_from_lines
 from ..core.replacement import (
     ReplacementPayload,
     coerce_replacement_payload,
 )
 from ..batch.selection import (
-    acquire_batch_ownership_for_display_ids_from_lines,
     resolve_current_batch_binary_file_scope,
     resolve_batch_file_scope,
     require_single_file_context_for_line_selection,
@@ -40,23 +36,12 @@ from ..batch.submodule_pointer import (
     stage_submodule_pointer_from_batch,
 )
 from ..batch.validation import batch_exists
-from ..core.text_lifecycle import (
-    TextFileChangeType,
-    mode_for_text_materialization,
-    normalized_text_change_type,
-    selected_text_target_change_type,
-)
 from ..data.file_review.records import FileReviewAction
 from ..data.file_review.state import (
     finish_review_scoped_line_action,
     resolve_batch_source_action_scope,
 )
 from ..data.file_review.batch_selection import translate_batch_file_gutter_ids_to_selection_ids
-from ..core.buffer import LineBuffer
-from ..utils.repository_buffers import (
-    load_git_object_as_buffer,
-    load_working_tree_file_as_buffer,
-)
 from ..data.session import snapshot_file_if_untracked
 from ..data.undo import undo_checkpoint
 from ..exceptions import (
@@ -68,7 +53,6 @@ from ..exceptions import (
 )
 from ..i18n import _
 from ..utils.git import (
-    get_git_repository_root_path,
     git_refresh_index,
     require_git_repository,
 )
@@ -251,14 +235,11 @@ def command_include_from_batch(
         )
         return
 
-    repo_root = get_git_repository_root_path()
     failed_files = []
     candidate_counts = {}
     include_plans = []
 
     for file_path, file_meta in files.items():
-        merged_index_buffer = None
-        merged_working_buffer = None
         try:
             if file_meta.get("file_type") == "binary":
                 batch_buffer = read_binary_file_from_batch(
@@ -283,140 +264,43 @@ def command_include_from_batch(
                 )
                 continue
 
-            text_change_type = normalized_text_change_type(file_meta.get("change_type"))
-
-            index_buffer = load_git_object_as_buffer(f":{file_path}")
-            index_exists = index_buffer is not None
-            if index_buffer is None:
-                index_buffer = LineBuffer.from_bytes(b"")
-
-            full_path = repo_root / file_path
-            working_exists = os.path.lexists(full_path)
-
-            batch_file_mode = str(file_meta.get("mode", "100644"))
-            index_file_mode = mode_for_text_materialization(
-                batch_file_mode,
-                selected_ids,
-                destination_exists=index_exists,
-            )
-            working_file_mode = mode_for_text_materialization(
-                batch_file_mode,
-                selected_ids,
-                destination_exists=working_exists,
-            )
-            if selected_ids is None and text_change_type == TextFileChangeType.DELETED:
-                index_buffer.close()
-                include_plans.append(
-                    _action_plans.IncludeTextFileActionPlan(
-                        file_path,
-                        None,
-                        None,
-                        index_file_mode,
-                        working_file_mode,
-                        text_change_type,
-                        text_change_type,
+            try:
+                text_plan_result = (
+                    _text_plan_builders.build_include_text_file_action_plan(
+                        file_path=file_path,
+                        file_meta=file_meta,
+                        selected_ids=selected_ids,
+                        selection_ids_to_include=selection_ids_to_include,
+                        replacement_payload=replacement_payload,
                     )
                 )
-                continue
+            except AtomicUnitError as e:
+                if rendered:
+                    translate_atomic_unit_error_to_gutter_ids(
+                        e,
+                        rendered,
+                        "include from",
+                        batch_name,
+                    )
+                _action_plans.close_action_plans(include_plans)
+                exit_with_error(
+                    _("Failed to include from batch '{name}': {error}").format(
+                        name=batch_name,
+                        error=str(e),
+                    )
+                )
+            except ValueError as e:
+                _action_plans.close_action_plans(include_plans)
+                exit_with_error(str(e))
 
-            batch_source_commit = file_meta["batch_source_commit"]
-            batch_source_buffer = load_git_object_as_buffer(
-                f"{batch_source_commit}:{file_path}"
-            )
-            if batch_source_buffer is None:
-                index_buffer.close()
+            if text_plan_result.missing_source:
                 failed_files.append(file_path)
                 continue
-
-            with (
-                batch_source_buffer as batch_source_lines,
-                index_buffer as index_lines,
-                load_working_tree_file_as_buffer(file_path) as working_lines,
-            ):
-                try:
-                    with acquire_batch_ownership_for_display_ids_from_lines(
-                        file_meta,
-                        batch_source_lines,
-                        selection_ids_to_include,
-                    ) as ownership:
-                        if ownership.is_empty():
-                            if selected_ids is None and text_change_type == TextFileChangeType.ADDED:
-                                merged_index_buffer = LineBuffer.from_bytes(b"")
-                                merged_working_buffer = LineBuffer.from_bytes(b"")
-                            else:
-                                continue
-                        elif replacement_payload is not None:
-                            try:
-                                replacement_view = build_replacement_batch_view_from_lines(
-                                    batch_source_lines,
-                                    ownership,
-                                    replacement_payload,
-                                )
-                            except ValueError as e:
-                                _action_plans.close_action_plans(include_plans)
-                                exit_with_error(str(e))
-
-                            with replacement_view:
-                                ownership = replacement_view.ownership
-                                merged_index_buffer = merge_batch_from_line_sequences_as_buffer(
-                                    replacement_view.source_buffer,
-                                    ownership,
-                                    index_lines,
-                                )
-                                merged_working_buffer = merge_batch_from_line_sequences_as_buffer(
-                                    replacement_view.source_buffer,
-                                    ownership,
-                                    working_lines,
-                                )
-                        else:
-                            merged_index_buffer = merge_batch_from_line_sequences_as_buffer(
-                                batch_source_lines,
-                                ownership,
-                                index_lines,
-                            )
-                            merged_working_buffer = merge_batch_from_line_sequences_as_buffer(
-                                batch_source_lines,
-                                ownership,
-                                working_lines,
-                            )
-                except AtomicUnitError as e:
-                    if rendered:
-                        translate_atomic_unit_error_to_gutter_ids(e, rendered, "include from", batch_name)
-                    _action_plans.close_action_plans(include_plans)
-                    exit_with_error(_("Failed to include from batch '{name}': {error}").format(
-                        name=batch_name,
-                        error=str(e)
-                    ))
-
-            index_change_type = selected_text_target_change_type(
-                text_change_type,
-                selected_ids,
-                merged_index_buffer,
-            )
-            working_change_type = selected_text_target_change_type(
-                text_change_type,
-                selected_ids,
-                merged_working_buffer,
-            )
-            include_plans.append(
-                _action_plans.IncludeTextFileActionPlan(
-                    file_path,
-                    merged_index_buffer,
-                    merged_working_buffer,
-                    index_file_mode,
-                    working_file_mode,
-                    index_change_type,
-                    working_change_type,
-                )
-            )
-            merged_index_buffer = None
-            merged_working_buffer = None
+            if text_plan_result.plan is None:
+                continue
+            include_plans.append(text_plan_result.plan)
 
         except MergeError:
-            if merged_index_buffer is not None:
-                merged_index_buffer.close()
-            if merged_working_buffer is not None:
-                merged_working_buffer.close()
             # Merge conflict - batch created from different file version
             candidate_count = (
                 _candidate_preview_counts.count_include_candidate_previews_for_file(

--- a/src/git_stage_batch/commands/include_from.py
+++ b/src/git_stage_batch/commands/include_from.py
@@ -11,6 +11,7 @@ from .batch_source import action_plans as _action_plans
 from .batch_source import binary_file_actions as _binary_file_actions
 from .batch_source import candidate_previews as _candidate_previews
 from .batch_source import candidate_refusals as _candidate_refusals
+from .batch_source import candidate_selectors as _candidate_selectors
 from .batch_source import text_file_actions as _text_file_actions
 from .selection import replacement_selection
 from ..batch.binary_file_content import read_binary_file_from_batch
@@ -38,10 +39,6 @@ from ..batch.submodule_pointer import (
     is_batch_submodule_pointer,
     refuse_batch_submodule_pointer_lines,
     stage_submodule_pointer_from_batch,
-)
-from ..batch.source_selector import (
-    parse_batch_source_selector,
-    require_candidate_operation,
 )
 from ..batch.validation import batch_exists
 from ..core.text_lifecycle import (
@@ -357,23 +354,11 @@ def command_include_from_batch(
     """
     require_git_repository()
     raw_selector = batch_name
-    selector = parse_batch_source_selector(batch_name)
-    require_candidate_operation(selector, "include", raw_value=raw_selector, file=file)
-    if selector.candidate_operation == "include" and selector.candidate_ordinal is None:
-        exit_with_error(
-            _(
-                "'{selector}' names the include candidate preview set.\n"
-                "Use 'git-stage-batch show --from {selector}' to preview candidates, "
-                "or use '{batch}:include:N' to include a candidate."
-            ).format(selector=raw_selector, batch=selector.batch_name)
-        )
-    if selector.candidate_ordinal is not None and file is None:
-        exit_with_error(
-            _(
-                "Candidate selector '{selector}' requires --file in this implementation.\n"
-                "No changes applied."
-            ).format(selector=raw_selector)
-        )
+    selector = _candidate_selectors.resolve_batch_source_action_selector(
+        raw_selector,
+        "include",
+        file=file,
+    )
     batch_name = selector.batch_name
     scope_resolution = resolve_batch_source_action_scope(
         FileReviewAction.INCLUDE_FROM_BATCH,

--- a/src/git_stage_batch/commands/show_from.py
+++ b/src/git_stage_batch/commands/show_from.py
@@ -8,6 +8,7 @@ import sys
 from contextlib import ExitStack
 from typing import Optional
 
+from .batch_source import candidate_previews as _candidate_previews
 from .selection import replacement_selection
 from ..batch.atomic_file_changes import (
     binary_change_from_batch_file_metadata,
@@ -122,24 +123,26 @@ def _resolve_candidate_ordinal(
     *,
     explicit_ordinal: int,
 ) -> OperationCandidatePreview:
+    preview = _candidate_previews.candidate_preview_for_ordinal(
+        previews,
+        explicit_ordinal,
+    )
+    if preview is not None:
+        return preview
     if not previews:
         raise CommandError(_("No candidates available."))
-    first = previews[0]
-    ordinal = explicit_ordinal
-
-    if ordinal > len(previews):
-        raise CommandError(
-            _("Batch '{batch}' has {count} {operation} candidates for {file}; candidate {ordinal} does not exist.").format(
-                batch=first.batch_name,
-                count=len(previews),
-                operation=first.operation,
-                file=first.file_path,
-                ordinal=ordinal,
-            )
-        )
-    if ordinal < 1:
+    if explicit_ordinal < 1:
         raise CommandError(_("Candidate ordinal must be at least 1."))
-    return previews[ordinal - 1]
+    first = previews[0]
+    raise CommandError(
+        _("Batch '{batch}' has {count} {operation} candidates for {file}; candidate {ordinal} does not exist.").format(
+            batch=first.batch_name,
+            count=len(previews),
+            operation=first.operation,
+            file=first.file_path,
+            ordinal=explicit_ordinal,
+        )
+    )
 
 
 def _preview_replacement_batch_view(
@@ -415,8 +418,7 @@ def command_show_from_batch(
                 for preview in reviewed_previews:
                     save_candidate_preview_state(preview)
             finally:
-                for candidate in previews:
-                    candidate.close()
+                _candidate_previews.close_candidate_previews(previews)
             return
 
         preview = _resolve_candidate_ordinal(previews, explicit_ordinal=selector.candidate_ordinal)
@@ -428,8 +430,7 @@ def command_show_from_batch(
             )
             save_candidate_preview_state(preview)
         finally:
-            for candidate in previews:
-                candidate.close()
+            _candidate_previews.close_candidate_previews(previews)
         return
 
     if porcelain:

--- a/src/git_stage_batch/commands/show_from.py
+++ b/src/git_stage_batch/commands/show_from.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 from .batch_source import candidate_preview_builders as _candidate_preview_builders
 from .batch_source import candidate_previews as _candidate_previews
-from .selection import replacement_selection
+from .batch_source import replacement_previews as _replacement_previews
 from ..batch.atomic_file_changes import (
     binary_change_from_batch_file_metadata,
     gitlink_change_from_batch_file_metadata,
@@ -16,21 +16,14 @@ from ..batch.atomic_file_changes import (
 from ..batch.metadata_validation import read_validated_batch_metadata
 from ..batch.operation_candidates import (
     OperationCandidatePreview,
-    render_candidate_buffer_diff,
     save_candidate_preview_state,
 )
-from ..batch.replacement import build_replacement_batch_view_from_lines
-from ..core.replacement import (
-    ReplacementPayload,
-    coerce_replacement_payload,
-)
+from ..core.replacement import ReplacementPayload
 from ..batch.selection import (
-    acquire_batch_ownership_for_display_ids_from_lines,
     resolve_batch_file_scope,
     require_single_file_context_for_line_selection,
 )
 from ..batch.source_selector import parse_batch_source_selector
-from ..batch.submodule_pointer import is_batch_submodule_pointer
 from ..batch.validation import batch_exists
 from ..batch.file_display import render_batch_file_display
 from ..data.batch_selected_changes import (
@@ -50,7 +43,7 @@ from ..data.selected_change.file_changes import (
     cache_binary_file_change,
     cache_gitlink_change,
 )
-from ..data.file_review.records import FileReviewAction, ReviewSource
+from ..data.file_review.records import ReviewSource
 from ..data.file_review.state import (
     clear_last_file_review_state,
     write_last_file_review_state,
@@ -77,8 +70,6 @@ from ..output.candidate_preview import (
     render_operation_candidate,
     render_operation_candidate_overview,
 )
-from ..core.buffer import LineBuffer
-from ..utils.repository_buffers import load_git_object_as_buffer
 from ..exceptions import (
     exit_with_error,
     BatchMetadataError,
@@ -88,7 +79,6 @@ from ..exceptions import (
 from ..i18n import _
 from ..core.models import LineLevelChange
 from ..utils.git import require_git_repository
-from ..utils.paths import get_context_lines
 
 
 def _batch_source_args(batch_name: str) -> str:
@@ -133,65 +123,6 @@ def _resolve_candidate_ordinal(
             ordinal=explicit_ordinal,
         )
     )
-
-
-def _preview_replacement_batch_view(
-    batch_name: str,
-    metadata: dict,
-    files: dict,
-    line_ids: str,
-    file_path: str,
-    selected_ids: set[int],
-    replacement_text: str | ReplacementPayload,
-) -> None:
-    file_meta = files[file_path]
-    if file_meta.get("file_type") == "binary":
-        exit_with_error(_("Cannot preview replacement text for binary files."))
-    if is_batch_submodule_pointer(file_meta):
-        exit_with_error(_("Cannot preview replacement text for submodule pointers."))
-
-    replacement_selection.require_contiguous_display_selection(selected_ids)
-    batch_source_commit = file_meta["batch_source_commit"]
-    batch_source_buffer = load_git_object_as_buffer(f"{batch_source_commit}:{file_path}")
-    if batch_source_buffer is None:
-        exit_with_error(_("Batch source content is missing for {file}.").format(file=file_path))
-
-    with batch_source_buffer as batch_source_lines:
-        selection_ids, _rendered = translate_batch_file_gutter_ids_to_selection_ids(
-            batch_name,
-            file_path,
-            selected_ids,
-            # Replacement preview is include-shaped because it previews include --from --as.
-            FileReviewAction.INCLUDE_FROM_BATCH,
-        )
-        with acquire_batch_ownership_for_display_ids_from_lines(
-            file_meta,
-            batch_source_lines,
-            selection_ids,
-        ) as ownership:
-            try:
-                replacement_view = build_replacement_batch_view_from_lines(
-                    batch_source_lines,
-                    ownership,
-                    coerce_replacement_payload(replacement_text),
-                )
-            except ValueError as e:
-                exit_with_error(str(e))
-            with replacement_view:
-                before = LineBuffer.from_bytes(batch_source_buffer.to_bytes())
-                try:
-                    diff_text = render_candidate_buffer_diff(
-                        file_path,
-                        before,
-                        replacement_view.source_buffer,
-                        label_before="batch",
-                        label_after="replacement-preview",
-                        context_lines=get_context_lines(),
-                    )
-                    if diff_text:
-                        print(diff_text, end="" if diff_text.endswith("\n") else "\n")
-                finally:
-                    before.close()
 
 
 def command_show_from_batch(
@@ -304,14 +235,15 @@ def command_show_from_batch(
         if len(files) != 1:
             exit_with_error(_("`show --from --as` requires exactly one file."))
         file_path = list(files.keys())[0]
-        _preview_replacement_batch_view(
-            batch_name,
-            metadata,
-            files,
-            line_ids,
-            file_path,
-            selected_ids,
-            replacement_text,
+        _replacement_previews.print_batch_source_replacement_preview(
+            batch_name=batch_name,
+            files=files,
+            file_path=file_path,
+            selected_ids=selected_ids,
+            replacement_text=replacement_text,
+            translate_selection_ids=(
+                translate_batch_file_gutter_ids_to_selection_ids
+            ),
         )
         return
 

--- a/src/git_stage_batch/commands/show_from.py
+++ b/src/git_stage_batch/commands/show_from.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
-import os
 import shlex
 import sys
-from contextlib import ExitStack
 from typing import Optional
 
+from .batch_source import candidate_preview_builders as _candidate_preview_builders
 from .batch_source import candidate_previews as _candidate_previews
 from .selection import replacement_selection
 from ..batch.atomic_file_changes import (
@@ -17,8 +16,6 @@ from ..batch.atomic_file_changes import (
 from ..batch.metadata_validation import read_validated_batch_metadata
 from ..batch.operation_candidates import (
     OperationCandidatePreview,
-    build_apply_candidate_previews,
-    build_include_candidate_previews,
     render_candidate_buffer_diff,
     save_candidate_preview_state,
 )
@@ -35,10 +32,6 @@ from ..batch.selection import (
 from ..batch.source_selector import parse_batch_source_selector
 from ..batch.submodule_pointer import is_batch_submodule_pointer
 from ..batch.validation import batch_exists
-from ..core.text_lifecycle import (
-    mode_for_text_materialization,
-    normalized_text_change_type,
-)
 from ..batch.file_display import render_batch_file_display
 from ..data.batch_selected_changes import (
     compute_batch_binary_fingerprint,
@@ -85,10 +78,7 @@ from ..output.candidate_preview import (
     render_operation_candidate_overview,
 )
 from ..core.buffer import LineBuffer
-from ..utils.repository_buffers import (
-    load_git_object_as_buffer,
-    load_working_tree_file_as_buffer,
-)
+from ..utils.repository_buffers import load_git_object_as_buffer
 from ..exceptions import (
     exit_with_error,
     BatchMetadataError,
@@ -97,7 +87,7 @@ from ..exceptions import (
 )
 from ..i18n import _
 from ..core.models import LineLevelChange
-from ..utils.git import get_git_repository_root_path, require_git_repository
+from ..utils.git import require_git_repository
 from ..utils.paths import get_context_lines
 
 
@@ -204,135 +194,6 @@ def _preview_replacement_batch_view(
                     before.close()
 
 
-def _build_candidate_previews(
-    *,
-    selector,
-    metadata: dict,
-    files: dict,
-    file_path: str,
-    selected_ids: set[int] | None,
-    replacement_text: str | ReplacementPayload | None,
-) -> tuple[OperationCandidatePreview, ...]:
-    file_meta = files[file_path]
-    if file_meta.get("file_type") == "binary" or is_batch_submodule_pointer(file_meta):
-        exit_with_error(_("Candidate preview is only available for text batch entries."))
-
-    batch_source_commit = file_meta["batch_source_commit"]
-    batch_source_buffer = load_git_object_as_buffer(f"{batch_source_commit}:{file_path}")
-    if batch_source_buffer is None:
-        exit_with_error(_("Batch source content is missing for {file}.").format(file=file_path))
-
-    repo_root = get_git_repository_root_path()
-    full_path = repo_root / file_path
-    working_exists = os.path.lexists(full_path)
-    text_change_type = normalized_text_change_type(file_meta.get("change_type"))
-    batch_file_mode = str(file_meta.get("mode", "100644"))
-
-    with batch_source_buffer as batch_source_lines:
-        selection_ids_to_apply = selected_ids
-        if selected_ids:
-            action = (
-                FileReviewAction.APPLY_FROM_BATCH
-                if selector.candidate_operation == "apply"
-                else FileReviewAction.INCLUDE_FROM_BATCH
-            )
-            selection_ids_to_apply, _rendered = translate_batch_file_gutter_ids_to_selection_ids(
-                selector.batch_name,
-                file_path,
-                selected_ids,
-                action,
-            )
-
-        with acquire_batch_ownership_for_display_ids_from_lines(
-            file_meta,
-            batch_source_lines,
-            selection_ids_to_apply,
-        ) as ownership:
-            with ExitStack() as stack:
-                source_for_candidates = batch_source_lines
-                candidate_ownership = ownership
-                replacement_payload = None
-                if replacement_text is not None:
-                    if selector.candidate_operation == "apply":
-                        exit_with_error(_("Replacement preview is not valid for apply candidates."))
-                    if not selected_ids:
-                        exit_with_error(_("`show --from --as` requires `--line`."))
-                    replacement_selection.require_contiguous_display_selection(
-                        selected_ids,
-                    )
-                    replacement_payload = coerce_replacement_payload(replacement_text)
-                    try:
-                        replacement_view = build_replacement_batch_view_from_lines(
-                            batch_source_lines,
-                            ownership,
-                            replacement_payload,
-                        )
-                    except ValueError as e:
-                        exit_with_error(str(e))
-                    replacement_view = stack.enter_context(replacement_view)
-                    source_for_candidates = replacement_view.source_buffer
-                    candidate_ownership = replacement_view.ownership
-
-                if selector.candidate_operation == "apply":
-                    worktree_file_mode = mode_for_text_materialization(
-                        batch_file_mode,
-                        selected_ids,
-                        destination_exists=working_exists,
-                    )
-                    with load_working_tree_file_as_buffer(file_path) as working_lines:
-                        return build_apply_candidate_previews(
-                            batch_name=selector.batch_name,
-                            file_path=file_path,
-                            source_lines=source_for_candidates,
-                            ownership=candidate_ownership,
-                            worktree_lines=working_lines,
-                            batch_source_commit=batch_source_commit,
-                            file_meta=file_meta,
-                            text_change_type=text_change_type,
-                            worktree_file_mode=worktree_file_mode,
-                            worktree_exists=working_exists,
-                            selected_ids=selected_ids,
-                            selection_ids=selection_ids_to_apply,
-                        )
-
-                index_buffer = load_git_object_as_buffer(f":{file_path}")
-                index_exists = index_buffer is not None
-                if index_buffer is None:
-                    index_buffer = LineBuffer.from_bytes(b"")
-                index_file_mode = mode_for_text_materialization(
-                    batch_file_mode,
-                    selected_ids,
-                    destination_exists=index_exists,
-                )
-                worktree_file_mode = mode_for_text_materialization(
-                    batch_file_mode,
-                    selected_ids,
-                    destination_exists=working_exists,
-                )
-                with (
-                    index_buffer as index_lines,
-                    load_working_tree_file_as_buffer(file_path) as working_lines,
-                ):
-                    return build_include_candidate_previews(
-                        batch_name=selector.batch_name,
-                        file_path=file_path,
-                        source_lines=source_for_candidates,
-                        ownership=candidate_ownership,
-                        index_lines=index_lines,
-                        worktree_lines=working_lines,
-                        batch_source_commit=batch_source_commit,
-                        file_meta=file_meta,
-                        text_change_type=text_change_type,
-                        index_file_mode=index_file_mode,
-                        worktree_file_mode=worktree_file_mode,
-                        index_exists=index_exists,
-                        worktree_exists=working_exists,
-                        selected_ids=selected_ids,
-                        selection_ids=selection_ids_to_apply,
-                        replacement_payload=replacement_payload,
-                    )
-
-
 def command_show_from_batch(
     batch_name: str,
     line_ids: Optional[str] = None,
@@ -386,13 +247,15 @@ def command_show_from_batch(
             exit_with_error(_("Candidate preview requires exactly one file."))
         file_path = list(files.keys())[0]
         try:
-            previews = _build_candidate_previews(
+            previews = _candidate_preview_builders.build_batch_source_candidate_previews(
                 selector=selector,
-                metadata=metadata,
                 files=files,
                 file_path=file_path,
                 selected_ids=selected_ids,
                 replacement_text=replacement_text,
+                translate_selection_ids=(
+                    translate_batch_file_gutter_ids_to_selection_ids
+                ),
             )
         except ValueError as e:
             exit_with_error(str(e))

--- a/src/git_stage_batch/commands/show_from.py
+++ b/src/git_stage_batch/commands/show_from.py
@@ -14,10 +14,7 @@ from ..batch.atomic_file_changes import (
     gitlink_change_from_batch_file_metadata,
 )
 from ..batch.metadata_validation import read_validated_batch_metadata
-from ..batch.operation_candidates import (
-    OperationCandidatePreview,
-    save_candidate_preview_state,
-)
+from ..batch.operation_candidates import save_candidate_preview_state
 from ..core.replacement import ReplacementPayload
 from ..batch.selection import (
     resolve_batch_file_scope,
@@ -73,7 +70,6 @@ from ..output.candidate_preview import (
 from ..exceptions import (
     exit_with_error,
     BatchMetadataError,
-    CommandError,
     MergeError,
 )
 from ..i18n import _
@@ -94,33 +90,6 @@ def _shown_pages_for_display_ids(review_model, display_ids: set[int]) -> tuple[i
                 for change in review_model.changes
                 if set(change.display_ids) & display_ids
             }
-        )
-    )
-
-
-def _resolve_candidate_ordinal(
-    previews: tuple[OperationCandidatePreview, ...],
-    *,
-    explicit_ordinal: int,
-) -> OperationCandidatePreview:
-    preview = _candidate_previews.candidate_preview_for_ordinal(
-        previews,
-        explicit_ordinal,
-    )
-    if preview is not None:
-        return preview
-    if not previews:
-        raise CommandError(_("No candidates available."))
-    if explicit_ordinal < 1:
-        raise CommandError(_("Candidate ordinal must be at least 1."))
-    first = previews[0]
-    raise CommandError(
-        _("Batch '{batch}' has {count} {operation} candidates for {file}; candidate {ordinal} does not exist.").format(
-            batch=first.batch_name,
-            count=len(previews),
-            operation=first.operation,
-            file=first.file_path,
-            ordinal=explicit_ordinal,
         )
     )
 
@@ -215,8 +184,14 @@ def command_show_from_batch(
                 _candidate_previews.close_candidate_previews(previews)
             return
 
-        preview = _resolve_candidate_ordinal(previews, explicit_ordinal=selector.candidate_ordinal)
         try:
+            preview = _candidate_previews.require_candidate_preview_for_ordinal(
+                previews,
+                selector.candidate_ordinal,
+                batch_name=batch_name,
+                operation=selector.candidate_operation,
+                file_path=file_path,
+            )
             render_operation_candidate(
                 preview,
                 porcelain=porcelain,

--- a/src/git_stage_batch/data/file_modes.py
+++ b/src/git_stage_batch/data/file_modes.py
@@ -14,6 +14,18 @@ def detect_file_mode(file_path: str) -> str:
     return detect_file_mode_from_root(get_git_repository_root_path(), file_path)
 
 
+def detect_file_mode_in_commit(commit: str, file_path: str) -> str | None:
+    """Return the file mode for a path in a commit tree, if present."""
+    result = run_git_command(
+        ["ls-tree", commit, "--", file_path],
+        check=False,
+        requires_index_lock=False,
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+    return result.stdout.split(maxsplit=1)[0]
+
+
 def detect_file_mode_from_root(repo_root: Path, file_path: str) -> str:
     """Return the current git file mode using a known repository root."""
     absolute_path = repo_root / file_path
@@ -33,3 +45,14 @@ def detect_file_mode_from_root(repo_root: Path, file_path: str) -> str:
         if parts:
             return parts[0]
     return "100644"
+
+
+def apply_git_file_mode(path: Path, file_mode: str | None) -> None:
+    """Apply Git executable-bit semantics to an existing worktree path."""
+    if file_mode is None or file_mode == "120000":
+        return
+    current_mode = path.stat().st_mode
+    if file_mode == "100755":
+        path.chmod(current_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    else:
+        path.chmod(current_mode & ~(stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH))

--- a/src/git_stage_batch/output/candidate_preview.py
+++ b/src/git_stage_batch/output/candidate_preview.py
@@ -84,7 +84,7 @@ def _candidate_overview_subject(
         ]
 
     labels = [
-        _("working tree") if target_name == "worktree" else _("index")
+        _candidate_target_subject_label(target_name)
         for target_name in ambiguous_targets
     ]
     if len(labels) == 1:
@@ -95,6 +95,18 @@ def _candidate_overview_subject(
             second=labels[1],
         ), _("have")
     return _("target files"), _("have")
+
+
+def _candidate_target_label(target_name: str) -> str:
+    if target_name == "index":
+        return _("Index")
+    return _("Working tree")
+
+
+def _candidate_target_subject_label(target_name: str) -> str:
+    if target_name == "index":
+        return _("index")
+    return _("working tree")
 
 
 def _candidate_choice_count(count: int) -> str:
@@ -589,7 +601,7 @@ def _summarize_candidate_target(target) -> _CandidateTargetSummary:
     before_lines = _decode_overview_lines(target.before_buffer)
     after_lines = _decode_overview_lines(target.after_buffer)
     opcode = _first_changed_opcode(before_lines, after_lines)
-    label = _("Index") if target.target == "index" else _("Working tree")
+    label = _candidate_target_label(target.target)
     if opcode is None:
         return _CandidateTargetSummary(label=label, title=_("No text changes"), lines=())
 
@@ -688,7 +700,7 @@ def _print_common_candidate_target_blocks(
     for target_index in common_target_indexes:
         target = previews[0].targets[target_index]
         summary = first_summaries[target_index]
-        label = _("Index") if target.target == "index" else _("Working tree")
+        label = _candidate_target_label(target.target)
         print(
             _("{target} update, same for all candidates: {summary}").format(
                 target=label,
@@ -802,7 +814,7 @@ def render_operation_candidate_overview(
         else:
             print(candidate_header)
             for target, summary in visible_summaries:
-                label = _("Index") if target.target == "index" else _("Working tree")
+                label = _candidate_target_label(target.target)
                 print(f"   {label}: {summary.title}")
                 _print_candidate_summary_block(summary, indent="      ")
         action = _("Apply") if preview.operation == "apply" else _("Include")
@@ -871,7 +883,7 @@ def render_operation_candidate(
         if has_multiple_targets:
             if target_index > 0:
                 print()
-            target_label = _("Index") if target.target == "index" else _("Working tree")
+            target_label = _candidate_target_label(target.target)
             print(
                 _("{target} update: {summary}").format(
                     target=target_label,

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -4045,6 +4045,66 @@ def test_batch_source_action_plans_own_resource_plans():
     assert old_include_names.isdisjoint(include_from_helpers)
 
 
+def test_batch_source_text_plan_builders_own_apply_text_planning():
+    """Regular apply-from text plan construction should live in batch-source support."""
+    text_plan_builders = __import__(
+        "git_stage_batch.commands.batch_source.text_plan_builders",
+        fromlist=["text_plan_builders"],
+    )
+    apply_from_path = SRC_ROOT / "commands" / "apply_from.py"
+    public_names = {
+        "ApplyTextPlanBuildResult",
+        "build_apply_text_file_action_plan",
+    }
+    disallowed_imports = {
+        "git_stage_batch.batch.merge": {
+            "merge_batch_from_line_sequences_as_buffer",
+        },
+        "git_stage_batch.batch.selection": {
+            "acquire_batch_ownership_for_display_ids_from_lines",
+        },
+        "git_stage_batch.core.buffer": {
+            "LineBuffer",
+        },
+        "git_stage_batch.core.text_lifecycle": {
+            "TextFileChangeType",
+            "mode_for_text_materialization",
+            "normalized_text_change_type",
+            "selected_text_target_change_type",
+        },
+        "git_stage_batch.utils.repository_buffers": {
+            "load_git_object_as_buffer",
+            "load_working_tree_file_as_buffer",
+        },
+        "git_stage_batch.utils.git": {
+            "get_git_repository_root_path",
+        },
+    }
+    imports_text_plan_builders = False
+    direct_plan_imports = set()
+
+    for imported_module, node in _import_from_nodes(apply_from_path):
+        imported_names = {alias.name for alias in node.names}
+        if (
+            imported_module == "git_stage_batch.commands.batch_source"
+            and "text_plan_builders" in imported_names
+        ):
+            imports_text_plan_builders = True
+        direct_plan_imports |= imported_names & disallowed_imports.get(
+            imported_module,
+            set(),
+        )
+
+    command_text = apply_from_path.read_text()
+
+    assert public_names <= vars(text_plan_builders).keys()
+    assert imports_text_plan_builders
+    assert direct_plan_imports == set()
+    assert "build_apply_text_file_action_plan(" in command_text
+    assert "merge_batch_from_line_sequences_as_buffer(" not in command_text
+    assert "selected_text_target_change_type(" not in command_text
+
+
 def test_batch_source_candidate_previews_own_candidate_preview_checks():
     """Shared candidate preview checks should live outside command entries."""
     candidate_previews = __import__(

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -4145,6 +4145,62 @@ def test_batch_source_candidate_refusals_own_candidate_count_refusals():
             assert snippet not in command_text
 
 
+def test_batch_source_candidate_selectors_own_action_selector_validation():
+    """Shared candidate selector validation should live outside action entries."""
+    candidate_selectors = __import__(
+        "git_stage_batch.commands.batch_source.candidate_selectors",
+        fromlist=["candidate_selectors"],
+    )
+    apply_from_path = SRC_ROOT / "commands" / "apply_from.py"
+    public_names = {
+        "resolve_batch_source_action_selector",
+    }
+    old_source_selector_names = {
+        "parse_batch_source_selector",
+        "require_candidate_operation",
+    }
+    old_snippets_by_path = {
+        apply_from_path: {
+            "names the apply candidate preview set",
+            "requires --file in this implementation",
+        },
+    }
+    command_paths = set(old_snippets_by_path)
+    imports_candidate_selectors = {
+        path: False
+        for path in command_paths
+    }
+    direct_selector_imports = {
+        path: set()
+        for path in command_paths
+    }
+
+    for path in command_paths:
+        for imported_module, node in _import_from_nodes(path):
+            imported_names = {alias.name for alias in node.names}
+            if (
+                imported_module == "git_stage_batch.commands.batch_source"
+                and "candidate_selectors" in imported_names
+            ):
+                imports_candidate_selectors[path] = True
+            if imported_module == "git_stage_batch.batch.source_selector":
+                direct_selector_imports[path] |= (
+                    imported_names & old_source_selector_names
+                )
+
+    assert public_names <= vars(candidate_selectors).keys()
+    assert imports_candidate_selectors == {
+        apply_from_path: True,
+    }
+    assert direct_selector_imports == {
+        apply_from_path: set(),
+    }
+    for path, old_snippets in old_snippets_by_path.items():
+        command_text = path.read_text()
+        for snippet in old_snippets:
+            assert snippet not in command_text
+
+
 def test_batch_source_text_actions_own_text_file_mutations():
     """Shared text file actions should live outside command entries."""
     text_file_actions = __import__(

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -4105,6 +4105,70 @@ def test_batch_source_text_plan_builders_own_apply_text_planning():
     assert "selected_text_target_change_type(" not in command_text
 
 
+def test_batch_source_text_plan_builders_own_include_text_planning():
+    """Regular include-from text plan construction should live in batch-source support."""
+    text_plan_builders = __import__(
+        "git_stage_batch.commands.batch_source.text_plan_builders",
+        fromlist=["text_plan_builders"],
+    )
+    include_from_path = SRC_ROOT / "commands" / "include_from.py"
+    public_names = {
+        "IncludeTextPlanBuildResult",
+        "build_include_text_file_action_plan",
+    }
+    disallowed_imports = {
+        "git_stage_batch.batch.merge": {
+            "merge_batch_from_line_sequences_as_buffer",
+        },
+        "git_stage_batch.batch.replacement": {
+            "build_replacement_batch_view_from_lines",
+        },
+        "git_stage_batch.batch.selection": {
+            "acquire_batch_ownership_for_display_ids_from_lines",
+        },
+        "git_stage_batch.core.buffer": {
+            "LineBuffer",
+        },
+        "git_stage_batch.core.text_lifecycle": {
+            "TextFileChangeType",
+            "mode_for_text_materialization",
+            "normalized_text_change_type",
+            "selected_text_target_change_type",
+        },
+        "git_stage_batch.utils.repository_buffers": {
+            "load_git_object_as_buffer",
+            "load_working_tree_file_as_buffer",
+        },
+        "git_stage_batch.utils.git": {
+            "get_git_repository_root_path",
+        },
+    }
+    imports_text_plan_builders = False
+    direct_plan_imports = set()
+
+    for imported_module, node in _import_from_nodes(include_from_path):
+        imported_names = {alias.name for alias in node.names}
+        if (
+            imported_module == "git_stage_batch.commands.batch_source"
+            and "text_plan_builders" in imported_names
+        ):
+            imports_text_plan_builders = True
+        direct_plan_imports |= imported_names & disallowed_imports.get(
+            imported_module,
+            set(),
+        )
+
+    command_text = include_from_path.read_text()
+
+    assert public_names <= vars(text_plan_builders).keys()
+    assert imports_text_plan_builders
+    assert direct_plan_imports == set()
+    assert "build_include_text_file_action_plan(" in command_text
+    assert "merge_batch_from_line_sequences_as_buffer(" not in command_text
+    assert "build_replacement_batch_view_from_lines(" not in command_text
+    assert "selected_text_target_change_type(" not in command_text
+
+
 def test_batch_source_candidate_previews_own_candidate_preview_checks():
     """Shared candidate preview checks should live outside command entries."""
     candidate_previews = __import__(

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -4050,6 +4050,7 @@ def test_batch_source_candidate_previews_own_candidate_preview_checks():
     )
     apply_from_path = SRC_ROOT / "commands" / "apply_from.py"
     include_from_path = SRC_ROOT / "commands" / "include_from.py"
+    show_from_path = SRC_ROOT / "commands" / "show_from.py"
     public_names = {
         "candidate_preview_for_ordinal",
         "candidate_preview_state_matches",
@@ -4058,6 +4059,7 @@ def test_batch_source_candidate_previews_own_candidate_preview_checks():
     command_paths = {
         apply_from_path,
         include_from_path,
+        show_from_path,
     }
     imports_candidate_previews = {
         path: False
@@ -4085,10 +4087,12 @@ def test_batch_source_candidate_previews_own_candidate_preview_checks():
     assert imports_candidate_previews == {
         apply_from_path: True,
         include_from_path: True,
+        show_from_path: True,
     }
     assert direct_state_imports == {
         apply_from_path: set(),
         include_from_path: set(),
+        show_from_path: set(),
     }
 
 

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -4096,6 +4096,46 @@ def test_batch_source_candidate_previews_own_candidate_preview_checks():
     }
 
 
+def test_batch_source_candidate_refusals_own_candidate_count_refusals():
+    """Shared candidate count refusals should live outside command entries."""
+    candidate_refusals = __import__(
+        "git_stage_batch.commands.batch_source.candidate_refusals",
+        fromlist=["candidate_refusals"],
+    )
+    apply_from_path = SRC_ROOT / "commands" / "apply_from.py"
+    public_names = {
+        "refuse_candidate_conflicts",
+    }
+    old_snippets = {
+        "too many apply candidates",
+        "Cannot enumerate apply candidates",
+        "multiple files need apply decisions",
+    }
+    command_paths = {
+        apply_from_path,
+    }
+    imports_candidate_refusals = {
+        path: False
+        for path in command_paths
+    }
+
+    for path in command_paths:
+        for imported_module, node in _import_from_nodes(path):
+            imported_names = {alias.name for alias in node.names}
+            if (
+                imported_module == "git_stage_batch.commands.batch_source"
+                and "candidate_refusals" in imported_names
+            ):
+                imports_candidate_refusals[path] = True
+
+    assert public_names <= vars(candidate_refusals).keys()
+    assert imports_candidate_refusals == {
+        apply_from_path: True,
+    }
+    for snippet in old_snippets:
+        assert snippet not in apply_from_path.read_text()
+
+
 def test_batch_source_text_actions_own_text_file_mutations():
     """Shared text file actions should live outside command entries."""
     text_file_actions = __import__(

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -4096,6 +4096,51 @@ def test_batch_source_candidate_previews_own_candidate_preview_checks():
     }
 
 
+def test_batch_source_candidate_preview_builders_own_show_candidate_construction():
+    """Show-from candidate construction should live in batch-source support."""
+    candidate_preview_builders = __import__(
+        "git_stage_batch.commands.batch_source.candidate_preview_builders",
+        fromlist=["candidate_preview_builders"],
+    )
+    show_from_path = SRC_ROOT / "commands" / "show_from.py"
+    public_names = {
+        "build_batch_source_candidate_previews",
+    }
+    old_function_names = {
+        "_build_candidate_previews",
+    }
+    old_import_names = {
+        "build_apply_candidate_previews",
+        "build_include_candidate_previews",
+    }
+    show_from_tree = ast.parse(
+        show_from_path.read_text(),
+        filename=str(show_from_path),
+    )
+    show_from_helpers = {
+        node.name
+        for node in ast.walk(show_from_tree)
+        if isinstance(node, ast.FunctionDef)
+    }
+    imports_candidate_preview_builders = False
+    direct_operation_builder_imports = set()
+
+    for imported_module, node in _import_from_nodes(show_from_path):
+        imported_names = {alias.name for alias in node.names}
+        if (
+            imported_module == "git_stage_batch.commands.batch_source"
+            and "candidate_preview_builders" in imported_names
+        ):
+            imports_candidate_preview_builders = True
+        if imported_module == "git_stage_batch.batch.operation_candidates":
+            direct_operation_builder_imports |= imported_names & old_import_names
+
+    assert public_names <= vars(candidate_preview_builders).keys()
+    assert imports_candidate_preview_builders
+    assert old_function_names.isdisjoint(show_from_helpers)
+    assert direct_operation_builder_imports == set()
+
+
 def test_batch_source_candidate_refusals_own_candidate_count_refusals():
     """Shared candidate count refusals should live outside command entries."""
     candidate_refusals = __import__(

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -4090,8 +4090,8 @@ def test_batch_source_candidate_previews_own_candidate_preview_checks():
 
     assert public_names <= vars(candidate_previews).keys()
     assert imports_candidate_previews == {
-        apply_from_path: True,
-        include_from_path: True,
+        apply_from_path: False,
+        include_from_path: False,
         show_from_path: True,
     }
     assert direct_state_imports == {
@@ -4214,6 +4214,97 @@ def test_batch_source_candidate_preview_counts_own_failure_enumeration():
     }
     for path, old_names in old_function_names.items():
         assert old_names.isdisjoint(helper_names[path])
+
+
+def test_batch_source_candidate_materialization_owns_reviewed_candidate_loading():
+    """Apply/include reviewed candidate loading should live in batch-source support."""
+    candidate_materialization = __import__(
+        "git_stage_batch.commands.batch_source.candidate_materialization",
+        fromlist=["candidate_materialization"],
+    )
+    apply_from_path = SRC_ROOT / "commands" / "apply_from.py"
+    include_from_path = SRC_ROOT / "commands" / "include_from.py"
+    materialization_path = (
+        SRC_ROOT / "commands" / "batch_source" / "candidate_materialization.py"
+    )
+    public_names = {
+        "ApplyCandidateMaterialization",
+        "IncludeCandidateMaterialization",
+        "materialize_apply_candidate",
+        "materialize_include_candidate",
+    }
+    builder_names = {
+        "build_apply_candidate_previews",
+        "build_include_candidate_previews",
+    }
+    command_paths = {
+        apply_from_path,
+        include_from_path,
+    }
+    imports_candidate_materialization = {
+        path: False
+        for path in command_paths
+    }
+    imports_candidate_previews = {
+        path: False
+        for path in command_paths
+    }
+    direct_builder_imports = {
+        path: set()
+        for path in command_paths
+    }
+    materialization_imports_candidate_previews = False
+    materialization_builder_imports = set()
+
+    for path in command_paths:
+        for imported_module, node in _import_from_nodes(path):
+            imported_names = {alias.name for alias in node.names}
+            if (
+                imported_module == "git_stage_batch.commands.batch_source"
+                and "candidate_materialization" in imported_names
+            ):
+                imports_candidate_materialization[path] = True
+            if (
+                imported_module == "git_stage_batch.commands.batch_source"
+                and "candidate_previews" in imported_names
+            ):
+                imports_candidate_previews[path] = True
+            if imported_module == "git_stage_batch.batch.operation_candidates":
+                direct_builder_imports[path] |= imported_names & builder_names
+
+    for imported_module, node in _import_from_nodes(materialization_path):
+        imported_names = {alias.name for alias in node.names}
+        if (
+            imported_module == "git_stage_batch.commands.batch_source"
+            and "candidate_previews" in imported_names
+        ):
+            materialization_imports_candidate_previews = True
+        if imported_module == "git_stage_batch.batch.operation_candidates":
+            materialization_builder_imports |= imported_names & builder_names
+
+    assert public_names <= vars(candidate_materialization).keys()
+    assert imports_candidate_materialization == {
+        apply_from_path: True,
+        include_from_path: True,
+    }
+    assert imports_candidate_previews == {
+        apply_from_path: False,
+        include_from_path: False,
+    }
+    assert direct_builder_imports == {
+        apply_from_path: set(),
+        include_from_path: set(),
+    }
+    assert materialization_imports_candidate_previews
+    assert materialization_builder_imports == builder_names
+
+    for path in command_paths:
+        command_text = path.read_text()
+        assert ".require_candidate_preview_for_ordinal(" not in command_text
+        assert ".require_candidate_preview_state(" not in command_text
+        assert ".close_candidate_previews(" not in command_text
+        assert "build_apply_candidate_previews(" not in command_text
+        assert "build_include_candidate_previews(" not in command_text
 
 
 def test_batch_source_replacement_previews_own_show_replacement_preview():

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -4055,6 +4055,8 @@ def test_batch_source_candidate_previews_own_candidate_preview_checks():
         "candidate_preview_for_ordinal",
         "candidate_preview_state_matches",
         "close_candidate_previews",
+        "require_candidate_preview_for_ordinal",
+        "require_candidate_preview_state",
     }
     command_paths = {
         apply_from_path,
@@ -4094,6 +4096,11 @@ def test_batch_source_candidate_previews_own_candidate_preview_checks():
         include_from_path: set(),
         show_from_path: set(),
     }
+    for path in command_paths:
+        command_text = path.read_text()
+        assert "_resolve_candidate_ordinal" not in command_text
+        assert ".candidate_preview_for_ordinal(" not in command_text
+        assert ".candidate_preview_state_matches(" not in command_text
 
 
 def test_batch_source_candidate_preview_builders_own_show_candidate_construction():

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -4103,17 +4103,23 @@ def test_batch_source_candidate_refusals_own_candidate_count_refusals():
         fromlist=["candidate_refusals"],
     )
     apply_from_path = SRC_ROOT / "commands" / "apply_from.py"
+    include_from_path = SRC_ROOT / "commands" / "include_from.py"
     public_names = {
         "refuse_candidate_conflicts",
     }
-    old_snippets = {
-        "too many apply candidates",
-        "Cannot enumerate apply candidates",
-        "multiple files need apply decisions",
+    old_snippets_by_path = {
+        apply_from_path: {
+            "too many apply candidates",
+            "Cannot enumerate apply candidates",
+            "multiple files need apply decisions",
+        },
+        include_from_path: {
+            "too many include candidates",
+            "Cannot enumerate include candidates",
+            "multiple files need include decisions",
+        },
     }
-    command_paths = {
-        apply_from_path,
-    }
+    command_paths = set(old_snippets_by_path)
     imports_candidate_refusals = {
         path: False
         for path in command_paths
@@ -4131,9 +4137,12 @@ def test_batch_source_candidate_refusals_own_candidate_count_refusals():
     assert public_names <= vars(candidate_refusals).keys()
     assert imports_candidate_refusals == {
         apply_from_path: True,
+        include_from_path: True,
     }
-    for snippet in old_snippets:
-        assert snippet not in apply_from_path.read_text()
+    for path, old_snippets in old_snippets_by_path.items():
+        command_text = path.read_text()
+        for snippet in old_snippets:
+            assert snippet not in command_text
 
 
 def test_batch_source_text_actions_own_text_file_mutations():

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -1030,9 +1030,9 @@ def test_file_review_records_stay_out_of_state_module():
             "ReviewSource",
         },
         SRC_ROOT / "commands" / "show.py": {"ReviewSource"},
-        SRC_ROOT / "commands" / "show_from.py": {
+        SRC_ROOT / "commands" / "show_from.py": {"ReviewSource"},
+        SRC_ROOT / "commands" / "batch_source" / "replacement_previews.py": {
             "FileReviewAction",
-            "ReviewSource",
         },
         SRC_ROOT / "commands" / "skip.py": {"FileReviewAction"},
         SRC_ROOT / "commands" / "status.py": {
@@ -4141,6 +4141,69 @@ def test_batch_source_candidate_preview_builders_own_show_candidate_construction
     assert direct_operation_builder_imports == set()
 
 
+def test_batch_source_replacement_previews_own_show_replacement_preview():
+    """Show-from replacement preview rendering should live in batch-source support."""
+    replacement_previews = __import__(
+        "git_stage_batch.commands.batch_source.replacement_previews",
+        fromlist=["replacement_previews"],
+    )
+    show_from_path = SRC_ROOT / "commands" / "show_from.py"
+    public_names = {
+        "print_batch_source_replacement_preview",
+    }
+    old_function_names = {
+        "_preview_replacement_batch_view",
+    }
+    old_import_names_by_module = {
+        "git_stage_batch.batch.operation_candidates": {
+            "render_candidate_buffer_diff",
+        },
+        "git_stage_batch.batch.replacement": {
+            "build_replacement_batch_view_from_lines",
+        },
+        "git_stage_batch.batch.selection": {
+            "acquire_batch_ownership_for_display_ids_from_lines",
+        },
+        "git_stage_batch.commands.selection": {
+            "replacement_selection",
+        },
+        "git_stage_batch.core.replacement": {
+            "coerce_replacement_payload",
+        },
+        "git_stage_batch.utils.repository_buffers": {
+            "load_git_object_as_buffer",
+        },
+    }
+    show_from_tree = ast.parse(
+        show_from_path.read_text(),
+        filename=str(show_from_path),
+    )
+    show_from_helpers = {
+        node.name
+        for node in ast.walk(show_from_tree)
+        if isinstance(node, ast.FunctionDef)
+    }
+    imports_replacement_previews = False
+    direct_preview_imports = set()
+
+    for imported_module, node in _import_from_nodes(show_from_path):
+        imported_names = {alias.name for alias in node.names}
+        if (
+            imported_module == "git_stage_batch.commands.batch_source"
+            and "replacement_previews" in imported_names
+        ):
+            imports_replacement_previews = True
+        direct_preview_imports |= imported_names & old_import_names_by_module.get(
+            imported_module,
+            set(),
+        )
+
+    assert public_names <= vars(replacement_previews).keys()
+    assert imports_replacement_previews
+    assert old_function_names.isdisjoint(show_from_helpers)
+    assert direct_preview_imports == set()
+
+
 def test_batch_source_candidate_refusals_own_candidate_count_refusals():
     """Shared candidate count refusals should live outside command entries."""
     candidate_refusals = __import__(
@@ -6212,6 +6275,9 @@ def test_replacement_selection_stays_in_command_helper():
     include_from_path = SRC_ROOT / "commands" / "include_from.py"
     discard_path = SRC_ROOT / "commands" / "discard.py"
     show_from_path = SRC_ROOT / "commands" / "show_from.py"
+    replacement_previews_path = (
+        SRC_ROOT / "commands" / "batch_source" / "replacement_previews.py"
+    )
     discard_replacement_path = (
         SRC_ROOT / "commands" / "selection" / "discard_line_replacement.py"
     )
@@ -6243,7 +6309,7 @@ def test_replacement_selection_stays_in_command_helper():
         include_path,
         include_from_path,
         discard_replacement_path,
-        show_from_path,
+        replacement_previews_path,
     )
     violations = []
 

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -4049,6 +4049,7 @@ def test_batch_source_candidate_previews_own_candidate_preview_checks():
         fromlist=["candidate_previews"],
     )
     apply_from_path = SRC_ROOT / "commands" / "apply_from.py"
+    include_from_path = SRC_ROOT / "commands" / "include_from.py"
     public_names = {
         "candidate_preview_for_ordinal",
         "candidate_preview_state_matches",
@@ -4056,6 +4057,7 @@ def test_batch_source_candidate_previews_own_candidate_preview_checks():
     }
     command_paths = {
         apply_from_path,
+        include_from_path,
     }
     imports_candidate_previews = {
         path: False
@@ -4082,9 +4084,11 @@ def test_batch_source_candidate_previews_own_candidate_preview_checks():
     assert public_names <= vars(candidate_previews).keys()
     assert imports_candidate_previews == {
         apply_from_path: True,
+        include_from_path: True,
     }
     assert direct_state_imports == {
         apply_from_path: set(),
+        include_from_path: set(),
     }
 
 

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -4216,6 +4216,72 @@ def test_batch_source_candidate_preview_counts_own_failure_enumeration():
         assert old_names.isdisjoint(helper_names[path])
 
 
+def test_batch_source_candidate_inputs_own_text_candidate_metadata():
+    """Candidate input metadata should live in batch-source support."""
+    candidate_inputs = __import__(
+        "git_stage_batch.commands.batch_source.candidate_inputs",
+        fromlist=["candidate_inputs"],
+    )
+    support_paths = {
+        SRC_ROOT / "commands" / "batch_source" / "candidate_preview_builders.py",
+        SRC_ROOT / "commands" / "batch_source" / "candidate_preview_counts.py",
+        SRC_ROOT / "commands" / "batch_source" / "candidate_materialization.py",
+    }
+    public_names = {
+        "CandidateBatchSourceRef",
+        "CandidateIndexTarget",
+        "CandidateWorktreeTarget",
+        "candidate_batch_source_ref",
+        "candidate_index_text_target",
+        "candidate_worktree_text_target",
+        "is_text_candidate_entry",
+        "require_candidate_batch_source_ref",
+    }
+    disallowed_imports = {
+        "git_stage_batch.batch.submodule_pointer": {
+            "is_batch_submodule_pointer",
+        },
+        "git_stage_batch.core.text_lifecycle": {
+            "mode_for_text_materialization",
+            "normalized_text_change_type",
+        },
+        "git_stage_batch.utils.git": {
+            "get_git_repository_root_path",
+        },
+    }
+    imports_candidate_inputs = {
+        path: False
+        for path in support_paths
+    }
+    direct_metadata_imports = {
+        path: set()
+        for path in support_paths
+    }
+
+    for path in support_paths:
+        for imported_module, node in _import_from_nodes(path):
+            imported_names = {alias.name for alias in node.names}
+            if (
+                imported_module == "git_stage_batch.commands.batch_source"
+                and "candidate_inputs" in imported_names
+            ):
+                imports_candidate_inputs[path] = True
+            direct_metadata_imports[path] |= imported_names & disallowed_imports.get(
+                imported_module,
+                set(),
+            )
+
+    assert public_names <= vars(candidate_inputs).keys()
+    assert imports_candidate_inputs == {
+        path: True
+        for path in support_paths
+    }
+    assert direct_metadata_imports == {
+        path: set()
+        for path in support_paths
+    }
+
+
 def test_batch_source_candidate_materialization_owns_reviewed_candidate_loading():
     """Apply/include reviewed candidate loading should live in batch-source support."""
     candidate_materialization = __import__(

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -4152,6 +4152,7 @@ def test_batch_source_candidate_selectors_own_action_selector_validation():
         fromlist=["candidate_selectors"],
     )
     apply_from_path = SRC_ROOT / "commands" / "apply_from.py"
+    include_from_path = SRC_ROOT / "commands" / "include_from.py"
     public_names = {
         "resolve_batch_source_action_selector",
     }
@@ -4162,6 +4163,10 @@ def test_batch_source_candidate_selectors_own_action_selector_validation():
     old_snippets_by_path = {
         apply_from_path: {
             "names the apply candidate preview set",
+            "requires --file in this implementation",
+        },
+        include_from_path: {
+            "names the include candidate preview set",
             "requires --file in this implementation",
         },
     }
@@ -4191,9 +4196,11 @@ def test_batch_source_candidate_selectors_own_action_selector_validation():
     assert public_names <= vars(candidate_selectors).keys()
     assert imports_candidate_selectors == {
         apply_from_path: True,
+        include_from_path: True,
     }
     assert direct_selector_imports == {
         apply_from_path: set(),
+        include_from_path: set(),
     }
     for path, old_snippets in old_snippets_by_path.items():
         command_text = path.read_text()

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -4208,6 +4208,58 @@ def test_batch_source_candidate_selectors_own_action_selector_validation():
             assert snippet not in command_text
 
 
+def test_batch_source_merge_refusals_own_merge_failure_refusals():
+    """Shared merge failure refusals should live outside command entries."""
+    merge_refusals = __import__(
+        "git_stage_batch.commands.batch_source.merge_refusals",
+        fromlist=["merge_refusals"],
+    )
+    apply_from_path = SRC_ROOT / "commands" / "apply_from.py"
+    public_names = {
+        "refuse_batch_source_merge_failures",
+    }
+    old_snippets_by_path = {
+        apply_from_path: {
+            "gutter_to_selection_id",
+            "Failed for: {files}",
+        },
+    }
+    command_paths = set(old_snippets_by_path)
+    imports_merge_refusals = {
+        path: False
+        for path in command_paths
+    }
+    direct_display_imports = {
+        path: set()
+        for path in command_paths
+    }
+
+    for path in command_paths:
+        for imported_module, node in _import_from_nodes(path):
+            imported_names = {alias.name for alias in node.names}
+            if (
+                imported_module == "git_stage_batch.commands.batch_source"
+                and "merge_refusals" in imported_names
+            ):
+                imports_merge_refusals[path] = True
+            if imported_module == "git_stage_batch.batch.file_display":
+                direct_display_imports[path] |= (
+                    imported_names & {"render_batch_file_display"}
+                )
+
+    assert public_names <= vars(merge_refusals).keys()
+    assert imports_merge_refusals == {
+        apply_from_path: True,
+    }
+    assert direct_display_imports == {
+        apply_from_path: set(),
+    }
+    for path, old_snippets in old_snippets_by_path.items():
+        command_text = path.read_text()
+        for snippet in old_snippets:
+            assert snippet not in command_text
+
+
 def test_batch_source_text_actions_own_text_file_mutations():
     """Shared text file actions should live outside command entries."""
     text_file_actions = __import__(

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -3819,8 +3819,11 @@ def test_operation_candidates_owns_candidate_preview_count():
         "_IncludeCandidateCount",
     }
     expected_imports = {
-        SRC_ROOT / "commands" / "apply_from.py": public_names,
-        SRC_ROOT / "commands" / "include_from.py": public_names,
+        SRC_ROOT
+        / "commands"
+        / "batch_source"
+        / "candidate_preview_counts.py": public_names,
+        SRC_ROOT / "commands" / "batch_source" / "candidate_refusals.py": public_names,
     }
 
     assert public_names <= vars(operation_candidates).keys()
@@ -4146,6 +4149,71 @@ def test_batch_source_candidate_preview_builders_own_show_candidate_construction
     assert imports_candidate_preview_builders
     assert old_function_names.isdisjoint(show_from_helpers)
     assert direct_operation_builder_imports == set()
+
+
+def test_batch_source_candidate_preview_counts_own_failure_enumeration():
+    """Apply/include candidate count enumeration should live in batch-source support."""
+    candidate_preview_counts = __import__(
+        "git_stage_batch.commands.batch_source.candidate_preview_counts",
+        fromlist=["candidate_preview_counts"],
+    )
+    apply_from_path = SRC_ROOT / "commands" / "apply_from.py"
+    include_from_path = SRC_ROOT / "commands" / "include_from.py"
+    public_names = {
+        "count_apply_candidate_previews_for_file",
+        "count_include_candidate_previews_for_file",
+    }
+    old_function_names = {
+        apply_from_path: {
+            "_apply_candidate_count_for_file",
+        },
+        include_from_path: {
+            "_include_candidate_count_for_file",
+        },
+    }
+    old_import_names = {
+        "CandidateEnumerationLimitError",
+        "CandidatePreviewCount",
+    }
+    command_paths = set(old_function_names)
+    imports_candidate_preview_counts = {
+        path: False
+        for path in command_paths
+    }
+    direct_count_imports = {
+        path: set()
+        for path in command_paths
+    }
+    helper_names = {}
+
+    for path in command_paths:
+        tree = ast.parse(path.read_text(), filename=str(path))
+        helper_names[path] = {
+            node.name
+            for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef)
+        }
+        for imported_module, node in _import_from_nodes(path):
+            imported_names = {alias.name for alias in node.names}
+            if (
+                imported_module == "git_stage_batch.commands.batch_source"
+                and "candidate_preview_counts" in imported_names
+            ):
+                imports_candidate_preview_counts[path] = True
+            if imported_module == "git_stage_batch.batch.operation_candidates":
+                direct_count_imports[path] |= imported_names & old_import_names
+
+    assert public_names <= vars(candidate_preview_counts).keys()
+    assert imports_candidate_preview_counts == {
+        apply_from_path: True,
+        include_from_path: True,
+    }
+    assert direct_count_imports == {
+        apply_from_path: set(),
+        include_from_path: set(),
+    }
+    for path, old_names in old_function_names.items():
+        assert old_names.isdisjoint(helper_names[path])
 
 
 def test_batch_source_replacement_previews_own_show_replacement_preview():

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -4215,11 +4215,16 @@ def test_batch_source_merge_refusals_own_merge_failure_refusals():
         fromlist=["merge_refusals"],
     )
     apply_from_path = SRC_ROOT / "commands" / "apply_from.py"
+    include_from_path = SRC_ROOT / "commands" / "include_from.py"
     public_names = {
         "refuse_batch_source_merge_failures",
     }
     old_snippets_by_path = {
         apply_from_path: {
+            "gutter_to_selection_id",
+            "Failed for: {files}",
+        },
+        include_from_path: {
             "gutter_to_selection_id",
             "Failed for: {files}",
         },
@@ -4250,9 +4255,11 @@ def test_batch_source_merge_refusals_own_merge_failure_refusals():
     assert public_names <= vars(merge_refusals).keys()
     assert imports_merge_refusals == {
         apply_from_path: True,
+        include_from_path: True,
     }
     assert direct_display_imports == {
         apply_from_path: set(),
+        include_from_path: set(),
     }
     for path, old_snippets in old_snippets_by_path.items():
         command_text = path.read_text()

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -4042,6 +4042,52 @@ def test_batch_source_action_plans_own_resource_plans():
     assert old_include_names.isdisjoint(include_from_helpers)
 
 
+def test_batch_source_candidate_previews_own_candidate_preview_checks():
+    """Shared candidate preview checks should live outside command entries."""
+    candidate_previews = __import__(
+        "git_stage_batch.commands.batch_source.candidate_previews",
+        fromlist=["candidate_previews"],
+    )
+    apply_from_path = SRC_ROOT / "commands" / "apply_from.py"
+    public_names = {
+        "candidate_preview_for_ordinal",
+        "candidate_preview_state_matches",
+        "close_candidate_previews",
+    }
+    command_paths = {
+        apply_from_path,
+    }
+    imports_candidate_previews = {
+        path: False
+        for path in command_paths
+    }
+    direct_state_imports = {
+        path: set()
+        for path in command_paths
+    }
+
+    for path in command_paths:
+        for imported_module, node in _import_from_nodes(path):
+            imported_names = {alias.name for alias in node.names}
+            if (
+                imported_module == "git_stage_batch.commands.batch_source"
+                and "candidate_previews" in imported_names
+            ):
+                imports_candidate_previews[path] = True
+            if imported_module == "git_stage_batch.batch.operation_candidates":
+                direct_state_imports[path] |= (
+                    imported_names & {"load_candidate_preview_state"}
+                )
+
+    assert public_names <= vars(candidate_previews).keys()
+    assert imports_candidate_previews == {
+        apply_from_path: True,
+    }
+    assert direct_state_imports == {
+        apply_from_path: set(),
+    }
+
+
 def test_batch_source_text_actions_own_text_file_mutations():
     """Shared text file actions should live outside command entries."""
     text_file_actions = __import__(

--- a/tests/batch/test_operation_candidates.py
+++ b/tests/batch/test_operation_candidates.py
@@ -1,0 +1,73 @@
+"""Tests for operation candidate preview models."""
+
+from __future__ import annotations
+
+import pytest
+
+from git_stage_batch.batch.operation_candidates import (
+    OperationCandidatePreview,
+    TargetCandidatePreview,
+)
+from git_stage_batch.core.buffer import LineBuffer
+
+
+def _target(name: str) -> TargetCandidatePreview:
+    return TargetCandidatePreview(
+        target=name,
+        file_path="notes.txt",
+        before_buffer=LineBuffer.from_bytes(b"before\n"),
+        after_buffer=LineBuffer.from_bytes(b"after\n"),
+        file_mode=None,
+        change_type="modified",
+        destination_exists=True,
+        resolution=None,
+        resolution_ordinal=1,
+        resolution_count=1,
+        summary="",
+        explanation="",
+        ambiguity_target_line_range=None,
+    )
+
+
+def _preview(
+    *targets: TargetCandidatePreview,
+) -> OperationCandidatePreview:
+    return OperationCandidatePreview(
+        operation="include",
+        batch_name="cleanup",
+        file_path="notes.txt",
+        ordinal=1,
+        count=1,
+        candidate_id="candidate-1",
+        targets=targets,
+        batch_fingerprint="batch",
+        target_fingerprints={},
+        target_result_fingerprints={},
+        scope_fingerprint="scope",
+    )
+
+
+def test_operation_candidate_preview_requires_named_target():
+    """Named target lookup should return the matching target preview."""
+    worktree_target = _target("worktree")
+    index_target = _target("index")
+    preview = _preview(worktree_target, index_target)
+
+    try:
+        assert preview.require_target("index") is index_target
+        assert preview.require_target("worktree") is worktree_target
+    finally:
+        preview.close()
+
+
+def test_operation_candidate_preview_rejects_missing_target():
+    """Named target lookup should reject an invalid candidate shape."""
+    preview = _preview(_target("worktree"))
+
+    try:
+        with pytest.raises(KeyError) as exc_info:
+            preview.require_target("index")
+    finally:
+        preview.close()
+
+    assert exc_info.value.args == ("index",)

--- a/tests/commands/batch_source/test_action_plans.py
+++ b/tests/commands/batch_source/test_action_plans.py
@@ -74,3 +74,30 @@ def test_include_text_file_action_plan_closes_shared_buffer_once():
     plan.close()
 
     assert buffer.close_count == 1
+
+
+def test_discard_text_file_action_plan_closes_buffer():
+    """Discard text plans should close held worktree content."""
+    buffer = _CloseCountingBuffer()
+    plan = action_plans.DiscardTextFileActionPlan(
+        "notes.txt",
+        buffer,
+        "100644",
+        "modified",
+    )
+
+    plan.close()
+
+    assert buffer.close_count == 1
+
+
+def test_discard_text_file_action_plan_allows_missing_buffer():
+    """Discard text deletion plans should allow absent content buffers."""
+    plan = action_plans.DiscardTextFileActionPlan(
+        "notes.txt",
+        None,
+        None,
+        "deleted",
+    )
+
+    plan.close()

--- a/tests/commands/batch_source/test_candidate_inputs.py
+++ b/tests/commands/batch_source/test_candidate_inputs.py
@@ -1,0 +1,111 @@
+"""Tests for batch-source candidate input metadata helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from git_stage_batch.core.text_lifecycle import TextFileChangeType
+import git_stage_batch.commands.batch_source.candidate_inputs as inputs
+
+
+def test_is_text_candidate_entry_rejects_atomic_entries():
+    """Text candidate input handling should skip binary and gitlink entries."""
+    assert inputs.is_text_candidate_entry({"change_type": "modified"})
+    assert not inputs.is_text_candidate_entry({"file_type": "binary"})
+    assert not inputs.is_text_candidate_entry({"file_type": "gitlink"})
+
+
+def test_candidate_batch_source_ref_returns_object_spec():
+    """Batch source refs should carry both commit and object spec."""
+    ref = inputs.candidate_batch_source_ref(
+        "notes.txt",
+        {"batch_source_commit": "abc123"},
+    )
+
+    assert ref == inputs.CandidateBatchSourceRef(
+        commit="abc123",
+        object_spec="abc123:notes.txt",
+    )
+    assert inputs.candidate_batch_source_ref("notes.txt", {}) is None
+
+
+def test_require_candidate_batch_source_ref_uses_validated_metadata():
+    """Required batch source refs should keep validated metadata failures visible."""
+    ref = inputs.require_candidate_batch_source_ref(
+        "notes.txt",
+        {"batch_source_commit": "abc123"},
+    )
+
+    assert ref.object_spec == "abc123:notes.txt"
+    with pytest.raises(KeyError):
+        inputs.require_candidate_batch_source_ref("notes.txt", {})
+
+
+def test_candidate_worktree_text_target_reports_existing_partial_path(
+    monkeypatch,
+    tmp_path,
+):
+    """Worktree target metadata should account for partial selections."""
+    (tmp_path / "notes.txt").write_text("worktree\n")
+    monkeypatch.setattr(
+        inputs,
+        "get_git_repository_root_path",
+        lambda: tmp_path,
+    )
+
+    target = inputs.candidate_worktree_text_target(
+        file_path="notes.txt",
+        file_meta={
+            "change_type": "deleted",
+            "mode": "100755",
+        },
+        selected_ids={1},
+    )
+
+    assert target == inputs.CandidateWorktreeTarget(
+        exists=True,
+        file_mode=None,
+        text_change_type=TextFileChangeType.DELETED,
+    )
+
+
+def test_candidate_worktree_text_target_reports_missing_whole_path(
+    monkeypatch,
+    tmp_path,
+):
+    """Worktree target metadata should preserve modes for missing paths."""
+    monkeypatch.setattr(
+        inputs,
+        "get_git_repository_root_path",
+        lambda: tmp_path,
+    )
+
+    target = inputs.candidate_worktree_text_target(
+        file_path="notes.txt",
+        file_meta={
+            "change_type": "added",
+            "mode": "100755",
+        },
+        selected_ids=None,
+    )
+
+    assert target == inputs.CandidateWorktreeTarget(
+        exists=False,
+        file_mode="100755",
+        text_change_type=TextFileChangeType.ADDED,
+    )
+
+
+def test_candidate_index_text_target_reports_mode_for_index_state():
+    """Index target metadata should account for path existence and selection."""
+    assert inputs.candidate_index_text_target(
+        file_meta={"mode": "100755"},
+        selected_ids={1},
+        index_exists=True,
+    ) == inputs.CandidateIndexTarget(exists=True, file_mode=None)
+
+    assert inputs.candidate_index_text_target(
+        file_meta={"mode": "100755"},
+        selected_ids={1},
+        index_exists=False,
+    ) == inputs.CandidateIndexTarget(exists=False, file_mode="100755")

--- a/tests/commands/batch_source/test_candidate_materialization.py
+++ b/tests/commands/batch_source/test_candidate_materialization.py
@@ -41,6 +41,9 @@ class _Preview:
     def close(self) -> None:
         self.closed = True
 
+    def require_target(self, name: str) -> _Target:
+        return next(target for target in self.targets if target.target == name)
+
 
 class _ReplacementView(AbstractContextManager):
     def __init__(self, source_buffer: LineBuffer, ownership: object) -> None:

--- a/tests/commands/batch_source/test_candidate_materialization.py
+++ b/tests/commands/batch_source/test_candidate_materialization.py
@@ -67,7 +67,7 @@ def _patch_apply_materialization_io(monkeypatch, tmp_path):
     (tmp_path / "notes.txt").write_bytes(b"worktree\n")
 
     monkeypatch.setattr(
-        materialization,
+        materialization._candidate_inputs,
         "get_git_repository_root_path",
         lambda: tmp_path,
     )
@@ -255,7 +255,7 @@ def _patch_include_materialization_io(monkeypatch, tmp_path):
         return None
 
     monkeypatch.setattr(
-        materialization,
+        materialization._candidate_inputs,
         "get_git_repository_root_path",
         lambda: tmp_path,
     )

--- a/tests/commands/batch_source/test_candidate_materialization.py
+++ b/tests/commands/batch_source/test_candidate_materialization.py
@@ -1,0 +1,217 @@
+"""Tests for batch-source candidate materialization."""
+
+from __future__ import annotations
+
+from contextlib import AbstractContextManager
+
+import pytest
+
+from git_stage_batch.core.buffer import LineBuffer
+from git_stage_batch.exceptions import CommandError
+import git_stage_batch.commands.batch_source.candidate_materialization as materialization
+
+
+class _OwnershipContext(AbstractContextManager):
+    def __init__(self, ownership: object) -> None:
+        self.ownership = ownership
+
+    def __enter__(self) -> object:
+        return self.ownership
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        return None
+
+
+class _Target:
+    def __init__(self, name: str = "worktree") -> None:
+        self.target = name
+
+
+class _Preview:
+    def __init__(self, name: str = "preview") -> None:
+        self.name = name
+        self.targets = (_Target(),)
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _patch_apply_materialization_io(monkeypatch, tmp_path):
+    ownership = object()
+    batch_buffer = LineBuffer.from_bytes(b"batch\n")
+    worktree_buffer = LineBuffer.from_bytes(b"worktree\n")
+    (tmp_path / "notes.txt").write_bytes(b"worktree\n")
+
+    monkeypatch.setattr(
+        materialization,
+        "get_git_repository_root_path",
+        lambda: tmp_path,
+    )
+    monkeypatch.setattr(
+        materialization,
+        "load_git_object_as_buffer",
+        lambda spec: batch_buffer if spec == "commit:notes.txt" else None,
+    )
+    monkeypatch.setattr(
+        materialization,
+        "load_working_tree_file_as_buffer",
+        lambda file_path: worktree_buffer,
+    )
+    monkeypatch.setattr(
+        materialization,
+        "acquire_batch_ownership_for_display_ids_from_lines",
+        lambda file_meta, source_lines, selection_ids: _OwnershipContext(ownership),
+    )
+    return ownership
+
+
+def test_materialize_apply_candidate_returns_reviewed_preview(monkeypatch, tmp_path):
+    """Apply materialization should return the reviewed preview and mode."""
+    ownership = _patch_apply_materialization_io(monkeypatch, tmp_path)
+    previews = (_Preview("first"), _Preview("second"))
+    calls = {}
+
+    def build_apply_candidate_previews(**kwargs):
+        calls["build"] = kwargs
+        return previews
+
+    def require_preview(loaded_previews, ordinal, **kwargs):
+        calls["require_preview"] = (loaded_previews, ordinal, kwargs)
+        return loaded_previews[1]
+
+    def require_state(preview, ordinal, **kwargs):
+        calls["require_state"] = (preview, ordinal, kwargs)
+
+    monkeypatch.setattr(
+        materialization,
+        "build_apply_candidate_previews",
+        build_apply_candidate_previews,
+    )
+    monkeypatch.setattr(
+        materialization._candidate_previews,
+        "require_candidate_preview_for_ordinal",
+        require_preview,
+    )
+    monkeypatch.setattr(
+        materialization._candidate_previews,
+        "require_candidate_preview_state",
+        require_state,
+    )
+
+    result = materialization.materialize_apply_candidate(
+        batch_name="cleanup",
+        raw_selector="cleanup:apply:2",
+        ordinal=2,
+        files={
+            "notes.txt": {
+                "batch_source_commit": "commit",
+                "change_type": "modified",
+                "mode": "100644",
+            },
+        },
+        selected_ids={3},
+        selection_ids_to_apply={9},
+    )
+
+    assert result.preview is previews[1]
+    assert result.previews is previews
+    assert result.target is previews[1].targets[0]
+    assert result.file_path == "notes.txt"
+    assert result.file_mode is None
+    assert calls["build"]["batch_name"] == "cleanup"
+    assert calls["build"]["file_path"] == "notes.txt"
+    assert calls["build"]["ownership"] is ownership
+    assert calls["build"]["selected_ids"] == {3}
+    assert calls["build"]["selection_ids"] == {9}
+    assert calls["build"]["worktree_exists"]
+    assert calls["require_preview"] == (
+        previews,
+        2,
+        {
+            "batch_name": "cleanup",
+            "operation": "apply",
+            "file_path": "notes.txt",
+        },
+    )
+    assert calls["require_state"] == (
+        previews[1],
+        2,
+        {
+            "selector": "cleanup:apply:2",
+            "file_path": "notes.txt",
+        },
+    )
+
+    result.close()
+
+    assert [preview.closed for preview in previews] == [True, True]
+
+
+def test_materialize_apply_candidate_closes_previews_on_state_failure(
+    monkeypatch,
+    tmp_path,
+):
+    """Apply materialization should close previews when state validation fails."""
+    _patch_apply_materialization_io(monkeypatch, tmp_path)
+    previews = (_Preview("first"), _Preview("second"))
+
+    monkeypatch.setattr(
+        materialization,
+        "build_apply_candidate_previews",
+        lambda **kwargs: previews,
+    )
+    monkeypatch.setattr(
+        materialization._candidate_previews,
+        "require_candidate_preview_for_ordinal",
+        lambda loaded_previews, ordinal, **kwargs: loaded_previews[0],
+    )
+
+    def reject_state(preview, ordinal, **kwargs):
+        raise CommandError("stale")
+
+    monkeypatch.setattr(
+        materialization._candidate_previews,
+        "require_candidate_preview_state",
+        reject_state,
+    )
+
+    with pytest.raises(CommandError):
+        materialization.materialize_apply_candidate(
+            batch_name="cleanup",
+            raw_selector="cleanup:apply:1",
+            ordinal=1,
+            files={
+                "notes.txt": {
+                    "batch_source_commit": "commit",
+                    "change_type": "modified",
+                    "mode": "100644",
+                },
+            },
+            selected_ids={3},
+            selection_ids_to_apply={9},
+        )
+
+    assert [preview.closed for preview in previews] == [True, True]
+
+
+def test_materialize_apply_candidate_rejects_binary_entries():
+    """Apply materialization should reject binary batch entries."""
+    with pytest.raises(CommandError) as exc_info:
+        materialization.materialize_apply_candidate(
+            batch_name="cleanup",
+            raw_selector="cleanup:apply:1",
+            ordinal=1,
+            files={
+                "notes.bin": {
+                    "file_type": "binary",
+                    "batch_source_commit": "commit",
+                    "change_type": "modified",
+                    "mode": "100644",
+                },
+            },
+            selected_ids=None,
+            selection_ids_to_apply=None,
+        )
+
+    assert "text batch entries" in exc_info.value.message

--- a/tests/commands/batch_source/test_candidate_materialization.py
+++ b/tests/commands/batch_source/test_candidate_materialization.py
@@ -7,6 +7,7 @@ from contextlib import AbstractContextManager
 import pytest
 
 from git_stage_batch.core.buffer import LineBuffer
+from git_stage_batch.core.replacement import ReplacementPayload
 from git_stage_batch.exceptions import CommandError
 import git_stage_batch.commands.batch_source.candidate_materialization as materialization
 
@@ -28,13 +29,32 @@ class _Target:
 
 
 class _Preview:
-    def __init__(self, name: str = "preview") -> None:
+    def __init__(
+        self,
+        name: str = "preview",
+        targets: tuple[_Target, ...] | None = None,
+    ) -> None:
         self.name = name
-        self.targets = (_Target(),)
+        self.targets = targets or (_Target(),)
         self.closed = False
 
     def close(self) -> None:
         self.closed = True
+
+
+class _ReplacementView(AbstractContextManager):
+    def __init__(self, source_buffer: LineBuffer, ownership: object) -> None:
+        self.source_buffer = source_buffer
+        self.ownership = ownership
+        self.closed = False
+
+    def __enter__(self) -> _ReplacementView:
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        self.source_buffer.close()
+        self.closed = True
+        return None
 
 
 def _patch_apply_materialization_io(monkeypatch, tmp_path):
@@ -215,3 +235,201 @@ def test_materialize_apply_candidate_rejects_binary_entries():
         )
 
     assert "text batch entries" in exc_info.value.message
+
+
+def _patch_include_materialization_io(monkeypatch, tmp_path):
+    ownership = object()
+    batch_buffer = LineBuffer.from_bytes(b"batch\n")
+    index_buffer = LineBuffer.from_bytes(b"index\n")
+    worktree_buffer = LineBuffer.from_bytes(b"worktree\n")
+    (tmp_path / "notes.txt").write_bytes(b"worktree\n")
+
+    def load_git_object_as_buffer(spec):
+        if spec == "commit:notes.txt":
+            return batch_buffer
+        if spec == ":notes.txt":
+            return index_buffer
+        return None
+
+    monkeypatch.setattr(
+        materialization,
+        "get_git_repository_root_path",
+        lambda: tmp_path,
+    )
+    monkeypatch.setattr(
+        materialization,
+        "load_git_object_as_buffer",
+        load_git_object_as_buffer,
+    )
+    monkeypatch.setattr(
+        materialization,
+        "load_working_tree_file_as_buffer",
+        lambda file_path: worktree_buffer,
+    )
+    monkeypatch.setattr(
+        materialization,
+        "acquire_batch_ownership_for_display_ids_from_lines",
+        lambda file_meta, source_lines, selection_ids: _OwnershipContext(ownership),
+    )
+    return ownership
+
+
+def test_materialize_include_candidate_returns_reviewed_preview(
+    monkeypatch,
+    tmp_path,
+):
+    """Include materialization should return the reviewed preview and modes."""
+    ownership = _patch_include_materialization_io(monkeypatch, tmp_path)
+    replacement_payload = ReplacementPayload.from_text("replacement\n")
+    replacement_ownership = object()
+    replacement_view = _ReplacementView(
+        LineBuffer.from_bytes(b"replacement\n"),
+        replacement_ownership,
+    )
+    targets = (_Target("index"), _Target("worktree"))
+    previews = (_Preview("first"), _Preview("second", targets))
+    calls = {}
+
+    def build_replacement_batch_view_from_lines(source_lines, view_ownership, payload):
+        calls["replacement"] = (source_lines, view_ownership, payload)
+        return replacement_view
+
+    def build_include_candidate_previews(**kwargs):
+        calls["build"] = kwargs
+        return previews
+
+    def require_preview(loaded_previews, ordinal, **kwargs):
+        calls["require_preview"] = (loaded_previews, ordinal, kwargs)
+        return loaded_previews[1]
+
+    def require_state(preview, ordinal, **kwargs):
+        calls["require_state"] = (preview, ordinal, kwargs)
+
+    monkeypatch.setattr(
+        materialization,
+        "build_replacement_batch_view_from_lines",
+        build_replacement_batch_view_from_lines,
+    )
+    monkeypatch.setattr(
+        materialization,
+        "build_include_candidate_previews",
+        build_include_candidate_previews,
+    )
+    monkeypatch.setattr(
+        materialization._candidate_previews,
+        "require_candidate_preview_for_ordinal",
+        require_preview,
+    )
+    monkeypatch.setattr(
+        materialization._candidate_previews,
+        "require_candidate_preview_state",
+        require_state,
+    )
+
+    result = materialization.materialize_include_candidate(
+        batch_name="cleanup",
+        raw_selector="cleanup:include:2",
+        ordinal=2,
+        files={
+            "notes.txt": {
+                "batch_source_commit": "commit",
+                "change_type": "modified",
+                "mode": "100644",
+            },
+        },
+        selected_ids={3},
+        selection_ids_to_include={9},
+        replacement_payload=replacement_payload,
+    )
+
+    assert result.preview is previews[1]
+    assert result.previews is previews
+    assert result.index_target is targets[0]
+    assert result.worktree_target is targets[1]
+    assert result.file_path == "notes.txt"
+    assert result.index_file_mode is None
+    assert result.worktree_file_mode is None
+    assert calls["replacement"][1] is ownership
+    assert calls["replacement"][2] is replacement_payload
+    assert calls["build"]["batch_name"] == "cleanup"
+    assert calls["build"]["file_path"] == "notes.txt"
+    assert calls["build"]["source_lines"] is replacement_view.source_buffer
+    assert calls["build"]["ownership"] is replacement_ownership
+    assert calls["build"]["selected_ids"] == {3}
+    assert calls["build"]["selection_ids"] == {9}
+    assert calls["build"]["replacement_payload"] is replacement_payload
+    assert calls["build"]["index_exists"]
+    assert calls["build"]["worktree_exists"]
+    assert calls["require_preview"] == (
+        previews,
+        2,
+        {
+            "batch_name": "cleanup",
+            "operation": "include",
+            "file_path": "notes.txt",
+        },
+    )
+    assert calls["require_state"] == (
+        previews[1],
+        2,
+        {
+            "selector": "cleanup:include:2",
+            "file_path": "notes.txt",
+        },
+    )
+    assert replacement_view.closed
+
+    result.close()
+
+    assert [preview.closed for preview in previews] == [True, True]
+
+
+def test_materialize_include_candidate_closes_previews_on_state_failure(
+    monkeypatch,
+    tmp_path,
+):
+    """Include materialization should close previews when state validation fails."""
+    _patch_include_materialization_io(monkeypatch, tmp_path)
+    previews = (
+        _Preview("first", (_Target("index"), _Target("worktree"))),
+        _Preview("second"),
+    )
+
+    monkeypatch.setattr(
+        materialization,
+        "build_include_candidate_previews",
+        lambda **kwargs: previews,
+    )
+    monkeypatch.setattr(
+        materialization._candidate_previews,
+        "require_candidate_preview_for_ordinal",
+        lambda loaded_previews, ordinal, **kwargs: loaded_previews[0],
+    )
+
+    def reject_state(preview, ordinal, **kwargs):
+        raise CommandError("stale")
+
+    monkeypatch.setattr(
+        materialization._candidate_previews,
+        "require_candidate_preview_state",
+        reject_state,
+    )
+
+    with pytest.raises(CommandError):
+        materialization.materialize_include_candidate(
+            batch_name="cleanup",
+            raw_selector="cleanup:include:1",
+            ordinal=1,
+            files={
+                "notes.txt": {
+                    "batch_source_commit": "commit",
+                    "change_type": "modified",
+                    "mode": "100644",
+                },
+            },
+            selected_ids={3},
+            selection_ids_to_include={9},
+            replacement_payload=None,
+        )
+
+    assert [preview.closed for preview in previews] == [True, True]

--- a/tests/commands/batch_source/test_candidate_preview_builders.py
+++ b/tests/commands/batch_source/test_candidate_preview_builders.py
@@ -48,7 +48,11 @@ def _patch_common_candidate_builder_io(monkeypatch, tmp_path):
             return index_buffer
         return None
 
-    monkeypatch.setattr(builders, "get_git_repository_root_path", lambda: tmp_path)
+    monkeypatch.setattr(
+        builders._candidate_inputs,
+        "get_git_repository_root_path",
+        lambda: tmp_path,
+    )
     monkeypatch.setattr(builders, "load_git_object_as_buffer", load_git_object)
     monkeypatch.setattr(
         builders,

--- a/tests/commands/batch_source/test_candidate_preview_builders.py
+++ b/tests/commands/batch_source/test_candidate_preview_builders.py
@@ -1,0 +1,226 @@
+"""Tests for batch-source candidate preview builders."""
+
+from __future__ import annotations
+
+from contextlib import AbstractContextManager
+
+import pytest
+
+from git_stage_batch.batch.source_selector import BatchSourceSelector
+from git_stage_batch.core.buffer import LineBuffer
+from git_stage_batch.data.file_review.records import FileReviewAction
+import git_stage_batch.commands.batch_source.candidate_preview_builders as builders
+from git_stage_batch.exceptions import CommandError
+
+
+class _OwnershipContext(AbstractContextManager):
+    def __init__(self, ownership: object) -> None:
+        self.ownership = ownership
+
+    def __enter__(self) -> object:
+        return self.ownership
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        return None
+
+
+class _ReplacementView(AbstractContextManager):
+    def __init__(self, source_buffer: LineBuffer, ownership: object) -> None:
+        self.source_buffer = source_buffer
+        self.ownership = ownership
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        self.source_buffer.close()
+        return None
+
+
+def _patch_common_candidate_builder_io(monkeypatch, tmp_path):
+    ownership = object()
+    batch_buffer = LineBuffer.from_bytes(b"batch\n")
+    worktree_buffer = LineBuffer.from_bytes(b"worktree\n")
+    index_buffer = LineBuffer.from_bytes(b"index\n")
+    (tmp_path / "notes.txt").write_bytes(b"worktree\n")
+
+    def load_git_object(spec: str):
+        if spec == "commit:notes.txt":
+            return batch_buffer
+        if spec == ":notes.txt":
+            return index_buffer
+        return None
+
+    monkeypatch.setattr(builders, "get_git_repository_root_path", lambda: tmp_path)
+    monkeypatch.setattr(builders, "load_git_object_as_buffer", load_git_object)
+    monkeypatch.setattr(
+        builders,
+        "load_working_tree_file_as_buffer",
+        lambda file_path: worktree_buffer,
+    )
+    monkeypatch.setattr(
+        builders,
+        "acquire_batch_ownership_for_display_ids_from_lines",
+        lambda file_meta, source_lines, selection_ids: _OwnershipContext(ownership),
+    )
+    return ownership
+
+
+def test_build_batch_source_candidate_previews_builds_apply_candidates(
+    monkeypatch,
+    tmp_path,
+):
+    """Apply candidate construction should pass translated selection IDs."""
+    ownership = _patch_common_candidate_builder_io(monkeypatch, tmp_path)
+    calls = {}
+
+    def translate_selection_ids(batch_name, file_path, selected_ids, action):
+        calls["translation"] = (batch_name, file_path, selected_ids, action)
+        return {10}, None
+
+    def build_apply_candidate_previews(**kwargs):
+        calls["build"] = kwargs
+        return ("apply-preview",)
+
+    monkeypatch.setattr(
+        builders,
+        "build_apply_candidate_previews",
+        build_apply_candidate_previews,
+    )
+
+    previews = builders.build_batch_source_candidate_previews(
+        selector=BatchSourceSelector("cleanup", "apply", 1),
+        files={
+            "notes.txt": {
+                "batch_source_commit": "commit",
+                "change_type": "modified",
+                "mode": "100644",
+            },
+        },
+        file_path="notes.txt",
+        selected_ids={1},
+        replacement_text=None,
+        translate_selection_ids=translate_selection_ids,
+    )
+
+    assert previews == ("apply-preview",)
+    assert calls["translation"] == (
+        "cleanup",
+        "notes.txt",
+        {1},
+        FileReviewAction.APPLY_FROM_BATCH,
+    )
+    assert calls["build"]["batch_name"] == "cleanup"
+    assert calls["build"]["file_path"] == "notes.txt"
+    assert calls["build"]["ownership"] is ownership
+    assert calls["build"]["selected_ids"] == {1}
+    assert calls["build"]["selection_ids"] == {10}
+    assert calls["build"]["worktree_exists"]
+
+
+def test_build_batch_source_candidate_previews_builds_include_replacement(
+    monkeypatch,
+    tmp_path,
+):
+    """Include candidate construction should pass replacement preview state."""
+    replacement_ownership = object()
+    _patch_common_candidate_builder_io(monkeypatch, tmp_path)
+    calls = {}
+
+    def translate_selection_ids(batch_name, file_path, selected_ids, action):
+        calls["translation"] = (batch_name, file_path, selected_ids, action)
+        return {20}, None
+
+    def build_replacement_batch_view_from_lines(source_lines, ownership, payload):
+        calls["replacement_payload"] = payload
+        return _ReplacementView(
+            LineBuffer.from_bytes(b"replacement\n"),
+            replacement_ownership,
+        )
+
+    def build_include_candidate_previews(**kwargs):
+        calls["build"] = kwargs
+        return ("include-preview",)
+
+    monkeypatch.setattr(
+        builders,
+        "build_replacement_batch_view_from_lines",
+        build_replacement_batch_view_from_lines,
+    )
+    monkeypatch.setattr(
+        builders.replacement_selection,
+        "require_contiguous_display_selection",
+        lambda selected_ids: calls.setdefault("contiguous", selected_ids),
+    )
+    monkeypatch.setattr(
+        builders,
+        "build_include_candidate_previews",
+        build_include_candidate_previews,
+    )
+
+    previews = builders.build_batch_source_candidate_previews(
+        selector=BatchSourceSelector("cleanup", "include", 2),
+        files={
+            "notes.txt": {
+                "batch_source_commit": "commit",
+                "change_type": "modified",
+                "mode": "100644",
+            },
+        },
+        file_path="notes.txt",
+        selected_ids={1},
+        replacement_text="new\n",
+        translate_selection_ids=translate_selection_ids,
+    )
+
+    assert previews == ("include-preview",)
+    assert calls["translation"] == (
+        "cleanup",
+        "notes.txt",
+        {1},
+        FileReviewAction.INCLUDE_FROM_BATCH,
+    )
+    assert calls["contiguous"] == {1}
+    assert calls["build"]["ownership"] is replacement_ownership
+    assert calls["build"]["replacement_payload"] is calls["replacement_payload"]
+    assert calls["build"]["selection_ids"] == {20}
+    assert calls["build"]["index_exists"]
+    assert calls["build"]["worktree_exists"]
+
+
+def test_build_batch_source_candidate_previews_rejects_apply_replacement(
+    monkeypatch,
+    tmp_path,
+):
+    """Replacement previews should belong to include candidates."""
+    _patch_common_candidate_builder_io(monkeypatch, tmp_path)
+
+    with pytest.raises(CommandError) as exc_info:
+        builders.build_batch_source_candidate_previews(
+            selector=BatchSourceSelector("cleanup", "apply", 1),
+            files={
+                "notes.txt": {
+                    "batch_source_commit": "commit",
+                    "change_type": "modified",
+                    "mode": "100644",
+                },
+            },
+            file_path="notes.txt",
+            selected_ids={1},
+            replacement_text="new\n",
+        )
+
+    assert "Replacement preview is not valid for apply candidates." in (
+        exc_info.value.message
+    )
+
+
+def test_build_batch_source_candidate_previews_requires_candidate_selector():
+    """Candidate construction should require a candidate operation."""
+    with pytest.raises(ValueError) as exc_info:
+        builders.build_batch_source_candidate_previews(
+            selector=BatchSourceSelector("cleanup"),
+            files={},
+            file_path="notes.txt",
+            selected_ids=None,
+            replacement_text=None,
+        )
+
+    assert "candidate selector" in str(exc_info.value)

--- a/tests/commands/batch_source/test_candidate_preview_counts.py
+++ b/tests/commands/batch_source/test_candidate_preview_counts.py
@@ -51,7 +51,11 @@ def _patch_apply_candidate_count_io(monkeypatch, tmp_path):
     worktree_buffer = LineBuffer.from_bytes(b"worktree\n")
     (tmp_path / "notes.txt").write_bytes(b"worktree\n")
 
-    monkeypatch.setattr(counts, "get_git_repository_root_path", lambda: tmp_path)
+    monkeypatch.setattr(
+        counts._candidate_inputs,
+        "get_git_repository_root_path",
+        lambda: tmp_path,
+    )
     monkeypatch.setattr(
         counts,
         "load_git_object_as_buffer",
@@ -84,7 +88,11 @@ def _patch_include_candidate_count_io(monkeypatch, tmp_path):
             return index_buffer
         return None
 
-    monkeypatch.setattr(counts, "get_git_repository_root_path", lambda: tmp_path)
+    monkeypatch.setattr(
+        counts._candidate_inputs,
+        "get_git_repository_root_path",
+        lambda: tmp_path,
+    )
     monkeypatch.setattr(counts, "load_git_object_as_buffer", load_git_object)
     monkeypatch.setattr(
         counts,

--- a/tests/commands/batch_source/test_candidate_preview_counts.py
+++ b/tests/commands/batch_source/test_candidate_preview_counts.py
@@ -9,6 +9,7 @@ from git_stage_batch.batch.operation_candidates import (
     CandidatePreviewCount,
 )
 from git_stage_batch.core.buffer import LineBuffer
+from git_stage_batch.core.replacement import ReplacementPayload
 import git_stage_batch.commands.batch_source.candidate_preview_counts as counts
 
 
@@ -31,6 +32,19 @@ class _Preview:
         self.closed = True
 
 
+class _ReplacementView(AbstractContextManager):
+    def __init__(self, source_buffer: LineBuffer, ownership: object) -> None:
+        self.source_buffer = source_buffer
+        self.ownership = ownership
+
+    def __enter__(self) -> "_ReplacementView":
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        self.source_buffer.close()
+        return None
+
+
 def _patch_apply_candidate_count_io(monkeypatch, tmp_path):
     ownership = object()
     batch_buffer = LineBuffer.from_bytes(b"batch\n")
@@ -43,6 +57,35 @@ def _patch_apply_candidate_count_io(monkeypatch, tmp_path):
         "load_git_object_as_buffer",
         lambda spec: batch_buffer if spec == "commit:notes.txt" else None,
     )
+    monkeypatch.setattr(
+        counts,
+        "load_working_tree_file_as_buffer",
+        lambda file_path: worktree_buffer,
+    )
+    monkeypatch.setattr(
+        counts,
+        "acquire_batch_ownership_for_display_ids_from_lines",
+        lambda file_meta, source_lines, selection_ids: _OwnershipContext(ownership),
+    )
+    return ownership
+
+
+def _patch_include_candidate_count_io(monkeypatch, tmp_path):
+    ownership = object()
+    batch_buffer = LineBuffer.from_bytes(b"batch\n")
+    index_buffer = LineBuffer.from_bytes(b"index\n")
+    worktree_buffer = LineBuffer.from_bytes(b"worktree\n")
+    (tmp_path / "notes.txt").write_bytes(b"worktree\n")
+
+    def load_git_object(spec: str):
+        if spec == "commit:notes.txt":
+            return batch_buffer
+        if spec == ":notes.txt":
+            return index_buffer
+        return None
+
+    monkeypatch.setattr(counts, "get_git_repository_root_path", lambda: tmp_path)
+    monkeypatch.setattr(counts, "load_git_object_as_buffer", load_git_object)
     monkeypatch.setattr(
         counts,
         "load_working_tree_file_as_buffer",
@@ -144,6 +187,99 @@ def test_count_apply_candidate_previews_for_file_reports_limit(
             "mode": "100644",
         },
         selection_ids_to_apply={7},
+    )
+
+    assert result == CandidatePreviewCount(too_many=True, error="too many")
+
+
+def test_count_include_candidate_previews_for_file_counts_replacements(
+    monkeypatch,
+    tmp_path,
+):
+    """Include candidate counting should count replacement previews."""
+    base_ownership = _patch_include_candidate_count_io(monkeypatch, tmp_path)
+    replacement_ownership = object()
+    payload = ReplacementPayload.from_text("new\n")
+    previews = (_Preview(),)
+    calls = {}
+
+    def build_replacement_view(source_lines, ownership, replacement_payload):
+        calls["replacement"] = (source_lines.to_bytes(), ownership, replacement_payload)
+        return _ReplacementView(
+            LineBuffer.from_bytes(b"replacement\n"),
+            replacement_ownership,
+        )
+
+    def build_include_candidate_previews(**kwargs):
+        calls["build"] = {
+            **kwargs,
+            "source_bytes": kwargs["source_lines"].to_bytes(),
+        }
+        return previews
+
+    monkeypatch.setattr(
+        counts,
+        "build_replacement_batch_view_from_lines",
+        build_replacement_view,
+    )
+    monkeypatch.setattr(
+        counts,
+        "build_include_candidate_previews",
+        build_include_candidate_previews,
+    )
+
+    result = counts.count_include_candidate_previews_for_file(
+        batch_name="cleanup",
+        file_path="notes.txt",
+        file_meta={
+            "batch_source_commit": "commit",
+            "change_type": "modified",
+            "mode": "100644",
+        },
+        selection_ids_to_include={9},
+        replacement_payload=payload,
+    )
+
+    assert result == CandidatePreviewCount(count=1)
+    assert calls["replacement"] == (b"batch\n", base_ownership, payload)
+    assert calls["build"]["batch_name"] == "cleanup"
+    assert calls["build"]["file_path"] == "notes.txt"
+    assert calls["build"]["source_bytes"] == b"replacement\n"
+    assert calls["build"]["ownership"] is replacement_ownership
+    assert calls["build"]["selected_ids"] == {9}
+    assert calls["build"]["selection_ids"] == {9}
+    assert calls["build"]["replacement_payload"] is payload
+    assert calls["build"]["index_exists"]
+    assert calls["build"]["worktree_exists"]
+    assert previews[0].closed
+
+
+def test_count_include_candidate_previews_for_file_reports_limit(
+    monkeypatch,
+    tmp_path,
+):
+    """Include candidate counting should preserve enumeration limit messages."""
+    _patch_include_candidate_count_io(monkeypatch, tmp_path)
+
+    def build_include_candidate_previews(**kwargs):
+        raise CandidateEnumerationLimitError("too many")
+
+    monkeypatch.setattr(
+        counts,
+        "build_include_candidate_previews",
+        build_include_candidate_previews,
+    )
+
+    result = counts.count_include_candidate_previews_for_file(
+        batch_name="cleanup",
+        file_path="notes.txt",
+        file_meta={
+            "batch_source_commit": "commit",
+            "change_type": "modified",
+            "mode": "100644",
+        },
+        selection_ids_to_include={9},
+        replacement_payload=None,
     )
 
     assert result == CandidatePreviewCount(too_many=True, error="too many")

--- a/tests/commands/batch_source/test_candidate_preview_counts.py
+++ b/tests/commands/batch_source/test_candidate_preview_counts.py
@@ -1,0 +1,149 @@
+"""Tests for batch-source candidate preview counts."""
+
+from __future__ import annotations
+
+from contextlib import AbstractContextManager
+
+from git_stage_batch.batch.operation_candidates import (
+    CandidateEnumerationLimitError,
+    CandidatePreviewCount,
+)
+from git_stage_batch.core.buffer import LineBuffer
+import git_stage_batch.commands.batch_source.candidate_preview_counts as counts
+
+
+class _OwnershipContext(AbstractContextManager):
+    def __init__(self, ownership: object) -> None:
+        self.ownership = ownership
+
+    def __enter__(self) -> object:
+        return self.ownership
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        return None
+
+
+class _Preview:
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _patch_apply_candidate_count_io(monkeypatch, tmp_path):
+    ownership = object()
+    batch_buffer = LineBuffer.from_bytes(b"batch\n")
+    worktree_buffer = LineBuffer.from_bytes(b"worktree\n")
+    (tmp_path / "notes.txt").write_bytes(b"worktree\n")
+
+    monkeypatch.setattr(counts, "get_git_repository_root_path", lambda: tmp_path)
+    monkeypatch.setattr(
+        counts,
+        "load_git_object_as_buffer",
+        lambda spec: batch_buffer if spec == "commit:notes.txt" else None,
+    )
+    monkeypatch.setattr(
+        counts,
+        "load_working_tree_file_as_buffer",
+        lambda file_path: worktree_buffer,
+    )
+    monkeypatch.setattr(
+        counts,
+        "acquire_batch_ownership_for_display_ids_from_lines",
+        lambda file_meta, source_lines, selection_ids: _OwnershipContext(ownership),
+    )
+    return ownership
+
+
+def test_count_apply_candidate_previews_for_file_counts_previews(
+    monkeypatch,
+    tmp_path,
+):
+    """Apply candidate counting should return closed preview counts."""
+    ownership = _patch_apply_candidate_count_io(monkeypatch, tmp_path)
+    previews = (_Preview(), _Preview())
+    calls = {}
+
+    def build_apply_candidate_previews(**kwargs):
+        calls["build"] = kwargs
+        return previews
+
+    monkeypatch.setattr(
+        counts,
+        "build_apply_candidate_previews",
+        build_apply_candidate_previews,
+    )
+
+    result = counts.count_apply_candidate_previews_for_file(
+        batch_name="cleanup",
+        file_path="notes.txt",
+        file_meta={
+            "batch_source_commit": "commit",
+            "change_type": "modified",
+            "mode": "100644",
+        },
+        selection_ids_to_apply={7},
+    )
+
+    assert result == CandidatePreviewCount(count=2)
+    assert calls["build"]["batch_name"] == "cleanup"
+    assert calls["build"]["file_path"] == "notes.txt"
+    assert calls["build"]["ownership"] is ownership
+    assert calls["build"]["selected_ids"] == {7}
+    assert calls["build"]["selection_ids"] == {7}
+    assert calls["build"]["worktree_exists"]
+    assert [preview.closed for preview in previews] == [True, True]
+
+
+def test_count_apply_candidate_previews_for_file_skips_binary_entries(monkeypatch):
+    """Apply candidate counting should ignore binary batch entries."""
+    monkeypatch.setattr(
+        counts,
+        "load_git_object_as_buffer",
+        lambda spec: (_ for _ in ()).throw(AssertionError("unexpected load")),
+    )
+
+    result = counts.count_apply_candidate_previews_for_file(
+        batch_name="cleanup",
+        file_path="notes.bin",
+        file_meta={
+            "file_type": "binary",
+            "batch_source_commit": "commit",
+            "change_type": "modified",
+            "mode": "100644",
+        },
+        selection_ids_to_apply=None,
+    )
+
+    assert result == CandidatePreviewCount()
+
+
+def test_count_apply_candidate_previews_for_file_reports_limit(
+    monkeypatch,
+    tmp_path,
+):
+    """Apply candidate counting should preserve enumeration limit messages."""
+    _patch_apply_candidate_count_io(monkeypatch, tmp_path)
+
+    def build_apply_candidate_previews(**kwargs):
+        raise CandidateEnumerationLimitError("too many")
+
+    monkeypatch.setattr(
+        counts,
+        "build_apply_candidate_previews",
+        build_apply_candidate_previews,
+    )
+
+    result = counts.count_apply_candidate_previews_for_file(
+        batch_name="cleanup",
+        file_path="notes.txt",
+        file_meta={
+            "batch_source_commit": "commit",
+            "change_type": "modified",
+            "mode": "100644",
+        },
+        selection_ids_to_apply={7},
+    )
+
+    assert result == CandidatePreviewCount(too_many=True, error="too many")

--- a/tests/commands/batch_source/test_candidate_previews.py
+++ b/tests/commands/batch_source/test_candidate_previews.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 import git_stage_batch.commands.batch_source.candidate_previews as candidate_previews
+from git_stage_batch.exceptions import CommandError
 
 
 class _Preview:
@@ -52,6 +53,56 @@ def test_candidate_preview_for_ordinal_returns_none_for_missing_ordinal(
     preview = candidate_previews.candidate_preview_for_ordinal(previews, ordinal)
 
     assert preview is None
+
+
+def test_require_candidate_preview_for_ordinal_returns_one_based_preview():
+    """Required ordinal lookup should return matching previews."""
+    previews = [_Preview(candidate_id="first"), _Preview(candidate_id="second")]
+
+    preview = candidate_previews.require_candidate_preview_for_ordinal(
+        previews,
+        2,
+        batch_name="cleanup",
+        operation="apply",
+        file_path="notes.txt",
+    )
+
+    assert preview is previews[1]
+
+
+def test_require_candidate_preview_for_ordinal_rejects_non_positive_ordinal():
+    """Required ordinal lookup should reject invalid selector numbering."""
+    previews = [_Preview(candidate_id="first")]
+
+    with pytest.raises(CommandError) as exc_info:
+        candidate_previews.require_candidate_preview_for_ordinal(
+            previews,
+            0,
+            batch_name="cleanup",
+            operation="apply",
+            file_path="notes.txt",
+        )
+
+    assert "Candidate ordinal must be at least 1." in exc_info.value.message
+
+
+def test_require_candidate_preview_for_ordinal_reports_missing_ordinal():
+    """Required ordinal lookup should report the candidate count."""
+    previews = [_Preview(candidate_id="first")]
+
+    with pytest.raises(CommandError) as exc_info:
+        candidate_previews.require_candidate_preview_for_ordinal(
+            previews,
+            2,
+            batch_name="cleanup",
+            operation="include",
+            file_path="notes.txt",
+        )
+
+    assert (
+        "Batch 'cleanup' has 1 include candidates for notes.txt; "
+        "candidate 2 does not exist."
+    ) in exc_info.value.message
 
 
 def test_candidate_preview_state_matches_stored_state(monkeypatch):
@@ -103,6 +154,45 @@ def test_candidate_preview_state_rejects_mismatched_state(
     )
 
     assert not candidate_previews.candidate_preview_state_matches(preview, 1)
+
+
+def test_require_candidate_preview_state_accepts_matching_state(monkeypatch):
+    """Required preview state should accept a matching stored preview."""
+    preview = _Preview()
+    monkeypatch.setattr(
+        candidate_previews,
+        "load_candidate_preview_state",
+        lambda loaded_preview: _matching_state(loaded_preview),
+    )
+
+    candidate_previews.require_candidate_preview_state(
+        preview,
+        1,
+        selector="cleanup:apply:1",
+        file_path="notes.txt",
+    )
+
+
+def test_require_candidate_preview_state_reports_stale_state(monkeypatch):
+    """Required preview state should report missing or stale preview state."""
+    preview = _Preview()
+    monkeypatch.setattr(
+        candidate_previews,
+        "load_candidate_preview_state",
+        lambda _preview: None,
+    )
+
+    with pytest.raises(CommandError) as exc_info:
+        candidate_previews.require_candidate_preview_state(
+            preview,
+            1,
+            selector="cleanup:apply:1",
+            file_path="notes.txt",
+        )
+
+    assert (
+        "Candidate selector 'cleanup:apply:1' has not been previewed for notes.txt."
+    ) in exc_info.value.message
 
 
 def test_close_candidate_previews_closes_every_preview():

--- a/tests/commands/batch_source/test_candidate_refusals.py
+++ b/tests/commands/batch_source/test_candidate_refusals.py
@@ -1,0 +1,134 @@
+"""Tests for batch-source candidate refusal helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from git_stage_batch.batch.operation_candidates import CandidatePreviewCount
+import git_stage_batch.commands.batch_source.candidate_refusals as candidate_refusals
+from git_stage_batch.exceptions import CommandError
+
+
+def _refusal_message(
+    *,
+    operation: str,
+    failed_files: list[str],
+    candidate_counts: dict[str, CandidatePreviewCount],
+) -> str:
+    with pytest.raises(CommandError) as exc_info:
+        candidate_refusals.refuse_candidate_conflicts(
+            batch_name="cleanup",
+            operation=operation,
+            failed_files=failed_files,
+            candidate_counts=candidate_counts,
+        )
+    return exc_info.value.message
+
+
+def test_refuse_candidate_conflicts_reports_single_candidate_limit():
+    """A single candidate limit should name the affected file."""
+    message = _refusal_message(
+        operation="apply",
+        failed_files=["notes.txt"],
+        candidate_counts={"notes.txt": CandidatePreviewCount(too_many=True)},
+    )
+
+    assert (
+        "Cannot apply batch 'cleanup': notes.txt has too many apply candidates"
+        in message
+    )
+    assert "Use --line with a narrower selection" in message
+
+
+def test_refuse_candidate_conflicts_reports_multiple_candidate_limits():
+    """Multiple candidate limits should avoid picking one file."""
+    message = _refusal_message(
+        operation="include",
+        failed_files=["a.txt", "b.txt"],
+        candidate_counts={
+            "a.txt": CandidatePreviewCount(too_many=True),
+            "b.txt": CandidatePreviewCount(too_many=True),
+        },
+    )
+
+    assert "multiple files have too many include candidates" in message
+    assert "Use --line with narrower selections" in message
+
+
+def test_refuse_candidate_conflicts_reports_single_enumeration_error():
+    """A single enumeration failure should include the error detail."""
+    message = _refusal_message(
+        operation="apply",
+        failed_files=["notes.txt"],
+        candidate_counts={
+            "notes.txt": CandidatePreviewCount(error="metadata drift"),
+        },
+    )
+
+    assert (
+        "Cannot enumerate apply candidates for notes.txt: metadata drift"
+        in message
+    )
+    assert "No changes applied." in message
+
+
+def test_refuse_candidate_conflicts_reports_multiple_enumeration_errors():
+    """Multiple enumeration failures should list bounded examples."""
+    message = _refusal_message(
+        operation="include",
+        failed_files=["a.txt", "b.txt", "c.txt", "d.txt"],
+        candidate_counts={
+            "a.txt": CandidatePreviewCount(error="first"),
+            "b.txt": CandidatePreviewCount(error="second"),
+            "c.txt": CandidatePreviewCount(error="third"),
+            "d.txt": CandidatePreviewCount(error="fourth"),
+        },
+    )
+
+    assert "Cannot enumerate include candidates for multiple files." in message
+    assert "  a.txt: first" in message
+    assert "  c.txt: third" in message
+    assert "  d.txt: fourth" not in message
+
+
+def test_refuse_candidate_conflicts_reports_single_ambiguous_file():
+    """A single ambiguous file should point to preview and command execution."""
+    message = _refusal_message(
+        operation="include",
+        failed_files=["notes.txt"],
+        candidate_counts={"notes.txt": CandidatePreviewCount(count=2)},
+    )
+
+    assert "notes.txt has 2 include candidates" in message
+    assert "git-stage-batch show --from cleanup:include --file notes.txt" in message
+    assert (
+        "git-stage-batch include --from cleanup:include:N --file notes.txt"
+        in message
+    )
+    assert "Include a reviewed candidate:" in message
+
+
+def test_refuse_candidate_conflicts_reports_multiple_ambiguous_files():
+    """Multiple ambiguous files should list preview commands."""
+    message = _refusal_message(
+        operation="apply",
+        failed_files=["a.txt", "b.txt"],
+        candidate_counts={
+            "a.txt": CandidatePreviewCount(count=2),
+            "b.txt": CandidatePreviewCount(count=3),
+        },
+    )
+
+    assert "multiple files need apply decisions" in message
+    assert "git-stage-batch show --from cleanup:apply --file a.txt" in message
+    assert "git-stage-batch show --from cleanup:apply --file b.txt" in message
+
+
+def test_refuse_candidate_conflicts_returns_without_candidate_details():
+    """Generic merge failures should fall through to command-specific errors."""
+    candidate_refusals.refuse_candidate_conflicts(
+        batch_name="cleanup",
+        operation="apply",
+        failed_files=["notes.txt"],
+        candidate_counts={},
+    )

--- a/tests/commands/batch_source/test_candidate_selectors.py
+++ b/tests/commands/batch_source/test_candidate_selectors.py
@@ -1,0 +1,82 @@
+"""Tests for batch-source candidate selector helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+import git_stage_batch.commands.batch_source.candidate_selectors as candidate_selectors
+from git_stage_batch.exceptions import CommandError
+
+
+def test_resolve_batch_source_action_selector_accepts_plain_batch_name():
+    """Plain batch names should pass through as non-candidate selectors."""
+    selector = candidate_selectors.resolve_batch_source_action_selector(
+        "cleanup",
+        "apply",
+        file=None,
+    )
+
+    assert selector.batch_name == "cleanup"
+    assert selector.candidate_operation is None
+    assert selector.candidate_ordinal is None
+
+
+def test_resolve_batch_source_action_selector_accepts_numbered_candidate():
+    """Numbered selectors should pass when the required file scope is present."""
+    selector = candidate_selectors.resolve_batch_source_action_selector(
+        "cleanup:include:2",
+        "include",
+        file="notes.txt",
+    )
+
+    assert selector.batch_name == "cleanup"
+    assert selector.candidate_operation == "include"
+    assert selector.candidate_ordinal == 2
+
+
+def test_resolve_batch_source_action_selector_rejects_preview_set():
+    """Bare candidate preview sets should stay preview-only."""
+    with pytest.raises(CommandError) as exc_info:
+        candidate_selectors.resolve_batch_source_action_selector(
+            "cleanup:apply",
+            "apply",
+            file="notes.txt",
+        )
+
+    assert "'cleanup:apply' names the apply candidate preview set." in (
+        exc_info.value.message
+    )
+    assert "git-stage-batch show --from cleanup:apply" in exc_info.value.message
+    assert "cleanup:apply:N" in exc_info.value.message
+
+
+def test_resolve_batch_source_action_selector_requires_file_for_numbered_candidate():
+    """Numbered candidate execution should require an explicit file."""
+    with pytest.raises(CommandError) as exc_info:
+        candidate_selectors.resolve_batch_source_action_selector(
+            "cleanup:include:2",
+            "include",
+            file=None,
+        )
+
+    assert (
+        "Candidate selector 'cleanup:include:2' requires --file"
+        in exc_info.value.message
+    )
+    assert "No changes applied." in exc_info.value.message
+
+
+def test_resolve_batch_source_action_selector_rejects_wrong_operation():
+    """Action commands should reject candidate selectors for the other action."""
+    with pytest.raises(CommandError) as exc_info:
+        candidate_selectors.resolve_batch_source_action_selector(
+            "cleanup:include:2",
+            "apply",
+            file="notes.txt",
+        )
+
+    assert "'cleanup:include:2' is an include candidate" in exc_info.value.message
+    assert "not an apply candidate" in exc_info.value.message
+    assert "git-stage-batch show --from cleanup:apply --file notes.txt" in (
+        exc_info.value.message
+    )

--- a/tests/commands/batch_source/test_merge_refusals.py
+++ b/tests/commands/batch_source/test_merge_refusals.py
@@ -1,0 +1,66 @@
+"""Tests for batch-source merge refusal helpers."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+import git_stage_batch.commands.batch_source.merge_refusals as merge_refusals
+from git_stage_batch.exceptions import CommandError
+
+
+def _refusal_message(failed_files: list[str]) -> str:
+    with pytest.raises(CommandError) as exc_info:
+        merge_refusals.refuse_batch_source_merge_failures(
+            batch_name="cleanup",
+            failed_files=failed_files,
+        )
+    return exc_info.value.message
+
+
+def test_refuse_batch_source_merge_failures_suggests_line_selection(
+    monkeypatch,
+):
+    """Single-file merge failures should mention --lines when lines map."""
+    monkeypatch.setattr(
+        merge_refusals,
+        "render_batch_file_display",
+        lambda batch_name, file_path: SimpleNamespace(gutter_to_selection_id={1: 10}),
+    )
+
+    message = _refusal_message(["notes.txt"])
+
+    assert "cleanup' contains changes to notes.txt" in message
+    assert "or use '--lines' to apply only specific changes." in message
+
+
+def test_refuse_batch_source_merge_failures_omits_line_hint_without_mapping(
+    monkeypatch,
+):
+    """Single-file merge failures should omit --lines when no lines map."""
+    monkeypatch.setattr(
+        merge_refusals,
+        "render_batch_file_display",
+        lambda batch_name, file_path: None,
+    )
+
+    message = _refusal_message(["notes.txt"])
+
+    assert "cleanup' contains changes to notes.txt" in message
+    assert "or use '--lines'" not in message
+
+
+def test_refuse_batch_source_merge_failures_reports_multiple_files(monkeypatch):
+    """Multi-file merge failures should list the failed files."""
+    monkeypatch.setattr(
+        merge_refusals,
+        "render_batch_file_display",
+        lambda batch_name, file_path: pytest.fail("should not render files"),
+    )
+
+    message = _refusal_message(["a.txt", "b.txt"])
+
+    assert "one or more files" in message
+    assert "Failed for: a.txt, b.txt." in message
+    assert "or use '--lines' to apply only specific changes." in message

--- a/tests/commands/batch_source/test_replacement_previews.py
+++ b/tests/commands/batch_source/test_replacement_previews.py
@@ -1,0 +1,178 @@
+"""Tests for batch-source replacement previews."""
+
+from __future__ import annotations
+
+from contextlib import AbstractContextManager
+
+import pytest
+
+from git_stage_batch.core.buffer import LineBuffer
+from git_stage_batch.data.file_review.records import FileReviewAction
+from git_stage_batch.exceptions import CommandError
+import git_stage_batch.commands.batch_source.replacement_previews as previews
+
+
+class _OwnershipContext(AbstractContextManager):
+    def __init__(self, ownership: object) -> None:
+        self.ownership = ownership
+
+    def __enter__(self) -> object:
+        return self.ownership
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        return None
+
+
+class _ReplacementView(AbstractContextManager):
+    def __init__(self, source_buffer: LineBuffer, ownership: object) -> None:
+        self.source_buffer = source_buffer
+        self.ownership = ownership
+
+    def __enter__(self) -> "_ReplacementView":
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        self.source_buffer.close()
+        return None
+
+
+def test_print_batch_source_replacement_preview_prints_diff(
+    monkeypatch,
+    capsys,
+):
+    """Replacement preview printing should wire selection, ownership, and diff."""
+    ownership = object()
+    replacement_ownership = object()
+    batch_buffer = LineBuffer.from_bytes(b"old\n")
+    replacement_buffer = LineBuffer.from_bytes(b"new\n")
+    calls = {}
+
+    def load_git_object(spec: str):
+        calls["git_object"] = spec
+        return batch_buffer
+
+    def translate_selection_ids(batch_name, file_path, selected_ids, action):
+        calls["translation"] = (batch_name, file_path, selected_ids, action)
+        return {7}, None
+
+    def acquire_ownership(file_meta, source_lines, selection_ids):
+        calls["ownership"] = (file_meta, source_lines, selection_ids)
+        return _OwnershipContext(ownership)
+
+    def build_replacement_view(source_lines, acquired_ownership, payload):
+        calls["replacement"] = (source_lines, acquired_ownership, payload)
+        return _ReplacementView(replacement_buffer, replacement_ownership)
+
+    def render_diff(
+        file_path,
+        before,
+        after,
+        *,
+        label_before,
+        label_after,
+        context_lines,
+    ):
+        calls["render"] = (
+            file_path,
+            before.to_bytes(),
+            after.to_bytes(),
+            label_before,
+            label_after,
+            context_lines,
+        )
+        return "diff\n"
+
+    monkeypatch.setattr(previews, "load_git_object_as_buffer", load_git_object)
+    monkeypatch.setattr(
+        previews,
+        "acquire_batch_ownership_for_display_ids_from_lines",
+        acquire_ownership,
+    )
+    monkeypatch.setattr(
+        previews,
+        "build_replacement_batch_view_from_lines",
+        build_replacement_view,
+    )
+    monkeypatch.setattr(previews, "render_candidate_buffer_diff", render_diff)
+    monkeypatch.setattr(previews, "get_context_lines", lambda: 8)
+
+    previews.print_batch_source_replacement_preview(
+        batch_name="cleanup",
+        files={
+            "notes.txt": {
+                "batch_source_commit": "commit",
+                "change_type": "modified",
+                "mode": "100644",
+            },
+        },
+        file_path="notes.txt",
+        selected_ids={3},
+        replacement_text="new\n",
+        translate_selection_ids=translate_selection_ids,
+    )
+
+    captured = capsys.readouterr()
+    assert captured.out == "diff\n"
+    assert calls["git_object"] == "commit:notes.txt"
+    assert calls["translation"] == (
+        "cleanup",
+        "notes.txt",
+        {3},
+        FileReviewAction.INCLUDE_FROM_BATCH,
+    )
+    assert calls["ownership"][2] == {7}
+    assert calls["replacement"][1] is ownership
+    assert calls["replacement"][2].as_text() == "new\n"
+    assert calls["render"] == (
+        "notes.txt",
+        b"old\n",
+        b"new\n",
+        "batch",
+        "replacement-preview",
+        8,
+    )
+
+
+def test_print_batch_source_replacement_preview_rejects_binary_entries():
+    """Replacement previews should reject binary batch entries."""
+    with pytest.raises(CommandError) as exc_info:
+        previews.print_batch_source_replacement_preview(
+            batch_name="cleanup",
+            files={
+                "notes.bin": {
+                    "file_type": "binary",
+                    "batch_source_commit": "commit",
+                    "change_type": "modified",
+                    "mode": "100644",
+                },
+            },
+            file_path="notes.bin",
+            selected_ids={1},
+            replacement_text="new\n",
+        )
+
+    assert "binary files" in exc_info.value.message
+
+
+def test_print_batch_source_replacement_preview_reports_missing_source(
+    monkeypatch,
+):
+    """Replacement previews should report missing batch source content."""
+    monkeypatch.setattr(previews, "load_git_object_as_buffer", lambda spec: None)
+
+    with pytest.raises(CommandError) as exc_info:
+        previews.print_batch_source_replacement_preview(
+            batch_name="cleanup",
+            files={
+                "notes.txt": {
+                    "batch_source_commit": "commit",
+                    "change_type": "modified",
+                    "mode": "100644",
+                },
+            },
+            file_path="notes.txt",
+            selected_ids={1},
+            replacement_text="new\n",
+        )
+
+    assert "Batch source content is missing for notes.txt." in exc_info.value.message

--- a/tests/commands/batch_source/test_text_plan_builders.py
+++ b/tests/commands/batch_source/test_text_plan_builders.py
@@ -1,0 +1,190 @@
+"""Tests for batch-source text action plan builders."""
+
+from __future__ import annotations
+
+from contextlib import AbstractContextManager
+
+from git_stage_batch.core.buffer import LineBuffer
+from git_stage_batch.core.text_lifecycle import TextFileChangeType
+import git_stage_batch.commands.batch_source.text_plan_builders as builders
+
+
+class _Ownership:
+    def __init__(self, *, empty: bool = False) -> None:
+        self._empty = empty
+
+    def is_empty(self) -> bool:
+        return self._empty
+
+
+class _OwnershipContext(AbstractContextManager):
+    def __init__(self, ownership: _Ownership) -> None:
+        self.ownership = ownership
+
+    def __enter__(self) -> _Ownership:
+        return self.ownership
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        return None
+
+
+def _patch_apply_text_plan_io(monkeypatch, tmp_path, ownership: _Ownership):
+    batch_buffer = LineBuffer.from_bytes(b"batch\n")
+    worktree_buffer = LineBuffer.from_bytes(b"worktree\n")
+    (tmp_path / "notes.txt").write_bytes(b"worktree\n")
+
+    monkeypatch.setattr(
+        builders,
+        "get_git_repository_root_path",
+        lambda: tmp_path,
+    )
+    monkeypatch.setattr(
+        builders,
+        "load_git_object_as_buffer",
+        lambda spec: batch_buffer if spec == "commit:notes.txt" else None,
+    )
+    monkeypatch.setattr(
+        builders,
+        "load_working_tree_file_as_buffer",
+        lambda file_path: worktree_buffer,
+    )
+    monkeypatch.setattr(
+        builders,
+        "acquire_batch_ownership_for_display_ids_from_lines",
+        lambda file_meta, source_lines, selection_ids: _OwnershipContext(ownership),
+    )
+    return batch_buffer, worktree_buffer
+
+
+def test_build_apply_text_file_action_plan_returns_merged_plan(
+    monkeypatch,
+    tmp_path,
+):
+    """Apply text planning should merge owned source lines into worktree lines."""
+    ownership = _Ownership()
+    batch_buffer, worktree_buffer = _patch_apply_text_plan_io(
+        monkeypatch,
+        tmp_path,
+        ownership,
+    )
+    calls = {}
+
+    def merge_batch_from_line_sequences_as_buffer(source_lines, line_ownership, target):
+        calls["merge"] = (source_lines, line_ownership, target)
+        return LineBuffer.from_bytes(b"merged\n")
+
+    monkeypatch.setattr(
+        builders,
+        "merge_batch_from_line_sequences_as_buffer",
+        merge_batch_from_line_sequences_as_buffer,
+    )
+
+    result = builders.build_apply_text_file_action_plan(
+        file_path="notes.txt",
+        file_meta={
+            "batch_source_commit": "commit",
+            "change_type": "modified",
+            "mode": "100755",
+        },
+        selected_ids={1},
+        selection_ids_to_apply={7},
+    )
+
+    assert not result.missing_source
+    assert result.plan is not None
+    assert result.plan.file_path == "notes.txt"
+    assert result.plan.buffer is not None
+    assert result.plan.buffer.to_bytes() == b"merged\n"
+    assert result.plan.file_mode is None
+    assert result.plan.change_type == TextFileChangeType.MODIFIED
+    assert calls["merge"] == (batch_buffer, ownership, worktree_buffer)
+
+    result.plan.close()
+
+
+def test_build_apply_text_file_action_plan_returns_deleted_plan(
+    monkeypatch,
+    tmp_path,
+):
+    """Whole-file deletion planning should not load batch source content."""
+    monkeypatch.setattr(
+        builders,
+        "get_git_repository_root_path",
+        lambda: tmp_path,
+    )
+    monkeypatch.setattr(
+        builders,
+        "load_git_object_as_buffer",
+        lambda spec: (_ for _ in ()).throw(AssertionError("unexpected load")),
+    )
+
+    result = builders.build_apply_text_file_action_plan(
+        file_path="notes.txt",
+        file_meta={
+            "batch_source_commit": "commit",
+            "change_type": "deleted",
+            "mode": "100644",
+        },
+        selected_ids=None,
+        selection_ids_to_apply=None,
+    )
+
+    assert not result.missing_source
+    assert result.plan is not None
+    assert result.plan.file_path == "notes.txt"
+    assert result.plan.buffer is None
+    assert result.plan.file_mode == "100644"
+    assert result.plan.change_type == TextFileChangeType.DELETED
+
+
+def test_build_apply_text_file_action_plan_reports_missing_source(
+    monkeypatch,
+    tmp_path,
+):
+    """Missing batch source content should stay visible to the command."""
+    monkeypatch.setattr(
+        builders,
+        "get_git_repository_root_path",
+        lambda: tmp_path,
+    )
+    monkeypatch.setattr(
+        builders,
+        "load_git_object_as_buffer",
+        lambda spec: None,
+    )
+
+    result = builders.build_apply_text_file_action_plan(
+        file_path="notes.txt",
+        file_meta={
+            "batch_source_commit": "commit",
+            "change_type": "modified",
+            "mode": "100644",
+        },
+        selected_ids=None,
+        selection_ids_to_apply=None,
+    )
+
+    assert result.missing_source
+    assert result.plan is None
+
+
+def test_build_apply_text_file_action_plan_skips_empty_partial_ownership(
+    monkeypatch,
+    tmp_path,
+):
+    """Empty partial ownership should produce no action plan."""
+    _patch_apply_text_plan_io(monkeypatch, tmp_path, _Ownership(empty=True))
+
+    result = builders.build_apply_text_file_action_plan(
+        file_path="notes.txt",
+        file_meta={
+            "batch_source_commit": "commit",
+            "change_type": "modified",
+            "mode": "100644",
+        },
+        selected_ids={1},
+        selection_ids_to_apply=set(),
+    )
+
+    assert not result.missing_source
+    assert result.plan is None

--- a/tests/commands/batch_source/test_text_plan_builders.py
+++ b/tests/commands/batch_source/test_text_plan_builders.py
@@ -56,6 +56,43 @@ def _patch_apply_text_plan_io(monkeypatch, tmp_path, ownership: _Ownership):
     return batch_buffer, worktree_buffer
 
 
+def _patch_include_text_plan_io(monkeypatch, tmp_path, ownership: _Ownership):
+    index_buffer = LineBuffer.from_bytes(b"index\n")
+    batch_buffer = LineBuffer.from_bytes(b"batch\n")
+    worktree_buffer = LineBuffer.from_bytes(b"worktree\n")
+    (tmp_path / "notes.txt").write_bytes(b"worktree\n")
+
+    monkeypatch.setattr(
+        builders,
+        "get_git_repository_root_path",
+        lambda: tmp_path,
+    )
+
+    def load_git_object_as_buffer(spec):
+        if spec == ":notes.txt":
+            return index_buffer
+        if spec == "commit:notes.txt":
+            return batch_buffer
+        return None
+
+    monkeypatch.setattr(
+        builders,
+        "load_git_object_as_buffer",
+        load_git_object_as_buffer,
+    )
+    monkeypatch.setattr(
+        builders,
+        "load_working_tree_file_as_buffer",
+        lambda file_path: worktree_buffer,
+    )
+    monkeypatch.setattr(
+        builders,
+        "acquire_batch_ownership_for_display_ids_from_lines",
+        lambda file_meta, source_lines, selection_ids: _OwnershipContext(ownership),
+    )
+    return index_buffer, batch_buffer, worktree_buffer
+
+
 def test_build_apply_text_file_action_plan_returns_merged_plan(
     monkeypatch,
     tmp_path,
@@ -184,6 +221,170 @@ def test_build_apply_text_file_action_plan_skips_empty_partial_ownership(
         },
         selected_ids={1},
         selection_ids_to_apply=set(),
+    )
+
+    assert not result.missing_source
+    assert result.plan is None
+
+
+def test_build_include_text_file_action_plan_returns_merged_plan(
+    monkeypatch,
+    tmp_path,
+):
+    """Include text planning should merge owned source lines into both targets."""
+    ownership = _Ownership()
+    index_buffer, batch_buffer, worktree_buffer = _patch_include_text_plan_io(
+        monkeypatch,
+        tmp_path,
+        ownership,
+    )
+    calls = []
+
+    def merge_batch_from_line_sequences_as_buffer(source_lines, line_ownership, target):
+        calls.append((source_lines, line_ownership, target))
+        if target is index_buffer:
+            return LineBuffer.from_bytes(b"merged-index\n")
+        return LineBuffer.from_bytes(b"merged-worktree\n")
+
+    monkeypatch.setattr(
+        builders,
+        "merge_batch_from_line_sequences_as_buffer",
+        merge_batch_from_line_sequences_as_buffer,
+    )
+
+    result = builders.build_include_text_file_action_plan(
+        file_path="notes.txt",
+        file_meta={
+            "batch_source_commit": "commit",
+            "change_type": "modified",
+            "mode": "100755",
+        },
+        selected_ids={1},
+        selection_ids_to_include={7},
+        replacement_payload=None,
+    )
+
+    assert not result.missing_source
+    assert result.plan is not None
+    assert result.plan.file_path == "notes.txt"
+    assert result.plan.index_buffer is not None
+    assert result.plan.working_buffer is not None
+    assert result.plan.index_buffer.to_bytes() == b"merged-index\n"
+    assert result.plan.working_buffer.to_bytes() == b"merged-worktree\n"
+    assert result.plan.index_file_mode is None
+    assert result.plan.working_file_mode is None
+    assert result.plan.index_change_type == TextFileChangeType.MODIFIED
+    assert result.plan.working_change_type == TextFileChangeType.MODIFIED
+    assert calls == [
+        (batch_buffer, ownership, index_buffer),
+        (batch_buffer, ownership, worktree_buffer),
+    ]
+
+    result.plan.close()
+
+
+def test_build_include_text_file_action_plan_returns_deleted_plan(
+    monkeypatch,
+    tmp_path,
+):
+    """Whole-file deletion planning should not load batch source content."""
+    index_buffer = LineBuffer.from_bytes(b"index\n")
+    monkeypatch.setattr(
+        builders,
+        "get_git_repository_root_path",
+        lambda: tmp_path,
+    )
+
+    def load_git_object_as_buffer(spec):
+        if spec == ":notes.txt":
+            return index_buffer
+        raise AssertionError("unexpected load")
+
+    monkeypatch.setattr(
+        builders,
+        "load_git_object_as_buffer",
+        load_git_object_as_buffer,
+    )
+
+    result = builders.build_include_text_file_action_plan(
+        file_path="notes.txt",
+        file_meta={
+            "batch_source_commit": "commit",
+            "change_type": "deleted",
+            "mode": "100644",
+        },
+        selected_ids=None,
+        selection_ids_to_include=None,
+        replacement_payload=None,
+    )
+
+    assert not result.missing_source
+    assert result.plan is not None
+    assert result.plan.file_path == "notes.txt"
+    assert result.plan.index_buffer is None
+    assert result.plan.working_buffer is None
+    assert result.plan.index_file_mode == "100644"
+    assert result.plan.working_file_mode == "100644"
+    assert result.plan.index_change_type == TextFileChangeType.DELETED
+    assert result.plan.working_change_type == TextFileChangeType.DELETED
+
+
+def test_build_include_text_file_action_plan_reports_missing_source(
+    monkeypatch,
+    tmp_path,
+):
+    """Missing batch source content should stay visible to the command."""
+    index_buffer = LineBuffer.from_bytes(b"index\n")
+    monkeypatch.setattr(
+        builders,
+        "get_git_repository_root_path",
+        lambda: tmp_path,
+    )
+
+    def load_git_object_as_buffer(spec):
+        if spec == ":notes.txt":
+            return index_buffer
+        return None
+
+    monkeypatch.setattr(
+        builders,
+        "load_git_object_as_buffer",
+        load_git_object_as_buffer,
+    )
+
+    result = builders.build_include_text_file_action_plan(
+        file_path="notes.txt",
+        file_meta={
+            "batch_source_commit": "commit",
+            "change_type": "modified",
+            "mode": "100644",
+        },
+        selected_ids=None,
+        selection_ids_to_include=None,
+        replacement_payload=None,
+    )
+
+    assert result.missing_source
+    assert result.plan is None
+
+
+def test_build_include_text_file_action_plan_skips_empty_partial_ownership(
+    monkeypatch,
+    tmp_path,
+):
+    """Empty partial ownership should produce no action plan."""
+    _patch_include_text_plan_io(monkeypatch, tmp_path, _Ownership(empty=True))
+
+    result = builders.build_include_text_file_action_plan(
+        file_path="notes.txt",
+        file_meta={
+            "batch_source_commit": "commit",
+            "change_type": "modified",
+            "mode": "100644",
+        },
+        selected_ids={1},
+        selection_ids_to_include=set(),
+        replacement_payload=None,
     )
 
     assert not result.missing_source

--- a/tests/commands/batch_source/test_text_plan_builders.py
+++ b/tests/commands/batch_source/test_text_plan_builders.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 from contextlib import AbstractContextManager
 
+import pytest
+
 from git_stage_batch.core.buffer import LineBuffer
 from git_stage_batch.core.replacement import ReplacementPayload
 from git_stage_batch.core.text_lifecycle import TextFileChangeType
+from git_stage_batch.exceptions import MergeError
 import git_stage_batch.commands.batch_source.text_plan_builders as builders
 
 
@@ -310,6 +313,47 @@ def test_build_include_text_file_action_plan_uses_replacement_view(
     assert replacement_view.closed
 
     result.plan.close()
+
+
+def test_build_include_text_file_action_plan_closes_partial_merge_on_failure(
+    monkeypatch,
+    tmp_path,
+):
+    """A failed second merge should release the first merged target buffer."""
+    ownership = _Ownership()
+    index_buffer, _batch_buffer, _worktree_buffer = _patch_include_text_plan_io(
+        monkeypatch,
+        tmp_path,
+        ownership,
+    )
+    merged_index_buffer = LineBuffer.from_bytes(b"merged-index\n")
+
+    def merge_batch_from_line_sequences_as_buffer(source_lines, line_ownership, target):
+        if target is index_buffer:
+            return merged_index_buffer
+        raise MergeError("worktree conflict")
+
+    monkeypatch.setattr(
+        builders,
+        "merge_batch_from_line_sequences_as_buffer",
+        merge_batch_from_line_sequences_as_buffer,
+    )
+
+    with pytest.raises(MergeError, match="worktree conflict"):
+        builders.build_include_text_file_action_plan(
+            file_path="notes.txt",
+            file_meta={
+                "batch_source_commit": "commit",
+                "change_type": "modified",
+                "mode": "100644",
+            },
+            selected_ids={1},
+            selection_ids_to_include={7},
+            replacement_payload=None,
+        )
+
+    with pytest.raises(ValueError, match="buffer is closed"):
+        merged_index_buffer.to_bytes()
 
 
 def test_build_include_text_file_action_plan_returns_merged_plan(

--- a/tests/commands/batch_source/test_text_plan_builders.py
+++ b/tests/commands/batch_source/test_text_plan_builders.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from contextlib import AbstractContextManager
 
 from git_stage_batch.core.buffer import LineBuffer
+from git_stage_batch.core.replacement import ReplacementPayload
 from git_stage_batch.core.text_lifecycle import TextFileChangeType
 import git_stage_batch.commands.batch_source.text_plan_builders as builders
 
@@ -26,6 +27,23 @@ class _OwnershipContext(AbstractContextManager):
 
     def __exit__(self, exc_type, exc_value, traceback) -> None:
         return None
+
+
+class _ReplacementView(AbstractContextManager):
+    def __init__(self, source_buffer: LineBuffer, ownership: _Ownership) -> None:
+        self.source_buffer = source_buffer
+        self.ownership = ownership
+        self.closed = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        self.close()
+
+    def close(self) -> None:
+        self.closed = True
+        self.source_buffer.close()
 
 
 def _patch_apply_text_plan_io(monkeypatch, tmp_path, ownership: _Ownership):
@@ -225,6 +243,73 @@ def test_build_apply_text_file_action_plan_skips_empty_partial_ownership(
 
     assert not result.missing_source
     assert result.plan is None
+
+
+def test_build_include_text_file_action_plan_uses_replacement_view(
+    monkeypatch,
+    tmp_path,
+):
+    """Replacement include planning should merge generated source lines."""
+    ownership = _Ownership()
+    replacement_ownership = _Ownership()
+    replacement_view = _ReplacementView(
+        LineBuffer.from_bytes(b"replacement\n"),
+        replacement_ownership,
+    )
+    index_buffer, batch_buffer, worktree_buffer = _patch_include_text_plan_io(
+        monkeypatch,
+        tmp_path,
+        ownership,
+    )
+    payload = ReplacementPayload.from_text("new\n")
+    calls = {"merge": []}
+
+    def build_replacement_batch_view_from_lines(source_lines, line_ownership, value):
+        calls["replacement"] = (source_lines, line_ownership, value)
+        return replacement_view
+
+    def merge_batch_from_line_sequences_as_buffer(source_lines, line_ownership, target):
+        calls["merge"].append((source_lines, line_ownership, target))
+        if target is index_buffer:
+            return LineBuffer.from_bytes(b"replacement-index\n")
+        return LineBuffer.from_bytes(b"replacement-worktree\n")
+
+    monkeypatch.setattr(
+        builders,
+        "build_replacement_batch_view_from_lines",
+        build_replacement_batch_view_from_lines,
+    )
+    monkeypatch.setattr(
+        builders,
+        "merge_batch_from_line_sequences_as_buffer",
+        merge_batch_from_line_sequences_as_buffer,
+    )
+
+    result = builders.build_include_text_file_action_plan(
+        file_path="notes.txt",
+        file_meta={
+            "batch_source_commit": "commit",
+            "change_type": "modified",
+            "mode": "100644",
+        },
+        selected_ids={1},
+        selection_ids_to_include={7},
+        replacement_payload=payload,
+    )
+
+    assert result.plan is not None
+    assert result.plan.index_buffer is not None
+    assert result.plan.working_buffer is not None
+    assert result.plan.index_buffer.to_bytes() == b"replacement-index\n"
+    assert result.plan.working_buffer.to_bytes() == b"replacement-worktree\n"
+    assert calls["replacement"] == (batch_buffer, ownership, payload)
+    assert calls["merge"] == [
+        (replacement_view.source_buffer, replacement_ownership, index_buffer),
+        (replacement_view.source_buffer, replacement_ownership, worktree_buffer),
+    ]
+    assert replacement_view.closed
+
+    result.plan.close()
 
 
 def test_build_include_text_file_action_plan_returns_merged_plan(

--- a/tests/commands/test_candidate_previews.py
+++ b/tests/commands/test_candidate_previews.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 import pytest
 
 import git_stage_batch.batch.operation_candidates as operation_candidates
+import git_stage_batch.commands.batch_source.candidate_preview_counts as candidate_preview_counts
 import git_stage_batch.commands.apply_from as apply_from_module
 import git_stage_batch.commands.include_from as include_from_module
 import git_stage_batch.commands.show_from as show_from_module
@@ -388,7 +389,7 @@ def test_apply_from_reports_candidate_enumeration_error(
         raise RuntimeError("metadata drift")
 
     monkeypatch.setattr(
-        apply_from_module,
+        candidate_preview_counts,
         "build_apply_candidate_previews",
         fail_count,
     )

--- a/tests/commands/test_candidate_previews.py
+++ b/tests/commands/test_candidate_previews.py
@@ -586,7 +586,7 @@ def test_include_from_reports_candidate_limit(temp_git_repo, monkeypatch):
         )
 
     monkeypatch.setattr(
-        include_from_module,
+        candidate_preview_counts,
         "build_include_candidate_previews",
         fail_count,
     )

--- a/tests/data/test_file_modes.py
+++ b/tests/data/test_file_modes.py
@@ -2,11 +2,14 @@
 
 import os
 import subprocess
+import stat
 
 import pytest
 
 from git_stage_batch.data.file_modes import (
+    apply_git_file_mode,
     detect_file_mode,
+    detect_file_mode_in_commit,
     detect_file_mode_from_root,
 )
 
@@ -89,3 +92,34 @@ def test_uses_index_mode_for_missing_worktree_path(temp_git_repo):
 
 def test_defaults_to_regular_file_mode_for_unknown_path(temp_git_repo):
     assert detect_file_mode_from_root(temp_git_repo, "missing.txt") == "100644"
+
+
+def test_detects_file_mode_in_commit_tree(temp_git_repo):
+    script_file = temp_git_repo / "script.sh"
+    script_file.write_text("#!/bin/sh\n")
+    script_file.chmod(0o755)
+    subprocess.run(["git", "add", "script.sh"], check=True, cwd=temp_git_repo)
+    subprocess.run(
+        ["git", "commit", "-m", "Add script"],
+        check=True,
+        cwd=temp_git_repo,
+        capture_output=True,
+    )
+
+    assert detect_file_mode_in_commit("HEAD", "script.sh") == "100755"
+    assert detect_file_mode_in_commit("HEAD", "missing.txt") is None
+
+
+def test_applies_git_file_mode_to_worktree_path(temp_git_repo):
+    target_file = temp_git_repo / "target.txt"
+    target_file.write_text("content\n")
+    target_file.chmod(0o644)
+
+    apply_git_file_mode(target_file, "100755")
+
+    executable_bits = stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+    assert target_file.stat().st_mode & executable_bits == executable_bits
+
+    apply_git_file_mode(target_file, "100644")
+
+    assert target_file.stat().st_mode & executable_bits == 0


### PR DESCRIPTION
Selection and file-scope batch operations now have narrower helpers, while
batch-source workflows still combine candidate lookup, preview cleanup,
mode lookup, and action planning.

The project does not have a stable planning layer for batch-source actions,
so each command path has to understand too much of the preview and merge
setup.

This PR routes apply and include previews through shared helpers, moves
mode lookups to data owners, and adds a discard text action plan builder.

The next PR will consolidate batch-source execution and asset catalog
ownership around the new planning seams.

Test plan: .venv/bin/python -m pytest -n auto passed on the final stack tip
  before landing; each PR branch is rebased without code changes before
  merge.
