### PR TITLE
jobs: Capture file inputs in invocation-local workspaces

### DIFF
--- a/src/git_stage_batch/batch/attribution.py
+++ b/src/git_stage_batch/batch/attribution.py
@@ -172,16 +172,21 @@ def build_file_attribution_from_lines(
     if metrics is not None:
         metrics.candidate_batches = len(batch_metadata_by_name)
 
-    # Capture names before merging supplemental metadata. Only entries from the
-    # primary metadata map may resolve source_path through state-backed storage.
-    # Supplemental entries, including __consumed__, use batch_source_commit.
-    state_backed_batch_names = frozenset(batch_metadata_by_name)
+    # Only entries retained from the primary metadata map may resolve
+    # source_path through state-backed storage. Supplemental entries, including
+    # __consumed__ and any same-name override, use batch_source_commit.
+    state_backed_batch_names = set()
     for batch_name, metadata in batch_metadata_by_name.items():
         if file_path in metadata.get("files", {}):
             all_batch_metadata[batch_name] = metadata
+            state_backed_batch_names.add(batch_name)
 
     if supplemental_batch_metadata:
-        all_batch_metadata.update(supplemental_batch_metadata)
+        for batch_name, metadata in supplemental_batch_metadata.items():
+            if file_path not in metadata.get("files", {}):
+                continue
+            all_batch_metadata[batch_name] = metadata
+            state_backed_batch_names.discard(batch_name)
     if metrics is not None:
         metrics.claimed_batches = len(all_batch_metadata)
 
@@ -199,7 +204,7 @@ def build_file_attribution_from_lines(
     _attribute_batches(
         file_path,
         all_batch_metadata,
-        state_backed_batch_names=state_backed_batch_names,
+        state_backed_batch_names=frozenset(state_backed_batch_names),
         batch_state_commit_by_name=batch_state_commit_by_name,
         spool_dir=spool_dir,
         working_tree_lines=working_tree_lines,

--- a/src/git_stage_batch/batch/attribution.py
+++ b/src/git_stage_batch/batch/attribution.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from pathlib import Path
 
 from ..utils.git_object_io import (
     GitObjectInfo,
@@ -128,12 +129,19 @@ def build_file_attribution(
     *,
     batch_metadata_by_name: dict[str, dict] | None = None,
     supplemental_batch_metadata: dict[str, dict] | None = None,
+    spool_dir: str | Path | None = None,
     metrics: AttributionMetrics | None = None,
 ) -> FileAttribution:
     """Open repository buffers and build complete ownership attribution."""
     with (
-        read_git_object_buffer_or_empty(f"HEAD:{file_path}") as baseline_lines,
-        load_working_tree_file_as_buffer(file_path) as working_tree_lines,
+        read_git_object_buffer_or_empty(
+            f"HEAD:{file_path}",
+            spool_dir=spool_dir,
+        ) as baseline_lines,
+        load_working_tree_file_as_buffer(
+            file_path,
+            spool_dir=spool_dir,
+        ) as working_tree_lines,
     ):
         return build_file_attribution_from_lines(
             file_path,
@@ -141,6 +149,7 @@ def build_file_attribution(
             working_tree_lines=working_tree_lines,
             batch_metadata_by_name=batch_metadata_by_name,
             supplemental_batch_metadata=supplemental_batch_metadata,
+            spool_dir=spool_dir,
             metrics=metrics,
         )
 
@@ -153,6 +162,7 @@ def build_file_attribution_from_lines(
     batch_metadata_by_name: dict[str, dict] | None = None,
     supplemental_batch_metadata: dict[str, dict] | None = None,
     batch_state_commit_by_name: Mapping[str, str] | None = None,
+    spool_dir: str | Path | None = None,
     metrics: AttributionMetrics | None = None,
 ) -> FileAttribution:
     """Build file attribution from caller-owned indexed line sequences."""
@@ -180,6 +190,7 @@ def build_file_attribution_from_lines(
         file_path,
         baseline_lines=baseline_lines,
         working_tree_lines=working_tree_lines,
+        spool_dir=spool_dir,
     ) as comparison:
         _enumerate_units_from_file_comparison(comparison, all_units_map)
 
@@ -190,6 +201,7 @@ def build_file_attribution_from_lines(
         all_batch_metadata,
         state_backed_batch_names=state_backed_batch_names,
         batch_state_commit_by_name=batch_state_commit_by_name,
+        spool_dir=spool_dir,
         working_tree_lines=working_tree_lines,
         all_units_map=all_units_map,
         baseline_unit_ids=baseline_unit_ids,
@@ -216,6 +228,7 @@ def _attribute_batches(
     *,
     state_backed_batch_names: frozenset[str],
     batch_state_commit_by_name: Mapping[str, str] | None,
+    spool_dir: str | Path | None,
     working_tree_lines: Sequence[bytes],
     all_units_map: dict[str, _AttributionUnit],
     baseline_unit_ids: Sequence[str],
@@ -262,7 +275,10 @@ def _attribute_batches(
         metrics.mapping_computations = len(source_groups)
 
     if source_object_ids:
-        for source_blob in stream_git_blob_buffers(source_object_ids):
+        for source_blob in stream_git_blob_buffers(
+            source_object_ids,
+            spool_dir=spool_dir,
+        ):
             if metrics is not None:
                 metrics.object_bytes += source_blob.size
             _attribute_source_group(
@@ -270,6 +286,7 @@ def _attribute_batches(
                 source_groups[source_blob.object_id],
                 source_lines=source_blob.buffer,
                 working_tree_lines=working_tree_lines,
+                spool_dir=spool_dir,
                 deletion_fingerprints=deletion_fingerprints,
                 all_units_map=all_units_map,
                 baseline_unit_ids=baseline_unit_ids,
@@ -283,6 +300,7 @@ def _attribute_batches(
             empty_source_group,
             source_lines=(),
             working_tree_lines=working_tree_lines,
+            spool_dir=spool_dir,
             deletion_fingerprints=deletion_fingerprints,
             all_units_map=all_units_map,
             baseline_unit_ids=baseline_unit_ids,
@@ -361,6 +379,7 @@ def _attribute_source_group(
     *,
     source_lines: Sequence[bytes],
     working_tree_lines: Sequence[bytes],
+    spool_dir: str | Path | None,
     deletion_fingerprints: dict[
         str,
         _attribution_fingerprints.ContentFingerprint,
@@ -373,6 +392,7 @@ def _attribute_source_group(
     with match_lines(
         source_lines=source_lines,
         target_lines=working_tree_lines,
+        spool_dir=spool_dir,
     ) as alignment:
         for request in requests:
             context = BatchAttributionContext(

--- a/src/git_stage_batch/batch/attribution_units.py
+++ b/src/git_stage_batch/batch/attribution_units.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import Enum
+from pathlib import Path
 
 from . import attribution_fingerprints as _attribution_fingerprints
 from .line_matching.line_mapping import LineMapping
@@ -124,8 +125,13 @@ def build_file_comparison_from_lines(
     *,
     baseline_lines: Sequence[bytes],
     working_tree_lines: Sequence[bytes],
+    spool_dir: str | Path | None = None,
 ) -> FileComparison:
-    alignment = match_lines(source_lines=baseline_lines, target_lines=working_tree_lines)
+    alignment = match_lines(
+        source_lines=baseline_lines,
+        target_lines=working_tree_lines,
+        spool_dir=spool_dir,
+    )
     return FileComparison(
         file_path=file_path,
         baseline_lines=baseline_lines,

--- a/src/git_stage_batch/batch/line_matching/match.py
+++ b/src/git_stage_batch/batch/line_matching/match.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from bisect import bisect_left
 from collections.abc import Hashable, Sequence
+from pathlib import Path
 from typing import TypeVar
 
 from .line_mapping import IntVector as _IntVector, LineMapping as _LineMapping
@@ -31,11 +32,17 @@ def _line_mapping_width(max_line_number: int) -> int:
     return 8
 
 
-def _new_line_mapping(size: int, max_line_number: int) -> MappedIntVector:
+def _new_line_mapping(
+    size: int,
+    max_line_number: int,
+    *,
+    spool_dir: str | Path | None = None,
+) -> MappedIntVector:
     return MappedIntVector(
         size,
         width=_line_mapping_width(max_line_number),
         fill=0,
+        spool_dir=spool_dir,
     )
 
 
@@ -528,7 +535,9 @@ def _align_segment(
 
 def match_acquirable_lines(
     source_lines: AcquirableLineSequence[LineContent],
-    target_lines: AcquirableLineSequence[LineContent]
+    target_lines: AcquirableLineSequence[LineContent],
+    *,
+    spool_dir: str | Path | None = None,
 ) -> _LineMapping:
     """Compute conservative structural alignment between source and target.
 
@@ -550,8 +559,8 @@ def match_acquirable_lines(
     Returns:
         A bidirectional line mapping with ambiguous lines left unmapped.
     """
-    source_to_target: MappedIntVector
-    target_to_source: MappedIntVector
+    source_to_target: MappedIntVector | None = None
+    target_to_source: MappedIntVector | None = None
     workspace: MatcherWorkspace
     max_line_number: int
     source_line_count: int
@@ -560,12 +569,19 @@ def match_acquirable_lines(
     source_line_count = len(source_lines)
     target_line_count = len(target_lines)
     max_line_number = max(source_line_count, target_line_count)
-    source_to_target = _new_line_mapping(source_line_count, max_line_number)
-    target_to_source = _new_line_mapping(target_line_count, max_line_number)
-
     try:
+        source_to_target = _new_line_mapping(
+            source_line_count,
+            max_line_number,
+            spool_dir=spool_dir,
+        )
+        target_to_source = _new_line_mapping(
+            target_line_count,
+            max_line_number,
+            spool_dir=spool_dir,
+        )
         with (
-            MatcherWorkspace() as workspace,
+            MatcherWorkspace(spool_dir=spool_dir) as workspace,
             source_lines.acquire_lines() as acquired_source_lines,
             target_lines.acquire_lines() as acquired_target_lines,
         ):
@@ -585,18 +601,23 @@ def match_acquirable_lines(
             source_to_target=source_to_target,
             target_to_source=target_to_source
         )
-    except Exception:
-        source_to_target.close()
-        target_to_source.close()
+    except BaseException:
+        if source_to_target is not None:
+            source_to_target.close()
+        if target_to_source is not None:
+            target_to_source.close()
         raise
 
 
 def match_lines(
     source_lines: Sequence[LineContent],
-    target_lines: Sequence[LineContent]
+    target_lines: Sequence[LineContent],
+    *,
+    spool_dir: str | Path | None = None,
 ) -> _LineMapping:
     """Compute conservative structural alignment between source and target."""
     return match_acquirable_lines(
         as_acquirable_line_sequence(source_lines),
         as_acquirable_line_sequence(target_lines),
+        spool_dir=spool_dir,
     )

--- a/src/git_stage_batch/batch/source/annotation.py
+++ b/src/git_stage_batch/batch/source/annotation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
+from pathlib import Path
 
 from ...core.models import LineEntry, LineLevelChange
 from ...utils.git_repository import get_git_repository_root_path
@@ -96,6 +97,7 @@ def acquire_batch_source_mapping(
     *,
     batch_source_commit: str | None,
     working_lines: Sequence[bytes],
+    spool_dir: str | Path | None = None,
 ) -> Iterator[LineMapping | None]:
     """Acquire one reusable source-to-working mapping for a repository file."""
     if not batch_source_commit:
@@ -103,7 +105,8 @@ def acquire_batch_source_mapping(
         return
 
     batch_source_buffer = read_git_object_buffer_or_none(
-        f"{batch_source_commit}:{path_value}"
+        f"{batch_source_commit}:{path_value}",
+        spool_dir=spool_dir,
     )
     if batch_source_buffer is None:
         yield None
@@ -111,7 +114,11 @@ def acquire_batch_source_mapping(
 
     with (
         batch_source_buffer as batch_source_lines,
-        match_lines(batch_source_lines, working_lines) as mapping,
+        match_lines(
+            batch_source_lines,
+            working_lines,
+            spool_dir=spool_dir,
+        ) as mapping,
     ):
         yield mapping
 
@@ -199,6 +206,8 @@ def annotate_with_batch_source_working_lines(
     path_value: str,
     line_changes: LineLevelChange,
     working_lines: Sequence[bytes],
+    *,
+    spool_dir: str | Path | None = None,
 ) -> LineLevelChange:
     """Annotate LineLevelChange with indexed working content lines."""
     batch_source_commit = get_batch_source_for_file(path_value)
@@ -206,6 +215,7 @@ def annotate_with_batch_source_working_lines(
         path_value,
         batch_source_commit=batch_source_commit,
         working_lines=working_lines,
+        spool_dir=spool_dir,
     ) as mapping:
         return annotate_with_batch_source_mapping(line_changes, mapping)
 
@@ -215,7 +225,12 @@ def annotate_with_batch_source_lines(
     *,
     batch_source_lines: Sequence[bytes],
     working_lines: Sequence[bytes],
+    spool_dir: str | Path | None = None,
 ) -> LineLevelChange:
     """Annotate LineLevelChange from indexed batch-source and working lines."""
-    with match_lines(batch_source_lines, working_lines) as mapping:
+    with match_lines(
+        batch_source_lines,
+        working_lines,
+        spool_dir=spool_dir,
+    ) as mapping:
         return annotate_with_batch_source_mapping(line_changes, mapping)

--- a/src/git_stage_batch/batch/state/query.py
+++ b/src/git_stage_batch/batch/state/query.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from typing import Optional
 
 from .reference_names import BATCH_CONTENT_REF_PREFIX, LEGACY_BATCH_REF_PREFIX
@@ -49,13 +49,20 @@ def read_batch_metadata(name: str) -> dict:
     return _read_file_backed_batch_metadata_or_empty(name)
 
 
-def read_batch_metadata_for_batches(batch_names: Iterable[str]) -> dict[str, dict]:
-    """Read metadata for many batches with one state-ref lookup pass."""
+def read_batch_metadata_for_batches(
+    batch_names: Iterable[str],
+    *,
+    batch_state_commit_by_name: Mapping[str, str] | None = None,
+) -> dict[str, dict]:
+    """Read metadata for many batches with one bulk state lookup pass."""
     unique_batch_names = list(dict.fromkeys(batch_names))
     if not unique_batch_names:
         return {}
 
-    metadata_by_name = read_batch_state_metadata_for_batches(unique_batch_names)
+    metadata_by_name = read_batch_state_metadata_for_batches(
+        unique_batch_names,
+        state_commit_by_name=batch_state_commit_by_name,
+    )
     missing_batch_names = [
         batch_name
         for batch_name in unique_batch_names

--- a/src/git_stage_batch/batch/state/references.py
+++ b/src/git_stage_batch/batch/state/references.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import shutil
 import subprocess
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from typing import Any
 
@@ -136,18 +136,31 @@ def read_batch_state_metadata(batch_name: str) -> dict[str, Any] | None:
 
 def read_batch_state_metadata_for_batches(
     batch_names: Iterable[str],
+    *,
+    state_commit_by_name: Mapping[str, str] | None = None,
 ) -> dict[str, dict[str, Any]]:
-    """Read normalized state-ref metadata for many batches in one Git process."""
+    """Read normalized state metadata for many validated batches.
+
+    When canonical commits are supplied, missing mappings intentionally skip
+    mutable state refs so the caller can retain one captured state boundary.
+    """
     unique_batch_names = list(dict.fromkeys(batch_names))
     for batch_name in unique_batch_names:
         validate_batch_name(batch_name)
     if not unique_batch_names:
         return {}
 
-    refspec_by_name = {
-        batch_name: f"{format_batch_state_ref_name(batch_name)}:batch.json"
-        for batch_name in unique_batch_names
-    }
+    refspec_by_name = {}
+    for batch_name in unique_batch_names:
+        if state_commit_by_name is not None:
+            if batch_name not in state_commit_by_name:
+                continue
+            state_commit = state_commit_by_name[batch_name]
+            _validate_canonical_state_commit(state_commit, batch_name)
+            state_source = state_commit
+        else:
+            state_source = format_batch_state_ref_name(batch_name)
+        refspec_by_name[batch_name] = f"{state_source}:batch.json"
     blobs = read_git_blobs_as_bytes(refspec_by_name.values())
 
     metadata_by_name: dict[str, dict[str, Any]] = {}
@@ -160,6 +173,24 @@ def read_batch_state_metadata_for_batches(
             batch_name,
         ).to_application_dict()
     return metadata_by_name
+
+
+def _validate_canonical_state_commit(
+    state_commit: object,
+    batch_name: str,
+) -> None:
+    if (
+        type(state_commit) is not str
+        or len(state_commit) not in {40, 64}
+        or any(
+            character not in "0123456789abcdefABCDEF"
+            for character in state_commit
+        )
+    ):
+        raise ValueError(
+            f"Canonical state commit for batch '{batch_name}' must be a "
+            "full hexadecimal object ID"
+        )
 
 
 def get_authoritative_batch_commit_sha(batch_name: str) -> str | None:

--- a/src/git_stage_batch/core/buffer.py
+++ b/src/git_stage_batch/core/buffer.py
@@ -63,10 +63,11 @@ class _BufferBacking:
 class _LineSpanVector:
     """Compact append-only storage for byte line spans."""
 
-    def __init__(self) -> None:
+    def __init__(self, *, spool_dir: str | Path | None = None) -> None:
         self._records = ChunkedMappedRecordVector(
             record_format="QQ",
             chunk_capacity=_LINE_SPAN_CHUNK_CAPACITY,
+            spool_dir=spool_dir,
         )
 
     def __len__(self) -> int:
@@ -91,21 +92,39 @@ class LineBuffer(Sequence[bytes]):
         data: bytes | mmap.mmap,
         *,
         file_handle: BinaryIO | None = None,
+        spool_dir: str | Path | None = None,
     ) -> None:
         self._backing = _BufferBacking(data, file_handle)
-        self._initialize_line_index()
+        self._spool_dir = spool_dir
+        try:
+            self._initialize_line_index()
+        except BaseException:
+            self._backing.release()
+            raise
 
     def _initialize_line_index(self) -> None:
-        self._line_spans = _LineSpanVector()
+        scan_complete = len(self._data) == 0
+        line_spans = _LineSpanVector(spool_dir=self._spool_dir)
+        self._line_spans = line_spans
         self._scan_position = 0
-        self._scan_complete = len(self._data) == 0
+        self._scan_complete = scan_complete
         self._closed = False
 
     @classmethod
-    def _from_backing(cls, backing: _BufferBacking) -> LineBuffer:
+    def _from_backing(
+        cls,
+        backing: _BufferBacking,
+        *,
+        spool_dir: str | Path | None = None,
+    ) -> LineBuffer:
         buffer = cls.__new__(cls)
         buffer._backing = backing.retain()
-        buffer._initialize_line_index()
+        buffer._spool_dir = spool_dir
+        try:
+            buffer._initialize_line_index()
+        except BaseException:
+            buffer._backing.release()
+            raise
         return buffer
 
     @property
@@ -113,15 +132,29 @@ class LineBuffer(Sequence[bytes]):
         return self._backing.data
 
     @classmethod
-    def from_bytes(cls, data: _BytesLike) -> LineBuffer:
+    def from_bytes(
+        cls,
+        data: _BytesLike,
+        *,
+        spool_dir: str | Path | None = None,
+    ) -> LineBuffer:
         """Create a buffer from in-memory bytes."""
-        return cls(bytes(data))
+        return cls(bytes(data), spool_dir=spool_dir)
 
     @classmethod
-    def from_path(cls, path: str | Path) -> LineBuffer:
+    def from_path(
+        cls,
+        path: str | Path,
+        *,
+        spool_dir: str | Path | None = None,
+    ) -> LineBuffer:
         """Create a buffer from a file using mmap when possible."""
         data, file_handle = byte_storage_from_path(path)
-        return cls(data, file_handle=file_handle)
+        return cls(
+            data,
+            file_handle=file_handle,
+            spool_dir=spool_dir,
+        )
 
     @classmethod
     def from_chunks(
@@ -135,12 +168,23 @@ class LineBuffer(Sequence[bytes]):
             chunks,
             spool_dir=spool_dir,
         )
-        return cls(data, file_handle=file_handle)
+        return cls(
+            data,
+            file_handle=file_handle,
+            spool_dir=spool_dir,
+        )
 
-    def clone(self) -> LineBuffer:
+    def clone(
+        self,
+        *,
+        spool_dir: str | Path | None = None,
+    ) -> LineBuffer:
         """Return an independently closable buffer sharing immutable storage."""
         self._require_open()
-        return LineBuffer._from_backing(self._backing)
+        return LineBuffer._from_backing(
+            self._backing,
+            spool_dir=self._spool_dir if spool_dir is None else spool_dir,
+        )
 
     @property
     def uses_mapped_storage(self) -> bool:

--- a/src/git_stage_batch/data/live_change_candidates.py
+++ b/src/git_stage_batch/data/live_change_candidates.py
@@ -87,24 +87,35 @@ class EligibleLiveChange:
 class LiveChangeScanContext:
     """Repository policy state loaded at most once for one diff scan."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        batch_metadata_by_name: dict[str, dict] | None = None,
+    ) -> None:
         self.blocked_paths = read_file_paths_file(get_blocked_files_file_path())
         self.blocked_hashes = read_text_file_line_set(get_block_list_file_path())
-        self._metadata_by_name: dict[str, dict] | None = None
+        self._metadata_by_name = batch_metadata_by_name
         self._metadata_by_path: dict[str, dict[str, dict]] | None = None
 
-    def metadata_for_path(self, file_path: str) -> dict[str, dict]:
+    def metadata_by_name(self) -> dict[str, dict]:
+        """Return the complete batch metadata snapshot for this scan."""
         if self._metadata_by_name is None:
-            self._metadata_by_name = read_batch_metadata_for_batches(list_batch_names())
+            self._metadata_by_name = read_batch_metadata_for_batches(
+                list_batch_names()
+            )
+        return self._metadata_by_name
+
+    def metadata_for_path(self, file_path: str) -> dict[str, dict]:
         if self._metadata_by_path is None:
             self._metadata_by_path = {}
-            for batch_name, metadata in self._metadata_by_name.items():
+            for batch_name, metadata in self.metadata_by_name().items():
                 for path in metadata.get("files", {}):
                     self._metadata_by_path.setdefault(path, {})[batch_name] = metadata
         return self._metadata_by_path.get(file_path, {})
 
 
-def _paths_for_item(item: object) -> tuple[str, ...]:
+def live_change_paths(item: object) -> tuple[str, ...]:
+    """Return every repository path covered by one parsed live change."""
     if isinstance(item, RenameChange):
         return item.old_path, item.new_path
     if isinstance(item, SingleHunkPatch) and item.old_path != item.new_path:
@@ -112,11 +123,42 @@ def _paths_for_item(item: object) -> tuple[str, ...]:
     return (item.path(),)  # type: ignore[attr-defined]
 
 
-def prepare_live_change(
+def blocked_live_change_reason(
+    item: object,
+    stable_hash: str,
+    context: LiveChangeScanContext,
+) -> SkipReason | None:
+    """Return the shared blocked hash/path decision for one live change."""
+    if stable_hash in context.blocked_hashes:
+        return SkipReason.BLOCKED_HASH
+    if any(
+        is_path_blocked(path, context.blocked_paths)
+        for path in live_change_paths(item)
+    ):
+        return SkipReason.BLOCKED_PATH
+    return None
+
+
+def text_hunk_block_reason(
+    item: SingleHunkPatch,
+    stable_hash: str,
+    context: LiveChangeScanContext,
+) -> SkipReason | None:
+    """Return the blocked decision for a text hunk and any covering rename."""
+    if item.old_path != item.new_path:
+        rename_hash = compute_rename_change_hash(
+            RenameChange(item.old_path, item.new_path)
+        )
+        if rename_hash in context.blocked_hashes:
+            return SkipReason.BLOCKED_HASH
+    return blocked_live_change_reason(item, stable_hash, context)
+
+
+def prepare_atomic_live_change(
     item: object,
     context: LiveChangeScanContext,
 ) -> tuple[EligibleLiveChange | None, SkipReason | None]:
-    """Apply the common blocked/batched policy to one parsed diff item."""
+    """Apply shared eligibility policy to one non-text live diff item."""
     if isinstance(item, FileModeChange):
         stable_hash = compute_file_mode_change_hash(item)
         change: LiveChange = item
@@ -137,48 +179,54 @@ def prepare_live_change(
     elif isinstance(item, BinaryFileChange):
         change = attach_live_binary_fingerprint(item)
         stable_hash = compute_binary_file_hash(change)
-    elif isinstance(item, SingleHunkPatch):
-        if item.old_path != item.new_path:
-            rename_hash = compute_rename_change_hash(
-                RenameChange(item.old_path, item.new_path)
-            )
-            if rename_hash in context.blocked_hashes:
-                return None, SkipReason.BLOCKED_HASH
-        stable_hash = compute_stable_hunk_hash_from_lines(item.lines)
-        line_change = build_line_changes_from_patch_lines(
-            item.lines,
-            annotator=annotate_with_batch_source,
-        )
-        filtered = filter_line_level_change_for_batches(
-            line_change,
-            batch_metadata_by_name=context.metadata_for_path(line_change.path),
-        )
-        if filtered is None:
-            return None, SkipReason.ALREADY_BATCHED
-        change = filtered
     else:
-        raise TypeError(f"Unsupported live diff item: {type(item).__name__}")
+        raise TypeError(f"Unsupported atomic live diff item: {type(item).__name__}")
 
-    if stable_hash in context.blocked_hashes:
-        return None, SkipReason.BLOCKED_HASH
-    if any(
-        is_path_blocked(path, context.blocked_paths) for path in _paths_for_item(item)
-    ):
-        return None, SkipReason.BLOCKED_PATH
-    if isinstance(item, SingleHunkPatch):
-        owned_patch_lines = (
-            item.lines.clone()
-            if isinstance(item.lines, LineBuffer)
-            else LineBuffer.from_chunks(item.lines)
-        )
-        raw_patch = SingleHunkPatch(
-            item.old_path,
-            item.new_path,
-            owned_patch_lines,
-        )
-    else:
-        raw_patch = item
-    return EligibleLiveChange(change, stable_hash, raw_patch), None
+    blocked_reason = blocked_live_change_reason(item, stable_hash, context)
+    if blocked_reason is not None:
+        return None, blocked_reason
+    return EligibleLiveChange(change, stable_hash, item), None
+
+
+def prepare_live_change(
+    item: object,
+    context: LiveChangeScanContext,
+) -> tuple[EligibleLiveChange | None, SkipReason | None]:
+    """Apply the common blocked/batched policy to one parsed diff item."""
+    if not isinstance(item, SingleHunkPatch):
+        return prepare_atomic_live_change(item, context)
+
+    stable_hash = compute_stable_hunk_hash_from_lines(item.lines)
+    blocked_reason = text_hunk_block_reason(item, stable_hash, context)
+    if blocked_reason is not None:
+        return None, blocked_reason
+
+    line_change = build_line_changes_from_patch_lines(
+        item.lines,
+        annotator=annotate_with_batch_source,
+    )
+    filtered = filter_line_level_change_for_batches(
+        line_change,
+        batch_metadata_by_name=context.metadata_for_path(line_change.path),
+    )
+    if filtered is None:
+        return None, SkipReason.ALREADY_BATCHED
+
+    owned_patch_lines = (
+        item.lines.clone()
+        if isinstance(item.lines, LineBuffer)
+        else LineBuffer.from_chunks(item.lines)
+    )
+    raw_patch = SingleHunkPatch(
+        item.old_path,
+        item.new_path,
+        owned_patch_lines,
+    )
+    return EligibleLiveChange(
+        filtered,
+        stable_hash,
+        raw_patch,
+    ), None
 
 
 def stream_eligible_live_changes() -> Iterator[EligibleLiveChange]:

--- a/src/git_stage_batch/data/selected_change/hunk_filtering.py
+++ b/src/git_stage_batch/data/selected_change/hunk_filtering.py
@@ -81,7 +81,7 @@ def filter_line_level_change_for_batches(
     attribution = build_file_attribution(
         file_path,
         batch_metadata_by_name=batch_metadata_by_name,
-        supplemental_batch_metadata=_consumed_batch_metadata(
+        supplemental_batch_metadata=consumed_batch_metadata(
             file_path,
             consumed_file_metadata,
         ),
@@ -105,12 +105,25 @@ def filter_line_level_change_with_attribution(
     attribution: FileAttribution,
     batch_metadata_by_name: dict[str, dict],
     consumed_file_metadata: dict | None,
+    captured_empty_lifecycle_is_batched: bool | None = None,
 ) -> LineLevelChange | None:
-    """Filter one hunk from caller-supplied file attribution and metadata."""
-    if _empty_lifecycle_change_is_batched(
-        line_changes,
-        batch_metadata_by_name=batch_metadata_by_name,
-    ):
+    """Filter one hunk from caller-supplied attribution and metadata.
+
+    ``None`` preserves the established repository-backed empty-lifecycle
+    check. File jobs pass a captured boolean to keep worker computation free
+    of mutable repository/session reads.
+    """
+    if captured_empty_lifecycle_is_batched is None:
+        lifecycle_is_batched = _empty_lifecycle_change_is_batched(
+            line_changes,
+            batch_metadata_by_name=batch_metadata_by_name,
+        )
+    else:
+        lifecycle_is_batched = (
+            not line_changes.lines
+            and captured_empty_lifecycle_is_batched
+        )
+    if lifecycle_is_batched:
         return None
 
     return _filter_line_level_change_with_prepared_resources(
@@ -154,7 +167,7 @@ def _filter_line_level_change_with_prepared_resources(
     )
 
 
-def _consumed_batch_metadata(
+def consumed_batch_metadata(
     file_path: str,
     consumed_file_metadata: dict | None,
 ) -> dict[str, dict] | None:

--- a/src/git_stage_batch/utils/file_job_workspace.py
+++ b/src/git_stage_batch/utils/file_job_workspace.py
@@ -1,0 +1,391 @@
+"""Invocation-private artifact storage for file-scoped jobs."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator
+from contextlib import AbstractContextManager
+from dataclasses import fields, is_dataclass
+from enum import Enum
+import json
+from pathlib import (
+    Path,
+    PosixPath,
+    PurePath,
+    PurePosixPath,
+    PureWindowsPath,
+    WindowsPath,
+)
+import pickle
+import stat
+import tempfile
+from typing import Any
+
+from ..core.buffer import BufferInput, write_buffer_to_path
+
+
+_STANDARD_PATH_TYPES = frozenset({
+    Path,
+    PosixPath,
+    PurePath,
+    PurePosixPath,
+    PureWindowsPath,
+    WindowsPath,
+})
+
+
+class FileJobWorkspace(AbstractContextManager["FileJobWorkspace"]):
+    """Own private input, output, and scratch paths for one invocation."""
+
+    def __init__(
+        self,
+        *,
+        parent_directory: str | Path | None = None,
+    ) -> None:
+        resolved_parent = (
+            None
+            if parent_directory is None
+            else Path(parent_directory).resolve()
+        )
+        self._temporary_directory = tempfile.TemporaryDirectory(
+            prefix="git-stage-batch-file-jobs-",
+            dir=resolved_parent,
+        )
+        self._root = Path(self._temporary_directory.name).resolve()
+        self._root.chmod(0o700)
+        self._path_counters: dict[tuple[int, str], int] = {}
+        self._closed = False
+
+    @property
+    def root(self) -> Path:
+        """Return the workspace root."""
+        return self._root
+
+    def job_directory(self, ordinal: int) -> Path:
+        """Return the deterministic private directory for one job ordinal."""
+        self._require_open()
+        normalized_ordinal = _normalize_ordinal(ordinal)
+        path = self._require_workspace_path(
+            self._root / "jobs" / f"{normalized_ordinal:08d}"
+        )
+        path.mkdir(mode=0o700, parents=True, exist_ok=True)
+        return path
+
+    def scratch_directory(self, ordinal: int) -> Path:
+        """Return the mapped-storage scratch directory for one job."""
+        path = self._require_workspace_path(
+            self.job_directory(ordinal) / "scratch"
+        )
+        path.mkdir(mode=0o700, exist_ok=True)
+        return path
+
+    def artifact_path(self, ordinal: int, name: str) -> Path:
+        """Allocate a unique parent-written artifact path for one job."""
+        return self._allocate_path(ordinal, "artifacts", name)
+
+    def output_path(self, ordinal: int, name: str) -> Path:
+        """Allocate a unique worker-writable output path for one job."""
+        return self._allocate_path(ordinal, "outputs", name)
+
+    def write_buffer(
+        self,
+        ordinal: int,
+        name: str,
+        buffer: BufferInput,
+    ) -> Path:
+        """Stream buffer content to a unique private artifact."""
+        path = self.artifact_path(ordinal, name)
+        write_buffer_to_path(path, buffer)
+        return path
+
+    def write_json(
+        self,
+        ordinal: int,
+        name: str,
+        value: Any,
+    ) -> Path:
+        """Write small JSON metadata to a unique private artifact."""
+        path = self.artifact_path(ordinal, name)
+        with path.open("x", encoding="utf-8") as output:
+            json.dump(value, output, ensure_ascii=True, separators=(",", ":"))
+            output.write("\n")
+        return path
+
+    def read_json(self, path: str | Path) -> Any:
+        """Read small JSON metadata from a workspace artifact."""
+        artifact_path = self._require_regular_workspace_file(path)
+        with artifact_path.open(encoding="utf-8") as source:
+            return json.load(source)
+
+    def write_jsonl(
+        self,
+        ordinal: int,
+        name: str,
+        values: Iterable[Any],
+    ) -> Path:
+        """Stream JSON records to a unique private JSONL artifact."""
+        path = self.artifact_path(ordinal, name)
+        with path.open("x", encoding="utf-8") as output:
+            for value in values:
+                json.dump(
+                    value,
+                    output,
+                    ensure_ascii=True,
+                    separators=(",", ":"),
+                )
+                output.write("\n")
+        return path
+
+    def stream_jsonl(self, path: str | Path) -> Iterator[Any]:
+        """Yield JSON records from a workspace artifact."""
+        artifact_path = self._require_regular_workspace_file(path)
+        with artifact_path.open(encoding="utf-8") as source:
+            for line in source:
+                yield json.loads(line)
+
+    def write_pickle(
+        self,
+        ordinal: int,
+        name: str,
+        value: Any,
+    ) -> Path:
+        """Write trusted private metadata to a pickle artifact."""
+        _assert_pickle_metadata_value(
+            value,
+            label="pickle metadata",
+            active_ids=set(),
+        )
+        path = self.artifact_path(ordinal, name)
+        with path.open("xb") as output:
+            pickle.dump(value, output, protocol=pickle.HIGHEST_PROTOCOL)
+        return path
+
+    def read_pickle(self, path: str | Path) -> Any:
+        """Read trusted private metadata from a workspace pickle artifact."""
+        artifact_path = self._require_regular_workspace_file(path)
+        with artifact_path.open("rb") as source:
+            return pickle.load(source)
+
+    def close(self) -> None:
+        """Remove the workspace and every artifact it owns."""
+        if self._closed:
+            return
+        self._temporary_directory.cleanup()
+        self._closed = True
+
+    def __enter__(self) -> FileJobWorkspace:
+        self._require_open()
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        self.close()
+
+    def _allocate_path(
+        self,
+        ordinal: int,
+        category: str,
+        name: str,
+    ) -> Path:
+        normalized_name = _normalize_artifact_name(name)
+        directory = self._require_workspace_path(
+            self.job_directory(ordinal) / category
+        )
+        directory.mkdir(mode=0o700, exist_ok=True)
+        key = (ordinal, category)
+        sequence = self._path_counters.get(key, 0)
+        self._path_counters[key] = sequence + 1
+        path = directory / f"{sequence:08d}-{normalized_name}"
+        return self._require_workspace_path(path)
+
+    def _require_workspace_path(self, path: str | Path) -> Path:
+        self._require_open()
+        candidate = Path(path)
+        if not candidate.is_absolute():
+            candidate = self._root / candidate
+        resolved = candidate.resolve(strict=False)
+        if not resolved.is_relative_to(self._root):
+            raise ValueError("artifact path must stay inside the file-job workspace")
+        return resolved
+
+    def _require_regular_workspace_file(self, path: str | Path) -> Path:
+        candidate = Path(path)
+        if not candidate.is_absolute():
+            candidate = self._root / candidate
+        artifact_path = self._require_workspace_path(candidate)
+        metadata = candidate.lstat()
+        if not stat.S_ISREG(metadata.st_mode):
+            raise ValueError("workspace artifact must be a regular file")
+        return artifact_path
+
+    def _require_open(self) -> None:
+        if self._closed:
+            raise ValueError("file-job workspace is closed")
+
+
+def _normalize_ordinal(ordinal: int) -> int:
+    if isinstance(ordinal, bool) or not isinstance(ordinal, int) or ordinal < 0:
+        raise ValueError("job ordinal must be a non-negative integer")
+    return ordinal
+
+
+def _normalize_artifact_name(name: str) -> str:
+    if not isinstance(name, str) or not name:
+        raise ValueError("artifact name must be a non-empty file name")
+    path = Path(name)
+    if path.is_absolute() or len(path.parts) != 1 or path.name in {".", ".."}:
+        raise ValueError("artifact name must not contain path traversal")
+    return path.name
+
+
+def _assert_pickle_metadata_value(
+    value: object,
+    *,
+    label: str,
+    active_ids: set[int],
+) -> None:
+    if value is None or type(value) in {bool, int, float, str}:
+        return
+    if isinstance(value, Enum):
+        _assert_pickle_metadata_enum_shape(value, label=label)
+        _assert_pickle_metadata_collection(
+            value,
+            label=label,
+            active_ids=active_ids,
+            values=(value.value,),
+        )
+        return
+    if isinstance(value, (bool, int, float, str)):
+        raise TypeError(f"{label} contains a state-bearing scalar subtype")
+    if isinstance(value, PurePath):
+        if type(value) not in _STANDARD_PATH_TYPES:
+            raise TypeError(f"{label} contains a custom path subtype")
+        return
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        raise TypeError(f"{label} contains file-content bytes")
+    if callable(getattr(value, "close", None)):
+        raise TypeError(f"{label} contains a resource-bearing value")
+    if type(value) is dict:
+        _assert_pickle_metadata_collection(
+            value,
+            label=label,
+            active_ids=active_ids,
+            values=(
+                item
+                for key_value in value.items()
+                for item in key_value
+            ),
+        )
+        return
+    if type(value) in {list, tuple, set, frozenset}:
+        _assert_pickle_metadata_collection(
+            value,
+            label=label,
+            active_ids=active_ids,
+            values=value,
+        )
+        return
+    if isinstance(value, (dict, list, tuple, set, frozenset)):
+        raise TypeError(f"{label} contains a state-bearing collection subtype")
+    if is_dataclass(value) and not isinstance(value, type):
+        field_names = {field.name for field in fields(value)}
+        instance_state = getattr(value, "__dict__", {})
+        extra_state_names = set(instance_state) - field_names
+        if extra_state_names:
+            raise TypeError(f"{label} contains undeclared dataclass state")
+        _assert_pickle_metadata_dataclass_shape(
+            value,
+            label=label,
+            field_names=field_names,
+        )
+        _assert_pickle_metadata_collection(
+            value,
+            label=label,
+            active_ids=active_ids,
+            values=(getattr(value, field.name) for field in fields(value)),
+        )
+        return
+    raise TypeError(
+        f"{label} contains unsupported {type(value).__module__}."
+        f"{type(value).__qualname__}"
+    )
+
+
+def _assert_pickle_metadata_enum_shape(value: Enum, *, label: str) -> None:
+    for value_class in type(value).__mro__:
+        if value_class.__module__ in {"builtins", "enum"}:
+            continue
+        if _has_pickle_hook(value_class):
+            raise TypeError(f"{label} contains custom pickle behavior")
+
+
+def _assert_pickle_metadata_dataclass_shape(
+    value: object,
+    *,
+    label: str,
+    field_names: set[str],
+) -> None:
+    for value_class in type(value).__mro__:
+        if value_class is object:
+            continue
+        slots = value_class.__dict__.get("__slots__", ())
+        if isinstance(slots, str):
+            slots = (slots,)
+        undeclared_slots = set(slots) - field_names - {
+            "__dict__",
+            "__weakref__",
+        }
+        if undeclared_slots:
+            raise TypeError(f"{label} contains undeclared dataclass slots")
+
+        for hook_name in (
+            "__reduce__",
+            "__reduce_ex__",
+            "__getnewargs__",
+            "__getnewargs_ex__",
+            "__getstate__",
+            "__setstate__",
+        ):
+            hook = value_class.__dict__.get(hook_name)
+            if hook is None:
+                continue
+            if (
+                hook_name in {"__getstate__", "__setstate__"}
+                and getattr(hook, "__module__", None) == "dataclasses"
+            ):
+                continue
+            raise TypeError(f"{label} contains custom pickle behavior")
+
+
+def _has_pickle_hook(value_class: type[object]) -> bool:
+    return any(
+        hook_name in value_class.__dict__
+        for hook_name in (
+            "__reduce__",
+            "__reduce_ex__",
+            "__getnewargs__",
+            "__getnewargs_ex__",
+            "__getstate__",
+            "__setstate__",
+        )
+    )
+
+
+def _assert_pickle_metadata_collection(
+    collection: object,
+    *,
+    label: str,
+    active_ids: set[int],
+    values: Iterable[object],
+) -> None:
+    collection_id = id(collection)
+    if collection_id in active_ids:
+        raise TypeError(f"{label} contains a recursive value")
+    active_ids.add(collection_id)
+    try:
+        for value in values:
+            _assert_pickle_metadata_value(
+                value,
+                label=label,
+                active_ids=active_ids,
+            )
+    finally:
+        active_ids.remove(collection_id)

--- a/src/git_stage_batch/utils/repository_buffers.py
+++ b/src/git_stage_batch/utils/repository_buffers.py
@@ -8,6 +8,7 @@ import stat
 import subprocess
 from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
+from pathlib import Path
 
 from ..core.buffer import LineBuffer
 from ..utils.git_command import stream_git_command
@@ -47,15 +48,29 @@ class WorkingTreeObject:
     git_mode: str
 
 
-def load_git_blob_as_buffer(blob_sha: str) -> LineBuffer:
+def load_git_blob_as_buffer(
+    blob_sha: str,
+    *,
+    spool_dir: str | Path | None = None,
+) -> LineBuffer:
     """Load a Git blob as a line buffer."""
-    return LineBuffer.from_chunks(read_git_blob(blob_sha))
+    return LineBuffer.from_chunks(
+        read_git_blob(blob_sha),
+        spool_dir=spool_dir,
+    )
 
 
-def stream_git_blob_buffers(blob_names: Iterable[str]) -> Iterator[GitBlobBuffer]:
+def stream_git_blob_buffers(
+    blob_names: Iterable[str],
+    *,
+    spool_dir: str | Path | None = None,
+) -> Iterator[GitBlobBuffer]:
     """Yield one mmap-capable line buffer at a time from a Git batch reader."""
     for blob in stream_git_blobs(blob_names):
-        buffer = LineBuffer.from_chunks(blob.content_chunks)
+        buffer = LineBuffer.from_chunks(
+            blob.content_chunks,
+            spool_dir=spool_dir,
+        )
         try:
             yield GitBlobBuffer(
                 requested_name=blob.requested_name,
@@ -70,21 +85,30 @@ def stream_git_blob_buffers(blob_names: Iterable[str]) -> Iterator[GitBlobBuffer
 def load_git_tree_files_as_buffers(
     treeish: str,
     file_paths: list[str],
+    *,
+    spool_dir: str | Path | None = None,
 ) -> dict[str, LineBuffer]:
     """Load files from a Git tree as line buffers."""
     tree_blobs = list_git_tree_blobs(treeish, file_paths)
     buffers: dict[str, LineBuffer] = {}
     try:
         for file_path, blob in tree_blobs.items():
-            buffers[file_path] = load_git_blob_as_buffer(blob.blob_sha)
-    except Exception:
+            buffers[file_path] = load_git_blob_as_buffer(
+                blob.blob_sha,
+                spool_dir=spool_dir,
+            )
+    except BaseException:
         for buffer in buffers.values():
             buffer.close()
         raise
     return buffers
 
 
-def read_git_object_buffer_or_none(revision_path: str) -> LineBuffer | None:
+def read_git_object_buffer_or_none(
+    revision_path: str,
+    *,
+    spool_dir: str | Path | None = None,
+) -> LineBuffer | None:
     """Load a Git object, returning ``None`` only when it is absent."""
     # cat-file's traditional batch protocol is line-delimited and cannot
     # represent object expressions containing newlines. Validate the revision
@@ -111,7 +135,10 @@ def read_git_object_buffer_or_none(revision_path: str) -> LineBuffer | None:
                     f"Could not resolve Git revision {revision!r}"
                 ) from error
         try:
-            return LineBuffer.from_chunks(_stream_git_object(revision_path))
+            return LineBuffer.from_chunks(
+                _stream_git_object(revision_path),
+                spool_dir=spool_dir,
+            )
         except subprocess.CalledProcessError:
             return None
     try:
@@ -127,38 +154,66 @@ def read_git_object_buffer_or_none(revision_path: str) -> LineBuffer | None:
             f"Git object {revision_path!r} is {resolved.object_type}, not a blob"
         )
     try:
-        return load_git_blob_as_buffer(resolved.object_id)
+        return load_git_blob_as_buffer(
+            resolved.object_id,
+            spool_dir=spool_dir,
+        )
     except (subprocess.CalledProcessError, RuntimeError) as error:
         raise GitOperationFailed(
             f"Could not read Git object {revision_path!r}"
         ) from error
 
 
-def read_git_object_buffer(revision_path: str) -> LineBuffer:
+def read_git_object_buffer(
+    revision_path: str,
+    *,
+    spool_dir: str | Path | None = None,
+) -> LineBuffer:
     """Load a Git blob or raise a typed missing/failure exception."""
-    buffer = read_git_object_buffer_or_none(revision_path)
+    buffer = read_git_object_buffer_or_none(
+        revision_path,
+        spool_dir=spool_dir,
+    )
     if buffer is None:
         raise RepositoryObjectMissing(revision_path)
     return buffer
 
 
-def read_git_object_buffer_or_empty(revision_path: str) -> LineBuffer:
+def read_git_object_buffer_or_empty(
+    revision_path: str,
+    *,
+    spool_dir: str | Path | None = None,
+) -> LineBuffer:
     """Load a Git object as a line buffer, or an empty buffer if missing."""
-    buffer = read_git_object_buffer_or_none(revision_path)
+    buffer = read_git_object_buffer_or_none(
+        revision_path,
+        spool_dir=spool_dir,
+    )
     if buffer is None:
-        return LineBuffer.from_bytes(b"")
+        return LineBuffer.from_bytes(b"", spool_dir=spool_dir)
     return buffer
 
 
-def load_working_tree_file_as_buffer(file_path: str) -> LineBuffer:
+def load_working_tree_file_as_buffer(
+    file_path: str,
+    *,
+    spool_dir: str | Path | None = None,
+) -> LineBuffer:
     """Load a working-tree file, returning empty only when it is absent."""
     try:
-        return read_working_tree_object(file_path).buffer
+        return read_working_tree_object(
+            file_path,
+            spool_dir=spool_dir,
+        ).buffer
     except RepositoryPathMissing:
-        return LineBuffer.from_bytes(b"")
+        return LineBuffer.from_bytes(b"", spool_dir=spool_dir)
 
 
-def read_working_tree_object(file_path: str) -> WorkingTreeObject:
+def read_working_tree_object(
+    file_path: str,
+    *,
+    spool_dir: str | Path | None = None,
+) -> WorkingTreeObject:
     """Read Git-visible worktree content without following symlinks."""
     repo_root = get_git_repository_root_path()
     full_path = repo_root / file_path
@@ -166,7 +221,10 @@ def read_working_tree_object(file_path: str) -> WorkingTreeObject:
         metadata = full_path.lstat()
         if stat.S_ISLNK(metadata.st_mode):
             return WorkingTreeObject(
-                buffer=LineBuffer.from_bytes(os.readlink(os.fsencode(full_path))),
+                buffer=LineBuffer.from_bytes(
+                    os.readlink(os.fsencode(full_path)),
+                    spool_dir=spool_dir,
+                ),
                 kind="symlink",
                 git_mode="120000",
             )
@@ -176,7 +234,10 @@ def read_working_tree_object(file_path: str) -> WorkingTreeObject:
             )
         mode = "100755" if metadata.st_mode & stat.S_IXUSR else "100644"
         return WorkingTreeObject(
-            buffer=LineBuffer.from_path(full_path),
+            buffer=LineBuffer.from_path(
+                full_path,
+                spool_dir=spool_dir,
+            ),
             kind="regular",
             git_mode=mode,
         )

--- a/tests/batch/line_matching/test_match_workspace.py
+++ b/tests/batch/line_matching/test_match_workspace.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+import pytest
+
+import git_stage_batch.batch.line_matching.match as match_module
+import git_stage_batch.core.mapped_storage as mapped_storage_module
+from git_stage_batch.batch.line_matching.match import match_lines
 from git_stage_batch.batch.line_matching.match_workspace import MatcherWorkspace
 
 
@@ -22,3 +27,67 @@ def test_matcher_workspace_tracks_and_closes_resources():
     workspace.close()
     assert records.closed
     assert workspace.current_bytes == 0
+
+
+def test_match_lines_routes_mapped_storage_to_requested_spool(
+    tmp_path,
+    monkeypatch,
+):
+    """Mappings and matcher scratch should stay in invocation-owned storage."""
+    temporary_directories = []
+    real_temporary_file = mapped_storage_module._temporary_file
+
+    def recording_temporary_file(spool_dir=None):
+        temporary_directories.append(spool_dir)
+        return real_temporary_file(spool_dir)
+
+    monkeypatch.setattr(
+        mapped_storage_module,
+        "_temporary_file",
+        recording_temporary_file,
+    )
+    spool_dir = tmp_path / "scratch"
+    spool_dir.mkdir()
+    lines = [f"line {index}\n".encode() for index in range(2_000)]
+
+    with match_lines(lines, lines, spool_dir=spool_dir) as mapping:
+        assert len(tuple(mapping.mapped_line_pairs())) == len(lines)
+
+    assert temporary_directories
+    assert all(
+        directory is not None
+        and directory.resolve() == spool_dir.resolve()
+        for directory in temporary_directories
+    )
+
+
+def test_match_lines_closes_first_mapping_if_second_allocation_fails(
+    monkeypatch,
+):
+    """Partial mapping allocation should not leak the first mapped vector."""
+    class ClosingVector(list):
+        closed = False
+
+        def close(self):
+            self.closed = True
+
+    source_mapping = ClosingVector([0])
+    calls = 0
+
+    def allocate_mapping(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return source_mapping
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(
+        match_module,
+        "_new_line_mapping",
+        allocate_mapping,
+    )
+
+    with pytest.raises(KeyboardInterrupt):
+        match_lines([b"line\n"], [b"line\n"])
+
+    assert source_mapping.closed is True

--- a/tests/batch/ownership/test_model.py
+++ b/tests/batch/ownership/test_model.py
@@ -371,10 +371,10 @@ def test_build_file_attribution_bulk_loads_batch_source_buffers(
         resolution_calls.append(refspecs)
         return original_resolve(refspecs)
 
-    def counting_buffer_stream(object_ids):
+    def counting_buffer_stream(object_ids, **kwargs):
         object_ids = tuple(object_ids)
         buffer_stream_calls.append(object_ids)
-        yield from original_buffer_stream(object_ids)
+        yield from original_buffer_stream(object_ids, **kwargs)
 
     monkeypatch.setattr(
         attribution_module,
@@ -461,10 +461,10 @@ def test_build_file_attribution_deduplicates_sources_deletions_and_mappings(
         deletion_stream_calls.append(object_ids)
         yield from original_deletion_stream(object_ids, **kwargs)
 
-    def recording_buffer_stream(object_ids):
+    def recording_buffer_stream(object_ids, **kwargs):
         object_ids = tuple(object_ids)
         buffer_stream_calls.append(object_ids)
-        yield from original_buffer_stream(object_ids)
+        yield from original_buffer_stream(object_ids, **kwargs)
 
     match_calls = 0
     original_match = attribution_module.match_lines
@@ -653,6 +653,38 @@ def test_file_attribution_from_lines_matches_repository_wrapper(temp_repo):
 
     assert explicit == wrapped
     assert explicit_metrics == wrapper_metrics
+
+
+def test_file_attribution_from_lines_propagates_invocation_spool(
+    tmp_path,
+    monkeypatch,
+):
+    """Baseline matching should use the supplied job scratch storage."""
+    spool_directories = []
+    original_match_lines = attribution_units_module.match_lines
+
+    def record_match(*args, **kwargs):
+        spool_directories.append(kwargs.get("spool_dir"))
+        return original_match_lines(*args, **kwargs)
+
+    monkeypatch.setattr(
+        attribution_units_module,
+        "match_lines",
+        record_match,
+    )
+    spool_dir = tmp_path / "scratch"
+    spool_dir.mkdir()
+
+    attribution = build_file_attribution_from_lines(
+        "file.txt",
+        baseline_lines=[b"old\n"],
+        working_tree_lines=[b"new\n"],
+        batch_metadata_by_name={},
+        spool_dir=spool_dir,
+    )
+
+    assert attribution.file_path == "file.txt"
+    assert spool_directories == [spool_dir]
 
 
 def test_build_file_attribution_is_independent_of_batch_traversal_order(temp_repo):

--- a/tests/batch/ownership/test_model.py
+++ b/tests/batch/ownership/test_model.py
@@ -587,6 +587,72 @@ def test_supplemental_attribution_does_not_construct_a_state_ref():
     )
 
 
+def test_supplemental_override_is_not_treated_as_state_backed(monkeypatch):
+    """A same-name supplemental entry must retain supplemental source rules."""
+    captured = {}
+
+    def capture_batches(
+        _file_path,
+        all_batch_metadata,
+        *,
+        state_backed_batch_names,
+        **_kwargs,
+    ):
+        captured["metadata"] = all_batch_metadata
+        captured["state_backed_names"] = state_backed_batch_names
+
+    monkeypatch.setattr(
+        attribution_module,
+        "_attribute_batches",
+        capture_batches,
+    )
+    primary_metadata = {
+        "real": {
+            "files": {
+                "test.txt": {
+                    "batch_source_commit": "primary-source",
+                    "source_path": "primary/test.txt",
+                }
+            }
+        }
+    }
+    supplemental_metadata = {
+        "real": {
+            "files": {
+                "test.txt": {
+                    "batch_source_commit": "supplemental-source",
+                    "source_path": "supplemental/test.txt",
+                }
+            }
+        },
+        "unrelated": {
+            "files": {
+                "other.txt": {
+                    "batch_source_commit": "other-source",
+                }
+            }
+        },
+    }
+
+    build_file_attribution_from_lines(
+        "test.txt",
+        baseline_lines=(),
+        working_tree_lines=(),
+        batch_metadata_by_name=primary_metadata,
+        supplemental_batch_metadata=supplemental_metadata,
+    )
+
+    assert set(captured["metadata"]) == {"real"}
+    assert captured["state_backed_names"] == frozenset()
+    request = attribution_module._batch_source_requests(
+        "test.txt",
+        captured["metadata"],
+        state_backed_batch_names=captured["state_backed_names"],
+    )[0]
+    assert request.primary_refspec == "supplemental-source:test.txt"
+    assert request.fallback_refspec == "supplemental-source:test.txt"
+
+
 def test_trusted_many_batch_source_requests_do_not_revalidate_names(monkeypatch):
     """Attribution's trusted boundary must not spawn validation per batch."""
     metadata = {

--- a/tests/batch/source/test_annotation.py
+++ b/tests/batch/source/test_annotation.py
@@ -105,7 +105,7 @@ def test_annotate_with_batch_source_working_lines_accepts_sequences(
     monkeypatch.setattr(
         source_annotation_module,
         "read_git_object_buffer_or_none",
-        lambda revision_path: LineBuffer.from_chunks(
+        lambda revision_path, **_kwargs: LineBuffer.from_chunks(
             iter([b"line 1\n", b"line 2\n"])
         ),
     )
@@ -171,7 +171,7 @@ def test_annotate_with_batch_source_loads_indexed_buffers(monkeypatch, tmp_path)
         lambda path: "source-commit",
     )
 
-    def fake_read_git_object_buffer_or_none(revision_path):
+    def fake_read_git_object_buffer_or_none(revision_path, **_kwargs):
         loaded_revisions.append(revision_path)
         return LineBuffer.from_chunks(iter([b"line 1\n", b"line 2\n"]))
 
@@ -231,12 +231,12 @@ def test_acquired_mapping_annotates_multiple_hunks_with_one_match(monkeypatch):
     monkeypatch.setattr(
         source_annotation_module,
         "read_git_object_buffer_or_none",
-        lambda _refspec: LineBuffer.from_chunks([b"line 1\n"]),
+        lambda _refspec, **_kwargs: LineBuffer.from_chunks([b"line 1\n"]),
     )
 
-    def counting_match_lines(source_lines, working_lines):
+    def counting_match_lines(source_lines, working_lines, **kwargs):
         calls.append((source_lines, working_lines))
-        return original_match_lines(source_lines, working_lines)
+        return original_match_lines(source_lines, working_lines, **kwargs)
 
     monkeypatch.setattr(
         source_annotation_module,
@@ -256,3 +256,53 @@ def test_acquired_mapping_annotates_multiple_hunks_with_one_match(monkeypatch):
     assert len(calls) == 1
     assert [line.source_line for line in first.lines] == [1, None]
     assert [line.source_line for line in second.lines] == [1, None]
+
+
+def test_acquired_mapping_propagates_invocation_spool(tmp_path, monkeypatch):
+    """Source loading and matching should share the job scratch directory."""
+    loaded_spool_directories = []
+    matching_spool_directories = []
+    original_match_lines = source_annotation_module.match_lines
+
+    def load_source(_refspec, *, spool_dir=None):
+        loaded_spool_directories.append(spool_dir)
+        return LineBuffer.from_chunks(
+            [b"line 1\n"],
+            spool_dir=spool_dir,
+        )
+
+    def record_match(source_lines, working_lines, *, spool_dir=None):
+        matching_spool_directories.append(spool_dir)
+        return original_match_lines(
+            source_lines,
+            working_lines,
+            spool_dir=spool_dir,
+        )
+
+    monkeypatch.setattr(
+        source_annotation_module,
+        "read_git_object_buffer_or_none",
+        load_source,
+    )
+    monkeypatch.setattr(
+        source_annotation_module,
+        "match_lines",
+        record_match,
+    )
+    spool_dir = tmp_path / "scratch"
+    spool_dir.mkdir()
+
+    with LineBuffer.from_chunks(
+        [b"line 1\n"],
+        spool_dir=spool_dir,
+    ) as working_lines:
+        with acquire_batch_source_mapping(
+            "file.txt",
+            batch_source_commit="source-commit",
+            working_lines=working_lines,
+            spool_dir=spool_dir,
+        ):
+            pass
+
+    assert loaded_spool_directories == [spool_dir]
+    assert matching_spool_directories == [spool_dir]

--- a/tests/batch/state/test_query.py
+++ b/tests/batch/state/test_query.py
@@ -15,7 +15,8 @@ from git_stage_batch.batch.state.query import (
     read_batch_metadata,
     read_batch_metadata_for_batches,
 )
-from git_stage_batch.batch.state.lifecycle import create_batch
+from git_stage_batch.batch.state.lifecycle import create_batch, update_batch_note
+from git_stage_batch.batch.state.references import get_batch_state_ref_name
 from git_stage_batch.batch.text_file_storage import add_file_to_batch
 from git_stage_batch.batch.ownership.model import BatchOwnership
 from git_stage_batch.data.session import initialize_abort_state
@@ -89,6 +90,28 @@ def test_read_batch_metadata_for_batches_reads_existing_batches(temp_git_repo):
     assert metadata_by_name["batch-b"]["note"] == "B"
     assert metadata_by_name["batch-a"]["created_at"]
     assert metadata_by_name["batch-b"]["created_at"]
+
+
+def test_bulk_metadata_can_read_a_captured_state_commit(temp_git_repo):
+    """Canonical state commits should keep metadata stable across ref movement."""
+    create_batch("test-batch", "Before")
+    captured_state_commit = subprocess.run(
+        ["git", "rev-parse", get_batch_state_ref_name("test-batch")],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    update_batch_note("test-batch", "After")
+
+    metadata_by_name = read_batch_metadata_for_batches(
+        ["test-batch"],
+        batch_state_commit_by_name={
+            "test-batch": captured_state_commit,
+        },
+    )
+
+    assert metadata_by_name["test-batch"]["note"] == "Before"
+    assert read_batch_metadata("test-batch")["note"] == "After"
 
 
 def test_read_batch_metadata_for_batches_returns_empty_for_missing_batch(temp_git_repo):

--- a/tests/batch/state/test_references.py
+++ b/tests/batch/state/test_references.py
@@ -176,6 +176,61 @@ def test_read_batch_state_metadata_for_batches_uses_one_batch_object_read(
     )
 
 
+@pytest.mark.parametrize(
+    "state_commit",
+    (
+        "not-an-object-id",
+        "a" * 39,
+        "g" * 40,
+        "a" * 64 + "\n",
+        None,
+        b"a" * 40,
+    ),
+)
+def test_canonical_state_metadata_rejects_malformed_object_ids(
+    monkeypatch,
+    state_commit,
+):
+    """Canonical mappings must not inject expressions into Git batch input."""
+    monkeypatch.setattr(
+        state_refs_module,
+        "read_git_blobs_as_bytes",
+        lambda _refspecs: (_ for _ in ()).throw(
+            AssertionError("unexpected Git object read")
+        ),
+    )
+
+    with pytest.raises(ValueError, match="full hexadecimal object ID"):
+        read_batch_state_metadata_for_batches(
+            ["batch-a"],
+            state_commit_by_name={"batch-a": state_commit},
+        )
+
+
+def test_canonical_state_metadata_skips_names_without_captured_commits(
+    monkeypatch,
+):
+    """A partial snapshot must not fall back to mutable state refs."""
+    captured_refspecs = []
+    monkeypatch.setattr(
+        state_refs_module,
+        "validate_batch_name",
+        lambda _name: None,
+    )
+    monkeypatch.setattr(
+        state_refs_module,
+        "read_git_blobs_as_bytes",
+        lambda refspecs: captured_refspecs.extend(refspecs) or {},
+    )
+    state_commit = "a" * 40
+
+    assert read_batch_state_metadata_for_batches(
+        ["captured", "missing"],
+        state_commit_by_name={"captured": state_commit},
+    ) == {}
+    assert captured_refspecs == [f"{state_commit}:batch.json"]
+
+
 def test_delete_batch_removes_experimental_refs(temp_git_repo):
     """Deleting a batch removes its mirrored content and state refs."""
     create_batch("test-batch", "Test")

--- a/tests/core/test_buffer.py
+++ b/tests/core/test_buffer.py
@@ -396,6 +396,41 @@ def test_line_buffer_uses_mapped_storage_for_page_sized_files(tmp_path):
         assert buffer[1] == b"x" * (mmap.PAGESIZE - len(b"alpha\n"))
 
 
+def test_line_buffer_releases_mapped_backing_when_index_setup_fails(
+    tmp_path,
+    monkeypatch,
+):
+    """Failed line-index setup should close newly acquired mapped storage."""
+    file_path = tmp_path / "buffer.txt"
+    file_path.write_bytes(b"x" * mmap.PAGESIZE)
+    released_backings = []
+    real_release = buffer_module._BufferBacking.release
+
+    def recording_release(backing):
+        real_release(backing)
+        released_backings.append(backing)
+
+    def fail_line_index(*, spool_dir=None):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(
+        buffer_module._BufferBacking,
+        "release",
+        recording_release,
+    )
+    monkeypatch.setattr(buffer_module, "_LineSpanVector", fail_line_index)
+
+    with pytest.raises(KeyboardInterrupt):
+        LineBuffer.from_path(file_path)
+
+    assert len(released_backings) == 1
+    backing = released_backings[0]
+    assert isinstance(backing.data, mmap.mmap)
+    assert backing.data.closed is True
+    assert backing.file_handle is not None
+    assert backing.file_handle.closed is True
+
+
 def test_line_buffer_clone_survives_original_close():
     """A clone retains shared heap storage after its original closes."""
     original = LineBuffer.from_bytes(b"alpha\nbeta\n")
@@ -436,6 +471,24 @@ def test_line_buffer_clones_have_independent_line_indexes():
 
     original.close()
     clone.close()
+
+
+def test_line_buffer_failed_clone_releases_retained_backing(monkeypatch):
+    """Failed clone setup should undo its backing retain."""
+    original = LineBuffer.from_bytes(b"alpha\nbeta\n")
+    backing = original._backing
+
+    def fail_line_index(*, spool_dir=None):
+        raise OSError("line-index setup failed")
+
+    monkeypatch.setattr(buffer_module, "_LineSpanVector", fail_line_index)
+
+    with pytest.raises(OSError, match="line-index setup failed"):
+        original.clone()
+
+    assert backing._reference_count == 1
+    original.close()
+    assert backing._closed is True
 
 
 def test_line_buffer_mapped_backing_closes_after_final_clone(tmp_path):

--- a/tests/data/test_selected_hunk_filtering.py
+++ b/tests/data/test_selected_hunk_filtering.py
@@ -151,6 +151,37 @@ def test_explicit_attribution_filter_is_io_free(monkeypatch):
         attribution=FileAttribution(file_path="file.txt", units=[]),
         batch_metadata_by_name={},
         consumed_file_metadata=None,
+        captured_empty_lifecycle_is_batched=False,
     )
 
     assert filtered is line_changes
+
+
+def test_explicit_filter_preserves_existing_empty_lifecycle_default(monkeypatch):
+    """Callers that omit a snapshot should retain repository-backed behavior."""
+    line_changes = LineLevelChange(
+        path="empty.txt",
+        header=HunkHeader(old_start=0, old_len=0, new_start=0, new_len=0),
+        lines=[],
+    )
+    monkeypatch.setattr(
+        hunk_filtering_module,
+        "_empty_lifecycle_change_is_batched",
+        lambda _changes, **_kwargs: True,
+    )
+    monkeypatch.setattr(
+        hunk_filtering_module,
+        "filter_owned_diff_fragments",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("owned projection should not run")
+        ),
+    )
+
+    filtered = filter_line_level_change_with_attribution(
+        line_changes,
+        attribution=FileAttribution(file_path="empty.txt", units=[]),
+        batch_metadata_by_name={},
+        consumed_file_metadata=None,
+    )
+
+    assert filtered is None

--- a/tests/utils/test_file_job_workspace.py
+++ b/tests/utils/test_file_job_workspace.py
@@ -1,0 +1,371 @@
+"""Tests for invocation-private file-job artifacts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+import stat
+
+import pytest
+
+import git_stage_batch.core.mapped_storage as mapped_storage_module
+from git_stage_batch.batch.line_matching.line_mapping import LineMapping
+from git_stage_batch.core.buffer import LineBuffer
+from git_stage_batch.utils.file_job_workspace import FileJobWorkspace
+
+
+@dataclass
+class _MetadataRecord:
+    marker: int
+
+
+class _MetadataTuple(tuple):
+    pass
+
+
+class _MetadataBase:
+    __slots__ = ("hidden",)
+
+
+@dataclass(slots=True)
+class _SlottedMetadataRecord(_MetadataBase):
+    marker: int
+
+
+@dataclass
+class _ListMetadata(list):
+    __slots__ = ()
+
+
+@dataclass
+class _CustomPickleMetadata:
+    marker: int
+
+    def __reduce__(self):
+        return bytes, (b"content",)
+
+
+class _CustomPickleMetadataMarker(Enum):
+    ONE = 1
+
+    def __reduce_ex__(self, _protocol):
+        return bytes, (b"content",)
+
+
+class _RecursiveMetadataMarker(Enum):
+    ONE = 1
+
+
+def test_workspace_owns_deterministic_job_paths_and_cleans_up(tmp_path):
+    """Job directories should be ordinal-based and removed with the workspace."""
+    with FileJobWorkspace(parent_directory=tmp_path) as workspace:
+        root = workspace.root
+        first_job = workspace.job_directory(7)
+        repeated_job = workspace.job_directory(7)
+        scratch = workspace.scratch_directory(7)
+        first_output = workspace.output_path(7, "result.json")
+        second_output = workspace.output_path(7, "result.json")
+
+        assert stat.S_IMODE(root.stat().st_mode) == 0o700
+        assert first_job == root / "jobs" / "00000007"
+        assert repeated_job == first_job
+        assert scratch == first_job / "scratch"
+        assert first_output.parent == first_job / "outputs"
+        assert second_output.parent == first_job / "outputs"
+        assert first_output != second_output
+
+    assert not root.exists()
+
+
+@pytest.mark.parametrize(
+    "name",
+    (
+        "",
+        ".",
+        "..",
+        "../outside",
+        "nested/artifact",
+        "/absolute",
+    ),
+)
+def test_workspace_rejects_artifact_path_traversal(tmp_path, name):
+    """Artifact names must not escape or introduce path-derived directories."""
+    with FileJobWorkspace(parent_directory=tmp_path) as workspace:
+        with pytest.raises(ValueError):
+            workspace.artifact_path(0, name)
+
+
+def test_workspace_rejects_symlinked_job_directory_escape(tmp_path):
+    """Ordinal paths should be validated before creating escaped directories."""
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    with FileJobWorkspace(parent_directory=tmp_path) as workspace:
+        (workspace.root / "jobs").symlink_to(
+            outside,
+            target_is_directory=True,
+        )
+
+        with pytest.raises(
+            ValueError,
+            match="must stay inside",
+        ):
+            workspace.scratch_directory(0)
+
+    assert list(outside.iterdir()) == []
+
+
+def test_workspace_streams_buffer_without_materializing_it(tmp_path, monkeypatch):
+    """Buffer artifacts should use chunk streaming rather than to_bytes."""
+    source = LineBuffer.from_chunks(
+        (b"line\n" for _ in range(2_000)),
+        spool_dir=tmp_path,
+    )
+    try:
+        monkeypatch.setattr(
+            LineBuffer,
+            "to_bytes",
+            lambda self: (_ for _ in ()).throw(
+                AssertionError("buffer was materialized")
+            ),
+        )
+        with FileJobWorkspace(parent_directory=tmp_path) as workspace:
+            artifact = workspace.write_buffer(0, "input.patch", source)
+
+            with LineBuffer.from_path(
+                artifact,
+                spool_dir=workspace.scratch_directory(0),
+            ) as written:
+                assert len(written) == 2_000
+    finally:
+        source.close()
+
+
+def test_workspace_metadata_reads_reject_external_symlink_alias(tmp_path):
+    """Worker output aliases should not redirect parent artifact reads."""
+    outside = tmp_path / "outside"
+    outside.write_text('{"outside":true}\n', encoding="utf-8")
+    with FileJobWorkspace(parent_directory=tmp_path) as workspace:
+        output = workspace.output_path(0, "result.json")
+        output.symlink_to(outside)
+
+        with pytest.raises(ValueError, match="must stay inside"):
+            workspace.read_json(output)
+
+
+def test_workspace_metadata_reads_reject_internal_symlink_alias(tmp_path):
+    """Even in-workspace aliases should not substitute worker output."""
+    with FileJobWorkspace(parent_directory=tmp_path) as workspace:
+        artifact = workspace.write_json(0, "input.json", {"content": True})
+        output = workspace.output_path(0, "result.json")
+        output.symlink_to(artifact)
+
+        with pytest.raises(ValueError, match="regular file"):
+            workspace.read_json(output)
+
+
+def test_workspace_supports_private_metadata_formats(tmp_path):
+    """JSON, JSONL, and pickle metadata should round trip inside the workspace."""
+    with FileJobWorkspace(parent_directory=tmp_path) as workspace:
+        json_path = workspace.write_json(1, "metadata.json", {"name": "one"})
+        jsonl_path = workspace.write_jsonl(
+            1,
+            "records.jsonl",
+            ({"ordinal": ordinal} for ordinal in range(3)),
+        )
+        pickle_path = workspace.write_pickle(
+            1,
+            "metadata.pickle",
+            {"paths": (Path("one"), Path("two"))},
+        )
+
+        assert workspace.read_json(json_path) == {"name": "one"}
+        assert list(workspace.stream_jsonl(jsonl_path)) == [
+            {"ordinal": 0},
+            {"ordinal": 1},
+            {"ordinal": 2},
+        ]
+        assert workspace.read_pickle(pickle_path) == {
+            "paths": (Path("one"), Path("two"))
+        }
+
+
+def test_workspace_json_formats_preserve_surrogateescaped_paths(tmp_path):
+    """Private JSON metadata should support arbitrary Git path bytes."""
+    file_path = "invalid-\udcff.txt"
+    with FileJobWorkspace(parent_directory=tmp_path) as workspace:
+        json_path = workspace.write_json(
+            1,
+            "metadata.json",
+            {"file_path": file_path},
+        )
+        jsonl_path = workspace.write_jsonl(
+            1,
+            "records.jsonl",
+            ({"file_path": file_path},),
+        )
+
+        assert workspace.read_json(json_path) == {"file_path": file_path}
+        assert list(workspace.stream_jsonl(jsonl_path)) == [
+            {"file_path": file_path}
+        ]
+
+
+def test_workspace_pickle_rejects_content_and_resource_graphs(tmp_path):
+    """Private pickle metadata must not become a content transport."""
+    with (
+        FileJobWorkspace(parent_directory=tmp_path) as workspace,
+        LineBuffer.from_bytes(b"content") as buffer,
+        LineMapping([0], [0]) as mapping,
+    ):
+        for value in (
+            b"content",
+            {"lines": [b"content"]},
+            buffer,
+            mapping,
+        ):
+            with pytest.raises(TypeError):
+                workspace.write_pickle(0, "metadata.pickle", value)
+
+
+def test_workspace_pickle_rejects_hidden_instance_state(tmp_path):
+    """Private metadata must not hide content in undeclared pickle state."""
+    record = _MetadataRecord(1)
+    record.hidden = b"content"
+    tuple_value = _MetadataTuple((1,))
+    tuple_value.hidden = b"content"
+    slotted_value = _SlottedMetadataRecord(1)
+    slotted_value.hidden = b"content"
+    list_value = _ListMetadata()
+    list_value.append(b"content")
+
+    with FileJobWorkspace(parent_directory=tmp_path) as workspace:
+        for value in (record, tuple_value, slotted_value, list_value):
+            with pytest.raises(TypeError):
+                workspace.write_pickle(0, "metadata.pickle", value)
+
+
+def test_workspace_pickle_rejects_custom_pickle_behavior(tmp_path):
+    """Private metadata serialization must match the validated object graph."""
+    with FileJobWorkspace(parent_directory=tmp_path) as workspace:
+        for value in (
+            _CustomPickleMetadata(1),
+            _CustomPickleMetadataMarker.ONE,
+        ):
+            with pytest.raises(TypeError, match="custom pickle behavior"):
+                workspace.write_pickle(0, "metadata.pickle", value)
+
+
+def test_workspace_pickle_rejects_recursive_enum(tmp_path, monkeypatch):
+    """Enum value cycles should fail before pickle traversal."""
+    monkeypatch.setattr(
+        _RecursiveMetadataMarker.ONE,
+        "_value_",
+        _RecursiveMetadataMarker.ONE,
+    )
+
+    with FileJobWorkspace(parent_directory=tmp_path) as workspace:
+        with pytest.raises(TypeError, match="recursive value"):
+            workspace.write_pickle(
+                0,
+                "metadata.pickle",
+                _RecursiveMetadataMarker.ONE,
+            )
+
+
+def test_workspace_with_relative_parent_cleans_up_after_cwd_change(
+    tmp_path,
+    monkeypatch,
+):
+    """Cleanup should not depend on the cwd used to create the workspace."""
+    parent = tmp_path / "workspaces"
+    parent.mkdir()
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.chdir(tmp_path)
+    workspace = FileJobWorkspace(parent_directory="workspaces")
+    root = workspace.root
+
+    monkeypatch.chdir(elsewhere)
+    workspace.close()
+
+    assert not root.exists()
+
+
+def test_workspace_cleanup_can_be_retried_after_failure(tmp_path, monkeypatch):
+    """A failed removal should not permanently mark the workspace closed."""
+    workspace = FileJobWorkspace(parent_directory=tmp_path)
+    root = workspace.root
+    real_cleanup = workspace._temporary_directory.cleanup
+    cleanup_calls = 0
+
+    def flaky_cleanup():
+        nonlocal cleanup_calls
+        cleanup_calls += 1
+        if cleanup_calls == 1:
+            raise OSError("cleanup interrupted")
+        real_cleanup()
+
+    monkeypatch.setattr(
+        workspace._temporary_directory,
+        "cleanup",
+        flaky_cleanup,
+    )
+
+    with pytest.raises(OSError, match="cleanup interrupted"):
+        workspace.close()
+
+    assert root.exists()
+    assert workspace.job_directory(1).exists()
+
+    workspace.close()
+
+    assert cleanup_calls == 2
+    assert not root.exists()
+
+
+def test_path_backed_line_buffer_spools_indexes_inside_job_scratch(
+    tmp_path,
+    monkeypatch,
+):
+    """Path-backed line indexes should honor the invocation scratch directory."""
+    temporary_directories = []
+    real_temporary_file = mapped_storage_module._temporary_file
+
+    def recording_temporary_file(spool_dir=None):
+        temporary_directories.append(spool_dir)
+        return real_temporary_file(spool_dir)
+
+    monkeypatch.setattr(
+        mapped_storage_module,
+        "_temporary_file",
+        recording_temporary_file,
+    )
+
+    with FileJobWorkspace(parent_directory=tmp_path) as workspace:
+        artifact = workspace.write_buffer(
+            2,
+            "large.txt",
+            (b"unchanged line\n" for _ in range(2_000)),
+        )
+        scratch = workspace.scratch_directory(2)
+        with LineBuffer.from_path(artifact, spool_dir=scratch) as buffer:
+            assert len(buffer) == 2_000
+
+        assert temporary_directories
+        assert all(
+            directory is not None
+            and directory.resolve() == scratch.resolve()
+            for directory in temporary_directories
+        )
+
+
+def test_workspace_cleanup_runs_after_keyboard_interrupt(tmp_path):
+    """Invocation artifacts should be removed when the owner is interrupted."""
+    with pytest.raises(KeyboardInterrupt):
+        with FileJobWorkspace(parent_directory=tmp_path) as workspace:
+            root = workspace.root
+            workspace.write_json(0, "metadata.json", {"ready": True})
+            raise KeyboardInterrupt
+
+    assert not root.exists()

--- a/tests/utils/test_repository_buffers.py
+++ b/tests/utils/test_repository_buffers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import pytest
 
+import git_stage_batch.core.mapped_storage as mapped_storage_module
 from git_stage_batch.core.buffer import LineBuffer
 import git_stage_batch.utils.repository_buffers as repository_buffers
 from git_stage_batch.utils.repository_buffers import (
@@ -38,9 +39,18 @@ def test_load_git_blob_as_buffer_loads_streamed_blob(monkeypatch):
         assert buffer[1] == b"beta\n"
 
 
-def test_stream_git_blob_buffers_spools_and_closes_each_source(monkeypatch):
+def test_stream_git_blob_buffers_spools_and_closes_each_source(
+    monkeypatch,
+    tmp_path,
+):
     """Batch-loaded source buffers should be mmap-backed and file-local."""
     payload = b"line\n" * 2_000
+    temporary_directories = []
+    real_temporary_file = mapped_storage_module._temporary_file
+
+    def recording_temporary_file(spool_dir=None):
+        temporary_directories.append(spool_dir)
+        return real_temporary_file(spool_dir)
 
     def fake_stream_git_blobs(blob_names):
         for blob_name in blob_names:
@@ -56,8 +66,18 @@ def test_stream_git_blob_buffers_spools_and_closes_each_source(monkeypatch):
         "stream_git_blobs",
         fake_stream_git_blobs,
     )
+    monkeypatch.setattr(
+        mapped_storage_module,
+        "_temporary_file",
+        recording_temporary_file,
+    )
+    spool_dir = tmp_path / "scratch"
+    spool_dir.mkdir()
 
-    buffers = stream_git_blob_buffers(["first", "second"])
+    buffers = stream_git_blob_buffers(
+        ["first", "second"],
+        spool_dir=spool_dir,
+    )
     first = next(buffers)
     assert first.buffer.uses_mapped_storage is True
     assert first.buffer[0] == b"line\n"
@@ -70,11 +90,18 @@ def test_stream_git_blob_buffers_spools_and_closes_each_source(monkeypatch):
     buffers.close()
     with pytest.raises(ValueError, match="closed"):
         len(second.buffer)
+    assert temporary_directories
+    assert all(
+        directory is not None
+        and directory.resolve() == spool_dir.resolve()
+        for directory in temporary_directories
+    )
 
 
-def test_load_git_tree_files_as_buffers_loads_tree_blobs(monkeypatch):
+def test_load_git_tree_files_as_buffers_loads_tree_blobs(monkeypatch, tmp_path):
     """Files from a Git tree are loaded by blob SHA."""
     calls = []
+    loaded_blobs = []
 
     def fake_list_git_tree_blobs(treeish, file_paths):
         calls.append((treeish, list(file_paths)))
@@ -83,8 +110,12 @@ def test_load_git_tree_files_as_buffers_loads_tree_blobs(monkeypatch):
             "beta.txt": GitTreeBlob("beta.txt", "100644", "beta-sha"),
         }
 
-    def fake_load_git_blob_as_buffer(blob_sha):
-        return LineBuffer.from_bytes(blob_sha.encode("ascii") + b"\n")
+    def fake_load_git_blob_as_buffer(blob_sha, *, spool_dir=None):
+        loaded_blobs.append((blob_sha, spool_dir))
+        return LineBuffer.from_bytes(
+            blob_sha.encode("ascii") + b"\n",
+            spool_dir=spool_dir,
+        )
 
     monkeypatch.setattr(
         repository_buffers,
@@ -97,9 +128,19 @@ def test_load_git_tree_files_as_buffers_loads_tree_blobs(monkeypatch):
         fake_load_git_blob_as_buffer,
     )
 
-    buffers = load_git_tree_files_as_buffers("HEAD", ["alpha.txt", "beta.txt"])
+    spool_dir = tmp_path / "scratch"
+    spool_dir.mkdir()
+    buffers = load_git_tree_files_as_buffers(
+        "HEAD",
+        ["alpha.txt", "beta.txt"],
+        spool_dir=spool_dir,
+    )
     try:
         assert calls == [("HEAD", ["alpha.txt", "beta.txt"])]
+        assert loaded_blobs == [
+            ("alpha-sha", spool_dir),
+            ("beta-sha", spool_dir),
+        ]
         assert buffers["alpha.txt"][0] == b"alpha-sha\n"
         assert buffers["beta.txt"][0] == b"beta-sha\n"
     finally:
@@ -119,7 +160,7 @@ def test_read_git_object_buffer_or_none_loads_streamed_output(monkeypatch):
         },
     )
 
-    def fake_load(blob_sha):
+    def fake_load(blob_sha, **_kwargs):
         calls.append(blob_sha)
         return LineBuffer.from_chunks([b"alpha\nbe", b"ta\n"])
 


### PR DESCRIPTION
Per-file computation needs immutable repository inputs and mapped scratch storage without carrying file content through a future execution transport.

Mapped buffers and path-backed artifacts must not escape their invocation, and worker-safe computation cannot reread mutable session state. Captured attribution also needs to preserve the distinction between canonical state commits and supplemental overrides.

This pull request confines mapped buffers and artifacts to private file-job workspaces, validates every artifact against its invocation, reads metadata from captured commit ids, and filters hunks from captured lifecycle state. Live text candidate preparation is split into parent-safe capture and computation that no longer performs session reads.

Coverage pins workspace-local propagation, private artifact boundaries, captured metadata, supplemental override trust, and lifecycle filtering. These immutable inputs establish the boundary needed by the ordered file-job runner.