### PR TITLE
tui: Release session locks around prompts

### DIFF
--- a/src/git_stage_batch/tui/asset_menu.py
+++ b/src/git_stage_batch/tui/asset_menu.py
@@ -8,6 +8,7 @@ import sys
 from ..commands.install_assets import command_install_assets
 from ..data.asset_catalog import ASSET_GROUPS
 from ..i18n import _
+from .prompts import unlocked_input
 
 
 def handle_asset_menu() -> None:
@@ -21,7 +22,7 @@ def handle_asset_menu() -> None:
         print(f"  [{idx}] {group_name}")
 
     try:
-        choice = input(_("Group (empty to cancel): ")).strip()
+        choice = unlocked_input(_("Group (empty to cancel): ")).strip()
     except (KeyboardInterrupt, EOFError):
         return
 
@@ -45,7 +46,7 @@ def handle_asset_menu() -> None:
         return
 
     try:
-        filters_text = input(_("Filters (empty for all): ")).strip()
+        filters_text = unlocked_input(_("Filters (empty for all): ")).strip()
     except (KeyboardInterrupt, EOFError):
         return
 
@@ -62,7 +63,7 @@ def handle_asset_menu() -> None:
         filters = None
 
     try:
-        force_text = input(_("Overwrite existing assets? [y/N]: ")).strip().lower()
+        force_text = unlocked_input(_("Overwrite existing assets? [y/N]: ")).strip().lower()
     except (KeyboardInterrupt, EOFError):
         return
 

--- a/src/git_stage_batch/tui/batch_menu.py
+++ b/src/git_stage_batch/tui/batch_menu.py
@@ -12,6 +12,7 @@ from ..commands.new import command_new_batch
 from ..commands.sift import command_sift_batch
 from ..i18n import _
 from ..output.colors import Colors, format_hotkey
+from .prompts import unlocked_input
 
 
 def handle_batch_menu() -> None:
@@ -64,7 +65,7 @@ def handle_batch_menu() -> None:
         print()
 
         try:
-            action = input(_("Select: ")).strip().lower()
+            action = unlocked_input(_("Select: ")).strip().lower()
         except (KeyboardInterrupt, EOFError):
             return
 
@@ -88,11 +89,11 @@ def handle_batch_menu() -> None:
 def _batch_create() -> bool:
     """Prompt for batch ID and note, then create a new batch."""
     try:
-        batch_id = input(_("Batch ID: ")).strip()
+        batch_id = unlocked_input(_("Batch ID: ")).strip()
         if not batch_id:
             return False
 
-        note = input(_("Note (optional): ")).strip()
+        note = unlocked_input(_("Note (optional): ")).strip()
     except (KeyboardInterrupt, EOFError):
         return False
 
@@ -108,7 +109,7 @@ def _batch_edit() -> None:
         return
 
     try:
-        note = input(_("New note: ")).strip()
+        note = unlocked_input(_("New note: ")).strip()
     except (KeyboardInterrupt, EOFError):
         return
 
@@ -143,7 +144,7 @@ def _batch_sift() -> None:
         return
 
     try:
-        dest_batch = input(_("Destination batch (empty for in-place): ")).strip()
+        dest_batch = unlocked_input(_("Destination batch (empty for in-place): ")).strip()
     except (KeyboardInterrupt, EOFError):
         return
 
@@ -180,7 +181,7 @@ def _prompt_select_batch(purpose: str, skip_if_single: bool = False) -> str:
 
     print()
     try:
-        choice = input(_("Select: ")).strip()
+        choice = unlocked_input(_("Select: ")).strip()
     except (KeyboardInterrupt, EOFError):
         return ""
 

--- a/src/git_stage_batch/tui/file_review/action_router.py
+++ b/src/git_stage_batch/tui/file_review/action_router.py
@@ -21,6 +21,7 @@ from ..flow import LocationRole
 from ..prompts import (
     confirm_destructive_operation,
     prompt_line_ids,
+    unlocked_input,
     wrap_prompt_for_readline,
 )
 
@@ -94,7 +95,7 @@ def apply_file_action(state: FileReviewSessionState, action: str) -> None:
 
 def _prompt_replacement_text() -> str | None:
     try:
-        value = input(
+        value = unlocked_input(
             wrap_prompt_for_readline(_("Replacement text (empty cancels): "))
         )
     except (KeyboardInterrupt, EOFError):

--- a/src/git_stage_batch/tui/file_review/candidates.py
+++ b/src/git_stage_batch/tui/file_review/candidates.py
@@ -8,7 +8,7 @@ from ...exceptions import CommandError
 from ...i18n import _
 from .session import FileReviewSessionState
 from ..flow import LocationRole
-from ..prompts import wrap_prompt_for_readline
+from ..prompts import unlocked_input, wrap_prompt_for_readline
 
 
 def browse_candidates(state: FileReviewSessionState) -> None:
@@ -56,7 +56,7 @@ def browse_candidates(state: FileReviewSessionState) -> None:
 
 def _prompt_candidate_operation() -> str | None:
     try:
-        choice = input(
+        choice = unlocked_input(
             wrap_prompt_for_readline(
                 _("Candidate operation [i]nclude, [a]pply, or q: ")
             )
@@ -77,7 +77,7 @@ def _prompt_candidate_operation() -> str | None:
 
 def _prompt_candidate_action() -> str | None:
     try:
-        choice = input(
+        choice = unlocked_input(
             wrap_prompt_for_readline(
                 _("Candidate number to preview, e N to execute, or q: ")
             )

--- a/src/git_stage_batch/tui/file_review/file_browser.py
+++ b/src/git_stage_batch/tui/file_review/file_browser.py
@@ -15,7 +15,7 @@ from .block_actions import block_review_file
 from .live_actions import apply_live_file_action
 from .session import FileReviewSessionState
 from ..flow import FlowState, LocationRole
-from ..prompts import confirm_destructive_operation, wrap_prompt_for_readline
+from ..prompts import confirm_destructive_operation, unlocked_input, wrap_prompt_for_readline
 
 
 @dataclass(frozen=True)
@@ -81,7 +81,7 @@ def choose_review_file(
 
         print()
         try:
-            choice = input(
+            choice = unlocked_input(
                 wrap_prompt_for_readline(
                     _("File number, /pattern, m N, u N, i/s/d/B marked, or q: ")
                 )
@@ -115,7 +115,7 @@ def choose_review_file(
 def prompt_block_local_only() -> bool | None:
     """Prompt for the block-file destination."""
     try:
-        choice = input(
+        choice = unlocked_input(
             wrap_prompt_for_readline(
                 _("Block target [g]itignore, [l]ocal exclude, or q: ")
             )

--- a/src/git_stage_batch/tui/file_review/page_navigation.py
+++ b/src/git_stage_batch/tui/file_review/page_navigation.py
@@ -6,13 +6,13 @@ import sys
 
 from ...data.file_review.state import read_last_file_review_state
 from ...i18n import _
-from ..prompts import wrap_prompt_for_readline
+from ..prompts import unlocked_input, wrap_prompt_for_readline
 
 
 def prompt_page_spec() -> str | None:
     """Prompt for an explicit file-review page specification."""
     try:
-        value = input(
+        value = unlocked_input(
             wrap_prompt_for_readline(_("Page(s), for example 1, 2-4, all: "))
         ).strip()
     except (KeyboardInterrupt, EOFError):

--- a/src/git_stage_batch/tui/file_review/prompts.py
+++ b/src/git_stage_batch/tui/file_review/prompts.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from ...i18n import _
 from ..flow import FlowState, LocationRole
-from ..prompts import wrap_prompt_for_readline
+from ..prompts import unlocked_input, wrap_prompt_for_readline
 
 
 def prompt_review_action(flow_state: FlowState) -> str:
@@ -30,7 +30,7 @@ def prompt_review_action(flow_state: FlowState) -> str:
         )
 
     try:
-        return input(wrap_prompt_for_readline(_("Action: "))).strip()
+        return unlocked_input(wrap_prompt_for_readline(_("Action: "))).strip()
     except (KeyboardInterrupt, EOFError):
         return "q"
 

--- a/src/git_stage_batch/tui/file_selection_menu.py
+++ b/src/git_stage_batch/tui/file_selection_menu.py
@@ -13,7 +13,7 @@ from ..data.line_state import load_line_changes_from_state
 from ..i18n import _
 from ..output.colors import Colors, format_hotkey
 from .flow import FlowState, LocationRole
-from .prompts import confirm_destructive_operation, wrap_prompt_for_readline
+from .prompts import confirm_destructive_operation, unlocked_input, wrap_prompt_for_readline
 
 
 def handle_file_selection_menu(flow_state: FlowState) -> None:
@@ -58,10 +58,10 @@ def handle_file_selection_menu(flow_state: FlowState) -> None:
                     include=format_hotkey("include", "i", Colors.GREEN),
                     discard=format_hotkey("discard", "d", Colors.RED),
             )
-            action_input = input(wrap_prompt_for_readline(prompt_text)).strip().lower()
+            action_input = unlocked_input(wrap_prompt_for_readline(prompt_text)).strip().lower()
         else:
             action_input = (
-                input(action_prompt.format(filename=filename)).strip().lower()
+                unlocked_input(action_prompt.format(filename=filename)).strip().lower()
             )
     except (KeyboardInterrupt, EOFError):
         return

--- a/src/git_stage_batch/tui/flow_menu.py
+++ b/src/git_stage_batch/tui/flow_menu.py
@@ -7,6 +7,7 @@ from ..commands.new import command_new_batch
 from ..i18n import _
 from ..output.colors import Colors
 from .flow import FlowLocation, FlowState, LocationRole
+from .prompts import unlocked_input
 
 
 def handle_from_menu(flow_state: FlowState) -> None:
@@ -52,7 +53,7 @@ def handle_from_menu(flow_state: FlowState) -> None:
 
     print()
     try:
-        choice = input(_("Select: ")).strip()
+        choice = unlocked_input(_("Select: ")).strip()
     except (KeyboardInterrupt, EOFError):
         return
 
@@ -115,7 +116,7 @@ def handle_to_menu(flow_state: FlowState) -> None:
 
     print()
     try:
-        choice = input(_("Select: ")).strip()
+        choice = unlocked_input(_("Select: ")).strip()
     except (KeyboardInterrupt, EOFError):
         return
 
@@ -123,10 +124,10 @@ def handle_to_menu(flow_state: FlowState) -> None:
         idx = int(choice) - 1
         if idx == len(options) - 1:
             try:
-                batch_id = input(_("Batch ID: ")).strip()
+                batch_id = unlocked_input(_("Batch ID: ")).strip()
                 if not batch_id:
                     return
-                note = input(_("Note (optional): ")).strip()
+                note = unlocked_input(_("Note (optional): ")).strip()
             except (KeyboardInterrupt, EOFError):
                 return
 

--- a/src/git_stage_batch/tui/interactive.py
+++ b/src/git_stage_batch/tui/interactive.py
@@ -8,7 +8,10 @@ from ..exceptions import BypassRefresh, QuitInteractive
 from ..i18n import _
 from ..output.colors import Colors
 from ..utils.journal import flush_journal
-from ..utils.session_lock import acquire_session_lock
+from ..utils.session_lock import (
+    SessionLockChangedDuringPrompt,
+    acquire_session_lock,
+)
 from . import current_change
 from .action_dispatch import ACTION_HANDLERS, dispatch_action
 from .flow import FlowLocation, FlowState
@@ -108,6 +111,15 @@ def start_interactive_mode() -> None:
             should_refresh = True
         except BypassRefresh:
             should_refresh = False
+        except SessionLockChangedDuringPrompt:
+            print(
+                _(
+                    "Repository state changed while the prompt was open; "
+                    "no action was taken."
+                ),
+                file=sys.stderr,
+            )
+            should_refresh = True
         except QuitInteractive:
             break
         finally:

--- a/src/git_stage_batch/tui/line_selection_menu.py
+++ b/src/git_stage_batch/tui/line_selection_menu.py
@@ -17,6 +17,7 @@ from .flow import FlowState, LocationRole
 from .prompts import (
     confirm_destructive_operation,
     prompt_line_ids,
+    unlocked_input,
     wrap_prompt_for_readline,
 )
 
@@ -59,10 +60,10 @@ def handle_line_selection_menu(flow_state: FlowState) -> None:
                 discard=format_hotkey("discard", "d", Colors.RED),
             )
             action_input = (
-                input(wrap_prompt_for_readline(prompt_text)).strip().lower()
+                unlocked_input(wrap_prompt_for_readline(prompt_text)).strip().lower()
             )
         else:
-            action_input = input(action_prompt).strip().lower()
+            action_input = unlocked_input(action_prompt).strip().lower()
     except (KeyboardInterrupt, EOFError):
         return
 

--- a/src/git_stage_batch/tui/prompts.py
+++ b/src/git_stage_batch/tui/prompts.py
@@ -31,9 +31,16 @@ from . import action_prompt_choices
 from . import action_prompt_menu
 from ..output.colors import Colors, format_hotkey
 from ..i18n import _, pgettext
+from ..utils.session_lock import temporarily_release_session_lock
 
 # Module-level storage for shell command history
 _shell_command_history: list[str] = []
+
+
+def unlocked_input(prompt: str) -> str:
+    """Read input without holding the repository session lock."""
+    with temporarily_release_session_lock():
+        return input(prompt)
 
 
 def wrap_prompt_for_readline(prompt: str) -> str:

--- a/src/git_stage_batch/tui/prompts.py
+++ b/src/git_stage_batch/tui/prompts.py
@@ -140,7 +140,7 @@ def prompt_action(use_color: bool = True, show_question: bool = True, has_hunk: 
         if use_color and Colors.enabled():
             # Remove trailing space, add color, add space after reset
             prompt_text = f"{Colors.BOLD}{prompt_text.rstrip()}{Colors.RESET} "
-        choice = input(wrap_prompt_for_readline(prompt_text)).strip()
+        choice = unlocked_input(wrap_prompt_for_readline(prompt_text)).strip()
     except (KeyboardInterrupt, EOFError):
         return "q"  # Ctrl-C or Ctrl-D exits
 
@@ -182,7 +182,7 @@ def confirm_destructive_operation(_operation: str, message: str) -> bool:
             yes=yes_label,
             no=no_label,
         )
-        response = input(wrap_prompt_for_readline(prompt_text)).strip().lower()
+        response = unlocked_input(wrap_prompt_for_readline(prompt_text)).strip().lower()
     except (KeyboardInterrupt, EOFError):
         return False
 
@@ -197,7 +197,7 @@ def prompt_line_ids() -> str:
         User input string (e.g., "1,3,5-7")
     """
     try:
-        return input(_("Enter line IDs (e.g., 1,3,5-7): ")).strip()
+        return unlocked_input(_("Enter line IDs (e.g., 1,3,5-7): ")).strip()
     except (KeyboardInterrupt, EOFError):
         return ""
 
@@ -229,7 +229,7 @@ def prompt_quit_session() -> str:
             y=y_label,
             n=n_label,
         )
-        response = input(wrap_prompt_for_readline(prompt_text)).strip().lower()
+        response = unlocked_input(wrap_prompt_for_readline(prompt_text)).strip().lower()
     except (KeyboardInterrupt, EOFError):
         return "cancel"
 
@@ -265,7 +265,7 @@ def prompt_shell_command() -> str:
                 pass
 
     try:
-        command = input("❯ ").strip()
+        command = unlocked_input("❯ ").strip()
         if command:
             # Save to module-level history
             _shell_command_history.append(command)
@@ -313,7 +313,7 @@ def prompt_fixup_action(use_color: bool = True) -> str:
             n=n_label,
             r=r_label,
         )
-        choice = input(wrap_prompt_for_readline(prompt_text)).strip().lower()
+        choice = unlocked_input(wrap_prompt_for_readline(prompt_text)).strip().lower()
     except (KeyboardInterrupt, EOFError):
         return "q"  # Ctrl-C or Ctrl-D cancels
 

--- a/src/git_stage_batch/tui/shell_command.py
+++ b/src/git_stage_batch/tui/shell_command.py
@@ -6,7 +6,7 @@ import subprocess
 
 from ..i18n import _
 from ..utils.git_repository import get_git_repository_root_path
-from .prompts import prompt_shell_command
+from .prompts import prompt_shell_command, unlocked_input
 
 
 def handle_shell_command(action: str) -> None:
@@ -26,7 +26,7 @@ def handle_shell_command(action: str) -> None:
             print(_("Command exited with status {}").format(result.returncode))
 
         try:
-            input(_("\nPress Enter to continue..."))
+            unlocked_input(_("\nPress Enter to continue..."))
         except (KeyboardInterrupt, EOFError):
             pass
     else:

--- a/src/git_stage_batch/utils/session_lock.py
+++ b/src/git_stage_batch/utils/session_lock.py
@@ -47,3 +47,25 @@ def acquire_session_lock():
             fcntl.flock(lock_handle.fileno(), fcntl.LOCK_UN)
         finally:
             lock_handle.close()
+
+
+@contextmanager
+def temporarily_release_session_lock():
+    """Release an acquired session lock while waiting for user input."""
+    global _LOCK_DEPTH, _LOCK_HANDLE
+
+    if _LOCK_DEPTH == 0 or _LOCK_HANDLE is None:
+        yield
+        return
+
+    lock_handle = _LOCK_HANDLE
+    lock_depth = _LOCK_DEPTH
+    fcntl.flock(lock_handle.fileno(), fcntl.LOCK_UN)
+    _LOCK_DEPTH = 0
+    _LOCK_HANDLE = None
+    try:
+        yield
+    finally:
+        fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX)
+        _LOCK_HANDLE = lock_handle
+        _LOCK_DEPTH = lock_depth

--- a/src/git_stage_batch/utils/session_lock.py
+++ b/src/git_stage_batch/utils/session_lock.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import fcntl
+import os
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -10,6 +11,31 @@ from .paths import ensure_common_state_directory_exists, get_session_lock_file_p
 
 _LOCK_DEPTH = 0
 _LOCK_HANDLE = None
+_LOCK_GENERATION: int | None = None
+
+
+class SessionLockChangedDuringPrompt(RuntimeError):
+    """Another process acquired the session lock while a prompt was open."""
+
+
+def _read_lock_generation(lock_handle) -> int:
+    """Return the generation stored in an acquired lock file."""
+    lock_handle.seek(0)
+    try:
+        return int(lock_handle.read().strip() or "0")
+    except ValueError:
+        return 0
+
+
+def _advance_lock_generation(lock_handle) -> int:
+    """Advance and durably publish the acquired lock generation."""
+    generation = _read_lock_generation(lock_handle) + 1
+    lock_handle.seek(0)
+    lock_handle.truncate()
+    lock_handle.write(f"{generation}\n")
+    lock_handle.flush()
+    os.fsync(lock_handle.fileno())
+    return generation
 
 
 @contextmanager
@@ -20,7 +46,7 @@ def acquire_session_lock():
     not deadlock. Because it uses `flock`, the kernel releases the lock
     automatically if the process exits or crashes.
     """
-    global _LOCK_DEPTH, _LOCK_HANDLE
+    global _LOCK_DEPTH, _LOCK_GENERATION, _LOCK_HANDLE
 
     if _LOCK_DEPTH > 0:
         _LOCK_DEPTH += 1
@@ -37,11 +63,13 @@ def acquire_session_lock():
 
     try:
         fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX)
+        _LOCK_GENERATION = _advance_lock_generation(lock_handle)
         _LOCK_HANDLE = lock_handle
         _LOCK_DEPTH = 1
         yield
     finally:
         _LOCK_DEPTH = 0
+        _LOCK_GENERATION = None
         _LOCK_HANDLE = None
         try:
             fcntl.flock(lock_handle.fileno(), fcntl.LOCK_UN)
@@ -51,8 +79,13 @@ def acquire_session_lock():
 
 @contextmanager
 def temporarily_release_session_lock():
-    """Release an acquired session lock while waiting for user input."""
-    global _LOCK_DEPTH, _LOCK_HANDLE
+    """Release an acquired session lock while waiting for user input.
+
+    Interactive actions run under the repository lock, but prompts must not
+    prevent another process from making progress.  Restore the full reentrant
+    depth before returning so the action resumes with the same lock contract.
+    """
+    global _LOCK_DEPTH, _LOCK_GENERATION, _LOCK_HANDLE
 
     if _LOCK_DEPTH == 0 or _LOCK_HANDLE is None:
         yield
@@ -60,12 +93,22 @@ def temporarily_release_session_lock():
 
     lock_handle = _LOCK_HANDLE
     lock_depth = _LOCK_DEPTH
+    lock_generation = _LOCK_GENERATION
     fcntl.flock(lock_handle.fileno(), fcntl.LOCK_UN)
     _LOCK_DEPTH = 0
+    _LOCK_GENERATION = None
     _LOCK_HANDLE = None
+    prompt_raised = False
     try:
         yield
+    except BaseException:
+        prompt_raised = True
+        raise
     finally:
         fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX)
+        current_generation = _read_lock_generation(lock_handle)
         _LOCK_HANDLE = lock_handle
         _LOCK_DEPTH = lock_depth
+        _LOCK_GENERATION = current_generation
+        if not prompt_raised and current_generation != lock_generation:
+            raise SessionLockChangedDuringPrompt

--- a/tests/tui/test_prompts.py
+++ b/tests/tui/test_prompts.py
@@ -3,9 +3,12 @@
 from git_stage_batch.tui.prompts import _shell_command_history
 
 from io import StringIO
-from contextlib import contextmanager
 from os import terminal_size
+from contextlib import contextmanager
+import subprocess
 from unittest.mock import patch
+
+import pytest
 
 from git_stage_batch.output.colors import Colors
 from git_stage_batch.tui.prompts import (
@@ -17,6 +20,20 @@ from git_stage_batch.tui.prompts import (
     prompt_shell_command,
     unlocked_input,
 )
+from git_stage_batch.tui.flow import FlowLocation, FlowState
+from git_stage_batch.tui.hunk_actions import handle_hunk_discard
+from git_stage_batch.utils.session_lock import (
+    SessionLockChangedDuringPrompt,
+    acquire_session_lock,
+)
+
+
+@pytest.fixture
+def prompt_git_repo(tmp_path, monkeypatch):
+    """Create a repository whose common state owns the test lock."""
+    subprocess.run(["git", "init", str(tmp_path)], check=True, capture_output=True)
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
 
 
 def test_unlocked_input_releases_lock_while_waiting():
@@ -42,6 +59,31 @@ def test_unlocked_input_releases_lock_while_waiting():
         assert unlocked_input("Prompt: ") == "answer"
 
     assert events == ["released", ("input", "Prompt: "), "reacquired"]
+
+
+def test_discard_confirmation_cancels_after_intervening_lock_holder(
+    prompt_git_repo,
+):
+    """A confirmation must not apply after another process gets the lock."""
+    flow_state = FlowState(
+        source=FlowLocation.WORKING_TREE,
+        target=FlowLocation.STAGING_AREA,
+    )
+
+    def intervening_action(_prompt):
+        with acquire_session_lock():
+            pass
+        return "yes"
+
+    with (
+        acquire_session_lock(),
+        patch("builtins.input", side_effect=intervening_action),
+        patch("git_stage_batch.tui.hunk_actions.command_discard") as discard,
+        pytest.raises(SessionLockChangedDuringPrompt),
+    ):
+        handle_hunk_discard(flow_state)
+
+    discard.assert_not_called()
 
 
 class TestPromptAction:

--- a/tests/tui/test_prompts.py
+++ b/tests/tui/test_prompts.py
@@ -3,6 +3,7 @@
 from git_stage_batch.tui.prompts import _shell_command_history
 
 from io import StringIO
+from contextlib import contextmanager
 from os import terminal_size
 from unittest.mock import patch
 
@@ -14,7 +15,33 @@ from git_stage_batch.tui.prompts import (
     prompt_line_ids,
     prompt_quit_session,
     prompt_shell_command,
+    unlocked_input,
 )
+
+
+def test_unlocked_input_releases_lock_while_waiting():
+    events = []
+
+    @contextmanager
+    def released_lock():
+        events.append("released")
+        yield
+        events.append("reacquired")
+
+    def read_input(prompt):
+        events.append(("input", prompt))
+        return "answer"
+
+    with (
+        patch(
+            "git_stage_batch.tui.prompts.temporarily_release_session_lock",
+            released_lock,
+        ),
+        patch("builtins.input", side_effect=read_input),
+    ):
+        assert unlocked_input("Prompt: ") == "answer"
+
+    assert events == ["released", ("input", "Prompt: "), "reacquired"]
 
 
 class TestPromptAction:

--- a/tests/utils/test_session_lock.py
+++ b/tests/utils/test_session_lock.py
@@ -1,0 +1,25 @@
+"""Tests for repository session-lock handoff behavior."""
+
+import subprocess
+
+import pytest
+
+from git_stage_batch.utils.session_lock import (
+    acquire_session_lock,
+    temporarily_release_session_lock,
+)
+
+
+@pytest.fixture
+def lock_git_repo(tmp_path, monkeypatch):
+    """Create a repository whose common state owns the test lock."""
+    subprocess.run(["git", "init", str(tmp_path)], check=True, capture_output=True)
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+def test_prompt_handoff_without_intervening_lock_holder(lock_git_repo):
+    """Reacquiring an uncontended prompt lock preserves the action lease."""
+    with acquire_session_lock():
+        with temporarily_release_session_lock():
+            pass

--- a/tests/utils/test_session_lock.py
+++ b/tests/utils/test_session_lock.py
@@ -5,6 +5,7 @@ import subprocess
 import pytest
 
 from git_stage_batch.utils.session_lock import (
+    SessionLockChangedDuringPrompt,
     acquire_session_lock,
     temporarily_release_session_lock,
 )
@@ -23,3 +24,12 @@ def test_prompt_handoff_without_intervening_lock_holder(lock_git_repo):
     with acquire_session_lock():
         with temporarily_release_session_lock():
             pass
+
+
+def test_prompt_handoff_detects_intervening_lock_holder(lock_git_repo):
+    """A prompt response is stale after another lock holder runs."""
+    with acquire_session_lock():
+        with pytest.raises(SessionLockChangedDuringPrompt):
+            with temporarily_release_session_lock():
+                with acquire_session_lock():
+                    pass


### PR DESCRIPTION
The interactive TUI holds the session lock while waiting for prompt input and nested confirmations.

Long-lived prompts block other processes, while releasing the lock without detecting intervening changes risks applying stale destructive responses.

This PR adds reentrant prompt-time release with a durable lock generation, provides stale refresh handling, and adopts unlocked input across every prompt surface with destructive-confirmation coverage.

Interactive prompts now permit concurrency without dispatching responses against stale state.