### PR TITLE
patterns: Avoid candidate file materialization

### DIFF
--- a/src/git_stage_batch/utils/file_patterns.py
+++ b/src/git_stage_batch/utils/file_patterns.py
@@ -28,17 +28,6 @@ def _validate_patterns(patterns: Iterable[str]) -> list[str]:
     return normalized_patterns
 
 
-def _materialize_candidates(root: Path, candidates: list[str]) -> None:
-    """Create candidate paths in a temporary repository for Git-backed matching."""
-    for candidate in candidates:
-        candidate_path = root / candidate
-        if candidate.endswith("/"):
-            candidate_path.mkdir(parents=True, exist_ok=True)
-            continue
-        candidate_path.parent.mkdir(parents=True, exist_ok=True)
-        candidate_path.touch(exist_ok=True)
-
-
 def resolve_gitignore_style_patterns(
     candidates: Iterable[str],
     patterns: Iterable[str],
@@ -63,7 +52,6 @@ def resolve_gitignore_style_patterns(
             requires_index_lock=False,
         )
         write_text_file_contents(temp_root / ".gitignore", "".join(f"{pattern}\n" for pattern in normalized_patterns))
-        _materialize_candidates(temp_root, normalized_candidates)
 
         payload = b"".join(candidate.encode("utf-8") + b"\0" for candidate in normalized_candidates)
         result = run_git_command(

--- a/tests/utils/test_file_patterns.py
+++ b/tests/utils/test_file_patterns.py
@@ -1,6 +1,7 @@
 """Tests for gitignore-style file pattern resolution."""
 
 import subprocess
+from pathlib import Path
 
 from git_stage_batch.utils.file_patterns import list_changed_files, resolve_gitignore_style_patterns
 
@@ -103,6 +104,21 @@ def test_resolve_gitignore_style_patterns_returns_empty_list_for_no_matches():
     )
 
     assert resolved == []
+
+
+def test_resolve_gitignore_style_patterns_does_not_materialize_candidate_files(monkeypatch):
+    """Git can match candidate pathnames without creating files in the temp repo."""
+    def fail_touch(self, *args, **kwargs):
+        raise AssertionError(f"unexpected candidate materialization: {self}")
+
+    monkeypatch.setattr(Path, "touch", fail_touch)
+
+    resolved = resolve_gitignore_style_patterns(
+        ["docs/guide.md", "build/output.o"],
+        ["docs/**"],
+    )
+
+    assert resolved == ["docs/guide.md"]
 
 
 def test_list_changed_files_reports_rename_delete_and_add(tmp_path, monkeypatch):


### PR DESCRIPTION
Gitignore-style pattern resolution delegates matching to git check-ignore
in a temporary repository and sends candidate pathnames through stdin.

The matcher also creates every candidate path in that temporary repository
before asking Git to match names. That filesystem setup is unnecessary for
--no-index pathname matching and adds work for large candidate sets.

This PR removes candidate path creation, lets git check-ignore match the
supplied names directly, and covers the path-only behavior by making
Path.touch fail in the test.

The file-pattern materialization change is covered within this PR.
