### PR TITLE
Reject malformed unified diffs

### DIFF
--- a/src/git_stage_batch/core/diff_parser.py
+++ b/src/git_stage_batch/core/diff_parser.py
@@ -365,10 +365,14 @@ class _UnifiedDiffParserBuildContext:
                     # Get +++ line
                     plus_line = next_line()
                     if plus_line is None:
-                        return
+                        raise CommandError(
+                            _("Malformed unified diff: missing +++ file header.")
+                        )
                     plus_line_stripped = plus_line.rstrip(b'\n')
-                    if not plus_line_stripped.startswith(b"+++"):
-                        continue
+                    if not _patch_headers.line_is_new_file_header(plus_line_stripped):
+                        raise CommandError(
+                            _("Malformed unified diff: expected +++ file header.")
+                        )
                     new_file_line = plus_line_stripped
 
                     patch_old_path = _patch_headers.old_file_path_from_header(

--- a/src/git_stage_batch/core/line_change_body.py
+++ b/src/git_stage_batch/core/line_change_body.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from ..exceptions import CommandError
+from ..i18n import _
 from .models import HunkHeader, LineEntry
 
 
@@ -44,7 +46,11 @@ class LineChangeBodyBuilder:
         elif sign == "+":
             self._append_addition_line(text_bytes)
         else:
-            self._append_context_line(text_bytes)
+            raise CommandError(
+                _("Invalid line prefix in hunk body: {prefix!r}").format(
+                    prefix=sign,
+                )
+            )
 
     def _append_context_line(self, text_bytes: bytes) -> None:
         self.line_entries.append(

--- a/tests/core/test_diff_parser.py
+++ b/tests/core/test_diff_parser.py
@@ -201,6 +201,22 @@ diff --git a/file2.txt b/file2.txt
         with pytest.raises(CommandError, match=message):
             collect_unified_diff(diff.splitlines(keepends=True))
 
+    @pytest.mark.parametrize(
+        "following_line",
+        [b"@@ -1 +1 @@\n", b"diff --git a/next.txt b/next.txt\n", None],
+    )
+    def test_malformed_file_headers_are_rejected(self, following_line):
+        """An old-file header must be immediately followed by a new-file header."""
+        lines = [
+            b"diff --git a/file.txt b/file.txt\n",
+            b"--- a/file.txt\n",
+        ]
+        if following_line is not None:
+            lines.append(following_line)
+
+        with pytest.raises(CommandError, match=r"missing \+\+\+|expected \+\+\+"):
+            collect_unified_diff(lines)
+
     def test_new_file(self):
         """Test parsing a diff for a newly created file."""
         diff = """\

--- a/tests/core/test_line_change_body.py
+++ b/tests/core/test_line_change_body.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import pytest
+
 from git_stage_batch.core.line_change_body import LineChangeBodyBuilder
 from git_stage_batch.core.models import HunkHeader
+from git_stage_batch.exceptions import CommandError
 
 
 def test_body_builder_appends_context_deletion_and_addition_lines():
@@ -43,17 +46,24 @@ def test_body_builder_marks_previous_line_without_trailing_newline():
     assert builder.line_entries[0].has_trailing_newline is False
 
 
-def test_body_builder_treats_empty_and_unknown_lines_as_context():
-    """Empty and unknown body lines should be represented as context."""
+def test_body_builder_treats_empty_lines_as_context():
+    """Empty body lines retain the parser's compatibility representation."""
     builder = LineChangeBodyBuilder()
 
     builder.reset_for_hunk_header(HunkHeader(3, 2, 4, 2))
     builder.append_patch_line(b"")
-    builder.append_patch_line(b"!body")
 
     assert [(entry.kind, entry.text_bytes) for entry in builder.line_entries] == [
         (" ", b""),
-        (" ", b"body"),
     ]
-    assert builder.old_line_number == 5
-    assert builder.new_line_number == 6
+    assert builder.old_line_number == 4
+    assert builder.new_line_number == 5
+
+
+def test_body_builder_rejects_unknown_line_prefix():
+    """Unknown prefixes cannot silently skew parsed line numbers."""
+    builder = LineChangeBodyBuilder()
+    builder.reset_for_hunk_header(HunkHeader(3, 1, 4, 1))
+
+    with pytest.raises(CommandError, match="Invalid line prefix"):
+        builder.append_patch_line(b"!body")


### PR DESCRIPTION
Unified-diff parsing validates hunk counts and streaming body prefixes, while
some file-header and line-body builder paths accept malformed input.

The project can silently skip an invalid +++ header or treat an unknown hunk
line prefix as context, producing incomplete records or incorrect line counts.

This pull request requires paired --- and +++ headers and rejects line-body
prefixes outside the recognized context, addition, deletion, and no-newline
forms.

Unified-diff parsing now reports malformed structure consistently across file
headers, streaming hunks, and buffered line-body construction.

---

Stack: 6 of 6. Depends on #209.
Base: `pr/tui-mutation-locking`.