### PR TITLE
staging: Preserve unterminated replacement output

### DIFF
--- a/src/git_stage_batch/staging/content_buffers.py
+++ b/src/git_stage_batch/staging/content_buffers.py
@@ -735,5 +735,5 @@ def _build_target_working_tree_buffer_with_replaced_lines(
         selection_start=replace_start,
         selection_end=replace_end,
         has_trailing_newline=trailing_newline,
-        add_trailing_newline_when_nonempty=True,
+        add_trailing_newline_when_nonempty=working_line_count == 0,
     )

--- a/tests/commands/test_discard.py
+++ b/tests/commands/test_discard.py
@@ -790,6 +790,32 @@ class TestCommandDiscardToBatch:
         file_txt = temp_git_repo_with_session / "file.txt"
         assert not file_txt.exists()  # File removed after discard
 
+    def test_discard_line_as_to_batch_preserves_missing_final_newline(
+        self,
+        temp_git_repo,
+    ):
+        """Replacement discard must preserve an absent final newline."""
+        test_file = temp_git_repo / "test.txt"
+        test_file.write_bytes(b"keep\nold")
+        subprocess.run(["git", "add", "test.txt"], check=True, cwd=temp_git_repo)
+        subprocess.run(
+            ["git", "commit", "-m", "Add test file"],
+            check=True,
+            cwd=temp_git_repo,
+        )
+        test_file.write_bytes(b"keep\nchanged")
+        command_start(quiet=True)
+
+        command_discard_line_as_to_batch(
+            "replacement-batch",
+            "1,2",
+            "new",
+            quiet=True,
+        )
+        command_apply_from_batch("replacement-batch")
+
+        assert test_file.read_bytes() == b"keep\nnew"
+
     def test_discard_to_batch_auto_creates_batch(self, temp_git_repo_with_session):
         """Test that discard to batch auto-creates batch if it doesn't exist."""
 

--- a/tests/staging/test_content_buffers.py
+++ b/tests/staging/test_content_buffers.py
@@ -1053,6 +1053,27 @@ class TestBuildTargetIndexContent:
 
         assert result == b"keep\r\nreplacement\r\ntail\r\n"
 
+    def test_working_tree_replacement_preserves_missing_final_newline(self):
+        """Replacing a final line must not invent a trailing newline."""
+        header = HunkHeader(1, 2, 1, 2)
+        lines = [
+            LineEntry(None, " ", 1, 1, text_bytes=b"keep", text="keep"),
+            LineEntry(1, "-", 2, None, text_bytes=b"old", text="old"),
+            LineEntry(2, "+", None, 2, text_bytes=b"changed", text="changed"),
+        ]
+        line_changes = LineLevelChange(path="test.txt", header=header, lines=lines)
+
+        with LineBuffer.from_bytes(b"keep\nchanged") as working_lines:
+            result = _build_target_working_tree_replacement_bytes(
+                line_changes,
+                {1, 2},
+                "new",
+                working_lines,
+                working_has_trailing_newline=False,
+            )
+
+        assert result == b"keep\nnew"
+
     def test_working_tree_replacement_can_return_buffer(self, line_sequence):
         """Working-tree replacement can return a buffer for streaming callers."""
         header = HunkHeader(1, 3, 1, 3)


### PR DESCRIPTION
Worktree line replacement derives output from the replacement payload and the source file newline state.

Replacing the final line of a nonempty unterminated file could still invent a trailing newline, changing bytes beyond the selected replacement.

This change requests a fallback terminator only for originally empty files and covers the buffer builder and discard-to-batch workflow.

Replacement output now retains an intentional missing final newline through batch application. The focused 106-test staging and discard suite passes.