### PR TITLE
Keep interactive actions aligned with displayed changes

### DIFF
--- a/src/git_stage_batch/tui/file_review/live_actions.py
+++ b/src/git_stage_batch/tui/file_review/live_actions.py
@@ -31,18 +31,6 @@ def apply_live_line_action(
         return
 
     if action == "s":
-        if state.flow_state.target.role is LocationRole.BATCH:
-            from ...commands.include import command_include_to_batch
-
-            command_include_to_batch(
-                state.flow_state.target.batch_name,
-                line_ids=line_ids,
-                file=state.file_path,
-                quiet=True,
-                auto_advance=False,
-            )
-            return
-
         from ...commands.skip import command_skip_line
 
         command_skip_line(line_ids, file=state.file_path, auto_advance=False)
@@ -122,17 +110,6 @@ def apply_live_file_action(
         return
 
     if action == "S":
-        if state.flow_state.target.role is LocationRole.BATCH:
-            from ...commands.include import command_include_to_batch
-
-            command_include_to_batch(
-                state.flow_state.target.batch_name,
-                file=state.file_path,
-                quiet=True,
-                auto_advance=False,
-            )
-            return
-
         from ...commands.skip import command_skip_file
 
         command_skip_file(

--- a/src/git_stage_batch/tui/file_selection_menu.py
+++ b/src/git_stage_batch/tui/file_selection_menu.py
@@ -9,7 +9,6 @@ from ..commands.discard_from import command_discard_from_batch
 from ..commands.include import command_include_file, command_include_to_batch
 from ..commands.include_from import command_include_from_batch
 from ..commands.skip import command_skip_file
-from ..data.hunk_tracking import fetch_next_change
 from ..data.line_state import load_line_changes_from_state
 from ..i18n import _
 from ..output.colors import Colors, format_hotkey
@@ -97,24 +96,18 @@ def _handle_file_include(flow_state: FlowState) -> None:
         command_include_from_batch(flow_state.source.batch_name, file="")
     else:
         raise ValueError(f"Unknown source role: {flow_state.source.role}")
-    fetch_next_change()
 
 
 def _handle_file_skip(flow_state: FlowState) -> None:
     if flow_state.source.role is LocationRole.BATCH:
         print(_("Skip is not available when pulling from a batch."), file=sys.stderr)
         return
-    if flow_state.target.role is LocationRole.STAGING_AREA:
-        command_skip_file(auto_advance=True)
-    elif flow_state.target.role is LocationRole.BATCH:
-        command_include_to_batch(
-            flow_state.target.batch_name,
-            file="",
-            auto_advance=True,
-        )
-    else:
+    if flow_state.target.role not in (
+        LocationRole.STAGING_AREA,
+        LocationRole.BATCH,
+    ):
         raise ValueError(f"Unknown target role: {flow_state.target.role}")
-    fetch_next_change()
+    command_skip_file(auto_advance=True)
 
 
 def _handle_file_discard(flow_state: FlowState, filename: str) -> None:
@@ -141,4 +134,3 @@ def _handle_file_discard(flow_state: FlowState, filename: str) -> None:
         command_discard_from_batch(flow_state.source.batch_name, file="")
     else:
         raise ValueError(f"Unknown source role: {flow_state.source.role}")
-    fetch_next_change()

--- a/src/git_stage_batch/tui/hunk_actions.py
+++ b/src/git_stage_batch/tui/hunk_actions.py
@@ -43,16 +43,12 @@ def handle_hunk_include(flow_state: FlowState) -> None:
 def handle_hunk_skip(flow_state: FlowState) -> None:
     """Handle skip action based on source and target."""
     if flow_state.source.role is LocationRole.WORKING_TREE:
-        if flow_state.target.role is LocationRole.STAGING_AREA:
-            command_skip(quiet=True, auto_advance=True)
-        elif flow_state.target.role is LocationRole.BATCH:
-            command_include_to_batch(
-                flow_state.target.batch_name,
-                quiet=True,
-                auto_advance=True,
-            )
-        else:
+        if flow_state.target.role not in (
+            LocationRole.STAGING_AREA,
+            LocationRole.BATCH,
+        ):
             raise ValueError(f"Unknown target role: {flow_state.target.role}")
+        command_skip(quiet=True, auto_advance=True)
     elif flow_state.source.role is LocationRole.BATCH:
         print(_("Skip is not available when pulling from a batch."), file=sys.stderr)
         raise BypassRefresh()

--- a/src/git_stage_batch/tui/interactive.py
+++ b/src/git_stage_batch/tui/interactive.py
@@ -77,6 +77,19 @@ def start_interactive_mode() -> None:
         try:
             if action in ACTION_HANDLERS:
                 with acquire_session_lock():
+                    handler = ACTION_HANDLERS[action]
+                    if handler.needs_hunk:
+                        current = current_change.load_current_change(flow_state)
+                        if current != loaded_change:
+                            print(
+                                _(
+                                    "The selected change advanced while the prompt "
+                                    "was open; no action was taken."
+                                ),
+                                file=sys.stderr,
+                            )
+                            should_refresh = True
+                            continue
                     dispatch_action(
                         action,
                         has_hunk=has_hunk,

--- a/src/git_stage_batch/tui/line_selection_menu.py
+++ b/src/git_stage_batch/tui/line_selection_menu.py
@@ -125,16 +125,12 @@ def _handle_line_skip(flow_state: FlowState, line_ids: str) -> None:
     if flow_state.source.role is LocationRole.BATCH:
         print(_("Skip is not available when pulling from a batch."), file=sys.stderr)
         return
-    if flow_state.target.role is LocationRole.STAGING_AREA:
-        command_skip_line(line_ids, auto_advance=True)
-    elif flow_state.target.role is LocationRole.BATCH:
-        command_include_to_batch(
-            flow_state.target.batch_name,
-            line_ids=line_ids,
-            auto_advance=True,
-        )
-    else:
+    if flow_state.target.role not in (
+        LocationRole.STAGING_AREA,
+        LocationRole.BATCH,
+    ):
         raise ValueError(f"Unknown target role: {flow_state.target.role}")
+    command_skip_line(line_ids, auto_advance=True)
 
 
 def _handle_line_discard(flow_state: FlowState, line_ids: str) -> None:

--- a/tests/tui/test_file_review.py
+++ b/tests/tui/test_file_review.py
@@ -11,6 +11,11 @@ from git_stage_batch.tui.file_review.file_browser import ReviewFileEntry
 from git_stage_batch.tui.file_review.browser import handle_file_browser
 from git_stage_batch.tui.file_review.browser import handle_current_file_review
 from git_stage_batch.tui.file_review.file_browser import list_review_file_entries
+from git_stage_batch.tui.file_review.live_actions import (
+    apply_live_file_action,
+    apply_live_line_action,
+)
+from git_stage_batch.tui.file_review.session import FileReviewSessionState
 from git_stage_batch.tui.flow import FlowLocation, FlowState
 
 
@@ -331,6 +336,57 @@ class TestHandleCurrentFileReview:
             advance=False,
             auto_advance=False,
         )
+
+    def test_target_batch_line_skip_uses_skip_command(self):
+        """File-review line skip must not include lines in the target batch."""
+        state = FileReviewSessionState(
+            flow_state=FlowState(
+                source=FlowLocation.WORKING_TREE,
+                target=FlowLocation.for_batch("scratch"),
+            ),
+            file_path="test.txt",
+        )
+
+        with patch(
+            "git_stage_batch.commands.skip.command_skip_line"
+        ) as mock_skip:
+            with patch(
+                "git_stage_batch.commands.include.command_include_to_batch"
+            ) as mock_include:
+                apply_live_line_action(state, "s", "1")
+
+        mock_skip.assert_called_once_with(
+            "1",
+            file="test.txt",
+            auto_advance=False,
+        )
+        mock_include.assert_not_called()
+
+    def test_target_batch_file_skip_uses_skip_command(self):
+        """File-review whole-file skip must not include into the target batch."""
+        state = FileReviewSessionState(
+            flow_state=FlowState(
+                source=FlowLocation.WORKING_TREE,
+                target=FlowLocation.for_batch("scratch"),
+            ),
+            file_path="test.txt",
+        )
+
+        with patch(
+            "git_stage_batch.commands.skip.command_skip_file"
+        ) as mock_skip:
+            with patch(
+                "git_stage_batch.commands.include.command_include_to_batch"
+            ) as mock_include:
+                apply_live_file_action(state, "S")
+
+        mock_skip.assert_called_once_with(
+            "test.txt",
+            quiet=True,
+            advance=False,
+            auto_advance=False,
+        )
+        mock_include.assert_not_called()
 
     def test_current_file_review_blocks_file_in_gitignore(self):
         """Test block action routes to block-file using gitignore."""

--- a/tests/tui/test_interactive.py
+++ b/tests/tui/test_interactive.py
@@ -21,6 +21,7 @@ from git_stage_batch.tui.flow import FlowLocation, FlowState
 from git_stage_batch.tui.interactive import (
     start_interactive_mode,
 )
+from git_stage_batch.tui.current_change import CurrentChange
 from git_stage_batch.tui.asset_menu import handle_asset_menu
 from git_stage_batch.tui.file_selection_menu import handle_file_selection_menu
 from git_stage_batch.tui.help_display import print_help
@@ -185,6 +186,27 @@ class TestActionHandlers:
             )
 
         mock_skip.assert_called_once_with(quiet=True, auto_advance=True)
+
+    def test_skip_action_with_batch_target_does_not_include(self):
+        """A target batch must not change skip into include-to-batch."""
+        flow_state = FlowState(
+            source=FlowLocation.WORKING_TREE,
+            target=FlowLocation.for_batch("scratch"),
+        )
+
+        with patch("git_stage_batch.tui.hunk_actions.command_skip") as mock_skip:
+            with patch(
+                "git_stage_batch.tui.hunk_actions.command_include_to_batch"
+            ) as mock_include:
+                dispatch_action(
+                    "s",
+                    has_hunk=True,
+                    use_color=False,
+                    flow_state=flow_state,
+                )
+
+        mock_skip.assert_called_once_with(quiet=True, auto_advance=True)
+        mock_include.assert_not_called()
 
     def test_discard_action_dispatches_hunk_action(self):
         """Test discard action routes through the hunk action adapter."""
@@ -419,13 +441,12 @@ class TestHandleFileSelection:
 
         with patch("git_stage_batch.tui.file_selection_menu.load_line_changes_from_state", return_value=line_changes):
             with patch("git_stage_batch.tui.file_selection_menu.command_include_file") as mock_include:
-                with patch("git_stage_batch.tui.file_selection_menu.fetch_next_change", return_value=None):
-                    with patch("builtins.input", return_value="i"):
-                        handle_file_selection_menu(FlowState(
-                            source=FlowLocation.WORKING_TREE,
-                            target=FlowLocation.STAGING_AREA
-                        ))
-                        mock_include.assert_called_once()
+                with patch("builtins.input", return_value="i"):
+                    handle_file_selection_menu(FlowState(
+                        source=FlowLocation.WORKING_TREE,
+                        target=FlowLocation.STAGING_AREA
+                    ))
+                    mock_include.assert_called_once()
 
     def test_handle_file_selection_skip(self):
         """Test file selection with skip action."""
@@ -439,13 +460,12 @@ class TestHandleFileSelection:
 
         with patch("git_stage_batch.tui.file_selection_menu.load_line_changes_from_state", return_value=line_changes):
             with patch("git_stage_batch.tui.file_selection_menu.command_skip_file") as mock_skip:
-                with patch("git_stage_batch.tui.file_selection_menu.fetch_next_change", return_value=None):
-                    with patch("builtins.input", return_value="s"):
-                        handle_file_selection_menu(FlowState(
-                            source=FlowLocation.WORKING_TREE,
-                            target=FlowLocation.STAGING_AREA
-                        ))
-                        mock_skip.assert_called_once()
+                with patch("builtins.input", return_value="s"):
+                    handle_file_selection_menu(FlowState(
+                        source=FlowLocation.WORKING_TREE,
+                        target=FlowLocation.STAGING_AREA
+                    ))
+                    mock_skip.assert_called_once()
 
     def test_handle_file_selection_discard(self):
         """Test file selection with discard action."""
@@ -459,14 +479,13 @@ class TestHandleFileSelection:
 
         with patch("git_stage_batch.tui.file_selection_menu.load_line_changes_from_state", return_value=line_changes):
             with patch("git_stage_batch.tui.file_selection_menu.command_discard_file") as mock_discard:
-                with patch("git_stage_batch.tui.file_selection_menu.fetch_next_change", return_value=None):
-                    with patch("git_stage_batch.tui.file_selection_menu.confirm_destructive_operation", return_value=True):
-                        with patch("builtins.input", return_value="d"):
-                            handle_file_selection_menu(FlowState(
-                                source=FlowLocation.WORKING_TREE,
-                                target=FlowLocation.STAGING_AREA
-                            ))
-                            mock_discard.assert_called_once()
+                with patch("git_stage_batch.tui.file_selection_menu.confirm_destructive_operation", return_value=True):
+                    with patch("builtins.input", return_value="d"):
+                        handle_file_selection_menu(FlowState(
+                            source=FlowLocation.WORKING_TREE,
+                            target=FlowLocation.STAGING_AREA
+                        ))
+                        mock_discard.assert_called_once()
 
     def test_handle_file_selection_discard_to_batch(self):
         """Test file selection with discard action when target is batch."""
@@ -480,18 +499,54 @@ class TestHandleFileSelection:
 
         with patch("git_stage_batch.tui.file_selection_menu.load_line_changes_from_state", return_value=line_changes):
             with patch("git_stage_batch.tui.file_selection_menu.command_discard_to_batch") as mock_discard:
-                with patch("git_stage_batch.tui.file_selection_menu.fetch_next_change", return_value=None):
-                    with patch("builtins.input", return_value="d"):
-                        handle_file_selection_menu(FlowState(
-                            source=FlowLocation.WORKING_TREE,
-                            target=FlowLocation.for_batch("mybatch")
-                        ))
-                        mock_discard.assert_called_once_with(
-                            "mybatch",
-                            file="",
-                            quiet=True,
-                            auto_advance=True,
+                with patch("builtins.input", return_value="d"):
+                    handle_file_selection_menu(FlowState(
+                        source=FlowLocation.WORKING_TREE,
+                        target=FlowLocation.for_batch("mybatch")
+                    ))
+                    mock_discard.assert_called_once_with(
+                        "mybatch",
+                        file="",
+                        quiet=True,
+                        auto_advance=True,
+                    )
+
+    def test_handle_file_selection_skip_with_batch_target_still_skips(self):
+        """Skip should never save the file into the target batch."""
+        line_changes = LineLevelChange(
+            path="test.txt",
+            header=HunkHeader(old_start=1, old_len=1, new_start=1, new_len=1),
+            lines=[
+                LineEntry(
+                    id=1,
+                    kind="+",
+                    old_line_number=None,
+                    new_line_number=1,
+                    text_bytes=b"test\n",
+                )
+            ],
+        )
+
+        with patch(
+            "git_stage_batch.tui.file_selection_menu.load_line_changes_from_state",
+            return_value=line_changes,
+        ):
+            with patch(
+                "git_stage_batch.tui.file_selection_menu.command_skip_file"
+            ) as mock_skip:
+                with patch(
+                    "git_stage_batch.tui.file_selection_menu.command_include_to_batch"
+                ) as mock_include:
+                    with patch("builtins.input", return_value="s"):
+                        handle_file_selection_menu(
+                            FlowState(
+                                source=FlowLocation.WORKING_TREE,
+                                target=FlowLocation.for_batch("scratch"),
+                            )
                         )
+
+        mock_skip.assert_called_once_with(auto_advance=True)
+        mock_include.assert_not_called()
 
     def test_handle_file_selection_cancel(self):
         """Test file selection with Ctrl-C."""
@@ -573,6 +628,47 @@ class TestHandleLineSelection:
                             target=FlowLocation.STAGING_AREA
                         ))
 
+    def test_handle_line_skip_with_batch_target_still_skips(self):
+        """Line skip should leave the selected lines for a later pass."""
+        line_changes = LineLevelChange(
+            path="test.txt",
+            header=HunkHeader(old_start=1, old_len=1, new_start=1, new_len=1),
+            lines=[
+                LineEntry(
+                    id=1,
+                    kind="+",
+                    old_line_number=None,
+                    new_line_number=1,
+                    text_bytes=b"test\n",
+                )
+            ],
+        )
+
+        with patch(
+            "git_stage_batch.tui.line_selection_menu.load_line_changes_from_state",
+            return_value=line_changes,
+        ):
+            with patch(
+                "git_stage_batch.tui.line_selection_menu.command_skip_line"
+            ) as mock_skip:
+                with patch(
+                    "git_stage_batch.tui.line_selection_menu.command_include_to_batch"
+                ) as mock_include:
+                    with patch(
+                        "git_stage_batch.tui.line_selection_menu.prompt_line_ids",
+                        return_value="1",
+                    ):
+                        with patch("builtins.input", return_value="s"):
+                            handle_line_selection_menu(
+                                FlowState(
+                                    source=FlowLocation.WORKING_TREE,
+                                    target=FlowLocation.for_batch("scratch"),
+                                )
+                            )
+
+        mock_skip.assert_called_once_with("1", auto_advance=True)
+        mock_include.assert_not_called()
+
 
 class TestDegradedMode:
     """Tests for degraded mode (no changes available)."""
@@ -616,6 +712,75 @@ class TestDegradedMode:
                     start_interactive_mode()
 
         assert lock_depth == 0
+
+    def test_selection_advance_during_prompt_cancels_hunk_action(
+        self,
+        temp_git_repo,
+        capsys,
+    ):
+        """A keypress must not act on a different change than was displayed."""
+        first = LineLevelChange(
+            path="first.txt",
+            header=HunkHeader(old_start=1, old_len=0, new_start=1, new_len=1),
+            lines=[
+                LineEntry(
+                    id=1,
+                    kind="+",
+                    old_line_number=None,
+                    new_line_number=1,
+                    text_bytes=b"first\n",
+                )
+            ],
+        )
+        second = LineLevelChange(
+            path="second.txt",
+            header=HunkHeader(old_start=1, old_len=0, new_start=1, new_len=1),
+            lines=[
+                LineEntry(
+                    id=1,
+                    kind="+",
+                    old_line_number=None,
+                    new_line_number=1,
+                    text_bytes=b"second\n",
+                )
+            ],
+        )
+        loaded = [CurrentChange(first), CurrentChange(second), CurrentChange(second)]
+        dispatched = []
+
+        def dispatch(action, **_kwargs):
+            dispatched.append(action)
+            if action == "q":
+                raise QuitInteractive()
+
+        startup = type(
+            "Startup",
+            (),
+            {"degraded_mode": False, "session_was_active": True},
+        )()
+        with patch(
+            "git_stage_batch.tui.interactive.prepare_interactive_session",
+            return_value=startup,
+        ):
+            with patch(
+                "git_stage_batch.tui.interactive.current_change.load_current_change",
+                side_effect=loaded,
+            ):
+                with patch(
+                    "git_stage_batch.tui.interactive.current_change.display_current_change"
+                ):
+                    with patch(
+                        "git_stage_batch.tui.interactive.prompt_action",
+                        side_effect=["i", "q"],
+                    ):
+                        with patch(
+                            "git_stage_batch.tui.interactive.dispatch_action",
+                            side_effect=dispatch,
+                        ):
+                            start_interactive_mode()
+
+        assert dispatched == ["q"]
+        assert "advanced while the prompt was open" in capsys.readouterr().err
 
     def test_start_interactive_mode_quit_preserves_existing_session(self, temp_git_repo):
         """Test quitting does not stop a session that already existed."""


### PR DESCRIPTION
Interactive review currently presents a selected hunk, line, or file before dispatching the requested action.

Batch-target skips can save work instead of leaving it untouched, final-file handlers can over-advance, and another process can replace the displayed selection during an unlocked prompt.

This PR preserves neutral skip behavior, removes duplicate file advancement, and reloads the displayed selection while holding the session lock.

It builds on #211 and keeps every interactive mutation tied to the change and intent shown to the user.

Validation completed with `uv run pytest` and Ruff checks across every changed Python file.