### PR TITLE
output: Restore modified atomic terminal colors

### DIFF
--- a/src/git_stage_batch/output/colors.py
+++ b/src/git_stage_batch/output/colors.py
@@ -12,6 +12,7 @@ class Colors:
     REVERSE = "\033[7m"
     RED = "\033[31m"
     GREEN = "\033[32m"
+    YELLOW = "\033[33m"
     CYAN = "\033[36m"
     GRAY = "\033[90m"
 

--- a/tests/output/test_colors.py
+++ b/tests/output/test_colors.py
@@ -9,6 +9,7 @@ def test_colors_class_has_codes():
     assert hasattr(Colors, 'BOLD')
     assert hasattr(Colors, 'RED')
     assert hasattr(Colors, 'GREEN')
+    assert hasattr(Colors, 'YELLOW')
     assert hasattr(Colors, 'CYAN')
 
 

--- a/tests/output/test_patch.py
+++ b/tests/output/test_patch.py
@@ -1,6 +1,9 @@
 """Tests for patch printing."""
 
+from unittest.mock import patch
+
 from git_stage_batch.core.models import GitlinkChange
+from git_stage_batch.output.colors import Colors
 from git_stage_batch.output.patch import print_colored_patch, print_gitlink_change
 
 
@@ -43,6 +46,22 @@ def test_print_gitlink_change_modified(capsys):
     assert "sub :: Submodule pointer modified" in captured.out
     assert "old 111111111111" in captured.out
     assert "new 222222222222" in captured.out
+
+
+def test_print_gitlink_change_modified_with_color(capsys):
+    """Modified atomic changes use a defined terminal color."""
+    with patch("git_stage_batch.output.patch.Colors.enabled", return_value=True):
+        print_gitlink_change(
+            GitlinkChange(
+                old_path="sub",
+                new_path="sub",
+                old_oid="1" * 40,
+                new_oid="2" * 40,
+                change_type="modified",
+            )
+        )
+
+    assert Colors.YELLOW in capsys.readouterr().out
 
 
 def test_print_gitlink_change_added(capsys):


### PR DESCRIPTION
Patch output has shared terminal colors for textual and atomic change renderers.

Modified binary, submodule, and rename changes reference a yellow palette entry that is absent, so rendering those changes on a terminal raises an attribute error.

This PR restores that rendering path by defining the yellow palette entry and exercising a modified submodule renderer with colors enabled.

Modified atomic changes can now render on color terminals without crashing.