### PR TITLE
batch: Build attribution from validated state snapshots

### DIFF
--- a/src/git_stage_batch/batch/attribution.py
+++ b/src/git_stage_batch/batch/attribution.py
@@ -161,6 +161,10 @@ def build_file_attribution_from_lines(
     if metrics is not None:
         metrics.candidate_batches = len(batch_metadata_by_name)
 
+    # Capture names before merging supplemental metadata. Only entries from the
+    # primary metadata map may resolve source_path through state-backed storage.
+    # Supplemental entries, including __consumed__, use batch_source_commit.
+    state_backed_batch_names = frozenset(batch_metadata_by_name)
     for batch_name, metadata in batch_metadata_by_name.items():
         if file_path in metadata.get("files", {}):
             all_batch_metadata[batch_name] = metadata
@@ -183,6 +187,7 @@ def build_file_attribution_from_lines(
     _attribute_batches(
         file_path,
         all_batch_metadata,
+        state_backed_batch_names=state_backed_batch_names,
         working_tree_lines=working_tree_lines,
         all_units_map=all_units_map,
         baseline_unit_ids=baseline_unit_ids,
@@ -207,6 +212,7 @@ def _attribute_batches(
     file_path: str,
     all_batch_metadata: dict,
     *,
+    state_backed_batch_names: frozenset[str],
     working_tree_lines: Sequence[bytes],
     all_units_map: dict[str, _AttributionUnit],
     baseline_unit_ids: Sequence[str],
@@ -214,7 +220,11 @@ def _attribute_batches(
     metrics: AttributionMetrics | None = None,
 ) -> None:
     """Attribute claims while retaining one source alignment at a time."""
-    source_requests = _batch_source_requests(file_path, all_batch_metadata)
+    source_requests = _batch_source_requests(
+        file_path,
+        all_batch_metadata,
+        state_backed_batch_names=state_backed_batch_names,
+    )
     deletion_blob_ids = _deletion_blob_ids(source_requests)
     object_names = list(
         dict.fromkeys(
@@ -390,6 +400,8 @@ def _attribute_source_group(
 def _batch_source_requests(
     file_path: str,
     all_batch_metadata: dict,
+    *,
+    state_backed_batch_names: frozenset[str],
 ) -> list[_BatchSourceRequest]:
     requests: list[_BatchSourceRequest] = []
     for batch_name in sorted(all_batch_metadata):
@@ -397,11 +409,11 @@ def _batch_source_requests(
         file_metadata = batch_metadata["files"][file_path]
         fallback_refspec = f"{file_metadata['batch_source_commit']}:{file_path}"
         source_path = file_metadata.get("source_path")
-        primary_refspec = (
-            f"{format_batch_state_ref_name(batch_name)}:{source_path}"
-            if source_path
-            else fallback_refspec
-        )
+        primary_refspec = fallback_refspec
+        if source_path and batch_name in state_backed_batch_names:
+            primary_refspec = (
+                f"{format_batch_state_ref_name(batch_name)}:{source_path}"
+            )
         requests.append(
             _BatchSourceRequest(
                 batch_name=batch_name,

--- a/src/git_stage_batch/batch/attribution.py
+++ b/src/git_stage_batch/batch/attribution.py
@@ -8,7 +8,7 @@ content that may not currently be visible in the working tree.
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 
 from ..utils.git_object_io import (
@@ -152,6 +152,7 @@ def build_file_attribution_from_lines(
     working_tree_lines: Sequence[bytes],
     batch_metadata_by_name: dict[str, dict] | None = None,
     supplemental_batch_metadata: dict[str, dict] | None = None,
+    batch_state_commit_by_name: Mapping[str, str] | None = None,
     metrics: AttributionMetrics | None = None,
 ) -> FileAttribution:
     """Build file attribution from caller-owned indexed line sequences."""
@@ -188,6 +189,7 @@ def build_file_attribution_from_lines(
         file_path,
         all_batch_metadata,
         state_backed_batch_names=state_backed_batch_names,
+        batch_state_commit_by_name=batch_state_commit_by_name,
         working_tree_lines=working_tree_lines,
         all_units_map=all_units_map,
         baseline_unit_ids=baseline_unit_ids,
@@ -213,6 +215,7 @@ def _attribute_batches(
     all_batch_metadata: dict,
     *,
     state_backed_batch_names: frozenset[str],
+    batch_state_commit_by_name: Mapping[str, str] | None,
     working_tree_lines: Sequence[bytes],
     all_units_map: dict[str, _AttributionUnit],
     baseline_unit_ids: Sequence[str],
@@ -224,6 +227,7 @@ def _attribute_batches(
         file_path,
         all_batch_metadata,
         state_backed_batch_names=state_backed_batch_names,
+        batch_state_commit_by_name=batch_state_commit_by_name,
     )
     deletion_blob_ids = _deletion_blob_ids(source_requests)
     object_names = list(
@@ -402,6 +406,7 @@ def _batch_source_requests(
     all_batch_metadata: dict,
     *,
     state_backed_batch_names: frozenset[str],
+    batch_state_commit_by_name: Mapping[str, str] | None = None,
 ) -> list[_BatchSourceRequest]:
     requests: list[_BatchSourceRequest] = []
     for batch_name in sorted(all_batch_metadata):
@@ -411,9 +416,14 @@ def _batch_source_requests(
         source_path = file_metadata.get("source_path")
         primary_refspec = fallback_refspec
         if source_path and batch_name in state_backed_batch_names:
-            primary_refspec = (
-                f"{format_batch_state_ref_name(batch_name)}:{source_path}"
-            )
+            if batch_state_commit_by_name is None:
+                primary_refspec = (
+                    f"{format_batch_state_ref_name(batch_name)}:{source_path}"
+                )
+            elif batch_name in batch_state_commit_by_name:
+                primary_refspec = (
+                    f"{batch_state_commit_by_name[batch_name]}:{source_path}"
+                )
         requests.append(
             _BatchSourceRequest(
                 batch_name=batch_name,

--- a/src/git_stage_batch/batch/attribution.py
+++ b/src/git_stage_batch/batch/attribution.py
@@ -130,7 +130,31 @@ def build_file_attribution(
     supplemental_batch_metadata: dict[str, dict] | None = None,
     metrics: AttributionMetrics | None = None,
 ) -> FileAttribution:
-    """Build complete ownership attribution for a file."""
+    """Open repository buffers and build complete ownership attribution."""
+    with (
+        read_git_object_buffer_or_empty(f"HEAD:{file_path}") as baseline_lines,
+        load_working_tree_file_as_buffer(file_path) as working_tree_lines,
+    ):
+        return build_file_attribution_from_lines(
+            file_path,
+            baseline_lines=baseline_lines,
+            working_tree_lines=working_tree_lines,
+            batch_metadata_by_name=batch_metadata_by_name,
+            supplemental_batch_metadata=supplemental_batch_metadata,
+            metrics=metrics,
+        )
+
+
+def build_file_attribution_from_lines(
+    file_path: str,
+    *,
+    baseline_lines: Sequence[bytes],
+    working_tree_lines: Sequence[bytes],
+    batch_metadata_by_name: dict[str, dict] | None = None,
+    supplemental_batch_metadata: dict[str, dict] | None = None,
+    metrics: AttributionMetrics | None = None,
+) -> FileAttribution:
+    """Build file attribution from caller-owned indexed line sequences."""
     all_batch_metadata = {}
     if batch_metadata_by_name is None:
         batch_metadata_by_name = read_batch_metadata_for_batches(list_batch_names())
@@ -146,38 +170,35 @@ def build_file_attribution(
     if metrics is not None:
         metrics.claimed_batches = len(all_batch_metadata)
 
-    baseline_buffer = read_git_object_buffer_or_empty(f"HEAD:{file_path}")
-    working_tree_buffer = load_working_tree_file_as_buffer(file_path)
-    with baseline_buffer as baseline_lines, working_tree_buffer as working_tree_lines:
-        all_units_map: dict[str, _AttributionUnit] = {}
-        with _build_file_comparison_from_lines(
-            file_path,
-            baseline_lines=baseline_lines,
-            working_tree_lines=working_tree_lines,
-        ) as comparison:
-            _enumerate_units_from_file_comparison(comparison, all_units_map)
+    all_units_map: dict[str, _AttributionUnit] = {}
+    with _build_file_comparison_from_lines(
+        file_path,
+        baseline_lines=baseline_lines,
+        working_tree_lines=working_tree_lines,
+    ) as comparison:
+        _enumerate_units_from_file_comparison(comparison, all_units_map)
 
-        baseline_unit_ids = tuple(all_units_map)
-        owners_by_unit_id = {unit_id: set() for unit_id in baseline_unit_ids}
-        _attribute_batches(
-            file_path,
-            all_batch_metadata,
-            working_tree_lines=working_tree_lines,
-            all_units_map=all_units_map,
-            baseline_unit_ids=baseline_unit_ids,
-            owners_by_unit_id=owners_by_unit_id,
-            metrics=metrics,
+    baseline_unit_ids = tuple(all_units_map)
+    owners_by_unit_id = {unit_id: set() for unit_id in baseline_unit_ids}
+    _attribute_batches(
+        file_path,
+        all_batch_metadata,
+        working_tree_lines=working_tree_lines,
+        all_units_map=all_units_map,
+        baseline_unit_ids=baseline_unit_ids,
+        owners_by_unit_id=owners_by_unit_id,
+        metrics=metrics,
+    )
+
+    attributed_units = [
+        AttributedUnit(
+            unit=unit,
+            owning_batches=owners_by_unit_id[unit_id],
         )
-
-        attributed_units = [
-            AttributedUnit(
-                unit=unit,
-                owning_batches=owners_by_unit_id[unit_id],
-            )
-            for unit_id, unit in all_units_map.items()
-        ]
-        if metrics is not None:
-            metrics.attributed_units = len(attributed_units)
+        for unit_id, unit in all_units_map.items()
+    ]
+    if metrics is not None:
+        metrics.attributed_units = len(attributed_units)
 
     return FileAttribution(file_path=file_path, units=attributed_units)
 

--- a/src/git_stage_batch/batch/attribution.py
+++ b/src/git_stage_batch/batch/attribution.py
@@ -27,7 +27,7 @@ from .attribution_units import (
     make_attribution_unit_id as _make_attribution_unit_id,
 )
 from .state.query import list_batch_names, read_batch_metadata_for_batches
-from .state.references import get_batch_state_ref_name
+from .state.reference_names import format_batch_state_ref_name
 from ..core.line_selection import parse_line_selection
 from ..utils.repository_buffers import (
     read_git_object_buffer_or_empty,
@@ -377,7 +377,7 @@ def _batch_source_requests(
         fallback_refspec = f"{file_metadata['batch_source_commit']}:{file_path}"
         source_path = file_metadata.get("source_path")
         primary_refspec = (
-            f"{get_batch_state_ref_name(batch_name)}:{source_path}"
+            f"{format_batch_state_ref_name(batch_name)}:{source_path}"
             if source_path
             else fallback_refspec
         )

--- a/src/git_stage_batch/batch/state/query.py
+++ b/src/git_stage_batch/batch/state/query.py
@@ -52,8 +52,6 @@ def read_batch_metadata(name: str) -> dict:
 def read_batch_metadata_for_batches(batch_names: Iterable[str]) -> dict[str, dict]:
     """Read metadata for many batches with one state-ref lookup pass."""
     unique_batch_names = list(dict.fromkeys(batch_names))
-    for batch_name in unique_batch_names:
-        validate_batch_name(batch_name)
     if not unique_batch_names:
         return {}
 

--- a/src/git_stage_batch/batch/state/reference_names.py
+++ b/src/git_stage_batch/batch/state/reference_names.py
@@ -1,6 +1,21 @@
-"""Git ref namespace constants for batch storage."""
+"""Git ref namespace constants and trusted batch-ref formatting."""
 
 GIT_STAGE_BATCH_REF_NAMESPACE = "refs/git-stage-batch"
 BATCH_CONTENT_REF_PREFIX = f"{GIT_STAGE_BATCH_REF_NAMESPACE}/batches/"
 BATCH_STATE_REF_PREFIX = f"{GIT_STAGE_BATCH_REF_NAMESPACE}/state/"
 LEGACY_BATCH_REF_PREFIX = "refs/batches/"
+
+
+def format_batch_content_ref_name(batch_name: str) -> str:
+    """Format an already-validated batch name as its authoritative content ref."""
+    return f"{BATCH_CONTENT_REF_PREFIX}{batch_name}"
+
+
+def format_batch_state_ref_name(batch_name: str) -> str:
+    """Format an already-validated batch name as its authoritative state ref."""
+    return f"{BATCH_STATE_REF_PREFIX}{batch_name}"
+
+
+def format_legacy_batch_ref_name(batch_name: str) -> str:
+    """Format an already-validated batch name as its compatibility content ref."""
+    return f"{LEGACY_BATCH_REF_PREFIX}{batch_name}"

--- a/src/git_stage_batch/batch/state/references.py
+++ b/src/git_stage_batch/batch/state/references.py
@@ -145,7 +145,7 @@ def read_batch_state_metadata_for_batches(
         return {}
 
     refspec_by_name = {
-        batch_name: f"{get_batch_state_ref_name(batch_name)}:batch.json"
+        batch_name: f"{format_batch_state_ref_name(batch_name)}:batch.json"
         for batch_name in unique_batch_names
     }
     blobs = read_git_blobs_as_bytes(refspec_by_name.values())

--- a/src/git_stage_batch/batch/state/references.py
+++ b/src/git_stage_batch/batch/state/references.py
@@ -8,7 +8,11 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Any
 
-from .reference_names import BATCH_CONTENT_REF_PREFIX, BATCH_STATE_REF_PREFIX, LEGACY_BATCH_REF_PREFIX
+from .reference_names import (
+    format_batch_content_ref_name,
+    format_batch_state_ref_name,
+    format_legacy_batch_ref_name,
+)
 from .compatibility_metadata import read_file_backed_batch_metadata_model
 from .metadata_schema import (
     BatchMetadata,
@@ -57,19 +61,19 @@ def _buffer_chunks(buffer: _StateBufferData):
 def get_batch_content_ref_name(batch_name: str) -> str:
     """Return the authoritative content ref for a batch."""
     validate_batch_name(batch_name)
-    return f"{BATCH_CONTENT_REF_PREFIX}{batch_name}"
+    return format_batch_content_ref_name(batch_name)
 
 
 def get_batch_state_ref_name(batch_name: str) -> str:
     """Return the authoritative state ref for a batch."""
     validate_batch_name(batch_name)
-    return f"{BATCH_STATE_REF_PREFIX}{batch_name}"
+    return format_batch_state_ref_name(batch_name)
 
 
 def get_legacy_batch_ref_name(batch_name: str) -> str:
     """Return the compatibility content ref for a batch."""
     validate_batch_name(batch_name)
-    return f"{LEGACY_BATCH_REF_PREFIX}{batch_name}"
+    return format_legacy_batch_ref_name(batch_name)
 
 
 def delete_batch_state_refs(batch_name: str) -> None:

--- a/tests/batch/ownership/test_model.py
+++ b/tests/batch/ownership/test_model.py
@@ -573,6 +573,20 @@ def test_supplemental_attribution_does_not_construct_a_state_ref():
     assert by_name["__consumed__"].primary_refspec == "consumed-source:test.txt"
     assert by_name["__consumed__"].fallback_refspec == "consumed-source:test.txt"
 
+    canonical_requests = attribution_module._batch_source_requests(
+        "test.txt",
+        metadata,
+        state_backed_batch_names=frozenset({"real"}),
+        batch_state_commit_by_name={"real": "canonical-state"},
+    )
+    canonical_by_name = {
+        request.batch_name: request for request in canonical_requests
+    }
+    assert canonical_by_name["real"].primary_refspec == (
+        "canonical-state:sources/test.txt"
+    )
+
+
 def test_trusted_many_batch_source_requests_do_not_revalidate_names(monkeypatch):
     """Attribution's trusted boundary must not spawn validation per batch."""
     metadata = {

--- a/tests/batch/ownership/test_model.py
+++ b/tests/batch/ownership/test_model.py
@@ -12,6 +12,7 @@ from git_stage_batch.batch.attribution import (
     AttributedUnit,
     FileAttribution,
     build_file_attribution,
+    build_file_attribution_from_lines,
 )
 from git_stage_batch.batch.attribution_units import (
     AttributionUnitKind,
@@ -535,6 +536,41 @@ def test_build_file_attribution_deduplicates_sources_deletions_and_mappings(
     assert metrics.unique_source_contents == 1
     assert metrics.mapping_computations == 1
     assert metrics.deletion_fingerprints == 1
+
+
+def test_file_attribution_from_lines_matches_repository_wrapper(temp_repo):
+    """Caller-owned buffers should drive the same attribution computation."""
+    test_file = temp_repo / "test.txt"
+    test_file.write_text("first\nsecond\n")
+    subprocess.run(["git", "add", "test.txt"], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "baseline"],
+        check=True,
+        capture_output=True,
+    )
+    test_file.write_text("first\nchanged\n")
+    wrapper_metrics = AttributionMetrics()
+    explicit_metrics = AttributionMetrics()
+
+    wrapped = build_file_attribution(
+        "test.txt",
+        batch_metadata_by_name={},
+        metrics=wrapper_metrics,
+    )
+    with (
+        read_git_object_buffer_or_empty("HEAD:test.txt") as baseline_lines,
+        load_working_tree_file_as_buffer("test.txt") as working_lines,
+    ):
+        explicit = build_file_attribution_from_lines(
+            "test.txt",
+            baseline_lines=baseline_lines,
+            working_tree_lines=working_lines,
+            batch_metadata_by_name={},
+            metrics=explicit_metrics,
+        )
+
+    assert explicit == wrapped
+    assert explicit_metrics == wrapper_metrics
 
 
 def test_build_file_attribution_is_independent_of_batch_traversal_order(temp_repo):

--- a/tests/batch/ownership/test_model.py
+++ b/tests/batch/ownership/test_model.py
@@ -7,6 +7,7 @@ import pytest
 
 import git_stage_batch.batch.attribution as attribution_module
 import git_stage_batch.batch.attribution_units as attribution_units_module
+import git_stage_batch.batch.state.references as state_references_module
 from git_stage_batch.batch.attribution import (
     AttributionMetrics,
     AttributedUnit,
@@ -536,6 +537,73 @@ def test_build_file_attribution_deduplicates_sources_deletions_and_mappings(
     assert metrics.unique_source_contents == 1
     assert metrics.mapping_computations == 1
     assert metrics.deletion_fingerprints == 1
+
+
+def test_supplemental_attribution_does_not_construct_a_state_ref():
+    """Synthetic consumed metadata must use its immutable fallback source."""
+    metadata = {
+        "real": {
+            "files": {
+                "test.txt": {
+                    "batch_source_commit": "real-source",
+                    "source_path": "sources/test.txt",
+                }
+            }
+        },
+        "__consumed__": {
+            "files": {
+                "test.txt": {
+                    "batch_source_commit": "consumed-source",
+                    "source_path": "sources/test.txt",
+                }
+            }
+        },
+    }
+
+    requests = attribution_module._batch_source_requests(
+        "test.txt",
+        metadata,
+        state_backed_batch_names=frozenset({"real"}),
+    )
+
+    by_name = {request.batch_name: request for request in requests}
+    assert by_name["real"].primary_refspec == (
+        f"{get_batch_state_ref_name('real')}:sources/test.txt"
+    )
+    assert by_name["__consumed__"].primary_refspec == "consumed-source:test.txt"
+    assert by_name["__consumed__"].fallback_refspec == "consumed-source:test.txt"
+
+def test_trusted_many_batch_source_requests_do_not_revalidate_names(monkeypatch):
+    """Attribution's trusted boundary must not spawn validation per batch."""
+    metadata = {
+        f"batch-{index:04d}": {
+            "files": {
+                "test.txt": {
+                    "batch_source_commit": "source-commit",
+                    "source_path": "sources/test.txt",
+                }
+            }
+        }
+        for index in range(1_000)
+    }
+    monkeypatch.setattr(
+        state_references_module,
+        "validate_batch_name",
+        lambda _name: (_ for _ in ()).throw(
+            AssertionError("unexpected batch-name validation")
+        ),
+    )
+
+    requests = attribution_module._batch_source_requests(
+        "test.txt",
+        metadata,
+        state_backed_batch_names=frozenset(metadata),
+    )
+
+    assert len(requests) == 1_000
+    assert requests[-1].primary_refspec == (
+        "refs/git-stage-batch/state/batch-0999:sources/test.txt"
+    )
 
 
 def test_file_attribution_from_lines_matches_repository_wrapper(temp_repo):

--- a/tests/batch/state/test_query.py
+++ b/tests/batch/state/test_query.py
@@ -4,6 +4,8 @@ import subprocess
 
 import pytest
 
+import git_stage_batch.batch.state.query as query_module
+import git_stage_batch.batch.state.references as state_refs_module
 from git_stage_batch.batch.state.query import (
     get_batch_baseline_commit,
     get_batch_commit_sha,
@@ -17,6 +19,7 @@ from git_stage_batch.batch.state.lifecycle import create_batch
 from git_stage_batch.batch.text_file_storage import add_file_to_batch
 from git_stage_batch.batch.ownership.model import BatchOwnership
 from git_stage_batch.data.session import initialize_abort_state
+from git_stage_batch.exceptions import CommandError
 from git_stage_batch.utils.paths import get_batch_metadata_file_path, ensure_state_directory_exists
 
 
@@ -93,6 +96,56 @@ def test_read_batch_metadata_for_batches_returns_empty_for_missing_batch(temp_gi
     metadata_by_name = read_batch_metadata_for_batches(["missing"])
 
     assert metadata_by_name["missing"] == read_batch_metadata("missing")
+
+
+def test_bulk_metadata_validates_each_unique_name_once(monkeypatch):
+    """Bulk query boundaries should not revalidate names in lower layers."""
+    names = [f"batch-{index:04d}" for index in range(1_000)]
+    validation_calls = []
+
+    monkeypatch.setattr(
+        state_refs_module,
+        "validate_batch_name",
+        validation_calls.append,
+    )
+    monkeypatch.setattr(
+        state_refs_module,
+        "read_git_blobs_as_bytes",
+        lambda _refspecs: {},
+    )
+    monkeypatch.setattr(
+        query_module,
+        "_read_file_backed_batch_metadata_or_empty",
+        lambda _name: {"files": {}},
+    )
+
+    metadata = read_batch_metadata_for_batches([*names, *names[:10]])
+
+    assert list(metadata) == names
+    assert validation_calls == names
+
+
+def test_bulk_metadata_rejects_invalid_name_before_state_or_fallback_reads(
+    monkeypatch,
+):
+    """The public state reader remains the validation boundary for queries."""
+    monkeypatch.setattr(
+        state_refs_module,
+        "read_git_blobs_as_bytes",
+        lambda _refspecs: (_ for _ in ()).throw(
+            AssertionError("unexpected state read")
+        ),
+    )
+    monkeypatch.setattr(
+        query_module,
+        "_read_file_backed_batch_metadata_or_empty",
+        lambda _name: (_ for _ in ()).throw(
+            AssertionError("unexpected fallback read")
+        ),
+    )
+
+    with pytest.raises(CommandError):
+        read_batch_metadata_for_batches(["valid", "invalid/name"])
 
 
 def test_get_batch_commit_sha_existing(temp_git_repo):

--- a/tests/batch/state/test_references.py
+++ b/tests/batch/state/test_references.py
@@ -12,13 +12,19 @@ from git_stage_batch.batch.ownership.model import BatchOwnership
 import git_stage_batch.batch.state.references as state_refs_module
 from git_stage_batch.batch.state.references import (
     get_batch_content_ref_name,
+    get_legacy_batch_ref_name,
     get_batch_state_ref_name,
     read_batch_state_metadata_for_batches,
     sync_batch_state_refs,
 )
+from git_stage_batch.batch.state.reference_names import (
+    format_batch_content_ref_name,
+    format_batch_state_ref_name,
+    format_legacy_batch_ref_name,
+)
 from git_stage_batch.batch.text_file_storage import add_file_to_batch
 from git_stage_batch.data.session import initialize_abort_state
-from git_stage_batch.exceptions import BatchMetadataError
+from git_stage_batch.exceptions import BatchMetadataError, CommandError
 from git_stage_batch.utils.paths import ensure_state_directory_exists
 
 
@@ -57,6 +63,33 @@ def _git_rev_parse(refname: str) -> str:
         capture_output=True,
         text=True,
     ).stdout.strip()
+
+
+@pytest.mark.parametrize("batch_name", ["ordinary", "café", "release-2026.07"])
+def test_validated_ref_wrappers_match_pure_formatters(temp_git_repo, batch_name):
+    """Trusted formatters must preserve every established ref namespace."""
+    assert get_batch_content_ref_name(batch_name) == format_batch_content_ref_name(
+        batch_name
+    )
+    assert get_batch_state_ref_name(batch_name) == format_batch_state_ref_name(
+        batch_name
+    )
+    assert get_legacy_batch_ref_name(batch_name) == format_legacy_batch_ref_name(
+        batch_name
+    )
+
+
+@pytest.mark.parametrize(
+    "formatter",
+    (
+        get_batch_content_ref_name,
+        get_batch_state_ref_name,
+        get_legacy_batch_ref_name,
+    ),
+)
+def test_validated_ref_wrappers_still_reject_invalid_names(temp_git_repo, formatter):
+    with pytest.raises(CommandError, match="Git ref naming rules"):
+        formatter("invalid^name")
 
 
 def test_state_ref_contains_batch_json_and_source_snapshot(temp_git_repo):


### PR DESCRIPTION
Bulk state reads discover trusted batch names, while attribution combines canonical state commits with optional supplemental metadata.

Repeated name validation and ref construction add avoidable work at those trusted boundaries, and repository-owned line storage prevents callers from retaining prepared inputs. Supplemental metadata also needs to remain distinct from authoritative state refs when it overrides a primary source.

This pull request validates each unique batch name once in the public bulk reader, formats already-trusted refs directly, accepts caller-owned attribution lines, and resolves primary sources through captured canonical state commits. Supplemental sources stay off state refs, and overridden names are removed from the state-backed set.

Coverage pins single-pass validation, trusted high-count ref formatting, caller-owned input parity, canonical source selection, and supplemental override behavior. The resulting attribution boundary is ready for reusable live-change preparation.