### PR TITLE
index: Retry streamed index-info updates

### DIFF
--- a/src/git_stage_batch/utils/git_index.py
+++ b/src/git_stage_batch/utils/git_index.py
@@ -9,7 +9,7 @@ from collections.abc import Iterable, Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
 
-from .git_command import run_git_command, stream_git_command
+from .git_command import run_git_command
 from ..git_paths import encode_path
 from .git_repository import null_object_id
 
@@ -150,13 +150,12 @@ def git_update_index_entries(
     if not payload_chunks:
         return
 
-    for _chunk in stream_git_command(
+    run_git_command(
         ["update-index", "-z", "--index-info"],
-        payload_chunks,
+        stdin_chunks=payload_chunks,
         env=env,
         requires_index_lock=True,
-    ):
-        pass
+    )
 
 
 def git_write_tree(*, env: dict[str, str] | None = None) -> str:


### PR DESCRIPTION
Streamed index-info updates write bounded payloads through Git standard input.

Unlike buffered index mutations, they return immediately when a concurrent Git process briefly owns index.lock.

This PR routes index-info payloads through the existing bounded, retrying command helper.

Streaming index updates now share the repository transient-lock behavior.