### PR TITLE
jobs: Run compact file work in stable order

### DIFF
--- a/src/git_stage_batch/utils/file_job_process.py
+++ b/src/git_stage_batch/utils/file_job_process.py
@@ -1,0 +1,291 @@
+"""Bounded process supervision for file-job execution."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Generic, Protocol, TypeVar
+
+
+if TYPE_CHECKING:
+    from multiprocessing import Process
+    from multiprocessing.connection import Connection
+    from multiprocessing.context import BaseContext
+
+
+JobT = TypeVar("JobT")
+ResultT = TypeVar("ResultT")
+_PENDING_JOBS_PER_WORKER = 2
+_WORKER_EXIT_TIMEOUT_SECONDS = 5.0
+
+
+class _OrderedJob(Protocol[JobT]):
+    ordinal: int
+    payload: JobT
+
+
+@dataclass(frozen=True, slots=True)
+class _WorkerResponse(Generic[ResultT]):
+    """One value or failure returned by a file-job worker."""
+
+    ordinal: int
+    result: ResultT | None = None
+    error_type: str | None = None
+    error_message: str | None = None
+    interrupted: bool = False
+
+
+class _FileJobSupervisorError(Exception):
+    """Failure of process construction, communication, or worker lifetime."""
+
+    def __init__(self, message: str, *, ordinal: int | None = None) -> None:
+        self.ordinal = ordinal
+        super().__init__(message)
+
+
+class _ProcessFileJobSupervisor(Generic[JobT, ResultT]):
+    """Small forkserver supervisor with explicit public worker termination."""
+
+    def __init__(
+        self,
+        compute: Callable[[JobT], ResultT],
+        *,
+        max_workers: int,
+        repository_root: Path,
+        worker_target: Callable[..., None],
+        context_factory: Callable[[], BaseContext],
+    ) -> None:
+        self._workers: list[Process] = []
+        self._connections: list[Connection] = []
+        self._pending_ordinals: list[list[int]] = []
+        self._closed = False
+        try:
+            context = context_factory()
+            for worker_index in range(max_workers):
+                self._start_worker(
+                    context,
+                    worker_target,
+                    compute,
+                    repository_root,
+                    worker_index,
+                )
+        except BaseException:
+            self.terminate()
+            raise
+
+    @property
+    def pending_count(self) -> int:
+        return sum(len(ordinals) for ordinals in self._pending_ordinals)
+
+    @property
+    def can_submit(self) -> bool:
+        return any(
+            len(ordinals) < _PENDING_JOBS_PER_WORKER
+            for ordinals in self._pending_ordinals
+        )
+
+    def submit(self, job: _OrderedJob[JobT]) -> None:
+        """Submit one job to the least-loaded live worker."""
+        self._require_open()
+        self._raise_for_dead_workers()
+        worker_index = min(
+            (
+                index
+                for index, ordinals in enumerate(self._pending_ordinals)
+                if len(ordinals) < _PENDING_JOBS_PER_WORKER
+            ),
+            key=lambda index: (len(self._pending_ordinals[index]), index),
+        )
+        try:
+            self._connections[worker_index].send(job)
+        except Exception as error:
+            raise _FileJobSupervisorError(
+                f"could not submit job {job.ordinal}: {error}",
+                ordinal=job.ordinal,
+            ) from error
+        self._pending_ordinals[worker_index].append(job.ordinal)
+
+    def receive(self) -> _WorkerResponse[ResultT]:
+        """Wait for one result while detecting unexpected worker exits."""
+        from multiprocessing.connection import wait
+
+        self._require_open()
+        if not self.pending_count:
+            raise _FileJobSupervisorError("no pending file job result")
+
+        while True:
+            pending_connections = [
+                connection
+                for connection, ordinals in zip(
+                    self._connections,
+                    self._pending_ordinals,
+                )
+                if ordinals
+            ]
+            ready_connections = wait(pending_connections, timeout=0.05)
+            if ready_connections:
+                connection = ready_connections[0]
+                worker_index = self._connections.index(connection)
+                expected_ordinal = self._pending_ordinals[worker_index].pop(0)
+                try:
+                    response = connection.recv()
+                except Exception as error:
+                    raise _FileJobSupervisorError(
+                        f"worker exited while running job {expected_ordinal}",
+                        ordinal=expected_ordinal,
+                    ) from error
+                if (
+                    not isinstance(response, _WorkerResponse)
+                    or response.ordinal != expected_ordinal
+                ):
+                    raise _FileJobSupervisorError(
+                        f"worker returned an invalid result for job {expected_ordinal}",
+                        ordinal=expected_ordinal,
+                    )
+                return response
+            self._raise_for_dead_workers()
+
+    def close(self) -> None:
+        """Finish workers normally and wait for every process to exit."""
+        if self._closed:
+            return
+        if self.pending_count:
+            raise _FileJobSupervisorError(
+                "cannot close file-job workers with pending work"
+            )
+        try:
+            for connection, process in zip(
+                self._connections,
+                self._workers,
+            ):
+                if process.exitcode is None:
+                    connection.send(None)
+            for process in self._workers:
+                process.join(_WORKER_EXIT_TIMEOUT_SECONDS)
+                if process.is_alive():
+                    raise _FileJobSupervisorError(f"worker {process.name} did not exit")
+                if process.exitcode != 0:
+                    raise _FileJobSupervisorError(
+                        f"worker {process.name} exited with status {process.exitcode}"
+                    )
+        except BaseException:
+            self.terminate()
+            raise
+        self._close_connections()
+        self._closed = True
+
+    def terminate(self) -> None:
+        """Terminate running workers and wait before returning."""
+        if self._closed:
+            return
+        try:
+            for process in self._workers:
+                try:
+                    if process.is_alive():
+                        process.terminate()
+                except BaseException:
+                    pass
+            for process in self._workers:
+                try:
+                    process.join(_WORKER_EXIT_TIMEOUT_SECONDS)
+                except BaseException:
+                    pass
+            for process in self._workers:
+                try:
+                    if process.is_alive():
+                        process.kill()
+                except BaseException:
+                    pass
+            for process in self._workers:
+                try:
+                    if process.is_alive():
+                        process.join()
+                except BaseException:
+                    pass
+        finally:
+            self._close_connections()
+            self._closed = True
+
+    def _start_worker(
+        self,
+        context: BaseContext,
+        worker_target: Callable[..., None],
+        compute: Callable[[JobT], ResultT],
+        repository_root: Path,
+        worker_index: int,
+    ) -> None:
+        parent_connection: Connection | None = None
+        child_connection: Connection | None = None
+        process: Process | None = None
+        try:
+            parent_connection, child_connection = context.Pipe(duplex=True)
+            process = context.Process(
+                target=worker_target,
+                args=(child_connection, compute, repository_root),
+                name=f"git-stage-batch-file-job-{worker_index}",
+            )
+            process.start()
+        except BaseException:
+            self._stop_partially_started_worker(process)
+            if parent_connection is not None:
+                try:
+                    parent_connection.close()
+                except BaseException:
+                    pass
+            raise
+        finally:
+            if child_connection is not None:
+                try:
+                    child_connection.close()
+                except BaseException:
+                    pass
+        assert process is not None
+        assert parent_connection is not None
+        self._workers.append(process)
+        self._connections.append(parent_connection)
+        self._pending_ordinals.append([])
+
+    def _stop_partially_started_worker(self, process: Process | None) -> None:
+        if process is None:
+            return
+        try:
+            if process.pid is not None and process.is_alive():
+                process.terminate()
+        except BaseException:
+            pass
+        try:
+            if process.pid is not None:
+                process.join(_WORKER_EXIT_TIMEOUT_SECONDS)
+        except BaseException:
+            pass
+        try:
+            if process.is_alive():
+                process.kill()
+        except BaseException:
+            pass
+        try:
+            if process.pid is not None:
+                process.join(_WORKER_EXIT_TIMEOUT_SECONDS)
+        except BaseException:
+            pass
+
+    def _raise_for_dead_workers(self) -> None:
+        for worker_index, process in enumerate(self._workers):
+            if process.exitcode is not None:
+                pending_ordinals = self._pending_ordinals[worker_index]
+                raise _FileJobSupervisorError(
+                    f"worker {process.name} exited with status {process.exitcode}",
+                    ordinal=pending_ordinals[0] if pending_ordinals else None,
+                )
+
+    def _close_connections(self) -> None:
+        for connection in self._connections:
+            try:
+                connection.close()
+            except BaseException:
+                pass
+
+    def _require_open(self) -> None:
+        if self._closed:
+            raise _FileJobSupervisorError("file-job supervisor is closed")

--- a/src/git_stage_batch/utils/file_job_transport.py
+++ b/src/git_stage_batch/utils/file_job_transport.py
@@ -1,0 +1,264 @@
+"""Shape and size validation for file-job transport values."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Sequence
+from dataclasses import dataclass, fields, is_dataclass
+from enum import Enum
+import importlib
+from pathlib import (
+    Path,
+    PosixPath,
+    PurePath,
+    PurePosixPath,
+    PureWindowsPath,
+    WindowsPath,
+)
+
+
+_MAX_TRANSPORT_STRING_CHARACTERS = 16 * 1024
+_MAX_TRANSPORT_TUPLE_ITEMS = 256
+_MAX_TRANSPORT_INTEGER_BITS = 256
+_MAX_TRANSPORT_VALUE_COUNT = 4 * 1024
+_MAX_TRANSPORT_NESTING_DEPTH = 64
+_MAX_TRANSPORT_TOTAL_STRING_CHARACTERS = 64 * 1024
+_STANDARD_PATH_TYPES = frozenset(
+    {
+        Path,
+        PosixPath,
+        PurePath,
+        PurePosixPath,
+        PureWindowsPath,
+        WindowsPath,
+    }
+)
+
+
+@dataclass(slots=True)
+class _TransportValidationState:
+    active_ids: set[int]
+    value_count: int = 0
+    string_characters: int = 0
+
+
+def assert_file_job_transport_value(
+    value: object,
+    *,
+    label: str = "transport value",
+) -> None:
+    """Reject content-bearing or non-compact values before Python IPC."""
+    _assert_transport_value(
+        value,
+        label=label,
+        state=_TransportValidationState(set()),
+        depth=0,
+    )
+
+
+def _assert_transport_value(
+    value: object,
+    *,
+    label: str,
+    state: _TransportValidationState,
+    depth: int,
+) -> None:
+    state.value_count += 1
+    if state.value_count > _MAX_TRANSPORT_VALUE_COUNT:
+        raise TypeError(f"{label} contains too many transport values")
+    if depth > _MAX_TRANSPORT_NESTING_DEPTH:
+        raise TypeError(f"{label} contains excessive nesting")
+
+    if value is None:
+        return
+    if isinstance(value, Enum):
+        _assert_importable_transport_type(value, label=label)
+        _assert_transport_enum_shape(value, label=label)
+        _recurse_transport_values(
+            value,
+            label=label,
+            state=state,
+            depth=depth,
+            values=(value.value,),
+        )
+        return
+    # Exact scalar and collection types are intentional. State-bearing
+    # subclasses may customize pickle behavior or hide additional content.
+    if type(value) in {bool, float}:
+        return
+    if type(value) is int:
+        if value.bit_length() > _MAX_TRANSPORT_INTEGER_BITS:
+            raise TypeError(f"{label} contains an oversized integer")
+        return
+    if type(value) is str:
+        _assert_transport_string(value, label=label, state=state)
+        return
+    if isinstance(value, (bool, int, float, str)):
+        raise TypeError(f"{label} contains a state-bearing scalar subtype")
+    if isinstance(value, PurePath):
+        _assert_importable_transport_type(value, label=label)
+        if type(value) not in _STANDARD_PATH_TYPES:
+            raise TypeError(f"{label} contains a custom path subtype")
+        _assert_transport_string(str(value), label=label, state=state)
+        return
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        raise TypeError(f"{label} contains file-content bytes")
+    if isinstance(value, (list, dict, set, frozenset)):
+        raise TypeError(f"{label} contains a state-bearing collection subtype")
+    if type(value) is tuple:
+        if len(value) > _MAX_TRANSPORT_TUPLE_ITEMS:
+            raise TypeError(f"{label} contains too many tuple items")
+        _recurse_transport_values(
+            value,
+            label=label,
+            state=state,
+            depth=depth,
+            values=value,
+        )
+        return
+    if isinstance(value, tuple):
+        raise TypeError(f"{label} contains a state-bearing tuple subtype")
+    if is_dataclass(value) and not isinstance(value, type):
+        _assert_importable_transport_type(value, label=label)
+        _assert_transport_dataclass_shape(value, label=label)
+        _recurse_transport_values(
+            value,
+            label=label,
+            state=state,
+            depth=depth,
+            values=(
+                (field.name, getattr(value, field.name)) for field in fields(value)
+            ),
+            named_values=True,
+        )
+        return
+    raise TypeError(
+        f"{label} contains unsupported {type(value).__module__}."
+        f"{type(value).__qualname__}"
+    )
+
+
+def _assert_importable_transport_type(value: object, *, label: str) -> None:
+    value_type = type(value)
+    module_name = getattr(value_type, "__module__", "")
+    name = getattr(value_type, "__name__", "")
+    qualified_name = getattr(value_type, "__qualname__", "")
+    if (
+        not module_name
+        or module_name == "__main__"
+        or not name
+        or qualified_name != name
+    ):
+        raise TypeError(f"{label} has a non-importable value type")
+    try:
+        imported_type = getattr(importlib.import_module(module_name), name)
+    except Exception as error:
+        raise TypeError(f"{label} has a non-importable value type") from error
+    if imported_type is not value_type:
+        raise TypeError(f"{label} has a non-importable value type")
+
+
+def _assert_transport_enum_shape(value: Enum, *, label: str) -> None:
+    for value_class in type(value).__mro__:
+        if value_class.__module__ in {"builtins", "enum"}:
+            continue
+        if _has_custom_pickle_hook(value_class):
+            raise TypeError(f"{label} contains custom pickle behavior")
+
+
+def _assert_transport_dataclass_shape(value: object, *, label: str) -> None:
+    value_type = type(value)
+    parameters = getattr(value_type, "__dataclass_params__", None)
+    if parameters is None or not parameters.frozen or hasattr(value, "__dict__"):
+        raise TypeError(f"{label} must use a frozen slots dataclass")
+
+    field_names = {field.name for field in fields(value)}
+    for value_class in value_type.__mro__:
+        if value_class is object:
+            continue
+        slots = value_class.__dict__.get("__slots__", ())
+        if isinstance(slots, str):
+            slots = (slots,)
+        undeclared_slots = (
+            set(slots)
+            - field_names
+            - {
+                "__dict__",
+                "__weakref__",
+            }
+        )
+        if undeclared_slots:
+            raise TypeError(f"{label} contains undeclared dataclass slots")
+
+        for hook_name in (
+            "__reduce__",
+            "__reduce_ex__",
+            "__getnewargs__",
+            "__getnewargs_ex__",
+            "__getstate__",
+            "__setstate__",
+        ):
+            hook = value_class.__dict__.get(hook_name)
+            if hook is None:
+                continue
+            if (
+                hook_name in {"__getstate__", "__setstate__"}
+                and getattr(hook, "__module__", None) == "dataclasses"
+            ):
+                continue
+            raise TypeError(f"{label} contains custom pickle behavior")
+
+
+def _has_custom_pickle_hook(value_class: type[object]) -> bool:
+    return any(
+        hook_name in value_class.__dict__
+        for hook_name in (
+            "__reduce__",
+            "__reduce_ex__",
+            "__getnewargs__",
+            "__getnewargs_ex__",
+            "__getstate__",
+            "__setstate__",
+        )
+    )
+
+
+def _assert_transport_string(
+    value: str,
+    *,
+    label: str,
+    state: _TransportValidationState,
+) -> None:
+    if len(value) > _MAX_TRANSPORT_STRING_CHARACTERS:
+        raise TypeError(f"{label} contains an oversized string")
+    state.string_characters += len(value)
+    if state.string_characters > _MAX_TRANSPORT_TOTAL_STRING_CHARACTERS:
+        raise TypeError(f"{label} contains too much string data")
+
+
+def _recurse_transport_values(
+    owner: object,
+    *,
+    label: str,
+    state: _TransportValidationState,
+    depth: int,
+    values: Sequence[object] | Iterator[tuple[str, object]],
+    named_values: bool = False,
+) -> None:
+    value_id = id(owner)
+    if value_id in state.active_ids:
+        raise TypeError(f"{label} contains a recursive value")
+    state.active_ids.add(value_id)
+    try:
+        for index, value in enumerate(values):
+            value_label = f"{label}[{index}]"
+            if named_values:
+                value_name, value = value
+                value_label = f"{label}.{value_name}"
+            _assert_transport_value(
+                value,
+                label=value_label,
+                state=state,
+                depth=depth + 1,
+            )
+    finally:
+        state.active_ids.remove(value_id)

--- a/src/git_stage_batch/utils/file_jobs.py
+++ b/src/git_stage_batch/utils/file_jobs.py
@@ -1,0 +1,584 @@
+"""Ordered inline and forkserver execution for compact file-scoped jobs."""
+
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Callable, Iterator, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass
+import importlib
+import os
+from pathlib import Path
+import sys
+from typing import TYPE_CHECKING, Generic, Literal, TypeVar
+
+from ..exceptions import CommandError
+from .file_job_process import (
+    _FileJobSupervisorError,
+    _ProcessFileJobSupervisor as _ProcessSupervisor,
+    _WorkerResponse,
+)
+from .file_job_transport import (
+    _MAX_TRANSPORT_INTEGER_BITS as _MAX_TRANSPORT_INTEGER_BITS,
+    _MAX_TRANSPORT_NESTING_DEPTH as _MAX_TRANSPORT_NESTING_DEPTH,
+    _MAX_TRANSPORT_STRING_CHARACTERS as _MAX_TRANSPORT_STRING_CHARACTERS,
+    _MAX_TRANSPORT_TOTAL_STRING_CHARACTERS as _MAX_TRANSPORT_TOTAL_STRING_CHARACTERS,
+    _MAX_TRANSPORT_TUPLE_ITEMS as _MAX_TRANSPORT_TUPLE_ITEMS,
+    _MAX_TRANSPORT_VALUE_COUNT as _MAX_TRANSPORT_VALUE_COUNT,
+    assert_file_job_transport_value,
+)
+
+
+if TYPE_CHECKING:
+    from multiprocessing.connection import Connection
+
+
+JobT = TypeVar("JobT")
+ResultT = TypeVar("ResultT")
+_MAX_FILE_JOB_WORKERS = 4
+_AUTO_PROCESS_MINIMUM_ESTIMATED_BYTES = 256 * 1024
+_MAX_ERROR_MESSAGE_CHARACTERS = 4 * 1024
+
+
+@dataclass(frozen=True, slots=True)
+class OrderedFileJob(Generic[JobT]):
+    """One compact file job with stable reduction and scheduling metadata."""
+
+    ordinal: int
+    file_path: str
+    estimated_bytes: int
+    payload: JobT
+
+
+@dataclass(frozen=True, slots=True)
+class FileJobExecution:
+    """Selected transport and bounded worker count for one invocation."""
+
+    transport: Literal["inline", "process"]
+    max_workers: int
+    reason: str
+
+
+class FileJobError(CommandError):
+    """Unexpected failure while computing one ordered file job."""
+
+    def __init__(
+        self,
+        ordinal: int,
+        file_path: str,
+        original_message: str,
+    ) -> None:
+        self.ordinal = ordinal
+        self.file_path = file_path
+        self.original_message = original_message
+        super().__init__(
+            f"File job {ordinal} for '{file_path}' failed: {original_message}"
+        )
+
+
+class _ProcessFileJobSupervisor(_ProcessSupervisor[JobT, ResultT]):
+    """Bind the generic process supervisor to this module's worker."""
+
+    def __init__(
+        self,
+        compute: Callable[[JobT], ResultT],
+        *,
+        max_workers: int,
+        repository_root: Path,
+    ) -> None:
+        super().__init__(
+            compute,
+            max_workers=max_workers,
+            repository_root=repository_root,
+            worker_target=_file_job_worker,
+            context_factory=_get_process_context,
+        )
+
+
+def select_file_job_execution(
+    jobs: Sequence[OrderedFileJob[object]],
+    *,
+    requested_jobs: str | None,
+    platform: str,
+    cpu_count: int | None,
+) -> FileJobExecution:
+    """Select inline or bounded Linux process execution."""
+    job_count = len(jobs)
+    requested_value = "auto" if requested_jobs is None else requested_jobs
+    if requested_value == "":
+        raise _invalid_jobs_value()
+
+    if requested_value == "auto":
+        if platform != "linux":
+            return FileJobExecution(
+                "inline",
+                1,
+                f"automatic process execution is unavailable on {platform}",
+            )
+        if job_count < 2:
+            return FileJobExecution(
+                "inline",
+                1,
+                "automatic process execution requires at least 2 file jobs",
+            )
+        available_cpus = _normalize_cpu_count(cpu_count)
+        if available_cpus < 2:
+            return FileJobExecution(
+                "inline",
+                1,
+                "automatic process execution requires at least 2 CPUs",
+            )
+        total_estimated_bytes = sum(job.estimated_bytes for job in jobs)
+        # A 2026-07-16 whole-prompt benchmark measured a 20 percent gain near
+        # 242 KiB and larger gains above it. Use a round 256 KiB heuristic to
+        # amortize process startup without implying a precise crossover.
+        if total_estimated_bytes < _AUTO_PROCESS_MINIMUM_ESTIMATED_BYTES:
+            return FileJobExecution(
+                "inline",
+                1,
+                "automatic process execution kept "
+                f"{total_estimated_bytes} estimated bytes inline below the "
+                f"{_AUTO_PROCESS_MINIMUM_ESTIMATED_BYTES}-byte threshold",
+            )
+        worker_count = min(
+            job_count,
+            available_cpus,
+            _MAX_FILE_JOB_WORKERS,
+        )
+        return FileJobExecution(
+            "process",
+            worker_count,
+            "automatic process execution selected "
+            f"{worker_count} workers for {job_count} file jobs totaling "
+            f"{total_estimated_bytes} estimated bytes",
+        )
+
+    try:
+        requested_count = int(requested_value)
+    except ValueError as error:
+        raise _invalid_jobs_value() from error
+
+    if requested_count <= 0:
+        raise _invalid_jobs_value()
+    if requested_count == 1:
+        reason = "GIT_STAGE_BATCH_JOBS requests inline execution"
+        return FileJobExecution("inline", 1, reason)
+    if platform != "linux":
+        raise CommandError("GIT_STAGE_BATCH_JOBS greater than 1 requires Linux.")
+    if job_count == 0:
+        return FileJobExecution("inline", 1, "no eligible file jobs")
+
+    worker_count = min(
+        job_count,
+        requested_count,
+        _normalize_cpu_count(cpu_count),
+        _MAX_FILE_JOB_WORKERS,
+    )
+    return FileJobExecution(
+        "process",
+        worker_count,
+        f"GIT_STAGE_BATCH_JOBS requests {requested_count} processes",
+    )
+
+
+def run_file_jobs(
+    jobs: Sequence[OrderedFileJob[JobT]],
+    compute: Callable[[JobT], ResultT],
+    *,
+    execution: FileJobExecution,
+    repository_root: Path,
+) -> list[ResultT]:
+    """Run one ordered job pipeline through the selected transport."""
+    ordered_jobs = _validate_jobs(jobs)
+    _validate_compute(compute)
+    if execution.transport not in {"inline", "process"}:
+        raise ValueError(f"unsupported file-job transport: {execution.transport}")
+    if type(execution.max_workers) is not int or execution.max_workers <= 0:
+        raise ValueError("file-job execution requires a positive worker count")
+    if execution.transport == "process" and sys.platform != "linux":
+        raise ValueError("process file-job execution requires Linux")
+    if not ordered_jobs:
+        return []
+    repository_root = repository_root.resolve()
+    if execution.transport == "inline":
+        return _run_inline_file_jobs(
+            ordered_jobs,
+            compute,
+            repository_root=repository_root,
+        )
+
+    return _run_process_file_jobs(
+        ordered_jobs,
+        compute,
+        max_workers=min(
+            execution.max_workers,
+            len(ordered_jobs),
+            _MAX_FILE_JOB_WORKERS,
+        ),
+        repository_root=repository_root,
+    )
+
+
+def run_validated_file_jobs(
+    jobs: Sequence[OrderedFileJob[JobT]],
+    compute: Callable[[JobT], ResultT],
+    validate_result: Callable[[JobT, ResultT], None],
+    *,
+    repository_root: Path,
+    result_label: str,
+    run_jobs: Callable[..., list[ResultT]] = run_file_jobs,
+) -> list[tuple[OrderedFileJob[JobT], ResultT]]:
+    """Select, execute, pair, and validate one ordered job pipeline."""
+    execution = select_file_job_execution(
+        jobs,
+        requested_jobs=os.environ.get("GIT_STAGE_BATCH_JOBS"),
+        platform=sys.platform,
+        cpu_count=None,
+    )
+    results = run_jobs(
+        jobs,
+        compute,
+        execution=execution,
+        repository_root=repository_root,
+    )
+    ordered_jobs = sorted(jobs, key=lambda job: job.ordinal)
+    if len(results) != len(ordered_jobs):
+        raise RuntimeError(
+            f"{result_label} execution returned an unexpected result count"
+        )
+    paired_results = list(zip(ordered_jobs, results, strict=True))
+    for job, result in paired_results:
+        validate_result(job.payload, result)
+    return paired_results
+
+
+def _run_inline_file_jobs(
+    jobs: Sequence[OrderedFileJob[JobT]],
+    compute: Callable[[JobT], ResultT],
+    *,
+    repository_root: Path,
+) -> list[ResultT]:
+    try:
+        with _repository_working_directory(repository_root):
+            results = []
+            for job in jobs:
+                try:
+                    result = compute(job.payload)
+                    assert_file_job_transport_value(
+                        result,
+                        label=f"result for job {job.ordinal}",
+                    )
+                except KeyboardInterrupt:
+                    raise
+                except BaseException as error:
+                    raise _job_error(job, error) from error
+                results.append(result)
+            return results
+    except (KeyboardInterrupt, FileJobError):
+        raise
+    except BaseException as error:
+        raise _job_error(jobs[0], error) from error
+
+
+def _run_process_file_jobs(
+    jobs: Sequence[OrderedFileJob[JobT]],
+    compute: Callable[[JobT], ResultT],
+    *,
+    max_workers: int,
+    repository_root: Path,
+) -> list[ResultT]:
+    supervisor: _ProcessFileJobSupervisor[JobT, ResultT] | None = None
+    results_by_ordinal: dict[int, ResultT] = {}
+    failures_by_ordinal: dict[int, _WorkerResponse[ResultT]] = {}
+    pending_ordinals: set[int] = set()
+    try:
+        supervisor = _ProcessFileJobSupervisor(
+            compute,
+            max_workers=max_workers,
+            repository_root=repository_root,
+        )
+        ready_jobs = deque(_jobs_by_submission_priority(jobs))
+
+        while ready_jobs or supervisor.pending_count:
+            while ready_jobs and not failures_by_ordinal and supervisor.can_submit:
+                job = ready_jobs.popleft()
+                supervisor.submit(job)
+                pending_ordinals.add(job.ordinal)
+
+            if failures_by_ordinal and not _has_pending_lower_ordinal(
+                pending_ordinals,
+                failures_by_ordinal,
+            ):
+                supervisor.terminate()
+                supervisor = None
+                break
+
+            response = supervisor.receive()
+            pending_ordinals.discard(response.ordinal)
+            if response.interrupted:
+                raise KeyboardInterrupt
+            if response.error_type is None:
+                results_by_ordinal[response.ordinal] = response.result  # type: ignore[assignment]
+            else:
+                failures_by_ordinal[response.ordinal] = response
+                ready_jobs.clear()
+
+        if supervisor is not None:
+            supervisor.close()
+            supervisor = None
+    except KeyboardInterrupt:
+        if supervisor is not None:
+            supervisor.terminate()
+        raise
+    except BaseException as error:
+        if supervisor is not None:
+            supervisor.terminate()
+        if isinstance(error, FileJobError):
+            raise
+        supervisor_ordinal = (
+            error.ordinal if isinstance(error, _FileJobSupervisorError) else None
+        )
+        failure_ordinal = _lowest_failure_ordinal(
+            jobs,
+            failures_by_ordinal=failures_by_ordinal,
+            supervisor_ordinal=supervisor_ordinal,
+            results_by_ordinal=results_by_ordinal,
+        )
+        if failure_ordinal in failures_by_ordinal:
+            _raise_worker_failure(
+                jobs,
+                failures_by_ordinal[failure_ordinal],
+            )
+        job = next(job for job in jobs if job.ordinal == failure_ordinal)
+        raise _job_error(job, error) from error
+
+    if failures_by_ordinal:
+        _raise_worker_failure(
+            jobs,
+            failures_by_ordinal[min(failures_by_ordinal)],
+        )
+
+    return [results_by_ordinal[job.ordinal] for job in jobs]
+
+
+def _has_pending_lower_ordinal(
+    pending_ordinals: set[int],
+    failures_by_ordinal: dict[int, _WorkerResponse[object]],
+) -> bool:
+    failure_ordinal = min(failures_by_ordinal)
+    return any(ordinal < failure_ordinal for ordinal in pending_ordinals)
+
+
+def _jobs_by_submission_priority(
+    jobs: Sequence[OrderedFileJob[JobT]],
+) -> list[OrderedFileJob[JobT]]:
+    return sorted(
+        jobs,
+        key=lambda job: (-job.estimated_bytes, job.ordinal),
+    )
+
+
+def _file_job_worker(
+    connection: Connection,
+    compute: Callable[[JobT], ResultT],
+    repository_root: Path,
+) -> None:
+    try:
+        _initialize_file_job_worker(repository_root)
+        while True:
+            job = connection.recv()
+            if job is None:
+                return
+            try:
+                result = compute(job.payload)
+                assert_file_job_transport_value(
+                    result,
+                    label=f"result for job {job.ordinal}",
+                )
+                response = _WorkerResponse(job.ordinal, result=result)
+            except KeyboardInterrupt:
+                response = _WorkerResponse(job.ordinal, interrupted=True)
+            except BaseException as error:
+                error_type = _bounded_error_type(error)
+                response = _WorkerResponse(
+                    job.ordinal,
+                    error_type=error_type,
+                    error_message=_bounded_error_message(error),
+                )
+            try:
+                connection.send(response)
+            except (BrokenPipeError, EOFError, OSError):
+                return
+            except BaseException as error:
+                error_type = _bounded_error_type(error)
+                try:
+                    connection.send(
+                        _WorkerResponse(
+                            job.ordinal,
+                            error_type=error_type,
+                            error_message=_bounded_message(
+                                "could not serialize worker result: "
+                                f"{_bounded_error_message(error)}"
+                            ),
+                        )
+                    )
+                except BaseException:
+                    return
+    except (EOFError, KeyboardInterrupt):
+        return
+    finally:
+        try:
+            connection.close()
+        except BaseException:
+            pass
+
+
+def _get_process_context():
+    import multiprocessing
+
+    return multiprocessing.get_context("forkserver")
+
+
+def _initialize_file_job_worker(repository_root: Path) -> None:
+    os.chdir(repository_root)
+
+
+@contextmanager
+def _repository_working_directory(
+    repository_root: Path,
+) -> Iterator[None]:
+    original_directory = os.open(
+        ".",
+        os.O_RDONLY | getattr(os, "O_DIRECTORY", 0),
+    )
+    try:
+        os.chdir(repository_root)
+        yield
+    finally:
+        try:
+            os.fchdir(original_directory)
+        finally:
+            os.close(original_directory)
+
+
+def _validate_jobs(
+    jobs: Sequence[OrderedFileJob[JobT]],
+) -> list[OrderedFileJob[JobT]]:
+    by_ordinal: dict[int, OrderedFileJob[JobT]] = {}
+    for job in jobs:
+        if (
+            isinstance(job.ordinal, bool)
+            or not isinstance(job.ordinal, int)
+            or job.ordinal < 0
+        ):
+            raise ValueError("file-job ordinals must be non-negative integers")
+        if job.ordinal in by_ordinal:
+            raise ValueError(f"duplicate file-job ordinal: {job.ordinal}")
+        if not isinstance(job.file_path, str):
+            raise ValueError("file-job paths must be strings")
+        if (
+            isinstance(job.estimated_bytes, bool)
+            or not isinstance(job.estimated_bytes, int)
+            or job.estimated_bytes < 0
+        ):
+            raise ValueError("file-job estimated bytes must be non-negative")
+        assert_file_job_transport_value(job, label=f"job {job.ordinal}")
+        by_ordinal[job.ordinal] = job
+    return [by_ordinal[ordinal] for ordinal in sorted(by_ordinal)]
+
+
+def _validate_compute(compute: Callable[[JobT], ResultT]) -> None:
+    module_name = getattr(compute, "__module__", "")
+    name = getattr(compute, "__name__", "")
+    qualified_name = getattr(compute, "__qualname__", "")
+    if (
+        not callable(compute)
+        or not module_name
+        or module_name == "__main__"
+        or not name
+        or qualified_name != name
+        or name == "<lambda>"
+    ):
+        raise TypeError("file-job compute must be a top-level importable function")
+    try:
+        imported_compute = getattr(importlib.import_module(module_name), name)
+    except Exception as error:
+        raise TypeError(
+            "file-job compute must be a top-level importable function"
+        ) from error
+    if imported_compute is not compute:
+        raise TypeError("file-job compute must be a top-level importable function")
+
+
+def _normalize_cpu_count(cpu_count: int | None) -> int:
+    if cpu_count is None:
+        try:
+            cpu_count = len(os.sched_getaffinity(0))
+        except (AttributeError, OSError):
+            cpu_count = os.cpu_count()
+    return max(1, cpu_count or 1)
+
+
+def _invalid_jobs_value() -> CommandError:
+    return CommandError("GIT_STAGE_BATCH_JOBS must be 'auto' or a positive integer.")
+
+
+def _lowest_failure_ordinal(
+    jobs: Sequence[OrderedFileJob[object]],
+    *,
+    failures_by_ordinal: dict[int, _WorkerResponse[object]],
+    supervisor_ordinal: int | None,
+    results_by_ordinal: dict[int, object],
+) -> int:
+    candidates = list(failures_by_ordinal)
+    if supervisor_ordinal is not None:
+        candidates.append(supervisor_ordinal)
+    if candidates:
+        return min(candidates)
+
+    unresolved_ordinals = [
+        job.ordinal for job in jobs if job.ordinal not in results_by_ordinal
+    ]
+    return min(unresolved_ordinals or (job.ordinal for job in jobs))
+
+
+def _raise_worker_failure(
+    jobs: Sequence[OrderedFileJob[object]],
+    response: _WorkerResponse[object],
+) -> None:
+    job = next(job for job in jobs if job.ordinal == response.ordinal)
+    message = response.error_type or "worker task failed"
+    if response.error_message:
+        message = f"{message}: {response.error_message}"
+    raise FileJobError(
+        job.ordinal,
+        job.file_path,
+        _bounded_message(message),
+    )
+
+
+def _job_error(
+    job: OrderedFileJob[object],
+    error: BaseException,
+) -> FileJobError:
+    message = _bounded_error_message(error)
+    return FileJobError(job.ordinal, job.file_path, message)
+
+
+def _bounded_error_message(error: BaseException) -> str:
+    try:
+        message = str(error)
+    except BaseException:
+        message = ""
+    return _bounded_message(message or type(error).__name__)
+
+
+def _bounded_error_type(error: BaseException) -> str:
+    return _bounded_message(f"{type(error).__module__}.{type(error).__qualname__}")
+
+
+def _bounded_message(message: str) -> str:
+    if len(message) <= _MAX_ERROR_MESSAGE_CHARACTERS:
+        return message
+    suffix = "..."
+    return message[: _MAX_ERROR_MESSAGE_CHARACTERS - len(suffix)] + suffix

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -9,6 +9,7 @@ from .import_boundary_helpers import (
     SRC_ROOT,
     external_package_child_module_import_violations as _child_import_violations,
     import_from_nodes as _import_from_nodes,
+    internal_import_edges as _internal_import_edges,
     module_name_for_path as _module_name_for_path,
 )
 
@@ -271,6 +272,40 @@ def test_lower_packages_do_not_import_command_exit_helper():
                 violations.append(
                     f"{relative_path}:{node.lineno} imports exit_with_error"
                 )
+
+    assert violations == []
+
+
+def test_file_job_infrastructure_stays_domain_neutral():
+    """Generic job mechanics should not depend on product workflow layers."""
+    forbidden_import_roots = {
+        "git_stage_batch.batch",
+        "git_stage_batch.cli",
+        "git_stage_batch.commands",
+        "git_stage_batch.data",
+        "git_stage_batch.output",
+        "git_stage_batch.tui",
+        "git_stage_batch.utils.journal",
+        "git_stage_batch.utils.session_lock",
+    }
+    violations = []
+    infrastructure_modules = {
+        _module_name_for_path(path)
+        for path in (
+            SRC_ROOT / "utils" / "file_job_process.py",
+            SRC_ROOT / "utils" / "file_job_transport.py",
+            SRC_ROOT / "utils" / "file_jobs.py",
+            SRC_ROOT / "utils" / "file_job_workspace.py",
+        )
+    }
+    for edge in _internal_import_edges():
+        if edge.source not in infrastructure_modules:
+            continue
+        if any(
+            edge.target == root or edge.target.startswith(f"{root}.")
+            for root in forbidden_import_roots
+        ):
+            violations.append(f"{edge.source} imports {edge.target}")
 
     assert violations == []
 

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -9,6 +9,8 @@ from unittest.mock import patch
 
 import pytest
 
+from git_stage_batch.utils.file_jobs import FileJobError
+
 main_module = import_module("git_stage_batch.cli.main")
 
 
@@ -30,6 +32,28 @@ def test_main_with_no_args():
                 with pytest.raises(SystemExit) as exc_info:
                     main_module.main()
                 assert exc_info.value.code == 1
+
+
+def test_main_reports_file_job_failures_without_a_traceback(capsys):
+    """Expected executor failures should use the command error boundary."""
+    error = FileJobError(3, "example.txt", "worker exited unexpectedly")
+
+    with patch.object(sys, "argv", ["git-stage-batch"]):
+        with patch.object(
+            main_module,
+            "dispatch_cli_mode",
+            side_effect=error,
+        ):
+            with patch.object(
+                main_module,
+                "parse_command_line",
+                return_value=Namespace(working_directory=None),
+            ):
+                with pytest.raises(SystemExit) as exc_info:
+                    main_module.main()
+
+    assert exc_info.value.code == 1
+    assert capsys.readouterr().err == f"{error}\n"
 
 
 def test_main_acquires_session_lock_before_dispatch():

--- a/tests/utils/test_file_jobs.py
+++ b/tests/utils/test_file_jobs.py
@@ -544,3 +544,572 @@ def test_process_scheduler_stops_admission_after_task_failure(
     assert error.value.ordinal == 0
     assert submitted == [0, 1]
     assert lifecycle == {"closed": False, "terminated": True}
+
+
+def test_process_failure_waits_only_for_pending_lower_ordinals(
+    tmp_path,
+    monkeypatch,
+):
+    """Deterministic failure selection should not drain unrelated work."""
+    received = []
+    lifecycle = {"closed": False, "terminated": False}
+
+    class FailingSupervisor:
+        def __init__(self, _compute, *, max_workers, repository_root):
+            self.pending = []
+
+        @property
+        def pending_count(self):
+            return len(self.pending)
+
+        @property
+        def can_submit(self):
+            return len(self.pending) < 3
+
+        def submit(self, job):
+            self.pending.append(job)
+
+        def receive(self):
+            if not received:
+                job = next(job for job in self.pending if job.ordinal == 2)
+                self.pending.remove(job)
+                received.append(job.ordinal)
+                return file_jobs_module._WorkerResponse(
+                    job.ordinal,
+                    error_type="builtins.RuntimeError",
+                    error_message="two failed",
+                )
+            job = next(job for job in self.pending if job.ordinal == 1)
+            self.pending.remove(job)
+            received.append(job.ordinal)
+            return file_jobs_module._WorkerResponse(
+                job.ordinal,
+                result=job.payload,
+            )
+
+        def close(self):
+            lifecycle["closed"] = True
+
+        def terminate(self):
+            self.pending.clear()
+            lifecycle["terminated"] = True
+
+    monkeypatch.setattr(
+        file_jobs_module,
+        "_ProcessFileJobSupervisor",
+        FailingSupervisor,
+    )
+    jobs = [
+        OrderedFileJob(1, "one.txt", 20, 1),
+        OrderedFileJob(2, "two.txt", 30, 2),
+        OrderedFileJob(3, "three.txt", 10, 3),
+    ]
+
+    with pytest.raises(FileJobError) as error:
+        run_file_jobs(
+            jobs,
+            _identity,
+            execution=FileJobExecution("process", 2, "test"),
+            repository_root=tmp_path,
+        )
+
+    assert error.value.ordinal == 2
+    assert received == [2, 1]
+    assert lifecycle == {"closed": False, "terminated": True}
+
+
+@_PROCESS_TEST
+def test_lowest_ordinal_failure_wins(tmp_path):
+    """Several task failures should reduce to the lowest input ordinal."""
+    with FileJobWorkspace(parent_directory=tmp_path) as workspace:
+        artifact = workspace.write_buffer(0, "input.txt", (b"line\n",))
+        scratch = workspace.scratch_directory(0)
+        jobs = [
+            OrderedFileJob(
+                4,
+                "four.txt",
+                30,
+                _DigestJob(artifact, scratch, 4, failure="four"),
+            ),
+            OrderedFileJob(
+                1,
+                "one.txt",
+                10,
+                _DigestJob(
+                    artifact,
+                    scratch,
+                    1,
+                    delay_seconds=0.04,
+                    failure="one",
+                ),
+            ),
+            OrderedFileJob(
+                3,
+                "three.txt",
+                20,
+                _DigestJob(artifact, scratch, 3, failure="three"),
+            ),
+        ]
+
+        with pytest.raises(FileJobError) as error:
+            run_file_jobs(
+                jobs,
+                _compute_digest,
+                execution=FileJobExecution("process", 2, "test"),
+                repository_root=tmp_path,
+            )
+
+    assert error.value.ordinal == 1
+    assert error.value.file_path == "one.txt"
+    assert "one" in error.value.original_message
+
+
+def test_process_construction_failure_does_not_compute_inline(
+    tmp_path,
+    monkeypatch,
+):
+    """Supervisor startup errors must not switch to the inline transport."""
+    global _PARENT_COMPUTE_CALLS
+    _PARENT_COMPUTE_CALLS = 0
+
+    monkeypatch.setattr(
+        file_jobs_module,
+        "_get_process_context",
+        lambda *_args: (_ for _ in ()).throw(OSError("cannot start forkserver")),
+    )
+
+    with pytest.raises(FileJobError, match="cannot start forkserver"):
+        run_file_jobs(
+            [OrderedFileJob(0, "file.txt", 1, 7)],
+            _record_parent_call,
+            execution=FileJobExecution("process", 2, "test"),
+            repository_root=tmp_path,
+        )
+
+    assert _PARENT_COMPUTE_CALLS == 0
+
+
+def test_partially_started_worker_is_killed_and_connections_are_closed(
+    tmp_path,
+    monkeypatch,
+):
+    """A failed process start must not leave an unregistered child alive."""
+    lifecycle = []
+
+    class FakeConnection:
+        def __init__(self, label):
+            self.label = label
+
+        def close(self):
+            lifecycle.append(f"close {self.label}")
+
+    class FakeProcess:
+        pid = 123
+        name = "partial-worker"
+        exitcode = None
+
+        def __init__(self):
+            self.alive = True
+
+        def start(self):
+            raise OSError("start failed after launch")
+
+        def is_alive(self):
+            return self.alive
+
+        def terminate(self):
+            lifecycle.append("terminate")
+
+        def kill(self):
+            lifecycle.append("kill")
+            self.alive = False
+
+        def join(self, timeout=None):
+            lifecycle.append(("join", timeout))
+
+    class FakeContext:
+        def Pipe(self, *, duplex):
+            assert duplex is True
+            return FakeConnection("parent"), FakeConnection("child")
+
+        def Process(self, **_kwargs):
+            return FakeProcess()
+
+    monkeypatch.setattr(
+        file_jobs_module,
+        "_get_process_context",
+        lambda: FakeContext(),
+    )
+
+    with pytest.raises(FileJobError, match="start failed after launch"):
+        run_file_jobs(
+            [OrderedFileJob(0, "file.txt", 1, 1)],
+            _identity,
+            execution=FileJobExecution("process", 1, "test"),
+            repository_root=tmp_path,
+        )
+
+    assert lifecycle == [
+        "terminate",
+        ("join", 5.0),
+        "kill",
+        ("join", 5.0),
+        "close parent",
+        "close child",
+    ]
+
+
+def test_worker_initialization_failure_exits_abnormally(tmp_path, monkeypatch):
+    """An initializer bug must not look like a clean worker shutdown."""
+
+    class FakeConnection:
+        def close(self):
+            return None
+
+    monkeypatch.setattr(
+        file_jobs_module,
+        "_initialize_file_job_worker",
+        lambda _root: (_ for _ in ()).throw(OSError("cannot enter root")),
+    )
+
+    with pytest.raises(OSError, match="cannot enter root"):
+        file_jobs_module._file_job_worker(
+            FakeConnection(),
+            _identity,
+            tmp_path,
+        )
+
+
+@_PROCESS_TEST
+def test_worker_death_does_not_retry_inline(tmp_path):
+    """A dead worker should fail the selected transport without fallback."""
+    global _PARENT_COMPUTE_CALLS
+    _PARENT_COMPUTE_CALLS = 0
+
+    with FileJobWorkspace(parent_directory=tmp_path) as workspace:
+        artifact = workspace.write_buffer(0, "input.txt", (b"line\n",))
+        job = OrderedFileJob(
+            0,
+            "file.txt",
+            1,
+            _DigestJob(
+                artifact,
+                workspace.scratch_directory(0),
+                0,
+                exit_code=7,
+                parent_pid=os.getpid(),
+            ),
+        )
+
+        with pytest.raises(FileJobError, match="worker"):
+            run_file_jobs(
+                [job],
+                _compute_digest,
+                execution=FileJobExecution("process", 1, "test"),
+                repository_root=tmp_path,
+            )
+
+    assert _PARENT_COMPUTE_CALLS == 0
+
+
+def test_keyboard_interrupt_terminates_workers_before_workspace_cleanup(
+    tmp_path,
+    monkeypatch,
+):
+    """Parent interruption should terminate transport before artifacts vanish."""
+    lifecycle = {"terminated": False}
+
+    class InterruptingSupervisor:
+        def __init__(self, *_args, **_kwargs):
+            self.pending = 0
+
+        @property
+        def pending_count(self):
+            return self.pending
+
+        @property
+        def can_submit(self):
+            return self.pending == 0
+
+        def submit(self, _job):
+            self.pending = 1
+
+        def receive(self):
+            raise KeyboardInterrupt
+
+        def close(self):
+            raise AssertionError("interrupted supervisor closed normally")
+
+        def terminate(self):
+            lifecycle["terminated"] = True
+
+    monkeypatch.setattr(
+        file_jobs_module,
+        "_ProcessFileJobSupervisor",
+        InterruptingSupervisor,
+    )
+
+    with pytest.raises(KeyboardInterrupt):
+        with FileJobWorkspace(parent_directory=tmp_path) as workspace:
+            root = workspace.root
+            run_file_jobs(
+                [OrderedFileJob(0, "file.txt", 1, 1)],
+                _identity,
+                execution=FileJobExecution("process", 1, "test"),
+                repository_root=tmp_path,
+            )
+
+    assert lifecycle["terminated"] is True
+    assert not root.exists()
+
+
+@pytest.mark.parametrize("requested_jobs", ("", "0", "-1", "many", "1.5"))
+def test_invalid_requested_job_values_raise_deterministic_error(requested_jobs):
+    """Only auto and positive integer controls should reach selection."""
+    with pytest.raises(
+        CommandError,
+        match=(r"GIT_STAGE_BATCH_JOBS must be 'auto' or a positive integer\."),
+    ):
+        select_file_job_execution(
+            [OrderedFileJob(0, "file.txt", 1, None)],
+            requested_jobs=requested_jobs,
+            platform="linux",
+            cpu_count=8,
+        )
+
+
+@pytest.mark.parametrize("requested_jobs", (None, "auto", "1"))
+def test_non_linux_inline_selection_never_creates_context(
+    tmp_path,
+    monkeypatch,
+    requested_jobs,
+):
+    """Darwin auto and inline controls must not touch multiprocessing."""
+    monkeypatch.setattr(
+        file_jobs_module,
+        "_get_process_context",
+        lambda *_args: (_ for _ in ()).throw(
+            AssertionError("multiprocessing context requested")
+        ),
+    )
+    jobs = [OrderedFileJob(0, "file.txt", 1, 5)]
+    execution = select_file_job_execution(
+        jobs,
+        requested_jobs=requested_jobs,
+        platform="darwin",
+        cpu_count=8,
+    )
+
+    assert execution.transport == "inline"
+    assert run_file_jobs(
+        jobs,
+        _identity,
+        execution=execution,
+        repository_root=tmp_path,
+    ) == [5]
+
+
+def test_non_linux_forced_process_selection_fails_before_execution():
+    """Darwin must reject a forced process count instead of falling back."""
+    with pytest.raises(
+        CommandError,
+        match="requires Linux",
+    ):
+        select_file_job_execution(
+            [OrderedFileJob(0, "file.txt", 1, None)],
+            requested_jobs="2",
+            platform="darwin",
+            cpu_count=8,
+        )
+
+
+def test_non_linux_forced_process_selection_fails_without_jobs():
+    """A forced non-Linux process request should fail even with no work."""
+    with pytest.raises(
+        CommandError,
+        match="requires Linux",
+    ):
+        select_file_job_execution(
+            [],
+            requested_jobs="2",
+            platform="darwin",
+            cpu_count=8,
+        )
+
+
+def test_linux_auto_keeps_work_just_below_the_round_heuristic_inline():
+    """Automatic execution should avoid process startup below 256 KiB."""
+    jobs = [
+        OrderedFileJob(0, "a.txt", 128 * 1024 - 1, None),
+        OrderedFileJob(1, "b.txt", 128 * 1024, None),
+    ]
+
+    execution = select_file_job_execution(
+        jobs,
+        requested_jobs="auto",
+        platform="linux",
+        cpu_count=8,
+    )
+
+    assert execution.transport == "inline"
+    assert execution.max_workers == 1
+    assert "below the" in execution.reason
+
+
+def test_linux_auto_selects_processes_at_the_round_heuristic():
+    """The 256 KiB heuristic should be inclusive."""
+    jobs = [
+        OrderedFileJob(0, "a.txt", 128 * 1024, None),
+        OrderedFileJob(1, "b.txt", 128 * 1024, None),
+    ]
+
+    execution = select_file_job_execution(
+        jobs,
+        requested_jobs="auto",
+        platform="linux",
+        cpu_count=8,
+    )
+
+    assert execution.transport == "process"
+    assert execution.max_workers == 2
+    assert "262144 estimated bytes" in execution.reason
+
+
+def test_linux_auto_selects_bounded_processes_above_the_heuristic():
+    """Automatic execution should admit measured multi-file CPU wins."""
+    jobs = [
+        OrderedFileJob(ordinal, f"{ordinal}.txt", 125_000, None) for ordinal in range(5)
+    ]
+
+    execution = select_file_job_execution(
+        jobs,
+        requested_jobs=None,
+        platform="linux",
+        cpu_count=8,
+    )
+
+    assert execution.transport == "process"
+    assert execution.max_workers == 4
+    assert "625000 estimated bytes" in execution.reason
+
+
+def test_linux_auto_respects_cpu_availability():
+    """Automatic worker selection should not exceed available CPUs."""
+    jobs = [
+        OrderedFileJob(ordinal, f"{ordinal}.txt", 250_000, None) for ordinal in range(2)
+    ]
+
+    assert (
+        select_file_job_execution(
+            jobs,
+            requested_jobs="auto",
+            platform="linux",
+            cpu_count=1,
+        ).transport
+        == "inline"
+    )
+    assert (
+        select_file_job_execution(
+            jobs,
+            requested_jobs="auto",
+            platform="linux",
+            cpu_count=2,
+        ).max_workers
+        == 2
+    )
+
+
+def test_linux_auto_uses_process_affinity_when_cpu_count_is_unspecified(
+    monkeypatch,
+):
+    """Production selection should honor a constrained CPU affinity mask."""
+    jobs = [
+        OrderedFileJob(ordinal, f"{ordinal}.txt", 125_000, None) for ordinal in range(4)
+    ]
+    monkeypatch.setattr(
+        file_jobs_module.os,
+        "sched_getaffinity",
+        lambda _process_id: {0, 1},
+    )
+
+    execution = select_file_job_execution(
+        jobs,
+        requested_jobs="auto",
+        platform="linux",
+        cpu_count=None,
+    )
+
+    assert execution.transport == "process"
+    assert execution.max_workers == 2
+
+
+def test_forced_process_selection_respects_job_cpu_and_worker_caps():
+    """Forced worker counts should remain bounded by every execution limit."""
+    jobs = [OrderedFileJob(ordinal, f"{ordinal}.txt", 1, None) for ordinal in range(10)]
+
+    assert select_file_job_execution(
+        jobs,
+        requested_jobs="9",
+        platform="linux",
+        cpu_count=3,
+    ) == FileJobExecution(
+        "process",
+        3,
+        "GIT_STAGE_BATCH_JOBS requests 9 processes",
+    )
+
+
+def test_process_execution_enforces_the_hard_worker_cap(
+    tmp_path,
+    monkeypatch,
+):
+    """Direct execution records must not bypass the generic worker ceiling."""
+    observed_max_workers = []
+
+    class FakeSupervisor:
+        def __init__(self, _compute, *, max_workers, repository_root):
+            observed_max_workers.append(max_workers)
+            self.pending = []
+
+        @property
+        def pending_count(self):
+            return len(self.pending)
+
+        @property
+        def can_submit(self):
+            return len(self.pending) < 8
+
+        def submit(self, job):
+            self.pending.append(job)
+
+        def receive(self):
+            job = self.pending.pop()
+            return file_jobs_module._WorkerResponse(
+                job.ordinal,
+                result=job.payload,
+            )
+
+        def close(self):
+            return None
+
+        def terminate(self):
+            raise AssertionError("successful execution was terminated")
+
+    monkeypatch.setattr(
+        file_jobs_module,
+        "_ProcessFileJobSupervisor",
+        FakeSupervisor,
+    )
+    jobs = [
+        OrderedFileJob(ordinal, f"{ordinal}.txt", 1, ordinal) for ordinal in range(10)
+    ]
+
+    results = run_file_jobs(
+        jobs,
+        _identity,
+        execution=FileJobExecution("process", 99, "test"),
+        repository_root=tmp_path,
+    )
+
+    assert results == list(range(10))
+    assert observed_max_workers == [file_jobs_module._MAX_FILE_JOB_WORKERS]

--- a/tests/utils/test_file_jobs.py
+++ b/tests/utils/test_file_jobs.py
@@ -1,0 +1,546 @@
+"""Tests for ordered inline and forkserver file-job execution."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum, IntEnum
+import hashlib
+import itertools
+import mmap
+import os
+from pathlib import Path
+import pickle
+import subprocess
+import sys
+import time
+
+import pytest
+
+import git_stage_batch.utils.file_jobs as file_jobs_module
+from git_stage_batch.batch.line_matching.line_mapping import LineMapping
+from git_stage_batch.core.buffer import LineBuffer
+from git_stage_batch.exceptions import CommandError
+from git_stage_batch.utils.file_job_workspace import FileJobWorkspace
+from git_stage_batch.utils.file_jobs import (
+    FileJobError,
+    FileJobExecution,
+    OrderedFileJob,
+    assert_file_job_transport_value,
+    run_file_jobs,
+    run_validated_file_jobs,
+    select_file_job_execution,
+)
+from git_stage_batch.utils.paths import get_session_lock_file_path
+from git_stage_batch.utils.session_lock import acquire_session_lock
+
+
+_RUNNING_UNDER_XDIST = "PYTEST_XDIST_WORKER" in os.environ
+_REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPOSITORY_ROOT))
+_PROCESS_TEST = pytest.mark.skipif(
+    sys.platform != "linux" or _RUNNING_UNDER_XDIST,
+    reason="forced forkserver coverage runs on Linux with pytest -n 0",
+)
+_PARENT_COMPUTE_CALLS = 0
+
+
+@dataclass(frozen=True, slots=True)
+class _DigestJob:
+    artifact_path: Path
+    scratch_directory: Path
+    marker: int
+    delay_seconds: float = 0.0
+    failure: str | None = None
+    exit_code: int | None = None
+    parent_pid: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _DigestResult:
+    marker: int
+    digest: str
+    line_count: int
+    cwd: str
+
+
+@dataclass(frozen=True, slots=True)
+class _BytesPayload:
+    content: bytes
+
+
+@dataclass
+class _ExtensiblePayload:
+    marker: int
+
+
+@dataclass(frozen=True)
+class _ManualSlotsPayload:
+    __slots__ = ("hidden", "marker")
+
+    marker: int
+
+
+@dataclass(frozen=True)
+class _ListPayload(list):
+    __slots__ = ()
+
+
+class _ExtensibleTuple(tuple):
+    pass
+
+
+class _ExtensibleInteger(int):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class _CustomPicklePayload:
+    marker: int
+
+    def __reduce__(self):
+        return bytes, (b"content",)
+
+
+class _CustomPickleMarker(Enum):
+    ONE = 1
+
+    def __reduce_ex__(self, _protocol):
+        return bytes, (b"content",)
+
+
+class _RecursiveMarker(Enum):
+    ONE = 1
+
+
+def _compute_digest(job: _DigestJob) -> _DigestResult:
+    if job.delay_seconds:
+        time.sleep(job.delay_seconds)
+    if job.exit_code is not None:
+        if job.parent_pid == os.getpid():
+            global _PARENT_COMPUTE_CALLS
+            _PARENT_COMPUTE_CALLS += 1
+            raise AssertionError("dead worker job retried inline")
+        os._exit(job.exit_code)
+    if job.failure is not None:
+        raise RuntimeError(job.failure)
+
+    digest = hashlib.sha256()
+    with LineBuffer.from_path(
+        job.artifact_path,
+        spool_dir=job.scratch_directory,
+    ) as buffer:
+        for chunk in buffer.byte_chunks():
+            digest.update(chunk)
+        line_count = len(buffer)
+    return _DigestResult(
+        marker=job.marker,
+        digest=digest.hexdigest(),
+        line_count=line_count,
+        cwd=os.getcwd(),
+    )
+
+
+def _identity(value: int) -> int:
+    return value
+
+
+def _current_directory(_value: int) -> str:
+    return os.getcwd()
+
+
+def _has_open_descriptor_for_path(path: Path) -> bool:
+    expected_path = path.resolve()
+    for descriptor_path in Path("/proc/self/fd").iterdir():
+        try:
+            if descriptor_path.resolve() == expected_path:
+                return True
+        except OSError:
+            continue
+    return False
+
+
+def _interrupt_compute(_value: int) -> int:
+    raise KeyboardInterrupt
+
+
+def _large_error_compute(_value: int) -> int:
+    raise RuntimeError("x" * (file_jobs_module._MAX_ERROR_MESSAGE_CHARACTERS * 2))
+
+
+def _oversized_transport_string():
+    return "x" * (file_jobs_module._MAX_TRANSPORT_STRING_CHARACTERS + 1)
+
+
+def _oversized_transport_integer():
+    return 1 << (file_jobs_module._MAX_TRANSPORT_INTEGER_BITS + 1)
+
+
+def _oversized_transport_tuple():
+    return tuple(range(file_jobs_module._MAX_TRANSPORT_TUPLE_ITEMS + 1))
+
+
+def _transport_value_with_too_many_strings():
+    string_count = (
+        file_jobs_module._MAX_TRANSPORT_TOTAL_STRING_CHARACTERS
+        // file_jobs_module._MAX_TRANSPORT_STRING_CHARACTERS
+        + 1
+    )
+    return tuple(
+        "x" * file_jobs_module._MAX_TRANSPORT_STRING_CHARACTERS
+        for _index in range(string_count)
+    )
+
+
+def _transport_value_with_too_many_values():
+    tuple_count = (
+        file_jobs_module._MAX_TRANSPORT_VALUE_COUNT
+        // file_jobs_module._MAX_TRANSPORT_TUPLE_ITEMS
+        + 1
+    )
+    return tuple(
+        tuple(range(file_jobs_module._MAX_TRANSPORT_TUPLE_ITEMS))
+        for _index in range(tuple_count)
+    )
+
+
+def _transport_value_with_excessive_nesting():
+    value = 0
+    for _depth in range(file_jobs_module._MAX_TRANSPORT_NESTING_DEPTH + 1):
+        value = (value,)
+    return value
+
+
+def _record_parent_call(value: int) -> int:
+    global _PARENT_COMPUTE_CALLS
+    _PARENT_COMPUTE_CALLS += 1
+    return value
+
+
+def _jobs_for_artifact(
+    artifact: Path,
+    scratch: Path,
+) -> list[OrderedFileJob[_DigestJob]]:
+    return [
+        OrderedFileJob(
+            ordinal=2,
+            file_path="two.txt",
+            estimated_bytes=20,
+            payload=_DigestJob(artifact, scratch, 2, delay_seconds=0.00),
+        ),
+        OrderedFileJob(
+            ordinal=0,
+            file_path="zero.txt",
+            estimated_bytes=60,
+            payload=_DigestJob(artifact, scratch, 0, delay_seconds=0.06),
+        ),
+        OrderedFileJob(
+            ordinal=1,
+            file_path="one.txt",
+            estimated_bytes=40,
+            payload=_DigestJob(artifact, scratch, 1, delay_seconds=0.03),
+        ),
+    ]
+
+
+@_PROCESS_TEST
+def test_inline_and_forced_process_runs_return_identical_ordered_results(
+    tmp_path,
+    monkeypatch,
+):
+    """Reverse task completion must not change ordinal reduction or cwd."""
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    invocation_directory = repository / "nested"
+    invocation_directory.mkdir()
+    monkeypatch.chdir(invocation_directory)
+
+    with FileJobWorkspace(parent_directory=tmp_path) as workspace:
+        artifact = workspace.write_buffer(
+            0,
+            "input.txt",
+            (f"line {index}\n".encode() for index in range(2_000)),
+        )
+        jobs = _jobs_for_artifact(
+            artifact,
+            workspace.scratch_directory(0),
+        )
+        inline = run_file_jobs(
+            jobs,
+            _compute_digest,
+            execution=FileJobExecution("inline", 1, "test"),
+            repository_root=repository,
+        )
+        assert Path.cwd() == invocation_directory
+        processed = run_file_jobs(
+            jobs,
+            _compute_digest,
+            execution=FileJobExecution("process", 2, "test"),
+            repository_root=repository,
+        )
+        assert Path.cwd() == invocation_directory
+
+    assert processed == inline
+    assert [result.marker for result in processed] == [0, 1, 2]
+    assert {result.cwd for result in processed} == {str(repository)}
+
+
+def test_inline_compute_uses_repository_root_and_restores_cwd(
+    tmp_path,
+    monkeypatch,
+):
+    """Direct execution should observe the same cwd as a process worker."""
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    invocation_directory = repository / "nested"
+    invocation_directory.mkdir()
+    monkeypatch.chdir(invocation_directory)
+
+    results = run_file_jobs(
+        [OrderedFileJob(0, "file.txt", 1, 1)],
+        _current_directory,
+        execution=FileJobExecution("inline", 1, "test"),
+        repository_root=repository,
+    )
+
+    assert results == [str(repository)]
+    assert Path.cwd() == invocation_directory
+
+
+def test_validated_runner_pairs_results_in_ordinal_order(tmp_path, monkeypatch):
+    """The shared pipeline should retain ordering and domain validation."""
+    monkeypatch.setenv("GIT_STAGE_BATCH_JOBS", "1")
+    observed = []
+
+    def run_jobs(jobs, compute, *, execution, repository_root):
+        assert [job.ordinal for job in jobs] == [1, 0]
+        assert compute is _identity
+        assert execution.transport == "inline"
+        assert repository_root == tmp_path
+        return ["zero", "one"]
+
+    def validate(payload, result):
+        observed.append((payload, result))
+
+    jobs = [
+        OrderedFileJob(1, "one.txt", 1, "one payload"),
+        OrderedFileJob(0, "zero.txt", 1, "zero payload"),
+    ]
+
+    paired = run_validated_file_jobs(
+        jobs,
+        _identity,
+        validate,
+        repository_root=tmp_path,
+        result_label="test jobs",
+        run_jobs=run_jobs,
+    )
+
+    assert [(job.ordinal, result) for job, result in paired] == [
+        (0, "zero"),
+        (1, "one"),
+    ]
+    assert observed == [
+        ("zero payload", "zero"),
+        ("one payload", "one"),
+    ]
+
+
+def test_validated_runner_rejects_an_unexpected_result_count(
+    tmp_path,
+    monkeypatch,
+):
+    """A broken runner must not silently truncate job/result pairing."""
+    monkeypatch.setenv("GIT_STAGE_BATCH_JOBS", "1")
+
+    with pytest.raises(RuntimeError, match="unexpected result count"):
+        run_validated_file_jobs(
+            [OrderedFileJob(0, "file.txt", 1, "payload")],
+            _identity,
+            lambda _payload, _result: None,
+            repository_root=tmp_path,
+            result_label="test jobs",
+            run_jobs=lambda *_args, **_kwargs: [],
+        )
+
+
+@_PROCESS_TEST
+def test_forkserver_worker_does_not_inherit_the_parent_session_lock(
+    tmp_path,
+    monkeypatch,
+):
+    """A status worker must not keep the repository lock descriptor alive."""
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    subprocess.run(
+        ["git", "init"],
+        cwd=repository,
+        check=True,
+        capture_output=True,
+    )
+    monkeypatch.chdir(repository)
+
+    with acquire_session_lock():
+        lock_path = get_session_lock_file_path()
+        assert _has_open_descriptor_for_path(lock_path)
+        worker_observations = run_file_jobs(
+            [OrderedFileJob(0, "file.txt", 1, lock_path)],
+            _has_open_descriptor_for_path,
+            execution=FileJobExecution("process", 1, "test"),
+            repository_root=repository,
+        )
+
+    assert worker_observations == [False]
+
+
+@_PROCESS_TEST
+def test_compute_keyboard_interrupt_propagates_across_process_transport(
+    tmp_path,
+):
+    """A compute interruption should retain inline control-flow semantics."""
+    with FileJobWorkspace(parent_directory=tmp_path) as workspace:
+        root = workspace.root
+        with pytest.raises(KeyboardInterrupt):
+            run_file_jobs(
+                [OrderedFileJob(0, "file.txt", 1, 1)],
+                _interrupt_compute,
+                execution=FileJobExecution("process", 1, "test"),
+                repository_root=tmp_path,
+            )
+
+    assert not root.exists()
+
+
+def test_process_scheduler_submits_largest_first_with_bounded_pending(
+    tmp_path,
+    monkeypatch,
+):
+    """Admission priority and pending bounds should be independent of reduction."""
+    submitted = []
+    max_pending = 0
+    lifecycle = {"closed": False, "terminated": False}
+
+    class FakeSupervisor:
+        def __init__(self, _compute, *, max_workers, repository_root):
+            self.capacity = max_workers * 2
+            self.pending = []
+            assert repository_root == tmp_path.resolve()
+
+        @property
+        def pending_count(self):
+            return len(self.pending)
+
+        @property
+        def can_submit(self):
+            return len(self.pending) < self.capacity
+
+        def submit(self, job):
+            nonlocal max_pending
+            submitted.append(job.ordinal)
+            self.pending.append(job)
+            max_pending = max(max_pending, len(self.pending))
+
+        def receive(self):
+            job = self.pending.pop()
+            return file_jobs_module._WorkerResponse(
+                job.ordinal,
+                result=job.payload,
+            )
+
+        def close(self):
+            lifecycle["closed"] = True
+
+        def terminate(self):
+            lifecycle["terminated"] = True
+
+    monkeypatch.setattr(
+        file_jobs_module,
+        "_ProcessFileJobSupervisor",
+        FakeSupervisor,
+    )
+    jobs = [
+        OrderedFileJob(ordinal, f"{ordinal}.txt", size, ordinal)
+        for ordinal, size in enumerate((10, 80, 30, 80, 20, 50))
+    ]
+
+    results = run_file_jobs(
+        jobs,
+        _identity,
+        execution=FileJobExecution("process", 2, "test"),
+        repository_root=tmp_path,
+    )
+
+    assert submitted == [1, 3, 5, 2, 4, 0]
+    assert max_pending <= 4
+    assert results == [0, 1, 2, 3, 4, 5]
+    assert lifecycle == {"closed": True, "terminated": False}
+
+
+def test_process_scheduler_stops_admission_after_task_failure(
+    tmp_path,
+    monkeypatch,
+):
+    """A task failure should terminate pending and unadmitted work."""
+    submitted = []
+    lifecycle = {"closed": False, "terminated": False}
+
+    class FailingSupervisor:
+        def __init__(self, _compute, *, max_workers, repository_root):
+            self.capacity = max_workers
+            self.pending = []
+            self.received = 0
+
+        @property
+        def pending_count(self):
+            return len(self.pending)
+
+        @property
+        def can_submit(self):
+            return len(self.pending) < self.capacity
+
+        def submit(self, job):
+            submitted.append(job.ordinal)
+            self.pending.append(job)
+
+        def receive(self):
+            self.received += 1
+            job = self.pending.pop(0)
+            if self.received == 1:
+                return file_jobs_module._WorkerResponse(
+                    job.ordinal,
+                    error_type="builtins.RuntimeError",
+                    error_message="failed",
+                )
+            return file_jobs_module._WorkerResponse(
+                job.ordinal,
+                result=job.payload,
+            )
+
+        def close(self):
+            lifecycle["closed"] = True
+
+        def terminate(self):
+            self.pending.clear()
+            lifecycle["terminated"] = True
+
+    monkeypatch.setattr(
+        file_jobs_module,
+        "_ProcessFileJobSupervisor",
+        FailingSupervisor,
+    )
+    jobs = [
+        OrderedFileJob(ordinal, f"{ordinal}.txt", 40 - ordinal, ordinal)
+        for ordinal in range(4)
+    ]
+
+    with pytest.raises(FileJobError) as error:
+        run_file_jobs(
+            jobs,
+            _identity,
+            execution=FileJobExecution("process", 2, "test"),
+            repository_root=tmp_path,
+        )
+
+    assert error.value.ordinal == 0
+    assert submitted == [0, 1]
+    assert lifecycle == {"closed": False, "terminated": True}

--- a/tests/utils/test_file_jobs.py
+++ b/tests/utils/test_file_jobs.py
@@ -1113,3 +1113,349 @@ def test_process_execution_enforces_the_hard_worker_cap(
 
     assert results == list(range(10))
     assert observed_max_workers == [file_jobs_module._MAX_FILE_JOB_WORKERS]
+
+
+def test_collected_lower_ordinal_failure_wins_over_worker_failure(
+    tmp_path,
+    monkeypatch,
+):
+    """A later supervisor failure must not hide an earlier task failure."""
+
+    class FailingSupervisor:
+        def __init__(self, _compute, *, max_workers, repository_root):
+            self.pending = []
+            self.responses = 0
+
+        @property
+        def pending_count(self):
+            return len(self.pending)
+
+        @property
+        def can_submit(self):
+            return len(self.pending) < 4
+
+        def submit(self, job):
+            self.pending.append(job)
+
+        def receive(self):
+            self.responses += 1
+            if self.responses == 1:
+                self.pending = [job for job in self.pending if job.ordinal != 1]
+                return file_jobs_module._WorkerResponse(
+                    1,
+                    error_type="builtins.RuntimeError",
+                    error_message="one failed",
+                )
+            raise file_jobs_module._FileJobSupervisorError(
+                "worker exited while running job 4",
+                ordinal=4,
+            )
+
+        def close(self):
+            raise AssertionError("failed supervisor closed normally")
+
+        def terminate(self):
+            self.pending.clear()
+
+    monkeypatch.setattr(
+        file_jobs_module,
+        "_ProcessFileJobSupervisor",
+        FailingSupervisor,
+    )
+    jobs = [
+        OrderedFileJob(1, "one.txt", 20, 1),
+        OrderedFileJob(4, "four.txt", 10, 4),
+    ]
+
+    with pytest.raises(FileJobError) as error:
+        run_file_jobs(
+            jobs,
+            _identity,
+            execution=FileJobExecution("process", 2, "test"),
+            repository_root=tmp_path,
+        )
+
+    assert error.value.ordinal == 1
+    assert "one failed" in error.value.original_message
+
+
+def test_worker_failure_reports_its_job_instead_of_an_unrelated_ordinal(
+    tmp_path,
+    monkeypatch,
+):
+    """A specific worker failure should retain its own job identity."""
+
+    class FailingSupervisor:
+        def __init__(self, _compute, *, max_workers, repository_root):
+            self.pending = []
+
+        @property
+        def pending_count(self):
+            return len(self.pending)
+
+        @property
+        def can_submit(self):
+            return len(self.pending) < 4
+
+        def submit(self, job):
+            self.pending.append(job)
+
+        def receive(self):
+            raise file_jobs_module._FileJobSupervisorError(
+                "worker exited while running job 4",
+                ordinal=4,
+            )
+
+        def close(self):
+            raise AssertionError("failed supervisor closed normally")
+
+        def terminate(self):
+            self.pending.clear()
+
+    monkeypatch.setattr(
+        file_jobs_module,
+        "_ProcessFileJobSupervisor",
+        FailingSupervisor,
+    )
+    jobs = [
+        OrderedFileJob(0, "zero.txt", 10, 0),
+        OrderedFileJob(4, "four.txt", 20, 4),
+    ]
+
+    with pytest.raises(FileJobError) as error:
+        run_file_jobs(
+            jobs,
+            _identity,
+            execution=FileJobExecution("process", 2, "test"),
+            repository_root=tmp_path,
+        )
+
+    assert error.value.ordinal == 4
+    assert error.value.file_path == "four.txt"
+
+
+def test_transport_records_remain_compact_as_artifact_content_grows(tmp_path):
+    """Pickle should see paths and scalars, never complete artifact content."""
+    with FileJobWorkspace(parent_directory=tmp_path) as workspace:
+        small_path = workspace.write_buffer(
+            0,
+            "small.txt",
+            (b"unchanged\n", b"changed\n", b"unchanged\n"),
+        )
+        large_path = workspace.write_buffer(
+            0,
+            "large.txt",
+            itertools.chain(
+                itertools.repeat(b"unchanged\n", 100_000),
+                (b"changed\n",),
+            ),
+        )
+        scratch = workspace.scratch_directory(0)
+        small_job = _DigestJob(small_path, scratch, 0)
+        large_job = _DigestJob(large_path, scratch, 0)
+        small_result = _compute_digest(small_job)
+        large_result = _compute_digest(large_job)
+
+        assert abs(len(pickle.dumps(small_job)) - len(pickle.dumps(large_job))) < 32
+        assert (
+            abs(len(pickle.dumps(small_result)) - len(pickle.dumps(large_result))) < 16
+        )
+
+
+def test_transport_value_assertion_rejects_content_and_resource_graphs(
+    tmp_path,
+):
+    """IPC records must reject bytes, buffers, mappings, and mapped storage."""
+    forbidden_values = [
+        b"content",
+        bytearray(b"content"),
+        memoryview(b"content"),
+        (b"line\n",),
+        [b"line\n"],
+        _BytesPayload(b"content"),
+        LineMapping([0], [0]),
+    ]
+    with LineBuffer.from_bytes(b"line\n") as buffer:
+        forbidden_values.append(buffer)
+        for value in forbidden_values:
+            with pytest.raises(TypeError):
+                assert_file_job_transport_value(value)
+
+    mapped_path = tmp_path / "mapped"
+    mapped_path.write_bytes(b"mapped")
+    with mapped_path.open("r+b") as mapped_file:
+        with mmap.mmap(mapped_file.fileno(), 0) as mapped:
+            with pytest.raises(TypeError):
+                assert_file_job_transport_value(mapped)
+
+
+def test_transport_value_assertion_rejects_hidden_instance_state():
+    """Pickle-visible state must not hide outside declared record fields."""
+    payload = _ExtensiblePayload(1)
+    payload.hidden = b"content"
+    slotted_payload = _ManualSlotsPayload(1)
+    object.__setattr__(slotted_payload, "hidden", b"content")
+    list_payload = _ListPayload()
+    list_payload.append(b"content")
+    tuple_value = _ExtensibleTuple((1,))
+    tuple_value.hidden = b"content"
+    integer_value = _ExtensibleInteger(1)
+    integer_value.hidden = b"content"
+
+    for value in (
+        payload,
+        slotted_payload,
+        list_payload,
+        tuple_value,
+        integer_value,
+    ):
+        with pytest.raises(TypeError):
+            assert_file_job_transport_value(value)
+
+
+def test_transport_value_assertion_rejects_custom_pickle_behavior():
+    """Validated fields must be the only state serialized across IPC."""
+    for value in (_CustomPicklePayload(1), _CustomPickleMarker.ONE):
+        with pytest.raises(TypeError, match="custom pickle behavior"):
+            assert_file_job_transport_value(value)
+
+
+def test_transport_value_assertion_rejects_recursive_enum(monkeypatch):
+    """An enum value cycle should fail deterministically."""
+    monkeypatch.setattr(_RecursiveMarker.ONE, "_value_", _RecursiveMarker.ONE)
+
+    with pytest.raises(TypeError, match="recursive value"):
+        assert_file_job_transport_value(_RecursiveMarker.ONE)
+
+
+@pytest.mark.parametrize(
+    "value_builder",
+    (
+        _oversized_transport_string,
+        _oversized_transport_integer,
+        _oversized_transport_tuple,
+        _transport_value_with_too_many_strings,
+        _transport_value_with_too_many_values,
+        _transport_value_with_excessive_nesting,
+    ),
+)
+def test_transport_value_assertion_rejects_unbounded_values(value_builder):
+    """Successful IPC values should remain bounded independently of content."""
+    with pytest.raises(TypeError):
+        assert_file_job_transport_value(value_builder())
+
+
+@_PROCESS_TEST
+def test_process_failure_message_is_bounded(tmp_path):
+    """Worker diagnostics should not become an unbounded IPC result."""
+    with pytest.raises(FileJobError) as error:
+        run_file_jobs(
+            [OrderedFileJob(0, "file.txt", 1, 1)],
+            _large_error_compute,
+            execution=FileJobExecution("process", 1, "test"),
+            repository_root=tmp_path,
+        )
+
+    assert error.value.original_message.endswith("...")
+    assert (
+        len(error.value.original_message)
+        <= file_jobs_module._MAX_ERROR_MESSAGE_CHARACTERS
+    )
+
+
+def test_nested_compute_function_is_rejected_before_execution(tmp_path):
+    """Process callables must be top-level importable functions."""
+
+    def nested_compute(value):
+        return value
+
+    with pytest.raises(TypeError, match="top-level importable"):
+        run_file_jobs(
+            [OrderedFileJob(0, "file.txt", 1, 1)],
+            nested_compute,
+            execution=FileJobExecution("inline", 1, "test"),
+            repository_root=tmp_path,
+        )
+
+
+def test_main_module_compute_function_is_rejected_before_execution(
+    tmp_path,
+    monkeypatch,
+):
+    """Forkserver callables cannot depend on the launching main module."""
+    monkeypatch.setattr(_identity, "__module__", "__main__")
+
+    with pytest.raises(TypeError, match="top-level importable"):
+        run_file_jobs(
+            [OrderedFileJob(0, "file.txt", 1, 1)],
+            _identity,
+            execution=FileJobExecution("inline", 1, "test"),
+            repository_root=tmp_path,
+        )
+
+
+def test_non_importable_transport_dataclass_is_rejected():
+    """IPC dataclass types must be reconstructable in a forkserver child."""
+
+    @dataclass(frozen=True)
+    class LocalPayload:
+        marker: int
+
+    with pytest.raises(TypeError, match="non-importable value type"):
+        assert_file_job_transport_value(LocalPayload(1))
+
+
+def test_non_importable_integer_enum_is_rejected():
+    """Integer enum subclasses should not bypass IPC type validation."""
+
+    class LocalMarker(IntEnum):
+        ONE = 1
+
+    with pytest.raises(TypeError, match="non-importable value type"):
+        assert_file_job_transport_value(LocalMarker.ONE)
+
+
+def test_invalid_transport_is_rejected_even_without_jobs(tmp_path):
+    """An empty input should not hide an invalid execution contract."""
+    with pytest.raises(ValueError, match="unsupported file-job transport"):
+        run_file_jobs(
+            [],
+            _identity,
+            execution=FileJobExecution("unknown", 1, "test"),  # type: ignore[arg-type]
+            repository_root=tmp_path,
+        )
+
+
+def test_process_transport_is_rejected_outside_linux(
+    tmp_path,
+    monkeypatch,
+):
+    """A manually constructed execution policy cannot bypass platform scope."""
+    monkeypatch.setattr(file_jobs_module.sys, "platform", "darwin")
+
+    with pytest.raises(ValueError, match="requires Linux"):
+        run_file_jobs(
+            [],
+            _identity,
+            execution=FileJobExecution("process", 2, "test"),
+            repository_root=tmp_path,
+        )
+
+
+@pytest.mark.parametrize("max_workers", (0, -1, True, 1.5))
+def test_invalid_worker_count_is_rejected_even_without_jobs(
+    tmp_path,
+    max_workers,
+):
+    """An empty input should not hide an invalid worker-count contract."""
+    with pytest.raises(ValueError, match="positive worker count"):
+        run_file_jobs(
+            [],
+            _identity,
+            execution=FileJobExecution(
+                "inline",
+                max_workers,  # type: ignore[arg-type]
+                "test",
+            ),
+            repository_root=tmp_path,
+        )


### PR DESCRIPTION
Captured file inputs need one execution contract that produces the same ordered results inline and under bounded Linux process workers.

General-purpose pool behavior does not enforce this project's compact transport, deterministic reduction, workspace ownership, or worker lifecycle requirements. Scheduling in completion order would also make refusals and diagnostics depend on timing.

This pull request defines exact content-free job and result records, supervises forkserver workers with bounded largest-first admission, and reduces successful results in source order. The public runner selects inline or process execution once, pairs jobs with results, validates outcomes, and converts execution failures into command-level errors.

Coverage exercises ordered inline and process execution, selection policy, start and worker failures, termination and kill cleanup, per-invocation artifacts, and strict transport shapes. The executor is ready for its first canonical status consumer.