### PR TITLE
state: Publish complete selected-change snapshots

### DIFF
--- a/src/git_stage_batch/data/selected_change/batch_file_cache.py
+++ b/src/git_stage_batch/data/selected_change/batch_file_cache.py
@@ -15,12 +15,14 @@ from ...utils.paths import (
     get_index_snapshot_file_path,
     get_line_changes_json_file_path,
     get_selected_hunk_hash_file_path,
+    get_snapshot_metadata_file_path,
     get_working_tree_snapshot_file_path,
 )
 from ...batch.file_display import render_batch_file_display
 from ..line_state import convert_line_changes_to_serializable_dict
 from .store import (
     SelectedChangeKind,
+    invalidate_selected_change_cache,
     write_selected_change_kind,
     write_selected_hunk_patch_lines,
 )
@@ -96,9 +98,9 @@ def cache_rendered_batch_file_display(
 
     patch_hash = compute_stable_hunk_hash_from_lines(patch_lines)
 
+    invalidate_selected_change_cache()
     write_selected_hunk_patch_lines(patch_lines)
     write_text_file_contents(get_selected_hunk_hash_file_path(), patch_hash)
-    write_selected_change_kind(SelectedChangeKind.BATCH_FILE)
 
     write_text_file_contents(
         get_line_changes_json_file_path(),
@@ -111,3 +113,5 @@ def cache_rendered_batch_file_display(
 
     get_index_snapshot_file_path().unlink(missing_ok=True)
     get_working_tree_snapshot_file_path().unlink(missing_ok=True)
+    get_snapshot_metadata_file_path().unlink(missing_ok=True)
+    write_selected_change_kind(SelectedChangeKind.BATCH_FILE)

--- a/src/git_stage_batch/data/selected_change/file_changes.py
+++ b/src/git_stage_batch/data/selected_change/file_changes.py
@@ -30,11 +30,13 @@ from ...utils.paths import (
     get_selected_hunk_hash_file_path,
     get_selected_hunk_patch_file_path,
     get_selected_rename_file_json_path,
+    get_snapshot_metadata_file_path,
     get_selected_text_deletion_file_json_path,
     get_working_tree_snapshot_file_path,
 )
 from .store import (
     SelectedChangeKind,
+    invalidate_selected_change_cache,
     read_selected_change_kind,
     write_selected_change_kind,
 )
@@ -346,9 +348,11 @@ def cache_text_deletion_change(deletion_change: TextFileDeletionChange) -> None:
 
 def _clear_selected_line_payload_files() -> None:
     """Clear selected line/hunk state before storing an atomic file selection."""
+    invalidate_selected_change_cache()
     get_selected_hunk_patch_file_path().unlink(missing_ok=True)
     get_line_changes_json_file_path().unlink(missing_ok=True)
     get_index_snapshot_file_path().unlink(missing_ok=True)
     get_working_tree_snapshot_file_path().unlink(missing_ok=True)
+    get_snapshot_metadata_file_path().unlink(missing_ok=True)
     get_processed_include_ids_file_path().unlink(missing_ok=True)
     get_processed_skip_ids_file_path().unlink(missing_ok=True)

--- a/src/git_stage_batch/data/selected_change/file_hunk_cache.py
+++ b/src/git_stage_batch/data/selected_change/file_hunk_cache.py
@@ -25,6 +25,7 @@ from ..line_state import convert_line_changes_to_serializable_dict
 from .snapshots import write_snapshots_for_selected_file_path
 from .store import (
     SelectedChangeKind,
+    invalidate_selected_change_cache,
     write_selected_change_kind,
     write_selected_hunk_patch_lines,
 )
@@ -85,9 +86,9 @@ def _cache_combined_file_line_changes(
 
     patch_hash = compute_stable_hunk_hash_from_lines(patch_lines)
 
+    invalidate_selected_change_cache()
     write_selected_hunk_patch_lines(patch_lines)
     write_text_file_contents(get_selected_hunk_hash_file_path(), patch_hash)
-    write_selected_change_kind(SelectedChangeKind.FILE)
     write_line_ids_file(get_processed_include_ids_file_path(), set())
     write_line_ids_file(get_processed_skip_ids_file_path(), set())
     write_text_file_contents(
@@ -100,5 +101,6 @@ def _cache_combined_file_line_changes(
     )
 
     write_snapshots_for_selected_file_path(file_path)
+    write_selected_change_kind(SelectedChangeKind.FILE)
 
     return combined_line_changes

--- a/src/git_stage_batch/data/selected_change/snapshots.py
+++ b/src/git_stage_batch/data/selected_change/snapshots.py
@@ -17,8 +17,8 @@ from ...utils.repository_buffers import (
     read_working_tree_object,
 )
 from ...exceptions import RepositoryPathMissing
-from ...data.index_entries import IndexEntry, read_index_entry
-from ...data.file_modes import detect_file_mode_in_commit
+from ...data.index_entries import read_index_entry
+from ...data.session import path_is_intent_to_add
 from ...utils.file_io import write_text_file_contents
 from ...utils.journal import JournalLevel, journal_enabled, log_journal
 from ...utils.paths import (
@@ -28,7 +28,7 @@ from ...utils.paths import (
 )
 
 
-_SNAPSHOT_SCHEMA_VERSION = 1
+_SNAPSHOT_SCHEMA_VERSION = 2
 
 
 def write_snapshots_for_selected_file_path(file_path: str) -> None:
@@ -52,6 +52,10 @@ def write_snapshots_for_selected_file_path(file_path: str) -> None:
             working_tree_version = LineBuffer.from_bytes(b"")
             worktree_metadata = {"exists": False, "kind": None, "mode": None}
         stack.enter_context(working_tree_version)
+        index_snapshot_source = "index"
+        index_is_intent_to_add = (
+            index_entry is not None and path_is_intent_to_add(file_path)
+        )
 
         # When index is empty but working tree has content, check if file exists in HEAD.
         # For new files (not in HEAD), use empty index snapshot.
@@ -59,15 +63,13 @@ def write_snapshots_for_selected_file_path(file_path: str) -> None:
         if (
             buffer_byte_count(index_version) == 0
             and buffer_byte_count(working_tree_version) > 0
+            and index_is_intent_to_add
         ):
             head_version = read_git_object_buffer_or_none(f"HEAD:{file_path}")
             if head_version is not None:
                 if buffer_byte_count(head_version) > 0:
                     index_version = stack.enter_context(head_version)
-                    # Intent-to-add represents the pre-session HEAD state here.
-                    head_mode = detect_file_mode_in_commit("HEAD", file_path)
-                    if head_mode is not None:
-                        index_entry = IndexEntry(head_mode, "") if index_entry else None
+                    index_snapshot_source = "head"
                 else:
                     head_version.close()
 
@@ -81,6 +83,11 @@ def write_snapshots_for_selected_file_path(file_path: str) -> None:
             "index": {
                 "exists": index_entry is not None,
                 "mode": index_entry.mode if index_entry is not None else None,
+                "object_id": (
+                    index_entry.object_id if index_entry is not None else None
+                ),
+                "intent_to_add": index_is_intent_to_add,
+                "snapshot_source": index_snapshot_source,
             },
             "worktree": worktree_metadata,
         }
@@ -174,6 +181,15 @@ def snapshots_are_stale(file_path: str) -> bool:
             index_metadata = {
                 "exists": index_entry is not None,
                 "mode": index_entry.mode if index_entry is not None else None,
+                "object_id": (
+                    index_entry.object_id if index_entry is not None else None
+                ),
+                "intent_to_add": (
+                    index_entry is not None and path_is_intent_to_add(file_path)
+                ),
+                "snapshot_source": manifest.get("index", {}).get(
+                    "snapshot_source"
+                ),
             }
             if manifest.get("index") != index_metadata:
                 return True
@@ -181,6 +197,18 @@ def snapshots_are_stale(file_path: str) -> bool:
             if selected_index_content is None:
                 selected_index_content = LineBuffer.from_bytes(b"")
             stack.enter_context(selected_index_content)
+            index_snapshot_source = manifest["index"]["snapshot_source"]
+            if index_snapshot_source == "head":
+                selected_snapshot_base = read_git_object_buffer_or_none(
+                    f"HEAD:{file_path}"
+                )
+                if selected_snapshot_base is None:
+                    return True
+                stack.enter_context(selected_snapshot_base)
+            elif index_snapshot_source == "index":
+                selected_snapshot_base = selected_index_content
+            else:
+                return True
 
             try:
                 worktree_object = read_working_tree_object(file_path)
@@ -198,7 +226,7 @@ def snapshots_are_stale(file_path: str) -> bool:
                 return True
 
             return not buffer_matches(
-                cached_index_content, selected_index_content
+                cached_index_content, selected_snapshot_base
             ) or not buffer_matches(cached_worktree_content, selected_worktree_content)
     except Exception:
         return True  # Error reading means state is stale

--- a/src/git_stage_batch/data/selected_change/store.py
+++ b/src/git_stage_batch/data/selected_change/store.py
@@ -99,11 +99,12 @@ def cache_hunk_change(
     line_changes: LineLevelChange,
 ) -> None:
     """Cache a text hunk as the current selected change."""
+    invalidate_selected_change_cache()
     write_selected_hunk_patch_lines(patch_lines)
     write_text_file_contents(get_selected_hunk_hash_file_path(), hunk_hash)
-    write_selected_change_kind(SelectedChangeKind.HUNK)
     write_line_changes_state(line_changes)
     write_snapshots_for_selected_file_path(line_changes.path)
+    write_selected_change_kind(SelectedChangeKind.HUNK)
 
 
 def load_line_changes_from_patch_path(patch_path: Path) -> LineLevelChange:

--- a/src/git_stage_batch/data/selected_change/store.py
+++ b/src/git_stage_batch/data/selected_change/store.py
@@ -18,7 +18,11 @@ from ...core.buffer import (
     LineBuffer,
     write_buffer_to_path,
 )
-from ...utils.file_io import read_text_file_contents, write_text_file_contents
+from ...utils.file_io import (
+    fsync_directory,
+    read_text_file_contents,
+    write_text_file_contents,
+)
 from ...utils.paths import (
     get_index_snapshot_file_path,
     get_line_changes_json_file_path,
@@ -181,6 +185,13 @@ def write_selected_change_kind(kind: SelectedChangeKind) -> None:
     if kind not in (SelectedChangeKind.MODE, SelectedChangeKind.BATCH_MODE):
         get_selected_mode_change_json_path().unlink(missing_ok=True)
     write_text_file_contents(get_selected_change_kind_file_path(), kind)
+
+
+def invalidate_selected_change_cache() -> None:
+    """Durably hide the old cache before replacing its component files."""
+    kind_path = get_selected_change_kind_file_path()
+    kind_path.unlink(missing_ok=True)
+    fsync_directory(kind_path.parent)
 
 
 def read_selected_change_kind() -> SelectedChangeKind | None:

--- a/src/git_stage_batch/data/selected_change/store.py
+++ b/src/git_stage_batch/data/selected_change/store.py
@@ -21,6 +21,7 @@ from ...core.buffer import (
 from ...utils.file_io import (
     fsync_directory,
     read_text_file_contents,
+    write_file_bytes,
     write_text_file_contents,
 )
 from ...utils.paths import (
@@ -155,14 +156,21 @@ def snapshot_selected_change_state() -> SelectedChangeStateSnapshot:
 
 
 def restore_selected_change_state(snapshot: SelectedChangeStateSnapshot) -> None:
-    """Restore a previously captured selected change cache."""
-    for name, path in _selected_change_state_paths().items():
+    """Restore a cache privately and publish its kind marker last."""
+    state_paths = _selected_change_state_paths()
+    invalidate_selected_change_cache()
+    for name, path in state_paths.items():
+        if name == "kind":
+            continue
         snapshot_path = snapshot.paths.get(name)
         if snapshot_path is None:
             path.unlink(missing_ok=True)
         else:
-            path.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copyfile(snapshot_path, path)
+            write_file_bytes(path, snapshot_path.read_bytes())
+
+    kind_snapshot_path = snapshot.paths.get("kind")
+    if kind_snapshot_path is not None:
+        write_file_bytes(state_paths["kind"], kind_snapshot_path.read_bytes())
 
 
 def clear_selected_change_persistence_files() -> None:

--- a/src/git_stage_batch/utils/file_io.py
+++ b/src/git_stage_batch/utils/file_io.py
@@ -160,7 +160,8 @@ def _preserve_ownership(
     return True
 
 
-def _fsync_directory(path: Path) -> None:
+def fsync_directory(path: Path) -> None:
+    """Durably publish directory-entry changes where the platform permits."""
     flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
     try:
         directory_descriptor = os.open(path, flags)
@@ -205,7 +206,7 @@ def _write_file_contents_atomically(
             os.fchmod(file_handle.fileno(), replacement_mode)
             os.fsync(file_handle.fileno())
         os.replace(temporary_path, path)
-        _fsync_directory(path.parent)
+        fsync_directory(path.parent)
     finally:
         temporary_path.unlink(missing_ok=True)
 

--- a/tests/data/test_selected_change_store.py
+++ b/tests/data/test_selected_change_store.py
@@ -128,3 +128,26 @@ def test_selected_state_snapshot_restores_snapshot_metadata(temp_git_repo):
         restore_selected_change_state(snapshot)
 
     assert metadata_path.read_bytes() == original_metadata
+
+def test_interrupted_hunk_cache_is_not_visible(temp_git_repo, monkeypatch):
+    """The kind marker publishes a cache only after every component is durable."""
+    from git_stage_batch.data.selected_change import store
+
+    line_changes = LineLevelChange(
+        path="test.py",
+        header=HunkHeader(old_start=1, old_len=1, new_start=1, new_len=1),
+        lines=[],
+    )
+    cache_hunk_change([b"old patch\n"], "old-hash", line_changes)
+    assert read_selected_change_kind() is SelectedChangeKind.HUNK
+
+    monkeypatch.setattr(
+        store,
+        "write_snapshots_for_selected_file_path",
+        lambda _path: (_ for _ in ()).throw(OSError("synthetic crash")),
+    )
+
+    with pytest.raises(OSError, match="synthetic crash"):
+        cache_hunk_change([b"new patch\n"], "new-hash", line_changes)
+
+    assert read_selected_change_kind() is None

--- a/tests/data/test_selected_change_store.py
+++ b/tests/data/test_selected_change_store.py
@@ -129,6 +129,34 @@ def test_selected_state_snapshot_restores_snapshot_metadata(temp_git_repo):
 
     assert metadata_path.read_bytes() == original_metadata
 
+
+def test_selected_state_restore_publishes_kind_last(temp_git_repo, monkeypatch):
+    """A failed restore remains invisible until every component is durable."""
+    from git_stage_batch.data.selected_change import store
+
+    line_changes = LineLevelChange(
+        path="test.py",
+        header=HunkHeader(old_start=1, old_len=1, new_start=1, new_len=1),
+        lines=[],
+    )
+    cache_hunk_change([b"patch\n"], "hash", line_changes)
+
+    with snapshot_selected_change_state() as snapshot:
+        real_write_file_bytes = store.write_file_bytes
+
+        def fail_on_line_state(path, content):
+            if path == get_line_changes_json_file_path():
+                assert read_selected_change_kind() is None
+                raise OSError("synthetic restore crash")
+            real_write_file_bytes(path, content)
+
+        monkeypatch.setattr(store, "write_file_bytes", fail_on_line_state)
+        with pytest.raises(OSError, match="synthetic restore crash"):
+            restore_selected_change_state(snapshot)
+
+    assert read_selected_change_kind() is None
+
+
 def test_interrupted_hunk_cache_is_not_visible(temp_git_repo, monkeypatch):
     """The kind marker publishes a cache only after every component is durable."""
     from git_stage_batch.data.selected_change import store

--- a/tests/data/test_selected_snapshots.py
+++ b/tests/data/test_selected_snapshots.py
@@ -136,6 +136,72 @@ def new_function():
             working_tree_snapshot_path
         )
         assert working_tree_snapshot_content == modified_content
+        assert snapshots_are_stale("tracked.py") is False
+
+    def test_staged_empty_tracked_file_does_not_use_head_as_snapshot(self, temp_git_repo):
+        """Only a real ITA entry may use HEAD as the logical diff base."""
+        test_file = temp_git_repo / "empty-staged.txt"
+        test_file.write_text("head content\n")
+        subprocess.run(["git", "add", "empty-staged.txt"], cwd=temp_git_repo, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Add tracked file"],
+            cwd=temp_git_repo,
+            check=True,
+        )
+        test_file.write_bytes(b"")
+        subprocess.run(["git", "add", "empty-staged.txt"], cwd=temp_git_repo, check=True)
+        test_file.write_text("working content\n")
+
+        write_snapshots_for_selected_file_path("empty-staged.txt")
+
+        assert get_index_snapshot_file_path().read_bytes() == b""
+        assert snapshots_are_stale("empty-staged.txt") is False
+
+    def test_clearing_ita_flag_with_same_empty_blob_is_stale(self, temp_git_repo):
+        """Freshness includes the extended ITA identity, not only mode and OID."""
+        test_file = temp_git_repo / "tracked-ita.txt"
+        test_file.write_text("head content\n")
+        subprocess.run(["git", "add", test_file.name], cwd=temp_git_repo, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Add ITA test file"],
+            cwd=temp_git_repo,
+            check=True,
+        )
+        test_file.write_text("working content\n")
+        subprocess.run(
+            ["git", "rm", "--cached", "-q", test_file.name],
+            cwd=temp_git_repo,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "add", "-N", test_file.name],
+            cwd=temp_git_repo,
+            check=True,
+        )
+        write_snapshots_for_selected_file_path(test_file.name)
+        assert snapshots_are_stale(test_file.name) is False
+
+        empty_blob = subprocess.run(
+            ["git", "hash-object", "-t", "blob", "/dev/null"],
+            cwd=temp_git_repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        subprocess.run(
+            [
+                "git",
+                "update-index",
+                "--cacheinfo",
+                "100644",
+                empty_blob,
+                test_file.name,
+            ],
+            cwd=temp_git_repo,
+            check=True,
+        )
+
+        assert snapshots_are_stale(test_file.name) is True
 
     def test_intent_to_add_new_file_keeps_empty_index(self, temp_git_repo):
         """New files with intent-to-add should keep empty index snapshot."""


### PR DESCRIPTION
Selected-change caches publish multiple component files plus a kind marker and snapshot metadata.

Interrupted writes can expose mixed generations, while intent-to-add paths with HEAD content can compare freshness against the wrong blob.

This PR adds durable invalidation and publish-last ordering across cache writers and restoration, then records logical snapshot identity for intent-to-add entries.

Selected-change state now exposes only complete generations and compares against live index semantics.