### PR TITLE
utils: Add object IO batch helpers

### DIFF
--- a/src/git_stage_batch/utils/git_object_io.py
+++ b/src/git_stage_batch/utils/git_object_io.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import subprocess
 from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
+from pathlib import Path
 
 from .git_command import run_git_command, stream_git_command
 
@@ -50,6 +51,47 @@ def create_git_blob(content_chunks: Iterable[bytes]) -> str:
     stdout_bytes = b"".join(stdout_chunks)
     blob_sha = stdout_bytes.strip().decode("utf-8")
     return blob_sha
+
+
+def create_git_blobs_from_paths(paths: Iterable[Path]) -> dict[Path, str]:
+    """Create git blobs for filesystem paths with batched hash-object calls."""
+    unique_paths = list(dict.fromkeys(paths))
+    if not unique_paths:
+        return {}
+
+    blob_shas: dict[Path, str] = {}
+    chunk_size = 512
+    for offset in range(0, len(unique_paths), chunk_size):
+        chunk = unique_paths[offset:offset + chunk_size]
+        try:
+            result = run_git_command(
+                [
+                    "hash-object",
+                    "-w",
+                    "--no-filters",
+                    "--",
+                    *(str(path) for path in chunk),
+                ],
+                requires_index_lock=False,
+            )
+        except subprocess.CalledProcessError as error:
+            raise RuntimeError(
+                f"git hash-object failed with exit code {error.returncode}: "
+                f"{error.stderr}"
+            ) from error
+
+        chunk_shas = [
+            line.strip()
+            for line in result.stdout.splitlines()
+            if line.strip()
+        ]
+        if len(chunk_shas) != len(chunk):
+            raise RuntimeError(
+                "git hash-object produced an unexpected number of blobs"
+            )
+        blob_shas.update(zip(chunk, chunk_shas, strict=True))
+
+    return blob_shas
 
 
 def read_git_blob(blob_sha: str) -> Iterator[bytes]:

--- a/src/git_stage_batch/utils/git_object_io.py
+++ b/src/git_stage_batch/utils/git_object_io.py
@@ -123,7 +123,9 @@ def read_git_blobs_as_bytes(blob_hashes: Iterable[str]) -> dict[str, bytes]:
     if not unique_blob_hashes:
         return {}
 
-    payload = "".join(f"{blob_hash}\n" for blob_hash in unique_blob_hashes).encode("ascii")
+    payload = "".join(f"{blob_hash}\n" for blob_hash in unique_blob_hashes).encode(
+        "utf-8"
+    )
     result = run_git_command(
         ["cat-file", "--batch"],
         stdin_chunks=[payload],

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -2692,6 +2692,7 @@ def test_git_object_io_stays_out_of_git_command_module():
     public_names = {
         "GitTreeBlob",
         "create_git_blob",
+        "create_git_blobs_from_paths",
         "read_git_blob",
         "read_git_blobs_as_bytes",
         "list_git_tree_blobs",

--- a/tests/utils/test_git_object_io.py
+++ b/tests/utils/test_git_object_io.py
@@ -1,0 +1,65 @@
+"""Tests for Git object IO helpers."""
+
+import subprocess
+
+import pytest
+
+from git_stage_batch.utils.git_command import run_git_command
+from git_stage_batch.utils.git_object_io import create_git_blobs_from_paths
+
+
+@pytest.fixture
+def temp_git_repo(tmp_path, monkeypatch):
+    """Create a temporary git repository for testing."""
+    repo = tmp_path / "test_repo"
+    repo.mkdir()
+    monkeypatch.chdir(repo)
+
+    subprocess.run(["git", "init"], check=True, cwd=repo, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"],
+        check=True,
+        cwd=repo,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        check=True,
+        cwd=repo,
+        capture_output=True,
+    )
+
+    (repo / "README.md").write_text("# Test\n")
+    subprocess.run(["git", "add", "README.md"], check=True, cwd=repo, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "Initial commit"],
+        check=True,
+        cwd=repo,
+        capture_output=True,
+    )
+
+    return repo
+
+
+def test_create_git_blobs_from_paths_hashes_path_bytes(temp_git_repo):
+    """Path-based blob creation should store exact file bytes."""
+    files = [
+        temp_git_repo / "alpha.txt",
+        temp_git_repo / "nested" / "beta.bin",
+        temp_git_repo / "name,with,commas.txt",
+    ]
+    files[1].parent.mkdir()
+    files[0].write_bytes(b"alpha\n")
+    files[1].write_bytes(b"\x00\x01beta\n")
+    files[2].write_bytes(b"comma\n")
+
+    blobs = create_git_blobs_from_paths([files[0], files[1], files[0], files[2]])
+
+    assert set(blobs) == set(files)
+    for file_path in files:
+        result = run_git_command(
+            ["cat-file", "blob", blobs[file_path]],
+            text_output=False,
+            requires_index_lock=False,
+        )
+        assert result.stdout == file_path.read_bytes()

--- a/tests/utils/test_git_object_io.py
+++ b/tests/utils/test_git_object_io.py
@@ -5,7 +5,10 @@ import subprocess
 import pytest
 
 from git_stage_batch.utils.git_command import run_git_command
-from git_stage_batch.utils.git_object_io import create_git_blobs_from_paths
+from git_stage_batch.utils.git_object_io import (
+    create_git_blobs_from_paths,
+    read_git_blobs_as_bytes,
+)
 
 
 @pytest.fixture
@@ -63,3 +66,19 @@ def test_create_git_blobs_from_paths_hashes_path_bytes(temp_git_repo):
             requires_index_lock=False,
         )
         assert result.stdout == file_path.read_bytes()
+
+
+def test_read_git_blobs_as_bytes_accepts_revision_paths(temp_git_repo):
+    """Batch object reads should support Git revision:path expressions."""
+    file_path = temp_git_repo / "unicodé.txt"
+    file_path.write_text("accented\n")
+    subprocess.run(["git", "add", file_path.name], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "Add unicode path"],
+        check=True,
+        capture_output=True,
+    )
+
+    blobs = read_git_blobs_as_bytes([f"HEAD:{file_path.name}"])
+
+    assert blobs[f"HEAD:{file_path.name}"] == b"accented\n"


### PR DESCRIPTION
The Git object IO layer can create blobs from streamed bytes and read
objects through cat-file batch mode.

Callers that already have filesystem paths still need local hash-object
loops, and revision:path object reads cannot address paths that Git exposes
as UTF-8 text.

This PR adds path-based blob hashing, switches cat-file batch requests to
UTF-8 input, and covers both helper surfaces with focused utility and
architecture tests.

Later PRs will reuse these helpers in bulk metadata reads and undo
checkpoint snapshots.
