### PR TITLE
Preserve generated index entry modes

### DIFF
--- a/src/git_stage_batch/staging/index_update.py
+++ b/src/git_stage_batch/staging/index_update.py
@@ -11,6 +11,17 @@ from ..data.index_entries import IndexEntry, read_index_entry
 from ..utils.git_index import git_update_index
 from ..utils.git_object_io import create_git_blob
 from ..utils.journal import JournalLevel, journal_enabled, log_journal
+from ..utils.repository_buffers import read_working_tree_object
+from ..exceptions import RepositoryPathMissing
+
+
+_BLOB_MODES = {"100644", "100755", "120000"}
+
+
+def _validate_blob_mode(mode: str) -> str:
+    if mode not in _BLOB_MODES:
+        raise ValueError(f"Unsupported blob-backed Git mode: {mode}")
+    return mode
 
 
 def _index_entry_fields(entry: IndexEntry | None) -> dict[str, str] | None:
@@ -20,7 +31,12 @@ def _index_entry_fields(entry: IndexEntry | None) -> dict[str, str] | None:
     return {"mode": entry.mode, "object_id": entry.object_id}
 
 
-def update_index_with_blob_buffer(path: str, buffer: LineBuffer) -> None:
+def update_index_with_blob_buffer(
+    path: str,
+    buffer: LineBuffer,
+    *,
+    mode: str | None = None,
+) -> None:
     """
     Update the git index with a new buffer for a file.
 
@@ -29,9 +45,21 @@ def update_index_with_blob_buffer(path: str, buffer: LineBuffer) -> None:
     """
     index_before = read_index_entry(path)
 
-    blob_hash = create_git_blob(buffer.byte_chunks())
+    if mode is not None:
+        file_mode = _validate_blob_mode(mode)
+        mode_source = "explicit"
+    elif index_before is not None:
+        file_mode = _validate_blob_mode(index_before.mode)
+        mode_source = "index"
+    else:
+        try:
+            file_mode = _validate_blob_mode(read_working_tree_object(path).git_mode)
+            mode_source = "worktree"
+        except RepositoryPathMissing:
+            file_mode = "100644"
+            mode_source = "default"
 
-    file_mode = index_before.mode if index_before is not None else "100644"
+    blob_hash = create_git_blob(buffer.byte_chunks())
 
     git_update_index(mode=file_mode, blob_sha=blob_hash, file_path=path)
 
@@ -41,6 +69,7 @@ def update_index_with_blob_buffer(path: str, buffer: LineBuffer) -> None:
             "content_len": buffer_byte_count(buffer),
             "blob_hash": blob_hash,
             "file_mode": file_mode,
+            "file_mode_source": mode_source,
             "index_entry_before": _index_entry_fields(index_before),
             "index_entry_after": _index_entry_fields(read_index_entry(path)),
         }

--- a/tests/staging/test_index_update.py
+++ b/tests/staging/test_index_update.py
@@ -215,6 +215,46 @@ class TestUpdateIndexWithBlobContent:
         )
         assert result.stdout == "generated\ncontent\n"
 
+    def test_missing_index_entry_uses_executable_worktree_mode(self, temp_git_repo):
+        """Generated content retains an executable worktree path's mode."""
+        path = temp_git_repo / "tool"
+        path.write_text("old\n")
+        path.chmod(0o755)
+
+        with LineBuffer.from_bytes(b"new\n") as buffer:
+            update_index_with_blob_buffer("tool", buffer)
+
+        result = subprocess.run(
+            ["git", "ls-files", "--stage", "--", "tool"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+            text=True,
+        )
+        assert result.stdout.split()[0] == "100755"
+
+    def test_missing_index_entry_uses_symlink_worktree_mode(self, temp_git_repo):
+        """Generated symlink target bytes are installed as a symlink entry."""
+        (temp_git_repo / "link").symlink_to("target")
+
+        with LineBuffer.from_bytes(b"target") as buffer:
+            update_index_with_blob_buffer("link", buffer)
+
+        result = subprocess.run(
+            ["git", "ls-files", "--stage", "--", "link"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+            text=True,
+        )
+        assert result.stdout.split()[0] == "120000"
+
+    def test_rejects_non_blob_explicit_mode(self, temp_git_repo):
+        """Gitlinks cannot be written through the blob content helper."""
+        with LineBuffer.from_bytes(b"object id") as buffer:
+            with pytest.raises(ValueError, match="160000"):
+                update_index_with_blob_buffer("submodule", buffer, mode="160000")
+
     def test_disabled_journal_does_not_add_index_observations_or_previews(
         self,
         temp_git_repo,


### PR DESCRIPTION
Generated index entries use a fixed regular-file mode whenever line staging writes a newly created blob into the index.

Users can lose executable intent or receive an invalid synthetic entry when the destination has a different worktree mode or represents a gitlink.

This pull request selects modes from the index or worktree, accepts an explicit caller mode, rejects gitlinks before writing, and covers the supported precedence and fallback behavior.

Line-level staging now preserves the destination's Git mode for supported entry shapes.