### PR TITLE
core: Parse diff hunks by declared line counts

### DIFF
--- a/src/git_stage_batch/core/diff_parser.py
+++ b/src/git_stage_batch/core/diff_parser.py
@@ -158,50 +158,66 @@ class _UnifiedDiffParserBuildContext:
             new_file_line: bytes,
             hunk_header_line: bytes,
         ) -> Iterator[bytes]:
-            nonlocal lookahead
-
             yield old_file_line + b'\n'
             yield new_file_line + b'\n'
             yield hunk_header_line + b'\n'
 
-            # Collect hunk body (lines starting with space, +, or -)
+            header = _hunk_headers.parse_hunk_header_line(hunk_header_line)
+            old_consumed = 0
+            new_consumed = 0
+
             while True:
                 body_line = peek_line()
+                old_remaining, new_remaining = header.remaining_body_counts(
+                    old_consumed,
+                    new_consumed,
+                )
+
                 if body_line is None:
-                    # End of input
-                    break
+                    if old_remaining or new_remaining:
+                        raise CommandError(
+                            _("Diff ended before the hunk body was complete")
+                        )
+                    return
 
                 body_line_stripped = body_line.rstrip(b'\n')
 
-                if _diff_headers.line_is_diff_git_header(body_line_stripped):
-                    # Next file starting
-                    break
-                if _hunk_headers.line_is_hunk_header(body_line_stripped):
-                    # Next hunk for same file
-                    break
-                # Check for start of new file diff (---/+++)
-                if body_line_stripped.startswith(b"---"):
-                    # Peek ahead one more line to see if it's followed by +++
-                    next_line()  # consume ---
-                    peek_plus = peek_line()
-                    if peek_plus and peek_plus.rstrip(b'\n').startswith(b"+++"):
-                        # This is a new file diff, put --- back in lookahead
-                        lookahead = body_line
-                        break
-
-                    # False alarm, this --- is part of the hunk body
-                    # Add with \n terminator
-                    yield body_line_stripped + b'\n'
+                if body_line_stripped.startswith(b"\\"):
+                    if body_line_stripped != b"\\ No newline at end of file":
+                        raise CommandError(_("Invalid marker in diff hunk body"))
+                    next_line()
+                    yield body_line
                     continue
 
-                # Include lines that are part of the hunk
-                if body_line_stripped.startswith((b" ", b"+", b"-", b"\\")):
-                    next_line()  # consume
-                    # Add with \n terminator
-                    yield body_line_stripped + b'\n'
+                if not old_remaining and not new_remaining:
+                    if (
+                        _diff_headers.line_is_diff_git_header(body_line_stripped)
+                        or _hunk_headers.line_is_hunk_header(body_line_stripped)
+                    ):
+                        return
+                    if body_line_stripped.startswith((b" ", b"+", b"-")):
+                        raise CommandError(_("Diff hunk body exceeds declared counts"))
+                    raise CommandError(_("Invalid line prefix after diff hunk body"))
+
+                prefix = body_line_stripped[:1]
+                if prefix == b" ":
+                    if not old_remaining or not new_remaining:
+                        raise CommandError(_("Diff hunk body exceeds declared counts"))
+                    old_consumed += 1
+                    new_consumed += 1
+                elif prefix == b"-":
+                    if not old_remaining:
+                        raise CommandError(_("Diff hunk body exceeds declared old count"))
+                    old_consumed += 1
+                elif prefix == b"+":
+                    if not new_remaining:
+                        raise CommandError(_("Diff hunk body exceeds declared new count"))
+                    new_consumed += 1
                 else:
-                    # Unknown line, stop collecting this hunk
-                    break
+                    raise CommandError(_("Invalid line prefix in diff hunk body"))
+
+                next_line()
+                yield body_line
 
         try:
             while True:

--- a/src/git_stage_batch/core/models.py
+++ b/src/git_stage_batch/core/models.py
@@ -15,6 +15,14 @@ class HunkHeader:
     new_start: int
     new_len: int
 
+    def remaining_body_counts(
+        self,
+        old_consumed: int = 0,
+        new_consumed: int = 0,
+    ) -> tuple[int, int]:
+        """Return unconsumed old- and new-side lines in this hunk."""
+        return self.old_len - old_consumed, self.new_len - new_consumed
+
     def old_prefix_line_count(self) -> int:
         """Return the number of old-file lines before this hunk applies.
 

--- a/tests/core/test_diff_parser.py
+++ b/tests/core/test_diff_parser.py
@@ -11,6 +11,7 @@ from git_stage_batch.core.diff_parser import (
 )
 from git_stage_batch.core.models import SingleHunkPatch
 from git_stage_batch.core.buffer import LineBuffer
+from git_stage_batch.exceptions import CommandError
 from tests.diff_parser_helpers import collect_unified_diff
 
 
@@ -140,6 +141,65 @@ diff --git a/file2.txt b/file2.txt
         assert len(patches) == 2
         assert patches[0].old_path == "file1.txt"
         assert patches[1].old_path == "file2.txt"
+
+    @pytest.mark.parametrize(
+        ("hunk_header", "body"),
+        [
+            (b"@@ -1 +1 @@\n", b"---old\n+++new\n"),
+            (b"@@ -1,2 +1,2 @@\n", b"---old\n+++new\n trailing\n"),
+            (b"@@ -1,2 +1,2 @@\n", b" leading\n---old\n+++new\n"),
+            (
+                b"@@ -1,3 +1,3 @@\n",
+                b" leading\n---old\n+++new\n trailing\n",
+            ),
+        ],
+    )
+    def test_header_like_changed_content_uses_declared_counts(
+        self,
+        hunk_header,
+        body,
+    ):
+        """Changed lines resembling file headers remain in the hunk body."""
+        diff = (
+            b"diff --git a/file.txt b/file.txt\n"
+            b"--- a/file.txt\n"
+            b"+++ b/file.txt\n"
+            + hunk_header
+            + body
+            + b"diff --git a/next.txt b/next.txt\n"
+            b"--- a/next.txt\n"
+            b"+++ b/next.txt\n"
+            b"@@ -1 +1 @@\n"
+            b"-before\n"
+            b"+after\n"
+        )
+
+        patches = collect_unified_diff(diff.splitlines(keepends=True))
+
+        assert len(patches) == 2
+        assert b"---old\n+++new\n" in b"".join(patches[0].lines)
+        assert patches[1].path() == "next.txt"
+
+    @pytest.mark.parametrize(
+        ("body", "message"),
+        [
+            (b"-old\n", "before the hunk body was complete"),
+            (b"-old\n+new\n+extra\n", "exceeds declared counts"),
+            (b"-old\ninvalid\n", "Invalid line prefix"),
+        ],
+    )
+    def test_malformed_hunk_body_is_rejected(self, body, message):
+        """Malformed bodies never produce a partial parsed patch."""
+        diff = (
+            b"diff --git a/file.txt b/file.txt\n"
+            b"--- a/file.txt\n"
+            b"+++ b/file.txt\n"
+            b"@@ -1 +1 @@\n"
+            + body
+        )
+
+        with pytest.raises(CommandError, match=message):
+            collect_unified_diff(diff.splitlines(keepends=True))
 
     def test_new_file(self):
         """Test parsing a diff for a newly created file."""

--- a/tests/core/test_models.py
+++ b/tests/core/test_models.py
@@ -31,6 +31,13 @@ class TestHunkHeader:
         assert header1 == header2
         assert header1 != header3
 
+    def test_remaining_body_counts(self):
+        """Hunk headers report independent old- and new-side counts."""
+        header = HunkHeader(10, 5, 15, 7)
+
+        assert header.remaining_body_counts() == (5, 7)
+        assert header.remaining_body_counts(2, 4) == (3, 3)
+
     def test_old_prefix_line_count_for_non_empty_range(self):
         """Non-empty old ranges start at the first changed old line."""
         header = HunkHeader(old_start=10, old_len=3, new_start=12, new_len=5)

--- a/tests/functional/test_header_like_hunk_content.py
+++ b/tests/functional/test_header_like_hunk_content.py
@@ -50,3 +50,14 @@ def test_start_show_and_include_header_like_change(functional_repo):
         text=True,
     )
     assert staged.stdout == "before\n++new\nafter\n"
+
+
+def test_discard_header_like_change(functional_repo):
+    """Header-looking replacement content can be discarded end to end."""
+    path = _prepare_header_like_change(functional_repo)
+
+    git_stage_batch("start")
+    shown = git_stage_batch("show")
+    git_stage_batch("discard", "--line", _displayed_line_ids(shown.stdout))
+
+    assert path.read_text() == "before\n--old\nafter\n"

--- a/tests/functional/test_header_like_hunk_content.py
+++ b/tests/functional/test_header_like_hunk_content.py
@@ -1,0 +1,52 @@
+"""Functional coverage for changed content resembling patch headers."""
+
+import re
+import subprocess
+
+from .conftest import git_stage_batch
+
+
+def _prepare_header_like_change(repo):
+    path = repo / "header-like.txt"
+    path.write_text("before\n--old\nafter\n")
+    subprocess.run(
+        ["git", "add", path.name],
+        check=True,
+        cwd=repo,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "Add header-like content"],
+        check=True,
+        cwd=repo,
+        capture_output=True,
+    )
+    path.write_text("before\n++new\nafter\n")
+    return path
+
+
+def _displayed_line_ids(output: str) -> str:
+    line_ids = re.findall(r"\[#(\d+)\]", output)
+    assert line_ids
+    return ",".join(line_ids)
+
+
+def test_start_show_and_include_header_like_change(functional_repo):
+    """Header-looking replacement content can be displayed and included."""
+    path = _prepare_header_like_change(functional_repo)
+
+    git_stage_batch("start")
+    shown = git_stage_batch("show")
+    assert "--old" in shown.stdout
+    assert "++new" in shown.stdout
+
+    git_stage_batch("include", "--line", _displayed_line_ids(shown.stdout))
+
+    staged = subprocess.run(
+        ["git", "show", f":{path.name}"],
+        check=True,
+        cwd=functional_repo,
+        capture_output=True,
+        text=True,
+    )
+    assert staged.stdout == "before\n++new\nafter\n"


### PR DESCRIPTION
Unified diff parsing currently guesses that content beginning with `---` followed by `+++` starts a new file.

Legitimate replacement text can have the same prefixes, causing the parser to terminate the hunk early, emit incomplete state, and lose changed content before staging commands process it.

This series makes the hunk header's declared old- and new-side counts authoritative. It preserves header-like content, retains lookahead for following hunks and files, handles no-newline markers, and rejects incomplete, overlong, or invalid bodies with a command error.

Focused parser coverage exercises header-like content at every hunk position and malformed bodies. Functional coverage validates the complete start, show, include, and discard workflows.

Validation: `3016 passed`; focused tests and Ruff also pass.