### PR TITLE
Make repository read outcomes explicit

### DIFF
--- a/scripts/benchmark_matching.py
+++ b/scripts/benchmark_matching.py
@@ -45,7 +45,7 @@ from git_stage_batch.batch.state.references import get_batch_state_ref_name
 from git_stage_batch.core.buffer import LineBuffer
 from git_stage_batch.utils.git_object_io import resolve_git_objects
 from git_stage_batch.utils.repository_buffers import (
-    load_git_object_as_buffer_or_empty,
+    read_git_object_buffer_or_empty,
     load_working_tree_file_as_buffer,
     stream_git_blob_buffers,
 )
@@ -699,7 +699,7 @@ def _measure_blob_loading(fixture: AttributionFixture) -> dict[str, Any]:
 def _open_repository_buffers(
     fixture: AttributionFixture,
 ) -> _MappingState:
-    source = load_git_object_as_buffer_or_empty(
+    source = read_git_object_buffer_or_empty(
         next(iter(fixture.metadata.values()))["files"][fixture.file_path][
             "batch_source_commit"
         ]
@@ -823,7 +823,7 @@ def run_attribution_case(
 def _prepare_repository_unit_enumeration(
     fixture: AttributionFixture,
 ) -> _UnitEnumerationState:
-    source = load_git_object_as_buffer_or_empty(f"HEAD:{fixture.file_path}")
+    source = read_git_object_buffer_or_empty(f"HEAD:{fixture.file_path}")
     try:
         working = load_working_tree_file_as_buffer(fixture.file_path)
     except Exception:

--- a/src/git_stage_batch/batch/attribution.py
+++ b/src/git_stage_batch/batch/attribution.py
@@ -30,7 +30,7 @@ from .state.query import list_batch_names, read_batch_metadata_for_batches
 from .state.references import get_batch_state_ref_name
 from ..core.line_selection import parse_line_selection
 from ..utils.repository_buffers import (
-    load_git_object_as_buffer_or_empty,
+    read_git_object_buffer_or_empty,
     load_working_tree_file_as_buffer,
     stream_git_blob_buffers,
 )
@@ -146,7 +146,7 @@ def build_file_attribution(
     if metrics is not None:
         metrics.claimed_batches = len(all_batch_metadata)
 
-    baseline_buffer = load_git_object_as_buffer_or_empty(f"HEAD:{file_path}")
+    baseline_buffer = read_git_object_buffer_or_empty(f"HEAD:{file_path}")
     working_tree_buffer = load_working_tree_file_as_buffer(file_path)
     with baseline_buffer as baseline_lines, working_tree_buffer as working_tree_lines:
         all_units_map: dict[str, _AttributionUnit] = {}

--- a/src/git_stage_batch/batch/binary_file_content.py
+++ b/src/git_stage_batch/batch/binary_file_content.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 
 from ..core.buffer import LineBuffer
-from ..utils.repository_buffers import load_git_object_as_buffer
+from ..utils.repository_buffers import read_git_object_buffer_or_none
 from .state.query import get_batch_commit_sha
 
 
@@ -25,7 +25,7 @@ def read_binary_file_from_batch(
     if change_type == "deleted":
         return None
 
-    batch_buffer = load_git_object_as_buffer(f"{batch_commit}:{file_path}")
+    batch_buffer = read_git_object_buffer_or_none(f"{batch_commit}:{file_path}")
     if batch_buffer is None:
         if missing_content_message is None:
             missing_content_message = (

--- a/src/git_stage_batch/batch/file_display.py
+++ b/src/git_stage_batch/batch/file_display.py
@@ -15,7 +15,7 @@ from ..core.models import (
     RenderedBatchDisplay,
 )
 from ..utils.repository_buffers import (
-    load_git_object_as_buffer,
+    read_git_object_buffer_or_none,
 )
 from ..utils.paths import get_context_lines
 
@@ -84,7 +84,7 @@ def _render_batch_file_display_from_ownership(
 ) -> Optional['RenderedBatchDisplay']:
     """Render batch file display from already-acquired ownership metadata."""
 
-    batch_source_buffer = load_git_object_as_buffer(
+    batch_source_buffer = read_git_object_buffer_or_none(
         f"{batch_source_commit}:{file_path}"
     )
     if batch_source_buffer is None:

--- a/src/git_stage_batch/batch/file_entry_storage.py
+++ b/src/git_stage_batch/batch/file_entry_storage.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from copy import deepcopy
 from typing import Optional
 
-from ..utils.repository_buffers import load_git_object_as_buffer
+from ..utils.repository_buffers import read_git_object_buffer_or_none
 from ..utils.git_command import run_git_command
 from ..utils.git_object_io import create_git_blob
 from .state import content_commits as _content_commits
@@ -56,7 +56,7 @@ def copy_file_from_batch_to_batch(
         _content_commits.update_batch_gitlink_commit(dest_batch, file_path, oid)
         return
 
-    source_buffer = load_git_object_as_buffer(f"{source_commit}:{file_path}")
+    source_buffer = read_git_object_buffer_or_none(f"{source_commit}:{file_path}")
     if source_buffer is not None:
         with source_buffer:
             blob_sha = create_git_blob(source_buffer.byte_chunks())

--- a/src/git_stage_batch/batch/source/advancement.py
+++ b/src/git_stage_batch/batch/source/advancement.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from ...core.buffer import LineBuffer
 from .snapshots import create_batch_source_commit
 from ...utils.repository_buffers import (
-    load_git_object_as_buffer,
+    read_git_object_buffer_or_none,
     load_working_tree_file_as_buffer,
 )
 from ...utils.git_repository import get_git_repository_root_path
@@ -123,7 +123,7 @@ def advance_batch_source_for_file_with_provenance(
             f"file does not exist in working tree"
         )
 
-    old_source_buffer = load_git_object_as_buffer(
+    old_source_buffer = read_git_object_buffer_or_none(
         f"{old_batch_source_commit}:{file_path}"
     )
     if old_source_buffer is None:

--- a/src/git_stage_batch/batch/source/annotation.py
+++ b/src/git_stage_batch/batch/source/annotation.py
@@ -7,7 +7,7 @@ from collections.abc import Sequence
 from ...core.models import LineEntry, LineLevelChange
 from ...utils.git_repository import get_git_repository_root_path
 from ...utils.repository_buffers import (
-    load_git_object_as_buffer,
+    read_git_object_buffer_or_none,
     load_working_tree_file_as_buffer,
 )
 from ..line_matching.line_mapping import LineMapping
@@ -168,7 +168,7 @@ def annotate_with_batch_source_working_lines(
     if not batch_source_commit:
         return _fill_source_from_working_tree(line_changes)
 
-    batch_source_buffer = load_git_object_as_buffer(
+    batch_source_buffer = read_git_object_buffer_or_none(
         f"{batch_source_commit}:{path_value}"
     )
     if batch_source_buffer is None:

--- a/src/git_stage_batch/batch/source/buffers.py
+++ b/src/git_stage_batch/batch/source/buffers.py
@@ -13,7 +13,7 @@ from ...utils.git_object_io import list_git_tree_blobs
 from ...utils.git_repository import get_git_repository_root_path
 from ...utils.repository_buffers import (
     load_git_blob_as_buffer,
-    load_git_object_as_buffer,
+    read_git_object_buffer_or_none,
     load_working_tree_file_as_buffer,
 )
 from ...utils.paths import (
@@ -67,7 +67,7 @@ def load_saved_session_file_as_buffer(file_path: str) -> LineBuffer:
         if stash_commit:
             # Extract file from stash commit
             # The stash commit contains the working tree state
-            buffer = load_git_object_as_buffer(f"{stash_commit}:{file_path}")
+            buffer = read_git_object_buffer_or_none(f"{stash_commit}:{file_path}")
             if buffer is not None:
                 return buffer
 
@@ -78,7 +78,7 @@ def load_saved_session_file_as_buffer(file_path: str) -> LineBuffer:
         raise CommandError(_("No session found"))
 
     baseline_commit = read_text_file_contents(abort_head_path).strip()
-    buffer = load_git_object_as_buffer(f"{baseline_commit}:{file_path}")
+    buffer = read_git_object_buffer_or_none(f"{baseline_commit}:{file_path}")
     if buffer is None:
         # File might not exist in baseline (new file)
         return LineBuffer.from_bytes(b"")

--- a/src/git_stage_batch/batch/source/refresh.py
+++ b/src/git_stage_batch/batch/source/refresh.py
@@ -15,7 +15,7 @@ from .cache import (
 )
 from .snapshots import create_batch_source_commit
 from ...utils.repository_buffers import (
-    load_git_object_as_buffer,
+    read_git_object_buffer_or_none,
     load_working_tree_file_as_buffer,
 )
 from ..ownership.model import (
@@ -200,7 +200,7 @@ def _prepare_initial_cached_source_for_selection(
     if not batch_source_commit:
         return None
 
-    source_buffer = load_git_object_as_buffer(f"{batch_source_commit}:{file_path}")
+    source_buffer = read_git_object_buffer_or_none(f"{batch_source_commit}:{file_path}")
     if source_buffer is None:
         raise ValueError(
             f"Cannot read cached batch source for {file_path} at "

--- a/src/git_stage_batch/batch/state/references.py
+++ b/src/git_stage_batch/batch/state/references.py
@@ -19,7 +19,7 @@ from .metadata_schema import (
 from .batch_names import validate_batch_name
 from ...exceptions import BatchMetadataError
 from ...core.buffer import LineBuffer
-from ...utils.repository_buffers import load_git_object_as_buffer
+from ...utils.repository_buffers import read_git_object_buffer_or_none
 from ...utils.git_command import (
     run_git_command,
 )
@@ -229,7 +229,7 @@ def sync_batch_state_refs(
                 if source_commit:
                     source_buffer = source_buffers.get(file_path)
                     if source_buffer is None:
-                        source_buffer = load_git_object_as_buffer(
+                        source_buffer = read_git_object_buffer_or_none(
                             f"{source_commit}:{file_path}"
                         )
                         if source_buffer is not None:

--- a/src/git_stage_batch/commands/batch_source/binary_file_actions.py
+++ b/src/git_stage_batch/commands/batch_source/binary_file_actions.py
@@ -11,7 +11,7 @@ from ...core.buffer import (
     write_buffer_to_working_tree_path,
 )
 from ...data.file_modes import apply_git_file_mode, detect_file_mode_in_commit
-from ...utils.repository_buffers import load_git_object_as_buffer
+from ...utils.repository_buffers import read_git_object_buffer_or_none
 from ...utils.git_index import git_update_index
 from ...utils.git_repository import get_git_repository_root_path
 from ...utils.git_object_io import create_git_blob
@@ -33,7 +33,7 @@ def discard_binary_file_to_worktree(
     repo_root = get_git_repository_root_path()
     full_path = repo_root / file_path
 
-    baseline_buffer = load_git_object_as_buffer(f"{baseline_commit}:{file_path}")
+    baseline_buffer = read_git_object_buffer_or_none(f"{baseline_commit}:{file_path}")
     if baseline_buffer is not None:
         with baseline_buffer:
             write_buffer_to_path(full_path, baseline_buffer)

--- a/src/git_stage_batch/commands/batch_source/candidate_materialization.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_materialization.py
@@ -20,7 +20,7 @@ from ...batch.selection import acquire_batch_ownership_for_display_ids_from_line
 from ...core.buffer import LineBuffer
 from ...core.replacement import ReplacementPayload
 from ...utils.repository_buffers import (
-    load_git_object_as_buffer,
+    read_git_object_buffer_or_none,
     load_working_tree_file_as_buffer,
 )
 from ...exceptions import MergeError, exit_with_error
@@ -88,7 +88,7 @@ def materialize_apply_candidate(
         file_path,
         file_meta,
     )
-    batch_source_buffer = load_git_object_as_buffer(batch_source_ref.object_spec)
+    batch_source_buffer = read_git_object_buffer_or_none(batch_source_ref.object_spec)
     if batch_source_buffer is None:
         exit_with_error(
             _("Batch source content is missing for {file}.").format(file=file_path)
@@ -176,13 +176,13 @@ def materialize_include_candidate(
         file_path,
         file_meta,
     )
-    batch_source_buffer = load_git_object_as_buffer(batch_source_ref.object_spec)
+    batch_source_buffer = read_git_object_buffer_or_none(batch_source_ref.object_spec)
     if batch_source_buffer is None:
         exit_with_error(
             _("Batch source content is missing for {file}.").format(file=file_path)
         )
 
-    index_buffer = load_git_object_as_buffer(f":{file_path}")
+    index_buffer = read_git_object_buffer_or_none(f":{file_path}")
     index_exists = index_buffer is not None
     if index_buffer is None:
         index_buffer = LineBuffer.from_bytes(b"")

--- a/src/git_stage_batch/commands/batch_source/candidate_preview_builders.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_preview_builders.py
@@ -23,7 +23,7 @@ from ...data.file_review.batch_selection import (
 )
 from ...data.file_review.records import FileReviewAction
 from ...utils.repository_buffers import (
-    load_git_object_as_buffer,
+    read_git_object_buffer_or_none,
     load_working_tree_file_as_buffer,
 )
 from ...exceptions import exit_with_error
@@ -62,7 +62,7 @@ def build_batch_source_candidate_previews(
         file_path,
         file_meta,
     )
-    batch_source_buffer = load_git_object_as_buffer(batch_source_ref.object_spec)
+    batch_source_buffer = read_git_object_buffer_or_none(batch_source_ref.object_spec)
     if batch_source_buffer is None:
         exit_with_error(
             _("Batch source content is missing for {file}.").format(file=file_path)
@@ -138,7 +138,7 @@ def build_batch_source_candidate_previews(
                             selection_ids=selection_ids_to_apply,
                         )
 
-                index_buffer = load_git_object_as_buffer(f":{file_path}")
+                index_buffer = read_git_object_buffer_or_none(f":{file_path}")
                 index_exists = index_buffer is not None
                 if index_buffer is None:
                     index_buffer = LineBuffer.from_bytes(b"")

--- a/src/git_stage_batch/commands/batch_source/candidate_preview_counts.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_preview_counts.py
@@ -19,7 +19,7 @@ from ...batch.selection import acquire_batch_ownership_for_display_ids_from_line
 from ...core.buffer import LineBuffer
 from ...core.replacement import ReplacementPayload
 from ...utils.repository_buffers import (
-    load_git_object_as_buffer,
+    read_git_object_buffer_or_none,
     load_working_tree_file_as_buffer,
 )
 from ...exceptions import MergeError
@@ -38,7 +38,7 @@ def count_apply_candidate_previews_for_file(
     batch_source_ref = _candidate_inputs.candidate_batch_source_ref(file_path, file_meta)
     if batch_source_ref is None:
         return CandidatePreviewCount()
-    batch_source_buffer = load_git_object_as_buffer(batch_source_ref.object_spec)
+    batch_source_buffer = read_git_object_buffer_or_none(batch_source_ref.object_spec)
     if batch_source_buffer is None:
         return CandidatePreviewCount()
 
@@ -97,11 +97,11 @@ def count_include_candidate_previews_for_file(
     batch_source_ref = _candidate_inputs.candidate_batch_source_ref(file_path, file_meta)
     if batch_source_ref is None:
         return CandidatePreviewCount()
-    batch_source_buffer = load_git_object_as_buffer(batch_source_ref.object_spec)
+    batch_source_buffer = read_git_object_buffer_or_none(batch_source_ref.object_spec)
     if batch_source_buffer is None:
         return CandidatePreviewCount()
 
-    index_buffer = load_git_object_as_buffer(f":{file_path}")
+    index_buffer = read_git_object_buffer_or_none(f":{file_path}")
     index_exists = index_buffer is not None
     if index_buffer is None:
         index_buffer = LineBuffer.from_bytes(b"")

--- a/src/git_stage_batch/commands/batch_source/replacement_previews.py
+++ b/src/git_stage_batch/commands/batch_source/replacement_previews.py
@@ -9,13 +9,12 @@ from ..selection import replacement_selection
 from ...batch.replacement import build_replacement_batch_view_from_lines
 from ...batch.selection import acquire_batch_ownership_for_display_ids_from_lines
 from ...batch.submodule_pointer import is_batch_submodule_pointer
-from ...core.buffer import LineBuffer
 from ...core.replacement import ReplacementPayload, coerce_replacement_payload
 from ...data.file_review.batch_selection import (
     translate_batch_file_gutter_ids_to_selection_ids,
 )
 from ...data.file_review.records import FileReviewAction
-from ...utils.repository_buffers import load_git_object_as_buffer
+from ...utils.repository_buffers import read_git_object_buffer_or_none
 from ...exceptions import exit_with_error
 from ...i18n import _
 from ...output.candidate_preview_diff import render_candidate_buffer_diff
@@ -48,7 +47,9 @@ def print_batch_source_replacement_preview(
 
     replacement_selection.require_contiguous_display_selection(selected_ids)
     batch_source_commit = file_meta["batch_source_commit"]
-    batch_source_buffer = load_git_object_as_buffer(f"{batch_source_commit}:{file_path}")
+    batch_source_buffer = read_git_object_buffer_or_none(
+        f"{batch_source_commit}:{file_path}"
+    )
     if batch_source_buffer is None:
         exit_with_error(
             _("Batch source content is missing for {file}.").format(file=file_path)

--- a/src/git_stage_batch/commands/batch_source/reset_claims.py
+++ b/src/git_stage_batch/commands/batch_source/reset_claims.py
@@ -35,7 +35,7 @@ from ...batch.submodule_pointer import (
 from ...batch.state.batch_names import batch_exists
 from ...core.line_selection import LineRanges
 from ...data.batch_file_scope import resolve_batch_file_scope
-from ...utils.repository_buffers import load_git_object_as_buffer
+from ...utils.repository_buffers import read_git_object_buffer_or_none
 from ...exceptions import MergeError, exit_with_error
 from ...i18n import _
 
@@ -171,7 +171,7 @@ def reset_line_claims_for_file(
         refuse_batch_submodule_pointer_lines(_("Reset"))
 
     batch_source_commit = file_meta["batch_source_commit"]
-    batch_source_buffer = load_git_object_as_buffer(
+    batch_source_buffer = read_git_object_buffer_or_none(
         f"{batch_source_commit}:{file_path}"
     )
     if batch_source_buffer is None:
@@ -354,7 +354,7 @@ def _acquire_line_ownership_for_file(
         refuse_batch_submodule_pointer_lines(_("Reset"))
 
     batch_source_commit = file_meta["batch_source_commit"]
-    batch_source_buffer = load_git_object_as_buffer(
+    batch_source_buffer = read_git_object_buffer_or_none(
         f"{batch_source_commit}:{file_path}"
     )
     if batch_source_buffer is None:

--- a/src/git_stage_batch/commands/batch_source/text_plan_builders.py
+++ b/src/git_stage_batch/commands/batch_source/text_plan_builders.py
@@ -22,7 +22,7 @@ from ...core.text_lifecycle import (
 )
 from ...data.file_modes import detect_file_mode_in_commit
 from ...utils.repository_buffers import (
-    load_git_object_as_buffer,
+    read_git_object_buffer_or_none,
     load_working_tree_file_as_buffer,
 )
 from ...utils.git_repository import get_git_repository_root_path
@@ -91,7 +91,7 @@ def build_apply_text_file_action_plan(
         )
 
     batch_source_commit = file_meta["batch_source_commit"]
-    batch_source_buffer = load_git_object_as_buffer(
+    batch_source_buffer = read_git_object_buffer_or_none(
         f"{batch_source_commit}:{file_path}"
     )
     if batch_source_buffer is None:
@@ -144,7 +144,7 @@ def build_include_text_file_action_plan(
     """Build one deferred include-from text action plan."""
     text_change_type = normalized_text_change_type(file_meta.get("change_type"))
 
-    index_buffer = load_git_object_as_buffer(f":{file_path}")
+    index_buffer = read_git_object_buffer_or_none(f":{file_path}")
     index_exists = index_buffer is not None
     if index_buffer is None:
         index_buffer = LineBuffer.from_bytes(b"")
@@ -178,7 +178,7 @@ def build_include_text_file_action_plan(
         )
 
     batch_source_commit = file_meta["batch_source_commit"]
-    batch_source_buffer = load_git_object_as_buffer(
+    batch_source_buffer = read_git_object_buffer_or_none(
         f"{batch_source_commit}:{file_path}"
     )
     if batch_source_buffer is None:
@@ -283,13 +283,13 @@ def build_discard_text_file_action_plan(
         )
 
     batch_source_commit = file_meta["batch_source_commit"]
-    batch_source_buffer = load_git_object_as_buffer(
+    batch_source_buffer = read_git_object_buffer_or_none(
         f"{batch_source_commit}:{file_path}"
     )
     if batch_source_buffer is None:
         return DiscardTextPlanBuildResult(missing_source=True)
 
-    baseline_buffer = load_git_object_as_buffer(f"{baseline_commit}:{file_path}")
+    baseline_buffer = read_git_object_buffer_or_none(f"{baseline_commit}:{file_path}")
     baseline_exists = baseline_buffer is not None
     if baseline_buffer is None:
         baseline_buffer = LineBuffer.from_bytes(b"")
@@ -353,7 +353,7 @@ def _build_baseline_restore_text_plan(
     file_path: str,
     baseline_commit: str,
 ) -> _action_plans.DiscardTextFileActionPlan:
-    baseline_buffer = load_git_object_as_buffer(f"{baseline_commit}:{file_path}")
+    baseline_buffer = read_git_object_buffer_or_none(f"{baseline_commit}:{file_path}")
     if baseline_buffer is None:
         return _action_plans.DiscardTextFileActionPlan(
             file_path,

--- a/src/git_stage_batch/commands/batch_transform/sift_results.py
+++ b/src/git_stage_batch/commands/batch_transform/sift_results.py
@@ -31,7 +31,7 @@ from ...core.text_lifecycle import (
     normalized_text_change_type,
     sifted_empty_text_path_change_type,
 )
-from ...utils.repository_buffers import load_git_object_as_buffer_or_empty
+from ...utils.repository_buffers import read_git_object_buffer_or_empty
 from ...utils.repository_buffers import load_working_tree_file_as_buffer
 from ...exceptions import MergeError
 from ...core.text_lines import normalize_line_sequence_endings
@@ -104,7 +104,7 @@ def compute_sifted_binary_file(
     batch_source_commit = file_meta["batch_source_commit"]
     change_type = file_meta["change_type"]
 
-    batch_source_buffer = load_git_object_as_buffer_or_empty(
+    batch_source_buffer = read_git_object_buffer_or_empty(
         f"{batch_source_commit}:{file_path}"
     )
 
@@ -161,11 +161,11 @@ def compute_sifted_text_file(
     full_path = repo_root / file_path
     working_exists = full_path.exists()
 
-    batch_source_buffer = load_git_object_as_buffer_or_empty(
+    batch_source_buffer = read_git_object_buffer_or_empty(
         f"{batch_source_commit}:{file_path}"
     )
     baseline_buffer = (
-        load_git_object_as_buffer_or_empty(f"{baseline_commit}:{file_path}")
+        read_git_object_buffer_or_empty(f"{baseline_commit}:{file_path}")
         if baseline_commit is not None else
         LineBuffer.from_bytes(b"")
     )

--- a/src/git_stage_batch/commands/selection/discard_line_replacement.py
+++ b/src/git_stage_batch/commands/selection/discard_line_replacement.py
@@ -10,9 +10,6 @@ from pathlib import Path
 
 from ...batch.source.annotation import annotate_with_batch_source_working_lines
 from ...batch.state.lifecycle import create_batch
-from ...batch.ownership.model import (
-    BatchOwnership,
-)
 from ...batch.ownership.metadata_loading import acquire_ownership_for_metadata_dict
 from ...batch.ownership.merging import merge_batch_ownership
 from ...batch.ownership.remapping import remap_batch_ownership_with_lineage
@@ -24,7 +21,9 @@ from ...batch.ownership.replacement_line_runs import (
     derive_replacement_line_runs_from_lines,
 )
 from ...batch.selection import require_line_selection_in_view
-from ...batch.source.advancement import advance_source_lines_preserving_existing_presence
+from ...batch.source.advancement import (
+    advance_source_lines_preserving_existing_presence,
+)
 from ...batch.source.selected_line_refresh import (
     refresh_selected_lines_against_source_lines,
 )
@@ -42,8 +41,8 @@ from ...data.file_modes import detect_file_mode
 from ...data.file_hunk_display import build_file_hunk_from_buffer
 from ...data.line_state import load_line_changes_from_state
 from ...utils.repository_buffers import (
-    load_git_object_as_buffer,
-    load_git_object_as_buffer_or_empty,
+    read_git_object_buffer_or_none,
+    read_git_object_buffer_or_empty,
     load_working_tree_file_as_buffer,
 )
 from ...data.session import snapshot_file_if_untracked
@@ -73,7 +72,7 @@ class DiscardLineReplacementSelection:
 def derive_live_replacement_line_runs(file_path: str) -> list[ReplacementLineRun]:
     """Derive file-level replacement runs for the current live file state."""
     with (
-        load_git_object_as_buffer_or_empty(f"HEAD:{file_path}") as baseline_lines,
+        read_git_object_buffer_or_empty(f"HEAD:{file_path}") as baseline_lines,
         load_working_tree_file_as_buffer(file_path) as working_lines,
     ):
         return derive_replacement_line_runs_from_lines(
@@ -102,9 +101,7 @@ def prepare_discard_line_replacement_selection(
         requested_ids,
     )
 
-    selected_lines = [
-        line for line in line_changes.lines if line.id in effective_ids
-    ]
+    selected_lines = [line for line in line_changes.lines if line.id in effective_ids]
     if not selected_lines:
         exit_with_error(
             _("No matching lines found for selection: {ids}").format(
@@ -115,9 +112,7 @@ def prepare_discard_line_replacement_selection(
     working_file_path = get_git_repository_root_path() / line_changes.path
     if not os.path.lexists(working_file_path):
         exit_with_error(
-            _("File not found in working tree: {file}").format(
-                file=line_changes.path
-            )
+            _("File not found in working tree: {file}").format(file=line_changes.path)
         )
 
     replacement_payload = coerce_replacement_payload(replacement_text)
@@ -129,9 +124,7 @@ def prepare_discard_line_replacement_selection(
                     effective_ids,
                     replacement_payload,
                     working_lines,
-                    working_has_trailing_newline=buffer_ends_with_lf(
-                        working_lines
-                    ),
+                    working_has_trailing_newline=buffer_ends_with_lf(working_lines),
                     trim_unchanged_edge_anchors=not no_edge_overlap,
                 )
             )
@@ -252,7 +245,7 @@ def _merge_replacement_with_batch(
     existing_ownership = ownership_stack.enter_context(
         acquire_ownership_for_metadata_dict(file_metadata)
     )
-    old_source_buffer = load_git_object_as_buffer(
+    old_source_buffer = read_git_object_buffer_or_none(
         f"{current_batch_source}:{selection.file_path}"
     )
     if old_source_buffer is None:
@@ -280,9 +273,7 @@ def _merge_replacement_with_batch(
             working_lines=(),
             lineage=source_with_provenance.lineage,
         )
-        new_ownership = translate_lines_to_batch_ownership(
-            refreshed_selected_lines
-        )
+        new_ownership = translate_lines_to_batch_ownership(refreshed_selected_lines)
         batch_source_commit = create_batch_source_commit(
             selection.file_path,
             file_buffer_override=source_with_provenance.source_buffer,
@@ -319,7 +310,8 @@ def _select_rewritten_replacement_lines(
     matching_indices = [
         index
         for index, line in enumerate(rewritten_line_changes.lines)
-        if line.kind != " " and (
+        if line.kind != " "
+        and (
             line.old_line_number in original_old_lines
             or line.new_line_number in original_new_lines
         )
@@ -329,7 +321,7 @@ def _select_rewritten_replacement_lines(
         end_index = max(matching_indices)
         return [
             line
-            for line in rewritten_line_changes.lines[start_index:end_index + 1]
+            for line in rewritten_line_changes.lines[start_index : end_index + 1]
             if line.kind != " "
         ]
 

--- a/src/git_stage_batch/commands/selection/include_line_action.py
+++ b/src/git_stage_batch/commands/selection/include_line_action.py
@@ -11,7 +11,7 @@ from ...core.line_selection import parse_line_selection
 from ...data.file_review.action_scope import finish_review_scoped_line_action
 from ...data.selected_change.paths import get_selected_change_file_path
 from ...data.line_id_files import read_line_ids_file, write_line_ids_file
-from ...utils.repository_buffers import load_git_object_as_buffer
+from ...utils.repository_buffers import read_git_object_buffer_or_none
 from ...data.selected_change.store import (
     SelectedChangeKind,
     read_selected_change_kind,
@@ -72,7 +72,7 @@ def include_live_line_selection(
             )
         combined_include_ids = already_included_ids | set(requested_ids)
 
-        current_index_buffer = load_git_object_as_buffer(f":{line_changes.path}")
+        current_index_buffer = read_git_object_buffer_or_none(f":{line_changes.path}")
         if current_index_buffer is None:
             current_index_buffer = LineBuffer.from_bytes(b"")
 

--- a/src/git_stage_batch/commands/selection/include_line_replacement.py
+++ b/src/git_stage_batch/commands/selection/include_line_replacement.py
@@ -14,7 +14,7 @@ from ...data.file_hunk_display import render_unstaged_file_as_single_hunk
 from ...data.selected_change.file_hunk_cache import cache_unstaged_file_as_single_hunk
 from ...data.line_state import load_line_changes_from_state
 from ...utils.repository_buffers import (
-    load_git_object_as_buffer_or_empty,
+    read_git_object_buffer_or_empty,
     load_working_tree_file_as_buffer,
 )
 from ...data.selected_change.loading import require_selected_hunk
@@ -148,7 +148,7 @@ def prepare_pathless_include_line_replacement(
         if translated_replacement is not None:
             replacement_line_changes, replacement_ids = translated_replacement
             replacement_line_id_specification = format_line_ids(sorted(replacement_ids))
-            replacement_base_buffer = load_git_object_as_buffer_or_empty(
+            replacement_base_buffer = read_git_object_buffer_or_empty(
                 f":{line_changes.path}"
             )
             replacement_source_buffer = load_working_tree_file_as_buffer(
@@ -209,7 +209,7 @@ def prepare_file_include_line_replacement(
     return IncludeLineReplacementFileSelection(
         target_file=target_file,
         line_changes=annotate_with_batch_source(target_file, cached_lines),
-        base_buffer=load_git_object_as_buffer_or_empty(f":{target_file}"),
+        base_buffer=read_git_object_buffer_or_empty(f":{target_file}"),
         source_buffer=load_working_tree_file_as_buffer(target_file),
         preserve_selected_state=preserve_selected_state,
         saved_selected_state=saved_selected_state,

--- a/src/git_stage_batch/commands/selection/include_line_selection.py
+++ b/src/git_stage_batch/commands/selection/include_line_selection.py
@@ -24,7 +24,7 @@ from ...data.file_modes import detect_file_mode
 from ...data.file_tracking import auto_add_untracked_files
 from ...data.line_state import load_line_changes_from_state
 from ...utils.repository_buffers import (
-    load_git_object_as_buffer,
+    read_git_object_buffer_or_none,
     load_working_tree_file_as_buffer,
 )
 from ...data.selected_change.loading import require_selected_hunk
@@ -320,7 +320,7 @@ def try_build_index_content_via_transient_batch(
                     TransientIncludeFailureReason.MISSING_BATCH_METADATA
                 )
 
-            source_buffer = load_git_object_as_buffer(
+            source_buffer = read_git_object_buffer_or_none(
                 f"{batch_source_commit}:{line_changes.path}"
             )
             if source_buffer is None:

--- a/src/git_stage_batch/data/file_hunk_display.py
+++ b/src/git_stage_batch/data/file_hunk_display.py
@@ -23,7 +23,7 @@ from ..core.models import (
     TextFileDeletionChange,
 )
 from ..core.buffer import LineBuffer
-from ..utils.repository_buffers import load_git_object_as_buffer
+from ..utils.repository_buffers import read_git_object_buffer_or_none
 from ..i18n import ngettext
 from ..utils.git_command import stream_git_command
 from ..git_paths import encode_path, quote_path_token
@@ -76,7 +76,7 @@ def build_file_hunk_from_buffer(
     file_buffer: LineBuffer,
 ) -> Optional[LineLevelChange]:
     """Build a file-scoped line view for a hypothetical file buffer without writing it."""
-    head_buffer = load_git_object_as_buffer(f"HEAD:{file_path}")
+    head_buffer = read_git_object_buffer_or_none(f"HEAD:{file_path}")
 
     with tempfile.NamedTemporaryFile(delete=False) as old_tmp:
         if head_buffer is not None:

--- a/src/git_stage_batch/data/selected_change/snapshots.py
+++ b/src/git_stage_batch/data/selected_change/snapshots.py
@@ -11,7 +11,7 @@ from ...core.buffer import (
     buffer_preview,
     write_buffer_to_path,
 )
-from ...utils.repository_buffers import load_git_object_as_buffer
+from ...utils.repository_buffers import read_git_object_buffer_or_none
 from ...utils.git_repository import get_git_repository_root_path
 from ...utils.journal import JournalLevel, journal_enabled, log_journal
 from ...utils.paths import get_index_snapshot_file_path, get_working_tree_snapshot_file_path
@@ -20,7 +20,7 @@ from ...utils.paths import get_index_snapshot_file_path, get_working_tree_snapsh
 def write_snapshots_for_selected_file_path(file_path: str) -> None:
     """Write snapshots of the file from both the index and working tree."""
     with ExitStack() as stack:
-        index_version = load_git_object_as_buffer(f":{file_path}")
+        index_version = read_git_object_buffer_or_none(f":{file_path}")
         if index_version is None:
             index_version = LineBuffer.from_bytes(b"")
         stack.enter_context(index_version)
@@ -37,7 +37,7 @@ def write_snapshots_for_selected_file_path(file_path: str) -> None:
         # For new files (not in HEAD), use empty index snapshot.
         # For existing files with intent-to-add applied, use HEAD content.
         if buffer_byte_count(index_version) == 0 and buffer_byte_count(working_tree_version) > 0:
-            head_version = load_git_object_as_buffer(f"HEAD:{file_path}")
+            head_version = read_git_object_buffer_or_none(f"HEAD:{file_path}")
             if head_version is not None:
                 if buffer_byte_count(head_version) > 0:
                     index_version = stack.enter_context(head_version)
@@ -115,7 +115,7 @@ def snapshots_are_stale(file_path: str) -> bool:
                 LineBuffer.from_path(snapshot_new_path)
             )
 
-            selected_index_content = load_git_object_as_buffer(f":{file_path}")
+            selected_index_content = read_git_object_buffer_or_none(f":{file_path}")
             if selected_index_content is None:
                 selected_index_content = LineBuffer.from_bytes(b"")
             stack.enter_context(selected_index_content)

--- a/src/git_stage_batch/data/text_lifecycle_detection.py
+++ b/src/git_stage_batch/data/text_lifecycle_detection.py
@@ -6,7 +6,7 @@ from contextlib import ExitStack
 
 from ..core.buffer import LineBuffer, buffer_byte_count
 from ..core.text_lifecycle import TextFileChangeType
-from ..utils.repository_buffers import load_git_object_as_buffer
+from ..utils.repository_buffers import read_git_object_buffer_or_none
 from ..utils.git_repository import get_git_repository_root_path
 
 
@@ -24,13 +24,13 @@ def detect_empty_text_lifecycle_change(
             if buffer_byte_count(working_buffer) != 0:
                 return None
 
-            baseline_buffer = load_git_object_as_buffer(f"{baseline_ref}:{file_path}")
+            baseline_buffer = read_git_object_buffer_or_none(f"{baseline_ref}:{file_path}")
             if baseline_buffer is None:
                 return TextFileChangeType.ADDED
             baseline_buffer.close()
             return None
 
-        baseline_buffer = load_git_object_as_buffer(f"{baseline_ref}:{file_path}")
+        baseline_buffer = read_git_object_buffer_or_none(f"{baseline_ref}:{file_path}")
         if baseline_buffer is not None:
             stack.enter_context(baseline_buffer)
             if buffer_byte_count(baseline_buffer) == 0:

--- a/src/git_stage_batch/exceptions.py
+++ b/src/git_stage_batch/exceptions.py
@@ -16,6 +16,30 @@ class CommandError(Exception):
         super().__init__(message)
 
 
+class RepositoryReadError(Exception):
+    """Base class for failures while reading repository state."""
+
+
+class RepositoryObjectMissing(RepositoryReadError):
+    """Raised when a requested Git object or path is absent."""
+
+
+class RepositoryPathMissing(RepositoryReadError):
+    """Raised when a requested working-tree path is absent."""
+
+
+class RepositoryPathInaccessible(RepositoryReadError):
+    """Raised when repository data exists but cannot be read."""
+
+
+class RepositoryDataInvalid(RepositoryReadError):
+    """Raised when repository data has an unsupported or invalid shape."""
+
+
+class GitOperationFailed(RepositoryReadError):
+    """Raised when Git fails while reading repository state."""
+
+
 def exit_with_error(message: str, exit_code: int = 1) -> None:
     """Raise a CommandError instead of exiting directly."""
     raise CommandError(message, exit_code)
@@ -23,16 +47,19 @@ def exit_with_error(message: str, exit_code: int = 1) -> None:
 
 class QuitInteractive(Exception):
     """Raised to exit the interactive mode main loop."""
+
     pass
 
 
 class BypassRefresh(Exception):
     """Raised when an action should not refresh the display."""
+
     pass
 
 
 class MergeError(Exception):
     """Raised when batch merge fails due to structural ambiguity."""
+
     pass
 
 
@@ -84,6 +111,7 @@ class MissingAnchorError(MergeError):
     This is a recoverable condition during discard: the absence claim
     is simply not applicable to the current state.
     """
+
     pass
 
 
@@ -93,6 +121,7 @@ class AmbiguousAnchorError(MergeError):
     This is not recoverable: structural ambiguity means we cannot determine
     the correct boundary for the deletion.
     """
+
     pass
 
 
@@ -106,6 +135,7 @@ class AtomicUnitError(MergeError):
         required_selection_ids: Selection IDs that must be selected together
         unit_kind: Kind of unit (for error messages)
     """
+
     def __init__(
         self,
         message: str,
@@ -119,6 +149,7 @@ class AtomicUnitError(MergeError):
 
 class NoMoreHunks(Exception):
     """Raised when there are no more hunks or binary files to process."""
+
     pass
 
 
@@ -128,4 +159,5 @@ class BatchMetadataError(Exception):
     This represents infrastructure/state corruption distinct from semantic
     merge conflicts or batch content issues.
     """
+
     pass

--- a/src/git_stage_batch/utils/git_repository.py
+++ b/src/git_stage_batch/utils/git_repository.py
@@ -126,27 +126,3 @@ def object_id_hex_length() -> int:
 def null_object_id() -> str:
     """Return Git's all-zero object ID at the repository's native width."""
     return "0" * object_id_hex_length()
-
-
-def resolve_file_path_to_repo_relative(file_path: str) -> str:
-    """Convert a file path to repository-relative format.
-
-    Args:
-        file_path: File path to convert
-
-    Returns:
-        Repository-relative path, or original path if outside repo
-    """
-    repo_root = get_git_repository_root_path()
-    path = Path(file_path)
-
-    # If it's already relative, use it as-is
-    if not path.is_absolute():
-        return file_path
-
-    # If it's absolute, make it relative to repo root
-    try:
-        return str(path.relative_to(repo_root))
-    except ValueError:
-        # Path is outside repo, return as-is
-        return file_path

--- a/src/git_stage_batch/utils/repository_buffers.py
+++ b/src/git_stage_batch/utils/repository_buffers.py
@@ -3,17 +3,28 @@
 from __future__ import annotations
 
 import os
+import errno
+import stat
 import subprocess
 from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 
 from ..core.buffer import LineBuffer
 from ..utils.git_command import stream_git_command
+from ..utils.git_command import run_git_command
 from ..utils.git_repository import get_git_repository_root_path
 from ..utils.git_object_io import (
     list_git_tree_blobs,
     read_git_blob,
     stream_git_blobs,
+    resolve_git_objects,
+)
+from ..exceptions import (
+    GitOperationFailed,
+    RepositoryDataInvalid,
+    RepositoryObjectMissing,
+    RepositoryPathInaccessible,
+    RepositoryPathMissing,
 )
 
 
@@ -25,6 +36,15 @@ class GitBlobBuffer:
     object_id: str
     size: int
     buffer: LineBuffer
+
+
+@dataclass(frozen=True)
+class WorkingTreeObject:
+    """Content and Git-visible metadata for one worktree directory entry."""
+
+    buffer: LineBuffer
+    kind: str
+    git_mode: str
 
 
 def load_git_blob_as_buffer(blob_sha: str) -> LineBuffer:
@@ -64,32 +84,108 @@ def load_git_tree_files_as_buffers(
     return buffers
 
 
-def load_git_object_as_buffer(revision_path: str) -> LineBuffer | None:
-    """Load a Git object as a line buffer."""
+def read_git_object_buffer_or_none(revision_path: str) -> LineBuffer | None:
+    """Load a Git object, returning ``None`` only when it is absent."""
+    # cat-file's traditional batch protocol is line-delimited and cannot
+    # represent object expressions containing newlines. Validate the revision
+    # independently, then use argv-safe `git show` for these unusual paths.
     try:
-        return LineBuffer.from_chunks(_stream_git_object(revision_path))
-    except subprocess.CalledProcessError:
+        revision_path.encode("utf-8")
+        batch_protocol_safe = "\n" not in revision_path and "\r" not in revision_path
+    except UnicodeEncodeError:
+        batch_protocol_safe = False
+    if not batch_protocol_safe:
+        revision = (
+            revision_path[1:]
+            if revision_path.startswith(":")
+            else revision_path.split(":", 1)[0]
+        )
+        if not revision_path.startswith(":"):
+            try:
+                run_git_command(
+                    ["rev-parse", "--verify", f"{revision}^{{tree}}"],
+                    requires_index_lock=False,
+                )
+            except subprocess.CalledProcessError as error:
+                raise GitOperationFailed(
+                    f"Could not resolve Git revision {revision!r}"
+                ) from error
+        try:
+            return LineBuffer.from_chunks(_stream_git_object(revision_path))
+        except subprocess.CalledProcessError:
+            return None
+    try:
+        resolved = resolve_git_objects([revision_path]).get(revision_path)
+    except (subprocess.CalledProcessError, RuntimeError) as error:
+        raise GitOperationFailed(
+            f"Could not resolve Git object {revision_path!r}"
+        ) from error
+    if resolved is None:
         return None
+    if resolved.object_type != "blob":
+        raise RepositoryDataInvalid(
+            f"Git object {revision_path!r} is {resolved.object_type}, not a blob"
+        )
+    try:
+        return load_git_blob_as_buffer(resolved.object_id)
+    except (subprocess.CalledProcessError, RuntimeError) as error:
+        raise GitOperationFailed(
+            f"Could not read Git object {revision_path!r}"
+        ) from error
 
 
-def load_git_object_as_buffer_or_empty(revision_path: str) -> LineBuffer:
+def read_git_object_buffer(revision_path: str) -> LineBuffer:
+    """Load a Git blob or raise a typed missing/failure exception."""
+    buffer = read_git_object_buffer_or_none(revision_path)
+    if buffer is None:
+        raise RepositoryObjectMissing(revision_path)
+    return buffer
+
+
+def read_git_object_buffer_or_empty(revision_path: str) -> LineBuffer:
     """Load a Git object as a line buffer, or an empty buffer if missing."""
-    buffer = load_git_object_as_buffer(revision_path)
+    buffer = read_git_object_buffer_or_none(revision_path)
     if buffer is None:
         return LineBuffer.from_bytes(b"")
     return buffer
 
 
 def load_working_tree_file_as_buffer(file_path: str) -> LineBuffer:
-    """Load a working-tree file as a line buffer."""
+    """Load a working-tree file, returning empty only when it is absent."""
+    try:
+        return read_working_tree_object(file_path).buffer
+    except RepositoryPathMissing:
+        return LineBuffer.from_bytes(b"")
+
+
+def read_working_tree_object(file_path: str) -> WorkingTreeObject:
+    """Read Git-visible worktree content without following symlinks."""
     repo_root = get_git_repository_root_path()
     full_path = repo_root / file_path
     try:
-        if full_path.is_symlink():
-            return LineBuffer.from_bytes(os.readlink(os.fsencode(full_path)))
-        return LineBuffer.from_path(full_path)
-    except OSError:
-        return LineBuffer.from_bytes(b"")
+        metadata = full_path.lstat()
+        if stat.S_ISLNK(metadata.st_mode):
+            return WorkingTreeObject(
+                buffer=LineBuffer.from_bytes(os.readlink(os.fsencode(full_path))),
+                kind="symlink",
+                git_mode="120000",
+            )
+        if not stat.S_ISREG(metadata.st_mode):
+            raise RepositoryDataInvalid(
+                f"Unsupported working-tree path kind: {file_path}"
+            )
+        mode = "100755" if metadata.st_mode & stat.S_IXUSR else "100644"
+        return WorkingTreeObject(
+            buffer=LineBuffer.from_path(full_path),
+            kind="regular",
+            git_mode=mode,
+        )
+    except OSError as error:
+        if error.errno in (errno.ENOENT, errno.ENOTDIR):
+            raise RepositoryPathMissing(file_path) from error
+        raise RepositoryPathInaccessible(
+            f"Could not read working-tree path {file_path!r}"
+        ) from error
 
 
 def _stream_git_object(revision_path: str) -> Iterator[bytes]:

--- a/tests/batch/ownership/test_model.py
+++ b/tests/batch/ownership/test_model.py
@@ -25,7 +25,7 @@ from git_stage_batch.core.diff_parser import (
     build_line_changes_from_patch_lines,
 )
 from git_stage_batch.utils.repository_buffers import (
-    load_git_object_as_buffer_or_empty,
+    read_git_object_buffer_or_empty,
     load_working_tree_file_as_buffer,
 )
 from git_stage_batch.utils.git_command import stream_git_command
@@ -92,7 +92,7 @@ def _point_batch_state_refs(batch_names, state_commit: str) -> None:
 
 
 def _enumerate_units_from_head_and_working_tree(file_path: str):
-    baseline_buffer = load_git_object_as_buffer_or_empty(f"HEAD:{file_path}")
+    baseline_buffer = read_git_object_buffer_or_empty(f"HEAD:{file_path}")
     working_tree_buffer = load_working_tree_file_as_buffer(file_path)
 
     with baseline_buffer as baseline_lines, working_tree_buffer as working_tree_lines:

--- a/tests/batch/source/test_annotation.py
+++ b/tests/batch/source/test_annotation.py
@@ -102,7 +102,7 @@ def test_annotate_with_batch_source_working_lines_accepts_sequences(
     )
     monkeypatch.setattr(
         source_annotation_module,
-        "load_git_object_as_buffer",
+        "read_git_object_buffer_or_none",
         lambda revision_path: LineBuffer.from_chunks(
             iter([b"line 1\n", b"line 2\n"])
         ),
@@ -169,14 +169,14 @@ def test_annotate_with_batch_source_loads_indexed_buffers(monkeypatch, tmp_path)
         lambda path: "source-commit",
     )
 
-    def fake_load_git_object_as_buffer(revision_path):
+    def fake_read_git_object_buffer_or_none(revision_path):
         loaded_revisions.append(revision_path)
         return LineBuffer.from_chunks(iter([b"line 1\n", b"line 2\n"]))
 
     monkeypatch.setattr(
         source_annotation_module,
-        "load_git_object_as_buffer",
-        fake_load_git_object_as_buffer,
+        "read_git_object_buffer_or_none",
+        fake_read_git_object_buffer_or_none,
     )
 
     def fake_load_working_tree_file_as_buffer(path):

--- a/tests/batch/test_binary_file_content.py
+++ b/tests/batch/test_binary_file_content.py
@@ -17,7 +17,7 @@ def test_read_binary_file_from_batch_returns_none_for_deletion(monkeypatch):
     def fail_load(_spec):
         raise AssertionError("deleted binary entries should not load content")
 
-    monkeypatch.setattr(binary_file_content, "load_git_object_as_buffer", fail_load)
+    monkeypatch.setattr(binary_file_content, "read_git_object_buffer_or_none", fail_load)
 
     assert binary_file_content.read_binary_file_from_batch(
         "feature",
@@ -53,7 +53,7 @@ def test_read_binary_file_from_batch_reports_missing_content(monkeypatch):
     )
     monkeypatch.setattr(
         binary_file_content,
-        "load_git_object_as_buffer",
+        "read_git_object_buffer_or_none",
         lambda spec: None,
     )
 
@@ -79,7 +79,7 @@ def test_read_binary_file_from_batch_accepts_missing_content_message(monkeypatch
     )
     monkeypatch.setattr(
         binary_file_content,
-        "load_git_object_as_buffer",
+        "read_git_object_buffer_or_none",
         lambda spec: None,
     )
 
@@ -109,7 +109,7 @@ def test_read_binary_file_from_batch_loads_batch_blob(monkeypatch):
         loaded_specs.append(spec)
         return buffer
 
-    monkeypatch.setattr(binary_file_content, "load_git_object_as_buffer", load)
+    monkeypatch.setattr(binary_file_content, "read_git_object_buffer_or_none", load)
 
     try:
         assert binary_file_content.read_binary_file_from_batch(

--- a/tests/commands/batch_source/test_binary_file_actions.py
+++ b/tests/commands/batch_source/test_binary_file_actions.py
@@ -22,7 +22,7 @@ def test_discard_binary_file_to_worktree_restores_baseline(
     baseline_buffer = LineBuffer.from_bytes(b"baseline")
     monkeypatch.setattr(
         binary_file_actions,
-        "load_git_object_as_buffer",
+        "read_git_object_buffer_or_none",
         lambda spec: baseline_buffer if spec == "base:image.png" else None,
     )
     monkeypatch.setattr(
@@ -62,7 +62,7 @@ def test_discard_binary_file_to_worktree_deletes_without_baseline(
     )
     monkeypatch.setattr(
         binary_file_actions,
-        "load_git_object_as_buffer",
+        "read_git_object_buffer_or_none",
         lambda spec: None,
     )
     target = tmp_path / "image.png"
@@ -89,7 +89,7 @@ def test_discard_binary_file_to_worktree_ignores_missing_path_without_baseline(
     )
     monkeypatch.setattr(
         binary_file_actions,
-        "load_git_object_as_buffer",
+        "read_git_object_buffer_or_none",
         lambda spec: None,
     )
 

--- a/tests/commands/batch_source/test_candidate_materialization.py
+++ b/tests/commands/batch_source/test_candidate_materialization.py
@@ -73,7 +73,7 @@ def _patch_apply_materialization_io(monkeypatch, tmp_path):
     )
     monkeypatch.setattr(
         materialization,
-        "load_git_object_as_buffer",
+        "read_git_object_buffer_or_none",
         lambda spec: batch_buffer if spec == "commit:notes.txt" else None,
     )
     monkeypatch.setattr(
@@ -247,7 +247,7 @@ def _patch_include_materialization_io(monkeypatch, tmp_path):
     worktree_buffer = LineBuffer.from_bytes(b"worktree\n")
     (tmp_path / "notes.txt").write_bytes(b"worktree\n")
 
-    def load_git_object_as_buffer(spec):
+    def read_git_object_buffer_or_none(spec):
         if spec == "commit:notes.txt":
             return batch_buffer
         if spec == ":notes.txt":
@@ -261,8 +261,8 @@ def _patch_include_materialization_io(monkeypatch, tmp_path):
     )
     monkeypatch.setattr(
         materialization,
-        "load_git_object_as_buffer",
-        load_git_object_as_buffer,
+        "read_git_object_buffer_or_none",
+        read_git_object_buffer_or_none,
     )
     monkeypatch.setattr(
         materialization,

--- a/tests/commands/batch_source/test_candidate_preview_builders.py
+++ b/tests/commands/batch_source/test_candidate_preview_builders.py
@@ -53,7 +53,7 @@ def _patch_common_candidate_builder_io(monkeypatch, tmp_path):
         "get_git_repository_root_path",
         lambda: tmp_path,
     )
-    monkeypatch.setattr(builders, "load_git_object_as_buffer", load_git_object)
+    monkeypatch.setattr(builders, "read_git_object_buffer_or_none", load_git_object)
     monkeypatch.setattr(
         builders,
         "load_working_tree_file_as_buffer",

--- a/tests/commands/batch_source/test_candidate_preview_counts.py
+++ b/tests/commands/batch_source/test_candidate_preview_counts.py
@@ -58,7 +58,7 @@ def _patch_apply_candidate_count_io(monkeypatch, tmp_path):
     )
     monkeypatch.setattr(
         counts,
-        "load_git_object_as_buffer",
+        "read_git_object_buffer_or_none",
         lambda spec: batch_buffer if spec == "commit:notes.txt" else None,
     )
     monkeypatch.setattr(
@@ -93,7 +93,7 @@ def _patch_include_candidate_count_io(monkeypatch, tmp_path):
         "get_git_repository_root_path",
         lambda: tmp_path,
     )
-    monkeypatch.setattr(counts, "load_git_object_as_buffer", load_git_object)
+    monkeypatch.setattr(counts, "read_git_object_buffer_or_none", load_git_object)
     monkeypatch.setattr(
         counts,
         "load_working_tree_file_as_buffer",
@@ -151,7 +151,7 @@ def test_count_apply_candidate_previews_for_file_skips_binary_entries(monkeypatc
     """Apply candidate counting should ignore binary batch entries."""
     monkeypatch.setattr(
         counts,
-        "load_git_object_as_buffer",
+        "read_git_object_buffer_or_none",
         lambda spec: (_ for _ in ()).throw(AssertionError("unexpected load")),
     )
 

--- a/tests/commands/batch_source/test_replacement_previews.py
+++ b/tests/commands/batch_source/test_replacement_previews.py
@@ -82,7 +82,7 @@ def test_print_batch_source_replacement_preview_prints_diff(
         )
         return "diff\n"
 
-    monkeypatch.setattr(previews, "load_git_object_as_buffer", load_git_object)
+    monkeypatch.setattr(previews, "read_git_object_buffer_or_none", load_git_object)
     monkeypatch.setattr(
         previews,
         "acquire_batch_ownership_for_display_ids_from_lines",
@@ -158,7 +158,7 @@ def test_print_batch_source_replacement_preview_reports_missing_source(
     monkeypatch,
 ):
     """Replacement previews should report missing batch source content."""
-    monkeypatch.setattr(previews, "load_git_object_as_buffer", lambda spec: None)
+    monkeypatch.setattr(previews, "read_git_object_buffer_or_none", lambda spec: None)
 
     with pytest.raises(CommandError) as exc_info:
         previews.print_batch_source_replacement_preview(

--- a/tests/commands/batch_source/test_text_plan_builders.py
+++ b/tests/commands/batch_source/test_text_plan_builders.py
@@ -61,7 +61,7 @@ def _patch_apply_text_plan_io(monkeypatch, tmp_path, ownership: _Ownership):
     )
     monkeypatch.setattr(
         builders,
-        "load_git_object_as_buffer",
+        "read_git_object_buffer_or_none",
         lambda spec: batch_buffer if spec == "commit:notes.txt" else None,
     )
     monkeypatch.setattr(
@@ -89,7 +89,7 @@ def _patch_include_text_plan_io(monkeypatch, tmp_path, ownership: _Ownership):
         lambda: tmp_path,
     )
 
-    def load_git_object_as_buffer(spec):
+    def read_git_object_buffer_or_none(spec):
         if spec == ":notes.txt":
             return index_buffer
         if spec == "commit:notes.txt":
@@ -98,8 +98,8 @@ def _patch_include_text_plan_io(monkeypatch, tmp_path, ownership: _Ownership):
 
     monkeypatch.setattr(
         builders,
-        "load_git_object_as_buffer",
-        load_git_object_as_buffer,
+        "read_git_object_buffer_or_none",
+        read_git_object_buffer_or_none,
     )
     monkeypatch.setattr(
         builders,
@@ -136,7 +136,7 @@ def _patch_discard_text_plan_io(
         lambda: tmp_path,
     )
 
-    def load_git_object_as_buffer(spec):
+    def read_git_object_buffer_or_none(spec):
         if spec == "commit:notes.txt":
             return batch_buffer
         if spec == "baseline:notes.txt":
@@ -145,8 +145,8 @@ def _patch_discard_text_plan_io(
 
     monkeypatch.setattr(
         builders,
-        "load_git_object_as_buffer",
-        load_git_object_as_buffer,
+        "read_git_object_buffer_or_none",
+        read_git_object_buffer_or_none,
     )
     monkeypatch.setattr(
         builders,
@@ -224,7 +224,7 @@ def test_build_apply_text_file_action_plan_returns_deleted_plan(
     )
     monkeypatch.setattr(
         builders,
-        "load_git_object_as_buffer",
+        "read_git_object_buffer_or_none",
         lambda spec: (_ for _ in ()).throw(AssertionError("unexpected load")),
     )
 
@@ -259,7 +259,7 @@ def test_build_apply_text_file_action_plan_reports_missing_source(
     )
     monkeypatch.setattr(
         builders,
-        "load_git_object_as_buffer",
+        "read_git_object_buffer_or_none",
         lambda spec: None,
     )
 
@@ -368,15 +368,15 @@ def test_build_discard_text_file_action_plan_restores_lifecycle_baseline(
     """Whole-path discard planning should restore baseline content."""
     baseline_buffer = LineBuffer.from_bytes(b"baseline\n")
 
-    def load_git_object_as_buffer(spec):
+    def read_git_object_buffer_or_none(spec):
         if spec == "baseline:notes.txt":
             return baseline_buffer
         raise AssertionError("unexpected load")
 
     monkeypatch.setattr(
         builders,
-        "load_git_object_as_buffer",
-        load_git_object_as_buffer,
+        "read_git_object_buffer_or_none",
+        read_git_object_buffer_or_none,
     )
     monkeypatch.setattr(
         builders,
@@ -411,7 +411,7 @@ def test_build_discard_text_file_action_plan_deletes_lifecycle_without_baseline(
     """Whole-path discard planning should delete paths absent from baseline."""
     monkeypatch.setattr(
         builders,
-        "load_git_object_as_buffer",
+        "read_git_object_buffer_or_none",
         lambda spec: None,
     )
     monkeypatch.setattr(
@@ -445,7 +445,7 @@ def test_build_discard_text_file_action_plan_reports_missing_source(
     """Missing batch source content should stay visible to the command."""
     monkeypatch.setattr(
         builders,
-        "load_git_object_as_buffer",
+        "read_git_object_buffer_or_none",
         lambda spec: None,
     )
 
@@ -708,15 +708,15 @@ def test_build_include_text_file_action_plan_returns_deleted_plan(
         lambda: tmp_path,
     )
 
-    def load_git_object_as_buffer(spec):
+    def read_git_object_buffer_or_none(spec):
         if spec == ":notes.txt":
             return index_buffer
         raise AssertionError("unexpected load")
 
     monkeypatch.setattr(
         builders,
-        "load_git_object_as_buffer",
-        load_git_object_as_buffer,
+        "read_git_object_buffer_or_none",
+        read_git_object_buffer_or_none,
     )
 
     result = builders.build_include_text_file_action_plan(
@@ -754,15 +754,15 @@ def test_build_include_text_file_action_plan_reports_missing_source(
         lambda: tmp_path,
     )
 
-    def load_git_object_as_buffer(spec):
+    def read_git_object_buffer_or_none(spec):
         if spec == ":notes.txt":
             return index_buffer
         return None
 
     monkeypatch.setattr(
         builders,
-        "load_git_object_as_buffer",
-        load_git_object_as_buffer,
+        "read_git_object_buffer_or_none",
+        read_git_object_buffer_or_none,
     )
 
     result = builders.build_include_text_file_action_plan(

--- a/tests/commands/batch_transform/test_sift_results.py
+++ b/tests/commands/batch_transform/test_sift_results.py
@@ -17,7 +17,7 @@ def test_compute_sifted_binary_file_removes_matching_content(
     (tmp_path / "data.bin").write_bytes(b"target")
     monkeypatch.setattr(
         sift_results,
-        "load_git_object_as_buffer_or_empty",
+        "read_git_object_buffer_or_empty",
         lambda spec: batch_source_buffer,
     )
 
@@ -44,7 +44,7 @@ def test_compute_sifted_binary_file_retains_changed_content(
     (tmp_path / "data.bin").write_bytes(b"working")
     monkeypatch.setattr(
         sift_results,
-        "load_git_object_as_buffer_or_empty",
+        "read_git_object_buffer_or_empty",
         lambda spec: batch_source_buffer,
     )
 
@@ -76,7 +76,7 @@ def test_compute_sifted_binary_file_removes_absent_deletion(
     batch_source_buffer = LineBuffer.from_bytes(b"")
     monkeypatch.setattr(
         sift_results,
-        "load_git_object_as_buffer_or_empty",
+        "read_git_object_buffer_or_empty",
         lambda spec: batch_source_buffer,
     )
 
@@ -103,7 +103,7 @@ def test_compute_sifted_binary_file_retains_existing_deletion(
     (tmp_path / "data.bin").write_bytes(b"working")
     monkeypatch.setattr(
         sift_results,
-        "load_git_object_as_buffer_or_empty",
+        "read_git_object_buffer_or_empty",
         lambda spec: batch_source_buffer,
     )
 

--- a/tests/commands/test_show_from.py
+++ b/tests/commands/test_show_from.py
@@ -340,14 +340,14 @@ class TestCommandShowFromBatch:
         command_start()
         command_include_to_batch("preview-batch", quiet=True)
 
-        original_load_git_object_as_buffer = file_display.load_git_object_as_buffer
+        original_read_git_object_buffer_or_none = file_display.read_git_object_buffer_or_none
         loaded_revisions = []
 
-        def tracking_load_git_object_as_buffer(revision_path):
+        def tracking_read_git_object_buffer_or_none(revision_path):
             loaded_revisions.append(revision_path)
-            return original_load_git_object_as_buffer(revision_path)
+            return original_read_git_object_buffer_or_none(revision_path)
 
-        monkeypatch.setattr(file_display, "load_git_object_as_buffer", tracking_load_git_object_as_buffer)
+        monkeypatch.setattr(file_display, "read_git_object_buffer_or_none", tracking_read_git_object_buffer_or_none)
 
         rendered = render_batch_file_display(
             "preview-batch",

--- a/tests/utils/test_git_repository.py
+++ b/tests/utils/test_git_repository.py
@@ -9,8 +9,8 @@ from git_stage_batch.exceptions import CommandError
 from git_stage_batch.utils.git_repository import (
     get_git_repository_root_path,
     require_git_repository,
-    resolve_file_path_to_repo_relative,
 )
+from git_stage_batch.utils.repository_path import normalize_repository_path
 
 
 @pytest.fixture
@@ -35,7 +35,9 @@ def temp_git_repo(tmp_path, monkeypatch):
     )
 
     (repo / "README.md").write_text("# Test\n")
-    subprocess.run(["git", "add", "README.md"], check=True, cwd=repo, capture_output=True)
+    subprocess.run(
+        ["git", "add", "README.md"], check=True, cwd=repo, capture_output=True
+    )
     subprocess.run(
         ["git", "commit", "-m", "Initial commit"],
         check=True,
@@ -83,25 +85,24 @@ class TestGetGitRepositoryRootPath:
         assert root == temp_git_repo
 
 
-class TestResolveFilePathToRepoRelative:
-    """Tests for resolve_file_path_to_repo_relative function."""
+class TestNormalizeRepositoryPath:
+    """Tests for normalized repository paths."""
 
-    def test_resolve_file_path_to_repo_relative_relative(self, temp_git_repo):
+    def test_normalizes_relative_path(self, temp_git_repo):
         """Test that relative paths are returned as-is."""
-        result = resolve_file_path_to_repo_relative("src/file.py")
+        result = normalize_repository_path("src/file.py").value
 
         assert result == "src/file.py"
 
-    def test_resolve_file_path_to_repo_relative_absolute(self, temp_git_repo):
+    def test_normalizes_absolute_path(self, temp_git_repo):
         """Test that absolute paths inside repo are made relative."""
         absolute_path = str(temp_git_repo / "src" / "file.py")
-        result = resolve_file_path_to_repo_relative(absolute_path)
+        result = normalize_repository_path(absolute_path).value
 
         assert result == "src/file.py"
 
-    def test_resolve_file_path_to_repo_relative_outside_repo(self, temp_git_repo, tmp_path):
-        """Test that paths outside repo are returned as-is."""
+    def test_rejects_path_outside_repository(self, temp_git_repo, tmp_path):
+        """Test that paths outside the repository are rejected."""
         outside_path = str(tmp_path / "outside.txt")
-        result = resolve_file_path_to_repo_relative(outside_path)
-
-        assert result == outside_path
+        with pytest.raises(CommandError, match="outside the repository"):
+            normalize_repository_path(outside_path)

--- a/tests/utils/test_repository_buffers.py
+++ b/tests/utils/test_repository_buffers.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import subprocess
 
 import pytest
 
@@ -10,13 +9,17 @@ from git_stage_batch.core.buffer import LineBuffer
 import git_stage_batch.utils.repository_buffers as repository_buffers
 from git_stage_batch.utils.repository_buffers import (
     load_git_blob_as_buffer,
-    load_git_object_as_buffer,
-    load_git_object_as_buffer_or_empty,
+    read_git_object_buffer_or_none,
+    read_git_object_buffer_or_empty,
     load_git_tree_files_as_buffers,
     load_working_tree_file_as_buffer,
     stream_git_blob_buffers,
 )
-from git_stage_batch.utils.git_object_io import GitBlobStream, GitTreeBlob
+from git_stage_batch.utils.git_object_io import (
+    GitBlobStream,
+    GitObjectInfo,
+    GitTreeBlob,
+)
 
 
 def test_load_git_blob_as_buffer_loads_streamed_blob(monkeypatch):
@@ -104,50 +107,46 @@ def test_load_git_tree_files_as_buffers_loads_tree_blobs(monkeypatch):
             buffer.close()
 
 
-def test_load_git_object_as_buffer_loads_streamed_output(monkeypatch):
-    """Git object buffers are loaded from streamed command output."""
+def test_read_git_object_buffer_or_none_loads_streamed_output(monkeypatch):
+    """Git object buffers are loaded from precisely resolved blobs."""
     calls = []
 
-    def fake_stream_git_object(revision_path):
-        calls.append(revision_path)
-        return iter([b"alpha\nbe", b"ta\n"])
+    monkeypatch.setattr(
+        repository_buffers,
+        "resolve_git_objects",
+        lambda names: {
+            names[0]: GitObjectInfo("abc123", "blob", 11),
+        },
+    )
 
-    monkeypatch.setattr(repository_buffers, "_stream_git_object", fake_stream_git_object)
+    def fake_load(blob_sha):
+        calls.append(blob_sha)
+        return LineBuffer.from_chunks([b"alpha\nbe", b"ta\n"])
 
-    with load_git_object_as_buffer("HEAD:file.txt") as buffer:
-        assert calls == ["HEAD:file.txt"]
+    monkeypatch.setattr(repository_buffers, "load_git_blob_as_buffer", fake_load)
+
+    with read_git_object_buffer_or_none("HEAD:file.txt") as buffer:
+        assert calls == ["abc123"]
         assert buffer.uses_mapped_storage is False
         assert buffer[1] == b"beta\n"
 
 
-def test_load_git_object_as_buffer_returns_none_for_missing_object(monkeypatch):
+def test_read_git_object_buffer_or_none_returns_none_for_missing_object(monkeypatch):
     """Missing Git objects return None instead of a buffer."""
 
-    def fake_stream_git_object(revision_path):
-        raise subprocess.CalledProcessError(
-            128,
-            ["git", "show", revision_path],
-        )
+    monkeypatch.setattr(repository_buffers, "resolve_git_objects", lambda _names: {})
 
-    monkeypatch.setattr(repository_buffers, "_stream_git_object", fake_stream_git_object)
-
-    assert load_git_object_as_buffer("HEAD:missing.txt") is None
+    assert read_git_object_buffer_or_none("HEAD:missing.txt") is None
 
 
-def test_load_git_object_as_buffer_or_empty_returns_empty_for_missing_object(
+def test_read_git_object_buffer_or_empty_returns_empty_for_missing_object(
     monkeypatch,
 ):
     """Missing Git objects can be loaded as empty file buffers."""
 
-    def fake_stream_git_object(revision_path):
-        raise subprocess.CalledProcessError(
-            128,
-            ["git", "show", revision_path],
-        )
+    monkeypatch.setattr(repository_buffers, "resolve_git_objects", lambda _names: {})
 
-    monkeypatch.setattr(repository_buffers, "_stream_git_object", fake_stream_git_object)
-
-    with load_git_object_as_buffer_or_empty("HEAD:missing.txt") as buffer:
+    with read_git_object_buffer_or_empty("HEAD:missing.txt") as buffer:
         assert len(buffer) == 0
 
 


### PR DESCRIPTION
Repository readers expose one nullable buffer helper whose callers infer whether an empty result means a missing object, empty content, or a failed Git operation.

The project cannot preserve repository state reliably while absence, valid empty blobs, malformed paths, and Git failures share overlapping return behavior. Compatibility exports also risk remaining after their callers no longer need them.

This pull request adds typed repository read failures, separates nullable and empty-default object readers, handles lossless Git paths, migrates every production and test caller, and removes the superseded exports with their final adopters.

Repository object reads now have one explicit contract from implementation through validation, without compatibility shims left behind.