### PR TITLE
commands: Use scoped undo checkpoints

### DIFF
--- a/src/git_stage_batch/commands/annotate.py
+++ b/src/git_stage_batch/commands/annotate.py
@@ -14,6 +14,6 @@ def command_annotate_batch(batch_name: str, note: str) -> None:
     """Add or update batch description."""
     require_git_repository()
     batch_name = require_plain_batch_name(batch_name, "annotate")
-    with undo_checkpoint(f"annotate {batch_name}"):
+    with undo_checkpoint(f"annotate {batch_name}", worktree_paths=[]):
         update_batch_note(batch_name, note)
     print(_("✓ Updated note for batch '{name}'").format(name=batch_name), file=sys.stderr)

--- a/src/git_stage_batch/commands/drop.py
+++ b/src/git_stage_batch/commands/drop.py
@@ -14,6 +14,6 @@ def command_drop_batch(batch_name: str) -> None:
     """Delete a batch."""
     require_git_repository()
     batch_name = require_plain_batch_name(batch_name, "drop")
-    with undo_checkpoint(f"drop {batch_name}"):
+    with undo_checkpoint(f"drop {batch_name}", worktree_paths=[]):
         delete_batch(batch_name)
     print(_("✓ Deleted batch '{name}'").format(name=batch_name), file=sys.stderr)

--- a/src/git_stage_batch/commands/file_scope/discard_file.py
+++ b/src/git_stage_batch/commands/file_scope/discard_file.py
@@ -66,7 +66,10 @@ def discard_file_changes(
         target_file = file
 
     auto_add_untracked_files([target_file])
-    with undo_checkpoint(f"discard --file {file}".rstrip()):
+    with undo_checkpoint(
+        f"discard --file {file}".rstrip(),
+        worktree_paths=[target_file],
+    ):
         blocklist_path = get_block_list_file_path()
         blocked_hashes = read_text_file_line_set(blocklist_path)
 

--- a/src/git_stage_batch/commands/file_scope/include_file.py
+++ b/src/git_stage_batch/commands/file_scope/include_file.py
@@ -61,7 +61,10 @@ def include_file_changes(
         target_file = file
 
     auto_add_untracked_files([target_file])
-    with undo_checkpoint(f"include --file {file}".rstrip()):
+    with undo_checkpoint(
+        f"include --file {file}".rstrip(),
+        worktree_paths=[target_file],
+    ):
         hunks_staged = 0
         submodule_pointers_staged = 0
         renames_staged = 0

--- a/src/git_stage_batch/commands/file_scope/skip_file.py
+++ b/src/git_stage_batch/commands/file_scope/skip_file.py
@@ -56,7 +56,10 @@ def skip_file_changes(
         target_file = file
 
     auto_add_untracked_files([target_file])
-    with undo_checkpoint(f"skip --file {file}".rstrip()):
+    with undo_checkpoint(
+        f"skip --file {file}".rstrip(),
+        worktree_paths=[target_file],
+    ):
         blocklist_path = get_block_list_file_path()
         blocked_hashes = read_text_file_line_set(blocklist_path)
 

--- a/src/git_stage_batch/commands/new.py
+++ b/src/git_stage_batch/commands/new.py
@@ -14,6 +14,6 @@ def command_new_batch(batch_name: str, note: str = "") -> None:
     """Create a new batch."""
     require_git_repository()
     batch_name = require_plain_batch_name(batch_name, "new")
-    with undo_checkpoint(f"new {batch_name}"):
+    with undo_checkpoint(f"new {batch_name}", worktree_paths=[]):
         create_batch(batch_name, note)
     print(_("✓ Created batch '{name}'").format(name=batch_name), file=sys.stderr)

--- a/src/git_stage_batch/commands/reset.py
+++ b/src/git_stage_batch/commands/reset.py
@@ -43,7 +43,7 @@ def command_reset_from_batch(
     file = selection.file
     effective_line_ids = selection.effective_line_ids
 
-    with undo_checkpoint(" ".join(selection.operation_parts)):
+    with undo_checkpoint(" ".join(selection.operation_parts), worktree_paths=[]):
         if to_batch is not None:
             _reset_claims.move_claims_between_batches(
                 batch_name,

--- a/src/git_stage_batch/commands/selection/selected_change_discarding.py
+++ b/src/git_stage_batch/commands/selection/selected_change_discarding.py
@@ -17,6 +17,7 @@ from ...core.models import (
 from ...data.hunk_tracking import fetch_next_change
 from ...data.progress import record_hunk_discarded
 from ...data.selected_change.loading import load_selected_change
+from ...data.selected_change.paths import worktree_paths_for_selected_change
 from ...data.session import snapshot_file_if_untracked, snapshot_files_if_untracked
 from ...data.undo_checkpoints import undo_checkpoint
 from ...exceptions import CommandError, NoMoreHunks, exit_with_error
@@ -67,7 +68,10 @@ def discard_selected_change(
                 print(_("No more hunks to process."), file=sys.stderr)
             return
 
-    with undo_checkpoint("discard"):
+    with undo_checkpoint(
+        "discard",
+        worktree_paths=worktree_paths_for_selected_change(item),
+    ):
         _discard_loaded_selected_change(
             item,
             quiet=quiet,

--- a/src/git_stage_batch/commands/selection/selected_change_skipping.py
+++ b/src/git_stage_batch/commands/selection/selected_change_skipping.py
@@ -19,6 +19,7 @@ from ...data.progress import (
     record_text_deletion_hunk_skipped,
 )
 from ...data.selected_change.loading import load_selected_change
+from ...data.selected_change.paths import worktree_paths_for_selected_change
 from ...data.undo_checkpoints import undo_checkpoint
 from ...exceptions import NoMoreHunks
 from ...i18n import _
@@ -45,7 +46,10 @@ def skip_selected_change(
                 print(_("No more hunks to process."), file=sys.stderr)
             return
 
-    with undo_checkpoint("skip"):
+    with undo_checkpoint(
+        "skip",
+        worktree_paths=worktree_paths_for_selected_change(item),
+    ):
         _skip_loaded_selected_change(
             item,
             quiet=quiet,

--- a/src/git_stage_batch/commands/selection/selected_change_staging.py
+++ b/src/git_stage_batch/commands/selection/selected_change_staging.py
@@ -17,6 +17,7 @@ from ...data.hunk_tracking import fetch_next_change
 from ...data.index_entries import read_index_entry
 from ...data.progress import record_hunk_included
 from ...data.selected_change.loading import load_selected_change
+from ...data.selected_change.paths import worktree_paths_for_selected_change
 from ...data.undo_checkpoints import undo_checkpoint
 from ...exceptions import NoMoreHunks, exit_with_error
 from ...i18n import _
@@ -52,7 +53,10 @@ def include_selected_change(
                 print(_("No more hunks to process."), file=sys.stderr)
             return 0
 
-    with undo_checkpoint("include"):
+    with undo_checkpoint(
+        "include",
+        worktree_paths=worktree_paths_for_selected_change(item),
+    ):
         return _include_loaded_selected_change(
             item,
             quiet=quiet,

--- a/tests/commands/test_block_file.py
+++ b/tests/commands/test_block_file.py
@@ -214,6 +214,40 @@ class TestCommandBlockFile:
         blocked = read_file_paths_file(get_blocked_files_file_path())
         assert "local.txt" in blocked
 
+    def test_block_file_local_only_uses_empty_worktree_checkpoint_scope(
+        self,
+        temp_git_repo,
+        monkeypatch,
+    ):
+        """Local excludes should not checkpoint unrelated dirty worktree paths."""
+        import git_stage_batch.commands.block_file as block_file
+
+        calls = []
+
+        class Checkpoint:
+            def __enter__(self):
+                return None
+
+            def __exit__(self, exc_type, exc, traceback):
+                return False
+
+        def fake_undo_checkpoint(operation, *, worktree_paths=None):
+            calls.append((operation, worktree_paths))
+            return Checkpoint()
+
+        (temp_git_repo / "local.txt").write_text("local content\n")
+        monkeypatch.setattr(block_file, "session_is_active", lambda: True)
+        monkeypatch.setattr(block_file, "undo_checkpoint", fake_undo_checkpoint)
+        monkeypatch.setattr(
+            block_file,
+            "advance_to_and_show_next_change",
+            lambda: None,
+        )
+
+        command_block_file("local.txt", local_only=True)
+
+        assert calls == [("block-file local.txt", [])]
+
     def test_block_file_local_only_no_duplicates_in_exclude(self, temp_git_repo):
         """Test that --local-only blocking the same file twice doesn't duplicate entries."""
         (temp_git_repo / "dup.txt").write_text("content\n")


### PR DESCRIPTION
Selected-change, file-scoped, and batch-state commands create undo
checkpoints before mutating state or restoring worktree paths.

Those commands now have checkpoint APIs that can represent an explicit
worktree scope, but the command layer still records broad checkpoints for
operations whose affected paths are already known.

This PR passes selected-change paths, file arguments, and empty worktree
path lists into the relevant command checkpoints, then covers the
local-only block-file checkpoint path.

Command checkpoint adoption is complete for the paths touched in the
stack.
