### PR TITLE
paths: Reject oversized octal escapes

### DIFF
--- a/src/git_stage_batch/git_paths.py
+++ b/src/git_stage_batch/git_paths.py
@@ -98,7 +98,10 @@ def unquote_path_token(token: bytes) -> bytes:
                 and ord("0") <= token[octal_end] <= ord("7")
             ):
                 octal_end += 1
-            result.append(int(token[index:octal_end], 8))
+            octal_value = int(token[index:octal_end], 8)
+            if octal_value > 0xFF:
+                raise CommandError("Octal escape is outside byte range in Git pathname")
+            result.append(octal_value)
             index = octal_end
             continue
         raise CommandError("Invalid escape in Git pathname")

--- a/tests/utils/test_git_paths.py
+++ b/tests/utils/test_git_paths.py
@@ -37,7 +37,10 @@ def test_git_c_quoted_path_round_trips_raw_bytes():
     assert unquote_path_token(quote_path_token(raw_path)) == raw_path
 
 
-@pytest.mark.parametrize("token", [b'"unfinished', b'"bad\\x"', b'"bad\\"'])
+@pytest.mark.parametrize(
+    "token",
+    [b'"unfinished', b'"bad\\x"', b'"bad\\"', b'"bad\\400path"'],
+)
 def test_invalid_git_c_quoted_paths_are_rejected(token):
     with pytest.raises(CommandError):
         unquote_path_token(token)


### PR DESCRIPTION
Git pathname decoding translates C-style octal escapes into raw path bytes.

Malformed quoted paths can encode values above the byte range, currently exposing an unstructured ValueError instead of the command error used for other invalid path escapes.

This PR validates octal values before appending them and adds a regression case for the first value above one byte.

Malformed octal paths now fail through the same structured boundary as other invalid Git path escapes.