### PR TITLE
Roll back failed multi-file command mutations

### DIFF
--- a/src/git_stage_batch/commands/batch_source/apply_action.py
+++ b/src/git_stage_batch/commands/batch_source/apply_action.py
@@ -169,7 +169,11 @@ def execute_apply_action(
 
     try:
         try:
-            with undo_checkpoint(" ".join(operation_parts), worktree_paths=list(files)):
+            with undo_checkpoint(
+                " ".join(operation_parts),
+                worktree_paths=list(files),
+                rollback_on_error=True,
+            ):
                 for plan in apply_plans:
                     snapshot_file_if_untracked(plan.file_path)
                     if isinstance(plan, _action_plans.ApplyTextFileActionPlan):
@@ -200,10 +204,11 @@ def execute_apply_action(
                     _file_mode_actions.apply_new_file_mode(file_path, file_meta)
         except CommandError:
             raise
-        except Exception:
+        except Exception as error:
             _worktree_refusals.refuse_incompatible_worktree_action(
                 batch_name=batch_name,
                 file_paths=files,
+                error=error,
             )
     finally:
         _action_plans.close_action_plans(apply_plans)

--- a/src/git_stage_batch/commands/batch_source/discard_action.py
+++ b/src/git_stage_batch/commands/batch_source/discard_action.py
@@ -65,7 +65,11 @@ def execute_discard_action(
     rendered = selection.rendered
     operation_parts = list(selection.operation_parts)
 
-    with undo_checkpoint(" ".join(operation_parts), worktree_paths=list(files)):
+    with undo_checkpoint(
+        " ".join(operation_parts),
+        worktree_paths=list(files),
+        rollback_on_error=True,
+    ):
         failed_files = []
 
         for file_path, file_meta in files.items():
@@ -152,9 +156,9 @@ def execute_discard_action(
                 )
                 failed_files.append(file_path)
 
-    if failed_files:
-        exit_with_error(
-            _("Failed to discard changes for some files: {files}").format(
-                files=", ".join(failed_files),
+        if failed_files:
+            exit_with_error(
+                _("Failed to discard changes for some files: {files}").format(
+                    files=", ".join(failed_files),
+                )
             )
-        )

--- a/src/git_stage_batch/commands/batch_source/include_action.py
+++ b/src/git_stage_batch/commands/batch_source/include_action.py
@@ -157,7 +157,11 @@ def execute_include_action(
 
     try:
         try:
-            with undo_checkpoint(" ".join(operation_parts), worktree_paths=list(files)):
+            with undo_checkpoint(
+                " ".join(operation_parts),
+                worktree_paths=list(files),
+                rollback_on_error=True,
+            ):
                 for plan in include_plans:
                     snapshot_file_if_untracked(plan.file_path)
                     if isinstance(plan, _action_plans.IncludeTextFileActionPlan):
@@ -194,10 +198,11 @@ def execute_include_action(
                     _file_mode_actions.apply_new_file_mode(file_path, file_meta)
         except CommandError:
             raise
-        except Exception:
+        except Exception as error:
             _worktree_refusals.refuse_incompatible_worktree_action(
                 batch_name=batch_name,
                 file_paths=files,
+                error=error,
             )
     finally:
         _action_plans.close_action_plans(include_plans)

--- a/src/git_stage_batch/commands/batch_source/worktree_refusals.py
+++ b/src/git_stage_batch/commands/batch_source/worktree_refusals.py
@@ -12,9 +12,15 @@ def refuse_incompatible_worktree_action(
     *,
     batch_name: str,
     file_paths: Iterable[str],
+    error: Exception | None = None,
 ) -> None:
     """Exit when batch-source execution is incompatible with the worktree."""
     paths = tuple(file_paths)
+    error_suffix = (
+        _(" Underlying error: {error}").format(error=error)
+        if error is not None
+        else ""
+    )
     if len(paths) == 1:
         file_path = paths[0]
         exit_with_error(
@@ -22,9 +28,11 @@ def refuse_incompatible_worktree_action(
                 "Batch '{batch}' contains changes to {file} that are "
                 "incompatible with the current working tree. "
                 "Use 'git-stage-batch show --from {batch}' to review the batch."
+                "{error_suffix}"
             ).format(
                 batch=batch_name,
                 file=file_path,
+                error_suffix=error_suffix,
             )
         )
     exit_with_error(
@@ -32,5 +40,6 @@ def refuse_incompatible_worktree_action(
             "Batch '{batch}' contains changes to one or more files that are "
             "incompatible with the current working tree. "
             "Use 'git-stage-batch show --from {batch}' to review the batch."
-        ).format(batch=batch_name)
+            "{error_suffix}"
+        ).format(batch=batch_name, error_suffix=error_suffix)
     )

--- a/src/git_stage_batch/commands/file_scope/multi_file_actions.py
+++ b/src/git_stage_batch/commands/file_scope/multi_file_actions.py
@@ -52,6 +52,7 @@ def _multi_file_undo_checkpoint(
     return undo_checkpoint(
         _format_multi_file_operation(command, files),
         worktree_paths=paths,
+        rollback_on_error=True,
     )
 
 

--- a/src/git_stage_batch/commands/selection/discard_to_batch_action.py
+++ b/src/git_stage_batch/commands/selection/discard_to_batch_action.py
@@ -44,7 +44,11 @@ def execute_discard_to_batch_action(
 
     selected_change = load_selected_change() if file is None else None
     worktree_paths = checkpoint_paths_for_file_scope(file, selected_change)
-    with undo_checkpoint(" ".join(operation_parts), worktree_paths=worktree_paths):
+    with undo_checkpoint(
+        " ".join(operation_parts),
+        worktree_paths=worktree_paths,
+        rollback_on_error=True,
+    ):
         if (
             file is None
             and line_ids is None

--- a/src/git_stage_batch/data/undo_checkpoints.py
+++ b/src/git_stage_batch/data/undo_checkpoints.py
@@ -241,8 +241,14 @@ def undo_checkpoint(
     *,
     worktree_paths: list[str],
     index_paths: list[str] | None = None,
+    rollback_on_error: bool = False,
 ) -> Iterator[None]:
-    """Bracket an undoable operation with before and after snapshots."""
+    """Bracket an undoable operation with before and after snapshots.
+
+    When rollback_on_error is true, restore the before-image and discard the
+    checkpoint before propagating an exception. This turns the checkpoint into
+    a transaction boundary for commands that span several files or stores.
+    """
     global _PENDING_CHECKPOINT
     if _PENDING_CHECKPOINT is not None:
         if current_undo_commit() == _PENDING_CHECKPOINT:
@@ -250,6 +256,7 @@ def undo_checkpoint(
             return
         _PENDING_CHECKPOINT = None
 
+    previous_redo = current_redo_commit()
     checkpoint = _create_undo_checkpoint(
         operation,
         worktree_paths=worktree_paths,
@@ -257,9 +264,67 @@ def undo_checkpoint(
     )
     try:
         yield
-    finally:
+    except BaseException as operation_error:
+        if checkpoint is not None and rollback_on_error:
+            try:
+                _rollback_failed_checkpoint(
+                    checkpoint,
+                    previous_redo=previous_redo,
+                )
+            except Exception as rollback_error:
+                raise CommandError(
+                    _(
+                        "Operation failed and its automatic rollback also failed. "
+                        "The before-image remains available through `undo --force`.\n"
+                        "Operation error: {operation_error}\n"
+                        "Rollback error: {rollback_error}"
+                    ).format(
+                        operation_error=operation_error,
+                        rollback_error=rollback_error,
+                    )
+                ) from operation_error
+        elif checkpoint is not None:
+            finalize_pending_checkpoint()
+        raise
+    else:
         if checkpoint is not None:
             finalize_pending_checkpoint()
+
+
+def _rollback_failed_checkpoint(
+    checkpoint: str,
+    *,
+    previous_redo: str | None,
+) -> None:
+    """Restore an incomplete checkpoint after its operation raises."""
+    global _PENDING_CHECKPOINT
+    _PENDING_CHECKPOINT = None
+
+    if current_undo_commit() != checkpoint:
+        raise CommandError(
+            _("Cannot roll back a failed operation because its checkpoint moved.")
+        )
+
+    manifest = _undo_restore.read_json_from_commit(checkpoint, "manifest.json")
+    validate_recovery_state(manifest)
+    _restore_metadata_state(checkpoint, manifest)
+    _undo_restore.restore_refs(manifest.get("refs", {}))
+    _restore_index_state(manifest)
+    _undo_restore.restore_worktree(checkpoint, manifest)
+    _undo_restore.restore_intent_to_add_entries()
+
+    parent = checkpoint_parent(checkpoint)
+    updates: list[tuple[str, str]] = []
+    deletes: list[str] = []
+    if parent is None:
+        deletes.append(SESSION_UNDO_STACK_REF)
+    else:
+        updates.append((SESSION_UNDO_STACK_REF, parent))
+    if previous_redo is None:
+        deletes.append(SESSION_REDO_STACK_REF)
+    else:
+        updates.append((SESSION_REDO_STACK_REF, previous_redo))
+    update_git_refs(updates=updates, deletes=deletes)
 
 
 def finalize_pending_checkpoint() -> None:

--- a/tests/commands/test_apply_from.py
+++ b/tests/commands/test_apply_from.py
@@ -12,6 +12,7 @@ import subprocess
 
 import pytest
 
+import git_stage_batch.commands.batch_source.apply_action as apply_action
 from git_stage_batch.batch.state.lifecycle import create_batch
 from git_stage_batch.commands.apply_from import command_apply_from_batch
 from git_stage_batch.data.session import initialize_abort_state
@@ -107,6 +108,57 @@ class TestCommandApplyFromBatch:
         assert "line 1" in content
         assert "line 2" in content
         assert "line 3" in content
+
+    def test_multi_file_write_failure_rolls_back_earlier_applies(
+        self,
+        temp_git_repo,
+        monkeypatch,
+    ):
+        """A failed later file should roll back every worktree write."""
+        for name in ("a.txt", "b.txt"):
+            (temp_git_repo / name).write_text(f"{name} base\n")
+        subprocess.run(
+            ["git", "add", "a.txt", "b.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add files"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        for name in ("a.txt", "b.txt"):
+            (temp_git_repo / name).write_text(f"{name} batch\n")
+
+        command_start(quiet=True)
+        command_include_to_batch("test-batch", file="a.txt", quiet=True)
+        command_include_to_batch("test-batch", file="b.txt", quiet=True)
+        for name in ("a.txt", "b.txt"):
+            (temp_git_repo / name).write_text(f"{name} base\n")
+
+        original_write = apply_action._text_file_actions.write_text_file_to_worktree
+        calls = 0
+
+        def fail_second_write(*args, **kwargs):
+            nonlocal calls
+            calls += 1
+            if calls == 2:
+                raise OSError("injected write failure")
+            return original_write(*args, **kwargs)
+
+        monkeypatch.setattr(
+            apply_action._text_file_actions,
+            "write_text_file_to_worktree",
+            fail_second_write,
+        )
+
+        with pytest.raises(CommandError, match="injected write failure"):
+            command_apply_from_batch("test-batch")
+
+        assert (temp_git_repo / "a.txt").read_text() == "a.txt base\n"
+        assert (temp_git_repo / "b.txt").read_text() == "b.txt base\n"
 
     def test_apply_from_batch_does_not_stage(self, temp_git_repo):
         """Test that apply does not stage changes to index."""

--- a/tests/commands/test_discard.py
+++ b/tests/commands/test_discard.py
@@ -25,6 +25,7 @@ import subprocess
 import pytest
 
 import git_stage_batch.commands.selection.selected_change_discarding as selected_change_discarding
+import git_stage_batch.commands.selection.selected_change_batch_discarding as selected_change_batch_discarding
 from git_stage_batch.commands.discard import command_discard, command_discard_line, command_discard_line_as_to_batch
 from git_stage_batch.commands.include import command_include
 from git_stage_batch.commands.start import command_start
@@ -121,6 +122,30 @@ class TestCommandDiscard:
             command_discard(quiet=True)
 
         assert test_file.read_text() == "base\nselected\n"
+
+    def test_failed_discard_to_batch_rolls_back_batch_and_progress(
+        self,
+        temp_git_repo,
+        monkeypatch,
+    ):
+        """A reverse-apply failure must not publish ownership to the batch."""
+        test_file = _prepare_single_line_change(temp_git_repo)
+        monkeypatch.setattr(
+            selected_change_batch_discarding,
+            "git_apply_to_worktree",
+            lambda *_args, **_kwargs: subprocess.CompletedProcess(
+                ["git", "apply"],
+                1,
+                "",
+                "reverse apply failed",
+            ),
+        )
+
+        with pytest.raises(CommandError, match="reverse apply failed"):
+            command_discard_to_batch("failed-batch", quiet=True)
+
+        assert test_file.read_text() == "base\nselected\n"
+        assert not batch_exists("failed-batch")
 
     def test_discard_only_line_from_intent_to_add_file_leaves_empty_file(
         self,

--- a/tests/commands/test_discard_from.py
+++ b/tests/commands/test_discard_from.py
@@ -7,6 +7,7 @@ import subprocess
 
 import pytest
 
+import git_stage_batch.commands.batch_source.discard_action as discard_action
 from git_stage_batch.batch.state.lifecycle import create_batch
 from git_stage_batch.batch.file_display import render_batch_file_display
 from git_stage_batch.commands.discard_from import command_discard_from_batch
@@ -63,6 +64,57 @@ class TestCommandDiscardFromBatch:
 
         captured = capsys.readouterr()
         assert "Discarded changes from batch" in captured.err
+
+    def test_multi_file_failure_rolls_back_earlier_discards(
+        self,
+        temp_git_repo,
+        monkeypatch,
+    ):
+        """A later write failure must not leave earlier files discarded."""
+        for name in ("a.txt", "b.txt"):
+            (temp_git_repo / name).write_text(f"{name} base\n")
+        subprocess.run(
+            ["git", "add", "a.txt", "b.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add files"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        for name in ("a.txt", "b.txt"):
+            (temp_git_repo / name).write_text(f"{name} batch\n")
+
+        command_start(quiet=True)
+        command_include_to_batch("test-batch", file="a.txt", quiet=True)
+        command_include_to_batch("test-batch", file="b.txt", quiet=True)
+
+        original_write = (
+            discard_action._text_file_actions.write_discarded_text_file_to_worktree
+        )
+        calls = 0
+
+        def fail_second_write(*args, **kwargs):
+            nonlocal calls
+            calls += 1
+            if calls == 2:
+                raise OSError("injected write failure")
+            return original_write(*args, **kwargs)
+
+        monkeypatch.setattr(
+            discard_action._text_file_actions,
+            "write_discarded_text_file_to_worktree",
+            fail_second_write,
+        )
+
+        with pytest.raises(CommandError, match="a.txt|b.txt"):
+            command_discard_from_batch("test-batch")
+
+        assert (temp_git_repo / "a.txt").read_text() == "a.txt batch\n"
+        assert (temp_git_repo / "b.txt").read_text() == "b.txt batch\n"
 
     def test_discard_from_batch_partial_atomic_unit_shows_required_lines(self, temp_git_repo):
         """Partial replacement selections should keep the atomic-selection guidance."""

--- a/tests/commands/test_file_scope_actions.py
+++ b/tests/commands/test_file_scope_actions.py
@@ -34,7 +34,13 @@ class _Checkpoint:
 def _capture_undo_checkpoints(monkeypatch):
     calls = []
 
-    def fake_undo_checkpoint(operation, *, worktree_paths=None):
+    def fake_undo_checkpoint(
+        operation,
+        *,
+        worktree_paths=None,
+        rollback_on_error=False,
+    ):
+        assert rollback_on_error is True
         return _Checkpoint(calls, operation, worktree_paths)
 
     monkeypatch.setattr(multi_file_actions, "undo_checkpoint", fake_undo_checkpoint)

--- a/tests/commands/test_include_from.py
+++ b/tests/commands/test_include_from.py
@@ -6,6 +6,7 @@ import subprocess
 
 import pytest
 
+import git_stage_batch.commands.batch_source.include_action as include_action
 from git_stage_batch.batch.state.lifecycle import create_batch
 from git_stage_batch.batch.ownership.model import BatchOwnership
 from git_stage_batch.batch.state.query import read_batch_metadata
@@ -91,6 +92,59 @@ class TestCommandIncludeFromBatch:
 
         captured = capsys.readouterr()
         assert "Staged changes from batch" in captured.err
+
+    def test_multi_file_write_failure_rolls_back_index_and_worktree(
+        self,
+        temp_git_repo,
+        monkeypatch,
+    ):
+        """A later worktree failure must roll back prior staging and writes."""
+        for name in ("a.txt", "b.txt"):
+            (temp_git_repo / name).write_text(f"{name} base\n")
+        subprocess.run(
+            ["git", "add", "a.txt", "b.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add files"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        for name in ("a.txt", "b.txt"):
+            (temp_git_repo / name).write_text(f"{name} batch\n")
+
+        command_start(quiet=True)
+        command_include_to_batch("test-batch", file="a.txt", quiet=True)
+        command_include_to_batch("test-batch", file="b.txt", quiet=True)
+        for name in ("a.txt", "b.txt"):
+            (temp_git_repo / name).write_text(f"{name} base\n")
+
+        original_write = include_action._text_file_actions.write_text_file_to_worktree
+        calls = 0
+
+        def fail_second_write(*args, **kwargs):
+            nonlocal calls
+            calls += 1
+            if calls == 2:
+                raise OSError("injected write failure")
+            return original_write(*args, **kwargs)
+
+        monkeypatch.setattr(
+            include_action._text_file_actions,
+            "write_text_file_to_worktree",
+            fail_second_write,
+        )
+
+        with pytest.raises(CommandError, match="injected write failure"):
+            command_include_from_batch("test-batch")
+
+        assert (temp_git_repo / "a.txt").read_text() == "a.txt base\n"
+        assert (temp_git_repo / "b.txt").read_text() == "b.txt base\n"
+        staged = run_git_command(["diff", "--cached", "--name-only"])
+        assert staged.stdout == ""
 
     def test_include_from_empty_batch_fails(self, temp_git_repo):
         """Test including from an empty batch fails."""

--- a/tests/commands/test_undo.py
+++ b/tests/commands/test_undo.py
@@ -199,6 +199,32 @@ def test_failed_operation_keeps_partial_mutation_undoable(temp_git_repo):
     assert target.read_text() == "before\n"
 
 
+def test_atomic_failed_operation_rolls_back_before_propagating(temp_git_repo):
+    """An atomic checkpoint should restore its state and retain no undo node."""
+    target = _commit_text_file(temp_git_repo, "target.txt", "before\n")
+    get_session_directory_path().mkdir(parents=True, exist_ok=True)
+    previous_checkpoint = current_undo_commit()
+
+    with pytest.raises(RuntimeError, match="operation failed"):
+        with undo_checkpoint(
+            "change target",
+            worktree_paths=["target.txt"],
+            rollback_on_error=True,
+        ):
+            target.write_text("partial mutation\n")
+            subprocess.run(
+                ["git", "add", "target.txt"],
+                check=True,
+                cwd=temp_git_repo,
+                capture_output=True,
+            )
+            raise RuntimeError("operation failed")
+
+    assert target.read_text() == "before\n"
+    assert _show_index_path(temp_git_repo, "target.txt") == b"before\n"
+    assert current_undo_commit() == previous_checkpoint
+
+
 def test_failed_checkpoint_finalization_requires_force(temp_git_repo, monkeypatch):
     """A manifest persistence failure should leave a guarded before-image."""
     from git_stage_batch.data import undo_checkpoints as checkpoints


### PR DESCRIPTION
Undo checkpoints currently preserve partial state after an operation raises so users can recover it manually.

Commands that publish batch ownership or mutate several files need stronger transaction semantics because a late failure can leave earlier index, worktree, or session writes applied.

This PR adds opt-in checkpoint rollback and adopts it for discard-to-batch, batch-source, and resolved multi-file actions while preserving original error details.

It builds on #212 and turns the high-risk multi-file workflows into all-or-nothing operations without changing legacy checkpoint behavior.

Validation completed with `uv run pytest` and Ruff checks across every changed Python file.