### PR TITLE
batch: Project replacement origins from live HEAD

### DIFF
--- a/src/git_stage_batch/batch/merge/baseline_reference_translation.py
+++ b/src/git_stage_batch/batch/merge/baseline_reference_translation.py
@@ -14,6 +14,7 @@ from ...core.text_lines import (
     normalize_line_endings,
     normalize_line_sequence_endings,
 )
+from ..line_matching.line_range_view import LineRangeView
 from ..line_matching.line_mapping import LineMapping
 from ..line_matching.match import match_lines
 from ..ownership.model import BatchOwnership
@@ -359,12 +360,72 @@ def _translate_deletion_references(
         )
 
 
+def _translate_replacement_origin_references(
+    ownership: BatchOwnership,
+    source_lines: Sequence[bytes],
+    target_lines: Sequence[bytes],
+    mapping: LineMapping,
+) -> None:
+    """Translate each shared replacement-parent reference exactly once."""
+    with MappedRecordVector(
+        len(ownership.replacement_units),
+        "QQ",
+    ) as origin_units:
+        for unit_index, unit in enumerate(ownership.replacement_units):
+            if unit.origin is not None:
+                origin_units.append((id(unit.origin), unit_index))
+        sort_mapped_records(origin_units)
+
+        previous_origin_id: int | None = None
+        for origin_id, unit_index in origin_units:
+            if origin_id == previous_origin_id:
+                continue
+            previous_origin_id = origin_id
+            origin = ownership.replacement_units[unit_index].origin
+            assert origin is not None
+
+            old_start = origin.old_start
+            old_end = origin.old_end
+            if (
+                type(old_start) is not int
+                or type(old_end) is not int
+                or old_start < 1
+                or old_end < old_start
+                or old_end > len(source_lines)
+            ):
+                origin.baseline_reference = None
+                continue
+
+            content_lines = LineRangeView(
+                source_lines,
+                old_start - 1,
+                old_end,
+            )
+            translated = _translate_removal_reference(
+                origin.baseline_reference,
+                content_lines,
+                source_lines,
+                target_lines,
+                mapping,
+            )
+            origin.baseline_reference = (
+                translated[0] if translated is not None else None
+            )
+
+
 def translate_ownership_baseline_references(
     ownership: BatchOwnership,
     source_baseline_lines: Sequence[bytes],
     target_baseline_lines: Sequence[bytes],
+    *,
+    replacement_origin_source_lines: Sequence[bytes] | None = None,
 ) -> None:
-    """Rebase newly translated ownership references onto a batch baseline."""
+    """Rebase newly translated ownership references onto a batch baseline.
+
+    Ordinary claims use the selected view's comparison base. File-derived
+    replacement origins use live HEAD coordinates and require their separate
+    source sequence when available.
+    """
     with MappedIntVector(
         len(ownership.deletions),
         width=4,
@@ -391,6 +452,7 @@ def translate_ownership_baseline_references(
                 target_lines,
                 mapping,
             )
+
             _translate_deletion_references(
                 ownership,
                 (
@@ -399,6 +461,42 @@ def translate_ownership_baseline_references(
                     if origin_backed[deletion_index] == 0
                 ),
                 source_lines,
+                target_lines,
+                mapping,
+            )
+
+        if (
+            replacement_origin_source_lines is None
+            or not ownership.replacement_units
+        ):
+            return
+
+        normalized_origin_source = normalize_line_sequence_endings(
+            replacement_origin_source_lines
+        )
+        origin_source_sequence = as_acquirable_line_sequence(
+            normalized_origin_source
+        )
+
+        with (
+            origin_source_sequence.acquire_lines() as origin_source_lines,
+            target_sequence.acquire_lines() as target_lines,
+            match_lines(origin_source_lines, target_lines) as mapping,
+        ):
+            _translate_deletion_references(
+                ownership,
+                (
+                    deletion_index
+                    for deletion_index in range(len(ownership.deletions))
+                    if origin_backed[deletion_index] != 0
+                ),
+                origin_source_lines,
+                target_lines,
+                mapping,
+            )
+            _translate_replacement_origin_references(
+                ownership,
+                origin_source_lines,
                 target_lines,
                 mapping,
             )

--- a/src/git_stage_batch/batch/ownership/hunk_replacement_translation.py
+++ b/src/git_stage_batch/batch/ownership/hunk_replacement_translation.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Iterator, Sequence
 from dataclasses import dataclass
 
 from ...core.line_selection import LineRanges
@@ -12,6 +12,7 @@ from .absence_content import AbsenceContentBuilder
 from .absence_claims import AbsenceClaim
 from .claims import LineRangeBuilder
 from .line_entries import (
+    baseline_reference_for_file_line_range,
     baseline_reference_for_old_line_range,
     baseline_reference_for_presence_line,
     replacement_unit_origin_for_line_run,
@@ -33,15 +34,68 @@ class HunkReplacementTranslation:
     consumed_display_ids: set[int]
 
 
+def _close_replacement_run_iterator(
+    iterator: Iterator[ReplacementLineRun],
+) -> None:
+    close = getattr(iterator, "close", None)
+    if close is not None:
+        close()
+
+
 def translate_hunk_replacement_line_runs(
     *,
     hunk_lines: list[LineEntry],
     selected_display_ids: set[int],
-    replacement_line_runs: Sequence[ReplacementLineRun],
+    replacement_line_runs: Iterable[ReplacementLineRun],
     old_line_content: dict[int, bytes],
     hunk_content_view: Sequence[bytes],
+    replacement_origin_line_runs: Iterable[ReplacementLineRun] | None = None,
+    replacement_origin_source_lines: Sequence[bytes] | None = None,
 ) -> HunkReplacementTranslation:
     """Translate selected portions of file-derived replacement runs."""
+    if (
+        replacement_origin_line_runs is None
+    ) != (
+        replacement_origin_source_lines is None
+    ):
+        raise ValueError(
+            "replacement origin runs and source lines must be provided together"
+        )
+
+    replacement_run_iterator = iter(replacement_line_runs)
+    try:
+        origin_run_iterator = iter(
+            ()
+            if replacement_origin_line_runs is None
+            else replacement_origin_line_runs
+        )
+        try:
+            return _translate_hunk_replacement_line_runs(
+                hunk_lines=hunk_lines,
+                selected_display_ids=selected_display_ids,
+                replacement_run_iterator=replacement_run_iterator,
+                old_line_content=old_line_content,
+                hunk_content_view=hunk_content_view,
+                origin_run_iterator=origin_run_iterator,
+                replacement_origin_source_lines=replacement_origin_source_lines,
+            )
+        finally:
+            _close_replacement_run_iterator(origin_run_iterator)
+    finally:
+        _close_replacement_run_iterator(replacement_run_iterator)
+
+
+def _translate_hunk_replacement_line_runs(
+    *,
+    hunk_lines: list[LineEntry],
+    selected_display_ids: set[int],
+    replacement_run_iterator: Iterator[ReplacementLineRun],
+    old_line_content: dict[int, bytes],
+    hunk_content_view: Sequence[bytes],
+    origin_run_iterator: Iterator[ReplacementLineRun],
+    replacement_origin_source_lines: Sequence[bytes] | None,
+) -> HunkReplacementTranslation:
+    """Translate replacement runs whose iterator lifetimes are caller-owned."""
     claimed_source_lines = LineRangeBuilder()
     presence_baseline_references: dict[int, BaselineReference] = {}
     absence_claims: list[AbsenceClaim] = []
@@ -55,26 +109,43 @@ def translate_hunk_replacement_line_runs(
         old_start: int,
         old_end: int,
         origin: ReplacementUnitOrigin | None = None,
+        origin_old_start: int | None = None,
+        origin_old_end: int | None = None,
     ) -> None:
         deletion_anchor: int | None = None
         old_line_seen = False
         selected_source_lines = LineRangeBuilder()
         consumed_ids: list[int] = []
+        use_origin_content = (
+            origin_old_start is not None
+            and origin_old_end is not None
+            and replacement_origin_source_lines is not None
+        )
         with AbsenceContentBuilder() as builder:
             for range_start, range_stop in selected_old_ranges:
                 if not old_line_seen:
                     deletion_anchor = hunk_lines[range_start].source_line
                     old_line_seen = True
-                builder.append_line_range(
-                    hunk_content_view,
-                    range_start,
-                    range_stop,
-                )
+                if not use_origin_content:
+                    builder.append_line_range(
+                        hunk_content_view,
+                        range_start,
+                        range_stop,
+                    )
                 for index in range(range_start, range_stop):
                     old_line = hunk_lines[index]
                     if old_line.id is not None:
                         consumed_ids.append(old_line.id)
 
+            if use_origin_content:
+                assert origin_old_start is not None
+                assert origin_old_end is not None
+                assert replacement_origin_source_lines is not None
+                builder.append_line_range(
+                    replacement_origin_source_lines,
+                    origin_old_start - 1,
+                    origin_old_end,
+                )
             content_lines = builder.finish()
 
         for new_line in selected_new_lines:
@@ -99,10 +170,22 @@ def translate_hunk_replacement_line_runs(
             AbsenceClaim(
                 anchor_line=deletion_anchor,
                 content_lines=content_lines,
-                baseline_reference=baseline_reference_for_old_line_range(
-                    old_start,
-                    old_end,
-                    old_line_content,
+                baseline_reference=(
+                    baseline_reference_for_file_line_range(
+                        origin_old_start,
+                        origin_old_end,
+                        replacement_origin_source_lines,
+                    )
+                    if (
+                        origin_old_start is not None
+                        and origin_old_end is not None
+                        and replacement_origin_source_lines is not None
+                    )
+                    else baseline_reference_for_old_line_range(
+                        old_start,
+                        old_end,
+                        old_line_content,
+                    )
                 ),
             )
         )
@@ -117,11 +200,68 @@ def translate_hunk_replacement_line_runs(
 
     old_cursor = 0
     new_cursor = 0
+    next_origin_run = next(origin_run_iterator, None)
+    cached_origin_run: ReplacementLineRun | None = None
+    cached_origin: ReplacementUnitOrigin | None = None
 
-    for replacement_run in replacement_line_runs:
-        replacement_origin = replacement_unit_origin_for_line_run(
-            replacement_run,
-            old_line_content,
+    def origin_projection_for_new_range(
+        new_start: int,
+        new_end: int,
+    ) -> tuple[ReplacementUnitOrigin, int, int] | None:
+        """Project a displayed replacement range through live HEAD."""
+        nonlocal next_origin_run
+        nonlocal cached_origin_run
+        nonlocal cached_origin
+
+        if replacement_origin_source_lines is None:
+            return None
+
+        while (
+            next_origin_run is not None
+            and next_origin_run.new_end < new_start
+        ):
+            next_origin_run = next(origin_run_iterator, None)
+        origin_run = next_origin_run
+        if (
+            origin_run is None
+            or origin_run.new_start > new_start
+            or new_end > origin_run.new_end
+        ):
+            return None
+
+        if (
+            new_start == origin_run.new_start
+            and new_end == origin_run.new_end
+        ):
+            origin_old_start = origin_run.old_start
+            origin_old_end = origin_run.old_end
+        else:
+            origin_old_count = origin_run.old_end - origin_run.old_start + 1
+            origin_new_count = origin_run.new_end - origin_run.new_start + 1
+            if origin_old_count != origin_new_count:
+                return None
+            origin_old_start = (
+                origin_run.old_start + new_start - origin_run.new_start
+            )
+            origin_old_end = origin_old_start + new_end - new_start
+
+        if cached_origin_run != origin_run:
+            cached_origin_run = origin_run
+            cached_origin = replacement_unit_origin_for_line_run(
+                origin_run,
+                old_file_lines=replacement_origin_source_lines,
+            )
+        assert cached_origin is not None
+        return cached_origin, origin_old_start, origin_old_end
+
+    for replacement_run in replacement_run_iterator:
+        legacy_replacement_origin = (
+            replacement_unit_origin_for_line_run(
+                replacement_run,
+                old_line_content,
+            )
+            if replacement_origin_source_lines is None
+            else None
         )
         old_scan = _hunk_line_ranges.scan_hunk_line_range(
             hunk_lines,
@@ -172,18 +312,43 @@ def translate_hunk_replacement_line_runs(
                     and new_line.id in selected_display_ids
                 )
                 if old_selected and new_selected:
-                    if old_line.old_line_number is None:
+                    if (
+                        old_line.old_line_number is None
+                        or new_line.new_line_number is None
+                    ):
                         continue
+                    origin_projection = origin_projection_for_new_range(
+                        new_line.new_line_number,
+                        new_line.new_line_number,
+                    )
                     add_replacement_unit(
                         ((old_index, old_index + 1),),
                         (new_line,),
                         old_start=old_line.old_line_number,
                         old_end=old_line.old_line_number,
-                        origin=replacement_origin,
+                        origin=(
+                            origin_projection[0]
+                            if origin_projection is not None
+                            else legacy_replacement_origin
+                        ),
+                        origin_old_start=(
+                            origin_projection[1]
+                            if origin_projection is not None
+                            else None
+                        ),
+                        origin_old_end=(
+                            origin_projection[2]
+                            if origin_projection is not None
+                            else None
+                        ),
                     )
             continue
 
         if old_scan.fully_selected and new_scan.fully_selected:
+            origin_projection = origin_projection_for_new_range(
+                replacement_run.new_start,
+                replacement_run.new_end,
+            )
             add_replacement_unit(
                 _hunk_line_ranges.hunk_line_index_ranges_in_range(
                     hunk_lines,
@@ -202,7 +367,21 @@ def translate_hunk_replacement_line_runs(
                 ),
                 old_start=replacement_run.old_start,
                 old_end=replacement_run.old_end,
-                origin=replacement_origin,
+                origin=(
+                    origin_projection[0]
+                    if origin_projection is not None
+                    else legacy_replacement_origin
+                ),
+                origin_old_start=(
+                    origin_projection[1]
+                    if origin_projection is not None
+                    else None
+                ),
+                origin_old_end=(
+                    origin_projection[2]
+                    if origin_projection is not None
+                    else None
+                ),
             )
 
     return HunkReplacementTranslation(

--- a/src/git_stage_batch/batch/ownership/hunk_translation.py
+++ b/src/git_stage_batch/batch/ownership/hunk_translation.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 
 from ...core.line_selection import LineRanges
 from ...core.models import LineEntry
@@ -29,7 +29,9 @@ def translate_hunk_selection_to_batch_ownership(
     hunk_lines: list[LineEntry],
     selected_display_ids: set[int],
     *,
-    replacement_line_runs: list[_ReplacementLineRun] | None = None,
+    replacement_line_runs: Iterable[_ReplacementLineRun] | None = None,
+    replacement_origin_line_runs: Iterable[_ReplacementLineRun] | None = None,
+    replacement_origin_source_lines: Sequence[bytes] | None = None,
     baseline_lines: Sequence[bytes] | None = None,
 ) -> BatchOwnership:
     """Translate selected live-hunk IDs while retaining full-hunk boundaries.
@@ -61,6 +63,8 @@ def translate_hunk_selection_to_batch_ownership(
             replacement_line_runs=replacement_line_runs or (),
             old_line_content=old_line_content,
             hunk_content_view=hunk_content_view,
+            replacement_origin_line_runs=replacement_origin_line_runs,
+            replacement_origin_source_lines=replacement_origin_source_lines,
         )
     )
     claimed_source_lines = LineRangeBuilder()

--- a/src/git_stage_batch/batch/ownership/line_entries.py
+++ b/src/git_stage_batch/batch/ownership/line_entries.py
@@ -76,6 +76,32 @@ def baseline_reference_for_old_line_range(
     )
 
 
+def baseline_reference_for_file_line_range(
+    old_start: int,
+    old_end: int,
+    old_file_lines: Sequence[bytes],
+) -> BaselineReference:
+    """Build a reference for a range in a complete old-file sequence."""
+    after_line = old_start - 1 if old_start > 1 else None
+    before_line = old_end + 1 if old_end < len(old_file_lines) else None
+    return BaselineReference(
+        after_line=after_line,
+        after_content=(
+            bytes(old_file_lines[after_line - 1])
+            if after_line is not None
+            else None
+        ),
+        has_after_line=True,
+        before_line=before_line,
+        before_content=(
+            bytes(old_file_lines[before_line - 1])
+            if before_line is not None
+            else None
+        ),
+        has_before_line=True,
+    )
+
+
 def baseline_reference_for_presence_line(
     line: LineEntry,
 ) -> BaselineReference | None:
@@ -95,17 +121,30 @@ def baseline_reference_for_presence_line(
 
 def replacement_unit_origin_for_line_run(
     replacement_run: ReplacementLineRun,
-    old_line_content: dict[int, bytes],
+    old_line_content: dict[int, bytes] | None = None,
+    *,
+    old_file_lines: Sequence[bytes] | None = None,
 ) -> ReplacementUnitOrigin:
     """Build parent replacement context for a file-derived replacement run."""
+    if old_file_lines is not None:
+        baseline_reference = baseline_reference_for_file_line_range(
+            replacement_run.old_start,
+            replacement_run.old_end,
+            old_file_lines,
+        )
+    elif old_line_content is not None:
+        baseline_reference = baseline_reference_for_old_line_range(
+            replacement_run.old_start,
+            replacement_run.old_end,
+            old_line_content,
+        )
+    else:
+        raise ValueError("replacement origin requires old-file content")
+
     return ReplacementUnitOrigin(
         old_start=replacement_run.old_start,
         old_end=replacement_run.old_end,
         new_start=replacement_run.new_start,
         new_end=replacement_run.new_end,
-        baseline_reference=baseline_reference_for_old_line_range(
-            replacement_run.old_start,
-            replacement_run.old_end,
-            old_line_content,
-        ),
+        baseline_reference=baseline_reference,
     )

--- a/src/git_stage_batch/batch/ownership_update.py
+++ b/src/git_stage_batch/batch/ownership_update.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator, Sequence
+from collections.abc import Iterable, Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
 
@@ -61,7 +61,9 @@ def _translate_selection_to_batch_ownership(
     selected_lines: list,
     *,
     hunk_lines: Sequence[LineEntry] | None = None,
-    replacement_line_runs: Sequence[ReplacementLineRun] | None = None,
+    replacement_line_runs: Iterable[ReplacementLineRun] | None = None,
+    replacement_origin_line_runs: Iterable[ReplacementLineRun] | None = None,
+    replacement_origin_source_lines: Sequence[bytes] | None = None,
 ) -> BatchOwnership:
     """Translate a selection, using full-hunk replacement context when available."""
     selected_ids = {
@@ -76,7 +78,13 @@ def _translate_selection_to_batch_ownership(
                 selected_lines,
             ),
             selected_ids,
-            replacement_line_runs=list(replacement_line_runs),
+            replacement_line_runs=replacement_line_runs,
+            replacement_origin_line_runs=replacement_origin_line_runs,
+            replacement_origin_source_lines=(
+                replacement_origin_source_lines
+                if replacement_origin_line_runs is not None
+                else None
+            ),
         )
 
     return translate_lines_to_batch_ownership(selected_lines)
@@ -90,9 +98,11 @@ def prepare_batch_ownership_update_for_selection(
     selected_lines: list,
     *,
     hunk_lines: Sequence[LineEntry] | None = None,
-    replacement_line_runs: Sequence[ReplacementLineRun] | None = None,
+    replacement_line_runs: Iterable[ReplacementLineRun] | None = None,
+    replacement_origin_line_runs: Iterable[ReplacementLineRun] | None = None,
     reference_source_lines: Sequence[bytes] | None = None,
     reference_target_lines: Sequence[bytes] | None = None,
+    replacement_origin_source_lines: Sequence[bytes] | None = None,
 ) -> PreparedBatchUpdate:
     """Prepare complete ownership update after stale-source handling."""
     refreshed = ensure_batch_source_current_for_selection(
@@ -107,16 +117,26 @@ def prepare_batch_ownership_update_for_selection(
         refreshed.selected_lines,
         hunk_lines=hunk_lines,
         replacement_line_runs=replacement_line_runs,
+        replacement_origin_line_runs=replacement_origin_line_runs,
+        replacement_origin_source_lines=replacement_origin_source_lines,
     )
     if (reference_source_lines is None) != (reference_target_lines is None):
         raise ValueError(
             "reference source and target lines must be provided together"
+        )
+    if (
+        replacement_origin_source_lines is not None
+        and reference_target_lines is None
+    ):
+        raise ValueError(
+            "replacement origin source lines require reference target lines"
         )
     if reference_source_lines is not None and reference_target_lines is not None:
         translate_ownership_baseline_references(
             new_ownership,
             reference_source_lines,
             reference_target_lines,
+            replacement_origin_source_lines=replacement_origin_source_lines,
         )
 
     if refreshed.ownership:
@@ -139,9 +159,11 @@ def acquire_batch_ownership_update_for_selection(
     file_metadata: dict | None,
     selected_lines: list,
     hunk_lines: Sequence[LineEntry] | None = None,
-    replacement_line_runs: Sequence[ReplacementLineRun] | None = None,
+    replacement_line_runs: Iterable[ReplacementLineRun] | None = None,
+    replacement_origin_line_runs: Iterable[ReplacementLineRun] | None = None,
     reference_source_lines: Sequence[bytes] | None = None,
     reference_target_lines: Sequence[bytes] | None = None,
+    replacement_origin_source_lines: Sequence[bytes] | None = None,
 ) -> Iterator[PreparedBatchUpdate]:
     """Acquire existing ownership metadata while preparing a batch update.
 
@@ -157,8 +179,10 @@ def acquire_batch_ownership_update_for_selection(
             selected_lines=selected_lines,
             hunk_lines=hunk_lines,
             replacement_line_runs=replacement_line_runs,
+            replacement_origin_line_runs=replacement_origin_line_runs,
             reference_source_lines=reference_source_lines,
             reference_target_lines=reference_target_lines,
+            replacement_origin_source_lines=replacement_origin_source_lines,
         )
         return
 
@@ -171,6 +195,8 @@ def acquire_batch_ownership_update_for_selection(
             selected_lines=selected_lines,
             hunk_lines=hunk_lines,
             replacement_line_runs=replacement_line_runs,
+            replacement_origin_line_runs=replacement_origin_line_runs,
             reference_source_lines=reference_source_lines,
             reference_target_lines=reference_target_lines,
+            replacement_origin_source_lines=replacement_origin_source_lines,
         )

--- a/src/git_stage_batch/commands/selection/batch_line_updates.py
+++ b/src/git_stage_batch/commands/selection/batch_line_updates.py
@@ -11,7 +11,6 @@ from ...batch.state.query import read_batch_metadata
 from ...batch.state.validation import get_validated_baseline_commit
 from ...batch.text_file_storage import add_file_to_batch
 from ...batch.state.batch_names import batch_exists
-from ...core.buffer import LineBuffer
 from ...data.file_modes import detect_file_mode
 from ...data.session import snapshot_file_if_untracked
 from ...data.selected_change.snapshots import (
@@ -19,7 +18,7 @@ from ...data.selected_change.snapshots import (
 )
 from ...exceptions import exit_with_error
 from ...i18n import _
-from ...utils.repository_buffers import read_git_object_buffer_or_none
+from ...utils.repository_buffers import read_git_object_buffer_or_empty
 
 
 def add_selected_lines_to_batch(
@@ -41,15 +40,23 @@ def add_selected_lines_to_batch(
     metadata = read_batch_metadata(batch_name)
     file_metadata = metadata.get("files", {}).get(file_path)
     baseline_commit = get_validated_baseline_commit(batch_name)
-    batch_baseline_lines = read_git_object_buffer_or_none(
+    batch_baseline_lines = read_git_object_buffer_or_empty(
         f"{baseline_commit}:{file_path}"
     )
-    if batch_baseline_lines is None:
-        batch_baseline_lines = LineBuffer.from_bytes(b"")
+    replacement_origin_source_buffer = (
+        read_git_object_buffer_or_empty(f"HEAD:{file_path}")
+        if hunk_lines is not None and replacement_line_runs
+        else None
+    )
 
     with ExitStack() as ownership_stack:
         reference_target_lines = ownership_stack.enter_context(
             batch_baseline_lines
+        )
+        replacement_origin_source_lines = (
+            ownership_stack.enter_context(replacement_origin_source_buffer)
+            if replacement_origin_source_buffer is not None
+            else None
         )
         try:
             reference_source_lines = ownership_stack.enter_context(
@@ -65,6 +72,9 @@ def add_selected_lines_to_batch(
                     replacement_line_runs=replacement_line_runs,
                     reference_source_lines=reference_source_lines,
                     reference_target_lines=reference_target_lines,
+                    replacement_origin_source_lines=(
+                        replacement_origin_source_lines
+                    ),
                 )
             )
         except ValueError as e:

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -9639,7 +9639,7 @@ def test_batch_hunk_replacement_translation_owns_replacement_runs():
         "_hunk_replacement_translation.translate_hunk_replacement_line_runs"
         in hunk_text
     )
-    assert "for replacement_run in replacement_line_runs" in replacement_text
+    assert "for replacement_run in replacement_run_iterator" in replacement_text
 
 
 def test_batch_ownership_line_entries_own_entry_helpers():
@@ -10488,11 +10488,15 @@ def test_batch_replacement_line_runs_own_public_derivation():
         SRC_ROOT / "batch" / "ownership_update.py": {
             "ReplacementLineRun",
         },
-        SRC_ROOT / "commands" / "selection" / "discard_line_replacement.py": (
-            public_names
-        ),
+        SRC_ROOT / "commands" / "selection" / "discard_line_replacement.py": {
+            "ReplacementLineRun",
+            "derive_replacement_line_runs_from_lines",
+        },
         SRC_ROOT / "commands" / "selection" / "replacement_selection.py": (
-            public_names
+            {
+                "ReplacementLineRun",
+                "derive_replacement_line_runs_from_lines",
+            }
         ),
     }
     violations = []
@@ -11919,6 +11923,7 @@ def test_batch_line_range_view_stays_out_of_realized_entries():
     }
     expected_imports = {
         SRC_ROOT / "batch" / "merge/baseline_correspondence.py": public_names,
+        SRC_ROOT / "batch" / "merge/baseline_reference_translation.py": public_names,
         SRC_ROOT / "batch" / "realization/entry_storage.py": public_names,
     }
     violations = []
@@ -17980,7 +17985,6 @@ def test_discard_line_replacement_stays_in_command_helper():
     }
     old_discard_names = {
         "_add_discard_line_replacement_to_batch",
-        "_derive_live_replacement_line_runs",
         "_command_discard_file_lines_to_batch",
         "_command_discard_lines_to_batch",
         "_command_discard_lines_to_batch_as",

--- a/tests/batch/merge/test_baseline_reference_translation.py
+++ b/tests/batch/merge/test_baseline_reference_translation.py
@@ -6,6 +6,10 @@ from git_stage_batch.batch.merge.baseline_reference_translation import (
 from git_stage_batch.batch.ownership.absence_claims import AbsenceClaim
 from git_stage_batch.batch.ownership.model import BatchOwnership
 from git_stage_batch.batch.ownership.references import BaselineReference
+from git_stage_batch.batch.ownership.replacement_units import (
+    ReplacementUnit,
+    ReplacementUnitOrigin,
+)
 
 
 def test_translates_presence_gap_from_shifted_selection_baseline():
@@ -139,3 +143,63 @@ def test_translates_trailing_deletion_before_target_suffix():
     assert reference.before_line == 3
     assert reference.after_content == b"head\n"
     assert reference.before_content == b"suffix\n"
+
+
+def test_translates_replacement_origin_from_live_head_to_batch_baseline():
+    head = [b"section2\n", b"x\n", b"old\n", b"y\n", b"end\n"]
+    selection_source = [b"staged\n", *head]
+    target = [
+        b"section1\n",
+        b"x\n",
+        b"old\n",
+        b"y\n",
+        b"section2\n",
+        b"x\n",
+        b"old\n",
+        b"y\n",
+        b"end\n",
+    ]
+    reference = BaselineReference(
+        after_line=2,
+        after_content=b"x",
+        before_line=4,
+        before_content=b"y",
+        has_before_line=True,
+    )
+    deletion = AbsenceClaim(
+        anchor_line=2,
+        content_lines=[b"old\n"],
+        baseline_reference=reference,
+    )
+    origin = ReplacementUnitOrigin(
+        old_start=3,
+        old_end=3,
+        new_start=3,
+        new_end=3,
+        baseline_reference=reference,
+    )
+    ownership = BatchOwnership.from_presence_lines(
+        ["3"],
+        [deletion],
+        replacement_units=[
+            ReplacementUnit(
+                presence_lines=["3"],
+                deletion_indices=[0],
+                origin=origin,
+            )
+        ],
+    )
+
+    translate_ownership_baseline_references(
+        ownership,
+        selection_source,
+        target,
+        replacement_origin_source_lines=head,
+    )
+
+    assert deletion.baseline_reference is not None
+    assert deletion.baseline_reference.after_line == 6
+    assert deletion.baseline_reference.before_line == 8
+    assert origin.baseline_reference is not None
+    assert origin.baseline_reference.after_line == 6
+    assert origin.baseline_reference.before_line == 8

--- a/tests/batch/ownership/test_hunk_replacement_translation.py
+++ b/tests/batch/ownership/test_hunk_replacement_translation.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from git_stage_batch.batch.ownership.hunk_replacement_translation import (
     translate_hunk_replacement_line_runs,
 )
@@ -34,6 +36,59 @@ def test_translate_hunk_replacement_line_runs_returns_empty_result():
     assert result.absence_claims == []
     assert result.replacement_units == []
     assert result.consumed_display_ids == set()
+
+
+def test_translate_hunk_replacement_line_runs_closes_inputs_on_error():
+    """Translation failures must release both streamed comparison inputs."""
+
+    class ClosableRuns:
+        def __init__(self, runs):
+            self._runs = iter(runs)
+            self.closed = False
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            return next(self._runs)
+
+        def close(self):
+            self.closed = True
+
+    displayed_runs = ClosableRuns((ReplacementLineRun(1, 1, 1, 1),))
+    origin_runs = ClosableRuns((ReplacementLineRun(1, 1, 1, 1),))
+    lines = [
+        LineEntry(
+            id=1,
+            kind="-",
+            old_line_number=1,
+            new_line_number=None,
+            text_bytes=b"old",
+            source_line=None,
+        ),
+        LineEntry(
+            id=2,
+            kind="+",
+            old_line_number=None,
+            new_line_number=1,
+            text_bytes=b"new",
+            source_line=None,
+        ),
+    ]
+
+    with pytest.raises(ValueError, match="source_line is None"):
+        translate_hunk_replacement_line_runs(
+            hunk_lines=lines,
+            selected_display_ids={1, 2},
+            replacement_line_runs=displayed_runs,
+            old_line_content=old_line_content_by_number(lines),
+            hunk_content_view=LineEntryContentSequence(lines),
+            replacement_origin_line_runs=origin_runs,
+            replacement_origin_source_lines=[b"old\n"],
+        )
+
+    assert displayed_runs.closed is True
+    assert origin_runs.closed is True
 
 
 def test_translate_hunk_replacement_line_runs_builds_replacement_result():
@@ -101,6 +156,74 @@ def test_translate_hunk_replacement_line_runs_builds_replacement_result():
     assert result.replacement_units[0].origin.new_start == 1
     assert result.replacement_units[0].origin.new_end == 2
     assert result.consumed_display_ids == {1, 3}
+
+
+def test_translate_hunk_replacement_uses_origin_baseline_content():
+    """Displayed index bytes must not become persistent replacement removals."""
+    lines = [
+        LineEntry(
+            id=1,
+            kind="-",
+            old_line_number=3,
+            new_line_number=None,
+            text_bytes=b"staged-one",
+            source_line=1,
+        ),
+        LineEntry(
+            id=2,
+            kind="-",
+            old_line_number=4,
+            new_line_number=None,
+            text_bytes=b"staged-two",
+            source_line=1,
+        ),
+        LineEntry(
+            id=3,
+            kind="+",
+            old_line_number=None,
+            new_line_number=3,
+            text_bytes=b"work-one",
+            source_line=3,
+        ),
+        LineEntry(
+            id=4,
+            kind="+",
+            old_line_number=None,
+            new_line_number=4,
+            text_bytes=b"work-two",
+            source_line=4,
+        ),
+    ]
+    displayed_run = ReplacementLineRun(
+        old_start=3,
+        old_end=4,
+        new_start=3,
+        new_end=4,
+    )
+    origin_run = ReplacementLineRun(
+        old_start=2,
+        old_end=3,
+        new_start=3,
+        new_end=4,
+    )
+    head_lines = [b"head\n", b"orig-one\n", b"orig-two\n", b"tail\n"]
+
+    result = translate_hunk_replacement_line_runs(
+        hunk_lines=lines,
+        selected_display_ids={1, 3},
+        replacement_line_runs=(displayed_run,),
+        old_line_content=old_line_content_by_number(lines),
+        hunk_content_view=LineEntryContentSequence(lines),
+        replacement_origin_line_runs=(origin_run,),
+        replacement_origin_source_lines=head_lines,
+    )
+
+    assert list(result.absence_claims[0].content_lines) == [b"orig-one\n"]
+    reference = result.absence_claims[0].baseline_reference
+    assert reference is not None
+    assert reference.after_line == 1
+    assert reference.before_line == 3
+    assert reference.before_content == b"orig-two\n"
 
 
 def test_translate_hunk_replacement_line_runs_keeps_large_ranges_compact(

--- a/tests/functional/test_include_line_transient_staging.py
+++ b/tests/functional/test_include_line_transient_staging.py
@@ -255,6 +255,46 @@ def test_discard_translates_repeated_boundary_from_staged_index(functional_repo)
     )
 
 
+def test_discard_translates_deletion_position_from_staged_index(functional_repo):
+    """Saved deletions use the batch baseline, not shifted index coordinates."""
+    _commit_file(functional_repo, "file.txt", "a\nb\na\nb\n")
+    (functional_repo / "file.txt").write_text(
+        "staged-one\n"
+        "staged-two\n"
+        "a\n"
+        "b\n"
+        "a\n"
+        "b\n"
+    )
+    subprocess.run(
+        ["git", "add", "file.txt"],
+        check=True,
+        cwd=functional_repo,
+        capture_output=True,
+    )
+    (functional_repo / "file.txt").write_text(
+        "staged-one\n"
+        "staged-two\n"
+        "a\n"
+        "a\n"
+        "b\n"
+    )
+
+    git_stage_batch("start", "--no-auto-advance")
+    result = git_stage_batch(
+        "discard",
+        "--to",
+        "saved",
+        "--file",
+        "file.txt",
+        "--line",
+        "1",
+        "--no-auto-advance",
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert _batch_content(functional_repo, "saved", "file.txt") == "a\na\nb\n"
 def test_include_to_batch_translates_position_from_staged_index(functional_repo):
     """Persistent includes project index-relative gaps onto the batch baseline."""
     _commit_file(functional_repo, "file.txt", "a\nb\nb\nb\nb\n")

--- a/tests/functional/test_include_line_transient_staging.py
+++ b/tests/functional/test_include_line_transient_staging.py
@@ -295,6 +295,69 @@ def test_discard_translates_deletion_position_from_staged_index(functional_repo)
 
     assert result.returncode == 0, result.stderr
     assert _batch_content(functional_repo, "saved", "file.txt") == "a\na\nb\n"
+
+
+def test_discard_translates_replacement_origin_for_older_batch(functional_repo):
+    """Replacement fallback uses the persisted batch baseline coordinates."""
+    original = (
+        "section1\n"
+        "x\n"
+        "old\n"
+        "y\n"
+        "section2\n"
+        "x\n"
+        "old\n"
+        "y\n"
+        "end\n"
+    )
+    _commit_file(functional_repo, "file.txt", original)
+    git_stage_batch("new", "saved")
+
+    (functional_repo / "file.txt").write_text(
+        "section2\n"
+        "x\n"
+        "old\n"
+        "y\n"
+        "end\n"
+    )
+    subprocess.run(
+        ["git", "add", "file.txt"],
+        check=True,
+        cwd=functional_repo,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "Remove first section"],
+        check=True,
+        cwd=functional_repo,
+        capture_output=True,
+    )
+    (functional_repo / "file.txt").write_text(
+        "section2\n"
+        "x\n"
+        "NEW\n"
+        "y\n"
+        "end\n"
+    )
+
+    git_stage_batch("start", "--no-auto-advance")
+    result = git_stage_batch(
+        "discard",
+        "--to",
+        "saved",
+        "--line",
+        "1-2",
+        "--no-auto-advance",
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert _batch_content(functional_repo, "saved", "file.txt") == original.replace(
+        "section2\nx\nold\n",
+        "section2\nx\nNEW\n",
+    )
+
+
 def test_include_to_batch_translates_position_from_staged_index(functional_repo):
     """Persistent includes project index-relative gaps onto the batch baseline."""
     _commit_file(functional_repo, "file.txt", "a\nb\nb\nb\nb\n")


### PR DESCRIPTION
Deletion ownership reaches saved baselines, including references mapped
away from source file edges.

Replacement units derive original ranges from live HEAD.
Those ranges can differ from the selected comparison and batch baseline.
Using the wrong source can link a deletion and its origin to different
repeated blocks.

This commit series projects shared replacement origins through live HEAD.
It rewrites every linked removal against the saved batch baseline.

Replacement-backed removals now survive preparation and realization
in saved-baseline coordinates.