### PR TITLE
undo: Keep checkpoint state repository-safe

### DIFF
--- a/src/git_stage_batch/data/undo_checkpoints.py
+++ b/src/git_stage_batch/data/undo_checkpoints.py
@@ -296,7 +296,14 @@ def undo_checkpoint(
         elif current_undo_commit() == _PENDING_CHECKPOINT:
             yield
             return
-        _clear_pending_checkpoint()
+        else:
+            _clear_pending_checkpoint()
+            raise CommandError(
+                _(
+                    "Cannot start an undoable operation because the pending "
+                    "checkpoint reference moved."
+                )
+            )
 
     previous_redo = current_redo_commit()
     checkpoint = _create_undo_checkpoint(

--- a/src/git_stage_batch/data/undo_checkpoints.py
+++ b/src/git_stage_batch/data/undo_checkpoints.py
@@ -55,8 +55,16 @@ from ..utils.paths import (
 
 
 _PENDING_CHECKPOINT: str | None = None
+_PENDING_CHECKPOINT_REPOSITORY: Path | None = None
 EXPLICIT_WORKTREE_SCOPE = "explicit"
 CHANGED_WORKTREE_SCOPE = "changed"
+
+
+def _clear_pending_checkpoint() -> None:
+    """Forget process-local state for the pending checkpoint."""
+    global _PENDING_CHECKPOINT, _PENDING_CHECKPOINT_REPOSITORY
+    _PENDING_CHECKPOINT = None
+    _PENDING_CHECKPOINT_REPOSITORY = None
 
 
 def _checkpoint_worktree_scope(
@@ -189,7 +197,7 @@ def _create_undo_checkpoint(
     if not session_dir.exists():
         return None
 
-    global _PENDING_CHECKPOINT
+    global _PENDING_CHECKPOINT, _PENDING_CHECKPOINT_REPOSITORY
 
     worktree_path_scope, tracked_worktree_paths = _checkpoint_worktree_scope(
         worktree_paths
@@ -259,6 +267,7 @@ def _create_undo_checkpoint(
         deletes=[SESSION_REDO_STACK_REF],
     )
     _PENDING_CHECKPOINT = checkpoint_commit
+    _PENDING_CHECKPOINT_REPOSITORY = get_git_directory_path()
     return checkpoint_commit
 
 
@@ -277,12 +286,17 @@ def undo_checkpoint(
     checkpoint before propagating an exception. This turns the checkpoint into
     a transaction boundary for commands that span several files or stores.
     """
-    global _PENDING_CHECKPOINT
     if _PENDING_CHECKPOINT is not None:
-        if current_undo_commit() == _PENDING_CHECKPOINT:
+        current_repository = get_git_directory_path()
+        if (
+            _PENDING_CHECKPOINT_REPOSITORY is not None
+            and current_repository != _PENDING_CHECKPOINT_REPOSITORY
+        ):
+            _clear_pending_checkpoint()
+        elif current_undo_commit() == _PENDING_CHECKPOINT:
             yield
             return
-        _PENDING_CHECKPOINT = None
+        _clear_pending_checkpoint()
 
     previous_redo = current_redo_commit()
     checkpoint = _create_undo_checkpoint(
@@ -326,8 +340,7 @@ def _rollback_failed_checkpoint(
     previous_redo: str | None,
 ) -> None:
     """Restore an incomplete checkpoint after its operation raises."""
-    global _PENDING_CHECKPOINT
-    _PENDING_CHECKPOINT = None
+    _clear_pending_checkpoint()
 
     if current_undo_commit() != checkpoint:
         raise CommandError(
@@ -358,11 +371,10 @@ def _rollback_failed_checkpoint(
 
 def finalize_pending_checkpoint() -> None:
     """Record the post-operation state for conflict detection."""
-    global _PENDING_CHECKPOINT
     checkpoint = _PENDING_CHECKPOINT
     if checkpoint is None:
         return
-    _PENDING_CHECKPOINT = None
+    _clear_pending_checkpoint()
 
     current = current_undo_commit()
     if current != checkpoint:

--- a/src/git_stage_batch/data/undo_restore.py
+++ b/src/git_stage_batch/data/undo_restore.py
@@ -50,6 +50,7 @@ def _tree_entries(commit: str, prefix: str) -> list[tuple[str, str, str]]:
         ["ls-tree", "-r", "-z", commit, prefix],
         check=False,
         text_output=False,
+        cwd=str(get_git_repository_root_path()),
         requires_index_lock=False,
     )
     if result.returncode != 0 or not result.stdout:

--- a/tests/data/test_undo_checkpoints.py
+++ b/tests/data/test_undo_checkpoints.py
@@ -1,6 +1,11 @@
 """Focused tests for undo checkpoint compatibility behavior."""
 
+from pathlib import Path
+
+import pytest
+
 from git_stage_batch.data import undo_checkpoints
+from git_stage_batch.exceptions import CommandError
 
 
 def test_legacy_ita_fallback_does_not_guess_from_empty_index_blobs(monkeypatch):
@@ -59,3 +64,26 @@ def test_legacy_gitlink_absence_is_normalized_for_conflict_checks():
 def test_redo_conflicts_fail_closed_without_after_undo_state():
     """A partial redo node must require an explicit force override."""
     assert undo_checkpoints._detect_redo_conflicts({}) == ["incomplete checkpoint"]
+
+
+def test_pending_checkpoint_from_another_repository_is_cleared(monkeypatch):
+    """Process-local checkpoint state must not leak between repositories."""
+    monkeypatch.setattr(undo_checkpoints, "_PENDING_CHECKPOINT", "old-pending")
+    monkeypatch.setattr(
+        undo_checkpoints,
+        "_PENDING_CHECKPOINT_REPOSITORY",
+        Path("/old/.git"),
+    )
+    monkeypatch.setattr(
+        undo_checkpoints,
+        "get_git_directory_path",
+        lambda: Path("/new/.git"),
+    )
+    monkeypatch.setattr(undo_checkpoints, "current_redo_commit", lambda: None)
+    monkeypatch.setattr(undo_checkpoints, "_create_undo_checkpoint", lambda *args, **kwargs: None)
+
+    with undo_checkpoints.undo_checkpoint("new operation", worktree_paths=[]):
+        pass
+
+    assert undo_checkpoints._PENDING_CHECKPOINT is None
+    assert undo_checkpoints._PENDING_CHECKPOINT_REPOSITORY is None

--- a/tests/data/test_undo_checkpoints.py
+++ b/tests/data/test_undo_checkpoints.py
@@ -66,6 +66,28 @@ def test_redo_conflicts_fail_closed_without_after_undo_state():
     assert undo_checkpoints._detect_redo_conflicts({}) == ["incomplete checkpoint"]
 
 
+def test_nested_checkpoint_fails_when_pending_reference_moved(monkeypatch):
+    """A nested operation must not silently discard a mismatched pending node."""
+    monkeypatch.setattr(undo_checkpoints, "_PENDING_CHECKPOINT", "pending")
+    monkeypatch.setattr(
+        undo_checkpoints,
+        "_PENDING_CHECKPOINT_REPOSITORY",
+        Path("/repo/.git"),
+    )
+    monkeypatch.setattr(
+        undo_checkpoints,
+        "get_git_directory_path",
+        lambda: Path("/repo/.git"),
+    )
+    monkeypatch.setattr(undo_checkpoints, "current_undo_commit", lambda: "moved")
+
+    with pytest.raises(CommandError, match="pending checkpoint reference moved"):
+        with undo_checkpoints.undo_checkpoint("nested", worktree_paths=[]):
+            pass
+
+    assert undo_checkpoints._PENDING_CHECKPOINT is None
+
+
 def test_pending_checkpoint_from_another_repository_is_cleared(monkeypatch):
     """Process-local checkpoint state must not leak between repositories."""
     monkeypatch.setattr(undo_checkpoints, "_PENDING_CHECKPOINT", "old-pending")


### PR DESCRIPTION
Undo checkpoints store root-relative archive paths and retain a process-local pending identity while an operation completes.

Commands run from subdirectories could resolve archive entries against the wrong prefix, while a process switching repositories or observing a moved stack ref could reuse pending state whose repository identity was no longer trustworthy.

This change reads checkpoint trees from the repository root, scopes pending identities to Git directories, clears cross-repository state, and refuses same-repository nested reuse after stack movement.

Checkpoint restoration and nesting now preserve repository context instead of silently crossing it. The focused 23-test undo suite passes.