### PR TITLE
tui: Preserve case-sensitive action keys

### DIFF
--- a/src/git_stage_batch/tui/action_prompt_choices.py
+++ b/src/git_stage_batch/tui/action_prompt_choices.py
@@ -79,6 +79,9 @@ def action_prompt_option_groups(
 
 def normalize_action_prompt_choice(choice: str) -> str:
     """Return the single-character action code for a prompt choice."""
+    if choice in {"U", "S", "A"}:
+        return choice
+
     choice_lower = choice.lower()
     word_to_letter = {
         "include": "i",

--- a/tests/tui/test_action_prompt_choices.py
+++ b/tests/tui/test_action_prompt_choices.py
@@ -1,0 +1,17 @@
+"""Tests for interactive action prompt choice normalization."""
+
+from git_stage_batch.tui.action_prompt_choices import normalize_action_prompt_choice
+
+
+def test_case_sensitive_single_letter_actions_are_preserved():
+    """Documented uppercase actions must not collapse into lowercase actions."""
+    assert normalize_action_prompt_choice("U") == "U"
+    assert normalize_action_prompt_choice("S") == "S"
+    assert normalize_action_prompt_choice("A") == "A"
+
+
+def test_word_aliases_remain_case_insensitive():
+    """Full action names should continue to accept mixed case."""
+    assert normalize_action_prompt_choice("Redo") == "U"
+    assert normalize_action_prompt_choice("STATUS") == "S"
+    assert normalize_action_prompt_choice("Assets") == "A"


### PR DESCRIPTION
The interactive action prompt documents uppercase single-letter actions alongside lowercase alternatives.

Normalizing every single-letter input to lowercase can turn redo into undo, status into skip, and assets into again.

This PR resolves exact-case keys before case-insensitive word aliases and covers uppercase keys and mixed-case words.

Interactive action dispatch now matches the documented key contract.