### PR TITLE
Harden diff and path identity parsing

### DIFF
--- a/src/git_stage_batch/core/diff_parser.py
+++ b/src/git_stage_batch/core/diff_parser.py
@@ -234,7 +234,7 @@ class _UnifiedDiffParserBuildContext:
                 if _diff_headers.line_is_diff_git_header(line):
                     file_paths = _diff_headers.diff_git_paths(line)
                     if file_paths is None:
-                        continue
+                        raise CommandError(_("Malformed diff --git header"))
                     old_path, new_path = file_paths
 
                     # Collect metadata lines until we hit the --- line (start of unified diff)

--- a/src/git_stage_batch/core/gitlink_diff.py
+++ b/src/git_stage_batch/core/gitlink_diff.py
@@ -8,7 +8,6 @@ from collections.abc import Callable, Iterable
 
 INDEX_LINE_PATTERN = re.compile(br"^index ([0-9a-f]+)\.\.([0-9a-f]+)(?: ([0-7]+))?$")
 SUBPROJECT_COMMIT_PATTERN = re.compile(br"^([+-])Subproject commit ([0-9a-f]+)(?:-[^\s]+)?$")
-NULL_OBJECT_PREFIX = "0" * 7
 
 
 def metadata_indicates_gitlink(metadata_lines: list[bytes]) -> bool:
@@ -45,7 +44,7 @@ def non_null_git_oid(oid: str | None) -> str | None:
     """Return an object id unless it represents the null side of a diff."""
     if oid is None:
         return None
-    if oid.startswith(NULL_OBJECT_PREFIX):
+    if oid and all(character == "0" for character in oid):
         return None
     return oid
 

--- a/src/git_stage_batch/core/hashing.py
+++ b/src/git_stage_batch/core/hashing.py
@@ -6,6 +6,8 @@ import hashlib
 from collections.abc import Iterable
 from typing import TYPE_CHECKING
 
+from ..git_paths import unquote_path_token
+
 if TYPE_CHECKING:
     from .models import (
         BinaryFileChange,
@@ -54,12 +56,12 @@ def compute_stable_hunk_hash_from_lines(patch_lines: Iterable[bytes]) -> str:
         line = line_with_ending.rstrip(b'\n')
 
         if line.startswith(b"+++ "):
-            path_value = line.split(b" ", 1)[1].strip()
+            path_value = unquote_path_token(line.split(b" ", 1)[1].strip())
             if path_value != b"/dev/null":
                 selected_path_bytes = path_value[2:] if path_value.startswith(b"b/") else path_value
             continue
         if line.startswith(b"--- ") and not selected_path_bytes:
-            path_value = line.split(b" ", 1)[1].strip()
+            path_value = unquote_path_token(line.split(b" ", 1)[1].strip())
             if path_value != b"/dev/null":
                 selected_path_bytes = path_value[2:] if path_value.startswith(b"a/") else path_value
             continue
@@ -98,7 +100,10 @@ def compute_binary_file_hash(binary_change: BinaryFileChange) -> str:
     path = binary_change.path()
 
     # Hash: "BINARY:" + path + ":" + change_type
-    key = f"BINARY:{path}:{binary_change.change_type}".encode('utf-8')
+    key = f"BINARY:{path}:{binary_change.change_type}".encode(
+        "utf-8",
+        errors="surrogateescape",
+    )
     return hashlib.sha1(key).hexdigest()
 
 

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -1037,7 +1037,6 @@ def test_gitlink_diff_owns_gitlink_parser_helpers():
     }
     old_parser_names = {
         "INDEX_LINE_PATTERN",
-        "NULL_OBJECT_PREFIX",
         "SUBPROJECT_COMMIT_PATTERN",
         "_consume_gitlink_hunks",
         "_gitlink_change_type",

--- a/tests/core/test_diff_parser.py
+++ b/tests/core/test_diff_parser.py
@@ -217,6 +217,20 @@ diff --git a/file2.txt b/file2.txt
         with pytest.raises(CommandError, match=r"missing \+\+\+|expected \+\+\+"):
             collect_unified_diff(lines)
 
+    def test_malformed_diff_git_header_is_rejected(self):
+        """A recognized but unparseable file header must not drop the file."""
+        lines = [
+            b"diff --git a/file.txt\n",
+            b"--- a/file.txt\n",
+            b"+++ b/file.txt\n",
+            b"@@ -1 +1 @@\n",
+            b"-old\n",
+            b"+new\n",
+        ]
+
+        with pytest.raises(CommandError, match="Malformed diff --git header"):
+            collect_unified_diff(lines)
+
     def test_new_file(self):
         """Test parsing a diff for a newly created file."""
         diff = """\

--- a/tests/core/test_gitlink_diff.py
+++ b/tests/core/test_gitlink_diff.py
@@ -31,6 +31,16 @@ def test_gitlink_paths_and_change_type_use_null_oid_sides():
     assert gitlink_diff.gitlink_change_type([], "1234567", "89abcde") == "modified"
 
 
+def test_gitlink_oid_with_seven_leading_zeroes_is_not_null():
+    """A real full object id is not null merely because its prefix is zero."""
+    oid = "0000000" + "1" * 33
+
+    assert gitlink_diff.non_null_git_oid(oid) == oid
+    assert gitlink_diff.gitlink_old_path("sub", oid) == "sub"
+    assert gitlink_diff.gitlink_new_path("sub", oid) == "sub"
+    assert gitlink_diff.gitlink_change_type([], oid, "2" * 40) == "modified"
+
+
 def test_gitlink_subproject_commit_patch_oids():
     """Subproject commit patch lines should yield old and new oids."""
     assert gitlink_diff.gitlink_oids_from_subproject_commit_patch(

--- a/tests/core/test_hashing.py
+++ b/tests/core/test_hashing.py
@@ -2,10 +2,11 @@
 
 
 from git_stage_batch.core.hashing import (
+    compute_binary_file_hash,
     compute_gitlink_change_hash,
     compute_stable_hunk_hash_from_lines,
 )
-from git_stage_batch.core.models import GitlinkChange
+from git_stage_batch.core.models import BinaryFileChange, GitlinkChange
 
 
 class TestComputeStableHunkHash:
@@ -99,6 +100,44 @@ class TestComputeStableHunkHash:
         )
 
         assert hash_from_lines == hash_from_list
+
+    def test_quoted_and_raw_git_paths_have_the_same_hash(self):
+        """Git's core.quotepath setting does not change hunk identity."""
+        raw_path_patch = (
+            b"--- a/caf\xc3\xa9.txt\n"
+            b"+++ b/caf\xc3\xa9.txt\n"
+            b"@@ -1 +1 @@\n"
+            b"-old\n"
+            b"+new\n"
+        )
+        quoted_path_patch = (
+            b'--- "a/caf\\303\\251.txt"\n'
+            b'+++ "b/caf\\303\\251.txt"\n'
+            b"@@ -1 +1 @@\n"
+            b"-old\n"
+            b"+new\n"
+        )
+
+        assert self._hash_patch(raw_path_patch) == self._hash_patch(
+            quoted_path_patch
+        )
+
+
+class TestComputeBinaryFileHash:
+    """Tests for compute_binary_file_hash."""
+
+    def test_non_utf8_path_is_hashed_with_surrogateescape(self):
+        """Undecodable filesystem bytes remain valid binary identities."""
+        change = BinaryFileChange(
+            old_path="asset\udcff.bin",
+            new_path="asset\udcff.bin",
+            change_type="modified",
+        )
+
+        hash_value = compute_binary_file_hash(change)
+
+        assert len(hash_value) == 40
+        assert hash_value == compute_binary_file_hash(change)
 
 
 class TestComputeGitlinkChangeHash:


### PR DESCRIPTION
Diff discovery and stable identity currently trust several path and object representations emitted by Git.

Malformed file headers can disappear silently, abbreviated null matching can misclassify valid gitlinks, and display quoting or undecodable bytes can destabilize hashes.

This PR rejects malformed file headers, requires complete null object IDs, and normalizes text and binary path identities.

It builds on #210 and extends strict diff validation into file boundaries and durable change identity.

Validation completed with `uv run pytest` and Ruff checks across every changed Python file.