### PR TITLE
include: Close partial plans on interruption

### DIFF
--- a/src/git_stage_batch/commands/batch_source/text_plan_builders.py
+++ b/src/git_stage_batch/commands/batch_source/text_plan_builders.py
@@ -317,7 +317,7 @@ def build_include_text_file_action_plan(
         merged_index_buffer = None
         merged_working_buffer = None
         return IncludeTextPlanBuildResult(plan=plan)
-    except Exception:
+    except BaseException:
         _close_include_merge_buffers(merged_index_buffer, merged_working_buffer)
         raise
 

--- a/tests/commands/batch_source/test_text_plan_builders.py
+++ b/tests/commands/batch_source/test_text_plan_builders.py
@@ -706,6 +706,51 @@ def test_build_include_text_file_action_plan_closes_partial_merge_on_failure(
         merged_index_buffer.to_bytes()
 
 
+def test_build_include_text_file_action_plan_closes_partial_merge_on_interrupt(
+    monkeypatch,
+    tmp_path,
+):
+    """An interrupted second merge should release the first target buffer."""
+    ownership = _Ownership()
+    index_buffer, _batch_buffer, _worktree_buffer = _patch_include_text_plan_io(
+        monkeypatch,
+        tmp_path,
+        ownership,
+    )
+    merged_index_buffer = LineBuffer.from_bytes(b"merged-index\n")
+
+    def merge_batch_from_line_sequences_as_buffer(
+        source_lines,
+        line_ownership,
+        target,
+    ):
+        if target is index_buffer:
+            return merged_index_buffer
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(
+        builders,
+        "merge_batch_from_line_sequences_as_buffer",
+        merge_batch_from_line_sequences_as_buffer,
+    )
+
+    with pytest.raises(KeyboardInterrupt):
+        builders.build_include_text_file_action_plan(
+            file_path="notes.txt",
+            file_meta={
+                "batch_source_commit": "commit",
+                "change_type": "modified",
+                "mode": "100644",
+            },
+            selected_ids={1},
+            selection_ids_to_include={7},
+            replacement_payload=None,
+        )
+
+    with pytest.raises(ValueError, match="buffer is closed"):
+        merged_index_buffer.to_bytes()
+
+
 def test_build_include_text_file_action_plan_returns_merged_plan(
     monkeypatch,
     tmp_path,


### PR DESCRIPTION
Include text planning closes partially merged target buffers when ordinary planning failures unwind construction.

Interruptions derive from `BaseException` rather than `Exception`. If the second target merge is interrupted after the first buffer has been created, that partial result currently has no remaining owner to release it.

This pull request applies the existing cleanup path to every exceptional exit from include plan construction, then re-raises the original interruption unchanged.

Coverage interrupts the second merge with `KeyboardInterrupt` and verifies that the first merged target buffer has already been closed.