### PR TITLE
journal: Make diagnostic capture explicit

### DIFF
--- a/completions/git-stage-batch
+++ b/completions/git-stage-batch
@@ -49,7 +49,7 @@ _git_stage_batch()
     local cur prev words cword
     _init_completion || return
 
-    local commands="start show include skip discard status again stop abort block-file unblock-file suggest-fixup new list drop annotate apply reset undo redo validate"
+    local commands="start show include skip discard status again stop abort block-file unblock-file suggest-fixup new list drop annotate apply reset undo redo validate journal"
 
     # Handle subcommands
     if [[ $cword -eq 1 ]]; then
@@ -235,6 +235,9 @@ _git_stage_batch()
             ;;
         validate)
             COMPREPLY=($(compgen -W "--porcelain" -- "$cur"))
+            ;;
+        journal)
+            COMPREPLY=($(compgen -W "--path --purge --all --porcelain" -- "$cur"))
             ;;
         *)
             ;;

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -878,6 +878,32 @@ Installing `codex-skills` also writes the shared internal drafter brief at
 
 ---
 
+## Diagnostics
+
+### `journal`
+
+Locate, summarize, or remove private diagnostic journal data.
+
+```bash
+git-stage-batch journal
+git-stage-batch journal --path
+git-stage-batch journal --purge
+```
+
+Journaling is disabled by default. Enable content-free operation metadata for
+a reproduction with `GIT_STAGE_BATCH_JOURNAL=metadata-only`, or add bounded
+call stacks with `verbose`. The `content-debug` level also records raw paths,
+Git command output, and short content previews, so use it only for a limited
+reproduction and purge it afterward.
+
+The default command prints the configured level, private per-user path, file
+count, entry count, and total size. `--porcelain` returns the same summary as
+stable JSON. `--path` prints only the current repository's location. `--purge`
+removes its active and rotated files; combine it with `--all` to remove journal
+data for every repository.
+
+---
+
 ## Batch Operations
 
 ### `validate`

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -53,9 +53,9 @@ versions.
 ## Atomic file permissions
 
 Git-stage-batch writes session metadata, recovery manifests, batch
-compatibility metadata, and journals as private application state. Newly
-created state files use mode `0600`, including when the process has a
-permissive umask. Rewriting private state also restores that restrictive mode.
+compatibility metadata as private application state. Newly created state files
+use mode `0600`, including when the process has a permissive umask. Rewriting
+private state also restores that restrictive mode.
 
 Repository-owned files use a separate atomic-write policy. Updates to
 `.gitignore`, `.git/info/exclude`, and previously installed assistant assets
@@ -70,6 +70,49 @@ the platform supports that operation. A failure before replacement leaves the
 old file complete. Symlink targets are never followed or silently replaced;
 the command stops with recovery guidance so callers can update the intended
 target explicitly.
+
+## Diagnostic journals
+
+Diagnostic journaling is disabled by default, so ordinary commands do not
+inspect the Python stack, serialize journal entries, open journal files, or run
+extra Git queries for diagnostics. Set `GIT_STAGE_BATCH_JOURNAL` to one of the
+following levels when investigating a problem:
+
+- `metadata-only` records structured operation names, stable source IDs,
+  object IDs, modes, sizes, and hashed path identifiers.
+- `verbose` adds a bounded stack for each event. Error events also include a
+  bounded stack at the metadata level.
+- `content-debug` additionally records raw paths, Git command output, and
+  short content previews. This level can expose repository content and should
+  only be enabled for a limited reproduction.
+- `disabled` turns journaling off explicitly.
+
+The historical `GIT_STAGE_BATCH_DEBUG` switch selects `verbose` for
+compatibility; it does not enable raw content capture.
+
+Journal files are stored under
+`$XDG_STATE_HOME/git-stage-batch/journals/`, or
+`~/.local/state/git-stage-batch/journals/` when `XDG_STATE_HOME` is unset. The
+filename contains a stable hash of the repository identity rather than its
+path. The journal directory uses mode `0700` and files use mode `0600`.
+`GIT_STAGE_BATCH_JOURNAL_PATH` can override the destination for a controlled
+debugging environment.
+
+Entries are queued in a bounded process buffer. The buffer flushes when it
+reaches 64 KiB, at each interactive action boundary, and when a CLI command
+exits. A process terminated without normal cleanup can lose entries since the
+last boundary; journaling never changes the durability of repository state.
+Writers use a per-journal lock so concurrent processes append complete JSON
+lines.
+
+The active file rotates at 5 MiB, retains at most three rotated files, and
+expires journal files after 30 days. Use `GIT_STAGE_BATCH_JOURNAL_MAX_BYTES`
+and `GIT_STAGE_BATCH_JOURNAL_RETENTION_DAYS` to adjust those limits. Run
+`git-stage-batch journal` for a content-free summary,
+`git-stage-batch journal --path` to locate the file, or
+`git-stage-batch journal --purge` to remove it. Add `--all` to purge data for
+all repositories. The disabled/event-heavy paths can be compared with
+`scripts/benchmark_journal.py` from a source checkout.
 
 ## Batch metadata schema
 

--- a/man/git-stage-batch-journal.1.in
+++ b/man/git-stage-batch-journal.1.in
@@ -1,0 +1,65 @@
+.TH GIT-STAGE-BATCH-JOURNAL 1 "July 2026" "git-stage-batch @VERSION@" "User Commands"
+.SH NAME
+git-stage-batch-journal \- inspect or purge diagnostic journal data
+.SH SYNOPSIS
+.B git-stage-batch journal
+[
+.B \-\-path
+|
+.B \-\-purge
+]
+[
+.B \-\-all
+]
+[
+.B \-\-porcelain
+]
+.SH DESCRIPTION
+Shows a content-free summary of the diagnostic journal for the current
+repository. Journaling is disabled unless
+.B GIT_STAGE_BATCH_JOURNAL
+is configured.
+.PP
+Journal files live in a private per-user state directory, are identified by a
+hash of the repository, and are rotated and expired automatically. Metadata
+and verbose levels redact paths, command output, and content previews.
+.SH OPTIONS
+.TP
+.B \-\-path
+Print only the current repository's journal path.
+.TP
+.B \-\-purge
+Delete the current repository's journal files.
+.TP
+.B \-\-all
+With
+.BR \-\-purge ,
+delete journal files for every repository.
+.TP
+.B \-\-porcelain
+Emit stable JSON output.
+.SH ENVIRONMENT
+.TP
+.B GIT_STAGE_BATCH_JOURNAL
+Select
+.BR disabled ,
+.BR metadata-only ,
+.BR verbose ,
+or
+.BR content-debug .
+The default is
+.BR disabled .
+.TP
+.B GIT_STAGE_BATCH_JOURNAL_PATH
+Override the journal file path.
+.TP
+.B XDG_STATE_HOME
+Set the base per-user state directory when the journal path is not overridden.
+.SH PRIVACY
+.B content-debug
+records raw paths, command output, and short content previews. Enable it only
+for a limited reproduction and purge it afterward. The other enabled levels
+record stable path hashes and content-free metadata.
+.SH SEE ALSO
+.BR git-stage-batch (1),
+.BR git-stage-batch-validate (1)

--- a/man/git-stage-batch.1.in
+++ b/man/git-stage-batch.1.in
@@ -11,7 +11,7 @@ provides a command-oriented workflow for reviewing and staging git changes.
 It presents hunks, files, and batches as numbered review targets so changes
 can be included, skipped, discarded, saved for later, or moved between batches.
 .PP
-State is maintained under
+Session and repository compatibility state is maintained under
 .BR .git/git-stage-batch/ .
 Sessions can be stopped, resumed, undone, or redone while preserving enough
 state to keep later commands tied to the selected review.
@@ -124,6 +124,9 @@ Suggest a commit to fix up with the selected hunk.
 .TP
 .BR git-stage-batch-install-assets (1)
 Install bundled assistant assets into the repository.
+.TP
+.BR git-stage-batch-journal (1)
+Locate, summarize, or purge private diagnostic journal data.
 .SH LINE IDS
 Line-oriented commands accept comma-separated IDs and ranges such as
 .BR 1 ,
@@ -176,4 +179,5 @@ License: MIT
 .BR git-stage-batch-include (1),
 .BR git-stage-batch-skip (1),
 .BR git-stage-batch-discard (1),
-.BR git-stage-batch-status (1)
+.BR git-stage-batch-status (1),
+.BR git-stage-batch-journal (1)

--- a/meson.build
+++ b/meson.build
@@ -61,6 +61,7 @@ manpage_specs = [
   ['git-stage-batch-unblock-file.1.in', 'git-stage-batch-unblock-file.1'],
   ['git-stage-batch-undo.1.in', 'git-stage-batch-undo.1'],
   ['git-stage-batch-validate.1.in', 'git-stage-batch-validate.1'],
+  ['git-stage-batch-journal.1.in', 'git-stage-batch-journal.1'],
 ]
 manpages = []
 foreach manpage_spec : manpage_specs

--- a/scripts/benchmark_journal.py
+++ b/scripts/benchmark_journal.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Measure diagnostic journal overhead at representative event volumes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import tempfile
+import time
+from pathlib import Path
+
+from git_stage_batch.utils.journal import (
+    JOURNAL_LEVEL_ENV,
+    JOURNAL_PATH_ENV,
+    flush_journal,
+    log_journal,
+)
+
+
+def _measure(level: str, event_count: int, journal_path: Path) -> dict[str, float | int | str]:
+    os.environ[JOURNAL_LEVEL_ENV] = level
+    os.environ[JOURNAL_PATH_ENV] = str(journal_path)
+    started = time.perf_counter()
+    for number in range(event_count):
+        log_journal(
+            "representative_hot_path",
+            file_path=f"src/generated/{number % 1000}.py",
+            object_id=f"{number:040x}",
+            content_len=4096,
+        )
+    flush_journal()
+    elapsed = time.perf_counter() - started
+    return {
+        "level": level,
+        "event_count": event_count,
+        "elapsed_seconds": elapsed,
+        "microseconds_per_event": elapsed * 1_000_000 / event_count,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--events", type=int, default=100_000)
+    args = parser.parse_args()
+    if args.events <= 0:
+        parser.error("--events must be positive")
+
+    with tempfile.TemporaryDirectory(prefix="git-stage-batch-journal-") as directory:
+        root = Path(directory)
+        report = {
+            "disabled": _measure("disabled", args.events, root / "disabled.jsonl"),
+            "metadata_only": _measure(
+                "metadata-only",
+                args.events,
+                root / "metadata.jsonl",
+            ),
+        }
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/git_stage_batch/batch/source_snapshots.py
+++ b/src/git_stage_batch/batch/source_snapshots.py
@@ -30,7 +30,7 @@ from ..utils.git_index import (
 )
 from ..utils.git_repository import get_git_repository_root_path
 from ..utils.git_object_io import create_git_blob
-from ..utils.journal import log_journal
+from ..utils.journal import JournalLevel, journal_enabled, log_journal
 from ..utils.paths import get_abort_head_file_path
 from .source_buffers import (
     load_saved_session_file_as_buffer as _load_saved_session_file_as_buffer,
@@ -119,7 +119,7 @@ def create_batch_source_commits(file_paths: list[str]) -> dict[str, BatchSourceC
     try:
         repo_root = get_git_repository_root_path()
         file_modes: dict[str, str] = {}
-        content_stats: dict[str, tuple[int, int]] = {}
+        content_sizes: dict[str, int] = {}
         for file_path in unique_file_paths:
             full_path = repo_root / file_path
             if os.path.lexists(full_path):
@@ -134,17 +134,18 @@ def create_batch_source_commits(file_paths: list[str]) -> dict[str, BatchSourceC
 
             buffer = file_buffers[file_path]
             buffer_len = buffer.byte_count
-            buffer_lines = len(buffer) if buffer_len else 0
-            content_stats[file_path] = (buffer_len, buffer_lines)
-            log_journal(
-                "batch_source_creating",
-                file_path=file_path,
-                baseline_commit=baseline_commit,
-                file_existed_at_session_start=file_path in files_existing_at_session_start,
-                content_len=buffer_len,
-                content_lines=buffer_lines,
-                buffer_preview=_buffer_preview(buffer),
-            )
+            content_sizes[file_path] = buffer_len
+            if journal_enabled():
+                fields = {
+                    "file_path": file_path,
+                    "baseline_commit": baseline_commit,
+                    "file_existed_at_session_start": file_path in files_existing_at_session_start,
+                    "content_len": buffer_len,
+                }
+                if journal_enabled(JournalLevel.CONTENT_DEBUG):
+                    fields["content_lines"] = len(buffer) if buffer_len else 0
+                    fields["buffer_preview"] = _buffer_preview(buffer)
+                log_journal("batch_source_creating", **fields)
 
         import_id = uuid.uuid4().hex
         temp_refs = [
@@ -158,7 +159,7 @@ def create_batch_source_commits(file_paths: list[str]) -> dict[str, BatchSourceC
             for index, file_path in enumerate(unique_file_paths):
                 blob_mark = blob_mark_start + index
                 buffer = file_buffers[file_path]
-                buffer_len, _buffer_lines = content_stats[file_path]
+                buffer_len = content_sizes[file_path]
                 yield f"blob\nmark :{blob_mark}\ndata {buffer_len}\n".encode("ascii")
                 yield from buffer.byte_chunks()
                 yield b"\n"
@@ -213,7 +214,7 @@ def create_batch_source_commits(file_paths: list[str]) -> dict[str, BatchSourceC
         results: dict[str, BatchSourceCommit] = {}
         for index, file_path in enumerate(unique_file_paths):
             commit_sha = marks[commit_mark_start + index]
-            content_len, content_lines = content_stats[file_path]
+            content_len = content_sizes[file_path]
             results[file_path] = BatchSourceCommit(
                 commit_sha=commit_sha,
                 file_buffer=file_buffers[file_path],
@@ -226,7 +227,6 @@ def create_batch_source_commits(file_paths: list[str]) -> dict[str, BatchSourceC
                 mode=file_modes[file_path],
                 tree=None,
                 verified_content_len=content_len,
-                verified_lines=content_lines,
             )
         return_file_buffers = True
         return results
@@ -283,7 +283,6 @@ def create_batch_source_commit(
     file_buffer: LineBuffer | None = None
     close_file_buffer = True
     content_len = 0
-    content_lines = 0
     try:
         if file_buffer_override is not None:
             file_buffer = file_buffer_override
@@ -299,16 +298,17 @@ def create_batch_source_commit(
                 file_buffer = load_working_tree_file_as_buffer(file_path)
 
         content_len = file_buffer.byte_count
-        content_lines = len(file_buffer) if content_len else 0
-        log_journal(
-            "batch_source_creating",
-            file_path=file_path,
-            baseline_commit=baseline_commit,
-            file_existed_at_session_start=file_existed_at_session_start,
-            content_len=content_len,
-            content_lines=content_lines,
-            buffer_preview=_buffer_preview(file_buffer)
-        )
+        if journal_enabled():
+            fields = {
+                "file_path": file_path,
+                "baseline_commit": baseline_commit,
+                "file_existed_at_session_start": file_existed_at_session_start,
+                "content_len": content_len,
+            }
+            if journal_enabled(JournalLevel.CONTENT_DEBUG):
+                fields["content_lines"] = len(file_buffer) if content_len else 0
+                fields["buffer_preview"] = _buffer_preview(file_buffer)
+            log_journal("batch_source_creating", **fields)
 
         blob_sha = create_git_blob(file_buffer.byte_chunks())
     finally:
@@ -346,7 +346,6 @@ def create_batch_source_commit(
         mode=mode,
         tree=new_tree,
         verified_content_len=content_len,
-        verified_lines=content_lines,
     )
 
     return batch_source_commit

--- a/src/git_stage_batch/cli/journal_subcommands.py
+++ b/src/git_stage_batch/cli/journal_subcommands.py
@@ -1,0 +1,46 @@
+"""Diagnostic journal subcommand registration."""
+
+from __future__ import annotations
+
+from ..commands.journal import command_journal
+from ..i18n import _
+from .subcommand_parser import add_subcommand_parser
+
+
+def add_journal_subcommand(subparsers) -> None:
+    """Register the diagnostic journal management command."""
+    parser = add_subcommand_parser(
+        subparsers,
+        "journal",
+        help=_("Inspect or purge diagnostic journal data"),
+    )
+    action = parser.add_mutually_exclusive_group()
+    action.add_argument(
+        "--path",
+        action="store_true",
+        help=_("Print the journal path"),
+    )
+    action.add_argument(
+        "--purge",
+        action="store_true",
+        help=_("Delete journal data for this repository"),
+    )
+    parser.add_argument(
+        "--all",
+        dest="all_repositories",
+        action="store_true",
+        help=_("With --purge, delete journal data for all repositories"),
+    )
+    parser.add_argument(
+        "--porcelain",
+        action="store_true",
+        help=_("Output stable JSON"),
+    )
+    parser.set_defaults(
+        func=lambda args: command_journal(
+            path_only=args.path,
+            purge=args.purge,
+            all_repositories=args.all_repositories,
+            porcelain=args.porcelain,
+        )
+    )

--- a/src/git_stage_batch/cli/main.py
+++ b/src/git_stage_batch/cli/main.py
@@ -12,6 +12,7 @@ from ..i18n import _
 from ..runtime import dispatch_cli_mode
 from ..data.session_ownership import require_no_foreign_session_owner
 from ..utils.session_lock import acquire_session_lock
+from ..utils.journal import flush_journal
 from .argument_parser import parse_command_line
 from .pager import pager_output, should_page_output
 
@@ -70,6 +71,8 @@ def main() -> None:
     except KeyboardInterrupt:
         print(_("Interrupted."), file=sys.stderr)
         sys.exit(130)
+    finally:
+        flush_journal()
 
 
 if __name__ == "__main__":

--- a/src/git_stage_batch/cli/main.py
+++ b/src/git_stage_batch/cli/main.py
@@ -17,7 +17,14 @@ from .argument_parser import parse_command_line
 from .pager import pager_output, should_page_output
 
 
-_READ_ONLY_COMMANDS = frozenset({"check-unstaged", "list", "show", "status", "validate"})
+_READ_ONLY_COMMANDS = frozenset({
+    "check-unstaged",
+    "journal",
+    "list",
+    "show",
+    "status",
+    "validate",
+})
 
 
 def _command_may_mutate(args) -> bool:

--- a/src/git_stage_batch/cli/subcommand_registry.py
+++ b/src/git_stage_batch/cli/subcommand_registry.py
@@ -19,6 +19,7 @@ from .file_blocking_subcommands import (
     add_unblock_file_subcommand,
 )
 from .fixup_subcommands import add_suggest_fixup_subcommand
+from .journal_subcommands import add_journal_subcommand
 from .selection_subcommands import (
     add_discard_subcommand,
     add_include_subcommand,
@@ -59,6 +60,7 @@ def add_cli_subcommands(subparsers) -> None:
     add_new_subcommand(subparsers)
     add_list_subcommand(subparsers)
     add_validate_subcommand(subparsers)
+    add_journal_subcommand(subparsers)
     add_drop_subcommand(subparsers)
     add_annotate_subcommand(subparsers)
     add_apply_subcommand(subparsers)

--- a/src/git_stage_batch/commands/journal.py
+++ b/src/git_stage_batch/commands/journal.py
@@ -1,0 +1,66 @@
+"""Inspect and remove diagnostic journal data."""
+
+from __future__ import annotations
+
+import json
+
+from ..exceptions import CommandError
+from ..i18n import _
+from ..utils.journal import (
+    JournalLevel,
+    get_journal_level,
+    get_journal_path,
+    purge_journal,
+    summarize_journal,
+)
+
+
+def command_journal(
+    *,
+    path_only: bool = False,
+    purge: bool = False,
+    all_repositories: bool = False,
+    porcelain: bool = False,
+) -> None:
+    """Locate, summarize, or purge diagnostic journal data."""
+    if all_repositories and not purge:
+        raise CommandError(_("--all can only be used with --purge."))
+
+    if path_only:
+        path = str(get_journal_path())
+        if porcelain:
+            print(json.dumps({"path": path}, sort_keys=True))
+        else:
+            print(path)
+        return
+
+    if purge:
+        removed = purge_journal(all_repositories=all_repositories)
+        if porcelain:
+            print(json.dumps({"removed_file_count": removed}, sort_keys=True))
+        else:
+            print(
+                _("Removed {count} diagnostic journal file(s).").format(
+                    count=removed
+                )
+            )
+        return
+
+    summary = summarize_journal()
+    if porcelain:
+        print(json.dumps(summary, sort_keys=True))
+        return
+
+    print(_("Diagnostic journal"))
+    print(_("  Level: {level}").format(level=summary["level"]))
+    print(_("  Path: {path}").format(path=summary["path"]))
+    print(_("  Files: {count}").format(count=summary["file_count"]))
+    print(_("  Entries: {count}").format(count=summary["entry_count"]))
+    print(_("  Size: {count} bytes").format(count=summary["total_bytes"]))
+    if get_journal_level() == JournalLevel.CONTENT_DEBUG:
+        print(
+            _(
+                "  Warning: content-debug records raw paths and short content "
+                "previews."
+            )
+        )

--- a/src/git_stage_batch/data/selected_change/snapshots.py
+++ b/src/git_stage_batch/data/selected_change/snapshots.py
@@ -13,7 +13,7 @@ from ...core.buffer import (
 )
 from ...utils.repository_buffers import load_git_object_as_buffer
 from ...utils.git_repository import get_git_repository_root_path
-from ...utils.journal import log_journal
+from ...utils.journal import JournalLevel, journal_enabled, log_journal
 from ...utils.paths import get_index_snapshot_file_path, get_working_tree_snapshot_file_path
 
 
@@ -47,19 +47,19 @@ def write_snapshots_for_selected_file_path(file_path: str) -> None:
         write_buffer_to_path(get_index_snapshot_file_path(), index_version)
         write_buffer_to_path(get_working_tree_snapshot_file_path(), working_tree_version)
 
-        log_journal(
-            "write_snapshots_for_selected_file",
-            file_path=file_path,
-            index_len=buffer_byte_count(index_version),
-            index_lines=_buffer_line_count(index_version),
-            index_preview=(
-                buffer_preview(index_version)
-                if buffer_byte_count(index_version) > 0 else
-                "(empty)"
-            ),
-            working_tree_len=buffer_byte_count(working_tree_version),
-            working_tree_lines=_buffer_line_count(working_tree_version),
-        )
+        if journal_enabled():
+            fields = {
+                "file_path": file_path,
+                "index_len": buffer_byte_count(index_version),
+                "working_tree_len": buffer_byte_count(working_tree_version),
+            }
+            if journal_enabled(JournalLevel.CONTENT_DEBUG):
+                fields.update({
+                    "index_lines": _buffer_line_count(index_version),
+                    "index_preview": buffer_preview(index_version),
+                    "working_tree_lines": _buffer_line_count(working_tree_version),
+                })
+            log_journal("write_snapshots_for_selected_file", **fields)
 
 
 def _buffer_line_count(buffer: LineBuffer) -> int:

--- a/src/git_stage_batch/data/session.py
+++ b/src/git_stage_batch/data/session.py
@@ -25,9 +25,10 @@ from ..utils.file_io import (
 from ..utils.git_command import run_git_command
 from ..git_paths import decode_path, nul_records
 from ..utils.git_worktree import git_remove_paths
-from ..utils.git_index import git_add_paths
+from ..utils.git_index import git_add_paths_from_stdin
 from ..utils.git_repository import get_git_repository_root_path
-from ..utils.journal import log_journal
+from ..utils.journal import journal_enabled, log_journal
+from .index_entries import IndexEntry, read_index_entries
 from ..utils.paths import (
     get_abort_head_file_path,
     get_abort_snapshot_list_file_path,
@@ -54,6 +55,23 @@ SESSION_STATE_FILES = [
     "session",
     "journal.jsonl",
 ]
+
+
+def _journal_index_entries(
+    file_paths: list[str],
+    entries: dict[str, IndexEntry],
+) -> list[dict[str, str | None]]:
+    """Build structured index metadata while retaining input path order."""
+    return [
+        {
+            "path": file_path,
+            "mode": entries[file_path].mode if file_path in entries else None,
+            "object_id": (
+                entries[file_path].object_id if file_path in entries else None
+            ),
+        }
+        for file_path in file_paths
+    ]
 
 
 def active_session_marker_path(git_dir: Path | None = None) -> Path:
@@ -241,23 +259,28 @@ def _initialize_abort_state() -> None:
                 quiet=True,
                 check=False,
             )
-            for file_path in all_intent_to_add_files:
-                ls_before = run_git_command(
-                    ["ls-files", "--stage", "--", file_path],
-                    check=False,
-                    requires_index_lock=False,
-                ).stdout.strip()
-                git_add_paths([file_path], intent_to_add=True, check=False)
-                ls_after = run_git_command(
-                    ["ls-files", "--stage", "--", file_path],
-                    check=False,
-                    requires_index_lock=False,
-                ).stdout.strip()
+            index_before = (
+                read_index_entries(all_intent_to_add_files)
+                if journal_enabled()
+                else {}
+            )
+            git_add_paths_from_stdin(
+                all_intent_to_add_files,
+                intent_to_add=True,
+                check=False,
+            )
+            if journal_enabled():
                 log_journal(
-                    "session_re_add_intent_to_add",
-                    file_path=file_path,
-                    index_before=ls_before,
-                    index_after=ls_after,
+                    "session_re_add_intent_to_add_files",
+                    file_count=len(all_intent_to_add_files),
+                    index_entries_before=_journal_index_entries(
+                        all_intent_to_add_files,
+                        index_before,
+                    ),
+                    index_entries_after=_journal_index_entries(
+                        all_intent_to_add_files,
+                        read_index_entries(all_intent_to_add_files),
+                    ),
                 )
 
     if stash_returncode != 0:

--- a/src/git_stage_batch/staging/index_update.py
+++ b/src/git_stage_batch/staging/index_update.py
@@ -7,10 +7,17 @@ from ..core.buffer import (
     buffer_byte_count,
     buffer_preview,
 )
-from ..utils.git_command import run_git_command
+from ..data.index_entries import IndexEntry, read_index_entry
 from ..utils.git_index import git_update_index
 from ..utils.git_object_io import create_git_blob
-from ..utils.journal import log_journal
+from ..utils.journal import JournalLevel, journal_enabled, log_journal
+
+
+def _index_entry_fields(entry: IndexEntry | None) -> dict[str, str] | None:
+    """Convert an index entry to content-free journal fields."""
+    if entry is None:
+        return None
+    return {"mode": entry.mode, "object_id": entry.object_id}
 
 
 def update_index_with_blob_buffer(path: str, buffer: LineBuffer) -> None:
@@ -20,47 +27,23 @@ def update_index_with_blob_buffer(path: str, buffer: LineBuffer) -> None:
     Creates a temporary blob, hashes it, and updates the index entry.
     Preserves the file mode from the existing index entry if available.
     """
-    ls_before = run_git_command(
-        ["ls-files", "--stage", "--", path],
-        check=False,
-        requires_index_lock=False,
-    ).stdout.strip()
+    index_before = read_index_entry(path)
 
     blob_hash = create_git_blob(buffer.byte_chunks())
 
-    file_mode = ""
-    try:
-        ls_output = run_git_command(
-            ["ls-files", "-s", "--", path],
-            check=False,
-            requires_index_lock=False,
-        ).stdout.strip()
-        if ls_output:
-            file_mode = ls_output.split()[0]
-    except Exception:
-        file_mode = ""
-
-    if not file_mode:
-        file_mode = "100644"
+    file_mode = index_before.mode if index_before is not None else "100644"
 
     git_update_index(mode=file_mode, blob_sha=blob_hash, file_path=path)
 
-    ls_after = run_git_command(
-        ["ls-files", "--stage", "--", path],
-        check=False,
-        requires_index_lock=False,
-    ).stdout.strip()
-    log_journal(
-        "update_index_with_blob_buffer",
-        path=path,
-        content_len=buffer_byte_count(buffer),
-        buffer_preview=(
-            buffer_preview(buffer).decode("utf-8", errors="replace")
-            if buffer_byte_count(buffer) > 0 else
-            "(empty)"
-        ),
-        blob_hash=blob_hash,
-        file_mode=file_mode,
-        index_before=ls_before,
-        index_after=ls_after,
-    )
+    if journal_enabled():
+        fields = {
+            "path": path,
+            "content_len": buffer_byte_count(buffer),
+            "blob_hash": blob_hash,
+            "file_mode": file_mode,
+            "index_entry_before": _index_entry_fields(index_before),
+            "index_entry_after": _index_entry_fields(read_index_entry(path)),
+        }
+        if journal_enabled(JournalLevel.CONTENT_DEBUG):
+            fields["buffer_preview"] = buffer_preview(buffer)
+        log_journal("update_index_with_blob_buffer", **fields)

--- a/src/git_stage_batch/tui/interactive.py
+++ b/src/git_stage_batch/tui/interactive.py
@@ -7,6 +7,7 @@ import sys
 from ..exceptions import BypassRefresh, QuitInteractive
 from ..i18n import _
 from ..output.colors import Colors
+from ..utils.journal import flush_journal
 from . import current_change
 from .action_dispatch import dispatch_action
 from .flow import FlowLocation, LocationRole, FlowState
@@ -82,3 +83,5 @@ def start_interactive_mode() -> None:
             should_refresh = False
         except QuitInteractive:
             break
+        finally:
+            flush_journal()

--- a/src/git_stage_batch/utils/journal.py
+++ b/src/git_stage_batch/utils/journal.py
@@ -23,6 +23,12 @@ JOURNAL_LEVEL_ENV = "GIT_STAGE_BATCH_JOURNAL"
 JOURNAL_PATH_ENV = "GIT_STAGE_BATCH_JOURNAL_PATH"
 # Kept as a path-override alias for existing debugging setups.
 GLOBAL_JOURNAL_PATH_ENV = "GIT_STAGE_BATCH_GLOBAL_JOURNAL_PATH"
+JOURNAL_MAX_BYTES_ENV = "GIT_STAGE_BATCH_JOURNAL_MAX_BYTES"
+JOURNAL_RETENTION_DAYS_ENV = "GIT_STAGE_BATCH_JOURNAL_RETENTION_DAYS"
+
+DEFAULT_MAX_BYTES = 5 * 1024 * 1024
+DEFAULT_RETENTION_DAYS = 30
+MAX_ROTATED_FILES = 3
 BUFFER_FLUSH_BYTES = 64 * 1024
 MAX_CONTENT_FIELD_BYTES = 4 * 1024
 
@@ -133,6 +139,14 @@ def get_journal_path() -> Path:
         / "journals"
         / f"{_repository_id()}.jsonl"
     )
+
+
+def _positive_int_environment(name: str, default: int) -> int:
+    try:
+        value = int(os.environ.get(name, str(default)))
+    except ValueError:
+        return default
+    return value if value > 0 else default
 
 
 def _byte_count(value: Any) -> int | None:
@@ -314,6 +328,7 @@ class _JournalWriter:
             try:
                 os.fchmod(lock_fd, 0o600)
                 fcntl.flock(lock_fd, fcntl.LOCK_EX)
+                self._prune_and_rotate(len(payload))
                 journal_fd = os.open(
                     self.path,
                     os.O_WRONLY | os.O_CREAT | os.O_APPEND,
@@ -334,6 +349,41 @@ class _JournalWriter:
             pass
         finally:
             self._buffer.clear()
+
+    def _prune_and_rotate(self, incoming_bytes: int) -> None:
+        retention_seconds = _positive_int_environment(
+            JOURNAL_RETENTION_DAYS_ENV,
+            DEFAULT_RETENTION_DAYS,
+        ) * 24 * 60 * 60
+        cutoff = datetime.now(tz=timezone.utc).timestamp() - retention_seconds
+        for candidate in _journal_files(self.path):
+            try:
+                if candidate.stat().st_mtime < cutoff:
+                    candidate.unlink()
+            except OSError:
+                pass
+
+        max_bytes = _positive_int_environment(
+            JOURNAL_MAX_BYTES_ENV,
+            DEFAULT_MAX_BYTES,
+        )
+        try:
+            current_size = self.path.stat().st_size
+        except OSError:
+            current_size = 0
+        if current_size and current_size + incoming_bytes > max_bytes:
+            oldest = _rotated_path(self.path, MAX_ROTATED_FILES)
+            try:
+                oldest.unlink()
+            except FileNotFoundError:
+                pass
+            for number in range(MAX_ROTATED_FILES - 1, 0, -1):
+                source = _rotated_path(self.path, number)
+                if source.exists():
+                    source.replace(_rotated_path(self.path, number + 1))
+            if self.path.exists():
+                self.path.replace(_rotated_path(self.path, 1))
+
 
 _WRITERS: dict[Path, _JournalWriter] = {}
 _WRITERS_LOCK = threading.Lock()
@@ -386,6 +436,20 @@ def flush_journal() -> None:
         writers = list(_WRITERS.values())
     for writer in writers:
         writer.flush()
+
+
+def _rotated_path(path: Path, number: int) -> Path:
+    return path.with_name(f"{path.name}.{number}")
+
+
+def _journal_files(path: Path) -> list[Path]:
+    return [
+        path,
+        *[
+            _rotated_path(path, number)
+            for number in range(1, MAX_ROTATED_FILES + 1)
+        ],
+    ]
 
 
 def _reset_journal_state_for_tests() -> None:

--- a/src/git_stage_batch/utils/journal.py
+++ b/src/git_stage_batch/utils/journal.py
@@ -11,6 +11,7 @@ import os
 import sys
 import threading
 import traceback
+from collections import Counter
 from datetime import datetime, timezone
 from enum import IntEnum
 from pathlib import Path
@@ -450,6 +451,78 @@ def _journal_files(path: Path) -> list[Path]:
             for number in range(1, MAX_ROTATED_FILES + 1)
         ],
     ]
+
+
+def summarize_journal() -> dict[str, Any]:
+    """Return content-free statistics for the current repository journal."""
+    flush_journal()
+    path = get_journal_path()
+    operations: Counter[str] = Counter()
+    entry_count = 0
+    total_bytes = 0
+    oldest: str | None = None
+    newest: str | None = None
+    file_count = 0
+    for journal_file in reversed(_journal_files(path)):
+        try:
+            total_bytes += journal_file.stat().st_size
+            file_count += 1
+            with journal_file.open("r", encoding="utf-8") as stream:
+                for line in stream:
+                    try:
+                        entry = json.loads(line)
+                    except (json.JSONDecodeError, UnicodeDecodeError):
+                        continue
+                    entry_count += 1
+                    operation = entry.get("operation")
+                    if isinstance(operation, str):
+                        operations[operation] += 1
+                    timestamp = entry.get("timestamp")
+                    if isinstance(timestamp, str):
+                        oldest = timestamp if oldest is None else min(oldest, timestamp)
+                        newest = timestamp if newest is None else max(newest, timestamp)
+        except OSError:
+            continue
+    return {
+        "enabled": journal_enabled(),
+        "level": journal_level_name(),
+        "path": str(path),
+        "exists": file_count > 0,
+        "file_count": file_count,
+        "total_bytes": total_bytes,
+        "entry_count": entry_count,
+        "oldest_timestamp": oldest,
+        "newest_timestamp": newest,
+        "operations": dict(sorted(operations.items())),
+    }
+
+
+def purge_journal(*, all_repositories: bool = False) -> int:
+    """Delete diagnostic data and return the number of journal files removed."""
+    path = get_journal_path()
+    with _WRITERS_LOCK:
+        writers = list(_WRITERS.values())
+    for writer in writers:
+        writer.discard_buffer()
+
+    candidates: list[Path]
+    if all_repositories and not (
+        os.environ.get(JOURNAL_PATH_ENV) or os.environ.get(GLOBAL_JOURNAL_PATH_ENV)
+    ):
+        candidates = list(path.parent.glob("*.jsonl"))
+        for number in range(1, MAX_ROTATED_FILES + 1):
+            candidates.extend(path.parent.glob(f"*.jsonl.{number}"))
+    else:
+        candidates = _journal_files(path)
+
+    removed = 0
+    for candidate in candidates:
+        try:
+            candidate.unlink()
+            removed += 1
+        except FileNotFoundError:
+            pass
+    return removed
 
 
 def _reset_journal_state_for_tests() -> None:

--- a/src/git_stage_batch/utils/journal.py
+++ b/src/git_stage_batch/utils/journal.py
@@ -1,131 +1,399 @@
-"""Debug journal for tracking all operations."""
+"""Low-overhead, privacy-conscious diagnostic journal."""
 
 from __future__ import annotations
 
+import atexit
+import base64
+import fcntl
+import hashlib
 import json
 import os
+import sys
+import threading
 import traceback
-from datetime import datetime
+from datetime import datetime, timezone
+from enum import IntEnum
 from pathlib import Path
 from typing import Any
 
-from .git_command import run_git_command
-from ..git_paths import decode_path, nul_records
-from .paths import get_state_directory_path
+from .git_repository import get_git_common_directory_path
 
 
+JOURNAL_LEVEL_ENV = "GIT_STAGE_BATCH_JOURNAL"
+JOURNAL_PATH_ENV = "GIT_STAGE_BATCH_JOURNAL_PATH"
+# Kept as a path-override alias for existing debugging setups.
 GLOBAL_JOURNAL_PATH_ENV = "GIT_STAGE_BATCH_GLOBAL_JOURNAL_PATH"
-DEFAULT_GLOBAL_JOURNAL_PATH = Path("/var/tmp/git-stage-batch-journal.jsonl")
+BUFFER_FLUSH_BYTES = 64 * 1024
+MAX_CONTENT_FIELD_BYTES = 4 * 1024
 
 
-def _get_journal_path() -> Path:
-    """Get path to journal file."""
-    return get_state_directory_path() / "journal.jsonl"
+class JournalLevel(IntEnum):
+    """Amount of diagnostic information retained by the journal."""
+
+    DISABLED = 0
+    METADATA_ONLY = 1
+    VERBOSE = 2
+    CONTENT_DEBUG = 3
 
 
-def _get_global_journal_path() -> Path:
-    """Get path to the cross-repository debug journal file."""
-    override = os.environ.get(GLOBAL_JOURNAL_PATH_ENV)
+_LEVEL_NAMES = {
+    JournalLevel.DISABLED: "disabled",
+    JournalLevel.METADATA_ONLY: "metadata-only",
+    JournalLevel.VERBOSE: "verbose",
+    JournalLevel.CONTENT_DEBUG: "content-debug",
+}
+_LEVEL_VALUES = {name: level for level, name in _LEVEL_NAMES.items()}
+_LEVEL_VALUES.update({
+    "off": JournalLevel.DISABLED,
+    "0": JournalLevel.DISABLED,
+    "metadata": JournalLevel.METADATA_ONLY,
+    "1": JournalLevel.METADATA_ONLY,
+    "2": JournalLevel.VERBOSE,
+    "content": JournalLevel.CONTENT_DEBUG,
+    "3": JournalLevel.CONTENT_DEBUG,
+})
+
+_CONTENT_FIELDS = frozenset({
+    "content",
+    "raw_content",
+    "stderr",
+    "stdout",
+    "detail",
+    "index_before",
+    "index_after",
+})
+_PATH_FIELDS = frozenset({
+    "file_path",
+    "filename",
+    "path",
+    "repo",
+    "files",
+    "renames",
+    "deletions",
+})
+_REPOSITORY_IDS: dict[Path, str] = {}
+
+
+def get_journal_level() -> JournalLevel:
+    """Return the configured journal level without doing filesystem work."""
+    configured = os.environ.get(JOURNAL_LEVEL_ENV)
+    if configured is None:
+        # Preserve the old debugging switch without making content capture implicit.
+        return (
+            JournalLevel.VERBOSE
+            if os.environ.get("GIT_STAGE_BATCH_DEBUG")
+            else JournalLevel.DISABLED
+        )
+    return _LEVEL_VALUES.get(configured.strip().lower(), JournalLevel.DISABLED)
+
+
+def journal_level_name(level: JournalLevel | None = None) -> str:
+    """Return the public name for a journal level."""
+    return _LEVEL_NAMES[level if level is not None else get_journal_level()]
+
+
+def journal_enabled(minimum: JournalLevel = JournalLevel.METADATA_ONLY) -> bool:
+    """Cheap guard for call sites that would otherwise construct diagnostics."""
+    return get_journal_level() >= minimum
+
+
+def _state_home() -> Path:
+    override = os.environ.get("XDG_STATE_HOME")
+    if override:
+        return Path(override).expanduser().absolute()
+    return Path.home() / ".local" / "state"
+
+
+def _repository_id() -> str:
+    """Return a stable repository identifier without exposing its path."""
+    cwd = Path.cwd()
+    cached = _REPOSITORY_IDS.get(cwd)
+    if cached is not None:
+        return cached
+    try:
+        identity = os.fsencode(get_git_common_directory_path().resolve())
+    except Exception:
+        identity = os.fsencode(cwd.resolve())
+    repository_id = hashlib.sha256(identity).hexdigest()[:24]
+    _REPOSITORY_IDS[cwd] = repository_id
+    return repository_id
+
+
+def get_journal_path() -> Path:
+    """Return the current repository's private diagnostic journal path."""
+    override = (
+        os.environ.get(JOURNAL_PATH_ENV)
+        or os.environ.get(GLOBAL_JOURNAL_PATH_ENV)
+    )
     if override:
         return Path(override)
-    return DEFAULT_GLOBAL_JOURNAL_PATH
+    return (
+        _state_home()
+        / "git-stage-batch"
+        / "journals"
+        / f"{_repository_id()}.jsonl"
+    )
 
 
-def _get_index_state(file_path: str | None = None) -> dict[str, Any]:
-    """Get selected index state for a file or all files."""
-    try:
-        if file_path:
-            ls_result = run_git_command(
-                ["ls-files", "--stage", "-z", "--", file_path],
-                check=False,
-                text_output=False,
-                requires_index_lock=False,
-            )
-        else:
-            ls_result = run_git_command(
-                ["ls-files", "--stage", "-z"],
-                check=False,
-                text_output=False,
-                requires_index_lock=False,
-            )
-
-        if ls_result.stdout:
-            entries = []
-            for record in nul_records(ls_result.stdout):
-                metadata, separator, path = record.partition(b"\t")
-                parts = metadata.decode("ascii", errors="replace").split()
-                if separator and len(parts) >= 3:
-                    entries.append({
-                        "mode": parts[0],
-                        "hash": parts[1],
-                        "stage": parts[2],
-                        "path": decode_path(path),
-                    })
-            return entries[0] if file_path and entries else entries
-        return {"status": "not_in_index"} if file_path else []
-    except Exception as e:
-        return {"error": str(e)}
+def _byte_count(value: Any) -> int | None:
+    if isinstance(value, bytes):
+        return len(value)
+    if isinstance(value, str):
+        return len(value.encode("utf-8", errors="surrogateescape"))
+    return None
 
 
-def log_journal(operation: str, **kwargs: Any) -> None:
-    """Log an operation to the journal.
+def _redacted_content(value: Any) -> dict[str, Any]:
+    result: dict[str, Any] = {"redacted": True}
+    byte_count = _byte_count(value)
+    if byte_count is not None:
+        result["byte_count"] = byte_count
+    elif isinstance(value, (list, tuple, dict)):
+        result["item_count"] = len(value)
+    return result
 
-    Always writes to session journal: .git/git-stage-batch/journal.jsonl
-    (cleared by abort, preserved by again)
 
-    If GIT_STAGE_BATCH_DEBUG environment variable is set, also writes to
-    global journal: /var/tmp/git-stage-batch-journal.jsonl by default
-    (persists across sessions and repositories, useful for debugging).
-    Tests and callers can override the global path with
-    GIT_STAGE_BATCH_GLOBAL_JOURNAL_PATH.
+def _path_identifier(value: str | bytes) -> dict[str, str]:
+    if isinstance(value, bytes):
+        raw = value
+    else:
+        raw = os.path.normpath(value).encode("utf-8", errors="surrogateescape")
+    return {"path_id": hashlib.sha256(raw).hexdigest()[:16]}
 
-    Args:
-        operation: Name of the operation
-        **kwargs: Additional context to log
-    """
-    try:
-        # Add stack trace to show call chain
-        stack = traceback.extract_stack()
-        # Filter to only our code
-        filtered_stack = [
-            {"file": s.filename.split("/")[-1], "line": s.lineno, "func": s.name}
-            for s in stack
-            if "git_stage_batch" in s.filename
-        ][-5:]  # Last 5 frames
 
-        entry = {
-            "timestamp": datetime.now().isoformat(),
-            "pid": os.getpid(),
-            "operation": operation,
-            "stack": filtered_stack,
-            **kwargs
+def _redact_paths(value: Any) -> Any:
+    if isinstance(value, (str, bytes)):
+        return _path_identifier(value)
+    if isinstance(value, (list, tuple, set)):
+        return [_redact_paths(item) for item in value]
+    if isinstance(value, dict):
+        return [
+            {"from": _redact_paths(key), "to": _redact_paths(item)}
+            for key, item in value.items()
+        ]
+    return _json_safe(value, include_content=False)
+
+
+def _json_safe(value: Any, *, include_content: bool) -> Any:
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, bytes):
+        if not include_content:
+            return _redacted_content(value)
+        return _bounded_content(value)
+    if isinstance(value, dict):
+        return {
+            str(key): _json_safe(item, include_content=include_content)
+            for key, item in value.items()
         }
+    if isinstance(value, (list, tuple, set)):
+        return [_json_safe(item, include_content=include_content) for item in value]
+    return {"type": type(value).__name__}
 
-        # Write to session journal
-        journal_path = _get_journal_path()
-        journal_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(journal_path, "a") as f:
-            f.write(json.dumps(entry) + "\n")
 
-        # Write to global persistent journal if debug mode enabled
-        if os.environ.get("GIT_STAGE_BATCH_DEBUG"):
-            # Get repository path for global journal (to distinguish different repos)
-            repo_path = None
+def _sanitize_fields(fields: dict[str, Any], level: JournalLevel) -> dict[str, Any]:
+    include_content = level >= JournalLevel.CONTENT_DEBUG
+    return {
+        key: _sanitize_value(key, value, include_content=include_content)
+        for key, value in fields.items()
+    }
+
+
+def _sanitize_value(key: str, value: Any, *, include_content: bool) -> Any:
+    is_preview = key.endswith("preview") or key.endswith("_preview")
+    is_content = key in _CONTENT_FIELDS or is_preview
+    is_path = (
+        key in _PATH_FIELDS
+        or key.endswith("_path")
+        or key.endswith("_paths")
+        or key.endswith("_files")
+    )
+    if is_content and not include_content:
+        return _redacted_content(value)
+    if is_content:
+        return _bounded_content(value)
+    if is_path and not include_content:
+        return _redact_paths(value)
+    if isinstance(value, dict):
+        return {
+            str(nested_key): _sanitize_value(
+                str(nested_key),
+                nested_value,
+                include_content=include_content,
+            )
+            for nested_key, nested_value in value.items()
+        }
+    if isinstance(value, (list, tuple, set)):
+        return [
+            _sanitize_value(key, item, include_content=include_content)
+            for item in value
+        ]
+    return _json_safe(value, include_content=include_content)
+
+
+def _bounded_content(value: Any) -> Any:
+    """Encode explicitly enabled content without allowing one huge entry."""
+    if isinstance(value, bytes):
+        content = value[:MAX_CONTENT_FIELD_BYTES]
+        result: dict[str, Any] = {
+            "encoding": "base64",
+            "data": base64.b64encode(content).decode("ascii"),
+        }
+        if len(value) > len(content):
+            result.update({
+                "truncated": True,
+                "original_byte_count": len(value),
+            })
+        return result
+    if isinstance(value, str):
+        encoded = value.encode("utf-8", errors="surrogateescape")
+        if len(encoded) <= MAX_CONTENT_FIELD_BYTES:
+            return value
+        prefix = encoded[:MAX_CONTENT_FIELD_BYTES]
+        return {
+            "text": prefix.decode("utf-8", errors="replace"),
+            "truncated": True,
+            "original_byte_count": len(encoded),
+        }
+    return _json_safe(value, include_content=True)
+
+
+def _source_identifier(frame) -> str:
+    module = frame.f_globals.get("__name__", "unknown")
+    return f"{module}:{frame.f_code.co_name}"
+
+
+def _bounded_stack() -> list[dict[str, Any]]:
+    frames = traceback.extract_stack(limit=10)[:-2]
+    return [
+        {
+            "source": Path(item.filename).name,
+            "line": item.lineno,
+            "function": item.name,
+        }
+        for item in frames
+    ][-6:]
+
+
+def _is_error_operation(operation: str) -> bool:
+    lowered = operation.lower()
+    return any(word in lowered for word in ("error", "fail", "exception"))
+
+
+class _JournalWriter:
+    """Buffer journal lines and serialize cross-process flushes."""
+
+    def __init__(self, path: Path):
+        self.path = path
+        self._buffer = bytearray()
+        self._lock = threading.RLock()
+
+    def append(self, line: bytes) -> None:
+        with self._lock:
+            self._buffer.extend(line)
+            if len(self._buffer) >= BUFFER_FLUSH_BYTES:
+                self._flush_locked()
+
+    def flush(self) -> None:
+        with self._lock:
+            self._flush_locked()
+
+    def discard_buffer(self) -> None:
+        with self._lock:
+            self._buffer.clear()
+
+    def _flush_locked(self) -> None:
+        if not self._buffer:
+            return
+        payload = bytes(self._buffer)
+        try:
+            self.path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+            os.chmod(self.path.parent, 0o700)
+            lock_path = self.path.with_name(f"{self.path.name}.lock")
+            lock_fd = os.open(lock_path, os.O_WRONLY | os.O_CREAT, 0o600)
             try:
-                result = run_git_command(["rev-parse", "--show-toplevel"], check=False, requires_index_lock=False)
-                if result.returncode == 0:
-                    repo_path = result.stdout.strip()
-            except Exception:
-                pass
+                os.fchmod(lock_fd, 0o600)
+                fcntl.flock(lock_fd, fcntl.LOCK_EX)
+                journal_fd = os.open(
+                    self.path,
+                    os.O_WRONLY | os.O_CREAT | os.O_APPEND,
+                    0o600,
+                )
+                try:
+                    os.fchmod(journal_fd, 0o600)
+                    view = memoryview(payload)
+                    while view:
+                        view = view[os.write(journal_fd, view):]
+                finally:
+                    os.close(journal_fd)
+            finally:
+                os.close(lock_fd)
+        except Exception:
+            # Diagnostics must never change command behavior. Drop failed entries so
+            # an unwritable destination cannot grow the process heap indefinitely.
+            pass
+        finally:
+            self._buffer.clear()
 
-            global_journal_path = _get_global_journal_path()
-            global_journal_path.parent.mkdir(parents=True, exist_ok=True)
-            global_entry = {
-                "repo": repo_path,
-                **entry
-            }
-            with open(global_journal_path, "a") as f:
-                f.write(json.dumps(global_entry) + "\n")
+_WRITERS: dict[Path, _JournalWriter] = {}
+_WRITERS_LOCK = threading.Lock()
+
+
+def _writer(path: Path) -> _JournalWriter:
+    with _WRITERS_LOCK:
+        writer = _WRITERS.get(path)
+        if writer is None:
+            writer = _JournalWriter(path)
+            _WRITERS[path] = writer
+        return writer
+
+
+def log_journal(operation: str, **fields: Any) -> None:
+    """Queue a structured diagnostic event when journaling is enabled."""
+    level = get_journal_level()
+    if level == JournalLevel.DISABLED:
+        return
+    try:
+        caller = sys._getframe(1)
+        entry: dict[str, Any] = {
+            "timestamp": (
+                datetime.now(tz=timezone.utc)
+                .isoformat()
+                .replace("+00:00", "Z")
+            ),
+            "pid": os.getpid(),
+            "repository_id": _repository_id(),
+            "level": journal_level_name(level),
+            "operation": operation,
+            "source": _source_identifier(caller),
+            "fields": _sanitize_fields(fields, level),
+        }
+        if level >= JournalLevel.VERBOSE or _is_error_operation(operation):
+            entry["stack"] = _bounded_stack()
+        encoded = (
+            json.dumps(entry, separators=(",", ":"), sort_keys=True)
+            .encode("utf-8")
+            + b"\n"
+        )
+        _writer(get_journal_path()).append(encoded)
     except Exception:
-        # Never let journal logging break the actual operation
         pass
+
+
+def flush_journal() -> None:
+    """Flush queued events at a command or interactive-action boundary."""
+    with _WRITERS_LOCK:
+        writers = list(_WRITERS.values())
+    for writer in writers:
+        writer.flush()
+
+
+def _reset_journal_state_for_tests() -> None:
+    """Discard process-global writers after environment changes in tests."""
+    global _WRITERS, _REPOSITORY_IDS
+    with _WRITERS_LOCK:
+        _WRITERS = {}
+        _REPOSITORY_IDS = {}
+
+
+atexit.register(flush_journal)

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -531,7 +531,6 @@ def test_staging_index_update_owns_git_index_mutation():
         fromlist=["index_update"],
     )
     mutation_modules = {
-        "git_stage_batch.utils.git_command",
         "git_stage_batch.utils.git_index",
         "git_stage_batch.utils.git_object_io",
         "git_stage_batch.utils.journal",
@@ -550,6 +549,8 @@ def test_staging_index_update_owns_git_index_mutation():
     assert "update_index_with_blob_buffer" in vars(index_update)
     assert content_buffer_imports.isdisjoint(mutation_modules)
     assert mutation_modules <= index_update_imports
+    assert "git_stage_batch.data.index_entries" in index_update_imports
+    assert "git_stage_batch.utils.git_command" not in index_update_imports
 
 
 def test_replacement_payload_imports_use_core_boundary():

--- a/tests/cli/test_completion.py
+++ b/tests/cli/test_completion.py
@@ -1,5 +1,7 @@
 """Tests for CLI completion helpers."""
 
+from pathlib import Path
+
 from git_stage_batch.cli.completion import list_file_completion_candidates
 
 
@@ -52,3 +54,13 @@ def test_list_file_completion_candidates_treats_wildmatch_as_directory_prefix(mo
 
     assert "src/auth.py" in candidates
     assert "src/core/" in candidates
+
+
+def test_bash_completion_covers_journal_command_and_options():
+    """Installed Bash completion should expose diagnostic journal controls."""
+    completion = (
+        Path(__file__).resolve().parents[2] / "completions" / "git-stage-batch"
+    ).read_text()
+
+    assert 'validate journal"' in completion
+    assert "--path --purge --all --porcelain" in completion

--- a/tests/commands/test_journal.py
+++ b/tests/commands/test_journal.py
@@ -1,0 +1,55 @@
+"""Tests for diagnostic journal management."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+
+from git_stage_batch.commands.journal import command_journal
+from git_stage_batch.exceptions import CommandError
+from git_stage_batch.utils import journal
+from git_stage_batch.utils.journal import JOURNAL_LEVEL_ENV, JOURNAL_PATH_ENV, flush_journal, log_journal
+
+
+@pytest.fixture
+def temp_git_repo(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    subprocess.run(["git", "init"], check=True, capture_output=True)
+    monkeypatch.setenv(JOURNAL_PATH_ENV, str(tmp_path / "state" / "journal.jsonl"))
+    monkeypatch.setenv(JOURNAL_LEVEL_ENV, "metadata-only")
+    journal._reset_journal_state_for_tests()
+    yield tmp_path
+    journal._reset_journal_state_for_tests()
+
+
+def test_journal_command_reports_json_summary(temp_git_repo, capsys):
+    log_journal("sample")
+    flush_journal()
+
+    command_journal(porcelain=True)
+
+    report = json.loads(capsys.readouterr().out)
+    assert report["entry_count"] == 1
+    assert report["level"] == "metadata-only"
+
+
+def test_journal_command_prints_path(temp_git_repo, capsys):
+    command_journal(path_only=True)
+
+    assert capsys.readouterr().out.strip().endswith("state/journal.jsonl")
+
+
+def test_journal_command_purges_data(temp_git_repo, capsys):
+    log_journal("sample")
+    flush_journal()
+
+    command_journal(purge=True, porcelain=True)
+
+    assert json.loads(capsys.readouterr().out) == {"removed_file_count": 1}
+
+
+def test_all_requires_purge(temp_git_repo):
+    with pytest.raises(CommandError, match="--all"):
+        command_journal(all_repositories=True)

--- a/tests/staging/test_index_update.py
+++ b/tests/staging/test_index_update.py
@@ -5,7 +5,9 @@ import subprocess
 import pytest
 
 from git_stage_batch.core.buffer import LineBuffer
+from git_stage_batch.staging import index_update
 from git_stage_batch.staging.index_update import update_index_with_blob_buffer
+from git_stage_batch.utils.journal import JOURNAL_LEVEL_ENV
 from git_stage_batch.utils.paths import ensure_state_directory_exists
 
 
@@ -212,3 +214,29 @@ class TestUpdateIndexWithBlobContent:
             text=True,
         )
         assert result.stdout == "generated\ncontent\n"
+
+    def test_disabled_journal_does_not_add_index_observations_or_previews(
+        self,
+        temp_git_repo,
+        monkeypatch,
+    ):
+        """Normal index updates should perform only the mode lookup they need."""
+        monkeypatch.delenv(JOURNAL_LEVEL_ENV, raising=False)
+        monkeypatch.delenv("GIT_STAGE_BATCH_DEBUG", raising=False)
+        original_read = index_update.read_index_entry
+        observed_paths = []
+
+        def recording_read(file_path):
+            observed_paths.append(file_path)
+            return original_read(file_path)
+
+        monkeypatch.setattr(index_update, "read_index_entry", recording_read)
+        monkeypatch.setattr(
+            index_update,
+            "buffer_preview",
+            lambda _buffer: pytest.fail("constructed a journal preview"),
+        )
+
+        _update_index_with_bytes("newfile.txt", b"content\n")
+
+        assert observed_paths == ["newfile.txt"]

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -79,6 +79,31 @@ def test_validate_man_page_generated(tmp_path):
     assert "porcelain" in content
 
 
+def test_journal_man_page_generated(tmp_path):
+    """The diagnostic journal command should ship its dedicated manual."""
+    project_root = Path(__file__).parent.parent
+    build_dir = tmp_path / "build"
+
+    subprocess.run(
+        ["meson", "setup", str(build_dir)],
+        cwd=project_root,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["meson", "compile", "-C", str(build_dir)],
+        cwd=project_root,
+        check=True,
+        capture_output=True,
+    )
+
+    man_page = build_dir / "git-stage-batch-journal.1"
+    assert man_page.exists()
+    content = man_page.read_text(encoding="utf-8")
+    assert "diagnostic journal data" in content
+    assert "content-debug" in content
+
+
 def test_package_importable_from_build(tmp_path):
     """Test that the package can be imported from the build directory."""
     project_root = Path(__file__).parent.parent

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -83,6 +83,7 @@ class TestWheelContents:
             'git-stage-batch-include.1',
             'git-stage-batch-discard.1',
             'git-stage-batch-install-assets.1',
+            'git-stage-batch-journal.1',
             'git-stage-batch-validate.1',
         }
 

--- a/tests/utils/test_journal.py
+++ b/tests/utils/test_journal.py
@@ -6,6 +6,8 @@ import json
 import os
 import stat
 import subprocess
+import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -14,7 +16,9 @@ from git_stage_batch.commands.start import command_start
 from git_stage_batch.utils import journal
 from git_stage_batch.utils.journal import (
     JOURNAL_LEVEL_ENV,
+    JOURNAL_MAX_BYTES_ENV,
     JOURNAL_PATH_ENV,
+    JOURNAL_RETENTION_DAYS_ENV,
     JournalLevel,
     flush_journal,
     get_journal_path,
@@ -176,6 +180,41 @@ def test_journal_uses_private_permissions(temp_git_repo, monkeypatch):
     assert stat.S_IMODE(path.stat().st_mode) == 0o600
 
 
+def test_rotation_bounds_journal_files(temp_git_repo, monkeypatch):
+    monkeypatch.setenv(JOURNAL_LEVEL_ENV, "metadata-only")
+    monkeypatch.setenv(JOURNAL_MAX_BYTES_ENV, "300")
+
+    for number in range(8):
+        log_journal("rotation_event", number=number, padding="x" * 100)
+        flush_journal()
+
+    path = get_journal_path()
+    files = [
+        candidate
+        for candidate in path.parent.iterdir()
+        if ".jsonl" in candidate.name and not candidate.name.endswith(".lock")
+    ]
+    assert len(files) <= 4
+    assert path.exists()
+
+
+def test_expired_rotated_journals_are_removed(temp_git_repo, monkeypatch):
+    monkeypatch.setenv(JOURNAL_LEVEL_ENV, "metadata-only")
+    monkeypatch.setenv(JOURNAL_RETENTION_DAYS_ENV, "1")
+    path = get_journal_path()
+    path.parent.mkdir()
+    expired = path.with_name(f"{path.name}.1")
+    expired.write_text('{"operation":"expired"}\n')
+    old_time = time.time() - 2 * 24 * 60 * 60
+    os.utime(expired, (old_time, old_time))
+
+    log_journal("current")
+    flush_journal()
+
+    assert not expired.exists()
+    assert path.exists()
+
+
 def test_default_path_is_private_per_user_and_uses_repository_id(
     temp_git_repo,
     monkeypatch,
@@ -209,3 +248,40 @@ def test_journal_logging_failure_never_breaks_operation(temp_git_repo, monkeypat
 
     log_journal("unwritable_destination")
     flush_journal()
+
+
+def test_concurrent_processes_write_complete_json_lines(temp_git_repo, monkeypatch):
+    monkeypatch.setenv(JOURNAL_LEVEL_ENV, "metadata-only")
+    path = get_journal_path()
+    environment = os.environ.copy()
+    code = (
+        "from git_stage_batch.utils.journal import log_journal, flush_journal; "
+        "[log_journal('child', number=n) for n in range(20)]; flush_journal()"
+    )
+
+    processes = [
+        subprocess.Popen([sys.executable, "-c", code], env=environment)
+        for _ in range(4)
+    ]
+    assert all(process.wait() == 0 for process in processes)
+
+    entries = _entries(path)
+    assert len(entries) == 80
+    assert all(entry["operation"] == "child" for entry in entries)
+
+
+def test_abrupt_exit_may_lose_events_since_last_boundary(temp_git_repo, monkeypatch):
+    """Journal buffering is not part of repository-state crash durability."""
+    monkeypatch.setenv(JOURNAL_LEVEL_ENV, "metadata-only")
+    path = get_journal_path()
+    environment = os.environ.copy()
+    code = (
+        "import os; "
+        "from git_stage_batch.utils.journal import log_journal; "
+        "log_journal('not_flushed'); os._exit(0)"
+    )
+
+    result = subprocess.run([sys.executable, "-c", code], env=environment)
+
+    assert result.returncode == 0
+    assert not path.exists()

--- a/tests/utils/test_journal.py
+++ b/tests/utils/test_journal.py
@@ -1,171 +1,211 @@
-"""Tests for journal logging."""
+"""Tests for low-overhead, privacy-conscious journal logging."""
 
-from git_stage_batch.utils.paths import ensure_state_directory_exists
+from __future__ import annotations
 
 import json
+import os
+import stat
 import subprocess
+from pathlib import Path
 
 import pytest
 
 from git_stage_batch.commands.start import command_start
-from git_stage_batch.utils.journal import GLOBAL_JOURNAL_PATH_ENV, log_journal
-from git_stage_batch.utils.paths import get_state_directory_path
+from git_stage_batch.utils import journal
+from git_stage_batch.utils.journal import (
+    JOURNAL_LEVEL_ENV,
+    JOURNAL_PATH_ENV,
+    JournalLevel,
+    flush_journal,
+    get_journal_path,
+    journal_enabled,
+    log_journal,
+)
 
 
 @pytest.fixture
 def temp_git_repo(tmp_path, monkeypatch):
-    """Create a temporary git repository for testing."""
+    """Create a temporary Git repository with an isolated journal."""
     monkeypatch.chdir(tmp_path)
     subprocess.run(["git", "init"], check=True, capture_output=True)
     subprocess.run(["git", "config", "user.name", "Test User"], check=True)
     subprocess.run(["git", "config", "user.email", "test@example.com"], check=True)
-
-    # Create initial commit
     (tmp_path / "README.md").write_text("# Test\n")
     subprocess.run(["git", "add", "README.md"], check=True)
     subprocess.run(["git", "commit", "-m", "initial"], check=True, capture_output=True)
-
-    return tmp_path
-
-
-@pytest.fixture
-def global_journal_path(tmp_path, monkeypatch):
-    """Provide an isolated global journal path for tests."""
-    path = tmp_path / "journals" / "global.jsonl"
-    monkeypatch.setenv(GLOBAL_JOURNAL_PATH_ENV, str(path))
-    return path
+    monkeypatch.setenv(JOURNAL_PATH_ENV, str(tmp_path / "private" / "journal.jsonl"))
+    journal._reset_journal_state_for_tests()
+    yield tmp_path
+    journal._reset_journal_state_for_tests()
 
 
-class TestJournal:
-    """Tests for journal logging."""
+def _entries(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text().splitlines()]
 
-    def test_journal_always_logs_to_session(self, temp_git_repo):
-        """Test that journal always logs to session journal."""
-        # Make changes for start
-        (temp_git_repo / "README.md").write_text("# Test\nmodified\n")
-        command_start()
 
-        state_dir = get_state_directory_path()
-        journal_file = state_dir / "journal.jsonl"
+def test_journal_is_disabled_without_opt_in(temp_git_repo, monkeypatch):
+    path = get_journal_path()
+    monkeypatch.delenv(JOURNAL_LEVEL_ENV, raising=False)
+    monkeypatch.delenv("GIT_STAGE_BATCH_DEBUG", raising=False)
+    monkeypatch.setattr(
+        journal.sys,
+        "_getframe",
+        lambda _depth: pytest.fail("inspected frame"),
+    )
 
-        # Session journal should exist
-        assert journal_file.exists(), "Session journal should be created"
+    for _ in range(1000):
+        log_journal("disabled_event", path="secret.txt")
+    flush_journal()
 
-        # Should have content
-        content = journal_file.read_text()
-        assert content, "Session journal should have content"
+    assert not path.exists()
+    assert not path.parent.exists()
 
-        # Should be valid JSON lines
-        lines = [line for line in content.strip().split('\n') if line]
-        for line in lines:
-            entry = json.loads(line)
-            assert "timestamp" in entry
-            assert "operation" in entry
 
-    def test_journal_global_only_with_debug_env(
-        self,
-        temp_git_repo,
-        monkeypatch,
-        global_journal_path,
-    ):
-        """Test that global journal only logs when GIT_STAGE_BATCH_DEBUG is set."""
+def test_metadata_journal_redacts_paths_content_and_command_output(
+    temp_git_repo,
+    monkeypatch,
+):
+    monkeypatch.setenv(JOURNAL_LEVEL_ENV, "metadata-only")
+    path = get_journal_path()
 
-        # Ensure state directory exists
-        ensure_state_directory_exists()
+    log_journal(
+        "metadata_event",
+        file_path="private/customer.txt",
+        buffer_preview=b"account-token",
+        stderr="password=secret",
+        object_id="abc123",
+        content_len=13,
+    )
+    assert not path.exists(), "small entries should remain buffered until a boundary"
+    flush_journal()
 
-        # Without debug env var, global journal is not created.
-        monkeypatch.delenv("GIT_STAGE_BATCH_DEBUG", raising=False)
+    entry = _entries(path)[0]
+    assert entry["level"] == "metadata-only"
+    assert entry["source"].endswith(
+        ":test_metadata_journal_redacts_paths_content_and_command_output"
+    )
+    assert entry["fields"]["file_path"]["path_id"]
+    assert entry["fields"]["buffer_preview"] == {"redacted": True, "byte_count": 13}
+    assert entry["fields"]["stderr"] == {"redacted": True, "byte_count": 15}
+    assert entry["fields"]["object_id"] == "abc123"
+    serialized = path.read_text()
+    assert "customer.txt" not in serialized
+    assert "account-token" not in serialized
+    assert "password" not in serialized
+    assert "stack" not in entry
 
-        # Just log directly (don't need start)
-        log_journal("test_operation_no_debug", test=True)
 
-        # Global journal should not be created.
-        assert not global_journal_path.exists() or "test_operation_no_debug" not in global_journal_path.read_text()
+def test_metadata_start_workflow_does_not_record_repository_content(
+    temp_git_repo,
+    monkeypatch,
+):
+    monkeypatch.setenv(JOURNAL_LEVEL_ENV, "metadata-only")
+    secret_path = temp_git_repo / "customer-secret.txt"
+    secret_path.write_text("API_KEY=do-not-record\n")
 
-        # Test 2: With debug env var, should create global journal
-        monkeypatch.setenv("GIT_STAGE_BATCH_DEBUG", "1")
+    command_start()
+    flush_journal()
 
-        log_journal("test_operation_with_debug", test=True)
+    serialized = get_journal_path().read_text()
+    assert "customer-secret.txt" not in serialized
+    assert "do-not-record" not in serialized
 
-        # Global journal should now exist and have content
-        assert global_journal_path.exists(), "Global journal should be created with debug env"
 
-        content = global_journal_path.read_text()
-        assert "test_operation_with_debug" in content
+def test_verbose_adds_bounded_stack_without_exposing_content(temp_git_repo, monkeypatch):
+    monkeypatch.setenv(JOURNAL_LEVEL_ENV, "verbose")
 
-    def test_journal_entries_have_required_fields(self, temp_git_repo):
-        """Test that journal entries have all required fields."""
-        # Make changes for start
-        (temp_git_repo / "README.md").write_text("# Test\nmodified\n")
-        command_start()
+    log_journal("verbose_event", path="private.txt", index_preview=b"secret")
+    flush_journal()
 
-        state_dir = get_state_directory_path()
-        journal_file = state_dir / "journal.jsonl"
+    entry = _entries(get_journal_path())[0]
+    assert 0 < len(entry["stack"]) <= 6
+    assert entry["fields"]["index_preview"]["redacted"] is True
+    assert "private.txt" not in get_journal_path().read_text()
 
-        content = journal_file.read_text()
-        lines = [line for line in content.strip().split('\n') if line]
 
-        # Check first entry
-        entry = json.loads(lines[0])
+def test_error_event_adds_stack_at_metadata_level(temp_git_repo, monkeypatch):
+    monkeypatch.setenv(JOURNAL_LEVEL_ENV, "metadata-only")
 
-        # Required fields
-        assert "timestamp" in entry
-        assert "pid" in entry
-        assert "operation" in entry
-        assert "stack" in entry
+    log_journal("operation_failed", reason="test")
+    flush_journal()
 
-        # Timestamp should be ISO format
-        assert "T" in entry["timestamp"]
+    assert _entries(get_journal_path())[0]["stack"]
 
-        # PID should be positive integer
-        assert entry["pid"] > 0
 
-        # Stack should be a list
-        assert isinstance(entry["stack"], list)
+def test_content_debug_is_a_separate_raw_content_opt_in(temp_git_repo, monkeypatch):
+    monkeypatch.setenv(JOURNAL_LEVEL_ENV, "content-debug")
 
-    def test_journal_global_includes_repo_path(
-        self,
-        temp_git_repo,
-        monkeypatch,
-        global_journal_path,
-    ):
-        """Test that global journal entries include repo path."""
-        monkeypatch.setenv("GIT_STAGE_BATCH_DEBUG", "1")
+    log_journal(
+        "content_event",
+        file_path="private/customer.txt",
+        buffer_preview=b"\x00secret",
+    )
+    flush_journal()
 
-        log_journal("test_repo_path", test=True)
+    entry = _entries(get_journal_path())[0]
+    assert entry["fields"]["file_path"] == "private/customer.txt"
+    assert entry["fields"]["buffer_preview"] == {
+        "encoding": "base64",
+        "data": "AHNlY3JldA==",
+    }
 
-        # Read global journal
-        assert global_journal_path.exists()
-        content = global_journal_path.read_text()
 
-        entry = json.loads(content.strip().split('\n')[-1])
+def test_content_debug_bounds_individual_content_fields(temp_git_repo, monkeypatch):
+    monkeypatch.setenv(JOURNAL_LEVEL_ENV, "content-debug")
 
-        # Should have repo field
-        assert "repo" in entry
-        assert entry["repo"] is not None
-        assert str(temp_git_repo) in entry["repo"]
+    log_journal("large_output", stderr="x" * 10_000)
+    flush_journal()
 
-    def test_journal_logging_never_breaks_operations(self, temp_git_repo, monkeypatch):
-        """Test that journal logging failures don't break operations."""
+    stderr = _entries(get_journal_path())[0]["fields"]["stderr"]
+    assert stderr["truncated"] is True
+    assert stderr["original_byte_count"] == 10_000
+    assert len(stderr["text"].encode()) == journal.MAX_CONTENT_FIELD_BYTES
 
-        # Ensure state directory exists first
-        ensure_state_directory_exists()
 
-        # Make journal path unwritable (this will cause journal to fail)
-        state_dir = get_state_directory_path()
-        journal_file = state_dir / "journal.jsonl"
+def test_journal_uses_private_permissions(temp_git_repo, monkeypatch):
+    monkeypatch.setenv(JOURNAL_LEVEL_ENV, "metadata-only")
+    old_umask = os.umask(0)
+    try:
+        log_journal("permissions")
+        flush_journal()
+    finally:
+        os.umask(old_umask)
 
-        # Create journal as a directory (will cause write to fail)
-        if journal_file.exists():
-            journal_file.unlink()
-        journal_file.mkdir()
+    path = get_journal_path()
+    assert stat.S_IMODE(path.parent.stat().st_mode) == 0o700
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
 
-        # This should not raise an exception.
-        try:
-            log_journal("test_operation", test=True)
-        except Exception as e:
-            pytest.fail(f"Journal logging failure should not raise exception: {e}")
 
-        # Clean up
-        if journal_file.exists() and journal_file.is_dir():
-            journal_file.rmdir()
+def test_default_path_is_private_per_user_and_uses_repository_id(
+    temp_git_repo,
+    monkeypatch,
+):
+    state_home = temp_git_repo / "user-state"
+    monkeypatch.delenv(JOURNAL_PATH_ENV)
+    monkeypatch.delenv(journal.GLOBAL_JOURNAL_PATH_ENV, raising=False)
+    monkeypatch.setenv("XDG_STATE_HOME", str(state_home))
+
+    path = get_journal_path()
+
+    assert path.parent == state_home / "git-stage-batch" / "journals"
+    assert path.suffix == ".jsonl"
+    assert len(path.stem) == 24
+    assert str(temp_git_repo) not in path.name
+
+
+def test_legacy_debug_switch_selects_verbose_not_content(temp_git_repo, monkeypatch):
+    monkeypatch.delenv(JOURNAL_LEVEL_ENV, raising=False)
+    monkeypatch.setenv("GIT_STAGE_BATCH_DEBUG", "1")
+
+    assert journal_enabled(JournalLevel.VERBOSE)
+    assert not journal_enabled(JournalLevel.CONTENT_DEBUG)
+
+
+def test_journal_logging_failure_never_breaks_operation(temp_git_repo, monkeypatch):
+    monkeypatch.setenv(JOURNAL_LEVEL_ENV, "metadata-only")
+    path = get_journal_path()
+    path.parent.mkdir()
+    path.mkdir()
+
+    log_journal("unwritable_destination")
+    flush_journal()

--- a/tests/utils/test_journal.py
+++ b/tests/utils/test_journal.py
@@ -24,6 +24,8 @@ from git_stage_batch.utils.journal import (
     get_journal_path,
     journal_enabled,
     log_journal,
+    purge_journal,
+    summarize_journal,
 )
 
 
@@ -230,6 +232,20 @@ def test_default_path_is_private_per_user_and_uses_repository_id(
     assert path.suffix == ".jsonl"
     assert len(path.stem) == 24
     assert str(temp_git_repo) not in path.name
+
+
+def test_summary_and_purge_are_content_free(temp_git_repo, monkeypatch):
+    monkeypatch.setenv(JOURNAL_LEVEL_ENV, "metadata-only")
+    log_journal("one", file_path="secret.txt")
+    log_journal("two", file_path="secret.txt")
+
+    summary = summarize_journal()
+
+    assert summary["entry_count"] == 2
+    assert summary["operations"] == {"one": 1, "two": 1}
+    assert "secret.txt" not in json.dumps(summary)
+    assert purge_journal() == 1
+    assert not get_journal_path().exists()
 
 
 def test_legacy_debug_switch_selects_verbose_not_content(temp_git_repo, monkeypatch):


### PR DESCRIPTION
Git-stage-batch currently keeps an always-on diagnostic journal inside each
repository. Every event inspects the Python stack and opens the journal file,
while several hot callers construct content previews or run additional Git
queries before recording anything.

Users need enough diagnostic context to investigate difficult reproductions,
but ordinary commands should not pay that cost or retain repository paths and
content implicitly. Enabled diagnostics also need a clear private location,
bounded lifetime, and a supported way to inspect or remove their data.

This pull request makes journal capture explicit and disabled by default. It
adds redacted metadata, verbose, and content-debug levels; private buffered
storage with rotation and retention; stable source and repository identifiers;
and guarded callers that avoid diagnostics-only content work and Git queries.
It also adds command and TUI flush boundaries plus a `journal` command for
content-free summaries, path lookup, and scoped purge operations.

The resulting diagnostics workflow is inexpensive when disabled, private and
bounded when enabled, discoverable through completion and manual pages, and
covered from storage internals through packaging and user documentation.

Tests:

- `.venv/bin/pytest -q` (3,181 passed)
- committed-snapshot compile verification across all 29 commits
- `git diff --check main...HEAD`
