### PR TITLE
session: Retry silent recovery snapshot refusals

### DIFF
--- a/src/git_stage_batch/data/session.py
+++ b/src/git_stage_batch/data/session.py
@@ -260,6 +260,20 @@ def _initialize_abort_state() -> None:
                 check=False,
                 requires_index_lock=False,
             )
+            # Git can refresh an ignored stat-only change and return 1 without
+            # a diagnostic. Retry once after that refresh before treating the
+            # result as a recovery-snapshot failure.
+            if (
+                stash_result.returncode == 1
+                and not stash_result.stdout.strip()
+                and not stash_result.stderr.strip()
+            ):
+                log_journal("session_retrying_silent_stash_failure")
+                stash_result = run_git_command(
+                    ["stash", "create"],
+                    check=False,
+                    requires_index_lock=False,
+                )
             stash_hash = stash_result.stdout.strip()
             stash_returncode = stash_result.returncode
             stash_stderr = stash_result.stderr

--- a/tests/commands/test_start.py
+++ b/tests/commands/test_start.py
@@ -125,6 +125,40 @@ class TestCommandStart:
         assert not session_is_active()
         assert readme.read_text() == "# Test\nModified\n"
 
+    def test_start_retries_silent_recovery_snapshot_refusal(self, temp_git_repo):
+        """A silent stash refusal should be retried before startup fails."""
+        readme = temp_git_repo / "README.md"
+        readme.write_text("# Test\nModified\n")
+
+        from git_stage_batch.data import session as session_module
+
+        real_run_git_command = session_module.run_git_command
+        stash_calls = 0
+
+        def refuse_first_stash(command, *args, **kwargs):
+            nonlocal stash_calls
+            if command == ["stash", "create"]:
+                stash_calls += 1
+                if stash_calls == 1:
+                    return subprocess.CompletedProcess(
+                        command,
+                        1,
+                        stdout="",
+                        stderr="",
+                    )
+            return real_run_git_command(command, *args, **kwargs)
+
+        with patch.object(
+            session_module,
+            "run_git_command",
+            side_effect=refuse_first_stash,
+        ):
+            command_start()
+
+        assert stash_calls == 2
+        assert session_is_active()
+        assert read_text_file_contents(get_abort_stash_file_path()).strip()
+
     def test_start_preserves_original_error_when_abort_also_fails(
         self,
         temp_git_repo,


### PR DESCRIPTION
Session startup creates a dangling stash commit before publishing an active session so abort can restore tracked index and worktree changes.

Git can refresh an ignored stat-only change and return exit status 1 with empty stdout and stderr even when no tracked content needs a stash. Startup treats every nonzero result as a hard snapshot failure, which makes core.fileMode=false repositories fail intermittently.

This pull request retries stash creation once only after that exact silent exit-1 signature. A diagnosed failure, a different status, or any nonzero retry still fails closed, while a dirty worktree must still produce a real recovery object.

Deterministic coverage injects the silent first result and verifies two attempts, an active session, and a nonempty abort stash. The previously flaky core.fileMode=false workflow also passed 50 consecutive local repetitions.