### PR TITLE
architecture: Extract selection actions and subcommand parsing

### DIFF
--- a/src/git_stage_batch/batch/selection.py
+++ b/src/git_stage_batch/batch/selection.py
@@ -196,23 +196,6 @@ def resolve_current_batch_atomic_file_scope(
     return file
 
 
-def resolve_current_batch_binary_file_scope(
-    batch_name: str,
-    all_files: dict[str, dict],
-    file: Optional[str] = None,
-    patterns: Optional[list[str]] = None,
-    line_ids: Optional[str] = None,
-) -> Optional[str]:
-    """Backward-compatible wrapper for atomic batch selections."""
-    return resolve_current_batch_atomic_file_scope(
-        batch_name,
-        all_files,
-        file,
-        patterns,
-        line_ids,
-    )
-
-
 def _get_batch_file_for_line_operation(
     batch_name: str,
     all_files: dict[str, dict],

--- a/src/git_stage_batch/cli/argument_parser.py
+++ b/src/git_stage_batch/cli/argument_parser.py
@@ -42,20 +42,7 @@ from .quick_actions import expand_quick_actions
 from .reset_dispatch import dispatch_reset_command
 from .show_dispatch import dispatch_show_command
 from .skip_dispatch import dispatch_skip_command
-
-
-def _add_subcommand_parser(
-    subparsers,
-    command_name: str,
-    **kwargs,
-) -> GitHelpArgumentParser:
-    """Add a subcommand parser wired to its git help topic."""
-    help_topic = kwargs.pop("help_topic", f"stage-batch-{command_name}")
-    return subparsers.add_parser(
-        command_name,
-        help_topic=help_topic,
-        **kwargs,
-    )
+from .subcommand_parser import add_subcommand_parser
 
 
 def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Namespace | None:
@@ -102,7 +89,7 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
     )
 
     # check-unstaged - Check whether the index fits an unstaged-only workflow
-    parser_check_unstaged = _add_subcommand_parser(
+    parser_check_unstaged = add_subcommand_parser(
         subparsers,
         "check-unstaged",
         help=_("Check whether the index fits an unstaged-only workflow"),
@@ -110,7 +97,7 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
     parser_check_unstaged.set_defaults(func=lambda _: command_check_unstaged())
 
     # start - Start a new batch staging session
-    parser_start = _add_subcommand_parser(
+    parser_start = add_subcommand_parser(
         subparsers,
         "start",
         help=_("Start a new batch staging session"),
@@ -132,7 +119,7 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
     )
 
     # interactive - Start interactive hunk-by-hunk mode
-    parser_interactive = _add_subcommand_parser(
+    parser_interactive = add_subcommand_parser(
         subparsers,
         "interactive",
         help=_("Start interactive hunk-by-hunk mode"),
@@ -140,7 +127,7 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
     parser_interactive.set_defaults(interactive_command=True)
 
     # stop - Stop the selected session and clear state
-    parser_stop = _add_subcommand_parser(
+    parser_stop = add_subcommand_parser(
         subparsers,
         "stop",
         help=_("Stop the selected session and clear state"),
@@ -148,7 +135,7 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
     parser_stop.set_defaults(func=lambda _: command_stop())
 
     # again - Clear state and start a fresh pass
-    parser_again = _add_subcommand_parser(
+    parser_again = add_subcommand_parser(
         subparsers,
         "again",
         aliases=["a"],
@@ -160,7 +147,7 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
     )
 
     # undo - Undo the most recent undoable session operation
-    parser_undo = _add_subcommand_parser(
+    parser_undo = add_subcommand_parser(
         subparsers,
         "undo",
         aliases=["u", "back"],
@@ -174,7 +161,7 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
     parser_undo.set_defaults(func=lambda args: command_undo(force=args.force))
 
     # redo - Redo the most recently undone session operation
-    parser_redo = _add_subcommand_parser(
+    parser_redo = add_subcommand_parser(
         subparsers,
         "redo",
         aliases=["forward"],
@@ -188,7 +175,7 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
     parser_redo.set_defaults(func=lambda args: command_redo(force=args.force))
 
     # show - Show the selected hunk
-    parser_show = _add_subcommand_parser(
+    parser_show = add_subcommand_parser(
         subparsers,
         "show",
         help=_("Show the selected hunk"),
@@ -252,7 +239,7 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
     parser_show.set_defaults(func=dispatch_show_command)
 
     # status - Show selected session status
-    parser_status = _add_subcommand_parser(
+    parser_status = add_subcommand_parser(
         subparsers,
         "status",
         aliases=["st"],
@@ -280,7 +267,7 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
     )
 
     # include - Stage the selected hunk
-    parser_include = _add_subcommand_parser(
+    parser_include = add_subcommand_parser(
         subparsers,
         "include",
         aliases=["i"],
@@ -341,7 +328,7 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
     parser_include.set_defaults(func=dispatch_include_command)
 
     # skip - Skip the selected hunk without staging
-    parser_skip = _add_subcommand_parser(
+    parser_skip = add_subcommand_parser(
         subparsers,
         "skip",
         aliases=["s"],
@@ -365,7 +352,7 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
     parser_skip.set_defaults(func=dispatch_skip_command)
 
     # discard - Remove the selected hunk from working tree
-    parser_discard = _add_subcommand_parser(
+    parser_discard = add_subcommand_parser(
         subparsers,
         "discard",
         aliases=["d"],
@@ -426,7 +413,7 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
     parser_discard.set_defaults(func=dispatch_discard_command)
 
     # abort - Restore repository to pre-session state
-    parser_abort = _add_subcommand_parser(
+    parser_abort = add_subcommand_parser(
         subparsers,
         "abort",
         help=_("Restore repository to pre-session state"),
@@ -434,7 +421,7 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
     parser_abort.set_defaults(func=lambda _: command_abort())
 
     # block-file - Permanently exclude a file
-    parser_block_file = _add_subcommand_parser(
+    parser_block_file = add_subcommand_parser(
         subparsers,
         "block-file",
         aliases=["bf"],
@@ -455,7 +442,7 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
     parser_block_file.set_defaults(func=lambda args: command_block_file(args.file_path, local_only=args.local_only))
 
     # unblock-file - Remove a file from blocked list
-    parser_unblock_file = _add_subcommand_parser(
+    parser_unblock_file = add_subcommand_parser(
         subparsers,
         "unblock-file",
         aliases=["ubf"],
@@ -468,7 +455,7 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
     parser_unblock_file.set_defaults(func=lambda args: command_unblock_file(args.file_path))
 
     # suggest-fixup - Suggest which commit the selected hunk should be fixed up to
-    parser_suggest_fixup = _add_subcommand_parser(
+    parser_suggest_fixup = add_subcommand_parser(
         subparsers,
         "suggest-fixup",
         aliases=["x"],
@@ -519,7 +506,7 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
     ))
 
     # new - Create a new batch
-    parser_new = _add_subcommand_parser(
+    parser_new = add_subcommand_parser(
         subparsers,
         "new",
         help=_("Create a new batch"),
@@ -536,7 +523,7 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
     parser_new.set_defaults(func=lambda args: command_new_batch(args.batch_name, args.note))
 
     # list - List all batches
-    parser_list = _add_subcommand_parser(
+    parser_list = add_subcommand_parser(
         subparsers,
         "list",
         help=_("List all batches"),
@@ -544,7 +531,7 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
     parser_list.set_defaults(func=lambda _: command_list_batches())
 
     # drop - Delete a batch
-    parser_drop = _add_subcommand_parser(
+    parser_drop = add_subcommand_parser(
         subparsers,
         "drop",
         help=_("Delete a batch"),
@@ -556,7 +543,7 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
     parser_drop.set_defaults(func=lambda args: command_drop_batch(args.batch_name))
 
     # annotate - Add/update batch description
-    parser_annotate = _add_subcommand_parser(
+    parser_annotate = add_subcommand_parser(
         subparsers,
         "annotate",
         help=_("Add or update batch description"),
@@ -572,7 +559,7 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
     parser_annotate.set_defaults(func=lambda args: command_annotate_batch(args.batch_name, args.note))
 
     # apply - Apply batch changes to working tree
-    parser_apply = _add_subcommand_parser(
+    parser_apply = add_subcommand_parser(
         subparsers,
         "apply",
         help=_("Apply batch changes to working tree"),
@@ -601,7 +588,7 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
     parser_apply.set_defaults(func=dispatch_apply_command)
 
     # reset - Remove claims from batch
-    parser_reset = _add_subcommand_parser(
+    parser_reset = add_subcommand_parser(
         subparsers,
         "reset",
         help=_("Remove claims from batch"),
@@ -636,7 +623,7 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
     parser_reset.set_defaults(func=dispatch_reset_command)
 
     # sift - Reconcile batch against current tip
-    parser_sift = _add_subcommand_parser(
+    parser_sift = add_subcommand_parser(
         subparsers,
         "sift",
         help=_("Remove already-present portions from a batch"),
@@ -657,7 +644,7 @@ def parse_command_line(args: list[str], *, quiet: bool = False) -> argparse.Name
     )
     parser_sift.set_defaults(func=lambda args: command_sift_batch(args.from_batch, args.to_batch))
 
-    parser_install_assets = _add_subcommand_parser(
+    parser_install_assets = add_subcommand_parser(
         subparsers,
         "install-assets",
         help=_("Install bundled assistant assets into the repository"),

--- a/src/git_stage_batch/cli/subcommand_parser.py
+++ b/src/git_stage_batch/cli/subcommand_parser.py
@@ -1,0 +1,19 @@
+"""Subcommand parser construction helpers."""
+
+from __future__ import annotations
+
+from .git_help import GitHelpArgumentParser
+
+
+def add_subcommand_parser(
+    subparsers,
+    command_name: str,
+    **kwargs,
+) -> GitHelpArgumentParser:
+    """Add a subcommand parser wired to its git help topic."""
+    help_topic = kwargs.pop("help_topic", f"stage-batch-{command_name}")
+    return subparsers.add_parser(
+        command_name,
+        help_topic=help_topic,
+        **kwargs,
+    )

--- a/src/git_stage_batch/commands/apply_from.py
+++ b/src/git_stage_batch/commands/apply_from.py
@@ -5,51 +5,13 @@ from __future__ import annotations
 import sys
 from typing import Optional
 
-from .batch_source import action_completion as _action_completion
 from .batch_source import action_context as _action_context
 from .batch_source import action_selection as _action_selection
-from .batch_source import action_plans as _action_plans
-from .batch_source import binary_file_actions as _binary_file_actions
+from .batch_source import apply_action as _apply_action
 from .batch_source import candidate_execution as _candidate_execution
-from .batch_source import candidate_preview_counts as _candidate_preview_counts
-from .batch_source import candidate_refusals as _candidate_refusals
-from .batch_source import merge_refusals as _merge_refusals
-from .batch_source import text_file_actions as _text_file_actions
-from .batch_source import text_plan_builders as _text_plan_builders
-from .batch_source import worktree_refusals as _worktree_refusals
-from ..batch.binary_file_content import read_binary_file_from_batch
-from ..batch.selection import (
-    translate_atomic_unit_error_to_gutter_ids,
-)
-from ..batch.submodule_pointer import (
-    apply_submodule_pointer_from_batch,
-    is_batch_submodule_pointer,
-)
 from ..data.file_review.records import FileReviewAction
-from ..data.session import snapshot_file_if_untracked
-from ..data.undo import undo_checkpoint
-from ..exceptions import exit_with_error, MergeError, CommandError, AtomicUnitError
 from ..i18n import _
 from ..utils.git_repository import require_git_repository
-
-
-def _print_binary_worktree_result(
-    file_path: str,
-    action: _binary_file_actions.BinaryWorktreeAction | None,
-) -> None:
-    """Print apply-from status for a binary working-tree action."""
-    if action is None:
-        return
-
-    if action is _binary_file_actions.BinaryWorktreeAction.DELETED:
-        print(_("✓ Deleted binary file: {file}").format(file=file_path), file=sys.stderr)
-    elif action is _binary_file_actions.BinaryWorktreeAction.ADDED:
-        print(_("✓ Applied new binary file: {file}").format(file=file_path), file=sys.stderr)
-    else:
-        print(
-            _("✓ Replaced binary file: {file}").format(file=file_path),
-            file=sys.stderr,
-        )
 
 
 def command_apply_from_batch(
@@ -90,8 +52,6 @@ def command_apply_from_batch(
     files = selection.files
     selected_ids = selection.selected_ids
     selection_ids_to_apply = selection.selection_ids
-    rendered = selection.rendered
-    operation_parts = list(selection.operation_parts)
     if selector.candidate_ordinal is not None:
         _candidate_execution.execute_apply_candidate(
             batch_name=batch_name,
@@ -103,134 +63,11 @@ def command_apply_from_batch(
         )
         return
 
-    failed_files = []
-    candidate_counts = {}
-    apply_plans = []
-
-    for file_path, file_meta in files.items():
-        try:
-            # Binary files are atomic units - handle separately without ownership/merge logic
-            if file_meta.get("file_type") == "binary":
-                batch_buffer = read_binary_file_from_batch(
-                    batch_name,
-                    file_path,
-                    file_meta,
-                )
-                apply_plans.append(
-                    _action_plans.BinaryFileActionPlan(
-                        file_path,
-                        file_meta,
-                        batch_buffer,
-                    )
-                )
-                continue
-            if is_batch_submodule_pointer(file_meta):
-                apply_plans.append(
-                    _action_plans.SubmodulePointerActionPlan(file_path, file_meta)
-                )
-                continue
-
-            try:
-                text_plan_result = (
-                    _text_plan_builders.build_apply_text_file_action_plan(
-                        file_path=file_path,
-                        file_meta=file_meta,
-                        selected_ids=selected_ids,
-                        selection_ids_to_apply=selection_ids_to_apply,
-                    )
-                )
-            except AtomicUnitError as e:
-                if rendered:
-                    translate_atomic_unit_error_to_gutter_ids(
-                        e,
-                        rendered,
-                        "apply",
-                        batch_name,
-                    )
-                _action_plans.close_action_plans(apply_plans)
-                exit_with_error(_("Failed to apply batch '{name}': {error}").format(
-                    name=batch_name,
-                    error=str(e)
-                ))
-
-            if text_plan_result.missing_source:
-                failed_files.append(file_path)
-                continue
-            if text_plan_result.plan is None:
-                continue
-            apply_plans.append(text_plan_result.plan)
-
-        except MergeError:
-            # Merge conflict - batch created from different file version
-            candidate_count = (
-                _candidate_preview_counts.count_apply_candidate_previews_for_file(
-                    batch_name=batch_name,
-                    file_path=file_path,
-                    file_meta=file_meta,
-                    selection_ids_to_apply=selection_ids_to_apply,
-                )
-            )
-            if candidate_count.count or candidate_count.too_many or candidate_count.error:
-                candidate_counts[file_path] = candidate_count
-            failed_files.append(file_path)
-        except CommandError:
-            # Re-raise user errors (e.g., partial atomic selection)
-            _action_plans.close_action_plans(apply_plans)
-            raise
-        except Exception as e:
-            print(_("Error applying {file}: {error}").format(file=file_path, error=str(e)), file=sys.stderr)
-            failed_files.append(file_path)
-
-    if failed_files:
-        _action_plans.close_action_plans(apply_plans)
-        _candidate_refusals.refuse_candidate_conflicts(
-            batch_name=batch_name,
-            operation="apply",
-            failed_files=failed_files,
-            candidate_counts=candidate_counts,
-        )
-        _merge_refusals.refuse_batch_source_merge_failures(
-            batch_name=batch_name,
-            failed_files=failed_files,
-        )
-
-    try:
-        try:
-            with undo_checkpoint(" ".join(operation_parts), worktree_paths=list(files)):
-                for plan in apply_plans:
-                    snapshot_file_if_untracked(plan.file_path)
-                    if isinstance(plan, _action_plans.ApplyTextFileActionPlan):
-                        _text_file_actions.write_text_file_to_worktree(
-                            plan.file_path,
-                            plan.buffer,
-                            plan.file_mode,
-                            plan.change_type,
-                        )
-                    elif isinstance(plan, _action_plans.BinaryFileActionPlan):
-                        action = _binary_file_actions.write_binary_file_to_worktree(
-                            plan.file_path,
-                            plan.file_meta,
-                            plan.buffer,
-                            missing_content_message=(
-                                f"Binary file metadata for {plan.file_path} "
-                                f"says {plan.file_meta.get('change_type', 'modified')}, "
-                                "but the batch content is missing"
-                            ),
-                        )
-                        _print_binary_worktree_result(plan.file_path, action)
-                    else:
-                        apply_submodule_pointer_from_batch(plan.file_path, plan.file_meta)
-        except CommandError:
-            raise
-        except Exception:
-            _worktree_refusals.refuse_incompatible_worktree_action(
-                batch_name=batch_name,
-                file_paths=files,
-            )
-    finally:
-        _action_plans.close_action_plans(apply_plans)
-
-    _action_completion.finish_batch_source_action_review(context, files)
+    _apply_action.execute_apply_action(
+        batch_name=batch_name,
+        context=context,
+        selection=selection,
+    )
 
     if line_ids:
         print(_("✓ Applied selected lines from batch '{name}' to working tree").format(name=batch_name), file=sys.stderr)

--- a/src/git_stage_batch/commands/apply_from.py
+++ b/src/git_stage_batch/commands/apply_from.py
@@ -10,7 +10,7 @@ from .batch_source import action_context as _action_context
 from .batch_source import action_selection as _action_selection
 from .batch_source import action_plans as _action_plans
 from .batch_source import binary_file_actions as _binary_file_actions
-from .batch_source import candidate_materialization as _candidate_materialization
+from .batch_source import candidate_execution as _candidate_execution
 from .batch_source import candidate_preview_counts as _candidate_preview_counts
 from .batch_source import candidate_refusals as _candidate_refusals
 from .batch_source import merge_refusals as _merge_refusals
@@ -18,9 +18,6 @@ from .batch_source import text_file_actions as _text_file_actions
 from .batch_source import text_plan_builders as _text_plan_builders
 from .batch_source import worktree_refusals as _worktree_refusals
 from ..batch.binary_file_content import read_binary_file_from_batch
-from ..batch.operation_candidates import (
-    clear_candidate_preview_state_for_file,
-)
 from ..batch.selection import (
     translate_atomic_unit_error_to_gutter_ids,
 )
@@ -53,62 +50,6 @@ def _print_binary_worktree_result(
             _("✓ Replaced binary file: {file}").format(file=file_path),
             file=sys.stderr,
         )
-
-
-def _execute_apply_candidate(
-    *,
-    batch_name: str,
-    raw_selector: str,
-    ordinal: int,
-    files: dict,
-    selected_ids: set[int] | None,
-    selection_ids_to_apply: set[int] | None,
-) -> None:
-    """Recompute and apply one previewed apply candidate."""
-    materialized = _candidate_materialization.materialize_apply_candidate(
-        batch_name=batch_name,
-        raw_selector=raw_selector,
-        ordinal=ordinal,
-        files=files,
-        selected_ids=selected_ids,
-        selection_ids_to_apply=selection_ids_to_apply,
-    )
-    try:
-        target = materialized.target
-        preview = materialized.preview
-        file_path = materialized.file_path
-        print(
-            _("Applying candidate {ordinal} of {count} from batch '{batch}':").format(
-                ordinal=preview.ordinal,
-                count=preview.count,
-                batch=batch_name,
-            ),
-            file=sys.stderr,
-        )
-        print(f"  {file_path}: {_('Working tree')}", file=sys.stderr)
-        operation_parts = ["apply", "--from", raw_selector, "--file", file_path]
-        with undo_checkpoint(" ".join(operation_parts), worktree_paths=[file_path]):
-            snapshot_file_if_untracked(file_path)
-            _text_file_actions.write_text_file_to_worktree(
-                file_path,
-                target.after_buffer,
-                materialized.file_mode,
-                target.change_type,
-            )
-        clear_candidate_preview_state_for_file(
-            batch_name=batch_name,
-            file_path=file_path,
-        )
-        print(
-            _("✓ Applied candidate {ordinal} of {count} from batch '{batch}' to working tree").format(
-                ordinal=preview.ordinal,
-                count=preview.count,
-                batch=batch_name,
-            ),
-            file=sys.stderr,
-        )
-    finally:
-        materialized.close()
 
 
 def command_apply_from_batch(
@@ -152,7 +93,7 @@ def command_apply_from_batch(
     rendered = selection.rendered
     operation_parts = list(selection.operation_parts)
     if selector.candidate_ordinal is not None:
-        _execute_apply_candidate(
+        _candidate_execution.execute_apply_candidate(
             batch_name=batch_name,
             raw_selector=raw_selector,
             ordinal=selector.candidate_ordinal,

--- a/src/git_stage_batch/commands/batch_source/action_selection.py
+++ b/src/git_stage_batch/commands/batch_source/action_selection.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 from ...batch.selection import (
     require_single_file_context_for_line_selection,
     resolve_batch_file_scope,
-    resolve_current_batch_binary_file_scope,
+    resolve_current_batch_atomic_file_scope,
 )
 from ...batch.submodule_pointer import (
     is_batch_submodule_pointer,
@@ -175,7 +175,7 @@ def _resolve_batch_source_action_files(
     patterns: list[str] | None,
     command_name: str,
 ) -> tuple[str | None, dict, set[int] | None]:
-    file = resolve_current_batch_binary_file_scope(
+    file = resolve_current_batch_atomic_file_scope(
         context.batch_name,
         context.all_files,
         context.file,

--- a/src/git_stage_batch/commands/batch_source/apply_action.py
+++ b/src/git_stage_batch/commands/batch_source/apply_action.py
@@ -1,0 +1,204 @@
+"""Apply-from execution for batch-source action commands."""
+
+from __future__ import annotations
+
+import sys
+
+from . import action_completion as _action_completion
+from . import action_context as _action_context
+from . import action_plans as _action_plans
+from . import action_selection as _action_selection
+from . import binary_file_actions as _binary_file_actions
+from . import candidate_preview_counts as _candidate_preview_counts
+from . import candidate_refusals as _candidate_refusals
+from . import merge_refusals as _merge_refusals
+from . import text_file_actions as _text_file_actions
+from . import text_plan_builders as _text_plan_builders
+from . import worktree_refusals as _worktree_refusals
+from ...batch.binary_file_content import read_binary_file_from_batch
+from ...batch.selection import translate_atomic_unit_error_to_gutter_ids
+from ...batch.submodule_pointer import (
+    apply_submodule_pointer_from_batch,
+    is_batch_submodule_pointer,
+)
+from ...data.session import snapshot_file_if_untracked
+from ...data.undo import undo_checkpoint
+from ...exceptions import (
+    AtomicUnitError,
+    CommandError,
+    MergeError,
+    exit_with_error,
+)
+from ...i18n import _
+
+
+def _print_binary_worktree_result(
+    file_path: str,
+    action: _binary_file_actions.BinaryWorktreeAction | None,
+) -> None:
+    """Print apply-from status for a binary working-tree action."""
+    if action is None:
+        return
+
+    if action is _binary_file_actions.BinaryWorktreeAction.DELETED:
+        print(_("✓ Deleted binary file: {file}").format(file=file_path), file=sys.stderr)
+    elif action is _binary_file_actions.BinaryWorktreeAction.ADDED:
+        print(
+            _("✓ Applied new binary file: {file}").format(file=file_path),
+            file=sys.stderr,
+        )
+    else:
+        print(
+            _("✓ Replaced binary file: {file}").format(file=file_path),
+            file=sys.stderr,
+        )
+
+
+def execute_apply_action(
+    *,
+    batch_name: str,
+    context: _action_context.BatchSourceActionContext,
+    selection: _action_selection.BatchSourceActionSelection,
+) -> None:
+    """Apply selected batch-source changes to the working tree."""
+    files = selection.files
+    selected_ids = selection.selected_ids
+    selection_ids_to_apply = selection.selection_ids
+    rendered = selection.rendered
+    operation_parts = list(selection.operation_parts)
+    failed_files = []
+    candidate_counts = {}
+    apply_plans = []
+
+    for file_path, file_meta in files.items():
+        try:
+            if file_meta.get("file_type") == "binary":
+                batch_buffer = read_binary_file_from_batch(
+                    batch_name,
+                    file_path,
+                    file_meta,
+                )
+                apply_plans.append(
+                    _action_plans.BinaryFileActionPlan(
+                        file_path,
+                        file_meta,
+                        batch_buffer,
+                    )
+                )
+                continue
+            if is_batch_submodule_pointer(file_meta):
+                apply_plans.append(
+                    _action_plans.SubmodulePointerActionPlan(file_path, file_meta)
+                )
+                continue
+
+            try:
+                text_plan_result = (
+                    _text_plan_builders.build_apply_text_file_action_plan(
+                        file_path=file_path,
+                        file_meta=file_meta,
+                        selected_ids=selected_ids,
+                        selection_ids_to_apply=selection_ids_to_apply,
+                    )
+                )
+            except AtomicUnitError as e:
+                if rendered:
+                    translate_atomic_unit_error_to_gutter_ids(
+                        e,
+                        rendered,
+                        "apply",
+                        batch_name,
+                    )
+                _action_plans.close_action_plans(apply_plans)
+                exit_with_error(
+                    _("Failed to apply batch '{name}': {error}").format(
+                        name=batch_name,
+                        error=str(e),
+                    )
+                )
+
+            if text_plan_result.missing_source:
+                failed_files.append(file_path)
+                continue
+            if text_plan_result.plan is None:
+                continue
+            apply_plans.append(text_plan_result.plan)
+
+        except MergeError:
+            candidate_count = (
+                _candidate_preview_counts.count_apply_candidate_previews_for_file(
+                    batch_name=batch_name,
+                    file_path=file_path,
+                    file_meta=file_meta,
+                    selection_ids_to_apply=selection_ids_to_apply,
+                )
+            )
+            if candidate_count.count or candidate_count.too_many or candidate_count.error:
+                candidate_counts[file_path] = candidate_count
+            failed_files.append(file_path)
+        except CommandError:
+            _action_plans.close_action_plans(apply_plans)
+            raise
+        except Exception as e:
+            print(
+                _("Error applying {file}: {error}").format(
+                    file=file_path,
+                    error=str(e),
+                ),
+                file=sys.stderr,
+            )
+            failed_files.append(file_path)
+
+    if failed_files:
+        _action_plans.close_action_plans(apply_plans)
+        _candidate_refusals.refuse_candidate_conflicts(
+            batch_name=batch_name,
+            operation="apply",
+            failed_files=failed_files,
+            candidate_counts=candidate_counts,
+        )
+        _merge_refusals.refuse_batch_source_merge_failures(
+            batch_name=batch_name,
+            failed_files=failed_files,
+        )
+
+    try:
+        try:
+            with undo_checkpoint(" ".join(operation_parts), worktree_paths=list(files)):
+                for plan in apply_plans:
+                    snapshot_file_if_untracked(plan.file_path)
+                    if isinstance(plan, _action_plans.ApplyTextFileActionPlan):
+                        _text_file_actions.write_text_file_to_worktree(
+                            plan.file_path,
+                            plan.buffer,
+                            plan.file_mode,
+                            plan.change_type,
+                        )
+                    elif isinstance(plan, _action_plans.BinaryFileActionPlan):
+                        action = _binary_file_actions.write_binary_file_to_worktree(
+                            plan.file_path,
+                            plan.file_meta,
+                            plan.buffer,
+                            missing_content_message=(
+                                f"Binary file metadata for {plan.file_path} "
+                                f"says {plan.file_meta.get('change_type', 'modified')}, "
+                                "but the batch content is missing"
+                            ),
+                        )
+                        _print_binary_worktree_result(plan.file_path, action)
+                    else:
+                        apply_submodule_pointer_from_batch(
+                            plan.file_path,
+                            plan.file_meta,
+                        )
+        except CommandError:
+            raise
+        except Exception:
+            _worktree_refusals.refuse_incompatible_worktree_action(
+                batch_name=batch_name,
+                file_paths=files,
+            )
+    finally:
+        _action_plans.close_action_plans(apply_plans)
+
+    _action_completion.finish_batch_source_action_review(context, files)

--- a/src/git_stage_batch/commands/batch_source/candidate_execution.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_execution.py
@@ -7,6 +7,7 @@ import sys
 from . import candidate_materialization as _candidate_materialization
 from . import text_file_actions as _text_file_actions
 from ...batch.operation_candidates import clear_candidate_preview_state_for_file
+from ...core.replacement import ReplacementPayload
 from ...data.session import snapshot_file_if_untracked
 from ...data.undo import undo_checkpoint
 from ...i18n import _
@@ -61,6 +62,73 @@ def execute_apply_candidate(
                 "✓ Applied candidate {ordinal} of {count} from batch "
                 "'{batch}' to working tree"
             ).format(
+                ordinal=preview.ordinal,
+                count=preview.count,
+                batch=batch_name,
+            ),
+            file=sys.stderr,
+        )
+    finally:
+        materialized.close()
+
+
+def execute_include_candidate(
+    *,
+    batch_name: str,
+    raw_selector: str,
+    ordinal: int,
+    files: dict,
+    selected_ids: set[int] | None,
+    selection_ids_to_include: set[int] | None,
+    replacement_payload: ReplacementPayload | None,
+) -> None:
+    """Recompute and include one previewed include candidate."""
+    materialized = _candidate_materialization.materialize_include_candidate(
+        batch_name=batch_name,
+        raw_selector=raw_selector,
+        ordinal=ordinal,
+        files=files,
+        selected_ids=selected_ids,
+        selection_ids_to_include=selection_ids_to_include,
+        replacement_payload=replacement_payload,
+    )
+    try:
+        preview = materialized.preview
+        file_path = materialized.file_path
+        index_target = materialized.index_target
+        worktree_target = materialized.worktree_target
+        print(
+            _("Including candidate {ordinal} of {count} for batch '{batch}':").format(
+                ordinal=preview.ordinal,
+                count=preview.count,
+                batch=batch_name,
+            ),
+            file=sys.stderr,
+        )
+        print(f"  {file_path}:", file=sys.stderr)
+        print(f"    {_('Index')}", file=sys.stderr)
+        print(f"    {_('Working tree')}", file=sys.stderr)
+        operation_parts = ["include", "--from", raw_selector, "--file", file_path]
+        with undo_checkpoint(" ".join(operation_parts), worktree_paths=[file_path]):
+            snapshot_file_if_untracked(file_path)
+            _text_file_actions.stage_text_file_to_index(
+                file_path,
+                index_target.after_buffer,
+                materialized.index_file_mode,
+                index_target.change_type,
+            )
+            _text_file_actions.write_text_file_to_worktree(
+                file_path,
+                worktree_target.after_buffer,
+                materialized.worktree_file_mode,
+                worktree_target.change_type,
+            )
+        clear_candidate_preview_state_for_file(
+            batch_name=batch_name,
+            file_path=file_path,
+        )
+        print(
+            _("✓ Included candidate {ordinal} of {count} from batch '{batch}'").format(
                 ordinal=preview.ordinal,
                 count=preview.count,
                 batch=batch_name,

--- a/src/git_stage_batch/commands/batch_source/candidate_execution.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_execution.py
@@ -1,0 +1,71 @@
+"""Reviewed candidate execution for batch-source action commands."""
+
+from __future__ import annotations
+
+import sys
+
+from . import candidate_materialization as _candidate_materialization
+from . import text_file_actions as _text_file_actions
+from ...batch.operation_candidates import clear_candidate_preview_state_for_file
+from ...data.session import snapshot_file_if_untracked
+from ...data.undo import undo_checkpoint
+from ...i18n import _
+
+
+def execute_apply_candidate(
+    *,
+    batch_name: str,
+    raw_selector: str,
+    ordinal: int,
+    files: dict,
+    selected_ids: set[int] | None,
+    selection_ids_to_apply: set[int] | None,
+) -> None:
+    """Recompute and apply one previewed apply candidate."""
+    materialized = _candidate_materialization.materialize_apply_candidate(
+        batch_name=batch_name,
+        raw_selector=raw_selector,
+        ordinal=ordinal,
+        files=files,
+        selected_ids=selected_ids,
+        selection_ids_to_apply=selection_ids_to_apply,
+    )
+    try:
+        target = materialized.target
+        preview = materialized.preview
+        file_path = materialized.file_path
+        print(
+            _("Applying candidate {ordinal} of {count} from batch '{batch}':").format(
+                ordinal=preview.ordinal,
+                count=preview.count,
+                batch=batch_name,
+            ),
+            file=sys.stderr,
+        )
+        print(f"  {file_path}: {_('Working tree')}", file=sys.stderr)
+        operation_parts = ["apply", "--from", raw_selector, "--file", file_path]
+        with undo_checkpoint(" ".join(operation_parts), worktree_paths=[file_path]):
+            snapshot_file_if_untracked(file_path)
+            _text_file_actions.write_text_file_to_worktree(
+                file_path,
+                target.after_buffer,
+                materialized.file_mode,
+                target.change_type,
+            )
+        clear_candidate_preview_state_for_file(
+            batch_name=batch_name,
+            file_path=file_path,
+        )
+        print(
+            _(
+                "✓ Applied candidate {ordinal} of {count} from batch "
+                "'{batch}' to working tree"
+            ).format(
+                ordinal=preview.ordinal,
+                count=preview.count,
+                batch=batch_name,
+            ),
+            file=sys.stderr,
+        )
+    finally:
+        materialized.close()

--- a/src/git_stage_batch/commands/batch_source/candidate_preview_action.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_preview_action.py
@@ -1,0 +1,88 @@
+"""Show-from candidate preview action orchestration."""
+
+from __future__ import annotations
+
+from ...batch.operation_candidates import save_candidate_preview_state
+from ...core.replacement import ReplacementPayload
+from ...data.file_review.batch_selection import (
+    translate_batch_file_gutter_ids_to_selection_ids,
+)
+from ...exceptions import MergeError, exit_with_error
+from ...i18n import _
+from ...output.candidate_preview import (
+    render_operation_candidate,
+    render_operation_candidate_overview,
+)
+from . import candidate_preview_builders as _candidate_preview_builders
+from . import candidate_previews as _candidate_previews
+
+
+def show_batch_source_candidate_preview(
+    *,
+    selector,
+    batch_name: str,
+    files: dict,
+    selected_ids: set[int] | None,
+    replacement_text: str | ReplacementPayload | None,
+    patterns: list[str] | None,
+    porcelain: bool,
+    note: str | None,
+) -> None:
+    """Render a candidate preview for a show-from batch source selector."""
+    if patterns is not None or len(files) != 1:
+        exit_with_error(_("Candidate preview requires exactly one file."))
+    file_path = list(files.keys())[0]
+    try:
+        previews = _candidate_preview_builders.build_batch_source_candidate_previews(
+            selector=selector,
+            files=files,
+            file_path=file_path,
+            selected_ids=selected_ids,
+            replacement_text=replacement_text,
+            translate_selection_ids=(
+                translate_batch_file_gutter_ids_to_selection_ids
+            ),
+        )
+    except ValueError as error:
+        exit_with_error(str(error))
+    except MergeError as error:
+        exit_with_error(str(error))
+
+    if not previews:
+        exit_with_error(
+            _("Batch '{batch}' has no {operation} candidates for {file}.").format(
+                batch=batch_name,
+                operation=selector.candidate_operation,
+                file=file_path,
+            )
+        )
+
+    if selector.candidate_ordinal is None:
+        try:
+            reviewed_previews = render_operation_candidate_overview(
+                previews,
+                porcelain=porcelain,
+                note=note,
+            )
+            for preview in reviewed_previews:
+                save_candidate_preview_state(preview)
+        finally:
+            _candidate_previews.close_candidate_previews(previews)
+        return
+
+    try:
+        preview = _candidate_previews.require_candidate_preview_for_ordinal(
+            previews,
+            selector.candidate_ordinal,
+            batch_name=batch_name,
+            operation=selector.candidate_operation,
+            file_path=file_path,
+        )
+        render_operation_candidate(
+            preview,
+            porcelain=porcelain,
+            note=note,
+        )
+        save_candidate_preview_state(preview)
+    finally:
+        _candidate_previews.close_candidate_previews(previews)

--- a/src/git_stage_batch/commands/batch_source/discard_action.py
+++ b/src/git_stage_batch/commands/batch_source/discard_action.py
@@ -1,0 +1,156 @@
+"""Discard-from execution for batch-source action commands."""
+
+from __future__ import annotations
+
+import sys
+
+from . import action_selection as _action_selection
+from . import binary_file_actions as _binary_file_actions
+from . import text_file_actions as _text_file_actions
+from . import text_plan_builders as _text_plan_builders
+from ...batch.metadata_validation import get_validated_baseline_commit
+from ...batch.selection import translate_atomic_unit_error_to_gutter_ids
+from ...batch.submodule_pointer import (
+    discard_submodule_pointer_from_batch,
+    is_batch_submodule_pointer,
+)
+from ...data.session import snapshot_file_if_untracked
+from ...data.undo import undo_checkpoint
+from ...exceptions import (
+    AtomicUnitError,
+    BatchMetadataError,
+    CommandError,
+    MergeError,
+    exit_with_error,
+)
+from ...i18n import _
+
+
+def _print_binary_discard_result(
+    file_path: str,
+    action: _binary_file_actions.BinaryWorktreeAction,
+) -> None:
+    """Print discard-from status for a binary working-tree action."""
+    if action is _binary_file_actions.BinaryWorktreeAction.REPLACED:
+        print(
+            _("✓ Restored binary file to baseline: {file}").format(
+                file=file_path,
+            ),
+            file=sys.stderr,
+        )
+    elif action is _binary_file_actions.BinaryWorktreeAction.DELETED:
+        print(
+            _("✓ Removed binary file (not in baseline): {file}").format(
+                file=file_path,
+            ),
+            file=sys.stderr,
+        )
+
+
+def execute_discard_action(
+    *,
+    batch_name: str,
+    selection: _action_selection.BatchSourceActionSelection,
+) -> None:
+    """Discard selected batch-source changes from the working tree."""
+    try:
+        baseline_commit = get_validated_baseline_commit(batch_name)
+    except BatchMetadataError as e:
+        exit_with_error(str(e))
+
+    files = selection.files
+    selected_ids = selection.selected_ids
+    selection_ids_to_discard = selection.selection_ids
+    rendered = selection.rendered
+    operation_parts = list(selection.operation_parts)
+
+    with undo_checkpoint(" ".join(operation_parts), worktree_paths=list(files)):
+        failed_files = []
+
+        for file_path, file_meta in files.items():
+            try:
+                if file_meta.get("file_type") == "binary":
+                    snapshot_file_if_untracked(file_path)
+                    binary_action = (
+                        _binary_file_actions.discard_binary_file_to_worktree(
+                            file_path,
+                            baseline_commit,
+                        )
+                    )
+                    _print_binary_discard_result(file_path, binary_action)
+                    continue
+
+                if is_batch_submodule_pointer(file_meta):
+                    discard_submodule_pointer_from_batch(file_path, file_meta)
+                    continue
+
+                snapshot_file_if_untracked(file_path)
+
+                try:
+                    text_plan_result = (
+                        _text_plan_builders.build_discard_text_file_action_plan(
+                            file_path=file_path,
+                            file_meta=file_meta,
+                            baseline_commit=baseline_commit,
+                            selected_ids=selected_ids,
+                            selection_ids_to_discard=selection_ids_to_discard,
+                        )
+                    )
+                except AtomicUnitError as e:
+                    if rendered:
+                        translate_atomic_unit_error_to_gutter_ids(
+                            e,
+                            rendered,
+                            "discard from",
+                            batch_name,
+                        )
+                    exit_with_error(
+                        _("Failed to discard from batch '{name}': {error}").format(
+                            name=batch_name,
+                            error=str(e),
+                        )
+                    )
+
+                if text_plan_result.missing_source:
+                    failed_files.append(file_path)
+                    continue
+                if text_plan_result.plan is None:
+                    continue
+
+                try:
+                    _text_file_actions.write_discarded_text_file_to_worktree(
+                        text_plan_result.plan.file_path,
+                        text_plan_result.plan.buffer,
+                        text_plan_result.plan.file_mode,
+                        text_plan_result.plan.change_type,
+                    )
+                finally:
+                    text_plan_result.plan.close()
+
+            except CommandError:
+                raise
+            except MergeError as e:
+                print(
+                    _("Error discarding {file}: {error}").format(
+                        file=file_path,
+                        error=str(e),
+                    ),
+                    file=sys.stderr,
+                )
+                failed_files.append(file_path)
+            except Exception as e:
+                print(
+                    _("Error discarding {file}: {error}").format(
+                        file=file_path,
+                        error=str(e),
+                    ),
+                    file=sys.stderr,
+                )
+                failed_files.append(file_path)
+
+    if failed_files:
+        exit_with_error(
+            _("Failed to discard changes for some files: {files}").format(
+                files=", ".join(failed_files),
+            )
+        )

--- a/src/git_stage_batch/commands/batch_source/file_display_action.py
+++ b/src/git_stage_batch/commands/batch_source/file_display_action.py
@@ -1,0 +1,273 @@
+"""Show-from single-file display action orchestration."""
+
+from __future__ import annotations
+
+import sys
+
+from ...batch.atomic_file_changes import (
+    binary_change_from_batch_file_metadata,
+    gitlink_change_from_batch_file_metadata,
+)
+from ...batch.file_display import render_batch_file_display
+from ...core.models import LineLevelChange
+from ...data.selected_change.batch_file_cache import cache_rendered_batch_file_display
+from ...data.batch_selected_changes import (
+    compute_batch_binary_fingerprint,
+    compute_batch_gitlink_fingerprint,
+)
+from ...data.file_review.pages import normalize_page_spec
+from ...data.file_review.records import ReviewSource
+from ...data.file_review.state import (
+    clear_last_file_review_state,
+    write_last_file_review_state,
+)
+from ...data.selected_change.file_changes import (
+    cache_binary_file_change,
+    cache_gitlink_change,
+)
+from ...data.selected_change.lifecycle import clear_selected_change_state_files
+from ...data.selected_change.store import SelectedChangeKind
+from ...exceptions import exit_with_error
+from ...i18n import _
+from ...output.file_review import print_file_review
+from ...output.file_review_model_builder import build_file_review_model
+from ...output.file_review_state_builder import (
+    make_file_review_state,
+    resolve_default_review_pages,
+)
+from ...output.hunk import print_line_level_changes
+from ...output.patch import (
+    print_binary_file_change,
+    print_gitlink_change,
+)
+
+
+def _shown_pages_for_display_ids(review_model, display_ids: set[int]) -> tuple[int, ...]:
+    """Return review pages that contain the selected display IDs."""
+    return tuple(
+        sorted(
+            {
+                change.first_page
+                for change in review_model.changes
+                if set(change.display_ids) & display_ids
+            }
+        )
+    )
+
+
+def show_batch_source_file_display(
+    *,
+    batch_name: str,
+    file_path: str,
+    files: dict[str, dict],
+    metadata: dict,
+    selected_ids: set[int] | None,
+    selectable: bool,
+    page: str | None,
+    command_source_args: str,
+) -> None:
+    """Show one file from a batch source selection."""
+    file_meta = files[file_path]
+    binary_change = binary_change_from_batch_file_metadata(
+        file_path,
+        file_meta,
+    )
+    if binary_change is not None:
+        if selected_ids:
+            exit_with_error(
+                _(
+                    "Cannot use --lines with binary files. Run without --lines "
+                    "to view the binary change summary."
+                )
+            )
+        if page is not None:
+            exit_with_error(_("File review pages are only available for text changes."))
+        if selectable:
+            clear_selected_change_state_files()
+            cache_binary_file_change(
+                binary_change,
+                kind=SelectedChangeKind.BATCH_BINARY,
+                batch_name=batch_name,
+                batch_binary_fingerprint=compute_batch_binary_fingerprint(
+                    batch_name,
+                    file_path,
+                    file_meta,
+                ),
+            )
+        print_binary_file_change(binary_change)
+        return
+
+    gitlink_change = gitlink_change_from_batch_file_metadata(
+        file_path,
+        file_meta,
+    )
+    if gitlink_change is not None:
+        if selected_ids:
+            exit_with_error(
+                _(
+                    "Cannot use --lines with submodule pointers. Run without "
+                    "--lines to view the submodule pointer summary."
+                )
+            )
+        if page is not None:
+            exit_with_error(_("File review pages are only available for text changes."))
+        if selectable:
+            clear_selected_change_state_files()
+            cache_gitlink_change(
+                gitlink_change,
+                kind=SelectedChangeKind.BATCH_GITLINK,
+                batch_name=batch_name,
+                batch_gitlink_fingerprint=compute_batch_gitlink_fingerprint(
+                    file_path,
+                    file_meta,
+                ),
+            )
+        print_gitlink_change(gitlink_change)
+        return
+
+    rendered = render_batch_file_display(batch_name, file_path, metadata=metadata)
+    if rendered is None:
+        print(
+            _("No changes for file '{file}' in batch '{name}'.").format(
+                file=file_path,
+                name=batch_name,
+            ),
+            file=sys.stderr,
+        )
+        return
+
+    review_model = None
+    review_gutter_to_selection_id = (
+        rendered.review_gutter_to_selection_id
+        or rendered.gutter_to_selection_id
+    )
+    review_selection_id_to_gutter = (
+        rendered.review_selection_id_to_gutter
+        or rendered.selection_id_to_gutter
+    )
+    review_action_groups = rendered.review_action_groups or None
+
+    def get_review_model():
+        nonlocal review_model
+        if review_model is None:
+            review_model = build_file_review_model(
+                rendered.line_changes,
+                gutter_to_selection_id=review_gutter_to_selection_id,
+                actionable_selection_groups=rendered.actionable_selection_groups,
+                review_action_groups=review_action_groups,
+            )
+        return review_model
+
+    if selectable and page is not None:
+        resolve_default_review_pages(
+            get_review_model(),
+            requested_page_spec=page,
+            previous_selection=None,
+        )
+
+    if page is not None or (selectable and not selected_ids):
+        review_model = get_review_model()
+        shown_pages = resolve_default_review_pages(
+            review_model,
+            requested_page_spec=page,
+            previous_selection=None,
+        )
+        page_spec = normalize_page_spec(shown_pages, len(review_model.pages))
+        if selectable:
+            clear_last_file_review_state()
+            cache_rendered_batch_file_display(file_path, rendered)
+            write_last_file_review_state(
+                make_file_review_state(
+                    review_model,
+                    source=ReviewSource.BATCH,
+                    batch_name=batch_name,
+                    shown_pages=shown_pages,
+                    selected_change_kind=SelectedChangeKind.BATCH_FILE,
+                    gutter_to_selection_id=review_gutter_to_selection_id,
+                    actionable_selection_groups=rendered.actionable_selection_groups,
+                    review_action_groups=review_action_groups,
+                )
+            )
+        print_file_review(
+            review_model,
+            shown_pages=shown_pages,
+            source_label=_("Changes: batch {name}").format(name=batch_name),
+            page_spec=page_spec,
+            command_source_args=command_source_args,
+            source=ReviewSource.BATCH,
+            batch_name=batch_name,
+            note=metadata.get("note") or None,
+        )
+        return
+
+    if selected_ids:
+        line_gutter_to_selection_id = (
+            review_gutter_to_selection_id
+            if selectable
+            else rendered.gutter_to_selection_id
+        )
+
+        selection_ids = set()
+        for gutter_id in selected_ids:
+            if gutter_id in line_gutter_to_selection_id:
+                selection_ids.add(line_gutter_to_selection_id[gutter_id])
+            else:
+                exit_with_error(
+                    _(
+                        "Line ID {id} is not available for this action. "
+                        "Select one of the numbered lines shown for this "
+                        "batch file."
+                    ).format(id=gutter_id)
+                )
+
+        if selectable:
+            clear_last_file_review_state()
+            cache_rendered_batch_file_display(file_path, rendered)
+            review_model = get_review_model()
+            visible_review_display_ids = {
+                review_selection_id_to_gutter[selection_id]
+                for selection_id in selection_ids
+                if selection_id in review_selection_id_to_gutter
+            }
+            shown_pages = _shown_pages_for_display_ids(
+                review_model,
+                visible_review_display_ids,
+            )
+            if shown_pages:
+                write_last_file_review_state(
+                    make_file_review_state(
+                        review_model,
+                        source=ReviewSource.BATCH,
+                        batch_name=batch_name,
+                        shown_pages=shown_pages,
+                        selected_change_kind=SelectedChangeKind.BATCH_FILE,
+                        gutter_to_selection_id=review_gutter_to_selection_id,
+                        actionable_selection_groups=rendered.actionable_selection_groups,
+                        review_action_groups=review_action_groups,
+                        visible_display_ids=visible_review_display_ids,
+                        entire_file_shown=False,
+                    )
+                )
+
+        filtered_lines = [
+            line for line in rendered.line_changes.lines if line.id in selection_ids
+        ]
+        if filtered_lines:
+            filtered_line_changes = LineLevelChange(
+                path=rendered.line_changes.path,
+                lines=filtered_lines,
+                header=rendered.line_changes.header,
+            )
+            print_line_level_changes(
+                filtered_line_changes,
+                gutter_to_selection_id=line_gutter_to_selection_id,
+            )
+    else:
+        print_line_level_changes(
+            rendered.line_changes,
+            gutter_to_selection_id=(
+                review_gutter_to_selection_id
+                if selectable
+                else {}
+            ),
+        )

--- a/src/git_stage_batch/commands/batch_source/file_list_action.py
+++ b/src/git_stage_batch/commands/batch_source/file_list_action.py
@@ -1,0 +1,71 @@
+"""Show-from multi-file list action orchestration."""
+
+from __future__ import annotations
+
+import sys
+
+from ...batch.atomic_file_changes import (
+    binary_change_from_batch_file_metadata,
+    gitlink_change_from_batch_file_metadata,
+)
+from ...batch.file_display import render_batch_file_display
+from ...data.file_review.records import ReviewSource
+from ...data.selected_change.clear_reasons import (
+    mark_selected_change_cleared_by_file_list,
+)
+from ...data.selected_change.lifecycle import clear_selected_change_state_files
+from ...i18n import _
+from ...output.file_review_list import (
+    make_binary_file_review_list_entry,
+    make_file_review_list_entry,
+    make_gitlink_file_review_list_entry,
+    print_file_review_list,
+)
+
+
+def show_batch_source_file_list(
+    *,
+    batch_name: str,
+    files: dict[str, dict],
+    metadata: dict,
+    selectable: bool,
+    command_source_args: str,
+) -> None:
+    """Show a navigational list for multiple files from a batch."""
+    entries = []
+    for file_path, file_meta in files.items():
+        binary_change = binary_change_from_batch_file_metadata(file_path, file_meta)
+        if binary_change is not None:
+            entries.append(make_binary_file_review_list_entry(binary_change))
+            continue
+        gitlink_change = gitlink_change_from_batch_file_metadata(file_path, file_meta)
+        if gitlink_change is not None:
+            entries.append(make_gitlink_file_review_list_entry(gitlink_change))
+            continue
+        rendered = render_batch_file_display(
+            batch_name,
+            file_path,
+            metadata=metadata,
+            probe_mergeability=False,
+        )
+        if rendered is not None:
+            entries.append(
+                make_file_review_list_entry(
+                    rendered.line_changes,
+                )
+            )
+
+    if entries:
+        if selectable:
+            clear_selected_change_state_files()
+            mark_selected_change_cleared_by_file_list(
+                source=ReviewSource.BATCH.value,
+                batch_name=batch_name,
+            )
+        print_file_review_list(
+            source_label=_("Changes: batch {name}").format(name=batch_name),
+            entries=entries,
+            command_source_args=command_source_args,
+        )
+    else:
+        print(_("Batch '{name}' is empty").format(name=batch_name), file=sys.stderr)

--- a/src/git_stage_batch/commands/batch_source/include_action.py
+++ b/src/git_stage_batch/commands/batch_source/include_action.py
@@ -1,0 +1,197 @@
+"""Include-from execution for batch-source action commands."""
+
+from __future__ import annotations
+
+import sys
+
+from . import action_completion as _action_completion
+from . import action_context as _action_context
+from . import action_plans as _action_plans
+from . import action_selection as _action_selection
+from . import binary_file_actions as _binary_file_actions
+from . import candidate_preview_counts as _candidate_preview_counts
+from . import candidate_refusals as _candidate_refusals
+from . import merge_refusals as _merge_refusals
+from . import text_file_actions as _text_file_actions
+from . import text_plan_builders as _text_plan_builders
+from . import worktree_refusals as _worktree_refusals
+from ...batch.binary_file_content import read_binary_file_from_batch
+from ...batch.selection import translate_atomic_unit_error_to_gutter_ids
+from ...batch.submodule_pointer import (
+    is_batch_submodule_pointer,
+    stage_submodule_pointer_from_batch,
+)
+from ...core.replacement import ReplacementPayload
+from ...data.session import snapshot_file_if_untracked
+from ...data.undo import undo_checkpoint
+from ...exceptions import (
+    AtomicUnitError,
+    CommandError,
+    MergeError,
+    exit_with_error,
+)
+from ...i18n import _
+
+
+def execute_include_action(
+    *,
+    batch_name: str,
+    context: _action_context.BatchSourceActionContext,
+    selection: _action_selection.BatchSourceActionSelection,
+    replacement_payload: ReplacementPayload | None,
+) -> None:
+    """Include selected batch-source changes into the index and worktree."""
+    files = selection.files
+    selected_ids = selection.selected_ids
+    selection_ids_to_include = selection.selection_ids
+    rendered = selection.rendered
+    operation_parts = list(selection.operation_parts)
+    failed_files = []
+    candidate_counts = {}
+    include_plans = []
+
+    for file_path, file_meta in files.items():
+        try:
+            if file_meta.get("file_type") == "binary":
+                batch_buffer = read_binary_file_from_batch(
+                    batch_name,
+                    file_path,
+                    file_meta,
+                    missing_content_message=(
+                        f"Binary file not found in batch commit: {file_path}"
+                    ),
+                )
+                include_plans.append(
+                    _action_plans.BinaryFileActionPlan(
+                        file_path,
+                        file_meta,
+                        batch_buffer,
+                    )
+                )
+                continue
+            if is_batch_submodule_pointer(file_meta):
+                include_plans.append(
+                    _action_plans.SubmodulePointerActionPlan(file_path, file_meta)
+                )
+                continue
+
+            try:
+                text_plan_result = (
+                    _text_plan_builders.build_include_text_file_action_plan(
+                        file_path=file_path,
+                        file_meta=file_meta,
+                        selected_ids=selected_ids,
+                        selection_ids_to_include=selection_ids_to_include,
+                        replacement_payload=replacement_payload,
+                    )
+                )
+            except AtomicUnitError as e:
+                if rendered:
+                    translate_atomic_unit_error_to_gutter_ids(
+                        e,
+                        rendered,
+                        "include from",
+                        batch_name,
+                    )
+                _action_plans.close_action_plans(include_plans)
+                exit_with_error(
+                    _("Failed to include from batch '{name}': {error}").format(
+                        name=batch_name,
+                        error=str(e),
+                    )
+                )
+            except ValueError as e:
+                _action_plans.close_action_plans(include_plans)
+                exit_with_error(str(e))
+
+            if text_plan_result.missing_source:
+                failed_files.append(file_path)
+                continue
+            if text_plan_result.plan is None:
+                continue
+            include_plans.append(text_plan_result.plan)
+
+        except MergeError:
+            candidate_count = (
+                _candidate_preview_counts.count_include_candidate_previews_for_file(
+                    batch_name=batch_name,
+                    file_path=file_path,
+                    file_meta=file_meta,
+                    selection_ids_to_include=selection_ids_to_include,
+                    replacement_payload=replacement_payload,
+                )
+            )
+            if candidate_count.count or candidate_count.too_many or candidate_count.error:
+                candidate_counts[file_path] = candidate_count
+            failed_files.append(file_path)
+        except CommandError:
+            _action_plans.close_action_plans(include_plans)
+            raise
+        except Exception as e:
+            print(
+                _("Error staging {file}: {error}").format(
+                    file=file_path,
+                    error=str(e),
+                ),
+                file=sys.stderr,
+            )
+            failed_files.append(file_path)
+
+    if failed_files:
+        _action_plans.close_action_plans(include_plans)
+        _candidate_refusals.refuse_candidate_conflicts(
+            batch_name=batch_name,
+            operation="include",
+            failed_files=failed_files,
+            candidate_counts=candidate_counts,
+        )
+        _merge_refusals.refuse_batch_source_merge_failures(
+            batch_name=batch_name,
+            failed_files=failed_files,
+        )
+
+    try:
+        try:
+            with undo_checkpoint(" ".join(operation_parts), worktree_paths=list(files)):
+                for plan in include_plans:
+                    snapshot_file_if_untracked(plan.file_path)
+                    if isinstance(plan, _action_plans.IncludeTextFileActionPlan):
+                        _text_file_actions.stage_text_file_to_index(
+                            plan.file_path,
+                            plan.index_buffer,
+                            plan.index_file_mode,
+                            plan.index_change_type,
+                        )
+                        _text_file_actions.write_text_file_to_worktree(
+                            plan.file_path,
+                            plan.working_buffer,
+                            plan.working_file_mode,
+                            plan.working_change_type,
+                        )
+                    elif isinstance(plan, _action_plans.BinaryFileActionPlan):
+                        _binary_file_actions.stage_binary_file_to_index(
+                            plan.file_path,
+                            plan.file_meta,
+                            plan.buffer,
+                        )
+                        _binary_file_actions.write_binary_file_to_worktree(
+                            plan.file_path,
+                            plan.file_meta,
+                            plan.buffer,
+                        )
+                    else:
+                        stage_submodule_pointer_from_batch(
+                            plan.file_path,
+                            plan.file_meta,
+                        )
+        except CommandError:
+            raise
+        except Exception:
+            _worktree_refusals.refuse_incompatible_worktree_action(
+                batch_name=batch_name,
+                file_paths=files,
+            )
+    finally:
+        _action_plans.close_action_plans(include_plans)
+
+    _action_completion.finish_batch_source_action_review(context, files)

--- a/src/git_stage_batch/commands/batch_source/reset_selection.py
+++ b/src/git_stage_batch/commands/batch_source/reset_selection.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from ...batch.query import read_batch_metadata
 from ...batch.selection import (
     resolve_batch_file_scope,
-    resolve_current_batch_binary_file_scope,
+    resolve_current_batch_atomic_file_scope,
 )
 from ...batch.source_selector import require_plain_batch_name
 from ...batch.validation import batch_exists, validate_batch_name
@@ -64,7 +64,7 @@ def resolve_reset_claim_selection(
 
     metadata = read_batch_metadata(batch_name)
     all_files = metadata.get("files", {})
-    file = resolve_current_batch_binary_file_scope(
+    file = resolve_current_batch_atomic_file_scope(
         batch_name,
         all_files,
         file,

--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from ..core.replacement import (
     ReplacementPayload,
 )
-from ..core.models import BinaryFileChange, GitlinkChange, RenameChange, TextFileDeletionChange
+from ..core.models import BinaryFileChange, RenameChange, TextFileDeletionChange
 from ..data.selected_change.loading import (
     load_selected_change,
 )
@@ -17,7 +17,6 @@ from ..data.selected_change.clear_reasons import (
     refuse_bare_action_after_auto_advance_disabled,
     refuse_bare_action_after_file_list,
 )
-from ..data.file_hunk_display import cache_unstaged_file_as_single_hunk
 from ..data.file_review.records import FileReviewAction, ReviewSource
 from ..data.file_review.action_scope import (
     finish_review_scoped_line_action,
@@ -28,12 +27,8 @@ from ..data.file_review.action_scope import (
 )
 from ..data.session import require_session_started
 from ..data.undo import undo_checkpoint
-from ..core.buffer import (
-    LineBuffer,
-)
 from ..exceptions import exit_with_error
 from ..i18n import _
-from ..utils.git_command import run_git_command
 from ..utils.git_repository import require_git_repository
 from ..utils.journal import log_journal
 from ..utils.paths import (

--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -5,10 +5,6 @@ from __future__ import annotations
 from ..core.replacement import (
     ReplacementPayload,
 )
-from ..core.models import BinaryFileChange, RenameChange, TextFileDeletionChange
-from ..data.selected_change.loading import (
-    load_selected_change,
-)
 from ..data.selected_change.store import (
     SelectedChangeKind,
     read_selected_change_kind,
@@ -19,37 +15,26 @@ from ..data.selected_change.clear_reasons import (
 )
 from ..data.file_review.records import FileReviewAction, ReviewSource
 from ..data.file_review.action_scope import (
-    finish_review_scoped_line_action,
     refuse_ambiguous_bare_action_after_partial_file_review,
     refuse_live_action_for_batch_selection,
     resolve_live_line_action_scope,
     resolve_live_to_batch_action_scope,
 )
 from ..data.session import require_session_started
-from ..data.undo import undo_checkpoint
-from ..exceptions import exit_with_error
-from ..i18n import _
 from ..utils.git_repository import require_git_repository
 from ..utils.journal import log_journal
 from ..utils.paths import (
     ensure_state_directory_exists,
 )
+from .selection import discard_to_batch_action as _discard_to_batch_action
 from .selection import discard_line_action as _discard_line_action
-from .selection import discard_line_batching as _discard_line_batching
 from .selection import (
     discard_line_replacement_action as _discard_line_replacement_action,
 )
-from .selection import selected_change_batch_discarding as _selected_change_batch_discarding
 from .selection import selected_change_discarding as _selected_change_discarding
 from .selection import selected_file_discarding as _selected_file_discarding
 from .file_scope import discard_file as _file_scope_discard_file
 from .file_scope import discard_file_replacement as _file_scope_discard_file_replacement
-from .file_scope.discard_file_to_batch import discard_file_to_batch
-from .file_scope.target_path import require_file_scope_target_path
-from .selection.whole_file_batch_discarding import (
-    discard_binary_to_batch,
-    discard_text_deletion_to_batch,
-)
 
 
 def command_discard(
@@ -214,116 +199,16 @@ def command_discard_to_batch(
         return 0
     file = scope_resolution.file
     review_state = scope_resolution.review_state
-    operation_parts = ["discard", "--to", batch_name]
-    if line_ids is not None:
-        operation_parts.extend(["--line", line_ids])
-    if file is not None:
-        operation_parts.extend(["--file", file])
-    with undo_checkpoint(" ".join(operation_parts)):
-        if (
-            file is None
-            and line_ids is None
-            and read_selected_change_kind() == SelectedChangeKind.RENAME
-        ):
-            selected_change = load_selected_change()
-            if isinstance(selected_change, RenameChange):
-                exit_with_error(
-                    _(
-                        "Cannot discard rename '{old} -> {new}' to a batch yet. "
-                        "Discard, skip, or stage the rename first."
-                    ).format(
-                        old=selected_change.old_path,
-                        new=selected_change.new_path,
-                    )
-                )
-        if (
-            file is None
-            and line_ids is None
-            and read_selected_change_kind() == SelectedChangeKind.GITLINK
-        ):
-            exit_with_error(_("Discarding submodule pointer changes to a batch is not supported yet."))
-        if (
-            file is None
-            and line_ids is None
-            and read_selected_change_kind() == SelectedChangeKind.BINARY
-        ):
-            selected_change = load_selected_change()
-            if isinstance(selected_change, BinaryFileChange):
-                saved_hunks = discard_binary_to_batch(
-                    batch_name,
-                    selected_change,
-                    quiet=quiet,
-                    auto_advance=auto_advance,
-                )
-            else:
-                saved_hunks = _selected_change_batch_discarding.discard_selected_change_to_batch(
-                    batch_name,
-                    file_only=False,
-                    quiet=quiet,
-                    auto_advance=auto_advance,
-                )
-        elif (
-            file is None
-            and line_ids is None
-            and read_selected_change_kind() == SelectedChangeKind.DELETION
-        ):
-            selected_change = load_selected_change()
-            if isinstance(selected_change, TextFileDeletionChange):
-                saved_hunks = discard_text_deletion_to_batch(
-                    batch_name,
-                    selected_change,
-                    quiet=quiet,
-                    auto_advance=auto_advance,
-                )
-            else:
-                saved_hunks = _selected_change_batch_discarding.discard_selected_change_to_batch(
-                    batch_name,
-                    file_only=False,
-                    quiet=quiet,
-                    auto_advance=auto_advance,
-                )
-        elif file is not None:
-            # File-scoped operation
-            target_file = require_file_scope_target_path(file)
-
-            if line_ids is None:
-                # --file without --line: discard entire file
-                saved_hunks = discard_file_to_batch(
-                    batch_name,
-                    target_file,
-                    quiet=quiet,
-                    advance=advance,
-                    auto_advance=auto_advance,
-                )
-            else:
-                # --file with --line: discard specific lines from file
-                saved_hunks = _discard_line_batching.discard_file_lines_to_batch(
-                    batch_name,
-                    target_file,
-                    line_ids,
-                    quiet=quiet,
-                    auto_advance=auto_advance,
-                )
-        else:
-            # Hunk-scoped operation (selected behavior)
-            if line_ids is not None:
-                saved_hunks = _discard_line_batching.discard_selected_lines_to_batch(
-                    batch_name,
-                    line_ids,
-                    quiet=quiet,
-                    auto_advance=auto_advance,
-                )
-            else:
-                # Discard entire selected hunk
-                saved_hunks = _selected_change_batch_discarding.discard_selected_change_to_batch(
-                    batch_name,
-                    file_only=False,
-                    quiet=quiet,
-                    auto_advance=auto_advance,
-                )
-    if original_file_scope in (None, "") and line_ids is not None:
-        finish_review_scoped_line_action(review_state)
-    return saved_hunks
+    return _discard_to_batch_action.execute_discard_to_batch_action(
+        batch_name=batch_name,
+        line_ids=line_ids,
+        file=file,
+        original_file_scope=original_file_scope,
+        review_state=review_state,
+        quiet=quiet,
+        advance=advance,
+        auto_advance=auto_advance,
+    )
 
 
 def command_discard_line_as_to_batch(

--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -4,18 +4,14 @@ from __future__ import annotations
 
 from ..core.replacement import (
     ReplacementPayload,
-    coerce_replacement_payload,
 )
 from ..core.models import BinaryFileChange, GitlinkChange, RenameChange, TextFileDeletionChange
 from ..data.selected_change.loading import (
     load_selected_change,
-    require_selected_hunk,
 )
 from ..data.selected_change.store import (
     SelectedChangeKind,
     read_selected_change_kind,
-    restore_selected_change_state,
-    snapshot_selected_change_state,
 )
 from ..data.selected_change.clear_reasons import (
     refuse_bare_action_after_auto_advance_disabled,
@@ -43,9 +39,11 @@ from ..utils.journal import log_journal
 from ..utils.paths import (
     ensure_state_directory_exists,
 )
-from .selection import discard_file_selection as _discard_file_selection
 from .selection import discard_line_action as _discard_line_action
 from .selection import discard_line_batching as _discard_line_batching
+from .selection import (
+    discard_line_replacement_action as _discard_line_replacement_action,
+)
 from .selection import selected_change_batch_discarding as _selected_change_batch_discarding
 from .selection import selected_change_discarding as _selected_change_discarding
 from .selection import selected_file_discarding as _selected_file_discarding
@@ -57,11 +55,6 @@ from .selection.whole_file_batch_discarding import (
     discard_binary_to_batch,
     discard_text_deletion_to_batch,
 )
-from .selection.selected_hunk_refresh import (
-    recalculate_selected_hunk_for_command,
-    refresh_selected_hunk_after_line_action,
-)
-from .selection.action_completion import finish_selected_change_action
 
 
 def command_discard(
@@ -363,45 +356,13 @@ def command_discard_line_as_to_batch(
         return
     review_state = scope_resolution.review_state
 
-    replacement_payload = coerce_replacement_payload(replacement_text)
-    operation_parts = [
-        "discard",
-        "--to", batch_name,
-        "--line", line_id_specification,
-        "--as", replacement_payload.display_text or "<stdin>",
-    ]
-    if no_edge_overlap:
-        operation_parts.append("--no-edge-overlap")
-    if file is not None:
-        operation_parts.extend(["--file", file])
-    with (
-        undo_checkpoint(" ".join(operation_parts)),
-        snapshot_selected_change_state() as saved_selected_state,
-    ):
-        preserve_selected_state = file not in (None, "")
-
-        try:
-            if file is None:
-                require_selected_hunk()
-            else:
-                target_file = require_file_scope_target_path(file)
-                _discard_file_selection.load_explicit_file_selection(target_file)
-
-            _discard_line_batching.discard_lines_as_to_batch(
-                batch_name,
-                line_id_specification,
-                replacement_text,
-                no_edge_overlap=no_edge_overlap,
-                quiet=quiet,
-                auto_advance=auto_advance,
-            )
-
-            if preserve_selected_state:
-                restore_selected_change_state(saved_selected_state)
-        except Exception:
-            restore_selected_change_state(saved_selected_state)
-            raise
-    if file is None:
-        finish_review_scoped_line_action(review_state)
-    else:
-        finish_review_scoped_line_action(review_state, file_path=target_file)
+    _discard_line_replacement_action.discard_live_line_replacement_to_batch(
+        batch_name,
+        line_id_specification,
+        replacement_text,
+        file,
+        review_state=review_state,
+        no_edge_overlap=no_edge_overlap,
+        quiet=quiet,
+        auto_advance=auto_advance,
+    )

--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import sys
-
 from ..core.replacement import (
     ReplacementPayload,
     coerce_replacement_payload,
@@ -46,8 +44,8 @@ from ..utils.paths import (
     ensure_state_directory_exists,
 )
 from .selection import discard_file_selection as _discard_file_selection
+from .selection import discard_line_action as _discard_line_action
 from .selection import discard_line_batching as _discard_line_batching
-from .selection import discard_line_selection as _discard_line_selection
 from .selection import selected_change_batch_discarding as _selected_change_batch_discarding
 from .selection import selected_change_discarding as _selected_change_discarding
 from .selection import selected_file_discarding as _selected_file_discarding
@@ -182,26 +180,12 @@ def command_discard_line(
     if scope_resolution.should_stop:
         return
     review_state = scope_resolution.review_state
-    operation_parts = ["discard", "--line", line_id_specification]
-    if file is not None:
-        operation_parts.extend(["--file", file])
-    with undo_checkpoint(" ".join(operation_parts)):
-        file_path = _discard_line_selection.discard_worktree_line_selection(
-            line_id_specification,
-            file=file,
-        )
-        print(
-            _("✓ Discarded line(s): {lines} from {file}").format(
-                lines=line_id_specification,
-                file=file_path,
-            ),
-            file=sys.stderr,
-        )
-        refresh_selected_hunk_after_line_action(
-            file_path,
-            auto_advance=auto_advance,
-        )
-        finish_review_scoped_line_action(review_state)
+    _discard_line_action.discard_live_line_selection(
+        line_id_specification,
+        file,
+        review_state=review_state,
+        auto_advance=auto_advance,
+    )
 
 
 def command_discard_to_batch(

--- a/src/git_stage_batch/commands/discard_from.py
+++ b/src/git_stage_batch/commands/discard_from.py
@@ -7,21 +7,8 @@ from typing import Optional
 
 from .batch_source import action_context as _action_context
 from .batch_source import action_selection as _action_selection
-from .batch_source import binary_file_actions as _binary_file_actions
-from .batch_source import text_file_actions as _text_file_actions
-from .batch_source import text_plan_builders as _text_plan_builders
-from ..batch.metadata_validation import get_validated_baseline_commit
-from ..batch.selection import (
-    translate_atomic_unit_error_to_gutter_ids,
-)
-from ..batch.submodule_pointer import (
-    discard_submodule_pointer_from_batch,
-    is_batch_submodule_pointer,
-)
+from .batch_source import discard_action as _discard_action
 from ..data.file_review.records import FileReviewAction
-from ..data.session import snapshot_file_if_untracked
-from ..data.undo import undo_checkpoint
-from ..exceptions import exit_with_error, AtomicUnitError, CommandError, MergeError, BatchMetadataError
 from ..i18n import _
 from ..utils.git_repository import require_git_repository
 
@@ -60,113 +47,10 @@ def command_discard_from_batch(
     )
     file = selection.file
     files = selection.files
-    selected_ids = selection.selected_ids
-    selection_ids_to_discard = selection.selection_ids
-    rendered = selection.rendered
-
-    # Get baseline commit (raises BatchMetadataError with clear message if missing)
-    try:
-        baseline_commit = get_validated_baseline_commit(batch_name)
-    except BatchMetadataError as e:
-        exit_with_error(str(e))
-    operation_parts = list(selection.operation_parts)
-    with undo_checkpoint(" ".join(operation_parts), worktree_paths=list(files)):
-        # Discard all files in batch
-        failed_files = []
-
-        for file_path, file_meta in files.items():
-            try:
-                # Binary files are atomic units - handle separately without ownership/merge logic
-                if file_meta.get("file_type") == "binary":
-                    snapshot_file_if_untracked(file_path)
-                    binary_action = (
-                        _binary_file_actions.discard_binary_file_to_worktree(
-                            file_path,
-                            baseline_commit,
-                        )
-                    )
-                    if (
-                        binary_action
-                        is _binary_file_actions.BinaryWorktreeAction.REPLACED
-                    ):
-                        print(
-                            _("✓ Restored binary file to baseline: {file}").format(
-                                file=file_path,
-                            ),
-                            file=sys.stderr,
-                        )
-                    elif (
-                        binary_action
-                        is _binary_file_actions.BinaryWorktreeAction.DELETED
-                    ):
-                        print(
-                            _(
-                                "✓ Removed binary file (not in baseline): {file}"
-                            ).format(file=file_path),
-                            file=sys.stderr,
-                        )
-                    continue
-                if is_batch_submodule_pointer(file_meta):
-                    discard_submodule_pointer_from_batch(file_path, file_meta)
-                    continue
-
-                # Snapshot file before modifying
-                snapshot_file_if_untracked(file_path)
-
-                try:
-                    text_plan_result = (
-                        _text_plan_builders.build_discard_text_file_action_plan(
-                            file_path=file_path,
-                            file_meta=file_meta,
-                            baseline_commit=baseline_commit,
-                            selected_ids=selected_ids,
-                            selection_ids_to_discard=selection_ids_to_discard,
-                        )
-                    )
-                except AtomicUnitError as e:
-                    if rendered:
-                        translate_atomic_unit_error_to_gutter_ids(
-                            e,
-                            rendered,
-                            "discard from",
-                            batch_name,
-                        )
-                    exit_with_error(
-                        _("Failed to discard from batch '{name}': {error}").format(
-                            name=batch_name,
-                            error=str(e),
-                        )
-                    )
-
-                if text_plan_result.missing_source:
-                    failed_files.append(file_path)
-                    continue
-                if text_plan_result.plan is None:
-                    continue
-
-                try:
-                    _text_file_actions.write_discarded_text_file_to_worktree(
-                        text_plan_result.plan.file_path,
-                        text_plan_result.plan.buffer,
-                        text_plan_result.plan.file_mode,
-                        text_plan_result.plan.change_type,
-                    )
-                finally:
-                    text_plan_result.plan.close()
-
-            except CommandError:
-                raise
-            except MergeError as e:
-                print(_("Error discarding {file}: {error}").format(file=file_path, error=str(e)), file=sys.stderr)
-                failed_files.append(file_path)
-            except Exception as e:
-                print(_("Error discarding {file}: {error}").format(file=file_path, error=str(e)), file=sys.stderr)
-                failed_files.append(file_path)
-
-    if failed_files:
-        exit_with_error(
-            _("Failed to discard changes for some files: {files}").format(files=", ".join(failed_files))
-        )
+    _discard_action.execute_discard_action(
+        batch_name=batch_name,
+        selection=selection,
+    )
 
     # Success message
     if line_ids:

--- a/src/git_stage_batch/commands/file_scope/file_display_action.py
+++ b/src/git_stage_batch/commands/file_scope/file_display_action.py
@@ -1,0 +1,214 @@
+"""Live single-file display action orchestration."""
+
+from __future__ import annotations
+
+import sys
+
+from ...data.change_freshness import text_deletion_change_is_batched
+from ...data.file_change_display import (
+    render_binary_file_change,
+    render_gitlink_change,
+    render_rename_change,
+    render_text_deletion_change,
+)
+from ...data.file_hunk_display import (
+    cache_file_as_single_hunk,
+    render_file_as_single_hunk,
+)
+from ...data.file_review.pages import normalize_page_spec
+from ...data.file_review.records import ReviewSource
+from ...data.file_review.state import (
+    clear_last_file_review_state,
+    write_last_file_review_state,
+)
+from ...data.line_state import load_line_changes_from_state
+from ...data.selected_change.file_changes import (
+    cache_binary_file_change,
+    cache_gitlink_change,
+    cache_rename_change,
+    cache_text_deletion_change,
+)
+from ...data.selected_change.paths import get_selected_change_file_path
+from ...data.selected_change.store import SelectedChangeKind
+from ...exceptions import exit_with_error
+from ...i18n import _
+from ...output.file_review import print_file_review
+from ...output.file_review_model_builder import build_file_review_model
+from ...output.file_review_state_builder import (
+    make_file_review_state,
+    resolve_default_review_pages,
+)
+from ...output.hunk import print_line_level_changes
+from ...output.patch import (
+    print_binary_file_change,
+    print_gitlink_change,
+    print_rename_change,
+    print_text_file_deletion_change,
+)
+
+
+def _load_previous_selection_for_review():
+    """Best-effort load of the prior selection for page anchoring."""
+    try:
+        return load_line_changes_from_state()
+    except Exception:
+        return None
+
+
+def show_live_file_display(
+    file_arg: str,
+    *,
+    page: str | None,
+    porcelain: bool,
+    selectable: bool,
+) -> None:
+    """Show one live file-scope review."""
+    previous_selection = _load_previous_selection_for_review()
+
+    if file_arg == "":
+        target_file = get_selected_change_file_path()
+        if target_file is None:
+            exit_with_error(_("No selected hunk. Run 'show' first or specify file path."))
+    else:
+        target_file = file_arg
+
+    preview_lines = render_file_as_single_hunk(target_file)
+    deletion_change = (
+        render_text_deletion_change(target_file) if preview_lines is None else None
+    )
+    if deletion_change is not None and text_deletion_change_is_batched(
+        deletion_change
+    ):
+        deletion_change = None
+    binary_change = (
+        render_binary_file_change(target_file)
+        if preview_lines is None and deletion_change is None
+        else None
+    )
+    gitlink_change = (
+        render_gitlink_change(target_file)
+        if preview_lines is None
+        and deletion_change is None
+        and binary_change is None
+        else None
+    )
+    rename_change = (
+        render_rename_change(target_file)
+        if preview_lines is None
+        and deletion_change is None
+        and binary_change is None
+        and gitlink_change is None
+        else None
+    )
+
+    if deletion_change is not None:
+        if page is not None:
+            exit_with_error(_("File review pages are only available for text changes."))
+        if selectable:
+            clear_last_file_review_state()
+            cache_text_deletion_change(deletion_change)
+        if porcelain:
+            return
+        print_text_file_deletion_change(deletion_change)
+        return
+
+    if rename_change is not None:
+        if page is not None:
+            exit_with_error(_("File review pages are only available for text changes."))
+        if selectable:
+            clear_last_file_review_state()
+            cache_rename_change(rename_change)
+        if porcelain:
+            return
+        print_rename_change(rename_change)
+        return
+
+    if gitlink_change is not None:
+        if page is not None:
+            exit_with_error(_("File review pages are only available for text changes."))
+        if selectable:
+            clear_last_file_review_state()
+            cache_gitlink_change(gitlink_change)
+        if porcelain:
+            return
+        print_gitlink_change(gitlink_change)
+        return
+
+    if binary_change is not None:
+        if page is not None:
+            exit_with_error(_("File review pages are only available for text changes."))
+        if selectable:
+            clear_last_file_review_state()
+            cache_binary_file_change(binary_change)
+        if porcelain:
+            return
+        print_binary_file_change(binary_change)
+        return
+
+    if selectable and page is not None and preview_lines is not None:
+        preview_model = build_file_review_model(preview_lines)
+        resolve_default_review_pages(
+            preview_model,
+            requested_page_spec=page,
+            previous_selection=previous_selection,
+        )
+
+    file_lines = cache_file_as_single_hunk(target_file) if selectable else preview_lines
+    if file_lines is None:
+        if porcelain:
+            sys.exit(1)
+        print(_("No changes in file '{file}'.").format(file=target_file), file=sys.stderr)
+        return
+
+    if selectable:
+        clear_last_file_review_state()
+
+    if porcelain:
+        return
+
+    if selectable:
+        review_model = build_file_review_model(file_lines)
+        shown_pages = resolve_default_review_pages(
+            review_model,
+            requested_page_spec=page,
+            previous_selection=previous_selection,
+        )
+        page_spec = normalize_page_spec(shown_pages, len(review_model.pages))
+        review_state = make_file_review_state(
+            review_model,
+            source=ReviewSource.FILE_VS_HEAD,
+            batch_name=None,
+            shown_pages=shown_pages,
+            selected_change_kind=SelectedChangeKind.FILE,
+        )
+        write_last_file_review_state(review_state)
+        print_file_review(
+            review_model,
+            shown_pages=shown_pages,
+            source_label=_("Changes: file vs HEAD"),
+            page_spec=page_spec,
+            source=ReviewSource.FILE_VS_HEAD,
+            opened_near_selected_hunk=(
+                page is None
+                and previous_selection is not None
+                and previous_selection.path == file_lines.path
+                and len(review_model.pages) > 1
+            ),
+        )
+    elif page is not None:
+        review_model = build_file_review_model(file_lines, gutter_to_selection_id={})
+        shown_pages = resolve_default_review_pages(
+            review_model,
+            requested_page_spec=page,
+            previous_selection=previous_selection,
+        )
+        page_spec = normalize_page_spec(shown_pages, len(review_model.pages))
+        print_file_review(
+            review_model,
+            shown_pages=shown_pages,
+            source_label=_("Changes: file vs HEAD"),
+            page_spec=page_spec,
+            source=ReviewSource.FILE_VS_HEAD,
+        )
+    else:
+        print_line_level_changes(file_lines, gutter_to_selection_id={})

--- a/src/git_stage_batch/commands/file_scope/file_list_action.py
+++ b/src/git_stage_batch/commands/file_scope/file_list_action.py
@@ -1,0 +1,75 @@
+"""Live file-scope list action orchestration."""
+
+from __future__ import annotations
+
+import sys
+
+from ...core.hashing import compute_rename_change_hash
+from ...data.change_freshness import text_deletion_change_is_batched
+from ...data.file_change_display import (
+    render_binary_file_change,
+    render_gitlink_change,
+    render_rename_change,
+    render_text_deletion_change,
+)
+from ...data.file_hunk_display import render_file_as_single_hunk
+from ...data.file_review.records import ReviewSource
+from ...data.selected_change.clear_reasons import (
+    mark_selected_change_cleared_by_file_list,
+)
+from ...data.selected_change.lifecycle import clear_selected_change_state_files
+from ...i18n import _
+from ...output.file_review_list import (
+    make_binary_file_review_list_entry,
+    make_file_review_list_entry,
+    make_gitlink_file_review_list_entry,
+    make_rename_file_review_list_entry,
+    make_text_deletion_file_review_list_entry,
+    print_file_review_list,
+)
+
+
+def show_live_file_list(files: list[str], *, selectable: bool = True) -> None:
+    """Show a navigational file list for multiple live file reviews."""
+    entries = []
+    seen_rename_hashes: set[str] = set()
+    for file_path in files:
+        line_changes = render_file_as_single_hunk(file_path)
+        if line_changes is not None:
+            entries.append(make_file_review_list_entry(line_changes))
+            continue
+        deletion_change = render_text_deletion_change(file_path)
+        if deletion_change is not None and not text_deletion_change_is_batched(
+            deletion_change
+        ):
+            entries.append(make_text_deletion_file_review_list_entry(deletion_change))
+            continue
+        binary_change = render_binary_file_change(file_path)
+        if binary_change is not None:
+            entries.append(make_binary_file_review_list_entry(binary_change))
+            continue
+        gitlink_change = render_gitlink_change(file_path)
+        if gitlink_change is not None:
+            entries.append(make_gitlink_file_review_list_entry(gitlink_change))
+            continue
+        rename_change = render_rename_change(file_path)
+        if rename_change is not None:
+            rename_hash = compute_rename_change_hash(rename_change)
+            if rename_hash not in seen_rename_hashes:
+                entries.append(make_rename_file_review_list_entry(rename_change))
+                seen_rename_hashes.add(rename_hash)
+
+    if not entries:
+        print(_("No reviewable changes in matched files."), file=sys.stderr)
+        return
+
+    if selectable:
+        clear_selected_change_state_files()
+        mark_selected_change_cleared_by_file_list(
+            source=ReviewSource.FILE_VS_HEAD.value
+        )
+
+    print_file_review_list(
+        source_label=_("Changes: file vs HEAD"),
+        entries=entries,
+    )

--- a/src/git_stage_batch/commands/file_scope/multi_file_actions.py
+++ b/src/git_stage_batch/commands/file_scope/multi_file_actions.py
@@ -9,13 +9,16 @@ import sys
 from typing import Protocol
 
 from ...data.hunk_tracking import select_next_change_after_action
+from ...data.session import require_session_started
 from ...data.undo import undo_checkpoint
 from ...exceptions import CommandError
 from ...i18n import _, ngettext
+from ...utils.git_repository import require_git_repository
+from ...utils.paths import ensure_state_directory_exists
 from .discard_to_batch import discard_files_to_batch
-from ..include import command_include_file
+from . import include_file as _include_file
 from ..selection.selected_change_display import show_selected_change
-from ..skip import command_skip_file
+from . import skip_file as _skip_file
 
 
 class ResolvedFileScope(Protocol):
@@ -91,18 +94,26 @@ def _format_file_summary(files: Sequence[str]) -> str:
     ).format(count=len(files))
 
 
+def _prepare_live_multi_file_action() -> None:
+    """Run command setup shared by live multi-file include and skip actions."""
+    require_git_repository()
+    require_session_started()
+    ensure_state_directory_exists()
+
+
 def include_each_resolved_file(
     files: Sequence[str],
     *,
     auto_advance: bool | None = None,
 ) -> None:
     """Stage a multi-file live scope and report one aggregate summary."""
+    _prepare_live_multi_file_action()
     total_hunks = 0
     staged_files: list[str] = []
 
     with _multi_file_undo_checkpoint("include", files):
         for file_path in files:
-            staged_hunks = command_include_file(
+            staged_hunks = _include_file.include_file_changes(
                 file_path,
                 quiet=True,
                 advance=False,
@@ -136,12 +147,13 @@ def skip_each_resolved_file(
     auto_advance: bool | None = None,
 ) -> None:
     """Skip a multi-file live scope and report one aggregate summary."""
+    _prepare_live_multi_file_action()
     total_hunks = 0
     skipped_files: list[str] = []
 
     with _multi_file_undo_checkpoint("skip", files):
         for file_path in files:
-            skipped_hunks = command_skip_file(
+            skipped_hunks = _skip_file.skip_file_changes(
                 file_path,
                 quiet=True,
                 advance=False,

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -49,10 +49,6 @@ from .file_scope import include_file as _file_scope_include_file
 from .file_scope import include_file_replacement as _file_scope_include_file_replacement
 from .file_scope import include_file_to_batch as _file_scope_include_file_to_batch
 from .file_scope.target_path import require_file_scope_target_path
-from .selection.selected_hunk_refresh import (
-    recalculate_selected_hunk_for_command,
-)
-from .selection.action_completion import finish_selected_change_action
 
 
 def command_include(

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -2,22 +2,16 @@
 
 from __future__ import annotations
 
-from contextlib import ExitStack
-import sys
-
 from ..core.replacement import (
     ReplacementPayload,
-    coerce_replacement_payload,
 )
 from ..core.models import BinaryFileChange, GitlinkChange, RenameChange, TextFileDeletionChange
-from ..data.line_id_files import write_line_ids_file
 from ..data.selected_change.loading import (
     load_selected_change,
 )
 from ..data.selected_change.store import (
     SelectedChangeKind,
     read_selected_change_kind,
-    restore_selected_change_state,
 )
 from ..data.selected_change.clear_reasons import (
     refuse_bare_action_after_auto_advance_disabled,
@@ -42,11 +36,12 @@ from ..utils.git_repository import require_git_repository
 from ..utils.journal import log_journal
 from ..utils.paths import (
     ensure_state_directory_exists,
-    get_processed_include_ids_file_path,
 )
 from .selection import include_line_action as _include_line_action
 from .selection import include_line_batching as _include_line_batching
-from .selection import include_line_replacement as _include_line_replacement
+from .selection import (
+    include_line_replacement_action as _include_line_replacement_action,
+)
 from .selection import selected_change_batch_staging as _selected_change_batch_staging
 from .selection import selected_change_staging as _selected_change_staging
 from .selection import whole_file_batch_staging as _whole_file_batch_staging
@@ -56,7 +51,6 @@ from .file_scope import include_file_to_batch as _file_scope_include_file_to_bat
 from .file_scope.target_path import require_file_scope_target_path
 from .selection.selected_hunk_refresh import (
     recalculate_selected_hunk_for_command,
-    refresh_selected_hunk_after_line_action,
 )
 from .selection.action_completion import finish_selected_change_action
 
@@ -215,108 +209,14 @@ def command_include_line_as(
         return
     review_state = scope_resolution.review_state
 
-    replacement_payload = coerce_replacement_payload(replacement_text)
-    operation_parts = [
-        "include",
-        "--line",
+    _include_line_replacement_action.include_live_line_replacement(
         line_id_specification,
-        "--as",
-        replacement_payload.display_text or "<stdin>",
-    ]
-    if no_edge_overlap:
-        operation_parts.append("--no-edge-overlap")
-    if file is not None:
-        operation_parts.extend(["--file", file])
-
-    replacement_file_context = None
-    with undo_checkpoint(" ".join(operation_parts)), ExitStack() as selected_state_stack:
-        if file is None:
-            replacement_context = (
-                _include_line_replacement.prepare_pathless_include_line_replacement(
-                    line_id_specification
-                )
-            )
-            line_changes = replacement_context.display_line_changes
-            with (
-                replacement_context.base_buffer as hunk_base_lines,
-                replacement_context.source_buffer as hunk_source_lines,
-            ):
-                _include_line_replacement.apply_include_line_replacement(
-                    replacement_context.replacement_line_changes,
-                    line_id_specification=replacement_context.line_id_specification,
-                    replacement_text=replacement_text,
-                    hunk_base_lines=hunk_base_lines,
-                    hunk_source_lines=hunk_source_lines,
-                    trim_unchanged_edge_anchors=not no_edge_overlap,
-                )
-
-            write_line_ids_file(get_processed_include_ids_file_path(), set())
-            print(
-                _("✓ Included line(s) as replacement: {lines} from {file}").format(
-                    lines=line_id_specification,
-                    file=line_changes.path,
-                ),
-                file=sys.stderr,
-            )
-            refresh_selected_hunk_after_line_action(
-                line_changes.path,
-                auto_advance=auto_advance,
-            )
-            finish_review_scoped_line_action(review_state, file_path=line_changes.path)
-        else:
-            replacement_file_context = (
-                _include_line_replacement.prepare_file_include_line_replacement(
-                    file,
-                    selected_state_stack,
-                )
-            )
-            with (
-                replacement_file_context.base_buffer as hunk_base_lines,
-                replacement_file_context.source_buffer as hunk_source_lines,
-            ):
-                _include_line_replacement.apply_include_line_replacement(
-                    replacement_file_context.line_changes,
-                    line_id_specification=line_id_specification,
-                    replacement_text=replacement_text,
-                    hunk_base_lines=hunk_base_lines,
-                    hunk_source_lines=hunk_source_lines,
-                    trim_unchanged_edge_anchors=not no_edge_overlap,
-                )
-
-            if replacement_file_context.preserve_selected_state:
-                assert replacement_file_context.saved_selected_state is not None
-                restore_selected_change_state(
-                    replacement_file_context.saved_selected_state
-                )
-            else:
-                write_line_ids_file(get_processed_include_ids_file_path(), set())
-                print(
-                    _("✓ Included line(s) as replacement: {lines} from {file}").format(
-                        lines=line_id_specification,
-                        file=replacement_file_context.target_file,
-                    ),
-                    file=sys.stderr,
-                )
-                refresh_selected_hunk_after_line_action(
-                    replacement_file_context.target_file,
-                    auto_advance=auto_advance,
-                )
-            finish_review_scoped_line_action(
-                review_state,
-                file_path=replacement_file_context.target_file,
-            )
-
-    if (
-        replacement_file_context is not None
-        and replacement_file_context.preserve_selected_state
-    ):
-        print(
-            _("✓ Included line(s) as replacement: {lines} from {file}").format(
-                lines=line_id_specification,
-                file=replacement_file_context.target_file,
-            ),
-            file=sys.stderr,
-        )
+        replacement_text,
+        file,
+        review_state=review_state,
+        no_edge_overlap=no_edge_overlap,
+        auto_advance=auto_advance,
+    )
 
 
 def command_include_to_batch(

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -17,9 +17,6 @@ from ..data.selected_change.clear_reasons import (
     refuse_bare_action_after_auto_advance_disabled,
     refuse_bare_action_after_file_list,
 )
-from ..data.file_hunk_display import (
-    cache_unstaged_file_as_single_hunk,
-)
 from ..data.file_review.records import FileReviewAction
 from ..data.file_review.action_scope import (
     finish_review_scoped_line_action,

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -5,10 +5,6 @@ from __future__ import annotations
 from ..core.replacement import (
     ReplacementPayload,
 )
-from ..core.models import BinaryFileChange, GitlinkChange, RenameChange, TextFileDeletionChange
-from ..data.selected_change.loading import (
-    load_selected_change,
-)
 from ..data.selected_change.store import (
     SelectedChangeKind,
     read_selected_change_kind,
@@ -19,33 +15,25 @@ from ..data.selected_change.clear_reasons import (
 )
 from ..data.file_review.records import FileReviewAction
 from ..data.file_review.action_scope import (
-    finish_review_scoped_line_action,
     refuse_ambiguous_bare_action_after_partial_file_review,
     refuse_live_action_for_batch_selection,
     resolve_live_line_action_scope,
     resolve_live_to_batch_action_scope,
 )
 from ..data.session import require_session_started
-from ..data.undo import undo_checkpoint
-from ..exceptions import exit_with_error
-from ..i18n import _
 from ..utils.git_repository import require_git_repository
 from ..utils.journal import log_journal
 from ..utils.paths import (
     ensure_state_directory_exists,
 )
+from .selection import include_to_batch_action as _include_to_batch_action
 from .selection import include_line_action as _include_line_action
-from .selection import include_line_batching as _include_line_batching
 from .selection import (
     include_line_replacement_action as _include_line_replacement_action,
 )
-from .selection import selected_change_batch_staging as _selected_change_batch_staging
 from .selection import selected_change_staging as _selected_change_staging
-from .selection import whole_file_batch_staging as _whole_file_batch_staging
 from .file_scope import include_file as _file_scope_include_file
 from .file_scope import include_file_replacement as _file_scope_include_file_replacement
-from .file_scope import include_file_to_batch as _file_scope_include_file_to_batch
-from .file_scope.target_path import require_file_scope_target_path
 
 
 def command_include(
@@ -245,127 +233,12 @@ def command_include_to_batch(
         return
     file = scope_resolution.file
     review_state = scope_resolution.review_state
-    operation_parts = ["include", "--to", batch_name]
-    if line_ids is not None:
-        operation_parts.extend(["--line", line_ids])
-    if file is not None:
-        operation_parts.extend(["--file", file])
-    with undo_checkpoint(" ".join(operation_parts)):
-        if (
-            file is None
-            and line_ids is None
-            and read_selected_change_kind() == SelectedChangeKind.RENAME
-        ):
-            selected_change = load_selected_change()
-            if isinstance(selected_change, RenameChange):
-                exit_with_error(
-                    _(
-                        "Cannot include rename '{old} -> {new}' to a batch yet. "
-                        "Stage, skip, or discard the rename first."
-                    ).format(
-                        old=selected_change.old_path,
-                        new=selected_change.new_path,
-                    )
-                )
-        if (
-            file is None
-            and line_ids is None
-            and read_selected_change_kind() == SelectedChangeKind.GITLINK
-        ):
-            selected_change = load_selected_change()
-            if isinstance(selected_change, GitlinkChange):
-                _whole_file_batch_staging.include_gitlink_to_batch(
-                    batch_name,
-                    selected_change,
-                    quiet=quiet,
-                    auto_advance=auto_advance,
-                )
-                return
-            else:
-                _selected_change_batch_staging.include_selected_change_to_batch(
-                    batch_name,
-                    quiet=quiet,
-                    auto_advance=auto_advance,
-                )
-                return
-        elif (
-            file is None
-            and line_ids is None
-            and read_selected_change_kind() == SelectedChangeKind.DELETION
-        ):
-            selected_change = load_selected_change()
-            if isinstance(selected_change, TextFileDeletionChange):
-                _whole_file_batch_staging.include_text_deletion_to_batch(
-                    batch_name,
-                    selected_change,
-                    quiet=quiet,
-                    auto_advance=auto_advance,
-                )
-                return
-            else:
-                _selected_change_batch_staging.include_selected_change_to_batch(
-                    batch_name,
-                    quiet=quiet,
-                    auto_advance=auto_advance,
-                )
-                return
-        elif (
-            file is None
-            and line_ids is None
-            and read_selected_change_kind() == SelectedChangeKind.BINARY
-        ):
-            selected_change = load_selected_change()
-            if isinstance(selected_change, BinaryFileChange):
-                _whole_file_batch_staging.include_binary_to_batch(
-                    batch_name,
-                    selected_change,
-                    quiet=quiet,
-                    auto_advance=auto_advance,
-                )
-                return
-            else:
-                _selected_change_batch_staging.include_selected_change_to_batch(
-                    batch_name,
-                    quiet=quiet,
-                    auto_advance=auto_advance,
-                )
-                return
-        elif file is not None:
-            # File-scoped operation
-            target_file = require_file_scope_target_path(file)
-
-            if line_ids is None:
-                # --file without --line: include entire file
-                _file_scope_include_file_to_batch.include_file_to_batch(
-                    batch_name,
-                    target_file,
-                    quiet=quiet,
-                    auto_advance=auto_advance,
-                )
-            else:
-                # --file with --line: include specific lines from file
-                _include_line_batching.include_file_lines_to_batch(
-                    batch_name,
-                    target_file,
-                    line_ids,
-                    quiet=quiet,
-                    auto_advance=auto_advance,
-                )
-        else:
-            # Hunk-scoped operation (selected behavior)
-            if line_ids is not None:
-                _include_line_batching.include_selected_lines_to_batch(
-                    batch_name,
-                    line_ids,
-                    quiet=quiet,
-                    auto_advance=auto_advance,
-                )
-            else:
-                # Include entire selected hunk
-                _selected_change_batch_staging.include_selected_change_to_batch(
-                    batch_name,
-                    quiet=quiet,
-                    auto_advance=auto_advance,
-                )
-    if original_file_scope in (None, "") and line_ids is not None:
-        finish_review_scoped_line_action(review_state)
+    _include_to_batch_action.execute_include_to_batch_action(
+        batch_name=batch_name,
+        line_ids=line_ids,
+        file=file,
+        original_file_scope=original_file_scope,
+        review_state=review_state,
+        quiet=quiet,
+        auto_advance=auto_advance,
+    )

--- a/src/git_stage_batch/commands/include_from.py
+++ b/src/git_stage_batch/commands/include_from.py
@@ -10,7 +10,7 @@ from .batch_source import action_context as _action_context
 from .batch_source import action_selection as _action_selection
 from .batch_source import action_plans as _action_plans
 from .batch_source import binary_file_actions as _binary_file_actions
-from .batch_source import candidate_materialization as _candidate_materialization
+from .batch_source import candidate_execution as _candidate_execution
 from .batch_source import candidate_preview_counts as _candidate_preview_counts
 from .batch_source import candidate_refusals as _candidate_refusals
 from .batch_source import merge_refusals as _merge_refusals
@@ -18,9 +18,6 @@ from .batch_source import text_plan_builders as _text_plan_builders
 from .batch_source import text_file_actions as _text_file_actions
 from .batch_source import worktree_refusals as _worktree_refusals
 from ..batch.binary_file_content import read_binary_file_from_batch
-from ..batch.operation_candidates import (
-    clear_candidate_preview_state_for_file,
-)
 from ..core.replacement import (
     ReplacementPayload,
     coerce_replacement_payload,
@@ -44,73 +41,6 @@ from ..exceptions import (
 from ..i18n import _
 from ..utils.git_index import git_refresh_index
 from ..utils.git_repository import require_git_repository
-
-
-def _execute_include_candidate(
-    *,
-    batch_name: str,
-    raw_selector: str,
-    ordinal: int,
-    files: dict,
-    selected_ids: set[int] | None,
-    selection_ids_to_include: set[int] | None,
-    replacement_payload: ReplacementPayload | None,
-) -> None:
-    """Recompute and include one previewed include candidate."""
-    materialized = _candidate_materialization.materialize_include_candidate(
-        batch_name=batch_name,
-        raw_selector=raw_selector,
-        ordinal=ordinal,
-        files=files,
-        selected_ids=selected_ids,
-        selection_ids_to_include=selection_ids_to_include,
-        replacement_payload=replacement_payload,
-    )
-    try:
-        preview = materialized.preview
-        file_path = materialized.file_path
-        index_target = materialized.index_target
-        worktree_target = materialized.worktree_target
-        print(
-            _("Including candidate {ordinal} of {count} for batch '{batch}':").format(
-                ordinal=preview.ordinal,
-                count=preview.count,
-                batch=batch_name,
-            ),
-            file=sys.stderr,
-        )
-        print(f"  {file_path}:", file=sys.stderr)
-        print(f"    {_('Index')}", file=sys.stderr)
-        print(f"    {_('Working tree')}", file=sys.stderr)
-        operation_parts = ["include", "--from", raw_selector, "--file", file_path]
-        with undo_checkpoint(" ".join(operation_parts), worktree_paths=[file_path]):
-            snapshot_file_if_untracked(file_path)
-            _text_file_actions.stage_text_file_to_index(
-                file_path,
-                index_target.after_buffer,
-                materialized.index_file_mode,
-                index_target.change_type,
-            )
-            _text_file_actions.write_text_file_to_worktree(
-                file_path,
-                worktree_target.after_buffer,
-                materialized.worktree_file_mode,
-                worktree_target.change_type,
-            )
-        clear_candidate_preview_state_for_file(
-            batch_name=batch_name,
-            file_path=file_path,
-        )
-        print(
-            _("✓ Included candidate {ordinal} of {count} from batch '{batch}'").format(
-                ordinal=preview.ordinal,
-                count=preview.count,
-                batch=batch_name,
-            ),
-            file=sys.stderr,
-        )
-    finally:
-        materialized.close()
 
 
 def command_include_from_batch(
@@ -165,7 +95,7 @@ def command_include_from_batch(
     rendered = selection.rendered
     operation_parts = list(selection.operation_parts)
     if selector.candidate_ordinal is not None:
-        _execute_include_candidate(
+        _candidate_execution.execute_include_candidate(
             batch_name=batch_name,
             raw_selector=raw_selector,
             ordinal=selector.candidate_ordinal,

--- a/src/git_stage_batch/commands/include_from.py
+++ b/src/git_stage_batch/commands/include_from.py
@@ -5,39 +5,15 @@ from __future__ import annotations
 import sys
 from typing import Optional
 
-from .batch_source import action_completion as _action_completion
 from .batch_source import action_context as _action_context
 from .batch_source import action_selection as _action_selection
-from .batch_source import action_plans as _action_plans
-from .batch_source import binary_file_actions as _binary_file_actions
 from .batch_source import candidate_execution as _candidate_execution
-from .batch_source import candidate_preview_counts as _candidate_preview_counts
-from .batch_source import candidate_refusals as _candidate_refusals
-from .batch_source import merge_refusals as _merge_refusals
-from .batch_source import text_plan_builders as _text_plan_builders
-from .batch_source import text_file_actions as _text_file_actions
-from .batch_source import worktree_refusals as _worktree_refusals
-from ..batch.binary_file_content import read_binary_file_from_batch
+from .batch_source import include_action as _include_action
 from ..core.replacement import (
     ReplacementPayload,
     coerce_replacement_payload,
 )
-from ..batch.selection import (
-    translate_atomic_unit_error_to_gutter_ids,
-)
-from ..batch.submodule_pointer import (
-    is_batch_submodule_pointer,
-    stage_submodule_pointer_from_batch,
-)
 from ..data.file_review.records import FileReviewAction
-from ..data.session import snapshot_file_if_untracked
-from ..data.undo import undo_checkpoint
-from ..exceptions import (
-    AtomicUnitError,
-    CommandError,
-    MergeError,
-    exit_with_error,
-)
 from ..i18n import _
 from ..utils.git_index import git_refresh_index
 from ..utils.git_repository import require_git_repository
@@ -92,8 +68,6 @@ def command_include_from_batch(
     files = selection.files
     selected_ids = selection.selected_ids
     selection_ids_to_include = selection.selection_ids
-    rendered = selection.rendered
-    operation_parts = list(selection.operation_parts)
     if selector.candidate_ordinal is not None:
         _candidate_execution.execute_include_candidate(
             batch_name=batch_name,
@@ -106,148 +80,12 @@ def command_include_from_batch(
         )
         return
 
-    failed_files = []
-    candidate_counts = {}
-    include_plans = []
-
-    for file_path, file_meta in files.items():
-        try:
-            if file_meta.get("file_type") == "binary":
-                batch_buffer = read_binary_file_from_batch(
-                    batch_name,
-                    file_path,
-                    file_meta,
-                    missing_content_message=(
-                        f"Binary file not found in batch commit: {file_path}"
-                    ),
-                )
-                include_plans.append(
-                    _action_plans.BinaryFileActionPlan(
-                        file_path,
-                        file_meta,
-                        batch_buffer,
-                    )
-                )
-                continue
-            if is_batch_submodule_pointer(file_meta):
-                include_plans.append(
-                    _action_plans.SubmodulePointerActionPlan(file_path, file_meta)
-                )
-                continue
-
-            try:
-                text_plan_result = (
-                    _text_plan_builders.build_include_text_file_action_plan(
-                        file_path=file_path,
-                        file_meta=file_meta,
-                        selected_ids=selected_ids,
-                        selection_ids_to_include=selection_ids_to_include,
-                        replacement_payload=replacement_payload,
-                    )
-                )
-            except AtomicUnitError as e:
-                if rendered:
-                    translate_atomic_unit_error_to_gutter_ids(
-                        e,
-                        rendered,
-                        "include from",
-                        batch_name,
-                    )
-                _action_plans.close_action_plans(include_plans)
-                exit_with_error(
-                    _("Failed to include from batch '{name}': {error}").format(
-                        name=batch_name,
-                        error=str(e),
-                    )
-                )
-            except ValueError as e:
-                _action_plans.close_action_plans(include_plans)
-                exit_with_error(str(e))
-
-            if text_plan_result.missing_source:
-                failed_files.append(file_path)
-                continue
-            if text_plan_result.plan is None:
-                continue
-            include_plans.append(text_plan_result.plan)
-
-        except MergeError:
-            # Merge conflict - batch created from different file version
-            candidate_count = (
-                _candidate_preview_counts.count_include_candidate_previews_for_file(
-                    batch_name=batch_name,
-                    file_path=file_path,
-                    file_meta=file_meta,
-                    selection_ids_to_include=selection_ids_to_include,
-                    replacement_payload=replacement_payload,
-                )
-            )
-            if candidate_count.count or candidate_count.too_many or candidate_count.error:
-                candidate_counts[file_path] = candidate_count
-            failed_files.append(file_path)
-        except CommandError:
-            # Re-raise user errors (e.g., partial atomic selection)
-            _action_plans.close_action_plans(include_plans)
-            raise
-        except Exception as e:
-            print(_("Error staging {file}: {error}").format(file=file_path, error=str(e)), file=sys.stderr)
-            failed_files.append(file_path)
-
-    if failed_files:
-        _action_plans.close_action_plans(include_plans)
-        _candidate_refusals.refuse_candidate_conflicts(
-            batch_name=batch_name,
-            operation="include",
-            failed_files=failed_files,
-            candidate_counts=candidate_counts,
-        )
-        _merge_refusals.refuse_batch_source_merge_failures(
-            batch_name=batch_name,
-            failed_files=failed_files,
-        )
-
-    try:
-        try:
-            with undo_checkpoint(" ".join(operation_parts), worktree_paths=list(files)):
-                for plan in include_plans:
-                    snapshot_file_if_untracked(plan.file_path)
-                    if isinstance(plan, _action_plans.IncludeTextFileActionPlan):
-                        _text_file_actions.stage_text_file_to_index(
-                            plan.file_path,
-                            plan.index_buffer,
-                            plan.index_file_mode,
-                            plan.index_change_type,
-                        )
-                        _text_file_actions.write_text_file_to_worktree(
-                            plan.file_path,
-                            plan.working_buffer,
-                            plan.working_file_mode,
-                            plan.working_change_type,
-                        )
-                    elif isinstance(plan, _action_plans.BinaryFileActionPlan):
-                        _binary_file_actions.stage_binary_file_to_index(
-                            plan.file_path,
-                            plan.file_meta,
-                            plan.buffer,
-                        )
-                        _binary_file_actions.write_binary_file_to_worktree(
-                            plan.file_path,
-                            plan.file_meta,
-                            plan.buffer,
-                        )
-                    else:
-                        stage_submodule_pointer_from_batch(plan.file_path, plan.file_meta)
-        except CommandError:
-            raise
-        except Exception:
-            _worktree_refusals.refuse_incompatible_worktree_action(
-                batch_name=batch_name,
-                file_paths=files,
-            )
-    finally:
-        _action_plans.close_action_plans(include_plans)
-
-    _action_completion.finish_batch_source_action_review(context, files)
+    _include_action.execute_include_action(
+        batch_name=batch_name,
+        context=context,
+        selection=selection,
+        replacement_payload=replacement_payload,
+    )
 
     if replacement_payload is not None and line_ids:
         print(

--- a/src/git_stage_batch/commands/selection/discard_line_action.py
+++ b/src/git_stage_batch/commands/selection/discard_line_action.py
@@ -1,0 +1,42 @@
+"""Live discard line action orchestration."""
+
+from __future__ import annotations
+
+import sys
+
+from ...data.file_review.action_scope import finish_review_scoped_line_action
+from ...data.undo import undo_checkpoint
+from ...i18n import _
+from . import discard_line_selection as _discard_line_selection
+from .selected_hunk_refresh import refresh_selected_hunk_after_line_action
+
+
+def discard_live_line_selection(
+    line_id_specification: str,
+    file: str | None = None,
+    *,
+    review_state,
+    auto_advance: bool | None = None,
+) -> None:
+    """Discard selected lines from the live working-tree view."""
+    operation_parts = ["discard", "--line", line_id_specification]
+    if file is not None:
+        operation_parts.extend(["--file", file])
+
+    with undo_checkpoint(" ".join(operation_parts)):
+        file_path = _discard_line_selection.discard_worktree_line_selection(
+            line_id_specification,
+            file=file,
+        )
+        print(
+            _("✓ Discarded line(s): {lines} from {file}").format(
+                lines=line_id_specification,
+                file=file_path,
+            ),
+            file=sys.stderr,
+        )
+        refresh_selected_hunk_after_line_action(
+            file_path,
+            auto_advance=auto_advance,
+        )
+        finish_review_scoped_line_action(review_state)

--- a/src/git_stage_batch/commands/selection/discard_line_replacement_action.py
+++ b/src/git_stage_batch/commands/selection/discard_line_replacement_action.py
@@ -1,0 +1,78 @@
+"""Live discard line replacement action orchestration."""
+
+from __future__ import annotations
+
+from ...core.replacement import ReplacementPayload, coerce_replacement_payload
+from ...data.file_review.action_scope import finish_review_scoped_line_action
+from ...data.selected_change.loading import require_selected_hunk
+from ...data.selected_change.store import (
+    restore_selected_change_state,
+    snapshot_selected_change_state,
+)
+from ...data.undo import undo_checkpoint
+from ..file_scope.target_path import require_file_scope_target_path
+from . import discard_file_selection as _discard_file_selection
+from . import discard_line_batching as _discard_line_batching
+
+
+def discard_live_line_replacement_to_batch(
+    batch_name: str,
+    line_id_specification: str,
+    replacement_text: str | ReplacementPayload,
+    file: str | None = None,
+    *,
+    review_state,
+    no_edge_overlap: bool = False,
+    quiet: bool = False,
+    auto_advance: bool | None = None,
+) -> None:
+    """Save replacement text to a batch, then discard selected live lines."""
+    replacement_payload = coerce_replacement_payload(replacement_text)
+    operation_parts = [
+        "discard",
+        "--to",
+        batch_name,
+        "--line",
+        line_id_specification,
+        "--as",
+        replacement_payload.display_text or "<stdin>",
+    ]
+    if no_edge_overlap:
+        operation_parts.append("--no-edge-overlap")
+    if file is not None:
+        operation_parts.extend(["--file", file])
+
+    target_file = None
+    with (
+        undo_checkpoint(" ".join(operation_parts)),
+        snapshot_selected_change_state() as saved_selected_state,
+    ):
+        preserve_selected_state = file not in (None, "")
+
+        try:
+            if file is None:
+                require_selected_hunk()
+            else:
+                target_file = require_file_scope_target_path(file)
+                _discard_file_selection.load_explicit_file_selection(target_file)
+
+            _discard_line_batching.discard_lines_as_to_batch(
+                batch_name,
+                line_id_specification,
+                replacement_text,
+                no_edge_overlap=no_edge_overlap,
+                quiet=quiet,
+                auto_advance=auto_advance,
+            )
+
+            if preserve_selected_state:
+                restore_selected_change_state(saved_selected_state)
+        except Exception:
+            restore_selected_change_state(saved_selected_state)
+            raise
+
+    if file is None:
+        finish_review_scoped_line_action(review_state)
+    else:
+        assert target_file is not None
+        finish_review_scoped_line_action(review_state, file_path=target_file)

--- a/src/git_stage_batch/commands/selection/discard_to_batch_action.py
+++ b/src/git_stage_batch/commands/selection/discard_to_batch_action.py
@@ -1,0 +1,150 @@
+"""Discard-to-batch command routing after live selection resolution."""
+
+from __future__ import annotations
+
+from ...core.models import BinaryFileChange, RenameChange, TextFileDeletionChange
+from ...data.file_review.action_scope import finish_review_scoped_line_action
+from ...data.selected_change.loading import load_selected_change
+from ...data.selected_change.store import (
+    SelectedChangeKind,
+    read_selected_change_kind,
+)
+from ...data.undo import undo_checkpoint
+from ...exceptions import exit_with_error
+from ...i18n import _
+from ..file_scope import discard_file_to_batch as _file_scope_discard_file_to_batch
+from ..file_scope.target_path import require_file_scope_target_path
+from . import discard_line_batching as _discard_line_batching
+from . import selected_change_batch_discarding as _selected_change_batch_discarding
+from . import whole_file_batch_discarding as _whole_file_batch_discarding
+
+
+def execute_discard_to_batch_action(
+    *,
+    batch_name: str,
+    line_ids: str | None,
+    file: str | None,
+    original_file_scope: str | None,
+    review_state,
+    quiet: bool,
+    advance: bool,
+    auto_advance: bool | None,
+) -> int:
+    """Route one resolved discard-to-batch request to the selected action."""
+    operation_parts = ["discard", "--to", batch_name]
+    if line_ids is not None:
+        operation_parts.extend(["--line", line_ids])
+    if file is not None:
+        operation_parts.extend(["--file", file])
+
+    with undo_checkpoint(" ".join(operation_parts)):
+        if (
+            file is None
+            and line_ids is None
+            and read_selected_change_kind() == SelectedChangeKind.RENAME
+        ):
+            selected_change = load_selected_change()
+            if isinstance(selected_change, RenameChange):
+                exit_with_error(
+                    _(
+                        "Cannot discard rename '{old} -> {new}' to a batch yet. "
+                        "Discard, skip, or stage the rename first."
+                    ).format(
+                        old=selected_change.old_path,
+                        new=selected_change.new_path,
+                    )
+                )
+
+        if (
+            file is None
+            and line_ids is None
+            and read_selected_change_kind() == SelectedChangeKind.GITLINK
+        ):
+            exit_with_error(
+                _("Discarding submodule pointer changes to a batch is not supported yet.")
+            )
+
+        if (
+            file is None
+            and line_ids is None
+            and read_selected_change_kind() == SelectedChangeKind.BINARY
+        ):
+            selected_change = load_selected_change()
+            if isinstance(selected_change, BinaryFileChange):
+                saved_hunks = _whole_file_batch_discarding.discard_binary_to_batch(
+                    batch_name,
+                    selected_change,
+                    quiet=quiet,
+                    auto_advance=auto_advance,
+                )
+            else:
+                saved_hunks = (
+                    _selected_change_batch_discarding.discard_selected_change_to_batch(
+                        batch_name,
+                        file_only=False,
+                        quiet=quiet,
+                        auto_advance=auto_advance,
+                    )
+                )
+        elif (
+            file is None
+            and line_ids is None
+            and read_selected_change_kind() == SelectedChangeKind.DELETION
+        ):
+            selected_change = load_selected_change()
+            if isinstance(selected_change, TextFileDeletionChange):
+                saved_hunks = (
+                    _whole_file_batch_discarding.discard_text_deletion_to_batch(
+                        batch_name,
+                        selected_change,
+                        quiet=quiet,
+                        auto_advance=auto_advance,
+                    )
+                )
+            else:
+                saved_hunks = (
+                    _selected_change_batch_discarding.discard_selected_change_to_batch(
+                        batch_name,
+                        file_only=False,
+                        quiet=quiet,
+                        auto_advance=auto_advance,
+                    )
+                )
+        elif file is not None:
+            target_file = require_file_scope_target_path(file)
+            if line_ids is None:
+                saved_hunks = _file_scope_discard_file_to_batch.discard_file_to_batch(
+                    batch_name,
+                    target_file,
+                    quiet=quiet,
+                    advance=advance,
+                    auto_advance=auto_advance,
+                )
+            else:
+                saved_hunks = _discard_line_batching.discard_file_lines_to_batch(
+                    batch_name,
+                    target_file,
+                    line_ids,
+                    quiet=quiet,
+                    auto_advance=auto_advance,
+                )
+        elif line_ids is not None:
+            saved_hunks = _discard_line_batching.discard_selected_lines_to_batch(
+                batch_name,
+                line_ids,
+                quiet=quiet,
+                auto_advance=auto_advance,
+            )
+        else:
+            saved_hunks = (
+                _selected_change_batch_discarding.discard_selected_change_to_batch(
+                    batch_name,
+                    file_only=False,
+                    quiet=quiet,
+                    auto_advance=auto_advance,
+                )
+            )
+
+    if original_file_scope in (None, "") and line_ids is not None:
+        finish_review_scoped_line_action(review_state)
+    return saved_hunks

--- a/src/git_stage_batch/commands/selection/include_line_replacement_action.py
+++ b/src/git_stage_batch/commands/selection/include_line_replacement_action.py
@@ -1,0 +1,130 @@
+"""Live include line replacement action orchestration."""
+
+from __future__ import annotations
+
+from contextlib import ExitStack
+import sys
+
+from ...core.replacement import ReplacementPayload, coerce_replacement_payload
+from ...data.file_review.action_scope import finish_review_scoped_line_action
+from ...data.line_id_files import write_line_ids_file
+from ...data.selected_change.store import restore_selected_change_state
+from ...data.undo import undo_checkpoint
+from ...i18n import _
+from ...utils.paths import get_processed_include_ids_file_path
+from . import include_line_replacement as _include_line_replacement
+from .selected_hunk_refresh import refresh_selected_hunk_after_line_action
+
+
+def include_live_line_replacement(
+    line_id_specification: str,
+    replacement_text: str | ReplacementPayload,
+    file: str | None = None,
+    *,
+    review_state,
+    no_edge_overlap: bool = False,
+    auto_advance: bool | None = None,
+) -> None:
+    """Stage replacement text for selected lines from the live view."""
+    replacement_payload = coerce_replacement_payload(replacement_text)
+    operation_parts = [
+        "include",
+        "--line",
+        line_id_specification,
+        "--as",
+        replacement_payload.display_text or "<stdin>",
+    ]
+    if no_edge_overlap:
+        operation_parts.append("--no-edge-overlap")
+    if file is not None:
+        operation_parts.extend(["--file", file])
+
+    replacement_file_context = None
+    with undo_checkpoint(" ".join(operation_parts)), ExitStack() as selected_state_stack:
+        if file is None:
+            replacement_context = (
+                _include_line_replacement.prepare_pathless_include_line_replacement(
+                    line_id_specification
+                )
+            )
+            line_changes = replacement_context.display_line_changes
+            with (
+                replacement_context.base_buffer as hunk_base_lines,
+                replacement_context.source_buffer as hunk_source_lines,
+            ):
+                _include_line_replacement.apply_include_line_replacement(
+                    replacement_context.replacement_line_changes,
+                    line_id_specification=replacement_context.line_id_specification,
+                    replacement_text=replacement_text,
+                    hunk_base_lines=hunk_base_lines,
+                    hunk_source_lines=hunk_source_lines,
+                    trim_unchanged_edge_anchors=not no_edge_overlap,
+                )
+
+            write_line_ids_file(get_processed_include_ids_file_path(), set())
+            print(
+                _("✓ Included line(s) as replacement: {lines} from {file}").format(
+                    lines=line_id_specification,
+                    file=line_changes.path,
+                ),
+                file=sys.stderr,
+            )
+            refresh_selected_hunk_after_line_action(
+                line_changes.path,
+                auto_advance=auto_advance,
+            )
+            finish_review_scoped_line_action(review_state, file_path=line_changes.path)
+        else:
+            replacement_file_context = (
+                _include_line_replacement.prepare_file_include_line_replacement(
+                    file,
+                    selected_state_stack,
+                )
+            )
+            with (
+                replacement_file_context.base_buffer as hunk_base_lines,
+                replacement_file_context.source_buffer as hunk_source_lines,
+            ):
+                _include_line_replacement.apply_include_line_replacement(
+                    replacement_file_context.line_changes,
+                    line_id_specification=line_id_specification,
+                    replacement_text=replacement_text,
+                    hunk_base_lines=hunk_base_lines,
+                    hunk_source_lines=hunk_source_lines,
+                    trim_unchanged_edge_anchors=not no_edge_overlap,
+                )
+
+            if replacement_file_context.preserve_selected_state:
+                assert replacement_file_context.saved_selected_state is not None
+                restore_selected_change_state(
+                    replacement_file_context.saved_selected_state
+                )
+            else:
+                write_line_ids_file(get_processed_include_ids_file_path(), set())
+                print(
+                    _("✓ Included line(s) as replacement: {lines} from {file}").format(
+                        lines=line_id_specification,
+                        file=replacement_file_context.target_file,
+                    ),
+                    file=sys.stderr,
+                )
+                refresh_selected_hunk_after_line_action(
+                    replacement_file_context.target_file,
+                    auto_advance=auto_advance,
+                )
+            finish_review_scoped_line_action(
+                review_state,
+                file_path=replacement_file_context.target_file,
+            )
+
+    if (
+        replacement_file_context is not None
+        and replacement_file_context.preserve_selected_state
+    ):
+        print(
+            _("✓ Included line(s) as replacement: {lines} from {file}").format(
+                lines=line_id_specification,
+                file=replacement_file_context.target_file,
+            ),
+            file=sys.stderr,
+        )

--- a/src/git_stage_batch/commands/selection/include_to_batch_action.py
+++ b/src/git_stage_batch/commands/selection/include_to_batch_action.py
@@ -1,0 +1,157 @@
+"""Include-to-batch command routing after live selection resolution."""
+
+from __future__ import annotations
+
+from ...core.models import (
+    BinaryFileChange,
+    GitlinkChange,
+    RenameChange,
+    TextFileDeletionChange,
+)
+from ...data.file_review.action_scope import finish_review_scoped_line_action
+from ...data.selected_change.loading import load_selected_change
+from ...data.selected_change.store import (
+    SelectedChangeKind,
+    read_selected_change_kind,
+)
+from ...data.undo import undo_checkpoint
+from ...exceptions import exit_with_error
+from ...i18n import _
+from ..file_scope import include_file_to_batch as _file_scope_include_file_to_batch
+from ..file_scope.target_path import require_file_scope_target_path
+from . import include_line_batching as _include_line_batching
+from . import selected_change_batch_staging as _selected_change_batch_staging
+from . import whole_file_batch_staging as _whole_file_batch_staging
+
+
+def execute_include_to_batch_action(
+    *,
+    batch_name: str,
+    line_ids: str | None,
+    file: str | None,
+    original_file_scope: str | None,
+    review_state,
+    quiet: bool,
+    auto_advance: bool | None,
+) -> None:
+    """Route one resolved include-to-batch request to the selected action."""
+    operation_parts = ["include", "--to", batch_name]
+    if line_ids is not None:
+        operation_parts.extend(["--line", line_ids])
+    if file is not None:
+        operation_parts.extend(["--file", file])
+
+    with undo_checkpoint(" ".join(operation_parts)):
+        if (
+            file is None
+            and line_ids is None
+            and read_selected_change_kind() == SelectedChangeKind.RENAME
+        ):
+            selected_change = load_selected_change()
+            if isinstance(selected_change, RenameChange):
+                exit_with_error(
+                    _(
+                        "Cannot include rename '{old} -> {new}' to a batch yet. "
+                        "Stage, skip, or discard the rename first."
+                    ).format(
+                        old=selected_change.old_path,
+                        new=selected_change.new_path,
+                    )
+                )
+
+        if (
+            file is None
+            and line_ids is None
+            and read_selected_change_kind() == SelectedChangeKind.GITLINK
+        ):
+            selected_change = load_selected_change()
+            if isinstance(selected_change, GitlinkChange):
+                _whole_file_batch_staging.include_gitlink_to_batch(
+                    batch_name,
+                    selected_change,
+                    quiet=quiet,
+                    auto_advance=auto_advance,
+                )
+                return
+            _selected_change_batch_staging.include_selected_change_to_batch(
+                batch_name,
+                quiet=quiet,
+                auto_advance=auto_advance,
+            )
+            return
+
+        if (
+            file is None
+            and line_ids is None
+            and read_selected_change_kind() == SelectedChangeKind.DELETION
+        ):
+            selected_change = load_selected_change()
+            if isinstance(selected_change, TextFileDeletionChange):
+                _whole_file_batch_staging.include_text_deletion_to_batch(
+                    batch_name,
+                    selected_change,
+                    quiet=quiet,
+                    auto_advance=auto_advance,
+                )
+                return
+            _selected_change_batch_staging.include_selected_change_to_batch(
+                batch_name,
+                quiet=quiet,
+                auto_advance=auto_advance,
+            )
+            return
+
+        if (
+            file is None
+            and line_ids is None
+            and read_selected_change_kind() == SelectedChangeKind.BINARY
+        ):
+            selected_change = load_selected_change()
+            if isinstance(selected_change, BinaryFileChange):
+                _whole_file_batch_staging.include_binary_to_batch(
+                    batch_name,
+                    selected_change,
+                    quiet=quiet,
+                    auto_advance=auto_advance,
+                )
+                return
+            _selected_change_batch_staging.include_selected_change_to_batch(
+                batch_name,
+                quiet=quiet,
+                auto_advance=auto_advance,
+            )
+            return
+
+        if file is not None:
+            target_file = require_file_scope_target_path(file)
+            if line_ids is None:
+                _file_scope_include_file_to_batch.include_file_to_batch(
+                    batch_name,
+                    target_file,
+                    quiet=quiet,
+                    auto_advance=auto_advance,
+                )
+            else:
+                _include_line_batching.include_file_lines_to_batch(
+                    batch_name,
+                    target_file,
+                    line_ids,
+                    quiet=quiet,
+                    auto_advance=auto_advance,
+                )
+        elif line_ids is not None:
+            _include_line_batching.include_selected_lines_to_batch(
+                batch_name,
+                line_ids,
+                quiet=quiet,
+                auto_advance=auto_advance,
+            )
+        else:
+            _selected_change_batch_staging.include_selected_change_to_batch(
+                batch_name,
+                quiet=quiet,
+                auto_advance=auto_advance,
+            )
+
+    if original_file_scope in (None, "") and line_ids is not None:
+        finish_review_scoped_line_action(review_state)

--- a/src/git_stage_batch/commands/show.py
+++ b/src/git_stage_batch/commands/show.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import sys
 
 from ..core.hashing import compute_rename_change_hash
-from ..core.models import GitlinkChange, RenameChange, TextFileDeletionChange
 from ..data.selected_change.store import (
     SelectedChangeKind,
 )

--- a/src/git_stage_batch/commands/show.py
+++ b/src/git_stage_batch/commands/show.py
@@ -4,14 +4,10 @@ from __future__ import annotations
 
 import sys
 
-from ..core.hashing import compute_rename_change_hash
 from ..data.selected_change.store import (
     SelectedChangeKind,
 )
 from ..data.selected_change.paths import get_selected_change_file_path
-from ..data.selected_change.clear_reasons import (
-    mark_selected_change_cleared_by_file_list,
-)
 from ..data.selected_change.file_changes import (
     cache_binary_file_change,
     cache_gitlink_change,
@@ -34,7 +30,6 @@ from ..data.file_review.state import (
 )
 from ..data.line_state import load_line_changes_from_state
 from ..data.session import require_session_started
-from ..data.selected_change.lifecycle import clear_selected_change_state_files
 from ..exceptions import exit_with_error
 from ..i18n import _
 from ..output.hunk import print_line_level_changes
@@ -52,18 +47,11 @@ from ..output.file_review_state_builder import (
     make_file_review_state,
     resolve_default_review_pages,
 )
-from ..output.file_review_list import (
-    make_binary_file_review_list_entry,
-    make_file_review_list_entry,
-    make_gitlink_file_review_list_entry,
-    make_rename_file_review_list_entry,
-    make_text_deletion_file_review_list_entry,
-    print_file_review_list,
-)
 from ..utils.git_repository import require_git_repository
 from ..utils.paths import (
     ensure_state_directory_exists,
 )
+from .file_scope import file_list_action as _file_list_action
 from .selection.next_change_display import show_next_unprocessed_change
 
 
@@ -81,44 +69,7 @@ def command_show_file_list(files: list[str], *, selectable: bool = True) -> None
     require_session_started()
     ensure_state_directory_exists()
 
-    entries = []
-    seen_rename_hashes: set[str] = set()
-    for file_path in files:
-        line_changes = render_file_as_single_hunk(file_path)
-        if line_changes is not None:
-            entries.append(make_file_review_list_entry(line_changes))
-            continue
-        deletion_change = render_text_deletion_change(file_path)
-        if deletion_change is not None and not text_deletion_change_is_batched(deletion_change):
-            entries.append(make_text_deletion_file_review_list_entry(deletion_change))
-            continue
-        binary_change = render_binary_file_change(file_path)
-        if binary_change is not None:
-            entries.append(make_binary_file_review_list_entry(binary_change))
-            continue
-        gitlink_change = render_gitlink_change(file_path)
-        if gitlink_change is not None:
-            entries.append(make_gitlink_file_review_list_entry(gitlink_change))
-            continue
-        rename_change = render_rename_change(file_path)
-        if rename_change is not None:
-            rename_hash = compute_rename_change_hash(rename_change)
-            if rename_hash not in seen_rename_hashes:
-                entries.append(make_rename_file_review_list_entry(rename_change))
-                seen_rename_hashes.add(rename_hash)
-
-    if not entries:
-        print(_("No reviewable changes in matched files."), file=sys.stderr)
-        return
-
-    if selectable:
-        clear_selected_change_state_files()
-        mark_selected_change_cleared_by_file_list(source=ReviewSource.FILE_VS_HEAD.value)
-
-    print_file_review_list(
-        source_label=_("Changes: file vs HEAD"),
-        entries=entries,
-    )
+    _file_list_action.show_live_file_list(files, selectable=selectable)
 
 
 def command_show(

--- a/src/git_stage_batch/commands/show.py
+++ b/src/git_stage_batch/commands/show.py
@@ -2,65 +2,14 @@
 
 from __future__ import annotations
 
-import sys
-
-from ..data.selected_change.store import (
-    SelectedChangeKind,
-)
-from ..data.selected_change.paths import get_selected_change_file_path
-from ..data.selected_change.file_changes import (
-    cache_binary_file_change,
-    cache_gitlink_change,
-    cache_rename_change,
-    cache_text_deletion_change,
-)
-from ..data.change_freshness import text_deletion_change_is_batched
-from ..data.file_hunk_display import cache_file_as_single_hunk, render_file_as_single_hunk
-from ..data.file_change_display import (
-    render_binary_file_change,
-    render_gitlink_change,
-    render_rename_change,
-    render_text_deletion_change,
-)
-from ..data.file_review.pages import normalize_page_spec
-from ..data.file_review.records import ReviewSource
-from ..data.file_review.state import (
-    clear_last_file_review_state,
-    write_last_file_review_state,
-)
-from ..data.line_state import load_line_changes_from_state
 from ..data.session import require_session_started
-from ..exceptions import exit_with_error
-from ..i18n import _
-from ..output.hunk import print_line_level_changes
-from ..output.patch import (
-    print_binary_file_change,
-    print_gitlink_change,
-    print_rename_change,
-    print_text_file_deletion_change,
-)
-from ..output.file_review import (
-    print_file_review,
-)
-from ..output.file_review_model_builder import build_file_review_model
-from ..output.file_review_state_builder import (
-    make_file_review_state,
-    resolve_default_review_pages,
-)
 from ..utils.git_repository import require_git_repository
 from ..utils.paths import (
     ensure_state_directory_exists,
 )
+from .file_scope import file_display_action as _file_display_action
 from .file_scope import file_list_action as _file_list_action
 from .selection.next_change_display import show_next_unprocessed_change
-
-
-def _load_previous_selection_for_review():
-    """Best-effort load of the prior selection for page anchoring."""
-    try:
-        return load_line_changes_from_state()
-    except Exception:
-        return None
 
 
 def command_show_file_list(files: list[str], *, selectable: bool = True) -> None:
@@ -96,152 +45,12 @@ def command_show(
 
     # File-scoped operation
     if file is not None:
-        previous_selection = _load_previous_selection_for_review()
-
-        # Determine target file
-        if file == "":
-            # --file with no arg: use selected hunk's file
-            target_file = get_selected_change_file_path()
-            if target_file is None:
-                exit_with_error(_("No selected hunk. Run 'show' first or specify file path."))
-        else:
-            target_file = file
-
-        preview_lines = render_file_as_single_hunk(target_file)
-        deletion_change = render_text_deletion_change(target_file) if preview_lines is None else None
-        if deletion_change is not None and text_deletion_change_is_batched(deletion_change):
-            deletion_change = None
-        binary_change = (
-            render_binary_file_change(target_file)
-            if preview_lines is None and deletion_change is None else
-            None
+        _file_display_action.show_live_file_display(
+            file,
+            page=page,
+            porcelain=porcelain,
+            selectable=selectable,
         )
-        gitlink_change = (
-            render_gitlink_change(target_file)
-            if preview_lines is None and deletion_change is None and binary_change is None else
-            None
-        )
-        rename_change = (
-            render_rename_change(target_file)
-            if preview_lines is None and deletion_change is None and binary_change is None and gitlink_change is None else
-            None
-        )
-        if deletion_change is not None:
-            if page is not None:
-                exit_with_error(_("File review pages are only available for text changes."))
-            if selectable:
-                clear_last_file_review_state()
-                cache_text_deletion_change(deletion_change)
-            if porcelain:
-                return
-            print_text_file_deletion_change(deletion_change)
-            return
-        if rename_change is not None:
-            if page is not None:
-                exit_with_error(_("File review pages are only available for text changes."))
-            if selectable:
-                clear_last_file_review_state()
-                cache_rename_change(rename_change)
-            if porcelain:
-                return
-            print_rename_change(rename_change)
-            return
-        if gitlink_change is not None:
-            if page is not None:
-                exit_with_error(_("File review pages are only available for text changes."))
-            if selectable:
-                clear_last_file_review_state()
-                cache_gitlink_change(gitlink_change)
-            if porcelain:
-                return
-            print_gitlink_change(gitlink_change)
-            return
-        if binary_change is not None:
-            if page is not None:
-                exit_with_error(_("File review pages are only available for text changes."))
-            if selectable:
-                clear_last_file_review_state()
-                cache_binary_file_change(binary_change)
-            if porcelain:
-                return
-            print_binary_file_change(binary_change)
-            return
-
-        if selectable and page is not None and preview_lines is not None:
-            preview_model = build_file_review_model(preview_lines)
-            resolve_default_review_pages(
-                preview_model,
-                requested_page_spec=page,
-                previous_selection=previous_selection,
-            )
-
-        # Cache and display entire file when it's the active selection.
-        file_lines = (
-            cache_file_as_single_hunk(target_file)
-            if selectable else
-            preview_lines
-        )
-        if file_lines is None:
-            if porcelain:
-                sys.exit(1)
-            else:
-                print(_("No changes in file '{file}'.").format(file=target_file), file=sys.stderr)
-            return
-
-        if selectable:
-            clear_last_file_review_state()
-
-        if porcelain:
-            return
-
-        if not porcelain:
-            if selectable:
-                review_model = build_file_review_model(file_lines)
-                shown_pages = resolve_default_review_pages(
-                    review_model,
-                    requested_page_spec=page,
-                    previous_selection=previous_selection,
-                )
-                page_spec = normalize_page_spec(shown_pages, len(review_model.pages))
-                review_state = make_file_review_state(
-                    review_model,
-                    source=ReviewSource.FILE_VS_HEAD,
-                    batch_name=None,
-                    shown_pages=shown_pages,
-                    selected_change_kind=SelectedChangeKind.FILE,
-                )
-                write_last_file_review_state(review_state)
-                print_file_review(
-                    review_model,
-                    shown_pages=shown_pages,
-                    source_label=_("Changes: file vs HEAD"),
-                    page_spec=page_spec,
-                    source=ReviewSource.FILE_VS_HEAD,
-                    opened_near_selected_hunk=(
-                        page is None
-                        and previous_selection is not None
-                        and previous_selection.path == file_lines.path
-                        and len(review_model.pages) > 1
-                    ),
-                )
-            else:
-                if page is not None:
-                    review_model = build_file_review_model(file_lines, gutter_to_selection_id={})
-                    shown_pages = resolve_default_review_pages(
-                        review_model,
-                        requested_page_spec=page,
-                        previous_selection=previous_selection,
-                    )
-                    page_spec = normalize_page_spec(shown_pages, len(review_model.pages))
-                    print_file_review(
-                        review_model,
-                        shown_pages=shown_pages,
-                        source_label=_("Changes: file vs HEAD"),
-                        page_spec=page_spec,
-                        source=ReviewSource.FILE_VS_HEAD,
-                    )
-                else:
-                    print_line_level_changes(file_lines, gutter_to_selection_id={})
         return
 
     show_next_unprocessed_change(porcelain=porcelain, selectable=selectable)

--- a/src/git_stage_batch/commands/show_from.py
+++ b/src/git_stage_batch/commands/show_from.py
@@ -7,6 +7,7 @@ import sys
 from typing import Optional
 
 from .batch_source import candidate_preview_action as _candidate_preview_action
+from .batch_source import file_display_action as _file_display_action
 from .batch_source import replacement_previews as _replacement_previews
 from ..batch.atomic_file_changes import (
     binary_change_from_batch_file_metadata,
@@ -21,42 +22,12 @@ from ..batch.selection import (
 from ..batch.source_selector import parse_batch_source_selector
 from ..batch.validation import batch_exists
 from ..batch.file_display import render_batch_file_display
-from ..data.batch_selected_changes import (
-    compute_batch_binary_fingerprint,
-    compute_batch_gitlink_fingerprint,
-)
-from ..data.selected_change.batch_file_cache import cache_rendered_batch_file_display
 from ..data.file_review.batch_selection import translate_batch_file_gutter_ids_to_selection_ids
-from ..data.file_review.pages import normalize_page_spec
 from ..data.selected_change.lifecycle import clear_selected_change_state_files
-from ..data.selected_change.store import (
-    SelectedChangeKind,
-)
 from ..data.selected_change.clear_reasons import (
     mark_selected_change_cleared_by_file_list,
 )
-from ..data.selected_change.file_changes import (
-    cache_binary_file_change,
-    cache_gitlink_change,
-)
 from ..data.file_review.records import ReviewSource
-from ..data.file_review.state import (
-    clear_last_file_review_state,
-    write_last_file_review_state,
-)
-from ..output.hunk import print_line_level_changes
-from ..output.patch import (
-    print_binary_file_change,
-    print_gitlink_change,
-)
-from ..output.file_review import (
-    print_file_review,
-)
-from ..output.file_review_model_builder import build_file_review_model
-from ..output.file_review_state_builder import (
-    make_file_review_state,
-    resolve_default_review_pages,
-)
 from ..output.file_review_list import (
     make_binary_file_review_list_entry,
     make_file_review_list_entry,
@@ -68,25 +39,11 @@ from ..exceptions import (
     BatchMetadataError,
 )
 from ..i18n import _
-from ..core.models import LineLevelChange
 from ..utils.git_repository import require_git_repository
 
 
 def _batch_source_args(batch_name: str) -> str:
     return f" --from {shlex.quote(batch_name)}"
-
-
-def _shown_pages_for_display_ids(review_model, display_ids: set[int]) -> tuple[int, ...]:
-    """Return review pages that contain the selected display IDs."""
-    return tuple(
-        sorted(
-            {
-                change.first_page
-                for change in review_model.changes
-                if set(change.display_ids) & display_ids
-            }
-        )
-    )
 
 
 def command_show_from_batch(
@@ -171,194 +128,17 @@ def command_show_from_batch(
         return
 
     if len(files) == 1:
-        # Show specific file from batch
-        # Get the resolved file path
         file_path = list(files.keys())[0]
-        binary_change = binary_change_from_batch_file_metadata(
-            file_path,
-            files[file_path],
+        _file_display_action.show_batch_source_file_display(
+            batch_name=batch_name,
+            file_path=file_path,
+            files=files,
+            metadata=metadata,
+            selected_ids=selected_ids,
+            selectable=selectable,
+            page=page,
+            command_source_args=_batch_source_args(batch_name),
         )
-        if binary_change is not None:
-            if selected_ids:
-                exit_with_error(
-                    _("Cannot use --lines with binary files. Run without --lines to view the binary change summary.")
-                )
-            if page is not None:
-                exit_with_error(_("File review pages are only available for text changes."))
-            if selectable:
-                clear_selected_change_state_files()
-                cache_binary_file_change(
-                    binary_change,
-                    kind=SelectedChangeKind.BATCH_BINARY,
-                    batch_name=batch_name,
-                    batch_binary_fingerprint=compute_batch_binary_fingerprint(
-                        batch_name,
-                        file_path,
-                        files[file_path],
-                    ),
-                )
-            print_binary_file_change(binary_change)
-            return
-
-        gitlink_change = gitlink_change_from_batch_file_metadata(
-            file_path,
-            files[file_path],
-        )
-        if gitlink_change is not None:
-            if selected_ids:
-                exit_with_error(
-                    _("Cannot use --lines with submodule pointers. Run without --lines to view the submodule pointer summary.")
-                )
-            if page is not None:
-                exit_with_error(_("File review pages are only available for text changes."))
-            if selectable:
-                clear_selected_change_state_files()
-                cache_gitlink_change(
-                    gitlink_change,
-                    kind=SelectedChangeKind.BATCH_GITLINK,
-                    batch_name=batch_name,
-                    batch_gitlink_fingerprint=compute_batch_gitlink_fingerprint(
-                        file_path,
-                        files[file_path],
-                    ),
-                )
-            print_gitlink_change(gitlink_change)
-            return
-
-        rendered = render_batch_file_display(batch_name, file_path, metadata=metadata)
-        if rendered is None:
-            print(_("No changes for file '{file}' in batch '{name}'.").format(file=file_path, name=batch_name), file=sys.stderr)
-            return
-
-        review_model = None
-        review_gutter_to_selection_id = (
-            rendered.review_gutter_to_selection_id
-            or rendered.gutter_to_selection_id
-        )
-        review_selection_id_to_gutter = (
-            rendered.review_selection_id_to_gutter
-            or rendered.selection_id_to_gutter
-        )
-        review_action_groups = rendered.review_action_groups or None
-
-        def get_review_model():
-            nonlocal review_model
-            if review_model is None:
-                review_model = build_file_review_model(
-                    rendered.line_changes,
-                    gutter_to_selection_id=review_gutter_to_selection_id,
-                    actionable_selection_groups=rendered.actionable_selection_groups,
-                    review_action_groups=review_action_groups,
-                )
-            return review_model
-
-        if selectable and page is not None:
-            resolve_default_review_pages(
-                get_review_model(),
-                requested_page_spec=page,
-                previous_selection=None,
-            )
-
-        if page is not None or (selectable and not selected_ids):
-            review_model = get_review_model()
-            shown_pages = resolve_default_review_pages(
-                review_model,
-                requested_page_spec=page,
-                previous_selection=None,
-            )
-            page_spec = normalize_page_spec(shown_pages, len(review_model.pages))
-            if selectable:
-                clear_last_file_review_state()
-                cache_rendered_batch_file_display(file_path, rendered)
-                write_last_file_review_state(
-                    make_file_review_state(
-                        review_model,
-                        source=ReviewSource.BATCH,
-                        batch_name=batch_name,
-                        shown_pages=shown_pages,
-                        selected_change_kind=SelectedChangeKind.BATCH_FILE,
-                        gutter_to_selection_id=review_gutter_to_selection_id,
-                        actionable_selection_groups=rendered.actionable_selection_groups,
-                        review_action_groups=review_action_groups,
-                    )
-                )
-            print_file_review(
-                review_model,
-                shown_pages=shown_pages,
-                source_label=_("Changes: batch {name}").format(name=batch_name),
-                page_spec=page_spec,
-                command_source_args=_batch_source_args(batch_name),
-                source=ReviewSource.BATCH,
-                batch_name=batch_name,
-                note=metadata.get("note") or None,
-            )
-            return
-
-        # Filter by line IDs if specified (for display only)
-        if selected_ids:
-            line_gutter_to_selection_id = (
-                review_gutter_to_selection_id
-                if selectable else
-                rendered.gutter_to_selection_id
-            )
-
-            # Translate gutter IDs (what user sees) to selection IDs (internal)
-            selection_ids = set()
-            for gutter_id in selected_ids:
-                if gutter_id in line_gutter_to_selection_id:
-                    selection_ids.add(line_gutter_to_selection_id[gutter_id])
-                else:
-                    exit_with_error(
-                        _("Line ID {id} is not available for this action. Select one of the numbered lines shown for this batch file.").format(
-                            id=gutter_id
-                        )
-                    )
-
-            if selectable:
-                clear_last_file_review_state()
-                cache_rendered_batch_file_display(file_path, rendered)
-                review_model = get_review_model()
-                visible_review_display_ids = {
-                    review_selection_id_to_gutter[selection_id]
-                    for selection_id in selection_ids
-                    if selection_id in review_selection_id_to_gutter
-                }
-                shown_pages = _shown_pages_for_display_ids(review_model, visible_review_display_ids)
-                if shown_pages:
-                    write_last_file_review_state(
-                        make_file_review_state(
-                            review_model,
-                            source=ReviewSource.BATCH,
-                            batch_name=batch_name,
-                            shown_pages=shown_pages,
-                            selected_change_kind=SelectedChangeKind.BATCH_FILE,
-                            gutter_to_selection_id=review_gutter_to_selection_id,
-                            actionable_selection_groups=rendered.actionable_selection_groups,
-                            review_action_groups=review_action_groups,
-                            visible_display_ids=visible_review_display_ids,
-                            entire_file_shown=False,
-                        )
-                    )
-
-            # Filter by selection IDs (not gutter IDs)
-            filtered_lines = [line for line in rendered.line_changes.lines if line.id in selection_ids]
-            if filtered_lines:
-                filtered_line_changes = LineLevelChange(
-                    path=rendered.line_changes.path,
-                    lines=filtered_lines,
-                    header=rendered.line_changes.header
-                )
-                print_line_level_changes(filtered_line_changes, gutter_to_selection_id=line_gutter_to_selection_id)
-        else:
-            print_line_level_changes(
-                    rendered.line_changes,
-                    gutter_to_selection_id=(
-                        review_gutter_to_selection_id
-                        if selectable else
-                        {}
-                    ),
-                )
-
         return
 
     entries = []

--- a/src/git_stage_batch/commands/show_from.py
+++ b/src/git_stage_batch/commands/show_from.py
@@ -6,15 +6,13 @@ import shlex
 import sys
 from typing import Optional
 
-from .batch_source import candidate_preview_builders as _candidate_preview_builders
-from .batch_source import candidate_previews as _candidate_previews
+from .batch_source import candidate_preview_action as _candidate_preview_action
 from .batch_source import replacement_previews as _replacement_previews
 from ..batch.atomic_file_changes import (
     binary_change_from_batch_file_metadata,
     gitlink_change_from_batch_file_metadata,
 )
 from ..batch.metadata_validation import read_validated_batch_metadata
-from ..batch.operation_candidates import save_candidate_preview_state
 from ..core.replacement import ReplacementPayload
 from ..batch.selection import (
     resolve_batch_file_scope,
@@ -65,14 +63,9 @@ from ..output.file_review_list import (
     make_gitlink_file_review_list_entry,
     print_file_review_list,
 )
-from ..output.candidate_preview import (
-    render_operation_candidate,
-    render_operation_candidate_overview,
-)
 from ..exceptions import (
     exit_with_error,
     BatchMetadataError,
-    MergeError,
 )
 from ..i18n import _
 from ..core.models import LineLevelChange
@@ -145,63 +138,16 @@ def command_show_from_batch(
     )
 
     if selector.candidate_operation is not None:
-        if patterns is not None or len(files) != 1:
-            exit_with_error(_("Candidate preview requires exactly one file."))
-        file_path = list(files.keys())[0]
-        try:
-            previews = _candidate_preview_builders.build_batch_source_candidate_previews(
-                selector=selector,
-                files=files,
-                file_path=file_path,
-                selected_ids=selected_ids,
-                replacement_text=replacement_text,
-                translate_selection_ids=(
-                    translate_batch_file_gutter_ids_to_selection_ids
-                ),
-            )
-        except ValueError as e:
-            exit_with_error(str(e))
-        except MergeError as e:
-            exit_with_error(str(e))
-
-        if not previews:
-            exit_with_error(
-                _("Batch '{batch}' has no {operation} candidates for {file}.").format(
-                    batch=batch_name,
-                    operation=selector.candidate_operation,
-                    file=file_path,
-                )
-            )
-
-        if selector.candidate_ordinal is None:
-            try:
-                reviewed_previews = render_operation_candidate_overview(
-                    previews,
-                    porcelain=porcelain,
-                    note=metadata.get("note") or None,
-                )
-                for preview in reviewed_previews:
-                    save_candidate_preview_state(preview)
-            finally:
-                _candidate_previews.close_candidate_previews(previews)
-            return
-
-        try:
-            preview = _candidate_previews.require_candidate_preview_for_ordinal(
-                previews,
-                selector.candidate_ordinal,
-                batch_name=batch_name,
-                operation=selector.candidate_operation,
-                file_path=file_path,
-            )
-            render_operation_candidate(
-                preview,
-                porcelain=porcelain,
-                note=metadata.get("note") or None,
-            )
-            save_candidate_preview_state(preview)
-        finally:
-            _candidate_previews.close_candidate_previews(previews)
+        _candidate_preview_action.show_batch_source_candidate_preview(
+            selector=selector,
+            batch_name=batch_name,
+            files=files,
+            selected_ids=selected_ids,
+            replacement_text=replacement_text,
+            patterns=patterns,
+            porcelain=porcelain,
+            note=metadata.get("note") or None,
+        )
         return
 
     if porcelain:

--- a/src/git_stage_batch/commands/show_from.py
+++ b/src/git_stage_batch/commands/show_from.py
@@ -3,16 +3,12 @@
 from __future__ import annotations
 
 import shlex
-import sys
 from typing import Optional
 
 from .batch_source import candidate_preview_action as _candidate_preview_action
 from .batch_source import file_display_action as _file_display_action
+from .batch_source import file_list_action as _file_list_action
 from .batch_source import replacement_previews as _replacement_previews
-from ..batch.atomic_file_changes import (
-    binary_change_from_batch_file_metadata,
-    gitlink_change_from_batch_file_metadata,
-)
 from ..batch.metadata_validation import read_validated_batch_metadata
 from ..core.replacement import ReplacementPayload
 from ..batch.selection import (
@@ -21,19 +17,7 @@ from ..batch.selection import (
 )
 from ..batch.source_selector import parse_batch_source_selector
 from ..batch.validation import batch_exists
-from ..batch.file_display import render_batch_file_display
 from ..data.file_review.batch_selection import translate_batch_file_gutter_ids_to_selection_ids
-from ..data.selected_change.lifecycle import clear_selected_change_state_files
-from ..data.selected_change.clear_reasons import (
-    mark_selected_change_cleared_by_file_list,
-)
-from ..data.file_review.records import ReviewSource
-from ..output.file_review_list import (
-    make_binary_file_review_list_entry,
-    make_file_review_list_entry,
-    make_gitlink_file_review_list_entry,
-    print_file_review_list,
-)
 from ..exceptions import (
     exit_with_error,
     BatchMetadataError,
@@ -141,42 +125,10 @@ def command_show_from_batch(
         )
         return
 
-    entries = []
-    for file_path, file_meta in files.items():
-        binary_change = binary_change_from_batch_file_metadata(file_path, file_meta)
-        if binary_change is not None:
-            entries.append(make_binary_file_review_list_entry(binary_change))
-            continue
-        gitlink_change = gitlink_change_from_batch_file_metadata(file_path, file_meta)
-        if gitlink_change is not None:
-            entries.append(make_gitlink_file_review_list_entry(gitlink_change))
-            continue
-        rendered = render_batch_file_display(
-            batch_name,
-            file_path,
-            metadata=metadata,
-            probe_mergeability=False,
-        )
-        if rendered is not None:
-            entries.append(
-                make_file_review_list_entry(
-                    rendered.line_changes,
-                )
-            )
-
-    if entries:
-        # Multi-file batch output is navigational; it must not leave a hidden
-        # selected file that a later bare action could operate on.
-        if selectable:
-            clear_selected_change_state_files()
-            mark_selected_change_cleared_by_file_list(
-                source=ReviewSource.BATCH.value,
-                batch_name=batch_name,
-            )
-        print_file_review_list(
-            source_label=_("Changes: batch {name}").format(name=batch_name),
-            entries=entries,
-            command_source_args=_batch_source_args(batch_name),
-        )
-    else:
-        print(_("Batch '{name}' is empty").format(name=batch_name), file=sys.stderr)
+    _file_list_action.show_batch_source_file_list(
+        batch_name=batch_name,
+        files=files,
+        metadata=metadata,
+        selectable=selectable,
+        command_source_args=_batch_source_args(batch_name),
+    )

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -3342,6 +3342,46 @@ def test_selected_change_batch_staging_owns_include_pipeline():
     assert helper_imports <= helper_imported_names
 
 
+def test_include_to_batch_action_owns_resolved_dispatch():
+    """Include-to-batch action routing should stay in the selection package."""
+    action_path = SRC_ROOT / "commands" / "selection" / "include_to_batch_action.py"
+    action_tree = ast.parse(action_path.read_text(), filename=str(action_path))
+    action_names = {
+        node.name for node in ast.walk(action_tree) if isinstance(node, ast.FunctionDef)
+    }
+    action_imports = {}
+    for imported_module, node in _import_from_nodes(action_path):
+        action_imports.setdefault(imported_module, set()).update(
+            alias.name for alias in node.names
+        )
+
+    assert "execute_include_to_batch_action" in action_names
+    assert "finish_review_scoped_line_action" in action_imports[
+        "git_stage_batch.data.file_review.action_scope"
+    ]
+    assert "load_selected_change" in action_imports[
+        "git_stage_batch.data.selected_change.loading"
+    ]
+    assert "undo_checkpoint" in action_imports["git_stage_batch.data.undo"]
+    assert {
+        "BinaryFileChange",
+        "GitlinkChange",
+        "RenameChange",
+        "TextFileDeletionChange",
+    } <= action_imports["git_stage_batch.core.models"]
+    assert {
+        "selected_change_batch_staging",
+        "whole_file_batch_staging",
+        "include_line_batching",
+    } <= action_imports["git_stage_batch.commands.selection"]
+    assert "include_file_to_batch" in action_imports[
+        "git_stage_batch.commands.file_scope"
+    ]
+    assert "require_file_scope_target_path" in action_imports[
+        "git_stage_batch.commands.file_scope.target_path"
+    ]
+
+
 def test_file_scope_include_file_owns_file_pipeline():
     """Explicit file-scope include support should stay out of include.py."""
     include_path = SRC_ROOT / "commands" / "include.py"

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -388,6 +388,26 @@ def test_cli_package_does_not_reexport_cli_apis():
     assert violations == []
 
 
+def test_cli_argument_parser_uses_subcommand_parser_module():
+    """Argument parsing should not own reusable subcommand construction."""
+    argument_parser_path = SRC_ROOT / "cli" / "argument_parser.py"
+    subcommand_parser_path = SRC_ROOT / "cli" / "subcommand_parser.py"
+    argument_parser_text = argument_parser_path.read_text()
+    argument_parser_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(argument_parser_path)
+    }
+    subcommand_parser = __import__(
+        "git_stage_batch.cli.subcommand_parser",
+        fromlist=["subcommand_parser"],
+    )
+
+    assert "git_stage_batch.cli.subcommand_parser" in argument_parser_imports
+    assert "add_subcommand_parser" in vars(subcommand_parser)
+    assert "def _add_subcommand_parser" not in argument_parser_text
+    assert subcommand_parser_path.exists()
+
+
 def test_tui_package_does_not_reexport_tui_apis():
     """TUI callers should import concrete modules instead of the package."""
     tui_path = SRC_ROOT / "tui" / "__init__.py"

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -7662,6 +7662,59 @@ def test_batch_source_file_list_action_owns_list_rendering():
     assert helper_imports <= helper_imported_names
 
 
+def test_batch_source_file_list_action_owns_show_flow():
+    """Show-from multi-file list flow should stay in batch-source support."""
+    show_from_path = SRC_ROOT / "commands" / "show_from.py"
+    helper_path = SRC_ROOT / "commands" / "batch_source" / "file_list_action.py"
+    action_dependency_names = {
+        "ReviewSource",
+        "binary_change_from_batch_file_metadata",
+        "clear_selected_change_state_files",
+        "gitlink_change_from_batch_file_metadata",
+        "make_binary_file_review_list_entry",
+        "make_file_review_list_entry",
+        "make_gitlink_file_review_list_entry",
+        "mark_selected_change_cleared_by_file_list",
+        "print_file_review_list",
+        "render_batch_file_display",
+    }
+
+    show_from_tree = ast.parse(
+        show_from_path.read_text(),
+        filename=str(show_from_path),
+    )
+    show_from_functions = {
+        node.name: node
+        for node in ast.walk(show_from_tree)
+        if isinstance(node, ast.FunctionDef)
+    }
+    command_names = {
+        node.id
+        for node in ast.walk(show_from_functions["command_show_from_batch"])
+        if isinstance(node, ast.Name)
+    }
+    command_attrs = {
+        node.attr
+        for node in ast.walk(show_from_functions["command_show_from_batch"])
+        if isinstance(node, ast.Attribute)
+    }
+    batch_source_imports = set()
+    for imported_module, node in _import_from_nodes(show_from_path):
+        if imported_module != "git_stage_batch.commands.batch_source":
+            continue
+        batch_source_imports |= {alias.name for alias in node.names}
+
+    helper_imported_names = set()
+    for _imported_module, node in _import_from_nodes(helper_path):
+        helper_imported_names |= {alias.name for alias in node.names}
+
+    assert "file_list_action" in batch_source_imports
+    assert "show_batch_source_file_list" in command_attrs
+    assert action_dependency_names.isdisjoint(command_names)
+    assert action_dependency_names.isdisjoint(command_attrs)
+    assert action_dependency_names <= helper_imported_names
+
+
 def test_batch_owns_binary_file_content_loading():
     """Stored binary batch content loading should live in batch."""
     binary_file_content = __import__(

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -3463,6 +3463,45 @@ def test_include_delegates_include_to_batch_action_routing():
     assert violations == []
 
 
+def test_discard_to_batch_action_owns_resolved_dispatch():
+    """Discard-to-batch action routing should stay in the selection package."""
+    action_path = SRC_ROOT / "commands" / "selection" / "discard_to_batch_action.py"
+    action_tree = ast.parse(action_path.read_text(), filename=str(action_path))
+    action_names = {
+        node.name for node in ast.walk(action_tree) if isinstance(node, ast.FunctionDef)
+    }
+    action_imports = {}
+    for imported_module, node in _import_from_nodes(action_path):
+        action_imports.setdefault(imported_module, set()).update(
+            alias.name for alias in node.names
+        )
+
+    assert "execute_discard_to_batch_action" in action_names
+    assert "finish_review_scoped_line_action" in action_imports[
+        "git_stage_batch.data.file_review.action_scope"
+    ]
+    assert "load_selected_change" in action_imports[
+        "git_stage_batch.data.selected_change.loading"
+    ]
+    assert "undo_checkpoint" in action_imports["git_stage_batch.data.undo"]
+    assert {
+        "BinaryFileChange",
+        "RenameChange",
+        "TextFileDeletionChange",
+    } <= action_imports["git_stage_batch.core.models"]
+    assert {
+        "discard_line_batching",
+        "selected_change_batch_discarding",
+        "whole_file_batch_discarding",
+    } <= action_imports["git_stage_batch.commands.selection"]
+    assert "discard_file_to_batch" in action_imports[
+        "git_stage_batch.commands.file_scope"
+    ]
+    assert "require_file_scope_target_path" in action_imports[
+        "git_stage_batch.commands.file_scope.target_path"
+    ]
+
+
 def test_file_scope_include_file_owns_file_pipeline():
     """Explicit file-scope include support should stay out of include.py."""
     include_path = SRC_ROOT / "commands" / "include.py"

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -10765,6 +10765,78 @@ def test_discard_line_replacement_stays_in_command_helper():
     assert helper_imports <= helper_imported_names
 
 
+def test_discard_line_replacement_action_stays_in_command_helper():
+    """Discard line-replacement action support should stay out of the entrypoint."""
+    discard_path = SRC_ROOT / "commands" / "discard.py"
+    helper_path = (
+        SRC_ROOT / "commands" / "selection" / "discard_line_replacement_action.py"
+    )
+    helper = __import__(
+        "git_stage_batch.commands.selection.discard_line_replacement_action",
+        fromlist=["discard_line_replacement_action"],
+    )
+    public_names = {"discard_live_line_replacement_to_batch"}
+    action_dependency_names = {
+        "coerce_replacement_payload",
+        "discard_file_selection",
+        "discard_line_batching",
+        "discard_lines_as_to_batch",
+        "finish_review_scoped_line_action",
+        "load_explicit_file_selection",
+        "require_file_scope_target_path",
+        "require_selected_hunk",
+        "restore_selected_change_state",
+        "snapshot_selected_change_state",
+        "undo_checkpoint",
+    }
+    helper_imports = {
+        "ReplacementPayload",
+        "coerce_replacement_payload",
+        "discard_file_selection",
+        "discard_line_batching",
+        "finish_review_scoped_line_action",
+        "require_file_scope_target_path",
+        "require_selected_hunk",
+        "restore_selected_change_state",
+        "snapshot_selected_change_state",
+        "undo_checkpoint",
+    }
+
+    assert public_names <= vars(helper).keys()
+
+    discard_tree = ast.parse(discard_path.read_text(), filename=str(discard_path))
+    discard_functions = {
+        node.name: node
+        for node in ast.walk(discard_tree)
+        if isinstance(node, ast.FunctionDef)
+    }
+    command_line_as_names = {
+        node.id
+        for node in ast.walk(discard_functions["command_discard_line_as_to_batch"])
+        if isinstance(node, ast.Name)
+    }
+    command_line_as_attributes = {
+        node.attr
+        for node in ast.walk(discard_functions["command_discard_line_as_to_batch"])
+        if isinstance(node, ast.Attribute)
+    }
+    discard_selection_imports = set()
+    for imported_module, node in _import_from_nodes(discard_path):
+        if imported_module != "git_stage_batch.commands.selection":
+            continue
+        discard_selection_imports |= {alias.name for alias in node.names}
+
+    helper_imported_names = set()
+    for _imported_module, node in _import_from_nodes(helper_path):
+        helper_imported_names |= {alias.name for alias in node.names}
+
+    assert "discard_line_replacement_action" in discard_selection_imports
+    assert "discard_live_line_replacement_to_batch" in command_line_as_attributes
+    assert action_dependency_names.isdisjoint(command_line_as_names)
+    assert action_dependency_names.isdisjoint(command_line_as_attributes)
+    assert helper_imports <= helper_imported_names
+
+
 def test_batch_line_selection_stays_in_command_helper():
     """Batch line-selection validation should live in command selection support."""
     include_line_batching_path = (

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -7417,6 +7417,9 @@ def test_output_owns_operation_candidate_preview_rendering():
         fromlist=["candidate_preview_summary"],
     )
     show_from_path = SRC_ROOT / "commands" / "show_from.py"
+    action_path = (
+        SRC_ROOT / "commands" / "batch_source" / "candidate_preview_action.py"
+    )
     candidate_preview_path = SRC_ROOT / "output" / "candidate_preview.py"
     candidate_summary_path = SRC_ROOT / "output" / "candidate_preview_summary.py"
     public_renderer_names = {
@@ -7450,7 +7453,7 @@ def test_output_owns_operation_candidate_preview_rendering():
         for node in ast.walk(show_from_tree)
         if isinstance(node, (ast.ClassDef, ast.FunctionDef))
     }
-    show_from_renderer_imports = set()
+    action_renderer_imports = set()
     candidate_preview_imports = {
         imported_module
         for imported_module, _node in _import_from_nodes(candidate_preview_path)
@@ -7460,15 +7463,15 @@ def test_output_owns_operation_candidate_preview_rendering():
         for imported_module, _node in _import_from_nodes(candidate_summary_path)
     }
 
-    for imported_module, node in _import_from_nodes(show_from_path):
+    for imported_module, node in _import_from_nodes(action_path):
         if imported_module != "git_stage_batch.output.candidate_preview":
             continue
-        show_from_renderer_imports |= {alias.name for alias in node.names}
+        action_renderer_imports |= {alias.name for alias in node.names}
 
     assert public_renderer_names <= vars(candidate_preview).keys()
     assert renderer_helper_names <= vars(candidate_preview).keys()
     assert summary_names <= vars(candidate_preview_summary).keys()
-    assert public_renderer_names <= show_from_renderer_imports
+    assert public_renderer_names <= action_renderer_imports
     assert renderer_helper_names.isdisjoint(show_from_helpers)
     assert summary_names.isdisjoint(vars(candidate_preview))
     assert old_renderer_summary_names.isdisjoint(vars(candidate_preview))
@@ -7821,7 +7824,9 @@ def test_batch_source_candidate_previews_own_candidate_preview_checks():
     )
     apply_from_path = SRC_ROOT / "commands" / "apply_from.py"
     include_from_path = SRC_ROOT / "commands" / "include_from.py"
-    show_from_path = SRC_ROOT / "commands" / "show_from.py"
+    action_path = (
+        SRC_ROOT / "commands" / "batch_source" / "candidate_preview_action.py"
+    )
     public_names = {
         "candidate_preview_for_ordinal",
         "candidate_preview_state_matches",
@@ -7832,7 +7837,7 @@ def test_batch_source_candidate_previews_own_candidate_preview_checks():
     command_paths = {
         apply_from_path,
         include_from_path,
-        show_from_path,
+        action_path,
     }
     imports_candidate_previews = {
         path: False
@@ -7860,12 +7865,12 @@ def test_batch_source_candidate_previews_own_candidate_preview_checks():
     assert imports_candidate_previews == {
         apply_from_path: False,
         include_from_path: False,
-        show_from_path: True,
+        action_path: True,
     }
     assert direct_state_imports == {
         apply_from_path: set(),
         include_from_path: set(),
-        show_from_path: set(),
+        action_path: set(),
     }
     for path in command_paths:
         command_text = path.read_text()
@@ -7880,7 +7885,9 @@ def test_batch_source_candidate_preview_builders_own_show_candidate_construction
         "git_stage_batch.commands.batch_source.candidate_preview_builders",
         fromlist=["candidate_preview_builders"],
     )
-    show_from_path = SRC_ROOT / "commands" / "show_from.py"
+    action_path = (
+        SRC_ROOT / "commands" / "batch_source" / "candidate_preview_action.py"
+    )
     public_names = {
         "build_batch_source_candidate_previews",
     }
@@ -7891,19 +7898,19 @@ def test_batch_source_candidate_preview_builders_own_show_candidate_construction
         "build_apply_candidate_previews",
         "build_include_candidate_previews",
     }
-    show_from_tree = ast.parse(
-        show_from_path.read_text(),
-        filename=str(show_from_path),
+    action_tree = ast.parse(
+        action_path.read_text(),
+        filename=str(action_path),
     )
-    show_from_helpers = {
+    action_helpers = {
         node.name
-        for node in ast.walk(show_from_tree)
+        for node in ast.walk(action_tree)
         if isinstance(node, ast.FunctionDef)
     }
     imports_candidate_preview_builders = False
     direct_operation_builder_imports = set()
 
-    for imported_module, node in _import_from_nodes(show_from_path):
+    for imported_module, node in _import_from_nodes(action_path):
         imported_names = {alias.name for alias in node.names}
         if (
             imported_module == "git_stage_batch.commands.batch_source"
@@ -7915,7 +7922,7 @@ def test_batch_source_candidate_preview_builders_own_show_candidate_construction
 
     assert public_names <= vars(candidate_preview_builders).keys()
     assert imports_candidate_preview_builders
-    assert old_function_names.isdisjoint(show_from_helpers)
+    assert old_function_names.isdisjoint(action_helpers)
     assert direct_operation_builder_imports == set()
 
 

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -2001,11 +2001,13 @@ def test_file_review_action_scope_stays_out_of_state_module():
             "resolve_batch_source_action_scope",
         },
         SRC_ROOT / "commands" / "discard.py": {
-            "finish_review_scoped_line_action",
             "refuse_ambiguous_bare_action_after_partial_file_review",
             "refuse_live_action_for_batch_selection",
             "resolve_live_line_action_scope",
             "resolve_live_to_batch_action_scope",
+        },
+        SRC_ROOT / "commands" / "selection" / "discard_to_batch_action.py": {
+            "finish_review_scoped_line_action",
         },
         SRC_ROOT / "commands" / "include.py": {
             "refuse_ambiguous_bare_action_after_partial_file_review",
@@ -3150,6 +3152,7 @@ def test_file_scope_discard_to_batch_owns_multi_file_pipeline():
 def test_file_scope_single_file_discard_to_batch_breaks_command_import_cycle():
     """File-scope fallback support should not depend on discard.py."""
     discard_path = SRC_ROOT / "commands" / "discard.py"
+    action_path = SRC_ROOT / "commands" / "selection" / "discard_to_batch_action.py"
     multi_file_helper_path = (
         SRC_ROOT / "commands" / "file_scope" / "discard_to_batch.py"
     )
@@ -3184,6 +3187,17 @@ def test_file_scope_single_file_discard_to_batch_breaks_command_import_cycle():
         imported_module
         for imported_module, _node in _import_from_nodes(discard_path)
     }
+    discard_selection_imported_names = set()
+    for imported_module, node in _import_from_nodes(discard_path):
+        if imported_module == "git_stage_batch.commands.selection":
+            discard_selection_imported_names |= {alias.name for alias in node.names}
+    action_file_scope_imported_names = set()
+    action_selection_imported_names = set()
+    for imported_module, node in _import_from_nodes(action_path):
+        if imported_module == "git_stage_batch.commands.file_scope":
+            action_file_scope_imported_names |= {alias.name for alias in node.names}
+        if imported_module == "git_stage_batch.commands.selection":
+            action_selection_imported_names |= {alias.name for alias in node.names}
     multi_file_helper_imports = {
         imported_module
         for imported_module, _node in _import_from_nodes(multi_file_helper_path)
@@ -3207,14 +3221,13 @@ def test_file_scope_single_file_discard_to_batch_breaks_command_import_cycle():
     assert old_command_helper_names.isdisjoint(vars(single_file_helper).keys())
     assert old_command_helper_names.isdisjoint(vars(whole_file_helper).keys())
     assert old_command_helper_names.isdisjoint(discard_names)
+    assert "discard_to_batch_action" in discard_selection_imported_names
     assert (
         "git_stage_batch.commands.file_scope.discard_file_to_batch"
-        in discard_imports
+        not in discard_imports
     )
-    assert (
-        "git_stage_batch.commands.selection.whole_file_batch_discarding"
-        in discard_imports
-    )
+    assert "discard_file_to_batch" in action_file_scope_imported_names
+    assert "whole_file_batch_discarding" in action_selection_imported_names
     assert (
         "git_stage_batch.commands.file_scope.discard_file_to_batch"
         in multi_file_helper_imports
@@ -3502,6 +3515,70 @@ def test_discard_to_batch_action_owns_resolved_dispatch():
     ]
 
 
+def test_discard_delegates_discard_to_batch_action_routing():
+    """The discard-to-batch command should delegate resolved action routing."""
+    discard_path = SRC_ROOT / "commands" / "discard.py"
+    discard_tree = ast.parse(discard_path.read_text(), filename=str(discard_path))
+    discard_functions = {
+        node.name: node
+        for node in ast.walk(discard_tree)
+        if isinstance(node, ast.FunctionDef)
+    }
+    command_attrs = {
+        node.attr
+        for node in ast.walk(discard_functions["command_discard_to_batch"])
+        if isinstance(node, ast.Attribute)
+    }
+    discard_imports = {}
+    for imported_module, node in _import_from_nodes(discard_path):
+        discard_imports.setdefault(imported_module, set()).update(
+            alias.name for alias in node.names
+        )
+    disallowed_imports = {
+        "git_stage_batch.core.models": {
+            "BinaryFileChange",
+            "RenameChange",
+            "TextFileDeletionChange",
+        },
+        "git_stage_batch.data.file_review.action_scope": {
+            "finish_review_scoped_line_action",
+        },
+        "git_stage_batch.data.selected_change.loading": {
+            "load_selected_change",
+        },
+        "git_stage_batch.data.undo": {
+            "undo_checkpoint",
+        },
+        "git_stage_batch.exceptions": {
+            "exit_with_error",
+        },
+        "git_stage_batch.commands.selection": {
+            "discard_line_batching",
+            "selected_change_batch_discarding",
+            "whole_file_batch_discarding",
+        },
+        "git_stage_batch.commands.file_scope": {
+            "discard_file_to_batch",
+        },
+        "git_stage_batch.commands.file_scope.target_path": {
+            "require_file_scope_target_path",
+        },
+    }
+    violations = []
+
+    for imported_module, disallowed_names in disallowed_imports.items():
+        stale_names = discard_imports.get(imported_module, set()) & disallowed_names
+        if stale_names:
+            names = ", ".join(sorted(stale_names))
+            violations.append(f"{imported_module} imports {names}")
+
+    assert "discard_to_batch_action" in discard_imports[
+        "git_stage_batch.commands.selection"
+    ]
+    assert "execute_discard_to_batch_action" in command_attrs
+    assert violations == []
+
+
 def test_file_scope_include_file_owns_file_pipeline():
     """Explicit file-scope include support should stay out of include.py."""
     include_path = SRC_ROOT / "commands" / "include.py"
@@ -3784,10 +3861,13 @@ def test_file_scope_file_display_action_owns_show_entry_flow():
 def test_file_scope_target_path_stays_in_file_scope_support():
     """File-scope target fallback should stay out of command entrypoints."""
     direct_target_path_paths = {
-        SRC_ROOT / "commands" / "discard.py",
         SRC_ROOT / "commands" / "selection" / "include_to_batch_action.py",
+        SRC_ROOT / "commands" / "selection" / "discard_to_batch_action.py",
     }
-    include_path = SRC_ROOT / "commands" / "include.py"
+    command_paths = {
+        SRC_ROOT / "commands" / "discard.py",
+        SRC_ROOT / "commands" / "include.py",
+    }
     helper_path = SRC_ROOT / "commands" / "file_scope" / "target_path.py"
     helper = __import__(
         "git_stage_batch.commands.file_scope.target_path",
@@ -3798,7 +3878,7 @@ def test_file_scope_target_path_stays_in_file_scope_support():
     imports_by_path = {}
     imported_names = set()
 
-    for path in direct_target_path_paths | {include_path}:
+    for path in direct_target_path_paths | command_paths:
         imports_by_path[path] = set()
         for imported_module, node in _import_from_nodes(path):
             imports_by_path[path].add(imported_module)
@@ -3816,8 +3896,10 @@ def test_file_scope_target_path_stays_in_file_scope_support():
             "git_stage_batch.commands.file_scope.target_path" in imports_by_path[path]
         )
     assert (
-        "git_stage_batch.commands.file_scope.target_path"
-        not in imports_by_path[include_path]
+        all(
+            "git_stage_batch.commands.file_scope.target_path" not in imports_by_path[path]
+            for path in command_paths
+        )
     )
     for imports in imports_by_path.values():
         assert "git_stage_batch.data.selected_change.paths" not in imports
@@ -4135,6 +4217,7 @@ def test_file_scope_include_replacement_owns_file_pipeline():
 def test_selected_change_batch_discarding_owns_hunk_pipeline():
     """Selected change batch support should stay out of discard.py."""
     discard_path = SRC_ROOT / "commands" / "discard.py"
+    action_path = SRC_ROOT / "commands" / "selection" / "discard_to_batch_action.py"
     helper_path = (
         SRC_ROOT / "commands" / "selection" / "selected_change_batch_discarding.py"
     )
@@ -4172,6 +4255,10 @@ def test_selected_change_batch_discarding_owns_hunk_pipeline():
     for imported_module, node in _import_from_nodes(discard_path):
         if imported_module == "git_stage_batch.commands.selection":
             discard_imported_names |= {alias.name for alias in node.names}
+    action_imported_names = set()
+    for imported_module, node in _import_from_nodes(action_path):
+        if imported_module == "git_stage_batch.commands.selection":
+            action_imported_names |= {alias.name for alias in node.names}
 
     helper_imported_names = set()
     for _imported_module, node in _import_from_nodes(helper_path):
@@ -4180,7 +4267,9 @@ def test_selected_change_batch_discarding_owns_hunk_pipeline():
     assert public_names <= vars(helper).keys()
     assert internal_names <= vars(helper).keys()
     assert old_command_helper_names.isdisjoint(discard_names)
-    assert "selected_change_batch_discarding" in discard_imported_names
+    assert "discard_to_batch_action" in discard_imported_names
+    assert "selected_change_batch_discarding" not in discard_imported_names
+    assert "selected_change_batch_discarding" in action_imported_names
     assert helper_imports <= helper_imported_names
 
 
@@ -10456,7 +10545,10 @@ def test_selected_change_loading_stays_out_of_hunk_tracking():
         / "commands"
         / "selection"
         / "include_line_batching.py": {"require_selected_hunk"},
-        SRC_ROOT / "commands" / "discard.py": {"load_selected_change"},
+        SRC_ROOT
+        / "commands"
+        / "selection"
+        / "discard_to_batch_action.py": {"load_selected_change"},
         SRC_ROOT
         / "commands"
         / "selection"
@@ -11819,6 +11911,7 @@ def test_skip_line_selection_stays_in_command_helper():
 def test_discard_line_replacement_stays_in_command_helper():
     """Discard line-replacement support should stay out of the command entrypoint."""
     discard_path = SRC_ROOT / "commands" / "discard.py"
+    action_path = SRC_ROOT / "commands" / "selection" / "discard_to_batch_action.py"
     helper_path = (
         SRC_ROOT / "commands" / "selection" / "discard_line_replacement.py"
     )
@@ -11913,6 +12006,7 @@ def test_discard_line_replacement_stays_in_command_helper():
         if isinstance(node, ast.FunctionDef)
     }
     discard_imports_line_batching = False
+    action_imports_line_batching = False
     line_batching_imports_helper = False
 
     for imported_module, node in _import_from_nodes(discard_path):
@@ -11921,6 +12015,12 @@ def test_discard_line_replacement_stays_in_command_helper():
         imported_names = {alias.name for alias in node.names}
         if "discard_line_batching" in imported_names:
             discard_imports_line_batching = True
+    for imported_module, node in _import_from_nodes(action_path):
+        if imported_module != "git_stage_batch.commands.selection":
+            continue
+        imported_names = {alias.name for alias in node.names}
+        if "discard_line_batching" in imported_names:
+            action_imports_line_batching = True
 
     for imported_module, node in _import_from_nodes(line_batching_path):
         if imported_module != "git_stage_batch.commands.selection":
@@ -11940,7 +12040,8 @@ def test_discard_line_replacement_stays_in_command_helper():
 
     assert old_discard_names.isdisjoint(discard_helpers)
     assert moved_batch_update_names.isdisjoint(command_update_names)
-    assert discard_imports_line_batching
+    assert not discard_imports_line_batching
+    assert action_imports_line_batching
     assert line_batching_imports_helper
     assert helper_imports <= helper_imported_names
 

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -7939,6 +7939,7 @@ def test_batch_owns_binary_file_content_loading():
         fromlist=["binary_file_content"],
     )
     apply_from_path = SRC_ROOT / "commands" / "apply_from.py"
+    apply_action_path = SRC_ROOT / "commands" / "batch_source" / "apply_action.py"
     include_from_path = SRC_ROOT / "commands" / "include_from.py"
     public_names = {
         "read_binary_file_from_batch",
@@ -7946,10 +7947,13 @@ def test_batch_owns_binary_file_content_loading():
     old_names = {
         "_read_binary_file_from_batch",
     }
-    apply_from_tree = ast.parse(apply_from_path.read_text(), filename=str(apply_from_path))
-    apply_from_helpers = {
+    apply_action_tree = ast.parse(
+        apply_action_path.read_text(),
+        filename=str(apply_action_path),
+    )
+    apply_action_helpers = {
         node.name
-        for node in ast.walk(apply_from_tree)
+        for node in ast.walk(apply_action_tree)
         if isinstance(node, (ast.ClassDef, ast.FunctionDef))
     }
     include_from_tree = ast.parse(
@@ -7962,7 +7966,7 @@ def test_batch_owns_binary_file_content_loading():
         if isinstance(node, (ast.ClassDef, ast.FunctionDef))
     }
     loader_imports_by_path = {
-        apply_from_path: set(),
+        apply_action_path: set(),
         include_from_path: set(),
     }
 
@@ -7973,9 +7977,9 @@ def test_batch_owns_binary_file_content_loading():
             loader_imports_by_path[path] |= {alias.name for alias in node.names}
 
     assert public_names <= vars(binary_file_content).keys()
-    assert public_names <= loader_imports_by_path[apply_from_path]
+    assert public_names <= loader_imports_by_path[apply_action_path]
     assert public_names <= loader_imports_by_path[include_from_path]
-    assert old_names.isdisjoint(apply_from_helpers)
+    assert old_names.isdisjoint(apply_action_helpers)
     assert old_names.isdisjoint(include_from_helpers)
 
 
@@ -7986,6 +7990,7 @@ def test_batch_source_action_plans_own_resource_plans():
         fromlist=["action_plans"],
     )
     apply_from_path = SRC_ROOT / "commands" / "apply_from.py"
+    apply_action_path = SRC_ROOT / "commands" / "batch_source" / "apply_action.py"
     include_from_path = SRC_ROOT / "commands" / "include_from.py"
     public_names = {
         "ApplyTextFileActionPlan",
@@ -8007,10 +8012,13 @@ def test_batch_source_action_plans_own_resource_plans():
         "_IncludeSubmodulePlan",
         "_close_include_plans",
     }
-    apply_from_tree = ast.parse(apply_from_path.read_text(), filename=str(apply_from_path))
-    apply_from_helpers = {
+    apply_action_tree = ast.parse(
+        apply_action_path.read_text(),
+        filename=str(apply_action_path),
+    )
+    apply_action_helpers = {
         node.name
-        for node in ast.walk(apply_from_tree)
+        for node in ast.walk(apply_action_tree)
         if isinstance(node, (ast.ClassDef, ast.FunctionDef))
     }
     include_from_tree = ast.parse(
@@ -8023,7 +8031,7 @@ def test_batch_source_action_plans_own_resource_plans():
         if isinstance(node, (ast.ClassDef, ast.FunctionDef))
     }
     imports_action_plans = {
-        apply_from_path: False,
+        apply_action_path: False,
         include_from_path: False,
     }
 
@@ -8037,9 +8045,9 @@ def test_batch_source_action_plans_own_resource_plans():
                 imports_action_plans[path] = True
 
     assert public_names <= vars(action_plans).keys()
-    assert imports_action_plans[apply_from_path]
+    assert imports_action_plans[apply_action_path]
     assert imports_action_plans[include_from_path]
-    assert old_apply_names.isdisjoint(apply_from_helpers)
+    assert old_apply_names.isdisjoint(apply_action_helpers)
     assert old_include_names.isdisjoint(include_from_helpers)
 
 
@@ -8049,7 +8057,7 @@ def test_batch_source_text_plan_builders_own_apply_text_planning():
         "git_stage_batch.commands.batch_source.text_plan_builders",
         fromlist=["text_plan_builders"],
     )
-    apply_from_path = SRC_ROOT / "commands" / "apply_from.py"
+    apply_action_path = SRC_ROOT / "commands" / "batch_source" / "apply_action.py"
     public_names = {
         "ApplyTextPlanBuildResult",
         "build_apply_text_file_action_plan",
@@ -8081,7 +8089,7 @@ def test_batch_source_text_plan_builders_own_apply_text_planning():
     imports_text_plan_builders = False
     direct_plan_imports = set()
 
-    for imported_module, node in _import_from_nodes(apply_from_path):
+    for imported_module, node in _import_from_nodes(apply_action_path):
         imported_names = {alias.name for alias in node.names}
         if (
             imported_module == "git_stage_batch.commands.batch_source"
@@ -8093,14 +8101,14 @@ def test_batch_source_text_plan_builders_own_apply_text_planning():
             set(),
         )
 
-    command_text = apply_from_path.read_text()
+    action_text = apply_action_path.read_text()
 
     assert public_names <= vars(text_plan_builders).keys()
     assert imports_text_plan_builders
     assert direct_plan_imports == set()
-    assert "build_apply_text_file_action_plan(" in command_text
-    assert "merge_batch_from_line_sequences_as_buffer(" not in command_text
-    assert "selected_text_target_change_type(" not in command_text
+    assert "build_apply_text_file_action_plan(" in action_text
+    assert "merge_batch_from_line_sequences_as_buffer(" not in action_text
+    assert "selected_text_target_change_type(" not in action_text
 
 
 def test_batch_source_text_plan_builders_own_include_text_planning():
@@ -8416,13 +8424,14 @@ def test_batch_source_candidate_preview_counts_own_failure_enumeration():
         fromlist=["candidate_preview_counts"],
     )
     apply_from_path = SRC_ROOT / "commands" / "apply_from.py"
+    apply_action_path = SRC_ROOT / "commands" / "batch_source" / "apply_action.py"
     include_from_path = SRC_ROOT / "commands" / "include_from.py"
     public_names = {
         "count_apply_candidate_previews_for_file",
         "count_include_candidate_previews_for_file",
     }
     old_function_names = {
-        apply_from_path: {
+        apply_action_path: {
             "_apply_candidate_count_for_file",
         },
         include_from_path: {
@@ -8463,11 +8472,11 @@ def test_batch_source_candidate_preview_counts_own_failure_enumeration():
 
     assert public_names <= vars(candidate_preview_counts).keys()
     assert imports_candidate_preview_counts == {
-        apply_from_path: True,
+        apply_action_path: True,
         include_from_path: True,
     }
     assert direct_count_imports == {
-        apply_from_path: set(),
+        apply_action_path: set(),
         include_from_path: set(),
     }
     for path, old_names in old_function_names.items():
@@ -8851,12 +8860,13 @@ def test_batch_source_candidate_refusals_own_candidate_count_refusals():
         fromlist=["candidate_refusals"],
     )
     apply_from_path = SRC_ROOT / "commands" / "apply_from.py"
+    apply_action_path = SRC_ROOT / "commands" / "batch_source" / "apply_action.py"
     include_from_path = SRC_ROOT / "commands" / "include_from.py"
     public_names = {
         "refuse_candidate_conflicts",
     }
     old_snippets_by_path = {
-        apply_from_path: {
+        apply_action_path: {
             "too many apply candidates",
             "Cannot enumerate apply candidates",
             "multiple files need apply decisions",
@@ -8884,7 +8894,7 @@ def test_batch_source_candidate_refusals_own_candidate_count_refusals():
 
     assert public_names <= vars(candidate_refusals).keys()
     assert imports_candidate_refusals == {
-        apply_from_path: True,
+        apply_action_path: True,
         include_from_path: True,
     }
     for path, old_snippets in old_snippets_by_path.items():
@@ -8900,6 +8910,7 @@ def test_batch_source_action_context_owns_action_prologue():
         fromlist=["action_context"],
     )
     apply_from_path = SRC_ROOT / "commands" / "apply_from.py"
+    apply_action_path = SRC_ROOT / "commands" / "batch_source" / "apply_action.py"
     include_from_path = SRC_ROOT / "commands" / "include_from.py"
     discard_from_path = SRC_ROOT / "commands" / "discard_from.py"
     public_names = {
@@ -8986,6 +8997,7 @@ def test_batch_source_action_selection_owns_file_line_selection():
         fromlist=["action_selection"],
     )
     apply_from_path = SRC_ROOT / "commands" / "apply_from.py"
+    apply_action_path = SRC_ROOT / "commands" / "batch_source" / "apply_action.py"
     include_from_path = SRC_ROOT / "commands" / "include_from.py"
     discard_from_path = SRC_ROOT / "commands" / "discard_from.py"
     public_names = {
@@ -9057,12 +9069,13 @@ def test_batch_source_action_completion_owns_review_finalization():
         fromlist=["action_completion"],
     )
     apply_from_path = SRC_ROOT / "commands" / "apply_from.py"
+    apply_action_path = SRC_ROOT / "commands" / "batch_source" / "apply_action.py"
     include_from_path = SRC_ROOT / "commands" / "include_from.py"
     public_names = {
         "finish_batch_source_action_review",
     }
     command_paths = {
-        apply_from_path,
+        apply_action_path,
         include_from_path,
     }
     imports_action_completion = {
@@ -9089,11 +9102,11 @@ def test_batch_source_action_completion_owns_review_finalization():
 
     assert public_names <= vars(action_completion).keys()
     assert imports_action_completion == {
-        apply_from_path: True,
+        apply_action_path: True,
         include_from_path: True,
     }
     assert direct_review_imports == {
-        apply_from_path: set(),
+        apply_action_path: set(),
         include_from_path: set(),
     }
 
@@ -9138,6 +9151,63 @@ def test_batch_source_apply_action_owns_apply_execution():
     assert "write_text_file_to_worktree(" in action_text
     assert "write_binary_file_to_worktree(" in action_text
     assert "finish_batch_source_action_review(" in action_text
+
+
+def test_apply_from_delegates_apply_action_execution():
+    """Apply-from should delegate selected file execution to batch-source support."""
+    apply_from_path = SRC_ROOT / "commands" / "apply_from.py"
+    disallowed_imports = {
+        "git_stage_batch.commands.batch_source": {
+            "action_completion",
+            "action_plans",
+            "binary_file_actions",
+            "candidate_preview_counts",
+            "candidate_refusals",
+            "merge_refusals",
+            "text_file_actions",
+            "text_plan_builders",
+            "worktree_refusals",
+        },
+        "git_stage_batch.batch.binary_file_content": {
+            "read_binary_file_from_batch",
+        },
+        "git_stage_batch.batch.selection": {
+            "translate_atomic_unit_error_to_gutter_ids",
+        },
+        "git_stage_batch.batch.submodule_pointer": {
+            "apply_submodule_pointer_from_batch",
+            "is_batch_submodule_pointer",
+        },
+        "git_stage_batch.data.session": {
+            "snapshot_file_if_untracked",
+        },
+        "git_stage_batch.data.undo": {
+            "undo_checkpoint",
+        },
+    }
+    imports_apply_action = False
+    direct_execution_imports = set()
+
+    for imported_module, node in _import_from_nodes(apply_from_path):
+        imported_names = {alias.name for alias in node.names}
+        if (
+            imported_module == "git_stage_batch.commands.batch_source"
+            and "apply_action" in imported_names
+        ):
+            imports_apply_action = True
+        direct_execution_imports |= imported_names & disallowed_imports.get(
+            imported_module,
+            set(),
+        )
+
+    command_text = apply_from_path.read_text()
+
+    assert imports_apply_action
+    assert direct_execution_imports == set()
+    assert "execute_apply_action(" in command_text
+    assert "build_apply_text_file_action_plan(" not in command_text
+    assert "write_binary_file_to_worktree(" not in command_text
+    assert "write_text_file_to_worktree(" not in command_text
 
 
 def test_batch_source_discard_action_owns_discard_execution():
@@ -9532,12 +9602,13 @@ def test_batch_source_merge_refusals_own_merge_failure_refusals():
         fromlist=["merge_refusals"],
     )
     apply_from_path = SRC_ROOT / "commands" / "apply_from.py"
+    apply_action_path = SRC_ROOT / "commands" / "batch_source" / "apply_action.py"
     include_from_path = SRC_ROOT / "commands" / "include_from.py"
     public_names = {
         "refuse_batch_source_merge_failures",
     }
     old_snippets_by_path = {
-        apply_from_path: {
+        apply_action_path: {
             "gutter_to_selection_id",
             "Failed for: {files}",
         },
@@ -9571,11 +9642,11 @@ def test_batch_source_merge_refusals_own_merge_failure_refusals():
 
     assert public_names <= vars(merge_refusals).keys()
     assert imports_merge_refusals == {
-        apply_from_path: True,
+        apply_action_path: True,
         include_from_path: True,
     }
     assert direct_display_imports == {
-        apply_from_path: set(),
+        apply_action_path: set(),
         include_from_path: set(),
     }
     for path, old_snippets in old_snippets_by_path.items():
@@ -9591,12 +9662,13 @@ def test_batch_source_worktree_refusals_own_execution_refusals():
         fromlist=["worktree_refusals"],
     )
     apply_from_path = SRC_ROOT / "commands" / "apply_from.py"
+    apply_action_path = SRC_ROOT / "commands" / "batch_source" / "apply_action.py"
     include_from_path = SRC_ROOT / "commands" / "include_from.py"
     public_names = {
         "refuse_incompatible_worktree_action",
     }
     old_snippets_by_path = {
-        apply_from_path: {
+        apply_action_path: {
             "contains changes to {file} that are incompatible",
             "one or more files that are incompatible",
         },
@@ -9622,7 +9694,7 @@ def test_batch_source_worktree_refusals_own_execution_refusals():
 
     assert public_names <= vars(worktree_refusals).keys()
     assert imports_worktree_refusals == {
-        apply_from_path: True,
+        apply_action_path: True,
         include_from_path: True,
     }
     for path, old_snippets in old_snippets_by_path.items():
@@ -9638,6 +9710,7 @@ def test_batch_source_text_actions_own_text_file_mutations():
         fromlist=["text_file_actions"],
     )
     apply_from_path = SRC_ROOT / "commands" / "apply_from.py"
+    apply_action_path = SRC_ROOT / "commands" / "batch_source" / "apply_action.py"
     include_from_path = SRC_ROOT / "commands" / "include_from.py"
     discard_from_path = SRC_ROOT / "commands" / "discard_from.py"
     discard_action_path = (
@@ -9654,7 +9727,7 @@ def test_batch_source_text_actions_own_text_file_mutations():
         "_write_text_file_from_batch",
     }
     helper_paths = {
-        apply_from_path,
+        apply_action_path,
         discard_action_path,
         include_from_path,
     }
@@ -9682,7 +9755,7 @@ def test_batch_source_text_actions_own_text_file_mutations():
 
     assert public_names <= vars(text_file_actions).keys()
     assert imports_text_file_actions == {
-        apply_from_path: True,
+        apply_action_path: True,
         discard_action_path: True,
         include_from_path: True,
     }
@@ -9734,6 +9807,7 @@ def test_batch_source_binary_actions_own_worktree_mutation():
         fromlist=["binary_file_actions"],
     )
     apply_from_path = SRC_ROOT / "commands" / "apply_from.py"
+    apply_action_path = SRC_ROOT / "commands" / "batch_source" / "apply_action.py"
     discard_from_path = SRC_ROOT / "commands" / "discard_from.py"
     include_from_path = SRC_ROOT / "commands" / "include_from.py"
     discard_action_path = (
@@ -9749,7 +9823,7 @@ def test_batch_source_binary_actions_own_worktree_mutation():
         "_write_binary_file_from_batch",
     }
     helper_paths = {
-        apply_from_path,
+        apply_action_path,
         discard_action_path,
         include_from_path,
     }
@@ -9777,7 +9851,7 @@ def test_batch_source_binary_actions_own_worktree_mutation():
 
     assert public_names <= vars(binary_file_actions).keys()
     assert imports_binary_file_actions == {
-        apply_from_path: True,
+        apply_action_path: True,
         discard_action_path: True,
         include_from_path: True,
     }

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -8568,7 +8568,6 @@ def test_batch_source_candidate_materialization_owns_reviewed_candidate_loading(
     }
     materialization_consumer_paths = {
         candidate_execution_path,
-        include_from_path,
     }
     preview_free_paths = command_paths | {
         candidate_execution_path,
@@ -8618,7 +8617,6 @@ def test_batch_source_candidate_materialization_owns_reviewed_candidate_loading(
     assert public_names <= vars(candidate_materialization).keys()
     assert imports_candidate_materialization == {
         candidate_execution_path: True,
-        include_from_path: True,
     }
     assert imports_candidate_previews == {
         apply_from_path: False,
@@ -8735,6 +8733,46 @@ def test_batch_source_candidate_execution_owns_apply_from_flow():
     assert "candidate_execution" in command_imported_names
     assert "execute_apply_candidate" in command_attrs
     assert "_execute_apply_candidate" not in command_functions
+    assert "candidate_materialization" not in command_imported_names
+    assert "clear_candidate_preview_state_for_file" not in command_imported_names
+    assert "candidate_materialization" in helper_imported_names
+    assert "clear_candidate_preview_state_for_file" in helper_imported_names
+
+
+def test_batch_source_candidate_execution_owns_include_from_flow():
+    """Include-from should delegate reviewed candidate execution."""
+    include_from_path = SRC_ROOT / "commands" / "include_from.py"
+    helper_path = (
+        SRC_ROOT / "commands" / "batch_source" / "candidate_execution.py"
+    )
+    command_tree = ast.parse(
+        include_from_path.read_text(),
+        filename=str(include_from_path),
+    )
+    command_functions = {
+        node.name: node
+        for node in ast.walk(command_tree)
+        if isinstance(node, ast.FunctionDef)
+    }
+    command_attrs = {
+        node.attr
+        for node in ast.walk(command_functions["command_include_from_batch"])
+        if isinstance(node, ast.Attribute)
+    }
+    command_imports = set()
+    command_imported_names = set()
+    for imported_module, node in _import_from_nodes(include_from_path):
+        command_imports.add(imported_module)
+        command_imported_names |= {alias.name for alias in node.names}
+
+    helper_imported_names = set()
+    for _imported_module, node in _import_from_nodes(helper_path):
+        helper_imported_names |= {alias.name for alias in node.names}
+
+    assert "git_stage_batch.commands.batch_source" in command_imports
+    assert "candidate_execution" in command_imported_names
+    assert "execute_include_candidate" in command_attrs
+    assert "_execute_include_candidate" not in command_functions
     assert "candidate_materialization" not in command_imported_names
     assert "clear_candidate_preview_state_for_file" not in command_imported_names
     assert "candidate_materialization" in helper_imported_names

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -189,11 +189,14 @@ def test_line_id_file_persistence_stays_in_data_layer():
         "write_line_ids_file",
     }
     expected_imports = {
-        SRC_ROOT / "commands" / "include.py": {"write_line_ids_file"},
         SRC_ROOT
         / "commands"
         / "selection"
         / "include_line_action.py": file_helper_names,
+        SRC_ROOT
+        / "commands"
+        / "selection"
+        / "include_line_replacement_action.py": {"write_line_ids_file"},
         SRC_ROOT / "commands" / "file_scope" / "include_file_replacement.py": {
             "write_line_ids_file",
         },
@@ -9927,6 +9930,9 @@ def test_include_line_action_stays_in_command_helper():
 def test_include_line_replacement_stays_in_command_helper():
     """Include line-replacement support should stay out of the command entrypoint."""
     include_path = SRC_ROOT / "commands" / "include.py"
+    action_path = (
+        SRC_ROOT / "commands" / "selection" / "include_line_replacement_action.py"
+    )
     helper_path = (
         SRC_ROOT / "commands" / "selection" / "include_line_replacement.py"
     )
@@ -9999,19 +10005,25 @@ def test_include_line_replacement_stays_in_command_helper():
         for node in ast.walk(include_tree)
         if isinstance(node, ast.FunctionDef)
     }
-    include_imports_helper = False
+    action_imports_helper = False
 
-    for imported_module, node in _import_from_nodes(include_path):
+    for imported_module, node in _import_from_nodes(action_path):
         if imported_module != "git_stage_batch.commands.selection":
             continue
         imported_names = {alias.name for alias in node.names}
         if "include_line_replacement" in imported_names:
-            include_imports_helper = True
+            action_imports_helper = True
 
     helper_imported_names = set()
     for _imported_module, node in _import_from_nodes(helper_path):
         helper_imported_names |= {alias.name for alias in node.names}
 
+    action_tree = ast.parse(action_path.read_text(), filename=str(action_path))
+    action_functions = {
+        node.name: node
+        for node in ast.walk(action_tree)
+        if isinstance(node, ast.FunctionDef)
+    }
     command_line_as_names = {
         node.id
         for node in ast.walk(include_functions["command_include_line_as"])
@@ -10022,11 +10034,16 @@ def test_include_line_replacement_stays_in_command_helper():
         for node in ast.walk(include_functions["command_include_line_as"])
         if isinstance(node, ast.Attribute)
     }
+    action_line_as_attributes = {
+        node.attr
+        for node in ast.walk(action_functions["include_live_line_replacement"])
+        if isinstance(node, ast.Attribute)
+    }
 
     assert old_include_names.isdisjoint(include_names)
-    assert include_imports_helper
-    assert "prepare_file_include_line_replacement" in command_line_as_attributes
-    assert "prepare_pathless_include_line_replacement" in command_line_as_attributes
+    assert action_imports_helper
+    assert "prepare_file_include_line_replacement" in action_line_as_attributes
+    assert "prepare_pathless_include_line_replacement" in action_line_as_attributes
     assert replacement_context_names.isdisjoint(command_line_as_names)
     assert replacement_context_names.isdisjoint(command_line_as_attributes)
     assert helper_imports <= helper_imported_names
@@ -11066,14 +11083,19 @@ def test_advance_display_stays_in_command_helper():
 
 def test_line_action_refresh_header_stays_in_command_helper():
     """Include and discard line actions should use the command refresh helper."""
-    command_paths = (
-        SRC_ROOT / "commands" / "include.py",
+    action_paths = (
+        SRC_ROOT / "commands" / "selection" / "include_line_action.py",
+        SRC_ROOT
+        / "commands"
+        / "selection"
+        / "include_line_replacement_action.py",
+        SRC_ROOT / "commands" / "selection" / "discard_line_action.py",
         SRC_ROOT / "commands" / "discard.py",
     )
     violations = []
 
-    for command_path in command_paths:
-        imports = _import_from_nodes(command_path)
+    for action_path in action_paths:
+        imports = _import_from_nodes(action_path)
         imports_refresh_helper = False
         for imported_module, node in imports:
             imported_names = {alias.name for alias in node.names}
@@ -11086,7 +11108,7 @@ def test_line_action_refresh_header_stays_in_command_helper():
             if imported_module != "git_stage_batch.output":
                 continue
             if "print_remaining_line_changes_header" in imported_names:
-                relative_path = command_path.relative_to(REPO_ROOT)
+                relative_path = action_path.relative_to(REPO_ROOT)
                 violations.append(
                     f"{relative_path}:{node.lineno} imports "
                     "print_remaining_line_changes_header"

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -10286,6 +10286,9 @@ def test_selected_change_skipping_owns_skip_pipeline():
 def test_discard_file_selection_stays_in_command_helper():
     """Discard file selection should stay out of the command entrypoint."""
     discard_path = SRC_ROOT / "commands" / "discard.py"
+    action_path = (
+        SRC_ROOT / "commands" / "selection" / "discard_line_replacement_action.py"
+    )
     helper_path = (
         SRC_ROOT / "commands" / "selection" / "discard_file_selection.py"
     )
@@ -10309,21 +10312,21 @@ def test_discard_file_selection_stays_in_command_helper():
     discard_helpers = {
         node.name for node in ast.walk(discard_tree) if isinstance(node, ast.FunctionDef)
     }
-    discard_imports_helper = False
+    action_imports_helper = False
 
-    for imported_module, node in _import_from_nodes(discard_path):
+    for imported_module, node in _import_from_nodes(action_path):
         if imported_module != "git_stage_batch.commands.selection":
             continue
         imported_names = {alias.name for alias in node.names}
         if "discard_file_selection" in imported_names:
-            discard_imports_helper = True
+            action_imports_helper = True
 
     helper_imported_names = set()
     for _imported_module, node in _import_from_nodes(helper_path):
         helper_imported_names |= {alias.name for alias in node.names}
 
     assert old_discard_names.isdisjoint(discard_helpers)
-    assert discard_imports_helper
+    assert action_imports_helper
     assert helper_imports <= helper_imported_names
 
 

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -9098,6 +9098,48 @@ def test_batch_source_action_completion_owns_review_finalization():
     }
 
 
+def test_batch_source_apply_action_owns_apply_execution():
+    """Apply-from file execution should live in batch-source support."""
+    apply_action = __import__(
+        "git_stage_batch.commands.batch_source.apply_action",
+        fromlist=["apply_action"],
+    )
+    action_path = SRC_ROOT / "commands" / "batch_source" / "apply_action.py"
+    public_names = {
+        "execute_apply_action",
+    }
+    required_imports = {
+        ("git_stage_batch.commands.batch_source", "action_completion"),
+        ("git_stage_batch.commands.batch_source", "action_plans"),
+        ("git_stage_batch.commands.batch_source", "binary_file_actions"),
+        ("git_stage_batch.commands.batch_source", "candidate_preview_counts"),
+        ("git_stage_batch.commands.batch_source", "candidate_refusals"),
+        ("git_stage_batch.commands.batch_source", "merge_refusals"),
+        ("git_stage_batch.commands.batch_source", "text_file_actions"),
+        ("git_stage_batch.commands.batch_source", "text_plan_builders"),
+        ("git_stage_batch.commands.batch_source", "worktree_refusals"),
+        ("git_stage_batch.batch.binary_file_content", "read_binary_file_from_batch"),
+        ("git_stage_batch.batch.selection", "translate_atomic_unit_error_to_gutter_ids"),
+        ("git_stage_batch.batch.submodule_pointer", "apply_submodule_pointer_from_batch"),
+        ("git_stage_batch.data.session", "snapshot_file_if_untracked"),
+        ("git_stage_batch.data.undo", "undo_checkpoint"),
+    }
+    action_imports = set()
+
+    for imported_module, node in _import_from_nodes(action_path):
+        for alias in node.names:
+            action_imports.add((imported_module, alias.name))
+
+    action_text = action_path.read_text()
+
+    assert public_names <= vars(apply_action).keys()
+    assert required_imports <= action_imports
+    assert "build_apply_text_file_action_plan(" in action_text
+    assert "write_text_file_to_worktree(" in action_text
+    assert "write_binary_file_to_worktree(" in action_text
+    assert "finish_batch_source_action_review(" in action_text
+
+
 def test_batch_source_discard_action_owns_discard_execution():
     """Discard-from file execution should live in batch-source support."""
     discard_action = __import__(

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -7488,7 +7488,9 @@ def test_batch_owns_atomic_file_change_metadata_conversion():
         "git_stage_batch.batch.atomic_file_changes",
         fromlist=["atomic_file_changes"],
     )
-    show_from_path = SRC_ROOT / "commands" / "show_from.py"
+    action_path = (
+        SRC_ROOT / "commands" / "batch_source" / "file_display_action.py"
+    )
     public_names = {
         "binary_change_from_batch_file_metadata",
         "gitlink_change_from_batch_file_metadata",
@@ -7501,27 +7503,27 @@ def test_batch_owns_atomic_file_change_metadata_conversion():
         "BinaryFileChange",
         "GitlinkChange",
     }
-    show_from_tree = ast.parse(show_from_path.read_text(), filename=str(show_from_path))
-    show_from_helpers = {
+    action_tree = ast.parse(action_path.read_text(), filename=str(action_path))
+    action_helpers = {
         node.name
-        for node in ast.walk(show_from_tree)
+        for node in ast.walk(action_tree)
         if isinstance(node, (ast.ClassDef, ast.FunctionDef))
     }
-    show_from_atomic_imports = set()
-    show_from_model_imports = set()
+    action_atomic_imports = set()
+    action_model_imports = set()
 
-    for imported_module, node in _import_from_nodes(show_from_path):
+    for imported_module, node in _import_from_nodes(action_path):
         imported_names = {alias.name for alias in node.names}
         if imported_module == "git_stage_batch.batch.atomic_file_changes":
-            show_from_atomic_imports |= imported_names
+            action_atomic_imports |= imported_names
         if imported_module == "git_stage_batch.core.models":
-            show_from_model_imports |= imported_names & model_names
+            action_model_imports |= imported_names & model_names
 
     assert public_names <= vars(atomic_file_changes).keys()
     assert model_names <= vars(atomic_file_changes).keys()
-    assert public_names <= show_from_atomic_imports
-    assert old_names.isdisjoint(show_from_helpers)
-    assert show_from_model_imports == set()
+    assert public_names <= action_atomic_imports
+    assert old_names.isdisjoint(action_helpers)
+    assert action_model_imports == set()
 
 
 def test_batch_owns_binary_file_content_loading():

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -1781,7 +1781,7 @@ def test_file_review_callers_use_model_builder():
     review_output_text = review_output_path.read_text()
     caller_paths = (
         SRC_ROOT / "commands" / "show.py",
-        SRC_ROOT / "commands" / "show_from.py",
+        SRC_ROOT / "commands" / "batch_source" / "file_display_action.py",
         SRC_ROOT / "output" / "file_review_list.py",
     )
     file_review_model_builder = __import__(
@@ -1809,12 +1809,16 @@ def test_file_review_callers_use_model_builder():
     assert "def build_file_review_model" not in review_output_text
     assert direct_model_builder_imports == {
         "src/git_stage_batch/commands/show.py": public_names,
-        "src/git_stage_batch/commands/show_from.py": public_names,
+        "src/git_stage_batch/commands/batch_source/file_display_action.py": (
+            public_names
+        ),
         "src/git_stage_batch/output/file_review_list.py": public_names,
     }
     assert old_renderer_imports == {
         "src/git_stage_batch/commands/show.py": set(),
-        "src/git_stage_batch/commands/show_from.py": set(),
+        "src/git_stage_batch/commands/batch_source/file_display_action.py": (
+            set()
+        ),
         "src/git_stage_batch/output/file_review_list.py": set(),
     }
 
@@ -1854,13 +1858,13 @@ def test_file_review_output_uses_action_selection_module():
     assert "def _selection_ids_for_display_ids" not in review_output_text
 
 
-def test_show_commands_use_file_review_state_builder():
-    """Show commands should not import review state assembly from rendering."""
+def test_show_file_display_uses_file_review_state_builder():
+    """Show file display should not import review state assembly from rendering."""
     review_output_path = SRC_ROOT / "output" / "file_review.py"
     review_output_text = review_output_path.read_text()
     show_paths = (
         SRC_ROOT / "commands" / "show.py",
-        SRC_ROOT / "commands" / "show_from.py",
+        SRC_ROOT / "commands" / "batch_source" / "file_display_action.py",
     )
     file_review_state_builder = __import__(
         "git_stage_batch.output.file_review_state_builder",
@@ -1892,11 +1896,15 @@ def test_show_commands_use_file_review_state_builder():
     assert "def resolve_default_review_pages" not in review_output_text
     assert direct_state_builder_imports == {
         "src/git_stage_batch/commands/show.py": public_names,
-        "src/git_stage_batch/commands/show_from.py": public_names,
+        "src/git_stage_batch/commands/batch_source/file_display_action.py": (
+            public_names
+        ),
     }
     assert old_renderer_imports == {
         "src/git_stage_batch/commands/show.py": set(),
-        "src/git_stage_batch/commands/show_from.py": set(),
+        "src/git_stage_batch/commands/batch_source/file_display_action.py": (
+            set()
+        ),
     }
 
 

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -2645,6 +2645,10 @@ def test_argument_parser_delegates_multi_file_action_flow():
         imported_module
         for imported_module, _node in _import_from_nodes(helper_path)
     }
+    helper_file_scope_imported_names = set()
+    for imported_module, node in _import_from_nodes(helper_path):
+        if imported_module == "git_stage_batch.commands.file_scope":
+            helper_file_scope_imported_names |= {alias.name for alias in node.names}
 
     assert "git_stage_batch.data.hunk_tracking" not in parser_imports
     assert "git_stage_batch.data.undo" not in parser_imports
@@ -2658,6 +2662,9 @@ def test_argument_parser_delegates_multi_file_action_flow():
     )
     assert "git_stage_batch.data.hunk_tracking" in helper_imports
     assert "git_stage_batch.data.undo" in helper_imports
+    assert "git_stage_batch.commands.include" not in helper_imports
+    assert "git_stage_batch.commands.skip" not in helper_imports
+    assert {"include_file", "skip_file"} <= helper_file_scope_imported_names
     assert not hasattr(
         __import__(
             "git_stage_batch.cli.argument_parser",

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -7926,6 +7926,79 @@ def test_batch_source_candidate_preview_builders_own_show_candidate_construction
     assert direct_operation_builder_imports == set()
 
 
+def test_batch_source_candidate_preview_action_owns_show_flow():
+    """Show-from candidate preview flow should live in batch-source support."""
+    helper = __import__(
+        "git_stage_batch.commands.batch_source.candidate_preview_action",
+        fromlist=["candidate_preview_action"],
+    )
+    show_from_path = SRC_ROOT / "commands" / "show_from.py"
+    helper_path = (
+        SRC_ROOT / "commands" / "batch_source" / "candidate_preview_action.py"
+    )
+    public_names = {
+        "show_batch_source_candidate_preview",
+    }
+    action_dependency_names = {
+        "build_batch_source_candidate_previews",
+        "candidate_preview_builders",
+        "candidate_previews",
+        "close_candidate_previews",
+        "render_operation_candidate",
+        "render_operation_candidate_overview",
+        "require_candidate_preview_for_ordinal",
+        "save_candidate_preview_state",
+    }
+    helper_imports = {
+        "MergeError",
+        "ReplacementPayload",
+        "candidate_preview_builders",
+        "candidate_previews",
+        "exit_with_error",
+        "render_operation_candidate",
+        "render_operation_candidate_overview",
+        "save_candidate_preview_state",
+        "translate_batch_file_gutter_ids_to_selection_ids",
+    }
+
+    assert public_names <= vars(helper).keys()
+
+    show_from_tree = ast.parse(
+        show_from_path.read_text(),
+        filename=str(show_from_path),
+    )
+    show_from_functions = {
+        node.name: node
+        for node in ast.walk(show_from_tree)
+        if isinstance(node, ast.FunctionDef)
+    }
+    command_names = {
+        node.id
+        for node in ast.walk(show_from_functions["command_show_from_batch"])
+        if isinstance(node, ast.Name)
+    }
+    command_attrs = {
+        node.attr
+        for node in ast.walk(show_from_functions["command_show_from_batch"])
+        if isinstance(node, ast.Attribute)
+    }
+    batch_source_imports = set()
+    for imported_module, node in _import_from_nodes(show_from_path):
+        if imported_module != "git_stage_batch.commands.batch_source":
+            continue
+        batch_source_imports |= {alias.name for alias in node.names}
+
+    helper_imported_names = set()
+    for _imported_module, node in _import_from_nodes(helper_path):
+        helper_imported_names |= {alias.name for alias in node.names}
+
+    assert "candidate_preview_action" in batch_source_imports
+    assert "show_batch_source_candidate_preview" in command_attrs
+    assert action_dependency_names.isdisjoint(command_names)
+    assert action_dependency_names.isdisjoint(command_attrs)
+    assert helper_imports <= helper_imported_names
+
+
 def test_batch_source_candidate_preview_counts_own_failure_enumeration():
     """Apply/include candidate count enumeration should live in batch-source support."""
     candidate_preview_counts = __import__(

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -9029,7 +9029,7 @@ def test_batch_merge_does_not_reexport_merge_exceptions():
         "MergeError",
         "MissingAnchorError",
     }
-    show_from_exception_imports = set()
+    candidate_preview_action_exception_imports = set()
     violations = []
 
     assert exception_names.isdisjoint(vars(merge))
@@ -9038,8 +9038,16 @@ def test_batch_merge_does_not_reexport_merge_exceptions():
         for imported_module, node in _import_from_nodes(path):
             imported_names = {alias.name for alias in node.names}
             if imported_module == "git_stage_batch.exceptions":
-                if path == SRC_ROOT / "commands" / "show_from.py":
-                    show_from_exception_imports |= imported_names & exception_names
+                if (
+                    path
+                    == SRC_ROOT
+                    / "commands"
+                    / "batch_source"
+                    / "candidate_preview_action.py"
+                ):
+                    candidate_preview_action_exception_imports |= (
+                        imported_names & exception_names
+                    )
                 continue
 
             if imported_module != "git_stage_batch.batch.merge":
@@ -9051,7 +9059,7 @@ def test_batch_merge_does_not_reexport_merge_exceptions():
                 names = ", ".join(sorted(moved_names))
                 violations.append(f"{relative_path}:{node.lineno} imports {names}")
 
-    assert "MergeError" in show_from_exception_imports
+    assert "MergeError" in candidate_preview_action_exception_imports
     assert violations == []
 
 

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -10049,6 +10049,80 @@ def test_include_line_replacement_stays_in_command_helper():
     assert helper_imports <= helper_imported_names
 
 
+def test_include_line_replacement_action_stays_in_command_helper():
+    """Include line-replacement action support should stay out of the entrypoint."""
+    include_path = SRC_ROOT / "commands" / "include.py"
+    helper_path = (
+        SRC_ROOT / "commands" / "selection" / "include_line_replacement_action.py"
+    )
+    helper = __import__(
+        "git_stage_batch.commands.selection.include_line_replacement_action",
+        fromlist=["include_line_replacement_action"],
+    )
+    public_names = {"include_live_line_replacement"}
+    action_dependency_names = {
+        "ExitStack",
+        "apply_include_line_replacement",
+        "coerce_replacement_payload",
+        "finish_review_scoped_line_action",
+        "get_processed_include_ids_file_path",
+        "prepare_file_include_line_replacement",
+        "prepare_pathless_include_line_replacement",
+        "print",
+        "refresh_selected_hunk_after_line_action",
+        "restore_selected_change_state",
+        "sys",
+        "undo_checkpoint",
+        "write_line_ids_file",
+    }
+    helper_imports = {
+        "ExitStack",
+        "ReplacementPayload",
+        "coerce_replacement_payload",
+        "finish_review_scoped_line_action",
+        "get_processed_include_ids_file_path",
+        "include_line_replacement",
+        "refresh_selected_hunk_after_line_action",
+        "restore_selected_change_state",
+        "undo_checkpoint",
+        "write_line_ids_file",
+    }
+
+    assert public_names <= vars(helper).keys()
+
+    include_tree = ast.parse(include_path.read_text(), filename=str(include_path))
+    include_functions = {
+        node.name: node
+        for node in ast.walk(include_tree)
+        if isinstance(node, ast.FunctionDef)
+    }
+    command_line_as_names = {
+        node.id
+        for node in ast.walk(include_functions["command_include_line_as"])
+        if isinstance(node, ast.Name)
+    }
+    command_line_as_attributes = {
+        node.attr
+        for node in ast.walk(include_functions["command_include_line_as"])
+        if isinstance(node, ast.Attribute)
+    }
+    include_selection_imports = set()
+    for imported_module, node in _import_from_nodes(include_path):
+        if imported_module != "git_stage_batch.commands.selection":
+            continue
+        include_selection_imports |= {alias.name for alias in node.names}
+
+    helper_imported_names = set()
+    for _imported_module, node in _import_from_nodes(helper_path):
+        helper_imported_names |= {alias.name for alias in node.names}
+
+    assert "include_line_replacement_action" in include_selection_imports
+    assert "include_live_line_replacement" in command_line_as_attributes
+    assert action_dependency_names.isdisjoint(command_line_as_names)
+    assert action_dependency_names.isdisjoint(command_line_as_attributes)
+    assert helper_imports <= helper_imported_names
+
+
 def test_selected_change_discarding_owns_discard_pipeline():
     """Selected change discard support should stay out of discard.py."""
     discard_path = SRC_ROOT / "commands" / "discard.py"

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -3441,6 +3441,56 @@ def test_file_scope_file_list_action_owns_live_list_rendering():
     assert helper_imports <= helper_imported_names
 
 
+def test_file_scope_file_display_action_owns_live_display_rendering():
+    """Live single-file display rendering should live in file-scope support."""
+    helper = __import__(
+        "git_stage_batch.commands.file_scope.file_display_action",
+        fromlist=["file_display_action"],
+    )
+    helper_path = SRC_ROOT / "commands" / "file_scope" / "file_display_action.py"
+    public_names = {
+        "show_live_file_display",
+    }
+    helper_imports = {
+        "ReviewSource",
+        "SelectedChangeKind",
+        "_",
+        "build_file_review_model",
+        "cache_binary_file_change",
+        "cache_file_as_single_hunk",
+        "cache_gitlink_change",
+        "cache_rename_change",
+        "cache_text_deletion_change",
+        "clear_last_file_review_state",
+        "exit_with_error",
+        "get_selected_change_file_path",
+        "load_line_changes_from_state",
+        "make_file_review_state",
+        "normalize_page_spec",
+        "print_binary_file_change",
+        "print_file_review",
+        "print_gitlink_change",
+        "print_line_level_changes",
+        "print_rename_change",
+        "print_text_file_deletion_change",
+        "render_binary_file_change",
+        "render_file_as_single_hunk",
+        "render_gitlink_change",
+        "render_rename_change",
+        "render_text_deletion_change",
+        "resolve_default_review_pages",
+        "text_deletion_change_is_batched",
+        "write_last_file_review_state",
+    }
+
+    helper_imported_names = set()
+    for _imported_module, node in _import_from_nodes(helper_path):
+        helper_imported_names |= {alias.name for alias in node.names}
+
+    assert public_names <= vars(helper).keys()
+    assert helper_imports <= helper_imported_names
+
+
 def test_file_scope_file_list_action_owns_show_entry_flow():
     """The show file-list entrypoint should delegate live list rendering."""
     show_path = SRC_ROOT / "commands" / "show.py"

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -8629,6 +8629,35 @@ def test_batch_source_candidate_materialization_owns_reviewed_candidate_loading(
         assert "build_include_candidate_previews(" not in command_text
 
 
+def test_batch_source_candidate_execution_owns_apply_candidate_side_effects():
+    """Apply candidate side effects should live in batch-source support."""
+    candidate_execution = __import__(
+        "git_stage_batch.commands.batch_source.candidate_execution",
+        fromlist=["candidate_execution"],
+    )
+    helper_path = (
+        SRC_ROOT / "commands" / "batch_source" / "candidate_execution.py"
+    )
+    public_names = {
+        "execute_apply_candidate",
+    }
+    helper_imports = {
+        "_",
+        "candidate_materialization",
+        "clear_candidate_preview_state_for_file",
+        "snapshot_file_if_untracked",
+        "text_file_actions",
+        "undo_checkpoint",
+    }
+
+    helper_imported_names = set()
+    for _imported_module, node in _import_from_nodes(helper_path):
+        helper_imported_names |= {alias.name for alias in node.names}
+
+    assert public_names <= vars(candidate_execution).keys()
+    assert helper_imports <= helper_imported_names
+
+
 def test_batch_source_replacement_previews_own_show_replacement_preview():
     """Show-from replacement preview rendering should live in batch-source support."""
     replacement_previews = __import__(

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -9210,6 +9210,48 @@ def test_apply_from_delegates_apply_action_execution():
     assert "write_text_file_to_worktree(" not in command_text
 
 
+def test_batch_source_include_action_owns_include_execution():
+    """Include-from file execution should live in batch-source support."""
+    include_action = __import__(
+        "git_stage_batch.commands.batch_source.include_action",
+        fromlist=["include_action"],
+    )
+    action_path = SRC_ROOT / "commands" / "batch_source" / "include_action.py"
+    public_names = {
+        "execute_include_action",
+    }
+    required_imports = {
+        ("git_stage_batch.commands.batch_source", "action_completion"),
+        ("git_stage_batch.commands.batch_source", "action_plans"),
+        ("git_stage_batch.commands.batch_source", "binary_file_actions"),
+        ("git_stage_batch.commands.batch_source", "candidate_preview_counts"),
+        ("git_stage_batch.commands.batch_source", "candidate_refusals"),
+        ("git_stage_batch.commands.batch_source", "merge_refusals"),
+        ("git_stage_batch.commands.batch_source", "text_file_actions"),
+        ("git_stage_batch.commands.batch_source", "text_plan_builders"),
+        ("git_stage_batch.commands.batch_source", "worktree_refusals"),
+        ("git_stage_batch.batch.binary_file_content", "read_binary_file_from_batch"),
+        ("git_stage_batch.batch.selection", "translate_atomic_unit_error_to_gutter_ids"),
+        ("git_stage_batch.batch.submodule_pointer", "stage_submodule_pointer_from_batch"),
+        ("git_stage_batch.data.session", "snapshot_file_if_untracked"),
+        ("git_stage_batch.data.undo", "undo_checkpoint"),
+    }
+    action_imports = set()
+
+    for imported_module, node in _import_from_nodes(action_path):
+        for alias in node.names:
+            action_imports.add((imported_module, alias.name))
+
+    action_text = action_path.read_text()
+
+    assert public_names <= vars(include_action).keys()
+    assert required_imports <= action_imports
+    assert "build_include_text_file_action_plan(" in action_text
+    assert "stage_text_file_to_index(" in action_text
+    assert "stage_binary_file_to_index(" in action_text
+    assert "finish_batch_source_action_review(" in action_text
+
+
 def test_batch_source_discard_action_owns_discard_execution():
     """Discard-from file execution should live in batch-source support."""
     discard_action = __import__(

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -10965,8 +10965,8 @@ def test_discard_uses_core_buffer_newline_helper():
 def test_recalc_handoff_stays_in_command_helper():
     """Include and discard commands should use the command refresh handoff."""
     command_paths = (
-        SRC_ROOT / "commands" / "include.py",
-        SRC_ROOT / "commands" / "discard.py",
+        SRC_ROOT / "commands" / "selection" / "include_line_batching.py",
+        SRC_ROOT / "commands" / "selection" / "discard_line_batching.py",
     )
     forbidden_names = {
         "RecalculateSelectedHunkResult",
@@ -11004,8 +11004,8 @@ def test_action_completion_stays_in_command_helper():
     assert "finish_selected_change_action" not in vars(hunk_tracking)
 
     command_paths = (
-        SRC_ROOT / "commands" / "include.py",
-        SRC_ROOT / "commands" / "discard.py",
+        SRC_ROOT / "commands" / "selection" / "selected_change_staging.py",
+        SRC_ROOT / "commands" / "selection" / "selected_change_discarding.py",
         SRC_ROOT / "commands" / "file_scope" / "skip_file.py",
         SRC_ROOT / "commands" / "selection" / "selected_change_skipping.py",
         SRC_ROOT / "commands" / "selection" / "skip_line_selection.py",

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -9096,6 +9096,41 @@ def test_batch_source_action_completion_owns_review_finalization():
     }
 
 
+def test_batch_source_discard_action_owns_discard_execution():
+    """Discard-from file execution should live in batch-source support."""
+    discard_action = __import__(
+        "git_stage_batch.commands.batch_source.discard_action",
+        fromlist=["discard_action"],
+    )
+    action_path = SRC_ROOT / "commands" / "batch_source" / "discard_action.py"
+    public_names = {
+        "execute_discard_action",
+    }
+    required_imports = {
+        ("git_stage_batch.commands.batch_source", "binary_file_actions"),
+        ("git_stage_batch.commands.batch_source", "text_file_actions"),
+        ("git_stage_batch.commands.batch_source", "text_plan_builders"),
+        ("git_stage_batch.batch.metadata_validation", "get_validated_baseline_commit"),
+        ("git_stage_batch.batch.selection", "translate_atomic_unit_error_to_gutter_ids"),
+        ("git_stage_batch.batch.submodule_pointer", "discard_submodule_pointer_from_batch"),
+        ("git_stage_batch.data.session", "snapshot_file_if_untracked"),
+        ("git_stage_batch.data.undo", "undo_checkpoint"),
+    }
+    action_imports = set()
+
+    for imported_module, node in _import_from_nodes(action_path):
+        for alias in node.names:
+            action_imports.add((imported_module, alias.name))
+
+    action_text = action_path.read_text()
+
+    assert public_names <= vars(discard_action).keys()
+    assert required_imports <= action_imports
+    assert "discard_binary_file_to_worktree(" in action_text
+    assert "write_discarded_text_file_to_worktree(" in action_text
+    assert "build_discard_text_file_action_plan(" in action_text
+
+
 def test_batch_source_selection_state_cleanup_owns_reset_cleanup():
     """Reset selected-state cleanup should live outside the reset entry."""
     selection_state_cleanup = __import__(

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -8173,7 +8173,9 @@ def test_batch_source_text_plan_builders_own_discard_text_planning():
         "git_stage_batch.commands.batch_source.text_plan_builders",
         fromlist=["text_plan_builders"],
     )
-    discard_from_path = SRC_ROOT / "commands" / "discard_from.py"
+    discard_action_path = (
+        SRC_ROOT / "commands" / "batch_source" / "discard_action.py"
+    )
     public_names = {
         "DiscardTextPlanBuildResult",
         "build_discard_text_file_action_plan",
@@ -8201,7 +8203,7 @@ def test_batch_source_text_plan_builders_own_discard_text_planning():
     imports_text_plan_builders = False
     direct_plan_imports = set()
 
-    for imported_module, node in _import_from_nodes(discard_from_path):
+    for imported_module, node in _import_from_nodes(discard_action_path):
         imported_names = {alias.name for alias in node.names}
         if (
             imported_module == "git_stage_batch.commands.batch_source"
@@ -8213,15 +8215,15 @@ def test_batch_source_text_plan_builders_own_discard_text_planning():
             set(),
         )
 
-    command_text = discard_from_path.read_text()
+    action_text = discard_action_path.read_text()
 
     assert public_names <= vars(text_plan_builders).keys()
     assert imports_text_plan_builders
     assert direct_plan_imports == set()
-    assert "build_discard_text_file_action_plan(" in command_text
-    assert "_discard_text_file_lifecycle_from_batch" not in command_text
-    assert "discard_batch_from_line_sequences_as_buffer(" not in command_text
-    assert "selected_text_discard_change_type(" not in command_text
+    assert "build_discard_text_file_action_plan(" in action_text
+    assert "_discard_text_file_lifecycle_from_batch" not in action_text
+    assert "discard_batch_from_line_sequences_as_buffer(" not in action_text
+    assert "selected_text_discard_change_type(" not in action_text
 
 
 def test_batch_source_candidate_previews_own_candidate_preview_checks():
@@ -9131,6 +9133,57 @@ def test_batch_source_discard_action_owns_discard_execution():
     assert "build_discard_text_file_action_plan(" in action_text
 
 
+def test_discard_from_delegates_discard_action_execution():
+    """Discard-from should delegate selected file execution to batch-source support."""
+    discard_from_path = SRC_ROOT / "commands" / "discard_from.py"
+    disallowed_imports = {
+        "git_stage_batch.commands.batch_source": {
+            "binary_file_actions",
+            "text_file_actions",
+            "text_plan_builders",
+        },
+        "git_stage_batch.batch.metadata_validation": {
+            "get_validated_baseline_commit",
+        },
+        "git_stage_batch.batch.selection": {
+            "translate_atomic_unit_error_to_gutter_ids",
+        },
+        "git_stage_batch.batch.submodule_pointer": {
+            "discard_submodule_pointer_from_batch",
+            "is_batch_submodule_pointer",
+        },
+        "git_stage_batch.data.session": {
+            "snapshot_file_if_untracked",
+        },
+        "git_stage_batch.data.undo": {
+            "undo_checkpoint",
+        },
+    }
+    imports_discard_action = False
+    direct_execution_imports = set()
+
+    for imported_module, node in _import_from_nodes(discard_from_path):
+        imported_names = {alias.name for alias in node.names}
+        if (
+            imported_module == "git_stage_batch.commands.batch_source"
+            and "discard_action" in imported_names
+        ):
+            imports_discard_action = True
+        direct_execution_imports |= imported_names & disallowed_imports.get(
+            imported_module,
+            set(),
+        )
+
+    command_text = discard_from_path.read_text()
+
+    assert imports_discard_action
+    assert direct_execution_imports == set()
+    assert "execute_discard_action(" in command_text
+    assert "build_discard_text_file_action_plan(" not in command_text
+    assert "discard_binary_file_to_worktree(" not in command_text
+    assert "write_discarded_text_file_to_worktree(" not in command_text
+
+
 def test_batch_source_selection_state_cleanup_owns_reset_cleanup():
     """Reset selected-state cleanup should live outside the reset entry."""
     selection_state_cleanup = __import__(
@@ -9545,6 +9598,9 @@ def test_batch_source_text_actions_own_text_file_mutations():
     apply_from_path = SRC_ROOT / "commands" / "apply_from.py"
     include_from_path = SRC_ROOT / "commands" / "include_from.py"
     discard_from_path = SRC_ROOT / "commands" / "discard_from.py"
+    discard_action_path = (
+        SRC_ROOT / "commands" / "batch_source" / "discard_action.py"
+    )
     public_names = {
         "stage_text_file_to_index",
         "write_discarded_text_file_to_worktree",
@@ -9555,9 +9611,9 @@ def test_batch_source_text_actions_own_text_file_mutations():
         "_stage_text_file_from_batch",
         "_write_text_file_from_batch",
     }
-    command_paths = {
+    helper_paths = {
         apply_from_path,
-        discard_from_path,
+        discard_action_path,
         include_from_path,
     }
     helpers_by_path = {
@@ -9566,14 +9622,14 @@ def test_batch_source_text_actions_own_text_file_mutations():
             for node in ast.walk(ast.parse(path.read_text(), filename=str(path)))
             if isinstance(node, (ast.ClassDef, ast.FunctionDef))
         }
-        for path in command_paths
+        for path in {*helper_paths, discard_from_path}
     }
     imports_text_file_actions = {
         path: False
-        for path in command_paths
+        for path in helper_paths
     }
 
-    for path in command_paths:
+    for path in helper_paths:
         for imported_module, node in _import_from_nodes(path):
             imported_names = {alias.name for alias in node.names}
             if (
@@ -9585,7 +9641,7 @@ def test_batch_source_text_actions_own_text_file_mutations():
     assert public_names <= vars(text_file_actions).keys()
     assert imports_text_file_actions == {
         apply_from_path: True,
-        discard_from_path: True,
+        discard_action_path: True,
         include_from_path: True,
     }
     for helpers in helpers_by_path.values():
@@ -9638,6 +9694,9 @@ def test_batch_source_binary_actions_own_worktree_mutation():
     apply_from_path = SRC_ROOT / "commands" / "apply_from.py"
     discard_from_path = SRC_ROOT / "commands" / "discard_from.py"
     include_from_path = SRC_ROOT / "commands" / "include_from.py"
+    discard_action_path = (
+        SRC_ROOT / "commands" / "batch_source" / "discard_action.py"
+    )
     public_names = {
         "BinaryWorktreeAction",
         "discard_binary_file_to_worktree",
@@ -9647,9 +9706,9 @@ def test_batch_source_binary_actions_own_worktree_mutation():
         "_discard_binary_file_from_batch",
         "_write_binary_file_from_batch",
     }
-    command_paths = {
+    helper_paths = {
         apply_from_path,
-        discard_from_path,
+        discard_action_path,
         include_from_path,
     }
     helpers_by_path = {
@@ -9658,14 +9717,14 @@ def test_batch_source_binary_actions_own_worktree_mutation():
             for node in ast.walk(ast.parse(path.read_text(), filename=str(path)))
             if isinstance(node, (ast.ClassDef, ast.FunctionDef))
         }
-        for path in command_paths
+        for path in {*helper_paths, discard_from_path}
     }
     imports_binary_file_actions = {
         path: False
-        for path in command_paths
+        for path in helper_paths
     }
 
-    for path in command_paths:
+    for path in helper_paths:
         for imported_module, node in _import_from_nodes(path):
             imported_names = {alias.name for alias in node.names}
             if (
@@ -9677,7 +9736,7 @@ def test_batch_source_binary_actions_own_worktree_mutation():
     assert public_names <= vars(binary_file_actions).keys()
     assert imports_binary_file_actions == {
         apply_from_path: True,
-        discard_from_path: True,
+        discard_action_path: True,
         include_from_path: True,
     }
     for helpers in helpers_by_path.values():

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -1603,7 +1603,9 @@ def test_file_review_records_stay_out_of_state_module():
         SRC_ROOT / "commands" / "batch_source" / "reset_selection.py": {
             "FileReviewAction",
         },
-        SRC_ROOT / "commands" / "show.py": {"ReviewSource"},
+        SRC_ROOT / "commands" / "file_scope" / "file_display_action.py": {
+            "ReviewSource",
+        },
         SRC_ROOT / "commands" / "batch_source" / "file_list_action.py": {
             "ReviewSource",
         },
@@ -1782,7 +1784,7 @@ def test_file_review_callers_use_model_builder():
     review_output_path = SRC_ROOT / "output" / "file_review.py"
     review_output_text = review_output_path.read_text()
     caller_paths = (
-        SRC_ROOT / "commands" / "show.py",
+        SRC_ROOT / "commands" / "file_scope" / "file_display_action.py",
         SRC_ROOT / "commands" / "batch_source" / "file_display_action.py",
         SRC_ROOT / "output" / "file_review_list.py",
     )
@@ -1810,14 +1812,16 @@ def test_file_review_callers_use_model_builder():
     assert public_names <= vars(file_review_model_builder).keys()
     assert "def build_file_review_model" not in review_output_text
     assert direct_model_builder_imports == {
-        "src/git_stage_batch/commands/show.py": public_names,
+        "src/git_stage_batch/commands/file_scope/file_display_action.py": (
+            public_names
+        ),
         "src/git_stage_batch/commands/batch_source/file_display_action.py": (
             public_names
         ),
         "src/git_stage_batch/output/file_review_list.py": public_names,
     }
     assert old_renderer_imports == {
-        "src/git_stage_batch/commands/show.py": set(),
+        "src/git_stage_batch/commands/file_scope/file_display_action.py": set(),
         "src/git_stage_batch/commands/batch_source/file_display_action.py": (
             set()
         ),
@@ -1865,7 +1869,7 @@ def test_show_file_display_uses_file_review_state_builder():
     review_output_path = SRC_ROOT / "output" / "file_review.py"
     review_output_text = review_output_path.read_text()
     show_paths = (
-        SRC_ROOT / "commands" / "show.py",
+        SRC_ROOT / "commands" / "file_scope" / "file_display_action.py",
         SRC_ROOT / "commands" / "batch_source" / "file_display_action.py",
     )
     file_review_state_builder = __import__(
@@ -1897,13 +1901,15 @@ def test_show_file_display_uses_file_review_state_builder():
     assert "def make_file_review_state" not in review_output_text
     assert "def resolve_default_review_pages" not in review_output_text
     assert direct_state_builder_imports == {
-        "src/git_stage_batch/commands/show.py": public_names,
+        "src/git_stage_batch/commands/file_scope/file_display_action.py": (
+            public_names
+        ),
         "src/git_stage_batch/commands/batch_source/file_display_action.py": (
             public_names
         ),
     }
     assert old_renderer_imports == {
-        "src/git_stage_batch/commands/show.py": set(),
+        "src/git_stage_batch/commands/file_scope/file_display_action.py": set(),
         "src/git_stage_batch/commands/batch_source/file_display_action.py": (
             set()
         ),
@@ -3541,6 +3547,75 @@ def test_file_scope_file_list_action_owns_show_entry_flow():
 
     assert "file_list_action" in file_scope_imports
     assert "show_live_file_list" in command_attrs
+    assert action_dependency_names.isdisjoint(command_names)
+    assert action_dependency_names.isdisjoint(command_attrs)
+    assert action_dependency_names <= helper_imported_names
+
+
+def test_file_scope_file_display_action_owns_show_entry_flow():
+    """The show file display entrypoint should delegate live display rendering."""
+    show_path = SRC_ROOT / "commands" / "show.py"
+    helper_path = SRC_ROOT / "commands" / "file_scope" / "file_display_action.py"
+    action_dependency_names = {
+        "ReviewSource",
+        "SelectedChangeKind",
+        "_",
+        "build_file_review_model",
+        "cache_binary_file_change",
+        "cache_file_as_single_hunk",
+        "cache_gitlink_change",
+        "cache_rename_change",
+        "cache_text_deletion_change",
+        "clear_last_file_review_state",
+        "exit_with_error",
+        "get_selected_change_file_path",
+        "load_line_changes_from_state",
+        "make_file_review_state",
+        "normalize_page_spec",
+        "print_binary_file_change",
+        "print_file_review",
+        "print_gitlink_change",
+        "print_line_level_changes",
+        "print_rename_change",
+        "print_text_file_deletion_change",
+        "render_binary_file_change",
+        "render_file_as_single_hunk",
+        "render_gitlink_change",
+        "render_rename_change",
+        "render_text_deletion_change",
+        "resolve_default_review_pages",
+        "text_deletion_change_is_batched",
+        "write_last_file_review_state",
+    }
+
+    show_tree = ast.parse(show_path.read_text(), filename=str(show_path))
+    show_functions = {
+        node.name: node
+        for node in ast.walk(show_tree)
+        if isinstance(node, ast.FunctionDef)
+    }
+    command_names = {
+        node.id
+        for node in ast.walk(show_functions["command_show"])
+        if isinstance(node, ast.Name)
+    }
+    command_attrs = {
+        node.attr
+        for node in ast.walk(show_functions["command_show"])
+        if isinstance(node, ast.Attribute)
+    }
+    file_scope_imports = set()
+    for imported_module, node in _import_from_nodes(show_path):
+        if imported_module != "git_stage_batch.commands.file_scope":
+            continue
+        file_scope_imports |= {alias.name for alias in node.names}
+
+    helper_imported_names = set()
+    for _imported_module, node in _import_from_nodes(helper_path):
+        helper_imported_names |= {alias.name for alias in node.names}
+
+    assert "file_display_action" in file_scope_imports
+    assert "show_live_file_display" in command_attrs
     assert action_dependency_names.isdisjoint(command_names)
     assert action_dependency_names.isdisjoint(command_attrs)
     assert action_dependency_names <= helper_imported_names

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -8996,7 +8996,7 @@ def test_batch_source_action_selection_owns_file_line_selection():
         "git_stage_batch.batch.selection": {
             "require_single_file_context_for_line_selection",
             "resolve_batch_file_scope",
-            "resolve_current_batch_binary_file_scope",
+            "resolve_current_batch_atomic_file_scope",
         },
         "git_stage_batch.batch.submodule_pointer": {
             "refuse_batch_submodule_pointer_lines",
@@ -9270,7 +9270,7 @@ def test_batch_source_reset_selection_owns_reset_scope():
         },
         "git_stage_batch.batch.selection": {
             "resolve_batch_file_scope",
-            "resolve_current_batch_binary_file_scope",
+            "resolve_current_batch_atomic_file_scope",
         },
         "git_stage_batch.batch.source_selector": {
             "require_plain_batch_name",

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -7629,6 +7629,37 @@ def test_batch_source_file_display_action_owns_show_flow():
     assert helper_imports <= helper_imported_names
 
 
+def test_batch_source_file_list_action_owns_list_rendering():
+    """Show-from multi-file list rendering should live in batch-source support."""
+    helper = __import__(
+        "git_stage_batch.commands.batch_source.file_list_action",
+        fromlist=["file_list_action"],
+    )
+    helper_path = SRC_ROOT / "commands" / "batch_source" / "file_list_action.py"
+    public_names = {
+        "show_batch_source_file_list",
+    }
+    helper_imports = {
+        "ReviewSource",
+        "binary_change_from_batch_file_metadata",
+        "clear_selected_change_state_files",
+        "gitlink_change_from_batch_file_metadata",
+        "make_binary_file_review_list_entry",
+        "make_file_review_list_entry",
+        "make_gitlink_file_review_list_entry",
+        "mark_selected_change_cleared_by_file_list",
+        "print_file_review_list",
+        "render_batch_file_display",
+    }
+
+    helper_imported_names = set()
+    for _imported_module, node in _import_from_nodes(helper_path):
+        helper_imported_names |= {alias.name for alias in node.names}
+
+    assert public_names <= vars(helper).keys()
+    assert helper_imports <= helper_imported_names
+
+
 def test_batch_owns_binary_file_content_loading():
     """Stored binary batch content loading should live in batch."""
     binary_file_content = __import__(

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -8546,6 +8546,9 @@ def test_batch_source_candidate_materialization_owns_reviewed_candidate_loading(
     )
     apply_from_path = SRC_ROOT / "commands" / "apply_from.py"
     include_from_path = SRC_ROOT / "commands" / "include_from.py"
+    candidate_execution_path = (
+        SRC_ROOT / "commands" / "batch_source" / "candidate_execution.py"
+    )
     materialization_path = (
         SRC_ROOT / "commands" / "batch_source" / "candidate_materialization.py"
     )
@@ -8563,27 +8566,35 @@ def test_batch_source_candidate_materialization_owns_reviewed_candidate_loading(
         apply_from_path,
         include_from_path,
     }
+    materialization_consumer_paths = {
+        candidate_execution_path,
+        include_from_path,
+    }
+    preview_free_paths = command_paths | {
+        candidate_execution_path,
+    }
     imports_candidate_materialization = {
         path: False
-        for path in command_paths
+        for path in materialization_consumer_paths
     }
     imports_candidate_previews = {
         path: False
-        for path in command_paths
+        for path in preview_free_paths
     }
     direct_builder_imports = {
         path: set()
-        for path in command_paths
+        for path in preview_free_paths
     }
     materialization_imports_candidate_previews = False
     materialization_builder_imports = set()
 
-    for path in command_paths:
+    for path in preview_free_paths:
         for imported_module, node in _import_from_nodes(path):
             imported_names = {alias.name for alias in node.names}
             if (
                 imported_module == "git_stage_batch.commands.batch_source"
                 and "candidate_materialization" in imported_names
+                and path in imports_candidate_materialization
             ):
                 imports_candidate_materialization[path] = True
             if (
@@ -8606,21 +8617,23 @@ def test_batch_source_candidate_materialization_owns_reviewed_candidate_loading(
 
     assert public_names <= vars(candidate_materialization).keys()
     assert imports_candidate_materialization == {
-        apply_from_path: True,
+        candidate_execution_path: True,
         include_from_path: True,
     }
     assert imports_candidate_previews == {
         apply_from_path: False,
+        candidate_execution_path: False,
         include_from_path: False,
     }
     assert direct_builder_imports == {
         apply_from_path: set(),
+        candidate_execution_path: set(),
         include_from_path: set(),
     }
     assert materialization_imports_candidate_previews
     assert materialization_builder_imports == builder_names
 
-    for path in command_paths:
+    for path in preview_free_paths:
         command_text = path.read_text()
         assert ".require_candidate_preview_for_ordinal(" not in command_text
         assert ".require_candidate_preview_state(" not in command_text
@@ -8656,6 +8669,46 @@ def test_batch_source_candidate_execution_owns_apply_candidate_side_effects():
 
     assert public_names <= vars(candidate_execution).keys()
     assert helper_imports <= helper_imported_names
+
+
+def test_batch_source_candidate_execution_owns_apply_from_flow():
+    """Apply-from should delegate reviewed candidate execution."""
+    apply_from_path = SRC_ROOT / "commands" / "apply_from.py"
+    helper_path = (
+        SRC_ROOT / "commands" / "batch_source" / "candidate_execution.py"
+    )
+    command_tree = ast.parse(
+        apply_from_path.read_text(),
+        filename=str(apply_from_path),
+    )
+    command_functions = {
+        node.name: node
+        for node in ast.walk(command_tree)
+        if isinstance(node, ast.FunctionDef)
+    }
+    command_attrs = {
+        node.attr
+        for node in ast.walk(command_functions["command_apply_from_batch"])
+        if isinstance(node, ast.Attribute)
+    }
+    command_imports = set()
+    command_imported_names = set()
+    for imported_module, node in _import_from_nodes(apply_from_path):
+        command_imports.add(imported_module)
+        command_imported_names |= {alias.name for alias in node.names}
+
+    helper_imported_names = set()
+    for _imported_module, node in _import_from_nodes(helper_path):
+        helper_imported_names |= {alias.name for alias in node.names}
+
+    assert "git_stage_batch.commands.batch_source" in command_imports
+    assert "candidate_execution" in command_imported_names
+    assert "execute_apply_candidate" in command_attrs
+    assert "_execute_apply_candidate" not in command_functions
+    assert "candidate_materialization" not in command_imported_names
+    assert "clear_candidate_preview_state_for_file" not in command_imported_names
+    assert "candidate_materialization" in helper_imported_names
+    assert "clear_candidate_preview_state_for_file" in helper_imported_names
 
 
 def test_batch_source_replacement_previews_own_show_replacement_preview():

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -7534,6 +7534,101 @@ def test_batch_owns_atomic_file_change_metadata_conversion():
     assert action_model_imports == set()
 
 
+def test_batch_source_file_display_action_owns_show_flow():
+    """Show-from single-file display should live in batch-source support."""
+    helper = __import__(
+        "git_stage_batch.commands.batch_source.file_display_action",
+        fromlist=["file_display_action"],
+    )
+    show_from_path = SRC_ROOT / "commands" / "show_from.py"
+    helper_path = (
+        SRC_ROOT / "commands" / "batch_source" / "file_display_action.py"
+    )
+    public_names = {
+        "show_batch_source_file_display",
+    }
+    action_dependency_names = {
+        "LineLevelChange",
+        "SelectedChangeKind",
+        "_shown_pages_for_display_ids",
+        "build_file_review_model",
+        "cache_binary_file_change",
+        "cache_gitlink_change",
+        "cache_rendered_batch_file_display",
+        "clear_last_file_review_state",
+        "compute_batch_binary_fingerprint",
+        "compute_batch_gitlink_fingerprint",
+        "make_file_review_state",
+        "normalize_page_spec",
+        "print_binary_file_change",
+        "print_file_review",
+        "print_gitlink_change",
+        "print_line_level_changes",
+        "resolve_default_review_pages",
+        "write_last_file_review_state",
+    }
+    helper_imports = {
+        "LineLevelChange",
+        "SelectedChangeKind",
+        "binary_change_from_batch_file_metadata",
+        "build_file_review_model",
+        "cache_binary_file_change",
+        "cache_gitlink_change",
+        "cache_rendered_batch_file_display",
+        "clear_last_file_review_state",
+        "compute_batch_binary_fingerprint",
+        "compute_batch_gitlink_fingerprint",
+        "exit_with_error",
+        "gitlink_change_from_batch_file_metadata",
+        "make_file_review_state",
+        "normalize_page_spec",
+        "print_binary_file_change",
+        "print_file_review",
+        "print_gitlink_change",
+        "print_line_level_changes",
+        "render_batch_file_display",
+        "resolve_default_review_pages",
+        "write_last_file_review_state",
+    }
+
+    assert public_names <= vars(helper).keys()
+
+    show_from_tree = ast.parse(
+        show_from_path.read_text(),
+        filename=str(show_from_path),
+    )
+    show_from_functions = {
+        node.name: node
+        for node in ast.walk(show_from_tree)
+        if isinstance(node, ast.FunctionDef)
+    }
+    command_names = {
+        node.id
+        for node in ast.walk(show_from_functions["command_show_from_batch"])
+        if isinstance(node, ast.Name)
+    }
+    command_attrs = {
+        node.attr
+        for node in ast.walk(show_from_functions["command_show_from_batch"])
+        if isinstance(node, ast.Attribute)
+    }
+    batch_source_imports = set()
+    for imported_module, node in _import_from_nodes(show_from_path):
+        if imported_module != "git_stage_batch.commands.batch_source":
+            continue
+        batch_source_imports |= {alias.name for alias in node.names}
+
+    helper_imported_names = set()
+    for _imported_module, node in _import_from_nodes(helper_path):
+        helper_imported_names |= {alias.name for alias in node.names}
+
+    assert "file_display_action" in batch_source_imports
+    assert "show_batch_source_file_display" in command_attrs
+    assert action_dependency_names.isdisjoint(command_names)
+    assert action_dependency_names.isdisjoint(command_attrs)
+    assert helper_imports <= helper_imported_names
+
+
 def test_batch_owns_binary_file_content_loading():
     """Stored binary batch content loading should live in batch."""
     binary_file_content = __import__(

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -2008,11 +2008,13 @@ def test_file_review_action_scope_stays_out_of_state_module():
             "resolve_live_to_batch_action_scope",
         },
         SRC_ROOT / "commands" / "include.py": {
-            "finish_review_scoped_line_action",
             "refuse_ambiguous_bare_action_after_partial_file_review",
             "refuse_live_action_for_batch_selection",
             "resolve_live_line_action_scope",
             "resolve_live_to_batch_action_scope",
+        },
+        SRC_ROOT / "commands" / "selection" / "include_to_batch_action.py": {
+            "finish_review_scoped_line_action",
         },
         SRC_ROOT / "commands" / "skip.py": {
             "refuse_ambiguous_bare_action_after_partial_file_review",
@@ -3228,6 +3230,7 @@ def test_whole_file_batch_staging_owns_include_pipeline():
     helper_path = (
         SRC_ROOT / "commands" / "selection" / "whole_file_batch_staging.py"
     )
+    action_path = SRC_ROOT / "commands" / "selection" / "include_to_batch_action.py"
     helper = __import__(
         "git_stage_batch.commands.selection.whole_file_batch_staging",
         fromlist=["whole_file_batch_staging"],
@@ -3272,11 +3275,17 @@ def test_whole_file_batch_staging_owns_include_pipeline():
     helper_imported_names = set()
     for _imported_module, node in _import_from_nodes(helper_path):
         helper_imported_names |= {alias.name for alias in node.names}
+    action_selection_imports = set()
+    for imported_module, node in _import_from_nodes(action_path):
+        if imported_module == "git_stage_batch.commands.selection":
+            action_selection_imports |= {alias.name for alias in node.names}
 
     assert public_names <= vars(helper).keys()
     assert old_command_helper_names.isdisjoint(include_names)
     assert old_command_helper_names.isdisjoint(vars(helper).keys())
-    assert "whole_file_batch_staging" in include_selection_imports
+    assert "include_to_batch_action" in include_selection_imports
+    assert "whole_file_batch_staging" not in include_selection_imports
+    assert "whole_file_batch_staging" in action_selection_imports
     assert moved_import_names.isdisjoint(include_imported_names)
     assert moved_import_names <= helper_imported_names
 
@@ -3287,6 +3296,7 @@ def test_selected_change_batch_staging_owns_include_pipeline():
     helper_path = (
         SRC_ROOT / "commands" / "selection" / "selected_change_batch_staging.py"
     )
+    action_path = SRC_ROOT / "commands" / "selection" / "include_to_batch_action.py"
     helper = __import__(
         "git_stage_batch.commands.selection.selected_change_batch_staging",
         fromlist=["selected_change_batch_staging"],
@@ -3333,11 +3343,17 @@ def test_selected_change_batch_staging_owns_include_pipeline():
     helper_imported_names = set()
     for _imported_module, node in _import_from_nodes(helper_path):
         helper_imported_names |= {alias.name for alias in node.names}
+    action_selection_imports = set()
+    for imported_module, node in _import_from_nodes(action_path):
+        if imported_module == "git_stage_batch.commands.selection":
+            action_selection_imports |= {alias.name for alias in node.names}
 
     assert public_names <= vars(helper).keys()
     assert old_command_helper_names.isdisjoint(include_names)
     assert old_command_helper_names.isdisjoint(vars(helper).keys())
-    assert "selected_change_batch_staging" in include_selection_imports
+    assert "include_to_batch_action" in include_selection_imports
+    assert "selected_change_batch_staging" not in include_selection_imports
+    assert "selected_change_batch_staging" in action_selection_imports
     assert moved_import_names.isdisjoint(include_imported_names)
     assert helper_imports <= helper_imported_names
 
@@ -3380,6 +3396,71 @@ def test_include_to_batch_action_owns_resolved_dispatch():
     assert "require_file_scope_target_path" in action_imports[
         "git_stage_batch.commands.file_scope.target_path"
     ]
+
+
+def test_include_delegates_include_to_batch_action_routing():
+    """The include-to-batch command should delegate resolved action routing."""
+    include_path = SRC_ROOT / "commands" / "include.py"
+    include_tree = ast.parse(include_path.read_text(), filename=str(include_path))
+    include_functions = {
+        node.name: node
+        for node in ast.walk(include_tree)
+        if isinstance(node, ast.FunctionDef)
+    }
+    command_attrs = {
+        node.attr
+        for node in ast.walk(include_functions["command_include_to_batch"])
+        if isinstance(node, ast.Attribute)
+    }
+    include_imports = {}
+    for imported_module, node in _import_from_nodes(include_path):
+        include_imports.setdefault(imported_module, set()).update(
+            alias.name for alias in node.names
+        )
+    disallowed_imports = {
+        "git_stage_batch.core.models": {
+            "BinaryFileChange",
+            "GitlinkChange",
+            "RenameChange",
+            "TextFileDeletionChange",
+        },
+        "git_stage_batch.data.file_review.action_scope": {
+            "finish_review_scoped_line_action",
+        },
+        "git_stage_batch.data.selected_change.loading": {
+            "load_selected_change",
+        },
+        "git_stage_batch.data.undo": {
+            "undo_checkpoint",
+        },
+        "git_stage_batch.exceptions": {
+            "exit_with_error",
+        },
+        "git_stage_batch.commands.selection": {
+            "include_line_batching",
+            "selected_change_batch_staging",
+            "whole_file_batch_staging",
+        },
+        "git_stage_batch.commands.file_scope": {
+            "include_file_to_batch",
+        },
+        "git_stage_batch.commands.file_scope.target_path": {
+            "require_file_scope_target_path",
+        },
+    }
+    violations = []
+
+    for imported_module, disallowed_names in disallowed_imports.items():
+        stale_names = include_imports.get(imported_module, set()) & disallowed_names
+        if stale_names:
+            names = ", ".join(sorted(stale_names))
+            violations.append(f"{imported_module} imports {names}")
+
+    assert "include_to_batch_action" in include_imports[
+        "git_stage_batch.commands.selection"
+    ]
+    assert "execute_include_to_batch_action" in command_attrs
+    assert violations == []
 
 
 def test_file_scope_include_file_owns_file_pipeline():
@@ -3663,10 +3744,11 @@ def test_file_scope_file_display_action_owns_show_entry_flow():
 
 def test_file_scope_target_path_stays_in_file_scope_support():
     """File-scope target fallback should stay out of command entrypoints."""
-    command_paths = {
+    direct_target_path_paths = {
         SRC_ROOT / "commands" / "discard.py",
-        SRC_ROOT / "commands" / "include.py",
+        SRC_ROOT / "commands" / "selection" / "include_to_batch_action.py",
     }
+    include_path = SRC_ROOT / "commands" / "include.py"
     helper_path = SRC_ROOT / "commands" / "file_scope" / "target_path.py"
     helper = __import__(
         "git_stage_batch.commands.file_scope.target_path",
@@ -3674,14 +3756,14 @@ def test_file_scope_target_path_stays_in_file_scope_support():
     )
     public_names = {"require_file_scope_target_path"}
     moved_names = {"get_selected_change_file_path"}
-    command_imports = {}
-    command_imported_names = set()
+    imports_by_path = {}
+    imported_names = set()
 
-    for path in command_paths:
-        command_imports[path] = set()
+    for path in direct_target_path_paths | {include_path}:
+        imports_by_path[path] = set()
         for imported_module, node in _import_from_nodes(path):
-            command_imports[path].add(imported_module)
-            command_imported_names |= {alias.name for alias in node.names}
+            imports_by_path[path].add(imported_module)
+            imported_names |= {alias.name for alias in node.names}
 
     helper_imports = set()
     helper_imported_names = set()
@@ -3690,11 +3772,18 @@ def test_file_scope_target_path_stays_in_file_scope_support():
         helper_imported_names |= {alias.name for alias in node.names}
 
     assert public_names <= vars(helper).keys()
-    for imports in command_imports.values():
-        assert "git_stage_batch.commands.file_scope.target_path" in imports
+    for path in direct_target_path_paths:
+        assert (
+            "git_stage_batch.commands.file_scope.target_path" in imports_by_path[path]
+        )
+    assert (
+        "git_stage_batch.commands.file_scope.target_path"
+        not in imports_by_path[include_path]
+    )
+    for imports in imports_by_path.values():
         assert "git_stage_batch.data.selected_change.paths" not in imports
     assert "git_stage_batch.data.selected_change.paths" in helper_imports
-    assert moved_names.isdisjoint(command_imported_names)
+    assert moved_names.isdisjoint(imported_names)
     assert moved_names <= helper_imported_names
 
 
@@ -3775,6 +3864,7 @@ def test_file_scope_skip_owns_file_pipeline():
 def test_file_scope_include_to_batch_owns_file_pipeline():
     """Explicit file-scope include-to-batch support should stay out of include.py."""
     include_path = SRC_ROOT / "commands" / "include.py"
+    action_path = SRC_ROOT / "commands" / "selection" / "include_to_batch_action.py"
     helper_path = SRC_ROOT / "commands" / "file_scope" / "include_file_to_batch.py"
     helper = __import__(
         "git_stage_batch.commands.file_scope.include_file_to_batch",
@@ -3815,9 +3905,16 @@ def test_file_scope_include_to_batch_owns_file_pipeline():
     }
     include_names = set(include_functions)
     include_file_scope_imports = set()
+    include_selection_imports = set()
     for imported_module, node in _import_from_nodes(include_path):
         if imported_module == "git_stage_batch.commands.file_scope":
             include_file_scope_imports |= {alias.name for alias in node.names}
+        if imported_module == "git_stage_batch.commands.selection":
+            include_selection_imports |= {alias.name for alias in node.names}
+    action_file_scope_imports = set()
+    for imported_module, node in _import_from_nodes(action_path):
+        if imported_module == "git_stage_batch.commands.file_scope":
+            action_file_scope_imports |= {alias.name for alias in node.names}
 
     helper_imported_names = set()
     for _imported_module, node in _import_from_nodes(helper_path):
@@ -3825,7 +3922,9 @@ def test_file_scope_include_to_batch_owns_file_pipeline():
 
     assert public_names <= vars(helper).keys()
     assert old_command_helper_names.isdisjoint(include_names)
-    assert "include_file_to_batch" in include_file_scope_imports
+    assert "include_to_batch_action" in include_selection_imports
+    assert "include_file_to_batch" not in include_file_scope_imports
+    assert "include_file_to_batch" in action_file_scope_imports
     assert moved_names.isdisjoint(command_include_to_batch_names)
     assert helper_imports <= helper_imported_names
 
@@ -10310,7 +10409,10 @@ def test_selected_change_loading_stays_out_of_hunk_tracking():
         "require_selected_hunk",
     }
     expected_imports = {
-        SRC_ROOT / "commands" / "include.py": {"load_selected_change"},
+        SRC_ROOT
+        / "commands"
+        / "selection"
+        / "include_to_batch_action.py": {"load_selected_change"},
         SRC_ROOT
         / "commands"
         / "selection"
@@ -11420,6 +11522,7 @@ def test_include_file_selection_stays_in_command_helper():
 def test_include_line_batching_stays_in_command_helper():
     """Include line-to-batch support should stay out of the command entrypoint."""
     include_path = SRC_ROOT / "commands" / "include.py"
+    action_path = SRC_ROOT / "commands" / "selection" / "include_to_batch_action.py"
     helper_path = (
         SRC_ROOT / "commands" / "selection" / "include_line_batching.py"
     )
@@ -11452,12 +11555,19 @@ def test_include_line_batching_stays_in_command_helper():
         node.name for node in ast.walk(include_tree) if isinstance(node, ast.FunctionDef)
     }
     include_imports_helper = False
+    action_imports_helper = False
     for imported_module, node in _import_from_nodes(include_path):
         if imported_module != "git_stage_batch.commands.selection":
             continue
         imported_names = {alias.name for alias in node.names}
         if "include_line_batching" in imported_names:
             include_imports_helper = True
+    for imported_module, node in _import_from_nodes(action_path):
+        if imported_module != "git_stage_batch.commands.selection":
+            continue
+        imported_names = {alias.name for alias in node.names}
+        if "include_line_batching" in imported_names:
+            action_imports_helper = True
 
     helper_imported_names = set()
     for _imported_module, node in _import_from_nodes(helper_path):
@@ -11466,7 +11576,8 @@ def test_include_line_batching_stays_in_command_helper():
     assert public_names <= vars(helper).keys()
     assert old_include_names.isdisjoint(include_names)
     assert old_include_names.isdisjoint(vars(helper).keys())
-    assert include_imports_helper
+    assert not include_imports_helper
+    assert action_imports_helper
     assert helper_imports <= helper_imported_names
 
 

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -7941,6 +7941,9 @@ def test_batch_owns_binary_file_content_loading():
     apply_from_path = SRC_ROOT / "commands" / "apply_from.py"
     apply_action_path = SRC_ROOT / "commands" / "batch_source" / "apply_action.py"
     include_from_path = SRC_ROOT / "commands" / "include_from.py"
+    include_action_path = (
+        SRC_ROOT / "commands" / "batch_source" / "include_action.py"
+    )
     public_names = {
         "read_binary_file_from_batch",
     }
@@ -7956,18 +7959,18 @@ def test_batch_owns_binary_file_content_loading():
         for node in ast.walk(apply_action_tree)
         if isinstance(node, (ast.ClassDef, ast.FunctionDef))
     }
-    include_from_tree = ast.parse(
-        include_from_path.read_text(),
-        filename=str(include_from_path),
+    include_action_tree = ast.parse(
+        include_action_path.read_text(),
+        filename=str(include_action_path),
     )
-    include_from_helpers = {
+    include_action_helpers = {
         node.name
-        for node in ast.walk(include_from_tree)
+        for node in ast.walk(include_action_tree)
         if isinstance(node, (ast.ClassDef, ast.FunctionDef))
     }
     loader_imports_by_path = {
         apply_action_path: set(),
-        include_from_path: set(),
+        include_action_path: set(),
     }
 
     for path in loader_imports_by_path:
@@ -7978,9 +7981,9 @@ def test_batch_owns_binary_file_content_loading():
 
     assert public_names <= vars(binary_file_content).keys()
     assert public_names <= loader_imports_by_path[apply_action_path]
-    assert public_names <= loader_imports_by_path[include_from_path]
+    assert public_names <= loader_imports_by_path[include_action_path]
     assert old_names.isdisjoint(apply_action_helpers)
-    assert old_names.isdisjoint(include_from_helpers)
+    assert old_names.isdisjoint(include_action_helpers)
 
 
 def test_batch_source_action_plans_own_resource_plans():
@@ -7992,6 +7995,9 @@ def test_batch_source_action_plans_own_resource_plans():
     apply_from_path = SRC_ROOT / "commands" / "apply_from.py"
     apply_action_path = SRC_ROOT / "commands" / "batch_source" / "apply_action.py"
     include_from_path = SRC_ROOT / "commands" / "include_from.py"
+    include_action_path = (
+        SRC_ROOT / "commands" / "batch_source" / "include_action.py"
+    )
     public_names = {
         "ApplyTextFileActionPlan",
         "BatchSourceActionPlan",
@@ -8021,18 +8027,18 @@ def test_batch_source_action_plans_own_resource_plans():
         for node in ast.walk(apply_action_tree)
         if isinstance(node, (ast.ClassDef, ast.FunctionDef))
     }
-    include_from_tree = ast.parse(
-        include_from_path.read_text(),
-        filename=str(include_from_path),
+    include_action_tree = ast.parse(
+        include_action_path.read_text(),
+        filename=str(include_action_path),
     )
-    include_from_helpers = {
+    include_action_helpers = {
         node.name
-        for node in ast.walk(include_from_tree)
+        for node in ast.walk(include_action_tree)
         if isinstance(node, (ast.ClassDef, ast.FunctionDef))
     }
     imports_action_plans = {
         apply_action_path: False,
-        include_from_path: False,
+        include_action_path: False,
     }
 
     for path in imports_action_plans:
@@ -8046,9 +8052,9 @@ def test_batch_source_action_plans_own_resource_plans():
 
     assert public_names <= vars(action_plans).keys()
     assert imports_action_plans[apply_action_path]
-    assert imports_action_plans[include_from_path]
+    assert imports_action_plans[include_action_path]
     assert old_apply_names.isdisjoint(apply_action_helpers)
-    assert old_include_names.isdisjoint(include_from_helpers)
+    assert old_include_names.isdisjoint(include_action_helpers)
 
 
 def test_batch_source_text_plan_builders_own_apply_text_planning():
@@ -8117,7 +8123,9 @@ def test_batch_source_text_plan_builders_own_include_text_planning():
         "git_stage_batch.commands.batch_source.text_plan_builders",
         fromlist=["text_plan_builders"],
     )
-    include_from_path = SRC_ROOT / "commands" / "include_from.py"
+    include_action_path = (
+        SRC_ROOT / "commands" / "batch_source" / "include_action.py"
+    )
     public_names = {
         "IncludeTextPlanBuildResult",
         "build_include_text_file_action_plan",
@@ -8152,7 +8160,7 @@ def test_batch_source_text_plan_builders_own_include_text_planning():
     imports_text_plan_builders = False
     direct_plan_imports = set()
 
-    for imported_module, node in _import_from_nodes(include_from_path):
+    for imported_module, node in _import_from_nodes(include_action_path):
         imported_names = {alias.name for alias in node.names}
         if (
             imported_module == "git_stage_batch.commands.batch_source"
@@ -8164,15 +8172,15 @@ def test_batch_source_text_plan_builders_own_include_text_planning():
             set(),
         )
 
-    command_text = include_from_path.read_text()
+    action_text = include_action_path.read_text()
 
     assert public_names <= vars(text_plan_builders).keys()
     assert imports_text_plan_builders
     assert direct_plan_imports == set()
-    assert "build_include_text_file_action_plan(" in command_text
-    assert "merge_batch_from_line_sequences_as_buffer(" not in command_text
-    assert "build_replacement_batch_view_from_lines(" not in command_text
-    assert "selected_text_target_change_type(" not in command_text
+    assert "build_include_text_file_action_plan(" in action_text
+    assert "merge_batch_from_line_sequences_as_buffer(" not in action_text
+    assert "build_replacement_batch_view_from_lines(" not in action_text
+    assert "selected_text_target_change_type(" not in action_text
 
 
 def test_batch_source_text_plan_builders_own_discard_text_planning():
@@ -8426,6 +8434,9 @@ def test_batch_source_candidate_preview_counts_own_failure_enumeration():
     apply_from_path = SRC_ROOT / "commands" / "apply_from.py"
     apply_action_path = SRC_ROOT / "commands" / "batch_source" / "apply_action.py"
     include_from_path = SRC_ROOT / "commands" / "include_from.py"
+    include_action_path = (
+        SRC_ROOT / "commands" / "batch_source" / "include_action.py"
+    )
     public_names = {
         "count_apply_candidate_previews_for_file",
         "count_include_candidate_previews_for_file",
@@ -8434,7 +8445,7 @@ def test_batch_source_candidate_preview_counts_own_failure_enumeration():
         apply_action_path: {
             "_apply_candidate_count_for_file",
         },
-        include_from_path: {
+        include_action_path: {
             "_include_candidate_count_for_file",
         },
     }
@@ -8473,11 +8484,11 @@ def test_batch_source_candidate_preview_counts_own_failure_enumeration():
     assert public_names <= vars(candidate_preview_counts).keys()
     assert imports_candidate_preview_counts == {
         apply_action_path: True,
-        include_from_path: True,
+        include_action_path: True,
     }
     assert direct_count_imports == {
         apply_action_path: set(),
-        include_from_path: set(),
+        include_action_path: set(),
     }
     for path, old_names in old_function_names.items():
         assert old_names.isdisjoint(helper_names[path])
@@ -8862,6 +8873,9 @@ def test_batch_source_candidate_refusals_own_candidate_count_refusals():
     apply_from_path = SRC_ROOT / "commands" / "apply_from.py"
     apply_action_path = SRC_ROOT / "commands" / "batch_source" / "apply_action.py"
     include_from_path = SRC_ROOT / "commands" / "include_from.py"
+    include_action_path = (
+        SRC_ROOT / "commands" / "batch_source" / "include_action.py"
+    )
     public_names = {
         "refuse_candidate_conflicts",
     }
@@ -8871,7 +8885,7 @@ def test_batch_source_candidate_refusals_own_candidate_count_refusals():
             "Cannot enumerate apply candidates",
             "multiple files need apply decisions",
         },
-        include_from_path: {
+        include_action_path: {
             "too many include candidates",
             "Cannot enumerate include candidates",
             "multiple files need include decisions",
@@ -8895,7 +8909,7 @@ def test_batch_source_candidate_refusals_own_candidate_count_refusals():
     assert public_names <= vars(candidate_refusals).keys()
     assert imports_candidate_refusals == {
         apply_action_path: True,
-        include_from_path: True,
+        include_action_path: True,
     }
     for path, old_snippets in old_snippets_by_path.items():
         command_text = path.read_text()
@@ -8912,6 +8926,9 @@ def test_batch_source_action_context_owns_action_prologue():
     apply_from_path = SRC_ROOT / "commands" / "apply_from.py"
     apply_action_path = SRC_ROOT / "commands" / "batch_source" / "apply_action.py"
     include_from_path = SRC_ROOT / "commands" / "include_from.py"
+    include_action_path = (
+        SRC_ROOT / "commands" / "batch_source" / "include_action.py"
+    )
     discard_from_path = SRC_ROOT / "commands" / "discard_from.py"
     public_names = {
         "BatchSourceActionContext",
@@ -9071,12 +9088,15 @@ def test_batch_source_action_completion_owns_review_finalization():
     apply_from_path = SRC_ROOT / "commands" / "apply_from.py"
     apply_action_path = SRC_ROOT / "commands" / "batch_source" / "apply_action.py"
     include_from_path = SRC_ROOT / "commands" / "include_from.py"
+    include_action_path = (
+        SRC_ROOT / "commands" / "batch_source" / "include_action.py"
+    )
     public_names = {
         "finish_batch_source_action_review",
     }
     command_paths = {
         apply_action_path,
-        include_from_path,
+        include_action_path,
     }
     imports_action_completion = {
         path: False
@@ -9103,11 +9123,11 @@ def test_batch_source_action_completion_owns_review_finalization():
     assert public_names <= vars(action_completion).keys()
     assert imports_action_completion == {
         apply_action_path: True,
-        include_from_path: True,
+        include_action_path: True,
     }
     assert direct_review_imports == {
         apply_action_path: set(),
-        include_from_path: set(),
+        include_action_path: set(),
     }
 
 
@@ -9250,6 +9270,63 @@ def test_batch_source_include_action_owns_include_execution():
     assert "stage_text_file_to_index(" in action_text
     assert "stage_binary_file_to_index(" in action_text
     assert "finish_batch_source_action_review(" in action_text
+
+
+def test_include_from_delegates_include_action_execution():
+    """Include-from should delegate selected file execution to batch-source support."""
+    include_from_path = SRC_ROOT / "commands" / "include_from.py"
+    disallowed_imports = {
+        "git_stage_batch.commands.batch_source": {
+            "action_completion",
+            "action_plans",
+            "binary_file_actions",
+            "candidate_preview_counts",
+            "candidate_refusals",
+            "merge_refusals",
+            "text_file_actions",
+            "text_plan_builders",
+            "worktree_refusals",
+        },
+        "git_stage_batch.batch.binary_file_content": {
+            "read_binary_file_from_batch",
+        },
+        "git_stage_batch.batch.selection": {
+            "translate_atomic_unit_error_to_gutter_ids",
+        },
+        "git_stage_batch.batch.submodule_pointer": {
+            "is_batch_submodule_pointer",
+            "stage_submodule_pointer_from_batch",
+        },
+        "git_stage_batch.data.session": {
+            "snapshot_file_if_untracked",
+        },
+        "git_stage_batch.data.undo": {
+            "undo_checkpoint",
+        },
+    }
+    imports_include_action = False
+    direct_execution_imports = set()
+
+    for imported_module, node in _import_from_nodes(include_from_path):
+        imported_names = {alias.name for alias in node.names}
+        if (
+            imported_module == "git_stage_batch.commands.batch_source"
+            and "include_action" in imported_names
+        ):
+            imports_include_action = True
+        direct_execution_imports |= imported_names & disallowed_imports.get(
+            imported_module,
+            set(),
+        )
+
+    command_text = include_from_path.read_text()
+
+    assert imports_include_action
+    assert direct_execution_imports == set()
+    assert "execute_include_action(" in command_text
+    assert "build_include_text_file_action_plan(" not in command_text
+    assert "stage_binary_file_to_index(" not in command_text
+    assert "stage_text_file_to_index(" not in command_text
 
 
 def test_batch_source_discard_action_owns_discard_execution():
@@ -9646,6 +9723,9 @@ def test_batch_source_merge_refusals_own_merge_failure_refusals():
     apply_from_path = SRC_ROOT / "commands" / "apply_from.py"
     apply_action_path = SRC_ROOT / "commands" / "batch_source" / "apply_action.py"
     include_from_path = SRC_ROOT / "commands" / "include_from.py"
+    include_action_path = (
+        SRC_ROOT / "commands" / "batch_source" / "include_action.py"
+    )
     public_names = {
         "refuse_batch_source_merge_failures",
     }
@@ -9654,7 +9734,7 @@ def test_batch_source_merge_refusals_own_merge_failure_refusals():
             "gutter_to_selection_id",
             "Failed for: {files}",
         },
-        include_from_path: {
+        include_action_path: {
             "gutter_to_selection_id",
             "Failed for: {files}",
         },
@@ -9685,11 +9765,11 @@ def test_batch_source_merge_refusals_own_merge_failure_refusals():
     assert public_names <= vars(merge_refusals).keys()
     assert imports_merge_refusals == {
         apply_action_path: True,
-        include_from_path: True,
+        include_action_path: True,
     }
     assert direct_display_imports == {
         apply_action_path: set(),
-        include_from_path: set(),
+        include_action_path: set(),
     }
     for path, old_snippets in old_snippets_by_path.items():
         command_text = path.read_text()
@@ -9706,6 +9786,9 @@ def test_batch_source_worktree_refusals_own_execution_refusals():
     apply_from_path = SRC_ROOT / "commands" / "apply_from.py"
     apply_action_path = SRC_ROOT / "commands" / "batch_source" / "apply_action.py"
     include_from_path = SRC_ROOT / "commands" / "include_from.py"
+    include_action_path = (
+        SRC_ROOT / "commands" / "batch_source" / "include_action.py"
+    )
     public_names = {
         "refuse_incompatible_worktree_action",
     }
@@ -9714,7 +9797,7 @@ def test_batch_source_worktree_refusals_own_execution_refusals():
             "contains changes to {file} that are incompatible",
             "one or more files that are incompatible",
         },
-        include_from_path: {
+        include_action_path: {
             "contains changes to {file} that are incompatible",
             "one or more files that are incompatible",
         },
@@ -9737,7 +9820,7 @@ def test_batch_source_worktree_refusals_own_execution_refusals():
     assert public_names <= vars(worktree_refusals).keys()
     assert imports_worktree_refusals == {
         apply_action_path: True,
-        include_from_path: True,
+        include_action_path: True,
     }
     for path, old_snippets in old_snippets_by_path.items():
         command_text = path.read_text()
@@ -9754,6 +9837,9 @@ def test_batch_source_text_actions_own_text_file_mutations():
     apply_from_path = SRC_ROOT / "commands" / "apply_from.py"
     apply_action_path = SRC_ROOT / "commands" / "batch_source" / "apply_action.py"
     include_from_path = SRC_ROOT / "commands" / "include_from.py"
+    include_action_path = (
+        SRC_ROOT / "commands" / "batch_source" / "include_action.py"
+    )
     discard_from_path = SRC_ROOT / "commands" / "discard_from.py"
     discard_action_path = (
         SRC_ROOT / "commands" / "batch_source" / "discard_action.py"
@@ -9771,7 +9857,7 @@ def test_batch_source_text_actions_own_text_file_mutations():
     helper_paths = {
         apply_action_path,
         discard_action_path,
-        include_from_path,
+        include_action_path,
     }
     helpers_by_path = {
         path: {
@@ -9779,7 +9865,7 @@ def test_batch_source_text_actions_own_text_file_mutations():
             for node in ast.walk(ast.parse(path.read_text(), filename=str(path)))
             if isinstance(node, (ast.ClassDef, ast.FunctionDef))
         }
-        for path in {*helper_paths, discard_from_path}
+        for path in {*helper_paths, discard_from_path, include_from_path}
     }
     imports_text_file_actions = {
         path: False
@@ -9799,7 +9885,7 @@ def test_batch_source_text_actions_own_text_file_mutations():
     assert imports_text_file_actions == {
         apply_action_path: True,
         discard_action_path: True,
-        include_from_path: True,
+        include_action_path: True,
     }
     for helpers in helpers_by_path.values():
         assert old_names.isdisjoint(helpers)
@@ -9812,24 +9898,27 @@ def test_batch_source_binary_actions_own_index_mutation():
         fromlist=["binary_file_actions"],
     )
     include_from_path = SRC_ROOT / "commands" / "include_from.py"
+    include_action_path = (
+        SRC_ROOT / "commands" / "batch_source" / "include_action.py"
+    )
     public_names = {
         "stage_binary_file_to_index",
     }
     old_names = {
         "_stage_binary_file_from_batch",
     }
-    include_from_tree = ast.parse(
-        include_from_path.read_text(),
-        filename=str(include_from_path),
+    include_action_tree = ast.parse(
+        include_action_path.read_text(),
+        filename=str(include_action_path),
     )
-    include_from_helpers = {
+    include_action_helpers = {
         node.name
-        for node in ast.walk(include_from_tree)
+        for node in ast.walk(include_action_tree)
         if isinstance(node, (ast.ClassDef, ast.FunctionDef))
     }
     imports_binary_file_actions = False
 
-    for imported_module, node in _import_from_nodes(include_from_path):
+    for imported_module, node in _import_from_nodes(include_action_path):
         imported_names = {alias.name for alias in node.names}
         if (
             imported_module == "git_stage_batch.commands.batch_source"
@@ -9839,7 +9928,7 @@ def test_batch_source_binary_actions_own_index_mutation():
 
     assert public_names <= vars(binary_file_actions).keys()
     assert imports_binary_file_actions
-    assert old_names.isdisjoint(include_from_helpers)
+    assert old_names.isdisjoint(include_action_helpers)
 
 
 def test_batch_source_binary_actions_own_worktree_mutation():
@@ -9852,6 +9941,9 @@ def test_batch_source_binary_actions_own_worktree_mutation():
     apply_action_path = SRC_ROOT / "commands" / "batch_source" / "apply_action.py"
     discard_from_path = SRC_ROOT / "commands" / "discard_from.py"
     include_from_path = SRC_ROOT / "commands" / "include_from.py"
+    include_action_path = (
+        SRC_ROOT / "commands" / "batch_source" / "include_action.py"
+    )
     discard_action_path = (
         SRC_ROOT / "commands" / "batch_source" / "discard_action.py"
     )
@@ -9867,7 +9959,7 @@ def test_batch_source_binary_actions_own_worktree_mutation():
     helper_paths = {
         apply_action_path,
         discard_action_path,
-        include_from_path,
+        include_action_path,
     }
     helpers_by_path = {
         path: {
@@ -9875,7 +9967,7 @@ def test_batch_source_binary_actions_own_worktree_mutation():
             for node in ast.walk(ast.parse(path.read_text(), filename=str(path)))
             if isinstance(node, (ast.ClassDef, ast.FunctionDef))
         }
-        for path in {*helper_paths, discard_from_path}
+        for path in {*helper_paths, discard_from_path, include_from_path}
     }
     imports_binary_file_actions = {
         path: False
@@ -9895,7 +9987,7 @@ def test_batch_source_binary_actions_own_worktree_mutation():
     assert imports_binary_file_actions == {
         apply_action_path: True,
         discard_action_path: True,
-        include_from_path: True,
+        include_action_path: True,
     }
     for helpers in helpers_by_path.values():
         assert old_names.isdisjoint(helpers)

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -10400,6 +10400,66 @@ def test_discard_line_selection_stays_in_command_helper():
     assert helper_imports <= helper_imported_names
 
 
+def test_discard_line_action_stays_in_command_helper():
+    """Live discard-line action support should stay out of the entrypoint."""
+    discard_path = SRC_ROOT / "commands" / "discard.py"
+    helper_path = (
+        SRC_ROOT / "commands" / "selection" / "discard_line_action.py"
+    )
+    helper = __import__(
+        "git_stage_batch.commands.selection.discard_line_action",
+        fromlist=["discard_line_action"],
+    )
+    public_names = {"discard_live_line_selection"}
+    action_dependency_names = {
+        "discard_worktree_line_selection",
+        "finish_review_scoped_line_action",
+        "print",
+        "refresh_selected_hunk_after_line_action",
+        "sys",
+        "undo_checkpoint",
+    }
+    helper_imports = {
+        "discard_line_selection",
+        "finish_review_scoped_line_action",
+        "refresh_selected_hunk_after_line_action",
+        "undo_checkpoint",
+    }
+
+    assert public_names <= vars(helper).keys()
+
+    discard_tree = ast.parse(discard_path.read_text(), filename=str(discard_path))
+    discard_functions = {
+        node.name: node
+        for node in ast.walk(discard_tree)
+        if isinstance(node, ast.FunctionDef)
+    }
+    command_discard_line_names = {
+        node.id
+        for node in ast.walk(discard_functions["command_discard_line"])
+        if isinstance(node, ast.Name)
+    }
+    command_discard_line_attributes = {
+        node.attr
+        for node in ast.walk(discard_functions["command_discard_line"])
+        if isinstance(node, ast.Attribute)
+    }
+    discard_selection_imports = set()
+    for imported_module, node in _import_from_nodes(discard_path):
+        if imported_module != "git_stage_batch.commands.selection":
+            continue
+        discard_selection_imports |= {alias.name for alias in node.names}
+
+    helper_imported_names = set()
+    for _imported_module, node in _import_from_nodes(helper_path):
+        helper_imported_names |= {alias.name for alias in node.names}
+
+    assert "discard_line_action" in discard_selection_imports
+    assert "discard_live_line_selection" in command_discard_line_attributes
+    assert action_dependency_names.isdisjoint(command_discard_line_names)
+    assert helper_imports <= helper_imported_names
+
+
 def test_skip_line_selection_stays_in_command_helper():
     """Skip line-selection editing should stay out of the command entrypoint."""
     skip_path = SRC_ROOT / "commands" / "skip.py"

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -1604,7 +1604,9 @@ def test_file_review_records_stay_out_of_state_module():
             "FileReviewAction",
         },
         SRC_ROOT / "commands" / "show.py": {"ReviewSource"},
-        SRC_ROOT / "commands" / "show_from.py": {"ReviewSource"},
+        SRC_ROOT / "commands" / "batch_source" / "file_list_action.py": {
+            "ReviewSource",
+        },
         SRC_ROOT / "commands" / "batch_source" / "replacement_previews.py": {
             "FileReviewAction",
         },

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -8671,6 +8671,36 @@ def test_batch_source_candidate_execution_owns_apply_candidate_side_effects():
     assert helper_imports <= helper_imported_names
 
 
+def test_batch_source_candidate_execution_owns_include_candidate_side_effects():
+    """Include candidate side effects should live in batch-source support."""
+    candidate_execution = __import__(
+        "git_stage_batch.commands.batch_source.candidate_execution",
+        fromlist=["candidate_execution"],
+    )
+    helper_path = (
+        SRC_ROOT / "commands" / "batch_source" / "candidate_execution.py"
+    )
+    public_names = {
+        "execute_include_candidate",
+    }
+    helper_imports = {
+        "ReplacementPayload",
+        "_",
+        "candidate_materialization",
+        "clear_candidate_preview_state_for_file",
+        "snapshot_file_if_untracked",
+        "text_file_actions",
+        "undo_checkpoint",
+    }
+
+    helper_imported_names = set()
+    for _imported_module, node in _import_from_nodes(helper_path):
+        helper_imported_names |= {alias.name for alias in node.names}
+
+    assert public_names <= vars(candidate_execution).keys()
+    assert helper_imports <= helper_imported_names
+
+
 def test_batch_source_candidate_execution_owns_apply_from_flow():
     """Apply-from should delegate reviewed candidate execution."""
     apply_from_path = SRC_ROOT / "commands" / "apply_from.py"

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -3404,6 +3404,43 @@ def test_file_scope_include_file_owns_file_pipeline():
     assert helper_imports <= helper_imported_names
 
 
+def test_file_scope_file_list_action_owns_live_list_rendering():
+    """Live multi-file list rendering should live in file-scope support."""
+    helper = __import__(
+        "git_stage_batch.commands.file_scope.file_list_action",
+        fromlist=["file_list_action"],
+    )
+    helper_path = SRC_ROOT / "commands" / "file_scope" / "file_list_action.py"
+    public_names = {
+        "show_live_file_list",
+    }
+    helper_imports = {
+        "ReviewSource",
+        "clear_selected_change_state_files",
+        "compute_rename_change_hash",
+        "make_binary_file_review_list_entry",
+        "make_file_review_list_entry",
+        "make_gitlink_file_review_list_entry",
+        "make_rename_file_review_list_entry",
+        "make_text_deletion_file_review_list_entry",
+        "mark_selected_change_cleared_by_file_list",
+        "print_file_review_list",
+        "render_binary_file_change",
+        "render_file_as_single_hunk",
+        "render_gitlink_change",
+        "render_rename_change",
+        "render_text_deletion_change",
+        "text_deletion_change_is_batched",
+    }
+
+    helper_imported_names = set()
+    for _imported_module, node in _import_from_nodes(helper_path):
+        helper_imported_names |= {alias.name for alias in node.names}
+
+    assert public_names <= vars(helper).keys()
+    assert helper_imports <= helper_imported_names
+
+
 def test_file_scope_target_path_stays_in_file_scope_support():
     """File-scope target fallback should stay out of command entrypoints."""
     command_paths = {

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -3441,6 +3441,61 @@ def test_file_scope_file_list_action_owns_live_list_rendering():
     assert helper_imports <= helper_imported_names
 
 
+def test_file_scope_file_list_action_owns_show_entry_flow():
+    """The show file-list entrypoint should delegate live list rendering."""
+    show_path = SRC_ROOT / "commands" / "show.py"
+    helper_path = SRC_ROOT / "commands" / "file_scope" / "file_list_action.py"
+    action_dependency_names = {
+        "compute_rename_change_hash",
+        "clear_selected_change_state_files",
+        "make_binary_file_review_list_entry",
+        "make_file_review_list_entry",
+        "make_gitlink_file_review_list_entry",
+        "make_rename_file_review_list_entry",
+        "make_text_deletion_file_review_list_entry",
+        "mark_selected_change_cleared_by_file_list",
+        "print_file_review_list",
+        "render_binary_file_change",
+        "render_file_as_single_hunk",
+        "render_gitlink_change",
+        "render_rename_change",
+        "render_text_deletion_change",
+        "text_deletion_change_is_batched",
+    }
+
+    show_tree = ast.parse(show_path.read_text(), filename=str(show_path))
+    show_functions = {
+        node.name: node
+        for node in ast.walk(show_tree)
+        if isinstance(node, ast.FunctionDef)
+    }
+    command_names = {
+        node.id
+        for node in ast.walk(show_functions["command_show_file_list"])
+        if isinstance(node, ast.Name)
+    }
+    command_attrs = {
+        node.attr
+        for node in ast.walk(show_functions["command_show_file_list"])
+        if isinstance(node, ast.Attribute)
+    }
+    file_scope_imports = set()
+    for imported_module, node in _import_from_nodes(show_path):
+        if imported_module != "git_stage_batch.commands.file_scope":
+            continue
+        file_scope_imports |= {alias.name for alias in node.names}
+
+    helper_imported_names = set()
+    for _imported_module, node in _import_from_nodes(helper_path):
+        helper_imported_names |= {alias.name for alias in node.names}
+
+    assert "file_list_action" in file_scope_imports
+    assert "show_live_file_list" in command_attrs
+    assert action_dependency_names.isdisjoint(command_names)
+    assert action_dependency_names.isdisjoint(command_attrs)
+    assert action_dependency_names <= helper_imported_names
+
+
 def test_file_scope_target_path_stays_in_file_scope_support():
     """File-scope target fallback should stay out of command entrypoints."""
     command_paths = {

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -9285,7 +9285,11 @@ def test_selected_change_loading_stays_out_of_hunk_tracking():
         / "commands"
         / "selection"
         / "include_line_batching.py": {"require_selected_hunk"},
-        SRC_ROOT / "commands" / "discard.py": moved_names,
+        SRC_ROOT / "commands" / "discard.py": {"load_selected_change"},
+        SRC_ROOT
+        / "commands"
+        / "selection"
+        / "discard_line_replacement_action.py": {"require_selected_hunk"},
         SRC_ROOT
         / "commands"
         / "selection"
@@ -11164,7 +11168,6 @@ def test_line_action_refresh_header_stays_in_command_helper():
         / "selection"
         / "include_line_replacement_action.py",
         SRC_ROOT / "commands" / "selection" / "discard_line_action.py",
-        SRC_ROOT / "commands" / "discard.py",
     )
     violations = []
 

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -10345,6 +10345,9 @@ def test_include_line_batching_stays_in_command_helper():
 def test_discard_line_selection_stays_in_command_helper():
     """Discard line-selection editing should stay out of the command entrypoint."""
     discard_path = SRC_ROOT / "commands" / "discard.py"
+    action_path = (
+        SRC_ROOT / "commands" / "selection" / "discard_line_action.py"
+    )
     helper_path = (
         SRC_ROOT / "commands" / "selection" / "discard_line_selection.py"
     )
@@ -10367,6 +10370,7 @@ def test_discard_line_selection_stays_in_command_helper():
         "load_line_changes_from_state",
         "require_selected_hunk",
     }
+    action_imports_helper = False
 
     assert public_names <= vars(helper).keys()
 
@@ -10379,21 +10383,20 @@ def test_discard_line_selection_stays_in_command_helper():
     command_names = {
         node.id for node in ast.walk(command_discard_line) if isinstance(node, ast.Name)
     }
-    discard_imports_helper = False
 
-    for imported_module, node in _import_from_nodes(discard_path):
+    for imported_module, node in _import_from_nodes(action_path):
         if imported_module != "git_stage_batch.commands.selection":
             continue
         imported_names = {alias.name for alias in node.names}
         if "discard_line_selection" in imported_names:
-            discard_imports_helper = True
+            action_imports_helper = True
 
     helper_imported_names = set()
     for _imported_module, node in _import_from_nodes(helper_path):
         helper_imported_names |= {alias.name for alias in node.names}
 
     assert command_level_names.isdisjoint(command_names)
-    assert discard_imports_helper
+    assert action_imports_helper
     assert helper_imports <= helper_imported_names
 
 

--- a/tests/commands/test_candidate_previews.py
+++ b/tests/commands/test_candidate_previews.py
@@ -8,6 +8,7 @@ import pytest
 
 import git_stage_batch.batch.operation_candidates as operation_candidates
 import git_stage_batch.commands.batch_source.action_selection as action_selection
+import git_stage_batch.commands.batch_source.candidate_preview_action as candidate_preview_action
 import git_stage_batch.commands.batch_source.candidate_preview_counts as candidate_preview_counts
 import git_stage_batch.commands.show_from as show_from_module
 import git_stage_batch.output.candidate_preview as candidate_preview_module
@@ -349,6 +350,11 @@ def test_candidate_preview_allows_equivalent_line_selection_spelling(
 
     monkeypatch.setattr(
         show_from_module,
+        "translate_batch_file_gutter_ids_to_selection_ids",
+        resolve_selected_lines,
+    )
+    monkeypatch.setattr(
+        candidate_preview_action,
         "translate_batch_file_gutter_ids_to_selection_ids",
         resolve_selected_lines,
     )

--- a/tests/commands/test_file_review.py
+++ b/tests/commands/test_file_review.py
@@ -19,6 +19,7 @@ from git_stage_batch.commands.include_from import command_include_from_batch
 from git_stage_batch.commands.reset import command_reset_from_batch
 from git_stage_batch.commands.show_from import command_show_from_batch
 import git_stage_batch.commands.show_from as show_from_module
+import git_stage_batch.commands.batch_source.file_display_action as batch_file_display_action
 from git_stage_batch.commands.show import command_show, command_show_file_list
 import git_stage_batch.commands.selection.next_change_display as next_change_display
 from git_stage_batch.commands.skip import command_skip, command_skip_file, command_skip_line
@@ -2534,7 +2535,7 @@ def test_show_from_batch_line_after_review_uses_review_id_space(
         "100644",
     )
 
-    original_render = show_from_module.render_batch_file_display
+    original_render = file_display_module.render_batch_file_display
 
     def render_with_review_only_first_line(batch_name, file_path, metadata=None):
         rendered = original_render(batch_name, file_path, metadata=metadata)
@@ -2565,7 +2566,17 @@ def test_show_from_batch_line_after_review_uses_review_id_space(
             ),
         )
 
-    monkeypatch.setattr(show_from_module, "render_batch_file_display", render_with_review_only_first_line)
+    monkeypatch.setattr(
+        batch_file_display_action,
+        "render_batch_file_display",
+        render_with_review_only_first_line,
+    )
+    if hasattr(show_from_module, "render_batch_file_display"):
+        monkeypatch.setattr(
+            show_from_module,
+            "render_batch_file_display",
+            render_with_review_only_first_line,
+        )
     monkeypatch.setattr(file_display_module, "render_batch_file_display", render_with_review_only_first_line)
     monkeypatch.setattr(
         file_review_freshness_module,
@@ -2663,7 +2674,17 @@ def test_show_from_batch_line_without_review_uses_printed_review_id_space(
             ),
         )
 
-    monkeypatch.setattr(show_from_module, "render_batch_file_display", render_with_review_only_second_line)
+    monkeypatch.setattr(
+        batch_file_display_action,
+        "render_batch_file_display",
+        render_with_review_only_second_line,
+    )
+    if hasattr(show_from_module, "render_batch_file_display"):
+        monkeypatch.setattr(
+            show_from_module,
+            "render_batch_file_display",
+            render_with_review_only_second_line,
+        )
     monkeypatch.setattr(file_display_module, "render_batch_file_display", render_with_review_only_second_line)
     monkeypatch.setattr(
         file_review_freshness_module,

--- a/tests/commands/test_file_scope_actions.py
+++ b/tests/commands/test_file_scope_actions.py
@@ -107,7 +107,16 @@ def test_include_each_resolved_file_reports_aggregate_result(
         include_calls.append((file_path, quiet, advance))
         return {"alpha.txt": 2, "beta.txt": 0}[file_path]
 
-    monkeypatch.setattr(multi_file_actions, "command_include_file", fake_include_file)
+    monkeypatch.setattr(
+        multi_file_actions,
+        "_prepare_live_multi_file_action",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        multi_file_actions._include_file,
+        "include_file_changes",
+        fake_include_file,
+    )
     monkeypatch.setattr(
         multi_file_actions,
         "select_next_change_after_action",
@@ -150,7 +159,16 @@ def test_skip_each_resolved_file_stops_after_empty_result(
         skip_calls.append((file_path, quiet, advance))
         return 0
 
-    monkeypatch.setattr(multi_file_actions, "command_skip_file", fake_skip_file)
+    monkeypatch.setattr(
+        multi_file_actions,
+        "_prepare_live_multi_file_action",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        multi_file_actions._skip_file,
+        "skip_file_changes",
+        fake_skip_file,
+    )
     monkeypatch.setattr(
         multi_file_actions,
         "select_next_change_after_action",

--- a/tests/commands/test_reset.py
+++ b/tests/commands/test_reset.py
@@ -5,6 +5,7 @@ import subprocess
 import pytest
 
 import git_stage_batch.commands.batch_source.reset_claims as reset_claims
+import git_stage_batch.commands.batch_source.file_display_action as batch_file_display_action
 import git_stage_batch.commands.reset as reset_module
 import git_stage_batch.commands.show_from as show_from_module
 import git_stage_batch.batch.file_display as file_display_module
@@ -301,7 +302,17 @@ class TestResetFromBatch:
             )
 
         monkeypatch.setattr(batch_review_selection_module, "render_batch_file_display", render_with_shifted_gutter)
-        monkeypatch.setattr(show_from_module, "render_batch_file_display", render_with_shifted_gutter)
+        monkeypatch.setattr(
+            batch_file_display_action,
+            "render_batch_file_display",
+            render_with_shifted_gutter,
+        )
+        if hasattr(show_from_module, "render_batch_file_display"):
+            monkeypatch.setattr(
+                show_from_module,
+                "render_batch_file_display",
+                render_with_shifted_gutter,
+            )
         monkeypatch.setattr(file_display_module, "render_batch_file_display", render_with_shifted_gutter)
         monkeypatch.setattr(file_review_freshness_module, "render_batch_file_display", render_with_shifted_gutter)
 
@@ -349,7 +360,17 @@ class TestResetFromBatch:
             )
 
         monkeypatch.setattr(batch_review_selection_module, "render_batch_file_display", render_with_shifted_gutter)
-        monkeypatch.setattr(show_from_module, "render_batch_file_display", render_with_shifted_gutter)
+        monkeypatch.setattr(
+            batch_file_display_action,
+            "render_batch_file_display",
+            render_with_shifted_gutter,
+        )
+        if hasattr(show_from_module, "render_batch_file_display"):
+            monkeypatch.setattr(
+                show_from_module,
+                "render_batch_file_display",
+                render_with_shifted_gutter,
+            )
         monkeypatch.setattr(file_display_module, "render_batch_file_display", render_with_shifted_gutter)
         monkeypatch.setattr(file_review_freshness_module, "render_batch_file_display", render_with_shifted_gutter)
 
@@ -413,7 +434,17 @@ class TestResetFromBatch:
             )
 
         monkeypatch.setattr(batch_review_selection_module, "render_batch_file_display", render_with_shifted_gutter)
-        monkeypatch.setattr(show_from_module, "render_batch_file_display", render_with_shifted_gutter)
+        monkeypatch.setattr(
+            batch_file_display_action,
+            "render_batch_file_display",
+            render_with_shifted_gutter,
+        )
+        if hasattr(show_from_module, "render_batch_file_display"):
+            monkeypatch.setattr(
+                show_from_module,
+                "render_batch_file_display",
+                render_with_shifted_gutter,
+            )
         monkeypatch.setattr(file_display_module, "render_batch_file_display", render_with_shifted_gutter)
         monkeypatch.setattr(file_review_freshness_module, "render_batch_file_display", render_with_shifted_gutter)
 

--- a/tests/commands/test_show_from.py
+++ b/tests/commands/test_show_from.py
@@ -12,6 +12,7 @@ import git_stage_batch.batch.display as display_module
 import git_stage_batch.batch.file_display as file_display
 import git_stage_batch.data.selected_change.paths as selected_change_paths
 import git_stage_batch.commands.show_from as show_from_module
+import git_stage_batch.commands.batch_source.file_list_action as file_list_action
 
 import subprocess
 
@@ -457,7 +458,13 @@ class TestCommandShowFromBatch:
                 probe_mergeability=probe_mergeability,
             )
 
-        monkeypatch.setattr(show_from_module, "render_batch_file_display", counting_render)
+        monkeypatch.setattr(file_list_action, "render_batch_file_display", counting_render)
+        if hasattr(show_from_module, "render_batch_file_display"):
+            monkeypatch.setattr(
+                show_from_module,
+                "render_batch_file_display",
+                counting_render,
+            )
 
         command_show_from_batch("multi-file-batch")
 


### PR DESCRIPTION
Skip, fixup, and line-action flows now have focused support modules, while
selection action variants and parser construction still share broader
command and CLI files.

The project lacks a clear command surface for selected-line, selected-file,
file-scope, and batch-source action variants, and CLI parser setup remains
hard to navigate.

This PR moves selection actions, file-scope helpers, batch-source command
support, and subcommand parser construction behind focused modules.

The next PR will use that parser seam to move individual CLI registration
and batch content helpers.

Test plan: .venv/bin/python -m pytest -n auto passed on the final stack tip
  before landing; each PR branch is rebased without code changes before
  merge.
