### PR TITLE
state: Recover embedded repositories during abort

### DIFF
--- a/src/git_stage_batch/commands/abort.py
+++ b/src/git_stage_batch/commands/abort.py
@@ -143,12 +143,30 @@ def command_abort(*, quiet: bool = False) -> None:
         repo_root = get_git_repository_root_path()
         snapshots_dir = get_abort_snapshots_directory_path()
 
+        # Refuse every obstructed directory before restoring any snapshot so a
+        # later conflict cannot make an earlier directory block the retry.
+        for file_path in snapshotted_files:
+            snapshot_path = snapshots_dir / file_path
+            if not snapshot_path.is_dir() or snapshot_path.is_symlink():
+                continue
+            target_path = repo_root / file_path
+            if os.path.lexists(target_path):
+                raise CommandError(
+                    _(
+                        "Could not restore untracked directory {file}: "
+                        "the path already exists. The session remains active."
+                    ).format(file=file_path)
+                )
+
         for file_path in snapshotted_files:
             snapshot_path = snapshots_dir / file_path
             if snapshot_path.exists():
                 target_path = repo_root / file_path
                 target_path.parent.mkdir(parents=True, exist_ok=True)
-                shutil.copy2(snapshot_path, target_path)
+                if snapshot_path.is_dir() and not snapshot_path.is_symlink():
+                    shutil.copytree(snapshot_path, target_path, symlinks=True)
+                else:
+                    shutil.copy2(snapshot_path, target_path)
                 if not quiet:
                     print(_("Restored: {}").format(file_path), file=sys.stderr)
 

--- a/src/git_stage_batch/commands/selection/selected_change_discarding.py
+++ b/src/git_stage_batch/commands/selection/selected_change_discarding.py
@@ -304,6 +304,8 @@ def _discard_text_hunk(
 def discard_gitlink_change(gitlink_change: GitlinkChange) -> None:
     """Restore one submodule pointer change to its baseline state."""
     file_path = gitlink_change.path()
+    if gitlink_change.is_new_file():
+        snapshot_file_if_untracked(file_path, intent_to_add=True)
     file_meta = {
         "file_type": "gitlink",
         "change_type": gitlink_change.change_type,

--- a/src/git_stage_batch/data/session.py
+++ b/src/git_stage_batch/data/session.py
@@ -384,15 +384,14 @@ def snapshot_file_if_untracked(
     full_path = repo_root / file_path
     if not full_path.exists():
         return  # File doesn't exist
-    if full_path.is_dir():
-        log_journal("skip_untracked_directory_snapshot", file_path=file_path)
-        return
-
-    # Save snapshot (use binary copy to handle all file types)
+    # Save a complete before-image for files and standalone repositories.
     snapshot_dir = get_abort_snapshots_directory_path()
     snapshot_path = snapshot_dir / file_path
     snapshot_path.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copy2(full_path, snapshot_path)
+    if full_path.is_dir() and not full_path.is_symlink():
+        shutil.copytree(full_path, snapshot_path, symlinks=True)
+    else:
+        shutil.copy2(full_path, snapshot_path)
 
     # Record snapshot in list
     append_file_path_to_file(get_abort_snapshot_list_file_path(), file_path)
@@ -440,13 +439,12 @@ def snapshot_files_if_untracked(file_paths: list[str]) -> None:
         full_path = repo_root / file_path
         if not full_path.exists():
             continue
-        if full_path.is_dir():
-            log_journal("skip_untracked_directory_snapshot", file_path=file_path)
-            continue
-
         snapshot_path = snapshot_dir / file_path
         snapshot_path.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(full_path, snapshot_path)
+        if full_path.is_dir() and not full_path.is_symlink():
+            shutil.copytree(full_path, snapshot_path, symlinks=True)
+        else:
+            shutil.copy2(full_path, snapshot_path)
         newly_snapshotted.append(file_path)
 
     if newly_snapshotted:

--- a/tests/commands/test_submodule_pointers.py
+++ b/tests/commands/test_submodule_pointers.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from git_stage_batch.commands.discard import command_discard, command_discard_file
+from git_stage_batch.commands.abort import command_abort
 from git_stage_batch.commands.apply_from import command_apply_from_batch
 from git_stage_batch.commands.discard_from import command_discard_from_batch
 from git_stage_batch.batch.state.query import get_batch_commit_sha, read_batch_metadata
@@ -463,6 +464,61 @@ def test_discard_removes_added_submodule_pointer(
     assert not (repo / "sub").exists()
     assert _cached_raw_diff(repo) == ""
     assert _git_stdout(["diff", "--ignore-submodules=none", "--", "sub"], cwd=repo) == ""
+
+
+def test_abort_restores_discarded_untracked_submodule_pointer(
+    untracked_submodule_pointer_repo: tuple[Path, str],
+) -> None:
+    """Abort should restore a discarded standalone nested repository."""
+    repo, nested_oid = untracked_submodule_pointer_repo
+
+    command_start(quiet=True)
+    command_discard(quiet=True)
+    assert not (repo / "sub").exists()
+
+    command_abort(quiet=True)
+
+    assert (repo / "sub" / ".git").is_dir()
+    assert _git_stdout(["rev-parse", "HEAD"], cwd=repo / "sub") == nested_oid
+    assert (repo / "sub" / "file.txt").read_text() == "sub\n"
+
+
+def test_abort_preflights_nested_repository_restore_for_retry(
+    untracked_submodule_pointer_repo: tuple[Path, str],
+) -> None:
+    """Abort should leave every snapshot untouched before a retryable conflict."""
+    repo, first_oid = untracked_submodule_pointer_repo
+    second = repo / "sub-b"
+    second.mkdir()
+    _run(["git", "init"], cwd=second)
+    _configure_identity(second)
+    (second / "file.txt").write_text("second\n")
+    _run(["git", "add", "file.txt"], cwd=second)
+    _run(["git", "commit", "-m", "Add second file"], cwd=second)
+    second_oid = _git_stdout(["rev-parse", "HEAD"], cwd=second)
+
+    command_start(quiet=True)
+    command_discard_file("sub")
+    command_discard_file("sub-b")
+    assert not (repo / "sub").exists()
+    assert not second.exists()
+
+    second.mkdir()
+    obstruction = second / "obstruction.txt"
+    obstruction.write_text("new\n")
+
+    with pytest.raises(CommandError, match="sub-b"):
+        command_abort(quiet=True)
+
+    assert not (repo / "sub").exists()
+    assert obstruction.read_text() == "new\n"
+
+    obstruction.unlink()
+    second.rmdir()
+    command_abort(quiet=True)
+
+    assert _git_stdout(["rev-parse", "HEAD"], cwd=repo / "sub") == first_oid
+    assert _git_stdout(["rev-parse", "HEAD"], cwd=second) == second_oid
 
 
 def test_discard_file_restores_submodule_pointer(


### PR DESCRIPTION
Abort recovery stores before-images for untracked paths that session
commands may remove, but its snapshot and restoration paths handle only
files.

Discarding an added submodule pointer can remove a standalone repository and
its nested object database. A restoration obstruction discovered after an
earlier directory copy can also prevent users from retrying recovery.

This pull request snapshots complete untracked directories before removal,
preflights all directory destinations before restoring any snapshot, and
covers nested repository recovery and retryable multi-directory conflicts.