### PR TITLE
state: Reject corrupt consumed selections

### DIFF
--- a/src/git_stage_batch/data/consumed_selections.py
+++ b/src/git_stage_batch/data/consumed_selections.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from typing import Any
 
+from ..exceptions import CommandError
+from ..i18n import _
 from ..utils.file_io import read_text_file_contents, write_text_file_contents
 from ..utils.paths import get_session_consumed_selections_file_path
 
@@ -17,12 +19,30 @@ def load_consumed_selections_metadata() -> dict[str, Any]:
 
     try:
         data = json.loads(read_text_file_contents(path))
-    except json.JSONDecodeError:
-        return {"files": {}}
+    except json.JSONDecodeError as exc:
+        raise CommandError(
+            _(
+                "Consumed-selection state is corrupt: {path}. "
+                "Abort the session to recover safely."
+            ).format(path=path)
+        ) from exc
 
+    if not isinstance(data, dict) or not isinstance(data.get("files", {}), dict):
+        raise CommandError(
+            _(
+                "Consumed-selection state has an invalid structure: {path}. "
+                "Abort the session to recover safely."
+            ).format(path=path)
+        )
     files = data.get("files", {})
-    if not isinstance(files, dict):
-        return {"files": {}}
+    for file_path, file_metadata in files.items():
+        if not isinstance(file_metadata, dict):
+            raise CommandError(
+                _(
+                    "Consumed-selection state has an invalid entry for {file}: "
+                    "{path}. Abort the session to recover safely."
+                ).format(file=file_path, path=path)
+            )
     return {"files": files}
 
 
@@ -30,7 +50,7 @@ def read_consumed_file_metadata(file_path: str) -> dict[str, Any] | None:
     """Return hidden consumed-selection metadata for one file."""
     metadata = load_consumed_selections_metadata()
     file_metadata = metadata.get("files", {}).get(file_path)
-    return file_metadata if isinstance(file_metadata, dict) else None
+    return file_metadata
 
 
 def write_consumed_file_metadata(

--- a/tests/commands/selection/test_consumed_selection_recording.py
+++ b/tests/commands/selection/test_consumed_selection_recording.py
@@ -12,8 +12,11 @@ from git_stage_batch.commands.selection.consumed_selection_recording import (
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.core.models import LineEntry
 from git_stage_batch.data.consumed_selections import (
+    load_consumed_selections_metadata,
     read_consumed_file_metadata,
 )
+from git_stage_batch.exceptions import CommandError
+from git_stage_batch.utils.paths import get_session_consumed_selections_file_path
 from git_stage_batch.core.buffer import LineBuffer
 from tests.batch.ownership.metadata_helpers import acquire_ownership_for_metadata
 
@@ -72,6 +75,32 @@ def test_record_consumed_selection_refreshes_stale_first_selection(temp_git_repo
             "added_lines": ["line1"],
         }
     ]
+
+
+def test_corrupt_consumed_selection_state_fails_closed(temp_git_repo):
+    """Corrupt masking state must not make consumed lines visible again."""
+    get_session_consumed_selections_file_path().parent.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+    get_session_consumed_selections_file_path().write_text("{not-json")
+
+    with pytest.raises(CommandError, match="Consumed-selection state is corrupt"):
+        load_consumed_selections_metadata()
+
+
+def test_corrupt_consumed_file_entry_fails_closed(temp_git_repo):
+    """A malformed file entry must not make consumed lines visible again."""
+    get_session_consumed_selections_file_path().parent.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+    get_session_consumed_selections_file_path().write_text(
+        '{"files": {"tracked.txt": "corrupt"}}'
+    )
+
+    with pytest.raises(CommandError, match="invalid entry for tracked.txt"):
+        load_consumed_selections_metadata()
 
 
 def test_record_consumed_selection_accepts_buffer(temp_git_repo):


### PR DESCRIPTION
Consumed-selection state records which displayed changes have already been handled so later views can keep them masked.

Malformed JSON was previously treated as an empty record, silently re-exposing selections and allowing work to proceed from state whose history could not be trusted.

This change reports corrupt consumed-selection data as a structured command error and adds coverage for both loading and user-visible failure behavior.

Corrupt state now fails closed instead of being mistaken for a fresh session. The full 3,339-test suite passes.