### PR TITLE
session: Isolate linked-worktree staging sessions

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -326,6 +326,19 @@ Format fields include `{status}`, `{status_label}`, `{progress_status}`,
 
 ## Session Management
 
+Only one linked worktree in a repository may own an active staging session at
+a time. Session scratch data remains local to its worktree, while batch and
+undo refs are shared by the repository. Mutating commands in another linked
+worktree therefore stop with an error until the owning worktree runs `stop` or
+`abort`. Read-only commands such as `status`, `show`, and `list` remain
+available.
+
+Ownership is released automatically by a successful `stop` or `abort`. If a
+worktree's session marker has already been removed, the next mutating command
+can reclaim the stale ownership record safely. An invalid ownership record is
+not removed automatically; its error identifies the file to inspect after
+confirming that no linked worktree still has an active session.
+
 ### `again`
 
 Clear the blocklist and restart iteration through all hunks.

--- a/src/git_stage_batch/cli/main.py
+++ b/src/git_stage_batch/cli/main.py
@@ -10,9 +10,22 @@ from contextlib import nullcontext
 from ..exceptions import CommandError
 from ..i18n import _
 from ..runtime import dispatch_cli_mode
+from ..data.session_ownership import require_no_foreign_session_owner
 from ..utils.session_lock import acquire_session_lock
 from .argument_parser import parse_command_line
 from .pager import pager_output, should_page_output
+
+
+_READ_ONLY_COMMANDS = frozenset({"check-unstaged", "list", "show", "status"})
+
+
+def _command_may_mutate(args) -> bool:
+    """Return whether dispatch may change worktree-local or shared state."""
+    if getattr(args, "interactive_flag", False):
+        return True
+    if getattr(args, "interactive_command", False):
+        return True
+    return getattr(args, "command", None) not in _READ_ONLY_COMMANDS
 
 
 def main() -> None:
@@ -31,6 +44,8 @@ def main() -> None:
             )
             with pager_context:
                 with lock_context:
+                    if not skip_session_lock and _command_may_mutate(args):
+                        require_no_foreign_session_owner()
                     dispatch_cli_mode(args)
         else:
             # Parsing failed

--- a/src/git_stage_batch/commands/abort.py
+++ b/src/git_stage_batch/commands/abort.py
@@ -8,6 +8,11 @@ import sys
 
 from ..data.batch_refs import restore_batch_refs
 from ..data.session import clear_session_state
+from ..data.session_ownership import (
+    release_session_ownership,
+    require_current_session_owner,
+    require_no_foreign_session_owner,
+)
 from ..data.start_time_changes import read_staged_renames
 from ..exceptions import exit_with_error
 from ..i18n import _
@@ -60,10 +65,12 @@ def _remove_normalized_rename_destinations_before_stash_apply() -> None:
 def command_abort(*, quiet: bool = False) -> None:
     """Abort the session and undo all changes including commits and discards."""
     require_git_repository()
+    require_no_foreign_session_owner()
 
     # Check if abort state exists
     if not get_abort_head_file_path().exists():
         exit_with_error(_("No session to abort. Abort state not found."))
+    require_current_session_owner()
 
     # Read abort state
     abort_head = read_text_file_contents(get_abort_head_file_path()).strip()
@@ -126,6 +133,7 @@ def command_abort(*, quiet: bool = False) -> None:
     # Clear all session state (preserves batches and batch-sources)
     # Do this AFTER restore_batch_refs so snapshot file is available
     clear_session_state()
+    release_session_ownership()
 
     if not quiet:
         print(_("✓ Session aborted. All changes reverted."), file=sys.stderr)

--- a/src/git_stage_batch/commands/start.py
+++ b/src/git_stage_batch/commands/start.py
@@ -8,7 +8,11 @@ from ..data.auto_advance import DEFAULT_AUTO_ADVANCE, write_auto_advance_default
 from ..data.hunk_tracking import fetch_next_change
 from ..data.selected_change.lifecycle import clear_selected_change_state_files
 from ..data.file_tracking import auto_add_untracked_files
-from ..data.session import initialize_abort_state, session_is_active
+from ..data.session import clear_session_state, initialize_abort_state, session_is_active
+from ..data.session_ownership import (
+    claim_session_ownership,
+    require_no_foreign_session_owner,
+)
 from ..data.start_time_changes import (
     normalize_start_time_staged_deletions,
     normalize_start_time_staged_renames,
@@ -37,9 +41,11 @@ def command_start(
     """
     require_git_repository()
     ensure_state_directory_exists()
+    require_no_foreign_session_owner()
 
     # If session already exists, run again logic instead
     if session_is_active():
+        claim_session_ownership()
         if auto_advance is not None:
             write_auto_advance_default(auto_advance)
         restart_iteration_pass(quiet=quiet)
@@ -51,6 +57,13 @@ def command_start(
 
     # Initialize abort state for new session
     initialize_abort_state()
+    try:
+        claim_session_ownership()
+    except BaseException:
+        # The snapshot is worktree-local and has not been published as an
+        # active shared session. Remove it if ownership publication fails.
+        clear_session_state()
+        raise
 
     try:
         # Staged renames and text deletions are already in the index, so a plain

--- a/src/git_stage_batch/commands/stop.py
+++ b/src/git_stage_batch/commands/stop.py
@@ -8,7 +8,12 @@ from ..data.start_time_changes import (
     restore_unstaged_start_time_deletions,
     restore_unstaged_start_time_renames,
 )
-from ..data.session import clear_session_state
+from ..data.session import clear_session_state, session_is_active
+from ..data.session_ownership import (
+    release_session_ownership,
+    require_current_session_owner,
+    require_no_foreign_session_owner,
+)
 from ..i18n import _
 from ..utils.file_io import read_file_paths_file
 from ..utils.git_command import run_git_command
@@ -29,6 +34,10 @@ def _path_has_staged_content(file_path: str) -> bool:
 def command_stop() -> None:
     """Stop the selected batch staging session."""
     require_git_repository()
+    require_no_foreign_session_owner()
+    session_owned = session_is_active()
+    if session_owned:
+        require_current_session_owner()
 
     # Undo auto-added files before clearing state
     auto_added_path = get_auto_added_files_file_path()
@@ -44,5 +53,7 @@ def command_stop() -> None:
 
     # Clear all session state (preserves batches and batch-sources)
     clear_session_state()
+    if session_owned:
+        release_session_ownership()
 
     print(_("✓ State cleared."), file=sys.stderr)

--- a/src/git_stage_batch/data/session.py
+++ b/src/git_stage_batch/data/session.py
@@ -245,8 +245,9 @@ def require_session_started() -> None:
     Raises:
         CommandError: If no session is active
     """
-    if not session_is_active():
-        raise CommandError(_("No session in progress. Run 'git-stage-batch start' first."))
+    from .session_ownership import require_current_session_owner
+
+    require_current_session_owner()
 
 
 def snapshot_file_if_untracked(file_path: str) -> None:

--- a/src/git_stage_batch/data/session_ownership.py
+++ b/src/git_stage_batch/data/session_ownership.py
@@ -1,0 +1,158 @@
+"""Repository-wide ownership for worktree-local staging sessions."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from ..exceptions import CommandError
+from ..i18n import _
+from ..utils.file_io import read_text_file_contents, write_text_file_contents
+from ..utils.git_repository import get_git_directory_path
+from ..utils.paths import (
+    get_active_session_owner_file_path,
+    get_common_state_directory_path,
+)
+from .session import active_session_marker_path, session_is_active
+
+
+@dataclass(frozen=True)
+class SessionOwner:
+    """Identity and marker location for the worktree owning the session."""
+
+    worktree_git_dir: Path
+    marker_path: Path
+    started_at: str
+
+
+def _current_worktree_git_dir() -> Path:
+    return get_git_directory_path().resolve()
+
+
+def _current_owner() -> SessionOwner:
+    git_dir = _current_worktree_git_dir()
+    return SessionOwner(
+        worktree_git_dir=git_dir,
+        marker_path=active_session_marker_path(git_dir).resolve(),
+        started_at=datetime.now(timezone.utc).isoformat(),
+    )
+
+
+def _load_owner() -> SessionOwner | None:
+    owner_path = get_active_session_owner_file_path()
+    if not owner_path.exists():
+        return None
+    try:
+        data = json.loads(read_text_file_contents(owner_path))
+        return SessionOwner(
+            worktree_git_dir=Path(data["worktree_git_dir"]).resolve(),
+            marker_path=Path(data["marker_path"]).resolve(),
+            started_at=str(data["started_at"]),
+        )
+    except (json.JSONDecodeError, KeyError, TypeError, ValueError) as error:
+        raise CommandError(
+            _(
+                "The repository's active-session ownership record is invalid: {path}. "
+                "Inspect or remove it only after confirming no worktree has an active session."
+            ).format(path=owner_path)
+        ) from error
+
+
+def _write_owner(owner: SessionOwner) -> None:
+    write_text_file_contents(
+        get_active_session_owner_file_path(),
+        json.dumps(
+            {
+                "version": 1,
+                "worktree_git_dir": str(owner.worktree_git_dir),
+                "marker_path": str(owner.marker_path),
+                "started_at": owner.started_at,
+            },
+            indent=2,
+            sort_keys=True,
+        ) + "\n",
+    )
+
+
+def _owner_is_current_worktree(owner: SessionOwner) -> bool:
+    return owner.worktree_git_dir == _current_worktree_git_dir()
+
+
+def _discard_stale_owner(owner: SessionOwner) -> bool:
+    """Remove an owner whose worktree-local session marker no longer exists."""
+    if owner.marker_path.exists():
+        return False
+    get_active_session_owner_file_path().unlink(missing_ok=True)
+    return True
+
+
+def _foreign_owner_error(owner: SessionOwner) -> CommandError:
+    return CommandError(
+        _(
+            "Another linked worktree has an active git-stage-batch session "
+            "({git_dir}, started {started_at}). Stop or abort that session before "
+            "mutating shared batch state from this worktree."
+        ).format(
+            git_dir=owner.worktree_git_dir,
+            started_at=owner.started_at,
+        )
+    )
+
+
+def require_no_foreign_session_owner() -> None:
+    """Refuse mutation while a live session belongs to another worktree."""
+    owner = _load_owner()
+    if owner is None or _owner_is_current_worktree(owner):
+        return
+    if _discard_stale_owner(owner):
+        return
+    raise _foreign_owner_error(owner)
+
+
+def claim_session_ownership() -> None:
+    """Publish the current worktree as owner of its completed abort snapshot."""
+    if not session_is_active():
+        raise CommandError(
+            _("Cannot claim session ownership before the recovery snapshot is complete.")
+        )
+    require_no_foreign_session_owner()
+    owner = _load_owner()
+    if owner is not None and _owner_is_current_worktree(owner):
+        return
+    _write_owner(_current_owner())
+
+
+def require_current_session_owner() -> None:
+    """Require the current worktree to own its active session.
+
+    A session created by an older version has no common ownership record. It
+    is claimed lazily while the repository-wide lock is held by normal CLI
+    dispatch.
+    """
+    if not session_is_active():
+        raise CommandError(_("No session in progress. Run 'git-stage-batch start' first."))
+    require_no_foreign_session_owner()
+    owner = _load_owner()
+    if owner is None:
+        _write_owner(_current_owner())
+        return
+    if not _owner_is_current_worktree(owner):
+        raise _foreign_owner_error(owner)
+
+
+def release_session_ownership() -> None:
+    """Remove ownership after the current worktree completes stop or abort."""
+    owner = _load_owner()
+    if owner is None:
+        return
+    if not _owner_is_current_worktree(owner):
+        raise _foreign_owner_error(owner)
+    get_active_session_owner_file_path().unlink(missing_ok=True)
+    common_state_dir = get_common_state_directory_path()
+    try:
+        common_state_dir.rmdir()
+    except OSError:
+        # The common lock, shared state, or another durable file still exists.
+        pass

--- a/src/git_stage_batch/utils/git_repository.py
+++ b/src/git_stage_batch/utils/git_repository.py
@@ -13,6 +13,7 @@ from .git_command import run_git_command
 
 _GIT_REPOSITORY_ROOT_CACHE: dict[Path, Path] = {}
 _GIT_DIRECTORY_CACHE: dict[Path, Path] = {}
+_GIT_COMMON_DIRECTORY_CACHE: dict[Path, Path] = {}
 
 
 def require_git_repository() -> None:
@@ -72,6 +73,26 @@ def get_git_directory_path() -> Path:
     ).stdout.strip()
     path = Path(output)
     _GIT_DIRECTORY_CACHE[cwd] = path
+    return path
+
+
+def get_git_common_directory_path() -> Path:
+    """Get the absolute path to the repository's shared Git directory.
+
+    In a linked worktree this differs from :func:`get_git_directory_path` and
+    identifies the directory that owns shared refs and objects.
+    """
+    cwd = Path.cwd()
+    cached = _GIT_COMMON_DIRECTORY_CACHE.get(cwd)
+    if cached is not None:
+        return cached
+
+    output = run_git_command(
+        ["rev-parse", "--path-format=absolute", "--git-common-dir"],
+        requires_index_lock=False,
+    ).stdout.strip()
+    path = Path(output)
+    _GIT_COMMON_DIRECTORY_CACHE[cwd] = path
     return path
 
 

--- a/src/git_stage_batch/utils/paths.py
+++ b/src/git_stage_batch/utils/paths.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from .file_io import read_text_file_contents
-from .git_repository import get_git_directory_path
+from .git_repository import get_git_common_directory_path, get_git_directory_path
 
 
 def get_state_directory_path() -> Path:
@@ -18,12 +18,27 @@ def get_state_directory_path() -> Path:
 
 
 def get_session_lock_file_path() -> Path:
-    """Get the path to the session lock file.
+    """Get the path to the repository-wide session lock file.
 
     Returns:
         Path to session lock file
     """
-    return get_state_directory_path() / "session.lock"
+    return get_common_state_directory_path() / "session.lock"
+
+
+def get_common_state_directory_path() -> Path:
+    """Get the state directory shared by every linked worktree."""
+    return get_git_common_directory_path() / "git-stage-batch"
+
+
+def get_active_session_owner_file_path() -> Path:
+    """Get the repository-wide active-session ownership record path."""
+    return get_common_state_directory_path() / "active-session.json"
+
+
+def ensure_common_state_directory_exists() -> None:
+    """Create the repository-wide state directory if it does not exist."""
+    get_common_state_directory_path().mkdir(parents=True, exist_ok=True)
 
 
 def ensure_state_directory_exists() -> None:

--- a/src/git_stage_batch/utils/session_lock.py
+++ b/src/git_stage_batch/utils/session_lock.py
@@ -6,7 +6,7 @@ import fcntl
 from contextlib import contextmanager
 from pathlib import Path
 
-from .paths import ensure_state_directory_exists, get_session_lock_file_path
+from .paths import ensure_common_state_directory_exists, get_session_lock_file_path
 
 _LOCK_DEPTH = 0
 _LOCK_HANDLE = None
@@ -30,7 +30,7 @@ def acquire_session_lock():
             _LOCK_DEPTH -= 1
         return
 
-    ensure_state_directory_exists()
+    ensure_common_state_directory_exists()
     lock_path = get_session_lock_file_path()
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     lock_handle = Path(lock_path).open("a+", encoding="utf-8")

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -63,6 +63,45 @@ def test_main_acquires_session_lock_before_dispatch():
     assert events == ["lock-enter", "dispatch", "lock-exit"]
 
 
+def test_main_rejects_mutation_owned_by_another_worktree(capsys):
+    """Foreign ownership is checked before a mutating command dispatches."""
+    args = Namespace(working_directory=None, command="drop")
+
+    with patch.object(sys, "argv", ["git-stage-batch", "drop", "batch"]):
+        with patch.object(main_module, "parse_command_line", return_value=args):
+            with patch.object(main_module, "should_page_output", return_value=False):
+                with patch.object(
+                    main_module,
+                    "require_no_foreign_session_owner",
+                    side_effect=main_module.CommandError("foreign session"),
+                ):
+                    with patch.object(main_module, "dispatch_cli_mode") as dispatch:
+                        with pytest.raises(SystemExit) as exc_info:
+                            main_module.main()
+
+    assert exc_info.value.code == 1
+    assert "foreign session" in capsys.readouterr().err
+    dispatch.assert_not_called()
+
+
+def test_main_allows_read_only_command_with_foreign_owner():
+    """Read-only repository inspection does not require session ownership."""
+    args = Namespace(working_directory=None, command="status")
+
+    with patch.object(sys, "argv", ["git-stage-batch", "status"]):
+        with patch.object(main_module, "parse_command_line", return_value=args):
+            with patch.object(main_module, "should_page_output", return_value=False):
+                with patch.object(
+                    main_module,
+                    "require_no_foreign_session_owner",
+                    side_effect=AssertionError("status must remain readable"),
+                ):
+                    with patch.object(main_module, "dispatch_cli_mode") as dispatch:
+                        main_module.main()
+
+    dispatch.assert_called_once_with(args)
+
+
 def test_main_skips_session_lock_for_prompt_status():
     """Prompt status should not create or lock session state before dispatch."""
     events = []

--- a/tests/data/test_session_ownership.py
+++ b/tests/data/test_session_ownership.py
@@ -1,0 +1,123 @@
+"""Linked-worktree session ownership tests."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from git_stage_batch.commands.abort import command_abort
+from git_stage_batch.commands.start import command_start
+from git_stage_batch.commands.stop import command_stop
+from git_stage_batch.data.session import session_is_active
+from git_stage_batch.data.session_ownership import require_no_foreign_session_owner
+from git_stage_batch.exceptions import CommandError
+from git_stage_batch.utils.paths import get_active_session_owner_file_path
+
+
+@pytest.fixture
+def temp_git_repo(tmp_path, monkeypatch):
+    """Create a committed repository for linked-worktree ownership tests."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.chdir(repo)
+    subprocess.run(["git", "init"], check=True, cwd=repo, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"],
+        check=True,
+        cwd=repo,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        check=True,
+        cwd=repo,
+        capture_output=True,
+    )
+    (repo / "README.md").write_text("# Test\n")
+    subprocess.run(["git", "add", "README.md"], check=True, cwd=repo, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "Initial commit"],
+        check=True,
+        cwd=repo,
+        capture_output=True,
+    )
+    return repo
+
+
+def _add_linked_worktree(repo, path) -> None:
+    subprocess.run(
+        ["git", "worktree", "add", "-b", "linked-session-test", str(path)],
+        check=True,
+        cwd=repo,
+        capture_output=True,
+    )
+
+
+def test_linked_worktree_cannot_start_while_main_worktree_owns_session(
+    temp_git_repo,
+    tmp_path,
+    monkeypatch,
+):
+    """A foreign session is rejected before linked-worktree state is created."""
+    worktree = tmp_path / "linked"
+    _add_linked_worktree(temp_git_repo, worktree)
+    (temp_git_repo / "README.md").write_text("# Test\nmain change\n")
+    command_start(quiet=True)
+    owner_data = json.loads(get_active_session_owner_file_path().read_text())
+
+    monkeypatch.chdir(worktree)
+    (worktree / "README.md").write_text("# Test\nlinked change\n")
+    with pytest.raises(CommandError, match="Another linked worktree"):
+        command_start(quiet=True)
+
+    assert not session_is_active()
+    assert json.loads(get_active_session_owner_file_path().read_text()) == owner_data
+
+    monkeypatch.chdir(temp_git_repo)
+    command_abort(quiet=True)
+
+
+def test_foreign_owner_blocks_stop_and_abort(
+    temp_git_repo,
+    tmp_path,
+    monkeypatch,
+):
+    """A linked worktree cannot clear or restore the owning session."""
+    worktree = tmp_path / "linked"
+    _add_linked_worktree(temp_git_repo, worktree)
+    (temp_git_repo / "README.md").write_text("# Test\nmain change\n")
+    command_start(quiet=True)
+
+    monkeypatch.chdir(worktree)
+    with pytest.raises(CommandError, match="Another linked worktree"):
+        command_stop()
+    with pytest.raises(CommandError, match="Another linked worktree"):
+        command_abort(quiet=True)
+
+    monkeypatch.chdir(temp_git_repo)
+    command_abort(quiet=True)
+
+
+def test_stale_foreign_owner_is_reclaimed(
+    temp_git_repo,
+    tmp_path,
+    monkeypatch,
+):
+    """Ownership becomes reclaimable only after its local marker disappears."""
+    worktree = tmp_path / "linked"
+    _add_linked_worktree(temp_git_repo, worktree)
+    (temp_git_repo / "README.md").write_text("# Test\nmain change\n")
+    command_start(quiet=True)
+    owner_path = get_active_session_owner_file_path()
+
+    # Simulate explicit/manual cleanup of the owning worktree's local marker.
+    marker_path = json.loads(owner_path.read_text())["marker_path"]
+    monkeypatch.chdir(worktree)
+    Path(marker_path).unlink()
+
+    require_no_foreign_session_owner()
+
+    assert not owner_path.exists()

--- a/tests/utils/test_paths.py
+++ b/tests/utils/test_paths.py
@@ -3,6 +3,7 @@
 from git_stage_batch.utils.paths import get_processed_include_ids_file_path
 from git_stage_batch.utils.paths import get_processed_skip_ids_file_path
 from git_stage_batch.utils.paths import get_session_lock_file_path
+from git_stage_batch.utils.paths import get_common_state_directory_path
 from git_stage_batch.utils.paths import get_line_changes_json_file_path
 from git_stage_batch.utils.paths import get_index_snapshot_file_path
 from git_stage_batch.utils.paths import get_working_tree_snapshot_file_path
@@ -98,6 +99,30 @@ class TestGetStateDirectoryPath:
         ensure_state_directory_exists()
 
         assert state_dir.is_dir()
+
+    def test_linked_worktree_uses_shared_common_state_for_lock(
+        self,
+        temp_git_repo,
+        tmp_path,
+        monkeypatch,
+    ):
+        """Linked worktrees share their repository mutation lock."""
+        main_lock = get_session_lock_file_path()
+        worktree = tmp_path / "linked-lock"
+        subprocess.run(
+            ["git", "worktree", "add", str(worktree)],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        monkeypatch.chdir(worktree)
+
+        linked_state = get_state_directory_path()
+        linked_lock = get_session_lock_file_path()
+
+        assert linked_state != temp_git_repo / ".git" / "git-stage-batch"
+        assert get_common_state_directory_path() == temp_git_repo / ".git" / "git-stage-batch"
+        assert linked_lock == main_lock
 
 
 class TestEnsureStateDirectoryExists:


### PR DESCRIPTION
Git-stage-batch keeps session scratch data beside each worktree while batch,
undo, and recovery refs belong to the shared Git repository.

Users of linked worktrees can otherwise start overlapping sessions whose
separate locks allow one worktree to consume or restore state created by
another worktree.

This pull request addresses that race by moving mutation locking to the Git
common directory, publishing an atomic active-worktree owner, enforcing that
ownership at session and CLI mutation boundaries, and releasing it only after
successful stop or abort cleanup.

The linked-worktree session isolation goal is complete, including stale-owner
recovery, read-only command access, command documentation, and regression
coverage across linked worktrees.

Tests:

- `uv run pytest -q` (2987 passed)
- `uv run pytest tests/architecture/test_import_boundaries.py -q` (370 passed)
- Ruff checks for all changed Python files
- `git diff --check origin/main..HEAD`
