### PR TITLE
start: Require recoverable session startup

### DIFF
--- a/STORAGE.md
+++ b/STORAGE.md
@@ -671,6 +671,11 @@ reset target:
 git reset --hard <head>
 ```
 
+This file is also the active-session marker. Startup writes it only after the
+stash, untracked-file metadata, intent-to-add restoration, and batch-ref
+snapshot have completed. Failure to create any required recovery state aborts
+startup and removes the incomplete session state.
+
 ### `stash.txt`
 
 Stores the commit SHA returned by:
@@ -682,6 +687,9 @@ git stash create
 The stash commit captures tracked worktree and index changes at session start.
 Abort applies it with `--index` to restore both staged and unstaged tracked
 state.
+
+If `git stash create` fails, the session is not started. Continuing without
+this recovery object would make a later hard reset destructive.
 
 ### `untracked-paths.txt` and `untracked/`
 

--- a/src/git_stage_batch/commands/abort.py
+++ b/src/git_stage_batch/commands/abort.py
@@ -57,7 +57,7 @@ def _remove_normalized_rename_destinations_before_stash_apply() -> None:
             target_path.unlink(missing_ok=True)
 
 
-def command_abort() -> None:
+def command_abort(*, quiet: bool = False) -> None:
     """Abort the session and undo all changes including commits and discards."""
     require_git_repository()
 
@@ -81,16 +81,19 @@ def command_abort() -> None:
     env = os.environ.copy()
     env["GIT_REFLOG_ACTION"] = "stage-batch abort"
 
-    print(_("Resetting to {}...").format(abort_head[:7]), file=sys.stderr)
+    if not quiet:
+        print(_("Resetting to {}...").format(abort_head[:7]), file=sys.stderr)
     git_reset_hard(abort_head, env=env)
     _remove_normalized_rename_destinations_before_stash_apply()
 
     # Apply original stash if it exists (with --index to restore staged state)
     if abort_stash:
-        print(_("Applying original changes..."), file=sys.stderr)
+        if not quiet:
+            print(_("Applying original changes..."), file=sys.stderr)
         result = git_apply_stash(abort_stash, restore_index=True, env=env, check=False)
         if result.returncode != 0:
-            print(_("⚠ Warning: Could not apply stash cleanly: {}").format(result.stderr), file=sys.stderr)
+            if not quiet:
+                print(_("⚠ Warning: Could not apply stash cleanly: {}").format(result.stderr), file=sys.stderr)
 
     # Restore snapshotted untracked files
     snapshot_list_path = get_abort_snapshot_list_file_path()
@@ -105,7 +108,8 @@ def command_abort() -> None:
                 target_path = repo_root / file_path
                 target_path.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copy2(snapshot_path, target_path)
-                print(_("Restored: {}").format(file_path), file=sys.stderr)
+                if not quiet:
+                    print(_("Restored: {}").format(file_path), file=sys.stderr)
 
     # Restore intent-to-add status for files that had it before session
     intent_to_add_path = get_abort_state_directory_path() / "intent-to-add-files.txt"
@@ -123,4 +127,5 @@ def command_abort() -> None:
     # Do this AFTER restore_batch_refs so snapshot file is available
     clear_session_state()
 
-    print(_("✓ Session aborted. All changes reverted."), file=sys.stderr)
+    if not quiet:
+        print(_("✓ Session aborted. All changes reverted."), file=sys.stderr)

--- a/src/git_stage_batch/commands/start.py
+++ b/src/git_stage_batch/commands/start.py
@@ -52,32 +52,36 @@ def command_start(
     # Initialize abort state for new session
     initialize_abort_state()
 
-    # Staged renames and text deletions are already in the index, so a plain
-    # worktree-vs-index pass would otherwise never offer them as workflow
-    # choices. Preserve the exact start state in abort metadata first, then
-    # expose those staged entries as unstaged choices for this session.
-    normalize_start_time_staged_renames()
-    normalize_start_time_staged_deletions()
-
-    write_auto_advance_default(
-        DEFAULT_AUTO_ADVANCE
-        if auto_advance is None else
-        auto_advance
-    )
-
-    # Save context lines setting if provided
-    if context_lines is not None:
-        write_text_file_contents(get_context_lines_file_path(), str(context_lines))
-
-    # Make untracked files visible to git diff so they can be staged, blocked by .gitignore, or deleted
-    auto_add_untracked_files()
-
-    # Find and cache first hunk
     try:
-        fetch_next_change()
-    except NoMoreHunks:
-        raise CommandError(_("No changes to process."), exit_code=2)
+        # Staged renames and text deletions are already in the index, so a plain
+        # worktree-vs-index pass would otherwise never offer them as workflow
+        # choices. Preserve the exact start state in abort metadata first, then
+        # expose those staged entries as unstaged choices for this session.
+        normalize_start_time_staged_renames()
+        normalize_start_time_staged_deletions()
 
-    # Display the first hunk
-    if not quiet:
-        show_selected_change()
+        write_auto_advance_default(
+            DEFAULT_AUTO_ADVANCE
+            if auto_advance is None else
+            auto_advance
+        )
+
+        if context_lines is not None:
+            write_text_file_contents(get_context_lines_file_path(), str(context_lines))
+
+        # Make untracked files visible to git diff so they can be staged,
+        # blocked by .gitignore, or deleted.
+        auto_add_untracked_files()
+
+        try:
+            fetch_next_change()
+        except NoMoreHunks:
+            raise CommandError(_("No changes to process."), exit_code=2)
+
+        if not quiet:
+            show_selected_change()
+    except BaseException:
+        from .abort import command_abort
+
+        command_abort(quiet=True)
+        raise

--- a/src/git_stage_batch/data/session.py
+++ b/src/git_stage_batch/data/session.py
@@ -114,52 +114,108 @@ def _snapshot_intent_to_add_files() -> tuple[list[str], list[str]]:
 
 
 def initialize_abort_state() -> None:
-    """Save selected HEAD and stash for abort functionality."""
-    # Save selected HEAD
+    """Save the recovery state required before publishing an active session."""
+    try:
+        _initialize_abort_state()
+    except BaseException:
+        clear_session_state()
+        raise
+
+
+def _initialize_abort_state() -> None:
+    """Build abort state, writing the active-session marker last."""
     head_result = run_git_command(["rev-parse", "HEAD"], requires_index_lock=False)
-    write_text_file_contents(get_abort_head_file_path(), head_result.stdout.strip())
+    abort_head = head_result.stdout.strip()
 
     # Snapshot all intent-to-add files upfront
     # These files won't survive git reset --hard but aren't in the stash
     # We need to snapshot them now so they can be restored on abort
     all_intent_to_add_files, new_intent_to_add_files = _snapshot_intent_to_add_files()
+    tracked_intent_to_add_files = sorted(
+        set(all_intent_to_add_files) - set(new_intent_to_add_files)
+    )
 
-    # Temporarily remove new intent-to-add files from index so git stash create can succeed.
-    # Intent-to-add files with content in working tree cause "not uptodate" errors
-    # Only remove files absent from HEAD. Removing tracked files stages deletions.
-    if new_intent_to_add_files:
-        log_journal("session_removing_intent_to_add_files_for_stash", files=new_intent_to_add_files)
-        git_remove_paths(new_intent_to_add_files, cached=True, quiet=True, check=False)
+    try:
+        # Normalize intent-to-add entries so stash creation sees valid index state.
+        if new_intent_to_add_files:
+            log_journal(
+                "session_removing_intent_to_add_files_for_stash",
+                files=new_intent_to_add_files,
+            )
+            git_remove_paths(
+                new_intent_to_add_files,
+                cached=True,
+                quiet=True,
+                check=False,
+            )
+        if tracked_intent_to_add_files:
+            log_journal(
+                "session_normalizing_tracked_intent_to_add_files_for_stash",
+                files=tracked_intent_to_add_files,
+            )
+            run_git_command(
+                ["reset", "-q", "HEAD", "--", *tracked_intent_to_add_files],
+                requires_index_lock=True,
+            )
 
-    # Create stash of tracked file changes
-    # git stash create (without -u) only captures changes to tracked files
-    # Untracked files that we modify will be handled by lazy snapshots
-    log_journal("session_creating_stash")
-    stash_result = run_git_command(["stash", "create"], check=False, requires_index_lock=False)
-    if stash_result.returncode == 0 and stash_result.stdout.strip():
-        write_text_file_contents(get_abort_stash_file_path(), stash_result.stdout.strip())
+        # The stash covers tracked worktree and index changes. Untracked files
+        # that the session may modify are handled by lazy snapshots.
+        log_journal("session_creating_stash")
+        stash_result = run_git_command(
+            ["stash", "create"],
+            check=False,
+            requires_index_lock=False,
+        )
+    finally:
+        # Restore all intent-to-add entries even when snapshot creation fails.
+        if all_intent_to_add_files:
+            log_journal(
+                "session_re_adding_intent_to_add_files",
+                files=all_intent_to_add_files,
+            )
+            git_remove_paths(
+                all_intent_to_add_files,
+                cached=True,
+                quiet=True,
+                check=False,
+            )
+            for file_path in all_intent_to_add_files:
+                ls_before = run_git_command(
+                    ["ls-files", "--stage", "--", file_path],
+                    check=False,
+                    requires_index_lock=False,
+                ).stdout.strip()
+                git_add_paths([file_path], intent_to_add=True, check=False)
+                ls_after = run_git_command(
+                    ["ls-files", "--stage", "--", file_path],
+                    check=False,
+                    requires_index_lock=False,
+                ).stdout.strip()
+                log_journal(
+                    "session_re_add_intent_to_add",
+                    file_path=file_path,
+                    index_before=ls_before,
+                    index_after=ls_after,
+                )
+
+    if stash_result.returncode != 0:
+        log_journal(
+            "session_stash_failed",
+            returncode=stash_result.returncode,
+            stderr=stash_result.stderr,
+        )
+        raise CommandError(
+            _("Could not create the recovery snapshot required to start a session: {error}").format(
+                error=stash_result.stderr.strip() or _("git stash create failed")
+            )
+        )
+
+    write_text_file_contents(get_abort_stash_file_path(), stash_result.stdout.strip())
+    if stash_result.stdout.strip():
         log_journal("session_stash_created", stash_hash=stash_result.stdout.strip())
-    else:
-        log_journal("session_stash_failed", returncode=stash_result.returncode, stderr=stash_result.stderr)
-
-    # Re-add NEW intent-to-add files to index (the ones we removed)
-    if new_intent_to_add_files:
-        log_journal("session_re_adding_intent_to_add_files", files=new_intent_to_add_files)
-        for file_path in new_intent_to_add_files:
-            ls_before = run_git_command(
-                ["ls-files", "--stage", "--", file_path],
-                check=False,
-                requires_index_lock=False,
-            ).stdout.strip()
-            git_add_paths([file_path], intent_to_add=True, check=False)
-            ls_after = run_git_command(
-                ["ls-files", "--stage", "--", file_path],
-                check=False,
-                requires_index_lock=False,
-            ).stdout.strip()
-            log_journal("session_re_add_intent_to_add", file_path=file_path, index_before=ls_before, index_after=ls_after)
 
     snapshot_batch_refs()
+    write_text_file_contents(get_abort_head_file_path(), abort_head)
 
 
 def require_session_started() -> None:

--- a/tests/commands/test_start.py
+++ b/tests/commands/test_start.py
@@ -85,6 +85,20 @@ class TestCommandStart:
         abort_stash_path = get_abort_stash_file_path()
         assert abort_stash_path.exists()
 
+    def test_start_without_changes_rolls_back_session(self, temp_git_repo):
+        """A rejected start should not leave an active empty session."""
+        with pytest.raises(CommandError, match="No changes to process"):
+            command_start()
+
+        assert not session_is_active()
+        assert subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=temp_git_repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout == ""
+
     def test_start_refuses_failed_recovery_snapshot(self, temp_git_repo):
         """Startup should fail closed when Git cannot create the abort stash."""
         readme = temp_git_repo / "README.md"

--- a/tests/commands/test_start.py
+++ b/tests/commands/test_start.py
@@ -1,10 +1,13 @@
 """Tests for start command."""
 
 import subprocess
+from unittest.mock import patch
 
 import pytest
 
 from git_stage_batch.commands.start import command_start
+from git_stage_batch.data.session import session_is_active
+from git_stage_batch.exceptions import CommandError
 from git_stage_batch.utils.file_io import read_text_file_contents
 from git_stage_batch.utils.paths import (
     get_abort_head_file_path,
@@ -81,3 +84,29 @@ class TestCommandStart:
         # Verify abort-stash file was created (may be empty if no tracked changes)
         abort_stash_path = get_abort_stash_file_path()
         assert abort_stash_path.exists()
+
+    def test_start_refuses_failed_recovery_snapshot(self, temp_git_repo):
+        """Startup should fail closed when Git cannot create the abort stash."""
+        readme = temp_git_repo / "README.md"
+        readme.write_text("# Test\nModified\n")
+
+        from git_stage_batch.data import session as session_module
+
+        real_run_git_command = session_module.run_git_command
+
+        def fail_stash(command, *args, **kwargs):
+            if command == ["stash", "create"]:
+                return subprocess.CompletedProcess(
+                    command,
+                    1,
+                    stdout="",
+                    stderr="snapshot failed",
+                )
+            return real_run_git_command(command, *args, **kwargs)
+
+        with patch.object(session_module, "run_git_command", side_effect=fail_stash):
+            with pytest.raises(CommandError, match="snapshot failed"):
+                command_start()
+
+        assert not session_is_active()
+        assert readme.read_text() == "# Test\nModified\n"


### PR DESCRIPTION
Replacement-style state now publishes atomically, and session startup records
the repository state needed by abort.

A failed stash or a later startup rejection can leave an active marker,
normalized index entries, or partial recovery data behind. Users can then
enter a session that cannot safely restore its starting state.

This PR addresses that failure mode by requiring a complete recovery snapshot
before publishing the active marker and by invoking quiet rollback for later
startup failures. Focused tests cover both rejection stages, and the storage
reference records the marker-last contract.

This PR is stacked on #155 because recovery publication relies on the atomic
replacement guarantee introduced there.
