### PR TITLE
include: Make classic line fallback fail closed

### DIFF
--- a/src/git_stage_batch/commands/selection/include_line_action.py
+++ b/src/git_stage_batch/commands/selection/include_line_action.py
@@ -147,10 +147,10 @@ def include_live_line_selection(
                     build_target_index_buffer_from_lines(
                         line_changes,
                         set(combined_include_ids),
-                        hunk_source_lines,
+                        hunk_base_lines,
                         base_has_trailing_newline=(
                             _include_line_selection.line_sequence_ends_with_lf(
-                                hunk_source_lines
+                                hunk_base_lines
                             )
                         ),
                     ) as target_working_lines,

--- a/src/git_stage_batch/staging/content_buffers.py
+++ b/src/git_stage_batch/staging/content_buffers.py
@@ -217,10 +217,11 @@ def _target_index_line_contents(
             yield from pending_additions
             pending_additions.clear()
 
-    def base_line_matches(text: bytes) -> bool:
+    def base_line_matches(line_entry: LineEntry) -> bool:
         return (
             base_pointer < base_line_count
-            and _line_payload_at(base_lines, base_pointer) == text
+            and _line_payload_at(base_lines, base_pointer)
+            == _line_entry_payload(line_entry)
         )
 
     def copy_unchanged_lines_before(old_line_number: int | None) -> Iterator[bytes]:
@@ -243,20 +244,22 @@ def _target_index_line_contents(
         if line_entry.kind == " ":
             yield from copy_unchanged_lines_before(line_entry.old_line_number)
             yield from flush_pending_additions()
-            if base_pointer < base_line_count:
-                yield _line_content_at(base_lines, base_pointer)
-                base_pointer += 1
+            if not base_line_matches(line_entry):
+                raise ValueError("Index content no longer matches the selected line view")
+            yield _line_content_at(base_lines, base_pointer)
+            base_pointer += 1
         elif line_entry.kind == "-":
             yield from copy_unchanged_lines_before(line_entry.old_line_number)
             yield from flush_pending_additions()
+            if not base_line_matches(line_entry):
+                raise ValueError("Index content no longer matches the selected line view")
             if line_entry.id in include_ids:
-                if base_line_matches(line_entry.text_bytes):
-                    base_pointer += 1
-            elif base_line_matches(line_entry.text_bytes):
+                base_pointer += 1
+            else:
                 yield _line_content_at(base_lines, base_pointer)
                 base_pointer += 1
         elif line_entry.kind == "+":
-            if base_line_matches(line_entry.text_bytes):
+            if base_line_matches(line_entry):
                 yield from flush_pending_additions()
                 yield _line_content_at(base_lines, base_pointer)
                 base_pointer += 1

--- a/src/git_stage_batch/staging/content_buffers.py
+++ b/src/git_stage_batch/staging/content_buffers.py
@@ -259,11 +259,7 @@ def _target_index_line_contents(
                 yield _line_content_at(base_lines, base_pointer)
                 base_pointer += 1
         elif line_entry.kind == "+":
-            if base_line_matches(line_entry):
-                yield from flush_pending_additions()
-                yield _line_content_at(base_lines, base_pointer)
-                base_pointer += 1
-            elif line_entry.id in include_ids:
+            if line_entry.id in include_ids:
                 pending_additions.append(_line_entry_content(line_entry))
 
     yield from flush_pending_additions()

--- a/tests/staging/test_content_buffers.py
+++ b/tests/staging/test_content_buffers.py
@@ -1,5 +1,7 @@
 """Tests for line-level staging content buffers."""
 
+import pytest
+
 from git_stage_batch.core.models import LineLevelChange, HunkHeader, LineEntry
 from git_stage_batch.core.buffer import LineBuffer
 from git_stage_batch.core.replacement import ReplacementPayload
@@ -374,6 +376,26 @@ class TestBuildTargetIndexContent:
 
         assert result == b"keep\nnew\r\ntail\n"
 
+    def test_index_selected_lines_refuse_drifted_base_content(self):
+        """Classic index staging must fail instead of skipping a mismatch."""
+        header = HunkHeader(1, 3, 1, 3)
+        lines = [
+            LineEntry(None, " ", 1, 1, text_bytes=b"keep", text="keep"),
+            LineEntry(1, "-", 2, None, text_bytes=b"old", text="old"),
+            LineEntry(2, "+", None, 2, text_bytes=b"new", text="new"),
+            LineEntry(None, " ", 3, 3, text_bytes=b"tail", text="tail"),
+        ]
+        line_changes = LineLevelChange(path="test.txt", header=header, lines=lines)
+        base_content = b"keep\ndrifted\ntail\n"
+
+        with LineBuffer.from_bytes(base_content) as base_lines:
+            with pytest.raises(ValueError, match="no longer matches"):
+                _build_target_index_content_bytes(
+                    line_changes,
+                    {1, 2},
+                    base_lines,
+                    base_has_trailing_newline=True,
+                )
 
     def test_preserves_trailing_newline(self):
         """Test that trailing newline is preserved from base."""

--- a/tests/staging/test_content_buffers.py
+++ b/tests/staging/test_content_buffers.py
@@ -397,6 +397,25 @@ class TestBuildTargetIndexContent:
                     base_has_trailing_newline=True,
                 )
 
+    def test_index_selected_insertion_is_not_deduplicated_against_base(self):
+        """A selected addition equal to its anchor remains a real addition."""
+        header = HunkHeader(0, 0, 1, 1)
+        lines = [
+            LineEntry(1, "+", None, 1, text_bytes=b"same", text="same"),
+        ]
+        line_changes = LineLevelChange(path="test.txt", header=header, lines=lines)
+        base_content = b"same\n"
+
+        with LineBuffer.from_bytes(base_content) as base_lines:
+            result = _build_target_index_content_bytes(
+                line_changes,
+                {1},
+                base_lines,
+                base_has_trailing_newline=True,
+            )
+
+        assert result == b"same\nsame\n"
+
     def test_preserves_trailing_newline(self):
         """Test that trailing newline is preserved from base."""
         header = HunkHeader(1, 1, 1, 2)


### PR DESCRIPTION
Line inclusion normally uses the transient merge engine, but classic content reconstruction remains available for fallback and direct builder paths.

That builder could accept drifted deletion lines, collapse selected duplicate additions, or read an unverified working-tree base after a merge refusal, producing silently incorrect index content.

This change validates every classic base line, retains explicitly selected duplicates, and requires the fallback hunk base to match the current index before reconstruction.

Classic line fallback now refuses stale inputs and preserves the exact selected edit sequence. The full 3,339-test suite passes.