### PR TITLE
abort: Preserve recovery after stash conflicts

### DIFF
--- a/src/git_stage_batch/commands/abort.py
+++ b/src/git_stage_batch/commands/abort.py
@@ -17,7 +17,7 @@ from ..data.session_ownership import (
 from ..data.recovery_anchors import validate_recovery_objects
 from ..utils.session_start_point import load_session_start_point
 from ..data.start_time_changes import read_staged_renames
-from ..exceptions import exit_with_error
+from ..exceptions import CommandError, exit_with_error
 from ..i18n import _
 from ..utils.file_io import read_file_paths_file, read_text_file_contents
 from ..utils.git_command import run_git_command
@@ -128,8 +128,13 @@ def command_abort(*, quiet: bool = False) -> None:
             print(_("Applying original changes..."), file=sys.stderr)
         result = git_apply_stash(abort_stash, restore_index=True, env=env, check=False)
         if result.returncode != 0:
-            if not quiet:
-                print(_("⚠ Warning: Could not apply stash cleanly: {}").format(result.stderr), file=sys.stderr)
+            raise CommandError(
+                _(
+                    "Could not restore the session's original changes: {error}\n"
+                    "The session remains active. Resolve the obstruction and run "
+                    "'git-stage-batch abort' again."
+                ).format(error=result.stderr.strip())
+            )
 
     # Restore snapshotted untracked files
     snapshot_list_path = get_abort_snapshot_list_file_path()

--- a/tests/functional/test_abort_restoration.py
+++ b/tests/functional/test_abort_restoration.py
@@ -250,3 +250,45 @@ def test_abort_multiple_files_discarded_all_restored(repo_with_staged_files):
     assert "file_b.py" in files_after, "file_b.py should be restored"
     assert "file_c.py" in files_after, "file_c.py should be restored"
     assert len(files_after) == 3, f"Expected 3 files after abort, got {len(files_after)}: {files_after}"
+
+
+def test_abort_stash_conflict_keeps_session_for_retry(functional_repo):
+    """A failed stash restoration should retain the recovery session."""
+    readme_path = functional_repo / "README.md"
+    original_readme = "# Test Project\n\nChanged before the session.\n"
+    readme_path.write_text(original_readme)
+
+    staged_path = functional_repo / "new.txt"
+    staged_path.write_text("original staged content\n")
+    subprocess.run(["git", "add", "new.txt"], check=True, capture_output=True)
+
+    git_stage_batch("start")
+
+    subprocess.run(
+        ["git", "rm", "--cached", "new.txt"],
+        check=True,
+        capture_output=True,
+    )
+    staged_path.write_text("colliding untracked content\n")
+
+    failed_abort = git_stage_batch("abort", check=False)
+
+    assert failed_abort.returncode != 0
+    assert "The session remains active" in failed_abort.stderr
+    assert staged_path.read_text() == "colliding untracked content\n"
+
+    collision_path = functional_repo / "collision.txt"
+    staged_path.rename(collision_path)
+
+    git_stage_batch("abort")
+
+    assert readme_path.read_text() == original_readme
+    assert staged_path.read_text() == "original staged content\n"
+    assert collision_path.read_text() == "colliding untracked content\n"
+    status = subprocess.run(
+        ["git", "status", "--porcelain=v1", "-z"],
+        check=True,
+        capture_output=True,
+    ).stdout.split(b"\0")
+    assert b" M README.md" in status
+    assert b"A  new.txt" in status


### PR DESCRIPTION
Abort restores the original index and working tree from a session recovery
snapshot before removing the session metadata.

A stash restoration conflict can occur after the reset has already changed
the repository. Removing the remaining recovery state at that point leaves
users without a route to restore their original changes.

This pull request makes failed aborts retryable by returning a command error,
retaining the session metadata and recovery anchors, and covering an
obstructed untracked path followed by successful recovery.