### PR TITLE
ci: Bootstrap Meson in SHA-256 job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,13 @@ jobs:
       - name: Set up Python
         run: uv python install 3.10
 
-      - name: Install dependencies
+      - name: Set up venv
+        run: uv venv --python 3.10
+
+      - name: Install meson
+        run: uv pip install meson-python
+
+      - name: Install other dependencies
         run: uv sync --all-groups
 
       - name: Report Git object-format support


### PR DESCRIPTION
The SHA-256 repository job synchronizes dependencies into a fresh environment with build isolation disabled.

That environment cannot import the Meson Python build backend while building the editable project, causing the job to fail before its tests run.

This change creates the virtual environment and installs meson-python before synchronization, matching the established test and build job setup.