### PR TITLE
buffer: Publish generic symlinks atomically

### DIFF
--- a/src/git_stage_batch/core/buffer.py
+++ b/src/git_stage_batch/core/buffer.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import stat
 import tempfile
 from typing import Any, BinaryIO, Generic, Iterator, TypeVar, overload
+import uuid
 
 from .mapped_storage import (
     ChunkedMappedRecordVector,
@@ -768,6 +769,28 @@ def _write_regular_file_atomically(
                     pass
             os.fchmod(file_handle.fileno(), replacement_mode)
             os.fsync(file_handle.fileno())
+        os.replace(temporary_path, file_path)
+        _fsync_directory(file_path.parent)
+    finally:
+        temporary_path.unlink(missing_ok=True)
+
+
+def _replace_with_symlink_atomically(file_path: Path, target: bytes) -> None:
+    """Publish a symlink through a same-directory atomic replacement."""
+    temporary_path = None
+    for _attempt in range(100):
+        candidate = file_path.parent / f".git-stage-batch-{uuid.uuid4().hex}.tmp"
+        try:
+            os.symlink(target, os.fsencode(candidate))
+        except FileExistsError:
+            continue
+        temporary_path = candidate
+        break
+
+    if temporary_path is None:
+        raise FileExistsError(f"Unable to create temporary symlink for {file_path}")
+
+    try:
         os.replace(temporary_path, file_path)
         _fsync_directory(file_path.parent)
     finally:

--- a/src/git_stage_batch/core/buffer.py
+++ b/src/git_stage_batch/core/buffer.py
@@ -700,8 +700,7 @@ def write_buffer_to_path(path: str | Path, buffer: BufferInput) -> None:
     file_path.parent.mkdir(parents=True, exist_ok=True)
     if file_path.is_symlink():
         target = b"".join(buffer_byte_chunks(buffer))
-        file_path.unlink()
-        os.symlink(target, os.fsencode(file_path))
+        _replace_with_symlink_atomically(file_path, target)
         return
 
     _write_regular_file_atomically(file_path, buffer)

--- a/src/git_stage_batch/core/buffer.py
+++ b/src/git_stage_batch/core/buffer.py
@@ -769,13 +769,17 @@ def _write_regular_file_atomically(
             os.fchmod(file_handle.fileno(), replacement_mode)
             os.fsync(file_handle.fileno())
         os.replace(temporary_path, file_path)
-        directory_descriptor = os.open(
-            file_path.parent,
-            os.O_RDONLY | getattr(os, "O_DIRECTORY", 0),
-        )
-        try:
-            os.fsync(directory_descriptor)
-        finally:
-            os.close(directory_descriptor)
+        _fsync_directory(file_path.parent)
     finally:
         temporary_path.unlink(missing_ok=True)
+
+
+def _fsync_directory(directory: Path) -> None:
+    directory_descriptor = os.open(
+        directory,
+        os.O_RDONLY | getattr(os, "O_DIRECTORY", 0),
+    )
+    try:
+        os.fsync(directory_descriptor)
+    finally:
+        os.close(directory_descriptor)

--- a/tests/core/test_buffer.py
+++ b/tests/core/test_buffer.py
@@ -8,6 +8,7 @@ from collections.abc import Sequence
 
 import pytest
 
+from git_stage_batch.core import buffer as buffer_module
 from git_stage_batch.core.buffer import (
     LineBuffer,
     buffer_byte_chunks,
@@ -247,6 +248,26 @@ def test_regular_write_supports_maximum_length_filename(tmp_path):
     write_buffer_to_path(output_path, b"new contents")
 
     assert output_path.read_bytes() == b"new contents"
+
+
+def test_symlink_write_keeps_old_entry_until_atomic_replace(tmp_path, monkeypatch):
+    """Publishing a new symlink target must not expose a missing path."""
+    output_path = tmp_path / "link"
+    os.symlink(b"old-target", os.fsencode(output_path))
+    original_replace = os.replace
+
+    def inspect_replace(source, destination):
+        assert destination == output_path
+        assert output_path.is_symlink()
+        assert os.readlink(output_path) == "old-target"
+        original_replace(source, destination)
+
+    monkeypatch.setattr(buffer_module.os, "replace", inspect_replace)
+
+    write_buffer_to_path(output_path, b"new-target")
+
+    assert output_path.is_symlink()
+    assert os.readlink(output_path) == "new-target"
 
 
 def test_buffer_matches_across_chunk_boundaries(line_sequence):

--- a/tests/core/test_buffer.py
+++ b/tests/core/test_buffer.py
@@ -270,6 +270,24 @@ def test_symlink_write_keeps_old_entry_until_atomic_replace(tmp_path, monkeypatc
     assert os.readlink(output_path) == "new-target"
 
 
+def test_failed_symlink_publication_preserves_old_entry(tmp_path, monkeypatch):
+    """A failed atomic publish must leave the existing symlink intact."""
+    output_path = tmp_path / "link"
+    os.symlink(b"old-target", os.fsencode(output_path))
+
+    def fail_replace(*args):
+        raise OSError("simulated publication failure")
+
+    monkeypatch.setattr(buffer_module.os, "replace", fail_replace)
+
+    with pytest.raises(OSError, match="simulated publication failure"):
+        write_buffer_to_path(output_path, b"new-target")
+
+    assert output_path.is_symlink()
+    assert os.readlink(output_path) == "old-target"
+    assert list(tmp_path.glob(".git-stage-batch-*.tmp")) == []
+
+
 def test_buffer_matches_across_chunk_boundaries(line_sequence):
     """Buffer comparison ignores how inputs are chunked."""
     left = line_sequence([b"alpha\n", b"beta\n"])

--- a/tests/core/test_buffer.py
+++ b/tests/core/test_buffer.py
@@ -288,6 +288,18 @@ def test_failed_symlink_publication_preserves_old_entry(tmp_path, monkeypatch):
     assert list(tmp_path.glob(".git-stage-batch-*.tmp")) == []
 
 
+def test_symlink_write_supports_maximum_length_filename(tmp_path):
+    """The private publication name must not depend on user filename length."""
+    maximum_name_length = os.pathconf(tmp_path, "PC_NAME_MAX")
+    output_path = tmp_path / ("x" * maximum_name_length)
+    os.symlink(b"old-target", os.fsencode(output_path))
+
+    write_buffer_to_path(output_path, b"new-target")
+
+    assert output_path.is_symlink()
+    assert os.readlink(output_path) == "new-target"
+
+
 def test_buffer_matches_across_chunk_boundaries(line_sequence):
     """Buffer comparison ignores how inputs are chunked."""
     left = line_sequence([b"alpha\n", b"beta\n"])


### PR DESCRIPTION
Generic buffer writes preserve an existing symlink by interpreting reconstructed bytes as its replacement target.

Those writes removed the destination before recreating it, exposing a crash window with a missing path and risking filename-limit failures in derived temporary names.

This change adds a same-directory atomic symlink publication primitive, shares directory durability synchronization, adopts the primitive for generic writes, and covers visibility, failure, and maximum-length names.

Generic symlink replacement now avoids unlink-before-create windows across supported filename lengths. The focused 38-test buffer suite passes.