### PR TITLE
include: Checkpoint multi-file rename partners

### DIFF
--- a/src/git_stage_batch/commands/file_scope/multi_file_actions.py
+++ b/src/git_stage_batch/commands/file_scope/multi_file_actions.py
@@ -17,6 +17,7 @@ from ...utils.git_repository import require_git_repository
 from ...utils.paths import ensure_state_directory_exists
 from .discard_to_batch import discard_files_to_batch
 from . import include_file as _include_file
+from .target_path import checkpoint_paths_for_live_files
 from ..selection.selected_change_display import show_selected_change
 from . import skip_file as _skip_file
 
@@ -112,7 +113,12 @@ def include_each_resolved_file(
     total_hunks = 0
     staged_files: list[str] = []
 
-    with _multi_file_undo_checkpoint("include", files):
+    checkpoint_paths = checkpoint_paths_for_live_files(list(files))
+    with _multi_file_undo_checkpoint(
+        "include",
+        files,
+        worktree_paths=checkpoint_paths,
+    ):
         for file_path in files:
             staged_hunks = _include_file.include_file_changes(
                 file_path,

--- a/src/git_stage_batch/commands/file_scope/target_path.py
+++ b/src/git_stage_batch/commands/file_scope/target_path.py
@@ -40,6 +40,13 @@ def checkpoint_paths_for_file_scope(
 
 def checkpoint_paths_for_live_file(target_file: str) -> list[str]:
     """Return every path a live whole-file action may mutate."""
+    return checkpoint_paths_for_live_files([target_file])
+
+
+def checkpoint_paths_for_live_files(target_files: list[str]) -> list[str]:
+    """Expand rename partners for several live paths with one diff scan."""
+    requested_paths = set(target_files)
+    checkpoint_paths = set(target_files)
     with acquire_unified_diff(
         stream_live_git_diff(
             full_index=True,
@@ -48,9 +55,8 @@ def checkpoint_paths_for_live_file(target_file: str) -> list[str]:
         )
     ) as patches:
         for patch in patches:
-            if isinstance(patch, RenameChange) and target_file in (
-                patch.old_path,
-                patch.new_path,
+            if isinstance(patch, RenameChange) and requested_paths.intersection(
+                (patch.old_path, patch.new_path)
             ):
-                return [patch.old_path, patch.new_path]
-    return [target_file]
+                checkpoint_paths.update((patch.old_path, patch.new_path))
+    return list(dict.fromkeys([*target_files, *sorted(checkpoint_paths - requested_paths)]))

--- a/tests/functional/test_undo.py
+++ b/tests/functional/test_undo.py
@@ -148,6 +148,26 @@ def test_undo_include_files_restores_entire_multi_file_operation(functional_repo
     assert beta.read_text() == "beta\nbeta change\n"
 
 
+def test_undo_include_files_restores_unmatched_rename_source(functional_repo):
+    """The multi-file checkpoint must include both sides of a staged rename."""
+    old_path = functional_repo / "old.txt"
+    other_path = functional_repo / "other.txt"
+    _commit_file(old_path, "renamed content\n")
+    _commit_file(other_path, "other\n")
+    new_path = functional_repo / "new.txt"
+    old_path.rename(new_path)
+    other_path.write_text("other\nchanged\n")
+
+    git_stage_batch("start")
+    git_stage_batch("include", "--files", "new.txt", "other.txt")
+    git_stage_batch("undo", "--force")
+
+    assert _git("diff", "--cached", "--name-status").stdout == ""
+    assert not old_path.exists()
+    assert new_path.read_text() == "renamed content\n"
+    assert other_path.read_text() == "other\nchanged\n"
+
+
 def test_undo_skip_files_restores_entire_multi_file_operation(functional_repo):
     """Undoing skip --files should clear every skipped hunk."""
     _create_two_changed_text_files(functional_repo)


### PR DESCRIPTION
Multi-file include uses one outer undo checkpoint while staging each matched path.

Destination-only rename matches can mutate both index sides while the outer checkpoint records only the selected destination.

This PR expands rename partners in one scan, uses that scope for the outer checkpoint, and covers forced undo.

Multi-file rename includes now restore the complete pre-operation index.