### PR TITLE
batch: Project deletion references onto saved baselines

### DIFF
--- a/src/git_stage_batch/batch/merge/baseline_edits.py
+++ b/src/git_stage_batch/batch/merge/baseline_edits.py
@@ -24,6 +24,7 @@ from ..line_matching.sequence_equality import (
     line_slice_equals as _line_slice_matches,
 )
 from ..line_matching.line_mapping import LineMapping
+from ..line_matching.match import match_lines as _match_lines
 from ..line_matching.match_workspace import MatcherWorkspace
 from ..line_matching.occurrence_index import (
     LinePayloadOccurrenceIndex,
@@ -509,6 +510,7 @@ def try_apply_baseline_replacement_units(
     *,
     resolution: _MergeResolution | None = None,
     max_resolution_choices: int = _DEFAULT_RESOLUTION_CHOICE_LIMIT,
+    spool_dir: str | Path | None = None,
 ) -> Iterator[bytes] | None:
     """Apply baseline-coordinate edits when structural source anchors fail.
 
@@ -579,6 +581,7 @@ def try_apply_baseline_replacement_units(
     claimed_line_references = ownership.presence_baseline_references()
     if remaining_claimed_lines:
         grouped_insertions: dict[int, list[int]] = {}
+        has_mapped_claimed_lines = False
         for claimed_line in sorted(remaining_claimed_lines):
             if claimed_line < 1 or claimed_line > len(source_lines):
                 return None
@@ -588,8 +591,31 @@ def try_apply_baseline_replacement_units(
                 working_lines,
             )
             if position is None:
-                return None
+                has_mapped_claimed_lines = True
+                continue
             grouped_insertions.setdefault(position, []).append(claimed_line)
+
+        if has_mapped_claimed_lines:
+            with _match_lines(
+                source_lines,
+                working_lines,
+                spool_dir=spool_dir,
+            ) as mapping:
+                for claimed_line in remaining_claimed_lines:
+                    reference = claimed_line_references.get(claimed_line)
+                    if _find_baseline_insertion_position(
+                        reference,
+                        working_lines,
+                    ) is not None:
+                        continue
+                    target_line = mapping.get_target_line_from_source_line(
+                        claimed_line
+                    )
+                    if target_line is None or any(
+                        start <= target_line - 1 < end
+                        for start, end, _replacement_lines in edits
+                    ):
+                        return None
 
         for position, claimed_lines in grouped_insertions.items():
             insertion_lines = [

--- a/src/git_stage_batch/batch/merge/baseline_reference_translation.py
+++ b/src/git_stage_batch/batch/merge/baseline_reference_translation.py
@@ -160,19 +160,27 @@ def _mapped_removal_position(
         candidates.add(first_target_line - 1)
 
     previous_target_line = (
-        0
+        None
         if source_position == 0
         else mapping.get_target_line_from_source_line(source_position)
     )
     next_source_line = source_position + line_count + 1
     next_target_line = (
-        len(target_lines) + 1
+        None
         if next_source_line > len(source_lines)
         else mapping.get_target_line_from_source_line(next_source_line)
     )
     if previous_target_line is not None and next_target_line is not None:
         if next_target_line - previous_target_line == line_count + 1:
             candidates.add(previous_target_line)
+    elif source_position == 0 and next_target_line == line_count + 1:
+        candidates.add(0)
+    elif (
+        next_source_line > len(source_lines)
+        and previous_target_line is not None
+        and len(target_lines) - previous_target_line == line_count
+    ):
+        candidates.add(previous_target_line)
 
     if len(candidates) != 1:
         return None

--- a/src/git_stage_batch/batch/merge/baseline_reference_translation.py
+++ b/src/git_stage_batch/batch/merge/baseline_reference_translation.py
@@ -2,14 +2,16 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 
 from ...core.mapped_storage import (
+    MappedIntVector,
     MappedRecordVector,
     sort_mapped_records,
 )
 from ...core.text_lines import (
     as_acquirable_line_sequence,
+    normalize_line_endings,
     normalize_line_sequence_endings,
 )
 from ..line_matching.line_mapping import LineMapping
@@ -41,6 +43,194 @@ def _reference_for_insertion(
             else None
         ),
         has_before_line=True,
+    )
+
+
+def _reference_for_removal(
+    target_lines: Sequence[bytes],
+    position: int,
+    line_count: int,
+) -> BaselineReference:
+    """Return an exact two-sided reference for one target line range."""
+    before_position = position + line_count
+    return BaselineReference(
+        after_line=position or None,
+        after_content=(
+            bytes(target_lines[position - 1]) if position > 0 else None
+        ),
+        has_after_line=True,
+        before_line=(
+            before_position + 1
+            if before_position < len(target_lines)
+            else None
+        ),
+        before_content=(
+            bytes(target_lines[before_position])
+            if before_position < len(target_lines)
+            else None
+        ),
+        has_before_line=True,
+    )
+
+
+def _line_payload(content: bytes) -> bytes:
+    normalized = normalize_line_endings(bytes(content))
+    if normalized.endswith(b"\n"):
+        return normalized[:-1]
+    return normalized
+
+
+def _reference_content_matches(
+    line: bytes,
+    reference_content: bytes | None,
+) -> bool:
+    return (
+        reference_content is not None
+        and _line_payload(line) == _line_payload(reference_content)
+    )
+
+
+def _recorded_removal_position(
+    reference: BaselineReference | None,
+    content_lines: Sequence[bytes],
+    baseline_lines: Sequence[bytes],
+) -> int | None:
+    """Return a removal position recorded against this exact baseline."""
+    if reference is None or not reference.has_after_line or not content_lines:
+        return None
+
+    position = reference.after_line or 0
+    if position < 0 or position + len(content_lines) > len(baseline_lines):
+        return None
+    if any(
+        baseline_lines[position + offset] != content
+        for offset, content in enumerate(content_lines)
+    ):
+        return None
+
+    if reference.after_line is not None and reference.after_content is not None:
+        if position == 0 or not _reference_content_matches(
+            baseline_lines[position - 1],
+            reference.after_content,
+        ):
+            return None
+
+    if reference.has_before_line:
+        before_position = position + len(content_lines)
+        if reference.before_line is None:
+            if before_position != len(baseline_lines):
+                return None
+        elif reference.before_content is not None:
+            if before_position >= len(baseline_lines) or not (
+                _reference_content_matches(
+                    baseline_lines[before_position],
+                    reference.before_content,
+                )
+            ):
+                return None
+
+    return position
+
+
+def _mapped_removal_position(
+    source_position: int,
+    line_count: int,
+    source_lines: Sequence[bytes],
+    target_lines: Sequence[bytes],
+    mapping: LineMapping,
+) -> int | None:
+    """Map one exact source range into a coherent target range."""
+    candidates: set[int] = set()
+    first_target_line: int | None = None
+    content_range_is_contiguous = line_count > 0
+    for offset, source_line in enumerate(range(
+        source_position + 1,
+        source_position + line_count + 1,
+    )):
+        target_line = mapping.get_target_line_from_source_line(source_line)
+        if target_line is None:
+            content_range_is_contiguous = False
+            break
+        if first_target_line is None:
+            first_target_line = target_line
+        elif target_line != first_target_line + offset:
+            content_range_is_contiguous = False
+            break
+    if content_range_is_contiguous and first_target_line is not None:
+        candidates.add(first_target_line - 1)
+
+    previous_target_line = (
+        0
+        if source_position == 0
+        else mapping.get_target_line_from_source_line(source_position)
+    )
+    next_source_line = source_position + line_count + 1
+    next_target_line = (
+        len(target_lines) + 1
+        if next_source_line > len(source_lines)
+        else mapping.get_target_line_from_source_line(next_source_line)
+    )
+    if previous_target_line is not None and next_target_line is not None:
+        if next_target_line - previous_target_line == line_count + 1:
+            candidates.add(previous_target_line)
+
+    if len(candidates) != 1:
+        return None
+    target_position = next(iter(candidates))
+
+    if previous_target_line is not None and target_position != previous_target_line:
+        return None
+    if (
+        next_target_line is not None
+        and target_position + line_count != next_target_line - 1
+    ):
+        return None
+    if target_position < 0 or target_position + line_count > len(target_lines):
+        return None
+    return target_position
+
+
+def _translate_removal_reference(
+    reference: BaselineReference | None,
+    content_lines: Sequence[bytes],
+    source_lines: Sequence[bytes],
+    target_lines: Sequence[bytes],
+    mapping: LineMapping,
+) -> tuple[BaselineReference, int] | None:
+    source_position = _recorded_removal_position(
+        reference,
+        content_lines,
+        source_lines,
+    )
+    if source_position is None:
+        target_position = _recorded_removal_position(
+            reference,
+            content_lines,
+            target_lines,
+        )
+        if target_position is None:
+            return None
+        return reference, target_position
+
+    target_position = _mapped_removal_position(
+        source_position,
+        len(content_lines),
+        source_lines,
+        target_lines,
+        mapping,
+    )
+    if target_position is None or any(
+        target_lines[target_position + offset] != content
+        for offset, content in enumerate(content_lines)
+    ):
+        return None
+    return (
+        _reference_for_removal(
+            target_lines,
+            target_position,
+            len(content_lines),
+        ),
+        target_position,
     )
 
 
@@ -118,25 +308,89 @@ def _translate_presence_references(
             )
 
 
+def _mark_origin_backed_deletions(
+    ownership: BatchOwnership,
+    origin_backed: MappedIntVector,
+) -> None:
+    """Mark deletion indexes whose coordinates come from replacement origins."""
+    for unit in ownership.replacement_units:
+        if unit.origin is None:
+            continue
+        for deletion_index in unit.deletion_indices:
+            if (
+                type(deletion_index) is int
+                and 0 <= deletion_index < len(origin_backed)
+            ):
+                origin_backed[deletion_index] = 1
+
+
+def _translate_deletion_references(
+    ownership: BatchOwnership,
+    deletion_indices: Iterable[int],
+    source_lines: Sequence[bytes],
+    target_lines: Sequence[bytes],
+    mapping: LineMapping,
+) -> None:
+    """Translate the selected deletion references in one baseline space."""
+    for deletion_index in deletion_indices:
+        if deletion_index < 0 or deletion_index >= len(ownership.deletions):
+            continue
+        deletion = ownership.deletions[deletion_index]
+        content_lines = normalize_line_sequence_endings(
+            deletion.content_lines
+        )
+        translated = _translate_removal_reference(
+            deletion.baseline_reference,
+            content_lines,
+            source_lines,
+            target_lines,
+            mapping,
+        )
+        deletion.baseline_reference = (
+            translated[0] if translated is not None else None
+        )
+
+
 def translate_ownership_baseline_references(
     ownership: BatchOwnership,
     source_baseline_lines: Sequence[bytes],
     target_baseline_lines: Sequence[bytes],
 ) -> None:
     """Rebase newly translated ownership references onto a batch baseline."""
-    normalized_source = normalize_line_sequence_endings(source_baseline_lines)
-    normalized_target = normalize_line_sequence_endings(target_baseline_lines)
-    source_sequence = as_acquirable_line_sequence(normalized_source)
-    target_sequence = as_acquirable_line_sequence(normalized_target)
-
-    with (
-        source_sequence.acquire_lines() as source_lines,
-        target_sequence.acquire_lines() as target_lines,
-        match_lines(source_lines, target_lines) as mapping,
-    ):
-        _translate_presence_references(
-            ownership,
-            source_lines,
-            target_lines,
-            mapping,
+    with MappedIntVector(
+        len(ownership.deletions),
+        width=4,
+        fill=0,
+    ) as origin_backed:
+        _mark_origin_backed_deletions(ownership, origin_backed)
+        normalized_source = normalize_line_sequence_endings(
+            source_baseline_lines
         )
+        normalized_target = normalize_line_sequence_endings(
+            target_baseline_lines
+        )
+        source_sequence = as_acquirable_line_sequence(normalized_source)
+        target_sequence = as_acquirable_line_sequence(normalized_target)
+
+        with (
+            source_sequence.acquire_lines() as source_lines,
+            target_sequence.acquire_lines() as target_lines,
+            match_lines(source_lines, target_lines) as mapping,
+        ):
+            _translate_presence_references(
+                ownership,
+                source_lines,
+                target_lines,
+                mapping,
+            )
+            _translate_deletion_references(
+                ownership,
+                (
+                    deletion_index
+                    for deletion_index in range(len(ownership.deletions))
+                    if origin_backed[deletion_index] == 0
+                ),
+                source_lines,
+                target_lines,
+                mapping,
+            )

--- a/src/git_stage_batch/batch/merge/merge.py
+++ b/src/git_stage_batch/batch/merge/merge.py
@@ -163,6 +163,7 @@ def _merge_batch_acquired_line_chunks(
         deletion_claims,
         resolution=resolution,
         max_resolution_choices=_MERGE_CANDIDATE_CAP + 1,
+        spool_dir=spool_dir,
     )
     if fallback_chunks is not None:
         yield from _byte_chunks(fallback_chunks)
@@ -221,6 +222,7 @@ def _merge_batch_acquired_line_chunks(
             deletion_claims,
             resolution=resolution,
             max_resolution_choices=_MERGE_CANDIDATE_CAP + 1,
+            spool_dir=spool_dir,
         )
         if fallback_chunks is not None:
             yield from _byte_chunks(fallback_chunks)

--- a/src/git_stage_batch/batch/ownership/translation.py
+++ b/src/git_stage_batch/batch/ownership/translation.py
@@ -80,9 +80,13 @@ def translate_lines_to_batch_ownership(selected_lines: list) -> BatchOwnership:
 
     # Track current deletion run
     current_absence_anchor: int | None = None
-    current_absence_baseline_reference: BaselineReference | None = None
     current_absence_start: int | None = None
     current_absence_stop: int | None = None
+    current_absence_old_start: int | None = None
+    current_absence_old_end: int | None = None
+    current_absence_after_content: bytes | None = None
+    previous_old_line: int | None = None
+    previous_old_content: bytes | None = None
     active_replacement_unit: _ReplacementUnitBuilder | None = None
 
     def finish_replacement_unit(
@@ -94,9 +98,11 @@ def translate_lines_to_batch_ownership(selected_lines: list) -> BatchOwnership:
     def flush_absence_run() -> list[int]:
         """Finalize current deletion run as an AbsenceClaim."""
         nonlocal current_absence_anchor
-        nonlocal current_absence_baseline_reference
         nonlocal current_absence_start
         nonlocal current_absence_stop
+        nonlocal current_absence_old_start
+        nonlocal current_absence_old_end
+        nonlocal current_absence_after_content
         if current_absence_start is None or current_absence_stop is None:
             return []
 
@@ -105,18 +111,50 @@ def translate_lines_to_batch_ownership(selected_lines: list) -> BatchOwnership:
             current_absence_start,
             current_absence_stop,
         )
+        baseline_reference = None
+        if (
+            current_absence_old_start is not None
+            and current_absence_old_end is not None
+        ):
+            before_line = current_absence_old_end + 1
+            before_content = None
+            for following_index in range(
+                current_absence_stop,
+                len(selected_lines),
+            ):
+                following_line = selected_lines[following_index]
+                if (
+                    following_line.kind in {" ", "-"}
+                    and following_line.old_line_number == before_line
+                ):
+                    before_content = following_line.text_bytes
+                    break
+            baseline_reference = BaselineReference(
+                after_line=(
+                    current_absence_old_start - 1
+                    if current_absence_old_start > 1
+                    else None
+                ),
+                after_content=current_absence_after_content,
+                has_after_line=True,
+                before_line=before_line if before_content is not None else None,
+                before_content=before_content,
+                has_before_line=before_content is not None,
+            )
         absence_claims.append(
             AbsenceClaim(
                 anchor_line=current_absence_anchor,
                 content_lines=content_lines,
-                baseline_reference=current_absence_baseline_reference,
+                baseline_reference=baseline_reference,
             )
         )
         absence_index = len(absence_claims) - 1
         current_absence_start = None
         current_absence_stop = None
         current_absence_anchor = None
-        current_absence_baseline_reference = None
+        current_absence_old_start = None
+        current_absence_old_end = None
+        current_absence_after_content = None
         return [absence_index]
 
     for index, line in enumerate(selected_lines):
@@ -157,10 +195,20 @@ def translate_lines_to_batch_ownership(selected_lines: list) -> BatchOwnership:
 
             # Update anchor for next deletion run
             current_absence_anchor = line.source_line
+            if line.kind == " " and line.old_line_number is not None:
+                previous_old_line = line.old_line_number
+                previous_old_content = line.text_bytes
 
         elif line.kind == '-':
             finish_replacement_unit(active_replacement_unit)
             active_replacement_unit = None
+            if (
+                current_absence_start is not None
+                and current_absence_old_end is not None
+                and line.old_line_number is not None
+                and line.old_line_number != current_absence_old_end + 1
+            ):
+                flush_absence_run()
             # Deletion: suppression constraint
             # Anchor each deletion run at its first deleted line. A None anchor
             # means the run starts before the first source line and must not be
@@ -168,14 +216,16 @@ def translate_lines_to_batch_ownership(selected_lines: list) -> BatchOwnership:
             if current_absence_start is None:
                 current_absence_start = index
                 current_absence_anchor = line.source_line
-                if line.old_line_number is not None:
-                    current_absence_baseline_reference = BaselineReference(
-                        after_line=(
-                            line.old_line_number - 1
-                            if line.old_line_number > 1 else
-                            None
-                        )
-                    )
+                current_absence_old_start = line.old_line_number
+                if (
+                    line.old_line_number is not None
+                    and previous_old_line == line.old_line_number - 1
+                ):
+                    current_absence_after_content = previous_old_content
+            if line.old_line_number is not None:
+                current_absence_old_end = line.old_line_number
+                previous_old_line = line.old_line_number
+                previous_old_content = line.text_bytes
             current_absence_stop = index + 1
 
     # Flush any final deletion run

--- a/src/git_stage_batch/batch/realized_file_content.py
+++ b/src/git_stage_batch/batch/realized_file_content.py
@@ -52,6 +52,23 @@ def _stream_realized_content_chunks_from_lines(
     presence_line_set = resolved.presence_line_set
     deletion_claims = resolved.deletion_claims
 
+    if any(
+        claim.anchor_line is None
+        and claim.baseline_reference is not None
+        and claim.baseline_reference.after_line is not None
+        for claim in deletion_claims
+    ):
+        baseline_chunks = _baseline_edits.try_apply_baseline_replacement_units(
+            batch_source_lines,
+            base_lines,
+            ownership,
+            presence_line_set,
+            deletion_claims,
+        )
+        if baseline_chunks is not None:
+            yield from baseline_chunks
+            return
+
     try:
         realized_entries = satisfy_constraints(
             batch_source_lines,

--- a/tests/batch/merge/test_baseline_reference_translation.py
+++ b/tests/batch/merge/test_baseline_reference_translation.py
@@ -3,6 +3,7 @@
 from git_stage_batch.batch.merge.baseline_reference_translation import (
     translate_ownership_baseline_references,
 )
+from git_stage_batch.batch.ownership.absence_claims import AbsenceClaim
 from git_stage_batch.batch.ownership.model import BatchOwnership
 from git_stage_batch.batch.ownership.references import BaselineReference
 
@@ -61,3 +62,29 @@ def test_translates_presence_references_from_mapped_record_order():
     assert references[2].before_line == 2
     assert references[4].after_line == 3
     assert references[4].before_line == 4
+
+
+def test_translates_deletion_range_from_shifted_selection_baseline():
+    source = [b"staged-one\n", b"staged-two\n", b"a\n", b"b\n", b"a\n", b"b\n"]
+    target = [b"a\n", b"b\n", b"a\n", b"b\n"]
+    deletion = AbsenceClaim(
+        anchor_line=3,
+        content_lines=[b"b\n"],
+        baseline_reference=BaselineReference(
+            after_line=3,
+            after_content=b"a",
+            before_line=5,
+            before_content=b"a",
+            has_before_line=True,
+        ),
+    )
+    ownership = BatchOwnership.from_presence_lines([], [deletion])
+
+    translate_ownership_baseline_references(ownership, source, target)
+
+    reference = deletion.baseline_reference
+    assert reference is not None
+    assert reference.after_line == 1
+    assert reference.before_line == 3
+    assert reference.after_content == b"a\n"
+    assert reference.before_content == b"a\n"

--- a/tests/batch/merge/test_baseline_reference_translation.py
+++ b/tests/batch/merge/test_baseline_reference_translation.py
@@ -115,3 +115,27 @@ def test_translates_leading_deletion_past_target_prefix():
     assert reference.before_line == 3
     assert reference.after_content == b"prefix\n"
     assert reference.before_content == b"tail\n"
+
+
+def test_translates_trailing_deletion_before_target_suffix():
+    source = [b"head\n", b"old\n"]
+    target = [b"head\n", b"old\n", b"suffix\n"]
+    deletion = AbsenceClaim(
+        anchor_line=1,
+        content_lines=[b"old\n"],
+        baseline_reference=BaselineReference(
+            after_line=1,
+            after_content=b"head",
+            has_after_line=True,
+        ),
+    )
+    ownership = BatchOwnership.from_presence_lines([], [deletion])
+
+    translate_ownership_baseline_references(ownership, source, target)
+
+    reference = deletion.baseline_reference
+    assert reference is not None
+    assert reference.after_line == 1
+    assert reference.before_line == 3
+    assert reference.after_content == b"head\n"
+    assert reference.before_content == b"suffix\n"

--- a/tests/batch/merge/test_baseline_reference_translation.py
+++ b/tests/batch/merge/test_baseline_reference_translation.py
@@ -88,3 +88,30 @@ def test_translates_deletion_range_from_shifted_selection_baseline():
     assert reference.before_line == 3
     assert reference.after_content == b"a\n"
     assert reference.before_content == b"a\n"
+
+
+def test_translates_leading_deletion_past_target_prefix():
+    source = [b"old\n", b"tail\n"]
+    target = [b"prefix\n", b"old\n", b"tail\n"]
+    deletion = AbsenceClaim(
+        anchor_line=None,
+        content_lines=[b"old\n"],
+        baseline_reference=BaselineReference(
+            after_line=None,
+            after_content=None,
+            has_after_line=True,
+            before_line=2,
+            before_content=b"tail",
+            has_before_line=True,
+        ),
+    )
+    ownership = BatchOwnership.from_presence_lines([], [deletion])
+
+    translate_ownership_baseline_references(ownership, source, target)
+
+    reference = deletion.baseline_reference
+    assert reference is not None
+    assert reference.after_line == 1
+    assert reference.before_line == 3
+    assert reference.after_content == b"prefix\n"
+    assert reference.before_content == b"tail\n"

--- a/tests/batch/ownership/test_translation.py
+++ b/tests/batch/ownership/test_translation.py
@@ -218,6 +218,11 @@ def test_translate_lines_preserves_deletion_structure():
     assert isinstance(ownership.deletions[1].content_lines, LineBuffer)
     assert list(ownership.deletions[1].content_lines) == [b'del3\n']
     assert ownership.deletions[1].anchor_line == 1  # after source line 1
+    interior_reference = ownership.deletions[1].baseline_reference
+    assert interior_reference.has_after_line is True
+    assert interior_reference.after_line == 3
+    assert interior_reference.after_content == b'context'
+    assert interior_reference.has_before_line is False
     assert ownership.replacement_units == []
 
 

--- a/tests/batch/ownership/test_translation.py
+++ b/tests/batch/ownership/test_translation.py
@@ -209,6 +209,12 @@ def test_translate_lines_preserves_deletion_structure():
     assert isinstance(ownership.deletions[0].content_lines, LineBuffer)
     assert list(ownership.deletions[0].content_lines) == [b'del1\n', b'del2\n']
     assert ownership.deletions[0].anchor_line is None  # before any source line
+    leading_reference = ownership.deletions[0].baseline_reference
+    assert leading_reference.has_after_line is True
+    assert leading_reference.after_line is None
+    assert leading_reference.has_before_line is True
+    assert leading_reference.before_line == 3
+    assert leading_reference.before_content == b'context'
     assert isinstance(ownership.deletions[1].content_lines, LineBuffer)
     assert list(ownership.deletions[1].content_lines) == [b'del3\n']
     assert ownership.deletions[1].anchor_line == 1  # after source line 1
@@ -233,6 +239,36 @@ def test_translate_lines_keeps_file_start_anchor_for_deletion_run():
         b'first\n',
         b'second\n',
     ]
+
+
+def test_translate_lines_splits_deletions_separated_in_old_file():
+    """Omitted unchanged rows still delimit selected deletion claims."""
+    lines = [
+        LineEntry(
+            id=1,
+            kind="-",
+            old_line_number=1,
+            new_line_number=None,
+            text_bytes=b"first",
+            source_line=None,
+        ),
+        LineEntry(
+            id=2,
+            kind="-",
+            old_line_number=3,
+            new_line_number=None,
+            text_bytes=b"third",
+            source_line=1,
+        ),
+    ]
+
+    ownership = translate_lines_to_batch_ownership(lines)
+
+    assert len(ownership.deletions) == 2
+    assert list(ownership.deletions[0].content_lines) == [b"first\n"]
+    assert list(ownership.deletions[1].content_lines) == [b"third\n"]
+    assert ownership.deletions[0].anchor_line is None
+    assert ownership.deletions[1].anchor_line == 1
 
 
 def test_translate_hunk_selection_uses_full_hunk_boundaries():


### PR DESCRIPTION
Removal records constrain repeated-line matching with verified boundary
identities stored outside the Python heap.

Ordinary deletion claims describe the comparison source.
A named batch can persist a different saved baseline. Reusing source
coordinates can identify the wrong repeated range, including at file edges.

This commit series records neighboring removal text and projects complete
deletion references through mapped source-to-baseline pairs.

Deletion ownership now reaches persistence in saved-baseline coordinates,
including ranges that map away from source file edges.