### PR TITLE
replacement: Keep payload lines in scoped buffers

### DIFF
--- a/src/git_stage_batch/batch/replacement.py
+++ b/src/git_stage_batch/batch/replacement.py
@@ -54,9 +54,22 @@ def build_replacement_batch_view_from_lines(
     replacement_text: str | ReplacementPayload,
 ) -> ReplacementBatchView:
     """Build replacement source content from an indexed byte-line sequence."""
-    claimed_source_lines = sorted(ownership.presence_line_set())
     payload = coerce_replacement_payload(replacement_text)
-    replacement_lines = replacement_line_chunks(payload)
+    with replacement_line_chunks(payload) as replacement_lines:
+        return _build_replacement_batch_view(
+            source_lines,
+            ownership,
+            replacement_lines,
+        )
+
+
+def _build_replacement_batch_view(
+    source_lines: Sequence[bytes],
+    ownership: BatchOwnership,
+    replacement_lines: Sequence[bytes],
+) -> ReplacementBatchView:
+    """Build a replacement view while its replacement line sequence is open."""
+    claimed_source_lines = sorted(ownership.presence_line_set())
 
     if claimed_source_lines:
         expected_claimed = list(range(claimed_source_lines[0], claimed_source_lines[-1] + 1))

--- a/src/git_stage_batch/core/replacement.py
+++ b/src/git_stage_batch/core/replacement.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
 from dataclasses import dataclass
+from typing import overload
 
-from .text_lines import bytes_to_lines
+from .buffer import LineBuffer
 
 
 @dataclass(frozen=True, slots=True)
@@ -66,21 +69,86 @@ def coerce_replacement_payload(
     return ReplacementPayload.from_text(replacement, exact=False)
 
 
-def replacement_line_chunks(payload: ReplacementPayload) -> list[bytes]:
-    """Split replacement bytes into exact line chunks."""
-    if not payload.exact:
-        return [line + b"\n" for line in payload.data.splitlines()]
-    return list(bytes_to_lines([payload.data]))
+class _ReplacementLineBodies(Sequence[bytes]):
+    """Lazy editor-line bodies over exact replacement chunks."""
 
+    def __init__(
+        self,
+        lines: Sequence[bytes],
+        indices: range | None = None,
+    ) -> None:
+        self._lines = lines
+        self._indices = range(len(lines)) if indices is None else indices
 
-def replacement_line_bodies(payload: ReplacementPayload) -> list[bytes]:
-    """Return editor line bodies while preserving CRLF as body CR bytes."""
-    if not payload.exact:
-        return payload.data.splitlines()
-    bodies: list[bytes] = []
-    for line in replacement_line_chunks(payload):
+    def __len__(self) -> int:
+        return len(self._indices)
+
+    @overload
+    def __getitem__(self, index: int) -> bytes: ...
+
+    @overload
+    def __getitem__(self, index: slice) -> Sequence[bytes]: ...
+
+    def __getitem__(self, index: int | slice) -> bytes | Sequence[bytes]:
+        if isinstance(index, slice):
+            return _ReplacementLineBodies(self._lines, self._indices[index])
+        try:
+            line_index = self._indices[index]
+        except IndexError as exc:
+            raise IndexError(index) from exc
+        line = self._lines[line_index]
         if line.endswith(b"\n"):
-            bodies.append(line[:-1])
-        else:
-            bodies.append(line)
-    return bodies
+            line = line[:-1]
+        return line
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Sequence):
+            return NotImplemented
+        return len(self) == len(other) and all(
+            self[index] == other[index]
+            for index in range(len(self))
+        )
+
+
+_LEGACY_LINE_BREAKS = frozenset((10, 13))
+
+
+def _legacy_replacement_line_chunks(data: bytes) -> Iterator[bytes]:
+    """Yield legacy splitlines-compatible chunks normalized to LF."""
+    start = 0
+    index = 0
+    while index < len(data):
+        byte = data[index]
+        if byte not in _LEGACY_LINE_BREAKS:
+            index += 1
+            continue
+        yield data[start:index] + b"\n"
+        index += 1
+        if byte == 13 and index < len(data) and data[index] == 10:
+            index += 1
+        start = index
+    if start < len(data):
+        yield data[start:] + b"\n"
+
+
+@contextmanager
+def replacement_line_chunks(
+    payload: ReplacementPayload,
+) -> Iterator[Sequence[bytes]]:
+    """Expose replacement bytes as a scoped indexed line sequence."""
+    buffer = (
+        LineBuffer.from_bytes(payload.data)
+        if payload.exact
+        else LineBuffer.from_chunks(_legacy_replacement_line_chunks(payload.data))
+    )
+    with buffer:
+        yield buffer
+
+
+@contextmanager
+def replacement_line_bodies(
+    payload: ReplacementPayload,
+) -> Iterator[Sequence[bytes]]:
+    """Expose scoped editor line bodies without retaining per-line objects."""
+    with replacement_line_chunks(payload) as lines:
+        yield _ReplacementLineBodies(lines)

--- a/src/git_stage_batch/staging/content_buffers.py
+++ b/src/git_stage_batch/staging/content_buffers.py
@@ -187,6 +187,30 @@ def build_target_index_buffer_with_replaced_lines(
     trim_unchanged_edge_anchors: bool = True,
 ) -> LineBuffer:
     """Build target index content by replacing a span in indexed base lines."""
+    replacement_payload = coerce_replacement_payload(replacement_text)
+    with replacement_line_bodies(replacement_payload) as replacement_lines:
+        return _build_target_index_buffer_with_replaced_lines(
+            line_changes,
+            replace_ids,
+            replacement_payload,
+            replacement_lines,
+            base_lines,
+            base_has_trailing_newline=base_has_trailing_newline,
+            trim_unchanged_edge_anchors=trim_unchanged_edge_anchors,
+        )
+
+
+def _build_target_index_buffer_with_replaced_lines(
+    line_changes: LineLevelChange,
+    replace_ids: set[int],
+    replacement_payload: ReplacementPayload,
+    replacement_lines: Sequence[bytes],
+    base_lines: Sequence[bytes],
+    *,
+    base_has_trailing_newline: bool,
+    trim_unchanged_edge_anchors: bool,
+) -> LineBuffer:
+    """Build index content while replacement line storage is open."""
     def longest_prefix_context_match(
         candidate_lines: list[bytes],
         context_lines: list[bytes],
@@ -225,8 +249,6 @@ def build_target_index_buffer_with_replaced_lines(
     if selected_ids != expected_range:
         raise ValueError("Replacement selection must be one contiguous line range")
 
-    replacement_payload = coerce_replacement_payload(replacement_text)
-    replacement_lines = replacement_line_bodies(replacement_payload)
     base_line_count = len(base_lines)
     selected_indices = [
         index
@@ -430,6 +452,30 @@ def build_target_working_tree_buffer_with_replaced_lines(
     trim_unchanged_edge_anchors: bool = True,
 ) -> LineBuffer:
     """Build working tree content by replacing a span in indexed lines."""
+    replacement_payload = coerce_replacement_payload(replacement_text)
+    with replacement_line_bodies(replacement_payload) as replacement_lines:
+        return _build_target_working_tree_buffer_with_replaced_lines(
+            line_changes,
+            replace_ids,
+            replacement_payload,
+            replacement_lines,
+            working_lines,
+            working_has_trailing_newline=working_has_trailing_newline,
+            trim_unchanged_edge_anchors=trim_unchanged_edge_anchors,
+        )
+
+
+def _build_target_working_tree_buffer_with_replaced_lines(
+    line_changes: LineLevelChange,
+    replace_ids: set[int],
+    replacement_payload: ReplacementPayload,
+    replacement_lines: Sequence[bytes],
+    working_lines: Sequence[bytes],
+    *,
+    working_has_trailing_newline: bool,
+    trim_unchanged_edge_anchors: bool,
+) -> LineBuffer:
+    """Build working content while replacement line storage is open."""
     def longest_prefix_context_match(
         candidate_lines: list[bytes],
         context_lines: list[bytes],
@@ -469,8 +515,6 @@ def build_target_working_tree_buffer_with_replaced_lines(
         raise ValueError("Replacement selection must be one contiguous line range")
 
     working_line_count = len(working_lines)
-    replacement_payload = coerce_replacement_payload(replacement_text)
-    replacement_lines = replacement_line_bodies(replacement_payload)
     selected_indices = [
         index
         for index, line in enumerate(line_changes.lines)

--- a/tests/batch/test_replacement.py
+++ b/tests/batch/test_replacement.py
@@ -9,6 +9,7 @@ from git_stage_batch.batch.replacement import (
 from git_stage_batch.core.replacement import (
     ReplacementText,
     coerce_replacement_payload,
+    replacement_line_bodies,
     replacement_line_chunks,
 )
 
@@ -63,4 +64,16 @@ def test_replacement_text_can_carry_exact_stdin_bytes():
         )
     )
 
-    assert replacement_line_chunks(payload) == [b"first\r\n", b"second"]
+    with replacement_line_chunks(payload) as lines:
+        assert list(lines) == [b"first\r\n", b"second"]
+    with replacement_line_bodies(payload) as bodies:
+        assert list(bodies) == [b"first\r", b"second"]
+
+
+def test_legacy_replacement_text_normalizes_line_endings():
+    payload = coerce_replacement_payload("first\r\nsecond")
+
+    with replacement_line_chunks(payload) as lines:
+        assert list(lines) == [b"first\n", b"second\n"]
+    with replacement_line_bodies(payload) as bodies:
+        assert list(bodies) == [b"first", b"second"]


### PR DESCRIPTION
Replacement builders consume exact stdin bodies and legacy normalized text
as indexed byte-line sequences.

The current helpers expand replacement-scale content into lists of separate
byte objects that remain live through batch and staging construction. Large
stdin replacements therefore bypass mapped line storage.

This PR addresses that allocation by exposing scoped LineBuffer sequences
and consuming them within each builder lifetime. Regression coverage pins
exact CRLF bodies, chunked input, and legacy normalization.

Replacement payloads now remain buffer-backed without changing the input
semantics expected by existing callers.
