### PR TITLE
sift: Plan text files through ordered jobs

### DIFF
--- a/src/git_stage_batch/batch/line_matching/comparison.py
+++ b/src/git_stage_batch/batch/line_matching/comparison.py
@@ -11,6 +11,7 @@ from collections.abc import Iterable, Iterator, Sequence
 from dataclasses import dataclass
 from enum import Enum, auto
 from itertools import chain
+from pathlib import Path
 
 from .match import match_lines
 from ...core.models import LineLevelChange
@@ -99,13 +100,21 @@ def _validate_range_pair(
 def _trusted_matched_pairs(
     source_lines: Sequence[bytes],
     target_lines: Sequence[bytes],
+    *,
+    spool_dir: str | Path | None = None,
 ) -> Iterator[tuple[int, int]]:
     """Yield bidirectionally trusted source/target line pairs."""
+    match_options = {} if spool_dir is None else {"spool_dir": spool_dir}
     with (
-        match_lines(source_lines=source_lines, target_lines=target_lines) as alignment,
+        match_lines(
+            source_lines=source_lines,
+            target_lines=target_lines,
+            **match_options,
+        ) as alignment,
         match_lines(
             source_lines=target_lines,
             target_lines=source_lines,
+            **match_options,
         ) as reverse_alignment,
     ):
         for source_line, target_line in alignment.mapped_line_pairs():
@@ -118,7 +127,9 @@ def _trusted_matched_pairs(
 
 def derive_semantic_change_runs(
     source_lines: Sequence[bytes],
-    target_lines: Sequence[bytes]
+    target_lines: Sequence[bytes],
+    *,
+    spool_dir: str | Path | None = None,
 ) -> list[SemanticChangeRun]:
     """Derive semantic change runs from source ↔ target comparison.
 
@@ -146,7 +157,11 @@ def derive_semantic_change_runs(
     previous_source = 0
     previous_target = 0
 
-    matched_pairs = _trusted_matched_pairs(source_lines, target_lines)
+    matched_pairs = _trusted_matched_pairs(
+        source_lines,
+        target_lines,
+        spool_dir=spool_dir,
+    )
     sentinel_pair = ((len(source_lines) + 1, len(target_lines) + 1),)
 
     for source_line, target_line in chain(matched_pairs, sentinel_pair):

--- a/src/git_stage_batch/batch/ownership/absence_content.py
+++ b/src/git_stage_batch/batch/ownership/absence_content.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from pathlib import Path
 
 from ...core.buffer import (
     LineBuffer,
@@ -14,8 +15,9 @@ from ...editor.line_editor import LineEditor
 class AbsenceContentBuilder:
     """Build absence content as a LineBuffer from appended line ranges."""
 
-    def __init__(self) -> None:
+    def __init__(self, *, spool_dir: str | Path | None = None) -> None:
         self._editor: LineEditor | None = LineEditor(())
+        self._spool_dir = spool_dir
 
     def __enter__(self) -> AbsenceContentBuilder:
         self._check_open()
@@ -36,7 +38,10 @@ class AbsenceContentBuilder:
     def finish(self) -> LineBuffer:
         editor = self._check_open()
         try:
-            return LineBuffer.from_chunks(editor.line_chunks())
+            return LineBuffer.from_chunks(
+                editor.line_chunks(),
+                spool_dir=self._spool_dir,
+            )
         finally:
             self.close()
 

--- a/src/git_stage_batch/batch/realized_file_content.py
+++ b/src/git_stage_batch/batch/realized_file_content.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator, Sequence
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ..core.buffer import LineBuffer
@@ -22,6 +23,8 @@ def build_realized_buffer_from_lines(
     base_lines: Sequence[bytes],
     batch_source_lines: Sequence[bytes],
     ownership: "BatchOwnership",
+    *,
+    spool_dir: str | Path | None = None,
 ) -> LineBuffer:
     """Build realized batch content as a line buffer."""
     return LineBuffer.from_chunks(
@@ -32,7 +35,8 @@ def build_realized_buffer_from_lines(
                 ownership,
             ),
             detect_line_ending(batch_source_lines),
-        )
+        ),
+        spool_dir=spool_dir,
     )
 
 

--- a/src/git_stage_batch/commands/batch_transform/sift_jobs.py
+++ b/src/git_stage_batch/commands/batch_transform/sift_jobs.py
@@ -1,0 +1,307 @@
+"""Artifact-backed text computation for sift commands."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import pickle
+from typing import Literal
+
+from . import sift_results as _sift_results
+from ...batch.ownership.absence_claims import AbsenceClaim
+from ...batch.ownership.model import BatchOwnership
+from ...core.buffer import LineBuffer, write_buffer_to_path
+from ...data.file_target_identity import WorktreeIdentity
+from ...exceptions import MergeError
+from ...utils.file_job_workspace import FileJobWorkspace
+
+
+SiftTextJobOutcome = Literal["retained", "removed", "merge_error"]
+_MANIFEST_VERSION = 1
+_MAX_ERROR_MESSAGE_CHARACTERS = 4 * 1024
+
+
+@dataclass(frozen=True, slots=True)
+class SiftTextFileJob:
+    """Compact worker request for one captured text sift computation."""
+
+    ordinal: int
+    file_path: str
+    input_artifact_path: str
+    target_output_path: str
+    manifest_output_path: str
+    deletion_output_directory: str
+    scratch_directory: str
+    expected_worktree_identity: WorktreeIdentity
+
+
+@dataclass(frozen=True, slots=True)
+class SiftTextFileJobResult:
+    """Compact worker response for one text sift computation."""
+
+    ordinal: int
+    file_path: str
+    outcome: SiftTextJobOutcome
+    manifest_path: str | None = None
+    target_path: str | None = None
+    error_message: str | None = None
+
+
+def compute_sifted_text_file_job(
+    job: SiftTextFileJob,
+) -> SiftTextFileJobResult:
+    """Compute and stream one text sift result into private artifacts."""
+    input_metadata = _read_pickle(job.input_artifact_path)
+    if type(input_metadata) is not dict:
+        raise TypeError("sift text input must be a dictionary")
+
+    try:
+        result = _sift_results.compute_sifted_text_file(
+            job.file_path,
+            input_metadata["file_meta"],
+            baseline_object_id=input_metadata["baseline_object_id"],
+            batch_source_object_id=input_metadata["batch_source_object_id"],
+            working_tree_artifact_path=input_metadata[
+                "working_tree_artifact_path"
+            ],
+            captured_working_tree_exists=(
+                job.expected_worktree_identity.exists
+            ),
+            spool_dir=job.scratch_directory,
+        )
+    except MergeError as error:
+        return SiftTextFileJobResult(
+            ordinal=job.ordinal,
+            file_path=job.file_path,
+            outcome="merge_error",
+            error_message=str(error)[:_MAX_ERROR_MESSAGE_CHARACTERS],
+        )
+
+    if result is None:
+        return SiftTextFileJobResult(
+            ordinal=job.ordinal,
+            file_path=job.file_path,
+            outcome="removed",
+        )
+
+    try:
+        _write_sifted_text_result(job, result)
+    finally:
+        result.close()
+    return SiftTextFileJobResult(
+        ordinal=job.ordinal,
+        file_path=job.file_path,
+        outcome="retained",
+        manifest_path=job.manifest_output_path,
+        target_path=job.target_output_path,
+    )
+
+
+def validate_sifted_text_file_job_result(
+    job: SiftTextFileJob,
+    result: SiftTextFileJobResult,
+) -> None:
+    """Validate one worker response before opening its artifacts."""
+    if not isinstance(result, SiftTextFileJobResult):
+        raise TypeError("sift text worker returned an invalid result")
+    if result.ordinal != job.ordinal or result.file_path != job.file_path:
+        raise ValueError(
+            f"sift text worker returned a mismatched result for {job.file_path}"
+        )
+    if result.outcome == "retained":
+        if result.manifest_path != job.manifest_output_path:
+            raise ValueError("retained sift text result omitted its manifest")
+        if result.target_path != job.target_output_path:
+            raise ValueError("retained sift text result omitted its target")
+        if result.error_message is not None:
+            raise ValueError("retained sift text result returned an error")
+        return
+    if result.outcome == "removed":
+        if any(
+            value is not None
+            for value in (
+                result.manifest_path,
+                result.target_path,
+                result.error_message,
+            )
+        ):
+            raise ValueError("removed sift text result returned artifacts")
+        return
+    if result.outcome == "merge_error":
+        if result.manifest_path is not None or result.target_path is not None:
+            raise ValueError("failed sift text result returned content artifacts")
+        if not isinstance(result.error_message, str) or not result.error_message:
+            raise ValueError("failed sift text result omitted its error")
+        return
+    raise ValueError(f"unsupported sift text result outcome: {result.outcome}")
+
+
+def load_sifted_text_file_result(
+    workspace: FileJobWorkspace,
+    job: SiftTextFileJob,
+    result: SiftTextFileJobResult,
+) -> _sift_results.SiftedTextFileResult:
+    """Reconstruct one retained result from validated private artifacts."""
+    validate_sifted_text_file_job_result(job, result)
+    if result.outcome != "retained":
+        raise ValueError("only retained sift text results can be loaded")
+
+    manifest = workspace.read_json(job.manifest_output_path)
+    presence_lines, deletion_records, change_type = _validate_manifest(
+        manifest,
+        job,
+    )
+    opened_buffers: list[LineBuffer] = []
+    try:
+        target_buffer = workspace.read_buffer(
+            job.target_output_path,
+            spool_dir=job.scratch_directory,
+        )
+        opened_buffers.append(target_buffer)
+        deletions = []
+        for deletion_record in deletion_records:
+            content_buffer = workspace.read_buffer(
+                deletion_record["content_path"],
+                spool_dir=job.scratch_directory,
+            )
+            opened_buffers.append(content_buffer)
+            if len(content_buffer) == 0:
+                raise ValueError(
+                    "sift text manifest deletion content must not be empty"
+                )
+            deletions.append(
+                AbsenceClaim(
+                    anchor_line=deletion_record["anchor_line"],
+                    content_lines=content_buffer,
+                )
+            )
+        ownership = BatchOwnership.from_presence_lines(
+            presence_lines,
+            deletions,
+        )
+        loaded = _sift_results.SiftedTextFileResult(
+            ownership=ownership,
+            target_buffer=target_buffer,
+            change_type=change_type,
+        )
+        opened_buffers.clear()
+        return loaded
+    finally:
+        for buffer in opened_buffers:
+            buffer.close()
+
+
+def _write_sifted_text_result(
+    job: SiftTextFileJob,
+    result: _sift_results.SiftedTextFileResult,
+) -> None:
+    _require_supported_ownership(result.ownership)
+    write_buffer_to_path(job.target_output_path, result.target_buffer)
+    deletion_directory = Path(job.deletion_output_directory)
+    deletion_directory.mkdir(mode=0o700)
+    deletion_records = []
+    for index, deletion in enumerate(result.ownership.deletions):
+        content_path = deletion_directory / f"{index:08d}-content.bin"
+        write_buffer_to_path(content_path, deletion.content_lines)
+        deletion_records.append(
+            {
+                "anchor_line": deletion.anchor_line,
+                "content_path": str(content_path),
+                "output_order": index,
+            }
+        )
+    manifest = {
+        "version": _MANIFEST_VERSION,
+        "ordinal": job.ordinal,
+        "file_path": job.file_path,
+        "output_order": job.ordinal,
+        "change_type": result.change_type,
+        "presence_lines": (
+            result.ownership.presence_line_set().to_range_strings()
+        ),
+        "deletions": deletion_records,
+    }
+    with Path(job.manifest_output_path).open("x", encoding="utf-8") as output:
+        json.dump(manifest, output, ensure_ascii=True, separators=(",", ":"))
+        output.write("\n")
+
+
+def _require_supported_ownership(ownership: BatchOwnership) -> None:
+    if ownership.replacement_units:
+        raise ValueError("sift text artifacts do not support replacement units")
+    if any(claim.baseline_references for claim in ownership.presence_claims):
+        raise ValueError("sift text artifacts do not support presence references")
+    if any(
+        deletion.baseline_reference is not None
+        for deletion in ownership.deletions
+    ):
+        raise ValueError("sift text artifacts do not support deletion references")
+
+
+def _validate_manifest(
+    value: object,
+    job: SiftTextFileJob,
+) -> tuple[list[str], list[dict[str, object]], str]:
+    if type(value) is not dict:
+        raise TypeError("sift text manifest must be a dictionary")
+    if set(value) != {
+        "version",
+        "ordinal",
+        "file_path",
+        "output_order",
+        "change_type",
+        "presence_lines",
+        "deletions",
+    }:
+        raise ValueError("sift text manifest has unsupported fields")
+    if value.get("version") != _MANIFEST_VERSION:
+        raise ValueError("sift text manifest has an unsupported version")
+    if value.get("ordinal") != job.ordinal or value.get("output_order") != job.ordinal:
+        raise ValueError("sift text manifest has a mismatched output order")
+    if value.get("file_path") != job.file_path:
+        raise ValueError("sift text manifest has a mismatched file path")
+    change_type = value.get("change_type")
+    if change_type not in {"added", "modified", "deleted"}:
+        raise ValueError("sift text manifest has an invalid change type")
+    presence_lines = value.get("presence_lines")
+    if not isinstance(presence_lines, list) or any(
+        not isinstance(line_range, str) for line_range in presence_lines
+    ):
+        raise TypeError("sift text manifest has invalid presence ranges")
+    deletion_values = value.get("deletions")
+    if not isinstance(deletion_values, list):
+        raise TypeError("sift text manifest has invalid deletions")
+    deletion_records: list[dict[str, object]] = []
+    deletion_directory = Path(job.deletion_output_directory)
+    for index, deletion_value in enumerate(deletion_values):
+        if type(deletion_value) is not dict:
+            raise TypeError("sift text manifest has an invalid deletion")
+        if set(deletion_value) != {
+            "anchor_line",
+            "content_path",
+            "output_order",
+        }:
+            raise ValueError("sift text manifest deletion has unsupported fields")
+        anchor_line = deletion_value.get("anchor_line")
+        if anchor_line is not None and (
+            type(anchor_line) is not int or anchor_line < 1
+        ):
+            raise ValueError("sift text manifest has an invalid deletion anchor")
+        expected_path = deletion_directory / f"{index:08d}-content.bin"
+        if deletion_value.get("content_path") != str(expected_path):
+            raise ValueError("sift text manifest has a mismatched deletion path")
+        if deletion_value.get("output_order") != index:
+            raise ValueError("sift text manifest has a mismatched deletion order")
+        deletion_records.append(
+            {
+                "anchor_line": anchor_line,
+                "content_path": str(expected_path),
+            }
+        )
+    return presence_lines, deletion_records, change_type
+
+
+def _read_pickle(path: str | Path):
+    with Path(path).open("rb") as source:
+        return pickle.load(source)

--- a/src/git_stage_batch/commands/batch_transform/sift_results.py
+++ b/src/git_stage_batch/commands/batch_transform/sift_results.py
@@ -103,6 +103,9 @@ def compute_sifted_binary_file(
     file_path: str,
     file_meta: dict,
     repo_root: Path,
+    *,
+    working_tree_artifact_path: str | Path | None = None,
+    captured_working_tree_exists: bool | None = None,
 ) -> Optional[SiftedBinaryFileResult]:
     """Compute a sifted binary file result."""
     batch_source_commit = file_meta["batch_source_commit"]
@@ -113,9 +116,17 @@ def compute_sifted_binary_file(
     )
 
     full_path = repo_root / file_path
-    working_exists = full_path.exists()
+    working_exists = (
+        full_path.exists()
+        if captured_working_tree_exists is None
+        else captured_working_tree_exists
+    )
     working_buffer = (
-        LineBuffer.from_path(full_path)
+        LineBuffer.from_path(
+            full_path
+            if working_tree_artifact_path is None
+            else working_tree_artifact_path
+        )
         if working_exists else
         LineBuffer.from_bytes(b"")
     )

--- a/src/git_stage_batch/commands/batch_transform/sift_results.py
+++ b/src/git_stage_batch/commands/batch_transform/sift_results.py
@@ -16,7 +16,6 @@ from ...batch.ownership.absence_content import AbsenceContentBuilder
 from ...batch.ownership.model import BatchOwnership
 from ...batch.ownership.absence_claims import AbsenceClaim
 from ...batch.ownership.metadata_loading import acquire_ownership_for_metadata_dict
-from ...batch.state.query import get_batch_baseline_commit
 from ...batch.realized_file_content import build_realized_buffer_from_lines
 from ...core.buffer import (
     LineBuffer,
@@ -32,7 +31,7 @@ from ...core.text_lifecycle import (
     sifted_empty_text_path_change_type,
 )
 from ...utils.repository_buffers import read_git_object_buffer_or_empty
-from ...utils.repository_buffers import load_working_tree_file_as_buffer
+from ...utils.repository_buffers import load_git_blob_as_buffer
 from ...exceptions import MergeError
 from ...core.text_lines import normalize_line_sequence_endings
 
@@ -171,43 +170,50 @@ def compute_sifted_binary_file(
 
 
 def compute_sifted_text_file(
-    source_batch: str,
     file_path: str,
     file_meta: dict,
-    repo_root: Path,
+    *,
+    baseline_object_id: str | None,
+    batch_source_object_id: str | None,
+    working_tree_artifact_path: str | Path,
+    captured_working_tree_exists: bool,
+    spool_dir: str | Path,
 ) -> Optional[SiftedTextFileResult]:
-    """Compute a sifted text file result."""
-    batch_source_commit = file_meta["batch_source_commit"]
+    """Compute one text sift result from immutable captured inputs."""
     change_type = normalized_text_change_type(file_meta.get("change_type"))
-    baseline_commit = get_batch_baseline_commit(source_batch)
-    full_path = repo_root / file_path
-    working_exists = full_path.exists()
-
-    batch_source_buffer = read_git_object_buffer_or_empty(
-        f"{batch_source_commit}:{file_path}"
+    batch_source_buffer = _load_git_blob_or_empty(
+        batch_source_object_id,
+        spool_dir=spool_dir,
     )
-    baseline_buffer = (
-        read_git_object_buffer_or_empty(f"{baseline_commit}:{file_path}")
-        if baseline_commit is not None else
-        LineBuffer.from_bytes(b"")
+    baseline_buffer = _load_git_blob_or_empty(
+        baseline_object_id,
+        spool_dir=spool_dir,
     )
-    working_buffer = load_working_tree_file_as_buffer(file_path)
+    working_buffer = LineBuffer.from_path(
+        working_tree_artifact_path,
+        spool_dir=spool_dir,
+    )
     target_buffer: LineBuffer | None = None
+    new_ownership: BatchOwnership | None = None
 
     with (
         batch_source_buffer,
         baseline_buffer,
         working_buffer,
-        acquire_ownership_for_metadata_dict(file_meta) as source_ownership,
+        acquire_ownership_for_metadata_dict(
+            file_meta,
+            spool_dir=spool_dir,
+        ) as source_ownership,
     ):
         target_buffer = build_realized_buffer_from_lines(
             baseline_buffer,
             batch_source_buffer,
             source_ownership,
+            spool_dir=spool_dir,
         )
         try:
             target_exists = change_type != TextFileChangeType.DELETED
-            if target_exists == working_exists and buffer_matches(
+            if target_exists == captured_working_tree_exists and buffer_matches(
                 working_buffer,
                 target_buffer,
             ):
@@ -219,12 +225,13 @@ def compute_sifted_text_file(
             new_ownership = build_ownership_from_working_and_target_lines(
                 working_lines=working_lines,
                 target_lines=target_lines,
+                spool_dir=spool_dir,
             )
             if new_ownership is None or new_ownership.is_empty():
                 result_change_type = sifted_empty_text_path_change_type(
                     change_type,
                     target_exists=target_exists,
-                    working_exists=working_exists,
+                    working_exists=captured_working_tree_exists,
                     target_content=target_buffer,
                     ownership_is_empty=True,
                 )
@@ -238,18 +245,33 @@ def compute_sifted_text_file(
                 target_lines=target_lines,
                 dest_ownership=new_ownership,
                 working_lines=working_lines,
+                spool_dir=spool_dir,
             )
 
             returned_target_buffer = target_buffer
             target_buffer = None
+            returned_ownership = new_ownership
+            new_ownership = None
             return SiftedTextFileResult(
-                ownership=new_ownership,
+                ownership=returned_ownership,
                 target_buffer=returned_target_buffer,
                 change_type=result_change_type.value,
             )
         finally:
             if target_buffer is not None:
                 target_buffer.close()
+            if new_ownership is not None:
+                _close_text_ownership_buffers(new_ownership)
+
+
+def _load_git_blob_or_empty(
+    object_id: str | None,
+    *,
+    spool_dir: str | Path,
+) -> LineBuffer:
+    if object_id is None:
+        return LineBuffer.from_bytes(b"", spool_dir=spool_dir)
+    return load_git_blob_as_buffer(object_id, spool_dir=spool_dir)
 
 
 def _close_text_result_buffers(
@@ -259,6 +281,16 @@ def _close_text_result_buffers(
     buffers = [target_buffer, *_text_ownership_buffers(ownership)]
     closed_ids: set[int] = set()
     for buffer in buffers:
+        buffer_id = id(buffer)
+        if buffer_id in closed_ids:
+            continue
+        closed_ids.add(buffer_id)
+        buffer.close()
+
+
+def _close_text_ownership_buffers(ownership: BatchOwnership) -> None:
+    closed_ids: set[int] = set()
+    for buffer in _text_ownership_buffers(ownership):
         buffer_id = id(buffer)
         if buffer_id in closed_ids:
             continue
@@ -277,11 +309,14 @@ def _text_ownership_buffers(ownership: BatchOwnership) -> list[LineBuffer]:
 def build_ownership_from_working_and_target_lines(
     working_lines: Sequence[bytes],
     target_lines: Sequence[bytes],
+    *,
+    spool_dir: str | Path | None = None,
 ) -> Optional[BatchOwnership]:
     """Build ownership from normalized working and target byte-line sequences."""
     semantic_runs = derive_semantic_change_runs(
         source_lines=working_lines,
         target_lines=target_lines,
+        **({} if spool_dir is None else {"spool_dir": spool_dir}),
     )
 
     claimed_ranges: list[tuple[int, int]] = []
@@ -293,7 +328,7 @@ def build_ownership_from_working_and_target_lines(
         source_start: int,
         source_end: int,
     ) -> AbsenceClaim:
-        with AbsenceContentBuilder() as builder:
+        with AbsenceContentBuilder(spool_dir=spool_dir) as builder:
             builder.append_line_range(
                 working_lines,
                 source_start - 1,
@@ -357,6 +392,8 @@ def validate_sifted_text_file_result_from_lines(
     target_lines: Sequence[bytes],
     dest_ownership: BatchOwnership,
     working_lines: Sequence[bytes],
+    *,
+    spool_dir: str | Path | None = None,
 ) -> None:
     """Validate a sifted representation against normalized byte-line sequences."""
     resolved = dest_ownership.resolve()
@@ -386,6 +423,7 @@ def validate_sifted_text_file_result_from_lines(
             target_lines,
             dest_ownership,
             working_lines,
+            spool_dir=spool_dir,
         )
     except MergeError as e:
         raise MergeError(

--- a/src/git_stage_batch/commands/batch_transform/sift_results.py
+++ b/src/git_stage_batch/commands/batch_transform/sift_results.py
@@ -91,10 +91,17 @@ def compute_sifted_mode_file(
     file_path: str,
     file_meta: dict,
     repo_root: Path,
+    *,
+    captured_worktree_mode: str | None = None,
 ) -> SiftedModeFileResult | None:
     """Drop a mode action once its target mode is already present."""
     change = FileModeChange(file_path, file_meta["old_mode"], file_meta["new_mode"])
-    if detect_file_mode_from_root(repo_root, file_path) == change.new_mode:
+    current_mode = (
+        detect_file_mode_from_root(repo_root, file_path)
+        if captured_worktree_mode is None
+        else captured_worktree_mode
+    )
+    if current_mode == change.new_mode:
         return None
     return SiftedModeFileResult(change)
 

--- a/src/git_stage_batch/commands/sift.py
+++ b/src/git_stage_batch/commands/sift.py
@@ -547,12 +547,7 @@ def _require_unchanged_sift_inputs(
         or final_ref_identities != current_ref_identities
         or current_metadata != source_snapshot.metadata
     ):
-        exit_with_error(
-            _(
-                "Cannot sift batch '{source}' because it changed while sift "
-                "was running. Retry against the latest batch state."
-            ).format(source=source_batch)
-        )
+        _exit_sift_batch_changed(source_batch)
 
     current_worktree_identities = capture_worktree_identities(
         expected_worktree_identities
@@ -566,6 +561,22 @@ def _require_unchanged_sift_inputs(
                     "the current working tree."
                 ).format(source=source_batch, file=file_path)
             )
+
+    publication_ref_identities = _capture_source_batch_ref_identities(
+        source_batch
+    )
+    if publication_ref_identities != source_snapshot.ref_identities:
+        _exit_sift_batch_changed(source_batch)
+
+
+def _exit_sift_batch_changed(source_batch: str) -> None:
+    exit_with_error(
+        _(
+            "Cannot sift batch '{source}' because it changed while sift "
+            "was running. Retry against the latest batch state."
+        ).format(source=source_batch)
+    )
+
 
 def _close_sifted_results(
     retained_files: list[_sift_persistence.RetainedSiftedFile],

--- a/src/git_stage_batch/commands/sift.py
+++ b/src/git_stage_batch/commands/sift.py
@@ -31,7 +31,6 @@ from ..batch.state.reference_names import (
     format_legacy_batch_ref_name,
 )
 from ..batch.state.lifecycle import create_batch
-from ..batch.state.query import read_batch_metadata
 from ..batch.state.batch_names import batch_exists, validate_batch_name
 from ..batch.source.selector import require_plain_batch_name
 from .batch_transform import sift_persistence as _sift_persistence
@@ -105,7 +104,16 @@ def command_sift_batch(source_batch: str, dest_batch: str) -> None:
 
     source_files = source_metadata.get("files", {})
     if not source_files:
-        _handle_empty_source_batch(source_batch, dest_batch)
+        _require_unchanged_sift_inputs(
+            source_batch=source_batch,
+            source_snapshot=source_snapshot,
+            expected_worktree_identities={},
+        )
+        _handle_empty_source_batch(
+            source_batch,
+            dest_batch,
+            source_metadata=source_metadata,
+        )
         return
 
     in_place = source_batch == dest_batch
@@ -567,13 +575,17 @@ def _close_sifted_results(
         result.close()
 
 
-def _handle_empty_source_batch(source_batch: str, dest_batch: str) -> None:
+def _handle_empty_source_batch(
+    source_batch: str,
+    dest_batch: str,
+    *,
+    source_metadata: dict,
+) -> None:
     """Handle the case where the source batch is empty."""
     if source_batch == dest_batch:
         print(_("Batch '{name}' is already empty").format(name=source_batch), file=sys.stderr)
         return
 
-    source_metadata = read_batch_metadata(source_batch)
     create_batch(
         dest_batch,
         note=f"Sifted from {source_batch} (was empty)",

--- a/src/git_stage_batch/commands/sift.py
+++ b/src/git_stage_batch/commands/sift.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
+import stat
 import sys
 
 from ..exceptions import MergeError
@@ -41,6 +42,7 @@ from ..data.file_target_identity import (
     capture_worktree_identities,
     capture_worktree_identity,
 )
+from ..data.file_modes import detect_file_mode_from_root
 from ..exceptions import BatchMetadataError, exit_with_error
 from ..i18n import _
 from ..utils.git_repository import (
@@ -76,6 +78,7 @@ class _TextSiftInput:
 class _SiftInputCapture:
     text_inputs: tuple[_TextSiftInput, ...]
     worktree_identities: dict[str, WorktreeIdentity]
+    worktree_modes: dict[str, str]
     content_artifacts: dict[str, Path]
 
 
@@ -103,11 +106,14 @@ def command_sift_batch(source_batch: str, dest_batch: str) -> None:
     source_metadata = source_snapshot.metadata
 
     source_files = source_metadata.get("files", {})
+    repo_root = get_git_repository_root_path()
     if not source_files:
         _require_unchanged_sift_inputs(
             source_batch=source_batch,
             source_snapshot=source_snapshot,
             expected_worktree_identities={},
+            expected_worktree_modes={},
+            repository_root=repo_root,
         )
         _handle_empty_source_batch(
             source_batch,
@@ -129,13 +135,13 @@ def command_sift_batch(source_batch: str, dest_batch: str) -> None:
                 )
             )
 
-    repo_root = get_git_repository_root_path()
     with FileJobWorkspace() as workspace:
         retained_files: list[_sift_persistence.RetainedSiftedFile] = []
         try:
             (
                 retained_files,
                 expected_worktree_identities,
+                expected_worktree_modes,
             ) = _build_sifted_files(
                 source_metadata=source_metadata,
                 repository_root=repo_root,
@@ -145,6 +151,8 @@ def command_sift_batch(source_batch: str, dest_batch: str) -> None:
                 source_batch=source_batch,
                 source_snapshot=source_snapshot,
                 expected_worktree_identities=expected_worktree_identities,
+                expected_worktree_modes=expected_worktree_modes,
+                repository_root=repo_root,
             )
             if in_place:
                 _sift_persistence.replace_batch_with_sifted_files(
@@ -239,10 +247,12 @@ def _build_sifted_files(
 ) -> tuple[
     list[_sift_persistence.RetainedSiftedFile],
     dict[str, WorktreeIdentity],
+    dict[str, str],
 ]:
     source_files = source_metadata.get("files", {})
     capture = _capture_sift_inputs(
         source_files=source_files,
+        repository_root=repository_root,
         workspace=workspace,
     )
     jobs = _build_sift_text_jobs(
@@ -261,17 +271,23 @@ def _build_sifted_files(
         repository_root=repository_root,
         workspace=workspace,
     )
-    return retained_files, capture.worktree_identities
+    return (
+        retained_files,
+        capture.worktree_identities,
+        capture.worktree_modes,
+    )
 
 
 def _capture_sift_inputs(
     *,
     source_files: dict[str, dict],
+    repository_root: Path,
     workspace: FileJobWorkspace,
 ) -> _SiftInputCapture:
     """Capture immutable worktree inputs for every sifted file."""
     text_inputs: list[_TextSiftInput] = []
     worktree_identities: dict[str, WorktreeIdentity] = {}
+    worktree_modes: dict[str, str] = {}
     content_artifacts: dict[str, Path] = {}
     for ordinal, (file_path, file_meta) in enumerate(source_files.items()):
         is_text = file_meta.get("file_type") not in {"binary", "mode"}
@@ -288,6 +304,11 @@ def _capture_sift_inputs(
             content_artifacts[file_path] = worktree_artifact
         else:
             identity = capture_worktree_identity(file_path)
+            worktree_modes[file_path] = _git_mode_for_worktree_identity(
+                repository_root,
+                file_path,
+                identity,
+            )
         if is_text:
             text_inputs.append(
                 _TextSiftInput(
@@ -303,6 +324,7 @@ def _capture_sift_inputs(
     return _SiftInputCapture(
         text_inputs=tuple(text_inputs),
         worktree_identities=worktree_identities,
+        worktree_modes=worktree_modes,
         content_artifacts=content_artifacts,
     )
 
@@ -420,6 +442,7 @@ def _reduce_sift_results(
                     file_path,
                     file_meta,
                     repository_root,
+                    captured_worktree_mode=capture.worktree_modes[file_path],
                 )
             elif file_meta.get("file_type") == "binary":
                 sifted_result = _sift_results.compute_sifted_binary_file(
@@ -535,6 +558,8 @@ def _require_unchanged_sift_inputs(
     source_batch: str,
     source_snapshot: _SourceBatchSnapshot,
     expected_worktree_identities: dict[str, WorktreeIdentity],
+    expected_worktree_modes: dict[str, str],
+    repository_root: Path,
 ) -> None:
     current_ref_identities = _capture_source_batch_ref_identities(source_batch)
     try:
@@ -562,6 +587,21 @@ def _require_unchanged_sift_inputs(
                 ).format(source=source_batch, file=file_path)
             )
 
+    for file_path, expected_mode in expected_worktree_modes.items():
+        current_mode = _git_mode_for_worktree_identity(
+            repository_root,
+            file_path,
+            current_worktree_identities[file_path],
+        )
+        if current_mode != expected_mode:
+            exit_with_error(
+                _(
+                    "Cannot sift batch '{source}' because the file mode for "
+                    "'{file}' changed while sift was running. Retry against "
+                    "the current working tree."
+                ).format(source=source_batch, file=file_path)
+            )
+
     publication_ref_identities = _capture_source_batch_ref_identities(
         source_batch
     )
@@ -576,6 +616,18 @@ def _exit_sift_batch_changed(source_batch: str) -> None:
             "was running. Retry against the latest batch state."
         ).format(source=source_batch)
     )
+
+
+def _git_mode_for_worktree_identity(
+    repository_root: Path,
+    file_path: str,
+    identity: WorktreeIdentity,
+) -> str:
+    if identity.exists and identity.kind == "symlink":
+        return "120000"
+    if identity.exists and identity.mode is not None:
+        return "100755" if identity.mode & stat.S_IXUSR else "100644"
+    return detect_file_mode_from_root(repository_root, file_path)
 
 
 def _close_sifted_results(

--- a/src/git_stage_batch/commands/sift.py
+++ b/src/git_stage_batch/commands/sift.py
@@ -19,22 +19,71 @@ produce the intended target content.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from pathlib import Path
 import sys
 
 from ..exceptions import MergeError
 from ..batch.state.validation import read_validated_batch_metadata
+from ..batch.state.reference_names import (
+    format_batch_content_ref_name,
+    format_batch_state_ref_name,
+    format_legacy_batch_ref_name,
+)
 from ..batch.state.lifecycle import create_batch
 from ..batch.state.query import read_batch_metadata
 from ..batch.state.batch_names import batch_exists, validate_batch_name
 from ..batch.source.selector import require_plain_batch_name
 from .batch_transform import sift_persistence as _sift_persistence
+from .batch_transform import sift_jobs as _sift_jobs
 from .batch_transform import sift_results as _sift_results
+from ..data.file_target_identity import (
+    WorktreeIdentity,
+    capture_worktree_identities,
+    capture_worktree_identity,
+)
 from ..exceptions import BatchMetadataError, exit_with_error
 from ..i18n import _
 from ..utils.git_repository import (
     get_git_repository_root_path,
     require_git_repository,
 )
+from ..utils.file_job_workspace import FileJobWorkspace
+from ..utils.file_jobs import (
+    OrderedFileJob,
+    run_file_jobs,
+    run_validated_file_jobs,
+)
+from ..utils.git_object_io import list_git_tree_blobs, resolve_git_objects
+
+
+@dataclass(frozen=True, slots=True)
+class _SourceBatchSnapshot:
+    metadata: dict
+    ref_identities: tuple[tuple[str, str | None], ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _TextSiftInput:
+    ordinal: int
+    file_path: str
+    file_meta: dict
+    worktree_identity: WorktreeIdentity
+    worktree_artifact_path: Path
+    scratch_directory: Path
+
+
+@dataclass(frozen=True, slots=True)
+class _SiftInputCapture:
+    text_inputs: tuple[_TextSiftInput, ...]
+    worktree_identities: dict[str, WorktreeIdentity]
+    content_artifacts: dict[str, Path]
+
+
+@dataclass(frozen=True, slots=True)
+class _SiftTextExecution:
+    jobs_by_ordinal: dict[int, _sift_jobs.SiftTextFileJob]
+    results_by_ordinal: dict[int, _sift_jobs.SiftTextFileJobResult]
 
 
 def command_sift_batch(source_batch: str, dest_batch: str) -> None:
@@ -49,9 +98,10 @@ def command_sift_batch(source_batch: str, dest_batch: str) -> None:
         exit_with_error(_("Batch '{name}' does not exist").format(name=source_batch))
 
     try:
-        source_metadata = read_validated_batch_metadata(source_batch)
-    except BatchMetadataError as e:
-        exit_with_error(str(e))
+        source_snapshot = _read_source_batch_snapshot(source_batch)
+    except BatchMetadataError as error:
+        exit_with_error(str(error))
+    source_metadata = source_snapshot.metadata
 
     source_files = source_metadata.get("files", {})
     if not source_files:
@@ -59,8 +109,6 @@ def command_sift_batch(source_batch: str, dest_batch: str) -> None:
         return
 
     in_place = source_batch == dest_batch
-    retained_files: list[_sift_persistence.RetainedSiftedFile] = []
-
     if not in_place:
         if batch_exists(dest_batch):
             exit_with_error(
@@ -73,67 +121,65 @@ def command_sift_batch(source_batch: str, dest_batch: str) -> None:
                 )
             )
 
-    try:
-        repo_root = get_git_repository_root_path()
-        stats = {
-            "total_files": len(source_files),
-            "files_removed": 0,
-            "files_retained": 0,
-        }
-
-        for file_path, file_meta in source_files.items():
-            is_binary = file_meta.get("file_type") == "binary"
-            is_mode = file_meta.get("file_type") == "mode"
-
-            if is_mode:
-                result = _sift_results.compute_sifted_mode_file(
-                    file_path, file_meta, repo_root
-                )
-            elif is_binary:
-                result = _sift_results.compute_sifted_binary_file(
-                    file_path,
-                    file_meta,
-                    repo_root,
+    repo_root = get_git_repository_root_path()
+    with FileJobWorkspace() as workspace:
+        retained_files: list[_sift_persistence.RetainedSiftedFile] = []
+        try:
+            (
+                retained_files,
+                expected_worktree_identities,
+            ) = _build_sifted_files(
+                source_metadata=source_metadata,
+                repository_root=repo_root,
+                workspace=workspace,
+            )
+            _require_unchanged_sift_inputs(
+                source_batch=source_batch,
+                source_snapshot=source_snapshot,
+                expected_worktree_identities=expected_worktree_identities,
+            )
+            if in_place:
+                _sift_persistence.replace_batch_with_sifted_files(
+                    batch_name=source_batch,
+                    retained_files=retained_files,
+                    source_metadata=source_metadata,
                 )
             else:
-                result = _sift_results.compute_sifted_text_file(
-                    source_batch,
-                    file_path,
-                    file_meta,
-                    repo_root,
+                _sift_persistence.publish_sifted_files(
+                    destination_batch=dest_batch,
+                    retained_files=retained_files,
+                    source_metadata=source_metadata,
+                    destination_note=f"Sifted from {source_batch}",
+                    replace_existing=False,
                 )
-
-            if result is None:
-                stats["files_removed"] += 1
-            else:
-                stats["files_retained"] += 1
-                retained_files.append((file_path, file_meta, result))
-
-        if in_place:
-            _sift_persistence.replace_batch_with_sifted_files(
-                batch_name=source_batch,
-                retained_files=retained_files,
-                source_metadata=source_metadata,
+        except MergeError as error:
+            exit_with_error(
+                _("Could not sift batch '{source}': {error}").format(
+                    source=source_batch,
+                    error=error,
+                )
             )
-        else:
-            _sift_persistence.publish_sifted_files(
-                destination_batch=dest_batch,
-                retained_files=retained_files,
-                source_metadata=source_metadata,
-                destination_note=f"Sifted from {source_batch}",
-                replace_existing=False,
-            )
-    except MergeError as e:
-        exit_with_error(
-            _("Could not sift batch '{source}': {error}").format(
-                source=source_batch,
-                error=e,
-            )
-        )
-    finally:
-        _close_sifted_results(retained_files)
+        finally:
+            _close_sifted_results(retained_files)
 
-    if stats["files_retained"] == 0:
+    _print_sift_summary(
+        source_batch=source_batch,
+        dest_batch=dest_batch,
+        retained_count=len(retained_files),
+        total_count=len(source_files),
+    )
+
+
+def _print_sift_summary(
+    *,
+    source_batch: str,
+    dest_batch: str,
+    retained_count: int,
+    total_count: int,
+) -> None:
+    """Print the translated summary for one completed sift."""
+    in_place = source_batch == dest_batch
+    if retained_count == 0:
         if in_place:
             print(
                 _(
@@ -158,8 +204,8 @@ def command_sift_batch(source_batch: str, dest_batch: str) -> None:
                     "✓ Sifted batch '{name}' in-place: {retained} of {total} files still need changes"
                 ).format(
                     name=source_batch,
-                    retained=stats["files_retained"],
-                    total=stats["total_files"],
+                    retained=retained_count,
+                    total=total_count,
                 ),
                 file=sys.stderr,
             )
@@ -170,17 +216,353 @@ def command_sift_batch(source_batch: str, dest_batch: str) -> None:
                 ).format(
                     source=source_batch,
                     dest=dest_batch,
-                    retained=stats["files_retained"],
-                    total=stats["total_files"],
+                    retained=retained_count,
+                    total=total_count,
                 ),
                 file=sys.stderr,
             )
 
 
+def _build_sifted_files(
+    *,
+    source_metadata: dict,
+    repository_root: Path,
+    workspace: FileJobWorkspace,
+) -> tuple[
+    list[_sift_persistence.RetainedSiftedFile],
+    dict[str, WorktreeIdentity],
+]:
+    source_files = source_metadata.get("files", {})
+    capture = _capture_sift_inputs(
+        source_files=source_files,
+        workspace=workspace,
+    )
+    jobs = _build_sift_text_jobs(
+        source_metadata=source_metadata,
+        capture=capture,
+        workspace=workspace,
+    )
+    execution = _run_sift_text_jobs(
+        jobs,
+        repository_root=repository_root,
+    )
+    retained_files = _reduce_sift_results(
+        source_files=source_files,
+        capture=capture,
+        execution=execution,
+        repository_root=repository_root,
+        workspace=workspace,
+    )
+    return retained_files, capture.worktree_identities
+
+
+def _capture_sift_inputs(
+    *,
+    source_files: dict[str, dict],
+    workspace: FileJobWorkspace,
+) -> _SiftInputCapture:
+    """Capture immutable worktree inputs for every sifted file."""
+    text_inputs: list[_TextSiftInput] = []
+    worktree_identities: dict[str, WorktreeIdentity] = {}
+    content_artifacts: dict[str, Path] = {}
+    for ordinal, (file_path, file_meta) in enumerate(source_files.items()):
+        is_text = file_meta.get("file_type") not in {"binary", "mode"}
+        captures_content = file_meta.get("file_type") != "mode"
+        if captures_content:
+            worktree_artifact = workspace.artifact_path(
+                ordinal,
+                "worktree-input",
+            )
+            identity = capture_worktree_identity(
+                file_path,
+                content_artifact_path=worktree_artifact,
+            )
+            content_artifacts[file_path] = worktree_artifact
+        else:
+            identity = capture_worktree_identity(file_path)
+        if is_text:
+            text_inputs.append(
+                _TextSiftInput(
+                    ordinal=ordinal,
+                    file_path=file_path,
+                    file_meta=file_meta,
+                    worktree_identity=identity,
+                    worktree_artifact_path=worktree_artifact,
+                    scratch_directory=workspace.scratch_directory(ordinal),
+                )
+            )
+        worktree_identities[file_path] = identity
+    return _SiftInputCapture(
+        text_inputs=tuple(text_inputs),
+        worktree_identities=worktree_identities,
+        content_artifacts=content_artifacts,
+    )
+
+
+def _build_sift_text_jobs(
+    *,
+    source_metadata: dict,
+    capture: _SiftInputCapture,
+    workspace: FileJobWorkspace,
+) -> list[OrderedFileJob[_sift_jobs.SiftTextFileJob]]:
+    """Build compact text jobs from captured sift inputs."""
+    text_inputs = capture.text_inputs
+
+    baseline_blob_by_path = _resolve_baseline_blobs(
+        source_metadata.get("baseline"),
+        text_inputs,
+    )
+    source_blob_by_input = _resolve_source_blobs(text_inputs)
+    object_info_by_name = resolve_git_objects(
+        [
+            *baseline_blob_by_path.values(),
+            *source_blob_by_input.values(),
+        ]
+    )
+    jobs: list[OrderedFileJob[_sift_jobs.SiftTextFileJob]] = []
+    for text_input in text_inputs:
+        baseline_object_id = baseline_blob_by_path.get(text_input.file_path)
+        source_object_id = source_blob_by_input.get(
+            (text_input.ordinal, text_input.file_path)
+        )
+        input_artifact = workspace.write_pickle(
+            text_input.ordinal,
+            "sift-input.pickle",
+            {
+                "baseline_object_id": baseline_object_id,
+                "batch_source_object_id": source_object_id,
+                "file_meta": text_input.file_meta,
+                "working_tree_artifact_path": str(
+                    text_input.worktree_artifact_path
+                ),
+            },
+        )
+        target_output_path = workspace.output_path(
+            text_input.ordinal,
+            "target.bin",
+        )
+        manifest_output_path = workspace.output_path(
+            text_input.ordinal,
+            "manifest.json",
+        )
+        deletion_output_directory = (
+            target_output_path.parent / "deletions"
+        )
+        payload = _sift_jobs.SiftTextFileJob(
+            ordinal=text_input.ordinal,
+            file_path=text_input.file_path,
+            input_artifact_path=str(input_artifact),
+            target_output_path=str(target_output_path),
+            manifest_output_path=str(manifest_output_path),
+            deletion_output_directory=str(deletion_output_directory),
+            scratch_directory=str(text_input.scratch_directory),
+            expected_worktree_identity=text_input.worktree_identity,
+        )
+        estimated_bytes = text_input.worktree_identity.size or 0
+        for object_id in (baseline_object_id, source_object_id):
+            if object_id is not None and object_id in object_info_by_name:
+                estimated_bytes += object_info_by_name[object_id].size
+        jobs.append(
+            OrderedFileJob(
+                ordinal=text_input.ordinal,
+                file_path=text_input.file_path,
+                estimated_bytes=estimated_bytes,
+                payload=payload,
+            )
+        )
+    return jobs
+
+
+def _run_sift_text_jobs(
+    jobs: list[OrderedFileJob[_sift_jobs.SiftTextFileJob]],
+    *,
+    repository_root: Path,
+) -> _SiftTextExecution:
+    """Execute and validate sift text jobs in stable ordinal order."""
+    paired_results = run_validated_file_jobs(
+        jobs,
+        _sift_jobs.compute_sifted_text_file_job,
+        _sift_jobs.validate_sifted_text_file_job_result,
+        repository_root=repository_root,
+        result_label="sift text",
+        run_jobs=run_file_jobs,
+    )
+    job_by_ordinal = {}
+    result_by_ordinal = {}
+    for ordered_job, result in paired_results:
+        job_by_ordinal[ordered_job.ordinal] = ordered_job.payload
+        result_by_ordinal[result.ordinal] = result
+    return _SiftTextExecution(job_by_ordinal, result_by_ordinal)
+
+
+def _reduce_sift_results(
+    *,
+    source_files: dict[str, dict],
+    capture: _SiftInputCapture,
+    execution: _SiftTextExecution,
+    repository_root: Path,
+    workspace: FileJobWorkspace,
+) -> list[_sift_persistence.RetainedSiftedFile]:
+    """Reduce atomic and text sift results in source-file order."""
+    retained_files: list[_sift_persistence.RetainedSiftedFile] = []
+    try:
+        for ordinal, (file_path, file_meta) in enumerate(source_files.items()):
+            if file_meta.get("file_type") == "mode":
+                sifted_result = _sift_results.compute_sifted_mode_file(
+                    file_path,
+                    file_meta,
+                    repository_root,
+                )
+            elif file_meta.get("file_type") == "binary":
+                sifted_result = _sift_results.compute_sifted_binary_file(
+                    file_path,
+                    file_meta,
+                    repository_root,
+                    working_tree_artifact_path=(
+                        capture.content_artifacts[file_path]
+                    ),
+                    captured_working_tree_exists=(
+                        capture.worktree_identities[file_path].exists
+                    ),
+                )
+            else:
+                job = execution.jobs_by_ordinal[ordinal]
+                job_result = execution.results_by_ordinal[ordinal]
+                if job_result.outcome == "merge_error":
+                    raise MergeError(job_result.error_message or "sift failed")
+                sifted_result = (
+                    None
+                    if job_result.outcome == "removed"
+                    else _sift_jobs.load_sifted_text_file_result(
+                        workspace,
+                        job,
+                        job_result,
+                    )
+                )
+            if sifted_result is not None:
+                retained_files.append((file_path, file_meta, sifted_result))
+        return retained_files
+    except BaseException:
+        _close_sifted_results(retained_files)
+        raise
+
+
+def _resolve_baseline_blobs(
+    baseline_commit: str | None,
+    text_inputs: tuple[_TextSiftInput, ...],
+) -> dict[str, str]:
+    if baseline_commit is None:
+        return {}
+    return {
+        file_path: entry.blob_sha
+        for file_path, entry in list_git_tree_blobs(
+            baseline_commit,
+            (text_input.file_path for text_input in text_inputs),
+        ).items()
+    }
+
+
+def _resolve_source_blobs(
+    text_inputs: tuple[_TextSiftInput, ...],
+) -> dict[tuple[int, str], str]:
+    inputs_by_commit: dict[str, list[_TextSiftInput]] = {}
+    for text_input in text_inputs:
+        source_commit = text_input.file_meta["batch_source_commit"]
+        inputs_by_commit.setdefault(source_commit, []).append(text_input)
+
+    blob_by_input: dict[tuple[int, str], str] = {}
+    for source_commit, commit_inputs in inputs_by_commit.items():
+        entries = list_git_tree_blobs(
+            source_commit,
+            (text_input.file_path for text_input in commit_inputs),
+        )
+        for text_input in commit_inputs:
+            entry = entries.get(text_input.file_path)
+            if entry is not None:
+                blob_by_input[(text_input.ordinal, text_input.file_path)] = (
+                    entry.blob_sha
+                )
+    return blob_by_input
+
+
+def _read_source_batch_snapshot(batch_name: str) -> _SourceBatchSnapshot:
+    initial_ref_identities = _capture_source_batch_ref_identities(batch_name)
+    metadata = read_validated_batch_metadata(batch_name)
+    final_ref_identities = _capture_source_batch_ref_identities(batch_name)
+    if final_ref_identities != initial_ref_identities:
+        raise BatchMetadataError(
+            f"Batch '{batch_name}' changed while its sift inputs were read. "
+            "Retry the operation against the latest batch state."
+        )
+    return _SourceBatchSnapshot(
+        metadata=metadata,
+        ref_identities=final_ref_identities,
+    )
+
+
+def _capture_source_batch_ref_identities(
+    batch_name: str,
+) -> tuple[tuple[str, str | None], ...]:
+    ref_names = (
+        format_batch_content_ref_name(batch_name),
+        format_batch_state_ref_name(batch_name),
+        format_legacy_batch_ref_name(batch_name),
+    )
+    object_info_by_ref = resolve_git_objects(ref_names)
+    return tuple(
+        (
+            ref_name,
+            (
+                None
+                if ref_name not in object_info_by_ref
+                else object_info_by_ref[ref_name].object_id
+            ),
+        )
+        for ref_name in ref_names
+    )
+
+
+def _require_unchanged_sift_inputs(
+    *,
+    source_batch: str,
+    source_snapshot: _SourceBatchSnapshot,
+    expected_worktree_identities: dict[str, WorktreeIdentity],
+) -> None:
+    current_ref_identities = _capture_source_batch_ref_identities(source_batch)
+    try:
+        current_metadata = read_validated_batch_metadata(source_batch)
+    except BatchMetadataError as error:
+        exit_with_error(str(error))
+    final_ref_identities = _capture_source_batch_ref_identities(source_batch)
+    if (
+        current_ref_identities != source_snapshot.ref_identities
+        or final_ref_identities != current_ref_identities
+        or current_metadata != source_snapshot.metadata
+    ):
+        exit_with_error(
+            _(
+                "Cannot sift batch '{source}' because it changed while sift "
+                "was running. Retry against the latest batch state."
+            ).format(source=source_batch)
+        )
+
+    current_worktree_identities = capture_worktree_identities(
+        expected_worktree_identities
+    )
+    for file_path, expected_identity in expected_worktree_identities.items():
+        if current_worktree_identities[file_path] != expected_identity:
+            exit_with_error(
+                _(
+                    "Cannot sift batch '{source}' because working-tree file "
+                    "'{file}' changed while sift was running. Retry against "
+                    "the current working tree."
+                ).format(source=source_batch, file=file_path)
+            )
+
 def _close_sifted_results(
     retained_files: list[_sift_persistence.RetainedSiftedFile],
 ) -> None:
-    """Close target buffers held by retained sift results."""
+    """Close all buffers held by retained sift results."""
     for _file_path, _file_meta, result in retained_files:
         result.close()
 

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -15259,6 +15259,51 @@ def test_text_plan_jobs_do_not_bypass_command_or_git_boundaries():
     assert violations == []
 
 
+def test_sift_jobs_do_not_bypass_parent_mutation_boundaries():
+    """Sift workers may read immutable inputs but must not publish or spawn."""
+    sift_jobs_path = (
+        SRC_ROOT / "commands" / "batch_transform" / "sift_jobs.py"
+    )
+    imported_modules = {
+        imported_module
+        for imported_module, _node in _import_from_nodes(sift_jobs_path)
+    }
+    prohibited_imports = {
+        "git_stage_batch.batch.state.lifecycle",
+        "git_stage_batch.batch.state.references",
+        "git_stage_batch.commands.batch_transform.sift_persistence",
+        "git_stage_batch.data.undo_checkpoints",
+        "git_stage_batch.staging.index_update",
+        "git_stage_batch.utils.git_command",
+        "git_stage_batch.utils.journal",
+    }
+    prohibited_calls = {
+        "Popen",
+        "run",
+        "call",
+        "check_call",
+        "check_output",
+    }
+    tree = ast.parse(sift_jobs_path.read_text(), filename=str(sift_jobs_path))
+    subprocess_calls = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        function = node.func
+        if (
+            isinstance(function, ast.Attribute)
+            and isinstance(function.value, ast.Name)
+            and function.value.id == "subprocess"
+            and function.attr in prohibited_calls
+        ):
+            subprocess_calls.append(node.lineno)
+        elif isinstance(function, ast.Name) and function.id == "Popen":
+            subprocess_calls.append(node.lineno)
+
+    assert imported_modules.isdisjoint(prohibited_imports)
+    assert subprocess_calls == []
+
+
 def test_apply_from_delegates_apply_action_execution():
     """Apply-from should delegate selected file execution to batch-source support."""
     apply_from_path = SRC_ROOT / "commands" / "apply_from.py"

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -15259,6 +15259,34 @@ def test_text_plan_jobs_do_not_bypass_command_or_git_boundaries():
     assert violations == []
 
 
+def test_sift_owns_artifact_backed_text_job_pipeline():
+    """Sift should reduce text jobs while retaining parent-side publication."""
+    sift = __import__(
+        "git_stage_batch.commands.sift",
+        fromlist=["sift"],
+    )
+    sift_path = SRC_ROOT / "commands" / "sift.py"
+    required_imports = {
+        ("git_stage_batch.commands.batch_transform", "sift_jobs"),
+        ("git_stage_batch.commands.batch_transform", "sift_persistence"),
+        ("git_stage_batch.utils.file_jobs", "run_file_jobs"),
+        ("git_stage_batch.utils.file_job_workspace", "FileJobWorkspace"),
+    }
+    sift_imports = set()
+    for imported_module, node in _import_from_nodes(sift_path):
+        for alias in node.names:
+            sift_imports.add((imported_module, alias.name))
+
+    sift_text = sift_path.read_text()
+
+    assert "command_sift_batch" in vars(sift)
+    assert required_imports <= sift_imports
+    assert "compute_sifted_text_file_job" in sift_text
+    assert "_sift_results.compute_sifted_text_file(" not in sift_text
+    assert "publish_sifted_files(" in sift_text
+    assert "replace_batch_with_sifted_files(" in sift_text
+
+
 def test_sift_jobs_do_not_bypass_parent_mutation_boundaries():
     """Sift workers may read immutable inputs but must not publish or spawn."""
     sift_jobs_path = (

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -15304,6 +15304,27 @@ def test_sift_jobs_do_not_bypass_parent_mutation_boundaries():
     assert subprocess_calls == []
 
 
+def test_sift_job_transport_has_no_content_bearing_fields():
+    """Sift IPC records should carry only compact scalars and artifact paths."""
+    sift_jobs = __import__(
+        "git_stage_batch.commands.batch_transform.sift_jobs",
+        fromlist=["sift_jobs"],
+    )
+    job_fields = set(sift_jobs.SiftTextFileJob.__dataclass_fields__)
+    result_fields = set(sift_jobs.SiftTextFileJobResult.__dataclass_fields__)
+    forbidden_fields = {
+        "content",
+        "content_bytes",
+        "lines",
+        "ownership",
+        "target_buffer",
+        "working_lines",
+    }
+
+    assert job_fields.isdisjoint(forbidden_fields)
+    assert result_fields.isdisjoint(forbidden_fields)
+
+
 def test_apply_from_delegates_apply_action_execution():
     """Apply-from should delegate selected file execution to batch-source support."""
     apply_from_path = SRC_ROOT / "commands" / "apply_from.py"

--- a/tests/commands/batch_transform/test_sift_jobs.py
+++ b/tests/commands/batch_transform/test_sift_jobs.py
@@ -1,0 +1,278 @@
+"""Tests for artifact-backed text sift jobs."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import pickle
+
+import pytest
+
+from git_stage_batch.batch.ownership.absence_claims import AbsenceClaim
+from git_stage_batch.batch.ownership.model import BatchOwnership
+from git_stage_batch.commands.batch_transform.sift_jobs import (
+    SiftTextFileJob,
+    SiftTextFileJobResult,
+    compute_sifted_text_file_job,
+    load_sifted_text_file_result,
+    validate_sifted_text_file_job_result,
+)
+from git_stage_batch.commands.batch_transform.sift_results import (
+    SiftedTextFileResult,
+)
+import git_stage_batch.commands.batch_transform.sift_jobs as sift_jobs
+from git_stage_batch.core.buffer import LineBuffer
+from git_stage_batch.data.file_target_identity import WorktreeIdentity
+from git_stage_batch.exceptions import MergeError
+from git_stage_batch.utils.file_job_workspace import FileJobWorkspace
+from git_stage_batch.utils.file_jobs import assert_file_job_transport_value
+
+
+def _job(workspace: FileJobWorkspace, *, ordinal: int = 0) -> SiftTextFileJob:
+    worktree_path = workspace.write_buffer(
+        ordinal,
+        "worktree-input",
+        (b"working\n",),
+    )
+    input_path = workspace.write_pickle(
+        ordinal,
+        "sift-input.pickle",
+        {
+            "baseline_object_id": "a" * 40,
+            "batch_source_object_id": "b" * 40,
+            "file_meta": {"change_type": "modified"},
+            "working_tree_artifact_path": str(worktree_path),
+        },
+    )
+    target_path = workspace.output_path(ordinal, "target.bin")
+    manifest_path = workspace.output_path(ordinal, "manifest.json")
+    return SiftTextFileJob(
+        ordinal=ordinal,
+        file_path="file.txt",
+        input_artifact_path=str(input_path),
+        target_output_path=str(target_path),
+        manifest_output_path=str(manifest_path),
+        deletion_output_directory=str(target_path.parent / "deletions"),
+        scratch_directory=str(workspace.scratch_directory(ordinal)),
+        expected_worktree_identity=WorktreeIdentity(
+            True,
+            "regular",
+            0o644,
+            8,
+            "digest",
+        ),
+    )
+
+
+def _retained_result() -> SiftedTextFileResult:
+    deletion = LineBuffer.from_bytes(b"old\n")
+    return SiftedTextFileResult(
+        ownership=BatchOwnership.from_presence_lines(
+            ["2-3"],
+            [AbsenceClaim(anchor_line=1, content_lines=deletion)],
+        ),
+        target_buffer=LineBuffer.from_bytes(b"base\nnew\nmore\n"),
+        change_type="modified",
+    )
+
+
+def test_compute_streams_target_and_deletions_to_manifest(
+    tmp_path,
+    monkeypatch,
+):
+    with FileJobWorkspace(parent_directory=tmp_path) as workspace:
+        job = _job(workspace)
+        source_result = _retained_result()
+        captured = {}
+
+        def compute(*args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            return source_result
+
+        monkeypatch.setattr(
+            sift_jobs._sift_results,
+            "compute_sifted_text_file",
+            compute,
+        )
+
+        result = compute_sifted_text_file_job(job)
+
+        validate_sifted_text_file_job_result(job, result)
+        assert_file_job_transport_value(result)
+        assert Path(job.target_output_path).read_bytes() == b"base\nnew\nmore\n"
+        manifest = json.loads(Path(job.manifest_output_path).read_text())
+        assert manifest["presence_lines"] == ["2-3"]
+        assert manifest["output_order"] == 0
+        assert manifest["deletions"] == [
+            {
+                "anchor_line": 1,
+                "content_path": str(
+                    Path(job.deletion_output_directory) / "00000000-content.bin"
+                ),
+                "output_order": 0,
+            }
+        ]
+        assert Path(manifest["deletions"][0]["content_path"]).read_bytes() == b"old\n"
+        assert captured["args"] == ("file.txt", {"change_type": "modified"})
+        assert captured["kwargs"]["spool_dir"] == job.scratch_directory
+        with pytest.raises(ValueError, match="buffer is closed"):
+            source_result.target_buffer.to_bytes()
+
+        loaded = load_sifted_text_file_result(workspace, job, result)
+        try:
+            assert loaded.target_buffer.to_bytes() == b"base\nnew\nmore\n"
+            assert loaded.ownership.presence_line_set().to_range_strings() == ["2-3"]
+            assert loaded.ownership.deletions[0].content_lines.to_bytes() == b"old\n"
+        finally:
+            loaded.close()
+
+
+def test_compute_reports_removed_result_without_artifacts(tmp_path, monkeypatch):
+    with FileJobWorkspace(parent_directory=tmp_path) as workspace:
+        job = _job(workspace)
+        monkeypatch.setattr(
+            sift_jobs._sift_results,
+            "compute_sifted_text_file",
+            lambda *args, **kwargs: None,
+        )
+
+        result = compute_sifted_text_file_job(job)
+
+        assert result == SiftTextFileJobResult(0, "file.txt", "removed")
+        assert_file_job_transport_value(result)
+        assert not Path(job.target_output_path).exists()
+        assert not Path(job.manifest_output_path).exists()
+
+
+def test_compute_reports_merge_error_as_ordered_scalar(tmp_path, monkeypatch):
+    with FileJobWorkspace(parent_directory=tmp_path) as workspace:
+        job = _job(workspace)
+
+        def fail(*args, **kwargs):
+            raise MergeError("ambiguous placement")
+
+        monkeypatch.setattr(
+            sift_jobs._sift_results,
+            "compute_sifted_text_file",
+            fail,
+        )
+
+        result = compute_sifted_text_file_job(job)
+
+        assert result == SiftTextFileJobResult(
+            0,
+            "file.txt",
+            "merge_error",
+            error_message="ambiguous placement",
+        )
+        validate_sifted_text_file_job_result(job, result)
+        assert_file_job_transport_value(result)
+
+
+def test_compute_refuses_unrepresented_ownership_fields(tmp_path, monkeypatch):
+    with FileJobWorkspace(parent_directory=tmp_path) as workspace:
+        job = _job(workspace)
+        source_result = _retained_result()
+        source_result.ownership.replacement_units.append(object())
+        monkeypatch.setattr(
+            sift_jobs._sift_results,
+            "compute_sifted_text_file",
+            lambda *args, **kwargs: source_result,
+        )
+
+        with pytest.raises(
+            ValueError,
+            match="do not support replacement units",
+        ):
+            compute_sifted_text_file_job(job)
+
+        with pytest.raises(ValueError, match="buffer is closed"):
+            source_result.target_buffer.to_bytes()
+
+
+def test_loader_rejects_manifest_path_substitution(tmp_path, monkeypatch):
+    with FileJobWorkspace(parent_directory=tmp_path) as workspace:
+        job = _job(workspace)
+        monkeypatch.setattr(
+            sift_jobs._sift_results,
+            "compute_sifted_text_file",
+            lambda *args, **kwargs: _retained_result(),
+        )
+        result = compute_sifted_text_file_job(job)
+        manifest = json.loads(Path(job.manifest_output_path).read_text())
+        manifest["deletions"][0]["content_path"] = str(tmp_path / "outside")
+        Path(job.manifest_output_path).write_text(json.dumps(manifest))
+
+        with pytest.raises(ValueError, match="mismatched deletion path"):
+            load_sifted_text_file_result(workspace, job, result)
+
+
+def test_loader_rejects_empty_deletion_content(tmp_path, monkeypatch):
+    with FileJobWorkspace(parent_directory=tmp_path) as workspace:
+        job = _job(workspace)
+        monkeypatch.setattr(
+            sift_jobs._sift_results,
+            "compute_sifted_text_file",
+            lambda *args, **kwargs: _retained_result(),
+        )
+        result = compute_sifted_text_file_job(job)
+        deletion_path = (
+            Path(job.deletion_output_directory) / "00000000-content.bin"
+        )
+        deletion_path.write_bytes(b"")
+
+        with pytest.raises(ValueError, match="must not be empty"):
+            load_sifted_text_file_result(workspace, job, result)
+
+
+def test_job_and_result_pickle_sizes_exclude_file_content(tmp_path):
+    with FileJobWorkspace(parent_directory=tmp_path) as workspace:
+        job = _job(workspace)
+        Path(job.target_output_path).write_bytes(b"x" * (2 * 1024 * 1024))
+        result = SiftTextFileJobResult(
+            ordinal=job.ordinal,
+            file_path=job.file_path,
+            outcome="retained",
+            manifest_path=job.manifest_output_path,
+            target_path=job.target_output_path,
+        )
+
+        assert len(pickle.dumps(job)) < 2_000
+        assert len(pickle.dumps(result)) < 1_000
+        assert_file_job_transport_value(job)
+        assert_file_job_transport_value(result)
+
+
+@pytest.mark.parametrize(
+    "result, message",
+    [
+        (
+            SiftTextFileJobResult(1, "file.txt", "removed"),
+            "mismatched result",
+        ),
+        (
+            SiftTextFileJobResult(0, "file.txt", "retained"),
+            "omitted its manifest",
+        ),
+        (
+            SiftTextFileJobResult(
+                0,
+                "file.txt",
+                "merge_error",
+                error_message=None,
+            ),
+            "omitted its error",
+        ),
+    ],
+)
+def test_result_validation_rejects_malformed_responses(
+    tmp_path,
+    result,
+    message,
+):
+    with FileJobWorkspace(parent_directory=tmp_path) as workspace:
+        job = _job(workspace)
+
+        with pytest.raises(ValueError, match=message):
+            validate_sifted_text_file_job_result(job, result)

--- a/tests/commands/batch_transform/test_sift_results.py
+++ b/tests/commands/batch_transform/test_sift_results.py
@@ -70,6 +70,35 @@ def test_compute_sifted_binary_file_retains_changed_content(
     result.target_buffer.close()
 
 
+def test_compute_sifted_binary_file_uses_captured_worktree(
+    monkeypatch,
+    tmp_path,
+):
+    """Parent-local binary sift should compare its stable captured artifact."""
+    batch_source_buffer = LineBuffer.from_bytes(b"target")
+    (tmp_path / "data.bin").write_bytes(b"changed live content")
+    artifact = tmp_path / "captured.bin"
+    artifact.write_bytes(b"target")
+    monkeypatch.setattr(
+        sift_results,
+        "read_git_object_buffer_or_empty",
+        lambda spec: batch_source_buffer,
+    )
+
+    result = sift_results.compute_sifted_binary_file(
+        "data.bin",
+        {
+            "batch_source_commit": "commit",
+            "change_type": "modified",
+        },
+        tmp_path,
+        working_tree_artifact_path=artifact,
+        captured_working_tree_exists=True,
+    )
+
+    assert result is None
+
+
 def test_compute_sifted_binary_file_removes_absent_deletion(
     monkeypatch,
     tmp_path,

--- a/tests/commands/test_sift.py
+++ b/tests/commands/test_sift.py
@@ -1206,6 +1206,27 @@ def _comparable_sift_metadata(batch_name: str) -> dict:
 class TestSiftFileJobs:
     """Contract tests for inline and process text sift execution."""
 
+    def test_empty_source_change_before_copy_aborts(self, temp_git_repo, monkeypatch):
+        command_new_batch("empty-source")
+        original_snapshot = sift_command._read_source_batch_snapshot
+
+        def snapshot_then_annotate(batch_name):
+            snapshot = original_snapshot(batch_name)
+            command_annotate_batch(batch_name, "changed after snapshot")
+            return snapshot
+
+        monkeypatch.setattr(
+            sift_command,
+            "_read_source_batch_snapshot",
+            snapshot_then_annotate,
+        )
+
+        with pytest.raises(CommandError, match="changed while sift was running"):
+            command_sift_batch("empty-source", "empty-destination")
+
+        assert not batch_exists("empty-destination")
+        assert read_batch_metadata("empty-source")["note"] == "changed after snapshot"
+
     def test_forced_process_matches_inline_publication(
         self,
         temp_git_repo,

--- a/tests/commands/test_sift.py
+++ b/tests/commands/test_sift.py
@@ -1358,6 +1358,64 @@ class TestSiftFileJobs:
             "changed during recheck"
         )
 
+    def test_mode_sift_uses_captured_mode_across_transient_change(
+        self,
+        temp_git_repo,
+        monkeypatch,
+    ):
+        script = temp_git_repo / "script.sh"
+        script.write_text("#!/bin/sh\necho test\n")
+        script.chmod(0o644)
+        subprocess.run(
+            ["git", "add", script.name],
+            check=True,
+            cwd=temp_git_repo,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Mode sift baseline"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        script.chmod(0o755)
+        command_start()
+        command_include_to_batch(
+            "mode-source",
+            file=script.name,
+            quiet=True,
+        )
+        script.chmod(0o644)
+
+        def change_before_mode_compute(jobs, compute, **kwargs):
+            assert jobs == []
+            script.chmod(0o755)
+            return []
+
+        original_capture = sift_command.capture_worktree_identities
+
+        def restore_then_capture(file_paths):
+            script.chmod(0o644)
+            return original_capture(file_paths)
+
+        monkeypatch.setattr(
+            sift_command,
+            "run_file_jobs",
+            change_before_mode_compute,
+        )
+        monkeypatch.setattr(
+            sift_command,
+            "capture_worktree_identities",
+            restore_then_capture,
+        )
+
+        command_sift_batch("mode-source", "mode-destination")
+
+        mode_metadata = read_batch_metadata("mode-destination")["files"][
+            script.name
+        ]
+        assert mode_metadata["file_type"] == "mode"
+        assert mode_metadata["new_mode"] == "100755"
+
     def test_destination_appearing_after_compute_is_preserved(
         self,
         temp_git_repo,

--- a/tests/commands/test_sift.py
+++ b/tests/commands/test_sift.py
@@ -1330,6 +1330,34 @@ class TestSiftFileJobs:
         assert read_batch_metadata("parallel-source")["note"] == "changed during sift"
         assert not any(name.startswith("sift-tmp-") for name in list_batch_names())
 
+    def test_source_change_during_worktree_recheck_aborts_before_publication(
+        self,
+        temp_git_repo,
+        monkeypatch,
+    ):
+        _prepare_parallel_sift_source(temp_git_repo)
+        original_capture = sift_command.capture_worktree_identities
+
+        def capture_then_annotate(file_paths):
+            identities = original_capture(file_paths)
+            command_annotate_batch("parallel-source", "changed during recheck")
+            return identities
+
+        monkeypatch.setenv("GIT_STAGE_BATCH_JOBS", "1")
+        monkeypatch.setattr(
+            sift_command,
+            "capture_worktree_identities",
+            capture_then_annotate,
+        )
+
+        with pytest.raises(CommandError, match="changed while sift was running"):
+            command_sift_batch("parallel-source", "recheck-race-destination")
+
+        assert not batch_exists("recheck-race-destination")
+        assert read_batch_metadata("parallel-source")["note"] == (
+            "changed during recheck"
+        )
+
     def test_destination_appearing_after_compute_is_preserved(
         self,
         temp_git_repo,

--- a/tests/commands/test_sift.py
+++ b/tests/commands/test_sift.py
@@ -1103,7 +1103,11 @@ class TestSiftCopyVsInPlace:
         command_include_to_batch("source-batch")
         readme.write_text("# Test\nbase\n")
 
+        failed_result = None
+
         def fail_persistence(*_args, **_kwargs):
+            nonlocal failed_result
+            failed_result = _args[3]
             raise OSError("synthetic persistence failure")
 
         monkeypatch.setattr(
@@ -1116,6 +1120,13 @@ class TestSiftCopyVsInPlace:
 
         assert not batch_exists("dest-batch")
         assert not any(name.startswith("sift-tmp-") for name in list_batch_names())
+        assert isinstance(failed_result, sift_results.SiftedTextFileResult)
+        with pytest.raises(ValueError, match="buffer is closed"):
+            failed_result.target_buffer.to_bytes()
+        for deletion in failed_result.ownership.deletions:
+            if isinstance(deletion.content_lines, LineBuffer):
+                with pytest.raises(ValueError, match="buffer is closed"):
+                    deletion.content_lines.to_bytes()
 
     def test_in_place_mode_is_atomic(self, temp_git_repo):
         """Test that in-place mode uses atomic update (all-or-nothing).

--- a/tests/commands/test_sift.py
+++ b/tests/commands/test_sift.py
@@ -1,5 +1,7 @@
 """Tests for sift command."""
 
+from pathlib import Path
+
 from git_stage_batch.batch.merge.merge import merge_batch_from_line_sequences_as_buffer
 
 import subprocess
@@ -23,11 +25,15 @@ from git_stage_batch.commands.sift import (
     command_sift_batch,
 )
 from git_stage_batch.batch.state.query import list_batch_names, read_batch_metadata
+from git_stage_batch.batch.state.query import get_batch_tree_sha
 from git_stage_batch.batch.binary_file_storage import add_binary_file_to_batch
 from git_stage_batch.batch.file_entry_storage import read_file_from_batch
 from git_stage_batch.core.models import BinaryFileChange
 from git_stage_batch.data.hunk_tracking import fetch_next_change
 from git_stage_batch.exceptions import CommandError, MergeError
+from git_stage_batch.commands.annotate import command_annotate_batch
+import git_stage_batch.commands.sift as sift_command
+from git_stage_batch.utils.file_job_workspace import FileJobWorkspace
 from tests.batch.ownership.metadata_helpers import (
     acquire_ownership_for_metadata,
     reject_materialized_ownership_metadata as _reject_materialized_ownership_metadata,
@@ -1155,3 +1161,290 @@ class TestSiftCopyVsInPlace:
         assert batch_exists("atomic-batch")
         metadata_after = read_batch_metadata("atomic-batch")
         assert "files" in metadata_after
+
+
+def _prepare_parallel_sift_source(repo, *, file_count: int = 2) -> list[str]:
+    file_paths = [f"parallel-{index}.txt" for index in range(file_count)]
+    for index, file_path in enumerate(file_paths):
+        (repo / file_path).write_text(f"start {index}\nold {index}\nend {index}\n")
+    subprocess.run(["git", "add", *file_paths], check=True, cwd=repo)
+    subprocess.run(
+        ["git", "commit", "-m", "Parallel sift baseline"],
+        check=True,
+        cwd=repo,
+        capture_output=True,
+    )
+    for index, file_path in enumerate(file_paths):
+        (repo / file_path).write_text(f"start {index}\nnew {index}\nend {index}\n")
+    command_start()
+    for file_path in file_paths:
+        command_include_to_batch(
+            "parallel-source",
+            file=file_path,
+            quiet=True,
+        )
+    for index, file_path in enumerate(file_paths):
+        (repo / file_path).write_text(f"start {index}\nold {index}\nend {index}\n")
+    return file_paths
+
+
+def _comparable_sift_metadata(batch_name: str) -> dict:
+    metadata = read_batch_metadata(batch_name)
+    return {
+        "baseline": metadata["baseline"],
+        "files": {
+            file_path: {
+                key: value
+                for key, value in file_meta.items()
+                if key != "batch_source_commit"
+            }
+            for file_path, file_meta in metadata["files"].items()
+        },
+    }
+
+
+class TestSiftFileJobs:
+    """Contract tests for inline and process text sift execution."""
+
+    def test_forced_process_matches_inline_publication(
+        self,
+        temp_git_repo,
+        monkeypatch,
+    ):
+        file_paths = _prepare_parallel_sift_source(temp_git_repo, file_count=4)
+        initial_worktree = {
+            file_path: (temp_git_repo / file_path).read_bytes()
+            for file_path in file_paths
+        }
+
+        monkeypatch.setenv("GIT_STAGE_BATCH_JOBS", "1")
+        command_sift_batch("parallel-source", "inline-destination")
+        for worker_count in (2, 4):
+            destination = f"process-{worker_count}-destination"
+            monkeypatch.setenv("GIT_STAGE_BATCH_JOBS", str(worker_count))
+            command_sift_batch("parallel-source", destination)
+
+            assert get_batch_tree_sha("inline-destination") == get_batch_tree_sha(
+                destination
+            )
+            assert _comparable_sift_metadata(
+                "inline-destination"
+            ) == _comparable_sift_metadata(destination)
+            assert list(read_batch_metadata(destination)["files"]) == file_paths
+        assert {
+            file_path: (temp_git_repo / file_path).read_bytes()
+            for file_path in file_paths
+        } == initial_worktree
+
+    def test_worktree_change_after_compute_aborts_before_publication(
+        self,
+        temp_git_repo,
+        monkeypatch,
+    ):
+        file_paths = _prepare_parallel_sift_source(temp_git_repo)
+        original_run = sift_command.run_file_jobs
+
+        def run_then_change(*args, **kwargs):
+            results = original_run(*args, **kwargs)
+            (temp_git_repo / file_paths[0]).write_text("changed after compute\n")
+            return results
+
+        monkeypatch.setenv("GIT_STAGE_BATCH_JOBS", "1")
+        monkeypatch.setattr(sift_command, "run_file_jobs", run_then_change)
+
+        with pytest.raises(
+            CommandError,
+            match="working-tree file 'parallel-0.txt' changed",
+        ):
+            command_sift_batch("parallel-source", "stale-worktree-destination")
+
+        assert not batch_exists("stale-worktree-destination")
+        assert not any(name.startswith("sift-tmp-") for name in list_batch_names())
+
+    def test_multiple_worker_refusals_report_source_order(
+        self,
+        temp_git_repo,
+        monkeypatch,
+    ):
+        file_paths = _prepare_parallel_sift_source(temp_git_repo)
+
+        def refuse_all(jobs, compute, **kwargs):
+            return [
+                sift_command._sift_jobs.SiftTextFileJobResult(
+                    ordinal=job.ordinal,
+                    file_path=job.file_path,
+                    outcome="merge_error",
+                    error_message=f"refused {job.file_path}",
+                )
+                for job in sorted(jobs, key=lambda item: item.ordinal)
+            ]
+
+        monkeypatch.setattr(sift_command, "run_file_jobs", refuse_all)
+
+        with pytest.raises(CommandError, match=f"refused {file_paths[0]}"):
+            command_sift_batch("parallel-source", "refused-destination")
+
+        assert not batch_exists("refused-destination")
+
+    def test_source_revision_change_after_compute_aborts_before_publication(
+        self,
+        temp_git_repo,
+        monkeypatch,
+    ):
+        _prepare_parallel_sift_source(temp_git_repo)
+        original_run = sift_command.run_file_jobs
+
+        def run_then_annotate(*args, **kwargs):
+            results = original_run(*args, **kwargs)
+            command_annotate_batch("parallel-source", "changed during sift")
+            return results
+
+        monkeypatch.setenv("GIT_STAGE_BATCH_JOBS", "1")
+        monkeypatch.setattr(sift_command, "run_file_jobs", run_then_annotate)
+
+        with pytest.raises(CommandError, match="changed while sift was running"):
+            command_sift_batch("parallel-source", "stale-source-destination")
+
+        assert not batch_exists("stale-source-destination")
+        assert read_batch_metadata("parallel-source")["note"] == "changed during sift"
+        assert not any(name.startswith("sift-tmp-") for name in list_batch_names())
+
+    def test_destination_appearing_after_compute_is_preserved(
+        self,
+        temp_git_repo,
+        monkeypatch,
+    ):
+        _prepare_parallel_sift_source(temp_git_repo)
+        original_run = sift_command.run_file_jobs
+
+        def run_then_create_destination(*args, **kwargs):
+            results = original_run(*args, **kwargs)
+            command_new_batch("raced-destination")
+            return results
+
+        monkeypatch.setenv("GIT_STAGE_BATCH_JOBS", "1")
+        monkeypatch.setattr(
+            sift_command,
+            "run_file_jobs",
+            run_then_create_destination,
+        )
+
+        with pytest.raises(CommandError, match="created while sift was running"):
+            command_sift_batch("parallel-source", "raced-destination")
+
+        assert batch_exists("raced-destination")
+        assert read_batch_metadata("raced-destination")["files"] == {}
+        assert not any(name.startswith("sift-tmp-") for name in list_batch_names())
+
+    def test_process_sift_preserves_added_text_boundaries(
+        self,
+        temp_git_repo,
+        monkeypatch,
+    ):
+        expected_content = {
+            "added-crlf.txt": b"first\r\nsecond\r\n",
+            "added-no-final-newline.txt": b"first\nsecond",
+        }
+        for file_path, content in expected_content.items():
+            (temp_git_repo / file_path).write_bytes(content)
+        command_start()
+        for file_path in expected_content:
+            command_include_to_batch(
+                "added-source",
+                file=file_path,
+                quiet=True,
+            )
+            (temp_git_repo / file_path).unlink()
+
+        monkeypatch.setenv("GIT_STAGE_BATCH_JOBS", "2")
+        command_sift_batch("added-source", "added-destination")
+
+        metadata = read_batch_metadata("added-destination")
+        assert list(metadata["files"]) == list(expected_content)
+        assert {
+            file_meta["change_type"]
+            for file_meta in metadata["files"].values()
+        } == {"added"}
+        command_apply_from_batch("added-destination")
+        assert {
+            file_path: (temp_git_repo / file_path).read_bytes()
+            for file_path in expected_content
+        } == expected_content
+
+    def test_process_sift_preserves_text_deletions(
+        self,
+        temp_git_repo,
+        monkeypatch,
+    ):
+        original_content = {
+            "deleted-a.txt": b"first\nold a\n",
+            "deleted-b.txt": b"first\nold b",
+        }
+        for file_path, content in original_content.items():
+            (temp_git_repo / file_path).write_bytes(content)
+        subprocess.run(
+            ["git", "add", *original_content],
+            check=True,
+            cwd=temp_git_repo,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Deletion baseline"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        for file_path in original_content:
+            (temp_git_repo / file_path).unlink()
+        command_start()
+        for file_path in original_content:
+            command_include_to_batch(
+                "deleted-source",
+                file=file_path,
+                quiet=True,
+            )
+        for file_path, content in original_content.items():
+            (temp_git_repo / file_path).write_bytes(content)
+
+        monkeypatch.setenv("GIT_STAGE_BATCH_JOBS", "2")
+        command_sift_batch("deleted-source", "deleted-destination")
+
+        metadata = read_batch_metadata("deleted-destination")
+        assert list(metadata["files"]) == list(original_content)
+        assert {
+            file_meta["change_type"]
+            for file_meta in metadata["files"].values()
+        } == {"deleted"}
+        command_apply_from_batch("deleted-destination")
+        assert all(
+            not (temp_git_repo / file_path).exists()
+            for file_path in original_content
+        )
+
+    def test_interruption_removes_private_sift_workspace(
+        self,
+        temp_git_repo,
+        tmp_path,
+        monkeypatch,
+    ):
+        _prepare_parallel_sift_source(temp_git_repo)
+        workspace_roots = []
+
+        class RecordingWorkspace(FileJobWorkspace):
+            def __init__(self):
+                super().__init__(parent_directory=tmp_path)
+                workspace_roots.append(self.root)
+
+        def interrupt(jobs, compute, **kwargs):
+            Path(jobs[0].payload.target_output_path).write_bytes(b"partial")
+            raise KeyboardInterrupt
+
+        monkeypatch.setenv("GIT_STAGE_BATCH_JOBS", "1")
+        monkeypatch.setattr(sift_command, "FileJobWorkspace", RecordingWorkspace)
+        monkeypatch.setattr(sift_command, "run_file_jobs", interrupt)
+
+        with pytest.raises(KeyboardInterrupt):
+            command_sift_batch("parallel-source", "interrupted-destination")
+
+        assert workspace_roots
+        assert all(not root.exists() for root in workspace_roots)
+        assert not batch_exists("interrupted-destination")


### PR DESCRIPTION
With sift result ownership made explicit in #279, the command still computes each file serially while result builders read live repository and worktree state.

Bounded text work needs captured binary, mode, and text inputs; invocation-owned intermediate storage; compact artifact-backed records; deterministic parent reduction; and source and target rechecks immediately before publication.

This pull request routes comparison, absence, and realized content through caller storage, computes sift results from captured inputs, defines validated text jobs, resolves source blobs in bulk, dispatches jobs in source order, and keeps all destination publication in the parent. It also closes empty-source, source-ref, worktree, and transient-mode races around publication.

Coverage verifies worker outcomes and transport size, result cleanup, inline and process parity, ordered failures, workspace removal, parent-only mutation, empty and changing source snapshots, destination races, and mode decisions derived from the captured state.