### PR TITLE
undo: Fail closed during checkpoint finalization

### DIFF
--- a/src/git_stage_batch/data/undo_checkpoints.py
+++ b/src/git_stage_batch/data/undo_checkpoints.py
@@ -385,7 +385,12 @@ def finalize_pending_checkpoint() -> None:
 
     current = current_undo_commit()
     if current != checkpoint:
-        return
+        raise CommandError(
+            _(
+                "Cannot finalize the undo checkpoint because its stack "
+                "reference moved."
+            )
+        )
 
     try:
         manifest = _undo_restore.read_json_from_commit(checkpoint, "manifest.json")

--- a/src/git_stage_batch/data/undo_checkpoints.py
+++ b/src/git_stage_batch/data/undo_checkpoints.py
@@ -394,8 +394,14 @@ def finalize_pending_checkpoint() -> None:
 
     try:
         manifest = _undo_restore.read_json_from_commit(checkpoint, "manifest.json")
-    except CommandError:
-        return
+    except CommandError as error:
+        raise CommandError(
+            _(
+                "Cannot finalize the undo checkpoint because its before-image "
+                "manifest is unavailable. The operation completed, but its "
+                "checkpoint is incomplete."
+            )
+        ) from error
 
     paths = set(manifest.get("tracked_worktree_paths", []))
     if not _uses_explicit_worktree_scope(manifest):

--- a/tests/commands/test_undo.py
+++ b/tests/commands/test_undo.py
@@ -378,6 +378,37 @@ def test_failed_checkpoint_finalization_requires_force(temp_git_repo, monkeypatc
     assert target.read_text() == "before\n"
 
 
+def test_unreadable_checkpoint_manifest_fails_finalization(temp_git_repo, monkeypatch):
+    """Finalization must report an unreadable before-image manifest."""
+    from git_stage_batch.data import undo_checkpoints as checkpoints
+
+    target = _commit_text_file(temp_git_repo, "target.txt", "before\n")
+    get_session_directory_path().mkdir(parents=True, exist_ok=True)
+    original_read_json = checkpoints._undo_restore.read_json_from_commit
+
+    def unreadable_manifest(*args, **kwargs):
+        raise CommandError("manifest unavailable")
+
+    monkeypatch.setattr(
+        checkpoints._undo_restore,
+        "read_json_from_commit",
+        unreadable_manifest,
+    )
+
+    with pytest.raises(CommandError, match="before-image manifest is unavailable"):
+        with undo_checkpoint("change target", worktree_paths=["target.txt"]):
+            target.write_text("changed\n")
+
+    monkeypatch.setattr(
+        checkpoints._undo_restore,
+        "read_json_from_commit",
+        original_read_json,
+    )
+    undo_last_checkpoint(force=True)
+
+    assert target.read_text() == "before\n"
+
+
 def test_scoped_undo_preserves_unrelated_batch_ref_changes(temp_git_repo):
     """Undo should restore changed batch refs without replacing unrelated refs."""
     target_ref = "refs/git-stage-batch/batches/target"

--- a/tests/data/test_undo_checkpoints.py
+++ b/tests/data/test_undo_checkpoints.py
@@ -109,3 +109,20 @@ def test_pending_checkpoint_from_another_repository_is_cleared(monkeypatch):
 
     assert undo_checkpoints._PENDING_CHECKPOINT is None
     assert undo_checkpoints._PENDING_CHECKPOINT_REPOSITORY is None
+
+
+def test_checkpoint_finalization_fails_when_stack_reference_moved(monkeypatch):
+    """Finalization must not silently abandon a displaced checkpoint."""
+    monkeypatch.setattr(undo_checkpoints, "_PENDING_CHECKPOINT", "pending")
+    monkeypatch.setattr(
+        undo_checkpoints,
+        "_PENDING_CHECKPOINT_REPOSITORY",
+        Path("/repo/.git"),
+    )
+    monkeypatch.setattr(undo_checkpoints, "current_undo_commit", lambda: "moved")
+
+    with pytest.raises(CommandError, match="stack reference moved"):
+        undo_checkpoints.finalize_pending_checkpoint()
+
+    assert undo_checkpoints._PENDING_CHECKPOINT is None
+    assert undo_checkpoints._PENDING_CHECKPOINT_REPOSITORY is None


### PR DESCRIPTION
Pending checkpoint finalization records an after-image only while the undo stack still identifies the node created for the completed operation.

A moved stack ref or unreadable before-image manifest previously caused an early return, silently leaving an incomplete checkpoint without explaining why finalization stopped.

This change reports both conditions as contextual command errors and retains the before-image for explicit forced recovery, with focused stack-movement and manifest-failure coverage.

Checkpoint finalization now fails closed whenever it cannot establish a trustworthy before-and-after pair. The focused 25-test undo suite passes.