### PR TITLE
session: Support staging before the first commit

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -339,6 +339,14 @@ can reclaim the stale ownership record safely. An invalid ownership record is
 not removed automatically; its error identifies the file to inspect after
 confirming that no linked worktree still has an active session.
 
+A session can start before the repository has its first commit. In that case,
+Git's empty tree is used only as the staging comparison baseline while the
+unborn symbolic branch and initial index are recorded explicitly. `stop`
+preserves a first commit created during the session. `abort` removes that
+session-created branch tip, restores the original index, and leaves original
+first-commit files in the worktree. History-dependent commands such as
+`suggest-fixup` remain unavailable until the first commit exists.
+
 ### `again`
 
 Clear the blocklist and restart iteration through all hunks.

--- a/src/git_stage_batch/batch/content_commits.py
+++ b/src/git_stage_batch/batch/content_commits.py
@@ -11,6 +11,7 @@ from ..utils.git_index import (
     git_write_tree,
     temp_git_index,
 )
+from ..utils.git_object_io import get_git_object_type
 from .query import get_batch_baseline_commit, get_batch_commit_sha
 from .state_refs import read_file_backed_batch_metadata, sync_batch_state_refs
 
@@ -19,7 +20,7 @@ def batch_content_commit_parents(batch_name: str) -> list[str]:
     """Return parent commits for a batch content commit."""
     parents = []
     baseline = get_batch_baseline_commit(batch_name)
-    if baseline:
+    if baseline and get_git_object_type(baseline) == "commit":
         parents.append(baseline)
 
     metadata = read_file_backed_batch_metadata(batch_name)

--- a/src/git_stage_batch/batch/lifecycle.py
+++ b/src/git_stage_batch/batch/lifecycle.py
@@ -13,6 +13,7 @@ from ..i18n import _
 from ..utils.file_io import write_text_file_contents
 from ..utils.git_command import run_git_command
 from ..utils.git_index import git_commit_tree
+from ..utils.git_object_io import get_empty_git_tree_object_id, get_git_object_type
 from ..utils.paths import get_batch_directory_path, get_batch_metadata_file_path
 
 
@@ -31,7 +32,11 @@ def create_batch(name: str, note: str = "", baseline_commit: str | None = None) 
     # Determine baseline (selected HEAD or caller-provided baseline)
     if baseline_commit is None:
         head_result = run_git_command(["rev-parse", "--verify", "HEAD"], check=False, requires_index_lock=False)
-        baseline_commit = head_result.stdout.strip() if head_result.returncode == 0 else None
+        baseline_commit = (
+            head_result.stdout.strip()
+            if head_result.returncode == 0
+            else get_empty_git_tree_object_id()
+        )
 
     metadata = {
         "note": note,
@@ -42,16 +47,10 @@ def create_batch(name: str, note: str = "", baseline_commit: str | None = None) 
     metadata_path = get_batch_metadata_file_path(name)
     write_text_file_contents(metadata_path, json.dumps(metadata, indent=2))
 
-    if baseline_commit:
-        tree_result = run_git_command(["rev-parse", f"{baseline_commit}^{{tree}}"], requires_index_lock=False)
-        tree_sha = tree_result.stdout.strip()
-
-        commit_sha = git_commit_tree(tree_sha, parents=[baseline_commit], message=f"Batch: {name}")
-    else:
-        tree_result = run_git_command(["hash-object", "-t", "tree", "/dev/null"], requires_index_lock=False)
-        tree_sha = tree_result.stdout.strip()
-
-        commit_sha = git_commit_tree(tree_sha, message=f"Batch: {name}")
+    tree_result = run_git_command(["rev-parse", f"{baseline_commit}^{{tree}}"], requires_index_lock=False)
+    tree_sha = tree_result.stdout.strip()
+    parents = [baseline_commit] if get_git_object_type(baseline_commit) == "commit" else []
+    commit_sha = git_commit_tree(tree_sha, parents=parents, message=f"Batch: {name}")
 
     from .state_refs import sync_batch_state_refs
     sync_batch_state_refs(name, content_commit=commit_sha)

--- a/src/git_stage_batch/batch/metadata_validation.py
+++ b/src/git_stage_batch/batch/metadata_validation.py
@@ -112,12 +112,12 @@ def validate_batch_metadata_structure(metadata: dict[str, Any], batch_name: str)
     baseline = metadata.get("baseline")
     if baseline is None:
         raise BatchMetadataError(
-            _("Batch '{name}' has no baseline commit.\n"
+            _("Batch '{name}' has no baseline object.\n"
               "The batch metadata exists but baseline is null or missing.\n"
               "This indicates corrupted or incomplete batch state.").format(name=batch_name)
         )
 
-    # Validate baseline commit is a valid git object
+    # A normal batch uses a commit; a no-history batch uses the empty tree.
     if baseline:
         result = run_git_command(
             ["cat-file", "-e", baseline],
@@ -126,8 +126,8 @@ def validate_batch_metadata_structure(metadata: dict[str, Any], batch_name: str)
         )
         if result.returncode != 0:
             raise BatchMetadataError(
-                _("Batch '{name}' has invalid baseline commit: {baseline}\n"
-                  "The baseline commit does not exist in the repository.\n"
+                _("Batch '{name}' has invalid baseline object: {baseline}\n"
+                  "The baseline object does not exist in the repository.\n"
                   "The batch metadata may be corrupted.").format(
                     name=batch_name,
                     baseline=baseline
@@ -267,7 +267,7 @@ def require_batch_metadata_sane(batch_name: str) -> None:
 
 
 def get_validated_baseline_commit(batch_name: str) -> str:
-    """Get baseline commit for a batch with validation.
+    """Get the commit-or-tree baseline for a batch with validation.
 
     This is a helper for commands that require a valid baseline commit.
     It validates metadata structure and ensures baseline is present.
@@ -276,7 +276,7 @@ def get_validated_baseline_commit(batch_name: str) -> str:
         batch_name: Name of the batch
 
     Returns:
-        Baseline commit SHA (guaranteed non-None)
+        Baseline object ID (guaranteed non-None)
 
     Raises:
         BatchMetadataError: If metadata is missing, corrupted, or baseline is None

--- a/src/git_stage_batch/batch/source_snapshots.py
+++ b/src/git_stage_batch/batch/source_snapshots.py
@@ -6,9 +6,10 @@ import os
 import stat
 import tempfile
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 from ..core.buffer import LineBuffer
+from ..utils.session_start_point import load_session_start_point
 from ..utils.repository_buffers import (
     load_working_tree_file_as_buffer,
 )
@@ -29,9 +30,7 @@ from ..utils.git_index import (
 from ..utils.git_repository import get_git_repository_root_path
 from ..utils.git_object_io import create_git_blob
 from ..utils.journal import log_journal
-from ..utils.paths import (
-    get_abort_head_file_path,
-)
+from ..utils.paths import get_abort_head_file_path
 from .source_buffers import (
     load_saved_session_file_as_buffer as _load_saved_session_file_as_buffer,
     read_session_file_buffers as _read_session_file_buffers,
@@ -84,11 +83,36 @@ def create_batch_source_commits(file_paths: list[str]) -> dict[str, BatchSourceC
     if not unique_file_paths:
         return {}
 
-    baseline_commit = read_text_file_contents(get_abort_head_file_path()).strip()
+    start_point = load_session_start_point()
+    abort_head = read_text_file_contents(get_abort_head_file_path()).strip()
+    if abort_head != "UNBORN":
+        start_point = replace(
+            start_point,
+            head_commit=abort_head,
+            symbolic_head=None,
+        )
+    baseline_commit = start_point.head_commit or start_point.index_tree
     file_buffers, files_existing_at_session_start = _read_session_file_buffers(
         unique_file_paths,
         baseline_commit=baseline_commit,
     )
+
+    if start_point.is_unborn:
+        try:
+            return {
+                file_path: BatchSourceCommit(
+                    commit_sha=create_batch_source_commit(
+                        file_path,
+                        file_buffer_override=file_buffers[file_path],
+                    ),
+                    file_buffer=file_buffers[file_path],
+                )
+                for file_path in unique_file_paths
+            }
+        except Exception:
+            for buffer in file_buffers.values():
+                buffer.close()
+            raise
 
     return_file_buffers = False
     try:
@@ -234,12 +258,20 @@ def create_batch_source_commit(
     Raises:
         CommandError: If batch source commit cannot be created
     """
-    # Get baseline commit (HEAD at session start)
-    baseline_commit = read_text_file_contents(get_abort_head_file_path()).strip()
+    start_point = load_session_start_point()
+    abort_head = read_text_file_contents(get_abort_head_file_path()).strip()
+    if abort_head != "UNBORN":
+        start_point = replace(
+            start_point,
+            head_commit=abort_head,
+            symbolic_head=None,
+        )
+    baseline_commit = start_point.head_commit
+    baseline_treeish = baseline_commit or start_point.index_tree
 
     # Check if file existed at session start
     baseline_result = run_git_command(
-        ["cat-file", "-e", f"{baseline_commit}:{file_path}"],
+        ["cat-file", "-e", f"{baseline_treeish}:{file_path}"],
         check=False,
         requires_index_lock=False,
     )
@@ -295,13 +327,13 @@ def create_batch_source_commit(
         mode = "100644"
 
     with temp_git_index() as env:
-        git_read_tree(baseline_commit, env=env)
+        git_read_tree(baseline_treeish, env=env)
         git_update_index(mode=mode, blob_sha=blob_sha, file_path=file_path, env=env)
         new_tree = git_write_tree(env=env)
 
     batch_source_commit = git_commit_tree(
         new_tree,
-        parents=[baseline_commit],
+        parents=[baseline_commit] if baseline_commit else [],
         message=f"Batch source for {file_path}",
     )
 

--- a/src/git_stage_batch/commands/abort.py
+++ b/src/git_stage_batch/commands/abort.py
@@ -15,6 +15,7 @@ from ..data.session_ownership import (
     require_no_foreign_session_owner,
 )
 from ..data.recovery_anchors import validate_recovery_objects
+from ..utils.session_start_point import load_session_start_point
 from ..data.start_time_changes import read_staged_renames
 from ..exceptions import exit_with_error
 from ..i18n import _
@@ -26,8 +27,10 @@ from ..utils.git_worktree import (
 )
 from ..utils.git_index import (
     git_add_paths,
+    git_read_tree,
     git_reset_paths,
 )
+from ..utils.git_refs import update_git_refs
 from ..utils.git_repository import (
     get_git_repository_root_path,
     require_git_repository,
@@ -77,9 +80,10 @@ def command_abort(*, quiet: bool = False) -> None:
 
     # Read abort state
     abort_head = read_text_file_contents(get_abort_head_file_path()).strip()
+    start_point = load_session_start_point()
     abort_stash_path = get_abort_stash_file_path()
     abort_stash = read_text_file_contents(abort_stash_path).strip() if abort_stash_path.exists() else None
-    recovery_objects = [abort_head, abort_stash]
+    recovery_objects = [start_point.head_commit, start_point.index_tree, abort_stash]
     batch_snapshot_path = get_abort_state_directory_path() / "batch-refs.json"
     try:
         batch_snapshot = json.loads(read_text_file_contents(batch_snapshot_path))
@@ -98,7 +102,7 @@ def command_abort(*, quiet: bool = False) -> None:
     validate_recovery_objects(recovery_objects, anchors=recovery_anchors)
 
     # Reset auto-added files first
-    if get_auto_added_files_file_path().exists():
+    if not start_point.is_unborn and get_auto_added_files_file_path().exists():
         auto_added = read_file_paths_file(get_auto_added_files_file_path())
         for file_path in auto_added:
             git_reset_paths([file_path], check=False)
@@ -108,10 +112,15 @@ def command_abort(*, quiet: bool = False) -> None:
     env = os.environ.copy()
     env["GIT_REFLOG_ACTION"] = "stage-batch abort"
 
-    if not quiet:
-        print(_("Resetting to {}...").format(abort_head[:7]), file=sys.stderr)
-    git_reset_hard(abort_head, env=env)
-    _remove_normalized_rename_destinations_before_stash_apply()
+    if start_point.is_unborn:
+        if start_point.symbolic_head:
+            update_git_refs(deletes=[start_point.symbolic_head])
+        git_read_tree(start_point.index_tree)
+    else:
+        if not quiet:
+            print(_("Resetting to {}...").format(abort_head[:7]), file=sys.stderr)
+        git_reset_hard(abort_head, env=env)
+        _remove_normalized_rename_destinations_before_stash_apply()
 
     # Apply original stash if it exists (with --index to restore staged state)
     if abort_stash:

--- a/src/git_stage_batch/commands/file_scope/include_file_to_batch.py
+++ b/src/git_stage_batch/commands/file_scope/include_file_to_batch.py
@@ -21,6 +21,7 @@ from ...data.file_change_display import (
 from ...data.file_modes import detect_file_mode
 from ...data.file_tracking import auto_add_untracked_files
 from ...data.live_diff import stream_live_git_diff
+from ...utils.session_start_point import session_comparison_base
 from ...data.session import snapshot_file_if_untracked
 from ...exceptions import exit_with_error
 from ...i18n import _
@@ -76,7 +77,7 @@ def include_file_to_batch(
 
     with acquire_unified_diff(
         stream_live_git_diff(
-            base="HEAD",
+            base=session_comparison_base(),
             context_lines=get_context_lines(),
             paths=[file_path],
         )

--- a/src/git_stage_batch/commands/selection/include_line_selection.py
+++ b/src/git_stage_batch/commands/selection/include_line_selection.py
@@ -12,7 +12,6 @@ from ...batch.hunk_ownership_translation import (
 )
 from ...batch.merge import merge_batch_from_line_sequences_as_buffer
 from ...batch.lifecycle import create_batch, delete_batch
-from ...batch.ownership import BatchOwnership
 from ...batch.ownership_metadata_loading import acquire_ownership_for_metadata_dict
 from ...batch.query import read_batch_metadata
 from ...batch.selection import line_selection_not_valid_message
@@ -258,6 +257,18 @@ def try_build_index_content_via_transient_batch(
     if not selected_lines:
         return TransientIncludeResult.failure(
             TransientIncludeFailureReason.NO_SELECTED_LINES
+        )
+
+    if (
+        not current_index_lines
+        and all(line.kind == "+" for line in line_changes.lines)
+    ):
+        return TransientIncludeResult.success(
+            LineBuffer.from_chunks(
+                hunk_source_lines[line.source_line - 1]
+                for line in selected_lines
+                if line.source_line is not None
+            )
         )
 
     batch_name = f"include-line-{uuid.uuid4().hex}"

--- a/src/git_stage_batch/commands/suggest_fixup.py
+++ b/src/git_stage_batch/commands/suggest_fixup.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from ..data.session import require_session_started
+from ..utils.session_start_point import require_repository_history
 from ..utils.git_repository import require_git_repository
 from ..utils.paths import ensure_state_directory_exists
 from .fixup.iteration_state import prepare_suggest_fixup_iteration
@@ -39,6 +40,7 @@ def command_suggest_fixup(
     """
     require_git_repository()
     ensure_state_directory_exists()
+    require_repository_history()
 
     iteration_context = prepare_suggest_fixup_iteration(
         boundary=boundary,
@@ -95,6 +97,7 @@ def command_suggest_fixup_line(
     require_git_repository()
     ensure_state_directory_exists()
     require_session_started()
+    require_repository_history()
 
     iteration_context = prepare_suggest_fixup_iteration(
         boundary=boundary,

--- a/src/git_stage_batch/data/file_hunk_display.py
+++ b/src/git_stage_batch/data/file_hunk_display.py
@@ -29,6 +29,7 @@ from ..utils.paths import get_context_lines
 from ..core.text_lines import bytes_to_lines
 from .file_tracking import auto_add_untracked_files
 from .live_diff import stream_live_git_diff
+from ..utils.session_start_point import session_comparison_base
 
 
 def render_file_as_single_hunk(file_path: str) -> Optional[LineLevelChange]:
@@ -36,7 +37,7 @@ def render_file_as_single_hunk(file_path: str) -> Optional[LineLevelChange]:
     auto_add_untracked_files([file_path])
     with acquire_unified_diff(
         stream_live_git_diff(
-            base="HEAD",
+            base=session_comparison_base(),
             context_lines=get_context_lines(),
             full_index=True,
             ignore_submodules="none",

--- a/src/git_stage_batch/data/session.py
+++ b/src/git_stage_batch/data/session.py
@@ -8,6 +8,11 @@ import shutil
 
 from .batch_refs import snapshot_batch_refs
 from .recovery_anchors import anchor_recovery_objects
+from ..utils.session_start_point import (
+    resolve_session_start_point,
+    save_session_start_point,
+    session_comparison_base,
+)
 from ..exceptions import CommandError
 from ..i18n import _
 from ..utils.file_io import (
@@ -76,7 +81,7 @@ def _diff_index_name_status(*, intent_to_add_visible: bool) -> dict[str, str]:
             "-z",
             "--no-renames",
             visibility_option,
-            "HEAD",
+            session_comparison_base(),
             "--",
         ],
         check=True,
@@ -157,8 +162,22 @@ def initialize_abort_state() -> None:
 
 def _initialize_abort_state() -> None:
     """Build abort state, writing the active-session marker last."""
-    head_result = run_git_command(["rev-parse", "HEAD"], requires_index_lock=False)
-    abort_head = head_result.stdout.strip()
+    start_point = resolve_session_start_point()
+    save_session_start_point(start_point)
+    abort_head = start_point.head_commit or "UNBORN"
+
+    if start_point.is_unborn:
+        indexed_paths_result = run_git_command(
+            ["ls-files", "-z"],
+            text_output=False,
+            requires_index_lock=False,
+        )
+        indexed_paths = [
+            path.decode("utf-8", errors="surrogateescape")
+            for path in indexed_paths_result.stdout.split(b"\0")
+            if path
+        ]
+        _snapshot_worktree_paths_for_unborn_abort(indexed_paths)
 
     # Snapshot all intent-to-add files upfront
     # These files won't survive git reset --hard but aren't in the stash
@@ -193,12 +212,20 @@ def _initialize_abort_state() -> None:
 
         # The stash covers tracked worktree and index changes. Untracked files
         # that the session may modify are handled by lazy snapshots.
-        log_journal("session_creating_stash")
-        stash_result = run_git_command(
-            ["stash", "create"],
-            check=False,
-            requires_index_lock=False,
-        )
+        if start_point.is_unborn:
+            stash_hash = ""
+            stash_returncode = 0
+            stash_stderr = ""
+        else:
+            log_journal("session_creating_stash")
+            stash_result = run_git_command(
+                ["stash", "create"],
+                check=False,
+                requires_index_lock=False,
+            )
+            stash_hash = stash_result.stdout.strip()
+            stash_returncode = stash_result.returncode
+            stash_stderr = stash_result.stderr
     finally:
         # Restore all intent-to-add entries even when snapshot creation fails.
         if all_intent_to_add_files:
@@ -231,24 +258,24 @@ def _initialize_abort_state() -> None:
                     index_after=ls_after,
                 )
 
-    if stash_result.returncode != 0:
+    if stash_returncode != 0:
         log_journal(
             "session_stash_failed",
-            returncode=stash_result.returncode,
-            stderr=stash_result.stderr,
+            returncode=stash_returncode,
+            stderr=stash_stderr,
         )
         raise CommandError(
             _("Could not create the recovery snapshot required to start a session: {error}").format(
-                error=stash_result.stderr.strip() or _("git stash create failed")
+                error=stash_stderr.strip() or _("git stash create failed")
             )
         )
 
-    write_text_file_contents(get_abort_stash_file_path(), stash_result.stdout.strip())
-    if stash_result.stdout.strip():
-        log_journal("session_stash_created", stash_hash=stash_result.stdout.strip())
+    write_text_file_contents(get_abort_stash_file_path(), stash_hash)
+    if stash_hash:
+        log_journal("session_stash_created", stash_hash=stash_hash)
 
     batch_snapshot = snapshot_batch_refs()
-    recovery_objects = [abort_head, stash_result.stdout.strip()]
+    recovery_objects = [start_point.head_commit, stash_hash, start_point.index_tree]
     for batch_state in batch_snapshot.values():
         recovery_objects.extend(
             [batch_state.get("commit_sha"), batch_state.get("state_commit_sha")]
@@ -259,6 +286,29 @@ def _initialize_abort_state() -> None:
         json.dumps(recovery_anchors, indent=2, sort_keys=True),
     )
     write_text_file_contents(get_abort_head_file_path(), abort_head)
+
+
+def _snapshot_worktree_paths_for_unborn_abort(file_paths: list[str]) -> None:
+    """Snapshot initially indexed paths that unborn abort may need to restore."""
+    if not file_paths:
+        return
+    repo_root = get_git_repository_root_path()
+    snapshot_dir = get_abort_snapshots_directory_path()
+    existing = set(read_file_paths_file(get_abort_snapshot_list_file_path()))
+    captured: list[str] = []
+    for file_path in file_paths:
+        source = repo_root / file_path
+        if not source.exists() or source.is_dir():
+            continue
+        target = snapshot_dir / file_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, target, follow_symlinks=False)
+        captured.append(file_path)
+    if captured:
+        write_file_paths_file(
+            get_abort_snapshot_list_file_path(),
+            [*existing, *captured],
+        )
 
 
 def require_session_started() -> None:

--- a/src/git_stage_batch/data/undo_checkpoints.py
+++ b/src/git_stage_batch/data/undo_checkpoints.py
@@ -25,6 +25,7 @@ from .recovery_anchors import (
     state_recovery_objects,
     validate_recovery_state,
 )
+from ..utils.session_start_point import current_head_commit
 from . import undo_restore as _undo_restore
 from . import undo_worktree as _undo_worktree
 from ..exceptions import CommandError
@@ -142,7 +143,7 @@ def _create_undo_checkpoint(operation: str, *, worktree_paths: list[str] | None 
 
     manifest = {
         "operation": operation,
-        "head": run_git_command(["rev-parse", "HEAD"], check=False, requires_index_lock=False).stdout.strip(),
+        "head": current_head_commit(),
         "index_tree": before["index_tree"],
         "refs": before["refs"],
         "worktree_paths": [
@@ -367,7 +368,7 @@ def _push_redo_node(
         "undo_checkpoint": undo_checkpoint,
         "head": target.get(
             "head",
-            run_git_command(["rev-parse", "HEAD"], check=False, requires_index_lock=False).stdout.strip(),
+            current_head_commit(),
         ),
         "index_tree": target.get("index_tree"),
         "refs": target.get("refs", {}),

--- a/src/git_stage_batch/tui/session_quit.py
+++ b/src/git_stage_batch/tui/session_quit.py
@@ -35,9 +35,13 @@ def handle_quit(*, stop_session: bool = True) -> None:
     start_index_tree = read_text_file_contents(start_index_tree_file).strip()
 
     selected_head = run_git_command(
-        ["rev-parse", "HEAD"],
+        ["rev-parse", "--verify", "HEAD^{commit}"],
+        check=False,
         requires_index_lock=False,
-    ).stdout.strip()
+    )
+    selected_head_value = (
+        selected_head.stdout.strip() if selected_head.returncode == 0 else "UNBORN"
+    )
     selected_index_tree = run_git_command(
         ["write-tree"],
         requires_index_lock=False,
@@ -47,7 +51,7 @@ def handle_quit(*, stop_session: bool = True) -> None:
     has_discards = stats.get("discarded", 0) > 0
 
     if (
-        selected_head == start_head
+        selected_head_value == start_head
         and selected_index_tree == start_index_tree
         and not has_discards
     ):

--- a/src/git_stage_batch/tui/session_startup.py
+++ b/src/git_stage_batch/tui/session_startup.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 import sys
 
 from ..data.session import session_is_active
+from ..utils.session_start_point import load_session_start_point
 from ..exceptions import CommandError
 from ..i18n import _
 from ..utils.file_io import write_text_file_contents
@@ -49,8 +50,11 @@ def prepare_interactive_session() -> InteractiveSessionStartup:
 
 
 def _record_start_repository_state() -> None:
-    head_result = run_git_command(["rev-parse", "HEAD"], requires_index_lock=False)
-    write_text_file_contents(get_start_head_file_path(), head_result.stdout.strip())
+    start_point = load_session_start_point()
+    write_text_file_contents(
+        get_start_head_file_path(),
+        start_point.head_commit or "UNBORN",
+    )
 
     index_tree_result = run_git_command(["write-tree"], requires_index_lock=False)
     write_text_file_contents(

--- a/src/git_stage_batch/utils/git_object_io.py
+++ b/src/git_stage_batch/utils/git_object_io.py
@@ -10,6 +10,36 @@ from pathlib import Path
 from .git_command import run_git_command, stream_git_command
 
 
+_EMPTY_TREE_OBJECT_CACHE: dict[Path, str] = {}
+
+
+def get_empty_git_tree_object_id() -> str:
+    """Return the repository-native object ID for Git's empty tree."""
+    cwd = Path.cwd()
+    cached = _EMPTY_TREE_OBJECT_CACHE.get(cwd)
+    if cached is not None:
+        return cached
+    object_id = run_git_command(
+        ["mktree"],
+        stdin_chunks=[b""],
+        requires_index_lock=False,
+    ).stdout.strip()
+    if not object_id:
+        raise RuntimeError("git mktree produced no empty tree object")
+    _EMPTY_TREE_OBJECT_CACHE[cwd] = object_id
+    return object_id
+
+
+def get_git_object_type(object_id: str) -> str | None:
+    """Return an object's Git type, or None when it does not exist."""
+    result = run_git_command(
+        ["cat-file", "-t", object_id],
+        check=False,
+        requires_index_lock=False,
+    )
+    return result.stdout.strip() if result.returncode == 0 else None
+
+
 @dataclass(frozen=True)
 class GitTreeBlob:
     """One blob entry from a Git tree."""

--- a/src/git_stage_batch/utils/paths.py
+++ b/src/git_stage_batch/utils/paths.py
@@ -491,3 +491,8 @@ def get_batch_refs_snapshot_file_path() -> Path:
 def get_abort_recovery_anchors_file_path() -> Path:
     """Get the path recording abort recovery anchor refs and object IDs."""
     return get_abort_state_directory_path() / "recovery-anchors.json"
+
+
+def get_session_start_point_file_path() -> Path:
+    """Get the persisted commit-backed or unborn session start point."""
+    return get_abort_state_directory_path() / "start-point.json"

--- a/src/git_stage_batch/utils/session_start_point.py
+++ b/src/git_stage_batch/utils/session_start_point.py
@@ -1,0 +1,128 @@
+"""Git start-point discovery for commit-backed and unborn repositories."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+
+from ..exceptions import CommandError
+from ..i18n import _
+from .file_io import read_text_file_contents, write_text_file_contents
+from .git_command import run_git_command
+from .git_object_io import get_empty_git_tree_object_id
+from .paths import get_session_start_point_file_path
+
+
+@dataclass(frozen=True)
+class SessionStartPoint:
+    """Repository identity and index state captured before session mutation."""
+
+    head_commit: str | None
+    symbolic_head: str | None
+    index_tree: str
+
+    @property
+    def is_unborn(self) -> bool:
+        return self.head_commit is None
+
+
+def resolve_session_start_point() -> SessionStartPoint:
+    """Capture HEAD identity and the exact current index tree."""
+    head_result = run_git_command(
+        ["rev-parse", "--verify", "HEAD^{commit}"],
+        check=False,
+        requires_index_lock=False,
+    )
+    head_commit = head_result.stdout.strip() if head_result.returncode == 0 else None
+    symbolic_result = run_git_command(
+        ["symbolic-ref", "-q", "HEAD"],
+        check=False,
+        requires_index_lock=False,
+    )
+    symbolic_head = (
+        symbolic_result.stdout.strip() if symbolic_result.returncode == 0 else None
+    )
+    if head_commit is None and symbolic_head is None:
+        raise CommandError(_("Cannot determine the unborn branch for HEAD."))
+    index_result = run_git_command(
+        ["write-tree"],
+        check=False,
+        requires_index_lock=False,
+    )
+    if index_result.returncode != 0:
+        raise CommandError(
+            _("Cannot snapshot the index before starting the session: {error}").format(
+                error=index_result.stderr.strip() or _("git write-tree failed")
+            )
+        )
+    return SessionStartPoint(
+        head_commit=head_commit,
+        symbolic_head=symbolic_head,
+        index_tree=index_result.stdout.strip(),
+    )
+
+
+def save_session_start_point(start_point: SessionStartPoint) -> None:
+    """Persist a start point before publishing the active-session marker."""
+    write_text_file_contents(
+        get_session_start_point_file_path(),
+        json.dumps(asdict(start_point), indent=2, sort_keys=True) + "\n",
+    )
+
+
+def load_session_start_point() -> SessionStartPoint:
+    """Load the current session start point, including legacy sessions."""
+    path = get_session_start_point_file_path()
+    if path.exists():
+        try:
+            data = json.loads(read_text_file_contents(path))
+            return SessionStartPoint(
+                head_commit=data.get("head_commit"),
+                symbolic_head=data.get("symbolic_head"),
+                index_tree=data["index_tree"],
+            )
+        except (json.JSONDecodeError, KeyError, TypeError) as error:
+            raise CommandError(_("Session start-point metadata is invalid.")) from error
+
+    from .paths import get_abort_head_file_path
+
+    legacy_head = read_text_file_contents(get_abort_head_file_path()).strip()
+    if not legacy_head:
+        raise CommandError(_("Session start-point metadata is missing."))
+    tree = run_git_command(
+        ["rev-parse", f"{legacy_head}^{{tree}}"],
+        requires_index_lock=False,
+    ).stdout.strip()
+    return SessionStartPoint(legacy_head, None, tree)
+
+
+def session_comparison_base() -> str:
+    """Return HEAD when it exists, otherwise the empty tree."""
+    result = run_git_command(
+        ["rev-parse", "--verify", "HEAD^{commit}"],
+        check=False,
+        requires_index_lock=False,
+    )
+    return (
+        result.stdout.strip()
+        if result.returncode == 0
+        else get_empty_git_tree_object_id()
+    )
+
+
+def current_head_commit() -> str | None:
+    """Return the selected HEAD commit, or None while HEAD is unborn."""
+    result = run_git_command(
+        ["rev-parse", "--verify", "HEAD^{commit}"],
+        check=False,
+        requires_index_lock=False,
+    )
+    return result.stdout.strip() if result.returncode == 0 else None
+
+
+def require_repository_history() -> None:
+    """Reject a history-dependent operation while HEAD is unborn."""
+    if current_head_commit() is None:
+        raise CommandError(
+            _("This command requires at least one commit; HEAD is still unborn.")
+        )

--- a/tests/batch/test_metadata_validation.py
+++ b/tests/batch/test_metadata_validation.py
@@ -205,7 +205,7 @@ def test_validate_batch_metadata_structure_null_baseline(temp_git_repo):
         validate_batch_metadata_structure(metadata, "test-batch")
 
     error_msg = str(exc_info.value)
-    assert "has no baseline commit" in error_msg
+    assert "has no baseline object" in error_msg
     assert "test-batch" in error_msg
     assert "corrupted or incomplete" in error_msg
 
@@ -223,7 +223,7 @@ def test_validate_batch_metadata_structure_invalid_baseline_commit(temp_git_repo
         validate_batch_metadata_structure(metadata, "test-batch")
 
     error_msg = str(exc_info.value)
-    assert "invalid baseline commit" in error_msg
+    assert "invalid baseline object" in error_msg
     assert "0000000000000000000000000000000000000000" in error_msg
     assert "does not exist in the repository" in error_msg
 
@@ -401,7 +401,7 @@ def test_get_validated_baseline_commit_missing(temp_git_repo):
         get_validated_baseline_commit("test-batch")
 
     error_msg = str(exc_info.value)
-    assert "has no baseline commit" in error_msg
+    assert "has no baseline object" in error_msg
     assert "test-batch" in error_msg
 
 

--- a/tests/functional/test_metadata_corruption_handling.py
+++ b/tests/functional/test_metadata_corruption_handling.py
@@ -116,7 +116,7 @@ def test_missing_baseline_clear_error(functional_repo):
         command_show_from_batch("test-batch")
 
     error_msg = str(exc_info.value.message)
-    assert "no baseline commit" in error_msg.lower()
+    assert "no baseline object" in error_msg.lower()
     assert "test-batch" in error_msg
     assert "corrupted or incomplete" in error_msg.lower()
 
@@ -158,5 +158,5 @@ def test_invalid_baseline_commit_clear_error(functional_repo):
         command_show_from_batch("test-batch")
 
     error_msg = str(exc_info.value.message)
-    assert "invalid baseline commit" in error_msg.lower()
+    assert "invalid baseline object" in error_msg.lower()
     assert "0000000000000000000000000000000000000000" in error_msg

--- a/tests/functional/test_unborn_repository.py
+++ b/tests/functional/test_unborn_repository.py
@@ -1,0 +1,188 @@
+"""First-commit staging sessions in repositories with an unborn HEAD."""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from .conftest import git_stage_batch
+
+
+def _git(*args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.fixture
+def unborn_repo(tmp_path, monkeypatch):
+    """Create a configured repository without any commits."""
+    repo = tmp_path / "unborn"
+    _git("init", str(repo))
+    monkeypatch.chdir(repo)
+    _git("config", "user.name", "Test User")
+    _git("config", "user.email", "test@example.com")
+    return repo
+
+
+def test_start_include_and_abort_restore_unborn_branch(unborn_repo):
+    """Abort should return a first-file session to its pre-commit state."""
+    first_file = unborn_repo / "first.txt"
+    first_file.write_text("one\ntwo\n")
+    symbolic_head = _git("symbolic-ref", "HEAD").stdout.strip()
+
+    git_stage_batch("start")
+    git_stage_batch("include", "--file", "first.txt")
+    assert _git("diff", "--cached", "--name-only").stdout == "first.txt\n"
+
+    git_stage_batch("abort")
+
+    assert _git("rev-parse", "--verify", "HEAD", check=False).returncode != 0
+    assert _git("symbolic-ref", "HEAD").stdout.strip() == symbolic_head
+    assert _git("ls-files").stdout == ""
+    assert first_file.read_text() == "one\ntwo\n"
+    assert _git("status", "--porcelain").stdout == "?? first.txt\n"
+
+
+def test_abort_removes_first_commit_but_keeps_original_file(unborn_repo):
+    """A commit created during the session should not make HEAD permanently born."""
+    first_file = unborn_repo / "first.txt"
+    first_file.write_text("first\n")
+    git_stage_batch("start")
+    git_stage_batch("include", "--file", "first.txt")
+    _git("commit", "-m", "First commit")
+    assert _git("rev-parse", "--verify", "HEAD").returncode == 0
+
+    git_stage_batch("abort")
+
+    assert _git("rev-parse", "--verify", "HEAD", check=False).returncode != 0
+    assert first_file.read_text() == "first\n"
+    assert _git("status", "--porcelain").stdout == "?? first.txt\n"
+
+
+def test_stop_preserves_first_commit(unborn_repo):
+    """Stopping should end the session without undoing a newly created HEAD."""
+    first_file = unborn_repo / "first.txt"
+    first_file.write_text("first\n")
+    git_stage_batch("start")
+    git_stage_batch("include", "--file", "first.txt")
+    _git("commit", "-m", "First commit")
+    first_commit = _git("rev-parse", "HEAD").stdout.strip()
+
+    git_stage_batch("stop")
+
+    assert _git("rev-parse", "HEAD").stdout.strip() == first_commit
+    assert _git("status", "--porcelain").stdout == ""
+
+
+def test_abort_preserves_unborn_file_kinds_and_ignored_paths(unborn_repo):
+    """Abort should preserve original first-commit inputs without indexing them."""
+    (unborn_repo / ".gitignore").write_text("ignored.bin\n")
+    (unborn_repo / "script.sh").write_text("#!/bin/sh\nexit 0\n")
+    (unborn_repo / "script.sh").chmod(0o755)
+    (unborn_repo / "binary.bin").write_bytes(b"\x00\x01\xff")
+    (unborn_repo / "empty.txt").write_bytes(b"")
+    (unborn_repo / "ignored.bin").write_bytes(b"ignored")
+    (unborn_repo / "target.txt").write_text("target\n")
+    (unborn_repo / "link").symlink_to("target.txt")
+
+    git_stage_batch("start")
+    git_stage_batch("abort")
+
+    assert _git("rev-parse", "--verify", "HEAD", check=False).returncode != 0
+    assert _git("ls-files").stdout == ""
+    assert (unborn_repo / "script.sh").stat().st_mode & 0o111
+    assert (unborn_repo / "binary.bin").read_bytes() == b"\x00\x01\xff"
+    assert (unborn_repo / "empty.txt").read_bytes() == b""
+    assert (unborn_repo / "ignored.bin").read_bytes() == b"ignored"
+    assert (unborn_repo / "link").is_symlink()
+
+
+def test_unborn_intent_to_add_is_restored_on_abort(unborn_repo):
+    """An existing intent-to-add entry should remain intent-to-add."""
+    intent = unborn_repo / "intent.txt"
+    intent.write_text("intent\n")
+    _git("add", "-N", "intent.txt")
+
+    git_stage_batch("start")
+    git_stage_batch("abort")
+
+    assert _git("status", "--porcelain").stdout == " A intent.txt\n"
+
+
+def test_suggest_fixup_reports_unborn_history_boundary(unborn_repo):
+    """History-dependent assistance should explain the missing first commit."""
+    (unborn_repo / "first.txt").write_text("first\n")
+    git_stage_batch("start")
+
+    result = git_stage_batch("suggest-fixup", check=False)
+
+    assert result.returncode != 0
+    assert "requires at least one commit" in result.stderr
+    assert "unborn" in result.stderr
+
+
+def test_abort_restores_mixed_staged_and_untracked_start_state(unborn_repo):
+    """Unborn abort should restore the exact initial index tree."""
+    staged = unborn_repo / "staged.txt"
+    staged.write_text("staged\n")
+    _git("add", "staged.txt")
+    review = unborn_repo / "review.txt"
+    review.write_text("review\n")
+
+    git_stage_batch("start")
+    git_stage_batch("include", "--file", "review.txt")
+    git_stage_batch("abort")
+
+    assert _git("diff", "--cached", "--name-only").stdout == "staged.txt\n"
+    assert _git("status", "--porcelain").stdout.splitlines() == [
+        "A  staged.txt",
+        "?? review.txt",
+    ]
+
+
+def test_unborn_line_include_can_be_undone(unborn_repo):
+    """Line-level staging should create a restorable unborn checkpoint."""
+    first_file = unborn_repo / "first.txt"
+    first_file.write_text("one\ntwo\n")
+    git_stage_batch("start")
+    git_stage_batch("show", "--file", "first.txt")
+
+    git_stage_batch("include", "--line", "1-2")
+    assert _git("diff", "--cached", "--name-only").stdout == "first.txt\n"
+    git_stage_batch("undo")
+
+    assert _git("diff", "--cached", "--name-only").stdout == ""
+    assert first_file.read_text() == "one\ntwo\n"
+
+
+def test_session_continues_after_first_commit(unborn_repo):
+    """A session started unborn should process later post-commit changes."""
+    first_file = unborn_repo / "first.txt"
+    first_file.write_text("first\n")
+    git_stage_batch("start")
+    git_stage_batch("include", "--file", "first.txt")
+    _git("commit", "-m", "First commit")
+    first_file.write_text("first\nsecond\n")
+
+    git_stage_batch("start")
+    git_stage_batch("include", "--file", "first.txt")
+    git_stage_batch("stop")
+
+    assert "+second" in _git("diff", "--cached").stdout
+
+
+def test_unborn_session_can_store_first_file_in_batch(unborn_repo):
+    """A no-history batch should accept first-commit file content."""
+    first_file = unborn_repo / "first.txt"
+    first_file.write_text("first\n")
+    git_stage_batch("new", "first-batch")
+    git_stage_batch("start")
+
+    git_stage_batch("include", "--to", "first-batch", "--file", "first.txt")
+
+    assert "first" in git_stage_batch("show", "--from", "first-batch").stdout

--- a/tests/tui/test_interactive.py
+++ b/tests/tui/test_interactive.py
@@ -590,7 +590,13 @@ class TestDegradedMode:
     def test_start_interactive_mode_quit_preserves_existing_session(self, temp_git_repo):
         """Test quitting does not stop a session that already existed."""
         ensure_state_directory_exists()
-        write_text_file_contents(get_abort_head_file_path(), "existing-session\n")
+        head = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        write_text_file_contents(get_abort_head_file_path(), head + "\n")
 
         with patch("git_stage_batch.commands.start.command_start"):
             with patch("git_stage_batch.tui.interactive.prompt_action", return_value="q"):

--- a/tests/utils/test_git_object_io.py
+++ b/tests/utils/test_git_object_io.py
@@ -10,6 +10,7 @@ from git_stage_batch.utils.git_index import git_write_tree, temp_git_index
 from git_stage_batch.utils.git_object_io import (
     create_git_blob,
     create_git_blobs_from_paths,
+    get_empty_git_tree_object_id,
     read_git_blobs_as_bytes,
 )
 
@@ -45,6 +46,14 @@ def temp_git_repo(tmp_path, monkeypatch):
     )
 
     return repo
+
+
+def test_empty_tree_helper_returns_a_tree_object(temp_git_repo):
+    """The shared empty-tree helper should create a repository tree object."""
+    object_id = get_empty_git_tree_object_id()
+
+    assert run_git_command(["cat-file", "-t", object_id]).stdout.strip() == "tree"
+    assert run_git_command(["ls-tree", object_id]).stdout == ""
 
 
 def test_create_git_blobs_from_paths_hashes_path_bytes(temp_git_repo):

--- a/tests/utils/test_git_repository_object_format.py
+++ b/tests/utils/test_git_repository_object_format.py
@@ -11,6 +11,7 @@ from git_stage_batch.utils.git_repository import (
     null_object_id,
     object_id_hex_length,
 )
+from git_stage_batch.utils.git_object_io import get_empty_git_tree_object_id
 
 
 @pytest.mark.parametrize(("object_format", "width"), [("sha1", 40), ("sha256", 64)])
@@ -32,3 +33,11 @@ def test_repository_object_format_controls_oid_width(
     assert get_git_object_format() == object_format
     assert object_id_hex_length() == width
     assert null_object_id() == "0" * width
+    empty_tree = get_empty_git_tree_object_id()
+    assert len(empty_tree) == width
+    assert subprocess.run(
+        ["git", "cat-file", "-t", empty_tree],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip() == "tree"


### PR DESCRIPTION
Git-stage-batch records commit-backed session baselines, index snapshots, and
batch source history while staging changes through Git plumbing.

Users cannot safely prepare their first commit because an unborn repository has
no HEAD commit for startup, file comparison, batch baselines, undo checkpoints,
interactive state, or abort restoration.

This pull request addresses those gaps by recording an explicit symbolic-HEAD
start point and initial index tree, sharing a repository-native empty-tree API,
and teaching staging, batches, undo, abort, TUI, and history-dependent commands
how to handle the no-history state.

The first-commit staging goal is complete with file and line inclusion, batch
storage, exact unborn index restoration, first-commit stop and abort behavior,
continued post-commit sessions, documented semantics, and focused regression
coverage.

Tests:

- `uv run pytest -q` (3009 passed)
- `uv run pytest tests/architecture/test_import_boundaries.py -q` (370 passed)
- Focused unborn, batch, TUI, and object utility suite (123 passed)
- `uv run mkdocs build --strict`
- Ruff checks for all changed Python files
- `git diff --check origin/main..HEAD`
