### PR TITLE
Track selected-file object metadata

### DIFF
--- a/src/git_stage_batch/data/selected_change/snapshots.py
+++ b/src/git_stage_batch/data/selected_change/snapshots.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from contextlib import ExitStack
+import json
 
 from ...core.buffer import (
     LineBuffer,
@@ -11,41 +12,82 @@ from ...core.buffer import (
     buffer_preview,
     write_buffer_to_path,
 )
-from ...utils.repository_buffers import read_git_object_buffer_or_none
-from ...utils.git_repository import get_git_repository_root_path
+from ...utils.repository_buffers import (
+    read_git_object_buffer_or_none,
+    read_working_tree_object,
+)
+from ...exceptions import RepositoryPathMissing
+from ...data.index_entries import IndexEntry, read_index_entry
+from ...data.file_modes import detect_file_mode_in_commit
+from ...utils.file_io import write_text_file_contents
 from ...utils.journal import JournalLevel, journal_enabled, log_journal
-from ...utils.paths import get_index_snapshot_file_path, get_working_tree_snapshot_file_path
+from ...utils.paths import (
+    get_index_snapshot_file_path,
+    get_snapshot_metadata_file_path,
+    get_working_tree_snapshot_file_path,
+)
+
+
+_SNAPSHOT_SCHEMA_VERSION = 1
 
 
 def write_snapshots_for_selected_file_path(file_path: str) -> None:
     """Write snapshots of the file from both the index and working tree."""
     with ExitStack() as stack:
+        index_entry = read_index_entry(file_path)
         index_version = read_git_object_buffer_or_none(f":{file_path}")
         if index_version is None:
             index_version = LineBuffer.from_bytes(b"")
         stack.enter_context(index_version)
 
-        repo_root = get_git_repository_root_path()
-        file_full_path = repo_root / file_path
-        if file_full_path.exists():
-            working_tree_version = LineBuffer.from_path(file_full_path)
-        else:
+        try:
+            worktree_object = read_working_tree_object(file_path)
+            working_tree_version = worktree_object.buffer
+            worktree_metadata = {
+                "exists": True,
+                "kind": worktree_object.kind,
+                "mode": worktree_object.git_mode,
+            }
+        except RepositoryPathMissing:
             working_tree_version = LineBuffer.from_bytes(b"")
+            worktree_metadata = {"exists": False, "kind": None, "mode": None}
         stack.enter_context(working_tree_version)
 
         # When index is empty but working tree has content, check if file exists in HEAD.
         # For new files (not in HEAD), use empty index snapshot.
         # For existing files with intent-to-add applied, use HEAD content.
-        if buffer_byte_count(index_version) == 0 and buffer_byte_count(working_tree_version) > 0:
+        if (
+            buffer_byte_count(index_version) == 0
+            and buffer_byte_count(working_tree_version) > 0
+        ):
             head_version = read_git_object_buffer_or_none(f"HEAD:{file_path}")
             if head_version is not None:
                 if buffer_byte_count(head_version) > 0:
                     index_version = stack.enter_context(head_version)
+                    # Intent-to-add represents the pre-session HEAD state here.
+                    head_mode = detect_file_mode_in_commit("HEAD", file_path)
+                    if head_mode is not None:
+                        index_entry = IndexEntry(head_mode, "") if index_entry else None
                 else:
                     head_version.close()
 
         write_buffer_to_path(get_index_snapshot_file_path(), index_version)
-        write_buffer_to_path(get_working_tree_snapshot_file_path(), working_tree_version)
+        write_buffer_to_path(
+            get_working_tree_snapshot_file_path(), working_tree_version
+        )
+        manifest = {
+            "schema_version": _SNAPSHOT_SCHEMA_VERSION,
+            "path": file_path,
+            "index": {
+                "exists": index_entry is not None,
+                "mode": index_entry.mode if index_entry is not None else None,
+            },
+            "worktree": worktree_metadata,
+        }
+        write_text_file_contents(
+            get_snapshot_metadata_file_path(),
+            json.dumps(manifest, sort_keys=True) + "\n",
+        )
 
         if journal_enabled():
             fields = {
@@ -54,11 +96,13 @@ def write_snapshots_for_selected_file_path(file_path: str) -> None:
                 "working_tree_len": buffer_byte_count(working_tree_version),
             }
             if journal_enabled(JournalLevel.CONTENT_DEBUG):
-                fields.update({
-                    "index_lines": _buffer_line_count(index_version),
-                    "index_preview": buffer_preview(index_version),
-                    "working_tree_lines": _buffer_line_count(working_tree_version),
-                })
+                fields.update(
+                    {
+                        "index_lines": _buffer_line_count(index_version),
+                        "index_preview": buffer_preview(index_version),
+                        "working_tree_lines": _buffer_line_count(working_tree_version),
+                    }
+                )
             log_journal("write_snapshots_for_selected_file", **fields)
 
 
@@ -101,9 +145,14 @@ def snapshots_are_stale(file_path: str) -> bool:
     """
     snapshot_base_path = get_index_snapshot_file_path()
     snapshot_new_path = get_working_tree_snapshot_file_path()
+    metadata_path = get_snapshot_metadata_file_path()
 
     # Missing snapshots means state is incomplete/stale
-    if not snapshot_base_path.exists() or not snapshot_new_path.exists():
+    if (
+        not snapshot_base_path.exists()
+        or not snapshot_new_path.exists()
+        or not metadata_path.exists()
+    ):
         return True
 
     try:
@@ -114,23 +163,42 @@ def snapshots_are_stale(file_path: str) -> bool:
             cached_worktree_content = stack.enter_context(
                 LineBuffer.from_path(snapshot_new_path)
             )
+            manifest = json.loads(metadata_path.read_text(encoding="utf-8"))
+            if (
+                manifest.get("schema_version") != _SNAPSHOT_SCHEMA_VERSION
+                or manifest.get("path") != file_path
+            ):
+                return True
 
+            index_entry = read_index_entry(file_path)
+            index_metadata = {
+                "exists": index_entry is not None,
+                "mode": index_entry.mode if index_entry is not None else None,
+            }
+            if manifest.get("index") != index_metadata:
+                return True
             selected_index_content = read_git_object_buffer_or_none(f":{file_path}")
             if selected_index_content is None:
                 selected_index_content = LineBuffer.from_bytes(b"")
             stack.enter_context(selected_index_content)
 
-            repo_root = get_git_repository_root_path()
-            file_full_path = repo_root / file_path
-            if file_full_path.exists():
-                selected_worktree_content = LineBuffer.from_path(file_full_path)
-            else:
+            try:
+                worktree_object = read_working_tree_object(file_path)
+                selected_worktree_content = worktree_object.buffer
+                worktree_metadata = {
+                    "exists": True,
+                    "kind": worktree_object.kind,
+                    "mode": worktree_object.git_mode,
+                }
+            except RepositoryPathMissing:
                 selected_worktree_content = LineBuffer.from_bytes(b"")
+                worktree_metadata = {"exists": False, "kind": None, "mode": None}
             stack.enter_context(selected_worktree_content)
+            if manifest.get("worktree") != worktree_metadata:
+                return True
 
-            return (
-                not buffer_matches(cached_index_content, selected_index_content)
-                or not buffer_matches(cached_worktree_content, selected_worktree_content)
-            )
+            return not buffer_matches(
+                cached_index_content, selected_index_content
+            ) or not buffer_matches(cached_worktree_content, selected_worktree_content)
     except Exception:
         return True  # Error reading means state is stale

--- a/src/git_stage_batch/utils/paths.py
+++ b/src/git_stage_batch/utils/paths.py
@@ -166,6 +166,11 @@ def get_working_tree_snapshot_file_path() -> Path:
     return get_selected_state_directory_path() / "working-tree.snapshot"
 
 
+def get_snapshot_metadata_file_path() -> Path:
+    """Get the selected-file snapshot metadata manifest path."""
+    return get_selected_state_directory_path() / "snapshots.json"
+
+
 def get_block_list_file_path() -> Path:
     """Get the path to the blocklist file for tracking processed hunks.
 

--- a/tests/data/test_selected_snapshots.py
+++ b/tests/data/test_selected_snapshots.py
@@ -24,13 +24,21 @@ class TestWriteSnapshotsForCurrentFilePath:
         """Create a temporary git repository."""
         monkeypatch.chdir(tmp_path)
         subprocess.run(["git", "init"], check=True, capture_output=True)
-        subprocess.run(["git", "config", "user.name", "Test User"], check=True, capture_output=True)
-        subprocess.run(["git", "config", "user.email", "test@example.com"], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.name", "Test User"], check=True, capture_output=True
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "test@example.com"],
+            check=True,
+            capture_output=True,
+        )
 
         # Create initial commit
         (tmp_path / "README.md").write_text("# Test\n")
         subprocess.run(["git", "add", "README.md"], check=True, capture_output=True)
-        subprocess.run(["git", "commit", "-m", "Initial commit"], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Initial commit"], check=True, capture_output=True
+        )
 
         # Ensure state directory exists
         ensure_state_directory_exists()
@@ -48,8 +56,18 @@ def original_function():
     return "original"
 '''
         test_file.write_text(original_content)
-        subprocess.run(["git", "add", "tracked.py"], cwd=temp_git_repo, check=True, capture_output=True)
-        subprocess.run(["git", "commit", "-m", "Add tracked file"], cwd=temp_git_repo, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "add", "tracked.py"],
+            cwd=temp_git_repo,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add tracked file"],
+            cwd=temp_git_repo,
+            check=True,
+            capture_output=True,
+        )
 
         # Modify the file in working tree
         modified_content = '''"""Module docstring."""
@@ -66,8 +84,18 @@ def new_function():
 
         # Simulate intent-to-add by removing from cache and re-adding with -N.
         # This creates an empty blob (e69de29...) in the index.
-        subprocess.run(["git", "rm", "--cached", "tracked.py"], cwd=temp_git_repo, check=True, capture_output=True)
-        subprocess.run(["git", "add", "-N", "tracked.py"], cwd=temp_git_repo, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "rm", "--cached", "tracked.py"],
+            cwd=temp_git_repo,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "add", "-N", "tracked.py"],
+            cwd=temp_git_repo,
+            check=True,
+            capture_output=True,
+        )
 
         # Verify we have an empty blob in index.
         ls_result = subprocess.run(
@@ -77,7 +105,9 @@ def new_function():
             capture_output=True,
             text=True,
         )
-        assert "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391" in ls_result.stdout, "Should have empty blob in index"
+        assert "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391" in ls_result.stdout, (
+            "Should have empty blob in index"
+        )
 
         # Verify git show :file returns empty content.
         show_result = subprocess.run(
@@ -87,7 +117,9 @@ def new_function():
             capture_output=True,
             text=True,
         )
-        assert show_result.stdout == "", "Index should return empty content for intent-to-add"
+        assert show_result.stdout == "", (
+            "Index should return empty content for intent-to-add"
+        )
 
         write_snapshots_for_selected_file_path("tracked.py")
 
@@ -100,7 +132,9 @@ def new_function():
         )
 
         working_tree_snapshot_path = get_working_tree_snapshot_file_path()
-        working_tree_snapshot_content = read_text_file_contents(working_tree_snapshot_path)
+        working_tree_snapshot_content = read_text_file_contents(
+            working_tree_snapshot_path
+        )
         assert working_tree_snapshot_content == modified_content
 
     def test_intent_to_add_new_file_keeps_empty_index(self, temp_git_repo):
@@ -113,7 +147,12 @@ def new_function():
 '''
         test_file.write_text(new_content)
 
-        subprocess.run(["git", "add", "-N", "newfile.py"], cwd=temp_git_repo, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "add", "-N", "newfile.py"],
+            cwd=temp_git_repo,
+            check=True,
+            capture_output=True,
+        )
 
         head_check = subprocess.run(
             ["git", "cat-file", "-e", "HEAD:newfile.py"],
@@ -130,7 +169,9 @@ def new_function():
         assert index_snapshot_content == "", "New file should have empty index snapshot"
 
         working_tree_snapshot_path = get_working_tree_snapshot_file_path()
-        working_tree_snapshot_content = read_text_file_contents(working_tree_snapshot_path)
+        working_tree_snapshot_content = read_text_file_contents(
+            working_tree_snapshot_path
+        )
         assert working_tree_snapshot_content == new_content
 
     def test_normal_tracked_file_uses_index_content(self, temp_git_repo):
@@ -138,12 +179,27 @@ def new_function():
         test_file = temp_git_repo / "normal.py"
         original_content = "original content\n"
         test_file.write_text(original_content)
-        subprocess.run(["git", "add", "normal.py"], cwd=temp_git_repo, check=True, capture_output=True)
-        subprocess.run(["git", "commit", "-m", "Add normal file"], cwd=temp_git_repo, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "add", "normal.py"],
+            cwd=temp_git_repo,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add normal file"],
+            cwd=temp_git_repo,
+            check=True,
+            capture_output=True,
+        )
 
         staged_content = "staged content\n"
         test_file.write_text(staged_content)
-        subprocess.run(["git", "add", "normal.py"], cwd=temp_git_repo, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "add", "normal.py"],
+            cwd=temp_git_repo,
+            check=True,
+            capture_output=True,
+        )
 
         working_content = "working tree content\n"
         test_file.write_text(working_content)
@@ -155,7 +211,9 @@ def new_function():
         assert index_snapshot_content == staged_content
 
         working_tree_snapshot_path = get_working_tree_snapshot_file_path()
-        working_tree_snapshot_content = read_text_file_contents(working_tree_snapshot_path)
+        working_tree_snapshot_content = read_text_file_contents(
+            working_tree_snapshot_path
+        )
         assert working_tree_snapshot_content == working_content
 
 
@@ -167,12 +225,20 @@ class TestSnapshotsAreStale:
         """Create a temporary git repository."""
         monkeypatch.chdir(tmp_path)
         subprocess.run(["git", "init"], check=True, capture_output=True)
-        subprocess.run(["git", "config", "user.name", "Test User"], check=True, capture_output=True)
-        subprocess.run(["git", "config", "user.email", "test@example.com"], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.name", "Test User"], check=True, capture_output=True
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "test@example.com"],
+            check=True,
+            capture_output=True,
+        )
 
         (tmp_path / "README.md").write_text("# Test\n")
         subprocess.run(["git", "add", "README.md"], check=True, capture_output=True)
-        subprocess.run(["git", "commit", "-m", "Initial commit"], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Initial commit"], check=True, capture_output=True
+        )
 
         ensure_state_directory_exists()
 
@@ -186,8 +252,18 @@ class TestSnapshotsAreStale:
         """Current index and working tree snapshots should not be stale."""
         test_file = temp_git_repo / "test.txt"
         test_file.write_text("content\n")
-        subprocess.run(["git", "add", "test.txt"], check=True, cwd=temp_git_repo, capture_output=True)
-        subprocess.run(["git", "commit", "-m", "Add file"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(
+            ["git", "add", "test.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add file"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
 
         test_file.write_text("modified\n")
 
@@ -199,14 +275,29 @@ class TestSnapshotsAreStale:
         """Index changes should make selected-file snapshots stale."""
         test_file = temp_git_repo / "test.txt"
         test_file.write_text("content\n")
-        subprocess.run(["git", "add", "test.txt"], check=True, cwd=temp_git_repo, capture_output=True)
-        subprocess.run(["git", "commit", "-m", "Add file"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(
+            ["git", "add", "test.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add file"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
 
         test_file.write_text("modified\n")
         write_snapshots_for_selected_file_path("test.txt")
 
         test_file.write_text("changed again\n")
-        subprocess.run(["git", "add", "test.txt"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(
+            ["git", "add", "test.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
 
         assert snapshots_are_stale("test.txt") is True
 
@@ -214,8 +305,18 @@ class TestSnapshotsAreStale:
         """Working tree changes should make selected-file snapshots stale."""
         test_file = temp_git_repo / "test.txt"
         test_file.write_text("content\n")
-        subprocess.run(["git", "add", "test.txt"], check=True, cwd=temp_git_repo, capture_output=True)
-        subprocess.run(["git", "commit", "-m", "Add file"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(
+            ["git", "add", "test.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add file"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
 
         test_file.write_text("modified\n")
         write_snapshots_for_selected_file_path("test.txt")
@@ -223,3 +324,49 @@ class TestSnapshotsAreStale:
         test_file.write_text("different content\n")
 
         assert snapshots_are_stale("test.txt") is True
+
+    def test_symlink_freshness_uses_link_target_not_referent(self, temp_git_repo):
+        """Changing a referent does not change Git-visible symlink content."""
+        (temp_git_repo / "target").write_text("one\n")
+        (temp_git_repo / "link").symlink_to("target")
+        subprocess.run(["git", "add", "link"], check=True, cwd=temp_git_repo)
+
+        write_snapshots_for_selected_file_path("link")
+        (temp_git_repo / "target").write_text("two\n")
+
+        assert snapshots_are_stale("link") is False
+
+    def test_symlink_retarget_is_stale_even_for_equal_referents(self, temp_git_repo):
+        """Freshness compares link-target bytes, not referent bytes."""
+        (temp_git_repo / "first").write_text("same\n")
+        (temp_git_repo / "second").write_text("same\n")
+        link = temp_git_repo / "link"
+        link.symlink_to("first")
+        subprocess.run(["git", "add", "link"], check=True, cwd=temp_git_repo)
+
+        write_snapshots_for_selected_file_path("link")
+        link.unlink()
+        link.symlink_to("second")
+
+        assert snapshots_are_stale("link") is True
+
+    def test_dangling_symlink_can_be_fresh(self, temp_git_repo):
+        """A dangling link remains a present Git path."""
+        (temp_git_repo / "link").symlink_to("missing")
+        subprocess.run(["git", "add", "link"], check=True, cwd=temp_git_repo)
+
+        write_snapshots_for_selected_file_path("link")
+
+        assert snapshots_are_stale("link") is False
+
+    def test_regular_file_replacing_symlink_is_stale(self, temp_git_repo):
+        """Path kind participates in freshness even when bytes match."""
+        link = temp_git_repo / "link"
+        link.symlink_to("target")
+        subprocess.run(["git", "add", "link"], check=True, cwd=temp_git_repo)
+        write_snapshots_for_selected_file_path("link")
+
+        link.unlink()
+        link.write_bytes(b"target")
+
+        assert snapshots_are_stale("link") is True


### PR DESCRIPTION
Selected-file snapshots record index and working-tree bytes while freshness checks compare only those saved byte streams.

Mode-only edits and symlink-target changes can retain the same apparent text while changing the Git object that later line operations would update.

This pull request records index modes and working-tree kinds, modes, and link payloads in a versioned snapshot manifest, then validates regular files, executable modes, symlinks, intent-to-add entries, and stale metadata.

Selected-file reuse now checks both content and Git-visible object identity.