### PR TITLE
submodules: Require independently rooted worktrees

### DIFF
--- a/src/git_stage_batch/batch/submodule_pointer.py
+++ b/src/git_stage_batch/batch/submodule_pointer.py
@@ -15,7 +15,10 @@ from ..utils.git_index import (
     git_add_paths,
     git_update_gitlink,
 )
-from ..utils.git_repository import get_git_repository_root_path
+from ..utils.git_repository import (
+    get_git_repository_root_path,
+    is_git_repository_root_path,
+)
 
 
 def is_batch_submodule_pointer(file_meta: dict) -> bool:
@@ -66,11 +69,25 @@ def _submodule_worktree_path(file_path: str):
     return get_git_repository_root_path() / file_path
 
 
+def _require_submodule_worktree(file_path: str, action: str):
+    """Return an independently rooted submodule worktree or fail closed."""
+    full_path = _submodule_worktree_path(file_path)
+    if not is_git_repository_root_path(full_path):
+        raise CommandError(
+            _(
+                "Cannot {action} submodule pointer for {file}: "
+                "the path is not a standalone Git repository."
+            ).format(action=action.lower(), file=file_path)
+        )
+    return full_path
+
+
 def _checkout_submodule_pointer(file_path: str, oid: str, action: str) -> None:
     """Move a clean submodule worktree to one commit."""
+    full_path = _require_submodule_worktree(file_path, action)
     status_result = run_git_command(
         ["status", "--porcelain"],
-        cwd=file_path,
+        cwd=str(full_path),
         check=False,
         requires_index_lock=False,
     )
@@ -87,7 +104,11 @@ def _checkout_submodule_pointer(file_path: str, oid: str, action: str) -> None:
             ).format(action=action, file=file_path)
         )
 
-    checkout_result = git_checkout_detached(oid, cwd=file_path, check=False)
+    checkout_result = git_checkout_detached(
+        oid,
+        cwd=str(full_path),
+        check=False,
+    )
     if checkout_result.returncode != 0:
         raise CommandError(
             _(
@@ -100,7 +121,11 @@ def _ensure_submodule_worktree(file_path: str, oid: str, action: str) -> None:
     """Ensure a submodule worktree exists, then check out one commit."""
     full_path = _submodule_worktree_path(file_path)
     if not full_path.exists():
-        update_result = git_submodule_update_checkout([file_path], check=False)
+        update_result = git_submodule_update_checkout(
+            [file_path],
+            cwd=str(get_git_repository_root_path()),
+            check=False,
+        )
         if update_result.returncode != 0:
             raise CommandError(
                 _(
@@ -116,9 +141,11 @@ def _remove_submodule_worktree(file_path: str, action: str) -> None:
     if not full_path.exists():
         return
 
+    full_path = _require_submodule_worktree(file_path, action)
+
     status_result = run_git_command(
         ["status", "--porcelain"],
-        cwd=file_path,
+        cwd=str(full_path),
         check=False,
         requires_index_lock=False,
     )

--- a/src/git_stage_batch/utils/git_repository.py
+++ b/src/git_stage_batch/utils/git_repository.py
@@ -61,6 +61,36 @@ def get_git_repository_root_path() -> Path:
     return path
 
 
+def is_git_repository_root_path(path: Path) -> bool:
+    """Return whether ``path`` is the root of its own Git worktree.
+
+    Git searches parent directories when a command's working directory is not
+    itself a repository.  Nested-worktree callers must distinguish that
+    fallback from a repository rooted at the requested path before running
+    mutations there.
+    """
+    try:
+        result = run_git_command(
+            ["rev-parse", "--show-toplevel"],
+            cwd=str(path),
+            check=False,
+            requires_index_lock=False,
+        )
+    except OSError:
+        return False
+    if result.returncode != 0:
+        return False
+    try:
+        requested_absolute = path.absolute()
+        requested_root = path.resolve()
+        reported_root = Path(result.stdout.strip()).resolve()
+    except OSError:
+        return False
+    if requested_absolute != requested_root:
+        return False
+    return reported_root == requested_root
+
+
 def get_git_directory_path() -> Path:
     """Get the absolute path to the repository's git directory."""
     cwd = Path.cwd()

--- a/src/git_stage_batch/utils/git_worktree.py
+++ b/src/git_stage_batch/utils/git_worktree.py
@@ -135,11 +135,13 @@ def git_apply_stash(
 def git_submodule_update_checkout(
     paths: Sequence[str],
     *,
+    cwd: str | None = None,
     check: bool = True,
 ) -> subprocess.CompletedProcess:
     """Ensure submodule worktrees exist using checkout update mode."""
     return run_git_command(
         ["submodule", "update", "--init", "--checkout", "--", *paths],
+        cwd=cwd,
         check=check,
         requires_index_lock=True,
     )

--- a/tests/commands/test_submodule_pointers.py
+++ b/tests/commands/test_submodule_pointers.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 
+from git_stage_batch.batch import submodule_pointer as submodule_pointer_actions
 from git_stage_batch.commands.discard import command_discard, command_discard_file
 from git_stage_batch.commands.abort import command_abort
 from git_stage_batch.commands.apply_from import command_apply_from_batch
@@ -36,6 +37,83 @@ from git_stage_batch.data.selected_change.lifecycle import clear_selected_change
 from git_stage_batch.exceptions import CommandError
 
 EMPTY_BLOB_HASH = "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"
+
+
+def test_missing_submodule_update_runs_from_superproject_root(tmp_path, monkeypatch):
+    """Submodule initialization does not interpret paths relative to the caller."""
+    calls = []
+    monkeypatch.setattr(
+        submodule_pointer_actions,
+        "get_git_repository_root_path",
+        lambda: tmp_path,
+    )
+    monkeypatch.setattr(
+        submodule_pointer_actions,
+        "git_submodule_update_checkout",
+        lambda paths, **kwargs: calls.append((paths, kwargs))
+        or subprocess.CompletedProcess([], 0, "", ""),
+    )
+    monkeypatch.setattr(
+        submodule_pointer_actions,
+        "_checkout_submodule_pointer",
+        lambda *_args: None,
+    )
+
+    submodule_pointer_actions._ensure_submodule_worktree(
+        "sub",
+        "1" * 40,
+        "Apply",
+    )
+
+    assert calls == [(["sub"], {"cwd": str(tmp_path), "check": False})]
+
+
+@pytest.fixture
+def superproject_with_plain_subdirectory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[Path, str]:
+    """Create a clean superproject containing an empty non-repository path."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _run(["git", "init"], cwd=repo)
+    _configure_identity(repo)
+    (repo / "tracked.txt").write_text("tracked\n")
+    _run(["git", "add", "tracked.txt"], cwd=repo)
+    _run(["git", "commit", "-m", "Initial commit"], cwd=repo)
+    (repo / "sub").mkdir()
+    monkeypatch.chdir(repo)
+    return repo, _git_stdout(["rev-parse", "HEAD"], cwd=repo)
+
+
+def test_submodule_checkout_refuses_superproject_walk_up(
+    superproject_with_plain_subdirectory: tuple[Path, str],
+) -> None:
+    """A plain subdirectory must never redirect checkout to the superproject."""
+    repo, head_oid = superproject_with_plain_subdirectory
+    symbolic_head = _git_stdout(["symbolic-ref", "HEAD"], cwd=repo)
+
+    with pytest.raises(CommandError, match="not a standalone Git repository"):
+        submodule_pointer_actions._checkout_submodule_pointer(
+            "sub",
+            head_oid,
+            "Apply",
+        )
+
+    assert _git_stdout(["rev-parse", "HEAD"], cwd=repo) == head_oid
+    assert _git_stdout(["symbolic-ref", "HEAD"], cwd=repo) == symbolic_head
+
+
+def test_submodule_removal_refuses_superproject_walk_up(
+    superproject_with_plain_subdirectory: tuple[Path, str],
+) -> None:
+    """Superproject status must not authorize deleting a plain directory."""
+    repo, _head_oid = superproject_with_plain_subdirectory
+
+    with pytest.raises(CommandError, match="not a standalone Git repository"):
+        submodule_pointer_actions._remove_submodule_worktree("sub", "Discard")
+
+    assert (repo / "sub").is_dir()
 
 
 @pytest.fixture
@@ -680,6 +758,24 @@ def test_include_from_batch_stages_submodule_pointer(
     assert old_oid in raw_diff
     assert new_oid in raw_diff
     assert _worktree_pointer_diff(repo) == ""
+
+
+def test_include_from_batch_updates_submodule_from_superproject_subdirectory(
+    submodule_pointer_repo: tuple[Path, str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Nested Git commands resolve submodule paths from the repository root."""
+    repo, old_oid, new_oid = submodule_pointer_repo
+    command_start(quiet=True)
+    command_include_to_batch("pointers", quiet=True)
+    _run(["git", "checkout", "--detach", old_oid], cwd=repo / "sub")
+    subdirectory = repo / "nested-cwd"
+    subdirectory.mkdir()
+    monkeypatch.chdir(subdirectory)
+
+    command_include_from_batch("pointers", file="sub")
+
+    assert _git_stdout(["rev-parse", "HEAD"], cwd=repo / "sub") == new_oid
 
 
 def test_include_from_batch_stages_added_submodule_pointer(

--- a/tests/utils/test_git_repository.py
+++ b/tests/utils/test_git_repository.py
@@ -8,6 +8,7 @@ import pytest
 from git_stage_batch.exceptions import CommandError
 from git_stage_batch.utils.git_repository import (
     get_git_repository_root_path,
+    is_git_repository_root_path,
     require_git_repository,
 )
 from git_stage_batch.utils.repository_path import normalize_repository_path
@@ -83,6 +84,28 @@ class TestGetGitRepositoryRootPath:
         root = get_git_repository_root_path()
 
         assert root == temp_git_repo
+
+
+class TestIsGitRepositoryRootPath:
+    """Tests for exact repository-root identification."""
+
+    def test_accepts_repository_root(self, temp_git_repo):
+        """The worktree root identifies its own repository."""
+        assert is_git_repository_root_path(temp_git_repo)
+
+    def test_rejects_plain_descendant(self, temp_git_repo):
+        """Git parent discovery does not make a plain directory a repository."""
+        descendant = temp_git_repo / "plain"
+        descendant.mkdir()
+
+        assert not is_git_repository_root_path(descendant)
+
+    def test_rejects_symlink_to_repository_root(self, temp_git_repo):
+        """A nested path cannot alias the outer repository root."""
+        alias = temp_git_repo / "alias"
+        alias.symlink_to(temp_git_repo, target_is_directory=True)
+
+        assert not is_git_repository_root_path(alias)
 
 
 class TestNormalizeRepositoryPath:


### PR DESCRIPTION
Batch submodule operations resolve repository-relative pointers and run nested Git commands while applying or discarding stored state.

Git can resolve those paths from the caller directory or walk from a plain descendant into the superproject, risking inspection or mutation of the wrong repository.

This PR anchors targets at the superproject root, requires each nested path to identify an independent Git worktree, and rejects checkout or removal through parent discovery and symlink aliases.

Batch pointer operations now fail closed before a nested Git command can escape into the superproject.