### PR TITLE
Preserve staged binary and added-file state

### DIFF
--- a/src/git_stage_batch/commands/selection/selected_change_discarding.py
+++ b/src/git_stage_batch/commands/selection/selected_change_discarding.py
@@ -19,7 +19,11 @@ from ...data.hunk_tracking import fetch_next_change
 from ...data.progress import record_hunk_discarded
 from ...data.selected_change.loading import load_selected_change
 from ...data.selected_change.paths import worktree_paths_for_selected_change
-from ...data.session import snapshot_file_if_untracked, snapshot_files_if_untracked
+from ...data.session import (
+    path_is_intent_to_add,
+    snapshot_file_if_untracked,
+    snapshot_files_if_untracked,
+)
 from ...data.file_modes import apply_git_file_mode
 from ...data.undo_checkpoints import undo_checkpoint
 from ...exceptions import CommandError, NoMoreHunks, exit_with_error
@@ -407,3 +411,21 @@ def _remove_worktree_path(file_path: str) -> None:
         absolute_path.rmdir()
         return
     absolute_path.unlink()
+
+
+def _drop_intent_to_add_entry(file_path: str) -> None:
+    """Remove a session-only intent-to-add marker after deleting its path."""
+    if not path_is_intent_to_add(file_path):
+        return
+    result = git_update_index(
+        file_path=file_path,
+        force_remove=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        exit_with_error(
+            _("Failed to remove intent-to-add entry for {file}: {error}").format(
+                file=file_path,
+                error=result.stderr,
+            )
+        )

--- a/src/git_stage_batch/commands/selection/selected_change_discarding.py
+++ b/src/git_stage_batch/commands/selection/selected_change_discarding.py
@@ -28,7 +28,7 @@ from ...utils.file_io import append_lines_to_file, path_is_empty, read_text_file
 from ...utils.git_command import run_git_command
 from ...utils.git_worktree import (
     git_apply_to_worktree,
-    git_checkout_paths,
+    git_checkout_index_paths,
     git_remove_paths,
 )
 from ...utils.git_index import (
@@ -195,14 +195,14 @@ def _discard_binary_change(
             absolute_path.unlink()
             log_journal("command_discard_binary_deleted", file_path=file_path)
     elif item.is_deleted_file():
-        result = git_checkout_paths("HEAD", [file_path], check=False)
+        result = git_checkout_index_paths([file_path], check=False)
         if result.returncode != 0:
             exit_with_error(
                 _("Failed to restore binary file: {}").format(result.stderr)
             )
         log_journal("command_discard_binary_restored", file_path=file_path)
     else:
-        result = git_checkout_paths("HEAD", [file_path], check=False)
+        result = git_checkout_index_paths([file_path], check=False)
         if result.returncode != 0:
             exit_with_error(
                 _("Failed to restore binary file: {}").format(result.stderr)

--- a/src/git_stage_batch/commands/selection/selected_change_discarding.py
+++ b/src/git_stage_batch/commands/selection/selected_change_discarding.py
@@ -292,6 +292,7 @@ def _discard_text_hunk(
         absolute_path = get_git_repository_root_path() / file_path
         if absolute_path.exists() and path_is_empty(absolute_path):
             absolute_path.unlink()
+            _drop_intent_to_add_entry(file_path)
 
     append_lines_to_file(get_block_list_file_path(), [patch_hash])
     record_hunk_discarded(patch_hash)

--- a/src/git_stage_batch/commands/selection/selected_change_discarding.py
+++ b/src/git_stage_batch/commands/selection/selected_change_discarding.py
@@ -197,7 +197,8 @@ def _discard_binary_change(
         absolute_path = get_git_repository_root_path() / file_path
         if absolute_path.exists():
             absolute_path.unlink()
-            log_journal("command_discard_binary_deleted", file_path=file_path)
+        _drop_intent_to_add_entry(file_path)
+        log_journal("command_discard_binary_deleted", file_path=file_path)
     elif item.is_deleted_file():
         result = git_checkout_index_paths([file_path], check=False)
         if result.returncode != 0:

--- a/src/git_stage_batch/utils/git_worktree.py
+++ b/src/git_stage_batch/utils/git_worktree.py
@@ -46,6 +46,19 @@ def git_checkout_paths(
     )
 
 
+def git_checkout_index_paths(
+    paths: Sequence[str],
+    *,
+    check: bool = True,
+) -> subprocess.CompletedProcess:
+    """Restore working-tree paths from the index without changing the index."""
+    return run_git_command(
+        ["checkout", "--", *paths],
+        check=check,
+        requires_index_lock=True,
+    )
+
+
 def git_checkout_detached(
     oid: str,
     *,

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -17227,7 +17227,7 @@ def test_selected_change_discarding_owns_discard_pipeline():
         "get_selected_hunk_hash_file_path",
         "get_selected_hunk_patch_file_path",
         "git_apply_to_worktree",
-        "git_checkout_paths",
+        "git_checkout_index_paths",
         "path_is_empty",
         "patch_is_new_file",
         "read_text_file_contents",

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -2878,6 +2878,7 @@ def test_git_worktree_helpers_stay_out_of_git_command_module():
     )
     public_names = {
         "git_apply_to_worktree",
+        "git_checkout_index_paths",
         "git_checkout_paths",
         "git_checkout_detached",
         "git_remove_paths",

--- a/tests/commands/test_binary_files.py
+++ b/tests/commands/test_binary_files.py
@@ -292,6 +292,32 @@ def test_binary_file_modified_discard(binary_file_repo: Path, monkeypatch: pytes
     assert (binary_file_repo / "image.png").read_bytes() == original_content
 
 
+def test_binary_file_modified_discard_preserves_staged_content(
+    binary_file_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Binary discard restores the index version without resetting it to HEAD."""
+    monkeypatch.chdir(binary_file_repo)
+    image_path = binary_file_repo / "image.png"
+    staged_content = b"\x00STAGED"
+    image_path.write_bytes(staged_content)
+    subprocess.run(["git", "add", "image.png"], check=True, capture_output=True)
+    image_path.write_bytes(b"\x00UNSTAGED")
+
+    initialize_abort_state()
+    selected_change = fetch_next_change()
+    assert isinstance(selected_change, BinaryFileChange)
+
+    command_discard(quiet=True)
+
+    assert image_path.read_bytes() == staged_content
+    assert run_git_command(["show", ":image.png"], text_output=False).stdout == staged_content
+    assert run_git_command(
+        ["diff", "--cached", "--quiet", "--", "image.png"],
+        check=False,
+    ).returncode == 1
+
+
 def test_binary_file_deleted_discard(binary_file_repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Test discarding deletion of a binary file (restore it)."""
     monkeypatch.chdir(binary_file_repo)


### PR DESCRIPTION
Selected-change discard uses worktree-versus-index diffs for text hunks,
while binary restoration has HEAD-based paths and session-managed additions
use intent-to-add markers.

Users can lose staged binary content when discarding later worktree changes,
and removed added paths can remain visible through procedural index entries.

This pull request adds an index-only checkout helper, restores binary files
from staged blobs, and removes intent-to-add entries when added binary or
empty text paths disappear.

Binary and added-file discard now returns the worktree to the live-diff
baseline without rewriting staged content or leaving session residue.

---

Stack: 1 of 6. Base: `main`.