### PR TITLE
batch-transform: Close sift ownership buffers

### DIFF
--- a/src/git_stage_batch/commands/batch_transform/sift_results.py
+++ b/src/git_stage_batch/commands/batch_transform/sift_results.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
 
@@ -59,12 +59,16 @@ class SiftedTextFileResult:
     ownership: BatchOwnership
     target_buffer: LineBuffer
     change_type: str
+    _closed: bool = field(default=False, init=False, repr=False)
 
     def target_source_buffer(self) -> LineBuffer | None:
         return self.target_buffer
 
     def close(self) -> None:
-        self.target_buffer.close()
+        if self._closed:
+            return
+        self._closed = True
+        _close_text_result_buffers(self.target_buffer, self.ownership)
 
 
 @dataclass
@@ -228,6 +232,28 @@ def compute_sifted_text_file(
         finally:
             if target_buffer is not None:
                 target_buffer.close()
+
+
+def _close_text_result_buffers(
+    target_buffer: LineBuffer,
+    ownership: BatchOwnership,
+) -> None:
+    buffers = [target_buffer, *_text_ownership_buffers(ownership)]
+    closed_ids: set[int] = set()
+    for buffer in buffers:
+        buffer_id = id(buffer)
+        if buffer_id in closed_ids:
+            continue
+        closed_ids.add(buffer_id)
+        buffer.close()
+
+
+def _text_ownership_buffers(ownership: BatchOwnership) -> list[LineBuffer]:
+    return [
+        deletion.content_lines
+        for deletion in ownership.deletions
+        if isinstance(deletion.content_lines, LineBuffer)
+    ]
 
 
 def build_ownership_from_working_and_target_lines(

--- a/src/git_stage_batch/commands/batch_transform/sift_results.py
+++ b/src/git_stage_batch/commands/batch_transform/sift_results.py
@@ -287,39 +287,52 @@ def build_ownership_from_working_and_target_lines(
             content_lines=content_lines,
         )
 
-    for run in semantic_runs:
-        if run.kind == SemanticChangeKind.PRESENCE:
-            if run.target_start is not None and run.target_end is not None:
-                claimed_ranges.append((run.target_start, run.target_end))
-        elif run.kind == SemanticChangeKind.DELETION:
-            if run.source_start is not None and run.source_end is not None:
-                deletion_claims.append(
-                    build_absence_claim(
-                        anchor_line=run.target_anchor,
-                        source_start=run.source_start,
-                        source_end=run.source_end,
+    try:
+        for run in semantic_runs:
+            if run.kind == SemanticChangeKind.PRESENCE:
+                if run.target_start is not None and run.target_end is not None:
+                    claimed_ranges.append((run.target_start, run.target_end))
+            elif run.kind == SemanticChangeKind.DELETION:
+                if run.source_start is not None and run.source_end is not None:
+                    deletion_claims.append(
+                        build_absence_claim(
+                            anchor_line=run.target_anchor,
+                            source_start=run.source_start,
+                            source_end=run.source_end,
+                        )
                     )
-                )
-        elif run.kind == SemanticChangeKind.REPLACEMENT:
-            if run.source_start is not None and run.source_end is not None:
-                deletion_claims.append(
-                    build_absence_claim(
-                        anchor_line=run.target_anchor,
-                        source_start=run.source_start,
-                        source_end=run.source_end,
+            elif run.kind == SemanticChangeKind.REPLACEMENT:
+                if run.source_start is not None and run.source_end is not None:
+                    deletion_claims.append(
+                        build_absence_claim(
+                            anchor_line=run.target_anchor,
+                            source_start=run.source_start,
+                            source_end=run.source_end,
+                        )
                     )
-                )
-            if run.target_start is not None and run.target_end is not None:
-                claimed_ranges.append((run.target_start, run.target_end))
+                if run.target_start is not None and run.target_end is not None:
+                    claimed_ranges.append((run.target_start, run.target_end))
 
-    claimed_line_ranges = LineRanges.from_ranges(claimed_ranges)
-    if not claimed_line_ranges and not deletion_claims:
-        return None
+        claimed_line_ranges = LineRanges.from_ranges(claimed_ranges)
+        if not claimed_line_ranges and not deletion_claims:
+            return None
 
-    return BatchOwnership.from_presence_lines(
-        claimed_line_ranges.to_range_strings(),
-        deletion_claims,
-    )
+        return BatchOwnership.from_presence_lines(
+            claimed_line_ranges.to_range_strings(),
+            deletion_claims,
+        )
+    except BaseException:
+        closed_ids: set[int] = set()
+        for deletion in deletion_claims:
+            content_lines = deletion.content_lines
+            if not isinstance(content_lines, LineBuffer):
+                continue
+            buffer_id = id(content_lines)
+            if buffer_id in closed_ids:
+                continue
+            closed_ids.add(buffer_id)
+            content_lines.close()
+        raise
 
 
 def validate_sifted_text_file_result_from_lines(

--- a/tests/commands/batch_transform/test_sift_results.py
+++ b/tests/commands/batch_transform/test_sift_results.py
@@ -157,3 +157,44 @@ def test_sifted_text_result_closes_all_owned_buffers_once(monkeypatch):
     result.close()
 
     assert close_counts == {id(target): 1, id(deletion): 1}
+
+
+def test_ownership_derivation_closes_deletions_on_late_failure(monkeypatch):
+    """A failure after deletion construction must release its mapped content."""
+    deletion = LineBuffer.from_bytes(b"old\n")
+
+    class FakeBuilder:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            return None
+
+        def append_line_range(self, lines, start, end):
+            return None
+
+        def finish(self):
+            return deletion
+
+    def fail_ranges(ranges):
+        raise RuntimeError("late range failure")
+
+    monkeypatch.setattr(
+        sift_results,
+        "AbsenceContentBuilder",
+        lambda **kwargs: FakeBuilder(),
+    )
+    monkeypatch.setattr(
+        sift_results.LineRanges,
+        "from_ranges",
+        staticmethod(fail_ranges),
+    )
+
+    with pytest.raises(RuntimeError, match="late range failure"):
+        sift_results.build_ownership_from_working_and_target_lines(
+            [b"old\n"],
+            [],
+        )
+
+    with pytest.raises(ValueError, match="buffer is closed"):
+        deletion.to_bytes()

--- a/tests/commands/batch_transform/test_sift_results.py
+++ b/tests/commands/batch_transform/test_sift_results.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import pytest
 
 import git_stage_batch.commands.batch_transform.sift_results as sift_results
+from git_stage_batch.batch.ownership.absence_claims import AbsenceClaim
+from git_stage_batch.batch.ownership.model import BatchOwnership
 from git_stage_batch.core.buffer import LineBuffer
 
 
@@ -124,3 +126,34 @@ def test_compute_sifted_binary_file_retains_existing_deletion(
     assert result.target_buffer is None
     with pytest.raises(ValueError, match="buffer is closed"):
         batch_source_buffer.to_bytes()
+
+
+def test_sifted_text_result_closes_all_owned_buffers_once(monkeypatch):
+    """Text results own their target and unique deletion content buffers."""
+    target = LineBuffer.from_bytes(b"target\n")
+    deletion = LineBuffer.from_bytes(b"old\n")
+    ownership = BatchOwnership.from_presence_lines(
+        ["1"],
+        [
+            AbsenceClaim(anchor_line=None, content_lines=deletion),
+            AbsenceClaim(anchor_line=1, content_lines=deletion),
+        ],
+    )
+    result = sift_results.SiftedTextFileResult(
+        ownership=ownership,
+        target_buffer=target,
+        change_type="modified",
+    )
+    close_counts: dict[int, int] = {}
+    original_close = LineBuffer.close
+
+    def count_close(buffer):
+        close_counts[id(buffer)] = close_counts.get(id(buffer), 0) + 1
+        original_close(buffer)
+
+    monkeypatch.setattr(LineBuffer, "close", count_close)
+
+    result.close()
+    result.close()
+
+    assert close_counts == {id(target): 1, id(deletion): 1}


### PR DESCRIPTION
Sifted text results own a realized target buffer and can carry line-buffer-backed deletion content through their ownership model.

Closing a completed result currently releases only its target, while ownership derivation can allocate deletion buffers before a later operation fails. Both paths can leave mapped resources open after their logical owner is gone.

This pull request makes text-result closure idempotently release every unique owned buffer and makes partial ownership construction close every unique deletion buffer before propagating an exceptional exit.

Coverage records repeated closure with shared buffers and injects a late ownership failure after deletion content has been allocated, protecting both completed-result and partial-construction lifetimes.