### PR TITLE
undo: Scope checkpoint snapshots

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -414,7 +414,9 @@ to its state before that operation.
 **Options:**
 - `--force`: Overwrite changes made after the undo checkpoint
 
-Refuses by default if the current state has changed since the checkpoint.
+Refuses by default if a path, index entry, or batch ref in the operation's
+checkpoint scope has changed. Unrelated dirty and staged files are not retained
+by the checkpoint, do not cause conflicts, and are left unchanged by undo.
 
 ---
 
@@ -429,7 +431,8 @@ Redo the most recently undone session operation.
 **Options:**
 - `--force`: Overwrite changes made after the undo
 
-Refuses by default if the current state has changed since the undo.
+Refuses by default if scoped state has changed since the undo. Unrelated
+worktree and index changes remain untouched.
 
 Multiple undo/redo works in editor order:
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -32,6 +32,24 @@ an object has already been pruned, restoration stops before mutation and
 reports the missing recovery object rather than partially applying the
 checkpoint.
 
+## Scoped undo checkpoints
+
+Each mutating command declares the repository paths it reads or writes. Undo
+manifests record only those worktree paths and index entries. Once an operation
+finishes, its checkpoint is also reduced to the session files, batch metadata,
+and refs that actually changed. Unrelated dirty or staged files and unrelated
+application metadata are not copied into the finalized checkpoint. Regular
+files in one scope share bulk index, HEAD, and object writes, so checkpoint
+process count does not grow with unrelated worktree dirtiness.
+
+Undo and redo restore scoped index entries individually instead of replacing
+the complete index, and restore only changed application-state paths and batch
+refs. A later change outside the command scope remains in place. Changes to a
+scoped path or ref still cause the default safety refusal, and `--force`
+overwrites only state owned by that checkpoint. Legacy whole-index and
+whole-state checkpoints remain readable for sessions created by older
+versions.
+
 ## Atomic file permissions
 
 Git-stage-batch writes session metadata, recovery manifests, batch

--- a/man/git-stage-batch-redo.1.in
+++ b/man/git-stage-batch-redo.1.in
@@ -8,7 +8,8 @@ git-stage-batch-redo \- redo the most recently undone operation
 .B redo
 restores the state that existed before the most recent undo. A new undoable
 operation after undo clears the redo stack. By default redo refuses if later
-changes make the checkpoint unsafe to apply.
+changes to scoped state make the checkpoint unsafe to apply. Unrelated
+worktree and index changes remain unchanged.
 .SH OPTIONS
 .TP
 .B \-\-force

--- a/man/git-stage-batch-undo.1.in
+++ b/man/git-stage-batch-undo.1.in
@@ -9,7 +9,8 @@ git-stage-batch-undo \- undo the most recent undoable session operation
 restores the repository state to the point before the most recent undoable
 session operation. It restores the index, working tree, session files, and
 batch refs recorded in that checkpoint. By default it refuses if later changes
-make the checkpoint unsafe to apply.
+to scoped state make the checkpoint unsafe to apply. Unrelated dirty and staged
+files are not retained by the checkpoint and remain unchanged.
 .SH OPTIONS
 .TP
 .B \-\-force

--- a/src/git_stage_batch/commands/block_file.py
+++ b/src/git_stage_batch/commands/block_file.py
@@ -62,7 +62,11 @@ def command_block_file(file_path_arg: str = "", local_only: bool = False) -> Non
     session_active = session_is_active()
     checkpoint_paths = [] if local_only else [".gitignore"]
     checkpoint = (
-        undo_checkpoint(f"block-file {file_path}", worktree_paths=checkpoint_paths)
+        undo_checkpoint(
+            f"block-file {file_path}",
+            worktree_paths=checkpoint_paths,
+            index_paths=[file_path] if not file_path.endswith("/") else [],
+        )
         if session_active else nullcontext()
     )
 

--- a/src/git_stage_batch/commands/file_scope/discard_file_replacement.py
+++ b/src/git_stage_batch/commands/file_scope/discard_file_replacement.py
@@ -33,16 +33,18 @@ def discard_file_as_replacement(
     if file is not None:
         operation_parts.extend(["--file", file])
 
-    with undo_checkpoint(" ".join(operation_parts)), ExitStack() as selected_state_stack:
+    target_file = file if file not in (None, "") else get_selected_change_file_path()
+    if target_file is None:
+        exit_with_error(_("No selected hunk. Run 'show' first or specify file path."))
+
+    with (
+        undo_checkpoint(" ".join(operation_parts), worktree_paths=[target_file]),
+        ExitStack() as selected_state_stack,
+    ):
         preserve_selected_state = False
         saved_selected_state = None
 
-        if file is None or file == "":
-            target_file = get_selected_change_file_path()
-            if target_file is None:
-                exit_with_error(_("No selected hunk. Run 'show' first or specify file path."))
-        else:
-            target_file = file
+        if file not in (None, ""):
             preserve_selected_state = True
             saved_selected_state = selected_state_stack.enter_context(
                 snapshot_selected_change_state()

--- a/src/git_stage_batch/commands/file_scope/include_file_replacement.py
+++ b/src/git_stage_batch/commands/file_scope/include_file_replacement.py
@@ -42,7 +42,14 @@ def include_file_as_replacement(
     if file is not None:
         operation_parts.extend(["--file", file])
 
-    with undo_checkpoint(" ".join(operation_parts)), ExitStack() as selected_state_stack:
+    target_file = file if file not in (None, "") else get_selected_change_file_path()
+    with (
+        undo_checkpoint(
+            " ".join(operation_parts),
+            worktree_paths=[target_file] if target_file is not None else [],
+        ),
+        ExitStack() as selected_state_stack,
+    ):
         preserve_selected_state = False
         saved_selected_state = None
 

--- a/src/git_stage_batch/commands/file_scope/multi_file_actions.py
+++ b/src/git_stage_batch/commands/file_scope/multi_file_actions.py
@@ -48,7 +48,7 @@ def _multi_file_undo_checkpoint(
     worktree_paths: Sequence[str] | None = None,
 ) -> AbstractContextManager[None]:
     """Create one undo checkpoint for a resolved multi-file command."""
-    paths = list(worktree_paths) if worktree_paths is not None else None
+    paths = list(worktree_paths) if worktree_paths is not None else list(files)
     return undo_checkpoint(
         _format_multi_file_operation(command, files),
         worktree_paths=paths,

--- a/src/git_stage_batch/commands/file_scope/target_path.py
+++ b/src/git_stage_batch/commands/file_scope/target_path.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
-from ...data.selected_change.paths import get_selected_change_file_path
+from ...data.selected_change.paths import (
+    SelectedChange,
+    get_selected_change_file_path,
+    worktree_paths_for_selected_change,
+)
 from ...exceptions import exit_with_error
 from ...i18n import _
 
@@ -16,3 +20,16 @@ def require_file_scope_target_path(file: str) -> str:
     if target_file is None:
         exit_with_error(_("No selected hunk. Run 'show' first or specify file path."))
     return target_file
+
+
+def checkpoint_paths_for_file_scope(
+    file: str | None,
+    selected_change: SelectedChange | None,
+) -> list[str]:
+    """Return concrete paths read by a selected or explicit file operation."""
+    if file not in (None, ""):
+        return [file]
+    if selected_change is not None:
+        return worktree_paths_for_selected_change(selected_change)
+    target_file = get_selected_change_file_path()
+    return [target_file] if target_file is not None else []

--- a/src/git_stage_batch/commands/selection/discard_line_action.py
+++ b/src/git_stage_batch/commands/selection/discard_line_action.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import sys
 
 from ...data.file_review.action_scope import finish_review_scoped_line_action
+from ...data.selected_change.paths import get_selected_change_file_path
 from ...data.undo_checkpoints import undo_checkpoint
 from ...i18n import _
 from . import discard_line_selection as _discard_line_selection
@@ -23,7 +24,11 @@ def discard_live_line_selection(
     if file is not None:
         operation_parts.extend(["--file", file])
 
-    with undo_checkpoint(" ".join(operation_parts)):
+    target_file = file if file not in (None, "") else get_selected_change_file_path()
+    with undo_checkpoint(
+        " ".join(operation_parts),
+        worktree_paths=[target_file] if target_file is not None else [],
+    ):
         file_path = _discard_line_selection.discard_worktree_line_selection(
             line_id_specification,
             file=file,

--- a/src/git_stage_batch/commands/selection/discard_line_replacement_action.py
+++ b/src/git_stage_batch/commands/selection/discard_line_replacement_action.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from ...core.replacement import ReplacementPayload, coerce_replacement_payload
 from ...data.file_review.action_scope import finish_review_scoped_line_action
 from ...data.selected_change.loading import require_selected_hunk
+from ...data.selected_change.paths import get_selected_change_file_path
 from ...data.selected_change.store import (
     restore_selected_change_state,
     snapshot_selected_change_state,
@@ -42,9 +43,12 @@ def discard_live_line_replacement_to_batch(
     if file is not None:
         operation_parts.extend(["--file", file])
 
-    target_file = None
+    target_file = file if file not in (None, "") else get_selected_change_file_path()
     with (
-        undo_checkpoint(" ".join(operation_parts)),
+        undo_checkpoint(
+            " ".join(operation_parts),
+            worktree_paths=[target_file] if target_file is not None else [],
+        ),
         snapshot_selected_change_state() as saved_selected_state,
     ):
         preserve_selected_state = file not in (None, "")

--- a/src/git_stage_batch/commands/selection/discard_to_batch_action.py
+++ b/src/git_stage_batch/commands/selection/discard_to_batch_action.py
@@ -14,7 +14,10 @@ from ...batch.validation import validate_batch_name
 from ...exceptions import exit_with_error
 from ...i18n import _
 from ..file_scope import discard_file_to_batch as _file_scope_discard_file_to_batch
-from ..file_scope.target_path import require_file_scope_target_path
+from ..file_scope.target_path import (
+    checkpoint_paths_for_file_scope,
+    require_file_scope_target_path,
+)
 from . import discard_line_batching as _discard_line_batching
 from . import selected_change_batch_discarding as _selected_change_batch_discarding
 from . import whole_file_batch_discarding as _whole_file_batch_discarding
@@ -39,7 +42,9 @@ def execute_discard_to_batch_action(
     if file is not None:
         operation_parts.extend(["--file", file])
 
-    with undo_checkpoint(" ".join(operation_parts)):
+    selected_change = load_selected_change() if file is None else None
+    worktree_paths = checkpoint_paths_for_file_scope(file, selected_change)
+    with undo_checkpoint(" ".join(operation_parts), worktree_paths=worktree_paths):
         if (
             file is None
             and line_ids is None

--- a/src/git_stage_batch/commands/selection/include_line_action.py
+++ b/src/git_stage_batch/commands/selection/include_line_action.py
@@ -9,6 +9,7 @@ from ...batch.selection import require_line_selection_in_view
 from ...core.buffer import LineBuffer, buffer_matches
 from ...core.line_selection import parse_line_selection
 from ...data.file_review.action_scope import finish_review_scoped_line_action
+from ...data.selected_change.paths import get_selected_change_file_path
 from ...data.line_id_files import read_line_ids_file, write_line_ids_file
 from ...utils.repository_buffers import load_git_object_as_buffer
 from ...data.selected_change.store import (
@@ -43,7 +44,14 @@ def include_live_line_selection(
     if file is not None:
         operation_parts.extend(["--file", file])
 
-    with undo_checkpoint(" ".join(operation_parts)), ExitStack() as selected_state_stack:
+    target_file = file if file not in (None, "") else get_selected_change_file_path()
+    with (
+        undo_checkpoint(
+            " ".join(operation_parts),
+            worktree_paths=[target_file] if target_file is not None else [],
+        ),
+        ExitStack() as selected_state_stack,
+    ):
         selection_context = _include_line_selection.load_include_line_selection_context(
             file,
             selected_state_stack,

--- a/src/git_stage_batch/commands/selection/include_line_replacement_action.py
+++ b/src/git_stage_batch/commands/selection/include_line_replacement_action.py
@@ -7,6 +7,7 @@ import sys
 
 from ...core.replacement import ReplacementPayload, coerce_replacement_payload
 from ...data.file_review.action_scope import finish_review_scoped_line_action
+from ...data.selected_change.paths import get_selected_change_file_path
 from ...data.line_id_files import write_line_ids_file
 from ...data.selected_change.store import restore_selected_change_state
 from ...data.undo_checkpoints import undo_checkpoint
@@ -40,7 +41,14 @@ def include_live_line_replacement(
         operation_parts.extend(["--file", file])
 
     replacement_file_context = None
-    with undo_checkpoint(" ".join(operation_parts)), ExitStack() as selected_state_stack:
+    target_file = file if file not in (None, "") else get_selected_change_file_path()
+    with (
+        undo_checkpoint(
+            " ".join(operation_parts),
+            worktree_paths=[target_file] if target_file is not None else [],
+        ),
+        ExitStack() as selected_state_stack,
+    ):
         if file is None:
             replacement_context = (
                 _include_line_replacement.prepare_pathless_include_line_replacement(

--- a/src/git_stage_batch/commands/selection/include_to_batch_action.py
+++ b/src/git_stage_batch/commands/selection/include_to_batch_action.py
@@ -20,7 +20,10 @@ from ...batch.validation import validate_batch_name
 from ...exceptions import exit_with_error
 from ...i18n import _
 from ..file_scope import include_file_to_batch as _file_scope_include_file_to_batch
-from ..file_scope.target_path import require_file_scope_target_path
+from ..file_scope.target_path import (
+    checkpoint_paths_for_file_scope,
+    require_file_scope_target_path,
+)
 from . import include_line_batching as _include_line_batching
 from . import selected_change_batch_staging as _selected_change_batch_staging
 from . import whole_file_batch_staging as _whole_file_batch_staging
@@ -44,7 +47,9 @@ def execute_include_to_batch_action(
     if file is not None:
         operation_parts.extend(["--file", file])
 
-    with undo_checkpoint(" ".join(operation_parts)):
+    selected_change = load_selected_change() if file is None else None
+    worktree_paths = checkpoint_paths_for_file_scope(file, selected_change)
+    with undo_checkpoint(" ".join(operation_parts), worktree_paths=worktree_paths):
         if (
             file is None
             and line_ids is None

--- a/src/git_stage_batch/commands/selection/selected_file_discarding.py
+++ b/src/git_stage_batch/commands/selection/selected_file_discarding.py
@@ -26,7 +26,7 @@ def discard_selected_file(
             print(_("No selected hunk. Run 'show' first or specify file path."), file=sys.stderr)
         return
 
-    with undo_checkpoint("discard"):
+    with undo_checkpoint("discard", worktree_paths=[target_file]):
         snapshot_file_if_untracked(target_file)
 
         head_result = run_git_command(

--- a/src/git_stage_batch/commands/selection/skip_line_selection.py
+++ b/src/git_stage_batch/commands/selection/skip_line_selection.py
@@ -58,6 +58,7 @@ def skip_line_selection(
     reuse_selected_file_view = False
     if file is None:
         require_selected_hunk()
+        target_file = get_selected_change_file_path()
     else:
         if file == "":
             target_file = get_selected_change_file_path()
@@ -83,7 +84,7 @@ def skip_line_selection(
     operation_parts = ["skip", "--line", line_id_specification]
     if file is not None:
         operation_parts.extend(["--file", file])
-    with undo_checkpoint(" ".join(operation_parts)):
+    with undo_checkpoint(" ".join(operation_parts), worktree_paths=[target_file]):
         if file is not None:
             if not reuse_selected_file_view:
                 if cache_unstaged_file_as_single_hunk(target_file) is None:

--- a/src/git_stage_batch/commands/unblock_file.py
+++ b/src/git_stage_batch/commands/unblock_file.py
@@ -67,7 +67,11 @@ def command_unblock_file(file_path_arg: str) -> None:
         file_path = file_path.rstrip("/") + "/"
     session_active = session_is_active()
     checkpoint = (
-        undo_checkpoint(f"unblock-file {file_path}", worktree_paths=[".gitignore"])
+        undo_checkpoint(
+            f"unblock-file {file_path}",
+            worktree_paths=[".gitignore"],
+            index_paths=[file_path] if not file_path.endswith("/") else [],
+        )
         if session_active else nullcontext()
     )
 

--- a/src/git_stage_batch/data/index_entries.py
+++ b/src/git_stage_batch/data/index_entries.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from collections.abc import Iterable
 
 from ..utils.git_command import run_git_command
 from ..git_paths import decode_path
@@ -46,3 +47,41 @@ def read_index_entry(file_path: str) -> IndexEntry | None:
         )
 
     return None
+
+
+def read_index_entries(file_paths: Iterable[str]) -> dict[str, IndexEntry]:
+    """Return stage-zero index entries for paths with one Git query."""
+    unique_paths = list(dict.fromkeys(file_paths))
+    if not unique_paths:
+        return {}
+    result = run_git_command(
+        ["ls-files", "--stage", "-z", "--", *unique_paths],
+        check=False,
+        text_output=False,
+        requires_index_lock=False,
+    )
+    if result.returncode != 0:
+        return {}
+
+    requested_paths = set(unique_paths)
+    entries: dict[str, IndexEntry] = {}
+    for record in result.stdout.split(b"\0"):
+        if not record:
+            continue
+        try:
+            metadata, path_bytes = record.split(b"\t", 1)
+        except ValueError:
+            continue
+        file_path = decode_path(path_bytes)
+        parts = metadata.split()
+        if (
+            file_path not in requested_paths
+            or len(parts) < 3
+            or parts[2] != b"0"
+        ):
+            continue
+        entries[file_path] = IndexEntry(
+            mode=parts[0].decode("ascii", errors="replace"),
+            object_id=parts[1].decode("ascii", errors="replace"),
+        )
+    return entries

--- a/src/git_stage_batch/data/recovery_anchors.py
+++ b/src/git_stage_batch/data/recovery_anchors.py
@@ -28,6 +28,9 @@ def state_recovery_objects(state: Mapping[str, Any]) -> set[str]:
     object_names = _existing_object_names(
         [state.get("head"), state.get("index_tree"), *state.get("refs", {}).values()]
     )
+    for entry in state.get("index_entries", {}).values():
+        if isinstance(entry, Mapping) and entry.get("mode") != "160000":
+            object_names.update(_existing_object_names([entry.get("object_id")]))
     for entry in state.get("worktree_paths", []):
         if not isinstance(entry, Mapping):
             continue

--- a/src/git_stage_batch/data/undo_checkpoints.py
+++ b/src/git_stage_batch/data/undo_checkpoints.py
@@ -14,7 +14,6 @@ from .undo_refs import (
     SESSION_REDO_STACK_REF,
     SESSION_UNDO_STACK_REF,
     checkpoint_parent,
-    clear_redo_history,
     current_redo_commit,
     current_undo_commit,
     list_restorable_refs,
@@ -44,6 +43,7 @@ from ..utils.git_index import (
     git_write_tree,
     temp_git_index,
 )
+from .index_entries import read_index_entries
 from ..utils.git_repository import get_git_repository_root_path
 from ..utils.git_object_io import create_git_blob, create_git_blobs_from_paths
 from ..utils.paths import (
@@ -59,11 +59,9 @@ CHANGED_WORKTREE_SCOPE = "changed"
 
 
 def _checkpoint_worktree_scope(
-    worktree_paths: list[str] | None,
+    worktree_paths: list[str],
 ) -> tuple[str, list[str]]:
     """Return checkpoint scope metadata and paths to snapshot."""
-    if worktree_paths is None:
-        return CHANGED_WORKTREE_SCOPE, _undo_worktree.changed_worktree_paths()
     return EXPLICIT_WORKTREE_SCOPE, sorted(set(worktree_paths))
 
 
@@ -72,12 +70,25 @@ def _uses_explicit_worktree_scope(manifest: dict[str, Any]) -> bool:
     return manifest.get("worktree_path_scope") == EXPLICIT_WORKTREE_SCOPE
 
 
-def _snapshot_current_state(paths: list[str]) -> dict[str, Any]:
-    index_result = run_git_command(["write-tree"], check=False, requires_index_lock=False)
+def _snapshot_current_state(
+    worktree_paths: list[str],
+    *,
+    index_paths: list[str] | None = None,
+    ref_names: list[str] | None = None,
+) -> dict[str, Any]:
+    if index_paths is None:
+        index_paths = worktree_paths
+    index_entries = read_index_entries(index_paths)
+    refs = list_restorable_refs()
+    if ref_names is not None:
+        refs = {name: refs[name] for name in ref_names if name in refs}
     return {
-        "index_tree": index_result.stdout.strip() if index_result.returncode == 0 else None,
-        "refs": list_restorable_refs(),
-        "worktree_paths": _undo_worktree.snapshot_worktree_paths(paths),
+        "index_entries": {
+            path: {"mode": entry.mode, "object_id": entry.object_id}
+            for path, entry in sorted(index_entries.items())
+        },
+        "refs": refs,
+        "worktree_paths": _undo_worktree.snapshot_worktree_paths(worktree_paths),
     }
 
 
@@ -94,63 +105,98 @@ def _add_blob_to_index(env: dict[str, str], path: str, data: bytes, mode: str = 
     )
 
 
-def _add_directory_to_index(env: dict[str, str], *, source_dir: Path, tree_prefix: str) -> None:
-    if not source_dir.exists():
-        return
-    file_paths = sorted(path for path in source_dir.rglob("*") if path.is_file())
-    normal_file_blobs = create_git_blobs_from_paths(
-        path for path in file_paths if not path.is_symlink()
+def _add_directory_to_index(
+    env: dict[str, str],
+    *,
+    source_dir: Path,
+    tree_prefix: str,
+    relative_paths: list[str] | None = None,
+) -> None:
+    state = _filesystem_directory_state(
+        source_dir,
+        relative_paths=relative_paths,
     )
-    updates: list[GitIndexEntryUpdate] = []
-    for file_path in file_paths:
-        relative_path = file_path.relative_to(source_dir).as_posix()
-        tree_path = f"{tree_prefix}/{relative_path}"
-        mode = _undo_worktree.file_mode_for_path(file_path)
-        if file_path.is_symlink():
-            updates.append(
-                _undo_worktree.index_update_from_path(
-                    index_path=tree_path,
-                    source_path=file_path,
-                    mode=mode,
-                )
-            )
-        else:
-            updates.append(
-                GitIndexEntryUpdate(
-                    file_path=tree_path,
-                    mode=mode,
-                    blob_sha=normal_file_blobs[file_path],
-                )
-            )
+    updates = [
+        GitIndexEntryUpdate(
+            file_path=f"{tree_prefix}/{relative_path}",
+            mode=entry["mode"],
+            blob_sha=entry["object_id"],
+        )
+        for relative_path, entry in sorted(state.items())
+    ]
     git_update_index_entries(updates, env=env)
 
 
-def _create_undo_checkpoint(operation: str, *, worktree_paths: list[str] | None = None) -> str | None:
+def _filesystem_directory_state(
+    source_dir: Path,
+    *,
+    relative_paths: list[str] | None = None,
+) -> dict[str, dict[str, str]]:
+    """Return content identities for application-state files."""
+    if not source_dir.exists():
+        return {}
+    if relative_paths is None:
+        file_paths = sorted(path for path in source_dir.rglob("*") if path.is_file())
+    else:
+        file_paths = sorted(
+            source_dir / relative_path
+            for relative_path in relative_paths
+            if (source_dir / relative_path).is_file()
+        )
+    normal_file_blobs = create_git_blobs_from_paths(
+        path for path in file_paths if not path.is_symlink()
+    )
+    state: dict[str, dict[str, str]] = {}
+    for file_path in file_paths:
+        relative_path = file_path.relative_to(source_dir).as_posix()
+        mode = _undo_worktree.file_mode_for_path(file_path)
+        if file_path.is_symlink():
+            object_id = _undo_worktree.create_blob_from_worktree_path(
+                file_path,
+                mode=mode,
+            )
+        else:
+            object_id = normal_file_blobs[file_path]
+        state[relative_path] = {"mode": mode, "object_id": object_id}
+    return state
+
+
+def _create_undo_checkpoint(
+    operation: str,
+    *,
+    worktree_paths: list[str],
+    index_paths: list[str] | None = None,
+) -> str | None:
     """Create a before-image checkpoint for an undoable operation."""
     session_dir = get_state_directory_path() / "session"
     if not session_dir.exists():
         return None
-
-    clear_redo_history()
 
     global _PENDING_CHECKPOINT
 
     worktree_path_scope, tracked_worktree_paths = _checkpoint_worktree_scope(
         worktree_paths
     )
-    before = _snapshot_current_state(tracked_worktree_paths)
+    tracked_index_paths = sorted(
+        set(worktree_paths if index_paths is None else index_paths)
+    )
+    before = _snapshot_current_state(
+        tracked_worktree_paths,
+        index_paths=tracked_index_paths,
+    )
     recovery_anchors = anchor_recovery_state(before)
 
     manifest = {
         "operation": operation,
         "head": current_head_commit(),
-        "index_tree": before["index_tree"],
+        "index_entries": before["index_entries"],
         "refs": before["refs"],
         "worktree_paths": [
             {key: value for key, value in entry.items() if key != "blob"}
             for entry in before["worktree_paths"]
         ],
         "tracked_worktree_paths": tracked_worktree_paths,
+        "tracked_index_paths": tracked_index_paths,
         "worktree_path_scope": worktree_path_scope,
         "recovery_anchors": recovery_anchors,
     }
@@ -181,19 +227,34 @@ def _create_undo_checkpoint(operation: str, *, worktree_paths: list[str] | None 
         parents=[parent] if parent else [],
         message=f"Undo checkpoint: {operation}",
     )
-    update_git_refs(updates=[(SESSION_UNDO_STACK_REF, checkpoint_commit)])
+    update_git_refs(
+        updates=[(SESSION_UNDO_STACK_REF, checkpoint_commit)],
+        deletes=[SESSION_REDO_STACK_REF],
+    )
     _PENDING_CHECKPOINT = checkpoint_commit
     return checkpoint_commit
 
 
 @contextmanager
-def undo_checkpoint(operation: str, *, worktree_paths: list[str] | None = None) -> Iterator[None]:
+def undo_checkpoint(
+    operation: str,
+    *,
+    worktree_paths: list[str],
+    index_paths: list[str] | None = None,
+) -> Iterator[None]:
     """Bracket an undoable operation with before and after snapshots."""
+    global _PENDING_CHECKPOINT
     if _PENDING_CHECKPOINT is not None:
-        yield
-        return
+        if current_undo_commit() == _PENDING_CHECKPOINT:
+            yield
+            return
+        _PENDING_CHECKPOINT = None
 
-    checkpoint = _create_undo_checkpoint(operation, worktree_paths=worktree_paths)
+    checkpoint = _create_undo_checkpoint(
+        operation,
+        worktree_paths=worktree_paths,
+        index_paths=index_paths,
+    )
     try:
         yield
     finally:
@@ -222,12 +283,71 @@ def finalize_pending_checkpoint() -> None:
     if not _uses_explicit_worktree_scope(manifest):
         paths.update(_undo_worktree.changed_worktree_paths())
     paths = sorted(paths)
-    manifest["after"] = _snapshot_current_state(paths)
+    index_paths = sorted(
+        set(manifest.get("tracked_index_paths", manifest.get("tracked_worktree_paths", [])))
+    )
+    manifest["after"] = _snapshot_current_state(paths, index_paths=index_paths)
+    manifest["after"]["tracked_index_paths"] = index_paths
+    before_refs = manifest.get("refs", {})
+    after_refs = manifest["after"].get("refs", {})
+    tracked_refs = sorted(
+        ref_name
+        for ref_name in set(before_refs) | set(after_refs)
+        if before_refs.get(ref_name) != after_refs.get(ref_name)
+    )
+    manifest["tracked_refs"] = tracked_refs
+    manifest["refs"] = {
+        ref_name: before_refs[ref_name]
+        for ref_name in tracked_refs
+        if ref_name in before_refs
+    }
+    manifest["after"]["tracked_refs"] = tracked_refs
+    manifest["after"]["refs"] = {
+        ref_name: after_refs[ref_name]
+        for ref_name in tracked_refs
+        if ref_name in after_refs
+    }
+    metadata_scopes = (
+        ("session", get_session_directory_path()),
+        ("batches", get_batches_directory_path()),
+    )
+    tree_removals: list[GitIndexEntryUpdate] = []
+    for prefix, source_dir in metadata_scopes:
+        before_files = _undo_restore.tree_prefix_state(checkpoint, prefix)
+        after_files = _filesystem_directory_state(source_dir)
+        tracked_paths = sorted(
+            relative_path
+            for relative_path in set(before_files) | set(after_files)
+            if before_files.get(relative_path) != after_files.get(relative_path)
+        )
+        manifest[f"tracked_{prefix}_paths"] = tracked_paths
+        manifest["after"][f"tracked_{prefix}_paths"] = tracked_paths
+        manifest["after"][f"{prefix}_files"] = {
+            relative_path: after_files[relative_path]
+            for relative_path in tracked_paths
+            if relative_path in after_files
+        }
+        tree_removals.extend(
+            GitIndexEntryUpdate(
+                file_path=f"{prefix}/{relative_path}",
+                force_remove=True,
+            )
+            for relative_path in before_files
+            if relative_path not in tracked_paths
+        )
     manifest["after"]["worktree_paths"] = manifest["after"]["worktree_paths"]
     manifest["recovery_anchors"].update(anchor_recovery_state(manifest["after"]))
+    retained_objects = state_recovery_objects(manifest)
+    retained_objects.update(state_recovery_objects(manifest["after"]))
+    manifest["recovery_anchors"] = {
+        ref_name: object_name
+        for ref_name, object_name in manifest["recovery_anchors"].items()
+        if object_name in retained_objects
+    }
 
     with temp_git_index() as env:
         git_read_tree(checkpoint, env=env)
+        git_update_index_entries(tree_removals, env=env)
         _add_blob_to_index(env, "manifest.json", json.dumps(manifest, indent=2, sort_keys=True).encode("utf-8"))
         tree_sha = git_write_tree(env=env)
 
@@ -246,9 +366,26 @@ def _worktree_state_by_path(entries: list[dict[str, Any]]) -> dict[str, dict[str
 
 def _detect_conflicts_against_state(expected_state: dict[str, Any]) -> list[str]:
     conflicts: list[str] = []
-    current = _snapshot_current_state([entry["path"] for entry in expected_state.get("worktree_paths", [])])
+    current = _snapshot_current_state(
+        [entry["path"] for entry in expected_state.get("worktree_paths", [])],
+        index_paths=expected_state.get("tracked_index_paths"),
+        ref_names=expected_state.get("tracked_refs"),
+    )
 
-    if current.get("index_tree") != expected_state.get("index_tree"):
+    if "index_entries" in expected_state:
+        index_changed = current.get("index_entries") != expected_state.get(
+            "index_entries"
+        )
+    else:
+        index_result = run_git_command(
+            ["write-tree"],
+            check=False,
+            requires_index_lock=False,
+        )
+        index_changed = (
+            index_result.stdout.strip() if index_result.returncode == 0 else None
+        ) != expected_state.get("index_tree")
+    if index_changed:
         conflicts.append(_("index"))
 
     if current.get("refs") != expected_state.get("refs"):
@@ -292,6 +429,89 @@ def _redo_relevant_paths(manifest: dict[str, Any]) -> list[str]:
     return sorted(paths)
 
 
+def _redo_relevant_index_paths(manifest: dict[str, Any]) -> list[str]:
+    """Return index paths owned by an undo/redo checkpoint."""
+    paths = set(
+        manifest.get("tracked_index_paths", manifest.get("tracked_worktree_paths", []))
+    )
+    for state_name in ("after", "after_undo"):
+        state = manifest.get(state_name)
+        if isinstance(state, dict):
+            paths.update(state.get("tracked_index_paths", []))
+            paths.update(state.get("index_entries", {}))
+    paths.update(manifest.get("index_entries", {}))
+    return sorted(paths)
+
+
+def _redo_relevant_refs(manifest: dict[str, Any]) -> list[str]:
+    """Return refs owned by an undo/redo checkpoint."""
+    refs = set(manifest.get("tracked_refs", []))
+    for state_name in ("after", "after_undo"):
+        state = manifest.get(state_name)
+        if isinstance(state, dict):
+            refs.update(state.get("tracked_refs", []))
+    return sorted(refs)
+
+
+def _restore_index_state(state: dict[str, Any]) -> None:
+    """Restore scoped index entries, with legacy whole-tree compatibility."""
+    index_entries = state.get("index_entries")
+    if not isinstance(index_entries, dict):
+        index_tree = state.get("index_tree")
+        if index_tree:
+            git_read_tree(index_tree)
+        return
+
+    if "tracked_index_paths" in state:
+        scoped_paths = set(state.get("tracked_index_paths", []))
+    else:
+        scoped_paths = set(state.get("tracked_worktree_paths", []))
+        for entry in state.get("worktree_paths", []):
+            if isinstance(entry, dict) and isinstance(entry.get("path"), str):
+                scoped_paths.add(entry["path"])
+    scoped_paths.update(index_entries)
+
+    updates: list[GitIndexEntryUpdate] = []
+    for file_path in sorted(scoped_paths):
+        entry = index_entries.get(file_path)
+        if isinstance(entry, dict):
+            mode = entry.get("mode")
+            object_id = entry.get("object_id")
+            if isinstance(mode, str) and isinstance(object_id, str):
+                updates.append(
+                    GitIndexEntryUpdate(
+                        file_path=file_path,
+                        mode=mode,
+                        blob_sha=object_id,
+                    )
+                )
+                continue
+        updates.append(GitIndexEntryUpdate(file_path=file_path, force_remove=True))
+    git_update_index_entries(updates)
+
+
+def _restore_metadata_state(commit: str, manifest: dict[str, Any]) -> None:
+    """Restore scoped application state with legacy whole-directory support."""
+    for prefix, target_dir in (
+        ("session", get_session_directory_path()),
+        ("batches", get_batches_directory_path()),
+    ):
+        tracked_paths = manifest.get(f"tracked_{prefix}_paths")
+        if isinstance(tracked_paths, list):
+            _undo_restore.restore_tree_paths(
+                commit,
+                prefix=prefix,
+                target_dir=target_dir,
+                tracked_paths=tracked_paths,
+            )
+        else:
+            _undo_restore.restore_tree_prefix(
+                commit,
+                prefix=prefix,
+                target_dir=target_dir,
+            )
+
+
 def _write_snapshot_commit(
     *,
     ref_name: str,
@@ -301,11 +521,23 @@ def _write_snapshot_commit(
     batches_dir: Path,
     worktree_entries: list[dict[str, Any]],
     parent: str | None,
+    session_paths: list[str] | None = None,
+    batch_paths: list[str] | None = None,
 ) -> str:
     with temp_git_index() as env:
         _add_blob_to_index(env, "manifest.json", json.dumps(manifest, indent=2, sort_keys=True).encode("utf-8"))
-        _add_directory_to_index(env, source_dir=session_dir, tree_prefix="session")
-        _add_directory_to_index(env, source_dir=batches_dir, tree_prefix="batches")
+        _add_directory_to_index(
+            env,
+            source_dir=session_dir,
+            tree_prefix="session",
+            relative_paths=session_paths,
+        )
+        _add_directory_to_index(
+            env,
+            source_dir=batches_dir,
+            tree_prefix="batches",
+            relative_paths=batch_paths,
+        )
 
         repo_root = get_git_repository_root_path()
         index_updates: list[GitIndexEntryUpdate] = []
@@ -359,6 +591,8 @@ def _push_redo_node(
     target_batches_dir: Path,
     after_undo: dict[str, Any],
     worktree_entries: list[dict[str, Any]],
+    session_paths: list[str],
+    batch_paths: list[str],
 ) -> str:
     recovery_objects = state_recovery_objects(target)
     recovery_objects.update(state_recovery_objects(after_undo))
@@ -370,8 +604,12 @@ def _push_redo_node(
             "head",
             current_head_commit(),
         ),
-        "index_tree": target.get("index_tree"),
+        "index_entries": target.get("index_entries", {}),
+        "tracked_index_paths": target.get("tracked_index_paths", []),
         "refs": target.get("refs", {}),
+        "tracked_refs": target.get("tracked_refs", []),
+        "tracked_session_paths": session_paths,
+        "tracked_batches_paths": batch_paths,
         "worktree_paths": [
             {key: value for key, value in entry.items() if key != "blob"}
             for entry in worktree_entries
@@ -389,6 +627,8 @@ def _push_redo_node(
         batches_dir=target_batches_dir,
         worktree_entries=worktree_entries,
         parent=parent,
+        session_paths=session_paths,
+        batch_paths=batch_paths,
     )
 
 
@@ -416,7 +656,15 @@ def undo_last_checkpoint(*, force: bool = False) -> str:
 
     operation = str(manifest.get("operation", "operation"))
     redo_paths = _redo_relevant_paths(manifest)
-    redo_target = _snapshot_current_state(redo_paths)
+    redo_index_paths = _redo_relevant_index_paths(manifest)
+    redo_refs = _redo_relevant_refs(manifest)
+    redo_target = _snapshot_current_state(
+        redo_paths,
+        index_paths=redo_index_paths,
+        ref_names=redo_refs,
+    )
+    redo_target["tracked_index_paths"] = redo_index_paths
+    redo_target["tracked_refs"] = redo_refs
     redo_worktree_entries = _undo_worktree.snapshot_worktree_paths(redo_paths)
 
     redo_session_dir = tempfile.mkdtemp(prefix="gsb-redo-session-")
@@ -429,26 +677,36 @@ def undo_last_checkpoint(*, force: bool = False) -> str:
         if live_batches_dir.exists():
             shutil.copytree(live_batches_dir, redo_batches_dir, dirs_exist_ok=True)
 
-        _undo_restore.restore_tree_prefix(
-            checkpoint,
-            prefix="session",
-            target_dir=live_session_dir,
+        _restore_metadata_state(checkpoint, manifest)
+        _undo_restore.restore_refs(
+            manifest.get("refs", {}),
+            tracked_refs=manifest.get("tracked_refs"),
         )
-        _undo_restore.restore_tree_prefix(
-            checkpoint,
-            prefix="batches",
-            target_dir=live_batches_dir,
-        )
-        _undo_restore.restore_refs(manifest.get("refs", {}))
 
-        index_tree = manifest.get("index_tree")
-        if index_tree:
-            git_read_tree(index_tree)
+        _restore_index_state(manifest)
 
         _undo_restore.restore_worktree(checkpoint, manifest)
         _undo_restore.restore_intent_to_add_entries()
 
-        after_undo = _snapshot_current_state(redo_paths)
+        after_undo = _snapshot_current_state(
+            redo_paths,
+            index_paths=redo_index_paths,
+            ref_names=redo_refs,
+        )
+        after_undo["tracked_index_paths"] = redo_index_paths
+        after_undo["tracked_refs"] = redo_refs
+        session_paths = list(manifest.get("tracked_session_paths", []))
+        batch_paths = list(manifest.get("tracked_batches_paths", []))
+        after_undo["tracked_session_paths"] = session_paths
+        after_undo["tracked_batches_paths"] = batch_paths
+        after_undo["session_files"] = _filesystem_directory_state(
+            get_session_directory_path(),
+            relative_paths=session_paths,
+        )
+        after_undo["batches_files"] = _filesystem_directory_state(
+            get_batches_directory_path(),
+            relative_paths=batch_paths,
+        )
 
         _push_redo_node(
             operation=operation,
@@ -458,6 +716,8 @@ def undo_last_checkpoint(*, force: bool = False) -> str:
             target_batches_dir=Path(redo_batches_dir),
             after_undo=after_undo,
             worktree_entries=redo_worktree_entries,
+            session_paths=session_paths,
+            batch_paths=batch_paths,
         )
     finally:
         shutil.rmtree(redo_session_dir, ignore_errors=True)
@@ -494,21 +754,13 @@ def redo_last_checkpoint(*, force: bool = False) -> str:
               "Run 'git-stage-batch redo --force' to overwrite those changes.").format(items=preview)
         )
 
-    _undo_restore.restore_tree_prefix(
-        redo_node,
-        prefix="session",
-        target_dir=get_session_directory_path(),
+    _restore_metadata_state(redo_node, manifest)
+    _undo_restore.restore_refs(
+        manifest.get("refs", {}),
+        tracked_refs=manifest.get("tracked_refs"),
     )
-    _undo_restore.restore_tree_prefix(
-        redo_node,
-        prefix="batches",
-        target_dir=get_batches_directory_path(),
-    )
-    _undo_restore.restore_refs(manifest.get("refs", {}))
 
-    index_tree = manifest.get("index_tree")
-    if index_tree:
-        git_read_tree(index_tree)
+    _restore_index_state(manifest)
 
     _undo_restore.restore_worktree(redo_node, manifest)
     _undo_restore.restore_intent_to_add_entries()

--- a/src/git_stage_batch/data/undo_restore.py
+++ b/src/git_stage_batch/data/undo_restore.py
@@ -26,7 +26,7 @@ from ..utils.git_refs import (
     update_git_refs,
 )
 from ..utils.git_worktree import git_checkout_detached
-from ..utils.git_index import git_add_paths
+from ..utils.git_index import git_add_paths, git_update_index
 from ..utils.git_repository import get_git_repository_root_path
 from ..utils.paths import get_auto_added_files_file_path
 
@@ -114,13 +114,59 @@ def restore_tree_prefix(commit: str, *, prefix: str, target_dir: Path) -> None:
         _restore_file_mode(target_path, mode)
 
 
-def restore_refs(saved_refs: dict[str, str]) -> None:
+def restore_tree_paths(
+    commit: str,
+    *,
+    prefix: str,
+    target_dir: Path,
+    tracked_paths: list[str],
+) -> None:
+    """Restore only tracked relative paths from one checkpoint tree prefix."""
+    saved_entries = {
+        Path(tree_path).relative_to(prefix).as_posix(): (mode, blob_sha)
+        for mode, blob_sha, tree_path in _tree_entries(commit, prefix)
+    }
+    for relative_name in tracked_paths:
+        target_path = target_dir / relative_name
+        saved_entry = saved_entries.get(relative_name)
+        if saved_entry is None:
+            if target_path.is_dir() and not target_path.is_symlink():
+                shutil.rmtree(target_path)
+            elif os.path.lexists(target_path):
+                target_path.unlink()
+            continue
+        mode, blob_sha = saved_entry
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        _write_blob_to_path(blob_sha, target_path)
+        _restore_file_mode(target_path, mode)
+
+
+def tree_prefix_state(commit: str, prefix: str) -> dict[str, dict[str, str]]:
+    """Return relative path, mode, and blob identity for a tree prefix."""
+    return {
+        Path(tree_path).relative_to(prefix).as_posix(): {
+            "mode": mode,
+            "object_id": blob_sha,
+        }
+        for mode, blob_sha, tree_path in _tree_entries(commit, prefix)
+    }
+
+
+def restore_refs(
+    saved_refs: dict[str, str],
+    *,
+    tracked_refs: list[str] | None = None,
+) -> None:
     """Restore undo-managed refs to a saved mapping."""
     current_refs = list_restorable_refs()
+    if tracked_refs is None:
+        tracked_refs = sorted(set(current_refs) | set(saved_refs))
     update_git_refs(
         updates=sorted(saved_refs.items()),
         deletes=sorted(
-            ref_name for ref_name in current_refs if ref_name not in saved_refs
+            ref_name
+            for ref_name in tracked_refs
+            if ref_name in current_refs and ref_name not in saved_refs
         ),
     )
 
@@ -168,4 +214,5 @@ def restore_intent_to_add_entries() -> None:
     for file_path in read_file_paths_file(get_auto_added_files_file_path()):
         full_path = repo_root / file_path
         if os.path.lexists(full_path):
+            git_update_index(file_path=file_path, force_remove=True, check=False)
             git_add_paths([file_path], intent_to_add=True, check=False)

--- a/src/git_stage_batch/data/undo_worktree.py
+++ b/src/git_stage_batch/data/undo_worktree.py
@@ -11,7 +11,7 @@ from ..core.buffer import LineBuffer
 from ..utils.git_command import run_git_command
 from ..utils.git_index import GitIndexEntryUpdate
 from ..utils.git_repository import get_git_repository_root_path
-from ..utils.git_object_io import create_git_blob
+from ..utils.git_object_io import create_git_blob, create_git_blobs_from_paths
 from ..git_paths import decode_path, nul_records
 
 
@@ -55,38 +55,50 @@ def changed_worktree_paths() -> list[str]:
     return sorted(paths)
 
 
-def _gitlink_oid_from_index(path: str) -> str | None:
+def _gitlink_oids_from_index(paths: list[str]) -> dict[str, str]:
+    """Return gitlink object IDs from the index with one Git query."""
+    if not paths:
+        return {}
     result = run_git_command(
-        ["ls-files", "--stage", "-z", "--", path],
+        ["ls-files", "--stage", "-z", "--", *paths],
         check=False,
         text_output=False,
         requires_index_lock=False,
     )
     if result.returncode != 0:
-        return None
+        return {}
+    object_ids: dict[str, str] = {}
     for record in nul_records(result.stdout):
-        metadata, _separator, _entry_path = record.partition(b"\t")
+        metadata, separator, entry_path = record.partition(b"\t")
+        if not separator:
+            continue
         parts = metadata.decode("ascii", errors="replace").split()
-        if len(parts) >= 2 and parts[0] == "160000":
-            return parts[1]
-    return None
+        if len(parts) >= 3 and parts[0] == "160000" and parts[2] == "0":
+            object_ids[decode_path(entry_path)] = parts[1]
+    return object_ids
 
 
-def _gitlink_oid_from_head(path: str) -> str | None:
+def _gitlink_oids_from_head(paths: list[str]) -> dict[str, str]:
+    """Return gitlink object IDs from HEAD with one Git query."""
+    if not paths:
+        return {}
     result = run_git_command(
-        ["ls-tree", "-z", "HEAD", "--", path],
+        ["ls-tree", "-z", "HEAD", "--", *paths],
         check=False,
         text_output=False,
         requires_index_lock=False,
     )
     if result.returncode != 0:
-        return None
+        return {}
+    object_ids: dict[str, str] = {}
     for record in nul_records(result.stdout):
-        metadata, _separator, _entry_path = record.partition(b"\t")
+        metadata, separator, entry_path = record.partition(b"\t")
+        if not separator:
+            continue
         parts = metadata.decode("ascii", errors="replace").split()
         if len(parts) >= 3 and parts[0] == "160000" and parts[1] == "commit":
-            return parts[2]
-    return None
+            object_ids[decode_path(entry_path)] = parts[2]
+    return object_ids
 
 
 def _worktree_commit_oid(path: str) -> str | None:
@@ -111,13 +123,12 @@ def _worktree_is_dirty(path: str) -> bool:
     return result.returncode != 0 or bool(result.stdout.strip())
 
 
-def _is_gitlink_path(path: str) -> bool:
-    return _gitlink_oid_from_index(path) is not None or _gitlink_oid_from_head(path) is not None
-
-
-def _snapshot_gitlink_path(path: str) -> dict[str, Any]:
-    index_oid = _gitlink_oid_from_index(path)
-    head_oid = _gitlink_oid_from_head(path)
+def _snapshot_gitlink_path(
+    path: str,
+    *,
+    index_oid: str | None,
+    head_oid: str | None,
+) -> dict[str, Any]:
     worktree_oid = _worktree_commit_oid(path)
     return {
         "path": path,
@@ -150,25 +161,52 @@ def _snapshot_embedded_repo_path(path: str) -> dict[str, Any]:
 def snapshot_worktree_paths(paths: list[str]) -> list[dict[str, Any]]:
     """Return before-image entries for repository-relative worktree paths."""
     repo_root = get_git_repository_root_path()
-    worktree_paths: list[dict[str, Any]] = []
-    for file_path in sorted(set(paths)):
+    unique_paths = sorted(set(paths))
+    index_gitlinks = _gitlink_oids_from_index(unique_paths)
+    head_gitlinks = _gitlink_oids_from_head(unique_paths)
+    normal_paths: list[Path] = []
+    modes_by_path: dict[str, str] = {}
+    for file_path in unique_paths:
         full_path = repo_root / file_path
-        if _is_gitlink_path(file_path):
-            worktree_paths.append(_snapshot_gitlink_path(file_path))
+        if file_path in index_gitlinks or file_path in head_gitlinks:
+            continue
+        if full_path.is_dir() and (full_path / ".git").exists():
+            continue
+        if os.path.lexists(full_path):
+            mode = file_mode_for_path(full_path)
+            modes_by_path[file_path] = mode
+            if mode != "120000":
+                normal_paths.append(full_path)
+    normal_blobs = create_git_blobs_from_paths(normal_paths)
+
+    worktree_paths: list[dict[str, Any]] = []
+    for file_path in unique_paths:
+        full_path = repo_root / file_path
+        index_oid = index_gitlinks.get(file_path)
+        head_oid = head_gitlinks.get(file_path)
+        if index_oid is not None or head_oid is not None:
+            worktree_paths.append(
+                _snapshot_gitlink_path(
+                    file_path,
+                    index_oid=index_oid,
+                    head_oid=head_oid,
+                )
+            )
             continue
         if full_path.is_dir() and (full_path / ".git").exists():
             worktree_paths.append(_snapshot_embedded_repo_path(file_path))
             continue
         if os.path.lexists(full_path):
-            mode = file_mode_for_path(full_path)
+            mode = modes_by_path[file_path]
             worktree_paths.append(
                 {
                     "path": file_path,
                     "exists": True,
                     "mode": mode,
-                    "blob": create_blob_from_worktree_path(
-                        full_path,
-                        mode=mode,
+                    "blob": (
+                        create_blob_from_worktree_path(full_path, mode=mode)
+                        if mode == "120000"
+                        else normal_blobs[full_path]
                     ),
                 }
             )

--- a/tests/commands/test_block_file.py
+++ b/tests/commands/test_block_file.py
@@ -231,8 +231,13 @@ class TestCommandBlockFile:
             def __exit__(self, exc_type, exc, traceback):
                 return False
 
-        def fake_undo_checkpoint(operation, *, worktree_paths=None):
-            calls.append((operation, worktree_paths))
+        def fake_undo_checkpoint(
+            operation,
+            *,
+            worktree_paths=None,
+            index_paths=None,
+        ):
+            calls.append((operation, worktree_paths, index_paths))
             return Checkpoint()
 
         (temp_git_repo / "local.txt").write_text("local content\n")
@@ -246,7 +251,7 @@ class TestCommandBlockFile:
 
         command_block_file("local.txt", local_only=True)
 
-        assert calls == [("block-file local.txt", [])]
+        assert calls == [("block-file local.txt", [], ["local.txt"])]
 
     def test_block_file_local_only_no_duplicates_in_exclude(self, temp_git_repo):
         """Test that --local-only blocking the same file twice doesn't duplicate entries."""

--- a/tests/commands/test_file_scope_actions.py
+++ b/tests/commands/test_file_scope_actions.py
@@ -135,7 +135,11 @@ def test_include_each_resolved_file_reports_aggregate_result(
 
     captured = capsys.readouterr()
     assert checkpoint_calls == [
-        ("enter", "include --files alpha.txt beta.txt", None),
+        (
+            "enter",
+            "include --files alpha.txt beta.txt",
+            ["alpha.txt", "beta.txt"],
+        ),
         ("exit",),
     ]
     assert include_calls == [
@@ -179,7 +183,11 @@ def test_skip_each_resolved_file_stops_after_empty_result(
 
     captured = capsys.readouterr()
     assert checkpoint_calls == [
-        ("enter", "skip --files alpha.txt beta.txt", None),
+        (
+            "enter",
+            "skip --files alpha.txt beta.txt",
+            ["alpha.txt", "beta.txt"],
+        ),
         ("exit",),
     ]
     assert skip_calls == [

--- a/tests/commands/test_undo.py
+++ b/tests/commands/test_undo.py
@@ -8,9 +8,17 @@ import pytest
 from git_stage_batch.commands.include import command_include_line
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.commands.undo import command_undo
-from git_stage_batch.data.undo_checkpoints import undo_checkpoint, undo_last_checkpoint
+from git_stage_batch.data.undo_checkpoints import (
+    redo_last_checkpoint,
+    undo_checkpoint,
+    undo_last_checkpoint,
+)
+from git_stage_batch.data.undo_refs import current_undo_commit
 from git_stage_batch.exceptions import CommandError
-from git_stage_batch.utils.paths import get_session_directory_path
+from git_stage_batch.utils.paths import (
+    get_batches_directory_path,
+    get_session_directory_path,
+)
 
 
 @pytest.fixture
@@ -110,6 +118,250 @@ def test_scoped_undo_ignores_unrelated_untracked_worktree_edits(temp_git_repo):
 
     assert target.read_text() == "before\n"
     assert unrelated.read_text() == "second\n"
+
+
+def test_scoped_checkpoint_does_not_retain_unrelated_content(temp_git_repo):
+    """A narrow checkpoint tree should contain only its declared worktree path."""
+    target = _commit_text_file(temp_git_repo, "target.txt", "before\n")
+    unrelated = temp_git_repo / "unrelated-secret.txt"
+    unrelated.write_text("content that must not be retained\n")
+    get_session_directory_path().mkdir(parents=True, exist_ok=True)
+
+    with undo_checkpoint("change target", worktree_paths=["target.txt"]):
+        target.write_text("after\n")
+
+    checkpoint = current_undo_commit()
+    assert checkpoint is not None
+    tree_paths = subprocess.run(
+        ["git", "ls-tree", "-r", "--name-only", checkpoint],
+        check=True,
+        cwd=temp_git_repo,
+        capture_output=True,
+        text=True,
+    ).stdout.splitlines()
+
+    assert "worktree/target.txt" in tree_paths
+    assert "worktree/unrelated-secret.txt" not in tree_paths
+
+
+def test_scoped_undo_preserves_unrelated_index_changes(temp_git_repo):
+    """Undo should restore scoped index entries without replacing the whole index."""
+    target = _commit_text_file(temp_git_repo, "target.txt", "target base\n")
+    unrelated = _commit_text_file(
+        temp_git_repo,
+        "unrelated.txt",
+        "unrelated base\n",
+    )
+    target.write_text("target staged\n")
+    get_session_directory_path().mkdir(parents=True, exist_ok=True)
+
+    with undo_checkpoint("stage target", worktree_paths=["target.txt"]):
+        subprocess.run(
+            ["git", "add", "target.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+
+    unrelated.write_text("unrelated staged later\n")
+    subprocess.run(
+        ["git", "add", "unrelated.txt"],
+        check=True,
+        cwd=temp_git_repo,
+        capture_output=True,
+    )
+
+    undo_last_checkpoint()
+
+    staged_paths = subprocess.run(
+        ["git", "diff", "--cached", "--name-only"],
+        check=True,
+        cwd=temp_git_repo,
+        capture_output=True,
+        text=True,
+    ).stdout.splitlines()
+    assert staged_paths == ["unrelated.txt"]
+    assert target.read_text() == "target staged\n"
+
+
+def test_failed_operation_keeps_partial_mutation_undoable(temp_git_repo):
+    """An operation error should finalize its checkpoint before propagating."""
+    target = _commit_text_file(temp_git_repo, "target.txt", "before\n")
+    get_session_directory_path().mkdir(parents=True, exist_ok=True)
+
+    with pytest.raises(RuntimeError, match="operation failed"):
+        with undo_checkpoint("change target", worktree_paths=["target.txt"]):
+            target.write_text("partial mutation\n")
+            raise RuntimeError("operation failed")
+
+    undo_last_checkpoint()
+
+    assert target.read_text() == "before\n"
+
+
+def test_failed_checkpoint_finalization_requires_force(temp_git_repo, monkeypatch):
+    """A manifest persistence failure should leave a guarded before-image."""
+    from git_stage_batch.data import undo_checkpoints as checkpoints
+
+    target = _commit_text_file(temp_git_repo, "target.txt", "before\n")
+    get_session_directory_path().mkdir(parents=True, exist_ok=True)
+    original_directory_state = checkpoints._filesystem_directory_state
+    calls = 0
+
+    def fail_during_finalization(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls > 2:
+            raise RuntimeError("manifest persistence failed")
+        return original_directory_state(*args, **kwargs)
+
+    monkeypatch.setattr(
+        checkpoints,
+        "_filesystem_directory_state",
+        fail_during_finalization,
+    )
+
+    with pytest.raises(RuntimeError, match="manifest persistence failed"):
+        with undo_checkpoint("change target", worktree_paths=["target.txt"]):
+            target.write_text("partial mutation\n")
+
+    with pytest.raises(CommandError, match="incomplete checkpoint"):
+        undo_last_checkpoint()
+
+    monkeypatch.setattr(
+        checkpoints,
+        "_filesystem_directory_state",
+        original_directory_state,
+    )
+    undo_last_checkpoint(force=True)
+
+    assert target.read_text() == "before\n"
+
+
+def test_scoped_undo_preserves_unrelated_batch_ref_changes(temp_git_repo):
+    """Undo should restore changed batch refs without replacing unrelated refs."""
+    target_ref = "refs/git-stage-batch/batches/target"
+    unrelated_ref = "refs/git-stage-batch/batches/unrelated"
+    head = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        check=True,
+        cwd=temp_git_repo,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    tree = subprocess.run(
+        ["git", "rev-parse", "HEAD^{tree}"],
+        check=True,
+        cwd=temp_git_repo,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    def create_commit(message):
+        return subprocess.run(
+            ["git", "commit-tree", tree, "-m", message],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+
+    target_after = create_commit("target after")
+    unrelated_after = create_commit("unrelated after")
+    subprocess.run(
+        ["git", "update-ref", target_ref, head],
+        check=True,
+        cwd=temp_git_repo,
+    )
+    subprocess.run(
+        ["git", "update-ref", unrelated_ref, head],
+        check=True,
+        cwd=temp_git_repo,
+    )
+    get_session_directory_path().mkdir(parents=True, exist_ok=True)
+
+    with undo_checkpoint("move target ref", worktree_paths=[]):
+        subprocess.run(
+            ["git", "update-ref", target_ref, target_after],
+            check=True,
+            cwd=temp_git_repo,
+        )
+
+    subprocess.run(
+        ["git", "update-ref", unrelated_ref, unrelated_after],
+        check=True,
+        cwd=temp_git_repo,
+    )
+
+    undo_last_checkpoint()
+
+    assert subprocess.run(
+        ["git", "rev-parse", target_ref],
+        check=True,
+        cwd=temp_git_repo,
+        capture_output=True,
+        text=True,
+    ).stdout.strip() == head
+    assert subprocess.run(
+        ["git", "rev-parse", unrelated_ref],
+        check=True,
+        cwd=temp_git_repo,
+        capture_output=True,
+        text=True,
+    ).stdout.strip() == unrelated_after
+
+
+def test_scoped_undo_preserves_unrelated_application_metadata(temp_git_repo):
+    """Final checkpoints should retain and restore only changed state files."""
+    session_dir = get_session_directory_path()
+    batches_dir = get_batches_directory_path()
+    session_dir.mkdir(parents=True, exist_ok=True)
+    batches_dir.mkdir(parents=True, exist_ok=True)
+    target_session = session_dir / "target-state"
+    unrelated_session = session_dir / "unrelated-state"
+    target_batch = batches_dir / "target" / "metadata.json"
+    unrelated_batch = batches_dir / "unrelated" / "metadata.json"
+    target_batch.parent.mkdir()
+    unrelated_batch.parent.mkdir()
+    target_session.write_text("before\n")
+    unrelated_session.write_text("unrelated before\n")
+    target_batch.write_text("before\n")
+    unrelated_batch.write_text("unrelated before\n")
+
+    with undo_checkpoint("change metadata", worktree_paths=[]):
+        target_session.write_text("after\n")
+        target_batch.write_text("after\n")
+
+    unrelated_session.write_text("unrelated later\n")
+    unrelated_batch.write_text("unrelated later\n")
+    checkpoint = current_undo_commit()
+    assert checkpoint is not None
+    tree_paths = subprocess.run(
+        ["git", "ls-tree", "-r", "--name-only", checkpoint],
+        check=True,
+        cwd=temp_git_repo,
+        capture_output=True,
+        text=True,
+    ).stdout.splitlines()
+
+    assert "session/target-state" in tree_paths
+    assert "batches/target/metadata.json" in tree_paths
+    assert "session/unrelated-state" not in tree_paths
+    assert "batches/unrelated/metadata.json" not in tree_paths
+
+    undo_last_checkpoint()
+
+    assert target_session.read_text() == "before\n"
+    assert target_batch.read_text() == "before\n"
+    assert unrelated_session.read_text() == "unrelated later\n"
+    assert unrelated_batch.read_text() == "unrelated later\n"
+
+    redo_last_checkpoint()
+
+    assert target_session.read_text() == "after\n"
+    assert target_batch.read_text() == "after\n"
+    assert unrelated_session.read_text() == "unrelated later\n"
+    assert unrelated_batch.read_text() == "unrelated later\n"
 
 
 def test_incomplete_checkpoint_requires_force(temp_git_repo, monkeypatch):

--- a/tests/data/test_index_entries.py
+++ b/tests/data/test_index_entries.py
@@ -4,7 +4,7 @@ import subprocess
 
 import pytest
 
-from git_stage_batch.data.index_entries import read_index_entry
+from git_stage_batch.data.index_entries import read_index_entries, read_index_entry
 
 
 @pytest.fixture
@@ -67,3 +67,18 @@ def test_does_not_treat_directory_path_as_nested_file_entry(temp_git_repo):
     subprocess.run(["git", "add", "nested/file.txt"], check=True, cwd=temp_git_repo)
 
     assert read_index_entry("nested") is None
+
+
+def test_reads_several_scoped_index_entries_in_one_lookup(temp_git_repo):
+    for path in ("one.txt", "two.txt", "unrelated.txt"):
+        (temp_git_repo / path).write_text(f"{path}\n")
+    subprocess.run(
+        ["git", "add", "one.txt", "two.txt", "unrelated.txt"],
+        check=True,
+        cwd=temp_git_repo,
+    )
+
+    entries = read_index_entries(["one.txt", "missing.txt", "two.txt"])
+
+    assert set(entries) == {"one.txt", "two.txt"}
+    assert all(entry.mode == "100644" for entry in entries.values())

--- a/tests/data/test_undo_worktree.py
+++ b/tests/data/test_undo_worktree.py
@@ -1,0 +1,89 @@
+"""Tests for scoped undo worktree capture."""
+
+from __future__ import annotations
+
+import subprocess
+
+from git_stage_batch.data import undo_worktree
+
+
+def _initialize_repository(tmp_path, monkeypatch):
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    monkeypatch.chdir(repository)
+    subprocess.run(["git", "init"], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        check=True,
+        capture_output=True,
+    )
+    return repository
+
+
+def test_regular_path_capture_uses_bulk_git_queries(tmp_path, monkeypatch):
+    """Normal files should share index, HEAD, and hash-object processes."""
+    repository = _initialize_repository(tmp_path, monkeypatch)
+    paths = ["one.txt", "two.txt", "nested/three.txt"]
+    for path in paths:
+        file_path = repository / path
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.write_text(f"{path}\n")
+    subprocess.run(["git", "add", "--", *paths], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "Add files"],
+        check=True,
+        capture_output=True,
+    )
+
+    git_calls = []
+    original_run_git_command = undo_worktree.run_git_command
+
+    def recording_run_git_command(args, **kwargs):
+        git_calls.append(tuple(args))
+        return original_run_git_command(args, **kwargs)
+
+    hash_batches = []
+    original_create_blobs = undo_worktree.create_git_blobs_from_paths
+
+    def recording_create_blobs(file_paths):
+        file_paths = tuple(file_paths)
+        hash_batches.append(file_paths)
+        return original_create_blobs(file_paths)
+
+    monkeypatch.setattr(undo_worktree, "run_git_command", recording_run_git_command)
+    monkeypatch.setattr(
+        undo_worktree,
+        "create_git_blobs_from_paths",
+        recording_create_blobs,
+    )
+
+    entries = undo_worktree.snapshot_worktree_paths(paths)
+
+    assert [entry["path"] for entry in entries] == sorted(paths)
+    assert [call[0] for call in git_calls] == ["ls-files", "ls-tree"]
+    assert len(hash_batches) == 1
+    assert set(hash_batches[0]) == {repository / path for path in paths}
+
+
+def test_scoped_capture_does_not_inspect_unrelated_dirty_paths(tmp_path, monkeypatch):
+    """Capture cost should depend on declared scope, not worktree dirtiness."""
+    repository = _initialize_repository(tmp_path, monkeypatch)
+    target = repository / "target.txt"
+    target.write_text("target\n")
+    subprocess.run(["git", "add", "target.txt"], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "Add target"],
+        check=True,
+        capture_output=True,
+    )
+    for index in range(100):
+        (repository / f"unrelated-{index}.txt").write_text("private\n")
+
+    entries = undo_worktree.snapshot_worktree_paths(["target.txt"])
+
+    assert [entry["path"] for entry in entries] == ["target.txt"]


### PR DESCRIPTION
Undo checkpoints preserve repository state before each mutating session
operation so undo and redo can restore worktree, index, batch, and session
changes safely.

The existing checkpoint path scans broad dirty state, stores the complete
index and application-state directories, and restores every batch ref. Small
operations can therefore retain unrelated content, scale with overall
worktree dirtiness, reject safe undo attempts, or overwrite later changes
outside the operation.

This pull request makes every undoable command declare its path scope, captures
ordinary files with bulk Git queries and object writes, and persists scoped
index entries. Finalized checkpoints retain only refs, session files, and batch
metadata that actually changed; undo and redo restore those deltas while
preserving unrelated dirty, staged, ref, and metadata changes.

The series adds privacy, process-scaling, failure-injection, legacy checkpoint,
unborn repository, gitlink, and scoped restoration coverage, then documents
the retention and conflict contract in project and installed manuals. The full
suite passes with 3,138 tests, and the focused architecture and recovery suite
passes with 457 tests.
