### PR TITLE
recovery: Keep session recovery objects reachable

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -1,0 +1,33 @@
+# Storage and Recovery Refs
+
+Git-stage-batch stores durable batch state under `refs/git-stage-batch/` and
+worktree-local session scratch files below the worktree's Git directory.
+
+## Object identifiers are not reachability roots
+
+Session manifests and abort snapshots serialize Git object IDs so state can be
+restored later. An object ID written into JSON is not an edge in Git's object
+graph. If the batch ref that previously named that object moves or is deleted,
+reflog expiration followed by garbage collection may otherwise prune it.
+
+During an active session, git-stage-batch creates internal refs below
+`refs/git-stage-batch/session/anchors/`. Each ref names a commit, tree, or blob
+that an undo, redo, or abort operation promises to restore. Checkpoint stack
+refs describe undo and redo order; anchor refs provide reachability. Those are
+separate responsibilities.
+
+Gitlink entries name commits in a submodule's separate object database. They
+cannot be rooted by refs in the superproject; their availability remains the
+responsibility of the nested repository.
+
+Anchors are created before a checkpoint is published or a command can mutate
+the protected refs. They remain for the session lifetime so every checkpoint
+still present on either stack remains recoverable. A successful `stop` or
+`abort` removes the complete anchor namespace. Reclaiming a stale linked-
+worktree owner also removes the abandoned session's anchors.
+
+Older checkpoints may not contain recorded anchor metadata. Git-stage-batch
+attempts to restore them while their serialized objects remain available. If
+an object has already been pruned, restoration stops before mutation and
+reports the missing recovery object rather than partially applying the
+checkpoint.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,6 +70,7 @@ nav:
     - AI Assistants: ai-assistants.md
   - Advanced Features:
     - Batch Operations: batches.md
+    - Storage and Recovery: storage.md
 
 plugins:
   - search

--- a/src/git_stage_batch/commands/abort.py
+++ b/src/git_stage_batch/commands/abort.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import shutil
 import sys
+import json
 
 from ..data.batch_refs import restore_batch_refs
 from ..data.session import clear_session_state
@@ -13,6 +14,7 @@ from ..data.session_ownership import (
     require_current_session_owner,
     require_no_foreign_session_owner,
 )
+from ..data.recovery_anchors import validate_recovery_objects
 from ..data.start_time_changes import read_staged_renames
 from ..exceptions import exit_with_error
 from ..i18n import _
@@ -37,6 +39,7 @@ from ..utils.paths import (
     get_abort_stash_file_path,
     get_auto_added_files_file_path,
     get_abort_state_directory_path,
+    get_abort_recovery_anchors_file_path,
 )
 
 
@@ -76,6 +79,23 @@ def command_abort(*, quiet: bool = False) -> None:
     abort_head = read_text_file_contents(get_abort_head_file_path()).strip()
     abort_stash_path = get_abort_stash_file_path()
     abort_stash = read_text_file_contents(abort_stash_path).strip() if abort_stash_path.exists() else None
+    recovery_objects = [abort_head, abort_stash]
+    batch_snapshot_path = get_abort_state_directory_path() / "batch-refs.json"
+    try:
+        batch_snapshot = json.loads(read_text_file_contents(batch_snapshot_path))
+    except json.JSONDecodeError:
+        batch_snapshot = {}
+    for batch_state in batch_snapshot.values():
+        recovery_objects.extend(
+            [batch_state.get("commit_sha"), batch_state.get("state_commit_sha")]
+        )
+    try:
+        recovery_anchors = json.loads(
+            read_text_file_contents(get_abort_recovery_anchors_file_path())
+        )
+    except json.JSONDecodeError:
+        recovery_anchors = None
+    validate_recovery_objects(recovery_objects, anchors=recovery_anchors)
 
     # Reset auto-added files first
     if get_auto_added_files_file_path().exists():

--- a/src/git_stage_batch/data/batch_refs.py
+++ b/src/git_stage_batch/data/batch_refs.py
@@ -59,7 +59,7 @@ def _get_batch_state_ref_commit(batch_name: str) -> str | None:
     return result.stdout.strip()
 
 
-def snapshot_batch_refs() -> None:
+def snapshot_batch_refs() -> dict[str, dict[str, Any]]:
     """Save selected state of all batch refs to snapshot file for abort support.
 
     Stores a single JSON object mapping batch names to their state:
@@ -78,6 +78,7 @@ def snapshot_batch_refs() -> None:
         }
 
     write_text_file_contents(get_batch_refs_snapshot_file_path(), json.dumps(snapshot_data, indent=2))
+    return snapshot_data
 
 
 def restore_batch_refs() -> None:

--- a/src/git_stage_batch/data/recovery_anchors.py
+++ b/src/git_stage_batch/data/recovery_anchors.py
@@ -1,0 +1,112 @@
+"""Reachability roots for objects promised by session recovery metadata."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from ..exceptions import CommandError
+from ..i18n import _
+from ..utils.git_command import run_git_command
+from ..utils.git_refs import update_git_refs
+
+
+RECOVERY_ANCHOR_REF_PREFIX = "refs/git-stage-batch/session/anchors/"
+
+
+def recovery_anchor_ref(object_name: str) -> str:
+    """Return the session-lifetime anchor ref for one Git object."""
+    return f"{RECOVERY_ANCHOR_REF_PREFIX}{object_name}"
+
+
+def _existing_object_names(object_names: Iterable[str | None]) -> set[str]:
+    return {name for name in object_names if isinstance(name, str) and name}
+
+
+def state_recovery_objects(state: Mapping[str, Any]) -> set[str]:
+    """Collect object IDs serialized in one undo state mapping."""
+    object_names = _existing_object_names(
+        [state.get("head"), state.get("index_tree"), *state.get("refs", {}).values()]
+    )
+    for entry in state.get("worktree_paths", []):
+        if not isinstance(entry, Mapping):
+            continue
+        # A gitlink's worktree_oid belongs to the nested repository, not this
+        # repository's object database, and cannot be the target of a
+        # superproject ref. Blob IDs are owned by the current repository.
+        object_names.update(_existing_object_names([entry.get("blob")]))
+    return object_names
+
+
+def anchor_recovery_objects(object_names: Iterable[str | None]) -> dict[str, str]:
+    """Create session refs that keep the supplied objects reachable."""
+    objects = sorted(_existing_object_names(object_names))
+    if not objects:
+        return {}
+    anchors = {recovery_anchor_ref(object_name): object_name for object_name in objects}
+    update_git_refs(updates=anchors.items())
+    return anchors
+
+
+def anchor_recovery_state(state: Mapping[str, Any]) -> dict[str, str]:
+    """Anchor every object serialized by an undo/redo state mapping."""
+    return anchor_recovery_objects(state_recovery_objects(state))
+
+
+def validate_recovery_objects(
+    object_names: Iterable[str | None],
+    *,
+    anchors: Mapping[str, str] | None = None,
+) -> None:
+    """Verify recovery objects and any recorded anchor refs before mutation."""
+    expected_objects = sorted(_existing_object_names(object_names))
+    for object_name in expected_objects:
+        result = run_git_command(
+            ["cat-file", "-e", object_name],
+            check=False,
+            requires_index_lock=False,
+        )
+        if result.returncode != 0:
+            raise CommandError(
+                _(
+                    "Recovery object {object_name} is no longer available. "
+                    "The checkpoint was created without a durable reachability root "
+                    "or the repository's recovery refs were removed."
+                ).format(object_name=object_name)
+            )
+
+    for ref_name, object_name in sorted((anchors or {}).items()):
+        result = run_git_command(
+            ["rev-parse", "--verify", ref_name],
+            check=False,
+            requires_index_lock=False,
+        )
+        if result.returncode != 0 or result.stdout.strip() != object_name:
+            raise CommandError(
+                _(
+                    "Recovery anchor {ref_name} is missing or does not name "
+                    "the expected object {object_name}."
+                ).format(ref_name=ref_name, object_name=object_name)
+            )
+
+
+def validate_recovery_state(state: Mapping[str, Any]) -> None:
+    """Validate a current or legacy state mapping before restoring it."""
+    validate_recovery_objects(
+        state_recovery_objects(state),
+        anchors=state.get("recovery_anchors")
+        if isinstance(state.get("recovery_anchors"), Mapping)
+        else None,
+    )
+
+
+def clear_recovery_anchors() -> None:
+    """Delete every object anchor owned by the completed session."""
+    result = run_git_command(
+        ["for-each-ref", "--format=%(refname)", RECOVERY_ANCHOR_REF_PREFIX],
+        check=False,
+        requires_index_lock=False,
+    )
+    if result.returncode != 0:
+        return
+    update_git_refs(deletes=[line for line in result.stdout.splitlines() if line])

--- a/src/git_stage_batch/data/session.py
+++ b/src/git_stage_batch/data/session.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 import shutil
 
 from .batch_refs import snapshot_batch_refs
+from .recovery_anchors import anchor_recovery_objects
 from ..exceptions import CommandError
 from ..i18n import _
 from ..utils.file_io import (
@@ -25,6 +27,7 @@ from ..utils.paths import (
     get_abort_snapshot_list_file_path,
     get_abort_snapshots_directory_path,
     get_abort_stash_file_path,
+    get_abort_recovery_anchors_file_path,
     get_iteration_count_file_path,
     get_state_directory_path,
 )
@@ -235,7 +238,17 @@ def _initialize_abort_state() -> None:
     if stash_result.stdout.strip():
         log_journal("session_stash_created", stash_hash=stash_result.stdout.strip())
 
-    snapshot_batch_refs()
+    batch_snapshot = snapshot_batch_refs()
+    recovery_objects = [abort_head, stash_result.stdout.strip()]
+    for batch_state in batch_snapshot.values():
+        recovery_objects.extend(
+            [batch_state.get("commit_sha"), batch_state.get("state_commit_sha")]
+        )
+    recovery_anchors = anchor_recovery_objects(recovery_objects)
+    write_text_file_contents(
+        get_abort_recovery_anchors_file_path(),
+        json.dumps(recovery_anchors, indent=2, sort_keys=True),
+    )
     write_text_file_contents(get_abort_head_file_path(), abort_head)
 
 

--- a/src/git_stage_batch/data/session_ownership.py
+++ b/src/git_stage_batch/data/session_ownership.py
@@ -84,6 +84,9 @@ def _discard_stale_owner(owner: SessionOwner) -> bool:
     """Remove an owner whose worktree-local session marker no longer exists."""
     if owner.marker_path.exists():
         return False
+    from .recovery_anchors import clear_recovery_anchors
+
+    clear_recovery_anchors()
     get_active_session_owner_file_path().unlink(missing_ok=True)
     return True
 

--- a/src/git_stage_batch/data/undo_checkpoints.py
+++ b/src/git_stage_batch/data/undo_checkpoints.py
@@ -19,7 +19,12 @@ from .undo_refs import (
     current_undo_commit,
     list_restorable_refs,
 )
-from .recovery_anchors import anchor_recovery_state
+from .recovery_anchors import (
+    anchor_recovery_objects,
+    anchor_recovery_state,
+    state_recovery_objects,
+    validate_recovery_state,
+)
 from . import undo_restore as _undo_restore
 from . import undo_worktree as _undo_worktree
 from ..exceptions import CommandError
@@ -354,6 +359,9 @@ def _push_redo_node(
     after_undo: dict[str, Any],
     worktree_entries: list[dict[str, Any]],
 ) -> str:
+    recovery_objects = state_recovery_objects(target)
+    recovery_objects.update(state_recovery_objects(after_undo))
+    recovery_objects.add(undo_checkpoint)
     manifest = {
         "operation": operation,
         "undo_checkpoint": undo_checkpoint,
@@ -368,6 +376,7 @@ def _push_redo_node(
             for entry in worktree_entries
         ],
         "after_undo": after_undo,
+        "recovery_anchors": anchor_recovery_objects(recovery_objects),
     }
 
     parent = current_redo_commit()
@@ -390,6 +399,10 @@ def undo_last_checkpoint(*, force: bool = False) -> str:
         raise CommandError(_("Nothing to undo."))
 
     manifest = _undo_restore.read_json_from_commit(checkpoint, "manifest.json")
+    validate_recovery_state(manifest)
+    after = manifest.get("after")
+    if isinstance(after, dict):
+        validate_recovery_state(after)
     conflicts = _detect_conflicts(manifest)
     if conflicts and not force:
         preview = ", ".join(conflicts[:5])
@@ -466,6 +479,10 @@ def redo_last_checkpoint(*, force: bool = False) -> str:
         raise CommandError(_("Nothing to redo."))
 
     manifest = _undo_restore.read_json_from_commit(redo_node, "manifest.json")
+    validate_recovery_state(manifest)
+    after_undo = manifest.get("after_undo")
+    if isinstance(after_undo, dict):
+        validate_recovery_state(after_undo)
     conflicts = _detect_redo_conflicts(manifest)
     if conflicts and not force:
         preview = ", ".join(conflicts[:5])

--- a/src/git_stage_batch/data/undo_checkpoints.py
+++ b/src/git_stage_batch/data/undo_checkpoints.py
@@ -19,6 +19,7 @@ from .undo_refs import (
     current_undo_commit,
     list_restorable_refs,
 )
+from .recovery_anchors import anchor_recovery_state
 from . import undo_restore as _undo_restore
 from . import undo_worktree as _undo_worktree
 from ..exceptions import CommandError
@@ -132,6 +133,7 @@ def _create_undo_checkpoint(operation: str, *, worktree_paths: list[str] | None 
         worktree_paths
     )
     before = _snapshot_current_state(tracked_worktree_paths)
+    recovery_anchors = anchor_recovery_state(before)
 
     manifest = {
         "operation": operation,
@@ -144,6 +146,7 @@ def _create_undo_checkpoint(operation: str, *, worktree_paths: list[str] | None 
         ],
         "tracked_worktree_paths": tracked_worktree_paths,
         "worktree_path_scope": worktree_path_scope,
+        "recovery_anchors": recovery_anchors,
     }
 
     with temp_git_index() as env:
@@ -215,6 +218,7 @@ def finalize_pending_checkpoint() -> None:
     paths = sorted(paths)
     manifest["after"] = _snapshot_current_state(paths)
     manifest["after"]["worktree_paths"] = manifest["after"]["worktree_paths"]
+    manifest["recovery_anchors"].update(anchor_recovery_state(manifest["after"]))
 
     with temp_git_index() as env:
         git_read_tree(checkpoint, env=env)

--- a/src/git_stage_batch/data/undo_refs.py
+++ b/src/git_stage_batch/data/undo_refs.py
@@ -80,5 +80,8 @@ def clear_redo_history() -> None:
 
 def clear_undo_history() -> None:
     """Clear all undo and redo checkpoints for the current session."""
+    from .recovery_anchors import clear_recovery_anchors
+
     update_git_refs(deletes=[SESSION_UNDO_STACK_REF])
     clear_redo_history()
+    clear_recovery_anchors()

--- a/src/git_stage_batch/utils/paths.py
+++ b/src/git_stage_batch/utils/paths.py
@@ -486,3 +486,8 @@ def get_batch_refs_snapshot_file_path() -> Path:
         Path to batch refs snapshot JSON file
     """
     return get_abort_state_directory_path() / "batch-refs.json"
+
+
+def get_abort_recovery_anchors_file_path() -> Path:
+    """Get the path recording abort recovery anchor refs and object IDs."""
+    return get_abort_state_directory_path() / "recovery-anchors.json"

--- a/tests/functional/test_recovery_gc.py
+++ b/tests/functional/test_recovery_gc.py
@@ -1,0 +1,117 @@
+"""Recovery objects remain available across aggressive Git garbage collection."""
+
+from __future__ import annotations
+
+import subprocess
+
+from .conftest import git_stage_batch
+
+
+def _git(*args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _prepare_session_with_batch(functional_repo, batch_name: str) -> tuple[str, str]:
+    git_stage_batch("new", batch_name)
+    content = _git(
+        "rev-parse", f"refs/git-stage-batch/batches/{batch_name}"
+    ).stdout.strip()
+    state = _git(
+        "rev-parse", f"refs/git-stage-batch/state/{batch_name}"
+    ).stdout.strip()
+    (functional_repo / "README.md").write_text("# changed\n")
+    git_stage_batch("start")
+    return content, state
+
+
+def _prune_unreachable_objects() -> None:
+    _git("reflog", "expire", "--expire=now", "--expire-unreachable=now", "--all")
+    _git("gc", "--prune=now")
+
+
+def _assert_object_exists(object_name: str) -> None:
+    assert _git("cat-file", "-e", object_name, check=False).returncode == 0
+
+
+def test_undo_restores_dropped_batch_after_aggressive_gc(functional_repo):
+    """Undo roots old batch commits even after their public refs are deleted."""
+    content, state = _prepare_session_with_batch(functional_repo, "undo-gc")
+
+    git_stage_batch("drop", "undo-gc")
+    _prune_unreachable_objects()
+
+    _assert_object_exists(content)
+    _assert_object_exists(state)
+    git_stage_batch("undo")
+
+    assert _git(
+        "rev-parse", "refs/git-stage-batch/batches/undo-gc"
+    ).stdout.strip() == content
+    assert _git(
+        "rev-parse", "refs/git-stage-batch/state/undo-gc"
+    ).stdout.strip() == state
+
+
+def test_abort_restores_manually_deleted_batch_after_aggressive_gc(functional_repo):
+    """Abort roots its batch snapshot independently of current batch refs."""
+    content, state = _prepare_session_with_batch(functional_repo, "abort-gc")
+
+    _git("update-ref", "-d", "refs/git-stage-batch/batches/abort-gc")
+    _git("update-ref", "-d", "refs/git-stage-batch/state/abort-gc")
+    _prune_unreachable_objects()
+
+    _assert_object_exists(content)
+    _assert_object_exists(state)
+    git_stage_batch("abort")
+
+    assert _git(
+        "rev-parse", "refs/git-stage-batch/batches/abort-gc"
+    ).stdout.strip() == content
+    assert _git(
+        "rev-parse", "refs/git-stage-batch/state/abort-gc"
+    ).stdout.strip() == state
+    assert not _git(
+        "for-each-ref",
+        "--format=%(refname)",
+        "refs/git-stage-batch/session/anchors/",
+    ).stdout.strip()
+
+
+def test_stop_removes_session_recovery_anchors(functional_repo):
+    """A completed session leaves no internal reachability roots behind."""
+    _prepare_session_with_batch(functional_repo, "cleanup-gc")
+    assert _git(
+        "for-each-ref",
+        "--format=%(refname)",
+        "refs/git-stage-batch/session/anchors/",
+    ).stdout.strip()
+
+    git_stage_batch("stop")
+
+    assert not _git(
+        "for-each-ref",
+        "--format=%(refname)",
+        "refs/git-stage-batch/session/anchors/",
+    ).stdout.strip()
+
+
+def test_abort_refuses_before_mutation_when_an_anchor_is_missing(functional_repo):
+    """A damaged current-format recovery root fails before abort resets HEAD."""
+    content, _state = _prepare_session_with_batch(functional_repo, "damaged-anchor")
+    anchor_ref = f"refs/git-stage-batch/session/anchors/{content}"
+    changed_bytes = (functional_repo / "README.md").read_bytes()
+    _git("update-ref", "-d", anchor_ref)
+
+    result = git_stage_batch("abort", check=False)
+
+    assert result.returncode != 0
+    assert "Recovery anchor" in result.stderr
+    assert (functional_repo / "README.md").read_bytes() == changed_bytes
+
+    _git("update-ref", anchor_ref, content)
+    git_stage_batch("abort")


### PR DESCRIPTION
Git-stage-batch records object identifiers for the commits, trees, and blobs
needed by live abort, undo, and redo operations.

Users can lose that promised recovery state when batch refs move or disappear
and reflog expiration allows Git garbage collection to prune objects named only
by serialized session metadata.

This pull request addresses that risk by anchoring recovery objects under
session-lifetime internal refs, recording and validating those anchors before
restoration, and removing them when sessions complete or stale ownership is
reclaimed.

The recovery durability goal is complete with destructive garbage-collection
coverage, safe failure for damaged and legacy recovery data, submodule object-
ownership documentation, and a discoverable storage guide.

Tests:

- `uv run pytest -q` (2991 passed)
- `uv run pytest tests/architecture/test_import_boundaries.py -q` (370 passed)
- `uv run pytest tests/commands/test_submodule_pointers.py -q` (31 passed)
- `uv run mkdocs build --strict`
- Ruff checks for all changed Python files
- `git diff --check origin/main..HEAD`
