### PR TITLE
ownership: Preserve baseline placement identity

### DIFF
--- a/src/git_stage_batch/batch/merge/baseline_reference_positions.py
+++ b/src/git_stage_batch/batch/merge/baseline_reference_positions.py
@@ -88,7 +88,9 @@ def baseline_reference_absence_position(
         return None
 
     after_content = getattr(reference, "after_content", None)
-    if after_line is not None and after_content is not None:
+    if after_line is not None:
+        if after_content is None:
+            return None
         if after_line < 1 or after_line > len(working_lines):
             return None
         if not _reference_line_matches(

--- a/src/git_stage_batch/batch/ownership/hunk_translation.py
+++ b/src/git_stage_batch/batch/ownership/hunk_translation.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from ...core.line_selection import LineRanges
 from ...core.models import LineEntry
 from . import hunk_replacement_translation as _hunk_replacement_translation
@@ -28,6 +30,7 @@ def translate_hunk_selection_to_batch_ownership(
     selected_display_ids: set[int],
     *,
     replacement_line_runs: list[_ReplacementLineRun] | None = None,
+    baseline_lines: Sequence[bytes] | None = None,
 ) -> BatchOwnership:
     """Translate selected live-hunk IDs while retaining full-hunk boundaries.
 
@@ -41,7 +44,15 @@ def translate_hunk_selection_to_batch_ownership(
     runs derived from the full files represented by the hunk. This function does
     not infer semantic replacement units from the pregenerated diff layout.
     """
-    old_line_content = _old_line_content_by_number(hunk_lines)
+    old_line_content = (
+        {
+            line_number: content
+            for line_number, content in enumerate(baseline_lines, start=1)
+        }
+        if baseline_lines is not None
+        else {}
+    )
+    old_line_content.update(_old_line_content_by_number(hunk_lines))
     hunk_content_view = _LineEntryContentSequence(hunk_lines)
     replacement_translation = (
         _hunk_replacement_translation.translate_hunk_replacement_line_runs(

--- a/src/git_stage_batch/batch/ownership/unit_rebuild.py
+++ b/src/git_stage_batch/batch/ownership/unit_rebuild.py
@@ -18,11 +18,19 @@ from .unit_types import (
 def rebuild_ownership_from_units(units: list[_UnitRecord]) -> BatchOwnership:
     """Rebuild BatchOwnership from semantic ownership units."""
     all_presence_lines = LineRanges.empty()
+    all_presence_references = {}
     all_deletions = []
     replacement_units: list[ReplacementUnit] = []
 
     for unit in units:
         all_presence_lines = all_presence_lines.union(unit.claimed_source_lines)
+        all_presence_references.update(
+            {
+                line: reference
+                for line, reference in unit.baseline_references.items()
+                if line in unit.claimed_source_lines
+            }
+        )
         deletion_indices = []
         for deletion in unit.deletion_claims:
             all_deletions.append(deletion)
@@ -38,7 +46,10 @@ def rebuild_ownership_from_units(units: list[_UnitRecord]) -> BatchOwnership:
             ))
 
     return BatchOwnership(
-        presence_claims=presence_claims_from_source_lines(all_presence_lines),
+        presence_claims=presence_claims_from_source_lines(
+            all_presence_lines,
+            all_presence_references,
+        ),
         deletions=all_deletions,
         replacement_units=normalize_replacement_units(
             replacement_units,

--- a/src/git_stage_batch/batch/ownership/unit_types.py
+++ b/src/git_stage_batch/batch/ownership/unit_types.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 
 from ...core.line_selection import LineRanges
 from .absence_claims import AbsenceClaim
+from .references import BaselineReference
 from .replacement_units import ReplacementUnitOrigin
 
 
@@ -44,6 +45,7 @@ class OwnershipUnit:
     claimed_source_lines: LineRanges
     deletion_claims: list[AbsenceClaim]
     display_line_ids: LineRanges
+    baseline_references: dict[int, BaselineReference] = field(default_factory=dict)
     is_atomic: bool = False
     atomic_reason: str | None = None
     preserves_replacement_unit: bool = False

--- a/src/git_stage_batch/batch/ownership/units.py
+++ b/src/git_stage_batch/batch/ownership/units.py
@@ -20,6 +20,18 @@ from .unit_types import (
 from .replacement_units import normalize_replacement_units
 
 
+def _presence_references_for_lines(
+    ownership: BatchOwnership,
+    source_lines: LineSelection,
+) -> dict:
+    """Return baseline references owned by one semantic unit."""
+    return {
+        line: reference
+        for line, reference in ownership.presence_baseline_references().items()
+        if line in source_lines
+    }
+
+
 def build_ownership_units_from_display_lines(
     ownership: BatchOwnership,
     display_lines: list[dict],
@@ -136,6 +148,10 @@ def build_ownership_units_from_display_lines(
                     claimed_source_lines=LineRanges.from_lines([claimed_source_line]),
                     deletion_claims=[],
                     display_line_ids=LineRanges.from_lines([claimed_display_id]),
+                    baseline_references=_presence_references_for_lines(
+                        ownership,
+                        LineRanges.from_lines([claimed_source_line]),
+                    ),
                     is_atomic=False,
                     atomic_reason=None
                 ))
@@ -205,6 +221,10 @@ def _build_explicit_replacement_units_from_display_lines(
             claimed_source_lines=claimed_source_lines,
             deletion_claims=deletion_claims,
             display_line_ids=claimed_display_ids.union(deletion_display_ids),
+            baseline_references=_presence_references_for_lines(
+                ownership,
+                claimed_source_lines,
+            ),
             is_atomic=True,
             atomic_reason="explicit_replacement",
             preserves_replacement_unit=True,
@@ -301,12 +321,17 @@ def _build_replacement_unit(
         for idx in set(deletion_run["deletion_indices"])
     ]
 
+    claimed_source_lines = LineRanges.from_lines(claimed_run["source_lines"])
     return _UnitRecord(
         kind=_UnitKind.REPLACEMENT,
-        claimed_source_lines=LineRanges.from_lines(claimed_run["source_lines"]),
+        claimed_source_lines=claimed_source_lines,
         deletion_claims=deletion_claims,
         display_line_ids=LineRanges.from_lines(
             [*deletion_run["display_ids"], *claimed_run["display_ids"]]
+        ),
+        baseline_references=_presence_references_for_lines(
+            ownership,
+            claimed_source_lines,
         ),
         is_atomic=True,
         atomic_reason="display_adjacency"

--- a/src/git_stage_batch/commands/selection/include_line_selection.py
+++ b/src/git_stage_batch/commands/selection/include_line_selection.py
@@ -289,6 +289,7 @@ def try_build_index_content_via_transient_batch(
         ownership = translate_hunk_selection_to_batch_ownership(
             line_changes.lines,
             selected_display_ids,
+            baseline_lines=hunk_base_lines,
             replacement_line_runs=replacement_selection.derive_replacement_line_runs(
                 hunk_base_lines=hunk_base_lines,
                 hunk_source_lines=hunk_source_lines,

--- a/tests/batch/merge/test_merge.py
+++ b/tests/batch/merge/test_merge.py
@@ -1025,7 +1025,10 @@ class TestMergeBatch:
                 AbsenceClaim(
                     anchor_line=2,
                     content_lines=[b"old value\n"],
-                    baseline_reference=BaselineReference(after_line=1),
+                    baseline_reference=BaselineReference(
+                        after_line=1,
+                        after_content=b"line1\n",
+                    ),
                 )
             ],
         )
@@ -1033,6 +1036,24 @@ class TestMergeBatch:
         result = merge_batch(source, ownership, working)
 
         assert result == b"line1\nline3\n"
+
+    def test_baseline_referenced_absence_rejects_unidentified_numeric_anchor(self):
+        """A line number alone cannot prove which duplicate occurrence is owned."""
+        source = b"line1\nnew context\nline3\n"
+        working = b"line1\nold value\nline3\n"
+        ownership = BatchOwnership.from_presence_lines(
+            [],
+            [
+                AbsenceClaim(
+                    anchor_line=2,
+                    content_lines=[b"old value\n"],
+                    baseline_reference=BaselineReference(after_line=1),
+                )
+            ],
+        )
+
+        with pytest.raises(MergeError):
+            merge_batch(source, ownership, working)
 
     def test_baseline_referenced_absence_is_noop_when_already_absent(self):
         """Already-satisfied absence constraints should not block a round trip."""

--- a/tests/batch/ownership/test_units.py
+++ b/tests/batch/ownership/test_units.py
@@ -632,6 +632,30 @@ def test_rebuild_preserves_explicit_replacement_units():
     assert rebuilt.replacement_units[0].origin == origin
 
 
+def test_rebuild_preserves_presence_baseline_references():
+    """Unit filtering must retain placement identity for surviving claims."""
+    first_reference = BaselineReference(
+        after_line=1,
+        after_content=b"anchor one\n",
+    )
+    second_reference = BaselineReference(
+        after_line=2,
+        after_content=b"anchor two\n",
+    )
+    ownership = BatchOwnership.from_presence_lines(
+        ["1-2"],
+        baseline_references={1: first_reference, 2: second_reference},
+    )
+    units = _ownership_units_for_source(ownership, b"first\nsecond\n")
+
+    rebuilt = rebuild_ownership_from_units([units[1]])
+
+    assert rebuilt.presence_claims[0].source_lines == ["2"]
+    assert rebuilt.presence_claims[0].baseline_references == {
+        2: second_reference,
+    }
+
+
 def test_rebuild_preserves_mixed_same_anchor_deletion_order():
     """Same-anchor explicit and inferred deletions should keep stable indexes."""
     batch_source = b"new explicit\nnew inferred\nkeep\n"


### PR DESCRIPTION
Line ownership uses baseline references to place insertions and deletions after content drifts.

Rebuilding presence claims can drop those references, while absence anchors and context-free hunks can retain line numbers without content identity.

This PR stores references on semantic units, restores surviving references during rebuilds, rejects contentless absence anchors, and translates hunks against complete baselines.

Ownership transformations now preserve content-backed placement identity.