### PR TITLE
repository: Support SHA-256 object formats

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,3 +75,39 @@ jobs:
           uv venv /tmp/test-install
           uv pip install --python /tmp/test-install/bin/python dist/*.whl
           /tmp/test-install/bin/git-stage-batch --help
+
+  sha256-repository:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure git identity
+        run: |
+          git config --global user.name "CI"
+          git config --global user.email "ci@test"
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y gettext
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Set up Python
+        run: uv python install 3.10
+
+      - name: Install dependencies
+        run: uv sync --all-groups
+
+      - name: Report Git object-format support
+        run: |
+          git --version
+          probe=$(mktemp -d)
+          if git init --object-format=sha256 "$probe"; then
+            git -C "$probe" rev-parse --show-object-format
+          else
+            echo "Installed Git does not support SHA-256 repositories"
+          fi
+
+      - name: Run SHA-256 repository workflows
+        run: uv run pytest -n auto tests/functional/test_sha256_repository.py

--- a/src/git_stage_batch/commands/block_file.py
+++ b/src/git_stage_batch/commands/block_file.py
@@ -6,7 +6,7 @@ import sys
 from contextlib import nullcontext
 from pathlib import Path
 
-from ..data.session import session_is_active
+from ..data.session import path_is_intent_to_add, session_is_active
 from ..data.undo_checkpoints import undo_checkpoint
 from ..data.ignore_files import (
     add_file_to_local_exclude,
@@ -29,9 +29,6 @@ from ..utils.paths import (
 from .selection.action_completion import advance_to_and_show_next_change
 
 
-EMPTY_BLOB_HASH = "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"
-
-
 def _is_new_intent_to_add_file(file_path: str) -> bool:
     """Return True when file_path is an intent-to-add entry absent from HEAD."""
     stage_result = run_git_command(["ls-files", "--stage", "--", file_path], check=False, requires_index_lock=False)
@@ -39,8 +36,7 @@ def _is_new_intent_to_add_file(file_path: str) -> bool:
     if not stage_output:
         return False
 
-    parts = stage_output.split()
-    if len(parts) < 2 or parts[1] != EMPTY_BLOB_HASH:
+    if not path_is_intent_to_add(file_path):
         return False
 
     head_check = run_git_command(["cat-file", "-e", f"HEAD:{file_path}"], check=False, requires_index_lock=False)

--- a/src/git_stage_batch/core/empty_file_diff.py
+++ b/src/git_stage_batch/core/empty_file_diff.py
@@ -3,16 +3,16 @@
 from __future__ import annotations
 
 
-EMPTY_BLOB_SHORT_HASH = b"e69de29"
 NEW_FILE_MODE_MARKER = b"new file mode"
 SYNTHETIC_EMPTY_HUNK_HEADER = b"@@ -0,0 +0,0 @@"
 
 
 def metadata_indicates_new_empty_file(metadata_lines: list[bytes]) -> bool:
     """Return whether diff metadata describes a newly added empty file."""
-    is_new_file = any(NEW_FILE_MODE_MARKER in line for line in metadata_lines)
-    is_empty = any(EMPTY_BLOB_SHORT_HASH in line for line in metadata_lines)
-    return is_new_file and is_empty
+    # The parser calls this only after observing that the file has no text
+    # hunks and after binary changes have been handled. A newly created file
+    # in that state is empty regardless of the repository's hash algorithm.
+    return any(NEW_FILE_MODE_MARKER in line for line in metadata_lines)
 
 
 def synthetic_empty_file_patch_lines(

--- a/src/git_stage_batch/data/session.py
+++ b/src/git_stage_batch/data/session.py
@@ -90,16 +90,25 @@ def _diff_index_name_status(*, intent_to_add_visible: bool) -> dict[str, str]:
     return dict(zip(fields[1::2], fields[0::2]))
 
 
-def _intent_to_add_files() -> list[str]:
+def _intent_to_add_files(file_paths: list[str] | None = None) -> list[str]:
     """Return paths whose cached status changes with Git's intent visibility."""
     visible_statuses = _diff_index_name_status(intent_to_add_visible=True)
     invisible_statuses = _diff_index_name_status(intent_to_add_visible=False)
     candidate_paths = visible_statuses.keys() | invisible_statuses.keys()
-    return sorted(
+    intent_paths = sorted(
         file_path
         for file_path in candidate_paths
         if visible_statuses.get(file_path) != invisible_statuses.get(file_path)
     )
+    if file_paths is None:
+        return intent_paths
+    selected = set(file_paths)
+    return [file_path for file_path in intent_paths if file_path in selected]
+
+
+def path_is_intent_to_add(file_path: str) -> bool:
+    """Return whether one path is represented by an intent-to-add entry."""
+    return bool(_intent_to_add_files([file_path]))
 
 
 def _snapshot_intent_to_add_files() -> tuple[list[str], list[str]]:
@@ -118,7 +127,7 @@ def _snapshot_intent_to_add_files() -> tuple[list[str], list[str]]:
     new_intent_to_add_files = []
 
     for file_path in all_intent_to_add_files:
-        snapshot_file_if_untracked(file_path)
+        snapshot_file_if_untracked(file_path, intent_to_add=True)
 
         # Only new files absent from HEAD are safe to git rm --cached.
         head_check = run_git_command(
@@ -263,18 +272,16 @@ def require_session_started() -> None:
     require_current_session_owner()
 
 
-def snapshot_file_if_untracked(file_path: str) -> None:
+def snapshot_file_if_untracked(
+    file_path: str,
+    *,
+    intent_to_add: bool | None = None,
+) -> None:
     """Snapshot an untracked file before modification for abort functionality.
 
     Args:
         file_path: Repository-relative path to the file
     """
-    # Check index status using git ls-files --stage
-    # - Not in output: untracked (should snapshot)
-    # - Empty blob hash (e69de29...): intent-to-add (should snapshot)
-    # - Real blob hash: tracked with content (don't snapshot)
-    EMPTY_BLOB_HASH = "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"
-
     stage_result = run_git_command(
         ["ls-files", "--stage", "--", file_path],
         check=False,
@@ -284,13 +291,13 @@ def snapshot_file_if_untracked(file_path: str) -> None:
         # File not in index at all - it's untracked
         pass  # Continue to snapshot
     else:
-        # File is in index - check if it has real content or is intent-to-add
-        # Format: <mode> <hash> <stage>\t<path>
-        parts = stage_result.stdout.strip().split()
-        if len(parts) >= 2:
-            blob_hash = parts[1]
-            if blob_hash != EMPTY_BLOB_HASH:
-                return  # File has real content in index, don't snapshot
+        is_intent_to_add = (
+            path_is_intent_to_add(file_path)
+            if intent_to_add is None
+            else intent_to_add
+        )
+        if not is_intent_to_add:
+            return  # File has real content in index, don't snapshot
 
     # Check if already snapshotted
     snapshotted_files = read_file_paths_file(get_abort_snapshot_list_file_path())
@@ -322,7 +329,7 @@ def snapshot_files_if_untracked(file_paths: list[str]) -> None:
     if not unique_file_paths:
         return
 
-    empty_blob_hash = "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"
+    intent_to_add_paths = set(_intent_to_add_files(unique_file_paths))
     stage_result = run_git_command(
         ["ls-files", "--stage", "-z", "--", *unique_file_paths],
         check=False,
@@ -331,7 +338,6 @@ def snapshot_files_if_untracked(file_paths: list[str]) -> None:
     )
 
     tracked_real_content: set[str] = set()
-    tracked_empty_content: set[str] = set()
     for record in stage_result.stdout.split(b"\0"):
         if not record:
             continue
@@ -343,10 +349,7 @@ def snapshot_files_if_untracked(file_paths: list[str]) -> None:
         if len(parts) < 2:
             continue
         file_path = path_bytes.decode("utf-8")
-        blob_hash = parts[1].decode("ascii", errors="replace")
-        if blob_hash == empty_blob_hash:
-            tracked_empty_content.add(file_path)
-        else:
+        if file_path not in intent_to_add_paths:
             tracked_real_content.add(file_path)
 
     snapshotted_files = set(read_file_paths_file(get_abort_snapshot_list_file_path()))

--- a/src/git_stage_batch/utils/git_index.py
+++ b/src/git_stage_batch/utils/git_index.py
@@ -10,6 +10,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 
 from .git_command import run_git_command, stream_git_command
+from .git_repository import null_object_id
 
 
 @dataclass(frozen=True)
@@ -118,13 +119,18 @@ def git_update_index_entries(
 ) -> None:
     """Update several index entries through one update-index process."""
     payload_chunks: list[bytes] = []
+    null_oid: bytes | None = None
     for entry in entries:
         path_bytes = entry.file_path.encode("utf-8")
         if entry.force_remove:
             if entry.mode is not None or entry.blob_sha is not None:
                 raise ValueError("mode and blob_sha cannot be used with force_remove=True")
+            if null_oid is None:
+                null_oid = null_object_id().encode("ascii")
             payload_chunks.extend([
-                b"0 0000000000000000000000000000000000000000\t",
+                b"0 ",
+                null_oid,
+                b"\t",
                 path_bytes,
                 b"\0",
             ])

--- a/src/git_stage_batch/utils/git_object_io.py
+++ b/src/git_stage_batch/utils/git_object_io.py
@@ -26,7 +26,7 @@ def create_git_blob(content_chunks: Iterable[bytes]) -> str:
         content_chunks: Iterable yielding binary content chunks to store
 
     Returns:
-        SHA-1 hash of the created blob object
+        Repository-native object ID of the created blob object
 
     Raises:
         RuntimeError: If git hash-object fails or produces no output
@@ -98,7 +98,7 @@ def read_git_blob(blob_sha: str) -> Iterator[bytes]:
     """Read a git blob object as a stream.
 
     Args:
-        blob_sha: SHA-1 hash of the blob to read
+        blob_sha: Repository-native object ID of the blob to read
 
     Yields:
         Binary chunks from the blob content

--- a/src/git_stage_batch/utils/git_repository.py
+++ b/src/git_stage_batch/utils/git_repository.py
@@ -14,6 +14,7 @@ from .git_command import run_git_command
 _GIT_REPOSITORY_ROOT_CACHE: dict[Path, Path] = {}
 _GIT_DIRECTORY_CACHE: dict[Path, Path] = {}
 _GIT_COMMON_DIRECTORY_CACHE: dict[Path, Path] = {}
+_GIT_OBJECT_FORMAT_CACHE: dict[Path, str] = {}
 
 
 def require_git_repository() -> None:
@@ -94,6 +95,37 @@ def get_git_common_directory_path() -> Path:
     path = Path(output)
     _GIT_COMMON_DIRECTORY_CACHE[cwd] = path
     return path
+
+
+def get_git_object_format() -> str:
+    """Return the repository object format reported by Git."""
+    cwd = Path.cwd()
+    cached = _GIT_OBJECT_FORMAT_CACHE.get(cwd)
+    if cached is not None:
+        return cached
+
+    object_format = run_git_command(
+        ["rev-parse", "--show-object-format"],
+        requires_index_lock=False,
+    ).stdout.strip()
+    if object_format not in {"sha1", "sha256"}:
+        raise CommandError(
+            _("Unsupported Git object format: {object_format}").format(
+                object_format=object_format or _("unknown")
+            )
+        )
+    _GIT_OBJECT_FORMAT_CACHE[cwd] = object_format
+    return object_format
+
+
+def object_id_hex_length() -> int:
+    """Return the full hexadecimal object-ID width for this repository."""
+    return 40 if get_git_object_format() == "sha1" else 64
+
+
+def null_object_id() -> str:
+    """Return Git's all-zero object ID at the repository's native width."""
+    return "0" * object_id_hex_length()
 
 
 def resolve_file_path_to_repo_relative(file_path: str) -> str:

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -922,7 +922,6 @@ def test_empty_file_diff_owns_empty_file_parser_helpers():
         "synthetic_empty_file_patch_lines",
     }
     helper_constants = {
-        "EMPTY_BLOB_SHORT_HASH",
         "NEW_FILE_MODE_MARKER",
     }
     diff_imports = {}

--- a/tests/core/test_empty_file_diff.py
+++ b/tests/core/test_empty_file_diff.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 from git_stage_batch.core import empty_file_diff
 
 
-def test_new_empty_file_metadata_detection_requires_mode_and_empty_blob():
-    """New empty file metadata should require both path creation and empty blob."""
+def test_new_empty_file_metadata_detection_uses_new_file_mode_without_digest():
+    """A no-hunk new file is empty without inspecting its hash algorithm."""
     assert empty_file_diff.metadata_indicates_new_empty_file(
         [b"new file mode 100644", b"index 0000000..e69de29"]
     )
-    assert not empty_file_diff.metadata_indicates_new_empty_file(
+    assert empty_file_diff.metadata_indicates_new_empty_file(
         [b"new file mode 100644", b"index 0000000..1111111"]
     )
     assert not empty_file_diff.metadata_indicates_new_empty_file(

--- a/tests/functional/test_sha256_repository.py
+++ b/tests/functional/test_sha256_repository.py
@@ -40,6 +40,17 @@ def sha256_repo(tmp_path, monkeypatch):
     return repo
 
 
+def test_new_empty_file_can_be_selected_and_staged(sha256_repo):
+    """SHA-256 empty-blob metadata should produce an empty-file selection."""
+    empty_file = sha256_repo / "empty.txt"
+    empty_file.write_bytes(b"")
+
+    git_stage_batch("start")
+    git_stage_batch("include", "--file", "empty.txt")
+
+    assert _git("diff", "--cached", "--name-only").stdout == "empty.txt\n"
+
+
 def test_intent_to_add_survives_start_and_abort(sha256_repo):
     """Intent-to-add detection should not depend on SHA-1's empty blob ID."""
     intent_file = sha256_repo / "intent.txt"

--- a/tests/functional/test_sha256_repository.py
+++ b/tests/functional/test_sha256_repository.py
@@ -75,3 +75,26 @@ def test_block_file_removes_sha256_intent_to_add_entry(sha256_repo):
 
     assert _git("ls-files", "generated.log").stdout == ""
     assert "generated.log" in (sha256_repo / ".gitignore").read_text()
+
+
+def test_batch_drop_undo_and_abort_use_sha256_objects(sha256_repo):
+    """Batch lifecycle and recovery should preserve native-width object IDs."""
+    git_stage_batch("new", "native")
+    original = _git(
+        "rev-parse", "refs/git-stage-batch/state/native"
+    ).stdout.strip()
+    assert len(original) == 64
+    (sha256_repo / "README.md").write_text("one\ntwo\n")
+    git_stage_batch("start")
+
+    git_stage_batch("drop", "native")
+    git_stage_batch("undo")
+    assert _git(
+        "rev-parse", "refs/git-stage-batch/state/native"
+    ).stdout.strip() == original
+
+    git_stage_batch("drop", "native")
+    git_stage_batch("abort")
+    assert _git(
+        "rev-parse", "refs/git-stage-batch/state/native"
+    ).stdout.strip() == original

--- a/tests/functional/test_sha256_repository.py
+++ b/tests/functional/test_sha256_repository.py
@@ -1,0 +1,54 @@
+"""End-to-end workflows in repositories using SHA-256 object IDs."""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from .conftest import git_stage_batch
+
+
+def _git(*args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.fixture
+def sha256_repo(tmp_path, monkeypatch):
+    """Create a committed SHA-256 repository."""
+    repo = tmp_path / "sha256-repo"
+    result = subprocess.run(
+        ["git", "init", "--object-format=sha256", str(repo)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        pytest.skip(f"installed Git lacks SHA-256 repository support: {result.stderr}")
+    monkeypatch.chdir(repo)
+    _git("config", "user.name", "Test User")
+    _git("config", "user.email", "test@example.com")
+    (repo / "README.md").write_text("one\n")
+    _git("add", "README.md")
+    _git("commit", "-m", "Initial commit")
+    assert _git("rev-parse", "--show-object-format").stdout.strip() == "sha256"
+    return repo
+
+
+def test_intent_to_add_survives_start_and_abort(sha256_repo):
+    """Intent-to-add detection should not depend on SHA-1's empty blob ID."""
+    intent_file = sha256_repo / "intent.txt"
+    intent_file.write_text("new\n")
+    _git("add", "-N", "intent.txt")
+
+    git_stage_batch("start")
+    entry = _git("ls-files", "--stage", "intent.txt").stdout.split()[1]
+    assert len(entry) == 64
+    git_stage_batch("abort")
+
+    assert _git("status", "--porcelain", "--", "intent.txt").stdout == " A intent.txt\n"

--- a/tests/functional/test_sha256_repository.py
+++ b/tests/functional/test_sha256_repository.py
@@ -63,3 +63,15 @@ def test_intent_to_add_survives_start_and_abort(sha256_repo):
     git_stage_batch("abort")
 
     assert _git("status", "--porcelain", "--", "intent.txt").stdout == " A intent.txt\n"
+
+
+def test_block_file_removes_sha256_intent_to_add_entry(sha256_repo):
+    """Blocking an auto-added file should recognize native intent metadata."""
+    generated = sha256_repo / "generated.log"
+    generated.write_text("generated\n")
+
+    git_stage_batch("start")
+    git_stage_batch("block-file", "generated.log")
+
+    assert _git("ls-files", "generated.log").stdout == ""
+    assert "generated.log" in (sha256_repo / ".gitignore").read_text()

--- a/tests/utils/test_git_index.py
+++ b/tests/utils/test_git_index.py
@@ -10,6 +10,8 @@ from git_stage_batch.utils.git_index import (
     git_commit_tree,
     git_read_tree,
     git_update_index,
+    git_update_index_entries,
+    GitIndexEntryUpdate,
     git_write_tree,
     temp_git_index,
 )
@@ -119,6 +121,28 @@ class TestGitIndexPlumbing:
 
         assert result.returncode != 0
         assert run_git_command(["status", "--short"]).stdout == ""
+
+    def test_batched_force_remove_uses_repository_object_width(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        """Index-info removal should use a SHA-256-width null object ID."""
+        repo = tmp_path / "sha256-index"
+        subprocess.run(
+            ["git", "init", "--object-format=sha256", str(repo)],
+            check=True,
+            capture_output=True,
+        )
+        monkeypatch.chdir(repo)
+        (repo / "tracked.txt").write_text("tracked\n")
+        subprocess.run(["git", "add", "tracked.txt"], check=True, cwd=repo)
+
+        git_update_index_entries(
+            [GitIndexEntryUpdate(file_path="tracked.txt", force_remove=True)]
+        )
+
+        assert run_git_command(["ls-files", "tracked.txt"]).stdout == ""
 
     def test_update_index_rejects_ambiguous_modes(self, temp_git_repo):
         """Test that update-index helper modes are explicit."""

--- a/tests/utils/test_git_repository_object_format.py
+++ b/tests/utils/test_git_repository_object_format.py
@@ -1,0 +1,34 @@
+"""Repository object-format discovery tests."""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from git_stage_batch.utils.git_repository import (
+    get_git_object_format,
+    null_object_id,
+    object_id_hex_length,
+)
+
+
+@pytest.mark.parametrize(("object_format", "width"), [("sha1", 40), ("sha256", 64)])
+def test_repository_object_format_controls_oid_width(
+    tmp_path,
+    monkeypatch,
+    object_format,
+    width,
+):
+    """Object helpers should follow the format selected by git init."""
+    repo = tmp_path / object_format
+    subprocess.run(
+        ["git", "init", f"--object-format={object_format}", str(repo)],
+        check=True,
+        capture_output=True,
+    )
+    monkeypatch.chdir(repo)
+
+    assert get_git_object_format() == object_format
+    assert object_id_hex_length() == width
+    assert null_object_id() == "0" * width


### PR DESCRIPTION
Git-stage-batch passes repository object IDs through Git plumbing while several
staging paths construct null IDs or interpret index and diff metadata.

Users of SHA-256 repositories encounter invalid index-removal records, missed
empty-file selections, and incorrectly classified intent-to-add entries where
those paths assume SHA-1 digest values or widths.

This pull request addresses those failures by discovering the native object
format, generating format-correct null IDs, using Git visibility semantics for
intent-to-add state, and recognizing empty additions without inspecting a
digest.

The SHA-256 compatibility goal is complete with end-to-end coverage for empty
files, intent-to-add recovery, block-file, batch deletion, undo, and abort, plus
a dedicated CI job that reports and exercises installed Git support.

Tests:

- `uv run pytest -q` (2998 passed)
- `uv run pytest tests/architecture/test_import_boundaries.py -q` (370 passed)
- Focused lifecycle and object-format suite (106 passed)
- Final intent/object-format regression set (16 passed)
- Ruff checks for all changed Python files
- `git diff --check origin/main..HEAD`
