### PR TITLE
architecture: Split undo output and TUI prompts

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -175,7 +175,7 @@ Important modules include:
 - `data.selected_change`
   Persistence, loading, snapshots, stale-cache validation, and file-scoped views
   for the current selected change.
-- `data.undo`
+- `data.undo_checkpoints`
   Undo/redo checkpoints for session operations.
 - `data.line_state`
   Serialization of the currently selected line-level view.

--- a/src/git_stage_batch/commands/annotate.py
+++ b/src/git_stage_batch/commands/annotate.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from ..batch.lifecycle import update_batch_note
 from ..batch.source_selector import require_plain_batch_name
 import sys
-from ..data.undo import undo_checkpoint
+from ..data.undo_checkpoints import undo_checkpoint
 from ..i18n import _
 from ..utils.git_repository import require_git_repository
 

--- a/src/git_stage_batch/commands/batch_source/apply_action.py
+++ b/src/git_stage_batch/commands/batch_source/apply_action.py
@@ -22,7 +22,7 @@ from ...batch.submodule_pointer import (
     is_batch_submodule_pointer,
 )
 from ...data.session import snapshot_file_if_untracked
-from ...data.undo import undo_checkpoint
+from ...data.undo_checkpoints import undo_checkpoint
 from ...exceptions import (
     AtomicUnitError,
     CommandError,

--- a/src/git_stage_batch/commands/batch_source/candidate_execution.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_execution.py
@@ -9,7 +9,7 @@ from . import text_file_actions as _text_file_actions
 from ...batch.operation_candidate_state import clear_candidate_preview_state_for_file
 from ...core.replacement import ReplacementPayload
 from ...data.session import snapshot_file_if_untracked
-from ...data.undo import undo_checkpoint
+from ...data.undo_checkpoints import undo_checkpoint
 from ...i18n import _
 
 

--- a/src/git_stage_batch/commands/batch_source/discard_action.py
+++ b/src/git_stage_batch/commands/batch_source/discard_action.py
@@ -15,7 +15,7 @@ from ...batch.submodule_pointer import (
     is_batch_submodule_pointer,
 )
 from ...data.session import snapshot_file_if_untracked
-from ...data.undo import undo_checkpoint
+from ...data.undo_checkpoints import undo_checkpoint
 from ...exceptions import (
     AtomicUnitError,
     BatchMetadataError,

--- a/src/git_stage_batch/commands/batch_source/include_action.py
+++ b/src/git_stage_batch/commands/batch_source/include_action.py
@@ -23,7 +23,7 @@ from ...batch.submodule_pointer import (
 )
 from ...core.replacement import ReplacementPayload
 from ...data.session import snapshot_file_if_untracked
-from ...data.undo import undo_checkpoint
+from ...data.undo_checkpoints import undo_checkpoint
 from ...exceptions import (
     AtomicUnitError,
     CommandError,

--- a/src/git_stage_batch/commands/block_file.py
+++ b/src/git_stage_batch/commands/block_file.py
@@ -7,7 +7,7 @@ from contextlib import nullcontext
 from pathlib import Path
 
 from ..data.session import session_is_active
-from ..data.undo import undo_checkpoint
+from ..data.undo_checkpoints import undo_checkpoint
 from ..data.ignore_files import (
     add_file_to_local_exclude,
     add_file_to_gitignore,

--- a/src/git_stage_batch/commands/drop.py
+++ b/src/git_stage_batch/commands/drop.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from ..batch.lifecycle import delete_batch
 from ..batch.source_selector import require_plain_batch_name
 import sys
-from ..data.undo import undo_checkpoint
+from ..data.undo_checkpoints import undo_checkpoint
 from ..i18n import _
 from ..utils.git_repository import require_git_repository
 

--- a/src/git_stage_batch/commands/file_scope/discard_file.py
+++ b/src/git_stage_batch/commands/file_scope/discard_file.py
@@ -23,7 +23,7 @@ from ...data.live_diff import stream_live_git_diff
 from ...data.progress import record_hunk_discarded
 from ...data.selected_change.paths import get_selected_change_file_path
 from ...data.session import snapshot_file_if_untracked
-from ...data.undo import undo_checkpoint
+from ...data.undo_checkpoints import undo_checkpoint
 from ...i18n import _
 from ...utils.file_io import append_lines_to_file, read_text_file_line_set
 from ...utils.git_command import run_git_command

--- a/src/git_stage_batch/commands/file_scope/discard_file_replacement.py
+++ b/src/git_stage_batch/commands/file_scope/discard_file_replacement.py
@@ -13,7 +13,7 @@ from ...data.selected_change.store import (
     snapshot_selected_change_state,
 )
 from ...data.session import snapshot_file_if_untracked
-from ...data.undo import undo_checkpoint
+from ...data.undo_checkpoints import undo_checkpoint
 from ...exceptions import exit_with_error
 from ...i18n import _
 from ...utils.git_repository import get_git_repository_root_path

--- a/src/git_stage_batch/commands/file_scope/include_file.py
+++ b/src/git_stage_batch/commands/file_scope/include_file.py
@@ -18,7 +18,7 @@ from ...data.file_tracking import auto_add_untracked_files
 from ...data.live_diff import stream_live_git_diff
 from ...data.progress import record_hunk_included
 from ...data.selected_change.paths import get_selected_change_file_path
-from ...data.undo import undo_checkpoint
+from ...data.undo_checkpoints import undo_checkpoint
 from ...i18n import _, ngettext
 from ...staging.index_update import update_index_with_blob_buffer
 from ...utils.git_command import run_git_command

--- a/src/git_stage_batch/commands/file_scope/include_file_replacement.py
+++ b/src/git_stage_batch/commands/file_scope/include_file_replacement.py
@@ -21,7 +21,7 @@ from ...data.selected_change.store import (
     restore_selected_change_state,
     snapshot_selected_change_state,
 )
-from ...data.undo import undo_checkpoint
+from ...data.undo_checkpoints import undo_checkpoint
 from ...exceptions import exit_with_error
 from ...i18n import _
 from ...staging.index_update import update_index_with_blob_buffer

--- a/src/git_stage_batch/commands/file_scope/multi_file_actions.py
+++ b/src/git_stage_batch/commands/file_scope/multi_file_actions.py
@@ -10,7 +10,7 @@ from typing import Protocol
 
 from ...data.hunk_tracking import select_next_change_after_action
 from ...data.session import require_session_started
-from ...data.undo import undo_checkpoint
+from ...data.undo_checkpoints import undo_checkpoint
 from ...exceptions import CommandError
 from ...i18n import _, ngettext
 from ...utils.git_repository import require_git_repository

--- a/src/git_stage_batch/commands/file_scope/skip_file.py
+++ b/src/git_stage_batch/commands/file_scope/skip_file.py
@@ -28,7 +28,7 @@ from ...data.progress import (
     record_text_deletion_hunk_skipped,
 )
 from ...data.selected_change.paths import get_selected_change_file_path
-from ...data.undo import undo_checkpoint
+from ...data.undo_checkpoints import undo_checkpoint
 from ...i18n import _, ngettext
 from ...utils.file_io import append_lines_to_file, read_text_file_line_set
 from ...utils.paths import get_block_list_file_path, get_context_lines

--- a/src/git_stage_batch/commands/new.py
+++ b/src/git_stage_batch/commands/new.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from ..batch.lifecycle import create_batch
 from ..batch.source_selector import require_plain_batch_name
 import sys
-from ..data.undo import undo_checkpoint
+from ..data.undo_checkpoints import undo_checkpoint
 from ..i18n import _
 from ..utils.git_repository import require_git_repository
 

--- a/src/git_stage_batch/commands/redo.py
+++ b/src/git_stage_batch/commands/redo.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import sys
 
 from ..data.session import require_session_started
-from ..data.undo import redo_last_checkpoint
+from ..data.undo_checkpoints import redo_last_checkpoint
 from ..i18n import _
 from ..utils.git_repository import require_git_repository
 

--- a/src/git_stage_batch/commands/reset.py
+++ b/src/git_stage_batch/commands/reset.py
@@ -8,7 +8,7 @@ from .batch_source import reset_claims as _reset_claims
 from .batch_source import reset_selection as _reset_selection
 from .batch_source import selection_state_cleanup as _selection_state_cleanup
 from ..i18n import _
-from ..data.undo import undo_checkpoint
+from ..data.undo_checkpoints import undo_checkpoint
 from ..utils.git_repository import require_git_repository
 from ..utils.paths import ensure_state_directory_exists
 

--- a/src/git_stage_batch/commands/selection/discard_line_action.py
+++ b/src/git_stage_batch/commands/selection/discard_line_action.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import sys
 
 from ...data.file_review.action_scope import finish_review_scoped_line_action
-from ...data.undo import undo_checkpoint
+from ...data.undo_checkpoints import undo_checkpoint
 from ...i18n import _
 from . import discard_line_selection as _discard_line_selection
 from .selected_hunk_refresh import refresh_selected_hunk_after_line_action

--- a/src/git_stage_batch/commands/selection/discard_line_replacement_action.py
+++ b/src/git_stage_batch/commands/selection/discard_line_replacement_action.py
@@ -9,7 +9,7 @@ from ...data.selected_change.store import (
     restore_selected_change_state,
     snapshot_selected_change_state,
 )
-from ...data.undo import undo_checkpoint
+from ...data.undo_checkpoints import undo_checkpoint
 from ..file_scope.target_path import require_file_scope_target_path
 from . import discard_file_selection as _discard_file_selection
 from . import discard_line_batching as _discard_line_batching

--- a/src/git_stage_batch/commands/selection/discard_to_batch_action.py
+++ b/src/git_stage_batch/commands/selection/discard_to_batch_action.py
@@ -9,7 +9,7 @@ from ...data.selected_change.store import (
     SelectedChangeKind,
     read_selected_change_kind,
 )
-from ...data.undo import undo_checkpoint
+from ...data.undo_checkpoints import undo_checkpoint
 from ...exceptions import exit_with_error
 from ...i18n import _
 from ..file_scope import discard_file_to_batch as _file_scope_discard_file_to_batch

--- a/src/git_stage_batch/commands/selection/include_line_action.py
+++ b/src/git_stage_batch/commands/selection/include_line_action.py
@@ -16,7 +16,7 @@ from ...data.selected_change.store import (
     read_selected_change_kind,
     restore_selected_change_state,
 )
-from ...data.undo import undo_checkpoint
+from ...data.undo_checkpoints import undo_checkpoint
 from ...exceptions import exit_with_error
 from ...i18n import _
 from ...staging.content_buffers import build_target_index_buffer_from_lines

--- a/src/git_stage_batch/commands/selection/include_line_replacement_action.py
+++ b/src/git_stage_batch/commands/selection/include_line_replacement_action.py
@@ -9,7 +9,7 @@ from ...core.replacement import ReplacementPayload, coerce_replacement_payload
 from ...data.file_review.action_scope import finish_review_scoped_line_action
 from ...data.line_id_files import write_line_ids_file
 from ...data.selected_change.store import restore_selected_change_state
-from ...data.undo import undo_checkpoint
+from ...data.undo_checkpoints import undo_checkpoint
 from ...i18n import _
 from ...utils.paths import get_processed_include_ids_file_path
 from . import include_line_replacement as _include_line_replacement

--- a/src/git_stage_batch/commands/selection/include_to_batch_action.py
+++ b/src/git_stage_batch/commands/selection/include_to_batch_action.py
@@ -14,7 +14,7 @@ from ...data.selected_change.store import (
     SelectedChangeKind,
     read_selected_change_kind,
 )
-from ...data.undo import undo_checkpoint
+from ...data.undo_checkpoints import undo_checkpoint
 from ...exceptions import exit_with_error
 from ...i18n import _
 from ..file_scope import include_file_to_batch as _file_scope_include_file_to_batch

--- a/src/git_stage_batch/commands/selection/selected_change_discarding.py
+++ b/src/git_stage_batch/commands/selection/selected_change_discarding.py
@@ -18,7 +18,7 @@ from ...data.hunk_tracking import fetch_next_change
 from ...data.progress import record_hunk_discarded
 from ...data.selected_change.loading import load_selected_change
 from ...data.session import snapshot_file_if_untracked, snapshot_files_if_untracked
-from ...data.undo import undo_checkpoint
+from ...data.undo_checkpoints import undo_checkpoint
 from ...exceptions import CommandError, NoMoreHunks, exit_with_error
 from ...i18n import _
 from ...utils.file_io import append_lines_to_file, path_is_empty, read_text_file_contents

--- a/src/git_stage_batch/commands/selection/selected_change_skipping.py
+++ b/src/git_stage_batch/commands/selection/selected_change_skipping.py
@@ -19,7 +19,7 @@ from ...data.progress import (
     record_text_deletion_hunk_skipped,
 )
 from ...data.selected_change.loading import load_selected_change
-from ...data.undo import undo_checkpoint
+from ...data.undo_checkpoints import undo_checkpoint
 from ...exceptions import NoMoreHunks
 from ...i18n import _
 from ...utils.file_io import append_lines_to_file, read_text_file_contents

--- a/src/git_stage_batch/commands/selection/selected_change_staging.py
+++ b/src/git_stage_batch/commands/selection/selected_change_staging.py
@@ -17,7 +17,7 @@ from ...data.hunk_tracking import fetch_next_change
 from ...data.index_entries import read_index_entry
 from ...data.progress import record_hunk_included
 from ...data.selected_change.loading import load_selected_change
-from ...data.undo import undo_checkpoint
+from ...data.undo_checkpoints import undo_checkpoint
 from ...exceptions import NoMoreHunks, exit_with_error
 from ...i18n import _
 from ...staging.index_update import update_index_with_blob_buffer

--- a/src/git_stage_batch/commands/selection/selected_file_discarding.py
+++ b/src/git_stage_batch/commands/selection/selected_file_discarding.py
@@ -6,7 +6,7 @@ import sys
 
 from ...data.selected_change.paths import get_selected_change_file_path
 from ...data.session import snapshot_file_if_untracked
-from ...data.undo import undo_checkpoint
+from ...data.undo_checkpoints import undo_checkpoint
 from ...i18n import _
 from ...utils.git_command import run_git_command
 from ...utils.git_worktree import git_checkout_paths

--- a/src/git_stage_batch/commands/selection/skip_line_selection.py
+++ b/src/git_stage_batch/commands/selection/skip_line_selection.py
@@ -24,7 +24,7 @@ from ...data.selected_change.store import (
     SelectedChangeKind,
     read_selected_change_kind,
 )
-from ...data.undo import undo_checkpoint
+from ...data.undo_checkpoints import undo_checkpoint
 from ...exceptions import NoMoreHunks, exit_with_error
 from ...i18n import _
 from ...output.hunk import (

--- a/src/git_stage_batch/commands/unblock_file.py
+++ b/src/git_stage_batch/commands/unblock_file.py
@@ -7,7 +7,7 @@ from contextlib import nullcontext
 from pathlib import Path
 
 from ..data.session import session_is_active
-from ..data.undo import undo_checkpoint
+from ..data.undo_checkpoints import undo_checkpoint
 from ..data.ignore_files import (
     add_file_to_gitignore,
     add_file_to_local_exclude,

--- a/src/git_stage_batch/commands/undo.py
+++ b/src/git_stage_batch/commands/undo.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import sys
 
 from ..data.session import require_session_started
-from ..data.undo import undo_last_checkpoint
+from ..data.undo_checkpoints import undo_last_checkpoint
 from ..i18n import _
 from ..utils.git_repository import require_git_repository
 

--- a/src/git_stage_batch/data/undo_checkpoints.py
+++ b/src/git_stage_batch/data/undo_checkpoints.py
@@ -1,4 +1,4 @@
-"""Undo checkpoint orchestration."""
+"""Undo checkpoint stack orchestration."""
 
 from __future__ import annotations
 

--- a/src/git_stage_batch/output/candidate_preview.py
+++ b/src/git_stage_batch/output/candidate_preview.py
@@ -4,12 +4,7 @@ from __future__ import annotations
 
 import json
 
-from ..batch.operation_candidates import (
-    OperationCandidatePreview,
-    render_candidate_buffer_diff,
-)
-from ..core.buffer import LineBuffer
-from ..core.diff_parser import build_line_changes_from_patch_lines
+from ..batch.operation_candidates import OperationCandidatePreview
 from ..i18n import _
 from ..utils.paths import get_context_lines
 from . import candidate_preview_summary
@@ -18,6 +13,7 @@ from .candidate_preview_commands import (
     execute_candidate_command,
     show_candidate_command,
 )
+from .candidate_preview_diff import print_candidate_buffer_diff
 from .colors import Colors
 
 
@@ -116,120 +112,6 @@ def _style_candidate_snippet_line(
     if line.marker == "-":
         return f"{Colors.GRAY}{gutter}{Colors.RESET}{Colors.RED}{body}{Colors.RESET}"
     return f"{Colors.GRAY}{gutter}{Colors.RESET}{body}"
-
-
-def _candidate_diff_hunks(diff_text: str) -> tuple[tuple[bytes, ...], ...]:
-    headers: list[bytes] = []
-    current_hunk: list[bytes] = []
-    hunks: list[tuple[bytes, ...]] = []
-    for line in diff_text.splitlines(keepends=True):
-        line_bytes = line.encode("utf-8", errors="surrogateescape")
-        if line_bytes.startswith((b"--- ", b"+++ ")):
-            headers.append(line_bytes)
-            continue
-        if line_bytes.startswith(b"@@ "):
-            if current_hunk:
-                hunks.append(tuple(headers + current_hunk))
-            current_hunk = [line_bytes]
-            continue
-        if current_hunk:
-            current_hunk.append(line_bytes)
-
-    if current_hunk:
-        hunks.append(tuple(headers + current_hunk))
-    return tuple(hunks)
-
-
-def _candidate_line_number(line) -> int | None:
-    if line.kind == "+":
-        return line.new_line_number
-    return line.old_line_number if line.old_line_number is not None else line.new_line_number
-
-
-def _print_candidate_line_changes(
-    line_changes,
-    *,
-    ambiguity_target_line_range: tuple[int, int] | None,
-) -> None:
-    use_color = Colors.enabled()
-    header = line_changes.header
-    header_part = f"@@ -{header.old_start},{header.old_len} +{header.new_start},{header.new_len} @@"
-    if use_color:
-        print(f"{Colors.BOLD}{line_changes.path}{Colors.RESET} :: {Colors.CYAN}{header_part}{Colors.RESET}")
-    else:
-        print(f"{line_changes.path} :: {header_part}")
-
-    line_numbers = [
-        line_number
-        for line_number in (_candidate_line_number(line) for line in line_changes.lines)
-        if line_number is not None
-    ]
-    width = max((len(str(line_number)) for line_number in line_numbers), default=1)
-
-    for line in line_changes.lines:
-        line_number = _candidate_line_number(line)
-        gutter_number = " " * width if line_number is None else f"{line_number:>{width}}"
-        gutter = (
-            f"{gutter_number}"
-            f"{candidate_preview_summary.CANDIDATE_GUTTER_SEPARATOR} "
-        )
-        body = f"{line.kind}{line.display_text()}"
-
-        if not use_color:
-            print(f"{gutter}{body}")
-            continue
-
-        styled_gutter = f"{Colors.GRAY}{gutter}{Colors.RESET}"
-        if line.kind == "+":
-            print(f"{styled_gutter}{Colors.GREEN}{body}{Colors.RESET}")
-        elif line.kind == "-":
-            print(f"{styled_gutter}{Colors.RED}{body}{Colors.RESET}")
-        elif candidate_preview_summary.candidate_line_in_range(
-            line_number,
-            ambiguity_target_line_range,
-        ):
-            print(f"{styled_gutter}{Colors.REVERSE}{Colors.GRAY}{body}{Colors.RESET}")
-        else:
-            print(f"{styled_gutter}{body}")
-
-
-def _print_candidate_buffer_diff(
-    file_path: str,
-    before_buffer: LineBuffer,
-    after_buffer: LineBuffer,
-    *,
-    context_lines: int,
-    ambiguity_target_line_range: tuple[int, int] | None,
-    leading_blank: bool = False,
-) -> bool:
-    diff_text = render_candidate_buffer_diff(
-        file_path,
-        before_buffer,
-        after_buffer,
-        label_before="a",
-        label_after="b",
-        context_lines=context_lines,
-    )
-    if not diff_text:
-        return False
-
-    if leading_blank:
-        print()
-
-    hunks = _candidate_diff_hunks(diff_text)
-    if not hunks:
-        print(diff_text, end="" if diff_text.endswith("\n") else "\n")
-        return True
-
-    for index, hunk in enumerate(hunks):
-        if index:
-            print()
-        line_changes = build_line_changes_from_patch_lines(hunk)
-        _print_candidate_line_changes(
-            line_changes,
-            ambiguity_target_line_range=ambiguity_target_line_range,
-        )
-    return True
 
 
 def _print_candidate_summary_block(
@@ -454,7 +336,7 @@ def render_operation_candidate(
             )
         else:
             print(summary.title)
-        _print_candidate_buffer_diff(
+        print_candidate_buffer_diff(
             preview.file_path,
             target.before_buffer,
             target.after_buffer,

--- a/src/git_stage_batch/output/candidate_preview.py
+++ b/src/git_stage_batch/output/candidate_preview.py
@@ -7,6 +7,7 @@ import json
 from ..batch.operation_candidates import OperationCandidatePreview
 from ..i18n import _
 from ..utils.paths import get_context_lines
+from . import candidate_preview_snippets
 from . import candidate_preview_summary
 from .candidate_preview_commands import (
     candidate_selector_text,
@@ -89,7 +90,7 @@ def _print_candidate_detail_header(
 
 
 def _style_candidate_snippet_line(
-    line: candidate_preview_summary.CandidateSnippetLine,
+    line: candidate_preview_snippets.CandidateSnippetLine,
     *,
     width: int,
 ) -> str:
@@ -99,11 +100,11 @@ def _style_candidate_snippet_line(
 
     line_number = " " * width if line.line_number is None else f"{line.line_number:>{width}}"
     gutter = (
-        f"{line_number}{candidate_preview_summary.CANDIDATE_GUTTER_SEPARATOR} "
+        f"{line_number}{candidate_preview_snippets.CANDIDATE_GUTTER_SEPARATOR} "
     )
     body = (
         f"{line.marker}"
-        f"{candidate_preview_summary.shorten_candidate_overview_text(line.text)}"
+        f"{candidate_preview_snippets.shorten_candidate_overview_text(line.text)}"
     )
     if line.highlight:
         return f"{Colors.GRAY}{gutter}{Colors.RESET}{Colors.REVERSE}{Colors.GRAY}{body}{Colors.RESET}"
@@ -119,7 +120,7 @@ def _print_candidate_summary_block(
     *,
     indent: str,
 ) -> None:
-    width = candidate_preview_summary.snippet_line_width(summary.lines)
+    width = candidate_preview_snippets.snippet_line_width(summary.lines)
     for line in summary.lines:
         print(f"{indent}{_style_candidate_snippet_line(line, width=width)}")
 
@@ -198,7 +199,7 @@ def render_operation_candidate_overview(
                             "target": target.target,
                             "summary": summary.title,
                             "context": list(
-                                candidate_preview_summary.plain_candidate_snippet_lines(
+                                candidate_preview_snippets.plain_candidate_snippet_lines(
                                     summary.lines
                                 )
                             ),

--- a/src/git_stage_batch/output/candidate_preview.py
+++ b/src/git_stage_batch/output/candidate_preview.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import shlex
 
 from ..batch.operation_candidates import (
     OperationCandidatePreview,
@@ -14,43 +13,15 @@ from ..core.diff_parser import build_line_changes_from_patch_lines
 from ..i18n import _
 from ..utils.paths import get_context_lines
 from . import candidate_preview_summary
+from .candidate_preview_commands import (
+    candidate_selector_text,
+    execute_candidate_command,
+    show_candidate_command,
+)
 from .colors import Colors
 
 
 _CANDIDATE_OVERVIEW_MAX_CANDIDATES = 10
-
-
-def _candidate_selector_text(
-    batch_name: str,
-    operation: str,
-    ordinal: int | None = None,
-) -> str:
-    if ordinal is None:
-        return f"{batch_name}:{operation}"
-    return f"{batch_name}:{operation}:{ordinal}"
-
-
-def _show_candidate_command(preview: OperationCandidatePreview, ordinal: int | None = None) -> str:
-    return "git-stage-batch show --from {selector} --file {file}".format(
-        selector=_candidate_selector_text(
-            preview.batch_name,
-            preview.operation,
-            ordinal,
-        ),
-        file=shlex.quote(preview.file_path),
-    )
-
-
-def _execute_candidate_command(preview: OperationCandidatePreview) -> str:
-    return "git-stage-batch {command} --from {selector} --file {file}".format(
-        command=preview.operation,
-        selector=_candidate_selector_text(
-            preview.batch_name,
-            preview.operation,
-            preview.ordinal,
-        ),
-        file=shlex.quote(preview.file_path),
-    )
 
 
 def _candidate_choice_count(count: int) -> str:
@@ -326,24 +297,18 @@ def render_operation_candidate_overview(
             "candidates": [
                 {
                     "ordinal": preview.ordinal,
-                    "selector": _candidate_selector_text(
+                    "selector": candidate_selector_text(
                         preview.batch_name,
                         preview.operation,
                         preview.ordinal,
                     ),
                     "commands": {
-                        "preview": (
-                            "git-stage-batch show --from {selector} --file {file}".format(
-                                selector=_candidate_selector_text(
-                                    preview.batch_name,
-                                    preview.operation,
-                                    preview.ordinal,
-                                ),
-                                file=shlex.quote(preview.file_path),
-                            )
+                        "preview": show_candidate_command(
+                            preview,
+                            preview.ordinal,
                         ),
                         "execute": (
-                            _execute_candidate_command(preview)
+                            execute_candidate_command(preview)
                         ),
                     },
                     "targets": [
@@ -411,9 +376,9 @@ def render_operation_candidate_overview(
                 _print_candidate_summary_block(summary, indent="      ")
         action = _("Apply") if preview.operation == "apply" else _("Include")
         print(f"   {_('Preview this candidate:')}")
-        print(f"     {_show_candidate_command(preview, preview.ordinal)}")
+        print(f"     {show_candidate_command(preview, preview.ordinal)}")
         print(f"   {_('{action} this candidate:').format(action=action)}")
-        print(f"     {_execute_candidate_command(preview)}")
+        print(f"     {execute_candidate_command(preview)}")
         print()
 
     if len(previews) > len(shown_previews):
@@ -421,7 +386,10 @@ def render_operation_candidate_overview(
         print(
             _("... {count} more candidates. Preview another candidate with {selector}:N.").format(
                 count=remaining,
-                selector=_candidate_selector_text(first.batch_name, first.operation),
+                selector=candidate_selector_text(
+                    first.batch_name,
+                    first.operation,
+                ),
             )
         )
         print()
@@ -500,19 +468,19 @@ def render_operation_candidate(
     print(
         _("{action} this candidate:\n  {command}").format(
             action=action,
-            command=_execute_candidate_command(preview),
+            command=execute_candidate_command(preview),
         ),
     )
     print()
     print(_("Review candidates:"))
     print(_("  overview: {command}").format(
-        command=_show_candidate_command(preview),
+        command=show_candidate_command(preview),
     ))
     if preview.ordinal > 1:
         print(_("  previous: {command}").format(
-            command=_show_candidate_command(preview, preview.ordinal - 1),
+            command=show_candidate_command(preview, preview.ordinal - 1),
         ))
     if preview.ordinal < preview.count:
         print(_("  next: {command}").format(
-            command=_show_candidate_command(preview, preview.ordinal + 1),
+            command=show_candidate_command(preview, preview.ordinal + 1),
         ))

--- a/src/git_stage_batch/output/candidate_preview.py
+++ b/src/git_stage_batch/output/candidate_preview.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import json
-
 from ..batch.operation_candidates import OperationCandidatePreview
 from ..i18n import _
 from ..utils.paths import get_context_lines
@@ -15,6 +13,7 @@ from .candidate_preview_commands import (
     show_candidate_command,
 )
 from .candidate_preview_diff import print_candidate_buffer_diff
+from . import candidate_preview_porcelain
 from .colors import Colors
 
 
@@ -166,50 +165,10 @@ def render_operation_candidate_overview(
     ]
 
     if porcelain:
-        print(json.dumps({
-            "status": "candidates",
-            "changed": False,
-            "batch": first.batch_name,
-            "selector": {
-                "operation": first.operation,
-                "count": len(previews),
-            },
-            "scope": {
-                "file": first.file_path,
-            },
-            "candidates": [
-                {
-                    "ordinal": preview.ordinal,
-                    "selector": candidate_selector_text(
-                        preview.batch_name,
-                        preview.operation,
-                        preview.ordinal,
-                    ),
-                    "commands": {
-                        "preview": show_candidate_command(
-                            preview,
-                            preview.ordinal,
-                        ),
-                        "execute": (
-                            execute_candidate_command(preview)
-                        ),
-                    },
-                    "targets": [
-                        {
-                            "target": target.target,
-                            "summary": summary.title,
-                            "context": list(
-                                candidate_preview_snippets.plain_candidate_snippet_lines(
-                                    summary.lines
-                                )
-                            ),
-                        }
-                        for target, summary in zip(preview.targets, summaries)
-                    ],
-                }
-                for preview, summaries in zip(previews, candidate_summaries)
-            ],
-        }, sort_keys=True))
+        candidate_preview_porcelain.print_operation_candidate_overview_porcelain(
+            previews,
+            candidate_summaries,
+        )
         return previews
 
     targets, verb = candidate_preview_summary.candidate_overview_subject(previews)
@@ -291,30 +250,7 @@ def render_operation_candidate(
     note: str | None,
 ) -> None:
     if porcelain:
-        print(json.dumps({
-            "status": "candidate",
-            "changed": False,
-            "batch": preview.batch_name,
-            "selector": {
-                "operation": preview.operation,
-                "ordinal": preview.ordinal,
-                "count": preview.count,
-                "id": preview.candidate_id,
-            },
-            "scope": {
-                "file": preview.file_path,
-            },
-            "targets": [
-                {
-                    "target": target.target,
-                    "file": target.file_path,
-                    "summary": target.summary,
-                    "resolution_ordinal": target.resolution_ordinal,
-                    "resolution_count": target.resolution_count,
-                }
-                for target in preview.targets
-            ],
-        }, sort_keys=True))
+        candidate_preview_porcelain.print_operation_candidate_porcelain(preview)
         return
 
     _print_candidate_detail_header(preview, note=note)

--- a/src/git_stage_batch/output/candidate_preview_commands.py
+++ b/src/git_stage_batch/output/candidate_preview_commands.py
@@ -1,0 +1,46 @@
+"""Command text helpers for operation candidate previews."""
+
+from __future__ import annotations
+
+import shlex
+
+from ..batch.operation_candidates import OperationCandidatePreview
+
+
+def candidate_selector_text(
+    batch_name: str,
+    operation: str,
+    ordinal: int | None = None,
+) -> str:
+    """Return the selector text for an operation candidate preview."""
+    if ordinal is None:
+        return f"{batch_name}:{operation}"
+    return f"{batch_name}:{operation}:{ordinal}"
+
+
+def show_candidate_command(
+    preview: OperationCandidatePreview,
+    ordinal: int | None = None,
+) -> str:
+    """Return the command that previews one candidate selector."""
+    return "git-stage-batch show --from {selector} --file {file}".format(
+        selector=candidate_selector_text(
+            preview.batch_name,
+            preview.operation,
+            ordinal,
+        ),
+        file=shlex.quote(preview.file_path),
+    )
+
+
+def execute_candidate_command(preview: OperationCandidatePreview) -> str:
+    """Return the command that executes one candidate selector."""
+    return "git-stage-batch {command} --from {selector} --file {file}".format(
+        command=preview.operation,
+        selector=candidate_selector_text(
+            preview.batch_name,
+            preview.operation,
+            preview.ordinal,
+        ),
+        file=shlex.quote(preview.file_path),
+    )

--- a/src/git_stage_batch/output/candidate_preview_diff.py
+++ b/src/git_stage_batch/output/candidate_preview_diff.py
@@ -1,0 +1,124 @@
+"""Diff rendering for operation candidate previews."""
+
+from __future__ import annotations
+
+from ..batch.operation_candidates import render_candidate_buffer_diff
+from ..core.buffer import LineBuffer
+from ..core.diff_parser import build_line_changes_from_patch_lines
+from . import candidate_preview_summary
+from .colors import Colors
+
+
+def _candidate_diff_hunks(diff_text: str) -> tuple[tuple[bytes, ...], ...]:
+    headers: list[bytes] = []
+    current_hunk: list[bytes] = []
+    hunks: list[tuple[bytes, ...]] = []
+    for line in diff_text.splitlines(keepends=True):
+        line_bytes = line.encode("utf-8", errors="surrogateescape")
+        if line_bytes.startswith((b"--- ", b"+++ ")):
+            headers.append(line_bytes)
+            continue
+        if line_bytes.startswith(b"@@ "):
+            if current_hunk:
+                hunks.append(tuple(headers + current_hunk))
+            current_hunk = [line_bytes]
+            continue
+        if current_hunk:
+            current_hunk.append(line_bytes)
+
+    if current_hunk:
+        hunks.append(tuple(headers + current_hunk))
+    return tuple(hunks)
+
+
+def _candidate_line_number(line) -> int | None:
+    if line.kind == "+":
+        return line.new_line_number
+    return line.old_line_number if line.old_line_number is not None else line.new_line_number
+
+
+def _print_candidate_line_changes(
+    line_changes,
+    *,
+    ambiguity_target_line_range: tuple[int, int] | None,
+) -> None:
+    use_color = Colors.enabled()
+    header = line_changes.header
+    header_part = f"@@ -{header.old_start},{header.old_len} +{header.new_start},{header.new_len} @@"
+    if use_color:
+        print(f"{Colors.BOLD}{line_changes.path}{Colors.RESET} :: {Colors.CYAN}{header_part}{Colors.RESET}")
+    else:
+        print(f"{line_changes.path} :: {header_part}")
+
+    line_numbers = [
+        line_number
+        for line_number in (_candidate_line_number(line) for line in line_changes.lines)
+        if line_number is not None
+    ]
+    width = max((len(str(line_number)) for line_number in line_numbers), default=1)
+
+    for line in line_changes.lines:
+        line_number = _candidate_line_number(line)
+        gutter_number = " " * width if line_number is None else f"{line_number:>{width}}"
+        gutter = (
+            f"{gutter_number}"
+            f"{candidate_preview_summary.CANDIDATE_GUTTER_SEPARATOR} "
+        )
+        body = f"{line.kind}{line.display_text()}"
+
+        if not use_color:
+            print(f"{gutter}{body}")
+            continue
+
+        styled_gutter = f"{Colors.GRAY}{gutter}{Colors.RESET}"
+        if line.kind == "+":
+            print(f"{styled_gutter}{Colors.GREEN}{body}{Colors.RESET}")
+        elif line.kind == "-":
+            print(f"{styled_gutter}{Colors.RED}{body}{Colors.RESET}")
+        elif candidate_preview_summary.candidate_line_in_range(
+            line_number,
+            ambiguity_target_line_range,
+        ):
+            print(f"{styled_gutter}{Colors.REVERSE}{Colors.GRAY}{body}{Colors.RESET}")
+        else:
+            print(f"{styled_gutter}{body}")
+
+
+def print_candidate_buffer_diff(
+    file_path: str,
+    before_buffer: LineBuffer,
+    after_buffer: LineBuffer,
+    *,
+    context_lines: int,
+    ambiguity_target_line_range: tuple[int, int] | None,
+    leading_blank: bool = False,
+) -> bool:
+    """Print the diff between one candidate target's buffers."""
+    diff_text = render_candidate_buffer_diff(
+        file_path,
+        before_buffer,
+        after_buffer,
+        label_before="a",
+        label_after="b",
+        context_lines=context_lines,
+    )
+    if not diff_text:
+        return False
+
+    if leading_blank:
+        print()
+
+    hunks = _candidate_diff_hunks(diff_text)
+    if not hunks:
+        print(diff_text, end="" if diff_text.endswith("\n") else "\n")
+        return True
+
+    for index, hunk in enumerate(hunks):
+        if index:
+            print()
+        line_changes = build_line_changes_from_patch_lines(hunk)
+        _print_candidate_line_changes(
+            line_changes,
+            ambiguity_target_line_range=ambiguity_target_line_range,
+        )
+    return True

--- a/src/git_stage_batch/output/candidate_preview_diff.py
+++ b/src/git_stage_batch/output/candidate_preview_diff.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from ..batch.operation_candidates import render_candidate_buffer_diff
 from ..core.buffer import LineBuffer
 from ..core.diff_parser import build_line_changes_from_patch_lines
-from . import candidate_preview_summary
+from . import candidate_preview_snippets
 from .colors import Colors
 
 
@@ -62,7 +62,7 @@ def _print_candidate_line_changes(
         gutter_number = " " * width if line_number is None else f"{line_number:>{width}}"
         gutter = (
             f"{gutter_number}"
-            f"{candidate_preview_summary.CANDIDATE_GUTTER_SEPARATOR} "
+            f"{candidate_preview_snippets.CANDIDATE_GUTTER_SEPARATOR} "
         )
         body = f"{line.kind}{line.display_text()}"
 
@@ -75,7 +75,7 @@ def _print_candidate_line_changes(
             print(f"{styled_gutter}{Colors.GREEN}{body}{Colors.RESET}")
         elif line.kind == "-":
             print(f"{styled_gutter}{Colors.RED}{body}{Colors.RESET}")
-        elif candidate_preview_summary.candidate_line_in_range(
+        elif candidate_preview_snippets.candidate_line_in_range(
             line_number,
             ambiguity_target_line_range,
         ):

--- a/src/git_stage_batch/output/candidate_preview_porcelain.py
+++ b/src/git_stage_batch/output/candidate_preview_porcelain.py
@@ -1,0 +1,98 @@
+"""Porcelain JSON output for operation candidate previews."""
+
+from __future__ import annotations
+
+import json
+
+from ..batch.operation_candidates import OperationCandidatePreview
+from . import candidate_preview_snippets
+from . import candidate_preview_summary
+from .candidate_preview_commands import (
+    candidate_selector_text,
+    execute_candidate_command,
+    show_candidate_command,
+)
+
+
+def print_operation_candidate_overview_porcelain(
+    previews: tuple[OperationCandidatePreview, ...],
+    candidate_summaries: list[
+        list[candidate_preview_summary.CandidateTargetSummary]
+    ],
+) -> None:
+    """Print the machine-readable overview for candidate choices."""
+    first = previews[0]
+    print(json.dumps({
+        "status": "candidates",
+        "changed": False,
+        "batch": first.batch_name,
+        "selector": {
+            "operation": first.operation,
+            "count": len(previews),
+        },
+        "scope": {
+            "file": first.file_path,
+        },
+        "candidates": [
+            {
+                "ordinal": preview.ordinal,
+                "selector": candidate_selector_text(
+                    preview.batch_name,
+                    preview.operation,
+                    preview.ordinal,
+                ),
+                "commands": {
+                    "preview": show_candidate_command(
+                        preview,
+                        preview.ordinal,
+                    ),
+                    "execute": (
+                        execute_candidate_command(preview)
+                    ),
+                },
+                "targets": [
+                    {
+                        "target": target.target,
+                        "summary": summary.title,
+                        "context": list(
+                            candidate_preview_snippets.plain_candidate_snippet_lines(
+                                summary.lines,
+                            )
+                        ),
+                    }
+                    for target, summary in zip(preview.targets, summaries)
+                ],
+            }
+            for preview, summaries in zip(previews, candidate_summaries)
+        ],
+    }, sort_keys=True))
+
+
+def print_operation_candidate_porcelain(
+    preview: OperationCandidatePreview,
+) -> None:
+    """Print the machine-readable detail for one candidate choice."""
+    print(json.dumps({
+        "status": "candidate",
+        "changed": False,
+        "batch": preview.batch_name,
+        "selector": {
+            "operation": preview.operation,
+            "ordinal": preview.ordinal,
+            "count": preview.count,
+            "id": preview.candidate_id,
+        },
+        "scope": {
+            "file": preview.file_path,
+        },
+        "targets": [
+            {
+                "target": target.target,
+                "file": target.file_path,
+                "summary": target.summary,
+                "resolution_ordinal": target.resolution_ordinal,
+                "resolution_count": target.resolution_count,
+            }
+            for target in preview.targets
+        ],
+    }, sort_keys=True))

--- a/src/git_stage_batch/output/candidate_preview_snippets.py
+++ b/src/git_stage_batch/output/candidate_preview_snippets.py
@@ -1,0 +1,65 @@
+"""Snippet formatting primitives for operation candidate previews."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+CANDIDATE_GUTTER_SEPARATOR = "│"
+
+_CANDIDATE_OVERVIEW_MAX_LINE_WIDTH = 64
+
+
+@dataclass(frozen=True)
+class CandidateSnippetLine:
+    line_number: int | None
+    marker: str
+    text: str
+    highlight: bool = False
+
+    def plain(self, *, width: int) -> str:
+        line_number = (
+            " " * width
+            if self.line_number is None
+            else f"{self.line_number:>{width}}"
+        )
+        return (
+            f"{line_number}{CANDIDATE_GUTTER_SEPARATOR} "
+            f"{self.marker}{shorten_candidate_overview_text(self.text)}"
+        )
+
+
+def shorten_candidate_overview_text(
+    text: str,
+    max_width: int = _CANDIDATE_OVERVIEW_MAX_LINE_WIDTH,
+) -> str:
+    compact = text.strip()
+    if len(compact) <= max_width:
+        return compact
+    if max_width <= 3:
+        return compact[:max_width]
+    return compact[: max_width - 3] + "..."
+
+
+def snippet_line_width(lines: tuple[CandidateSnippetLine, ...]) -> int:
+    numbered_lines = [line for line in lines if line.line_number is not None]
+    if not numbered_lines:
+        return 1
+    return max(len(str(line.line_number)) for line in numbered_lines)
+
+
+def plain_candidate_snippet_lines(
+    lines: tuple[CandidateSnippetLine, ...],
+) -> tuple[str, ...]:
+    width = snippet_line_width(lines)
+    return tuple(line.plain(width=width) for line in lines)
+
+
+def candidate_line_in_range(
+    line_number: int | None,
+    line_range: tuple[int, int] | None,
+) -> bool:
+    if line_number is None or line_range is None:
+        return False
+    start, end = line_range
+    return start <= line_number <= end

--- a/src/git_stage_batch/output/candidate_preview_summary.py
+++ b/src/git_stage_batch/output/candidate_preview_summary.py
@@ -8,20 +8,17 @@ from dataclasses import dataclass
 from ..batch.operation_candidates import OperationCandidatePreview
 from ..core.buffer import LineBuffer
 from ..i18n import _
-
-
-CANDIDATE_GUTTER_SEPARATOR = "│"
+from . import candidate_preview_snippets
 
 _CANDIDATE_OVERVIEW_CONTEXT_LINES = 2
 _CANDIDATE_OVERVIEW_MAX_LINES = 9
-_CANDIDATE_OVERVIEW_MAX_LINE_WIDTH = 64
 
 
 @dataclass(frozen=True)
 class CandidateTargetSummary:
     label: str
     title: str
-    lines: tuple["CandidateSnippetLine", ...]
+    lines: tuple[candidate_preview_snippets.CandidateSnippetLine, ...]
     ambiguity_line_range: tuple[int, int] | None = None
 
 
@@ -30,25 +27,6 @@ class AmbiguityBlockContext:
     relation: str
     line_range: tuple[int, int]
     description: str
-
-
-@dataclass(frozen=True)
-class CandidateSnippetLine:
-    line_number: int | None
-    marker: str
-    text: str
-    highlight: bool = False
-
-    def plain(self, *, width: int) -> str:
-        line_number = (
-            " " * width
-            if self.line_number is None
-            else f"{self.line_number:>{width}}"
-        )
-        return (
-            f"{line_number}{CANDIDATE_GUTTER_SEPARATOR} "
-            f"{self.marker}{shorten_candidate_overview_text(self.text)}"
-        )
 
 
 def candidate_overview_subject(
@@ -102,56 +80,23 @@ def candidate_target_subject_label(target_name: str) -> str:
     return _("working tree")
 
 
-def shorten_candidate_overview_text(
-    text: str,
-    max_width: int = _CANDIDATE_OVERVIEW_MAX_LINE_WIDTH,
-) -> str:
-    compact = text.strip()
-    if len(compact) <= max_width:
-        return compact
-    if max_width <= 3:
-        return compact[:max_width]
-    return compact[: max_width - 3] + "..."
-
-
 def summarize_ambiguity_block(lines: list[str]) -> str:
     if not lines:
         return _("ambiguous block")
     if len(lines) == 1:
-        text = shorten_candidate_overview_text(lines[0], 36)
+        text = candidate_preview_snippets.shorten_candidate_overview_text(
+            lines[0],
+            36,
+        )
         if text:
             return f'"{text}"'
         return _("an empty line")
 
-    first = shorten_candidate_overview_text(lines[0], 24)
-    last = shorten_candidate_overview_text(lines[-1], 24)
+    first = candidate_preview_snippets.shorten_candidate_overview_text(lines[0], 24)
+    last = candidate_preview_snippets.shorten_candidate_overview_text(lines[-1], 24)
     if first and last:
         return f'"{first} … {last}"'
     return _("{count} lines").format(count=len(lines))
-
-
-def snippet_line_width(lines: tuple[CandidateSnippetLine, ...]) -> int:
-    numbered_lines = [line for line in lines if line.line_number is not None]
-    if not numbered_lines:
-        return 1
-    return max(len(str(line.line_number)) for line in numbered_lines)
-
-
-def plain_candidate_snippet_lines(
-    lines: tuple[CandidateSnippetLine, ...],
-) -> tuple[str, ...]:
-    width = snippet_line_width(lines)
-    return tuple(line.plain(width=width) for line in lines)
-
-
-def candidate_line_in_range(
-    line_number: int | None,
-    line_range: tuple[int, int] | None,
-) -> bool:
-    if line_number is None or line_range is None:
-        return False
-    start, end = line_range
-    return start <= line_number <= end
 
 
 def candidate_target_summary(target) -> CandidateTargetSummary:
@@ -204,7 +149,9 @@ def candidate_target_summary(target) -> CandidateTargetSummary:
 def candidate_summary_key(
     summary: CandidateTargetSummary,
 ) -> tuple[str, tuple[str, ...]]:
-    return summary.title, plain_candidate_snippet_lines(summary.lines)
+    return summary.title, candidate_preview_snippets.plain_candidate_snippet_lines(
+        summary.lines,
+    )
 
 
 def common_candidate_target_indexes(
@@ -246,7 +193,10 @@ def _summarize_overview_lines(lines: list[str]) -> str:
     if not lines:
         return _("nothing")
     if len(lines) == 1:
-        text = shorten_candidate_overview_text(lines[0], 36)
+        text = candidate_preview_snippets.shorten_candidate_overview_text(
+            lines[0],
+            36,
+        )
         if text:
             return f'"{text}"'
         return _("an empty line")
@@ -332,12 +282,12 @@ def _nearby_context_summary(
         candidates.append(before_lines[before_end])
 
     for line in candidates:
-        text = shorten_candidate_overview_text(line, 36)
+        text = candidate_preview_snippets.shorten_candidate_overview_text(line, 36)
         if text and text not in changed_text:
             return _(' near "{context}"').format(context=text)
 
     for line in candidates:
-        text = shorten_candidate_overview_text(line, 36)
+        text = candidate_preview_snippets.shorten_candidate_overview_text(line, 36)
         if text:
             return _(' near "{context}"').format(context=text)
     return ""
@@ -392,14 +342,21 @@ def _overview_action_title(
 
 
 def _append_overview_line(
-    lines: list[CandidateSnippetLine],
+    lines: list[candidate_preview_snippets.CandidateSnippetLine],
     *,
     line_number: int,
     marker: str,
     text: str,
     highlight: bool = False,
 ) -> None:
-    lines.append(CandidateSnippetLine(line_number, marker, text, highlight))
+    lines.append(
+        candidate_preview_snippets.CandidateSnippetLine(
+            line_number,
+            marker,
+            text,
+            highlight,
+        )
+    )
 
 
 def _overview_snippet_lines(
@@ -410,8 +367,8 @@ def _overview_snippet_lines(
     after_start: int,
     after_end: int,
     ambiguity_target_line_range: tuple[int, int] | None,
-) -> tuple[CandidateSnippetLine, ...]:
-    lines: list[CandidateSnippetLine] = []
+) -> tuple[candidate_preview_snippets.CandidateSnippetLine, ...]:
+    lines: list[candidate_preview_snippets.CandidateSnippetLine] = []
 
     context_start = max(0, before_start - _CANDIDATE_OVERVIEW_CONTEXT_LINES)
     context_end = min(len(before_lines), before_end + _CANDIDATE_OVERVIEW_CONTEXT_LINES)
@@ -422,7 +379,10 @@ def _overview_snippet_lines(
             line_number=index + 1,
             marker=" ",
             text=before_lines[index],
-            highlight=candidate_line_in_range(index + 1, ambiguity_target_line_range),
+            highlight=candidate_preview_snippets.candidate_line_in_range(
+                index + 1,
+                ambiguity_target_line_range,
+            ),
         )
 
     for index in range(before_start, before_end):
@@ -447,12 +407,15 @@ def _overview_snippet_lines(
             line_number=index + 1,
             marker=" ",
             text=before_lines[index],
-            highlight=candidate_line_in_range(index + 1, ambiguity_target_line_range),
+            highlight=candidate_preview_snippets.candidate_line_in_range(
+                index + 1,
+                ambiguity_target_line_range,
+            ),
         )
 
     if len(lines) > _CANDIDATE_OVERVIEW_MAX_LINES:
         return tuple(
             lines[:_CANDIDATE_OVERVIEW_MAX_LINES]
-            + [CandidateSnippetLine(None, " ", "...")]
+            + [candidate_preview_snippets.CandidateSnippetLine(None, " ", "...")]
         )
     return tuple(lines)

--- a/src/git_stage_batch/output/file_review.py
+++ b/src/git_stage_batch/output/file_review.py
@@ -6,10 +6,7 @@ import os
 import shlex
 import sys
 
-from ..core.actionable_changes import (
-    ActionableSelection,
-    ActionableSelectionReason,
-)
+from ..core.actionable_changes import ActionableSelection
 from ..core.line_selection import format_line_ids
 from ..data.file_review.records import (
     FileReviewAction,
@@ -22,10 +19,7 @@ from ..i18n import _
 from .colors import Colors
 from .file_review_action_selections import shown_line_action_selections
 from .file_review_display_ids import display_ids_for_rows
-from .file_review_model import (
-    FileReviewModel,
-    ReviewChange,
-)
+from .file_review_model import FileReviewModel
 from .file_review_rows import (
     maximum_display_id_digit_count,
     print_file_review_rows,
@@ -176,15 +170,6 @@ def _line_spec_for_selections(selections: list[ActionableSelection]) -> str:
     for selection in selections:
         display_ids.extend(selection.display_ids)
     return format_line_ids(display_ids)
-
-
-def _review_change_heading_action(change: ReviewChange) -> str:
-    """Return the concise action label shown for one review change."""
-    if change.reason == ActionableSelectionReason.REPLACEMENT:
-        return _("select together")
-    if change.actions == (FileReviewAction.RESET_FROM_BATCH.value,):
-        return _("reset")
-    return _("select")
 
 
 def _print_header(

--- a/src/git_stage_batch/output/file_review.py
+++ b/src/git_stage_batch/output/file_review.py
@@ -2,23 +2,12 @@
 
 from __future__ import annotations
 
-import os
-import shlex
-import sys
-
-from ..core.actionable_changes import ActionableSelection
-from ..core.line_selection import format_line_ids
-from ..data.file_review.records import (
-    FileReviewAction,
-    FileReviewState,
-    ReviewSource,
-)
-from ..data.file_review.action_commands import line_action_command
-from ..data.selected_change.store import SelectedChangeKind
+from ..data.file_review.records import ReviewSource
 from ..i18n import _
 from .colors import Colors
 from .file_review_action_selections import shown_line_action_selections
 from .file_review_display_ids import display_ids_for_rows
+from .file_review_footer import print_file_review_footer
 from .file_review_model import FileReviewModel
 from .file_review_rows import (
     maximum_display_id_digit_count,
@@ -31,10 +20,6 @@ from .file_review_summary import (
     page_summary,
     review_source_summary,
 )
-
-
-def _quote(value: str) -> str:
-    return shlex.quote(value)
 
 
 def print_file_review(
@@ -145,7 +130,7 @@ def print_file_review(
                 allowed_selection_ids=set(change.selection_ids) if change.display_ids else set(),
             )
 
-    _print_footer(
+    print_file_review_footer(
         model.line_changes.path,
         shown_pages=shown_pages,
         page_count=page_count,
@@ -153,23 +138,10 @@ def print_file_review(
         shown_line_spec=shown_line_spec,
         complete_line_action_selections=complete_line_action_selections,
         total_changes=len(model.changes),
-        page_spec=page_spec,
         command_source_args=command_source_args,
         source=source,
         batch_name=batch_name,
     )
-
-
-def _selection_supports_action(selection: ActionableSelection, action: FileReviewAction) -> bool:
-    """Return whether a line-action selection supports an action."""
-    return not selection.actions or action.value in selection.actions
-
-
-def _line_spec_for_selections(selections: list[ActionableSelection]) -> str:
-    display_ids: list[int] = []
-    for selection in selections:
-        display_ids.extend(selection.display_ids)
-    return format_line_ids(display_ids)
 
 
 def _print_header(
@@ -215,242 +187,3 @@ def _print_header(
                 print(f"    {line}")
     rule = "─" * 78
     print(f"{Colors.GRAY}{rule}{Colors.RESET}" if use_color else rule)
-
-
-def _style_footer_command(command: str) -> str:
-    try:
-        tokens = shlex.split(command, posix=False)
-    except ValueError:
-        return command
-
-    dynamic_value_options = {"--file", "--from", "--line", "--page", "--to"}
-    if tokens[:2] == ["git", "stage-batch"]:
-        action_index = 2
-    elif tokens[:1] == ["git-stage-batch"]:
-        action_index = 1
-    else:
-        action_index = -1
-    styled_tokens: list[str] = []
-    bold_next = False
-    for index, token in enumerate(tokens):
-        should_bold = bold_next or index == action_index
-        if should_bold:
-            styled_tokens.append(f"{Colors.BOLD}{token}{Colors.RESET}")
-        else:
-            styled_tokens.append(token)
-        bold_next = token in dynamic_value_options
-    return " ".join(styled_tokens)
-
-
-def _invoked_command_prefix() -> str:
-    executable = os.path.basename(sys.argv[0])
-    if executable == "git" and len(sys.argv) > 1 and sys.argv[1] == "stage-batch":
-        return "git stage-batch"
-    return "git-stage-batch"
-
-
-def _display_footer_command(command: str) -> str:
-    if command.startswith("git-stage-batch "):
-        return _invoked_command_prefix() + command[len("git-stage-batch"):]
-    return command
-
-
-def _print_footer(
-    path: str,
-    *,
-    shown_pages: tuple[int, ...],
-    page_count: int,
-    shown_change_spec: str,
-    shown_line_spec: str,
-    complete_line_action_selections: list[ActionableSelection],
-    total_changes: int,
-    page_spec: str,
-    command_source_args: str,
-    source: ReviewSource,
-    batch_name: str | None,
-) -> None:
-    shown = set(shown_pages)
-    is_entire = shown == set(range(1, page_count + 1))
-    hints: list[tuple[str, str]] = []
-    navigation_hints: list[tuple[str, str]] = []
-
-    review_state = _footer_review_state(
-        path=path,
-        shown_pages=shown_pages,
-        page_count=page_count,
-        source=source,
-        batch_name=batch_name,
-    )
-    primary_action = (
-        FileReviewAction.INCLUDE_FROM_BATCH
-        if source == ReviewSource.BATCH else
-        FileReviewAction.INCLUDE
-    )
-    primary_selections = [
-        selection
-        for selection in complete_line_action_selections
-        if _selection_supports_action(selection, primary_action)
-    ]
-    reset_selections = [
-        selection
-        for selection in complete_line_action_selections
-        if _selection_supports_action(selection, FileReviewAction.RESET_FROM_BATCH)
-    ]
-
-    if primary_selections:
-        combined_selection = _line_spec_for_selections(primary_selections)
-        include_line_command = (
-            line_action_command("include", review_state, line_spec=combined_selection, pathless_line=True)
-            if review_state is not None else
-            None
-        )
-        hints.append(
-            (
-                _("include"),
-                include_line_command or f"git-stage-batch include{command_source_args} --line {combined_selection}",
-            )
-        )
-        if not command_source_args:
-            skip_line_command = (
-                line_action_command("skip", review_state, line_spec=combined_selection, pathless_line=True)
-                if review_state is not None else
-                None
-            )
-            hints.append(
-                (
-                    _("skip"),
-                    skip_line_command or f"git-stage-batch skip --line {combined_selection}",
-                )
-            )
-        discard_line_command = (
-            line_action_command("discard", review_state, line_spec=combined_selection, pathless_line=True)
-            if review_state is not None else
-            None
-        )
-        hints.append(
-            (
-                _("discard"),
-                discard_line_command or f"git-stage-batch discard{command_source_args} --line {combined_selection}",
-            )
-        )
-        if source == ReviewSource.BATCH and reset_selections:
-            reset_selection = _line_spec_for_selections(reset_selections)
-            reset_line_command = line_action_command(
-                FileReviewAction.RESET_FROM_BATCH,
-                review_state,
-                line_spec=reset_selection,
-                pathless_line=True,
-            )
-            hints.append(
-                (
-                    _("reset"),
-                    reset_line_command or f"git-stage-batch reset{command_source_args} --line {reset_selection}",
-                )
-            )
-    elif reset_selections:
-        reset_selection = _line_spec_for_selections(reset_selections)
-        reset_line_command = line_action_command(
-            FileReviewAction.RESET_FROM_BATCH,
-            review_state,
-            line_spec=reset_selection,
-            pathless_line=True,
-        )
-        hints.append(
-            (
-                _("reset"),
-                reset_line_command or f"git-stage-batch reset{command_source_args} --line {reset_selection}",
-            )
-        )
-    elif not is_entire:
-        hints.append((_("No complete change is actionable from this page."), ""))
-
-    if not is_entire and max(shown_pages) < page_count:
-        navigation_hints.append(
-            (
-                _("next"),
-                f"git-stage-batch show{command_source_args} --file {_quote(path)} --page {max(shown_pages) + 1}",
-            )
-        )
-
-    if is_entire:
-        hints.append(
-            (
-                _("include"),
-                f"git-stage-batch include{command_source_args} --file {_quote(path)}",
-            )
-        )
-    else:
-        navigation_hints.append(
-            (
-                _("all"),
-                f"git-stage-batch show{command_source_args} --file {_quote(path)} --page all",
-            )
-        )
-
-    hints.extend(navigation_hints)
-    if hints:
-        print()
-        use_color = Colors.enabled()
-        rule = "─" * 78
-        print(f"{Colors.GRAY}{rule}{Colors.RESET}" if use_color else rule)
-        status = "  ·  ".join(
-            (
-                path,
-                page_summary(shown_pages, page_count),
-                change_summary(shown_change_spec, total_changes),
-                _("lines {lines}").format(lines=shown_line_spec),
-            )
-        )
-        if use_color:
-            print(f"{Colors.BOLD}{status}{Colors.RESET}")
-        else:
-            print(status)
-        print()
-        action_width = max(len(action) for action, command in hints if command)
-        for action, command in hints:
-            if not command:
-                print(action)
-                continue
-            display_command = _display_footer_command(command)
-            action_text = action.ljust(action_width)
-            if use_color:
-                print(f"{Colors.CYAN}{action_text}{Colors.RESET}  {_style_footer_command(display_command)}")
-            else:
-                print(f"{action_text}  {display_command}")
-
-
-def _footer_review_state(
-    *,
-    path: str,
-    shown_pages: tuple[int, ...],
-    page_count: int,
-    source: ReviewSource,
-    batch_name: str | None,
-) -> FileReviewState:
-    if source == ReviewSource.BATCH:
-        return FileReviewState(
-            source=ReviewSource.BATCH,
-            batch_name=batch_name,
-            file_path=path,
-            page_spec="all",
-            shown_pages=shown_pages,
-            page_count=page_count,
-            entire_file_shown=set(shown_pages) == set(range(1, page_count + 1)),
-            selections=tuple(),
-            selected_change_kind=SelectedChangeKind.BATCH_FILE,
-            selected_file_fingerprint="",
-            diff_fingerprint="",
-        )
-    return FileReviewState(
-        source=source,
-        batch_name=None,
-        file_path=path,
-        page_spec="all",
-        shown_pages=shown_pages,
-        page_count=page_count,
-        entire_file_shown=set(shown_pages) == set(range(1, page_count + 1)),
-        selections=tuple(),
-        selected_change_kind=SelectedChangeKind.FILE,
-        selected_file_fingerprint="",
-        diff_fingerprint="",
-    )

--- a/src/git_stage_batch/output/file_review.py
+++ b/src/git_stage_batch/output/file_review.py
@@ -11,7 +11,6 @@ from ..core.actionable_changes import (
     ActionableSelectionReason,
 )
 from ..core.line_selection import format_line_ids
-from ..core.models import LineEntry
 from ..data.file_review.records import (
     FileReviewAction,
     FileReviewState,
@@ -27,6 +26,10 @@ from .file_review_model import (
     FileReviewModel,
     ReviewChange,
     ReviewChangeFragment,
+)
+from .file_review_rows import (
+    maximum_display_id_digit_count,
+    print_file_review_rows,
 )
 
 
@@ -155,9 +158,9 @@ def print_file_review(
                         note=change.note or _("not currently selectable"),
                     )
                 )
-            _print_rows(
+            print_file_review_rows(
                 fragment.rows,
-                _maximum_display_id_digit_count(model),
+                maximum_display_id_digit_count(model),
                 display_id_by_selection_id=model.display_id_by_selection_id,
                 allowed_selection_ids=set(change.selection_ids) if change.display_ids else set(),
             )
@@ -276,65 +279,6 @@ def _print_header(
                 print(f"    {line}")
     rule = "─" * 78
     print(f"{Colors.GRAY}{rule}{Colors.RESET}" if use_color else rule)
-
-
-def _maximum_display_id_digit_count(model: FileReviewModel) -> int:
-    if model.display_id_by_selection_id is None:
-        return model.line_changes.maximum_line_id_digit_count()
-    if not model.display_id_by_selection_id:
-        return 1
-    return len(str(max(model.display_id_by_selection_id.values())))
-
-
-def _print_rows(
-    rows: tuple[LineEntry, ...],
-    maximum_digits: int,
-    *,
-    display_id_by_selection_id: dict[int, int] | None,
-    allowed_selection_ids: set[int] | None = None,
-) -> None:
-    use_color = Colors.enabled()
-    label_width = maximum_digits + 3
-    for line in rows:
-        is_gap_line = (
-            line.id is None
-            and line.kind == " "
-            and line.old_line_number is None
-            and line.new_line_number is None
-            and line.source_line is None
-        )
-        if line.id is None or (
-            allowed_selection_ids is not None
-            and line.id not in allowed_selection_ids
-        ):
-            display_id = None
-        elif display_id_by_selection_id is not None:
-            display_id = display_id_by_selection_id.get(line.id)
-        else:
-            display_id = line.id
-        if display_id is None:
-            label = ""
-        else:
-            label = f"[#{display_id}]"
-        padding = " " * max(0, label_width - len(label))
-        row_text = f" {line.kind} {line.display_text()}"
-        if not use_color:
-            print(f"{label}{padding}{row_text}")
-            continue
-
-        if label:
-            print(f"{Colors.GRAY}{label}{Colors.RESET}{padding}", end="")
-        else:
-            print(padding, end="")
-
-        if line.kind == "+":
-            print(f"{Colors.GREEN}{row_text}{Colors.RESET}")
-        elif line.kind == "-":
-            print(f"{Colors.RED}{row_text}{Colors.RESET}")
-        elif is_gap_line:
-            print(f"{Colors.GRAY}{row_text}{Colors.RESET}")
-        else:
-            print(row_text)
 
 
 def _style_footer_command(command: str) -> str:

--- a/src/git_stage_batch/output/file_review.py
+++ b/src/git_stage_batch/output/file_review.py
@@ -25,36 +25,22 @@ from .file_review_display_ids import display_ids_for_rows
 from .file_review_model import (
     FileReviewModel,
     ReviewChange,
-    ReviewChangeFragment,
 )
 from .file_review_rows import (
     maximum_display_id_digit_count,
     print_file_review_rows,
 )
+from .file_review_summary import (
+    change_spec_for_fragments,
+    change_summary,
+    line_spec_for_display_ids,
+    page_summary,
+    review_source_summary,
+)
 
 
 def _quote(value: str) -> str:
     return shlex.quote(value)
-
-
-def _line_spec_for_display_ids(display_ids: tuple[int, ...]) -> str:
-    if not display_ids:
-        return "-"
-    return _display_line_spec(format_line_ids(list(display_ids)))
-
-
-def _change_spec_for_fragments(fragments: list[ReviewChangeFragment]) -> str:
-    change_ids: list[int] = []
-    seen: set[int] = set()
-    for fragment in fragments:
-        change_id = fragment.change.index
-        if change_id in seen:
-            continue
-        change_ids.append(change_id)
-        seen.add(change_id)
-    if not change_ids:
-        return "-"
-    return _display_line_spec(format_line_ids(change_ids))
 
 
 def print_file_review(
@@ -94,8 +80,8 @@ def print_file_review(
                 continue
             shown_display_ids.append(display_id)
             seen_display_ids.add(display_id)
-    shown_line_spec = _line_spec_for_display_ids(tuple(shown_display_ids))
-    shown_change_spec = _change_spec_for_fragments(shown_fragments)
+    shown_line_spec = line_spec_for_display_ids(tuple(shown_display_ids))
+    shown_change_spec = change_spec_for_fragments(shown_fragments)
     complete_line_action_selections = shown_line_action_selections(
         model,
         shown_pages,
@@ -129,7 +115,7 @@ def print_file_review(
                 model.display_id_by_selection_id,
             )
             selection_spec = (
-                _line_spec_for_display_ids(fragment_display_ids)
+                line_spec_for_display_ids(fragment_display_ids)
                 if fragment_display_ids else
                 change.select_as or "-"
             )
@@ -201,41 +187,6 @@ def _review_change_heading_action(change: ReviewChange) -> str:
     return _("select")
 
 
-def _display_line_spec(line_spec: str) -> str:
-    return line_spec.replace("-", "–")
-
-
-def _page_summary(shown_pages: tuple[int, ...], page_count: int) -> str:
-    page_word = _("page") if len(shown_pages) == 1 else _("pages")
-    return _("{page_word} {pages}/{page_count}").format(
-        page_word=page_word,
-        pages=_display_line_spec(format_line_ids(list(shown_pages))),
-        page_count=page_count,
-    )
-
-
-def _change_summary(change_spec: str, total_changes: int) -> str:
-    change_word = _("change") if "," not in change_spec and "–" not in change_spec else _("changes")
-    return _("{change_word} {changes}/{total}").format(
-        change_word=change_word,
-        changes=change_spec,
-        total=total_changes,
-    )
-
-
-def _review_source_summary(
-    source: ReviewSource,
-    batch_name: str | None,
-    source_label: str,
-) -> str:
-    if source == ReviewSource.BATCH and batch_name:
-        return batch_name
-    prefix = _("Changes: ")
-    if source_label.startswith(prefix):
-        return source_label[len(prefix):]
-    return source_label
-
-
 def _print_header(
     path: str,
     *,
@@ -254,9 +205,9 @@ def _print_header(
     status = "  ·  ".join(
         (
             path,
-            _review_source_summary(source, batch_name, source_label),
-            _page_summary(shown_pages, page_count),
-            _change_summary(shown_change_spec, total_changes),
+            review_source_summary(source, batch_name, source_label),
+            page_summary(shown_pages, page_count),
+            change_summary(shown_change_spec, total_changes),
             _("lines {lines}").format(lines=shown_line_spec),
         )
     )
@@ -460,8 +411,8 @@ def _print_footer(
         status = "  ·  ".join(
             (
                 path,
-                _page_summary(shown_pages, page_count),
-                _change_summary(shown_change_spec, total_changes),
+                page_summary(shown_pages, page_count),
+                change_summary(shown_change_spec, total_changes),
                 _("lines {lines}").format(lines=shown_line_spec),
             )
         )

--- a/src/git_stage_batch/output/file_review_changes.py
+++ b/src/git_stage_batch/output/file_review_changes.py
@@ -1,0 +1,228 @@
+"""ReviewChange construction for file review output models."""
+
+from __future__ import annotations
+
+from ..core.actionable_changes import ActionableSelection, ActionableSelectionReason
+from ..core.line_selection import format_line_ids
+from ..core.models import LineEntry, LineLevelChange
+from ..i18n import _
+from .file_review_model import ReviewChange
+
+
+def build_file_review_changes(
+    line_changes: LineLevelChange,
+    actionable_selections: tuple[ActionableSelection, ...],
+    display_id_by_selection_id: dict[int, int] | None,
+) -> tuple[ReviewChange, ...]:
+    """Build change records from line rows and prepared actionable selections."""
+    changes: list[ReviewChange] = []
+    current_rows: list[LineEntry] = []
+    actionable_by_selection = {
+        selection.selection_ids: selection
+        for selection in actionable_selections
+    }
+
+    def append_change(
+        rows: list[LineEntry],
+        actionable: ActionableSelection | None,
+    ) -> None:
+        old_line_numbers = [
+            line.old_line_number
+            for line in rows
+            if line.kind != "+" and line.old_line_number is not None
+        ]
+        new_line_numbers = [
+            line.new_line_number
+            for line in rows
+            if line.kind != "-" and line.new_line_number is not None
+        ]
+        changed_kinds = {line.kind for line in rows if line.kind in ("+", "-")}
+        reason = (
+            ActionableSelectionReason.REPLACEMENT
+            if {"-", "+"}.issubset(changed_kinds)
+            else ActionableSelectionReason.SIMPLE
+        )
+        display_ids = actionable.display_ids if actionable is not None else tuple()
+        selection_ids = (
+            actionable.selection_ids
+            if actionable is not None else
+            tuple(
+                line.id
+                for line in rows
+                if line.kind in ("+", "-") and line.id is not None
+            )
+        )
+        selection_text = format_line_ids(list(display_ids)) if display_ids else None
+        changes.append(
+            ReviewChange(
+                index=len(changes) + 1,
+                total=0,
+                path=line_changes.path,
+                hunk_header=line_changes.header,
+                old_start=min(old_line_numbers) if old_line_numbers else None,
+                old_end=max(old_line_numbers) if old_line_numbers else None,
+                new_start=min(new_line_numbers) if new_line_numbers else None,
+                new_end=max(new_line_numbers) if new_line_numbers else None,
+                rows=tuple(rows),
+                display_ids=display_ids,
+                selection_ids=selection_ids,
+                select_as=selection_text,
+                reason=actionable.reason if actionable is not None else reason,
+                is_oversized=False,
+                note=(
+                    actionable.note
+                    if actionable is not None else
+                    _("not currently selectable")
+                ),
+                actions=actionable.actions if actionable is not None else tuple(),
+            )
+        )
+
+    def flush_segment() -> None:
+        nonlocal current_rows
+        pending_rows: list[LineEntry] = []
+        active_rows: list[LineEntry] = []
+        active_actionable: ActionableSelection | None = None
+        has_active_change = False
+        changed_run: list[LineEntry] = []
+        changed_run_displayable: bool | None = None
+        actionable_group_by_selection_id = {
+            selection_id: selection.selection_ids
+            for selection in actionable_selections
+            for selection_id in selection.selection_ids
+        }
+
+        def flush_active_change() -> None:
+            nonlocal active_rows, active_actionable, has_active_change
+            if has_active_change and active_rows:
+                append_change(active_rows, active_actionable)
+            active_rows = []
+            active_actionable = None
+            has_active_change = False
+
+        def activate_changed_run(
+            *,
+            trailing_rows: list[LineEntry] | None = None,
+        ) -> None:
+            nonlocal pending_rows, changed_run, active_rows, active_actionable
+            nonlocal has_active_change, changed_run_displayable
+
+            def actionable_for_chunk(
+                chunk_rows: list[LineEntry],
+                group: tuple[int, ...] | None,
+            ) -> ActionableSelection | None:
+                if group is None:
+                    return None
+                chunk_selection_ids = tuple(
+                    line.id
+                    for line in chunk_rows
+                    if line.id is not None
+                )
+                if chunk_selection_ids != group:
+                    return None
+                return actionable_by_selection.get(group)
+
+            chunks: list[tuple[list[LineEntry], ActionableSelection | None]] = []
+            current_chunk: list[LineEntry] = []
+            current_group: tuple[int, ...] | None = None
+            for line in changed_run:
+                group = (
+                    actionable_group_by_selection_id.get(line.id)
+                    if changed_run_displayable else
+                    None
+                )
+                if current_chunk and group != current_group:
+                    chunks.append(
+                        (
+                            current_chunk,
+                            actionable_for_chunk(current_chunk, current_group),
+                        )
+                    )
+                    current_chunk = []
+                current_chunk.append(line)
+                current_group = group
+
+            if current_chunk:
+                chunks.append(
+                    (
+                        current_chunk,
+                        actionable_for_chunk(current_chunk, current_group),
+                    )
+                )
+
+            for index, (chunk_rows, actionable) in enumerate(chunks):
+                flush_active_change()
+                active_rows = (pending_rows if index == 0 else []) + chunk_rows
+                if trailing_rows is not None and index == len(chunks) - 1:
+                    active_rows.extend(trailing_rows)
+                active_actionable = actionable
+                has_active_change = True
+            pending_rows = []
+            changed_run = []
+            changed_run_displayable = None
+
+        def changed_row_displayable(row: LineEntry) -> bool | None:
+            if row.kind not in ("+", "-") or row.id is None:
+                return None
+            if display_id_by_selection_id is None:
+                return True
+            return row.id in display_id_by_selection_id
+
+        for row in current_rows:
+            row_displayable = changed_row_displayable(row)
+            if row_displayable is not None:
+                if changed_run and changed_run_displayable != row_displayable:
+                    activate_changed_run()
+                changed_run.append(row)
+                changed_run_displayable = row_displayable
+                continue
+            if changed_run:
+                activate_changed_run(trailing_rows=[row])
+                continue
+            if has_active_change:
+                active_rows.append(row)
+            else:
+                pending_rows.append(row)
+
+        if changed_run:
+            activate_changed_run()
+        flush_active_change()
+        current_rows = []
+
+    for line in line_changes.lines:
+        is_gap = (
+            line.id is None
+            and line.kind == " "
+            and line.old_line_number is None
+            and line.new_line_number is None
+            and line.source_line is None
+        )
+        if is_gap:
+            flush_segment()
+            current_rows.append(line)
+            continue
+        current_rows.append(line)
+    flush_segment()
+
+    total = len(changes)
+    return tuple(
+        ReviewChange(
+            index=change.index,
+            total=total,
+            path=change.path,
+            hunk_header=change.hunk_header,
+            old_start=change.old_start,
+            old_end=change.old_end,
+            new_start=change.new_start,
+            new_end=change.new_end,
+            rows=change.rows,
+            display_ids=change.display_ids,
+            selection_ids=change.selection_ids,
+            select_as=change.select_as,
+            reason=change.reason,
+            is_oversized=change.is_oversized,
+            note=change.note,
+            actions=change.actions,
+        )
+        for change in changes
+    )

--- a/src/git_stage_batch/output/file_review_footer.py
+++ b/src/git_stage_batch/output/file_review_footer.py
@@ -1,0 +1,296 @@
+"""Footer command rendering for file review output."""
+
+from __future__ import annotations
+
+import os
+import shlex
+import sys
+
+from ..core.actionable_changes import ActionableSelection
+from ..core.line_selection import format_line_ids
+from ..data.file_review.action_commands import line_action_command
+from ..data.file_review.records import FileReviewAction, FileReviewState, ReviewSource
+from ..data.selected_change.store import SelectedChangeKind
+from ..i18n import _
+from .colors import Colors
+from .file_review_summary import change_summary, page_summary
+
+
+def _quote(value: str) -> str:
+    return shlex.quote(value)
+
+
+def _selection_supports_action(
+    selection: ActionableSelection,
+    action: FileReviewAction,
+) -> bool:
+    return not selection.actions or action.value in selection.actions
+
+
+def _line_spec_for_selections(selections: list[ActionableSelection]) -> str:
+    display_ids: list[int] = []
+    for selection in selections:
+        display_ids.extend(selection.display_ids)
+    return format_line_ids(display_ids)
+
+
+def _style_footer_command(command: str) -> str:
+    try:
+        tokens = shlex.split(command, posix=False)
+    except ValueError:
+        return command
+
+    dynamic_value_options = {"--file", "--from", "--line", "--page", "--to"}
+    if tokens[:2] == ["git", "stage-batch"]:
+        action_index = 2
+    elif tokens[:1] == ["git-stage-batch"]:
+        action_index = 1
+    else:
+        action_index = -1
+    styled_tokens: list[str] = []
+    bold_next = False
+    for index, token in enumerate(tokens):
+        should_bold = bold_next or index == action_index
+        if should_bold:
+            styled_tokens.append(f"{Colors.BOLD}{token}{Colors.RESET}")
+        else:
+            styled_tokens.append(token)
+        bold_next = token in dynamic_value_options
+    return " ".join(styled_tokens)
+
+
+def _invoked_command_prefix() -> str:
+    executable = os.path.basename(sys.argv[0])
+    if executable == "git" and len(sys.argv) > 1 and sys.argv[1] == "stage-batch":
+        return "git stage-batch"
+    return "git-stage-batch"
+
+
+def _display_footer_command(command: str) -> str:
+    if command.startswith("git-stage-batch "):
+        return _invoked_command_prefix() + command[len("git-stage-batch"):]
+    return command
+
+
+def print_file_review_footer(
+    path: str,
+    *,
+    shown_pages: tuple[int, ...],
+    page_count: int,
+    shown_change_spec: str,
+    shown_line_spec: str,
+    complete_line_action_selections: list[ActionableSelection],
+    total_changes: int,
+    command_source_args: str,
+    source: ReviewSource,
+    batch_name: str | None,
+) -> None:
+    """Print the command footer for one file review."""
+    shown = set(shown_pages)
+    is_entire = shown == set(range(1, page_count + 1))
+    hints: list[tuple[str, str]] = []
+    navigation_hints: list[tuple[str, str]] = []
+
+    review_state = _footer_review_state(
+        path=path,
+        shown_pages=shown_pages,
+        page_count=page_count,
+        source=source,
+        batch_name=batch_name,
+    )
+    primary_action = (
+        FileReviewAction.INCLUDE_FROM_BATCH
+        if source == ReviewSource.BATCH else
+        FileReviewAction.INCLUDE
+    )
+    primary_selections = [
+        selection
+        for selection in complete_line_action_selections
+        if _selection_supports_action(selection, primary_action)
+    ]
+    reset_selections = [
+        selection
+        for selection in complete_line_action_selections
+        if _selection_supports_action(selection, FileReviewAction.RESET_FROM_BATCH)
+    ]
+
+    if primary_selections:
+        combined_selection = _line_spec_for_selections(primary_selections)
+        include_line_command = line_action_command(
+            "include",
+            review_state,
+            line_spec=combined_selection,
+            pathless_line=True,
+        )
+        hints.append(
+            (
+                _("include"),
+                include_line_command
+                or (
+                    "git-stage-batch include"
+                    f"{command_source_args} --line {combined_selection}"
+                ),
+            )
+        )
+        if not command_source_args:
+            skip_line_command = line_action_command(
+                "skip",
+                review_state,
+                line_spec=combined_selection,
+                pathless_line=True,
+            )
+            hints.append(
+                (
+                    _("skip"),
+                    skip_line_command
+                    or f"git-stage-batch skip --line {combined_selection}",
+                )
+            )
+        discard_line_command = line_action_command(
+            "discard",
+            review_state,
+            line_spec=combined_selection,
+            pathless_line=True,
+        )
+        hints.append(
+            (
+                _("discard"),
+                discard_line_command
+                or (
+                    "git-stage-batch discard"
+                    f"{command_source_args} --line {combined_selection}"
+                ),
+            )
+        )
+        if source == ReviewSource.BATCH and reset_selections:
+            reset_selection = _line_spec_for_selections(reset_selections)
+            reset_line_command = line_action_command(
+                FileReviewAction.RESET_FROM_BATCH,
+                review_state,
+                line_spec=reset_selection,
+                pathless_line=True,
+            )
+            hints.append(
+                (
+                    _("reset"),
+                    reset_line_command
+                    or f"git-stage-batch reset{command_source_args} --line {reset_selection}",
+                )
+            )
+    elif reset_selections:
+        reset_selection = _line_spec_for_selections(reset_selections)
+        reset_line_command = line_action_command(
+            FileReviewAction.RESET_FROM_BATCH,
+            review_state,
+            line_spec=reset_selection,
+            pathless_line=True,
+        )
+        hints.append(
+            (
+                _("reset"),
+                reset_line_command
+                or f"git-stage-batch reset{command_source_args} --line {reset_selection}",
+            )
+        )
+    elif not is_entire:
+        hints.append((_("No complete change is actionable from this page."), ""))
+
+    if not is_entire and max(shown_pages) < page_count:
+        navigation_hints.append(
+            (
+                _("next"),
+                (
+                    "git-stage-batch show"
+                    f"{command_source_args} --file {_quote(path)} "
+                    f"--page {max(shown_pages) + 1}"
+                ),
+            )
+        )
+
+    if is_entire:
+        hints.append(
+            (
+                _("include"),
+                f"git-stage-batch include{command_source_args} --file {_quote(path)}",
+            )
+        )
+    else:
+        navigation_hints.append(
+            (
+                _("all"),
+                f"git-stage-batch show{command_source_args} --file {_quote(path)} --page all",
+            )
+        )
+
+    hints.extend(navigation_hints)
+    if not hints:
+        return
+
+    print()
+    use_color = Colors.enabled()
+    rule = "─" * 78
+    print(f"{Colors.GRAY}{rule}{Colors.RESET}" if use_color else rule)
+    status = "  ·  ".join(
+        (
+            path,
+            page_summary(shown_pages, page_count),
+            change_summary(shown_change_spec, total_changes),
+            _("lines {lines}").format(lines=shown_line_spec),
+        )
+    )
+    if use_color:
+        print(f"{Colors.BOLD}{status}{Colors.RESET}")
+    else:
+        print(status)
+    print()
+    action_width = max(len(action) for action, command in hints if command)
+    for action, command in hints:
+        if not command:
+            print(action)
+            continue
+        display_command = _display_footer_command(command)
+        action_text = action.ljust(action_width)
+        if use_color:
+            print(
+                f"{Colors.CYAN}{action_text}{Colors.RESET}  "
+                f"{_style_footer_command(display_command)}"
+            )
+        else:
+            print(f"{action_text}  {display_command}")
+
+
+def _footer_review_state(
+    *,
+    path: str,
+    shown_pages: tuple[int, ...],
+    page_count: int,
+    source: ReviewSource,
+    batch_name: str | None,
+) -> FileReviewState:
+    if source == ReviewSource.BATCH:
+        return FileReviewState(
+            source=ReviewSource.BATCH,
+            batch_name=batch_name,
+            file_path=path,
+            page_spec="all",
+            shown_pages=shown_pages,
+            page_count=page_count,
+            entire_file_shown=set(shown_pages) == set(range(1, page_count + 1)),
+            selections=tuple(),
+            selected_change_kind=SelectedChangeKind.BATCH_FILE,
+            selected_file_fingerprint="",
+            diff_fingerprint="",
+        )
+    return FileReviewState(
+        source=source,
+        batch_name=None,
+        file_path=path,
+        page_spec="all",
+        shown_pages=shown_pages,
+        page_count=page_count,
+        entire_file_shown=set(shown_pages) == set(range(1, page_count + 1)),
+        selections=tuple(),
+        selected_change_kind=SelectedChangeKind.FILE,
+        selected_file_fingerprint="",
+        diff_fingerprint="",
+    )

--- a/src/git_stage_batch/output/file_review_footer.py
+++ b/src/git_stage_batch/output/file_review_footer.py
@@ -7,31 +7,11 @@ import shlex
 import sys
 
 from ..core.actionable_changes import ActionableSelection
-from ..core.line_selection import format_line_ids
-from ..data.file_review.action_commands import line_action_command
-from ..data.file_review.records import FileReviewAction, FileReviewState, ReviewSource
-from ..data.selected_change.store import SelectedChangeKind
+from ..data.file_review.records import ReviewSource
 from ..i18n import _
 from .colors import Colors
+from . import file_review_footer_hints
 from .file_review_summary import change_summary, page_summary
-
-
-def _quote(value: str) -> str:
-    return shlex.quote(value)
-
-
-def _selection_supports_action(
-    selection: ActionableSelection,
-    action: FileReviewAction,
-) -> bool:
-    return not selection.actions or action.value in selection.actions
-
-
-def _line_spec_for_selections(selections: list[ActionableSelection]) -> str:
-    display_ids: list[int] = []
-    for selection in selections:
-        display_ids.extend(selection.display_ids)
-    return format_line_ids(display_ids)
 
 
 def _style_footer_command(command: str) -> str:
@@ -86,143 +66,15 @@ def print_file_review_footer(
     batch_name: str | None,
 ) -> None:
     """Print the command footer for one file review."""
-    shown = set(shown_pages)
-    is_entire = shown == set(range(1, page_count + 1))
-    hints: list[tuple[str, str]] = []
-    navigation_hints: list[tuple[str, str]] = []
-
-    review_state = _footer_review_state(
-        path=path,
+    hints = file_review_footer_hints.build_file_review_footer_hints(
+        path,
         shown_pages=shown_pages,
         page_count=page_count,
+        complete_line_action_selections=complete_line_action_selections,
+        command_source_args=command_source_args,
         source=source,
         batch_name=batch_name,
     )
-    primary_action = (
-        FileReviewAction.INCLUDE_FROM_BATCH
-        if source == ReviewSource.BATCH else
-        FileReviewAction.INCLUDE
-    )
-    primary_selections = [
-        selection
-        for selection in complete_line_action_selections
-        if _selection_supports_action(selection, primary_action)
-    ]
-    reset_selections = [
-        selection
-        for selection in complete_line_action_selections
-        if _selection_supports_action(selection, FileReviewAction.RESET_FROM_BATCH)
-    ]
-
-    if primary_selections:
-        combined_selection = _line_spec_for_selections(primary_selections)
-        include_line_command = line_action_command(
-            "include",
-            review_state,
-            line_spec=combined_selection,
-            pathless_line=True,
-        )
-        hints.append(
-            (
-                _("include"),
-                include_line_command
-                or (
-                    "git-stage-batch include"
-                    f"{command_source_args} --line {combined_selection}"
-                ),
-            )
-        )
-        if not command_source_args:
-            skip_line_command = line_action_command(
-                "skip",
-                review_state,
-                line_spec=combined_selection,
-                pathless_line=True,
-            )
-            hints.append(
-                (
-                    _("skip"),
-                    skip_line_command
-                    or f"git-stage-batch skip --line {combined_selection}",
-                )
-            )
-        discard_line_command = line_action_command(
-            "discard",
-            review_state,
-            line_spec=combined_selection,
-            pathless_line=True,
-        )
-        hints.append(
-            (
-                _("discard"),
-                discard_line_command
-                or (
-                    "git-stage-batch discard"
-                    f"{command_source_args} --line {combined_selection}"
-                ),
-            )
-        )
-        if source == ReviewSource.BATCH and reset_selections:
-            reset_selection = _line_spec_for_selections(reset_selections)
-            reset_line_command = line_action_command(
-                FileReviewAction.RESET_FROM_BATCH,
-                review_state,
-                line_spec=reset_selection,
-                pathless_line=True,
-            )
-            hints.append(
-                (
-                    _("reset"),
-                    reset_line_command
-                    or f"git-stage-batch reset{command_source_args} --line {reset_selection}",
-                )
-            )
-    elif reset_selections:
-        reset_selection = _line_spec_for_selections(reset_selections)
-        reset_line_command = line_action_command(
-            FileReviewAction.RESET_FROM_BATCH,
-            review_state,
-            line_spec=reset_selection,
-            pathless_line=True,
-        )
-        hints.append(
-            (
-                _("reset"),
-                reset_line_command
-                or f"git-stage-batch reset{command_source_args} --line {reset_selection}",
-            )
-        )
-    elif not is_entire:
-        hints.append((_("No complete change is actionable from this page."), ""))
-
-    if not is_entire and max(shown_pages) < page_count:
-        navigation_hints.append(
-            (
-                _("next"),
-                (
-                    "git-stage-batch show"
-                    f"{command_source_args} --file {_quote(path)} "
-                    f"--page {max(shown_pages) + 1}"
-                ),
-            )
-        )
-
-    if is_entire:
-        hints.append(
-            (
-                _("include"),
-                f"git-stage-batch include{command_source_args} --file {_quote(path)}",
-            )
-        )
-    else:
-        navigation_hints.append(
-            (
-                _("all"),
-                f"git-stage-batch show{command_source_args} --file {_quote(path)} --page all",
-            )
-        )
-
-    hints.extend(navigation_hints)
     if not hints:
         return
 
@@ -243,13 +95,13 @@ def print_file_review_footer(
     else:
         print(status)
     print()
-    action_width = max(len(action) for action, command in hints if command)
-    for action, command in hints:
-        if not command:
-            print(action)
+    action_width = max(len(hint.action) for hint in hints if hint.command)
+    for hint in hints:
+        if not hint.command:
+            print(hint.action)
             continue
-        display_command = _display_footer_command(command)
-        action_text = action.ljust(action_width)
+        display_command = _display_footer_command(hint.command)
+        action_text = hint.action.ljust(action_width)
         if use_color:
             print(
                 f"{Colors.CYAN}{action_text}{Colors.RESET}  "
@@ -257,40 +109,3 @@ def print_file_review_footer(
             )
         else:
             print(f"{action_text}  {display_command}")
-
-
-def _footer_review_state(
-    *,
-    path: str,
-    shown_pages: tuple[int, ...],
-    page_count: int,
-    source: ReviewSource,
-    batch_name: str | None,
-) -> FileReviewState:
-    if source == ReviewSource.BATCH:
-        return FileReviewState(
-            source=ReviewSource.BATCH,
-            batch_name=batch_name,
-            file_path=path,
-            page_spec="all",
-            shown_pages=shown_pages,
-            page_count=page_count,
-            entire_file_shown=set(shown_pages) == set(range(1, page_count + 1)),
-            selections=tuple(),
-            selected_change_kind=SelectedChangeKind.BATCH_FILE,
-            selected_file_fingerprint="",
-            diff_fingerprint="",
-        )
-    return FileReviewState(
-        source=source,
-        batch_name=None,
-        file_path=path,
-        page_spec="all",
-        shown_pages=shown_pages,
-        page_count=page_count,
-        entire_file_shown=set(shown_pages) == set(range(1, page_count + 1)),
-        selections=tuple(),
-        selected_change_kind=SelectedChangeKind.FILE,
-        selected_file_fingerprint="",
-        diff_fingerprint="",
-    )

--- a/src/git_stage_batch/output/file_review_footer_hints.py
+++ b/src/git_stage_batch/output/file_review_footer_hints.py
@@ -1,0 +1,231 @@
+"""Command hint construction for file review footers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import shlex
+
+from ..core.actionable_changes import ActionableSelection
+from ..core.line_selection import format_line_ids
+from ..data.file_review.action_commands import line_action_command
+from ..data.file_review.records import FileReviewAction, FileReviewState, ReviewSource
+from ..data.selected_change.store import SelectedChangeKind
+from ..i18n import _
+
+
+@dataclass(frozen=True)
+class FileReviewFooterHint:
+    action: str
+    command: str
+
+
+def _quote(value: str) -> str:
+    return shlex.quote(value)
+
+
+def _selection_supports_action(
+    selection: ActionableSelection,
+    action: FileReviewAction,
+) -> bool:
+    return not selection.actions or action.value in selection.actions
+
+
+def _line_spec_for_selections(selections: list[ActionableSelection]) -> str:
+    display_ids: list[int] = []
+    for selection in selections:
+        display_ids.extend(selection.display_ids)
+    return format_line_ids(display_ids)
+
+
+def build_file_review_footer_hints(
+    path: str,
+    *,
+    shown_pages: tuple[int, ...],
+    page_count: int,
+    complete_line_action_selections: list[ActionableSelection],
+    command_source_args: str,
+    source: ReviewSource,
+    batch_name: str | None,
+) -> tuple[FileReviewFooterHint, ...]:
+    """Return command hints for one file-review footer."""
+    shown = set(shown_pages)
+    is_entire = shown == set(range(1, page_count + 1))
+    hints: list[FileReviewFooterHint] = []
+    navigation_hints: list[FileReviewFooterHint] = []
+
+    review_state = _footer_review_state(
+        path=path,
+        shown_pages=shown_pages,
+        page_count=page_count,
+        source=source,
+        batch_name=batch_name,
+    )
+    primary_action = (
+        FileReviewAction.INCLUDE_FROM_BATCH
+        if source == ReviewSource.BATCH else
+        FileReviewAction.INCLUDE
+    )
+    primary_selections = [
+        selection
+        for selection in complete_line_action_selections
+        if _selection_supports_action(selection, primary_action)
+    ]
+    reset_selections = [
+        selection
+        for selection in complete_line_action_selections
+        if _selection_supports_action(selection, FileReviewAction.RESET_FROM_BATCH)
+    ]
+
+    if primary_selections:
+        combined_selection = _line_spec_for_selections(primary_selections)
+        include_line_command = line_action_command(
+            "include",
+            review_state,
+            line_spec=combined_selection,
+            pathless_line=True,
+        )
+        hints.append(
+            FileReviewFooterHint(
+                _("include"),
+                include_line_command
+                or (
+                    "git-stage-batch include"
+                    f"{command_source_args} --line {combined_selection}"
+                ),
+            )
+        )
+        if not command_source_args:
+            skip_line_command = line_action_command(
+                "skip",
+                review_state,
+                line_spec=combined_selection,
+                pathless_line=True,
+            )
+            hints.append(
+                FileReviewFooterHint(
+                    _("skip"),
+                    skip_line_command
+                    or f"git-stage-batch skip --line {combined_selection}",
+                )
+            )
+        discard_line_command = line_action_command(
+            "discard",
+            review_state,
+            line_spec=combined_selection,
+            pathless_line=True,
+        )
+        hints.append(
+            FileReviewFooterHint(
+                _("discard"),
+                discard_line_command
+                or (
+                    "git-stage-batch discard"
+                    f"{command_source_args} --line {combined_selection}"
+                ),
+            )
+        )
+        if source == ReviewSource.BATCH and reset_selections:
+            reset_selection = _line_spec_for_selections(reset_selections)
+            reset_line_command = line_action_command(
+                FileReviewAction.RESET_FROM_BATCH,
+                review_state,
+                line_spec=reset_selection,
+                pathless_line=True,
+            )
+            hints.append(
+                FileReviewFooterHint(
+                    _("reset"),
+                    reset_line_command
+                    or f"git-stage-batch reset{command_source_args} --line {reset_selection}",
+                )
+            )
+    elif reset_selections:
+        reset_selection = _line_spec_for_selections(reset_selections)
+        reset_line_command = line_action_command(
+            FileReviewAction.RESET_FROM_BATCH,
+            review_state,
+            line_spec=reset_selection,
+            pathless_line=True,
+        )
+        hints.append(
+            FileReviewFooterHint(
+                _("reset"),
+                reset_line_command
+                or f"git-stage-batch reset{command_source_args} --line {reset_selection}",
+            )
+        )
+    elif not is_entire:
+        hints.append(
+            FileReviewFooterHint(
+                _("No complete change is actionable from this page."),
+                "",
+            )
+        )
+
+    if not is_entire and max(shown_pages) < page_count:
+        navigation_hints.append(
+            FileReviewFooterHint(
+                _("next"),
+                (
+                    "git-stage-batch show"
+                    f"{command_source_args} --file {_quote(path)} "
+                    f"--page {max(shown_pages) + 1}"
+                ),
+            )
+        )
+
+    if is_entire:
+        hints.append(
+            FileReviewFooterHint(
+                _("include"),
+                f"git-stage-batch include{command_source_args} --file {_quote(path)}",
+            )
+        )
+    else:
+        navigation_hints.append(
+            FileReviewFooterHint(
+                _("all"),
+                f"git-stage-batch show{command_source_args} --file {_quote(path)} --page all",
+            )
+        )
+
+    hints.extend(navigation_hints)
+    return tuple(hints)
+
+
+def _footer_review_state(
+    *,
+    path: str,
+    shown_pages: tuple[int, ...],
+    page_count: int,
+    source: ReviewSource,
+    batch_name: str | None,
+) -> FileReviewState:
+    entire_file_shown = set(shown_pages) == set(range(1, page_count + 1))
+    if source == ReviewSource.BATCH:
+        return FileReviewState(
+            source=ReviewSource.BATCH,
+            batch_name=batch_name,
+            file_path=path,
+            page_spec="all",
+            shown_pages=shown_pages,
+            page_count=page_count,
+            entire_file_shown=entire_file_shown,
+            selections=tuple(),
+            selected_change_kind=SelectedChangeKind.BATCH_FILE,
+            selected_file_fingerprint="",
+            diff_fingerprint="",
+        )
+    return FileReviewState(
+        source=source,
+        batch_name=None,
+        file_path=path,
+        page_spec="all",
+        shown_pages=shown_pages,
+        page_count=page_count,
+        entire_file_shown=entire_file_shown,
+        selections=tuple(),
+        selected_change_kind=SelectedChangeKind.FILE,
+        selected_file_fingerprint="",
+        diff_fingerprint="",
+    )

--- a/src/git_stage_batch/output/file_review_model_builder.py
+++ b/src/git_stage_batch/output/file_review_model_builder.py
@@ -10,13 +10,8 @@ from ..core.actionable_changes import (
 from ..core.line_selection import format_line_ids
 from ..core.models import LineEntry, LineLevelChange, ReviewActionGroup
 from ..i18n import _
-from . import file_review_layout
-from .file_review_model import (
-    FileReviewModel,
-    FileReviewPage,
-    ReviewChange,
-    ReviewChangeFragment,
-)
+from .file_review_model import FileReviewModel, ReviewChange
+from .file_review_pagination import paginate_file_review_changes
 
 
 def _partly_selects_ownership_group(
@@ -404,101 +399,13 @@ def build_file_review_model(
         for change in changes
     ]
 
-    body_budget = file_review_layout.body_budget()
-    page_fragments: list[
-        list[tuple[ReviewChange, tuple[LineEntry, ...], bool, bool]]
-    ] = []
-    current_page: list[tuple[ReviewChange, tuple[LineEntry, ...], bool, bool]] = []
-    current_height = 0
-    for change in changes:
-        change_height = len(change.rows) + 2
-        if change_height <= body_budget or body_budget <= 2:
-            if current_page and current_height + change_height > body_budget:
-                page_fragments.append(current_page)
-                current_page = []
-                current_height = 0
-            current_page.append((change, change.rows, True, True))
-            current_height += change_height
-            continue
-
-        rows_per_fragment = max(1, body_budget - 2)
-        row_chunks = [
-            tuple(change.rows[index:index + rows_per_fragment])
-            for index in range(0, len(change.rows), rows_per_fragment)
-        ]
-        for chunk_index, row_chunk in enumerate(row_chunks):
-            fragment_height = len(row_chunk) + 2
-            if current_page:
-                page_fragments.append(current_page)
-                current_page = []
-            current_page.append(
-                (
-                    change,
-                    row_chunk,
-                    chunk_index == 0,
-                    chunk_index == len(row_chunks) - 1,
-                )
-            )
-            current_height = fragment_height
-            if chunk_index < len(row_chunks) - 1:
-                page_fragments.append(current_page)
-                current_page = []
-                current_height = 0
-    if current_page:
-        page_fragments.append(current_page)
-    if not page_fragments:
-        page_fragments = [[]]
-
-    change_pages: dict[int, list[int]] = {}
-    for page_number, fragments in enumerate(page_fragments, start=1):
-        for change, _rows, _is_first, _is_last in fragments:
-            change_pages.setdefault(change.index, []).append(page_number)
-
-    paged_changes: list[ReviewChange] = []
-    for change in changes:
-        pages_for_change = change_pages.get(change.index, [1])
-        paged_changes.append(
-            ReviewChange(
-                index=change.index,
-                total=change.total,
-                path=change.path,
-                hunk_header=change.hunk_header,
-                old_start=change.old_start,
-                old_end=change.old_end,
-                new_start=change.new_start,
-                new_end=change.new_end,
-                rows=change.rows,
-                display_ids=change.display_ids,
-                selection_ids=change.selection_ids,
-                select_as=change.select_as,
-                reason=change.reason,
-                is_oversized=(len(change.rows) + 2) > body_budget,
-                note=change.note,
-                actions=change.actions,
-                first_page=min(pages_for_change),
-                last_page=max(pages_for_change),
-            )
-        )
-    by_index = {change.index: change for change in paged_changes}
-    final_pages = tuple(
-        FileReviewPage(
-            page=page_number,
-            changes=tuple(
-                ReviewChangeFragment(
-                    change=by_index[change.index],
-                    rows=rows,
-                    is_first_fragment=is_first,
-                    is_last_fragment=is_last,
-                )
-                for change, rows, is_first, is_last in fragments
-            ),
-        )
-        for page_number, fragments in enumerate(page_fragments, start=1)
+    paged_changes, pages = paginate_file_review_changes(
+        tuple(changes),
     )
     return FileReviewModel(
         line_changes=line_changes,
-        changes=tuple(paged_changes),
-        pages=final_pages,
+        changes=paged_changes,
+        pages=pages,
         display_id_by_selection_id=display_id_by_selection_id,
         review_action_groups=review_action_groups or (),
     )

--- a/src/git_stage_batch/output/file_review_model_builder.py
+++ b/src/git_stage_batch/output/file_review_model_builder.py
@@ -2,11 +2,9 @@
 
 from __future__ import annotations
 
-from ..core.actionable_changes import ActionableSelection, ActionableSelectionReason
-from ..core.line_selection import format_line_ids
-from ..core.models import LineEntry, LineLevelChange, ReviewActionGroup
-from ..i18n import _
-from .file_review_model import FileReviewModel, ReviewChange
+from ..core.models import LineLevelChange, ReviewActionGroup
+from .file_review_changes import build_file_review_changes
+from .file_review_model import FileReviewModel
 from .file_review_model_selections import derive_file_review_actionable_selections
 from .file_review_pagination import paginate_file_review_changes
 
@@ -19,8 +17,6 @@ def build_file_review_model(
     review_action_groups: tuple[ReviewActionGroup, ...] | None = None,
 ) -> FileReviewModel:
     """Build a conservative change-first page model from a file-scoped hunk."""
-    changes: list[ReviewChange] = []
-    current_rows: list[LineEntry] = []
     display_id_by_selection_id = (
         {
             selection_id: gutter_id
@@ -35,212 +31,14 @@ def build_file_review_model(
         review_action_groups=review_action_groups,
         display_id_by_selection_id=display_id_by_selection_id,
     )
-    actionable_by_selection = {
-        selection.selection_ids: selection
-        for selection in actionable_selections
-    }
-
-    def append_change(rows: list[LineEntry], actionable: ActionableSelection | None) -> None:
-        old_line_numbers = [
-            line.old_line_number
-            for line in rows
-            if line.kind != "+" and line.old_line_number is not None
-        ]
-        new_line_numbers = [
-            line.new_line_number
-            for line in rows
-            if line.kind != "-" and line.new_line_number is not None
-        ]
-        changed_kinds = {line.kind for line in rows if line.kind in ("+", "-")}
-        reason = (
-            ActionableSelectionReason.REPLACEMENT
-            if {"-", "+"}.issubset(changed_kinds)
-            else ActionableSelectionReason.SIMPLE
-        )
-        display_ids = actionable.display_ids if actionable is not None else tuple()
-        selection_ids = (
-            actionable.selection_ids
-            if actionable is not None else
-            tuple(
-                line.id
-                for line in rows
-                if line.kind in ("+", "-") and line.id is not None
-            )
-        )
-        selection_text = format_line_ids(list(display_ids)) if display_ids else None
-        changes.append(
-            ReviewChange(
-                index=len(changes) + 1,
-                total=0,
-                path=line_changes.path,
-                hunk_header=line_changes.header,
-                old_start=min(old_line_numbers) if old_line_numbers else None,
-                old_end=max(old_line_numbers) if old_line_numbers else None,
-                new_start=min(new_line_numbers) if new_line_numbers else None,
-                new_end=max(new_line_numbers) if new_line_numbers else None,
-                rows=tuple(rows),
-                display_ids=display_ids,
-                selection_ids=selection_ids,
-                select_as=selection_text,
-                reason=actionable.reason if actionable is not None else reason,
-                is_oversized=False,
-                note=(
-                    actionable.note
-                    if actionable is not None else
-                    _("not currently selectable")
-                ),
-                actions=actionable.actions if actionable is not None else tuple(),
-            )
-        )
-
-    def flush_segment() -> None:
-        nonlocal current_rows
-        pending_rows: list[LineEntry] = []
-        active_rows: list[LineEntry] = []
-        active_actionable: ActionableSelection | None = None
-        has_active_change = False
-        changed_run: list[LineEntry] = []
-        changed_run_displayable: bool | None = None
-        actionable_group_by_selection_id = {
-            selection_id: selection.selection_ids
-            for selection in actionable_selections
-            for selection_id in selection.selection_ids
-        }
-
-        def flush_active_change() -> None:
-            nonlocal active_rows, active_actionable, has_active_change
-            if has_active_change and active_rows:
-                append_change(active_rows, active_actionable)
-            active_rows = []
-            active_actionable = None
-            has_active_change = False
-
-        def activate_changed_run(*, trailing_rows: list[LineEntry] | None = None) -> None:
-            nonlocal pending_rows, changed_run, active_rows, active_actionable
-            nonlocal has_active_change, changed_run_displayable
-
-            def actionable_for_chunk(
-                chunk_rows: list[LineEntry],
-                group: tuple[int, ...] | None,
-            ) -> ActionableSelection | None:
-                if group is None:
-                    return None
-                chunk_selection_ids = tuple(
-                    line.id
-                    for line in chunk_rows
-                    if line.id is not None
-                )
-                if chunk_selection_ids != group:
-                    return None
-                return actionable_by_selection.get(group)
-
-            chunks: list[tuple[list[LineEntry], ActionableSelection | None]] = []
-            current_chunk: list[LineEntry] = []
-            current_group: tuple[int, ...] | None = None
-            for line in changed_run:
-                group = (
-                    actionable_group_by_selection_id.get(line.id)
-                    if changed_run_displayable else
-                    None
-                )
-                if current_chunk and group != current_group:
-                    chunks.append(
-                        (
-                            current_chunk,
-                            actionable_for_chunk(current_chunk, current_group),
-                        )
-                    )
-                    current_chunk = []
-                current_chunk.append(line)
-                current_group = group
-
-            if current_chunk:
-                chunks.append(
-                    (
-                        current_chunk,
-                        actionable_for_chunk(current_chunk, current_group),
-                    )
-                )
-
-            for index, (chunk_rows, actionable) in enumerate(chunks):
-                flush_active_change()
-                active_rows = (pending_rows if index == 0 else []) + chunk_rows
-                if trailing_rows is not None and index == len(chunks) - 1:
-                    active_rows.extend(trailing_rows)
-                active_actionable = actionable
-                has_active_change = True
-            pending_rows = []
-            changed_run = []
-            changed_run_displayable = None
-
-        def changed_row_displayable(row: LineEntry) -> bool | None:
-            if row.kind not in ("+", "-") or row.id is None:
-                return None
-            if display_id_by_selection_id is None:
-                return True
-            return row.id in display_id_by_selection_id
-
-        for row in current_rows:
-            row_displayable = changed_row_displayable(row)
-            if row_displayable is not None:
-                if changed_run and changed_run_displayable != row_displayable:
-                    activate_changed_run()
-                changed_run.append(row)
-                changed_run_displayable = row_displayable
-                continue
-            if changed_run:
-                activate_changed_run(trailing_rows=[row])
-                continue
-            if has_active_change:
-                active_rows.append(row)
-            else:
-                pending_rows.append(row)
-
-        if changed_run:
-            activate_changed_run()
-        flush_active_change()
-        current_rows = []
-
-    for line in line_changes.lines:
-        is_gap = (
-            line.id is None
-            and line.kind == " "
-            and line.old_line_number is None
-            and line.new_line_number is None
-            and line.source_line is None
-        )
-        if is_gap:
-            flush_segment()
-            current_rows.append(line)
-            continue
-        current_rows.append(line)
-    flush_segment()
-
-    total = len(changes)
-    changes = [
-        ReviewChange(
-            index=change.index,
-            total=total,
-            path=change.path,
-            hunk_header=change.hunk_header,
-            old_start=change.old_start,
-            old_end=change.old_end,
-            new_start=change.new_start,
-            new_end=change.new_end,
-            rows=change.rows,
-            display_ids=change.display_ids,
-            selection_ids=change.selection_ids,
-            select_as=change.select_as,
-            reason=change.reason,
-            is_oversized=change.is_oversized,
-            note=change.note,
-            actions=change.actions,
-        )
-        for change in changes
-    ]
+    changes = build_file_review_changes(
+        line_changes,
+        actionable_selections,
+        display_id_by_selection_id,
+    )
 
     paged_changes, pages = paginate_file_review_changes(
-        tuple(changes),
+        changes,
     )
     return FileReviewModel(
         line_changes=line_changes,

--- a/src/git_stage_batch/output/file_review_model_builder.py
+++ b/src/git_stage_batch/output/file_review_model_builder.py
@@ -2,153 +2,13 @@
 
 from __future__ import annotations
 
-from ..core.actionable_changes import (
-    ActionableSelection,
-    ActionableSelectionReason,
-    derive_actionable_selections,
-)
+from ..core.actionable_changes import ActionableSelection, ActionableSelectionReason
 from ..core.line_selection import format_line_ids
 from ..core.models import LineEntry, LineLevelChange, ReviewActionGroup
 from ..i18n import _
 from .file_review_model import FileReviewModel, ReviewChange
+from .file_review_model_selections import derive_file_review_actionable_selections
 from .file_review_pagination import paginate_file_review_changes
-
-
-def _partly_selects_ownership_group(
-    selection: ActionableSelection,
-    ownership_group_sets: list[set[int]],
-) -> bool:
-    """Return whether a review selection splits a complete batch ownership group."""
-    selected_ids = set(selection.selection_ids)
-    return any(
-        selected_ids & ownership_group
-        and not ownership_group.issubset(selected_ids)
-        for ownership_group in ownership_group_sets
-    )
-
-
-def _reason_for_selection_ids(
-    line_changes: LineLevelChange,
-    selection_ids: tuple[int, ...],
-) -> ActionableSelectionReason:
-    selected_id_set = set(selection_ids)
-    saw_addition = False
-    saw_deletion = False
-    for line in line_changes.lines:
-        if line.id not in selected_id_set or line.kind not in ("+", "-"):
-            continue
-        if line.kind == "+":
-            saw_addition = True
-        else:
-            saw_deletion = True
-        if saw_addition and saw_deletion:
-            return ActionableSelectionReason.REPLACEMENT
-    return ActionableSelectionReason.SIMPLE
-
-
-def _actionable_selections_from_selection_groups(
-    line_changes: LineLevelChange,
-    selection_groups: tuple[tuple[int, ...], ...],
-    display_id_by_selection_id: dict[int, int] | None,
-) -> tuple[ActionableSelection, ...]:
-    """Create review selections directly from complete ownership groups."""
-    selections: list[ActionableSelection] = []
-    for group in selection_groups:
-        selection_ids = tuple(
-            selection_id
-            for selection_id in group
-            if selection_id is not None
-        )
-        if not selection_ids:
-            continue
-        if display_id_by_selection_id is None:
-            display_ids = selection_ids
-        else:
-            if any(
-                selection_id not in display_id_by_selection_id
-                for selection_id in selection_ids
-            ):
-                continue
-            display_ids = tuple(
-                display_id_by_selection_id[selection_id]
-                for selection_id in selection_ids
-            )
-        selections.append(
-            ActionableSelection(
-                display_ids=display_ids,
-                selection_ids=selection_ids,
-                reason=_reason_for_selection_ids(line_changes, selection_ids),
-            )
-        )
-    return tuple(selections)
-
-
-def _display_actionable_selections_from_review_action_groups(
-    line_changes: LineLevelChange,
-    review_action_groups: tuple[ReviewActionGroup, ...],
-    gutter_to_selection_id: dict[int, int] | None,
-) -> tuple[ActionableSelection, ...]:
-    """Derive user-facing batch review changes without splitting reset atoms."""
-    action_group_by_selection_id = {
-        selection_id: group
-        for group in review_action_groups
-        for selection_id in group.selection_ids
-    }
-    atomic_group_sets = [
-        set(group.selection_ids)
-        for group in review_action_groups
-        if group.reason in (
-            ActionableSelectionReason.REPLACEMENT.value,
-            ActionableSelectionReason.STRUCTURAL_RUN.value,
-        )
-    ]
-    selections = []
-    for selection in derive_actionable_selections(
-        line_changes,
-        gutter_to_selection_id=gutter_to_selection_id,
-    ):
-        chunk_display_ids: list[int] = []
-        chunk_selection_ids: list[int] = []
-        chunk_actions: tuple[str, ...] | None = None
-
-        def flush_chunk() -> None:
-            nonlocal chunk_display_ids, chunk_selection_ids, chunk_actions
-            if not chunk_display_ids or chunk_actions is None:
-                chunk_display_ids = []
-                chunk_selection_ids = []
-                chunk_actions = None
-                return
-            chunk = ActionableSelection(
-                display_ids=tuple(chunk_display_ids),
-                selection_ids=tuple(chunk_selection_ids),
-                reason=_reason_for_selection_ids(
-                    line_changes,
-                    tuple(chunk_selection_ids),
-                ),
-                actions=chunk_actions,
-            )
-            if not _partly_selects_ownership_group(chunk, atomic_group_sets):
-                selections.append(chunk)
-            chunk_display_ids = []
-            chunk_selection_ids = []
-            chunk_actions = None
-
-        for display_id, selection_id in zip(
-            selection.display_ids,
-            selection.selection_ids,
-        ):
-            action_group = action_group_by_selection_id.get(selection_id)
-            if action_group is None:
-                flush_chunk()
-                continue
-            actions = action_group.actions
-            if chunk_actions is not None and actions != chunk_actions:
-                flush_chunk()
-            chunk_display_ids.append(display_id)
-            chunk_selection_ids.append(selection_id)
-            chunk_actions = actions
-        flush_chunk()
-    return tuple(selections)
 
 
 def build_file_review_model(
@@ -168,33 +28,13 @@ def build_file_review_model(
         }
         if gutter_to_selection_id is not None else None
     )
-    if review_action_groups is not None:
-        actionable_selections = _display_actionable_selections_from_review_action_groups(
-            line_changes,
-            review_action_groups,
-            gutter_to_selection_id,
-        )
-    elif actionable_selection_groups is not None:
-        actionable_selections = _actionable_selections_from_selection_groups(
-            line_changes,
-            actionable_selection_groups,
-            display_id_by_selection_id,
-        )
-        ownership_group_sets = [
-            set(group)
-            for group in actionable_selection_groups
-            if group
-        ]
-        actionable_selections = tuple(
-            selection
-            for selection in actionable_selections
-            if not _partly_selects_ownership_group(selection, ownership_group_sets)
-        )
-    else:
-        actionable_selections = derive_actionable_selections(
-            line_changes,
-            gutter_to_selection_id=gutter_to_selection_id,
-        )
+    actionable_selections = derive_file_review_actionable_selections(
+        line_changes,
+        gutter_to_selection_id=gutter_to_selection_id,
+        actionable_selection_groups=actionable_selection_groups,
+        review_action_groups=review_action_groups,
+        display_id_by_selection_id=display_id_by_selection_id,
+    )
     actionable_by_selection = {
         selection.selection_ids: selection
         for selection in actionable_selections

--- a/src/git_stage_batch/output/file_review_model_selections.py
+++ b/src/git_stage_batch/output/file_review_model_selections.py
@@ -1,0 +1,184 @@
+"""Actionable selection derivation for file review model construction."""
+
+from __future__ import annotations
+
+from ..core.actionable_changes import (
+    ActionableSelection,
+    ActionableSelectionReason,
+    derive_actionable_selections,
+)
+from ..core.models import LineLevelChange, ReviewActionGroup
+
+
+def _partly_selects_ownership_group(
+    selection: ActionableSelection,
+    ownership_group_sets: list[set[int]],
+) -> bool:
+    """Return whether a review selection splits a complete batch ownership group."""
+    selected_ids = set(selection.selection_ids)
+    return any(
+        selected_ids & ownership_group
+        and not ownership_group.issubset(selected_ids)
+        for ownership_group in ownership_group_sets
+    )
+
+
+def _reason_for_selection_ids(
+    line_changes: LineLevelChange,
+    selection_ids: tuple[int, ...],
+) -> ActionableSelectionReason:
+    selected_id_set = set(selection_ids)
+    saw_addition = False
+    saw_deletion = False
+    for line in line_changes.lines:
+        if line.id not in selected_id_set or line.kind not in ("+", "-"):
+            continue
+        if line.kind == "+":
+            saw_addition = True
+        else:
+            saw_deletion = True
+        if saw_addition and saw_deletion:
+            return ActionableSelectionReason.REPLACEMENT
+    return ActionableSelectionReason.SIMPLE
+
+
+def _actionable_selections_from_selection_groups(
+    line_changes: LineLevelChange,
+    selection_groups: tuple[tuple[int, ...], ...],
+    display_id_by_selection_id: dict[int, int] | None,
+) -> tuple[ActionableSelection, ...]:
+    """Create review selections directly from complete ownership groups."""
+    selections: list[ActionableSelection] = []
+    for group in selection_groups:
+        selection_ids = tuple(
+            selection_id
+            for selection_id in group
+            if selection_id is not None
+        )
+        if not selection_ids:
+            continue
+        if display_id_by_selection_id is None:
+            display_ids = selection_ids
+        else:
+            if any(
+                selection_id not in display_id_by_selection_id
+                for selection_id in selection_ids
+            ):
+                continue
+            display_ids = tuple(
+                display_id_by_selection_id[selection_id]
+                for selection_id in selection_ids
+            )
+        selections.append(
+            ActionableSelection(
+                display_ids=display_ids,
+                selection_ids=selection_ids,
+                reason=_reason_for_selection_ids(line_changes, selection_ids),
+            )
+        )
+    return tuple(selections)
+
+
+def _display_actionable_selections_from_review_action_groups(
+    line_changes: LineLevelChange,
+    review_action_groups: tuple[ReviewActionGroup, ...],
+    gutter_to_selection_id: dict[int, int] | None,
+) -> tuple[ActionableSelection, ...]:
+    """Derive user-facing batch review changes without splitting reset atoms."""
+    action_group_by_selection_id = {
+        selection_id: group
+        for group in review_action_groups
+        for selection_id in group.selection_ids
+    }
+    atomic_group_sets = [
+        set(group.selection_ids)
+        for group in review_action_groups
+        if group.reason in (
+            ActionableSelectionReason.REPLACEMENT.value,
+            ActionableSelectionReason.STRUCTURAL_RUN.value,
+        )
+    ]
+    selections = []
+    for selection in derive_actionable_selections(
+        line_changes,
+        gutter_to_selection_id=gutter_to_selection_id,
+    ):
+        chunk_display_ids: list[int] = []
+        chunk_selection_ids: list[int] = []
+        chunk_actions: tuple[str, ...] | None = None
+
+        def flush_chunk() -> None:
+            nonlocal chunk_display_ids, chunk_selection_ids, chunk_actions
+            if not chunk_display_ids or chunk_actions is None:
+                chunk_display_ids = []
+                chunk_selection_ids = []
+                chunk_actions = None
+                return
+            chunk = ActionableSelection(
+                display_ids=tuple(chunk_display_ids),
+                selection_ids=tuple(chunk_selection_ids),
+                reason=_reason_for_selection_ids(
+                    line_changes,
+                    tuple(chunk_selection_ids),
+                ),
+                actions=chunk_actions,
+            )
+            if not _partly_selects_ownership_group(chunk, atomic_group_sets):
+                selections.append(chunk)
+            chunk_display_ids = []
+            chunk_selection_ids = []
+            chunk_actions = None
+
+        for display_id, selection_id in zip(
+            selection.display_ids,
+            selection.selection_ids,
+        ):
+            action_group = action_group_by_selection_id.get(selection_id)
+            if action_group is None:
+                flush_chunk()
+                continue
+            actions = action_group.actions
+            if chunk_actions is not None and actions != chunk_actions:
+                flush_chunk()
+            chunk_display_ids.append(display_id)
+            chunk_selection_ids.append(selection_id)
+            chunk_actions = actions
+        flush_chunk()
+    return tuple(selections)
+
+
+def derive_file_review_actionable_selections(
+    line_changes: LineLevelChange,
+    *,
+    gutter_to_selection_id: dict[int, int] | None,
+    actionable_selection_groups: tuple[tuple[int, ...], ...] | None,
+    review_action_groups: tuple[ReviewActionGroup, ...] | None,
+    display_id_by_selection_id: dict[int, int] | None,
+) -> tuple[ActionableSelection, ...]:
+    """Return selections that file-review model construction can display."""
+    if review_action_groups is not None:
+        return _display_actionable_selections_from_review_action_groups(
+            line_changes,
+            review_action_groups,
+            gutter_to_selection_id,
+        )
+    if actionable_selection_groups is not None:
+        actionable_selections = _actionable_selections_from_selection_groups(
+            line_changes,
+            actionable_selection_groups,
+            display_id_by_selection_id,
+        )
+        ownership_group_sets = [
+            set(group)
+            for group in actionable_selection_groups
+            if group
+        ]
+        return tuple(
+            selection
+            for selection in actionable_selections
+            if not _partly_selects_ownership_group(selection, ownership_group_sets)
+        )
+    return derive_actionable_selections(
+        line_changes,
+        gutter_to_selection_id=gutter_to_selection_id,
+    )

--- a/src/git_stage_batch/output/file_review_pagination.py
+++ b/src/git_stage_batch/output/file_review_pagination.py
@@ -1,0 +1,105 @@
+"""Pagination for file review output models."""
+
+from __future__ import annotations
+
+from ..core.models import LineEntry
+from . import file_review_layout
+from .file_review_model import FileReviewPage, ReviewChange, ReviewChangeFragment
+
+
+def paginate_file_review_changes(
+    changes: tuple[ReviewChange, ...],
+) -> tuple[tuple[ReviewChange, ...], tuple[FileReviewPage, ...]]:
+    """Return page-aware changes and pages for file-review output."""
+    body_budget = file_review_layout.body_budget()
+    page_fragments: list[
+        list[tuple[ReviewChange, tuple[LineEntry, ...], bool, bool]]
+    ] = []
+    current_page: list[tuple[ReviewChange, tuple[LineEntry, ...], bool, bool]] = []
+    current_height = 0
+    for change in changes:
+        change_height = len(change.rows) + 2
+        if change_height <= body_budget or body_budget <= 2:
+            if current_page and current_height + change_height > body_budget:
+                page_fragments.append(current_page)
+                current_page = []
+                current_height = 0
+            current_page.append((change, change.rows, True, True))
+            current_height += change_height
+            continue
+
+        rows_per_fragment = max(1, body_budget - 2)
+        row_chunks = [
+            tuple(change.rows[index:index + rows_per_fragment])
+            for index in range(0, len(change.rows), rows_per_fragment)
+        ]
+        for chunk_index, row_chunk in enumerate(row_chunks):
+            fragment_height = len(row_chunk) + 2
+            if current_page:
+                page_fragments.append(current_page)
+                current_page = []
+            current_page.append(
+                (
+                    change,
+                    row_chunk,
+                    chunk_index == 0,
+                    chunk_index == len(row_chunks) - 1,
+                )
+            )
+            current_height = fragment_height
+            if chunk_index < len(row_chunks) - 1:
+                page_fragments.append(current_page)
+                current_page = []
+                current_height = 0
+    if current_page:
+        page_fragments.append(current_page)
+    if not page_fragments:
+        page_fragments = [[]]
+
+    change_pages: dict[int, list[int]] = {}
+    for page_number, fragments in enumerate(page_fragments, start=1):
+        for change, _rows, _is_first, _is_last in fragments:
+            change_pages.setdefault(change.index, []).append(page_number)
+
+    paged_changes: list[ReviewChange] = []
+    for change in changes:
+        pages_for_change = change_pages.get(change.index, [1])
+        paged_changes.append(
+            ReviewChange(
+                index=change.index,
+                total=change.total,
+                path=change.path,
+                hunk_header=change.hunk_header,
+                old_start=change.old_start,
+                old_end=change.old_end,
+                new_start=change.new_start,
+                new_end=change.new_end,
+                rows=change.rows,
+                display_ids=change.display_ids,
+                selection_ids=change.selection_ids,
+                select_as=change.select_as,
+                reason=change.reason,
+                is_oversized=(len(change.rows) + 2) > body_budget,
+                note=change.note,
+                actions=change.actions,
+                first_page=min(pages_for_change),
+                last_page=max(pages_for_change),
+            )
+        )
+    by_index = {change.index: change for change in paged_changes}
+    final_pages = tuple(
+        FileReviewPage(
+            page=page_number,
+            changes=tuple(
+                ReviewChangeFragment(
+                    change=by_index[change.index],
+                    rows=rows,
+                    is_first_fragment=is_first,
+                    is_last_fragment=is_last,
+                )
+                for change, rows, is_first, is_last in fragments
+            ),
+        )
+        for page_number, fragments in enumerate(page_fragments, start=1)
+    )
+    return tuple(paged_changes), final_pages

--- a/src/git_stage_batch/output/file_review_rows.py
+++ b/src/git_stage_batch/output/file_review_rows.py
@@ -1,0 +1,68 @@
+"""Line row rendering for file review output."""
+
+from __future__ import annotations
+
+from ..core.models import LineEntry
+from .colors import Colors
+from .file_review_model import FileReviewModel
+
+
+def maximum_display_id_digit_count(model: FileReviewModel) -> int:
+    """Return the display ID width needed for one file-review model."""
+    if model.display_id_by_selection_id is None:
+        return model.line_changes.maximum_line_id_digit_count()
+    if not model.display_id_by_selection_id:
+        return 1
+    return len(str(max(model.display_id_by_selection_id.values())))
+
+
+def print_file_review_rows(
+    rows: tuple[LineEntry, ...],
+    maximum_digits: int,
+    *,
+    display_id_by_selection_id: dict[int, int] | None,
+    allowed_selection_ids: set[int] | None = None,
+) -> None:
+    """Print rows for one file-review change fragment."""
+    use_color = Colors.enabled()
+    label_width = maximum_digits + 3
+    for line in rows:
+        is_gap_line = (
+            line.id is None
+            and line.kind == " "
+            and line.old_line_number is None
+            and line.new_line_number is None
+            and line.source_line is None
+        )
+        if line.id is None or (
+            allowed_selection_ids is not None
+            and line.id not in allowed_selection_ids
+        ):
+            display_id = None
+        elif display_id_by_selection_id is not None:
+            display_id = display_id_by_selection_id.get(line.id)
+        else:
+            display_id = line.id
+        if display_id is None:
+            label = ""
+        else:
+            label = f"[#{display_id}]"
+        padding = " " * max(0, label_width - len(label))
+        row_text = f" {line.kind} {line.display_text()}"
+        if not use_color:
+            print(f"{label}{padding}{row_text}")
+            continue
+
+        if label:
+            print(f"{Colors.GRAY}{label}{Colors.RESET}{padding}", end="")
+        else:
+            print(padding, end="")
+
+        if line.kind == "+":
+            print(f"{Colors.GREEN}{row_text}{Colors.RESET}")
+        elif line.kind == "-":
+            print(f"{Colors.RED}{row_text}{Colors.RESET}")
+        elif is_gap_line:
+            print(f"{Colors.GRAY}{row_text}{Colors.RESET}")
+        else:
+            print(row_text)

--- a/src/git_stage_batch/output/file_review_summary.py
+++ b/src/git_stage_batch/output/file_review_summary.py
@@ -1,0 +1,73 @@
+"""File-review summary labels and selection specs."""
+
+from __future__ import annotations
+
+from ..core.line_selection import format_line_ids
+from ..data.file_review.records import ReviewSource
+from ..i18n import _
+from .file_review_model import ReviewChangeFragment
+
+
+def display_line_spec(line_spec: str) -> str:
+    """Return a display-formatted line or page range."""
+    return line_spec.replace("-", "–")
+
+
+def line_spec_for_display_ids(display_ids: tuple[int, ...]) -> str:
+    """Return a footer/header line spec for display IDs."""
+    if not display_ids:
+        return "-"
+    return display_line_spec(format_line_ids(list(display_ids)))
+
+
+def change_spec_for_fragments(fragments: list[ReviewChangeFragment]) -> str:
+    """Return a summary spec for the unique changes in shown fragments."""
+    change_ids: list[int] = []
+    seen: set[int] = set()
+    for fragment in fragments:
+        change_id = fragment.change.index
+        if change_id in seen:
+            continue
+        change_ids.append(change_id)
+        seen.add(change_id)
+    if not change_ids:
+        return "-"
+    return display_line_spec(format_line_ids(change_ids))
+
+
+def page_summary(shown_pages: tuple[int, ...], page_count: int) -> str:
+    """Return a concise shown-page summary."""
+    page_word = _("page") if len(shown_pages) == 1 else _("pages")
+    return _("{page_word} {pages}/{page_count}").format(
+        page_word=page_word,
+        pages=display_line_spec(format_line_ids(list(shown_pages))),
+        page_count=page_count,
+    )
+
+
+def change_summary(change_spec: str, total_changes: int) -> str:
+    """Return a concise shown-change summary."""
+    change_word = (
+        _("change")
+        if "," not in change_spec and "–" not in change_spec else
+        _("changes")
+    )
+    return _("{change_word} {changes}/{total}").format(
+        change_word=change_word,
+        changes=change_spec,
+        total=total_changes,
+    )
+
+
+def review_source_summary(
+    source: ReviewSource,
+    batch_name: str | None,
+    source_label: str,
+) -> str:
+    """Return the source label used in file-review status lines."""
+    if source == ReviewSource.BATCH and batch_name:
+        return batch_name
+    prefix = _("Changes: ")
+    if source_label.startswith(prefix):
+        return source_label[len(prefix):]
+    return source_label

--- a/src/git_stage_batch/tui/action_prompt_choices.py
+++ b/src/git_stage_batch/tui/action_prompt_choices.py
@@ -1,0 +1,107 @@
+"""Action prompt choices and normalization for interactive TUI mode."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..output.colors import Colors
+
+
+ActionPromptOption = tuple[str, str, str]
+
+
+@dataclass(frozen=True)
+class ActionPromptOptionGroups:
+    primary: tuple[ActionPromptOption, ...]
+    scope: tuple[ActionPromptOption, ...]
+    flow: tuple[ActionPromptOption, ...]
+    more: tuple[ActionPromptOption, ...]
+
+
+def action_prompt_option_groups(
+    *,
+    has_hunk: bool,
+    use_color: bool,
+) -> ActionPromptOptionGroups:
+    """Return grouped action choices for the interactive action prompt."""
+    if has_hunk:
+        return ActionPromptOptionGroups(
+            primary=(
+                ("include", "i", Colors.GREEN if use_color else ""),
+                ("skip", "s", ""),
+                ("discard", "d", Colors.RED if use_color else ""),
+                ("quit", "q", ""),
+            ),
+            scope=(
+                ("lines", "l", ""),
+                ("file", "f", ""),
+                ("view", "v", ""),
+            ),
+            flow=(
+                ("from", "<", ""),
+                ("to", ">", ""),
+            ),
+            more=(
+                ("again", "a", ""),
+                ("undo", "u", ""),
+                ("redo", "U", ""),
+                ("status", "S", ""),
+                ("assets", "A", ""),
+                ("batch", "b", ""),
+                ("open", "o", ""),
+                ("fixup", "x", ""),
+                ("cmd", "!", ""),
+                ("help", "?", ""),
+            ),
+        )
+
+    return ActionPromptOptionGroups(
+        primary=(
+            ("quit", "q", ""),
+            ("help", "?", ""),
+        ),
+        scope=(),
+        flow=(
+            ("from", "<", ""),
+            ("to", ">", ""),
+        ),
+        more=(
+            ("undo", "u", ""),
+            ("redo", "U", ""),
+            ("status", "S", ""),
+            ("assets", "A", ""),
+            ("batch", "b", ""),
+            ("open", "o", ""),
+            ("cmd", "!", ""),
+        ),
+    )
+
+
+def normalize_action_prompt_choice(choice: str) -> str:
+    """Return the single-character action code for a prompt choice."""
+    choice_lower = choice.lower()
+    word_to_letter = {
+        "include": "i",
+        "skip": "s",
+        "discard": "d",
+        "quit": "q",
+        "again": "a",
+        "undo": "u",
+        "redo": "U",
+        "status": "S",
+        "assets": "A",
+        "install-assets": "A",
+        "lines": "l",
+        "file": "f",
+        "review": "v",
+        "view": "v",
+        "open": "o",
+        "files": "o",
+        "batch": "b",
+        "fixup": "x",
+        "command": "!",
+        "help": "?",
+        "from": "<",
+        "to": ">",
+    }
+    return word_to_letter.get(choice_lower, choice_lower)

--- a/src/git_stage_batch/tui/action_prompt_menu.py
+++ b/src/git_stage_batch/tui/action_prompt_menu.py
@@ -1,0 +1,60 @@
+"""Action prompt menu formatting for interactive TUI mode."""
+
+from __future__ import annotations
+
+import re
+import shutil
+
+from ..i18n import _
+from ..output.colors import Colors, format_hotkey
+
+
+ANSI_PATTERN = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _visible_len(text: str) -> int:
+    """Return display length without ANSI color sequences."""
+    return len(ANSI_PATTERN.sub("", text))
+
+
+def format_menu_section_lines(
+    label: str,
+    options: list[tuple[str, str, str]],
+    use_color: bool,
+) -> list[str]:
+    """Format one menu section, wrapping options across continuation lines."""
+    width = max(40, shutil.get_terminal_size((88, 20)).columns)
+    formatted_options = [
+        format_hotkey(text, hotkey, color)
+        for text, hotkey, color in options
+    ]
+
+    if use_color and Colors.enabled():
+        rendered_label = f"{Colors.GRAY}{label}{Colors.RESET}"
+        rendered_prefix = f"{rendered_label}: {Colors.CYAN}"
+        rendered_suffix = Colors.RESET
+    else:
+        rendered_prefix = _("{label}: ").format(label=label)
+        rendered_suffix = ""
+
+    continuation_prefix = " " * (_visible_len(label) + 2)
+    lines: list[str] = []
+    current = rendered_prefix
+    current_visible_len = _visible_len(current)
+
+    for option in formatted_options:
+        separator = "" if current == rendered_prefix else ", "
+        candidate_len = current_visible_len + len(separator) + _visible_len(option)
+        if current != rendered_prefix and candidate_len > width:
+            lines.append(f"{current}{rendered_suffix}")
+            current = continuation_prefix + option
+            current_visible_len = _visible_len(current)
+            continue
+
+        current = f"{current}{separator}{option}"
+        current_visible_len = candidate_len
+
+    if current != rendered_prefix:
+        lines.append(f"{current}{rendered_suffix}")
+
+    return lines

--- a/src/git_stage_batch/tui/prompts.py
+++ b/src/git_stage_batch/tui/prompts.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import re
-import shutil
 
 try:
     import readline
@@ -28,61 +27,12 @@ except ImportError:
     INPUT_USES_LIBEDIT = False
     readline = None  # type: ignore
 
+from . import action_prompt_menu
 from ..output.colors import Colors, format_hotkey
 from ..i18n import _, pgettext
 
 # Module-level storage for shell command history
 _shell_command_history: list[str] = []
-
-ANSI_PATTERN = re.compile(r"\x1b\[[0-9;]*m")
-
-
-def _visible_len(text: str) -> int:
-    """Return display length without ANSI color sequences."""
-    return len(ANSI_PATTERN.sub("", text))
-
-
-def _format_menu_section_lines(
-    label: str,
-    options: list[tuple[str, str, str]],
-    use_color: bool,
-) -> list[str]:
-    """Format one menu section, wrapping options across continuation lines."""
-    width = max(40, shutil.get_terminal_size((88, 20)).columns)
-    formatted_options = [
-        format_hotkey(text, hotkey, color)
-        for text, hotkey, color in options
-    ]
-
-    if use_color and Colors.enabled():
-        rendered_label = f"{Colors.GRAY}{label}{Colors.RESET}"
-        rendered_prefix = f"{rendered_label}: {Colors.CYAN}"
-        rendered_suffix = Colors.RESET
-    else:
-        rendered_prefix = _("{label}: ").format(label=label)
-        rendered_suffix = ""
-
-    continuation_prefix = " " * (_visible_len(label) + 2)
-    lines: list[str] = []
-    current = rendered_prefix
-    current_visible_len = _visible_len(current)
-
-    for option in formatted_options:
-        separator = "" if current == rendered_prefix else ", "
-        candidate_len = current_visible_len + len(separator) + _visible_len(option)
-        if current != rendered_prefix and candidate_len > width:
-            lines.append(f"{current}{rendered_suffix}")
-            current = continuation_prefix + option
-            current_visible_len = _visible_len(current)
-            continue
-
-        current = f"{current}{separator}{option}"
-        current_visible_len = candidate_len
-
-    if current != rendered_prefix:
-        lines.append(f"{current}{rendered_suffix}")
-
-    return lines
 
 
 def wrap_prompt_for_readline(prompt: str) -> str:
@@ -207,7 +157,11 @@ def prompt_action(use_color: bool = True, show_question: bool = True, has_hunk: 
                 use_color,
         ):
                 rendered_sections.extend(
-                        _format_menu_section_lines(label, options, use_color)
+                        action_prompt_menu.format_menu_section_lines(
+                                label,
+                                options,
+                                use_color,
+                        )
                 )
 
         section_specs = [

--- a/src/git_stage_batch/tui/prompts.py
+++ b/src/git_stage_batch/tui/prompts.py
@@ -27,6 +27,7 @@ except ImportError:
     INPUT_USES_LIBEDIT = False
     readline = None  # type: ignore
 
+from . import action_prompt_choices
 from . import action_prompt_menu
 from ..output.colors import Colors, format_hotkey
 from ..i18n import _, pgettext
@@ -73,67 +74,10 @@ def prompt_action(use_color: bool = True, show_question: bool = True, has_hunk: 
     Returns:
         Normalized choice (e.g., 'i', 's', 'd', 'q', 'a', 'l', 'x', '!', etc.)
     """
-    if has_hunk:
-        # Primary actions
-        primary_options = [
-            ("include", "i", Colors.GREEN if use_color else ""),
-            ("skip", "s", ""),
-            ("discard", "d", Colors.RED if use_color else ""),
-            ("quit", "q", ""),
-        ]
-
-        # Scope options
-        scope_options = [
-            ("lines", "l", ""),
-            ("file", "f", ""),
-            ("view", "v", ""),
-        ]
-
-        # Flow options
-        flow_options = [
-            ("from", "<", ""),
-            ("to", ">", ""),
-        ]
-
-        # More options
-        more_options = [
-            ("again", "a", ""),
-            ("undo", "u", ""),
-            ("redo", "U", ""),
-            ("status", "S", ""),
-            ("assets", "A", ""),
-            ("batch", "b", ""),
-            ("open", "o", ""),
-            ("fixup", "x", ""),
-            ("cmd", "!", ""),
-            ("help", "?", ""),
-        ]
-    else:
-        # No hunk available - only show non-hunk actions
-        primary_options = [
-            ("quit", "q", ""),
-            ("help", "?", ""),
-        ]
-
-        # Scope options - none in degraded mode
-        scope_options = []
-
-        # Flow options - still available
-        flow_options = [
-            ("from", "<", ""),
-            ("to", ">", ""),
-        ]
-
-        # More options - limited set
-        more_options = [
-            ("undo", "u", ""),
-            ("redo", "U", ""),
-            ("status", "S", ""),
-            ("assets", "A", ""),
-            ("batch", "b", ""),
-            ("open", "o", ""),
-            ("cmd", "!", ""),
-        ]
+    option_groups = action_prompt_choices.action_prompt_option_groups(
+        has_hunk=has_hunk,
+        use_color=use_color,
+    )
 
     if show_question:
         print()
@@ -141,7 +85,7 @@ def prompt_action(use_color: bool = True, show_question: bool = True, has_hunk: 
             print(_("What do you want to do with this hunk?"))
         else:
             print(_("What do you want to do?"))
-        for text, hotkey, color in primary_options:
+        for text, hotkey, color in option_groups.primary:
             formatted = format_hotkey(text, hotkey, color)
             print(f"  {formatted}")
 
@@ -165,9 +109,9 @@ def prompt_action(use_color: bool = True, show_question: bool = True, has_hunk: 
                 )
 
         section_specs = [
-                (pgettext("menu section label", "Other scope"), scope_options),
-                (pgettext("menu section label", "Flow"), flow_options),
-                (pgettext("menu section label", "More"), more_options),
+                (pgettext("menu section label", "Other scope"), option_groups.scope),
+                (pgettext("menu section label", "Flow"), option_groups.flow),
+                (pgettext("menu section label", "More"), option_groups.more),
         ]
 
         for label, options in section_specs:
@@ -193,34 +137,7 @@ def prompt_action(use_color: bool = True, show_question: bool = True, has_hunk: 
     except (KeyboardInterrupt, EOFError):
         return "q"  # Ctrl-C or Ctrl-D exits
 
-    # Normalize full words to single letters (case-insensitive)
-    choice_lower = choice.lower()
-    word_to_letter = {
-        "include": "i",
-        "skip": "s",
-        "discard": "d",
-        "quit": "q",
-        "again": "a",
-        "undo": "u",
-        "redo": "U",
-        "status": "S",
-        "assets": "A",
-        "install-assets": "A",
-        "lines": "l",
-        "file": "f",
-        "review": "v",
-        "view": "v",
-        "open": "o",
-        "files": "o",
-        "batch": "b",
-        "fixup": "x",
-        "command": "!",
-        "help": "?",
-        "from": "<",
-        "to": ">",
-    }
-
-    return word_to_letter.get(choice_lower, choice_lower)
+    return action_prompt_choices.normalize_action_prompt_choice(choice)
 
 
 def confirm_destructive_operation(_operation: str, message: str) -> bool:

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -1771,9 +1771,10 @@ def test_selected_change_path_query_stays_in_path_module():
 
 def test_undo_ref_bookkeeping_stays_in_undo_refs():
     """Undo stack ref helpers should stay out of undo snapshot storage."""
+    old_undo_path = SRC_ROOT / "data" / "undo.py"
     undo = __import__(
-        "git_stage_batch.data.undo",
-        fromlist=["undo"],
+        "git_stage_batch.data.undo_checkpoints",
+        fromlist=["undo_checkpoints"],
     )
     undo_refs = __import__(
         "git_stage_batch.data.undo_refs",
@@ -1802,9 +1803,20 @@ def test_undo_ref_bookkeeping_stays_in_undo_refs():
     }
     session_path = SRC_ROOT / "data" / "session.py"
     session_imports_undo_refs = False
+    old_imports = []
 
     assert ref_names <= vars(undo_refs).keys()
     assert old_undo_names.isdisjoint(vars(undo))
+
+    for path in SRC_ROOT.rglob("*.py"):
+        for imported_module, node in _import_from_nodes(path):
+            if imported_module != "git_stage_batch.data.undo":
+                continue
+
+            relative_path = path.relative_to(REPO_ROOT)
+            old_imports.append(
+                f"{relative_path}:{node.lineno} imports {imported_module}"
+            )
 
     for imported_module, node in _import_from_nodes(session_path):
         imported_names = {alias.name for alias in node.names}
@@ -1814,14 +1826,16 @@ def test_undo_ref_bookkeeping_stays_in_undo_refs():
         ):
             session_imports_undo_refs = True
 
+    assert not old_undo_path.exists()
+    assert old_imports == []
     assert session_imports_undo_refs
 
 
 def test_undo_worktree_capture_stays_in_worktree_module():
     """Undo worktree capture should stay out of checkpoint orchestration."""
     undo = __import__(
-        "git_stage_batch.data.undo",
-        fromlist=["undo"],
+        "git_stage_batch.data.undo_checkpoints",
+        fromlist=["undo_checkpoints"],
     )
     undo_worktree = __import__(
         "git_stage_batch.data.undo_worktree",
@@ -1857,10 +1871,10 @@ def test_undo_worktree_capture_stays_in_worktree_module():
 
 def test_undo_snapshot_restore_stays_in_restore_module():
     """Undo snapshot restoration should stay out of checkpoint orchestration."""
-    undo_path = SRC_ROOT / "data" / "undo.py"
+    undo_path = SRC_ROOT / "data" / "undo_checkpoints.py"
     undo = __import__(
-        "git_stage_batch.data.undo",
-        fromlist=["undo"],
+        "git_stage_batch.data.undo_checkpoints",
+        fromlist=["undo_checkpoints"],
     )
     undo_restore = __import__(
         "git_stage_batch.data.undo_restore",
@@ -3932,7 +3946,7 @@ def test_argument_parser_delegates_multi_file_action_flow():
             helper_file_scope_imported_names |= {alias.name for alias in node.names}
 
     assert "git_stage_batch.data.hunk_tracking" not in parser_imports
-    assert "git_stage_batch.data.undo" not in parser_imports
+    assert "git_stage_batch.data.undo_checkpoints" not in parser_imports
     assert (
         "git_stage_batch.commands.file_scope.multi_file_actions"
         not in parser_imports
@@ -3942,7 +3956,7 @@ def test_argument_parser_delegates_multi_file_action_flow():
         for imports in dispatch_imports.values()
     )
     assert "git_stage_batch.data.hunk_tracking" in helper_imports
-    assert "git_stage_batch.data.undo" in helper_imports
+    assert "git_stage_batch.data.undo_checkpoints" in helper_imports
     assert "git_stage_batch.commands.include" not in helper_imports
     assert "git_stage_batch.commands.skip" not in helper_imports
     assert {"include_file", "skip_file"} <= helper_file_scope_imported_names
@@ -4728,7 +4742,7 @@ def test_include_to_batch_action_owns_resolved_dispatch():
     assert "load_selected_change" in action_imports[
         "git_stage_batch.data.selected_change.loading"
     ]
-    assert "undo_checkpoint" in action_imports["git_stage_batch.data.undo"]
+    assert "undo_checkpoint" in action_imports["git_stage_batch.data.undo_checkpoints"]
     assert {
         "BinaryFileChange",
         "GitlinkChange",
@@ -4780,7 +4794,7 @@ def test_include_delegates_include_to_batch_action_routing():
         "git_stage_batch.data.selected_change.loading": {
             "load_selected_change",
         },
-        "git_stage_batch.data.undo": {
+        "git_stage_batch.data.undo_checkpoints": {
             "undo_checkpoint",
         },
         "git_stage_batch.exceptions": {
@@ -4833,7 +4847,7 @@ def test_discard_to_batch_action_owns_resolved_dispatch():
     assert "load_selected_change" in action_imports[
         "git_stage_batch.data.selected_change.loading"
     ]
-    assert "undo_checkpoint" in action_imports["git_stage_batch.data.undo"]
+    assert "undo_checkpoint" in action_imports["git_stage_batch.data.undo_checkpoints"]
     assert {
         "BinaryFileChange",
         "RenameChange",
@@ -4883,7 +4897,7 @@ def test_discard_delegates_discard_to_batch_action_routing():
         "git_stage_batch.data.selected_change.loading": {
             "load_selected_change",
         },
-        "git_stage_batch.data.undo": {
+        "git_stage_batch.data.undo_checkpoints": {
             "undo_checkpoint",
         },
         "git_stage_batch.exceptions": {
@@ -13095,7 +13109,7 @@ def test_batch_source_apply_action_owns_apply_execution():
         ("git_stage_batch.batch.binary_file_content", "read_binary_file_from_batch"),
         ("git_stage_batch.batch.submodule_pointer", "apply_submodule_pointer_from_batch"),
         ("git_stage_batch.data.session", "snapshot_file_if_untracked"),
-        ("git_stage_batch.data.undo", "undo_checkpoint"),
+        ("git_stage_batch.data.undo_checkpoints", "undo_checkpoint"),
     }
     action_imports = set()
 
@@ -13142,7 +13156,7 @@ def test_apply_from_delegates_apply_action_execution():
         "git_stage_batch.data.session": {
             "snapshot_file_if_untracked",
         },
-        "git_stage_batch.data.undo": {
+        "git_stage_batch.data.undo_checkpoints": {
             "undo_checkpoint",
         },
     }
@@ -13195,7 +13209,7 @@ def test_batch_source_include_action_owns_include_execution():
         ("git_stage_batch.batch.binary_file_content", "read_binary_file_from_batch"),
         ("git_stage_batch.batch.submodule_pointer", "stage_submodule_pointer_from_batch"),
         ("git_stage_batch.data.session", "snapshot_file_if_untracked"),
-        ("git_stage_batch.data.undo", "undo_checkpoint"),
+        ("git_stage_batch.data.undo_checkpoints", "undo_checkpoint"),
     }
     action_imports = set()
 
@@ -13242,7 +13256,7 @@ def test_include_from_delegates_include_action_execution():
         "git_stage_batch.data.session": {
             "snapshot_file_if_untracked",
         },
-        "git_stage_batch.data.undo": {
+        "git_stage_batch.data.undo_checkpoints": {
             "undo_checkpoint",
         },
     }
@@ -13289,7 +13303,7 @@ def test_batch_source_discard_action_owns_discard_execution():
         ("git_stage_batch.batch.metadata_validation", "get_validated_baseline_commit"),
         ("git_stage_batch.batch.submodule_pointer", "discard_submodule_pointer_from_batch"),
         ("git_stage_batch.data.session", "snapshot_file_if_untracked"),
-        ("git_stage_batch.data.undo", "undo_checkpoint"),
+        ("git_stage_batch.data.undo_checkpoints", "undo_checkpoint"),
     }
     action_imports = set()
 
@@ -13329,7 +13343,7 @@ def test_discard_from_delegates_discard_action_execution():
         "git_stage_batch.data.session": {
             "snapshot_file_if_untracked",
         },
-        "git_stage_batch.data.undo": {
+        "git_stage_batch.data.undo_checkpoints": {
             "undo_checkpoint",
         },
     }

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -2882,6 +2882,40 @@ def test_file_review_output_uses_display_id_module():
     assert "def _display_ids_for_rows" not in review_output_text
 
 
+def test_file_review_rows_own_row_rendering():
+    """File-review row rendering should stay out of page orchestration."""
+    review_output_path = SRC_ROOT / "output" / "file_review.py"
+    review_output_text = review_output_path.read_text()
+    row_output_path = SRC_ROOT / "output" / "file_review_rows.py"
+    row_output_text = row_output_path.read_text()
+    review_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(review_output_path)
+    }
+    row_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(row_output_path)
+    }
+    file_review_rows = __import__(
+        "git_stage_batch.output.file_review_rows",
+        fromlist=["file_review_rows"],
+    )
+    public_names = {
+        "maximum_display_id_digit_count",
+        "print_file_review_rows",
+    }
+
+    assert "git_stage_batch.output.file_review_rows" in review_imports
+    assert "git_stage_batch.core.models" not in review_imports
+    assert "git_stage_batch.core.models" in row_imports
+    assert public_names <= vars(file_review_rows).keys()
+    assert "def _maximum_display_id_digit_count" not in review_output_text
+    assert "def _print_rows" not in review_output_text
+    assert "LineEntry" not in review_output_text
+    assert "display_text()" not in review_output_text
+    assert "display_text()" in row_output_text
+
+
 def test_file_review_callers_use_model_builder():
     """File-review callers should not import model construction from rendering."""
     review_output_path = SRC_ROOT / "output" / "file_review.py"

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -2660,6 +2660,9 @@ def test_file_review_records_stay_out_of_state_module():
         },
         SRC_ROOT / "data" / "file_review" / "batch_selection.py": {"FileReviewAction"},
         SRC_ROOT / "output" / "file_review.py": {
+            "ReviewSource",
+        },
+        SRC_ROOT / "output" / "file_review_footer.py": {
             "FileReviewAction",
             "FileReviewState",
             "ReviewSource",
@@ -3114,7 +3117,7 @@ def test_file_review_action_commands_stay_out_of_state_module():
             "line_action_command",
             "show_command_for_review_state",
         },
-        SRC_ROOT / "output" / "file_review.py": {"line_action_command"},
+        SRC_ROOT / "output" / "file_review_footer.py": {"line_action_command"},
     }
     violations = []
 

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -11547,12 +11547,10 @@ def test_output_owns_operation_candidate_preview_rendering():
     }
     renderer_helper_names: set[str] = set()
     summary_names = {
-        "CandidateSnippetLine",
         "CandidateTargetSummary",
         "candidate_overview_subject",
         "candidate_target_summary",
         "common_candidate_target_indexes",
-        "plain_candidate_snippet_lines",
         "summarize_ambiguity_block",
     }
     old_renderer_summary_names = {

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -7576,6 +7576,41 @@ def test_tui_file_review_prompts_own_action_vocabulary():
     assert "Review action:" in prompt_text
 
 
+def test_tui_action_prompt_menu_owns_grouped_section_layout():
+    """Interactive action prompt menu layout should stay out of input prompts."""
+    prompts = __import__(
+        "git_stage_batch.tui.prompts",
+        fromlist=["prompts"],
+    )
+    action_prompt_menu = __import__(
+        "git_stage_batch.tui.action_prompt_menu",
+        fromlist=["action_prompt_menu"],
+    )
+    prompts_path = SRC_ROOT / "tui" / "prompts.py"
+    menu_path = SRC_ROOT / "tui" / "action_prompt_menu.py"
+    prompts_text = prompts_path.read_text()
+    menu_text = menu_path.read_text()
+    prompts_imports_menu = any(
+        imported_module == "git_stage_batch.tui"
+        and any(alias.name == "action_prompt_menu" for alias in node.names)
+        for imported_module, node in _import_from_nodes(prompts_path)
+    )
+    public_names = {
+        "format_menu_section_lines",
+    }
+
+    assert public_names <= vars(action_prompt_menu).keys()
+    assert public_names.isdisjoint(vars(prompts))
+    assert prompts_imports_menu
+    assert "shutil.get_terminal_size" not in prompts_text
+    assert "ANSI_PATTERN" not in prompts_text
+    assert "_visible_len" not in prompts_text
+    assert "format_menu_section_lines" in menu_text
+    assert "shutil.get_terminal_size" in menu_text
+    assert "ANSI_PATTERN" in menu_text
+    assert "format_hotkey" in menu_text
+
+
 def test_tui_file_review_action_router_owns_standard_actions():
     """TUI file review action router should own standard action gates."""
     browser_path = SRC_ROOT / "tui" / "file_review" / "browser.py"

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -11485,6 +11485,53 @@ def test_output_owns_operation_candidate_preview_rendering():
     assert "git_stage_batch.core.diff_parser" not in candidate_summary_imports
 
 
+def test_candidate_preview_commands_own_command_text():
+    """Candidate preview command text should stay out of rendering."""
+    candidate_preview = __import__(
+        "git_stage_batch.output.candidate_preview",
+        fromlist=["candidate_preview"],
+    )
+    candidate_preview_commands = __import__(
+        "git_stage_batch.output.candidate_preview_commands",
+        fromlist=["candidate_preview_commands"],
+    )
+    candidate_preview_path = SRC_ROOT / "output" / "candidate_preview.py"
+    candidate_commands_path = SRC_ROOT / "output" / "candidate_preview_commands.py"
+    candidate_preview_text = candidate_preview_path.read_text()
+    candidate_commands_text = candidate_commands_path.read_text()
+    candidate_preview_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(candidate_preview_path)
+    }
+    candidate_commands_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(candidate_commands_path)
+    }
+    command_names = {
+        "candidate_selector_text",
+        "execute_candidate_command",
+        "show_candidate_command",
+    }
+    old_command_names = {
+        "_candidate_selector_text",
+        "_execute_candidate_command",
+        "_show_candidate_command",
+    }
+
+    assert "git_stage_batch.output.candidate_preview_commands" in candidate_preview_imports
+    assert command_names <= vars(candidate_preview_commands).keys()
+    assert old_command_names.isdisjoint(vars(candidate_preview))
+    assert "shlex" not in candidate_preview_imports
+    assert "import shlex" in candidate_commands_text
+    assert "def _candidate_selector_text" not in candidate_preview_text
+    assert "def _show_candidate_command" not in candidate_preview_text
+    assert "def _execute_candidate_command" not in candidate_preview_text
+    assert "git-stage-batch show --from" not in candidate_preview_text
+    assert "git-stage-batch {command} --from" not in candidate_preview_text
+    assert "git-stage-batch show --from" in candidate_commands_text
+    assert "git-stage-batch {command} --from" in candidate_commands_text
+
+
 def test_batch_owns_atomic_file_change_metadata_conversion():
     """Stored atomic file metadata conversion should live in batch."""
     atomic_file_changes = __import__(

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -11431,9 +11431,7 @@ def test_output_owns_operation_candidate_preview_rendering():
         "render_operation_candidate",
         "render_operation_candidate_overview",
     }
-    renderer_helper_names = {
-        "_print_candidate_buffer_diff",
-    }
+    renderer_helper_names: set[str] = set()
     summary_names = {
         "CandidateSnippetLine",
         "CandidateTargetSummary",
@@ -11480,7 +11478,6 @@ def test_output_owns_operation_candidate_preview_rendering():
     assert old_renderer_summary_names.isdisjoint(vars(candidate_preview))
     assert "git_stage_batch.output" in candidate_preview_imports
     assert "git_stage_batch.output.colors" in candidate_preview_imports
-    assert "git_stage_batch.core.diff_parser" in candidate_preview_imports
     assert "git_stage_batch.output.colors" not in candidate_summary_imports
     assert "git_stage_batch.core.diff_parser" not in candidate_summary_imports
 

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -7611,6 +7611,41 @@ def test_tui_action_prompt_menu_owns_grouped_section_layout():
     assert "format_hotkey" in menu_text
 
 
+def test_tui_action_prompt_choices_own_action_vocabulary():
+    """Interactive action prompt choices should stay out of input prompts."""
+    prompts = __import__(
+        "git_stage_batch.tui.prompts",
+        fromlist=["prompts"],
+    )
+    action_prompt_choices = __import__(
+        "git_stage_batch.tui.action_prompt_choices",
+        fromlist=["action_prompt_choices"],
+    )
+    prompts_path = SRC_ROOT / "tui" / "prompts.py"
+    choices_path = SRC_ROOT / "tui" / "action_prompt_choices.py"
+    prompts_text = prompts_path.read_text()
+    choices_text = choices_path.read_text()
+    prompts_imports_choices = any(
+        imported_module == "git_stage_batch.tui"
+        and any(alias.name == "action_prompt_choices" for alias in node.names)
+        for imported_module, node in _import_from_nodes(prompts_path)
+    )
+    public_names = {
+        "ActionPromptOptionGroups",
+        "action_prompt_option_groups",
+        "normalize_action_prompt_choice",
+    }
+
+    assert public_names <= vars(action_prompt_choices).keys()
+    assert public_names.isdisjoint(vars(prompts))
+    assert prompts_imports_choices
+    assert '"install-assets"' not in prompts_text
+    assert "action_prompt_option_groups" in choices_text
+    assert "normalize_action_prompt_choice" in choices_text
+    assert '"install-assets"' in choices_text
+    assert "Colors.GREEN" in choices_text
+
+
 def test_tui_file_review_action_router_owns_standard_actions():
     """TUI file review action router should own standard action gates."""
     browser_path = SRC_ROOT / "tui" / "file_review" / "browser.py"

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -2882,6 +2882,38 @@ def test_file_review_output_uses_display_id_module():
     assert "def _display_ids_for_rows" not in review_output_text
 
 
+def test_file_review_output_uses_summary_module():
+    """File-review output should not own shared status summary formatting."""
+    review_output_path = SRC_ROOT / "output" / "file_review.py"
+    review_output_text = review_output_path.read_text()
+    imported_modules = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(review_output_path)
+    }
+    file_review_summary = __import__(
+        "git_stage_batch.output.file_review_summary",
+        fromlist=["file_review_summary"],
+    )
+    public_names = {
+        "change_spec_for_fragments",
+        "change_summary",
+        "display_line_spec",
+        "line_spec_for_display_ids",
+        "page_summary",
+        "review_source_summary",
+    }
+
+    assert "git_stage_batch.output.file_review_summary" in imported_modules
+    assert public_names <= vars(file_review_summary).keys()
+    assert "ReviewChangeFragment" not in review_output_text
+    assert "def _line_spec_for_display_ids" not in review_output_text
+    assert "def _change_spec_for_fragments" not in review_output_text
+    assert "def _display_line_spec" not in review_output_text
+    assert "def _page_summary" not in review_output_text
+    assert "def _change_summary" not in review_output_text
+    assert "def _review_source_summary" not in review_output_text
+
+
 def test_file_review_rows_own_row_rendering():
     """File-review row rendering should stay out of page orchestration."""
     review_output_path = SRC_ROOT / "output" / "file_review.py"

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -3059,6 +3059,48 @@ def test_file_review_footer_owns_command_rendering():
     assert "line_action_command" not in review_output_text
 
 
+def test_file_review_footer_hints_own_command_construction():
+    """File-review footer hints should stay out of terminal styling."""
+    file_review_footer = __import__(
+        "git_stage_batch.output.file_review_footer",
+        fromlist=["file_review_footer"],
+    )
+    footer_hints = __import__(
+        "git_stage_batch.output.file_review_footer_hints",
+        fromlist=["file_review_footer_hints"],
+    )
+    footer_output_path = SRC_ROOT / "output" / "file_review_footer.py"
+    footer_hints_path = SRC_ROOT / "output" / "file_review_footer_hints.py"
+    footer_output_text = footer_output_path.read_text()
+    footer_hints_text = footer_hints_path.read_text()
+    footer_imports_hints = any(
+        imported_module == "git_stage_batch.output"
+        and any(alias.name == "file_review_footer_hints" for alias in node.names)
+        for imported_module, node in _import_from_nodes(footer_output_path)
+    )
+    hint_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(footer_hints_path)
+    }
+    public_names = {
+        "FileReviewFooterHint",
+        "build_file_review_footer_hints",
+    }
+
+    assert public_names <= vars(footer_hints).keys()
+    assert public_names.isdisjoint(vars(file_review_footer))
+    assert footer_imports_hints
+    assert "line_action_command" not in footer_output_text
+    assert "FileReviewState" not in footer_output_text
+    assert "SelectedChangeKind" not in footer_output_text
+    assert "format_line_ids" not in footer_output_text
+    assert "line_action_command" in footer_hints_text
+    assert "FileReviewState" in footer_hints_text
+    assert "SelectedChangeKind" in footer_hints_text
+    assert "format_line_ids" in footer_hints_text
+    assert "git_stage_batch.output.colors" not in hint_imports
+
+
 def test_file_review_rows_own_row_rendering():
     """File-review row rendering should stay out of page orchestration."""
     review_output_path = SRC_ROOT / "output" / "file_review.py"

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -11432,9 +11432,7 @@ def test_output_owns_operation_candidate_preview_rendering():
         "render_operation_candidate_overview",
     }
     renderer_helper_names = {
-        "_execute_candidate_command",
         "_print_candidate_buffer_diff",
-        "_show_candidate_command",
     }
     summary_names = {
         "CandidateSnippetLine",

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -2810,12 +2810,6 @@ def test_file_review_model_builder_uses_layout_module():
     review_output_text = review_output_path.read_text()
     review_model_builder_path = SRC_ROOT / "output" / "file_review_model_builder.py"
     review_model_builder_text = review_model_builder_path.read_text()
-    imports = _import_from_nodes(review_model_builder_path)
-    imports_layout_module = any(
-        imported_module == "git_stage_batch.output"
-        and any(alias.name == "file_review_layout" for alias in node.names)
-        for imported_module, node in imports
-    )
     file_review_model_builder = __import__(
         "git_stage_batch.output.file_review_model_builder",
         fromlist=["file_review_model_builder"],
@@ -2825,7 +2819,6 @@ def test_file_review_model_builder_uses_layout_module():
         fromlist=["file_review_layout"],
     )
 
-    assert imports_layout_module
     assert "body_budget" in vars(file_review_layout)
     assert "body_budget" not in vars(file_review_model_builder)
     assert "git_stage_batch.output.file_review_layout" not in {

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -11482,6 +11482,52 @@ def test_output_owns_operation_candidate_preview_rendering():
     assert "git_stage_batch.core.diff_parser" not in candidate_summary_imports
 
 
+def test_candidate_preview_diff_owns_buffer_diff_rendering():
+    """Candidate preview diff rendering should stay out of overview pages."""
+    candidate_preview = __import__(
+        "git_stage_batch.output.candidate_preview",
+        fromlist=["candidate_preview"],
+    )
+    candidate_preview_diff = __import__(
+        "git_stage_batch.output.candidate_preview_diff",
+        fromlist=["candidate_preview_diff"],
+    )
+    candidate_preview_path = SRC_ROOT / "output" / "candidate_preview.py"
+    candidate_diff_path = SRC_ROOT / "output" / "candidate_preview_diff.py"
+    candidate_preview_text = candidate_preview_path.read_text()
+    candidate_diff_text = candidate_diff_path.read_text()
+    candidate_preview_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(candidate_preview_path)
+    }
+    candidate_diff_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(candidate_diff_path)
+    }
+    old_diff_names = {
+        "_candidate_diff_hunks",
+        "_candidate_line_number",
+        "_print_candidate_buffer_diff",
+        "_print_candidate_line_changes",
+    }
+
+    assert "git_stage_batch.output.candidate_preview_diff" in candidate_preview_imports
+    assert "print_candidate_buffer_diff" in vars(candidate_preview_diff)
+    assert old_diff_names.isdisjoint(vars(candidate_preview))
+    assert "git_stage_batch.core.diff_parser" not in candidate_preview_imports
+    assert "git_stage_batch.core.diff_parser" in candidate_diff_imports
+    assert "git_stage_batch.core.buffer" not in candidate_preview_imports
+    assert "git_stage_batch.core.buffer" in candidate_diff_imports
+    assert "def _candidate_diff_hunks" not in candidate_preview_text
+    assert "def _candidate_line_number" not in candidate_preview_text
+    assert "def _print_candidate_buffer_diff" not in candidate_preview_text
+    assert "def _print_candidate_line_changes" not in candidate_preview_text
+    assert "render_candidate_buffer_diff" not in candidate_preview_text
+    assert "splitlines(keepends=True)" not in candidate_preview_text
+    assert "render_candidate_buffer_diff" in candidate_diff_text
+    assert "splitlines(keepends=True)" in candidate_diff_text
+
+
 def test_candidate_preview_commands_own_command_text():
     """Candidate preview command text should stay out of rendering."""
     candidate_preview = __import__(

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -3061,11 +3061,6 @@ def test_file_review_footer_owns_command_rendering():
     assert "def _display_footer_command" not in review_output_text
     assert "def _footer_review_state" not in review_output_text
     assert "line_action_command" not in review_output_text
-    assert "FileReviewState" not in review_output_text
-    assert "SelectedChangeKind" not in review_output_text
-    assert "line_action_command" in footer_output_text
-    assert "FileReviewState" in footer_output_text
-    assert "SelectedChangeKind" in footer_output_text
 
 
 def test_file_review_rows_own_row_rendering():

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -11594,6 +11594,77 @@ def test_output_owns_operation_candidate_preview_rendering():
     assert "git_stage_batch.core.diff_parser" not in candidate_summary_imports
 
 
+def test_candidate_preview_snippets_own_snippet_formatting():
+    """Candidate preview snippets should stay out of target-summary derivation."""
+    candidate_preview_summary = __import__(
+        "git_stage_batch.output.candidate_preview_summary",
+        fromlist=["candidate_preview_summary"],
+    )
+    candidate_preview_snippets = __import__(
+        "git_stage_batch.output.candidate_preview_snippets",
+        fromlist=["candidate_preview_snippets"],
+    )
+    candidate_preview_path = SRC_ROOT / "output" / "candidate_preview.py"
+    candidate_diff_path = SRC_ROOT / "output" / "candidate_preview_diff.py"
+    candidate_summary_path = SRC_ROOT / "output" / "candidate_preview_summary.py"
+    candidate_snippets_path = SRC_ROOT / "output" / "candidate_preview_snippets.py"
+    candidate_preview_text = candidate_preview_path.read_text()
+    candidate_diff_text = candidate_diff_path.read_text()
+    candidate_summary_text = candidate_summary_path.read_text()
+    candidate_snippets_text = candidate_snippets_path.read_text()
+    imports_snippets = {
+        path: any(
+            imported_module == "git_stage_batch.output"
+            and any(alias.name == "candidate_preview_snippets" for alias in node.names)
+            for imported_module, node in _import_from_nodes(path)
+        )
+        for path in (
+            candidate_preview_path,
+            candidate_diff_path,
+            candidate_summary_path,
+        )
+    }
+    snippet_names = {
+        "CANDIDATE_GUTTER_SEPARATOR",
+        "CandidateSnippetLine",
+        "candidate_line_in_range",
+        "plain_candidate_snippet_lines",
+        "shorten_candidate_overview_text",
+        "snippet_line_width",
+    }
+
+    assert snippet_names <= vars(candidate_preview_snippets).keys()
+    assert snippet_names.isdisjoint(vars(candidate_preview_summary))
+    assert all(imports_snippets.values())
+    assert "class CandidateSnippetLine" not in candidate_summary_text
+    assert "def shorten_candidate_overview_text" not in candidate_summary_text
+    assert "def plain_candidate_snippet_lines" not in candidate_summary_text
+    assert "def candidate_line_in_range" not in candidate_summary_text
+    assert "CANDIDATE_GUTTER_SEPARATOR =" not in candidate_summary_text
+    assert "candidate_preview_summary.CANDIDATE_GUTTER_SEPARATOR" not in (
+        candidate_preview_text
+    )
+    assert "candidate_preview_summary.shorten_candidate_overview_text" not in (
+        candidate_preview_text
+    )
+    assert "candidate_preview_summary.plain_candidate_snippet_lines" not in (
+        candidate_preview_text
+    )
+    assert "candidate_preview_summary.snippet_line_width" not in (
+        candidate_preview_text
+    )
+    assert "candidate_preview_summary.CANDIDATE_GUTTER_SEPARATOR" not in (
+        candidate_diff_text
+    )
+    assert "candidate_preview_summary.candidate_line_in_range" not in (
+        candidate_diff_text
+    )
+    assert "class CandidateSnippetLine" in candidate_snippets_text
+    assert "def shorten_candidate_overview_text" in candidate_snippets_text
+    assert "def plain_candidate_snippet_lines" in candidate_snippets_text
+    assert "def candidate_line_in_range" in candidate_snippets_text
+
+
 def test_candidate_preview_diff_owns_buffer_diff_rendering():
     """Candidate preview diff rendering should stay out of overview pages."""
     candidate_preview = __import__(

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -2917,6 +2917,43 @@ def test_file_review_output_uses_summary_module():
     assert "def _review_source_summary" not in review_output_text
 
 
+def test_file_review_footer_owns_command_rendering():
+    """File-review footer rendering should stay out of page orchestration."""
+    review_output_path = SRC_ROOT / "output" / "file_review.py"
+    review_output_text = review_output_path.read_text()
+    footer_output_path = SRC_ROOT / "output" / "file_review_footer.py"
+    footer_output_text = footer_output_path.read_text()
+    review_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(review_output_path)
+    }
+    footer_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(footer_output_path)
+    }
+    file_review_footer = __import__(
+        "git_stage_batch.output.file_review_footer",
+        fromlist=["file_review_footer"],
+    )
+
+    assert "git_stage_batch.output.file_review_footer" in review_imports
+    assert "print_file_review_footer" in vars(file_review_footer)
+    assert "git_stage_batch.data.file_review.action_commands" not in review_imports
+    assert "git_stage_batch.data.file_review.action_commands" in footer_imports
+    assert "git_stage_batch.data.selected_change.store" not in review_imports
+    assert "git_stage_batch.data.selected_change.store" in footer_imports
+    assert "def _print_footer" not in review_output_text
+    assert "def _style_footer_command" not in review_output_text
+    assert "def _display_footer_command" not in review_output_text
+    assert "def _footer_review_state" not in review_output_text
+    assert "line_action_command" not in review_output_text
+    assert "FileReviewState" not in review_output_text
+    assert "SelectedChangeKind" not in review_output_text
+    assert "line_action_command" in footer_output_text
+    assert "FileReviewState" in footer_output_text
+    assert "SelectedChangeKind" in footer_output_text
+
+
 def test_file_review_rows_own_row_rendering():
     """File-review row rendering should stay out of page orchestration."""
     review_output_path = SRC_ROOT / "output" / "file_review.py"

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -11665,6 +11665,46 @@ def test_candidate_preview_snippets_own_snippet_formatting():
     assert "def candidate_line_in_range" in candidate_snippets_text
 
 
+def test_candidate_preview_porcelain_owns_json_rendering():
+    """Candidate preview porcelain should stay out of terminal rendering."""
+    candidate_preview = __import__(
+        "git_stage_batch.output.candidate_preview",
+        fromlist=["candidate_preview"],
+    )
+    candidate_preview_porcelain = __import__(
+        "git_stage_batch.output.candidate_preview_porcelain",
+        fromlist=["candidate_preview_porcelain"],
+    )
+    candidate_preview_path = SRC_ROOT / "output" / "candidate_preview.py"
+    candidate_porcelain_path = SRC_ROOT / "output" / "candidate_preview_porcelain.py"
+    candidate_preview_text = candidate_preview_path.read_text()
+    candidate_porcelain_text = candidate_porcelain_path.read_text()
+    preview_imports = tuple(_import_from_nodes(candidate_preview_path))
+    preview_imports_porcelain = any(
+        imported_module == "git_stage_batch.output"
+        and any(alias.name == "candidate_preview_porcelain" for alias in node.names)
+        for imported_module, node in preview_imports
+    )
+    porcelain_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(candidate_porcelain_path)
+    }
+    public_names = {
+        "print_operation_candidate_overview_porcelain",
+        "print_operation_candidate_porcelain",
+    }
+
+    assert public_names <= vars(candidate_preview_porcelain).keys()
+    assert public_names.isdisjoint(vars(candidate_preview))
+    assert preview_imports_porcelain
+    assert "import json" not in candidate_preview_text
+    assert "json.dumps" not in candidate_preview_text
+    assert "import json" in candidate_porcelain_text
+    assert "json.dumps" in candidate_porcelain_text
+    assert "git_stage_batch.output.colors" not in porcelain_imports
+    assert "candidate_preview_snippets" in candidate_porcelain_text
+
+
 def test_candidate_preview_diff_owns_buffer_diff_rendering():
     """Candidate preview diff rendering should stay out of overview pages."""
     candidate_preview = __import__(

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -2663,8 +2663,6 @@ def test_file_review_records_stay_out_of_state_module():
             "ReviewSource",
         },
         SRC_ROOT / "output" / "file_review_footer.py": {
-            "FileReviewAction",
-            "FileReviewState",
             "ReviewSource",
         },
         SRC_ROOT / "output" / "file_review_action_selections.py": {
@@ -3053,9 +3051,7 @@ def test_file_review_footer_owns_command_rendering():
     assert "git_stage_batch.output.file_review_footer" in review_imports
     assert "print_file_review_footer" in vars(file_review_footer)
     assert "git_stage_batch.data.file_review.action_commands" not in review_imports
-    assert "git_stage_batch.data.file_review.action_commands" in footer_imports
     assert "git_stage_batch.data.selected_change.store" not in review_imports
-    assert "git_stage_batch.data.selected_change.store" in footer_imports
     assert "def _print_footer" not in review_output_text
     assert "def _style_footer_command" not in review_output_text
     assert "def _display_footer_command" not in review_output_text
@@ -3263,7 +3259,6 @@ def test_file_review_action_commands_stay_out_of_state_module():
             "line_action_command",
             "show_command_for_review_state",
         },
-        SRC_ROOT / "output" / "file_review_footer.py": {"line_action_command"},
     }
     violations = []
 

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -2918,6 +2918,41 @@ def test_file_review_model_selections_own_actionable_derivation():
     )
 
 
+def test_file_review_changes_own_review_change_assembly():
+    """ReviewChange assembly should stay out of model orchestration."""
+    review_model_builder_path = SRC_ROOT / "output" / "file_review_model_builder.py"
+    changes_path = SRC_ROOT / "output" / "file_review_changes.py"
+    review_model_builder_text = review_model_builder_path.read_text()
+    changes_text = changes_path.read_text()
+    builder_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(review_model_builder_path)
+    }
+    builder_model_imports = {
+        alias.name
+        for imported_module, node in _import_from_nodes(review_model_builder_path)
+        if imported_module == "git_stage_batch.output.file_review_model"
+        for alias in node.names
+    }
+    file_review_changes = __import__(
+        "git_stage_batch.output.file_review_changes",
+        fromlist=["file_review_changes"],
+    )
+
+    assert "git_stage_batch.output.file_review_changes" in builder_imports
+    assert "build_file_review_changes" in vars(file_review_changes)
+    assert builder_model_imports == {"FileReviewModel"}
+    assert "ActionableSelectionReason" not in review_model_builder_text
+    assert "format_line_ids" not in review_model_builder_text
+    assert "LineEntry" not in review_model_builder_text
+    assert "ReviewChange" not in review_model_builder_text
+    assert "not currently selectable" not in review_model_builder_text
+    assert "flush_segment" not in review_model_builder_text
+    assert "ReviewChange" in changes_text
+    assert "format_line_ids" in changes_text
+    assert "flush_segment" in changes_text
+
+
 def test_file_review_output_uses_model_module():
     """File-review output should not own passive model records."""
     review_output_path = SRC_ROOT / "output" / "file_review.py"

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -2832,6 +2832,47 @@ def test_file_review_model_builder_uses_layout_module():
     assert "file_review_layout" not in review_output_text
 
 
+def test_file_review_pagination_owns_page_assembly():
+    """File-review pagination should stay out of change construction."""
+    review_model_builder_path = SRC_ROOT / "output" / "file_review_model_builder.py"
+    pagination_path = SRC_ROOT / "output" / "file_review_pagination.py"
+    review_model_builder_text = review_model_builder_path.read_text()
+    pagination_text = pagination_path.read_text()
+    builder_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(review_model_builder_path)
+    }
+    pagination_imports = tuple(_import_from_nodes(pagination_path))
+    pagination_imports_layout = any(
+        imported_module == "git_stage_batch.output"
+        and any(alias.name == "file_review_layout" for alias in node.names)
+        for imported_module, node in pagination_imports
+    )
+    builder_imports_layout = any(
+        imported_module == "git_stage_batch.output"
+        and any(alias.name == "file_review_layout" for alias in node.names)
+        for imported_module, node in _import_from_nodes(review_model_builder_path)
+    )
+    file_review_pagination = __import__(
+        "git_stage_batch.output.file_review_pagination",
+        fromlist=["file_review_pagination"],
+    )
+
+    assert "git_stage_batch.output.file_review_pagination" in builder_imports
+    assert "paginate_file_review_changes" in vars(file_review_pagination)
+    assert not builder_imports_layout
+    assert pagination_imports_layout
+    assert "file_review_layout.body_budget" not in review_model_builder_text
+    assert "ReviewChangeFragment" not in review_model_builder_text
+    assert "FileReviewPage" not in review_model_builder_text
+    assert "page_fragments" not in review_model_builder_text
+    assert "change_pages" not in review_model_builder_text
+    assert "is_first_fragment" not in review_model_builder_text
+    assert "file_review_layout.body_budget" in pagination_text
+    assert "ReviewChangeFragment" in pagination_text
+    assert "page_fragments" in pagination_text
+
+
 def test_file_review_output_uses_model_module():
     """File-review output should not own passive model records."""
     review_output_path = SRC_ROOT / "output" / "file_review.py"

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -2873,6 +2873,51 @@ def test_file_review_pagination_owns_page_assembly():
     assert "page_fragments" in pagination_text
 
 
+def test_file_review_model_selections_own_actionable_derivation():
+    """File-review selection derivation should stay out of change assembly."""
+    review_model_builder_path = SRC_ROOT / "output" / "file_review_model_builder.py"
+    model_selections_path = SRC_ROOT / "output" / "file_review_model_selections.py"
+    review_model_builder_text = review_model_builder_path.read_text()
+    model_selections_text = model_selections_path.read_text()
+    builder_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(review_model_builder_path)
+    }
+    builder_core_imports = {
+        alias.name
+        for imported_module, node in _import_from_nodes(review_model_builder_path)
+        if imported_module == "git_stage_batch.core.actionable_changes"
+        for alias in node.names
+    }
+    model_selection_imports = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(model_selections_path)
+    }
+    file_review_model_selections = __import__(
+        "git_stage_batch.output.file_review_model_selections",
+        fromlist=["file_review_model_selections"],
+    )
+
+    assert "git_stage_batch.output.file_review_model_selections" in builder_imports
+    assert "derive_file_review_actionable_selections" in vars(
+        file_review_model_selections
+    )
+    assert "derive_actionable_selections" not in builder_core_imports
+    assert "_partly_selects_ownership_group" not in review_model_builder_text
+    assert "_reason_for_selection_ids" not in review_model_builder_text
+    assert "_actionable_selections_from_selection_groups" not in (
+        review_model_builder_text
+    )
+    assert "_display_actionable_selections_from_review_action_groups" not in (
+        review_model_builder_text
+    )
+    assert "git_stage_batch.core.actionable_changes" in model_selection_imports
+    assert "_partly_selects_ownership_group" in model_selections_text
+    assert "_display_actionable_selections_from_review_action_groups" in (
+        model_selections_text
+    )
+
+
 def test_file_review_output_uses_model_module():
     """File-review output should not own passive model records."""
     review_output_path = SRC_ROOT / "output" / "file_review.py"

--- a/tests/tui/test_prompts.py
+++ b/tests/tui/test_prompts.py
@@ -17,6 +17,14 @@ from git_stage_batch.tui.prompts import (
 )
 
 
+def _terminal_size_patch_target() -> str:
+    try:
+        import git_stage_batch.tui.action_prompt_menu  # noqa: F401
+    except ModuleNotFoundError:
+        return "git_stage_batch.tui.prompts.shutil.get_terminal_size"
+    return "git_stage_batch.tui.action_prompt_menu.shutil.get_terminal_size"
+
+
 class TestPromptAction:
     """Tests for prompt_action function."""
 
@@ -190,7 +198,7 @@ class TestPromptAction:
             with patch("sys.stdout", new=StringIO()) as fake_out:
                 with patch("sys.stdout.isatty", return_value=False):
                     with patch(
-                        "git_stage_batch.tui.prompts.shutil.get_terminal_size",
+                        _terminal_size_patch_target(),
                         return_value=terminal_size((56, 20)),
                     ):
                         result = prompt_action(use_color=False, has_hunk=True)

--- a/tests/tui/test_prompts.py
+++ b/tests/tui/test_prompts.py
@@ -17,14 +17,6 @@ from git_stage_batch.tui.prompts import (
 )
 
 
-def _terminal_size_patch_target() -> str:
-    try:
-        import git_stage_batch.tui.action_prompt_menu  # noqa: F401
-    except ModuleNotFoundError:
-        return "git_stage_batch.tui.prompts.shutil.get_terminal_size"
-    return "git_stage_batch.tui.action_prompt_menu.shutil.get_terminal_size"
-
-
 class TestPromptAction:
     """Tests for prompt_action function."""
 
@@ -198,7 +190,7 @@ class TestPromptAction:
             with patch("sys.stdout", new=StringIO()) as fake_out:
                 with patch("sys.stdout.isatty", return_value=False):
                     with patch(
-                        _terminal_size_patch_target(),
+                        "git_stage_batch.tui.action_prompt_menu.shutil.get_terminal_size",
                         return_value=terminal_size((56, 20)),
                     ):
                         result = prompt_action(use_color=False, has_hunk=True)


### PR DESCRIPTION
Core, staging, and editor primitives now have clearer package homes, while
undo checkpointing, output review data, and TUI prompt choices still sit in
broader modules.

The project lacks focused owners for undo checkpoint naming, review-output
assembly, footer rendering, status rendering, and reusable interactive
prompt choices.

This PR renames undo checkpoint ownership, extracts output and review
renderers, and moves TUI prompt-choice formatting into focused helpers.

The next PR will move batch source cache and metadata loading out of
broader batch refresh and display paths.

Test plan: .venv/bin/python -m pytest -n auto passed on the final stack tip
  before landing; each PR branch is rebased without code changes before
  merge.
