### PR TITLE
Preserve live binary and gitlink comparison bases

### DIFF
--- a/src/git_stage_batch/commands/file_scope/file_display_action.py
+++ b/src/git_stage_batch/commands/file_scope/file_display_action.py
@@ -46,6 +46,7 @@ from ...output.patch import (
     print_file_mode_change,
     print_text_file_deletion_change,
 )
+from ...utils.session_start_point import session_comparison_base
 
 
 def _load_previous_selection_for_review():
@@ -74,6 +75,7 @@ def show_live_file_display(
         target_file = file_arg
 
     preview_lines = render_file_as_single_hunk(target_file)
+    comparison_base = session_comparison_base()
     deletion_change = (
         render_text_deletion_change(target_file) if preview_lines is None else None
     )
@@ -82,12 +84,12 @@ def show_live_file_display(
     ):
         deletion_change = None
     binary_change = (
-        render_binary_file_change(target_file)
+        render_binary_file_change(target_file, base=comparison_base)
         if preview_lines is None and deletion_change is None
         else None
     )
     gitlink_change = (
-        render_gitlink_change(target_file)
+        render_gitlink_change(target_file, base=comparison_base)
         if preview_lines is None
         and deletion_change is None
         and binary_change is None
@@ -141,7 +143,10 @@ def show_live_file_display(
             exit_with_error(_("File review pages are only available for text changes."))
         if selectable:
             clear_last_file_review_state()
-            cache_gitlink_change(gitlink_change)
+            cache_gitlink_change(
+                gitlink_change,
+                comparison_base=comparison_base,
+            )
         if porcelain:
             return
         print_gitlink_change(gitlink_change)
@@ -152,7 +157,10 @@ def show_live_file_display(
             exit_with_error(_("File review pages are only available for text changes."))
         if selectable:
             clear_last_file_review_state()
-            cache_binary_file_change(binary_change)
+            cache_binary_file_change(
+                binary_change,
+                comparison_base=comparison_base,
+            )
         if porcelain:
             return
         print_binary_file_change(binary_change)

--- a/src/git_stage_batch/commands/file_scope/file_list_action.py
+++ b/src/git_stage_batch/commands/file_scope/file_list_action.py
@@ -29,11 +29,13 @@ from ...output.file_review_list import (
     make_text_deletion_file_review_list_entry,
     print_file_review_list,
 )
+from ...utils.session_start_point import session_comparison_base
 
 
 def show_live_file_list(files: list[str], *, selectable: bool = True) -> None:
     """Show a navigational file list for multiple live file reviews."""
     entries = []
+    comparison_base = session_comparison_base()
     seen_rename_hashes: set[str] = set()
     for file_path in files:
         line_changes = render_file_as_single_hunk(file_path)
@@ -50,11 +52,17 @@ def show_live_file_list(files: list[str], *, selectable: bool = True) -> None:
         ):
             entries.append(make_text_deletion_file_review_list_entry(deletion_change))
             continue
-        binary_change = render_binary_file_change(file_path)
+        binary_change = render_binary_file_change(
+            file_path,
+            base=comparison_base,
+        )
         if binary_change is not None:
             entries.append(make_binary_file_review_list_entry(binary_change))
             continue
-        gitlink_change = render_gitlink_change(file_path)
+        gitlink_change = render_gitlink_change(
+            file_path,
+            base=comparison_base,
+        )
         if gitlink_change is not None:
             entries.append(make_gitlink_file_review_list_entry(gitlink_change))
             continue

--- a/src/git_stage_batch/commands/file_scope/include_file_to_batch.py
+++ b/src/git_stage_batch/commands/file_scope/include_file_to_batch.py
@@ -53,7 +53,11 @@ def include_file_to_batch(
         )
         return
 
-    binary_change = render_binary_file_change(file_path)
+    comparison_base = session_comparison_base()
+    binary_change = render_binary_file_change(
+        file_path,
+        base=comparison_base,
+    )
     if binary_change is not None:
         _whole_file_batch_staging.include_binary_to_batch(
             batch_name,
@@ -62,7 +66,10 @@ def include_file_to_batch(
             auto_advance=auto_advance,
         )
         return
-    gitlink_change = render_gitlink_change(file_path)
+    gitlink_change = render_gitlink_change(
+        file_path,
+        base=comparison_base,
+    )
     if gitlink_change is not None:
         _whole_file_batch_staging.include_gitlink_to_batch(
             batch_name,
@@ -78,7 +85,7 @@ def include_file_to_batch(
 
     with acquire_unified_diff(
         stream_live_git_diff(
-            base=session_comparison_base(),
+            base=comparison_base,
             context_lines=get_context_lines(),
             paths=[file_path],
         )

--- a/src/git_stage_batch/data/change_freshness.py
+++ b/src/git_stage_batch/data/change_freshness.py
@@ -21,12 +21,19 @@ from .file_change_display import (
 from .selected_change.snapshots import snapshots_are_stale
 
 
-def binary_file_change_is_stale(binary_change: BinaryFileChange) -> bool:
+def binary_file_change_is_stale(
+    binary_change: BinaryFileChange,
+    *,
+    comparison_base: str | None = None,
+) -> bool:
     """Return whether a cached binary selection no longer matches repository state."""
     file_path = binary_change.path()
     if snapshots_are_stale(file_path):
         return True
-    current_change = render_binary_file_change(file_path)
+    current_change = render_binary_file_change(
+        file_path,
+        base=comparison_base,
+    )
     if current_change is None:
         return True
     return (
@@ -41,9 +48,16 @@ def file_mode_change_is_stale(mode_change: FileModeChange) -> bool:
     return render_mode_change(mode_change.path()) != mode_change
 
 
-def gitlink_change_is_stale(gitlink_change: GitlinkChange) -> bool:
+def gitlink_change_is_stale(
+    gitlink_change: GitlinkChange,
+    *,
+    comparison_base: str | None = None,
+) -> bool:
     """Return whether a cached gitlink selection no longer matches Git state."""
-    current_change = render_gitlink_change(gitlink_change.path())
+    current_change = render_gitlink_change(
+        gitlink_change.path(),
+        base=comparison_base,
+    )
     if current_change is None:
         return True
     return (

--- a/src/git_stage_batch/data/file_change_display.py
+++ b/src/git_stage_batch/data/file_change_display.py
@@ -31,13 +31,17 @@ def render_mode_change(file_path: str) -> Optional[FileModeChange]:
         return None
 
 
-def render_binary_file_change(file_path: str) -> Optional[BinaryFileChange]:
-    """Render a binary file change for file-scoped display without caching state."""
+def render_binary_file_change(
+    file_path: str,
+    *,
+    base: str | None = None,
+) -> Optional[BinaryFileChange]:
+    """Render a binary change against the requested comparison base."""
     auto_add_untracked_files([file_path])
     try:
         with acquire_unified_diff(
             stream_live_git_diff(
-                base="HEAD",
+                base=base,
                 full_index=True,
                 ignore_submodules="none",
                 submodule_format="short",
@@ -52,13 +56,17 @@ def render_binary_file_change(file_path: str) -> Optional[BinaryFileChange]:
     return None
 
 
-def render_gitlink_change(file_path: str) -> Optional[GitlinkChange]:
-    """Render a gitlink change for file-scoped display without caching state."""
+def render_gitlink_change(
+    file_path: str,
+    *,
+    base: str | None = None,
+) -> Optional[GitlinkChange]:
+    """Render a gitlink change against the requested comparison base."""
     auto_add_untracked_files([file_path])
     try:
         with acquire_unified_diff(
             stream_live_git_diff(
-                base="HEAD",
+                base=base,
                 full_index=True,
                 ignore_submodules="none",
                 submodule_format="short",

--- a/src/git_stage_batch/data/selected_change/file_changes.py
+++ b/src/git_stage_batch/data/selected_change/file_changes.py
@@ -206,6 +206,7 @@ def cache_binary_file_change(
     kind: SelectedChangeKind = SelectedChangeKind.BINARY,
     batch_name: str | None = None,
     batch_binary_fingerprint: str | None = None,
+    comparison_base: str | None = None,
 ) -> None:
     """Cache a binary file change as the current selected change."""
     if kind not in (SelectedChangeKind.BINARY, SelectedChangeKind.BATCH_BINARY):
@@ -221,6 +222,7 @@ def cache_binary_file_change(
             if kind == SelectedChangeKind.BATCH_BINARY else
             None
         ),
+        "comparison_base": comparison_base,
     }
     _clear_selected_line_payload_files()
     write_text_file_contents(
@@ -242,6 +244,7 @@ def cache_gitlink_change(
     kind: SelectedChangeKind = SelectedChangeKind.GITLINK,
     batch_name: str | None = None,
     batch_gitlink_fingerprint: str | None = None,
+    comparison_base: str | None = None,
 ) -> None:
     """Cache a gitlink change as the current selected change."""
     if kind not in (SelectedChangeKind.GITLINK, SelectedChangeKind.BATCH_GITLINK):
@@ -258,6 +261,7 @@ def cache_gitlink_change(
             if kind == SelectedChangeKind.BATCH_GITLINK else
             None
         ),
+        "comparison_base": comparison_base,
     }
     _clear_selected_line_payload_files()
     write_text_file_contents(

--- a/src/git_stage_batch/data/selected_change/loading.py
+++ b/src/git_stage_batch/data/selected_change/loading.py
@@ -88,9 +88,13 @@ def load_selected_change() -> Optional[SelectedChange]:
 
     gitlink_change = _selected_file_changes.load_selected_gitlink_change()
     if gitlink_change is not None:
+        gitlink_data = _selected_file_changes.read_selected_gitlink_data() or {}
         if (
             selected_kind == _selected_store.SelectedChangeKind.GITLINK
-            and _change_freshness.gitlink_change_is_stale(gitlink_change)
+            and _change_freshness.gitlink_change_is_stale(
+                gitlink_change,
+                comparison_base=gitlink_data.get("comparison_base"),
+            )
         ):
             raise CommandError(
                 _(
@@ -102,9 +106,13 @@ def load_selected_change() -> Optional[SelectedChange]:
 
     binary_file = _selected_file_changes.load_selected_binary_file()
     if binary_file is not None:
+        binary_data = _selected_file_changes.read_selected_binary_data() or {}
         if (
             selected_kind == _selected_store.SelectedChangeKind.BINARY
-            and _change_freshness.binary_file_change_is_stale(binary_file)
+            and _change_freshness.binary_file_change_is_stale(
+                binary_file,
+                comparison_base=binary_data.get("comparison_base"),
+            )
         ):
             file_path = binary_file.path()
             raise CommandError(

--- a/tests/commands/test_submodule_pointers.py
+++ b/tests/commands/test_submodule_pointers.py
@@ -535,6 +535,24 @@ def test_discard_file_restores_submodule_pointer(
     assert _git_stdout(["diff", "--ignore-submodules=none", "--", "sub"], cwd=repo) == ""
 
 
+def test_unstaged_gitlink_selection_freshness_uses_index_base(
+    submodule_pointer_repo: tuple[Path, str, str],
+) -> None:
+    """A staged pointer plus a newer worktree pointer should remain actionable."""
+    repo, _old_oid, new_oid = submodule_pointer_repo
+    _run(["git", "add", "sub"], cwd=repo)
+    submodule = repo / "sub"
+    (submodule / "file.txt").write_text("three\n")
+    _run(["git", "commit", "-am", "Third pointer"], cwd=submodule)
+    third_oid = _git_stdout(["rev-parse", "HEAD"], cwd=submodule)
+
+    command_start(quiet=True)
+    command_skip(quiet=True)
+
+    assert _git_stdout(["rev-parse", "HEAD"], cwd=submodule) == third_oid
+    assert _git_stdout(["rev-parse", ":sub"], cwd=repo) == new_oid
+
+
 def test_discard_refuses_dirty_submodule_pointer(
     submodule_pointer_repo: tuple[Path, str, str],
 ) -> None:


### PR DESCRIPTION
Live binary and gitlink selections currently render against different Git bases across discovery, explicit file review, and freshness validation.

A staged value followed by further worktree changes can therefore appear current in one path and stale in another even when the displayed selection has not changed.

This PR carries the selected comparison base through rendering, caching, freshness checks, and file-scoped review for both special-file change types.

It builds on #213 and establishes the consistent live-selection view required by the following discard restoration layer.

Validation completed with `uv run pytest` and Ruff checks across every changed Python file.