### PR TITLE
output: Keep candidate previews buffer-backed

### DIFF
--- a/src/git_stage_batch/batch/operation_candidates.py
+++ b/src/git_stage_batch/batch/operation_candidates.py
@@ -74,7 +74,7 @@ def _materialize_target_candidate(
     destination_exists: bool,
     selected_ids: set[int] | None,
 ) -> _TargetCandidatePreview:
-    before_copy = LineBuffer.from_bytes(before_lines.to_bytes())
+    before_copy = before_lines.clone()
     after = merge_batch_from_line_sequences_as_buffer(
         source_lines,
         ownership,

--- a/src/git_stage_batch/commands/batch_source/replacement_previews.py
+++ b/src/git_stage_batch/commands/batch_source/replacement_previews.py
@@ -75,20 +75,16 @@ def print_batch_source_replacement_preview(
             except ValueError as e:
                 exit_with_error(str(e))
             with replacement_view:
-                before = LineBuffer.from_bytes(batch_source_buffer.to_bytes())
-                try:
-                    diff_text = render_candidate_buffer_diff(
-                        file_path,
-                        before,
-                        replacement_view.source_buffer,
-                        label_before="batch",
-                        label_after="replacement-preview",
-                        context_lines=get_context_lines(),
+                diff_text = render_candidate_buffer_diff(
+                    file_path,
+                    batch_source_buffer,
+                    replacement_view.source_buffer,
+                    label_before="batch",
+                    label_after="replacement-preview",
+                    context_lines=get_context_lines(),
+                )
+                if diff_text:
+                    print(
+                        diff_text,
+                        end="" if diff_text.endswith("\n") else "\n",
                     )
-                    if diff_text:
-                        print(
-                            diff_text,
-                            end="" if diff_text.endswith("\n") else "\n",
-                        )
-                finally:
-                    before.close()

--- a/src/git_stage_batch/core/buffer.py
+++ b/src/git_stage_batch/core/buffer.py
@@ -22,6 +22,41 @@ _BytesLike = bytes | bytearray | memoryview
 _LineT = TypeVar("_LineT")
 
 
+class _BufferBacking:
+    """Reference-counted immutable byte storage shared by line buffers."""
+
+    def __init__(
+        self,
+        data: bytes | mmap.mmap,
+        file_handle: BinaryIO | None = None,
+    ) -> None:
+        self.data = data
+        self.file_handle = file_handle
+        self._reference_count = 1
+        self._closed = False
+
+    def retain(self) -> _BufferBacking:
+        if self._closed:
+            raise ValueError("buffer backing is closed")
+        self._reference_count += 1
+        return self
+
+    def release(self) -> None:
+        if self._closed:
+            return
+        self._reference_count -= 1
+        if self._reference_count > 0:
+            return
+
+        self._closed = True
+        try:
+            if isinstance(self.data, mmap.mmap):
+                self.data.close()
+        finally:
+            if self.file_handle is not None:
+                self.file_handle.close()
+
+
 class _LineSpanVector:
     """Compact append-only storage for byte line spans."""
 
@@ -54,12 +89,25 @@ class LineBuffer(Sequence[bytes]):
         *,
         file_handle: BinaryIO | None = None,
     ) -> None:
-        self._data = data
-        self._file_handle = file_handle
+        self._backing = _BufferBacking(data, file_handle)
+        self._initialize_line_index()
+
+    def _initialize_line_index(self) -> None:
         self._line_spans = _LineSpanVector()
         self._scan_position = 0
-        self._scan_complete = len(data) == 0
+        self._scan_complete = len(self._data) == 0
         self._closed = False
+
+    @classmethod
+    def _from_backing(cls, backing: _BufferBacking) -> LineBuffer:
+        buffer = cls.__new__(cls)
+        buffer._backing = backing.retain()
+        buffer._initialize_line_index()
+        return buffer
+
+    @property
+    def _data(self) -> bytes | mmap.mmap:
+        return self._backing.data
 
     @classmethod
     def from_bytes(cls, data: _BytesLike) -> LineBuffer:
@@ -86,6 +134,11 @@ class LineBuffer(Sequence[bytes]):
         )
         return cls(data, file_handle=file_handle)
 
+    def clone(self) -> LineBuffer:
+        """Return an independently closable buffer sharing immutable storage."""
+        self._require_open()
+        return LineBuffer._from_backing(self._backing)
+
     @property
     def uses_mapped_storage(self) -> bool:
         """Return whether this buffer uses mapped storage."""
@@ -101,14 +154,11 @@ class LineBuffer(Sequence[bytes]):
         """Close any open mmap and file resources."""
         if self._closed:
             return
-
-        data = self._data
-        if isinstance(data, mmap.mmap):
-            data.close()
-        if self._file_handle is not None:
-            self._file_handle.close()
-        self._line_spans.close()
         self._closed = True
+        try:
+            self._line_spans.close()
+        finally:
+            self._backing.release()
 
     def __del__(self) -> None:
         try:

--- a/src/git_stage_batch/output/candidate_preview_diff.py
+++ b/src/git_stage_batch/output/candidate_preview_diff.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import difflib
+from collections.abc import Iterable, Iterator, Sequence
+from itertools import chain
 
 from ..core.buffer import LineBuffer
 from ..core.diff_parser import build_line_changes_from_patch_lines
@@ -20,39 +22,105 @@ def render_candidate_buffer_diff(
     context_lines: int,
 ) -> str:
     """Render a unified diff between two candidate buffers."""
-    before_text = before_buffer.to_bytes().decode("utf-8", errors="surrogateescape")
-    after_text = after_buffer.to_bytes().decode("utf-8", errors="surrogateescape")
-    return "".join(
-        difflib.unified_diff(
-            before_text.splitlines(keepends=True),
-            after_text.splitlines(keepends=True),
-            fromfile=f"{label_before}/{file_path}",
-            tofile=f"{label_after}/{file_path}",
-            n=context_lines,
+    with _candidate_buffer_diff(
+        file_path,
+        before_buffer,
+        after_buffer,
+        label_before=label_before,
+        label_after=label_after,
+        context_lines=context_lines,
+    ) as diff_buffer:
+        return "".join(
+            line.decode("utf-8", errors="surrogateescape")
+            for line in diff_buffer
+        )
+
+
+def _candidate_buffer_diff(
+    file_path: str,
+    before_buffer: LineBuffer,
+    after_buffer: LineBuffer,
+    *,
+    label_before: str,
+    label_after: str,
+    context_lines: int,
+) -> LineBuffer:
+    """Build a mapped line buffer containing one candidate diff."""
+    return LineBuffer.from_chunks(
+        _unified_diff_lines(
+            before_buffer,
+            after_buffer,
+            fromfile=f"{label_before}/{file_path}".encode(),
+            tofile=f"{label_after}/{file_path}".encode(),
+            context_lines=context_lines,
         )
     )
 
 
-def _candidate_diff_hunks(diff_text: str) -> tuple[tuple[bytes, ...], ...]:
-    headers: list[bytes] = []
-    current_hunk: list[bytes] = []
-    hunks: list[tuple[bytes, ...]] = []
-    for line in diff_text.splitlines(keepends=True):
-        line_bytes = line.encode("utf-8", errors="surrogateescape")
-        if line_bytes.startswith((b"--- ", b"+++ ")):
-            headers.append(line_bytes)
-            continue
-        if line_bytes.startswith(b"@@ "):
-            if current_hunk:
-                hunks.append(tuple(headers + current_hunk))
-            current_hunk = [line_bytes]
-            continue
-        if current_hunk:
-            current_hunk.append(line_bytes)
+def _format_unified_range(start: int, stop: int) -> str:
+    beginning = start + 1
+    length = stop - start
+    if length == 1:
+        return str(beginning)
+    if length == 0:
+        beginning -= 1
+    return f"{beginning},{length}"
 
-    if current_hunk:
-        hunks.append(tuple(headers + current_hunk))
-    return tuple(hunks)
+
+def _unified_diff_lines(
+    before_buffer: LineBuffer,
+    after_buffer: LineBuffer,
+    *,
+    fromfile: bytes,
+    tofile: bytes,
+    context_lines: int,
+) -> Iterator[bytes]:
+    """Yield a unified diff while retaining file content in line buffers."""
+    with (
+        before_buffer.acquire_lines() as before_lines,
+        after_buffer.acquire_lines() as after_lines,
+    ):
+        matcher = difflib.SequenceMatcher(None, before_lines, after_lines)
+        groups = matcher.get_grouped_opcodes(context_lines)
+        started = False
+        for group in groups:
+            if not started:
+                started = True
+                yield b"--- " + fromfile + b"\n"
+                yield b"+++ " + tofile + b"\n"
+            first, last = group[0], group[-1]
+            old_range = _format_unified_range(first[1], last[2]).encode()
+            new_range = _format_unified_range(first[3], last[4]).encode()
+            yield b"@@ -" + old_range + b" +" + new_range + b" @@\n"
+            for tag, old_start, old_end, new_start, new_end in group:
+                if tag == "equal":
+                    for index in range(old_start, old_end):
+                        yield b" " + bytes(before_lines[index])
+                if tag in {"replace", "delete"}:
+                    for index in range(old_start, old_end):
+                        yield b"-" + bytes(before_lines[index])
+                if tag in {"replace", "insert"}:
+                    for index in range(new_start, new_end):
+                        yield b"+" + bytes(after_lines[index])
+
+
+def _candidate_diff_hunks(
+    diff_lines: Sequence[bytes],
+) -> Iterator[Iterable[bytes]]:
+    headers: list[bytes] = []
+    current_hunk_start: int | None = None
+    for index in range(len(diff_lines)):
+        line = diff_lines[index]
+        if line.startswith((b"--- ", b"+++ ")):
+            headers.append(line)
+            continue
+        if line.startswith(b"@@ "):
+            if current_hunk_start is not None:
+                yield chain(headers, diff_lines[current_hunk_start:index])
+            current_hunk_start = index
+
+    if current_hunk_start is not None:
+        yield chain(headers, diff_lines[current_hunk_start:])
 
 
 def _candidate_line_number(line) -> int | None:
@@ -118,7 +186,7 @@ def print_candidate_buffer_diff(
     leading_blank: bool = False,
 ) -> bool:
     """Print the diff between one candidate target's buffers."""
-    diff_text = render_candidate_buffer_diff(
+    diff_buffer = _candidate_buffer_diff(
         file_path,
         before_buffer,
         after_buffer,
@@ -126,23 +194,29 @@ def print_candidate_buffer_diff(
         label_after="b",
         context_lines=context_lines,
     )
-    if not diff_text:
-        return False
+    with diff_buffer:
+        if diff_buffer.byte_count == 0:
+            return False
 
-    if leading_blank:
-        print()
-
-    hunks = _candidate_diff_hunks(diff_text)
-    if not hunks:
-        print(diff_text, end="" if diff_text.endswith("\n") else "\n")
-        return True
-
-    for index, hunk in enumerate(hunks):
-        if index:
+        if leading_blank:
             print()
-        line_changes = build_line_changes_from_patch_lines(hunk)
-        _print_candidate_line_changes(
-            line_changes,
-            ambiguity_target_line_range=ambiguity_target_line_range,
-        )
-    return True
+
+        hunks = iter(_candidate_diff_hunks(diff_buffer))
+        first_hunk = next(hunks, None)
+        if first_hunk is None:
+            diff_text = "".join(
+                line.decode("utf-8", errors="surrogateescape")
+                for line in diff_buffer
+            )
+            print(diff_text, end="" if diff_text.endswith("\n") else "\n")
+            return True
+
+        for index, hunk in enumerate(chain((first_hunk,), hunks)):
+            if index:
+                print()
+            line_changes = build_line_changes_from_patch_lines(hunk)
+            _print_candidate_line_changes(
+                line_changes,
+                ambiguity_target_line_range=ambiguity_target_line_range,
+            )
+        return True

--- a/src/git_stage_batch/output/candidate_preview_summary.py
+++ b/src/git_stage_batch/output/candidate_preview_summary.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import difflib
+from collections.abc import Sequence
 from dataclasses import dataclass
 
 from ..batch.operation_candidate_types import OperationCandidatePreview
-from ..core.buffer import LineBuffer
 from ..i18n import _
 from . import candidate_preview_snippets
 
@@ -80,28 +80,55 @@ def candidate_target_subject_label(target_name: str) -> str:
     return _("working tree")
 
 
-def summarize_ambiguity_block(lines: list[str]) -> str:
+def _ambiguity_block_line_text(line: object) -> str:
+    if not isinstance(line, str):
+        return _overview_line_text(bytes(line))
+    return line.rstrip("\n").rstrip("\r")
+
+
+def summarize_ambiguity_block(lines: Sequence[bytes | str]) -> str:
     if not lines:
         return _("ambiguous block")
     if len(lines) == 1:
         text = candidate_preview_snippets.shorten_candidate_overview_text(
-            lines[0],
+            _ambiguity_block_line_text(lines[0]),
             36,
         )
         if text:
             return f'"{text}"'
         return _("an empty line")
 
-    first = candidate_preview_snippets.shorten_candidate_overview_text(lines[0], 24)
-    last = candidate_preview_snippets.shorten_candidate_overview_text(lines[-1], 24)
+    first = candidate_preview_snippets.shorten_candidate_overview_text(
+        _ambiguity_block_line_text(lines[0]),
+        24,
+    )
+    last = candidate_preview_snippets.shorten_candidate_overview_text(
+        _ambiguity_block_line_text(lines[-1]),
+        24,
+    )
     if first and last:
         return f'"{first} … {last}"'
     return _("{count} lines").format(count=len(lines))
 
 
 def candidate_target_summary(target) -> CandidateTargetSummary:
-    before_lines = _decode_overview_lines(target.before_buffer)
-    after_lines = _decode_overview_lines(target.after_buffer)
+    with (
+        target.before_buffer.acquire_lines() as before_lines,
+        target.after_buffer.acquire_lines() as after_lines,
+    ):
+        return _candidate_target_summary_from_lines(
+            target,
+            before_lines,
+            after_lines,
+        )
+
+
+def _candidate_target_summary_from_lines(
+    target,
+    before_lines: Sequence[bytes],
+    after_lines: Sequence[bytes],
+) -> CandidateTargetSummary:
+    """Build a summary while scoped no-copy line views are active."""
     opcode = _first_changed_opcode(before_lines, after_lines)
     label = candidate_target_label(target.target)
     if opcode is None:
@@ -184,17 +211,21 @@ def common_candidate_target_indexes(
     return tuple(common_indexes)
 
 
-def _decode_overview_lines(buffer: LineBuffer) -> list[str]:
-    text = buffer.to_bytes().decode("utf-8", errors="surrogateescape")
-    return text.splitlines()
+def _overview_line_text(line: bytes) -> str:
+    line = bytes(line)
+    if line.endswith(b"\n"):
+        line = line[:-1]
+        if line.endswith(b"\r"):
+            line = line[:-1]
+    return line.decode("utf-8", errors="surrogateescape")
 
 
-def _summarize_overview_lines(lines: list[str]) -> str:
+def _summarize_overview_lines(lines: Sequence[bytes]) -> str:
     if not lines:
         return _("nothing")
     if len(lines) == 1:
         text = candidate_preview_snippets.shorten_candidate_overview_text(
-            lines[0],
+            _overview_line_text(lines[0]),
             36,
         )
         if text:
@@ -204,7 +235,7 @@ def _summarize_overview_lines(lines: list[str]) -> str:
 
 
 def _delete_ambiguity_block_context(
-    before_lines: list[str],
+    before_lines: Sequence[bytes],
     before_start: int,
     before_end: int,
     ambiguity_target_line_range: tuple[int, int] | None,
@@ -258,8 +289,8 @@ def _delete_ambiguity_block_context(
 
 
 def _first_changed_opcode(
-    before_lines: list[str],
-    after_lines: list[str],
+    before_lines: Sequence[bytes],
+    after_lines: Sequence[bytes],
 ) -> tuple[str, int, int, int, int] | None:
     matcher = difflib.SequenceMatcher(a=before_lines, b=after_lines, autojunk=False)
     for tag, before_start, before_end, after_start, after_end in matcher.get_opcodes():
@@ -269,12 +300,16 @@ def _first_changed_opcode(
 
 
 def _nearby_context_summary(
-    before_lines: list[str],
+    before_lines: Sequence[bytes],
     before_start: int,
     before_end: int,
-    changed_lines: list[str],
+    changed_lines: Sequence[bytes],
 ) -> str:
-    changed_text = {line.strip() for line in changed_lines if line.strip()}
+    changed_text = {
+        text.strip()
+        for line in changed_lines
+        if (text := _overview_line_text(line)).strip()
+    }
     candidates = []
     if before_start > 0:
         candidates.append(before_lines[before_start - 1])
@@ -282,12 +317,16 @@ def _nearby_context_summary(
         candidates.append(before_lines[before_end])
 
     for line in candidates:
-        text = candidate_preview_snippets.shorten_candidate_overview_text(line, 36)
+        text = candidate_preview_snippets.shorten_candidate_overview_text(
+            _overview_line_text(line), 36
+        )
         if text and text not in changed_text:
             return _(' near "{context}"').format(context=text)
 
     for line in candidates:
-        text = candidate_preview_snippets.shorten_candidate_overview_text(line, 36)
+        text = candidate_preview_snippets.shorten_candidate_overview_text(
+            _overview_line_text(line), 36
+        )
         if text:
             return _(' near "{context}"').format(context=text)
     return ""
@@ -295,8 +334,8 @@ def _nearby_context_summary(
 
 def _overview_action_title(
     tag: str,
-    before_lines: list[str],
-    after_lines: list[str],
+    before_lines: Sequence[bytes],
+    after_lines: Sequence[bytes],
     before_start: int,
     before_end: int,
     after_start: int,
@@ -360,8 +399,8 @@ def _append_overview_line(
 
 
 def _overview_snippet_lines(
-    before_lines: list[str],
-    after_lines: list[str],
+    before_lines: Sequence[bytes],
+    after_lines: Sequence[bytes],
     before_start: int,
     before_end: int,
     after_start: int,
@@ -378,7 +417,7 @@ def _overview_snippet_lines(
             lines,
             line_number=index + 1,
             marker=" ",
-            text=before_lines[index],
+            text=_overview_line_text(before_lines[index]),
             highlight=candidate_preview_snippets.candidate_line_in_range(
                 index + 1,
                 ambiguity_target_line_range,
@@ -390,7 +429,7 @@ def _overview_snippet_lines(
             lines,
             line_number=index + 1,
             marker="-",
-            text=before_lines[index],
+            text=_overview_line_text(before_lines[index]),
         )
 
     for index in range(after_start, after_end):
@@ -398,7 +437,7 @@ def _overview_snippet_lines(
             lines,
             line_number=index + 1,
             marker="+",
-            text=after_lines[index],
+            text=_overview_line_text(after_lines[index]),
         )
 
     for index in range(before_end, context_end):
@@ -406,7 +445,7 @@ def _overview_snippet_lines(
             lines,
             line_number=index + 1,
             marker=" ",
-            text=before_lines[index],
+            text=_overview_line_text(before_lines[index]),
             highlight=candidate_preview_snippets.candidate_line_in_range(
                 index + 1,
                 ambiguity_target_line_range,

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -13298,7 +13298,7 @@ def test_candidate_preview_diff_owns_buffer_diff_rendering():
     assert "render_candidate_buffer_diff" not in candidate_preview_text
     assert "splitlines(keepends=True)" not in candidate_preview_text
     assert "render_candidate_buffer_diff" in candidate_diff_text
-    assert "splitlines(keepends=True)" in candidate_diff_text
+    assert "def _unified_diff_lines" in candidate_diff_text
     assert "def render_candidate_buffer_diff" not in operation_candidates_text
     assert "import difflib" not in operation_candidates_text
     assert "import difflib" in candidate_diff_text

--- a/tests/batch/test_operation_candidates.py
+++ b/tests/batch/test_operation_candidates.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from git_stage_batch.batch import operation_candidates
 from git_stage_batch.batch.operation_candidate_types import (
     OperationCandidatePreview,
     TargetCandidatePreview,
@@ -71,3 +72,44 @@ def test_operation_candidate_preview_rejects_missing_target():
         preview.close()
 
     assert exc_info.value.args == ("index",)
+
+
+def test_target_candidate_materialization_clones_before_buffer(monkeypatch):
+    """Candidate previews share immutable before-storage without copying it."""
+    before = LineBuffer.from_bytes(b"before\n")
+
+    monkeypatch.setattr(
+        operation_candidates,
+        "merge_batch_from_line_sequences_as_buffer",
+        lambda *args, **kwargs: LineBuffer.from_bytes(b"after\n"),
+    )
+
+    class _ChangeType:
+        value = "modified"
+
+    monkeypatch.setattr(
+        operation_candidates,
+        "selected_text_target_change_type",
+        lambda *args, **kwargs: _ChangeType(),
+    )
+
+    preview = operation_candidates._materialize_target_candidate(
+        target="worktree",
+        file_path="notes.txt",
+        source_lines=LineBuffer.from_bytes(b"source\n"),
+        ownership=object(),
+        before_lines=before,
+        candidate=None,
+        file_mode=None,
+        text_change_type=object(),
+        destination_exists=True,
+        selected_ids=None,
+    )
+
+    try:
+        assert preview.before_buffer._backing is before._backing
+        before.close()
+        assert preview.before_buffer[0] == b"before\n"
+    finally:
+        before.close()
+        preview.close()

--- a/tests/core/test_buffer.py
+++ b/tests/core/test_buffer.py
@@ -267,6 +267,77 @@ def test_line_buffer_uses_mapped_storage_for_page_sized_files(tmp_path):
         assert buffer[1] == b"x" * (mmap.PAGESIZE - len(b"alpha\n"))
 
 
+def test_line_buffer_clone_survives_original_close():
+    """A clone retains shared heap storage after its original closes."""
+    original = LineBuffer.from_bytes(b"alpha\nbeta\n")
+    clone = original.clone()
+
+    original.close()
+
+    with pytest.raises(ValueError, match="buffer is closed"):
+        _ = original[0]
+    assert clone[0] == b"alpha\n"
+    assert clone[1] == b"beta\n"
+    clone.close()
+
+
+def test_line_buffer_original_survives_clone_close():
+    """Closing a clone does not release storage retained by its original."""
+    original = LineBuffer.from_bytes(b"alpha\nbeta\n")
+    clone = original.clone()
+
+    clone.close()
+
+    with pytest.raises(ValueError, match="buffer is closed"):
+        _ = clone[0]
+    assert original[0] == b"alpha\n"
+    assert original[1] == b"beta\n"
+    original.close()
+
+
+def test_line_buffer_clones_have_independent_line_indexes():
+    """Clones share bytes without sharing mutable line-scan state."""
+    original = LineBuffer.from_bytes(b"alpha\nbeta\ngamma\n")
+    clone = original.clone()
+
+    assert original[0] == b"alpha\n"
+    assert clone[2] == b"gamma\n"
+    assert original._line_span_count() == 1
+    assert clone._line_span_count() == 3
+
+    original.close()
+    clone.close()
+
+
+def test_line_buffer_mapped_backing_closes_after_final_clone(tmp_path):
+    """Mapped storage and its file remain open until every clone closes."""
+    data = b"alpha\n" + b"x" * (mmap.PAGESIZE - len(b"alpha\n"))
+    file_path = tmp_path / "buffer.txt"
+    file_path.write_bytes(data)
+    original = LineBuffer.from_path(file_path)
+    first_clone = original.clone()
+    final_clone = original.clone()
+    mapped_data = original._data
+    file_handle = original._backing.file_handle
+
+    assert isinstance(mapped_data, mmap.mmap)
+    assert file_handle is not None
+    assert original._backing is first_clone._backing
+    assert original._backing is final_clone._backing
+
+    original.close()
+    first_clone.close()
+
+    assert mapped_data.closed is False
+    assert file_handle.closed is False
+    assert final_clone[0] == b"alpha\n"
+
+    final_clone.close()
+
+    assert mapped_data.closed is True
+    assert file_handle.closed is True
+
+
 def test_line_buffer_skips_mapped_storage_for_empty_files(tmp_path):
     """Empty files do not use mapped storage but still expose an empty buffer."""
     file_path = tmp_path / "empty.txt"

--- a/tests/output/test_candidate_preview_buffers.py
+++ b/tests/output/test_candidate_preview_buffers.py
@@ -1,11 +1,13 @@
 """Tests for buffer-backed candidate preview rendering."""
 
+from types import SimpleNamespace
 
 from git_stage_batch.core.buffer import LineBuffer
 from git_stage_batch.output.candidate_preview_diff import (
     print_candidate_buffer_diff,
     render_candidate_buffer_diff,
 )
+from git_stage_batch.output.candidate_preview_summary import candidate_target_summary
 
 
 class _IndexGuardedLineBuffer(LineBuffer):
@@ -58,3 +60,21 @@ def test_candidate_diff_printing_consumes_buffered_hunks(capsys):
     output = capsys.readouterr().out
     assert "-old" in output
     assert "+new" in output
+
+
+def test_candidate_summary_matches_through_acquired_line_views():
+    with (
+        _guarded_buffer(b"old\n") as before,
+        _guarded_buffer(b"new\n") as after,
+    ):
+        summary = candidate_target_summary(
+            SimpleNamespace(
+                target="worktree",
+                before_buffer=before,
+                after_buffer=after,
+                ambiguity_target_line_range=None,
+            )
+        )
+
+    assert [line.marker for line in summary.lines] == ["-", "+"]
+    assert [line.text for line in summary.lines] == ["old", "new"]

--- a/tests/output/test_candidate_preview_buffers.py
+++ b/tests/output/test_candidate_preview_buffers.py
@@ -1,0 +1,60 @@
+"""Tests for buffer-backed candidate preview rendering."""
+
+
+from git_stage_batch.core.buffer import LineBuffer
+from git_stage_batch.output.candidate_preview_diff import (
+    print_candidate_buffer_diff,
+    render_candidate_buffer_diff,
+)
+
+
+class _IndexGuardedLineBuffer(LineBuffer):
+    """Line buffer that requires consumers to use scoped acquisition."""
+
+    def __getitem__(self, index):
+        raise AssertionError("public line indexing should not be used")
+
+
+def _guarded_buffer(content: bytes) -> _IndexGuardedLineBuffer:
+    return _IndexGuardedLineBuffer.from_bytes(content)
+
+
+def test_candidate_diff_matches_through_acquired_line_views():
+    with (
+        _guarded_buffer(b"old\n") as before,
+        _guarded_buffer(b"new\n") as after,
+    ):
+        rendered = render_candidate_buffer_diff(
+            "file.txt",
+            before,
+            after,
+            label_before="a",
+            label_after="b",
+            context_lines=3,
+        )
+
+    assert rendered == (
+        "--- a/file.txt\n"
+        "+++ b/file.txt\n"
+        "@@ -1 +1 @@\n"
+        "-old\n"
+        "+new\n"
+    )
+
+
+def test_candidate_diff_printing_consumes_buffered_hunks(capsys):
+    with (
+        _guarded_buffer(b"old\n") as before,
+        _guarded_buffer(b"new\n") as after,
+    ):
+        assert print_candidate_buffer_diff(
+            "file.txt",
+            before,
+            after,
+            context_lines=3,
+            ambiguity_target_line_range=None,
+        ) is True
+
+    output = capsys.readouterr().out
+    assert "-old" in output
+    assert "+new" in output


### PR DESCRIPTION
Candidate previews use line-addressable before and after content to build
diffs, replacement views, titles, and snippets.

Candidate construction and rendering currently copy mapped files into bytes,
decoded strings, or per-line collections. Large files can therefore occupy
several simultaneous Python heap representations for one preview.

This PR addresses that memory growth by adding independently closable
LineBuffer clones over shared backing and adopting buffer views throughout
candidate construction, diff rendering, replacement previews, and summary
matching. Lifecycle and output regressions cover the new ownership model.

Candidate previews now retain file-scale content in mapped or shared buffer
storage and decode only bounded display output.
