### PR TITLE
batch: Place claims from contextual anchors

### DIFF
--- a/src/git_stage_batch/batch/merge_candidate_enumeration.py
+++ b/src/git_stage_batch/batch/merge_candidate_enumeration.py
@@ -168,6 +168,7 @@ def _presence_candidate_set(
     source_lines: Sequence[bytes],
     working_lines: Sequence[bytes],
     presence_line_set: LineSelection,
+    deletion_claims: list["AbsenceClaim"],
     *,
     resolution_is_valid: _MergeResolutionValidator,
     max_candidates: int,
@@ -181,6 +182,11 @@ def _presence_candidate_set(
                 presence_line_set,
                 presence_mapping,
                 max_results=max_candidates + 1,
+                trusted_source_lines={
+                    deletion.anchor_line
+                    for deletion in deletion_claims
+                    if deletion.anchor_line is not None
+                },
             )
         )
     finally:
@@ -388,6 +394,7 @@ def enumerate_merge_batch_candidates_for_lines(
         source_lines,
         working_lines,
         presence_line_set,
+        deletion_claims,
         resolution_is_valid=resolution_is_valid,
         max_candidates=max_candidates,
     )

--- a/src/git_stage_batch/batch/merge_validation.py
+++ b/src/git_stage_batch/batch/merge_validation.py
@@ -3,46 +3,21 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from ..core.line_selection import LineRanges, LineSelection
+from ..core.line_selection import LineSelection
 from ..exceptions import MergeError as _MergeError
 from ..i18n import _
 from .line_mapping import LineMapping
+from .presence_context import (
+    contextual_presence_placements as _contextual_presence_placements,
+)
 from .presence_missing_claims import (
     mapped_missing_source_lines as _mapped_missing_source_lines,
 )
 
 if TYPE_CHECKING:
     from .ownership_absence_claims import AbsenceClaim
-
-
-@dataclass
-class _ClaimedRunIntervalFacts:
-    """Structural facts about one contiguous run of missing claimed lines.
-
-    These facts make the merge-time safety decision explicit instead of hiding
-    the reasoning inside a single trailing-gap threshold.
-    """
-
-    run_start: int
-    run_end: int
-    run_length: int
-    before_source_line: int | None
-    after_source_line: int | None
-    before_target_line: int | None
-    after_target_line: int | None
-    leading_unmapped_source_gap: int
-    trailing_unmapped_source_gap: int
-    bracketed_on_both_sides: bool
-    bracketed_on_one_side_only: bool
-    source_interval_span: int | None
-    target_interval_span: int | None
-    surrounding_source_gap_outside_run: int | None
-    target_lines_after_before_anchor: int | None
-    has_deletion_at_before_anchor: bool
-    deletion_line_count_at_before_anchor: int
 
 
 def check_structural_validity(
@@ -122,6 +97,7 @@ def check_structural_validity(
                     )
                 )
 
+    has_unmapped_deletion_anchor = False
     for deletion in deletions:
         after_line = deletion.anchor_line
 
@@ -132,6 +108,7 @@ def check_structural_validity(
                 )
 
             if not line_mapping.is_source_line_present(after_line):
+                has_unmapped_deletion_anchor = True
                 has_context = False
                 for check_line in range(
                     max(1, after_line - 3),
@@ -151,7 +128,23 @@ def check_structural_validity(
                         )
                     )
 
-    _check_claimed_region_compatibility(
+    # Let absence realization report its more precise missing-anchor error once
+    # nearby mapped context has allowed an unmapped deletion anchor through.
+    if has_unmapped_deletion_anchor:
+        return
+
+    _contextual_presence_placements(
+        source_lines,
+        target_lines,
+        claimed_lines,
+        line_mapping,
+        trusted_source_lines={
+            deletion.anchor_line
+            for deletion in deletions
+            if deletion.anchor_line is not None
+        },
+    )
+    _check_unbounded_trailing_context(
         line_mapping,
         claimed_lines,
         deletions,
@@ -160,50 +153,90 @@ def check_structural_validity(
     )
 
 
-def _check_claimed_region_compatibility(
+def _check_unbounded_trailing_context(
     line_mapping: LineMapping,
     claimed_lines: LineSelection,
     deletions: list[AbsenceClaim],
     source_lines: Sequence[bytes],
     target_lines: Sequence[bytes],
 ) -> None:
-    """Check whether claimed lines have structurally coherent context."""
-    missing_claimed = _get_missing_claimed_lines(
-        line_mapping,
-        claimed_lines,
-        source_lines,
-    )
+    """Reject large unmatched tails not resolved by contextual anchors.
 
-    if not missing_claimed or len(target_lines) == 0:
-        return
-
-    for run_start, run_end in missing_claimed.ranges():
-        facts = _collect_claimed_run_interval_facts(
-            run_start,
-            run_end,
-            line_mapping,
-            source_lines,
-            target_lines,
-            deletions,
-        )
-
-        if not _is_claimed_run_structurally_coherent(facts):
-            raise _MergeError(
-                _("Batch was created from a different version of the file")
-            )
-
-
-def _get_missing_claimed_lines(
-    line_mapping: LineMapping,
-    claimed_lines: LineSelection,
-    source_lines: Sequence[bytes],
-) -> LineRanges:
-    """Return claimed source lines that are not present in the working tree."""
-    return _mapped_missing_source_lines(
+    Distinctive anchors choose insertion ordering.  They cannot establish that
+    a large, unselected source tail is compatible with unrelated target
+    content, so retain the existing conservative protection for that separate
+    version-skew shape.
+    """
+    missing = _mapped_missing_source_lines(
         claimed_lines,
         len(source_lines),
         line_mapping,
     )
+
+    for run_start, run_end in missing.ranges():
+        before_source_line = next(
+            (
+                line
+                for line in range(run_start - 1, 0, -1)
+                if line_mapping.is_source_line_present(line)
+            ),
+            None,
+        )
+        after_source_line = next(
+            (
+                line
+                for line in range(run_end + 1, len(source_lines) + 1)
+                if line_mapping.is_source_line_present(line)
+            ),
+            None,
+        )
+        trailing_gap = (
+            after_source_line - run_end - 1
+            if after_source_line is not None
+            else len(source_lines) - run_end
+        )
+        if trailing_gap < 3:
+            continue
+
+        before_target_line = (
+            line_mapping.get_target_line_from_source_line(before_source_line)
+            if before_source_line is not None
+            else None
+        )
+        after_target_line = (
+            line_mapping.get_target_line_from_source_line(after_source_line)
+            if after_source_line is not None
+            else None
+        )
+
+        if before_target_line is not None and after_target_line is not None:
+            target_span = after_target_line - before_target_line - 1
+            source_span_outside_run = (
+                after_source_line - before_source_line - 1
+                - (run_end - run_start + 1)
+            )
+            if (
+                target_span < source_span_outside_run
+                or target_span <= run_end - run_start + 1
+            ):
+                raise _MergeError(
+                    _("Batch was created from a different version of the file")
+                )
+            continue
+
+        if before_target_line is None or after_target_line is not None:
+            continue
+
+        target_tail = len(target_lines) - before_target_line
+        deleted_at_boundary = sum(
+            len(deletion.content_lines)
+            for deletion in deletions
+            if deletion.anchor_line == before_source_line
+        )
+        if target_tail != 0 and target_tail > deleted_at_boundary:
+            raise _MergeError(
+                _("Batch was created from a different version of the file")
+            )
 
 
 def _first_selected_line(lines: LineSelection) -> int | None:
@@ -211,205 +244,3 @@ def _first_selected_line(lines: LineSelection) -> int | None:
     if first is not None:
         return first()
     return min(lines) if lines else None
-
-
-def _find_nearest_mapped_source_line_before(
-    line_mapping: LineMapping,
-    source_line: int,
-) -> int | None:
-    """Find the nearest mapped source line strictly before the given line."""
-    for check_line in range(source_line - 1, 0, -1):
-        if line_mapping.get_target_line_from_source_line(check_line) is not None:
-            return check_line
-
-    return None
-
-
-def _find_nearest_mapped_source_line_after(
-    line_mapping: LineMapping,
-    source_line: int,
-    max_source_line: int,
-) -> int | None:
-    """Find the nearest mapped source line strictly after the given line."""
-    for check_line in range(source_line + 1, max_source_line + 1):
-        if line_mapping.get_target_line_from_source_line(check_line) is not None:
-            return check_line
-
-    return None
-
-
-def _collect_claimed_run_interval_facts(
-    run_start: int,
-    run_end: int,
-    line_mapping: LineMapping,
-    source_lines: Sequence[bytes],
-    target_lines: Sequence[bytes],
-    deletions: list[AbsenceClaim],
-) -> _ClaimedRunIntervalFacts:
-    """Collect explicit structural facts about one missing claimed run."""
-    before_source_line = _find_nearest_mapped_source_line_before(
-        line_mapping,
-        run_start,
-    )
-    after_source_line = _find_nearest_mapped_source_line_after(
-        line_mapping,
-        run_end,
-        len(source_lines),
-    )
-
-    before_target_line = None
-    after_target_line = None
-
-    if before_source_line is not None:
-        before_target_line = line_mapping.get_target_line_from_source_line(
-            before_source_line
-        )
-
-    if after_source_line is not None:
-        after_target_line = line_mapping.get_target_line_from_source_line(
-            after_source_line
-        )
-
-    leading_unmapped_source_gap = 0
-    if before_source_line is not None:
-        leading_unmapped_source_gap = run_start - before_source_line - 1
-
-    trailing_unmapped_source_gap = 0
-    if after_source_line is not None:
-        trailing_unmapped_source_gap = after_source_line - run_end - 1
-    else:
-        trailing_unmapped_source_gap = len(source_lines) - run_end
-
-    bracketed_on_both_sides = (
-        before_source_line is not None and
-        after_source_line is not None and
-        before_target_line is not None and
-        after_target_line is not None
-    )
-    bracketed_on_one_side_only = (
-        (before_source_line is None) != (after_source_line is None)
-    )
-
-    source_interval_span = None
-    target_interval_span = None
-    surrounding_source_gap_outside_run = None
-    target_lines_after_before_anchor = None
-    has_deletion_at_before_anchor = False
-    deletion_line_count_at_before_anchor = 0
-
-    if bracketed_on_both_sides:
-        source_interval_span = after_source_line - before_source_line - 1
-        target_interval_span = after_target_line - before_target_line - 1
-        surrounding_source_gap_outside_run = (
-            source_interval_span - (run_end - run_start + 1)
-        )
-    elif before_target_line is not None and after_target_line is None:
-        target_lines_after_before_anchor = len(target_lines) - before_target_line
-
-    if before_source_line is not None:
-        deletion_line_count_at_before_anchor = sum(
-            len(deletion.content_lines)
-            for deletion in deletions
-            if deletion.anchor_line == before_source_line
-        )
-        has_deletion_at_before_anchor = deletion_line_count_at_before_anchor > 0
-
-    return _ClaimedRunIntervalFacts(
-        run_start=run_start,
-        run_end=run_end,
-        run_length=run_end - run_start + 1,
-        before_source_line=before_source_line,
-        after_source_line=after_source_line,
-        before_target_line=before_target_line,
-        after_target_line=after_target_line,
-        leading_unmapped_source_gap=leading_unmapped_source_gap,
-        trailing_unmapped_source_gap=trailing_unmapped_source_gap,
-        bracketed_on_both_sides=bracketed_on_both_sides,
-        bracketed_on_one_side_only=bracketed_on_one_side_only,
-        source_interval_span=source_interval_span,
-        target_interval_span=target_interval_span,
-        surrounding_source_gap_outside_run=surrounding_source_gap_outside_run,
-        target_lines_after_before_anchor=target_lines_after_before_anchor,
-        has_deletion_at_before_anchor=has_deletion_at_before_anchor,
-        deletion_line_count_at_before_anchor=deletion_line_count_at_before_anchor,
-    )
-
-
-def _is_claimed_run_structurally_coherent(
-    facts: _ClaimedRunIntervalFacts,
-) -> bool:
-    """Check whether a missing claimed run fits its source/target interval."""
-    significant_trailing_gap = facts.trailing_unmapped_source_gap >= 3
-    significant_leading_gap = facts.leading_unmapped_source_gap >= 3
-
-    if not facts.bracketed_on_both_sides and not facts.bracketed_on_one_side_only:
-        return False
-
-    if facts.bracketed_on_both_sides:
-        if facts.before_target_line is None or facts.after_target_line is None:
-            return False
-
-        if facts.before_target_line >= facts.after_target_line:
-            return False
-
-        # A large source-only region before the claimed run means the preceding
-        # mapped line may belong to unrelated target content with common text.
-        # Automatic placement cannot distinguish that false anchor from an
-        # intentionally shared prefix.
-        if significant_leading_gap:
-            return False
-
-        if significant_trailing_gap:
-            if (
-                facts.target_interval_span is None
-                or facts.surrounding_source_gap_outside_run is None
-            ):
-                return False
-
-            # There is substantial source-side structure after the run before
-            # the next reliable source anchor, but almost no room for it in
-            # target-space. This is the characteristic shape of the corruption
-            # case: the selected run came from a neighborhood with extra
-            # source-only structure, so inserting it would preserve
-            # incompatible target content nearby.
-            if facts.target_interval_span < facts.surrounding_source_gap_outside_run:
-                return False
-
-            # Even if the overall interval is not smaller, a run followed by a
-            # large source-only tail with little or no target interval is still
-            # too weakly bracketed to trust.
-            if facts.target_interval_span <= facts.run_length:
-                return False
-
-        return True
-
-    if facts.before_source_line is not None and facts.after_source_line is None:
-        if significant_trailing_gap:
-            if facts.target_lines_after_before_anchor is None:
-                return False
-
-            # A source-only tail after the selected run is safe when applying
-            # into an empty target tail: this is the append/interleave case
-            # that lets independent batches compose in either order.
-            if facts.target_lines_after_before_anchor == 0:
-                return True
-
-            # A replacement can also be safe with target content after the
-            # anchor when an absence constraint at that same boundary removes
-            # the whole target tail before the new claimed lines are inserted.
-            if (
-                facts.has_deletion_at_before_anchor and
-                facts.target_lines_after_before_anchor
-                <= facts.deletion_line_count_at_before_anchor
-            ):
-                return True
-
-            return False
-        return True
-
-    if facts.before_source_line is None and facts.after_source_line is not None:
-        if significant_leading_gap:
-            return False
-        return True
-
-    return False

--- a/src/git_stage_batch/batch/presence_constraints.py
+++ b/src/git_stage_batch/batch/presence_constraints.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Collection, Sequence
 from typing import TYPE_CHECKING
 
 from .absence_constraints import (
@@ -11,6 +11,10 @@ from .absence_constraints import (
 from .line_mapping import LineMapping
 from .match import match_lines
 from .merge_candidates import MergeResolution as _MergeResolution
+from .presence_context import (
+    PresenceRunPlacement as _PresenceRunPlacement,
+    contextual_presence_placements as _contextual_presence_placements,
+)
 from .presence_missing_claims import (
     mapped_missing_source_lines as _mapped_missing_source_lines,
 )
@@ -41,6 +45,7 @@ def apply_presence_constraints(
     *,
     source_to_working_mapping: LineMapping | None = None,
     resolution: _MergeResolution | None = None,
+    trusted_source_lines: Collection[int] = (),
 ) -> RealizedEntries:
     """Apply presence constraints: ensure all claimed lines exist in result.
 
@@ -69,6 +74,7 @@ def apply_presence_constraints(
             presence_line_set,
             mapping,
             resolution=resolution,
+            trusted_source_lines=trusted_source_lines,
         )
     finally:
         if owned_mapping is not None:
@@ -82,6 +88,7 @@ def _apply_presence_constraints_with_mapping(
     mapping: LineMapping,
     *,
     resolution: _MergeResolution | None = None,
+    trusted_source_lines: Collection[int] = (),
 ) -> RealizedEntries:
     """Apply presence constraints using an existing source-to-working mapping."""
 
@@ -156,6 +163,26 @@ def _apply_presence_constraints_with_mapping(
                     return result
             raise _MergeError(_("Selected merge resolution is no longer valid"))
 
+    if all(
+        mapping.is_source_line_present(source_line)
+        for source_line in trusted_source_lines
+    ):
+        missing_claimed, placements = _contextual_presence_placements(
+            source_lines,
+            working_lines,
+            presence_line_set,
+            mapping,
+            trusted_source_lines=trusted_source_lines,
+        )
+        if placements:
+            return _realize_contextual_placements(
+                source_lines,
+                working_lines,
+                presence_line_set,
+                mapping,
+                placements,
+            )
+
     result = RealizedEntries()
     working_idx = 0
 
@@ -215,6 +242,50 @@ def _apply_presence_constraints_with_mapping(
     return result
 
 
+def _realize_contextual_placements(
+    source_lines: Sequence[bytes],
+    working_lines: Sequence[bytes],
+    presence_line_set: LineSelection,
+    mapping: LineMapping,
+    placements: Sequence[_PresenceRunPlacement],
+) -> RealizedEntries:
+    """Insert missing runs at gaps chosen from distinctive context."""
+    result = RealizedEntries()
+    working_idx = 0
+
+    for placement in placements:
+        if working_idx < placement.gap_index:
+            _realized_mapping.append_working_range_with_mapping(
+                result,
+                working_lines,
+                mapping,
+                working_idx,
+                placement.gap_index,
+                presence_line_set,
+            )
+            working_idx = placement.gap_index
+
+        result.append_line_range_from(
+            source_lines,
+            placement.run_start - 1,
+            placement.run_end,
+            source_line_start=placement.run_start,
+            is_claimed=True,
+        )
+
+    if working_idx < len(working_lines):
+        _realized_mapping.append_working_range_with_mapping(
+            result,
+            working_lines,
+            mapping,
+            working_idx,
+            len(working_lines),
+            presence_line_set,
+        )
+
+    return result
+
+
 def _missing_claimed_lines(
     entries: Sequence[_RealizedEntry],
     presence_line_set: LineSelection
@@ -255,12 +326,18 @@ def satisfy_constraints(
     resolution: _MergeResolution | None = None,
 ) -> RealizedEntries:
     """Apply presence and absence constraints until claimed lines survive."""
+    trusted_source_lines = {
+        deletion.anchor_line
+        for deletion in deletion_claims
+        if deletion.anchor_line is not None
+    }
     realized_entries = apply_presence_constraints(
         source_lines,
         working_lines,
         presence_line_set,
         source_to_working_mapping=source_to_working_mapping,
         resolution=resolution,
+        trusted_source_lines=trusted_source_lines,
     )
 
     try:
@@ -285,6 +362,7 @@ def satisfy_constraints(
                 current_lines,
                 presence_line_set,
                 resolution=resolution,
+                trusted_source_lines=trusted_source_lines,
             )
         finally:
             previous_entries.close()

--- a/src/git_stage_batch/batch/presence_constraints.py
+++ b/src/git_stage_batch/batch/presence_constraints.py
@@ -130,6 +130,7 @@ def _apply_presence_constraints_with_mapping(
                 presence_line_set,
                 mapping,
                 max_results=_PRESENCE_CANDIDATE_CAP + 1,
+                trusted_source_lines=trusted_source_lines,
             )
         )
         if presence_key is not None and presence_key in resolution.decisions:

--- a/src/git_stage_batch/batch/presence_context.py
+++ b/src/git_stage_batch/batch/presence_context.py
@@ -1,0 +1,343 @@
+"""Context-sensitive placement for missing presence claims."""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Collection, Sequence
+from dataclasses import dataclass
+
+from .line_mapping import LineMapping
+from .presence_missing_claims import mapped_missing_source_lines
+from ..core.line_selection import LineRanges, LineSelection
+from ..exceptions import MergeError
+from ..i18n import _
+
+
+_CONTEXTUAL_LEADING_GAP = 3
+
+
+@dataclass(frozen=True)
+class PresenceRunPlacement:
+    """One missing claimed run with a context-supported target gap."""
+
+    run_start: int
+    run_end: int
+    gap_index: int
+    before_source_line: int | None
+    after_source_line: int | None
+    before_target_line: int | None
+    after_target_line: int | None
+
+
+@dataclass(frozen=True)
+class ContextualPresenceAmbiguity:
+    """A missing claimed run with multiple context-compatible target gaps."""
+
+    run_start: int
+    run_end: int
+    before_source_line: int | None
+    after_source_line: int | None
+    start_gap: int
+    end_gap: int
+
+
+@dataclass(frozen=True)
+class _PresenceRunAnalysis:
+    run_start: int
+    run_end: int
+    before: tuple[int, int] | None
+    after: tuple[int, int] | None
+    gap_index: int | None
+
+
+def _distinctive_mapped_source_lines(
+    source_lines: Sequence[bytes],
+    target_lines: Sequence[bytes],
+    mapping: LineMapping,
+    trusted_source_lines: Collection[int],
+) -> list[tuple[int, int]]:
+    """Return mapped pairs whose line identity is safe as a boundary.
+
+    A raw alignment can map repeated punctuation through an equal prefix or
+    suffix.  Such a mapping is useful for preserving content, but it does not
+    identify which structural occurrence owns an insertion boundary.  A line
+    is therefore a contextual boundary only when it is unique in both file
+    versions, or when another constraint explicitly anchors that source line.
+    """
+    source_counts = Counter(source_lines)
+    target_counts = Counter(target_lines)
+    trusted = set(trusted_source_lines)
+    pairs: list[tuple[int, int]] = []
+
+    for source_line, target_line in mapping.mapped_line_pairs():
+        content = source_lines[source_line - 1]
+        if (
+            source_line in trusted
+            or (
+                source_counts[content] == 1
+                and target_counts[content] == 1
+            )
+        ):
+            pairs.append((source_line, target_line))
+
+    return pairs
+
+
+def _nearest_context_before(
+    pairs: Sequence[tuple[int, int]],
+    run_start: int,
+) -> tuple[int, int] | None:
+    nearest = None
+    for source_line, target_line in pairs:
+        if source_line >= run_start:
+            break
+        nearest = (source_line, target_line)
+    return nearest
+
+
+def _nearest_context_after(
+    pairs: Sequence[tuple[int, int]],
+    run_end: int,
+) -> tuple[int, int] | None:
+    for source_line, target_line in pairs:
+        if source_line > run_end:
+            return source_line, target_line
+    return None
+
+
+def _nearest_mapped_before(
+    mapping: LineMapping,
+    run_start: int,
+) -> tuple[int, int] | None:
+    for source_line in range(run_start - 1, 0, -1):
+        target_line = mapping.get_target_line_from_source_line(source_line)
+        if target_line is not None:
+            return source_line, target_line
+    return None
+
+
+def _nearest_mapped_after(
+    mapping: LineMapping,
+    run_end: int,
+    source_line_count: int,
+) -> tuple[int, int] | None:
+    for source_line in range(run_end + 1, source_line_count + 1):
+        target_line = mapping.get_target_line_from_source_line(source_line)
+        if target_line is not None:
+            return source_line, target_line
+    return None
+
+
+def _choose_insertion_gap(
+    *,
+    run_start: int,
+    run_end: int,
+    source_line_count: int,
+    target_line_count: int,
+    before: tuple[int, int] | None,
+    after: tuple[int, int] | None,
+) -> int | None:
+    """Choose the only target gap supported by distinctive context.
+
+    Target-only lines and source-only lines may occupy the same interval
+    between anchors.  In that situation their relative order is knowable only
+    when the claimed run is directly adjacent to one boundary.  File edges are
+    boundaries too, which keeps edge insertions deterministic.
+    """
+    before_source_line = before[0] if before is not None else 0
+    before_gap = before[1] if before is not None else 0
+    after_source_line = after[0] if after is not None else source_line_count + 1
+    after_gap = after[1] - 1 if after is not None else target_line_count
+
+    if before_gap > after_gap:
+        raise MergeError(_("Batch was created from a different version of the file"))
+
+    if before_gap == after_gap:
+        return before_gap
+
+    adjacent_to_before = run_start == before_source_line + 1
+    adjacent_to_after = run_end + 1 == after_source_line
+
+    # A file edge fixes ordering even when the opposite contextual anchor is
+    # also adjacent.  This preserves deterministic prepend and append merges.
+    if run_start == 1:
+        return 0
+    if run_end == source_line_count:
+        return target_line_count
+
+    if adjacent_to_before and not adjacent_to_after:
+        return before_gap
+    if adjacent_to_after and not adjacent_to_before:
+        return after_gap
+
+    # Both-adjacent real anchors with target-only content between them admit
+    # two valid orders.  Neither-adjacent runs have no context tying them to a
+    # side.  Automatic placement must not choose either shape silently, but a
+    # reviewed merge can enumerate the bounded gaps.
+    return None
+
+
+def _contextual_ambiguity(
+    *,
+    run_start: int,
+    run_end: int,
+    target_line_count: int,
+    before: tuple[int, int] | None,
+    after: tuple[int, int] | None,
+) -> ContextualPresenceAmbiguity:
+    start_gap = before[1] if before is not None else 0
+    end_gap = after[1] - 1 if after is not None else target_line_count
+    return ContextualPresenceAmbiguity(
+        run_start=run_start,
+        run_end=run_end,
+        before_source_line=before[0] if before is not None else None,
+        after_source_line=after[0] if after is not None else None,
+        start_gap=start_gap,
+        end_gap=end_gap,
+    )
+
+
+def _analyze_presence_runs(
+    source_lines: Sequence[bytes],
+    target_lines: Sequence[bytes],
+    source_selection: LineSelection,
+    mapping: LineMapping,
+    trusted_source_lines: Collection[int],
+) -> tuple[LineRanges, tuple[_PresenceRunAnalysis, ...]]:
+    missing = mapped_missing_source_lines(
+        source_selection,
+        len(source_lines),
+        mapping,
+    )
+    distinctive_pairs = None
+    analyses: list[_PresenceRunAnalysis] = []
+
+    for run_start, run_end in missing.ranges():
+        mapped_before = _nearest_mapped_before(mapping, run_start)
+        mapped_after = _nearest_mapped_after(mapping, run_end, len(source_lines))
+        leading_gap = (
+            run_start - mapped_before[0] - 1
+            if mapped_before is not None
+            else 0
+        )
+
+        if leading_gap < _CONTEXTUAL_LEADING_GAP:
+            before = mapped_before
+            after = mapped_after
+            gap_index = before[1] if before is not None else 0
+        else:
+            if distinctive_pairs is None:
+                distinctive_pairs = _distinctive_mapped_source_lines(
+                    source_lines,
+                    target_lines,
+                    mapping,
+                    trusted_source_lines,
+                )
+            before = _nearest_context_before(distinctive_pairs, run_start)
+            after = _nearest_context_after(distinctive_pairs, run_end)
+            gap_index = _choose_insertion_gap(
+                run_start=run_start,
+                run_end=run_end,
+                source_line_count=len(source_lines),
+                target_line_count=len(target_lines),
+                before=before,
+                after=after,
+            )
+
+        analyses.append(_PresenceRunAnalysis(
+            run_start=run_start,
+            run_end=run_end,
+            before=before,
+            after=after,
+            gap_index=gap_index,
+        ))
+
+    return missing, tuple(analyses)
+
+
+def contextual_presence_ambiguities(
+    source_lines: Sequence[bytes],
+    target_lines: Sequence[bytes],
+    source_selection: LineSelection,
+    mapping: LineMapping,
+    *,
+    trusted_source_lines: Collection[int] = (),
+) -> tuple[ContextualPresenceAmbiguity, ...]:
+    """Return bounded placement ambiguities for suspicious missing runs."""
+    _, analyses = _analyze_presence_runs(
+        source_lines,
+        target_lines,
+        source_selection,
+        mapping,
+        trusted_source_lines,
+    )
+    ambiguities: list[ContextualPresenceAmbiguity] = []
+
+    for analysis in analyses:
+        if analysis.gap_index is not None:
+            continue
+        ambiguities.append(_contextual_ambiguity(
+            run_start=analysis.run_start,
+            run_end=analysis.run_end,
+            target_line_count=len(target_lines),
+            before=analysis.before,
+            after=analysis.after,
+        ))
+
+    return tuple(ambiguities)
+
+
+def contextual_presence_placements(
+    source_lines: Sequence[bytes],
+    target_lines: Sequence[bytes],
+    source_selection: LineSelection,
+    mapping: LineMapping,
+    *,
+    trusted_source_lines: Collection[int] = (),
+) -> tuple[LineRanges, tuple[PresenceRunPlacement, ...]]:
+    """Return missing claims and their context-supported insertion gaps.
+
+    Ordinary missing runs retain their established placement immediately after
+    the nearest preceding mapping.  When a substantial source-only region
+    separates that mapping from the claim, globally distinctive mappings must
+    instead identify which side of target-only content owns the insertion.
+    This prevents a repeated brace or blank line from deciding how competing
+    unmatched source and target regions should be interleaved.
+    """
+    missing, analyses = _analyze_presence_runs(
+        source_lines,
+        target_lines,
+        source_selection,
+        mapping,
+        trusted_source_lines,
+    )
+    if not missing:
+        return missing, ()
+
+    placements: list[PresenceRunPlacement] = []
+
+    for analysis in analyses:
+        if analysis.gap_index is None:
+            raise MergeError(
+                _("Batch was created from a different version of the file")
+            )
+        placements.append(PresenceRunPlacement(
+            run_start=analysis.run_start,
+            run_end=analysis.run_end,
+            gap_index=analysis.gap_index,
+            before_source_line=(
+                analysis.before[0] if analysis.before is not None else None
+            ),
+            after_source_line=(
+                analysis.after[0] if analysis.after is not None else None
+            ),
+            before_target_line=(
+                analysis.before[1] if analysis.before is not None else None
+            ),
+            after_target_line=(
+                analysis.after[1] if analysis.after is not None else None
+            ),
+        ))
+
+    placements.sort(key=lambda placement: (placement.gap_index, placement.run_start))
+    return missing, tuple(placements)

--- a/src/git_stage_batch/batch/presence_placement_choices.py
+++ b/src/git_stage_batch/batch/presence_placement_choices.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Collection, Sequence
 from dataclasses import dataclass
 import hashlib
 
@@ -10,6 +10,9 @@ from ..core.line_selection import LineSelection
 from .line_mapping import LineMapping
 from .line_sequence_equality import line_slice_equals as _line_slice_matches
 from .line_sequence_search import iter_exact_context_gaps
+from .presence_context import (
+    contextual_presence_ambiguities as _contextual_presence_ambiguities,
+)
 from .presence_missing_claims import (
     mapped_missing_source_lines as _mapped_missing_source_lines,
 )
@@ -32,6 +35,7 @@ def presence_choices_for_missing_claimed_run(
     mapping: LineMapping,
     *,
     max_results: int,
+    trusted_source_lines: Collection[int] = (),
 ) -> tuple[str | None, tuple["PresenceChoice", ...]]:
     missing_claimed = _mapped_missing_source_lines(
         presence_line_set,
@@ -43,6 +47,39 @@ def presence_choices_for_missing_claimed_run(
         return None, ()
 
     run_start, run_end = ranges[0]
+    adjacent_key, adjacent_choices = _adjacent_context_choices(
+        source_lines,
+        working_lines,
+        mapping,
+        run_start=run_start,
+        run_end=run_end,
+        max_results=max_results,
+    )
+    if adjacent_key is not None:
+        return adjacent_key, adjacent_choices
+
+    return _contextual_choices(
+        source_lines,
+        working_lines,
+        presence_line_set,
+        mapping,
+        run_start=run_start,
+        run_end=run_end,
+        max_results=max_results,
+        trusted_source_lines=trusted_source_lines,
+    )
+
+
+def _adjacent_context_choices(
+    source_lines: Sequence[bytes],
+    working_lines: Sequence[bytes],
+    mapping: LineMapping,
+    *,
+    run_start: int,
+    run_end: int,
+    max_results: int,
+) -> tuple[str | None, tuple[PresenceChoice, ...]]:
+    """Return choices bracketed by immediately adjacent source lines."""
     before_source_line = run_start - 1
     after_source_line = run_end + 1
     if before_source_line < 1 or after_source_line > len(source_lines):
@@ -88,6 +125,62 @@ def presence_choices_for_missing_claimed_run(
     return key, tuple(choices)
 
 
+def _contextual_choices(
+    source_lines: Sequence[bytes],
+    working_lines: Sequence[bytes],
+    presence_line_set: LineSelection,
+    mapping: LineMapping,
+    *,
+    run_start: int,
+    run_end: int,
+    max_results: int,
+    trusted_source_lines: Collection[int],
+) -> tuple[str | None, tuple[PresenceChoice, ...]]:
+    """Return reviewed gaps bounded by distinctive contextual anchors."""
+    ambiguities = _contextual_presence_ambiguities(
+        source_lines,
+        working_lines,
+        presence_line_set,
+        mapping,
+        trusted_source_lines=trusted_source_lines,
+    )
+    if len(ambiguities) != 1:
+        return None, ()
+
+    ambiguity = ambiguities[0]
+    if ambiguity.run_start != run_start or ambiguity.run_end != run_end:
+        return None, ()
+
+    claimed_run = source_lines[run_start - 1:run_end]
+    before_source_line = ambiguity.before_source_line or 0
+    after_source_line = ambiguity.after_source_line or len(source_lines) + 1
+    key = presence_ambiguity_key(
+        run_start,
+        run_end,
+        claimed_run,
+        before_source_line,
+        after_source_line,
+    )
+    choices: list[PresenceChoice] = []
+    for gap_index in range(ambiguity.start_gap, ambiguity.end_gap + 1):
+        if _line_slice_matches(working_lines, gap_index, claimed_run):
+            continue
+        choices.append(PresenceChoice(
+            choice_index=len(choices) + 1,
+            gap_index=gap_index,
+            run_start=run_start,
+            run_end=run_end,
+            target_after_line=gap_index if gap_index > 0 else None,
+            target_before_line=(
+                gap_index + 1 if gap_index < len(working_lines) else None
+            ),
+        ))
+        if len(choices) >= max_results:
+            break
+
+    return key, tuple(choices)
+
+
 def presence_ambiguity_key(
     run_start: int,
     run_end: int,
@@ -97,7 +190,7 @@ def presence_ambiguity_key(
 ) -> str:
     hasher = hashlib.sha256()
     for line in claimed_run:
-        hasher.update(line)
+        hasher.update(bytes(line))
     digest = hasher.hexdigest()[:12]
     return (
         f"presence:{run_start}-{run_end}:claimed:{digest}:"

--- a/tests/batch/test_merge.py
+++ b/tests/batch/test_merge.py
@@ -1588,6 +1588,104 @@ class TestMergeBatch:
 
         assert result == b"line1\nline2\nline3\nline4\nline5\n"
 
+    def test_enumerates_contextual_presence_gaps(self):
+        """Distinctive outer anchors expose ambiguous insertion gaps."""
+        source = b"""header
+old one
+old two
+old three
+claimed
+old tail
+footer
+"""
+        working = b"""header
+target one
+target two
+footer
+"""
+        ownership = BatchOwnership.from_presence_lines(["5"], [])
+
+        with pytest.raises(MergeError, match="different version"):
+            merge_batch(source, ownership, working)
+
+        candidate_set = enumerate_merge_batch_candidates_from_line_sequences(
+            source.splitlines(keepends=True),
+            ownership,
+            working.splitlines(keepends=True),
+            max_candidates=10,
+        )
+
+        assert [candidate.summary for candidate in candidate_set.candidates] == [
+            "insert source lines 5-5 after target line 1, before target line 2",
+            "insert source lines 5-5 after target line 2, before target line 3",
+            "insert source lines 5-5 after target line 3, before target line 4",
+        ]
+        assert [
+            merge_batch(
+                source,
+                ownership,
+                working,
+                resolution=candidate.resolution,
+            )
+            for candidate in candidate_set.candidates
+        ] == [
+            b"header\nclaimed\ntarget one\ntarget two\nfooter\n",
+            b"header\ntarget one\nclaimed\ntarget two\nfooter\n",
+            b"header\ntarget one\ntarget two\nclaimed\nfooter\n",
+        ]
+
+    def test_contextual_presence_candidates_honor_preview_cap(self):
+        """Wide ambiguous intervals should stop at the candidate safety cap."""
+        source = b"header\nold one\nold two\nold three\nclaimed\nold tail\nfooter\n"
+        working = b"header\none\ntwo\nthree\nfour\nfooter\n"
+        ownership = BatchOwnership.from_presence_lines(["5"], [])
+
+        with pytest.raises(MergeError, match="Too many merge candidates"):
+            enumerate_merge_batch_candidates_from_line_sequences(
+                source.splitlines(keepends=True),
+                ownership,
+                working.splitlines(keepends=True),
+                max_candidates=3,
+            )
+
+    def test_multiple_contextual_ambiguities_remain_a_hard_refusal(self):
+        """Independent ambiguous runs should not form a candidate product."""
+        source = b"""header
+a old one
+a old two
+a old three
+claimed a
+a old tail
+middle
+b old one
+b old two
+b old three
+claimed b
+b old tail
+footer
+"""
+        working = b"""header
+a target one
+a target two
+middle
+b target one
+b target two
+footer
+"""
+        ownership = BatchOwnership.from_presence_lines(["5", "11"], [])
+
+        with pytest.raises(MergeError, match="different version"):
+            merge_batch(source, ownership, working)
+
+        candidate_set = enumerate_merge_batch_candidates_from_line_sequences(
+            source.splitlines(keepends=True),
+            ownership,
+            working.splitlines(keepends=True),
+            max_candidates=10,
+        )
+
+        assert candidate_set.candidates == ()
+
     def test_enumerates_displaced_absence_candidates(self):
         """Ambiguous nearby deletion content can be previewed as candidates."""
         source = [b"a\n", b"b\n"]

--- a/tests/batch/test_merge_validation.py
+++ b/tests/batch/test_merge_validation.py
@@ -338,6 +338,33 @@ def test_claimed_run_rejects_large_unmapped_leading_context():
         merge_batch(batch_source, ownership, working)
 
 
+def test_claimed_run_uses_distinctive_trailing_context_after_large_gap():
+    """A unique trailing boundary can place a claim after target-only lines."""
+    batch_source = b"""distinctive shared header
+obsolete source one
+obsolete source two
+obsolete source three
+obsolete source four
+claimed addition
+distinctive shared footer
+"""
+    working = b"""distinctive shared header
+replacement target one
+replacement target two
+distinctive shared footer
+"""
+    ownership = BatchOwnership.from_presence_lines(["6"], [])
+
+    result = merge_batch(batch_source, ownership, working)
+
+    assert result == b"""distinctive shared header
+replacement target one
+replacement target two
+claimed addition
+distinctive shared footer
+"""
+
+
 def test_append_only_interleaved_batch_first_application_succeeds():
     """One-sided anchoring is safe when applying into an empty target tail."""
     batch_source = b"""Header

--- a/tests/commands/test_candidate_previews.py
+++ b/tests/commands/test_candidate_previews.py
@@ -192,6 +192,27 @@ def _create_split_replacement_origin_batch(repo):
     (repo / "file.txt").write_text("head\nold2\nmid\nold2\ntail\n")
 
 
+def _create_contextual_presence_batch(repo):
+    source = "header\nold one\nold two\nold three\nclaimed\nold tail\nfooter\n"
+    (repo / "file.txt").write_text(source)
+    subprocess.run(["git", "add", "file.txt"], check=True, cwd=repo, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "Add contextual source file"],
+        check=True,
+        cwd=repo,
+        capture_output=True,
+    )
+    initialize_abort_state()
+    create_batch("contextual")
+    add_file_to_batch(
+        "contextual",
+        "file.txt",
+        BatchOwnership.from_presence_lines(["5"], []),
+        "100644",
+    )
+    (repo / "file.txt").write_text("header\ntarget one\ntarget two\nfooter\n")
+
+
 def _candidate_state_has_file(batch_name, file_path):
     state_path = get_batch_candidate_state_file_path()
     if not state_path.exists():
@@ -201,6 +222,28 @@ def _candidate_state_has_file(batch_name, file_path):
     return any(
         scope.get("batch_name") == batch_name and scope.get("file") == file_path
         for scope in data.get("scopes", {}).values()
+    )
+
+
+def test_contextual_presence_candidates_can_be_previewed_and_applied(
+    temp_git_repo,
+    capsys,
+):
+    """Contextual insertion gaps should use the reviewed candidate workflow."""
+    _create_contextual_presence_batch(temp_git_repo)
+
+    command_show_from_batch("contextual:apply", file="file.txt")
+
+    overview = capsys.readouterr()
+    assert "contextual  ·  apply candidates  ·  3 choices" in overview.out
+    assert 'Candidate 2/3   Add "claimed" near "target one"' in overview.out
+
+    command_apply_from_batch("contextual:apply:2", file="file.txt")
+
+    captured = capsys.readouterr()
+    assert "Applied candidate 2 of 3 from batch 'contextual'" in captured.err
+    assert (temp_git_repo / "file.txt").read_text() == (
+        "header\ntarget one\nclaimed\ntarget two\nfooter\n"
     )
 
 


### PR DESCRIPTION
Batch merges use structural line mappings to place claimed source lines in
changed targets.

Repeated syntax can make those mappings misleading, while large nearby edits
can hide safe placements or leave several bounded alternatives behind a generic
refusal.

This PR uses globally distinctive mapped boundaries and explicit deletion
anchors to place deterministic claims automatically. It also exposes stable,
replayable candidates when one contextual interval contains several plausible
gaps, while retaining safety caps and hard refusals for independent
ambiguities.

Contextual placement now succeeds automatically when the evidence identifies
one gap and asks the user to choose when a small set of safe gaps remains. The
full test suite passes with 3163 tests, including the existing even-odd
showcase.
