### PR TITLE
batch: Avoid transient line-sequence copies

### DIFF
--- a/src/git_stage_batch/batch/absence_constraints.py
+++ b/src/git_stage_batch/batch/absence_constraints.py
@@ -148,7 +148,10 @@ def absence_ambiguity_key(
 ) -> str:
     """Return the merge-resolution key for one absence ambiguity."""
     anchor = "start" if anchor_line is None else str(anchor_line)
-    digest = hashlib.sha256(b"".join(forbidden_sequence)).hexdigest()[:12]
+    hasher = hashlib.sha256()
+    for line in forbidden_sequence:
+        hasher.update(line)
+    digest = hasher.hexdigest()[:12]
     return f"absence:{claim_index}:{anchor}:{digest}"
 
 

--- a/src/git_stage_batch/batch/absence_constraints.py
+++ b/src/git_stage_batch/batch/absence_constraints.py
@@ -169,7 +169,7 @@ def absence_choices_for_claim(
     def add_position(position: int, explanation: str) -> None:
         if position in seen:
             return
-        if not _sequence_matches_at_position(entries, position, list(forbidden_sequence)):
+        if not _sequence_matches_at_position(entries, position, forbidden_sequence):
             return
         seen.add(position)
         positions.append((position, explanation))
@@ -249,7 +249,7 @@ def _normalize_line_content(content: Any) -> bytes:
 def _sequence_matches_at_position(
     entries: Sequence[_RealizedEntry],
     position: int,
-    sequence: list[bytes],
+    sequence: Sequence[bytes],
 ) -> bool:
     """Check if sequence matches entries starting at exact position."""
     if position + len(sequence) > len(entries):
@@ -266,7 +266,7 @@ def _sequence_matches_at_position(
 def _find_sequence_nearby(
     entries: Sequence[_RealizedEntry],
     position: int,
-    sequence: list[bytes],
+    sequence: Sequence[bytes],
     window: int = 20,
 ) -> int | None:
     """Search for sequence within window after position."""
@@ -291,7 +291,7 @@ def _iter_sequence_occurrences_nearby(
     search_end = min(position + window, len(entries) - len(sequence) + 1)
     result_count = 0
     for check_pos in range(position + 1, search_end):
-        if _sequence_matches_at_position(entries, check_pos, list(sequence)):
+        if _sequence_matches_at_position(entries, check_pos, sequence):
             yield check_pos
             result_count += 1
             if result_count >= max_results:
@@ -301,7 +301,7 @@ def _iter_sequence_occurrences_nearby(
 def _remove_sequence_at_position(
     entries: Sequence[_RealizedEntry],
     position: int,
-    sequence: list[bytes],
+    sequence: Sequence[bytes],
 ) -> RealizedEntries:
     """Remove sequence from entries at exact position."""
     return as_realized_entries(entries).without_range(
@@ -336,7 +336,7 @@ def _position_after_claimed_insertions_at_boundary(
 def _suppress_at_boundary_strict(
     entries: Sequence[_RealizedEntry],
     position: int,
-    forbidden_sequence: list[bytes],
+    forbidden_sequence: Sequence[bytes],
 ) -> RealizedEntries:
     """Suppress forbidden sequence with strict enforcement for merge operations."""
     if _sequence_matches_at_position(entries, position, forbidden_sequence):
@@ -370,7 +370,7 @@ def _suppress_at_boundary_strict(
 def _suppress_at_boundary_for_realization(
     entries: Sequence[_RealizedEntry],
     position: int,
-    forbidden_sequence: list[bytes],
+    forbidden_sequence: Sequence[bytes],
 ) -> RealizedEntries:
     """Suppress forbidden sequence leniently for content realization."""
     if _sequence_matches_at_position(entries, position, forbidden_sequence):

--- a/src/git_stage_batch/batch/baseline_replacement_choices.py
+++ b/src/git_stage_batch/batch/baseline_replacement_choices.py
@@ -100,4 +100,7 @@ def _replacement_origin_ambiguity_key(
 
 
 def _sequence_digest(lines: Sequence[bytes]) -> str:
-    return hashlib.sha256(b"".join(lines)).hexdigest()[:12]
+    hasher = hashlib.sha256()
+    for line in lines:
+        hasher.update(line)
+    return hasher.hexdigest()[:12]

--- a/src/git_stage_batch/batch/line_sequence_search.py
+++ b/src/git_stage_batch/batch/line_sequence_search.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
 
+from .line_sequence_equality import line_slice_equals
+
 
 @dataclass(frozen=True)
 class TargetGap:
@@ -72,14 +74,16 @@ def iter_exact_context_gaps(
             continue
         if (
             left_count
-            and tuple(target_lines[gap_index - left_count:gap_index])
-            != tuple(left_context)
+            and not line_slice_equals(
+                target_lines,
+                gap_index - left_count,
+                left_context,
+            )
         ):
             continue
         if (
             right_count
-            and tuple(target_lines[gap_index:gap_index + right_count])
-            != tuple(right_context)
+            and not line_slice_equals(target_lines, gap_index, right_context)
         ):
             continue
         yield TargetGap(

--- a/src/git_stage_batch/batch/presence_placement_choices.py
+++ b/src/git_stage_batch/batch/presence_placement_choices.py
@@ -98,7 +98,10 @@ def presence_ambiguity_key(
     before_source_line: int,
     after_source_line: int,
 ) -> str:
-    digest = hashlib.sha256(b"".join(claimed_run)).hexdigest()[:12]
+    hasher = hashlib.sha256()
+    for line in claimed_run:
+        hasher.update(line)
+    digest = hasher.hexdigest()[:12]
     return (
         f"presence:{run_start}-{run_end}:claimed:{digest}:"
         f"between:{before_source_line}-{after_source_line}"

--- a/src/git_stage_batch/batch/presence_placement_choices.py
+++ b/src/git_stage_batch/batch/presence_placement_choices.py
@@ -56,10 +56,7 @@ def presence_choices_for_missing_claimed_run(
 
     left_context = (bytes(source_lines[before_source_line - 1]),)
     right_context = (bytes(source_lines[after_source_line - 1]),)
-    claimed_run = tuple(
-        bytes(source_lines[index])
-        for index in range(run_start - 1, run_end)
-    )
+    claimed_run = source_lines[run_start - 1:run_end]
     key = presence_ambiguity_key(
         run_start,
         run_end,


### PR DESCRIPTION
Batch ambiguity and placement logic operates on indexed line sequences from
source and target content.

Several hashing and comparison paths join those sequences or convert slices
to tuples and lists. Large claims and repeated candidate scans therefore
duplicate content in the Python heap even though indexed storage already
provides the required access.

This PR addresses those allocations by updating digests incrementally and
preserving sequence views through presence, absence, and exact-context
matching.

Matching now operates on indexed line storage without claim-sized joins or
repeated context copies.
