### PR TITLE
state: Preserve symlinks through abort recovery

### DIFF
--- a/src/git_stage_batch/batch/source/buffers.py
+++ b/src/git_stage_batch/batch/source/buffers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 from ...core.buffer import LineBuffer
 from ...exceptions import CommandError
@@ -21,6 +22,12 @@ from ...utils.paths import (
     get_abort_snapshots_directory_path,
     get_abort_stash_file_path,
 )
+
+
+def _load_snapshot_as_buffer(snapshot_path: Path) -> LineBuffer:
+    if snapshot_path.is_symlink():
+        return LineBuffer.from_bytes(os.readlink(os.fsencode(snapshot_path)))
+    return LineBuffer.from_path(snapshot_path)
 
 
 def load_saved_session_file_as_buffer(file_path: str) -> LineBuffer:
@@ -46,8 +53,8 @@ def load_saved_session_file_as_buffer(file_path: str) -> LineBuffer:
         if file_path in snapshotted_files:
             # Read from snapshot directory
             snapshot_path = get_abort_snapshots_directory_path() / file_path
-            if snapshot_path.exists():
-                return LineBuffer.from_path(snapshot_path)
+            if os.path.lexists(snapshot_path):
+                return _load_snapshot_as_buffer(snapshot_path)
             else:
                 raise CommandError(
                     _("Snapshot for untracked file not found: {file}").format(file=file_path)
@@ -103,8 +110,8 @@ def read_session_file_buffers(
         for file_path in unique_file_paths:
             if file_path in snapshotted_files:
                 snapshot_path = snapshot_directory / file_path
-                if snapshot_path.exists():
-                    buffers[file_path] = LineBuffer.from_path(snapshot_path)
+                if os.path.lexists(snapshot_path):
+                    buffers[file_path] = _load_snapshot_as_buffer(snapshot_path)
                     continue
                 raise CommandError(
                     _("Snapshot for untracked file not found: {file}").format(file=file_path)

--- a/src/git_stage_batch/commands/abort.py
+++ b/src/git_stage_batch/commands/abort.py
@@ -160,12 +160,26 @@ def command_abort(*, quiet: bool = False) -> None:
 
         for file_path in snapshotted_files:
             snapshot_path = snapshots_dir / file_path
-            if snapshot_path.exists():
+            if os.path.lexists(snapshot_path):
                 target_path = repo_root / file_path
                 target_path.parent.mkdir(parents=True, exist_ok=True)
                 if snapshot_path.is_dir() and not snapshot_path.is_symlink():
                     shutil.copytree(snapshot_path, target_path, symlinks=True)
+                elif snapshot_path.is_symlink():
+                    if target_path.is_dir() and not target_path.is_symlink():
+                        raise CommandError(
+                            _(
+                                "Could not restore untracked symlink {file}: "
+                                "the path is now a directory. The session remains active."
+                            ).format(file=file_path)
+                        )
+                    if os.path.lexists(target_path):
+                        target_path.unlink()
+                    link_target = os.readlink(os.fsencode(snapshot_path))
+                    os.symlink(link_target, os.fsencode(target_path))
                 else:
+                    if target_path.is_symlink():
+                        target_path.unlink()
                     shutil.copy2(snapshot_path, target_path)
                 if not quiet:
                     print(_("Restored: {}").format(file_path), file=sys.stderr)

--- a/src/git_stage_batch/data/session.py
+++ b/src/git_stage_batch/data/session.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 import shutil
 
@@ -323,7 +324,9 @@ def _snapshot_worktree_paths_for_unborn_abort(file_paths: list[str]) -> None:
     captured: list[str] = []
     for file_path in file_paths:
         source = repo_root / file_path
-        if not source.exists() or source.is_dir():
+        if not os.path.lexists(source) or (
+            source.is_dir() and not source.is_symlink()
+        ):
             continue
         target = snapshot_dir / file_path
         target.parent.mkdir(parents=True, exist_ok=True)
@@ -382,7 +385,7 @@ def snapshot_file_if_untracked(
     # Read selected file content
     repo_root = get_git_repository_root_path()
     full_path = repo_root / file_path
-    if not full_path.exists():
+    if not os.path.lexists(full_path):
         return  # File doesn't exist
     # Save a complete before-image for files and standalone repositories.
     snapshot_dir = get_abort_snapshots_directory_path()
@@ -391,7 +394,7 @@ def snapshot_file_if_untracked(
     if full_path.is_dir() and not full_path.is_symlink():
         shutil.copytree(full_path, snapshot_path, symlinks=True)
     else:
-        shutil.copy2(full_path, snapshot_path)
+        shutil.copy2(full_path, snapshot_path, follow_symlinks=False)
 
     # Record snapshot in list
     append_file_path_to_file(get_abort_snapshot_list_file_path(), file_path)
@@ -437,14 +440,14 @@ def snapshot_files_if_untracked(file_paths: list[str]) -> None:
             continue
 
         full_path = repo_root / file_path
-        if not full_path.exists():
+        if not os.path.lexists(full_path):
             continue
         snapshot_path = snapshot_dir / file_path
         snapshot_path.parent.mkdir(parents=True, exist_ok=True)
         if full_path.is_dir() and not full_path.is_symlink():
             shutil.copytree(full_path, snapshot_path, symlinks=True)
         else:
-            shutil.copy2(full_path, snapshot_path)
+            shutil.copy2(full_path, snapshot_path, follow_symlinks=False)
         newly_snapshotted.append(file_path)
 
     if newly_snapshotted:

--- a/tests/functional/test_abort_restoration.py
+++ b/tests/functional/test_abort_restoration.py
@@ -1,5 +1,6 @@
 """Tests for abort restoration behavior."""
 
+import os
 import subprocess
 
 import pytest
@@ -292,3 +293,19 @@ def test_abort_stash_conflict_keeps_session_for_retry(functional_repo):
     ).stdout.split(b"\0")
     assert b" M README.md" in status
     assert b"A  new.txt" in status
+
+
+@pytest.mark.parametrize("link_target", ["README.md", "missing-target"])
+def test_abort_restores_discarded_untracked_symlink(functional_repo, link_target):
+    """Abort should restore symlink identity without following its target."""
+    link_path = functional_repo / "link"
+    os.symlink(link_target, link_path)
+
+    git_stage_batch("start")
+    git_stage_batch("discard")
+    assert not os.path.lexists(link_path)
+
+    git_stage_batch("abort")
+
+    assert link_path.is_symlink()
+    assert os.readlink(link_path) == link_target

--- a/tests/functional/test_unborn_repository.py
+++ b/tests/functional/test_unborn_repository.py
@@ -102,6 +102,25 @@ def test_abort_preserves_unborn_file_kinds_and_ignored_paths(unborn_repo):
     assert (unborn_repo / "link").is_symlink()
 
 
+def test_abort_restores_staged_unborn_symlink_to_directory(unborn_repo):
+    """Abort should restore an indexed link without following its directory."""
+    target = unborn_repo / "target"
+    target.mkdir()
+    link = unborn_repo / "link"
+    link.symlink_to("target", target_is_directory=True)
+    _git("add", "link")
+    (unborn_repo / "review.txt").write_text("review\n")
+
+    git_stage_batch("start")
+    _git("rm", "-f", "link")
+    assert not link.exists()
+
+    git_stage_batch("abort")
+
+    assert link.is_symlink()
+    assert str(link.readlink()) == "target"
+
+
 def test_unborn_intent_to_add_is_restored_on_abort(unborn_repo):
     """An existing intent-to-add entry should remain intent-to-add."""
     intent = unborn_repo / "intent.txt"


### PR DESCRIPTION
Abort recovery stores regular files and complete directories as untracked
before-images, and batch sources can consume those saved paths.

Referent-oriented file checks lose symlink identity: dangling links appear
missing, valid links contribute referent bytes, and links to directories can
be skipped during unborn-session capture.

This pull request uses lexical existence and type checks, snapshots and
restores links without dereferencing them, reads saved link targets into batch
sources, and covers valid, dangling, and directory-target symlinks.