### PR TITLE
batch: Stream derived replacement runs

### DIFF
--- a/src/git_stage_batch/batch/line_matching/comparison.py
+++ b/src/git_stage_batch/batch/line_matching/comparison.py
@@ -153,7 +153,22 @@ def derive_semantic_change_runs(
     Returns:
         List of semantic change runs describing the delta
     """
-    runs: list[SemanticChangeRun] = []
+    return list(
+        stream_semantic_change_runs(
+            source_lines,
+            target_lines,
+            spool_dir=spool_dir,
+        )
+    )
+
+
+def stream_semantic_change_runs(
+    source_lines: Sequence[bytes],
+    target_lines: Sequence[bytes],
+    *,
+    spool_dir: str | Path | None = None,
+) -> Iterator[SemanticChangeRun]:
+    """Yield semantic change runs without retaining one object per run."""
     previous_source = 0
     previous_target = 0
 
@@ -164,42 +179,45 @@ def derive_semantic_change_runs(
     )
     sentinel_pair = ((len(source_lines) + 1, len(target_lines) + 1),)
 
-    for source_line, target_line in chain(matched_pairs, sentinel_pair):
-        source_gap_start = previous_source + 1
-        source_gap_end = source_line - 1
-        target_gap_start = previous_target + 1
-        target_gap_end = target_line - 1
-        has_source_gap = source_gap_start <= source_gap_end
-        has_target_gap = target_gap_start <= target_gap_end
-        target_anchor = previous_target if previous_target != 0 else None
+    try:
+        for source_line, target_line in chain(matched_pairs, sentinel_pair):
+            source_gap_start = previous_source + 1
+            source_gap_end = source_line - 1
+            target_gap_start = previous_target + 1
+            target_gap_end = target_line - 1
+            has_source_gap = source_gap_start <= source_gap_end
+            has_target_gap = target_gap_start <= target_gap_end
+            target_anchor = previous_target if previous_target != 0 else None
 
-        if has_source_gap and has_target_gap:
-            runs.append(SemanticChangeRun(
-                kind=SemanticChangeKind.REPLACEMENT,
-                source_start=source_gap_start,
-                source_end=source_gap_end,
-                target_start=target_gap_start,
-                target_end=target_gap_end,
-                target_anchor=target_anchor,
-            ))
-        elif has_source_gap:
-            runs.append(SemanticChangeRun(
-                kind=SemanticChangeKind.DELETION,
-                source_start=source_gap_start,
-                source_end=source_gap_end,
-                target_anchor=target_anchor,
-            ))
-        elif has_target_gap:
-            runs.append(SemanticChangeRun(
-                kind=SemanticChangeKind.PRESENCE,
-                target_start=target_gap_start,
-                target_end=target_gap_end,
-            ))
+            if has_source_gap and has_target_gap:
+                yield SemanticChangeRun(
+                    kind=SemanticChangeKind.REPLACEMENT,
+                    source_start=source_gap_start,
+                    source_end=source_gap_end,
+                    target_start=target_gap_start,
+                    target_end=target_gap_end,
+                    target_anchor=target_anchor,
+                )
+            elif has_source_gap:
+                yield SemanticChangeRun(
+                    kind=SemanticChangeKind.DELETION,
+                    source_start=source_gap_start,
+                    source_end=source_gap_end,
+                    target_anchor=target_anchor,
+                )
+            elif has_target_gap:
+                yield SemanticChangeRun(
+                    kind=SemanticChangeKind.PRESENCE,
+                    target_start=target_gap_start,
+                    target_end=target_gap_end,
+                )
 
-        previous_source = source_line
-        previous_target = target_line
-
-    return runs
+            previous_source = source_line
+            previous_target = target_line
+    finally:
+        close = getattr(matched_pairs, "close", None)
+        if close is not None:
+            close()
 
 
 def derive_display_id_run_sets_from_lines(

--- a/src/git_stage_batch/batch/ownership/replacement_line_runs.py
+++ b/src/git_stage_batch/batch/ownership/replacement_line_runs.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
 
-from ..line_matching.comparison import SemanticChangeKind, derive_semantic_change_runs
+from ..line_matching.comparison import (
+    SemanticChangeKind,
+    stream_semantic_change_runs,
+)
 
 @dataclass(frozen=True, slots=True)
 class ReplacementLineRun:
@@ -37,22 +40,40 @@ def derive_replacement_line_runs_from_lines(
     new_file_lines: Sequence[bytes],
 ) -> list[ReplacementLineRun]:
     """Derive replacement line runs from old/new byte-line sequences."""
-    replacement_runs: list[ReplacementLineRun] = []
-    semantic_runs = derive_semantic_change_runs(old_file_lines, new_file_lines)
-    for run in semantic_runs:
-        if (
-            run.kind == SemanticChangeKind.REPLACEMENT
-            and run.source_start is not None
-            and run.source_end is not None
-            and run.target_start is not None
-            and run.target_end is not None
-        ):
-            replacement_runs.append(
-                ReplacementLineRun(
+    return list(
+        stream_replacement_line_runs_from_lines(
+            old_file_lines=old_file_lines,
+            new_file_lines=new_file_lines,
+        )
+    )
+
+
+def stream_replacement_line_runs_from_lines(
+    *,
+    old_file_lines: Sequence[bytes],
+    new_file_lines: Sequence[bytes],
+) -> Iterator[ReplacementLineRun]:
+    """Yield replacement runs without retaining a file-sized Python list."""
+    semantic_runs = stream_semantic_change_runs(
+        old_file_lines,
+        new_file_lines,
+    )
+    try:
+        for run in semantic_runs:
+            if (
+                run.kind == SemanticChangeKind.REPLACEMENT
+                and run.source_start is not None
+                and run.source_end is not None
+                and run.target_start is not None
+                and run.target_end is not None
+            ):
+                yield ReplacementLineRun(
                     old_start=run.source_start,
                     old_end=run.source_end,
                     new_start=run.target_start,
                     new_end=run.target_end,
                 )
-            )
-    return replacement_runs
+    finally:
+        close = getattr(semantic_runs, "close", None)
+        if close is not None:
+            close()

--- a/tests/batch/line_matching/test_comparison.py
+++ b/tests/batch/line_matching/test_comparison.py
@@ -2,11 +2,13 @@
 
 import pytest
 
+import git_stage_batch.batch.line_matching.comparison as comparison_module
 from git_stage_batch.batch.line_matching.comparison import (
     SemanticChangeKind,
     SemanticChangeRun,
     derive_replacement_display_id_run_sets_from_lines,
     derive_semantic_change_runs,
+    stream_semantic_change_runs,
 )
 from git_stage_batch.core.models import HunkHeader, LineEntry, LineLevelChange
 
@@ -23,6 +25,42 @@ def test_derive_semantic_change_runs_accepts_non_list_sequences(line_sequence):
     assert (runs[0].source_start, runs[0].source_end) == (2, 2)
     assert (runs[0].target_start, runs[0].target_end) == (2, 2)
     assert runs[0].target_anchor == 1
+
+
+def test_stream_semantic_change_runs_closes_matching_pairs(monkeypatch):
+    """Closing streamed changes must release their matcher resources."""
+
+    class ClosablePairs:
+        def __init__(self):
+            self._pairs = iter(((2, 2),))
+            self.closed = False
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            return next(self._pairs)
+
+        def close(self):
+            self.closed = True
+
+    matched_pairs = ClosablePairs()
+    monkeypatch.setattr(
+        comparison_module,
+        "_trusted_matched_pairs",
+        lambda *_args, **_kwargs: matched_pairs,
+    )
+    runs = stream_semantic_change_runs(
+        [b"old\n", b"tail\n"],
+        [b"new\n", b"tail\n"],
+    )
+
+    assert next(runs).kind == SemanticChangeKind.REPLACEMENT
+    assert matched_pairs.closed is False
+
+    runs.close()
+
+    assert matched_pairs.closed is True
 
 
 def test_derive_semantic_change_runs_uses_range_records():

--- a/tests/batch/ownership/test_replacement_line_runs.py
+++ b/tests/batch/ownership/test_replacement_line_runs.py
@@ -1,0 +1,55 @@
+"""Tests for streamed replacement-line run derivation."""
+
+from git_stage_batch.batch.line_matching.comparison import (
+    SemanticChangeKind,
+    SemanticChangeRun,
+)
+import git_stage_batch.batch.ownership.replacement_line_runs as runs_module
+from git_stage_batch.batch.ownership.replacement_line_runs import (
+    ReplacementLineRun,
+    stream_replacement_line_runs_from_lines,
+)
+
+
+def test_stream_replacement_line_runs_closes_semantic_runs(monkeypatch):
+    """Closing replacement runs must propagate to streamed comparison state."""
+
+    class ClosableSemanticRuns:
+        def __init__(self):
+            self._runs = iter((
+                SemanticChangeRun(
+                    kind=SemanticChangeKind.REPLACEMENT,
+                    source_start=1,
+                    source_end=1,
+                    target_start=1,
+                    target_end=1,
+                ),
+            ))
+            self.closed = False
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            return next(self._runs)
+
+        def close(self):
+            self.closed = True
+
+    semantic_runs = ClosableSemanticRuns()
+    monkeypatch.setattr(
+        runs_module,
+        "stream_semantic_change_runs",
+        lambda *_args, **_kwargs: semantic_runs,
+    )
+    replacement_runs = stream_replacement_line_runs_from_lines(
+        old_file_lines=[b"old\n"],
+        new_file_lines=[b"new\n"],
+    )
+
+    assert next(replacement_runs) == ReplacementLineRun(1, 1, 1, 1)
+    assert semantic_runs.closed is False
+
+    replacement_runs.close()
+
+    assert semantic_runs.closed is True


### PR DESCRIPTION
Semantic and replacement comparison currently returns complete lists of
change-run objects while the line matcher keeps file content in mapped
storage.

Large files with many alternating changes therefore retain one Python object
per discovered run even when ownership projection consumes the runs only
once and in order.

This PR adds streaming forms in the line-matching and ownership layers while
keeping the list-returning compatibility helpers. Closing either stream also
closes its nested matching resources when a consumer stops early.

Focused resource-lifetime coverage pins both streaming boundaries without
introducing line-proportional Python heap storage.