### PR TITLE
data: Scope undo checkpoint paths

### DIFF
--- a/src/git_stage_batch/data/selected_change/paths.py
+++ b/src/git_stage_batch/data/selected_change/paths.py
@@ -2,9 +2,39 @@
 
 from __future__ import annotations
 
+from ...core.models import (
+    BinaryFileChange,
+    GitlinkChange,
+    LineLevelChange,
+    RenameChange,
+    TextFileDeletionChange,
+)
 from ...utils.paths import get_selected_hunk_patch_file_path
 from . import file_changes as _selected_file_changes
 from .store import load_line_changes_from_patch_path
+
+
+SelectedChange = (
+    BinaryFileChange
+    | GitlinkChange
+    | LineLevelChange
+    | RenameChange
+    | TextFileDeletionChange
+)
+
+
+def file_path_for_selected_change(change: SelectedChange) -> str:
+    """Return the repository path that identifies a selected change."""
+    if isinstance(change, LineLevelChange):
+        return change.path
+    return change.path()
+
+
+def worktree_paths_for_selected_change(change: SelectedChange) -> list[str]:
+    """Return worktree paths that can be affected by a selected-change action."""
+    if isinstance(change, RenameChange):
+        return [change.old_path, change.new_path]
+    return [file_path_for_selected_change(change)]
 
 
 def get_selected_change_file_path() -> str | None:

--- a/src/git_stage_batch/data/selected_change/paths.py
+++ b/src/git_stage_batch/data/selected_change/paths.py
@@ -23,7 +23,7 @@ def get_selected_change_file_path() -> str | None:
 
     binary_file = _selected_file_changes.load_selected_binary_file()
     if binary_file is not None:
-            return binary_file.path()
+        return binary_file.path()
 
     patch_path = get_selected_hunk_patch_file_path()
     if not patch_path.exists():

--- a/src/git_stage_batch/data/undo_checkpoints.py
+++ b/src/git_stage_batch/data/undo_checkpoints.py
@@ -38,7 +38,7 @@ from ..utils.git_index import (
     temp_git_index,
 )
 from ..utils.git_repository import get_git_repository_root_path
-from ..utils.git_object_io import create_git_blob
+from ..utils.git_object_io import create_git_blob, create_git_blobs_from_paths
 from ..utils.paths import (
     get_batches_directory_path,
     get_session_directory_path,
@@ -74,17 +74,31 @@ def _add_blob_to_index(env: dict[str, str], path: str, data: bytes, mode: str = 
 def _add_directory_to_index(env: dict[str, str], *, source_dir: Path, tree_prefix: str) -> None:
     if not source_dir.exists():
         return
+    file_paths = sorted(path for path in source_dir.rglob("*") if path.is_file())
+    normal_file_blobs = create_git_blobs_from_paths(
+        path for path in file_paths if not path.is_symlink()
+    )
     updates: list[GitIndexEntryUpdate] = []
-    for file_path in sorted(path for path in source_dir.rglob("*") if path.is_file()):
+    for file_path in file_paths:
         relative_path = file_path.relative_to(source_dir).as_posix()
         tree_path = f"{tree_prefix}/{relative_path}"
-        updates.append(
-            _undo_worktree.index_update_from_path(
-                index_path=tree_path,
-                source_path=file_path,
-                mode=_undo_worktree.file_mode_for_path(file_path),
+        mode = _undo_worktree.file_mode_for_path(file_path)
+        if file_path.is_symlink():
+            updates.append(
+                _undo_worktree.index_update_from_path(
+                    index_path=tree_path,
+                    source_path=file_path,
+                    mode=mode,
+                )
             )
-        )
+        else:
+            updates.append(
+                GitIndexEntryUpdate(
+                    file_path=tree_path,
+                    mode=mode,
+                    blob_sha=normal_file_blobs[file_path],
+                )
+            )
     git_update_index_entries(updates, env=env)
 
 

--- a/src/git_stage_batch/data/undo_checkpoints.py
+++ b/src/git_stage_batch/data/undo_checkpoints.py
@@ -47,6 +47,22 @@ from ..utils.paths import (
 
 
 _PENDING_CHECKPOINT: str | None = None
+EXPLICIT_WORKTREE_SCOPE = "explicit"
+CHANGED_WORKTREE_SCOPE = "changed"
+
+
+def _checkpoint_worktree_scope(
+    worktree_paths: list[str] | None,
+) -> tuple[str, list[str]]:
+    """Return checkpoint scope metadata and paths to snapshot."""
+    if worktree_paths is None:
+        return CHANGED_WORKTREE_SCOPE, _undo_worktree.changed_worktree_paths()
+    return EXPLICIT_WORKTREE_SCOPE, sorted(set(worktree_paths))
+
+
+def _uses_explicit_worktree_scope(manifest: dict[str, Any]) -> bool:
+    """Return whether a checkpoint intentionally scoped worktree snapshots."""
+    return manifest.get("worktree_path_scope") == EXPLICIT_WORKTREE_SCOPE
 
 
 def _snapshot_current_state(paths: list[str]) -> dict[str, Any]:
@@ -112,8 +128,8 @@ def _create_undo_checkpoint(operation: str, *, worktree_paths: list[str] | None 
 
     global _PENDING_CHECKPOINT
 
-    tracked_worktree_paths = sorted(
-        set(_undo_worktree.changed_worktree_paths()) | set(worktree_paths or [])
+    worktree_path_scope, tracked_worktree_paths = _checkpoint_worktree_scope(
+        worktree_paths
     )
     before = _snapshot_current_state(tracked_worktree_paths)
 
@@ -127,6 +143,7 @@ def _create_undo_checkpoint(operation: str, *, worktree_paths: list[str] | None 
             for entry in before["worktree_paths"]
         ],
         "tracked_worktree_paths": tracked_worktree_paths,
+        "worktree_path_scope": worktree_path_scope,
     }
 
     with temp_git_index() as env:
@@ -192,10 +209,10 @@ def finalize_pending_checkpoint() -> None:
     except CommandError:
         return
 
-    paths = sorted(
-        set(manifest.get("tracked_worktree_paths", []))
-        | set(_undo_worktree.changed_worktree_paths())
-    )
+    paths = set(manifest.get("tracked_worktree_paths", []))
+    if not _uses_explicit_worktree_scope(manifest):
+        paths.update(_undo_worktree.changed_worktree_paths())
+    paths = sorted(paths)
     manifest["after"] = _snapshot_current_state(paths)
     manifest["after"]["worktree_paths"] = manifest["after"]["worktree_paths"]
 
@@ -260,7 +277,8 @@ def _redo_relevant_paths(manifest: dict[str, Any]) -> list[str]:
     if isinstance(after, dict):
         for entry in after.get("worktree_paths", []):
             paths.add(entry["path"])
-    paths.update(_undo_worktree.changed_worktree_paths())
+    if not _uses_explicit_worktree_scope(manifest):
+        paths.update(_undo_worktree.changed_worktree_paths())
     return sorted(paths)
 
 

--- a/tests/commands/test_undo.py
+++ b/tests/commands/test_undo.py
@@ -8,6 +8,8 @@ import pytest
 from git_stage_batch.commands.include import command_include_line
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.commands.undo import command_undo
+from git_stage_batch.data.undo_checkpoints import undo_checkpoint, undo_last_checkpoint
+from git_stage_batch.utils.paths import get_session_directory_path
 
 
 @pytest.fixture
@@ -46,6 +48,19 @@ def _commit_symlink(repo, *, target):
     return link_path
 
 
+def _commit_text_file(repo, path: str, content: str):
+    file_path = repo / path
+    file_path.write_text(content)
+    subprocess.run(["git", "add", path], check=True, cwd=repo, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", f"Add {path}"],
+        check=True,
+        cwd=repo,
+        capture_output=True,
+    )
+    return file_path
+
+
 def test_undo_include_line_restores_symlink_worktree_snapshot(temp_git_repo):
     """Undo should restore a symlink target, not the referent bytes."""
     link_path = _commit_symlink(temp_git_repo, target="old")
@@ -77,3 +92,20 @@ def test_undo_include_line_restores_dangling_symlink_snapshot(temp_git_repo):
     assert os.path.islink(link_path)
     assert os.readlink(link_path) == "missing"
     assert _show_index_path(temp_git_repo, "link") == b"old"
+
+
+def test_scoped_undo_ignores_unrelated_untracked_worktree_edits(temp_git_repo):
+    """Explicit checkpoint scopes should not conflict on unrelated dirty files."""
+    target = _commit_text_file(temp_git_repo, "target.txt", "before\n")
+    unrelated = temp_git_repo / "unrelated.txt"
+    unrelated.write_text("first\n")
+    get_session_directory_path().mkdir(parents=True, exist_ok=True)
+
+    with undo_checkpoint("change target", worktree_paths=["target.txt"]):
+        target.write_text("during\n")
+
+    unrelated.write_text("second\n")
+    undo_last_checkpoint()
+
+    assert target.read_text() == "before\n"
+    assert unrelated.read_text() == "second\n"

--- a/tests/data/test_selected_change_paths.py
+++ b/tests/data/test_selected_change_paths.py
@@ -1,0 +1,38 @@
+"""Tests for selected-change path helpers."""
+
+from git_stage_batch.core.models import (
+    BinaryFileChange,
+    HunkHeader,
+    LineLevelChange,
+    RenameChange,
+)
+from git_stage_batch.data.selected_change.paths import worktree_paths_for_selected_change
+
+
+def test_worktree_paths_for_line_level_change_uses_path_attribute():
+    """Text hunks carry their repository path as an attribute."""
+    change = LineLevelChange(
+        path="notes.txt",
+        header=HunkHeader(old_start=1, old_len=1, new_start=1, new_len=1),
+        lines=[],
+    )
+
+    assert worktree_paths_for_selected_change(change) == ["notes.txt"]
+
+
+def test_worktree_paths_for_rename_include_source_and_destination():
+    """Rename actions can affect both sides of the rename."""
+    change = RenameChange(old_path="old.txt", new_path="new.txt")
+
+    assert worktree_paths_for_selected_change(change) == ["old.txt", "new.txt"]
+
+
+def test_worktree_paths_for_wrapped_change_uses_path_method():
+    """Binary/gitlink/deletion wrappers expose their path through path()."""
+    change = BinaryFileChange(
+        old_path="image.png",
+        new_path="image.png",
+        change_type="modified",
+    )
+
+    assert worktree_paths_for_selected_change(change) == ["image.png"]

--- a/tests/utils/test_git_object_io.py
+++ b/tests/utils/test_git_object_io.py
@@ -4,8 +4,11 @@ import subprocess
 
 import pytest
 
+from git_stage_batch.data import undo_checkpoints
 from git_stage_batch.utils.git_command import run_git_command
+from git_stage_batch.utils.git_index import git_write_tree, temp_git_index
 from git_stage_batch.utils.git_object_io import (
+    create_git_blob,
     create_git_blobs_from_paths,
     read_git_blobs_as_bytes,
 )
@@ -82,3 +85,44 @@ def test_read_git_blobs_as_bytes_accepts_revision_paths(temp_git_repo):
     blobs = read_git_blobs_as_bytes([f"HEAD:{file_path.name}"])
 
     assert blobs[f"HEAD:{file_path.name}"] == b"accented\n"
+
+
+def test_directory_snapshot_hashes_normal_files_in_one_batch(
+    temp_git_repo,
+    monkeypatch,
+):
+    """Undo directory snapshots should not spawn one hash-object per file."""
+    source_dir = temp_git_repo / "session"
+    source_dir.mkdir()
+    files = [
+        source_dir / "one.txt",
+        source_dir / "nested" / "two.txt",
+        source_dir / "three.txt",
+    ]
+    files[1].parent.mkdir()
+    for file_path in files:
+        file_path.write_text(f"{file_path.name}\n")
+
+    blob_sha = create_git_blob([b"snapshot\n"])
+    calls = []
+
+    def fake_create_git_blobs_from_paths(paths):
+        paths = tuple(paths)
+        calls.append(paths)
+        return {path: blob_sha for path in paths}
+
+    monkeypatch.setattr(
+        undo_checkpoints,
+        "create_git_blobs_from_paths",
+        fake_create_git_blobs_from_paths,
+    )
+
+    with temp_git_index() as env:
+        undo_checkpoints._add_directory_to_index(
+            env,
+            source_dir=source_dir,
+            tree_prefix="session",
+        )
+        git_write_tree(env=env)
+
+    assert calls == [tuple(sorted(files))]


### PR DESCRIPTION
Undo checkpoints store session and batch state directories and can record
the worktree paths used for the before-image snapshot.

Checkpoint finalization still treats explicit path lists like one input to
a broader dirty-worktree scan. Commands that know their affected paths
cannot keep unrelated files out of checkpoint conflict checks.

This PR batches normal-file snapshot writes, preserves explicit checkpoint
path lists, and adds selected-change path helpers that report the worktree
scope for loaded selections.

The next PR will pass those scoped paths from selected, file-scoped, and
batch-state commands.
