### PR TITLE
redo: Fail closed on incomplete checkpoints

### DIFF
--- a/src/git_stage_batch/data/undo_checkpoints.py
+++ b/src/git_stage_batch/data/undo_checkpoints.py
@@ -530,7 +530,7 @@ def _detect_conflicts(manifest: dict[str, Any]) -> list[str]:
 def _detect_redo_conflicts(manifest: dict[str, Any]) -> list[str]:
     after_undo = manifest.get("after_undo")
     if not isinstance(after_undo, dict):
-        return []
+        return [_('incomplete checkpoint')]
     return _detect_conflicts_against_state(after_undo)
 
 

--- a/tests/data/test_undo_checkpoints.py
+++ b/tests/data/test_undo_checkpoints.py
@@ -54,3 +54,8 @@ def test_legacy_gitlink_absence_is_normalized_for_conflict_checks():
     assert undo_checkpoints._worktree_state_by_path([legacy]) == (
         undo_checkpoints._worktree_state_by_path([current])
     )
+
+
+def test_redo_conflicts_fail_closed_without_after_undo_state():
+    """A partial redo node must require an explicit force override."""
+    assert undo_checkpoints._detect_redo_conflicts({}) == ["incomplete checkpoint"]


### PR DESCRIPTION
Undo checkpoints keep both pre-operation and post-undo state for conflict checks.

If after_undo is missing, redo treats the checkpoint as conflict-free even though its expected state is incomplete.

This PR makes missing redo state a conflict and covers the refusal directly.

Redo now fails closed at the same incomplete-checkpoint boundary as undo.