### PR TITLE
undo: Recover missing gitlink worktrees

### DIFF
--- a/src/git_stage_batch/data/undo_restore.py
+++ b/src/git_stage_batch/data/undo_restore.py
@@ -22,7 +22,7 @@ from ..git_paths import decode_path
 from ..utils.git_refs import (
     update_git_refs,
 )
-from ..utils.git_worktree import git_checkout_detached
+from ..utils.git_worktree import git_checkout_detached, git_submodule_update_checkout
 from ..utils.git_index import git_add_paths, git_update_index
 from ..utils.git_repository import (
     get_git_repository_root_path,
@@ -228,6 +228,12 @@ def _checkout_gitlink_worktree(
     force: bool = False,
 ) -> None:
     """Check out a gitlink commit only inside its exact nested repository."""
+    if not os.path.lexists(target_path):
+        git_submodule_update_checkout(
+            [file_path],
+            cwd=str(get_git_repository_root_path()),
+            check=False,
+        )
     if not is_git_repository_root_path(target_path):
         raise CommandError(
             _(

--- a/src/git_stage_batch/data/undo_worktree.py
+++ b/src/git_stage_batch/data/undo_worktree.py
@@ -156,7 +156,10 @@ def _snapshot_gitlink_path(
         "dirty": dirty,
         "blob": None,
     }
-    if worktree_exists and (head_oid is None or worktree_oid is None or dirty):
+    # A clean nested worktree can disappear after the checkpoint just as a
+    # dirty one can. Preserve a complete before-image so undo does not depend
+    # on a remote, .gitmodules entry, or still-present nested Git directory.
+    if worktree_exists:
         entry["archive"] = True
         entry["storage_mode"] = "100644"
         entry["blob"] = _create_directory_archive_blob(

--- a/src/git_stage_batch/utils/git_repository.py
+++ b/src/git_stage_batch/utils/git_repository.py
@@ -81,12 +81,11 @@ def is_git_repository_root_path(path: Path) -> bool:
     if result.returncode != 0:
         return False
     try:
-        requested_absolute = path.absolute()
+        if path.is_symlink():
+            return False
         requested_root = path.resolve()
         reported_root = Path(result.stdout.strip()).resolve()
     except OSError:
-        return False
-    if requested_absolute != requested_root:
         return False
     return reported_root == requested_root
 

--- a/tests/data/test_undo_restore.py
+++ b/tests/data/test_undo_restore.py
@@ -369,6 +369,54 @@ def test_restore_gitlink_refuses_superproject_walk_up(tmp_path, monkeypatch):
     ).stdout.strip() == symbolic_head
 
 
+def test_restore_legacy_clean_gitlink_initializes_missing_submodule(
+    tmp_path,
+    monkeypatch,
+):
+    """A missing legacy clean worktree gets one registered-submodule fallback."""
+    monkeypatch.chdir(tmp_path)
+    subprocess.run(["git", "init"], check=True, capture_output=True)
+    target = tmp_path / "sub"
+    update_calls = []
+
+    def initialize_submodule(paths, **kwargs):
+        update_calls.append((paths, kwargs))
+        subprocess.run(["git", "init", str(target)], check=True, capture_output=True)
+        return subprocess.CompletedProcess(["git", "submodule", "update"], 0, "", "")
+
+    checkout_calls = []
+    monkeypatch.setattr(undo_restore, "git_submodule_update_checkout", initialize_submodule)
+    monkeypatch.setattr(
+        undo_restore,
+        "git_checkout_detached",
+        lambda oid, **kwargs: (
+            checkout_calls.append((oid, kwargs))
+            or subprocess.CompletedProcess(["git", "checkout"], 0, "", "")
+        ),
+    )
+    monkeypatch.setattr(undo_restore, "_tree_entries", lambda *_args: [])
+
+    undo_restore.restore_worktree(
+        "checkpoint",
+        {
+            "worktree_paths": [
+                {
+                    "path": "sub",
+                    "kind": "gitlink",
+                    "exists": True,
+                    "worktree_oid": "1" * 40,
+                    "archive": False,
+                }
+            ]
+        },
+    )
+
+    assert update_calls == [
+        (["sub"], {"cwd": str(tmp_path), "check": False})
+    ]
+    assert checkout_calls[0][0] == "1" * 40
+
+
 def test_restore_directory_archive_allows_self_created_symlinks(tmp_path, monkeypatch):
     """The explicit tar filter remains compatible with archived symlinks."""
     monkeypatch.chdir(tmp_path)

--- a/tests/data/test_undo_worktree.py
+++ b/tests/data/test_undo_worktree.py
@@ -199,6 +199,8 @@ def test_gitlink_capture_uses_repository_relative_paths_from_subdirectory(
     assert entry["kind"] == "gitlink"
     assert entry["index_oid"] == nested_oid
     assert entry["head_oid"] == nested_oid
+    assert entry["archive"] is True
+    assert entry["blob"]
 
 
 def test_dirty_gitlink_capture_archives_exact_worktree_bytes(tmp_path, monkeypatch):

--- a/tests/utils/test_git_repository.py
+++ b/tests/utils/test_git_repository.py
@@ -107,6 +107,15 @@ class TestIsGitRepositoryRootPath:
 
         assert not is_git_repository_root_path(alias)
 
+    def test_accepts_repository_beneath_symlinked_parent(self, temp_git_repo):
+        """Only a symlink leaf is ambiguous; parent aliases may resolve normally."""
+        parent_alias = temp_git_repo.parent / "parent-alias"
+        parent_alias.symlink_to(temp_git_repo.parent, target_is_directory=True)
+        aliased_repository = parent_alias / temp_git_repo.name
+
+        assert not aliased_repository.is_symlink()
+        assert is_git_repository_root_path(aliased_repository)
+
 
 class TestNormalizeRepositoryPath:
     """Tests for normalized repository paths."""


### PR DESCRIPTION
Gitlink undo records nested commit identities and archives worktrees containing local changes.

Clean nested worktrees can disappear without an archive, legacy restoration assumes an existing root, and parent symlink aliases can falsely fail validation.

This PR archives every present gitlink, initializes missing legacy submodules, and accepts repository roots reached through symlinked parents while still rejecting leaf symlinks.

Gitlink restoration can recreate missing worktrees without weakening exact-root checks.