### PR TITLE
batch: Project insertion references onto saved baselines

### DIFF
--- a/src/git_stage_batch/batch/merge/baseline_reference_translation.py
+++ b/src/git_stage_batch/batch/merge/baseline_reference_translation.py
@@ -1,0 +1,142 @@
+"""Translate ownership references between saved baseline files."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from ...core.mapped_storage import (
+    MappedRecordVector,
+    sort_mapped_records,
+)
+from ...core.text_lines import (
+    as_acquirable_line_sequence,
+    normalize_line_sequence_endings,
+)
+from ..line_matching.line_mapping import LineMapping
+from ..line_matching.match import match_lines
+from ..ownership.model import BatchOwnership
+from ..ownership.references import BaselineReference
+from .baseline_reference_positions import (
+    baseline_reference_insertion_position,
+)
+
+
+def _reference_for_insertion(
+    target_lines: Sequence[bytes],
+    position: int,
+) -> BaselineReference:
+    """Return an exact two-sided reference for one target gap."""
+    after_line = position or None
+    before_line = position + 1 if position < len(target_lines) else None
+    return BaselineReference(
+        after_line=after_line,
+        after_content=(
+            bytes(target_lines[position - 1]) if position > 0 else None
+        ),
+        has_after_line=True,
+        before_line=before_line,
+        before_content=(
+            bytes(target_lines[position])
+            if position < len(target_lines)
+            else None
+        ),
+        has_before_line=True,
+    )
+
+
+def _translate_presence_references(
+    ownership: BatchOwnership,
+    source_lines: Sequence[bytes],
+    target_lines: Sequence[bytes],
+    mapping: LineMapping,
+) -> None:
+    reference_count = sum(
+        len(claim.baseline_references)
+        for claim in ownership.presence_claims
+    )
+    with (
+        MappedRecordVector(reference_count, "QQQ") as referenced_lines,
+        MappedRecordVector(reference_count, "QQ") as dropped_references,
+    ):
+        previous_source_position = -1
+        records_are_sorted = True
+        for claim_index, claim in enumerate(ownership.presence_claims):
+            for claimed_line, reference in claim.baseline_references.items():
+                source_position = baseline_reference_insertion_position(
+                    reference,
+                    source_lines,
+                )
+                if source_position is None:
+                    if baseline_reference_insertion_position(
+                        reference,
+                        target_lines,
+                    ) is None:
+                        dropped_references.append((
+                            claim_index,
+                            claimed_line,
+                        ))
+                    continue
+                if source_position < previous_source_position:
+                    records_are_sorted = False
+                referenced_lines.append((
+                    source_position,
+                    claim_index,
+                    claimed_line,
+                ))
+                previous_source_position = source_position
+
+        for claim_index, claimed_line in dropped_references:
+            ownership.presence_claims[
+                claim_index
+            ].baseline_references.pop(claimed_line, None)
+
+        if not records_are_sorted:
+            sort_mapped_records(referenced_lines)
+        mapped_pairs = mapping.mapped_line_pairs()
+        previous_pair: tuple[int, int] | None = None
+        next_pair = next(mapped_pairs, None)
+        for source_position, claim_index, claimed_line in referenced_lines:
+            while next_pair is not None and next_pair[0] <= source_position:
+                previous_pair = next_pair
+                next_pair = next(mapped_pairs, None)
+
+            target_position = (
+                previous_pair[1] if previous_pair is not None else 0
+            )
+            target_before_line = (
+                next_pair[1]
+                if next_pair is not None
+                else len(target_lines) + 1
+            )
+            claim = ownership.presence_claims[claim_index]
+            if target_before_line != target_position + 1:
+                claim.baseline_references.pop(claimed_line, None)
+                continue
+            claim.baseline_references[claimed_line] = _reference_for_insertion(
+                target_lines,
+                target_position,
+            )
+
+
+def translate_ownership_baseline_references(
+    ownership: BatchOwnership,
+    source_baseline_lines: Sequence[bytes],
+    target_baseline_lines: Sequence[bytes],
+) -> None:
+    """Rebase newly translated ownership references onto a batch baseline."""
+    normalized_source = normalize_line_sequence_endings(source_baseline_lines)
+    normalized_target = normalize_line_sequence_endings(target_baseline_lines)
+    source_sequence = as_acquirable_line_sequence(normalized_source)
+    target_sequence = as_acquirable_line_sequence(normalized_target)
+
+    with (
+        source_sequence.acquire_lines() as source_lines,
+        target_sequence.acquire_lines() as target_lines,
+        match_lines(source_lines, target_lines) as mapping,
+    ):
+        _translate_presence_references(
+            ownership,
+            source_lines,
+            target_lines,
+            mapping,
+        )

--- a/src/git_stage_batch/batch/ownership/insertion_references.py
+++ b/src/git_stage_batch/batch/ownership/insertion_references.py
@@ -1,0 +1,210 @@
+"""Attach persistent baseline references to selected insertion lines."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from ...core.mapped_storage import MappedRecordVector, sort_mapped_records
+from ...core.text_lines import normalize_line_sequence_endings
+from ..line_matching.match import match_lines
+from ..merge.baseline_reference_positions import (
+    baseline_reference_insertion_position,
+)
+from .references import BaselineReference
+
+
+def _record_diff_baseline_references_for_additions(line_changes) -> None:
+    """Attach insertion references from the old side of the displayed diff."""
+    last_old_line: int | None = None
+    last_old_text_bytes: bytes | None = None
+    index = 0
+
+    while index < len(line_changes.lines):
+        line = line_changes.lines[index]
+        if line.kind == "+":
+            next_old_line: int | None = None
+            next_old_text_bytes: bytes | None = None
+            scan_index = index + 1
+            while scan_index < len(line_changes.lines):
+                next_line = line_changes.lines[scan_index]
+                if (
+                    next_line.kind in {" ", "-"}
+                    and next_line.old_line_number is not None
+                ):
+                    next_old_line = next_line.old_line_number
+                    next_old_text_bytes = next_line.text_bytes
+                    break
+                scan_index += 1
+
+            while (
+                index < len(line_changes.lines)
+                and line_changes.lines[index].kind == "+"
+            ):
+                addition_line = line_changes.lines[index]
+                addition_line.baseline_reference_after_line = last_old_line
+                addition_line.baseline_reference_after_text_bytes = (
+                    last_old_text_bytes
+                )
+                addition_line.has_baseline_reference_after = True
+                addition_line.baseline_reference_before_line = next_old_line
+                addition_line.baseline_reference_before_text_bytes = (
+                    next_old_text_bytes
+                )
+                # A missing next old line is an explicit EOF boundary, not an
+                # unknown second side.
+                addition_line.has_baseline_reference_before = True
+                index += 1
+            continue
+
+        if line.kind in {" ", "-"} and line.old_line_number is not None:
+            last_old_line = line.old_line_number
+            last_old_text_bytes = line.text_bytes
+        index += 1
+
+
+def _clear_addition_baseline_reference(addition_line) -> None:
+    """Remove insertion metadata that does not fit the captured baseline."""
+    addition_line.baseline_reference_after_line = None
+    addition_line.baseline_reference_after_text_bytes = None
+    addition_line.has_baseline_reference_after = False
+    addition_line.baseline_reference_before_line = None
+    addition_line.baseline_reference_before_text_bytes = None
+    addition_line.has_baseline_reference_before = False
+
+
+def _set_addition_baseline_reference(
+    addition_line,
+    baseline_lines: Sequence[bytes],
+    insertion_position: int,
+) -> None:
+    """Record the two baseline lines surrounding an insertion position."""
+    after_line = insertion_position or None
+    before_line = (
+        insertion_position + 1
+        if insertion_position < len(baseline_lines)
+        else None
+    )
+    addition_line.baseline_reference_after_line = after_line
+    addition_line.baseline_reference_after_text_bytes = (
+        bytes(baseline_lines[after_line - 1])
+        if after_line is not None
+        else None
+    )
+    addition_line.has_baseline_reference_after = True
+    addition_line.baseline_reference_before_line = before_line
+    addition_line.baseline_reference_before_text_bytes = (
+        bytes(baseline_lines[before_line - 1])
+        if before_line is not None
+        else None
+    )
+    addition_line.has_baseline_reference_before = True
+
+
+def _record_snapshot_baseline_references_for_additions(
+    line_changes,
+    *,
+    baseline_lines: Sequence[bytes],
+    source_lines: Sequence[bytes],
+) -> None:
+    """Attach insertion references in captured baseline coordinates."""
+
+    def reference_fits_baseline(line) -> bool:
+        reference = BaselineReference(
+            after_line=line.baseline_reference_after_line,
+            after_content=line.baseline_reference_after_text_bytes,
+            has_after_line=line.has_baseline_reference_after,
+            before_line=line.baseline_reference_before_line,
+            before_content=line.baseline_reference_before_text_bytes,
+            has_before_line=line.has_baseline_reference_before,
+        )
+        position = baseline_reference_insertion_position(
+            reference,
+            baseline_lines,
+        )
+        if position is None:
+            return False
+
+        # Legacy line views may carry an after-only EOF reference. If the
+        # baseline now continues past that position, rebuild it from snapshots.
+        return line.has_baseline_reference_before or position == len(baseline_lines)
+
+    with MappedRecordVector(
+        len(line_changes.lines),
+        "QQ",
+    ) as addition_line_records:
+        for line_index, line in enumerate(line_changes.lines):
+            if (
+                line.kind == "+"
+                and line.source_line is not None
+                and 1 <= line.source_line <= len(source_lines)
+                and not reference_fits_baseline(line)
+            ):
+                addition_line_records.append((
+                    line.source_line,
+                    line_index,
+                ))
+
+        if not addition_line_records:
+            return
+        sort_mapped_records(addition_line_records)
+
+        normalized_source_lines = normalize_line_sequence_endings(source_lines)
+        normalized_baseline_lines = normalize_line_sequence_endings(baseline_lines)
+        with match_lines(
+            normalized_source_lines,
+            normalized_baseline_lines,
+        ) as mapping:
+            mapped_pairs = mapping.mapped_line_pairs()
+            previous_pair: tuple[int, int] | None = None
+            next_pair = next(mapped_pairs, None)
+
+            for source_line, line_index in addition_line_records:
+                addition_line = line_changes.lines[line_index]
+
+                while next_pair is not None and next_pair[0] < source_line:
+                    previous_pair = next_pair
+                    next_pair = next(mapped_pairs, None)
+
+                if next_pair is not None and next_pair[0] == source_line:
+                    target_line = next_pair[1]
+                    after_line = target_line - 1 if target_line > 1 else None
+                    previous_pair = next_pair
+                    next_pair = next(mapped_pairs, None)
+                else:
+                    after_line = (
+                        previous_pair[1] if previous_pair is not None else None
+                    )
+                    before_line = next_pair[1] if next_pair is not None else None
+                    insertion_position = after_line or 0
+                    expected_before_line = insertion_position + 1
+                    actual_before_line = before_line or len(baseline_lines) + 1
+                    if expected_before_line != actual_before_line:
+                        # Target-only content leaves the relative insertion order
+                        # ambiguous.
+                        _clear_addition_baseline_reference(addition_line)
+                        continue
+
+                _set_addition_baseline_reference(
+                    addition_line,
+                    baseline_lines,
+                    after_line or 0,
+                )
+
+
+def record_baseline_references_for_additions(
+    line_changes,
+    *,
+    baseline_lines: Sequence[bytes] | None = None,
+    source_lines: Sequence[bytes] | None = None,
+) -> None:
+    """Attach insertion references to addition lines for batch round trips."""
+    _record_diff_baseline_references_for_additions(line_changes)
+    if baseline_lines is None and source_lines is None:
+        return
+    if baseline_lines is None or source_lines is None:
+        raise ValueError("baseline_lines and source_lines must be provided together")
+    _record_snapshot_baseline_references_for_additions(
+        line_changes,
+        baseline_lines=baseline_lines,
+        source_lines=source_lines,
+    )

--- a/src/git_stage_batch/batch/ownership_update.py
+++ b/src/git_stage_batch/batch/ownership_update.py
@@ -13,6 +13,9 @@ from .ownership.metadata_loading import acquire_ownership_for_metadata_dict
 from .ownership.merging import merge_batch_ownership
 from .ownership.translation import translate_lines_to_batch_ownership
 from .ownership.replacement_line_runs import ReplacementLineRun
+from .merge.baseline_reference_translation import (
+    translate_ownership_baseline_references,
+)
 from .source.refresh import ensure_batch_source_current_for_selection
 
 
@@ -88,6 +91,8 @@ def prepare_batch_ownership_update_for_selection(
     *,
     hunk_lines: Sequence[LineEntry] | None = None,
     replacement_line_runs: Sequence[ReplacementLineRun] | None = None,
+    reference_source_lines: Sequence[bytes] | None = None,
+    reference_target_lines: Sequence[bytes] | None = None,
 ) -> PreparedBatchUpdate:
     """Prepare complete ownership update after stale-source handling."""
     refreshed = ensure_batch_source_current_for_selection(
@@ -103,6 +108,16 @@ def prepare_batch_ownership_update_for_selection(
         hunk_lines=hunk_lines,
         replacement_line_runs=replacement_line_runs,
     )
+    if (reference_source_lines is None) != (reference_target_lines is None):
+        raise ValueError(
+            "reference source and target lines must be provided together"
+        )
+    if reference_source_lines is not None and reference_target_lines is not None:
+        translate_ownership_baseline_references(
+            new_ownership,
+            reference_source_lines,
+            reference_target_lines,
+        )
 
     if refreshed.ownership:
         merged_ownership = merge_batch_ownership(refreshed.ownership, new_ownership)
@@ -125,6 +140,8 @@ def acquire_batch_ownership_update_for_selection(
     selected_lines: list,
     hunk_lines: Sequence[LineEntry] | None = None,
     replacement_line_runs: Sequence[ReplacementLineRun] | None = None,
+    reference_source_lines: Sequence[bytes] | None = None,
+    reference_target_lines: Sequence[bytes] | None = None,
 ) -> Iterator[PreparedBatchUpdate]:
     """Acquire existing ownership metadata while preparing a batch update.
 
@@ -140,6 +157,8 @@ def acquire_batch_ownership_update_for_selection(
             selected_lines=selected_lines,
             hunk_lines=hunk_lines,
             replacement_line_runs=replacement_line_runs,
+            reference_source_lines=reference_source_lines,
+            reference_target_lines=reference_target_lines,
         )
         return
 
@@ -152,4 +171,6 @@ def acquire_batch_ownership_update_for_selection(
             selected_lines=selected_lines,
             hunk_lines=hunk_lines,
             replacement_line_runs=replacement_line_runs,
+            reference_source_lines=reference_source_lines,
+            reference_target_lines=reference_target_lines,
         )

--- a/src/git_stage_batch/commands/selection/batch_line_updates.py
+++ b/src/git_stage_batch/commands/selection/batch_line_updates.py
@@ -8,12 +8,18 @@ from contextlib import ExitStack
 from ...batch.state.lifecycle import create_batch
 from ...batch.ownership_update import acquire_batch_ownership_update_for_selection
 from ...batch.state.query import read_batch_metadata
+from ...batch.state.validation import get_validated_baseline_commit
 from ...batch.text_file_storage import add_file_to_batch
 from ...batch.state.batch_names import batch_exists
+from ...core.buffer import LineBuffer
 from ...data.file_modes import detect_file_mode
 from ...data.session import snapshot_file_if_untracked
+from ...data.selected_change.snapshots import (
+    load_selected_file_comparison_base_buffer,
+)
 from ...exceptions import exit_with_error
 from ...i18n import _
+from ...utils.repository_buffers import read_git_object_buffer_or_none
 
 
 def add_selected_lines_to_batch(
@@ -34,9 +40,21 @@ def add_selected_lines_to_batch(
     file_mode = detect_file_mode(file_path)
     metadata = read_batch_metadata(batch_name)
     file_metadata = metadata.get("files", {}).get(file_path)
+    baseline_commit = get_validated_baseline_commit(batch_name)
+    batch_baseline_lines = read_git_object_buffer_or_none(
+        f"{baseline_commit}:{file_path}"
+    )
+    if batch_baseline_lines is None:
+        batch_baseline_lines = LineBuffer.from_bytes(b"")
 
     with ExitStack() as ownership_stack:
+        reference_target_lines = ownership_stack.enter_context(
+            batch_baseline_lines
+        )
         try:
+            reference_source_lines = ownership_stack.enter_context(
+                load_selected_file_comparison_base_buffer(file_path)
+            )
             update = ownership_stack.enter_context(
                 acquire_batch_ownership_update_for_selection(
                     batch_name=batch_name,
@@ -45,6 +63,8 @@ def add_selected_lines_to_batch(
                     selected_lines=selected_lines,
                     hunk_lines=hunk_lines,
                     replacement_line_runs=replacement_line_runs,
+                    reference_source_lines=reference_source_lines,
+                    reference_target_lines=reference_target_lines,
                 )
             )
         except ValueError as e:

--- a/src/git_stage_batch/commands/selection/discard_line_batching.py
+++ b/src/git_stage_batch/commands/selection/discard_line_batching.py
@@ -6,16 +6,19 @@ import os
 import sys
 
 from ...batch.source.annotation import annotate_with_batch_source
+from ...batch.ownership import insertion_references as _insertion_references
 from ...core.buffer import LineBuffer
 from ...core.replacement import ReplacementPayload
 from ...data.line_state import load_line_changes_from_state
-from ...utils.repository_buffers import load_working_tree_file_as_buffer
 from ...data.selected_change.loading import require_selected_hunk
 from ...exceptions import exit_with_error
 from ...i18n import _
 from ...staging.content_buffers import build_target_working_tree_buffer_from_lines
 from ...utils.git_repository import get_git_repository_root_path
 from ...utils.journal import log_journal
+from ...utils.repository_buffers import (
+    load_working_tree_file_as_buffer,
+)
 from . import batch_line_selection as _batch_line_selection
 from . import batch_line_updates as _batch_line_updates
 from . import discard_file_selection as _discard_file_selection
@@ -111,6 +114,9 @@ def discard_file_lines_to_batch(
             )
         return 0
 
+    _insertion_references.record_baseline_references_for_additions(
+        line_changes,
+    )
     replacement_line_runs = (
         _discard_line_replacement.derive_live_replacement_line_runs(file_path)
     )
@@ -187,6 +193,9 @@ def discard_selected_lines_to_batch(
             )
         )
 
+    _insertion_references.record_baseline_references_for_additions(
+        line_changes,
+    )
     replacement_line_runs = (
         _discard_line_replacement.derive_live_replacement_line_runs(
             line_changes.path

--- a/src/git_stage_batch/commands/selection/include_line_batching.py
+++ b/src/git_stage_batch/commands/selection/include_line_batching.py
@@ -28,7 +28,9 @@ def include_file_lines_to_batch(
     """Include specific lines from a file to batch."""
     cached_lines = _include_file_selection.load_explicit_file_selection(file_path)
     line_changes = annotate_with_batch_source(file_path, cached_lines)
-    _include_line_selection.record_baseline_references_for_additions(line_changes)
+    _include_line_selection.record_baseline_references_for_additions(
+        line_changes
+    )
 
     selection = _batch_line_selection.select_lines_for_batch_action(
         line_changes,
@@ -77,7 +79,9 @@ def include_selected_lines_to_batch(
     require_selected_hunk()
 
     line_changes = load_line_changes_from_state()
-    _include_line_selection.record_baseline_references_for_additions(line_changes)
+    _include_line_selection.record_baseline_references_for_additions(
+        line_changes
+    )
     selection = _batch_line_selection.select_lines_for_batch_action(
         line_changes,
         line_id_specification,

--- a/src/git_stage_batch/commands/selection/include_line_selection.py
+++ b/src/git_stage_batch/commands/selection/include_line_selection.py
@@ -151,6 +151,34 @@ def _clear_addition_baseline_reference(addition_line) -> None:
     addition_line.has_baseline_reference_before = False
 
 
+def _set_addition_baseline_reference(
+    addition_line,
+    baseline_lines: Sequence[bytes],
+    insertion_position: int,
+) -> None:
+    """Record the two baseline lines surrounding an insertion position."""
+    after_line = insertion_position or None
+    before_line = (
+        insertion_position + 1
+        if insertion_position < len(baseline_lines)
+        else None
+    )
+    addition_line.baseline_reference_after_line = after_line
+    addition_line.baseline_reference_after_text_bytes = (
+        bytes(baseline_lines[after_line - 1])
+        if after_line is not None
+        else None
+    )
+    addition_line.has_baseline_reference_after = True
+    addition_line.baseline_reference_before_line = before_line
+    addition_line.baseline_reference_before_text_bytes = (
+        bytes(baseline_lines[before_line - 1])
+        if before_line is not None
+        else None
+    )
+    addition_line.has_baseline_reference_before = True
+
+
 def _record_snapshot_baseline_references_for_additions(
     line_changes,
     *,
@@ -235,20 +263,11 @@ def _record_snapshot_baseline_references_for_additions(
                     _clear_addition_baseline_reference(addition_line)
                     continue
 
-            addition_line.baseline_reference_after_line = after_line
-            addition_line.baseline_reference_after_text_bytes = (
-                bytes(baseline_lines[after_line - 1])
-                if after_line is not None
-                else None
+            _set_addition_baseline_reference(
+                addition_line,
+                baseline_lines,
+                after_line or 0,
             )
-            addition_line.has_baseline_reference_after = True
-            addition_line.baseline_reference_before_line = before_line
-            addition_line.baseline_reference_before_text_bytes = (
-                bytes(baseline_lines[before_line - 1])
-                if before_line is not None
-                else None
-            )
-            addition_line.has_baseline_reference_before = True
 
 
 def record_baseline_references_for_additions(

--- a/src/git_stage_batch/commands/selection/include_line_selection.py
+++ b/src/git_stage_batch/commands/selection/include_line_selection.py
@@ -11,12 +11,8 @@ import uuid
 from ...batch.ownership.hunk_translation import (
     translate_hunk_selection_to_batch_ownership,
 )
-from ...batch.line_matching.match import match_lines
-from ...batch.merge.baseline_reference_positions import (
-    baseline_reference_insertion_position as _baseline_reference_insertion_position,
-)
+from ...batch.ownership import insertion_references as _insertion_references
 from ...batch.merge.merge import merge_batch_from_line_sequences_as_buffer
-from ...batch.ownership.references import BaselineReference as _BaselineReference
 from ...batch.state.lifecycle import create_batch, delete_batch
 from ...batch.ownership.metadata_loading import acquire_ownership_for_metadata_dict
 from ...batch.state.query import read_batch_metadata
@@ -24,7 +20,6 @@ from ...batch.selection import line_selection_not_valid_message
 from ...batch.text_file_storage import add_file_to_batch
 from ...batch.state.batch_names import batch_exists
 from ...core.buffer import LineBuffer, buffer_matches
-from ...core.text_lines import normalize_line_sequence_endings
 from ...batch.source.snapshots import create_batch_source_commit
 from ...data.selected_change.file_hunk_cache import cache_unstaged_file_as_single_hunk
 from ...data.file_modes import detect_file_mode
@@ -48,6 +43,11 @@ from ...utils.file_io import write_file_bytes
 from ...utils.git_index import git_write_tree
 from ...utils.paths import get_session_batch_sources_file_path
 from . import replacement_selection
+
+
+record_baseline_references_for_additions = (
+    _insertion_references.record_baseline_references_for_additions
+)
 
 
 class TransientIncludeFailureReason(Enum):
@@ -93,200 +93,6 @@ class IncludeLineSelectionContext:
     preserve_selected_state: bool = False
     saved_selected_state: object | None = None
     reset_processed_include_ids: bool = False
-
-
-def _record_diff_baseline_references_for_additions(line_changes) -> None:
-    """Attach insertion references from the old side of the displayed diff."""
-    last_old_line: int | None = None
-    last_old_text_bytes: bytes | None = None
-    index = 0
-
-    while index < len(line_changes.lines):
-        line = line_changes.lines[index]
-        if line.kind == "+":
-            next_old_line: int | None = None
-            next_old_text_bytes: bytes | None = None
-            scan_index = index + 1
-            while scan_index < len(line_changes.lines):
-                next_line = line_changes.lines[scan_index]
-                if (
-                    next_line.kind in {" ", "-"}
-                    and next_line.old_line_number is not None
-                ):
-                    next_old_line = next_line.old_line_number
-                    next_old_text_bytes = next_line.text_bytes
-                    break
-                scan_index += 1
-
-            while (
-                index < len(line_changes.lines)
-                and line_changes.lines[index].kind == "+"
-            ):
-                addition_line = line_changes.lines[index]
-                addition_line.baseline_reference_after_line = last_old_line
-                addition_line.baseline_reference_after_text_bytes = last_old_text_bytes
-                addition_line.has_baseline_reference_after = True
-                addition_line.baseline_reference_before_line = next_old_line
-                addition_line.baseline_reference_before_text_bytes = next_old_text_bytes
-                # A missing next old line is an explicit EOF boundary, not an
-                # unknown second side.  Preserve that distinction so a later
-                # merge does not insert before content appended to the target.
-                addition_line.has_baseline_reference_before = True
-                index += 1
-            continue
-
-        if line.kind in {" ", "-"} and line.old_line_number is not None:
-            last_old_line = line.old_line_number
-            last_old_text_bytes = line.text_bytes
-        index += 1
-
-
-def _clear_addition_baseline_reference(addition_line) -> None:
-    """Remove insertion metadata that does not fit the captured baseline."""
-    addition_line.baseline_reference_after_line = None
-    addition_line.baseline_reference_after_text_bytes = None
-    addition_line.has_baseline_reference_after = False
-    addition_line.baseline_reference_before_line = None
-    addition_line.baseline_reference_before_text_bytes = None
-    addition_line.has_baseline_reference_before = False
-
-
-def _set_addition_baseline_reference(
-    addition_line,
-    baseline_lines: Sequence[bytes],
-    insertion_position: int,
-) -> None:
-    """Record the two baseline lines surrounding an insertion position."""
-    after_line = insertion_position or None
-    before_line = (
-        insertion_position + 1
-        if insertion_position < len(baseline_lines)
-        else None
-    )
-    addition_line.baseline_reference_after_line = after_line
-    addition_line.baseline_reference_after_text_bytes = (
-        bytes(baseline_lines[after_line - 1])
-        if after_line is not None
-        else None
-    )
-    addition_line.has_baseline_reference_after = True
-    addition_line.baseline_reference_before_line = before_line
-    addition_line.baseline_reference_before_text_bytes = (
-        bytes(baseline_lines[before_line - 1])
-        if before_line is not None
-        else None
-    )
-    addition_line.has_baseline_reference_before = True
-
-
-def _record_snapshot_baseline_references_for_additions(
-    line_changes,
-    *,
-    baseline_lines: Sequence[bytes],
-    source_lines: Sequence[bytes],
-) -> None:
-    """Attach insertion references in captured baseline coordinates.
-
-    A file-scoped view is rendered against the session comparison base, which
-    can differ from the current index after an earlier partial include. Align
-    the captured source and index directly so later selections use boundaries
-    from the baseline they will actually be merged into.
-    """
-
-    def reference_fits_baseline(line) -> bool:
-        reference = _BaselineReference(
-            after_line=line.baseline_reference_after_line,
-            after_content=line.baseline_reference_after_text_bytes,
-            has_after_line=line.has_baseline_reference_after,
-            before_line=line.baseline_reference_before_line,
-            before_content=line.baseline_reference_before_text_bytes,
-            has_before_line=line.has_baseline_reference_before,
-        )
-        position = _baseline_reference_insertion_position(
-            reference,
-            baseline_lines,
-        )
-        if position is None:
-            return False
-
-        # Legacy line views may carry an after-only EOF reference.  If the
-        # index now continues past that position, rebuild it from snapshots.
-        return line.has_baseline_reference_before or position == len(baseline_lines)
-
-    addition_lines = sorted(
-        (
-            line
-            for line in line_changes.lines
-            if (
-                line.kind == "+"
-                and line.source_line is not None
-                and 1 <= line.source_line <= len(source_lines)
-                and not reference_fits_baseline(line)
-            )
-        ),
-        key=lambda line: line.source_line,
-    )
-    if not addition_lines:
-        return
-
-    normalized_source_lines = normalize_line_sequence_endings(source_lines)
-    normalized_baseline_lines = normalize_line_sequence_endings(baseline_lines)
-    with match_lines(normalized_source_lines, normalized_baseline_lines) as mapping:
-        mapped_pairs = mapping.mapped_line_pairs()
-        previous_pair: tuple[int, int] | None = None
-        next_pair = next(mapped_pairs, None)
-
-        for addition_line in addition_lines:
-            source_line = addition_line.source_line
-            assert source_line is not None
-
-            while next_pair is not None and next_pair[0] < source_line:
-                previous_pair = next_pair
-                next_pair = next(mapped_pairs, None)
-
-            if next_pair is not None and next_pair[0] == source_line:
-                target_line = next_pair[1]
-                after_line = target_line - 1 if target_line > 1 else None
-                before_line = target_line
-                previous_pair = next_pair
-                next_pair = next(mapped_pairs, None)
-            else:
-                after_line = previous_pair[1] if previous_pair is not None else None
-                before_line = next_pair[1] if next_pair is not None else None
-                insertion_position = after_line or 0
-                expected_before_line = insertion_position + 1
-                actual_before_line = before_line or len(baseline_lines) + 1
-                if expected_before_line != actual_before_line:
-                    # Target-only content leaves the relative insertion order
-                    # ambiguous. Do not retain the diff reference that was
-                    # already proven invalid against this baseline.
-                    _clear_addition_baseline_reference(addition_line)
-                    continue
-
-            _set_addition_baseline_reference(
-                addition_line,
-                baseline_lines,
-                after_line or 0,
-            )
-
-
-def record_baseline_references_for_additions(
-    line_changes,
-    *,
-    baseline_lines: Sequence[bytes] | None = None,
-    source_lines: Sequence[bytes] | None = None,
-) -> None:
-    """Attach insertion references to addition lines for batch round trips."""
-    _record_diff_baseline_references_for_additions(line_changes)
-    if baseline_lines is None and source_lines is None:
-        return
-    if baseline_lines is None or source_lines is None:
-        raise ValueError("baseline_lines and source_lines must be provided together")
-    _record_snapshot_baseline_references_for_additions(
-        line_changes,
-        baseline_lines=baseline_lines,
-        source_lines=source_lines,
-    )
 
 
 def _snapshot_session_batch_sources_file() -> tuple[bool, bytes | None]:
@@ -483,7 +289,7 @@ def try_build_index_content_via_transient_batch(
         )
         created_batch = True
 
-        record_baseline_references_for_additions(
+        _insertion_references.record_baseline_references_for_additions(
             line_changes,
             baseline_lines=hunk_base_lines,
             source_lines=hunk_source_lines,

--- a/src/git_stage_batch/core/mapped_storage.py
+++ b/src/git_stage_batch/core/mapped_storage.py
@@ -393,6 +393,13 @@ class MappedRecordVector(Sequence[tuple[int, ...]]):
         self._length += 1
         return index
 
+    def truncate(self, length: int) -> None:
+        """Reduce the logical record count without reallocating storage."""
+        self._require_open()
+        if length < 0 or length > self._length:
+            raise ValueError("length must not extend the record vector")
+        self._length = length
+
     def fill(self, record: Sequence[int]) -> None:
         """Set every existing record to one value."""
         self._require_open()
@@ -441,6 +448,39 @@ class MappedRecordVector(Sequence[tuple[int, ...]]):
     def _require_open(self) -> None:
         if self._closed:
             raise ValueError("mapped record vector is closed")
+
+
+def sort_mapped_records(records: MappedRecordVector) -> None:
+    """Sort fixed-width records in place without materializing a Python list."""
+    record_count = len(records)
+    for start in range(record_count // 2 - 1, -1, -1):
+        _sift_mapped_record(records, start, record_count)
+    for end in range(record_count - 1, 0, -1):
+        first = records[0]
+        records[0] = records[end]
+        records[end] = first
+        _sift_mapped_record(records, 0, end)
+
+
+def _sift_mapped_record(
+    records: MappedRecordVector,
+    start: int,
+    end: int,
+) -> None:
+    """Restore one max-heap branch within a mapped record vector."""
+    root = start
+    while True:
+        child = root * 2 + 1
+        if child >= end:
+            return
+        if child + 1 < end and records[child] < records[child + 1]:
+            child += 1
+        if records[root] >= records[child]:
+            return
+        root_record = records[root]
+        records[root] = records[child]
+        records[child] = root_record
+        root = child
 
 
 class ChunkedMappedRecordVector(Sequence[tuple[int, ...]]):

--- a/src/git_stage_batch/data/file_hunk_display.py
+++ b/src/git_stage_batch/data/file_hunk_display.py
@@ -34,12 +34,18 @@ from .live_diff import stream_live_git_diff
 from ..utils.session_start_point import session_comparison_base
 
 
-def render_file_as_single_hunk(file_path: str) -> Optional[LineLevelChange]:
+def render_file_as_single_hunk(
+    file_path: str,
+    *,
+    comparison_base: str | None = None,
+) -> Optional[LineLevelChange]:
     """Render all changes for a file as a single hunk without caching state."""
     auto_add_untracked_files([file_path])
+    if comparison_base is None:
+        comparison_base = session_comparison_base()
     with acquire_unified_diff(
         stream_live_git_diff(
-            base=session_comparison_base(),
+            base=comparison_base,
             context_lines=get_context_lines(),
             full_index=True,
             ignore_submodules="none",

--- a/src/git_stage_batch/data/selected_change/file_hunk_cache.py
+++ b/src/git_stage_batch/data/selected_change/file_hunk_cache.py
@@ -16,6 +16,7 @@ from ...utils.paths import (
     get_processed_skip_ids_file_path,
     get_selected_hunk_hash_file_path,
 )
+from ...utils.session_start_point import session_comparison_base
 from ..file_hunk_display import (
     render_file_as_single_hunk,
     render_unstaged_file_as_single_hunk,
@@ -48,8 +49,16 @@ def cache_file_as_single_hunk(file_path: str) -> Optional[LineLevelChange]:
         LineLevelChange with all file changes, or None if no changes
     """
     try:
-        combined_line_changes = render_file_as_single_hunk(file_path)
-        return _cache_combined_file_line_changes(file_path, combined_line_changes)
+        comparison_base = session_comparison_base()
+        combined_line_changes = render_file_as_single_hunk(
+            file_path,
+            comparison_base=comparison_base,
+        )
+        return _cache_combined_file_line_changes(
+            file_path,
+            combined_line_changes,
+            comparison_base=comparison_base,
+        )
     except subprocess.CalledProcessError:
         return None
 
@@ -58,7 +67,11 @@ def cache_unstaged_file_as_single_hunk(file_path: str) -> Optional[LineLevelChan
     """Cache the remaining unstaged changes for a file as a single hunk."""
     try:
         combined_line_changes = render_unstaged_file_as_single_hunk(file_path)
-        return _cache_combined_file_line_changes(file_path, combined_line_changes)
+        return _cache_combined_file_line_changes(
+            file_path,
+            combined_line_changes,
+            comparison_base="index",
+        )
     except subprocess.CalledProcessError:
         return None
 
@@ -66,6 +79,8 @@ def cache_unstaged_file_as_single_hunk(file_path: str) -> Optional[LineLevelChan
 def _cache_combined_file_line_changes(
     file_path: str,
     combined_line_changes: Optional[LineLevelChange],
+    *,
+    comparison_base: str,
 ) -> Optional[LineLevelChange]:
     """Persist a combined file-scoped view as the current selection."""
     if combined_line_changes is None:
@@ -100,7 +115,10 @@ def _cache_combined_file_line_changes(
         ),
     )
 
-    write_snapshots_for_selected_file_path(file_path)
+    write_snapshots_for_selected_file_path(
+        file_path,
+        comparison_base=comparison_base,
+    )
     write_selected_change_kind(SelectedChangeKind.FILE)
 
     return combined_line_changes

--- a/src/git_stage_batch/data/selected_change/snapshots.py
+++ b/src/git_stage_batch/data/selected_change/snapshots.py
@@ -28,10 +28,14 @@ from ...utils.paths import (
 )
 
 
-_SNAPSHOT_SCHEMA_VERSION = 2
+_SNAPSHOT_SCHEMA_VERSION = 3
 
 
-def write_snapshots_for_selected_file_path(file_path: str) -> None:
+def write_snapshots_for_selected_file_path(
+    file_path: str,
+    *,
+    comparison_base: str = "index",
+) -> None:
     """Write snapshots of the file from both the index and working tree."""
     with ExitStack() as stack:
         index_entry = read_index_entry(file_path)
@@ -80,6 +84,7 @@ def write_snapshots_for_selected_file_path(file_path: str) -> None:
         manifest = {
             "schema_version": _SNAPSHOT_SCHEMA_VERSION,
             "path": file_path,
+            "comparison_base": comparison_base,
             "index": {
                 "exists": index_entry is not None,
                 "mode": index_entry.mode if index_entry is not None else None,
@@ -111,6 +116,26 @@ def write_snapshots_for_selected_file_path(file_path: str) -> None:
                     }
                 )
             log_journal("write_snapshots_for_selected_file", **fields)
+
+
+def load_selected_file_comparison_base_buffer(file_path: str) -> LineBuffer:
+    """Load the old-side file used to render the current line selection."""
+    manifest = json.loads(
+        get_snapshot_metadata_file_path().read_text(encoding="utf-8")
+    )
+    if manifest.get("path") != file_path:
+        raise ValueError("selected-file snapshot path does not match selection")
+
+    comparison_base = manifest.get("comparison_base")
+    if comparison_base == "index":
+        return LineBuffer.from_path(get_index_snapshot_file_path())
+    if not isinstance(comparison_base, str) or not comparison_base:
+        raise ValueError("selected-file snapshot has no comparison base")
+
+    buffer = read_git_object_buffer_or_none(f"{comparison_base}:{file_path}")
+    if buffer is None:
+        return LineBuffer.from_bytes(b"")
+    return buffer
 
 
 def _buffer_line_count(buffer: LineBuffer) -> int:
@@ -174,6 +199,8 @@ def snapshots_are_stale(file_path: str) -> bool:
             if (
                 manifest.get("schema_version") != _SNAPSHOT_SCHEMA_VERSION
                 or manifest.get("path") != file_path
+                or not isinstance(manifest.get("comparison_base"), str)
+                or not manifest["comparison_base"]
             ):
                 return True
 

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -17085,7 +17085,6 @@ def test_include_line_selection_stays_in_command_helper():
         "annotate_line_changes_with_working_tree_source",
         "line_sequence_ends_with_lf",
         "load_include_line_selection_context",
-        "record_baseline_references_for_additions",
         "selected_file_view_is_fresh_for",
         "selected_file_view_targets",
         "stage_live_line_target_buffer",
@@ -17714,7 +17713,6 @@ def test_include_line_batching_stays_in_command_helper():
         "batch_line_selection",
         "batch_line_updates",
         "include_file_selection",
-        "include_line_selection",
         "load_line_changes_from_state",
         "recalculate_selected_hunk_for_command",
         "require_selected_hunk",
@@ -17749,6 +17747,10 @@ def test_include_line_batching_stays_in_command_helper():
     assert not include_imports_helper
     assert action_imports_helper
     assert helper_imports <= helper_imported_names
+    assert {
+        "include_line_selection",
+        "insertion_references",
+    } & helper_imported_names
 
 
 def test_discard_line_selection_stays_in_command_helper():

--- a/tests/batch/merge/test_baseline_reference_translation.py
+++ b/tests/batch/merge/test_baseline_reference_translation.py
@@ -28,3 +28,36 @@ def test_translates_presence_gap_from_shifted_selection_baseline():
     reference = ownership.presence_baseline_references()[6]
     assert reference.after_line == 3
     assert reference.before_line == 4
+
+
+def test_translates_presence_references_from_mapped_record_order():
+    """Reference projection sorts mapped records without relying on dict order."""
+    source = [b"staged\n", b"a\n", b"b\n", b"c\n", b"d\n"]
+    target = [b"a\n", b"b\n", b"c\n", b"d\n"]
+    ownership = BatchOwnership.from_presence_lines(
+        ["2,4"],
+        baseline_references={
+            4: BaselineReference(
+                after_line=4,
+                after_content=b"c",
+                before_line=5,
+                before_content=b"d",
+                has_before_line=True,
+            ),
+            2: BaselineReference(
+                after_line=2,
+                after_content=b"a",
+                before_line=3,
+                before_content=b"b",
+                has_before_line=True,
+            ),
+        },
+    )
+
+    translate_ownership_baseline_references(ownership, source, target)
+
+    references = ownership.presence_baseline_references()
+    assert references[2].after_line == 1
+    assert references[2].before_line == 2
+    assert references[4].after_line == 3
+    assert references[4].before_line == 4

--- a/tests/batch/merge/test_baseline_reference_translation.py
+++ b/tests/batch/merge/test_baseline_reference_translation.py
@@ -1,0 +1,30 @@
+"""Tests for translating selection references onto batch baselines."""
+
+from git_stage_batch.batch.merge.baseline_reference_translation import (
+    translate_ownership_baseline_references,
+)
+from git_stage_batch.batch.ownership.model import BatchOwnership
+from git_stage_batch.batch.ownership.references import BaselineReference
+
+
+def test_translates_presence_gap_from_shifted_selection_baseline():
+    source = [b"staged\n", b"a\n", b"b\n", b"b\n", b"b\n", b"b\n"]
+    target = [b"a\n", b"b\n", b"b\n", b"b\n", b"b\n"]
+    ownership = BatchOwnership.from_presence_lines(
+        ["6"],
+        baseline_references={
+            6: BaselineReference(
+                after_line=4,
+                after_content=b"b",
+                before_line=5,
+                before_content=b"b",
+                has_before_line=True,
+            )
+        },
+    )
+
+    translate_ownership_baseline_references(ownership, source, target)
+
+    reference = ownership.presence_baseline_references()[6]
+    assert reference.after_line == 3
+    assert reference.before_line == 4

--- a/tests/batch/ownership/test_insertion_references.py
+++ b/tests/batch/ownership/test_insertion_references.py
@@ -1,6 +1,7 @@
-"""Focused tests for live include-line selection metadata."""
+"""Tests for persistent insertion-reference metadata."""
 
-from git_stage_batch.commands.selection.include_line_selection import (
+import git_stage_batch.batch.ownership.insertion_references as insertion_references
+from git_stage_batch.batch.ownership.insertion_references import (
     record_baseline_references_for_additions,
 )
 from git_stage_batch.core.models import HunkHeader, LineEntry, LineLevelChange
@@ -157,3 +158,42 @@ def test_snapshot_references_clear_ambiguous_stale_reference() -> None:
     assert not addition.has_baseline_reference_before
     assert addition.baseline_reference_before_line is None
     assert addition.baseline_reference_before_text_bytes is None
+
+
+def test_snapshot_reference_order_avoids_python_line_collections(
+    monkeypatch,
+) -> None:
+    """Source-order indexing should stay in storage-backed records."""
+    def fail_sorted(*_args, **_kwargs):
+        raise AssertionError("addition lines must not be collected on the heap")
+
+    monkeypatch.setattr(
+        insertion_references,
+        "sorted",
+        fail_sorted,
+        raising=False,
+    )
+    addition = LineEntry(
+        id=1,
+        kind="+",
+        old_line_number=None,
+        new_line_number=1,
+        text_bytes=b"added",
+        source_line=1,
+    )
+    tail = LineEntry(
+        id=None,
+        kind=" ",
+        old_line_number=1,
+        new_line_number=2,
+        text_bytes=b"tail",
+        source_line=2,
+    )
+
+    record_baseline_references_for_additions(
+        _line_changes([addition, tail]),
+        baseline_lines=[b"tail\n"],
+        source_lines=[b"added\n", b"tail\n"],
+    )
+
+    assert addition.baseline_reference_before_line == 1

--- a/tests/commands/selection/test_batch_line_updates.py
+++ b/tests/commands/selection/test_batch_line_updates.py
@@ -1,0 +1,70 @@
+"""Tests for selected-line batch update command boundaries."""
+
+import pytest
+
+import git_stage_batch.commands.selection.batch_line_updates as batch_line_updates
+from git_stage_batch.core.buffer import LineBuffer
+from git_stage_batch.exceptions import CommandError
+
+
+def test_invalid_comparison_snapshot_becomes_command_error(monkeypatch):
+    """Malformed selected-file state must not escape the command boundary."""
+    reference_buffer = LineBuffer.from_bytes(b"old\n")
+    persisted = []
+
+    monkeypatch.setattr(batch_line_updates, "batch_exists", lambda _name: True)
+    monkeypatch.setattr(
+        batch_line_updates,
+        "detect_file_mode",
+        lambda _path: "100644",
+    )
+    monkeypatch.setattr(
+        batch_line_updates,
+        "read_batch_metadata",
+        lambda _name: {"files": {}},
+    )
+    monkeypatch.setattr(
+        batch_line_updates,
+        "get_validated_baseline_commit",
+        lambda _name: "baseline",
+    )
+    buffer_reader_name = (
+        "read_git_object_buffer_or_empty"
+        if hasattr(batch_line_updates, "read_git_object_buffer_or_empty")
+        else "read_git_object_buffer_or_none"
+    )
+    monkeypatch.setattr(
+        batch_line_updates,
+        buffer_reader_name,
+        lambda _refspec: reference_buffer,
+    )
+    monkeypatch.setattr(
+        batch_line_updates,
+        "load_selected_file_comparison_base_buffer",
+        lambda _path: (_ for _ in ()).throw(
+            ValueError("selected-file snapshot path does not match selection")
+        ),
+    )
+    monkeypatch.setattr(
+        batch_line_updates,
+        "add_file_to_batch",
+        lambda *args, **kwargs: persisted.append((args, kwargs)),
+    )
+
+    with pytest.raises(
+        CommandError,
+        match="selected-file snapshot path does not match selection",
+    ) as error:
+        batch_line_updates.add_selected_lines_to_batch(
+            batch_name="saved",
+            file_path="module.py",
+            selected_lines=[],
+            stale_source_action="Cannot include lines to batch",
+            hunk_lines=[object()],
+            replacement_line_runs=[object()],
+        )
+
+    assert error.value.exit_code == 1
+    assert persisted == []
+    with pytest.raises(ValueError, match="buffer is closed"):
+        reference_buffer.byte_count

--- a/tests/data/test_file_hunk_cache.py
+++ b/tests/data/test_file_hunk_cache.py
@@ -1,0 +1,48 @@
+"""Tests for selected file-hunk caching."""
+
+import git_stage_batch.data.selected_change.file_hunk_cache as file_hunk_cache
+
+
+def test_file_hunk_cache_uses_one_comparison_base(monkeypatch):
+    """Rendered coordinates and snapshot metadata must share one base."""
+    line_changes = object()
+    calls = []
+
+    def comparison_base():
+        calls.append("resolve")
+        if len(calls) > 1:
+            raise AssertionError("comparison base must be resolved once")
+        return "session-base"
+
+    def render(file_path, *, comparison_base):
+        calls.append(("render", file_path, comparison_base))
+        return line_changes
+
+    def cache(file_path, rendered, *, comparison_base):
+        calls.append(("cache", file_path, rendered, comparison_base))
+        return rendered
+
+    monkeypatch.setattr(
+        file_hunk_cache,
+        "session_comparison_base",
+        comparison_base,
+    )
+    monkeypatch.setattr(
+        file_hunk_cache,
+        "render_file_as_single_hunk",
+        render,
+    )
+    monkeypatch.setattr(
+        file_hunk_cache,
+        "_cache_combined_file_line_changes",
+        cache,
+    )
+
+    result = file_hunk_cache.cache_file_as_single_hunk("module.py")
+
+    assert result is line_changes
+    assert calls == [
+        "resolve",
+        ("render", "module.py", "session-base"),
+        ("cache", "module.py", line_changes, "session-base"),
+    ]

--- a/tests/functional/test_include_line_transient_staging.py
+++ b/tests/functional/test_include_line_transient_staging.py
@@ -134,6 +134,48 @@ def test_include_line_transient_staging_pure_addition(functional_repo):
     assert _index_content(functional_repo, "file.txt") == "base\nfoo\n"
 
 
+def test_discard_to_batch_after_consecutive_line_includes(functional_repo):
+    _prepare_ambiguous_middle_insertion(functional_repo)
+
+    result = git_stage_batch(
+        "discard",
+        "--to",
+        "saved",
+        "--line",
+        "5-6",
+        "--no-auto-advance",
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert _batch_content(functional_repo, "saved", "file.txt") == (
+        "top\n"
+        "save-a\n"
+        "save-b\n"
+        "\n"
+        "bottom\n"
+    )
+    assert _index_content(functional_repo, "file.txt") == (
+        "top\n"
+        "import-a\n"
+        "import-b\n"
+        "import-c\n"
+        "\n"
+        "bottom\n"
+    )
+    assert (functional_repo / "file.txt").read_text() == (
+        "top\n"
+        "import-a\n"
+        "import-b\n"
+        "import-c\n"
+        "\n"
+        "later-a\n"
+        "\n"
+        "bottom\n"
+    )
+
+
+
 def test_include_to_batch_translates_position_from_staged_index(functional_repo):
     """Persistent includes project index-relative gaps onto the batch baseline."""
     _commit_file(functional_repo, "file.txt", "a\nb\nb\nb\nb\n")

--- a/tests/functional/test_include_line_transient_staging.py
+++ b/tests/functional/test_include_line_transient_staging.py
@@ -190,6 +190,71 @@ def test_discard_to_batch_after_consecutive_line_includes(functional_repo):
     )
 
 
+def test_discard_translates_repeated_boundary_from_staged_index(functional_repo):
+    _commit_file(
+        functional_repo,
+        "file.txt",
+        "top\n"
+        "\n"
+        "top\n"
+        "\n"
+        "bottom\n",
+    )
+    (functional_repo / "file.txt").write_text(
+        "staged-u\n"
+        "staged-v\n"
+        "top\n"
+        "\n"
+        "top\n"
+        "\n"
+        "bottom\n"
+    )
+    subprocess.run(
+        ["git", "add", "file.txt"],
+        check=True,
+        cwd=functional_repo,
+        capture_output=True,
+    )
+    (functional_repo / "file.txt").write_text(
+        "staged-u\n"
+        "staged-v\n"
+        "top\n"
+        "import-a\n"
+        "import-b\n"
+        "import-c\n"
+        "\n"
+        "save-a\n"
+        "save-b\n"
+        "later-a\n"
+        "\n"
+        "top\n"
+        "\n"
+        "bottom\n"
+    )
+
+    git_stage_batch("start", "--no-auto-advance")
+    result = git_stage_batch(
+        "discard",
+        "--to",
+        "saved",
+        "--line",
+        "5-6",
+        "--no-auto-advance",
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert _batch_content(functional_repo, "saved", "file.txt") == (
+        "top\n"
+        "save-a\n"
+        "save-b\n"
+        "\n"
+        "top\n"
+        "\n"
+        "bottom\n"
+    )
+
+
 def test_include_to_batch_translates_position_from_staged_index(functional_repo):
     """Persistent includes project index-relative gaps onto the batch baseline."""
     _commit_file(functional_repo, "file.txt", "a\nb\nb\nb\nb\n")

--- a/tests/functional/test_include_line_transient_staging.py
+++ b/tests/functional/test_include_line_transient_staging.py
@@ -40,6 +40,21 @@ def _index_bytes(repo, path: str) -> bytes:
     return result.stdout
 
 
+def _batch_content(repo, batch_name: str, path: str) -> str:
+    result = subprocess.run(
+        [
+            "git",
+            "show",
+            f"refs/git-stage-batch/batches/{batch_name}:{path}",
+        ],
+        check=True,
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
 def _prepare_ambiguous_middle_insertion(repo) -> None:
     _commit_file(
         repo,
@@ -117,6 +132,57 @@ def test_include_line_transient_staging_pure_addition(functional_repo):
     git_stage_batch("include", "--line", "1")
 
     assert _index_content(functional_repo, "file.txt") == "base\nfoo\n"
+
+
+def test_include_to_batch_translates_position_from_staged_index(functional_repo):
+    """Persistent includes project index-relative gaps onto the batch baseline."""
+    _commit_file(functional_repo, "file.txt", "a\nb\nb\nb\nb\n")
+    (functional_repo / "file.txt").write_text(
+        "staged\n"
+        "a\n"
+        "b\n"
+        "b\n"
+        "b\n"
+        "b\n"
+    )
+    subprocess.run(
+        ["git", "add", "file.txt"],
+        check=True,
+        cwd=functional_repo,
+        capture_output=True,
+    )
+    (functional_repo / "file.txt").write_text(
+        "staged\n"
+        "a\n"
+        "unselected-before\n"
+        "b\n"
+        "b\n"
+        "selected\n"
+        "unselected-after\n"
+        "b\n"
+        "b\n"
+    )
+
+    git_stage_batch("start", "--no-auto-advance")
+    result = git_stage_batch(
+        "include",
+        "--to",
+        "saved",
+        "--line",
+        "2",
+        "--no-auto-advance",
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert _batch_content(functional_repo, "saved", "file.txt") == (
+        "a\n"
+        "b\n"
+        "b\n"
+        "selected\n"
+        "b\n"
+        "b\n"
+    )
 
 
 def test_consecutive_line_includes_stage_ambiguous_middle_insertion(functional_repo):

--- a/tests/functional/test_include_line_transient_staging.py
+++ b/tests/functional/test_include_line_transient_staging.py
@@ -174,6 +174,20 @@ def test_discard_to_batch_after_consecutive_line_includes(functional_repo):
         "bottom\n"
     )
 
+    git_stage_batch("apply", "--from", "saved", "--file", "file.txt")
+
+    assert (functional_repo / "file.txt").read_text() == (
+        "top\n"
+        "import-a\n"
+        "import-b\n"
+        "import-c\n"
+        "\n"
+        "save-a\n"
+        "save-b\n"
+        "later-a\n"
+        "\n"
+        "bottom\n"
+    )
 
 
 def test_include_to_batch_translates_position_from_staged_index(functional_repo):


### PR DESCRIPTION
File selections can derive line numbers from the index or session starting
point while a named batch retains a different saved baseline.

Repeated gaps can make both numeric positions look valid, so persisting the
selection coordinate can place an addition at the wrong occurrence.

This PR records the exact comparison base, maps insertion boundaries through
mapped storage, centralizes boundary metadata, and wires include and discard.

Recorded-position fallback now receives references in the saved baseline
coordinate system without introducing line-proportional Python heap indexes.