### PR TITLE
modes: Make executable-bit changes actionable

### DIFF
--- a/docs/batches.md
+++ b/docs/batches.md
@@ -88,6 +88,14 @@ with `include --to BATCH`, shown with `show --from BATCH`, staged with
 Because a submodule pointer has no line content in the superproject, `--line`
 is not supported for those entries.
 
+### Executable Modes
+
+Executable-bit changes are stored as atomic batch metadata with no line-content
+claims. They can be saved with `include --to` or `discard --to`, reviewed with
+`show --from`, staged or applied with `include --from` and `apply --from`,
+restored with `discard --from`, removed or moved with `reset --from`, and
+filtered with `sift`. Line selection is not supported for mode actions.
+
 ---
 
 ## `new`

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -135,6 +135,16 @@ Re-preview after editing the target file or changing the index.
 Submodule pointer changes are shown as atomic entries. They support whole-entry
 actions, but not `--line`.
 
+Executable-bit changes (`100644` ↔ `100755`) are also shown as atomic entries.
+When content and mode both change, content hunks are presented first and the
+mode remains as a separate later action. Mode actions support whole-file
+include, discard, skip, undo, redo, abort, and batch operations, but not
+`--line` or paged line review. Repositories configured with
+`core.fileMode=false` intentionally do not report executable-bit changes.
+
+Regular-file, symlink, and submodule type transitions are never treated as
+executable-bit changes. Unsupported type transitions are refused explicitly.
+
 **Options:**
 - `--file [PATH]`: Display entire file instead of single hunk
   - Without PATH: uses selected hunk's file

--- a/src/git_stage_batch/batch/file_mode_storage.py
+++ b/src/git_stage_batch/batch/file_mode_storage.py
@@ -1,0 +1,55 @@
+"""Batch persistence for atomic executable-mode changes."""
+
+from __future__ import annotations
+
+import json
+
+from ..core.buffer import LineBuffer
+from ..core.models import FileModeChange
+from ..utils.file_io import write_text_file_contents
+from ..utils.git_object_io import create_git_blob
+from ..utils.git_repository import get_git_repository_root_path
+from ..utils.paths import get_batch_metadata_file_path
+from . import content_commits as _content_commits
+from .lifecycle import create_batch
+from .query import read_batch_metadata
+from .source_snapshots import create_batch_source_commit
+from .validation import batch_exists, validate_batch_name
+
+
+def add_file_mode_to_batch(batch_name: str, change: FileModeChange) -> None:
+    """Store a mode action without claiming any file content."""
+    validate_batch_name(batch_name)
+    if not batch_exists(batch_name):
+        create_batch(batch_name, "Auto-created")
+
+    file_path = change.path()
+    full_path = get_git_repository_root_path() / file_path
+    with LineBuffer.from_path(full_path) as buffer:
+        source_commit = create_batch_source_commit(
+            file_path,
+            file_buffer_override=buffer,
+        )
+        blob_sha = create_git_blob(buffer.byte_chunks())
+
+        metadata = read_batch_metadata(batch_name)
+        metadata.setdefault("files", {})[file_path] = {
+            "file_type": "mode",
+            "batch_source_commit": source_commit,
+            "old_mode": change.old_mode,
+            "new_mode": change.new_mode,
+            "mode": change.new_mode,
+            "presence_claims": [],
+            "deletions": [],
+        }
+        write_text_file_contents(
+            get_batch_metadata_file_path(batch_name),
+            json.dumps(metadata, indent=2),
+        )
+        _content_commits.update_batch_commit(
+            batch_name,
+            file_path,
+            blob_sha,
+            change.new_mode,
+            source_buffers={file_path: buffer},
+        )

--- a/src/git_stage_batch/commands/batch_source/action_selection.py
+++ b/src/git_stage_batch/commands/batch_source/action_selection.py
@@ -212,6 +212,10 @@ def _refuse_line_selection_for_atomic_files(
     file_meta = files[file_path]
     if file_meta.get("file_type") == "binary":
         exit_with_error(binary_message)
+    if file_meta.get("file_type") == "mode":
+        exit_with_error(
+            _("Cannot use --lines with file mode actions. Use the whole action instead.")
+        )
     if is_batch_submodule_pointer(file_meta):
         refuse_batch_submodule_pointer_lines(submodule_action)
 

--- a/src/git_stage_batch/commands/batch_source/apply_action.py
+++ b/src/git_stage_batch/commands/batch_source/apply_action.py
@@ -10,6 +10,7 @@ from . import action_plans as _action_plans
 from . import action_selection as _action_selection
 from . import atomic_unit_refusals as _atomic_unit_refusals
 from . import binary_file_actions as _binary_file_actions
+from . import file_mode_actions as _file_mode_actions
 from . import candidate_preview_counts as _candidate_preview_counts
 from . import candidate_refusals as _candidate_refusals
 from . import merge_refusals as _merge_refusals
@@ -69,9 +70,13 @@ def execute_apply_action(
     failed_files = []
     candidate_counts = {}
     apply_plans = []
+    mode_actions = []
 
     for file_path, file_meta in files.items():
         try:
+            if _file_mode_actions.is_file_mode_action(file_meta):
+                mode_actions.append((file_path, file_meta))
+                continue
             if file_meta.get("file_type") == "binary":
                 batch_buffer = read_binary_file_from_batch(
                     batch_name,
@@ -191,6 +196,8 @@ def execute_apply_action(
                             plan.file_path,
                             plan.file_meta,
                         )
+                for file_path, file_meta in mode_actions:
+                    _file_mode_actions.apply_new_file_mode(file_path, file_meta)
         except CommandError:
             raise
         except Exception:

--- a/src/git_stage_batch/commands/batch_source/candidate_inputs.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_inputs.py
@@ -42,9 +42,7 @@ class CandidateIndexTarget:
 
 def is_text_candidate_entry(file_meta: dict) -> bool:
     """Return whether a batch file entry supports text candidate handling."""
-    return file_meta.get("file_type") != "binary" and not is_batch_submodule_pointer(
-        file_meta
-    )
+    return file_meta.get("file_type") not in {"binary", "mode"} and not is_batch_submodule_pointer(file_meta)
 
 
 def candidate_batch_source_ref(

--- a/src/git_stage_batch/commands/batch_source/discard_action.py
+++ b/src/git_stage_batch/commands/batch_source/discard_action.py
@@ -7,6 +7,7 @@ import sys
 from . import action_selection as _action_selection
 from . import atomic_unit_refusals as _atomic_unit_refusals
 from . import binary_file_actions as _binary_file_actions
+from . import file_mode_actions as _file_mode_actions
 from . import text_file_actions as _text_file_actions
 from . import text_plan_builders as _text_plan_builders
 from ...batch.metadata_validation import get_validated_baseline_commit
@@ -69,6 +70,9 @@ def execute_discard_action(
 
         for file_path, file_meta in files.items():
             try:
+                if _file_mode_actions.is_file_mode_action(file_meta):
+                    _file_mode_actions.apply_old_file_mode(file_path, file_meta)
+                    continue
                 if file_meta.get("file_type") == "binary":
                     snapshot_file_if_untracked(file_path)
                     binary_action = (

--- a/src/git_stage_batch/commands/batch_source/file_display_action.py
+++ b/src/git_stage_batch/commands/batch_source/file_display_action.py
@@ -9,7 +9,7 @@ from ...batch.atomic_file_changes import (
     gitlink_change_from_batch_file_metadata,
 )
 from ...batch.file_display import render_batch_file_display
-from ...core.models import LineLevelChange
+from ...core.models import FileModeChange, LineLevelChange
 from ...data.selected_change.batch_file_cache import cache_rendered_batch_file_display
 from ...data.batch_selected_changes import (
     compute_batch_binary_fingerprint,
@@ -24,6 +24,7 @@ from ...data.file_review.state import (
 from ...data.selected_change.file_changes import (
     cache_binary_file_change,
     cache_gitlink_change,
+    cache_mode_change,
 )
 from ...data.selected_change.lifecycle import clear_selected_change_state_files
 from ...data.selected_change.store import SelectedChangeKind
@@ -39,6 +40,7 @@ from ...output.hunk import print_line_level_changes
 from ...output.patch import (
     print_binary_file_change,
     print_gitlink_change,
+    print_file_mode_change,
 )
 
 
@@ -68,6 +70,25 @@ def show_batch_source_file_display(
 ) -> None:
     """Show one file from a batch source selection."""
     file_meta = files[file_path]
+    if file_meta.get("file_type") == "mode":
+        if selected_ids:
+            exit_with_error(_("Cannot use --lines with file mode actions."))
+        if page is not None:
+            exit_with_error(_("File review pages are only available for text changes."))
+        mode_change = FileModeChange(
+            file_path,
+            file_meta["old_mode"],
+            file_meta["new_mode"],
+        )
+        if selectable:
+            clear_selected_change_state_files()
+            cache_mode_change(
+                mode_change,
+                kind=SelectedChangeKind.BATCH_MODE,
+                batch_name=batch_name,
+            )
+        print_file_mode_change(mode_change)
+        return
     binary_change = binary_change_from_batch_file_metadata(
         file_path,
         file_meta,

--- a/src/git_stage_batch/commands/batch_source/file_list_action.py
+++ b/src/git_stage_batch/commands/batch_source/file_list_action.py
@@ -9,6 +9,7 @@ from ...batch.atomic_file_changes import (
     gitlink_change_from_batch_file_metadata,
 )
 from ...batch.file_display import render_batch_file_display
+from ...core.models import FileModeChange
 from ...data.file_review.records import ReviewSource
 from ...data.selected_change.clear_reasons import (
     mark_selected_change_cleared_by_file_list,
@@ -19,6 +20,7 @@ from ...output.file_review_list import (
     make_binary_file_review_list_entry,
     make_file_review_list_entry,
     make_gitlink_file_review_list_entry,
+    make_mode_file_review_list_entry,
     print_file_review_list,
 )
 
@@ -34,6 +36,17 @@ def show_batch_source_file_list(
     """Show a navigational list for multiple files from a batch."""
     entries = []
     for file_path, file_meta in files.items():
+        if file_meta.get("file_type") == "mode":
+            entries.append(
+                make_mode_file_review_list_entry(
+                    FileModeChange(
+                        file_path,
+                        file_meta["old_mode"],
+                        file_meta["new_mode"],
+                    )
+                )
+            )
+            continue
         binary_change = binary_change_from_batch_file_metadata(file_path, file_meta)
         if binary_change is not None:
             entries.append(make_binary_file_review_list_entry(binary_change))

--- a/src/git_stage_batch/commands/batch_source/file_mode_actions.py
+++ b/src/git_stage_batch/commands/batch_source/file_mode_actions.py
@@ -1,0 +1,47 @@
+"""Apply atomic batch executable-mode actions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ...data.file_modes import apply_git_file_mode
+from ...exceptions import CommandError
+from ...utils.git_command import run_git_command
+from ...utils.git_repository import get_git_repository_root_path
+
+
+def is_file_mode_action(file_meta: dict) -> bool:
+    return file_meta.get("file_type") == "mode"
+
+
+def _mode(file_meta: dict, field: str) -> str:
+    mode = file_meta.get(field)
+    if mode not in {"100644", "100755"}:
+        raise CommandError(f"Invalid batch file mode: {mode}")
+    return mode
+
+
+def stage_file_mode(file_path: str, file_meta: dict) -> None:
+    mode = _mode(file_meta, "new_mode")
+    chmod = "+x" if mode == "100755" else "-x"
+    result = run_git_command(
+        ["update-index", f"--chmod={chmod}", "--", file_path],
+        check=False,
+    )
+    if result.returncode != 0:
+        raise CommandError(f"Failed to stage file mode for {file_path}")
+
+
+def apply_new_file_mode(file_path: str, file_meta: dict) -> None:
+    _apply(file_path, _mode(file_meta, "new_mode"))
+
+
+def apply_old_file_mode(file_path: str, file_meta: dict) -> None:
+    _apply(file_path, _mode(file_meta, "old_mode"))
+
+
+def _apply(file_path: str, mode: str) -> None:
+    path: Path = get_git_repository_root_path() / file_path
+    if not path.exists() or path.is_symlink():
+        raise CommandError(f"Cannot apply executable mode to {file_path}")
+    apply_git_file_mode(path, mode)

--- a/src/git_stage_batch/commands/batch_source/include_action.py
+++ b/src/git_stage_batch/commands/batch_source/include_action.py
@@ -10,6 +10,7 @@ from . import action_plans as _action_plans
 from . import action_selection as _action_selection
 from . import atomic_unit_refusals as _atomic_unit_refusals
 from . import binary_file_actions as _binary_file_actions
+from . import file_mode_actions as _file_mode_actions
 from . import candidate_preview_counts as _candidate_preview_counts
 from . import candidate_refusals as _candidate_refusals
 from . import merge_refusals as _merge_refusals
@@ -49,9 +50,13 @@ def execute_include_action(
     failed_files = []
     candidate_counts = {}
     include_plans = []
+    mode_actions = []
 
     for file_path, file_meta in files.items():
         try:
+            if _file_mode_actions.is_file_mode_action(file_meta):
+                mode_actions.append((file_path, file_meta))
+                continue
             if file_meta.get("file_type") == "binary":
                 batch_buffer = read_binary_file_from_batch(
                     batch_name,
@@ -184,6 +189,9 @@ def execute_include_action(
                             plan.file_path,
                             plan.file_meta,
                         )
+                for file_path, file_meta in mode_actions:
+                    _file_mode_actions.stage_file_mode(file_path, file_meta)
+                    _file_mode_actions.apply_new_file_mode(file_path, file_meta)
         except CommandError:
             raise
         except Exception:

--- a/src/git_stage_batch/commands/batch_source/reset_claims.py
+++ b/src/git_stage_batch/commands/batch_source/reset_claims.py
@@ -76,7 +76,7 @@ def move_claims_between_batches(
         return
 
     for file_path, file_meta in files.items():
-        if file_meta.get("file_type") == "binary" or is_batch_submodule_pointer(
+        if file_meta.get("file_type") in {"binary", "mode"} or is_batch_submodule_pointer(
             file_meta
         ):
             dest_file_meta = (
@@ -164,6 +164,10 @@ def reset_line_claims_for_file(
     if file_meta.get("file_type") == "binary":
         exit_with_error(
             _("Cannot use --lines with binary files. Reset the whole file instead.")
+        )
+    if file_meta.get("file_type") == "mode":
+        exit_with_error(
+            _("Cannot use --lines with file modes. Reset the whole mode action instead.")
         )
     if is_batch_submodule_pointer(file_meta):
         refuse_batch_submodule_pointer_lines(_("Reset"))
@@ -307,7 +311,7 @@ def _add_ownership_to_destination(
         )
 
     if dest_file_meta is not None:
-        if dest_file_meta.get("file_type") == "binary":
+        if dest_file_meta.get("file_type") in {"binary", "mode"}:
             exit_with_error(
                 _(
                     "Destination batch already has a binary version of '{file}', "
@@ -344,6 +348,10 @@ def _acquire_line_ownership_for_file(
     if file_meta.get("file_type") == "binary":
         exit_with_error(
             _("Cannot use --lines with binary files. Reset the whole file instead.")
+        )
+    if file_meta.get("file_type") == "mode":
+        exit_with_error(
+            _("Cannot use --lines with file modes. Reset the whole mode action instead.")
         )
     if is_batch_submodule_pointer(file_meta):
         refuse_batch_submodule_pointer_lines(_("Reset"))

--- a/src/git_stage_batch/commands/batch_source/selection_state_cleanup.py
+++ b/src/git_stage_batch/commands/batch_source/selection_state_cleanup.py
@@ -31,6 +31,7 @@ def clear_selected_batch_state_after_batch_mutation(
         SelectedChangeKind.BATCH_FILE,
         SelectedChangeKind.BATCH_BINARY,
         SelectedChangeKind.BATCH_GITLINK,
+        SelectedChangeKind.BATCH_MODE,
     ):
         return
 
@@ -51,6 +52,9 @@ def clear_selected_batch_state_after_batch_mutation(
             dest_batch=dest_batch,
             selected_file=selected_file,
         )
+        return
+    if selected_kind == SelectedChangeKind.BATCH_MODE:
+        clear_selected_change_state_files()
         return
 
     review_state = read_last_file_review_state()

--- a/src/git_stage_batch/commands/batch_transform/sift_persistence.py
+++ b/src/git_stage_batch/commands/batch_transform/sift_persistence.py
@@ -17,6 +17,7 @@ from ...batch.content_commits import (
     update_batch_commit,
 )
 from ...batch.binary_file_storage import add_binary_file_to_batch
+from ...batch.file_mode_storage import add_file_mode_to_batch
 from ...batch.validation import batch_exists, validate_batch_name
 from ...core.buffer import LineBuffer
 from ...core.text_lifecycle import TextFileChangeType, normalized_text_change_type
@@ -33,7 +34,7 @@ from ...utils.git_index import (
 )
 from ...utils.git_object_io import create_git_blob
 from ...utils.paths import get_batch_metadata_file_path
-from .sift_results import SiftedBinaryFileResult, SiftedFileResult
+from .sift_results import SiftedBinaryFileResult, SiftedFileResult, SiftedModeFileResult
 
 
 RetainedSiftedFile = tuple[str, dict, SiftedFileResult]
@@ -159,6 +160,10 @@ def add_sifted_file_to_batch(
             file_mode=file_mode,
             file_buffer_override=result.target_buffer,
         )
+        return
+
+    if isinstance(result, SiftedModeFileResult):
+        add_file_mode_to_batch(batch_name, result.mode_change)
         return
 
     add_sifted_text_file_to_batch(

--- a/src/git_stage_batch/commands/batch_transform/sift_results.py
+++ b/src/git_stage_batch/commands/batch_transform/sift_results.py
@@ -24,7 +24,8 @@ from ...core.buffer import (
     buffer_matches,
 )
 from ...core.line_selection import LineRanges
-from ...core.models import BinaryFileChange
+from ...core.models import BinaryFileChange, FileModeChange
+from ...data.file_modes import detect_file_mode_from_root
 from ...core.text_lifecycle import (
     TextFileChangeType,
     normalized_text_change_type,
@@ -66,7 +67,32 @@ class SiftedTextFileResult:
         self.target_buffer.close()
 
 
-SiftedFileResult = SiftedBinaryFileResult | SiftedTextFileResult
+@dataclass
+class SiftedModeFileResult:
+    """Retained atomic executable-mode action."""
+
+    mode_change: FileModeChange
+
+    def target_source_buffer(self) -> LineBuffer | None:
+        return None
+
+    def close(self) -> None:
+        return None
+
+
+SiftedFileResult = SiftedBinaryFileResult | SiftedTextFileResult | SiftedModeFileResult
+
+
+def compute_sifted_mode_file(
+    file_path: str,
+    file_meta: dict,
+    repo_root: Path,
+) -> SiftedModeFileResult | None:
+    """Drop a mode action once its target mode is already present."""
+    change = FileModeChange(file_path, file_meta["old_mode"], file_meta["new_mode"])
+    if detect_file_mode_from_root(repo_root, file_path) == change.new_mode:
+        return None
+    return SiftedModeFileResult(change)
 
 
 def compute_sifted_binary_file(

--- a/src/git_stage_batch/commands/file_scope/discard_file.py
+++ b/src/git_stage_batch/commands/file_scope/discard_file.py
@@ -7,6 +7,7 @@ import sys
 from ...core.diff_parser import acquire_unified_diff
 from ...core.hashing import (
     compute_binary_file_hash,
+    compute_file_mode_change_hash,
     compute_gitlink_change_hash,
     compute_rename_change_hash,
     compute_stable_hunk_hash_from_lines,
@@ -15,6 +16,7 @@ from ...core.hashing import (
 from ...core.models import BinaryFileChange, RenameChange, TextFileDeletionChange
 from ...data.file_change_display import (
     render_gitlink_change,
+    render_mode_change,
     render_rename_change,
     render_text_deletion_change,
 )
@@ -32,6 +34,7 @@ from ...utils.paths import get_block_list_file_path, get_context_lines
 from ..selection.action_completion import finish_selected_change_action
 from ..selection.selected_change_discarding import (
     discard_gitlink_change,
+    discard_file_mode_change,
     discard_rename_change,
     discard_text_deletion_change,
 )
@@ -115,6 +118,16 @@ def discard_file_changes(
                 ),
                 file=sys.stderr,
             )
+            finish_selected_change_action(quiet=False, auto_advance=auto_advance)
+            return
+
+        mode_change = render_mode_change(target_file)
+        if mode_change is not None:
+            patch_hash = compute_file_mode_change_hash(mode_change)
+            discard_file_mode_change(mode_change)
+            append_lines_to_file(blocklist_path, [patch_hash])
+            record_hunk_discarded(patch_hash)
+            print(_("✓ File mode discarded: {}").format(target_file), file=sys.stderr)
             finish_selected_change_action(quiet=False, auto_advance=auto_advance)
             return
 

--- a/src/git_stage_batch/commands/file_scope/discard_file_to_batch.py
+++ b/src/git_stage_batch/commands/file_scope/discard_file_to_batch.py
@@ -15,7 +15,7 @@ from ...batch.validation import batch_exists
 from ...core.buffer import LineBuffer
 from ...core.diff_parser import acquire_unified_diff, build_line_changes_from_patch_lines
 from ...core.hashing import compute_stable_hunk_hash_from_lines
-from ...core.models import BinaryFileChange, GitlinkChange, RenameChange, TextFileDeletionChange
+from ...core.models import BinaryFileChange, FileModeChange, GitlinkChange, RenameChange, TextFileDeletionChange
 from ...core.text_lifecycle import TextFileChangeType
 from ...data.file_change_display import (
     render_binary_file_change,
@@ -88,6 +88,7 @@ def discard_file_to_batch(
     with ExitStack() as patch_stack:
         all_lines_to_batch = []
         patches_to_discard = []
+        mode_change = None
 
         with acquire_unified_diff(
             stream_live_git_diff(
@@ -97,6 +98,9 @@ def discard_file_to_batch(
             )
         ) as patches:
             for patch in patches:
+                if isinstance(patch, FileModeChange):
+                    mode_change = patch
+                    continue
                 if isinstance(patch, RenameChange):
                     continue
 
@@ -124,6 +128,14 @@ def discard_file_to_batch(
                 ))
 
         if not all_lines_to_batch:
+            if mode_change is not None:
+                _whole_file_batch_discarding.discard_mode_to_batch(
+                    batch_name,
+                    mode_change,
+                    quiet=quiet,
+                    auto_advance=auto_advance,
+                )
+                return 1
             repo_root = get_git_repository_root_path()
             full_path = repo_root / file_path
             lifecycle_change_type = detect_empty_text_lifecycle_change(file_path)

--- a/src/git_stage_batch/commands/file_scope/discard_to_batch.py
+++ b/src/git_stage_batch/commands/file_scope/discard_to_batch.py
@@ -15,7 +15,7 @@ from ...batch.validation import batch_exists
 from ...core.buffer import LineBuffer
 from ...core.diff_parser import acquire_unified_diff, build_line_changes_from_patch_lines
 from ...core.hashing import compute_stable_hunk_hash_from_lines
-from ...core.models import BinaryFileChange, GitlinkChange, RenameChange, TextFileDeletionChange
+from ...core.models import BinaryFileChange, FileModeChange, GitlinkChange, RenameChange, TextFileDeletionChange
 from ...data.file_modes import detect_file_mode_from_root
 from ...data.file_tracking import auto_add_untracked_files
 from ...data.live_diff import stream_live_git_diff
@@ -226,6 +226,8 @@ def _collect_text_file_discard_inputs(
         )
     ) as patches:
         for patch in patches:
+            if isinstance(patch, FileModeChange):
+                continue
             if isinstance(patch, RenameChange):
                 continue
 

--- a/src/git_stage_batch/commands/file_scope/file_display_action.py
+++ b/src/git_stage_batch/commands/file_scope/file_display_action.py
@@ -9,6 +9,7 @@ from ...data.file_change_display import (
     render_binary_file_change,
     render_gitlink_change,
     render_rename_change,
+    render_mode_change,
     render_text_deletion_change,
 )
 from ...data.file_hunk_display import render_file_as_single_hunk
@@ -24,6 +25,7 @@ from ...data.selected_change.file_changes import (
     cache_binary_file_change,
     cache_gitlink_change,
     cache_rename_change,
+    cache_mode_change,
     cache_text_deletion_change,
 )
 from ...data.selected_change.paths import get_selected_change_file_path
@@ -41,6 +43,7 @@ from ...output.patch import (
     print_binary_file_change,
     print_gitlink_change,
     print_rename_change,
+    print_file_mode_change,
     print_text_file_deletion_change,
 )
 
@@ -98,6 +101,7 @@ def show_live_file_display(
         and gitlink_change is None
         else None
     )
+    mode_change = render_mode_change(target_file) if preview_lines is None else None
 
     if deletion_change is not None:
         if page is not None:
@@ -119,6 +123,17 @@ def show_live_file_display(
         if porcelain:
             return
         print_rename_change(rename_change)
+        return
+
+    if mode_change is not None:
+        if page is not None:
+            exit_with_error(_("File review pages are only available for text changes."))
+        if selectable:
+            clear_last_file_review_state()
+            cache_mode_change(mode_change)
+        if porcelain:
+            return
+        print_file_mode_change(mode_change)
         return
 
     if gitlink_change is not None:

--- a/src/git_stage_batch/commands/file_scope/file_list_action.py
+++ b/src/git_stage_batch/commands/file_scope/file_list_action.py
@@ -9,6 +9,7 @@ from ...data.change_freshness import text_deletion_change_is_batched
 from ...data.file_change_display import (
     render_binary_file_change,
     render_gitlink_change,
+    render_mode_change,
     render_rename_change,
     render_text_deletion_change,
 )
@@ -23,6 +24,7 @@ from ...output.file_review_list import (
     make_binary_file_review_list_entry,
     make_file_review_list_entry,
     make_gitlink_file_review_list_entry,
+    make_mode_file_review_list_entry,
     make_rename_file_review_list_entry,
     make_text_deletion_file_review_list_entry,
     print_file_review_list,
@@ -37,6 +39,10 @@ def show_live_file_list(files: list[str], *, selectable: bool = True) -> None:
         line_changes = render_file_as_single_hunk(file_path)
         if line_changes is not None:
             entries.append(make_file_review_list_entry(line_changes))
+            continue
+        mode_change = render_mode_change(file_path)
+        if mode_change is not None:
+            entries.append(make_mode_file_review_list_entry(mode_change))
             continue
         deletion_change = render_text_deletion_change(file_path)
         if deletion_change is not None and not text_deletion_change_is_batched(

--- a/src/git_stage_batch/commands/file_scope/include_file.py
+++ b/src/git_stage_batch/commands/file_scope/include_file.py
@@ -8,12 +8,13 @@ from ...core.buffer import LineBuffer
 from ...core.diff_parser import acquire_unified_diff, patch_is_file_deletion
 from ...core.hashing import (
     compute_binary_file_hash,
+    compute_file_mode_change_hash,
     compute_gitlink_change_hash,
     compute_rename_change_hash,
     compute_stable_hunk_hash_from_lines,
     compute_text_file_deletion_hash,
 )
-from ...core.models import BinaryFileChange, GitlinkChange, RenameChange, TextFileDeletionChange
+from ...core.models import BinaryFileChange, FileModeChange, GitlinkChange, RenameChange, TextFileDeletionChange
 from ...data.file_tracking import auto_add_untracked_files
 from ...data.live_diff import stream_live_git_diff
 from ...data.progress import record_hunk_included
@@ -77,6 +78,14 @@ def include_file_changes(
             )
         ) as patches:
             for patch in patches:
+                if isinstance(patch, FileModeChange):
+                    if patch.path() != target_file:
+                        continue
+                    _selected_change_staging.stage_file_mode_change(patch)
+                    record_hunk_included(compute_file_mode_change_hash(patch))
+                    hunks_staged += 1
+                    continue
+
                 if isinstance(patch, RenameChange):
                     if target_file not in (patch.old_path, patch.new_path):
                         continue

--- a/src/git_stage_batch/commands/file_scope/include_file_to_batch.py
+++ b/src/git_stage_batch/commands/file_scope/include_file_to_batch.py
@@ -12,7 +12,7 @@ from ...batch.query import read_batch_metadata
 from ...batch.text_file_storage import add_file_to_batch
 from ...batch.validation import batch_exists
 from ...core.diff_parser import acquire_unified_diff, build_line_changes_from_patch_lines
-from ...core.models import RenameChange, TextFileDeletionChange
+from ...core.models import FileModeChange, RenameChange, TextFileDeletionChange
 from ...data.file_change_display import (
     render_binary_file_change,
     render_gitlink_change,
@@ -74,6 +74,7 @@ def include_file_to_batch(
 
     file_mode = detect_file_mode(file_path)
     all_lines_to_batch = []
+    mode_change = None
 
     with acquire_unified_diff(
         stream_live_git_diff(
@@ -83,6 +84,9 @@ def include_file_to_batch(
         )
     ) as patches:
         for patch in patches:
+            if isinstance(patch, FileModeChange):
+                mode_change = patch
+                continue
             if isinstance(patch, (RenameChange, TextFileDeletionChange)):
                 continue
             hunk_lines = build_line_changes_from_patch_lines(
@@ -92,6 +96,14 @@ def include_file_to_batch(
             all_lines_to_batch.extend(hunk_lines.lines)
 
     if not all_lines_to_batch:
+        if mode_change is not None:
+            _whole_file_batch_staging.include_mode_to_batch(
+                batch_name,
+                mode_change,
+                quiet=quiet,
+                auto_advance=auto_advance,
+            )
+            return
         if (
             _whole_file_batch_staging.save_empty_text_lifecycle_to_batch(
                 batch_name,

--- a/src/git_stage_batch/commands/file_scope/skip_file.py
+++ b/src/git_stage_batch/commands/file_scope/skip_file.py
@@ -7,6 +7,7 @@ import sys
 from ...core.diff_parser import acquire_unified_diff, build_line_changes_from_patch_lines
 from ...core.hashing import (
     compute_binary_file_hash,
+    compute_file_mode_change_hash,
     compute_gitlink_change_hash,
     compute_rename_change_hash,
     compute_stable_hunk_hash_from_lines,
@@ -14,6 +15,7 @@ from ...core.hashing import (
 )
 from ...core.models import (
     BinaryFileChange,
+    FileModeChange,
     GitlinkChange,
     RenameChange,
     TextFileDeletionChange,
@@ -24,6 +26,7 @@ from ...data.progress import (
     record_binary_hunk_skipped,
     record_gitlink_hunk_skipped,
     record_hunk_skipped,
+    record_mode_change_skipped,
     record_rename_hunk_skipped,
     record_text_deletion_hunk_skipped,
 )
@@ -73,6 +76,18 @@ def skip_file_changes(
             )
         ) as patches:
             for patch in patches:
+                if isinstance(patch, FileModeChange):
+                    if patch.path() != target_file:
+                        continue
+                    patch_hash = compute_file_mode_change_hash(patch)
+                    if patch_hash in blocked_hashes:
+                        continue
+                    append_lines_to_file(blocklist_path, [patch_hash])
+                    blocked_hashes.add(patch_hash)
+                    record_mode_change_skipped(patch, patch_hash)
+                    hunks_skipped += 1
+                    continue
+
                 if isinstance(patch, RenameChange):
                     if target_file not in (patch.old_path, patch.new_path):
                         continue

--- a/src/git_stage_batch/commands/selection/discard_to_batch_action.py
+++ b/src/git_stage_batch/commands/selection/discard_to_batch_action.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from ...core.models import BinaryFileChange, RenameChange, TextFileDeletionChange
+from ...core.models import BinaryFileChange, FileModeChange, RenameChange, TextFileDeletionChange
 from ...data.file_review.action_scope import finish_review_scoped_line_action
 from ...data.selected_change.loading import load_selected_change
 from ...data.selected_change.store import (
@@ -38,6 +38,20 @@ def execute_discard_to_batch_action(
         operation_parts.extend(["--file", file])
 
     with undo_checkpoint(" ".join(operation_parts)):
+        if (
+            file is None
+            and line_ids is None
+            and read_selected_change_kind() == SelectedChangeKind.MODE
+        ):
+            selected_change = load_selected_change()
+            if isinstance(selected_change, FileModeChange):
+                return _whole_file_batch_discarding.discard_mode_to_batch(
+                    batch_name,
+                    selected_change,
+                    quiet=quiet,
+                    auto_advance=auto_advance,
+                )
+
         if (
             file is None
             and line_ids is None

--- a/src/git_stage_batch/commands/selection/include_to_batch_action.py
+++ b/src/git_stage_batch/commands/selection/include_to_batch_action.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from ...core.models import (
     BinaryFileChange,
+    FileModeChange,
     GitlinkChange,
     RenameChange,
     TextFileDeletionChange,
@@ -42,6 +43,21 @@ def execute_include_to_batch_action(
         operation_parts.extend(["--file", file])
 
     with undo_checkpoint(" ".join(operation_parts)):
+        if (
+            file is None
+            and line_ids is None
+            and read_selected_change_kind() == SelectedChangeKind.MODE
+        ):
+            selected_change = load_selected_change()
+            if isinstance(selected_change, FileModeChange):
+                _whole_file_batch_staging.include_mode_to_batch(
+                    batch_name,
+                    selected_change,
+                    quiet=quiet,
+                    auto_advance=auto_advance,
+                )
+                return
+
         if (
             file is None
             and line_ids is None

--- a/src/git_stage_batch/commands/selection/next_change_display.py
+++ b/src/git_stage_batch/commands/selection/next_change_display.py
@@ -8,6 +8,7 @@ from ...batch.source_annotation import annotate_with_batch_source
 from ...core.diff_parser import acquire_unified_diff, build_line_changes_from_patch_lines
 from ...core.hashing import (
     compute_binary_file_hash,
+    compute_file_mode_change_hash,
     compute_gitlink_change_hash,
     compute_rename_change_hash,
     compute_stable_hunk_hash_from_lines,
@@ -15,6 +16,7 @@ from ...core.hashing import (
 )
 from ...core.models import (
     BinaryFileChange,
+    FileModeChange,
     GitlinkChange,
     RenameChange,
     TextFileDeletionChange,
@@ -25,6 +27,7 @@ from ...data.line_state import load_line_changes_from_state
 from ...data.live_diff import stream_live_git_diff
 from ...data.selected_change.file_changes import (
     cache_binary_file_change,
+    cache_mode_change,
     cache_gitlink_change,
     cache_rename_change,
     cache_text_deletion_change,
@@ -41,6 +44,7 @@ from ...i18n import _
 from ...output.hunk import print_line_level_changes
 from ...output.patch import (
     print_binary_file_change,
+    print_file_mode_change,
     print_gitlink_change,
     print_rename_change,
     print_text_file_deletion_change,
@@ -69,6 +73,17 @@ def show_next_unprocessed_change(
             )
         ) as patches:
             for patch in patches:
+                if isinstance(patch, FileModeChange):
+                    mode_hash = compute_file_mode_change_hash(patch)
+                    if mode_hash not in blocked_hashes:
+                        cache_mode_change(patch)
+                        if selectable:
+                            clear_last_file_review_state()
+                        if not porcelain:
+                            print_file_mode_change(patch)
+                        return
+                    continue
+
                 if isinstance(patch, RenameChange):
                     rename_hash = compute_rename_change_hash(patch)
                     if rename_hash not in blocked_hashes:

--- a/src/git_stage_batch/commands/selection/selected_change_discarding.py
+++ b/src/git_stage_batch/commands/selection/selected_change_discarding.py
@@ -10,6 +10,7 @@ from ...core.buffer import LineBuffer
 from ...core.diff_parser import build_line_changes_from_patch_lines, patch_is_new_file
 from ...core.models import (
     BinaryFileChange,
+    FileModeChange,
     GitlinkChange,
     RenameChange,
     TextFileDeletionChange,
@@ -19,6 +20,7 @@ from ...data.progress import record_hunk_discarded
 from ...data.selected_change.loading import load_selected_change
 from ...data.selected_change.paths import worktree_paths_for_selected_change
 from ...data.session import snapshot_file_if_untracked, snapshot_files_if_untracked
+from ...data.file_modes import apply_git_file_mode
 from ...data.undo_checkpoints import undo_checkpoint
 from ...exceptions import CommandError, NoMoreHunks, exit_with_error
 from ...i18n import _
@@ -88,6 +90,14 @@ def _discard_loaded_selected_change(
     """Discard one loaded selected change from the working tree."""
     patch_hash = read_text_file_contents(get_selected_hunk_hash_file_path()).strip()
 
+    if isinstance(item, FileModeChange):
+        discard_file_mode_change(item)
+        append_lines_to_file(get_block_list_file_path(), [patch_hash])
+        record_hunk_discarded(patch_hash)
+        if not quiet:
+            print(_("✓ File mode discarded: {file}").format(file=item.path()), file=sys.stderr)
+        finish_selected_change_action(quiet=quiet, auto_advance=auto_advance)
+        return
     if isinstance(item, RenameChange):
         discard_rename_change(item)
         append_lines_to_file(get_block_list_file_path(), [patch_hash])
@@ -219,6 +229,12 @@ def _discard_binary_change(
         quiet=quiet,
         auto_advance=auto_advance,
     )
+
+
+def discard_file_mode_change(item: FileModeChange) -> None:
+    """Restore the old executable mode in the working tree."""
+    path = get_git_repository_root_path() / item.path()
+    apply_git_file_mode(path, item.old_mode)
 
 
 def _discard_text_hunk(

--- a/src/git_stage_batch/commands/selection/selected_change_display.py
+++ b/src/git_stage_batch/commands/selection/selected_change_display.py
@@ -7,6 +7,7 @@ from ...data.selected_change.store import load_line_changes_from_patch_path
 from ...data.selected_change.file_changes import (
     load_selected_binary_file,
     load_selected_gitlink_change,
+    load_selected_mode_change,
     load_selected_rename_change,
     load_selected_text_deletion_change,
 )
@@ -14,6 +15,7 @@ from ...output.hunk import print_line_level_changes
 from ...output.patch import (
     print_binary_file_change,
     print_gitlink_change,
+    print_file_mode_change,
     print_rename_change,
     print_text_file_deletion_change,
 )
@@ -25,6 +27,11 @@ def show_selected_change() -> None:
     rename_change = load_selected_rename_change()
     if rename_change is not None:
         print_rename_change(rename_change)
+        return
+
+    mode_change = load_selected_mode_change()
+    if mode_change is not None:
+        print_file_mode_change(mode_change)
         return
 
     deletion_change = load_selected_text_deletion_change()

--- a/src/git_stage_batch/commands/selection/selected_change_skipping.py
+++ b/src/git_stage_batch/commands/selection/selected_change_skipping.py
@@ -6,6 +6,7 @@ import sys
 
 from ...core.models import (
     BinaryFileChange,
+    FileModeChange,
     GitlinkChange,
     RenameChange,
     TextFileDeletionChange,
@@ -15,6 +16,7 @@ from ...data.progress import (
     record_binary_hunk_skipped,
     record_gitlink_hunk_skipped,
     record_hunk_skipped,
+    record_mode_change_skipped,
     record_rename_hunk_skipped,
     record_text_deletion_hunk_skipped,
 )
@@ -66,6 +68,14 @@ def _skip_loaded_selected_change(
     """Skip one loaded selected change."""
     patch_hash = read_text_file_contents(get_selected_hunk_hash_file_path()).strip()
     blocklist_path = get_block_list_file_path()
+
+    if isinstance(item, FileModeChange):
+        append_lines_to_file(blocklist_path, [patch_hash])
+        record_mode_change_skipped(item, patch_hash)
+        if not quiet:
+            print(_("✓ File mode skipped: {file}").format(file=item.path()), file=sys.stderr)
+        finish_selected_change_action(quiet=quiet, auto_advance=auto_advance)
+        return
 
     if isinstance(item, RenameChange):
         append_lines_to_file(blocklist_path, [patch_hash])

--- a/src/git_stage_batch/commands/selection/selected_change_staging.py
+++ b/src/git_stage_batch/commands/selection/selected_change_staging.py
@@ -9,6 +9,7 @@ from ...core.buffer import LineBuffer
 from ...core.diff_parser import patch_is_file_deletion
 from ...core.models import (
     BinaryFileChange,
+    FileModeChange,
     GitlinkChange,
     RenameChange,
     TextFileDeletionChange,
@@ -31,6 +32,7 @@ from ...utils.git_index import (
     git_update_index,
     git_update_index_entries,
 )
+from ...utils.git_command import run_git_command
 from ...utils.paths import (
     get_selected_hunk_hash_file_path,
     get_selected_hunk_patch_file_path,
@@ -73,6 +75,13 @@ def _include_loaded_selected_change(
     """Include one loaded selected change in the index."""
     patch_hash = read_text_file_contents(get_selected_hunk_hash_file_path()).strip()
 
+    if isinstance(item, FileModeChange):
+        stage_file_mode_change(item)
+        record_hunk_included(patch_hash)
+        if not quiet:
+            print(_("✓ File mode staged: {file}").format(file=item.path()), file=sys.stderr)
+        finish_selected_change_action(quiet=quiet, auto_advance=auto_advance)
+        return
     if isinstance(item, RenameChange):
         stage_rename_change(item)
         record_hunk_included(patch_hash)
@@ -200,6 +209,17 @@ def _include_loaded_selected_change(
         quiet=quiet,
         auto_advance=auto_advance,
     )
+
+
+def stage_file_mode_change(item: FileModeChange) -> None:
+    """Stage one executable-mode transition in the index."""
+    chmod = "+x" if item.new_mode == "100755" else "-x"
+    result = run_git_command(
+        ["update-index", f"--chmod={chmod}", "--", item.path()],
+        check=False,
+    )
+    if result.returncode != 0:
+        exit_with_error(_("Failed to stage executable mode change."))
 
 
 def stage_gitlink_change(gitlink_change: GitlinkChange) -> subprocess.CompletedProcess:

--- a/src/git_stage_batch/commands/selection/whole_file_batch_discarding.py
+++ b/src/git_stage_batch/commands/selection/whole_file_batch_discarding.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 import sys
 
 from ...batch.binary_file_storage import add_binary_file_to_batch
+from ...batch.file_mode_storage import add_file_mode_to_batch
 from ...batch.ownership import BatchOwnership
 from ...batch.text_file_storage import add_file_to_batch
-from ...core.hashing import compute_binary_file_hash, compute_text_file_deletion_hash
-from ...core.models import BinaryFileChange, TextFileDeletionChange
+from ...core.hashing import compute_binary_file_hash, compute_file_mode_change_hash, compute_text_file_deletion_hash
+from ...core.models import BinaryFileChange, FileModeChange, TextFileDeletionChange
 from ...core.text_lifecycle import TextFileChangeType
 from ...data.file_modes import detect_file_mode
+from ...data.file_modes import apply_git_file_mode
 from ...data.progress import record_hunk_discarded
 from ...data.session import snapshot_file_if_untracked
 from ...exceptions import exit_with_error
@@ -76,6 +78,33 @@ def discard_binary_to_batch(
 
     if advance:
         finish_selected_change_action(quiet=quiet, auto_advance=auto_advance)
+    return 1
+
+
+def discard_mode_to_batch(
+    batch_name: str,
+    mode_change: FileModeChange,
+    *,
+    quiet: bool = False,
+    auto_advance: bool | None = None,
+) -> int:
+    """Save a mode action to a batch and restore its old worktree mode."""
+    patch_hash = compute_file_mode_change_hash(mode_change)
+    add_file_mode_to_batch(batch_name, mode_change)
+    apply_git_file_mode(
+        get_git_repository_root_path() / mode_change.path(),
+        mode_change.old_mode,
+    )
+    append_lines_to_file(get_block_list_file_path(), [patch_hash])
+    record_hunk_discarded(patch_hash)
+    if not quiet:
+        print(
+            _("Discarded file mode '{file}' to batch '{batch}'").format(
+                file=mode_change.path(), batch=batch_name
+            ),
+            file=sys.stderr,
+        )
+    finish_selected_change_action(quiet=quiet, auto_advance=auto_advance)
     return 1
 
 

--- a/src/git_stage_batch/commands/selection/whole_file_batch_staging.py
+++ b/src/git_stage_batch/commands/selection/whole_file_batch_staging.py
@@ -6,6 +6,7 @@ import sys
 
 from ...batch.binary_file_storage import add_binary_file_to_batch
 from ...batch.gitlink_storage import add_gitlink_to_batch
+from ...batch.file_mode_storage import add_file_mode_to_batch
 from ...batch.ownership import BatchOwnership
 from ...batch.text_file_storage import (
     add_file_to_batch,
@@ -13,14 +14,16 @@ from ...batch.text_file_storage import (
 from ...core.hashing import (
     compute_binary_file_hash,
     compute_gitlink_change_hash,
+    compute_file_mode_change_hash,
     compute_text_file_deletion_hash,
 )
-from ...core.models import BinaryFileChange, GitlinkChange, TextFileDeletionChange
+from ...core.models import BinaryFileChange, FileModeChange, GitlinkChange, TextFileDeletionChange
 from ...core.text_lifecycle import TextFileChangeType
 from ...data.file_modes import detect_file_mode
 from ...data.progress import (
     record_binary_hunk_skipped,
     record_gitlink_hunk_skipped,
+    record_mode_change_skipped,
     record_text_deletion_hunk_skipped,
 )
 from ...data.session import snapshot_file_if_untracked
@@ -113,6 +116,28 @@ def include_binary_to_batch(
             file=sys.stderr,
         )
 
+    finish_selected_change_action(quiet=quiet, auto_advance=auto_advance)
+
+
+def include_mode_to_batch(
+    batch_name: str,
+    mode_change: FileModeChange,
+    *,
+    quiet: bool = False,
+    auto_advance: bool | None = None,
+) -> None:
+    """Save one executable-mode action to a batch without content claims."""
+    patch_hash = compute_file_mode_change_hash(mode_change)
+    add_file_mode_to_batch(batch_name, mode_change)
+    append_lines_to_file(get_block_list_file_path(), [patch_hash])
+    record_mode_change_skipped(mode_change, patch_hash)
+    if not quiet:
+        print(
+            _("Included file mode '{file}' to batch '{batch}'").format(
+                file=mode_change.path(), batch=batch_name
+            ),
+            file=sys.stderr,
+        )
     finish_selected_change_action(quiet=quiet, auto_advance=auto_advance)
 
 

--- a/src/git_stage_batch/commands/sift.py
+++ b/src/git_stage_batch/commands/sift.py
@@ -91,8 +91,13 @@ def command_sift_batch(source_batch: str, dest_batch: str) -> None:
 
         for file_path, file_meta in source_files.items():
             is_binary = file_meta.get("file_type") == "binary"
+            is_mode = file_meta.get("file_type") == "mode"
 
-            if is_binary:
+            if is_mode:
+                result = _sift_results.compute_sifted_mode_file(
+                    file_path, file_meta, repo_root
+                )
+            elif is_binary:
                 result = _sift_results.compute_sifted_binary_file(
                     file_path,
                     file_meta,

--- a/src/git_stage_batch/core/diff_parser.py
+++ b/src/git_stage_batch/core/diff_parser.py
@@ -16,6 +16,7 @@ from . import patch_headers as _patch_headers
 from .buffer import LineBuffer
 from .models import (
     BinaryFileChange,
+    FileModeChange,
     GitlinkChange,
     LineLevelChange,
     HunkHeader,
@@ -30,7 +31,7 @@ from ..git_paths import encode_path, quote_path_token
 
 # Type for annotator hooks that enrich LineLevelChange with additional metadata
 LineLevelChangeAnnotator = Callable[[str, LineLevelChange], LineLevelChange]
-UnifiedDiffItem = Union[SingleHunkPatch, BinaryFileChange, GitlinkChange, RenameChange, TextFileDeletionChange]
+UnifiedDiffItem = Union[SingleHunkPatch, BinaryFileChange, FileModeChange, GitlinkChange, RenameChange, TextFileDeletionChange]
 
 
 def patch_is_file_deletion(patch_lines: Iterable[bytes]) -> bool:
@@ -269,6 +270,28 @@ class _UnifiedDiffParserBuildContext:
                         )
                         if renamed_paths is not None:
                             old_path, new_path = renamed_paths
+                    mode_transition = _file_metadata_diff.executable_mode_change(
+                        metadata_lines
+                    )
+                    type_transition = _file_metadata_diff.file_type_change(
+                        metadata_lines
+                    )
+                    if type_transition is not None and not is_gitlink:
+                        raise CommandError(
+                            _(
+                                "File type changes are atomic and are not supported yet: "
+                                "{file} ({old} -> {new})"
+                            ).format(
+                                file=old_path,
+                                old=type_transition[0],
+                                new=type_transition[1],
+                            )
+                        )
+                    mode_change = (
+                        FileModeChange(old_path, *mode_transition)
+                        if mode_transition is not None
+                        else None
+                    )
                     is_deleted_file = (
                         _file_metadata_diff.metadata_indicates_deleted_file(
                             metadata_lines
@@ -311,6 +334,8 @@ class _UnifiedDiffParserBuildContext:
                                     metadata_lines
                                 ),
                             )
+                            if mode_change is not None:
+                                yield mode_change
                             continue
 
                         if is_rename:
@@ -332,6 +357,8 @@ class _UnifiedDiffParserBuildContext:
                                     + quote_path_token(b"b/" + encode_path(new_path)),
                                 ),
                             )
+                        if mode_change is not None:
+                            yield mode_change
                         # Skip other files without hunks (mode-only, rename-only, etc.)
                         continue
 
@@ -398,7 +425,7 @@ class _UnifiedDiffParserBuildContext:
                         # Check if next line is a hunk header
                         hunk_header_line = peek_line()
                         if hunk_header_line is None:
-                            return
+                            break
                         hunk_header_stripped = hunk_header_line.rstrip(b'\n')
                         if not _hunk_headers.line_is_hunk_header(
                             hunk_header_stripped
@@ -468,6 +495,8 @@ class _UnifiedDiffParserBuildContext:
                             )
                         elif is_deleted_file:
                             yield TextFileDeletionChange(old_path=old_path)
+                    if mode_change is not None:
+                        yield mode_change
         finally:
             close = getattr(line_iter, "close", None)
             if close is not None:

--- a/src/git_stage_batch/core/file_metadata_diff.py
+++ b/src/git_stage_batch/core/file_metadata_diff.py
@@ -6,6 +6,8 @@ from ..git_paths import decode_path, unquote_path_token
 
 
 DELETED_FILE_MODE_PREFIX = b"deleted file mode "
+OLD_MODE_PREFIX = b"old mode "
+NEW_MODE_PREFIX = b"new mode "
 RENAME_FROM_PREFIX = b"rename from "
 RENAME_TO_PREFIX = b"rename to "
 
@@ -47,3 +49,50 @@ def rename_paths(metadata_lines: list[bytes]) -> tuple[str, str] | None:
     if old_path is None or new_path is None:
         return None
     return old_path, new_path
+
+
+def executable_mode_change(
+    metadata_lines: list[bytes],
+) -> tuple[str, str] | None:
+    """Return a regular-file executable-bit transition, if present."""
+    old_mode = next(
+        (
+            line[len(OLD_MODE_PREFIX):].decode("ascii", errors="replace")
+            for line in metadata_lines
+            if line.startswith(OLD_MODE_PREFIX)
+        ),
+        None,
+    )
+    new_mode = next(
+        (
+            line[len(NEW_MODE_PREFIX):].decode("ascii", errors="replace")
+            for line in metadata_lines
+            if line.startswith(NEW_MODE_PREFIX)
+        ),
+        None,
+    )
+    regular_modes = {"100644", "100755"}
+    if (
+        old_mode not in regular_modes
+        or new_mode not in regular_modes
+        or old_mode == new_mode
+    ):
+        return None
+    return old_mode, new_mode
+
+
+def file_type_change(metadata_lines: list[bytes]) -> tuple[str, str] | None:
+    """Return a non-executable file-type transition, if present."""
+    old_mode = next(
+        (line[len(OLD_MODE_PREFIX):].decode("ascii") for line in metadata_lines if line.startswith(OLD_MODE_PREFIX)),
+        None,
+    )
+    new_mode = next(
+        (line[len(NEW_MODE_PREFIX):].decode("ascii") for line in metadata_lines if line.startswith(NEW_MODE_PREFIX)),
+        None,
+    )
+    if old_mode is None or new_mode is None:
+        return None
+    if {old_mode, new_mode} <= {"100644", "100755"}:
+        return None
+    return old_mode, new_mode

--- a/src/git_stage_batch/core/hashing.py
+++ b/src/git_stage_batch/core/hashing.py
@@ -7,7 +7,13 @@ from collections.abc import Iterable
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from .models import BinaryFileChange, GitlinkChange, RenameChange, TextFileDeletionChange
+    from .models import (
+        BinaryFileChange,
+        FileModeChange,
+        GitlinkChange,
+        RenameChange,
+        TextFileDeletionChange,
+    )
 
 
 def compute_stable_hunk_hash_from_lines(patch_lines: Iterable[bytes]) -> str:
@@ -105,6 +111,19 @@ def compute_gitlink_change_hash(gitlink_change: GitlinkChange) -> str:
         gitlink_change.old_oid or "",
         gitlink_change.new_oid or "",
         gitlink_change.change_type,
+    ]
+    return hashlib.sha256(
+        "\0".join(parts).encode("utf-8", errors="surrogateescape")
+    ).hexdigest()
+
+
+def compute_file_mode_change_hash(mode_change: FileModeChange) -> str:
+    """Compute a stable identity hash for an executable-mode change."""
+    parts = [
+        "file-mode",
+        mode_change.file_path,
+        mode_change.old_mode,
+        mode_change.new_mode,
     ]
     return hashlib.sha256(
         "\0".join(parts).encode("utf-8", errors="surrogateescape")

--- a/src/git_stage_batch/core/models.py
+++ b/src/git_stage_batch/core/models.py
@@ -101,6 +101,19 @@ class RenameChange:
 
 
 @dataclass(frozen=True)
+class FileModeChange:
+    """Atomic executable-bit change for one regular repository file."""
+
+    file_path: str
+    old_mode: str
+    new_mode: str
+
+    def path(self) -> str:
+        """Return the repository path affected by this mode change."""
+        return self.file_path
+
+
+@dataclass(frozen=True)
 class TextFileDeletionChange:
     """Represents an atomic whole-text-file deletion."""
     old_path: str

--- a/src/git_stage_batch/data/batch_file_scope.py
+++ b/src/git_stage_batch/data/batch_file_scope.py
@@ -16,6 +16,7 @@ from .selected_change.store import (
     SelectedChangeKind,
     read_selected_change_kind,
 )
+from .selected_change.file_changes import load_selected_mode_change, read_selected_mode_data
 
 
 def resolve_batch_file_scope(
@@ -100,6 +101,16 @@ def resolve_current_batch_atomic_file_scope(
             all_files,
         )
         return selected_file if selected_file is not None else file
+    if selected_kind == SelectedChangeKind.BATCH_MODE:
+        mode_change = load_selected_mode_change()
+        mode_data = read_selected_mode_data()
+        if (
+            mode_change is not None
+            and mode_data is not None
+            and mode_data.get("batch_name") == batch_name
+            and mode_change.path() in all_files
+        ):
+            return mode_change.path()
 
     return file
 

--- a/src/git_stage_batch/data/change_freshness.py
+++ b/src/git_stage_batch/data/change_freshness.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from ..batch.query import list_batch_names, read_batch_metadata_for_batches
 from ..core.models import (
     BinaryFileChange,
+    FileModeChange,
     GitlinkChange,
     RenameChange,
     TextFileDeletionChange,
@@ -13,6 +14,7 @@ from .text_lifecycle_detection import detect_empty_text_lifecycle_change
 from .file_change_display import (
     render_binary_file_change,
     render_gitlink_change,
+    render_mode_change,
     render_rename_change,
     render_text_deletion_change,
 )
@@ -32,6 +34,11 @@ def binary_file_change_is_stale(binary_change: BinaryFileChange) -> bool:
         or current_change.new_path != binary_change.new_path
         or current_change.change_type != binary_change.change_type
     )
+
+
+def file_mode_change_is_stale(mode_change: FileModeChange) -> bool:
+    """Return whether a cached executable-mode action changed."""
+    return render_mode_change(mode_change.path()) != mode_change
 
 
 def gitlink_change_is_stale(gitlink_change: GitlinkChange) -> bool:

--- a/src/git_stage_batch/data/file_change_display.py
+++ b/src/git_stage_batch/data/file_change_display.py
@@ -8,12 +8,27 @@ from typing import Optional
 from ..core.diff_parser import acquire_unified_diff
 from ..core.models import (
     BinaryFileChange,
+    FileModeChange,
     GitlinkChange,
     RenameChange,
     TextFileDeletionChange,
 )
 from .file_tracking import auto_add_untracked_files
 from .live_diff import stream_live_git_diff
+
+
+def render_mode_change(file_path: str) -> Optional[FileModeChange]:
+    """Render one executable-mode action without caching state."""
+    try:
+        with acquire_unified_diff(
+            stream_live_git_diff(full_index=True, paths=[file_path])
+        ) as patches:
+            return next(
+                (item for item in patches if isinstance(item, FileModeChange)),
+                None,
+            )
+    except subprocess.CalledProcessError:
+        return None
 
 
 def render_binary_file_change(file_path: str) -> Optional[BinaryFileChange]:

--- a/src/git_stage_batch/data/file_hunk_display.py
+++ b/src/git_stage_batch/data/file_hunk_display.py
@@ -14,6 +14,7 @@ from ..core.diff_parser import (
 )
 from ..core.models import (
     BinaryFileChange,
+    FileModeChange,
     GitlinkChange,
     HunkHeader,
     LineEntry,
@@ -175,7 +176,7 @@ def _build_combined_file_line_changes(
     for single_hunk in patches:
         if isinstance(
             single_hunk,
-            (BinaryFileChange, GitlinkChange, RenameChange, TextFileDeletionChange),
+            (BinaryFileChange, FileModeChange, GitlinkChange, RenameChange, TextFileDeletionChange),
         ):
             continue
 

--- a/src/git_stage_batch/data/file_review/action_refusals.py
+++ b/src/git_stage_batch/data/file_review/action_refusals.py
@@ -41,6 +41,7 @@ def refuse_live_action_for_batch_selection(action: _records.FileReviewAction | s
         SelectedChangeKind.BATCH_FILE,
         SelectedChangeKind.BATCH_BINARY,
         SelectedChangeKind.BATCH_GITLINK,
+        SelectedChangeKind.BATCH_MODE,
     ):
         return False
 
@@ -125,6 +126,7 @@ def refuse_ambiguous_bare_action_after_partial_file_review(
             SelectedChangeKind.BATCH_FILE,
             SelectedChangeKind.BATCH_BINARY,
             SelectedChangeKind.BATCH_GITLINK,
+            SelectedChangeKind.BATCH_MODE,
         ):
             _raise_stale_or_mismatched_file_review(review_state)
         clear_last_file_review_state()

--- a/src/git_stage_batch/data/file_review/action_scope.py
+++ b/src/git_stage_batch/data/file_review/action_scope.py
@@ -21,6 +21,9 @@ from .state import (
     clear_last_file_review_state_if_file_matches,
     read_last_file_review_state,
 )
+from ..selected_change.store import SelectedChangeKind, read_selected_change_kind
+from ...exceptions import CommandError
+from ...i18n import _
 
 
 def line_action_came_from_partial_review(review_state: _records.FileReviewState | None) -> bool:
@@ -273,6 +276,14 @@ def resolve_live_line_action_scope(
 
     if file not in (None, ""):
         return _records.ActionScopeResolution(file=file)
+
+    if read_selected_change_kind() in (
+        SelectedChangeKind.MODE,
+        SelectedChangeKind.BATCH_MODE,
+    ):
+        raise CommandError(
+            _("File mode actions are atomic and cannot be selected by line.")
+        )
 
     review_action = _records.coerce_review_action(action)
     refuse_bare_action_after_file_list(action_command)

--- a/src/git_stage_batch/data/file_review/batch_selection.py
+++ b/src/git_stage_batch/data/file_review/batch_selection.py
@@ -156,6 +156,8 @@ def translate_reset_batch_file_gutter_ids_to_selection_ranges(
     file_path = list(files.keys())[0]
     if files[file_path].get("file_type") == "binary":
         raise CommandError(_("Cannot use --lines with binary files. Reset the whole file instead."))
+    if files[file_path].get("file_type") == "mode":
+        raise CommandError(_("Cannot use --lines with file mode actions."))
     if is_batch_submodule_pointer(files[file_path]):
         refuse_batch_submodule_pointer_lines(_("Reset"))
 

--- a/src/git_stage_batch/data/file_review/freshness.py
+++ b/src/git_stage_batch/data/file_review/freshness.py
@@ -28,6 +28,7 @@ def selected_change_kind_matches_review_source(
             SelectedChangeKind.BATCH_FILE,
             SelectedChangeKind.BATCH_BINARY,
             SelectedChangeKind.BATCH_GITLINK,
+            SelectedChangeKind.BATCH_MODE,
         )
     return False
 

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -9,6 +9,7 @@ from ..batch.query import list_batch_names, read_batch_metadata_for_batches
 from ..batch.source_annotation import annotate_with_batch_source
 from ..core.hashing import (
     compute_binary_file_hash,
+    compute_file_mode_change_hash,
     compute_gitlink_change_hash,
     compute_rename_change_hash,
     compute_stable_hunk_hash_from_lines,
@@ -16,6 +17,7 @@ from ..core.hashing import (
 )
 from ..core.models import (
     BinaryFileChange,
+    FileModeChange,
     GitlinkChange,
     LineLevelChange,
     RenameChange,
@@ -63,7 +65,7 @@ class _BatchMetadataSnapshot:
         return self._metadata_by_name
 
 
-def fetch_next_change() -> Union[LineLevelChange, BinaryFileChange, GitlinkChange, RenameChange, TextFileDeletionChange]:
+def fetch_next_change() -> Union[LineLevelChange, BinaryFileChange, FileModeChange, GitlinkChange, RenameChange, TextFileDeletionChange]:
     """Find the next hunk or binary file that isn't blocked and cache it as selected.
 
     Returns:
@@ -90,6 +92,15 @@ def fetch_next_change() -> Union[LineLevelChange, BinaryFileChange, GitlinkChang
             )
         ) as patches:
             for item in patches:
+                if isinstance(item, FileModeChange):
+                    mode_hash = compute_file_mode_change_hash(item)
+                    if mode_hash in blocked_hashes:
+                        continue
+                    if is_path_blocked(item.path(), blocked_files):
+                        continue
+                    _selected_file_changes.cache_mode_change(item)
+                    return item
+
                 if isinstance(item, RenameChange):
                     rename_hash = compute_rename_change_hash(item)
                     if rename_hash in blocked_hashes:

--- a/src/git_stage_batch/data/progress.py
+++ b/src/git_stage_batch/data/progress.py
@@ -6,6 +6,7 @@ import json
 
 from ..core.models import (
     BinaryFileChange,
+    FileModeChange,
     GitlinkChange,
     LineLevelChange,
     RenameChange,
@@ -79,6 +80,21 @@ def record_binary_hunk_skipped(binary_change: BinaryFileChange, hunk_hash: str) 
         "change_type": binary_change.change_type,
     }
     _append_skipped_hunk_metadata(metadata)
+
+
+def record_mode_change_skipped(mode_change: FileModeChange, hunk_hash: str) -> None:
+    """Record a skipped executable-mode action."""
+    _append_skipped_hunk_metadata(
+        {
+            "hash": hunk_hash,
+            "file": mode_change.path(),
+            "line": None,
+            "ids": [],
+            "type": "mode",
+            "old_mode": mode_change.old_mode,
+            "new_mode": mode_change.new_mode,
+        }
+    )
 
 
 def record_gitlink_hunk_skipped(gitlink_change: GitlinkChange, hunk_hash: str) -> None:

--- a/src/git_stage_batch/data/remaining_hunks.py
+++ b/src/git_stage_batch/data/remaining_hunks.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from ..core.diff_parser import acquire_unified_diff
 from ..core.hashing import (
     compute_binary_file_hash,
+    compute_file_mode_change_hash,
     compute_gitlink_change_hash,
     compute_rename_change_hash,
     compute_stable_hunk_hash_from_lines,
@@ -12,6 +13,7 @@ from ..core.hashing import (
 )
 from ..core.models import (
     BinaryFileChange,
+    FileModeChange,
     GitlinkChange,
     RenameChange,
     TextFileDeletionChange,
@@ -75,6 +77,9 @@ def _unprocessed_patch_count(
         if text_deletion_change_is_batched(patch):
             return 0
         hunk_hash = compute_text_file_deletion_hash(patch)
+        file_path = patch.path()
+    elif isinstance(patch, FileModeChange):
+        hunk_hash = compute_file_mode_change_hash(patch)
         file_path = patch.path()
     elif isinstance(patch, GitlinkChange):
         hunk_hash = compute_gitlink_change_hash(patch)

--- a/src/git_stage_batch/data/selected_change/file_changes.py
+++ b/src/git_stage_batch/data/selected_change/file_changes.py
@@ -6,12 +6,14 @@ import json
 
 from ...core.hashing import (
     compute_binary_file_hash,
+    compute_file_mode_change_hash,
     compute_gitlink_change_hash,
     compute_rename_change_hash,
     compute_text_file_deletion_hash,
 )
 from ...core.models import (
     BinaryFileChange,
+    FileModeChange,
     GitlinkChange,
     RenameChange,
     TextFileDeletionChange,
@@ -24,6 +26,7 @@ from ...utils.paths import (
     get_processed_skip_ids_file_path,
     get_selected_binary_file_json_path,
     get_selected_gitlink_file_json_path,
+    get_selected_mode_change_json_path,
     get_selected_hunk_hash_file_path,
     get_selected_hunk_patch_file_path,
     get_selected_rename_file_json_path,
@@ -106,6 +109,35 @@ def load_selected_gitlink_change() -> GitlinkChange | None:
         )
     except KeyError:
         return None
+
+
+def load_selected_mode_change() -> FileModeChange | None:
+    """Load the currently cached executable-mode change."""
+    if read_selected_change_kind() not in (
+        SelectedChangeKind.MODE,
+        SelectedChangeKind.BATCH_MODE,
+    ):
+        return None
+    data = read_selected_mode_data()
+    if data is None:
+        return None
+    try:
+        return FileModeChange(
+            file_path=data["file_path"],
+            old_mode=data["old_mode"],
+            new_mode=data["new_mode"],
+        )
+    except (KeyError, TypeError):
+        return None
+
+
+def read_selected_mode_data() -> dict | None:
+    """Read cached mode selection data, if structurally valid."""
+    try:
+        data = json.loads(read_text_file_contents(get_selected_mode_change_json_path()))
+    except (FileNotFoundError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
 
 
 def read_selected_rename_data() -> dict | None:
@@ -236,6 +268,36 @@ def cache_gitlink_change(
         get_selected_hunk_hash_file_path(),
         compute_gitlink_change_hash(gitlink_change),
     )
+    write_selected_change_kind(kind)
+
+
+def cache_mode_change(
+    mode_change: FileModeChange,
+    *,
+    kind: SelectedChangeKind = SelectedChangeKind.MODE,
+    batch_name: str | None = None,
+) -> None:
+    """Cache an executable-mode change as the current selected change."""
+    _clear_selected_line_payload_files()
+    write_text_file_contents(
+        get_selected_mode_change_json_path(),
+        json.dumps(
+            {
+                "file_path": mode_change.file_path,
+                "old_mode": mode_change.old_mode,
+                "new_mode": mode_change.new_mode,
+                "batch_name": batch_name,
+            },
+            ensure_ascii=False,
+            indent=0,
+        ),
+    )
+    write_text_file_contents(
+        get_selected_hunk_hash_file_path(),
+        compute_file_mode_change_hash(mode_change),
+    )
+    if kind == SelectedChangeKind.MODE:
+        write_snapshots_for_selected_file_path(mode_change.file_path)
     write_selected_change_kind(kind)
 
 

--- a/src/git_stage_batch/data/selected_change/hunk_recalculation.py
+++ b/src/git_stage_batch/data/selected_change/hunk_recalculation.py
@@ -19,6 +19,7 @@ from ...core.hashing import (
 from ...core.line_identity import preserve_line_ids_from_previous_view
 from ...core.models import (
     BinaryFileChange,
+    FileModeChange,
     GitlinkChange,
     RenameChange,
     TextFileDeletionChange,
@@ -116,6 +117,8 @@ def recalculate_selected_hunk_for_file(
             )
         ) as patches:
             for single_hunk in patches:
+                if isinstance(single_hunk, FileModeChange):
+                    continue
                 if single_hunk.old_path != file_path and single_hunk.new_path != file_path:
                     continue
 

--- a/src/git_stage_batch/data/selected_change/loading.py
+++ b/src/git_stage_batch/data/selected_change/loading.py
@@ -7,6 +7,7 @@ from typing import Optional, Union
 
 from ...core.models import (
     BinaryFileChange,
+    FileModeChange,
     GitlinkChange,
     LineLevelChange,
     RenameChange,
@@ -34,6 +35,7 @@ from .snapshots import (
 SelectedChange = Union[
     LineLevelChange,
     BinaryFileChange,
+    FileModeChange,
     GitlinkChange,
     RenameChange,
     TextFileDeletionChange,
@@ -43,6 +45,19 @@ SelectedChange = Union[
 def load_selected_change() -> Optional[SelectedChange]:
     """Load the currently cached selected change, if any."""
     selected_kind = _selected_store.read_selected_change_kind()
+    mode_change = _selected_file_changes.load_selected_mode_change()
+    if mode_change is not None:
+        if (
+            selected_kind == _selected_store.SelectedChangeKind.MODE
+            and _change_freshness.file_mode_change_is_stale(mode_change)
+        ):
+            raise CommandError(
+                _(
+                    "Selected file mode no longer matches the working tree: {file}.\n"
+                    "Run 'show' again before using a pathless action."
+                ).format(file=mode_change.path())
+            )
+        return mode_change
     rename_change = _selected_file_changes.load_selected_rename_change()
     if rename_change is not None:
         if (

--- a/src/git_stage_batch/data/selected_change/paths.py
+++ b/src/git_stage_batch/data/selected_change/paths.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from ...core.models import (
     BinaryFileChange,
+    FileModeChange,
     GitlinkChange,
     LineLevelChange,
     RenameChange,
@@ -16,6 +17,7 @@ from .store import load_line_changes_from_patch_path
 
 SelectedChange = (
     BinaryFileChange
+    | FileModeChange
     | GitlinkChange
     | LineLevelChange
     | RenameChange
@@ -42,6 +44,10 @@ def get_selected_change_file_path() -> str | None:
     rename_change = _selected_file_changes.load_selected_rename_change()
     if rename_change is not None:
         return rename_change.path()
+
+    mode_change = _selected_file_changes.load_selected_mode_change()
+    if mode_change is not None:
+        return mode_change.path()
 
     deletion_change = _selected_file_changes.load_selected_text_deletion_change()
     if deletion_change is not None:

--- a/src/git_stage_batch/data/selected_change/store.py
+++ b/src/git_stage_batch/data/selected_change/store.py
@@ -28,6 +28,7 @@ from ...utils.paths import (
     get_selected_change_clear_reason_file_path,
     get_selected_change_kind_file_path,
     get_selected_gitlink_file_json_path,
+    get_selected_mode_change_json_path,
     get_selected_hunk_hash_file_path,
     get_selected_hunk_patch_file_path,
     get_selected_rename_file_json_path,
@@ -47,6 +48,8 @@ class SelectedChangeKind(str, Enum):
     DELETION = "deletion"
     BINARY = "binary"
     GITLINK = "submodule"
+    MODE = "mode"
+    BATCH_MODE = "batch-mode"
     BATCH_FILE = "batch-file"
     BATCH_BINARY = "batch-binary"
     BATCH_GITLINK = "batch-submodule"
@@ -115,6 +118,7 @@ def _selected_change_state_paths():
         "text_deletion": get_selected_text_deletion_file_json_path(),
         "binary": get_selected_binary_file_json_path(),
         "gitlink": get_selected_gitlink_file_json_path(),
+        "mode": get_selected_mode_change_json_path(),
         "index_snapshot": get_index_snapshot_file_path(),
         "working_snapshot": get_working_tree_snapshot_file_path(),
         "processed_include_ids": get_processed_include_ids_file_path(),
@@ -172,6 +176,8 @@ def write_selected_change_kind(kind: SelectedChangeKind) -> None:
         get_selected_binary_file_json_path().unlink(missing_ok=True)
     if kind not in (SelectedChangeKind.GITLINK, SelectedChangeKind.BATCH_GITLINK):
         get_selected_gitlink_file_json_path().unlink(missing_ok=True)
+    if kind not in (SelectedChangeKind.MODE, SelectedChangeKind.BATCH_MODE):
+        get_selected_mode_change_json_path().unlink(missing_ok=True)
     write_text_file_contents(get_selected_change_kind_file_path(), kind)
 
 

--- a/src/git_stage_batch/output/file_review_list.py
+++ b/src/git_stage_batch/output/file_review_list.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import shlex
 from dataclasses import dataclass
 
-from ..core.models import BinaryFileChange, GitlinkChange, LineLevelChange, RenameChange, TextFileDeletionChange
+from ..core.models import BinaryFileChange, FileModeChange, GitlinkChange, LineLevelChange, RenameChange, TextFileDeletionChange
 from ..i18n import _
 from .file_review_model_builder import build_file_review_model
 
@@ -23,6 +23,7 @@ class FileReviewListEntry:
     binary_change_type: str | None = None
     gitlink_change_type: str | None = None
     text_deletion: bool = False
+    mode_change: bool = False
     rename_old_path: str | None = None
     rename_new_path: str | None = None
 
@@ -75,6 +76,19 @@ def make_gitlink_file_review_list_entry(gitlink_change: GitlinkChange) -> FileRe
         deletion_count=0,
         page_count=1,
         gitlink_change_type=gitlink_change.change_type,
+    )
+
+
+def make_mode_file_review_list_entry(mode_change: FileModeChange) -> FileReviewListEntry:
+    """Build a list entry from an executable-mode action."""
+    return FileReviewListEntry(
+        path=mode_change.path(),
+        change_count=1,
+        changed_line_count=0,
+        addition_count=0,
+        deletion_count=0,
+        page_count=1,
+        mode_change=True,
     )
 
 
@@ -140,6 +154,12 @@ def print_file_review_list(
                 f"{index}. {entry.path.ljust(path_width)}  "
                 f"{entry.change_count} {change_word} · "
                 f"text file deleted · "
+                f"{entry.page_count} {page_word}"
+            )
+        elif entry.mode_change:
+            print(
+                f"{index}. {entry.path.ljust(path_width)}  "
+                f"{entry.change_count} {change_word} · executable mode · "
                 f"{entry.page_count} {page_word}"
             )
         elif entry.rename_old_path is not None and entry.rename_new_path is not None:

--- a/src/git_stage_batch/output/patch.py
+++ b/src/git_stage_batch/output/patch.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 from .colors import Colors
 
 if TYPE_CHECKING:
-    from ..core.models import BinaryFileChange, GitlinkChange, RenameChange, TextFileDeletionChange
+    from ..core.models import BinaryFileChange, FileModeChange, GitlinkChange, RenameChange, TextFileDeletionChange
 
 
 def print_colored_patch(patch_text: str) -> None:
@@ -56,6 +56,13 @@ def print_binary_file_change(binary_change: BinaryFileChange) -> None:
 
     # Print file header
     print(f"{bold}{path}{reset} :: {color}Binary file {change_desc}{reset}")
+
+
+def print_file_mode_change(mode_change: FileModeChange) -> None:
+    """Print an atomic executable-mode change."""
+    executable = mode_change.new_mode == "100755"
+    description = "Executable bit added" if executable else "Executable bit removed"
+    print(f"{mode_change.path()} :: {description}")
 
 
 def print_gitlink_change(gitlink_change: GitlinkChange) -> None:

--- a/src/git_stage_batch/utils/paths.py
+++ b/src/git_stage_batch/utils/paths.py
@@ -225,6 +225,11 @@ def get_selected_gitlink_file_json_path() -> Path:
     return get_selected_state_directory_path() / "gitlink-file.json"
 
 
+def get_selected_mode_change_json_path() -> Path:
+    """Get the path to the selected executable-mode change JSON file."""
+    return get_selected_state_directory_path() / "mode-change.json"
+
+
 def get_selected_rename_file_json_path() -> Path:
     """Get the path to the selected rename JSON file."""
     return get_selected_state_directory_path() / "rename-file.json"

--- a/tests/core/test_diff_parser_edge_cases.py
+++ b/tests/core/test_diff_parser_edge_cases.py
@@ -8,13 +8,17 @@ Tests for handling:
 - Mixed scenarios
 """
 
+import pytest
+
 from git_stage_batch.core.models import (
     BinaryFileChange,
+    FileModeChange,
     GitlinkChange,
     RenameChange,
     SingleHunkPatch,
     TextFileDeletionChange,
 )
+from git_stage_batch.exceptions import CommandError
 
 from tests.diff_parser_helpers import collect_unified_diff
 
@@ -501,9 +505,9 @@ index abc1234..def5678 100644
 """
         patches = list(collect_unified_diff(diff.splitlines(keepends=True)))
 
-        # Should parse other.txt (mode change has no hunks)
-        assert len(patches) == 1
-        assert patches[0].new_path == "other.txt"
+        assert len(patches) == 2
+        assert patches[0] == FileModeChange("script.sh", "100644", "100755")
+        assert patches[1].new_path == "other.txt"
 
     def test_mode_change_with_content_changes(self):
         """File with both mode and content changes."""
@@ -521,8 +525,20 @@ index abc1234..def5678
 """
         patches = list(collect_unified_diff(diff.splitlines(keepends=True)))
 
-        assert len(patches) == 1
+        assert len(patches) == 2
         assert patches[0].new_path == "script.sh"
+        assert patches[1] == FileModeChange("script.sh", "100644", "100755")
+
+    def test_type_change_is_not_an_executable_mode_change(self):
+        """Regular-file and symlink transitions remain separate actions."""
+        diff = b"""\
+diff --git a/link b/link
+old mode 100644
+new mode 120000
+"""
+
+        with pytest.raises(CommandError, match="File type changes are atomic"):
+            collect_unified_diff(diff.splitlines(keepends=True))
 
 
 class TestMixedScenarios:
@@ -569,9 +585,9 @@ index ghi789..jkl012 100644
 
         patches = list(collect_unified_diff(diff.splitlines(keepends=True)))
 
-        # Expected: deleted_empty.txt (deletion), new_empty.txt (empty),
-        # image.png (binary), old->new rename, normal1.txt, normal2.txt
-        assert len(patches) == 6
+        # Expected: deleted empty, new empty, binary, rename, two text hunks,
+        # and the executable-bit action between the text changes.
+        assert len(patches) == 7
         assert isinstance(patches[0], TextFileDeletionChange)
         assert patches[0].path() == "deleted_empty.txt"
         assert isinstance(patches[1], SingleHunkPatch)
@@ -584,8 +600,9 @@ index ghi789..jkl012 100644
         assert patches[3].new_path == "new.txt"
         assert isinstance(patches[4], SingleHunkPatch)
         assert patches[4].new_path == "normal1.txt"
-        assert isinstance(patches[5], SingleHunkPatch)
-        assert patches[5].new_path == "normal2.txt"
+        assert patches[5] == FileModeChange("script.sh", "100644", "100755")
+        assert isinstance(patches[6], SingleHunkPatch)
+        assert patches[6].new_path == "normal2.txt"
 
     def test_intent_to_add_files(self):
         """Files added with git add -N (intent-to-add)."""

--- a/tests/core/test_file_metadata_diff.py
+++ b/tests/core/test_file_metadata_diff.py
@@ -35,3 +35,15 @@ def test_rename_paths_decode_git_quoting():
             b'rename to "new\\nname\\377"',
         ]
     ) == ("old\tname\udcff", "new\nname\udcff")
+
+
+def test_executable_mode_change_accepts_only_regular_file_transitions():
+    assert file_metadata_diff.executable_mode_change(
+        [b"old mode 100644", b"new mode 100755"]
+    ) == ("100644", "100755")
+    assert file_metadata_diff.executable_mode_change(
+        [b"old mode 100755", b"new mode 100644"]
+    ) == ("100755", "100644")
+    assert file_metadata_diff.executable_mode_change(
+        [b"old mode 100644", b"new mode 120000"]
+    ) is None

--- a/tests/core/test_models.py
+++ b/tests/core/test_models.py
@@ -4,6 +4,7 @@ import pytest
 
 from git_stage_batch.core.models import (
     BinaryFileChange,
+    FileModeChange,
     HunkHeader,
     LineEntry,
     SingleHunkPatch,
@@ -111,6 +112,12 @@ class TestBinaryFileChange:
             ).path()
             == "asset.bin"
         )
+
+
+def test_file_mode_change_path():
+    change = FileModeChange("script.sh", "100644", "100755")
+
+    assert change.path() == "script.sh"
 
 
 class TestSingleHunkPatch:

--- a/tests/functional/test_file_mode_workflow.py
+++ b/tests/functional/test_file_mode_workflow.py
@@ -149,3 +149,21 @@ def test_mode_action_refuses_line_selection(functional_repo):
 
     assert result.returncode != 0
     assert "mode" in result.stderr.lower()
+
+
+def test_mode_batch_reset_and_sift(functional_repo):
+    path = _commit_script(functional_repo)
+    path.chmod(0o755)
+    git_stage_batch("start")
+    git_stage_batch("show")
+    git_stage_batch("include", "--to", "modes")
+
+    assert read_batch_metadata("modes")["files"][path.name]["presence_claims"] == []
+    git_stage_batch("reset", "--from", "modes", "--file", path.name)
+    assert path.name not in read_batch_metadata("modes")["files"]
+
+    git_stage_batch("again")
+    git_stage_batch("show")
+    git_stage_batch("include", "--to", "modes")
+    command_sift_batch("modes", "sifted")
+    assert read_batch_metadata("sifted")["files"] == {}

--- a/tests/functional/test_file_mode_workflow.py
+++ b/tests/functional/test_file_mode_workflow.py
@@ -79,6 +79,28 @@ def test_content_is_presented_before_independent_mode_action(functional_repo):
     assert "Executable bit added" in shown.stdout
     git_stage_batch("include")
     assert _index_mode(functional_repo, path.name) == "100755"
+
+
+def test_mode_change_round_trips_through_batch(functional_repo):
+    path = _commit_script(functional_repo)
+    git_stage_batch("new", "modes")
+    path.chmod(0o755)
+
+    git_stage_batch("start")
+    git_stage_batch("show")
+    git_stage_batch("include", "--to", "modes")
+
+    path.chmod(0o644)
+    shown = git_stage_batch("show", "--from", "modes", "--file", path.name)
+    assert "Executable bit added" in shown.stdout
+    git_stage_batch("include", "--from", "modes")
+    assert os.access(path, os.X_OK)
+    assert _index_mode(functional_repo, path.name) == "100755"
+
+    git_stage_batch("discard", "--from", "modes", "--file", path.name)
+    assert not os.access(path, os.X_OK)
+
+
 def test_mode_actions_support_skip_undo_redo_and_abort(functional_repo):
     path = _commit_script(functional_repo)
     path.chmod(0o755)

--- a/tests/functional/test_file_mode_workflow.py
+++ b/tests/functional/test_file_mode_workflow.py
@@ -1,0 +1,81 @@
+"""End-to-end executable-mode action coverage."""
+
+import os
+import re
+import subprocess
+
+from git_stage_batch.batch.query import read_batch_metadata
+from git_stage_batch.commands.sift import command_sift_batch
+
+from .conftest import git_stage_batch
+
+
+def _commit_script(repo, *, executable: bool = False):
+    path = repo / "script.sh"
+    path.write_text("#!/bin/sh\necho old\n")
+    path.chmod(0o755 if executable else 0o644)
+    subprocess.run(["git", "add", path.name], check=True, cwd=repo)
+    subprocess.run(["git", "commit", "-m", "Add script"], check=True, cwd=repo)
+    return path
+
+
+def _index_mode(repo, path: str) -> str:
+    return subprocess.run(
+        ["git", "ls-files", "-s", "--", path],
+        check=True,
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    ).stdout.split()[0]
+
+
+def test_include_mode_only_change(functional_repo):
+    path = _commit_script(functional_repo)
+    path.chmod(0o755)
+
+    git_stage_batch("start")
+    shown = git_stage_batch("show")
+    assert "Executable bit added" in shown.stdout
+    git_stage_batch("include")
+
+    assert _index_mode(functional_repo, path.name) == "100755"
+
+
+def test_discard_mode_only_change(functional_repo):
+    path = _commit_script(functional_repo, executable=True)
+    path.chmod(0o644)
+
+    git_stage_batch("start")
+    git_stage_batch("discard")
+
+    assert os.access(path, os.X_OK)
+
+
+def test_include_executable_bit_removal(functional_repo):
+    path = _commit_script(functional_repo, executable=True)
+    path.chmod(0o644)
+
+    git_stage_batch("start")
+    git_stage_batch("show")
+    git_stage_batch("include")
+
+    assert _index_mode(functional_repo, path.name) == "100644"
+
+
+def test_content_is_presented_before_independent_mode_action(functional_repo):
+    path = _commit_script(functional_repo)
+    path.write_text("#!/bin/sh\necho new\n")
+    path.chmod(0o755)
+
+    started = git_stage_batch("start")
+    line_ids = re.findall(r"\[#(\d+)\]", started.stdout)
+    assert line_ids
+    assert "Executable bit" not in started.stdout
+
+    git_stage_batch("include", "--line", ",".join(line_ids))
+    assert _index_mode(functional_repo, path.name) == "100644"
+
+    shown = git_stage_batch("show")
+    assert "Executable bit added" in shown.stdout
+    git_stage_batch("include")
+    assert _index_mode(functional_repo, path.name) == "100755"

--- a/tests/functional/test_file_mode_workflow.py
+++ b/tests/functional/test_file_mode_workflow.py
@@ -79,3 +79,51 @@ def test_content_is_presented_before_independent_mode_action(functional_repo):
     assert "Executable bit added" in shown.stdout
     git_stage_batch("include")
     assert _index_mode(functional_repo, path.name) == "100755"
+def test_mode_actions_support_skip_undo_redo_and_abort(functional_repo):
+    path = _commit_script(functional_repo)
+    path.chmod(0o755)
+
+    git_stage_batch("start")
+    git_stage_batch("show", "--file", path.name)
+    git_stage_batch("include")
+    assert _index_mode(functional_repo, path.name) == "100755"
+
+    git_stage_batch("undo")
+    assert _index_mode(functional_repo, path.name) == "100644"
+    git_stage_batch("redo")
+    assert _index_mode(functional_repo, path.name) == "100755"
+    git_stage_batch("abort")
+    assert _index_mode(functional_repo, path.name) == "100644"
+    assert os.access(path, os.X_OK)
+
+    git_stage_batch("start")
+    git_stage_batch("show", "--file", path.name)
+    git_stage_batch("skip")
+    assert os.access(path, os.X_OK)
+
+
+def test_core_file_mode_false_hides_mode_actions(functional_repo):
+    path = _commit_script(functional_repo)
+    subprocess.run(
+        ["git", "config", "core.fileMode", "false"],
+        check=True,
+        cwd=functional_repo,
+    )
+    path.chmod(0o755)
+
+    result = git_stage_batch("start", check=False)
+
+    assert result.returncode != 0
+    assert "No changes" in result.stderr or "No hunks" in result.stderr
+
+
+def test_mode_action_refuses_line_selection(functional_repo):
+    path = _commit_script(functional_repo)
+    path.chmod(0o755)
+    git_stage_batch("start")
+    git_stage_batch("show")
+
+    result = git_stage_batch("include", "--line", "1", check=False)
+
+    assert result.returncode != 0
+    assert "mode" in result.stderr.lower()


### PR DESCRIPTION
Git-visible executable-bit changes currently fall outside the actionable change model.

Mode-only edits are skipped entirely, while content-plus-mode changes stage their text and leave an invisible metadata-only remainder. Users consequently cannot review, classify, stage, discard, or recover executable-bit transitions consistently.

This series introduces atomic `100644 ↔ 100755` mode actions. Content hunks remain line-selectable and are presented first; the independent mode action remains visible afterward. Mode selections participate in hashing, persistence, freshness, blocklists, file review, include/discard/skip, undo/redo/abort, and file-scoped commands.

Batch metadata stores mode actions with empty content claims and supports include, apply, discard, reset, sift, display, and pathless reviewed actions. Regular-file, symlink, and gitlink type transitions are kept outside executable-mode handling and unsupported transitions receive an explicit refusal. Repositories using `core.fileMode=false` continue to suppress mode actions by Git configuration.

Validation: `3054 passed` in the full suite; the final mode workflow suite has `9 passed`; Ruff and whitespace checks also pass.