### PR TITLE
commands: Require sessions for live batch mutations

### DIFF
--- a/src/git_stage_batch/commands/discard.py
+++ b/src/git_stage_batch/commands/discard.py
@@ -190,6 +190,7 @@ def command_discard_to_batch(
     """
     require_git_repository()
     validate_batch_name(batch_name)
+    require_session_started()
     ensure_state_directory_exists()
     original_file_scope = file
     scope_resolution = resolve_live_to_batch_action_scope(

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -242,6 +242,7 @@ def command_include_to_batch(
     """
     require_git_repository()
     validate_batch_name(batch_name)
+    require_session_started()
     ensure_state_directory_exists()
     original_file_scope = file
     scope_resolution = resolve_live_to_batch_action_scope(

--- a/tests/commands/test_discard.py
+++ b/tests/commands/test_discard.py
@@ -73,7 +73,7 @@ class TestCommandDiscard:
         self,
         temp_git_repo,
     ):
-        with pytest.raises(CommandError):
+        with pytest.raises(CommandError, match="not compatible"):
             command_discard_to_batch("invalid^name")
 
         assert not get_state_directory_path().exists()

--- a/tests/commands/test_include.py
+++ b/tests/commands/test_include.py
@@ -86,7 +86,7 @@ class TestCommandInclude:
         self,
         temp_git_repo,
     ):
-        with pytest.raises(CommandError):
+        with pytest.raises(CommandError, match="not compatible"):
             command_include_to_batch("invalid^name")
 
         assert not get_state_directory_path().exists()

--- a/tests/commands/test_submodule_pointers.py
+++ b/tests/commands/test_submodule_pointers.py
@@ -32,6 +32,7 @@ from git_stage_batch.data.selected_change.store import (
     read_selected_change_kind,
 )
 from git_stage_batch.data.selected_change.paths import get_selected_change_file_path
+from git_stage_batch.data.selected_change.lifecycle import clear_selected_change_state_files
 from git_stage_batch.exceptions import CommandError
 
 EMPTY_BLOB_HASH = "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"
@@ -388,6 +389,8 @@ def test_include_to_batch_finds_submodule_pointer_without_selection_when_config_
     """include --to should find submodule pointers hidden by user config."""
     repo, old_oid, new_oid = submodule_pointer_repo
 
+    command_start(quiet=True)
+    clear_selected_change_state_files()
     command_include_to_batch("pointers", quiet=True)
 
     file_meta = read_batch_metadata("pointers")["files"]["sub"]
@@ -406,6 +409,7 @@ def test_include_to_batch_stores_added_submodule_pointer(
     """include --to should store added submodule pointers atomically."""
     repo, new_oid = added_submodule_pointer_repo
 
+    command_start(quiet=True)
     command_include_to_batch("pointers", quiet=True)
 
     file_meta = read_batch_metadata("pointers")["files"]["sub"]
@@ -426,6 +430,7 @@ def test_include_to_batch_stores_deleted_submodule_pointer(
     """include --to should store deleted submodule pointers atomically."""
     repo, old_oid = deleted_submodule_pointer_repo
 
+    command_start(quiet=True)
     command_include_to_batch("pointers", quiet=True)
 
     file_meta = read_batch_metadata("pointers")["files"]["sub"]
@@ -683,6 +688,7 @@ def test_include_from_batch_stages_added_submodule_pointer(
     """include --from should stage a stored added submodule pointer."""
     repo, new_oid = added_submodule_pointer_repo
 
+    command_start(quiet=True)
     command_include_to_batch("pointers", quiet=True)
 
     command_include_from_batch("pointers", file="sub")
@@ -699,6 +705,7 @@ def test_apply_from_batch_applies_added_submodule_pointer_as_live_diff(
     """apply --from should make an added pointer visible without staging it."""
     repo, new_oid = added_submodule_pointer_repo
 
+    command_start(quiet=True)
     command_include_to_batch("pointers", quiet=True)
     _run(["git", "update-index", "--force-remove", "--", "sub"], cwd=repo)
 
@@ -714,6 +721,7 @@ def test_include_from_batch_stages_deleted_submodule_pointer(
     """include --from should stage a stored deleted submodule pointer."""
     repo, old_oid = deleted_submodule_pointer_repo
 
+    command_start(quiet=True)
     command_include_to_batch("pointers", quiet=True)
 
     command_include_from_batch("pointers", file="sub")

--- a/tests/functional/test_error_handling.py
+++ b/tests/functional/test_error_handling.py
@@ -70,6 +70,26 @@ class TestOperationWithoutSession:
         )
         assert refs.stdout == ""
 
+    def test_discard_to_batch_without_session_does_not_create_batch(self, repo_with_changes):
+        """A rejected discard-to operation must not publish a batch ref."""
+        result = git_stage_batch("discard", "--to", "saved", "--file", "file.txt", check=False)
+
+        assert result.returncode != 0
+        refs = subprocess.run(
+            [
+                "git",
+                "for-each-ref",
+                "--format=%(refname)",
+                "refs/git-stage-batch/batches/saved",
+                "refs/git-stage-batch/state/saved",
+                "refs/batches/saved",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        assert refs.stdout == ""
+
 
 class TestNonexistentBatch:
     """Test operations on nonexistent batches."""

--- a/tests/functional/test_error_handling.py
+++ b/tests/functional/test_error_handling.py
@@ -50,6 +50,26 @@ class TestOperationWithoutSession:
         result = git_stage_batch("skip", check=False)
         assert result.returncode != 0
 
+    def test_include_to_batch_without_session_does_not_create_batch(self, repo_with_changes):
+        """A rejected include-to operation must not publish a batch ref."""
+        result = git_stage_batch("include", "--to", "saved", "--file", "file.txt", check=False)
+
+        assert result.returncode != 0
+        refs = subprocess.run(
+            [
+                "git",
+                "for-each-ref",
+                "--format=%(refname)",
+                "refs/git-stage-batch/batches/saved",
+                "refs/git-stage-batch/state/saved",
+                "refs/batches/saved",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        assert refs.stdout == ""
+
 
 class TestNonexistentBatch:
     """Test operations on nonexistent batches."""


### PR DESCRIPTION
Live include-to-batch and discard-to-batch commands validate batch names before publishing persistent batch state.

Both mutations can currently begin without an active session, allowing refs to appear before missing session metadata stops the operation.

This PR requires a session before either live mutation, preserves batch-name validation precedence, and verifies that rejected calls publish no authoritative or legacy refs.

Live batch mutations now share an explicit session boundary through both Python and command-line entry points.