### PR TITLE
discard: Publish reconstructed lines by target kind

### DIFF
--- a/src/git_stage_batch/commands/selection/discard_line_batching.py
+++ b/src/git_stage_batch/commands/selection/discard_line_batching.py
@@ -6,7 +6,7 @@ import os
 import sys
 
 from ...batch.source.annotation import annotate_with_batch_source
-from ...core.buffer import LineBuffer, write_buffer_to_path
+from ...core.buffer import LineBuffer
 from ...core.replacement import ReplacementPayload
 from ...data.line_state import load_line_changes_from_state
 from ...utils.repository_buffers import load_working_tree_file_as_buffer
@@ -62,7 +62,12 @@ def discard_lines_as_to_batch(
     assert target_working_buffer is not None
     assert replacement is not None
     with target_working_buffer:
-        write_buffer_to_path(replacement.working_file_path, target_working_buffer)
+        _discard_line_publication.publish_worktree_line_discard(
+            replacement.file_path,
+            replacement.working_file_path,
+            target_working_buffer,
+            force_regular=True,
+        )
 
     if not quiet:
         print(

--- a/src/git_stage_batch/commands/selection/discard_line_batching.py
+++ b/src/git_stage_batch/commands/selection/discard_line_batching.py
@@ -19,6 +19,7 @@ from ...utils.journal import log_journal
 from . import batch_line_selection as _batch_line_selection
 from . import batch_line_updates as _batch_line_updates
 from . import discard_file_selection as _discard_file_selection
+from . import discard_line_publication as _discard_line_publication
 from . import discard_line_replacement as _discard_line_replacement
 from .action_completion import finish_selected_change_action
 from .selected_hunk_refresh import recalculate_selected_hunk_for_command
@@ -131,7 +132,11 @@ def discard_file_lines_to_batch(
         )
 
     with target_working_buffer:
-        write_buffer_to_path(working_file_path, target_working_buffer)
+        _discard_line_publication.publish_worktree_line_discard(
+            file_path,
+            working_file_path,
+            target_working_buffer,
+        )
 
     if not quiet:
         print(
@@ -221,7 +226,11 @@ def discard_selected_lines_to_batch(
 
     log_journal("discard_lines_to_batch_before_write", file_path=str(working_file_path))
     with target_working_buffer:
-        write_buffer_to_path(working_file_path, target_working_buffer)
+        _discard_line_publication.publish_worktree_line_discard(
+            line_changes.path,
+            working_file_path,
+            target_working_buffer,
+        )
     log_journal("discard_lines_to_batch_after_write", file_path=str(working_file_path))
 
     if not quiet:

--- a/src/git_stage_batch/commands/selection/discard_line_publication.py
+++ b/src/git_stage_batch/commands/selection/discard_line_publication.py
@@ -1,0 +1,51 @@
+"""Publish reconstructed worktree content for line discard actions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ...core.buffer import (
+    BufferInput,
+    buffer_matches,
+    write_buffer_to_working_tree_path,
+)
+from ...data.file_modes import detect_file_mode
+from ...data.index_entries import read_index_entry
+from ...utils.repository_buffers import read_git_object_buffer_or_none
+
+
+def publish_worktree_line_discard(
+    file_path: str,
+    absolute_path: Path,
+    buffer: BufferInput,
+    *,
+    force_regular: bool = False,
+) -> None:
+    """Publish reconstructed line content with an explicit path-kind policy."""
+    mode = None if force_regular else _line_discard_publication_mode(file_path, buffer)
+    write_buffer_to_working_tree_path(absolute_path, buffer, mode=mode)
+
+
+def _line_discard_publication_mode(
+    file_path: str,
+    buffer: BufferInput,
+) -> str | None:
+    """Return an explicit mode only when publication must change path kind."""
+    worktree_mode = detect_file_mode(file_path)
+    index_entry = read_index_entry(file_path)
+
+    if worktree_mode == "120000":
+        if index_entry is not None and index_entry.mode != "120000":
+            return index_entry.mode
+        return "120000"
+
+    if index_entry is None or index_entry.mode != "120000":
+        return None
+
+    index_buffer = read_git_object_buffer_or_none(f":{file_path}")
+    if index_buffer is None:
+        return None
+    with index_buffer:
+        if buffer_matches(buffer, index_buffer):
+            return "120000"
+    return None

--- a/src/git_stage_batch/commands/selection/discard_line_selection.py
+++ b/src/git_stage_batch/commands/selection/discard_line_selection.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import os
 
 from ...batch.selection import require_line_selection_in_view
-from ...core.buffer import write_buffer_to_path
 from ...core.line_selection import parse_line_selection
 from ...data.line_state import load_line_changes_from_state
 from ...utils.repository_buffers import load_working_tree_file_as_buffer
@@ -16,6 +15,7 @@ from ...i18n import _
 from ...staging.content_buffers import build_target_working_tree_buffer_from_lines
 from ...utils.git_repository import get_git_repository_root_path
 from . import discard_file_selection as _discard_file_selection
+from . import discard_line_publication as _discard_line_publication
 
 
 def discard_worktree_line_selection(
@@ -64,6 +64,10 @@ def discard_worktree_line_selection(
         )
 
     with target_working_buffer:
-        write_buffer_to_path(working_file_path, target_working_buffer)
+        _discard_line_publication.publish_worktree_line_discard(
+            line_changes.path,
+            working_file_path,
+            target_working_buffer,
+        )
 
     return line_changes.path

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -17523,10 +17523,10 @@ def test_discard_line_selection_stays_in_command_helper():
     public_names = {"discard_worktree_line_selection"}
     command_level_names = {
         "build_target_working_tree_buffer_from_lines",
+        "discard_line_publication",
         "load_working_tree_file_as_buffer",
         "parse_line_selection",
         "require_line_selection_in_view",
-        "write_buffer_to_path",
     }
     helper_imports = command_level_names | {
         "get_git_repository_root_path",

--- a/tests/commands/test_discard.py
+++ b/tests/commands/test_discard.py
@@ -627,6 +627,42 @@ class TestCommandDiscardLine:
         assert file_path.read_bytes() == b"base\n"
         assert stat.S_IMODE(file_path.stat().st_mode) == 0o600
 
+    def test_discard_line_as_replaces_symlink_with_regular_output(
+        self,
+        temp_git_repo,
+    ):
+        """Multiline replacement output must not become a symlink target."""
+        link_path = temp_git_repo / "link"
+        referent_path = temp_git_repo / "newtarget"
+        os.symlink("oldtarget", link_path)
+        subprocess.run(
+            ["git", "add", "link"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add link"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        link_path.unlink()
+        os.symlink("newtarget", link_path)
+        referent_path.write_bytes(b"referent\n")
+
+        command_start(quiet=True)
+        command_discard_line_as_to_batch(
+            "replacement-batch",
+            "1,2",
+            "first\nsecond\n",
+            quiet=True,
+        )
+
+        assert not link_path.is_symlink()
+        assert link_path.read_bytes() == b"oldtarget\nsecond\n"
+        assert referent_path.read_bytes() == b"referent\n"
+
     def test_discard_line_requires_selected_hunk(self, temp_git_repo):
         """Test that discard --line requires an active hunk."""
         with pytest.raises(CommandError):

--- a/tests/commands/test_discard.py
+++ b/tests/commands/test_discard.py
@@ -1,6 +1,7 @@
 """Tests for discard command."""
 
 import os
+import stat
 from unittest.mock import patch
 
 from git_stage_batch.utils.paths import get_abort_snapshots_directory_path
@@ -510,6 +511,121 @@ class TestCommandDiscardLine:
 
         assert os.readlink(link_path) == "oldtarget"
         assert target_path.read_bytes() == b"contents of target\n"
+
+    def test_discard_line_replaces_worktree_symlink_for_regular_index(
+        self,
+        temp_git_repo,
+    ):
+        """Restoring regular lines must replace a worktree symlink path."""
+        file_path = temp_git_repo / "f.txt"
+        referent_path = temp_git_repo / "target"
+        file_path.write_bytes(b"old\nsecond\n")
+        subprocess.run(
+            ["git", "add", "f.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add regular file"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        file_path.unlink()
+        os.symlink("target", file_path)
+        referent_path.write_bytes(b"referent\n")
+
+        command_start(quiet=True)
+        command_discard_line("1,2", file="f.txt")
+
+        assert not file_path.is_symlink()
+        assert file_path.read_bytes() == b"old\nsecond\ntarget"
+        assert referent_path.read_bytes() == b"referent\n"
+
+    def test_partial_discard_keeps_regular_worktree_kind_for_symlink_index(
+        self,
+        temp_git_repo,
+    ):
+        """A partial regular-file edit must not publish a symlink target."""
+        file_path = temp_git_repo / "f"
+        os.symlink("oldtarget", file_path)
+        subprocess.run(
+            ["git", "add", "f"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add symlink"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        file_path.unlink()
+        file_path.write_bytes(b"line1\nline2\n")
+
+        command_start(quiet=True)
+        command_discard_line("2", file="f")
+
+        assert not file_path.is_symlink()
+        assert file_path.read_bytes() == b"line2\n"
+
+    def test_complete_discard_restores_symlink_index_kind(
+        self,
+        temp_git_repo,
+    ):
+        """An exact index target should restore the symlink path kind."""
+        file_path = temp_git_repo / "f"
+        os.symlink("oldtarget", file_path)
+        subprocess.run(
+            ["git", "add", "f"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add symlink"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        file_path.unlink()
+        file_path.write_bytes(b"line1\nline2\n")
+
+        command_start(quiet=True)
+        command_discard_line("1,2,3", file="f")
+
+        assert file_path.is_symlink()
+        assert os.readlink(file_path) == "oldtarget"
+
+    def test_discard_line_preserves_exact_regular_file_permissions(
+        self,
+        temp_git_repo,
+    ):
+        """Content discard must preserve permission bits outside Git's mode."""
+        file_path = temp_git_repo / "f.txt"
+        file_path.write_bytes(b"base\n")
+        subprocess.run(
+            ["git", "add", "f.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add regular file"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        file_path.write_bytes(b"base\nadded\n")
+        file_path.chmod(0o600)
+
+        command_start(quiet=True)
+        command_discard_line("1", file="f.txt")
+
+        assert file_path.read_bytes() == b"base\n"
+        assert stat.S_IMODE(file_path.stat().st_mode) == 0o600
 
     def test_discard_line_requires_selected_hunk(self, temp_git_repo):
         """Test that discard --line requires an active hunk."""


### PR DESCRIPTION
Line discard reconstructs logical rows safely before command workflows publish the resulting bytes to the worktree.

Users can discard across regular-file and symlink type changes, while publication based only on the current path can preserve the wrong kind, turn multiline content into a link target, or overwrite permission bits outside Git's mode model.

This change introduces a content-aware publication policy, adopts it separately in direct discard, batched discard, and replacement discard, and covers type transitions, exact symlink restoration, referent isolation, and regular-file permissions.

Every line discard workflow now publishes reconstructed content with an intentional target kind. The focused 421-test command and architecture suites pass.
