### PR TITLE
repository: Reuse bulk object reads across commands

### DIFF
--- a/src/git_stage_batch/batch/file_display.py
+++ b/src/git_stage_batch/batch/file_display.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import Optional
 
 from .ownership import display_lines as batch_display
@@ -90,26 +91,42 @@ def _render_batch_file_display_from_ownership(
     if batch_source_buffer is None:
         return None
 
-    mergeable_id_ranges = LineRanges.empty()
-    units = []
-
     with batch_source_buffer as batch_source_lines:
-        # Build display lines (already has correct line IDs matching ownership)
-        display_lines = batch_display.build_display_lines_from_batch_source_lines(
-            batch_source_lines,
-            ownership,
-            context_lines=get_context_lines(),
+        return build_batch_file_display_from_inputs(
+            file_path=file_path,
+            file_meta=file_meta,
+            ownership=ownership,
+            batch_source_lines=batch_source_lines,
+            probe_mergeability=probe_mergeability,
         )
 
-        if probe_mergeability and display_lines:
-            mergeability = _file_mergeability.probe_batch_file_mergeability(
-                file_path=file_path,
-                ownership=ownership,
-                display_lines=display_lines,
-                batch_source_lines=batch_source_lines,
-            )
-            mergeable_id_ranges = mergeability.mergeable_id_ranges
-            units = mergeability.units
+
+def build_batch_file_display_from_inputs(
+    *,
+    file_path: str,
+    file_meta: dict,
+    ownership: BatchOwnership,
+    batch_source_lines: Sequence[bytes],
+    probe_mergeability: bool,
+) -> Optional[RenderedBatchDisplay]:
+    """Build a batch display from caller-owned source and ownership inputs."""
+    display_lines = batch_display.build_display_lines_from_batch_source_lines(
+        batch_source_lines,
+        ownership,
+        context_lines=get_context_lines(),
+    )
+
+    mergeable_id_ranges = LineRanges.empty()
+    units = []
+    if probe_mergeability and display_lines:
+        mergeability = _file_mergeability.probe_batch_file_mergeability(
+            file_path=file_path,
+            ownership=ownership,
+            display_lines=display_lines,
+            batch_source_lines=batch_source_lines,
+        )
+        mergeable_id_ranges = mergeability.mergeable_id_ranges
+        units = mergeability.units
 
     return _file_display_model.build_rendered_batch_display_model(
         file_path=file_path,

--- a/src/git_stage_batch/batch/state/batch_names.py
+++ b/src/git_stage_batch/batch/state/batch_names.py
@@ -38,6 +38,18 @@ def _git_accepts_batch_name(name: str) -> bool:
 
 def validate_batch_name(name: str) -> None:
     """Validate a batch name against product and Git ref requirements."""
+    validate_batch_name_constraints(name)
+
+    if not _git_accepts_batch_name(name):
+        raise CommandError(
+            _("Batch name '{name}' is not compatible with Git ref naming rules").format(
+                name=name
+            )
+        )
+
+
+def validate_batch_name_constraints(name: str) -> None:
+    """Validate product rules for a name already discovered through Git refs."""
     if not name:
         raise CommandError(_("Batch name cannot be empty"))
 
@@ -57,25 +69,25 @@ def validate_batch_name(name: str) -> None:
             )
         )
 
-    if not _git_accepts_batch_name(name):
-        raise CommandError(
-            _("Batch name '{name}' is not compatible with Git ref naming rules").format(
-                name=name
-            )
-        )
 
-
-def invalid_file_backed_batch_names() -> list[str]:
+def invalid_file_backed_batch_names(
+    *,
+    trusted_batch_names: set[str] | None = None,
+) -> list[str]:
     """Return legacy metadata names that cannot be used by current storage."""
     batches_directory = get_batches_directory_path()
     if not batches_directory.is_dir():
         return []
 
     invalid_names = []
+    trusted_names = trusted_batch_names or set()
     for metadata_path in batches_directory.rglob("metadata.json"):
         batch_name = metadata_path.parent.relative_to(batches_directory).as_posix()
         try:
-            validate_batch_name(batch_name)
+            if batch_name in trusted_names:
+                validate_batch_name_constraints(batch_name)
+            else:
+                validate_batch_name(batch_name)
         except CommandError:
             invalid_names.append(batch_name)
     return sorted(invalid_names)

--- a/src/git_stage_batch/batch/state/validation.py
+++ b/src/git_stage_batch/batch/state/validation.py
@@ -13,6 +13,8 @@ from .references import get_batch_state_ref_name, get_legacy_batch_ref_name
 from ...exceptions import BatchMetadataError
 from ...i18n import _
 from ...utils.git_command import run_git_command
+from ...utils.git_object_io import resolve_git_objects
+from ...utils.repository_buffers import git_object_name_is_batch_protocol_safe
 from ...utils.paths import (
     get_batch_metadata_file_path,
     get_state_directory_path,
@@ -117,24 +119,8 @@ def validate_batch_metadata_structure(metadata: dict[str, Any], batch_name: str)
               "This indicates corrupted or incomplete batch state.").format(name=batch_name)
         )
 
-    # A normal batch uses a commit; a no-history batch uses the empty tree.
-    if baseline:
-        result = run_git_command(
-            ["cat-file", "-e", baseline],
-            check=False,
-            requires_index_lock=False,
-        )
-        if result.returncode != 0:
-            raise BatchMetadataError(
-                _("Batch '{name}' has invalid baseline object: {baseline}\n"
-                  "The baseline object does not exist in the repository.\n"
-                  "The batch metadata may be corrupted.").format(
-                    name=batch_name,
-                    baseline=baseline
-                )
-            )
-
     # Validate files structure if present
+    source_commits: list[tuple[str, object]] = []
     if "files" in metadata:
         files = metadata["files"]
         if not isinstance(files, dict):
@@ -170,21 +156,53 @@ def validate_batch_metadata_structure(metadata: dict[str, Any], batch_name: str)
             # Validate batch source commit exists
             batch_source_commit = file_meta.get("batch_source_commit")
             if batch_source_commit:
-                result = run_git_command(
-                    ["cat-file", "-e", batch_source_commit],
-                    check=False,
-                    requires_index_lock=False,
+                source_commits.append((file_path, batch_source_commit))
+
+    object_names = [
+        *([baseline] if baseline else []),
+        *(commit for _file_path, commit in source_commits),
+    ]
+    batch_object_names = [
+        object_name
+        for object_name in object_names
+        if isinstance(object_name, str)
+        and git_object_name_is_batch_protocol_safe(object_name)
+    ]
+    object_info_by_name = resolve_git_objects(batch_object_names)
+    if baseline and not _git_object_exists(baseline, object_info_by_name):
+        raise BatchMetadataError(
+            _("Batch '{name}' has invalid baseline object: {baseline}\n"
+              "The baseline object does not exist in the repository.\n"
+              "The batch metadata may be corrupted.").format(
+                name=batch_name,
+                baseline=baseline
+            )
+        )
+    for file_path, batch_source_commit in source_commits:
+        if not _git_object_exists(batch_source_commit, object_info_by_name):
+            raise BatchMetadataError(
+                _("Batch '{name}' has invalid batch_source_commit for file '{file}': {commit}\n"
+                  "The batch source commit does not exist in the repository.\n"
+                  "The batch metadata may be corrupted.").format(
+                    name=batch_name,
+                    file=file_path,
+                    commit=batch_source_commit
                 )
-                if result.returncode != 0:
-                    raise BatchMetadataError(
-                        _("Batch '{name}' has invalid batch_source_commit for file '{file}': {commit}\n"
-                          "The batch source commit does not exist in the repository.\n"
-                          "The batch metadata may be corrupted.").format(
-                            name=batch_name,
-                            file=file_path,
-                            commit=batch_source_commit
-                        )
-                    )
+            )
+
+
+def _git_object_exists(object_name: object, object_info_by_name: dict) -> bool:
+    """Check unusual metadata names through argv, outside the batch protocol."""
+    if not isinstance(object_name, str):
+        return False
+    if git_object_name_is_batch_protocol_safe(object_name):
+        return object_name in object_info_by_name
+    result = run_git_command(
+        ["cat-file", "-e", object_name],
+        check=False,
+        requires_index_lock=False,
+    )
+    return result.returncode == 0
 
 
 def load_and_validate_batch_metadata(batch_name: str) -> dict[str, Any]:

--- a/src/git_stage_batch/commands/batch_source/file_list_action.py
+++ b/src/git_stage_batch/commands/batch_source/file_list_action.py
@@ -2,19 +2,28 @@
 
 from __future__ import annotations
 
+from contextlib import ExitStack
 import sys
 
 from ...batch.atomic_file_changes import (
     binary_change_from_batch_file_metadata,
     gitlink_change_from_batch_file_metadata,
 )
-from ...batch.file_display import render_batch_file_display
+from ...batch.file_display import build_batch_file_display_from_inputs
+from ...batch.ownership.metadata_blobs import (
+    deletion_content_blob_ids,
+    deletion_reference_blob_ids,
+    presence_claim_reference_blob_ids,
+    replacement_origin_reference_blob_ids,
+)
+from ...batch.ownership.metadata_loading import ownership_from_metadata_dict
 from ...core.models import FileModeChange
 from ...data.file_review.records import ReviewSource
 from ...data.selected_change.clear_reasons import (
     mark_selected_change_cleared_by_file_list,
 )
 from ...data.selected_change.lifecycle import clear_selected_change_state_files
+from ...exceptions import RepositoryDataInvalid
 from ...i18n import _
 from ...output.file_review_list import (
     make_binary_file_review_list_entry,
@@ -23,18 +32,171 @@ from ...output.file_review_list import (
     make_mode_file_review_list_entry,
     print_file_review_list,
 )
+from ...utils.git_object_io import resolve_git_objects
+from ...utils.repository_buffers import (
+    acquire_git_blob_buffers,
+    git_object_name_is_batch_protocol_safe,
+    read_git_object_buffer_or_none,
+)
 
 
 def show_batch_source_file_list(
     *,
     batch_name: str,
     files: dict[str, dict],
-    metadata: dict,
     selectable: bool,
     command_source_args: str,
 ) -> None:
     """Show a navigational list for multiple files from a batch."""
     entries = []
+    text_files = {
+        file_path: file_meta
+        for file_path, file_meta in files.items()
+        if file_meta.get("file_type") not in {"binary", "gitlink", "mode"}
+    }
+    source_name_by_path = {
+        file_path: f"{file_meta['batch_source_commit']}:{file_path}"
+        for file_path, file_meta in text_files.items()
+    }
+    deletion_ids = list(
+        dict.fromkeys(
+            blob_id
+            for file_meta in text_files.values()
+            for blob_id in deletion_content_blob_ids(file_meta.get("deletions", []))
+        )
+    )
+    reference_ids = list(
+        dict.fromkeys(
+            blob_id
+            for file_meta in text_files.values()
+            for blob_id in [
+                *deletion_reference_blob_ids(file_meta.get("deletions", [])),
+                *presence_claim_reference_blob_ids(
+                    file_meta.get("presence_claims", [])
+                ),
+                *replacement_origin_reference_blob_ids(
+                    file_meta.get("replacement_units", [])
+                ),
+            ]
+        )
+    )
+    batch_source_names = [
+        source_name
+        for source_name in source_name_by_path.values()
+        if git_object_name_is_batch_protocol_safe(source_name)
+    ]
+    object_info_by_name = resolve_git_objects(
+        [*batch_source_names, *deletion_ids, *reference_ids]
+    )
+    for source_name in batch_source_names:
+        object_info = object_info_by_name.get(source_name)
+        if object_info is not None and object_info.object_type != "blob":
+            raise RepositoryDataInvalid(
+                f"Git object {source_name!r} is {object_info.object_type}, not a blob"
+            )
+    _require_ownership_blobs(
+        text_files=text_files,
+        object_info_by_name=object_info_by_name,
+    )
+    object_id_by_name = {
+        name: info.object_id
+        for name, info in object_info_by_name.items()
+        if info.object_type == "blob"
+    }
+    object_ids = list(dict.fromkeys(object_id_by_name.values()))
+
+    with ExitStack() as source_buffers:
+        source_buffer_by_path = {}
+        unsafe_source_paths = [
+            file_path
+            for file_path, source_name in source_name_by_path.items()
+            if not git_object_name_is_batch_protocol_safe(source_name)
+        ]
+        for file_path in unsafe_source_paths:
+            source_name = source_name_by_path[file_path]
+            source_buffer = read_git_object_buffer_or_none(source_name)
+            if source_buffer is not None:
+                source_buffer_by_path[file_path] = source_buffers.enter_context(
+                    source_buffer
+                )
+
+        with acquire_git_blob_buffers(object_ids) as buffer_by_id:
+            for file_path, source_name in source_name_by_path.items():
+                source_object_id = object_id_by_name.get(source_name)
+                if source_object_id is not None:
+                    source_buffer_by_path[file_path] = buffer_by_id[source_object_id]
+            reference_contents = {
+                blob_id: buffer_by_id[object_id_by_name[blob_id]].to_bytes()
+                for blob_id in reference_ids
+                if blob_id in object_id_by_name
+            }
+            deletion_buffers = {
+                blob_id: buffer_by_id[object_id_by_name[blob_id]]
+                for blob_id in deletion_ids
+                if blob_id in object_id_by_name
+            }
+            _append_batch_file_entries(
+                entries=entries,
+                files=files,
+                source_buffer_by_path=source_buffer_by_path,
+                reference_contents=reference_contents,
+                deletion_buffers=deletion_buffers,
+            )
+
+    if entries:
+        if selectable:
+            clear_selected_change_state_files()
+            mark_selected_change_cleared_by_file_list(
+                source=ReviewSource.BATCH.value,
+                batch_name=batch_name,
+            )
+        print_file_review_list(
+            source_label=_("Changes: batch {name}").format(name=batch_name),
+            entries=entries,
+            command_source_args=command_source_args,
+        )
+    else:
+        print(_("Batch '{name}' is empty").format(name=batch_name), file=sys.stderr)
+
+
+def _require_ownership_blobs(
+    *,
+    text_files: dict[str, dict],
+    object_info_by_name: dict,
+) -> None:
+    """Require every blob referenced by ownership metadata to be readable."""
+    for file_path, file_meta in text_files.items():
+        required_ids = [
+            *deletion_content_blob_ids(file_meta.get("deletions", [])),
+            *deletion_reference_blob_ids(file_meta.get("deletions", [])),
+            *presence_claim_reference_blob_ids(file_meta.get("presence_claims", [])),
+            *replacement_origin_reference_blob_ids(
+                file_meta.get("replacement_units", [])
+            ),
+        ]
+        for object_id in dict.fromkeys(required_ids):
+            object_info = object_info_by_name.get(object_id)
+            if object_info is None:
+                raise RepositoryDataInvalid(
+                    f"Git object {object_id!r} required by batch metadata for "
+                    f"{file_path!r} is missing"
+                )
+            if object_info.object_type != "blob":
+                raise RepositoryDataInvalid(
+                    f"Git object {object_id!r} required by batch metadata for "
+                    f"{file_path!r} is {object_info.object_type}, not a blob"
+                )
+
+
+def _append_batch_file_entries(
+    *,
+    entries: list,
+    files: dict[str, dict],
+    source_buffer_by_path: dict,
+    reference_contents: dict[str, bytes],
+    deletion_buffers: dict,
+) -> None:
+    """Append ordered batch entries from caller-owned bulk object inputs."""
     for file_path, file_meta in files.items():
         if file_meta.get("file_type") == "mode":
             entries.append(
@@ -55,10 +217,19 @@ def show_batch_source_file_list(
         if gitlink_change is not None:
             entries.append(make_gitlink_file_review_list_entry(gitlink_change))
             continue
-        rendered = render_batch_file_display(
-            batch_name,
-            file_path,
-            metadata=metadata,
+        source_buffer = source_buffer_by_path.get(file_path)
+        if source_buffer is None:
+            continue
+        ownership = ownership_from_metadata_dict(
+            file_meta,
+            blob_contents=reference_contents,
+            deletion_blob_buffers=deletion_buffers,
+        )
+        rendered = build_batch_file_display_from_inputs(
+            file_path=file_path,
+            file_meta=file_meta,
+            ownership=ownership,
+            batch_source_lines=source_buffer,
             probe_mergeability=False,
         )
         if rendered is not None:
@@ -67,18 +238,3 @@ def show_batch_source_file_list(
                     rendered.line_changes,
                 )
             )
-
-    if entries:
-        if selectable:
-            clear_selected_change_state_files()
-            mark_selected_change_cleared_by_file_list(
-                source=ReviewSource.BATCH.value,
-                batch_name=batch_name,
-            )
-        print_file_review_list(
-            source_label=_("Changes: batch {name}").format(name=batch_name),
-            entries=entries,
-            command_source_args=command_source_args,
-        )
-    else:
-        print(_("Batch '{name}' is empty").format(name=batch_name), file=sys.stderr)

--- a/src/git_stage_batch/commands/show_from.py
+++ b/src/git_stage_batch/commands/show_from.py
@@ -126,7 +126,6 @@ def command_show_from_batch(
     _file_list_action.show_batch_source_file_list(
         batch_name=batch_name,
         files=files,
-        metadata=metadata,
         selectable=selectable,
         command_source_args=_batch_source_args(batch_name),
     )

--- a/src/git_stage_batch/commands/validate.py
+++ b/src/git_stage_batch/commands/validate.py
@@ -16,28 +16,37 @@ from ..batch.state.query import list_batch_names
 from ..batch.state.batch_names import (
     invalid_file_backed_batch_names,
     validate_batch_name,
+    validate_batch_name_constraints,
 )
-from ..batch.state.references import (
-    get_authoritative_batch_commit_sha,
-    get_batch_content_ref_name,
-    get_batch_state_ref_name,
-    get_legacy_batch_ref_name,
+from ..batch.state.reference_names import (
+    format_batch_content_ref_name,
+    format_batch_state_ref_name,
+    format_legacy_batch_ref_name,
 )
 from ..exceptions import BatchMetadataError, CommandError
 from ..i18n import _
 from ..utils.file_io import read_text_file_contents
-from ..utils.git_command import run_git_command
+from ..utils.git_object_io import (
+    GitObjectInfo,
+    read_git_blobs_as_bytes,
+    resolve_git_objects,
+)
 from ..utils.git_repository import require_git_repository
 from ..utils.paths import get_batch_metadata_file_path
 
 
 def inspect_batch_metadata() -> list[dict[str, Any]]:
     """Return diagnostics for every discoverable batch without writing state."""
-    reports = []
-    invalid_file_names = invalid_file_backed_batch_names()
-    batch_names = sorted(
-        set(list_batch_names(validate_legacy_metadata=False)) | set(invalid_file_names)
+    ref_batch_names = list_batch_names(validate_legacy_metadata=False)
+    ref_batch_name_set = set(ref_batch_names)
+    invalid_file_names = invalid_file_backed_batch_names(
+        trusted_batch_names=ref_batch_name_set,
     )
+    batch_names = sorted(
+        ref_batch_name_set | set(invalid_file_names)
+    )
+    reports = []
+    validated_names = []
     for batch_name in batch_names:
         report: dict[str, Any] = {
             "batch": batch_name,
@@ -47,21 +56,83 @@ def inspect_batch_metadata() -> list[dict[str, Any]]:
             "errors": [],
         }
         try:
-            validate_batch_name(batch_name)
+            if batch_name in ref_batch_name_set:
+                validate_batch_name_constraints(batch_name)
+            else:
+                validate_batch_name(batch_name)
         except CommandError as error:
             report["status"] = "error"
             report["source"] = "legacy-file"
             report["errors"].append(error.message)
             reports.append(report)
             continue
-        state_result = run_git_command(
-            ["show", f"{get_batch_state_ref_name(batch_name)}:batch.json"],
-            check=False,
-            requires_index_lock=False,
+        validated_names.append(batch_name)
+        reports.append(report)
+
+    state_refspec_by_name = {
+        batch_name: f"{format_batch_state_ref_name(batch_name)}:batch.json"
+        for batch_name in validated_names
+    }
+    state_ref_by_name = {
+        batch_name: format_batch_state_ref_name(batch_name)
+        for batch_name in validated_names
+    }
+    related_ref_names = [
+        ref_name
+        for batch_name in validated_names
+        for ref_name in (
+            format_batch_content_ref_name(batch_name),
+            format_legacy_batch_ref_name(batch_name),
         )
-        if state_result.returncode == 0:
-            payload = state_result.stdout
+    ]
+    ref_objects = resolve_git_objects(
+        [
+            *state_ref_by_name.values(),
+            *state_refspec_by_name.values(),
+            *related_ref_names,
+        ]
+    )
+    state_payloads = read_git_blobs_as_bytes(
+        object_info.object_id
+        for refspec in state_refspec_by_name.values()
+        if (object_info := ref_objects.get(refspec)) is not None
+        and object_info.object_type == "blob"
+    )
+
+    decoded_models: list[tuple[dict[str, Any], BatchMetadata]] = []
+    reports_by_name = {report["batch"]: report for report in reports}
+    for batch_name in validated_names:
+        report = reports_by_name[batch_name]
+        state_ref = state_ref_by_name[batch_name]
+        state_refspec = state_refspec_by_name[batch_name]
+        state_ref_object = ref_objects.get(state_ref)
+        state_object = ref_objects.get(state_refspec)
+        authoritative_payload = (
+            state_payloads.get(state_object.object_id)
+            if state_object is not None and state_object.object_type == "blob"
+            else None
+        )
+        state_read_error = None
+        if state_ref_object is not None:
+            payload: str | bytes = (
+                authoritative_payload
+                if authoritative_payload is not None
+                else b""
+            )
             source = "state-ref"
+            if state_object is None:
+                state_read_error = (
+                    "authoritative batch state is missing path 'batch.json'"
+                )
+            elif state_object.object_type != "blob":
+                state_read_error = (
+                    "authoritative batch state path 'batch.json' is "
+                    f"{state_object.object_type}, not a blob"
+                )
+            elif authoritative_payload is None:
+                state_read_error = (
+                    "authoritative batch state object could not be read"
+                )
         else:
             metadata_path = get_batch_metadata_file_path(batch_name)
             payload = (
@@ -69,13 +140,20 @@ def inspect_batch_metadata() -> list[dict[str, Any]]:
             )
             source = "legacy-file"
         report["source"] = source
+        content_ref = format_batch_content_ref_name(batch_name)
+        legacy_ref = format_legacy_batch_ref_name(batch_name)
         _classify_compatibility_residue(
             batch_name,
             report,
-            authoritative_payload=(
-                state_result.stdout if state_result.returncode == 0 else None
+            authoritative_payload=authoritative_payload,
+            authoritative_state_exists=state_ref_object is not None,
+            related_ref_exists=(
+                content_ref in ref_objects or legacy_ref in ref_objects
             ),
         )
+        if state_read_error is not None:
+            report["errors"].append(state_read_error)
+            continue
 
         try:
             raw = json.loads(payload)
@@ -85,32 +163,48 @@ def inspect_batch_metadata() -> list[dict[str, Any]]:
             report["migration_required"] = report["schema_version"] == 0
             model = decode_batch_metadata(payload, expected_batch=batch_name)
             report["revision"] = model.revision
-            report["errors"].extend(_referential_errors(model))
+            decoded_models.append((report, model))
+        except UnicodeDecodeError as error:
+            report["errors"].append(
+                f"Batch '{batch_name}' metadata is not valid JSON: {error}"
+            )
         except (BatchMetadataError, json.JSONDecodeError) as error:
             report["errors"].append(str(error))
 
+    referenced_object_names = [
+        object_name
+        for _report, model in decoded_models
+        for _field, object_name in _metadata_object_fields(model)
+    ]
+    referenced_objects = resolve_git_objects(referenced_object_names)
+    for report, model in decoded_models:
+        content_ref = format_batch_content_ref_name(model.batch)
+        content_ref_info = ref_objects.get(content_ref)
+        report["errors"].extend(
+            _referential_errors(
+                model,
+                actual_commit=(
+                    content_ref_info.object_id
+                    if content_ref_info is not None
+                    else None
+                ),
+                object_info_by_name=referenced_objects,
+            )
+        )
+
+    for report in reports:
         if report["errors"]:
             report["status"] = "error"
-        reports.append(report)
     return reports
-
-
-def _ref_exists(ref_name: str) -> bool:
-    return (
-        run_git_command(
-            ["show-ref", "--verify", "--quiet", ref_name],
-            check=False,
-            requires_index_lock=False,
-        ).returncode
-        == 0
-    )
 
 
 def _classify_compatibility_residue(
     batch_name: str,
     report: dict[str, Any],
     *,
-    authoritative_payload: str | None,
+    authoritative_payload: str | bytes | None,
+    authoritative_state_exists: bool,
+    related_ref_exists: bool,
 ) -> None:
     """Classify crash-residual file metadata without making it authoritative."""
     metadata_path = get_batch_metadata_file_path(batch_name)
@@ -131,11 +225,29 @@ def _classify_compatibility_residue(
         report["errors"].append(f"invalid compatibility metadata residue: {error}")
         return
 
+    if authoritative_state_exists and authoritative_payload is None:
+        report["residue"] = {
+            "class": "unverifiable_residue",
+            "path": str(metadata_path),
+            "file_revision": file_model.revision,
+            "safe_automatic_repair": False,
+        }
+        return
+
     if authoritative_payload is not None:
-        state_model = decode_batch_metadata(
-            authoritative_payload,
-            expected_batch=batch_name,
-        )
+        try:
+            state_model = decode_batch_metadata(
+                authoritative_payload,
+                expected_batch=batch_name,
+            )
+        except (BatchMetadataError, json.JSONDecodeError):
+            report["residue"] = {
+                "class": "unverifiable_residue",
+                "path": str(metadata_path),
+                "file_revision": file_model.revision,
+                "safe_automatic_repair": False,
+            }
+            return
         if file_model.to_application_dict() == state_model.to_application_dict():
             residue_class = "redundant_residue"
             safe_repair = True
@@ -158,33 +270,19 @@ def _classify_compatibility_residue(
             )
         return
 
-    legacy_or_content = _ref_exists(
-        get_legacy_batch_ref_name(batch_name)
-    ) or _ref_exists(get_batch_content_ref_name(batch_name))
     report["residue"] = {
         "class": "legacy_compatibility_state"
-        if legacy_or_content
+        if related_ref_exists
         else "orphaned_create",
         "path": str(metadata_path),
         "file_revision": file_model.revision,
         "safe_automatic_repair": False,
     }
-    if not legacy_or_content:
+    if not related_ref_exists:
         report["errors"].append("orphaned batch metadata has no related refs")
 
 
-def _referential_errors(model: BatchMetadata) -> list[str]:
-    errors = []
-    expected_ref = get_batch_content_ref_name(model.batch)
-    actual_commit = get_authoritative_batch_commit_sha(model.batch)
-    if model.content_ref is not None and model.content_ref != expected_ref:
-        errors.append(
-            f"content_ref is {model.content_ref!r}; expected {expected_ref!r}"
-        )
-    if model.content_commit is not None and model.content_commit != actual_commit:
-        errors.append(
-            "content_commit does not match the authoritative batch content ref"
-        )
+def _metadata_object_fields(model: BatchMetadata) -> list[tuple[str, str]]:
     object_fields = []
     if model.baseline is not None:
         object_fields.append(("baseline", model.baseline))
@@ -200,13 +298,27 @@ def _referential_errors(model: BatchMetadata) -> list[str]:
                 object_fields.append(
                     (f"files[{entry.path!r}].deletions[{index}].blob", blob)
                 )
-    for field, object_id in object_fields:
-        result = run_git_command(
-            ["cat-file", "-e", object_id],
-            check=False,
-            requires_index_lock=False,
+    return object_fields
+
+
+def _referential_errors(
+    model: BatchMetadata,
+    *,
+    actual_commit: str | None,
+    object_info_by_name: Mapping[str, GitObjectInfo],
+) -> list[str]:
+    errors = []
+    expected_ref = format_batch_content_ref_name(model.batch)
+    if model.content_ref is not None and model.content_ref != expected_ref:
+        errors.append(
+            f"content_ref is {model.content_ref!r}; expected {expected_ref!r}"
         )
-        if result.returncode != 0:
+    if model.content_commit is not None and model.content_commit != actual_commit:
+        errors.append(
+            "content_commit does not match the authoritative batch content ref"
+        )
+    for field, object_id in _metadata_object_fields(model):
+        if object_id not in object_info_by_name:
             errors.append(f"{field} names missing object {object_id}")
     return errors
 

--- a/src/git_stage_batch/utils/repository_buffers.py
+++ b/src/git_stage_batch/utils/repository_buffers.py
@@ -7,6 +7,7 @@ import errno
 import stat
 import subprocess
 from collections.abc import Iterable, Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -87,6 +88,27 @@ def stream_git_blob_buffers(
                 buffer=buffer,
             )
         finally:
+            buffer.close()
+
+
+@contextmanager
+def acquire_git_blob_buffers(
+    blob_names: Iterable[str],
+    *,
+    spool_dir: str | Path | None = None,
+) -> Iterator[dict[str, LineBuffer]]:
+    """Acquire reusable buffers for unique blobs through one batch stream."""
+    buffers: dict[str, LineBuffer] = {}
+    owned_buffers: list[LineBuffer] = []
+    try:
+        for blob in stream_git_blob_buffers(blob_names, spool_dir=spool_dir):
+            buffer = blob.buffer.clone(spool_dir=spool_dir)
+            owned_buffers.append(buffer)
+            buffers[blob.requested_name] = buffer
+            buffers[blob.object_id] = buffer
+        yield buffers
+    finally:
+        for buffer in owned_buffers:
             buffer.close()
 
 

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -13586,15 +13586,22 @@ def test_batch_source_file_list_action_owns_list_rendering():
     }
     helper_imports = {
         "ReviewSource",
+        "acquire_git_blob_buffers",
         "binary_change_from_batch_file_metadata",
+        "build_batch_file_display_from_inputs",
         "clear_selected_change_state_files",
+        "deletion_content_blob_ids",
+        "deletion_reference_blob_ids",
         "gitlink_change_from_batch_file_metadata",
         "make_binary_file_review_list_entry",
         "make_file_review_list_entry",
         "make_gitlink_file_review_list_entry",
         "mark_selected_change_cleared_by_file_list",
+        "ownership_from_metadata_dict",
+        "presence_claim_reference_blob_ids",
         "print_file_review_list",
-        "render_batch_file_display",
+        "replacement_origin_reference_blob_ids",
+        "resolve_git_objects",
     }
 
     helper_imported_names = set()
@@ -13611,15 +13618,22 @@ def test_batch_source_file_list_action_owns_show_flow():
     helper_path = SRC_ROOT / "commands" / "batch_source" / "file_list_action.py"
     action_dependency_names = {
         "ReviewSource",
+        "acquire_git_blob_buffers",
         "binary_change_from_batch_file_metadata",
+        "build_batch_file_display_from_inputs",
         "clear_selected_change_state_files",
+        "deletion_content_blob_ids",
+        "deletion_reference_blob_ids",
         "gitlink_change_from_batch_file_metadata",
         "make_binary_file_review_list_entry",
         "make_file_review_list_entry",
         "make_gitlink_file_review_list_entry",
         "mark_selected_change_cleared_by_file_list",
+        "ownership_from_metadata_dict",
+        "presence_claim_reference_blob_ids",
         "print_file_review_list",
-        "render_batch_file_display",
+        "replacement_origin_reference_blob_ids",
+        "resolve_git_objects",
     }
 
     show_from_tree = ast.parse(

--- a/tests/batch/state/test_batch_names.py
+++ b/tests/batch/state/test_batch_names.py
@@ -9,6 +9,7 @@ from git_stage_batch.batch.state.query import list_batch_names
 from git_stage_batch.batch.state.batch_names import (
     MAX_BATCH_NAME_BYTES,
     batch_exists,
+    invalid_file_backed_batch_names,
     validate_batch_name,
 )
 from git_stage_batch.exceptions import CommandError
@@ -103,6 +104,17 @@ def test_batch_discovery_reports_invalid_legacy_metadata(temp_git_repo):
     assert "Legacy batch metadata" in exc_info.value.message
     assert "legacy^name" in exc_info.value.message
     assert "refs/batches" in exc_info.value.message
+
+
+def test_trusted_ref_name_still_obeys_product_constraints(temp_git_repo):
+    """Ref discovery should bypass only Git's already-satisfied name checks."""
+    metadata_path = get_batch_metadata_file_path("nested/name")
+    metadata_path.parent.mkdir(parents=True)
+    metadata_path.write_text("{}")
+
+    assert invalid_file_backed_batch_names(
+        trusted_batch_names={"nested/name"},
+    ) == ["nested/name"]
 
 
 @pytest.mark.parametrize("name", ["ordinary", "café", "release-2026.07"])

--- a/tests/batch/state/test_validation.py
+++ b/tests/batch/state/test_validation.py
@@ -6,6 +6,7 @@ import subprocess
 from pathlib import Path
 
 import pytest
+import git_stage_batch.utils.git_command as git_command_module
 
 from git_stage_batch.batch.state.validation import (
     get_validated_baseline_commit,
@@ -345,6 +346,37 @@ def test_validate_batch_metadata_structure_invalid_batch_source_commit(temp_git_
     assert "0000000000000000000000000000000000000000" in error_msg
 
 
+@pytest.mark.parametrize(
+    ("metadata", "message"),
+    [
+        (
+            {"baseline": "HEAD\nHEAD", "files": {}},
+            "invalid baseline object",
+        ),
+        (
+            {
+                "baseline": "HEAD",
+                "files": {
+                    "test.txt": {
+                        "batch_source_commit": "HEAD\nHEAD",
+                        "presence_claims": [],
+                    }
+                },
+            },
+            "invalid batch_source_commit",
+        ),
+    ],
+)
+def test_validate_batch_metadata_structure_rejects_batch_unsafe_object_name(
+    temp_git_repo,
+    metadata,
+    message,
+):
+    """Corrupt object names must not inject requests into the batch protocol."""
+    with pytest.raises(BatchMetadataError, match=message):
+        validate_batch_metadata_structure(metadata, "test-batch")
+
+
 def test_load_and_validate_batch_metadata_success(temp_git_repo):
     """Loading and validating batch metadata succeeds for valid batch."""
     create_batch("test-batch", "Test note")
@@ -473,3 +505,34 @@ def test_validate_batch_metadata_structure_valid_structure(temp_git_repo):
 
     # Should not raise
     validate_batch_metadata_structure(metadata, "test-batch")
+
+
+def test_validate_batch_metadata_structure_bulk_checks_objects(
+    temp_git_repo,
+    monkeypatch,
+):
+    """Metadata validation should check every source through one Git process."""
+    commit = run_git_command(["rev-parse", "HEAD"]).stdout.strip()
+    metadata = {
+        "baseline": commit,
+        "files": {
+            f"file-{index}.txt": {
+                "batch_source_commit": commit,
+                "presence_claims": [],
+            }
+            for index in range(16)
+        },
+    }
+    original_run = git_command_module.run_command
+    cat_file_commands = []
+
+    def counting_run(arguments, *args, **kwargs):
+        if arguments[:2] == ["git", "cat-file"]:
+            cat_file_commands.append(tuple(arguments[1:]))
+        return original_run(arguments, *args, **kwargs)
+
+    monkeypatch.setattr(git_command_module, "run_command", counting_run)
+
+    validate_batch_metadata_structure(metadata, "test-batch")
+
+    assert cat_file_commands == [("cat-file", "--batch-check")]

--- a/tests/commands/test_file_scoped_operations.py
+++ b/tests/commands/test_file_scoped_operations.py
@@ -26,6 +26,7 @@ import pytest
 import git_stage_batch.commands.file_scope.include_file as include_file_module
 import git_stage_batch.commands.file_scope.multi_file_actions as multi_file_actions
 import git_stage_batch.data.live_diff as live_diff
+import git_stage_batch.utils.git_command as git_command_module
 
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.commands.again import command_again
@@ -997,6 +998,7 @@ class TestShowFileFlag:
 
         assert len(calls) == expected_live_diff_count
 
+
 class TestIncludeToBatchWithFile:
     """Test include --to BATCH with --file flag."""
 
@@ -1293,6 +1295,44 @@ class TestMultiFileBatchDisplay:
         assert "alpha.txt" in captured.out
         assert "beta.txt" in captured.out
         assert "gamma.txt" in captured.out
+
+    def test_show_from_multi_file_list_batches_blob_subprocesses(
+        self,
+        multi_file_repo,
+        capsys,
+        monkeypatch,
+    ):
+        """Batch file lists should use a fixed set of bulk Git calls."""
+        command_start()
+        capsys.readouterr()
+        command_include_to_batch("bulk", file="alpha.txt")
+        command_include_to_batch("bulk", file="beta.txt")
+        command_include_to_batch("bulk", file="gamma.txt")
+        capsys.readouterr()
+        original_run = git_command_module.run_command
+        original_stream = git_command_module.stream_command
+        cat_file_commands = []
+
+        def counting_run(arguments, *args, **kwargs):
+            if arguments[:2] == ["git", "cat-file"]:
+                cat_file_commands.append(tuple(arguments[1:]))
+            return original_run(arguments, *args, **kwargs)
+
+        def counting_stream(arguments, *args, **kwargs):
+            if arguments[:2] == ["git", "cat-file"]:
+                cat_file_commands.append(tuple(arguments[1:]))
+            yield from original_stream(arguments, *args, **kwargs)
+
+        monkeypatch.setattr(git_command_module, "run_command", counting_run)
+        monkeypatch.setattr(git_command_module, "stream_command", counting_stream)
+
+        command_show_from_batch("bulk")
+
+        assert cat_file_commands == [
+            ("cat-file", "--batch-check"),
+            ("cat-file", "--batch-check"),
+            ("cat-file", "--batch"),
+        ]
 
     def test_show_from_multi_file_open_command_uses_page_review(self, multi_file_repo, capsys):
         """Matched-file open commands should route to the page-aware batch review."""

--- a/tests/commands/test_show_from.py
+++ b/tests/commands/test_show_from.py
@@ -12,7 +12,6 @@ import git_stage_batch.batch.ownership.display_lines as display_module
 import git_stage_batch.batch.file_display as file_display
 import git_stage_batch.batch.file_mergeability as file_mergeability
 import git_stage_batch.data.selected_change.paths as selected_change_paths
-import git_stage_batch.commands.show_from as show_from_module
 import git_stage_batch.commands.batch_source.file_list_action as file_list_action
 
 import subprocess
@@ -24,6 +23,8 @@ from git_stage_batch.commands.show_from import command_show_from_batch
 from git_stage_batch.core.line_selection import LineRanges
 from git_stage_batch.data.session import initialize_abort_state
 from git_stage_batch.exceptions import CommandError
+from git_stage_batch.exceptions import RepositoryDataInvalid
+from git_stage_batch.utils.git_object_io import GitObjectInfo
 from git_stage_batch.utils.paths import ensure_state_directory_exists
 from tests.batch.ownership.metadata_helpers import reject_materialized_ownership_metadata
 
@@ -445,27 +446,20 @@ class TestCommandShowFromBatch:
         command_include_to_batch("multi-file-batch", quiet=True, file="file2.txt")
         capsys.readouterr()
 
-        original_render = file_display.render_batch_file_display
+        original_build = file_list_action.build_batch_file_display_from_inputs
         rendered_files = []
         probe_flags = []
 
-        def counting_render(batch_name, file_path, metadata=None, *, probe_mergeability=True):
-            rendered_files.append(file_path)
-            probe_flags.append(probe_mergeability)
-            return original_render(
-                batch_name,
-                file_path,
-                metadata=metadata,
-                probe_mergeability=probe_mergeability,
-            )
+        def counting_build(**kwargs):
+            rendered_files.append(kwargs["file_path"])
+            probe_flags.append(kwargs["probe_mergeability"])
+            return original_build(**kwargs)
 
-        monkeypatch.setattr(file_list_action, "render_batch_file_display", counting_render)
-        if hasattr(show_from_module, "render_batch_file_display"):
-            monkeypatch.setattr(
-                show_from_module,
-                "render_batch_file_display",
-                counting_render,
-            )
+        monkeypatch.setattr(
+            file_list_action,
+            "build_batch_file_display_from_inputs",
+            counting_build,
+        )
 
         command_show_from_batch("multi-file-batch")
 
@@ -473,6 +467,150 @@ class TestCommandShowFromBatch:
         assert probe_flags == [False, False]
         captured = capsys.readouterr()
         assert "── matched files" in captured.out
+
+    def test_show_from_multi_file_list_supports_newline_path(
+        self,
+        temp_git_repo,
+        capsys,
+    ):
+        """Bulk source reads should retain the argv-safe unusual-path fallback."""
+        unusual_path = "unusual\npath.txt"
+        (temp_git_repo / unusual_path).write_text("before unusual\n")
+        (temp_git_repo / "normal.txt").write_text("before normal\n")
+        subprocess.run(
+            ["git", "add", "--", unusual_path, "normal.txt"],
+            cwd=temp_git_repo,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add unusual paths"],
+            cwd=temp_git_repo,
+            check=True,
+            capture_output=True,
+        )
+        (temp_git_repo / unusual_path).write_text("after unusual\n")
+        (temp_git_repo / "normal.txt").write_text("after normal\n")
+
+        command_start(quiet=True)
+        command_include_to_batch(
+            "unusual-paths",
+            quiet=True,
+            file=unusual_path,
+            auto_advance=False,
+        )
+        command_include_to_batch(
+            "unusual-paths",
+            quiet=True,
+            file="normal.txt",
+            auto_advance=False,
+        )
+        capsys.readouterr()
+
+        command_show_from_batch("unusual-paths")
+
+        output = capsys.readouterr().out
+        assert "Matched: 2 files" in output
+        assert unusual_path in output
+        assert "normal.txt" in output
+
+    def test_show_from_multi_file_list_rejects_non_blob_source(
+        self,
+        monkeypatch,
+    ):
+        """Malformed source entries must not disappear from the file list."""
+        source_commit = "a" * 40
+        source_name = f"{source_commit}:directory"
+        monkeypatch.setattr(
+            file_list_action,
+            "resolve_git_objects",
+            lambda _names: {
+                source_name: GitObjectInfo("b" * 40, "tree", 0),
+            },
+        )
+
+        with pytest.raises(RepositoryDataInvalid, match="tree, not a blob"):
+            file_list_action.show_batch_source_file_list(
+                batch_name="malformed",
+                files={
+                    "directory": {
+                        "batch_source_commit": source_commit,
+                        "presence_claims": [],
+                    },
+                    "other": {
+                        "file_type": "mode",
+                        "old_mode": "100644",
+                        "new_mode": "100755",
+                    },
+                },
+                selectable=False,
+                command_source_args="--from malformed",
+            )
+
+    @pytest.mark.parametrize("ownership_kind", ["deletion", "reference"])
+    @pytest.mark.parametrize(
+        ("bad_object_info", "message"),
+        [
+            (None, "is missing"),
+            (GitObjectInfo("c" * 40, "tree", 0), "tree, not a blob"),
+        ],
+    )
+    def test_show_from_multi_file_list_rejects_invalid_ownership_blob(
+        self,
+        monkeypatch,
+        ownership_kind,
+        bad_object_info,
+        message,
+    ):
+        """Bulk ownership reads should report malformed object references."""
+        source_commit = "a" * 40
+        source_name = f"{source_commit}:file.txt"
+        bad_object_id = "b" * 40
+        file_meta = {
+            "batch_source_commit": source_commit,
+            "presence_claims": [],
+        }
+        if ownership_kind == "deletion":
+            file_meta["deletions"] = [
+                {"after_source_line": None, "blob": bad_object_id}
+            ]
+        else:
+            file_meta["presence_claims"] = [
+                {
+                    "source_lines": ["1"],
+                    "baseline_references": {
+                        "1": {"after_line": 1, "after_blob": bad_object_id}
+                    },
+                }
+            ]
+
+        resolved = {
+            source_name: GitObjectInfo("d" * 40, "blob", 0),
+        }
+        if bad_object_info is not None:
+            resolved[bad_object_id] = bad_object_info
+        monkeypatch.setattr(
+            file_list_action,
+            "resolve_git_objects",
+            lambda _names: resolved,
+        )
+
+        with pytest.raises(
+            RepositoryDataInvalid,
+            match=rf"file\.txt.*{message}",
+        ):
+            file_list_action.show_batch_source_file_list(
+                batch_name="malformed",
+                files={
+                    "file.txt": file_meta,
+                    "other": {
+                        "file_type": "mode",
+                        "old_mode": "100644",
+                        "new_mode": "100755",
+                    },
+                },
+                selectable=False,
+                command_source_args="--from malformed",
+            )
 
     def test_non_selectable_multi_file_batch_preview_preserves_selection(self, temp_git_repo, capsys):
         """A non-selectable multi-file batch preview should not clear selected state."""

--- a/tests/commands/test_validate.py
+++ b/tests/commands/test_validate.py
@@ -6,6 +6,7 @@ import json
 import subprocess
 
 import pytest
+import git_stage_batch.utils.git_command as git_command_module
 
 from git_stage_batch.commands.validate import command_validate_batches
 from git_stage_batch.commands.new import command_new_batch
@@ -24,6 +25,62 @@ def temp_git_repo(tmp_path, monkeypatch):
     subprocess.run(["git", "add", "README"], check=True)
     subprocess.run(["git", "commit", "-m", "Initial"], check=True, capture_output=True)
     return tmp_path
+
+
+def _store_git_blob(content: bytes) -> str:
+    return subprocess.run(
+        ["git", "hash-object", "-w", "--stdin"],
+        input=content,
+        check=True,
+        capture_output=True,
+    ).stdout.decode("ascii").strip()
+
+
+def _store_git_tree_entry(
+    *,
+    mode: str,
+    object_type: str,
+    object_id: str,
+    path: str,
+) -> str:
+    return subprocess.run(
+        ["git", "mktree"],
+        input=f"{mode} {object_type} {object_id}\t{path}\n",
+        text=True,
+        check=True,
+        capture_output=True,
+    ).stdout.strip()
+
+
+def _replace_batch_state_entry(
+    batch_name: str,
+    *,
+    mode: str,
+    object_type: str,
+    object_id: str,
+    path: str = "batch.json",
+) -> None:
+    tree = _store_git_tree_entry(
+        mode=mode,
+        object_type=object_type,
+        object_id=object_id,
+        path=path,
+    )
+    commit = subprocess.run(
+        ["git", "commit-tree", tree, "-m", "Malformed test batch state"],
+        text=True,
+        check=True,
+        capture_output=True,
+    ).stdout.strip()
+    subprocess.run(
+        [
+            "git",
+            "update-ref",
+            f"refs/git-stage-batch/state/{batch_name}",
+            commit,
+        ],
+        check=True,
+    )
 
 
 def test_validate_reports_current_metadata_without_mutation(temp_git_repo, capsys):
@@ -87,3 +144,164 @@ def test_validate_reports_invalid_orphaned_legacy_name(temp_git_repo, capsys):
     report = json.loads(capsys.readouterr().out)["batches"][0]
     assert report["status"] == "error"
     assert "Git ref naming rules" in report["errors"][0]
+
+
+def test_validate_rejects_non_blob_state_with_compatibility_residue(
+    temp_git_repo,
+    capsys,
+):
+    """A compatibility file must not mask malformed authoritative state."""
+    command_new_batch("malformed")
+    state_payload = subprocess.run(
+        [
+            "git",
+            "show",
+            "refs/git-stage-batch/state/malformed:batch.json",
+        ],
+        text=True,
+        check=True,
+        capture_output=True,
+    ).stdout
+    metadata_path = get_batch_metadata_file_path("malformed")
+    metadata_path.parent.mkdir(parents=True, exist_ok=True)
+    write_text_file_contents(metadata_path, state_payload)
+
+    nested_blob = _store_git_blob(b"not metadata\n")
+    nested_tree = _store_git_tree_entry(
+        mode="100644",
+        object_type="blob",
+        object_id=nested_blob,
+        path="value",
+    )
+    _replace_batch_state_entry(
+        "malformed",
+        mode="040000",
+        object_type="tree",
+        object_id=nested_tree,
+    )
+    capsys.readouterr()
+
+    with pytest.raises(CommandError):
+        command_validate_batches(porcelain=True)
+
+    report = json.loads(capsys.readouterr().out)["batches"][0]
+    assert report["source"] == "state-ref"
+    assert report["status"] == "error"
+    assert report["residue"]["class"] == "unverifiable_residue"
+    assert "tree, not a blob" in report["errors"][0]
+
+
+def test_validate_rejects_missing_state_path_with_compatibility_residue(
+    temp_git_repo,
+    capsys,
+):
+    """A compatibility file must not mask a missing authoritative payload."""
+    command_new_batch("missing-state")
+    state_payload = subprocess.run(
+        [
+            "git",
+            "show",
+            "refs/git-stage-batch/state/missing-state:batch.json",
+        ],
+        text=True,
+        check=True,
+        capture_output=True,
+    ).stdout
+    metadata_path = get_batch_metadata_file_path("missing-state")
+    metadata_path.parent.mkdir(parents=True, exist_ok=True)
+    write_text_file_contents(metadata_path, state_payload)
+
+    other_blob = _store_git_blob(b"not the authoritative payload\n")
+    _replace_batch_state_entry(
+        "missing-state",
+        mode="100644",
+        object_type="blob",
+        object_id=other_blob,
+        path="other.json",
+    )
+    capsys.readouterr()
+
+    with pytest.raises(CommandError):
+        command_validate_batches(porcelain=True)
+
+    report = json.loads(capsys.readouterr().out)["batches"][0]
+    assert report["source"] == "state-ref"
+    assert report["status"] == "error"
+    assert report["residue"]["class"] == "unverifiable_residue"
+    assert "missing path 'batch.json'" in report["errors"][0]
+
+
+def test_validate_reports_non_utf8_state_payload(temp_git_repo, capsys):
+    """Invalid state bytes should become a diagnostic instead of escaping."""
+    command_new_batch("invalid-bytes")
+    state_payload = subprocess.run(
+        [
+            "git",
+            "show",
+            "refs/git-stage-batch/state/invalid-bytes:batch.json",
+        ],
+        text=True,
+        check=True,
+        capture_output=True,
+    ).stdout
+    metadata_path = get_batch_metadata_file_path("invalid-bytes")
+    metadata_path.parent.mkdir(parents=True, exist_ok=True)
+    write_text_file_contents(metadata_path, state_payload)
+    invalid_blob = _store_git_blob(b"\x80")
+    _replace_batch_state_entry(
+        "invalid-bytes",
+        mode="100644",
+        object_type="blob",
+        object_id=invalid_blob,
+    )
+    capsys.readouterr()
+
+    with pytest.raises(CommandError):
+        command_validate_batches(porcelain=True)
+
+    report = json.loads(capsys.readouterr().out)["batches"][0]
+    assert report["source"] == "state-ref"
+    assert report["status"] == "error"
+    assert report["residue"]["class"] == "unverifiable_residue"
+    assert "not valid JSON" in report["errors"][0]
+
+
+def test_validate_batches_bounds_git_object_subprocesses(
+    temp_git_repo,
+    capsys,
+    monkeypatch,
+):
+    """Validation should inspect many batches through fixed bulk Git calls."""
+    for index in range(16):
+        command_new_batch(f"batch-{index}")
+    capsys.readouterr()
+
+    original_run = git_command_module.run_command
+    original_stream = git_command_module.stream_command
+    cat_file_commands = []
+    check_ref_commands = []
+
+    def counting_run(arguments, *args, **kwargs):
+        if arguments[:2] == ["git", "cat-file"]:
+            cat_file_commands.append(tuple(arguments[1:]))
+        if arguments[:2] == ["git", "check-ref-format"]:
+            check_ref_commands.append(tuple(arguments[1:]))
+        return original_run(arguments, *args, **kwargs)
+
+    def counting_stream(arguments, *args, **kwargs):
+        if arguments[:2] == ["git", "cat-file"]:
+            cat_file_commands.append(tuple(arguments[1:]))
+        yield from original_stream(arguments, *args, **kwargs)
+
+    monkeypatch.setattr(git_command_module, "run_command", counting_run)
+    monkeypatch.setattr(git_command_module, "stream_command", counting_stream)
+
+    command_validate_batches(porcelain=True)
+
+    assert len(json.loads(capsys.readouterr().out)["batches"]) == 16
+    assert check_ref_commands == []
+    assert cat_file_commands == [
+        ("cat-file", "--batch-check"),
+        ("cat-file", "--batch"),
+        ("cat-file", "--batch-check"),
+    ]


### PR DESCRIPTION
Building on the argv-safe fallback in #282, batch file lists, metadata checks, and validation still resolve and read stored objects repeatedly as file or batch count grows.

Those callers need retained blob ownership and caller-supplied display inputs so ordinary references can share Git batch streams without weakening unusual-name handling, object-type validation, or authoritative-state diagnostics.

This pull request adds a context-managed retained-blob acquisition helper, lets file displays consume caller-owned metadata and content, builds matched batch file lists from bulk reads, resolves metadata references in one batch check, trusts names already established by ref discovery, and inspects validate state through bulk ref and blob reads.

Coverage verifies display parity, unusual paths, missing and non-blob ownership inputs, product validation for trusted names, malformed authoritative state, compatibility residue, buffer cleanup, and Git subprocess counts that remain bounded as file and batch counts increase.