### PR TITLE
batch: Keep realized matching storage in its spool

### DIFF
--- a/src/git_stage_batch/batch/realized_file_content.py
+++ b/src/git_stage_batch/batch/realized_file_content.py
@@ -35,6 +35,7 @@ def build_realized_buffer_from_lines(
                 normalize_line_sequence_endings(base_lines),
                 normalize_line_sequence_endings(batch_source_lines),
                 ownership,
+                spool_dir=spool_dir,
             ),
             detect_line_ending(batch_source_lines),
         ),
@@ -46,6 +47,8 @@ def _stream_realized_content_chunks_from_lines(
     base_lines: Sequence[bytes],
     batch_source_lines: Sequence[bytes],
     ownership: "BatchOwnership",
+    *,
+    spool_dir: str | Path | None = None,
 ) -> Iterator[bytes]:
     """Yield realized batch content chunks from normalized line sequences."""
     resolved = ownership.resolve()
@@ -76,6 +79,7 @@ def _stream_realized_content_chunks_from_lines(
             presence_line_set,
             deletion_claims,
             strict=False,
+            spool_dir=spool_dir,
         )
     except _MergeError:
         baseline_chunks = _baseline_edits.try_apply_baseline_replacement_units(
@@ -84,6 +88,7 @@ def _stream_realized_content_chunks_from_lines(
             ownership,
             presence_line_set,
             deletion_claims,
+            spool_dir=spool_dir,
         )
         if baseline_chunks is None:
             raise

--- a/tests/batch/merge/test_merge.py
+++ b/tests/batch/merge/test_merge.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+import git_stage_batch.batch.merge.baseline_edits as baseline_edits_module
 import git_stage_batch.batch.merge.merge as merge_module
 import git_stage_batch.batch.realization.provenance as provenance_module
 from git_stage_batch.batch.merge.baseline_correspondence import (
@@ -135,6 +136,43 @@ def test_merge_routes_mapping_and_output_storage_to_invocation_spool(
     assert observed_spools == [spool_dir]
     assert provenance_spools
     assert set(provenance_spools) == {spool_dir}
+
+
+def test_baseline_fallback_routes_matching_storage_to_invocation_spool(
+    tmp_path,
+    monkeypatch,
+):
+    """Fallback matching should remain beneath its job scratch directory."""
+    spool_dir = tmp_path / "scratch"
+    spool_dir.mkdir()
+    observed_spools = []
+    original_match_lines = baseline_edits_module._match_lines
+
+    def record_match(*args, **kwargs):
+        observed_spools.append(kwargs.get("spool_dir"))
+        return original_match_lines(*args, **kwargs)
+
+    monkeypatch.setattr(
+        baseline_edits_module,
+        "_match_lines",
+        record_match,
+    )
+    source_lines = [b"one\n", b"two\n"]
+    working_lines = [b"prefix\n", b"two\n"]
+    ownership = BatchOwnership.from_presence_lines(["2"], [])
+
+    fallback_chunks = try_apply_baseline_replacement_units(
+        source_lines,
+        working_lines,
+        ownership,
+        {2},
+        [],
+        spool_dir=spool_dir,
+    )
+
+    assert fallback_chunks is not None
+    assert list(fallback_chunks) == working_lines
+    assert observed_spools == [spool_dir]
 
 
 def merge_batch(

--- a/tests/batch/test_storage_duplication.py
+++ b/tests/batch/test_storage_duplication.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import git_stage_batch.batch.realized_file_content as realized_file_content
 from git_stage_batch.batch.ownership.absence_claims import AbsenceClaim
 from git_stage_batch.batch.ownership.model import BatchOwnership
 from git_stage_batch.batch.ownership.references import BaselineReference
@@ -26,6 +27,42 @@ def _build_realized_content_from_bytes(
         ) as result,
     ):
         return result.to_bytes()
+
+
+def test_build_realized_content_routes_storage_to_invocation_spool(
+    tmp_path,
+    monkeypatch,
+):
+    """Stored-file matching and realization use the caller's scratch path."""
+    spool_dir = tmp_path / "scratch"
+    spool_dir.mkdir()
+    realization_spools = []
+    original_satisfy_constraints = realized_file_content.satisfy_constraints
+
+    def record_realization(*args, **kwargs):
+        realization_spools.append(kwargs.get("spool_dir"))
+        return original_satisfy_constraints(*args, **kwargs)
+
+    monkeypatch.setattr(
+        realized_file_content,
+        "satisfy_constraints",
+        record_realization,
+    )
+
+    ownership = BatchOwnership.from_presence_lines(["2"], [])
+    with (
+        LineBuffer.from_bytes(b"one\n") as base_lines,
+        LineBuffer.from_bytes(b"one\ninserted\n") as source_lines,
+        build_realized_buffer_from_lines(
+            base_lines,
+            source_lines,
+            ownership,
+            spool_dir=spool_dir,
+        ) as result,
+    ):
+        assert result.to_bytes() == b"one\ninserted\n"
+
+    assert realization_spools == [spool_dir]
 
 
 def test_build_realized_content_no_duplication_when_claiming_moved_line():


### PR DESCRIPTION
Deletion references project complete ranges and neighboring identities onto
saved batch baselines.

Nested constraint and fallback matching can allocate mapped buffers.
During realization, ignoring the caller's spool lets temporary storage
escape the worker's selected lifetime and placement.

This commit series threads the caller spool through both nested matchers.
Focused storage assertions pin each boundary.

Realization now keeps every matching buffer in caller-selected scratch
storage.