### PR TITLE
repository: Resolve unsafe object names through argv

### DIFF
--- a/src/git_stage_batch/utils/repository_buffers.py
+++ b/src/git_stage_batch/utils/repository_buffers.py
@@ -11,7 +11,6 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from ..core.buffer import LineBuffer
-from ..utils.git_command import stream_git_command
 from ..utils.git_command import run_git_command
 from ..utils.git_repository import get_git_repository_root_path
 from ..utils.git_object_io import (
@@ -58,6 +57,15 @@ def load_git_blob_as_buffer(
         read_git_blob(blob_sha),
         spool_dir=spool_dir,
     )
+
+
+def git_object_name_is_batch_protocol_safe(object_name: str) -> bool:
+    """Return whether an object name fits Git's line-delimited batch protocol."""
+    try:
+        object_name.encode("utf-8")
+    except UnicodeEncodeError:
+        return False
+    return "\n" not in object_name and "\r" not in object_name
 
 
 def stream_git_blob_buffers(
@@ -112,13 +120,8 @@ def read_git_object_buffer_or_none(
     """Load a Git object, returning ``None`` only when it is absent."""
     # cat-file's traditional batch protocol is line-delimited and cannot
     # represent object expressions containing newlines. Validate the revision
-    # independently, then use argv-safe `git show` for these unusual paths.
-    try:
-        revision_path.encode("utf-8")
-        batch_protocol_safe = "\n" not in revision_path and "\r" not in revision_path
-    except UnicodeEncodeError:
-        batch_protocol_safe = False
-    if not batch_protocol_safe:
+    # independently, then resolve these unusual expressions through argv.
+    if not git_object_name_is_batch_protocol_safe(revision_path):
         revision = (
             revision_path[1:]
             if revision_path.startswith(":")
@@ -134,13 +137,37 @@ def read_git_object_buffer_or_none(
                 raise GitOperationFailed(
                     f"Could not resolve Git revision {revision!r}"
                 ) from error
+        object_result = run_git_command(
+            ["rev-parse", "--verify", revision_path],
+            check=False,
+            requires_index_lock=False,
+        )
+        if object_result.returncode != 0:
+            return None
+        object_id = object_result.stdout.strip()
+        type_result = run_git_command(
+            ["cat-file", "-t", object_id],
+            check=False,
+            requires_index_lock=False,
+        )
+        if type_result.returncode != 0:
+            raise GitOperationFailed(
+                f"Could not resolve Git object {revision_path!r}"
+            )
+        object_type = type_result.stdout.strip()
+        if object_type != "blob":
+            raise RepositoryDataInvalid(
+                f"Git object {revision_path!r} is {object_type}, not a blob"
+            )
         try:
-            return LineBuffer.from_chunks(
-                _stream_git_object(revision_path),
+            return load_git_blob_as_buffer(
+                object_id,
                 spool_dir=spool_dir,
             )
-        except subprocess.CalledProcessError:
-            return None
+        except (subprocess.CalledProcessError, RuntimeError) as error:
+            raise GitOperationFailed(
+                f"Could not read Git object {revision_path!r}"
+            ) from error
     try:
         resolved = resolve_git_objects([revision_path]).get(revision_path)
     except (subprocess.CalledProcessError, RuntimeError) as error:
@@ -246,18 +273,4 @@ def read_working_tree_object(
             raise RepositoryPathMissing(file_path) from error
         raise RepositoryPathInaccessible(
             f"Could not read working-tree path {file_path!r}"
-        ) from error
-
-
-def _stream_git_object(revision_path: str) -> Iterator[bytes]:
-    try:
-        yield from stream_git_command(
-            ["show", revision_path],
-            requires_index_lock=False,
-        )
-    except subprocess.CalledProcessError as error:
-        raise subprocess.CalledProcessError(
-            error.returncode,
-            ["git", "show", revision_path],
-            stderr=error.stderr,
         ) from error

--- a/tests/utils/test_repository_buffers.py
+++ b/tests/utils/test_repository_buffers.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 
 import pytest
 
 import git_stage_batch.core.mapped_storage as mapped_storage_module
 from git_stage_batch.core.buffer import LineBuffer
+from git_stage_batch.exceptions import RepositoryDataInvalid
 import git_stage_batch.utils.repository_buffers as repository_buffers
 from git_stage_batch.utils.repository_buffers import (
+    git_object_name_is_batch_protocol_safe,
     load_git_blob_as_buffer,
     read_git_object_buffer_or_none,
     read_git_object_buffer_or_empty,
@@ -37,6 +40,19 @@ def test_load_git_blob_as_buffer_loads_streamed_blob(monkeypatch):
         assert calls == ["abc123"]
         assert buffer.uses_mapped_storage is False
         assert buffer[1] == b"beta\n"
+
+
+@pytest.mark.parametrize(
+    "object_name",
+    ["HEAD:path\nname", "HEAD:path\rname", "HEAD:path\udcffname"],
+)
+def test_git_object_name_rejects_batch_protocol_unsafe_paths(object_name):
+    """Line delimiters and surrogateescaped bytes require argv-safe reads."""
+    assert git_object_name_is_batch_protocol_safe(object_name) is False
+
+
+def test_git_object_name_accepts_normal_unicode_path():
+    assert git_object_name_is_batch_protocol_safe("HEAD:naïve file.txt") is True
 
 
 def test_stream_git_blob_buffers_spools_and_closes_each_source(
@@ -178,6 +194,31 @@ def test_read_git_object_buffer_or_none_returns_none_for_missing_object(monkeypa
     monkeypatch.setattr(repository_buffers, "resolve_git_objects", lambda _names: {})
 
     assert read_git_object_buffer_or_none("HEAD:missing.txt") is None
+
+
+def test_read_git_object_buffer_or_none_rejects_unsafe_non_blob(monkeypatch):
+    """The unusual-path fallback must retain the normal blob-only contract."""
+    calls = []
+
+    def fake_run(arguments, **_kwargs):
+        calls.append(arguments)
+        if arguments == ["rev-parse", "--verify", "HEAD^{tree}"]:
+            return SimpleNamespace(returncode=0, stdout="tree-id\n")
+        if arguments[0] == "rev-parse":
+            return SimpleNamespace(returncode=0, stdout="object-id\n")
+        assert arguments[:2] == ["cat-file", "-t"]
+        return SimpleNamespace(returncode=0, stdout="tree\n")
+
+    monkeypatch.setattr(repository_buffers, "run_git_command", fake_run)
+
+    with pytest.raises(RepositoryDataInvalid, match="tree, not a blob"):
+        read_git_object_buffer_or_none("HEAD:directory\nname")
+
+    assert calls == [
+        ["rev-parse", "--verify", "HEAD^{tree}"],
+        ["rev-parse", "--verify", "HEAD:directory\nname"],
+        ["cat-file", "-t", "object-id"],
+    ]
 
 
 def test_read_git_object_buffer_or_empty_returns_empty_for_missing_object(


### PR DESCRIPTION
Repository object reads use Git’s batch protocol for ordinary names and an argv-based fallback for expressions that cannot cross its line-delimited input.

The fallback currently reads porcelain output and does not preserve the blob-only contract enforced by the batch path. Unusual names can therefore receive different type validation and failure behavior from ordinary object expressions.

This pull request names the protocol-safety boundary, resolves unsafe expressions through argv, verifies the resolved object type, and loads accepted blob identifiers through the existing repository buffer reader.

Coverage exercises line-delimited and surrogateescaped names, ordinary Unicode names, protocol-safety classification, and rejection of tree and commit results through the fallback.