### PR TITLE
core: Restrict replacement mode after ownership loss

### DIFF
--- a/src/git_stage_batch/core/buffer.py
+++ b/src/git_stage_batch/core/buffer.py
@@ -762,7 +762,7 @@ def _write_regular_file_atomically(
                 try:
                     os.fchown(file_handle.fileno(), metadata.st_uid, metadata.st_gid)
                 except PermissionError:
-                    pass
+                    replacement_mode &= 0o700
             os.fchmod(file_handle.fileno(), replacement_mode)
             os.fsync(file_handle.fileno())
         os.replace(temporary_path, file_path)

--- a/tests/core/test_buffer.py
+++ b/tests/core/test_buffer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import mmap
 import os
+import stat
 from collections.abc import Sequence
 
 import pytest
@@ -324,6 +325,29 @@ def test_worktree_regular_file_replaces_symlink_atomically(tmp_path):
     assert not output_path.is_symlink()
     assert output_path.read_bytes() == b"regular"
     assert referent.read_bytes() == b"referent contents"
+
+
+def test_atomic_regular_write_tightens_mode_when_ownership_cannot_be_preserved(
+    tmp_path,
+    monkeypatch,
+):
+    """A differently owned replacement must not retain group or other access."""
+    if not hasattr(buffer_module.os, "fchown"):
+        pytest.skip("fchown is not available")
+
+    output_path = tmp_path / "path"
+    output_path.write_bytes(b"old")
+    output_path.chmod(0o666)
+
+    def fail_fchown(*_args):
+        raise PermissionError("ownership cannot be preserved")
+
+    monkeypatch.setattr(buffer_module.os, "fchown", fail_fchown)
+
+    write_buffer_to_path(output_path, b"new")
+
+    assert output_path.read_bytes() == b"new"
+    assert stat.S_IMODE(output_path.stat().st_mode) == 0o600
 
 
 def test_buffer_matches_across_chunk_boundaries(line_sequence):


### PR DESCRIPTION
Atomic regular-file publication preserves the replaced node's mode and attempts to preserve its owner on the temporary file before replacement.

When fchown is denied, publication retains group and other permission bits even though the replacement may have a different owner. Users can receive a newly owned file with broader access than the original ownership relationship implied.

This pull request addresses that by masking the replacement mode to owner-only permissions whenever ownership preservation fails, while retaining the existing content publication and atomic replacement sequence.

A focused test injects fchown denial on a group-writable file and verifies the published bytes with mode 0600. Ownership failure can no longer carry broader inherited permissions onto the replacement node.
