### PR TITLE
data: Reuse prepared live changes across consumers

### DIFF
--- a/scripts/benchmark_matching.py
+++ b/scripts/benchmark_matching.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 """Benchmark public matching and ownership-attribution workflows."""
 
+# The script makes the repository source tree importable before project imports.
+# ruff: noqa: E402
+
 from __future__ import annotations
 
 import argparse
@@ -41,7 +44,7 @@ from git_stage_batch.batch.attribution_units import (
 )
 from git_stage_batch.batch.line_matching.line_mapping import LineMapping
 from git_stage_batch.batch.line_matching.match import match_lines
-from git_stage_batch.batch.state.references import get_batch_state_ref_name
+from git_stage_batch.batch.state.reference_names import format_batch_state_ref_name
 from git_stage_batch.core.buffer import LineBuffer
 from git_stage_batch.utils.git_object_io import resolve_git_objects
 from git_stage_batch.utils.repository_buffers import (
@@ -129,6 +132,21 @@ class _ClaimAttributionState:
 
     fixture: AttributionFixture
     attribution: FileAttribution | None = None
+
+
+@dataclass(frozen=True)
+class _FileWorkloadState:
+    """One repeated file/hunk matching workload."""
+
+    fixture: MatchingFixture
+    file_count: int
+    hunks_per_file: int
+    reuse_mapping: bool
+
+
+@dataclass
+class _GitProcessCounter:
+    count: int = 0
 
 
 CASES = (
@@ -310,6 +328,54 @@ def _summary(values: Sequence[float | int]) -> dict[str, float]:
     }
 
 
+def _command_is_git(arguments: object) -> bool:
+    if not isinstance(arguments, (list, tuple)) or not arguments:
+        return False
+    executable = arguments[0]
+    return isinstance(executable, (str, bytes, os.PathLike)) and (
+        os.path.basename(os.fsdecode(executable)) == "git"
+    )
+
+
+@contextmanager
+def _count_git_processes():
+    """Count Git children launched through subprocess or the POSIX runner."""
+    counter = _GitProcessCounter()
+    original_popen = subprocess.Popen
+    original_posix_spawn = os.posix_spawn
+
+    def counting_popen(*args, **kwargs):
+        arguments = args[0] if args else kwargs.get("args")
+        if _command_is_git(arguments):
+            counter.count += 1
+        return original_popen(*args, **kwargs)
+
+    def counting_posix_spawn(path, argv, env, **kwargs):
+        if _command_is_git(argv):
+            counter.count += 1
+        return original_posix_spawn(path, argv, env, **kwargs)
+
+    subprocess.Popen = counting_popen
+    os.posix_spawn = counting_posix_spawn
+    try:
+        yield counter
+    finally:
+        subprocess.Popen = original_popen
+        os.posix_spawn = original_posix_spawn
+
+
+def _peak_parent_rss_bytes() -> int:
+    """Return the Linux process high-water RSS, or zero when unavailable."""
+    try:
+        with open("/proc/self/status", encoding="ascii") as status_file:
+            for line in status_file:
+                if line.startswith("VmHWM:"):
+                    return int(line.split()[1]) * 1024
+    except (OSError, ValueError):
+        pass
+    return 0
+
+
 def _measure_phase(
     prepare: Callable[[], _StateT],
     operation: Callable[[_StateT], dict[str, Any]],
@@ -336,17 +402,23 @@ def _measure_phase(
             raise RuntimeError("benchmark phase produced inconsistent results")
 
     timing_samples = []
+    git_process_samples = []
+    parent_rss_samples = []
     for _ in range(repeats):
         state = prepare()
         try:
             gc.collect()
-            started = time.perf_counter()
-            result = operation(state)
-            elapsed = time.perf_counter() - started
+            with _count_git_processes() as process_counter:
+                started = time.perf_counter()
+                result = operation(state)
+                elapsed = time.perf_counter() - started
+            parent_rss = _peak_parent_rss_bytes()
         finally:
             cleanup(state)
         observe_result(result)
         timing_samples.append(elapsed)
+        git_process_samples.append(process_counter.count)
+        parent_rss_samples.append(parent_rss)
 
     memory_samples = []
     for _ in range(min(repeats, 3)):
@@ -370,9 +442,15 @@ def _measure_phase(
     return {
         "seconds": _summary(timing_samples),
         "tracemalloc_peak_bytes": _summary(memory_samples),
+        "git_subprocesses": _summary(git_process_samples),
+        "parent_peak_rss_bytes": _summary(parent_rss_samples),
+        "child_peak_rss_bytes": _summary([0 for _ in timing_samples]),
         "samples": {
             "seconds": timing_samples,
             "tracemalloc_peak_bytes": memory_samples,
+            "git_subprocesses": git_process_samples,
+            "parent_peak_rss_bytes": parent_rss_samples,
+            "child_peak_rss_bytes": [0 for _ in timing_samples],
         },
         "result": expected_result or {},
     }
@@ -434,6 +512,30 @@ def _measure_mapping(state: _MappingState) -> dict[str, Any]:
     }
 
 
+def _measure_file_workload(state: _FileWorkloadState) -> dict[str, Any]:
+    mapping_computations = 0
+    mapped_lines = 0
+    for _file_index in range(state.file_count):
+        mapping_state = _open_matching_buffers(state.fixture)
+        try:
+            computation_count = 1 if state.reuse_mapping else state.hunks_per_file
+            for _hunk_index in range(computation_count):
+                with match_lines(
+                    mapping_state.source,
+                    mapping_state.target,
+                ) as mapping:
+                    mapped_lines += sum(1 for _ in mapping.mapped_line_pairs())
+                mapping_computations += 1
+        finally:
+            _close_mapping(mapping_state)
+    return {
+        "files": state.file_count,
+        "logical_hunks": state.file_count * state.hunks_per_file,
+        "mapping_computations": mapping_computations,
+        "mapped_lines": mapped_lines,
+    }
+
+
 def _prepare_unit_enumeration(
     fixture: MatchingFixture,
 ) -> _UnitEnumerationState:
@@ -483,6 +585,8 @@ def run_matching_case(
     *,
     warmups: int,
     repeats: int,
+    file_count: int = 1,
+    hunks_per_file: int = 1,
 ) -> dict[str, Any]:
     """Run one text case with setup excluded from all measured phases."""
     fixture = build_matching_fixture(case.name, size, seed)
@@ -497,6 +601,8 @@ def run_matching_case(
         "chunk_size_bytes": FIXTURE_CHUNK_SIZE,
         "source_sha256": _chunks_sha256(fixture.source_chunks),
         "target_sha256": _chunks_sha256(fixture.target_chunks),
+        "files": file_count,
+        "hunks_per_file": hunks_per_file,
     }
     if case.kind == "binary":
         contains_nul = any(b"\0" in chunk for chunk in fixture.source_chunks)
@@ -533,6 +639,30 @@ def run_matching_case(
             warmups=warmups,
             repeats=repeats,
         ),
+        "per_hunk_mapping": _measure_phase(
+            lambda: _FileWorkloadState(
+                fixture,
+                file_count,
+                hunks_per_file,
+                False,
+            ),
+            _measure_file_workload,
+            lambda _state: None,
+            warmups=warmups,
+            repeats=repeats,
+        ),
+        "reused_file_mapping": _measure_phase(
+            lambda: _FileWorkloadState(
+                fixture,
+                file_count,
+                hunks_per_file,
+                True,
+            ),
+            _measure_file_workload,
+            lambda _state: None,
+            warmups=warmups,
+            repeats=repeats,
+        ),
     }
     return {
         "name": case.name,
@@ -561,8 +691,8 @@ def _git(repo: Path, *arguments: str, input_text: str | None = None) -> str:
 
 
 def _build_attribution_fixture(repo: Path, batch_count: int) -> AttributionFixture:
-    if batch_count <= 0:
-        raise ValueError("batch count must be positive")
+    if batch_count < 0:
+        raise ValueError("batch count must be non-negative")
     file_path = "benchmark.txt"
     line_count = 300
     baseline = _unique_lines("baseline", line_count)
@@ -635,19 +765,20 @@ def _build_attribution_fixture(repo: Path, batch_count: int) -> AttributionFixtu
         )
         for name in batch_names
     }
-    _git(
-        repo,
-        "update-ref",
-        "--stdin",
-        input_text="".join(
-            f"update {get_batch_state_ref_name(name)} {state_commits[name]}\n"
-            for name in batch_names
-        ),
-    )
+    if batch_names:
+        _git(
+            repo,
+            "update-ref",
+            "--stdin",
+            input_text="".join(
+                f"update {format_batch_state_ref_name(name)} {state_commits[name]}\n"
+                for name in batch_names
+            ),
+        )
     object_names = tuple(
         [
             *(
-                f"{get_batch_state_ref_name(name)}:sources/{file_path}"
+                f"{format_batch_state_ref_name(name)}:sources/{file_path}"
                 for name in batch_names
             ),
             fallback,
@@ -699,12 +830,7 @@ def _measure_blob_loading(fixture: AttributionFixture) -> dict[str, Any]:
 def _open_repository_buffers(
     fixture: AttributionFixture,
 ) -> _MappingState:
-    source = read_git_object_buffer_or_empty(
-        next(iter(fixture.metadata.values()))["files"][fixture.file_path][
-            "batch_source_commit"
-        ]
-        + f":{fixture.file_path}"
-    )
+    source = read_git_object_buffer_or_empty(fixture.source_object_ids[0])
     working: LineBuffer | None = None
     try:
         working = load_working_tree_file_as_buffer(fixture.file_path)
@@ -927,6 +1053,10 @@ def run_suite(
     seed: int = DEFAULT_SEED,
     warmups: int = 1,
     repeats: int = 3,
+    file_count: int = 1,
+    hunks_per_file: int = 1,
+    matching_size: int | None = None,
+    batch_count: int | None = None,
 ) -> dict[str, Any]:
     """Run selected deterministic cases and return the stable JSON schema."""
     if mode not in {"quick", "full"}:
@@ -935,12 +1065,28 @@ def run_suite(
         raise ValueError("warmups must be non-negative")
     if repeats <= 0:
         raise ValueError("repeats must be positive")
+    if file_count not in {1, 2, 4, 8, 16}:
+        raise ValueError("file_count must be one of 1, 2, 4, 8, or 16")
+    if hunks_per_file not in {1, 8}:
+        raise ValueError("hunks_per_file must be 1 or 8")
+    if matching_size is not None and matching_size <= 0:
+        raise ValueError("matching_size must be positive")
+    if batch_count is not None and batch_count not in {0, 1, 50, 1_000}:
+        raise ValueError("batch_count must be one of 0, 1, 50, or 1000")
 
     results = []
     for case in selected_cases(mode, case_names):
-        size = case.quick_size if mode == "quick" else case.full_size
+        default_size = case.quick_size if mode == "quick" else case.full_size
+        size = (
+            batch_count
+            if case.kind == "attribution" and batch_count is not None
+            else matching_size
+            if case.kind != "attribution" and matching_size is not None
+            else default_size
+        )
         if size is None or size <= 0:
-            continue
+            if case.kind != "attribution" or size != 0:
+                continue
         if case.kind == "attribution":
             result = run_attribution_case(
                 case,
@@ -956,6 +1102,8 @@ def run_suite(
                 seed,
                 warmups=warmups,
                 repeats=repeats,
+                file_count=file_count,
+                hunks_per_file=hunks_per_file,
             )
         results.append(result)
 
@@ -1137,6 +1285,30 @@ def _write_report(report: dict[str, Any], output: Path | None) -> None:
     sys.stdout.write(rendered)
 
 
+def _write_short_table(report: dict[str, Any]) -> None:
+    """Write a concise human-readable phase table beside JSON output."""
+    rows = []
+    for case in report.get("cases", []):
+        for phase_name, phase in case.get("phases", {}).items():
+            rows.append(
+                (
+                    case["name"],
+                    phase_name,
+                    phase["seconds"]["median"],
+                    phase["git_subprocesses"]["median"],
+                    phase["parent_peak_rss_bytes"]["median"] / (1024 * 1024),
+                )
+            )
+    if not rows:
+        return
+    sys.stderr.write("case phase seconds git parent-rss-mib\n")
+    for case_name, phase_name, seconds, git_count, rss_mib in rows:
+        sys.stderr.write(
+            f"{case_name} {phase_name} {seconds:.6f} "
+            f"{git_count:.0f} {rss_mib:.1f}\n"
+        )
+
+
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--mode", choices=("quick", "full"), default="quick")
@@ -1150,6 +1322,20 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--seed", type=int, default=DEFAULT_SEED)
     parser.add_argument("--warmups", type=int)
     parser.add_argument("--repeats", type=int)
+    parser.add_argument("--files", type=int, choices=(1, 2, 4, 8, 16), default=1)
+    parser.add_argument("--hunks-per-file", type=int, choices=(1, 8), default=1)
+    parser.add_argument(
+        "--matching-size",
+        type=int,
+        help="override text-case lines (use 300, 10000, or 50000 for the matrix)",
+    )
+    parser.add_argument(
+        "--batches",
+        type=int,
+        choices=(0, 1, 50, 1_000),
+        help="override attribution batch count",
+    )
+    parser.add_argument("--no-table", action="store_true")
     parser.add_argument("--output", type=Path)
     parser.add_argument(
         "--compare",
@@ -1212,11 +1398,17 @@ def main() -> None:
             seed=args.seed,
             warmups=warmups,
             repeats=repeats,
+            file_count=args.files,
+            hunks_per_file=args.hunks_per_file,
+            matching_size=args.matching_size,
+            batch_count=args.batches,
         )
     except ValueError as error:
         parser.error(str(error))
     try:
         _write_report(report, args.output)
+        if not args.no_table:
+            _write_short_table(report)
     except OSError as error:
         parser.error(str(error))
 

--- a/src/git_stage_batch/batch/source/annotation.py
+++ b/src/git_stage_batch/batch/source/annotation.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
 
 from ...core.models import LineEntry, LineLevelChange
 from ...utils.git_repository import get_git_repository_root_path
@@ -77,6 +78,42 @@ def _apply_batch_source_mapping(
         header=line_changes.header,
         lines=new_lines,
     )
+
+
+def annotate_with_batch_source_mapping(
+    line_changes: LineLevelChange,
+    mapping: LineMapping | None,
+) -> LineLevelChange:
+    """Annotate one hunk from a reusable batch-source mapping."""
+    if mapping is None:
+        return _fill_source_from_working_tree(line_changes)
+    return _apply_batch_source_mapping(line_changes, mapping)
+
+
+@contextmanager
+def acquire_batch_source_mapping(
+    path_value: str,
+    *,
+    batch_source_commit: str | None,
+    working_lines: Sequence[bytes],
+) -> Iterator[LineMapping | None]:
+    """Acquire one reusable source-to-working mapping for a repository file."""
+    if not batch_source_commit:
+        yield None
+        return
+
+    batch_source_buffer = read_git_object_buffer_or_none(
+        f"{batch_source_commit}:{path_value}"
+    )
+    if batch_source_buffer is None:
+        yield None
+        return
+
+    with (
+        batch_source_buffer as batch_source_lines,
+        match_lines(batch_source_lines, working_lines) as mapping,
+    ):
+        yield mapping
 
 
 def _fill_source_from_working_tree(line_changes: LineLevelChange) -> LineLevelChange:
@@ -165,21 +202,12 @@ def annotate_with_batch_source_working_lines(
 ) -> LineLevelChange:
     """Annotate LineLevelChange with indexed working content lines."""
     batch_source_commit = get_batch_source_for_file(path_value)
-    if not batch_source_commit:
-        return _fill_source_from_working_tree(line_changes)
-
-    batch_source_buffer = read_git_object_buffer_or_none(
-        f"{batch_source_commit}:{path_value}"
-    )
-    if batch_source_buffer is None:
-        return _fill_source_from_working_tree(line_changes)
-
-    with batch_source_buffer as batch_source_lines:
-        return annotate_with_batch_source_lines(
-            line_changes,
-            batch_source_lines=batch_source_lines,
-            working_lines=working_lines,
-        )
+    with acquire_batch_source_mapping(
+        path_value,
+        batch_source_commit=batch_source_commit,
+        working_lines=working_lines,
+    ) as mapping:
+        return annotate_with_batch_source_mapping(line_changes, mapping)
 
 
 def annotate_with_batch_source_lines(
@@ -190,4 +218,4 @@ def annotate_with_batch_source_lines(
 ) -> LineLevelChange:
     """Annotate LineLevelChange from indexed batch-source and working lines."""
     with match_lines(batch_source_lines, working_lines) as mapping:
-        return _apply_batch_source_mapping(line_changes, mapping)
+        return annotate_with_batch_source_mapping(line_changes, mapping)

--- a/src/git_stage_batch/commands/selection/next_change_display.py
+++ b/src/git_stage_batch/commands/selection/next_change_display.py
@@ -14,7 +14,7 @@ from ...core.models import (
 from ...data.file_review.state import clear_last_file_review_state
 from ...data.live_change_candidates import (
     EligibleLiveChange,
-    iter_eligible_live_changes,
+    next_eligible_live_change,
 )
 from ...data.selected_change.file_changes import (
     cache_binary_file_change,
@@ -86,18 +86,19 @@ def show_next_unprocessed_change(
     """Show the first live change accepted by the shared eligibility policy."""
     preview_state = snapshot_selected_change_state() if not selectable else None
     try:
-        candidate = next(iter_eligible_live_changes(), None)
+        candidate = next_eligible_live_change()
         if candidate is None:
             if porcelain:
                 sys.exit(1)
             print(_("No more hunks to process."), file=sys.stderr)
             return
 
-        _cache_candidate(candidate)
-        if selectable:
-            clear_last_file_review_state()
-        if not porcelain:
-            _print_candidate(candidate, selectable=selectable)
+        with candidate:
+            _cache_candidate(candidate)
+            if selectable:
+                clear_last_file_review_state()
+            if not porcelain:
+                _print_candidate(candidate, selectable=selectable)
     finally:
         if preview_state is not None:
             restore_selected_change_state(preview_state)

--- a/src/git_stage_batch/data/consumed_replacement_masks.py
+++ b/src/git_stage_batch/data/consumed_replacement_masks.py
@@ -11,6 +11,18 @@ def filter_consumed_replacement_masks(
 ) -> LineLevelChange | None:
     """Hide synthetic replacement runs created by `include --line --as`."""
     file_metadata = read_consumed_file_metadata(line_changes.path)
+    return filter_consumed_replacement_masks_with_metadata(
+        line_changes,
+        file_metadata=file_metadata,
+    )
+
+
+def filter_consumed_replacement_masks_with_metadata(
+    line_changes: LineLevelChange,
+    *,
+    file_metadata: dict | None,
+) -> LineLevelChange | None:
+    """Hide replacement runs using caller-supplied consumed metadata."""
     replacement_masks = (
         file_metadata.get("replacement_masks", []) if file_metadata else []
     )

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -21,7 +21,7 @@ from .selected_change import store as _selected_store
 from .selected_change.lifecycle import (
     clear_selected_change_state_files as _clear_selected_change_state_files,
 )
-from .live_change_candidates import iter_eligible_live_changes
+from .live_change_candidates import next_eligible_live_change
 
 
 class _BatchMetadataSnapshot:
@@ -63,26 +63,27 @@ def fetch_next_change() -> Union[
     Raises:
         NoMoreHunks: When there are no more items to process.
     """
-    candidate = next(iter_eligible_live_changes(), None)
+    candidate = next_eligible_live_change()
     if candidate is not None:
-        item = candidate.change
-        if isinstance(item, FileModeChange):
-            _selected_file_changes.cache_mode_change(item)
-        elif isinstance(item, RenameChange):
-            _selected_file_changes.cache_rename_change(item)
-        elif isinstance(item, TextFileDeletionChange):
-            _selected_file_changes.cache_text_deletion_change(item)
-        elif isinstance(item, GitlinkChange):
-            _selected_file_changes.cache_gitlink_change(item)
-        elif isinstance(item, BinaryFileChange):
-            _selected_file_changes.cache_binary_file_change(item)
-        else:
-            _selected_store.cache_hunk_change(
-                candidate.raw_patch.lines,
-                candidate.stable_hash,
-                item,
-            )
-        return item
+        with candidate:
+            item = candidate.change
+            if isinstance(item, FileModeChange):
+                _selected_file_changes.cache_mode_change(item)
+            elif isinstance(item, RenameChange):
+                _selected_file_changes.cache_rename_change(item)
+            elif isinstance(item, TextFileDeletionChange):
+                _selected_file_changes.cache_text_deletion_change(item)
+            elif isinstance(item, GitlinkChange):
+                _selected_file_changes.cache_gitlink_change(item)
+            elif isinstance(item, BinaryFileChange):
+                _selected_file_changes.cache_binary_file_change(item)
+            else:
+                _selected_store.cache_hunk_change(
+                    candidate.raw_patch.lines,
+                    candidate.stable_hash,
+                    item,
+                )
+            return item
 
     # No more items to process
     raise NoMoreHunks()

--- a/src/git_stage_batch/data/live_change_candidates.py
+++ b/src/git_stage_batch/data/live_change_candidates.py
@@ -196,3 +196,14 @@ def iter_eligible_live_changes() -> Iterator[EligibleLiveChange]:
             candidate, _reason = prepare_live_change(item, context)
             if candidate is not None:
                 yield candidate
+
+
+def next_eligible_live_change() -> EligibleLiveChange | None:
+    """Return one owned candidate and explicitly close its lazy diff scan."""
+    candidates = iter_eligible_live_changes()
+    try:
+        return next(candidates, None)
+    finally:
+        close = getattr(candidates, "close", None)
+        if close is not None:
+            close()

--- a/src/git_stage_batch/data/live_change_candidates.py
+++ b/src/git_stage_batch/data/live_change_candidates.py
@@ -181,7 +181,7 @@ def prepare_live_change(
     return EligibleLiveChange(change, stable_hash, raw_patch), None
 
 
-def iter_eligible_live_changes() -> Iterator[EligibleLiveChange]:
+def stream_eligible_live_changes() -> Iterator[EligibleLiveChange]:
     """Stream all actionable live changes using one shared policy snapshot."""
     context = LiveChangeScanContext()
     with acquire_unified_diff(
@@ -200,7 +200,7 @@ def iter_eligible_live_changes() -> Iterator[EligibleLiveChange]:
 
 def next_eligible_live_change() -> EligibleLiveChange | None:
     """Return one owned candidate and explicitly close its lazy diff scan."""
-    candidates = iter_eligible_live_changes()
+    candidates = stream_eligible_live_changes()
     try:
         return next(candidates, None)
     finally:

--- a/src/git_stage_batch/data/live_change_candidates.py
+++ b/src/git_stage_batch/data/live_change_candidates.py
@@ -9,6 +9,7 @@ from typing import Iterator
 from ..batch.state.query import list_batch_names, read_batch_metadata_for_batches
 from ..batch.source.annotation import annotate_with_batch_source
 from ..core.diff_parser import acquire_unified_diff, build_line_changes_from_patch_lines
+from ..core.buffer import LineBuffer
 from ..core.hashing import (
     compute_binary_file_hash,
     compute_file_mode_change_hash,
@@ -67,6 +68,20 @@ class EligibleLiveChange:
     change: LiveChange
     stable_hash: str
     raw_patch: object
+
+    def close(self) -> None:
+        """Close raw patch storage owned by this prepared candidate."""
+        if isinstance(self.raw_patch, SingleHunkPatch) and isinstance(
+            self.raw_patch.lines,
+            LineBuffer,
+        ):
+            self.raw_patch.lines.close()
+
+    def __enter__(self) -> EligibleLiveChange:
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        self.close()
 
 
 class LiveChangeScanContext:
@@ -150,11 +165,19 @@ def prepare_live_change(
         is_path_blocked(path, context.blocked_paths) for path in _paths_for_item(item)
     ):
         return None, SkipReason.BLOCKED_PATH
-    raw_patch = (
-        SingleHunkPatch(item.old_path, item.new_path, tuple(item.lines))
-        if isinstance(item, SingleHunkPatch)
-        else item
-    )
+    if isinstance(item, SingleHunkPatch):
+        owned_patch_lines = (
+            item.lines.clone()
+            if isinstance(item.lines, LineBuffer)
+            else LineBuffer.from_chunks(item.lines)
+        )
+        raw_patch = SingleHunkPatch(
+            item.old_path,
+            item.new_path,
+            owned_patch_lines,
+        )
+    else:
+        raw_patch = item
     return EligibleLiveChange(change, stable_hash, raw_patch), None
 
 

--- a/src/git_stage_batch/data/remaining_hunks.py
+++ b/src/git_stage_batch/data/remaining_hunks.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-from .live_change_candidates import iter_eligible_live_changes
+from .live_change_candidates import stream_eligible_live_changes
 
 
 def estimate_remaining_hunks() -> int:
     """Estimate the number of live hunks not yet included, skipped, or discarded."""
     count = 0
-    for candidate in iter_eligible_live_changes():
+    for candidate in stream_eligible_live_changes():
         with candidate:
             count += 1
     return count

--- a/src/git_stage_batch/data/remaining_hunks.py
+++ b/src/git_stage_batch/data/remaining_hunks.py
@@ -7,4 +7,8 @@ from .live_change_candidates import iter_eligible_live_changes
 
 def estimate_remaining_hunks() -> int:
     """Estimate the number of live hunks not yet included, skipped, or discarded."""
-    return sum(1 for _candidate in iter_eligible_live_changes())
+    count = 0
+    for candidate in iter_eligible_live_changes():
+        with candidate:
+            count += 1
+    return count

--- a/src/git_stage_batch/data/selected_change/hunk_filtering.py
+++ b/src/git_stage_batch/data/selected_change/hunk_filtering.py
@@ -5,8 +5,14 @@ from __future__ import annotations
 import json
 from dataclasses import asdict
 
-from ...batch.attribution import AttributionMetrics, build_file_attribution
+from ...batch.attribution import (
+    AttributionMetrics,
+    FileAttribution,
+    build_file_attribution,
+)
 from ...batch.attribution_projection import filter_owned_diff_fragments
+from ...batch.state.query import list_batch_names, read_batch_metadata_for_batches
+from ...core.models import LineLevelChange
 from ...utils.file_io import write_text_file_contents
 from ...utils.journal import log_journal
 from ...utils.paths import get_line_changes_json_file_path
@@ -56,27 +62,29 @@ def apply_line_level_batch_filter_to_cached_hunk(
 
 
 def filter_line_level_change_for_batches(
-    line_changes,
+    line_changes: LineLevelChange,
     *,
     batch_metadata_by_name: dict[str, dict] | None = None,
-):
+) -> LineLevelChange | None:
     """Return the unowned portion of a live line change, or ``None``."""
     file_path = line_changes.path
-
-    if (
-        not line_changes.lines
-        and _change_freshness.empty_text_lifecycle_change_is_batched(
-            file_path,
-            batch_metadata_by_name=batch_metadata_by_name,
-        )
+    if batch_metadata_by_name is None:
+        batch_metadata_by_name = read_batch_metadata_for_batches(list_batch_names())
+    if _empty_lifecycle_change_is_batched(
+        line_changes,
+        batch_metadata_by_name=batch_metadata_by_name,
     ):
         return None
+    consumed_file_metadata = read_consumed_file_metadata(file_path)
 
     attribution_metrics = AttributionMetrics()
     attribution = build_file_attribution(
         file_path,
         batch_metadata_by_name=batch_metadata_by_name,
-        supplemental_batch_metadata=_consumed_batch_metadata(file_path),
+        supplemental_batch_metadata=_consumed_batch_metadata(
+            file_path,
+            consumed_file_metadata,
+        ),
         metrics=attribution_metrics,
     )
     log_journal(
@@ -84,23 +92,72 @@ def filter_line_level_change_for_batches(
         file_path=file_path,
         **asdict(attribution_metrics),
     )
-    should_skip, filtered_line_changes = filter_owned_diff_fragments(
-        line_changes, attribution
+    return _filter_line_level_change_with_prepared_resources(
+        line_changes,
+        attribution=attribution,
+        consumed_file_metadata=consumed_file_metadata,
     )
 
+
+def filter_line_level_change_with_attribution(
+    line_changes: LineLevelChange,
+    *,
+    attribution: FileAttribution,
+    batch_metadata_by_name: dict[str, dict],
+    consumed_file_metadata: dict | None,
+) -> LineLevelChange | None:
+    """Filter one hunk from caller-supplied file attribution and metadata."""
+    if _empty_lifecycle_change_is_batched(
+        line_changes,
+        batch_metadata_by_name=batch_metadata_by_name,
+    ):
+        return None
+
+    return _filter_line_level_change_with_prepared_resources(
+        line_changes,
+        attribution=attribution,
+        consumed_file_metadata=consumed_file_metadata,
+    )
+
+
+def _empty_lifecycle_change_is_batched(
+    line_changes: LineLevelChange,
+    *,
+    batch_metadata_by_name: dict[str, dict],
+) -> bool:
+    return not line_changes.lines and (
+        _change_freshness.empty_text_lifecycle_change_is_batched(
+            line_changes.path,
+            batch_metadata_by_name=batch_metadata_by_name,
+        )
+    )
+
+
+def _filter_line_level_change_with_prepared_resources(
+    line_changes: LineLevelChange,
+    *,
+    attribution: FileAttribution,
+    consumed_file_metadata: dict | None,
+) -> LineLevelChange | None:
+    """Project attribution and replacement masks without repository I/O."""
+
+    should_skip, filtered_line_changes = filter_owned_diff_fragments(
+        line_changes,
+        attribution,
+    )
     if should_skip:
         return None
 
-    filtered_line_changes = (
-        _consumed_replacement_masks.filter_consumed_replacement_masks(
-            filtered_line_changes
-        )
+    return _consumed_replacement_masks.filter_consumed_replacement_masks_with_metadata(
+        filtered_line_changes,
+        file_metadata=consumed_file_metadata,
     )
-    return filtered_line_changes
 
 
-def _consumed_batch_metadata(file_path: str) -> dict[str, dict] | None:
-    consumed_file_metadata = read_consumed_file_metadata(file_path)
+def _consumed_batch_metadata(
+    file_path: str,
+    consumed_file_metadata: dict | None,
+) -> dict[str, dict] | None:
     if consumed_file_metadata is None:
         return None
     return {

--- a/tests/architecture/test_seam_rules.py
+++ b/tests/architecture/test_seam_rules.py
@@ -14,7 +14,7 @@ def test_live_change_policy_has_one_owner():
     """Hashing, blocking, and batch ownership policy belongs to candidates."""
     policy_symbols = {
         "prepare_live_change",
-        "iter_eligible_live_changes",
+        "stream_eligible_live_changes",
     }
     assert modules_defining(policy_symbols) == {
         "git_stage_batch.data.live_change_candidates": policy_symbols,

--- a/tests/batch/line_matching/test_benchmark.py
+++ b/tests/batch/line_matching/test_benchmark.py
@@ -79,17 +79,25 @@ def test_smallest_case_smokes_public_apis_and_stable_schema():
     assert set(case["phases"]) == {
         "buffer_loading",
         "mapping",
+        "per_hunk_mapping",
+        "reused_file_mapping",
         "unit_attribution",
     }
     for phase in case["phases"].values():
         assert set(phase) == {
             "seconds",
             "tracemalloc_peak_bytes",
+            "git_subprocesses",
+            "parent_peak_rss_bytes",
+            "child_peak_rss_bytes",
             "samples",
             "result",
         }
         assert len(phase["samples"]["seconds"]) == 1
         assert len(phase["samples"]["tracemalloc_peak_bytes"]) == 1
+        assert len(phase["samples"]["git_subprocesses"]) == 1
+        assert len(phase["samples"]["parent_peak_rss_bytes"]) == 1
+        assert phase["samples"]["child_peak_rss_bytes"] == [0]
 
 
 @pytest.mark.parametrize(
@@ -147,6 +155,44 @@ def test_attribution_case_exercises_many_claims_and_deduplicates_work():
         "resolved": 51,
         "unique_object_ids": 1,
     }
+
+
+def test_file_workload_covers_supported_file_and_hunk_dimensions():
+    report = benchmark_matching.run_suite(
+        "quick",
+        case_names=["small-interactive"],
+        warmups=0,
+        repeats=1,
+        file_count=2,
+        hunks_per_file=8,
+        matching_size=20,
+    )
+
+    phases = report["cases"][0]["phases"]
+    assert phases["per_hunk_mapping"]["result"]["mapping_computations"] == 16
+    assert phases["reused_file_mapping"]["result"]["mapping_computations"] == 2
+    assert report["cases"][0]["dimensions"]["files"] == 2
+    assert report["cases"][0]["dimensions"]["hunks_per_file"] == 8
+
+
+def test_attribution_workload_accepts_zero_batches():
+    report = benchmark_matching.run_suite(
+        "quick",
+        case_names=["many-batches"],
+        warmups=0,
+        repeats=1,
+        batch_count=0,
+    )
+
+    case = report["cases"][0]
+    assert case["dimensions"]["batches"] == 0
+    assert case["phases"]["claim_attribution"]["result"]["owner_links"] == 0
+    assert (
+        case["phases"]["claim_attribution"]["result"]["metrics"][
+            "candidate_batches"
+        ]
+        == 0
+    )
 
 
 def test_binary_case_is_explicitly_excluded_from_text_matching():

--- a/tests/batch/source/test_annotation.py
+++ b/tests/batch/source/test_annotation.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from git_stage_batch.batch.source import annotation as source_annotation_module
 from git_stage_batch.batch.source.annotation import (
+    acquire_batch_source_mapping,
+    annotate_with_batch_source_mapping,
     annotate_with_batch_source_lines,
     annotate_with_batch_source_working_lines,
 )
@@ -199,3 +201,58 @@ def test_annotate_with_batch_source_loads_indexed_buffers(monkeypatch, tmp_path)
     assert loaded_revisions == ["source-commit:file.txt"]
     assert loaded_working_paths == ["file.txt"]
     assert [line.source_line for line in annotated.lines] == [1, None, 2]
+
+
+def test_acquired_mapping_annotates_multiple_hunks_with_one_match(monkeypatch):
+    """One file-scoped mapping should be reusable across several hunks."""
+    line_changes = LineLevelChange(
+        path="file.txt",
+        header=HunkHeader(old_start=1, old_len=1, new_start=1, new_len=2),
+        lines=[
+            LineEntry(
+                id=None,
+                kind=" ",
+                old_line_number=1,
+                new_line_number=1,
+                text_bytes=b"line 1\n",
+            ),
+            LineEntry(
+                id=1,
+                kind="+",
+                old_line_number=None,
+                new_line_number=2,
+                text_bytes=b"inserted\n",
+            ),
+        ],
+    )
+    calls = []
+    original_match_lines = source_annotation_module.match_lines
+
+    monkeypatch.setattr(
+        source_annotation_module,
+        "read_git_object_buffer_or_none",
+        lambda _refspec: LineBuffer.from_chunks([b"line 1\n"]),
+    )
+
+    def counting_match_lines(source_lines, working_lines):
+        calls.append((source_lines, working_lines))
+        return original_match_lines(source_lines, working_lines)
+
+    monkeypatch.setattr(
+        source_annotation_module,
+        "match_lines",
+        counting_match_lines,
+    )
+
+    with LineBuffer.from_chunks([b"line 1\n", b"inserted\n"]) as working_lines:
+        with acquire_batch_source_mapping(
+            "file.txt",
+            batch_source_commit="source-commit",
+            working_lines=working_lines,
+        ) as mapping:
+            first = annotate_with_batch_source_mapping(line_changes, mapping)
+            second = annotate_with_batch_source_mapping(line_changes, mapping)
+
+    assert len(calls) == 1
+    assert [line.source_line for line in first.lines] == [1, None]
+    assert [line.source_line for line in second.lines] == [1, None]

--- a/tests/data/test_consumed_replacement_masks.py
+++ b/tests/data/test_consumed_replacement_masks.py
@@ -104,3 +104,23 @@ def test_filter_consumed_replacement_masks_returns_none_without_visible_changes(
     )
 
     assert replacement_masks.filter_consumed_replacement_masks(line_changes) is None
+
+
+def test_explicit_consumed_metadata_does_not_read_session_state(monkeypatch):
+    line_changes = _line_changes(_line("-", "old"), _line("+", "new"))
+    monkeypatch.setattr(
+        replacement_masks,
+        "read_consumed_file_metadata",
+        lambda _path: (_ for _ in ()).throw(AssertionError("unexpected session read")),
+    )
+
+    result = replacement_masks.filter_consumed_replacement_masks_with_metadata(
+        line_changes,
+        file_metadata={
+            "replacement_masks": [
+                {"deleted_lines": ["old"], "added_lines": ["new"]}
+            ]
+        },
+    )
+
+    assert result is None

--- a/tests/data/test_live_change_candidates.py
+++ b/tests/data/test_live_change_candidates.py
@@ -4,11 +4,15 @@ from __future__ import annotations
 
 import pytest
 
+import git_stage_batch.data.hunk_tracking as hunk_tracking_module
 import git_stage_batch.data.live_change_candidates as candidates_module
 from git_stage_batch.core.buffer import LineBuffer
 from git_stage_batch.core.diff_parser import build_line_changes_from_patch_lines
 from git_stage_batch.core.models import SingleHunkPatch
-from git_stage_batch.data.live_change_candidates import prepare_live_change
+from git_stage_batch.data.live_change_candidates import (
+    EligibleLiveChange,
+    prepare_live_change,
+)
 
 
 PATCH_LINES = (
@@ -76,3 +80,38 @@ def test_prepare_does_not_call_tuple_or_list_on_patch_lines(monkeypatch):
     )
 
     candidate.close()
+
+
+def _candidate_with_owned_patch() -> EligibleLiveChange:
+    patch_buffer = LineBuffer.from_chunks(PATCH_LINES)
+    change = build_line_changes_from_patch_lines(PATCH_LINES, annotator=None)
+    return EligibleLiveChange(
+        change=change,
+        stable_hash="hash",
+        raw_patch=SingleHunkPatch("file.txt", "file.txt", patch_buffer),
+    )
+
+
+@pytest.mark.parametrize("fail_cache", [False, True])
+def test_fetch_next_change_closes_candidate_after_cache(monkeypatch, fail_cache):
+    candidate = _candidate_with_owned_patch()
+    monkeypatch.setattr(
+        hunk_tracking_module,
+        "next_eligible_live_change",
+        lambda: candidate,
+    )
+
+    def cache(*_args):
+        if fail_cache:
+            raise RuntimeError("cache failed")
+
+    monkeypatch.setattr(hunk_tracking_module._selected_store, "cache_hunk_change", cache)
+
+    if fail_cache:
+        with pytest.raises(RuntimeError, match="cache failed"):
+            hunk_tracking_module.fetch_next_change()
+    else:
+        assert hunk_tracking_module.fetch_next_change() is candidate.change
+
+    with pytest.raises(ValueError, match="closed"):
+        candidate.raw_patch.lines.byte_chunks().__next__()

--- a/tests/data/test_live_change_candidates.py
+++ b/tests/data/test_live_change_candidates.py
@@ -1,0 +1,78 @@
+"""Resource ownership tests for prepared live-change candidates."""
+
+from __future__ import annotations
+
+import pytest
+
+import git_stage_batch.data.live_change_candidates as candidates_module
+from git_stage_batch.core.buffer import LineBuffer
+from git_stage_batch.core.diff_parser import build_line_changes_from_patch_lines
+from git_stage_batch.core.models import SingleHunkPatch
+from git_stage_batch.data.live_change_candidates import prepare_live_change
+
+
+PATCH_LINES = (
+    b"--- a/file.txt\n",
+    b"+++ b/file.txt\n",
+    b"@@ -1 +1 @@\n",
+    b"-old\n",
+    b"+new\n",
+)
+
+
+class _ScanContext:
+    blocked_paths: set[str] = set()
+    blocked_hashes: set[str] = set()
+
+    def metadata_for_path(self, _file_path: str) -> dict[str, dict]:
+        return {}
+
+
+def _prepare_without_repository_io(monkeypatch, patch: SingleHunkPatch):
+    monkeypatch.setattr(
+        candidates_module,
+        "build_line_changes_from_patch_lines",
+        lambda lines, annotator: build_line_changes_from_patch_lines(
+            lines,
+            annotator=None,
+        ),
+    )
+    monkeypatch.setattr(
+        candidates_module,
+        "filter_line_level_change_for_batches",
+        lambda line_changes, **_kwargs: line_changes,
+    )
+    candidate, reason = prepare_live_change(patch, _ScanContext())
+    assert reason is None
+    assert candidate is not None
+    return candidate
+
+
+def test_prepared_raw_patch_outlives_parser_buffer(monkeypatch):
+    parser_buffer = LineBuffer.from_chunks(PATCH_LINES)
+    candidate = _prepare_without_repository_io(
+        monkeypatch,
+        SingleHunkPatch("file.txt", "file.txt", parser_buffer),
+    )
+
+    parser_buffer.close()
+
+    assert b"".join(candidate.raw_patch.lines.byte_chunks()) == b"".join(PATCH_LINES)
+    candidate.close()
+    with pytest.raises(ValueError, match="closed"):
+        candidate.raw_patch.lines.byte_chunks().__next__()
+
+
+def test_prepare_does_not_call_tuple_or_list_on_patch_lines(monkeypatch):
+    def forbidden_materialization(*_args, **_kwargs):
+        raise AssertionError("patch sequence was materialized")
+
+    monkeypatch.setattr(candidates_module, "tuple", forbidden_materialization, raising=False)
+    monkeypatch.setattr(candidates_module, "list", forbidden_materialization, raising=False)
+
+    candidate = _prepare_without_repository_io(
+        monkeypatch,
+        SingleHunkPatch("file.txt", "file.txt", PATCH_LINES),
+    )
+
+    candidate.close()

--- a/tests/data/test_live_change_candidates.py
+++ b/tests/data/test_live_change_candidates.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+import git_stage_batch.commands.selection.next_change_display as display_module
 import git_stage_batch.data.hunk_tracking as hunk_tracking_module
 import git_stage_batch.data.live_change_candidates as candidates_module
 from git_stage_batch.core.buffer import LineBuffer
@@ -112,6 +113,30 @@ def test_fetch_next_change_closes_candidate_after_cache(monkeypatch, fail_cache)
             hunk_tracking_module.fetch_next_change()
     else:
         assert hunk_tracking_module.fetch_next_change() is candidate.change
+
+    with pytest.raises(ValueError, match="closed"):
+        candidate.raw_patch.lines.byte_chunks().__next__()
+
+
+@pytest.mark.parametrize("fail_print", [False, True])
+def test_show_next_change_closes_candidate_after_display(monkeypatch, fail_print):
+    candidate = _candidate_with_owned_patch()
+    monkeypatch.setattr(display_module, "next_eligible_live_change", lambda: candidate)
+    monkeypatch.setattr(display_module, "_cache_candidate", lambda _candidate: None)
+    monkeypatch.setattr(display_module, "clear_last_file_review_state", lambda: None)
+
+    def display(_candidate, *, selectable):
+        assert selectable is True
+        if fail_print:
+            raise RuntimeError("display failed")
+
+    monkeypatch.setattr(display_module, "_print_candidate", display)
+
+    if fail_print:
+        with pytest.raises(RuntimeError, match="display failed"):
+            display_module.show_next_unprocessed_change()
+    else:
+        display_module.show_next_unprocessed_change()
 
     with pytest.raises(ValueError, match="closed"):
         candidate.raw_patch.lines.byte_chunks().__next__()

--- a/tests/data/test_selected_hunk_filtering.py
+++ b/tests/data/test_selected_hunk_filtering.py
@@ -12,7 +12,10 @@ from git_stage_batch.data.hunk_tracking import fetch_next_change
 from git_stage_batch.data.line_id_files import write_line_ids_file
 from git_stage_batch.data.selected_change.hunk_filtering import (
     apply_line_level_batch_filter_to_cached_hunk,
+    filter_line_level_change_with_attribution,
 )
+from git_stage_batch.batch.attribution import FileAttribution
+from git_stage_batch.core.models import HunkHeader, LineEntry, LineLevelChange
 from git_stage_batch.utils.paths import (
     ensure_state_directory_exists,
     get_processed_batch_ids_file_path,
@@ -108,3 +111,46 @@ def test_apply_line_level_batch_filter_returns_true_without_cached_hunk(
     temp_git_repo,
 ):
     assert apply_line_level_batch_filter_to_cached_hunk() is True
+
+
+def test_explicit_attribution_filter_is_io_free(monkeypatch):
+    """Prepared filtering should consume only caller-supplied resources."""
+    line_changes = LineLevelChange(
+        path="file.txt",
+        header=HunkHeader(old_start=1, old_len=1, new_start=1, new_len=1),
+        lines=[
+            LineEntry(
+                id=1,
+                kind="+",
+                old_line_number=None,
+                new_line_number=1,
+                text_bytes=b"new\n",
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        hunk_filtering_module,
+        "filter_owned_diff_fragments",
+        lambda changes, _attribution: (False, changes),
+    )
+    monkeypatch.setattr(
+        hunk_filtering_module,
+        "read_consumed_file_metadata",
+        lambda _path: (_ for _ in ()).throw(AssertionError("unexpected session read")),
+    )
+    monkeypatch.setattr(
+        hunk_filtering_module,
+        "log_journal",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("unexpected journal write")
+        ),
+    )
+
+    filtered = filter_line_level_change_with_attribution(
+        line_changes,
+        attribution=FileAttribution(file_path="file.txt", units=[]),
+        batch_metadata_by_name={},
+        consumed_file_metadata=None,
+    )
+
+    assert filtered is line_changes


### PR DESCRIPTION
Live-change consumers repeatedly derive batch-source mappings, consumed replacement metadata, hunk filters, and raw diff storage while navigating or counting the same candidate set.

That repeated preparation scales with batch and hunk count, while borrowed raw patch buffers and lazy candidate streams make ownership and cleanup difficult to reason about. The maintained benchmark also needs dimensions that expose those costs before process execution is introduced.

This pull request makes attribution mappings, consumed masks, and hunk-filtering resources explicit reusable inputs. Accepted text patches and single-result candidates own their buffers, navigation and status consumers close them deterministically, and the public stream name follows the existing codebase vocabulary.

Coverage verifies reusable-input parity, mapped-buffer ownership, successful and failing candidate cleanup, and expanded file, hunk, matching-size, and batch-count benchmark controls. The result is heap-safe reusable preparation for captured file jobs.