### PR TITLE
batch: Preserve line identity during source refresh

### DIFF
--- a/src/git_stage_batch/batch/source/selected_line_refresh.py
+++ b/src/git_stage_batch/batch/source/selected_line_refresh.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from dataclasses import replace
 
 from ...core.models import LineEntry
 from ..line_matching.lineage import BatchSourceLineage
@@ -80,20 +81,7 @@ def refresh_selected_lines_against_new_source(selected_lines: list) -> list:
         else:
             source_line = None
 
-        reannotated_lines.append(LineEntry(
-            id=line.id,
-            kind=line.kind,
-            old_line_number=line.old_line_number,
-            new_line_number=line.new_line_number,
-            text_bytes=line.text_bytes,
-            source_line=source_line,
-            baseline_reference_after_line=line.baseline_reference_after_line,
-            baseline_reference_after_text_bytes=line.baseline_reference_after_text_bytes,
-            has_baseline_reference_after=line.has_baseline_reference_after,
-            baseline_reference_before_line=line.baseline_reference_before_line,
-            baseline_reference_before_text_bytes=line.baseline_reference_before_text_bytes,
-            has_baseline_reference_before=line.has_baseline_reference_before,
-        ))
+        reannotated_lines.append(replace(line, source_line=source_line))
 
     return reannotated_lines
 
@@ -138,20 +126,7 @@ def refresh_selected_lines_against_source_lines(
             else:
                 source_line = None
 
-            reannotated_lines.append(LineEntry(
-                id=line.id,
-                kind=line.kind,
-                old_line_number=line.old_line_number,
-                new_line_number=line.new_line_number,
-                text_bytes=line.text_bytes,
-                source_line=source_line,
-                baseline_reference_after_line=line.baseline_reference_after_line,
-                baseline_reference_after_text_bytes=line.baseline_reference_after_text_bytes,
-                has_baseline_reference_after=line.has_baseline_reference_after,
-                baseline_reference_before_line=line.baseline_reference_before_line,
-                baseline_reference_before_text_bytes=line.baseline_reference_before_text_bytes,
-                has_baseline_reference_before=line.has_baseline_reference_before,
-            ))
+            reannotated_lines.append(replace(line, source_line=source_line))
 
         return reannotated_lines
     finally:

--- a/tests/batch/source/test_refresh.py
+++ b/tests/batch/source/test_refresh.py
@@ -7,6 +7,7 @@ from git_stage_batch.batch.source.refresh import (
     ensure_batch_source_current_for_selection,
 )
 from git_stage_batch.batch.source.selected_line_refresh import (
+    refresh_selected_lines_against_new_source,
     refresh_selected_lines_against_source_lines,
 )
 from git_stage_batch.batch.ownership.model import BatchOwnership
@@ -102,6 +103,23 @@ def test_ensure_batch_source_current_first_time_stale():
     assert result.source_was_advanced is False
 
 
+def test_source_refresh_preserves_missing_final_newline():
+    """Coordinate refresh must not change selected-line byte identity."""
+    selected_lines = [
+        LineEntry(
+            id=1,
+            kind="+",
+            old_line_number=None,
+            new_line_number=1,
+            text_bytes=b"unterminated",
+            source_line=None,
+            has_trailing_newline=False,
+        ),
+    ]
+
+    refreshed_new = refresh_selected_lines_against_new_source(selected_lines)
+
+    assert refreshed_new[0].has_trailing_newline is False
 def test_refresh_selected_lines_uses_synthesized_working_line_provenance():
     """Repeated working lines should use known synthesis identity."""
     ownership = BatchOwnership.from_presence_lines(["1,4"], [])

--- a/tests/batch/source/test_refresh.py
+++ b/tests/batch/source/test_refresh.py
@@ -118,8 +118,14 @@ def test_source_refresh_preserves_missing_final_newline():
     ]
 
     refreshed_new = refresh_selected_lines_against_new_source(selected_lines)
+    refreshed_mapped = refresh_selected_lines_against_source_lines(
+        selected_lines,
+        source_lines=[b"unterminated"],
+        working_lines=[b"unterminated"],
+    )
 
     assert refreshed_new[0].has_trailing_newline is False
+    assert refreshed_mapped[0].has_trailing_newline is False
 def test_refresh_selected_lines_uses_synthesized_working_line_provenance():
     """Repeated working lines should use known synthesis identity."""
     ownership = BatchOwnership.from_presence_lines(["1,4"], [])


### PR DESCRIPTION
Selected-line source refresh currently rebuilds `LineEntry` objects while it updates their source coordinates.

A field-by-field reconstruction can lose byte-identity state such as a missing final newline, and it becomes stale whenever the model gains fields.

This PR replaces only the source coordinate through dataclass replacement so every other attribute remains owned by the existing entry.

Focused direct and mapped refresh tests pin unterminated input, keeping exact selected-line bytes intact without adding line-proportional Python heap storage.