### PR TITLE
git: Treat exact paths as literal pathspecs

### DIFF
--- a/src/git_stage_batch/commands/abort.py
+++ b/src/git_stage_batch/commands/abort.py
@@ -57,6 +57,7 @@ def _remove_normalized_rename_destinations_before_stash_apply() -> None:
             ["ls-files", "--error-unmatch", "--", rename.new_path],
             check=False,
             requires_index_lock=False,
+            literal_pathspecs=True,
         )
         if tracked_result.returncode == 0:
             continue

--- a/src/git_stage_batch/commands/block_file.py
+++ b/src/git_stage_batch/commands/block_file.py
@@ -31,7 +31,10 @@ from .selection.action_completion import advance_to_and_show_next_change
 def _is_new_intent_to_add_file(file_path: str) -> bool:
     """Return True when file_path is an intent-to-add entry absent from HEAD."""
     stage_result = run_git_command(
-        ["ls-files", "--stage", "--", file_path], check=False, requires_index_lock=False
+        ["ls-files", "--stage", "--", file_path],
+        check=False,
+        requires_index_lock=False,
+        literal_pathspecs=True,
     )
     stage_output = stage_result.stdout.strip()
     if not stage_output:

--- a/src/git_stage_batch/commands/stop.py
+++ b/src/git_stage_batch/commands/stop.py
@@ -28,6 +28,7 @@ def _path_has_staged_content(file_path: str) -> bool:
         ["diff", "--cached", "--quiet", "--no-renames", "--", file_path],
         check=False,
         requires_index_lock=False,
+        literal_pathspecs=True,
     )
     if result.returncode not in (0, 1):
         raise subprocess.CalledProcessError(

--- a/src/git_stage_batch/commands/unblock_file.py
+++ b/src/git_stage_batch/commands/unblock_file.py
@@ -56,7 +56,10 @@ def _is_absent_from_head(file_path: str) -> bool:
 def _is_absent_from_index(file_path: str) -> bool:
     """Return True when file_path has no index entry."""
     stage_result = run_git_command(
-        ["ls-files", "--stage", "--", file_path], check=False, requires_index_lock=False
+        ["ls-files", "--stage", "--", file_path],
+        check=False,
+        requires_index_lock=False,
+        literal_pathspecs=True,
     )
     return not stage_result.stdout.strip()
 

--- a/src/git_stage_batch/data/file_modes.py
+++ b/src/git_stage_batch/data/file_modes.py
@@ -21,6 +21,7 @@ def detect_file_mode_in_commit(commit: str, file_path: str) -> str | None:
         ["ls-tree", commit, "--", file_path],
         check=False,
         requires_index_lock=False,
+        literal_pathspecs=True,
     )
     if result.returncode != 0 or not result.stdout.strip():
         return None
@@ -40,6 +41,7 @@ def detect_file_mode_from_root(repo_root: Path, file_path: str) -> str:
         ["ls-files", "-s", "--", file_path],
         check=False,
         requires_index_lock=False,
+        literal_pathspecs=True,
     )
     if ls_result.returncode == 0 and ls_result.stdout.strip():
         parts = ls_result.stdout.strip().split()

--- a/src/git_stage_batch/data/file_tracking.py
+++ b/src/git_stage_batch/data/file_tracking.py
@@ -43,6 +43,7 @@ def list_untracked_files(paths: Iterable[str] | None = None) -> list[str]:
         check=False,
         text_output=False,
         requires_index_lock=False,
+        literal_pathspecs=paths is not None,
     )
     if result.returncode != 0:
         return []

--- a/src/git_stage_batch/data/index_entries.py
+++ b/src/git_stage_batch/data/index_entries.py
@@ -24,6 +24,7 @@ def read_index_entry(file_path: str) -> IndexEntry | None:
         check=False,
         text_output=False,
         requires_index_lock=False,
+        literal_pathspecs=True,
     )
     if result.returncode != 0:
         return None
@@ -59,6 +60,7 @@ def read_index_entries(file_paths: Iterable[str]) -> dict[str, IndexEntry]:
         check=False,
         text_output=False,
         requires_index_lock=False,
+        literal_pathspecs=True,
     )
     if result.returncode != 0:
         return {}

--- a/src/git_stage_batch/data/session.py
+++ b/src/git_stage_batch/data/session.py
@@ -375,6 +375,7 @@ def snapshot_file_if_untracked(
         ["ls-files", "--stage", "--", file_path],
         check=False,
         requires_index_lock=False,
+        literal_pathspecs=True,
     )
     if not stage_result.stdout.strip():
         # File not in index at all - it's untracked
@@ -421,6 +422,7 @@ def snapshot_files_if_untracked(file_paths: list[str]) -> None:
         check=False,
         text_output=False,
         requires_index_lock=False,
+        literal_pathspecs=True,
     )
 
     tracked_real_content: set[str] = set()

--- a/src/git_stage_batch/data/session.py
+++ b/src/git_stage_batch/data/session.py
@@ -244,6 +244,7 @@ def _initialize_abort_state() -> None:
             run_git_command(
                 ["reset", "-q", "HEAD", "--", *tracked_intent_to_add_files],
                 requires_index_lock=True,
+                literal_pathspecs=True,
             )
 
         # The stash covers tracked worktree and index changes. Untracked files

--- a/src/git_stage_batch/data/start_time_changes.py
+++ b/src/git_stage_batch/data/start_time_changes.py
@@ -386,6 +386,7 @@ def _paths_have_cached_diff(paths: list[str]) -> bool:
         ["diff", "--cached", "--quiet", "--no-renames", "--", *paths],
         check=False,
         requires_index_lock=False,
+        literal_pathspecs=True,
     )
     return result.returncode == 1
 
@@ -403,6 +404,7 @@ def _head_changed_since_session_start(paths: list[str]) -> bool:
         ["diff", "--quiet", abort_head, "HEAD", "--", *paths],
         check=False,
         requires_index_lock=False,
+        literal_pathspecs=True,
     )
     return result.returncode == 1
 

--- a/src/git_stage_batch/data/start_time_changes.py
+++ b/src/git_stage_batch/data/start_time_changes.py
@@ -91,6 +91,7 @@ def list_staged_change_records() -> list[StagedChangeRecord]:
         check=False,
         text_output=False,
         requires_index_lock=False,
+        literal_pathspecs=True,
     )
     if result.returncode != 0 or not result.stdout:
         return []

--- a/src/git_stage_batch/data/undo_worktree.py
+++ b/src/git_stage_batch/data/undo_worktree.py
@@ -70,6 +70,7 @@ def _gitlink_oids_from_index(paths: list[str]) -> dict[str, str]:
         check=False,
         text_output=False,
         requires_index_lock=False,
+        literal_pathspecs=True,
     )
     if result.returncode != 0:
         return {}
@@ -94,6 +95,7 @@ def _gitlink_oids_from_head(paths: list[str]) -> dict[str, str]:
         check=False,
         text_output=False,
         requires_index_lock=False,
+        literal_pathspecs=True,
     )
     if result.returncode != 0:
         return {}

--- a/src/git_stage_batch/utils/git_command.py
+++ b/src/git_stage_batch/utils/git_command.py
@@ -209,6 +209,7 @@ def stream_git_diff(
         cwd=cwd,
         env=env,
         requires_index_lock=False,
+        literal_pathspecs=bool(path_list),
     )
 
 

--- a/src/git_stage_batch/utils/git_command.py
+++ b/src/git_stage_batch/utils/git_command.py
@@ -68,6 +68,7 @@ def stream_git_command(
     cwd: str | None = None,
     env: dict[str, str] | None = None,
     requires_index_lock: bool = True,
+    literal_pathspecs: bool = False,
 ) -> Iterator[bytes]:
     """Stream git command output as bytes lines.
 
@@ -98,6 +99,7 @@ def stream_git_command(
             cwd=cwd,
             env=env,
             requires_index_lock=requires_index_lock,
+            literal_pathspecs=literal_pathspecs,
         )
     )
 
@@ -109,12 +111,18 @@ def stream_git_command_bytes(
     cwd: str | None = None,
     env: dict[str, str] | None = None,
     requires_index_lock: bool = True,
+    literal_pathspecs: bool = False,
 ) -> Iterator[bytes]:
     """Stream raw Git stdout chunks without line-oriented buffering."""
+    command_arguments = (
+        ["--literal-pathspecs", *arguments]
+        if literal_pathspecs
+        else arguments
+    )
     exit_code = 0
     stderr_chunks = []
     for event in stream_command(
-        ["git", *arguments],
+        ["git", *command_arguments],
         stdin_chunks,
         cwd=cwd,
         env=_prepare_git_command_environment(
@@ -135,7 +143,7 @@ def stream_git_command_bytes(
         stderr_text = b"".join(stderr_chunks).decode("utf-8", errors="replace")
         raise subprocess.CalledProcessError(
             exit_code,
-            ["git", *arguments],
+            ["git", *command_arguments],
             stderr=stderr_text,
         )
 
@@ -215,6 +223,7 @@ def run_git_command(
     capture_stdout: bool = True,
     capture_stderr: bool = True,
     requires_index_lock: bool = True,
+    literal_pathspecs: bool = False,
 ) -> subprocess.CompletedProcess:
     """Execute a git command with error handling.
 
@@ -235,7 +244,12 @@ def run_git_command(
     Raises:
         subprocess.CalledProcessError: If check=True and command fails
     """
-    command = ["git", *arguments]
+    command_arguments = (
+        ["--literal-pathspecs", *arguments]
+        if literal_pathspecs
+        else arguments
+    )
+    command = ["git", *command_arguments]
     reusable_stdin_chunks = (
         list(stdin_chunks)
         if requires_index_lock and stdin_chunks is not None

--- a/src/git_stage_batch/utils/git_index.py
+++ b/src/git_stage_batch/utils/git_index.py
@@ -255,4 +255,5 @@ def git_reset_paths(
         ["reset", "--", *paths],
         check=check,
         requires_index_lock=True,
+        literal_pathspecs=True,
     )

--- a/src/git_stage_batch/utils/git_index.py
+++ b/src/git_stage_batch/utils/git_index.py
@@ -208,7 +208,12 @@ def git_add_paths(
     if intent_to_add:
         arguments.append("-N")
     arguments.extend(["--", *paths])
-    return run_git_command(arguments, check=check, requires_index_lock=True)
+    return run_git_command(
+        arguments,
+        check=check,
+        requires_index_lock=True,
+        literal_pathspecs=True,
+    )
 
 
 def git_add_paths_from_stdin(

--- a/src/git_stage_batch/utils/git_object_io.py
+++ b/src/git_stage_batch/utils/git_object_io.py
@@ -343,6 +343,7 @@ def list_git_tree_blobs(
         check=False,
         text_output=False,
         requires_index_lock=False,
+        literal_pathspecs=True,
     )
     if result.returncode != 0:
         return {}

--- a/src/git_stage_batch/utils/git_worktree.py
+++ b/src/git_stage_batch/utils/git_worktree.py
@@ -43,6 +43,7 @@ def git_checkout_paths(
         ["checkout", treeish, "--", *paths],
         check=check,
         requires_index_lock=True,
+        literal_pathspecs=True,
     )
 
 

--- a/src/git_stage_batch/utils/git_worktree.py
+++ b/src/git_stage_batch/utils/git_worktree.py
@@ -101,7 +101,12 @@ def git_remove_paths(
     if ignore_unmatch:
         arguments.append("--ignore-unmatch")
     arguments.extend(["--", *paths])
-    return run_git_command(arguments, check=check, requires_index_lock=True)
+    return run_git_command(
+        arguments,
+        check=check,
+        requires_index_lock=True,
+        literal_pathspecs=True,
+    )
 
 
 def git_reset_hard(

--- a/src/git_stage_batch/utils/git_worktree.py
+++ b/src/git_stage_batch/utils/git_worktree.py
@@ -57,6 +57,7 @@ def git_checkout_index_paths(
         ["checkout", "--", *paths],
         check=check,
         requires_index_lock=True,
+        literal_pathspecs=True,
     )
 
 

--- a/src/git_stage_batch/utils/git_worktree.py
+++ b/src/git_stage_batch/utils/git_worktree.py
@@ -156,4 +156,5 @@ def git_submodule_update_checkout(
         cwd=cwd,
         check=check,
         requires_index_lock=True,
+        literal_pathspecs=True,
     )

--- a/tests/utils/test_git_index.py
+++ b/tests/utils/test_git_index.py
@@ -7,6 +7,7 @@ import pytest
 
 from git_stage_batch.utils.git_command import run_git_command
 from git_stage_batch.utils.git_index import (
+    git_add_paths,
     git_add_paths_from_stdin,
     git_commit_tree,
     git_read_tree,
@@ -139,6 +140,20 @@ class TestGitIndexPlumbing:
             path.encode("utf-8") for path in paths
         }
         assert run_git_command(["diff", "--cached", "--name-only"]).stdout == ""
+
+    def test_add_paths_treats_pathspec_metacharacters_literally(self, temp_git_repo):
+        """An exact filename must not expand into other worktree paths."""
+        (temp_git_repo / "*").write_text("literal star\n")
+        (temp_git_repo / "other.txt").write_text("other\n")
+
+        git_add_paths(["*"])
+
+        result = run_git_command(
+            ["diff", "--cached", "--name-only", "-z"],
+            text_output=False,
+            requires_index_lock=False,
+        )
+        assert result.stdout.split(b"\0") == [b"*", b""]
 
     def test_batched_force_remove_uses_repository_object_width(
         self,


### PR DESCRIPTION
Git path helpers accept repository-relative filenames from worktree and checkpoint state.

Passing those names through pathspec-aware commands can expand literal *, ?, or pathspec magic and affect unrelated paths.

This PR adds literal-pathspec execution to buffered and streamed Git helpers, then applies it across index, worktree, metadata, session, command, and gitlink operations.

Exact-path operations now preserve filename identity across every audited Git call.