### PR TITLE
Refuse incomplete stop cleanup

### DIFF
--- a/src/git_stage_batch/commands/stop.py
+++ b/src/git_stage_batch/commands/stop.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sys
+import subprocess
 
 from ..data.start_time_changes import (
     restore_unstaged_start_time_deletions,
@@ -28,6 +29,13 @@ def _path_has_staged_content(file_path: str) -> bool:
         check=False,
         requires_index_lock=False,
     )
+    if result.returncode not in (0, 1):
+        raise subprocess.CalledProcessError(
+            result.returncode,
+            result.args,
+            output=result.stdout,
+            stderr=result.stderr,
+        )
     return result.returncode == 1
 
 
@@ -43,10 +51,13 @@ def command_stop() -> None:
     auto_added_path = get_auto_added_files_file_path()
     if auto_added_path.exists():
         auto_added = read_file_paths_file(auto_added_path)
-        for file_path in auto_added:
-            if _path_has_staged_content(file_path):
-                continue
-            git_reset_paths([file_path], check=False)
+        reset_paths = [
+            file_path
+            for file_path in auto_added
+            if not _path_has_staged_content(file_path)
+        ]
+        if reset_paths:
+            git_reset_paths(reset_paths)
 
     restore_unstaged_start_time_renames()
     restore_unstaged_start_time_deletions()


### PR DESCRIPTION
Session stop removes temporary index state with commands whose return codes are not consistently checked before session records are cleared.

Users can lose recovery information for a session whose intent-to-add cleanup or index reset did not actually succeed.

This pull request checks each cleanup mutation and leaves session state available when Git refuses the requested index change.