### PR TITLE
batch: Reject claimed runs after large source gaps

### DIFF
--- a/src/git_stage_batch/batch/merge_validation.py
+++ b/src/git_stage_batch/batch/merge_validation.py
@@ -352,6 +352,13 @@ def _is_claimed_run_structurally_coherent(
         if facts.before_target_line >= facts.after_target_line:
             return False
 
+        # A large source-only region before the claimed run means the preceding
+        # mapped line may belong to unrelated target content with common text.
+        # Automatic placement cannot distinguish that false anchor from an
+        # intentionally shared prefix.
+        if significant_leading_gap:
+            return False
+
         if significant_trailing_gap:
             if (
                 facts.target_interval_span is None

--- a/tests/batch/test_merge_validation.py
+++ b/tests/batch/test_merge_validation.py
@@ -298,6 +298,46 @@ footer 2
     assert b"footer 2" in result
 
 
+def test_claimed_run_rejects_large_unmapped_leading_context():
+    """Repeated claimed braces must not anchor inside an unrelated method."""
+    batch_source = b"""class Example {
+    @Test
+    fun firstBatchMethod() {
+        val view = createView().apply {
+            configure()
+        }
+        assertFirstState()
+    }
+
+    @Test
+    fun secondBatchMethod() {
+        val view = createView().apply {
+            configure()
+        }
+        assertSecondState()
+    }
+
+    private fun helper() = Unit
+}
+"""
+    working = b"""class Example {
+    @Test
+    fun existingMethod() {
+        val view = createView().apply {
+            configure()
+        }
+        assertExistingState()
+    }
+
+    private fun helper() = Unit
+}
+"""
+    ownership = BatchOwnership.from_presence_lines(["1", "9-19"], [])
+
+    with pytest.raises(MergeError, match="different version"):
+        merge_batch(batch_source, ownership, working)
+
+
 def test_append_only_interleaved_batch_first_application_succeeds():
     """One-sided anchoring is safe when applying into an empty target tail."""
     batch_source = b"""Header

--- a/tests/commands/test_include_from.py
+++ b/tests/commands/test_include_from.py
@@ -374,7 +374,7 @@ class TestCommandIncludeFromBatch:
         subprocess.run(["git", "commit", "-m", "Partial"], check=True, cwd=temp_git_repo, capture_output=True)
         clear_last_file_review_state()
 
-        with pytest.raises(CommandError, match="Line selection #8-14"):
+        with pytest.raises(CommandError, match="Line selection #8-16"):
             command_include_from_batch("test-batch", line_ids="7-16", file="Test.kt")
 
         assert run_git_command(["diff", "--cached", "--", "Test.kt"]).stdout == ""


### PR DESCRIPTION
Batch merge validation checks surrounding mapped lines before restoring a
claimed run that is absent from the target version.

Repeated target text can make a distant mapped line look like a valid leading
anchor. Users can otherwise restore claimed content into an unrelated method
instead of receiving a version mismatch.

This pull request addresses that problem by rejecting bracketed runs that
follow a significant unmapped source gap. It adds focused merge-layer
coverage and aligns the include-from command regression expectation with the
full rejected interval.

The merge layer and include-from command now reject this false-anchor shape
while preserving the target unchanged.

Tests: `uv run pytest tests/batch/test_merge_validation.py tests/commands/test_include_from.py`
