### PR TITLE
storage: Publish replacement state atomically

### DIFF
--- a/STORAGE.md
+++ b/STORAGE.md
@@ -634,6 +634,12 @@ Session files are scratch state. They are allowed to be direct files because:
 Undo support can checkpoint these files without making the live state itself a
 Git ref.
 
+Replacement-style session files are written to a same-directory temporary file
+and published with an atomic rename. Readers therefore see either the previous
+complete value or the next complete value, not a partially overwritten JSON or
+text file. Append-only journal and progress records retain their streaming
+format rather than using replacement writes.
+
 ---
 
 ## Abort and Recovery State

--- a/src/git_stage_batch/batch/operation_candidate_state.py
+++ b/src/git_stage_batch/batch/operation_candidate_state.py
@@ -7,6 +7,7 @@ import json
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
+from ..utils.file_io import write_text_file_contents
 from ..utils.paths import get_batch_candidate_state_file_path
 from .operation_candidate_fingerprints import ALGORITHM_VERSION
 
@@ -40,7 +41,7 @@ def _load_state() -> dict:
 
 def _save_state(data: dict) -> None:
     path = get_batch_candidate_state_file_path()
-    path.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
+    write_text_file_contents(path, json.dumps(data, indent=2, sort_keys=True))
 
 
 def clear_candidate_preview_state_for_file(*, batch_name: str, file_path: str) -> None:

--- a/src/git_stage_batch/utils/file_io.py
+++ b/src/git_stage_batch/utils/file_io.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+import tempfile
 from collections.abc import Collection
 from pathlib import Path
 from typing import Iterable
@@ -20,14 +22,16 @@ def read_text_file_contents(path: Path) -> str:
 
 
 def write_text_file_contents(path: Path, data: str) -> None:
-    """Write text to a file, creating parent directories as needed.
+    """Atomically write text, creating parent directories as needed.
 
     Args:
         path: Path to the file to write
         data: Text content to write
     """
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(data, encoding="utf-8", errors="surrogateescape")
+    _write_file_contents_atomically(
+        path,
+        data.encode("utf-8", errors="surrogateescape"),
+    )
 
 
 def stream_text_file_lines(path: Path) -> Iterable[str]:
@@ -57,9 +61,27 @@ def count_nonblank_text_file_lines(path: Path) -> int:
 
 
 def write_file_bytes(path: Path, data: bytes) -> None:
-    """Write raw bytes to a file, creating parent directories as needed."""
+    """Atomically write raw bytes, creating parent directories as needed."""
+    _write_file_contents_atomically(path, data)
+
+
+def _write_file_contents_atomically(path: Path, data: bytes) -> None:
+    """Replace one state file without exposing partial contents."""
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_bytes(data)
+    file_descriptor, temporary_name = tempfile.mkstemp(
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(file_descriptor, "wb") as file_handle:
+            file_handle.write(data)
+            file_handle.flush()
+            os.fsync(file_handle.fileno())
+        os.replace(temporary_path, path)
+    finally:
+        temporary_path.unlink(missing_ok=True)
 
 
 def path_is_empty(path: Path) -> bool:

--- a/tests/utils/test_file_io.py
+++ b/tests/utils/test_file_io.py
@@ -1,7 +1,10 @@
 """Tests for file I/O utilities."""
 
+import os
 
+import pytest
 
+import git_stage_batch.utils.file_io as file_io
 from git_stage_batch.utils.file_io import read_file_paths_file
 from git_stage_batch.utils.file_io import write_file_paths_file
 from git_stage_batch.utils.file_io import append_file_path_to_file
@@ -91,6 +94,27 @@ class TestWriteTextFileContents:
 
         assert test_file.exists()
         assert test_file.read_text(encoding="utf-8") == ""
+
+    def test_failed_atomic_replace_preserves_existing_contents(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        """A failed replacement should leave the previous state file intact."""
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("Old content", encoding="utf-8")
+
+        def fail_replace(source, destination):
+            assert destination == test_file
+            raise OSError("replace failed")
+
+        monkeypatch.setattr(os, "replace", fail_replace)
+
+        with pytest.raises(OSError, match="replace failed"):
+            file_io.write_text_file_contents(test_file, "New content")
+
+        assert test_file.read_text(encoding="utf-8") == "Old content"
+        assert list(tmp_path.glob(".test.txt.*.tmp")) == []
 
 
 class TestAppendLinesToFile:


### PR DESCRIPTION
Session metadata and candidate decisions use replacement-style files that
readers treat as complete state.

A direct write can expose truncated contents during process failure or a
concurrent read. That can turn recoverable interruption into malformed
session state.

This PR addresses that risk by publishing replacement data through a
synced temporary file and atomic rename. It adds failure coverage, documents
the storage guarantee, and moves candidate persistence onto the shared
helper.

Replacement-style session data and candidate state now retain the previous
complete value until the new value is fully published.
