### PR TITLE
batch: Map first selections to their saved snapshots

### DIFF
--- a/src/git_stage_batch/batch/source/annotation.py
+++ b/src/git_stage_batch/batch/source/annotation.py
@@ -15,6 +15,7 @@ from ...utils.repository_buffers import (
 from ..line_matching.line_mapping import LineMapping
 from ..line_matching.match import match_lines
 from .cache import get_batch_source_for_file
+from .line_coordinates import translate_display_source_coordinates
 
 
 def _apply_batch_source_mapping(
@@ -27,31 +28,12 @@ def _apply_batch_source_mapping(
     numbers. For deletions, uses the last known batch source line as insertion
     position.
     """
-    last_source_line: int | None = None
     new_lines: list[LineEntry] = []
 
-    for line in line_changes.lines:
-        source_line = None
-
-        if line.kind in {" ", "+"}:
-            if line.new_line_number is not None:
-                source_line = mapping.get_source_line_from_target_line(
-                    line.new_line_number
-                )
-            if source_line is not None:
-                last_source_line = source_line
-
-        elif line.kind == "-":
-            source_line = last_source_line
-            if (
-                source_line is None
-                and line.old_line_number is not None
-                and line.old_line_number > 1
-            ):
-                source_line = mapping.get_source_line_from_target_line(
-                    line.old_line_number - 1
-                )
-
+    for line, source_line in translate_display_source_coordinates(
+        line_changes.lines,
+        mapping.get_source_line_from_target_line,
+    ):
         new_lines.append(
             LineEntry(
                 id=line.id,
@@ -129,25 +111,12 @@ def _fill_source_from_working_tree(line_changes: LineLevelChange) -> LineLevelCh
     Used when no batch source exists yet. The working tree will become the batch
     source when changes are saved.
     """
-    last_source_line: int | None = None
     new_lines: list[LineEntry] = []
 
-    for line in line_changes.lines:
-        source_line = None
-
-        if line.kind in {" ", "+"}:
-            source_line = line.new_line_number
-            if source_line is not None:
-                last_source_line = source_line
-        elif line.kind == "-":
-            source_line = last_source_line
-            if (
-                source_line is None
-                and line.old_line_number is not None
-                and line.old_line_number > 1
-            ):
-                source_line = line.old_line_number - 1
-
+    for line, source_line in translate_display_source_coordinates(
+        line_changes.lines,
+        lambda line_number: line_number,
+    ):
         new_lines.append(
             LineEntry(
                 id=line.id,

--- a/src/git_stage_batch/batch/source/line_coordinates.py
+++ b/src/git_stage_batch/batch/source/line_coordinates.py
@@ -1,0 +1,81 @@
+"""Source-coordinate translation for combined diff displays."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Iterator
+
+from ...core.models import LineEntry
+
+
+def translate_display_source_coordinates(
+    lines: Iterable[LineEntry],
+    map_working_line: Callable[[int], int | None],
+    *,
+    map_existing_source_line: Callable[[int], int | None] | None = None,
+) -> Iterator[tuple[LineEntry, int | None]]:
+    """Yield each display row with its translated source coordinate.
+
+    The running delta translates old-side deletion positions into the working
+    file. Synthetic gaps reset structural context between hunks, but the delta
+    remains valid across the omitted unchanged region.
+    """
+    last_source_line: int | None = None
+    coordinate_delta = 0
+    deletion_run_anchor: int | None = None
+    previous_deleted_old_line: int | None = None
+
+    for line in lines:
+        source_line: int | None = None
+
+        if line.kind == " ":
+            if line.new_line_number is None:
+                last_source_line = None
+            else:
+                source_line = map_working_line(line.new_line_number)
+                if source_line is not None:
+                    last_source_line = source_line
+                if line.old_line_number is not None:
+                    coordinate_delta = (
+                        line.new_line_number - line.old_line_number
+                    )
+            deletion_run_anchor = None
+            previous_deleted_old_line = None
+        elif line.kind == "+":
+            if line.new_line_number is not None:
+                source_line = map_working_line(line.new_line_number)
+            if source_line is not None:
+                last_source_line = source_line
+            coordinate_delta += 1
+            deletion_run_anchor = None
+            previous_deleted_old_line = None
+        elif line.kind == "-":
+            if not (
+                previous_deleted_old_line is not None
+                and line.old_line_number == previous_deleted_old_line + 1
+            ):
+                deletion_run_anchor = last_source_line
+                if (
+                    deletion_run_anchor is None
+                    and line.source_line is not None
+                    and map_existing_source_line is not None
+                ):
+                    deletion_run_anchor = map_existing_source_line(
+                        line.source_line
+                    )
+                if (
+                    deletion_run_anchor is None
+                    and line.old_line_number is not None
+                ):
+                    working_anchor = (
+                        line.old_line_number - 1 + coordinate_delta
+                    )
+                    if working_anchor > 0:
+                        deletion_run_anchor = map_working_line(working_anchor)
+            source_line = deletion_run_anchor
+            coordinate_delta -= 1
+            previous_deleted_old_line = line.old_line_number
+        else:
+            deletion_run_anchor = None
+            previous_deleted_old_line = None
+
+        yield line, source_line

--- a/src/git_stage_batch/batch/source/refresh.py
+++ b/src/git_stage_batch/batch/source/refresh.py
@@ -7,8 +7,10 @@ advancement, ownership remapping, cache updates, and line re-annotation.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 
+from ...core.models import LineEntry
 from .cache import (
     load_session_batch_sources,
     save_session_batch_sources,
@@ -59,6 +61,8 @@ def ensure_batch_source_current_for_selection(
     current_batch_source_commit: str | None,
     existing_ownership: BatchOwnership | None,
     selected_lines: list,
+    *,
+    coordinate_lines: Sequence[LineEntry] | None = None,
 ) -> RefreshedBatchSelection:
     """Ensure batch source is current for selection, advancing if needed.
 
@@ -83,6 +87,7 @@ def ensure_batch_source_current_for_selection(
         current_batch_source_commit: Current batch source commit (or None)
         existing_ownership: Existing ownership for this file (or None)
         selected_lines: LineEntry objects being added to batch
+        coordinate_lines: Complete hunk entries for selected-line coordinates.
 
     Returns:
         RefreshedBatchSelection with current source state
@@ -94,6 +99,7 @@ def ensure_batch_source_current_for_selection(
         cached_source_result = _prepare_initial_cached_source_for_selection(
             file_path,
             selected_lines,
+            coordinate_lines=coordinate_lines,
         )
         if cached_source_result is not None:
             batch_source_commit, prepared_selected_lines, source_was_advanced = (
@@ -130,6 +136,7 @@ def ensure_batch_source_current_for_selection(
                 source_lines=advance_result.source_buffer,
                 working_lines=(),
                 lineage=advance_result.lineage,
+                coordinate_lines=coordinate_lines,
             )
 
             return RefreshedBatchSelection(
@@ -151,7 +158,10 @@ def ensure_batch_source_current_for_selection(
         # First time - stale is normal. The batch source will be created from
         # the same working tree snapshot, so annotate now in that coordinate
         # space before translating ownership.
-        reannotated_lines = _refresh_lines_against_new_source(selected_lines)
+        reannotated_lines = _refresh_lines_against_new_source(
+            selected_lines,
+            coordinate_lines=coordinate_lines,
+        )
 
         return RefreshedBatchSelection(
             batch_source_commit=current_batch_source_commit,
@@ -179,6 +189,8 @@ def _cache_session_source(file_path: str, batch_source_commit: str) -> None:
 def _create_current_working_source_for_selection(
     file_path: str,
     selected_lines: list,
+    *,
+    coordinate_lines: Sequence[LineEntry] | None = None,
 ) -> tuple[str, list]:
     with load_working_tree_file_as_buffer(file_path) as working_lines:
         batch_source_commit = create_batch_source_commit(
@@ -188,13 +200,45 @@ def _create_current_working_source_for_selection(
     _cache_session_source(file_path, batch_source_commit)
     return (
         batch_source_commit,
-        _refresh_lines_against_new_source(selected_lines),
+        _refresh_lines_against_new_source(
+            selected_lines,
+            coordinate_lines=coordinate_lines,
+        ),
     )
+
+
+def _selection_mapped_to_source(
+    file_path: str,
+    selected_lines: list,
+    source_lines: Sequence[bytes],
+    *,
+    coordinate_lines: Sequence[LineEntry] | None = None,
+) -> list | None:
+    """Return selection coordinates verified against one saved source."""
+    has_deletion_lines = any(line.kind == "-" for line in selected_lines)
+    if (
+        not has_deletion_lines
+        and _selection_matches_source(selected_lines, source_lines)
+    ):
+        return selected_lines
+
+    with load_working_tree_file_as_buffer(file_path) as working_lines:
+        prepared_selected_lines = _refresh_lines_against_source(
+            selected_lines,
+            source_lines=source_lines,
+            working_lines=working_lines,
+            coordinate_lines=coordinate_lines,
+        )
+    if _selection_matches_source(prepared_selected_lines, source_lines):
+        return prepared_selected_lines
+    return None
 
 
 def _prepare_initial_cached_source_for_selection(
     file_path: str,
     selected_lines: list,
+    *,
+    coordinate_lines: Sequence[LineEntry] | None = None,
 ) -> tuple[str, list, bool] | None:
     batch_source_commit = load_session_batch_sources().get(file_path)
     if not batch_source_commit:
@@ -208,10 +252,69 @@ def _prepare_initial_cached_source_for_selection(
         )
 
     with source_buffer as source_lines:
-        if _selection_matches_source(selected_lines, source_lines):
-            return batch_source_commit, selected_lines, False
+        prepared_selected_lines = _selection_mapped_to_source(
+            file_path,
+            selected_lines,
+            source_lines,
+            coordinate_lines=coordinate_lines,
+        )
+        if prepared_selected_lines is not None:
+            return batch_source_commit, prepared_selected_lines, False
 
     new_batch_source_commit, reannotated_lines = (
-        _create_current_working_source_for_selection(file_path, selected_lines)
+        _create_current_working_source_for_selection(
+            file_path,
+            selected_lines,
+            coordinate_lines=coordinate_lines,
+        )
     )
     return new_batch_source_commit, reannotated_lines, True
+
+
+def prepare_initial_batch_source_for_selection(
+    file_path: str,
+    selected_lines: list,
+    *,
+    coordinate_lines: Sequence[LineEntry] | None = None,
+) -> tuple[str, list]:
+    """Create the first source and map selected lines into its coordinates."""
+    cached_source_result = _prepare_initial_cached_source_for_selection(
+        file_path,
+        selected_lines,
+        coordinate_lines=coordinate_lines,
+    )
+    if cached_source_result is not None:
+        batch_source_commit, prepared_selected_lines, _source_was_advanced = (
+            cached_source_result
+        )
+        return batch_source_commit, prepared_selected_lines
+
+    batch_source_commit = create_batch_source_commit(file_path)
+    _cache_session_source(file_path, batch_source_commit)
+    source_buffer = read_git_object_buffer_or_none(
+        f"{batch_source_commit}:{file_path}"
+    )
+    if source_buffer is None:
+        raise ValueError(
+            f"Cannot read initial batch source for {file_path} at "
+            f"{batch_source_commit}"
+        )
+
+    with source_buffer as source_lines:
+        prepared_selected_lines = _selection_mapped_to_source(
+            file_path,
+            selected_lines,
+            source_lines,
+            coordinate_lines=coordinate_lines,
+        )
+        if prepared_selected_lines is not None:
+            return batch_source_commit, prepared_selected_lines
+
+    new_batch_source_commit, reannotated_lines = (
+        _create_current_working_source_for_selection(
+            file_path,
+            selected_lines,
+            coordinate_lines=coordinate_lines,
+        )
+    )
+    return new_batch_source_commit, reannotated_lines

--- a/src/git_stage_batch/batch/source/selected_line_refresh.py
+++ b/src/git_stage_batch/batch/source/selected_line_refresh.py
@@ -2,13 +2,19 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Callable, Iterator, Sequence
+from contextlib import contextmanager
 from dataclasses import replace
 
+from ...core.mapped_storage import MappedRecordVector, sort_mapped_records
 from ...core.models import LineEntry
 from ..line_matching.lineage import BatchSourceLineage
 from ..line_matching.match import match_lines
 from ..ownership.translation import detect_stale_batch_source_for_selection
+from .line_coordinates import translate_display_source_coordinates
+
+
+_MAX_UINT64 = (1 << 64) - 1
 
 
 def _line_entry_content(line: LineEntry) -> bytes:
@@ -38,7 +44,172 @@ def selected_lines_fit_source(
     return True
 
 
-def refresh_selected_lines_against_new_source(selected_lines: list) -> list:
+def _selected_line_record_index(
+    selected_line_records: Sequence[tuple[int, ...]],
+    line_id: int,
+) -> int | None:
+    """Return the mapped record index for one selected display ID."""
+    start = 0
+    end = len(selected_line_records)
+    while start < end:
+        middle = (start + end) // 2
+        candidate_id = selected_line_records[middle][0]
+        if candidate_id < line_id:
+            start = middle + 1
+        else:
+            end = middle
+    if (
+        start >= len(selected_line_records)
+        or selected_line_records[start][0] != line_id
+    ):
+        return None
+    return start
+
+
+@contextmanager
+def _acquire_coordinate_selected_line_records(
+    selected_lines: Sequence[LineEntry],
+    coordinate_lines: Sequence[LineEntry] | None,
+) -> Iterator[MappedRecordVector | None]:
+    """Index selected IDs in mapped storage when complete context identifies them."""
+    if coordinate_lines is None:
+        yield None
+        return
+
+    with MappedRecordVector(
+        len(selected_lines),
+        "QQQQ",
+    ) as selected_line_records:
+        for line in selected_lines:
+            line_id = line.id
+            if (
+                type(line_id) is not int
+                or line_id < 0
+                or line_id > _MAX_UINT64
+            ):
+                yield None
+                return
+            selected_line_records.append((line_id, 0, 0, 0))
+
+        sort_mapped_records(selected_line_records)
+        previous_line_id: int | None = None
+        for line_id, _count, _coordinate_index, _source_line in (
+            selected_line_records
+        ):
+            if line_id == previous_line_id:
+                yield None
+                return
+            previous_line_id = line_id
+
+        for coordinate_index, line in enumerate(coordinate_lines):
+            line_id = line.id
+            if (
+                type(line_id) is not int
+                or line_id < 0
+                or line_id > _MAX_UINT64
+            ):
+                continue
+            record_index = _selected_line_record_index(
+                selected_line_records,
+                line_id,
+            )
+            if record_index is None:
+                continue
+            selected_id, count, _coordinate_index, source_line = (
+                selected_line_records[record_index]
+            )
+            selected_line_records[record_index] = (
+                selected_id,
+                count + 1,
+                coordinate_index + 1,
+                source_line,
+            )
+
+        if any(record[1] != 1 for record in selected_line_records):
+            yield None
+            return
+        yield selected_line_records
+
+
+def _refresh_selected_line_coordinates(
+    selected_lines: Sequence[LineEntry],
+    coordinate_lines: Sequence[LineEntry] | None,
+    selected_line_records: MappedRecordVector | None,
+    map_working_line: Callable[[int], int | None],
+    *,
+    map_existing_source_line: Callable[[int], int | None] | None = None,
+) -> list[LineEntry]:
+    """Refresh selected entries while scanning complete coordinates when usable."""
+    lines_to_refresh = (
+        coordinate_lines
+        if selected_line_records is not None and coordinate_lines is not None
+        else selected_lines
+    )
+    reannotated_lines: list[LineEntry] = []
+
+    for line, source_line in translate_display_source_coordinates(
+        lines_to_refresh,
+        map_working_line,
+        map_existing_source_line=map_existing_source_line,
+    ):
+        if selected_line_records is None:
+            reannotated_lines.append(replace(line, source_line=source_line))
+            continue
+        line_id = line.id
+        if (
+            type(line_id) is not int
+            or line_id < 0
+            or line_id > _MAX_UINT64
+        ):
+            continue
+        record_index = _selected_line_record_index(
+            selected_line_records,
+            line_id,
+        )
+        if record_index is None:
+            continue
+        selected_id, count, coordinate_index, _source_line = (
+            selected_line_records[record_index]
+        )
+        selected_line_records[record_index] = (
+            selected_id,
+            count,
+            coordinate_index,
+            0 if source_line is None else source_line + 1,
+        )
+
+    if selected_line_records is None:
+        return reannotated_lines
+
+    assert coordinate_lines is not None
+    for selected_line in selected_lines:
+        selected_id = selected_line.id
+        assert selected_id is not None
+        record_index = _selected_line_record_index(
+            selected_line_records,
+            selected_id,
+        )
+        assert record_index is not None
+        _line_id, _count, coordinate_index, encoded_source_line = (
+            selected_line_records[record_index]
+        )
+        reannotated_lines.append(replace(
+            coordinate_lines[coordinate_index - 1],
+            source_line=(
+                encoded_source_line - 1
+                if encoded_source_line > 0
+                else None
+            ),
+        ))
+
+    return reannotated_lines
+
+
+def refresh_selected_lines_against_new_source(
+    selected_lines: list,
+    *,
+    coordinate_lines: Sequence[LineEntry] | None = None,
+) -> list:
     """Re-annotate selected lines for a first-time batch source.
 
     This helper is only used before a batch source exists.
@@ -58,32 +229,21 @@ def refresh_selected_lines_against_new_source(selected_lines: list) -> list:
 
     Args:
         selected_lines: LineEntry objects with potentially stale source_line values
+        coordinate_lines: Complete hunk entries used to locate selected deletions.
 
     Returns:
         New list of LineEntry objects with refreshed source_line values
     """
-    last_source_line = None
-    reannotated_lines = []
-
-    for line in selected_lines:
-        if line.kind in (" ", "+"):
-            source_line = line.new_line_number
-            if source_line is not None:
-                last_source_line = source_line
-        elif line.kind == "-":
-            source_line = last_source_line
-            if (
-                source_line is None
-                and line.old_line_number is not None
-                and line.old_line_number > 1
-            ):
-                source_line = line.old_line_number - 1
-        else:
-            source_line = None
-
-        reannotated_lines.append(replace(line, source_line=source_line))
-
-    return reannotated_lines
+    with _acquire_coordinate_selected_line_records(
+        selected_lines,
+        coordinate_lines,
+    ) as selected_line_records:
+        return _refresh_selected_line_coordinates(
+            selected_lines,
+            coordinate_lines,
+            selected_line_records,
+            lambda line_number: line_number,
+        )
 
 
 def refresh_selected_lines_against_source_lines(
@@ -92,6 +252,7 @@ def refresh_selected_lines_against_source_lines(
     source_lines: Sequence[bytes],
     working_lines: Sequence[bytes],
     lineage: BatchSourceLineage | None = None,
+    coordinate_lines: Sequence[LineEntry] | None = None,
 ) -> list:
     """Re-annotate selected lines against source and working-tree line sequences."""
     mapping = None
@@ -107,28 +268,21 @@ def refresh_selected_lines_against_source_lines(
             assert mapping is not None
             return mapping.get_source_line_from_target_line(line_number)
 
-        last_source_line = None
-        reannotated_lines = []
-
-        for line in selected_lines:
-            if line.kind in (" ", "+"):
-                source_line = map_working_line(line.new_line_number)
-                if source_line is not None:
-                    last_source_line = source_line
-            elif line.kind == "-":
-                source_line = last_source_line
-                if (
-                    source_line is None
-                    and line.old_line_number is not None
-                    and line.old_line_number > 1
-                ):
-                    source_line = map_working_line(line.old_line_number - 1)
-            else:
-                source_line = None
-
-            reannotated_lines.append(replace(line, source_line=source_line))
-
-        return reannotated_lines
+        with _acquire_coordinate_selected_line_records(
+            selected_lines,
+            coordinate_lines,
+        ) as selected_line_records:
+            return _refresh_selected_line_coordinates(
+                selected_lines,
+                coordinate_lines,
+                selected_line_records,
+                map_working_line,
+                map_existing_source_line=(
+                    lineage.translate_source_line
+                    if lineage is not None
+                    else None
+                ),
+            )
     finally:
         if mapping is not None:
             mapping.close()

--- a/src/git_stage_batch/commands/selection/consumed_selection_recording.py
+++ b/src/git_stage_batch/commands/selection/consumed_selection_recording.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from ...batch.ownership.model import BatchOwnership
 from ...batch.ownership.metadata_loading import acquire_ownership_for_metadata_dict
 from ...batch.ownership.merging import merge_batch_ownership
@@ -15,6 +17,7 @@ from ...batch.source.selected_line_refresh import (
     refresh_selected_lines_against_source_lines,
 )
 from ...core.buffer import LineBuffer
+from ...core.models import LineEntry
 from ...batch.source.snapshots import create_batch_source_commit
 from ...data.consumed_selections import (
     read_consumed_file_metadata,
@@ -27,6 +30,7 @@ def record_consumed_selection(
     *,
     source_buffer: LineBuffer,
     selected_lines: list,
+    coordinate_lines: Sequence[LineEntry] | None = None,
     replacement_mask: dict[str, list[str]] | None = None,
 ) -> None:
     """Persist consumed selection ownership for masking across `again`."""
@@ -73,6 +77,7 @@ def record_consumed_selection(
                         source_lines=advance_result.source_buffer,
                         working_lines=(),
                         lineage=advance_result.lineage,
+                        coordinate_lines=coordinate_lines,
                     )
             new_ownership = translate_lines_to_batch_ownership(selected_lines)
             persist_selection(
@@ -82,7 +87,10 @@ def record_consumed_selection(
             return
     else:
         if detect_stale_batch_source_for_selection(selected_lines):
-            selected_lines = refresh_selected_lines_against_new_source(selected_lines)
+            selected_lines = refresh_selected_lines_against_new_source(
+                selected_lines,
+                coordinate_lines=coordinate_lines,
+            )
         merged_ownership = translate_lines_to_batch_ownership(selected_lines)
         batch_source_commit = create_batch_source_commit(
             file_path,

--- a/src/git_stage_batch/commands/selection/include_line_batching.py
+++ b/src/git_stage_batch/commands/selection/include_line_batching.py
@@ -52,6 +52,7 @@ def include_file_lines_to_batch(
         file_path=file_path,
         selected_lines=selection.selected_lines,
         stale_source_action=_("Cannot include lines to batch"),
+        hunk_lines=line_changes.lines,
         snapshot_untracked=True,
     )
 
@@ -99,6 +100,7 @@ def include_selected_lines_to_batch(
         file_path=line_changes.path,
         selected_lines=selection.selected_lines,
         stale_source_action=_("Cannot include lines to batch"),
+        hunk_lines=line_changes.lines,
     )
 
     if not quiet:

--- a/src/git_stage_batch/commands/selection/include_line_replacement.py
+++ b/src/git_stage_batch/commands/selection/include_line_replacement.py
@@ -112,6 +112,7 @@ def apply_include_line_replacement(
         line_changes.path,
         source_buffer=hunk_source_lines,
         selected_lines=selected_lines,
+        coordinate_lines=line_changes.lines,
         replacement_mask={
             "deleted_lines": replacement_payload.as_text().splitlines(),
             "added_lines": [

--- a/src/git_stage_batch/commands/selection/include_line_selection.py
+++ b/src/git_stage_batch/commands/selection/include_line_selection.py
@@ -21,6 +21,7 @@ from ...batch.text_file_storage import add_file_to_batch
 from ...batch.state.batch_names import batch_exists
 from ...core.buffer import LineBuffer, buffer_matches
 from ...batch.source.snapshots import create_batch_source_commit
+from ...batch.source.line_coordinates import translate_display_source_coordinates
 from ...data.selected_change.file_hunk_cache import cache_unstaged_file_as_single_hunk
 from ...data.file_modes import detect_file_mode
 from ...data.file_tracking import auto_add_untracked_files
@@ -195,44 +196,11 @@ def annotate_line_changes_with_working_tree_source(line_changes):
     if line_changes is None:
         return None
 
-    last_source_line: int | None = None
-    coordinate_delta = 0
-    in_deletion_run = False
-    deletion_run_anchor: int | None = None
     new_lines = []
-    for line in line_changes.lines:
-        source_line = None
-        if line.kind == " ":
-            source_line = line.new_line_number
-            if source_line is not None:
-                last_source_line = source_line
-                if line.old_line_number is not None:
-                    coordinate_delta = line.new_line_number - line.old_line_number
-            else:
-                # Synthetic gaps separate hunk coordinate spaces. Do not carry
-                # an anchor across omitted working-tree lines.
-                last_source_line = None
-            in_deletion_run = False
-            deletion_run_anchor = None
-        elif line.kind == "+":
-            source_line = line.new_line_number
-            if source_line is not None:
-                last_source_line = source_line
-            coordinate_delta += 1
-            in_deletion_run = False
-            deletion_run_anchor = None
-        elif line.kind == "-":
-            if not in_deletion_run:
-                deletion_run_anchor = last_source_line
-                if deletion_run_anchor is None and line.old_line_number is not None:
-                    translated_anchor = (
-                        line.old_line_number - 1 + coordinate_delta
-                    )
-                    deletion_run_anchor = max(translated_anchor, 0) or None
-            source_line = deletion_run_anchor
-            coordinate_delta -= 1
-            in_deletion_run = True
-
+    for line, source_line in translate_display_source_coordinates(
+        line_changes.lines,
+        lambda line_number: line_number,
+    ):
         new_lines.append(replace(line, source_line=source_line))
 
     return replace(line_changes, lines=new_lines)

--- a/tests/batch/source/test_annotation.py
+++ b/tests/batch/source/test_annotation.py
@@ -13,6 +13,129 @@ from git_stage_batch.core.buffer import LineBuffer
 from git_stage_batch.core.models import HunkHeader, LineEntry, LineLevelChange
 
 
+def _leading_deletion_changes() -> LineLevelChange:
+    return LineLevelChange(
+        path="file.txt",
+        header=HunkHeader(old_start=1, old_len=3, new_start=1, new_len=1),
+        lines=[
+            LineEntry(
+                id=1,
+                kind="-",
+                old_line_number=1,
+                new_line_number=None,
+                text_bytes=b"first",
+            ),
+            LineEntry(
+                id=2,
+                kind="-",
+                old_line_number=2,
+                new_line_number=None,
+                text_bytes=b"second",
+            ),
+            LineEntry(
+                id=None,
+                kind=" ",
+                old_line_number=3,
+                new_line_number=1,
+                text_bytes=b"remaining",
+            ),
+        ],
+    )
+
+
+def _gapped_deletion_changes() -> LineLevelChange:
+    return LineLevelChange(
+        path="file.txt",
+        header=HunkHeader(old_start=1, old_len=6, new_start=1, new_len=6),
+        lines=[
+            LineEntry(
+                id=1,
+                kind="+",
+                old_line_number=None,
+                new_line_number=1,
+                text_bytes=b"added",
+            ),
+            LineEntry(
+                id=None,
+                kind=" ",
+                old_line_number=1,
+                new_line_number=2,
+                text_bytes=b"one",
+            ),
+            LineEntry(
+                id=None,
+                kind=" ",
+                old_line_number=None,
+                new_line_number=None,
+                text_bytes=b"... 3 more lines ...",
+            ),
+            LineEntry(
+                id=2,
+                kind="-",
+                old_line_number=5,
+                new_line_number=None,
+                text_bytes=b"deleted",
+            ),
+            LineEntry(
+                id=None,
+                kind=" ",
+                old_line_number=6,
+                new_line_number=6,
+                text_bytes=b"six",
+            ),
+        ],
+    )
+
+
+def test_annotation_keeps_consecutive_leading_deletions_before_line_one():
+    """All rows in one leading deletion run share its file-start anchor."""
+    annotated = annotate_with_batch_source_mapping(
+        _leading_deletion_changes(),
+        None,
+    )
+
+    assert [line.source_line for line in annotated.lines] == [None, None, 1]
+
+
+def test_mapped_annotation_keeps_leading_deletion_run_anchor():
+    """Mapped annotation does not project later leading deletions after line one."""
+    annotated = annotate_with_batch_source_lines(
+        _leading_deletion_changes(),
+        batch_source_lines=[b"remaining\n"],
+        working_lines=[b"remaining\n"],
+    )
+
+    assert [line.source_line for line in annotated.lines] == [None, None, 1]
+
+
+def test_annotation_translates_deletion_anchor_after_synthetic_gap():
+    """A later hunk uses the cumulative diff delta, not earlier hunk context."""
+    changes = _gapped_deletion_changes()
+    working_lines = [
+        b"added\n",
+        b"one\n",
+        b"two\n",
+        b"three\n",
+        b"four\n",
+        b"six\n",
+    ]
+
+    first_source = annotate_with_batch_source_mapping(changes, None)
+    mapped_source = annotate_with_batch_source_lines(
+        changes,
+        batch_source_lines=working_lines,
+        working_lines=working_lines,
+    )
+
+    expected_source_lines = [1, 2, None, 5, 6]
+    assert [line.source_line for line in first_source.lines] == (
+        expected_source_lines
+    )
+    assert [line.source_line for line in mapped_source.lines] == (
+        expected_source_lines
+    )
+
+
 def test_annotate_with_batch_source_lines_accepts_non_list_byte_sequences(
     line_sequence,
 ):

--- a/tests/batch/source/test_refresh.py
+++ b/tests/batch/source/test_refresh.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import git_stage_batch.batch.source.refresh as source_refresh
 from git_stage_batch.batch.source.refresh import (
     RefreshedBatchSelection,
     ensure_batch_source_current_for_selection,
+    prepare_initial_batch_source_for_selection,
 )
 from git_stage_batch.batch.source.selected_line_refresh import (
     refresh_selected_lines_against_new_source,
@@ -101,6 +103,156 @@ def test_ensure_batch_source_current_first_time_stale():
     assert result.ownership is None
     assert result.selected_lines[0].source_line == 1
     assert result.source_was_advanced is False
+
+
+def test_prepare_initial_batch_source_maps_selection(monkeypatch):
+    """A first session source receives matching selection coordinates."""
+    lines = [
+        LineEntry(
+            id=1, kind='+', old_line_number=None, new_line_number=2,
+            text_bytes=b"new line", text="new line", source_line=None
+        ),
+    ]
+    cached_sources = {}
+    monkeypatch.setattr(
+        source_refresh,
+        "load_session_batch_sources",
+        lambda: dict(cached_sources),
+    )
+    monkeypatch.setattr(
+        source_refresh,
+        "save_session_batch_sources",
+        lambda sources: cached_sources.update(sources),
+    )
+    monkeypatch.setattr(
+        source_refresh,
+        "create_batch_source_commit",
+        lambda _file_path: "new_source",
+    )
+    monkeypatch.setattr(
+        source_refresh,
+        "read_git_object_buffer_or_none",
+        lambda _object_name: LineBuffer.from_bytes(
+            b"header\nremoved earlier\nnew line\n"
+        ),
+    )
+    monkeypatch.setattr(
+        source_refresh,
+        "load_working_tree_file_as_buffer",
+        lambda _file_path: LineBuffer.from_bytes(b"header\nnew line\n"),
+    )
+
+    batch_source_commit, prepared_lines = (
+        prepare_initial_batch_source_for_selection(
+            "test.py",
+            lines,
+        )
+    )
+
+    assert batch_source_commit == "new_source"
+    assert prepared_lines[0].source_line == 3
+def test_refresh_consecutive_leading_deletions_share_file_start_anchor():
+    """Later rows in one leading deletion run must remain before line one."""
+    first_deletion = LineEntry(
+        id=1,
+        kind="-",
+        old_line_number=1,
+        new_line_number=None,
+        text_bytes=b"first",
+        source_line=None,
+    )
+    second_deletion = LineEntry(
+        id=2,
+        kind="-",
+        old_line_number=2,
+        new_line_number=None,
+        text_bytes=b"second",
+        source_line=1,
+    )
+    trailing_context = LineEntry(
+        id=None,
+        kind=" ",
+        old_line_number=3,
+        new_line_number=1,
+        text_bytes=b"remaining",
+        source_line=1,
+    )
+
+    refreshed = refresh_selected_lines_against_new_source(
+        [second_deletion],
+        coordinate_lines=[
+            first_deletion,
+            second_deletion,
+            trailing_context,
+        ],
+    )
+
+    assert refreshed[0].source_line is None
+
+
+def test_refresh_translates_deletion_anchor_after_synthetic_gap():
+    """A later hunk must not inherit source context from an earlier hunk."""
+    selected_deletion = LineEntry(
+        id=2,
+        kind="-",
+        old_line_number=5,
+        new_line_number=None,
+        text_bytes=b"deleted",
+        source_line=None,
+    )
+    coordinate_lines = [
+        LineEntry(
+            id=1,
+            kind="+",
+            old_line_number=None,
+            new_line_number=1,
+            text_bytes=b"added",
+        ),
+        LineEntry(
+            id=None,
+            kind=" ",
+            old_line_number=1,
+            new_line_number=2,
+            text_bytes=b"one",
+        ),
+        LineEntry(
+            id=None,
+            kind=" ",
+            old_line_number=None,
+            new_line_number=None,
+            text_bytes=b"... 3 more lines ...",
+        ),
+        selected_deletion,
+        LineEntry(
+            id=None,
+            kind=" ",
+            old_line_number=6,
+            new_line_number=6,
+            text_bytes=b"six",
+        ),
+    ]
+    working_lines = [
+        b"added\n",
+        b"one\n",
+        b"two\n",
+        b"three\n",
+        b"four\n",
+        b"six\n",
+    ]
+
+    refreshed_new = refresh_selected_lines_against_new_source(
+        [selected_deletion],
+        coordinate_lines=coordinate_lines,
+    )
+    refreshed_mapped = refresh_selected_lines_against_source_lines(
+        [selected_deletion],
+        source_lines=working_lines,
+        working_lines=working_lines,
+        coordinate_lines=coordinate_lines,
+    )
+
+    assert refreshed_new[0].source_line == 5
+    assert refreshed_mapped[0].source_line == 5
 
 
 def test_source_refresh_preserves_missing_final_newline():

--- a/tests/batch/source/test_refresh.py
+++ b/tests/batch/source/test_refresh.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import git_stage_batch.batch.source.refresh as source_refresh
+import pytest
 from git_stage_batch.batch.source.refresh import (
     RefreshedBatchSelection,
     ensure_batch_source_current_for_selection,
@@ -11,6 +12,10 @@ from git_stage_batch.batch.source.refresh import (
 from git_stage_batch.batch.source.selected_line_refresh import (
     refresh_selected_lines_against_new_source,
     refresh_selected_lines_against_source_lines,
+)
+from git_stage_batch.batch.line_matching.lineage import (
+    BatchSourceLineage,
+    LineageRun,
 )
 from git_stage_batch.batch.ownership.model import BatchOwnership
 from git_stage_batch.batch.source.advancement import (
@@ -151,6 +156,83 @@ def test_prepare_initial_batch_source_maps_selection(monkeypatch):
 
     assert batch_source_commit == "new_source"
     assert prepared_lines[0].source_line == 3
+
+
+def test_prepare_initial_cached_source_remaps_deletion_anchor(monkeypatch):
+    """Deletion-only selections are mapped instead of range-validated."""
+    monkeypatch.setattr(
+        source_refresh,
+        "load_session_batch_sources",
+        lambda: {"test.py": "cached_source"},
+    )
+    monkeypatch.setattr(
+        source_refresh,
+        "read_git_object_buffer_or_none",
+        lambda _object_name: LineBuffer.from_bytes(
+            b"header\nextra\nanchor\ndelete me\nfooter\n"
+        ),
+    )
+    monkeypatch.setattr(
+        source_refresh,
+        "load_working_tree_file_as_buffer",
+        lambda _file_path: LineBuffer.from_bytes(
+            b"header\nanchor\nfooter\n"
+        ),
+    )
+    monkeypatch.setattr(
+        source_refresh,
+        "create_batch_source_commit",
+        lambda *_args, **_kwargs: pytest.fail(
+            "the cached source should remain usable"
+        ),
+    )
+    selected_lines = [
+        LineEntry(
+            id=1,
+            kind="-",
+            old_line_number=3,
+            new_line_number=None,
+            text_bytes=b"delete me",
+            source_line=2,
+        ),
+    ]
+
+    batch_source_commit, prepared_lines = (
+        prepare_initial_batch_source_for_selection(
+            "test.py",
+            selected_lines,
+        )
+    )
+
+    assert batch_source_commit == "cached_source"
+    assert prepared_lines[0].source_line == 3
+
+
+def test_refresh_deletion_anchor_uses_source_lineage_without_prior_context():
+    """A hunk-leading deletion retains its old batch-source identity."""
+    selected_line = LineEntry(
+        id=1,
+        kind="-",
+        old_line_number=3,
+        new_line_number=None,
+        text_bytes=b"delete me",
+        source_line=1,
+    )
+    with BatchSourceLineage.from_runs(
+        source_runs=[LineageRun(old_start=1, old_end=1, new_start=2)],
+        working_runs=[LineageRun(old_start=2, old_end=2, new_start=3)],
+    ) as lineage:
+        refreshed = refresh_selected_lines_against_source_lines(
+            [selected_line],
+            source_lines=[b"inserted\n", b"anchor\n"],
+            working_lines=[b"first\n", b"anchor\n"],
+            lineage=lineage,
+            coordinate_lines=[selected_line],
+        )
+
+    assert refreshed[0].source_line == 2
+
+
 def test_refresh_consecutive_leading_deletions_share_file_start_anchor():
     """Later rows in one leading deletion run must remain before line one."""
     first_deletion = LineEntry(
@@ -278,6 +360,8 @@ def test_source_refresh_preserves_missing_final_newline():
 
     assert refreshed_new[0].has_trailing_newline is False
     assert refreshed_mapped[0].has_trailing_newline is False
+
+
 def test_refresh_selected_lines_uses_synthesized_working_line_provenance():
     """Repeated working lines should use known synthesis identity."""
     ownership = BatchOwnership.from_presence_lines(["1,4"], [])

--- a/tests/commands/selection/test_consumed_selection_recording.py
+++ b/tests/commands/selection/test_consumed_selection_recording.py
@@ -77,6 +77,68 @@ def test_record_consumed_selection_refreshes_stale_first_selection(temp_git_repo
     ]
 
 
+def test_consumed_replacement_uses_complete_hunk_coordinates(temp_git_repo):
+    """A shifted deletion anchor must use preceding unselected hunk context."""
+    test_file = temp_git_repo / "test.txt"
+    test_file.write_text("staged\ntop\nold\n")
+    subprocess.run(
+        ["git", "add", "test.txt"],
+        check=True,
+        cwd=temp_git_repo,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "Add shifted replacement"],
+        check=True,
+        cwd=temp_git_repo,
+        capture_output=True,
+    )
+    test_file.write_text("top\nnew\n")
+    command_start()
+    context = LineEntry(
+        id=None,
+        kind=" ",
+        old_line_number=2,
+        new_line_number=1,
+        text_bytes=b"top",
+        text="top",
+        source_line=None,
+    )
+    deletion = LineEntry(
+        id=1,
+        kind="-",
+        old_line_number=3,
+        new_line_number=None,
+        text_bytes=b"old",
+        text="old",
+        source_line=None,
+    )
+    addition = LineEntry(
+        id=2,
+        kind="+",
+        old_line_number=None,
+        new_line_number=2,
+        text_bytes=b"new",
+        text="new",
+        source_line=None,
+    )
+
+    with LineBuffer.from_bytes(b"top\nnew\n") as source_buffer:
+        record_consumed_selection(
+            "test.txt",
+            source_buffer=source_buffer,
+            selected_lines=[deletion, addition],
+            coordinate_lines=[context, deletion, addition],
+        )
+
+    metadata = read_consumed_file_metadata("test.txt")
+    assert metadata is not None
+    with acquire_ownership_for_metadata(metadata) as ownership:
+        assert ownership.presence_line_set() == {2}
+        assert ownership.deletions[0].anchor_line == 1
+        assert list(ownership.deletions[0].content_lines) == [b"old\n"]
+
+
 def test_corrupt_consumed_selection_state_fails_closed(temp_git_repo):
     """Corrupt masking state must not make consumed lines visible again."""
     get_session_consumed_selections_file_path().parent.mkdir(


### PR DESCRIPTION
Saved-baseline fallback now validates live coordinates and round-trips
reordered whole-file batches.

A first selection can still use working or cached coordinates that are
numerically valid but name different lines in the snapshot stored for a new
batch. Shifted additions, deletion anchors, and consumed replacements can
persist the wrong ownership.

This commit series creates or loads the initial source before translation,
maps selected rows and hunk context through the working file, and replaces
a cached source only when it cannot be mapped.

First selections now retain saved-snapshot coordinates across shifted
additions, cached deletions, and consumed replacements.