### PR TITLE
batch: Validate saved-baseline fallback mappings

### DIFF
--- a/src/git_stage_batch/batch/merge/baseline_edits.py
+++ b/src/git_stage_batch/batch/merge/baseline_edits.py
@@ -346,30 +346,47 @@ def _replacement_edit_from_parent_offset(
     if old_line_count != new_line_count:
         return None
 
-    relative_offsets = [
-        claimed_line - new_start for claimed_line in sorted(claimed_lines)
-    ]
-    if (
-        not relative_offsets
-        or relative_offsets[0] < 0
-        or relative_offsets[-1] >= new_line_count
-    ):
+    if not claimed_lines:
         return None
-    if relative_offsets != list(
-        range(relative_offsets[0], relative_offsets[0] + len(relative_offsets))
+
+    first_claimed_line = claimed_lines[0]
+    if any(
+        claimed_line != first_claimed_line + offset
+        for offset, claimed_line in enumerate(claimed_lines)
     ):
         return None
 
     forbidden_sequence = normalize_line_sequence_endings(claim.content_lines)
-    if len(forbidden_sequence) != len(relative_offsets):
+    if len(forbidden_sequence) != len(claimed_lines):
         return None
 
     parent_bounds = _replacement_origin_absence_bounds(origin, working_lines)
     if parent_bounds is None:
         return None
 
+    claim_reference = claim.baseline_reference
+    origin_reference = getattr(origin, "baseline_reference", None)
+    if (
+        claim_reference is not None
+        and getattr(claim_reference, "has_after_line", False)
+        and origin_reference is not None
+        and getattr(origin_reference, "has_after_line", False)
+    ):
+        relative_offset = (
+            (getattr(claim_reference, "after_line", None) or 0)
+            - (getattr(origin_reference, "after_line", None) or 0)
+        )
+    else:
+        relative_offset = first_claimed_line - new_start
+
+    if (
+        relative_offset < 0
+        or relative_offset + len(claimed_lines) > new_line_count
+    ):
+        return None
+
     parent_start, parent_end = parent_bounds
-    start = parent_start + relative_offsets[0]
+    start = parent_start + relative_offset
     end = start + len(forbidden_sequence)
     if start < parent_start or end > parent_end:
         return None

--- a/src/git_stage_batch/batch/merge/baseline_edits.py
+++ b/src/git_stage_batch/batch/merge/baseline_edits.py
@@ -518,6 +518,45 @@ def _has_complete_baseline_references(
     return bool(presence_line_set or deletion_claims)
 
 
+def _all_deletions_are_already_absent(
+    deletion_claims: Sequence[AbsenceClaim],
+    working_lines: Sequence[bytes],
+) -> bool:
+    """Return whether baseline and source anchors prove removals satisfied."""
+    for claim in deletion_claims:
+        if not claim.content_lines:
+            continue
+        if _baseline_removal_edit(claim, working_lines) is not None:
+            return False
+
+        forbidden_sequence = normalize_line_sequence_endings(
+            claim.content_lines
+        )
+        if len(forbidden_sequence) > len(working_lines):
+            continue
+
+        anchor_line = claim.anchor_line
+        if anchor_line is None:
+            source_position = 0
+        elif (
+            type(anchor_line) is not int
+            or anchor_line < 1
+            or anchor_line > len(working_lines)
+        ):
+            return False
+        else:
+            source_position = anchor_line
+
+        if _line_slice_matches(
+            working_lines,
+            source_position,
+            forbidden_sequence,
+        ):
+            return False
+
+    return True
+
+
 def try_apply_baseline_replacement_units(
     source_lines: Sequence[bytes],
     working_lines: Sequence[bytes],
@@ -546,6 +585,9 @@ def try_apply_baseline_replacement_units(
         ownership,
         presence_line_set,
         deletion_claims,
+    ) and _all_deletions_are_already_absent(
+        deletion_claims,
+        working_lines,
     ):
         return iter(working_lines)
 

--- a/src/git_stage_batch/batch/merge/baseline_edits.py
+++ b/src/git_stage_batch/batch/merge/baseline_edits.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator, Sequence
+from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from ...core.line_selection import LineRanges, LineSelection, coerce_line_ranges
-from ...core.mapped_storage import sort_mapped_records
+from ...core.mapped_storage import MappedRecordVector, sort_mapped_records
 from ...exceptions import MergeError as _MergeError
 from ...i18n import _
 from ...core.text_lines import normalize_line_sequence_endings
@@ -275,6 +275,355 @@ def _live_removal_boundary_is_unique(
     return True
 
 
+def _insertion_boundary_identity_matches_at(
+    reference: Any,
+    target_lines: Sequence[bytes],
+    position: int,
+) -> bool:
+    """Return whether one insertion position has the reference's full identity."""
+    if reference is None or not getattr(reference, "has_after_line", False):
+        return False
+
+    after_line = getattr(reference, "after_line", None)
+    if after_line is None:
+        if position != 0:
+            return False
+    else:
+        after_content = getattr(reference, "after_content", None)
+        if (
+            position == 0
+            or after_content is None
+            or _reference_line_payload(target_lines[position - 1])
+            != _reference_line_payload(after_content)
+        ):
+            return False
+
+    if getattr(reference, "has_before_line", False):
+        before_line = getattr(reference, "before_line", None)
+        if before_line is None:
+            return position == len(target_lines)
+        before_content = getattr(reference, "before_content", None)
+        return (
+            position < len(target_lines)
+            and before_content is not None
+            and _reference_line_payload(target_lines[position])
+            == _reference_line_payload(before_content)
+        )
+
+    return position == len(target_lines)
+
+
+def _live_insertion_boundary_is_unique(
+    reference: Any,
+    target_lines: Sequence[bytes],
+    expected_position: int,
+    occurrence_index: LinePayloadOccurrenceIndex,
+) -> bool:
+    """Require an insertion reference to identify one live target boundary."""
+    if not _insertion_boundary_identity_matches_at(
+        reference,
+        target_lines,
+        expected_position,
+    ):
+        return False
+
+    after_line = getattr(reference, "after_line", None)
+    before_line = getattr(reference, "before_line", None)
+    if after_line is None or (
+        getattr(reference, "has_before_line", False)
+        and before_line is None
+    ):
+        return True
+
+    rarest_content: bytes | None = None
+    rarest_boundary_delta = 0
+    rarest_count = len(target_lines) + 1
+
+    def consider(content: bytes | None, boundary_delta: int) -> None:
+        nonlocal rarest_content
+        nonlocal rarest_boundary_delta
+        nonlocal rarest_count
+        if content is None:
+            return
+        count = occurrence_index.occurrence_count(content)
+        if count < rarest_count:
+            rarest_content = content
+            rarest_boundary_delta = boundary_delta
+            rarest_count = count
+
+    if after_line is not None:
+        consider(getattr(reference, "after_content", None), 1)
+    if getattr(reference, "has_before_line", False) and before_line is not None:
+        consider(getattr(reference, "before_content", None), 0)
+
+    if rarest_content is None or rarest_count == 0:
+        return False
+    if rarest_count == 1:
+        return True
+
+    for line_index in occurrence_index.matching_line_indexes(rarest_content):
+        position = line_index + rarest_boundary_delta
+        if (
+            position < 0
+            or position > len(target_lines)
+            or position == expected_position
+        ):
+            continue
+        if _insertion_boundary_identity_matches_at(
+            reference,
+            target_lines,
+            position,
+        ):
+            return False
+    return True
+
+
+def _replacement_origin_boundary_identity_matches_at(
+    origin: Any,
+    target_lines: Sequence[bytes],
+    position: int,
+) -> bool:
+    """Return whether one target span has the replacement parent's identity."""
+    reference = getattr(origin, "baseline_reference", None)
+    old_line_count = getattr(origin, "old_line_count", None)
+    if (
+        reference is None
+        or not getattr(reference, "has_after_line", False)
+        or type(old_line_count) is not int
+        or old_line_count <= 0
+        or position < 0
+        or position + old_line_count > len(target_lines)
+    ):
+        return False
+
+    after_line = getattr(reference, "after_line", None)
+    if after_line is None:
+        if position != 0:
+            return False
+    else:
+        after_content = getattr(reference, "after_content", None)
+        if (
+            position == 0
+            or after_content is None
+            or _reference_line_payload(target_lines[position - 1])
+            != _reference_line_payload(after_content)
+        ):
+            return False
+
+    if not getattr(reference, "has_before_line", False):
+        return True
+
+    before_line = getattr(reference, "before_line", None)
+    before_position = position + old_line_count
+    if before_line is None:
+        return before_position == len(target_lines)
+    before_content = getattr(reference, "before_content", None)
+    return (
+        before_position < len(target_lines)
+        and before_content is not None
+        and _reference_line_payload(target_lines[before_position])
+        == _reference_line_payload(before_content)
+    )
+
+
+def _live_replacement_origin_boundary_is_unique(
+    origin: Any,
+    target_lines: Sequence[bytes],
+    expected_position: int,
+    occurrence_index: LinePayloadOccurrenceIndex,
+) -> bool:
+    """Require a replacement parent to identify one live target span."""
+    if not _replacement_origin_boundary_identity_matches_at(
+        origin,
+        target_lines,
+        expected_position,
+    ):
+        return False
+
+    reference = origin.baseline_reference
+    after_line = reference.after_line
+    before_line = reference.before_line
+    if after_line is None or (
+        reference.has_before_line
+        and before_line is None
+    ):
+        return True
+
+    rarest_content: bytes | None = None
+    rarest_boundary_delta = 0
+    rarest_count = len(target_lines) + 1
+
+    def consider(content: bytes | None, boundary_delta: int) -> None:
+        nonlocal rarest_content
+        nonlocal rarest_boundary_delta
+        nonlocal rarest_count
+        if content is None:
+            return
+        count = occurrence_index.occurrence_count(content)
+        if count < rarest_count:
+            rarest_content = content
+            rarest_boundary_delta = boundary_delta
+            rarest_count = count
+
+    if after_line is not None:
+        consider(reference.after_content, 1)
+    if reference.has_before_line and before_line is not None:
+        consider(reference.before_content, -origin.old_line_count)
+
+    if rarest_content is None or rarest_count == 0:
+        return False
+    if rarest_count == 1:
+        return True
+
+    last_position = len(target_lines) - origin.old_line_count
+    for line_index in occurrence_index.matching_line_indexes(rarest_content):
+        position = line_index + rarest_boundary_delta
+        if (
+            position < 0
+            or position > last_position
+            or position == expected_position
+        ):
+            continue
+        if _replacement_origin_boundary_identity_matches_at(
+            origin,
+            target_lines,
+            position,
+        ):
+            return False
+    return True
+
+
+def _live_coordinate_edits_are_safe(
+    ownership: BatchOwnership,
+    working_lines: Sequence[bytes],
+    deletion_claims: Sequence[AbsenceClaim],
+    deletion_edit_bounds: Sequence[tuple[int, ...]],
+    insertion_groups: Mapping[int, Sequence[int]] | None,
+    claimed_line_references: Mapping[int, Any],
+    *,
+    spool_dir: str | Path | None,
+) -> bool:
+    """Return whether every coordinate edit has one live target boundary."""
+    if not deletion_claims and not insertion_groups:
+        return True
+
+    with MatcherWorkspace(spool_dir=spool_dir) as workspace:
+        occurrence_index = LinePayloadOccurrenceIndex(
+            workspace,
+            working_lines,
+        )
+        replacement_reference_count = sum(
+            len(unit.deletion_indices)
+            for unit in ownership.replacement_units
+        )
+        replacement_units_by_deletion = workspace.record_vector(
+            replacement_reference_count,
+            "QQ",
+        )
+        for unit_index, unit in enumerate(ownership.replacement_units):
+            for deletion_index in unit.deletion_indices:
+                if (
+                    type(deletion_index) is int
+                    and 0 <= deletion_index < len(deletion_claims)
+                ):
+                    replacement_units_by_deletion.append((
+                        deletion_index,
+                        unit_index,
+                    ))
+        sort_mapped_records(replacement_units_by_deletion)
+
+        replacement_reference_index = 0
+        for deletion_index, claim in enumerate(deletion_claims):
+            (
+                has_actual_bounds,
+                actual_start,
+                actual_end,
+                coordinate_was_reviewed,
+            ) = (
+                deletion_edit_bounds[deletion_index]
+            )
+            if not has_actual_bounds:
+                return False
+            actual_bounds = (actual_start, actual_end)
+            while (
+                replacement_reference_index
+                < len(replacement_units_by_deletion)
+                and replacement_units_by_deletion[
+                    replacement_reference_index
+                ][0] < deletion_index
+            ):
+                replacement_reference_index += 1
+            next_replacement_reference = replacement_reference_index
+            while (
+                next_replacement_reference
+                < len(replacement_units_by_deletion)
+                and replacement_units_by_deletion[
+                    next_replacement_reference
+                ][0] == deletion_index
+            ):
+                next_replacement_reference += 1
+            if coordinate_was_reviewed:
+                replacement_reference_index = next_replacement_reference
+                continue
+
+            removal_edit = _baseline_removal_edit(claim, working_lines)
+            if (
+                removal_edit is not None
+                and actual_bounds == removal_edit[:2]
+                and _live_removal_boundary_is_unique(
+                    claim,
+                    working_lines,
+                    removal_edit[0],
+                    occurrence_index,
+                )
+            ):
+                replacement_reference_index = next_replacement_reference
+                continue
+
+            origin_is_safe = False
+            for reference_index in range(
+                replacement_reference_index,
+                next_replacement_reference,
+            ):
+                unit_index = replacement_units_by_deletion[reference_index][1]
+                unit = ownership.replacement_units[unit_index]
+                origin = getattr(unit, "origin", None)
+                parent_bounds = _replacement_origin_absence_bounds(
+                    origin,
+                    working_lines,
+                )
+                if (
+                    parent_bounds is not None
+                    and parent_bounds[0] <= actual_bounds[0]
+                    and actual_bounds[1] <= parent_bounds[1]
+                    and _live_replacement_origin_boundary_is_unique(
+                        origin,
+                        working_lines,
+                        parent_bounds[0],
+                        occurrence_index,
+                    )
+                ):
+                    origin_is_safe = True
+                    break
+            if not origin_is_safe:
+                return False
+            replacement_reference_index = next_replacement_reference
+
+        if insertion_groups is not None:
+            for position, claimed_lines in insertion_groups.items():
+                for claimed_line in claimed_lines:
+                    reference = claimed_line_references.get(claimed_line)
+                    if not _live_insertion_boundary_is_unique(
+                        reference,
+                        working_lines,
+                        position,
+                        occurrence_index,
+                    ):
+                        return False
+
+    return True
+
+
 def _replacement_origin_absence_bounds(
     origin: Any,
     working_lines: Sequence[bytes],
@@ -442,8 +791,16 @@ def _replacement_baseline_edit(
     resolution: _MergeResolution | None,
     *,
     max_resolution_choices: int,
-) -> _BaselineLineEdit | None:
+) -> tuple[_BaselineLineEdit, bool] | None:
     origin = getattr(unit, "origin", None)
+    guarded_edit = _replacement_edit_with_origin_guard(
+        claim,
+        origin,
+        working_lines,
+    )
+    if guarded_edit is not None:
+        return guarded_edit, False
+
     offset_edit = _replacement_edit_from_parent_offset(
         claim,
         origin,
@@ -451,17 +808,9 @@ def _replacement_baseline_edit(
         working_lines,
     )
     if offset_edit is not None:
-        return offset_edit
+        return offset_edit, False
 
-    guarded_edit = _replacement_edit_with_origin_guard(
-        claim,
-        origin,
-        working_lines,
-    )
-    if guarded_edit is not None:
-        return guarded_edit
-
-    return _replacement_edit_from_origin_resolution(
+    reviewed_edit = _replacement_edit_from_origin_resolution(
         claim,
         unit_index,
         unit,
@@ -470,6 +819,9 @@ def _replacement_baseline_edit(
         resolution,
         max_results=max_resolution_choices,
     )
+    if reviewed_edit is None:
+        return None
+    return reviewed_edit, True
 
 
 def _apply_non_overlapping_baseline_edits(
@@ -566,6 +918,7 @@ def try_apply_baseline_replacement_units(
     *,
     resolution: _MergeResolution | None = None,
     max_resolution_choices: int = _DEFAULT_RESOLUTION_CHOICE_LIMIT,
+    trust_baseline_coordinates: bool = False,
     spool_dir: str | Path | None = None,
 ) -> Iterator[bytes] | None:
     """Apply baseline-coordinate edits when structural source anchors fail.
@@ -591,6 +944,40 @@ def try_apply_baseline_replacement_units(
     ):
         return iter(working_lines)
 
+    with MappedRecordVector(
+        len(deletion_claims),
+        "QQQQ",
+        length=len(deletion_claims),
+        spool_dir=spool_dir,
+    ) as deletion_edit_bounds:
+        return _try_apply_baseline_replacement_units(
+            source_lines,
+            working_lines,
+            ownership,
+            presence_line_set,
+            deletion_claims,
+            deletion_edit_bounds,
+            resolution=resolution,
+            max_resolution_choices=max_resolution_choices,
+            trust_baseline_coordinates=trust_baseline_coordinates,
+            spool_dir=spool_dir,
+        )
+
+
+def _try_apply_baseline_replacement_units(
+    source_lines: Sequence[bytes],
+    working_lines: Sequence[bytes],
+    ownership: BatchOwnership,
+    presence_line_set: LineSelection,
+    deletion_claims: list[AbsenceClaim],
+    deletion_edit_bounds: MappedRecordVector,
+    *,
+    resolution: _MergeResolution | None,
+    max_resolution_choices: int,
+    trust_baseline_coordinates: bool,
+    spool_dir: str | Path | None,
+) -> Iterator[bytes] | None:
+    """Build and validate exact-coordinate fallback edits."""
     replacement_units = getattr(ownership, "replacement_units", [])
     edits: list[_BaselineLineEdit] = []
     unit_claimed_lines = LineRanges.empty()
@@ -611,7 +998,7 @@ def try_apply_baseline_replacement_units(
                 return None
             replacement_lines.append(source_lines[claimed_line - 1])
 
-        removal_edit = _replacement_baseline_edit(
+        replacement_edit = _replacement_baseline_edit(
             deletion_claims[deletion_index],
             unit_index,
             unit,
@@ -620,10 +1007,17 @@ def try_apply_baseline_replacement_units(
             resolution,
             max_resolution_choices=max_resolution_choices,
         )
-        if removal_edit is None:
+        if replacement_edit is None:
             return None
+        removal_edit, coordinate_was_reviewed = replacement_edit
         start, end, _removed_lines = removal_edit
         edits.append((start, end, replacement_lines))
+        deletion_edit_bounds[deletion_index] = (
+            1,
+            start,
+            end,
+            coordinate_was_reviewed,
+        )
         unit_claimed_lines = unit_claimed_lines.union(claimed_selection)
         unit_deletion_indices.add(deletion_index)
 
@@ -634,12 +1028,19 @@ def try_apply_baseline_replacement_units(
         if removal_edit is None:
             return None
         edits.append(removal_edit)
+        deletion_edit_bounds[deletion_index] = (
+            1,
+            removal_edit[0],
+            removal_edit[1],
+            0,
+        )
 
     presence_lines = coerce_line_ranges(presence_line_set)
     remaining_claimed_lines = presence_lines.difference(unit_claimed_lines)
     claimed_line_references = ownership.presence_baseline_references()
+    grouped_insertions: dict[int, list[int]] | None = None
     if remaining_claimed_lines:
-        grouped_insertions: dict[int, list[int]] = {}
+        grouped_insertions = {}
         has_mapped_claimed_lines = False
         for claimed_line in sorted(remaining_claimed_lines):
             if claimed_line < 1 or claimed_line > len(source_lines):
@@ -680,7 +1081,14 @@ def try_apply_baseline_replacement_units(
             insertion_lines = [
                 source_lines[claimed_line - 1] for claimed_line in claimed_lines
             ]
-            if _line_slice_matches(working_lines, position, insertion_lines):
+            if (
+                not trust_baseline_coordinates
+                and _line_slice_matches(
+                    working_lines,
+                    position,
+                    insertion_lines,
+                )
+            ):
                 continue
             edits.append(
                 (
@@ -691,6 +1099,19 @@ def try_apply_baseline_replacement_units(
             )
 
     if unit_claimed_lines.union(remaining_claimed_lines) != presence_lines:
+        return None
+    if (
+        not trust_baseline_coordinates
+        and not _live_coordinate_edits_are_safe(
+            ownership,
+            working_lines,
+            deletion_claims,
+            deletion_edit_bounds,
+            grouped_insertions,
+            claimed_line_references,
+            spool_dir=spool_dir,
+        )
+    ):
         return None
 
     return _apply_non_overlapping_baseline_edits(working_lines, edits)

--- a/src/git_stage_batch/batch/merge/merge.py
+++ b/src/git_stage_batch/batch/merge/merge.py
@@ -171,13 +171,20 @@ def _merge_batch_acquired_line_chunks(
 
     owned_mapping: LineMapping | None = None
     mapping = source_to_working_mapping
-    if mapping is None:
-        owned_mapping = match_lines(
-            source_lines,
-            working_lines,
-            spool_dir=spool_dir,
-        )
-        mapping = owned_mapping
+    with _baseline_edits.acquire_deletion_anchor_pairs_for_target(
+        source_lines,
+        working_lines,
+        deletion_claims,
+        spool_dir=spool_dir,
+    ) as deletion_anchor_pairs:
+        if mapping is None or deletion_anchor_pairs:
+            owned_mapping = match_lines(
+                source_lines,
+                working_lines,
+                anchor_pairs=deletion_anchor_pairs,
+                spool_dir=spool_dir,
+            )
+            mapping = owned_mapping
     try:
         if _baseline_edits.has_missing_origin_replacement_claims(
             ownership,

--- a/src/git_stage_batch/batch/realized_file_content.py
+++ b/src/git_stage_batch/batch/realized_file_content.py
@@ -56,22 +56,18 @@ def _stream_realized_content_chunks_from_lines(
     presence_line_set = resolved.presence_line_set
     deletion_claims = resolved.deletion_claims
 
-    if any(
-        claim.anchor_line is None
-        and claim.baseline_reference is not None
-        and claim.baseline_reference.after_line is not None
-        for claim in deletion_claims
-    ):
-        baseline_chunks = _baseline_edits.try_apply_baseline_replacement_units(
-            batch_source_lines,
-            base_lines,
-            ownership,
-            presence_line_set,
-            deletion_claims,
-        )
-        if baseline_chunks is not None:
-            yield from baseline_chunks
-            return
+    baseline_chunks = _baseline_edits.try_apply_baseline_replacement_units(
+        batch_source_lines,
+        base_lines,
+        ownership,
+        presence_line_set,
+        deletion_claims,
+        trust_baseline_coordinates=True,
+        spool_dir=spool_dir,
+    )
+    if baseline_chunks is not None:
+        yield from baseline_chunks
+        return
 
     try:
         with (
@@ -105,6 +101,7 @@ def _stream_realized_content_chunks_from_lines(
             ownership,
             presence_line_set,
             deletion_claims,
+            trust_baseline_coordinates=True,
             spool_dir=spool_dir,
         )
         if baseline_chunks is None:

--- a/src/git_stage_batch/batch/realized_file_content.py
+++ b/src/git_stage_batch/batch/realized_file_content.py
@@ -13,6 +13,7 @@ from ..editor.line_endings import (
 )
 from ..core.text_lines import normalize_line_sequence_endings
 from ..exceptions import MergeError as _MergeError
+from .line_matching.match import match_lines as _match_lines
 from .merge import baseline_edits as _baseline_edits
 from .merge.presence_constraints import satisfy_constraints
 from .realization.entry_storage import realized_entry_content_chunks
@@ -73,14 +74,30 @@ def _stream_realized_content_chunks_from_lines(
             return
 
     try:
-        realized_entries = satisfy_constraints(
-            batch_source_lines,
-            base_lines,
-            presence_line_set,
-            deletion_claims,
-            strict=False,
-            spool_dir=spool_dir,
-        )
+        with (
+            _baseline_edits.acquire_deletion_anchor_pairs_for_target(
+                batch_source_lines,
+                base_lines,
+                deletion_claims,
+                trust_baseline_coordinates=True,
+                spool_dir=spool_dir,
+            ) as anchor_pairs,
+            _match_lines(
+                batch_source_lines,
+                base_lines,
+                anchor_pairs=anchor_pairs,
+                spool_dir=spool_dir,
+            ) as mapping,
+        ):
+            realized_entries = satisfy_constraints(
+                batch_source_lines,
+                base_lines,
+                presence_line_set,
+                deletion_claims,
+                strict=False,
+                source_to_working_mapping=mapping,
+                spool_dir=spool_dir,
+            )
     except _MergeError:
         baseline_chunks = _baseline_edits.try_apply_baseline_replacement_units(
             batch_source_lines,

--- a/tests/batch/merge/test_baseline_anchor_matching.py
+++ b/tests/batch/merge/test_baseline_anchor_matching.py
@@ -249,6 +249,42 @@ def test_live_merge_does_not_insert_at_ambiguous_baseline_coordinate():
     ]
 
 
+def test_live_target_accepts_one_unique_composite_deletion_boundary():
+    """Repeated payloads may still form one complete live boundary."""
+    source = [
+        b"A\n",
+        b"B\n",
+        b"A\n",
+        b"X\n",
+        b"O\n",
+        b"Y\n",
+        b"B\n",
+    ]
+    target = [
+        b"A\n",
+        b"O\n",
+        b"B\n",
+        b"A\n",
+        b"X\n",
+        b"O\n",
+        b"Y\n",
+        b"B\n",
+    ]
+    claim = AbsenceClaim(
+        anchor_line=1,
+        content_lines=[b"O\n"],
+        baseline_reference=BaselineReference(
+            after_line=1,
+            after_content=b"A\n",
+            before_line=3,
+            before_content=b"B\n",
+            has_before_line=True,
+        ),
+    )
+
+    assert _deletion_anchor_pairs(source, target, [claim]) == ((1, 1),)
+
+
 def test_live_target_checks_indexed_boundary_candidates(monkeypatch):
     """Many unique claims must not rescan every target boundary."""
     target = [f"line-{index}\n".encode() for index in range(1002)]

--- a/tests/batch/merge/test_baseline_anchor_matching.py
+++ b/tests/batch/merge/test_baseline_anchor_matching.py
@@ -189,6 +189,66 @@ def test_live_merge_does_not_apply_ambiguous_baseline_coordinate(supply_mapping)
     ]
 
 
+def test_live_merge_does_not_insert_at_ambiguous_baseline_coordinate():
+    """A stale repeated insertion boundary must defer to structural placement."""
+    source = [
+        b"P\n",
+        b"ANCHOR\n",
+        b"NEXT\n",
+        b"MIDDLE\n",
+        b"ANCHOR\n",
+        b"NEW\n",
+        b"NEXT\n",
+        b"TAIL\n",
+    ]
+    target = [
+        b"P\n",
+        b"ANCHOR\n",
+        b"NEXT\n",
+        b"FILL\n",
+        b"ANCHOR\n",
+        b"NEXT\n",
+        b"MIDDLE\n",
+        b"ANCHOR\n",
+        b"NEXT\n",
+        b"TAIL\n",
+    ]
+    ownership = BatchOwnership.from_presence_lines(
+        ["6"],
+        [],
+        baseline_references={
+            6: BaselineReference(
+                after_line=5,
+                after_content=b"ANCHOR\n",
+                before_line=6,
+                before_content=b"NEXT\n",
+                has_before_line=True,
+            ),
+        },
+    )
+
+    with merge_batch_from_line_sequences_as_buffer(
+        source,
+        ownership,
+        target,
+    ) as merged:
+        result = list(merged)
+
+    assert result == [
+        b"P\n",
+        b"ANCHOR\n",
+        b"NEXT\n",
+        b"FILL\n",
+        b"ANCHOR\n",
+        b"NEXT\n",
+        b"MIDDLE\n",
+        b"ANCHOR\n",
+        b"NEW\n",
+        b"NEXT\n",
+        b"TAIL\n",
+    ]
+
+
 def test_live_target_checks_indexed_boundary_candidates(monkeypatch):
     """Many unique claims must not rescan every target boundary."""
     target = [f"line-{index}\n".encode() for index in range(1002)]

--- a/tests/batch/merge/test_baseline_anchor_matching.py
+++ b/tests/batch/merge/test_baseline_anchor_matching.py
@@ -1,10 +1,19 @@
 """Tests for line-matching anchors derived from deletion references."""
 
+from contextlib import nullcontext
+
+import pytest
+
 import git_stage_batch.batch.merge.baseline_edits as baseline_edits
 from git_stage_batch.batch.merge.baseline_edits import (
     acquire_deletion_anchor_pairs_for_target,
 )
+from git_stage_batch.batch.line_matching.match import match_lines
+from git_stage_batch.batch.merge.merge import (
+    merge_batch_from_line_sequences_as_buffer,
+)
 from git_stage_batch.batch.ownership.absence_claims import AbsenceClaim
+from git_stage_batch.batch.ownership.model import BatchOwnership
 from git_stage_batch.batch.ownership.references import BaselineReference
 
 
@@ -106,6 +115,78 @@ def test_live_target_rejects_repeated_verified_deletion_boundary():
     )
 
     assert _deletion_anchor_pairs(source, target, [claim]) == ()
+
+
+@pytest.mark.parametrize("supply_mapping", [False, True])
+def test_live_merge_does_not_apply_ambiguous_baseline_coordinate(supply_mapping):
+    """Structural placement must outrank a stale repeated baseline coordinate."""
+    source = [
+        b"P\n",
+        b"ANCHOR\n",
+        b"OLD\n",
+        b"NEXT\n",
+        b"MIDDLE\n",
+        b"ANCHOR\n",
+        b"NEXT\n",
+        b"TAIL\n",
+    ]
+    target = [
+        b"P\n",
+        b"ANCHOR\n",
+        b"OLD\n",
+        b"NEXT\n",
+        b"FILL\n",
+        b"ANCHOR\n",
+        b"OLD\n",
+        b"NEXT\n",
+        b"MIDDLE\n",
+        b"ANCHOR\n",
+        b"OLD\n",
+        b"NEXT\n",
+        b"TAIL\n",
+    ]
+    claim = AbsenceClaim(
+        anchor_line=6,
+        content_lines=[b"OLD\n"],
+        baseline_reference=BaselineReference(
+            after_line=6,
+            after_content=b"ANCHOR\n",
+            before_line=8,
+            before_content=b"NEXT\n",
+            has_before_line=True,
+        ),
+    )
+    mapping_context = (
+        match_lines(source, target)
+        if supply_mapping
+        else nullcontext(None)
+    )
+
+    with (
+        mapping_context as mapping,
+        merge_batch_from_line_sequences_as_buffer(
+            source,
+            BatchOwnership([], [claim]),
+            target,
+            source_to_working_mapping=mapping,
+        ) as merged,
+    ):
+        result = list(merged)
+
+    assert result == [
+        b"P\n",
+        b"ANCHOR\n",
+        b"OLD\n",
+        b"NEXT\n",
+        b"FILL\n",
+        b"ANCHOR\n",
+        b"OLD\n",
+        b"NEXT\n",
+        b"MIDDLE\n",
+        b"ANCHOR\n",
+        b"NEXT\n",
+        b"TAIL\n",
+    ]
 
 
 def test_live_target_checks_indexed_boundary_candidates(monkeypatch):

--- a/tests/batch/merge/test_merge.py
+++ b/tests/batch/merge/test_merge.py
@@ -1860,6 +1860,64 @@ footer
             b"header\ntarget one\ntarget two\nclaimed\nfooter\n",
         ]
 
+    def test_repeated_presence_candidates_apply_reviewed_coordinates(self):
+        """A candidate must override an ambiguous saved insertion coordinate."""
+        source = b"""header
+old one
+old two
+old three
+claimed
+old tail
+footer
+"""
+        working = b"""header
+same
+same
+same
+footer
+"""
+        ownership = BatchOwnership.from_presence_lines(
+            ["5"],
+            [],
+            baseline_references={
+                5: BaselineReference(
+                    after_line=2,
+                    after_content=b"same",
+                    before_line=3,
+                    before_content=b"same",
+                    has_before_line=True,
+                )
+            },
+        )
+
+        candidate_set = enumerate_merge_batch_candidates_from_line_sequences(
+            source.splitlines(keepends=True),
+            ownership,
+            working.splitlines(keepends=True),
+            max_candidates=10,
+        )
+
+        assert [candidate.summary for candidate in candidate_set.candidates] == [
+            "insert source lines 5-5 after target line 1, before target line 2",
+            "insert source lines 5-5 after target line 2, before target line 3",
+            "insert source lines 5-5 after target line 3, before target line 4",
+            "insert source lines 5-5 after target line 4, before target line 5",
+        ]
+        assert [
+            merge_batch(
+                source,
+                ownership,
+                working,
+                resolution=candidate.resolution,
+            )
+            for candidate in candidate_set.candidates
+        ] == [
+            b"header\nclaimed\nsame\nsame\nsame\nfooter\n",
+            b"header\nsame\nclaimed\nsame\nsame\nfooter\n",
+            b"header\nsame\nsame\nclaimed\nsame\nfooter\n",
+            b"header\nsame\nsame\nsame\nclaimed\nfooter\n",
+        ]
+
     def test_contextual_presence_candidates_honor_preview_cap(self):
         """Wide ambiguous intervals should stop at the candidate safety cap."""
         source = b"header\nold one\nold two\nold three\nclaimed\nold tail\nfooter\n"
@@ -1911,6 +1969,65 @@ footer
         )
 
         assert candidate_set.candidates == ()
+
+    def test_replacement_review_does_not_waive_insertion_ambiguity(self):
+        """Reviewing one replacement cannot authorize an unrelated insertion."""
+        source = b"head\nnew one\nnew two\nclaimed\ntail\n"
+        working = b"head\nold two\nmid\nold two\nsame\nsame\nsame\ntail\n"
+        replacement_reference = BaselineReference(
+            after_line=2,
+            after_content=b"old one",
+            before_line=4,
+            before_content=b"tail",
+            has_before_line=True,
+        )
+        ownership = BatchOwnership.from_presence_lines(
+            ["3,4"],
+            [
+                AbsenceClaim(
+                    anchor_line=2,
+                    content_lines=[b"old two\n"],
+                    baseline_reference=replacement_reference,
+                )
+            ],
+            baseline_references={
+                3: replacement_reference,
+                4: BaselineReference(
+                    after_line=5,
+                    after_content=b"same",
+                    before_line=6,
+                    before_content=b"same",
+                    has_before_line=True,
+                ),
+            },
+            replacement_units=[
+                ReplacementUnit(
+                    presence_lines=["3"],
+                    deletion_indices=[0],
+                    origin=ReplacementUnitOrigin(
+                        old_start=2,
+                        old_end=3,
+                        new_start=2,
+                        new_end=3,
+                        baseline_reference=BaselineReference(
+                            after_line=1,
+                            after_content=b"head",
+                            before_line=4,
+                            before_content=b"tail",
+                            has_before_line=True,
+                        ),
+                    ),
+                )
+            ],
+        )
+
+        with pytest.raises(MergeError):
+            enumerate_merge_batch_candidates_from_line_sequences(
+                source.splitlines(keepends=True),
+                ownership,
+                working.splitlines(keepends=True),
+                max_candidates=10,
+            )
 
     def test_enumerates_displaced_absence_candidates(self):
         """Ambiguous nearby deletion content can be previewed as candidates."""

--- a/tests/batch/merge/test_merge.py
+++ b/tests/batch/merge/test_merge.py
@@ -1165,6 +1165,30 @@ class TestMergeBatch:
 
         assert result == b"line1\nline3\n"
 
+    def test_identical_shifted_source_keeps_pending_structural_removal(self):
+        """A stale baseline coordinate must not hide a source-anchored removal."""
+        source = b"prefix\nA\nold value\nB\n"
+        ownership = BatchOwnership.from_presence_lines(
+            [],
+            [
+                AbsenceClaim(
+                    anchor_line=2,
+                    content_lines=[b"old value\n"],
+                    baseline_reference=BaselineReference(
+                        after_line=1,
+                        after_content=b"A",
+                        before_line=3,
+                        before_content=b"B",
+                        has_before_line=True,
+                    ),
+                )
+            ],
+        )
+
+        result = merge_batch(source, ownership, source)
+
+        assert result == b"prefix\nA\nB\n"
+
     def test_baseline_referenced_absence_rejects_unidentified_numeric_anchor(self):
         """A line number alone cannot prove which duplicate occurrence is owned."""
         source = b"line1\nnew context\nline3\n"
@@ -1289,6 +1313,59 @@ class TestMergeBatch:
         result = merge_batch(source, ownership, working)
 
         assert result == b"head\nold1\nnew2\ntail\n"
+
+    def test_split_replacement_uses_baseline_offset_after_source_prefix(self):
+        """Retained source-only lines must not shift a split replacement."""
+        source = b"saved\nhead\nnew1\nnew2\ntail\n"
+        working = b"head\nsame\nsame\ntail\n"
+        ownership = BatchOwnership.from_presence_lines(
+            ["3"],
+            [
+                AbsenceClaim(
+                    anchor_line=2,
+                    content_lines=[b"same\n"],
+                    baseline_reference=BaselineReference(
+                        after_line=1,
+                        after_content=b"head",
+                        before_line=3,
+                        before_content=b"same",
+                        has_before_line=True,
+                    ),
+                )
+            ],
+            baseline_references={
+                3: BaselineReference(
+                    after_line=1,
+                    after_content=b"head",
+                    before_line=3,
+                    before_content=b"same",
+                    has_before_line=True,
+                )
+            },
+            replacement_units=[
+                ReplacementUnit(
+                    presence_lines=["3"],
+                    deletion_indices=[0],
+                    origin=ReplacementUnitOrigin(
+                        old_start=2,
+                        old_end=3,
+                        new_start=2,
+                        new_end=3,
+                        baseline_reference=BaselineReference(
+                            after_line=1,
+                            after_content=b"head",
+                            before_line=4,
+                            before_content=b"tail",
+                            has_before_line=True,
+                        ),
+                    ),
+                )
+            ],
+        )
+
+        result = merge_batch(source, ownership, working)
+
+        assert result == b"head\nnew1\nsame\ntail\n"
 
     def test_split_replacement_origin_places_subunit_in_hybrid_parent(self):
         """Split units should reapply where unselected sibling lines remain new."""
@@ -1855,6 +1932,52 @@ footer
             "delete target line 3",
             "delete target line 4",
         ]
+
+    def test_repeated_absence_candidates_apply_reviewed_coordinates(self):
+        """A candidate must override an ambiguous saved deletion coordinate."""
+        source = b"a\nb\n"
+        working = b"a\nsame\nremove\nend\nmid\nsame\nremove\nend\nb\n"
+        ownership = BatchOwnership(
+            [],
+            [
+                AbsenceClaim(
+                    anchor_line=1,
+                    content_lines=[b"remove\n"],
+                    baseline_reference=BaselineReference(
+                        after_line=2,
+                        after_content=b"same",
+                        before_line=4,
+                        before_content=b"end",
+                        has_before_line=True,
+                    ),
+                )
+            ],
+        )
+
+        candidate_set = enumerate_merge_batch_candidates_from_line_sequences(
+            source.splitlines(keepends=True),
+            ownership,
+            working.splitlines(keepends=True),
+            max_candidates=10,
+        )
+
+        assert [candidate.summary for candidate in candidate_set.candidates] == [
+            "delete target line 3",
+            "delete target line 7",
+        ]
+        first, second = candidate_set.candidates
+        assert merge_batch(
+            source,
+            ownership,
+            working,
+            resolution=first.resolution,
+        ) == b"a\nsame\nend\nmid\nsame\nremove\nend\nb\n"
+        assert merge_batch(
+            source,
+            ownership,
+            working,
+            resolution=second.resolution,
+        ) == b"a\nsame\nremove\nend\nmid\nsame\nend\nb\n"
 
     def test_merge_multiple_deletions(self):
         """Test merge with multiple deletion constraints at different positions."""

--- a/tests/batch/merge/test_merge.py
+++ b/tests/batch/merge/test_merge.py
@@ -537,6 +537,38 @@ class TestMergeLineSequences:
         assert isinstance(entries, RealizedEntries)
         assert b"".join(entry.content for entry in entries) == b"line1\nline2\nline3\n"
 
+    def test_supplied_mapping_preserves_verified_deletion_anchor(self):
+        """A reusable plain mapping must not bypass saved removal anchors."""
+        source = [b"head\n", b"new\n", b"\n", b"tail\n"]
+        working = [b"head\n", b"\n", b"old\n", b"\n", b"tail\n"]
+        ownership = BatchOwnership.from_presence_lines(
+            ["2"],
+            [
+                AbsenceClaim(
+                    anchor_line=3,
+                    content_lines=[b"old\n"],
+                    baseline_reference=BaselineReference(
+                        after_line=2,
+                        after_content=b"\n",
+                        before_line=4,
+                        before_content=b"\n",
+                        has_before_line=True,
+                    ),
+                )
+            ],
+        )
+
+        with match_lines(source, working) as mapping:
+            assert mapping.get_target_line_from_source_line(3) == 4
+            result = merge_batch(
+                b"".join(source),
+                ownership,
+                b"".join(working),
+                source_to_working_mapping=mapping,
+            )
+
+        assert result == b"head\nnew\n\n\ntail\n"
+
     def test_discard_entry_builder_accepts_non_list_sequences(self, line_sequence):
         """Discard entry construction only requires sized iterable line sequences."""
         source = line_sequence([b"line1\n", b"line2\n", b"line3\n"])

--- a/tests/batch/test_storage_duplication.py
+++ b/tests/batch/test_storage_duplication.py
@@ -36,13 +36,20 @@ def test_build_realized_content_routes_storage_to_invocation_spool(
     """Stored-file matching and realization use the caller's scratch path."""
     spool_dir = tmp_path / "scratch"
     spool_dir.mkdir()
+    matching_spools = []
     realization_spools = []
+    original_match_lines = realized_file_content._match_lines
     original_satisfy_constraints = realized_file_content.satisfy_constraints
+
+    def record_match(*args, **kwargs):
+        matching_spools.append(kwargs.get("spool_dir"))
+        return original_match_lines(*args, **kwargs)
 
     def record_realization(*args, **kwargs):
         realization_spools.append(kwargs.get("spool_dir"))
         return original_satisfy_constraints(*args, **kwargs)
 
+    monkeypatch.setattr(realized_file_content, "_match_lines", record_match)
     monkeypatch.setattr(
         realized_file_content,
         "satisfy_constraints",
@@ -62,6 +69,7 @@ def test_build_realized_content_routes_storage_to_invocation_spool(
     ):
         assert result.to_bytes() == b"one\ninserted\n"
 
+    assert matching_spools == [spool_dir]
     assert realization_spools == [spool_dir]
 
 

--- a/tests/batch/test_storage_duplication.py
+++ b/tests/batch/test_storage_duplication.py
@@ -225,6 +225,32 @@ def test_build_realized_content_uses_baseline_reference_for_ambiguous_insert():
     assert result == b"top\nsave-a\nsave-b\n\nbottom\n"
 
 
+def test_exact_baseline_inserts_content_equal_to_following_line():
+    """A baseline sibling must not masquerade as the selected insertion."""
+    base_content = b"same\nb\nsame\nsame\nb\nx\n"
+    batch_source_content = b"same\nsame\nsame\nsame\nb\nx\n"
+    ownership = BatchOwnership.from_presence_lines(
+        ["2"],
+        baseline_references={
+            2: BaselineReference(
+                after_line=2,
+                after_content=b"b",
+                before_line=3,
+                before_content=b"same",
+                has_before_line=True,
+            ),
+        },
+    )
+
+    result = _build_realized_content_from_bytes(
+        base_content,
+        batch_source_content,
+        ownership,
+    )
+
+    assert result == b"same\nb\nsame\nsame\nsame\nb\nx\n"
+
+
 def test_build_realized_content_applies_deletion_when_source_matches_baseline():
     """Baseline fallback must not bypass storage deletion constraints."""
     content = b"first\nold value\n"

--- a/tests/batch/test_storage_duplication.py
+++ b/tests/batch/test_storage_duplication.py
@@ -6,7 +6,10 @@ import git_stage_batch.batch.realized_file_content as realized_file_content
 from git_stage_batch.batch.ownership.absence_claims import AbsenceClaim
 from git_stage_batch.batch.ownership.model import BatchOwnership
 from git_stage_batch.batch.ownership.references import BaselineReference
-from git_stage_batch.batch.ownership.replacement_units import ReplacementUnit
+from git_stage_batch.batch.ownership.replacement_units import (
+    ReplacementUnit,
+    ReplacementUnitOrigin,
+)
 from git_stage_batch.batch.realized_file_content import (
     build_realized_buffer_from_lines,
 )
@@ -101,6 +104,53 @@ def test_build_realized_content_no_duplication_when_claiming_moved_line():
     # Count occurrences of "X"
     x_count = result_lines.count("X")
     assert x_count == 2, f"Expected 'X' to appear 2 times, but got {x_count} times: {result_lines}"
+
+
+def test_build_realized_content_uses_exact_split_replacement_reference():
+    """Repeated parent lines should retain the unselected sibling."""
+    ownership = BatchOwnership.from_presence_lines(
+        ["3"],
+        [
+            AbsenceClaim(
+                anchor_line=2,
+                content_lines=[b"same\n"],
+                baseline_reference=BaselineReference(
+                    after_line=1,
+                    after_content=b"head",
+                    before_line=3,
+                    before_content=b"same",
+                    has_before_line=True,
+                ),
+            )
+        ],
+        replacement_units=[
+            ReplacementUnit(
+                presence_lines=["3"],
+                deletion_indices=[0],
+                origin=ReplacementUnitOrigin(
+                    old_start=2,
+                    old_end=3,
+                    new_start=2,
+                    new_end=3,
+                    baseline_reference=BaselineReference(
+                        after_line=1,
+                        after_content=b"head",
+                        before_line=4,
+                        before_content=b"tail",
+                        has_before_line=True,
+                    ),
+                ),
+            )
+        ],
+    )
+
+    result = _build_realized_content_from_bytes(
+        b"head\nsame\nsame\ntail\n",
+        b"saved\nhead\nnew1\nnew2\ntail\n",
+        ownership,
+    )
+
+    assert result == b"head\nnew1\nsame\ntail\n"
 
 
 def test_build_realized_content_duplicate_line_claimed():

--- a/tests/batch/test_storage_duplication.py
+++ b/tests/batch/test_storage_duplication.py
@@ -6,6 +6,7 @@ import git_stage_batch.batch.realized_file_content as realized_file_content
 from git_stage_batch.batch.ownership.absence_claims import AbsenceClaim
 from git_stage_batch.batch.ownership.model import BatchOwnership
 from git_stage_batch.batch.ownership.references import BaselineReference
+from git_stage_batch.batch.ownership.replacement_units import ReplacementUnit
 from git_stage_batch.batch.realized_file_content import (
     build_realized_buffer_from_lines,
 )
@@ -191,6 +192,84 @@ def test_build_realized_content_applies_deletion_when_source_matches_baseline():
     result = _build_realized_content_from_bytes(content, content, ownership)
 
     assert result == b""
+
+
+def test_build_realized_content_uses_deletion_anchor_for_moved_block():
+    """Stored content uses a recorded boundary when an anchor line repeats."""
+    base_content = b"""def realize():
+    fallback = try_baseline(
+        source,
+        base,
+        ownership,
+        presence,
+        deletions,
+    )
+    if fallback is not None:
+        return fallback
+
+    result = satisfy_constraints(
+        source,
+        base,
+        presence,
+        deletions,
+        strict=False,
+    )
+
+    return result
+"""
+    batch_source_content = b"""def realize():
+    try:
+        result = satisfy_constraints(
+            source,
+            base,
+            presence,
+            deletions,
+            strict=False,
+        )
+    except MergeError:
+        fallback = try_baseline(
+            source,
+            base,
+            ownership,
+            presence,
+            deletions,
+        )
+        if fallback is None:
+            raise
+        return fallback
+
+    return result
+"""
+    base_lines = base_content.splitlines(keepends=True)
+    ownership = BatchOwnership.from_presence_lines(
+        ["1-22"],
+        [
+            AbsenceClaim(
+                anchor_line=1,
+                content_lines=base_lines[1:9],
+                baseline_reference=BaselineReference(after_line=1),
+            ),
+            AbsenceClaim(
+                anchor_line=21,
+                content_lines=base_lines[11:19],
+                baseline_reference=BaselineReference(after_line=11),
+            ),
+        ],
+        replacement_units=[
+            ReplacementUnit(
+                presence_lines=["2-19"],
+                deletion_indices=[0],
+            ),
+        ],
+    )
+
+    result = _build_realized_content_from_bytes(
+        base_content,
+        batch_source_content,
+        ownership,
+    )
+
+    assert result == batch_source_content
 
 
 def test_build_realized_content_from_lines_accepts_non_list_sequences(line_sequence):

--- a/tests/functional/test_discard_file_behavior.py
+++ b/tests/functional/test_discard_file_behavior.py
@@ -10,6 +10,94 @@ from .conftest import git_stage_batch
 class TestDiscardFile:
     """Tests for discard --file removing files and preserving batch content."""
 
+    def test_discard_file_batch_saves_reordered_block(self, functional_repo):
+        """A saved whole-file rewrite must not duplicate a moved block."""
+        file_path = functional_repo / "realize.py"
+        baseline = """def realize():
+    fallback = try_baseline(
+        source,
+        base,
+        ownership,
+        presence,
+        deletions,
+    )
+    if fallback is not None:
+        return fallback
+
+    result = satisfy_constraints(
+        source,
+        base,
+        presence,
+        deletions,
+        strict=False,
+    )
+
+    return result
+"""
+        rewritten = """def realize():
+    try:
+        result = satisfy_constraints(
+            source,
+            base,
+            presence,
+            deletions,
+            strict=False,
+        )
+    except MergeError:
+        fallback = try_baseline(
+            source,
+            base,
+            ownership,
+            presence,
+            deletions,
+        )
+        if fallback is None:
+            raise
+        return fallback
+
+    return result
+"""
+        file_path.write_text(baseline)
+        subprocess.run(
+            ["git", "add", "realize.py"],
+            check=True,
+            cwd=functional_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add realization example"],
+            check=True,
+            cwd=functional_repo,
+            capture_output=True,
+        )
+        file_path.write_text(rewritten)
+
+        git_stage_batch("start", "--no-auto-advance")
+        git_stage_batch("show", "--file", "realize.py", "--page", "all")
+        git_stage_batch(
+            "discard",
+            "--to",
+            "reordered-block",
+            "--file",
+            "realize.py",
+            "--no-auto-advance",
+        )
+
+        assert file_path.read_text() == baseline
+        stored_content = subprocess.run(
+            [
+                "git",
+                "show",
+                "refs/git-stage-batch/batches/reordered-block:realize.py",
+            ],
+            check=True,
+            cwd=functional_repo,
+            capture_output=True,
+            text=True,
+        ).stdout
+        assert stored_content == rewritten
+
+
     def test_discard_file_removes_new_file_from_working_tree(self, repo_with_changes):
         """Test that discarding a new file removes it from the working tree."""
         repo = repo_with_changes

--- a/tests/functional/test_discard_file_behavior.py
+++ b/tests/functional/test_discard_file_behavior.py
@@ -10,7 +10,7 @@ from .conftest import git_stage_batch
 class TestDiscardFile:
     """Tests for discard --file removing files and preserving batch content."""
 
-    def test_discard_file_batch_saves_reordered_block(self, functional_repo):
+    def test_discard_file_batch_round_trips_reordered_block(self, functional_repo):
         """A saved whole-file rewrite must not duplicate a moved block."""
         file_path = functional_repo / "realize.py"
         baseline = """def realize():
@@ -97,6 +97,15 @@ class TestDiscardFile:
         ).stdout
         assert stored_content == rewritten
 
+        git_stage_batch(
+            "apply",
+            "--from",
+            "reordered-block",
+            "--file",
+            "realize.py",
+        )
+
+        assert file_path.read_text() == rewritten
 
     def test_discard_file_removes_new_file_from_working_tree(self, repo_with_changes):
         """Test that discarding a new file removes it from the working tree."""


### PR DESCRIPTION
Replacement-backed removals now retain saved-baseline coordinates
through preparation and realization.

Fallback can still apply stored positions to live targets and unconstrained
mappings. Repeated boundaries can make those numbers stale or ambiguous,
editing a competing block or silently leaving a removal unapplied.

This commit series verifies saved removal anchors, distinguishes exact
baselines from live targets, and constrains mappings before ownership is
realized.

Saved whole-file batches now round-trip reordered content across repeated
boundaries without trusting stale live coordinates.