### PR TITLE
staging: Preserve restored line boundaries

### DIFF
--- a/src/git_stage_batch/commands/selection/discard_line_batching.py
+++ b/src/git_stage_batch/commands/selection/discard_line_batching.py
@@ -6,7 +6,7 @@ import os
 import sys
 
 from ...batch.source.annotation import annotate_with_batch_source
-from ...core.buffer import LineBuffer, buffer_ends_with_lf, write_buffer_to_path
+from ...core.buffer import LineBuffer, write_buffer_to_path
 from ...core.replacement import ReplacementPayload
 from ...data.line_state import load_line_changes_from_state
 from ...utils.repository_buffers import load_working_tree_file_as_buffer
@@ -128,7 +128,6 @@ def discard_file_lines_to_batch(
             line_changes,
             selection.requested_ids,
             working_lines,
-            working_has_trailing_newline=buffer_ends_with_lf(working_lines),
         )
 
     with target_working_buffer:
@@ -218,7 +217,6 @@ def discard_selected_lines_to_batch(
             line_changes,
             selection.requested_ids,
             working_lines,
-            working_has_trailing_newline=buffer_ends_with_lf(working_lines),
         )
 
     log_journal("discard_lines_to_batch_before_write", file_path=str(working_file_path))

--- a/src/git_stage_batch/commands/selection/discard_line_replacement.py
+++ b/src/git_stage_batch/commands/selection/discard_line_replacement.py
@@ -171,9 +171,6 @@ def build_discard_line_replacement_target_buffer(
         selection.rewritten_line_changes,
         rewritten_selected_ids,
         selection.rewritten_working_lines,
-        working_has_trailing_newline=buffer_ends_with_lf(
-            selection.rewritten_working_lines
-        ),
     )
 
 

--- a/src/git_stage_batch/commands/selection/discard_line_selection.py
+++ b/src/git_stage_batch/commands/selection/discard_line_selection.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 
 from ...batch.selection import require_line_selection_in_view
-from ...core.buffer import buffer_ends_with_lf, write_buffer_to_path
+from ...core.buffer import write_buffer_to_path
 from ...core.line_selection import parse_line_selection
 from ...data.line_state import load_line_changes_from_state
 from ...utils.repository_buffers import load_working_tree_file_as_buffer
@@ -61,7 +61,6 @@ def discard_worktree_line_selection(
             line_changes,
             set(requested_ids),
             working_lines,
-            working_has_trailing_newline=buffer_ends_with_lf(working_lines),
         )
 
     with target_working_buffer:

--- a/src/git_stage_batch/staging/content_buffers.py
+++ b/src/git_stage_batch/staging/content_buffers.py
@@ -547,17 +547,24 @@ def build_target_working_tree_buffer_from_lines(
     line_changes: LineLevelChange,
     discard_ids: set[int],
     working_lines: Sequence[bytes],
-    *,
-    working_has_trailing_newline: bool,
 ) -> LineBuffer:
     """Build target working tree content from indexed working tree lines."""
     working_line_count = len(working_lines)
+    detected_line_ending = detect_line_ending(working_lines)
+    default_line_ending = (
+        detected_line_ending
+        if detected_line_ending in (b"\n", b"\r\n")
+        else b"\n"
+    )
     return LineBuffer.from_chunks(
-        _target_working_tree_line_contents(
-            line_changes,
-            discard_ids,
-            working_lines,
-            working_line_count,
+        ensure_line_chunk_boundaries(
+            _target_working_tree_line_contents(
+                line_changes,
+                discard_ids,
+                working_lines,
+                working_line_count,
+            ),
+            default_line_ending=default_line_ending,
         )
     )
 

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -17529,7 +17529,6 @@ def test_discard_line_selection_stays_in_command_helper():
         "write_buffer_to_path",
     }
     helper_imports = command_level_names | {
-        "buffer_ends_with_lf",
         "get_git_repository_root_path",
         "get_selected_change_file_path",
         "load_line_changes_from_state",
@@ -18084,8 +18083,8 @@ def test_discard_uses_file_io_path_empty_helper():
 
 def test_discard_uses_core_buffer_newline_helper():
     """Discard should use core buffer helpers for trailing newline checks."""
-    line_batching_path = (
-        SRC_ROOT / "commands" / "selection" / "discard_line_batching.py"
+    replacement_path = (
+        SRC_ROOT / "commands" / "selection" / "discard_line_replacement.py"
     )
     core_buffer = __import__(
         "git_stage_batch.core.buffer",
@@ -18096,14 +18095,14 @@ def test_discard_uses_core_buffer_newline_helper():
     assert "buffer_ends_with_lf" in vars(core_buffer)
 
     tree = ast.parse(
-        line_batching_path.read_text(),
-        filename=str(line_batching_path),
+        replacement_path.read_text(),
+        filename=str(replacement_path),
     )
     discard_helpers = {
         node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)
     }
 
-    for imported_module, node in _import_from_nodes(line_batching_path):
+    for imported_module, node in _import_from_nodes(replacement_path):
         if imported_module != "git_stage_batch.core.buffer":
             continue
         imported_buffer_names |= {alias.name for alias in node.names}

--- a/tests/staging/test_content_buffers.py
+++ b/tests/staging/test_content_buffers.py
@@ -40,7 +40,6 @@ def _build_target_working_tree_content_text(
             line_changes,
             discard_ids,
             working_lines,
-            working_has_trailing_newline=working_text.endswith("\n"),
         )
     return result.decode("utf-8", errors="surrogateescape")
 
@@ -85,14 +84,11 @@ def _build_target_working_tree_content_bytes(
     line_changes: LineLevelChange,
     discard_ids: set[int],
     working_lines,
-    *,
-    working_has_trailing_newline: bool = True,
 ) -> bytes:
     with build_target_working_tree_buffer_from_lines(
         line_changes,
         discard_ids,
         working_lines,
-        working_has_trailing_newline=working_has_trailing_newline,
     ) as result:
         return result.to_bytes()
 
@@ -1232,10 +1228,42 @@ class TestBuildTargetWorkingTreeContent:
             line_changes,
             {1},
             working_lines,
-            working_has_trailing_newline=True,
         ) as result:
             assert isinstance(result, LineBuffer)
             assert result.to_bytes() == b"line1\r\nline2\r\n"
+
+    @pytest.mark.parametrize("line_ending", [b"\n", b"\r\n"])
+    def test_reinserted_unterminated_line_stays_separate_from_kept_lines(
+        self,
+        line_ending,
+    ):
+        """A restored EOF deletion must not join a later worktree line."""
+        line_changes = LineLevelChange(
+            path="test.txt",
+            header=HunkHeader(1, 1, 1, 2),
+            lines=[
+                LineEntry(
+                    1,
+                    "-",
+                    1,
+                    None,
+                    text_bytes=b"last",
+                    has_trailing_newline=False,
+                ),
+                LineEntry(2, "+", None, 1, text_bytes=b"last"),
+                LineEntry(3, "+", None, 2, text_bytes=b"more"),
+            ],
+        )
+        working_content = line_ending.join([b"last", b"more", b""])
+
+        with LineBuffer.from_bytes(working_content) as working_lines:
+            result = _build_target_working_tree_content_bytes(
+                line_changes,
+                {1},
+                working_lines,
+            )
+
+        assert result == line_ending.join([b"last", b"last", b"more", b""])
 
     def test_file_scoped_deletion_uses_prior_change_delta(self):
         """File-scoped deletions should keep anchors after prior hunks."""


### PR DESCRIPTION
Worktree line discard reconstructs selected content from exact source and working-tree bytes.

When an unterminated row restored from EOF precedes retained worktree content, users can receive adjacent logical rows as one glued byte sequence.

This change applies logical line boundaries with the detected worktree ending, removes the redundant trailing-newline argument from callers, and adds LF and CRLF regression coverage.

Line discard now keeps restored EOF content separate from following rows. The focused 415-test staging and architecture suite passes.
