### PR TITLE
utils: Reject unknown blocking child status

### DIFF
--- a/src/git_stage_batch/utils/command_streaming.py
+++ b/src/git_stage_batch/utils/command_streaming.py
@@ -58,7 +58,12 @@ class SpawnedProcess:
             return self.returncode
 
         if timeout is None:
-            _pid, status = os.waitpid(self.pid, 0)
+            try:
+                _pid, status = os.waitpid(self.pid, 0)
+            except ChildProcessError as error:
+                raise ChildProcessError(
+                    f"Cannot determine exit status for child process {self.pid}"
+                ) from error
         else:
             deadline = time.time() + timeout
             while True:

--- a/tests/utils/test_stream_process.py
+++ b/tests/utils/test_stream_process.py
@@ -513,6 +513,31 @@ class TestProcessControl:
 
         assert process.returncode is None
 
+    def test_wait_rejects_unknown_reaped_child_status(self, monkeypatch):
+        """Blocking waits should contextualize a missing child status."""
+        process = command_streaming.SpawnedProcess(1234)
+
+        def raise_child_process_error(*args):
+            raise ChildProcessError("already reaped")
+
+        monkeypatch.setattr(os, "waitpid", raise_child_process_error)
+
+        with pytest.raises(ChildProcessError, match="Cannot determine exit status"):
+            process.wait()
+
+        assert process.returncode is None
+
+    def test_wait_rejects_unsupported_child_status(self, monkeypatch):
+        """Blocking waits must not convert an unsupported status to success."""
+        process = command_streaming.SpawnedProcess(1234)
+        stopped_status = 0x7F
+        monkeypatch.setattr(os, "waitpid", lambda *args: (1234, stopped_status))
+
+        with pytest.raises(ChildProcessError, match="unsupported wait status"):
+            process.wait()
+
+        assert process.returncode is None
+
     def test_wait_closes_captured_fds(self):
         """Test wait() closes captured pipe fds when stream() is unused."""
         proc = start_command([


### PR DESCRIPTION
The streaming process wrapper reports normal exit and signal results and rejects unavailable status during nonblocking polling.

A blocking wait can still expose the raw operating-system exception after another consumer reaps the child, giving callers inconsistent diagnostics for the same unknown command outcome.

This change aligns blocking waits with polling by raising the contextual child-process error, leaving the cached return code unset, and covering missing and unsupported blocking wait statuses.

Blocking and nonblocking waits now fail consistently for unknown child outcomes. The focused 54-test streaming-process suite passes.
