### PR TITLE
discard: Restore paths safely across failures

### DIFF
--- a/src/git_stage_batch/commands/file_scope/discard_file_replacement.py
+++ b/src/git_stage_batch/commands/file_scope/discard_file_replacement.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from contextlib import ExitStack
 import sys
 
+from ...core.buffer import LineBuffer, write_buffer_to_working_tree_path
 from ...core.replacement import ReplacementPayload, coerce_replacement_payload
 from ...data.file_review.state import clear_last_file_review_state_if_file_matches
 from ...data.selected_change.paths import get_selected_change_file_path
@@ -55,7 +56,8 @@ def discard_file_as_replacement(
 
         absolute_path = get_git_repository_root_path() / target_file
         absolute_path.parent.mkdir(parents=True, exist_ok=True)
-        absolute_path.write_bytes(replacement_payload.data)
+        with LineBuffer.from_bytes(replacement_payload.data) as replacement_buffer:
+            write_buffer_to_working_tree_path(absolute_path, replacement_buffer)
 
         if preserve_selected_state:
             assert saved_selected_state is not None

--- a/src/git_stage_batch/commands/selection/selected_change_discarding.py
+++ b/src/git_stage_batch/commands/selection/selected_change_discarding.py
@@ -29,7 +29,6 @@ from ...data.undo_checkpoints import undo_checkpoint
 from ...exceptions import NoMoreHunks, exit_with_error
 from ...i18n import _
 from ...utils.file_io import append_lines_to_file, path_is_empty, read_text_file_contents
-from ...utils.git_command import run_git_command
 from ...utils.git_worktree import (
     git_apply_to_worktree,
     git_checkout_index_paths,
@@ -346,11 +345,7 @@ def discard_text_deletion_change(deletion_change: TextFileDeletionChange) -> Non
     file_path = deletion_change.path()
     snapshot_file_if_untracked(file_path)
 
-    restore_result = run_git_command(
-        ["checkout", "--", file_path],
-        check=False,
-        requires_index_lock=True,
-    )
+    restore_result = git_checkout_index_paths([file_path], check=False)
     if restore_result.returncode != 0:
         exit_with_error(
             _("Failed to restore deleted file {file}: {error}").format(

--- a/src/git_stage_batch/commands/selection/selected_change_discarding.py
+++ b/src/git_stage_batch/commands/selection/selected_change_discarding.py
@@ -63,6 +63,7 @@ def discard_selected_change(
     with undo_checkpoint(
         "discard",
         worktree_paths=worktree_paths_for_selected_change(item),
+        rollback_on_error=True,
     ):
         _discard_loaded_selected_change(
             item,

--- a/tests/commands/test_file_scoped_operations.py
+++ b/tests/commands/test_file_scoped_operations.py
@@ -43,6 +43,37 @@ from git_stage_batch.exceptions import CommandError
 from git_stage_batch.utils.git_command import run_git_command
 
 
+def test_discard_file_as_replaces_symlink_without_writing_referent(
+    tmp_path,
+    monkeypatch,
+):
+    """Explicit replacement must replace a Git path, never follow its symlink."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.chdir(repo)
+    subprocess.run(["git", "init"], check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test"], check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], check=True)
+    old_referent = tmp_path / "old-referent"
+    new_referent = tmp_path / "new-referent"
+    old_referent.write_text("old outside\n")
+    new_referent.write_text("new outside\n")
+    link = repo / "link"
+    link.symlink_to(old_referent)
+    subprocess.run(["git", "add", "link"], check=True)
+    subprocess.run(["git", "commit", "-m", "Add link"], check=True, capture_output=True)
+    link.unlink()
+    link.symlink_to(new_referent)
+
+    command_start(quiet=True)
+    command_discard_file_as("replacement\n", file="link")
+
+    assert not link.is_symlink()
+    assert link.read_text() == "replacement\n"
+    assert old_referent.read_text() == "old outside\n"
+    assert new_referent.read_text() == "new outside\n"
+
+
 @pytest.fixture
 def multi_file_repo(tmp_path, monkeypatch):
     """Create a repo with multiple modified files."""


### PR DESCRIPTION
Selected-change discard can replace path contents, restore deletions, and perform multiple rename-related operations.

Direct writes can follow symlinks or tear, inconsistent checkout bypasses path safety, and mid-operation failures can leave partially removed paths.

This PR uses atomic mode-aware replacement, routes restoration through the checkout helper, and rolls failed selected changes back through their checkpoint.

Discard now preserves path identity and restores pre-operation state on failure.