### PR TITLE
include: Plan text files through ordered jobs

### DIFF
--- a/src/git_stage_batch/batch/replacement.py
+++ b/src/git_stage_batch/batch/replacement.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
+from pathlib import Path
 
 from ..core.line_selection import format_line_ids
 from ..core.replacement import (
@@ -52,14 +53,20 @@ def build_replacement_batch_view_from_lines(
     source_lines: Sequence[bytes],
     ownership: BatchOwnership,
     replacement_text: str | ReplacementPayload,
+    *,
+    spool_dir: str | Path | None = None,
 ) -> ReplacementBatchView:
     """Build replacement source content from an indexed byte-line sequence."""
     payload = coerce_replacement_payload(replacement_text)
-    with replacement_line_chunks(payload) as replacement_lines:
+    with replacement_line_chunks(
+        payload,
+        spool_dir=spool_dir,
+    ) as replacement_lines:
         return _build_replacement_batch_view(
             source_lines,
             ownership,
             replacement_lines,
+            spool_dir=spool_dir,
         )
 
 
@@ -67,6 +74,8 @@ def _build_replacement_batch_view(
     source_lines: Sequence[bytes],
     ownership: BatchOwnership,
     replacement_lines: Sequence[bytes],
+    *,
+    spool_dir: str | Path | None = None,
 ) -> ReplacementBatchView:
     """Build a replacement view while its replacement line sequence is open."""
     claimed_source_lines = sorted(ownership.presence_line_set())
@@ -110,7 +119,8 @@ def _build_replacement_batch_view(
                     prefix_end=start_line - 1,
                     replacement_lines=replacement_lines,
                     suffix_start=end_line,
-                )
+                ),
+                spool_dir=spool_dir,
             ),
             ownership=BatchOwnership.from_presence_lines(
                 _format_presence_lines(new_claimed_lines),
@@ -162,7 +172,8 @@ def _build_replacement_batch_view(
                 prefix_end=insert_at,
                 replacement_lines=replacement_lines,
                 suffix_start=insert_at,
-            )
+            ),
+            spool_dir=spool_dir,
         ),
         ownership=BatchOwnership.from_presence_lines(
             _format_presence_lines(new_claimed_lines),

--- a/src/git_stage_batch/commands/batch_source/candidate_preview_counts.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_preview_counts.py
@@ -19,6 +19,7 @@ from ...batch.replacement import build_replacement_batch_view_from_lines
 from ...batch.selection import acquire_batch_ownership_for_display_ids_from_lines
 from ...core.buffer import LineBuffer
 from ...core.replacement import ReplacementPayload
+from ...data.file_target_identity import IndexIdentity
 from ...utils.repository_buffers import (
     load_git_blob_as_buffer,
     read_git_object_buffer_or_none,
@@ -136,6 +137,11 @@ def count_include_candidate_previews_for_file(
     file_meta: dict,
     selection_ids_to_include: set[int] | None,
     replacement_payload: ReplacementPayload | None,
+    batch_source_object_id: str | None = None,
+    captured_index_identity: IndexIdentity | None = None,
+    working_tree_artifact_path: str | Path | None = None,
+    captured_working_tree_exists: bool | None = None,
+    spool_dir: str | Path | None = None,
 ) -> CandidatePreviewCount:
     """Return previewable include candidate counts for one text batch file."""
     if not _candidate_inputs.is_text_candidate_entry(file_meta):
@@ -144,18 +150,39 @@ def count_include_candidate_previews_for_file(
     if batch_source_ref is None:
         return CandidatePreviewCount()
     try:
-        batch_source_buffer = read_git_object_buffer_or_none(
-            batch_source_ref.object_spec
-        )
+        if batch_source_object_id is None:
+            batch_source_buffer = read_git_object_buffer_or_none(
+                batch_source_ref.object_spec
+            )
+        else:
+            batch_source_buffer = load_git_blob_as_buffer(
+                batch_source_object_id,
+                spool_dir=spool_dir,
+            )
         if batch_source_buffer is None:
             return CandidatePreviewCount()
 
         with ExitStack() as stack:
             batch_source_lines = stack.enter_context(batch_source_buffer)
-            index_buffer = read_git_object_buffer_or_none(f":{file_path}")
-            index_exists = index_buffer is not None
+            if captured_index_identity is None:
+                index_buffer = read_git_object_buffer_or_none(f":{file_path}")
+                index_exists = index_buffer is not None
+            else:
+                index_exists = captured_index_identity.exists
+                index_object_id = captured_index_identity.content_object_id
+                index_buffer = (
+                    load_git_blob_as_buffer(
+                        index_object_id,
+                        spool_dir=spool_dir,
+                    )
+                    if index_object_id is not None
+                    else None
+                )
             if index_buffer is None:
-                index_buffer = LineBuffer.from_bytes(b"")
+                index_buffer = LineBuffer.from_bytes(
+                    b"",
+                    spool_dir=spool_dir,
+                )
             index_lines = stack.enter_context(index_buffer)
             index_target = _candidate_inputs.candidate_index_text_target(
                 file_meta=file_meta,
@@ -167,30 +194,56 @@ def count_include_candidate_previews_for_file(
                     file_path=file_path,
                     file_meta=file_meta,
                     selected_ids=selection_ids_to_include,
+                    captured_working_tree_exists=(
+                        captured_working_tree_exists
+                    ),
                 )
             )
-            working_lines = stack.enter_context(
-                load_working_tree_file_as_buffer(file_path)
-            )
+            if working_tree_artifact_path is None:
+                working_buffer = (
+                    load_working_tree_file_as_buffer(file_path)
+                    if spool_dir is None
+                    else load_working_tree_file_as_buffer(
+                        file_path,
+                        spool_dir=spool_dir,
+                    )
+                )
+            else:
+                working_buffer = LineBuffer.from_path(
+                    working_tree_artifact_path,
+                    spool_dir=spool_dir,
+                )
+            working_lines = stack.enter_context(working_buffer)
+            ownership_arguments = {}
+            if spool_dir is not None:
+                ownership_arguments["spool_dir"] = spool_dir
             ownership = stack.enter_context(
                 acquire_batch_ownership_for_display_ids_from_lines(
                     file_meta,
                     batch_source_lines,
                     selection_ids_to_include,
+                    **ownership_arguments,
                 )
             )
             source_for_candidates = batch_source_lines
             candidate_ownership = ownership
             if replacement_payload is not None:
+                replacement_arguments = {}
+                if spool_dir is not None:
+                    replacement_arguments["spool_dir"] = spool_dir
                 replacement_view = stack.enter_context(
                     build_replacement_batch_view_from_lines(
                         batch_source_lines,
                         ownership,
                         replacement_payload,
+                        **replacement_arguments,
                     )
                 )
                 source_for_candidates = replacement_view.source_buffer
                 candidate_ownership = replacement_view.ownership
+            preview_arguments = {}
+            if spool_dir is not None:
+                preview_arguments["spool_dir"] = spool_dir
             previews = build_include_candidate_previews(
                 batch_name=batch_name,
                 file_path=file_path,
@@ -208,6 +261,7 @@ def count_include_candidate_previews_for_file(
                 selected_ids=selection_ids_to_include,
                 selection_ids=selection_ids_to_include,
                 replacement_payload=replacement_payload,
+                **preview_arguments,
             )
             try:
                 return CandidatePreviewCount(count=len(previews))

--- a/src/git_stage_batch/commands/batch_source/include_action.py
+++ b/src/git_stage_batch/commands/batch_source/include_action.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from pathlib import Path
 import sys
 
 from . import action_completion as _action_completion
@@ -10,28 +12,63 @@ from . import action_plans as _action_plans
 from . import action_selection as _action_selection
 from . import atomic_unit_refusals as _atomic_unit_refusals
 from . import binary_file_actions as _binary_file_actions
-from . import file_mode_actions as _file_mode_actions
-from . import candidate_preview_counts as _candidate_preview_counts
 from . import candidate_refusals as _candidate_refusals
+from . import file_mode_actions as _file_mode_actions
 from . import merge_refusals as _merge_refusals
 from . import text_file_actions as _text_file_actions
-from . import text_plan_builders as _text_plan_builders
+from . import text_plan_jobs as _text_plan_jobs
 from . import worktree_refusals as _worktree_refusals
 from ...batch.binary_file_content import read_binary_file_from_batch
+from ...batch.operation_candidate_types import CandidatePreviewCount
 from ...batch.submodule_pointer import (
     is_batch_submodule_pointer,
     stage_submodule_pointer_from_batch,
 )
 from ...core.replacement import ReplacementPayload
+from ...data.file_target_identity import (
+    IndexIdentity,
+    WorktreeIdentity,
+    capture_worktree_identity,
+    index_identity_from_entry,
+)
+from ...data.index_entries import read_index_entries
 from ...data.session import snapshot_file_if_untracked
 from ...data.undo_checkpoints import undo_checkpoint
-from ...exceptions import (
-    AtomicUnitError,
-    CommandError,
-    MergeError,
-    exit_with_error,
-)
+from ...exceptions import AtomicUnitError, CommandError, exit_with_error
 from ...i18n import _
+from ...utils.file_job_workspace import FileJobWorkspace
+from ...utils.file_jobs import (
+    OrderedFileJob,
+    run_file_jobs,
+    run_validated_file_jobs,
+)
+from ...utils.git_object_io import list_git_tree_blobs, resolve_git_objects
+from ...utils.git_repository import get_git_repository_root_path
+
+
+@dataclass(frozen=True, slots=True)
+class _IncludeTextInput:
+    ordinal: int
+    file_path: str
+    file_meta: dict
+    index_identity: IndexIdentity
+    worktree_identity: WorktreeIdentity
+    worktree_artifact: Path
+    scratch_directory: Path
+    source_commit: str | None
+    source_required: bool
+
+
+@dataclass(frozen=True, slots=True)
+class _IncludePlanCapture:
+    text_inputs: tuple[_IncludeTextInput, ...]
+    plans_by_ordinal: dict[int, _action_plans.BatchSourceActionPlan]
+    command_errors_by_ordinal: dict[int, CommandError]
+    unexpected_errors_by_ordinal: dict[int, str]
+    mode_actions: list[tuple[str, dict]]
+    binary_metadata_by_ordinal: dict[int, dict]
+    index_identities: dict[str, IndexIdentity]
+    worktree_identities: dict[str, WorktreeIdentity]
 
 
 def execute_include_action(
@@ -43,107 +80,547 @@ def execute_include_action(
 ) -> None:
     """Include selected batch-source changes into the index and worktree."""
     files = selection.files
-    selected_ids = selection.selected_ids
-    selection_ids_to_include = selection.selection_ids
-    rendered = selection.rendered
-    operation_parts = list(selection.operation_parts)
-    failed_files = []
-    candidate_counts = {}
-    include_plans = []
-    mode_actions = []
+    repository_root = get_git_repository_root_path()
+    with FileJobWorkspace() as workspace:
+        (
+            include_plans,
+            mode_actions,
+            expected_index_identities,
+            expected_worktree_identities,
+        ) = _build_include_action_plans(
+            batch_name=batch_name,
+            files=files,
+            selected_ids=selection.selected_ids,
+            selection_ids_to_include=selection.selection_ids,
+            rendered=selection.rendered,
+            replacement_payload=replacement_payload,
+            repository_root=repository_root,
+            workspace=workspace,
+        )
+        try:
+            _require_unchanged_include_targets(
+                expected_index_identities,
+                expected_worktree_identities,
+            )
+            try:
+                with undo_checkpoint(
+                    " ".join(selection.operation_parts),
+                    worktree_paths=list(files),
+                    rollback_on_error=True,
+                ):
+                    for plan in include_plans:
+                        snapshot_file_if_untracked(plan.file_path)
+                        if isinstance(
+                            plan,
+                            _action_plans.IncludeTextFileActionPlan,
+                        ):
+                            _text_file_actions.stage_text_file_to_index(
+                                plan.file_path,
+                                plan.index_buffer,
+                                plan.index_file_mode,
+                                plan.index_change_type,
+                            )
+                            _text_file_actions.write_text_file_to_worktree(
+                                plan.file_path,
+                                plan.working_buffer,
+                                plan.working_file_mode,
+                                plan.working_change_type,
+                            )
+                        elif isinstance(
+                            plan,
+                            _action_plans.BinaryFileActionPlan,
+                        ):
+                            _binary_file_actions.stage_binary_file_to_index(
+                                plan.file_path,
+                                plan.file_meta,
+                                plan.buffer,
+                            )
+                            _binary_file_actions.write_binary_file_to_worktree(
+                                plan.file_path,
+                                plan.file_meta,
+                                plan.buffer,
+                            )
+                        else:
+                            stage_submodule_pointer_from_batch(
+                                plan.file_path,
+                                plan.file_meta,
+                            )
+                    for file_path, file_meta in mode_actions:
+                        _file_mode_actions.stage_file_mode(file_path, file_meta)
+                        _file_mode_actions.apply_new_file_mode(
+                            file_path,
+                            file_meta,
+                        )
+            except CommandError:
+                raise
+            except Exception as error:
+                _worktree_refusals.refuse_incompatible_worktree_action(
+                    batch_name=batch_name,
+                    file_paths=files,
+                    error=error,
+                )
+        finally:
+            _action_plans.close_action_plans(include_plans)
 
-    for file_path, file_meta in files.items():
+    _action_completion.finish_batch_source_action_review(context, files)
+
+
+def _build_include_action_plans(
+    *,
+    batch_name: str,
+    files: dict[str, dict],
+    selected_ids: set[int] | None,
+    selection_ids_to_include: set[int] | None,
+    rendered,
+    replacement_payload: ReplacementPayload | None,
+    repository_root: Path,
+    workspace: FileJobWorkspace,
+) -> tuple[
+    list[_action_plans.BatchSourceActionPlan],
+    list[tuple[str, dict]],
+    dict[str, IndexIdentity],
+    dict[str, WorktreeIdentity],
+]:
+    capture = _capture_include_plan_inputs(
+        files=files,
+        selected_ids=selected_ids,
+        workspace=workspace,
+    )
+    try:
+        jobs = _build_include_text_jobs(
+            batch_name=batch_name,
+            selected_ids=selected_ids,
+            selection_ids_to_include=selection_ids_to_include,
+            replacement_payload=replacement_payload,
+            capture=capture,
+            workspace=workspace,
+        )
+        text_results_by_ordinal = _run_include_text_jobs(
+            jobs,
+            repository_root=repository_root,
+        )
+        plans = _reduce_include_action_plans(
+            batch_name=batch_name,
+            files=files,
+            rendered=rendered,
+            capture=capture,
+            text_results_by_ordinal=text_results_by_ordinal,
+            workspace=workspace,
+        )
+        return (
+            plans,
+            capture.mode_actions,
+            capture.index_identities,
+            capture.worktree_identities,
+        )
+    except BaseException:
+        _action_plans.close_action_plans(capture.plans_by_ordinal.values())
+        raise
+
+
+def _capture_include_plan_inputs(
+    *,
+    files: dict[str, dict],
+    selected_ids: set[int] | None,
+    workspace: FileJobWorkspace,
+) -> _IncludePlanCapture:
+    """Capture include targets and classify atomic and text inputs."""
+    index_entries = read_index_entries(files)
+    index_identities = {
+        file_path: index_identity_from_entry(index_entries.get(file_path))
+        for file_path in files
+    }
+    worktree_identities: dict[str, WorktreeIdentity] = {}
+    plans_by_ordinal: dict[int, _action_plans.BatchSourceActionPlan] = {}
+    command_errors_by_ordinal: dict[int, CommandError] = {}
+    unexpected_errors_by_ordinal: dict[int, str] = {}
+    mode_actions: list[tuple[str, dict]] = []
+    binary_metadata_by_ordinal: dict[int, dict] = {}
+    text_inputs: list[_IncludeTextInput] = []
+
+    for ordinal, (file_path, file_meta) in enumerate(files.items()):
         try:
             if _file_mode_actions.is_file_mode_action(file_meta):
+                worktree_identities[file_path] = capture_worktree_identity(file_path)
                 mode_actions.append((file_path, file_meta))
                 continue
             if file_meta.get("file_type") == "binary":
+                worktree_identities[file_path] = capture_worktree_identity(file_path)
+                binary_metadata_by_ordinal[ordinal] = file_meta
+                continue
+            if is_batch_submodule_pointer(file_meta):
+                worktree_identities[file_path] = capture_worktree_identity(file_path)
+                plans_by_ordinal[ordinal] = _action_plans.SubmodulePointerActionPlan(
+                    file_path,
+                    file_meta,
+                )
+                continue
+
+            source_required = _text_plan_jobs.include_text_plan_requires_source(
+                file_meta,
+                selected_ids,
+            )
+            if source_required:
+                worktree_artifact = workspace.artifact_path(
+                    ordinal,
+                    "worktree-input",
+                )
+                worktree_identity = capture_worktree_identity(
+                    file_path,
+                    content_artifact_path=worktree_artifact,
+                )
+                source_commit = file_meta["batch_source_commit"]
+            else:
+                worktree_identity = capture_worktree_identity(file_path)
+                worktree_artifact = workspace.write_buffer(
+                    ordinal,
+                    "worktree-input",
+                    (),
+                )
+                source_commit = None
+            worktree_identities[file_path] = worktree_identity
+            text_inputs.append(
+                _IncludeTextInput(
+                    ordinal=ordinal,
+                    file_path=file_path,
+                    file_meta=file_meta,
+                    index_identity=index_identities[file_path],
+                    worktree_identity=worktree_identity,
+                    worktree_artifact=worktree_artifact,
+                    scratch_directory=workspace.scratch_directory(ordinal),
+                    source_commit=source_commit,
+                    source_required=source_required,
+                )
+            )
+        except CommandError as error:
+            command_errors_by_ordinal[ordinal] = error
+        except Exception as error:
+            unexpected_errors_by_ordinal[ordinal] = str(error)
+    return _IncludePlanCapture(
+        text_inputs=tuple(text_inputs),
+        plans_by_ordinal=plans_by_ordinal,
+        command_errors_by_ordinal=command_errors_by_ordinal,
+        unexpected_errors_by_ordinal=unexpected_errors_by_ordinal,
+        mode_actions=mode_actions,
+        binary_metadata_by_ordinal=binary_metadata_by_ordinal,
+        index_identities=index_identities,
+        worktree_identities=worktree_identities,
+    )
+
+
+def _build_include_text_jobs(
+    *,
+    batch_name: str,
+    selected_ids: set[int] | None,
+    selection_ids_to_include: set[int] | None,
+    replacement_payload: ReplacementPayload | None,
+    capture: _IncludePlanCapture,
+    workspace: FileJobWorkspace,
+) -> list[OrderedFileJob[_text_plan_jobs.IncludeTextPlanJob]]:
+    """Build compact include text jobs from captured inputs."""
+    text_inputs = capture.text_inputs
+    jobs: list[OrderedFileJob[_text_plan_jobs.IncludeTextPlanJob]] = []
+
+    source_blob_by_target = _resolve_include_text_source_blobs(text_inputs)
+    object_ids = [
+        *source_blob_by_target.values(),
+        *(
+            text_input.index_identity.content_object_id
+            for text_input in text_inputs
+            if (
+                text_input.source_required
+                and text_input.index_identity.content_object_id is not None
+            )
+        ),
+    ]
+    object_info_by_id = resolve_git_objects(object_ids)
+    for text_input in text_inputs:
+        ordinal = text_input.ordinal
+        file_path = text_input.file_path
+        source_object_id = source_blob_by_target.get((ordinal, file_path))
+        try:
+            replacement_artifact_path = None
+            if replacement_payload is not None:
+                replacement_artifact_path = workspace.write_buffer(
+                    ordinal,
+                    "replacement-input",
+                    (replacement_payload.data,),
+                )
+            input_artifact = workspace.write_pickle(
+                ordinal,
+                "include-input.pickle",
+                {
+                    "batch_name": batch_name,
+                    "batch_source_object_id": source_object_id,
+                    "file_meta": text_input.file_meta,
+                    "selected_ids": (
+                        None if selected_ids is None else sorted(selected_ids)
+                    ),
+                    "selection_ids": (
+                        None
+                        if selection_ids_to_include is None
+                        else sorted(selection_ids_to_include)
+                    ),
+                    "working_tree_artifact_path": str(text_input.worktree_artifact),
+                    "replacement_artifact_path": (
+                        None
+                        if replacement_artifact_path is None
+                        else str(replacement_artifact_path)
+                    ),
+                    "replacement_display_text": (
+                        None
+                        if replacement_payload is None
+                        else replacement_payload.display_text
+                    ),
+                    "replacement_exact": (
+                        True
+                        if replacement_payload is None
+                        else replacement_payload.exact
+                    ),
+                    "scratch_directory": str(text_input.scratch_directory),
+                },
+            )
+            index_output_path = workspace.output_path(
+                ordinal,
+                "index-output",
+            )
+            worktree_output_path = workspace.output_path(
+                ordinal,
+                "worktree-output",
+            )
+            details_path = workspace.output_path(
+                ordinal,
+                "details.pickle",
+            )
+            payload = _text_plan_jobs.IncludeTextPlanJob(
+                ordinal=ordinal,
+                file_path=file_path,
+                input_artifact_path=str(input_artifact),
+                index_output_path=str(index_output_path),
+                worktree_output_path=str(worktree_output_path),
+                details_artifact_path=str(details_path),
+                expected_index_identity=text_input.index_identity,
+                expected_worktree_identity=text_input.worktree_identity,
+            )
+            source_info = object_info_by_id.get(source_object_id)
+            index_info = object_info_by_id.get(
+                text_input.index_identity.content_object_id
+            )
+            jobs.append(
+                OrderedFileJob(
+                    ordinal=ordinal,
+                    file_path=file_path,
+                    estimated_bytes=(
+                        (
+                            (text_input.worktree_identity.size or 0)
+                            + (
+                                source_info.size
+                                if source_info is not None
+                                and source_info.object_type == "blob"
+                                else 0
+                            )
+                            + (
+                                index_info.size
+                                if index_info is not None
+                                and index_info.object_type == "blob"
+                                else 0
+                            )
+                            + (
+                                0
+                                if replacement_payload is None
+                                else len(replacement_payload.data)
+                            )
+                        )
+                        if text_input.source_required
+                        else 0
+                    ),
+                    payload=payload,
+                )
+            )
+        except CommandError as error:
+            capture.command_errors_by_ordinal[ordinal] = error
+        except Exception as error:
+            capture.unexpected_errors_by_ordinal[ordinal] = str(error)
+    return jobs
+
+
+def _run_include_text_jobs(
+    jobs: list[OrderedFileJob[_text_plan_jobs.IncludeTextPlanJob]],
+    *,
+    repository_root: Path,
+) -> dict[int, _text_plan_jobs.IncludeTextPlanJobResult]:
+    """Execute and validate include text jobs in stable ordinal order."""
+    paired_results = run_validated_file_jobs(
+        jobs,
+        _text_plan_jobs.compute_include_text_plan_job,
+        _text_plan_jobs.validate_include_text_plan_job_result,
+        repository_root=repository_root,
+        result_label="include text-plan",
+        run_jobs=run_file_jobs,
+    )
+    return {result.ordinal: result for _job, result in paired_results}
+
+
+def _reduce_include_action_plans(
+    *,
+    batch_name: str,
+    files: dict[str, dict],
+    rendered,
+    capture: _IncludePlanCapture,
+    text_results_by_ordinal: dict[int, _text_plan_jobs.IncludeTextPlanJobResult],
+    workspace: FileJobWorkspace,
+) -> list[_action_plans.BatchSourceActionPlan]:
+    """Reduce atomic and text include outcomes in source-file order."""
+    failed_by_ordinal = {}
+    candidate_counts = {}
+    plans_by_ordinal = capture.plans_by_ordinal
+    for ordinal, (file_path, _file_meta) in enumerate(files.items()):
+        command_error = capture.command_errors_by_ordinal.get(ordinal)
+        if command_error is not None:
+            raise command_error
+        unexpected_error = capture.unexpected_errors_by_ordinal.get(ordinal)
+        if unexpected_error is not None:
+            print(
+                _("Error staging {file}: {error}").format(
+                    file=file_path,
+                    error=unexpected_error,
+                ),
+                file=sys.stderr,
+            )
+            failed_by_ordinal[ordinal] = file_path
+            continue
+        binary_metadata = capture.binary_metadata_by_ordinal.get(ordinal)
+        if binary_metadata is not None:
+            try:
                 batch_buffer = read_binary_file_from_batch(
                     batch_name,
                     file_path,
-                    file_meta,
+                    binary_metadata,
                     missing_content_message=(
                         f"Binary file not found in batch commit: {file_path}"
                     ),
                 )
-                include_plans.append(
-                    _action_plans.BinaryFileActionPlan(
-                        file_path,
-                        file_meta,
-                        batch_buffer,
-                    )
+                plans_by_ordinal[ordinal] = _action_plans.BinaryFileActionPlan(
+                    file_path,
+                    binary_metadata,
+                    batch_buffer,
                 )
-                continue
-            if is_batch_submodule_pointer(file_meta):
-                include_plans.append(
-                    _action_plans.SubmodulePointerActionPlan(file_path, file_meta)
+            except CommandError:
+                raise
+            except Exception as error:
+                print(
+                    _("Error staging {file}: {error}").format(
+                        file=file_path,
+                        error=str(error),
+                    ),
+                    file=sys.stderr,
                 )
-                continue
-
-            try:
-                text_plan_result = (
-                    _text_plan_builders.build_include_text_file_action_plan(
-                        file_path=file_path,
-                        file_meta=file_meta,
-                        selected_ids=selected_ids,
-                        selection_ids_to_include=selection_ids_to_include,
-                        replacement_payload=replacement_payload,
-                    )
-                )
-            except AtomicUnitError as e:
-                if rendered:
-                    _atomic_unit_refusals.translate_atomic_unit_error_to_gutter_ids(
-                        e,
-                        rendered,
-                        "include from",
-                        batch_name,
-                    )
-                _action_plans.close_action_plans(include_plans)
-                exit_with_error(
-                    _("Failed to include from batch '{name}': {error}").format(
-                        name=batch_name,
-                        error=str(e),
-                    )
-                )
-            except ValueError as e:
-                _action_plans.close_action_plans(include_plans)
-                exit_with_error(str(e))
-
-            if text_plan_result.missing_source:
-                failed_files.append(file_path)
-                continue
-            if text_plan_result.plan is None:
-                continue
-            include_plans.append(text_plan_result.plan)
-
-        except MergeError:
-            candidate_count = (
-                _candidate_preview_counts.count_include_candidate_previews_for_file(
-                    batch_name=batch_name,
-                    file_path=file_path,
-                    file_meta=file_meta,
-                    selection_ids_to_include=selection_ids_to_include,
-                    replacement_payload=replacement_payload,
+                failed_by_ordinal[ordinal] = file_path
+            continue
+        result = text_results_by_ordinal.get(ordinal)
+        if result is None:
+            continue
+        details = (
+            {}
+            if result.details_artifact_path is None
+            else workspace.read_pickle(result.details_artifact_path)
+        )
+        if type(details) is not dict:
+            raise TypeError("include text-plan details must be a dictionary")
+        if result.outcome == "plan":
+            index_buffer = (
+                None
+                if result.index_output_path is None
+                else workspace.read_buffer(
+                    result.index_output_path,
+                    spool_dir=workspace.scratch_directory(result.ordinal),
                 )
             )
-            if candidate_count.count or candidate_count.too_many or candidate_count.error:
-                candidate_counts[file_path] = candidate_count
-            failed_files.append(file_path)
-        except CommandError:
-            _action_plans.close_action_plans(include_plans)
-            raise
-        except Exception as e:
+            try:
+                worktree_buffer = (
+                    None
+                    if result.worktree_output_path is None
+                    else workspace.read_buffer(
+                        result.worktree_output_path,
+                        spool_dir=workspace.scratch_directory(result.ordinal),
+                    )
+                )
+            except BaseException:
+                if index_buffer is not None:
+                    index_buffer.close()
+                raise
+            plans_by_ordinal[result.ordinal] = _action_plans.IncludeTextFileActionPlan(
+                result.file_path,
+                index_buffer,
+                worktree_buffer,
+                result.index_file_mode,
+                result.worktree_file_mode,
+                result.index_change_type,
+                result.worktree_change_type,
+            )
+        elif result.outcome == "noop":
+            continue
+        elif result.outcome == "atomic_unit_error":
+            error = AtomicUnitError(
+                details["message"],
+                details.get("required_selection_ids"),
+                details.get("unit_kind"),
+            )
+            if rendered:
+                _atomic_unit_refusals.translate_atomic_unit_error_to_gutter_ids(
+                    error,
+                    rendered,
+                    "include from",
+                    batch_name,
+                )
+            exit_with_error(
+                _("Failed to include from batch '{name}': {error}").format(
+                    name=batch_name,
+                    error=str(error),
+                )
+            )
+        elif result.outcome == "command_error":
+            raise CommandError(
+                details["message"],
+                details.get("exit_code", 1),
+            )
+        elif result.outcome == "value_error":
+            exit_with_error(details["message"])
+        elif result.outcome == "unexpected_error":
             print(
                 _("Error staging {file}: {error}").format(
-                    file=file_path,
-                    error=str(e),
+                    file=result.file_path,
+                    error=details["message"],
                 ),
                 file=sys.stderr,
             )
-            failed_files.append(file_path)
+            failed_by_ordinal[ordinal] = result.file_path
+        elif result.outcome == "merge_error":
+            _require_unchanged_include_target(
+                result.file_path,
+                capture.index_identities[result.file_path],
+                capture.worktree_identities[result.file_path],
+            )
+            candidate_count = CandidatePreviewCount(
+                count=details.get("candidate_count", 0),
+                too_many=details.get("candidate_too_many", False),
+                error=details.get("candidate_error"),
+            )
+            if (
+                candidate_count.count
+                or candidate_count.too_many
+                or candidate_count.error
+            ):
+                candidate_counts[result.file_path] = candidate_count
+            failed_by_ordinal[ordinal] = result.file_path
+        elif result.outcome == "missing_source":
+            failed_by_ordinal[ordinal] = result.file_path
+        else:
+            raise RuntimeError(f"Unhandled include text-plan outcome: {result.outcome}")
 
+    plans = [plans_by_ordinal[ordinal] for ordinal in sorted(plans_by_ordinal)]
+    failed_files = [failed_by_ordinal[ordinal] for ordinal in sorted(failed_by_ordinal)]
     if failed_files:
-        _action_plans.close_action_plans(include_plans)
         _candidate_refusals.refuse_candidate_conflicts(
             batch_name=batch_name,
             operation="include",
@@ -154,57 +631,82 @@ def execute_include_action(
             batch_name=batch_name,
             failed_files=failed_files,
         )
+    return plans
 
-    try:
-        try:
-            with undo_checkpoint(
-                " ".join(operation_parts),
-                worktree_paths=list(files),
-                rollback_on_error=True,
-            ):
-                for plan in include_plans:
-                    snapshot_file_if_untracked(plan.file_path)
-                    if isinstance(plan, _action_plans.IncludeTextFileActionPlan):
-                        _text_file_actions.stage_text_file_to_index(
-                            plan.file_path,
-                            plan.index_buffer,
-                            plan.index_file_mode,
-                            plan.index_change_type,
-                        )
-                        _text_file_actions.write_text_file_to_worktree(
-                            plan.file_path,
-                            plan.working_buffer,
-                            plan.working_file_mode,
-                            plan.working_change_type,
-                        )
-                    elif isinstance(plan, _action_plans.BinaryFileActionPlan):
-                        _binary_file_actions.stage_binary_file_to_index(
-                            plan.file_path,
-                            plan.file_meta,
-                            plan.buffer,
-                        )
-                        _binary_file_actions.write_binary_file_to_worktree(
-                            plan.file_path,
-                            plan.file_meta,
-                            plan.buffer,
-                        )
-                    else:
-                        stage_submodule_pointer_from_batch(
-                            plan.file_path,
-                            plan.file_meta,
-                        )
-                for file_path, file_meta in mode_actions:
-                    _file_mode_actions.stage_file_mode(file_path, file_meta)
-                    _file_mode_actions.apply_new_file_mode(file_path, file_meta)
-        except CommandError:
-            raise
-        except Exception as error:
-            _worktree_refusals.refuse_incompatible_worktree_action(
-                batch_name=batch_name,
-                file_paths=files,
-                error=error,
+
+def _resolve_include_text_source_blobs(
+    text_inputs: tuple[_IncludeTextInput, ...],
+) -> dict[tuple[int, str], str]:
+    paths_by_commit: dict[str, list[str]] = {}
+    for text_input in text_inputs:
+        if text_input.source_commit is None:
+            continue
+        paths_by_commit.setdefault(
+            text_input.source_commit,
+            [],
+        ).append(text_input.file_path)
+    entries_by_commit = {
+        source_commit: list_git_tree_blobs(source_commit, file_paths)
+        for source_commit, file_paths in paths_by_commit.items()
+    }
+    source_blob_by_target = {}
+    for text_input in text_inputs:
+        if text_input.source_commit is None:
+            continue
+        entry = entries_by_commit[text_input.source_commit].get(text_input.file_path)
+        if entry is not None:
+            source_blob_by_target[(text_input.ordinal, text_input.file_path)] = (
+                entry.blob_sha
             )
-    finally:
-        _action_plans.close_action_plans(include_plans)
+    return source_blob_by_target
 
-    _action_completion.finish_batch_source_action_review(context, files)
+
+def _include_target_changed_error(
+    file_path: str,
+    *,
+    target: str,
+) -> CommandError:
+    label = "Index" if target == "index" else "Working tree file"
+    return CommandError(
+        _(
+            "{label} changed while include was being calculated: "
+            "{file}. Retry the include command."
+        ).format(label=label, file=file_path)
+    )
+
+
+def _require_unchanged_include_targets(
+    expected_index_identities: dict[str, IndexIdentity],
+    expected_worktree_identities: dict[str, WorktreeIdentity],
+) -> None:
+    file_paths = tuple(expected_index_identities)
+    current_index_entries = read_index_entries(file_paths)
+    for file_path in file_paths:
+        current_index_identity = index_identity_from_entry(
+            current_index_entries.get(file_path)
+        )
+        if current_index_identity != expected_index_identities[file_path]:
+            raise _include_target_changed_error(
+                file_path,
+                target="index",
+            )
+        if (
+            capture_worktree_identity(file_path)
+            != expected_worktree_identities[file_path]
+        ):
+            raise _include_target_changed_error(
+                file_path,
+                target="worktree",
+            )
+
+
+def _require_unchanged_include_target(
+    file_path: str,
+    expected_index_identity: IndexIdentity,
+    expected_worktree_identity: WorktreeIdentity,
+) -> None:
+    current_index_entry = read_index_entries((file_path,)).get(file_path)
+    if index_identity_from_entry(current_index_entry) != expected_index_identity:
+        raise _include_target_changed_error(file_path, target="index")
+    if capture_worktree_identity(file_path) != expected_worktree_identity:
+        raise _include_target_changed_error(file_path, target="worktree")

--- a/src/git_stage_batch/commands/batch_source/text_plan_builders.py
+++ b/src/git_stage_batch/commands/batch_source/text_plan_builders.py
@@ -21,6 +21,7 @@ from ...core.text_lifecycle import (
     selected_text_discard_change_type,
     selected_text_target_change_type,
 )
+from ...data.file_target_identity import IndexIdentity
 from ...data.file_modes import detect_file_mode_in_commit
 from ...utils.repository_buffers import (
     load_git_blob_as_buffer,
@@ -74,6 +75,14 @@ def apply_text_plan_requires_source(
         and normalized_text_change_type(file_meta.get("change_type"))
         == TextFileChangeType.DELETED
     )
+
+
+def include_text_plan_requires_source(
+    file_meta: dict,
+    selected_ids: set[int] | None,
+) -> bool:
+    """Return whether one include text plan needs batch source content."""
+    return apply_text_plan_requires_source(file_meta, selected_ids)
 
 
 def build_apply_text_file_action_plan(
@@ -201,17 +210,27 @@ def build_include_text_file_action_plan(
     selected_ids: set[int] | None,
     selection_ids_to_include: set[int] | None,
     replacement_payload: ReplacementPayload | None,
+    batch_source_object_id: str | None = None,
+    captured_index_identity: IndexIdentity | None = None,
+    working_tree_artifact_path: str | Path | None = None,
+    captured_working_tree_exists: bool | None = None,
+    spool_dir: str | Path | None = None,
 ) -> IncludeTextPlanBuildResult:
     """Build one deferred include-from text action plan."""
     text_change_type = normalized_text_change_type(file_meta.get("change_type"))
 
-    index_buffer = read_git_object_buffer_or_none(f":{file_path}")
-    index_exists = index_buffer is not None
-    if index_buffer is None:
-        index_buffer = LineBuffer.from_bytes(b"")
+    if captured_index_identity is None:
+        index_buffer = read_git_object_buffer_or_none(f":{file_path}")
+        index_exists = index_buffer is not None
+    else:
+        index_exists = captured_index_identity.exists
+        index_buffer = None
 
-    repo_root = get_git_repository_root_path()
-    working_exists = os.path.lexists(repo_root / file_path)
+    if captured_working_tree_exists is None:
+        repo_root = get_git_repository_root_path()
+        working_exists = os.path.lexists(repo_root / file_path)
+    else:
+        working_exists = captured_working_tree_exists
 
     batch_file_mode = str(file_meta.get("mode", "100644"))
     index_file_mode = mode_for_text_materialization(
@@ -224,8 +243,9 @@ def build_include_text_file_action_plan(
         selected_ids,
         destination_exists=working_exists,
     )
-    if selected_ids is None and text_change_type == TextFileChangeType.DELETED:
-        index_buffer.close()
+    if not include_text_plan_requires_source(file_meta, selected_ids):
+        if index_buffer is not None:
+            index_buffer.close()
         return IncludeTextPlanBuildResult(
             plan=_action_plans.IncludeTextFileActionPlan(
                 file_path,
@@ -238,10 +258,28 @@ def build_include_text_file_action_plan(
             )
         )
 
+    if (
+        index_buffer is None
+        and captured_index_identity is not None
+        and captured_index_identity.content_object_id is not None
+    ):
+        index_buffer = load_git_blob_as_buffer(
+            captured_index_identity.content_object_id,
+            spool_dir=spool_dir,
+        )
+    if index_buffer is None:
+        index_buffer = LineBuffer.from_bytes(b"", spool_dir=spool_dir)
+
     batch_source_commit = file_meta["batch_source_commit"]
-    batch_source_buffer = read_git_object_buffer_or_none(
-        f"{batch_source_commit}:{file_path}"
-    )
+    if batch_source_object_id is None:
+        batch_source_buffer = read_git_object_buffer_or_none(
+            f"{batch_source_commit}:{file_path}"
+        )
+    else:
+        batch_source_buffer = load_git_blob_as_buffer(
+            batch_source_object_id,
+            spool_dir=spool_dir,
+        )
     if batch_source_buffer is None:
         index_buffer.close()
         return IncludeTextPlanBuildResult(missing_source=True)
@@ -249,23 +287,46 @@ def build_include_text_file_action_plan(
     merged_index_buffer = None
     merged_working_buffer = None
     try:
-        with (
-            batch_source_buffer as batch_source_lines,
-            index_buffer as index_lines,
-            load_working_tree_file_as_buffer(file_path) as working_lines,
-        ):
+        with ExitStack() as resources:
+            batch_source_lines = resources.enter_context(batch_source_buffer)
+            index_lines = resources.enter_context(index_buffer)
+            if working_tree_artifact_path is None:
+                working_buffer = (
+                    load_working_tree_file_as_buffer(file_path)
+                    if spool_dir is None
+                    else load_working_tree_file_as_buffer(
+                        file_path,
+                        spool_dir=spool_dir,
+                    )
+                )
+            else:
+                working_buffer = LineBuffer.from_path(
+                    working_tree_artifact_path,
+                    spool_dir=spool_dir,
+                )
+            working_lines = resources.enter_context(working_buffer)
+            ownership_arguments = {}
+            if spool_dir is not None:
+                ownership_arguments["spool_dir"] = spool_dir
             with acquire_batch_ownership_for_display_ids_from_lines(
                 file_meta,
                 batch_source_lines,
                 selection_ids_to_include,
+                **ownership_arguments,
             ) as ownership:
                 if ownership.is_empty():
                     if (
                         selected_ids is None
                         and text_change_type == TextFileChangeType.ADDED
                     ):
-                        merged_index_buffer = LineBuffer.from_bytes(b"")
-                        merged_working_buffer = LineBuffer.from_bytes(b"")
+                        merged_index_buffer = LineBuffer.from_bytes(
+                            b"",
+                            spool_dir=spool_dir,
+                        )
+                        merged_working_buffer = LineBuffer.from_bytes(
+                            b"",
+                            spool_dir=spool_dir,
+                        )
                     else:
                         return IncludeTextPlanBuildResult()
                 else:
@@ -273,25 +334,34 @@ def build_include_text_file_action_plan(
                         source_lines = batch_source_lines
                         merge_ownership = ownership
                         if replacement_payload is not None:
+                            replacement_arguments = {}
+                            if spool_dir is not None:
+                                replacement_arguments["spool_dir"] = spool_dir
                             replacement_view = stack.enter_context(
                                 build_replacement_batch_view_from_lines(
                                     batch_source_lines,
                                     ownership,
                                     replacement_payload,
+                                    **replacement_arguments,
                                 )
                             )
                             source_lines = replacement_view.source_buffer
                             merge_ownership = replacement_view.ownership
+                        merge_arguments = {}
+                        if spool_dir is not None:
+                            merge_arguments["spool_dir"] = spool_dir
                         merged_index_buffer = merge_batch_from_line_sequences_as_buffer(
                             source_lines,
                             merge_ownership,
                             index_lines,
+                            **merge_arguments,
                         )
                         merged_working_buffer = (
                             merge_batch_from_line_sequences_as_buffer(
                                 source_lines,
                                 merge_ownership,
                                 working_lines,
+                                **merge_arguments,
                             )
                         )
 

--- a/src/git_stage_batch/commands/batch_source/text_plan_jobs.py
+++ b/src/git_stage_batch/commands/batch_source/text_plan_jobs.py
@@ -10,7 +10,8 @@ from typing import Literal
 from . import candidate_preview_counts as _candidate_preview_counts
 from . import text_plan_builders as _text_plan_builders
 from ...core.buffer import write_buffer_to_path
-from ...data.file_target_identity import WorktreeIdentity
+from ...core.replacement import ReplacementPayload
+from ...data.file_target_identity import IndexIdentity, WorktreeIdentity
 from ...exceptions import AtomicUnitError, CommandError, MergeError
 
 
@@ -23,12 +24,23 @@ ApplyTextPlanOutcome = Literal[
     "command_error",
     "unexpected_error",
 ]
-_DETAIL_OUTCOMES = frozenset({
+IncludeTextPlanOutcome = Literal[
+    "plan",
+    "noop",
+    "missing_source",
+    "merge_error",
+    "atomic_unit_error",
+    "command_error",
+    "value_error",
+    "unexpected_error",
+]
+_APPLY_DETAIL_OUTCOMES = frozenset({
     "merge_error",
     "atomic_unit_error",
     "command_error",
     "unexpected_error",
 })
+_INCLUDE_DETAIL_OUTCOMES = _APPLY_DETAIL_OUTCOMES | {"value_error"}
 _EMPTY_OUTCOMES = frozenset({
     "noop",
     "missing_source",
@@ -63,6 +75,36 @@ class ApplyTextPlanJobResult:
     output_path: str | None
     file_mode: str | None
     change_type: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class IncludeTextPlanJob:
+    """Compact worker request for one text include plan."""
+
+    ordinal: int
+    file_path: str
+    input_artifact_path: str
+    index_output_path: str
+    worktree_output_path: str
+    details_artifact_path: str
+    expected_index_identity: IndexIdentity
+    expected_worktree_identity: WorktreeIdentity
+
+
+@dataclass(frozen=True, slots=True)
+class IncludeTextPlanJobResult:
+    """Compact worker result for one text include plan."""
+
+    ordinal: int
+    file_path: str
+    outcome: IncludeTextPlanOutcome
+    details_artifact_path: str | None
+    index_output_path: str | None
+    worktree_output_path: str | None
+    index_file_mode: str | None
+    worktree_file_mode: str | None
+    index_change_type: str | None
+    worktree_change_type: str | None
 
 
 def compute_apply_text_plan_job(
@@ -175,12 +217,167 @@ def compute_apply_text_plan_job(
         return _result(job, "unexpected_error", has_details=True)
 
 
+def compute_include_text_plan_job(
+    job: IncludeTextPlanJob,
+) -> IncludeTextPlanJobResult:
+    """Build one text include plan from immutable artifact inputs."""
+    input_metadata = _read_pickle(job.input_artifact_path)
+    if type(input_metadata) is not dict:
+        raise TypeError("include text-plan input must be a dictionary")
+    file_meta = input_metadata["file_meta"]
+    selected_ids = _optional_int_set(input_metadata["selected_ids"])
+    selection_ids = _optional_int_set(input_metadata["selection_ids"])
+    working_tree_artifact_path = input_metadata["working_tree_artifact_path"]
+    replacement_payload = _replacement_payload_from_metadata(input_metadata)
+    scratch_directory = input_metadata["scratch_directory"]
+    batch_name = input_metadata["batch_name"]
+    batch_source_object_id = input_metadata["batch_source_object_id"]
+    source_required = include_text_plan_requires_source(
+        file_meta,
+        selected_ids,
+    )
+    if source_required and batch_source_object_id is None:
+        return _include_result(job, "missing_source")
+
+    try:
+        build_result = _text_plan_builders.build_include_text_file_action_plan(
+            file_path=job.file_path,
+            file_meta=file_meta,
+            selected_ids=selected_ids,
+            selection_ids_to_include=selection_ids,
+            replacement_payload=replacement_payload,
+            batch_source_object_id=batch_source_object_id,
+            captured_index_identity=job.expected_index_identity,
+            working_tree_artifact_path=working_tree_artifact_path,
+            captured_working_tree_exists=job.expected_worktree_identity.exists,
+            spool_dir=scratch_directory,
+        )
+        if build_result.missing_source:
+            return _include_result(job, "missing_source")
+        if build_result.plan is None:
+            return _include_result(job, "noop")
+
+        plan = build_result.plan
+        try:
+            index_change_type = getattr(
+                plan.index_change_type,
+                "value",
+                plan.index_change_type,
+            )
+            worktree_change_type = getattr(
+                plan.working_change_type,
+                "value",
+                plan.working_change_type,
+            )
+            index_output_path = _write_plan_output(
+                job.index_output_path,
+                plan.index_buffer,
+                index_change_type,
+            )
+            worktree_output_path = _write_plan_output(
+                job.worktree_output_path,
+                plan.working_buffer,
+                worktree_change_type,
+            )
+            return _include_result(
+                job,
+                "plan",
+                index_output_path=index_output_path,
+                worktree_output_path=worktree_output_path,
+                index_file_mode=plan.index_file_mode,
+                worktree_file_mode=plan.working_file_mode,
+                index_change_type=index_change_type,
+                worktree_change_type=worktree_change_type,
+            )
+        finally:
+            plan.close()
+    except AtomicUnitError as error:
+        _write_pickle(
+            job.details_artifact_path,
+            {
+                "message": str(error),
+                "required_selection_ids": (
+                    None
+                    if error.required_selection_ids is None
+                    else sorted(error.required_selection_ids)
+                ),
+                "unit_kind": error.unit_kind,
+            },
+        )
+        return _include_result(
+            job,
+            "atomic_unit_error",
+            has_details=True,
+        )
+    except MergeError:
+        candidate_count = (
+            _candidate_preview_counts.count_include_candidate_previews_for_file(
+                batch_name=batch_name,
+                file_path=job.file_path,
+                file_meta=file_meta,
+                selection_ids_to_include=selection_ids,
+                replacement_payload=replacement_payload,
+                batch_source_object_id=batch_source_object_id,
+                captured_index_identity=job.expected_index_identity,
+                working_tree_artifact_path=working_tree_artifact_path,
+                captured_working_tree_exists=(
+                    job.expected_worktree_identity.exists
+                ),
+                spool_dir=scratch_directory,
+            )
+        )
+        _write_pickle(
+            job.details_artifact_path,
+            {
+                "candidate_count": candidate_count.count,
+                "candidate_too_many": candidate_count.too_many,
+                "candidate_error": candidate_count.error,
+            },
+        )
+        return _include_result(job, "merge_error", has_details=True)
+    except CommandError as error:
+        _write_pickle(
+            job.details_artifact_path,
+            {
+                "message": error.message,
+                "exit_code": error.exit_code,
+            },
+        )
+        return _include_result(job, "command_error", has_details=True)
+    except ValueError as error:
+        _write_pickle(
+            job.details_artifact_path,
+            {"message": str(error)},
+        )
+        return _include_result(job, "value_error", has_details=True)
+    except Exception as error:
+        _write_pickle(
+            job.details_artifact_path,
+            {
+                "message": str(error),
+                "error_type": type(error).__name__,
+            },
+        )
+        return _include_result(job, "unexpected_error", has_details=True)
+
+
 def apply_text_plan_requires_source(
     file_meta: dict,
     selected_ids: set[int] | None,
 ) -> bool:
     """Return whether one apply text plan needs batch source content."""
     return _text_plan_builders.apply_text_plan_requires_source(
+        file_meta,
+        selected_ids,
+    )
+
+
+def include_text_plan_requires_source(
+    file_meta: dict,
+    selected_ids: set[int] | None,
+) -> bool:
+    """Return whether one include text plan needs batch source content."""
+    return _text_plan_builders.include_text_plan_requires_source(
         file_meta,
         selected_ids,
     )
@@ -227,7 +424,7 @@ def validate_apply_text_plan_job_result(
             )
         return
 
-    if result.outcome in _DETAIL_OUTCOMES:
+    if result.outcome in _APPLY_DETAIL_OUTCOMES:
         if result.details_artifact_path != job.details_artifact_path:
             raise ValueError(
                 f"apply text-plan worker returned an invalid details path for "
@@ -256,6 +453,94 @@ def validate_apply_text_plan_job_result(
         )
 
 
+def validate_include_text_plan_job_result(
+    job: IncludeTextPlanJob,
+    result: IncludeTextPlanJobResult,
+) -> None:
+    """Validate one include worker result before opening its artifacts."""
+    if not isinstance(result, IncludeTextPlanJobResult):
+        raise TypeError("include text-plan worker returned an invalid result")
+    if result.ordinal != job.ordinal or result.file_path != job.file_path:
+        raise ValueError(
+            f"include text-plan worker returned a mismatched result for "
+            f"{job.file_path}"
+        )
+    scalar_fields = (
+        ("index file mode", result.index_file_mode),
+        ("worktree file mode", result.worktree_file_mode),
+        ("index change type", result.index_change_type),
+        ("worktree change type", result.worktree_change_type),
+    )
+    for label, value in scalar_fields:
+        if value is not None and not isinstance(value, str):
+            raise TypeError(f"include text-plan result {label} must be text")
+
+    if result.outcome == "plan":
+        if result.details_artifact_path is not None:
+            raise ValueError("successful include text plan returned error details")
+        for target, change_type, output_path, expected_path in (
+            (
+                "index",
+                result.index_change_type,
+                result.index_output_path,
+                job.index_output_path,
+            ),
+            (
+                "worktree",
+                result.worktree_change_type,
+                result.worktree_output_path,
+                job.worktree_output_path,
+            ),
+        ):
+            if change_type not in _TEXT_CHANGE_TYPES:
+                raise ValueError(
+                    f"successful include text plan returned an invalid "
+                    f"{target} change type"
+                )
+            required_path = (
+                None if change_type == "deleted" else expected_path
+            )
+            if output_path != required_path:
+                raise ValueError(
+                    f"include text-plan worker returned an invalid "
+                    f"{target} output path for {job.file_path}"
+                )
+        return
+
+    if result.outcome in _INCLUDE_DETAIL_OUTCOMES:
+        if result.details_artifact_path != job.details_artifact_path:
+            raise ValueError(
+                f"include text-plan worker returned an invalid details path "
+                f"for {job.file_path}"
+            )
+    elif result.outcome in _EMPTY_OUTCOMES:
+        if result.details_artifact_path is not None:
+            raise ValueError(
+                f"include text-plan worker returned unexpected details for "
+                f"{job.file_path}"
+            )
+    else:
+        raise ValueError(
+            f"include text-plan worker returned an unknown outcome for "
+            f"{job.file_path}"
+        )
+    if any(
+        value is not None
+        for value in (
+            result.index_output_path,
+            result.worktree_output_path,
+            result.index_file_mode,
+            result.worktree_file_mode,
+            result.index_change_type,
+            result.worktree_change_type,
+        )
+    ):
+        raise ValueError(
+            f"include text-plan worker returned plan fields for "
+            f"{job.file_path} without a plan"
+        )
+
+
 def _result(
     job: ApplyTextPlanJob,
     outcome: ApplyTextPlanOutcome,
@@ -275,6 +560,60 @@ def _result(
         output_path=output_path,
         file_mode=file_mode,
         change_type=change_type,
+    )
+
+
+def _include_result(
+    job: IncludeTextPlanJob,
+    outcome: IncludeTextPlanOutcome,
+    *,
+    has_details: bool = False,
+    index_output_path: str | None = None,
+    worktree_output_path: str | None = None,
+    index_file_mode: str | None = None,
+    worktree_file_mode: str | None = None,
+    index_change_type: str | None = None,
+    worktree_change_type: str | None = None,
+) -> IncludeTextPlanJobResult:
+    return IncludeTextPlanJobResult(
+        ordinal=job.ordinal,
+        file_path=job.file_path,
+        outcome=outcome,
+        details_artifact_path=(
+            job.details_artifact_path if has_details else None
+        ),
+        index_output_path=index_output_path,
+        worktree_output_path=worktree_output_path,
+        index_file_mode=index_file_mode,
+        worktree_file_mode=worktree_file_mode,
+        index_change_type=index_change_type,
+        worktree_change_type=worktree_change_type,
+    )
+
+
+def _write_plan_output(
+    path: str,
+    buffer,
+    change_type: str,
+) -> str | None:
+    if buffer is None or change_type == "deleted":
+        return None
+    write_buffer_to_path(path, buffer)
+    return path
+
+
+def _replacement_payload_from_metadata(
+    input_metadata: dict,
+) -> ReplacementPayload | None:
+    replacement_path = input_metadata["replacement_artifact_path"]
+    if replacement_path is None:
+        return None
+    with Path(replacement_path).open("rb") as source:
+        data = source.read()
+    return ReplacementPayload(
+        data=data,
+        display_text=input_metadata["replacement_display_text"],
+        exact=input_metadata["replacement_exact"],
     )
 
 

--- a/src/git_stage_batch/core/replacement.py
+++ b/src/git_stage_batch/core/replacement.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
+from pathlib import Path
 from typing import overload
 
 from .buffer import LineBuffer
@@ -136,12 +137,17 @@ def _legacy_replacement_line_chunks(data: bytes) -> Iterator[bytes]:
 @contextmanager
 def replacement_line_chunks(
     payload: ReplacementPayload,
+    *,
+    spool_dir: str | Path | None = None,
 ) -> Iterator[Sequence[bytes]]:
     """Expose replacement bytes as a scoped indexed line sequence."""
     buffer = (
-        LineBuffer.from_bytes(payload.data)
+        LineBuffer.from_bytes(payload.data, spool_dir=spool_dir)
         if payload.exact
-        else LineBuffer.from_chunks(_legacy_replacement_line_chunks(payload.data))
+        else LineBuffer.from_chunks(
+            _legacy_replacement_line_chunks(payload.data),
+            spool_dir=spool_dir,
+        )
     )
     with buffer:
         yield buffer
@@ -150,7 +156,9 @@ def replacement_line_chunks(
 @contextmanager
 def replacement_line_bodies(
     payload: ReplacementPayload,
+    *,
+    spool_dir: str | Path | None = None,
 ) -> Iterator[Sequence[bytes]]:
     """Expose scoped editor line bodies without retaining per-line objects."""
-    with replacement_line_chunks(payload) as lines:
+    with replacement_line_chunks(payload, spool_dir=spool_dir) as lines:
         yield _ReplacementLineBodies(lines)

--- a/src/git_stage_batch/data/file_target_identity.py
+++ b/src/git_stage_batch/data/file_target_identity.py
@@ -40,6 +40,20 @@ class IndexIdentity:
     mode: str | None
     object_id: str | None
 
+    @property
+    def exists(self) -> bool:
+        """Return whether the stage-zero index entry exists."""
+        return self.object_id is not None
+
+    @property
+    def content_object_id(self) -> str | None:
+        """Return the object ID when the entry has loadable content."""
+        if self.object_id is None or not any(
+            character != "0" for character in self.object_id
+        ):
+            return None
+        return self.object_id
+
 
 def index_identity_from_entry(entry: IndexEntry | None) -> IndexIdentity:
     """Convert an optional stage-zero entry to its compact identity."""

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -13821,27 +13821,35 @@ def test_batch_source_text_plan_builders_own_apply_text_planning():
             "get_git_repository_root_path",
         },
     }
-    imports_text_plan_builders = False
-    direct_plan_imports = set()
+    planning_paths = (text_plan_jobs_path, apply_action_path)
+    imports_text_plan_builders = {path: False for path in planning_paths}
+    direct_plan_imports = {path: set() for path in planning_paths}
 
-    for imported_module, node in _import_from_nodes(text_plan_jobs_path):
-        imported_names = {alias.name for alias in node.names}
-        if (
-            imported_module == "git_stage_batch.commands.batch_source"
-            and "text_plan_builders" in imported_names
-        ):
-            imports_text_plan_builders = True
-        direct_plan_imports |= imported_names & disallowed_imports.get(
-            imported_module,
-            set(),
-        )
+    for path in planning_paths:
+        for imported_module, node in _import_from_nodes(path):
+            imported_names = {alias.name for alias in node.names}
+            if (
+                imported_module == "git_stage_batch.commands.batch_source"
+                and "text_plan_builders" in imported_names
+            ):
+                imports_text_plan_builders[path] = True
+            direct_plan_imports[path] |= (
+                imported_names
+                & disallowed_imports.get(imported_module, set())
+            )
 
     action_text = apply_action_path.read_text()
     job_text = text_plan_jobs_path.read_text()
 
     assert public_names <= vars(text_plan_builders).keys()
-    assert imports_text_plan_builders
-    assert direct_plan_imports == set()
+    assert imports_text_plan_builders == {
+        text_plan_jobs_path: True,
+        apply_action_path: False,
+    }
+    assert direct_plan_imports == {
+        text_plan_jobs_path: set(),
+        apply_action_path: {"get_git_repository_root_path"},
+    }
     assert "build_apply_text_file_action_plan(" in job_text
     assert "build_apply_text_file_action_plan(" not in action_text
     assert "merge_batch_from_line_sequences_as_buffer(" not in action_text
@@ -13856,6 +13864,9 @@ def test_batch_source_text_plan_builders_own_include_text_planning():
     )
     include_action_path = (
         SRC_ROOT / "commands" / "batch_source" / "include_action.py"
+    )
+    text_plan_jobs_path = (
+        SRC_ROOT / "commands" / "batch_source" / "text_plan_jobs.py"
     )
     public_names = {
         "IncludeTextPlanBuildResult",
@@ -13888,27 +13899,37 @@ def test_batch_source_text_plan_builders_own_include_text_planning():
             "get_git_repository_root_path",
         },
     }
-    imports_text_plan_builders = False
-    direct_plan_imports = set()
+    planning_paths = (text_plan_jobs_path, include_action_path)
+    imports_text_plan_builders = {path: False for path in planning_paths}
+    direct_plan_imports = {path: set() for path in planning_paths}
 
-    for imported_module, node in _import_from_nodes(include_action_path):
-        imported_names = {alias.name for alias in node.names}
-        if (
-            imported_module == "git_stage_batch.commands.batch_source"
-            and "text_plan_builders" in imported_names
-        ):
-            imports_text_plan_builders = True
-        direct_plan_imports |= imported_names & disallowed_imports.get(
-            imported_module,
-            set(),
-        )
+    for path in planning_paths:
+        for imported_module, node in _import_from_nodes(path):
+            imported_names = {alias.name for alias in node.names}
+            if (
+                imported_module == "git_stage_batch.commands.batch_source"
+                and "text_plan_builders" in imported_names
+            ):
+                imports_text_plan_builders[path] = True
+            direct_plan_imports[path] |= (
+                imported_names
+                & disallowed_imports.get(imported_module, set())
+            )
 
     action_text = include_action_path.read_text()
+    job_text = text_plan_jobs_path.read_text()
 
     assert public_names <= vars(text_plan_builders).keys()
-    assert imports_text_plan_builders
-    assert direct_plan_imports == set()
-    assert "build_include_text_file_action_plan(" in action_text
+    assert imports_text_plan_builders == {
+        text_plan_jobs_path: True,
+        include_action_path: False,
+    }
+    assert direct_plan_imports == {
+        text_plan_jobs_path: set(),
+        include_action_path: {"get_git_repository_root_path"},
+    }
+    assert "build_include_text_file_action_plan(" in job_text
+    assert "build_include_text_file_action_plan(" not in action_text
     assert "merge_batch_from_line_sequences_as_buffer(" not in action_text
     assert "build_replacement_batch_view_from_lines(" not in action_text
     assert "selected_text_target_change_type(" not in action_text
@@ -14353,6 +14374,7 @@ def test_batch_source_candidate_preview_counts_own_failure_enumeration():
     }
     command_paths = {
         text_plan_jobs_path,
+        apply_action_path,
         include_action_path,
     }
     imports_candidate_preview_counts = {
@@ -14388,10 +14410,12 @@ def test_batch_source_candidate_preview_counts_own_failure_enumeration():
     assert public_names <= vars(candidate_preview_counts).keys()
     assert imports_candidate_preview_counts == {
         text_plan_jobs_path: True,
-        include_action_path: True,
+        apply_action_path: False,
+        include_action_path: False,
     }
     assert direct_count_imports == {
         text_plan_jobs_path: set(),
+        apply_action_path: set(),
         include_action_path: set(),
     }
     for path, old_names in old_function_names.items():
@@ -15198,8 +15222,8 @@ def test_batch_source_apply_action_owns_apply_execution():
     assert "finish_batch_source_action_review(" in action_text
 
 
-def test_apply_text_jobs_do_not_bypass_command_or_git_boundaries():
-    """Apply workers should use shared execution helpers and never spawn directly."""
+def test_text_plan_jobs_do_not_bypass_command_or_git_boundaries():
+    """Text-plan workers should use shared helpers and never spawn directly."""
     paths = (
         SRC_ROOT / "commands" / "batch_source" / "text_plan_jobs.py",
         SRC_ROOT / "data" / "file_target_identity.py",
@@ -15249,6 +15273,7 @@ def test_apply_from_delegates_apply_action_execution():
             "merge_refusals",
             "text_file_actions",
             "text_plan_builders",
+            "text_plan_jobs",
             "worktree_refusals",
         },
         "git_stage_batch.batch.binary_file_content": {
@@ -15308,16 +15333,18 @@ def test_batch_source_include_action_owns_include_execution():
         ("git_stage_batch.commands.batch_source", "action_plans"),
         ("git_stage_batch.commands.batch_source", "atomic_unit_refusals"),
         ("git_stage_batch.commands.batch_source", "binary_file_actions"),
-        ("git_stage_batch.commands.batch_source", "candidate_preview_counts"),
         ("git_stage_batch.commands.batch_source", "candidate_refusals"),
         ("git_stage_batch.commands.batch_source", "merge_refusals"),
         ("git_stage_batch.commands.batch_source", "text_file_actions"),
-        ("git_stage_batch.commands.batch_source", "text_plan_builders"),
+        ("git_stage_batch.commands.batch_source", "text_plan_jobs"),
         ("git_stage_batch.commands.batch_source", "worktree_refusals"),
         ("git_stage_batch.batch.binary_file_content", "read_binary_file_from_batch"),
         ("git_stage_batch.batch.submodule_pointer", "stage_submodule_pointer_from_batch"),
+        ("git_stage_batch.data.file_target_identity", "capture_worktree_identity"),
         ("git_stage_batch.data.session", "snapshot_file_if_untracked"),
         ("git_stage_batch.data.undo_checkpoints", "undo_checkpoint"),
+        ("git_stage_batch.utils.file_jobs", "run_file_jobs"),
+        ("git_stage_batch.utils.file_job_workspace", "FileJobWorkspace"),
     }
     action_imports = set()
 
@@ -15329,7 +15356,8 @@ def test_batch_source_include_action_owns_include_execution():
 
     assert public_names <= vars(include_action).keys()
     assert required_imports <= action_imports
-    assert "build_include_text_file_action_plan(" in action_text
+    assert "compute_include_text_plan_job" in action_text
+    assert "build_include_text_file_action_plan(" not in action_text
     assert "stage_text_file_to_index(" in action_text
     assert "stage_binary_file_to_index(" in action_text
     assert "finish_batch_source_action_review(" in action_text
@@ -15349,6 +15377,7 @@ def test_include_from_delegates_include_action_execution():
             "merge_refusals",
             "text_file_actions",
             "text_plan_builders",
+            "text_plan_jobs",
             "worktree_refusals",
         },
         "git_stage_batch.batch.binary_file_content": {

--- a/tests/commands/batch_source/test_text_plan_jobs.py
+++ b/tests/commands/batch_source/test_text_plan_jobs.py
@@ -1,4 +1,4 @@
-"""Tests for artifact-backed apply text planning."""
+"""Tests for artifact-backed batch-source text planning."""
 
 import pickle
 from pathlib import Path
@@ -7,20 +7,29 @@ import pytest
 
 from git_stage_batch.commands.batch_source.action_plans import (
     ApplyTextFileActionPlan,
+    IncludeTextFileActionPlan,
 )
 from git_stage_batch.commands.batch_source.text_plan_builders import (
     ApplyTextPlanBuildResult,
+    IncludeTextPlanBuildResult,
 )
 from git_stage_batch.commands.batch_source.text_plan_jobs import (
     ApplyTextPlanJob,
     ApplyTextPlanJobResult,
+    IncludeTextPlanJob,
+    IncludeTextPlanJobResult,
     compute_apply_text_plan_job,
+    compute_include_text_plan_job,
     validate_apply_text_plan_job_result,
+    validate_include_text_plan_job_result,
 )
 import git_stage_batch.commands.batch_source.apply_action as apply_action
 import git_stage_batch.commands.batch_source.text_plan_jobs as text_plan_jobs
 from git_stage_batch.core.buffer import LineBuffer
-from git_stage_batch.data.file_target_identity import WorktreeIdentity
+from git_stage_batch.data.file_target_identity import (
+    IndexIdentity,
+    WorktreeIdentity,
+)
 from git_stage_batch.exceptions import AtomicUnitError, CommandError
 from git_stage_batch.utils.file_job_workspace import FileJobWorkspace
 from git_stage_batch.utils.file_jobs import assert_file_job_transport_value
@@ -67,6 +76,243 @@ def _job(
     )
 
 
+def _include_job(
+    workspace,
+    *,
+    replacement_data: bytes | None = None,
+    batch_source_object_id: str | None = "a" * 40,
+    change_type: str = "modified",
+    whole_file: bool = False,
+) -> IncludeTextPlanJob:
+    worktree_path = workspace.write_buffer(0, "worktree", (b"worktree\n",))
+    replacement_path = (
+        None
+        if replacement_data is None
+        else workspace.write_buffer(0, "replacement", (replacement_data,))
+    )
+    scratch = workspace.scratch_directory(0)
+    input_path = workspace.write_pickle(
+        0,
+        "include-input.pickle",
+        {
+            "batch_name": "batch",
+            "batch_source_object_id": batch_source_object_id,
+            "file_meta": {
+                "batch_source_commit": "b" * 40,
+                "change_type": change_type,
+            },
+            "selected_ids": None if whole_file else [1],
+            "selection_ids": None if whole_file else [1],
+            "working_tree_artifact_path": str(worktree_path),
+            "replacement_artifact_path": (
+                None if replacement_path is None else str(replacement_path)
+            ),
+            "replacement_display_text": None,
+            "replacement_exact": True,
+            "scratch_directory": str(scratch),
+        },
+    )
+    return IncludeTextPlanJob(
+        ordinal=0,
+        file_path="file.txt",
+        input_artifact_path=str(input_path),
+        index_output_path=str(workspace.output_path(0, "index-output")),
+        worktree_output_path=str(
+            workspace.output_path(0, "worktree-output")
+        ),
+        details_artifact_path=str(workspace.output_path(0, "details")),
+        expected_index_identity=IndexIdentity("100644", "c" * 40),
+        expected_worktree_identity=WorktreeIdentity(
+            True,
+            "regular",
+            0o644,
+            9,
+            "digest",
+        ),
+    )
+
+
+def test_compute_include_streams_distinct_target_outputs(
+    tmp_path,
+    monkeypatch,
+):
+    with FileJobWorkspace(parent_directory=tmp_path) as workspace:
+        job = _include_job(workspace, replacement_data=b"replacement\n")
+        captured = {}
+
+        def build_plan(**kwargs):
+            captured.update(kwargs)
+            return IncludeTextPlanBuildResult(
+                plan=IncludeTextFileActionPlan(
+                    "file.txt",
+                    LineBuffer.from_bytes(b"index\n"),
+                    LineBuffer.from_bytes(b"worktree\n"),
+                    "100644",
+                    "100755",
+                    "modified",
+                    "modified",
+                )
+            )
+
+        monkeypatch.setattr(
+            text_plan_jobs._text_plan_builders,
+            "build_include_text_file_action_plan",
+            build_plan,
+        )
+
+        result = compute_include_text_plan_job(job)
+
+        assert result.outcome == "plan"
+        assert Path(job.index_output_path).read_bytes() == b"index\n"
+        assert Path(job.worktree_output_path).read_bytes() == b"worktree\n"
+        assert captured["captured_index_identity"] == IndexIdentity(
+            "100644",
+            "c" * 40,
+        )
+        assert captured["replacement_payload"].data == b"replacement\n"
+        assert captured["spool_dir"] == str(workspace.scratch_directory(0))
+
+
+def test_compute_include_preserves_independent_deletion_outputs(
+    tmp_path,
+    monkeypatch,
+):
+    with FileJobWorkspace(parent_directory=tmp_path) as workspace:
+        job = _include_job(workspace)
+
+        def build_plan(**_kwargs):
+            return IncludeTextPlanBuildResult(
+                plan=IncludeTextFileActionPlan(
+                    "file.txt",
+                    None,
+                    LineBuffer.from_bytes(b"retained\n"),
+                    None,
+                    "100644",
+                    "deleted",
+                    "modified",
+                )
+            )
+
+        monkeypatch.setattr(
+            text_plan_jobs._text_plan_builders,
+            "build_include_text_file_action_plan",
+            build_plan,
+        )
+
+        result = compute_include_text_plan_job(job)
+
+        assert result.index_output_path is None
+        assert not Path(job.index_output_path).exists()
+        assert result.worktree_output_path == job.worktree_output_path
+        assert Path(job.worktree_output_path).read_bytes() == b"retained\n"
+
+
+def test_compute_include_whole_deletion_does_not_load_target_blobs(
+    tmp_path,
+    monkeypatch,
+):
+    with FileJobWorkspace(parent_directory=tmp_path) as workspace:
+        job = _include_job(
+            workspace,
+            batch_source_object_id=None,
+            change_type="deleted",
+            whole_file=True,
+        )
+        monkeypatch.setattr(
+            text_plan_jobs._text_plan_builders,
+            "load_git_blob_as_buffer",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                AssertionError("whole deletion should not load a target blob")
+            ),
+        )
+
+        result = compute_include_text_plan_job(job)
+
+        assert result.outcome == "plan"
+        assert result.index_output_path is None
+        assert result.worktree_output_path is None
+        assert result.index_change_type == "deleted"
+        assert result.worktree_change_type == "deleted"
+
+
+def test_compute_include_closes_aliased_outputs_once(tmp_path, monkeypatch):
+    with FileJobWorkspace(parent_directory=tmp_path) as workspace:
+        job = _include_job(workspace)
+
+        class TrackingBuffer:
+            def __init__(self):
+                self.close_count = 0
+
+            def __iter__(self):
+                yield b"same\n"
+
+            def close(self):
+                self.close_count += 1
+
+        shared = TrackingBuffer()
+        monkeypatch.setattr(
+            text_plan_jobs._text_plan_builders,
+            "build_include_text_file_action_plan",
+            lambda **_kwargs: IncludeTextPlanBuildResult(
+                plan=IncludeTextFileActionPlan(
+                    "file.txt",
+                    shared,
+                    shared,
+                    "100644",
+                    "100644",
+                    "modified",
+                    "modified",
+                )
+            ),
+        )
+
+        compute_include_text_plan_job(job)
+
+        assert shared.close_count == 1
+
+
+def test_include_result_validation_rejects_worker_selected_paths(tmp_path):
+    with FileJobWorkspace(parent_directory=tmp_path) as workspace:
+        job = _include_job(workspace)
+        result = IncludeTextPlanJobResult(
+            ordinal=job.ordinal,
+            file_path=job.file_path,
+            outcome="plan",
+            details_artifact_path=None,
+            index_output_path=str(tmp_path / "outside"),
+            worktree_output_path=job.worktree_output_path,
+            index_file_mode="100644",
+            worktree_file_mode="100644",
+            index_change_type="modified",
+            worktree_change_type="modified",
+        )
+
+        with pytest.raises(ValueError, match="invalid index output path"):
+            validate_include_text_plan_job_result(job, result)
+
+
+def test_compute_include_preserves_replacement_value_errors(
+    tmp_path,
+    monkeypatch,
+):
+    with FileJobWorkspace(parent_directory=tmp_path) as workspace:
+        job = _include_job(workspace)
+        monkeypatch.setattr(
+            text_plan_jobs._text_plan_builders,
+            "build_include_text_file_action_plan",
+            lambda **_kwargs: (_ for _ in ()).throw(
+                ValueError("replacement must stay contiguous")
+            ),
+        )
+
+        result = compute_include_text_plan_job(job)
+
+        assert result.outcome == "value_error"
+        assert workspace.read_pickle(result.details_artifact_path) == {
+            "message": "replacement must stay contiguous"
+        }
+
+
 def test_compute_apply_keeps_value_errors_as_file_failures(
     tmp_path,
     monkeypatch,
@@ -88,6 +334,21 @@ def test_compute_apply_keeps_value_errors_as_file_failures(
             "message": "invalid apply target",
             "error_type": "ValueError",
         }
+
+
+def test_include_transport_size_does_not_follow_replacement_artifact(tmp_path):
+    with FileJobWorkspace(parent_directory=tmp_path) as workspace:
+        small = _include_job(workspace, replacement_data=b"x")
+        small_size = len(pickle.dumps(small))
+        large = _include_job(
+            workspace,
+            replacement_data=b"x" * (2 * 1024 * 1024),
+        )
+        large_size = len(pickle.dumps(large))
+
+        assert_file_job_transport_value(small)
+        assert_file_job_transport_value(large)
+        assert abs(large_size - small_size) < 128
 
 
 def test_compute_streams_plan_output_to_the_workspace(tmp_path, monkeypatch):
@@ -248,6 +509,26 @@ def test_result_validation_rejects_stale_apply_worker_outcome(tmp_path):
 
         with pytest.raises(ValueError, match="unknown outcome"):
             validate_apply_text_plan_job_result(job, result)
+
+
+def test_result_validation_rejects_stale_include_worker_outcome(tmp_path):
+    with FileJobWorkspace(parent_directory=tmp_path) as workspace:
+        job = _include_job(workspace)
+        result = IncludeTextPlanJobResult(
+            ordinal=job.ordinal,
+            file_path=job.file_path,
+            outcome="stale",
+            details_artifact_path=None,
+            index_output_path=None,
+            worktree_output_path=None,
+            index_file_mode=None,
+            worktree_file_mode=None,
+            index_change_type=None,
+            worktree_change_type=None,
+        )
+
+        with pytest.raises(ValueError, match="unknown outcome"):
+            validate_include_text_plan_job_result(job, result)
 
 
 def test_parent_builds_whole_file_deletion_without_resolving_source(

--- a/tests/commands/test_include_from.py
+++ b/tests/commands/test_include_from.py
@@ -3,6 +3,7 @@
 import os
 import stat
 import subprocess
+import sys
 
 import pytest
 
@@ -15,14 +16,27 @@ from git_stage_batch.commands.apply_from import command_apply_from_batch
 from git_stage_batch.commands.discard_from import command_discard_from_batch
 from git_stage_batch.commands.include import command_include_to_batch
 from git_stage_batch.commands.include_from import command_include_from_batch
+from git_stage_batch.commands.redo import command_redo
 from git_stage_batch.commands.show_from import command_show_from_batch
 from git_stage_batch.commands.start import command_start
+from git_stage_batch.commands.undo import command_undo
 from git_stage_batch.batch.file_display import render_batch_file_display
 from git_stage_batch.data.file_review.state import clear_last_file_review_state
+from git_stage_batch.data.file_target_identity import (
+    IndexIdentity,
+    WorktreeIdentity,
+)
 from git_stage_batch.data.session import initialize_abort_state
 from git_stage_batch.exceptions import CommandError
 from git_stage_batch.utils.git_command import run_git_command
 from git_stage_batch.utils.paths import ensure_state_directory_exists
+
+
+_RUNNING_UNDER_XDIST = "PYTEST_XDIST_WORKER" in os.environ
+_PROCESS_TEST = pytest.mark.skipif(
+    sys.platform != "linux" or _RUNNING_UNDER_XDIST,
+    reason="forced forkserver coverage runs on Linux with pytest -n 0",
+)
 
 
 @pytest.fixture
@@ -602,3 +616,233 @@ class TestCommandIncludeFromBatch:
         result = run_git_command(["show", ":test.txt"])
         assert result.stdout == "old one\nold two\nkeep\n"
         assert test_file.read_text() == "old one\nold two\nkeep\n"
+
+    def test_include_rejects_index_change_after_planning(
+        self,
+        temp_git_repo,
+        monkeypatch,
+    ):
+        """A changed index target should abort before include mutation."""
+        target = temp_git_repo / "target.txt"
+        target.write_text("base\n")
+        run_git_command(["add", "target.txt"])
+        run_git_command(["commit", "-m", "Add target"])
+        target.write_text("batch\n")
+        command_start(quiet=True)
+        command_include_to_batch(
+            "test-batch",
+            file="target.txt",
+            quiet=True,
+        )
+        target.write_text("worktree target\n")
+        run_git_command(["reset", "HEAD", "target.txt"])
+
+        real_run_file_jobs = include_action.run_file_jobs
+
+        def mutate_index(*args, **kwargs):
+            results = real_run_file_jobs(*args, **kwargs)
+            object_id = run_git_command(
+                ["hash-object", "-w", "--stdin"],
+                stdin_chunks=(b"stale index\n",),
+            ).stdout.strip()
+            run_git_command(
+                [
+                    "update-index",
+                    "--cacheinfo",
+                    "100644",
+                    object_id,
+                    "target.txt",
+                ]
+            )
+            return results
+
+        monkeypatch.setattr(include_action, "run_file_jobs", mutate_index)
+
+        with pytest.raises(CommandError, match="Index changed"):
+            command_include_from_batch("test-batch")
+
+        assert run_git_command(["show", ":target.txt"]).stdout == "stale index\n"
+        assert target.read_text() == "worktree target\n"
+
+    def test_include_rejects_worktree_change_after_planning(
+        self,
+        temp_git_repo,
+        monkeypatch,
+    ):
+        """A changed worktree target should abort before index mutation."""
+        target = temp_git_repo / "target.txt"
+        target.write_text("base\n")
+        run_git_command(["add", "target.txt"])
+        run_git_command(["commit", "-m", "Add target"])
+        target.write_text("batch\n")
+        command_start(quiet=True)
+        command_include_to_batch(
+            "test-batch",
+            file="target.txt",
+            quiet=True,
+        )
+        run_git_command(["checkout", "HEAD", "--", "target.txt"])
+
+        real_run_file_jobs = include_action.run_file_jobs
+        real_workspace = include_action.FileJobWorkspace
+        workspace_roots = []
+
+        def mutate_worktree(*args, **kwargs):
+            results = real_run_file_jobs(*args, **kwargs)
+            target.write_text("stale worktree\n")
+            return results
+
+        def record_workspace(*args, **kwargs):
+            workspace = real_workspace(*args, **kwargs)
+            workspace_roots.append(workspace.root)
+            return workspace
+
+        monkeypatch.setattr(include_action, "run_file_jobs", mutate_worktree)
+        monkeypatch.setattr(
+            include_action,
+            "FileJobWorkspace",
+            record_workspace,
+        )
+
+        with pytest.raises(CommandError, match="Working tree file changed"):
+            command_include_from_batch("test-batch")
+
+        assert run_git_command(["show", ":target.txt"]).stdout == "base\n"
+        assert target.read_text() == "stale worktree\n"
+        assert workspace_roots
+        assert all(not root.exists() for root in workspace_roots)
+
+    def test_include_reports_earlier_index_change_before_worktree_reads(
+        self,
+        monkeypatch,
+    ):
+        """Index staleness should win before any later worktree read failure."""
+        expected_index_identities = {
+            "first.txt": IndexIdentity("100644", "a" * 40),
+            "second.txt": IndexIdentity("100644", "b" * 40),
+        }
+        expected_worktree_identities = {
+            path: WorktreeIdentity(
+                True,
+                "regular",
+                0o644,
+                4,
+                "digest",
+            )
+            for path in expected_index_identities
+        }
+        monkeypatch.setattr(
+            include_action,
+            "read_index_entries",
+            lambda _paths: {},
+        )
+        monkeypatch.setattr(
+            include_action,
+            "capture_worktree_identity",
+            lambda _path: (_ for _ in ()).throw(
+                AssertionError("worktree read should not precede stale index")
+            ),
+        )
+
+        with pytest.raises(CommandError, match="Index changed.*first.txt"):
+            include_action._require_unchanged_include_targets(
+                expected_index_identities,
+                expected_worktree_identities,
+            )
+
+    @_PROCESS_TEST
+    def test_forced_process_include_matches_inline_targets_and_undo(
+        self,
+        temp_git_repo,
+        monkeypatch,
+        capsys,
+    ):
+        """Forced transports should publish the same ordered include result."""
+        baseline = {}
+        expected = {}
+        for index in range(4):
+            name = f"{index}.txt"
+            baseline[name] = f"base-{index}-" + "x" * 5000 + "\n"
+            expected[name] = f"batch-{index}-" + "y" * 5000 + "\n"
+            (temp_git_repo / name).write_text(baseline[name])
+        run_git_command(["add", "."])
+        run_git_command(["commit", "-m", "Add process targets"])
+        for name, content in expected.items():
+            (temp_git_repo / name).write_text(content)
+        command_start(quiet=True)
+        for name in expected:
+            command_include_to_batch(
+                "test-batch",
+                file=name,
+                quiet=True,
+            )
+        capsys.readouterr()
+        mapped_outputs = []
+        original_stage = (
+            include_action._text_file_actions.stage_text_file_to_index
+        )
+        original_write = (
+            include_action._text_file_actions.write_text_file_to_worktree
+        )
+
+        def record_stage(file_path, buffer, file_mode, change_type):
+            mapped_outputs.append(buffer.uses_mapped_storage)
+            return original_stage(
+                file_path,
+                buffer,
+                file_mode,
+                change_type,
+            )
+
+        def record_write(file_path, buffer, file_mode, change_type):
+            mapped_outputs.append(buffer.uses_mapped_storage)
+            return original_write(
+                file_path,
+                buffer,
+                file_mode,
+                change_type,
+            )
+
+        monkeypatch.setattr(
+            include_action._text_file_actions,
+            "stage_text_file_to_index",
+            record_stage,
+        )
+        monkeypatch.setattr(
+            include_action._text_file_actions,
+            "write_text_file_to_worktree",
+            record_write,
+        )
+
+        observations = []
+        for requested_jobs in ("1", "2"):
+            run_git_command(["reset", "--hard", "HEAD"])
+            monkeypatch.setenv("GIT_STAGE_BATCH_JOBS", requested_jobs)
+
+            command_include_from_batch("test-batch")
+
+            observations.append(
+                (
+                    {
+                        name: (temp_git_repo / name).read_text()
+                        for name in expected
+                    },
+                    run_git_command(["write-tree"]).stdout.strip(),
+                    capsys.readouterr(),
+                )
+            )
+            command_undo(force=True)
+            assert {
+                name: (temp_git_repo / name).read_text()
+                for name in baseline
+            } == baseline
+            command_redo(force=True)
+            assert {
+                name: (temp_git_repo / name).read_text()
+                for name in expected
+            } == expected
+            capsys.readouterr()
+
+        assert observations[0] == observations[1]
+        assert observations[0][0] == expected
+        assert mapped_outputs == [True] * 16

--- a/tests/data/test_file_target_identity.py
+++ b/tests/data/test_file_target_identity.py
@@ -193,3 +193,16 @@ def test_index_identity_converts_stage_zero_entries():
     assert index_identity_from_entry(
         IndexEntry("100755", "a" * 40)
     ) == IndexIdentity("100755", "a" * 40)
+
+
+def test_index_identity_distinguishes_entries_from_loadable_content():
+    missing = IndexIdentity(None, None)
+    intent_to_add = IndexIdentity("100644", "0" * 40)
+    populated = IndexIdentity("100644", "a" * 40)
+
+    assert missing.exists is False
+    assert missing.content_object_id is None
+    assert intent_to_add.exists is True
+    assert intent_to_add.content_object_id is None
+    assert populated.exists is True
+    assert populated.content_object_id == "a" * 40


### PR DESCRIPTION
Multi-file include currently plans text targets serially against live index and worktree state.

Bounded planning needs to distinguish missing and intent-to-add entries, keep replacement and merge storage invocation-local, capture every source and target before dispatch, and preserve file-order diagnostics before any mutation begins.

This pull request exposes loadable index identities, routes replacement buffers through caller-owned storage, builds plans and conflict details from captured artifacts, defines compact include jobs, and dispatches them through the shared ordered executor. The parent revalidates index and worktree identities before applying the reduced plans.

Coverage verifies loadable identity states, artifact ownership, deletion and replacement outcomes, strict result validation, process parity, stale-target ordering, workspace cleanup, undo and redo behavior, and the architecture boundary between worker planning and parent mutation.