### PR TITLE
state: Enforce nested checkpoint transaction contracts

### DIFF
--- a/src/git_stage_batch/data/undo_checkpoints.py
+++ b/src/git_stage_batch/data/undo_checkpoints.py
@@ -57,6 +57,7 @@ from ..utils.paths import (
 _PENDING_CHECKPOINT: str | None = None
 _PENDING_CHECKPOINT_REPOSITORY: Path | None = None
 _PENDING_CHECKPOINT_ROLLBACK_ON_ERROR: bool | None = None
+_PENDING_CHECKPOINT_ROLLBACK_CAUSE: BaseException | None = None
 EXPLICIT_WORKTREE_SCOPE = "explicit"
 CHANGED_WORKTREE_SCOPE = "changed"
 
@@ -64,10 +65,11 @@ CHANGED_WORKTREE_SCOPE = "changed"
 def _clear_pending_checkpoint() -> None:
     """Forget process-local state for the pending checkpoint."""
     global _PENDING_CHECKPOINT, _PENDING_CHECKPOINT_REPOSITORY
-    global _PENDING_CHECKPOINT_ROLLBACK_ON_ERROR
+    global _PENDING_CHECKPOINT_ROLLBACK_ON_ERROR, _PENDING_CHECKPOINT_ROLLBACK_CAUSE
     _PENDING_CHECKPOINT = None
     _PENDING_CHECKPOINT_REPOSITORY = None
     _PENDING_CHECKPOINT_ROLLBACK_ON_ERROR = None
+    _PENDING_CHECKPOINT_ROLLBACK_CAUSE = None
 
 
 def _validate_nested_checkpoint(
@@ -345,6 +347,8 @@ def undo_checkpoint(
     a transaction boundary for commands that span several files or stores.
     """
     global _PENDING_CHECKPOINT_ROLLBACK_ON_ERROR
+    global _PENDING_CHECKPOINT_ROLLBACK_CAUSE
+
     if _PENDING_CHECKPOINT is not None:
         current_repository = get_git_directory_path()
         if (
@@ -360,7 +364,12 @@ def undo_checkpoint(
                 repository_paths=repository_paths,
                 rollback_on_error=rollback_on_error,
             )
-            yield
+            try:
+                yield
+            except BaseException as nested_error:
+                if rollback_on_error:
+                    _PENDING_CHECKPOINT_ROLLBACK_CAUSE = nested_error
+                raise
             return
         else:
             _clear_pending_checkpoint()
@@ -406,6 +415,31 @@ def undo_checkpoint(
         raise
     else:
         if checkpoint is not None:
+            nested_error = _PENDING_CHECKPOINT_ROLLBACK_CAUSE
+            if nested_error is not None:
+                try:
+                    _rollback_failed_checkpoint(
+                        checkpoint,
+                        previous_redo=previous_redo,
+                    )
+                except Exception as rollback_error:
+                    raise CommandError(
+                        _(
+                            "Operation failed and its automatic rollback also failed. "
+                            "The before-image remains available through `undo --force`.\n"
+                            "Operation error: {operation_error}\n"
+                            "Rollback error: {rollback_error}"
+                        ).format(
+                            operation_error=nested_error,
+                            rollback_error=rollback_error,
+                        )
+                    ) from nested_error
+                raise CommandError(
+                    _(
+                        "A nested transactional operation failed, so the "
+                        "enclosing operation was rolled back: {error}"
+                    ).format(error=nested_error)
+                ) from nested_error
             finalize_pending_checkpoint()
 
 

--- a/src/git_stage_batch/data/undo_checkpoints.py
+++ b/src/git_stage_batch/data/undo_checkpoints.py
@@ -56,6 +56,7 @@ from ..utils.paths import (
 
 _PENDING_CHECKPOINT: str | None = None
 _PENDING_CHECKPOINT_REPOSITORY: Path | None = None
+_PENDING_CHECKPOINT_ROLLBACK_ON_ERROR: bool | None = None
 EXPLICIT_WORKTREE_SCOPE = "explicit"
 CHANGED_WORKTREE_SCOPE = "changed"
 
@@ -63,8 +64,10 @@ CHANGED_WORKTREE_SCOPE = "changed"
 def _clear_pending_checkpoint() -> None:
     """Forget process-local state for the pending checkpoint."""
     global _PENDING_CHECKPOINT, _PENDING_CHECKPOINT_REPOSITORY
+    global _PENDING_CHECKPOINT_ROLLBACK_ON_ERROR
     _PENDING_CHECKPOINT = None
     _PENDING_CHECKPOINT_REPOSITORY = None
+    _PENDING_CHECKPOINT_ROLLBACK_ON_ERROR = None
 
 
 def _validate_nested_checkpoint(
@@ -112,6 +115,14 @@ def _validate_nested_checkpoint(
                     paths=", ".join(missing_paths),
                 )
             )
+
+    if rollback_on_error and not _PENDING_CHECKPOINT_ROLLBACK_ON_ERROR:
+        raise CommandError(
+            _(
+                "Cannot start nested transactional operation because the outer "
+                "checkpoint does not roll back on error."
+            )
+        )
 
 
 def _checkpoint_worktree_scope(
@@ -333,6 +344,7 @@ def undo_checkpoint(
     checkpoint before propagating an exception. This turns the checkpoint into
     a transaction boundary for commands that span several files or stores.
     """
+    global _PENDING_CHECKPOINT_ROLLBACK_ON_ERROR
     if _PENDING_CHECKPOINT is not None:
         current_repository = get_git_directory_path()
         if (
@@ -366,6 +378,8 @@ def undo_checkpoint(
         index_paths=index_paths,
         repository_paths=repository_paths,
     )
+    if checkpoint is not None:
+        _PENDING_CHECKPOINT_ROLLBACK_ON_ERROR = rollback_on_error
     try:
         yield
     except BaseException as operation_error:

--- a/src/git_stage_batch/data/undo_checkpoints.py
+++ b/src/git_stage_batch/data/undo_checkpoints.py
@@ -67,6 +67,53 @@ def _clear_pending_checkpoint() -> None:
     _PENDING_CHECKPOINT_REPOSITORY = None
 
 
+def _validate_nested_checkpoint(
+    checkpoint: str,
+    *,
+    worktree_paths: list[str],
+    index_paths: list[str] | None,
+    repository_paths: list[str] | None,
+    rollback_on_error: bool,
+) -> None:
+    """Require a nested operation to fit inside the active transaction."""
+    manifest = _undo_restore.read_json_from_commit(checkpoint, "manifest.json")
+    requested_index_paths = worktree_paths if index_paths is None else index_paths
+    scope_pairs = (
+        (
+            _("worktree"),
+            set(worktree_paths),
+            set(manifest.get("tracked_worktree_paths", [])),
+        ),
+        (
+            _("index"),
+            set(requested_index_paths),
+            set(
+                manifest.get(
+                    "tracked_index_paths",
+                    manifest.get("tracked_worktree_paths", []),
+                )
+            ),
+        ),
+        (
+            _("repository"),
+            set(repository_paths or []),
+            set(manifest.get("tracked_repository_paths", [])),
+        ),
+    )
+    for scope_name, requested_paths, tracked_paths in scope_pairs:
+        missing_paths = sorted(requested_paths - tracked_paths)
+        if missing_paths:
+            raise CommandError(
+                _(
+                    "Cannot start nested undoable operation because the outer "
+                    "checkpoint does not cover {scope} path(s): {paths}"
+                ).format(
+                    scope=scope_name,
+                    paths=", ".join(missing_paths),
+                )
+            )
+
+
 def _checkpoint_worktree_scope(
     worktree_paths: list[str],
 ) -> tuple[str, list[str]]:
@@ -294,6 +341,13 @@ def undo_checkpoint(
         ):
             _clear_pending_checkpoint()
         elif current_undo_commit() == _PENDING_CHECKPOINT:
+            _validate_nested_checkpoint(
+                _PENDING_CHECKPOINT,
+                worktree_paths=worktree_paths,
+                index_paths=index_paths,
+                repository_paths=repository_paths,
+                rollback_on_error=rollback_on_error,
+            )
             yield
             return
         else:

--- a/tests/commands/test_undo.py
+++ b/tests/commands/test_undo.py
@@ -413,6 +413,34 @@ def test_nested_transaction_uses_compatible_outer_checkpoint(temp_git_repo):
     assert target.read_text() == "before\n"
 
 
+def test_caught_nested_transaction_error_rolls_back_outer_checkpoint(temp_git_repo):
+    """Catching an inner failure must not let its transaction commit."""
+    target = _commit_text_file(temp_git_repo, "target.txt", "before\n")
+    get_session_directory_path().mkdir(parents=True, exist_ok=True)
+    previous_checkpoint = current_undo_commit()
+
+    with pytest.raises(CommandError, match="enclosing operation was rolled back"):
+        with undo_checkpoint(
+            "outer",
+            worktree_paths=["target.txt"],
+            rollback_on_error=True,
+        ):
+            target.write_text("outer mutation\n")
+            try:
+                with undo_checkpoint(
+                    "inner",
+                    worktree_paths=["target.txt"],
+                    rollback_on_error=True,
+                ):
+                    target.write_text("inner mutation\n")
+                    raise RuntimeError("inner failed")
+            except RuntimeError:
+                target.write_text("continued after inner failure\n")
+
+    assert target.read_text() == "before\n"
+    assert current_undo_commit() == previous_checkpoint
+
+
 def test_failed_checkpoint_finalization_requires_force(temp_git_repo, monkeypatch):
     """A manifest persistence failure should leave a guarded before-image."""
     from git_stage_batch.data import undo_checkpoints as checkpoints

--- a/tests/commands/test_undo.py
+++ b/tests/commands/test_undo.py
@@ -339,6 +339,44 @@ def test_atomic_failed_operation_rolls_back_before_propagating(temp_git_repo):
     assert current_undo_commit() == previous_checkpoint
 
 
+@pytest.mark.parametrize(
+    ("outer_scope", "inner_scope", "scope_name"),
+    [
+        (
+            {"worktree_paths": ["outer.txt"]},
+            {"worktree_paths": ["inner.txt"]},
+            "worktree",
+        ),
+        (
+            {"worktree_paths": [], "index_paths": ["outer.txt"]},
+            {"worktree_paths": [], "index_paths": ["inner.txt"]},
+            "index",
+        ),
+        (
+            {"worktree_paths": [], "repository_paths": ["outer"]},
+            {"worktree_paths": [], "repository_paths": ["inner"]},
+            "repository",
+        ),
+    ],
+)
+def test_nested_checkpoint_rejects_paths_outside_outer_scope(
+    temp_git_repo,
+    outer_scope,
+    inner_scope,
+    scope_name,
+):
+    """Nested operations must not mutate paths absent from the before-image."""
+    get_session_directory_path().mkdir(parents=True, exist_ok=True)
+
+    with undo_checkpoint("outer", **outer_scope):
+        with pytest.raises(
+            CommandError,
+            match=rf"does not cover {scope_name} path.*inner",
+        ):
+            with undo_checkpoint("inner", **inner_scope):
+                raise AssertionError("nested operation should not run")
+
+
 def test_failed_checkpoint_finalization_requires_force(temp_git_repo, monkeypatch):
     """A manifest persistence failure should leave a guarded before-image."""
     from git_stage_batch.data import undo_checkpoints as checkpoints

--- a/tests/commands/test_undo.py
+++ b/tests/commands/test_undo.py
@@ -377,6 +377,42 @@ def test_nested_checkpoint_rejects_paths_outside_outer_scope(
                 raise AssertionError("nested operation should not run")
 
 
+def test_nested_transaction_requires_transactional_outer_checkpoint(temp_git_repo):
+    """A nested rollback promise must not disappear inside a weaker checkpoint."""
+    get_session_directory_path().mkdir(parents=True, exist_ok=True)
+
+    with undo_checkpoint("outer", worktree_paths=["target.txt"]):
+        with pytest.raises(CommandError, match="does not roll back on error"):
+            with undo_checkpoint(
+                "inner",
+                worktree_paths=["target.txt"],
+                rollback_on_error=True,
+            ):
+                raise AssertionError("nested operation should not run")
+
+
+def test_nested_transaction_uses_compatible_outer_checkpoint(temp_git_repo):
+    """A covered nested transaction should share the outer checkpoint."""
+    target = _commit_text_file(temp_git_repo, "target.txt", "before\n")
+    get_session_directory_path().mkdir(parents=True, exist_ok=True)
+
+    with undo_checkpoint(
+        "outer",
+        worktree_paths=["target.txt"],
+        rollback_on_error=True,
+    ):
+        with undo_checkpoint(
+            "inner",
+            worktree_paths=["target.txt"],
+            rollback_on_error=True,
+        ):
+            target.write_text("after\n")
+
+    undo_last_checkpoint()
+
+    assert target.read_text() == "before\n"
+
+
 def test_failed_checkpoint_finalization_requires_force(temp_git_repo, monkeypatch):
     """A manifest persistence failure should leave a guarded before-image."""
     from git_stage_batch.data import undo_checkpoints as checkpoints


### PR DESCRIPTION
Undo checkpoints provide before-images for worktree, index, and repository state, and nested operations reuse an active outer checkpoint.

Nested operations do not verify that the outer snapshot covers their paths or rollback requirements. A caught inner failure can therefore allow the enclosing operation to commit partial state despite the nested transaction promise.

This pull request addresses those gaps by validating every nested scope against the outer manifest, requiring a transactional outer checkpoint when the inner operation requests rollback, and marking the shared checkpoint for rollback when an inner failure is suppressed.

Focused coverage exercises all recorded scope types, compatible and incompatible rollback policies, and a caught inner failure that must restore the complete outer before-image. Nested operations now preserve the snapshot and rollback guarantees they request.
