### PR TITLE
discard: Fail closed when index cleanup fails

### DIFF
--- a/src/git_stage_batch/commands/file_scope/discard_file_to_batch.py
+++ b/src/git_stage_batch/commands/file_scope/discard_file_to_batch.py
@@ -35,7 +35,6 @@ from ...utils.file_io import read_text_file_line_set
 from ...utils.git_worktree import (
     git_apply_to_worktree,
     git_checkout_index_paths,
-    git_remove_paths,
 )
 from ...utils.git_repository import get_git_repository_root_path
 from ...utils.journal import log_journal
@@ -43,6 +42,7 @@ from ...utils.paths import get_block_list_file_path, get_context_lines
 from ...utils.session_start_point import session_comparison_base
 from ..selection.action_completion import finish_selected_change_action
 from ..selection import whole_file_batch_discarding as _whole_file_batch_discarding
+from ..index_cleanup import remove_path_from_index
 
 
 def discard_file_to_batch(
@@ -157,7 +157,7 @@ def discard_file_to_batch(
 
                 if lifecycle_change_type == TextFileChangeType.ADDED:
                     full_path.unlink()
-                    git_remove_paths([file_path], cached=True, quiet=True, check=False)
+                    remove_path_from_index(file_path)
                 else:
                     result = git_checkout_index_paths([file_path], check=False)
                     if result.returncode != 0:
@@ -246,7 +246,7 @@ def discard_file_to_batch(
         repo_root = get_git_repository_root_path()
         full_path = repo_root / file_path
         if not os.path.lexists(full_path):
-            git_remove_paths([file_path], cached=True, quiet=True, check=False)
+            remove_path_from_index(file_path)
 
         if not quiet:
             print(

--- a/src/git_stage_batch/commands/file_scope/discard_to_batch.py
+++ b/src/git_stage_batch/commands/file_scope/discard_to_batch.py
@@ -27,7 +27,6 @@ from ...i18n import _
 from ...utils.file_io import read_text_file_line_set
 from ...utils.git_worktree import (
     git_apply_to_worktree,
-    git_remove_paths,
 )
 from ...utils.git_repository import (
     get_git_repository_root_path,
@@ -41,6 +40,7 @@ from ...utils.paths import (
 )
 from ...utils.session_start_point import session_comparison_base
 from ..selection.action_completion import finish_selected_change_action
+from ..index_cleanup import remove_path_from_index
 from .discard_file_to_batch import discard_file_to_batch
 
 
@@ -336,7 +336,7 @@ def _discard_prepared_text_files_to_batch(
     for prepared in prepared_discards:
         full_path = repo_root / prepared.file_path
         if not os.path.lexists(full_path):
-            git_remove_paths([prepared.file_path], cached=True, quiet=True, check=False)
+            remove_path_from_index(prepared.file_path)
 
     hunk_hashes = [
         patch.patch_hash

--- a/src/git_stage_batch/commands/index_cleanup.py
+++ b/src/git_stage_batch/commands/index_cleanup.py
@@ -1,0 +1,23 @@
+"""Checked index cleanup shared by destructive command paths."""
+
+from __future__ import annotations
+
+from ..exceptions import exit_with_error
+from ..i18n import _
+from ..utils.git_index import git_update_index
+
+
+def remove_path_from_index(file_path: str) -> None:
+    """Force-remove one path from the index or fail the enclosing action."""
+    result = git_update_index(
+        file_path=file_path,
+        force_remove=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        exit_with_error(
+            _("Failed to remove {file} from the index: {error}").format(
+                file=file_path,
+                error=result.stderr,
+            )
+        )

--- a/src/git_stage_batch/commands/selection/selected_change_batch_discarding.py
+++ b/src/git_stage_batch/commands/selection/selected_change_batch_discarding.py
@@ -42,7 +42,6 @@ from ...utils.file_io import (
 )
 from ...utils.git_worktree import (
     git_apply_to_worktree,
-    git_remove_paths,
 )
 from ...utils.git_repository import get_git_repository_root_path
 from ...utils.journal import log_journal
@@ -54,6 +53,7 @@ from ...utils.paths import (
 )
 from .action_completion import finish_selected_change_action
 from . import whole_file_batch_discarding as _whole_file_batch_discarding
+from ..index_cleanup import remove_path_from_index
 
 
 def discard_selected_change_to_batch(
@@ -275,11 +275,11 @@ def _discard_text_hunk_to_batch(
             absolute_path = get_git_repository_root_path() / file_path
 
             if not os.path.lexists(absolute_path):
-                git_remove_paths([file_path], cached=True, quiet=True, check=False)
+                remove_path_from_index(file_path)
             elif is_new_file:
                 if path_is_empty(absolute_path):
                     absolute_path.unlink()
-                    git_remove_paths([file_path], cached=True, quiet=True, check=False)
+                    remove_path_from_index(file_path)
 
         log_journal(
             "discard_hunk_to_batch_success",

--- a/src/git_stage_batch/commands/selection/whole_file_batch_discarding.py
+++ b/src/git_stage_batch/commands/selection/whole_file_batch_discarding.py
@@ -21,12 +21,12 @@ from ...i18n import _
 from ...utils.file_io import append_lines_to_file
 from ...utils.git_worktree import (
     git_checkout_index_paths,
-    git_remove_paths,
 )
 from ...utils.git_repository import get_git_repository_root_path
 from ...utils.paths import get_block_list_file_path
 from .action_completion import finish_selected_change_action
 from .selected_change_discarding import discard_text_deletion_change
+from ..index_cleanup import remove_path_from_index
 
 
 def _discard_binary_change_from_working_tree(binary_change: BinaryFileChange) -> None:
@@ -37,7 +37,7 @@ def _discard_binary_change_from_working_tree(binary_change: BinaryFileChange) ->
     if binary_change.is_new_file():
         if os.path.lexists(absolute_path):
             absolute_path.unlink()
-        git_remove_paths([file_path], cached=True, quiet=True, check=False)
+        remove_path_from_index(file_path)
         return
 
     result = git_checkout_index_paths([file_path], check=False)

--- a/tests/commands/test_discard.py
+++ b/tests/commands/test_discard.py
@@ -29,6 +29,7 @@ import git_stage_batch.commands.selection.selected_change_discarding as selected
 import git_stage_batch.commands.selection.selected_change_batch_discarding as selected_change_batch_discarding
 import git_stage_batch.commands.selection.discard_line_action as discard_line_action
 import git_stage_batch.commands.selection.selected_file_discarding as selected_file_discarding
+import git_stage_batch.commands.index_cleanup as index_cleanup
 from git_stage_batch.commands.discard import command_discard, command_discard_line, command_discard_line_as_to_batch
 from git_stage_batch.commands.include import command_include, command_include_line
 from git_stage_batch.commands.show import command_show
@@ -246,6 +247,40 @@ class TestCommandDiscard:
 
         assert test_file.read_text() == "base\nselected\n"
         assert not batch_exists("failed-batch")
+
+    def test_failed_index_cleanup_rolls_back_new_file_discard_to_batch(
+        self,
+        temp_git_repo,
+        monkeypatch,
+    ):
+        """An index-removal failure must restore the file and batch state."""
+        new_file = temp_git_repo / "new.txt"
+        new_file.write_text("new content\n")
+        command_start(quiet=True)
+
+        monkeypatch.setattr(
+            index_cleanup,
+            "git_update_index",
+            lambda **_kwargs: subprocess.CompletedProcess(
+                ["git", "update-index"],
+                1,
+                "",
+                "index cleanup failed",
+            ),
+        )
+
+        with pytest.raises(CommandError, match="index cleanup failed"):
+            command_discard_to_batch("failed-batch", quiet=True)
+
+        assert new_file.read_text() == "new content\n"
+        assert not batch_exists("failed-batch")
+        assert subprocess.run(
+            ["git", "ls-files", "--stage", "--", "new.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+            text=True,
+        ).stdout
 
     def test_discard_only_line_from_intent_to_add_file_leaves_empty_file(
         self,


### PR DESCRIPTION
Discard-to-batch workflows can remove new worktree paths after publishing saved content and ownership metadata.

Several text, file-scoped, aggregate, and binary paths ignore failures while clearing the corresponding cached or intent-to-add index entry. Users can lose the worktree node, retain stale index state, and miss automatic rollback because no error reaches the transaction boundary.

This pull request addresses that by adding a translated, checked force-removal helper and adopting it independently in selected text, explicit file, aggregate text, and whole-file binary discard-to-batch workflows.

A focused failure test confirms that late cleanup errors restore the file, index entry, and batch state. Every discard-to-batch path that removes a new worktree file now fails closed so transactional rollback can run.
