### PR TITLE
batch: Reuse metadata across scans

### DIFF
--- a/src/git_stage_batch/batch/attribution.py
+++ b/src/git_stage_batch/batch/attribution.py
@@ -12,6 +12,8 @@ from collections.abc import Sequence
 from contextlib import ExitStack
 from dataclasses import dataclass
 
+from ..core.buffer import LineBuffer
+from ..utils.git_object_io import read_git_blobs_as_bytes
 from .line_mapping import LineMapping as _LineMapping
 from .match import match_lines
 from . import attribution_fingerprints as _attribution_fingerprints
@@ -23,6 +25,7 @@ from .attribution_units import (
     make_attribution_unit_id as _make_attribution_unit_id,
 )
 from .query import list_batch_names, read_batch_metadata_for_batches
+from .state_refs import get_batch_state_ref_name
 from ..core.line_selection import parse_line_selection
 from ..utils.repository_buffers import (
     load_git_object_as_buffer_or_empty,
@@ -54,6 +57,14 @@ class BatchAttributionContext:
     file_metadata: dict
     batch_source_lines: Sequence[bytes]
     alignment: _LineMapping
+
+
+@dataclass(frozen=True)
+class _BatchSourceRequest:
+    batch_name: str
+    file_metadata: dict
+    primary_refspec: str
+    fallback_refspec: str
 
 
 def _parse_presence_source_lines(file_metadata: dict) -> list[int]:
@@ -143,12 +154,16 @@ def _open_batch_attribution_contexts(
 ) -> list[BatchAttributionContext]:
     """Open reusable batch source buffers and alignments for one file."""
     contexts: list[BatchAttributionContext] = []
+    source_requests = _batch_source_requests(file_path, all_batch_metadata)
+    source_blobs = read_git_blobs_as_bytes(_source_refspecs(source_requests))
 
-    for batch_name, batch_metadata in all_batch_metadata.items():
-        file_metadata = batch_metadata["files"][file_path]
-        batch_source_commit = file_metadata["batch_source_commit"]
+    for request in source_requests:
+        file_metadata = request.file_metadata
+        source_blob = source_blobs.get(request.primary_refspec)
+        if source_blob is None:
+            source_blob = source_blobs.get(request.fallback_refspec, b"")
         batch_source_lines = stack.enter_context(
-            load_git_object_as_buffer_or_empty(f"{batch_source_commit}:{file_path}")
+            LineBuffer.from_chunks([source_blob])
         )
         alignment = stack.enter_context(
             match_lines(
@@ -158,7 +173,7 @@ def _open_batch_attribution_contexts(
         )
         contexts.append(
             BatchAttributionContext(
-                batch_name=batch_name,
+                batch_name=request.batch_name,
                 file_metadata=file_metadata,
                 batch_source_lines=batch_source_lines,
                 alignment=alignment,
@@ -166,6 +181,40 @@ def _open_batch_attribution_contexts(
         )
 
     return contexts
+
+
+def _batch_source_requests(
+    file_path: str,
+    all_batch_metadata: dict,
+) -> list[_BatchSourceRequest]:
+    requests: list[_BatchSourceRequest] = []
+    for batch_name, batch_metadata in all_batch_metadata.items():
+        file_metadata = batch_metadata["files"][file_path]
+        fallback_refspec = f"{file_metadata['batch_source_commit']}:{file_path}"
+        source_path = file_metadata.get("source_path")
+        primary_refspec = (
+            f"{get_batch_state_ref_name(batch_name)}:{source_path}"
+            if source_path
+            else fallback_refspec
+        )
+        requests.append(
+            _BatchSourceRequest(
+                batch_name=batch_name,
+                file_metadata=file_metadata,
+                primary_refspec=primary_refspec,
+                fallback_refspec=fallback_refspec,
+            )
+        )
+    return requests
+
+
+def _source_refspecs(source_requests: Sequence[_BatchSourceRequest]) -> list[str]:
+    refspecs: list[str] = []
+    for request in source_requests:
+        refspecs.append(request.primary_refspec)
+        if request.fallback_refspec != request.primary_refspec:
+            refspecs.append(request.fallback_refspec)
+    return refspecs
 
 
 def _enumerate_units_from_batches(

--- a/src/git_stage_batch/batch/attribution.py
+++ b/src/git_stage_batch/batch/attribution.py
@@ -22,7 +22,7 @@ from .attribution_units import (
     enumerate_units_from_file_comparison as _enumerate_units_from_file_comparison,
     make_attribution_unit_id as _make_attribution_unit_id,
 )
-from .query import list_batch_names, read_batch_metadata
+from .query import list_batch_names, read_batch_metadata_for_batches
 from ..core.line_selection import parse_line_selection
 from ..utils.repository_buffers import (
     load_git_object_as_buffer_or_empty,
@@ -82,12 +82,15 @@ def _has_presence_source_lines(file_metadata: dict) -> bool:
 def build_file_attribution(
     file_path: str,
     *,
+    batch_metadata_by_name: dict[str, dict] | None = None,
     supplemental_batch_metadata: dict[str, dict] | None = None,
 ) -> FileAttribution:
     """Build complete ownership attribution for a file."""
     all_batch_metadata = {}
-    for batch_name in list_batch_names():
-        metadata = read_batch_metadata(batch_name)
+    if batch_metadata_by_name is None:
+        batch_metadata_by_name = read_batch_metadata_for_batches(list_batch_names())
+
+    for batch_name, metadata in batch_metadata_by_name.items():
         if file_path in metadata.get("files", {}):
             all_batch_metadata[batch_name] = metadata
 

--- a/src/git_stage_batch/batch/query.py
+++ b/src/git_stage_batch/batch/query.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Iterable
 from typing import Optional
 
 from .ref_names import BATCH_CONTENT_REF_PREFIX, LEGACY_BATCH_REF_PREFIX
 from .state_refs import (
     get_authoritative_batch_commit_sha,
     get_legacy_batch_ref_name,
+    read_batch_state_metadata_for_batches,
     read_batch_state_metadata,
 )
 from .validation import validate_batch_name
@@ -43,14 +45,43 @@ def read_batch_metadata(name: str) -> dict:
     if state_metadata is not None:
         return state_metadata
 
+    return _read_file_backed_batch_metadata_or_empty(name)
+
+
+def read_batch_metadata_for_batches(batch_names: Iterable[str]) -> dict[str, dict]:
+    """Read metadata for many batches with one state-ref lookup pass."""
+    unique_batch_names = list(dict.fromkeys(batch_names))
+    for batch_name in unique_batch_names:
+        validate_batch_name(batch_name)
+    if not unique_batch_names:
+        return {}
+
+    metadata_by_name = read_batch_state_metadata_for_batches(unique_batch_names)
+    missing_batch_names = [
+        batch_name
+        for batch_name in unique_batch_names
+        if batch_name not in metadata_by_name
+    ]
+    for batch_name in missing_batch_names:
+        metadata_by_name[batch_name] = _read_file_backed_batch_metadata_or_empty(
+            batch_name
+        )
+    return metadata_by_name
+
+
+def _empty_batch_metadata() -> dict:
+    return {
+        "note": "",
+        "created_at": "",
+        "baseline": None,
+        "files": {},
+    }
+
+
+def _read_file_backed_batch_metadata_or_empty(name: str) -> dict:
     metadata_path = get_batch_metadata_file_path(name)
     if not metadata_path.exists():
-        return {
-            "note": "",
-            "created_at": "",
-            "baseline": None,
-            "files": {}
-        }
+        return _empty_batch_metadata()
 
     try:
         metadata = json.loads(read_text_file_contents(metadata_path))
@@ -61,12 +92,7 @@ def read_batch_metadata(name: str) -> dict:
             "files": metadata.get("files", {})
         }
     except (json.JSONDecodeError, KeyError):
-        return {
-            "note": "",
-            "created_at": "",
-            "baseline": None,
-            "files": {}
-        }
+        return _empty_batch_metadata()
 
 
 def get_batch_commit_sha(name: str) -> Optional[str]:

--- a/src/git_stage_batch/batch/state_refs.py
+++ b/src/git_stage_batch/batch/state_refs.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import shutil
+from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Any
 
@@ -25,7 +26,7 @@ from ..utils.git_index import (
     git_write_tree,
     temp_git_index,
 )
-from ..utils.git_object_io import create_git_blob
+from ..utils.git_object_io import create_git_blob, read_git_blobs_as_bytes
 from ..utils.paths import get_batch_metadata_file_path
 
 
@@ -111,6 +112,18 @@ def read_file_backed_batch_metadata(batch_name: str) -> dict[str, Any]:
     }
 
 
+def _normalize_state_metadata(state_metadata: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "note": state_metadata.get("note", ""),
+        "created_at": state_metadata.get("created_at", ""),
+        "baseline": state_metadata.get(
+            "baseline_commit",
+            state_metadata.get("baseline"),
+        ),
+        "files": state_metadata.get("files", {}),
+    }
+
+
 def read_batch_state_metadata(batch_name: str) -> dict[str, Any] | None:
     """Read normalized batch metadata from the authoritative state ref."""
     validate_batch_name(batch_name)
@@ -123,12 +136,32 @@ def read_batch_state_metadata(batch_name: str) -> dict[str, Any] | None:
         return None
 
     state_metadata = json.loads(result.stdout)
-    return {
-        "note": state_metadata.get("note", ""),
-        "created_at": state_metadata.get("created_at", ""),
-        "baseline": state_metadata.get("baseline_commit", state_metadata.get("baseline")),
-        "files": state_metadata.get("files", {}),
+    return _normalize_state_metadata(state_metadata)
+
+
+def read_batch_state_metadata_for_batches(
+    batch_names: Iterable[str],
+) -> dict[str, dict[str, Any]]:
+    """Read normalized state-ref metadata for many batches in one Git process."""
+    unique_batch_names = list(dict.fromkeys(batch_names))
+    for batch_name in unique_batch_names:
+        validate_batch_name(batch_name)
+    if not unique_batch_names:
+        return {}
+
+    refspec_by_name = {
+        batch_name: f"{get_batch_state_ref_name(batch_name)}:batch.json"
+        for batch_name in unique_batch_names
     }
+    blobs = read_git_blobs_as_bytes(refspec_by_name.values())
+
+    metadata_by_name: dict[str, dict[str, Any]] = {}
+    for batch_name, refspec in refspec_by_name.items():
+        blob = blobs.get(refspec)
+        if blob is None:
+            continue
+        metadata_by_name[batch_name] = _normalize_state_metadata(json.loads(blob))
+    return metadata_by_name
 
 
 def get_authoritative_batch_commit_sha(batch_name: str) -> str | None:

--- a/src/git_stage_batch/data/change_freshness.py
+++ b/src/git_stage_batch/data/change_freshness.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from ..batch.query import list_batch_names, read_batch_metadata
+from ..batch.query import list_batch_names, read_batch_metadata_for_batches
 from ..core.models import (
     BinaryFileChange,
     GitlinkChange,
@@ -78,19 +78,31 @@ def text_deletion_change_is_stale(
 
 def text_deletion_change_is_batched(
     deletion_change: TextFileDeletionChange,
+    *,
+    batch_metadata_by_name: dict[str, dict] | None = None,
 ) -> bool:
     """Return whether a whole-text-file deletion is already represented in a batch."""
-    return empty_text_lifecycle_change_is_batched(deletion_change.path())
+    return empty_text_lifecycle_change_is_batched(
+        deletion_change.path(),
+        batch_metadata_by_name=batch_metadata_by_name,
+    )
 
 
-def empty_text_lifecycle_change_is_batched(file_path: str) -> bool:
+def empty_text_lifecycle_change_is_batched(
+    file_path: str,
+    *,
+    batch_metadata_by_name: dict[str, dict] | None = None,
+) -> bool:
     """Return whether the current empty text lifecycle diff is already batched."""
     change_type = detect_empty_text_lifecycle_change(file_path)
     if change_type is None:
         return False
 
-    for batch_name in list_batch_names():
-        file_meta = read_batch_metadata(batch_name).get("files", {}).get(file_path)
+    if batch_metadata_by_name is None:
+        batch_metadata_by_name = read_batch_metadata_for_batches(list_batch_names())
+
+    for metadata in batch_metadata_by_name.values():
+        file_meta = metadata.get("files", {}).get(file_path)
         if file_meta is not None and file_meta.get("change_type") == change_type:
             return True
     return False

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import subprocess
 from typing import Union
 
+from ..batch.query import list_batch_names, read_batch_metadata_for_batches
 from ..batch.source_annotation import annotate_with_batch_source
 from ..core.hashing import (
     compute_binary_file_hash,
@@ -48,6 +49,20 @@ from .selected_change.lifecycle import (
 )
 
 
+class _BatchMetadataSnapshot:
+    """Lazy batch metadata snapshot for one hunk navigation scan."""
+
+    def __init__(self) -> None:
+        self._metadata_by_name: dict[str, dict] | None = None
+
+    def metadata_by_name(self) -> dict[str, dict]:
+        if self._metadata_by_name is None:
+            self._metadata_by_name = read_batch_metadata_for_batches(
+                list_batch_names()
+            )
+        return self._metadata_by_name
+
+
 def fetch_next_change() -> Union[LineLevelChange, BinaryFileChange, GitlinkChange, RenameChange, TextFileDeletionChange]:
     """Find the next hunk or binary file that isn't blocked and cache it as selected.
 
@@ -62,6 +77,7 @@ def fetch_next_change() -> Union[LineLevelChange, BinaryFileChange, GitlinkChang
 
     # Load blocklist (includes selected iteration)
     blocked_hashes = read_text_file_line_set(get_block_list_file_path())
+    batch_metadata_snapshot = _BatchMetadataSnapshot()
 
     # Stream git diff and parse incrementally - stops after first unblocked item found
     try:
@@ -92,7 +108,12 @@ def fetch_next_change() -> Union[LineLevelChange, BinaryFileChange, GitlinkChang
                     deletion_hash = compute_text_file_deletion_hash(item)
                     if (
                         deletion_hash in blocked_hashes
-                        or _change_freshness.text_deletion_change_is_batched(item)
+                        or _change_freshness.text_deletion_change_is_batched(
+                            item,
+                            batch_metadata_by_name=(
+                                batch_metadata_snapshot.metadata_by_name()
+                            ),
+                        )
                     ):
                         continue
 
@@ -157,7 +178,11 @@ def fetch_next_change() -> Union[LineLevelChange, BinaryFileChange, GitlinkChang
 
                 # Apply line-level batch filtering
                 if (
-                    _selected_hunk_filtering.apply_line_level_batch_filter_to_cached_hunk()
+                    _selected_hunk_filtering.apply_line_level_batch_filter_to_cached_hunk(
+                        batch_metadata_by_name=(
+                            batch_metadata_snapshot.metadata_by_name()
+                        ),
+                    )
                 ):
                     # All lines were batched, skip this hunk and continue
                     _clear_selected_change_state_files()

--- a/src/git_stage_batch/data/selected_change/hunk_filtering.py
+++ b/src/git_stage_batch/data/selected_change/hunk_filtering.py
@@ -14,7 +14,10 @@ from .. import line_state as _line_state
 from ..consumed_selections import read_consumed_file_metadata
 
 
-def apply_line_level_batch_filter_to_cached_hunk() -> bool:
+def apply_line_level_batch_filter_to_cached_hunk(
+    *,
+    batch_metadata_by_name: dict[str, dict] | None = None,
+) -> bool:
     """Filter cached hunk using file-centric ownership attribution.
 
     File-centric blame-like approach:
@@ -33,12 +36,16 @@ def apply_line_level_batch_filter_to_cached_hunk() -> bool:
 
     if (
         not line_changes.lines
-        and _change_freshness.empty_text_lifecycle_change_is_batched(file_path)
+        and _change_freshness.empty_text_lifecycle_change_is_batched(
+            file_path,
+            batch_metadata_by_name=batch_metadata_by_name,
+        )
     ):
         return True
 
     attribution = build_file_attribution(
         file_path,
+        batch_metadata_by_name=batch_metadata_by_name,
         supplemental_batch_metadata=_consumed_batch_metadata(file_path),
     )
     should_skip, filtered_line_changes = filter_owned_diff_fragments(

--- a/tests/batch/test_ownership_hardening.py
+++ b/tests/batch/test_ownership_hardening.py
@@ -273,6 +273,81 @@ def test_build_file_attribution_reuses_batch_alignment_per_file(temp_repo, monke
     assert match_call_count == 2
 
 
+def test_build_file_attribution_bulk_loads_batch_source_buffers(
+    temp_repo,
+    monkeypatch,
+):
+    """Batch source buffers should be loaded with one object batch read."""
+    test_file = temp_repo / "test.txt"
+    test_file.write_text("base\n")
+    subprocess.run(["git", "add", "test.txt"], check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "baseline"], check=True, capture_output=True)
+
+    first_source_commit = _create_batch_source_commit(
+        temp_repo,
+        "test.txt",
+        "base\nfirst\n",
+    )
+    second_source_commit = _create_batch_source_commit(
+        temp_repo,
+        "test.txt",
+        "base\nsecond\n",
+    )
+
+    monkeypatch.setattr(
+        attribution_module,
+        "list_batch_names",
+        lambda: ["first", "second"],
+    )
+    monkeypatch.setattr(
+        attribution_module,
+        "read_batch_metadata_for_batches",
+        lambda _names: {
+            "first": {
+                "files": {
+                    "test.txt": {
+                        "batch_source_commit": first_source_commit,
+                        "presence_claims": [{"source_lines": ["2"]}],
+                        "deletions": [],
+                    }
+                }
+            },
+            "second": {
+                "files": {
+                    "test.txt": {
+                        "batch_source_commit": second_source_commit,
+                        "presence_claims": [{"source_lines": ["2"]}],
+                        "deletions": [],
+                    }
+                }
+            },
+        },
+    )
+    calls = []
+    original_read_git_blobs_as_bytes = attribution_module.read_git_blobs_as_bytes
+
+    def counting_read_git_blobs_as_bytes(refspecs):
+        refspecs = tuple(refspecs)
+        calls.append(refspecs)
+        return original_read_git_blobs_as_bytes(refspecs)
+
+    monkeypatch.setattr(
+        attribution_module,
+        "read_git_blobs_as_bytes",
+        counting_read_git_blobs_as_bytes,
+    )
+
+    attribution = build_file_attribution("test.txt")
+
+    assert attribution.units
+    assert calls == [
+        (
+            f"{first_source_commit}:test.txt",
+            f"{second_source_commit}:test.txt",
+        )
+    ]
+
+
 class TestPresenceGranularity:
     """Test that PRESENCE_ONLY units are per-line, not per-run."""
 

--- a/tests/batch/test_ownership_hardening.py
+++ b/tests/batch/test_ownership_hardening.py
@@ -192,13 +192,15 @@ def test_legacy_claimed_lines_metadata_owns_presence_units(temp_repo, monkeypatc
     monkeypatch.setattr(attribution_module, "list_batch_names", lambda: ["legacy"])
     monkeypatch.setattr(
         attribution_module,
-        "read_batch_metadata",
-        lambda _name: {
-            "files": {
-                "test.txt": {
-                    "batch_source_commit": batch_source_commit,
-                    "claimed_lines": ["2"],
-                    "deletions": [],
+        "read_batch_metadata_for_batches",
+        lambda _names: {
+            "legacy": {
+                "files": {
+                    "test.txt": {
+                        "batch_source_commit": batch_source_commit,
+                        "claimed_lines": ["2"],
+                        "deletions": [],
+                    }
                 }
             }
         },
@@ -236,13 +238,15 @@ def test_build_file_attribution_reuses_batch_alignment_per_file(temp_repo, monke
     monkeypatch.setattr(attribution_module, "list_batch_names", lambda: ["batch"])
     monkeypatch.setattr(
         attribution_module,
-        "read_batch_metadata",
-        lambda _name: {
-            "files": {
-                "test.txt": {
-                    "batch_source_commit": batch_source_commit,
-                    "presence_claims": [{"source_lines": ["2", "4", "6"]}],
-                    "deletions": [],
+        "read_batch_metadata_for_batches",
+        lambda _names: {
+            "batch": {
+                "files": {
+                    "test.txt": {
+                        "batch_source_commit": batch_source_commit,
+                        "presence_claims": [{"source_lines": ["2", "4", "6"]}],
+                        "deletions": [],
+                    }
                 }
             }
         },

--- a/tests/batch/test_query.py
+++ b/tests/batch/test_query.py
@@ -11,6 +11,7 @@ from git_stage_batch.batch.query import (
     list_batch_files,
     list_batch_names,
     read_batch_metadata,
+    read_batch_metadata_for_batches,
 )
 from git_stage_batch.batch.lifecycle import create_batch
 from git_stage_batch.batch.text_file_storage import add_file_to_batch
@@ -72,6 +73,26 @@ def test_read_batch_metadata_ignores_corrupted_compat_file(temp_git_repo):
     metadata = read_batch_metadata("test-batch")
     assert metadata["note"] == "Original"
     assert metadata["created_at"] != ""
+
+
+def test_read_batch_metadata_for_batches_reads_existing_batches(temp_git_repo):
+    """Bulk metadata reads should preserve normal query semantics."""
+    create_batch("batch-a", "A")
+    create_batch("batch-b", "B")
+
+    metadata_by_name = read_batch_metadata_for_batches(["batch-a", "batch-b"])
+
+    assert metadata_by_name["batch-a"]["note"] == "A"
+    assert metadata_by_name["batch-b"]["note"] == "B"
+    assert metadata_by_name["batch-a"]["created_at"]
+    assert metadata_by_name["batch-b"]["created_at"]
+
+
+def test_read_batch_metadata_for_batches_returns_empty_for_missing_batch(temp_git_repo):
+    """Bulk metadata reads should match single-read missing batch behavior."""
+    metadata_by_name = read_batch_metadata_for_batches(["missing"])
+
+    assert metadata_by_name["missing"] == read_batch_metadata("missing")
 
 
 def test_get_batch_commit_sha_existing(temp_git_repo):

--- a/tests/batch/test_state_refs.py
+++ b/tests/batch/test_state_refs.py
@@ -7,7 +7,12 @@ import pytest
 
 from git_stage_batch.batch.lifecycle import create_batch, delete_batch, update_batch_note
 from git_stage_batch.batch.ownership import BatchOwnership
-from git_stage_batch.batch.state_refs import get_batch_content_ref_name, get_batch_state_ref_name
+import git_stage_batch.batch.state_refs as state_refs_module
+from git_stage_batch.batch.state_refs import (
+    get_batch_content_ref_name,
+    get_batch_state_ref_name,
+    read_batch_state_metadata_for_batches,
+)
 from git_stage_batch.batch.text_file_storage import add_file_to_batch
 from git_stage_batch.data.session import initialize_abort_state
 from git_stage_batch.utils.paths import ensure_state_directory_exists
@@ -82,6 +87,38 @@ def test_state_ref_updates_note_history(temp_git_repo):
     assert second_state != first_state
     batch_json = json.loads(_git_show(f"{state_ref}:batch.json"))
     assert batch_json["note"] == "After"
+
+
+def test_read_batch_state_metadata_for_batches_uses_one_batch_object_read(
+    temp_git_repo,
+    monkeypatch,
+):
+    """Many state metadata loads should share one cat-file batch process."""
+    create_batch("batch-a", "A")
+    create_batch("batch-b", "B")
+    calls = []
+    original_read_git_blobs_as_bytes = state_refs_module.read_git_blobs_as_bytes
+
+    def counting_read_git_blobs_as_bytes(refspecs):
+        refspecs = tuple(refspecs)
+        calls.append(refspecs)
+        return original_read_git_blobs_as_bytes(refspecs)
+
+    monkeypatch.setattr(
+        state_refs_module,
+        "read_git_blobs_as_bytes",
+        counting_read_git_blobs_as_bytes,
+    )
+
+    metadata_by_name = read_batch_state_metadata_for_batches(["batch-a", "batch-b"])
+
+    assert metadata_by_name["batch-a"]["note"] == "A"
+    assert metadata_by_name["batch-b"]["note"] == "B"
+    assert len(calls) == 1
+    assert calls[0] == (
+        f"{get_batch_state_ref_name('batch-a')}:batch.json",
+        f"{get_batch_state_ref_name('batch-b')}:batch.json",
+    )
 
 
 def test_delete_batch_removes_experimental_refs(temp_git_repo):

--- a/tests/data/test_change_freshness.py
+++ b/tests/data/test_change_freshness.py
@@ -1,0 +1,41 @@
+"""Tests for cached change freshness helpers."""
+
+import git_stage_batch.data.change_freshness as change_freshness
+
+
+def test_empty_text_lifecycle_batched_uses_bulk_metadata(monkeypatch):
+    """Empty text lifecycle checks should not read each batch individually."""
+    calls = []
+
+    monkeypatch.setattr(
+        change_freshness,
+        "detect_empty_text_lifecycle_change",
+        lambda _path: "deleted",
+    )
+    monkeypatch.setattr(
+        change_freshness,
+        "list_batch_names",
+        lambda: ["batch-a", "batch-b"],
+    )
+
+    def fake_read_batch_metadata_for_batches(batch_names):
+        calls.append(tuple(batch_names))
+        return {
+            "batch-a": {"files": {}},
+            "batch-b": {
+                "files": {
+                    "gone.txt": {
+                        "change_type": "deleted",
+                    },
+                },
+            },
+        }
+
+    monkeypatch.setattr(
+        change_freshness,
+        "read_batch_metadata_for_batches",
+        fake_read_batch_metadata_for_batches,
+    )
+
+    assert change_freshness.empty_text_lifecycle_change_is_batched("gone.txt")
+    assert calls == [("batch-a", "batch-b")]

--- a/tests/data/test_hunk_tracking.py
+++ b/tests/data/test_hunk_tracking.py
@@ -12,6 +12,7 @@ import subprocess
 
 import pytest
 
+import git_stage_batch.data.hunk_tracking as hunk_tracking
 from git_stage_batch.commands.again import command_again
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.data.hunk_tracking import (
@@ -49,6 +50,32 @@ def temp_git_repo(tmp_path, monkeypatch):
     ensure_state_directory_exists()
 
     return repo
+
+
+def test_batch_metadata_snapshot_loads_once(monkeypatch):
+    """One hunk scan should reuse a single batch metadata snapshot."""
+    calls = []
+
+    monkeypatch.setattr(hunk_tracking, "list_batch_names", lambda: ["batch-a"])
+
+    def fake_read_batch_metadata_for_batches(batch_names):
+        calls.append(tuple(batch_names))
+        return {"batch-a": {"files": {}}}
+
+    monkeypatch.setattr(
+        hunk_tracking,
+        "read_batch_metadata_for_batches",
+        fake_read_batch_metadata_for_batches,
+    )
+
+    snapshot = hunk_tracking._BatchMetadataSnapshot()
+
+    first = snapshot.metadata_by_name()
+    second = snapshot.metadata_by_name()
+
+    assert first == {"batch-a": {"files": {}}}
+    assert second is first
+    assert calls == [("batch-a",)]
 
 
 class TestFindAndCacheNextUnblockedHunk:


### PR DESCRIPTION
Batch state refs store normalized metadata, and attribution and hunk
navigation can ask for batch ownership while scanning user changes.

Those scans still repeat metadata and source blob reads while walking the
same batch set. The repeated object lookups happen inside several helper
layers, so callers cannot share one snapshot through the scan.

This PR adds bulk state-ref and batch metadata readers, routes attribution
source loading through one object batch, and threads reusable metadata
through freshness and hunk navigation checks.

The metadata scan work is complete within this PR.
