### PR TITLE
batch: Verify removal anchors before file matching

### DIFF
--- a/src/git_stage_batch/batch/line_matching/match.py
+++ b/src/git_stage_batch/batch/line_matching/match.py
@@ -9,7 +9,11 @@ from typing import TypeVar
 
 from .line_mapping import IntVector as _IntVector, LineMapping as _LineMapping
 from .match_workspace import MatcherWorkspace
-from ...core.mapped_storage import MappedIntVector, MappedRecordVector
+from ...core.mapped_storage import (
+    MappedIntVector,
+    MappedRecordVector,
+    sort_mapped_records,
+)
 from ...core.text_lines import AcquirableLineSequence, as_acquirable_line_sequence
 
 
@@ -533,10 +537,107 @@ def _align_segment(
         workspace.close_resource(anchors)
 
 
+def _validated_anchor_pairs(
+    source_lines: Sequence[LineContent],
+    target_lines: Sequence[LineContent],
+    anchor_pairs: Sequence[tuple[int, int]],
+    workspace: MatcherWorkspace,
+) -> MappedRecordVector:
+    """Return sorted one-based anchor pairs after validating their alignment."""
+    for pair in anchor_pairs:
+        if (
+            not isinstance(pair, tuple)
+            or len(pair) != 2
+            or type(pair[0]) is not int
+            or type(pair[1]) is not int
+        ):
+            raise ValueError("line-matching anchors must contain integer line numbers")
+
+    validated = workspace.record_vector(
+        len(anchor_pairs),
+        _LINE_PAIR_RECORD_FORMAT,
+    )
+    for source_line, target_line in anchor_pairs:
+        if source_line < 1 or source_line > len(source_lines):
+            raise ValueError("line-matching source anchor is out of range")
+        if target_line < 1 or target_line > len(target_lines):
+            raise ValueError("line-matching target anchor is out of range")
+        if source_lines[source_line - 1] != target_lines[target_line - 1]:
+            raise ValueError("line-matching anchor content differs")
+        validated.append((source_line, target_line))
+
+    sort_mapped_records(validated)
+    previous_source_line = 0
+    previous_target_line = 0
+    previous_pair: tuple[int, int] | None = None
+    validated_count = 0
+
+    for pair in validated:
+        if pair == previous_pair:
+            continue
+        source_line, target_line = pair
+        if source_line <= previous_source_line or target_line <= previous_target_line:
+            raise ValueError("line-matching anchors must be strictly increasing")
+
+        previous_pair = pair
+        previous_source_line = source_line
+        previous_target_line = target_line
+        validated[validated_count] = pair
+        validated_count += 1
+
+    validated.truncate(validated_count)
+    return validated
+
+
+def _align_segments_around_anchors(
+    source_lines: Sequence[LineContent],
+    target_lines: Sequence[LineContent],
+    anchor_pairs: Sequence[tuple[int, int]],
+    source_to_target: _IntVector,
+    target_to_source: _IntVector,
+    workspace: MatcherWorkspace,
+) -> None:
+    """Align independent segments separated by trusted equal-line anchors."""
+    source_start = 0
+    target_start = 0
+
+    for source_line, target_line in anchor_pairs:
+        source_index = source_line - 1
+        target_index = target_line - 1
+        _align_segment(
+            source_lines,
+            target_lines,
+            source_start,
+            source_index,
+            target_start,
+            target_index,
+            source_to_target,
+            target_to_source,
+            workspace,
+        )
+        source_to_target[source_index] = target_line
+        target_to_source[target_index] = source_line
+        source_start = source_index + 1
+        target_start = target_index + 1
+
+    _align_segment(
+        source_lines,
+        target_lines,
+        source_start,
+        len(source_lines),
+        target_start,
+        len(target_lines),
+        source_to_target,
+        target_to_source,
+        workspace,
+    )
+
+
 def match_acquirable_lines(
     source_lines: AcquirableLineSequence[LineContent],
     target_lines: AcquirableLineSequence[LineContent],
     *,
+    anchor_pairs: Sequence[tuple[int, int]] = (),
     spool_dir: str | Path | None = None,
 ) -> _LineMapping:
     """Compute conservative structural alignment between source and target.
@@ -555,6 +656,7 @@ def match_acquirable_lines(
     Args:
         source_lines: Batch source file lines.
         target_lines: Working tree file lines.
+        anchor_pairs: Verified one-based equal-line pairs that divide matching.
 
     Returns:
         A bidirectional line mapping with ambiguous lines left unmapped.
@@ -585,13 +687,16 @@ def match_acquirable_lines(
             source_lines.acquire_lines() as acquired_source_lines,
             target_lines.acquire_lines() as acquired_target_lines,
         ):
-            _align_segment(
+            validated_anchor_pairs = _validated_anchor_pairs(
                 acquired_source_lines,
                 acquired_target_lines,
-                0,
-                source_line_count,
-                0,
-                target_line_count,
+                anchor_pairs,
+                workspace,
+            )
+            _align_segments_around_anchors(
+                acquired_source_lines,
+                acquired_target_lines,
+                validated_anchor_pairs,
                 source_to_target,
                 target_to_source,
                 workspace,
@@ -613,11 +718,13 @@ def match_lines(
     source_lines: Sequence[LineContent],
     target_lines: Sequence[LineContent],
     *,
+    anchor_pairs: Sequence[tuple[int, int]] = (),
     spool_dir: str | Path | None = None,
 ) -> _LineMapping:
     """Compute conservative structural alignment between source and target."""
     return match_acquirable_lines(
         as_acquirable_line_sequence(source_lines),
         as_acquirable_line_sequence(target_lines),
+        anchor_pairs=anchor_pairs,
         spool_dir=spool_dir,
     )

--- a/src/git_stage_batch/batch/line_matching/occurrence_index.py
+++ b/src/git_stage_batch/batch/line_matching/occurrence_index.py
@@ -1,0 +1,157 @@
+"""Storage-backed target-line occurrence indexing."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Sequence
+
+from ...core.text_lines import normalize_line_endings
+from .match_workspace import MatcherWorkspace
+
+
+_MAX_UINT64 = (1 << 64) - 1
+_CONTENT_RECORD_FORMAT = "QQQQQ"
+_CONTENT_HASH = 0
+_CONTENT_REPRESENTATIVE_INDEX = 1
+_CONTENT_COUNT = 2
+_CONTENT_FIRST_POSITION = 3
+_CONTENT_NEXT = 4
+_POSITION_RECORD_FORMAT = "QQ"
+_POSITION_TARGET_INDEX = 0
+_POSITION_NEXT = 1
+
+
+def normalized_line_payload(content: bytes) -> bytes:
+    """Return normalized line bytes without the final line terminator."""
+    normalized = normalize_line_endings(bytes(content))
+    if normalized.endswith(b"\n"):
+        return normalized[:-1]
+    return normalized
+
+
+class LinePayloadOccurrenceIndex:
+    """Index target positions by normalized line payload using mapped storage."""
+
+    def __init__(
+        self,
+        workspace: MatcherWorkspace,
+        target_lines: Sequence[bytes],
+    ) -> None:
+        self._target_lines = target_lines
+        self._bucket_count = _bucket_capacity(len(target_lines))
+        self._buckets = workspace.int_vector(
+            self._bucket_count,
+            width=8,
+            fill=0,
+        )
+        self._contents = workspace.record_vector(
+            len(target_lines),
+            _CONTENT_RECORD_FORMAT,
+        )
+        self._positions = workspace.record_vector(
+            len(target_lines),
+            _POSITION_RECORD_FORMAT,
+        )
+        self._build()
+
+    def occurrence_count(self, content: bytes) -> int:
+        """Return the number of target lines with this normalized payload."""
+        payload = normalized_line_payload(content)
+        record_index = self._find_content_record(
+            payload,
+            _payload_hash(payload),
+        )
+        if record_index is None:
+            return 0
+        return self._contents[record_index][_CONTENT_COUNT]
+
+    def matching_line_indexes(self, content: bytes) -> Iterator[int]:
+        """Yield zero-based target indexes having this normalized payload."""
+        payload = normalized_line_payload(content)
+        record_index = self._find_content_record(
+            payload,
+            _payload_hash(payload),
+        )
+        if record_index is None:
+            return
+
+        position_number = self._contents[record_index][
+            _CONTENT_FIRST_POSITION
+        ]
+        while position_number != 0:
+            position = self._positions[position_number - 1]
+            yield position[_POSITION_TARGET_INDEX]
+            position_number = position[_POSITION_NEXT]
+
+    def _build(self) -> None:
+        for target_index in range(len(self._target_lines)):
+            payload = normalized_line_payload(self._target_lines[target_index])
+            payload_hash = _payload_hash(payload)
+            content_record_index = self._find_content_record(
+                payload,
+                payload_hash,
+            )
+
+            if content_record_index is None:
+                bucket_index = self._bucket_index(payload_hash)
+                position_index = self._positions.append((target_index, 0))
+                content_record_index = self._contents.append((
+                    payload_hash,
+                    target_index,
+                    1,
+                    position_index + 1,
+                    self._buckets[bucket_index],
+                ))
+                self._buckets[bucket_index] = content_record_index + 1
+                continue
+
+            record = self._contents[content_record_index]
+            position_index = self._positions.append((
+                target_index,
+                record[_CONTENT_FIRST_POSITION],
+            ))
+            self._contents[content_record_index] = (
+                record[_CONTENT_HASH],
+                record[_CONTENT_REPRESENTATIVE_INDEX],
+                record[_CONTENT_COUNT] + 1,
+                position_index + 1,
+                record[_CONTENT_NEXT],
+            )
+
+    def _find_content_record(
+        self,
+        payload: bytes,
+        payload_hash: int,
+    ) -> int | None:
+        record_number = self._buckets[self._bucket_index(payload_hash)]
+
+        while record_number != 0:
+            record_index = record_number - 1
+            record = self._contents[record_index]
+            if (
+                record[_CONTENT_HASH] == payload_hash
+                and normalized_line_payload(
+                    self._target_lines[
+                        record[_CONTENT_REPRESENTATIVE_INDEX]
+                    ]
+                )
+                == payload
+            ):
+                return record_index
+            record_number = record[_CONTENT_NEXT]
+
+        return None
+
+    def _bucket_index(self, payload_hash: int) -> int:
+        return payload_hash & (self._bucket_count - 1)
+
+
+def _bucket_capacity(line_count: int) -> int:
+    capacity = 1
+    target_capacity = max(1, line_count * 2)
+    while capacity < target_capacity:
+        capacity <<= 1
+    return capacity
+
+
+def _payload_hash(payload: bytes) -> int:
+    return hash(payload) & _MAX_UINT64

--- a/src/git_stage_batch/batch/merge/baseline_edits.py
+++ b/src/git_stage_batch/batch/merge/baseline_edits.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from ...core.line_selection import LineRanges, LineSelection, coerce_line_ranges
+from ...core.mapped_storage import sort_mapped_records
 from ...exceptions import MergeError as _MergeError
 from ...i18n import _
-from ...core.text_lines import normalize_line_endings
+from ...core.text_lines import normalize_line_sequence_endings
 from .baseline_reference_positions import (
     baseline_reference_absence_position as _find_baseline_absence_position,
     baseline_reference_insertion_position as _find_baseline_insertion_position,
@@ -21,6 +24,11 @@ from ..line_matching.sequence_equality import (
     line_slice_equals as _line_slice_matches,
 )
 from ..line_matching.line_mapping import LineMapping
+from ..line_matching.match_workspace import MatcherWorkspace
+from ..line_matching.occurrence_index import (
+    LinePayloadOccurrenceIndex,
+    normalized_line_payload as _reference_line_payload,
+)
 from .candidates import MergeResolution as _MergeResolution
 
 if TYPE_CHECKING:
@@ -39,6 +47,107 @@ def _selection_outside_bounds(lines: LineSelection, max_line: int) -> bool:
     return False
 
 
+@contextmanager
+def acquire_deletion_anchor_pairs_for_target(
+    source_lines: Sequence[bytes],
+    target_lines: Sequence[bytes],
+    deletion_claims: Sequence[AbsenceClaim],
+    *,
+    trust_baseline_coordinates: bool = False,
+    spool_dir: str | Path | None = None,
+) -> Iterator[Sequence[tuple[int, int]]]:
+    """Return coherent source-to-target anchors recorded by deletion claims.
+
+    Exact baseline realization may trust recorded coordinates after checking
+    the deleted bytes. Live targets additionally require the stored boundary
+    identity to match before a coordinate can constrain structural alignment.
+    """
+    with MatcherWorkspace(spool_dir=spool_dir) as workspace:
+        anchor_pairs = workspace.record_vector(
+            len(deletion_claims),
+            "QQ",
+        )
+        occurrence_index: LinePayloadOccurrenceIndex | None = None
+        for claim in deletion_claims:
+            source_line = claim.anchor_line
+            reference = claim.baseline_reference
+            target_line = None if reference is None else reference.after_line
+            if type(source_line) is not int or type(target_line) is not int:
+                continue
+            if source_line < 1 or source_line > len(source_lines):
+                continue
+            if target_line < 1 or target_line > len(target_lines):
+                continue
+            if source_lines[source_line - 1] != target_lines[target_line - 1]:
+                continue
+
+            if trust_baseline_coordinates:
+                forbidden_sequence = normalize_line_sequence_endings(
+                    claim.content_lines
+                )
+                if not forbidden_sequence or not _line_slice_matches(
+                    target_lines,
+                    target_line,
+                    forbidden_sequence,
+                ):
+                    continue
+            else:
+                removal_edit = _baseline_removal_edit(claim, target_lines)
+                if removal_edit is None:
+                    continue
+                if (
+                    not _removal_boundary_is_fixed_to_file_edge(claim)
+                    and occurrence_index is None
+                ):
+                    occurrence_index = LinePayloadOccurrenceIndex(
+                        workspace,
+                        target_lines,
+                    )
+                if not _live_removal_boundary_is_unique(
+                    claim,
+                    target_lines,
+                    removal_edit[0],
+                    occurrence_index,
+                ):
+                    continue
+
+            anchor_pairs.append((source_line, target_line))
+
+        sort_mapped_records(anchor_pairs)
+        previous_pair: tuple[int, int] | None = None
+        previous_source = 0
+        previous_target = 0
+        anchor_count = 0
+        for pair in anchor_pairs:
+            if pair == previous_pair:
+                continue
+            source_line, target_line = pair
+            if source_line <= previous_source or target_line <= previous_target:
+                anchor_pairs.truncate(0)
+                yield anchor_pairs
+                return
+            anchor_pairs[anchor_count] = pair
+            anchor_count += 1
+            previous_pair = pair
+            previous_source = source_line
+            previous_target = target_line
+
+        anchor_pairs.truncate(anchor_count)
+        yield anchor_pairs
+
+
+def _removal_boundary_is_fixed_to_file_edge(claim: AbsenceClaim) -> bool:
+    """Return whether a boundary marker admits only one target position."""
+    reference = claim.baseline_reference
+    return reference is not None and (
+        reference.after_line is None
+        or (
+            reference.has_before_line
+            and reference.before_line is None
+        )
+    )
+
+
 def _baseline_removal_edit(
     claim: AbsenceClaim,
     working_lines: Sequence[bytes],
@@ -46,7 +155,7 @@ def _baseline_removal_edit(
     if not claim.content_lines:
         return None
 
-    forbidden_sequence = [normalize_line_endings(line) for line in claim.content_lines]
+    forbidden_sequence = normalize_line_sequence_endings(claim.content_lines)
     position = _find_baseline_absence_position(
         claim.baseline_reference,
         working_lines,
@@ -57,6 +166,112 @@ def _baseline_removal_edit(
     if not _line_slice_matches(working_lines, position, forbidden_sequence):
         return None
     return position, position + len(forbidden_sequence), []
+
+
+def _removal_boundary_identity_matches_at(
+    claim: AbsenceClaim,
+    target_lines: Sequence[bytes],
+    position: int,
+    forbidden_sequence: Sequence[bytes],
+) -> bool:
+    """Return whether one target position has the claim's full identity."""
+    reference = claim.baseline_reference
+    if reference is None or not reference.has_after_line:
+        return False
+    if not _line_slice_matches(target_lines, position, forbidden_sequence):
+        return False
+
+    if reference.after_line is None:
+        if position != 0:
+            return False
+    else:
+        if position == 0 or reference.after_content is None:
+            return False
+        if _reference_line_payload(target_lines[position - 1]) != (
+            _reference_line_payload(reference.after_content)
+        ):
+            return False
+
+    if not reference.has_before_line:
+        return True
+
+    before_position = position + len(forbidden_sequence)
+    if reference.before_line is None:
+        return before_position == len(target_lines)
+    if before_position >= len(target_lines) or reference.before_content is None:
+        return False
+    return _reference_line_payload(target_lines[before_position]) == (
+        _reference_line_payload(reference.before_content)
+    )
+
+
+def _live_removal_boundary_is_unique(
+    claim: AbsenceClaim,
+    target_lines: Sequence[bytes],
+    expected_position: int,
+    occurrence_index: LinePayloadOccurrenceIndex | None,
+) -> bool:
+    """Require a live deletion boundary to identify one target occurrence."""
+    forbidden_sequence = normalize_line_sequence_endings(claim.content_lines)
+    if not forbidden_sequence or not _removal_boundary_identity_matches_at(
+        claim,
+        target_lines,
+        expected_position,
+        forbidden_sequence,
+    ):
+        return False
+    if _removal_boundary_is_fixed_to_file_edge(claim):
+        return True
+    if occurrence_index is None:
+        return False
+
+    reference = claim.baseline_reference
+    assert reference is not None
+    rarest_content: bytes | None = None
+    rarest_boundary_delta = 0
+    rarest_count = len(target_lines) + 1
+
+    def consider(content: bytes | None, boundary_delta: int) -> None:
+        nonlocal rarest_content
+        nonlocal rarest_boundary_delta
+        nonlocal rarest_count
+        if content is None:
+            return
+        count = occurrence_index.occurrence_count(content)
+        if count < rarest_count:
+            rarest_content = content
+            rarest_boundary_delta = boundary_delta
+            rarest_count = count
+
+    if reference.after_line is not None:
+        consider(reference.after_content, 1)
+    for offset in range(len(forbidden_sequence)):
+        consider(forbidden_sequence[offset], -offset)
+    if reference.has_before_line and reference.before_line is not None:
+        consider(reference.before_content, -len(forbidden_sequence))
+
+    if rarest_content is None or rarest_count == 0:
+        return False
+    if rarest_count == 1:
+        return True
+
+    last_position = len(target_lines) - len(forbidden_sequence)
+    for line_index in occurrence_index.matching_line_indexes(rarest_content):
+        position = line_index + rarest_boundary_delta
+        if (
+            position < 0
+            or position > last_position
+            or position == expected_position
+        ):
+            continue
+        if _removal_boundary_identity_matches_at(
+            claim,
+            target_lines,
+            position,
+            forbidden_sequence,
+        ):
+            return False
+    return True
 
 
 def _replacement_origin_absence_bounds(
@@ -144,7 +359,7 @@ def _replacement_edit_from_parent_offset(
     ):
         return None
 
-    forbidden_sequence = [normalize_line_endings(line) for line in claim.content_lines]
+    forbidden_sequence = normalize_line_sequence_endings(claim.content_lines)
     if len(forbidden_sequence) != len(relative_offsets):
         return None
 
@@ -188,7 +403,7 @@ def _replacement_edit_from_origin_resolution(
         return None
 
     choice_index = resolution.decisions[key]
-    forbidden_sequence = [normalize_line_endings(line) for line in claim.content_lines]
+    forbidden_sequence = normalize_line_sequence_endings(claim.content_lines)
     for choice in choices:
         if choice.choice_index == choice_index:
             return (

--- a/tests/batch/merge/test_baseline_anchor_matching.py
+++ b/tests/batch/merge/test_baseline_anchor_matching.py
@@ -30,3 +30,36 @@ def test_baseline_coordinates_anchor_exact_realization_target():
     )
 
     assert anchors == ((3, 2),)
+
+
+def test_live_target_anchor_requires_verified_deletion_boundary():
+    """Live targets require content identity around a deletion coordinate."""
+    source = [b"head\n", b"new\n", b"\n", b"tail\n"]
+    target = [b"head\n", b"\n", b"old\n", b"\n", b"tail\n"]
+    numeric_claim = AbsenceClaim(
+        anchor_line=3,
+        content_lines=[b"old\n"],
+        baseline_reference=BaselineReference(after_line=2),
+    )
+    verified_claim = AbsenceClaim(
+        anchor_line=3,
+        content_lines=[b"old\n"],
+        baseline_reference=BaselineReference(
+            after_line=2,
+            after_content=b"\n",
+            before_line=4,
+            before_content=b"\n",
+            has_before_line=True,
+        ),
+    )
+
+    assert _deletion_anchor_pairs(
+        source,
+        target,
+        [numeric_claim],
+    ) == ()
+    assert _deletion_anchor_pairs(
+        source,
+        target,
+        [verified_claim],
+    ) == ((3, 2),)

--- a/tests/batch/merge/test_baseline_anchor_matching.py
+++ b/tests/batch/merge/test_baseline_anchor_matching.py
@@ -63,3 +63,45 @@ def test_live_target_anchor_requires_verified_deletion_boundary():
         target,
         [verified_claim],
     ) == ((3, 2),)
+
+
+def test_live_target_rejects_repeated_verified_deletion_boundary():
+    """A stale coordinate must not select one of several identical blocks."""
+    source = [
+        b"P\n",
+        b"ANCHOR\n",
+        b"OLD\n",
+        b"NEXT\n",
+        b"MIDDLE\n",
+        b"ANCHOR\n",
+        b"NEXT\n",
+        b"TAIL\n",
+    ]
+    target = [
+        b"P\n",
+        b"ANCHOR\n",
+        b"OLD\n",
+        b"NEXT\n",
+        b"FILL\n",
+        b"ANCHOR\n",
+        b"OLD\n",
+        b"NEXT\n",
+        b"MIDDLE\n",
+        b"ANCHOR\n",
+        b"OLD\n",
+        b"NEXT\n",
+        b"TAIL\n",
+    ]
+    claim = AbsenceClaim(
+        anchor_line=6,
+        content_lines=[b"OLD\n"],
+        baseline_reference=BaselineReference(
+            after_line=6,
+            after_content=b"ANCHOR\n",
+            before_line=8,
+            before_content=b"NEXT\n",
+            has_before_line=True,
+        ),
+    )
+
+    assert _deletion_anchor_pairs(source, target, [claim]) == ()

--- a/tests/batch/merge/test_baseline_anchor_matching.py
+++ b/tests/batch/merge/test_baseline_anchor_matching.py
@@ -1,5 +1,6 @@
 """Tests for line-matching anchors derived from deletion references."""
 
+import git_stage_batch.batch.merge.baseline_edits as baseline_edits
 from git_stage_batch.batch.merge.baseline_edits import (
     acquire_deletion_anchor_pairs_for_target,
 )
@@ -105,3 +106,40 @@ def test_live_target_rejects_repeated_verified_deletion_boundary():
     )
 
     assert _deletion_anchor_pairs(source, target, [claim]) == ()
+
+
+def test_live_target_checks_indexed_boundary_candidates(monkeypatch):
+    """Many unique claims must not rescan every target boundary."""
+    target = [f"line-{index}\n".encode() for index in range(1002)]
+    claims = [
+        AbsenceClaim(
+            anchor_line=index,
+            content_lines=[target[index]],
+            baseline_reference=BaselineReference(
+                after_line=index,
+                after_content=target[index - 1],
+                before_line=index + 2,
+                before_content=target[index + 1],
+                has_before_line=True,
+            ),
+        )
+        for index in range(1, 1001)
+    ]
+    identity_checks = 0
+    original_check = baseline_edits._removal_boundary_identity_matches_at
+
+    def count_identity_checks(*args, **kwargs):
+        nonlocal identity_checks
+        identity_checks += 1
+        return original_check(*args, **kwargs)
+
+    monkeypatch.setattr(
+        baseline_edits,
+        "_removal_boundary_identity_matches_at",
+        count_identity_checks,
+    )
+
+    anchors = _deletion_anchor_pairs(target, target, claims)
+
+    assert len(anchors) == len(claims)
+    assert identity_checks == len(claims)

--- a/tests/batch/merge/test_baseline_anchor_matching.py
+++ b/tests/batch/merge/test_baseline_anchor_matching.py
@@ -1,0 +1,32 @@
+"""Tests for line-matching anchors derived from deletion references."""
+
+from git_stage_batch.batch.merge.baseline_edits import (
+    acquire_deletion_anchor_pairs_for_target,
+)
+from git_stage_batch.batch.ownership.absence_claims import AbsenceClaim
+from git_stage_batch.batch.ownership.references import BaselineReference
+
+
+def _deletion_anchor_pairs(*args, **kwargs):
+    with acquire_deletion_anchor_pairs_for_target(*args, **kwargs) as anchors:
+        return tuple(anchors)
+
+
+def test_baseline_coordinates_anchor_exact_realization_target():
+    """Exact baseline targets can use coordinate-only deletion references."""
+    source = [b"head\n", b"new\n", b"\n", b"tail\n"]
+    target = [b"head\n", b"\n", b"old\n", b"\n", b"tail\n"]
+    claim = AbsenceClaim(
+        anchor_line=3,
+        content_lines=[b"old\n"],
+        baseline_reference=BaselineReference(after_line=2),
+    )
+
+    anchors = _deletion_anchor_pairs(
+        source,
+        target,
+        [claim],
+        trust_baseline_coordinates=True,
+    )
+
+    assert anchors == ((3, 2),)

--- a/tests/batch/merge/test_merge.py
+++ b/tests/batch/merge/test_merge.py
@@ -234,6 +234,18 @@ class TestMatchLines:
             assert mapping.get_target_line_from_source_line(3) == 2
             assert mapping.get_source_line_from_target_line(4) is None
 
+    def test_line_mapping_rejects_malformed_mixed_type_anchors(self):
+        """Malformed anchors should fail with the public validation error."""
+        with pytest.raises(
+            ValueError,
+            match="anchors must contain integer line numbers",
+        ):
+            match_lines(
+                [b"one\n", b"two\n"],
+                [b"one\n", b"two\n"],
+                anchor_pairs=(("bad", 1), (2, 2)),
+            )
+
     def test_identical_files(self):
         """Test alignment of identical files."""
         source = [b"line1\n", b"line2\n", b"line3\n"]

--- a/tests/batch/merge/test_merge.py
+++ b/tests/batch/merge/test_merge.py
@@ -225,6 +225,15 @@ class TestMatchLines:
         ) as mapping:
             assert list(mapping.mapped_line_pairs()) == [(1, 1), (3, 2)]
 
+    def test_line_mapping_uses_explicit_anchor_between_repeated_lines(self):
+        """A verified anchor divides otherwise ambiguous matching segments."""
+        source = [b"head\n", b"new\n", b"\n", b"tail\n"]
+        target = [b"head\n", b"\n", b"old\n", b"\n", b"tail\n"]
+
+        with match_lines(source, target, anchor_pairs=((3, 2),)) as mapping:
+            assert mapping.get_target_line_from_source_line(3) == 2
+            assert mapping.get_source_line_from_target_line(4) is None
+
     def test_identical_files(self):
         """Test alignment of identical files."""
         source = [b"line1\n", b"line2\n", b"line3\n"]


### PR DESCRIPTION
Saved insertion references project onto a batch's baseline before include
and discard record ownership.

Removed blocks carry boundaries that can repeat or go stale.
Matching a file around an unverified numeric position can align the wrong
occurrence and duplicate moved content.

This commit series derives trusted removal anchors from saved content, then
constrains matching sections with those pairs through mapped occurrence
storage.

Removal records now constrain repeated-line matching without rescanning
each target or allocating line-proportional Python heap indexes.