### PR TITLE
state: Batch untracked startup

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -39,6 +39,14 @@ Find and display the first unprocessed hunk; cache as "selected".
 
 Resets state if a session is already in progress.
 
+Untracked, non-ignored paths are discovered with a NUL-safe repository query
+and registered as intent-to-add entries in one bulk index update. Startup
+persists the complete auto-added path manifest once instead of rewriting it
+for every file, so work scales with the number and bytes of candidate paths.
+If a path disappears during discovery, startup refreshes the candidate set
+once. Git publishes the index through its lockfile transaction, and a failed
+bulk update rolls back the planned session manifest.
+
 Live session diffs render renames as atomic `old -> new` choices. A selected
 rename can be included, skipped, or discarded with the rest of the workflow.
 At session start, staged renames and regular text deletions are temporarily

--- a/man/git-stage-batch-start.1.in
+++ b/man/git-stage-batch-start.1.in
@@ -9,6 +9,9 @@ git-stage-batch-start \- start a hunk review session
 .B start
 finds the first unprocessed hunk, stores it as the selected change, and prints
 it for review. If a session is already active, the command starts a fresh pass.
+Untracked, non-ignored paths are registered in one NUL-safe bulk index update
+and one atomic session-manifest write. A path removed during discovery causes
+one refreshed retry; a failed index update rolls back the planned manifest.
 .SH OPTIONS
 .TP
 .BI "\-U, \-\-unified=" N

--- a/src/git_stage_batch/commands/session/iteration.py
+++ b/src/git_stage_batch/commands/session/iteration.py
@@ -13,7 +13,7 @@ from ..selection.selected_change_display import show_selected_change
 def restart_iteration_pass(*, quiet: bool = False) -> None:
     """Clear iteration state and select the first available change."""
     clear_iteration_state()
-    auto_add_untracked_files()
+    auto_add_untracked_files(show_progress=not quiet)
 
     try:
         fetch_next_change()

--- a/src/git_stage_batch/commands/start.py
+++ b/src/git_stage_batch/commands/start.py
@@ -84,7 +84,7 @@ def command_start(
 
         # Make untracked files visible to git diff so they can be staged,
         # blocked by .gitignore, or deleted.
-        auto_add_untracked_files()
+        auto_add_untracked_files(show_progress=not quiet)
 
         try:
             fetch_next_change()

--- a/src/git_stage_batch/data/file_tracking.py
+++ b/src/git_stage_batch/data/file_tracking.py
@@ -2,15 +2,20 @@
 
 from __future__ import annotations
 
+import sys
 from collections.abc import Iterable
 
-from ..utils.file_io import append_file_path_to_file, read_file_paths_file
+from ..utils.file_io import read_file_paths_file, write_file_paths_file
 from ..utils.git_command import run_git_command
 from ..git_paths import decode_path, nul_records
-from ..utils.git_index import git_add_paths
+from ..utils.git_index import git_add_paths_from_stdin
 from ..utils.git_repository import get_git_repository_root_path
 from ..utils.journal import log_journal
 from ..utils.paths import get_auto_added_files_file_path
+from ..i18n import _
+
+
+UNTRACKED_PROGRESS_THRESHOLD = 1_000
 
 
 def _embedded_git_repository_index_path(file_path: str) -> str | None:
@@ -45,7 +50,11 @@ def list_untracked_files(paths: Iterable[str] | None = None) -> list[str]:
     return [decode_path(path) for path in nul_records(result.stdout)]
 
 
-def auto_add_untracked_files(paths: Iterable[str] | None = None) -> None:
+def auto_add_untracked_files(
+    paths: Iterable[str] | None = None,
+    *,
+    show_progress: bool = False,
+) -> None:
     """Automatically run git add -N on untracked files (except blocked ones).
 
     This makes untracked files visible to git diff without staging their
@@ -57,40 +66,65 @@ def auto_add_untracked_files(paths: Iterable[str] | None = None) -> None:
         return
 
     untracked_files = list(dict.fromkeys(untracked_files))
-    # Get already auto-added files
+    index_paths = list(
+        dict.fromkeys(
+            _embedded_git_repository_index_path(file_path) or file_path
+            for file_path in untracked_files
+        )
+    )
+    if show_progress and len(index_paths) >= UNTRACKED_PROGRESS_THRESHOLD:
+        print(
+            _("Preparing {count} untracked paths for review...").format(
+                count=len(index_paths),
+            ),
+            file=sys.stderr,
+        )
     auto_added_path = get_auto_added_files_file_path()
-    auto_added_files = set(read_file_paths_file(auto_added_path))
+    recorded_paths = read_file_paths_file(auto_added_path)
+    recorded_set = set(recorded_paths)
 
-    # Add untracked files even when they were recorded earlier. A user may have
-    # removed the intent-to-add entry with git restore --staged during a session.
-    for file_path in untracked_files:
-        index_path = _embedded_git_repository_index_path(file_path) or file_path
-
-        # Get before state
-        ls_before = run_git_command(
-            ["ls-files", "--stage", "--", index_path],
+    def apply_transition(candidate_paths: list[str]):
+        new_paths = [path for path in candidate_paths if path not in recorded_set]
+        manifest_existed = auto_added_path.exists()
+        if new_paths:
+            write_file_paths_file(auto_added_path, [*recorded_paths, *new_paths])
+        result = git_add_paths_from_stdin(
+            candidate_paths,
+            intent_to_add=True,
             check=False,
-            requires_index_lock=False,
-        ).stdout.strip()
+        )
+        if result.returncode != 0:
+            if new_paths:
+                if manifest_existed:
+                    write_file_paths_file(auto_added_path, recorded_paths)
+                else:
+                    auto_added_path.unlink(missing_ok=True)
+        return result, new_paths
 
-        result = git_add_paths([index_path], intent_to_add=True, check=False)
-        if result.returncode == 0:
-            already_recorded = index_path in auto_added_files
-            if not already_recorded:
-                append_file_path_to_file(auto_added_path, index_path)
-                auto_added_files.add(index_path)
-
-            # Get after state
-            ls_after = run_git_command(
-                ["ls-files", "--stage", "--", index_path],
-                check=False,
-                requires_index_lock=False,
-            ).stdout.strip()
-            log_journal(
-                "git_add_intent_to_add",
-                file_path=index_path,
-                index_before=ls_before,
-                index_after=ls_after,
-                already_recorded=already_recorded,
-                returncode=result.returncode,
+    result, new_paths = apply_transition(index_paths)
+    if result.returncode != 0:
+        # A candidate can disappear between discovery and index update. Refresh
+        # once and retry the complete surviving transition atomically.
+        remaining_files = list_untracked_files(paths)
+        index_paths = list(
+            dict.fromkeys(
+                _embedded_git_repository_index_path(file_path) or file_path
+                for file_path in remaining_files
             )
+        )
+        result, new_paths = apply_transition(index_paths)
+    if result.returncode != 0:
+        log_journal(
+            "git_add_intent_to_add_batch_failed",
+            candidate_count=len(index_paths),
+            returncode=result.returncode,
+        )
+        return
+
+    log_journal(
+        "git_add_intent_to_add_batch",
+        candidate_count=len(index_paths),
+        newly_recorded_count=len(new_paths),
+        already_recorded_count=len(index_paths) - len(new_paths),
+        returncode=result.returncode,
+    )

--- a/src/git_stage_batch/utils/git_index.py
+++ b/src/git_stage_batch/utils/git_index.py
@@ -211,6 +211,35 @@ def git_add_paths(
     return run_git_command(arguments, check=check, requires_index_lock=True)
 
 
+def git_add_paths_from_stdin(
+    paths: Sequence[str],
+    *,
+    intent_to_add: bool = False,
+    check: bool = True,
+) -> subprocess.CompletedProcess:
+    """Add arbitrarily many NUL-delimited paths without an argv-sized list."""
+    unique_paths = list(dict.fromkeys(paths))
+    if not unique_paths:
+        return subprocess.CompletedProcess(["git", "add"], 0, "", "")
+    arguments = [
+        "--literal-pathspecs",
+        "add",
+        "--pathspec-from-file=-",
+        "--pathspec-file-nul",
+    ]
+    if intent_to_add:
+        arguments.append("--intent-to-add")
+    payload: list[bytes] = []
+    for file_path in unique_paths:
+        payload.extend((encode_path(file_path), b"\0"))
+    return run_git_command(
+        arguments,
+        stdin_chunks=payload,
+        check=check,
+        requires_index_lock=True,
+    )
+
+
 def git_reset_paths(
     paths: Sequence[str],
     *,

--- a/tests/data/test_file_tracking.py
+++ b/tests/data/test_file_tracking.py
@@ -242,6 +242,25 @@ class TestAutoAddUntrackedFiles:
         auto_added = read_file_paths_file(get_auto_added_files_file_path())
         assert "my file.txt" in auto_added
 
+    def test_auto_add_preserves_file_kinds_and_unicode_paths(self, temp_git_repo):
+        """Bulk startup should preserve empty, binary, symlink, and Unicode paths."""
+        ensure_state_directory_exists()
+        (temp_git_repo / "empty.txt").write_bytes(b"")
+        (temp_git_repo / "binary.bin").write_bytes(b"\x00\xffbinary")
+        (temp_git_repo / "unicodé.txt").write_text("accented\n")
+        (temp_git_repo / "target.txt").write_text("target\n")
+        (temp_git_repo / "link").symlink_to("target.txt")
+
+        auto_add_untracked_files()
+
+        assert set(read_file_paths_file(get_auto_added_files_file_path())) == {
+            "binary.bin",
+            "empty.txt",
+            "link",
+            "target.txt",
+            "unicodé.txt",
+        }
+
     def test_auto_add_marks_untracked_embedded_git_repository_as_gitlink(self, temp_git_repo):
         """Test that untracked embedded repositories are auto-added as gitlinks."""
         ensure_state_directory_exists()
@@ -285,3 +304,211 @@ class TestAutoAddUntrackedFiles:
             text=True,
         )
         assert f"+Subproject commit {embedded_oid}" in diff_result.stdout
+
+    def test_auto_add_process_and_state_writes_are_constant(self, temp_git_repo, monkeypatch):
+        """A large candidate set should use one add and one manifest write."""
+        from git_stage_batch.data import file_tracking
+
+        candidates = [f"generated/file-{index}.txt" for index in range(10_000)]
+        add_calls = []
+        write_calls = []
+
+        monkeypatch.setattr(
+            file_tracking,
+            "list_untracked_files",
+            lambda paths=None: candidates,
+        )
+        monkeypatch.setattr(
+            file_tracking,
+            "_embedded_git_repository_index_path",
+            lambda path: None,
+        )
+
+        def fake_add(paths, *, intent_to_add=False, check=True):
+            add_calls.append((tuple(paths), intent_to_add, check))
+            return subprocess.CompletedProcess(["git", "add"], 0, "", "")
+
+        def fake_write(path, paths):
+            write_calls.append((path, tuple(paths)))
+
+        monkeypatch.setattr(file_tracking, "git_add_paths_from_stdin", fake_add)
+        monkeypatch.setattr(file_tracking, "write_file_paths_file", fake_write)
+
+        auto_add_untracked_files()
+
+        assert len(add_calls) == 1
+        assert len(add_calls[0][0]) == 10_000
+        assert len(write_calls) == 1
+        assert len(write_calls[0][1]) == 10_000
+
+    def test_auto_add_reports_large_bulk_transition(
+        self,
+        temp_git_repo,
+        monkeypatch,
+        capsys,
+    ):
+        """Interactive startup should expose progress for a large candidate set."""
+        from git_stage_batch.data import file_tracking
+
+        candidates = [f"file-{index}.txt" for index in range(1_000)]
+        monkeypatch.setattr(
+            file_tracking,
+            "list_untracked_files",
+            lambda paths=None: candidates,
+        )
+        monkeypatch.setattr(
+            file_tracking,
+            "_embedded_git_repository_index_path",
+            lambda path: None,
+        )
+        monkeypatch.setattr(
+            file_tracking,
+            "git_add_paths_from_stdin",
+            lambda paths, **kwargs: subprocess.CompletedProcess(
+                ["git", "add"], 0, "", ""
+            ),
+        )
+        monkeypatch.setattr(file_tracking, "write_file_paths_file", lambda *args: None)
+
+        auto_add_untracked_files(show_progress=True)
+
+        assert "Preparing 1000 untracked paths for review" in capsys.readouterr().err
+
+    def test_auto_add_thousand_files_uses_one_discovery_add_and_write(
+        self,
+        temp_git_repo,
+        monkeypatch,
+    ):
+        """The real 1,000-file path should remain constant in process topology."""
+        from git_stage_batch.data import file_tracking
+
+        ensure_state_directory_exists()
+        generated = temp_git_repo / "generated"
+        generated.mkdir()
+        for index in range(1_000):
+            (generated / f"file-{index}.txt").write_text("generated\n")
+
+        discovery_calls = 0
+        add_calls = 0
+        write_calls = 0
+        original_discovery = file_tracking.run_git_command
+        original_add = file_tracking.git_add_paths_from_stdin
+        original_write = file_tracking.write_file_paths_file
+
+        def recording_discovery(*args, **kwargs):
+            nonlocal discovery_calls
+            discovery_calls += 1
+            return original_discovery(*args, **kwargs)
+
+        def recording_add(*args, **kwargs):
+            nonlocal add_calls
+            add_calls += 1
+            return original_add(*args, **kwargs)
+
+        def recording_write(*args, **kwargs):
+            nonlocal write_calls
+            write_calls += 1
+            return original_write(*args, **kwargs)
+
+        monkeypatch.setattr(file_tracking, "run_git_command", recording_discovery)
+        monkeypatch.setattr(file_tracking, "git_add_paths_from_stdin", recording_add)
+        monkeypatch.setattr(file_tracking, "write_file_paths_file", recording_write)
+
+        auto_add_untracked_files()
+
+        assert (discovery_calls, add_calls, write_calls) == (1, 1, 1)
+        assert len(read_file_paths_file(get_auto_added_files_file_path())) == 1_000
+
+    def test_auto_add_retries_paths_removed_during_scan(self, temp_git_repo, monkeypatch):
+        """A disappearing candidate should be dropped by one refreshed retry."""
+        from git_stage_batch.data import file_tracking
+
+        discoveries = iter((["gone.txt", "kept.txt"], ["kept.txt"]))
+        add_calls = []
+
+        monkeypatch.setattr(
+            file_tracking,
+            "list_untracked_files",
+            lambda paths=None: list(next(discoveries)),
+        )
+        monkeypatch.setattr(
+            file_tracking,
+            "_embedded_git_repository_index_path",
+            lambda path: None,
+        )
+
+        def fake_add(paths, *, intent_to_add=False, check=True):
+            add_calls.append(tuple(paths))
+            return subprocess.CompletedProcess(
+                ["git", "add"],
+                1 if len(add_calls) == 1 else 0,
+                "",
+                "",
+            )
+
+        monkeypatch.setattr(file_tracking, "git_add_paths_from_stdin", fake_add)
+        auto_add_untracked_files()
+
+        assert add_calls == [("gone.txt", "kept.txt"), ("kept.txt",)]
+        assert read_file_paths_file(get_auto_added_files_file_path()) == ["kept.txt"]
+
+    def test_auto_add_rolls_back_manifest_when_index_update_fails(
+        self,
+        temp_git_repo,
+        monkeypatch,
+    ):
+        """A failed initial and retry update should leave no declared transition."""
+        from git_stage_batch.data import file_tracking
+
+        (temp_git_repo / "failed.txt").write_text("content\n")
+        monkeypatch.setattr(
+            file_tracking,
+            "git_add_paths_from_stdin",
+            lambda paths, **kwargs: subprocess.CompletedProcess(
+                ["git", "add"],
+                1,
+                "",
+                "failed",
+            ),
+        )
+        auto_add_untracked_files()
+
+        assert not get_auto_added_files_file_path().exists()
+
+    def test_auto_add_does_not_touch_index_when_manifest_write_fails(
+        self,
+        temp_git_repo,
+        monkeypatch,
+    ):
+        """Manifest persistence must succeed before the bulk index transition."""
+        from git_stage_batch.data import file_tracking
+
+        (temp_git_repo / "private.txt").write_text("content\n")
+        add_calls = []
+
+        def fail_manifest_write(*args, **kwargs):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(
+            file_tracking,
+            "write_file_paths_file",
+            fail_manifest_write,
+        )
+        monkeypatch.setattr(
+            file_tracking,
+            "git_add_paths_from_stdin",
+            lambda *args, **kwargs: add_calls.append(args),
+        )
+
+        with pytest.raises(OSError, match="disk full"):
+            auto_add_untracked_files()
+
+        assert add_calls == []
+        result = subprocess.run(
+            ["git", "ls-files", "--", "private.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+            text=True,
+        )
+        assert result.stdout == ""

--- a/tests/utils/test_git_index.py
+++ b/tests/utils/test_git_index.py
@@ -7,6 +7,7 @@ import pytest
 
 from git_stage_batch.utils.git_command import run_git_command
 from git_stage_batch.utils.git_index import (
+    git_add_paths_from_stdin,
     git_commit_tree,
     git_read_tree,
     git_update_index,
@@ -121,6 +122,23 @@ class TestGitIndexPlumbing:
 
         assert result.returncode != 0
         assert run_git_command(["status", "--short"]).stdout == ""
+
+    def test_add_paths_from_stdin_preserves_nul_safe_names(self, temp_git_repo):
+        """Bulk intent-to-add should support Unicode and newline path names."""
+        paths = ["unicodé.txt", "line\nbreak.txt", ":(glob)*.txt"]
+        for path in paths:
+            (temp_git_repo / path).write_text(f"{path}\n")
+
+        git_add_paths_from_stdin(paths, intent_to_add=True)
+
+        result = run_git_command(
+            ["ls-files", "-z", "--", *paths],
+            text_output=False,
+        )
+        assert set(result.stdout.rstrip(b"\0").split(b"\0")) == {
+            path.encode("utf-8") for path in paths
+        }
+        assert run_git_command(["diff", "--cached", "--name-only"]).stdout == ""
 
     def test_batched_force_remove_uses_repository_object_width(
         self,


### PR DESCRIPTION
Session startup discovers untracked, non-ignored paths, records them as
intent-to-add entries, persists their session ownership, and begins the first
review pass.

The existing workflow runs index probes and updates for every candidate while
repeatedly appending an ever-growing manifest and journal. Repositories with
large generated or vendored trees therefore pay process and durable-write costs
proportional to every file, and a path disappearing during discovery can leave
the transition incomplete.

This pull request adds a NUL-delimited, argument-size-safe bulk index helper and
uses it to publish untracked startup through one literal-pathspec Git
transaction and one atomic manifest write. Startup retries one refreshed
candidate set after a race, rolls back its planned manifest after a failed Git
transaction, emits one aggregate diagnostic event, and reports progress for
large scans.

The series covers ignored, empty, binary, symlink, Unicode, newline,
pathspec-like, and embedded-repository paths alongside failure recovery and
constant process topology at 1,000 real files and 10,000 synthetic paths. The
full suite passes with 3,147 tests, and the focused startup and architecture
suite passes with 491 tests.
