### PR TITLE
batch: Validate Git-compatible names

### DIFF
--- a/docs/batches.md
+++ b/docs/batches.md
@@ -35,6 +35,23 @@ This information is stored in:
 
 Legacy batches under `refs/batches/<name>` are read as migration inputs. Once a batch is written by the current version, the legacy ref and file-backed metadata for that batch are removed.
 
+Batch names must be non-empty single path components no longer than 250 UTF-8
+bytes. In addition to spaces, slashes, backslashes, and colons, Git reserves
+characters and sequences such as `~`, `^`, `?`, `*`, `[`, `..`, and `@{`, as
+well as trailing dots and `.lock` suffixes. The name is checked with Git's own
+ref-format rules before any batch or session state is written. Unicode names
+are supported when they satisfy those rules.
+
+If an older version left file-backed metadata with an invalid name, batch
+discovery reports the entry instead of ignoring it. The diagnostic identifies
+the invalid name and its metadata under Git's `git-stage-batch/batches`
+directory. If a matching legacy `refs/batches/<old-name>` ref exists, choose a
+valid unused name, rename that ref with `git update-ref`, and move the metadata
+directory to the same new name. If no matching ref exists, the directory is
+orphaned metadata from a failed creation and does not contain a recoverable
+batch commit; inspect it if needed, then move it outside the state directory or
+remove it. Run `git-stage-batch list` again to verify the repair.
+
 ### Application Model (include/apply --from)
 
 When applying a batch to your working tree or index, the tool uses **structural merge**:

--- a/src/git_stage_batch/batch/query.py
+++ b/src/git_stage_batch/batch/query.py
@@ -13,7 +13,9 @@ from .state_refs import (
     read_batch_state_metadata_for_batches,
     read_batch_state_metadata,
 )
-from .validation import validate_batch_name
+from .validation import invalid_file_backed_batch_names, validate_batch_name
+from ..exceptions import CommandError
+from ..i18n import _
 from ..utils.file_io import read_text_file_contents
 from ..utils.git_command import run_git_command
 from ..git_paths import decode_path, nul_records
@@ -117,6 +119,17 @@ def get_batch_commit_sha(name: str) -> Optional[str]:
 
 def list_batch_names() -> list[str]:
     """List all batch names by querying authoritative refs and legacy imports."""
+    invalid_legacy_names = invalid_file_backed_batch_names()
+    if invalid_legacy_names:
+        formatted_names = ", ".join(repr(name) for name in invalid_legacy_names)
+        raise CommandError(
+            _(
+                "Legacy batch metadata has invalid batch name(s): {names}. "
+                "Move these entries out of the batch metadata directory or rename "
+                "them and any corresponding refs/batches refs to valid, unused names."
+            ).format(names=formatted_names)
+        )
+
     batch_names: set[str] = set()
     for prefix in (BATCH_CONTENT_REF_PREFIX, LEGACY_BATCH_REF_PREFIX):
         result = run_git_command(["for-each-ref", "--format=%(refname)", prefix], check=False, requires_index_lock=False)

--- a/src/git_stage_batch/batch/validation.py
+++ b/src/git_stage_batch/batch/validation.py
@@ -2,30 +2,88 @@
 
 from __future__ import annotations
 
-from .ref_names import BATCH_CONTENT_REF_PREFIX, LEGACY_BATCH_REF_PREFIX
+from functools import lru_cache
+
+from .ref_names import (
+    BATCH_CONTENT_REF_PREFIX,
+    BATCH_STATE_REF_PREFIX,
+    LEGACY_BATCH_REF_PREFIX,
+)
 from ..exceptions import CommandError
 from ..i18n import _
 from ..utils.git_command import run_git_command
+from ..utils.paths import get_batches_directory_path
+
+
+MAX_BATCH_NAME_BYTES = 250
+
+
+@lru_cache(maxsize=512)
+def _git_accepts_batch_name(name: str) -> bool:
+    """Return whether Git accepts every ref namespace used for a batch."""
+    prefixes = (
+        BATCH_CONTENT_REF_PREFIX,
+        BATCH_STATE_REF_PREFIX,
+        LEGACY_BATCH_REF_PREFIX,
+    )
+    return all(
+        run_git_command(
+            ["check-ref-format", f"{prefix}{name}"],
+            check=False,
+            requires_index_lock=False,
+        ).returncode == 0
+        for prefix in prefixes
+    )
 
 
 def validate_batch_name(name: str) -> None:
-    """Validate that a batch name is safe for use in git refs."""
+    """Validate a batch name against product and Git ref requirements."""
     if not name:
         raise CommandError(_("Batch name cannot be empty"))
 
-    # Check for invalid characters
+    # Keep the established product restrictions and their specific diagnostics.
     invalid_chars = ['/', '\\', '..', ':', ' ', '\t', '\n', '\r']
     for char in invalid_chars:
         if char in name:
             raise CommandError(_("Batch name cannot contain: {char}").format(char=repr(char)))
 
-    # Check for leading dot
     if name.startswith('.'):
         raise CommandError(_("Batch name cannot start with '.'"))
+
+    if len(name.encode("utf-8")) > MAX_BATCH_NAME_BYTES:
+        raise CommandError(
+            _("Batch name cannot exceed {limit} UTF-8 bytes").format(
+                limit=MAX_BATCH_NAME_BYTES
+            )
+        )
+
+    if not _git_accepts_batch_name(name):
+        raise CommandError(
+            _("Batch name '{name}' is not compatible with Git ref naming rules").format(
+                name=name
+            )
+        )
+
+
+def invalid_file_backed_batch_names() -> list[str]:
+    """Return legacy metadata names that cannot be used by current storage."""
+    batches_directory = get_batches_directory_path()
+    if not batches_directory.is_dir():
+        return []
+
+    invalid_names = []
+    for metadata_path in batches_directory.rglob("metadata.json"):
+        batch_name = metadata_path.parent.relative_to(batches_directory).as_posix()
+        try:
+            validate_batch_name(batch_name)
+        except CommandError:
+            invalid_names.append(batch_name)
+    return sorted(invalid_names)
 
 
 def batch_exists(batch_name: str) -> bool:
     """Check if a batch exists by checking its authoritative git ref."""
+    validate_batch_name(batch_name)
     result = run_git_command(
         ["show-ref", "--verify", "--quiet", f"{BATCH_CONTENT_REF_PREFIX}{batch_name}"],
         check=False,

--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from ..batch.validation import validate_batch_name
 from ..core.replacement import (
     ReplacementPayload,
 )
@@ -188,6 +189,7 @@ def command_discard_to_batch(
         Number of hunks saved to the batch and discarded.
     """
     require_git_repository()
+    validate_batch_name(batch_name)
     ensure_state_directory_exists()
     original_file_scope = file
     scope_resolution = resolve_live_to_batch_action_scope(
@@ -225,6 +227,7 @@ def command_discard_line_as_to_batch(
 ) -> None:
     """Save replacement text to batch, then discard the original selection locally."""
     require_git_repository()
+    validate_batch_name(batch_name)
     require_session_started()
     ensure_state_directory_exists()
     scope_resolution = resolve_live_line_action_scope(

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from ..batch.validation import validate_batch_name
 from ..core.replacement import (
     ReplacementPayload,
 )
@@ -222,6 +223,7 @@ def command_include_to_batch(
         auto_advance: Whether to select the next hunk after this action.
     """
     require_git_repository()
+    validate_batch_name(batch_name)
     ensure_state_directory_exists()
     original_file_scope = file
     scope_resolution = resolve_live_to_batch_action_scope(

--- a/src/git_stage_batch/commands/selection/discard_to_batch_action.py
+++ b/src/git_stage_batch/commands/selection/discard_to_batch_action.py
@@ -10,6 +10,7 @@ from ...data.selected_change.store import (
     read_selected_change_kind,
 )
 from ...data.undo_checkpoints import undo_checkpoint
+from ...batch.validation import validate_batch_name
 from ...exceptions import exit_with_error
 from ...i18n import _
 from ..file_scope import discard_file_to_batch as _file_scope_discard_file_to_batch
@@ -31,6 +32,7 @@ def execute_discard_to_batch_action(
     auto_advance: bool | None,
 ) -> int:
     """Route one resolved discard-to-batch request to the selected action."""
+    validate_batch_name(batch_name)
     operation_parts = ["discard", "--to", batch_name]
     if line_ids is not None:
         operation_parts.extend(["--line", line_ids])

--- a/src/git_stage_batch/commands/selection/include_to_batch_action.py
+++ b/src/git_stage_batch/commands/selection/include_to_batch_action.py
@@ -16,6 +16,7 @@ from ...data.selected_change.store import (
     read_selected_change_kind,
 )
 from ...data.undo_checkpoints import undo_checkpoint
+from ...batch.validation import validate_batch_name
 from ...exceptions import exit_with_error
 from ...i18n import _
 from ..file_scope import include_file_to_batch as _file_scope_include_file_to_batch
@@ -36,6 +37,7 @@ def execute_include_to_batch_action(
     auto_advance: bool | None,
 ) -> None:
     """Route one resolved include-to-batch request to the selected action."""
+    validate_batch_name(batch_name)
     operation_parts = ["include", "--to", batch_name]
     if line_ids is not None:
         operation_parts.extend(["--line", line_ids])

--- a/tests/batch/test_validation.py
+++ b/tests/batch/test_validation.py
@@ -5,8 +5,17 @@ import subprocess
 import pytest
 
 from git_stage_batch.batch.lifecycle import create_batch
-from git_stage_batch.batch.validation import batch_exists, validate_batch_name
+from git_stage_batch.batch.query import list_batch_names
+from git_stage_batch.batch.validation import (
+    MAX_BATCH_NAME_BYTES,
+    batch_exists,
+    validate_batch_name,
+)
 from git_stage_batch.exceptions import CommandError
+from git_stage_batch.utils.paths import (
+    get_batch_directory_path,
+    get_batch_metadata_file_path,
+)
 
 
 @pytest.fixture
@@ -32,6 +41,79 @@ def test_validate_batch_name_valid(temp_git_repo):
     validate_batch_name("my_batch")
     validate_batch_name("batch123")
     validate_batch_name("UPPERCASE")
+    validate_batch_name("café")
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "has~tilde",
+        "has^caret",
+        "has?question",
+        "has*asterisk",
+        "has[bracket",
+        "has@{sequence",
+        "trailing.",
+        "reserved.lock",
+        "control\x01byte",
+    ],
+)
+def test_validate_batch_name_rejects_names_git_cannot_use(temp_git_repo, name):
+    with pytest.raises(CommandError) as exc_info:
+        validate_batch_name(name)
+
+    assert name in exc_info.value.message
+    assert "Git ref naming rules" in exc_info.value.message
+
+
+def test_validate_batch_name_enforces_storage_safe_byte_limit(temp_git_repo):
+    validate_batch_name("a" * MAX_BATCH_NAME_BYTES)
+
+    with pytest.raises(CommandError) as exc_info:
+        validate_batch_name("a" * (MAX_BATCH_NAME_BYTES + 1))
+
+    assert f"{MAX_BATCH_NAME_BYTES} UTF-8 bytes" in exc_info.value.message
+
+
+def test_create_batch_accepts_maximum_length_name(temp_git_repo):
+    name = "a" * MAX_BATCH_NAME_BYTES
+
+    create_batch(name)
+
+    assert batch_exists(name)
+
+
+def test_create_batch_rejects_git_invalid_name_without_metadata(temp_git_repo):
+    name = "invalid^name"
+
+    with pytest.raises(CommandError):
+        create_batch(name)
+
+    assert not get_batch_directory_path(name).exists()
+
+
+def test_batch_discovery_reports_invalid_legacy_metadata(temp_git_repo):
+    metadata_path = get_batch_metadata_file_path("legacy^name")
+    metadata_path.parent.mkdir(parents=True)
+    metadata_path.write_text("{}")
+
+    with pytest.raises(CommandError) as exc_info:
+        list_batch_names()
+
+    assert "Legacy batch metadata" in exc_info.value.message
+    assert "legacy^name" in exc_info.value.message
+    assert "refs/batches" in exc_info.value.message
+
+
+@pytest.mark.parametrize("name", ["ordinary", "café", "release-2026.07"])
+def test_validate_batch_name_matches_git_check_ref_format(temp_git_repo, name):
+    validate_batch_name(name)
+
+    result = subprocess.run(
+        ["git", "check-ref-format", f"refs/git-stage-batch/batches/{name}"],
+        check=False,
+    )
+    assert result.returncode == 0
 
 
 def test_validate_batch_name_empty(temp_git_repo):
@@ -92,6 +174,11 @@ def test_batch_exists_true(temp_git_repo):
 def test_batch_exists_false(temp_git_repo):
     """Test that batch_exists returns False for nonexistent batch."""
     assert batch_exists("nonexistent") is False
+
+
+def test_batch_exists_rejects_invalid_name_before_ref_lookup(temp_git_repo):
+    with pytest.raises(CommandError):
+        batch_exists("invalid^name")
 
 
 def test_batch_exists_after_creation(temp_git_repo):

--- a/tests/commands/test_discard.py
+++ b/tests/commands/test_discard.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 from git_stage_batch.batch.ownership import BatchOwnership
 from git_stage_batch.utils.paths import get_abort_snapshots_directory_path
+from git_stage_batch.utils.paths import get_state_directory_path
 from git_stage_batch.batch.query import list_batch_files, read_batch_metadata
 from git_stage_batch.batch.file_entry_storage import read_file_from_batch
 from git_stage_batch.commands.discard import command_discard_to_batch
@@ -66,6 +67,15 @@ def temp_git_repo(tmp_path, monkeypatch):
 
 class TestCommandDiscard:
     """Tests for discard command."""
+
+    def test_discard_to_invalid_batch_does_not_create_session_state(
+        self,
+        temp_git_repo,
+    ):
+        with pytest.raises(CommandError):
+            command_discard_to_batch("invalid^name")
+
+        assert not get_state_directory_path().exists()
 
     def test_discard_removes_hunk_from_working_tree(self, temp_git_repo, capsys):
         """Test that discard removes a hunk from the working tree."""

--- a/tests/commands/test_include.py
+++ b/tests/commands/test_include.py
@@ -30,6 +30,7 @@ from git_stage_batch.data.selected_change.clear_reasons import (
     selected_change_was_cleared_by_auto_advance_disabled,
 )
 from git_stage_batch.exceptions import CommandError, NoMoreHunks
+from git_stage_batch.utils.paths import get_state_directory_path
 from git_stage_batch.commands.again import command_again
 from tests.ownership_metadata_helpers import (
     reject_materialized_ownership_metadata as _reject_materialized_ownership_metadata,
@@ -68,6 +69,15 @@ def temp_git_repo(tmp_path, monkeypatch):
 
 class TestCommandInclude:
     """Tests for include command."""
+
+    def test_include_to_invalid_batch_does_not_create_session_state(
+        self,
+        temp_git_repo,
+    ):
+        with pytest.raises(CommandError):
+            command_include_to_batch("invalid^name")
+
+        assert not get_state_directory_path().exists()
 
     def test_include_stages_hunk(self, temp_git_repo, capsys):
         """Test that include stages a hunk."""


### PR DESCRIPTION
Batches use their names in authoritative content and state refs, legacy
refs, and compatibility metadata paths. Existing validation enforces only a
subset of the restrictions imposed by those storage layers.

Users can provide a name that passes command validation but is rejected when
Git publishes its ref. That late failure can create session or metadata state,
and invalid metadata left by older versions is otherwise difficult to
diagnose and repair.

This pull request validates each complete ref namespace with Git's own
ref-format rules, adds a storage-safe byte limit, and moves include and discard
validation ahead of state and undo setup. Batch discovery now reports invalid
legacy metadata, while the batch documentation describes naming restrictions
and recovery options.

The commit series pairs each behavior change with focused regression coverage
and concludes with user-facing guidance. The full test suite passes with
3,074 tests.