### PR TITLE
include: Preserve line selections as targets change

### DIFF
--- a/src/git_stage_batch/batch/merge/baseline_reference_positions.py
+++ b/src/git_stage_batch/batch/merge/baseline_reference_positions.py
@@ -67,6 +67,11 @@ def baseline_reference_insertion_position(
             ):
                 return None
             verified_boundary = True
+    elif position != len(working_lines):
+        # Historical EOF additions recorded only their preceding line.  That
+        # one-sided reference is exact only while the target still ends there;
+        # otherwise structural source mapping must choose the placement.
+        return None
 
     if not verified_boundary:
         return None

--- a/src/git_stage_batch/commands/selection/include_line_selection.py
+++ b/src/git_stage_batch/commands/selection/include_line_selection.py
@@ -121,7 +121,10 @@ def record_baseline_references_for_additions(line_changes) -> None:
                 addition_line.has_baseline_reference_after = True
                 addition_line.baseline_reference_before_line = next_old_line
                 addition_line.baseline_reference_before_text_bytes = next_old_text_bytes
-                addition_line.has_baseline_reference_before = next_old_line is not None
+                # A missing next old line is an explicit EOF boundary, not an
+                # unknown second side.  Preserve that distinction so a later
+                # merge does not insert before content appended to the target.
+                addition_line.has_baseline_reference_before = True
                 index += 1
             continue
 

--- a/src/git_stage_batch/commands/selection/include_line_selection.py
+++ b/src/git_stage_batch/commands/selection/include_line_selection.py
@@ -483,13 +483,19 @@ def try_build_index_content_via_transient_batch(
                 line_changes.path,
                 file_buffer_override=working_lines,
             )
-            add_file_to_batch(
-                batch_name,
-                line_changes.path,
-                ownership,
-                detect_file_mode(line_changes.path),
-                batch_source_commit=batch_source_commit,
-            )
+            try:
+                add_file_to_batch(
+                    batch_name,
+                    line_changes.path,
+                    ownership,
+                    detect_file_mode(line_changes.path),
+                    batch_source_commit=batch_source_commit,
+                )
+            except MergeError as error:
+                return TransientIncludeResult.failure(
+                    TransientIncludeFailureReason.PREPARATION_FAILED,
+                    detail=str(error),
+                )
 
             metadata = read_batch_metadata(batch_name)
             file_metadata = metadata.get("files", {}).get(line_changes.path)
@@ -525,7 +531,7 @@ def try_build_index_content_via_transient_batch(
                 except MergeError as error:
                     return TransientIncludeResult.failure(
                         TransientIncludeFailureReason.INDEX_MERGE_FAILED,
-                        detail=error.__class__.__name__,
+                        detail=str(error),
                     )
 
                 try:
@@ -539,7 +545,7 @@ def try_build_index_content_via_transient_batch(
                     target_index_buffer = None
                     return TransientIncludeResult.failure(
                         TransientIncludeFailureReason.WORKING_TREE_MERGE_FAILED,
-                        detail=error.__class__.__name__,
+                        detail=str(error),
                     )
 
                 with target_working_buffer:

--- a/src/git_stage_batch/commands/selection/include_line_selection.py
+++ b/src/git_stage_batch/commands/selection/include_line_selection.py
@@ -5,13 +5,18 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass, replace
 from enum import Enum
-import uuid
 import sys
+import uuid
 
 from ...batch.ownership.hunk_translation import (
     translate_hunk_selection_to_batch_ownership,
 )
+from ...batch.line_matching.match import match_lines
+from ...batch.merge.baseline_reference_positions import (
+    baseline_reference_insertion_position as _baseline_reference_insertion_position,
+)
 from ...batch.merge.merge import merge_batch_from_line_sequences_as_buffer
+from ...batch.ownership.references import BaselineReference as _BaselineReference
 from ...batch.state.lifecycle import create_batch, delete_batch
 from ...batch.ownership.metadata_loading import acquire_ownership_for_metadata_dict
 from ...batch.state.query import read_batch_metadata
@@ -19,6 +24,7 @@ from ...batch.selection import line_selection_not_valid_message
 from ...batch.text_file_storage import add_file_to_batch
 from ...batch.state.batch_names import batch_exists
 from ...core.buffer import LineBuffer, buffer_matches
+from ...core.text_lines import normalize_line_sequence_endings
 from ...batch.source.snapshots import create_batch_source_commit
 from ...data.selected_change.file_hunk_cache import cache_unstaged_file_as_single_hunk
 from ...data.file_modes import detect_file_mode
@@ -88,8 +94,8 @@ class IncludeLineSelectionContext:
     reset_processed_include_ids: bool = False
 
 
-def record_baseline_references_for_additions(line_changes) -> None:
-    """Attach old-file insertion references to addition lines for batch round trips."""
+def _record_diff_baseline_references_for_additions(line_changes) -> None:
+    """Attach insertion references from the old side of the displayed diff."""
     last_old_line: int | None = None
     last_old_text_bytes: bytes | None = None
     index = 0
@@ -132,6 +138,135 @@ def record_baseline_references_for_additions(line_changes) -> None:
             last_old_line = line.old_line_number
             last_old_text_bytes = line.text_bytes
         index += 1
+
+
+def _clear_addition_baseline_reference(addition_line) -> None:
+    """Remove insertion metadata that does not fit the captured baseline."""
+    addition_line.baseline_reference_after_line = None
+    addition_line.baseline_reference_after_text_bytes = None
+    addition_line.has_baseline_reference_after = False
+    addition_line.baseline_reference_before_line = None
+    addition_line.baseline_reference_before_text_bytes = None
+    addition_line.has_baseline_reference_before = False
+
+
+def _record_snapshot_baseline_references_for_additions(
+    line_changes,
+    *,
+    baseline_lines: Sequence[bytes],
+    source_lines: Sequence[bytes],
+) -> None:
+    """Attach insertion references in captured baseline coordinates.
+
+    A file-scoped view is rendered against the session comparison base, which
+    can differ from the current index after an earlier partial include. Align
+    the captured source and index directly so later selections use boundaries
+    from the baseline they will actually be merged into.
+    """
+
+    def reference_fits_baseline(line) -> bool:
+        reference = _BaselineReference(
+            after_line=line.baseline_reference_after_line,
+            after_content=line.baseline_reference_after_text_bytes,
+            has_after_line=line.has_baseline_reference_after,
+            before_line=line.baseline_reference_before_line,
+            before_content=line.baseline_reference_before_text_bytes,
+            has_before_line=line.has_baseline_reference_before,
+        )
+        position = _baseline_reference_insertion_position(
+            reference,
+            baseline_lines,
+        )
+        if position is None:
+            return False
+
+        # Legacy line views may carry an after-only EOF reference.  If the
+        # index now continues past that position, rebuild it from snapshots.
+        return line.has_baseline_reference_before or position == len(baseline_lines)
+
+    addition_lines = sorted(
+        (
+            line
+            for line in line_changes.lines
+            if (
+                line.kind == "+"
+                and line.source_line is not None
+                and 1 <= line.source_line <= len(source_lines)
+                and not reference_fits_baseline(line)
+            )
+        ),
+        key=lambda line: line.source_line,
+    )
+    if not addition_lines:
+        return
+
+    normalized_source_lines = normalize_line_sequence_endings(source_lines)
+    normalized_baseline_lines = normalize_line_sequence_endings(baseline_lines)
+    with match_lines(normalized_source_lines, normalized_baseline_lines) as mapping:
+        mapped_pairs = mapping.mapped_line_pairs()
+        previous_pair: tuple[int, int] | None = None
+        next_pair = next(mapped_pairs, None)
+
+        for addition_line in addition_lines:
+            source_line = addition_line.source_line
+            assert source_line is not None
+
+            while next_pair is not None and next_pair[0] < source_line:
+                previous_pair = next_pair
+                next_pair = next(mapped_pairs, None)
+
+            if next_pair is not None and next_pair[0] == source_line:
+                target_line = next_pair[1]
+                after_line = target_line - 1 if target_line > 1 else None
+                before_line = target_line
+                previous_pair = next_pair
+                next_pair = next(mapped_pairs, None)
+            else:
+                after_line = previous_pair[1] if previous_pair is not None else None
+                before_line = next_pair[1] if next_pair is not None else None
+                insertion_position = after_line or 0
+                expected_before_line = insertion_position + 1
+                actual_before_line = before_line or len(baseline_lines) + 1
+                if expected_before_line != actual_before_line:
+                    # Target-only content leaves the relative insertion order
+                    # ambiguous. Do not retain the diff reference that was
+                    # already proven invalid against this baseline.
+                    _clear_addition_baseline_reference(addition_line)
+                    continue
+
+            addition_line.baseline_reference_after_line = after_line
+            addition_line.baseline_reference_after_text_bytes = (
+                bytes(baseline_lines[after_line - 1])
+                if after_line is not None
+                else None
+            )
+            addition_line.has_baseline_reference_after = True
+            addition_line.baseline_reference_before_line = before_line
+            addition_line.baseline_reference_before_text_bytes = (
+                bytes(baseline_lines[before_line - 1])
+                if before_line is not None
+                else None
+            )
+            addition_line.has_baseline_reference_before = True
+
+
+def record_baseline_references_for_additions(
+    line_changes,
+    *,
+    baseline_lines: Sequence[bytes] | None = None,
+    source_lines: Sequence[bytes] | None = None,
+) -> None:
+    """Attach insertion references to addition lines for batch round trips."""
+    _record_diff_baseline_references_for_additions(line_changes)
+    if baseline_lines is None and source_lines is None:
+        return
+    if baseline_lines is None or source_lines is None:
+        raise ValueError("baseline_lines and source_lines must be provided together")
+    _record_snapshot_baseline_references_for_additions(
+        line_changes,
+        baseline_lines=baseline_lines,
+        source_lines=source_lines,
+    )
 
 
 def _snapshot_session_batch_sources_file() -> tuple[bool, bytes | None]:
@@ -324,7 +459,11 @@ def try_build_index_content_via_transient_batch(
         create_batch(batch_name, "Transient include-line selection")
         created_batch = True
 
-        record_baseline_references_for_additions(line_changes)
+        record_baseline_references_for_additions(
+            line_changes,
+            baseline_lines=hunk_base_lines,
+            source_lines=hunk_source_lines,
+        )
         ownership = translate_hunk_selection_to_batch_ownership(
             line_changes.lines,
             selected_display_ids,

--- a/tests/batch/merge/test_merge.py
+++ b/tests/batch/merge/test_merge.py
@@ -959,6 +959,27 @@ class TestMergeBatch:
 
         assert result == b"line1\nline2\nline4\n"
 
+    def test_legacy_eof_reference_defers_after_target_grows(self):
+        """An after-only EOF reference must not precede mapped target additions."""
+        source = b"base\nfirst\n\n"
+        working = b"base\nfirst\n"
+        ownership = BatchOwnership.from_presence_lines(
+            ["3"],
+            [],
+            baseline_references={
+                3: BaselineReference(
+                    after_line=1,
+                    after_content=b"base",
+                    before_line=None,
+                    has_before_line=False,
+                )
+            },
+        )
+
+        result = merge_batch(source, ownership, working)
+
+        assert result == source
+
     def test_baseline_referenced_fallback_yields_line_chunks(self):
         """Baseline-coordinate fallback returns line content chunks."""
         source_lines = [b"line1\n", b"line2\n", b"line3\n", b"line4\n"]

--- a/tests/commands/selection/test_include_line_selection.py
+++ b/tests/commands/selection/test_include_line_selection.py
@@ -14,6 +14,39 @@ def _line_changes(lines: list[LineEntry]) -> LineLevelChange:
     )
 
 
+def test_snapshot_references_preserve_start_of_file_insertion() -> None:
+    """A two-sided start reference should retain the first baseline gap."""
+    addition = LineEntry(
+        id=1,
+        kind="+",
+        old_line_number=None,
+        new_line_number=1,
+        text_bytes=b"added",
+        source_line=1,
+    )
+    tail = LineEntry(
+        id=None,
+        kind=" ",
+        old_line_number=1,
+        new_line_number=2,
+        text_bytes=b"tail",
+        source_line=2,
+    )
+
+    record_baseline_references_for_additions(
+        _line_changes([addition, tail]),
+        baseline_lines=[b"tail\n"],
+        source_lines=[b"added\n", b"tail\n"],
+    )
+
+    assert addition.has_baseline_reference_after
+    assert addition.baseline_reference_after_line is None
+    assert addition.baseline_reference_after_text_bytes is None
+    assert addition.has_baseline_reference_before
+    assert addition.baseline_reference_before_line == 1
+    assert addition.baseline_reference_before_text_bytes == b"tail"
+
+
 def test_diff_references_record_explicit_eof_boundary() -> None:
     """An EOF addition should distinguish EOF from an unknown next boundary."""
     base = LineEntry(
@@ -39,5 +72,88 @@ def test_diff_references_record_explicit_eof_boundary() -> None:
     assert addition.baseline_reference_after_line == 1
     assert addition.baseline_reference_after_text_bytes == b"base"
     assert addition.has_baseline_reference_before
+
+
+def test_snapshot_references_reanchor_stale_eof_additions() -> None:
+    """A grown index should move additions past an earlier staged EOF line."""
+    base = LineEntry(
+        id=None,
+        kind=" ",
+        old_line_number=1,
+        new_line_number=1,
+        text_bytes=b"base",
+        source_line=1,
+    )
+    first = LineEntry(
+        id=1,
+        kind="+",
+        old_line_number=None,
+        new_line_number=2,
+        text_bytes=b"first",
+        source_line=2,
+    )
+    blank = LineEntry(
+        id=2,
+        kind="+",
+        old_line_number=None,
+        new_line_number=3,
+        text_bytes=b"",
+        source_line=3,
+    )
+
+    record_baseline_references_for_additions(
+        _line_changes([base, first, blank]),
+        baseline_lines=[b"base\n", b"first\n"],
+        source_lines=[b"base\n", b"first\n", b"\n"],
+    )
+
+    assert first.baseline_reference_after_line == 1
+    assert first.baseline_reference_before_line == 2
+    assert first.baseline_reference_before_text_bytes == b"first\n"
+    assert blank.has_baseline_reference_after
+    assert blank.baseline_reference_after_line == 2
+    assert blank.baseline_reference_after_text_bytes == b"first\n"
+    assert blank.has_baseline_reference_before
+    assert blank.baseline_reference_before_line is None
+    assert blank.baseline_reference_before_text_bytes is None
+
+
+def test_snapshot_references_clear_ambiguous_stale_reference() -> None:
+    """Target-only content should leave no already-invalid insertion reference."""
+    base = LineEntry(
+        id=None,
+        kind=" ",
+        old_line_number=1,
+        new_line_number=1,
+        text_bytes=b"base",
+        source_line=1,
+    )
+    addition = LineEntry(
+        id=1,
+        kind="+",
+        old_line_number=None,
+        new_line_number=2,
+        text_bytes=b"selected",
+        source_line=2,
+    )
+    tail = LineEntry(
+        id=None,
+        kind=" ",
+        old_line_number=2,
+        new_line_number=3,
+        text_bytes=b"tail",
+        source_line=3,
+    )
+
+    record_baseline_references_for_additions(
+        _line_changes([base, addition, tail]),
+        baseline_lines=[b"base\n", b"staged only\n", b"tail\n"],
+        source_lines=[b"base\n", b"selected\n", b"tail\n"],
+    )
+
+    assert not addition.has_baseline_reference_after
+    assert addition.baseline_reference_after_line is None
+    assert addition.baseline_reference_after_text_bytes is None
+    assert not addition.has_baseline_reference_before
     assert addition.baseline_reference_before_line is None
     assert addition.baseline_reference_before_text_bytes is None

--- a/tests/commands/selection/test_include_line_selection.py
+++ b/tests/commands/selection/test_include_line_selection.py
@@ -1,0 +1,43 @@
+"""Focused tests for live include-line selection metadata."""
+
+from git_stage_batch.commands.selection.include_line_selection import (
+    record_baseline_references_for_additions,
+)
+from git_stage_batch.core.models import HunkHeader, LineEntry, LineLevelChange
+
+
+def _line_changes(lines: list[LineEntry]) -> LineLevelChange:
+    return LineLevelChange(
+        path="module.py",
+        header=HunkHeader(old_start=1, old_len=1, new_start=1, new_len=len(lines)),
+        lines=lines,
+    )
+
+
+def test_diff_references_record_explicit_eof_boundary() -> None:
+    """An EOF addition should distinguish EOF from an unknown next boundary."""
+    base = LineEntry(
+        id=None,
+        kind=" ",
+        old_line_number=1,
+        new_line_number=1,
+        text_bytes=b"base",
+        source_line=1,
+    )
+    addition = LineEntry(
+        id=1,
+        kind="+",
+        old_line_number=None,
+        new_line_number=2,
+        text_bytes=b"added",
+        source_line=2,
+    )
+
+    record_baseline_references_for_additions(_line_changes([base, addition]))
+
+    assert addition.has_baseline_reference_after
+    assert addition.baseline_reference_after_line == 1
+    assert addition.baseline_reference_after_text_bytes == b"base"
+    assert addition.has_baseline_reference_before
+    assert addition.baseline_reference_before_line is None
+    assert addition.baseline_reference_before_text_bytes is None

--- a/tests/commands/test_file_scoped_operations.py
+++ b/tests/commands/test_file_scoped_operations.py
@@ -1660,6 +1660,169 @@ class TestExplicitFilePath:
         expected.insert(17, "late staged\n")
         assert staged_content == "".join(expected)
 
+    def test_include_blank_lines_after_staging_adjacent_added_lines(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        """A later blank-line selection should merge with adjacent staged additions."""
+        repo = tmp_path / "test_repo"
+        repo.mkdir()
+        monkeypatch.chdir(repo)
+
+        subprocess.run(["git", "init"], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.name", "Test"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "test@test.com"],
+            check=True,
+            capture_output=True,
+        )
+
+        original = (
+            "def existing():\n"
+            "    pass\n"
+            "\n"
+            "\n"
+            "def following():\n"
+            "    pass\n"
+        )
+        rewritten = (
+            "def existing():\n"
+            "    pass\n"
+            "\n"
+            "\n"
+            "def first_added():\n"
+            "    first = 1\n"
+            "\n"
+            "\n"
+            "def second_added():\n"
+            "    second = 2\n"
+            "\n"
+            "\n"
+            "def following():\n"
+            "    pass\n"
+        )
+        first_staged = (
+            "def existing():\n"
+            "    pass\n"
+            "\n"
+            "\n"
+            "def first_added():\n"
+            "    first = 1\n"
+            "\n"
+            "\n"
+            "def following():\n"
+            "    pass\n"
+        )
+        file_path = repo / "module.py"
+        file_path.write_text(original)
+        subprocess.run(["git", "add", "module.py"], check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Initial"],
+            check=True,
+            capture_output=True,
+        )
+        file_path.write_text(rewritten)
+
+        command_start(quiet=True)
+        command_show(file="module.py", page="all", porcelain=True)
+        line_changes = load_line_changes_from_state()
+        assert line_changes is not None
+        content_ids = ",".join(
+            str(line.id)
+            for line in line_changes.lines
+            if line.id is not None
+            and line.kind == "+"
+            and line.display_text()
+            in {"def first_added():", "    first = 1"}
+        )
+        command_include_line(content_ids, file="module.py")
+
+        command_again(quiet=True)
+        command_show(file="module.py", page="all", porcelain=True)
+        line_changes = load_line_changes_from_state()
+        assert line_changes is not None
+        blank_id_values = [
+            line.id
+            for line in line_changes.lines
+            if line.id is not None
+            and line.kind == "+"
+            and not line.display_text()
+        ]
+        assert len(blank_id_values) == 4
+        blank_ids = ",".join(str(line_id) for line_id in blank_id_values[:2])
+
+        command_include_line(blank_ids, file="module.py")
+
+        assert run_git_command(["show", ":module.py"]).stdout == first_staged
+        assert file_path.read_text() == rewritten
+
+    def test_include_blank_line_after_staging_adjacent_eof_addition(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        """A later EOF separator should remain after an adjacent staged line."""
+        repo = tmp_path / "test_repo"
+        repo.mkdir()
+        monkeypatch.chdir(repo)
+
+        subprocess.run(["git", "init"], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.name", "Test"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "test@test.com"],
+            check=True,
+            capture_output=True,
+        )
+
+        file_path = repo / "module.py"
+        file_path.write_text("base\n")
+        subprocess.run(["git", "add", "module.py"], check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Initial"],
+            check=True,
+            capture_output=True,
+        )
+
+        rewritten = "base\nfirst\n\nsecond\n\n"
+        file_path.write_text(rewritten)
+
+        command_start(quiet=True)
+        command_show(file="module.py", page="all", porcelain=True)
+        line_changes = load_line_changes_from_state()
+        assert line_changes is not None
+        first_id = next(
+            line.id
+            for line in line_changes.lines
+            if line.id is not None and line.display_text() == "first"
+        )
+        command_include_line(str(first_id), file="module.py")
+
+        command_again(quiet=True)
+        command_show(file="module.py", page="all", porcelain=True)
+        line_changes = load_line_changes_from_state()
+        assert line_changes is not None
+        blank_id = next(
+            line.id
+            for line in line_changes.lines
+            if line.id is not None
+            and line.kind == "+"
+            and not line.display_text()
+        )
+
+        command_include_line(str(blank_id), file="module.py")
+
+        assert run_git_command(["show", ":module.py"]).stdout == "base\nfirst\n\n"
+        assert file_path.read_text() == rewritten
+
     def test_named_batch_eof_addition_applies_after_staged_source_line(
         self,
         tmp_path,

--- a/tests/commands/test_file_scoped_operations.py
+++ b/tests/commands/test_file_scoped_operations.py
@@ -26,6 +26,7 @@ import pytest
 import git_stage_batch.commands.file_scope.include_file as include_file_module
 
 from git_stage_batch.commands.start import command_start
+from git_stage_batch.commands.again import command_again
 from git_stage_batch.commands.show import command_show
 from git_stage_batch.commands.include import (
     command_include,
@@ -1658,6 +1659,75 @@ class TestExplicitFilePath:
         expected[2:2] = ["early one\n", "early two\n"]
         expected.insert(17, "late staged\n")
         assert staged_content == "".join(expected)
+
+    def test_named_batch_eof_addition_applies_after_staged_source_line(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        """A batched EOF separator should follow an already-staged source line."""
+        repo = tmp_path / "test_repo"
+        repo.mkdir()
+        monkeypatch.chdir(repo)
+
+        subprocess.run(["git", "init"], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.name", "Test"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "test@test.com"],
+            check=True,
+            capture_output=True,
+        )
+
+        file_path = repo / "module.py"
+        file_path.write_text("base\n")
+        subprocess.run(["git", "add", "module.py"], check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Initial"],
+            check=True,
+            capture_output=True,
+        )
+
+        rewritten = "base\nfirst\n\n"
+        file_path.write_text(rewritten)
+
+        command_start(quiet=True)
+        command_show(file="module.py", page="all", porcelain=True)
+        line_changes = load_line_changes_from_state()
+        assert line_changes is not None
+        first_id = next(
+            line.id
+            for line in line_changes.lines
+            if line.id is not None and line.display_text() == "first"
+        )
+        command_include_line(str(first_id), file="module.py")
+
+        command_again(quiet=True)
+        command_show(file="module.py", page="all", porcelain=True)
+        line_changes = load_line_changes_from_state()
+        assert line_changes is not None
+        blank_id = next(
+            line.id
+            for line in line_changes.lines
+            if line.id is not None
+            and line.kind == "+"
+            and not line.display_text()
+        )
+        command_include_to_batch(
+            "separator",
+            line_ids=str(blank_id),
+            file="module.py",
+            quiet=True,
+        )
+
+        assert run_git_command(["show", ":module.py"]).stdout == "base\nfirst\n"
+        command_include_from_batch("separator", file="module.py")
+
+        assert run_git_command(["show", ":module.py"]).stdout == rewritten
+        assert file_path.read_text() == rewritten
 
     def test_include_line_as_with_explicit_path_trims_matching_edge_anchors(self, tmp_path, monkeypatch):
         """Explicit file-scoped include --line --as should accept unchanged edge anchors."""

--- a/tests/commands/test_include.py
+++ b/tests/commands/test_include.py
@@ -15,7 +15,7 @@ from git_stage_batch.commands.include import (
     command_include_line_as,
     command_include_to_batch,
 )
-from git_stage_batch.commands.selection import include_line_selection
+from git_stage_batch.commands.selection import include_line_action, include_line_selection
 from git_stage_batch.commands.selection.replacement_selection import (
     derive_replacement_line_runs,
 )
@@ -31,7 +31,7 @@ from git_stage_batch.data.line_state import load_line_changes_from_state
 from git_stage_batch.data.selected_change.clear_reasons import (
     selected_change_was_cleared_by_auto_advance_disabled,
 )
-from git_stage_batch.exceptions import CommandError, NoMoreHunks
+from git_stage_batch.exceptions import CommandError, MergeError, NoMoreHunks
 from git_stage_batch.utils.paths import get_state_directory_path
 from git_stage_batch.commands.again import command_again
 from tests.batch.ownership.metadata_helpers import (
@@ -872,6 +872,42 @@ class TestCommandIncludeLine:
             capture_output=True,
             text=True,
         ).stdout == ""
+
+    def test_include_line_converts_preparation_merge_error_to_refusal(
+        self,
+        temp_git_repo,
+        monkeypatch,
+    ):
+        """Transient batch preparation ambiguity should remain user-facing."""
+        _prepare_single_line_change(temp_git_repo)
+        journal_entries = []
+
+        def raise_merge_error(*_args, **_kwargs):
+            raise MergeError("batch source no longer fits")
+
+        monkeypatch.setattr(
+            include_line_selection,
+            "add_file_to_batch",
+            raise_merge_error,
+        )
+        monkeypatch.setattr(
+            include_line_action,
+            "log_journal",
+            lambda event, **fields: journal_entries.append((event, fields)),
+        )
+
+        with pytest.raises(CommandError, match="Cannot safely include line"):
+            command_include_line("1")
+
+        assert subprocess.run(
+            ["git", "diff", "--cached", "--name-only"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+            text=True,
+        ).stdout == ""
+        assert journal_entries[-1][0] == "include_line_transient_batch_staging_declined"
+        assert journal_entries[-1][1]["detail"] == "batch source no longer fits"
 
     def test_include_line_handles_deletions(self, temp_git_repo):
         """Test that include --line handles deletions correctly."""


### PR DESCRIPTION
Partial line inclusion reconstructs selected changes from saved-destination and current-index context, including insertion-only hunks at end of file.

End-of-file ties could reverse insertion order, while index movement could leave selected lines anchored to stale coordinates. When transient preparation could not place a selection uniquely, the command could also discard saved work or obscure the cause.

This pull request preserves source order for end-of-file insertions, reanchors file selections against live index content, and reports preparation failures as refusals that leave staged content and saved work intact.

Regression coverage exercises end-of-file boundaries, additions and deletions around shifted anchors, saved-destination changes, and command-level refusal diagnostics. Partial line staging now remains deterministic as its inputs evolve.