### PR TITLE
undo: Restore exact checkpoint state

### DIFF
--- a/src/git_stage_batch/data/selected_change/store.py
+++ b/src/git_stage_batch/data/selected_change/store.py
@@ -24,6 +24,7 @@ from ...utils.paths import (
     get_line_changes_json_file_path,
     get_processed_include_ids_file_path,
     get_processed_skip_ids_file_path,
+    get_snapshot_metadata_file_path,
     get_selected_binary_file_json_path,
     get_selected_change_clear_reason_file_path,
     get_selected_change_kind_file_path,
@@ -121,6 +122,7 @@ def _selected_change_state_paths():
         "mode": get_selected_mode_change_json_path(),
         "index_snapshot": get_index_snapshot_file_path(),
         "working_snapshot": get_working_tree_snapshot_file_path(),
+        "snapshot_metadata": get_snapshot_metadata_file_path(),
         "processed_include_ids": get_processed_include_ids_file_path(),
         "processed_skip_ids": get_processed_skip_ids_file_path(),
     }

--- a/src/git_stage_batch/data/session.py
+++ b/src/git_stage_batch/data/session.py
@@ -36,6 +36,7 @@ from ..utils.paths import (
     get_abort_snapshots_directory_path,
     get_abort_stash_file_path,
     get_abort_recovery_anchors_file_path,
+    get_auto_added_files_file_path,
     get_iteration_count_file_path,
     get_state_directory_path,
 )
@@ -121,7 +122,7 @@ def _diff_index_name_status(*, intent_to_add_visible: bool) -> dict[str, str]:
     }
 
 
-def _intent_to_add_files(file_paths: list[str] | None = None) -> list[str]:
+def intent_to_add_files(file_paths: list[str] | None = None) -> list[str]:
     """Return paths whose cached status changes with Git's intent visibility."""
     visible_statuses = _diff_index_name_status(intent_to_add_visible=True)
     invisible_statuses = _diff_index_name_status(intent_to_add_visible=False)
@@ -137,9 +138,18 @@ def _intent_to_add_files(file_paths: list[str] | None = None) -> list[str]:
     return [file_path for file_path in intent_paths if file_path in selected]
 
 
+def auto_added_files(file_paths: list[str] | None = None) -> list[str]:
+    """Return session-tracked auto-added paths, optionally within a scope."""
+    paths = read_file_paths_file(get_auto_added_files_file_path())
+    if file_paths is None:
+        return paths
+    selected = set(file_paths)
+    return [file_path for file_path in paths if file_path in selected]
+
+
 def path_is_intent_to_add(file_path: str) -> bool:
     """Return whether one path is represented by an intent-to-add entry."""
-    return bool(_intent_to_add_files([file_path]))
+    return bool(intent_to_add_files([file_path]))
 
 
 def _snapshot_intent_to_add_files() -> tuple[list[str], list[str]]:
@@ -154,7 +164,7 @@ def _snapshot_intent_to_add_files() -> tuple[list[str], list[str]]:
         - all_intent_to_add_files: All files with intent-to-add
         - new_intent_to_add_files: Only files absent from HEAD
     """
-    all_intent_to_add_files = _intent_to_add_files()
+    all_intent_to_add_files = intent_to_add_files()
     new_intent_to_add_files = []
 
     for file_path in all_intent_to_add_files:
@@ -404,7 +414,7 @@ def snapshot_files_if_untracked(file_paths: list[str]) -> None:
     if not unique_file_paths:
         return
 
-    intent_to_add_paths = set(_intent_to_add_files(unique_file_paths))
+    intent_to_add_paths = set(intent_to_add_files(unique_file_paths))
     stage_result = run_git_command(
         ["ls-files", "--stage", "-z", "--", *unique_file_paths],
         check=False,

--- a/src/git_stage_batch/data/undo_checkpoints.py
+++ b/src/git_stage_batch/data/undo_checkpoints.py
@@ -44,6 +44,7 @@ from ..utils.git_index import (
     temp_git_index,
 )
 from .index_entries import read_index_entries
+from .session import auto_added_files, intent_to_add_files
 from ..utils.git_repository import get_git_repository_root_path
 from ..utils.git_object_io import create_git_blob, create_git_blobs_from_paths
 from ..utils.paths import (
@@ -88,8 +89,22 @@ def _snapshot_current_state(
             for path, entry in sorted(index_entries.items())
         },
         "refs": refs,
+        "intent_to_add_paths": intent_to_add_files(index_paths),
         "worktree_paths": _undo_worktree.snapshot_worktree_paths(worktree_paths),
     }
+
+
+def _restore_intent_to_add_state(state: dict[str, Any]) -> None:
+    """Restore scoped ITA flags, with a narrow legacy-checkpoint fallback."""
+    saved_paths = state.get("intent_to_add_paths")
+    if isinstance(saved_paths, list):
+        paths = [path for path in saved_paths if isinstance(path, str)]
+    else:
+        scoped_paths = set(
+            state.get("tracked_index_paths", state.get("tracked_worktree_paths", []))
+        )
+        paths = auto_added_files(list(scoped_paths))
+    _undo_restore.restore_intent_to_add_entries(paths)
 
 
 def _add_blob_to_index(env: dict[str, str], path: str, data: bytes, mode: str = "100644") -> None:
@@ -190,6 +205,7 @@ def _create_undo_checkpoint(
         "operation": operation,
         "head": current_head_commit(),
         "index_entries": before["index_entries"],
+        "intent_to_add_paths": before["intent_to_add_paths"],
         "refs": before["refs"],
         "worktree_paths": [
             {key: value for key, value in entry.items() if key != "blob"}
@@ -210,7 +226,7 @@ def _create_undo_checkpoint(
             [
                 GitIndexEntryUpdate(
                     file_path=f"worktree/{entry['path']}",
-                    mode=entry["mode"],
+                    mode=entry.get("storage_mode", entry["mode"]),
                     blob_sha=entry["blob"],
                 )
                 for entry in before["worktree_paths"]
@@ -311,7 +327,7 @@ def _rollback_failed_checkpoint(
     _undo_restore.restore_refs(manifest.get("refs", {}))
     _restore_index_state(manifest)
     _undo_restore.restore_worktree(checkpoint, manifest)
-    _undo_restore.restore_intent_to_add_entries()
+    _restore_intent_to_add_state(manifest)
 
     parent = checkpoint_parent(checkpoint)
     updates: list[tuple[str, str]] = []
@@ -463,6 +479,30 @@ def _detect_conflicts_against_state(expected_state: dict[str, Any]) -> list[str]
         if actual != expected:
             conflicts.append(path)
 
+    for prefix, source_dir, label in (
+        ("session", get_session_directory_path(), _("session state")),
+        ("batches", get_batches_directory_path(), _("batch metadata")),
+    ):
+        tracked_paths = expected_state.get(f"tracked_{prefix}_paths")
+        expected_files = expected_state.get(f"{prefix}_files")
+        if isinstance(tracked_paths, list) and isinstance(expected_files, dict):
+            conflict_paths = [
+                path
+                for path in tracked_paths
+                if not (prefix == "session" and path.startswith("selected/"))
+            ]
+            current_files = _filesystem_directory_state(
+                source_dir,
+                relative_paths=conflict_paths,
+            )
+            expected_conflict_files = {
+                path: expected_files[path]
+                for path in conflict_paths
+                if path in expected_files
+            }
+            if current_files != expected_conflict_files:
+                conflicts.append(label)
+
     return conflicts
 
 
@@ -607,7 +647,10 @@ def _write_snapshot_commit(
         repo_root = get_git_repository_root_path()
         index_updates: list[GitIndexEntryUpdate] = []
         for entry in worktree_entries:
-            if entry.get("kind") in {"gitlink", "embedded-repo"}:
+            if (
+                entry.get("kind") in {"gitlink", "embedded-repo"}
+                and not entry.get("archive")
+            ):
                 continue
             if not entry.get("exists", False):
                 continue
@@ -616,7 +659,7 @@ def _write_snapshot_commit(
                 index_updates.append(
                     GitIndexEntryUpdate(
                         file_path=f"worktree/{entry['path']}",
-                        mode=entry.get("mode", "100644"),
+                        mode=entry.get("storage_mode", entry.get("mode", "100644")),
                         blob_sha=blob_sha,
                     )
                 )
@@ -670,6 +713,7 @@ def _push_redo_node(
             current_head_commit(),
         ),
         "index_entries": target.get("index_entries", {}),
+        "intent_to_add_paths": target.get("intent_to_add_paths", []),
         "tracked_index_paths": target.get("tracked_index_paths", []),
         "refs": target.get("refs", {}),
         "tracked_refs": target.get("tracked_refs", []),
@@ -751,7 +795,7 @@ def undo_last_checkpoint(*, force: bool = False) -> str:
         _restore_index_state(manifest)
 
         _undo_restore.restore_worktree(checkpoint, manifest)
-        _undo_restore.restore_intent_to_add_entries()
+        _restore_intent_to_add_state(manifest)
 
         after_undo = _snapshot_current_state(
             redo_paths,
@@ -828,7 +872,7 @@ def redo_last_checkpoint(*, force: bool = False) -> str:
     _restore_index_state(manifest)
 
     _undo_restore.restore_worktree(redo_node, manifest)
-    _undo_restore.restore_intent_to_add_entries()
+    _restore_intent_to_add_state(manifest)
 
     undo_checkpoint = manifest.get("undo_checkpoint")
     if undo_checkpoint:

--- a/src/git_stage_batch/data/undo_restore.py
+++ b/src/git_stage_batch/data/undo_restore.py
@@ -6,6 +6,8 @@ import json
 import os
 import shutil
 import stat
+import tarfile
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -17,7 +19,6 @@ from ..utils.repository_buffers import load_git_blob_as_buffer
 from .undo_refs import list_restorable_refs
 from ..exceptions import CommandError
 from ..i18n import _
-from ..utils.file_io import read_file_paths_file
 from ..utils.git_command import (
     run_git_command,
 )
@@ -28,7 +29,6 @@ from ..utils.git_refs import (
 from ..utils.git_worktree import git_checkout_detached
 from ..utils.git_index import git_add_paths, git_update_index
 from ..utils.git_repository import get_git_repository_root_path
-from ..utils.paths import get_auto_added_files_file_path
 
 
 def _read_json_blob(blob_sha: str) -> dict[str, Any]:
@@ -185,6 +185,11 @@ def restore_worktree(commit: str, manifest: dict[str, Any]) -> None:
         if entry.get("kind") == "gitlink":
             worktree_oid = entry.get("worktree_oid")
             if entry.get("exists", False) and worktree_oid:
+                if not target_path.is_dir():
+                    _restore_directory_archive(
+                        target_path,
+                        worktree_blobs.get(file_path),
+                    )
                 result = git_checkout_detached(worktree_oid, cwd=file_path, check=False)
                 if result.returncode != 0:
                     raise CommandError(
@@ -193,25 +198,67 @@ def restore_worktree(commit: str, manifest: dict[str, Any]) -> None:
                             error=result.stderr,
                         )
                     )
+            elif not entry.get("exists", False):
+                _remove_worktree_path(target_path)
             continue
         if entry.get("kind") == "embedded-repo":
+            if entry.get("exists", False):
+                _restore_directory_archive(
+                    target_path,
+                    worktree_blobs.get(file_path),
+                )
+            else:
+                _remove_worktree_path(target_path)
             continue
         if not entry.get("exists", False):
-            if os.path.lexists(target_path):
-                target_path.unlink()
+            _remove_worktree_path(target_path)
             continue
 
         blob_info = worktree_blobs.get(file_path)
         if blob_info is None:
-            continue
+            raise CommandError(
+                _("Undo checkpoint is missing worktree content for {file}").format(
+                    file=file_path,
+                )
+            )
         mode, blob_sha = blob_info
         _write_blob_to_worktree_path(blob_sha, target_path, mode=mode)
 
 
-def restore_intent_to_add_entries() -> None:
-    """Restore intent-to-add markers tracked by the session."""
+def _remove_worktree_path(target_path: Path) -> None:
+    if target_path.is_dir() and not target_path.is_symlink():
+        shutil.rmtree(target_path)
+    elif os.path.lexists(target_path):
+        target_path.unlink()
+
+
+def _restore_directory_archive(
+    target_path: Path,
+    blob_info: tuple[str, str] | None,
+) -> None:
+    """Restore one nested repository from its checkpoint archive."""
+    if blob_info is None:
+        raise CommandError(
+            _("Undo checkpoint is missing nested repository content for {file}").format(
+                file=target_path.name,
+            )
+        )
+    _mode, blob_sha = blob_info
+    _remove_worktree_path(target_path)
+    target_path.mkdir(parents=True)
+    with load_git_blob_as_buffer(blob_sha) as archive_buffer:
+        with tempfile.NamedTemporaryFile() as archive_file:
+            for chunk in archive_buffer.byte_chunks():
+                archive_file.write(chunk)
+            archive_file.flush()
+            with tarfile.open(archive_file.name, mode="r") as archive:
+                archive.extractall(target_path)
+
+
+def restore_intent_to_add_entries(file_paths: list[str]) -> None:
+    """Restore the exact intent-to-add markers saved by one checkpoint."""
     repo_root = get_git_repository_root_path()
-    for file_path in read_file_paths_file(get_auto_added_files_file_path()):
+    for file_path in file_paths:
         full_path = repo_root / file_path
         if os.path.lexists(full_path):
             git_update_index(file_path=file_path, force_remove=True, check=False)

--- a/src/git_stage_batch/data/undo_worktree.py
+++ b/src/git_stage_batch/data/undo_worktree.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import os
 import stat
+import tarfile
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -130,7 +132,7 @@ def _snapshot_gitlink_path(
     head_oid: str | None,
 ) -> dict[str, Any]:
     worktree_oid = _worktree_commit_oid(path)
-    return {
+    entry = {
         "path": path,
         "kind": "gitlink",
         "exists": index_oid is not None or head_oid is not None or worktree_oid is not None,
@@ -141,6 +143,13 @@ def _snapshot_gitlink_path(
         "dirty": _worktree_is_dirty(path) if worktree_oid is not None else False,
         "blob": None,
     }
+    if head_oid is None and worktree_oid is not None:
+        entry["archive"] = True
+        entry["storage_mode"] = "100644"
+        entry["blob"] = _create_directory_archive_blob(
+            get_git_repository_root_path() / path
+        )
+    return entry
 
 
 def _snapshot_embedded_repo_path(path: str) -> dict[str, Any]:
@@ -154,8 +163,22 @@ def _snapshot_embedded_repo_path(path: str) -> dict[str, Any]:
         "head_oid": None,
         "worktree_oid": worktree_oid,
         "dirty": _worktree_is_dirty(path) if worktree_oid is not None else False,
-        "blob": None,
+        "archive": True,
+        "storage_mode": "100644",
+        "blob": _create_directory_archive_blob(
+            get_git_repository_root_path() / path
+        ),
     }
+
+
+def _create_directory_archive_blob(path: Path) -> str:
+    """Store a complete nested-repository directory as one recovery blob."""
+    with tempfile.NamedTemporaryFile() as archive_file:
+        with tarfile.open(fileobj=archive_file, mode="w") as archive:
+            archive.add(path, arcname=".", recursive=True)
+        archive_file.flush()
+        with LineBuffer.from_path(Path(archive_file.name)) as archive_buffer:
+            return create_git_blob(archive_buffer.byte_chunks())
 
 
 def snapshot_worktree_paths(paths: list[str]) -> list[dict[str, Any]]:

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -5946,10 +5946,8 @@ def test_file_scope_include_file_owns_file_pipeline():
         "record_hunk_included",
         "run_git_command",
         "stream_live_git_diff",
-        "update_index_with_blob_buffer",
     }
     helper_imports = moved_names | {
-        "LineBuffer",
         "finish_selected_change_action",
         "get_selected_change_file_path",
         "selected_change_staging",
@@ -16783,7 +16781,6 @@ def test_selected_change_staging_owns_include_pipeline():
         "patch_is_file_deletion",
         "read_text_file_contents",
         "record_hunk_included",
-        "update_index_with_blob_buffer",
     }
     helper_imports = moved_names | {
         "BinaryFileChange",
@@ -17215,7 +17212,6 @@ def test_selected_change_discarding_owns_discard_pipeline():
         "_discard_text_deletion_change",
     }
     moved_names = {
-        "CommandError",
         "NoMoreHunks",
         "append_lines_to_file",
         "build_line_changes_from_patch_lines",

--- a/tests/commands/test_submodule_pointers.py
+++ b/tests/commands/test_submodule_pointers.py
@@ -466,6 +466,31 @@ def test_discard_removes_added_submodule_pointer(
     assert _git_stdout(["diff", "--ignore-submodules=none", "--", "sub"], cwd=repo) == ""
 
 
+def test_discard_added_submodule_pointer_undo_redo(
+    added_submodule_pointer_repo: tuple[Path, str],
+) -> None:
+    """Undo should restore a removed added submodule directory and its ITA."""
+    repo, new_oid = added_submodule_pointer_repo
+
+    command_start(quiet=True)
+    command_discard(quiet=True, auto_advance=False)
+    assert not (repo / "sub").exists()
+
+    command_undo(force=True)
+
+    assert (repo / "sub" / ".git").is_dir()
+    assert _git_stdout(["rev-parse", "HEAD"], cwd=repo / "sub") == new_oid
+    assert EMPTY_BLOB_HASH in _git_stdout(
+        ["ls-files", "--stage", "--", "sub"],
+        cwd=repo,
+    )
+
+    command_redo(force=True)
+
+    assert not (repo / "sub").exists()
+    assert _git_stdout(["ls-files", "--stage", "--", "sub"], cwd=repo) == ""
+
+
 def test_abort_restores_discarded_untracked_submodule_pointer(
     untracked_submodule_pointer_repo: tuple[Path, str],
 ) -> None:

--- a/tests/commands/test_undo.py
+++ b/tests/commands/test_undo.py
@@ -146,6 +146,34 @@ def test_scoped_checkpoint_does_not_retain_unrelated_content(temp_git_repo):
     assert "worktree/unrelated-secret.txt" not in tree_paths
 
 
+@pytest.mark.parametrize(
+    ("directory_getter", "expected_label"),
+    [
+        (get_session_directory_path, "session state"),
+        (get_batches_directory_path, "batch metadata"),
+    ],
+)
+def test_undo_refuses_tracked_metadata_drift(
+    temp_git_repo,
+    directory_getter,
+    expected_label,
+):
+    """Undo should not overwrite metadata changed after checkpoint finalization."""
+    get_session_directory_path().mkdir(parents=True, exist_ok=True)
+    metadata_directory = directory_getter()
+    metadata_directory.mkdir(parents=True, exist_ok=True)
+    metadata_path = metadata_directory / "tracked.txt"
+    metadata_path.write_text("before\n")
+
+    with undo_checkpoint("change metadata", worktree_paths=[]):
+        metadata_path.write_text("after\n")
+
+    metadata_path.write_text("external drift\n")
+
+    with pytest.raises(CommandError, match=expected_label):
+        undo_last_checkpoint()
+
+
 def test_scoped_undo_preserves_unrelated_index_changes(temp_git_repo):
     """Undo should restore scoped index entries without replacing the whole index."""
     target = _commit_text_file(temp_git_repo, "target.txt", "target base\n")
@@ -184,6 +212,58 @@ def test_scoped_undo_preserves_unrelated_index_changes(temp_git_repo):
     ).stdout.splitlines()
     assert staged_paths == ["unrelated.txt"]
     assert target.read_text() == "target staged\n"
+
+
+def test_undo_preserves_unrelated_fully_staged_auto_added_file(temp_git_repo):
+    """Undo should not demote an unrelated staged new file back to ITA."""
+    other = _commit_text_file(temp_git_repo, "other.txt", "other base\n")
+    new_file = temp_git_repo / "new.txt"
+    new_file.write_text("staged new content\n")
+    other.write_text("other changed\n")
+
+    command_start(quiet=True)
+    command_include_file("new.txt", quiet=True, advance=False)
+    staged_object = subprocess.run(
+        ["git", "rev-parse", ":new.txt"],
+        check=True,
+        cwd=temp_git_repo,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    command_include_file("other.txt", quiet=True, advance=False)
+
+    command_undo(force=True)
+
+    restored_object = subprocess.run(
+        ["git", "rev-parse", ":new.txt"],
+        check=True,
+        cwd=temp_git_repo,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    assert restored_object == staged_object
+    assert _show_index_path(temp_git_repo, "new.txt") == b"staged new content\n"
+
+
+def test_undo_restores_fully_staged_state_for_scoped_auto_added_file(temp_git_repo):
+    """The exact before-image should distinguish staged content from ITA."""
+    new_file = temp_git_repo / "new.txt"
+    new_file.write_text("staged new content\n")
+    command_start(quiet=True)
+    command_include_file("new.txt", quiet=True, advance=False)
+
+    with undo_checkpoint("remove staged file", worktree_paths=["new.txt"]):
+        subprocess.run(
+            ["git", "rm", "--cached", "-f", "--", "new.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+
+    undo_last_checkpoint(force=True)
+
+    assert _show_index_path(temp_git_repo, "new.txt") == b"staged new content\n"
+    assert not path_is_intent_to_add("new.txt")
 
 
 def test_undo_file_include_restores_both_rename_paths(temp_git_repo):

--- a/tests/data/test_selected_change_store.py
+++ b/tests/data/test_selected_change_store.py
@@ -10,6 +10,8 @@ from git_stage_batch.data.selected_change.store import (
     SelectedChangeKind,
     cache_hunk_change,
     read_selected_change_kind,
+    restore_selected_change_state,
+    snapshot_selected_change_state,
 )
 from git_stage_batch.utils.paths import (
     ensure_state_directory_exists,
@@ -17,6 +19,7 @@ from git_stage_batch.utils.paths import (
     get_line_changes_json_file_path,
     get_selected_hunk_hash_file_path,
     get_selected_hunk_patch_file_path,
+    get_snapshot_metadata_file_path,
     get_working_tree_snapshot_file_path,
 )
 
@@ -100,3 +103,28 @@ def test_cache_hunk_change_writes_selected_hunk_state(temp_git_repo):
     assert cached_line_changes is not None
     assert cached_line_changes.path == "test.py"
     assert cached_line_changes.changed_line_ids() == [1, 2]
+
+
+def test_selected_state_snapshot_restores_snapshot_metadata(temp_git_repo):
+    """Preview rollback should restore the manifest used for stale checks."""
+    patch_lines = [
+        b"--- a/test.py\n",
+        b"+++ b/test.py\n",
+        b"@@ -1 +1 @@\n",
+        b"-old\n",
+        b"+new\n",
+    ]
+    line_changes = LineLevelChange(
+        path="test.py",
+        header=HunkHeader(old_start=1, old_len=1, new_start=1, new_len=1),
+        lines=[],
+    )
+    cache_hunk_change(patch_lines, "stable-hash", line_changes)
+    metadata_path = get_snapshot_metadata_file_path()
+    original_metadata = metadata_path.read_bytes()
+
+    with snapshot_selected_change_state() as snapshot:
+        metadata_path.write_text('{"path": "other.py"}\n')
+        restore_selected_change_state(snapshot)
+
+    assert metadata_path.read_bytes() == original_metadata

--- a/tests/data/test_undo_restore.py
+++ b/tests/data/test_undo_restore.py
@@ -1,0 +1,30 @@
+"""Tests for undo checkpoint restoration helpers."""
+
+from __future__ import annotations
+
+import pytest
+import subprocess
+
+from git_stage_batch.data import undo_restore
+from git_stage_batch.exceptions import CommandError
+
+
+def test_restore_worktree_rejects_missing_saved_blob(tmp_path, monkeypatch):
+    """An incomplete checkpoint must not silently preserve post-operation bytes."""
+    monkeypatch.chdir(tmp_path)
+    subprocess.run(["git", "init"], check=True, capture_output=True)
+    monkeypatch.setattr(undo_restore, "_tree_entries", lambda *_args: [])
+
+    with pytest.raises(CommandError, match="missing worktree content for file.txt"):
+        undo_restore.restore_worktree(
+            "checkpoint",
+            {
+                "worktree_paths": [
+                    {
+                        "path": "file.txt",
+                        "exists": True,
+                        "mode": "100644",
+                    }
+                ]
+            },
+        )


### PR DESCRIPTION
Session snapshots and undo checkpoints preserve selected state, scoped Git state, worktree paths, refs, and application metadata.

Some before-image details are incomplete: selected freshness metadata is omitted, session-tracked intent can overwrite staged content, durable metadata drift is not detected, missing blobs are ignored, and nested repository presence cannot be reconstructed reliably.

This PR records and restores those details explicitly. It scopes legacy intent fallback, compares durable metadata while allowing volatile selection views, rejects incomplete worktree snapshots, and archives nested repositories for undo and redo.

Tests: `uv run pytest -n auto -q` (3,266 passed)
