### PR TITLE
staging: Preserve exact source line endings

### DIFF
--- a/src/git_stage_batch/core/replacement.py
+++ b/src/git_stage_batch/core/replacement.py
@@ -97,7 +97,9 @@ class _ReplacementLineBodies(Sequence[bytes]):
         except IndexError as exc:
             raise IndexError(index) from exc
         line = self._lines[line_index]
-        if line.endswith(b"\n"):
+        if line.endswith(b"\r\n"):
+            line = line[:-2]
+        elif line.endswith(b"\n"):
             line = line[:-1]
         return line
 

--- a/src/git_stage_batch/staging/content_buffers.py
+++ b/src/git_stage_batch/staging/content_buffers.py
@@ -13,7 +13,7 @@ from ..core.replacement import (
 from ..core.buffer import (
     LineBuffer,
 )
-from ..editor.line_editor import edit_lines_as_buffer
+from ..editor.line_endings import detect_line_ending
 
 
 def _line_payload(line: bytes) -> bytes:
@@ -28,16 +28,119 @@ def _line_payload_at(lines: Sequence[bytes], index: int) -> bytes:
     return _line_payload(lines[index])
 
 
-def _line_entry_content(line_entry: LineEntry) -> bytes:
-    return line_entry.text_bytes + (
-        b"\n" if line_entry.has_trailing_newline else b""
+def _line_entry_content(
+    line_entry: LineEntry,
+) -> bytes:
+    payload = _line_entry_payload(line_entry)
+    if not line_entry.has_trailing_newline:
+        return payload
+    line_ending = b"\r\n" if line_entry.text_bytes.endswith(b"\r") else b"\n"
+    return payload + line_ending
+
+
+def _line_entry_payload(
+    line_entry: LineEntry,
+) -> bytes:
+    """Return patch-row content without its CRLF carriage return."""
+    if line_entry.has_trailing_newline and line_entry.text_bytes.endswith(b"\r"):
+        return line_entry.text_bytes[:-1]
+    return line_entry.text_bytes
+
+
+def _line_ending_from_line(line: bytes) -> bytes | None:
+    """Return an LF-based ending carried by one indexed source line."""
+    if line.endswith(b"\r\n"):
+        return b"\r\n"
+    if line.endswith(b"\n"):
+        return b"\n"
+    return None
+
+
+def _replacement_line_ending(
+    source_lines: Sequence[bytes],
+    selection_start: int,
+    selection_end: int,
+) -> bytes:
+    """Choose an ending near the replaced source span."""
+    source_line_count = len(source_lines)
+    for index in range(selection_start, min(selection_end, source_line_count)):
+        line_ending = _line_ending_from_line(source_lines[index])
+        if line_ending is not None:
+            return line_ending
+    for index in range(min(selection_start, source_line_count) - 1, -1, -1):
+        line_ending = _line_ending_from_line(source_lines[index])
+        if line_ending is not None:
+            return line_ending
+    for index in range(selection_end, source_line_count):
+        line_ending = _line_ending_from_line(source_lines[index])
+        if line_ending is not None:
+            return line_ending
+    return detect_line_ending(source_lines) or b"\n"
+
+
+def _edit_lines_preserving_source_endings_as_buffer(
+    source_lines: Sequence[bytes],
+    edited_lines: Sequence[bytes],
+    *,
+    selection_start: int,
+    selection_end: int,
+    has_trailing_newline: bool,
+    add_trailing_newline_when_nonempty: bool = False,
+) -> LineBuffer:
+    """Replace full lines while retaining each unchanged source line exactly."""
+    source_line_count = len(source_lines)
+    if (
+        selection_start < 0
+        or selection_end < selection_start
+        or selection_end > source_line_count
+    ):
+        raise ValueError("invalid line selection")
+
+    edited_line_count = len(edited_lines)
+    output_line_count = (
+        selection_start
+        + edited_line_count
+        + source_line_count
+        - selection_end
     )
+    generated_line_ending = _replacement_line_ending(
+        source_lines,
+        selection_start,
+        selection_end,
+    )
+
+    def output_lines() -> Iterator[tuple[bytes, bool]]:
+        for index in range(selection_start):
+            yield source_lines[index], True
+        for line in edited_lines:
+            yield line, False
+        for index in range(selection_end, source_line_count):
+            yield source_lines[index], True
+
+    def output_chunks() -> Iterator[bytes]:
+        for output_index, (line, is_source_line) in enumerate(output_lines()):
+            is_last = output_index == output_line_count - 1
+            needs_line_ending = (
+                not is_last
+                or has_trailing_newline
+                or add_trailing_newline_when_nonempty
+            )
+            payload = _line_payload(line)
+            if not needs_line_ending:
+                yield payload
+                continue
+
+            source_line_ending = (
+                _line_ending_from_line(line) if is_source_line else None
+            )
+            yield payload + (source_line_ending or generated_line_ending)
+
+    return LineBuffer.from_chunks(output_chunks())
 
 
 def _line_content_at(lines: Sequence[bytes], index: int) -> bytes:
-    return _line_payload(lines[index]) + (
-        b"\n" if lines[index].endswith(b"\n") else b""
-    )
+    """Return exact index bytes so untouched lines retain their endings."""
+    return lines[index]
 
 
 def _working_tree_line_content_at(
@@ -240,7 +343,7 @@ def _build_target_index_buffer_with_replaced_lines(
         return 0
 
     if not replace_ids:
-        return edit_lines_as_buffer(
+        return _edit_lines_preserving_source_endings_as_buffer(
             base_lines,
             [],
             selection_start=0,
@@ -352,7 +455,7 @@ def _build_target_index_buffer_with_replaced_lines(
         )
     else:
         trailing_newline = replacement_payload.has_trailing_lf or base_has_trailing_newline
-    return edit_lines_as_buffer(
+    return _edit_lines_preserving_source_endings_as_buffer(
         base_lines,
         replacement_lines,
         selection_start=replace_start,
@@ -505,7 +608,7 @@ def _build_target_working_tree_buffer_with_replaced_lines(
         return 0
 
     if not replace_ids:
-        return edit_lines_as_buffer(
+        return _edit_lines_preserving_source_endings_as_buffer(
             working_lines,
             [],
             selection_start=0,
@@ -617,7 +720,7 @@ def _build_target_working_tree_buffer_with_replaced_lines(
         )
     else:
         trailing_newline = replacement_payload.has_trailing_lf or working_has_trailing_newline
-    return edit_lines_as_buffer(
+    return _edit_lines_preserving_source_endings_as_buffer(
         working_lines,
         replacement_lines,
         selection_start=replace_start,

--- a/tests/batch/test_replacement.py
+++ b/tests/batch/test_replacement.py
@@ -67,7 +67,7 @@ def test_replacement_text_can_carry_exact_stdin_bytes():
     with replacement_line_chunks(payload) as lines:
         assert list(lines) == [b"first\r\n", b"second"]
     with replacement_line_bodies(payload) as bodies:
-        assert list(bodies) == [b"first\r", b"second"]
+        assert list(bodies) == [b"first", b"second"]
 
 
 def test_legacy_replacement_text_normalizes_line_endings():

--- a/tests/core/test_encoding_and_line_endings.py
+++ b/tests/core/test_encoding_and_line_endings.py
@@ -1,7 +1,7 @@
 """Tests for handling different encodings and line endings."""
 
 from git_stage_batch.commands.start import command_start
-from git_stage_batch.commands.include import command_include_line
+from git_stage_batch.commands.include import command_include_line, command_include_line_as
 from git_stage_batch.commands.discard import command_discard_line
 from git_stage_batch.commands.discard import command_discard_to_batch
 from git_stage_batch.batch.state.lifecycle import create_batch
@@ -148,6 +148,40 @@ class TestMixedLineEndings:
         assert changed_line is not None
         # The \r should be preserved in the content (not stripped)
         assert b"\r" in changed_line.text_bytes or changed_line.text_bytes == b"changed line\r"
+
+    def test_include_line_replacement_preserves_mixed_endings(self, temp_git_repo):
+        """Replacement staging should preserve untouched mixed line endings."""
+        test_file = temp_git_repo / "mixed-replacement.txt"
+        original = b"keep\nold\r\nuntouched-crlf\r\ntail\n"
+        working = b"keep\nworking\r\nuntouched-crlf\r\ntail\n"
+        expected_index = b"keep\nstaged\r\nuntouched-crlf\r\ntail\n"
+
+        test_file.write_bytes(original)
+        subprocess.run(
+            ["git", "add", "mixed-replacement.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add mixed replacement file"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        test_file.write_bytes(working)
+
+        command_start(quiet=True)
+        command_include_line_as("1-2", "staged")
+
+        result = subprocess.run(
+            ["git", "show", ":mixed-replacement.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        assert result.stdout == expected_index
+        assert test_file.read_bytes() == working
 
 
 class TestBareCRContent:

--- a/tests/staging/test_content_buffers.py
+++ b/tests/staging/test_content_buffers.py
@@ -2,6 +2,7 @@
 
 from git_stage_batch.core.models import LineLevelChange, HunkHeader, LineEntry
 from git_stage_batch.core.buffer import LineBuffer
+from git_stage_batch.core.replacement import ReplacementPayload
 from git_stage_batch.staging.content_buffers import (
     build_target_index_buffer_from_lines,
     build_target_index_buffer_with_replaced_lines,
@@ -313,10 +314,10 @@ class TestBuildTargetIndexContent:
         """Index staging can read from an indexed line sequence."""
         header = HunkHeader(1, 3, 1, 3)
         lines = [
-            LineEntry(None, " ", 1, 1, text_bytes=b"line1", text="line1"),
-            LineEntry(1, "-", 2, None, text_bytes=b"old", text="old"),
-            LineEntry(2, "+", None, 2, text_bytes=b"new", text="new"),
-            LineEntry(None, " ", 3, 3, text_bytes=b"line2", text="line2"),
+            LineEntry(None, " ", 1, 1, text_bytes=b"line1\r", text="line1"),
+            LineEntry(1, "-", 2, None, text_bytes=b"old\r", text="old"),
+            LineEntry(2, "+", None, 2, text_bytes=b"new\r", text="new"),
+            LineEntry(None, " ", 3, 3, text_bytes=b"line2\r", text="line2"),
         ]
         line_changes = LineLevelChange(path="test.txt", header=header, lines=lines)
         base_lines = line_sequence([b"line1\r\n", b"old\r\n", b"line2\r\n"])
@@ -328,16 +329,16 @@ class TestBuildTargetIndexContent:
             base_has_trailing_newline=True,
         )
 
-        assert result == b"line1\nold\nline2\n"
+        assert result == b"line1\r\nold\r\nline2\r\n"
 
     def test_index_selected_lines_can_return_buffer(self, line_sequence):
         """Index staging can return a buffer for streaming callers."""
         header = HunkHeader(1, 3, 1, 3)
         lines = [
-            LineEntry(None, " ", 1, 1, text_bytes=b"line1", text="line1"),
-            LineEntry(1, "-", 2, None, text_bytes=b"old", text="old"),
-            LineEntry(2, "+", None, 2, text_bytes=b"new", text="new"),
-            LineEntry(None, " ", 3, 3, text_bytes=b"line2", text="line2"),
+            LineEntry(None, " ", 1, 1, text_bytes=b"line1\r", text="line1"),
+            LineEntry(1, "-", 2, None, text_bytes=b"old\r", text="old"),
+            LineEntry(2, "+", None, 2, text_bytes=b"new\r", text="new"),
+            LineEntry(None, " ", 3, 3, text_bytes=b"line2\r", text="line2"),
         ]
         line_changes = LineLevelChange(path="test.txt", header=header, lines=lines)
         base_lines = line_sequence([b"line1\r\n", b"old\r\n", b"line2\r\n"])
@@ -349,7 +350,30 @@ class TestBuildTargetIndexContent:
             base_has_trailing_newline=True,
         ) as result:
             assert isinstance(result, LineBuffer)
-            assert result.to_bytes() == b"line1\nnew\nline2\n"
+            assert result.to_bytes() == b"line1\r\nnew\r\nline2\r\n"
+
+    def test_index_selected_lines_preserve_mixed_line_endings(self):
+        """Patch rows should carry their own endings in a mixed-ending file."""
+        header = HunkHeader(1, 3, 1, 3)
+        lines = [
+            LineEntry(None, " ", 1, 1, text_bytes=b"keep", text="keep"),
+            LineEntry(1, "-", 2, None, text_bytes=b"old\r", text="old"),
+            LineEntry(2, "+", None, 2, text_bytes=b"new\r", text="new"),
+            LineEntry(None, " ", 3, 3, text_bytes=b"tail", text="tail"),
+        ]
+        line_changes = LineLevelChange(path="test.txt", header=header, lines=lines)
+        base_content = b"keep\nold\r\ntail\n"
+
+        with LineBuffer.from_bytes(base_content) as base_lines:
+            result = _build_target_index_content_bytes(
+                line_changes,
+                {1, 2},
+                base_lines,
+                base_has_trailing_newline=True,
+            )
+
+        assert result == b"keep\nnew\r\ntail\n"
+
 
     def test_preserves_trailing_newline(self):
         """Test that trailing newline is preserved from base."""
@@ -772,7 +796,7 @@ class TestBuildTargetIndexContent:
             base_has_trailing_newline=True,
         )
 
-        assert result == b"keep\nstaged\ntail\n"
+        assert result == b"keep\r\nstaged\r\ntail\r\n"
 
     def test_index_replacement_can_return_buffer(self, line_sequence):
         """Index replacement can return a buffer for streaming callers."""
@@ -794,7 +818,63 @@ class TestBuildTargetIndexContent:
             base_has_trailing_newline=True,
         ) as result:
             assert isinstance(result, LineBuffer)
-            assert result.to_bytes() == b"keep\nstaged\ntail\n"
+            assert result.to_bytes() == b"keep\r\nstaged\r\ntail\r\n"
+
+    def test_index_replacement_preserves_unselected_mixed_line_endings(self):
+        """Replacement staging should alter only the selected lines' endings."""
+        header = HunkHeader(1, 4, 1, 4)
+        lines = [
+            LineEntry(None, " ", 1, 1, text_bytes=b"keep", text="keep"),
+            LineEntry(1, "-", 2, None, text_bytes=b"old\r", text="old"),
+            LineEntry(2, "+", None, 2, text_bytes=b"working\r", text="working"),
+            LineEntry(
+                None,
+                " ",
+                3,
+                3,
+                text_bytes=b"untouched-crlf\r",
+                text="untouched-crlf",
+            ),
+            LineEntry(None, " ", 4, 4, text_bytes=b"tail", text="tail"),
+        ]
+        line_changes = LineLevelChange(path="test.txt", header=header, lines=lines)
+        base_content = b"keep\nold\r\nuntouched-crlf\r\ntail\n"
+
+        with LineBuffer.from_bytes(base_content) as base_lines:
+            result = _build_target_index_replacement_bytes(
+                line_changes,
+                {1, 2},
+                "staged",
+                base_lines,
+                base_has_trailing_newline=True,
+            )
+
+        assert result == b"keep\nstaged\r\nuntouched-crlf\r\ntail\n"
+
+    def test_index_replacement_does_not_duplicate_exact_crlf(self):
+        """Exact CRLF replacement input should not become CRCRLF."""
+        header = HunkHeader(1, 3, 1, 3)
+        lines = [
+            LineEntry(None, " ", 1, 1, text_bytes=b"keep\r", text="keep"),
+            LineEntry(1, "-", 2, None, text_bytes=b"old\r", text="old"),
+            LineEntry(2, "+", None, 2, text_bytes=b"working\r", text="working"),
+            LineEntry(None, " ", 3, 3, text_bytes=b"tail\r", text="tail"),
+        ]
+        line_changes = LineLevelChange(path="test.txt", header=header, lines=lines)
+        base_content = b"keep\r\nold\r\ntail\r\n"
+        replacement = ReplacementPayload(b"first\r\nsecond")
+
+        with (
+            LineBuffer.from_bytes(base_content) as base_lines,
+            build_target_index_buffer_with_replaced_lines(
+                line_changes,
+                {1, 2},
+                replacement,
+                base_lines,
+                base_has_trailing_newline=True,
+            ) as result,
+        ):
+            assert result.to_bytes() == b"keep\r\nfirst\r\nsecond\r\ntail\r\n"
 
     def test_replace_selection_keeps_matching_edge_anchors_with_no_edge_overlap(self):
         """Replacement staging should preserve duplicated anchors when requested."""
@@ -910,7 +990,7 @@ class TestBuildTargetIndexContent:
             working_has_trailing_newline=True,
         )
 
-        assert result == b"keep\nreplacement\ntail\n"
+        assert result == b"keep\r\nreplacement\r\ntail\r\n"
 
     def test_working_tree_replacement_can_return_buffer(self, line_sequence):
         """Working-tree replacement can return a buffer for streaming callers."""
@@ -932,7 +1012,38 @@ class TestBuildTargetIndexContent:
             working_has_trailing_newline=True,
         ) as result:
             assert isinstance(result, LineBuffer)
-            assert result.to_bytes() == b"keep\nreplacement\ntail\n"
+            assert result.to_bytes() == b"keep\r\nreplacement\r\ntail\r\n"
+
+    def test_working_tree_replacement_preserves_mixed_line_endings(self):
+        """Replacement discard should retain every untouched source ending."""
+        header = HunkHeader(1, 4, 1, 4)
+        lines = [
+            LineEntry(None, " ", 1, 1, text_bytes=b"keep", text="keep"),
+            LineEntry(1, "-", 2, None, text_bytes=b"old\r", text="old"),
+            LineEntry(2, "+", None, 2, text_bytes=b"working\r", text="working"),
+            LineEntry(
+                None,
+                " ",
+                3,
+                3,
+                text_bytes=b"untouched-crlf\r",
+                text="untouched-crlf",
+            ),
+            LineEntry(None, " ", 4, 4, text_bytes=b"tail", text="tail"),
+        ]
+        line_changes = LineLevelChange(path="test.txt", header=header, lines=lines)
+        working_content = b"keep\nworking\r\nuntouched-crlf\r\ntail\n"
+
+        with LineBuffer.from_bytes(working_content) as working_lines:
+            result = _build_target_working_tree_replacement_bytes(
+                line_changes,
+                {1, 2},
+                "replacement",
+                working_lines,
+                working_has_trailing_newline=True,
+            )
+
+        assert result == b"keep\nreplacement\r\nuntouched-crlf\r\ntail\n"
 
 
 class TestBuildTargetWorkingTreeContent:


### PR DESCRIPTION
Classic content-buffer staging rebuilds index blobs from line-oriented selections, including replacement and --as workflows.

Its line helpers stripped complete CRLF endings but reattached only LF, so retained lines could silently change byte representation even when the repository intentionally stores CRLF or mixed endings.

This change keeps exact source bytes for retained lines, strips replacement boundaries correctly, preserves streaming line endings, and adds byte-exact CRLF and mixed-ending coverage.

Content-buffer staging now changes selected content without normalizing unrelated line endings. The full 3,339-test suite passes.