### PR TITLE
diff: Preserve header-like hunk content

### DIFF
--- a/src/git_stage_batch/core/diff_parser.py
+++ b/src/git_stage_batch/core/diff_parser.py
@@ -539,15 +539,15 @@ def build_line_changes_from_patch_lines(
         # Strip only \n for comparison (preserve \r in content)
         line = line_with_ending.rstrip(b'\n')
 
-        if _patch_headers.line_is_old_file_header(line):
+        if hunk_header is not None:
+            body_builder.append_patch_line(line)
+        elif _patch_headers.line_is_old_file_header(line):
             old_path_value = _patch_headers.old_file_path_from_header(line)
         elif _patch_headers.line_is_new_file_header(line):
             new_path_value = _patch_headers.new_file_path_from_header(line)
         elif _hunk_headers.line_is_hunk_header(line):
             hunk_header = _hunk_headers.parse_hunk_header_line(line)
             body_builder.reset_for_hunk_header(hunk_header)
-        elif hunk_header is not None:
-            body_builder.append_patch_line(line)
 
     path_value = _patch_headers.line_change_path(old_path_value, new_path_value)
 

--- a/src/git_stage_batch/core/hashing.py
+++ b/src/git_stage_batch/core/hashing.py
@@ -55,6 +55,17 @@ def compute_stable_hunk_hash_from_lines(patch_lines: Iterable[bytes]) -> str:
         # Strip \n for comparison
         line = line_with_ending.rstrip(b'\n')
 
+        if saw_header:
+            # Only include actual changes (+ or -), not context lines (space).
+            # Once the hunk body starts, content that happens to begin with a
+            # file-header prefix must remain content.
+            if line and line[0:1] in (b'+', b'-'):
+                write_hash_prefix()
+                if wrote_changed_line:
+                    digest.update(b"\n")
+                digest.update(line)
+                wrote_changed_line = True
+            continue
         if line.startswith(b"+++ "):
             path_value = unquote_path_token(line.split(b" ", 1)[1].strip())
             if path_value != b"/dev/null":
@@ -69,15 +80,6 @@ def compute_stable_hunk_hash_from_lines(patch_lines: Iterable[bytes]) -> str:
             header_bytes = line
             saw_header = True
             continue
-        if saw_header:
-            # Only include actual changes (+ or -), not context lines (space)
-            if line and line[0:1] in (b'+', b'-'):
-                write_hash_prefix()
-                if wrote_changed_line:
-                    digest.update(b"\n")
-                digest.update(line)
-                wrote_changed_line = True
-
     write_hash_prefix()
     return digest.hexdigest()
 

--- a/tests/core/test_diff_parser.py
+++ b/tests/core/test_diff_parser.py
@@ -406,6 +406,23 @@ class TestBuildLineLevelChangeFromPatchText:
         changed_ids = line_changes.changed_line_ids()
         assert changed_ids == [1]
 
+    def test_file_header_prefixes_in_hunk_body_remain_content(self):
+        """Changed content resembling file headers must not replace the path."""
+        patch_text = """--- a/file.py
++++ b/file.py
+@@ -1 +1 @@
+--- comment
++++ replacement
+"""
+
+        line_changes = self._build_line_changes_from_patch_text(patch_text)
+
+        assert line_changes.path == "file.py"
+        assert [line.text_bytes for line in line_changes.lines] == [
+            b"-- comment",
+            b"++ replacement",
+        ]
+
     def test_build_line_changes_multiple_changes(self):
         """Test building LineLevelChange from patch with multiple changes."""
         patch_text = """--- a/code.js

--- a/tests/core/test_hashing.py
+++ b/tests/core/test_hashing.py
@@ -53,6 +53,13 @@ class TestComputeStableHunkHash:
 
         assert hash1 != hash2
 
+    def test_file_header_prefixes_in_hunk_body_are_hashed_as_content(self):
+        """Changed content resembling file headers remains part of identity."""
+        patch1 = b"--- a/file\n+++ b/file\n@@ -1 +1 @@\n--- old\n+++ new\n"
+        patch2 = b"--- a/file\n+++ b/file\n@@ -1 +1 @@\n--- old\n+++ other\n"
+
+        assert self._hash_patch(patch1) != self._hash_patch(patch2)
+
     def test_hash_is_hexadecimal_string(self):
         """Test that hash is a valid hexadecimal string."""
         patch = b"--- a/file\n+++ b/file\n@@ -1 +1 @@\n-old\n+new\n"


### PR DESCRIPTION
Diff parsing and stable identities use unified-diff headers to locate file metadata before processing hunk bodies.

Source lines can begin with the same marker text as file headers. Treating those body lines as metadata drops selectable content and prevents changed skipped hunks from receiving a new identity.

This PR keeps header recognition outside hunk bodies, preserves header-like additions and deletions, and includes those changed lines in stable hunk hashes.

Header-like source content now remains selectable and becomes actionable again when it changes.