### PR TITLE
state: Preserve special paths in manifests

### DIFF
--- a/src/git_stage_batch/utils/file_io.py
+++ b/src/git_stage_batch/utils/file_io.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Iterable
 
 from ..exceptions import CommandError
+from ..git_paths import decode_path, encode_path, nul_records
 from ..i18n import _
 
 
@@ -25,6 +26,7 @@ class AtomicWriteModePolicy(Enum):
 
 PRIVATE_FILE_MODE = 0o600
 PROJECT_FILE_MODE = 0o644
+_PATH_LIST_MAGIC = b"\0git-stage-batch-path-list-v1\0"
 
 
 def read_text_file_contents(path: Path) -> str:
@@ -246,7 +248,19 @@ def read_file_paths_file(path: Path) -> list[str]:
     Returns:
         Sorted list of unique paths
     """
+    if not path.exists():
+        return []
+
+    contents = path.read_bytes()
+    if contents.startswith(_PATH_LIST_MAGIC):
+        encoded_paths = nul_records(contents[len(_PATH_LIST_MAGIC):])
+        return sorted({decode_path(encoded_path) for encoded_path in encoded_paths})
+
     return sorted(read_text_file_line_set(path))
+
+
+def _path_requires_lossless_list_encoding(path: str) -> bool:
+    return "\n" in path or "\r" in path or path != path.strip()
 
 
 def write_file_paths_file(path: Path, file_paths: Iterable[str]) -> None:
@@ -257,6 +271,14 @@ def write_file_paths_file(path: Path, file_paths: Iterable[str]) -> None:
         file_paths: Paths to write
     """
     unique_paths = sorted(set(file_paths))
+    if any(_path_requires_lossless_list_encoding(path) for path in unique_paths):
+        contents = _PATH_LIST_MAGIC + b"".join(
+            encode_path(path) + b"\0"
+            for path in unique_paths
+        )
+        write_file_bytes(path, contents)
+        return
+
     content = "\n".join(unique_paths)
     if unique_paths:
         content += "\n"

--- a/tests/functional/test_special_path_workflow.py
+++ b/tests/functional/test_special_path_workflow.py
@@ -147,6 +147,20 @@ def test_special_path_discard_and_abort(functional_repo):
     assert path.read_text() == "new\n"
 
 
+def test_untracked_newline_path_discard_and_abort(functional_repo):
+    """Abort should restore a discarded untracked newline pathname."""
+    path = functional_repo / "untracked\nname.txt"
+    path.write_text("valuable\n")
+
+    git_stage_batch("start")
+    git_stage_batch("discard", "--file", path.name)
+    assert not path.exists()
+
+    git_stage_batch("abort")
+
+    assert path.read_text() == "valuable\n"
+
+
 def test_block_and_unblock_special_path(functional_repo):
     """Blocking resolves the same canonical tab-containing pathname."""
     file_name = "blocked\tname.txt"

--- a/tests/utils/test_file_io.py
+++ b/tests/utils/test_file_io.py
@@ -385,6 +385,23 @@ class TestFilePathListManagement:
         result = read_file_paths_file(path)
         assert result == ["file1.txt", "file2.txt", "file3.txt"]
 
+    @pytest.mark.parametrize(
+        "file_path",
+        [
+            "line\nname.txt",
+            "line\rname.txt",
+            " leading-space.txt",
+            "trailing-space.txt ",
+        ],
+    )
+    def test_write_file_paths_file_preserves_special_paths(self, tmp_path, file_path):
+        """Path manifests should round-trip names unsafe for line storage."""
+        path = tmp_path / "paths.txt"
+
+        write_file_paths_file(path, ["ordinary.txt", file_path])
+
+        assert read_file_paths_file(path) == sorted(["ordinary.txt", file_path])
+
     def test_append_file_path_to_file(self, tmp_path):
         """Test appending a file path to a list."""
 


### PR DESCRIPTION
Session path manifests use a line-oriented text representation to carry
repository paths through abort, progress, and blocking workflows.

Valid Git paths can contain line breaks or surrounding whitespace. Splitting
or trimming those names prevents later commands from finding the original
path and makes recovery incomplete.

This pull request adds a versioned NUL-delimited representation when a path
cannot round-trip through the legacy format, retains legacy compatibility,
and covers manifest round trips and abort restoration for special names.