### PR TITLE
undo: Restore exact gitlink worktree state

### DIFF
--- a/src/git_stage_batch/data/undo_checkpoints.py
+++ b/src/git_stage_batch/data/undo_checkpoints.py
@@ -443,7 +443,20 @@ def finalize_pending_checkpoint() -> None:
 
 
 def _worktree_state_by_path(entries: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
-    return {entry["path"]: entry for entry in entries}
+    normalized = {}
+    for entry in entries:
+        normalized_entry = entry
+        if (
+            entry.get("kind") == "gitlink"
+            and entry.get("exists", False)
+            and not entry.get("worktree_oid")
+            and not entry.get("archive", False)
+        ):
+            # Before filesystem presence was recorded independently, an
+            # index/HEAD-only gitlink used exists=True for an absent worktree.
+            normalized_entry = {**entry, "exists": False}
+        normalized[entry["path"]] = normalized_entry
+    return normalized
 
 
 def _detect_conflicts_against_state(expected_state: dict[str, Any]) -> list[str]:

--- a/src/git_stage_batch/data/undo_restore.py
+++ b/src/git_stage_batch/data/undo_restore.py
@@ -317,7 +317,20 @@ def _restore_directory_archive(
                 archive_file.write(chunk)
             archive_file.flush()
             with tarfile.open(archive_file.name, mode="r") as archive:
-                archive.extractall(target_path)
+                _extract_directory_archive(archive, target_path)
+
+
+def _extract_directory_archive(
+    archive: tarfile.TarFile,
+    target_path: Path,
+) -> None:
+    """Extract a trusted checkpoint archive across supported Python versions."""
+    if hasattr(tarfile, "tar_filter"):
+        archive.extractall(target_path, filter="tar")
+    else:
+        # Extraction filters were backported to maintained Python 3.10
+        # releases, but the project also supports earlier 3.10 runtimes.
+        archive.extractall(target_path)
 
 
 def restore_intent_to_add_entries(file_paths: list[str]) -> None:

--- a/src/git_stage_batch/data/undo_restore.py
+++ b/src/git_stage_batch/data/undo_restore.py
@@ -24,7 +24,10 @@ from ..utils.git_refs import (
 )
 from ..utils.git_worktree import git_checkout_detached
 from ..utils.git_index import git_add_paths, git_update_index
-from ..utils.git_repository import get_git_repository_root_path
+from ..utils.git_repository import (
+    get_git_repository_root_path,
+    is_git_repository_root_path,
+)
 
 
 def _read_json_blob(blob_sha: str) -> dict[str, Any]:
@@ -163,20 +166,25 @@ def restore_worktree(commit: str, manifest: dict[str, Any]) -> None:
         target_path = repo_root / file_path
         if entry.get("kind") == "gitlink":
             worktree_oid = entry.get("worktree_oid")
-            if entry.get("exists", False) and worktree_oid:
-                if not target_path.is_dir():
-                    _restore_directory_archive(
+            if entry.get("exists", False):
+                if entry.get("archive", False):
+                    _restore_gitlink_archive(
                         target_path,
                         worktree_blobs.get(file_path),
+                        file_path=file_path,
+                        worktree_oid=worktree_oid,
                     )
-                result = git_checkout_detached(worktree_oid, cwd=file_path, check=False)
-                if result.returncode != 0:
-                    raise CommandError(
-                        _("Failed to restore submodule pointer for {file}: {error}").format(
-                            file=file_path,
-                            error=result.stderr,
-                        )
-                    )
+                    continue
+                if not worktree_oid:
+                    # Older checkpoints used index/HEAD gitlink presence for
+                    # "exists" even when no worktree directory was present.
+                    _remove_worktree_path(target_path)
+                    continue
+                _checkout_gitlink_worktree(
+                    target_path,
+                    worktree_oid,
+                    file_path=file_path,
+                )
             elif not entry.get("exists", False):
                 _remove_worktree_path(target_path)
             continue
@@ -185,6 +193,7 @@ def restore_worktree(commit: str, manifest: dict[str, Any]) -> None:
                 _restore_directory_archive(
                     target_path,
                     worktree_blobs.get(file_path),
+                    file_path=file_path,
                 )
             else:
                 _remove_worktree_path(target_path)
@@ -211,18 +220,95 @@ def _remove_worktree_path(target_path: Path) -> None:
         target_path.unlink()
 
 
-def _restore_directory_archive(
+def _checkout_gitlink_worktree(
+    target_path: Path,
+    worktree_oid: str,
+    *,
+    file_path: str,
+    force: bool = False,
+) -> None:
+    """Check out a gitlink commit only inside its exact nested repository."""
+    if not is_git_repository_root_path(target_path):
+        raise CommandError(
+            _(
+                "Cannot restore submodule pointer for {file}: "
+                "the path is not a standalone Git repository."
+            ).format(file=file_path)
+        )
+    result = git_checkout_detached(
+        worktree_oid,
+        cwd=str(target_path),
+        force=force,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise CommandError(
+            _("Failed to restore submodule pointer for {file}: {error}").format(
+                file=file_path,
+                error=result.stderr,
+            )
+        )
+
+
+def _restore_gitlink_archive(
     target_path: Path,
     blob_info: tuple[str, str] | None,
+    *,
+    file_path: str,
+    worktree_oid: str | None,
 ) -> None:
-    """Restore one nested repository from its checkpoint archive."""
+    """Restore an exact archived gitlink worktree and its nested HEAD."""
+    blob_info = _require_directory_archive(blob_info, file_path=file_path)
+    if worktree_oid and not is_git_repository_root_path(target_path):
+        # Recreate a missing worktree, including its .git file or directory,
+        # before asking Git to operate inside it.
+        _restore_directory_archive(
+            target_path,
+            blob_info,
+            file_path=file_path,
+        )
+
+    if worktree_oid:
+        # The archive is a complete before-image, so it is safe to force the
+        # nested HEAD/index back to the recorded commit before restoring the
+        # saved dirty worktree bytes below.
+        _checkout_gitlink_worktree(
+            target_path,
+            worktree_oid,
+            file_path=file_path,
+            force=True,
+        )
+
+    _restore_directory_archive(
+        target_path,
+        blob_info,
+        file_path=file_path,
+    )
+
+
+def _require_directory_archive(
+    blob_info: tuple[str, str] | None,
+    *,
+    file_path: str,
+) -> tuple[str, str]:
+    """Return stored archive information or report an incomplete checkpoint."""
     if blob_info is None:
         raise CommandError(
             _("Undo checkpoint is missing nested repository content for {file}").format(
-                file=target_path.name,
+                file=file_path,
             )
         )
-    _mode, blob_sha = blob_info
+    return blob_info
+
+
+def _restore_directory_archive(
+    target_path: Path,
+    blob_info: tuple[str, str] | None,
+    *,
+    file_path: str,
+) -> None:
+    """Restore one nested repository from its checkpoint archive."""
+    _mode, blob_sha = _require_directory_archive(blob_info, file_path=file_path)
     _remove_worktree_path(target_path)
     target_path.mkdir(parents=True)
     with load_git_blob_as_buffer(blob_sha) as archive_buffer:

--- a/src/git_stage_batch/utils/git_worktree.py
+++ b/src/git_stage_batch/utils/git_worktree.py
@@ -63,11 +63,16 @@ def git_checkout_detached(
     oid: str,
     *,
     cwd: str,
+    force: bool = False,
     check: bool = True,
 ) -> subprocess.CompletedProcess:
     """Check out one commit in detached mode inside another Git worktree."""
+    arguments = ["checkout", "--detach"]
+    if force:
+        arguments.append("--force")
+    arguments.append(oid)
     return run_git_command(
-        ["checkout", "--detach", oid],
+        arguments,
         cwd=cwd,
         check=check,
         requires_index_lock=True,

--- a/tests/data/test_undo_checkpoints.py
+++ b/tests/data/test_undo_checkpoints.py
@@ -39,3 +39,18 @@ def test_legacy_ita_fallback_without_index_identity_fails_closed(monkeypatch):
     )
 
     assert restored == []
+
+
+def test_legacy_gitlink_absence_is_normalized_for_conflict_checks():
+    """Old index-based existence matches a currently absent worktree."""
+    legacy = {
+        "path": "sub",
+        "kind": "gitlink",
+        "exists": True,
+        "worktree_oid": None,
+    }
+    current = {**legacy, "exists": False}
+
+    assert undo_checkpoints._worktree_state_by_path([legacy]) == (
+        undo_checkpoints._worktree_state_by_path([current])
+    )

--- a/tests/data/test_undo_restore.py
+++ b/tests/data/test_undo_restore.py
@@ -369,6 +369,51 @@ def test_restore_gitlink_refuses_superproject_walk_up(tmp_path, monkeypatch):
     ).stdout.strip() == symbolic_head
 
 
+def test_restore_directory_archive_allows_self_created_symlinks(tmp_path, monkeypatch):
+    """The explicit tar filter remains compatible with archived symlinks."""
+    monkeypatch.chdir(tmp_path)
+    subprocess.run(["git", "init"], check=True, capture_output=True)
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "link").symlink_to("/outside")
+    archive_blob = undo_worktree._create_directory_archive_blob(source)
+    target = tmp_path / "nested"
+
+    undo_restore._restore_directory_archive(
+        target,
+        ("100644", archive_blob),
+        file_path="path/to/nested",
+    )
+
+    assert (target / "link").is_symlink()
+    assert os.readlink(target / "link") == "/outside"
+
+
+def test_extract_directory_archive_supports_early_python_310(monkeypatch, tmp_path):
+    """Runtimes predating extraction filters use the trusted-archive fallback."""
+    calls = []
+
+    class LegacyArchive:
+        def extractall(self, path):
+            calls.append(path)
+
+    monkeypatch.delattr(undo_restore.tarfile, "tar_filter")
+
+    undo_restore._extract_directory_archive(LegacyArchive(), tmp_path)
+
+    assert calls == [tmp_path]
+
+
+def test_restore_directory_archive_error_keeps_repository_path(tmp_path):
+    """Missing archive diagnostics identify the scoped repository path."""
+    with pytest.raises(CommandError, match="nested/path"):
+        undo_restore._restore_directory_archive(
+            tmp_path / "path",
+            None,
+            file_path="nested/path",
+        )
+
+
 def test_restore_intent_to_add_entries_checks_git_failures(tmp_path, monkeypatch):
     """intent-to-add restoration does not silently accept failed index commands."""
     monkeypatch.chdir(tmp_path)

--- a/tests/data/test_undo_restore.py
+++ b/tests/data/test_undo_restore.py
@@ -6,7 +6,7 @@ import os
 import pytest
 import subprocess
 
-from git_stage_batch.data import undo_restore
+from git_stage_batch.data import undo_restore, undo_worktree
 from git_stage_batch.exceptions import CommandError
 from git_stage_batch.utils.git_object_io import create_git_blob
 
@@ -79,6 +79,296 @@ def test_restore_tree_paths_uses_saved_git_mode(
         assert not target.is_symlink()
         assert target.read_bytes() == saved_content
         assert referent.read_text() == "untouched\n"
+
+
+def test_restore_gitlink_recorded_absent_removes_post_operation_directory(
+    tmp_path,
+    monkeypatch,
+):
+    """Undo removes a gitlink worktree that was absent in the before-image."""
+    monkeypatch.chdir(tmp_path)
+    subprocess.run(["git", "init"], check=True, capture_output=True)
+    target = tmp_path / "sub"
+    target.mkdir()
+    (target / "leftover").write_text("post-operation\n")
+    monkeypatch.setattr(undo_restore, "_tree_entries", lambda *_args: [])
+
+    undo_restore.restore_worktree(
+        "checkpoint",
+        {
+            "worktree_paths": [
+                {
+                    "path": "sub",
+                    "kind": "gitlink",
+                    "exists": False,
+                    "worktree_oid": None,
+                }
+            ]
+        },
+    )
+
+    assert not target.exists()
+
+
+def test_restore_legacy_gitlink_without_worktree_removes_directory(
+    tmp_path,
+    monkeypatch,
+):
+    """Legacy index-based existence does not preserve a later worktree."""
+    monkeypatch.chdir(tmp_path)
+    subprocess.run(["git", "init"], check=True, capture_output=True)
+    target = tmp_path / "sub"
+    target.mkdir()
+    (target / "leftover").write_text("post-operation\n")
+    monkeypatch.setattr(undo_restore, "_tree_entries", lambda *_args: [])
+
+    undo_restore.restore_worktree(
+        "checkpoint",
+        {
+            "worktree_paths": [
+                {
+                    "path": "sub",
+                    "kind": "gitlink",
+                    "exists": True,
+                    "worktree_oid": None,
+                    "archive": False,
+                }
+            ]
+        },
+    )
+
+    assert not target.exists()
+
+
+def test_restore_gitlink_without_head_uses_saved_archive(tmp_path, monkeypatch):
+    """A present gitlink directory without a commit is restored from its archive."""
+    monkeypatch.chdir(tmp_path)
+    subprocess.run(["git", "init"], check=True, capture_output=True)
+    before = tmp_path / "before"
+    before.mkdir()
+    (before / "private.txt").write_text("before\n")
+    archive_blob = undo_worktree._create_directory_archive_blob(before)
+    target = tmp_path / "sub"
+    target.mkdir()
+    (target / "private.txt").write_text("after\n")
+    monkeypatch.setattr(
+        undo_restore,
+        "_tree_entries",
+        lambda *_args: [("100644", archive_blob, "worktree/sub")],
+    )
+
+    undo_restore.restore_worktree(
+        "checkpoint",
+        {
+            "worktree_paths": [
+                {
+                    "path": "sub",
+                    "kind": "gitlink",
+                    "exists": True,
+                    "worktree_oid": None,
+                    "archive": True,
+                }
+            ]
+        },
+    )
+
+    assert (target / "private.txt").read_text() == "before\n"
+
+
+def test_restore_archived_gitlink_reapplies_dirty_worktree(tmp_path, monkeypatch):
+    """An archive restores dirty bytes when a submodule's Git dir is external."""
+    source = tmp_path / "source"
+    source.mkdir()
+    subprocess.run(["git", "init"], cwd=source, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"],
+        cwd=source,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=source,
+        check=True,
+    )
+    source_file = source / "file.txt"
+    source_file.write_text("base\n")
+    subprocess.run(["git", "add", "file.txt"], cwd=source, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", "Initial nested commit"],
+        cwd=source,
+        check=True,
+        capture_output=True,
+    )
+    worktree_oid = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=source,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    subprocess.run(["git", "init"], cwd=repository, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"],
+        cwd=repository,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=repository,
+        check=True,
+    )
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "protocol.file.allow=always",
+            "submodule",
+            "add",
+            str(source),
+            "sub",
+        ],
+        cwd=repository,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "commit", "-am", "Add submodule"],
+        cwd=repository,
+        check=True,
+        capture_output=True,
+    )
+    monkeypatch.chdir(repository)
+    target = repository / "sub"
+    nested_file = target / "file.txt"
+    nested_file.write_text("saved dirty bytes\n")
+    archive_blob = undo_worktree._create_directory_archive_blob(target)
+
+    source_file.write_text("second commit\n")
+    subprocess.run(
+        ["git", "commit", "-am", "Update nested file"],
+        cwd=source,
+        check=True,
+        capture_output=True,
+    )
+    post_operation_oid = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=source,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    subprocess.run(
+        ["git", "fetch", str(source), post_operation_oid],
+        cwd=target,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "checkout", "--detach", "--force", post_operation_oid],
+        cwd=target,
+        check=True,
+        capture_output=True,
+    )
+    nested_file.write_text("post-operation bytes\n")
+    monkeypatch.setattr(
+        undo_restore,
+        "_tree_entries",
+        lambda *_args: [("100644", archive_blob, "worktree/sub")],
+    )
+
+    undo_restore.restore_worktree(
+        "checkpoint",
+        {
+            "worktree_paths": [
+                {
+                    "path": "sub",
+                    "kind": "gitlink",
+                    "exists": True,
+                    "worktree_oid": worktree_oid,
+                    "archive": True,
+                }
+            ]
+        },
+    )
+
+    assert nested_file.read_text() == "saved dirty bytes\n"
+    assert (target / ".git").is_file()
+    assert subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=target,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip() == worktree_oid
+
+
+def test_restore_gitlink_refuses_superproject_walk_up(tmp_path, monkeypatch):
+    """Legacy worktree IDs cannot redirect undo checkout to the superproject."""
+    monkeypatch.chdir(tmp_path)
+    subprocess.run(["git", "init"], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        check=True,
+    )
+    (tmp_path / "tracked.txt").write_text("tracked\n")
+    subprocess.run(["git", "add", "tracked.txt"], check=True)
+    subprocess.run(
+        ["git", "commit", "-m", "Initial commit"],
+        check=True,
+        capture_output=True,
+    )
+    head_oid = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    symbolic_head = subprocess.run(
+        ["git", "symbolic-ref", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    (tmp_path / "sub").mkdir()
+    monkeypatch.setattr(undo_restore, "_tree_entries", lambda *_args: [])
+
+    with pytest.raises(CommandError, match="not a standalone Git repository"):
+        undo_restore.restore_worktree(
+            "checkpoint",
+            {
+                "worktree_paths": [
+                    {
+                        "path": "sub",
+                        "kind": "gitlink",
+                        "exists": True,
+                        "worktree_oid": head_oid,
+                        "archive": False,
+                    }
+                ]
+            },
+        )
+
+    assert subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip() == head_oid
+    assert subprocess.run(
+        ["git", "symbolic-ref", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip() == symbolic_head
+
+
 def test_restore_intent_to_add_entries_checks_git_failures(tmp_path, monkeypatch):
     """intent-to-add restoration does not silently accept failed index commands."""
     monkeypatch.chdir(tmp_path)


### PR DESCRIPTION
Gitlink checkpoints distinguish absent worktrees, nested commit identities, and archived directories containing local content.

Restoration can still trust parent-repository discovery, skip dirty archive overlays, or apply runtime-dependent tar behavior that loses path context in diagnostics.

This PR validates exact nested roots, restores recorded commits before overlaying archived bytes, normalizes legacy absence, and makes trusted archive extraction explicit across supported Python versions.

Gitlink undo now preserves exact nested state while failing closed on unsafe paths and incomplete archives.