### PR TITLE
data: Reject stale review-only line ids

### DIFF
--- a/src/git_stage_batch/data/file_review/batch_selection.py
+++ b/src/git_stage_batch/data/file_review/batch_selection.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Iterator, Mapping
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING
 
 from ...batch.file_display import render_batch_file_display
@@ -22,6 +22,27 @@ from .selection_validation import validate_review_scoped_line_selection
 
 if TYPE_CHECKING:
     from ...core.models import RenderedBatchDisplay
+
+
+@dataclass(frozen=True)
+class _SelectionForValidation:
+    display_ids: tuple[int, ...]
+    is_splittable: bool = False
+
+
+def _current_action_selections_for_validation(
+    rendered: 'RenderedBatchDisplay',
+    action: 'FileReviewAction | str',
+) -> list[_SelectionForValidation]:
+    review_action = FileReviewAction(action).value
+    return [
+        _SelectionForValidation(
+            display_ids=group.display_ids,
+            is_splittable=group.reason in {"replacement", "structural-run"},
+        )
+        for group in rendered.review_action_groups
+        if group.display_ids and review_action in group.actions
+    ]
 
 
 def _selection_ids_from_gutter_ids(
@@ -49,8 +70,9 @@ def translate_batch_file_gutter_ids_to_selection_ids(
 
     If the IDs came after a fresh matching file review, validate them against
     the complete actions shown by that review before consulting the full batch
-    display. Without a matching review, keep the historical raw batch display
-    behavior.
+    display. Without a matching review, validate against the current review
+    action groups so reset-only review IDs cannot be reinterpreted as compact
+    mergeable IDs.
     """
     if selected_ids is None:
         return None, None
@@ -60,18 +82,36 @@ def translate_batch_file_gutter_ids_to_selection_ids(
         file_path,
         action,
     )
-    if review_selections is not None:
-        validate_review_scoped_line_selection(selected_ids, review_selections)
-
     rendered = render_batch_file_display(batch_name, file_path)
     if rendered is None:
         return selected_ids, None
 
-    display_id_map = (
-        rendered.review_gutter_to_selection_id or rendered.gutter_to_selection_id
-        if review_selections is not None else
-        rendered.gutter_to_selection_id
-    )
+    selection_ids: set[int] | None = None
+    if review_selections is not None:
+        display_id_map = (
+            rendered.review_gutter_to_selection_id
+            or rendered.gutter_to_selection_id
+        )
+        selection_ids = set(_selection_ids_from_gutter_ids(selected_ids, display_id_map))
+        validate_review_scoped_line_selection(selected_ids, review_selections)
+    else:
+        current_action_selections = _current_action_selections_for_validation(
+            rendered,
+            action,
+        )
+        if current_action_selections:
+            display_id_map = (
+                rendered.review_gutter_to_selection_id
+                or rendered.gutter_to_selection_id
+            )
+            selection_ids = set(_selection_ids_from_gutter_ids(selected_ids, display_id_map))
+            validate_review_scoped_line_selection(
+                selected_ids,
+                current_action_selections,
+            )
+        else:
+            display_id_map = rendered.gutter_to_selection_id
+
     rendered_for_messages = (
         replace(
             rendered,
@@ -84,7 +124,8 @@ def translate_batch_file_gutter_ids_to_selection_ids(
         if review_selections is not None else
         rendered
     )
-    selection_ids = set(_selection_ids_from_gutter_ids(selected_ids, display_id_map))
+    if selection_ids is None:
+        selection_ids = set(_selection_ids_from_gutter_ids(selected_ids, display_id_map))
     return selection_ids, rendered_for_messages
 
 

--- a/tests/commands/test_include_from.py
+++ b/tests/commands/test_include_from.py
@@ -17,6 +17,7 @@ from git_stage_batch.commands.include_from import command_include_from_batch
 from git_stage_batch.commands.show_from import command_show_from_batch
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.batch.file_display import render_batch_file_display
+from git_stage_batch.data.file_review.state import clear_last_file_review_state
 from git_stage_batch.data.session import initialize_abort_state
 from git_stage_batch.exceptions import CommandError
 from git_stage_batch.utils.git_command import run_git_command
@@ -326,6 +327,58 @@ class TestCommandIncludeFromBatch:
         assert index_entry.startswith("100755 ")
         assert tool_path.read_text() == "#!/bin/sh\necho batched\n"
         assert stat.S_IMODE(tool_path.stat().st_mode) & stat.S_IXUSR
+
+    def test_include_from_batch_rejects_reset_only_review_ids_without_cached_review(
+        self,
+        temp_git_repo,
+    ):
+        """Explicit batch line actions must not reinterpret stale review IDs."""
+        prefix = [
+            "class X {\n",
+            "    @Test\n",
+            "    fun presentBefore() {\n",
+            "        assert(\"before\")\n",
+            "    }\n",
+            "\n",
+        ]
+        missing_middle = [
+            "    @Test\n",
+            "    fun missingOne() {\n",
+            "        assert(\"body1\")\n",
+            "    }\n",
+            "\n",
+            "    @Test\n",
+            "    fun missingTwo() {\n",
+            "        assert(\"body2\")\n",
+            "    }\n",
+            "\n",
+        ]
+        suffix = [
+            "    @Test\n",
+            "    fun next() {\n",
+            "        assert(\"next\")\n",
+            "    }\n",
+            *[
+                f"    val filler{index} = {index}\n"
+                for index in range(1, 40)
+            ],
+            "}\n",
+        ]
+        test_file = temp_git_repo / "Test.kt"
+        test_file.write_text("".join([*prefix, *missing_middle, *suffix]))
+        command_start(quiet=True)
+        command_include_to_batch("test-batch", file="Test.kt", quiet=True)
+
+        test_file.write_text("".join([*prefix, *suffix]))
+        subprocess.run(["git", "add", "Test.kt"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Partial"], check=True, cwd=temp_git_repo, capture_output=True)
+        clear_last_file_review_state()
+
+        with pytest.raises(CommandError, match="Line selection #8-14"):
+            command_include_from_batch("test-batch", line_ids="7-16", file="Test.kt")
+
+        assert run_git_command(["diff", "--cached", "--", "Test.kt"]).stdout == ""
+        assert test_file.read_text() == "".join([*prefix, *suffix])
 
     def test_include_from_batch_line_scoped_deleted_text_file_stages_deletion(self, temp_git_repo):
         """Line-scoped include of a full deleted text file should stage path deletion."""


### PR DESCRIPTION
Batch file actions translate explicit line ids from recent reviews or the
current batch display.

A reset review can leave action-only ids whose numeric values overlap the
compact mergeable id map after the review cache is cleared. Include-from can
then stage unrelated edge lines instead of rejecting the stale selection.

This PR addresses that mismatch by validating explicit ids against current
action groups before falling back to raw batch display translation. A
focused added-file regression exercises overlapping reset-only ids.

Action-scoped line selection now rejects stale review ids before mutating
the index.
