### PR TITLE
discard: Roll back failed destructive actions

### DIFF
--- a/src/git_stage_batch/commands/file_scope/discard_file.py
+++ b/src/git_stage_batch/commands/file_scope/discard_file.py
@@ -116,6 +116,7 @@ def discard_file_changes(
     with undo_checkpoint(
         f"discard --file {file}".rstrip(),
         worktree_paths=checkpoint_paths,
+        rollback_on_error=True,
     ):
         blocklist_path = get_block_list_file_path()
         blocked_hashes = read_text_file_line_set(blocklist_path)

--- a/src/git_stage_batch/commands/file_scope/discard_file_replacement.py
+++ b/src/git_stage_batch/commands/file_scope/discard_file_replacement.py
@@ -39,7 +39,11 @@ def discard_file_as_replacement(
         exit_with_error(_("No selected hunk. Run 'show' first or specify file path."))
 
     with (
-        undo_checkpoint(" ".join(operation_parts), worktree_paths=[target_file]),
+        undo_checkpoint(
+            " ".join(operation_parts),
+            worktree_paths=[target_file],
+            rollback_on_error=True,
+        ),
         ExitStack() as selected_state_stack,
     ):
         preserve_selected_state = False

--- a/src/git_stage_batch/commands/selection/discard_line_action.py
+++ b/src/git_stage_batch/commands/selection/discard_line_action.py
@@ -28,6 +28,7 @@ def discard_live_line_selection(
     with undo_checkpoint(
         " ".join(operation_parts),
         worktree_paths=[target_file] if target_file is not None else [],
+        rollback_on_error=True,
     ):
         file_path = _discard_line_selection.discard_worktree_line_selection(
             line_id_specification,

--- a/src/git_stage_batch/commands/selection/discard_line_replacement_action.py
+++ b/src/git_stage_batch/commands/selection/discard_line_replacement_action.py
@@ -48,6 +48,7 @@ def discard_live_line_replacement_to_batch(
         undo_checkpoint(
             " ".join(operation_parts),
             worktree_paths=[target_file] if target_file is not None else [],
+            rollback_on_error=True,
         ),
         snapshot_selected_change_state() as saved_selected_state,
     ):

--- a/src/git_stage_batch/commands/selection/selected_file_discarding.py
+++ b/src/git_stage_batch/commands/selection/selected_file_discarding.py
@@ -28,8 +28,13 @@ def discard_selected_file(
         if not quiet:
             print(_("No selected hunk. Run 'show' first or specify file path."), file=sys.stderr)
         return
+
     require_selected_hunk()
-    with undo_checkpoint("discard", worktree_paths=[target_file]):
+    with undo_checkpoint(
+        "discard",
+        worktree_paths=[target_file],
+        rollback_on_error=True,
+    ):
         snapshot_file_if_untracked(target_file)
 
         index_entry = read_index_entry(target_file)

--- a/tests/commands/test_discard.py
+++ b/tests/commands/test_discard.py
@@ -26,6 +26,7 @@ import pytest
 
 import git_stage_batch.commands.selection.selected_change_discarding as selected_change_discarding
 import git_stage_batch.commands.selection.selected_change_batch_discarding as selected_change_batch_discarding
+import git_stage_batch.commands.selection.discard_line_action as discard_line_action
 import git_stage_batch.commands.selection.selected_file_discarding as selected_file_discarding
 from git_stage_batch.commands.discard import command_discard, command_discard_line, command_discard_line_as_to_batch
 from git_stage_batch.commands.include import command_include, command_include_line
@@ -136,6 +137,26 @@ class TestCommandDiscard:
             command_discard(quiet=True, auto_advance=False)
 
         assert readme.read_text() == "later unseen change\n"
+
+    def test_line_discard_rolls_back_when_completion_fails(
+        self,
+        temp_git_repo,
+        monkeypatch,
+    ):
+        """A post-write failure should restore discarded working-tree lines."""
+        test_file = _prepare_single_line_change(temp_git_repo)
+        monkeypatch.setattr(
+            discard_line_action,
+            "refresh_selected_hunk_after_line_action",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                RuntimeError("refresh failed")
+            ),
+        )
+
+        with pytest.raises(RuntimeError, match="refresh failed"):
+            command_discard_line("1")
+
+        assert test_file.read_text() == "base\nselected\n"
 
     def test_selected_file_discard_rolls_back_when_completion_fails(
         self,

--- a/tests/commands/test_discard.py
+++ b/tests/commands/test_discard.py
@@ -26,6 +26,7 @@ import pytest
 
 import git_stage_batch.commands.selection.selected_change_discarding as selected_change_discarding
 import git_stage_batch.commands.selection.selected_change_batch_discarding as selected_change_batch_discarding
+import git_stage_batch.commands.selection.selected_file_discarding as selected_file_discarding
 from git_stage_batch.commands.discard import command_discard, command_discard_line, command_discard_line_as_to_batch
 from git_stage_batch.commands.include import command_include, command_include_line
 from git_stage_batch.commands.show import command_show
@@ -135,6 +136,27 @@ class TestCommandDiscard:
             command_discard(quiet=True, auto_advance=False)
 
         assert readme.read_text() == "later unseen change\n"
+
+    def test_selected_file_discard_rolls_back_when_completion_fails(
+        self,
+        temp_git_repo,
+        monkeypatch,
+    ):
+        """A post-write failure should restore a discarded file-scoped view."""
+        readme = temp_git_repo / "README.md"
+        readme.write_text("# Test\nModified\n")
+        command_start(quiet=True)
+        command_show(file="README.md")
+        monkeypatch.setattr(
+            selected_file_discarding,
+            "finish_selected_change_action",
+            lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("finish failed")),
+        )
+
+        with pytest.raises(RuntimeError, match="finish failed"):
+            command_discard(quiet=True)
+
+        assert readme.read_text() == "# Test\nModified\n"
 
     def test_discard_full_new_file_hunk_removes_intent_to_add(
         self,


### PR DESCRIPTION
Discard workflows protect destructive mutations with undo checkpoints, but several line, file, and replacement paths finalized partially applied state when an operation raised an error.

That inconsistency leaves users dependent on a later manual undo and can expose intermediate worktree state after failures that should be atomic.

This change enables checkpoint rollback for selected-file, live-line, selected-file action, file-replacement, and line-replacement discard paths, with focused failure tests for each workflow.

Failed destructive actions now restore their starting state automatically and consistently. The full 3,339-test suite passes.