### PR TITLE
ignore: Treat blocked paths as literal names

### DIFF
--- a/src/git_stage_batch/commands/unblock_file.py
+++ b/src/git_stage_batch/commands/unblock_file.py
@@ -11,6 +11,9 @@ from ..data.undo_checkpoints import undo_checkpoint
 from ..data.ignore_files import (
     add_file_to_gitignore,
     add_file_to_local_exclude,
+    add_pattern_to_gitignore,
+    add_pattern_to_local_exclude,
+    literal_ignore_pattern,
     promote_directory_to_glob_in_gitignore,
     promote_directory_to_glob_in_local_exclude,
     remove_file_from_gitignore,
@@ -92,10 +95,12 @@ def command_unblock_file(file_path_arg: str) -> None:
             covering_dir = _find_covering_directory(file_path, blocked_files)
             if covering_dir is not None:
                 if promote_directory_to_glob_in_gitignore(covering_dir):
-                    add_file_to_gitignore(f"!{file_path}")
+                    add_pattern_to_gitignore(f"!{literal_ignore_pattern(file_path)}")
                     removed_from_gitignore = True
                 if promote_directory_to_glob_in_local_exclude(covering_dir):
-                    add_file_to_local_exclude(f"!{file_path}")
+                    add_pattern_to_local_exclude(
+                        f"!{literal_ignore_pattern(file_path)}"
+                    )
                     removed_from_local_exclude = True
                 append_file_path_to_file(get_blocked_files_file_path(), f"!{file_path}")
 

--- a/src/git_stage_batch/commands/unblock_file.py
+++ b/src/git_stage_batch/commands/unblock_file.py
@@ -9,8 +9,6 @@ from pathlib import Path
 from ..data.session import session_is_active
 from ..data.undo_checkpoints import undo_checkpoint
 from ..data.ignore_files import (
-    add_file_to_gitignore,
-    add_file_to_local_exclude,
     add_pattern_to_gitignore,
     add_pattern_to_local_exclude,
     literal_ignore_pattern,

--- a/src/git_stage_batch/data/ignore_files.py
+++ b/src/git_stage_batch/data/ignore_files.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from ..exceptions import CommandError
+from ..i18n import _
 from ..utils.file_io import (
     AtomicWriteModePolicy,
     PROJECT_FILE_MODE,
@@ -64,6 +66,40 @@ def write_gitignore_lines(lines: list[str]) -> None:
     _write_repository_ignore_file(gitignore_path, content)
 
 
+def literal_ignore_pattern(file_path: str) -> str:
+    """Return a gitignore pattern that matches one literal repository path."""
+    if "\n" in file_path or "\r" in file_path:
+        raise CommandError(
+            _("Cannot write an ignore rule for a path containing a line break.")
+        )
+
+    trailing_space_start = len(file_path.rstrip(" "))
+    escaped = []
+    for index, character in enumerate(file_path):
+        if (
+            character in "\\*?["
+            or (index == 0 and character in "#!")
+            or (character == " " and index >= trailing_space_start)
+        ):
+            escaped.append("\\")
+        escaped.append(character)
+    return "".join(escaped)
+
+
+def _literal_ignore_pattern_variants(file_path: str) -> set[str]:
+    """Return current and legacy encodings for one literal path."""
+    return {literal_ignore_pattern(file_path), file_path.rstrip("\n")}
+
+
+def _append_ignore_entry(lines: list[str], entry: str) -> bool:
+    if any(line.rstrip("\n") == entry for line in lines):
+        return False
+    if lines and not lines[-1].endswith("\n"):
+        lines[-1] += "\n"
+    lines.append(f"{entry}\n")
+    return True
+
+
 def add_file_to_gitignore(file_path: str) -> None:
     """Add a file path to .gitignore.
 
@@ -71,17 +107,15 @@ def add_file_to_gitignore(file_path: str) -> None:
         file_path: File path to add
     """
     lines = read_gitignore_lines()
+    if _append_ignore_entry(lines, literal_ignore_pattern(file_path)):
+        write_gitignore_lines(lines)
 
-    file_path_normalized = file_path.rstrip("\n")
-    for line in lines:
-        if line.rstrip("\n") == file_path_normalized:
-            return
 
-    if lines and not lines[-1].endswith("\n"):
-        lines[-1] += "\n"
-
-    lines.append(f"{file_path}\n")
-    write_gitignore_lines(lines)
+def add_pattern_to_gitignore(pattern: str) -> None:
+    """Add an intentional gitignore pattern without literal escaping."""
+    lines = read_gitignore_lines()
+    if _append_ignore_entry(lines, pattern.rstrip("\n")):
+        write_gitignore_lines(lines)
 
 
 def remove_file_from_gitignore(file_path: str) -> bool:
@@ -94,12 +128,12 @@ def remove_file_from_gitignore(file_path: str) -> bool:
         True if removed, False if not found
     """
     lines = read_gitignore_lines()
-    file_path_normalized = file_path.rstrip("\n")
+    file_path_patterns = _literal_ignore_pattern_variants(file_path)
 
     i = 0
     removed = False
     while i < len(lines):
-        if lines[i].rstrip("\n") == file_path_normalized:
+        if lines[i].rstrip("\n") in file_path_patterns:
             del lines[i]
             removed = True
             continue
@@ -126,16 +160,21 @@ def add_file_to_local_exclude(file_path: str) -> None:
     else:
         lines = []
 
-    file_path_normalized = file_path.rstrip("\n")
-    for line in lines:
-        if line.rstrip("\n") == file_path_normalized:
-            return
+    if _append_ignore_entry(lines, literal_ignore_pattern(file_path)):
+        _write_repository_ignore_file(exclude_path, "".join(lines))
 
-    if lines and not lines[-1].endswith("\n"):
-        lines[-1] += "\n"
 
-    lines.append(f"{file_path}\n")
-    _write_repository_ignore_file(exclude_path, "".join(lines))
+def add_pattern_to_local_exclude(pattern: str) -> None:
+    """Add an intentional local exclude pattern without literal escaping."""
+    exclude_path = get_local_exclude_path()
+    exclude_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = (
+        read_text_file_contents(exclude_path).splitlines(keepends=True)
+        if exclude_path.exists()
+        else []
+    )
+    if _append_ignore_entry(lines, pattern.rstrip("\n")):
+        _write_repository_ignore_file(exclude_path, "".join(lines))
 
 
 def remove_file_from_local_exclude(file_path: str) -> bool:
@@ -153,12 +192,12 @@ def remove_file_from_local_exclude(file_path: str) -> bool:
 
     content = read_text_file_contents(exclude_path)
     lines = content.splitlines(keepends=True)
-    file_path_normalized = file_path.rstrip("\n")
+    file_path_patterns = _literal_ignore_pattern_variants(file_path)
 
     i = 0
     removed = False
     while i < len(lines):
-        if lines[i].rstrip("\n") == file_path_normalized:
+        if lines[i].rstrip("\n") in file_path_patterns:
             del lines[i]
             removed = True
             continue
@@ -177,19 +216,24 @@ def promote_directory_to_glob_in_gitignore(dir_path: str) -> bool:
     has no entry in .gitignore.
     """
     lines = read_gitignore_lines()
-    dir_entry = dir_path.rstrip("/") + "/"
-    glob_entry = dir_path.rstrip("/") + "/**"
-
-    if any(line.rstrip("\n") == glob_entry for line in lines):
-        return True
+    directory_patterns = _literal_ignore_pattern_variants(dir_path.rstrip("/"))
+    dir_entries = {pattern + "/" for pattern in directory_patterns}
+    glob_entries = {pattern + "/**" for pattern in directory_patterns}
+    known_entries = dir_entries | glob_entries
+    glob_entry = literal_ignore_pattern(dir_path.rstrip("/")) + "/**"
 
     found = False
+    changed = False
     for i, line in enumerate(lines):
-        if line.rstrip("\n") == dir_entry:
-            lines[i] = glob_entry + ("\n" if line.endswith("\n") else "")
-            found = True
+        if line.rstrip("\n") not in known_entries:
+            continue
+        replacement = glob_entry + ("\n" if line.endswith("\n") else "")
+        found = True
+        if replacement != line:
+            lines[i] = replacement
+            changed = True
 
-    if found:
+    if changed:
         write_gitignore_lines(lines)
     return found
 
@@ -206,18 +250,23 @@ def promote_directory_to_glob_in_local_exclude(dir_path: str) -> bool:
 
     content = read_text_file_contents(exclude_path)
     lines = content.splitlines(keepends=True)
-    dir_entry = dir_path.rstrip("/") + "/"
-    glob_entry = dir_path.rstrip("/") + "/**"
-
-    if any(line.rstrip("\n") == glob_entry for line in lines):
-        return True
+    directory_patterns = _literal_ignore_pattern_variants(dir_path.rstrip("/"))
+    dir_entries = {pattern + "/" for pattern in directory_patterns}
+    glob_entries = {pattern + "/**" for pattern in directory_patterns}
+    known_entries = dir_entries | glob_entries
+    glob_entry = literal_ignore_pattern(dir_path.rstrip("/")) + "/**"
 
     found = False
+    changed = False
     for i, line in enumerate(lines):
-        if line.rstrip("\n") == dir_entry:
-            lines[i] = glob_entry + ("\n" if line.endswith("\n") else "")
-            found = True
+        if line.rstrip("\n") not in known_entries:
+            continue
+        replacement = glob_entry + ("\n" if line.endswith("\n") else "")
+        found = True
+        if replacement != line:
+            lines[i] = replacement
+            changed = True
 
-    if found:
+    if changed:
         _write_repository_ignore_file(exclude_path, "".join(lines))
     return found

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -2696,8 +2696,11 @@ def test_ignore_file_helpers_stay_in_data_layer():
     public_names = {
         "add_file_to_gitignore",
         "add_file_to_local_exclude",
+        "add_pattern_to_gitignore",
+        "add_pattern_to_local_exclude",
         "get_gitignore_path",
         "get_local_exclude_path",
+        "literal_ignore_pattern",
         "promote_directory_to_glob_in_gitignore",
         "promote_directory_to_glob_in_local_exclude",
         "read_gitignore_lines",
@@ -2711,8 +2714,9 @@ def test_ignore_file_helpers_stay_in_data_layer():
             "add_file_to_local_exclude",
         },
         SRC_ROOT / "commands" / "unblock_file.py": {
-            "add_file_to_gitignore",
-            "add_file_to_local_exclude",
+            "add_pattern_to_gitignore",
+            "add_pattern_to_local_exclude",
+            "literal_ignore_pattern",
             "promote_directory_to_glob_in_gitignore",
             "promote_directory_to_glob_in_local_exclude",
             "remove_file_from_gitignore",

--- a/tests/commands/test_block_file.py
+++ b/tests/commands/test_block_file.py
@@ -54,6 +54,29 @@ class TestCommandBlockFile:
         captured = capsys.readouterr()
         assert "Blocked file: unwanted.txt" in captured.err
 
+    @pytest.mark.parametrize(
+        "file_name",
+        [
+            "file[1].txt",
+            "literal*.txt",
+            "literal?.txt",
+            "#notes.txt",
+            "!important.txt",
+            "trailing-space.txt ",
+        ],
+    )
+    def test_block_file_ignores_literal_special_path(self, temp_git_repo, file_name):
+        """Blocking should quote pathname characters with pattern meaning."""
+        (temp_git_repo / file_name).write_text("generated\n")
+
+        command_block_file(file_name)
+
+        assert subprocess.run(
+            ["git", "check-ignore", "--quiet", "--", file_name],
+            cwd=temp_git_repo,
+            check=False,
+        ).returncode == 0
+
     def test_block_file_adds_to_blocked_list(self, temp_git_repo):
         """Test that block-file adds file to blocked-files state."""
         # Create untracked file

--- a/tests/commands/test_unblock_file.py
+++ b/tests/commands/test_unblock_file.py
@@ -59,6 +59,72 @@ class TestCommandUnblockFile:
         captured = capsys.readouterr()
         assert "Unblocked file: temp.txt" in captured.err
 
+    def test_unblock_file_removes_literal_special_path(self, temp_git_repo):
+        """Unblocking should remove the escaped rule for a literal pathname."""
+        file_name = "file[1].txt"
+        (temp_git_repo / file_name).write_text("content\n")
+        command_block_file(file_name)
+        assert subprocess.run(
+            ["git", "check-ignore", "--quiet", "--", file_name],
+            cwd=temp_git_repo,
+            check=False,
+        ).returncode == 0
+
+        command_unblock_file(file_name)
+
+        assert subprocess.run(
+            ["git", "check-ignore", "--quiet", "--", file_name],
+            cwd=temp_git_repo,
+            check=False,
+        ).returncode == 1
+
+    @pytest.mark.parametrize("local_only", [False, True])
+    def test_unblock_file_removes_legacy_literal_special_path(
+        self,
+        temp_git_repo,
+        local_only,
+    ):
+        """Unblocking should remove raw special rules written by older versions."""
+        file_name = "literal*.txt"
+        (temp_git_repo / file_name).write_text("content\n")
+        ignore_path = (
+            get_local_exclude_path() if local_only else get_gitignore_path()
+        )
+        ignore_path.parent.mkdir(parents=True, exist_ok=True)
+        ignore_path.write_text(f"{file_name}\n")
+        append_file_path_to_file(get_blocked_files_file_path(), file_name)
+
+        command_unblock_file(file_name)
+
+        assert file_name not in ignore_path.read_text()
+        blocked = read_file_paths_file(get_blocked_files_file_path())
+        assert file_name not in blocked
+
+    @pytest.mark.parametrize("local_only", [False, True])
+    def test_unblock_file_promotes_legacy_literal_directory(
+        self,
+        temp_git_repo,
+        local_only,
+    ):
+        """Unblocking a child should migrate an older raw directory rule."""
+        directory = temp_git_repo / "generated*"
+        directory.mkdir()
+        child = directory / "keep.txt"
+        child.write_text("content\n")
+        ignore_path = (
+            get_local_exclude_path() if local_only else get_gitignore_path()
+        )
+        ignore_path.parent.mkdir(parents=True, exist_ok=True)
+        ignore_path.write_text("generated*/\n")
+        append_file_path_to_file(get_blocked_files_file_path(), "generated*/")
+
+        command_unblock_file("generated*/keep.txt")
+
+        content = ignore_path.read_text()
+        assert "generated\\*/**\n" in content
+        assert "!generated\\*/keep.txt\n" in content
+        assert "generated*/\n" not in content
+
     def test_unblock_file_removes_from_blocked_list(self, temp_git_repo):
         """Test that unblock-file removes from blocked list."""
         # Create and block a file


### PR DESCRIPTION
Block and unblock edit repository ignore files through shared helpers that
store each supplied path as a Git pattern.

Pattern metacharacters in a filename can make a successful block command
ignore different paths. Changing the encoding alone would also leave rules
written by earlier versions behind during unblock or directory reinclusion.

This pull request escapes newly blocked literal paths, recognizes current and
legacy encodings during removal and promotion, separates intentional pattern
helpers from literal helpers, and covers both repository ignore sources.