### PR TITLE
ci: Bootstrap uv environments from development dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,15 +56,17 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
+        with:
+          python-version: ${{ matrix.python-version }}
 
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
 
       - name: Set up venv
-        run: uv venv --python ${{ matrix.python-version }}
+        run: uv venv
 
-      - name: Install meson
-        run: uv pip install meson-python
+      - name: Bootstrap development dependencies
+        run: uv pip install --group dev
 
       - name: Install other dependencies
         run: uv sync --all-groups

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,15 +128,17 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.10"
 
       - name: Set up Python
         run: uv python install 3.10
 
       - name: Set up venv
-        run: uv venv --python 3.10
+        run: uv venv
 
-      - name: Install meson
-        run: uv pip install meson-python
+      - name: Bootstrap development dependencies
+        run: uv pip install --group dev
 
       - name: Install other dependencies
         run: uv sync --all-groups

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,15 +88,17 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.10"
 
       - name: Set up Python
         run: uv python install 3.10
 
       - name: Set up venv
-        run: uv venv --python 3.10
+        run: uv venv
 
-      - name: Install meson
-        run: uv pip install meson-python
+      - name: Bootstrap development dependencies
+        run: uv pip install --group dev
 
       - name: Install other dependencies
         run: uv sync --all-groups


### PR DESCRIPTION
The CI test matrix, wheel build, and SHA-256 repository jobs use uv project environments with build isolation disabled.

The workflows install meson-python separately before synchronization without binding every project operation to the intended interpreter. Relying only on setup-uv also allows a runner-provided Python to satisfy the version request, while uv can otherwise recreate an environment from the repository Python default and leave the project build unable to import its backend.

This pull request addresses those bootstrap failures by selecting each job's Python through setup-uv, ensuring the matching uv-managed interpreter is installed, and installing the declared development group before synchronizing the complete project environment. The same sequence now covers every uv-based CI job.

The revised no-isolation sequence was reproduced in a clean exported checkout. The first CI run confirmed that all jobs reached the test phase and exposed the missing managed-interpreter installation on Python 3.12; the updated branch retains that installation while keeping synchronization pinned to the requested Python.