### PR TITLE
paths: Preserve Git pathnames without text loss

### DIFF
--- a/src/git_stage_batch/batch/query.py
+++ b/src/git_stage_batch/batch/query.py
@@ -16,6 +16,7 @@ from .state_refs import (
 from .validation import validate_batch_name
 from ..utils.file_io import read_text_file_contents
 from ..utils.git_command import run_git_command
+from ..git_paths import decode_path, nul_records
 from ..utils.paths import get_batch_metadata_file_path
 
 
@@ -158,14 +159,15 @@ def list_batch_files(name: str) -> list[str]:
 
     # Use git ls-tree to list files recursively
     result = run_git_command(
-        ["ls-tree", "-r", "--name-only", tree_sha],
+        ["ls-tree", "-rz", "--name-only", tree_sha],
         check=False,
+        text_output=False,
         requires_index_lock=False,
     )
     if result.returncode != 0:
         return []
 
-    files = [line.strip() for line in result.stdout.strip().splitlines() if line.strip()]
+    files = [decode_path(path) for path in nul_records(result.stdout)]
     return sorted(files)
 
 

--- a/src/git_stage_batch/batch/source_snapshots.py
+++ b/src/git_stage_batch/batch/source_snapshots.py
@@ -17,6 +17,7 @@ from ..utils.file_io import read_text_file_contents
 from ..utils.git_command import (
     run_git_command,
 )
+from ..git_paths import encode_path
 from ..utils.git_refs import (
     update_git_refs,
 )
@@ -54,7 +55,7 @@ def _buffer_preview(buffer: LineBuffer) -> bytes:
 
 def _fast_import_quote_path(file_path: str) -> str:
     """Quote a repository path for fast-import commands."""
-    raw_path = file_path.encode("utf-8")
+    raw_path = encode_path(file_path)
     if raw_path and all(byte not in b' \t\r\n"\\' and 32 <= byte < 127 for byte in raw_path):
         return file_path
 
@@ -165,7 +166,7 @@ def create_batch_source_commits(file_paths: list[str]) -> dict[str, BatchSourceC
             for index, file_path in enumerate(unique_file_paths):
                 commit_mark = commit_mark_start + index
                 blob_mark = blob_mark_start + index
-                message = f"Batch source for {file_path}".encode("utf-8")
+                message = b"Batch source for " + encode_path(file_path)
                 quoted_path = _fast_import_quote_path(file_path)
                 yield (
                     f"commit {temp_refs[index]}\n"

--- a/src/git_stage_batch/core/diff_headers.py
+++ b/src/git_stage_batch/core/diff_headers.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+from ..git_paths import decode_path, quoted_token_end, unquote_path_token
+
 
 DIFF_GIT_PREFIX = b"diff --git "
 OLD_PATH_PREFIX = b"a/"
+NEW_PATH_PREFIX = b"b/"
 NEW_PATH_MARKER = b" b/"
 
 
@@ -19,12 +22,44 @@ def diff_git_paths(line: bytes) -> tuple[str, str] | None:
         return None
 
     rest = line[len(DIFF_GIT_PREFIX):]
-    old_path_start = rest.find(OLD_PATH_PREFIX)
-    new_path_start = rest.find(NEW_PATH_MARKER)
+    if rest.startswith(b'"'):
+        old_end = quoted_token_end(rest)
+        if rest[old_end:old_end + 1] != b" ":
+            return None
+        old_token = rest[:old_end]
+        new_token = rest[old_end + 1:]
+    else:
+        # Git leaves ordinary spaces unquoted. Fixed prefixes make the final
+        # separator ambiguous when either path itself contains " b/". An
+        # unchanged pathname is the common case and identifies its boundary
+        # exactly; patch/rename metadata later supplies distinct pathnames.
+        separators = []
+        offset = 0
+        while True:
+            separator = rest.find(b" " + NEW_PATH_PREFIX, offset)
+            if separator < 0:
+                break
+            separators.append(separator)
+            offset = separator + 1
+        if not separators:
+            return None
+        separator = separators[-1]
+        for candidate in separators:
+            candidate_old = rest[len(OLD_PATH_PREFIX):candidate]
+            candidate_new = rest[candidate + 1 + len(NEW_PATH_PREFIX):]
+            if candidate_old == candidate_new:
+                separator = candidate
+                break
+        old_token = rest[:separator]
+        new_token = rest[separator + 1:]
 
-    if old_path_start == -1 or new_path_start == -1:
+    old_path = unquote_path_token(old_token)
+    new_path = unquote_path_token(new_token)
+    if not old_path.startswith(OLD_PATH_PREFIX) or not new_path.startswith(
+        NEW_PATH_PREFIX
+    ):
         return None
-
-    old_path = rest[old_path_start + len(OLD_PATH_PREFIX):new_path_start]
-    new_path = rest[new_path_start + len(NEW_PATH_MARKER):]
-    return old_path.decode("utf-8"), new_path.decode("utf-8")
+    return (
+        decode_path(old_path[len(OLD_PATH_PREFIX):]),
+        decode_path(new_path[len(NEW_PATH_PREFIX):]),
+    )

--- a/src/git_stage_batch/core/diff_parser.py
+++ b/src/git_stage_batch/core/diff_parser.py
@@ -25,6 +25,7 @@ from .models import (
 )
 from ..exceptions import CommandError
 from ..i18n import _
+from ..git_paths import encode_path, quote_path_token
 
 
 # Type for annotator hooks that enrich LineLevelChange with additional metadata
@@ -321,7 +322,8 @@ class _UnifiedDiffParserBuildContext:
                                 new_path=new_path,
                                 lines=_empty_file_diff.synthetic_empty_file_patch_lines(
                                     b"--- /dev/null",
-                                    f"+++ b/{new_path}".encode("utf-8"),
+                                    b"+++ "
+                                    + quote_path_token(b"b/" + encode_path(new_path)),
                                 ),
                             )
                         # Skip other files without hunks (mode-only, rename-only, etc.)

--- a/src/git_stage_batch/core/diff_parser.py
+++ b/src/git_stage_batch/core/diff_parser.py
@@ -336,6 +336,17 @@ class _UnifiedDiffParserBuildContext:
                         continue
                     new_file_line = plus_line_stripped
 
+                    patch_old_path = _patch_headers.old_file_path_from_header(
+                        old_file_line
+                    )
+                    patch_new_path = _patch_headers.new_file_path_from_header(
+                        new_file_line
+                    )
+                    if _patch_headers.path_names_repository_file(patch_old_path):
+                        old_path = patch_old_path
+                    if _patch_headers.path_names_repository_file(patch_new_path):
+                        new_path = patch_new_path
+
                     if is_rename:
                         yield RenameChange(old_path=old_path, new_path=new_path)
 

--- a/src/git_stage_batch/core/diff_parser.py
+++ b/src/git_stage_batch/core/diff_parser.py
@@ -263,6 +263,12 @@ class _UnifiedDiffParserBuildContext:
                     is_rename = _file_metadata_diff.metadata_indicates_rename(
                         metadata_lines
                     )
+                    if is_rename:
+                        renamed_paths = _file_metadata_diff.rename_paths(
+                            metadata_lines
+                        )
+                        if renamed_paths is not None:
+                            old_path, new_path = renamed_paths
                     is_deleted_file = (
                         _file_metadata_diff.metadata_indicates_deleted_file(
                             metadata_lines

--- a/src/git_stage_batch/core/file_metadata_diff.py
+++ b/src/git_stage_batch/core/file_metadata_diff.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from ..git_paths import decode_path, unquote_path_token
+
 
 DELETED_FILE_MODE_PREFIX = b"deleted file mode "
 RENAME_FROM_PREFIX = b"rename from "
@@ -22,3 +24,26 @@ def metadata_indicates_deleted_file(metadata_lines: list[bytes]) -> bool:
     return any(
         line.startswith(DELETED_FILE_MODE_PREFIX) for line in metadata_lines
     )
+
+
+def rename_paths(metadata_lines: list[bytes]) -> tuple[str, str] | None:
+    """Return byte-safe old and new paths from rename metadata."""
+    old_path = next(
+        (
+            decode_path(unquote_path_token(line[len(RENAME_FROM_PREFIX):]))
+            for line in metadata_lines
+            if line.startswith(RENAME_FROM_PREFIX)
+        ),
+        None,
+    )
+    new_path = next(
+        (
+            decode_path(unquote_path_token(line[len(RENAME_TO_PREFIX):]))
+            for line in metadata_lines
+            if line.startswith(RENAME_TO_PREFIX)
+        ),
+        None,
+    )
+    if old_path is None or new_path is None:
+        return None
+    return old_path, new_path

--- a/src/git_stage_batch/core/hashing.py
+++ b/src/git_stage_batch/core/hashing.py
@@ -106,7 +106,9 @@ def compute_gitlink_change_hash(gitlink_change: GitlinkChange) -> str:
         gitlink_change.new_oid or "",
         gitlink_change.change_type,
     ]
-    return hashlib.sha256("\0".join(parts).encode("utf-8")).hexdigest()
+    return hashlib.sha256(
+        "\0".join(parts).encode("utf-8", errors="surrogateescape")
+    ).hexdigest()
 
 
 def compute_rename_change_hash(rename_change: RenameChange) -> str:
@@ -116,7 +118,9 @@ def compute_rename_change_hash(rename_change: RenameChange) -> str:
         rename_change.old_path,
         rename_change.new_path,
     ]
-    return hashlib.sha256("\0".join(parts).encode("utf-8")).hexdigest()
+    return hashlib.sha256(
+        "\0".join(parts).encode("utf-8", errors="surrogateescape")
+    ).hexdigest()
 
 
 def compute_text_file_deletion_hash(deletion_change: TextFileDeletionChange) -> str:
@@ -126,4 +130,6 @@ def compute_text_file_deletion_hash(deletion_change: TextFileDeletionChange) -> 
         deletion_change.old_path,
         deletion_change.new_path,
     ]
-    return hashlib.sha256("\0".join(parts).encode("utf-8")).hexdigest()
+    return hashlib.sha256(
+        "\0".join(parts).encode("utf-8", errors="surrogateescape")
+    ).hexdigest()

--- a/src/git_stage_batch/core/patch_headers.py
+++ b/src/git_stage_batch/core/patch_headers.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 
+from ..git_paths import decode_path, quoted_token_end, unquote_path_token
+
 
 OLD_FILE_HEADER_PREFIX = b"--- "
 NEW_FILE_HEADER_PREFIX = b"+++ "
@@ -41,6 +43,11 @@ def line_change_path(old_path: str, new_path: str) -> str:
     return new_path or old_path or ""
 
 
+def path_names_repository_file(path: str) -> bool:
+    """Return whether a patch path names a file rather than the null device."""
+    return path != DEV_NULL_PATH
+
+
 def patch_targets_file_deletion(patch_lines: Iterable[bytes]) -> bool:
     """Return whether patch lines target a deleted file path."""
     return any(line.rstrip(b"\n") == b"+++ /dev/null" for line in patch_lines)
@@ -52,7 +59,12 @@ def patch_targets_new_file(patch_lines: Iterable[bytes]) -> bool:
 
 
 def _normalized_patch_path(line: bytes, path_prefix: str) -> str:
-    path = line.split(b" ", 1)[1].strip().decode("utf-8")
+    raw_path = line.split(b" ", 1)[1]
+    if raw_path.startswith(b'"'):
+        raw_path = raw_path[:quoted_token_end(raw_path)]
+    else:
+        raw_path = raw_path.split(b"\t", 1)[0]
+    path = decode_path(unquote_path_token(raw_path))
     if path != DEV_NULL_PATH and path.startswith(path_prefix):
         return path[len(path_prefix):]
     return path

--- a/src/git_stage_batch/data/file_hunk_display.py
+++ b/src/git_stage_batch/data/file_hunk_display.py
@@ -25,6 +25,7 @@ from ..core.buffer import LineBuffer
 from ..utils.repository_buffers import load_git_object_as_buffer
 from ..i18n import ngettext
 from ..utils.git_command import stream_git_command
+from ..git_paths import encode_path, quote_path_token
 from ..utils.paths import get_context_lines
 from ..core.text_lines import bytes_to_lines
 from .file_tracking import auto_add_untracked_files
@@ -116,6 +117,8 @@ def _stream_no_index_diff_lines(
     arguments = [
         "diff",
         "--no-index",
+        "--no-ext-diff",
+        "--no-textconv",
         f"-U{get_context_lines()}",
         "--no-color",
         old_path,
@@ -135,10 +138,10 @@ def _stream_no_index_diff_lines(
             if stderr is not None:
                 stderr_chunks.append(stderr.encode("utf-8", errors="replace"))
 
-    old_header = f"a{old_path}".encode("utf-8")
-    new_header = f"b{new_path}".encode("utf-8")
-    rendered_old_header = f"a/{file_path}".encode("utf-8")
-    rendered_new_header = f"b/{file_path}".encode("utf-8")
+    old_header = b"a" + encode_path(old_path)
+    new_header = b"b" + encode_path(new_path)
+    rendered_old_header = quote_path_token(b"a/" + encode_path(file_path))
+    rendered_new_header = quote_path_token(b"b/" + encode_path(file_path))
 
     for line in bytes_to_lines(stdout_chunks()):
         yield line.replace(old_header, rendered_old_header).replace(

--- a/src/git_stage_batch/data/file_tracking.py
+++ b/src/git_stage_batch/data/file_tracking.py
@@ -6,6 +6,7 @@ from collections.abc import Iterable
 
 from ..utils.file_io import append_file_path_to_file, read_file_paths_file
 from ..utils.git_command import run_git_command
+from ..git_paths import decode_path, nul_records
 from ..utils.git_index import git_add_paths
 from ..utils.git_repository import get_git_repository_root_path
 from ..utils.journal import log_journal
@@ -25,18 +26,23 @@ def _embedded_git_repository_index_path(file_path: str) -> str | None:
 
 def list_untracked_files(paths: Iterable[str] | None = None) -> list[str]:
     """Return untracked, non-ignored files, optionally limited to paths."""
-    arguments = ["ls-files", "--others", "--exclude-standard"]
+    arguments = ["ls-files", "-z", "--others", "--exclude-standard"]
     if paths is not None:
         unique_paths = list(dict.fromkeys(paths))
         if not unique_paths:
             return []
         arguments.extend(["--", *unique_paths])
 
-    result = run_git_command(arguments, check=False, requires_index_lock=False)
+    result = run_git_command(
+        arguments,
+        check=False,
+        text_output=False,
+        requires_index_lock=False,
+    )
     if result.returncode != 0:
         return []
 
-    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    return [decode_path(path) for path in nul_records(result.stdout)]
 
 
 def auto_add_untracked_files(paths: Iterable[str] | None = None) -> None:

--- a/src/git_stage_batch/data/index_entries.py
+++ b/src/git_stage_batch/data/index_entries.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from ..utils.git_command import run_git_command
+from ..git_paths import decode_path
 
 
 @dataclass(frozen=True)
@@ -33,7 +34,7 @@ def read_index_entry(file_path: str) -> IndexEntry | None:
             metadata, path_bytes = record.split(b"\t", 1)
         except ValueError:
             continue
-        if path_bytes.decode("utf-8", errors="surrogateescape") != file_path:
+        if decode_path(path_bytes) != file_path:
             continue
 
         parts = metadata.split()

--- a/src/git_stage_batch/data/progress.py
+++ b/src/git_stage_batch/data/progress.py
@@ -18,6 +18,7 @@ from ..utils.file_io import (
     write_text_file_contents,
 )
 from ..utils.git_command import run_git_command
+from ..git_paths import decode_path, nul_records
 from ..utils.paths import (
     get_line_changes_json_file_path,
     get_discarded_hunks_file_path,
@@ -219,17 +220,21 @@ def get_file_progress() -> tuple[int, int]:
                 "-c",
                 "diff.ignoreSubmodules=none",
                 "diff",
+                "--no-ext-diff",
+                "--no-textconv",
                 "--ignore-submodules=none",
                 "--name-only",
+                "-z",
                 "HEAD",
             ],
             check=False,
+            text_output=False,
             requires_index_lock=False,
         )
         if result.returncode != 0:
             return (0, 0)
 
-        files = [f for f in result.stdout.strip().splitlines() if f.strip()]
+        files = [decode_path(path) for path in nul_records(result.stdout)]
         total = len(files)
 
         if selected_path in files:

--- a/src/git_stage_batch/data/selected_change/batch_file_cache.py
+++ b/src/git_stage_batch/data/selected_change/batch_file_cache.py
@@ -10,6 +10,7 @@ from ...core.hashing import compute_stable_hunk_hash_from_lines
 from ...core.models import RenderedBatchDisplay
 from ...exceptions import CommandError
 from ...utils.file_io import write_text_file_contents
+from ...git_paths import encode_path, quote_path_token
 from ...utils.paths import (
     get_index_snapshot_file_path,
     get_line_changes_json_file_path,
@@ -23,6 +24,12 @@ from .store import (
     write_selected_change_kind,
     write_selected_hunk_patch_lines,
 )
+
+
+def _patch_path_token(path: str) -> bytes:
+    if path == "/dev/null":
+        return b"/dev/null"
+    return quote_path_token(encode_path(path))
 
 
 def cache_batch_as_single_hunk(
@@ -75,8 +82,8 @@ def cache_rendered_batch_file_display(
     )
 
     patch_lines = [
-        f"--- {old_path}\n".encode("utf-8"),
-        f"+++ {new_path}\n".encode("utf-8"),
+        b"--- " + _patch_path_token(old_path) + b"\n",
+        b"+++ " + _patch_path_token(new_path) + b"\n",
         (
             f"@@ -{header.old_start},{header.old_len} "
             f"+{header.new_start},{header.new_len} @@\n"

--- a/src/git_stage_batch/data/selected_change/file_hunk_cache.py
+++ b/src/git_stage_batch/data/selected_change/file_hunk_cache.py
@@ -9,6 +9,7 @@ from typing import Optional
 from ...core.hashing import compute_stable_hunk_hash_from_lines
 from ...core.models import LineLevelChange
 from ...utils.file_io import write_text_file_contents
+from ...git_paths import encode_path, quote_path_token
 from ...utils.paths import (
     get_line_changes_json_file_path,
     get_processed_include_ids_file_path,
@@ -70,8 +71,8 @@ def _cache_combined_file_line_changes(
         return None
 
     patch_lines = [
-        f"--- a/{file_path}\n".encode("utf-8"),
-        f"+++ b/{file_path}\n".encode("utf-8"),
+        b"--- " + quote_path_token(b"a/" + encode_path(file_path)) + b"\n",
+        b"+++ " + quote_path_token(b"b/" + encode_path(file_path)) + b"\n",
         (
             f"@@ -{combined_line_changes.header.old_start},{combined_line_changes.header.old_len} "
             f"+{combined_line_changes.header.new_start},{combined_line_changes.header.new_len} @@\n"

--- a/src/git_stage_batch/data/session.py
+++ b/src/git_stage_batch/data/session.py
@@ -176,9 +176,8 @@ def _initialize_abort_state() -> None:
             requires_index_lock=False,
         )
         indexed_paths = [
-            path.decode("utf-8", errors="surrogateescape")
-            for path in indexed_paths_result.stdout.split(b"\0")
-            if path
+            decode_path(path)
+            for path in nul_records(indexed_paths_result.stdout)
         ]
         _snapshot_worktree_paths_for_unborn_abort(indexed_paths)
 
@@ -391,7 +390,7 @@ def snapshot_files_if_untracked(file_paths: list[str]) -> None:
     )
 
     tracked_real_content: set[str] = set()
-    for record in stage_result.stdout.split(b"\0"):
+    for record in nul_records(stage_result.stdout):
         if not record:
             continue
         try:
@@ -401,7 +400,7 @@ def snapshot_files_if_untracked(file_paths: list[str]) -> None:
         parts = metadata.split()
         if len(parts) < 2:
             continue
-        file_path = path_bytes.decode("utf-8")
+        file_path = decode_path(path_bytes)
         if file_path not in intent_to_add_paths:
             tracked_real_content.add(file_path)
 

--- a/src/git_stage_batch/data/session.py
+++ b/src/git_stage_batch/data/session.py
@@ -23,6 +23,7 @@ from ..utils.file_io import (
     write_text_file_contents,
 )
 from ..utils.git_command import run_git_command
+from ..git_paths import decode_path, nul_records
 from ..utils.git_worktree import git_remove_paths
 from ..utils.git_index import git_add_paths
 from ..utils.git_repository import get_git_repository_root_path
@@ -85,14 +86,16 @@ def _diff_index_name_status(*, intent_to_add_visible: bool) -> dict[str, str]:
             "--",
         ],
         check=True,
+        text_output=False,
         requires_index_lock=False,
     )
-    fields = result.stdout.split("\0")
-    if fields[-1] == "":
-        fields.pop()
+    fields = nul_records(result.stdout)
     if len(fields) % 2 != 0:
         raise CommandError(_("Git returned malformed cached diff output."))
-    return dict(zip(fields[1::2], fields[0::2]))
+    return {
+        decode_path(path): status.decode("ascii", errors="replace")
+        for status, path in zip(fields[0::2], fields[1::2])
+    }
 
 
 def _intent_to_add_files(file_paths: list[str] | None = None) -> list[str]:

--- a/src/git_stage_batch/data/start_time_changes.py
+++ b/src/git_stage_batch/data/start_time_changes.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 
 from ..utils.file_io import read_text_file_contents, write_text_file_contents
 from ..utils.git_command import run_git_command
+from ..git_paths import decode_path
 from ..utils.git_index import (
     GitIndexEntryUpdate,
     git_reset_paths,
@@ -78,7 +79,15 @@ def _parse_name_status_z(data: bytes) -> list[StagedChangeRecord]:
 def list_staged_change_records() -> list[StagedChangeRecord]:
     """Return staged change records using Git's normal rename detection."""
     result = run_git_command(
-        ["diff", "--cached", "--name-status", "-M", "-z"],
+        [
+            "diff",
+            "--no-ext-diff",
+            "--no-textconv",
+            "--cached",
+            "--name-status",
+            "-M",
+            "-z",
+        ],
         check=False,
         text_output=False,
         requires_index_lock=False,
@@ -127,7 +136,7 @@ def _head_entry_for_path(file_path: str) -> tuple[str, str] | None:
             metadata, path_bytes = record.split(b"\t", 1)
         except ValueError:
             continue
-        if path_bytes.decode("utf-8", errors="surrogateescape") != file_path:
+        if decode_path(path_bytes) != file_path:
             continue
         parts = metadata.split()
         if len(parts) < 3 or parts[1] != b"blob":
@@ -141,7 +150,16 @@ def _head_entry_for_path(file_path: str) -> tuple[str, str] | None:
 
 def _staged_deletion_is_text(file_path: str) -> bool:
     result = run_git_command(
-        ["diff", "--cached", "--numstat", "-z", "--", file_path],
+        [
+            "diff",
+            "--no-ext-diff",
+            "--no-textconv",
+            "--cached",
+            "--numstat",
+            "-z",
+            "--",
+            file_path,
+        ],
         check=False,
         text_output=False,
         requires_index_lock=False,

--- a/src/git_stage_batch/data/undo_restore.py
+++ b/src/git_stage_batch/data/undo_restore.py
@@ -21,6 +21,7 @@ from ..utils.file_io import read_file_paths_file
 from ..utils.git_command import (
     run_git_command,
 )
+from ..git_paths import decode_path
 from ..utils.git_refs import (
     update_git_refs,
 )
@@ -72,7 +73,7 @@ def _tree_entries(commit: str, prefix: str) -> list[tuple[str, str, str]]:
             (
                 mode,
                 object_sha,
-                path_bytes.decode("utf-8", errors="surrogateescape"),
+                decode_path(path_bytes),
             )
         )
     return entries

--- a/src/git_stage_batch/data/undo_worktree.py
+++ b/src/git_stage_batch/data/undo_worktree.py
@@ -12,6 +12,7 @@ from ..utils.git_command import run_git_command
 from ..utils.git_index import GitIndexEntryUpdate
 from ..utils.git_repository import get_git_repository_root_path
 from ..utils.git_object_io import create_git_blob
+from ..git_paths import decode_path, nul_records
 
 
 def changed_worktree_paths() -> list[str]:
@@ -22,24 +23,35 @@ def changed_worktree_paths() -> list[str]:
             "-c",
             "diff.ignoreSubmodules=none",
             "diff",
+            "--no-ext-diff",
+            "--no-textconv",
             "--ignore-submodules=none",
             "--name-only",
+            "-z",
             "HEAD",
         ],
         [
             "-c",
             "diff.ignoreSubmodules=none",
             "diff",
+            "--no-ext-diff",
+            "--no-textconv",
             "--ignore-submodules=none",
             "--cached",
             "--name-only",
+            "-z",
         ],
-        ["ls-files", "--others", "--exclude-standard"],
+        ["ls-files", "-z", "--others", "--exclude-standard"],
     ]
     for args in commands:
-        result = run_git_command(args, check=False, requires_index_lock=False)
+        result = run_git_command(
+            args,
+            check=False,
+            text_output=False,
+            requires_index_lock=False,
+        )
         if result.returncode == 0:
-            paths.update(line for line in result.stdout.splitlines() if line)
+            paths.update(decode_path(path) for path in nul_records(result.stdout))
     return sorted(paths)
 
 

--- a/src/git_stage_batch/data/undo_worktree.py
+++ b/src/git_stage_batch/data/undo_worktree.py
@@ -57,14 +57,16 @@ def changed_worktree_paths() -> list[str]:
 
 def _gitlink_oid_from_index(path: str) -> str | None:
     result = run_git_command(
-        ["ls-files", "--stage", "--", path],
+        ["ls-files", "--stage", "-z", "--", path],
         check=False,
+        text_output=False,
         requires_index_lock=False,
     )
     if result.returncode != 0:
         return None
-    for line in result.stdout.splitlines():
-        parts = line.split()
+    for record in nul_records(result.stdout):
+        metadata, _separator, _entry_path = record.partition(b"\t")
+        parts = metadata.decode("ascii", errors="replace").split()
         if len(parts) >= 2 and parts[0] == "160000":
             return parts[1]
     return None
@@ -72,15 +74,16 @@ def _gitlink_oid_from_index(path: str) -> str | None:
 
 def _gitlink_oid_from_head(path: str) -> str | None:
     result = run_git_command(
-        ["ls-tree", "HEAD", "--", path],
+        ["ls-tree", "-z", "HEAD", "--", path],
         check=False,
+        text_output=False,
         requires_index_lock=False,
     )
     if result.returncode != 0:
         return None
-    for line in result.stdout.splitlines():
-        metadata, _separator, _entry_path = line.partition("\t")
-        parts = metadata.split()
+    for record in nul_records(result.stdout):
+        metadata, _separator, _entry_path = record.partition(b"\t")
+        parts = metadata.decode("ascii", errors="replace").split()
         if len(parts) >= 3 and parts[0] == "160000" and parts[1] == "commit":
             return parts[2]
     return None

--- a/src/git_stage_batch/git_paths.py
+++ b/src/git_stage_batch/git_paths.py
@@ -1,0 +1,121 @@
+"""Byte-safe conversion and parsing for pathnames emitted by Git."""
+
+from __future__ import annotations
+
+import os
+
+from .exceptions import CommandError
+
+
+_C_ESCAPES = {
+    ord("a"): b"\a",
+    ord("b"): b"\b",
+    ord("t"): b"\t",
+    ord("n"): b"\n",
+    ord("v"): b"\v",
+    ord("f"): b"\f",
+    ord("r"): b"\r",
+    ord('"'): b'"',
+    ord("\\"): b"\\",
+}
+
+
+def encode_path(path: str) -> bytes:
+    """Encode a filesystem path without losing undecodable bytes."""
+    return os.fsencode(path)
+
+
+def decode_path(path: bytes) -> str:
+    """Decode a filesystem path without losing undecodable bytes."""
+    return os.fsdecode(path)
+
+
+def nul_records(output: bytes) -> list[bytes]:
+    """Split NUL-delimited Git output, omitting its final empty record."""
+    records = output.split(b"\0")
+    if records and not records[-1]:
+        records.pop()
+    return records
+
+
+def quote_path_token(path: bytes) -> bytes:
+    """Encode raw pathname bytes as one Git C-style quoted token."""
+    if path and all(
+        32 < value < 127 and value not in (ord('"'), ord("\\"))
+        for value in path
+    ):
+        return path
+
+    escaped = bytearray(b'"')
+    for value in path:
+        if value == ord('"'):
+            escaped.extend(b'\\"')
+        elif value == ord("\\"):
+            escaped.extend(b"\\\\")
+        elif value == ord("\t"):
+            escaped.extend(b"\\t")
+        elif value == ord("\n"):
+            escaped.extend(b"\\n")
+        elif value == ord("\r"):
+            escaped.extend(b"\\r")
+        elif 32 <= value < 127:
+            escaped.append(value)
+        else:
+            escaped.extend(f"\\{value:03o}".encode("ascii"))
+    escaped.append(ord('"'))
+    return bytes(escaped)
+
+
+def unquote_path_token(token: bytes) -> bytes:
+    """Decode one Git C-style quoted pathname token to raw bytes."""
+    if not token.startswith(b'"'):
+        return token
+    if len(token) < 2 or not token.endswith(b'"'):
+        raise CommandError("Unterminated quoted Git pathname")
+
+    result = bytearray()
+    index = 1
+    end = len(token) - 1
+    while index < end:
+        value = token[index]
+        if value != ord("\\"):
+            result.append(value)
+            index += 1
+            continue
+
+        index += 1
+        if index >= end:
+            raise CommandError("Incomplete escape in Git pathname")
+        escaped = token[index]
+        if escaped in _C_ESCAPES:
+            result.extend(_C_ESCAPES[escaped])
+            index += 1
+            continue
+        if ord("0") <= escaped <= ord("7"):
+            octal_end = index
+            while (
+                octal_end < min(index + 3, end)
+                and ord("0") <= token[octal_end] <= ord("7")
+            ):
+                octal_end += 1
+            result.append(int(token[index:octal_end], 8))
+            index = octal_end
+            continue
+        raise CommandError("Invalid escape in Git pathname")
+
+    return bytes(result)
+
+
+def quoted_token_end(data: bytes, start: int = 0) -> int:
+    """Return the exclusive end of a C-quoted token in *data*."""
+    if start >= len(data) or data[start] != ord('"'):
+        raise CommandError("Expected quoted Git pathname")
+    index = start + 1
+    while index < len(data):
+        if data[index] == ord("\\"):
+            index += 2
+            continue
+        if data[index] == ord('"'):
+            return index + 1
+        index += 1
+    raise CommandError("Unterminated quoted Git pathname")

--- a/src/git_stage_batch/utils/file_patterns.py
+++ b/src/git_stage_batch/utils/file_patterns.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from .file_io import write_text_file_contents
 from .git_command import run_git_command
+from ..git_paths import decode_path, encode_path, nul_records
 
 
 def _normalize_path(path: str) -> str:
@@ -53,7 +54,7 @@ def resolve_gitignore_style_patterns(
         )
         write_text_file_contents(temp_root / ".gitignore", "".join(f"{pattern}\n" for pattern in normalized_patterns))
 
-        payload = b"".join(candidate.encode("utf-8") + b"\0" for candidate in normalized_candidates)
+        payload = b"".join(encode_path(candidate) + b"\0" for candidate in normalized_candidates)
         result = run_git_command(
             ["check-ignore", "--no-index", "--stdin", "-z", "-v", "-n"],
             stdin_chunks=[payload],
@@ -70,21 +71,21 @@ def resolve_gitignore_style_patterns(
                 stderr=result.stderr,
             )
 
-    fields = result.stdout.split(b"\0")
+    fields = nul_records(result.stdout)
     resolved_status: dict[str, bool] = {}
     for index in range(0, len(fields) - 1, 4):
         _source, _line_number, pattern, candidate = fields[index:index + 4]
         if not candidate:
             continue
-        candidate_text = candidate.decode("utf-8")
-        pattern_text = pattern.decode("utf-8")
+        candidate_text = decode_path(candidate)
+        pattern_text = decode_path(pattern)
         resolved_status[candidate_text] = bool(pattern_text) and not pattern_text.startswith("!")
 
     return [candidate for candidate in normalized_candidates if resolved_status.get(candidate, False)]
 
 
 def _paths_from_name_status_z(output: bytes) -> list[str]:
-    fields = output.split(b"\0")
+    fields = nul_records(output)
     changed_paths: list[str] = []
     index = 0
     while index < len(fields):
@@ -101,7 +102,7 @@ def _paths_from_name_status_z(output: bytes) -> list[str]:
             path = fields[index]
             index += 1
             if path:
-                changed_paths.append(_normalize_path(path.decode("utf-8")))
+                changed_paths.append(_normalize_path(decode_path(path)))
 
     return list(dict.fromkeys(changed_paths))
 
@@ -113,6 +114,8 @@ def list_changed_files() -> list[str]:
             "-c",
             "diff.ignoreSubmodules=none",
             "diff",
+            "--no-ext-diff",
+            "--no-textconv",
             "--ignore-submodules=none",
             "--find-renames",
             "--name-status",
@@ -132,6 +135,8 @@ def list_staged_files() -> list[str]:
             "-c",
             "diff.ignoreSubmodules=none",
             "diff",
+            "--no-ext-diff",
+            "--no-textconv",
             "--cached",
             "--ignore-submodules=none",
             "--find-renames",

--- a/src/git_stage_batch/utils/git_command.py
+++ b/src/git_stage_batch/utils/git_command.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import subprocess
 import time
-from collections.abc import Iterable, Iterator, Sequence
+from collections.abc import Iterable, Iterator
 
 from . import command_events, git_index_lock
 from .command import run_command, stream_command
@@ -145,9 +145,15 @@ def stream_git_diff(
     cwd: str | None = None,
     env: dict[str, str] | None = None,
 ) -> Iterator[bytes]:
-    """Stream a Git diff using keyworded options."""
+    """Stream a normalized, raw-content Git diff using keyworded options."""
     config_arguments = []
-    arguments = []
+    arguments = [
+        "--no-ext-diff",
+        "--no-textconv",
+        "--src-prefix=a/",
+        "--dst-prefix=b/",
+        "--no-color",
+    ]
     if ignore_submodules is not None:
         config_arguments.extend(["-c", f"diff.ignoreSubmodules={ignore_submodules}"])
         arguments.append(f"--ignore-submodules={ignore_submodules}")
@@ -160,8 +166,6 @@ def stream_git_diff(
         arguments.append("--find-renames")
     if no_renames:
         arguments.append("--no-renames")
-    if no_color:
-        arguments.append("--no-color")
     if cached:
         arguments.append("--cached")
     if context_lines is not None:

--- a/src/git_stage_batch/utils/git_index.py
+++ b/src/git_stage_batch/utils/git_index.py
@@ -10,6 +10,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 
 from .git_command import run_git_command, stream_git_command
+from ..git_paths import encode_path
 from .git_repository import null_object_id
 
 
@@ -121,7 +122,7 @@ def git_update_index_entries(
     payload_chunks: list[bytes] = []
     null_oid: bytes | None = None
     for entry in entries:
-        path_bytes = entry.file_path.encode("utf-8")
+        path_bytes = encode_path(entry.file_path)
         if entry.force_remove:
             if entry.mode is not None or entry.blob_sha is not None:
                 raise ValueError("mode and blob_sha cannot be used with force_remove=True")

--- a/src/git_stage_batch/utils/git_object_io.py
+++ b/src/git_stage_batch/utils/git_object_io.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from .git_command import run_git_command, stream_git_command
+from ..git_paths import decode_path, nul_records
 
 
 _EMPTY_TREE_OBJECT_CACHE: dict[Path, str] = {}
@@ -204,7 +205,7 @@ def list_git_tree_blobs(treeish: str, file_paths: Iterable[str]) -> dict[str, Gi
         return {}
 
     entries: dict[str, GitTreeBlob] = {}
-    for record in result.stdout.split(b"\0"):
+    for record in nul_records(result.stdout):
         if not record:
             continue
         try:
@@ -214,7 +215,7 @@ def list_git_tree_blobs(treeish: str, file_paths: Iterable[str]) -> dict[str, Gi
         metadata = metadata_bytes.decode("ascii", errors="replace").split()
         if len(metadata) < 3 or metadata[1] != "blob":
             continue
-        file_path = path_bytes.decode("utf-8")
+        file_path = decode_path(path_bytes)
         entries[file_path] = GitTreeBlob(
             file_path=file_path,
             mode=metadata[0],

--- a/src/git_stage_batch/utils/journal.py
+++ b/src/git_stage_batch/utils/journal.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any
 
 from .git_command import run_git_command
+from ..git_paths import decode_path, nul_records
 from .paths import get_state_directory_path
 
 
@@ -35,23 +36,30 @@ def _get_index_state(file_path: str | None = None) -> dict[str, Any]:
     try:
         if file_path:
             ls_result = run_git_command(
-                ["ls-files", "--stage", "--", file_path],
+                ["ls-files", "--stage", "-z", "--", file_path],
                 check=False,
+                text_output=False,
                 requires_index_lock=False,
             )
         else:
-            ls_result = run_git_command(["ls-files", "--stage"], check=False, requires_index_lock=False)
+            ls_result = run_git_command(
+                ["ls-files", "--stage", "-z"],
+                check=False,
+                text_output=False,
+                requires_index_lock=False,
+            )
 
-        if ls_result.stdout.strip():
+        if ls_result.stdout:
             entries = []
-            for line in ls_result.stdout.strip().split('\n'):
-                parts = line.split()
-                if len(parts) >= 4:
+            for record in nul_records(ls_result.stdout):
+                metadata, separator, path = record.partition(b"\t")
+                parts = metadata.decode("ascii", errors="replace").split()
+                if separator and len(parts) >= 3:
                     entries.append({
                         "mode": parts[0],
                         "hash": parts[1],
                         "stage": parts[2],
-                        "path": parts[3]
+                        "path": decode_path(path),
                     })
             return entries[0] if file_path and entries else entries
         return {"status": "not_in_index"} if file_path else []

--- a/tests/core/test_diff_headers.py
+++ b/tests/core/test_diff_headers.py
@@ -19,6 +19,20 @@ def test_diff_git_paths_extracts_old_and_new_paths():
     ) == ("src/old.txt", "src/new.txt")
 
 
+def test_diff_git_paths_decodes_quoted_paths():
+    """C-quoted path tokens should round-trip special and non-UTF-8 bytes."""
+    assert diff_headers.diff_git_paths(
+        b'diff --git "a/tab\\told\\377" "b/tab\\tnew\\377"'
+    ) == ("tab\told\udcff", "tab\tnew\udcff")
+
+
+def test_diff_git_paths_uses_the_final_new_path_prefix():
+    """An old pathname containing the new-side marker is not truncated."""
+    assert diff_headers.diff_git_paths(
+        b"diff --git a/old b/component b/new name"
+    ) == ("old b/component", "new name")
+
+
 def test_diff_git_paths_returns_none_for_malformed_headers():
     """Malformed file diff headers should not yield paths."""
     assert diff_headers.diff_git_paths(b"--- a/src/old.txt") is None

--- a/tests/core/test_diff_parser_edge_cases.py
+++ b/tests/core/test_diff_parser_edge_cases.py
@@ -268,6 +268,24 @@ index 1111111..2222222 160000
         assert patches[0].new_oid == new_oid.decode("ascii")
         assert patches[0].change_type == "modified"
 
+    def test_gitlink_with_quoted_special_path(self):
+        """Gitlink paths use the same byte-safe quoted-path decoder."""
+        diff = b"""\
+diff --git "a/sub\\tmodule" "b/sub\\tmodule"
+index 1111111..2222222 160000
+--- "a/sub\\tmodule"
++++ "b/sub\\tmodule"
+@@ -1 +1 @@
+-Subproject commit 1111111111111111111111111111111111111111
++Subproject commit 2222222222222222222222222222222222222222
+"""
+
+        patches = list(collect_unified_diff(diff.splitlines(keepends=True)))
+
+        assert len(patches) == 1
+        assert isinstance(patches[0], GitlinkChange)
+        assert patches[0].path() == "sub\tmodule"
+
     def test_gitlink_added_with_hunk(self):
         """Added gitlink yields /dev/null on the old side."""
         new_oid = b"3333333333333333333333333333333333333333"

--- a/tests/core/test_file_metadata_diff.py
+++ b/tests/core/test_file_metadata_diff.py
@@ -26,3 +26,12 @@ def test_metadata_indicates_deleted_file_reads_deleted_mode_marker():
     assert not file_metadata_diff.metadata_indicates_deleted_file(
         [b"new file mode 100644"]
     )
+
+
+def test_rename_paths_decode_git_quoting():
+    assert file_metadata_diff.rename_paths(
+        [
+            b'rename from "old\\tname\\377"',
+            b'rename to "new\\nname\\377"',
+        ]
+    ) == ("old\tname\udcff", "new\nname\udcff")

--- a/tests/core/test_patch_headers.py
+++ b/tests/core/test_patch_headers.py
@@ -25,6 +25,16 @@ def test_patch_header_path_helpers_normalize_git_prefixes():
     assert patch_headers.new_file_path_from_header(b"+++ /dev/null") == "/dev/null"
 
 
+def test_patch_header_paths_decode_quotes_without_stripping_spaces():
+    """Patch paths preserve escaped bytes and significant spaces."""
+    assert patch_headers.old_file_path_from_header(
+        b'--- "a/tab\\tname\\377"'
+    ) == "tab\tname\udcff"
+    assert patch_headers.new_file_path_from_header(
+        b"+++ b/space at end \t"
+    ) == "space at end "
+
+
 def test_line_change_path_prefers_non_null_new_path():
     """Line change paths should prefer the new side unless it is /dev/null."""
     assert patch_headers.line_change_path("old.txt", "new.txt") == "new.txt"

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -114,6 +114,8 @@ def git_stage_batch(*args, input_text=None, check=True):
         cmd,
         input=input_text,
         text=True,
+        encoding="utf-8",
+        errors="surrogateescape",
         capture_output=True,
         check=check
     )

--- a/tests/functional/test_special_path_workflow.py
+++ b/tests/functional/test_special_path_workflow.py
@@ -1,0 +1,68 @@
+"""End-to-end coverage for Git path normalization."""
+
+import os
+import subprocess
+
+import pytest
+
+from .conftest import git_stage_batch
+
+
+SPECIAL_PATHS = [
+    "space name.txt",
+    "quote\"name.txt",
+    "tab\tname.txt",
+    "line\nname.txt",
+    "old b/component.txt",
+    "trailing-space.txt ",
+]
+if os.name == "posix":
+    SPECIAL_PATHS.append(os.fsdecode(b"non-utf8-\xff.txt"))
+
+
+@pytest.mark.parametrize("file_path", SPECIAL_PATHS)
+def test_special_path_include_ignores_diff_configuration(functional_repo, file_path):
+    """Every filesystem pathname survives discovery, display, and inclusion."""
+    path = functional_repo / file_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"old\n")
+    subprocess.run(
+        ["git", "add", "--", file_path],
+        check=True,
+        cwd=functional_repo,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "Add special path"],
+        check=True,
+        cwd=functional_repo,
+        capture_output=True,
+    )
+    path.write_bytes(b"new\n")
+    subprocess.run(
+        ["git", "config", "diff.noprefix", "true"],
+        check=True,
+        cwd=functional_repo,
+    )
+    subprocess.run(
+        ["git", "config", "diff.external", "false"],
+        check=True,
+        cwd=functional_repo,
+    )
+    subprocess.run(
+        ["git", "config", "core.quotePath", "false"],
+        check=True,
+        cwd=functional_repo,
+    )
+
+    git_stage_batch("start")
+    git_stage_batch("show", "--file", file_path)
+    git_stage_batch("include", "--file", file_path)
+
+    staged = subprocess.run(
+        ["git", "show", f":{file_path}"],
+        check=True,
+        cwd=functional_repo,
+        capture_output=True,
+    )
+    assert staged.stdout == b"new\n"

--- a/tests/functional/test_special_path_workflow.py
+++ b/tests/functional/test_special_path_workflow.py
@@ -129,3 +129,19 @@ def test_special_path_rename_and_binary_include(functional_repo):
     ).stdout.split(b"\0")
     assert os.fsencode(new_name) in staged_names
     assert os.fsencode(binary_name) in staged_names
+
+
+def test_special_path_discard_and_abort(functional_repo):
+    """Discard and abort restore a pathname containing a newline."""
+    path = functional_repo / "discard\nname.txt"
+    path.write_text("old\n")
+    subprocess.run(["git", "add", "--", path.name], check=True, cwd=functional_repo)
+    subprocess.run(["git", "commit", "-m", "Add path"], check=True, cwd=functional_repo)
+    path.write_text("new\n")
+
+    git_stage_batch("start")
+    git_stage_batch("show", "--file", path.name)
+    git_stage_batch("discard", "--line", "1-2")
+    assert path.read_text() == "old\n"
+    git_stage_batch("abort")
+    assert path.read_text() == "new\n"

--- a/tests/functional/test_special_path_workflow.py
+++ b/tests/functional/test_special_path_workflow.py
@@ -92,3 +92,40 @@ def test_special_added_and_deleted_paths(functional_repo):
     ).stdout.split(b"\0")
     assert os.fsencode(added_name) in staged_names
     assert os.fsencode(deleted_name) in staged_names
+
+
+def test_special_path_rename_and_binary_include(functional_repo):
+    """Quoted rename metadata and binary headers retain canonical paths."""
+    old_name = "old b/name.txt"
+    new_name = "new\nname.txt"
+    old_path = functional_repo / old_name
+    old_path.parent.mkdir(parents=True)
+    old_path.write_text("content\n")
+    binary_name = 'binary"name.bin'
+    binary_path = functional_repo / binary_name
+    binary_path.write_bytes(b"old\0bytes")
+    subprocess.run(
+        ["git", "add", "--", old_name, binary_name],
+        check=True,
+        cwd=functional_repo,
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "Add special changes"],
+        check=True,
+        cwd=functional_repo,
+    )
+    old_path.rename(functional_repo / new_name)
+    binary_path.write_bytes(b"new\0bytes")
+
+    git_stage_batch("start")
+    git_stage_batch("include", "--file", new_name)
+    git_stage_batch("include", "--file", binary_name)
+
+    staged_names = subprocess.run(
+        ["git", "diff", "--cached", "--name-only", "-z"],
+        check=True,
+        cwd=functional_repo,
+        capture_output=True,
+    ).stdout.split(b"\0")
+    assert os.fsencode(new_name) in staged_names
+    assert os.fsencode(binary_name) in staged_names

--- a/tests/functional/test_special_path_workflow.py
+++ b/tests/functional/test_special_path_workflow.py
@@ -66,3 +66,29 @@ def test_special_path_include_ignores_diff_configuration(functional_repo, file_p
         capture_output=True,
     )
     assert staged.stdout == b"new\n"
+
+
+def test_special_added_and_deleted_paths(functional_repo):
+    """Added and deleted special paths retain their complete names."""
+    deleted_name = 'deleted"name.txt'
+    deleted_path = functional_repo / deleted_name
+    deleted_path.write_text("deleted\n")
+    subprocess.run(["git", "add", "--", deleted_name], check=True, cwd=functional_repo)
+    subprocess.run(["git", "commit", "-m", "Add deleted path"], check=True, cwd=functional_repo)
+    deleted_path.unlink()
+
+    added_name = "added\nname.txt"
+    (functional_repo / added_name).write_text("added\n")
+
+    git_stage_batch("start")
+    git_stage_batch("include", "--file", added_name)
+    git_stage_batch("include", "--file", deleted_name)
+
+    staged_names = subprocess.run(
+        ["git", "diff", "--cached", "--name-only", "-z"],
+        check=True,
+        cwd=functional_repo,
+        capture_output=True,
+    ).stdout.split(b"\0")
+    assert os.fsencode(added_name) in staged_names
+    assert os.fsencode(deleted_name) in staged_names

--- a/tests/functional/test_special_path_workflow.py
+++ b/tests/functional/test_special_path_workflow.py
@@ -145,3 +145,25 @@ def test_special_path_discard_and_abort(functional_repo):
     assert path.read_text() == "old\n"
     git_stage_batch("abort")
     assert path.read_text() == "new\n"
+
+
+def test_block_and_unblock_special_path(functional_repo):
+    """Blocking resolves the same canonical tab-containing pathname."""
+    file_name = "blocked\tname.txt"
+    (functional_repo / file_name).write_text("generated\n")
+
+    git_stage_batch("block-file", file_name)
+    blocked = subprocess.run(
+        ["git", "check-ignore", "--", file_name],
+        cwd=functional_repo,
+        capture_output=True,
+    )
+    assert blocked.returncode == 0
+
+    git_stage_batch("unblock-file", file_name)
+    unblocked = subprocess.run(
+        ["git", "check-ignore", "--", file_name],
+        cwd=functional_repo,
+        capture_output=True,
+    )
+    assert unblocked.returncode == 1

--- a/tests/utils/test_git_command.py
+++ b/tests/utils/test_git_command.py
@@ -384,3 +384,30 @@ class TestStreamGitDiff:
 
         assert lines
         assert not any(b"\x1b[" in line for line in lines)
+
+    def test_stream_git_diff_overrides_format_changing_configuration(
+        self,
+        temp_git_repo,
+    ):
+        """Repository configuration cannot alter consumed diff structure."""
+        subprocess.run(
+            ["git", "config", "diff.noprefix", "true"],
+            check=True,
+            cwd=temp_git_repo,
+        )
+        subprocess.run(
+            ["git", "config", "diff.external", "false"],
+            check=True,
+            cwd=temp_git_repo,
+        )
+        test_file = temp_git_repo / "configured.txt"
+        test_file.write_text("configured\n")
+        subprocess.run(
+            ["git", "add", test_file.name],
+            check=True,
+            cwd=temp_git_repo,
+        )
+
+        lines = list(stream_git_diff(cached=True))
+
+        assert b"diff --git a/configured.txt b/configured.txt\n" in lines

--- a/tests/utils/test_git_paths.py
+++ b/tests/utils/test_git_paths.py
@@ -1,0 +1,43 @@
+"""Tests for byte-safe Git pathname helpers."""
+
+import pytest
+
+from git_stage_batch.exceptions import CommandError
+from git_stage_batch.git_paths import (
+    decode_path,
+    encode_path,
+    nul_records,
+    quote_path_token,
+    unquote_path_token,
+)
+
+
+def test_path_conversion_round_trips_non_utf8_bytes():
+    raw_path = b"name-\xff"
+
+    assert encode_path(decode_path(raw_path)) == raw_path
+
+
+def test_nul_records_preserve_newlines_and_empty_path_components():
+    assert nul_records(b"first\nname\0trailing space \0") == [
+        b"first\nname",
+        b"trailing space ",
+    ]
+
+
+def test_git_c_quoted_path_decodes_escapes_and_octal_bytes():
+    assert unquote_path_token(b'"tab\\tquote\\"slash\\\\byte\\377"') == (
+        b'tab\tquote"slash\\byte\xff'
+    )
+
+
+def test_git_c_quoted_path_round_trips_raw_bytes():
+    raw_path = b'space tab\tline\nquote"slash\\byte\xff'
+
+    assert unquote_path_token(quote_path_token(raw_path)) == raw_path
+
+
+@pytest.mark.parametrize("token", [b'"unfinished', b'"bad\\x"', b'"bad\\"'])
+def test_invalid_git_c_quoted_paths_are_rejected(token):
+    with pytest.raises(CommandError):
+        unquote_path_token(token)


### PR DESCRIPTION
Git pathname handling currently crosses several text-oriented boundaries in diff parsing, discovery, staging, persistence, and recovery.

Legal repository paths containing control characters, quotes, significant whitespace, embedded diff markers, or undecodable bytes can consequently be skipped, misidentified, or reconstructed as a different path. Repository diff configuration can also alter the grammar consumed by internal parsers.

This series introduces a byte-safe pathname layer with surrogate-preserving filesystem conversion, NUL-record parsing, and Git C-style token quoting and decoding. It normalizes streamed diffs, adopts authoritative unified and rename paths, converts path-bearing discovery to NUL records, and preserves canonical paths through staging, batches, undo, abort, and pattern-based commands.

Coverage exercises modified, added, deleted, renamed, binary, and gitlink changes across spaces, tabs, newlines, quotes, backslashes, trailing spaces, embedded ` b/`, Unicode, and non-UTF-8 POSIX names. It also validates include, discard, abort, block/unblock, hostile diff configuration, and synthetic patch round trips.

Validation: `3043 passed`; focused Ruff and whitespace checks also pass.