### PR TITLE
state: Refuse symlink traversal during mode restore

### DIFF
--- a/src/git_stage_batch/data/file_modes.py
+++ b/src/git_stage_batch/data/file_modes.py
@@ -6,8 +6,11 @@ import os
 from pathlib import Path
 import stat
 
+from ..exceptions import CommandError
+from ..i18n import _
 from ..utils.git_command import run_git_command
 from ..utils.git_repository import get_git_repository_root_path
+from ..utils.repository_path import open_repository_path
 
 
 def detect_file_mode(file_path: str) -> str:
@@ -54,8 +57,34 @@ def apply_git_file_mode(path: Path, file_mode: str | None) -> None:
     """Apply Git executable-bit semantics to an existing worktree path."""
     if file_mode is None or file_mode == "120000":
         return
-    current_mode = path.stat().st_mode
-    if file_mode == "100755":
-        path.chmod(current_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
-    else:
-        path.chmod(current_mode & ~(stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH))
+
+    try:
+        with open_repository_path(
+            path,
+            access_modes=(os.O_RDONLY, os.O_WRONLY),
+        ) as file_descriptor:
+            current_mode = os.fstat(file_descriptor).st_mode
+            if not stat.S_ISREG(current_mode):
+                raise CommandError(
+                    _("Cannot apply Git file mode to non-regular path {path}").format(
+                        path=path
+                    )
+                )
+            if file_mode == "100755":
+                replacement_mode = (
+                    current_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+                )
+            else:
+                replacement_mode = current_mode & ~(
+                    stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+                )
+            os.fchmod(file_descriptor, replacement_mode)
+    except CommandError:
+        raise
+    except OSError as error:
+        raise CommandError(
+            _("Cannot safely apply Git file mode to {path}: {error}").format(
+                path=path,
+                error=error,
+            )
+        ) from error

--- a/src/git_stage_batch/utils/repository_path.py
+++ b/src/git_stage_batch/utils/repository_path.py
@@ -1,13 +1,21 @@
-"""Lexical normalization of user-supplied repository paths."""
+"""Repository path normalization and safe descriptor access."""
 
 from __future__ import annotations
 
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager, ExitStack
+import errno
 import os
 from dataclasses import dataclass
+from pathlib import Path
+import stat
 
 from ..exceptions import CommandError
 from ..i18n import _
 from .git_repository import get_git_repository_root_path
+
+
+_OPEN_SUPPORTS_DIRECTORY_DESCRIPTORS = os.open in os.supports_dir_fd
 
 
 @dataclass(frozen=True)
@@ -43,3 +51,98 @@ def normalize_repository_path(value: str) -> RepositoryPath:
     if is_directory:
         normalized = normalized.rstrip("/") + "/"
     return RepositoryPath(normalized, is_directory)
+
+
+@contextmanager
+def open_repository_path(
+    path: str | Path,
+    *,
+    access_modes: Sequence[int],
+) -> Iterator[int]:
+    """Open an in-worktree path without following any relative symlink component."""
+    valid_access_modes = {os.O_RDONLY, os.O_WRONLY, os.O_RDWR}
+    if not access_modes or any(mode not in valid_access_modes for mode in access_modes):
+        raise ValueError
+
+    no_follow = getattr(os, "O_NOFOLLOW", None)
+    directory_only = getattr(os, "O_DIRECTORY", None)
+    if (
+        no_follow is None
+        or directory_only is None
+        or not _OPEN_SUPPORTS_DIRECTORY_DESCRIPTORS
+    ):
+        raise OSError(
+            errno.ENOTSUP,
+            os.strerror(errno.ENOTSUP),
+            os.fspath(path),
+        )
+
+    repository_root = get_git_repository_root_path()
+    requested_path = Path(path)
+    absolute_path = (
+        requested_path
+        if requested_path.is_absolute()
+        else repository_root / requested_path
+    )
+    try:
+        relative_path = absolute_path.relative_to(repository_root)
+    except ValueError:
+        raise OSError(
+            errno.EPERM,
+            os.strerror(errno.EPERM),
+            os.fspath(path),
+        ) from None
+    path_parts = relative_path.parts
+    if not path_parts or ".." in path_parts:
+        raise OSError(
+            errno.EPERM,
+            os.strerror(errno.EPERM),
+            os.fspath(path),
+        )
+
+    close_on_exec = getattr(os, "O_CLOEXEC", 0)
+    directory_access = getattr(os, "O_PATH", os.O_RDONLY)
+    directory_flags = directory_access | directory_only | close_on_exec
+    leaf_flags = no_follow | close_on_exec | getattr(os, "O_NONBLOCK", 0)
+
+    with ExitStack() as descriptors:
+        directory_descriptor = os.open(repository_root, directory_flags)
+        descriptors.callback(os.close, directory_descriptor)
+        if not stat.S_ISDIR(os.fstat(directory_descriptor).st_mode):
+            raise OSError(
+                errno.ENOTDIR,
+                os.strerror(errno.ENOTDIR),
+                os.fspath(repository_root),
+            )
+
+        for component in path_parts[:-1]:
+            directory_descriptor = os.open(
+                component,
+                directory_flags | no_follow,
+                dir_fd=directory_descriptor,
+            )
+            descriptors.callback(os.close, directory_descriptor)
+            if not stat.S_ISDIR(os.fstat(directory_descriptor).st_mode):
+                raise OSError(
+                    errno.ENOTDIR,
+                    os.strerror(errno.ENOTDIR),
+                    component,
+                )
+
+        open_error: PermissionError | None = None
+        for access_mode in access_modes:
+            try:
+                file_descriptor = os.open(
+                    path_parts[-1],
+                    access_mode | leaf_flags,
+                    dir_fd=directory_descriptor,
+                )
+                descriptors.callback(os.close, file_descriptor)
+                break
+            except PermissionError as error:
+                open_error = error
+        else:
+            assert open_error is not None
+            raise open_error
+
+        yield file_descriptor

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -16640,7 +16640,21 @@ def test_batch_file_mode_detection_stays_in_data_module():
         "_detect_file_mode_from_root",
     }
 
-    assert {"detect_file_mode", "detect_file_mode_from_root"} <= vars(file_modes).keys()
+    assert {
+        "apply_git_file_mode",
+        "detect_file_mode",
+        "detect_file_mode_from_root",
+    } <= vars(file_modes).keys()
+
+    file_modes_path = SRC_ROOT / "data" / "file_modes.py"
+    file_modes_imports = {
+        imported_module: {alias.name for alias in node.names}
+        for imported_module, node in _import_from_nodes(file_modes_path)
+    }
+    assert "open_repository_path" in file_modes_imports[
+        "git_stage_batch.utils.repository_path"
+    ]
+    assert "O_NOFOLLOW" not in file_modes_path.read_text()
 
     for path, expected_names in expected_imports.items():
         tree = ast.parse(path.read_text(), filename=str(path))

--- a/tests/data/test_file_modes.py
+++ b/tests/data/test_file_modes.py
@@ -12,6 +12,8 @@ from git_stage_batch.data.file_modes import (
     detect_file_mode_in_commit,
     detect_file_mode_from_root,
 )
+from git_stage_batch.exceptions import CommandError
+from git_stage_batch.utils import repository_path as repository_path_module
 
 
 @pytest.fixture
@@ -123,3 +125,74 @@ def test_applies_git_file_mode_to_worktree_path(temp_git_repo):
     apply_git_file_mode(target_file, "100644")
 
     assert target_file.stat().st_mode & executable_bits == 0
+
+
+def test_apply_git_file_mode_refuses_symlink_without_changing_referent(
+    temp_git_repo,
+):
+    """Executable-bit updates must never follow a worktree symlink."""
+    target_file = temp_git_repo / "target.txt"
+    link_path = temp_git_repo / "linked.txt"
+    target_file.write_text("target\n")
+    target_file.chmod(0o644)
+    try:
+        os.symlink(target_file.name, link_path)
+    except OSError as error:
+        pytest.skip(f"symlink creation failed: {error}")
+
+    with pytest.raises(CommandError, match="Cannot safely apply Git file mode"):
+        apply_git_file_mode(link_path, "100755")
+
+    assert stat.S_IMODE(target_file.stat().st_mode) == 0o644
+    assert link_path.is_symlink()
+
+
+def test_apply_git_file_mode_refuses_symlinked_parent_without_changing_referent(
+    temp_git_repo,
+):
+    """Executable-bit updates must not traverse a worktree parent symlink."""
+    outside_directory = temp_git_repo.parent / "outside"
+    outside_directory.mkdir()
+    target_file = outside_directory / "target.txt"
+    target_file.write_text("target\n")
+    target_file.chmod(0o644)
+    linked_parent = temp_git_repo / "linked-parent"
+    try:
+        os.symlink(outside_directory, linked_parent, target_is_directory=True)
+    except OSError as error:
+        pytest.skip(f"symlink creation failed: {error}")
+
+    with pytest.raises(CommandError, match="Cannot safely apply Git file mode"):
+        apply_git_file_mode(linked_parent / target_file.name, "100755")
+
+    assert stat.S_IMODE(target_file.stat().st_mode) == 0o644
+    assert linked_parent.is_symlink()
+
+
+def test_apply_git_file_mode_uses_write_descriptor_when_read_is_denied(
+    temp_git_repo,
+    monkeypatch,
+):
+    """Mode restoration should still work for a write-only regular file."""
+    target_file = temp_git_repo / "write-only.txt"
+    target_file.write_text("content\n")
+    target_file.chmod(0o200)
+    original_open = repository_path_module.os.open
+    attempted_access_modes = []
+
+    def open_with_read_denied(path, flags, *, dir_fd=None):
+        if path == target_file.name and dir_fd is not None:
+            access_mode = flags & os.O_ACCMODE
+            attempted_access_modes.append(access_mode)
+            if access_mode == os.O_RDONLY:
+                raise PermissionError("read access denied")
+        if dir_fd is None:
+            return original_open(path, flags)
+        return original_open(path, flags, dir_fd=dir_fd)
+
+    monkeypatch.setattr(repository_path_module.os, "open", open_with_read_denied)
+
+    apply_git_file_mode(target_file, "100755")
+
+    assert attempted_access_modes == [os.O_RDONLY, os.O_WRONLY]
+    assert stat.S_IMODE(target_file.stat().st_mode) == 0o311

--- a/tests/functional/test_file_mode_workflow.py
+++ b/tests/functional/test_file_mode_workflow.py
@@ -2,6 +2,7 @@
 
 import os
 import re
+import stat
 import subprocess
 
 from git_stage_batch.batch.state.query import read_batch_metadata
@@ -99,6 +100,52 @@ def test_mode_change_round_trips_through_batch(functional_repo):
 
     git_stage_batch("discard", "--from", "modes", "--file", path.name)
     assert not os.access(path, os.X_OK)
+
+
+def test_mode_batch_refuses_symlinked_worktree_parent(functional_repo):
+    """Applying a mode batch must not chmod through a worktree parent symlink."""
+    directory = functional_repo / "dir"
+    directory.mkdir()
+    path = directory / "tool.sh"
+    path.write_text("#!/bin/sh\necho old\n")
+    path.chmod(0o644)
+    subprocess.run(
+        ["git", "add", "dir/tool.sh"],
+        check=True,
+        cwd=functional_repo,
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "Add nested tool"],
+        check=True,
+        cwd=functional_repo,
+    )
+
+    path.chmod(0o755)
+    git_stage_batch("start")
+    git_stage_batch("show", "--file", "dir/tool.sh")
+    git_stage_batch("discard", "--to", "modes")
+    assert not os.access(path, os.X_OK)
+
+    outside_directory = functional_repo.parent / "outside"
+    outside_directory.mkdir()
+    outside_path = outside_directory / path.name
+    outside_path.write_bytes(path.read_bytes())
+    outside_path.chmod(0o644)
+    directory.rename(functional_repo / "original-dir")
+    os.symlink(outside_directory, directory, target_is_directory=True)
+
+    result = git_stage_batch(
+        "apply",
+        "--from",
+        "modes",
+        "--file",
+        "dir/tool.sh",
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "Cannot safely apply Git file mode" in result.stderr
+    assert stat.S_IMODE(outside_path.stat().st_mode) == 0o644
 
 
 def test_mode_actions_support_skip_undo_redo_and_abort(functional_repo):


### PR DESCRIPTION
Git file-mode restoration applies executable-bit semantics to existing worktree paths when saved changes are replayed.

Path-based stat and chmod calls can follow a symlink in the leaf or an intermediate component. Users can redirect a repository-scoped mode update to a referent outside the intended worktree node, including during a path-kind race.

This pull request addresses that by adding a repository-rooted descriptor walker that rejects relative symlink components, opening mode targets through that utility, validating regular files with fstat, and applying bits through fchmod.

Data, functional, and architecture coverage protects leaf and parent symlink refusal, write-only file fallback, actual mode-batch application, and the intended utility-to-data dependency direction. File-mode restoration now changes only the regular repository path it safely opens.
