### PR TITLE
status: Keep prompt rendering observational

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -313,6 +313,9 @@ When no session is active, `--for-prompt` prints nothing, so any spacing or
 brackets included in `FORMAT` are hidden too. Without `FORMAT`, it prints
 `STAGING`. In prompt output, `{status}` is the operation name `STAGING`;
 `{progress_status}` exposes the underlying `in_progress` or `complete` state.
+Prompt rendering is lock-free and read-only so shell startup never waits for an
+in-progress staging operation. A prompt may briefly reflect either side of a
+concurrent update, but it does not modify or clean up session state.
 Format fields include `{status}`, `{status_label}`, `{progress_status}`,
 `{progress_label}`, `{iteration}`, `{processed}`, `{total}`, `{included}`,
 `{skipped}`, `{discarded}`, `{remaining}`, `{selected_file}`,

--- a/src/git_stage_batch/data/batch_selected_changes.py
+++ b/src/git_stage_batch/data/batch_selected_changes.py
@@ -112,15 +112,19 @@ def selected_batch_binary_file_for_batch(
     return file_path
 
 
-def load_current_selected_batch_binary_file() -> BinaryFileChange | None:
-    """Return the selected batch binary, clearing it if stale."""
+def load_current_selected_batch_binary_file(
+    *,
+    clear_stale: bool = True,
+) -> BinaryFileChange | None:
+    """Return the selected batch binary, optionally clearing stale state."""
     binary_file = load_selected_binary_file()
     if binary_file is None:
         return None
 
     batch_name = selected_batch_binary_batch_name()
     if batch_name is None:
-        clear_selected_change_state_files()
+        if clear_stale:
+            clear_selected_change_state_files()
         return None
 
     file_path = binary_file.path()
@@ -128,11 +132,12 @@ def load_current_selected_batch_binary_file() -> BinaryFileChange | None:
     if selected_batch_binary_file_for_batch(batch_name, metadata.get("files", {})):
         return binary_file
 
-    clear_selected_change_state_files()
-    mark_selected_change_cleared_by_stale_batch_selection(
-        batch_name=batch_name,
-        file_path=file_path,
-    )
+    if clear_stale:
+        clear_selected_change_state_files()
+        mark_selected_change_cleared_by_stale_batch_selection(
+            batch_name=batch_name,
+            file_path=file_path,
+        )
     return None
 
 

--- a/src/git_stage_batch/data/file_review/state.py
+++ b/src/git_stage_batch/data/file_review/state.py
@@ -20,8 +20,11 @@ def write_last_file_review_state(review_state: _records.FileReviewState) -> None
     )
 
 
-def read_last_file_review_state() -> _records.FileReviewState | None:
-    """Read the last file review state, if present and valid."""
+def read_last_file_review_state(
+    *,
+    clear_invalid: bool = True,
+) -> _records.FileReviewState | None:
+    """Read the last file review state, optionally clearing invalid state."""
     path = get_last_file_review_state_file_path()
     if not path.exists():
         return None
@@ -57,7 +60,8 @@ def read_last_file_review_state() -> _records.FileReviewState | None:
             diff_fingerprint=data["diff_fingerprint"],
         )
     except (KeyError, TypeError, ValueError, json.JSONDecodeError):
-        clear_last_file_review_state()
+        if clear_invalid:
+            clear_last_file_review_state()
         return None
 
 

--- a/src/git_stage_batch/data/status_summary.py
+++ b/src/git_stage_batch/data/status_summary.py
@@ -19,16 +19,12 @@ from .file_review.selection_validation import shown_review_selections_for_action
 from .file_review.state import read_last_file_review_state
 from .line_state import load_line_changes_from_state
 from .remaining_hunks import estimate_remaining_hunks as _estimate_remaining_hunks
-from .selected_change.clear_reasons import (
-    mark_selected_change_cleared_by_stale_batch_selection,
-)
 from .selected_change.file_changes import (
     load_selected_binary_file,
     load_selected_gitlink_change,
     load_selected_rename_change,
     load_selected_text_deletion_change,
 )
-from .selected_change.lifecycle import clear_selected_change_state_files
 from .selected_change.snapshots import snapshots_are_stale
 from .selected_change.store import (
     SelectedChangeKind,
@@ -107,7 +103,7 @@ def _selected_change_is_stale(
 
 def _read_batch_review_display_ids(file_path: str) -> list[int]:
     """Return user-visible gutter IDs for the current batch file review."""
-    review_state = read_last_file_review_state()
+    review_state = read_last_file_review_state(clear_invalid=False)
     if review_state is None:
         return []
     if review_state.source != ReviewSource.BATCH or review_state.file_path != file_path:
@@ -134,7 +130,7 @@ def _read_live_review_display_ids(file_path: str) -> list[int] | None:
     None means no matching live review exists; an empty list can also mean a
     matching review exists but is no longer fresh.
     """
-    review_state = read_last_file_review_state()
+    review_state = read_last_file_review_state(clear_invalid=False)
     if review_state is None:
         return None
     if review_state.source != ReviewSource.FILE_VS_HEAD or review_state.file_path != file_path:
@@ -208,7 +204,7 @@ def _read_selected_change_summary() -> tuple[bool, dict | None]:
 
     if selected_kind in (SelectedChangeKind.BINARY, SelectedChangeKind.BATCH_BINARY):
         binary_file = (
-            load_current_selected_batch_binary_file()
+            load_current_selected_batch_binary_file(clear_stale=False)
             if selected_kind == SelectedChangeKind.BATCH_BINARY
             else load_selected_binary_file()
         )
@@ -238,28 +234,12 @@ def _read_selected_change_summary() -> tuple[bool, dict | None]:
         if line_changes is None:
             return False, None
         if selected_kind == SelectedChangeKind.BATCH_FILE:
-            review_state = read_last_file_review_state()
+            review_state = read_last_file_review_state(clear_invalid=False)
             if review_state is not None:
                 try:
                     if not selected_change_matches_review_state(review_state):
-                        if (
-                            review_state.source == ReviewSource.BATCH
-                            and review_state.batch_name is not None
-                        ):
-                            mark_batch_name = review_state.batch_name
-                            mark_file_path = review_state.file_path
-                        else:
-                            mark_batch_name = None
-                            mark_file_path = None
-                        clear_selected_change_state_files()
-                        if mark_batch_name is not None and mark_file_path is not None:
-                            mark_selected_change_cleared_by_stale_batch_selection(
-                                batch_name=mark_batch_name,
-                                file_path=mark_file_path,
-                            )
                         return False, None
                 except Exception:
-                    clear_selected_change_state_files()
                     return False, None
         if _selected_change_is_stale(selected_kind, line_changes.path):
             return False, None
@@ -287,7 +267,7 @@ def _read_selected_change_summary() -> tuple[bool, dict | None]:
 
 
 def _read_file_review_summary() -> dict | None:
-    review_state = read_last_file_review_state()
+    review_state = read_last_file_review_state(clear_invalid=False)
     if review_state is None:
         return None
     try:

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -90,6 +90,36 @@ def test_main_skips_session_lock_for_prompt_status():
     assert events == [("dispatch", "STAGING")]
 
 
+def test_main_skips_session_lock_for_rich_prompt_status():
+    """Prompt summaries should remain nonblocking even when they read state."""
+    events = []
+
+    def fake_dispatch(args):
+        events.append(("dispatch", args.prompt_format))
+
+    args = Namespace(
+        working_directory=None,
+        prompt_format="{processed}/{total}",
+    )
+
+    with patch.object(sys, "argv", ["git-stage-batch", "status", "--for-prompt"]):
+        with patch.object(main_module, "parse_command_line", return_value=args):
+            with patch.object(main_module, "should_page_output", return_value=False):
+                with patch.object(
+                    main_module,
+                    "acquire_session_lock",
+                    side_effect=AssertionError("prompt status must not lock"),
+                ):
+                    with patch.object(
+                        main_module,
+                        "dispatch_cli_mode",
+                        side_effect=fake_dispatch,
+                    ):
+                        main_module.main()
+
+    assert events == [("dispatch", "{processed}/{total}")]
+
+
 def test_main_handles_keyboard_interrupt_without_traceback(capsys):
     """Ctrl-C should exit cleanly without Python's KeyboardInterrupt traceback."""
     args = Namespace(working_directory=None)

--- a/tests/commands/test_status.py
+++ b/tests/commands/test_status.py
@@ -661,8 +661,8 @@ class TestCommandStatus:
         assert output["selected_change"]["file"] == "asset.bin"
         assert output["selected_change"]["change_type"] == "deleted"
 
-    def test_status_drops_stale_batch_binary_selection(self, temp_git_repo, capsys):
-        """A cached batch-binary selection should not survive changed batch bytes."""
+    def test_status_hides_stale_batch_binary_without_clearing_it(self, temp_git_repo, capsys):
+        """Status should report stale batch binary state without mutating it."""
         binary_file = temp_git_repo / "asset.bin"
         binary_file.write_bytes(b"\x00\x01\x02")
         subprocess.run(["git", "add", "asset.bin"], check=True, cwd=temp_git_repo, capture_output=True)
@@ -688,4 +688,4 @@ class TestCommandStatus:
 
         output = json.loads(capsys.readouterr().out)
         assert output["selected_change"] is None
-        assert read_selected_change_kind() is None
+        assert read_selected_change_kind() == SelectedChangeKind.BATCH_BINARY


### PR DESCRIPTION
Prompt status renders shell-facing summaries without acquiring the session
lock.

Some summary lookups currently clear stale binary or file-review selections
as part of validation. A concurrent prompt read can therefore mutate state
owned by an active staging operation.

This PR addresses that race by adding non-mutating lookup modes and using
them throughout status summary rendering. Focused tests cover stale
selection retention and rich lock-free prompts, while the command reference
documents the observational behavior.

Prompt integrations can now read progress without taking the session lock
or cleaning persisted selections.
