### PR TITLE
file-scope: Reuse one live diff across matched files

### DIFF
--- a/src/git_stage_batch/commands/file_scope/discard_file.py
+++ b/src/git_stage_batch/commands/file_scope/discard_file.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+from contextlib import nullcontext
 import shlex
 import sys
 
-from ...core.diff_parser import acquire_unified_diff
+from ...core.diff_parser import UnifiedDiffItem, acquire_unified_diff
 from ...core.hashing import (
     compute_binary_file_hash,
     compute_file_mode_change_hash,
@@ -86,9 +88,12 @@ def _print_discard_file_result(file_path: str) -> None:
 def discard_file_changes(
     file: str,
     *,
+    quiet: bool = False,
+    advance: bool = True,
     auto_advance: bool | None = None,
-) -> None:
-    """Discard all changes from one resolved file scope."""
+    _prepared_changes: Sequence[UnifiedDiffItem] | None = None,
+) -> int:
+    """Discard one file; prepared inputs require a caller-owned transaction."""
     if file == "":
         target_file = get_selected_change_file_path()
         if target_file is None:
@@ -107,17 +112,31 @@ def discard_file_changes(
                 print(_("No more hunks to process."), file=sys.stderr)
             else:
                 print(_("No selected hunk. Run 'show' first or specify file path."), file=sys.stderr)
-            return
+            return 0
     else:
         target_file = file
 
-    auto_add_untracked_files([target_file])
-    checkpoint_paths = checkpoint_paths_for_live_file(target_file)
-    with undo_checkpoint(
-        f"discard --file {file}".rstrip(),
-        worktree_paths=checkpoint_paths,
-        rollback_on_error=True,
-    ):
+    if _prepared_changes is None:
+        auto_add_untracked_files([target_file])
+        checkpoint_paths = checkpoint_paths_for_live_file(target_file)
+        checkpoint = undo_checkpoint(
+            f"discard --file {file}".rstrip(),
+            worktree_paths=checkpoint_paths,
+            rollback_on_error=True,
+        )
+        patch_context = acquire_unified_diff(
+            stream_live_git_diff(
+                full_index=True,
+                ignore_submodules="none",
+                submodule_format="short",
+                context_lines=get_context_lines(),
+            )
+        )
+    else:
+        checkpoint = nullcontext()
+        patch_context = nullcontext(iter(_prepared_changes))
+
+    with checkpoint:
         blocklist_path = get_block_list_file_path()
         blocked_hashes = read_text_file_line_set(blocklist_path)
 
@@ -125,14 +144,7 @@ def discard_file_changes(
         matching_changes = 0
         rename_change: RenameChange | None = None
         gitlink_change: GitlinkChange | None = None
-        with acquire_unified_diff(
-            stream_live_git_diff(
-                full_index=True,
-                ignore_submodules="none",
-                submodule_format="short",
-                context_lines=get_context_lines(),
-            )
-        ) as patches:
+        with patch_context as patches:
             for patch in patches:
                 if isinstance(patch, RenameChange):
                     if target_file not in (patch.old_path, patch.new_path):
@@ -171,13 +183,14 @@ def discard_file_changes(
                     hashes_to_block.append(patch_hash)
 
         if matching_changes == 0:
-            print(
-                _("No unstaged changes in file '{file}' to discard.").format(
-                    file=target_file,
-                ),
-                file=sys.stderr,
-            )
-            return
+            if not quiet:
+                print(
+                    _("No unstaged changes in file '{file}' to discard.").format(
+                        file=target_file,
+                    ),
+                    file=sys.stderr,
+                )
+            return 0
 
         snapshot_file_if_untracked(target_file)
         if rename_change is not None:
@@ -191,6 +204,12 @@ def discard_file_changes(
             append_lines_to_file(blocklist_path, [patch_hash])
             record_hunk_discarded(patch_hash)
 
-        _print_discard_file_result(target_file)
+        if not quiet:
+            _print_discard_file_result(target_file)
 
-        finish_selected_change_action(quiet=False, auto_advance=auto_advance)
+        if advance:
+            finish_selected_change_action(
+                quiet=quiet,
+                auto_advance=auto_advance,
+            )
+        return matching_changes

--- a/src/git_stage_batch/commands/file_scope/file_list_action.py
+++ b/src/git_stage_batch/commands/file_scope/file_list_action.py
@@ -2,18 +2,23 @@
 
 from __future__ import annotations
 
+from contextlib import ExitStack
 import sys
 
 from ...core.hashing import compute_rename_change_hash
-from ...data.change_freshness import text_deletion_change_is_batched
-from ...data.file_change_display import (
-    render_binary_file_change,
-    render_gitlink_change,
-    render_mode_change,
-    render_rename_change,
-    render_text_deletion_change,
+from ...core.models import (
+    BinaryFileChange,
+    FileModeChange,
+    GitlinkChange,
+    RenameChange,
+    SingleHunkPatch,
+    TextFileDeletionChange,
 )
-from ...data.file_hunk_display import render_file_as_single_hunk
+from ...data.binary_identity import attach_live_binary_fingerprint
+from ...data.change_freshness import text_deletion_change_is_batched
+from ...data.file_hunk_display import build_combined_file_line_changes
+from ...data.file_tracking import auto_add_untracked_files
+from ...data.live_diff import acquire_prepared_live_diff, group_live_diff_by_file
 from ...data.file_review.records import ReviewSource
 from ...data.selected_change.clear_reasons import (
     mark_selected_change_cleared_by_file_list,
@@ -30,6 +35,7 @@ from ...output.file_review_list import (
     print_file_review_list,
 )
 from ...utils.session_start_point import session_comparison_base
+from ...utils.paths import get_context_lines
 
 
 def show_live_file_list(files: list[str], *, selectable: bool = True) -> None:
@@ -37,41 +43,116 @@ def show_live_file_list(files: list[str], *, selectable: bool = True) -> None:
     entries = []
     comparison_base = session_comparison_base()
     seen_rename_hashes: set[str] = set()
-    for file_path in files:
-        line_changes = render_file_as_single_hunk(file_path)
-        if line_changes is not None:
-            entries.append(make_file_review_list_entry(line_changes))
-            continue
-        mode_change = render_mode_change(file_path)
-        if mode_change is not None:
-            entries.append(make_mode_file_review_list_entry(mode_change))
-            continue
-        deletion_change = render_text_deletion_change(file_path)
-        if deletion_change is not None and not text_deletion_change_is_batched(
-            deletion_change
-        ):
-            entries.append(make_text_deletion_file_review_list_entry(deletion_change))
-            continue
-        binary_change = render_binary_file_change(
-            file_path,
-            base=comparison_base,
+    auto_add_untracked_files(files)
+    with ExitStack() as changes:
+        comparison_changes = changes.enter_context(
+            acquire_prepared_live_diff(
+                base=comparison_base,
+                context_lines=get_context_lines(),
+                full_index=True,
+                ignore_submodules="none",
+                submodule_format="short",
+            )
         )
-        if binary_change is not None:
-            entries.append(make_binary_file_review_list_entry(binary_change))
-            continue
-        gitlink_change = render_gitlink_change(
-            file_path,
-            base=comparison_base,
+        comparison_changes_by_file = group_live_diff_by_file(
+            files,
+            comparison_changes,
         )
-        if gitlink_change is not None:
-            entries.append(make_gitlink_file_review_list_entry(gitlink_change))
-            continue
-        rename_change = render_rename_change(file_path)
-        if rename_change is not None:
-            rename_hash = compute_rename_change_hash(rename_change)
-            if rename_hash not in seen_rename_hashes:
-                entries.append(make_rename_file_review_list_entry(rename_change))
-                seen_rename_hashes.add(rename_hash)
+        needs_unstaged_atomic_diff = any(
+            not any(
+                isinstance(change, SingleHunkPatch)
+                for change in comparison_changes_by_file[file_path]
+            )
+            for file_path in files
+        )
+        unstaged_changes = (
+            changes.enter_context(
+                acquire_prepared_live_diff(
+                    context_lines=get_context_lines(),
+                    full_index=True,
+                    ignore_submodules="none",
+                    submodule_format="short",
+                )
+            )
+            if needs_unstaged_atomic_diff
+            else ()
+        )
+        unstaged_changes_by_file = group_live_diff_by_file(files, unstaged_changes)
+        for file_path in files:
+            comparison_file_changes = comparison_changes_by_file[file_path]
+            unstaged_file_changes = unstaged_changes_by_file[file_path]
+            line_changes = build_combined_file_line_changes(
+                file_path,
+                comparison_file_changes,
+            )
+            if line_changes is not None:
+                entries.append(make_file_review_list_entry(line_changes))
+                continue
+            mode_change = next(
+                (
+                    change
+                    for change in unstaged_file_changes
+                    if isinstance(change, FileModeChange)
+                ),
+                None,
+            )
+            if mode_change is not None:
+                entries.append(make_mode_file_review_list_entry(mode_change))
+                continue
+            deletion_change = next(
+                (
+                    change
+                    for change in unstaged_file_changes
+                    if isinstance(change, TextFileDeletionChange)
+                ),
+                None,
+            )
+            if deletion_change is not None and not text_deletion_change_is_batched(
+                deletion_change
+            ):
+                entries.append(
+                    make_text_deletion_file_review_list_entry(deletion_change)
+                )
+                continue
+            binary_change = next(
+                (
+                    change
+                    for change in comparison_file_changes
+                    if isinstance(change, BinaryFileChange)
+                ),
+                None,
+            )
+            if binary_change is not None:
+                binary_change = attach_live_binary_fingerprint(
+                    binary_change,
+                    comparison_base=comparison_base,
+                )
+                entries.append(make_binary_file_review_list_entry(binary_change))
+                continue
+            gitlink_change = next(
+                (
+                    change
+                    for change in comparison_file_changes
+                    if isinstance(change, GitlinkChange)
+                ),
+                None,
+            )
+            if gitlink_change is not None:
+                entries.append(make_gitlink_file_review_list_entry(gitlink_change))
+                continue
+            rename_change = next(
+                (
+                    change
+                    for change in unstaged_file_changes
+                    if isinstance(change, RenameChange)
+                ),
+                None,
+            )
+            if rename_change is not None:
+                rename_hash = compute_rename_change_hash(rename_change)
+                if rename_hash not in seen_rename_hashes:
+                    entries.append(make_rename_file_review_list_entry(rename_change))
+                    seen_rename_hashes.add(rename_hash)
 
     if not entries:
         print(_("No reviewable changes in matched files."), file=sys.stderr)

--- a/src/git_stage_batch/commands/file_scope/include_file.py
+++ b/src/git_stage_batch/commands/file_scope/include_file.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
-from contextlib import contextmanager
+from collections.abc import Sequence
+from contextlib import contextmanager, nullcontext
 import sys
 from typing import Iterator
 
-from ...core.diff_parser import acquire_unified_diff, patch_is_file_deletion
+from ...core.diff_parser import (
+    UnifiedDiffItem,
+    acquire_unified_diff,
+    patch_is_file_deletion,
+)
 from ...core.hashing import (
     compute_binary_file_hash,
     compute_file_mode_change_hash,
@@ -15,7 +20,13 @@ from ...core.hashing import (
     compute_stable_hunk_hash_from_lines,
     compute_text_file_deletion_hash,
 )
-from ...core.models import BinaryFileChange, FileModeChange, GitlinkChange, RenameChange, TextFileDeletionChange
+from ...core.models import (
+    BinaryFileChange,
+    FileModeChange,
+    GitlinkChange,
+    RenameChange,
+    TextFileDeletionChange,
+)
 from ...data.file_tracking import auto_add_untracked_files
 from ...data.live_diff import stream_live_git_diff
 from ...data.progress import record_hunk_included
@@ -52,8 +63,9 @@ def include_file_changes(
     quiet: bool = False,
     advance: bool = True,
     auto_advance: bool | None = None,
+    _prepared_changes: Sequence[UnifiedDiffItem] | None = None,
 ) -> int:
-    """Include all changes from one resolved file scope."""
+    """Include one file; prepared inputs require a caller-owned transaction."""
     if file == "":
         target_file = get_selected_change_file_path()
         if target_file is None:
@@ -79,24 +91,33 @@ def include_file_changes(
     else:
         target_file = file
 
-    auto_add_untracked_files([target_file])
-    checkpoint_paths = checkpoint_paths_for_live_file(target_file)
-    with undo_checkpoint(
-        f"include --file {file}".rstrip(),
-        worktree_paths=checkpoint_paths,
-    ):
-        hunks_staged = 0
-        submodule_pointers_staged = 0
-        renames_staged = 0
-        included_hashes: list[str] = []
-        staged_rename_pairs: set[tuple[str, str]] = set()
-        with _rollback_index_on_error(), acquire_unified_diff(
+    if _prepared_changes is None:
+        auto_add_untracked_files([target_file])
+        checkpoint_paths = checkpoint_paths_for_live_file(target_file)
+        checkpoint = undo_checkpoint(
+            f"include --file {file}".rstrip(),
+            worktree_paths=checkpoint_paths,
+        )
+        patch_context = acquire_unified_diff(
             stream_live_git_diff(
                 full_index=True,
                 ignore_submodules="none",
                 submodule_format="short",
             )
-        ) as patches:
+        )
+        rollback_context = _rollback_index_on_error()
+    else:
+        checkpoint = nullcontext()
+        patch_context = nullcontext(iter(_prepared_changes))
+        rollback_context = nullcontext()
+
+    with checkpoint:
+        hunks_staged = 0
+        submodule_pointers_staged = 0
+        renames_staged = 0
+        included_hashes: list[str] = []
+        staged_rename_pairs: set[tuple[str, str]] = set()
+        with rollback_context, patch_context as patches:
             for patch in patches:
                 if isinstance(patch, FileModeChange):
                     if patch.path() != target_file:
@@ -210,7 +231,10 @@ def include_file_changes(
 
     if hunks_staged == 0:
         if not quiet:
-            print(_("No hunks staged from {file}").format(file=target_file), file=sys.stderr)
+            print(
+                _("No hunks staged from {file}").format(file=target_file),
+                file=sys.stderr,
+            )
         return 0
 
     if quiet and advance:

--- a/src/git_stage_batch/commands/file_scope/multi_file_actions.py
+++ b/src/git_stage_batch/commands/file_scope/multi_file_actions.py
@@ -4,11 +4,20 @@ from __future__ import annotations
 
 from collections.abc import Callable, Sequence
 from contextlib import AbstractContextManager, nullcontext
+from dataclasses import dataclass
 import shlex
 import sys
 from typing import Protocol
 
+from ...data.file_target_identity import (
+    IndexIdentity,
+    WorktreeIdentity,
+    capture_worktree_identities,
+    index_identity_from_entry,
+)
 from ...data.hunk_tracking import select_next_change_after_action
+from ...data.index_entries import read_index_entries
+from ...data.live_diff import paths_for_live_changes
 from ...data.session import require_session_started
 from ...data.undo_checkpoints import undo_checkpoint
 from ...exceptions import CommandError
@@ -36,6 +45,14 @@ class ResolvedFileScope(Protocol):
 
     def optional_file(self) -> str | None:
         """Return the optional single-file path for command callbacks."""
+
+
+@dataclass(frozen=True, slots=True)
+class _LiveActionTargetSnapshot:
+    """Worktree and index identities behind one prepared live diff."""
+
+    index_by_path: dict[str, IndexIdentity]
+    worktree_by_path: dict[str, WorktreeIdentity]
 
 
 def _format_multi_file_operation(command: str, files: Sequence[str]) -> str:
@@ -122,6 +139,89 @@ def _prepare_live_multi_file_action() -> None:
     require_git_repository()
     require_session_started()
     ensure_state_directory_exists()
+
+
+def _require_prepared_change_paths_covered(
+    files: Sequence[str],
+    changes_by_file: dict[str, tuple],
+    checkpoint_paths: Sequence[str],
+) -> None:
+    """Reject prepared changes that reach beyond the undo before-image."""
+    prepared_paths = paths_for_live_changes(
+        change
+        for file_path in files
+        for change in changes_by_file[file_path]
+    )
+    missing_paths = sorted(set(prepared_paths) - set(checkpoint_paths))
+    if missing_paths:
+        raise CommandError(
+            _(
+                "The matched files changed while the undo checkpoint was being "
+                "prepared. Review them again and retry. Uncaptured path(s): {paths}"
+            ).format(paths=", ".join(missing_paths))
+        )
+
+
+def _capture_live_action_targets(
+    paths: Sequence[str],
+) -> _LiveActionTargetSnapshot:
+    """Capture repository identities used to prepare a mutating live action."""
+    unique_paths = tuple(dict.fromkeys(paths))
+    index_entries = read_index_entries(unique_paths)
+    return _LiveActionTargetSnapshot(
+        index_by_path={
+            path: index_identity_from_entry(index_entries.get(path))
+            for path in unique_paths
+        },
+        worktree_by_path=capture_worktree_identities(unique_paths),
+    )
+
+
+def _require_live_action_targets_unchanged(
+    *,
+    operation: str,
+    expected: _LiveActionTargetSnapshot,
+    paths: Sequence[str] | None = None,
+) -> None:
+    """Reject a prepared mutation when its index or worktree input is stale."""
+    target_paths = tuple(
+        dict.fromkeys(paths if paths is not None else expected.index_by_path)
+    )
+    current_index_entries = read_index_entries(target_paths)
+    current_worktree = capture_worktree_identities(target_paths)
+    for path in target_paths:
+        current_index = index_identity_from_entry(current_index_entries.get(path))
+        if current_index != expected.index_by_path[path]:
+            raise _live_action_target_changed_error(
+                operation=operation,
+                path=path,
+                target="index",
+            )
+        if current_worktree[path] != expected.worktree_by_path[path]:
+            raise _live_action_target_changed_error(
+                operation=operation,
+                path=path,
+                target="worktree",
+            )
+
+
+def _live_action_target_changed_error(
+    *,
+    operation: str,
+    path: str,
+    target: str,
+) -> CommandError:
+    label = _("Index") if target == "index" else _("Working tree file")
+    return CommandError(
+        _(
+            "{label} changed while multi-file {operation} was being prepared: "
+            "{path}. Review the current changes and retry."
+        ).format(
+            label=label,
+            operation=operation,
+            path=path,
+        )
+    )
 
 
 def include_each_resolved_file(

--- a/src/git_stage_batch/commands/file_scope/multi_file_actions.py
+++ b/src/git_stage_batch/commands/file_scope/multi_file_actions.py
@@ -114,19 +114,65 @@ def discard_each_resolved_file(
     *,
     auto_advance: bool | None = None,
 ) -> None:
-    """Discard a multi-file live scope under one rename-complete checkpoint."""
+    """Discard a multi-file live scope and advance selection once."""
     _prepare_live_multi_file_action()
+    total_changes = 0
+    discarded_files = []
     checkpoint_paths = checkpoint_paths_for_live_files(list(files))
     with _multi_file_undo_checkpoint(
         "discard",
         files,
         worktree_paths=checkpoint_paths,
     ):
-        for file_path in files:
-            _discard_file.discard_file_changes(
-                file_path,
-                auto_advance=auto_advance,
+        auto_add_untracked_files(files)
+        target_snapshot = _capture_live_action_targets(checkpoint_paths)
+        with acquire_prepared_live_diff(
+            full_index=True,
+            ignore_submodules="none",
+            submodule_format="short",
+            context_lines=get_context_lines(),
+        ) as changes:
+            changes_by_file = group_live_diff_by_file(files, changes)
+            _require_prepared_change_paths_covered(
+                files,
+                changes_by_file,
+                checkpoint_paths,
             )
+            _require_live_action_targets_unchanged(
+                operation="discard",
+                expected=target_snapshot,
+            )
+            for file_path in files:
+                file_changes = changes_by_file[file_path]
+                if file_changes:
+                    _require_live_action_targets_unchanged(
+                        operation="discard",
+                        expected=target_snapshot,
+                        paths=paths_for_live_changes(file_changes),
+                    )
+                discarded_changes = _discard_file.discard_file_changes(
+                    file_path,
+                    quiet=True,
+                    advance=False,
+                    auto_advance=auto_advance,
+                    _prepared_changes=file_changes,
+                )
+                if discarded_changes > 0:
+                    total_changes += discarded_changes
+                    discarded_files.append(file_path)
+
+    if total_changes == 0:
+        print(_("No unstaged changes discarded from matched files."), file=sys.stderr)
+        return
+
+    should_show_next = select_next_change_after_action(auto_advance=auto_advance)
+    file_summary = _format_file_summary(discarded_files)
+    print(
+        _("✓ Unstaged changes discarded from {files}.").format(files=file_summary),
+        file=sys.stderr,
+    )
+    if should_show_next:
+        show_selected_change()
 
 
 def _format_file_summary(files: Sequence[str]) -> str:

--- a/src/git_stage_batch/commands/file_scope/multi_file_actions.py
+++ b/src/git_stage_batch/commands/file_scope/multi_file_actions.py
@@ -9,6 +9,7 @@ import shlex
 import sys
 from typing import Protocol
 
+from ...data.file_tracking import auto_add_untracked_files
 from ...data.file_target_identity import (
     IndexIdentity,
     WorktreeIdentity,
@@ -17,7 +18,11 @@ from ...data.file_target_identity import (
 )
 from ...data.hunk_tracking import select_next_change_after_action
 from ...data.index_entries import read_index_entries
-from ...data.live_diff import paths_for_live_changes
+from ...data.live_diff import (
+    acquire_prepared_live_diff,
+    group_live_diff_by_file,
+    paths_for_live_changes,
+)
 from ...data.session import require_session_started
 from ...data.undo_checkpoints import undo_checkpoint
 from ...exceptions import CommandError
@@ -240,15 +245,40 @@ def include_each_resolved_file(
         files,
         worktree_paths=checkpoint_paths,
     ):
-        for file_path in files:
-            staged_hunks = _include_file.include_file_changes(
-                file_path,
-                quiet=True,
-                advance=False,
+        auto_add_untracked_files(files)
+        target_snapshot = _capture_live_action_targets(checkpoint_paths)
+        with acquire_prepared_live_diff(
+            full_index=True,
+            ignore_submodules="none",
+            submodule_format="short",
+        ) as changes:
+            changes_by_file = group_live_diff_by_file(files, changes)
+            _require_prepared_change_paths_covered(
+                files,
+                changes_by_file,
+                checkpoint_paths,
             )
-            if staged_hunks > 0:
-                total_hunks += staged_hunks
-                staged_files.append(file_path)
+            _require_live_action_targets_unchanged(
+                operation="include",
+                expected=target_snapshot,
+            )
+            for file_path in files:
+                file_changes = changes_by_file[file_path]
+                if file_changes:
+                    _require_live_action_targets_unchanged(
+                        operation="include",
+                        expected=target_snapshot,
+                        paths=paths_for_live_changes(file_changes),
+                    )
+                staged_hunks = _include_file.include_file_changes(
+                    file_path,
+                    quiet=True,
+                    advance=False,
+                    _prepared_changes=file_changes,
+                )
+                if staged_hunks > 0:
+                    total_hunks += staged_hunks
+                    staged_files.append(file_path)
 
     if total_hunks == 0:
         print(_("No hunks staged from matched files."), file=sys.stderr)

--- a/src/git_stage_batch/commands/file_scope/multi_file_actions.py
+++ b/src/git_stage_batch/commands/file_scope/multi_file_actions.py
@@ -29,6 +29,7 @@ from ...exceptions import CommandError
 from ...i18n import _, ngettext
 from ...utils.git_repository import require_git_repository
 from ...utils.paths import ensure_state_directory_exists
+from ...utils.paths import get_context_lines
 from . import discard_file as _discard_file
 from .discard_to_batch import discard_files_to_batch
 from . import include_file as _include_file
@@ -310,15 +311,24 @@ def skip_each_resolved_file(
     skipped_files: list[str] = []
 
     with _multi_file_undo_checkpoint("skip", files):
-        for file_path in files:
-            skipped_hunks = _skip_file.skip_file_changes(
-                file_path,
-                quiet=True,
-                advance=False,
-            )
-            if skipped_hunks > 0:
-                total_hunks += skipped_hunks
-                skipped_files.append(file_path)
+        auto_add_untracked_files(files)
+        with acquire_prepared_live_diff(
+            context_lines=get_context_lines(),
+            full_index=True,
+            ignore_submodules="none",
+            submodule_format="short",
+        ) as changes:
+            changes_by_file = group_live_diff_by_file(files, changes)
+            for file_path in files:
+                skipped_hunks = _skip_file.skip_file_changes(
+                    file_path,
+                    quiet=True,
+                    advance=False,
+                    _prepared_changes=changes_by_file[file_path],
+                )
+                if skipped_hunks > 0:
+                    total_hunks += skipped_hunks
+                    skipped_files.append(file_path)
 
     if total_hunks == 0:
         print(_("No hunks skipped from matched files."), file=sys.stderr)

--- a/src/git_stage_batch/commands/file_scope/skip_file.py
+++ b/src/git_stage_batch/commands/file_scope/skip_file.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+from contextlib import nullcontext
 import sys
 
-from ...core.diff_parser import acquire_unified_diff, build_line_changes_from_patch_lines
+from ...core.diff_parser import (
+    UnifiedDiffItem,
+    acquire_unified_diff,
+    build_line_changes_from_patch_lines,
+)
 from ...core.hashing import (
     compute_binary_file_hash,
     compute_file_mode_change_hash,
@@ -44,8 +50,9 @@ def skip_file_changes(
     quiet: bool = False,
     advance: bool = True,
     auto_advance: bool | None = None,
+    _prepared_changes: Sequence[UnifiedDiffItem] | None = None,
 ) -> int:
-    """Skip all changes from one resolved file scope."""
+    """Skip one file; prepared inputs require a caller-owned transaction."""
     if file == "":
         target_file = get_selected_change_file_path()
         if target_file is None:
@@ -58,23 +65,30 @@ def skip_file_changes(
     else:
         target_file = file
 
-    auto_add_untracked_files([target_file])
-    with undo_checkpoint(
-        f"skip --file {file}".rstrip(),
-        worktree_paths=[target_file],
-    ):
-        blocklist_path = get_block_list_file_path()
-        blocked_hashes = read_text_file_line_set(blocklist_path)
-
-        hunks_skipped = 0
-        with acquire_unified_diff(
+    if _prepared_changes is None:
+        auto_add_untracked_files([target_file])
+        checkpoint = undo_checkpoint(
+            f"skip --file {file}".rstrip(),
+            worktree_paths=[target_file],
+        )
+        patch_context = acquire_unified_diff(
             stream_live_git_diff(
                 context_lines=get_context_lines(),
                 full_index=True,
                 ignore_submodules="none",
                 submodule_format="short",
             )
-        ) as patches:
+        )
+    else:
+        checkpoint = nullcontext()
+        patch_context = nullcontext(iter(_prepared_changes))
+
+    with checkpoint:
+        blocklist_path = get_block_list_file_path()
+        blocked_hashes = read_text_file_line_set(blocklist_path)
+
+        hunks_skipped = 0
+        with patch_context as patches:
             for patch in patches:
                 if isinstance(patch, FileModeChange):
                     if patch.path() != target_file:

--- a/src/git_stage_batch/data/file_hunk_display.py
+++ b/src/git_stage_batch/data/file_hunk_display.py
@@ -47,7 +47,7 @@ def render_file_as_single_hunk(file_path: str) -> Optional[LineLevelChange]:
             paths=[file_path],
         )
     ) as patches:
-        return _build_combined_file_line_changes(
+        return build_combined_file_line_changes(
             file_path,
             patches,
         )
@@ -65,7 +65,7 @@ def render_unstaged_file_as_single_hunk(file_path: str) -> Optional[LineLevelCha
             paths=[file_path],
         )
     ) as patches:
-        return _build_combined_file_line_changes(
+        return build_combined_file_line_changes(
             file_path,
             patches,
         )
@@ -97,7 +97,7 @@ def build_file_hunk_from_buffer(
                 new_path=new_path,
             )
         ) as patches:
-            return _build_combined_file_line_changes(
+            return build_combined_file_line_changes(
                 file_path,
                 patches,
             )
@@ -159,7 +159,7 @@ def _stream_no_index_diff_lines(
         )
 
 
-def _build_combined_file_line_changes(
+def build_combined_file_line_changes(
     file_path: str,
     patches,
 ) -> Optional[LineLevelChange]:
@@ -176,7 +176,13 @@ def _build_combined_file_line_changes(
     for single_hunk in patches:
         if isinstance(
             single_hunk,
-            (BinaryFileChange, FileModeChange, GitlinkChange, RenameChange, TextFileDeletionChange),
+            (
+                BinaryFileChange,
+                FileModeChange,
+                GitlinkChange,
+                RenameChange,
+                TextFileDeletionChange,
+            ),
         ):
             continue
 

--- a/src/git_stage_batch/data/live_diff.py
+++ b/src/git_stage_batch/data/live_diff.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator, Sequence
+from collections.abc import Iterable, Iterator, Sequence
 from contextlib import contextmanager
 
 from ..core.buffer import LineBuffer
@@ -66,3 +66,21 @@ def group_live_diff_by_file(
     return {
         file_path: tuple(file_changes) for file_path, file_changes in grouped.items()
     }
+
+
+def paths_for_live_changes(
+    changes: Iterable[UnifiedDiffItem],
+) -> tuple[str, ...]:
+    """Return every repository path touched by prepared live changes."""
+    paths = []
+    for change in changes:
+        old_path = getattr(change, "old_path", None)
+        new_path = getattr(change, "new_path", None)
+        paths.extend(
+            path
+            for path in (old_path, new_path)
+            if path is not None and path != "/dev/null"
+        )
+        if old_path is None and new_path is None:
+            paths.append(change.path())
+    return tuple(dict.fromkeys(paths))

--- a/src/git_stage_batch/data/live_diff.py
+++ b/src/git_stage_batch/data/live_diff.py
@@ -2,6 +2,12 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+from ..core.buffer import LineBuffer
+from ..core.diff_parser import UnifiedDiffItem, acquire_unified_diff
+from ..core.models import SingleHunkPatch
 from ..utils.git_command import stream_git_diff
 
 
@@ -9,3 +15,29 @@ def stream_live_git_diff(**kwargs):
     """Stream actionable live changes with rename detection enabled."""
     kwargs.setdefault("find_renames", True)
     return stream_git_diff(**kwargs)
+
+
+@contextmanager
+def acquire_prepared_live_diff(**kwargs) -> Iterator[tuple[UnifiedDiffItem, ...]]:
+    """Acquire one reusable live diff while owning cloned hunk buffers."""
+    owned_buffers: list[LineBuffer] = []
+    changes: list[UnifiedDiffItem] = []
+    try:
+        with acquire_unified_diff(stream_live_git_diff(**kwargs)) as parsed:
+            for change in parsed:
+                if isinstance(change, SingleHunkPatch):
+                    lines = change.lines
+                    if not isinstance(lines, LineBuffer):
+                        raise TypeError("parsed text hunk must use LineBuffer storage")
+                    cloned_lines = lines.clone()
+                    owned_buffers.append(cloned_lines)
+                    change = SingleHunkPatch(
+                        old_path=change.old_path,
+                        new_path=change.new_path,
+                        lines=cloned_lines,
+                    )
+                changes.append(change)
+        yield tuple(changes)
+    finally:
+        for buffer in owned_buffers:
+            buffer.close()

--- a/src/git_stage_batch/data/live_diff.py
+++ b/src/git_stage_batch/data/live_diff.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 
 from ..core.buffer import LineBuffer
@@ -41,3 +41,28 @@ def acquire_prepared_live_diff(**kwargs) -> Iterator[tuple[UnifiedDiffItem, ...]
     finally:
         for buffer in owned_buffers:
             buffer.close()
+
+
+def group_live_diff_by_file(
+    files: Sequence[str],
+    changes: Sequence[UnifiedDiffItem],
+) -> dict[str, tuple[UnifiedDiffItem, ...]]:
+    """Assign each live change once to its canonical requested file."""
+    requested_files = set(files)
+    grouped: dict[str, list[UnifiedDiffItem]] = {file_path: [] for file_path in files}
+    for change in changes:
+        preferred_path = change.path()
+        if preferred_path in requested_files:
+            grouped[preferred_path].append(change)
+            continue
+        change_paths = (
+            getattr(change, "old_path", None),
+            getattr(change, "new_path", None),
+        )
+        for file_path in files:
+            if file_path in change_paths:
+                grouped[file_path].append(change)
+                break
+    return {
+        file_path: tuple(file_changes) for file_path, file_changes in grouped.items()
+    }

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -6037,8 +6037,13 @@ def test_file_scope_file_list_action_owns_live_list_rendering():
     }
     helper_imports = {
         "ReviewSource",
+        "acquire_prepared_live_diff",
+        "attach_live_binary_fingerprint",
+        "auto_add_untracked_files",
+        "build_combined_file_line_changes",
         "clear_selected_change_state_files",
         "compute_rename_change_hash",
+        "group_live_diff_by_file",
         "make_binary_file_review_list_entry",
         "make_file_review_list_entry",
         "make_gitlink_file_review_list_entry",
@@ -6046,11 +6051,6 @@ def test_file_scope_file_list_action_owns_live_list_rendering():
         "make_text_deletion_file_review_list_entry",
         "mark_selected_change_cleared_by_file_list",
         "print_file_review_list",
-        "render_binary_file_change",
-        "render_file_as_single_hunk",
-        "render_gitlink_change",
-        "render_rename_change",
-        "render_text_deletion_change",
         "text_deletion_change_is_batched",
     }
 
@@ -6117,8 +6117,13 @@ def test_file_scope_file_list_action_owns_show_entry_flow():
     show_path = SRC_ROOT / "commands" / "show.py"
     helper_path = SRC_ROOT / "commands" / "file_scope" / "file_list_action.py"
     action_dependency_names = {
+        "acquire_prepared_live_diff",
+        "attach_live_binary_fingerprint",
+        "auto_add_untracked_files",
+        "build_combined_file_line_changes",
         "compute_rename_change_hash",
         "clear_selected_change_state_files",
+        "group_live_diff_by_file",
         "make_binary_file_review_list_entry",
         "make_file_review_list_entry",
         "make_gitlink_file_review_list_entry",
@@ -6126,11 +6131,6 @@ def test_file_scope_file_list_action_owns_show_entry_flow():
         "make_text_deletion_file_review_list_entry",
         "mark_selected_change_cleared_by_file_list",
         "print_file_review_list",
-        "render_binary_file_change",
-        "render_file_as_single_hunk",
-        "render_gitlink_change",
-        "render_rename_change",
-        "render_text_deletion_change",
         "text_deletion_change_is_batched",
     }
 

--- a/tests/commands/test_file_scope_actions.py
+++ b/tests/commands/test_file_scope_actions.py
@@ -104,6 +104,7 @@ def test_discard_each_resolved_file_expands_live_checkpoint_paths(monkeypatch):
     checkpoint_calls = _capture_undo_checkpoints(monkeypatch)
     discard_calls = []
     expansion_calls = []
+    prepared_changes = _stub_prepared_diff(monkeypatch)
 
     def expand_paths(paths):
         expansion_calls.append(paths)
@@ -122,8 +123,22 @@ def test_discard_each_resolved_file_expands_live_checkpoint_paths(monkeypatch):
     monkeypatch.setattr(
         multi_file_actions._discard_file,
         "discard_file_changes",
-        lambda file_path, *, auto_advance=None: discard_calls.append(
-            (file_path, auto_advance)
+        lambda file_path,
+        *,
+        quiet=False,
+        advance=True,
+        auto_advance=None,
+        _prepared_changes=None: (
+            discard_calls.append(
+                (
+                    file_path,
+                    quiet,
+                    advance,
+                    auto_advance,
+                    _prepared_changes,
+                )
+            )
+            or 0
         ),
     )
 
@@ -142,9 +157,80 @@ def test_discard_each_resolved_file_expands_live_checkpoint_paths(monkeypatch):
         ("exit",),
     ]
     assert discard_calls == [
-        ("rename-target.txt", False),
-        ("other.txt", False),
+        ("rename-target.txt", True, False, False, prepared_changes),
+        ("other.txt", True, False, False, prepared_changes),
     ]
+
+
+def test_discard_each_resolved_file_advances_once_after_transaction(
+    monkeypatch,
+    capsys,
+):
+    """A prepared multi-file discard should update selection only at the end."""
+    _capture_undo_checkpoints(monkeypatch)
+    prepared_changes = _stub_prepared_diff(monkeypatch)
+    discard_calls = []
+    selection_calls = []
+    show_calls = []
+
+    monkeypatch.setattr(
+        multi_file_actions,
+        "checkpoint_paths_for_live_files",
+        lambda files: list(files),
+    )
+    monkeypatch.setattr(
+        multi_file_actions,
+        "_prepare_live_multi_file_action",
+        lambda: None,
+    )
+
+    def fake_discard_file(
+        file_path,
+        *,
+        quiet=False,
+        advance=True,
+        auto_advance=None,
+        _prepared_changes=None,
+    ):
+        discard_calls.append(
+            (
+                file_path,
+                quiet,
+                advance,
+                auto_advance,
+                _prepared_changes,
+            )
+        )
+        return 1
+
+    monkeypatch.setattr(
+        multi_file_actions._discard_file,
+        "discard_file_changes",
+        fake_discard_file,
+    )
+    monkeypatch.setattr(
+        multi_file_actions,
+        "select_next_change_after_action",
+        lambda *, auto_advance=None: selection_calls.append(auto_advance) or True,
+    )
+    monkeypatch.setattr(
+        multi_file_actions,
+        "show_selected_change",
+        lambda: show_calls.append("show"),
+    )
+
+    multi_file_actions.discard_each_resolved_file(
+        ["alpha.txt", "beta.txt"],
+        auto_advance=True,
+    )
+
+    assert discard_calls == [
+        ("alpha.txt", True, False, True, prepared_changes),
+        ("beta.txt", True, False, True, prepared_changes),
+    ]
+    assert selection_calls == [True]
+    assert show_calls == ["show"]
+    assert "Unstaged changes discarded from 2 files" in capsys.readouterr().err
 
 
 def test_run_for_each_resolved_file_dispatches_optional_file(monkeypatch):

--- a/tests/commands/test_file_scope_actions.py
+++ b/tests/commands/test_file_scope_actions.py
@@ -249,9 +249,16 @@ def test_skip_each_resolved_file_stops_after_empty_result(
     checkpoint_calls = _capture_undo_checkpoints(monkeypatch)
     skip_calls = []
     selection_calls = []
+    prepared_changes = _stub_prepared_diff(monkeypatch)
 
-    def fake_skip_file(file_path, *, quiet=False, advance=True):
-        skip_calls.append((file_path, quiet, advance))
+    def fake_skip_file(
+        file_path,
+        *,
+        quiet=False,
+        advance=True,
+        _prepared_changes=None,
+    ):
+        skip_calls.append((file_path, quiet, advance, _prepared_changes))
         return 0
 
     monkeypatch.setattr(
@@ -282,8 +289,8 @@ def test_skip_each_resolved_file_stops_after_empty_result(
         ("exit",),
     ]
     assert skip_calls == [
-        ("alpha.txt", True, False),
-        ("beta.txt", True, False),
+        ("alpha.txt", True, False, prepared_changes),
+        ("beta.txt", True, False, prepared_changes),
     ]
     assert selection_calls == []
     assert "No hunks skipped from matched files." in captured.err

--- a/tests/commands/test_file_scope_actions.py
+++ b/tests/commands/test_file_scope_actions.py
@@ -1,3 +1,4 @@
+from contextlib import nullcontext
 from types import SimpleNamespace
 
 import git_stage_batch.commands.file_scope.multi_file_actions as multi_file_actions
@@ -45,6 +46,36 @@ def _capture_undo_checkpoints(monkeypatch):
 
     monkeypatch.setattr(multi_file_actions, "undo_checkpoint", fake_undo_checkpoint)
     return calls
+
+
+def _stub_prepared_diff(monkeypatch):
+    prepared_changes = ()
+    monkeypatch.setattr(
+        multi_file_actions,
+        "auto_add_untracked_files",
+        lambda files: None,
+    )
+    monkeypatch.setattr(
+        multi_file_actions,
+        "acquire_prepared_live_diff",
+        lambda **_kwargs: nullcontext(prepared_changes),
+    )
+    monkeypatch.setattr(
+        multi_file_actions,
+        "group_live_diff_by_file",
+        lambda files, changes: {file_path: changes for file_path in files},
+    )
+    monkeypatch.setattr(
+        multi_file_actions,
+        "_capture_live_action_targets",
+        lambda _paths: object(),
+    )
+    monkeypatch.setattr(
+        multi_file_actions,
+        "_require_live_action_targets_unchanged",
+        lambda **_kwargs: None,
+    )
+    return prepared_changes
 
 
 def test_run_for_each_resolved_file_wraps_multiple_files(monkeypatch):
@@ -155,9 +186,16 @@ def test_include_each_resolved_file_reports_aggregate_result(
     include_calls = []
     selection_calls = []
     show_calls = []
+    prepared_changes = _stub_prepared_diff(monkeypatch)
 
-    def fake_include_file(file_path, *, quiet=False, advance=True):
-        include_calls.append((file_path, quiet, advance))
+    def fake_include_file(
+        file_path,
+        *,
+        quiet=False,
+        advance=True,
+        _prepared_changes=None,
+    ):
+        include_calls.append((file_path, quiet, advance, _prepared_changes))
         return {"alpha.txt": 2, "beta.txt": 0}[file_path]
 
     monkeypatch.setattr(
@@ -196,8 +234,8 @@ def test_include_each_resolved_file_reports_aggregate_result(
         ("exit",),
     ]
     assert include_calls == [
-        ("alpha.txt", True, False),
-        ("beta.txt", True, False),
+        ("alpha.txt", True, False, prepared_changes),
+        ("beta.txt", True, False, prepared_changes),
     ]
     assert selection_calls == [True]
     assert show_calls == ["show"]

--- a/tests/commands/test_file_scoped_operations.py
+++ b/tests/commands/test_file_scoped_operations.py
@@ -931,6 +931,7 @@ class TestShowFileFlag:
         [
             (["show", "--files", "*.txt"], 1),
             (["include", "--files", "*.txt", "--no-auto-advance"], 2),
+            (["skip", "--files", "*.txt", "--no-auto-advance"], 1),
         ],
     )
     def test_multi_file_commands_bound_live_diff_subprocesses(

--- a/tests/commands/test_file_scoped_operations.py
+++ b/tests/commands/test_file_scoped_operations.py
@@ -24,6 +24,7 @@ import subprocess
 
 import pytest
 import git_stage_batch.commands.file_scope.include_file as include_file_module
+import git_stage_batch.commands.file_scope.multi_file_actions as multi_file_actions
 import git_stage_batch.data.live_diff as live_diff
 
 from git_stage_batch.commands.start import command_start
@@ -103,6 +104,75 @@ def multi_file_repo(tmp_path, monkeypatch):
     return repo
 
 
+@pytest.mark.parametrize(
+    "action",
+    [
+        multi_file_actions.include_each_resolved_file,
+    ],
+)
+def test_multi_file_mutation_rejects_uncaptured_rename_partner(
+    multi_file_repo,
+    action,
+):
+    """A rename revealed by auto-add must not escape the undo before-image."""
+    command_start(quiet=True, auto_advance=False)
+    (multi_file_repo / "alpha.txt").write_text("alpha1\nalpha2\nalpha3\n")
+    (multi_file_repo / "alpha.txt").rename(multi_file_repo / "renamed-alpha.txt")
+
+    with pytest.raises(CommandError, match="Uncaptured path.*alpha.txt"):
+        action(
+            ["renamed-alpha.txt", "beta.txt"],
+            auto_advance=False,
+        )
+
+    staged = subprocess.run(
+        ["git", "diff", "--cached", "--quiet"],
+        check=False,
+    )
+    assert staged.returncode == 0
+    renamed_index_entry = subprocess.run(
+        ["git", "ls-files", "--error-unmatch", "--", "renamed-alpha.txt"],
+        check=False,
+        capture_output=True,
+    )
+    assert renamed_index_entry.returncode != 0
+    assert not (multi_file_repo / "alpha.txt").exists()
+    assert (multi_file_repo / "renamed-alpha.txt").exists()
+    assert "beta2-modified" in (multi_file_repo / "beta.txt").read_text()
+
+
+def test_multi_file_include_rejects_index_drift_before_later_file(
+    multi_file_repo,
+    monkeypatch,
+):
+    """A later file must not be staged from a stale prepared index view."""
+    command_start(quiet=True, auto_advance=False)
+    original_include = multi_file_actions._include_file.include_file_changes
+
+    def include_then_drift(file_path, **kwargs):
+        result = original_include(file_path, **kwargs)
+        if file_path == "alpha.txt":
+            subprocess.run(["git", "add", "beta.txt"], check=True)
+        return result
+
+    monkeypatch.setattr(
+        multi_file_actions._include_file,
+        "include_file_changes",
+        include_then_drift,
+    )
+
+    with pytest.raises(CommandError, match=r"Index changed.*beta\.txt"):
+        multi_file_actions.include_each_resolved_file(
+            ["alpha.txt", "beta.txt"],
+            auto_advance=False,
+        )
+
+    assert subprocess.run(
+        ["git", "diff", "--cached", "--quiet"],
+        check=False,
+    ).returncode == 0
+    assert "alpha2-modified" in (multi_file_repo / "alpha.txt").read_text()
+    assert "beta2-modified" in (multi_file_repo / "beta.txt").read_text()
 def _create_one_to_many_replacement_repo(tmp_path, monkeypatch):
     repo = tmp_path / "test_repo"
     repo.mkdir()
@@ -860,6 +930,7 @@ class TestShowFileFlag:
         ("arguments", "expected_live_diff_count"),
         [
             (["show", "--files", "*.txt"], 1),
+            (["include", "--files", "*.txt", "--no-auto-advance"], 2),
         ],
     )
     def test_multi_file_commands_bound_live_diff_subprocesses(

--- a/tests/commands/test_file_scoped_operations.py
+++ b/tests/commands/test_file_scoped_operations.py
@@ -108,6 +108,7 @@ def multi_file_repo(tmp_path, monkeypatch):
     "action",
     [
         multi_file_actions.include_each_resolved_file,
+        multi_file_actions.discard_each_resolved_file,
     ],
 )
 def test_multi_file_mutation_rejects_uncaptured_rename_partner(
@@ -173,6 +174,41 @@ def test_multi_file_include_rejects_index_drift_before_later_file(
     ).returncode == 0
     assert "alpha2-modified" in (multi_file_repo / "alpha.txt").read_text()
     assert "beta2-modified" in (multi_file_repo / "beta.txt").read_text()
+
+
+def test_multi_file_discard_rejects_worktree_drift_before_later_file(
+    multi_file_repo,
+    monkeypatch,
+):
+    """A later file must not be discarded from a stale prepared worktree view."""
+    command_start(quiet=True, auto_advance=False)
+    original_discard = multi_file_actions._discard_file.discard_file_changes
+
+    def discard_then_drift(file_path, **kwargs):
+        result = original_discard(file_path, **kwargs)
+        if file_path == "alpha.txt":
+            (multi_file_repo / "beta.txt").write_text("concurrent change\n")
+        return result
+
+    monkeypatch.setattr(
+        multi_file_actions._discard_file,
+        "discard_file_changes",
+        discard_then_drift,
+    )
+
+    with pytest.raises(
+        CommandError,
+        match=r"Working tree file changed.*beta\.txt",
+    ):
+        multi_file_actions.discard_each_resolved_file(
+            ["alpha.txt", "beta.txt"],
+            auto_advance=False,
+        )
+
+    assert "alpha2-modified" in (multi_file_repo / "alpha.txt").read_text()
+    assert "beta2-modified" in (multi_file_repo / "beta.txt").read_text()
+
+
 def _create_one_to_many_replacement_repo(tmp_path, monkeypatch):
     repo = tmp_path / "test_repo"
     repo.mkdir()
@@ -932,6 +968,7 @@ class TestShowFileFlag:
             (["show", "--files", "*.txt"], 1),
             (["include", "--files", "*.txt", "--no-auto-advance"], 2),
             (["skip", "--files", "*.txt", "--no-auto-advance"], 1),
+            (["discard", "--files", "*.txt", "--no-auto-advance"], 2),
         ],
     )
     def test_multi_file_commands_bound_live_diff_subprocesses(

--- a/tests/commands/test_file_scoped_operations.py
+++ b/tests/commands/test_file_scoped_operations.py
@@ -24,10 +24,11 @@ import subprocess
 
 import pytest
 import git_stage_batch.commands.file_scope.include_file as include_file_module
+import git_stage_batch.data.live_diff as live_diff
 
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.commands.again import command_again
-from git_stage_batch.commands.show import command_show
+from git_stage_batch.commands.show import command_show, command_show_file_list
 from git_stage_batch.commands.include import (
     command_include,
     command_include_to_batch,
@@ -672,6 +673,86 @@ class TestShowFileFlag:
         result = run_git_command(["diff", "--cached", "--name-only"])
         assert result.stdout == ""
 
+    def test_show_files_preserves_atomic_staged_unstaged_semantics(
+        self,
+        tmp_path,
+        monkeypatch,
+        capsys,
+    ):
+        """Staged-only atomic changes should stay out of the unstaged file list."""
+        repo = tmp_path / "test_repo"
+        repo.mkdir()
+        monkeypatch.chdir(repo)
+        subprocess.run(["git", "init"], check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.name", "Test"], check=True)
+        subprocess.run(["git", "config", "user.email", "test@test.com"], check=True)
+        for file_path in (
+            "binary.bin",
+            "mode.txt",
+            "cancelled-mode.txt",
+            "delete.txt",
+            "rename-old.txt",
+            "visible.txt",
+        ):
+            (repo / file_path).write_text(f"{file_path}\n")
+        (repo / "binary.bin").write_bytes(b"old\0binary\n")
+        # An empty deletion has no line hunk and exercises the atomic deletion
+        # renderer whose historical comparison base differs from text hunks.
+        (repo / "delete.txt").write_text("")
+        subprocess.run(["git", "add", "."], check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Initial"],
+            check=True,
+            capture_output=True,
+        )
+
+        (repo / "visible.txt").write_text("visible worktree change\n")
+        command_start(quiet=True, auto_advance=False)
+        capsys.readouterr()
+
+        # Stage the atomic changes after session-start normalization so they
+        # remain index-only, matching manual staging during an active session.
+        (repo / "mode.txt").chmod(0o755)
+        subprocess.run(["git", "add", "mode.txt"], check=True)
+        (repo / "cancelled-mode.txt").chmod(0o755)
+        subprocess.run(["git", "add", "cancelled-mode.txt"], check=True)
+        (repo / "cancelled-mode.txt").chmod(0o644)
+        (repo / "binary.bin").chmod(0o755)
+        subprocess.run(["git", "add", "binary.bin"], check=True)
+        (repo / "binary.bin").chmod(0o644)
+        (repo / "binary.bin").write_bytes(b"new\0binary\n")
+        subprocess.run(["git", "rm", "delete.txt"], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "mv", "rename-old.txt", "rename-new.txt"],
+            check=True,
+        )
+        command_show_file_list(
+            [
+                "binary.bin",
+                "mode.txt",
+                "cancelled-mode.txt",
+                "delete.txt",
+                "rename-old.txt",
+                "rename-new.txt",
+                "visible.txt",
+            ],
+            selectable=False,
+        )
+
+        output = capsys.readouterr().out
+        binary_summary = next(
+            line
+            for line in output.splitlines()
+            if "binary.bin" in line and " · " in line
+        )
+        assert "executable mode" in binary_summary
+        assert "visible.txt" in output
+        assert "cancelled-mode.txt" in output
+        assert "show --file mode.txt" not in output
+        assert "delete.txt" not in output
+        assert "rename-old.txt" not in output
+        assert "rename-new.txt" not in output
+
     def test_include_files_reports_aggregate_staged_scope(self, multi_file_repo, capsys):
         """Include --files should report the full staged scope once."""
         command_start()
@@ -775,6 +856,37 @@ class TestShowFileFlag:
         with pytest.raises(CommandError, match="last command only showed files"):
             command_skip(quiet=True)
 
+    @pytest.mark.parametrize(
+        ("arguments", "expected_live_diff_count"),
+        [
+            (["show", "--files", "*.txt"], 1),
+        ],
+    )
+    def test_multi_file_commands_bound_live_diff_subprocesses(
+        self,
+        multi_file_repo,
+        capsys,
+        monkeypatch,
+        arguments,
+        expected_live_diff_count,
+    ):
+        """Multi-file work should use a fixed number of live Git diff scans."""
+        command_start()
+        capsys.readouterr()
+        original_stream = live_diff.stream_git_diff
+        calls = []
+
+        def counting_stream(**kwargs):
+            calls.append(kwargs)
+            return original_stream(**kwargs)
+
+        monkeypatch.setattr(live_diff, "stream_git_diff", counting_stream)
+
+        args = parse_command_line(arguments, quiet=True)
+        assert args is not None
+        args.func(args)
+
+        assert len(calls) == expected_live_diff_count
 
 class TestIncludeToBatchWithFile:
     """Test include --to BATCH with --file flag."""

--- a/tests/data/test_live_diff.py
+++ b/tests/data/test_live_diff.py
@@ -44,3 +44,9 @@ def test_group_live_diff_assigns_rename_partner_once():
         "new.txt": (rename,),
         "other.txt": (mode,),
     }
+
+
+def test_paths_for_live_changes_includes_both_rename_partners():
+    rename = RenameChange("old.txt", "new.txt")
+
+    assert live_diff.paths_for_live_changes([rename]) == ("old.txt", "new.txt")

--- a/tests/data/test_live_diff.py
+++ b/tests/data/test_live_diff.py
@@ -1,0 +1,30 @@
+import pytest
+
+from git_stage_batch.core.buffer import LineBuffer
+from git_stage_batch.core.models import SingleHunkPatch
+from git_stage_batch.data import live_diff
+
+
+def test_acquire_prepared_live_diff_keeps_hunks_until_context_exit(monkeypatch):
+    diff_lines = b"""\
+diff --git a/file.txt b/file.txt
+--- a/file.txt
++++ b/file.txt
+@@ -1 +1 @@
+-old
++new
+""".splitlines(keepends=True)
+    monkeypatch.setattr(
+        live_diff,
+        "stream_live_git_diff",
+        lambda **_kwargs: iter(diff_lines),
+    )
+
+    with live_diff.acquire_prepared_live_diff() as changes:
+        change = changes[0]
+        assert isinstance(change, SingleHunkPatch)
+        assert isinstance(change.lines, LineBuffer)
+        assert b"".join(change.lines).endswith(b"+new\n")
+
+    with pytest.raises(ValueError, match="buffer is closed"):
+        list(change.lines)

--- a/tests/data/test_live_diff.py
+++ b/tests/data/test_live_diff.py
@@ -1,7 +1,7 @@
 import pytest
 
 from git_stage_batch.core.buffer import LineBuffer
-from git_stage_batch.core.models import SingleHunkPatch
+from git_stage_batch.core.models import FileModeChange, RenameChange, SingleHunkPatch
 from git_stage_batch.data import live_diff
 
 
@@ -28,3 +28,19 @@ diff --git a/file.txt b/file.txt
 
     with pytest.raises(ValueError, match="buffer is closed"):
         list(change.lines)
+
+
+def test_group_live_diff_assigns_rename_partner_once():
+    rename = RenameChange("old.txt", "new.txt")
+    mode = FileModeChange("other.txt", "100644", "100755")
+
+    grouped = live_diff.group_live_diff_by_file(
+        ["old.txt", "new.txt", "other.txt"],
+        [rename, mode],
+    )
+
+    assert grouped == {
+        "old.txt": (),
+        "new.txt": (rename,),
+        "other.txt": (mode,),
+    }


### PR DESCRIPTION
Matched-file show, include, skip, and discard currently reopen complete live diffs as each resolved path is processed.

Repository process count therefore grows with file count, and mutating commands can combine later paths from a different index or worktree snapshot. Rename partners also need to be included in the undo before-image before any prepared mutation proceeds.

This pull request retains one invocation-owned live diff, groups changes by requested path, exposes every touched rename path, and lets file-list rendering consume the prepared hunks directly. Include and discard validate captured index and worktree identities before mutation, while read-only skip reuses the same grouped input without unnecessary target guards.

Coverage verifies buffer lifetimes, rename grouping and checkpoint completeness, staged and unstaged display parity, aggregate command behavior, stale-target rollback, single advancement, and live-diff command counts that remain bounded as matched file count grows.