### PR TITLE
utils: Reject unknown streaming child status

### DIFF
--- a/src/git_stage_batch/utils/command_streaming.py
+++ b/src/git_stage_batch/utils/command_streaming.py
@@ -33,8 +33,10 @@ class SpawnedProcess:
 
         try:
             pid, status = os.waitpid(self.pid, os.WNOHANG)
-        except ChildProcessError:
-            return 0
+        except ChildProcessError as error:
+            raise ChildProcessError(
+                f"Cannot determine exit status for child process {self.pid}"
+            ) from error
 
         if pid == 0:
             return None
@@ -44,7 +46,9 @@ class SpawnedProcess:
         elif os.WIFSIGNALED(status):
             self.returncode = -os.WTERMSIG(status)
         else:
-            self.returncode = 0
+            raise ChildProcessError(
+                f"Child process {self.pid} returned an unsupported wait status"
+            )
 
         return self.returncode
 
@@ -70,7 +74,9 @@ class SpawnedProcess:
         elif os.WIFSIGNALED(status):
             self.returncode = -os.WTERMSIG(status)
         else:
-            self.returncode = 0
+            raise ChildProcessError(
+                f"Child process {self.pid} returned an unsupported wait status"
+            )
 
         return self.returncode
 

--- a/tests/utils/test_stream_process.py
+++ b/tests/utils/test_stream_process.py
@@ -499,6 +499,20 @@ class TestProcessControl:
         exit_code = proc.wait()
         assert exit_code == 17
 
+    def test_poll_rejects_unknown_reaped_child_status(self, monkeypatch):
+        """A missing child status must not be reported as successful."""
+        process = command_streaming.SpawnedProcess(1234)
+
+        def raise_child_process_error(*args):
+            raise ChildProcessError("already reaped")
+
+        monkeypatch.setattr(os, "waitpid", raise_child_process_error)
+
+        with pytest.raises(ChildProcessError, match="Cannot determine exit status"):
+            process.poll()
+
+        assert process.returncode is None
+
     def test_wait_closes_captured_fds(self):
         """Test wait() closes captured pipe fds when stream() is unused."""
         proc = start_command([


### PR DESCRIPTION
The streaming command wrapper polls and waits for posix_spawn children while preserving normal exit and signal return codes.

A child reaped elsewhere or represented by an unsupported wait state could be reported as exit code zero, allowing callers to accept an unknown command outcome as success.

This change raises a contextual child-process error for missing and unsupported wait states while leaving known exit and signal handling unchanged.

Streaming commands now treat unavailable child status as failure instead of inventing success. The focused 52-test streaming-process suite passes.