### PR TITLE
selection: Keep actions aligned with reviewed changes

### DIFF
--- a/src/git_stage_batch/commands/file_scope/discard_file.py
+++ b/src/git_stage_batch/commands/file_scope/discard_file.py
@@ -37,6 +37,7 @@ from ...utils.git_repository import get_git_repository_root_path
 from ...utils.git_worktree import git_checkout_index_paths
 from ...utils.paths import get_block_list_file_path, get_context_lines
 from ..selection.action_completion import finish_selected_change_action
+from .target_path import checkpoint_paths_for_live_file
 from ..selection.selected_change_discarding import (
     discard_gitlink_change,
     discard_rename_change,
@@ -111,9 +112,10 @@ def discard_file_changes(
         target_file = file
 
     auto_add_untracked_files([target_file])
+    checkpoint_paths = checkpoint_paths_for_live_file(target_file)
     with undo_checkpoint(
         f"discard --file {file}".rstrip(),
-        worktree_paths=[target_file],
+        worktree_paths=checkpoint_paths,
     ):
         blocklist_path = get_block_list_file_path()
         blocked_hashes = read_text_file_line_set(blocklist_path)

--- a/src/git_stage_batch/commands/file_scope/include_file.py
+++ b/src/git_stage_batch/commands/file_scope/include_file.py
@@ -32,6 +32,7 @@ from ...utils.git_index import (
 )
 from ..selection import selected_change_staging as _selected_change_staging
 from ..selection.action_completion import finish_selected_change_action
+from .target_path import checkpoint_paths_for_live_file
 
 
 @contextmanager
@@ -79,9 +80,10 @@ def include_file_changes(
         target_file = file
 
     auto_add_untracked_files([target_file])
+    checkpoint_paths = checkpoint_paths_for_live_file(target_file)
     with undo_checkpoint(
         f"include --file {file}".rstrip(),
-        worktree_paths=[target_file],
+        worktree_paths=checkpoint_paths,
     ):
         hunks_staged = 0
         submodule_pointers_staged = 0

--- a/src/git_stage_batch/commands/file_scope/include_file.py
+++ b/src/git_stage_batch/commands/file_scope/include_file.py
@@ -6,7 +6,6 @@ from contextlib import contextmanager
 import sys
 from typing import Iterator
 
-from ...core.buffer import LineBuffer
 from ...core.diff_parser import acquire_unified_diff, patch_is_file_deletion
 from ...core.hashing import (
     compute_binary_file_hash,
@@ -24,7 +23,6 @@ from ...data.selected_change.paths import get_selected_change_file_path
 from ...data.undo_checkpoints import undo_checkpoint
 from ...exceptions import exit_with_error
 from ...i18n import _, ngettext
-from ...staging.index_update import update_index_with_blob_buffer
 from ...utils.git_command import run_git_command
 from ...utils.git_index import (
     git_add_paths,
@@ -191,8 +189,7 @@ def include_file_changes(
                     continue
 
                 if patch_is_file_deletion(patch.lines):
-                    with LineBuffer.from_bytes(b"") as empty_buffer:
-                        update_index_with_blob_buffer(target_file, empty_buffer)
+                    _selected_change_staging.stage_text_file_deletion(target_file)
                     apply_result = None
                 else:
                     apply_result = git_apply_to_index(patch.lines, check=False)

--- a/src/git_stage_batch/commands/file_scope/target_path.py
+++ b/src/git_stage_batch/commands/file_scope/target_path.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from ...core.diff_parser import acquire_unified_diff
+from ...core.models import RenameChange
+from ...data.live_diff import stream_live_git_diff
 from ...data.selected_change.paths import (
     SelectedChange,
     get_selected_change_file_path,
@@ -33,3 +36,21 @@ def checkpoint_paths_for_file_scope(
         return worktree_paths_for_selected_change(selected_change)
     target_file = get_selected_change_file_path()
     return [target_file] if target_file is not None else []
+
+
+def checkpoint_paths_for_live_file(target_file: str) -> list[str]:
+    """Return every path a live whole-file action may mutate."""
+    with acquire_unified_diff(
+        stream_live_git_diff(
+            full_index=True,
+            ignore_submodules="none",
+            submodule_format="short",
+        )
+    ) as patches:
+        for patch in patches:
+            if isinstance(patch, RenameChange) and target_file in (
+                patch.old_path,
+                patch.new_path,
+            ):
+                return [patch.old_path, patch.new_path]
+    return [target_file]

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -10,6 +10,8 @@ from ..data.selected_change.store import (
     SelectedChangeKind,
     read_selected_change_kind,
 )
+from ..data.line_id_files import read_line_ids_file
+from ..data.line_state import load_line_changes_from_state
 from ..data.selected_change.clear_reasons import (
     refuse_bare_action_after_auto_advance_disabled,
     refuse_bare_action_after_file_list,
@@ -28,6 +30,7 @@ from ..utils.git_repository import require_git_repository
 from ..utils.journal import log_journal
 from ..utils.paths import (
     ensure_state_directory_exists,
+    get_processed_skip_ids_file_path,
 )
 from .selection import include_to_batch_action as _include_to_batch_action
 from .selection import include_line_action as _include_line_action
@@ -62,6 +65,21 @@ def command_include(
     if read_selected_change_kind() == SelectedChangeKind.FILE:
         command_include_file("", auto_advance=auto_advance)
         return 0
+
+    if read_selected_change_kind() == SelectedChangeKind.HUNK:
+        skipped_ids = read_line_ids_file(get_processed_skip_ids_file_path())
+        line_changes = load_line_changes_from_state()
+        if skipped_ids and line_changes is not None:
+            remaining_ids = line_changes.changed_line_ids()
+            if remaining_ids:
+                _include_line_action.include_live_line_selection(
+                    ",".join(str(line_id) for line_id in remaining_ids),
+                    review_state=None,
+                    auto_advance=auto_advance,
+                    quiet=quiet,
+                    operation="include",
+                )
+                return 0
 
     return _selected_change_staging.include_selected_change(
         quiet=quiet,

--- a/src/git_stage_batch/commands/selection/include_line_action.py
+++ b/src/git_stage_batch/commands/selection/include_line_action.py
@@ -38,6 +38,8 @@ def include_live_line_selection(
     *,
     review_state,
     auto_advance: bool | None = None,
+    quiet: bool = False,
+    operation: str | None = None,
 ) -> None:
     """Stage selected lines from the live working-tree view."""
     operation_parts = ["include", "--line", line_id_specification]
@@ -47,7 +49,7 @@ def include_live_line_selection(
     target_file = file if file not in (None, "") else get_selected_change_file_path()
     with (
         undo_checkpoint(
-            " ".join(operation_parts),
+            operation or " ".join(operation_parts),
             worktree_paths=[target_file] if target_file is not None else [],
         ),
         ExitStack() as selected_state_stack,
@@ -173,19 +175,20 @@ def include_live_line_selection(
                 get_processed_include_ids_file_path(),
                 combined_include_ids,
             )
-            print(
-                _("✓ Included line(s): {lines} from {file}").format(
-                    lines=line_id_specification,
-                    file=line_changes.path,
-                ),
-                file=sys.stderr,
-            )
+            if not quiet:
+                print(
+                    _("✓ Included line(s): {lines} from {file}").format(
+                        lines=line_id_specification,
+                        file=line_changes.path,
+                    ),
+                    file=sys.stderr,
+                )
             refresh_selected_hunk_after_line_action(
                 line_changes.path,
                 auto_advance=auto_advance,
             )
         finish_review_scoped_line_action(review_state, file_path=line_changes.path)
-    if selection_context.preserve_selected_state:
+    if selection_context.preserve_selected_state and not quiet:
         print(
             _("✓ Included line(s): {lines} from {file}").format(
                 lines=line_id_specification,

--- a/src/git_stage_batch/commands/selection/selected_change_discarding.py
+++ b/src/git_stage_batch/commands/selection/selected_change_discarding.py
@@ -26,7 +26,7 @@ from ...data.session import (
 )
 from ...data.file_modes import apply_git_file_mode
 from ...data.undo_checkpoints import undo_checkpoint
-from ...exceptions import CommandError, NoMoreHunks, exit_with_error
+from ...exceptions import NoMoreHunks, exit_with_error
 from ...i18n import _
 from ...utils.file_io import append_lines_to_file, path_is_empty, read_text_file_contents
 from ...utils.git_command import run_git_command
@@ -51,16 +51,7 @@ def discard_selected_change(
     auto_advance: bool | None = None,
 ) -> None:
     """Discard the currently selected change from the working tree."""
-    try:
-        item = load_selected_change()
-    except CommandError as error:
-        stale_message = _(
-            "Cached hunk is stale (file was changed). Run 'start' or 'again' to continue."
-        )
-        if error.message == stale_message:
-            item = None
-        else:
-            raise
+    item = load_selected_change()
 
     if item is None:
         try:

--- a/src/git_stage_batch/commands/selection/selected_change_discarding.py
+++ b/src/git_stage_batch/commands/selection/selected_change_discarding.py
@@ -277,9 +277,9 @@ def _discard_text_hunk(
 
     if is_new_file:
         absolute_path = get_git_repository_root_path() / file_path
-        if absolute_path.exists() and path_is_empty(absolute_path):
+        if os.path.lexists(absolute_path) and path_is_empty(absolute_path):
             absolute_path.unlink()
-            _drop_intent_to_add_entry(file_path)
+        _drop_intent_to_add_entry(file_path)
 
     append_lines_to_file(get_block_list_file_path(), [patch_hash])
     record_hunk_discarded(patch_hash)

--- a/src/git_stage_batch/commands/selection/selected_change_staging.py
+++ b/src/git_stage_batch/commands/selection/selected_change_staging.py
@@ -22,7 +22,6 @@ from ...data.selected_change.paths import worktree_paths_for_selected_change
 from ...data.undo_checkpoints import undo_checkpoint
 from ...exceptions import NoMoreHunks, exit_with_error
 from ...i18n import _
-from ...staging.index_update import update_index_with_blob_buffer
 from ...utils.file_io import read_text_file_contents
 from ...utils.git_index import (
     GitIndexEntryUpdate,
@@ -180,8 +179,7 @@ def _include_loaded_selected_change(
 
     with LineBuffer.from_path(get_selected_hunk_patch_file_path()) as patch_buffer:
         if patch_is_file_deletion(patch_buffer):
-            with LineBuffer.from_bytes(b"") as empty_buffer:
-                update_index_with_blob_buffer(file_path, empty_buffer)
+            stage_text_file_deletion(file_path)
             apply_result = None
         else:
             apply_result = git_apply_to_index(
@@ -264,15 +262,20 @@ def stage_rename_change(rename_change: RenameChange) -> None:
 
 def stage_text_deletion_change(deletion_change: TextFileDeletionChange) -> None:
     """Stage a whole-text-file deletion in the index."""
+    stage_text_file_deletion(deletion_change.path())
+
+
+def stage_text_file_deletion(file_path: str) -> None:
+    """Stage deletion of one text path regardless of its previous contents."""
     result = git_update_index(
-        file_path=deletion_change.path(),
+        file_path=file_path,
         force_remove=True,
         check=False,
     )
     if result.returncode != 0:
         exit_with_error(
             _("Failed to stage deletion for {file}: {error}").format(
-                file=deletion_change.path(),
+                file=file_path,
                 error=result.stderr,
             )
         )

--- a/src/git_stage_batch/staging/content_buffers.py
+++ b/src/git_stage_batch/staging/content_buffers.py
@@ -40,6 +40,14 @@ def _line_content_at(lines: Sequence[bytes], index: int) -> bytes:
     )
 
 
+def _working_tree_line_content_at(
+    lines: Sequence[bytes],
+    index: int,
+) -> bytes:
+    """Return exact worktree bytes so untouched lines retain their endings."""
+    return lines[index]
+
+
 def _line_payloads(
     lines: Sequence[bytes],
     start: int,
@@ -372,7 +380,7 @@ def _target_working_tree_line_contents(
     def copy_unchanged_lines_until_index(target_index: int) -> Iterator[bytes]:
         nonlocal working_pointer
         while working_pointer < min(target_index, working_line_count):
-            yield _line_content_at(working_lines, working_pointer)
+            yield _working_tree_line_content_at(working_lines, working_pointer)
             working_pointer += 1
 
     def copy_remaining_lines_before_deletion(index: int) -> Iterator[bytes]:
@@ -394,7 +402,7 @@ def _target_working_tree_line_contents(
                 return
 
     for index in range(0, min(working_pointer, working_line_count)):
-        yield _line_content_at(working_lines, index)
+        yield _working_tree_line_content_at(working_lines, index)
 
     for index, line_entry in enumerate(line_changes.lines):
         if _is_synthetic_gap_line(line_entry):
@@ -403,7 +411,7 @@ def _target_working_tree_line_contents(
         if line_entry.kind == " ":
             yield from copy_unchanged_lines_before(line_entry.new_line_number)
             if working_pointer < working_line_count:
-                yield _line_content_at(working_lines, working_pointer)
+                yield _working_tree_line_content_at(working_lines, working_pointer)
                 working_pointer += 1
         elif line_entry.kind == "-":
             if line_entry.id in discard_ids:
@@ -415,11 +423,11 @@ def _target_working_tree_line_contents(
                 if line_entry.id in discard_ids:
                     working_pointer += 1
                 else:
-                    yield _line_content_at(working_lines, working_pointer)
+                    yield _working_tree_line_content_at(working_lines, working_pointer)
                     working_pointer += 1
 
     while 0 <= working_pointer < working_line_count:
-        yield _line_content_at(working_lines, working_pointer)
+        yield _working_tree_line_content_at(working_lines, working_pointer)
         working_pointer += 1
 
 

--- a/tests/commands/test_abort.py
+++ b/tests/commands/test_abort.py
@@ -5,6 +5,7 @@ import subprocess
 import pytest
 
 from git_stage_batch.commands.abort import command_abort
+from git_stage_batch.commands.again import command_again
 from git_stage_batch.commands.discard import command_discard
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.exceptions import CommandError
@@ -53,6 +54,7 @@ class TestCommandAbort:
 
         # Make more changes and discard them
         readme.write_text("# Test\nAnother change\n")
+        command_again()
         command_discard()
 
         # File should be back to original committed state

--- a/tests/commands/test_discard.py
+++ b/tests/commands/test_discard.py
@@ -27,7 +27,7 @@ import pytest
 import git_stage_batch.commands.selection.selected_change_discarding as selected_change_discarding
 import git_stage_batch.commands.selection.selected_change_batch_discarding as selected_change_batch_discarding
 from git_stage_batch.commands.discard import command_discard, command_discard_line, command_discard_line_as_to_batch
-from git_stage_batch.commands.include import command_include
+from git_stage_batch.commands.include import command_include, command_include_line
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.core.models import TextFileDeletionChange
 from git_stage_batch.exceptions import CommandError
@@ -122,6 +122,61 @@ class TestCommandDiscard:
             command_discard(quiet=True)
 
         assert test_file.read_text() == "base\nselected\n"
+
+    def test_discard_refuses_a_stale_selected_hunk(self, temp_git_repo):
+        """Pathless discard must not replace a stale selection and act on it."""
+        readme = temp_git_repo / "README.md"
+        readme.write_text("first displayed change\n")
+        command_start(quiet=True)
+        readme.write_text("later unseen change\n")
+
+        with pytest.raises(CommandError, match="Cached hunk is stale"):
+            command_discard(quiet=True, auto_advance=False)
+
+        assert readme.read_text() == "later unseen change\n"
+
+    def test_discard_full_new_file_hunk_removes_intent_to_add(
+        self,
+        temp_git_repo,
+    ):
+        """Discarding a complete new file should not leave a ghost ITA entry."""
+        new_file = temp_git_repo / "new.txt"
+        new_file.write_text("new content\n")
+
+        command_start(quiet=True)
+        command_discard(quiet=True, auto_advance=False)
+
+        assert not new_file.exists()
+        assert subprocess.run(
+            ["git", "ls-files", "--stage", "--", "new.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+            text=True,
+        ).stdout == ""
+
+    def test_discard_line_preserves_unselected_crlf_endings(self, temp_git_repo):
+        """Line discard should not normalize untouched CRLF lines to LF."""
+        target = temp_git_repo / "crlf.txt"
+        target.write_bytes(b"old\r\nkeep\r\n")
+        subprocess.run(
+            ["git", "add", "crlf.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add CRLF file"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        target.write_bytes(b"new\r\nkeep\r\n")
+
+        command_start(quiet=True)
+        command_discard_line("1-2", auto_advance=False)
+
+        assert target.read_bytes() == b"old\r\nkeep\r\n"
 
     def test_failed_discard_to_batch_rolls_back_batch_and_progress(
         self,
@@ -584,7 +639,7 @@ class TestCommandDiscardLine:
         test_file.unlink()
 
         command_start(quiet=True)
-        command_include(quiet=True)
+        command_include_line("1")
 
         selected_change = load_selected_change()
         assert isinstance(selected_change, TextFileDeletionChange)

--- a/tests/commands/test_include.py
+++ b/tests/commands/test_include.py
@@ -10,6 +10,7 @@ from git_stage_batch.batch.state.query import get_batch_commit_sha, read_batch_m
 from git_stage_batch.batch.state.batch_names import batch_exists
 from git_stage_batch.commands.include import (
     command_include,
+    command_include_file,
     command_include_line,
     command_include_line_as,
     command_include_to_batch,
@@ -19,6 +20,7 @@ from git_stage_batch.commands.selection.replacement_selection import (
     derive_replacement_line_runs,
 )
 from git_stage_batch.commands.start import command_start
+from git_stage_batch.commands.skip import command_skip_line
 from git_stage_batch.commands.show import command_show
 from git_stage_batch.core.models import TextFileDeletionChange
 from git_stage_batch.data.hunk_tracking import (
@@ -46,6 +48,16 @@ def _prepare_single_line_change(repo, file_name="test.txt"):
     command_start()
     fetch_next_change()
     return test_file
+
+
+def _show_index_file(repo, file_name: str) -> str:
+    return subprocess.run(
+        ["git", "show", f":{file_name}"],
+        check=True,
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    ).stdout
 
 
 @pytest.fixture
@@ -100,6 +112,83 @@ class TestCommandInclude:
 
         captured = capsys.readouterr()
         assert "Hunk staged" in captured.err
+
+    def test_bare_include_respects_partially_skipped_lines(self, temp_git_repo):
+        """Bare include should stage only the lines left visible after a skip."""
+        new_file = temp_git_repo / "new.txt"
+        new_file.write_text("skip me\ninclude me\n")
+
+        command_start(quiet=True)
+        command_skip_line("1", auto_advance=False)
+        command_include(quiet=True, auto_advance=False)
+
+        assert _show_index_file(temp_git_repo, "new.txt") == "include me\n"
+        assert new_file.read_text() == "skip me\ninclude me\n"
+
+    def test_include_stages_contentful_file_deletion(self, temp_git_repo):
+        """Bare include should stage a deletion rather than an empty blob."""
+        deleted = temp_git_repo / "deleted.txt"
+        deleted.write_text("content\n")
+        subprocess.run(
+            ["git", "add", "deleted.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add deleted file"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        deleted.unlink()
+
+        command_start(quiet=True)
+        command_include(quiet=True, auto_advance=False)
+
+        assert subprocess.run(
+            ["git", "status", "--short", "--", "deleted.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+            text=True,
+        ).stdout == "D  deleted.txt\n"
+        assert subprocess.run(
+            ["git", "ls-files", "--stage", "--", "deleted.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+            text=True,
+        ).stdout == ""
+
+    def test_include_file_stages_contentful_file_deletion(self, temp_git_repo):
+        """Whole-file include should stage a deletion in one operation."""
+        deleted = temp_git_repo / "deleted.txt"
+        deleted.write_text("content\n")
+        subprocess.run(
+            ["git", "add", "deleted.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add deleted file"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        deleted.unlink()
+
+        command_start(quiet=True)
+        command_include_file("deleted.txt", quiet=True, advance=False)
+
+        assert subprocess.run(
+            ["git", "status", "--short", "--", "deleted.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+            text=True,
+        ).stdout == "D  deleted.txt\n"
 
     def test_include_raises_when_git_rejects_hunk(self, temp_git_repo, monkeypatch):
         """A failed index update should fail the include command."""

--- a/tests/commands/test_start_time_changes.py
+++ b/tests/commands/test_start_time_changes.py
@@ -11,7 +11,7 @@ from git_stage_batch.commands.discard import command_discard
 from git_stage_batch.commands.selection.selected_change_display import show_selected_change
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.commands.stop import command_stop
-from git_stage_batch.core.models import LineLevelChange, RenameChange, TextFileDeletionChange
+from git_stage_batch.core.models import LineLevelChange, RenameChange
 from git_stage_batch.data.selected_change.loading import load_selected_change
 from git_stage_batch.exceptions import CommandError
 from git_stage_batch.utils.paths import get_staged_deletions_file_path, get_staged_renames_file_path
@@ -134,22 +134,14 @@ def test_start_exposes_staged_deletion_as_deleted_line_selection(rename_repo):
     assert {line.kind for line in selected_change.lines if line.id is not None} == {"-"}
 
 
-def test_include_staged_deletion_lines_then_path_removal(rename_repo):
+def test_include_staged_deletion_removes_path_in_one_action(rename_repo):
     _stage_deletion(rename_repo)
 
     command_start(quiet=True)
     command_include(quiet=True)
 
-    assert _cached_name_status(rename_repo).strip() == "M\told.txt"
-    assert _index_content(rename_repo, "old.txt") == ""
-    assert _uncached_name_status(rename_repo).strip() == "D\told.txt"
-    selected_change = load_selected_change()
-    assert isinstance(selected_change, TextFileDeletionChange)
-    assert selected_change.path() == "old.txt"
-
-    command_include(quiet=True)
-
     assert _cached_name_status(rename_repo).strip() == "D\told.txt"
+    assert _uncached_name_status(rename_repo) == ""
 
 
 def test_include_selected_rename_stages_rename_only_and_leaves_edits_unstaged(rename_repo):

--- a/tests/commands/test_undo.py
+++ b/tests/commands/test_undo.py
@@ -5,7 +5,8 @@ import subprocess
 
 import pytest
 
-from git_stage_batch.commands.include import command_include_line
+from git_stage_batch.commands.include import command_include_file, command_include_line
+from git_stage_batch.commands.discard import command_discard_file
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.commands.undo import command_undo
 from git_stage_batch.data.undo_checkpoints import (
@@ -14,6 +15,7 @@ from git_stage_batch.data.undo_checkpoints import (
     undo_last_checkpoint,
 )
 from git_stage_batch.data.undo_refs import current_undo_commit
+from git_stage_batch.data.session import path_is_intent_to_add
 from git_stage_batch.exceptions import CommandError
 from git_stage_batch.utils.paths import (
     get_batches_directory_path,
@@ -182,6 +184,38 @@ def test_scoped_undo_preserves_unrelated_index_changes(temp_git_repo):
     ).stdout.splitlines()
     assert staged_paths == ["unrelated.txt"]
     assert target.read_text() == "target staged\n"
+
+
+def test_undo_file_include_restores_both_rename_paths(temp_git_repo):
+    """Undoing file-scoped rename staging should restore both index entries."""
+    old_path = _commit_text_file(temp_git_repo, "old.txt", "rename content\n")
+    new_path = temp_git_repo / "new.txt"
+    old_path.rename(new_path)
+
+    command_start(quiet=True)
+    command_include_file("new.txt", quiet=True, advance=False)
+    command_undo(force=True)
+
+    assert not old_path.exists()
+    assert new_path.read_text() == "rename content\n"
+    assert _show_index_path(temp_git_repo, "old.txt") == b"rename content\n"
+    assert path_is_intent_to_add("new.txt")
+
+
+def test_undo_file_discard_restores_both_rename_paths(temp_git_repo):
+    """Undoing file-scoped rename discard should restore both worktree paths."""
+    old_path = _commit_text_file(temp_git_repo, "old.txt", "rename content\n")
+    new_path = temp_git_repo / "new.txt"
+    old_path.rename(new_path)
+
+    command_start(quiet=True)
+    command_discard_file("new.txt", auto_advance=False)
+    command_undo(force=True)
+
+    assert not old_path.exists()
+    assert new_path.read_text() == "rename content\n"
+    assert _show_index_path(temp_git_repo, "old.txt") == b"rename content\n"
+    assert path_is_intent_to_add("new.txt")
 
 
 def test_failed_operation_keeps_partial_mutation_undoable(temp_git_repo):

--- a/tests/staging/test_content_buffers.py
+++ b/tests/staging/test_content_buffers.py
@@ -1022,7 +1022,7 @@ class TestBuildTargetWorkingTreeContent:
             working_lines,
         )
 
-        assert result == b"line1\nline2\n"
+        assert result == b"line1\r\nline2\r\n"
 
     def test_working_tree_discard_can_return_buffer(self, line_sequence):
         """Working-tree discard can return a buffer for streaming callers."""
@@ -1042,7 +1042,7 @@ class TestBuildTargetWorkingTreeContent:
             working_has_trailing_newline=True,
         ) as result:
             assert isinstance(result, LineBuffer)
-            assert result.to_bytes() == b"line1\nline2\n"
+            assert result.to_bytes() == b"line1\r\nline2\r\n"
 
     def test_file_scoped_deletion_uses_prior_change_delta(self):
         """File-scoped deletions should keep anchors after prior hunks."""


### PR DESCRIPTION
Live include and discard actions operate on selected hunks, file scopes, and line-level review state.

Several edge paths can act outside that reviewed state: contentful deletions pass through empty blobs, rename undo records one path, stale discard discovers a replacement selection, partial skip is ignored by bare include, and worktree reconstruction normalizes untouched CRLF lines.

This PR makes each action honor the displayed path, line set, and byte representation. It also removes obsolete intent entries after a new file is discarded and adds direct command and buffer regressions for the corrected contracts.

Tests: `uv run pytest -n auto -q` (3,266 passed)
