### PR TITLE
Scope repository locks to interactive actions

### DIFF
--- a/src/git_stage_batch/cli/main.py
+++ b/src/git_stage_batch/cli/main.py
@@ -44,10 +44,16 @@ def main() -> None:
             if args.working_directory is not None:
                 os.chdir(args.working_directory)
             skip_session_lock = getattr(args, "prompt_format", None) is not None
-            pager_context = pager_output() if should_page_output(args) else nullcontext()
+            interactive = bool(
+                getattr(args, "interactive_flag", False)
+                or getattr(args, "interactive_command", False)
+            )
+            pager_context = (
+                pager_output() if should_page_output(args) else nullcontext()
+            )
             lock_context = (
                 nullcontext()
-                if skip_session_lock
+                if skip_session_lock or interactive
                 else acquire_session_lock()
             )
             with pager_context:

--- a/src/git_stage_batch/tui/cli_escape.py
+++ b/src/git_stage_batch/tui/cli_escape.py
@@ -3,28 +3,69 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+import os
 import shlex
 
 from ..cli.argument_parser import parse_command_line
 from ..cli.execution import execute_non_interactive_args
 from ..exceptions import BypassRefresh
 from ..i18n import _
+from ..data.session_ownership import require_no_foreign_session_owner
+from ..utils.session_lock import acquire_session_lock
+
+
+_READ_ONLY_COMMANDS = frozenset(
+    {
+        "check-unstaged",
+        "journal",
+        "list",
+        "show",
+        "status",
+        "validate",
+    }
+)
+
+
+def _execute_embedded_args(args) -> None:
+    """Apply normal cwd and target-repository locking for one TUI command."""
+    original_cwd = os.getcwd()
+    try:
+        working_directory = getattr(args, "working_directory", None)
+        if working_directory is not None:
+            os.chdir(working_directory)
+        skip_lock = getattr(args, "prompt_format", None) is not None
+        if skip_lock:
+            execute_non_interactive_args(args)
+            return
+        with acquire_session_lock():
+            if getattr(args, "command", None) not in _READ_ONLY_COMMANDS:
+                require_no_foreign_session_owner()
+            execute_non_interactive_args(args)
+    finally:
+        os.chdir(original_cwd)
 
 
 def handle_cli_escape(action: str, *, print_help: Callable[[], None]) -> None:
     """Handle arbitrary CLI command as an interactive escape hatch."""
     try:
         args_list = shlex.split(action)
-        args = parse_command_line(args_list, quiet=False)
+        try:
+            args = parse_command_line(args_list, quiet=False)
+        except SystemExit as error:
+            # argparse has already rendered help, version, or diagnostics.
+            if error.code not in (0, 2):
+                print(
+                    _("\nCommand exited with status {status}").format(status=error.code)
+                )
+            raise BypassRefresh() from None
 
         if args is not None:
-            if (
-                getattr(args, "interactive_flag", False)
-                or getattr(args, "interactive_command", False)
+            if getattr(args, "interactive_flag", False) or getattr(
+                args, "interactive_command", False
             ):
                 print(_("\nAlready in interactive mode."))
             else:
-                execute_non_interactive_args(args)
+                _execute_embedded_args(args)
         else:
             print(_("\nUnknown command: '{cmd}'").format(cmd=action))
             print_help()

--- a/src/git_stage_batch/tui/interactive.py
+++ b/src/git_stage_batch/tui/interactive.py
@@ -8,9 +8,10 @@ from ..exceptions import BypassRefresh, QuitInteractive
 from ..i18n import _
 from ..output.colors import Colors
 from ..utils.journal import flush_journal
+from ..utils.session_lock import acquire_session_lock
 from . import current_change
 from .action_dispatch import dispatch_action
-from .flow import FlowLocation, LocationRole, FlowState
+from .flow import FlowLocation, FlowState
 from .prompts import (
     prompt_action,
 )
@@ -27,7 +28,8 @@ def start_interactive_mode() -> None:
     If no changes exist, enters degraded mode where hunk-based actions
     are disabled but help, shell commands, and abort remain available.
     """
-    startup = prepare_interactive_session()
+    with acquire_session_lock():
+        startup = prepare_interactive_session()
     degraded_mode = startup.degraded_mode
 
     use_color = Colors.enabled()
@@ -43,7 +45,8 @@ def start_interactive_mode() -> None:
 
     # Main interactive loop
     while True:
-        loaded_change = current_change.load_current_change(flow_state)
+        with acquire_session_lock():
+            loaded_change = current_change.load_current_change(flow_state)
         has_hunk = loaded_change is not None
 
         if loaded_change is None:

--- a/src/git_stage_batch/tui/shell_command.py
+++ b/src/git_stage_batch/tui/shell_command.py
@@ -10,7 +10,7 @@ from .prompts import prompt_shell_command
 
 
 def handle_shell_command(action: str) -> None:
-    """Handle shell command execution."""
+    """Handle a trusted user shell command while no repository lock is held."""
     if len(action) > 1:
         command = action[1:].strip()
     else:


### PR DESCRIPTION
Interactive mode enters under the CLI lifetime lock and keeps that lock while waiting for prompts and running shell or embedded CLI escapes.

Users cannot safely run repository commands from an escape while the parent process owns the same session lock, and a changed working directory can leak into later TUI actions.

This pull request releases the lifetime lock for interactive mode, locks startup, reload, and embedded command operations individually, restores the original directory, and handles parser exits without terminating the TUI.