### PR TITLE
paths: Preserve arbitrary repository path bytes

### DIFF
--- a/src/git_stage_batch/cli/main.py
+++ b/src/git_stage_batch/cli/main.py
@@ -44,8 +44,22 @@ def _command_may_mutate(args) -> bool:
     return getattr(args, "command", None) not in _READ_ONLY_COMMANDS
 
 
+def _configure_terminal_streams() -> None:
+    """Preserve arbitrary filesystem bytes when writing terminal output."""
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        try:
+            reconfigure(errors="surrogateescape")
+        except (OSError, ValueError):
+            # Captured or already-detached streams may not be reconfigurable.
+            pass
+
+
 def main() -> None:
     """Main entry point for git-stage-batch."""
+    _configure_terminal_streams()
     try:
         if os.name != "posix":
             raise CommandError(

--- a/src/git_stage_batch/commands/start.py
+++ b/src/git_stage_batch/commands/start.py
@@ -93,8 +93,11 @@ def command_start(
 
         if not quiet:
             show_selected_change()
-    except BaseException:
+    except BaseException as start_error:
         from .abort import command_abort
 
-        command_abort(quiet=True)
+        try:
+            command_abort(quiet=True)
+        except BaseException as abort_error:
+            raise start_error from abort_error
         raise

--- a/src/git_stage_batch/git_paths.py
+++ b/src/git_stage_batch/git_paths.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 
 from .exceptions import CommandError
@@ -28,6 +29,19 @@ def encode_path(path: str) -> bytes:
 def decode_path(path: bytes) -> str:
     """Decode a filesystem path without losing undecodable bytes."""
     return os.fsdecode(path)
+
+
+def display_path(path: str) -> str:
+    """Return a terminal-safe, reversible representation of a path."""
+    raw_path = encode_path(path)
+    try:
+        decoded_path = raw_path.decode("utf-8")
+    except UnicodeDecodeError:
+        return quote_path_token(raw_path).decode("ascii")
+
+    if decoded_path and all(character.isprintable() for character in decoded_path):
+        return decoded_path
+    return json.dumps(decoded_path, ensure_ascii=False)
 
 
 def nul_records(output: bytes) -> list[bytes]:

--- a/src/git_stage_batch/output/hunk.py
+++ b/src/git_stage_batch/output/hunk.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from ..core.models import LineLevelChange
+from ..git_paths import display_path
 from ..i18n import _
 from .colors import Colors
 
@@ -10,7 +11,11 @@ from .colors import Colors
 def print_remaining_line_changes_header(file_path: str) -> None:
     """Print a boundary before refreshed remaining line changes."""
     print()
-    print(_("── remaining unstaged changes in {file} ──").format(file=file_path))
+    print(
+        _("── remaining unstaged changes in {file} ──").format(
+            file=display_path(file_path)
+        )
+    )
 
 
 def print_line_level_changes(line_changes: LineLevelChange, *, gutter_to_selection_id: dict[int, int] | None = None) -> None:
@@ -33,11 +38,12 @@ def print_line_level_changes(line_changes: LineLevelChange, *, gutter_to_selecti
     use_color = Colors.enabled()
 
     header = line_changes.header
-    header_line = f"{line_changes.path} :: @@ -{header.old_start},{header.old_len} +{header.new_start},{header.new_len} @@"
+    rendered_path = display_path(line_changes.path)
+    header_line = f"{rendered_path} :: @@ -{header.old_start},{header.old_len} +{header.new_start},{header.new_len} @@"
 
     if use_color:
         # Color the file path in bold and the @@ header in cyan
-        path_part = line_changes.path
+        path_part = rendered_path
         header_part = f"@@ -{header.old_start},{header.old_len} +{header.new_start},{header.new_len} @@"
         print(f"{Colors.BOLD}{path_part}{Colors.RESET} :: {Colors.CYAN}{header_part}{Colors.RESET}")
     else:

--- a/src/git_stage_batch/utils/command.py
+++ b/src/git_stage_batch/utils/command.py
@@ -365,8 +365,16 @@ def run_command(
 
     if text_output:
         encoding = locale.getpreferredencoding(False)
-        stdout = stdout.decode(encoding) if stdout is not None else None
-        stderr = stderr.decode(encoding) if stderr is not None else None
+        stdout = (
+            stdout.decode(encoding, errors="surrogateescape")
+            if stdout is not None
+            else None
+        )
+        stderr = (
+            stderr.decode(encoding, errors="surrogateescape")
+            if stderr is not None
+            else None
+        )
 
     result = subprocess.CompletedProcess(
         arguments,

--- a/tests/commands/test_start.py
+++ b/tests/commands/test_start.py
@@ -124,3 +124,26 @@ class TestCommandStart:
 
         assert not session_is_active()
         assert readme.read_text() == "# Test\nModified\n"
+
+    def test_start_preserves_original_error_when_abort_also_fails(
+        self,
+        temp_git_repo,
+    ):
+        """A recovery failure must not replace the startup failure."""
+        (temp_git_repo / "README.md").write_text("# Test\nModified\n")
+
+        with (
+            patch(
+                "git_stage_batch.commands.start.show_selected_change",
+                side_effect=RuntimeError("display failed"),
+            ),
+            patch(
+                "git_stage_batch.commands.abort.command_abort",
+                side_effect=RuntimeError("abort failed"),
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="display failed") as exc_info:
+                command_start()
+
+        assert isinstance(exc_info.value.__cause__, RuntimeError)
+        assert str(exc_info.value.__cause__) == "abort failed"

--- a/tests/output/test_hunk.py
+++ b/tests/output/test_hunk.py
@@ -1,6 +1,6 @@
 """Tests for hunk display with line IDs."""
 
-from io import StringIO
+from io import BytesIO, StringIO, TextIOWrapper
 from unittest.mock import patch
 
 from git_stage_batch.core.models import LineLevelChange, HunkHeader, LineEntry
@@ -30,6 +30,26 @@ class TestPrintAnnotatedHunkWithAlignedGutter:
         assert "[#1] - old line" in output
         assert "[#2] + new line" in output
         assert "       context" in output
+
+    def test_display_quotes_non_utf8_path_on_strict_stream(self):
+        """Undecodable pathname bytes should remain printable and identifiable."""
+        header = HunkHeader(old_start=0, old_len=0, new_start=1, new_len=1)
+        lines = [
+            LineEntry(1, "+", None, 1, text_bytes=b"content", text="content"),
+        ]
+        line_changes = LineLevelChange(
+            path="non-utf8-\udcff.txt",
+            header=header,
+            lines=lines,
+        )
+        raw_output = BytesIO()
+        strict_output = TextIOWrapper(raw_output, encoding="utf-8", errors="strict")
+
+        with patch("sys.stdout", new=strict_output):
+            print_line_level_changes(line_changes)
+            strict_output.flush()
+
+        assert b'"non-utf8-\\377.txt"' in raw_output.getvalue()
 
     def test_display_hunk_with_two_digit_ids(self):
         """Test displaying a hunk with two-digit line IDs."""

--- a/tests/utils/test_git_paths.py
+++ b/tests/utils/test_git_paths.py
@@ -5,6 +5,7 @@ import pytest
 from git_stage_batch.exceptions import CommandError
 from git_stage_batch.git_paths import (
     decode_path,
+    display_path,
     encode_path,
     nul_records,
     quote_path_token,
@@ -16,6 +17,14 @@ def test_path_conversion_round_trips_non_utf8_bytes():
     raw_path = b"name-\xff"
 
     assert encode_path(decode_path(raw_path)) == raw_path
+
+
+def test_display_path_keeps_printable_unicode_readable():
+    assert display_path("café.txt") == "café.txt"
+
+
+def test_display_path_quotes_control_characters_without_escaping_unicode():
+    assert display_path("café\n.txt") == '"café\\n.txt"'
 
 
 def test_nul_records_preserve_newlines_and_empty_path_components():

--- a/tests/utils/test_stream_process.py
+++ b/tests/utils/test_stream_process.py
@@ -102,6 +102,14 @@ class TestRunCommand:
         assert result.stdout == b"\xff"
         assert result.stderr == b""
 
+    def test_text_output_preserves_undecodable_bytes(self):
+        """Git path bytes survive text capture through surrogateescape."""
+        result = run_command(
+            [sys.executable, "-c", "import sys; sys.stdout.buffer.write(b'\\xff')"],
+        )
+
+        assert result.stdout.encode(sys.getfilesystemencoding(), "surrogateescape") == b"\xff"
+
     def test_failed_command_with_check_raises_with_output(self):
         """Test check=True raises CalledProcessError with captured output."""
         with pytest.raises(subprocess.CalledProcessError) as exc_info:


### PR DESCRIPTION
Git-stage-batch keeps repository pathnames in filesystem-decoded strings and starts sessions by selecting and displaying the first change.

Paths containing bytes outside the active locale can fail during text decoding or terminal output. A display failure can then trigger an abort whose own decoding error masks the initiating exception.

This change preserves undecodable subprocess output with surrogateescape, adds terminal-safe pathname rendering, uses it for hunk display, configures terminal streams for filesystem bytes, and keeps startup errors primary when cleanup also fails.

Arbitrary repository path bytes can now survive command capture, user-visible hunk output, and startup recovery. The full 3,339-test suite passes.