### PR TITLE
discard: Project replacement ownership onto batch baselines

### DIFF
--- a/src/git_stage_batch/batch/merge/baseline_reference_translation.py
+++ b/src/git_stage_batch/batch/merge/baseline_reference_translation.py
@@ -17,6 +17,7 @@ from ...core.text_lines import (
 from ..line_matching.line_range_view import LineRangeView
 from ..line_matching.line_mapping import LineMapping
 from ..line_matching.match import match_lines
+from ..ownership.absence_content import build_absence_content_from_range
 from ..ownership.model import BatchOwnership
 from ..ownership.references import BaselineReference
 from .baseline_reference_positions import (
@@ -205,6 +206,8 @@ def _translate_removal_reference(
     source_lines: Sequence[bytes],
     target_lines: Sequence[bytes],
     mapping: LineMapping,
+    *,
+    allow_content_change: bool = False,
 ) -> tuple[BaselineReference, int] | None:
     source_position = _recorded_removal_position(
         reference,
@@ -228,9 +231,12 @@ def _translate_removal_reference(
         target_lines,
         mapping,
     )
-    if target_position is None or any(
-        target_lines[target_position + offset] != content
-        for offset, content in enumerate(content_lines)
+    if target_position is None or (
+        not allow_content_change
+        and any(
+            target_lines[target_position + offset] != content
+            for offset, content in enumerate(content_lines)
+        )
     ):
         return None
     return (
@@ -355,9 +361,127 @@ def _translate_deletion_references(
             target_lines,
             mapping,
         )
-        deletion.baseline_reference = (
-            translated[0] if translated is not None else None
+        _apply_translated_deletion(
+            deletion,
+            content_lines,
+            target_lines,
+            translated,
         )
+
+
+def _apply_translated_deletion(
+    deletion,
+    content_lines: Sequence[bytes],
+    target_lines: Sequence[bytes],
+    translated: tuple[BaselineReference, int] | None,
+) -> None:
+    """Apply a projected reference and target-baseline removal content."""
+    if translated is None:
+        deletion.baseline_reference = None
+        return
+
+    deletion.baseline_reference, target_position = translated
+    if any(
+        target_lines[target_position + offset] != content
+        for offset, content in enumerate(content_lines)
+    ):
+        deletion.content_lines = build_absence_content_from_range(
+            target_lines,
+            target_position,
+            target_position + len(content_lines),
+        )
+
+
+def _translate_deletion_from_origin_offset(
+    deletion,
+    origin,
+    target_lines: Sequence[bytes],
+) -> tuple[BaselineReference, int] | None:
+    """Project one split replacement by its offset inside the parent."""
+    reference = deletion.baseline_reference
+    origin_reference = origin.baseline_reference
+    old_start = origin.old_start
+    old_line_count = origin.old_line_count
+    if (
+        reference is None
+        or not reference.has_after_line
+        or origin_reference is None
+        or not origin_reference.has_after_line
+        or type(old_start) is not int
+        or type(old_line_count) is not int
+        or old_line_count <= 0
+    ):
+        return None
+
+    source_position = reference.after_line or 0
+    relative_offset = source_position - (old_start - 1)
+    line_count = len(deletion.content_lines)
+    if (
+        relative_offset < 0
+        or line_count <= 0
+        or relative_offset + line_count > old_line_count
+    ):
+        return None
+
+    target_position = (origin_reference.after_line or 0) + relative_offset
+    if target_position + line_count > len(target_lines):
+        return None
+    return (
+        _reference_for_removal(
+            target_lines,
+            target_position,
+            line_count,
+        ),
+        target_position,
+    )
+
+
+def _translate_origin_backed_deletion_references(
+    ownership: BatchOwnership,
+    origin_backed: MappedIntVector,
+    source_lines: Sequence[bytes],
+    target_lines: Sequence[bytes],
+    mapping: LineMapping,
+) -> None:
+    """Translate replacement deletions from live HEAD, with parent fallback."""
+    for unit in ownership.replacement_units:
+        origin = unit.origin
+        if origin is None:
+            continue
+        for deletion_index in unit.deletion_indices:
+            if (
+                type(deletion_index) is not int
+                or deletion_index < 0
+                or deletion_index >= len(ownership.deletions)
+                or origin_backed[deletion_index] != 1
+            ):
+                continue
+
+            deletion = ownership.deletions[deletion_index]
+            content_lines = normalize_line_sequence_endings(
+                deletion.content_lines
+            )
+            translated = _translate_removal_reference(
+                deletion.baseline_reference,
+                content_lines,
+                source_lines,
+                target_lines,
+                mapping,
+                allow_content_change=True,
+            )
+            if translated is None:
+                translated = _translate_deletion_from_origin_offset(
+                    deletion,
+                    origin,
+                    target_lines,
+                )
+            _apply_translated_deletion(
+                deletion,
+                content_lines,
+                target_lines,
+                translated,
+            )
+            origin_backed[deletion_index] = 2
 
 
 def _translate_replacement_origin_references(
@@ -407,6 +531,7 @@ def _translate_replacement_origin_references(
                 source_lines,
                 target_lines,
                 mapping,
+                allow_content_change=True,
             )
             origin.baseline_reference = (
                 translated[0] if translated is not None else None
@@ -483,19 +608,15 @@ def translate_ownership_baseline_references(
             target_sequence.acquire_lines() as target_lines,
             match_lines(origin_source_lines, target_lines) as mapping,
         ):
-            _translate_deletion_references(
+            _translate_replacement_origin_references(
                 ownership,
-                (
-                    deletion_index
-                    for deletion_index in range(len(ownership.deletions))
-                    if origin_backed[deletion_index] != 0
-                ),
                 origin_source_lines,
                 target_lines,
                 mapping,
             )
-            _translate_replacement_origin_references(
+            _translate_origin_backed_deletion_references(
                 ownership,
+                origin_backed,
                 origin_source_lines,
                 target_lines,
                 mapping,

--- a/src/git_stage_batch/batch/ownership_update.py
+++ b/src/git_stage_batch/batch/ownership_update.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Iterator, Sequence
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
 
 from ..core.models import LineEntry
@@ -16,7 +16,12 @@ from .ownership.replacement_line_runs import ReplacementLineRun
 from .merge.baseline_reference_translation import (
     translate_ownership_baseline_references,
 )
-from .source.refresh import ensure_batch_source_current_for_selection
+from .source.refresh import (
+    RefreshedBatchSelection,
+    ensure_batch_source_current_for_selection,
+    prepare_initial_batch_source_for_selection,
+)
+from ..utils.repository_buffers import read_git_object_buffer_or_empty
 
 
 @dataclass
@@ -110,8 +115,31 @@ def prepare_batch_ownership_update_for_selection(
         file_path=file_path,
         current_batch_source_commit=current_batch_source_commit,
         existing_ownership=existing_ownership,
-        selected_lines=selected_lines
+        selected_lines=selected_lines,
+        coordinate_lines=hunk_lines,
     )
+    return _prepare_batch_ownership_update_from_refreshed_selection(
+        refreshed,
+        hunk_lines=hunk_lines,
+        replacement_line_runs=replacement_line_runs,
+        replacement_origin_line_runs=replacement_origin_line_runs,
+        reference_source_lines=reference_source_lines,
+        reference_target_lines=reference_target_lines,
+        replacement_origin_source_lines=replacement_origin_source_lines,
+    )
+
+
+def _prepare_batch_ownership_update_from_refreshed_selection(
+    refreshed: RefreshedBatchSelection,
+    *,
+    hunk_lines: Sequence[LineEntry] | None = None,
+    replacement_line_runs: Iterable[ReplacementLineRun] | None = None,
+    replacement_origin_line_runs: Iterable[ReplacementLineRun] | None = None,
+    reference_source_lines: Sequence[bytes] | None = None,
+    reference_target_lines: Sequence[bytes] | None = None,
+    replacement_origin_source_lines: Sequence[bytes] | None = None,
+) -> PreparedBatchUpdate:
+    """Translate and merge a selection whose source is already established."""
 
     new_ownership = _translate_selection_to_batch_ownership(
         refreshed.selected_lines,
@@ -158,11 +186,12 @@ def acquire_batch_ownership_update_for_selection(
     file_path: str,
     file_metadata: dict | None,
     selected_lines: list,
+    initial_batch_source_commit: str | None = None,
     hunk_lines: Sequence[LineEntry] | None = None,
     replacement_line_runs: Iterable[ReplacementLineRun] | None = None,
     replacement_origin_line_runs: Iterable[ReplacementLineRun] | None = None,
     reference_source_lines: Sequence[bytes] | None = None,
-    reference_target_lines: Sequence[bytes] | None = None,
+    batch_baseline_commit: str | None = None,
     replacement_origin_source_lines: Sequence[bytes] | None = None,
 ) -> Iterator[PreparedBatchUpdate]:
     """Acquire existing ownership metadata while preparing a batch update.
@@ -170,33 +199,67 @@ def acquire_batch_ownership_update_for_selection(
     The yielded ownership may borrow deletion content from acquired metadata,
     so callers should persist or detach it before leaving the context.
     """
-    if file_metadata is None:
-        yield prepare_batch_ownership_update_for_selection(
-            batch_name=batch_name,
-            file_path=file_path,
-            current_batch_source_commit=None,
-            existing_ownership=None,
-            selected_lines=selected_lines,
-            hunk_lines=hunk_lines,
-            replacement_line_runs=replacement_line_runs,
-            replacement_origin_line_runs=replacement_origin_line_runs,
-            reference_source_lines=reference_source_lines,
-            reference_target_lines=reference_target_lines,
-            replacement_origin_source_lines=replacement_origin_source_lines,
-        )
-        return
+    with ExitStack() as stack:
+        if file_metadata is None:
+            if initial_batch_source_commit is None:
+                current_batch_source_commit, prepared_selected_lines = (
+                    prepare_initial_batch_source_for_selection(
+                        file_path,
+                        selected_lines,
+                        coordinate_lines=hunk_lines,
+                    )
+                )
+            else:
+                current_batch_source_commit = initial_batch_source_commit
+                prepared_selected_lines = selected_lines
+            existing_ownership = None
+            refreshed = RefreshedBatchSelection(
+                batch_source_commit=current_batch_source_commit,
+                ownership=existing_ownership,
+                selected_lines=prepared_selected_lines,
+                source_was_advanced=False,
+            )
+        else:
+            current_batch_source_commit = file_metadata.get(
+                "batch_source_commit"
+            )
+            existing_ownership = stack.enter_context(
+                acquire_ownership_for_metadata_dict(file_metadata)
+            )
+            refreshed = ensure_batch_source_current_for_selection(
+                batch_name=batch_name,
+                file_path=file_path,
+                current_batch_source_commit=current_batch_source_commit,
+                existing_ownership=existing_ownership,
+                selected_lines=selected_lines,
+                coordinate_lines=hunk_lines,
+            )
 
-    with acquire_ownership_for_metadata_dict(file_metadata) as existing_ownership:
-        yield prepare_batch_ownership_update_for_selection(
-            batch_name=batch_name,
-            file_path=file_path,
-            current_batch_source_commit=file_metadata.get("batch_source_commit"),
-            existing_ownership=existing_ownership,
-            selected_lines=selected_lines,
-            hunk_lines=hunk_lines,
-            replacement_line_runs=replacement_line_runs,
-            replacement_origin_line_runs=replacement_origin_line_runs,
-            reference_source_lines=reference_source_lines,
-            reference_target_lines=reference_target_lines,
-            replacement_origin_source_lines=replacement_origin_source_lines,
-        )
+        def prepare_update(
+            reference_target_lines: Sequence[bytes] | None,
+        ) -> PreparedBatchUpdate:
+            return _prepare_batch_ownership_update_from_refreshed_selection(
+                refreshed,
+                hunk_lines=hunk_lines,
+                replacement_line_runs=replacement_line_runs,
+                replacement_origin_line_runs=replacement_origin_line_runs,
+                reference_source_lines=reference_source_lines,
+                reference_target_lines=reference_target_lines,
+                replacement_origin_source_lines=replacement_origin_source_lines,
+            )
+
+        if reference_source_lines is None:
+            update = prepare_update(None)
+        else:
+            if not isinstance(batch_baseline_commit, str) or not (
+                batch_baseline_commit
+            ):
+                raise ValueError(
+                    "selection baseline lines require a batch baseline commit"
+                )
+            with read_git_object_buffer_or_empty(
+                f"{batch_baseline_commit}:{file_path}"
+            ) as reference_target_lines:
+                update = prepare_update(reference_target_lines)
+
+        yield update

--- a/src/git_stage_batch/commands/selection/batch_line_updates.py
+++ b/src/git_stage_batch/commands/selection/batch_line_updates.py
@@ -40,9 +40,6 @@ def add_selected_lines_to_batch(
     metadata = read_batch_metadata(batch_name)
     file_metadata = metadata.get("files", {}).get(file_path)
     baseline_commit = get_validated_baseline_commit(batch_name)
-    batch_baseline_lines = read_git_object_buffer_or_empty(
-        f"{baseline_commit}:{file_path}"
-    )
     replacement_origin_source_buffer = (
         read_git_object_buffer_or_empty(f"HEAD:{file_path}")
         if hunk_lines is not None and replacement_line_runs
@@ -50,9 +47,6 @@ def add_selected_lines_to_batch(
     )
 
     with ExitStack() as ownership_stack:
-        reference_target_lines = ownership_stack.enter_context(
-            batch_baseline_lines
-        )
         replacement_origin_source_lines = (
             ownership_stack.enter_context(replacement_origin_source_buffer)
             if replacement_origin_source_buffer is not None
@@ -71,7 +65,7 @@ def add_selected_lines_to_batch(
                     hunk_lines=hunk_lines,
                     replacement_line_runs=replacement_line_runs,
                     reference_source_lines=reference_source_lines,
-                    reference_target_lines=reference_target_lines,
+                    batch_baseline_commit=baseline_commit,
                     replacement_origin_source_lines=(
                         replacement_origin_source_lines
                     ),

--- a/src/git_stage_batch/commands/selection/discard_line_replacement.py
+++ b/src/git_stage_batch/commands/selection/discard_line_replacement.py
@@ -15,6 +15,9 @@ from ...batch.ownership.merging import merge_batch_ownership
 from ...batch.ownership.remapping import remap_batch_ownership_with_lineage
 from ...batch.ownership.translation import translate_lines_to_batch_ownership
 from ...batch.ownership_update import acquire_batch_ownership_update_for_selection
+from ...batch.merge.baseline_reference_translation import (
+    translate_ownership_baseline_references,
+)
 from ...batch.state.query import read_batch_metadata
 from ...batch.ownership.replacement_line_runs import (
     ReplacementLineRun,
@@ -184,17 +187,40 @@ def add_discard_line_replacement_to_batch(
 
     metadata = read_batch_metadata(batch_name)
     file_metadata = metadata.get("files", {}).get(selection.file_path)
-    batch_source_commit = None
 
     with ExitStack() as ownership_stack:
         try:
             if file_metadata is None:
+                batch_source_commit = create_batch_source_commit(
+                    selection.file_path,
+                    file_buffer_override=selection.rewritten_working_lines,
+                )
+                _record_session_batch_source(
+                    selection.file_path,
+                    batch_source_commit,
+                )
+                prepared_selected_lines = (
+                    refresh_selected_lines_against_source_lines(
+                        selection.rewritten_selected_lines,
+                        source_lines=selection.rewritten_working_lines,
+                        working_lines=selection.rewritten_working_lines,
+                        coordinate_lines=selection.rewritten_line_changes.lines,
+                    )
+                )
+                reference_source_lines = ownership_stack.enter_context(
+                    read_git_object_buffer_or_empty(
+                        f"HEAD:{selection.file_path}"
+                    )
+                )
                 update = ownership_stack.enter_context(
                     acquire_batch_ownership_update_for_selection(
                         batch_name=batch_name,
                         file_path=selection.file_path,
                         file_metadata=None,
-                        selected_lines=selection.rewritten_selected_lines,
+                        selected_lines=prepared_selected_lines,
+                        initial_batch_source_commit=batch_source_commit,
+                        reference_source_lines=reference_source_lines,
+                        batch_baseline_commit=metadata.get("baseline"),
                     )
                 )
                 ownership = update.ownership_after
@@ -203,6 +229,7 @@ def add_discard_line_replacement_to_batch(
                 ownership, batch_source_commit = _merge_replacement_with_batch(
                     selection,
                     file_metadata=file_metadata,
+                    batch_baseline_commit=metadata.get("baseline"),
                     ownership_stack=ownership_stack,
                 )
         except ValueError as e:
@@ -214,13 +241,6 @@ def add_discard_line_replacement_to_batch(
                     "Error: {error}"
                 ).format(file=selection.file_path, batch=batch_name, error=str(e))
             )
-
-        if batch_source_commit is None:
-            batch_source_commit = create_batch_source_commit(
-                selection.file_path,
-                file_buffer_override=selection.rewritten_working_lines,
-            )
-            _record_session_batch_source(selection.file_path, batch_source_commit)
 
         snapshot_file_if_untracked(selection.file_path)
         add_file_to_batch(
@@ -236,8 +256,12 @@ def _merge_replacement_with_batch(
     selection: DiscardLineReplacementSelection,
     *,
     file_metadata: dict,
+    batch_baseline_commit: object,
     ownership_stack: ExitStack,
 ):
+    if not isinstance(batch_baseline_commit, str) or not batch_baseline_commit:
+        raise ValueError("replacement update requires a batch baseline commit")
+
     current_batch_source = file_metadata.get("batch_source_commit")
     existing_ownership = ownership_stack.enter_context(
         acquire_ownership_for_metadata_dict(file_metadata)
@@ -254,6 +278,12 @@ def _merge_replacement_with_batch(
 
     with (
         old_source_buffer as old_source_lines,
+        read_git_object_buffer_or_empty(
+            f"HEAD:{selection.file_path}"
+        ) as reference_source_lines,
+        read_git_object_buffer_or_empty(
+            f"{batch_baseline_commit}:{selection.file_path}"
+        ) as reference_target_lines,
         advance_source_lines_preserving_existing_presence(
             old_lines=old_source_lines,
             working_lines=selection.rewritten_working_lines,
@@ -269,8 +299,14 @@ def _merge_replacement_with_batch(
             source_lines=source_with_provenance.source_buffer,
             working_lines=(),
             lineage=source_with_provenance.lineage,
+            coordinate_lines=selection.rewritten_line_changes.lines,
         )
         new_ownership = translate_lines_to_batch_ownership(refreshed_selected_lines)
+        translate_ownership_baseline_references(
+            new_ownership,
+            reference_source_lines,
+            reference_target_lines,
+        )
         batch_source_commit = create_batch_source_commit(
             selection.file_path,
             file_buffer_override=source_with_provenance.source_buffer,

--- a/tests/batch/merge/test_baseline_reference_translation.py
+++ b/tests/batch/merge/test_baseline_reference_translation.py
@@ -203,3 +203,85 @@ def test_translates_replacement_origin_from_live_head_to_batch_baseline():
     assert origin.baseline_reference is not None
     assert origin.baseline_reference.after_line == 6
     assert origin.baseline_reference.before_line == 8
+
+
+def test_projects_split_replacement_content_through_parent_origin():
+    """A saved baseline may have different bytes inside the same parent span."""
+    head = [b"head\n", b"head-one\n", b"head-two\n", b"tail\n"]
+    target = [b"head\n", b"saved-one\n", b"saved-two\n", b"tail\n"]
+    deletion_reference = BaselineReference(
+        after_line=1,
+        after_content=b"head",
+        before_line=3,
+        before_content=b"head-two",
+        has_before_line=True,
+    )
+    origin_reference = BaselineReference(
+        after_line=1,
+        after_content=b"head",
+        before_line=4,
+        before_content=b"tail",
+        has_before_line=True,
+    )
+    deletion = AbsenceClaim(
+        anchor_line=1,
+        content_lines=[b"head-one\n"],
+        baseline_reference=deletion_reference,
+    )
+    origin = ReplacementUnitOrigin(
+        old_start=2,
+        old_end=3,
+        new_start=2,
+        new_end=3,
+        baseline_reference=origin_reference,
+    )
+    ownership = BatchOwnership.from_presence_lines(
+        ["2"],
+        [deletion],
+        replacement_units=[
+            ReplacementUnit(
+                presence_lines=["2"],
+                deletion_indices=[0],
+                origin=origin,
+            )
+        ],
+    )
+
+    translate_ownership_baseline_references(
+        ownership,
+        head,
+        target,
+        replacement_origin_source_lines=head,
+    )
+
+    assert list(deletion.content_lines) == [b"saved-one\n"]
+    assert deletion.baseline_reference is not None
+    assert deletion.baseline_reference.after_line == 1
+    assert deletion.baseline_reference.before_line == 3
+    assert deletion.baseline_reference.before_content == b"saved-two\n"
+    assert origin.baseline_reference is not None
+    assert origin.baseline_reference.after_line == 1
+    assert origin.baseline_reference.before_line == 4
+
+
+def test_does_not_project_plain_deletion_onto_different_content():
+    """Ordinary deletions must not absorb unrelated target-baseline bytes."""
+    source = [b"head\n", b"old\n", b"tail\n"]
+    target = [b"head\n", b"unrelated\n", b"tail\n"]
+    deletion = AbsenceClaim(
+        anchor_line=1,
+        content_lines=[b"old\n"],
+        baseline_reference=BaselineReference(
+            after_line=1,
+            after_content=b"head",
+            before_line=3,
+            before_content=b"tail",
+            has_before_line=True,
+        ),
+    )
+    ownership = BatchOwnership.from_presence_lines([], [deletion])
+
+    translate_ownership_baseline_references(ownership, source, target)
+
+    assert deletion.baseline_reference is None
+    assert list(deletion.content_lines) == [b"old\n"]

--- a/tests/commands/test_discard.py
+++ b/tests/commands/test_discard.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 from git_stage_batch.utils.paths import get_abort_snapshots_directory_path
 from git_stage_batch.utils.paths import get_state_directory_path
+from git_stage_batch.batch.state.lifecycle import create_batch
 from git_stage_batch.batch.state.query import list_batch_files, read_batch_metadata
 from git_stage_batch.batch.file_entry_storage import read_file_from_batch
 from git_stage_batch.commands.discard import command_discard_to_batch
@@ -1261,6 +1262,75 @@ class TestCommandDiscardToBatch:
 
         command_apply_from_batch("feature-batch")
         assert readme.read_text() == "# Test\nstaged1\nline2\nline3\nline4\nline5\nline6\nline7\nstaged8\n"
+
+    def test_followup_replacement_projects_onto_older_batch_baseline(
+        self,
+        temp_git_repo,
+    ):
+        """An existing replacement batch must retain its original baseline."""
+        file_path = temp_git_repo / "replacement.txt"
+        file_path.write_text(
+            "prefix\n"
+            "head\n"
+            "old1\n"
+            "middle\n"
+            "old2\n"
+            "tail\n"
+        )
+        subprocess.run(
+            ["git", "add", "replacement.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add repeated replacements"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        create_batch("feature-batch")
+
+        file_path.write_text("head\nold1\nmiddle\nold2\ntail\n")
+        subprocess.run(
+            ["git", "add", "replacement.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Remove prefix"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        file_path.write_text("head\nedit1\nmiddle\nedit2\ntail\n")
+
+        command_start(quiet=True)
+        fetch_next_change()
+        command_discard_line_as_to_batch(
+            "feature-batch",
+            "1",
+            "saved1",
+            quiet=True,
+        )
+        command_discard_line_as_to_batch(
+            "feature-batch",
+            "1",
+            "saved2",
+            file="replacement.txt",
+            quiet=True,
+        )
+
+        assert file_path.read_text() == "head\nold1\nmiddle\nold2\ntail\n"
+        assert read_file_from_batch(
+            "feature-batch",
+            "replacement.txt",
+        ) == "prefix\nhead\nsaved1\nmiddle\nsaved2\ntail\n"
+
+        command_apply_from_batch("feature-batch")
+
+        assert file_path.read_text() == "head\nsaved1\nmiddle\nsaved2\ntail\n"
 
     def test_discard_line_as_to_batch_replaces_disjoint_file_scoped_regions(self, temp_git_repo):
         """Discard replacement should accept one contiguous range across regions."""

--- a/tests/commands/test_include_to.py
+++ b/tests/commands/test_include_to.py
@@ -191,6 +191,43 @@ class TestCommandIncludeToBatch:
         with pytest.raises(NoMoreHunks):
             fetch_next_change()
 
+    def test_partial_leading_deletion_uses_full_hunk_boundary(self, temp_git_repo):
+        """Selecting a later leading deletion keeps an earlier deleted line."""
+        file_path = temp_git_repo / "leading.txt"
+        file_path.write_text("first\nsecond\nremaining\n")
+        subprocess.run(
+            ["git", "add", "leading.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add leading lines"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        file_path.write_text("remaining\n")
+
+        command_start()
+        fetch_next_change()
+        line_changes = load_line_changes_from_state()
+        second_deletion = next(
+            line
+            for line in line_changes.lines
+            if line.kind == "-" and line.text_bytes == b"second"
+        )
+
+        command_include_to_batch(
+            "leading-deletion",
+            line_ids=str(second_deletion.id),
+        )
+
+        assert read_file_from_batch(
+            "leading-deletion",
+            "leading.txt",
+        ) == "first\nremaining\n"
+
     def test_include_empty_deleted_text_file_to_batch(self, temp_git_repo):
         """Whole-file include to batch should persist empty text deletions."""
         empty_file = temp_git_repo / "empty.txt"

--- a/tests/functional/test_stale_batch_source_advancement.py
+++ b/tests/functional/test_stale_batch_source_advancement.py
@@ -158,6 +158,40 @@ def test_replacement_to_new_batch_uses_its_rewritten_source(functional_repo):
     )
 
 
+def test_replacement_after_earlier_deletion_uses_full_hunk_context(functional_repo):
+    """Rewritten deletion anchors must use current, not old-file, coordinates."""
+    test_file = functional_repo / "replacement.txt"
+    baseline = "A\nX\nB\nD\nC\n"
+    test_file.write_text(baseline)
+    subprocess.run(
+        ["git", "add", "replacement.txt"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "Add replacement anchors"],
+        check=True,
+        capture_output=True,
+    )
+
+    test_file.write_text("S\n" + baseline)
+    command_start(quiet=True)
+
+    test_file.write_text("A\nB\nC\n")
+    command_again(quiet=True)
+    command_discard_line_as_to_batch(
+        "replacement",
+        "2",
+        "Z",
+        file="replacement.txt",
+        quiet=True,
+    )
+
+    metadata = read_batch_metadata("replacement")
+    deletion = metadata["files"]["replacement.txt"]["deletions"][0]
+    assert deletion["after_source_line"] == 2
+
+
 def test_initial_deletion_anchor_uses_session_snapshot_coordinates(functional_repo):
     """A deletion-only first save remains extensible after session file drift."""
     test_file = functional_repo / "anchors.txt"

--- a/tests/functional/test_stale_batch_source_advancement.py
+++ b/tests/functional/test_stale_batch_source_advancement.py
@@ -112,7 +112,7 @@ def test_again_include_to_new_batch_does_not_reuse_stale_session_source(function
 
 
 def test_initial_deletion_anchor_uses_session_snapshot_coordinates(functional_repo):
-    """A deletion-only first save uses its session snapshot after file drift."""
+    """A deletion-only first save remains extensible after session file drift."""
     test_file = functional_repo / "anchors.txt"
     baseline = "header\nanchor\ndelete me\nfooter\n"
     test_file.write_text(baseline)
@@ -145,6 +145,20 @@ def test_initial_deletion_anchor_uses_session_snapshot_coordinates(functional_re
         "header\nanchor\nfooter\n"
     )
 
+    test_file.write_text(baseline + "later\n")
+    command_again(quiet=True)
+    command_discard_to_batch(
+        batch_name="saved",
+        file="anchors.txt",
+        quiet=True,
+        advance=False,
+    )
+
+    final_batch_commit = get_batch_commit_sha("saved")
+    assert final_batch_commit is not None
+    assert _show_file(final_batch_commit, "anchors.txt") == (
+        "header\nanchor\nfooter\nlater\n"
+    )
 
 
 def test_initial_later_deletion_uses_full_hunk_anchor_context(functional_repo):

--- a/tests/functional/test_stale_batch_source_advancement.py
+++ b/tests/functional/test_stale_batch_source_advancement.py
@@ -111,6 +111,41 @@ def test_again_include_to_new_batch_does_not_reuse_stale_session_source(function
     assert 'return "layer3"' not in realized_content
 
 
+def test_initial_deletion_anchor_uses_session_snapshot_coordinates(functional_repo):
+    """A deletion-only first save uses its session snapshot after file drift."""
+    test_file = functional_repo / "anchors.txt"
+    baseline = "header\nanchor\ndelete me\nfooter\n"
+    test_file.write_text(baseline)
+    subprocess.run(["git", "add", "anchors.txt"], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "Add anchored deletion"],
+        check=True,
+        capture_output=True,
+    )
+
+    test_file.write_text(
+        "header\nextra at session start\nanchor\ndelete me\nfooter\n"
+    )
+    command_start(quiet=True)
+
+    test_file.write_text("header\nanchor\nfooter\n")
+    command_again(quiet=True)
+    command_discard_to_batch(
+        batch_name="saved",
+        line_ids="1",
+        file="anchors.txt",
+        quiet=True,
+        advance=False,
+    )
+
+    assert test_file.read_text() == baseline
+    first_batch_commit = get_batch_commit_sha("saved")
+    assert first_batch_commit is not None
+    assert _show_file(first_batch_commit, "anchors.txt") == (
+        "header\nanchor\nfooter\n"
+    )
+
+
 def test_stale_discard_preserves_previously_discarded_claimed_lines(functional_repo):
     """Advancing a discard batch must not drop lines already removed from WT."""
     test_file = functional_repo / "test.py"

--- a/tests/functional/test_stale_batch_source_advancement.py
+++ b/tests/functional/test_stale_batch_source_advancement.py
@@ -181,6 +181,40 @@ def test_initial_later_deletion_uses_full_hunk_anchor_context(functional_repo):
     assert _show_file(batch_commit, "anchors.txt") == "A\nX\nB\nC\n"
 
 
+def test_initial_included_deletion_uses_full_hunk_anchor_context(functional_repo):
+    """Include-to-batch must retain context preceding a later deletion."""
+    test_file = functional_repo / "anchors.txt"
+    baseline = "A\nX\nB\nD\nC\n"
+    test_file.write_text(baseline)
+    subprocess.run(["git", "add", "anchors.txt"], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "Add included deletion anchors"],
+        check=True,
+        capture_output=True,
+    )
+
+    test_file.write_text("S\n" + baseline)
+    command_start(quiet=True)
+
+    test_file.write_text("A\nB\nC\n")
+    command_again(quiet=True)
+    command_include_to_batch(
+        batch_name="saved",
+        line_ids="2",
+        file="anchors.txt",
+        quiet=True,
+        auto_advance=False,
+    )
+
+    metadata = read_batch_metadata("saved")
+    deletion = metadata["files"]["anchors.txt"]["deletions"][0]
+    assert deletion["after_source_line"] == 4
+
+    batch_commit = get_batch_commit_sha("saved")
+    assert batch_commit is not None
+    assert _show_file(batch_commit, "anchors.txt") == "A\nX\nB\nC\n"
+
+
 def test_stale_discard_preserves_previously_discarded_claimed_lines(functional_repo):
     """Advancing a discard batch must not drop lines already removed from WT."""
     test_file = functional_repo / "test.py"

--- a/tests/functional/test_stale_batch_source_advancement.py
+++ b/tests/functional/test_stale_batch_source_advancement.py
@@ -8,7 +8,10 @@ import subprocess
 from git_stage_batch.batch.state.query import read_batch_metadata
 from git_stage_batch.batch.state.query import get_batch_commit_sha
 from git_stage_batch.commands.again import command_again
-from git_stage_batch.commands.discard import command_discard_to_batch
+from git_stage_batch.commands.discard import (
+    command_discard_line_as_to_batch,
+    command_discard_to_batch,
+)
 from git_stage_batch.commands.include import command_include_to_batch
 from git_stage_batch.commands.start import command_start
 
@@ -109,6 +112,50 @@ def test_again_include_to_new_batch_does_not_reuse_stale_session_source(function
     assert 'return "layer3"' not in source_content
     assert 'return "bridge"' in realized_content
     assert 'return "layer3"' not in realized_content
+
+
+def test_replacement_to_new_batch_uses_its_rewritten_source(functional_repo):
+    """A replacement must not retain coordinates from an earlier batch."""
+    test_file = functional_repo / "replacement.txt"
+    baseline = "header\nold\nfooter\n"
+    test_file.write_text(baseline)
+    subprocess.run(
+        ["git", "add", "replacement.txt"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "Add replacement file"],
+        check=True,
+        capture_output=True,
+    )
+
+    test_file.write_text("session-only\n" + baseline)
+    command_start(quiet=True)
+    command_discard_to_batch(
+        batch_name="earlier",
+        line_ids="1",
+        file="replacement.txt",
+        quiet=True,
+        advance=False,
+    )
+
+    test_file.write_text("header\nworking\nfooter\n")
+    command_again(quiet=True)
+    command_discard_line_as_to_batch(
+        "replacement",
+        "1",
+        "saved",
+        file="replacement.txt",
+        quiet=True,
+    )
+
+    assert test_file.read_text() == baseline
+    batch_commit = get_batch_commit_sha("replacement")
+    assert batch_commit is not None
+    assert _show_file(batch_commit, "replacement.txt") == (
+        "header\nsaved\nfooter\n"
+    )
 
 
 def test_initial_deletion_anchor_uses_session_snapshot_coordinates(functional_repo):

--- a/tests/functional/test_stale_batch_source_advancement.py
+++ b/tests/functional/test_stale_batch_source_advancement.py
@@ -146,6 +146,41 @@ def test_initial_deletion_anchor_uses_session_snapshot_coordinates(functional_re
     )
 
 
+
+def test_initial_later_deletion_uses_full_hunk_anchor_context(functional_repo):
+    """Earlier deletions must not shift a later selected deletion's source anchor."""
+    test_file = functional_repo / "anchors.txt"
+    baseline = "A\nX\nB\nD\nC\n"
+    test_file.write_text(baseline)
+    subprocess.run(["git", "add", "anchors.txt"], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "Add deletion anchors"],
+        check=True,
+        capture_output=True,
+    )
+
+    test_file.write_text("S\n" + baseline)
+    command_start(quiet=True)
+
+    test_file.write_text("A\nB\nC\n")
+    command_again(quiet=True)
+    command_discard_to_batch(
+        batch_name="saved",
+        line_ids="2",
+        file="anchors.txt",
+        quiet=True,
+        advance=False,
+    )
+
+    metadata = read_batch_metadata("saved")
+    deletion = metadata["files"]["anchors.txt"]["deletions"][0]
+    assert deletion["after_source_line"] == 4
+
+    batch_commit = get_batch_commit_sha("saved")
+    assert batch_commit is not None
+    assert _show_file(batch_commit, "anchors.txt") == "A\nX\nB\nC\n"
+
+
 def test_stale_discard_preserves_previously_discarded_claimed_lines(functional_repo):
     """Advancing a discard batch must not drop lines already removed from WT."""
     test_file = functional_repo / "test.py"


### PR DESCRIPTION
First selections now retain saved-snapshot coordinates across shifted
additions, cached deletions, and consumed replacements.

Replacement discard can establish or advance that snapshot while removal
references still originate in rewritten files and live HEAD. Persisting
those references directly can replay working text instead of the saved
replacement.

This commit series scopes source establishment inside ownership
acquisition, activates rewritten buffers before translation, and projects
deletion anchors and replacement origins onto the loaded batch baseline.

Replacement anchors now retain rewritten-source and saved-baseline
coordinates before and after later batch updates.