### PR TITLE
selection: Refuse stale file-scoped views

### DIFF
--- a/src/git_stage_batch/commands/selection/discard_file_selection.py
+++ b/src/git_stage_batch/commands/selection/discard_file_selection.py
@@ -12,6 +12,7 @@ from ...data.selected_change.store import (
 )
 from ...exceptions import exit_with_error
 from ...i18n import _
+from .include_line_selection import selected_file_view_is_fresh_for
 
 
 def load_explicit_file_selection(file_path: str):
@@ -22,6 +23,7 @@ def load_explicit_file_selection(file_path: str):
         and get_selected_change_file_path() == file_path
     )
     if reuse_selected_file_view:
+        selected_file_view_is_fresh_for(file_path)
         line_changes = load_line_changes_from_state()
     else:
         line_changes = cache_unstaged_file_as_single_hunk(file_path)

--- a/src/git_stage_batch/commands/selection/include_file_selection.py
+++ b/src/git_stage_batch/commands/selection/include_file_selection.py
@@ -7,7 +7,10 @@ from ...data.selected_change.file_hunk_cache import cache_unstaged_file_as_singl
 from ...data.line_state import load_line_changes_from_state
 from ...exceptions import exit_with_error
 from ...i18n import _
-from .include_line_selection import selected_file_view_targets
+from .include_line_selection import (
+    selected_file_view_is_fresh_for,
+    selected_file_view_targets,
+)
 
 
 def load_explicit_file_selection(file_path: str):
@@ -18,6 +21,7 @@ def load_explicit_file_selection(file_path: str):
         )
 
     if selected_file_view_targets(file_path):
+        selected_file_view_is_fresh_for(file_path)
         line_changes = load_line_changes_from_state()
     else:
         line_changes = cache_unstaged_file_as_single_hunk(file_path)

--- a/src/git_stage_batch/commands/selection/include_line_selection.py
+++ b/src/git_stage_batch/commands/selection/include_line_selection.py
@@ -35,7 +35,6 @@ from ...data.selected_change.store import (
     read_selected_change_kind,
     snapshot_selected_change_state,
 )
-from ...data.selected_change.snapshots import snapshots_are_stale
 from ...exceptions import MergeError, exit_with_error
 from ...i18n import _
 from ...staging.index_update import update_index_with_blob_buffer
@@ -160,10 +159,16 @@ def selected_file_view_targets(target_file: str) -> bool:
 
 
 def selected_file_view_is_fresh_for(target_file: str) -> bool:
-    """Return whether the selected file view can be reused for a path."""
-    return selected_file_view_targets(target_file) and not snapshots_are_stale(
-        target_file
-    )
+    """Return whether the selected file view can be reused for a path.
+
+    A matching view represents the line IDs the user actually saw.  If its
+    snapshots are stale, fail closed instead of rebuilding a different view
+    and applying those old IDs to it.
+    """
+    if not selected_file_view_targets(target_file):
+        return False
+    require_selected_hunk()
+    return True
 
 
 def load_include_line_selection_context(

--- a/src/git_stage_batch/commands/selection/selected_file_discarding.py
+++ b/src/git_stage_batch/commands/selection/selected_file_discarding.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import sys
 
 from ...data.selected_change.paths import get_selected_change_file_path
+from ...data.selected_change.loading import require_selected_hunk
 from ...data.index_entries import read_index_entry
 from ...data.session import path_is_intent_to_add, snapshot_file_if_untracked
 from ...data.undo_checkpoints import undo_checkpoint
@@ -27,7 +28,7 @@ def discard_selected_file(
         if not quiet:
             print(_("No selected hunk. Run 'show' first or specify file path."), file=sys.stderr)
         return
-
+    require_selected_hunk()
     with undo_checkpoint("discard", worktree_paths=[target_file]):
         snapshot_file_if_untracked(target_file)
 

--- a/src/git_stage_batch/commands/selection/skip_line_selection.py
+++ b/src/git_stage_batch/commands/selection/skip_line_selection.py
@@ -44,6 +44,7 @@ from ...utils.paths import (
 )
 from ..file_scope import skip_file as _file_scope_skip_file
 from .action_completion import finish_selected_change_action
+from .include_line_selection import selected_file_view_is_fresh_for
 
 
 def skip_line_selection(
@@ -70,10 +71,7 @@ def skip_line_selection(
             target_file = file
         auto_add_untracked_files([target_file])
 
-        reuse_selected_file_view = (
-            read_selected_change_kind() == SelectedChangeKind.FILE
-            and get_selected_change_file_path() == target_file
-        )
+        reuse_selected_file_view = selected_file_view_is_fresh_for(target_file)
         if (
             not reuse_selected_file_view
             and render_unstaged_file_as_single_hunk(target_file) is None

--- a/tests/commands/test_discard.py
+++ b/tests/commands/test_discard.py
@@ -28,6 +28,7 @@ import git_stage_batch.commands.selection.selected_change_discarding as selected
 import git_stage_batch.commands.selection.selected_change_batch_discarding as selected_change_batch_discarding
 from git_stage_batch.commands.discard import command_discard, command_discard_line, command_discard_line_as_to_batch
 from git_stage_batch.commands.include import command_include, command_include_line
+from git_stage_batch.commands.show import command_show
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.core.models import TextFileDeletionChange
 from git_stage_batch.exceptions import CommandError
@@ -666,6 +667,17 @@ class TestCommandDiscardLine:
 
         assert "Line selection 1,99 is not valid for test.txt." in exc_info.value.message
         assert test_file.read_text() == "base\nselected\n"
+
+    def test_discard_file_line_refuses_stale_same_file_view(self, temp_git_repo):
+        """Explicit file IDs must not be applied after an external edit."""
+        test_file = _prepare_single_line_change(temp_git_repo)
+        command_show(file="test.txt")
+        test_file.write_text("external\nbase\nselected\n")
+
+        with pytest.raises(CommandError, match="Cached hunk is stale"):
+            command_discard_line("1", file="test.txt")
+
+        assert test_file.read_text() == "external\nbase\nselected\n"
 
 
 class TestCommandDiscardToBatch:

--- a/tests/commands/test_file_scoped_operations.py
+++ b/tests/commands/test_file_scoped_operations.py
@@ -189,8 +189,8 @@ class TestShowFileFlag:
         result = run_git_command(["show", ":beta.txt"])
         assert result.stdout == "beta1\nbeta2\nbeta3\nbeta4-new\n"
 
-    def test_explicit_file_include_line_rebuilds_stale_same_file_view(self, tmp_path, monkeypatch):
-        """Explicit --file line IDs apply to the current file view, not stale state."""
+    def test_explicit_file_include_line_refuses_stale_same_file_view(self, tmp_path, monkeypatch):
+        """Explicit --file line IDs must not be remapped onto a changed file view."""
         repo = tmp_path / "test_repo"
         repo.mkdir()
         monkeypatch.chdir(repo)
@@ -209,10 +209,12 @@ class TestShowFileFlag:
         command_show(file="file.txt")
 
         file_path.write_text("base\nother\n")
-        command_include_line("1", file="file.txt")
+        with pytest.raises(CommandError, match="Cached hunk is stale"):
+            command_include_line("1", file="file.txt")
 
         result = run_git_command(["show", ":file.txt"])
-        assert result.stdout == "base\nother\n"
+        assert result.stdout == "base\n"
+        assert file_path.read_text() == "base\nother\n"
 
     def test_show_file_selection_can_feed_discard_line(self, multi_file_repo):
         """Show --file should cache a usable selection for later discard --line."""

--- a/tests/commands/test_skip.py
+++ b/tests/commands/test_skip.py
@@ -6,6 +6,7 @@ import pytest
 
 from git_stage_batch.commands.skip import command_skip, command_skip_line
 from git_stage_batch.commands.start import command_start
+from git_stage_batch.commands.show import command_show
 from git_stage_batch.data.hunk_tracking import (
     fetch_next_change,
 )
@@ -176,6 +177,17 @@ class TestCommandSkipLine:
         assert "Line selection 1,99 is not valid for test.txt." in exc_info.value.message
         skip_ids_content = read_text_file_contents(get_processed_skip_ids_file_path()).strip()
         assert skip_ids_content == ""
+
+    def test_skip_file_line_refuses_stale_same_file_view(self, temp_git_repo):
+        """Explicit file IDs must not be recorded after an external edit."""
+        test_file = _prepare_single_line_change(temp_git_repo)
+        command_show(file="test.txt")
+        test_file.write_text("external\nbase\nselected\n")
+
+        with pytest.raises(CommandError, match="Cached hunk is stale"):
+            command_skip_line("1", file="test.txt")
+
+        assert test_file.read_text() == "external\nbase\nselected\n"
 
     def test_skip_line_marks_single_addition(self, temp_git_repo):
         """Test skipping a single added line advances past that selection."""


### PR DESCRIPTION
File-scoped selection views provide displayed line identities to include, discard, skip, batch-include, and selected-file workflows.

External edits can invalidate a snapshot while older loaders still reuse it based only on path and selection kind. Those stale identities can then target content the user did not review.

This change routes matching views through the shared freshness check and makes every affected consumer refuse stale explicit or selected-file state before applying it.

All file-scoped consumers now preserve the identity of the reviewed worktree and index snapshots. The full 3,339-test suite passes.