### PR TITLE
io: Preserve modes during atomic writes

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -31,3 +31,24 @@ attempts to restore them while their serialized objects remain available. If
 an object has already been pruned, restoration stops before mutation and
 reports the missing recovery object rather than partially applying the
 checkpoint.
+
+## Atomic file permissions
+
+Git-stage-batch writes session metadata, recovery manifests, batch
+compatibility metadata, and journals as private application state. Newly
+created state files use mode `0600`, including when the process has a
+permissive umask. Rewriting private state also restores that restrictive mode.
+
+Repository-owned files use a separate atomic-write policy. Updates to
+`.gitignore`, `.git/info/exclude`, and previously installed assistant assets
+preserve the existing file's permission bits and ownership where the platform
+allows it. New repository files use the conventional mode `0644`. If ownership
+cannot be restored, replacement permissions are narrowed rather than granting
+access through a different group.
+
+Atomic replacement writes and syncs a temporary file in the destination
+directory before renaming it over the target, then syncs the directory where
+the platform supports that operation. A failure before replacement leaves the
+old file complete. Symlink targets are never followed or silently replaced;
+the command stops with recovery guidance so callers can update the intended
+target explicitly.

--- a/src/git_stage_batch/data/asset_installation.py
+++ b/src/git_stage_batch/data/asset_installation.py
@@ -7,7 +7,11 @@ from pathlib import Path
 from .asset_catalog import Traversable
 from ..exceptions import CommandError
 from ..i18n import _
-from ..utils.file_io import write_file_bytes
+from ..utils.file_io import (
+    AtomicWriteModePolicy,
+    PROJECT_FILE_MODE,
+    write_file_bytes,
+)
 
 
 def _should_skip_asset_entry(entry: Traversable) -> bool:
@@ -24,7 +28,12 @@ def copy_asset_tree(source: Traversable, destination: Path) -> None:
             copy_asset_tree(child, destination / child.name)
         return
     if source.is_file():
-        write_file_bytes(destination, source.read_bytes())
+        write_file_bytes(
+            destination,
+            source.read_bytes(),
+            mode_policy=AtomicWriteModePolicy.PRESERVE_EXISTING,
+            mode=PROJECT_FILE_MODE,
+        )
 
 
 def validate_asset_destination_path(

--- a/src/git_stage_batch/data/ignore_files.py
+++ b/src/git_stage_batch/data/ignore_files.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from ..utils.file_io import read_text_file_contents, write_text_file_contents
+from ..utils.file_io import (
+    AtomicWriteModePolicy,
+    PROJECT_FILE_MODE,
+    read_text_file_contents,
+    write_text_file_contents,
+)
 from ..utils.git_repository import get_git_directory_path, get_git_repository_root_path
 
 
@@ -24,6 +29,15 @@ def get_local_exclude_path() -> Path:
         Path to .git/info/exclude
     """
     return get_git_directory_path() / "info" / "exclude"
+
+
+def _write_repository_ignore_file(path: Path, content: str) -> None:
+    write_text_file_contents(
+        path,
+        content,
+        mode_policy=AtomicWriteModePolicy.PRESERVE_EXISTING,
+        mode=PROJECT_FILE_MODE,
+    )
 
 
 def read_gitignore_lines() -> list[str]:
@@ -47,7 +61,7 @@ def write_gitignore_lines(lines: list[str]) -> None:
     """
     gitignore_path = get_gitignore_path()
     content = "".join(lines)
-    write_text_file_contents(gitignore_path, content)
+    _write_repository_ignore_file(gitignore_path, content)
 
 
 def add_file_to_gitignore(file_path: str) -> None:
@@ -121,7 +135,7 @@ def add_file_to_local_exclude(file_path: str) -> None:
         lines[-1] += "\n"
 
     lines.append(f"{file_path}\n")
-    write_text_file_contents(exclude_path, "".join(lines))
+    _write_repository_ignore_file(exclude_path, "".join(lines))
 
 
 def remove_file_from_local_exclude(file_path: str) -> bool:
@@ -151,7 +165,7 @@ def remove_file_from_local_exclude(file_path: str) -> bool:
         i += 1
 
     if removed:
-        write_text_file_contents(exclude_path, "".join(lines))
+        _write_repository_ignore_file(exclude_path, "".join(lines))
 
     return removed
 
@@ -205,5 +219,5 @@ def promote_directory_to_glob_in_local_exclude(dir_path: str) -> bool:
             found = True
 
     if found:
-        write_text_file_contents(exclude_path, "".join(lines))
+        _write_repository_ignore_file(exclude_path, "".join(lines))
     return found

--- a/src/git_stage_batch/utils/file_io.py
+++ b/src/git_stage_batch/utils/file_io.py
@@ -2,11 +2,29 @@
 
 from __future__ import annotations
 
+import errno
 import os
+import stat
 import tempfile
 from collections.abc import Collection
+from enum import Enum
 from pathlib import Path
 from typing import Iterable
+
+from ..exceptions import CommandError
+from ..i18n import _
+
+
+class AtomicWriteModePolicy(Enum):
+    """Permission policy for an atomically replaced file."""
+
+    PRIVATE = "private"
+    PRESERVE_EXISTING = "preserve-existing"
+    CALLER_SUPPLIED = "caller-supplied"
+
+
+PRIVATE_FILE_MODE = 0o600
+PROJECT_FILE_MODE = 0o644
 
 
 def read_text_file_contents(path: Path) -> str:
@@ -21,7 +39,13 @@ def read_text_file_contents(path: Path) -> str:
     return path.read_text(encoding="utf-8", errors="surrogateescape") if path.exists() else ""
 
 
-def write_text_file_contents(path: Path, data: str) -> None:
+def write_text_file_contents(
+    path: Path,
+    data: str,
+    *,
+    mode_policy: AtomicWriteModePolicy = AtomicWriteModePolicy.PRIVATE,
+    mode: int | None = None,
+) -> None:
     """Atomically write text, creating parent directories as needed.
 
     Args:
@@ -31,6 +55,8 @@ def write_text_file_contents(path: Path, data: str) -> None:
     _write_file_contents_atomically(
         path,
         data.encode("utf-8", errors="surrogateescape"),
+        mode_policy=mode_policy,
+        mode=mode,
     )
 
 
@@ -60,14 +86,101 @@ def count_nonblank_text_file_lines(path: Path) -> int:
     return sum(1 for _line in stream_nonblank_text_file_lines(path))
 
 
-def write_file_bytes(path: Path, data: bytes) -> None:
+def write_file_bytes(
+    path: Path,
+    data: bytes,
+    *,
+    mode_policy: AtomicWriteModePolicy = AtomicWriteModePolicy.PRIVATE,
+    mode: int | None = None,
+) -> None:
     """Atomically write raw bytes, creating parent directories as needed."""
-    _write_file_contents_atomically(path, data)
+    _write_file_contents_atomically(
+        path,
+        data,
+        mode_policy=mode_policy,
+        mode=mode,
+    )
 
 
-def _write_file_contents_atomically(path: Path, data: bytes) -> None:
+def _existing_file_metadata(path: Path) -> os.stat_result | None:
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        return None
+    if stat.S_ISLNK(metadata.st_mode):
+        raise CommandError(
+            _(
+                "Refusing to replace symlink '{path}' with a regular file. "
+                "Remove the symlink or update its target explicitly."
+            ).format(path=path)
+        )
+    return metadata
+
+
+def _replacement_mode(
+    metadata: os.stat_result | None,
+    mode_policy: AtomicWriteModePolicy,
+    mode: int | None,
+) -> int:
+    if mode_policy is AtomicWriteModePolicy.PRIVATE:
+        if mode is not None:
+            raise ValueError("private atomic writes do not accept a caller-supplied mode")
+        return PRIVATE_FILE_MODE
+    if mode_policy is AtomicWriteModePolicy.PRESERVE_EXISTING:
+        if metadata is not None:
+            return stat.S_IMODE(metadata.st_mode)
+        return PROJECT_FILE_MODE if mode is None else mode
+    if mode_policy is AtomicWriteModePolicy.CALLER_SUPPLIED:
+        if mode is None:
+            raise ValueError("caller-supplied atomic writes require a mode")
+        return mode
+    raise ValueError(f"unsupported atomic write mode policy: {mode_policy!r}")
+
+
+def _preserve_ownership(
+    file_descriptor: int,
+    metadata: os.stat_result | None,
+) -> bool:
+    if metadata is None or not hasattr(os, "fchown"):
+        return True
+    try:
+        os.fchown(file_descriptor, metadata.st_uid, metadata.st_gid)
+    except PermissionError:
+        # An unprivileged owner often cannot restore a non-default group. The
+        # caller will remove group/other access before publishing the file.
+        return False
+    return True
+
+
+def _fsync_directory(path: Path) -> None:
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+    try:
+        directory_descriptor = os.open(path, flags)
+    except OSError as error:
+        if os.name == "nt" or error.errno in (errno.EINVAL, errno.ENOTSUP):
+            return
+        raise
+    try:
+        try:
+            os.fsync(directory_descriptor)
+        except OSError as error:
+            if error.errno not in (errno.EBADF, errno.EINVAL, errno.ENOTSUP):
+                raise
+    finally:
+        os.close(directory_descriptor)
+
+
+def _write_file_contents_atomically(
+    path: Path,
+    data: bytes,
+    *,
+    mode_policy: AtomicWriteModePolicy,
+    mode: int | None,
+) -> None:
     """Replace one state file without exposing partial contents."""
     path.parent.mkdir(parents=True, exist_ok=True)
+    metadata = _existing_file_metadata(path)
+    replacement_mode = _replacement_mode(metadata, mode_policy, mode)
     file_descriptor, temporary_name = tempfile.mkstemp(
         dir=path.parent,
         prefix=f".{path.name}.",
@@ -78,8 +191,13 @@ def _write_file_contents_atomically(path: Path, data: bytes) -> None:
         with os.fdopen(file_descriptor, "wb") as file_handle:
             file_handle.write(data)
             file_handle.flush()
+            ownership_preserved = _preserve_ownership(file_handle.fileno(), metadata)
+            if not ownership_preserved:
+                replacement_mode &= 0o700
+            os.fchmod(file_handle.fileno(), replacement_mode)
             os.fsync(file_handle.fileno())
         os.replace(temporary_path, path)
+        _fsync_directory(path.parent)
     finally:
         temporary_path.unlink(missing_ok=True)
 
@@ -103,7 +221,18 @@ def append_lines_to_file(path: Path, lines: Iterable[str]) -> None:
         lines: Lines to append (newlines will be normalized)
     """
     path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("a", encoding="utf-8", errors="surrogateescape") as file_handle:
+    file_descriptor = os.open(
+        path,
+        os.O_WRONLY | os.O_APPEND | os.O_CREAT,
+        PRIVATE_FILE_MODE,
+    )
+    os.fchmod(file_descriptor, PRIVATE_FILE_MODE)
+    with os.fdopen(
+        file_descriptor,
+        "a",
+        encoding="utf-8",
+        errors="surrogateescape",
+    ) as file_handle:
         for line in lines:
             file_handle.write(str(line).rstrip() + "\n")
 

--- a/tests/data/test_asset_installation.py
+++ b/tests/data/test_asset_installation.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import stat
+
 import pytest
 
 from git_stage_batch.data.asset_installation import (
@@ -32,6 +34,32 @@ def test_copy_asset_tree_ignores_python_cache_artifacts(tmp_path):
     assert not (destination / "scripts" / "__pycache__").exists()
     assert not (destination / "scripts" / "helper.pyc").exists()
     assert not (destination / "scripts" / "helper.pyo").exists()
+
+
+def test_copy_asset_tree_preserves_existing_destination_mode(tmp_path):
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "asset.txt").write_text("new\n", encoding="utf-8")
+    destination = tmp_path / "installed"
+    destination.mkdir()
+    installed_asset = destination / "asset.txt"
+    installed_asset.write_text("old\n", encoding="utf-8")
+    installed_asset.chmod(0o755)
+
+    copy_asset_tree(source, destination)
+
+    assert stat.S_IMODE(installed_asset.stat().st_mode) == 0o755
+
+
+def test_copy_asset_tree_uses_conventional_mode_for_new_files(tmp_path):
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "asset.txt").write_text("new\n", encoding="utf-8")
+    destination = tmp_path / "installed"
+
+    copy_asset_tree(source, destination)
+
+    assert stat.S_IMODE((destination / "asset.txt").stat().st_mode) == 0o644
 
 
 def test_validate_asset_destination_path_allows_missing_destination(tmp_path):

--- a/tests/data/test_ignore_files.py
+++ b/tests/data/test_ignore_files.py
@@ -1,12 +1,15 @@
 """Tests for repository ignore-file editing helpers."""
 
 import subprocess
+import stat
 
 import pytest
 
 from git_stage_batch.data.ignore_files import (
+    add_file_to_local_exclude,
     add_file_to_gitignore,
     get_gitignore_path,
+    get_local_exclude_path,
     read_gitignore_lines,
     remove_file_from_gitignore,
     write_gitignore_lines,
@@ -73,6 +76,28 @@ class TestGitignoreManipulation:
         gitignore = get_gitignore_path()
         content = gitignore.read_text()
         assert content == "*.pyc\n__pycache__/\n.env\n"
+
+    @pytest.mark.parametrize("mode", [0o600, 0o644, 0o660, 0o755])
+    def test_write_gitignore_lines_preserves_existing_mode(
+        self,
+        temp_git_repo,
+        mode,
+    ):
+        gitignore = get_gitignore_path()
+        gitignore.write_text("old\n")
+        gitignore.chmod(mode)
+
+        write_gitignore_lines(["new\n"])
+
+        assert stat.S_IMODE(gitignore.stat().st_mode) == mode
+
+    def test_write_gitignore_lines_creates_conventional_project_file(
+        self,
+        temp_git_repo,
+    ):
+        write_gitignore_lines(["entry\n"])
+
+        assert stat.S_IMODE(get_gitignore_path().stat().st_mode) == 0o644
 
     def test_add_file_to_gitignore_new(self, temp_git_repo):
         """Test adding a file to .gitignore when .gitignore doesn't exist."""
@@ -171,3 +196,18 @@ class TestGitignoreManipulation:
         assert removed is False
 
         assert gitignore.read_text() == "*.pyc\n"
+
+
+class TestLocalExcludeManipulation:
+    """Tests for repository-local exclude file permissions."""
+
+    def test_add_file_to_local_exclude_preserves_existing_mode(
+        self,
+        temp_git_repo,
+    ):
+        exclude = get_local_exclude_path()
+        exclude.chmod(0o660)
+
+        add_file_to_local_exclude("local.txt")
+
+        assert stat.S_IMODE(exclude.stat().st_mode) == 0o660

--- a/tests/utils/test_file_io.py
+++ b/tests/utils/test_file_io.py
@@ -1,18 +1,24 @@
 """Tests for file I/O utilities."""
 
 import os
+import errno
+import stat
 
 import pytest
 
 import git_stage_batch.utils.file_io as file_io
+from git_stage_batch.exceptions import CommandError
 from git_stage_batch.utils.file_io import read_file_paths_file
 from git_stage_batch.utils.file_io import write_file_paths_file
 from git_stage_batch.utils.file_io import append_file_path_to_file
 from git_stage_batch.utils.file_io import remove_file_path_from_file
 
 from git_stage_batch.utils.file_io import (
+    AtomicWriteModePolicy,
+    PROJECT_FILE_MODE,
     append_lines_to_file,
     read_text_file_contents,
+    write_file_bytes,
     write_text_file_contents,
 )
 
@@ -116,6 +122,159 @@ class TestWriteTextFileContents:
         assert test_file.read_text(encoding="utf-8") == "Old content"
         assert list(tmp_path.glob(".test.txt.*.tmp")) == []
 
+    @pytest.mark.parametrize("mode", [0o600, 0o644, 0o660, 0o755])
+    def test_project_write_preserves_existing_mode(self, tmp_path, mode):
+        test_file = tmp_path / "project-file"
+        test_file.write_text("old", encoding="utf-8")
+        test_file.chmod(mode)
+
+        write_text_file_contents(
+            test_file,
+            "new",
+            mode_policy=AtomicWriteModePolicy.PRESERVE_EXISTING,
+            mode=PROJECT_FILE_MODE,
+        )
+
+        assert stat.S_IMODE(test_file.stat().st_mode) == mode
+
+    def test_new_private_file_is_0600_under_permissive_umask(self, tmp_path):
+        test_file = tmp_path / "private-state"
+        old_umask = os.umask(0)
+        try:
+            write_text_file_contents(test_file, "state")
+        finally:
+            os.umask(old_umask)
+
+        assert stat.S_IMODE(test_file.stat().st_mode) == 0o600
+
+    def test_private_write_restricts_existing_file(self, tmp_path):
+        test_file = tmp_path / "private-state"
+        test_file.write_text("old", encoding="utf-8")
+        test_file.chmod(0o666)
+
+        write_text_file_contents(test_file, "new")
+
+        assert stat.S_IMODE(test_file.stat().st_mode) == 0o600
+
+    def test_new_project_file_receives_documented_mode(self, tmp_path):
+        test_file = tmp_path / "project-file"
+
+        write_file_bytes(
+            test_file,
+            b"content",
+            mode_policy=AtomicWriteModePolicy.PRESERVE_EXISTING,
+            mode=PROJECT_FILE_MODE,
+        )
+
+        assert stat.S_IMODE(test_file.stat().st_mode) == 0o644
+
+    def test_caller_supplied_mode_is_applied(self, tmp_path):
+        test_file = tmp_path / "generated-file"
+
+        write_text_file_contents(
+            test_file,
+            "content",
+            mode_policy=AtomicWriteModePolicy.CALLER_SUPPLIED,
+            mode=0o640,
+        )
+
+        assert stat.S_IMODE(test_file.stat().st_mode) == 0o640
+
+    def test_atomic_write_refuses_symlink(self, tmp_path):
+        target = tmp_path / "target"
+        target.write_text("target", encoding="utf-8")
+        link = tmp_path / "link"
+        link.symlink_to(target)
+
+        with pytest.raises(CommandError, match="Refusing to replace symlink"):
+            write_text_file_contents(
+                link,
+                "replacement",
+                mode_policy=AtomicWriteModePolicy.PRESERVE_EXISTING,
+            )
+
+        assert link.is_symlink()
+        assert target.read_text(encoding="utf-8") == "target"
+
+    def test_failed_temp_file_fsync_preserves_existing_contents(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("old", encoding="utf-8")
+
+        def fail_fsync(_file_descriptor):
+            raise OSError("fsync failed")
+
+        monkeypatch.setattr(os, "fsync", fail_fsync)
+
+        with pytest.raises(OSError, match="fsync failed"):
+            write_text_file_contents(test_file, "new")
+
+        assert test_file.read_text(encoding="utf-8") == "old"
+        assert list(tmp_path.glob(".test.txt.*.tmp")) == []
+
+    def test_unwritable_directory_failure_preserves_existing_contents(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("old", encoding="utf-8")
+
+        def refuse_temp_file(**_kwargs):
+            raise PermissionError("directory is read-only")
+
+        monkeypatch.setattr(file_io.tempfile, "mkstemp", refuse_temp_file)
+
+        with pytest.raises(PermissionError, match="read-only"):
+            write_text_file_contents(test_file, "new")
+
+        assert test_file.read_text(encoding="utf-8") == "old"
+
+    def test_ownership_permission_fallback_does_not_broaden_access(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        test_file = tmp_path / "project-file"
+        test_file.write_text("old", encoding="utf-8")
+        test_file.chmod(0o660)
+
+        def refuse_chown(_file_descriptor, _uid, _gid):
+            raise PermissionError("not permitted")
+
+        monkeypatch.setattr(os, "fchown", refuse_chown)
+
+        write_text_file_contents(
+            test_file,
+            "new",
+            mode_policy=AtomicWriteModePolicy.PRESERVE_EXISTING,
+        )
+
+        assert test_file.read_text(encoding="utf-8") == "new"
+        assert stat.S_IMODE(test_file.stat().st_mode) == 0o600
+
+    def test_unsupported_directory_fsync_is_tolerated(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        test_file = tmp_path / "test.txt"
+        real_open = os.open
+
+        def reject_directory_open(path, flags, mode=0o777):
+            if os.fspath(path) == os.fspath(tmp_path):
+                raise OSError(errno.EINVAL, "directory fsync unsupported")
+            return real_open(path, flags, mode)
+
+        monkeypatch.setattr(os, "open", reject_directory_open)
+
+        write_text_file_contents(test_file, "content")
+
+        assert test_file.read_text(encoding="utf-8") == "content"
+
 
 class TestAppendLinesToFile:
     """Tests for append_lines_to_file function."""
@@ -156,6 +315,25 @@ class TestAppendLinesToFile:
 
         assert test_file.exists()
         assert test_file.read_text(encoding="utf-8") == "Line 1\n"
+
+    def test_append_creates_private_file_under_permissive_umask(self, tmp_path):
+        test_file = tmp_path / "journal"
+        old_umask = os.umask(0)
+        try:
+            append_lines_to_file(test_file, ["entry"])
+        finally:
+            os.umask(old_umask)
+
+        assert stat.S_IMODE(test_file.stat().st_mode) == 0o600
+
+    def test_append_restricts_existing_state_file(self, tmp_path):
+        test_file = tmp_path / "journal"
+        test_file.write_text("old\n", encoding="utf-8")
+        test_file.chmod(0o666)
+
+        append_lines_to_file(test_file, ["new"])
+
+        assert stat.S_IMODE(test_file.stat().st_mode) == 0o600
 
     def test_append_empty_list(self, tmp_path):
         """Test appending an empty list."""


### PR DESCRIPTION
Git-stage-batch writes private session data and repository-owned files through
shared atomic replacement helpers. Those helpers provide complete-content
replacement but do not distinguish the permission policy of each target.

Users can see existing project files become private temporary-file modes,
including loss of executable or group-readable permissions. Conversely, new
private append-only state can inherit a permissive umask, and replacing a
symlink can silently change the kind of the repository path.

This pull request adds explicit private, preserve-existing, and caller-supplied
mode policies; preserves ownership where supported; narrows access when
ownership restoration fails; and syncs both replacement files and their
directories. Ignore files and installed assets adopt the project-file policy,
while state files and journals remain restricted to mode 0600.

The series adds permission, failure-injection, symlink, asset, and ignore-file
coverage and concludes by documenting the storage contract and recovery
behavior. The full test suite passes with 3,097 tests.