### PR TITLE
undo: Fail closed on intent-to-add restoration

### DIFF
--- a/src/git_stage_batch/data/undo_checkpoints.py
+++ b/src/git_stage_batch/data/undo_checkpoints.py
@@ -44,7 +44,7 @@ from ..utils.git_index import (
     temp_git_index,
 )
 from .index_entries import read_index_entries
-from .session import auto_added_files, intent_to_add_files
+from .session import intent_to_add_files
 from ..utils.git_repository import get_git_repository_root_path
 from ..utils.git_object_io import create_git_blob, create_git_blobs_from_paths
 from ..utils.paths import (
@@ -95,15 +95,16 @@ def _snapshot_current_state(
 
 
 def _restore_intent_to_add_state(state: dict[str, Any]) -> None:
-    """Restore scoped ITA flags, with a narrow legacy-checkpoint fallback."""
+    """Restore exact scoped ITA flags and fail closed for legacy checkpoints."""
     saved_paths = state.get("intent_to_add_paths")
     if isinstance(saved_paths, list):
         paths = [path for path in saved_paths if isinstance(path, str)]
     else:
-        scoped_paths = set(
-            state.get("tracked_index_paths", state.get("tracked_worktree_paths", []))
-        )
-        paths = auto_added_files(list(scoped_paths))
+        # Legacy checkpoints did not save the ITA bit. An empty index blob is
+        # ambiguous: it can be either ITA or a fully staged empty file. Failing
+        # closed avoids demoting staged content based on append-only session
+        # history.
+        paths = []
     _undo_restore.restore_intent_to_add_entries(paths)
 
 

--- a/src/git_stage_batch/data/undo_checkpoints.py
+++ b/src/git_stage_batch/data/undo_checkpoints.py
@@ -95,15 +95,15 @@ def _snapshot_current_state(
 
 
 def _restore_intent_to_add_state(state: dict[str, Any]) -> None:
-    """Restore exact scoped ITA flags and fail closed for legacy checkpoints."""
+    """Restore exact intent-to-add flags and fail closed for legacy checkpoints."""
     saved_paths = state.get("intent_to_add_paths")
     if isinstance(saved_paths, list):
         paths = [path for path in saved_paths if isinstance(path, str)]
     else:
-        # Legacy checkpoints did not save the ITA bit. An empty index blob is
-        # ambiguous: it can be either ITA or a fully staged empty file. Failing
-        # closed avoids demoting staged content based on append-only session
-        # history.
+        # Legacy checkpoints did not save the intent-to-add bit. An empty
+        # index blob is ambiguous: it can be either intent-to-add or a fully
+        # staged empty file. Failing closed avoids demoting staged content
+        # based on append-only session history.
         paths = []
     _undo_restore.restore_intent_to_add_entries(paths)
 

--- a/src/git_stage_batch/data/undo_restore.py
+++ b/src/git_stage_batch/data/undo_restore.py
@@ -240,5 +240,5 @@ def restore_intent_to_add_entries(file_paths: list[str]) -> None:
     for file_path in file_paths:
         full_path = repo_root / file_path
         if os.path.lexists(full_path):
-            git_update_index(file_path=file_path, force_remove=True, check=False)
-            git_add_paths([file_path], intent_to_add=True, check=False)
+            git_update_index(file_path=file_path, force_remove=True)
+            git_add_paths([file_path], intent_to_add=True)

--- a/tests/commands/test_discard.py
+++ b/tests/commands/test_discard.py
@@ -139,7 +139,7 @@ class TestCommandDiscard:
         self,
         temp_git_repo,
     ):
-        """Discarding a complete new file should not leave a ghost ITA entry."""
+        """Discarding a complete new file should not leave a ghost intent-to-add entry."""
         new_file = temp_git_repo / "new.txt"
         new_file.write_text("new content\n")
 

--- a/tests/commands/test_submodule_pointers.py
+++ b/tests/commands/test_submodule_pointers.py
@@ -552,7 +552,7 @@ def test_discard_removes_added_submodule_pointer(
 def test_discard_added_submodule_pointer_undo_redo(
     added_submodule_pointer_repo: tuple[Path, str],
 ) -> None:
-    """Undo should restore a removed added submodule directory and its ITA."""
+    """Undo should restore a removed added submodule directory and its intent-to-add."""
     repo, new_oid = added_submodule_pointer_repo
 
     command_start(quiet=True)

--- a/tests/commands/test_undo.py
+++ b/tests/commands/test_undo.py
@@ -215,7 +215,7 @@ def test_scoped_undo_preserves_unrelated_index_changes(temp_git_repo):
 
 
 def test_undo_preserves_unrelated_fully_staged_auto_added_file(temp_git_repo):
-    """Undo should not demote an unrelated staged new file back to ITA."""
+    """Undo should not demote an unrelated staged new file back to intent-to-add."""
     other = _commit_text_file(temp_git_repo, "other.txt", "other base\n")
     new_file = temp_git_repo / "new.txt"
     new_file.write_text("staged new content\n")
@@ -246,7 +246,7 @@ def test_undo_preserves_unrelated_fully_staged_auto_added_file(temp_git_repo):
 
 
 def test_undo_restores_fully_staged_state_for_scoped_auto_added_file(temp_git_repo):
-    """The exact before-image should distinguish staged content from ITA."""
+    """The exact before-image should distinguish staged content from intent-to-add."""
     new_file = temp_git_repo / "new.txt"
     new_file.write_text("staged new content\n")
     command_start(quiet=True)

--- a/tests/data/test_undo_checkpoints.py
+++ b/tests/data/test_undo_checkpoints.py
@@ -1,0 +1,41 @@
+"""Focused tests for undo checkpoint compatibility behavior."""
+
+from git_stage_batch.data import undo_checkpoints
+
+
+def test_legacy_ita_fallback_does_not_guess_from_empty_index_blobs(monkeypatch):
+    """An empty blob cannot distinguish ITA from a fully staged empty file."""
+    restored = []
+    monkeypatch.setattr(
+        undo_checkpoints._undo_restore,
+        "restore_intent_to_add_entries",
+        lambda paths: restored.extend(paths),
+    )
+
+    undo_checkpoints._restore_intent_to_add_state(
+        {
+            "tracked_index_paths": ["staged.txt", "intent.txt"],
+            "index_entries": {
+                "staged.txt": {"mode": "100644", "object_id": "content-blob"},
+                "intent.txt": {"mode": "100644", "object_id": "empty-blob"},
+            },
+        }
+    )
+
+    assert restored == []
+
+
+def test_legacy_ita_fallback_without_index_identity_fails_closed(monkeypatch):
+    """Very old checkpoints do not guess ITA state from append-only history."""
+    restored = []
+    monkeypatch.setattr(
+        undo_checkpoints._undo_restore,
+        "restore_intent_to_add_entries",
+        lambda paths: restored.extend(paths),
+    )
+
+    undo_checkpoints._restore_intent_to_add_state(
+        {"tracked_index_paths": ["possibly-staged.txt"]}
+    )
+
+    assert restored == []

--- a/tests/data/test_undo_checkpoints.py
+++ b/tests/data/test_undo_checkpoints.py
@@ -4,7 +4,7 @@ from git_stage_batch.data import undo_checkpoints
 
 
 def test_legacy_ita_fallback_does_not_guess_from_empty_index_blobs(monkeypatch):
-    """An empty blob cannot distinguish ITA from a fully staged empty file."""
+    """An empty blob cannot distinguish intent-to-add from a fully staged empty file."""
     restored = []
     monkeypatch.setattr(
         undo_checkpoints._undo_restore,
@@ -26,7 +26,7 @@ def test_legacy_ita_fallback_does_not_guess_from_empty_index_blobs(monkeypatch):
 
 
 def test_legacy_ita_fallback_without_index_identity_fails_closed(monkeypatch):
-    """Very old checkpoints do not guess ITA state from append-only history."""
+    """Very old checkpoints do not guess intent-to-add state from append-only history."""
     restored = []
     monkeypatch.setattr(
         undo_checkpoints._undo_restore,

--- a/tests/data/test_undo_restore.py
+++ b/tests/data/test_undo_restore.py
@@ -79,3 +79,25 @@ def test_restore_tree_paths_uses_saved_git_mode(
         assert not target.is_symlink()
         assert target.read_bytes() == saved_content
         assert referent.read_text() == "untouched\n"
+def test_restore_intent_to_add_entries_checks_git_failures(tmp_path, monkeypatch):
+    """ITA restoration does not silently accept failed index commands."""
+    monkeypatch.chdir(tmp_path)
+    subprocess.run(["git", "init"], check=True, capture_output=True)
+    (tmp_path / "new.txt").write_text("content\n")
+    update_calls = []
+    add_calls = []
+    monkeypatch.setattr(
+        undo_restore,
+        "git_update_index",
+        lambda **kwargs: update_calls.append(kwargs),
+    )
+    monkeypatch.setattr(
+        undo_restore,
+        "git_add_paths",
+        lambda paths, **kwargs: add_calls.append((paths, kwargs)),
+    )
+
+    undo_restore.restore_intent_to_add_entries(["new.txt"])
+
+    assert update_calls == [{"file_path": "new.txt", "force_remove": True}]
+    assert add_calls == [(["new.txt"], {"intent_to_add": True})]

--- a/tests/data/test_undo_restore.py
+++ b/tests/data/test_undo_restore.py
@@ -80,7 +80,7 @@ def test_restore_tree_paths_uses_saved_git_mode(
         assert target.read_bytes() == saved_content
         assert referent.read_text() == "untouched\n"
 def test_restore_intent_to_add_entries_checks_git_failures(tmp_path, monkeypatch):
-    """ITA restoration does not silently accept failed index commands."""
+    """intent-to-add restoration does not silently accept failed index commands."""
     monkeypatch.chdir(tmp_path)
     subprocess.run(["git", "init"], check=True, capture_output=True)
     (tmp_path / "new.txt").write_text("content\n")


### PR DESCRIPTION
Modern undo checkpoints record exact intent-to-add paths, while legacy snapshots cannot distinguish those entries from fully staged empty files.

Guessing from append-only auto-add history can demote staged content, and unchecked index commands can hide a partially restored state.

This PR restores only explicit markers, propagates index failures, covers ambiguous legacy shapes, and spells out the intent-to-add invariant across implementation and tests.

Undo no longer risks staged-content loss through legacy intent-to-add reconstruction.