### PR TITLE
Normalize blocked repository paths lexically

### DIFF
--- a/src/git_stage_batch/commands/block_file.py
+++ b/src/git_stage_batch/commands/block_file.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import sys
 from contextlib import nullcontext
-from pathlib import Path
 
 from ..data.session import path_is_intent_to_add, session_is_active
 from ..data.undo_checkpoints import undo_checkpoint
@@ -19,8 +18,8 @@ from ..utils.git_command import run_git_command
 from ..utils.git_worktree import git_remove_paths
 from ..utils.git_repository import (
     require_git_repository,
-    resolve_file_path_to_repo_relative,
 )
+from ..utils.repository_path import normalize_repository_path
 from ..utils.paths import (
     ensure_state_directory_exists,
     get_auto_added_files_file_path,
@@ -31,7 +30,9 @@ from .selection.action_completion import advance_to_and_show_next_change
 
 def _is_new_intent_to_add_file(file_path: str) -> bool:
     """Return True when file_path is an intent-to-add entry absent from HEAD."""
-    stage_result = run_git_command(["ls-files", "--stage", "--", file_path], check=False, requires_index_lock=False)
+    stage_result = run_git_command(
+        ["ls-files", "--stage", "--", file_path], check=False, requires_index_lock=False
+    )
     stage_output = stage_result.stdout.strip()
     if not stage_output:
         return False
@@ -39,7 +40,9 @@ def _is_new_intent_to_add_file(file_path: str) -> bool:
     if not path_is_intent_to_add(file_path):
         return False
 
-    head_check = run_git_command(["cat-file", "-e", f"HEAD:{file_path}"], check=False, requires_index_lock=False)
+    head_check = run_git_command(
+        ["cat-file", "-e", f"HEAD:{file_path}"], check=False, requires_index_lock=False
+    )
     return head_check.returncode != 0
 
 
@@ -50,15 +53,16 @@ def command_block_file(file_path_arg: str = "", local_only: bool = False) -> Non
 
     if not file_path_arg:
         from ..data.line_state import load_line_changes_from_state
+
         line_changes = load_line_changes_from_state()
         if line_changes is None:
-            exit_with_error(_("No selected hunk. Run 'show' first or specify file path."))
+            exit_with_error(
+                _("No selected hunk. Run 'show' first or specify file path.")
+            )
         file_path_arg = line_changes.path
 
     # Resolve to repo-relative path, normalizing directories to a trailing slash
-    file_path = resolve_file_path_to_repo_relative(file_path_arg)
-    if file_path_arg.endswith("/") or Path(file_path_arg).is_dir():
-        file_path = file_path.rstrip("/") + "/"
+    file_path = normalize_repository_path(file_path_arg).value
     session_active = session_is_active()
     checkpoint_paths = [] if local_only else [".gitignore"]
     checkpoint = (
@@ -67,7 +71,8 @@ def command_block_file(file_path_arg: str = "", local_only: bool = False) -> Non
             worktree_paths=checkpoint_paths,
             index_paths=[file_path] if not file_path.endswith("/") else [],
         )
-        if session_active else nullcontext()
+        if session_active
+        else nullcontext()
     )
 
     with checkpoint:
@@ -78,8 +83,17 @@ def command_block_file(file_path_arg: str = "", local_only: bool = False) -> Non
             add_file_to_gitignore(file_path)
 
         # Remove from index if session is active and the file is a new intent-to-add entry
-        if session_active and not file_path.endswith("/") and _is_new_intent_to_add_file(file_path):
-            git_remove_paths([file_path], cached=True, quiet=True, ignore_unmatch=True, check=False)
+        if (
+            session_active
+            and not file_path.endswith("/")
+            and _is_new_intent_to_add_file(file_path)
+        ):
+            git_remove_paths(
+                [file_path],
+                cached=True,
+                quiet=True,
+                ignore_unmatch=True,
+            )
             remove_file_path_from_file(get_auto_added_files_file_path(), file_path)
 
         # Add to blocked-files state

--- a/src/git_stage_batch/commands/unblock_file.py
+++ b/src/git_stage_batch/commands/unblock_file.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import sys
 from contextlib import nullcontext
-from pathlib import Path
 
 from ..data.session import session_is_active
 from ..data.undo_checkpoints import undo_checkpoint
@@ -19,13 +18,17 @@ from ..data.ignore_files import (
 )
 from ..exceptions import NoMoreHunks, exit_with_error
 from ..i18n import _
-from ..utils.file_io import append_file_path_to_file, read_file_paths_file, remove_file_path_from_file
+from ..utils.file_io import (
+    append_file_path_to_file,
+    read_file_paths_file,
+    remove_file_path_from_file,
+)
 from ..utils.git_command import run_git_command
 from ..utils.git_index import git_add_paths
 from ..utils.git_repository import (
     require_git_repository,
-    resolve_file_path_to_repo_relative,
 )
+from ..utils.repository_path import normalize_repository_path
 from ..utils.paths import (
     ensure_state_directory_exists,
     get_auto_added_files_file_path,
@@ -44,13 +47,17 @@ def _find_covering_directory(path: str, blocked_files: list[str]) -> str | None:
 
 def _is_absent_from_head(file_path: str) -> bool:
     """Return True when file_path has no entry in HEAD."""
-    head_check = run_git_command(["cat-file", "-e", f"HEAD:{file_path}"], check=False, requires_index_lock=False)
+    head_check = run_git_command(
+        ["cat-file", "-e", f"HEAD:{file_path}"], check=False, requires_index_lock=False
+    )
     return head_check.returncode != 0
 
 
 def _is_absent_from_index(file_path: str) -> bool:
     """Return True when file_path has no index entry."""
-    stage_result = run_git_command(["ls-files", "--stage", "--", file_path], check=False, requires_index_lock=False)
+    stage_result = run_git_command(
+        ["ls-files", "--stage", "--", file_path], check=False, requires_index_lock=False
+    )
     return not stage_result.stdout.strip()
 
 
@@ -63,9 +70,7 @@ def command_unblock_file(file_path_arg: str) -> None:
         exit_with_error(_("File path required for unblock-file command."))
 
     # Resolve to repo-relative path, normalizing directories to a trailing slash
-    file_path = resolve_file_path_to_repo_relative(file_path_arg)
-    if file_path_arg.endswith("/") or Path(file_path_arg).is_dir():
-        file_path = file_path.rstrip("/") + "/"
+    file_path = normalize_repository_path(file_path_arg).value
     session_active = session_is_active()
     checkpoint = (
         undo_checkpoint(
@@ -73,7 +78,8 @@ def command_unblock_file(file_path_arg: str) -> None:
             worktree_paths=[".gitignore"],
             index_paths=[file_path] if not file_path.endswith("/") else [],
         )
-        if session_active else nullcontext()
+        if session_active
+        else nullcontext()
     )
 
     with checkpoint:
@@ -89,29 +95,48 @@ def command_unblock_file(file_path_arg: str) -> None:
         # If not found directly, check whether a directory entry covers this path.
         # If so, promote dir/ to dir/** in the ignore file(s) and append a negation
         # so git re-includes this specific file while still ignoring the rest.
-        if not removed_from_gitignore and not removed_from_local_exclude and not directly_blocked:
+        if (
+            not removed_from_gitignore
+            and not removed_from_local_exclude
+            and not directly_blocked
+        ):
             covering_dir = _find_covering_directory(file_path, blocked_files)
             if covering_dir is not None:
                 if promote_directory_to_glob_in_gitignore(covering_dir):
                     add_pattern_to_gitignore(f"!{literal_ignore_pattern(file_path)}")
+                    if file_path.endswith("/"):
+                        add_pattern_to_gitignore(
+                            f"!{literal_ignore_pattern(file_path)}**"
+                        )
                     removed_from_gitignore = True
                 if promote_directory_to_glob_in_local_exclude(covering_dir):
                     add_pattern_to_local_exclude(
                         f"!{literal_ignore_pattern(file_path)}"
                     )
+                    if file_path.endswith("/"):
+                        add_pattern_to_local_exclude(
+                            f"!{literal_ignore_pattern(file_path)}**"
+                        )
                     removed_from_local_exclude = True
                 append_file_path_to_file(get_blocked_files_file_path(), f"!{file_path}")
 
         # Re-add new untracked files as intent-to-add if session is active
-        if session_active and not file_path.endswith("/") and _is_absent_from_head(file_path) and _is_absent_from_index(file_path):
-            result = git_add_paths([file_path], intent_to_add=True, check=False)
-            if result.returncode == 0:
-                append_file_path_to_file(get_auto_added_files_file_path(), file_path)
+        if (
+            session_active
+            and not file_path.endswith("/")
+            and _is_absent_from_head(file_path)
+            and _is_absent_from_index(file_path)
+        ):
+            git_add_paths([file_path], intent_to_add=True)
+            append_file_path_to_file(get_auto_added_files_file_path(), file_path)
 
     if removed_from_gitignore or removed_from_local_exclude:
         print(f"Unblocked file: {file_path}", file=sys.stderr)
     else:
-        print(f"Removed from blocked list: {file_path} (was not in .gitignore)", file=sys.stderr)
+        print(
+            f"Removed from blocked list: {file_path} (was not in .gitignore)",
+            file=sys.stderr,
+        )
 
     if session_active:
         try:

--- a/src/git_stage_batch/data/ignore_files.py
+++ b/src/git_stage_batch/data/ignore_files.py
@@ -83,12 +83,17 @@ def literal_ignore_pattern(file_path: str) -> str:
         ):
             escaped.append("\\")
         escaped.append(character)
-    return "".join(escaped)
+    return "/" + "".join(escaped)
 
 
 def _literal_ignore_pattern_variants(file_path: str) -> set[str]:
     """Return current and legacy encodings for one literal path."""
-    return {literal_ignore_pattern(file_path), file_path.rstrip("\n")}
+    anchored = literal_ignore_pattern(file_path)
+    return {
+        anchored,
+        anchored.removeprefix("/"),
+        file_path.rstrip("\n"),
+    }
 
 
 def _append_ignore_entry(lines: list[str], entry: str) -> bool:

--- a/src/git_stage_batch/utils/file_io.py
+++ b/src/git_stage_batch/utils/file_io.py
@@ -38,7 +38,11 @@ def read_text_file_contents(path: Path) -> str:
     Returns:
         File contents as string, or empty string if file doesn't exist
     """
-    return path.read_text(encoding="utf-8", errors="surrogateescape") if path.exists() else ""
+    return (
+        path.read_text(encoding="utf-8", errors="surrogateescape")
+        if path.exists()
+        else ""
+    )
 
 
 def write_text_file_contents(
@@ -126,7 +130,9 @@ def _replacement_mode(
 ) -> int:
     if mode_policy is AtomicWriteModePolicy.PRIVATE:
         if mode is not None:
-            raise ValueError("private atomic writes do not accept a caller-supplied mode")
+            raise ValueError(
+                "private atomic writes do not accept a caller-supplied mode"
+            )
         return PRIVATE_FILE_MODE
     if mode_policy is AtomicWriteModePolicy.PRESERVE_EXISTING:
         if metadata is not None:
@@ -253,7 +259,7 @@ def read_file_paths_file(path: Path) -> list[str]:
 
     contents = path.read_bytes()
     if contents.startswith(_PATH_LIST_MAGIC):
-        encoded_paths = nul_records(contents[len(_PATH_LIST_MAGIC):])
+        encoded_paths = nul_records(contents[len(_PATH_LIST_MAGIC) :])
         return sorted({decode_path(encoded_path) for encoded_path in encoded_paths})
 
     return sorted(read_text_file_line_set(path))
@@ -273,8 +279,7 @@ def write_file_paths_file(path: Path, file_paths: Iterable[str]) -> None:
     unique_paths = sorted(set(file_paths))
     if any(_path_requires_lossless_list_encoding(path) for path in unique_paths):
         contents = _PATH_LIST_MAGIC + b"".join(
-            encode_path(path) + b"\0"
-            for path in unique_paths
+            encode_path(path) + b"\0" for path in unique_paths
         )
         write_file_bytes(path, contents)
         return
@@ -305,11 +310,20 @@ def is_path_blocked(path: str, blocked_files: Collection[str]) -> bool:
     An entry covers path if it equals path exactly, or if the entry ends
     with '/' and path starts with that prefix (directory match).
     """
-    if f"!{path}" in blocked_files:
-        return False
-    if path in blocked_files:
-        return True
-    return any(path.startswith(entry) for entry in blocked_files if entry.endswith("/"))
+    # Exact and directory negations are authoritative in the compatibility
+    # state format, even when callers have loaded it into a set.
+    for entry in blocked_files:
+        if not entry.startswith("!"):
+            continue
+        included = entry[1:]
+        if path == included or (included.endswith("/") and path.startswith(included)):
+            return False
+    for entry in reversed(list(blocked_files)):
+        if entry.startswith("!"):
+            continue
+        elif path == entry or (entry.endswith("/") and path.startswith(entry)):
+            return True
+    return False
 
 
 def remove_file_path_from_file(state_file_path: Path, file_path: str) -> None:

--- a/src/git_stage_batch/utils/repository_path.py
+++ b/src/git_stage_batch/utils/repository_path.py
@@ -1,0 +1,45 @@
+"""Lexical normalization of user-supplied repository paths."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from ..exceptions import CommandError
+from ..i18n import _
+from .git_repository import get_git_repository_root_path
+
+
+@dataclass(frozen=True)
+class RepositoryPath:
+    """One normalized POSIX repository-relative path."""
+
+    value: str
+    is_directory: bool
+
+
+def normalize_repository_path(value: str) -> RepositoryPath:
+    """Interpret ``value`` from cwd without resolving symlink components."""
+    directory_intent = value.endswith(("/", os.sep))
+    repo_root = os.path.abspath(os.fspath(get_git_repository_root_path()))
+    candidate = os.path.abspath(value)
+    try:
+        inside = os.path.commonpath((repo_root, candidate)) == repo_root
+    except ValueError:
+        inside = False
+    if not inside:
+        raise CommandError(
+            _("Path is outside the repository worktree: {path}").format(path=value)
+        )
+    relative = os.path.relpath(candidate, repo_root)
+    if relative == ".":
+        raise CommandError(_("A repository file or directory path is required."))
+    normalized = relative.replace(os.sep, "/")
+    try:
+        present_directory = os.path.isdir(candidate) and not os.path.islink(candidate)
+    except OSError:
+        present_directory = False
+    is_directory = directory_intent or present_directory
+    if is_directory:
+        normalized = normalized.rstrip("/") + "/"
+    return RepositoryPath(normalized, is_directory)

--- a/tests/commands/test_unblock_file.py
+++ b/tests/commands/test_unblock_file.py
@@ -20,13 +20,30 @@ def temp_git_repo(tmp_path, monkeypatch):
     monkeypatch.chdir(repo)
 
     subprocess.run(["git", "init"], check=True, cwd=repo, capture_output=True)
-    subprocess.run(["git", "config", "user.name", "Test User"], check=True, cwd=repo, capture_output=True)
-    subprocess.run(["git", "config", "user.email", "test@example.com"], check=True, cwd=repo, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"],
+        check=True,
+        cwd=repo,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        check=True,
+        cwd=repo,
+        capture_output=True,
+    )
 
     # Create initial commit
     (repo / "README.md").write_text("# Test\n")
-    subprocess.run(["git", "add", "README.md"], check=True, cwd=repo, capture_output=True)
-    subprocess.run(["git", "commit", "-m", "Initial commit"], check=True, cwd=repo, capture_output=True)
+    subprocess.run(
+        ["git", "add", "README.md"], check=True, cwd=repo, capture_output=True
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "Initial commit"],
+        check=True,
+        cwd=repo,
+        capture_output=True,
+    )
 
     return repo
 
@@ -64,19 +81,25 @@ class TestCommandUnblockFile:
         file_name = "file[1].txt"
         (temp_git_repo / file_name).write_text("content\n")
         command_block_file(file_name)
-        assert subprocess.run(
-            ["git", "check-ignore", "--quiet", "--", file_name],
-            cwd=temp_git_repo,
-            check=False,
-        ).returncode == 0
+        assert (
+            subprocess.run(
+                ["git", "check-ignore", "--quiet", "--", file_name],
+                cwd=temp_git_repo,
+                check=False,
+            ).returncode
+            == 0
+        )
 
         command_unblock_file(file_name)
 
-        assert subprocess.run(
-            ["git", "check-ignore", "--quiet", "--", file_name],
-            cwd=temp_git_repo,
-            check=False,
-        ).returncode == 1
+        assert (
+            subprocess.run(
+                ["git", "check-ignore", "--quiet", "--", file_name],
+                cwd=temp_git_repo,
+                check=False,
+            ).returncode
+            == 1
+        )
 
     @pytest.mark.parametrize("local_only", [False, True])
     def test_unblock_file_removes_legacy_literal_special_path(
@@ -87,9 +110,7 @@ class TestCommandUnblockFile:
         """Unblocking should remove raw special rules written by older versions."""
         file_name = "literal*.txt"
         (temp_git_repo / file_name).write_text("content\n")
-        ignore_path = (
-            get_local_exclude_path() if local_only else get_gitignore_path()
-        )
+        ignore_path = get_local_exclude_path() if local_only else get_gitignore_path()
         ignore_path.parent.mkdir(parents=True, exist_ok=True)
         ignore_path.write_text(f"{file_name}\n")
         append_file_path_to_file(get_blocked_files_file_path(), file_name)
@@ -111,9 +132,7 @@ class TestCommandUnblockFile:
         directory.mkdir()
         child = directory / "keep.txt"
         child.write_text("content\n")
-        ignore_path = (
-            get_local_exclude_path() if local_only else get_gitignore_path()
-        )
+        ignore_path = get_local_exclude_path() if local_only else get_gitignore_path()
         ignore_path.parent.mkdir(parents=True, exist_ok=True)
         ignore_path.write_text("generated*/\n")
         append_file_path_to_file(get_blocked_files_file_path(), "generated*/")
@@ -122,7 +141,7 @@ class TestCommandUnblockFile:
 
         content = ignore_path.read_text()
         assert "generated\\*/**\n" in content
-        assert "!generated\\*/keep.txt\n" in content
+        assert "!/generated\\*/keep.txt\n" in content
         assert "generated*/\n" not in content
 
     def test_unblock_file_removes_from_blocked_list(self, temp_git_repo):
@@ -175,7 +194,10 @@ class TestCommandUnblockFile:
 
         # Should show appropriate message
         captured = capsys.readouterr()
-        assert "Removed from blocked list: manual.txt (was not in .gitignore)" in captured.err
+        assert (
+            "Removed from blocked list: manual.txt (was not in .gitignore)"
+            in captured.err
+        )
 
     def test_unblock_file_restores_intent_to_add_in_index(self, temp_git_repo):
         """Test that unblock-file re-adds the file to the index as intent-to-add during a session."""
@@ -189,14 +211,24 @@ class TestCommandUnblockFile:
         command_block_file("temp.txt")
 
         # Verify it's not in the index
-        result = subprocess.run(["git", "ls-files", "--", "temp.txt"], capture_output=True, text=True, cwd=temp_git_repo)
+        result = subprocess.run(
+            ["git", "ls-files", "--", "temp.txt"],
+            capture_output=True,
+            text=True,
+            cwd=temp_git_repo,
+        )
         assert "temp.txt" not in result.stdout
 
         # Unblock it
         command_unblock_file("temp.txt")
 
         # Should be back in the index as intent-to-add
-        result = subprocess.run(["git", "ls-files", "--", "temp.txt"], capture_output=True, text=True, cwd=temp_git_repo)
+        result = subprocess.run(
+            ["git", "ls-files", "--", "temp.txt"],
+            capture_output=True,
+            text=True,
+            cwd=temp_git_repo,
+        )
         assert "temp.txt" in result.stdout
 
     def test_unblock_file_preserves_staged_tracked_file_on_stop(self, temp_git_repo):
@@ -206,7 +238,12 @@ class TestCommandUnblockFile:
 
         # Stage a tracked file before the session starts.
         (temp_git_repo / "README.md").write_text("# Test\n\nStaged\n")
-        subprocess.run(["git", "add", "README.md"], check=True, cwd=temp_git_repo, capture_output=True)
+        subprocess.run(
+            ["git", "add", "README.md"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
 
         # Put the tracked file in blocked state so unblock-file can remove it.
         get_gitignore_path().write_text("README.md\n")
@@ -216,7 +253,12 @@ class TestCommandUnblockFile:
         command_unblock_file("README.md")
         command_stop()
 
-        result = subprocess.run(["git", "status", "--porcelain", "--", "README.md"], capture_output=True, text=True, cwd=temp_git_repo)
+        result = subprocess.run(
+            ["git", "status", "--porcelain", "--", "README.md"],
+            capture_output=True,
+            text=True,
+            cwd=temp_git_repo,
+        )
         assert result.stdout.startswith("M  ")
 
     def test_unblock_file_shows_next_hunk_during_session(self, temp_git_repo, capsys):
@@ -297,7 +339,9 @@ class TestCommandUnblockFile:
         captured = capsys.readouterr()
         assert "Unblocked file: local.txt" in captured.err
 
-    def test_unblock_file_removes_from_both_exclude_and_gitignore(self, temp_git_repo, capsys):
+    def test_unblock_file_removes_from_both_exclude_and_gitignore(
+        self, temp_git_repo, capsys
+    ):
         """Test that unblock-file removes file from both ignore sources at once."""
         (temp_git_repo / "both.txt").write_text("content\n")
 
@@ -351,7 +395,9 @@ class TestCommandUnblockFile:
         blocked = read_file_paths_file(get_blocked_files_file_path())
         assert "dist/" not in blocked
 
-    def test_unblock_file_via_negation_when_directory_covers_path(self, temp_git_repo, capsys):
+    def test_unblock_file_via_negation_when_directory_covers_path(
+        self, temp_git_repo, capsys
+    ):
         """Test that unblocking a file under a blocked directory uses negation."""
         subdir = temp_git_repo / "build"
         subdir.mkdir()
@@ -370,7 +416,7 @@ class TestCommandUnblockFile:
         # .gitignore should have build/** (promoted) and !build/keep.c (negation)
         content = gitignore.read_text()
         assert "build/**\n" in content
-        assert "!build/keep.c\n" in content
+        assert "!/build/keep.c\n" in content
         assert "build/\n" not in content
 
         # Blocked list should have !build/keep.c negation
@@ -413,11 +459,12 @@ class TestCommandUnblockFile:
         content = gitignore.read_text()
         assert "gen/**\n" in content
         assert content.count("gen/**") == 1  # not promoted twice
-        assert "!gen/a.c\n" in content
-        assert "!gen/b.c\n" in content
+        assert "!/gen/a.c\n" in content
+        assert "!/gen/b.c\n" in content
 
         blocked = set(read_file_paths_file(get_blocked_files_file_path()))
         from git_stage_batch.utils.file_io import is_path_blocked
+
         assert not is_path_blocked("gen/a.c", blocked)
         assert not is_path_blocked("gen/b.c", blocked)
         assert is_path_blocked("gen/c.o", blocked)

--- a/tests/data/test_ignore_files.py
+++ b/tests/data/test_ignore_files.py
@@ -38,7 +38,9 @@ def temp_git_repo(tmp_path, monkeypatch):
     )
 
     (repo / "README.md").write_text("# Test\n")
-    subprocess.run(["git", "add", "README.md"], check=True, cwd=repo, capture_output=True)
+    subprocess.run(
+        ["git", "add", "README.md"], check=True, cwd=repo, capture_output=True
+    )
     subprocess.run(
         ["git", "commit", "-m", "Initial commit"],
         check=True,
@@ -105,7 +107,7 @@ class TestGitignoreManipulation:
         add_file_to_gitignore("test.txt")
 
         lines = read_gitignore_lines()
-        assert "test.txt\n" in lines
+        assert "/test.txt\n" in lines
 
     def test_add_file_to_gitignore_existing(self, temp_git_repo):
         """Test adding a file to existing .gitignore."""
@@ -118,7 +120,7 @@ class TestGitignoreManipulation:
         lines = read_gitignore_lines()
         assert "*.pyc\n" in lines
         assert "__pycache__/\n" in lines
-        assert "test.txt\n" in lines
+        assert "/test.txt\n" in lines
 
     def test_add_file_to_gitignore_no_duplicates(self, temp_git_repo):
         """Test adding a file twice doesn't create duplicates."""
@@ -141,7 +143,7 @@ class TestGitignoreManipulation:
         add_file_to_gitignore("test.txt")
 
         content = gitignore.read_text()
-        assert content == "*.pyc\ntest.txt\n"
+        assert content == "*.pyc\n/test.txt\n"
 
     def test_remove_file_from_gitignore_with_marker(self, temp_git_repo):
         """Test removing a file from .gitignore."""
@@ -184,7 +186,7 @@ class TestGitignoreManipulation:
         lines = read_gitignore_lines()
         assert "*.pyc\n" in lines
         assert "test1.txt\n" not in lines
-        assert "test2.txt\n" in lines
+        assert "/test2.txt\n" in lines
 
     def test_remove_file_from_gitignore_nonexistent(self, temp_git_repo):
         """Test removing a file that doesn't exist in .gitignore."""


### PR DESCRIPTION
Blocked-path commands combine filesystem resolution, line-oriented persistence, and partially ordered ignore patterns when interpreting repository-relative input.

Users can receive different block behavior for missing paths, directory descendants, newline-bearing names, or negated entries even when the paths denote the same repository location.

This pull request adds one lexical repository normalizer, lossless path-list storage, anchored literal patterns, directory reinclusion, checked index mutations, and command-level validation for those shared semantics.

Blocked-path state now has one interpretation from command input through persisted and generated ignore rules.