### PR TITLE
staging: Separate additions after unterminated lines

### DIFF
--- a/src/git_stage_batch/batch/merge/merge.py
+++ b/src/git_stage_batch/batch/merge/merge.py
@@ -27,6 +27,7 @@ from ...editor.line_endings import (
     choose_line_ending,
     restore_line_endings_in_chunks,
 )
+from ...editor.line_export import ensure_line_chunk_boundaries
 from ...exceptions import (
     MergeError as _MergeError,
 )
@@ -73,12 +74,14 @@ def merge_batch_from_line_sequences_as_buffer(
     normalized_working_lines = normalize_line_sequence_endings(working_lines)
     return LineBuffer.from_chunks(
         restore_line_endings_in_chunks(
-            _merge_batch_line_chunks(
-                normalized_source_lines,
-                ownership,
-                normalized_working_lines,
-                source_to_working_mapping=source_to_working_mapping,
-                resolution=resolution,
+            ensure_line_chunk_boundaries(
+                _merge_batch_line_chunks(
+                    normalized_source_lines,
+                    ownership,
+                    normalized_working_lines,
+                    source_to_working_mapping=source_to_working_mapping,
+                    resolution=resolution,
+                )
             ),
             result_line_ending,
         )

--- a/src/git_stage_batch/editor/line_export.py
+++ b/src/git_stage_batch/editor/line_export.py
@@ -66,6 +66,35 @@ def line_body_chunks(
         yield previous_line
 
 
+def ensure_line_chunk_boundaries(
+    lines: Iterable[LineLike],
+    *,
+    default_line_ending: bytes = b"\n",
+) -> Iterator[bytes]:
+    """Terminate non-final logical lines while preserving the final EOF state."""
+    if default_line_ending not in (b"\n", b"\r\n"):
+        raise ValueError("default line ending must be LF or CRLF")
+
+    previous_line: bytes | None = None
+    for line in lines:
+        current_line = _line_bytes(line)
+        if previous_line is not None:
+            if previous_line.endswith(b"\n"):
+                yield previous_line
+            else:
+                if current_line.endswith(b"\r\n"):
+                    current_ending = b"\r\n"
+                elif current_line.endswith(b"\n"):
+                    current_ending = b"\n"
+                else:
+                    current_ending = default_line_ending
+                yield previous_line + current_ending
+        previous_line = current_line
+
+    if previous_line is not None:
+        yield previous_line
+
+
 def _line_bytes(line: LineLike) -> bytes:
     if isinstance(line, (bytes, bytearray, memoryview)):
         return bytes(line)

--- a/src/git_stage_batch/staging/content_buffers.py
+++ b/src/git_stage_batch/staging/content_buffers.py
@@ -14,6 +14,7 @@ from ..core.buffer import (
     LineBuffer,
 )
 from ..editor.line_endings import detect_line_ending
+from ..editor.line_export import ensure_line_chunk_boundaries
 
 
 def _line_payload(line: bytes) -> bytes:
@@ -277,12 +278,21 @@ def build_target_index_buffer_from_lines(
 ) -> LineBuffer:
     """Build target index content from indexed base content lines."""
     base_line_count = len(base_lines)
+    detected_line_ending = detect_line_ending(base_lines)
+    default_line_ending = (
+        detected_line_ending
+        if detected_line_ending in (b"\n", b"\r\n")
+        else b"\n"
+    )
     return LineBuffer.from_chunks(
-        _target_index_line_contents(
-            line_changes,
-            include_ids,
-            base_lines,
-            base_line_count,
+        ensure_line_chunk_boundaries(
+            _target_index_line_contents(
+                line_changes,
+                include_ids,
+                base_lines,
+                base_line_count,
+            ),
+            default_line_ending=default_line_ending,
         )
     )
 

--- a/tests/commands/test_include.py
+++ b/tests/commands/test_include.py
@@ -413,6 +413,42 @@ class TestCommandIncludeLine:
         assert blob_result.stdout == b"newtarget"
         assert mode_result.stdout.split()[0] == "120000"
 
+    @pytest.mark.parametrize("line_ending", [b"\n", b"\r\n"])
+    def test_include_line_after_unterminated_eof_does_not_glue_lines(
+        self,
+        temp_git_repo,
+        line_ending,
+    ):
+        """A selected line after an unterminated EOF remains a separate line."""
+        test_file = temp_git_repo / "test.txt"
+        test_file.write_bytes(line_ending.join([b"line1", b"line2"]))
+        subprocess.run(["git", "add", "test.txt"], check=True, cwd=temp_git_repo)
+        subprocess.run(
+            ["git", "commit", "-m", "Add test file"],
+            check=True,
+            cwd=temp_git_repo,
+        )
+        expected = line_ending.join([b"line1", b"line2", b"line3", b""])
+        test_file.write_bytes(expected)
+
+        command_start(quiet=True)
+        line_changes = load_line_changes_from_state()
+        line_id = next(
+            line.id
+            for line in line_changes.lines
+            if line.kind == "+" and line.text_bytes.removesuffix(b"\r") == b"line3"
+        )
+        assert line_id is not None
+        command_include_line(str(line_id))
+
+        result = subprocess.run(
+            ["git", "show", ":test.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        assert result.stdout == expected
+
     def test_include_to_batch_symlink_preserves_mode(self, temp_git_repo):
         """Line include to a batch should keep symlink mode and target bytes."""
         link_path = temp_git_repo / "link"

--- a/tests/staging/test_content_buffers.py
+++ b/tests/staging/test_content_buffers.py
@@ -416,6 +416,26 @@ class TestBuildTargetIndexContent:
 
         assert result == b"same\nsame\n"
 
+    def test_index_selected_insertion_terminates_unterminated_base_line(self):
+        """An insertion after an unterminated EOF line remains a new line."""
+        header = HunkHeader(1, 2, 1, 3)
+        lines = [
+            LineEntry(None, " ", 1, 1, text_bytes=b"line1", text="line1"),
+            LineEntry(None, " ", 2, 2, text_bytes=b"line2", text="line2"),
+            LineEntry(1, "+", None, 3, text_bytes=b"line3", text="line3"),
+        ]
+        line_changes = LineLevelChange(path="test.txt", header=header, lines=lines)
+
+        with LineBuffer.from_bytes(b"line1\nline2") as base_lines:
+            result = _build_target_index_content_bytes(
+                line_changes,
+                {1},
+                base_lines,
+                base_has_trailing_newline=False,
+            )
+
+        assert result == b"line1\nline2\nline3\n"
+
     def test_preserves_trailing_newline(self):
         """Test that trailing newline is preserved from base."""
         header = HunkHeader(1, 1, 1, 2)


### PR DESCRIPTION
Line-selection staging reconstructs index and transient batch content from streamed logical lines.

An addition placed after an unterminated EOF line could be concatenated with the preceding content, silently staging a joined line instead of the selected edit.

This change introduces streaming logical-boundary normalization and applies it to classic index reconstruction and transient batch merging, with LF and CRLF workflow coverage.

Selected additions now remain distinct without changing the target line-ending convention. The focused 94-test include and staging suite passes.