### PR TITLE
Preserve staged content across discard paths

### DIFF
--- a/src/git_stage_batch/commands/selection/selected_change_discarding.py
+++ b/src/git_stage_batch/commands/selection/selected_change_discarding.py
@@ -33,7 +33,6 @@ from ...utils.git_command import run_git_command
 from ...utils.git_worktree import (
     git_apply_to_worktree,
     git_checkout_index_paths,
-    git_remove_paths,
 )
 from ...utils.git_index import (
     git_update_gitlink,
@@ -344,31 +343,25 @@ def discard_gitlink_change(gitlink_change: GitlinkChange) -> None:
 
 
 def discard_rename_change(rename_change: RenameChange) -> None:
-    """Restore the old path and remove the renamed destination."""
+    """Restore an unstaged rename in the worktree without changing the index."""
     snapshot_files_if_untracked([rename_change.new_path])
-
-    remove_result = git_remove_paths(
-        [rename_change.new_path],
-        force=True,
-        ignore_unmatch=True,
-        check=False,
-    )
-    if remove_result.returncode != 0:
-        index_result = git_update_index(
+    destination_is_intent_to_add = path_is_intent_to_add(rename_change.new_path)
+    _remove_worktree_path(rename_change.new_path)
+    if destination_is_intent_to_add:
+        remove_result = git_update_index(
             file_path=rename_change.new_path,
             force_remove=True,
             check=False,
         )
-        if index_result.returncode != 0:
+        if remove_result.returncode != 0:
             exit_with_error(
-                _("Failed to remove renamed path {file}: {error}").format(
+                _("Failed to remove rename marker {file}: {error}").format(
                     file=rename_change.new_path,
-                    error=index_result.stderr,
+                    error=remove_result.stderr,
                 )
             )
-        _remove_worktree_path(rename_change.new_path)
 
-    restore_result = git_checkout_paths("HEAD", [rename_change.old_path], check=False)
+    restore_result = git_checkout_index_paths([rename_change.old_path], check=False)
     if restore_result.returncode != 0:
         exit_with_error(
             _("Failed to restore renamed source {file}: {error}").format(

--- a/src/git_stage_batch/commands/selection/selected_change_discarding.py
+++ b/src/git_stage_batch/commands/selection/selected_change_discarding.py
@@ -34,10 +34,7 @@ from ...utils.git_worktree import (
     git_apply_to_worktree,
     git_checkout_index_paths,
 )
-from ...utils.git_index import (
-    git_update_gitlink,
-    git_update_index,
-)
+from ...utils.git_index import git_update_index
 from ...utils.git_repository import get_git_repository_root_path
 from ...utils.journal import log_journal
 from ...utils.paths import (
@@ -320,26 +317,8 @@ def discard_gitlink_change(gitlink_change: GitlinkChange) -> None:
     }
     discard_submodule_pointer_from_batch(file_path, file_meta)
 
-    if gitlink_change.is_new_file():
-        return
-    if gitlink_change.old_oid is None:
-        exit_with_error(
-            _("Cannot discard submodule pointer for {file}: missing baseline commit.").format(
-                file=file_path,
-            )
-        )
-    index_result = git_update_gitlink(
-        file_path=file_path,
-        oid=gitlink_change.old_oid,
-        check=False,
-    )
-    if index_result.returncode != 0:
-        exit_with_error(
-            _("Failed to update submodule pointer in the index for {file}: {error}").format(
-                file=file_path,
-                error=index_result.stderr,
-            )
-        )
+    # The live diff baseline is the index. Restoring the submodule worktree is
+    # sufficient; changing the gitlink entry here would discard staged work.
 
 
 def discard_rename_change(rename_change: RenameChange) -> None:

--- a/src/git_stage_batch/commands/selection/selected_file_discarding.py
+++ b/src/git_stage_batch/commands/selection/selected_file_discarding.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 import sys
 
 from ...data.selected_change.paths import get_selected_change_file_path
+from ...data.index_entries import read_index_entry
 from ...data.session import snapshot_file_if_untracked
 from ...data.undo_checkpoints import undo_checkpoint
 from ...exceptions import exit_with_error
 from ...i18n import _
-from ...utils.git_command import run_git_command
-from ...utils.git_worktree import git_checkout_paths
+from ...utils.git_worktree import git_checkout_index_paths
 from ...utils.git_repository import get_git_repository_root_path
 from .action_completion import finish_selected_change_action
 
@@ -30,22 +30,17 @@ def discard_selected_file(
     with undo_checkpoint("discard", worktree_paths=[target_file]):
         snapshot_file_if_untracked(target_file)
 
-        head_result = run_git_command(
-            ["show", f"HEAD:{target_file}"],
-            check=False,
-            text_output=False,
-            requires_index_lock=False,
-        )
-        if head_result.returncode == 0:
-            result = git_checkout_paths("HEAD", [target_file], check=False)
+        index_entry = read_index_entry(target_file)
+        if index_entry is None:
+            absolute_path = get_git_repository_root_path() / target_file
+            if absolute_path.exists() or absolute_path.is_symlink():
+                absolute_path.unlink()
+        else:
+            result = git_checkout_index_paths([target_file], check=False)
             if result.returncode != 0:
                 exit_with_error(
                     _("Failed to discard file: {}").format(result.stderr)
                 )
-        else:
-            absolute_path = get_git_repository_root_path() / target_file
-            if absolute_path.exists():
-                absolute_path.unlink()
 
         if quiet:
             finish_selected_change_action(quiet=True, auto_advance=auto_advance)

--- a/src/git_stage_batch/commands/selection/selected_file_discarding.py
+++ b/src/git_stage_batch/commands/selection/selected_file_discarding.py
@@ -6,11 +6,12 @@ import sys
 
 from ...data.selected_change.paths import get_selected_change_file_path
 from ...data.index_entries import read_index_entry
-from ...data.session import snapshot_file_if_untracked
+from ...data.session import path_is_intent_to_add, snapshot_file_if_untracked
 from ...data.undo_checkpoints import undo_checkpoint
 from ...exceptions import exit_with_error
 from ...i18n import _
 from ...utils.git_worktree import git_checkout_index_paths
+from ...utils.git_index import git_update_index
 from ...utils.git_repository import get_git_repository_root_path
 from .action_completion import finish_selected_change_action
 
@@ -31,10 +32,21 @@ def discard_selected_file(
         snapshot_file_if_untracked(target_file)
 
         index_entry = read_index_entry(target_file)
-        if index_entry is None:
+        is_intent_to_add = path_is_intent_to_add(target_file)
+        if index_entry is None or is_intent_to_add:
             absolute_path = get_git_repository_root_path() / target_file
             if absolute_path.exists() or absolute_path.is_symlink():
                 absolute_path.unlink()
+            if is_intent_to_add:
+                remove_result = git_update_index(
+                    file_path=target_file,
+                    force_remove=True,
+                    check=False,
+                )
+                if remove_result.returncode != 0:
+                    exit_with_error(
+                        _("Failed to discard file: {}").format(remove_result.stderr)
+                    )
         else:
             result = git_checkout_index_paths([target_file], check=False)
             if result.returncode != 0:

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -17239,7 +17239,6 @@ def test_selected_change_discarding_owns_discard_pipeline():
         "LineBuffer",
         "discard_submodule_pointer_from_batch",
         "finish_selected_change_action",
-        "git_update_gitlink",
         "git_update_index",
         "load_selected_change",
         "undo_checkpoint",

--- a/tests/commands/test_file_review.py
+++ b/tests/commands/test_file_review.py
@@ -106,7 +106,7 @@ def test_reviewed_file_discard_raises_when_checkout_fails(
     command_show(file="file.txt", porcelain=True)
     monkeypatch.setattr(
         selected_file_discarding,
-        "git_checkout_paths",
+        "git_checkout_index_paths",
         lambda *_args, **_kwargs: subprocess.CompletedProcess(
             ["git", "checkout"],
             1,
@@ -119,6 +119,32 @@ def test_reviewed_file_discard_raises_when_checkout_fails(
         command_discard(quiet=True)
 
     assert "line 2 changed" in (paged_file_repo / "file.txt").read_text()
+
+
+def test_reviewed_file_discard_preserves_staged_content(
+    paged_file_repo,
+):
+    """Discarding a file review restores the worktree from the index."""
+    file_path = paged_file_repo / "file.txt"
+    staged_content = file_path.read_text()
+    subprocess.run(["git", "add", "file.txt"], check=True, capture_output=True)
+    file_path.write_text(staged_content + "unstaged tail\n")
+
+    command_start(quiet=True)
+    command_show(file="file.txt", porcelain=True)
+    command_discard(quiet=True)
+
+    assert file_path.read_text() == staged_content
+    assert subprocess.run(
+        ["git", "show", ":file.txt"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout == staged_content
+    assert subprocess.run(
+        ["git", "diff", "--cached", "--quiet", "--", "file.txt"],
+        check=False,
+    ).returncode == 1
 
 
 def _add_second_changed_file(repo):

--- a/tests/commands/test_start_time_changes.py
+++ b/tests/commands/test_start_time_changes.py
@@ -7,6 +7,7 @@ import pytest
 from git_stage_batch.commands.abort import command_abort
 from git_stage_batch.commands.check_unstaged import command_check_unstaged
 from git_stage_batch.commands.include import command_include
+from git_stage_batch.commands.discard import command_discard
 from git_stage_batch.commands.selection.selected_change_display import show_selected_change
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.commands.stop import command_stop
@@ -104,6 +105,19 @@ def test_start_exposes_unstaged_rename_as_rename_selection(rename_repo):
     assert isinstance(selected_change, RenameChange)
     assert selected_change.old_path == "old.txt"
     assert selected_change.new_path == "new.txt"
+
+
+def test_discard_unstaged_rename_preserves_index(rename_repo):
+    """Rename discard restores paths from the index without rewriting it."""
+    _rename_without_staging(rename_repo)
+    command_start(quiet=True)
+
+    command_discard(quiet=True)
+
+    assert (rename_repo / "old.txt").read_text() == "line 1\nline 2\n"
+    assert not (rename_repo / "new.txt").exists()
+    assert _cached_name_status(rename_repo) == ""
+    assert _uncached_name_status(rename_repo) == ""
 
 
 def test_start_exposes_staged_deletion_as_deleted_line_selection(rename_repo):


### PR DESCRIPTION
Selected-change discard preserves staged binary content and removes
procedural entries when added binary or empty text paths disappear.

Users can still lose staged text, rename, or submodule state because the
remaining file-level paths restore from HEAD or rewrite the index directly.

This pull request restores selected files and rename sources from the index,
removes only procedural destination entries, and leaves staged gitlinks
untouched while adding regression coverage for each path.

Discard now consistently treats the index as the baseline for live changes
across binary, file, rename, and submodule workflows.

---

Stack: 2 of 6. Depends on #205.
Base: `pr/discard-binary-index-baseline`.