### PR TITLE
Restore whole-file discard from the index

### DIFF
--- a/docs/batches.md
+++ b/docs/batches.md
@@ -547,7 +547,9 @@ Save and discard only specific lines, preserving other changes in your working t
 ❯ git-stage-batch discard --to batch-name --file
 ```
 
-Save the entire selected file to the batch, then discard the entire file from the working tree. Useful when you want to completely remove a file while preserving it for potential recovery.
+Save all changes in the selected file to the batch, then remove those changes
+from the working tree. A tracked file returns to its indexed baseline; a newly
+added file is removed because it has no indexed version to restore.
 
 **Example workflow:**
 ```bash

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -524,7 +524,7 @@ All hunks from the file are marked as skipped and can be revisited with `again`.
 
 ### `discard --file [PATH]`
 
-Discard entire file from the working tree.
+Discard all unstaged changes in one file.
 
 **Discard selected hunk's file:**
 ```
@@ -536,7 +536,7 @@ Discard entire file from the working tree.
 ❯ git-stage-batch discard --file src/debug.py
 ```
 
-Removes all changes from the specified file. When a path is provided, you can discard any file in your working tree regardless of which file the selected hunk is from.
+Restores the working-tree file from the index, preserving any staged content. A new untracked file is removed because it has no indexed version to restore. When a path is provided, you can discard changes from any file regardless of which file the selected hunk is from.
 
 **Use cases:**
 - `--file` (no path): Discard the entire file of the selected hunk
@@ -544,7 +544,7 @@ Removes all changes from the specified file. When a path is provided, you can di
 - `--files PATTERN...`: Discard all matched files as complete units
 
 !!! warning "Destructive Operation"
-    This permanently removes the entire file from your working tree.
+    This permanently removes the file's unstaged changes. To intentionally remove a tracked file, use `git rm -- PATH` instead.
 
 ---
 

--- a/man/git-stage-batch-discard.1.in
+++ b/man/git-stage-batch-discard.1.in
@@ -34,6 +34,11 @@ Discard or save only specific displayed line IDs.
 Operate on one complete file. If
 .I PATH
 is omitted, use the selected hunk's file.
+For a live discard, restore the path from the index and preserve staged
+content. New untracked files are removed because they have no indexed version.
+Use
+.B git rm -- PATH
+to intentionally remove a tracked file.
 .TP
 .BI "\-\-files " PATTERN "..."
 Operate on all changed files matched by gitignore-style patterns.

--- a/src/git_stage_batch/commands/batch_source/binary_file_actions.py
+++ b/src/git_stage_batch/commands/batch_source/binary_file_actions.py
@@ -7,10 +7,9 @@ import os
 
 from ...core.buffer import (
     LineBuffer,
-    write_buffer_to_path,
     write_buffer_to_working_tree_path,
 )
-from ...data.file_modes import apply_git_file_mode, detect_file_mode_in_commit
+from ...data.file_modes import detect_file_mode_in_commit
 from ...utils.repository_buffers import read_git_object_buffer_or_none
 from ...utils.git_index import git_update_index
 from ...utils.git_repository import get_git_repository_root_path
@@ -35,15 +34,16 @@ def discard_binary_file_to_worktree(
 
     baseline_buffer = read_git_object_buffer_or_none(f"{baseline_commit}:{file_path}")
     if baseline_buffer is not None:
+        file_mode = detect_file_mode_in_commit(baseline_commit, file_path)
         with baseline_buffer:
-            write_buffer_to_path(full_path, baseline_buffer)
-        apply_git_file_mode(
-            full_path,
-            detect_file_mode_in_commit(baseline_commit, file_path),
-        )
+            write_buffer_to_working_tree_path(
+                full_path,
+                baseline_buffer,
+                mode=file_mode,
+            )
         return BinaryWorktreeAction.REPLACED
 
-    if full_path.exists():
+    if os.path.lexists(full_path):
         full_path.unlink()
         return BinaryWorktreeAction.DELETED
     return None

--- a/src/git_stage_batch/commands/batch_source/text_file_actions.py
+++ b/src/git_stage_batch/commands/batch_source/text_file_actions.py
@@ -6,11 +6,9 @@ import os
 
 from ...core.buffer import (
     LineBuffer,
-    write_buffer_to_path,
     write_buffer_to_working_tree_path,
 )
 from ...core.text_lifecycle import TextFileChangeType, normalized_text_change_type
-from ...data.file_modes import apply_git_file_mode
 from ...staging.index_update import update_index_with_blob_buffer
 from ...utils.git_index import git_update_index
 from ...utils.git_repository import get_git_repository_root_path
@@ -75,12 +73,11 @@ def write_discarded_text_file_to_worktree(
     full_path = repo_root / file_path
 
     if normalized_text_change_type(change_type) == TextFileChangeType.DELETED:
-        if full_path.exists():
+        if os.path.lexists(full_path):
             full_path.unlink()
         return
 
     if buffer is None:
         raise RuntimeError(f"Text file not found in discarded content: {file_path}")
 
-    write_buffer_to_path(full_path, buffer)
-    apply_git_file_mode(full_path, file_mode)
+    write_buffer_to_working_tree_path(full_path, buffer, mode=file_mode)

--- a/src/git_stage_batch/commands/file_scope/discard_file.py
+++ b/src/git_stage_batch/commands/file_scope/discard_file.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shlex
 import sys
 
 from ...core.diff_parser import acquire_unified_diff
@@ -13,32 +14,72 @@ from ...core.hashing import (
     compute_stable_hunk_hash_from_lines,
     compute_text_file_deletion_hash,
 )
-from ...core.models import BinaryFileChange, RenameChange, TextFileDeletionChange
-from ...data.file_change_display import (
-    render_gitlink_change,
-    render_mode_change,
-    render_rename_change,
-    render_text_deletion_change,
+from ...core.models import (
+    BinaryFileChange,
+    FileModeChange,
+    GitlinkChange,
+    RenameChange,
+    TextFileDeletionChange,
 )
 from ...data.file_tracking import auto_add_untracked_files
+from ...data.index_entries import read_index_entry
 from ...data.live_diff import stream_live_git_diff
 from ...data.progress import record_hunk_discarded
 from ...data.selected_change.paths import get_selected_change_file_path
-from ...data.session import snapshot_file_if_untracked
+from ...data.session import path_is_intent_to_add, snapshot_file_if_untracked
 from ...data.undo_checkpoints import undo_checkpoint
 from ...exceptions import exit_with_error
 from ...i18n import _
 from ...utils.file_io import append_lines_to_file, read_text_file_line_set
 from ...utils.git_command import run_git_command
-from ...utils.git_worktree import git_remove_paths
+from ...utils.git_index import git_update_index
+from ...utils.git_repository import get_git_repository_root_path
+from ...utils.git_worktree import git_checkout_index_paths
 from ...utils.paths import get_block_list_file_path, get_context_lines
 from ..selection.action_completion import finish_selected_change_action
 from ..selection.selected_change_discarding import (
     discard_gitlink_change,
-    discard_file_mode_change,
     discard_rename_change,
-    discard_text_deletion_change,
 )
+
+
+def _discard_worktree_path_to_index(file_path: str) -> None:
+    """Restore one working-tree path from the index without changing staged work."""
+    index_entry = read_index_entry(file_path)
+    is_intent_to_add = path_is_intent_to_add(file_path)
+    if index_entry is not None and not is_intent_to_add:
+        result = git_checkout_index_paths([file_path], check=False)
+        if result.returncode != 0:
+            exit_with_error(
+                _("Failed to discard file: {}").format(result.stderr)
+            )
+        return
+
+    absolute_path = get_git_repository_root_path() / file_path
+    if absolute_path.exists() or absolute_path.is_symlink():
+        absolute_path.unlink()
+    if is_intent_to_add:
+        result = git_update_index(
+            file_path=file_path,
+            force_remove=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            exit_with_error(
+                _("Failed to discard file: {}").format(result.stderr)
+            )
+
+
+def _print_discard_file_result(file_path: str) -> None:
+    """Explain the non-deleting whole-file discard contract."""
+    removal_command = shlex.join(["git", "rm", "--", file_path])
+    print(
+        _(
+            "✓ Unstaged changes discarded from {file}. "
+            "To remove the file, use `{command}`."
+        ).format(file=file_path, command=removal_command),
+        file=sys.stderr,
+    )
 
 
 def discard_file_changes(
@@ -77,112 +118,76 @@ def discard_file_changes(
         blocklist_path = get_block_list_file_path()
         blocked_hashes = read_text_file_line_set(blocklist_path)
 
-        deletion_change = render_text_deletion_change(target_file)
-        if deletion_change is not None:
-            patch_hash = compute_text_file_deletion_hash(deletion_change)
-            discard_text_deletion_change(deletion_change)
-            if patch_hash not in blocked_hashes:
-                append_lines_to_file(blocklist_path, [patch_hash])
-                record_hunk_discarded(patch_hash)
-            print(
-                _("✓ Text file deletion discarded: {file}").format(file=target_file),
-                file=sys.stderr,
-            )
-            finish_selected_change_action(quiet=False, auto_advance=auto_advance)
-            return
-
-        gitlink_change = render_gitlink_change(target_file)
-        if gitlink_change is not None:
-            patch_hash = compute_gitlink_change_hash(gitlink_change)
-            discard_gitlink_change(gitlink_change)
-            if patch_hash not in blocked_hashes:
-                append_lines_to_file(blocklist_path, [patch_hash])
-                record_hunk_discarded(patch_hash)
-            print(
-                _("✓ Submodule pointer restored: {file}").format(file=target_file),
-                file=sys.stderr,
-            )
-            finish_selected_change_action(quiet=False, auto_advance=auto_advance)
-            return
-
-        rename_change = render_rename_change(target_file)
-        if rename_change is not None:
-            patch_hash = compute_rename_change_hash(rename_change)
-            discard_rename_change(rename_change)
-            if patch_hash not in blocked_hashes:
-                append_lines_to_file(blocklist_path, [patch_hash])
-                record_hunk_discarded(patch_hash)
-            print(
-                _("✓ Rename discarded: {old} -> {new}").format(
-                    old=rename_change.old_path,
-                    new=rename_change.new_path,
-                ),
-                file=sys.stderr,
-            )
-            finish_selected_change_action(quiet=False, auto_advance=auto_advance)
-            return
-
-        mode_change = render_mode_change(target_file)
-        if mode_change is not None:
-            patch_hash = compute_file_mode_change_hash(mode_change)
-            discard_file_mode_change(mode_change)
-            append_lines_to_file(blocklist_path, [patch_hash])
-            record_hunk_discarded(patch_hash)
-            print(_("✓ File mode discarded: {}").format(target_file), file=sys.stderr)
-            finish_selected_change_action(quiet=False, auto_advance=auto_advance)
-            return
-
-        snapshot_file_if_untracked(target_file)
-
-        hashes_to_block = []
+        hashes_to_block: list[str] = []
+        matching_changes = 0
+        rename_change: RenameChange | None = None
+        gitlink_change: GitlinkChange | None = None
         with acquire_unified_diff(
-            stream_live_git_diff(context_lines=get_context_lines())
+            stream_live_git_diff(
+                full_index=True,
+                ignore_submodules="none",
+                submodule_format="short",
+                context_lines=get_context_lines(),
+            )
         ) as patches:
             for patch in patches:
                 if isinstance(patch, RenameChange):
                     if target_file not in (patch.old_path, patch.new_path):
                         continue
-
+                    rename_change = patch
                     patch_hash = compute_rename_change_hash(patch)
-                    if patch_hash not in blocked_hashes:
-                        hashes_to_block.append(patch_hash)
-                    continue
-
-                if isinstance(patch, TextFileDeletionChange):
+                elif isinstance(patch, TextFileDeletionChange):
                     if patch.path() != target_file:
                         continue
-
                     patch_hash = compute_text_file_deletion_hash(patch)
-                    if patch_hash not in blocked_hashes:
-                        hashes_to_block.append(patch_hash)
-                    continue
-
-                if isinstance(patch, BinaryFileChange):
-                    file_path = patch.path()
-                    if file_path != target_file:
+                elif isinstance(patch, BinaryFileChange):
+                    if patch.path() != target_file:
                         continue
-
                     patch_hash = compute_binary_file_hash(patch)
-                    if patch_hash not in blocked_hashes:
-                        hashes_to_block.append(patch_hash)
-                    continue
+                elif isinstance(patch, GitlinkChange):
+                    if patch.path() != target_file:
+                        continue
+                    gitlink_change = patch
+                    patch_hash = compute_gitlink_change_hash(patch)
+                elif isinstance(patch, FileModeChange):
+                    if patch.path() != target_file:
+                        continue
+                    patch_hash = compute_file_mode_change_hash(patch)
+                else:
+                    patch_paths = {
+                        path
+                        for path in (patch.old_path, patch.new_path)
+                        if path != "/dev/null"
+                    }
+                    if target_file not in patch_paths:
+                        continue
+                    patch_hash = compute_stable_hunk_hash_from_lines(patch.lines)
 
-                if patch.new_path != target_file:
-                    continue
-
-                patch_hash = compute_stable_hunk_hash_from_lines(patch.lines)
-
+                matching_changes += 1
                 if patch_hash not in blocked_hashes:
                     hashes_to_block.append(patch_hash)
 
-        result = git_remove_paths([target_file], force=True, check=False)
-        if result.returncode != 0:
-            exit_with_error(_("Failed to discard file: {}").format(result.stderr))
+        if matching_changes == 0:
+            print(
+                _("No unstaged changes in file '{file}' to discard.").format(
+                    file=target_file,
+                ),
+                file=sys.stderr,
+            )
+            return
+
+        snapshot_file_if_untracked(target_file)
+        if rename_change is not None:
+            discard_rename_change(rename_change)
+        elif gitlink_change is not None:
+            discard_gitlink_change(gitlink_change)
+        else:
+            _discard_worktree_path_to_index(target_file)
 
         for patch_hash in hashes_to_block:
             append_lines_to_file(blocklist_path, [patch_hash])
             record_hunk_discarded(patch_hash)
 
-        print(_("✓ File discarded: {}").format(target_file), file=sys.stderr)
+        _print_discard_file_result(target_file)
 
         finish_selected_change_action(quiet=False, auto_advance=auto_advance)

--- a/src/git_stage_batch/commands/file_scope/discard_file_to_batch.py
+++ b/src/git_stage_batch/commands/file_scope/discard_file_to_batch.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from contextlib import ExitStack
+import os
 import sys
 
 from ...batch.source.annotation import annotate_with_batch_source
@@ -33,12 +34,13 @@ from ...i18n import _
 from ...utils.file_io import read_text_file_line_set
 from ...utils.git_worktree import (
     git_apply_to_worktree,
-    git_checkout_paths,
+    git_checkout_index_paths,
     git_remove_paths,
 )
 from ...utils.git_repository import get_git_repository_root_path
 from ...utils.journal import log_journal
 from ...utils.paths import get_block_list_file_path, get_context_lines
+from ...utils.session_start_point import session_comparison_base
 from ..selection.action_completion import finish_selected_change_action
 from ..selection import whole_file_batch_discarding as _whole_file_batch_discarding
 
@@ -69,7 +71,11 @@ def discard_file_to_batch(
             auto_advance=auto_advance,
         )
 
-    binary_change = render_binary_file_change(file_path)
+    comparison_base = session_comparison_base()
+    binary_change = render_binary_file_change(
+        file_path,
+        base=comparison_base,
+    )
     if binary_change is not None:
         return _whole_file_batch_discarding.discard_binary_to_batch(
             batch_name,
@@ -78,7 +84,7 @@ def discard_file_to_batch(
             advance=advance,
             auto_advance=auto_advance,
         )
-    if render_gitlink_change(file_path) is not None:
+    if render_gitlink_change(file_path, base=comparison_base) is not None:
         exit_with_error(_("Discarding submodule pointer changes to a batch is not supported yet."))
 
     blocklist_path = get_block_list_file_path()
@@ -92,7 +98,7 @@ def discard_file_to_batch(
 
         with acquire_unified_diff(
             stream_live_git_diff(
-                base="HEAD",
+                base=comparison_base,
                 context_lines=get_context_lines(),
                 paths=[file_path],
             )
@@ -153,7 +159,13 @@ def discard_file_to_batch(
                     full_path.unlink()
                     git_remove_paths([file_path], cached=True, quiet=True, check=False)
                 else:
-                    git_checkout_paths("HEAD", [file_path], check=False)
+                    result = git_checkout_index_paths([file_path], check=False)
+                    if result.returncode != 0:
+                        exit_with_error(
+                            _("Failed to restore file: {error}").format(
+                                error=result.stderr,
+                            )
+                        )
 
                 if not quiet:
                     print(
@@ -233,7 +245,7 @@ def discard_file_to_batch(
 
         repo_root = get_git_repository_root_path()
         full_path = repo_root / file_path
-        if not full_path.exists():
+        if not os.path.lexists(full_path):
             git_remove_paths([file_path], cached=True, quiet=True, check=False)
 
         if not quiet:

--- a/src/git_stage_batch/commands/file_scope/discard_to_batch.py
+++ b/src/git_stage_batch/commands/file_scope/discard_to_batch.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from contextlib import ExitStack
 from dataclasses import dataclass
+import os
 
 from ...batch.source.annotation import annotate_with_batch_source
 from ...batch.state.lifecycle import create_batch
@@ -38,6 +39,7 @@ from ...utils.paths import (
     get_block_list_file_path,
     get_context_lines,
 )
+from ...utils.session_start_point import session_comparison_base
 from ..selection.action_completion import finish_selected_change_action
 from .discard_file_to_batch import discard_file_to_batch
 
@@ -220,7 +222,7 @@ def _collect_text_file_discard_inputs(
 
     with acquire_unified_diff(
         stream_live_git_diff(
-            base="HEAD",
+            base=session_comparison_base(),
             context_lines=get_context_lines(),
             paths=files,
         )
@@ -333,7 +335,7 @@ def _discard_prepared_text_files_to_batch(
     repo_root = get_git_repository_root_path()
     for prepared in prepared_discards:
         full_path = repo_root / prepared.file_path
-        if not full_path.exists():
+        if not os.path.lexists(full_path):
             git_remove_paths([prepared.file_path], cached=True, quiet=True, check=False)
 
     hunk_hashes = [

--- a/src/git_stage_batch/commands/selection/selected_change_batch_discarding.py
+++ b/src/git_stage_batch/commands/selection/selected_change_batch_discarding.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from contextlib import ExitStack
+import os
 import sys
 
 from ...batch.source.annotation import annotate_with_batch_source
@@ -273,7 +274,7 @@ def _discard_text_hunk_to_batch(
         if is_new_file or file_only:
             absolute_path = get_git_repository_root_path() / file_path
 
-            if not absolute_path.exists():
+            if not os.path.lexists(absolute_path):
                 git_remove_paths([file_path], cached=True, quiet=True, check=False)
             elif is_new_file:
                 if path_is_empty(absolute_path):

--- a/src/git_stage_batch/commands/selection/selected_change_discarding.py
+++ b/src/git_stage_batch/commands/selection/selected_change_discarding.py
@@ -191,7 +191,7 @@ def _discard_binary_change(
 
     if item.is_new_file():
         absolute_path = get_git_repository_root_path() / file_path
-        if absolute_path.exists():
+        if os.path.lexists(absolute_path):
             absolute_path.unlink()
         _drop_intent_to_add_entry(file_path)
         log_journal("command_discard_binary_deleted", file_path=file_path)

--- a/src/git_stage_batch/commands/selection/whole_file_batch_discarding.py
+++ b/src/git_stage_batch/commands/selection/whole_file_batch_discarding.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import sys
 
 from ...batch.binary_file_storage import add_binary_file_to_batch
@@ -19,7 +20,7 @@ from ...exceptions import exit_with_error
 from ...i18n import _
 from ...utils.file_io import append_lines_to_file
 from ...utils.git_worktree import (
-    git_checkout_paths,
+    git_checkout_index_paths,
     git_remove_paths,
 )
 from ...utils.git_repository import get_git_repository_root_path
@@ -34,12 +35,12 @@ def _discard_binary_change_from_working_tree(binary_change: BinaryFileChange) ->
     absolute_path = get_git_repository_root_path() / file_path
 
     if binary_change.is_new_file():
-        if absolute_path.exists():
+        if os.path.lexists(absolute_path):
             absolute_path.unlink()
         git_remove_paths([file_path], cached=True, quiet=True, check=False)
         return
 
-    result = git_checkout_paths("HEAD", [file_path], check=False)
+    result = git_checkout_index_paths([file_path], check=False)
     if result.returncode != 0:
         exit_with_error(_("Failed to restore binary file: {error}").format(error=result.stderr))
 

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -6404,10 +6404,9 @@ def test_file_scope_discard_owns_file_pipeline():
     }
     moved_names = {
         "auto_add_untracked_files",
-        "git_remove_paths",
-        "render_gitlink_change",
-        "render_rename_change",
-        "render_text_deletion_change",
+        "git_checkout_index_paths",
+        "git_update_index",
+        "read_index_entry",
         "stream_live_git_diff",
     }
 

--- a/tests/commands/batch_source/test_binary_file_actions.py
+++ b/tests/commands/batch_source/test_binary_file_actions.py
@@ -1,5 +1,6 @@
 """Tests for batch-source binary file actions."""
 
+import os
 import stat
 from types import SimpleNamespace
 
@@ -30,13 +31,6 @@ def test_discard_binary_file_to_worktree_restores_baseline(
         "detect_file_mode_in_commit",
         lambda commit, file_path: "100755",
     )
-    mode_calls = []
-    monkeypatch.setattr(
-        binary_file_actions,
-        "apply_git_file_mode",
-        lambda path, file_mode: mode_calls.append((path, file_mode)),
-    )
-
     action = binary_file_actions.discard_binary_file_to_worktree(
         "image.png",
         "base",
@@ -45,7 +39,7 @@ def test_discard_binary_file_to_worktree_restores_baseline(
     target = tmp_path / "image.png"
     assert action is binary_file_actions.BinaryWorktreeAction.REPLACED
     assert target.read_bytes() == b"baseline"
-    assert mode_calls == [(target, "100755")]
+    assert stat.S_IMODE(target.stat().st_mode) & stat.S_IXUSR
     with pytest.raises(ValueError, match="buffer is closed"):
         baseline_buffer.to_bytes()
 
@@ -75,6 +69,67 @@ def test_discard_binary_file_to_worktree_deletes_without_baseline(
 
     assert action is binary_file_actions.BinaryWorktreeAction.DELETED
     assert not target.exists()
+
+
+def test_discard_binary_replaces_dangling_symlink_with_regular_file(
+    tmp_path,
+    monkeypatch,
+):
+    """Restoring a regular binary should unlink a current dangling symlink."""
+    monkeypatch.setattr(
+        binary_file_actions,
+        "get_git_repository_root_path",
+        lambda: tmp_path,
+    )
+    baseline_buffer = LineBuffer.from_bytes(b"baseline")
+    monkeypatch.setattr(
+        binary_file_actions,
+        "read_git_object_buffer_or_none",
+        lambda _spec: baseline_buffer,
+    )
+    monkeypatch.setattr(
+        binary_file_actions,
+        "detect_file_mode_in_commit",
+        lambda _commit, _file_path: "100644",
+    )
+    target = tmp_path / "image.png"
+    os.symlink("missing", target)
+
+    action = binary_file_actions.discard_binary_file_to_worktree(
+        "image.png",
+        "base",
+    )
+
+    assert action is binary_file_actions.BinaryWorktreeAction.REPLACED
+    assert not target.is_symlink()
+    assert target.read_bytes() == b"baseline"
+
+
+def test_discard_binary_deletes_dangling_symlink_without_baseline(
+    tmp_path,
+    monkeypatch,
+):
+    """Absent binary baselines should remove broken symlink paths."""
+    monkeypatch.setattr(
+        binary_file_actions,
+        "get_git_repository_root_path",
+        lambda: tmp_path,
+    )
+    monkeypatch.setattr(
+        binary_file_actions,
+        "read_git_object_buffer_or_none",
+        lambda _spec: None,
+    )
+    target = tmp_path / "image.png"
+    os.symlink("missing", target)
+
+    action = binary_file_actions.discard_binary_file_to_worktree(
+        "image.png",
+        "base",
+    )
+
+    assert action is binary_file_actions.BinaryWorktreeAction.DELETED
+    assert not os.path.lexists(target)
 
 
 def test_discard_binary_file_to_worktree_ignores_missing_path_without_baseline(

--- a/tests/commands/batch_source/test_text_file_actions.py
+++ b/tests/commands/batch_source/test_text_file_actions.py
@@ -1,5 +1,6 @@
 """Tests for batch-source text file actions."""
 
+import os
 import stat
 from types import SimpleNamespace
 
@@ -243,12 +244,6 @@ def test_write_discarded_text_file_to_worktree_writes_buffer_and_mode(
         "get_git_repository_root_path",
         lambda: tmp_path,
     )
-    mode_calls = []
-    monkeypatch.setattr(
-        text_file_actions,
-        "apply_git_file_mode",
-        lambda path, file_mode: mode_calls.append((path, file_mode)),
-    )
     buffer = LineBuffer.from_bytes(b"restored\n")
 
     try:
@@ -262,7 +257,35 @@ def test_write_discarded_text_file_to_worktree_writes_buffer_and_mode(
 
     target = tmp_path / "notes.txt"
     assert target.read_bytes() == b"restored\n"
-    assert mode_calls == [(target, "100755")]
+    assert stat.S_IMODE(target.stat().st_mode) & stat.S_IXUSR
+
+
+def test_write_discarded_text_replaces_dangling_symlink_with_regular_file(
+    tmp_path,
+    monkeypatch,
+):
+    """A regular baseline must replace a current symlink, not its target."""
+    monkeypatch.setattr(
+        text_file_actions,
+        "get_git_repository_root_path",
+        lambda: tmp_path,
+    )
+    target = tmp_path / "notes.txt"
+    os.symlink("missing-target", target)
+    buffer = LineBuffer.from_bytes(b"restored\n")
+
+    try:
+        text_file_actions.write_discarded_text_file_to_worktree(
+            "notes.txt",
+            buffer,
+            "100644",
+        )
+    finally:
+        buffer.close()
+
+    assert not target.is_symlink()
+    assert target.read_bytes() == b"restored\n"
+    assert not (tmp_path / "missing-target").exists()
 
 
 def test_write_discarded_text_file_to_worktree_deletes_existing_file(
@@ -286,6 +309,26 @@ def test_write_discarded_text_file_to_worktree_deletes_existing_file(
     )
 
     assert not target.exists()
+
+
+def test_write_discarded_text_deletes_dangling_symlink(tmp_path, monkeypatch):
+    """Deleted baselines should remove broken symlink paths too."""
+    monkeypatch.setattr(
+        text_file_actions,
+        "get_git_repository_root_path",
+        lambda: tmp_path,
+    )
+    target = tmp_path / "old.txt"
+    os.symlink("missing", target)
+
+    text_file_actions.write_discarded_text_file_to_worktree(
+        "old.txt",
+        None,
+        None,
+        change_type="deleted",
+    )
+
+    assert not os.path.lexists(target)
 
 
 def test_write_discarded_text_file_to_worktree_requires_buffer(

--- a/tests/commands/test_binary_files.py
+++ b/tests/commands/test_binary_files.py
@@ -374,6 +374,44 @@ def test_binary_file_skip(binary_file_repo: Path, monkeypatch: pytest.MonkeyPatc
     assert "A  new_image.png" not in status_result.stdout  # Not fully staged
 
 
+def test_unstaged_binary_selection_freshness_uses_index_base(
+    binary_file_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A staged addition with further edits should not be stale immediately."""
+    monkeypatch.chdir(binary_file_repo)
+    binary_path = binary_file_repo / "staged-new.bin"
+    binary_path.write_bytes(b"\x00STAGED")
+    subprocess.run(["git", "add", "staged-new.bin"], check=True, capture_output=True)
+    binary_path.write_bytes(b"\x00WORKTREE")
+
+    initialize_abort_state()
+    selected = fetch_next_change()
+
+    assert isinstance(selected, BinaryFileChange)
+    assert selected.change_type == "modified"
+    command_skip(quiet=True)
+    assert binary_path.read_bytes() == b"\x00WORKTREE"
+
+
+def test_head_based_binary_file_review_keeps_its_comparison_base(
+    binary_file_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicit file review should validate against the same HEAD view."""
+    monkeypatch.chdir(binary_file_repo)
+    binary_path = binary_file_repo / "staged-new.bin"
+    binary_path.write_bytes(b"\x00STAGED")
+    subprocess.run(["git", "add", "staged-new.bin"], check=True, capture_output=True)
+    binary_path.write_bytes(b"\x00WORKTREE")
+
+    initialize_abort_state()
+    command_show(file="staged-new.bin", porcelain=True)
+
+    command_skip(quiet=True)
+    assert binary_path.read_bytes() == b"\x00WORKTREE"
+
+
 def test_selected_binary_include_to_batch(binary_file_repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Selected binary include --to should not treat the binary as a text patch."""
     monkeypatch.chdir(binary_file_repo)
@@ -774,7 +812,7 @@ def test_show_from_batch_displays_binary_entries(
 
 
 def test_binary_file_modified_discard_file(binary_file_repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """File-scoped discard should remove binary files atomically like text files."""
+    """File-scoped discard should restore a binary from the index."""
     monkeypatch.chdir(binary_file_repo)
 
     image_path = binary_file_repo / "image.png"
@@ -784,9 +822,10 @@ def test_binary_file_modified_discard_file(binary_file_repo: Path, monkeypatch: 
 
     command_discard_file("image.png")
 
-    assert not image_path.exists()
+    assert image_path.exists()
+    assert image_path.read_bytes() != b"\x89PNG\r\n\x1a\nMODIFIED"
     status_result = run_git_command(["status", "--porcelain"])
-    assert "D  image.png" in status_result.stdout
+    assert "image.png" not in status_result.stdout
 
 def test_binary_file_modified_include_file(binary_file_repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """File-scoped include should stage binary files atomically."""

--- a/tests/commands/test_discard_file.py
+++ b/tests/commands/test_discard_file.py
@@ -40,8 +40,8 @@ def temp_git_repo(tmp_path, monkeypatch):
 class TestCommandDiscardFile:
     """Tests for discard-file command."""
 
-    def test_discard_file_removes_file_from_working_tree(self, temp_git_repo, capsys):
-        """Test that discard-file removes the entire file from working tree."""
+    def test_discard_file_restores_file_from_index(self, temp_git_repo, capsys):
+        """Discard-file should restore a tracked file without changing the index."""
         # Create and commit a file
         test_file = temp_git_repo / "unwanted.txt"
         test_file.write_text("line 1\nline 2\nline 3\n")
@@ -54,47 +54,48 @@ class TestCommandDiscardFile:
         command_start()
         command_discard_file(file="")
 
-        # File should be completely removed from working tree
-        assert not test_file.exists()
+        # The working tree should be restored to its indexed contents.
+        assert test_file.read_text() == "line 1\nline 2\nline 3\n"
 
-        # File should be staged for deletion
+        # The operation should not stage a deletion.
         result = subprocess.run(
             ["git", "diff", "--cached", "--name-status"],
             check=True,
             cwd=temp_git_repo,
             capture_output=True,)
-        assert b"D\tunwanted.txt" in result.stdout
+        assert result.stdout == b""
 
         captured = capsys.readouterr()
-        assert "File discarded: unwanted.txt" in captured.err
+        assert "Unstaged changes discarded from unwanted.txt" in captured.err
+        assert "git rm -- unwanted.txt" in captured.err
 
     def test_discard_file_raises_when_git_rejects_removal(
         self,
         temp_git_repo,
         monkeypatch,
     ):
-        """A failed named file removal should fail the discard command."""
+        """A failed index restore should fail the discard command."""
         readme = temp_git_repo / "README.md"
         readme.write_text("# Changed\n")
         command_start()
         monkeypatch.setattr(
             discard_file_scope,
-            "git_remove_paths",
+            "git_checkout_index_paths",
             lambda *_args, **_kwargs: subprocess.CompletedProcess(
-                ["git", "rm"],
+                ["git", "checkout"],
                 1,
                 "",
-                "file removal failed",
+                "file restore failed",
             ),
         )
 
-        with pytest.raises(CommandError, match="file removal failed"):
+        with pytest.raises(CommandError, match="file restore failed"):
             command_discard_file(file="README.md")
 
         assert readme.read_text() == "# Changed\n"
 
     def test_discard_file_with_multiple_hunks(self, temp_git_repo, capsys):
-        """Test that discard-file removes file even with multiple hunks."""
+        """Test that discard-file restores a file with multiple hunks."""
         # Create and commit a file with content that will create multiple hunks
         test_file = temp_git_repo / "multi.txt"
         test_file.write_text("line 1\nline 2\nline 3\nline 4\nline 5\nline 6\nline 7\n")
@@ -107,19 +108,21 @@ class TestCommandDiscardFile:
         command_start()
         command_discard_file(file="")
 
-        # File should be completely removed
-        assert not test_file.exists()
+        # File should be restored to the indexed version.
+        assert test_file.read_text() == (
+            "line 1\nline 2\nline 3\nline 4\nline 5\nline 6\nline 7\n"
+        )
 
-        # Verify it's staged for deletion
+        # Verify no deletion was staged.
         result = subprocess.run(
             ["git", "status", "--short"],
             check=True,
             cwd=temp_git_repo,
             capture_output=True,)
-        assert b"D  multi.txt" in result.stdout
+        assert result.stdout == b""
 
         captured = capsys.readouterr()
-        assert "File discarded: multi.txt" in captured.err
+        assert "Unstaged changes discarded from multi.txt" in captured.err
 
     def test_discard_file_only_affects_selected_file(self, temp_git_repo, capsys):
         """Test that discard-file only removes the selected file, not others."""
@@ -138,23 +141,84 @@ class TestCommandDiscardFile:
         command_start()
         command_discard_file(file="")
 
-        # Only the first file should be removed
-        assert not file1.exists()
+        # Only the first file should be restored.
+        assert file1.read_text() == "original 1\n"
         assert file2.exists()
 
         # Verify file2 still has its changes
         assert file2.read_text() == "modified 2\n"
 
-        # Verify file1 is staged for deletion
+        # Verify file1 was not staged for deletion.
         result = subprocess.run(
             ["git", "diff", "--cached", "--name-status"],
             check=True,
             cwd=temp_git_repo,
             capture_output=True,)
-        assert b"D\tfile1.txt" in result.stdout
+        assert result.stdout == b""
 
         captured = capsys.readouterr()
-        assert "File discarded: file1.txt" in captured.err
+        assert "Unstaged changes discarded from file1.txt" in captured.err
+
+    def test_discard_file_preserves_staged_content(self, temp_git_repo):
+        """Whole-file discard should restore from the index, not HEAD."""
+        test_file = temp_git_repo / "staged.txt"
+        test_file.write_text("base\n")
+        subprocess.run(
+            ["git", "add", "staged.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add staged file"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        test_file.write_text("staged\n")
+        subprocess.run(
+            ["git", "add", "staged.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        test_file.write_text("unstaged\n")
+
+        command_start()
+        command_discard_file(file="staged.txt")
+
+        assert test_file.read_text() == "staged\n"
+        staged = subprocess.run(
+            ["git", "show", ":staged.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+            text=True,
+        )
+        assert staged.stdout == "staged\n"
+
+    def test_discard_file_restores_an_unstaged_deletion(self, temp_git_repo):
+        """Discarding a tracked deletion should restore the indexed file."""
+        test_file = temp_git_repo / "deleted.txt"
+        test_file.write_text("indexed\n")
+        subprocess.run(
+            ["git", "add", "deleted.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add deleted file"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        test_file.unlink()
+
+        command_start()
+        command_discard_file(file="deleted.txt")
+
+        assert test_file.read_text() == "indexed\n"
 
     def test_discard_file_no_changes(self, temp_git_repo, capsys):
         """Test discard-file when no more hunks remain."""
@@ -202,7 +266,7 @@ class TestCommandDiscardFile:
         assert untracked_file.read_text() == original_content
 
     def test_discard_file_marks_all_hunks_as_processed(self, temp_git_repo):
-        """Test that discard-file marks all hunks as processed even after git rm stages deletion."""
+        """Test that discard-file marks every restored hunk as processed."""
         ensure_state_directory_exists()
 
         # Create and commit a file with content that will create multiple hunks
@@ -241,14 +305,14 @@ class TestCommandDiscardFile:
         # Discard the file
         command_discard_file(file="")
 
-        # File should be removed and staged for deletion
-        assert not test_file.exists()
+        # File should be restored without staging a deletion.
+        assert test_file.read_text() == "".join(f"line {i}\n" for i in range(1, 21))
         result = subprocess.run(
             ["git", "diff", "--cached", "--name-status"],
             check=True,
             cwd=temp_git_repo,
             capture_output=True,)
-        assert b"D\tmulti.txt" in result.stdout
+        assert result.stdout == b""
 
         # All hunks should be marked as processed in blocklist
         blocklist_path = get_block_list_file_path()

--- a/tests/commands/test_discard_file_to_batch.py
+++ b/tests/commands/test_discard_file_to_batch.py
@@ -9,6 +9,7 @@ import pytest
 from git_stage_batch.commands.discard import command_discard_to_batch
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.batch.state.lifecycle import create_batch
+from git_stage_batch.batch.state.batch_names import batch_exists
 from git_stage_batch.utils.git_repository import get_git_repository_root_path
 
 
@@ -193,3 +194,60 @@ class TestDiscardFileToBatchRemovesFromWorkingTree:
         assert status_result.stdout.strip() == "", (
             f"Expected clean status, file should not be recreated, got: {status_result.stdout}"
         )
+
+    def test_discard_modified_binary_to_batch_preserves_staged_index(
+        self,
+        temp_git_repo,
+    ):
+        """Binary discard-to should restore from the index rather than HEAD."""
+        binary_file = temp_git_repo / "data.bin"
+        binary_file.write_bytes(b"\x00BASE")
+        subprocess.run(["git", "add", "data.bin"], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Add binary"],
+            check=True,
+            capture_output=True,
+        )
+        binary_file.write_bytes(b"\x00STAGED")
+        subprocess.run(["git", "add", "data.bin"], check=True, capture_output=True)
+        binary_file.write_bytes(b"\x00WORKTREE")
+
+        command_start(quiet=True)
+        command_discard_to_batch("test-batch", file="data.bin", quiet=True)
+
+        assert binary_file.read_bytes() == b"\x00STAGED"
+        index_bytes = subprocess.run(
+            ["git", "show", ":data.bin"],
+            check=True,
+            capture_output=True,
+        ).stdout
+        assert index_bytes == b"\x00STAGED"
+
+    def test_discard_file_to_batch_supports_unborn_head(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        """Discard-to should compare against the empty tree on an unborn branch."""
+        repo = tmp_path / "unborn"
+        repo.mkdir()
+        monkeypatch.chdir(repo)
+        subprocess.run(["git", "init"], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.name", "Test User"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "test@example.com"],
+            check=True,
+            capture_output=True,
+        )
+        new_file = repo / "new.txt"
+        new_file.write_text("new content\n")
+
+        command_start(quiet=True)
+        command_discard_to_batch("test-batch", file="new.txt", quiet=True)
+
+        assert not new_file.exists()
+        assert batch_exists("test-batch")

--- a/tests/commands/test_file_scoped_operations.py
+++ b/tests/commands/test_file_scoped_operations.py
@@ -1142,12 +1142,12 @@ class TestDirectFileOperations:
         # Discard entire file
         command_discard_file(file="")
 
-        # File should be removed from working tree (git rm -f)
-        assert not (repo / "test.txt").exists(), "File should be removed from working tree"
+        # The working tree should be restored from the index.
+        assert (repo / "test.txt").read_text() == "".join(lines)
 
-        # Verify it's staged for deletion
+        # Verify no deletion was staged.
         result = run_git_command(["diff", "--cached", "--name-status"])
-        assert "D\ttest.txt" in result.stdout, "File should be staged for deletion"
+        assert result.stdout == ""
 
     def test_include_file_with_multiple_hunks(self, tmp_path, monkeypatch):
         """Include --file should stage all hunks from a multi-hunk file."""
@@ -1895,12 +1895,12 @@ class TestExplicitFilePath:
         assert line_changes_after.path == "alpha.txt", "Current hunk should still be from alpha.txt"
         assert line_changes_after.lines == line_changes_before.lines, "Current hunk should be unchanged"
 
-        # Verify gamma.txt is removed
-        assert not (multi_file_repo / "gamma.txt").exists()
-
-        # Verify it's staged for deletion
+        # Verify gamma.txt is restored from the index without staging a deletion.
+        assert (multi_file_repo / "gamma.txt").read_text() == (
+            "gamma1\ngamma2\ngamma3\n"
+        )
         result = run_git_command(["diff", "--cached", "--name-status"])
-        assert "D\tgamma.txt" in result.stdout
+        assert "gamma.txt" not in result.stdout
 
         # Verify alpha.txt is still untouched
         alpha_content = (multi_file_repo / "alpha.txt").read_text()
@@ -2040,12 +2040,12 @@ class TestExplicitFilePath:
         # Explicitly discard remove.txt (not the selected file)
         command_discard_file(file="remove.txt")
 
-        # Verify remove.txt is removed
-        assert not (repo / "remove.txt").exists()
-
-        # Verify it's staged for deletion
+        # Verify remove.txt is restored from the index without staging a deletion.
+        assert (repo / "remove.txt").read_text() == "".join(
+            f"r{i}\n" for i in range(1, 101)
+        )
         result = run_git_command(["diff", "--cached", "--name-status"])
-        assert "D\tremove.txt" in result.stdout
+        assert "remove.txt" not in result.stdout
 
         # Verify keep.txt is untouched
         content = (repo / "keep.txt").read_text()
@@ -2097,8 +2097,10 @@ class TestExplicitFilePath:
         # Explicitly discard gamma.txt (not the selected file)
         command_discard_file(file="gamma.txt")
 
-        # Gamma.txt should be removed
-        assert not (multi_file_repo / "gamma.txt").exists(), "gamma.txt should be removed"
+        # Gamma.txt should be restored from the index.
+        assert (multi_file_repo / "gamma.txt").read_text() == (
+            "gamma1\ngamma2\ngamma3\n"
+        )
 
         # Now iterate through remaining hunks - gamma.txt should be masked
         # We should only see alpha.txt and beta.txt hunks

--- a/tests/functional/test_undo.py
+++ b/tests/functional/test_undo.py
@@ -171,10 +171,10 @@ def test_undo_discard_files_restores_entire_multi_file_operation(functional_repo
     git_stage_batch("start")
     git_stage_batch("discard", "--files", "*.txt")
 
-    assert set(_git("diff", "--cached", "--name-only").stdout.splitlines()) == {
-        "alpha.txt",
-        "beta.txt",
-    }
+    assert _git("diff", "--cached", "--name-only").stdout == ""
+    assert _git("diff", "--name-only").stdout == ""
+    assert alpha.read_text() == "alpha\n"
+    assert beta.read_text() == "beta\n"
 
     git_stage_batch("undo")
 


### PR DESCRIPTION
Whole-file discard currently uses forced removal or HEAD-based restoration in several direct and batch-target paths.

That behavior can stage an unintended deletion, erase staged content, fail on unborn repositories, follow symlink targets, or leave dangling new symlinks behind.

This PR restores tracked paths from the index, removes only new paths, uses session comparison bases, writes through symlink-safe helpers, and directs intentional deletion to `git rm`.

It builds on #214 and applies one index-preserving discard contract across direct, batch-source, and discard-to-batch workflows.

Validation completed with `uv run pytest`; all 3,250 tests passed, and Ruff passed across every changed Python file.