### PR TITLE
batch: Version persisted metadata

### DIFF
--- a/completions/git-stage-batch
+++ b/completions/git-stage-batch
@@ -49,7 +49,7 @@ _git_stage_batch()
     local cur prev words cword
     _init_completion || return
 
-    local commands="start show include skip discard status again stop abort block-file unblock-file suggest-fixup new list drop annotate apply reset undo redo"
+    local commands="start show include skip discard status again stop abort block-file unblock-file suggest-fixup new list drop annotate apply reset undo redo validate"
 
     # Handle subcommands
     if [[ $cword -eq 1 ]]; then
@@ -232,6 +232,9 @@ _git_stage_batch()
             ;;
         list)
             # No arguments
+            ;;
+        validate)
+            COMPREPLY=($(compgen -W "--porcelain" -- "$cur"))
             ;;
         *)
             ;;

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -869,6 +869,20 @@ Installing `codex-skills` also writes the shared internal drafter brief at
 
 ## Batch Operations
 
+### `validate`
+
+Validate persisted metadata for every batch without modifying refs or files.
+
+```bash
+git-stage-batch validate
+git-stage-batch validate --porcelain
+```
+
+The report identifies malformed or unsupported schemas, missing Git objects,
+content-ref mismatches, and unversioned metadata eligible for migration.
+
+---
+
 ### `sift`
 
 Reconcile a batch against the current tip by removing portions whose effect is already present.

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -52,3 +52,22 @@ the platform supports that operation. A failure before replacement leaves the
 old file complete. Symlink targets are never followed or silently replaced;
 the command stops with recovery guidance so callers can update the intended
 target explicitly.
+
+## Batch metadata schema
+
+Authoritative `batch.json` records use a versioned schema. Schema version 1
+stores an opaque revision identifier, batch identity, timestamps, baseline and
+content object IDs, and validated per-path metadata. Writers emit only the
+canonical current schema, while readers migrate the historical unversioned
+shape in memory before exposing it to batch operations.
+
+An unversioned file-backed record is copied to `metadata.v0.json` before its
+first durable rewrite. Successful publication stores the canonical metadata in
+the state ref, whose parent retains the previous state-ref version, and removes
+the compatibility directory. Failed publication leaves the recovery copy for
+inspection. Metadata from a newer unsupported schema is never rewritten.
+
+Run `git-stage-batch validate` to validate every batch without changing it. The
+command checks schema compatibility, object IDs, content-ref agreement, and
+reports whether a legacy record would be migrated. Use `--porcelain` for a
+stable JSON report suitable for support tooling.

--- a/man/git-stage-batch-validate.1.in
+++ b/man/git-stage-batch-validate.1.in
@@ -1,0 +1,43 @@
+.TH GIT-STAGE-BATCH-VALIDATE 1 "July 2026" "git-stage-batch @VERSION@" "User Commands"
+.SH NAME
+git-stage-batch-validate \- validate persisted batch metadata
+.SH SYNOPSIS
+.B git-stage-batch validate
+[\fB\-\-porcelain\fR]
+.SH DESCRIPTION
+.B validate
+checks every discoverable batch without modifying refs or metadata files.
+It validates the metadata schema, batch identity, repository paths, Git object
+IDs, ownership claims, and agreement between metadata and authoritative batch
+content refs.
+.PP
+Current metadata uses a versioned schema. Historical unversioned metadata is
+validated through the supported migration path and reported as eligible for
+migration, but this command does not perform the migration. Metadata from a
+newer unsupported schema is reported and left unchanged.
+.SH OPTIONS
+.TP
+.B \-\-porcelain
+Write a stable JSON report containing the supported schema version and one
+diagnostic record per batch. This form is intended for scripts and support
+tooling.
+.SH EXIT STATUS
+.TP
+.B 0
+Every discovered batch is valid, including legacy metadata that can be
+migrated by the installed version.
+.TP
+.B 1
+At least one batch has invalid, unsupported, or referentially inconsistent
+metadata.
+.SH EXAMPLES
+.RS
+.nf
+git-stage-batch validate
+git-stage-batch validate --porcelain
+.fi
+.RE
+.SH SEE ALSO
+.BR git-stage-batch (1),
+.BR git-stage-batch-list (1),
+.BR git-stage-batch-new (1)

--- a/man/git-stage-batch.1.in
+++ b/man/git-stage-batch.1.in
@@ -105,6 +105,9 @@ Set a batch note.
 .TP
 .BR git-stage-batch-sift (1)
 Remove already-present changes from a batch.
+.TP
+.BR git-stage-batch-validate (1)
+Validate persisted batch metadata without modifying it.
 .SS Other Commands
 .TP
 .BR git-stage-batch-interactive (1)

--- a/meson.build
+++ b/meson.build
@@ -60,6 +60,7 @@ manpage_specs = [
   ['git-stage-batch-suggest-fixup.1.in', 'git-stage-batch-suggest-fixup.1'],
   ['git-stage-batch-unblock-file.1.in', 'git-stage-batch-unblock-file.1'],
   ['git-stage-batch-undo.1.in', 'git-stage-batch-undo.1'],
+  ['git-stage-batch-validate.1.in', 'git-stage-batch-validate.1'],
 ]
 manpages = []
 foreach manpage_spec : manpage_specs

--- a/src/git_stage_batch/batch/binary_file_storage.py
+++ b/src/git_stage_batch/batch/binary_file_storage.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import json
-
 from ..core.buffer import LineBuffer
 from ..core.models import BinaryFileChange
 from .source_cache import (
@@ -12,12 +10,11 @@ from .source_cache import (
     save_session_batch_sources,
 )
 from .source_snapshots import create_batch_source_commit
-from ..utils.file_io import write_text_file_contents
 from ..utils.git_object_io import create_git_blob
 from ..utils.git_repository import get_git_repository_root_path
-from ..utils.paths import get_batch_metadata_file_path
 from . import content_commits as _content_commits
 from .lifecycle import create_batch
+from .metadata_io import write_file_backed_batch_metadata
 from .query import read_batch_metadata
 from .validation import batch_exists, validate_batch_name
 
@@ -77,8 +74,7 @@ def add_binary_file_to_batch(
             "mode": file_mode,
         }
 
-        metadata_path = get_batch_metadata_file_path(batch_name)
-        write_text_file_contents(metadata_path, json.dumps(metadata, indent=2))
+        write_file_backed_batch_metadata(batch_name, metadata)
 
         source_buffers = (
             {file_path: current_binary_buffer}

--- a/src/git_stage_batch/batch/file_entry_storage.py
+++ b/src/git_stage_batch/batch/file_entry_storage.py
@@ -2,17 +2,15 @@
 
 from __future__ import annotations
 
-import json
 from copy import deepcopy
 from typing import Optional
 
 from ..utils.repository_buffers import load_git_object_as_buffer
-from ..utils.file_io import write_text_file_contents
 from ..utils.git_command import run_git_command
 from ..utils.git_object_io import create_git_blob
-from ..utils.paths import get_batch_metadata_file_path
 from . import content_commits as _content_commits
 from .query import get_batch_commit_sha, read_batch_metadata
+from .metadata_io import write_file_backed_batch_metadata
 from .validation import validate_batch_name
 
 
@@ -20,8 +18,7 @@ def remove_file_from_batch(batch_name: str, file_path: str) -> None:
     """Remove a file from batch metadata and batch commit tree."""
     metadata = read_batch_metadata(batch_name)
     metadata.get("files", {}).pop(file_path, None)
-    metadata_path = get_batch_metadata_file_path(batch_name)
-    write_text_file_contents(metadata_path, json.dumps(metadata, indent=2))
+    write_file_backed_batch_metadata(batch_name, metadata)
     _content_commits.remove_file_from_batch_commit(batch_name, file_path)
 
 
@@ -41,8 +38,7 @@ def copy_file_from_batch_to_batch(
         dest_metadata["files"] = {}
     dest_metadata["files"][file_path] = deepcopy(file_meta)
 
-    metadata_path = get_batch_metadata_file_path(dest_batch)
-    write_text_file_contents(metadata_path, json.dumps(dest_metadata, indent=2))
+    write_file_backed_batch_metadata(dest_batch, dest_metadata)
 
     source_commit = get_batch_commit_sha(source_batch)
     if not source_commit:

--- a/src/git_stage_batch/batch/file_mode_storage.py
+++ b/src/git_stage_batch/batch/file_mode_storage.py
@@ -2,16 +2,13 @@
 
 from __future__ import annotations
 
-import json
-
 from ..core.buffer import LineBuffer
 from ..core.models import FileModeChange
-from ..utils.file_io import write_text_file_contents
 from ..utils.git_object_io import create_git_blob
 from ..utils.git_repository import get_git_repository_root_path
-from ..utils.paths import get_batch_metadata_file_path
 from . import content_commits as _content_commits
 from .lifecycle import create_batch
+from .metadata_io import write_file_backed_batch_metadata
 from .query import read_batch_metadata
 from .source_snapshots import create_batch_source_commit
 from .validation import batch_exists, validate_batch_name
@@ -42,10 +39,7 @@ def add_file_mode_to_batch(batch_name: str, change: FileModeChange) -> None:
             "presence_claims": [],
             "deletions": [],
         }
-        write_text_file_contents(
-            get_batch_metadata_file_path(batch_name),
-            json.dumps(metadata, indent=2),
-        )
+        write_file_backed_batch_metadata(batch_name, metadata)
         _content_commits.update_batch_commit(
             batch_name,
             file_path,

--- a/src/git_stage_batch/batch/gitlink_storage.py
+++ b/src/git_stage_batch/batch/gitlink_storage.py
@@ -2,13 +2,10 @@
 
 from __future__ import annotations
 
-import json
-
 from ..core.models import GitlinkChange
-from ..utils.file_io import write_text_file_contents
-from ..utils.paths import get_batch_metadata_file_path
 from . import content_commits as _content_commits
 from .lifecycle import create_batch
+from .metadata_io import write_file_backed_batch_metadata
 from .query import read_batch_metadata
 from .validation import batch_exists, validate_batch_name
 
@@ -36,8 +33,7 @@ def add_gitlink_to_batch(
         "new_oid": gitlink_change.new_oid,
     }
 
-    metadata_path = get_batch_metadata_file_path(batch_name)
-    write_text_file_contents(metadata_path, json.dumps(metadata, indent=2))
+    write_file_backed_batch_metadata(batch_name, metadata)
 
     if gitlink_change.is_deleted_file():
         _content_commits.remove_file_from_batch_commit(batch_name, file_path)

--- a/src/git_stage_batch/batch/lifecycle.py
+++ b/src/git_stage_batch/batch/lifecycle.py
@@ -2,19 +2,18 @@
 
 from __future__ import annotations
 
-import json
 import shutil
 from datetime import datetime, timezone
 
 from .query import read_batch_metadata
+from .metadata_io import write_file_backed_batch_metadata
 from .validation import batch_exists, validate_batch_name
 from ..exceptions import CommandError
 from ..i18n import _
-from ..utils.file_io import write_text_file_contents
 from ..utils.git_command import run_git_command
 from ..utils.git_index import git_commit_tree
 from ..utils.git_object_io import get_empty_git_tree_object_id, get_git_object_type
-from ..utils.paths import get_batch_directory_path, get_batch_metadata_file_path
+from ..utils.paths import get_batch_directory_path
 
 
 def create_batch(name: str, note: str = "", baseline_commit: str | None = None) -> None:
@@ -44,8 +43,7 @@ def create_batch(name: str, note: str = "", baseline_commit: str | None = None) 
         "baseline": baseline_commit,
         "files": {}
     }
-    metadata_path = get_batch_metadata_file_path(name)
-    write_text_file_contents(metadata_path, json.dumps(metadata, indent=2))
+    write_file_backed_batch_metadata(name, metadata)
 
     tree_result = run_git_command(["rev-parse", f"{baseline_commit}^{{tree}}"], requires_index_lock=False)
     tree_sha = tree_result.stdout.strip()
@@ -79,12 +77,11 @@ def update_batch_note(name: str, note: str) -> None:
     if not batch_exists(name):
         raise CommandError(_("Batch '{name}' does not exist").format(name=name))
 
-    metadata_path = get_batch_metadata_file_path(name)
     metadata = read_batch_metadata(name)
 
     # Update note
     metadata["note"] = note
-    write_text_file_contents(metadata_path, json.dumps(metadata, indent=2))
+    write_file_backed_batch_metadata(name, metadata)
 
     from .state_refs import sync_batch_state_refs
     sync_batch_state_refs(name)

--- a/src/git_stage_batch/batch/metadata_io.py
+++ b/src/git_stage_batch/batch/metadata_io.py
@@ -1,0 +1,51 @@
+"""Canonical file-backed batch metadata I/O."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from typing import Any
+
+from .metadata_schema import (
+    BatchMetadata,
+    decode_batch_metadata,
+    encode_batch_metadata,
+    metadata_from_application_dict,
+)
+from ..utils.file_io import read_text_file_contents, write_text_file_contents
+from ..utils.paths import get_batch_metadata_file_path
+
+
+def read_file_backed_batch_metadata_model(batch_name: str) -> BatchMetadata | None:
+    """Read and validate compatibility metadata, if it exists."""
+    metadata_path = get_batch_metadata_file_path(batch_name)
+    if not metadata_path.exists():
+        return None
+    return decode_batch_metadata(
+        read_text_file_contents(metadata_path),
+        expected_batch=batch_name,
+    )
+
+
+def write_file_backed_batch_metadata(
+    batch_name: str,
+    metadata: Mapping[str, Any],
+) -> BatchMetadata:
+    """Validate and atomically write current-schema compatibility metadata."""
+    metadata_path = get_batch_metadata_file_path(batch_name)
+    if metadata_path.exists():
+        original_payload = read_text_file_contents(metadata_path)
+        # Validate before replacing so unknown future schemas are preserved.
+        decode_batch_metadata(original_payload, expected_batch=batch_name)
+        original_data = json.loads(original_payload)
+        if "schema_version" not in original_data:
+            backup_path = metadata_path.with_name("metadata.v0.json")
+            if not backup_path.exists():
+                write_text_file_contents(backup_path, original_payload)
+
+    model = metadata_from_application_dict(batch_name, metadata)
+    write_text_file_contents(
+        metadata_path,
+        encode_batch_metadata(model),
+    )
+    return model

--- a/src/git_stage_batch/batch/metadata_schema.py
+++ b/src/git_stage_batch/batch/metadata_schema.py
@@ -1,0 +1,575 @@
+"""Versioned batch metadata parsing and canonical serialization."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import uuid
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from types import MappingProxyType
+from typing import Any, TypeAlias
+
+from ..exceptions import BatchMetadataError
+from ..utils.git_repository import object_id_hex_length
+
+
+CURRENT_BATCH_METADATA_SCHEMA_VERSION = 1
+
+JsonScalar: TypeAlias = None | bool | int | str
+JsonValue: TypeAlias = JsonScalar | tuple["JsonValue", ...] | Mapping[str, "JsonValue"]
+
+_LINE_RANGE_RE = re.compile(r"^(?P<start>[1-9][0-9]*)(?:-(?P<end>[1-9][0-9]*))?$")
+_FILE_METADATA_KEYS = frozenset({
+    "batch_source_commit",
+    "change_type",
+    "claimed_lines",
+    "deletions",
+    "file_type",
+    "mode",
+    "new_mode",
+    "new_oid",
+    "old_mode",
+    "old_oid",
+    "presence_claims",
+    "replacement_masks",
+    "replacement_units",
+    "source_path",
+})
+_TOP_LEVEL_KEYS = frozenset({
+    "schema_version",
+    "revision",
+    "batch",
+    "note",
+    "created_at",
+    "baseline",
+    "content_ref",
+    "content_commit",
+    "files",
+})
+_GIT_FILE_MODES = frozenset({"100644", "100755", "120000", "160000"})
+
+
+class BatchFileType(Enum):
+    """Persisted atomic file type; text entries omit the field."""
+
+    BINARY = "binary"
+    GITLINK = "gitlink"
+    MODE = "mode"
+
+
+class BatchChangeType(Enum):
+    """Persisted whole-file lifecycle state."""
+
+    ADDED = "added"
+    MODIFIED = "modified"
+    DELETED = "deleted"
+
+
+@dataclass(frozen=True)
+class BatchFileMetadata:
+    """Immutable validated metadata for one repository path."""
+
+    path: str
+    values: Mapping[str, JsonValue]
+
+    def to_dict(self) -> dict[str, Any]:
+        return _thaw_mapping(self.values)
+
+
+@dataclass(frozen=True)
+class BatchMetadata:
+    """Immutable current-schema batch metadata."""
+
+    revision: str
+    batch: str
+    note: str
+    created_at: str
+    baseline: str | None
+    files: tuple[BatchFileMetadata, ...]
+    content_ref: str | None = None
+    content_commit: str | None = None
+
+    def to_application_dict(self) -> dict[str, Any]:
+        """Return the compatibility mapping used by current domain code."""
+        return {
+            "revision": self.revision,
+            "note": self.note,
+            "created_at": self.created_at,
+            "baseline": self.baseline,
+            "files": {entry.path: entry.to_dict() for entry in self.files},
+        }
+
+    def to_storage_dict(self) -> dict[str, Any]:
+        """Return the canonical current-version storage representation."""
+        return {
+            "schema_version": CURRENT_BATCH_METADATA_SCHEMA_VERSION,
+            "revision": self.revision,
+            "batch": self.batch,
+            "note": self.note,
+            "created_at": self.created_at,
+            "baseline": self.baseline,
+            "content_ref": self.content_ref,
+            "content_commit": self.content_commit,
+            "files": {entry.path: entry.to_dict() for entry in self.files},
+        }
+
+
+def new_batch_metadata_revision() -> str:
+    """Return an opaque revision identifier for stale-writer detection."""
+    return str(uuid.uuid4())
+
+
+def decode_batch_metadata(
+    payload: str | bytes | Mapping[str, Any],
+    *,
+    expected_batch: str,
+) -> BatchMetadata:
+    """Decode v0 or v1 metadata and return a validated immutable model."""
+    data = _load_json_object(payload, expected_batch)
+    version = data.get("schema_version", 0)
+    if type(version) is not int:
+        _invalid(expected_batch, "'schema_version' must be an integer")
+    if version > CURRENT_BATCH_METADATA_SCHEMA_VERSION:
+        raise BatchMetadataError(
+            f"Batch '{expected_batch}' uses metadata schema version {version}, but "
+            f"this version of git-stage-batch supports through version "
+            f"{CURRENT_BATCH_METADATA_SCHEMA_VERSION}. Upgrade git-stage-batch "
+            "or use a compatible version; the metadata was not modified."
+        )
+    if version < 0:
+        _invalid(expected_batch, "'schema_version' cannot be negative")
+    migrated_from_v0 = version == 0
+    if migrated_from_v0:
+        data = _migrate_v0_to_v1(data, expected_batch)
+    elif version != CURRENT_BATCH_METADATA_SCHEMA_VERSION:
+        _invalid(expected_batch, f"unsupported metadata schema version {version}")
+    return _decode_v1(data, expected_batch, allow_legacy=migrated_from_v0)
+
+
+def encode_batch_metadata(metadata: BatchMetadata) -> str:
+    """Serialize current metadata deterministically."""
+    return json.dumps(
+        metadata.to_storage_dict(),
+        indent=2,
+        ensure_ascii=False,
+    ) + "\n"
+
+
+def metadata_from_application_dict(
+    batch_name: str,
+    data: Mapping[str, Any],
+    *,
+    content_ref: str | None = None,
+    content_commit: str | None = None,
+    new_revision: bool = False,
+) -> BatchMetadata:
+    """Validate a mutable application mapping before persistence."""
+    revision = data.get("revision")
+    if new_revision or revision is None:
+        revision = new_batch_metadata_revision()
+    storage = {
+        "schema_version": CURRENT_BATCH_METADATA_SCHEMA_VERSION,
+        "revision": revision,
+        "batch": batch_name,
+        "note": data.get("note", ""),
+        "created_at": data.get("created_at", ""),
+        "baseline": data.get("baseline"),
+        "content_ref": content_ref,
+        "content_commit": content_commit,
+        "files": data.get("files", {}),
+    }
+    return _decode_v1(storage, batch_name)
+
+
+def _load_json_object(
+    payload: str | bytes | Mapping[str, Any],
+    batch_name: str,
+) -> dict[str, Any]:
+    if isinstance(payload, Mapping):
+        data = dict(payload)
+    else:
+        try:
+            data = json.loads(payload)
+        except (json.JSONDecodeError, UnicodeDecodeError) as error:
+            raise BatchMetadataError(
+                f"Batch '{batch_name}' metadata is not valid JSON: {error}"
+            ) from error
+    if not isinstance(data, dict):
+        _invalid(batch_name, "top-level metadata must be an object")
+    return data
+
+
+def _migrate_v0_to_v1(data: dict[str, Any], batch_name: str) -> dict[str, Any]:
+    """Pure, deterministic migration from the historical unversioned shape."""
+    canonical_legacy = json.dumps(data, sort_keys=True, separators=(",", ":"))
+    revision = data.get("revision")
+    if revision is None:
+        revision = "v0-" + hashlib.sha256(canonical_legacy.encode("utf-8")).hexdigest()
+    return {
+        "schema_version": CURRENT_BATCH_METADATA_SCHEMA_VERSION,
+        "revision": revision,
+        "batch": data.get("batch", batch_name),
+        "note": data.get("note", ""),
+        "created_at": data.get("created_at", ""),
+        "baseline": data.get("baseline_commit", data.get("baseline")),
+        "content_ref": data.get("content_ref"),
+        "content_commit": data.get("content_commit"),
+        "files": data.get("files", {}),
+    }
+
+
+def _decode_v1(
+    data: dict[str, Any],
+    expected_batch: str,
+    *,
+    allow_legacy: bool = False,
+) -> BatchMetadata:
+    unknown_keys = set(data) - _TOP_LEVEL_KEYS
+    missing_keys = _TOP_LEVEL_KEYS - set(data)
+    if unknown_keys:
+        _invalid(expected_batch, f"unknown top-level field(s): {_field_list(unknown_keys)}")
+    if missing_keys:
+        _invalid(expected_batch, f"missing required field(s): {_field_list(missing_keys)}")
+    if data["schema_version"] != CURRENT_BATCH_METADATA_SCHEMA_VERSION:
+        _invalid(expected_batch, "metadata was not migrated to the current schema")
+
+    revision = _required_string(data, "revision", expected_batch)
+    batch = _required_string(data, "batch", expected_batch)
+    if batch != expected_batch:
+        _invalid(expected_batch, f"metadata identifies batch '{batch}'")
+    note = _required_string(data, "note", expected_batch, allow_empty=True)
+    created_at = _required_string(data, "created_at", expected_batch, allow_empty=True)
+    if created_at:
+        try:
+            datetime.fromisoformat(
+                created_at[:-1] + "+00:00" if created_at.endswith("Z") else created_at
+            )
+        except ValueError as error:
+            raise BatchMetadataError(
+                f"Batch '{expected_batch}' metadata field 'created_at' is not an "
+                "ISO-8601 timestamp"
+            ) from error
+
+    baseline = _optional_object_id(data, "baseline", expected_batch)
+    content_ref = _optional_string(data, "content_ref", expected_batch)
+    content_commit = _optional_object_id(data, "content_commit", expected_batch)
+    files_data = data["files"]
+    if not isinstance(files_data, dict):
+        _invalid(expected_batch, "'files' must be an object")
+
+    files = tuple(
+        _decode_file_metadata(path, values, expected_batch, allow_legacy=allow_legacy)
+        for path, values in files_data.items()
+    )
+    return BatchMetadata(
+        revision=revision,
+        batch=batch,
+        note=note,
+        created_at=created_at,
+        baseline=baseline,
+        files=files,
+        content_ref=content_ref,
+        content_commit=content_commit,
+    )
+
+
+def _decode_file_metadata(
+    path: Any,
+    values: Any,
+    batch_name: str,
+    *,
+    allow_legacy: bool,
+) -> BatchFileMetadata:
+    if not isinstance(path, str) or not path or "\x00" in path:
+        _invalid(batch_name, "file metadata path must be a non-empty string without NUL")
+    path_parts = path.split("/")
+    if path.startswith("/") or any(part in ("", ".", "..") for part in path_parts):
+        _invalid(batch_name, f"file metadata path is not repository-relative: {path!r}")
+    if not isinstance(values, dict):
+        _invalid(batch_name, f"file entry for {path!r} must be an object")
+    unknown_keys = set(values) - _FILE_METADATA_KEYS
+    if unknown_keys:
+        _invalid(
+            batch_name,
+            f"file entry for {path!r} has unknown field(s): {_field_list(unknown_keys)}",
+        )
+
+    file_type = values.get("file_type")
+    if file_type is not None and file_type not in {item.value for item in BatchFileType}:
+        _invalid(batch_name, f"file entry for {path!r} has invalid file_type")
+    change_type = values.get("change_type")
+    if change_type is not None and change_type not in {item.value for item in BatchChangeType}:
+        _invalid(batch_name, f"file entry for {path!r} has invalid change_type")
+    for key in ("mode", "old_mode", "new_mode"):
+        value = values.get(key)
+        if value is not None and value not in _GIT_FILE_MODES:
+            _invalid(batch_name, f"file entry for {path!r} has invalid {key}")
+    for key in ("batch_source_commit",):
+        if key in values:
+            _validate_object_id(values[key], batch_name, f"files[{path!r}].{key}")
+    for key in ("old_oid", "new_oid"):
+        value = values.get(key)
+        if value is not None:
+            _validate_hex_object_id(value, batch_name, f"files[{path!r}].{key}", (40, 64))
+    if "source_path" in values and values["source_path"] != f"sources/{path}":
+        _invalid(batch_name, f"file entry for {path!r} has inconsistent source_path")
+    if file_type in (None, BatchFileType.BINARY.value, BatchFileType.MODE.value):
+        if "batch_source_commit" not in values:
+            if not allow_legacy or file_type not in {
+                BatchFileType.BINARY.value,
+                BatchFileType.GITLINK.value,
+            }:
+                _invalid(batch_name, f"file entry for {path!r} is missing 'batch_source_commit'")
+    if file_type == BatchFileType.GITLINK.value and values.get("mode") != "160000":
+        _invalid(batch_name, f"gitlink entry for {path!r} must use mode 160000")
+    if file_type == BatchFileType.MODE.value:
+        if not {"old_mode", "new_mode", "mode"} <= set(values):
+            _invalid(batch_name, f"mode entry for {path!r} is missing mode fields")
+        if values["mode"] != values["new_mode"] or values["old_mode"] == values["new_mode"]:
+            _invalid(batch_name, f"mode entry for {path!r} has inconsistent transition")
+
+    _validate_claims(values, path, batch_name)
+    return BatchFileMetadata(path=path, values=_freeze_mapping(values, batch_name))
+
+
+def _validate_claims(values: dict[str, Any], path: str, batch_name: str) -> None:
+    for key in ("presence_claims", "deletions", "replacement_units", "claimed_lines"):
+        if key in values and not isinstance(values[key], list):
+            _invalid(batch_name, f"files[{path!r}].{key} must be an array")
+    seen_presence: set[tuple[str, ...]] = set()
+    for claim in values.get("presence_claims", []):
+        if not isinstance(claim, dict) or not isinstance(claim.get("source_lines"), list):
+            _invalid(batch_name, f"files[{path!r}].presence_claims has an invalid claim")
+        _reject_unknown_keys(
+            claim,
+            {"source_lines", "baseline_references"},
+            batch_name,
+            f"files[{path!r}].presence_claims",
+        )
+        ranges = tuple(claim["source_lines"])
+        _validate_line_ranges(ranges, batch_name, f"files[{path!r}].presence_claims")
+        if ranges in seen_presence:
+            _invalid(batch_name, f"files[{path!r}] has duplicate presence claims")
+        seen_presence.add(ranges)
+        references = claim.get("baseline_references", {})
+        if not isinstance(references, dict):
+            _invalid(batch_name, f"files[{path!r}] has invalid baseline_references")
+        for line, reference in references.items():
+            if not isinstance(line, str) or not line.isdigit() or int(line) < 1:
+                _invalid(batch_name, f"files[{path!r}] has invalid baseline reference line")
+            _validate_baseline_reference(reference, batch_name, path)
+    for deletion in values.get("deletions", []):
+        if not isinstance(deletion, dict):
+            _invalid(batch_name, f"files[{path!r}].deletions has a non-object entry")
+        _reject_unknown_keys(
+            deletion,
+            {"after_source_line", "blob", "baseline_reference"},
+            batch_name,
+            f"files[{path!r}].deletions",
+        )
+        anchor = deletion.get("after_source_line")
+        if anchor is not None and (type(anchor) is not int or anchor < 1):
+            _invalid(batch_name, f"files[{path!r}] has an invalid deletion anchor")
+        _validate_object_id(deletion.get("blob"), batch_name, f"files[{path!r}].deletions.blob")
+        if "baseline_reference" in deletion:
+            _validate_baseline_reference(deletion["baseline_reference"], batch_name, path)
+    deletion_count = len(values.get("deletions", []))
+    for replacement in values.get("replacement_units", []):
+        if not isinstance(replacement, dict):
+            _invalid(batch_name, f"files[{path!r}].replacement_units has a non-object entry")
+        _reject_unknown_keys(
+            replacement,
+            {"presence_lines", "claimed_lines", "deletion_indices", "original_unit"},
+            batch_name,
+            f"files[{path!r}].replacement_units",
+        )
+        presence_lines = replacement.get("presence_lines", replacement.get("claimed_lines"))
+        deletion_indices = replacement.get("deletion_indices")
+        if not isinstance(presence_lines, list) or not isinstance(deletion_indices, list):
+            _invalid(batch_name, f"files[{path!r}] has an invalid replacement unit")
+        _validate_line_ranges(
+            tuple(presence_lines),
+            batch_name,
+            f"files[{path!r}].replacement_units.presence_lines",
+        )
+        if (
+            any(type(index) is not int or not 0 <= index < deletion_count for index in deletion_indices)
+            or len(set(deletion_indices)) != len(deletion_indices)
+        ):
+            _invalid(batch_name, f"files[{path!r}] has invalid replacement deletion indices")
+        if "original_unit" in replacement:
+            _validate_replacement_origin(replacement["original_unit"], batch_name, path)
+    if "claimed_lines" in values:
+        _validate_line_ranges(
+            tuple(values["claimed_lines"]),
+            batch_name,
+            f"files[{path!r}].claimed_lines",
+        )
+    _validate_json_value(values, batch_name, f"files[{path!r}]")
+
+
+def _validate_baseline_reference(reference: Any, batch_name: str, path: str) -> None:
+    if not isinstance(reference, dict):
+        _invalid(batch_name, f"files[{path!r}] has a non-object baseline reference")
+    _reject_unknown_keys(
+        reference,
+        {"after_line", "after_blob", "before_line", "before_blob"},
+        batch_name,
+        f"files[{path!r}].baseline_reference",
+    )
+    for key in ("after_line", "before_line"):
+        value = reference.get(key)
+        if value is not None and (type(value) is not int or value < 1):
+            _invalid(batch_name, f"files[{path!r}] has invalid {key}")
+    for key in ("after_blob", "before_blob"):
+        if key in reference:
+            _validate_object_id(reference[key], batch_name, f"files[{path!r}].{key}")
+
+
+def _validate_replacement_origin(origin: Any, batch_name: str, path: str) -> None:
+    if not isinstance(origin, dict):
+        _invalid(batch_name, f"files[{path!r}] has a non-object replacement origin")
+    required = {"old_start", "old_end", "new_start", "new_end"}
+    _reject_unknown_keys(
+        origin,
+        required | {"baseline_reference"},
+        batch_name,
+        f"files[{path!r}].replacement_units.original_unit",
+    )
+    if not required <= set(origin):
+        _invalid(batch_name, f"files[{path!r}] has an incomplete replacement origin")
+    for key in required:
+        if type(origin[key]) is not int or origin[key] < 1:
+            _invalid(batch_name, f"files[{path!r}] has invalid replacement {key}")
+    if origin["old_end"] < origin["old_start"] or origin["new_end"] < origin["new_start"]:
+        _invalid(batch_name, f"files[{path!r}] has descending replacement coordinates")
+    if "baseline_reference" in origin:
+        _validate_baseline_reference(origin["baseline_reference"], batch_name, path)
+
+
+def _reject_unknown_keys(
+    data: dict[str, Any],
+    allowed: set[str],
+    batch_name: str,
+    field: str,
+) -> None:
+    unknown = set(data) - allowed
+    if unknown:
+        _invalid(batch_name, f"{field} has unknown field(s): {_field_list(unknown)}")
+
+
+def _validate_line_ranges(values: tuple[Any, ...], batch_name: str, field: str) -> None:
+    for value in values:
+        if type(value) is int:
+            if value < 1:
+                _invalid(batch_name, f"{field} contains a non-positive line")
+            continue
+        if not isinstance(value, str):
+            _invalid(batch_name, f"{field} contains a non-string range")
+        for segment in value.split(","):
+            match = _LINE_RANGE_RE.fullmatch(segment)
+            if match is None:
+                _invalid(batch_name, f"{field} contains invalid range {value!r}")
+            end = match.group("end")
+            if end is not None and int(end) < int(match.group("start")):
+                _invalid(batch_name, f"{field} contains descending range {value!r}")
+
+
+def _freeze_mapping(values: Mapping[str, Any], batch_name: str) -> Mapping[str, JsonValue]:
+    return MappingProxyType({
+        key: _freeze_json_value(value, batch_name, key)
+        for key, value in values.items()
+    })
+
+
+def _freeze_json_value(value: Any, batch_name: str, field: str) -> JsonValue:
+    if value is None or type(value) in (bool, int, str):
+        return value
+    if isinstance(value, list):
+        return tuple(_freeze_json_value(item, batch_name, field) for item in value)
+    if isinstance(value, dict):
+        if not all(isinstance(key, str) for key in value):
+            _invalid(batch_name, f"{field} contains a non-string object key")
+        return _freeze_mapping(value, batch_name)
+    _invalid(batch_name, f"{field} contains unsupported value type {type(value).__name__}")
+
+
+def _validate_json_value(value: Any, batch_name: str, field: str) -> None:
+    _freeze_json_value(value, batch_name, field)
+
+
+def _thaw_mapping(values: Mapping[str, JsonValue]) -> dict[str, Any]:
+    return {key: _thaw_json_value(value) for key, value in values.items()}
+
+
+def _thaw_json_value(value: JsonValue) -> Any:
+    if isinstance(value, Mapping):
+        return _thaw_mapping(value)
+    if isinstance(value, tuple):
+        return [_thaw_json_value(item) for item in value]
+    return value
+
+
+def _required_string(
+    data: Mapping[str, Any],
+    key: str,
+    batch_name: str,
+    *,
+    allow_empty: bool = False,
+) -> str:
+    value = data[key]
+    if not isinstance(value, str) or (not allow_empty and not value):
+        _invalid(batch_name, f"'{key}' must be a {'possibly empty ' if allow_empty else ''}string")
+    return value
+
+
+def _optional_string(data: Mapping[str, Any], key: str, batch_name: str) -> str | None:
+    value = data[key]
+    if value is not None and not isinstance(value, str):
+        _invalid(batch_name, f"'{key}' must be a string or null")
+    return value
+
+
+def _required_object_id(data: Mapping[str, Any], key: str, batch_name: str) -> str:
+    value = data[key]
+    _validate_object_id(value, batch_name, key)
+    return value
+
+
+def _optional_object_id(data: Mapping[str, Any], key: str, batch_name: str) -> str | None:
+    value = data[key]
+    if value is not None:
+        _validate_object_id(value, batch_name, key)
+    return value
+
+
+def _validate_object_id(value: Any, batch_name: str, field: str) -> None:
+    _validate_hex_object_id(value, batch_name, field, (object_id_hex_length(),))
+
+
+def _validate_hex_object_id(
+    value: Any,
+    batch_name: str,
+    field: str,
+    lengths: tuple[int, ...],
+) -> None:
+    if not isinstance(value, str) or len(value) not in lengths:
+        _invalid(batch_name, f"'{field}' must be a hexadecimal object ID")
+    try:
+        int(value, 16)
+    except ValueError as error:
+        raise BatchMetadataError(
+            f"Batch '{batch_name}' metadata field '{field}' is not hexadecimal"
+        ) from error
+
+
+def _field_list(fields: set[str] | frozenset[str]) -> str:
+    return ", ".join(repr(field) for field in sorted(fields))
+
+
+def _invalid(batch_name: str, detail: str) -> None:
+    raise BatchMetadataError(f"Batch '{batch_name}' metadata is invalid: {detail}.")

--- a/src/git_stage_batch/batch/metadata_validation.py
+++ b/src/git_stage_batch/batch/metadata_validation.py
@@ -244,6 +244,7 @@ def load_and_validate_batch_metadata(batch_name: str) -> dict[str, Any]:
 
     # Normalize and return
     return {
+        "revision": metadata.get("revision"),
         "note": metadata.get("note", ""),
         "created_at": metadata.get("created_at", ""),
         "baseline": metadata.get("baseline", None),

--- a/src/git_stage_batch/batch/query.py
+++ b/src/git_stage_batch/batch/query.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from collections.abc import Iterable
 from typing import Optional
 
@@ -13,13 +12,12 @@ from .state_refs import (
     read_batch_state_metadata_for_batches,
     read_batch_state_metadata,
 )
+from .metadata_io import read_file_backed_batch_metadata_model
 from .validation import invalid_file_backed_batch_names, validate_batch_name
 from ..exceptions import CommandError
 from ..i18n import _
-from ..utils.file_io import read_text_file_contents
 from ..utils.git_command import run_git_command
 from ..git_paths import decode_path, nul_records
-from ..utils.paths import get_batch_metadata_file_path
 
 
 def read_batch_metadata(name: str) -> dict:
@@ -82,20 +80,10 @@ def _empty_batch_metadata() -> dict:
 
 
 def _read_file_backed_batch_metadata_or_empty(name: str) -> dict:
-    metadata_path = get_batch_metadata_file_path(name)
-    if not metadata_path.exists():
+    model = read_file_backed_batch_metadata_model(name)
+    if model is None:
         return _empty_batch_metadata()
-
-    try:
-        metadata = json.loads(read_text_file_contents(metadata_path))
-        return {
-            "note": metadata.get("note", ""),
-            "created_at": metadata.get("created_at", ""),
-            "baseline": metadata.get("baseline", None),
-            "files": metadata.get("files", {})
-        }
-    except (json.JSONDecodeError, KeyError):
-        return _empty_batch_metadata()
+    return model.to_application_dict()
 
 
 def get_batch_commit_sha(name: str) -> Optional[str]:
@@ -117,9 +105,13 @@ def get_batch_commit_sha(name: str) -> Optional[str]:
     return result.stdout.strip()
 
 
-def list_batch_names() -> list[str]:
+def list_batch_names(*, validate_legacy_metadata: bool = True) -> list[str]:
     """List all batch names by querying authoritative refs and legacy imports."""
-    invalid_legacy_names = invalid_file_backed_batch_names()
+    invalid_legacy_names = (
+        invalid_file_backed_batch_names()
+        if validate_legacy_metadata
+        else []
+    )
     if invalid_legacy_names:
         formatted_names = ", ".join(repr(name) for name in invalid_legacy_names)
         raise CommandError(

--- a/src/git_stage_batch/batch/state_refs.py
+++ b/src/git_stage_batch/batch/state_refs.py
@@ -2,17 +2,24 @@
 
 from __future__ import annotations
 
-import json
 import shutil
+import subprocess
 from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Any
 
 from .ref_names import BATCH_CONTENT_REF_PREFIX, BATCH_STATE_REF_PREFIX, LEGACY_BATCH_REF_PREFIX
+from .metadata_io import read_file_backed_batch_metadata_model
+from .metadata_schema import (
+    BatchMetadata,
+    decode_batch_metadata,
+    encode_batch_metadata,
+    metadata_from_application_dict,
+)
 from .validation import validate_batch_name
+from ..exceptions import BatchMetadataError
 from ..core.buffer import LineBuffer
 from ..utils.repository_buffers import load_git_object_as_buffer
-from ..utils.file_io import read_text_file_contents
 from ..utils.git_command import (
     run_git_command,
 )
@@ -93,35 +100,20 @@ def _legacy_batch_commit_sha(batch_name: str) -> str | None:
     return result.stdout.strip()
 
 
-def read_file_backed_batch_metadata(batch_name: str) -> dict[str, Any]:
-    metadata_path = get_batch_metadata_file_path(batch_name)
-    if not metadata_path.exists():
+def read_file_backed_batch_metadata(batch_name: str) -> dict:
+    model = read_file_backed_batch_metadata_model(batch_name)
+    if model is None:
         return {
             "note": "",
             "created_at": "",
             "baseline": None,
             "files": {},
         }
-
-    metadata = json.loads(read_text_file_contents(metadata_path))
-    return {
-        "note": metadata.get("note", ""),
-        "created_at": metadata.get("created_at", ""),
-        "baseline": metadata.get("baseline", None),
-        "files": metadata.get("files", {}),
-    }
+    return model.to_application_dict()
 
 
-def _normalize_state_metadata(state_metadata: dict[str, Any]) -> dict[str, Any]:
-    return {
-        "note": state_metadata.get("note", ""),
-        "created_at": state_metadata.get("created_at", ""),
-        "baseline": state_metadata.get(
-            "baseline_commit",
-            state_metadata.get("baseline"),
-        ),
-        "files": state_metadata.get("files", {}),
-    }
+def _decode_state_metadata(payload: str | bytes, batch_name: str) -> BatchMetadata:
+    return decode_batch_metadata(payload, expected_batch=batch_name)
 
 
 def read_batch_state_metadata(batch_name: str) -> dict[str, Any] | None:
@@ -135,8 +127,7 @@ def read_batch_state_metadata(batch_name: str) -> dict[str, Any] | None:
     if result.returncode != 0:
         return None
 
-    state_metadata = json.loads(result.stdout)
-    return _normalize_state_metadata(state_metadata)
+    return _decode_state_metadata(result.stdout, batch_name).to_application_dict()
 
 
 def read_batch_state_metadata_for_batches(
@@ -160,7 +151,10 @@ def read_batch_state_metadata_for_batches(
         blob = blobs.get(refspec)
         if blob is None:
             continue
-        metadata_by_name[batch_name] = _normalize_state_metadata(json.loads(blob))
+        metadata_by_name[batch_name] = _decode_state_metadata(
+            blob,
+            batch_name,
+        ).to_application_dict()
     return metadata_by_name
 
 
@@ -186,21 +180,41 @@ def sync_batch_state_refs(
     """Publish batch metadata and source snapshots into authoritative Git refs."""
     validate_batch_name(batch_name)
 
-    content_commit = content_commit or get_authoritative_batch_commit_sha(batch_name) or _legacy_batch_commit_sha(batch_name)
+    existing_content_commit = get_authoritative_batch_commit_sha(batch_name)
+    content_commit = content_commit or existing_content_commit or _legacy_batch_commit_sha(batch_name)
     if not content_commit:
         delete_batch_state_refs(batch_name)
         return
 
-    metadata = read_file_backed_batch_metadata(batch_name)
-    state_metadata = {
-        "batch": batch_name,
-        "note": metadata.get("note", ""),
-        "created_at": metadata.get("created_at", ""),
-        "baseline_commit": metadata.get("baseline"),
-        "content_ref": get_batch_content_ref_name(batch_name),
-        "content_commit": content_commit,
-        "files": {},
-    }
+    file_backed_model = read_file_backed_batch_metadata_model(batch_name)
+    if file_backed_model is None:
+        raise ValueError(f"Batch '{batch_name}' has no file-backed metadata to publish")
+    metadata = file_backed_model.to_application_dict()
+
+    existing_state_ref = run_git_command(
+        ["rev-parse", "--verify", get_batch_state_ref_name(batch_name)],
+        check=False,
+        requires_index_lock=False,
+    )
+    existing_state_commit = (
+        existing_state_ref.stdout.strip()
+        if existing_state_ref.returncode == 0
+        else None
+    )
+    if existing_state_commit is not None:
+        existing_state = run_git_command(
+            ["show", f"{existing_state_commit}:batch.json"],
+            requires_index_lock=False,
+        )
+        existing_state_model = _decode_state_metadata(existing_state.stdout, batch_name)
+        if file_backed_model.revision != existing_state_model.revision:
+            remove_file_backed_batch_metadata(batch_name)
+            raise BatchMetadataError(
+                f"Batch '{batch_name}' changed after its metadata was read. "
+                "Retry the operation against the latest batch state."
+            )
+
+    state_files = {}
 
     source_buffers = source_buffers or {}
     buffer_updates: list[_StateBufferUpdate] = []
@@ -232,9 +246,16 @@ def sync_batch_state_refs(
                         )
                         state_file_meta["source_path"] = source_path
 
-                state_metadata["files"][file_path] = state_file_meta
+                state_files[file_path] = state_file_meta
 
-            state_json = json.dumps(state_metadata, indent=2).encode("utf-8")
+            state_model = metadata_from_application_dict(
+                batch_name,
+                {**metadata, "files": state_files},
+                content_ref=get_batch_content_ref_name(batch_name),
+                content_commit=content_commit,
+                new_revision=True,
+            )
+            state_json = encode_batch_metadata(state_model).encode("utf-8")
             buffer_updates.append(_StateBufferUpdate(path="batch.json", data=state_json))
             blob_shas = [
                 create_git_blob(_buffer_chunks(update.data))
@@ -257,14 +278,7 @@ def sync_batch_state_refs(
         for buffer in managed_buffers:
             buffer.close()
 
-    existing_state = run_git_command(
-        ["rev-parse", "--verify", get_batch_state_ref_name(batch_name)],
-        check=False,
-        requires_index_lock=False,
-    )
-    parents = []
-    if existing_state.returncode == 0 and existing_state.stdout.strip():
-        parents.append(existing_state.stdout.strip())
+    parents = [existing_state_commit] if existing_state_commit is not None else []
 
     state_commit = git_commit_tree(
         tree_sha,
@@ -272,11 +286,22 @@ def sync_batch_state_refs(
         message=f"Batch state: {batch_name}",
     )
 
-    update_git_refs(
-        updates=[
-            (get_batch_content_ref_name(batch_name), content_commit),
-            (get_batch_state_ref_name(batch_name), state_commit),
-        ],
-        deletes=[get_legacy_batch_ref_name(batch_name)],
-    )
+    try:
+        update_git_refs(
+            updates=[
+                (get_batch_content_ref_name(batch_name), content_commit),
+                (get_batch_state_ref_name(batch_name), state_commit),
+            ],
+            deletes=[get_legacy_batch_ref_name(batch_name)],
+            expected_old_values={
+                get_batch_content_ref_name(batch_name): existing_content_commit,
+                get_batch_state_ref_name(batch_name): existing_state_commit,
+            },
+        )
+    except subprocess.CalledProcessError as error:
+        remove_file_backed_batch_metadata(batch_name)
+        raise BatchMetadataError(
+            f"Batch '{batch_name}' changed while its metadata was being published. "
+            "Retry the operation against the latest batch state."
+        ) from error
     remove_file_backed_batch_metadata(batch_name)

--- a/src/git_stage_batch/batch/text_file_storage.py
+++ b/src/git_stage_batch/batch/text_file_storage.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from .metadata_validation import get_validated_baseline_commit
+from .metadata_io import write_file_backed_batch_metadata
 from .lifecycle import create_batch
 from .query import get_batch_commit_sha, read_batch_metadata
 from .validation import batch_exists, validate_batch_name
@@ -24,7 +24,6 @@ from ..core.buffer import LineBuffer
 from ..utils.repository_buffers import (
     load_git_tree_files_as_buffers,
 )
-from ..utils.file_io import write_text_file_contents
 from ..utils.git_index import (
     GitIndexEntryUpdate,
     git_commit_tree,
@@ -35,7 +34,6 @@ from ..utils.git_index import (
 )
 from ..utils.git_repository import get_git_repository_root_path
 from ..utils.git_object_io import create_git_blob
-from ..utils.paths import get_batch_metadata_file_path
 from . import content_commits as _content_commits
 from . import realized_file_content as _realized_file_content
 
@@ -247,8 +245,7 @@ def add_files_to_batch(batch_name: str, updates: list[BatchFileUpdate]) -> None:
                 )
             git_update_index_entries(index_updates, env=env)
 
-            metadata_path = get_batch_metadata_file_path(batch_name)
-            write_text_file_contents(metadata_path, json.dumps(metadata, indent=2))
+            write_file_backed_batch_metadata(batch_name, metadata)
             if batch_sources_changed:
                 save_session_batch_sources(batch_sources)
 

--- a/src/git_stage_batch/cli/batch_subcommands.py
+++ b/src/git_stage_batch/cli/batch_subcommands.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from ..commands.annotate import command_annotate_batch
 from ..commands.drop import command_drop_batch
+from ..commands.validate import command_validate_batches
 from ..commands.list import command_list_batches
 from ..commands.new import command_new_batch
 from ..commands.sift import command_sift_batch
@@ -44,6 +45,23 @@ def add_list_subcommand(subparsers) -> None:
         help=_("List all batches"),
     )
     parser_list.set_defaults(func=lambda _: command_list_batches())
+
+
+def add_validate_subcommand(subparsers) -> None:
+    """Register the non-mutating batch metadata diagnostic command."""
+    parser_validate = add_subcommand_parser(
+        subparsers,
+        "validate",
+        help=_("Validate persisted batch metadata"),
+    )
+    parser_validate.add_argument(
+        "--porcelain",
+        action="store_true",
+        help=_("Output stable JSON diagnostics"),
+    )
+    parser_validate.set_defaults(
+        func=lambda args: command_validate_batches(porcelain=args.porcelain)
+    )
 
 
 def add_drop_subcommand(subparsers) -> None:

--- a/src/git_stage_batch/cli/main.py
+++ b/src/git_stage_batch/cli/main.py
@@ -16,7 +16,7 @@ from .argument_parser import parse_command_line
 from .pager import pager_output, should_page_output
 
 
-_READ_ONLY_COMMANDS = frozenset({"check-unstaged", "list", "show", "status"})
+_READ_ONLY_COMMANDS = frozenset({"check-unstaged", "list", "show", "status", "validate"})
 
 
 def _command_may_mutate(args) -> bool:

--- a/src/git_stage_batch/cli/subcommand_registry.py
+++ b/src/git_stage_batch/cli/subcommand_registry.py
@@ -7,6 +7,7 @@ from .batch_subcommands import (
     add_annotate_subcommand,
     add_apply_subcommand,
     add_drop_subcommand,
+    add_validate_subcommand,
     add_list_subcommand,
     add_new_subcommand,
     add_reset_subcommand,
@@ -57,6 +58,7 @@ def add_cli_subcommands(subparsers) -> None:
     add_suggest_fixup_subcommand(subparsers)
     add_new_subcommand(subparsers)
     add_list_subcommand(subparsers)
+    add_validate_subcommand(subparsers)
     add_drop_subcommand(subparsers)
     add_annotate_subcommand(subparsers)
     add_apply_subcommand(subparsers)

--- a/src/git_stage_batch/commands/batch_source/reset_claims.py
+++ b/src/git_stage_batch/commands/batch_source/reset_claims.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-import json
 import shlex
 from collections.abc import Sequence
 from contextlib import AbstractContextManager
 
 from ...batch.lifecycle import create_batch
+from ...batch.metadata_io import write_file_backed_batch_metadata
 from ...batch.ownership import BatchOwnership
 from ...batch.ownership_detachment import acquire_detached_batch_ownership
 from ...batch.ownership_metadata_loading import acquire_ownership_for_metadata_dict
@@ -38,8 +38,6 @@ from ...data.batch_file_scope import resolve_batch_file_scope
 from ...utils.repository_buffers import load_git_object_as_buffer
 from ...exceptions import MergeError, exit_with_error
 from ...i18n import _
-from ...utils.file_io import write_text_file_contents
-from ...utils.paths import get_batch_metadata_file_path
 
 
 def move_claims_between_batches(
@@ -254,8 +252,7 @@ def reset_all_claims_from_batch(batch_name: str) -> None:
     """Remove all claims from a batch."""
     metadata = read_batch_metadata(batch_name)
     metadata["files"] = {}
-    metadata_path = get_batch_metadata_file_path(batch_name)
-    write_text_file_contents(metadata_path, json.dumps(metadata, indent=2))
+    write_file_backed_batch_metadata(batch_name, metadata)
     sync_batch_state_refs(batch_name)
 
 

--- a/src/git_stage_batch/commands/batch_transform/sift_persistence.py
+++ b/src/git_stage_batch/commands/batch_transform/sift_persistence.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-import json
-
 from ...batch.lifecycle import create_batch, delete_batch
+from ...batch.metadata_io import write_file_backed_batch_metadata
 from ...batch.ownership import BatchOwnership
 from ...batch.query import get_batch_baseline_commit, read_batch_metadata
 from ...batch.state_refs import (
@@ -23,7 +22,6 @@ from ...core.buffer import LineBuffer
 from ...core.text_lifecycle import TextFileChangeType, normalized_text_change_type
 from ...exceptions import exit_with_error
 from ...i18n import _
-from ...utils.file_io import write_text_file_contents
 from ...utils.git_command import run_git_command
 from ...utils.git_index import (
     git_commit_tree,
@@ -33,7 +31,6 @@ from ...utils.git_index import (
     temp_git_index,
 )
 from ...utils.git_object_io import create_git_blob
-from ...utils.paths import get_batch_metadata_file_path
 from .sift_results import SiftedBinaryFileResult, SiftedFileResult, SiftedModeFileResult
 
 
@@ -124,8 +121,7 @@ def add_sifted_text_file_to_batch(
         file_metadata["change_type"] = text_change_type.value
     metadata["files"][file_path] = file_metadata
 
-    metadata_path = get_batch_metadata_file_path(batch_name)
-    write_text_file_contents(metadata_path, json.dumps(metadata, indent=2))
+    write_file_backed_batch_metadata(batch_name, metadata)
 
     source_buffers = {file_path: target_buffer}
     if text_change_type == TextFileChangeType.DELETED:
@@ -210,11 +206,8 @@ def replace_batch_with_sifted_files(
         if temp_commit.returncode == 0:
             commit_sha = temp_commit.stdout.strip()
             temp_metadata = read_batch_metadata(temp_batch_name)
-            metadata_path = get_batch_metadata_file_path(batch_name)
-            write_text_file_contents(
-                metadata_path,
-                json.dumps(temp_metadata, indent=2),
-            )
+            temp_metadata["revision"] = source_metadata.get("revision")
+            write_file_backed_batch_metadata(batch_name, temp_metadata)
             sync_batch_state_refs(
                 batch_name,
                 content_commit=commit_sha,

--- a/src/git_stage_batch/commands/validate.py
+++ b/src/git_stage_batch/commands/validate.py
@@ -1,0 +1,145 @@
+"""Non-mutating batch metadata diagnostics."""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections.abc import Mapping
+from typing import Any
+
+from ..batch.metadata_schema import (
+    CURRENT_BATCH_METADATA_SCHEMA_VERSION,
+    BatchMetadata,
+    decode_batch_metadata,
+)
+from ..batch.query import list_batch_names
+from ..batch.validation import invalid_file_backed_batch_names, validate_batch_name
+from ..batch.state_refs import (
+    get_authoritative_batch_commit_sha,
+    get_batch_content_ref_name,
+    get_batch_state_ref_name,
+)
+from ..exceptions import BatchMetadataError, CommandError
+from ..i18n import _
+from ..utils.file_io import read_text_file_contents
+from ..utils.git_command import run_git_command
+from ..utils.git_repository import require_git_repository
+from ..utils.paths import get_batch_metadata_file_path
+
+
+def inspect_batch_metadata() -> list[dict[str, Any]]:
+    """Return diagnostics for every discoverable batch without writing state."""
+    reports = []
+    invalid_file_names = invalid_file_backed_batch_names()
+    batch_names = sorted(set(list_batch_names(validate_legacy_metadata=False)) | set(invalid_file_names))
+    for batch_name in batch_names:
+        report: dict[str, Any] = {
+            "batch": batch_name,
+            "status": "ok",
+            "schema_version": None,
+            "migration_required": False,
+            "errors": [],
+        }
+        try:
+            validate_batch_name(batch_name)
+        except CommandError as error:
+            report["status"] = "error"
+            report["source"] = "legacy-file"
+            report["errors"].append(error.message)
+            reports.append(report)
+            continue
+        state_result = run_git_command(
+            ["show", f"{get_batch_state_ref_name(batch_name)}:batch.json"],
+            check=False,
+            requires_index_lock=False,
+        )
+        if state_result.returncode == 0:
+            payload = state_result.stdout
+            source = "state-ref"
+        else:
+            metadata_path = get_batch_metadata_file_path(batch_name)
+            payload = read_text_file_contents(metadata_path) if metadata_path.exists() else ""
+            source = "legacy-file"
+        report["source"] = source
+
+        try:
+            raw = json.loads(payload)
+            report["schema_version"] = raw.get("schema_version", 0) if isinstance(raw, dict) else None
+            report["migration_required"] = report["schema_version"] == 0
+            model = decode_batch_metadata(payload, expected_batch=batch_name)
+            report["revision"] = model.revision
+            report["errors"].extend(_referential_errors(model))
+        except (BatchMetadataError, json.JSONDecodeError) as error:
+            report["errors"].append(str(error))
+
+        if report["errors"]:
+            report["status"] = "error"
+        reports.append(report)
+    return reports
+
+
+def _referential_errors(model: BatchMetadata) -> list[str]:
+    errors = []
+    expected_ref = get_batch_content_ref_name(model.batch)
+    actual_commit = get_authoritative_batch_commit_sha(model.batch)
+    if model.content_ref is not None and model.content_ref != expected_ref:
+        errors.append(
+            f"content_ref is {model.content_ref!r}; expected {expected_ref!r}"
+        )
+    if model.content_commit is not None and model.content_commit != actual_commit:
+        errors.append(
+            "content_commit does not match the authoritative batch content ref"
+        )
+    object_fields = []
+    if model.baseline is not None:
+        object_fields.append(("baseline", model.baseline))
+    for entry in model.files:
+        source_commit = entry.values.get("batch_source_commit")
+        if isinstance(source_commit, str):
+            object_fields.append((f"files[{entry.path!r}].batch_source_commit", source_commit))
+        for index, deletion in enumerate(entry.values.get("deletions", ())):
+            blob = deletion.get("blob") if isinstance(deletion, Mapping) else None
+            if isinstance(blob, str):
+                object_fields.append((f"files[{entry.path!r}].deletions[{index}].blob", blob))
+    for field, object_id in object_fields:
+        result = run_git_command(
+            ["cat-file", "-e", object_id],
+            check=False,
+            requires_index_lock=False,
+        )
+        if result.returncode != 0:
+            errors.append(f"{field} names missing object {object_id}")
+    return errors
+
+
+def command_validate_batches(*, porcelain: bool = False) -> None:
+    """Validate all persisted batch metadata without migrating it."""
+    require_git_repository()
+    reports = inspect_batch_metadata()
+    if porcelain:
+        print(json.dumps(
+            {
+                "metadata_schema": CURRENT_BATCH_METADATA_SCHEMA_VERSION,
+                "batches": reports,
+            },
+            indent=2,
+        ))
+    elif not reports:
+        print(_("No batches found"), file=sys.stderr)
+    else:
+        for report in reports:
+            if report["status"] == "ok":
+                suffix = (
+                    _(" (migration to schema v{version} available)").format(
+                        version=CURRENT_BATCH_METADATA_SCHEMA_VERSION
+                    )
+                    if report["migration_required"]
+                    else ""
+                )
+                print(f"✓ {report['batch']}: metadata valid{suffix}")
+            else:
+                print(f"✗ {report['batch']}:", file=sys.stderr)
+                for error in report["errors"]:
+                    print(f"  {error}", file=sys.stderr)
+    if any(report["status"] == "error" for report in reports):
+        raise CommandError("", exit_code=1)

--- a/src/git_stage_batch/data/batch_refs.py
+++ b/src/git_stage_batch/data/batch_refs.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from ..batch.ref_names import BATCH_CONTENT_REF_PREFIX, LEGACY_BATCH_REF_PREFIX
 from ..batch.query import read_batch_metadata
+from ..batch.metadata_io import write_file_backed_batch_metadata
 from ..batch.state_refs import (
     delete_batch_state_refs,
     get_batch_content_ref_name,
@@ -18,11 +19,7 @@ from ..batch.state_refs import (
 from ..utils.file_io import read_text_file_contents, write_text_file_contents
 from ..utils.git_command import run_git_command
 from ..utils.git_refs import update_git_refs
-from ..utils.paths import (
-    get_batch_directory_path,
-    get_batch_metadata_file_path,
-    get_batch_refs_snapshot_file_path,
-)
+from ..utils.paths import get_batch_directory_path, get_batch_refs_snapshot_file_path
 
 
 def _list_batch_content_refs() -> dict[str, str]:
@@ -117,10 +114,6 @@ def restore_batch_refs() -> None:
         state_commit_sha = batch_state.get("state_commit_sha")
         full_metadata = batch_state.get("metadata", {})
 
-        # Restore complete metadata
-        metadata_path = get_batch_metadata_file_path(batch_name)
-        write_text_file_contents(metadata_path, json.dumps(full_metadata, indent=2))
-
         if state_commit_sha:
             update_git_refs(
                 updates=[
@@ -131,4 +124,5 @@ def restore_batch_refs() -> None:
             )
             remove_file_backed_batch_metadata(batch_name)
         else:
+            write_file_backed_batch_metadata(batch_name, full_metadata)
             sync_batch_state_refs(batch_name, content_commit=commit_sha)

--- a/src/git_stage_batch/utils/git_refs.py
+++ b/src/git_stage_batch/utils/git_refs.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 
 from .git_command import run_git_command, stream_git_command
+from .git_repository import null_object_id
 
 
 def _git_ref_exists(ref_name: str) -> bool:
@@ -21,6 +22,7 @@ def update_git_refs(
     updates: Iterable[tuple[str, str]] = (),
     deletes: Iterable[str] = (),
     ignore_missing_deletes: bool = True,
+    expected_old_values: Mapping[str, str | None] | None = None,
 ) -> None:
     """Update one or more Git refs in a single update-ref transaction."""
     update_commands = list(updates)
@@ -33,11 +35,40 @@ def update_git_refs(
         return
 
     commands = ["start"]
+    expected = expected_old_values or {}
     commands.extend(
-        f"update {ref_name} {object_name}"
+        " ".join(
+            part
+            for part in (
+                "update",
+                ref_name,
+                object_name,
+                (
+                    expected[ref_name] or null_object_id()
+                    if ref_name in expected
+                    else ""
+                ),
+            )
+            if part
+        )
         for ref_name, object_name in update_commands
     )
-    commands.extend(f"delete {ref_name}" for ref_name in delete_commands)
+    commands.extend(
+        " ".join(
+            part
+            for part in (
+                "delete",
+                ref_name,
+                (
+                    expected[ref_name] or null_object_id()
+                    if ref_name in expected
+                    else ""
+                ),
+            )
+            if part
+        )
+        for ref_name in delete_commands
+    )
     commands.extend(["prepare", "commit"])
     payload = ("\n".join(commands) + "\n").encode("utf-8")
     for _chunk in stream_git_command(

--- a/tests/batch/test_metadata_schema.py
+++ b/tests/batch/test_metadata_schema.py
@@ -1,0 +1,234 @@
+"""Tests for versioned batch metadata parsing and serialization."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from git_stage_batch.batch.metadata_schema import (
+    CURRENT_BATCH_METADATA_SCHEMA_VERSION,
+    decode_batch_metadata,
+    encode_batch_metadata,
+    metadata_from_application_dict,
+)
+from git_stage_batch.batch.metadata_io import write_file_backed_batch_metadata
+from git_stage_batch.exceptions import BatchMetadataError
+
+
+def _oid(character: str = "a") -> str:
+    return character * 40
+
+
+@pytest.fixture(autouse=True)
+def sha1_object_format(monkeypatch):
+    monkeypatch.setattr(
+        "git_stage_batch.batch.metadata_schema.object_id_hex_length",
+        lambda: 40,
+    )
+
+
+def _v1_metadata() -> dict:
+    return {
+        "schema_version": 1,
+        "revision": "revision-1",
+        "batch": "feature",
+        "note": "Feature work",
+        "created_at": "2026-07-10T12:00:00+00:00",
+        "baseline": _oid("a"),
+        "content_ref": "refs/git-stage-batch/batches/feature",
+        "content_commit": _oid("b"),
+        "files": {
+            "src/example.py": {
+                "batch_source_commit": _oid("c"),
+                "mode": "100644",
+                "presence_claims": [{"source_lines": ["1-3"]}],
+                "deletions": [],
+            }
+        },
+    }
+
+
+def test_v1_round_trip_is_deterministic_and_immutable():
+    model = decode_batch_metadata(_v1_metadata(), expected_batch="feature")
+
+    encoded = encode_batch_metadata(model)
+    reparsed = decode_batch_metadata(encoded, expected_batch="feature")
+
+    assert reparsed == model
+    assert encoded == encode_batch_metadata(reparsed)
+    with pytest.raises(FrozenInstanceError):
+        model.note = "changed"  # type: ignore[misc]
+    with pytest.raises(TypeError):
+        model.files[0].values["mode"] = "100755"  # type: ignore[index]
+
+
+def test_unversioned_state_metadata_migrates_deterministically():
+    legacy = {
+        "batch": "feature",
+        "note": "Legacy",
+        "created_at": "2026-07-10T12:00:00+00:00",
+        "baseline_commit": _oid("a"),
+        "content_ref": "refs/git-stage-batch/batches/feature",
+        "content_commit": _oid("b"),
+        "files": {},
+    }
+
+    first = decode_batch_metadata(legacy, expected_batch="feature")
+    second = decode_batch_metadata(dict(reversed(list(legacy.items()))), expected_batch="feature")
+
+    assert first == second
+    assert first.revision.startswith("v0-")
+    assert first.baseline == _oid("a")
+
+
+def test_application_mapping_serializes_only_current_schema():
+    model = metadata_from_application_dict(
+        "feature",
+        {
+            "revision": "revision-1",
+            "note": "Work",
+            "created_at": "2026-07-10T12:00:00+00:00",
+            "baseline": _oid("a"),
+            "files": {},
+        },
+    )
+
+    stored = json.loads(encode_batch_metadata(model))
+
+    assert stored["schema_version"] == CURRENT_BATCH_METADATA_SCHEMA_VERSION
+    assert stored["batch"] == "feature"
+    assert "baseline_commit" not in stored
+
+
+def test_file_backed_v0_migration_keeps_recovery_copy(tmp_path, monkeypatch):
+    metadata_path = tmp_path / "metadata.json"
+    legacy = {
+        "note": "Legacy",
+        "created_at": "2026-07-10T12:00:00Z",
+        "baseline": _oid("a"),
+        "files": {},
+    }
+    original = json.dumps(legacy)
+    metadata_path.write_text(original, encoding="utf-8")
+    monkeypatch.setattr(
+        "git_stage_batch.batch.metadata_io.get_batch_metadata_file_path",
+        lambda _batch_name: metadata_path,
+    )
+
+    write_file_backed_batch_metadata(
+        "feature",
+        decode_batch_metadata(legacy, expected_batch="feature").to_application_dict(),
+    )
+
+    assert metadata_path.with_name("metadata.v0.json").read_text() == original
+    assert json.loads(metadata_path.read_text())["schema_version"] == 1
+
+
+def test_file_backed_writer_refuses_to_replace_future_schema(tmp_path, monkeypatch):
+    metadata_path = tmp_path / "metadata.json"
+    future = _v1_metadata()
+    future["schema_version"] = CURRENT_BATCH_METADATA_SCHEMA_VERSION + 1
+    original = json.dumps(future)
+    metadata_path.write_text(original, encoding="utf-8")
+    monkeypatch.setattr(
+        "git_stage_batch.batch.metadata_io.get_batch_metadata_file_path",
+        lambda _batch_name: metadata_path,
+    )
+
+    with pytest.raises(BatchMetadataError, match="Upgrade git-stage-batch"):
+        write_file_backed_batch_metadata("feature", {})
+
+    assert metadata_path.read_text() == original
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (lambda data: data.update(schema_version="1"), "must be an integer"),
+        (lambda data: data.update(extra=True), "unknown top-level"),
+        (lambda data: data.pop("baseline"), "missing required"),
+        (lambda data: data.update(batch="other"), "identifies batch 'other'"),
+        (lambda data: data.update(files=[]), "'files' must be an object"),
+        (lambda data: data.update(baseline="not-an-oid"), "object ID"),
+    ],
+)
+def test_v1_rejects_malformed_top_level_metadata(mutation, message):
+    data = _v1_metadata()
+    mutation(data)
+
+    with pytest.raises(BatchMetadataError, match=message):
+        decode_batch_metadata(data, expected_batch="feature")
+
+
+def test_future_schema_reports_upgrade_without_rewriting():
+    data = _v1_metadata()
+    data["schema_version"] = CURRENT_BATCH_METADATA_SCHEMA_VERSION + 1
+
+    with pytest.raises(BatchMetadataError, match="Upgrade git-stage-batch"):
+        decode_batch_metadata(data, expected_batch="feature")
+
+
+@pytest.mark.parametrize("payload", ["", "{", "[]", "null", "42"])
+def test_decoder_rejects_truncated_or_non_object_json(payload):
+    with pytest.raises(BatchMetadataError, match="valid JSON|top-level"):
+        decode_batch_metadata(payload, expected_batch="feature")
+
+
+@pytest.mark.parametrize(
+    ("path", "message"),
+    [
+        ("/absolute", "repository-relative"),
+        ("parent/../escape", "repository-relative"),
+        ("double//slash", "repository-relative"),
+        ("nul\x00path", "without NUL"),
+    ],
+)
+def test_v1_rejects_invalid_repository_paths(path, message):
+    data = _v1_metadata()
+    data["files"] = {path: {}}
+
+    with pytest.raises(BatchMetadataError, match=message):
+        decode_batch_metadata(data, expected_batch="feature")
+
+
+def test_v1_rejects_duplicate_presence_claims():
+    data = _v1_metadata()
+    data["files"]["src/example.py"]["presence_claims"] *= 2
+
+    with pytest.raises(BatchMetadataError, match="duplicate presence claims"):
+        decode_batch_metadata(data, expected_batch="feature")
+
+
+def test_v1_rejects_replacement_with_out_of_range_deletion_index():
+    data = _v1_metadata()
+    file_metadata = data["files"]["src/example.py"]
+    file_metadata["deletions"] = [
+        {"after_source_line": 1, "blob": _oid("d")}
+    ]
+    file_metadata["replacement_units"] = [
+        {"presence_lines": ["1"], "deletion_indices": [1]}
+    ]
+
+    with pytest.raises(BatchMetadataError, match="replacement deletion indices"):
+        decode_batch_metadata(data, expected_batch="feature")
+
+
+def test_v1_rejects_unknown_nested_claim_field():
+    data = _v1_metadata()
+    data["files"]["src/example.py"]["presence_claims"][0]["typo"] = True
+
+    with pytest.raises(BatchMetadataError, match="unknown field"):
+        decode_batch_metadata(data, expected_batch="feature")
+
+
+@pytest.mark.parametrize("line_range", ["0", "3-1", "one", "1--2"])
+def test_v1_rejects_invalid_line_ranges(line_range):
+    data = _v1_metadata()
+    data["files"]["src/example.py"]["presence_claims"] = [
+        {"source_lines": [line_range]}
+    ]
+
+    with pytest.raises(BatchMetadataError, match="range|non-positive"):
+        decode_batch_metadata(data, expected_batch="feature")

--- a/tests/batch/test_state_refs.py
+++ b/tests/batch/test_state_refs.py
@@ -6,15 +6,19 @@ import subprocess
 import pytest
 
 from git_stage_batch.batch.lifecycle import create_batch, delete_batch, update_batch_note
+from git_stage_batch.batch.metadata_io import write_file_backed_batch_metadata
+from git_stage_batch.batch.query import read_batch_metadata
 from git_stage_batch.batch.ownership import BatchOwnership
 import git_stage_batch.batch.state_refs as state_refs_module
 from git_stage_batch.batch.state_refs import (
     get_batch_content_ref_name,
     get_batch_state_ref_name,
     read_batch_state_metadata_for_batches,
+    sync_batch_state_refs,
 )
 from git_stage_batch.batch.text_file_storage import add_file_to_batch
 from git_stage_batch.data.session import initialize_abort_state
+from git_stage_batch.exceptions import BatchMetadataError
 from git_stage_batch.utils.paths import ensure_state_directory_exists
 
 
@@ -65,6 +69,8 @@ def test_state_ref_contains_batch_json_and_source_snapshot(temp_git_repo):
     content_commit = _git_rev_parse(content_ref)
 
     batch_json = json.loads(_git_show(f"{state_ref}:batch.json"))
+    assert batch_json["schema_version"] == 1
+    assert batch_json["revision"]
     assert batch_json["batch"] == "test-batch"
     assert batch_json["note"] == "Test note"
     assert batch_json["content_ref"] == content_ref
@@ -73,6 +79,22 @@ def test_state_ref_contains_batch_json_and_source_snapshot(temp_git_repo):
 
     source_content = _git_show(f"{state_ref}:sources/file.txt")
     assert source_content == "line1\nline2\nline3\n"
+
+
+def test_stale_metadata_writer_cannot_replace_newer_state(temp_git_repo):
+    create_batch("test-batch", "Original")
+    stale_metadata = read_batch_metadata("test-batch")
+    update_batch_note("test-batch", "Current")
+    current_state = _git_rev_parse(get_batch_state_ref_name("test-batch"))
+
+    stale_metadata["note"] = "Stale"
+    write_file_backed_batch_metadata("test-batch", stale_metadata)
+
+    with pytest.raises(BatchMetadataError, match="changed after its metadata was read"):
+        sync_batch_state_refs("test-batch")
+
+    assert _git_rev_parse(get_batch_state_ref_name("test-batch")) == current_state
+    assert read_batch_metadata("test-batch")["note"] == "Current"
 
 
 def test_state_ref_updates_note_history(temp_git_repo):

--- a/tests/commands/test_validate.py
+++ b/tests/commands/test_validate.py
@@ -1,0 +1,89 @@
+"""Tests for non-mutating batch metadata diagnostics."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+
+from git_stage_batch.commands.validate import command_validate_batches
+from git_stage_batch.commands.new import command_new_batch
+from git_stage_batch.utils.file_io import write_text_file_contents
+from git_stage_batch.utils.paths import get_batch_metadata_file_path
+from git_stage_batch.exceptions import CommandError
+
+
+@pytest.fixture
+def temp_git_repo(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    subprocess.run(["git", "init"], check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], check=True)
+    (tmp_path / "README").write_text("initial\n")
+    subprocess.run(["git", "add", "README"], check=True)
+    subprocess.run(["git", "commit", "-m", "Initial"], check=True, capture_output=True)
+    return tmp_path
+
+
+def test_validate_reports_current_metadata_without_mutation(temp_git_repo, capsys):
+    command_new_batch("current")
+    before = subprocess.run(
+        ["git", "rev-parse", "refs/git-stage-batch/state/current"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    command_validate_batches(porcelain=True)
+
+    report = json.loads(capsys.readouterr().out)
+    assert report["batches"][0]["status"] == "ok"
+    assert report["batches"][0]["schema_version"] == 1
+    after = subprocess.run(
+        ["git", "rev-parse", "refs/git-stage-batch/state/current"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    assert after == before
+
+
+def test_validate_previews_legacy_migration(temp_git_repo, capsys):
+    subprocess.run(["git", "update-ref", "refs/batches/legacy", "HEAD"], check=True)
+    metadata_path = get_batch_metadata_file_path("legacy")
+    metadata_path.parent.mkdir(parents=True)
+    write_text_file_contents(
+        metadata_path,
+        json.dumps({
+            "note": "Legacy",
+            "created_at": "",
+            "baseline": subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip(),
+            "files": {},
+        }),
+    )
+
+    command_validate_batches(porcelain=True)
+
+    report = json.loads(capsys.readouterr().out)["batches"][0]
+    assert report["status"] == "ok"
+    assert report["migration_required"] is True
+    assert json.loads(metadata_path.read_text()).get("schema_version") is None
+
+
+def test_validate_reports_invalid_orphaned_legacy_name(temp_git_repo, capsys):
+    metadata_path = get_batch_metadata_file_path("invalid^name")
+    metadata_path.parent.mkdir(parents=True)
+    write_text_file_contents(metadata_path, "{}")
+
+    with pytest.raises(CommandError):
+        command_validate_batches(porcelain=True)
+
+    report = json.loads(capsys.readouterr().out)["batches"][0]
+    assert report["status"] == "error"
+    assert "Git ref naming rules" in report["errors"][0]

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -54,6 +54,31 @@ def test_version_file_generated(tmp_path):
     assert expected_version in content
 
 
+def test_validate_man_page_generated(tmp_path):
+    """The metadata validation command should ship its dedicated manual."""
+    project_root = Path(__file__).parent.parent
+    build_dir = tmp_path / "build"
+
+    subprocess.run(
+        ["meson", "setup", str(build_dir)],
+        cwd=project_root,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["meson", "compile", "-C", str(build_dir)],
+        cwd=project_root,
+        check=True,
+        capture_output=True,
+    )
+
+    man_page = build_dir / "git-stage-batch-validate.1"
+    assert man_page.exists()
+    content = man_page.read_text(encoding="utf-8")
+    assert "validate persisted batch metadata" in content
+    assert "porcelain" in content
+
+
 def test_package_importable_from_build(tmp_path):
     """Test that the package can be imported from the build directory."""
     project_root = Path(__file__).parent.parent

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -83,6 +83,7 @@ class TestWheelContents:
             'git-stage-batch-include.1',
             'git-stage-batch-discard.1',
             'git-stage-batch-install-assets.1',
+            'git-stage-batch-validate.1',
         }
 
         assert expected_pages <= packaged_pages


### PR DESCRIPTION
Batch storage persists notes, baselines, file claims, and content information
through compatibility files and state refs without a stable schema contract.

Readers cannot reliably distinguish current records from legacy or unsupported
formats, and writers lack one validation boundary for migration, canonical
serialization, and stale-update detection. Users also have no read-only way to
diagnose malformed records, missing objects, or disagreement between storage
layers.

This pull request introduces immutable versioned metadata models, guarded
canonical persistence, recovery copies, and revision-aware state publication.
It adds a non-mutating `validate` command with human-readable and porcelain
reports, then exposes that workflow through Bash completion and a dedicated
installed and packaged manual.

The series pairs schema, persistence, and diagnostic changes with focused
coverage and concludes with migration, recovery, and validation guidance. The
full test suite passes with 3,130 tests.
