### PR TITLE
batch: Place additions when surrounding lines repeat

### DIFF
--- a/src/git_stage_batch/batch/realized_file_content.py
+++ b/src/git_stage_batch/batch/realized_file_content.py
@@ -12,6 +12,8 @@ from ..editor.line_endings import (
     restore_line_endings_in_chunks,
 )
 from ..core.text_lines import normalize_line_sequence_endings
+from ..exceptions import MergeError as _MergeError
+from .merge import baseline_edits as _baseline_edits
 from .merge.presence_constraints import satisfy_constraints
 from .realization.entry_storage import realized_entry_content_chunks
 
@@ -50,13 +52,26 @@ def _stream_realized_content_chunks_from_lines(
     presence_line_set = resolved.presence_line_set
     deletion_claims = resolved.deletion_claims
 
-    realized_entries = satisfy_constraints(
-        batch_source_lines,
-        base_lines,
-        presence_line_set,
-        deletion_claims,
-        strict=False,
-    )
+    try:
+        realized_entries = satisfy_constraints(
+            batch_source_lines,
+            base_lines,
+            presence_line_set,
+            deletion_claims,
+            strict=False,
+        )
+    except _MergeError:
+        baseline_chunks = _baseline_edits.try_apply_baseline_replacement_units(
+            batch_source_lines,
+            base_lines,
+            ownership,
+            presence_line_set,
+            deletion_claims,
+        )
+        if baseline_chunks is None:
+            raise
+        yield from baseline_chunks
+        return
 
     try:
         yield from realized_entry_content_chunks(realized_entries)

--- a/src/git_stage_batch/commands/selection/include_line_selection.py
+++ b/src/git_stage_batch/commands/selection/include_line_selection.py
@@ -45,6 +45,7 @@ from ...exceptions import MergeError, exit_with_error
 from ...i18n import _
 from ...staging.index_update import update_index_with_blob_buffer
 from ...utils.file_io import write_file_bytes
+from ...utils.git_index import git_write_tree
 from ...utils.paths import get_session_batch_sources_file_path
 from . import replacement_selection
 
@@ -456,7 +457,11 @@ def try_build_index_content_via_transient_batch(
     target_index_buffer: LineBuffer | None = None
 
     try:
-        create_batch(batch_name, "Transient include-line selection")
+        create_batch(
+            batch_name,
+            "Transient include-line selection",
+            baseline_commit=git_write_tree(),
+        )
         created_batch = True
 
         record_baseline_references_for_additions(

--- a/tests/batch/test_storage_duplication.py
+++ b/tests/batch/test_storage_duplication.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from git_stage_batch.batch.ownership.absence_claims import AbsenceClaim
 from git_stage_batch.batch.ownership.model import BatchOwnership
 from git_stage_batch.batch.ownership.references import BaselineReference
 from git_stage_batch.batch.realized_file_content import (
@@ -88,6 +89,8 @@ def test_build_realized_content_simple_insert():
 
     result = _build_realized_content_from_bytes(base_content, batch_source_content, ownership)
     assert result == b"A\nNEW\nB\n"
+
+
 def test_build_realized_content_uses_baseline_reference_for_ambiguous_insert():
     """Stored content honors a verified insertion boundary when context repeats."""
     base_content = b"top\n\nbottom\n"
@@ -124,6 +127,25 @@ def test_build_realized_content_uses_baseline_reference_for_ambiguous_insert():
     )
 
     assert result == b"top\nsave-a\nsave-b\n\nbottom\n"
+
+
+def test_build_realized_content_applies_deletion_when_source_matches_baseline():
+    """Baseline fallback must not bypass storage deletion constraints."""
+    content = b"first\nold value\n"
+    ownership = BatchOwnership(
+        [],
+        [
+            AbsenceClaim(
+                anchor_line=None,
+                content_lines=content.splitlines(keepends=True),
+                baseline_reference=BaselineReference(after_line=None),
+            )
+        ],
+    )
+
+    result = _build_realized_content_from_bytes(content, content, ownership)
+
+    assert result == b""
 
 
 def test_build_realized_content_from_lines_accepts_non_list_sequences(line_sequence):

--- a/tests/batch/test_storage_duplication.py
+++ b/tests/batch/test_storage_duplication.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from git_stage_batch.batch.ownership.model import BatchOwnership
+from git_stage_batch.batch.ownership.references import BaselineReference
 from git_stage_batch.batch.realized_file_content import (
     build_realized_buffer_from_lines,
 )
@@ -87,6 +88,42 @@ def test_build_realized_content_simple_insert():
 
     result = _build_realized_content_from_bytes(base_content, batch_source_content, ownership)
     assert result == b"A\nNEW\nB\n"
+def test_build_realized_content_uses_baseline_reference_for_ambiguous_insert():
+    """Stored content honors a verified insertion boundary when context repeats."""
+    base_content = b"top\n\nbottom\n"
+    batch_source_content = (
+        b"top\n"
+        b"import-a\n"
+        b"import-b\n"
+        b"import-c\n"
+        b"\n"
+        b"save-a\n"
+        b"save-b\n"
+        b"later-a\n"
+        b"\n"
+        b"bottom\n"
+    )
+    ownership = BatchOwnership.from_presence_lines(
+        ["6-7"],
+        baseline_references={
+            line: BaselineReference(
+                after_line=1,
+                after_content=b"top",
+                before_line=2,
+                before_content=b"",
+                has_before_line=True,
+            )
+            for line in (6, 7)
+        },
+    )
+
+    result = _build_realized_content_from_bytes(
+        base_content,
+        batch_source_content,
+        ownership,
+    )
+
+    assert result == b"top\nsave-a\nsave-b\n\nbottom\n"
 
 
 def test_build_realized_content_from_lines_accepts_non_list_sequences(line_sequence):

--- a/tests/functional/test_include_line_transient_staging.py
+++ b/tests/functional/test_include_line_transient_staging.py
@@ -40,6 +40,35 @@ def _index_bytes(repo, path: str) -> bytes:
     return result.stdout
 
 
+def _prepare_ambiguous_middle_insertion(repo) -> None:
+    _commit_file(
+        repo,
+        "file.txt",
+        "top\n"
+        "\n"
+        "bottom\n",
+    )
+    (repo / "file.txt").write_text(
+        "top\n"
+        "import-a\n"
+        "import-b\n"
+        "import-c\n"
+        "\n"
+        "save-a\n"
+        "save-b\n"
+        "later-a\n"
+        "\n"
+        "bottom\n"
+    )
+
+    git_stage_batch("start", "--no-auto-advance")
+    git_stage_batch("show", "--file", "file.txt", "--page", "all")
+    git_stage_batch("include", "--line", "1-2", "--no-auto-advance")
+    git_stage_batch("show", "--file", "file.txt", "--page", "all")
+    git_stage_batch("include", "--line", "3", "--no-auto-advance")
+    git_stage_batch("show", "--file", "file.txt", "--page", "all")
+
+
 def test_include_line_transient_staging_first_replace_row(functional_repo):
     _commit_file(functional_repo, "file.txt", "a\nb\n")
     (functional_repo / "file.txt").write_text("A\nB\n")
@@ -88,6 +117,42 @@ def test_include_line_transient_staging_pure_addition(functional_repo):
     git_stage_batch("include", "--line", "1")
 
     assert _index_content(functional_repo, "file.txt") == "base\nfoo\n"
+
+
+def test_consecutive_line_includes_stage_ambiguous_middle_insertion(functional_repo):
+    _prepare_ambiguous_middle_insertion(functional_repo)
+
+    result = git_stage_batch(
+        "include",
+        "--line",
+        "5-6",
+        "--no-auto-advance",
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert _index_content(functional_repo, "file.txt") == (
+        "top\n"
+        "import-a\n"
+        "import-b\n"
+        "import-c\n"
+        "\n"
+        "save-a\n"
+        "save-b\n"
+        "bottom\n"
+    )
+    assert (functional_repo / "file.txt").read_text() == (
+        "top\n"
+        "import-a\n"
+        "import-b\n"
+        "import-c\n"
+        "\n"
+        "save-a\n"
+        "save-b\n"
+        "later-a\n"
+        "\n"
+        "bottom\n"
+    )
 
 
 def test_include_line_transient_staging_pure_addition_preserves_blank_anchor(functional_repo):


### PR DESCRIPTION
Batch realization matches unchanged lines between changed content and a saved
starting file. It also records candidate positions for selected additions.

Repeated or blank context can leave ordinary matching unable to choose a gap,
even when the recorded position still identifies the saved baseline exactly.

This PR adds a guarded recorded-position fallback after ordinary matching, pins
its ordering, and saves the staged snapshot used by transient include batches.

Transient includes can now place selected additions at their recorded gaps
without trusting unchecked coordinates or adding line-proportional heap state.