### PR TITLE
undo: Restore checkpoint paths through mode-aware writes

### DIFF
--- a/src/git_stage_batch/data/undo_restore.py
+++ b/src/git_stage_batch/data/undo_restore.py
@@ -5,16 +5,12 @@ from __future__ import annotations
 import json
 import os
 import shutil
-import stat
 import tarfile
 import tempfile
 from pathlib import Path
 from typing import Any
 
-from ..core.buffer import (
-    write_buffer_to_path,
-    write_buffer_to_working_tree_path,
-)
+from ..core.buffer import write_buffer_to_working_tree_path
 from ..utils.repository_buffers import load_git_blob_as_buffer
 from .undo_refs import list_restorable_refs
 from ..exceptions import CommandError
@@ -34,11 +30,6 @@ from ..utils.git_repository import get_git_repository_root_path
 def _read_json_blob(blob_sha: str) -> dict[str, Any]:
     with load_git_blob_as_buffer(blob_sha) as buffer:
         return json.loads(buffer.to_bytes().decode("utf-8"))
-
-
-def _write_blob_to_path(blob_sha: str, target_path: Path) -> None:
-    with load_git_blob_as_buffer(blob_sha) as buffer:
-        write_buffer_to_path(target_path, buffer)
 
 
 def _write_blob_to_worktree_path(
@@ -88,16 +79,6 @@ def read_json_from_commit(commit: str, path: str) -> dict[str, Any]:
     return _read_json_blob(blob_sha)
 
 
-def _restore_file_mode(path: Path, mode: str) -> None:
-    if mode == "120000":
-        return
-    current_mode = path.stat().st_mode
-    if mode == "100755":
-        path.chmod(current_mode | stat.S_IXUSR)
-    else:
-        path.chmod(current_mode & ~stat.S_IXUSR & ~stat.S_IXGRP & ~stat.S_IXOTH)
-
-
 def restore_tree_prefix(commit: str, *, prefix: str, target_dir: Path) -> None:
     """Restore one tree prefix from an undo snapshot commit."""
     if target_dir.exists():
@@ -110,8 +91,7 @@ def restore_tree_prefix(commit: str, *, prefix: str, target_dir: Path) -> None:
         relative_path = Path(tree_path).relative_to(prefix)
         target_path = target_dir / relative_path
         target_path.parent.mkdir(parents=True, exist_ok=True)
-        _write_blob_to_path(blob_sha, target_path)
-        _restore_file_mode(target_path, mode)
+        _write_blob_to_worktree_path(blob_sha, target_path, mode=mode)
 
 
 def restore_tree_paths(
@@ -137,8 +117,7 @@ def restore_tree_paths(
             continue
         mode, blob_sha = saved_entry
         target_path.parent.mkdir(parents=True, exist_ok=True)
-        _write_blob_to_path(blob_sha, target_path)
-        _restore_file_mode(target_path, mode)
+        _write_blob_to_worktree_path(blob_sha, target_path, mode=mode)
 
 
 def tree_prefix_state(commit: str, prefix: str) -> dict[str, dict[str, str]]:

--- a/tests/data/test_undo_restore.py
+++ b/tests/data/test_undo_restore.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import os
 import pytest
 import subprocess
 
 from git_stage_batch.data import undo_restore
 from git_stage_batch.exceptions import CommandError
+from git_stage_batch.utils.git_object_io import create_git_blob
 
 
 def test_restore_worktree_rejects_missing_saved_blob(tmp_path, monkeypatch):
@@ -28,3 +30,52 @@ def test_restore_worktree_rejects_missing_saved_blob(tmp_path, monkeypatch):
                 ]
             },
         )
+
+
+@pytest.mark.parametrize(
+    ("saved_mode", "saved_content", "current_kind"),
+    [
+        ("100644", b"regular bytes\n", "symlink"),
+        ("120000", b"saved-target", "regular"),
+    ],
+)
+def test_restore_tree_paths_uses_saved_git_mode(
+    tmp_path,
+    monkeypatch,
+    saved_mode,
+    saved_content,
+    current_kind,
+):
+    """Restore replaces the current path type instead of following it."""
+    monkeypatch.chdir(tmp_path)
+    subprocess.run(["git", "init"], check=True, capture_output=True)
+    blob_sha = create_git_blob([saved_content])
+    monkeypatch.setattr(
+        undo_restore,
+        "_tree_entries",
+        lambda *_args: [(saved_mode, blob_sha, "state/entry")],
+    )
+    target_dir = tmp_path / "target"
+    target_dir.mkdir()
+    target = target_dir / "entry"
+    referent = tmp_path / "referent"
+    referent.write_text("untouched\n")
+    if current_kind == "symlink":
+        target.symlink_to(referent)
+    else:
+        target.write_text("current\n")
+
+    undo_restore.restore_tree_paths(
+        "checkpoint",
+        prefix="state",
+        target_dir=target_dir,
+        tracked_paths=["entry"],
+    )
+
+    if saved_mode == "120000":
+        assert target.is_symlink()
+        assert os.readlink(target) == "saved-target"
+    else:
+        assert not target.is_symlink()
+        assert target.read_bytes() == saved_content
+        assert referent.read_text() == "untouched\n"


### PR DESCRIPTION
Undo restoration recreates saved blobs over the filesystem objects currently occupying checkpoint paths.

Writing through existing symlinks can modify their referents or leave the wrong object kind behind when the checkpoint expects a regular file or a symlink.

This PR routes scoped and prefix restoration through the mode-aware worktree writer and exercises both incompatible object transitions.

Checkpoint restoration now recreates saved path kinds without modifying unrelated symlink targets.