### PR TITLE
status: Count remaining changes with canonical file jobs

### DIFF
--- a/src/git_stage_batch/data/live_change_jobs.py
+++ b/src/git_stage_batch/data/live_change_jobs.py
@@ -1,0 +1,399 @@
+"""Artifact-backed per-file planning for remaining live text changes."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator, Mapping
+from contextlib import contextmanager
+from dataclasses import dataclass
+import json
+from pathlib import Path
+from typing import Any, TextIO
+
+from ..batch.source.cache import load_session_batch_sources
+from ..batch.state.query import list_batch_names, read_batch_metadata_for_batches
+from ..batch.state.reference_names import format_batch_state_ref_name
+from ..core.diff_parser import acquire_unified_diff
+from ..core.hashing import compute_stable_hunk_hash_from_lines
+from ..core.models import SingleHunkPatch
+from ..utils.file_job_workspace import FileJobWorkspace
+from ..utils.file_jobs import OrderedFileJob
+from ..utils.git_object_io import resolve_git_objects
+from ..utils.git_repository import get_git_repository_root_path
+from ..utils.paths import get_context_lines
+from ..utils.session_start_point import current_head_commit
+from .consumed_selections import load_consumed_selections_metadata
+from .live_change_candidates import (
+    LiveChangeScanContext,
+    prepare_atomic_live_change,
+    text_hunk_block_reason,
+)
+from .live_diff import stream_live_git_diff
+
+@dataclass(frozen=True, slots=True)
+class WorktreeStatIdentity:
+    """A compact lstat snapshot for one repository worktree path."""
+
+    exists: bool
+    mode: int
+    size: int
+    mtime_ns: int
+    ctime_ns: int
+    device: int
+    inode: int
+
+
+@dataclass(frozen=True, slots=True)
+class LiveTextFileJob:
+    """Compact transport record for one contiguous live text file group."""
+
+    ordinal: int
+    file_path: str
+    input_manifest_path: str
+    hunk_manifest_path: str
+    expected_worktree_identity: WorktreeStatIdentity
+
+
+@dataclass(frozen=True, slots=True)
+class LiveChangeCountPlan:
+    """One invocation's compact jobs and parent-counted atomic changes."""
+
+    jobs: tuple[OrderedFileJob[LiveTextFileJob], ...]
+    atomic_count: int
+    repository_root: Path
+
+
+def capture_worktree_stat_identity(
+    file_path: str,
+    *,
+    repository_root: Path | None = None,
+) -> WorktreeStatIdentity:
+    """Capture the current lstat identity of one repository-relative path."""
+    full_path = (repository_root or Path.cwd()) / file_path
+    try:
+        metadata = full_path.lstat()
+    except (FileNotFoundError, NotADirectoryError):
+        return WorktreeStatIdentity(
+            exists=False,
+            mode=0,
+            size=0,
+            mtime_ns=0,
+            ctime_ns=0,
+            device=0,
+            inode=0,
+        )
+    return WorktreeStatIdentity(
+        exists=True,
+        mode=metadata.st_mode,
+        size=metadata.st_size,
+        mtime_ns=metadata.st_mtime_ns,
+        ctime_ns=metadata.st_ctime_ns,
+        device=metadata.st_dev,
+        inode=metadata.st_ino,
+    )
+
+
+@contextmanager
+def acquire_live_change_count_plan() -> Iterator[LiveChangeCountPlan]:
+    """Build one artifact plan whose workspace outlives execution/reduction."""
+    with FileJobWorkspace() as workspace:
+        yield _build_live_change_count_plan(workspace)
+
+
+def _build_live_change_count_plan(
+    workspace: FileJobWorkspace,
+) -> LiveChangeCountPlan:
+    repository_root = get_git_repository_root_path().resolve()
+    batch_names = list_batch_names()
+    batch_state_commit_by_name = _batch_state_commit_snapshot(batch_names)
+    batch_metadata_by_name = read_batch_metadata_for_batches(
+        batch_names,
+        batch_state_commit_by_name=batch_state_commit_by_name,
+    )
+    context = LiveChangeScanContext(
+        batch_metadata_by_name=batch_metadata_by_name,
+    )
+    batch_source_by_path = load_session_batch_sources()
+    consumed_metadata_by_path = load_consumed_selections_metadata()["files"]
+    head_commit = current_head_commit()
+
+    jobs: list[OrderedFileJob[LiveTextFileJob]] = []
+    atomic_count = 0
+    active_group: _LiveTextFileGroup | None = None
+    try:
+        with acquire_unified_diff(
+            stream_live_git_diff(
+                context_lines=get_context_lines(),
+                full_index=True,
+                ignore_submodules="none",
+                submodule_format="short",
+            )
+        ) as patches:
+            for ordinal, item in enumerate(patches):
+                if isinstance(item, SingleHunkPatch):
+                    grouping_key = (
+                        item.path(),
+                        item.old_path,
+                        item.new_path,
+                    )
+                    if (
+                        active_group is not None
+                        and active_group.grouping_key != grouping_key
+                    ):
+                        jobs.append(active_group.finish())
+                        active_group = None
+
+                    stable_hash = compute_stable_hunk_hash_from_lines(
+                        item.lines
+                    )
+                    if (
+                        text_hunk_block_reason(
+                            item,
+                            stable_hash,
+                            context,
+                        )
+                        is not None
+                    ):
+                        continue
+
+                    if active_group is None:
+                        file_path = item.path()
+                        file_batch_metadata = _file_batch_metadata(
+                            context.metadata_for_path(file_path),
+                            file_path,
+                        )
+                        active_group = _LiveTextFileGroup(
+                            workspace=workspace,
+                            ordinal=ordinal,
+                            file_path=file_path,
+                            old_path=item.old_path,
+                            new_path=item.new_path,
+                            repository_root=repository_root,
+                            head_commit=head_commit,
+                            batch_source_commit=batch_source_by_path.get(
+                                file_path
+                            ),
+                            batch_metadata_by_name=file_batch_metadata,
+                            consumed_file_metadata=consumed_metadata_by_path.get(
+                                file_path
+                            ),
+                            batch_state_commit_by_name={
+                                batch_name: batch_state_commit_by_name[
+                                    batch_name
+                                ]
+                                for batch_name in file_batch_metadata
+                                if batch_name in batch_state_commit_by_name
+                            },
+                        )
+                    active_group.append_hunk(
+                        ordinal,
+                        item,
+                        stable_hash=stable_hash,
+                    )
+                    continue
+
+                if active_group is not None:
+                    jobs.append(active_group.finish())
+                    active_group = None
+
+                candidate, _reason = prepare_atomic_live_change(item, context)
+                if candidate is not None:
+                    with candidate:
+                        atomic_count += 1
+
+            if active_group is not None:
+                jobs.append(active_group.finish())
+                active_group = None
+    finally:
+        if active_group is not None:
+            active_group.abort()
+
+    return LiveChangeCountPlan(
+        jobs=tuple(jobs),
+        atomic_count=atomic_count,
+        repository_root=repository_root,
+    )
+
+
+class _LiveTextFileGroup:
+    """Stream artifacts for one contiguous repository text-file group."""
+
+    def __init__(
+        self,
+        *,
+        workspace: FileJobWorkspace,
+        ordinal: int,
+        file_path: str,
+        old_path: str,
+        new_path: str,
+        repository_root: Path,
+        head_commit: str | None,
+        batch_source_commit: str | None,
+        batch_metadata_by_name: dict[str, dict],
+        consumed_file_metadata: dict | None,
+        batch_state_commit_by_name: dict[str, str],
+    ) -> None:
+        self.workspace = workspace
+        self.ordinal = ordinal
+        self.file_path = file_path
+        self.old_path = old_path
+        self.new_path = new_path
+        self.head_commit = head_commit
+        self.batch_source_commit = batch_source_commit
+        self.batch_metadata_by_name = batch_metadata_by_name
+        self.consumed_file_metadata = consumed_file_metadata
+        self.batch_state_commit_by_name = batch_state_commit_by_name
+        self.expected_worktree_identity = capture_worktree_stat_identity(
+            file_path,
+            repository_root=repository_root,
+        )
+        self.hunk_manifest_path = workspace.artifact_path(
+            ordinal,
+            "live-hunks.jsonl",
+        )
+        self._hunk_manifest: TextIO | None = self.hunk_manifest_path.open(
+            "x",
+            encoding="utf-8",
+        )
+        self._patch_artifact_bytes = 0
+
+    @property
+    def grouping_key(self) -> tuple[str, str, str]:
+        """Return the contiguous grouping identity for this file."""
+        return self.file_path, self.old_path, self.new_path
+
+    def append_hunk(
+        self,
+        ordinal: int,
+        item: SingleHunkPatch,
+        *,
+        stable_hash: str,
+    ) -> None:
+        """Stream one parser-owned hunk to an artifact and manifest record."""
+        if self._hunk_manifest is None:
+            raise ValueError("live text file group is closed")
+        if (
+            item.path(),
+            item.old_path,
+            item.new_path,
+        ) != self.grouping_key:
+            raise AssertionError("contiguous text hunk grouping changed paths")
+
+        patch_path = self.workspace.write_buffer(
+            self.ordinal,
+            "live-hunk.patch",
+            item.lines,
+        )
+        self._patch_artifact_bytes += patch_path.stat().st_size
+        record = {
+            "ordinal": ordinal,
+            "old_path": item.old_path,
+            "new_path": item.new_path,
+            "stable_hash": stable_hash,
+            "patch_artifact_path": str(patch_path),
+        }
+        json.dump(
+            record,
+            self._hunk_manifest,
+            ensure_ascii=True,
+            separators=(",", ":"),
+        )
+        self._hunk_manifest.write("\n")
+
+    def finish(self) -> OrderedFileJob[LiveTextFileJob]:
+        """Close manifests and return the compact ordered file job."""
+        self._close_hunk_manifest()
+        scratch_directory = self.workspace.scratch_directory(self.ordinal)
+        input_manifest_path = _write_json_artifact(
+            self.workspace,
+            self.ordinal,
+            "live-input.json",
+            {
+                "file_path": self.file_path,
+                "baseline_path": self.old_path,
+                "head_commit": self.head_commit,
+                "batch_source_commit": self.batch_source_commit,
+                "batch_metadata_by_name": self.batch_metadata_by_name,
+                "consumed_file_metadata": self.consumed_file_metadata,
+                "batch_state_commit_by_name": (
+                    self.batch_state_commit_by_name
+                ),
+                "scratch_directory": str(scratch_directory),
+            },
+        )
+        estimated_bytes = (
+            self.expected_worktree_identity.size
+            + self._patch_artifact_bytes
+            + self.hunk_manifest_path.stat().st_size
+            + input_manifest_path.stat().st_size
+        )
+        payload = LiveTextFileJob(
+            ordinal=self.ordinal,
+            file_path=self.file_path,
+            input_manifest_path=str(input_manifest_path),
+            hunk_manifest_path=str(self.hunk_manifest_path),
+            expected_worktree_identity=self.expected_worktree_identity,
+        )
+        return OrderedFileJob(
+            ordinal=self.ordinal,
+            file_path=self.file_path,
+            estimated_bytes=estimated_bytes,
+            payload=payload,
+        )
+
+    def abort(self) -> None:
+        """Close the manifest writer after an interrupted plan build."""
+        self._close_hunk_manifest()
+
+    def _close_hunk_manifest(self) -> None:
+        if self._hunk_manifest is None:
+            return
+        self._hunk_manifest.close()
+        self._hunk_manifest = None
+
+
+def _batch_state_commit_snapshot(
+    batch_names: Iterable[str],
+) -> dict[str, str]:
+    state_ref_by_name = {
+        batch_name: format_batch_state_ref_name(batch_name)
+        for batch_name in batch_names
+    }
+    object_info_by_ref = resolve_git_objects(state_ref_by_name.values())
+    return {
+        batch_name: object_info.object_id
+        for batch_name, state_ref in state_ref_by_name.items()
+        if (object_info := object_info_by_ref.get(state_ref)) is not None
+        and object_info.object_type == "commit"
+    }
+
+
+def _file_batch_metadata(
+    batch_metadata_by_name: Mapping[str, dict],
+    file_path: str,
+) -> dict[str, dict]:
+    return {
+        batch_name: {
+            "files": {
+                file_path: metadata["files"][file_path],
+            },
+        }
+        for batch_name, metadata in batch_metadata_by_name.items()
+    }
+
+
+def _write_json_artifact(
+    workspace: FileJobWorkspace,
+    ordinal: int,
+    name: str,
+    value: Any,
+) -> Path:
+    path = workspace.artifact_path(ordinal, name)
+    with path.open("x", encoding="utf-8") as output:
+        json.dump(
+            value,
+            output,
+            ensure_ascii=True,
+            separators=(",", ":"),
+        )
+        output.write("\n")
+    return path

--- a/src/git_stage_batch/data/live_change_jobs.py
+++ b/src/git_stage_batch/data/live_change_jobs.py
@@ -1,25 +1,42 @@
-"""Artifact-backed per-file planning for remaining live text changes."""
+"""Artifact-backed per-file counting for remaining live text changes."""
 
 from __future__ import annotations
 
 from collections.abc import Iterable, Iterator, Mapping
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
 import json
 from pathlib import Path
 from typing import Any, TextIO
 
+from ..batch.attribution import (
+    AttributionMetrics,
+    build_file_attribution_from_lines,
+)
+from ..batch.source.annotation import (
+    acquire_batch_source_mapping,
+    annotate_with_batch_source_mapping,
+)
 from ..batch.source.cache import load_session_batch_sources
 from ..batch.state.query import list_batch_names, read_batch_metadata_for_batches
 from ..batch.state.reference_names import format_batch_state_ref_name
-from ..core.diff_parser import acquire_unified_diff
+from ..core.buffer import LineBuffer
+from ..core.diff_parser import (
+    acquire_unified_diff,
+    build_line_changes_from_patch_lines,
+)
 from ..core.hashing import compute_stable_hunk_hash_from_lines
 from ..core.models import SingleHunkPatch
+from ..core.text_lifecycle import TextFileChangeType
 from ..utils.file_job_workspace import FileJobWorkspace
 from ..utils.file_jobs import OrderedFileJob
 from ..utils.git_object_io import resolve_git_objects
 from ..utils.git_repository import get_git_repository_root_path
 from ..utils.paths import get_context_lines
+from ..utils.repository_buffers import (
+    load_working_tree_file_as_buffer,
+    read_git_object_buffer_or_none,
+)
 from ..utils.session_start_point import current_head_commit
 from .consumed_selections import load_consumed_selections_metadata
 from .live_change_candidates import (
@@ -28,6 +45,11 @@ from .live_change_candidates import (
     text_hunk_block_reason,
 )
 from .live_diff import stream_live_git_diff
+from .selected_change.hunk_filtering import (
+    consumed_batch_metadata,
+    filter_line_level_change_with_attribution,
+)
+
 
 @dataclass(frozen=True, slots=True)
 class WorktreeStatIdentity:
@@ -43,6 +65,39 @@ class WorktreeStatIdentity:
 
 
 @dataclass(frozen=True, slots=True)
+class AttributionMetricsSnapshot:
+    """Scalar attribution metrics safe to return through file-job transport."""
+
+    candidate_batches: int = 0
+    claimed_batches: int = 0
+    object_resolution_requests: int = 0
+    object_requests: int = 0
+    object_bytes: int = 0
+    unique_source_contents: int = 0
+    mapping_computations: int = 0
+    deletion_fingerprints: int = 0
+    attributed_units: int = 0
+
+    @classmethod
+    def from_metrics(
+        cls,
+        metrics: AttributionMetrics,
+    ) -> AttributionMetricsSnapshot:
+        """Freeze one mutable metrics accumulator."""
+        return cls(
+            candidate_batches=metrics.candidate_batches,
+            claimed_batches=metrics.claimed_batches,
+            object_resolution_requests=metrics.object_resolution_requests,
+            object_requests=metrics.object_requests,
+            object_bytes=metrics.object_bytes,
+            unique_source_contents=metrics.unique_source_contents,
+            mapping_computations=metrics.mapping_computations,
+            deletion_fingerprints=metrics.deletion_fingerprints,
+            attributed_units=metrics.attributed_units,
+        )
+
+
+@dataclass(frozen=True, slots=True)
 class LiveTextFileJob:
     """Compact transport record for one contiguous live text file group."""
 
@@ -51,6 +106,18 @@ class LiveTextFileJob:
     input_manifest_path: str
     hunk_manifest_path: str
     expected_worktree_identity: WorktreeStatIdentity
+
+
+@dataclass(frozen=True, slots=True)
+class LiveTextFileCountResult:
+    """Scalar remaining-change counts for one live text file group."""
+
+    ordinal: int
+    file_path: str
+    eligible_count: int
+    already_batched_count: int
+    attribution_metrics: AttributionMetricsSnapshot
+    stale: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -97,6 +164,126 @@ def acquire_live_change_count_plan() -> Iterator[LiveChangeCountPlan]:
     """Build one artifact plan whose workspace outlives execution/reduction."""
     with FileJobWorkspace() as workspace:
         yield _build_live_change_count_plan(workspace)
+
+
+def count_eligible_live_text_file(
+    job: LiveTextFileJob,
+) -> LiveTextFileCountResult:
+    """Count eligible hunks using one prepared attribution pass for a file."""
+    input_manifest = _read_json_manifest(job.input_manifest_path)
+    initial_identity = capture_worktree_stat_identity(job.file_path)
+    metrics = AttributionMetrics()
+    if initial_identity != job.expected_worktree_identity:
+        return _stale_result(job, metrics)
+
+    try:
+        with ExitStack() as stack:
+            spool_dir = Path(input_manifest["scratch_directory"])
+            working_tree_lines = stack.enter_context(
+                load_working_tree_file_as_buffer(
+                    job.file_path,
+                    spool_dir=spool_dir,
+                )
+            )
+            baseline_lines, baseline_exists = _acquire_baseline_lines(
+                input_manifest,
+                spool_dir=spool_dir,
+            )
+            baseline_lines = stack.enter_context(baseline_lines)
+            annotation_mapping = stack.enter_context(
+                acquire_batch_source_mapping(
+                    job.file_path,
+                    batch_source_commit=input_manifest.get(
+                        "batch_source_commit"
+                    ),
+                    working_lines=working_tree_lines,
+                    spool_dir=spool_dir,
+                )
+            )
+            batch_metadata_by_name = input_manifest["batch_metadata_by_name"]
+            consumed_file_metadata = input_manifest.get(
+                "consumed_file_metadata"
+            )
+            attribution = build_file_attribution_from_lines(
+                job.file_path,
+                baseline_lines=baseline_lines,
+                working_tree_lines=working_tree_lines,
+                batch_metadata_by_name=batch_metadata_by_name,
+                supplemental_batch_metadata=consumed_batch_metadata(
+                    job.file_path,
+                    consumed_file_metadata,
+                ),
+                batch_state_commit_by_name=input_manifest[
+                    "batch_state_commit_by_name"
+                ],
+                spool_dir=spool_dir,
+                metrics=metrics,
+            )
+            empty_lifecycle_change_type = _empty_lifecycle_change_type(
+                baseline_exists=baseline_exists,
+                baseline_lines=baseline_lines,
+                working_exists=initial_identity.exists,
+                working_tree_lines=working_tree_lines,
+            )
+            captured_empty_lifecycle_is_batched = (
+                _captured_empty_lifecycle_is_batched(
+                    job.file_path,
+                    change_type=empty_lifecycle_change_type,
+                    batch_metadata_by_name=batch_metadata_by_name,
+                )
+            )
+
+            eligible_count = 0
+            already_batched_count = 0
+            for hunk_record in _stream_hunk_manifest(job.hunk_manifest_path):
+                with LineBuffer.from_path(
+                    hunk_record["patch_artifact_path"],
+                    spool_dir=spool_dir,
+                ) as patch_lines:
+                    line_changes = build_line_changes_from_patch_lines(
+                        patch_lines,
+                        annotator=None,
+                    )
+                annotated_changes = annotate_with_batch_source_mapping(
+                    line_changes,
+                    annotation_mapping,
+                )
+                filtered_changes = filter_line_level_change_with_attribution(
+                    annotated_changes,
+                    attribution=attribution,
+                    batch_metadata_by_name=batch_metadata_by_name,
+                    consumed_file_metadata=consumed_file_metadata,
+                    captured_empty_lifecycle_is_batched=(
+                        captured_empty_lifecycle_is_batched
+                    ),
+                )
+                if filtered_changes is None:
+                    already_batched_count += 1
+                else:
+                    eligible_count += 1
+                del filtered_changes
+                del annotated_changes
+                del line_changes
+    except Exception:
+        if (
+            capture_worktree_stat_identity(job.file_path)
+            != job.expected_worktree_identity
+        ):
+            return _stale_result(job, metrics)
+        raise
+
+    if (
+        capture_worktree_stat_identity(job.file_path)
+        != job.expected_worktree_identity
+    ):
+        return _stale_result(job, metrics)
+    return LiveTextFileCountResult(
+        ordinal=job.ordinal,
+        file_path=job.file_path,
+        eligible_count=eligible_count,
+        already_batched_count=already_batched_count,
+        attribution_metrics=AttributionMetricsSnapshot.from_metrics(metrics),
+    )
 
 
 def _build_live_change_count_plan(
@@ -381,6 +568,59 @@ def _file_batch_metadata(
     }
 
 
+def _acquire_baseline_lines(
+    input_manifest: Mapping[str, Any],
+    *,
+    spool_dir: Path,
+) -> tuple[LineBuffer, bool]:
+    head_commit = input_manifest.get("head_commit")
+    baseline_path = input_manifest.get("baseline_path")
+    baseline_lines = None
+    if head_commit and baseline_path and baseline_path != "/dev/null":
+        baseline_lines = read_git_object_buffer_or_none(
+            f"{head_commit}:{baseline_path}",
+            spool_dir=spool_dir,
+        )
+    if baseline_lines is None:
+        return LineBuffer.from_bytes(b"", spool_dir=spool_dir), False
+    return baseline_lines, True
+
+
+def _empty_lifecycle_change_type(
+    *,
+    baseline_exists: bool,
+    baseline_lines: LineBuffer,
+    working_exists: bool,
+    working_tree_lines: LineBuffer,
+) -> TextFileChangeType | None:
+    if working_exists and working_tree_lines.byte_count == 0 and not baseline_exists:
+        return TextFileChangeType.ADDED
+    if (
+        not working_exists
+        and baseline_exists
+        and baseline_lines.byte_count == 0
+    ):
+        return TextFileChangeType.DELETED
+    return None
+
+
+def _captured_empty_lifecycle_is_batched(
+    file_path: str,
+    *,
+    change_type: TextFileChangeType | None,
+    batch_metadata_by_name: Mapping[str, dict],
+) -> bool:
+    if change_type is None:
+        return False
+    return any(
+        metadata.get("files", {})
+        .get(file_path, {})
+        .get("change_type")
+        == change_type
+        for metadata in batch_metadata_by_name.values()
+    )
+
+
 def _write_json_artifact(
     workspace: FileJobWorkspace,
     ordinal: int,
@@ -397,3 +637,28 @@ def _write_json_artifact(
         )
         output.write("\n")
     return path
+
+
+def _read_json_manifest(path: str) -> dict[str, Any]:
+    with Path(path).open(encoding="utf-8") as source:
+        return json.load(source)
+
+
+def _stream_hunk_manifest(path: str) -> Iterator[dict[str, Any]]:
+    with Path(path).open(encoding="utf-8") as source:
+        for line in source:
+            yield json.loads(line)
+
+
+def _stale_result(
+    job: LiveTextFileJob,
+    metrics: AttributionMetrics,
+) -> LiveTextFileCountResult:
+    return LiveTextFileCountResult(
+        ordinal=job.ordinal,
+        file_path=job.file_path,
+        eligible_count=0,
+        already_batched_count=0,
+        attribution_metrics=AttributionMetricsSnapshot.from_metrics(metrics),
+        stale=True,
+    )

--- a/src/git_stage_batch/data/remaining_hunks.py
+++ b/src/git_stage_batch/data/remaining_hunks.py
@@ -2,13 +2,50 @@
 
 from __future__ import annotations
 
-from .live_change_candidates import stream_eligible_live_changes
+from dataclasses import asdict
+
+from ..exceptions import CommandError
+from ..i18n import _
+from ..utils.file_jobs import FileJobExecution, run_file_jobs
+from ..utils.journal import log_journal
+from .live_change_jobs import (
+    acquire_live_change_count_plan,
+    count_eligible_live_text_file,
+)
 
 
 def estimate_remaining_hunks() -> int:
     """Estimate the number of live hunks not yet included, skipped, or discarded."""
-    count = 0
-    for candidate in stream_eligible_live_changes():
-        with candidate:
-            count += 1
-    return count
+    with acquire_live_change_count_plan() as plan:
+        execution = FileJobExecution(
+            transport="inline",
+            max_workers=1,
+            reason="remaining status counting is inline",
+        )
+        results = run_file_jobs(
+            plan.jobs,
+            count_eligible_live_text_file,
+            execution=execution,
+            repository_root=plan.repository_root,
+        )
+        stale_result = next(
+            (result for result in results if result.stale),
+            None,
+        )
+        if stale_result is not None:
+            raise CommandError(
+                _(
+                    "Working tree file changed while status was being "
+                    "calculated: {file}. Retry the status command."
+                ).format(file=stale_result.file_path)
+            )
+
+        for result in results:
+            log_journal(
+                "file_attribution_complete",
+                file_path=result.file_path,
+                **asdict(result.attribution_metrics),
+            )
+        return plan.atomic_count + sum(
+            result.eligible_count for result in results
+        )

--- a/tests/architecture/test_seam_rules.py
+++ b/tests/architecture/test_seam_rules.py
@@ -29,7 +29,12 @@ def test_live_change_policy_has_one_owner():
         ForbiddenImportRule(
             "git_stage_batch.data.remaining_hunks",
             "git_stage_batch.core.hashing",
-            "status must count prepared live-change candidates",
+            "status must count canonical file-job results",
+        ),
+        ForbiddenImportRule(
+            "git_stage_batch.data.remaining_hunks",
+            "git_stage_batch.data.live_change_candidates",
+            "status must not fall back to the lazy candidate stream",
         ),
         ForbiddenImportRule(
             "git_stage_batch.commands.selection.next_change_display",
@@ -51,9 +56,10 @@ def test_live_change_policy_has_one_owner():
     }
     assert {
         "git_stage_batch.data.hunk_tracking",
-        "git_stage_batch.data.remaining_hunks",
+        "git_stage_batch.data.live_change_jobs",
         "git_stage_batch.commands.selection.next_change_display",
     } <= consumers
+    assert "git_stage_batch.data.remaining_hunks" not in consumers
 
 
 def test_repository_readers_stay_below_policy_layers():

--- a/tests/data/test_live_change_jobs.py
+++ b/tests/data/test_live_change_jobs.py
@@ -299,3 +299,371 @@ def test_gitlink_change_remains_parent_counted(
     with acquire_live_change_count_plan() as plan:
         assert plan.atomic_count == 1
         assert plan.jobs == ()
+
+
+def test_many_hunks_reuse_one_file_preparation(temp_git_repo, monkeypatch):
+    _write_many_hunk_fixture(temp_git_repo)
+
+    with acquire_live_change_count_plan() as plan:
+        assert len(plan.jobs) == 1
+        calls = {
+            "working_tree": 0,
+            "annotation_mapping": 0,
+            "attribution": 0,
+        }
+        original_working_tree = live_jobs.load_working_tree_file_as_buffer
+        original_mapping = live_jobs.acquire_batch_source_mapping
+        original_attribution = live_jobs.build_file_attribution_from_lines
+
+        def load_working_tree(*args, **kwargs):
+            calls["working_tree"] += 1
+            return original_working_tree(*args, **kwargs)
+
+        @contextmanager
+        def acquire_mapping(*args, **kwargs):
+            calls["annotation_mapping"] += 1
+            with original_mapping(*args, **kwargs) as mapping:
+                yield mapping
+
+        def build_attribution(*args, **kwargs):
+            calls["attribution"] += 1
+            return original_attribution(*args, **kwargs)
+
+        monkeypatch.setattr(
+            live_jobs,
+            "load_working_tree_file_as_buffer",
+            load_working_tree,
+        )
+        monkeypatch.setattr(
+            live_jobs,
+            "acquire_batch_source_mapping",
+            acquire_mapping,
+        )
+        monkeypatch.setattr(
+            live_jobs,
+            "build_file_attribution_from_lines",
+            build_attribution,
+        )
+
+        result = count_eligible_live_text_file(plan.jobs[0].payload)
+
+    assert result.eligible_count == 2
+    assert result.already_batched_count == 0
+    assert calls == {
+        "working_tree": 1,
+        "annotation_mapping": 1,
+        "attribution": 1,
+    }
+
+
+def test_compute_does_not_read_session_metadata(
+    temp_git_repo,
+    monkeypatch,
+):
+    file_path = temp_git_repo / "file.txt"
+    file_path.write_text("old\n")
+    _commit_all(temp_git_repo)
+    file_path.write_text("new\n")
+
+    with acquire_live_change_count_plan() as plan:
+        assert len(plan.jobs) == 1
+
+        def unexpected_read(*_args, **_kwargs):
+            raise AssertionError("unexpected session metadata read")
+
+        monkeypatch.setattr(
+            live_jobs,
+            "load_session_batch_sources",
+            unexpected_read,
+        )
+        monkeypatch.setattr(
+            live_jobs,
+            "load_consumed_selections_metadata",
+            unexpected_read,
+        )
+        monkeypatch.setattr(
+            attribution_module,
+            "list_batch_names",
+            unexpected_read,
+        )
+        monkeypatch.setattr(
+            attribution_module,
+            "read_batch_metadata_for_batches",
+            unexpected_read,
+        )
+        monkeypatch.setattr(
+            annotation_module,
+            "get_batch_source_for_file",
+            unexpected_read,
+        )
+        monkeypatch.setattr(
+            hunk_filtering_module,
+            "read_consumed_file_metadata",
+            unexpected_read,
+        )
+        monkeypatch.setattr(
+            hunk_filtering_module,
+            "log_journal",
+            unexpected_read,
+        )
+
+        result = count_eligible_live_text_file(plan.jobs[0].payload)
+
+    assert result.eligible_count == 1
+    assert result.stale is False
+
+
+def test_empty_lifecycle_filter_uses_captured_metadata(
+    temp_git_repo,
+    monkeypatch,
+):
+    (temp_git_repo / "base.txt").write_text("base\n")
+    _commit_all(temp_git_repo)
+    empty_path = temp_git_repo / "empty.txt"
+    empty_path.write_bytes(b"")
+    _git(temp_git_repo, "add", "-N", "empty.txt")
+
+    with acquire_live_change_count_plan() as plan:
+        assert len(plan.jobs) == 1
+        job = plan.jobs[0].payload
+        input_path = Path(job.input_manifest_path)
+        input_manifest = json.loads(input_path.read_text())
+        input_manifest["batch_metadata_by_name"] = {
+            "empty-batch": {
+                "files": {
+                    "empty.txt": {
+                        "batch_source_commit": input_manifest["head_commit"],
+                        "change_type": "added",
+                    },
+                },
+            },
+        }
+        input_path.write_text(
+            json.dumps(input_manifest, ensure_ascii=True, separators=(",", ":"))
+            + "\n"
+        )
+        monkeypatch.setattr(
+            hunk_filtering_module._change_freshness,
+            "empty_text_lifecycle_change_is_batched",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                AssertionError("unexpected mutable lifecycle read")
+            ),
+        )
+
+        result = count_eligible_live_text_file(job)
+
+    assert result.eligible_count == 0
+    assert result.already_batched_count == 1
+
+
+def test_consumed_replacement_masks_are_loaded_once_and_applied(
+    temp_git_repo,
+):
+    file_path = temp_git_repo / "file.txt"
+    file_path.write_text("old\n")
+    _commit_all(temp_git_repo)
+    head_commit = _git_output(temp_git_repo, "rev-parse", "HEAD")
+    file_path.write_text("new\n")
+
+    consumed_path = get_session_consumed_selections_file_path()
+    consumed_path.parent.mkdir(parents=True, exist_ok=True)
+    consumed_path.write_text(
+        json.dumps({
+            "files": {
+                "file.txt": {
+                    "batch_source_commit": head_commit,
+                    "presence_claims": [],
+                    "deletions": [],
+                    "replacement_masks": [
+                        {
+                            "deleted_lines": ["old"],
+                            "added_lines": ["new"],
+                        },
+                    ],
+                },
+            },
+        })
+    )
+
+    assert _lazy_candidate_count() == 0
+    assert estimate_remaining_hunks() == 0
+    with acquire_live_change_count_plan() as plan:
+        assert len(plan.jobs) == 1
+        result = count_eligible_live_text_file(plan.jobs[0].payload)
+        assert result.eligible_count == 0
+        assert result.already_batched_count == 1
+
+
+def test_parser_buffers_can_close_immediately_after_spooling(
+    temp_git_repo,
+    monkeypatch,
+):
+    for file_name in ("a.txt", "b.txt"):
+        (temp_git_repo / file_name).write_text("old\n")
+    _commit_all(temp_git_repo)
+
+    path_sequence = ("a.txt", "b.txt", "a.txt")
+    parser_buffers = []
+
+    @contextmanager
+    def acquire_fake_diff(_lines):
+        def changes():
+            for path in path_sequence:
+                buffer = LineBuffer.from_chunks(
+                    (
+                        f"--- a/{path}\n".encode(),
+                        f"+++ b/{path}\n".encode(),
+                        b"@@ -1 +1 @@\n",
+                        b"-old\n",
+                        b"+new\n",
+                    )
+                )
+                parser_buffers.append(buffer)
+                try:
+                    yield SingleHunkPatch(path, path, buffer)
+                finally:
+                    buffer.close()
+
+        try:
+            yield changes()
+        finally:
+            for buffer in parser_buffers:
+                buffer.close()
+
+    monkeypatch.setattr(live_jobs, "acquire_unified_diff", acquire_fake_diff)
+    monkeypatch.setattr(live_jobs, "stream_live_git_diff", lambda **_kwargs: ())
+
+    with acquire_live_change_count_plan() as plan:
+        assert [job.file_path for job in plan.jobs] == list(path_sequence)
+        patch_paths = []
+        for job in plan.jobs:
+            records = [
+                json.loads(line)
+                for line in Path(
+                    job.payload.hunk_manifest_path
+                ).read_text().splitlines()
+            ]
+            assert len(records) == 1
+            patch_paths.append(Path(records[0]["patch_artifact_path"]))
+        assert all(path.read_bytes().endswith(b"+new\n") for path in patch_paths)
+
+    for buffer in parser_buffers:
+        with pytest.raises(ValueError, match="closed"):
+            next(buffer.byte_chunks())
+
+
+def test_job_and_result_transport_stay_content_independent(temp_git_repo):
+    file_path = temp_git_repo / "file.txt"
+    file_path.write_text("old\n")
+    _commit_all(temp_git_repo)
+    file_path.write_text("new\n")
+
+    with acquire_live_change_count_plan() as plan:
+        job = plan.jobs[0].payload
+        serialized_job = pickle.dumps(job)
+        hunk_records = [
+            json.loads(line)
+            for line in Path(job.hunk_manifest_path).read_text().splitlines()
+        ]
+        patch_path = Path(hunk_records[0]["patch_artifact_path"])
+        patch_path.write_bytes(b"x" * (2 * 1024 * 1024))
+
+        assert pickle.dumps(job) == serialized_job
+        assert len(serialized_job) < 1024
+        assert b"x" * 100 not in serialized_job
+        assert_file_job_transport_value(job)
+
+    result = LiveTextFileCountResult(
+        ordinal=0,
+        file_path="file.txt",
+        eligible_count=1,
+        already_batched_count=0,
+        attribution_metrics=AttributionMetricsSnapshot(),
+    )
+    assert len(pickle.dumps(result)) < 1024
+    assert_file_job_transport_value(result)
+
+
+def test_builder_loads_shared_snapshots_once(
+    temp_git_repo,
+    monkeypatch,
+):
+    for file_name in ("a.txt", "b.txt"):
+        (temp_git_repo / file_name).write_text("old\n")
+    _commit_all(temp_git_repo)
+    for file_name in ("a.txt", "b.txt"):
+        (temp_git_repo / file_name).write_text("new\n")
+
+    calls = {
+        "batch_names": 0,
+        "batch_metadata": 0,
+        "batch_sources": 0,
+        "consumed": 0,
+        "head": 0,
+        "state_commits": 0,
+    }
+    original_list_batch_names = live_jobs.list_batch_names
+    original_batch_metadata = live_jobs.read_batch_metadata_for_batches
+    original_batch_sources = live_jobs.load_session_batch_sources
+    original_consumed = live_jobs.load_consumed_selections_metadata
+    original_head = live_jobs.current_head_commit
+    original_resolve = live_jobs.resolve_git_objects
+
+    def list_batch_names():
+        calls["batch_names"] += 1
+        return original_list_batch_names()
+
+    def read_batch_metadata(batch_names, **kwargs):
+        calls["batch_metadata"] += 1
+        return original_batch_metadata(batch_names, **kwargs)
+
+    def load_batch_sources():
+        calls["batch_sources"] += 1
+        return original_batch_sources()
+
+    def load_consumed():
+        calls["consumed"] += 1
+        return original_consumed()
+
+    def read_head():
+        calls["head"] += 1
+        return original_head()
+
+    def resolve_state_commits(object_names):
+        calls["state_commits"] += 1
+        return original_resolve(object_names)
+
+    monkeypatch.setattr(live_jobs, "list_batch_names", list_batch_names)
+    monkeypatch.setattr(
+        live_jobs,
+        "read_batch_metadata_for_batches",
+        read_batch_metadata,
+    )
+    monkeypatch.setattr(
+        live_jobs,
+        "load_session_batch_sources",
+        load_batch_sources,
+    )
+    monkeypatch.setattr(
+        live_jobs,
+        "load_consumed_selections_metadata",
+        load_consumed,
+    )
+    monkeypatch.setattr(live_jobs, "current_head_commit", read_head)
+    monkeypatch.setattr(
+        live_jobs,
+        "resolve_git_objects",
+        resolve_state_commits,
+    )
+
+    with acquire_live_change_count_plan() as plan:
+        assert len(plan.jobs) == 2
+
+    assert calls == {
+        "batch_names": 1,
+        "batch_metadata": 1,
+        "batch_sources": 1,
+        "consumed": 1,
+        "head": 1,
+        "state_commits": 1,
+    }

--- a/tests/data/test_live_change_jobs.py
+++ b/tests/data/test_live_change_jobs.py
@@ -1,0 +1,301 @@
+"""Tests for artifact-backed remaining live-change counting."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+import json
+import os
+import pickle
+from pathlib import Path
+import subprocess
+import sys
+import time
+
+import pytest
+
+import git_stage_batch.batch.attribution as attribution_module
+import git_stage_batch.batch.source.annotation as annotation_module
+import git_stage_batch.data.live_change_jobs as live_jobs
+import git_stage_batch.data.remaining_hunks as remaining_hunks_module
+import git_stage_batch.data.selected_change.hunk_filtering as hunk_filtering_module
+from git_stage_batch.core.buffer import LineBuffer
+from git_stage_batch.core.hashing import compute_stable_hunk_hash_from_lines
+from git_stage_batch.core.models import SingleHunkPatch
+from git_stage_batch.data.live_change_candidates import (
+    stream_eligible_live_changes,
+)
+from git_stage_batch.data.live_change_jobs import (
+    AttributionMetricsSnapshot,
+    LiveTextFileCountResult,
+    acquire_live_change_count_plan,
+    count_eligible_live_text_file,
+)
+from git_stage_batch.data.remaining_hunks import estimate_remaining_hunks
+from git_stage_batch.exceptions import CommandError
+from git_stage_batch.utils.file_io import (
+    append_file_path_to_file,
+    append_lines_to_file,
+)
+from git_stage_batch.utils.file_jobs import (
+    assert_file_job_transport_value,
+)
+from git_stage_batch.utils.paths import (
+    ensure_state_directory_exists,
+    get_block_list_file_path,
+    get_blocked_files_file_path,
+    get_session_consumed_selections_file_path,
+)
+from tests.diff_parser_helpers import collect_unified_diff
+
+
+_RUNNING_UNDER_XDIST = "PYTEST_XDIST_WORKER" in os.environ
+_REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPOSITORY_ROOT))
+_PROCESS_TEST = pytest.mark.skipif(
+    sys.platform != "linux" or _RUNNING_UNDER_XDIST,
+    reason="forced forkserver coverage runs on Linux with pytest -n 0",
+)
+
+
+@pytest.fixture
+def temp_git_repo(tmp_path, monkeypatch):
+    """Create a repository with initialized private state paths."""
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    monkeypatch.chdir(repository)
+    _git(repository, "init")
+    _git(repository, "config", "user.name", "Test User")
+    _git(repository, "config", "user.email", "test@example.com")
+    ensure_state_directory_exists()
+    return repository
+
+
+def _git(repository: Path, *arguments: str) -> None:
+    subprocess.run(
+        ["git", *arguments],
+        cwd=repository,
+        check=True,
+        capture_output=True,
+    )
+
+
+def _git_output(repository: Path, *arguments: str) -> str:
+    return subprocess.run(
+        ["git", *arguments],
+        cwd=repository,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _commit_all(repository: Path, message: str = "base") -> None:
+    _git(repository, "add", ".")
+    _git(repository, "commit", "-m", message)
+
+
+def _lazy_candidate_count() -> int:
+    count = 0
+    for candidate in stream_eligible_live_changes():
+        with candidate:
+            count += 1
+    return count
+
+
+def _write_many_hunk_fixture(repository: Path, file_name: str = "many.txt") -> None:
+    file_path = repository / file_name
+    original = [f"line {number}\n" for number in range(1, 101)]
+    file_path.write_text("".join(original))
+    _commit_all(repository)
+    changed = original[:]
+    changed[1] = "first changed\n"
+    changed[80] = "second changed\n"
+    file_path.write_text("".join(changed))
+
+
+def _count_with_reverse_completion_marker(
+    job,
+) -> LiveTextFileCountResult:
+    result = count_eligible_live_text_file(job)
+    time.sleep(max(0, 3 - job.ordinal) * 0.15)
+    input_manifest = json.loads(Path(job.input_manifest_path).read_text())
+    Path(input_manifest["scratch_directory"], "completion.marker").write_text(
+        str(time.monotonic_ns())
+    )
+    return result
+
+
+def test_text_byte_edges_match_lazy_count_and_group_by_file(temp_git_repo):
+    many_path = temp_git_repo / "many.txt"
+    many_lines = [f"line {number}\n" for number in range(1, 101)]
+    many_path.write_text("".join(many_lines))
+    (temp_git_repo / "crlf.txt").write_bytes(b"alpha\r\nbeta\r\n")
+    (temp_git_repo / "no-final-newline.txt").write_bytes(b"old")
+    (temp_git_repo / "unicode.txt").write_bytes("café\nold\n".encode())
+    _commit_all(temp_git_repo)
+
+    many_lines[1] = "first changed\n"
+    many_lines[80] = "second changed\n"
+    many_path.write_text("".join(many_lines))
+    (temp_git_repo / "crlf.txt").write_bytes(b"alpha\r\nchanged\r\n")
+    (temp_git_repo / "no-final-newline.txt").write_bytes(b"new")
+    (temp_git_repo / "unicode.txt").write_bytes("café\n新しい\n".encode())
+
+    assert _lazy_candidate_count() == 5
+    assert estimate_remaining_hunks() == 5
+
+    with acquire_live_change_count_plan() as plan:
+        assert plan.atomic_count == 0
+        jobs_by_path = {job.file_path: job for job in plan.jobs}
+        assert set(jobs_by_path) == {
+            "crlf.txt",
+            "many.txt",
+            "no-final-newline.txt",
+            "unicode.txt",
+        }
+        many_records = [
+            json.loads(line)
+            for line in Path(
+                jobs_by_path["many.txt"].payload.hunk_manifest_path
+            ).read_text().splitlines()
+        ]
+        assert len(many_records) == 2
+        job_artifact_directory = Path(
+            jobs_by_path["many.txt"].payload.input_manifest_path
+        ).parent
+        assert {
+            Path(record["patch_artifact_path"]).parent
+            for record in many_records
+        } == {job_artifact_directory}
+
+
+def test_no_changes_builds_an_empty_plan(temp_git_repo):
+    (temp_git_repo / "file.txt").write_text("unchanged\n")
+    _commit_all(temp_git_repo)
+
+    assert _lazy_candidate_count() == 0
+    assert estimate_remaining_hunks() == 0
+    with acquire_live_change_count_plan() as plan:
+        assert plan.atomic_count == 0
+        assert plan.jobs == ()
+
+
+def test_blocked_hashes_and_paths_match_lazy_count(temp_git_repo):
+    for file_name in ("a.txt", "b.txt"):
+        (temp_git_repo / file_name).write_text("old\n")
+    _commit_all(temp_git_repo)
+    for file_name in ("a.txt", "b.txt"):
+        (temp_git_repo / file_name).write_text("new\n")
+
+    diff = subprocess.run(
+        ["git", "diff", "--no-color"],
+        cwd=temp_git_repo,
+        check=True,
+        capture_output=True,
+    ).stdout
+    patches = list(collect_unified_diff(diff.splitlines(keepends=True)))
+    first_hash = compute_stable_hunk_hash_from_lines(patches[0].lines)
+    append_lines_to_file(get_block_list_file_path(), [first_hash])
+
+    assert _lazy_candidate_count() == 1
+    assert estimate_remaining_hunks() == 1
+
+    append_file_path_to_file(get_blocked_files_file_path(), "b.txt")
+    assert _lazy_candidate_count() == 0
+    assert estimate_remaining_hunks() == 0
+
+
+def test_rename_with_text_change_uses_one_atomic_and_one_text_count(
+    temp_git_repo,
+):
+    old_path = temp_git_repo / "old.txt"
+    lines = [f"line {number}\n" for number in range(1, 31)]
+    old_path.write_text("".join(lines))
+    _commit_all(temp_git_repo)
+
+    new_path = temp_git_repo / "new.txt"
+    old_path.rename(new_path)
+    lines[10] = "renamed and changed\n"
+    new_path.write_text("".join(lines))
+    _git(temp_git_repo, "add", "-N", "new.txt")
+
+    assert _lazy_candidate_count() == 2
+    assert estimate_remaining_hunks() == 2
+    with acquire_live_change_count_plan() as plan:
+        assert plan.atomic_count == 1
+        assert [job.file_path for job in plan.jobs] == ["new.txt"]
+        result = count_eligible_live_text_file(plan.jobs[0].payload)
+        assert result.eligible_count == 1
+
+
+def test_atomic_changes_match_lazy_count(temp_git_repo):
+    mode_path = temp_git_repo / "script.sh"
+    mode_path.write_text("#!/bin/sh\nexit 0\n")
+    (temp_git_repo / "deleted.txt").write_text("delete me\n")
+    (temp_git_repo / "asset.bin").write_bytes(b"\x00old")
+    (temp_git_repo / "old.txt").write_text("rename me\n")
+    _commit_all(temp_git_repo)
+
+    mode_path.chmod(0o755)
+    (temp_git_repo / "deleted.txt").unlink()
+    (temp_git_repo / "asset.bin").write_bytes(b"\x00new")
+    (temp_git_repo / "old.txt").rename(temp_git_repo / "new.txt")
+    _git(temp_git_repo, "add", "-N", "new.txt")
+
+    assert _lazy_candidate_count() == 4
+    assert estimate_remaining_hunks() == 4
+    with acquire_live_change_count_plan() as plan:
+        assert plan.atomic_count == 3
+        assert [job.file_path for job in plan.jobs] == ["deleted.txt"]
+
+
+def test_empty_text_deletion_remains_atomic(temp_git_repo):
+    empty_path = temp_git_repo / "empty.txt"
+    empty_path.write_bytes(b"")
+    _commit_all(temp_git_repo)
+    empty_path.unlink()
+
+    assert _lazy_candidate_count() == 1
+    assert estimate_remaining_hunks() == 1
+    with acquire_live_change_count_plan() as plan:
+        assert plan.atomic_count == 1
+        assert plan.jobs == ()
+
+
+def test_gitlink_change_remains_parent_counted(
+    temp_git_repo,
+):
+    submodule_source = temp_git_repo.parent / "submodule-source"
+    submodule_source.mkdir()
+    _git(submodule_source, "init")
+    _git(submodule_source, "config", "user.name", "Test User")
+    _git(submodule_source, "config", "user.email", "test@example.com")
+    (submodule_source / "file.txt").write_text("one\n")
+    _commit_all(submodule_source, "first")
+
+    (temp_git_repo / "README").write_text("main\n")
+    _commit_all(temp_git_repo)
+    _git(
+        temp_git_repo,
+        "-c",
+        "protocol.file.allow=always",
+        "submodule",
+        "add",
+        str(submodule_source),
+        "vendor/submodule",
+    )
+    _git(temp_git_repo, "commit", "-am", "add submodule")
+
+    (submodule_source / "file.txt").write_text("two\n")
+    _commit_all(submodule_source, "second")
+    second_commit = _git_output(submodule_source, "rev-parse", "HEAD")
+    checked_out_submodule = temp_git_repo / "vendor" / "submodule"
+    _git(checked_out_submodule, "fetch")
+    _git(checked_out_submodule, "checkout", second_commit)
+
+    assert _lazy_candidate_count() == 1
+    assert estimate_remaining_hunks() == 1
+    with acquire_live_change_count_plan() as plan:
+        assert plan.atomic_count == 1
+        assert plan.jobs == ()

--- a/tests/data/test_live_change_jobs.py
+++ b/tests/data/test_live_change_jobs.py
@@ -494,6 +494,33 @@ def test_consumed_replacement_masks_are_loaded_once_and_applied(
         assert result.already_batched_count == 1
 
 
+def test_worktree_change_returns_stale_and_status_requests_retry(
+    temp_git_repo,
+    monkeypatch,
+):
+    file_path = temp_git_repo / "file.txt"
+    file_path.write_text("old\n")
+    _commit_all(temp_git_repo)
+    file_path.write_text("new\n")
+
+    with acquire_live_change_count_plan() as plan:
+        assert len(plan.jobs) == 1
+        file_path.write_text("changed after planning\n")
+        direct_result = count_eligible_live_text_file(plan.jobs[0].payload)
+        assert direct_result.stale is True
+
+        @contextmanager
+        def acquire_existing_plan():
+            yield plan
+
+        monkeypatch.setattr(
+            remaining_hunks_module,
+            "acquire_live_change_count_plan",
+            acquire_existing_plan,
+        )
+        with pytest.raises(CommandError, match="Retry the status command"):
+            estimate_remaining_hunks()
+
 def test_parser_buffers_can_close_immediately_after_spooling(
     temp_git_repo,
     monkeypatch,


### PR DESCRIPTION
Remaining-status calculation currently prepares and counts live candidates through a command-specific stream, without a canonical per-file request that can be executed or inspected independently.

Enabling process transport directly on that path would create a second business pipeline and make parity, captured-state isolation, and transport size difficult to prove. The first adopter needs to use one job definition while preserving the existing ordered count behavior.

This pull request captures immutable per-file count jobs, computes eligible text counts from path-backed artifacts, and reduces compact count results in file order. Status now uses that canonical job path while retaining conservative inline execution.

Coverage verifies count and plan parity, one-time preparation reuse, captured metadata isolation, artifact lifetimes, compact records, and command-level behavior. With the canonical adopter in place, automatic process selection can be evaluated separately.
