### PR TITLE
apply: Plan text files through ordered jobs

### DIFF
--- a/src/git_stage_batch/batch/merge/candidate_enumeration.py
+++ b/src/git_stage_batch/batch/merge/candidate_enumeration.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from .absence_constraints import (
@@ -48,9 +49,14 @@ def _replacement_origin_candidate_set(
     *,
     resolution_is_valid: _MergeResolutionValidator,
     max_candidates: int,
+    spool_dir: str | Path | None,
 ) -> _MergeCandidateSet:
     """Enumerate reviewed placements for one unresolved split replacement."""
-    owned_mapping = match_lines(source_lines, working_lines)
+    owned_mapping = match_lines(
+        source_lines,
+        working_lines,
+        spool_dir=spool_dir,
+    )
     try:
         selected_presence = coerce_line_ranges(presence_line_set)
         unresolved: list[
@@ -172,8 +178,13 @@ def _presence_candidate_set(
     *,
     resolution_is_valid: _MergeResolutionValidator,
     max_candidates: int,
+    spool_dir: str | Path | None,
 ) -> _MergeCandidateSet:
-    presence_mapping = match_lines(source_lines, working_lines)
+    presence_mapping = match_lines(
+        source_lines,
+        working_lines,
+        spool_dir=spool_dir,
+    )
     try:
         presence_key, presence_choices = (
             _presence_placement_choices.presence_choices_for_missing_claimed_run(
@@ -257,6 +268,7 @@ def _absence_candidate_set(
     *,
     resolution_is_valid: _MergeResolutionValidator,
     max_candidates: int,
+    spool_dir: str | Path | None,
 ) -> _MergeCandidateSet:
     if not deletion_claims:
         return _MergeCandidateSet(())
@@ -264,7 +276,11 @@ def _absence_candidate_set(
     if len([claim for claim in deletion_claims if claim.content_lines]) != 1:
         raise _MergeError(_("Batch was created from a different version of the file"))
 
-    owned_mapping = match_lines(source_lines, working_lines)
+    owned_mapping = match_lines(
+        source_lines,
+        working_lines,
+        spool_dir=spool_dir,
+    )
     try:
         _check_merge_structural_validity(
             owned_mapping,
@@ -273,11 +289,16 @@ def _absence_candidate_set(
             source_lines,
             working_lines,
         )
+        presence_arguments = {
+            "source_to_working_mapping": owned_mapping,
+        }
+        if spool_dir is not None:
+            presence_arguments["spool_dir"] = spool_dir
         realized_entries = _presence_constraints.apply_presence_constraints(
             source_lines,
             working_lines,
             presence_line_set,
-            source_to_working_mapping=owned_mapping,
+            **presence_arguments,
         )
     finally:
         owned_mapping.close()
@@ -372,6 +393,7 @@ def enumerate_merge_batch_candidates_for_lines(
     *,
     resolution_is_valid: _MergeResolutionValidator,
     max_candidates: int,
+    spool_dir: str | Path | None = None,
 ) -> _MergeCandidateSet:
     """Enumerate merge candidates for acquired normalized line sequences."""
     resolved = ownership.resolve()
@@ -386,6 +408,7 @@ def enumerate_merge_batch_candidates_for_lines(
         deletion_claims,
         resolution_is_valid=resolution_is_valid,
         max_candidates=max_candidates,
+        spool_dir=spool_dir,
     )
     if replacement_candidates.candidates:
         return replacement_candidates
@@ -397,6 +420,7 @@ def enumerate_merge_batch_candidates_for_lines(
         deletion_claims,
         resolution_is_valid=resolution_is_valid,
         max_candidates=max_candidates,
+        spool_dir=spool_dir,
     )
     if presence_candidates.candidates:
         return presence_candidates
@@ -409,4 +433,5 @@ def enumerate_merge_batch_candidates_for_lines(
         deletion_claims,
         resolution_is_valid=resolution_is_valid,
         max_candidates=max_candidates,
+        spool_dir=spool_dir,
     )

--- a/src/git_stage_batch/batch/merge/merge.py
+++ b/src/git_stage_batch/batch/merge/merge.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Iterator, Sequence
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from . import baseline_edits as _baseline_edits
@@ -64,6 +65,7 @@ def merge_batch_from_line_sequences_as_buffer(
     *,
     source_to_working_mapping: LineMapping | None = None,
     resolution: _MergeResolution | None = None,
+    spool_dir: str | Path | None = None,
 ) -> LineBuffer:
     """Merge line sequences and return a buffer with destination line endings."""
     result_line_ending = _merge_result_line_ending_from_lines(
@@ -81,10 +83,12 @@ def merge_batch_from_line_sequences_as_buffer(
                     normalized_working_lines,
                     source_to_working_mapping=source_to_working_mapping,
                     resolution=resolution,
+                    spool_dir=spool_dir,
                 )
             ),
             result_line_ending,
-        )
+        ),
+        spool_dir=spool_dir,
     )
 
 
@@ -120,6 +124,7 @@ def _merge_batch_line_chunks(
     *,
     source_to_working_mapping: LineMapping | None = None,
     resolution: _MergeResolution | None = None,
+    spool_dir: str | Path | None = None,
 ) -> Iterator[bytes]:
     """Merge normalized byte-line sequences and yield normalized chunks."""
     with (
@@ -132,6 +137,7 @@ def _merge_batch_line_chunks(
             acquired_working_lines,
             source_to_working_mapping=source_to_working_mapping,
             resolution=resolution,
+            spool_dir=spool_dir,
         )
 
 
@@ -142,6 +148,7 @@ def _merge_batch_acquired_line_chunks(
     *,
     source_to_working_mapping: LineMapping | None = None,
     resolution: _MergeResolution | None = None,
+    spool_dir: str | Path | None = None,
 ) -> Iterator[bytes]:
     """Merge acquired normalized line sequences and yield normalized chunks."""
     resolved = ownership.resolve()
@@ -164,7 +171,11 @@ def _merge_batch_acquired_line_chunks(
     owned_mapping: LineMapping | None = None
     mapping = source_to_working_mapping
     if mapping is None:
-        owned_mapping = match_lines(source_lines, working_lines)
+        owned_mapping = match_lines(
+            source_lines,
+            working_lines,
+            spool_dir=spool_dir,
+        )
         mapping = owned_mapping
     try:
         if _baseline_edits.has_missing_origin_replacement_claims(
@@ -188,13 +199,18 @@ def _merge_batch_acquired_line_chunks(
             if resolution is None:
                 raise
 
+        constraint_arguments = {
+            "source_to_working_mapping": mapping,
+            "resolution": resolution,
+        }
+        if spool_dir is not None:
+            constraint_arguments["spool_dir"] = spool_dir
         realized_entries = _presence_constraints.satisfy_constraints(
             source_lines,
             working_lines,
             presence_line_set,
             deletion_claims,
-            source_to_working_mapping=mapping,
-            resolution=resolution,
+            **constraint_arguments,
         )
     except _MergeError:
         fallback_chunks = _baseline_edits.try_apply_baseline_replacement_units(
@@ -226,6 +242,7 @@ def enumerate_merge_batch_candidates_from_line_sequences(
     working_lines: Sequence[bytes],
     *,
     max_candidates: int = _MERGE_CANDIDATE_CAP,
+    spool_dir: str | Path | None = None,
 ) -> _MergeCandidateSet:
     """Enumerate safe merge candidates for an otherwise-refused merge.
 
@@ -244,6 +261,7 @@ def enumerate_merge_batch_candidates_from_line_sequences(
                 acquired_source_lines,
                 ownership,
                 acquired_working_lines,
+                spool_dir=spool_dir,
             ):
                 pass
             return _MergeCandidateSet(())
@@ -257,6 +275,7 @@ def enumerate_merge_batch_candidates_from_line_sequences(
                     ownership,
                     acquired_working_lines,
                     resolution=candidate_resolution,
+                    spool_dir=spool_dir,
                 ):
                     pass
             except _MergeError:
@@ -269,4 +288,5 @@ def enumerate_merge_batch_candidates_from_line_sequences(
             acquired_working_lines,
             resolution_is_valid=resolution_is_valid,
             max_candidates=max_candidates,
+            spool_dir=spool_dir,
         )

--- a/src/git_stage_batch/batch/merge/presence_constraints.py
+++ b/src/git_stage_batch/batch/merge/presence_constraints.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Collection, Sequence
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from .absence_constraints import (
@@ -46,6 +47,7 @@ def apply_presence_constraints(
     source_to_working_mapping: LineMapping | None = None,
     resolution: _MergeResolution | None = None,
     trusted_source_lines: Collection[int] = (),
+    spool_dir: str | Path | None = None,
 ) -> RealizedEntries:
     """Apply presence constraints: ensure all claimed lines exist in result.
 
@@ -64,7 +66,11 @@ def apply_presence_constraints(
     owned_mapping: LineMapping | None = None
     mapping = source_to_working_mapping
     if mapping is None:
-        owned_mapping = match_lines(source_lines, working_lines)
+        owned_mapping = match_lines(
+            source_lines,
+            working_lines,
+            spool_dir=spool_dir,
+        )
         mapping = owned_mapping
 
     try:
@@ -75,6 +81,7 @@ def apply_presence_constraints(
             mapping,
             resolution=resolution,
             trusted_source_lines=trusted_source_lines,
+            spool_dir=spool_dir,
         )
     finally:
         if owned_mapping is not None:
@@ -89,11 +96,12 @@ def _apply_presence_constraints_with_mapping(
     *,
     resolution: _MergeResolution | None = None,
     trusted_source_lines: Collection[int] = (),
+    spool_dir: str | Path | None = None,
 ) -> RealizedEntries:
     """Apply presence constraints using an existing source-to-working mapping."""
 
     if not presence_line_set:
-        result = RealizedEntries()
+        result = RealizedEntries(spool_dir=spool_dir)
         _realized_mapping.append_working_range_with_mapping(
             result,
             working_lines,
@@ -111,7 +119,7 @@ def _apply_presence_constraints_with_mapping(
     )
 
     if not missing_claimed:
-        result = RealizedEntries()
+        result = RealizedEntries(spool_dir=spool_dir)
         _realized_mapping.append_working_range_with_mapping(
             result,
             working_lines,
@@ -137,7 +145,7 @@ def _apply_presence_constraints_with_mapping(
             selected_choice_index = resolution.decisions[presence_key]
             for choice in presence_choices:
                 if choice.choice_index == selected_choice_index:
-                    result = RealizedEntries()
+                    result = RealizedEntries(spool_dir=spool_dir)
                     _realized_mapping.append_working_range_with_mapping(
                         result,
                         working_lines,
@@ -182,9 +190,10 @@ def _apply_presence_constraints_with_mapping(
                 presence_line_set,
                 mapping,
                 placements,
+                spool_dir=spool_dir,
             )
 
-    result = RealizedEntries()
+    result = RealizedEntries(spool_dir=spool_dir)
     working_idx = 0
 
     for source_line in range(1, len(source_lines) + 1):
@@ -249,9 +258,11 @@ def _realize_contextual_placements(
     presence_line_set: LineSelection,
     mapping: LineMapping,
     placements: Sequence[_PresenceRunPlacement],
+    *,
+    spool_dir: str | Path | None = None,
 ) -> RealizedEntries:
     """Insert missing runs at gaps chosen from distinctive context."""
-    result = RealizedEntries()
+    result = RealizedEntries(spool_dir=spool_dir)
     working_idx = 0
 
     for placement in placements:
@@ -325,6 +336,7 @@ def satisfy_constraints(
     strict: bool = True,
     source_to_working_mapping: LineMapping | None = None,
     resolution: _MergeResolution | None = None,
+    spool_dir: str | Path | None = None,
 ) -> RealizedEntries:
     """Apply presence and absence constraints until claimed lines survive."""
     trusted_source_lines = {
@@ -339,6 +351,7 @@ def satisfy_constraints(
         source_to_working_mapping=source_to_working_mapping,
         resolution=resolution,
         trusted_source_lines=trusted_source_lines,
+        spool_dir=spool_dir,
     )
 
     try:
@@ -364,6 +377,7 @@ def satisfy_constraints(
                 presence_line_set,
                 resolution=resolution,
                 trusted_source_lines=trusted_source_lines,
+                spool_dir=spool_dir,
             )
         finally:
             previous_entries.close()

--- a/src/git_stage_batch/batch/operation_candidates.py
+++ b/src/git_stage_batch/batch/operation_candidates.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from itertools import product
+from pathlib import Path
 
 from ..core.buffer import LineBuffer
 from ..core.replacement import ReplacementPayload
@@ -35,12 +36,18 @@ def _merge_candidates_or_unambiguous(
     source_lines: LineBuffer,
     ownership,
     target_lines: LineBuffer,
+    *,
+    spool_dir: str | Path | None = None,
 ) -> tuple[MergeCandidate | None, ...]:
+    merge_arguments = {}
+    if spool_dir is not None:
+        merge_arguments["spool_dir"] = spool_dir
     try:
         with merge_batch_from_line_sequences_as_buffer(
             source_lines,
             ownership,
             target_lines,
+            **merge_arguments,
         ) as _buffer:
             pass
         return (None,)
@@ -49,11 +56,14 @@ def _merge_candidates_or_unambiguous(
     except MergeError:
         pass
 
+    candidate_arguments = {"max_candidates": _MAX_OPERATION_CANDIDATES}
+    if spool_dir is not None:
+        candidate_arguments["spool_dir"] = spool_dir
     candidate_set = enumerate_merge_batch_candidates_from_line_sequences(
         source_lines,
         ownership,
         target_lines,
-        max_candidates=_MAX_OPERATION_CANDIDATES,
+        **candidate_arguments,
     )
     if candidate_set.candidates:
         return candidate_set.candidates
@@ -72,35 +82,56 @@ def _materialize_target_candidate(
     text_change_type,
     destination_exists: bool,
     selected_ids: set[int] | None,
+    spool_dir: str | Path | None = None,
 ) -> _TargetCandidatePreview:
-    before_copy = before_lines.clone()
-    after = merge_batch_from_line_sequences_as_buffer(
-        source_lines,
-        ownership,
-        before_lines,
-        resolution=None if candidate is None else candidate.resolution,
+    before_copy = (
+        before_lines.clone()
+        if spool_dir is None
+        else before_lines.clone(spool_dir=spool_dir)
     )
-    return _TargetCandidatePreview(
-        target=target,
-        file_path=file_path,
-        before_buffer=before_copy,
-        after_buffer=after,
-        file_mode=file_mode,
-        change_type=selected_text_target_change_type(
-            text_change_type,
-            selected_ids,
-            after,
-        ).value,
-        destination_exists=destination_exists,
-        resolution=None if candidate is None else candidate.resolution,
-        resolution_ordinal=1 if candidate is None else candidate.ordinal,
-        resolution_count=1 if candidate is None else candidate.count,
-        summary="unambiguous" if candidate is None else candidate.summary,
-        explanation="" if candidate is None else candidate.explanation,
-        ambiguity_target_line_range=(
-            None if candidate is None else candidate.ambiguity_target_line_range
-        ),
-    )
+    merge_arguments = {
+        "resolution": None if candidate is None else candidate.resolution,
+    }
+    if spool_dir is not None:
+        merge_arguments["spool_dir"] = spool_dir
+    try:
+        after = merge_batch_from_line_sequences_as_buffer(
+            source_lines,
+            ownership,
+            before_lines,
+            **merge_arguments,
+        )
+    except BaseException:
+        before_copy.close()
+        raise
+    try:
+        return _TargetCandidatePreview(
+            target=target,
+            file_path=file_path,
+            before_buffer=before_copy,
+            after_buffer=after,
+            file_mode=file_mode,
+            change_type=selected_text_target_change_type(
+                text_change_type,
+                selected_ids,
+                after,
+            ).value,
+            destination_exists=destination_exists,
+            resolution=None if candidate is None else candidate.resolution,
+            resolution_ordinal=1 if candidate is None else candidate.ordinal,
+            resolution_count=1 if candidate is None else candidate.count,
+            summary="unambiguous" if candidate is None else candidate.summary,
+            explanation="" if candidate is None else candidate.explanation,
+            ambiguity_target_line_range=(
+                None
+                if candidate is None
+                else candidate.ambiguity_target_line_range
+            ),
+        )
+    except BaseException:
+        before_copy.close()
+        after.close()
+        raise
 
 
 def build_apply_candidate_previews(
@@ -117,12 +148,14 @@ def build_apply_candidate_previews(
     worktree_exists: bool,
     selected_ids: set[int] | None,
     selection_ids: set[int] | None,
+    spool_dir: str | Path | None = None,
 ) -> tuple[_OperationCandidatePreview, ...]:
     """Return apply candidates for a single file, or an empty tuple."""
     merge_candidates = _merge_candidates_or_unambiguous(
         source_lines,
         ownership,
         worktree_lines,
+        spool_dir=spool_dir,
     )
     if merge_candidates == (None,):
         return ()
@@ -143,54 +176,71 @@ def build_apply_candidate_previews(
     )
     count = len(merge_candidates)
     previews: list[_OperationCandidatePreview] = []
-    for ordinal, merge_candidate in enumerate(merge_candidates, start=1):
-        target_preview = _materialize_target_candidate(
-            target="worktree",
-            file_path=file_path,
-            source_lines=source_lines,
-            ownership=ownership,
-            before_lines=worktree_lines,
-            candidate=merge_candidate,
-            file_mode=worktree_file_mode,
-            text_change_type=text_change_type,
-            destination_exists=worktree_exists,
-            selected_ids=selected_ids,
-        )
-        target_fingerprints = {
-            "worktree": _fingerprint_target(
-                "worktree",
-                file_path,
-                target_preview.before_buffer,
+    try:
+        for ordinal, merge_candidate in enumerate(
+            merge_candidates,
+            start=1,
+        ):
+            target_preview = _materialize_target_candidate(
+                target="worktree",
+                file_path=file_path,
+                source_lines=source_lines,
+                ownership=ownership,
+                before_lines=worktree_lines,
+                candidate=merge_candidate,
+                file_mode=worktree_file_mode,
+                text_change_type=text_change_type,
+                destination_exists=worktree_exists,
+                selected_ids=selected_ids,
+                spool_dir=spool_dir,
             )
-        }
-        target_result_fingerprints = {
-            "worktree": _fingerprint_target_result(target_preview)
-        }
-        targets = (target_preview,)
-        preview = _OperationCandidatePreview(
-            operation="apply",
-            batch_name=batch_name,
-            file_path=file_path,
-            ordinal=ordinal,
-            count=count,
-            candidate_id="",
-            targets=targets,
-            batch_fingerprint=batch_fingerprint,
-            target_fingerprints=target_fingerprints,
-            target_result_fingerprints=target_result_fingerprints,
-            scope_fingerprint=scope_fingerprint,
-        )
-        preview.candidate_id = _fingerprint_candidate_id(
-            operation="apply",
-            batch_name=batch_name,
-            file_path=file_path,
-            scope_fingerprint=scope_fingerprint,
-            batch_fingerprint=batch_fingerprint,
-            target_fingerprints=target_fingerprints,
-            target_result_fingerprints=target_result_fingerprints,
-            targets=targets,
-        )
-        previews.append(preview)
+            try:
+                target_fingerprints = {
+                    "worktree": _fingerprint_target(
+                        "worktree",
+                        file_path,
+                        target_preview.before_buffer,
+                    )
+                }
+                target_result_fingerprints = {
+                    "worktree": _fingerprint_target_result(target_preview)
+                }
+                targets = (target_preview,)
+                preview = _OperationCandidatePreview(
+                    operation="apply",
+                    batch_name=batch_name,
+                    file_path=file_path,
+                    ordinal=ordinal,
+                    count=count,
+                    candidate_id="",
+                    targets=targets,
+                    batch_fingerprint=batch_fingerprint,
+                    target_fingerprints=target_fingerprints,
+                    target_result_fingerprints=(
+                        target_result_fingerprints
+                    ),
+                    scope_fingerprint=scope_fingerprint,
+                )
+                preview.candidate_id = _fingerprint_candidate_id(
+                    operation="apply",
+                    batch_name=batch_name,
+                    file_path=file_path,
+                    scope_fingerprint=scope_fingerprint,
+                    batch_fingerprint=batch_fingerprint,
+                    target_fingerprints=target_fingerprints,
+                    target_result_fingerprints=(
+                        target_result_fingerprints
+                    ),
+                    targets=targets,
+                )
+                previews.append(preview)
+            except BaseException:
+                target_preview.close()
+                raise
+    except BaseException:
+        for preview in previews:
+            preview.close()
+        raise
     return tuple(previews)
 
 
@@ -212,13 +262,20 @@ def build_include_candidate_previews(
     selected_ids: set[int] | None,
     selection_ids: set[int] | None,
     replacement_payload: ReplacementPayload | None = None,
+    spool_dir: str | Path | None = None,
 ) -> tuple[_OperationCandidatePreview, ...]:
     """Return include candidates for a single file, or an empty tuple."""
     index_candidates = _merge_candidates_or_unambiguous(
-        source_lines, ownership, index_lines
+        source_lines,
+        ownership,
+        index_lines,
+        spool_dir=spool_dir,
     )
     worktree_candidates = _merge_candidates_or_unambiguous(
-        source_lines, ownership, worktree_lines
+        source_lines,
+        ownership,
+        worktree_lines,
+        spool_dir=spool_dir,
     )
     if index_candidates == (None,) and worktree_candidates == (None,):
         return ()
@@ -246,70 +303,95 @@ def build_include_candidate_previews(
     )
     count = len(products)
     previews: list[_OperationCandidatePreview] = []
-    for ordinal, (index_candidate, worktree_candidate) in enumerate(products, start=1):
-        index_preview = _materialize_target_candidate(
-            target="index",
-            file_path=file_path,
-            source_lines=source_lines,
-            ownership=ownership,
-            before_lines=index_lines,
-            candidate=index_candidate,
-            file_mode=index_file_mode,
-            text_change_type=text_change_type,
-            destination_exists=index_exists,
-            selected_ids=selected_ids,
-        )
-        worktree_preview = _materialize_target_candidate(
-            target="worktree",
-            file_path=file_path,
-            source_lines=source_lines,
-            ownership=ownership,
-            before_lines=worktree_lines,
-            candidate=worktree_candidate,
-            file_mode=worktree_file_mode,
-            text_change_type=text_change_type,
-            destination_exists=worktree_exists,
-            selected_ids=selected_ids,
-        )
-        targets = (index_preview, worktree_preview)
-        target_fingerprints = {
-            "index": _fingerprint_target(
-                "index",
-                file_path,
-                index_preview.before_buffer,
-            ),
-            "worktree": _fingerprint_target(
-                "worktree",
-                file_path,
-                worktree_preview.before_buffer,
-            ),
-        }
-        target_result_fingerprints = {
-            "index": _fingerprint_target_result(index_preview),
-            "worktree": _fingerprint_target_result(worktree_preview),
-        }
-        preview = _OperationCandidatePreview(
-            operation="include",
-            batch_name=batch_name,
-            file_path=file_path,
-            ordinal=ordinal,
-            count=count,
-            candidate_id="",
-            targets=targets,
-            batch_fingerprint=batch_fingerprint,
-            target_fingerprints=target_fingerprints,
-            target_result_fingerprints=target_result_fingerprints,
-            scope_fingerprint=scope_fingerprint,
-        )
-        preview.candidate_id = _fingerprint_candidate_id(
-            operation="include",
-            batch_name=batch_name,
-            file_path=file_path,
-            scope_fingerprint=scope_fingerprint,
-            batch_fingerprint=batch_fingerprint,
-            target_fingerprints=target_fingerprints,
-            target_result_fingerprints=target_result_fingerprints,
-            targets=targets,
-        )
-        previews.append(preview)
+    try:
+        for ordinal, (
+            index_candidate,
+            worktree_candidate,
+        ) in enumerate(products, start=1):
+            index_preview = _materialize_target_candidate(
+                target="index",
+                file_path=file_path,
+                source_lines=source_lines,
+                ownership=ownership,
+                before_lines=index_lines,
+                candidate=index_candidate,
+                file_mode=index_file_mode,
+                text_change_type=text_change_type,
+                destination_exists=index_exists,
+                selected_ids=selected_ids,
+                spool_dir=spool_dir,
+            )
+            try:
+                worktree_preview = _materialize_target_candidate(
+                    target="worktree",
+                    file_path=file_path,
+                    source_lines=source_lines,
+                    ownership=ownership,
+                    before_lines=worktree_lines,
+                    candidate=worktree_candidate,
+                    file_mode=worktree_file_mode,
+                    text_change_type=text_change_type,
+                    destination_exists=worktree_exists,
+                    selected_ids=selected_ids,
+                    spool_dir=spool_dir,
+                )
+            except BaseException:
+                index_preview.close()
+                raise
+            try:
+                targets = (index_preview, worktree_preview)
+                target_fingerprints = {
+                    "index": _fingerprint_target(
+                        "index",
+                        file_path,
+                        index_preview.before_buffer,
+                    ),
+                    "worktree": _fingerprint_target(
+                        "worktree",
+                        file_path,
+                        worktree_preview.before_buffer,
+                    ),
+                }
+                target_result_fingerprints = {
+                    "index": _fingerprint_target_result(index_preview),
+                    "worktree": _fingerprint_target_result(
+                        worktree_preview
+                    ),
+                }
+                preview = _OperationCandidatePreview(
+                    operation="include",
+                    batch_name=batch_name,
+                    file_path=file_path,
+                    ordinal=ordinal,
+                    count=count,
+                    candidate_id="",
+                    targets=targets,
+                    batch_fingerprint=batch_fingerprint,
+                    target_fingerprints=target_fingerprints,
+                    target_result_fingerprints=(
+                        target_result_fingerprints
+                    ),
+                    scope_fingerprint=scope_fingerprint,
+                )
+                preview.candidate_id = _fingerprint_candidate_id(
+                    operation="include",
+                    batch_name=batch_name,
+                    file_path=file_path,
+                    scope_fingerprint=scope_fingerprint,
+                    batch_fingerprint=batch_fingerprint,
+                    target_fingerprints=target_fingerprints,
+                    target_result_fingerprints=(
+                        target_result_fingerprints
+                    ),
+                    targets=targets,
+                )
+                previews.append(preview)
+            except BaseException:
+                index_preview.close()
+                worktree_preview.close()
+                raise
+    except BaseException:
+        for preview in previews:
+            preview.close()
+        raise
     return tuple(previews)

--- a/src/git_stage_batch/batch/ownership/metadata_loading.py
+++ b/src/git_stage_batch/batch/ownership/metadata_loading.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from ...core.buffer import LineBuffer
 from ...utils.git_object_io import read_git_blobs_as_bytes
 from ...utils.repository_buffers import load_git_blob_as_buffer
@@ -24,6 +26,8 @@ from .replacement_units import ReplacementUnit
 
 def acquire_ownership_for_metadata_dict(
     data: dict,
+    *,
+    spool_dir: str | Path | None = None,
 ) -> AcquiredBatchOwnership[BatchOwnership]:
     """Acquire ownership for metadata with buffered deletion blobs."""
     deletion_metadata = data.get("deletions", [])
@@ -35,7 +39,10 @@ def acquire_ownership_for_metadata_dict(
         for blob_sha in deletion_content_blob_ids(deletion_metadata):
             if blob_sha in blob_buffers:
                 continue
-            buffer = load_git_blob_as_buffer(blob_sha)
+            buffer = load_git_blob_as_buffer(
+                blob_sha,
+                spool_dir=spool_dir,
+            )
             blob_buffers[blob_sha] = buffer
             buffers.append(buffer)
 

--- a/src/git_stage_batch/batch/realization/entry_storage.py
+++ b/src/git_stage_batch/batch/realization/entry_storage.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Iterator, Sequence
+from pathlib import Path
 from typing import Any
 
 from ...editor.line_editor import LineEditor
@@ -25,9 +26,17 @@ class RealizedEntries(Sequence[_RealizedEntry]):
     Python object per output line.
     """
 
-    def __init__(self, entries: Iterable[_RealizedEntry] = ()) -> None:
+    def __init__(
+        self,
+        entries: Iterable[_RealizedEntry] = (),
+        *,
+        spool_dir: str | Path | None = None,
+    ) -> None:
         self._editor = LineEditor(())
-        self._provenance = _RealizedProvenanceTable()
+        self._provenance = _RealizedProvenanceTable(
+            spool_dir=spool_dir,
+        )
+        self._spool_dir = spool_dir
         self._line_count = 0
         self._closed = False
 
@@ -49,7 +58,7 @@ class RealizedEntries(Sequence[_RealizedEntry]):
             if step == 1:
                 return self.slice(start, stop)
 
-            result = RealizedEntries()
+            result = RealizedEntries(spool_dir=self._spool_dir)
             for child_index in range(start, stop, step):
                 result.append_from(self, child_index)
             return result
@@ -225,14 +234,14 @@ class RealizedEntries(Sequence[_RealizedEntry]):
 
     def slice(self, start: int, stop: int) -> RealizedEntries:
         self._require_open()
-        result = RealizedEntries()
+        result = RealizedEntries(spool_dir=self._spool_dir)
         result.copy_slice_from(self, *self._validated_range(start, stop))
         return result
 
     def without_range(self, start: int, stop: int) -> RealizedEntries:
         self._require_open()
         start, stop = self._validated_range(start, stop)
-        result = RealizedEntries()
+        result = RealizedEntries(spool_dir=self._spool_dir)
         result.copy_slice_from(self, 0, start)
         result.copy_slice_from(self, stop, len(self))
         return result
@@ -244,7 +253,7 @@ class RealizedEntries(Sequence[_RealizedEntry]):
     ) -> RealizedEntries:
         self._require_open()
         position = self._validated_position(position)
-        result = RealizedEntries()
+        result = RealizedEntries(spool_dir=self._spool_dir)
         result.copy_slice_from(self, 0, position)
         result.copy_slice_from(entries, 0, len(entries))
         result.copy_slice_from(self, position, len(self))
@@ -314,10 +323,14 @@ class RealizedEntries(Sequence[_RealizedEntry]):
             raise ValueError("realized entries are closed")
 
 
-def as_realized_entries(entries: Sequence[_RealizedEntry]) -> RealizedEntries:
+def as_realized_entries(
+    entries: Sequence[_RealizedEntry],
+    *,
+    spool_dir: str | Path | None = None,
+) -> RealizedEntries:
     if isinstance(entries, RealizedEntries):
         return entries
-    return RealizedEntries(entries)
+    return RealizedEntries(entries, spool_dir=spool_dir)
 
 
 def realized_entry_content_at(entries: Sequence[_RealizedEntry], index: int) -> Any:

--- a/src/git_stage_batch/batch/realization/provenance.py
+++ b/src/git_stage_batch/batch/realization/provenance.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from dataclasses import dataclass
+from pathlib import Path
 
 from ...core.mapped_storage import ChunkedMappedRecordVector
 
@@ -109,10 +110,15 @@ def line_number_or_none(line_number: int) -> int | None:
 class ProvenanceRunTable:
     """Append-only mapped provenance runs with one pending Python run."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        spool_dir: str | Path | None = None,
+    ) -> None:
         self._runs = ChunkedMappedRecordVector(
             record_format="QQQQQ",
             chunk_capacity=_PROVENANCE_CHUNK_CAPACITY,
+            spool_dir=spool_dir,
         )
         self._pending_run: ProvenanceRun | None = None
         self._closed = False

--- a/src/git_stage_batch/batch/selection.py
+++ b/src/git_stage_batch/batch/selection.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Iterator, Sequence
 from contextlib import contextmanager
+from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
 from .ownership.model import BatchOwnership
@@ -188,9 +189,14 @@ def acquire_batch_ownership_for_display_ids_from_lines(
     file_meta: dict,
     batch_source_lines: Sequence[bytes],
     selected_ids: Optional[set[int]],
+    *,
+    spool_dir: str | Path | None = None,
 ) -> Iterator[BatchOwnership]:
     """Acquire selected ownership for indexed batch-source lines."""
-    with acquire_ownership_for_metadata_dict(file_meta) as ownership:
+    with acquire_ownership_for_metadata_dict(
+        file_meta,
+        spool_dir=spool_dir,
+    ) as ownership:
         if selected_ids is None:
             yield ownership
             return

--- a/src/git_stage_batch/commands/batch_source/apply_action.py
+++ b/src/git_stage_batch/commands/batch_source/apply_action.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from pathlib import Path
 import sys
 
 from . import action_completion as _action_completion
@@ -11,26 +13,61 @@ from . import action_selection as _action_selection
 from . import atomic_unit_refusals as _atomic_unit_refusals
 from . import binary_file_actions as _binary_file_actions
 from . import file_mode_actions as _file_mode_actions
-from . import candidate_preview_counts as _candidate_preview_counts
 from . import candidate_refusals as _candidate_refusals
 from . import merge_refusals as _merge_refusals
 from . import text_file_actions as _text_file_actions
-from . import text_plan_builders as _text_plan_builders
+from . import text_plan_jobs as _text_plan_jobs
 from . import worktree_refusals as _worktree_refusals
+from ...batch.operation_candidate_types import CandidatePreviewCount
 from ...batch.binary_file_content import read_binary_file_from_batch
 from ...batch.submodule_pointer import (
     apply_submodule_pointer_from_batch,
     is_batch_submodule_pointer,
 )
 from ...data.session import snapshot_file_if_untracked
+from ...data.file_target_identity import (
+    WorktreeIdentity,
+    capture_worktree_identities,
+    capture_worktree_identity,
+)
 from ...data.undo_checkpoints import undo_checkpoint
 from ...exceptions import (
     AtomicUnitError,
     CommandError,
-    MergeError,
     exit_with_error,
 )
 from ...i18n import _
+from ...utils.file_job_workspace import FileJobWorkspace
+from ...utils.file_jobs import (
+    OrderedFileJob,
+    run_file_jobs,
+    run_validated_file_jobs,
+)
+from ...utils.git_repository import get_git_repository_root_path
+from ...utils.git_object_io import list_git_tree_blobs, resolve_git_objects
+
+
+@dataclass(frozen=True, slots=True)
+class _ApplyTextInput:
+    ordinal: int
+    file_path: str
+    file_meta: dict
+    identity: WorktreeIdentity
+    worktree_artifact: Path
+    scratch_directory: Path
+    source_commit: str | None
+    source_required: bool
+
+
+@dataclass(frozen=True, slots=True)
+class _ApplyPlanCapture:
+    text_inputs: tuple[_ApplyTextInput, ...]
+    plans_by_ordinal: dict[int, _action_plans.BatchSourceActionPlan]
+    command_errors_by_ordinal: dict[int, CommandError]
+    unexpected_errors_by_ordinal: dict[int, str]
+    mode_actions: list[tuple[str, dict]]
+    binary_metadata_by_ordinal: dict[int, dict]
+    worktree_identities: dict[str, WorktreeIdentity]
 
 
 def _print_binary_worktree_result(
@@ -42,7 +79,9 @@ def _print_binary_worktree_result(
         return
 
     if action is _binary_file_actions.BinaryWorktreeAction.DELETED:
-        print(_("✓ Deleted binary file: {file}").format(file=file_path), file=sys.stderr)
+        print(
+            _("✓ Deleted binary file: {file}").format(file=file_path), file=sys.stderr
+        )
     elif action is _binary_file_actions.BinaryWorktreeAction.ADDED:
         print(
             _("✓ Applied new binary file: {file}").format(file=file_path),
@@ -67,95 +106,434 @@ def execute_apply_action(
     selection_ids_to_apply = selection.selection_ids
     rendered = selection.rendered
     operation_parts = list(selection.operation_parts)
-    failed_files = []
-    candidate_counts = {}
-    apply_plans = []
-    mode_actions = []
+    repository_root = get_git_repository_root_path()
+    with FileJobWorkspace() as workspace:
+        (
+            apply_plans,
+            mode_actions,
+            expected_worktree_identities,
+        ) = _build_apply_action_plans(
+            batch_name=batch_name,
+            files=files,
+            selected_ids=selected_ids,
+            selection_ids_to_apply=selection_ids_to_apply,
+            rendered=rendered,
+            repository_root=repository_root,
+            workspace=workspace,
+        )
+        try:
+            _require_unchanged_worktree_targets(
+                expected_worktree_identities,
+            )
+            try:
+                with undo_checkpoint(
+                    " ".join(operation_parts),
+                    worktree_paths=list(files),
+                    rollback_on_error=True,
+                ):
+                    for plan in apply_plans:
+                        snapshot_file_if_untracked(plan.file_path)
+                        if isinstance(plan, _action_plans.ApplyTextFileActionPlan):
+                            _text_file_actions.write_text_file_to_worktree(
+                                plan.file_path,
+                                plan.buffer,
+                                plan.file_mode,
+                                plan.change_type,
+                            )
+                        elif isinstance(plan, _action_plans.BinaryFileActionPlan):
+                            action = _binary_file_actions.write_binary_file_to_worktree(
+                                plan.file_path,
+                                plan.file_meta,
+                                plan.buffer,
+                                missing_content_message=(
+                                    "Binary file metadata for "
+                                    f"{plan.file_path} says "
+                                    f"{plan.file_meta.get('change_type', 'modified')}, "
+                                    "but the batch content is missing"
+                                ),
+                            )
+                            _print_binary_worktree_result(plan.file_path, action)
+                        else:
+                            apply_submodule_pointer_from_batch(
+                                plan.file_path,
+                                plan.file_meta,
+                            )
+                    for file_path, file_meta in mode_actions:
+                        _file_mode_actions.apply_new_file_mode(file_path, file_meta)
+            except CommandError:
+                raise
+            except Exception as error:
+                _worktree_refusals.refuse_incompatible_worktree_action(
+                    batch_name=batch_name,
+                    file_paths=files,
+                    error=error,
+                )
+        finally:
+            _action_plans.close_action_plans(apply_plans)
 
-    for file_path, file_meta in files.items():
+    _action_completion.finish_batch_source_action_review(context, files)
+
+
+def _build_apply_action_plans(
+    *,
+    batch_name: str,
+    files: dict[str, dict],
+    selected_ids: set[int] | None,
+    selection_ids_to_apply: set[int] | None,
+    rendered,
+    repository_root: Path,
+    workspace: FileJobWorkspace,
+) -> tuple[
+    list[_action_plans.BatchSourceActionPlan],
+    list[tuple[str, dict]],
+    dict[str, WorktreeIdentity],
+]:
+    capture = _capture_apply_plan_inputs(
+        files=files,
+        selected_ids=selected_ids,
+        workspace=workspace,
+    )
+    try:
+        jobs = _build_apply_text_jobs(
+            batch_name=batch_name,
+            selected_ids=selected_ids,
+            selection_ids_to_apply=selection_ids_to_apply,
+            capture=capture,
+            workspace=workspace,
+        )
+        text_results_by_ordinal = _run_apply_text_jobs(
+            jobs,
+            repository_root=repository_root,
+        )
+        plans = _reduce_apply_action_plans(
+            batch_name=batch_name,
+            files=files,
+            rendered=rendered,
+            capture=capture,
+            text_results_by_ordinal=text_results_by_ordinal,
+            workspace=workspace,
+        )
+        return plans, capture.mode_actions, capture.worktree_identities
+    except BaseException:
+        _action_plans.close_action_plans(capture.plans_by_ordinal.values())
+        raise
+
+
+def _capture_apply_plan_inputs(
+    *,
+    files: dict[str, dict],
+    selected_ids: set[int] | None,
+    workspace: FileJobWorkspace,
+) -> _ApplyPlanCapture:
+    """Capture apply targets and classify atomic and text inputs."""
+    plans_by_ordinal: dict[int, _action_plans.BatchSourceActionPlan] = {}
+    command_errors_by_ordinal: dict[int, CommandError] = {}
+    unexpected_errors_by_ordinal: dict[int, str] = {}
+    mode_actions: list[tuple[str, dict]] = []
+    binary_metadata_by_ordinal: dict[int, dict] = {}
+    worktree_identities: dict[str, WorktreeIdentity] = {}
+    text_inputs: list[_ApplyTextInput] = []
+
+    for ordinal, (file_path, file_meta) in enumerate(files.items()):
         try:
             if _file_mode_actions.is_file_mode_action(file_meta):
+                worktree_identities[file_path] = capture_worktree_identity(file_path)
                 mode_actions.append((file_path, file_meta))
                 continue
             if file_meta.get("file_type") == "binary":
-                batch_buffer = read_binary_file_from_batch(
-                    batch_name,
-                    file_path,
-                    file_meta,
-                )
-                apply_plans.append(
-                    _action_plans.BinaryFileActionPlan(
-                        file_path,
-                        file_meta,
-                        batch_buffer,
-                    )
-                )
+                worktree_identities[file_path] = capture_worktree_identity(file_path)
+                binary_metadata_by_ordinal[ordinal] = file_meta
                 continue
             if is_batch_submodule_pointer(file_meta):
-                apply_plans.append(
-                    _action_plans.SubmodulePointerActionPlan(file_path, file_meta)
+                worktree_identities[file_path] = capture_worktree_identity(file_path)
+                plans_by_ordinal[ordinal] = _action_plans.SubmodulePointerActionPlan(
+                    file_path, file_meta
                 )
                 continue
 
-            try:
-                text_plan_result = (
-                    _text_plan_builders.build_apply_text_file_action_plan(
-                        file_path=file_path,
-                        file_meta=file_meta,
-                        selected_ids=selected_ids,
-                        selection_ids_to_apply=selection_ids_to_apply,
-                    )
+            source_required = _text_plan_jobs.apply_text_plan_requires_source(
+                file_meta,
+                selected_ids,
+            )
+            if source_required:
+                worktree_artifact = workspace.artifact_path(
+                    ordinal,
+                    "worktree-input",
                 )
-            except AtomicUnitError as e:
-                if rendered:
-                    _atomic_unit_refusals.translate_atomic_unit_error_to_gutter_ids(
-                        e,
-                        rendered,
-                        "apply",
-                        batch_name,
-                    )
-                _action_plans.close_action_plans(apply_plans)
-                exit_with_error(
-                    _("Failed to apply batch '{name}': {error}").format(
-                        name=batch_name,
-                        error=str(e),
-                    )
+                identity = capture_worktree_identity(
+                    file_path,
+                    content_artifact_path=worktree_artifact,
                 )
-
-            if text_plan_result.missing_source:
-                failed_files.append(file_path)
-                continue
-            if text_plan_result.plan is None:
-                continue
-            apply_plans.append(text_plan_result.plan)
-
-        except MergeError:
-            candidate_count = (
-                _candidate_preview_counts.count_apply_candidate_previews_for_file(
-                    batch_name=batch_name,
+                source_commit = file_meta["batch_source_commit"]
+            else:
+                identity = capture_worktree_identity(file_path)
+                worktree_artifact = workspace.write_buffer(
+                    ordinal,
+                    "worktree-input",
+                    (),
+                )
+                source_commit = None
+            worktree_identities[file_path] = identity
+            scratch_directory = workspace.scratch_directory(ordinal)
+            text_inputs.append(
+                _ApplyTextInput(
+                    ordinal=ordinal,
                     file_path=file_path,
                     file_meta=file_meta,
-                    selection_ids_to_apply=selection_ids_to_apply,
+                    identity=identity,
+                    worktree_artifact=worktree_artifact,
+                    scratch_directory=scratch_directory,
+                    source_commit=source_commit,
+                    source_required=source_required,
                 )
             )
-            if candidate_count.count or candidate_count.too_many or candidate_count.error:
-                candidate_counts[file_path] = candidate_count
-            failed_files.append(file_path)
-        except CommandError:
-            _action_plans.close_action_plans(apply_plans)
-            raise
-        except Exception as e:
+        except CommandError as error:
+            command_errors_by_ordinal[ordinal] = error
+        except Exception as error:
+            unexpected_errors_by_ordinal[ordinal] = str(error)
+    return _ApplyPlanCapture(
+        text_inputs=tuple(text_inputs),
+        plans_by_ordinal=plans_by_ordinal,
+        command_errors_by_ordinal=command_errors_by_ordinal,
+        unexpected_errors_by_ordinal=unexpected_errors_by_ordinal,
+        mode_actions=mode_actions,
+        binary_metadata_by_ordinal=binary_metadata_by_ordinal,
+        worktree_identities=worktree_identities,
+    )
+
+
+def _build_apply_text_jobs(
+    *,
+    batch_name: str,
+    selected_ids: set[int] | None,
+    selection_ids_to_apply: set[int] | None,
+    capture: _ApplyPlanCapture,
+    workspace: FileJobWorkspace,
+) -> list[OrderedFileJob[_text_plan_jobs.ApplyTextPlanJob]]:
+    """Build compact apply text jobs from captured inputs."""
+    text_inputs = capture.text_inputs
+    jobs: list[OrderedFileJob[_text_plan_jobs.ApplyTextPlanJob]] = []
+
+    source_blob_by_target = _resolve_apply_text_source_blobs(text_inputs)
+    source_info_by_id = resolve_git_objects(source_blob_by_target.values())
+    for text_input in text_inputs:
+        ordinal = text_input.ordinal
+        file_path = text_input.file_path
+        source_object_id = source_blob_by_target.get((ordinal, file_path))
+        source_info = (
+            None
+            if source_object_id is None
+            else source_info_by_id.get(source_object_id)
+        )
+        source_size = (
+            source_info.size
+            if source_info is not None and source_info.object_type == "blob"
+            else 0
+        )
+        try:
+            input_artifact = workspace.write_pickle(
+                ordinal,
+                "apply-input.pickle",
+                {
+                    "batch_name": batch_name,
+                    "batch_source_object_id": source_object_id,
+                    "file_meta": text_input.file_meta,
+                    "selected_ids": (
+                        None if selected_ids is None else sorted(selected_ids)
+                    ),
+                    "selection_ids": (
+                        None
+                        if selection_ids_to_apply is None
+                        else sorted(selection_ids_to_apply)
+                    ),
+                    "working_tree_artifact_path": str(text_input.worktree_artifact),
+                    "scratch_directory": str(text_input.scratch_directory),
+                },
+            )
+            output_path = workspace.output_path(ordinal, "merged-output")
+            details_path = workspace.output_path(ordinal, "details.pickle")
+            payload = _text_plan_jobs.ApplyTextPlanJob(
+                ordinal=ordinal,
+                file_path=file_path,
+                input_artifact_path=str(input_artifact),
+                output_path=str(output_path),
+                details_artifact_path=str(details_path),
+                expected_worktree_identity=text_input.identity,
+            )
+            jobs.append(
+                OrderedFileJob(
+                    ordinal=ordinal,
+                    file_path=file_path,
+                    estimated_bytes=(
+                        ((text_input.identity.size or 0) + source_size)
+                        if text_input.source_required
+                        else 0
+                    ),
+                    payload=payload,
+                )
+            )
+        except CommandError as error:
+            capture.command_errors_by_ordinal[ordinal] = error
+        except Exception as error:
+            capture.unexpected_errors_by_ordinal[ordinal] = str(error)
+    return jobs
+
+
+def _run_apply_text_jobs(
+    jobs: list[OrderedFileJob[_text_plan_jobs.ApplyTextPlanJob]],
+    *,
+    repository_root: Path,
+) -> dict[int, _text_plan_jobs.ApplyTextPlanJobResult]:
+    """Execute and validate apply text jobs in stable ordinal order."""
+    paired_results = run_validated_file_jobs(
+        jobs,
+        _text_plan_jobs.compute_apply_text_plan_job,
+        _text_plan_jobs.validate_apply_text_plan_job_result,
+        repository_root=repository_root,
+        result_label="apply text-plan",
+        run_jobs=run_file_jobs,
+    )
+    return {result.ordinal: result for _job, result in paired_results}
+
+
+def _reduce_apply_action_plans(
+    *,
+    batch_name: str,
+    files: dict[str, dict],
+    rendered,
+    capture: _ApplyPlanCapture,
+    text_results_by_ordinal: dict[int, _text_plan_jobs.ApplyTextPlanJobResult],
+    workspace: FileJobWorkspace,
+) -> list[_action_plans.BatchSourceActionPlan]:
+    """Reduce atomic and text apply outcomes in source-file order."""
+    failed_by_ordinal = {}
+    candidate_counts = {}
+    plans_by_ordinal = capture.plans_by_ordinal
+    for ordinal, (file_path, _file_meta) in enumerate(files.items()):
+        command_error = capture.command_errors_by_ordinal.get(ordinal)
+        if command_error is not None:
+            raise command_error
+        unexpected_error = capture.unexpected_errors_by_ordinal.get(ordinal)
+        if unexpected_error is not None:
             print(
                 _("Error applying {file}: {error}").format(
                     file=file_path,
-                    error=str(e),
+                    error=unexpected_error,
                 ),
                 file=sys.stderr,
             )
-            failed_files.append(file_path)
+            failed_by_ordinal[ordinal] = file_path
+            continue
+        binary_metadata = capture.binary_metadata_by_ordinal.get(ordinal)
+        if binary_metadata is not None:
+            try:
+                batch_buffer = read_binary_file_from_batch(
+                    batch_name,
+                    file_path,
+                    binary_metadata,
+                )
+                plans_by_ordinal[ordinal] = _action_plans.BinaryFileActionPlan(
+                    file_path,
+                    binary_metadata,
+                    batch_buffer,
+                )
+            except CommandError:
+                raise
+            except Exception as error:
+                print(
+                    _("Error applying {file}: {error}").format(
+                        file=file_path,
+                        error=str(error),
+                    ),
+                    file=sys.stderr,
+                )
+                failed_by_ordinal[ordinal] = file_path
+            continue
+        result = text_results_by_ordinal.get(ordinal)
+        if result is None:
+            continue
+        details = (
+            {}
+            if result.details_artifact_path is None
+            else workspace.read_pickle(result.details_artifact_path)
+        )
+        if type(details) is not dict:
+            raise TypeError("apply text-plan details must be a dictionary")
+        if result.outcome == "plan":
+            buffer = (
+                None
+                if result.output_path is None
+                else workspace.read_buffer(
+                    result.output_path,
+                    spool_dir=workspace.scratch_directory(result.ordinal),
+                )
+            )
+            plans_by_ordinal[result.ordinal] = _action_plans.ApplyTextFileActionPlan(
+                result.file_path,
+                buffer,
+                result.file_mode,
+                result.change_type,
+            )
+        elif result.outcome == "noop":
+            continue
+        elif result.outcome == "atomic_unit_error":
+            error = AtomicUnitError(
+                details["message"],
+                details.get("required_selection_ids"),
+                details.get("unit_kind"),
+            )
+            if rendered:
+                _atomic_unit_refusals.translate_atomic_unit_error_to_gutter_ids(
+                    error,
+                    rendered,
+                    "apply",
+                    batch_name,
+                )
+            exit_with_error(
+                _("Failed to apply batch '{name}': {error}").format(
+                    name=batch_name,
+                    error=str(error),
+                )
+            )
+        elif result.outcome == "command_error":
+            raise CommandError(
+                details["message"],
+                details.get("exit_code", 1),
+            )
+        elif result.outcome == "unexpected_error":
+            print(
+                _("Error applying {file}: {error}").format(
+                    file=result.file_path,
+                    error=details["message"],
+                ),
+                file=sys.stderr,
+            )
+            failed_by_ordinal[ordinal] = result.file_path
+        elif result.outcome == "merge_error":
+            _require_unchanged_worktree_target(
+                result.file_path,
+                capture.worktree_identities[result.file_path],
+            )
+            candidate_count = CandidatePreviewCount(
+                count=details.get("candidate_count", 0),
+                too_many=details.get("candidate_too_many", False),
+                error=details.get("candidate_error"),
+            )
+            if (
+                candidate_count.count
+                or candidate_count.too_many
+                or candidate_count.error
+            ):
+                candidate_counts[result.file_path] = candidate_count
+            failed_by_ordinal[ordinal] = result.file_path
+        elif result.outcome == "missing_source":
+            failed_by_ordinal[ordinal] = result.file_path
+        else:
+            raise RuntimeError(f"Unhandled apply text-plan outcome: {result.outcome}")
 
+    plans = [plans_by_ordinal[ordinal] for ordinal in sorted(plans_by_ordinal)]
+    failed_files = [failed_by_ordinal[ordinal] for ordinal in sorted(failed_by_ordinal)]
     if failed_files:
-        _action_plans.close_action_plans(apply_plans)
         _candidate_refusals.refuse_candidate_conflicts(
             batch_name=batch_name,
             operation="apply",
@@ -166,51 +544,65 @@ def execute_apply_action(
             batch_name=batch_name,
             failed_files=failed_files,
         )
+    return plans
 
-    try:
-        try:
-            with undo_checkpoint(
-                " ".join(operation_parts),
-                worktree_paths=list(files),
-                rollback_on_error=True,
-            ):
-                for plan in apply_plans:
-                    snapshot_file_if_untracked(plan.file_path)
-                    if isinstance(plan, _action_plans.ApplyTextFileActionPlan):
-                        _text_file_actions.write_text_file_to_worktree(
-                            plan.file_path,
-                            plan.buffer,
-                            plan.file_mode,
-                            plan.change_type,
-                        )
-                    elif isinstance(plan, _action_plans.BinaryFileActionPlan):
-                        action = _binary_file_actions.write_binary_file_to_worktree(
-                            plan.file_path,
-                            plan.file_meta,
-                            plan.buffer,
-                            missing_content_message=(
-                                f"Binary file metadata for {plan.file_path} "
-                                f"says {plan.file_meta.get('change_type', 'modified')}, "
-                                "but the batch content is missing"
-                            ),
-                        )
-                        _print_binary_worktree_result(plan.file_path, action)
-                    else:
-                        apply_submodule_pointer_from_batch(
-                            plan.file_path,
-                            plan.file_meta,
-                        )
-                for file_path, file_meta in mode_actions:
-                    _file_mode_actions.apply_new_file_mode(file_path, file_meta)
-        except CommandError:
-            raise
-        except Exception as error:
-            _worktree_refusals.refuse_incompatible_worktree_action(
-                batch_name=batch_name,
-                file_paths=files,
-                error=error,
+
+def _resolve_apply_text_source_blobs(
+    text_inputs: tuple[_ApplyTextInput, ...],
+) -> dict[tuple[int, str], str]:
+    paths_by_commit: dict[str, list[str]] = {}
+    for text_input in text_inputs:
+        if text_input.source_commit is None:
+            continue
+        paths_by_commit.setdefault(
+            text_input.source_commit,
+            [],
+        ).append(text_input.file_path)
+
+    entries_by_commit = {
+        source_commit: list_git_tree_blobs(source_commit, file_paths)
+        for source_commit, file_paths in paths_by_commit.items()
+    }
+    source_blob_by_target = {}
+    for text_input in text_inputs:
+        if text_input.source_commit is None:
+            continue
+        entry = entries_by_commit[text_input.source_commit].get(text_input.file_path)
+        if entry is not None:
+            source_blob_by_target[(text_input.ordinal, text_input.file_path)] = (
+                entry.blob_sha
             )
-    finally:
-        _action_plans.close_action_plans(apply_plans)
+    return source_blob_by_target
 
-    _action_completion.finish_batch_source_action_review(context, files)
+
+def _worktree_target_changed_error(file_path: str) -> CommandError:
+    return CommandError(
+        _(
+            "Working tree file changed while apply was being calculated: "
+            "{file}. Retry the apply command."
+        ).format(file=file_path)
+    )
+
+
+def _require_unchanged_worktree_targets(
+    expected_identities: dict[str, WorktreeIdentity],
+) -> None:
+    current_identities = capture_worktree_identities(tuple(expected_identities))
+    stale_path = next(
+        (
+            file_path
+            for file_path, expected_identity in expected_identities.items()
+            if current_identities[file_path] != expected_identity
+        ),
+        None,
+    )
+    if stale_path is not None:
+        raise _worktree_target_changed_error(stale_path)
+
+
+def _require_unchanged_worktree_target(
+    file_path: str,
+    expected_identity: WorktreeIdentity,
+) -> None:
+    if capture_worktree_identity(file_path) != expected_identity:
+        raise _worktree_target_changed_error(file_path)

--- a/src/git_stage_batch/commands/batch_source/candidate_inputs.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_inputs.py
@@ -76,10 +76,14 @@ def candidate_worktree_text_target(
     file_path: str,
     file_meta: dict,
     selected_ids: Iterable[int] | None,
+    captured_working_tree_exists: bool | None = None,
 ) -> CandidateWorktreeTarget:
     """Return worktree existence, materialization mode, and text lifecycle."""
-    repo_root = get_git_repository_root_path()
-    working_exists = os.path.lexists(repo_root / file_path)
+    if captured_working_tree_exists is None:
+        repo_root = get_git_repository_root_path()
+        working_exists = os.path.lexists(repo_root / file_path)
+    else:
+        working_exists = captured_working_tree_exists
     return CandidateWorktreeTarget(
         exists=working_exists,
         file_mode=mode_for_text_materialization(

--- a/src/git_stage_batch/commands/batch_source/candidate_preview_counts.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_preview_counts.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from contextlib import ExitStack
+from pathlib import Path
 
 from . import candidate_inputs as _candidate_inputs
 from . import candidate_previews as _candidate_previews
@@ -19,6 +20,7 @@ from ...batch.selection import acquire_batch_ownership_for_display_ids_from_line
 from ...core.buffer import LineBuffer
 from ...core.replacement import ReplacementPayload
 from ...utils.repository_buffers import (
+    load_git_blob_as_buffer,
     read_git_object_buffer_or_none,
     load_working_tree_file_as_buffer,
 )
@@ -31,6 +33,10 @@ def count_apply_candidate_previews_for_file(
     file_path: str,
     file_meta: dict,
     selection_ids_to_apply: set[int] | None,
+    batch_source_object_id: str | None = None,
+    working_tree_artifact_path: str | Path | None = None,
+    captured_working_tree_exists: bool | None = None,
+    spool_dir: str | Path | None = None,
 ) -> CandidatePreviewCount:
     """Return previewable apply candidate counts for one text batch file."""
     if not _candidate_inputs.is_text_candidate_entry(file_meta):
@@ -38,43 +44,83 @@ def count_apply_candidate_previews_for_file(
     batch_source_ref = _candidate_inputs.candidate_batch_source_ref(file_path, file_meta)
     if batch_source_ref is None:
         return CandidatePreviewCount()
-    batch_source_buffer = read_git_object_buffer_or_none(batch_source_ref.object_spec)
-    if batch_source_buffer is None:
-        return CandidatePreviewCount()
-
-    worktree_target = _candidate_inputs.candidate_worktree_text_target(
-        file_path=file_path,
-        file_meta=file_meta,
-        selected_ids=selection_ids_to_apply,
-    )
-
     try:
-        with (
-            batch_source_buffer as batch_source_lines,
-            load_working_tree_file_as_buffer(file_path) as working_lines,
-        ):
-            with acquire_batch_ownership_for_display_ids_from_lines(
-                file_meta,
-                batch_source_lines,
-                selection_ids_to_apply,
-            ) as ownership:
-                previews = build_apply_candidate_previews(
-                    batch_name=batch_name,
-                    file_path=file_path,
-                    source_lines=batch_source_lines,
-                    ownership=ownership,
-                    worktree_lines=working_lines,
-                    batch_source_commit=batch_source_ref.commit,
-                    file_meta=file_meta,
-                    text_change_type=worktree_target.text_change_type,
-                    worktree_file_mode=worktree_target.file_mode,
-                    worktree_exists=worktree_target.exists,
-                    selected_ids=selection_ids_to_apply,
-                    selection_ids=selection_ids_to_apply,
+        if batch_source_object_id is None:
+            batch_source_spec = batch_source_ref.object_spec
+            batch_source_buffer = (
+                read_git_object_buffer_or_none(batch_source_spec)
+                if spool_dir is None
+                else read_git_object_buffer_or_none(
+                    batch_source_spec,
+                    spool_dir=spool_dir,
                 )
-                count = len(previews)
+            )
+        else:
+            batch_source_buffer = load_git_blob_as_buffer(
+                batch_source_object_id,
+                spool_dir=spool_dir,
+            )
+        if batch_source_buffer is None:
+            return CandidatePreviewCount()
+
+        with ExitStack() as stack:
+            batch_source_lines = stack.enter_context(batch_source_buffer)
+            worktree_target = _candidate_inputs.candidate_worktree_text_target(
+                file_path=file_path,
+                file_meta=file_meta,
+                selected_ids=selection_ids_to_apply,
+                captured_working_tree_exists=(
+                    captured_working_tree_exists
+                ),
+            )
+            if working_tree_artifact_path is None:
+                working_tree_buffer = (
+                    load_working_tree_file_as_buffer(file_path)
+                    if spool_dir is None
+                    else load_working_tree_file_as_buffer(
+                        file_path,
+                        spool_dir=spool_dir,
+                    )
+                )
+            else:
+                working_tree_buffer = LineBuffer.from_path(
+                    working_tree_artifact_path,
+                    spool_dir=spool_dir,
+                )
+            working_lines = stack.enter_context(working_tree_buffer)
+            ownership_arguments = {}
+            if spool_dir is not None:
+                ownership_arguments["spool_dir"] = spool_dir
+            ownership = stack.enter_context(
+                acquire_batch_ownership_for_display_ids_from_lines(
+                    file_meta,
+                    batch_source_lines,
+                    selection_ids_to_apply,
+                    **ownership_arguments,
+                )
+            )
+            preview_arguments = {}
+            if spool_dir is not None:
+                preview_arguments["spool_dir"] = spool_dir
+            previews = build_apply_candidate_previews(
+                batch_name=batch_name,
+                file_path=file_path,
+                source_lines=batch_source_lines,
+                ownership=ownership,
+                worktree_lines=working_lines,
+                batch_source_commit=batch_source_ref.commit,
+                file_meta=file_meta,
+                text_change_type=worktree_target.text_change_type,
+                worktree_file_mode=worktree_target.file_mode,
+                worktree_exists=worktree_target.exists,
+                selected_ids=selection_ids_to_apply,
+                selection_ids=selection_ids_to_apply,
+                **preview_arguments,
+            )
+            try:
+                return CandidatePreviewCount(count=len(previews))
+            finally:
                 _candidate_previews.close_candidate_previews(previews)
-                return CandidatePreviewCount(count=count)
     except CandidateEnumerationLimitError as e:
         return CandidatePreviewCount(too_many=True, error=str(e))
     except MergeError:
@@ -97,70 +143,76 @@ def count_include_candidate_previews_for_file(
     batch_source_ref = _candidate_inputs.candidate_batch_source_ref(file_path, file_meta)
     if batch_source_ref is None:
         return CandidatePreviewCount()
-    batch_source_buffer = read_git_object_buffer_or_none(batch_source_ref.object_spec)
-    if batch_source_buffer is None:
-        return CandidatePreviewCount()
-
-    index_buffer = read_git_object_buffer_or_none(f":{file_path}")
-    index_exists = index_buffer is not None
-    if index_buffer is None:
-        index_buffer = LineBuffer.from_bytes(b"")
-
-    index_target = _candidate_inputs.candidate_index_text_target(
-        file_meta=file_meta,
-        selected_ids=selection_ids_to_include,
-        index_exists=index_exists,
-    )
-    worktree_target = _candidate_inputs.candidate_worktree_text_target(
-        file_path=file_path,
-        file_meta=file_meta,
-        selected_ids=selection_ids_to_include,
-    )
-
     try:
-        with (
-            batch_source_buffer as batch_source_lines,
-            index_buffer as index_lines,
-            load_working_tree_file_as_buffer(file_path) as working_lines,
-        ):
-            with acquire_batch_ownership_for_display_ids_from_lines(
-                file_meta,
-                batch_source_lines,
-                selection_ids_to_include,
-            ) as ownership:
-                with ExitStack() as stack:
-                    source_for_candidates = batch_source_lines
-                    candidate_ownership = ownership
-                    if replacement_payload is not None:
-                        replacement_view = build_replacement_batch_view_from_lines(
-                            batch_source_lines,
-                            ownership,
-                            replacement_payload,
-                        )
-                        replacement_view = stack.enter_context(replacement_view)
-                        source_for_candidates = replacement_view.source_buffer
-                        candidate_ownership = replacement_view.ownership
-                    previews = build_include_candidate_previews(
-                        batch_name=batch_name,
-                        file_path=file_path,
-                        source_lines=source_for_candidates,
-                        ownership=candidate_ownership,
-                        index_lines=index_lines,
-                        worktree_lines=working_lines,
-                        batch_source_commit=batch_source_ref.commit,
-                        file_meta=file_meta,
-                        text_change_type=worktree_target.text_change_type,
-                        index_file_mode=index_target.file_mode,
-                        worktree_file_mode=worktree_target.file_mode,
-                        index_exists=index_target.exists,
-                        worktree_exists=worktree_target.exists,
-                        selected_ids=selection_ids_to_include,
-                        selection_ids=selection_ids_to_include,
-                        replacement_payload=replacement_payload,
+        batch_source_buffer = read_git_object_buffer_or_none(
+            batch_source_ref.object_spec
+        )
+        if batch_source_buffer is None:
+            return CandidatePreviewCount()
+
+        with ExitStack() as stack:
+            batch_source_lines = stack.enter_context(batch_source_buffer)
+            index_buffer = read_git_object_buffer_or_none(f":{file_path}")
+            index_exists = index_buffer is not None
+            if index_buffer is None:
+                index_buffer = LineBuffer.from_bytes(b"")
+            index_lines = stack.enter_context(index_buffer)
+            index_target = _candidate_inputs.candidate_index_text_target(
+                file_meta=file_meta,
+                selected_ids=selection_ids_to_include,
+                index_exists=index_exists,
+            )
+            worktree_target = (
+                _candidate_inputs.candidate_worktree_text_target(
+                    file_path=file_path,
+                    file_meta=file_meta,
+                    selected_ids=selection_ids_to_include,
+                )
+            )
+            working_lines = stack.enter_context(
+                load_working_tree_file_as_buffer(file_path)
+            )
+            ownership = stack.enter_context(
+                acquire_batch_ownership_for_display_ids_from_lines(
+                    file_meta,
+                    batch_source_lines,
+                    selection_ids_to_include,
+                )
+            )
+            source_for_candidates = batch_source_lines
+            candidate_ownership = ownership
+            if replacement_payload is not None:
+                replacement_view = stack.enter_context(
+                    build_replacement_batch_view_from_lines(
+                        batch_source_lines,
+                        ownership,
+                        replacement_payload,
                     )
-                count = len(previews)
+                )
+                source_for_candidates = replacement_view.source_buffer
+                candidate_ownership = replacement_view.ownership
+            previews = build_include_candidate_previews(
+                batch_name=batch_name,
+                file_path=file_path,
+                source_lines=source_for_candidates,
+                ownership=candidate_ownership,
+                index_lines=index_lines,
+                worktree_lines=working_lines,
+                batch_source_commit=batch_source_ref.commit,
+                file_meta=file_meta,
+                text_change_type=worktree_target.text_change_type,
+                index_file_mode=index_target.file_mode,
+                worktree_file_mode=worktree_target.file_mode,
+                index_exists=index_target.exists,
+                worktree_exists=worktree_target.exists,
+                selected_ids=selection_ids_to_include,
+                selection_ids=selection_ids_to_include,
+                replacement_payload=replacement_payload,
+            )
+            try:
+                return CandidatePreviewCount(count=len(previews))
+            finally:
                 _candidate_previews.close_candidate_previews(previews)
-                return CandidatePreviewCount(count=count)
     except CandidateEnumerationLimitError as e:
         return CandidatePreviewCount(too_many=True, error=str(e))
     except MergeError:

--- a/src/git_stage_batch/commands/batch_source/text_plan_builders.py
+++ b/src/git_stage_batch/commands/batch_source/text_plan_builders.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from contextlib import ExitStack
 from dataclasses import dataclass
 import os
+from pathlib import Path
 
 from . import action_plans as _action_plans
 from ...batch.discard import discard_batch_from_line_sequences_as_buffer
@@ -22,6 +23,7 @@ from ...core.text_lifecycle import (
 )
 from ...data.file_modes import detect_file_mode_in_commit
 from ...utils.repository_buffers import (
+    load_git_blob_as_buffer,
     read_git_object_buffer_or_none,
     load_working_tree_file_as_buffer,
 )
@@ -62,25 +64,44 @@ def _close_include_merge_buffers(
         working_buffer.close()
 
 
+def apply_text_plan_requires_source(
+    file_meta: dict,
+    selected_ids: set[int] | None,
+) -> bool:
+    """Return whether one apply text plan needs batch source content."""
+    return not (
+        selected_ids is None
+        and normalized_text_change_type(file_meta.get("change_type"))
+        == TextFileChangeType.DELETED
+    )
+
+
 def build_apply_text_file_action_plan(
     *,
     file_path: str,
     file_meta: dict,
     selected_ids: set[int] | None,
     selection_ids_to_apply: set[int] | None,
+    batch_source_object_id: str | None = None,
+    working_tree_artifact_path: str | Path | None = None,
+    captured_working_tree_exists: bool | None = None,
+    spool_dir: str | Path | None = None,
 ) -> ApplyTextPlanBuildResult:
     """Build one deferred apply-from text action plan."""
     text_change_type = normalized_text_change_type(file_meta.get("change_type"))
 
-    repo_root = get_git_repository_root_path()
-    working_exists = os.path.lexists(repo_root / file_path)
+    if captured_working_tree_exists is None:
+        repo_root = get_git_repository_root_path()
+        working_exists = os.path.lexists(repo_root / file_path)
+    else:
+        working_exists = captured_working_tree_exists
 
     file_mode = mode_for_text_materialization(
         str(file_meta.get("mode", "100644")),
         selected_ids,
         destination_exists=working_exists,
     )
-    if selected_ids is None and text_change_type == TextFileChangeType.DELETED:
+    if not apply_text_plan_requires_source(file_meta, selected_ids):
         return ApplyTextPlanBuildResult(
             plan=_action_plans.ApplyTextFileActionPlan(
                 file_path,
@@ -91,46 +112,86 @@ def build_apply_text_file_action_plan(
         )
 
     batch_source_commit = file_meta["batch_source_commit"]
-    batch_source_buffer = read_git_object_buffer_or_none(
-        f"{batch_source_commit}:{file_path}"
-    )
+    if batch_source_object_id is None:
+        batch_source_spec = f"{batch_source_commit}:{file_path}"
+        batch_source_buffer = (
+            read_git_object_buffer_or_none(batch_source_spec)
+            if spool_dir is None
+            else read_git_object_buffer_or_none(
+                batch_source_spec,
+                spool_dir=spool_dir,
+            )
+        )
+    else:
+        batch_source_buffer = load_git_blob_as_buffer(
+            batch_source_object_id,
+            spool_dir=spool_dir,
+        )
     if batch_source_buffer is None:
         return ApplyTextPlanBuildResult(missing_source=True)
 
-    with (
-        batch_source_buffer as batch_source_lines,
-        load_working_tree_file_as_buffer(file_path) as working_lines,
-    ):
+    with ExitStack() as stack:
+        batch_source_lines = stack.enter_context(batch_source_buffer)
+        if working_tree_artifact_path is None:
+            working_tree_buffer = (
+                load_working_tree_file_as_buffer(file_path)
+                if spool_dir is None
+                else load_working_tree_file_as_buffer(
+                    file_path,
+                    spool_dir=spool_dir,
+                )
+            )
+        else:
+            working_tree_buffer = LineBuffer.from_path(
+                working_tree_artifact_path,
+                spool_dir=spool_dir,
+            )
+        working_lines = stack.enter_context(working_tree_buffer)
+        ownership_arguments = {}
+        if spool_dir is not None:
+            ownership_arguments["spool_dir"] = spool_dir
         with acquire_batch_ownership_for_display_ids_from_lines(
             file_meta,
             batch_source_lines,
             selection_ids_to_apply,
+            **ownership_arguments,
         ) as ownership:
             if ownership.is_empty():
                 if selected_ids is None and text_change_type == TextFileChangeType.ADDED:
-                    merged_buffer = LineBuffer.from_bytes(b"")
+                    merged_buffer = LineBuffer.from_bytes(
+                        b"",
+                        spool_dir=spool_dir,
+                    )
                 else:
                     return ApplyTextPlanBuildResult()
             else:
+                merge_arguments = {}
+                if spool_dir is not None:
+                    merge_arguments["spool_dir"] = spool_dir
                 merged_buffer = merge_batch_from_line_sequences_as_buffer(
                     batch_source_lines,
                     ownership,
                     working_lines,
+                    **merge_arguments,
                 )
 
-    effective_change_type = selected_text_target_change_type(
-        text_change_type,
-        selected_ids,
-        merged_buffer,
-    )
-    return ApplyTextPlanBuildResult(
-        plan=_action_plans.ApplyTextFileActionPlan(
-            file_path,
+    try:
+        effective_change_type = selected_text_target_change_type(
+            text_change_type,
+            selected_ids,
             merged_buffer,
-            file_mode,
-            effective_change_type,
         )
-    )
+        return ApplyTextPlanBuildResult(
+            plan=_action_plans.ApplyTextFileActionPlan(
+                file_path,
+                merged_buffer,
+                file_mode,
+                effective_change_type,
+            )
+        )
+    except BaseException:
+        merged_buffer.close()
+        raise
 
 
 def build_include_text_file_action_plan(

--- a/src/git_stage_batch/commands/batch_source/text_plan_jobs.py
+++ b/src/git_stage_batch/commands/batch_source/text_plan_jobs.py
@@ -1,0 +1,298 @@
+"""Artifact-backed text planning for batch-source actions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import pickle
+from pathlib import Path
+from typing import Literal
+
+from . import candidate_preview_counts as _candidate_preview_counts
+from . import text_plan_builders as _text_plan_builders
+from ...core.buffer import write_buffer_to_path
+from ...data.file_target_identity import WorktreeIdentity
+from ...exceptions import AtomicUnitError, CommandError, MergeError
+
+
+ApplyTextPlanOutcome = Literal[
+    "plan",
+    "noop",
+    "missing_source",
+    "merge_error",
+    "atomic_unit_error",
+    "command_error",
+    "unexpected_error",
+]
+_DETAIL_OUTCOMES = frozenset({
+    "merge_error",
+    "atomic_unit_error",
+    "command_error",
+    "unexpected_error",
+})
+_EMPTY_OUTCOMES = frozenset({
+    "noop",
+    "missing_source",
+})
+_TEXT_CHANGE_TYPES = frozenset({
+    "added",
+    "modified",
+    "deleted",
+})
+
+
+@dataclass(frozen=True, slots=True)
+class ApplyTextPlanJob:
+    """Compact worker request for one text apply plan."""
+
+    ordinal: int
+    file_path: str
+    input_artifact_path: str
+    output_path: str
+    details_artifact_path: str
+    expected_worktree_identity: WorktreeIdentity
+
+
+@dataclass(frozen=True, slots=True)
+class ApplyTextPlanJobResult:
+    """Compact worker result for one text apply plan."""
+
+    ordinal: int
+    file_path: str
+    outcome: ApplyTextPlanOutcome
+    details_artifact_path: str | None
+    output_path: str | None
+    file_mode: str | None
+    change_type: str | None
+
+
+def compute_apply_text_plan_job(
+    job: ApplyTextPlanJob,
+) -> ApplyTextPlanJobResult:
+    """Build one text apply plan from immutable artifact inputs."""
+    input_metadata = _read_pickle(job.input_artifact_path)
+    if type(input_metadata) is not dict:
+        raise TypeError("apply text-plan input must be a dictionary")
+    file_meta = input_metadata["file_meta"]
+    selected_ids = _optional_int_set(input_metadata["selected_ids"])
+    selection_ids = _optional_int_set(input_metadata["selection_ids"])
+    working_tree_artifact_path = input_metadata["working_tree_artifact_path"]
+    scratch_directory = input_metadata["scratch_directory"]
+    batch_name = input_metadata["batch_name"]
+    batch_source_object_id = input_metadata["batch_source_object_id"]
+    batch_source_required = apply_text_plan_requires_source(
+        file_meta,
+        selected_ids,
+    )
+    working_tree_exists = job.expected_worktree_identity.exists
+    if batch_source_required and batch_source_object_id is None:
+        return _result(job, "missing_source")
+
+    try:
+        build_result = _text_plan_builders.build_apply_text_file_action_plan(
+            file_path=job.file_path,
+            file_meta=file_meta,
+            selected_ids=selected_ids,
+            selection_ids_to_apply=selection_ids,
+            batch_source_object_id=batch_source_object_id,
+            working_tree_artifact_path=working_tree_artifact_path,
+            captured_working_tree_exists=working_tree_exists,
+            spool_dir=scratch_directory,
+        )
+        if build_result.missing_source:
+            return _result(job, "missing_source")
+        if build_result.plan is None:
+            return _result(job, "noop")
+
+        plan = build_result.plan
+        try:
+            change_type = getattr(plan.change_type, "value", plan.change_type)
+            output_path = None
+            if plan.buffer is not None and change_type != "deleted":
+                write_buffer_to_path(job.output_path, plan.buffer)
+                output_path = job.output_path
+            return _result(
+                job,
+                "plan",
+                output_path=output_path,
+                file_mode=plan.file_mode,
+                change_type=change_type,
+            )
+        finally:
+            plan.close()
+    except AtomicUnitError as error:
+        _write_pickle(
+            job.details_artifact_path,
+            {
+                "message": str(error),
+                "required_selection_ids": (
+                    None
+                    if error.required_selection_ids is None
+                    else sorted(error.required_selection_ids)
+                ),
+                "unit_kind": error.unit_kind,
+            },
+        )
+        return _result(job, "atomic_unit_error", has_details=True)
+    except MergeError:
+        candidate_count = (
+            _candidate_preview_counts.count_apply_candidate_previews_for_file(
+                batch_name=batch_name,
+                file_path=job.file_path,
+                file_meta=file_meta,
+                selection_ids_to_apply=selection_ids,
+                batch_source_object_id=batch_source_object_id,
+                working_tree_artifact_path=working_tree_artifact_path,
+                captured_working_tree_exists=working_tree_exists,
+                spool_dir=scratch_directory,
+            )
+        )
+        _write_pickle(
+            job.details_artifact_path,
+            {
+                "candidate_count": candidate_count.count,
+                "candidate_too_many": candidate_count.too_many,
+                "candidate_error": candidate_count.error,
+            },
+        )
+        return _result(job, "merge_error", has_details=True)
+    except CommandError as error:
+        _write_pickle(
+            job.details_artifact_path,
+            {
+                "message": error.message,
+                "exit_code": error.exit_code,
+            },
+        )
+        return _result(job, "command_error", has_details=True)
+    except Exception as error:
+        _write_pickle(
+            job.details_artifact_path,
+            {
+                "message": str(error),
+                "error_type": type(error).__name__,
+            },
+        )
+        return _result(job, "unexpected_error", has_details=True)
+
+
+def apply_text_plan_requires_source(
+    file_meta: dict,
+    selected_ids: set[int] | None,
+) -> bool:
+    """Return whether one apply text plan needs batch source content."""
+    return _text_plan_builders.apply_text_plan_requires_source(
+        file_meta,
+        selected_ids,
+    )
+
+
+def validate_apply_text_plan_job_result(
+    job: ApplyTextPlanJob,
+    result: ApplyTextPlanJobResult,
+) -> None:
+    """Validate one worker result before the parent opens artifacts or mutates."""
+    if not isinstance(result, ApplyTextPlanJobResult):
+        raise TypeError("apply text-plan worker returned an invalid result")
+    if result.ordinal != job.ordinal or result.file_path != job.file_path:
+        raise ValueError(
+            f"apply text-plan worker returned a mismatched result for "
+            f"{job.file_path}"
+        )
+    if result.file_mode is not None and not isinstance(result.file_mode, str):
+        raise TypeError("apply text-plan result file mode must be text")
+    if result.change_type is not None and not isinstance(
+        result.change_type,
+        str,
+    ):
+        raise TypeError("apply text-plan result change type must be text")
+
+    if result.outcome == "plan":
+        if result.details_artifact_path is not None:
+            raise ValueError("successful apply text plan returned error details")
+        if result.change_type is None:
+            raise ValueError("successful apply text plan omitted its change type")
+        if result.change_type not in _TEXT_CHANGE_TYPES:
+            raise ValueError(
+                "successful apply text plan returned an invalid change type"
+            )
+        expected_output_path = (
+            None
+            if result.change_type == "deleted"
+            else job.output_path
+        )
+        if result.output_path != expected_output_path:
+            raise ValueError(
+                f"apply text-plan worker returned an invalid output path for "
+                f"{job.file_path}"
+            )
+        return
+
+    if result.outcome in _DETAIL_OUTCOMES:
+        if result.details_artifact_path != job.details_artifact_path:
+            raise ValueError(
+                f"apply text-plan worker returned an invalid details path for "
+                f"{job.file_path}"
+            )
+    elif result.outcome in _EMPTY_OUTCOMES:
+        if result.details_artifact_path is not None:
+            raise ValueError(
+                f"apply text-plan worker returned unexpected details for "
+                f"{job.file_path}"
+            )
+    else:
+        raise ValueError(
+            f"apply text-plan worker returned an unknown outcome for "
+            f"{job.file_path}"
+        )
+
+    if (
+        result.output_path is not None
+        or result.file_mode is not None
+        or result.change_type is not None
+    ):
+        raise ValueError(
+            f"apply text-plan worker returned plan fields for "
+            f"{job.file_path} without a plan"
+        )
+
+
+def _result(
+    job: ApplyTextPlanJob,
+    outcome: ApplyTextPlanOutcome,
+    *,
+    has_details: bool = False,
+    output_path: str | None = None,
+    file_mode: str | None = None,
+    change_type: str | None = None,
+) -> ApplyTextPlanJobResult:
+    return ApplyTextPlanJobResult(
+        ordinal=job.ordinal,
+        file_path=job.file_path,
+        outcome=outcome,
+        details_artifact_path=(
+            job.details_artifact_path if has_details else None
+        ),
+        output_path=output_path,
+        file_mode=file_mode,
+        change_type=change_type,
+    )
+
+
+def _optional_int_set(value: object) -> set[int] | None:
+    if value is None:
+        return None
+    if not isinstance(value, (list, tuple, set, frozenset)):
+        raise TypeError("selected identifiers must be a collection")
+    if any(type(item) is not int for item in value):
+        raise TypeError("selected identifiers must be integers")
+    return set(value)
+
+
+def _read_pickle(path: str | Path):
+    with Path(path).open("rb") as source:
+        return pickle.load(source)
+
+
+def _write_pickle(path: str | Path, value: object) -> None:
+    with Path(path).open("xb") as output:
+        pickle.dump(value, output, protocol=pickle.HIGHEST_PROTOCOL)

--- a/src/git_stage_batch/data/file_target_identity.py
+++ b/src/git_stage_batch/data/file_target_identity.py
@@ -1,0 +1,241 @@
+"""Stable identities for worktree and index mutation targets."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+import hashlib
+import os
+from pathlib import Path
+import stat
+import subprocess
+
+from .index_entries import IndexEntry
+from ..exceptions import RepositoryDataInvalid, RepositoryPathInaccessible
+from ..utils.git_command import stream_git_command_bytes
+from ..utils.git_repository import (
+    get_git_repository_root_path,
+    is_git_repository_root_path,
+)
+
+
+_DIGEST_CHUNK_SIZE = 1024 * 1024
+
+
+@dataclass(frozen=True, slots=True)
+class WorktreeIdentity:
+    """Content-bearing identity for one worktree mutation target."""
+
+    exists: bool
+    kind: str
+    mode: int | None
+    size: int | None
+    digest: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class IndexIdentity:
+    """Stage-zero identity for one index mutation target."""
+
+    mode: str | None
+    object_id: str | None
+
+
+def index_identity_from_entry(entry: IndexEntry | None) -> IndexIdentity:
+    """Convert an optional stage-zero entry to its compact identity."""
+    if entry is None:
+        return IndexIdentity(None, None)
+    return IndexIdentity(entry.mode, entry.object_id)
+
+
+def capture_worktree_identity(
+    file_path: str,
+    *,
+    content_artifact_path: str | Path | None = None,
+) -> WorktreeIdentity:
+    """Capture a target identity and optionally spool its exact text bytes."""
+    repository_root = get_git_repository_root_path()
+    target_path = repository_root / file_path
+    artifact_path = (
+        None if content_artifact_path is None else Path(content_artifact_path)
+    )
+    try:
+        metadata = target_path.lstat()
+    except FileNotFoundError:
+        _write_empty_artifact(artifact_path)
+        return WorktreeIdentity(False, "missing", None, None, None)
+    except NotADirectoryError:
+        _write_empty_artifact(artifact_path)
+        return WorktreeIdentity(False, "obstructed", None, None, None)
+    except OSError as error:
+        raise RepositoryPathInaccessible(
+            f"Could not inspect working-tree path {file_path!r}"
+        ) from error
+
+    mode = stat.S_IMODE(metadata.st_mode)
+    if stat.S_ISREG(metadata.st_mode):
+        return _capture_regular_identity(
+            file_path,
+            target_path,
+            metadata,
+            artifact_path=artifact_path,
+            mode=mode,
+        )
+    if stat.S_ISLNK(metadata.st_mode):
+        try:
+            content = os.readlink(os.fsencode(target_path))
+        except OSError as error:
+            raise RepositoryPathInaccessible(
+                f"Could not read working-tree path {file_path!r}"
+            ) from error
+        _write_artifact_bytes(artifact_path, content)
+        return WorktreeIdentity(
+            True,
+            "symlink",
+            mode,
+            len(content),
+            hashlib.sha256(content).hexdigest(),
+        )
+    if stat.S_ISDIR(metadata.st_mode):
+        if artifact_path is not None:
+            raise RepositoryDataInvalid(
+                f"Unsupported working-tree path kind: {file_path}"
+            )
+        return WorktreeIdentity(
+            True,
+            "directory",
+            mode,
+            None,
+            (
+                _submodule_state_digest(target_path)
+                if is_git_repository_root_path(target_path)
+                else None
+            ),
+        )
+    raise RepositoryDataInvalid(
+        f"Unsupported working-tree path kind: {file_path}"
+    )
+
+
+def capture_worktree_identities(
+    file_paths: Iterable[str],
+) -> dict[str, WorktreeIdentity]:
+    """Capture identities in input order for a set of mutation targets."""
+    return {
+        file_path: capture_worktree_identity(file_path)
+        for file_path in dict.fromkeys(file_paths)
+    }
+
+
+def _capture_regular_identity(
+    file_path: str,
+    target_path: Path,
+    expected_metadata: os.stat_result,
+    *,
+    artifact_path: Path | None,
+    mode: int,
+) -> WorktreeIdentity:
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor = None
+    output = None
+    digest = hashlib.sha256()
+    byte_count = 0
+    try:
+        descriptor = os.open(target_path, flags)
+        opened_metadata = os.fstat(descriptor)
+        if not _same_opened_file(expected_metadata, opened_metadata):
+            raise RepositoryPathInaccessible(
+                f"Working-tree path changed while being captured: {file_path!r}"
+            )
+        if artifact_path is not None:
+            output = artifact_path.open("xb")
+        while True:
+            chunk = os.read(descriptor, _DIGEST_CHUNK_SIZE)
+            if not chunk:
+                break
+            digest.update(chunk)
+            byte_count += len(chunk)
+            if output is not None:
+                output.write(chunk)
+        final_metadata = os.fstat(descriptor)
+        if not _same_opened_file(opened_metadata, final_metadata):
+            raise RepositoryPathInaccessible(
+                f"Working-tree path changed while being captured: {file_path!r}"
+            )
+    except OSError as error:
+        raise RepositoryPathInaccessible(
+            f"Could not read working-tree path {file_path!r}"
+        ) from error
+    finally:
+        try:
+            if output is not None:
+                output.close()
+        finally:
+            if descriptor is not None:
+                os.close(descriptor)
+    return WorktreeIdentity(
+        True,
+        "regular",
+        mode,
+        byte_count,
+        digest.hexdigest(),
+    )
+
+
+def _same_opened_file(
+    left: os.stat_result,
+    right: os.stat_result,
+) -> bool:
+    return (
+        left.st_dev,
+        left.st_ino,
+        left.st_mode,
+        left.st_size,
+        left.st_mtime_ns,
+        left.st_ctime_ns,
+    ) == (
+        right.st_dev,
+        right.st_ino,
+        right.st_mode,
+        right.st_size,
+        right.st_mtime_ns,
+        right.st_ctime_ns,
+    )
+
+
+def _submodule_state_digest(path: Path) -> str:
+    digest = hashlib.sha256()
+    for arguments in (
+        ("rev-parse", "--verify", "HEAD^{commit}"),
+        ("status", "--porcelain=v1", "-z", "--untracked-files=all"),
+    ):
+        returncode = 0
+        try:
+            for chunk in stream_git_command_bytes(
+                list(arguments),
+                cwd=str(path),
+                requires_index_lock=False,
+            ):
+                digest.update(chunk)
+        except subprocess.CalledProcessError as error:
+            returncode = error.returncode
+        digest.update(b"\0")
+        digest.update(str(returncode).encode("ascii"))
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def _write_empty_artifact(path: Path | None) -> None:
+    if path is None:
+        return
+    with path.open("xb"):
+        pass
+
+
+def _write_artifact_bytes(path: Path | None, content: bytes) -> None:
+    if path is None:
+        return
+    with path.open("xb") as output:
+        output.write(content)

--- a/src/git_stage_batch/utils/file_job_workspace.py
+++ b/src/git_stage_batch/utils/file_job_workspace.py
@@ -20,7 +20,7 @@ import stat
 import tempfile
 from typing import Any
 
-from ..core.buffer import BufferInput, write_buffer_to_path
+from ..core.buffer import BufferInput, LineBuffer, write_buffer_to_path
 
 
 _STANDARD_PATH_TYPES = frozenset({
@@ -96,6 +96,19 @@ class FileJobWorkspace(AbstractContextManager["FileJobWorkspace"]):
         path = self.artifact_path(ordinal, name)
         write_buffer_to_path(path, buffer)
         return path
+
+    def read_buffer(
+        self,
+        path: str | Path,
+        *,
+        spool_dir: str | Path | None = None,
+    ) -> LineBuffer:
+        """Open a regular workspace artifact as a path-backed line buffer."""
+        artifact_path = self._require_regular_workspace_file(path)
+        return LineBuffer.from_path(
+            artifact_path,
+            spool_dir=spool_dir,
+        )
 
     def write_json(
         self,

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -13790,6 +13790,9 @@ def test_batch_source_text_plan_builders_own_apply_text_planning():
         fromlist=["text_plan_builders"],
     )
     apply_action_path = SRC_ROOT / "commands" / "batch_source" / "apply_action.py"
+    text_plan_jobs_path = (
+        SRC_ROOT / "commands" / "batch_source" / "text_plan_jobs.py"
+    )
     public_names = {
         "ApplyTextPlanBuildResult",
         "build_apply_text_file_action_plan",
@@ -13821,7 +13824,7 @@ def test_batch_source_text_plan_builders_own_apply_text_planning():
     imports_text_plan_builders = False
     direct_plan_imports = set()
 
-    for imported_module, node in _import_from_nodes(apply_action_path):
+    for imported_module, node in _import_from_nodes(text_plan_jobs_path):
         imported_names = {alias.name for alias in node.names}
         if (
             imported_module == "git_stage_batch.commands.batch_source"
@@ -13834,11 +13837,13 @@ def test_batch_source_text_plan_builders_own_apply_text_planning():
         )
 
     action_text = apply_action_path.read_text()
+    job_text = text_plan_jobs_path.read_text()
 
     assert public_names <= vars(text_plan_builders).keys()
     assert imports_text_plan_builders
     assert direct_plan_imports == set()
-    assert "build_apply_text_file_action_plan(" in action_text
+    assert "build_apply_text_file_action_plan(" in job_text
+    assert "build_apply_text_file_action_plan(" not in action_text
     assert "merge_batch_from_line_sequences_as_buffer(" not in action_text
     assert "selected_text_target_change_type(" not in action_text
 
@@ -14323,6 +14328,9 @@ def test_batch_source_candidate_preview_counts_own_failure_enumeration():
     )
     SRC_ROOT / "commands" / "apply_from.py"
     apply_action_path = SRC_ROOT / "commands" / "batch_source" / "apply_action.py"
+    text_plan_jobs_path = (
+        SRC_ROOT / "commands" / "batch_source" / "text_plan_jobs.py"
+    )
     SRC_ROOT / "commands" / "include_from.py"
     include_action_path = (
         SRC_ROOT / "commands" / "batch_source" / "include_action.py"
@@ -14343,7 +14351,10 @@ def test_batch_source_candidate_preview_counts_own_failure_enumeration():
         "CandidateEnumerationLimitError",
         "CandidatePreviewCount",
     }
-    command_paths = set(old_function_names)
+    command_paths = {
+        text_plan_jobs_path,
+        include_action_path,
+    }
     imports_candidate_preview_counts = {
         path: False
         for path in command_paths
@@ -14352,15 +14363,18 @@ def test_batch_source_candidate_preview_counts_own_failure_enumeration():
         path: set()
         for path in command_paths
     }
-    helper_names = {}
-
-    for path in command_paths:
-        tree = ast.parse(path.read_text(), filename=str(path))
-        helper_names[path] = {
+    helper_names = {
+        path: {
             node.name
-            for node in ast.walk(tree)
+            for node in ast.walk(
+                ast.parse(path.read_text(), filename=str(path))
+            )
             if isinstance(node, ast.FunctionDef)
         }
+        for path in old_function_names
+    }
+
+    for path in command_paths:
         for imported_module, node in _import_from_nodes(path):
             imported_names = {alias.name for alias in node.names}
             if (
@@ -14373,11 +14387,11 @@ def test_batch_source_candidate_preview_counts_own_failure_enumeration():
 
     assert public_names <= vars(candidate_preview_counts).keys()
     assert imports_candidate_preview_counts == {
-        apply_action_path: True,
+        text_plan_jobs_path: True,
         include_action_path: True,
     }
     assert direct_count_imports == {
-        apply_action_path: set(),
+        text_plan_jobs_path: set(),
         include_action_path: set(),
     }
     for path, old_names in old_function_names.items():
@@ -15154,16 +15168,18 @@ def test_batch_source_apply_action_owns_apply_execution():
         ("git_stage_batch.commands.batch_source", "action_plans"),
         ("git_stage_batch.commands.batch_source", "atomic_unit_refusals"),
         ("git_stage_batch.commands.batch_source", "binary_file_actions"),
-        ("git_stage_batch.commands.batch_source", "candidate_preview_counts"),
         ("git_stage_batch.commands.batch_source", "candidate_refusals"),
         ("git_stage_batch.commands.batch_source", "merge_refusals"),
         ("git_stage_batch.commands.batch_source", "text_file_actions"),
-        ("git_stage_batch.commands.batch_source", "text_plan_builders"),
+        ("git_stage_batch.commands.batch_source", "text_plan_jobs"),
         ("git_stage_batch.commands.batch_source", "worktree_refusals"),
         ("git_stage_batch.batch.binary_file_content", "read_binary_file_from_batch"),
         ("git_stage_batch.batch.submodule_pointer", "apply_submodule_pointer_from_batch"),
+        ("git_stage_batch.data.file_target_identity", "capture_worktree_identity"),
         ("git_stage_batch.data.session", "snapshot_file_if_untracked"),
         ("git_stage_batch.data.undo_checkpoints", "undo_checkpoint"),
+        ("git_stage_batch.utils.file_jobs", "run_file_jobs"),
+        ("git_stage_batch.utils.file_job_workspace", "FileJobWorkspace"),
     }
     action_imports = set()
 
@@ -15175,10 +15191,48 @@ def test_batch_source_apply_action_owns_apply_execution():
 
     assert public_names <= vars(apply_action).keys()
     assert required_imports <= action_imports
-    assert "build_apply_text_file_action_plan(" in action_text
+    assert "compute_apply_text_plan_job" in action_text
+    assert "build_apply_text_file_action_plan(" not in action_text
     assert "write_text_file_to_worktree(" in action_text
     assert "write_binary_file_to_worktree(" in action_text
     assert "finish_batch_source_action_review(" in action_text
+
+
+def test_apply_text_jobs_do_not_bypass_command_or_git_boundaries():
+    """Apply workers should use shared execution helpers and never spawn directly."""
+    paths = (
+        SRC_ROOT / "commands" / "batch_source" / "text_plan_jobs.py",
+        SRC_ROOT / "data" / "file_target_identity.py",
+    )
+    prohibited_calls = {
+        "Popen",
+        "run",
+        "call",
+        "check_call",
+        "check_output",
+    }
+    violations = []
+
+    for path in paths:
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            function = node.func
+            if (
+                isinstance(function, ast.Attribute)
+                and isinstance(function.value, ast.Name)
+                and function.value.id == "subprocess"
+                and function.attr in prohibited_calls
+            ):
+                violations.append(f"{path.relative_to(REPO_ROOT)}:{node.lineno}")
+            elif (
+                isinstance(function, ast.Name)
+                and function.id == "Popen"
+            ):
+                violations.append(f"{path.relative_to(REPO_ROOT)}:{node.lineno}")
+
+    assert violations == []
 
 
 def test_apply_from_delegates_apply_action_execution():

--- a/tests/batch/merge/test_merge.py
+++ b/tests/batch/merge/test_merge.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+import git_stage_batch.batch.merge.merge as merge_module
+import git_stage_batch.batch.realization.provenance as provenance_module
 from git_stage_batch.batch.merge.baseline_correspondence import (
     RegionKind,
     build_baseline_correspondence,
@@ -87,6 +89,52 @@ class _GuardedLine:
 
     def endswith(self, suffix):
         raise AssertionError("line endings should not be materialized")
+
+
+def test_merge_routes_mapping_and_output_storage_to_invocation_spool(
+    tmp_path,
+    monkeypatch,
+):
+    """Worker merge storage should remain beneath its job scratch directory."""
+    spool_dir = tmp_path / "scratch"
+    spool_dir.mkdir()
+    observed_spools = []
+    provenance_spools = []
+    original_match_lines = merge_module.match_lines
+    original_provenance_storage = (
+        provenance_module.ChunkedMappedRecordVector
+    )
+
+    def record_match(*args, **kwargs):
+        observed_spools.append(kwargs.get("spool_dir"))
+        return original_match_lines(*args, **kwargs)
+
+    def record_provenance_storage(*args, **kwargs):
+        provenance_spools.append(kwargs.get("spool_dir"))
+        return original_provenance_storage(*args, **kwargs)
+
+    monkeypatch.setattr(merge_module, "match_lines", record_match)
+    monkeypatch.setattr(
+        provenance_module,
+        "ChunkedMappedRecordVector",
+        record_provenance_storage,
+    )
+    ownership = BatchOwnership.from_presence_lines(["2"], [])
+    with (
+        LineBuffer.from_bytes(b"one\ninserted\n") as source,
+        LineBuffer.from_bytes(b"one\n") as target,
+        merge_batch_from_line_sequences_as_buffer(
+            source,
+            ownership,
+            target,
+            spool_dir=spool_dir,
+        ) as merged,
+    ):
+        assert merged.to_bytes() == b"one\ninserted\n"
+
+    assert observed_spools == [spool_dir]
+    assert provenance_spools
+    assert set(provenance_spools) == {spool_dir}
 
 
 def merge_batch(

--- a/tests/batch/ownership/test_metadata_loading.py
+++ b/tests/batch/ownership/test_metadata_loading.py
@@ -1,0 +1,43 @@
+"""Tests for scoped ownership metadata loading."""
+
+from git_stage_batch.batch.ownership import metadata_loading
+from git_stage_batch.core.buffer import LineBuffer
+
+
+def test_deletion_content_uses_the_requested_spool_directory(
+    tmp_path,
+    monkeypatch,
+):
+    """Worker-owned deletion buffers should stay in invocation scratch."""
+    calls = []
+    buffer = LineBuffer.from_bytes(b"deleted\n", spool_dir=tmp_path)
+
+    def load_blob(blob_sha, *, spool_dir=None):
+        calls.append((blob_sha, spool_dir))
+        return buffer
+
+    monkeypatch.setattr(
+        metadata_loading,
+        "load_git_blob_as_buffer",
+        load_blob,
+    )
+    monkeypatch.setattr(
+        metadata_loading,
+        "read_git_blobs_as_bytes",
+        lambda object_ids: {},
+    )
+
+    acquired = metadata_loading.acquire_ownership_for_metadata_dict(
+        {
+            "deletions": [
+                {
+                    "blob": "a" * 40,
+                    "after_source_line": 1,
+                }
+            ]
+        },
+        spool_dir=tmp_path,
+    )
+    acquired.close()
+
+    assert calls == [("a" * 40, tmp_path)]

--- a/tests/batch/test_operation_candidates.py
+++ b/tests/batch/test_operation_candidates.py
@@ -113,3 +113,127 @@ def test_target_candidate_materialization_clones_before_buffer(monkeypatch):
     finally:
         before.close()
         preview.close()
+
+
+def test_target_candidate_materialization_closes_clone_when_merge_fails(
+    monkeypatch,
+):
+    """A refused candidate merge should release its cloned before-buffer."""
+    before = LineBuffer.from_bytes(b"before\n")
+    source = LineBuffer.from_bytes(b"source\n")
+    clones = []
+    real_clone = LineBuffer.clone
+
+    def record_clone(buffer, *, spool_dir=None):
+        clone = real_clone(buffer, spool_dir=spool_dir)
+        clones.append(clone)
+        return clone
+
+    monkeypatch.setattr(LineBuffer, "clone", record_clone)
+    monkeypatch.setattr(
+        operation_candidates,
+        "merge_batch_from_line_sequences_as_buffer",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            RuntimeError("merge failed")
+        ),
+    )
+
+    try:
+        with pytest.raises(RuntimeError, match="merge failed"):
+            operation_candidates._materialize_target_candidate(
+                target="worktree",
+                file_path="notes.txt",
+                source_lines=source,
+                ownership=object(),
+                before_lines=before,
+                candidate=None,
+                file_mode=None,
+                text_change_type=object(),
+                destination_exists=True,
+                selected_ids=None,
+            )
+
+        assert len(clones) == 1
+        with pytest.raises(ValueError, match="buffer is closed"):
+            _ = clones[0].byte_count
+    finally:
+        source.close()
+        before.close()
+
+
+def test_apply_candidate_build_closes_prior_previews_on_later_failure(
+    monkeypatch,
+):
+    """Partial candidate construction should not leak earlier previews."""
+
+    class _Target:
+        def __init__(self):
+            self.before_buffer = object()
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    first_target = _Target()
+    calls = 0
+
+    def materialize(**_kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return first_target
+        raise RuntimeError("second candidate failed")
+
+    monkeypatch.setattr(
+        operation_candidates,
+        "_merge_candidates_or_unambiguous",
+        lambda *args, **kwargs: (object(), object()),
+    )
+    monkeypatch.setattr(
+        operation_candidates,
+        "_materialize_target_candidate",
+        materialize,
+    )
+    monkeypatch.setattr(
+        operation_candidates,
+        "_fingerprint_batch",
+        lambda **kwargs: "batch",
+    )
+    monkeypatch.setattr(
+        operation_candidates,
+        "_fingerprint_scope",
+        lambda **kwargs: "scope",
+    )
+    monkeypatch.setattr(
+        operation_candidates,
+        "_fingerprint_target",
+        lambda *args: "target",
+    )
+    monkeypatch.setattr(
+        operation_candidates,
+        "_fingerprint_target_result",
+        lambda target: "result",
+    )
+    monkeypatch.setattr(
+        operation_candidates,
+        "_fingerprint_candidate_id",
+        lambda **kwargs: "candidate",
+    )
+
+    with pytest.raises(RuntimeError, match="second candidate failed"):
+        operation_candidates.build_apply_candidate_previews(
+            batch_name="batch",
+            file_path="notes.txt",
+            source_lines=object(),
+            ownership=object(),
+            worktree_lines=object(),
+            batch_source_commit="commit",
+            file_meta={},
+            text_change_type=object(),
+            worktree_file_mode=None,
+            worktree_exists=True,
+            selected_ids=None,
+            selection_ids=None,
+        )
+
+    assert first_target.closed

--- a/tests/commands/batch_source/test_candidate_preview_counts.py
+++ b/tests/commands/batch_source/test_candidate_preview_counts.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from contextlib import AbstractContextManager
 
+import pytest
+
 from git_stage_batch.batch.operation_candidate_types import (
     CandidateEnumerationLimitError,
     CandidatePreviewCount,
@@ -198,6 +200,65 @@ def test_count_apply_candidate_previews_for_file_reports_limit(
     )
 
     assert result == CandidatePreviewCount(too_many=True, error="too many")
+
+
+def test_count_apply_candidate_previews_closes_source_when_target_load_fails(
+    monkeypatch,
+    tmp_path,
+):
+    """Candidate failure details should not leave the exact source open."""
+    batch_buffer = LineBuffer.from_bytes(b"batch\n")
+    monkeypatch.setattr(
+        counts,
+        "load_git_blob_as_buffer",
+        lambda object_id, spool_dir=None: batch_buffer,
+    )
+
+    result = counts.count_apply_candidate_previews_for_file(
+        batch_name="cleanup",
+        file_path="notes.txt",
+        file_meta={
+            "batch_source_commit": "commit",
+            "change_type": "modified",
+            "mode": "100644",
+        },
+        selection_ids_to_apply=None,
+        batch_source_object_id="a" * 40,
+        working_tree_artifact_path=tmp_path / "missing",
+        captured_working_tree_exists=True,
+    )
+
+    assert result.error
+    with pytest.raises(ValueError, match="buffer is closed"):
+        _ = batch_buffer.byte_count
+
+
+def test_count_apply_candidate_previews_reports_exact_source_read_failure(
+    monkeypatch,
+):
+    """A candidate diagnostic read failure should remain a scalar result."""
+    monkeypatch.setattr(
+        counts,
+        "load_git_blob_as_buffer",
+        lambda object_id, spool_dir=None: (_ for _ in ()).throw(
+            RuntimeError("object read failed")
+        ),
+    )
+
+    result = counts.count_apply_candidate_previews_for_file(
+        batch_name="cleanup",
+        file_path="notes.txt",
+        file_meta={
+            "batch_source_commit": "commit",
+            "change_type": "modified",
+            "mode": "100644",
+        },
+        selection_ids_to_apply=None,
+        batch_source_object_id="a" * 40,
+        captured_working_tree_exists=True,
+    )
+
+    assert result == CandidatePreviewCount(error="object read failed")
 
 
 def test_count_include_candidate_previews_for_file_counts_replacements(

--- a/tests/commands/batch_source/test_text_plan_builders.py
+++ b/tests/commands/batch_source/test_text_plan_builders.py
@@ -212,6 +212,42 @@ def test_build_apply_text_file_action_plan_returns_merged_plan(
     result.plan.close()
 
 
+def test_build_apply_text_file_action_plan_closes_merge_on_lifecycle_failure(
+    monkeypatch,
+    tmp_path,
+):
+    """A lifecycle failure should release the completed merge buffer."""
+    _patch_apply_text_plan_io(monkeypatch, tmp_path, _Ownership())
+    merged_buffer = LineBuffer.from_bytes(b"merged\n")
+    monkeypatch.setattr(
+        builders,
+        "merge_batch_from_line_sequences_as_buffer",
+        lambda *args, **kwargs: merged_buffer,
+    )
+    monkeypatch.setattr(
+        builders,
+        "selected_text_target_change_type",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            RuntimeError("lifecycle failed")
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="lifecycle failed"):
+        builders.build_apply_text_file_action_plan(
+            file_path="notes.txt",
+            file_meta={
+                "batch_source_commit": "commit",
+                "change_type": "modified",
+                "mode": "100644",
+            },
+            selected_ids=None,
+            selection_ids_to_apply=None,
+        )
+
+    with pytest.raises(ValueError, match="buffer is closed"):
+        _ = merged_buffer.byte_count
+
+
 def test_build_apply_text_file_action_plan_returns_deleted_plan(
     monkeypatch,
     tmp_path,
@@ -276,6 +312,36 @@ def test_build_apply_text_file_action_plan_reports_missing_source(
 
     assert result.missing_source
     assert result.plan is None
+
+
+def test_build_apply_text_file_action_plan_closes_source_when_target_load_fails(
+    monkeypatch,
+    tmp_path,
+):
+    """An artifact read failure should not retain the exact source buffer."""
+    batch_buffer = LineBuffer.from_bytes(b"batch\n")
+    monkeypatch.setattr(
+        builders,
+        "load_git_blob_as_buffer",
+        lambda object_id, spool_dir=None: batch_buffer,
+    )
+
+    with pytest.raises(FileNotFoundError):
+        builders.build_apply_text_file_action_plan(
+            file_path="notes.txt",
+            file_meta={
+                "batch_source_commit": "commit",
+                "change_type": "modified",
+                "mode": "100644",
+            },
+            selected_ids=None,
+            selection_ids_to_apply=None,
+            batch_source_object_id="a" * 40,
+            working_tree_artifact_path=tmp_path / "missing",
+        )
+
+    with pytest.raises(ValueError, match="buffer is closed"):
+        _ = batch_buffer.byte_count
 
 
 def test_build_apply_text_file_action_plan_skips_empty_partial_ownership(

--- a/tests/commands/batch_source/test_text_plan_jobs.py
+++ b/tests/commands/batch_source/test_text_plan_jobs.py
@@ -1,0 +1,522 @@
+"""Tests for artifact-backed apply text planning."""
+
+import pickle
+from pathlib import Path
+
+import pytest
+
+from git_stage_batch.commands.batch_source.action_plans import (
+    ApplyTextFileActionPlan,
+)
+from git_stage_batch.commands.batch_source.text_plan_builders import (
+    ApplyTextPlanBuildResult,
+)
+from git_stage_batch.commands.batch_source.text_plan_jobs import (
+    ApplyTextPlanJob,
+    ApplyTextPlanJobResult,
+    compute_apply_text_plan_job,
+    validate_apply_text_plan_job_result,
+)
+import git_stage_batch.commands.batch_source.apply_action as apply_action
+import git_stage_batch.commands.batch_source.text_plan_jobs as text_plan_jobs
+from git_stage_batch.core.buffer import LineBuffer
+from git_stage_batch.data.file_target_identity import WorktreeIdentity
+from git_stage_batch.exceptions import AtomicUnitError, CommandError
+from git_stage_batch.utils.file_job_workspace import FileJobWorkspace
+from git_stage_batch.utils.file_jobs import assert_file_job_transport_value
+
+
+def _job(
+    workspace,
+    *,
+    selected_ids=None,
+    batch_source_object_id="a" * 40,
+    change_type="modified",
+):
+    worktree_path = workspace.write_buffer(0, "worktree", (b"old\n",))
+    scratch = workspace.scratch_directory(0)
+    input_path = workspace.write_pickle(
+        0,
+        "input.pickle",
+        {
+            "batch_name": "batch",
+            "batch_source_object_id": batch_source_object_id,
+            "file_meta": {
+                "batch_source_commit": "b" * 40,
+                "change_type": change_type,
+            },
+            "selected_ids": selected_ids,
+            "selection_ids": selected_ids,
+            "working_tree_artifact_path": str(worktree_path),
+            "scratch_directory": str(scratch),
+        },
+    )
+    return ApplyTextPlanJob(
+        ordinal=0,
+        file_path="file.txt",
+        input_artifact_path=str(input_path),
+        output_path=str(workspace.output_path(0, "merged")),
+        details_artifact_path=str(workspace.output_path(0, "details")),
+        expected_worktree_identity=WorktreeIdentity(
+            True,
+            "regular",
+            0o644,
+            4,
+            "digest",
+        ),
+    )
+
+
+def test_compute_apply_keeps_value_errors_as_file_failures(
+    tmp_path,
+    monkeypatch,
+):
+    with FileJobWorkspace(parent_directory=tmp_path) as workspace:
+        job = _job(workspace)
+        monkeypatch.setattr(
+            text_plan_jobs._text_plan_builders,
+            "build_apply_text_file_action_plan",
+            lambda **_kwargs: (_ for _ in ()).throw(
+                ValueError("invalid apply target")
+            ),
+        )
+
+        result = compute_apply_text_plan_job(job)
+
+        assert result.outcome == "unexpected_error"
+        assert workspace.read_pickle(result.details_artifact_path) == {
+            "message": "invalid apply target",
+            "error_type": "ValueError",
+        }
+
+
+def test_compute_streams_plan_output_to_the_workspace(tmp_path, monkeypatch):
+    with FileJobWorkspace(parent_directory=tmp_path) as workspace:
+        job = _job(workspace)
+        captured = {}
+
+        def build_plan(**kwargs):
+            captured.update(kwargs)
+            return ApplyTextPlanBuildResult(
+                plan=ApplyTextFileActionPlan(
+                    "file.txt",
+                    LineBuffer.from_bytes(b"merged\n"),
+                    "100644",
+                    "modified",
+                )
+            )
+
+        monkeypatch.setattr(
+            text_plan_jobs._text_plan_builders,
+            "build_apply_text_file_action_plan",
+            build_plan,
+        )
+
+        result = compute_apply_text_plan_job(job)
+
+        assert result.outcome == "plan"
+        assert result.output_path == job.output_path
+        assert result.details_artifact_path is None
+        assert Path(job.output_path).read_bytes() == b"merged\n"
+        assert captured["batch_source_object_id"] == "a" * 40
+        assert captured["working_tree_artifact_path"].endswith("worktree")
+        assert captured["spool_dir"] == str(workspace.scratch_directory(0))
+
+
+def test_compute_records_atomic_refusal_details(tmp_path, monkeypatch):
+    with FileJobWorkspace(parent_directory=tmp_path) as workspace:
+        job = _job(workspace, selected_ids=[1])
+
+        def refuse(**_kwargs):
+            raise AtomicUnitError(
+                "select together",
+                required_selection_ids={1, 2},
+                unit_kind="replacement",
+            )
+
+        monkeypatch.setattr(
+            text_plan_jobs._text_plan_builders,
+            "build_apply_text_file_action_plan",
+            refuse,
+        )
+
+        result = compute_apply_text_plan_job(job)
+        details = workspace.read_pickle(result.details_artifact_path)
+
+        assert result.outcome == "atomic_unit_error"
+        assert details == {
+            "message": "select together",
+            "required_selection_ids": [1, 2],
+            "unit_kind": "replacement",
+        }
+
+
+def test_compute_allows_whole_file_deletion_without_source_content(
+    tmp_path,
+):
+    with FileJobWorkspace(parent_directory=tmp_path) as workspace:
+        job = _job(
+            workspace,
+            batch_source_object_id=None,
+            change_type="deleted",
+        )
+
+        result = compute_apply_text_plan_job(job)
+
+        assert result.outcome == "plan"
+        assert result.output_path is None
+        assert result.change_type == "deleted"
+
+
+def test_compute_does_not_publish_empty_partial_deletion_output(
+    tmp_path,
+    monkeypatch,
+):
+    with FileJobWorkspace(parent_directory=tmp_path) as workspace:
+        job = _job(workspace)
+
+        def build_plan(**_kwargs):
+            return ApplyTextPlanBuildResult(
+                plan=ApplyTextFileActionPlan(
+                    "file.txt",
+                    LineBuffer.from_bytes(b""),
+                    None,
+                    "deleted",
+                )
+            )
+
+        monkeypatch.setattr(
+            text_plan_jobs._text_plan_builders,
+            "build_apply_text_file_action_plan",
+            build_plan,
+        )
+
+        result = compute_apply_text_plan_job(job)
+
+        assert result.outcome == "plan"
+        assert result.output_path is None
+        assert result.change_type == "deleted"
+        assert not Path(job.output_path).exists()
+
+
+def test_result_validation_rejects_worker_selected_paths(tmp_path):
+    with FileJobWorkspace(parent_directory=tmp_path) as workspace:
+        job = _job(workspace)
+        result = ApplyTextPlanJobResult(
+            ordinal=job.ordinal,
+            file_path=job.file_path,
+            outcome="plan",
+            details_artifact_path=None,
+            output_path=str(tmp_path / "outside"),
+            file_mode="100644",
+            change_type="modified",
+        )
+
+        with pytest.raises(ValueError, match="invalid output path"):
+            validate_apply_text_plan_job_result(job, result)
+
+
+def test_result_validation_rejects_mismatched_target(tmp_path):
+    with FileJobWorkspace(parent_directory=tmp_path) as workspace:
+        job = _job(workspace)
+        result = ApplyTextPlanJobResult(
+            ordinal=job.ordinal,
+            file_path="other.txt",
+            outcome="noop",
+            details_artifact_path=None,
+            output_path=None,
+            file_mode=None,
+            change_type=None,
+        )
+
+        with pytest.raises(ValueError, match="mismatched result"):
+            validate_apply_text_plan_job_result(job, result)
+
+
+def test_result_validation_rejects_stale_apply_worker_outcome(tmp_path):
+    with FileJobWorkspace(parent_directory=tmp_path) as workspace:
+        job = _job(workspace)
+        result = ApplyTextPlanJobResult(
+            ordinal=job.ordinal,
+            file_path=job.file_path,
+            outcome="stale",
+            details_artifact_path=None,
+            output_path=None,
+            file_mode=None,
+            change_type=None,
+        )
+
+        with pytest.raises(ValueError, match="unknown outcome"):
+            validate_apply_text_plan_job_result(job, result)
+
+
+def test_parent_builds_whole_file_deletion_without_resolving_source(
+    tmp_path,
+    monkeypatch,
+):
+    identity = WorktreeIdentity(
+        True,
+        "regular",
+        0o644,
+        4,
+        "digest",
+    )
+    monkeypatch.setattr(
+        apply_action,
+        "capture_worktree_identity",
+        lambda *args, **kwargs: identity,
+    )
+    monkeypatch.setattr(
+        apply_action,
+        "list_git_tree_blobs",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("deletion resolved a source tree")
+        ),
+    )
+
+    def resolve_no_objects(object_names):
+        assert list(object_names) == []
+        return {}
+
+    monkeypatch.setattr(
+        apply_action,
+        "resolve_git_objects",
+        resolve_no_objects,
+    )
+
+    with FileJobWorkspace(parent_directory=tmp_path) as workspace:
+        plans, mode_actions, expected_identities = (
+            apply_action._build_apply_action_plans(
+                batch_name="batch",
+                files={
+                    "file.txt": {
+                        "change_type": "deleted",
+                        "mode": "100644",
+                    },
+                },
+                selected_ids=None,
+                selection_ids_to_apply=None,
+                rendered=None,
+                repository_root=tmp_path,
+                workspace=workspace,
+            )
+        )
+        try:
+            assert len(plans) == 1
+            assert plans[0].buffer is None
+            assert plans[0].change_type == "deleted"
+            assert mode_actions == []
+            assert expected_identities == {"file.txt": identity}
+        finally:
+            plans[0].close()
+
+
+def test_parent_reduces_earlier_text_refusal_before_reading_later_binary(
+    tmp_path,
+    monkeypatch,
+):
+    identity = WorktreeIdentity(
+        False,
+        "missing",
+        None,
+        None,
+        None,
+    )
+    monkeypatch.setattr(
+        apply_action,
+        "capture_worktree_identity",
+        lambda *args, **kwargs: identity,
+    )
+    monkeypatch.setattr(
+        apply_action,
+        "resolve_git_objects",
+        lambda object_names: {},
+    )
+    binary_reads = []
+
+    def read_binary(*args, **kwargs):
+        binary_reads.append((args, kwargs))
+        return None
+
+    monkeypatch.setattr(
+        apply_action,
+        "read_binary_file_from_batch",
+        read_binary,
+    )
+
+    def return_atomic_refusal(jobs, _compute, **_kwargs):
+        payload = jobs[0].payload
+        with Path(payload.details_artifact_path).open("xb") as output:
+            pickle.dump(
+                {
+                    "message": "select together",
+                    "required_selection_ids": [1, 2],
+                    "unit_kind": "replacement",
+                },
+                output,
+            )
+        return [
+            ApplyTextPlanJobResult(
+                ordinal=payload.ordinal,
+                file_path=payload.file_path,
+                outcome="atomic_unit_error",
+                details_artifact_path=payload.details_artifact_path,
+                output_path=None,
+                file_mode=None,
+                change_type=None,
+            )
+        ]
+
+    monkeypatch.setattr(
+        apply_action,
+        "run_file_jobs",
+        return_atomic_refusal,
+    )
+
+    with FileJobWorkspace(parent_directory=tmp_path) as workspace:
+        with pytest.raises(CommandError, match="select together"):
+            apply_action._build_apply_action_plans(
+                batch_name="batch",
+                files={
+                    "first.txt": {
+                        "change_type": "deleted",
+                        "mode": "100644",
+                    },
+                    "second.bin": {
+                        "file_type": "binary",
+                        "change_type": "deleted",
+                    },
+                },
+                selected_ids=None,
+                selection_ids_to_apply=None,
+                rendered=None,
+                repository_root=tmp_path,
+                workspace=workspace,
+            )
+
+    assert binary_reads == []
+
+
+def test_parent_rejects_stale_merge_diagnostics(
+    tmp_path,
+    monkeypatch,
+):
+    """Candidate diagnostics should describe the target that was captured."""
+    identity = WorktreeIdentity(
+        True,
+        "regular",
+        0o644,
+        4,
+        "before",
+    )
+    stale_identity = WorktreeIdentity(
+        True,
+        "regular",
+        0o644,
+        6,
+        "after",
+    )
+    identities = iter((identity, stale_identity))
+    monkeypatch.setattr(
+        apply_action,
+        "capture_worktree_identity",
+        lambda *args, **kwargs: next(identities),
+    )
+    monkeypatch.setattr(
+        apply_action,
+        "resolve_git_objects",
+        lambda object_names: {},
+    )
+
+    def return_merge_refusal(jobs, _compute, **_kwargs):
+        payload = jobs[0].payload
+        with Path(payload.details_artifact_path).open("xb") as output:
+            pickle.dump(
+                {
+                    "candidate_count": 2,
+                    "candidate_too_many": False,
+                    "candidate_error": None,
+                },
+                output,
+            )
+        return [
+            ApplyTextPlanJobResult(
+                ordinal=payload.ordinal,
+                file_path=payload.file_path,
+                outcome="merge_error",
+                details_artifact_path=payload.details_artifact_path,
+                output_path=None,
+                file_mode=None,
+                change_type=None,
+            )
+        ]
+
+    monkeypatch.setattr(
+        apply_action,
+        "run_file_jobs",
+        return_merge_refusal,
+    )
+
+    with FileJobWorkspace(parent_directory=tmp_path) as workspace:
+        with pytest.raises(CommandError, match="Retry the apply command"):
+            apply_action._build_apply_action_plans(
+                batch_name="batch",
+                files={
+                    "file.txt": {
+                        "change_type": "deleted",
+                        "mode": "100644",
+                    },
+                },
+                selected_ids=None,
+                selection_ids_to_apply=None,
+                rendered=None,
+                repository_root=tmp_path,
+                workspace=workspace,
+            )
+
+
+def test_transport_size_does_not_follow_selected_id_artifacts(tmp_path):
+    with FileJobWorkspace(parent_directory=tmp_path) as workspace:
+        small = _job(workspace, selected_ids=[1])
+        small_size = len(pickle.dumps(small))
+        large_ids = list(range(100_000))
+        large = _job(
+            workspace,
+            selected_ids=large_ids,
+        )
+        large_size = len(pickle.dumps(large))
+
+        assert_file_job_transport_value(small)
+        assert_file_job_transport_value(large)
+        assert abs(large_size - small_size) < 128
+
+
+def test_result_transport_size_does_not_follow_merged_content(
+    tmp_path,
+    monkeypatch,
+):
+    sizes = []
+    with FileJobWorkspace(parent_directory=tmp_path) as workspace:
+        for byte_count in (8, 2 * 1024 * 1024):
+            job = _job(workspace)
+
+            def build_plan(**_kwargs):
+                return ApplyTextPlanBuildResult(
+                    plan=ApplyTextFileActionPlan(
+                        "file.txt",
+                        LineBuffer.from_bytes(b"x" * byte_count),
+                        "100644",
+                        "modified",
+                    )
+                )
+
+            monkeypatch.setattr(
+                text_plan_jobs._text_plan_builders,
+                "build_apply_text_file_action_plan",
+                build_plan,
+            )
+            result = compute_apply_text_plan_job(job)
+            assert_file_job_transport_value(result)
+            sizes.append(len(pickle.dumps(result)))
+
+    assert abs(sizes[1] - sizes[0]) < 128

--- a/tests/commands/test_apply_from.py
+++ b/tests/commands/test_apply_from.py
@@ -1,6 +1,7 @@
 """Tests for apply from batch command."""
 
 import os
+import sys
 
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.commands.include import command_include_to_batch
@@ -15,9 +16,18 @@ import pytest
 import git_stage_batch.commands.batch_source.apply_action as apply_action
 from git_stage_batch.batch.state.lifecycle import create_batch
 from git_stage_batch.commands.apply_from import command_apply_from_batch
+from git_stage_batch.commands.redo import command_redo
+from git_stage_batch.commands.undo import command_undo
 from git_stage_batch.data.session import initialize_abort_state
 from git_stage_batch.exceptions import CommandError
 from git_stage_batch.utils.paths import ensure_state_directory_exists
+
+
+_RUNNING_UNDER_XDIST = "PYTEST_XDIST_WORKER" in os.environ
+_PROCESS_TEST = pytest.mark.skipif(
+    sys.platform != "linux" or _RUNNING_UNDER_XDIST,
+    reason="forced forkserver coverage runs on Linux with pytest -n 0",
+)
 
 
 @pytest.fixture
@@ -369,3 +379,157 @@ class TestCommandApplyFromBatch:
         # This should fail because it's a partial selection of a replacement
         with pytest.raises(CommandError, match="must be selected together"):
             command_apply_from_batch("atomic-batch", line_ids="1", file="file.txt")
+
+    def test_apply_aborts_before_checkpoint_when_target_changes_after_planning(
+        self,
+        temp_git_repo,
+        monkeypatch,
+    ):
+        """A stale planned target should prevent undo and worktree mutation."""
+        file_path = temp_git_repo / "file.txt"
+        file_path.write_text("base\n")
+        subprocess.run(
+            ["git", "add", "file.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add file"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        file_path.write_text("batch\n")
+        command_start(quiet=True)
+        command_include_to_batch("stale-batch", quiet=True)
+        file_path.write_text("base\n")
+        monkeypatch.setenv("GIT_STAGE_BATCH_JOBS", "1")
+
+        real_run_file_jobs = apply_action.run_file_jobs
+        real_workspace = apply_action.FileJobWorkspace
+        workspace_roots = []
+
+        def mutate_after_planning(*args, **kwargs):
+            results = real_run_file_jobs(*args, **kwargs)
+            file_path.write_text("concurrent\n")
+            return results
+
+        def record_workspace():
+            workspace = real_workspace()
+            workspace_roots.append(workspace.root)
+            return workspace
+
+        def checkpoint_must_not_start(*_args, **_kwargs):
+            raise AssertionError("undo checkpoint started for a stale target")
+
+        monkeypatch.setattr(
+            apply_action,
+            "run_file_jobs",
+            mutate_after_planning,
+        )
+        monkeypatch.setattr(
+            apply_action,
+            "FileJobWorkspace",
+            record_workspace,
+        )
+        monkeypatch.setattr(
+            apply_action,
+            "undo_checkpoint",
+            checkpoint_must_not_start,
+        )
+
+        with pytest.raises(CommandError, match="Retry the apply command"):
+            command_apply_from_batch("stale-batch")
+
+        assert file_path.read_text() == "concurrent\n"
+        assert workspace_roots
+        assert all(not root.exists() for root in workspace_roots)
+
+    @_PROCESS_TEST
+    def test_forced_process_apply_matches_inline_order_and_output(
+        self,
+        temp_git_repo,
+        monkeypatch,
+        capsys,
+    ):
+        """Forced transports should publish the same ordered apply result."""
+        baseline = {}
+        expected = {}
+        for index in range(4):
+            file_name = f"{index}.txt"
+            baseline[file_name] = f"base-{index}-" + "x" * 5000 + "\n"
+            expected[file_name] = f"batch-{index}-" + "y" * 5000 + "\n"
+            (temp_git_repo / file_name).write_text(baseline[file_name])
+        subprocess.run(
+            ["git", "add", "."],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add files"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        for file_name, content in expected.items():
+            (temp_git_repo / file_name).write_text(content)
+        command_start(quiet=True)
+        for file_name in expected:
+            command_include_to_batch(
+                "parallel-batch",
+                file=file_name,
+                quiet=True,
+            )
+        capsys.readouterr()
+        mapped_outputs = []
+        original_write = apply_action._text_file_actions.write_text_file_to_worktree
+
+        def record_mapped_output(file_path, buffer, file_mode, change_type):
+            mapped_outputs.append(buffer.uses_mapped_storage)
+            return original_write(
+                file_path,
+                buffer,
+                file_mode,
+                change_type,
+            )
+
+        monkeypatch.setattr(
+            apply_action._text_file_actions,
+            "write_text_file_to_worktree",
+            record_mapped_output,
+        )
+
+        observations = []
+        for requested_jobs in ("1", "2"):
+            for file_name, content in baseline.items():
+                (temp_git_repo / file_name).write_text(content)
+            monkeypatch.setenv("GIT_STAGE_BATCH_JOBS", requested_jobs)
+
+            command_apply_from_batch("parallel-batch")
+
+            observations.append(
+                (
+                    {
+                        file_name: (temp_git_repo / file_name).read_text()
+                        for file_name in expected
+                    },
+                    capsys.readouterr(),
+                )
+            )
+            command_undo(force=True)
+            assert {
+                file_name: (temp_git_repo / file_name).read_text()
+                for file_name in baseline
+            } == baseline
+            command_redo(force=True)
+            assert {
+                file_name: (temp_git_repo / file_name).read_text()
+                for file_name in expected
+            } == expected
+            capsys.readouterr()
+
+        assert observations[0] == observations[1]
+        assert observations[0][0] == expected
+        assert mapped_outputs == [True] * 8

--- a/tests/data/test_file_target_identity.py
+++ b/tests/data/test_file_target_identity.py
@@ -1,0 +1,195 @@
+"""Tests for stable mutation-target identities."""
+
+import pytest
+
+from git_stage_batch.data.file_target_identity import (
+    IndexIdentity,
+    WorktreeIdentity,
+    capture_worktree_identity,
+    index_identity_from_entry,
+)
+from git_stage_batch.data.index_entries import IndexEntry
+from git_stage_batch.exceptions import RepositoryDataInvalid
+import git_stage_batch.data.file_target_identity as identities
+
+
+def test_regular_identity_spools_the_hashed_bytes(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        identities,
+        "get_git_repository_root_path",
+        lambda: tmp_path,
+    )
+    target = tmp_path / "file.txt"
+    target.write_bytes(b"alpha\nbeta\n")
+    artifact = tmp_path / "artifact"
+
+    identity = capture_worktree_identity(
+        "file.txt",
+        content_artifact_path=artifact,
+    )
+
+    assert identity == WorktreeIdentity(
+        exists=True,
+        kind="regular",
+        mode=0o644,
+        size=11,
+        digest="e49c81e2d2f84e259d40e2fb8192f3bcd198b355184845d76d8f58807d0d78ee",
+    )
+    assert artifact.read_bytes() == b"alpha\nbeta\n"
+
+
+def test_symlink_identity_hashes_the_link_payload(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        identities,
+        "get_git_repository_root_path",
+        lambda: tmp_path,
+    )
+    (tmp_path / "link").symlink_to("target")
+    artifact = tmp_path / "artifact"
+
+    identity = capture_worktree_identity(
+        "link",
+        content_artifact_path=artifact,
+    )
+
+    assert identity.exists is True
+    assert identity.kind == "symlink"
+    assert identity.size == len(b"target")
+    assert artifact.read_bytes() == b"target"
+
+
+def test_missing_identity_writes_an_empty_text_artifact(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        identities,
+        "get_git_repository_root_path",
+        lambda: tmp_path,
+    )
+    artifact = tmp_path / "artifact"
+
+    identity = capture_worktree_identity(
+        "missing.txt",
+        content_artifact_path=artifact,
+    )
+
+    assert identity == WorktreeIdentity(False, "missing", None, None, None)
+    assert artifact.read_bytes() == b""
+
+
+def test_obstructed_identity_distinguishes_a_non_directory_parent(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        identities,
+        "get_git_repository_root_path",
+        lambda: tmp_path,
+    )
+    (tmp_path / "parent").write_text("not a directory")
+    artifact = tmp_path / "artifact"
+
+    identity = capture_worktree_identity(
+        "parent/file.txt",
+        content_artifact_path=artifact,
+    )
+
+    assert identity == WorktreeIdentity(
+        False,
+        "obstructed",
+        None,
+        None,
+        None,
+    )
+    assert artifact.read_bytes() == b""
+
+
+def test_directory_text_capture_preserves_the_worktree_kind_diagnostic(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        identities,
+        "get_git_repository_root_path",
+        lambda: tmp_path,
+    )
+    (tmp_path / "directory").mkdir()
+
+    with pytest.raises(
+        RepositoryDataInvalid,
+        match="Unsupported working-tree path kind: directory",
+    ):
+        capture_worktree_identity(
+            "directory",
+            content_artifact_path=tmp_path / "artifact",
+        )
+
+
+def test_directory_identity_uses_the_git_command_boundary(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        identities,
+        "get_git_repository_root_path",
+        lambda: tmp_path,
+    )
+    submodule = tmp_path / "sub"
+    submodule.mkdir()
+    calls = []
+    monkeypatch.setattr(
+        identities,
+        "is_git_repository_root_path",
+        lambda path: path == submodule,
+    )
+
+    def stream_git(arguments, **kwargs):
+        calls.append((arguments, kwargs))
+        yield b"state\0"
+
+    monkeypatch.setattr(identities, "stream_git_command_bytes", stream_git)
+
+    identity = capture_worktree_identity("sub")
+
+    assert identity.exists is True
+    assert identity.kind == "directory"
+    assert identity.digest is not None
+    assert [call[0] for call in calls] == [
+        ["rev-parse", "--verify", "HEAD^{commit}"],
+        ["status", "--porcelain=v1", "-z", "--untracked-files=all"],
+    ]
+    assert {call[1]["cwd"] for call in calls} == {str(submodule)}
+    assert all(call[1]["requires_index_lock"] is False for call in calls)
+
+
+def test_ordinary_directory_identity_does_not_digest_parent_repo_state(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        identities,
+        "get_git_repository_root_path",
+        lambda: tmp_path,
+    )
+    directory = tmp_path / "directory"
+    directory.mkdir()
+    monkeypatch.setattr(
+        identities,
+        "is_git_repository_root_path",
+        lambda path: False,
+    )
+    monkeypatch.setattr(
+        identities,
+        "stream_git_command_bytes",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("ordinary directory invoked Git")
+        ),
+    )
+
+    identity = capture_worktree_identity("directory")
+
+    assert identity.exists is True
+    assert identity.kind == "directory"
+    assert identity.digest is None
+
+
+def test_index_identity_converts_stage_zero_entries():
+    assert index_identity_from_entry(None) == IndexIdentity(None, None)
+    assert index_identity_from_entry(
+        IndexEntry("100755", "a" * 40)
+    ) == IndexIdentity("100755", "a" * 40)

--- a/tests/utils/test_file_job_workspace.py
+++ b/tests/utils/test_file_job_workspace.py
@@ -132,7 +132,7 @@ def test_workspace_streams_buffer_without_materializing_it(tmp_path, monkeypatch
         with FileJobWorkspace(parent_directory=tmp_path) as workspace:
             artifact = workspace.write_buffer(0, "input.patch", source)
 
-            with LineBuffer.from_path(
+            with workspace.read_buffer(
                 artifact,
                 spool_dir=workspace.scratch_directory(0),
             ) as written:


### PR DESCRIPTION
Multi-file apply currently plans text entries serially and reads mutation targets as each file is reached.

Concurrent planning needs immutable worktree and index inputs, invocation-owned storage, compact worker contracts, and deterministic reduction. Mutation must also remain gated on the exact targets captured before planning so a stale file cannot turn a prepared plan into a mixed-state update.

This pull request captures stable mutation identities and source artifacts, keeps merge and preview buffers under job-local storage, defines artifact-backed text-plan jobs, dispatches them through the shared ordered executor, and revalidates every target before atomic mutation begins.

Coverage verifies captured bytes and index identities, cleanup on partial failures, deletion behavior, result validation, process parity, ordered diagnostics, stale worktree and index refusals, and architecture boundaries. Apply planning remains deterministic while becoming eligible for bounded parallel execution.