### PR TITLE
sift: Publish transformed batches atomically

### DIFF
--- a/src/git_stage_batch/commands/batch_transform/sift_persistence.py
+++ b/src/git_stage_batch/commands/batch_transform/sift_persistence.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import uuid
+
 from ...batch.state.lifecycle import create_batch, delete_batch
 from ...batch.state.compatibility_metadata import write_file_backed_batch_metadata
 from ...batch.ownership.model import BatchOwnership
@@ -9,6 +11,7 @@ from ...batch.state.query import get_batch_baseline_commit, read_batch_metadata
 from ...batch.state.references import (
     delete_batch_state_refs,
     get_batch_content_ref_name,
+    remove_file_backed_batch_metadata,
     sync_batch_state_refs,
 )
 from ...batch.state.content_commits import (
@@ -220,6 +223,87 @@ def replace_batch_with_sifted_files(
         if batch_exists(temp_batch_name):
             delete_batch(temp_batch_name)
         raise
+
+
+def publish_sifted_files(
+    *,
+    destination_batch: str,
+    retained_files: list[RetainedSiftedFile],
+    source_metadata: dict,
+    destination_note: str,
+    replace_existing: bool,
+) -> None:
+    """Build sift output privately and publish both destination refs together."""
+    temp_batch_name = _new_sift_temp_batch_name()
+    temp_batch_created = False
+    published = False
+    destination_metadata_written = False
+
+    try:
+        try:
+            create_batch(
+                temp_batch_name,
+                note=f"Temporary sift for {destination_batch}",
+                baseline_commit=source_metadata.get("baseline"),
+            )
+        except BaseException:
+            if not batch_exists(temp_batch_name):
+                remove_file_backed_batch_metadata(temp_batch_name)
+            raise
+        temp_batch_created = True
+
+        for file_path, file_meta, result in retained_files:
+            add_sifted_file_to_batch(
+                temp_batch_name,
+                file_path,
+                file_meta,
+                result,
+            )
+
+        temp_commit = run_git_command(
+            ["rev-parse", "--verify", get_batch_content_ref_name(temp_batch_name)],
+            requires_index_lock=False,
+        )
+        commit_sha = temp_commit.stdout.strip()
+        if not commit_sha:
+            raise RuntimeError("Temporary sift batch has no content commit")
+
+        if not replace_existing and batch_exists(destination_batch):
+            exit_with_error(
+                _("Destination batch '{name}' was created while sift was running").format(
+                    name=destination_batch,
+                )
+            )
+
+        temp_metadata = read_batch_metadata(temp_batch_name)
+        temp_metadata["note"] = destination_note
+        temp_metadata["revision"] = (
+            source_metadata.get("revision") if replace_existing else None
+        )
+        if replace_existing and source_metadata.get("created_at"):
+            temp_metadata["created_at"] = source_metadata["created_at"]
+        write_file_backed_batch_metadata(destination_batch, temp_metadata)
+        destination_metadata_written = True
+        sync_batch_state_refs(
+            destination_batch,
+            content_commit=commit_sha,
+            source_buffers=_source_buffers_from_sift_results(retained_files),
+        )
+        published = True
+    finally:
+        if destination_metadata_written and not published:
+            remove_file_backed_batch_metadata(destination_batch)
+        if temp_batch_created:
+            delete_batch_state_refs(temp_batch_name)
+            remove_file_backed_batch_metadata(temp_batch_name)
+
+
+def _new_sift_temp_batch_name() -> str:
+    """Return an unused invocation-owned batch name without deleting collisions."""
+    while True:
+        candidate = f"sift-tmp-{uuid.uuid4().hex}"
+        if not batch_exists(candidate):
+            return candidate
 
 
 def _source_buffers_from_sift_results(

--- a/src/git_stage_batch/commands/batch_transform/sift_persistence.py
+++ b/src/git_stage_batch/commands/batch_transform/sift_persistence.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import uuid
 
-from ...batch.state.lifecycle import create_batch, delete_batch
+from ...batch.state.lifecycle import create_batch
 from ...batch.state.compatibility_metadata import write_file_backed_batch_metadata
 from ...batch.ownership.model import BatchOwnership
 from ...batch.state.query import get_batch_baseline_commit, read_batch_metadata
@@ -181,48 +181,13 @@ def replace_batch_with_sifted_files(
     source_metadata: dict,
 ) -> None:
     """Replace a batch atomically with retained sifted file results."""
-    temp_batch_name = f"{batch_name}-sift-temp"
-
-    if batch_exists(temp_batch_name):
-        delete_batch(temp_batch_name)
-
-    create_batch(
-        temp_batch_name,
-        note=f"Temporary sift of {batch_name}",
-        baseline_commit=source_metadata.get("baseline"),
+    publish_sifted_files(
+        destination_batch=batch_name,
+        retained_files=retained_files,
+        source_metadata=source_metadata,
+        destination_note=source_metadata.get("note", ""),
+        replace_existing=True,
     )
-
-    try:
-        for file_path, file_meta, result in retained_files:
-            add_sifted_file_to_batch(
-                temp_batch_name,
-                file_path,
-                file_meta,
-                result,
-            )
-
-        temp_commit = run_git_command(
-            ["rev-parse", get_batch_content_ref_name(temp_batch_name)],
-            check=False,
-            requires_index_lock=False,
-        )
-        if temp_commit.returncode == 0:
-            commit_sha = temp_commit.stdout.strip()
-            temp_metadata = read_batch_metadata(temp_batch_name)
-            temp_metadata["revision"] = source_metadata.get("revision")
-            write_file_backed_batch_metadata(batch_name, temp_metadata)
-            sync_batch_state_refs(
-                batch_name,
-                content_commit=commit_sha,
-                source_buffers=_source_buffers_from_sift_results(retained_files),
-            )
-
-        delete_batch_state_refs(temp_batch_name)
-
-    except Exception:
-        if batch_exists(temp_batch_name):
-            delete_batch(temp_batch_name)
-        raise
 
 
 def publish_sifted_files(

--- a/src/git_stage_batch/commands/sift.py
+++ b/src/git_stage_batch/commands/sift.py
@@ -23,7 +23,7 @@ import sys
 
 from ..exceptions import MergeError
 from ..batch.state.validation import read_validated_batch_metadata
-from ..batch.state.lifecycle import create_batch, delete_batch
+from ..batch.state.lifecycle import create_batch
 from ..batch.state.query import read_batch_metadata
 from ..batch.state.batch_names import batch_exists, validate_batch_name
 from ..batch.source.selector import require_plain_batch_name
@@ -59,7 +59,6 @@ def command_sift_batch(source_batch: str, dest_batch: str) -> None:
         return
 
     in_place = source_batch == dest_batch
-    dest_created = False
     retained_files: list[_sift_persistence.RetainedSiftedFile] = []
 
     if not in_place:
@@ -73,13 +72,6 @@ def command_sift_batch(source_batch: str, dest_batch: str) -> None:
                     source=source_batch,
                 )
             )
-
-        create_batch(
-            dest_batch,
-            note=f"Sifted from {source_batch}",
-            baseline_commit=source_metadata.get("baseline"),
-        )
-        dest_created = True
 
     try:
         repo_root = get_git_repository_root_path()
@@ -124,16 +116,14 @@ def command_sift_batch(source_batch: str, dest_batch: str) -> None:
                 source_metadata=source_metadata,
             )
         else:
-            for file_path, file_meta, result in retained_files:
-                _sift_persistence.add_sifted_file_to_batch(
-                    dest_batch,
-                    file_path,
-                    file_meta,
-                    result,
-                )
+            _sift_persistence.publish_sifted_files(
+                destination_batch=dest_batch,
+                retained_files=retained_files,
+                source_metadata=source_metadata,
+                destination_note=f"Sifted from {source_batch}",
+                replace_existing=False,
+            )
     except MergeError as e:
-        if dest_created and batch_exists(dest_batch):
-            delete_batch(dest_batch)
         exit_with_error(
             _("Could not sift batch '{source}': {error}").format(
                 source=source_batch,

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -11064,6 +11064,7 @@ def test_batch_transform_sift_persistence_owns_file_writes():
         "add_sifted_file_to_batch",
         "add_sifted_text_file_to_batch",
         "create_synthetic_batch_source_commit",
+        "publish_sifted_files",
         "replace_batch_with_sifted_files",
     }
     disallowed_imports = {
@@ -11148,7 +11149,7 @@ def test_batch_transform_sift_persistence_owns_file_writes():
     assert imports_sift_persistence
     assert direct_persistence_imports == set()
     assert old_helper_names.isdisjoint(sift_helpers)
-    assert "add_sifted_file_to_batch" in persistence_calls
+    assert "publish_sifted_files" in persistence_calls
     assert "replace_batch_with_sifted_files" in persistence_calls
     assert "add_sifted_text_file_to_batch" not in persistence_calls
 

--- a/tests/commands/test_sift.py
+++ b/tests/commands/test_sift.py
@@ -18,6 +18,7 @@ import git_stage_batch.commands.batch_transform.sift_results as sift_results
 from git_stage_batch.commands.batch_transform.sift_persistence import (
     add_sifted_text_file_to_batch,
 )
+import git_stage_batch.commands.batch_transform.sift_persistence as sift_persistence
 from git_stage_batch.commands.sift import (
     command_sift_batch,
 )
@@ -1039,6 +1040,32 @@ class TestSiftCopyVsInPlace:
         metadata_after = read_batch_metadata("my-batch")
         # Batch should have changed (different content, different batch_source)
         assert metadata_after != metadata_before
+
+    def test_temp_name_race_never_deletes_an_unowned_batch(
+        self,
+        temp_git_repo,
+        monkeypatch,
+    ):
+        """Cleanup is limited to a temporary batch this invocation created."""
+        command_new_batch("sift-tmp-race")
+        collision_metadata = read_batch_metadata("sift-tmp-race")
+        monkeypatch.setattr(
+            sift_persistence,
+            "_new_sift_temp_batch_name",
+            lambda: "sift-tmp-race",
+        )
+
+        with pytest.raises(CommandError, match="already exists"):
+            sift_persistence.publish_sifted_files(
+                destination_batch="destination",
+                retained_files=[],
+                source_metadata={"baseline": "HEAD"},
+                destination_note="test",
+                replace_existing=False,
+            )
+
+        assert batch_exists("sift-tmp-race")
+        assert read_batch_metadata("sift-tmp-race") == collision_metadata
 
     def test_in_place_mode_is_atomic(self, temp_git_repo):
         """Test that in-place mode uses atomic update (all-or-nothing).

--- a/tests/commands/test_sift.py
+++ b/tests/commands/test_sift.py
@@ -22,7 +22,7 @@ import git_stage_batch.commands.batch_transform.sift_persistence as sift_persist
 from git_stage_batch.commands.sift import (
     command_sift_batch,
 )
-from git_stage_batch.batch.state.query import read_batch_metadata
+from git_stage_batch.batch.state.query import list_batch_names, read_batch_metadata
 from git_stage_batch.batch.binary_file_storage import add_binary_file_to_batch
 from git_stage_batch.batch.file_entry_storage import read_file_from_batch
 from git_stage_batch.core.models import BinaryFileChange
@@ -1085,6 +1085,37 @@ class TestSiftCopyVsInPlace:
 
         assert batch_exists("sift-tmp-race")
         assert read_batch_metadata("sift-tmp-race") == collision_metadata
+
+    def test_copy_mode_cleans_private_destination_after_unexpected_failure(
+        self,
+        temp_git_repo,
+        monkeypatch,
+    ):
+        """Any build failure should leave neither a destination nor temp batch."""
+        readme = temp_git_repo / "README.md"
+        readme.write_text("# Test\nbase\n")
+        subprocess.run(["git", "add", "README.md"], check=True, cwd=temp_git_repo)
+        subprocess.run(["git", "commit", "-m", "Base"], check=True, cwd=temp_git_repo)
+
+        readme.write_text("# Test\nchanged\n")
+        command_start()
+        fetch_next_change()
+        command_include_to_batch("source-batch")
+        readme.write_text("# Test\nbase\n")
+
+        def fail_persistence(*_args, **_kwargs):
+            raise OSError("synthetic persistence failure")
+
+        monkeypatch.setattr(
+            "git_stage_batch.commands.batch_transform.sift_persistence.add_sifted_file_to_batch",
+            fail_persistence,
+        )
+
+        with pytest.raises(OSError, match="synthetic persistence failure"):
+            command_sift_batch("source-batch", "dest-batch")
+
+        assert not batch_exists("dest-batch")
+        assert not any(name.startswith("sift-tmp-") for name in list_batch_names())
 
     def test_in_place_mode_is_atomic(self, temp_git_repo):
         """Test that in-place mode uses atomic update (all-or-nothing).

--- a/tests/commands/test_sift.py
+++ b/tests/commands/test_sift.py
@@ -1041,6 +1041,25 @@ class TestSiftCopyVsInPlace:
         # Batch should have changed (different content, different batch_source)
         assert metadata_after != metadata_before
 
+    def test_in_place_mode_preserves_old_derived_temp_name(self, temp_git_repo):
+        """Sift must not delete a user batch matching the former temp convention."""
+        readme = temp_git_repo / "README.md"
+        readme.write_text("# Test\nbase\n")
+        subprocess.run(["git", "add", "README.md"], check=True, cwd=temp_git_repo)
+        subprocess.run(["git", "commit", "-m", "Base"], check=True, cwd=temp_git_repo)
+
+        readme.write_text("# Test\nchanged\n")
+        command_start()
+        fetch_next_change()
+        command_include_to_batch("feature")
+        command_new_batch("feature-sift-temp")
+        collision_metadata = read_batch_metadata("feature-sift-temp")
+
+        command_sift_batch("feature", "feature")
+
+        assert batch_exists("feature-sift-temp")
+        assert read_batch_metadata("feature-sift-temp") == collision_metadata
+
     def test_temp_name_race_never_deletes_an_unowned_batch(
         self,
         temp_git_repo,


### PR DESCRIPTION
Sift transforms batches in place or copies selected files into a destination batch.

Derived temporary names can collide with user batches, and failures can leave partially visible destinations.

This PR introduces a UUID-named invocation-owned builder, publishes references atomically for in-place and copy workflows, and cleans only owned state with race and failure coverage.

Sift publication now protects user batches and destination visibility across failures.