### PR TITLE
commands: Report failed include and discard mutations

### DIFF
--- a/src/git_stage_batch/commands/file_scope/discard_file.py
+++ b/src/git_stage_batch/commands/file_scope/discard_file.py
@@ -26,6 +26,7 @@ from ...data.progress import record_hunk_discarded
 from ...data.selected_change.paths import get_selected_change_file_path
 from ...data.session import snapshot_file_if_untracked
 from ...data.undo_checkpoints import undo_checkpoint
+from ...exceptions import exit_with_error
 from ...i18n import _
 from ...utils.file_io import append_lines_to_file, read_text_file_line_set
 from ...utils.git_command import run_git_command
@@ -176,8 +177,7 @@ def discard_file_changes(
 
         result = git_remove_paths([target_file], force=True, check=False)
         if result.returncode != 0:
-            print(_("Failed to discard file: {}").format(result.stderr), file=sys.stderr)
-            return
+            exit_with_error(_("Failed to discard file: {}").format(result.stderr))
 
         for patch_hash in hashes_to_block:
             append_lines_to_file(blocklist_path, [patch_hash])

--- a/src/git_stage_batch/commands/selection/selected_change_discarding.py
+++ b/src/git_stage_batch/commands/selection/selected_change_discarding.py
@@ -197,14 +197,16 @@ def _discard_binary_change(
     elif item.is_deleted_file():
         result = git_checkout_paths("HEAD", [file_path], check=False)
         if result.returncode != 0:
-            print(_("Failed to restore binary file: {}").format(result.stderr), file=sys.stderr)
-            return
+            exit_with_error(
+                _("Failed to restore binary file: {}").format(result.stderr)
+            )
         log_journal("command_discard_binary_restored", file_path=file_path)
     else:
         result = git_checkout_paths("HEAD", [file_path], check=False)
         if result.returncode != 0:
-            print(_("Failed to restore binary file: {}").format(result.stderr), file=sys.stderr)
-            return
+            exit_with_error(
+                _("Failed to restore binary file: {}").format(result.stderr)
+            )
         log_journal("command_discard_binary_restored", file_path=file_path)
 
     append_lines_to_file(get_block_list_file_path(), [patch_hash])
@@ -279,8 +281,7 @@ def _discard_text_hunk(
             stderr=stderr_text,
             filename=file_path,
         )
-        print(_("Failed to discard hunk: {}").format(stderr_text), file=sys.stderr)
-        return
+        exit_with_error(_("Failed to discard hunk: {}").format(stderr_text))
 
     if is_new_file:
         absolute_path = get_git_repository_root_path() / file_path

--- a/src/git_stage_batch/commands/selection/selected_change_staging.py
+++ b/src/git_stage_batch/commands/selection/selected_change_staging.py
@@ -120,13 +120,11 @@ def _include_loaded_selected_change(
     if isinstance(item, GitlinkChange):
         result = stage_gitlink_change(item)
         if result.returncode != 0:
-            print(
+            exit_with_error(
                 _("Failed to stage submodule pointer: {error}").format(
                     error=result.stderr,
-                ),
-                file=sys.stderr,
+                )
             )
-            return
 
         record_hunk_included(patch_hash)
 
@@ -149,13 +147,11 @@ def _include_loaded_selected_change(
         file_path = item.path()
         result = git_add_paths([file_path], check=False)
         if result.returncode != 0:
-            print(
+            exit_with_error(
                 _("Failed to stage binary file: {error}").format(
                     error=result.stderr,
-                ),
-                file=sys.stderr,
+                )
             )
-            return
 
         record_hunk_included(patch_hash)
 
@@ -194,11 +190,9 @@ def _include_loaded_selected_change(
             )
 
     if apply_result is not None and apply_result.returncode != 0:
-        print(
-            _("Failed to apply hunk: {error}").format(error=apply_result.stderr),
-            file=sys.stderr,
+        exit_with_error(
+            _("Failed to apply hunk: {error}").format(error=apply_result.stderr)
         )
-        return
 
     record_hunk_included(patch_hash)
 

--- a/src/git_stage_batch/commands/selection/selected_file_discarding.py
+++ b/src/git_stage_batch/commands/selection/selected_file_discarding.py
@@ -7,6 +7,7 @@ import sys
 from ...data.selected_change.paths import get_selected_change_file_path
 from ...data.session import snapshot_file_if_untracked
 from ...data.undo_checkpoints import undo_checkpoint
+from ...exceptions import exit_with_error
 from ...i18n import _
 from ...utils.git_command import run_git_command
 from ...utils.git_worktree import git_checkout_paths
@@ -38,9 +39,9 @@ def discard_selected_file(
         if head_result.returncode == 0:
             result = git_checkout_paths("HEAD", [target_file], check=False)
             if result.returncode != 0:
-                if not quiet:
-                    print(_("Failed to discard file: {}").format(result.stderr), file=sys.stderr)
-                return
+                exit_with_error(
+                    _("Failed to discard file: {}").format(result.stderr)
+                )
         else:
             absolute_path = get_git_repository_root_path() / target_file
             if absolute_path.exists():

--- a/tests/commands/test_discard.py
+++ b/tests/commands/test_discard.py
@@ -25,6 +25,7 @@ import subprocess
 
 import pytest
 
+import git_stage_batch.commands.selection.selected_change_discarding as selected_change_discarding
 from git_stage_batch.commands.discard import command_discard, command_discard_line, command_discard_line_as_to_batch
 from git_stage_batch.commands.include import command_include
 from git_stage_batch.commands.start import command_start
@@ -102,6 +103,25 @@ class TestCommandDiscard:
 
         captured = capsys.readouterr()
         assert "Hunk discarded" in captured.err
+
+    def test_discard_raises_when_git_rejects_hunk(self, temp_git_repo, monkeypatch):
+        """A failed worktree update should fail the discard command."""
+        test_file = _prepare_single_line_change(temp_git_repo)
+        monkeypatch.setattr(
+            selected_change_discarding,
+            "git_apply_to_worktree",
+            lambda *_args, **_kwargs: subprocess.CompletedProcess(
+                ["git", "apply"],
+                1,
+                "",
+                "worktree update failed",
+            ),
+        )
+
+        with pytest.raises(CommandError, match="worktree update failed"):
+            command_discard(quiet=True)
+
+        assert test_file.read_text() == "base\nselected\n"
 
     def test_discard_only_line_from_intent_to_add_file_leaves_empty_file(
         self,

--- a/tests/commands/test_discard_file.py
+++ b/tests/commands/test_discard_file.py
@@ -4,10 +4,12 @@ import subprocess
 
 import pytest
 
+import git_stage_batch.commands.file_scope.discard_file as discard_file_scope
 from git_stage_batch.commands.abort import command_abort
 from git_stage_batch.commands.discard import command_discard_file
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.core.hashing import compute_stable_hunk_hash_from_lines
+from git_stage_batch.exceptions import CommandError
 from tests.diff_parser_helpers import collect_unified_diff
 from git_stage_batch.utils.file_io import read_text_file_contents
 from git_stage_batch.utils.paths import (
@@ -65,6 +67,31 @@ class TestCommandDiscardFile:
 
         captured = capsys.readouterr()
         assert "File discarded: unwanted.txt" in captured.err
+
+    def test_discard_file_raises_when_git_rejects_removal(
+        self,
+        temp_git_repo,
+        monkeypatch,
+    ):
+        """A failed named file removal should fail the discard command."""
+        readme = temp_git_repo / "README.md"
+        readme.write_text("# Changed\n")
+        command_start()
+        monkeypatch.setattr(
+            discard_file_scope,
+            "git_remove_paths",
+            lambda *_args, **_kwargs: subprocess.CompletedProcess(
+                ["git", "rm"],
+                1,
+                "",
+                "file removal failed",
+            ),
+        )
+
+        with pytest.raises(CommandError, match="file removal failed"):
+            command_discard_file(file="README.md")
+
+        assert readme.read_text() == "# Changed\n"
 
     def test_discard_file_with_multiple_hunks(self, temp_git_repo, capsys):
         """Test that discard-file removes file even with multiple hunks."""

--- a/tests/commands/test_file_review.py
+++ b/tests/commands/test_file_review.py
@@ -15,7 +15,8 @@ from git_stage_batch.batch.state.query import read_batch_metadata
 from git_stage_batch.batch.text_file_storage import add_file_to_batch
 from git_stage_batch.commands.apply_from import command_apply_from_batch
 from git_stage_batch.commands.discard_from import command_discard_from_batch
-from git_stage_batch.commands.discard import command_discard_file, command_discard_file_as, command_discard_line, command_discard_line_as_to_batch, command_discard_to_batch
+from git_stage_batch.commands.discard import command_discard, command_discard_file, command_discard_file_as, command_discard_line, command_discard_line_as_to_batch, command_discard_to_batch
+import git_stage_batch.commands.selection.selected_file_discarding as selected_file_discarding
 from git_stage_batch.commands.include import command_include, command_include_file, command_include_file_as, command_include_line, command_include_line_as
 from git_stage_batch.commands.include_from import command_include_from_batch
 from git_stage_batch.commands.reset import command_reset_from_batch
@@ -95,6 +96,30 @@ def _force_one_change_per_page(monkeypatch):
     import git_stage_batch.output.file_review_layout as file_review_layout
 
     monkeypatch.setattr(file_review_layout, "body_budget", lambda: 1)
+
+
+def test_reviewed_file_discard_raises_when_checkout_fails(
+    paged_file_repo,
+    monkeypatch,
+):
+    """A failed reviewed-file checkout should fail the discard command."""
+    command_start(quiet=True)
+    command_show(file="file.txt", porcelain=True)
+    monkeypatch.setattr(
+        selected_file_discarding,
+        "git_checkout_paths",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess(
+            ["git", "checkout"],
+            1,
+            "",
+            "file checkout failed",
+        ),
+    )
+
+    with pytest.raises(CommandError, match="file checkout failed"):
+        command_discard(quiet=True)
+
+    assert "line 2 changed" in (paged_file_repo / "file.txt").read_text()
 
 
 def _add_second_changed_file(repo):

--- a/tests/commands/test_include.py
+++ b/tests/commands/test_include.py
@@ -5,6 +5,7 @@ import subprocess
 
 import pytest
 
+import git_stage_batch.commands.selection.selected_change_staging as selected_change_staging
 from git_stage_batch.batch.ownership.model import BatchOwnership
 from git_stage_batch.batch.state.query import get_batch_commit_sha, read_batch_metadata
 from git_stage_batch.batch.state.batch_names import batch_exists
@@ -100,6 +101,29 @@ class TestCommandInclude:
 
         captured = capsys.readouterr()
         assert "Hunk staged" in captured.err
+
+    def test_include_raises_when_git_rejects_hunk(self, temp_git_repo, monkeypatch):
+        """A failed index update should fail the include command."""
+        _prepare_single_line_change(temp_git_repo)
+        monkeypatch.setattr(
+            selected_change_staging,
+            "git_apply_to_index",
+            lambda *_args, **_kwargs: subprocess.CompletedProcess(
+                ["git", "apply"],
+                1,
+                "",
+                "index update failed",
+            ),
+        )
+
+        with pytest.raises(CommandError, match="index update failed"):
+            command_include(quiet=True)
+
+        assert subprocess.run(
+            ["git", "diff", "--cached", "--quiet"],
+            cwd=temp_git_repo,
+            check=False,
+        ).returncode == 0
 
     def test_include_no_changes(self, temp_git_repo, capsys):
         """Test include when no more hunks remain."""


### PR DESCRIPTION
Include and discard run Git plumbing operations before recording selected
changes as processed.

A rejected index or worktree update can currently leave the requested change
in place while the command exits successfully. Automation cannot distinguish
that retained state from a completed include or discard operation.

This pull request routes selected staging, selected restoration, named file
removal, and reviewed file checkout failures through the command error policy,
with coverage for each nonzero result and unchanged repository state.