### PR TITLE
buffer: Support maximum-length regular filenames

### DIFF
--- a/src/git_stage_batch/core/buffer.py
+++ b/src/git_stage_batch/core/buffer.py
@@ -752,7 +752,7 @@ def _write_regular_file_atomically(
     )
     file_descriptor, temporary_name = tempfile.mkstemp(
         dir=file_path.parent,
-        prefix=f".{file_path.name}.",
+        prefix=".git-stage-batch-",
         suffix=".tmp",
     )
     temporary_path = Path(temporary_name)

--- a/tests/core/test_buffer.py
+++ b/tests/core/test_buffer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import mmap
+import os
 from collections.abc import Sequence
 
 import pytest
@@ -234,7 +235,18 @@ def test_write_buffer_failure_preserves_existing_file(tmp_path):
         write_buffer_to_path(output_path, failing_chunks())
 
     assert output_path.read_bytes() == b"original\n"
-    assert list(tmp_path.glob(".out.txt.*.tmp")) == []
+    assert list(tmp_path.glob(".git-stage-batch-*.tmp")) == []
+
+
+def test_regular_write_supports_maximum_length_filename(tmp_path):
+    """Atomic regular-file publication must use a short private filename."""
+    maximum_name_length = os.pathconf(tmp_path, "PC_NAME_MAX")
+    output_path = tmp_path / ("x" * maximum_name_length)
+    output_path.write_bytes(b"old contents")
+
+    write_buffer_to_path(output_path, b"new contents")
+
+    assert output_path.read_bytes() == b"new contents"
 
 
 def test_buffer_matches_across_chunk_boundaries(line_sequence):


### PR DESCRIPTION
Regular buffer writes publish through a same-directory temporary file before atomically replacing the destination.

A destination at the filesystem component-length limit could not be rewritten because the temporary prefix repeated its full filename and exceeded the same limit.

This change uses a short private temporary prefix whose length is independent of the destination and adds a maximum-length publication regression.

Atomic regular-file writes now support every destination component length accepted by the filesystem. The focused 35-test buffer suite passes.