### PR TITLE
binary: Refresh identities after content changes

### DIFF
--- a/src/git_stage_batch/core/hashing.py
+++ b/src/git_stage_batch/core/hashing.py
@@ -99,8 +99,12 @@ def compute_binary_file_hash(binary_change: BinaryFileChange) -> str:
     # Use new_path for added files, old_path for deleted files, either for modified
     path = binary_change.path()
 
-    # Hash: "BINARY:" + path + ":" + change_type
-    key = f"BINARY:{path}:{binary_change.change_type}".encode(
+    # Live changes include their baseline/worktree fingerprint so changed bytes
+    # become a new actionable identity during the same review pass.
+    key = (
+        f"BINARY:{path}:{binary_change.change_type}:"
+        f"{binary_change.content_fingerprint or ''}"
+    ).encode(
         "utf-8",
         errors="surrogateescape",
     )

--- a/src/git_stage_batch/core/models.py
+++ b/src/git_stage_batch/core/models.py
@@ -71,6 +71,7 @@ class BinaryFileChange:
     old_path: str
     new_path: str
     change_type: Literal["added", "modified", "deleted"]
+    content_fingerprint: str | None = None
 
     def is_new_file(self) -> bool:
         """Check if this is a newly added binary file."""

--- a/src/git_stage_batch/data/binary_identity.py
+++ b/src/git_stage_batch/data/binary_identity.py
@@ -1,0 +1,47 @@
+"""Content identities for live binary-file changes."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+import hashlib
+
+from ..core.models import BinaryFileChange
+from ..utils.git_command import run_git_command
+
+
+def _object_name(specification: str) -> str:
+    result = run_git_command(
+        ["rev-parse", "--verify", specification],
+        check=False,
+        requires_index_lock=False,
+    )
+    return result.stdout.strip() if result.returncode == 0 else "missing"
+
+
+def _worktree_object_name(file_path: str) -> str:
+    result = run_git_command(
+        ["hash-object", "--no-filters", "--", file_path],
+        check=False,
+        requires_index_lock=False,
+    )
+    return result.stdout.strip() if result.returncode == 0 else "missing"
+
+
+def attach_live_binary_fingerprint(
+    binary_change: BinaryFileChange,
+    *,
+    comparison_base: str | None = None,
+) -> BinaryFileChange:
+    """Attach a baseline/worktree content fingerprint to a live binary change."""
+    file_path = binary_change.path()
+    baseline_specification = (
+        f"{comparison_base}:{binary_change.old_path}"
+        if comparison_base is not None
+        else f":{binary_change.old_path}"
+    )
+    parts = (
+        _object_name(baseline_specification),
+        _worktree_object_name(file_path),
+    )
+    fingerprint = hashlib.sha256("\0".join(parts).encode("ascii")).hexdigest()
+    return replace(binary_change, content_fingerprint=fingerprint)

--- a/src/git_stage_batch/data/change_freshness.py
+++ b/src/git_stage_batch/data/change_freshness.py
@@ -40,6 +40,7 @@ def binary_file_change_is_stale(
         current_change.old_path != binary_change.old_path
         or current_change.new_path != binary_change.new_path
         or current_change.change_type != binary_change.change_type
+        or current_change.content_fingerprint != binary_change.content_fingerprint
     )
 
 

--- a/src/git_stage_batch/data/file_change_display.py
+++ b/src/git_stage_batch/data/file_change_display.py
@@ -14,6 +14,7 @@ from ..core.models import (
     TextFileDeletionChange,
 )
 from .file_tracking import auto_add_untracked_files
+from .binary_identity import attach_live_binary_fingerprint
 from .live_diff import stream_live_git_diff
 
 
@@ -50,7 +51,10 @@ def render_binary_file_change(
         ) as patches:
             for item in patches:
                 if isinstance(item, BinaryFileChange):
-                    return item
+                    return attach_live_binary_fingerprint(
+                        item,
+                        comparison_base=base,
+                    )
     except subprocess.CalledProcessError:
         return None
     return None

--- a/src/git_stage_batch/data/live_change_candidates.py
+++ b/src/git_stage_batch/data/live_change_candidates.py
@@ -37,6 +37,7 @@ from ..utils.paths import (
     get_context_lines,
 )
 from .change_freshness import text_deletion_change_is_batched
+from .binary_identity import attach_live_binary_fingerprint
 from .live_diff import stream_live_git_diff
 from .selected_change.hunk_filtering import filter_line_level_change_for_batches
 
@@ -119,8 +120,8 @@ def prepare_live_change(
         stable_hash = compute_gitlink_change_hash(item)
         change = item
     elif isinstance(item, BinaryFileChange):
-        stable_hash = compute_binary_file_hash(item)
-        change = item
+        change = attach_live_binary_fingerprint(item)
+        stable_hash = compute_binary_file_hash(change)
     elif isinstance(item, SingleHunkPatch):
         if item.old_path != item.new_path:
             rename_hash = compute_rename_change_hash(

--- a/src/git_stage_batch/data/selected_change/file_changes.py
+++ b/src/git_stage_batch/data/selected_change/file_changes.py
@@ -70,6 +70,7 @@ def load_selected_binary_file() -> BinaryFileChange | None:
             old_path=binary_data["old_path"],
             new_path=binary_data["new_path"],
             change_type=binary_data["change_type"],
+            content_fingerprint=binary_data.get("content_fingerprint"),
         )
     except KeyError:
         return None
@@ -216,6 +217,7 @@ def cache_binary_file_change(
         "old_path": binary_change.old_path,
         "new_path": binary_change.new_path,
         "change_type": binary_change.change_type,
+        "content_fingerprint": binary_change.content_fingerprint,
         "batch_name": batch_name if kind == SelectedChangeKind.BATCH_BINARY else None,
         "batch_binary_fingerprint": (
             batch_binary_fingerprint

--- a/tests/commands/test_binary_files.py
+++ b/tests/commands/test_binary_files.py
@@ -374,6 +374,27 @@ def test_binary_file_skip(binary_file_repo: Path, monkeypatch: pytest.MonkeyPatc
     assert "A  new_image.png" not in status_result.stdout  # Not fully staged
 
 
+def test_changed_binary_bytes_receive_a_new_live_identity(
+    binary_file_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A skipped binary should reappear when its worktree bytes change again."""
+    monkeypatch.chdir(binary_file_repo)
+    binary_path = binary_file_repo / "image.png"
+    binary_path.write_bytes(b"\x00FIRST")
+
+    initialize_abort_state()
+    first_change = fetch_next_change()
+    assert isinstance(first_change, BinaryFileChange)
+    command_skip(quiet=True, auto_advance=False)
+
+    binary_path.write_bytes(b"\x00SECOND")
+    second_change = fetch_next_change()
+
+    assert isinstance(second_change, BinaryFileChange)
+    assert second_change.path() == "image.png"
+
+
 def test_unstaged_binary_selection_freshness_uses_index_base(
     binary_file_repo: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Binary selections use stable identities so skip and discard decisions remain tied to the reviewed change.

A path-and-type identity remains unchanged when users replace the bytes of a binary file. The new content can therefore stay blocked even though it has never been reviewed.

This PR fingerprints the comparison object and worktree object, carries that identity through cached selection and freshness state, and proves changed bytes return for review after an earlier version was skipped.

Tests: `uv run pytest -n auto -q` (3,266 passed)
