### PR TITLE
Declare the tested Python and OS range

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
       fail-fast: false
 
     steps:
@@ -71,6 +71,9 @@ jobs:
 
       - name: Run tests
         run: uv run pytest -n auto
+
+      - name: Run Ruff
+        run: uv run ruff check src tests
 
   build:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ During development we experiment, refactor, backtrack, and fix mistakes. If ever
 - **State persistence** - Resume staging across multiple invocations
 - **Batch operations** - Save hunks for later, organize complex changes
 - **Machine-readable output** - `--porcelain` flag for scripting
-- **No dependencies** - Pure Python standard library
+- **No runtime Python packages** - Uses the standard library and the external Git executable
 
 ## Quick Start
 
@@ -171,8 +171,9 @@ pip install git-stage-batch
 
 ## Requirements
 
-- Python 3.10+
-- No other dependencies (pure stdlib!)
+- Python 3.10 through 3.13
+- Git 2.29 or newer
+- A POSIX operating system; Linux is the currently tested platform. Native Windows is not supported.
 
 ## Documentation
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -70,8 +70,16 @@ This runs the tool without permanently installing it.
 
 ## Requirements
 
-- **Python 3.10+**
-- No other dependencies (pure stdlib!)
+- **Python 3.10 through 3.13**
+- **Git 2.29 or newer** available on `PATH`
+- **POSIX operating system.** Linux is tested in CI; native Windows is not
+  supported because repository locking, signals, symlinks, and terminal process
+  control currently use POSIX facilities.
+
+There are no runtime Python package dependencies. Building from source also
+requires Meson, meson-python, Ninja, and gettext. Repository paths are handled
+with Git's byte-preserving surrogate-escape conventions; symlink workflows need
+a filesystem and account that permit creating symlinks.
 
 ## Verify Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,8 @@ keywords = ["git", "staging", "commit", "diff", "patch"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Environment :: Console",
+    "Operating System :: POSIX",
+    "Operating System :: POSIX :: Linux",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
@@ -38,6 +40,7 @@ dev = [
     "meson>=1.10.0",
     "ninja>=1.11.0",
     "pytest-xdist>=3.8.0",
+    "ruff==0.12.2",
 ]
 docs = [
     "mkdocs-material>=9.7.4",

--- a/src/git_stage_batch/cli/main.py
+++ b/src/git_stage_batch/cli/main.py
@@ -11,20 +11,28 @@ from ..exceptions import CommandError
 from ..i18n import _
 from ..runtime import dispatch_cli_mode
 from ..data.session_ownership import require_no_foreign_session_owner
-from ..utils.session_lock import acquire_session_lock
 from ..utils.journal import flush_journal
 from .argument_parser import parse_command_line
 from .pager import pager_output, should_page_output
 
 
-_READ_ONLY_COMMANDS = frozenset({
-    "check-unstaged",
-    "journal",
-    "list",
-    "show",
-    "status",
-    "validate",
-})
+_READ_ONLY_COMMANDS = frozenset(
+    {
+        "check-unstaged",
+        "journal",
+        "list",
+        "show",
+        "status",
+        "validate",
+    }
+)
+
+
+def acquire_session_lock():
+    """Load the POSIX lock backend only after the platform check."""
+    from ..utils.session_lock import acquire_session_lock as acquire_lock
+
+    return acquire_lock()
 
 
 def _command_may_mutate(args) -> bool:
@@ -39,6 +47,10 @@ def _command_may_mutate(args) -> bool:
 def main() -> None:
     """Main entry point for git-stage-batch."""
     try:
+        if os.name != "posix":
+            raise CommandError(
+                _("git-stage-batch currently supports POSIX operating systems only.")
+            )
         args = parse_command_line(sys.argv[1:], quiet=False)
         if args is not None:
             if args.working_directory is not None:


### PR DESCRIPTION
The package advertises Python 3.10 or newer without an operating-system boundary, while continuous integration exercises only Python 3.10 on one POSIX runner.

Users on unsupported systems receive backend import failures, and the project does not validate the newer Python versions included by its open-ended requirement.

This pull request declares POSIX support, diagnoses unsupported operating systems before backend imports, tests Python 3.10 through 3.13, pins lint validation, and aligns the README and installation guide with that contract.

The supported environment is now consistent from package discovery through installation and runtime diagnostics.