### PR TITLE
state: Persist resumable workflow data durably

### DIFF
--- a/src/git_stage_batch/commands/selection/include_line_selection.py
+++ b/src/git_stage_batch/commands/selection/include_line_selection.py
@@ -39,6 +39,7 @@ from ...data.selected_change.snapshots import snapshots_are_stale
 from ...exceptions import MergeError, exit_with_error
 from ...i18n import _
 from ...staging.index_update import update_index_with_blob_buffer
+from ...utils.file_io import write_file_bytes
 from ...utils.paths import get_session_batch_sources_file_path
 from . import replacement_selection
 
@@ -142,8 +143,7 @@ def _restore_session_batch_sources_file(existed: bool, content: bytes | None) ->
     path = get_session_batch_sources_file_path()
     if existed:
         assert content is not None
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_bytes(content)
+        write_file_bytes(path, content)
         return
     try:
         path.unlink()

--- a/src/git_stage_batch/data/progress.py
+++ b/src/git_stage_batch/data/progress.py
@@ -13,6 +13,7 @@ from ..core.models import (
     TextFileDeletionChange,
 )
 from ..utils.file_io import (
+    append_lines_to_file,
     count_nonblank_text_file_lines,
     read_text_file_contents,
     read_text_file_line_set,
@@ -144,8 +145,7 @@ def record_text_deletion_hunk_skipped(
 
 def _append_skipped_hunk_metadata(metadata: dict) -> None:
     jsonl_path = get_skipped_hunks_jsonl_file_path()
-    with jsonl_path.open("a", encoding="utf-8") as f:
-        f.write(json.dumps(metadata) + "\n")
+    append_lines_to_file(jsonl_path, [json.dumps(metadata)])
 
 
 def format_id_range(ids: list[int]) -> str:

--- a/src/git_stage_batch/utils/file_io.py
+++ b/src/git_stage_batch/utils/file_io.py
@@ -244,6 +244,9 @@ def append_lines_to_file(path: Path, lines: Iterable[str]) -> None:
     ) as file_handle:
         for line in lines:
             file_handle.write(str(line).rstrip() + "\n")
+        file_handle.flush()
+        os.fsync(file_handle.fileno())
+    fsync_directory(path.parent)
 
 
 def read_file_paths_file(path: Path) -> list[str]:


### PR DESCRIPTION
Append-only progress and saved batch sources record state used to resume selection workflows.

Unsynced appends can vanish after a crash, and direct source restoration can leave a partial file.

This PR syncs append records and their parent directories, routes progress through the durable helper, and atomically restores saved batch sources.

Resume state now survives abrupt process loss without torn files.