### PR TITLE
undo: Preserve exact nested worktree snapshots

### DIFF
--- a/src/git_stage_batch/data/undo_worktree.py
+++ b/src/git_stage_batch/data/undo_worktree.py
@@ -139,33 +139,37 @@ def _snapshot_gitlink_path(
     index_oid: str | None,
     head_oid: str | None,
 ) -> dict[str, Any]:
+    full_path = get_git_repository_root_path() / path
+    worktree_exists = os.path.lexists(full_path)
     worktree_oid = _worktree_commit_oid(path)
+    dirty = _worktree_is_dirty(path) if worktree_oid is not None else False
     entry = {
         "path": path,
         "kind": "gitlink",
-        "exists": index_oid is not None or head_oid is not None or worktree_oid is not None,
+        "exists": worktree_exists,
         "mode": "160000",
         "index_oid": index_oid,
         "head_oid": head_oid,
         "worktree_oid": worktree_oid,
-        "dirty": _worktree_is_dirty(path) if worktree_oid is not None else False,
+        "dirty": dirty,
         "blob": None,
     }
-    if head_oid is None and worktree_oid is not None:
+    if worktree_exists and (head_oid is None or worktree_oid is None or dirty):
         entry["archive"] = True
         entry["storage_mode"] = "100644"
         entry["blob"] = _create_directory_archive_blob(
-            get_git_repository_root_path() / path
+            full_path
         )
     return entry
 
 
 def _snapshot_embedded_repo_path(path: str) -> dict[str, Any]:
+    full_path = get_git_repository_root_path() / path
     worktree_oid = _worktree_commit_oid(path)
     return {
         "path": path,
         "kind": "embedded-repo",
-        "exists": worktree_oid is not None,
+        "exists": os.path.lexists(full_path),
         "mode": "160000",
         "index_oid": None,
         "head_oid": None,
@@ -174,7 +178,7 @@ def _snapshot_embedded_repo_path(path: str) -> dict[str, Any]:
         "archive": True,
         "storage_mode": "100644",
         "blob": _create_directory_archive_blob(
-            get_git_repository_root_path() / path
+            full_path
         ),
     }
 

--- a/src/git_stage_batch/data/undo_worktree.py
+++ b/src/git_stage_batch/data/undo_worktree.py
@@ -12,7 +12,10 @@ from typing import Any
 from ..core.buffer import LineBuffer
 from ..utils.git_command import run_git_command
 from ..utils.git_index import GitIndexEntryUpdate
-from ..utils.git_repository import get_git_repository_root_path
+from ..utils.git_repository import (
+    get_git_repository_root_path,
+    is_git_repository_root_path,
+)
 from ..utils.git_object_io import create_git_blob, create_git_blobs_from_paths
 from ..git_paths import decode_path, nul_records
 
@@ -63,6 +66,7 @@ def _gitlink_oids_from_index(paths: list[str]) -> dict[str, str]:
         return {}
     result = run_git_command(
         ["ls-files", "--stage", "-z", "--", *paths],
+        cwd=str(get_git_repository_root_path()),
         check=False,
         text_output=False,
         requires_index_lock=False,
@@ -86,6 +90,7 @@ def _gitlink_oids_from_head(paths: list[str]) -> dict[str, str]:
         return {}
     result = run_git_command(
         ["ls-tree", "-z", "HEAD", "--", *paths],
+        cwd=str(get_git_repository_root_path()),
         check=False,
         text_output=False,
         requires_index_lock=False,
@@ -104,9 +109,12 @@ def _gitlink_oids_from_head(paths: list[str]) -> dict[str, str]:
 
 
 def _worktree_commit_oid(path: str) -> str | None:
+    worktree_path = get_git_repository_root_path() / path
+    if not is_git_repository_root_path(worktree_path):
+        return None
     result = run_git_command(
         ["rev-parse", "--verify", "HEAD^{commit}"],
-        cwd=path,
+        cwd=str(worktree_path),
         check=False,
         requires_index_lock=False,
     )
@@ -118,7 +126,7 @@ def _worktree_commit_oid(path: str) -> str | None:
 def _worktree_is_dirty(path: str) -> bool:
     result = run_git_command(
         ["status", "--porcelain"],
-        cwd=path,
+        cwd=str(get_git_repository_root_path() / path),
         check=False,
         requires_index_lock=False,
     )

--- a/tests/data/test_undo_worktree.py
+++ b/tests/data/test_undo_worktree.py
@@ -199,3 +199,85 @@ def test_gitlink_capture_uses_repository_relative_paths_from_subdirectory(
     assert entry["kind"] == "gitlink"
     assert entry["index_oid"] == nested_oid
     assert entry["head_oid"] == nested_oid
+
+
+def test_dirty_gitlink_capture_archives_exact_worktree_bytes(tmp_path, monkeypatch):
+    """Dirty gitlinks retain content identity as well as commit identity."""
+    repository = _initialize_repository(tmp_path, monkeypatch)
+    nested = repository / "nested"
+    nested.mkdir()
+    subprocess.run(["git", "init"], cwd=nested, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"],
+        cwd=nested,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=nested,
+        check=True,
+    )
+    nested_file = nested / "file.txt"
+    nested_file.write_text("base\n")
+    subprocess.run(["git", "add", "file.txt"], cwd=nested, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", "Add nested file"],
+        cwd=nested,
+        check=True,
+        capture_output=True,
+    )
+    nested_oid = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=nested,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    subprocess.run(
+        [
+            "git",
+            "update-index",
+            "--add",
+            "--cacheinfo",
+            "160000",
+            nested_oid,
+            "nested",
+        ],
+        cwd=repository,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "Add gitlink"],
+        cwd=repository,
+        check=True,
+        capture_output=True,
+    )
+    nested_file.write_text("first dirty state\n")
+
+    first = undo_worktree.snapshot_worktree_paths(["nested"])[0]
+    nested_file.write_text("second dirty state\n")
+    second = undo_worktree.snapshot_worktree_paths(["nested"])[0]
+    unchanged = undo_worktree.snapshot_worktree_paths(["nested"])[0]
+
+    assert first["dirty"] is True
+    assert first["archive"] is True
+    assert first["blob"]
+    assert second["blob"] != first["blob"]
+    assert unchanged["blob"] == second["blob"]
+
+
+def test_broken_embedded_repository_is_snapshotted_as_present(tmp_path, monkeypatch):
+    """A present nested directory remains restorable even without a valid HEAD."""
+    repository = _initialize_repository(tmp_path, monkeypatch)
+    nested = repository / "broken"
+    nested.mkdir()
+    (nested / ".git").write_text("not a gitdir\n")
+    (nested / "private.txt").write_text("keep me\n")
+
+    entry = undo_worktree.snapshot_worktree_paths(["broken"])[0]
+
+    assert entry["kind"] == "embedded-repo"
+    assert entry["exists"] is True
+    assert entry["worktree_oid"] is None
+    assert entry["archive"] is True
+    assert entry["blob"]

--- a/tests/data/test_undo_worktree.py
+++ b/tests/data/test_undo_worktree.py
@@ -87,3 +87,115 @@ def test_scoped_capture_does_not_inspect_unrelated_dirty_paths(tmp_path, monkeyp
     entries = undo_worktree.snapshot_worktree_paths(["target.txt"])
 
     assert [entry["path"] for entry in entries] == ["target.txt"]
+
+
+def test_nested_repository_capture_uses_repository_relative_paths_from_subdirectory(
+    tmp_path,
+    monkeypatch,
+):
+    """Nested Git commands resolve paths from the outer repository root."""
+    repository = _initialize_repository(tmp_path, monkeypatch)
+    nested = repository / "nested"
+    nested.mkdir()
+    subprocess.run(["git", "init"], cwd=nested, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"],
+        cwd=nested,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=nested,
+        check=True,
+        capture_output=True,
+    )
+    (nested / "file.txt").write_text("nested\n")
+    subprocess.run(["git", "add", "file.txt"], cwd=nested, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", "Add nested file"],
+        cwd=nested,
+        check=True,
+        capture_output=True,
+    )
+    nested_oid = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=nested,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    subdirectory = repository / "elsewhere"
+    subdirectory.mkdir()
+    monkeypatch.chdir(subdirectory)
+
+    entry = undo_worktree.snapshot_worktree_paths(["nested"])[0]
+
+    assert entry["exists"] is True
+    assert entry["worktree_oid"] == nested_oid
+
+
+def test_gitlink_capture_uses_repository_relative_paths_from_subdirectory(
+    tmp_path,
+    monkeypatch,
+):
+    """Index and HEAD gitlink lookups run from the superproject root."""
+    repository = _initialize_repository(tmp_path, monkeypatch)
+    nested = repository / "nested"
+    nested.mkdir()
+    subprocess.run(["git", "init"], cwd=nested, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"],
+        cwd=nested,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=nested,
+        check=True,
+        capture_output=True,
+    )
+    (nested / "file.txt").write_text("nested\n")
+    subprocess.run(["git", "add", "file.txt"], cwd=nested, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", "Add nested file"],
+        cwd=nested,
+        check=True,
+        capture_output=True,
+    )
+    nested_oid = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=nested,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    subprocess.run(
+        [
+            "git",
+            "update-index",
+            "--add",
+            "--cacheinfo",
+            "160000",
+            nested_oid,
+            "nested",
+        ],
+        cwd=repository,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "Add gitlink"],
+        cwd=repository,
+        check=True,
+        capture_output=True,
+    )
+    subdirectory = repository / "elsewhere"
+    subdirectory.mkdir()
+    monkeypatch.chdir(subdirectory)
+
+    entry = undo_worktree.snapshot_worktree_paths(["nested"])[0]
+
+    assert entry["kind"] == "gitlink"
+    assert entry["index_oid"] == nested_oid
+    assert entry["head_oid"] == nested_oid


### PR DESCRIPTION
Undo snapshots record gitlinks and embedded repositories from repository-relative paths, commit identities, and recovery archives.

Caller-relative lookup can capture the wrong repository, while commit identity alone cannot reconstruct broken, unborn, or dirty nested worktrees.

This PR anchors snapshot discovery at exact repository roots, records filesystem presence independently, and archives nested state whenever Git metadata or commit identity is insufficient.

Undo capture now preserves nested worktree identity and bytes independently of the caller directory or repository health.