### PR TITLE
undo: Reject incomplete checkpoints by default

### DIFF
--- a/STORAGE.md
+++ b/STORAGE.md
@@ -1106,6 +1106,10 @@ The `after` object is recorded after the mutating command completes. Undo uses
 it for conflict detection: if the current index tree, batch refs, or tracked
 worktree path bytes differ from `after`, undo refuses by default.
 
+If a process exits after publishing the before-image but before recording
+`after`, the checkpoint is incomplete. Undo treats that missing post-state as a
+conflict and refuses unless the user explicitly supplies `--force`.
+
 ### Session and Metadata Before-Images
 
 Undo snapshots these filesystem trees:
@@ -1188,6 +1192,7 @@ recorded `after` state before restoring anything:
 * If the index tree changed, undo refuses.
 * If batch refs changed, undo refuses.
 * If a tracked worktree path changed, undo refuses.
+* If the checkpoint has no finalized `after` state, undo refuses.
 
 The user can bypass this guard with:
 

--- a/src/git_stage_batch/data/undo_checkpoints.py
+++ b/src/git_stage_batch/data/undo_checkpoints.py
@@ -257,7 +257,7 @@ def _detect_conflicts_against_state(expected_state: dict[str, Any]) -> list[str]
 def _detect_conflicts(manifest: dict[str, Any]) -> list[str]:
     after = manifest.get("after")
     if not isinstance(after, dict):
-        return []
+        return [_('incomplete checkpoint')]
     return _detect_conflicts_against_state(after)
 
 

--- a/tests/commands/test_undo.py
+++ b/tests/commands/test_undo.py
@@ -9,6 +9,7 @@ from git_stage_batch.commands.include import command_include_line
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.commands.undo import command_undo
 from git_stage_batch.data.undo_checkpoints import undo_checkpoint, undo_last_checkpoint
+from git_stage_batch.exceptions import CommandError
 from git_stage_batch.utils.paths import get_session_directory_path
 
 
@@ -109,3 +110,23 @@ def test_scoped_undo_ignores_unrelated_untracked_worktree_edits(temp_git_repo):
 
     assert target.read_text() == "before\n"
     assert unrelated.read_text() == "second\n"
+
+
+def test_incomplete_checkpoint_requires_force(temp_git_repo, monkeypatch):
+    """A checkpoint interrupted before finalization must not restore silently."""
+    from git_stage_batch.data import undo_checkpoints as checkpoints
+
+    target = _commit_text_file(temp_git_repo, "target.txt", "before\n")
+    get_session_directory_path().mkdir(parents=True, exist_ok=True)
+
+    checkpoints._create_undo_checkpoint(
+        "interrupted change",
+        worktree_paths=["target.txt"],
+    )
+    monkeypatch.setattr(checkpoints, "_PENDING_CHECKPOINT", None)
+    target.write_text("after process exit\n")
+
+    with pytest.raises(CommandError, match="incomplete checkpoint"):
+        undo_last_checkpoint()
+
+    assert target.read_text() == "after process exit\n"


### PR DESCRIPTION
Undo checkpoints record pre-operation state and normally finalize the
post-operation state used for conflict detection.

A process exit between those writes leaves no after-image against which
ordinary undo can detect later edits. Restoring such a checkpoint
automatically can overwrite work created after the interrupted operation.

This PR addresses that unsafe case by treating incomplete checkpoints as
conflicts unless the user explicitly forces restoration. It adds an
interrupted-checkpoint regression and documents the storage semantics.

Ordinary undo now preserves later work whenever checkpoint finalization did
not complete.
