### PR TITLE
Replace worktree files atomically

### DIFF
--- a/src/git_stage_batch/core/buffer.py
+++ b/src/git_stage_batch/core/buffer.py
@@ -7,6 +7,8 @@ from contextlib import nullcontext
 import mmap
 import os
 from pathlib import Path
+import stat
+import tempfile
 from typing import Any, BinaryIO, Generic, Iterator, TypeVar, overload
 
 from .mapped_storage import (
@@ -701,9 +703,7 @@ def write_buffer_to_path(path: str | Path, buffer: BufferInput) -> None:
         os.symlink(target, os.fsencode(file_path))
         return
 
-    with file_path.open("wb") as file_handle:
-        for chunk in buffer_byte_chunks(buffer):
-            file_handle.write(chunk)
+    _write_regular_file_atomically(file_path, buffer)
 
 
 def write_buffer_to_working_tree_path(
@@ -726,13 +726,56 @@ def write_buffer_to_working_tree_path(
     if file_path.is_symlink():
         file_path.unlink()
 
-    with file_path.open("wb") as file_handle:
-        for chunk in buffer_byte_chunks(buffer):
-            file_handle.write(chunk)
-
+    requested_mode = None
     if mode == "100755":
-        current_mode = file_path.stat().st_mode
-        file_path.chmod(current_mode | 0o111)
+        requested_mode = 0o755
     elif mode == "100644":
-        current_mode = file_path.stat().st_mode
-        file_path.chmod(current_mode & ~0o111)
+        requested_mode = 0o644
+    _write_regular_file_atomically(file_path, buffer, mode=requested_mode)
+
+
+def _write_regular_file_atomically(
+    file_path: Path,
+    buffer: BufferInput,
+    *,
+    mode: int | None = None,
+) -> None:
+    """Stream a regular file through a same-directory atomic replacement."""
+    try:
+        metadata = file_path.stat()
+    except FileNotFoundError:
+        metadata = None
+    replacement_mode = (
+        mode
+        if mode is not None
+        else stat.S_IMODE(metadata.st_mode) if metadata is not None else 0o644
+    )
+    file_descriptor, temporary_name = tempfile.mkstemp(
+        dir=file_path.parent,
+        prefix=f".{file_path.name}.",
+        suffix=".tmp",
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(file_descriptor, "wb") as file_handle:
+            for chunk in buffer_byte_chunks(buffer):
+                file_handle.write(chunk)
+            file_handle.flush()
+            if metadata is not None and hasattr(os, "fchown"):
+                try:
+                    os.fchown(file_handle.fileno(), metadata.st_uid, metadata.st_gid)
+                except PermissionError:
+                    pass
+            os.fchmod(file_handle.fileno(), replacement_mode)
+            os.fsync(file_handle.fileno())
+        os.replace(temporary_path, file_path)
+        directory_descriptor = os.open(
+            file_path.parent,
+            os.O_RDONLY | getattr(os, "O_DIRECTORY", 0),
+        )
+        try:
+            os.fsync(directory_descriptor)
+        finally:
+            os.close(directory_descriptor)
+    finally:
+        temporary_path.unlink(missing_ok=True)

--- a/tests/core/test_buffer.py
+++ b/tests/core/test_buffer.py
@@ -221,6 +221,22 @@ def test_buffer_helpers_accept_buffers(tmp_path):
     assert output_path.read_bytes() == b"alpha\nbeta\n"
 
 
+def test_write_buffer_failure_preserves_existing_file(tmp_path):
+    """A failed streaming write must not publish partial contents."""
+    output_path = tmp_path / "out.txt"
+    output_path.write_bytes(b"original\n")
+
+    def failing_chunks():
+        yield b"replacement prefix\n"
+        raise RuntimeError("simulated stream failure")
+
+    with pytest.raises(RuntimeError, match="simulated stream failure"):
+        write_buffer_to_path(output_path, failing_chunks())
+
+    assert output_path.read_bytes() == b"original\n"
+    assert list(tmp_path.glob(".out.txt.*.tmp")) == []
+
+
 def test_buffer_matches_across_chunk_boundaries(line_sequence):
     """Buffer comparison ignores how inputs are chunked."""
     left = line_sequence([b"alpha\n", b"beta\n"])


### PR DESCRIPTION
Buffer-backed worktree restoration streams bytes directly into the target
path for regular files used by discard and undo workflows.

Users can be left with truncated content if the process or input stream fails
after the destination has been opened but before all bytes are written.

This pull request writes regular files through same-directory temporary
paths, preserves applicable metadata, syncs the replacement, and atomically
installs it only after the stream completes.

Discard and undo restoration now retain the prior file when replacement
generation fails instead of exposing a partial write.

---

Stack: 4 of 6. Depends on #207.
Base: `pr/file-include-rollback`.