### PR TITLE
discard: Preserve rename partners in multi-file undo

### DIFF
--- a/src/git_stage_batch/cli/discard_dispatch.py
+++ b/src/git_stage_batch/cli/discard_dispatch.py
@@ -15,6 +15,7 @@ from ..commands.discard import (
 )
 from ..commands.discard_from import command_discard_from_batch
 from ..commands.file_scope.multi_file_actions import (
+    discard_each_resolved_file,
     discard_to_batch_each_resolved_file,
     run_for_each_resolved_file,
 )
@@ -134,14 +135,15 @@ def dispatch_discard_command(args: argparse.Namespace) -> None:
     else:
         resolved_live_scope = resolve_live_file_scope(args.file, args.file_patterns)
         if not resolved_live_scope.is_implicit:
-            run_for_each_resolved_file(
-                resolved_live_scope,
-                lambda file: command_discard_file(
-                    file,
+            if resolved_live_scope.is_multiple:
+                discard_each_resolved_file(
+                    list(resolved_live_scope.files),
                     auto_advance=args.auto_advance,
-                ),
-                undo_operation="discard",
-                worktree_paths=resolved_live_scope.files,
-            )
+                )
+            else:
+                command_discard_file(
+                    resolved_live_scope.optional_file(),
+                    auto_advance=args.auto_advance,
+                )
         else:
             command_discard(auto_advance=args.auto_advance)

--- a/src/git_stage_batch/commands/file_scope/multi_file_actions.py
+++ b/src/git_stage_batch/commands/file_scope/multi_file_actions.py
@@ -15,6 +15,7 @@ from ...exceptions import CommandError
 from ...i18n import _, ngettext
 from ...utils.git_repository import require_git_repository
 from ...utils.paths import ensure_state_directory_exists
+from . import discard_file as _discard_file
 from .discard_to_batch import discard_files_to_batch
 from . import include_file as _include_file
 from .target_path import checkpoint_paths_for_live_files
@@ -85,6 +86,26 @@ def run_for_each_resolved_file(
     callback(file_scope.optional_file())
 
 
+def discard_each_resolved_file(
+    files: Sequence[str],
+    *,
+    auto_advance: bool | None = None,
+) -> None:
+    """Discard a multi-file live scope under one rename-complete checkpoint."""
+    _prepare_live_multi_file_action()
+    checkpoint_paths = checkpoint_paths_for_live_files(list(files))
+    with _multi_file_undo_checkpoint(
+        "discard",
+        files,
+        worktree_paths=checkpoint_paths,
+    ):
+        for file_path in files:
+            _discard_file.discard_file_changes(
+                file_path,
+                auto_advance=auto_advance,
+            )
+
+
 def _format_file_summary(files: Sequence[str]) -> str:
     """Return a single path or plural file count for command output."""
     if len(files) == 1:
@@ -97,7 +118,7 @@ def _format_file_summary(files: Sequence[str]) -> str:
 
 
 def _prepare_live_multi_file_action() -> None:
-    """Run command setup shared by live multi-file include and skip actions."""
+    """Run command setup shared by live multi-file actions."""
     require_git_repository()
     require_session_started()
     ensure_state_directory_exists()

--- a/src/git_stage_batch/commands/file_scope/multi_file_actions.py
+++ b/src/git_stage_batch/commands/file_scope/multi_file_actions.py
@@ -217,7 +217,12 @@ def discard_to_batch_each_resolved_file(
 ) -> None:
     """Save a multi-file live scope to a batch and report one aggregate summary."""
     operation = f"discard --to {shlex.quote(batch_name)}"
-    with _multi_file_undo_checkpoint(operation, files, worktree_paths=files):
+    checkpoint_paths = checkpoint_paths_for_live_files(list(files))
+    with _multi_file_undo_checkpoint(
+        operation,
+        files,
+        worktree_paths=checkpoint_paths,
+    ):
         result = discard_files_to_batch(
             batch_name,
             list(files),

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -4949,7 +4949,9 @@ def test_argument_parser_delegates_multi_file_action_flow():
     assert "git_stage_batch.data.undo_checkpoints" in helper_imports
     assert "git_stage_batch.commands.include" not in helper_imports
     assert "git_stage_batch.commands.skip" not in helper_imports
-    assert {"include_file", "skip_file"} <= helper_file_scope_imported_names
+    assert {"discard_file", "include_file", "skip_file"} <= (
+        helper_file_scope_imported_names
+    )
     assert not hasattr(
         __import__(
             "git_stage_batch.cli.argument_parser",

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -5331,6 +5331,7 @@ def test_argument_parser_delegates_discard_dispatch():
         "command_discard_line",
         "command_discard_line_as_to_batch",
         "command_discard_to_batch",
+        "discard_each_resolved_file",
         "discard_to_batch_each_resolved_file",
     }
 
@@ -5346,6 +5347,7 @@ def test_argument_parser_delegates_discard_dispatch():
     assert "_dispatch_discard_replacement" in vars(discard_dispatch)
     assert discard_command_names.isdisjoint(vars(parser))
     assert "def dispatch_discard(" not in parser_text
+    assert "discard_each_resolved_file(" not in parser_text
     assert "discard_to_batch_each_resolved_file(" not in parser_text
     assert "command_discard_from_batch(" not in parser_text
     assert "command_discard_to_batch(" not in parser_text

--- a/tests/cli/test_argument_parser.py
+++ b/tests/cli/test_argument_parser.py
@@ -1034,36 +1034,46 @@ def test_parse_command_line_skip_combines_file_and_files_patterns(monkeypatch):
     )
 
 
-def test_parse_command_line_discard_with_files_dispatches_per_file(monkeypatch):
-    """Discard should dispatch once per file resolved from --files."""
+def test_parse_command_line_discard_with_files_dispatches_resolved_scope(monkeypatch):
+    """Discard should delegate the resolved --files scope to its command helper."""
     mock_command = Mock()
-    monkeypatch.setattr(discard_dispatch, "command_discard_file", mock_command)
+    monkeypatch.setattr(
+        discard_dispatch,
+        "discard_each_resolved_file",
+        mock_command,
+    )
     _mock_live_file_candidates(monkeypatch, ["foo.py", "bar.py", "notes.txt"])
 
     args = parse_command_line(["discard", "--files", "*.py"], quiet=True)
 
     assert args is not None
     args.func(args)
-    assert mock_command.call_args_list == [
-        call("foo.py", auto_advance=None),
-        call("bar.py", auto_advance=None),
-    ]
+    mock_command.assert_called_once_with(
+        ["foo.py", "bar.py"],
+        auto_advance=None,
+    )
 
 
-def test_parse_command_line_discard_with_file_pattern_dispatches_per_file(monkeypatch):
-    """Discard --file with a pattern should dispatch like --files."""
+def test_parse_command_line_discard_with_file_pattern_dispatches_resolved_scope(
+    monkeypatch,
+):
+    """Discard --file patterns should delegate like --files patterns."""
     mock_command = Mock()
-    monkeypatch.setattr(discard_dispatch, "command_discard_file", mock_command)
+    monkeypatch.setattr(
+        discard_dispatch,
+        "discard_each_resolved_file",
+        mock_command,
+    )
     _mock_live_file_candidates(monkeypatch, ["foo.py", "bar.py", "notes.txt"])
 
     args = parse_command_line(["discard", "--file", "*.py"], quiet=True)
 
     assert args is not None
     args.func(args)
-    assert mock_command.call_args_list == [
-        call("foo.py", auto_advance=None),
-        call("bar.py", auto_advance=None),
-    ]
+    mock_command.assert_called_once_with(
+        ["foo.py", "bar.py"],
+        auto_advance=None,
+    )
 
 
 def test_parse_command_line_discard_from_with_files_resolves_batch_scope_only(monkeypatch):

--- a/tests/commands/test_file_scope_actions.py
+++ b/tests/commands/test_file_scope_actions.py
@@ -69,6 +69,53 @@ def test_run_for_each_resolved_file_wraps_multiple_files(monkeypatch):
     assert callback_calls == ["alpha.txt", "beta.txt"]
 
 
+def test_discard_each_resolved_file_expands_live_checkpoint_paths(monkeypatch):
+    checkpoint_calls = _capture_undo_checkpoints(monkeypatch)
+    discard_calls = []
+    expansion_calls = []
+
+    def expand_paths(paths):
+        expansion_calls.append(paths)
+        return [*paths, "rename-source.txt"]
+
+    monkeypatch.setattr(
+        multi_file_actions,
+        "checkpoint_paths_for_live_files",
+        expand_paths,
+    )
+    monkeypatch.setattr(
+        multi_file_actions,
+        "_prepare_live_multi_file_action",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        multi_file_actions._discard_file,
+        "discard_file_changes",
+        lambda file_path, *, auto_advance=None: discard_calls.append(
+            (file_path, auto_advance)
+        ),
+    )
+
+    multi_file_actions.discard_each_resolved_file(
+        ["rename-target.txt", "other.txt"],
+        auto_advance=False,
+    )
+
+    assert expansion_calls == [["rename-target.txt", "other.txt"]]
+    assert checkpoint_calls == [
+        (
+            "enter",
+            "discard --files rename-target.txt other.txt",
+            ["rename-target.txt", "other.txt", "rename-source.txt"],
+        ),
+        ("exit",),
+    ]
+    assert discard_calls == [
+        ("rename-target.txt", False),
+        ("other.txt", False),
+    ]
+
+
 def test_run_for_each_resolved_file_dispatches_optional_file(monkeypatch):
     checkpoint_calls = _capture_undo_checkpoints(monkeypatch)
     callback_calls = []

--- a/tests/commands/test_file_scope_actions.py
+++ b/tests/commands/test_file_scope_actions.py
@@ -281,6 +281,11 @@ def test_discard_to_batch_each_resolved_file_reports_batch_result(
     )
     monkeypatch.setattr(
         multi_file_actions,
+        "checkpoint_paths_for_live_files",
+        lambda files: [*files, "rename-source.txt"],
+    )
+    monkeypatch.setattr(
+        multi_file_actions,
         "select_next_change_after_action",
         lambda *, auto_advance=None: selection_calls.append(auto_advance) or False,
     )
@@ -301,7 +306,7 @@ def test_discard_to_batch_each_resolved_file_reports_batch_result(
         (
             "enter",
             "discard --to scratch --files alpha.txt beta.txt",
-            ["alpha.txt", "beta.txt"],
+            ["alpha.txt", "beta.txt", "rename-source.txt"],
         ),
         ("exit",),
     ]

--- a/tests/functional/test_undo.py
+++ b/tests/functional/test_undo.py
@@ -227,6 +227,35 @@ def test_undo_discard_files_restores_unmatched_rename_destination(functional_rep
     assert other_path.read_text() == "other\nchanged\n"
 
 
+def test_undo_discard_to_batch_files_restores_unmatched_rename_destination(
+    functional_repo,
+):
+    """Discard-to-batch must also checkpoint both sides of a live rename."""
+    old_path = functional_repo / "old.txt"
+    other_path = functional_repo / "other.txt"
+    _commit_file(old_path, "renamed content\n")
+    _commit_file(other_path, "other\n")
+    new_path = functional_repo / "new.txt"
+    old_path.rename(new_path)
+    other_path.write_text("other\nchanged\n")
+
+    git_stage_batch("start")
+    git_stage_batch(
+        "discard",
+        "--to",
+        "saved",
+        "--files",
+        "new.txt",
+        "other.txt",
+    )
+    git_stage_batch("undo")
+
+    assert _git("diff", "--cached", "--name-status").stdout == ""
+    assert not old_path.exists()
+    assert new_path.read_text() == "renamed content\n"
+    assert other_path.read_text() == "other\nchanged\n"
+
+
 def test_undo_discard_to_batch_files_restores_entire_multi_file_operation(functional_repo):
     """Undoing discard --to --files should restore every discarded file."""
     alpha, beta = _create_two_changed_text_files(functional_repo)

--- a/tests/functional/test_undo.py
+++ b/tests/functional/test_undo.py
@@ -207,6 +207,26 @@ def test_undo_discard_files_restores_entire_multi_file_operation(functional_repo
     assert beta.read_text() == "beta\nbeta change\n"
 
 
+def test_undo_discard_files_restores_unmatched_rename_destination(functional_repo):
+    """The multi-file checkpoint must include both sides of a discarded rename."""
+    old_path = functional_repo / "old.txt"
+    other_path = functional_repo / "other.txt"
+    _commit_file(old_path, "renamed content\n")
+    _commit_file(other_path, "other\n")
+    new_path = functional_repo / "new.txt"
+    old_path.rename(new_path)
+    other_path.write_text("other\nchanged\n")
+
+    git_stage_batch("start")
+    git_stage_batch("discard", "--files", "new.txt", "other.txt")
+    git_stage_batch("undo")
+
+    assert _git("diff", "--cached", "--name-status").stdout == ""
+    assert not old_path.exists()
+    assert new_path.read_text() == "renamed content\n"
+    assert other_path.read_text() == "other\nchanged\n"
+
+
 def test_undo_discard_to_batch_files_restores_entire_multi_file_operation(functional_repo):
     """Undoing discard --to --files should restore every discarded file."""
     alpha, beta = _create_two_changed_text_files(functional_repo)


### PR DESCRIPTION
Multi-file file-scope actions use one outer undo checkpoint so a resolved operation can be restored as a unit.

Plain and batch-backed discard build that checkpoint from matched paths alone. Per-file nested checkpoints then reuse the incomplete outer snapshot, so undo can restore only one side of a rename and leave a ghost source or destination.

This pull request addresses that by adding a rename-aware plain-discard command helper, routing aggregate command-line scopes through it, and expanding checkpoint paths for discard-to-batch before any mutation begins.

Command, parser, architecture, and functional tests cover helper delegation and both user-visible workflows with an unmatched rename partner. Multi-file discard now restores complete rename state with or without a destination batch.
