### PR TITLE
attribution: Limit ownership analysis memory

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -89,3 +89,21 @@ Run `git-stage-batch validate` to validate every batch without changing it. The
 command checks schema compatibility, object IDs, content-ref agreement, and
 reports whether a legacy record would be migrated. Use `--porcelain` for a
 stable JSON report suitable for support tooling.
+
+## Attribution working set
+
+During hunk review, batch ownership is indexed by canonical file path for the
+current diff scan. Files without claims skip traversal across unrelated batch
+metadata. For a claimed file, source and deletion objects are requested once
+per role through bounded Git batch readers. Refspecs are resolved before
+content is loaded, so canonical state refs and legacy fallbacks that name the
+same blob share one source read and one line mapping. Deletion payloads are
+reduced to fingerprints as they stream, and normalized presence claims are
+computed once per batch/file key.
+
+Attribution processes one file and one unique source mapping at a time. It
+retains compact fingerprints and result units for the file, but releases each
+source payload and mapping before opening the next source. Traversal is sorted
+by batch name so optimization and metadata insertion order cannot alter
+ownership arbitration. Missing deletion objects and objects of the wrong Git
+type are ignored conservatively rather than hiding an unverified change.

--- a/src/git_stage_batch/batch/attribution.py
+++ b/src/git_stage_batch/batch/attribution.py
@@ -9,11 +9,13 @@ content that may not currently be visible in the working tree.
 from __future__ import annotations
 
 from collections.abc import Sequence
-from contextlib import ExitStack
 from dataclasses import dataclass
 
-from ..core.buffer import LineBuffer
-from ..utils.git_object_io import read_git_blobs_as_bytes
+from ..utils.git_object_io import (
+    GitObjectInfo,
+    resolve_git_objects,
+    stream_git_blobs,
+)
 from .line_mapping import LineMapping as _LineMapping
 from .match import match_lines
 from . import attribution_fingerprints as _attribution_fingerprints
@@ -30,6 +32,7 @@ from ..core.line_selection import parse_line_selection
 from ..utils.repository_buffers import (
     load_git_object_as_buffer_or_empty,
     load_working_tree_file_as_buffer,
+    stream_git_blob_buffers,
 )
 
 
@@ -50,6 +53,21 @@ class FileAttribution:
 
 
 @dataclass
+class AttributionMetrics:
+    """Phase counts for one bounded file attribution pass."""
+
+    candidate_batches: int = 0
+    claimed_batches: int = 0
+    object_resolution_requests: int = 0
+    object_requests: int = 0
+    object_bytes: int = 0
+    unique_source_contents: int = 0
+    mapping_computations: int = 0
+    deletion_fingerprints: int = 0
+    attributed_units: int = 0
+
+
+@dataclass
 class BatchAttributionContext:
     """Reusable source alignment for one batch/file attribution pass."""
 
@@ -57,6 +75,12 @@ class BatchAttributionContext:
     file_metadata: dict
     batch_source_lines: Sequence[bytes]
     alignment: _LineMapping
+    deletion_fingerprints: dict[
+        str,
+        _attribution_fingerprints.ContentFingerprint,
+    ]
+    presence_source_lines: tuple[int, ...]
+    presence_source_line_set: frozenset[int]
 
 
 @dataclass(frozen=True)
@@ -65,6 +89,16 @@ class _BatchSourceRequest:
     file_metadata: dict
     primary_refspec: str
     fallback_refspec: str
+
+
+@dataclass(frozen=True)
+class _ResolvedBatchSourceRequest:
+    """One batch claim grouped by its canonical source blob identity."""
+
+    batch_name: str
+    file_metadata: dict
+    source_object_id: str | None
+    presence_source_lines: tuple[int, ...]
 
 
 def _parse_presence_source_lines(file_metadata: dict) -> list[int]:
@@ -85,8 +119,7 @@ def _parse_presence_source_lines(file_metadata: dict) -> list[int]:
 
 def _has_presence_source_lines(file_metadata: dict) -> bool:
     return bool(
-        file_metadata.get("presence_claims")
-        or file_metadata.get("claimed_lines")
+        file_metadata.get("presence_claims") or file_metadata.get("claimed_lines")
     )
 
 
@@ -95,11 +128,14 @@ def build_file_attribution(
     *,
     batch_metadata_by_name: dict[str, dict] | None = None,
     supplemental_batch_metadata: dict[str, dict] | None = None,
+    metrics: AttributionMetrics | None = None,
 ) -> FileAttribution:
     """Build complete ownership attribution for a file."""
     all_batch_metadata = {}
     if batch_metadata_by_name is None:
         batch_metadata_by_name = read_batch_metadata_for_batches(list_batch_names())
+    if metrics is not None:
+        metrics.candidate_batches = len(batch_metadata_by_name)
 
     for batch_name, metadata in batch_metadata_by_name.items():
         if file_path in metadata.get("files", {}):
@@ -107,80 +143,227 @@ def build_file_attribution(
 
     if supplemental_batch_metadata:
         all_batch_metadata.update(supplemental_batch_metadata)
+    if metrics is not None:
+        metrics.claimed_batches = len(all_batch_metadata)
 
     baseline_buffer = load_git_object_as_buffer_or_empty(f"HEAD:{file_path}")
     working_tree_buffer = load_working_tree_file_as_buffer(file_path)
     with baseline_buffer as baseline_lines, working_tree_buffer as working_tree_lines:
-        with ExitStack() as batch_context_stack:
-            batch_contexts = _open_batch_attribution_contexts(
-                file_path,
-                all_batch_metadata,
-                working_tree_lines=working_tree_lines,
-                stack=batch_context_stack,
+        all_units_map: dict[str, _AttributionUnit] = {}
+        with _build_file_comparison_from_lines(
+            file_path,
+            baseline_lines=baseline_lines,
+            working_tree_lines=working_tree_lines,
+        ) as comparison:
+            _enumerate_units_from_file_comparison(comparison, all_units_map)
+
+        baseline_unit_ids = tuple(all_units_map)
+        owners_by_unit_id = {unit_id: set() for unit_id in baseline_unit_ids}
+        _attribute_batches(
+            file_path,
+            all_batch_metadata,
+            working_tree_lines=working_tree_lines,
+            all_units_map=all_units_map,
+            baseline_unit_ids=baseline_unit_ids,
+            owners_by_unit_id=owners_by_unit_id,
+            metrics=metrics,
+        )
+
+        attributed_units = [
+            AttributedUnit(
+                unit=unit,
+                owning_batches=owners_by_unit_id[unit_id],
             )
-
-            all_units_map: dict[str, _AttributionUnit] = {}
-            with _build_file_comparison_from_lines(
-                file_path,
-                baseline_lines=baseline_lines,
-                working_tree_lines=working_tree_lines,
-            ) as comparison:
-                _enumerate_units_from_file_comparison(comparison, all_units_map)
-
-            if batch_contexts:
-                _enumerate_units_from_batches(
-                    file_path,
-                    batch_contexts,
-                    all_units_map,
-                )
-
-            attributed_units = [
-                AttributedUnit(
-                    unit=unit,
-                    owning_batches=_find_owning_batches(unit, batch_contexts),
-                )
-                for unit in all_units_map.values()
-            ]
+            for unit_id, unit in all_units_map.items()
+        ]
+        if metrics is not None:
+            metrics.attributed_units = len(attributed_units)
 
     return FileAttribution(file_path=file_path, units=attributed_units)
 
 
-def _open_batch_attribution_contexts(
+def _attribute_batches(
     file_path: str,
     all_batch_metadata: dict,
     *,
     working_tree_lines: Sequence[bytes],
-    stack: ExitStack,
-) -> list[BatchAttributionContext]:
-    """Open reusable batch source buffers and alignments for one file."""
-    contexts: list[BatchAttributionContext] = []
+    all_units_map: dict[str, _AttributionUnit],
+    baseline_unit_ids: Sequence[str],
+    owners_by_unit_id: dict[str, set[str]],
+    metrics: AttributionMetrics | None = None,
+) -> None:
+    """Attribute claims while retaining one source alignment at a time."""
     source_requests = _batch_source_requests(file_path, all_batch_metadata)
-    source_blobs = read_git_blobs_as_bytes(_source_refspecs(source_requests))
+    deletion_blob_ids = _deletion_blob_ids(source_requests)
+    object_names = list(
+        dict.fromkeys(
+            [
+                *_source_refspecs(source_requests),
+                *deletion_blob_ids,
+            ]
+        )
+    )
+    object_infos = resolve_git_objects(object_names)
+    resolved_requests = _resolve_batch_source_requests(
+        source_requests,
+        object_infos,
+    )
+    deletion_fingerprints, deletion_object_ids, deletion_bytes = (
+        _read_deletion_fingerprints(deletion_blob_ids, object_infos)
+    )
+    source_groups: dict[str | None, list[_ResolvedBatchSourceRequest]] = {}
+    for request in resolved_requests:
+        source_groups.setdefault(request.source_object_id, []).append(request)
+    source_object_ids = [
+        object_id for object_id in source_groups if object_id is not None
+    ]
 
-    for request in source_requests:
-        file_metadata = request.file_metadata
-        source_blob = source_blobs.get(request.primary_refspec)
-        if source_blob is None:
-            source_blob = source_blobs.get(request.fallback_refspec, b"")
-        batch_source_lines = stack.enter_context(
-            LineBuffer.from_chunks([source_blob])
-        )
-        alignment = stack.enter_context(
-            match_lines(
-                source_lines=batch_source_lines,
-                target_lines=working_tree_lines,
+    if metrics is not None:
+        metrics.object_resolution_requests = len(object_names)
+        metrics.object_requests = len(deletion_object_ids) + len(source_object_ids)
+        metrics.object_bytes = deletion_bytes
+        metrics.deletion_fingerprints = len(deletion_fingerprints)
+        metrics.unique_source_contents = len(source_groups)
+        metrics.mapping_computations = len(source_groups)
+
+    if source_object_ids:
+        for source_blob in stream_git_blob_buffers(source_object_ids):
+            if metrics is not None:
+                metrics.object_bytes += source_blob.size
+            _attribute_source_group(
+                file_path,
+                source_groups[source_blob.object_id],
+                source_lines=source_blob.buffer,
+                working_tree_lines=working_tree_lines,
+                deletion_fingerprints=deletion_fingerprints,
+                all_units_map=all_units_map,
+                baseline_unit_ids=baseline_unit_ids,
+                owners_by_unit_id=owners_by_unit_id,
             )
+
+    empty_source_group = source_groups.get(None)
+    if empty_source_group:
+        _attribute_source_group(
+            file_path,
+            empty_source_group,
+            source_lines=(),
+            working_tree_lines=working_tree_lines,
+            deletion_fingerprints=deletion_fingerprints,
+            all_units_map=all_units_map,
+            baseline_unit_ids=baseline_unit_ids,
+            owners_by_unit_id=owners_by_unit_id,
         )
-        contexts.append(
-            BatchAttributionContext(
+
+
+def _resolve_batch_source_requests(
+    requests: Sequence[_BatchSourceRequest],
+    object_infos: dict[str, GitObjectInfo],
+) -> list[_ResolvedBatchSourceRequest]:
+    """Resolve primary/fallback expressions to canonical source blob IDs."""
+    resolved = []
+    for request in requests:
+        source_info = object_infos.get(request.primary_refspec)
+        if source_info is None or source_info.object_type != "blob":
+            source_info = object_infos.get(request.fallback_refspec)
+        source_object_id = (
+            source_info.object_id
+            if source_info is not None
+            and source_info.object_type == "blob"
+            and source_info.size > 0
+            else None
+        )
+        resolved.append(
+            _ResolvedBatchSourceRequest(
                 batch_name=request.batch_name,
-                file_metadata=file_metadata,
-                batch_source_lines=batch_source_lines,
-                alignment=alignment,
+                file_metadata=request.file_metadata,
+                source_object_id=source_object_id,
+                presence_source_lines=tuple(
+                    _parse_presence_source_lines(request.file_metadata)
+                ),
             )
         )
+    return resolved
 
-    return contexts
+
+def _read_deletion_fingerprints(
+    deletion_blob_ids: Sequence[str],
+    object_infos: dict[str, GitObjectInfo],
+) -> tuple[
+    dict[str, _attribution_fingerprints.ContentFingerprint],
+    list[str],
+    int,
+]:
+    """Stream deletion blobs and retain only canonical fingerprints."""
+    object_id_by_request = {
+        blob_id: info.object_id
+        for blob_id in deletion_blob_ids
+        if (info := object_infos.get(blob_id)) is not None
+        and info.object_type == "blob"
+    }
+    unique_object_ids = list(dict.fromkeys(object_id_by_request.values()))
+    fingerprints_by_object_id = {}
+    byte_count = 0
+    if unique_object_ids:
+        for blob in stream_git_blobs(unique_object_ids):
+            byte_count += blob.size
+            fingerprints_by_object_id[blob.object_id] = (
+                _attribution_fingerprints.fingerprint_chunks(blob.content_chunks)
+            )
+    return (
+        {
+            request: fingerprints_by_object_id[object_id]
+            for request, object_id in object_id_by_request.items()
+            if object_id in fingerprints_by_object_id
+        },
+        unique_object_ids,
+        byte_count,
+    )
+
+
+def _attribute_source_group(
+    file_path: str,
+    requests: Sequence[_ResolvedBatchSourceRequest],
+    *,
+    source_lines: Sequence[bytes],
+    working_tree_lines: Sequence[bytes],
+    deletion_fingerprints: dict[
+        str,
+        _attribution_fingerprints.ContentFingerprint,
+    ],
+    all_units_map: dict[str, _AttributionUnit],
+    baseline_unit_ids: Sequence[str],
+    owners_by_unit_id: dict[str, set[str]],
+) -> None:
+    """Attribute every batch sharing one source/target mapping."""
+    with match_lines(
+        source_lines=source_lines,
+        target_lines=working_tree_lines,
+    ) as alignment:
+        for request in requests:
+            context = BatchAttributionContext(
+                batch_name=request.batch_name,
+                file_metadata=request.file_metadata,
+                batch_source_lines=source_lines,
+                alignment=alignment,
+                deletion_fingerprints=deletion_fingerprints,
+                presence_source_lines=request.presence_source_lines,
+                presence_source_line_set=frozenset(request.presence_source_lines),
+            )
+            generated_unit_ids = _enumerate_units_from_batch(
+                file_path,
+                context,
+                all_units_map,
+            )
+            candidate_unit_ids = dict.fromkeys(
+                [
+                    *baseline_unit_ids,
+                    *generated_unit_ids,
+                ]
+            )
+            for unit_id in candidate_unit_ids:
+                owners_by_unit_id.setdefault(unit_id, set())
+                if _batch_owns_unit(all_units_map[unit_id], context):
+                    owners_by_unit_id[unit_id].add(request.batch_name)
 
 
 def _batch_source_requests(
@@ -188,7 +371,8 @@ def _batch_source_requests(
     all_batch_metadata: dict,
 ) -> list[_BatchSourceRequest]:
     requests: list[_BatchSourceRequest] = []
-    for batch_name, batch_metadata in all_batch_metadata.items():
+    for batch_name in sorted(all_batch_metadata):
+        batch_metadata = all_batch_metadata[batch_name]
         file_metadata = batch_metadata["files"][file_path]
         fallback_refspec = f"{file_metadata['batch_source_commit']}:{file_path}"
         source_path = file_metadata.get("source_path")
@@ -217,121 +401,112 @@ def _source_refspecs(source_requests: Sequence[_BatchSourceRequest]) -> list[str
     return refspecs
 
 
-def _enumerate_units_from_batches(
-    file_path: str,
-    batch_contexts: Sequence[BatchAttributionContext],
-    units_map: dict[str, _AttributionUnit],
-) -> None:
-    """Add batch-owned units that may not be visible in the working tree."""
-    for batch_context in batch_contexts:
-        file_metadata = batch_context.file_metadata
-        batch_source_lines = batch_context.batch_source_lines
-        alignment = batch_context.alignment
+def _deletion_blob_ids(
+    source_requests: Sequence[_BatchSourceRequest],
+) -> list[str]:
+    """Return unique deletion blobs required by one file attribution pass."""
+    blob_ids: list[str] = []
+    for request in source_requests:
+        for deletion in request.file_metadata.get("deletions", []):
+            blob_id = deletion.get("blob")
+            if isinstance(blob_id, str) and blob_id:
+                blob_ids.append(blob_id)
+    return list(dict.fromkeys(blob_ids))
 
-        if len(batch_source_lines) == 0 and _has_presence_source_lines(file_metadata):
+
+def _enumerate_units_from_batch(
+    file_path: str,
+    batch_context: BatchAttributionContext,
+    units_map: dict[str, _AttributionUnit],
+) -> list[str]:
+    """Add units claimed by one batch and return their semantic IDs."""
+    file_metadata = batch_context.file_metadata
+    batch_source_lines = batch_context.batch_source_lines
+    alignment = batch_context.alignment
+    generated_unit_ids: list[str] = []
+
+    if len(batch_source_lines) == 0 and _has_presence_source_lines(file_metadata):
+        return generated_unit_ids
+
+    for source_line in batch_context.presence_source_lines:
+        if source_line < 1 or source_line > len(batch_source_lines):
             continue
 
-        for source_line in _parse_presence_source_lines(file_metadata):
-            if source_line < 1 or source_line > len(batch_source_lines):
-                continue
-
-            claimed_content = batch_source_lines[source_line - 1]
-            working_tree_line = alignment.get_target_line_from_source_line(source_line)
-            unit = _AttributionUnit(
-                unit_id=_make_attribution_unit_id(
-                    _AttributionUnitKind.PRESENCE_ONLY,
-                    file_path,
-                    claimed_line=working_tree_line,
-                    claimed_content=claimed_content,
-                ),
-                kind=_AttributionUnitKind.PRESENCE_ONLY,
-                file_path=file_path,
-                claimed_line_in_working_tree=working_tree_line,
+        claimed_content = batch_source_lines[source_line - 1]
+        working_tree_line = alignment.get_target_line_from_source_line(source_line)
+        unit = _AttributionUnit(
+            unit_id=_make_attribution_unit_id(
+                _AttributionUnitKind.PRESENCE_ONLY,
+                file_path,
+                claimed_line=working_tree_line,
                 claimed_content=claimed_content,
-                deletion_anchor_in_working_tree=None,
-                deletion_content=None,
-            )
-            units_map.setdefault(unit.unit_id, unit)
+            ),
+            kind=_AttributionUnitKind.PRESENCE_ONLY,
+            file_path=file_path,
+            claimed_line_in_working_tree=working_tree_line,
+            claimed_content=claimed_content,
+            deletion_anchor_in_working_tree=None,
+            deletion_content=None,
+        )
+        units_map.setdefault(unit.unit_id, unit)
+        generated_unit_ids.append(unit.unit_id)
 
-        for deletion_entry in file_metadata.get("deletions", []):
-            blob_hash = deletion_entry.get("blob")
-            if not blob_hash:
-                continue
+    for deletion_entry in file_metadata.get("deletions", []):
+        blob_hash = deletion_entry.get("blob")
+        if not blob_hash:
+            continue
 
-            deletion_fingerprint = _attribution_fingerprints.fingerprint_git_blob(
-                blob_hash
-            )
-            if deletion_fingerprint is None:
-                continue
+        deletion_fingerprint = batch_context.deletion_fingerprints.get(blob_hash)
+        if deletion_fingerprint is None:
+            continue
 
-            after_source_line = deletion_entry.get("after_source_line")
-            deletion_anchor = (
-                None
-                if after_source_line is None
-                else alignment.get_target_line_from_source_line(after_source_line)
-            )
+        after_source_line = deletion_entry.get("after_source_line")
+        deletion_anchor = (
+            None
+            if after_source_line is None
+            else alignment.get_target_line_from_source_line(after_source_line)
+        )
 
-            unit = _AttributionUnit(
-                unit_id=_make_attribution_unit_id(
-                    _AttributionUnitKind.DELETION_ONLY,
-                    file_path,
-                    deletion_anchor=deletion_anchor,
-                    deletion_fingerprint=deletion_fingerprint,
-                ),
-                kind=_AttributionUnitKind.DELETION_ONLY,
-                file_path=file_path,
-                claimed_line_in_working_tree=None,
-                claimed_content=None,
-                deletion_anchor_in_working_tree=deletion_anchor,
-                deletion_content=None,
+        unit = _AttributionUnit(
+            unit_id=_make_attribution_unit_id(
+                _AttributionUnitKind.DELETION_ONLY,
+                file_path,
+                deletion_anchor=deletion_anchor,
                 deletion_fingerprint=deletion_fingerprint,
-            )
-            units_map.setdefault(unit.unit_id, unit)
+            ),
+            kind=_AttributionUnitKind.DELETION_ONLY,
+            file_path=file_path,
+            claimed_line_in_working_tree=None,
+            claimed_content=None,
+            deletion_anchor_in_working_tree=deletion_anchor,
+            deletion_content=None,
+            deletion_fingerprint=deletion_fingerprint,
+        )
+        units_map.setdefault(unit.unit_id, unit)
+        generated_unit_ids.append(unit.unit_id)
+
+    return generated_unit_ids
 
 
-def _find_owning_batches(
+def _batch_owns_unit(
     unit: _AttributionUnit,
-    batch_contexts: Sequence[BatchAttributionContext],
-) -> set[str]:
-    """Determine which batches own a given unit."""
-    owning_batches: set[str] = set()
-
-    for batch_context in batch_contexts:
-        file_metadata = batch_context.file_metadata
-        alignment = batch_context.alignment
-        batch_source_lines = batch_context.batch_source_lines
-
-        if unit.kind == _AttributionUnitKind.PRESENCE_ONLY:
-            if _batch_owns_presence_unit(
-                unit,
-                file_metadata,
-                alignment,
-                batch_source_lines,
-            ):
-                owning_batches.add(batch_context.batch_name)
-        elif unit.kind == _AttributionUnitKind.DELETION_ONLY:
-            if _batch_owns_deletion_unit(unit, file_metadata, alignment):
-                owning_batches.add(batch_context.batch_name)
-        elif unit.kind == _AttributionUnitKind.REPLACEMENT:
-            if (
-                _batch_owns_presence_unit(
-                    unit,
-                    file_metadata,
-                    alignment,
-                    batch_source_lines,
-                )
-                and _batch_owns_deletion_unit(unit, file_metadata, alignment)
-            ):
-                owning_batches.add(batch_context.batch_name)
-
-    return owning_batches
+    batch_context: BatchAttributionContext,
+) -> bool:
+    """Return whether one batch context owns one attribution unit."""
+    if unit.kind == _AttributionUnitKind.PRESENCE_ONLY:
+        return _batch_owns_presence_unit(unit, batch_context)
+    if unit.kind == _AttributionUnitKind.DELETION_ONLY:
+        return _batch_owns_deletion_unit(unit, batch_context)
+    if unit.kind == _AttributionUnitKind.REPLACEMENT:
+        return _batch_owns_presence_unit(
+            unit, batch_context
+        ) and _batch_owns_deletion_unit(unit, batch_context)
+    return False
 
 
 def _batch_owns_presence_unit(
     unit: _AttributionUnit,
-    file_metadata: dict,
-    alignment,
-    batch_source_lines: Sequence[bytes],
+    batch_context: BatchAttributionContext,
 ) -> bool:
     """Check whether a batch owns the presence side of a unit.
 
@@ -342,10 +517,12 @@ def _batch_owns_presence_unit(
     if unit.claimed_content is None and unit.claimed_fingerprint is None:
         return False
 
-    claimed_source_lines = _parse_presence_source_lines(file_metadata)
+    claimed_source_lines = batch_context.presence_source_lines
     if not claimed_source_lines:
         return False
-    claimed_source_line_set = set(claimed_source_lines)
+    claimed_source_line_set = batch_context.presence_source_line_set
+    alignment = batch_context.alignment
+    batch_source_lines = batch_context.batch_source_lines
 
     if unit.claimed_line_in_working_tree is not None:
         mapped_source_line = alignment.get_source_line_from_target_line(
@@ -421,13 +598,14 @@ def _batch_owns_presence_unit(
 
 def _batch_owns_deletion_unit(
     unit: _AttributionUnit,
-    file_metadata: dict,
-    alignment,
+    batch_context: BatchAttributionContext,
 ) -> bool:
     """Check whether a batch owns a deletion unit via explicit absence claims."""
     if unit.deletion_content is None and unit.deletion_fingerprint is None:
         return False
 
+    file_metadata = batch_context.file_metadata
+    alignment = batch_context.alignment
     for deletion_entry in file_metadata.get("deletions", []):
         blob_hash = deletion_entry.get("blob")
         if not blob_hash:
@@ -438,22 +616,15 @@ def _batch_owns_deletion_unit(
             if unit.deletion_anchor_in_working_tree is not None:
                 continue
         else:
-            mapped_anchor = alignment.get_target_line_from_source_line(after_source_line)
+            mapped_anchor = alignment.get_target_line_from_source_line(
+                after_source_line
+            )
             if mapped_anchor != unit.deletion_anchor_in_working_tree:
                 continue
 
         if (
-            unit.deletion_content is not None
-            and _attribution_fingerprints.blob_matches_content(
-                blob_hash,
-                unit.deletion_content,
-            )
-        ):
-            return True
-
-        if (
             unit.deletion_fingerprint is not None
-            and _attribution_fingerprints.fingerprint_git_blob(blob_hash)
+            and batch_context.deletion_fingerprints.get(blob_hash)
             == unit.deletion_fingerprint
         ):
             return True

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -56,6 +56,7 @@ class _BatchMetadataSnapshot:
 
     def __init__(self) -> None:
         self._metadata_by_name: dict[str, dict] | None = None
+        self._metadata_by_path: dict[str, dict[str, dict]] | None = None
 
     def metadata_by_name(self) -> dict[str, dict]:
         if self._metadata_by_name is None:
@@ -63,6 +64,16 @@ class _BatchMetadataSnapshot:
                 list_batch_names()
             )
         return self._metadata_by_name
+
+    def metadata_for_path(self, file_path: str) -> dict[str, dict]:
+        """Return only batches with metadata for one canonical path."""
+        if self._metadata_by_path is None:
+            metadata_by_path: dict[str, dict[str, dict]] = {}
+            for batch_name, metadata in self.metadata_by_name().items():
+                for path in metadata.get("files", {}):
+                    metadata_by_path.setdefault(path, {})[batch_name] = metadata
+            self._metadata_by_path = metadata_by_path
+        return self._metadata_by_path.get(file_path, {})
 
 
 def fetch_next_change() -> Union[LineLevelChange, BinaryFileChange, FileModeChange, GitlinkChange, RenameChange, TextFileDeletionChange]:
@@ -122,7 +133,7 @@ def fetch_next_change() -> Union[LineLevelChange, BinaryFileChange, FileModeChan
                         or _change_freshness.text_deletion_change_is_batched(
                             item,
                             batch_metadata_by_name=(
-                                batch_metadata_snapshot.metadata_by_name()
+                                batch_metadata_snapshot.metadata_for_path(item.path())
                             ),
                         )
                     ):
@@ -191,7 +202,7 @@ def fetch_next_change() -> Union[LineLevelChange, BinaryFileChange, FileModeChan
                 if (
                     _selected_hunk_filtering.apply_line_level_batch_filter_to_cached_hunk(
                         batch_metadata_by_name=(
-                            batch_metadata_snapshot.metadata_by_name()
+                            batch_metadata_snapshot.metadata_for_path(line_changes.path)
                         ),
                     )
                 ):

--- a/src/git_stage_batch/data/selected_change/hunk_filtering.py
+++ b/src/git_stage_batch/data/selected_change/hunk_filtering.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import json
+from dataclasses import asdict
 
-from ...batch.attribution import build_file_attribution
+from ...batch.attribution import AttributionMetrics, build_file_attribution
 from ...batch.attribution_projection import filter_owned_diff_fragments
 from ...utils.file_io import write_text_file_contents
+from ...utils.journal import log_journal
 from ...utils.paths import get_line_changes_json_file_path
 from .. import change_freshness as _change_freshness
 from .. import consumed_replacement_masks as _consumed_replacement_masks
@@ -43,10 +45,17 @@ def apply_line_level_batch_filter_to_cached_hunk(
     ):
         return True
 
+    attribution_metrics = AttributionMetrics()
     attribution = build_file_attribution(
         file_path,
         batch_metadata_by_name=batch_metadata_by_name,
         supplemental_batch_metadata=_consumed_batch_metadata(file_path),
+        metrics=attribution_metrics,
+    )
+    log_journal(
+        "file_attribution_complete",
+        file_path=file_path,
+        **asdict(attribution_metrics),
     )
     should_skip, filtered_line_changes = filter_owned_diff_fragments(
         line_changes, attribution
@@ -55,8 +64,10 @@ def apply_line_level_batch_filter_to_cached_hunk(
     if should_skip:
         return True
 
-    filtered_line_changes = _consumed_replacement_masks.filter_consumed_replacement_masks(
-        filtered_line_changes
+    filtered_line_changes = (
+        _consumed_replacement_masks.filter_consumed_replacement_masks(
+            filtered_line_changes
+        )
     )
     if filtered_line_changes is None:
         return True

--- a/src/git_stage_batch/utils/git_command.py
+++ b/src/git_stage_batch/utils/git_command.py
@@ -44,8 +44,7 @@ def _index_lock_error_text(stream: str | bytes | None) -> str:
 def _is_git_index_lock_error(result: subprocess.CompletedProcess) -> bool:
     stderr_text = _index_lock_error_text(result.stderr).lower()
     return "index.lock" in stderr_text and (
-        "file exists" in stderr_text
-        or "unable to create" in stderr_text
+        "file exists" in stderr_text or "unable to create" in stderr_text
     )
 
 
@@ -91,34 +90,47 @@ def stream_git_command(
     Raises:
         subprocess.CalledProcessError: If git command fails (includes stderr)
     """
-    def stdout_chunks():
-        """Generator that yields only stdout chunks from command events."""
-        nonlocal exit_code, stderr_chunks
-        for event in stream_command(
-            ["git", *arguments],
+
+    yield from bytes_to_lines(
+        stream_git_command_bytes(
+            arguments,
             stdin_chunks,
             cwd=cwd,
-            env=_prepare_git_command_environment(
-                requires_index_lock=requires_index_lock,
-                cwd=cwd,
-                env=env,
-            ),
-        ):
-            if isinstance(event, command_events.ExitEvent):
-                exit_code = event.exit_code
-            elif isinstance(event, command_events.OutputEvent):
-                if event.fd == 1:  # stdout
-                    yield event.data
-                elif event.fd == 2:  # stderr
-                    stderr_chunks.append(event.data)
+            env=env,
+            requires_index_lock=requires_index_lock,
+        )
+    )
 
+
+def stream_git_command_bytes(
+    arguments: list[str],
+    stdin_chunks: Iterable[bytes] | None = None,
+    *,
+    cwd: str | None = None,
+    env: dict[str, str] | None = None,
+    requires_index_lock: bool = True,
+) -> Iterator[bytes]:
+    """Stream raw Git stdout chunks without line-oriented buffering."""
     exit_code = 0
     stderr_chunks = []
+    for event in stream_command(
+        ["git", *arguments],
+        stdin_chunks,
+        cwd=cwd,
+        env=_prepare_git_command_environment(
+            requires_index_lock=requires_index_lock,
+            cwd=cwd,
+            env=env,
+        ),
+    ):
+        if isinstance(event, command_events.ExitEvent):
+            exit_code = event.exit_code
+        elif isinstance(event, command_events.OutputEvent):
+            if event.fd == 1:
+                yield event.data
+            elif event.fd == 2:
+                stderr_chunks.append(event.data)
 
-    # Convert binary stdout chunks to text lines
-    yield from bytes_to_lines(stdout_chunks())
-
-    # Check exit code after stream completes
     if exit_code != 0:
         stderr_text = b"".join(stderr_chunks).decode("utf-8", errors="replace")
         raise subprocess.CalledProcessError(

--- a/src/git_stage_batch/utils/git_object_io.py
+++ b/src/git_stage_batch/utils/git_object_io.py
@@ -7,7 +7,11 @@ from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from pathlib import Path
 
-from .git_command import run_git_command, stream_git_command
+from .git_command import (
+    run_git_command,
+    stream_git_command,
+    stream_git_command_bytes,
+)
 from ..git_paths import decode_path, nul_records
 
 
@@ -50,6 +54,73 @@ class GitTreeBlob:
     blob_sha: str
 
 
+@dataclass(frozen=True)
+class GitObjectInfo:
+    """Resolved identity and storage metadata for one Git object request."""
+
+    object_id: str
+    object_type: str
+    size: int
+
+
+@dataclass(frozen=True)
+class GitBlobStream:
+    """One blob response whose content must be consumed before the next."""
+
+    requested_name: str
+    object_id: str
+    size: int
+    content_chunks: Iterator[bytes]
+
+
+class _GitBatchOutputReader:
+    """Read headers and payloads from Git's batch object protocol."""
+
+    def __init__(self, chunks: Iterable[bytes]) -> None:
+        self._chunks = iter(chunks)
+        self._pending = bytearray()
+
+    def read_line(self) -> bytes:
+        """Read one newline-terminated protocol line without its delimiter."""
+        while True:
+            line_end = self._pending.find(b"\n")
+            if line_end >= 0:
+                line = bytes(self._pending[:line_end])
+                del self._pending[: line_end + 1]
+                return line
+            self._extend()
+
+    def read_exactly(self, size: int) -> bytes:
+        """Read exactly ``size`` bytes from the protocol stream."""
+        return b"".join(self.read_chunks(size))
+
+    def read_chunks(self, size: int) -> Iterator[bytes]:
+        """Yield exactly ``size`` payload bytes in bounded chunks."""
+        remaining = size
+        while remaining:
+            if not self._pending:
+                self._extend()
+            chunk_size = min(remaining, len(self._pending))
+            yield bytes(self._pending[:chunk_size])
+            del self._pending[:chunk_size]
+            remaining -= chunk_size
+
+    def finish(self) -> None:
+        """Require the protocol stream to end without trailing bytes."""
+        for chunk in self._chunks:
+            self._pending.extend(chunk)
+        if self._pending:
+            raise RuntimeError("Unexpected trailing git cat-file --batch output")
+
+    def _extend(self) -> None:
+        try:
+            self._pending.extend(next(self._chunks))
+        except StopIteration as error:
+            raise RuntimeError(
+                "Unexpected end of git cat-file --batch output"
+            ) from error
+
+
 def create_git_blob(content_chunks: Iterable[bytes]) -> str:
     """Create a git blob object from streaming content.
 
@@ -72,8 +143,7 @@ def create_git_blob(content_chunks: Iterable[bytes]) -> str:
             stdout_chunks.append(line)
     except subprocess.CalledProcessError as error:
         raise RuntimeError(
-            f"git hash-object failed with exit code {error.returncode}: "
-            f"{error.stderr}"
+            f"git hash-object failed with exit code {error.returncode}: {error.stderr}"
         ) from error
 
     if not stdout_chunks:
@@ -93,7 +163,7 @@ def create_git_blobs_from_paths(paths: Iterable[Path]) -> dict[Path, str]:
     blob_shas: dict[Path, str] = {}
     chunk_size = 512
     for offset in range(0, len(unique_paths), chunk_size):
-        chunk = unique_paths[offset:offset + chunk_size]
+        chunk = unique_paths[offset : offset + chunk_size]
         try:
             result = run_git_command(
                 [
@@ -112,14 +182,10 @@ def create_git_blobs_from_paths(paths: Iterable[Path]) -> dict[Path, str]:
             ) from error
 
         chunk_shas = [
-            line.strip()
-            for line in result.stdout.splitlines()
-            if line.strip()
+            line.strip() for line in result.stdout.splitlines() if line.strip()
         ]
         if len(chunk_shas) != len(chunk):
-            raise RuntimeError(
-                "git hash-object produced an unexpected number of blobs"
-            )
+            raise RuntimeError("git hash-object produced an unexpected number of blobs")
         blob_shas.update(zip(chunk, chunk_shas, strict=True))
 
     return blob_shas
@@ -148,48 +214,125 @@ def read_git_blob(blob_sha: str) -> Iterator[bytes]:
         ) from error
 
 
-def read_git_blobs_as_bytes(blob_hashes: Iterable[str]) -> dict[str, bytes]:
-    """Read multiple git blobs with one cat-file process."""
+def resolve_git_objects(object_names: Iterable[str]) -> dict[str, GitObjectInfo]:
+    """Resolve object expressions without loading their contents."""
+    unique_object_names = list(dict.fromkeys(object_names))
+    if not unique_object_names:
+        return {}
+
+    payload = (
+        f"{object_name}\n".encode("utf-8") for object_name in unique_object_names
+    )
+    result = run_git_command(
+        ["cat-file", "--batch-check"],
+        stdin_chunks=payload,
+        text_output=False,
+        requires_index_lock=False,
+    )
+    headers = result.stdout.splitlines()
+    if len(headers) != len(unique_object_names):
+        raise RuntimeError(
+            "git cat-file --batch-check returned an unexpected response count"
+        )
+
+    resolved: dict[str, GitObjectInfo] = {}
+    for requested_name, header_bytes in zip(
+        unique_object_names,
+        headers,
+        strict=True,
+    ):
+        header = header_bytes.decode("ascii", errors="replace")
+        parts = header.split()
+        if len(parts) >= 2 and parts[-1] == "missing":
+            continue
+        if len(parts) != 3:
+            raise RuntimeError(
+                f"Unexpected git cat-file --batch-check header: {header}"
+            )
+        object_id, object_type, size_text = parts
+        resolved[requested_name] = GitObjectInfo(
+            object_id=object_id,
+            object_type=object_type,
+            size=int(size_text),
+        )
+    return resolved
+
+
+def stream_git_blobs(
+    blob_names: Iterable[str],
+    *,
+    ignore_non_blobs: bool = False,
+) -> Iterator[GitBlobStream]:
+    """Yield blob payload streams from one Git process.
+
+    Each ``content_chunks`` iterator is valid until the outer iterator advances.
+    Advancing drains any unread content so the batch protocol remains aligned.
+    """
+    unique_blob_names = list(dict.fromkeys(blob_names))
+    if not unique_blob_names:
+        return
+
+    payload = (f"{blob_name}\n".encode("utf-8") for blob_name in unique_blob_names)
+    reader = _GitBatchOutputReader(
+        stream_git_command_bytes(
+            ["cat-file", "--batch"],
+            payload,
+            requires_index_lock=False,
+        )
+    )
+    for requested_name in unique_blob_names:
+        header = reader.read_line().decode("ascii", errors="replace")
+        parts = header.split()
+        if len(parts) >= 2 and parts[-1] == "missing":
+            continue
+        if len(parts) < 3:
+            raise RuntimeError(f"Unexpected git cat-file --batch header: {header}")
+
+        object_id, object_type, size_text = parts[:3]
+        size = int(size_text)
+        content_chunks = reader.read_chunks(size)
+        if object_type == "blob":
+            yield GitBlobStream(
+                requested_name=requested_name,
+                object_id=object_id,
+                size=size,
+                content_chunks=content_chunks,
+            )
+        elif not ignore_non_blobs:
+            raise RuntimeError(f"Unexpected git cat-file --batch header: {header}")
+
+        for _chunk in content_chunks:
+            pass
+        if reader.read_exactly(1) != b"\n":
+            raise RuntimeError("Unexpected git cat-file --batch object delimiter")
+    reader.finish()
+
+
+def read_git_blobs_as_bytes(
+    blob_hashes: Iterable[str],
+    *,
+    ignore_non_blobs: bool = False,
+) -> dict[str, bytes]:
+    """Read multiple Git blobs with one cat-file process."""
     unique_blob_hashes = list(dict.fromkeys(blob_hashes))
     if not unique_blob_hashes:
         return {}
 
-    payload = "".join(f"{blob_hash}\n" for blob_hash in unique_blob_hashes).encode(
-        "utf-8"
-    )
-    result = run_git_command(
-        ["cat-file", "--batch"],
-        stdin_chunks=[payload],
-        text_output=False,
-        requires_index_lock=False,
-    )
-
-    data = result.stdout
     blobs: dict[str, bytes] = {}
-    offset = 0
-    for requested_hash in unique_blob_hashes:
-        header_end = data.index(b"\n", offset)
-        header = data[offset:header_end].decode("ascii", errors="replace")
-        offset = header_end + 1
-        parts = header.split()
-        if len(parts) >= 2 and parts[1] == "missing":
-            continue
-        if len(parts) < 3 or parts[1] != "blob":
-            raise RuntimeError(f"Unexpected git cat-file --batch header: {header}")
-
-        object_hash = parts[0]
-        size = int(parts[2])
-        content = data[offset:offset + size]
-        offset += size
-        if offset < len(data) and data[offset:offset + 1] == b"\n":
-            offset += 1
-        blobs[requested_hash] = content
-        blobs[object_hash] = content
+    for blob in stream_git_blobs(
+        unique_blob_hashes,
+        ignore_non_blobs=ignore_non_blobs,
+    ):
+        content = b"".join(blob.content_chunks)
+        blobs[blob.requested_name] = content
+        blobs[blob.object_id] = content
 
     return blobs
 
 
-def list_git_tree_blobs(treeish: str, file_paths: Iterable[str]) -> dict[str, GitTreeBlob]:
+def list_git_tree_blobs(
+    treeish: str, file_paths: Iterable[str]
+) -> dict[str, GitTreeBlob]:
     """List blob entries for paths in one tree with one ls-tree process."""
     unique_file_paths = list(dict.fromkeys(file_paths))
     if not unique_file_paths:

--- a/src/git_stage_batch/utils/repository_buffers.py
+++ b/src/git_stage_batch/utils/repository_buffers.py
@@ -4,17 +4,47 @@ from __future__ import annotations
 
 import os
 import subprocess
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass
 
 from ..core.buffer import LineBuffer
 from ..utils.git_command import stream_git_command
 from ..utils.git_repository import get_git_repository_root_path
-from ..utils.git_object_io import list_git_tree_blobs, read_git_blob
+from ..utils.git_object_io import (
+    list_git_tree_blobs,
+    read_git_blob,
+    stream_git_blobs,
+)
+
+
+@dataclass(frozen=True)
+class GitBlobBuffer:
+    """One streamed Git blob exposed as a bounded line buffer."""
+
+    requested_name: str
+    object_id: str
+    size: int
+    buffer: LineBuffer
 
 
 def load_git_blob_as_buffer(blob_sha: str) -> LineBuffer:
     """Load a Git blob as a line buffer."""
     return LineBuffer.from_chunks(read_git_blob(blob_sha))
+
+
+def stream_git_blob_buffers(blob_names: Iterable[str]) -> Iterator[GitBlobBuffer]:
+    """Yield one mmap-capable line buffer at a time from a Git batch reader."""
+    for blob in stream_git_blobs(blob_names):
+        buffer = LineBuffer.from_chunks(blob.content_chunks)
+        try:
+            yield GitBlobBuffer(
+                requested_name=blob.requested_name,
+                object_id=blob.object_id,
+                size=blob.size,
+                buffer=buffer,
+            )
+        finally:
+            buffer.close()
 
 
 def load_git_tree_files_as_buffers(

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -2689,11 +2689,15 @@ def test_git_object_io_stays_out_of_git_command_module():
         fromlist=["git_object_io"],
     )
     public_names = {
+        "GitBlobStream",
+        "GitObjectInfo",
         "GitTreeBlob",
         "create_git_blob",
         "create_git_blobs_from_paths",
+        "resolve_git_objects",
         "read_git_blob",
         "read_git_blobs_as_bytes",
+        "stream_git_blobs",
         "list_git_tree_blobs",
     }
     violations = []

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -2266,6 +2266,7 @@ def test_repository_buffer_helpers_stay_in_utils_layer():
         "load_git_object_as_buffer_or_empty",
         "load_git_tree_files_as_buffers",
         "load_working_tree_file_as_buffer",
+        "stream_git_blob_buffers",
     }
     violations = []
 

--- a/tests/batch/test_ownership_hardening.py
+++ b/tests/batch/test_ownership_hardening.py
@@ -8,6 +8,7 @@ import pytest
 import git_stage_batch.batch.attribution as attribution_module
 import git_stage_batch.batch.attribution_units as attribution_units_module
 from git_stage_batch.batch.attribution import (
+    AttributionMetrics,
     AttributedUnit,
     FileAttribution,
     build_file_attribution,
@@ -19,6 +20,7 @@ from git_stage_batch.batch.attribution_units import (
 )
 from git_stage_batch.batch.attribution_projection import project_attribution_to_diff
 from git_stage_batch.batch.match import match_lines
+from git_stage_batch.batch.state_refs import get_batch_state_ref_name
 from git_stage_batch.core.diff_parser import (
     build_line_changes_from_patch_lines,
 )
@@ -35,14 +37,21 @@ def temp_repo(tmp_path, monkeypatch):
 
     monkeypatch.chdir(tmp_path)
     subprocess.run(["git", "init"], check=True, capture_output=True)
-    subprocess.run(["git", "config", "user.name", "Test"], check=True, capture_output=True)
-    subprocess.run(["git", "config", "user.email", "test@example.com"], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.name", "Test"], check=True, capture_output=True
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        check=True,
+        capture_output=True,
+    )
 
     return tmp_path
 
 
 def _create_batch_source_commit(repo, path: str, content: str) -> str:
     file_path = repo / path
+    file_path.parent.mkdir(parents=True, exist_ok=True)
     file_path.write_text(content)
     subprocess.run(["git", "add", path], check=True, cwd=repo, capture_output=True)
     tree = subprocess.run(
@@ -66,6 +75,20 @@ def _create_batch_source_commit(repo, path: str, content: str) -> str:
         capture_output=True,
     )
     return commit
+
+
+def _point_batch_state_refs(batch_names, state_commit: str) -> None:
+    updates = "".join(
+        f"update {get_batch_state_ref_name(batch_name)} {state_commit}\n"
+        for batch_name in batch_names
+    )
+    subprocess.run(
+        ["git", "update-ref", "--stdin"],
+        input=updates,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
 
 
 def _enumerate_units_from_head_and_working_tree(file_path: str):
@@ -112,18 +135,22 @@ def test_file_comparison_accepts_non_list_line_sequences(line_sequence):
 
 def test_multi_line_replacement_addition_uses_digest_for_projection(line_sequence):
     """Attribution can project replacements whose added side is not retained."""
-    baseline_lines = line_sequence([
-        b"line1\n",
-        b"old1\n",
-        b"old2\n",
-        b"line4\n",
-    ])
-    working_tree_lines = line_sequence([
-        b"line1\n",
-        b"new1\n",
-        b"new2\n",
-        b"line4\n",
-    ])
+    baseline_lines = line_sequence(
+        [
+            b"line1\n",
+            b"old1\n",
+            b"old2\n",
+            b"line4\n",
+        ]
+    )
+    working_tree_lines = line_sequence(
+        [
+            b"line1\n",
+            b"new1\n",
+            b"new2\n",
+            b"line4\n",
+        ]
+    )
     comparison = FileComparison(
         file_path="test.txt",
         baseline_lines=baseline_lines,
@@ -170,10 +197,7 @@ def test_multi_line_replacement_addition_uses_digest_for_projection(line_sequenc
 
     display_to_unit = project_attribution_to_diff(attribution, line_changes)
 
-    assert {
-        line_changes.lines[index].id
-        for index in display_to_unit
-    } == {1, 2, 3, 4}
+    assert {line_changes.lines[index].id for index in display_to_unit} == {1, 2, 3, 4}
 
 
 def test_legacy_claimed_lines_metadata_owns_presence_units(temp_repo, monkeypatch):
@@ -223,9 +247,7 @@ def test_legacy_claimed_lines_metadata_owns_presence_units(temp_repo, monkeypatc
 def test_build_file_attribution_reuses_batch_alignment_per_file(temp_repo, monkeypatch):
     """Batch source alignment should be built once per file, not once per unit."""
     test_file = temp_repo / "test.txt"
-    test_file.write_text(
-        "keep0\nold1\nkeep1\nold2\nkeep2\nold3\nkeep3\n"
-    )
+    test_file.write_text("keep0\nold1\nkeep1\nold2\nkeep2\nold3\nkeep3\n")
     subprocess.run(["git", "add", "test.txt"], check=True, capture_output=True)
     subprocess.run(["git", "commit", "-m", "baseline"], check=True, capture_output=True)
 
@@ -266,11 +288,25 @@ def test_build_file_attribution_reuses_batch_alignment_per_file(temp_repo, monke
         "match_lines",
         counting_match_lines,
     )
+    original_parse_presence = attribution_module._parse_presence_source_lines
+    presence_parse_count = 0
+
+    def counting_parse_presence(file_metadata):
+        nonlocal presence_parse_count
+        presence_parse_count += 1
+        return original_parse_presence(file_metadata)
+
+    monkeypatch.setattr(
+        attribution_module,
+        "_parse_presence_source_lines",
+        counting_parse_presence,
+    )
 
     attribution = build_file_attribution("test.txt")
 
     assert len(attribution.units) >= 3
     assert match_call_count == 2
+    assert presence_parse_count == 1
 
 
 def test_build_file_attribution_bulk_loads_batch_source_buffers(
@@ -323,29 +359,327 @@ def test_build_file_attribution_bulk_loads_batch_source_buffers(
             },
         },
     )
-    calls = []
-    original_read_git_blobs_as_bytes = attribution_module.read_git_blobs_as_bytes
+    resolution_calls = []
+    buffer_stream_calls = []
+    original_resolve = attribution_module.resolve_git_objects
+    original_buffer_stream = attribution_module.stream_git_blob_buffers
 
-    def counting_read_git_blobs_as_bytes(refspecs):
+    def counting_resolve(refspecs):
         refspecs = tuple(refspecs)
-        calls.append(refspecs)
-        return original_read_git_blobs_as_bytes(refspecs)
+        resolution_calls.append(refspecs)
+        return original_resolve(refspecs)
+
+    def counting_buffer_stream(object_ids):
+        object_ids = tuple(object_ids)
+        buffer_stream_calls.append(object_ids)
+        yield from original_buffer_stream(object_ids)
 
     monkeypatch.setattr(
         attribution_module,
-        "read_git_blobs_as_bytes",
-        counting_read_git_blobs_as_bytes,
+        "resolve_git_objects",
+        counting_resolve,
+    )
+    monkeypatch.setattr(
+        attribution_module, "stream_git_blob_buffers", counting_buffer_stream
     )
 
     attribution = build_file_attribution("test.txt")
 
     assert attribution.units
-    assert calls == [
+    assert resolution_calls == [
         (
             f"{first_source_commit}:test.txt",
             f"{second_source_commit}:test.txt",
         )
     ]
+    first_blob = subprocess.run(
+        ["git", "rev-parse", f"{first_source_commit}:test.txt"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    second_blob = subprocess.run(
+        ["git", "rev-parse", f"{second_source_commit}:test.txt"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    assert buffer_stream_calls == [(first_blob, second_blob)]
+
+
+def test_build_file_attribution_deduplicates_sources_deletions_and_mappings(
+    temp_repo,
+    monkeypatch,
+):
+    """Shared source and deletion objects should be read and computed once."""
+    test_file = temp_repo / "test.txt"
+    test_file.write_text("base\n")
+    subprocess.run(["git", "add", "test.txt"], check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "baseline"], check=True, capture_output=True)
+    source_commit = _create_batch_source_commit(temp_repo, "test.txt", "base\n")
+    state_commit = _create_batch_source_commit(
+        temp_repo,
+        "sources/test.txt",
+        "base\n",
+    )
+    _point_batch_state_refs(("first", "second"), state_commit)
+    deletion_blob = (
+        subprocess.run(
+            ["git", "hash-object", "-w", "--stdin"],
+            input=b"deleted\n",
+            check=True,
+            capture_output=True,
+        )
+        .stdout.decode("ascii")
+        .strip()
+    )
+    file_metadata = {
+        "batch_source_commit": source_commit,
+        "source_path": "sources/test.txt",
+        "presence_claims": [],
+        "deletions": [{"blob": deletion_blob, "after_source_line": 1}],
+    }
+    metadata = {
+        name: {"files": {"test.txt": file_metadata}} for name in ("first", "second")
+    }
+    resolution_calls = []
+    deletion_stream_calls = []
+    buffer_stream_calls = []
+    original_resolve = attribution_module.resolve_git_objects
+    original_deletion_stream = attribution_module.stream_git_blobs
+    original_buffer_stream = attribution_module.stream_git_blob_buffers
+
+    def recording_resolve(object_names):
+        object_names = tuple(object_names)
+        resolution_calls.append(object_names)
+        return original_resolve(object_names)
+
+    def recording_deletion_stream(object_ids, **kwargs):
+        object_ids = tuple(object_ids)
+        deletion_stream_calls.append(object_ids)
+        yield from original_deletion_stream(object_ids, **kwargs)
+
+    def recording_buffer_stream(object_ids):
+        object_ids = tuple(object_ids)
+        buffer_stream_calls.append(object_ids)
+        yield from original_buffer_stream(object_ids)
+
+    match_calls = 0
+    original_match = attribution_module.match_lines
+
+    def recording_match(*args, **kwargs):
+        nonlocal match_calls
+        match_calls += 1
+        return original_match(*args, **kwargs)
+
+    fingerprint_calls = 0
+    original_fingerprint = (
+        attribution_module._attribution_fingerprints.fingerprint_chunks
+    )
+
+    def recording_fingerprint(chunks):
+        nonlocal fingerprint_calls
+        fingerprint_calls += 1
+        return original_fingerprint(chunks)
+
+    monkeypatch.setattr(attribution_module, "resolve_git_objects", recording_resolve)
+    monkeypatch.setattr(
+        attribution_module, "stream_git_blobs", recording_deletion_stream
+    )
+    monkeypatch.setattr(
+        attribution_module, "stream_git_blob_buffers", recording_buffer_stream
+    )
+    monkeypatch.setattr(attribution_module, "match_lines", recording_match)
+    monkeypatch.setattr(
+        attribution_module._attribution_fingerprints,
+        "fingerprint_chunks",
+        recording_fingerprint,
+    )
+
+    metrics = AttributionMetrics()
+    attribution = build_file_attribution(
+        "test.txt",
+        batch_metadata_by_name=metadata,
+        metrics=metrics,
+    )
+
+    assert resolution_calls == [
+        (
+            f"{get_batch_state_ref_name('first')}:sources/test.txt",
+            f"{source_commit}:test.txt",
+            f"{get_batch_state_ref_name('second')}:sources/test.txt",
+            deletion_blob,
+        ),
+    ]
+    source_blob = subprocess.run(
+        ["git", "rev-parse", f"{source_commit}:test.txt"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    assert deletion_stream_calls == [(deletion_blob,)]
+    assert buffer_stream_calls == [(source_blob,)]
+    assert match_calls == 1
+    assert fingerprint_calls == 1
+    deletion_units = [
+        unit
+        for unit in attribution.units
+        if unit.unit.kind == AttributionUnitKind.DELETION_ONLY
+    ]
+    assert len(deletion_units) == 1
+    assert deletion_units[0].owning_batches == {"first", "second"}
+    assert metrics.candidate_batches == 2
+    assert metrics.claimed_batches == 2
+    assert metrics.object_resolution_requests == 4
+    assert metrics.object_requests == 2
+    assert metrics.unique_source_contents == 1
+    assert metrics.mapping_computations == 1
+    assert metrics.deletion_fingerprints == 1
+
+
+def test_build_file_attribution_is_independent_of_batch_traversal_order(temp_repo):
+    """Reordering batch metadata must not change units or ownership arbitration."""
+    test_file = temp_repo / "test.txt"
+    test_file.write_text("base\n")
+    subprocess.run(["git", "add", "test.txt"], check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "baseline"], check=True, capture_output=True)
+    first_source = _create_batch_source_commit(
+        temp_repo,
+        "test.txt",
+        "base\nfirst\n",
+    )
+    second_source = _create_batch_source_commit(
+        temp_repo,
+        "test.txt",
+        "base\nsecond\n",
+    )
+
+    def metadata(source):
+        return {
+            "files": {
+                "test.txt": {
+                    "batch_source_commit": source,
+                    "presence_claims": [{"source_lines": ["2"]}],
+                    "deletions": [],
+                }
+            }
+        }
+
+    first_order = {
+        "first": metadata(first_source),
+        "second": metadata(second_source),
+    }
+    second_order = dict(reversed(list(first_order.items())))
+
+    def snapshot(batch_metadata):
+        attribution = build_file_attribution(
+            "test.txt",
+            batch_metadata_by_name=batch_metadata,
+        )
+        return [
+            (attributed.unit.unit_id, sorted(attributed.owning_batches))
+            for attributed in attribution.units
+        ]
+
+    assert snapshot(first_order) == snapshot(second_order)
+
+
+def test_build_file_attribution_bounds_mapping_work_as_batches_grow(
+    temp_repo,
+    monkeypatch,
+):
+    """Shared content should keep object and mapping work constant at 1,000 batches."""
+    test_file = temp_repo / "test.txt"
+    test_file.write_text("base\n")
+    subprocess.run(["git", "add", "test.txt"], check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "baseline"], check=True, capture_output=True)
+    source_commit = _create_batch_source_commit(temp_repo, "test.txt", "base\n")
+    batch_names = tuple(f"batch-{index:04d}" for index in range(1_000))
+    metadata = {
+        batch_name: {
+            "files": {
+                "test.txt": {
+                    "batch_source_commit": source_commit,
+                    "source_path": "sources/test.txt",
+                    "presence_claims": [{"source_lines": ["1"]}],
+                    "deletions": [],
+                }
+            }
+        }
+        for batch_name in batch_names
+    }
+    fallback_refspec = f"{source_commit}:test.txt"
+    source_info = attribution_module.resolve_git_objects([fallback_refspec])[
+        fallback_refspec
+    ]
+    resolution_calls = []
+
+    def resolve_shared_state_sources(object_names):
+        object_names = tuple(object_names)
+        resolution_calls.append(object_names)
+        return {object_name: source_info for object_name in object_names}
+
+    monkeypatch.setattr(
+        attribution_module,
+        "resolve_git_objects",
+        resolve_shared_state_sources,
+    )
+    metrics = AttributionMetrics()
+
+    attribution = build_file_attribution(
+        "test.txt",
+        batch_metadata_by_name=metadata,
+        metrics=metrics,
+    )
+
+    assert metrics.claimed_batches == 1_000
+    assert metrics.object_resolution_requests == 1_001
+    assert metrics.object_requests == 1
+    assert metrics.unique_source_contents == 1
+    assert metrics.mapping_computations == 1
+    assert len(attribution.units) == 1
+    assert len(attribution.units[0].owning_batches) == 1_000
+    assert len(resolution_calls) == 1
+    assert len(resolution_calls[0]) == 1_001
+
+
+def test_build_file_attribution_ignores_missing_deletion_objects(temp_repo):
+    """Malformed deletion object references should remain conservative and visible."""
+    test_file = temp_repo / "test.txt"
+    test_file.write_text("base\n")
+    subprocess.run(["git", "add", "test.txt"], check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "baseline"], check=True, capture_output=True)
+    source_commit = _create_batch_source_commit(temp_repo, "test.txt", "base\n")
+    metadata = {
+        "broken": {
+            "files": {
+                "test.txt": {
+                    "batch_source_commit": source_commit,
+                    "presence_claims": [],
+                    "deletions": [
+                        {
+                            "blob": "0" * 40,
+                            "after_source_line": 1,
+                        },
+                        {
+                            "blob": "HEAD",
+                            "after_source_line": 1,
+                        },
+                    ],
+                }
+            }
+        }
+    }
+
+    attribution = build_file_attribution(
+        "test.txt",
+        batch_metadata_by_name=metadata,
+    )
+
+    assert all(
+        unit.unit.kind != AttributionUnitKind.DELETION_ONLY
+        for unit in attribution.units
+    )
 
 
 class TestPresenceGranularity:
@@ -358,7 +692,9 @@ class TestPresenceGranularity:
         test_file.write_text("line1\n")
 
         subprocess.run(["git", "add", "test.txt"], check=True, capture_output=True)
-        subprocess.run(["git", "commit", "-m", "baseline"], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "baseline"], check=True, capture_output=True
+        )
 
         # Add three consecutive lines
         test_file.write_text("line1\nline2\nline3\nline4\n")
@@ -367,14 +703,16 @@ class TestPresenceGranularity:
         units_map = _enumerate_units_from_head_and_working_tree("test.txt")
 
         # Should have THREE separate PRESENCE_ONLY units (lines 2, 3, 4)
-        presence_units = [u for u in units_map.values() if u.kind == AttributionUnitKind.PRESENCE_ONLY]
+        presence_units = [
+            u for u in units_map.values() if u.kind == AttributionUnitKind.PRESENCE_ONLY
+        ]
         assert len(presence_units) == 3, "Should have 3 separate PRESENCE_ONLY units"
 
         # Each should be a single line
         for unit in presence_units:
             assert unit.claimed_content is not None
             # Single line should not contain multiple newlines
-            assert unit.claimed_content.count(b'\n') <= 1
+            assert unit.claimed_content.count(b"\n") <= 1
 
     def test_only_individually_owned_lines_hidden(self, temp_repo):
         """Only individually owned added lines should be hidden, not grouped."""
@@ -384,17 +722,23 @@ class TestPresenceGranularity:
         test_file.write_text("original\n")
 
         subprocess.run(["git", "add", "test.txt"], check=True, capture_output=True)
-        subprocess.run(["git", "commit", "-m", "baseline"], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "baseline"], check=True, capture_output=True
+        )
 
         test_file.write_text("original\nadd1\nadd2\nadd3\n")
 
         units_map = _enumerate_units_from_head_and_working_tree("test.txt")
 
-        presence_units = [u for u in units_map.values() if u.kind == AttributionUnitKind.PRESENCE_ONLY]
+        presence_units = [
+            u for u in units_map.values() if u.kind == AttributionUnitKind.PRESENCE_ONLY
+        ]
 
         # Verify each has distinct line number
         line_numbers = [u.claimed_line_in_working_tree for u in presence_units]
-        assert len(line_numbers) == len(set(line_numbers)), "Each unit should have unique line number"
+        assert len(line_numbers) == len(set(line_numbers)), (
+            "Each unit should have unique line number"
+        )
 
 
 class TestReplacementPairing:
@@ -406,7 +750,9 @@ class TestReplacementPairing:
         test_file.write_text("line1\ndel1\nline2\ndel2\nline3\n")
 
         subprocess.run(["git", "add", "test.txt"], check=True, capture_output=True)
-        subprocess.run(["git", "commit", "-m", "baseline"], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "baseline"], check=True, capture_output=True
+        )
 
         # Replace both deletion targets
         test_file.write_text("line1\nadd1\nline2\nadd2\nline3\n")
@@ -414,8 +760,12 @@ class TestReplacementPairing:
         units_map = _enumerate_units_from_head_and_working_tree("test.txt")
 
         # Should have exactly 2 REPLACEMENT units
-        replacement_units = [u for u in units_map.values() if u.kind == AttributionUnitKind.REPLACEMENT]
-        assert len(replacement_units) == 2, f"Should have 2 replacements, got {len(replacement_units)}"
+        replacement_units = [
+            u for u in units_map.values() if u.kind == AttributionUnitKind.REPLACEMENT
+        ]
+        assert len(replacement_units) == 2, (
+            f"Should have 2 replacements, got {len(replacement_units)}"
+        )
 
         # Verify they have distinct anchors
         anchors = [u.deletion_anchor_in_working_tree for u in replacement_units]
@@ -427,7 +777,9 @@ class TestReplacementPairing:
         test_file.write_text("del1\ndel2\nkeep\n")
 
         subprocess.run(["git", "add", "test.txt"], check=True, capture_output=True)
-        subprocess.run(["git", "commit", "-m", "baseline"], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "baseline"], check=True, capture_output=True
+        )
 
         # One addition where two deletions were
         test_file.write_text("add\nkeep\n")
@@ -435,8 +787,12 @@ class TestReplacementPairing:
         units_map = _enumerate_units_from_head_and_working_tree("test.txt")
 
         # Should have at most 1 REPLACEMENT (one-to-one pairing)
-        replacement_units = [u for u in units_map.values() if u.kind == AttributionUnitKind.REPLACEMENT]
-        assert len(replacement_units) <= 1, "Addition run cannot be reused for multiple replacements"
+        replacement_units = [
+            u for u in units_map.values() if u.kind == AttributionUnitKind.REPLACEMENT
+        ]
+        assert len(replacement_units) <= 1, (
+            "Addition run cannot be reused for multiple replacements"
+        )
 
     def test_pairing_stable_regardless_of_order(self, temp_repo):
         """Replacement pairing should be stable regardless of iteration order."""
@@ -446,7 +802,9 @@ class TestReplacementPairing:
         test_file.write_text("line1\ndel1\nline2\ndel2\nline3\n")
 
         subprocess.run(["git", "add", "test.txt"], check=True, capture_output=True)
-        subprocess.run(["git", "commit", "-m", "baseline"], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "baseline"], check=True, capture_output=True
+        )
 
         test_file.write_text("line1\nadd1\nline2\nadd2\nline3\n")
 
@@ -456,15 +814,24 @@ class TestReplacementPairing:
             units_map = _enumerate_units_from_head_and_working_tree("test.txt")
 
             replacement_units = sorted(
-                [u for u in units_map.values() if u.kind == AttributionUnitKind.REPLACEMENT],
-                key=lambda u: (u.claimed_line_in_working_tree, u.deletion_anchor_in_working_tree)
+                [
+                    u
+                    for u in units_map.values()
+                    if u.kind == AttributionUnitKind.REPLACEMENT
+                ],
+                key=lambda u: (
+                    u.claimed_line_in_working_tree,
+                    u.deletion_anchor_in_working_tree,
+                ),
             )
             results.append(replacement_units)
 
         # All runs should produce identical results
         assert len(results[0]) == len(results[1]) == len(results[2])
         for i in range(len(results[0])):
-            assert results[0][i].unit_id == results[1][i].unit_id == results[2][i].unit_id
+            assert (
+                results[0][i].unit_id == results[1][i].unit_id == results[2][i].unit_id
+            )
 
 
 class TestAnchorSemantics:
@@ -477,14 +844,18 @@ class TestAnchorSemantics:
         test_file.write_text("header\nkeep1\nkeep2\ntarget\n")
 
         subprocess.run(["git", "add", "test.txt"], check=True, capture_output=True)
-        subprocess.run(["git", "commit", "-m", "baseline"], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "baseline"], check=True, capture_output=True
+        )
 
         # Delete target line
         test_file.write_text("header\nkeep1\nkeep2\n")
 
         units_map = _enumerate_units_from_head_and_working_tree("test.txt")
 
-        deletion_units = [u for u in units_map.values() if u.kind == AttributionUnitKind.DELETION_ONLY]
+        deletion_units = [
+            u for u in units_map.values() if u.kind == AttributionUnitKind.DELETION_ONLY
+        ]
         assert len(deletion_units) == 1
 
         # Anchor should be last matched line (keep2 at line 3), not arithmetic line-1
@@ -496,16 +867,22 @@ class TestAnchorSemantics:
         test_file.write_text("delete_me\nkeep\n")
 
         subprocess.run(["git", "add", "test.txt"], check=True, capture_output=True)
-        subprocess.run(["git", "commit", "-m", "baseline"], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "baseline"], check=True, capture_output=True
+        )
 
         # Delete first line
         test_file.write_text("keep\n")
 
         units_map = _enumerate_units_from_head_and_working_tree("test.txt")
 
-        deletion_units = [u for u in units_map.values() if u.kind == AttributionUnitKind.DELETION_ONLY]
+        deletion_units = [
+            u for u in units_map.values() if u.kind == AttributionUnitKind.DELETION_ONLY
+        ]
         assert len(deletion_units) == 1
-        assert deletion_units[0].deletion_anchor_in_working_tree is None, "Start-of-file anchor should be None"
+        assert deletion_units[0].deletion_anchor_in_working_tree is None, (
+            "Start-of-file anchor should be None"
+        )
 
 
 class TestPresenceOwnershipIdentity:
@@ -519,14 +896,18 @@ class TestPresenceOwnershipIdentity:
         test_file.write_text("same\nother\nsame\n")
 
         subprocess.run(["git", "add", "test.txt"], check=True, capture_output=True)
-        subprocess.run(["git", "commit", "-m", "baseline"], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "baseline"], check=True, capture_output=True
+        )
 
         # Add another "same" line
         test_file.write_text("same\nother\nsame\nsame\n")
 
         units_map = _enumerate_units_from_head_and_working_tree("test.txt")
 
-        presence_units = [u for u in units_map.values() if u.kind == AttributionUnitKind.PRESENCE_ONLY]
+        presence_units = [
+            u for u in units_map.values() if u.kind == AttributionUnitKind.PRESENCE_ONLY
+        ]
 
         # Even though content is identical, should have distinct line numbers
         assert len(presence_units) == 1  # Only one added line
@@ -542,7 +923,9 @@ class TestReplacementProjection:
         test_file.write_text("line1\nold\nline3\n")
 
         subprocess.run(["git", "add", "test.txt"], check=True, capture_output=True)
-        subprocess.run(["git", "commit", "-m", "baseline"], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "baseline"], check=True, capture_output=True
+        )
 
         test_file.write_text("line1\nnew\nline3\n")
 
@@ -550,21 +933,23 @@ class TestReplacementProjection:
         attribution = build_file_attribution("test.txt")
 
         # Should have explicit REPLACEMENT unit
-        replacement_units = [u.unit for u in attribution.units if u.unit.kind == AttributionUnitKind.REPLACEMENT]
+        replacement_units = [
+            u.unit
+            for u in attribution.units
+            if u.unit.kind == AttributionUnitKind.REPLACEMENT
+        ]
         assert len(replacement_units) >= 1, "Should have at least one REPLACEMENT unit"
 
         # Get diff for projection
         subprocess.run(
-            ["git", "diff", "HEAD", "test.txt"],
-            capture_output=True,
-            check=True
+            ["git", "diff", "HEAD", "test.txt"], capture_output=True, check=True
         )
 
         # Parse diff
 
-        patches = list(collect_unified_diff(
-            stream_git_command(["diff", "HEAD", "test.txt"])
-        ))
+        patches = list(
+            collect_unified_diff(stream_git_command(["diff", "HEAD", "test.txt"]))
+        )
         assert len(patches) >= 1
 
         line_changes = build_line_changes_from_patch_lines(patches[0].lines)
@@ -590,7 +975,9 @@ class TestAnchorConsistency:
         test_file.write_text("context1\ncontext2\nold\ncontext3\ncontext4\n")
 
         subprocess.run(["git", "add", "test.txt"], check=True, capture_output=True)
-        subprocess.run(["git", "commit", "-m", "baseline"], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "baseline"], check=True, capture_output=True
+        )
 
         # Replace middle line
         test_file.write_text("context1\ncontext2\nnew\ncontext3\ncontext4\n")
@@ -600,9 +987,13 @@ class TestAnchorConsistency:
 
         # Get diff with different context settings
         for context_lines in [0, 3, 10]:
-            patches = list(collect_unified_diff(
-                stream_git_command(["diff", f"-U{context_lines}", "HEAD", "test.txt"])
-            ))
+            patches = list(
+                collect_unified_diff(
+                    stream_git_command(
+                        ["diff", f"-U{context_lines}", "HEAD", "test.txt"]
+                    )
+                )
+            )
             if not patches:
                 continue
 
@@ -616,7 +1007,9 @@ class TestAnchorConsistency:
                 u.unit.kind == AttributionUnitKind.REPLACEMENT
                 for u in display_to_unit.values()
             )
-            assert replacement_found, f"REPLACEMENT should be found with -U{context_lines}"
+            assert replacement_found, (
+                f"REPLACEMENT should be found with -U{context_lines}"
+            )
 
     def test_deletion_projection_independent_of_nearby_context(self, temp_repo):
         """Deletion projection should not depend on specific nearby context lines."""
@@ -624,7 +1017,9 @@ class TestAnchorConsistency:
         test_file.write_text("keep1\nkeep2\ndelete_me\nkeep3\nkeep4\n")
 
         subprocess.run(["git", "add", "test.txt"], check=True, capture_output=True)
-        subprocess.run(["git", "commit", "-m", "baseline"], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "baseline"], check=True, capture_output=True
+        )
 
         # Delete middle line
         test_file.write_text("keep1\nkeep2\nkeep3\nkeep4\n")
@@ -633,13 +1028,17 @@ class TestAnchorConsistency:
         attribution = build_file_attribution("test.txt")
 
         # Should have DELETION_ONLY unit
-        deletion_units = [u.unit for u in attribution.units if u.unit.kind == AttributionUnitKind.DELETION_ONLY]
+        deletion_units = [
+            u.unit
+            for u in attribution.units
+            if u.unit.kind == AttributionUnitKind.DELETION_ONLY
+        ]
         assert len(deletion_units) == 1
 
         # Get diff
-        patches = list(collect_unified_diff(
-            stream_git_command(["diff", "HEAD", "test.txt"])
-        ))
+        patches = list(
+            collect_unified_diff(stream_git_command(["diff", "HEAD", "test.txt"]))
+        )
         line_changes = build_line_changes_from_patch_lines(patches[0].lines)
 
         # Project
@@ -658,7 +1057,9 @@ class TestAnchorConsistency:
         test_file.write_text("line1\nsame\nline3\nsame\nline5\n")
 
         subprocess.run(["git", "add", "test.txt"], check=True, capture_output=True)
-        subprocess.run(["git", "commit", "-m", "baseline"], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "baseline"], check=True, capture_output=True
+        )
 
         # Delete first "same" but not second
         test_file.write_text("line1\nline3\nsame\nline5\n")
@@ -667,16 +1068,20 @@ class TestAnchorConsistency:
         attribution = build_file_attribution("test.txt")
 
         # Should have one DELETION_ONLY unit with specific anchor
-        deletion_units = [u.unit for u in attribution.units if u.unit.kind == AttributionUnitKind.DELETION_ONLY]
+        deletion_units = [
+            u.unit
+            for u in attribution.units
+            if u.unit.kind == AttributionUnitKind.DELETION_ONLY
+        ]
         assert len(deletion_units) == 1
 
         # The deletion should have anchor = 1 (after line1)
         assert deletion_units[0].deletion_anchor_in_working_tree == 1
 
         # Get diff
-        patches = list(collect_unified_diff(
-            stream_git_command(["diff", "HEAD", "test.txt"])
-        ))
+        patches = list(
+            collect_unified_diff(stream_git_command(["diff", "HEAD", "test.txt"]))
+        )
         line_changes = build_line_changes_from_patch_lines(patches[0].lines)
 
         # Project
@@ -684,7 +1089,8 @@ class TestAnchorConsistency:
 
         # Should find exactly one deletion (not confused by the remaining "same" line)
         deletion_count = sum(
-            1 for u in display_to_unit.values()
+            1
+            for u in display_to_unit.values()
             if u.unit.kind == AttributionUnitKind.DELETION_ONLY
         )
         assert deletion_count >= 1, "Should find the deletion"
@@ -699,7 +1105,9 @@ class TestSemanticConsistency:
         test_file.write_text("keep\nold1\nold2\nkeep2\n")
 
         subprocess.run(["git", "add", "test.txt"], check=True, capture_output=True)
-        subprocess.run(["git", "commit", "-m", "baseline"], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "baseline"], check=True, capture_output=True
+        )
 
         test_file.write_text("keep\nnew1\nnew2\nkeep2\n")
 
@@ -713,9 +1121,9 @@ class TestSemanticConsistency:
         assert len(units_map) == len(attribution.units)
 
         # Get diff for projection layer
-        patches = list(collect_unified_diff(
-            stream_git_command(["diff", "HEAD", "test.txt"])
-        ))
+        patches = list(
+            collect_unified_diff(stream_git_command(["diff", "HEAD", "test.txt"]))
+        )
         line_changes = build_line_changes_from_patch_lines(patches[0].lines)
 
         # Projection layer
@@ -734,7 +1142,9 @@ class TestSemanticConsistency:
         test_file.write_text("line1\n")
 
         subprocess.run(["git", "add", "test.txt"], check=True, capture_output=True)
-        subprocess.run(["git", "commit", "-m", "baseline"], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "baseline"], check=True, capture_output=True
+        )
 
         test_file.write_text("line1\nambiguous\n")
 
@@ -744,4 +1154,6 @@ class TestSemanticConsistency:
         # All units should have empty owning_batches (unowned = visible)
         for attr_unit in attribution.units:
             # In absence of batches, units should be unowned
-            assert len(attr_unit.owning_batches) == 0, "Without batches, all units should be unowned"
+            assert len(attr_unit.owning_batches) == 0, (
+                "Without batches, all units should be unowned"
+            )

--- a/tests/data/test_hunk_tracking.py
+++ b/tests/data/test_hunk_tracking.py
@@ -78,6 +78,30 @@ def test_batch_metadata_snapshot_loads_once(monkeypatch):
     assert calls == [("batch-a",)]
 
 
+def test_batch_metadata_snapshot_indexes_claims_by_path(monkeypatch):
+    """Files without claims should skip traversal across unrelated batches."""
+    monkeypatch.setattr(
+        hunk_tracking,
+        "list_batch_names",
+        lambda: ["first", "second", "third"],
+    )
+    monkeypatch.setattr(
+        hunk_tracking,
+        "read_batch_metadata_for_batches",
+        lambda _names: {
+            "first": {"files": {"one.txt": {}}},
+            "second": {"files": {"two.txt": {}}},
+            "third": {"files": {"one.txt": {}, "three.txt": {}}},
+        },
+    )
+
+    snapshot = hunk_tracking._BatchMetadataSnapshot()
+
+    assert list(snapshot.metadata_for_path("one.txt")) == ["first", "third"]
+    assert list(snapshot.metadata_for_path("two.txt")) == ["second"]
+    assert snapshot.metadata_for_path("missing.txt") == {}
+
+
 class TestFindAndCacheNextUnblockedHunk:
     """Tests for fetch_next_change()."""
 

--- a/tests/data/test_selected_hunk_filtering.py
+++ b/tests/data/test_selected_hunk_filtering.py
@@ -6,6 +6,7 @@ import subprocess
 
 import pytest
 
+import git_stage_batch.data.selected_change.hunk_filtering as hunk_filtering_module
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.data.hunk_tracking import fetch_next_change
 from git_stage_batch.data.line_id_files import write_line_ids_file
@@ -40,7 +41,9 @@ def temp_git_repo(tmp_path, monkeypatch):
     )
 
     (repo / "README.md").write_text("# Test\n")
-    subprocess.run(["git", "add", "README.md"], check=True, cwd=repo, capture_output=True)
+    subprocess.run(
+        ["git", "add", "README.md"], check=True, cwd=repo, capture_output=True
+    )
     subprocess.run(
         ["git", "commit", "-m", "Initial commit"],
         check=True,
@@ -55,10 +58,13 @@ def temp_git_repo(tmp_path, monkeypatch):
 
 def test_apply_line_level_batch_filter_returns_false_without_batched_ids(
     temp_git_repo,
+    monkeypatch,
 ):
     test_file = temp_git_repo / "test.txt"
     test_file.write_text("line1\nline2\nline3\n")
-    subprocess.run(["git", "add", "test.txt"], check=True, cwd=temp_git_repo, capture_output=True)
+    subprocess.run(
+        ["git", "add", "test.txt"], check=True, cwd=temp_git_repo, capture_output=True
+    )
     subprocess.run(
         ["git", "commit", "-m", "Add file"],
         check=True,
@@ -71,8 +77,31 @@ def test_apply_line_level_batch_filter_returns_false_without_batched_ids(
     command_start()
     fetch_next_change()
     write_line_ids_file(get_processed_batch_ids_file_path(), set())
+    journal_entries = []
+    monkeypatch.setattr(
+        hunk_filtering_module,
+        "log_journal",
+        lambda operation, **fields: journal_entries.append((operation, fields)),
+    )
 
     assert apply_line_level_batch_filter_to_cached_hunk() is False
+    assert journal_entries == [
+        (
+            "file_attribution_complete",
+            {
+                "file_path": "test.txt",
+                "candidate_batches": 0,
+                "claimed_batches": 0,
+                "object_resolution_requests": 0,
+                "object_requests": 0,
+                "object_bytes": 0,
+                "unique_source_contents": 0,
+                "mapping_computations": 0,
+                "deletion_fingerprints": 0,
+                "attributed_units": 1,
+            },
+        )
+    ]
 
 
 def test_apply_line_level_batch_filter_returns_true_without_cached_hunk(

--- a/tests/utils/test_git_object_io.py
+++ b/tests/utils/test_git_object_io.py
@@ -12,6 +12,8 @@ from git_stage_batch.utils.git_object_io import (
     create_git_blobs_from_paths,
     get_empty_git_tree_object_id,
     read_git_blobs_as_bytes,
+    resolve_git_objects,
+    stream_git_blobs,
 )
 
 
@@ -37,7 +39,9 @@ def temp_git_repo(tmp_path, monkeypatch):
     )
 
     (repo / "README.md").write_text("# Test\n")
-    subprocess.run(["git", "add", "README.md"], check=True, cwd=repo, capture_output=True)
+    subprocess.run(
+        ["git", "add", "README.md"], check=True, cwd=repo, capture_output=True
+    )
     subprocess.run(
         ["git", "commit", "-m", "Initial commit"],
         check=True,
@@ -94,6 +98,76 @@ def test_read_git_blobs_as_bytes_accepts_revision_paths(temp_git_repo):
     blobs = read_git_blobs_as_bytes([f"HEAD:{file_path.name}"])
 
     assert blobs[f"HEAD:{file_path.name}"] == b"accented\n"
+
+
+def test_read_git_blobs_as_bytes_can_ignore_non_blob_objects(temp_git_repo):
+    """Tolerant batch readers should skip wrong object types without desync."""
+    blob = create_git_blob([b"content\n"])
+    tree = run_git_command(["write-tree"]).stdout.strip()
+    missing = "HEAD:path does not exist"
+
+    with pytest.raises(RuntimeError, match="Unexpected git cat-file"):
+        read_git_blobs_as_bytes([tree, blob])
+
+    blobs = read_git_blobs_as_bytes(
+        [tree, missing, blob],
+        ignore_non_blobs=True,
+    )
+
+    assert tree not in blobs
+    assert missing not in blobs
+    assert blobs[blob] == b"content\n"
+
+
+def test_resolve_git_objects_canonicalizes_revision_paths(temp_git_repo):
+    """Object checks should expose the shared canonical blob identity."""
+    blob = run_git_command(["rev-parse", "HEAD:README.md"]).stdout.strip()
+    tree = run_git_command(["write-tree"]).stdout.strip()
+    expressions = ["HEAD:README.md", blob, tree, "missing-object"]
+
+    resolved = resolve_git_objects(expressions)
+
+    assert resolved["HEAD:README.md"].object_id == blob
+    assert resolved[blob].object_id == blob
+    assert resolved[blob].object_type == "blob"
+    assert resolved[blob].size == len(b"# Test\n")
+    assert resolved[tree].object_type == "tree"
+    assert "missing-object" not in resolved
+
+
+def test_stream_git_blobs_preserves_binary_object_boundaries(
+    temp_git_repo,
+):
+    """Streaming batch reads should yield exact payloads one object at a time."""
+    first = create_git_blob([b"first\x00payload\n"])
+    second = create_git_blob([b"second\nline\n"])
+
+    blobs = [
+        (blob.requested_name, blob.object_id, b"".join(blob.content_chunks))
+        for blob in stream_git_blobs([first, second])
+    ]
+
+    assert blobs == [
+        (first, first, b"first\x00payload\n"),
+        (second, second, b"second\nline\n"),
+    ]
+
+
+def test_stream_git_blobs_does_not_materialize_large_payloads(temp_git_repo):
+    """Blob streams should expose bounded chunks instead of one payload value."""
+    payload_size = 256 * 1024
+    blob_id = create_git_blob([b"x" * payload_size])
+
+    streamed_size = 0
+    largest_chunk = 0
+    for blob in stream_git_blobs([blob_id]):
+        assert blob.size == payload_size
+        for chunk in blob.content_chunks:
+            streamed_size += len(chunk)
+            largest_chunk = max(largest_chunk, len(chunk))
+
+    assert streamed_size == payload_size
+    assert largest_chunk < payload_size
 
 
 def test_directory_snapshot_hashes_normal_files_in_one_batch(

--- a/tests/utils/test_repository_buffers.py
+++ b/tests/utils/test_repository_buffers.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import subprocess
 
+import pytest
+
 from git_stage_batch.core.buffer import LineBuffer
 import git_stage_batch.utils.repository_buffers as repository_buffers
 from git_stage_batch.utils.repository_buffers import (
@@ -12,8 +14,9 @@ from git_stage_batch.utils.repository_buffers import (
     load_git_object_as_buffer_or_empty,
     load_git_tree_files_as_buffers,
     load_working_tree_file_as_buffer,
+    stream_git_blob_buffers,
 )
-from git_stage_batch.utils.git_object_io import GitTreeBlob
+from git_stage_batch.utils.git_object_io import GitBlobStream, GitTreeBlob
 
 
 def test_load_git_blob_as_buffer_loads_streamed_blob(monkeypatch):
@@ -30,6 +33,40 @@ def test_load_git_blob_as_buffer_loads_streamed_blob(monkeypatch):
         assert calls == ["abc123"]
         assert buffer.uses_mapped_storage is False
         assert buffer[1] == b"beta\n"
+
+
+def test_stream_git_blob_buffers_spools_and_closes_each_source(monkeypatch):
+    """Batch-loaded source buffers should be mmap-backed and file-local."""
+    payload = b"line\n" * 2_000
+
+    def fake_stream_git_blobs(blob_names):
+        for blob_name in blob_names:
+            yield GitBlobStream(
+                requested_name=blob_name,
+                object_id=f"oid-{blob_name}",
+                size=len(payload),
+                content_chunks=iter((payload[:4_000], payload[4_000:])),
+            )
+
+    monkeypatch.setattr(
+        repository_buffers,
+        "stream_git_blobs",
+        fake_stream_git_blobs,
+    )
+
+    buffers = stream_git_blob_buffers(["first", "second"])
+    first = next(buffers)
+    assert first.buffer.uses_mapped_storage is True
+    assert first.buffer[0] == b"line\n"
+
+    second = next(buffers)
+    with pytest.raises(ValueError, match="closed"):
+        len(first.buffer)
+    assert second.buffer.uses_mapped_storage is True
+
+    buffers.close()
+    with pytest.raises(ValueError, match="closed"):
+        len(second.buffer)
 
 
 def test_load_git_tree_files_as_buffers_loads_tree_blobs(monkeypatch):


### PR DESCRIPTION
Hunk review uses ownership metadata to hide changes that are already saved in
a batch. It now limits that work to metadata for the current file. While
checking that file, it keeps only one source comparison open at a time.

The earlier implementation requested every source file and deleted fragment up
front. It kept those objects and their line comparisons until the file was
finished. Sessions with many saved batches could therefore use far more memory
than the file being reviewed required.

This pull request first teaches the Git object reader to recognize shared
objects and deliver their content in small pieces. Ownership analysis then
works through one source at a time and releases it before opening the next.
Hunk navigation also skips metadata for unrelated files. Normal filtering now
records counts that make regressions easier to investigate.

The changes remain organized as seven implementation, test, and documentation
steps. Every committed snapshot compiles. Focused snapshot tests pass, and the
complete test suite passes with 3,157 tests.
