### PR TITLE
include: Enforce line-selection safety boundaries

### DIFF
--- a/src/git_stage_batch/commands/selection/include_line_action.py
+++ b/src/git_stage_batch/commands/selection/include_line_action.py
@@ -11,7 +11,10 @@ from ...core.line_selection import parse_line_selection
 from ...data.file_review.action_scope import finish_review_scoped_line_action
 from ...data.selected_change.paths import get_selected_change_file_path
 from ...data.line_id_files import read_line_ids_file, write_line_ids_file
-from ...utils.repository_buffers import read_git_object_buffer_or_none
+from ...utils.repository_buffers import (
+    load_working_tree_file_as_buffer,
+    read_git_object_buffer_or_none,
+)
 from ...data.selected_change.store import (
     SelectedChangeKind,
     read_selected_change_kind,
@@ -30,6 +33,19 @@ from ...utils.paths import (
 from . import include_line_selection as _include_line_selection
 from . import replacement_selection
 from .selected_hunk_refresh import refresh_selected_hunk_after_line_action
+
+
+def _selection_uses_only_bare_cr_line_breaks(*line_sequences) -> bool:
+    """Return whether nonempty line breaks use bare CR and never LF."""
+    saw_bare_carriage_return = False
+    for lines in line_sequences:
+        for line in lines:
+            content = bytes(line)
+            if b"\n" in content:
+                return False
+            if b"\r" in content:
+                saw_bare_carriage_return = True
+    return saw_bare_carriage_return
 
 
 def include_live_line_selection(
@@ -121,19 +137,43 @@ def include_live_line_selection(
                 and transient_result.failure_reason
                 == _include_line_selection.TransientIncludeFailureReason.INDEX_MERGE_FAILED
                 and buffer_matches(current_index_lines, hunk_base_lines)
+                and _selection_uses_only_bare_cr_line_breaks(
+                    hunk_base_lines,
+                    hunk_source_lines,
+                )
             ):
-                transient_result = _include_line_selection.TransientIncludeResult.success(
+                with (
+                    load_working_tree_file_as_buffer(line_changes.path) as working_lines,
                     build_target_index_buffer_from_lines(
                         line_changes,
                         set(combined_include_ids),
-                        hunk_base_lines,
+                        hunk_source_lines,
                         base_has_trailing_newline=(
                             _include_line_selection.line_sequence_ends_with_lf(
-                                hunk_base_lines
+                                hunk_source_lines
                             )
                         ),
+                    ) as target_working_lines,
+                ):
+                    working_tree_is_unchanged = buffer_matches(
+                        working_lines,
+                        hunk_source_lines,
+                    ) and buffer_matches(working_lines, target_working_lines)
+                if working_tree_is_unchanged:
+                    transient_result = (
+                        _include_line_selection.TransientIncludeResult.success(
+                            build_target_index_buffer_from_lines(
+                                line_changes,
+                                set(combined_include_ids),
+                                hunk_base_lines,
+                                base_has_trailing_newline=(
+                                    _include_line_selection.line_sequence_ends_with_lf(
+                                        hunk_base_lines
+                                    )
+                                ),
+                            )
+                        )
                     )
-                )
         if transient_result.buffer is not None:
             log_journal(
                 "include_line_transient_batch_staging_used",

--- a/src/git_stage_batch/commands/selection/include_line_selection.py
+++ b/src/git_stage_batch/commands/selection/include_line_selection.py
@@ -227,21 +227,42 @@ def annotate_line_changes_with_working_tree_source(line_changes):
         return None
 
     last_source_line: int | None = None
+    coordinate_delta = 0
+    in_deletion_run = False
+    deletion_run_anchor: int | None = None
     new_lines = []
     for line in line_changes.lines:
         source_line = None
-        if line.kind in {" ", "+"}:
+        if line.kind == " ":
             source_line = line.new_line_number
             if source_line is not None:
                 last_source_line = source_line
+                if line.old_line_number is not None:
+                    coordinate_delta = line.new_line_number - line.old_line_number
+            else:
+                # Synthetic gaps separate hunk coordinate spaces. Do not carry
+                # an anchor across omitted working-tree lines.
+                last_source_line = None
+            in_deletion_run = False
+            deletion_run_anchor = None
+        elif line.kind == "+":
+            source_line = line.new_line_number
+            if source_line is not None:
+                last_source_line = source_line
+            coordinate_delta += 1
+            in_deletion_run = False
+            deletion_run_anchor = None
         elif line.kind == "-":
-            source_line = last_source_line
-            if (
-                source_line is None
-                and line.old_line_number is not None
-                and line.old_line_number > 1
-            ):
-                source_line = line.old_line_number - 1
+            if not in_deletion_run:
+                deletion_run_anchor = last_source_line
+                if deletion_run_anchor is None and line.old_line_number is not None:
+                    translated_anchor = (
+                        line.old_line_number - 1 + coordinate_delta
+                    )
+                    deletion_run_anchor = max(translated_anchor, 0) or None
+            source_line = deletion_run_anchor
+            coordinate_delta -= 1
+            in_deletion_run = True
 
         new_lines.append(replace(line, source_line=source_line))
 

--- a/src/git_stage_batch/commands/selection/include_line_selection.py
+++ b/src/git_stage_batch/commands/selection/include_line_selection.py
@@ -287,11 +287,21 @@ def try_build_index_content_via_transient_batch(
         )
 
     if not current_index_lines and all(line.kind == "+" for line in line_changes.lines):
+        if any(line.source_line is None for line in selected_lines):
+            return TransientIncludeResult.failure(
+                TransientIncludeFailureReason.PREPARATION_FAILED,
+                detail="missing source line for new-file selection",
+            )
+        with load_working_tree_file_as_buffer(line_changes.path) as working_lines:
+            if not buffer_matches(working_lines, hunk_source_lines):
+                return TransientIncludeResult.failure(
+                    TransientIncludeFailureReason.WORKING_TREE_WOULD_CHANGE,
+                    detail="working tree changed after new-file snapshot",
+                )
         return TransientIncludeResult.success(
             LineBuffer.from_chunks(
                 hunk_source_lines[line.source_line - 1]
                 for line in selected_lines
-                if line.source_line is not None
             )
         )
 

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -16935,6 +16935,7 @@ def test_include_line_action_stays_in_command_helper():
         "exit_with_error",
         "get_index_snapshot_file_path",
         "get_working_tree_snapshot_file_path",
+        "load_working_tree_file_as_buffer",
         "read_git_object_buffer_or_none",
         "parse_line_selection",
         "read_line_ids_file",

--- a/tests/commands/test_include.py
+++ b/tests/commands/test_include.py
@@ -800,6 +800,43 @@ class TestCommandIncludeLine:
         assert "round" not in exc_info.value.message.lower()
         assert "transient" not in exc_info.value.message.lower()
 
+    def test_include_line_does_not_bypass_index_merge_refusal(
+        self,
+        temp_git_repo,
+        monkeypatch,
+    ):
+        """Ordinary content must fail closed when its ownership merge is refused."""
+        test_file = temp_git_repo / "test.txt"
+        test_file.write_text("base\n")
+        subprocess.run(["git", "add", "test.txt"], check=True, cwd=temp_git_repo)
+        subprocess.run(
+            ["git", "commit", "-m", "Add file"],
+            check=True,
+            cwd=temp_git_repo,
+        )
+        test_file.write_text("base\nselected\n")
+        command_start()
+        fetch_next_change()
+
+        monkeypatch.setattr(
+            include_line_selection,
+            "try_build_index_content_via_transient_batch",
+            lambda **_kwargs: include_line_selection.TransientIncludeResult.failure(
+                include_line_selection.TransientIncludeFailureReason.INDEX_MERGE_FAILED
+            ),
+        )
+
+        with pytest.raises(CommandError, match="no longer fits the current staged content"):
+            command_include_line("1")
+
+        assert subprocess.run(
+            ["git", "diff", "--cached", "--name-only"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+            text=True,
+        ).stdout == ""
+
     def test_include_line_handles_deletions(self, temp_git_repo):
         """Test that include --line handles deletions correctly."""
         # Create a file with multiple lines


### PR DESCRIPTION
Line include translates selected diff coordinates into target index content and normally uses a transient merge.

Deletion coordinates can drift across hunks, new files can omit selected source lines, and classic fallback can bypass merge and working-tree safeguards.

This PR translates deletion runs with explicit deltas, validates new-file source coordinates and content, and restricts fallback to carriage-return compatibility with working-tree identity checks.

Line selection no longer stages ambiguous or stale content after merge refusal.