### PR TITLE
index: Propagate entry lookup failures

### DIFF
--- a/src/git_stage_batch/data/index_entries.py
+++ b/src/git_stage_batch/data/index_entries.py
@@ -21,13 +21,11 @@ def read_index_entry(file_path: str) -> IndexEntry | None:
     """Return the exact index entry for a repository path."""
     result = run_git_command(
         ["ls-files", "--stage", "-z", "--", file_path],
-        check=False,
+        check=True,
         text_output=False,
         requires_index_lock=False,
         literal_pathspecs=True,
     )
-    if result.returncode != 0:
-        return None
 
     for record in result.stdout.split(b"\0"):
         if not record:
@@ -57,13 +55,11 @@ def read_index_entries(file_paths: Iterable[str]) -> dict[str, IndexEntry]:
         return {}
     result = run_git_command(
         ["ls-files", "--stage", "-z", "--", *unique_paths],
-        check=False,
+        check=True,
         text_output=False,
         requires_index_lock=False,
         literal_pathspecs=True,
     )
-    if result.returncode != 0:
-        return {}
 
     requested_paths = set(unique_paths)
     entries: dict[str, IndexEntry] = {}

--- a/tests/data/test_index_entries.py
+++ b/tests/data/test_index_entries.py
@@ -82,3 +82,17 @@ def test_reads_several_scoped_index_entries_in_one_lookup(temp_git_repo):
 
     assert set(entries) == {"one.txt", "two.txt"}
     assert all(entry.mode == "100644" for entry in entries.values())
+
+
+def test_single_entry_read_propagates_index_failure(temp_git_repo):
+    (temp_git_repo / ".git" / "index").write_bytes(b"invalid index")
+
+    with pytest.raises(subprocess.CalledProcessError):
+        read_index_entry("regular.txt")
+
+
+def test_bulk_entry_read_propagates_index_failure(temp_git_repo):
+    (temp_git_repo / ".git" / "index").write_bytes(b"invalid index")
+
+    with pytest.raises(subprocess.CalledProcessError):
+        read_index_entries(["one.txt", "two.txt"])


### PR DESCRIPTION
Index entry helpers return stage-zero records for one path or a requested group of paths.

A failed `git ls-files` query currently looks identical to a successful lookup that found no entry. Callers can therefore plan work against an index state that was never read successfully.

This pull request requires both lookup forms to propagate the Git failure before interpreting command output, while preserving the existing absent-entry result for successful empty queries.

Coverage corrupts the index and verifies failure propagation through both the single-path and grouped public interfaces.