### PR TITLE
Lock interactive mutation handlers

### DIFF
--- a/src/git_stage_batch/tui/interactive.py
+++ b/src/git_stage_batch/tui/interactive.py
@@ -10,7 +10,7 @@ from ..output.colors import Colors
 from ..utils.journal import flush_journal
 from ..utils.session_lock import acquire_session_lock
 from . import current_change
-from .action_dispatch import dispatch_action
+from .action_dispatch import ACTION_HANDLERS, dispatch_action
 from .flow import FlowLocation, FlowState
 from .prompts import (
     prompt_action,
@@ -75,12 +75,23 @@ def start_interactive_mode() -> None:
         )
 
         try:
-            dispatch_action(
-                action,
-                has_hunk=has_hunk,
-                use_color=use_color,
-                flow_state=flow_state,
-            )
+            if action in ACTION_HANDLERS:
+                with acquire_session_lock():
+                    dispatch_action(
+                        action,
+                        has_hunk=has_hunk,
+                        use_color=use_color,
+                        flow_state=flow_state,
+                    )
+            else:
+                # Shell commands, flow changes, and CLI escapes either do not
+                # mutate session state or acquire the lock in their adapters.
+                dispatch_action(
+                    action,
+                    has_hunk=has_hunk,
+                    use_color=use_color,
+                    flow_state=flow_state,
+                )
             should_refresh = True
         except BypassRefresh:
             should_refresh = False

--- a/tests/tui/test_interactive.py
+++ b/tests/tui/test_interactive.py
@@ -15,7 +15,7 @@ from unittest.mock import patch
 
 import pytest
 
-from git_stage_batch.exceptions import BypassRefresh
+from git_stage_batch.exceptions import BypassRefresh, QuitInteractive
 from git_stage_batch.tui.action_dispatch import ACTION_HANDLERS, dispatch_action
 from git_stage_batch.tui.flow import FlowLocation, FlowState
 from git_stage_batch.tui.interactive import (
@@ -586,6 +586,36 @@ class TestDegradedMode:
 
         captured = capsys.readouterr()
         assert "No changes to stage" in captured.err
+
+    def test_registered_actions_run_under_session_lock(self, temp_git_repo):
+        """Interactive handlers must not race concurrent CLI mutations."""
+        lock_depth = 0
+
+        class RecordingLock:
+            def __enter__(self):
+                nonlocal lock_depth
+                lock_depth += 1
+
+            def __exit__(self, *_args):
+                nonlocal lock_depth
+                lock_depth -= 1
+
+        def dispatch_and_quit(*_args, **_kwargs):
+            assert lock_depth == 1
+            raise QuitInteractive()
+
+        with patch(
+            "git_stage_batch.tui.interactive.acquire_session_lock",
+            side_effect=lambda: RecordingLock(),
+        ):
+            with patch("git_stage_batch.tui.interactive.prompt_action", return_value="q"):
+                with patch(
+                    "git_stage_batch.tui.interactive.dispatch_action",
+                    side_effect=dispatch_and_quit,
+                ):
+                    start_interactive_mode()
+
+        assert lock_depth == 0
 
     def test_start_interactive_mode_quit_preserves_existing_session(self, temp_git_repo):
         """Test quitting does not stop a session that already existed."""


### PR DESCRIPTION
Interactive mode locks startup and selected-change loading while dispatching
normal include and discard handlers after those lock scopes end.

Users can run a concurrent CLI mutation while an interactive action changes
shared session files or the index, allowing the operations to race.

This pull request acquires the session lock around registered mutation
handlers while leaving shell commands, flow changes, and adapters with their
own lock behavior outside that scope.

Interactive repository mutations now share the same exclusion boundary as
non-interactive commands without holding a lock across user prompts.

---

Stack: 5 of 6. Depends on #208.
Base: `pr/atomic-worktree-writes`.