### PR TITLE
buffer: Publish Git worktree transitions atomically

### DIFF
--- a/src/git_stage_batch/core/buffer.py
+++ b/src/git_stage_batch/core/buffer.py
@@ -718,9 +718,7 @@ def write_buffer_to_working_tree_path(
 
     if mode == "120000":
         target = b"".join(buffer_byte_chunks(buffer))
-        if os.path.lexists(file_path):
-            file_path.unlink()
-        os.symlink(target, os.fsencode(file_path))
+        _replace_with_symlink_atomically(file_path, target)
         return
 
     if file_path.is_symlink():

--- a/src/git_stage_batch/core/buffer.py
+++ b/src/git_stage_batch/core/buffer.py
@@ -721,9 +721,6 @@ def write_buffer_to_working_tree_path(
         _replace_with_symlink_atomically(file_path, target)
         return
 
-    if file_path.is_symlink():
-        file_path.unlink()
-
     requested_mode = None
     if mode == "100755":
         requested_mode = 0o755
@@ -740,8 +737,10 @@ def _write_regular_file_atomically(
 ) -> None:
     """Stream a regular file through a same-directory atomic replacement."""
     try:
-        metadata = file_path.stat()
+        metadata = file_path.lstat()
     except FileNotFoundError:
+        metadata = None
+    if metadata is not None and not stat.S_ISREG(metadata.st_mode):
         metadata = None
     replacement_mode = (
         mode

--- a/tests/core/test_buffer.py
+++ b/tests/core/test_buffer.py
@@ -312,6 +312,20 @@ def test_worktree_symlink_replaces_regular_file_atomically(tmp_path):
     assert os.readlink(output_path) == "target"
 
 
+def test_worktree_regular_file_replaces_symlink_atomically(tmp_path):
+    """Git regular-file mode replaces the symlink, not its referent."""
+    output_path = tmp_path / "path"
+    referent = tmp_path / "referent"
+    referent.write_bytes(b"referent contents")
+    os.symlink(referent.name, output_path)
+
+    write_buffer_to_working_tree_path(output_path, b"regular", mode="100644")
+
+    assert not output_path.is_symlink()
+    assert output_path.read_bytes() == b"regular"
+    assert referent.read_bytes() == b"referent contents"
+
+
 def test_buffer_matches_across_chunk_boundaries(line_sequence):
     """Buffer comparison ignores how inputs are chunked."""
     left = line_sequence([b"alpha\n", b"beta\n"])

--- a/tests/core/test_buffer.py
+++ b/tests/core/test_buffer.py
@@ -18,6 +18,7 @@ from git_stage_batch.core.buffer import (
     buffer_matches,
     buffer_preview,
     write_buffer_to_path,
+    write_buffer_to_working_tree_path,
 )
 
 
@@ -298,6 +299,17 @@ def test_symlink_write_supports_maximum_length_filename(tmp_path):
 
     assert output_path.is_symlink()
     assert os.readlink(output_path) == "new-target"
+
+
+def test_worktree_symlink_replaces_regular_file_atomically(tmp_path):
+    """Git symlink mode atomically replaces a current regular file."""
+    output_path = tmp_path / "path"
+    output_path.write_bytes(b"regular contents")
+
+    write_buffer_to_working_tree_path(output_path, b"target", mode="120000")
+
+    assert output_path.is_symlink()
+    assert os.readlink(output_path) == "target"
 
 
 def test_buffer_matches_across_chunk_boundaries(line_sequence):


### PR DESCRIPTION
Mode-aware worktree writes reconstruct regular files and Git symlinks from stored blob bytes.

Switching either path type still removed the current entry before publishing its replacement, exposing a missing-path window and allowing regular-file writes through a symlink referent.

This change routes mode 120000 writes through atomic link publication and makes regular-file publication replace a current symlink without modifying its target, with coverage in both directions.

Git worktree symlink and regular-file transitions now publish atomically without touching symlink referents. The focused 40-test buffer suite passes.