### PR TITLE
Add an internal import graph report

### DIFF
--- a/scripts/architecture_graph.py
+++ b/scripts/architecture_graph.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Print the observed internal package import graph."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE = ROOT / "src" / "git_stage_batch"
+
+
+def module_name(path: Path) -> str:
+    return ".".join(("git_stage_batch", *path.relative_to(SOURCE).with_suffix("").parts))
+
+
+def resolve_relative(source: str, level: int, target: str | None) -> str | None:
+    if level == 0:
+        return target
+    package = source.split(".")[:-1]
+    if level - 1 > len(package):
+        return None
+    base = package[: len(package) - (level - 1)]
+    return ".".join((*base, *(target.split(".") if target else ())))
+
+
+def main() -> None:
+    edges = set()
+    for path in SOURCE.rglob("*.py"):
+        source = module_name(path)
+        for node in ast.walk(ast.parse(path.read_text(), filename=str(path))):
+            if not isinstance(node, ast.ImportFrom):
+                continue
+            target = resolve_relative(source, node.level, node.module)
+            if target and target.startswith("git_stage_batch"):
+                edges.add((source, target))
+    for source, target in sorted(edges):
+        print(f"{source} -> {target}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The project has architecture assertions but no lightweight way to inspect the complete internal import graph outside a failing test.

The project cannot review emerging dependency direction before deciding whether a boundary deserves an enforceable policy rule.

This pull request adds a read-only script that prints resolved internal import edges for architectural investigation.