### PR TITLE
include: Honor the command return contract

### DIFF
--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -56,15 +56,15 @@ def command_include(
     ensure_state_directory_exists()
 
     if refuse_live_action_for_batch_selection(FileReviewAction.INCLUDE):
-        return 0
+        return
     if refuse_ambiguous_bare_action_after_partial_file_review(FileReviewAction.INCLUDE):
-        return 0
+        return
     refuse_bare_action_after_file_list("include")
     refuse_bare_action_after_auto_advance_disabled("include")
 
     if read_selected_change_kind() == SelectedChangeKind.FILE:
         command_include_file("", auto_advance=auto_advance)
-        return 0
+        return
 
     if read_selected_change_kind() == SelectedChangeKind.HUNK:
         skipped_ids = read_line_ids_file(get_processed_skip_ids_file_path())
@@ -79,9 +79,9 @@ def command_include(
                     quiet=quiet,
                     operation="include",
                 )
-                return 0
+                return
 
-    return _selected_change_staging.include_selected_change(
+    _selected_change_staging.include_selected_change(
         quiet=quiet,
         auto_advance=auto_advance,
     )

--- a/tests/commands/test_include.py
+++ b/tests/commands/test_include.py
@@ -98,7 +98,9 @@ class TestCommandInclude:
         readme.write_text("# Test\nNew content\n")
 
         command_start()
-        command_include()
+        result = command_include()
+
+        assert result is None
 
         # Check that changes are staged
         result = subprocess.run(


### PR DESCRIPTION
The bare include command is a side-effecting Python interface annotated to return no value after staging or refusing a selected change.

Several paths leak integer helper statuses despite that declaration, making the public command inconsistent with the other include entry points.

This PR returns without a value across those paths and directly checks the result of a successful bare include.

The Python include interface now consistently matches its declared no-value contract.