### PR TITLE
batch: Project command ownership from source snapshots

### DIFF
--- a/src/git_stage_batch/batch/merge/baseline_reference_translation.py
+++ b/src/git_stage_batch/batch/merge/baseline_reference_translation.py
@@ -538,6 +538,33 @@ def _translate_replacement_origin_references(
             )
 
 
+def _require_projected_replacement_references(
+    ownership: BatchOwnership,
+) -> None:
+    """Reject replacement ownership that lost its persisted baseline identity."""
+    for unit in ownership.replacement_units:
+        if (
+            unit.origin is not None
+            and unit.origin.baseline_reference is None
+        ):
+            raise ValueError(
+                "replacement origin could not be projected onto the batch baseline"
+            )
+        for deletion_index in unit.deletion_indices:
+            if (
+                type(deletion_index) is not int
+                or deletion_index < 0
+                or deletion_index >= len(ownership.deletions)
+                or ownership.deletions[
+                    deletion_index
+                ].baseline_reference is None
+            ):
+                raise ValueError(
+                    "replacement deletion could not be projected onto "
+                    "the batch baseline"
+                )
+
+
 def translate_ownership_baseline_references(
     ownership: BatchOwnership,
     source_baseline_lines: Sequence[bytes],
@@ -594,6 +621,7 @@ def translate_ownership_baseline_references(
             replacement_origin_source_lines is None
             or not ownership.replacement_units
         ):
+            _require_projected_replacement_references(ownership)
             return
 
         normalized_origin_source = normalize_line_sequence_endings(
@@ -621,3 +649,4 @@ def translate_ownership_baseline_references(
                 target_lines,
                 mapping,
             )
+        _require_projected_replacement_references(ownership)

--- a/src/git_stage_batch/batch/ownership/translation.py
+++ b/src/git_stage_batch/batch/ownership/translation.py
@@ -22,8 +22,9 @@ from .replacement_units import (
 def detect_stale_batch_source_for_selection(selected_lines: list) -> bool:
     """Detect if selected lines cannot be expressed in current batch source.
 
-    Returns True if any claimed/addition line has source_line=None, indicating
-    the batch source is stale and must be advanced before translation.
+    Returns True if any context/addition line lacks a source coordinate,
+    indicating the batch source is stale and must be advanced before
+    translation.
 
     Args:
         selected_lines: List of LineEntry objects to check
@@ -32,8 +33,8 @@ def detect_stale_batch_source_for_selection(selected_lines: list) -> bool:
         True if batch source is stale, False otherwise
     """
     for line in selected_lines:
-        # Context and addition lines should have source_line populated
-        # If they don't, the current batch source cannot express this change
+        # Context and addition lines need source coordinates for claim
+        # translation and deletion boundaries.
         if line.kind in (' ', '+') and line.source_line is None:
             return True
         # A None deletion anchor is only current for deletions before line 1.
@@ -55,8 +56,8 @@ def translate_lines_to_batch_ownership(selected_lines: list) -> BatchOwnership:
 
     This function assumes all selected lines can be expressed in batch source
     space. Call detect_stale_batch_source_for_selection() first and handle stale
-    sources before calling this function. If source_line is None for claimed
-    lines, this raises an error instead of dropping them.
+    sources before calling this function. If a required source coordinate is
+    missing, this raises an error instead of dropping the affected change.
 
     Args:
         selected_lines: List of LineEntry objects to translate
@@ -65,11 +66,12 @@ def translate_lines_to_batch_ownership(selected_lines: list) -> BatchOwnership:
         BatchOwnership with presence claims and absence claims
 
     Raises:
-        ValueError: If any claimed line has source_line=None (stale batch source)
+        ValueError: If a required source coordinate is missing
     """
     # Translate to batch source-space ownership
     # Diff shows index→working tree, batch source = working tree
-    # Context/addition lines exist in batch source → presence claims
+    # Addition lines exist in batch source → presence claims
+    # Context lines only provide structural boundaries for those changes
     # Deletion lines don't exist in batch source → absence claims (suppression)
 
     content_view = _LineEntryContentSequence(selected_lines)
@@ -170,17 +172,23 @@ def translate_lines_to_batch_ownership(selected_lines: list) -> BatchOwnership:
                     f"Batch source is stale and must be advanced before translation."
                 )
 
-            claimed_source_lines.add_line(line.source_line)
-            if line.has_baseline_reference_after:
-                presence_baseline_references[line.source_line] = BaselineReference(
-                    after_line=line.baseline_reference_after_line,
-                    after_content=line.baseline_reference_after_text_bytes,
-                    has_after_line=line.has_baseline_reference_after,
-                    before_line=line.baseline_reference_before_line,
-                    before_content=line.baseline_reference_before_text_bytes,
-                    has_before_line=line.has_baseline_reference_before,
-                )
             if line.kind == '+':
+                claimed_source_lines.add_line(line.source_line)
+                if line.has_baseline_reference_after:
+                    presence_baseline_references[line.source_line] = (
+                        BaselineReference(
+                            after_line=line.baseline_reference_after_line,
+                            after_content=(
+                                line.baseline_reference_after_text_bytes
+                            ),
+                            has_after_line=line.has_baseline_reference_after,
+                            before_line=line.baseline_reference_before_line,
+                            before_content=(
+                                line.baseline_reference_before_text_bytes
+                            ),
+                            has_before_line=line.has_baseline_reference_before,
+                        )
+                    )
                 if flushed_deletion_indices:
                     finish_replacement_unit(active_replacement_unit)
                     active_replacement_unit = _ReplacementUnitBuilder(

--- a/src/git_stage_batch/batch/ownership_update.py
+++ b/src/git_stage_batch/batch/ownership_update.py
@@ -95,6 +95,44 @@ def _translate_selection_to_batch_ownership(
     return translate_lines_to_batch_ownership(selected_lines)
 
 
+def _ownership_has_baseline_references(ownership: BatchOwnership) -> bool:
+    """Return whether newly translated ownership carries baseline coordinates."""
+    if any(
+        claim.baseline_references
+        for claim in ownership.presence_claims
+    ):
+        return True
+    if any(
+        deletion.baseline_reference is not None
+        for deletion in ownership.deletions
+    ):
+        return True
+    return any(
+        unit.origin is not None
+        and unit.origin.baseline_reference is not None
+        for unit in ownership.replacement_units
+    )
+
+
+def _ownership_has_replacement_origin_references(
+    ownership: BatchOwnership,
+) -> bool:
+    """Return whether replacement metadata needs live-HEAD projection."""
+    for unit in ownership.replacement_units:
+        if unit.origin is None:
+            continue
+        if unit.origin.baseline_reference is not None:
+            return True
+        if any(
+            type(deletion_index) is int
+            and 0 <= deletion_index < len(ownership.deletions)
+            and ownership.deletions[deletion_index].baseline_reference is not None
+            for deletion_index in unit.deletion_indices
+        ):
+            return True
+    return False
+
+
 def prepare_batch_ownership_update_for_selection(
     batch_name: str,
     file_path: str,
@@ -158,6 +196,20 @@ def _prepare_batch_ownership_update_from_refreshed_selection(
     ):
         raise ValueError(
             "replacement origin source lines require reference target lines"
+        )
+    if (
+        _ownership_has_baseline_references(new_ownership)
+        and reference_source_lines is None
+    ):
+        raise ValueError(
+            "selection baseline references require source and batch baseline lines"
+        )
+    if (
+        _ownership_has_replacement_origin_references(new_ownership)
+        and replacement_origin_source_lines is None
+    ):
+        raise ValueError(
+            "replacement baseline references require live HEAD lines"
         )
     if reference_source_lines is not None and reference_target_lines is not None:
         translate_ownership_baseline_references(

--- a/src/git_stage_batch/commands/file_scope/discard_file_to_batch.py
+++ b/src/git_stage_batch/commands/file_scope/discard_file_to_batch.py
@@ -7,10 +7,12 @@ import os
 import sys
 
 from ...batch.source.annotation import annotate_with_batch_source
+from ...batch.ownership import insertion_references as _insertion_references
 from ...batch.state.lifecycle import create_batch
 from ...batch.ownership.model import BatchOwnership
 from ...batch.ownership_update import acquire_batch_ownership_update_for_selection
 from ...batch.state.query import read_batch_metadata
+from ...batch.state.validation import get_validated_baseline_commit
 from ...batch.text_file_storage import add_file_to_batch
 from ...batch.state.batch_names import batch_exists
 from ...core.buffer import LineBuffer
@@ -39,6 +41,7 @@ from ...utils.git_worktree import (
 from ...utils.git_repository import get_git_repository_root_path
 from ...utils.journal import log_journal
 from ...utils.paths import get_block_list_file_path, get_context_lines
+from ...utils.repository_buffers import read_git_object_buffer_or_empty
 from ...utils.session_start_point import session_comparison_base
 from ..selection.action_completion import finish_selected_change_action
 from ..selection import whole_file_batch_discarding as _whole_file_batch_discarding
@@ -127,6 +130,9 @@ def discard_file_to_batch(
                     patch.lines,
                     annotator=annotate_with_batch_source,
                 )
+                _insertion_references.record_baseline_references_for_additions(
+                    hunk_lines,
+                )
                 all_lines_to_batch.extend(hunk_lines.lines)
                 patches_to_discard.append((
                     patch_stack.enter_context(LineBuffer.from_chunks(patch.lines)),
@@ -185,8 +191,14 @@ def discard_file_to_batch(
 
         metadata = read_batch_metadata(batch_name)
         file_metadata = metadata.get("files", {}).get(file_path)
+        baseline_commit = get_validated_baseline_commit(batch_name)
 
         with ExitStack() as ownership_stack:
+            reference_source_lines = ownership_stack.enter_context(
+                read_git_object_buffer_or_empty(
+                    f"{comparison_base}:{file_path}"
+                )
+            )
             try:
                 update = ownership_stack.enter_context(
                     acquire_batch_ownership_update_for_selection(
@@ -194,6 +206,8 @@ def discard_file_to_batch(
                         file_path=file_path,
                         file_metadata=file_metadata,
                         selected_lines=all_lines_to_batch,
+                        reference_source_lines=reference_source_lines,
+                        batch_baseline_commit=baseline_commit,
                     )
                 )
             except ValueError as e:

--- a/src/git_stage_batch/commands/file_scope/discard_to_batch.py
+++ b/src/git_stage_batch/commands/file_scope/discard_to_batch.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 import os
 
 from ...batch.source.annotation import annotate_with_batch_source
+from ...batch.ownership import insertion_references as _insertion_references
 from ...batch.state.lifecycle import create_batch
 from ...batch.ownership_update import acquire_batch_ownership_update_for_selection
 from ...batch.state.query import read_batch_metadata
@@ -38,6 +39,7 @@ from ...utils.paths import (
     get_block_list_file_path,
     get_context_lines,
 )
+from ...utils.repository_buffers import read_git_object_buffer_or_empty
 from ...utils.session_start_point import session_comparison_base
 from ..selection.action_completion import finish_selected_change_action
 from ..index_cleanup import remove_path_from_index
@@ -58,6 +60,7 @@ class _TextFileDiscardInput:
 
     file_path: str
     file_mode: str
+    comparison_base: str
     all_lines_to_batch: list
     patches_to_discard: list[_PreparedPatchDiscard]
 
@@ -176,14 +179,19 @@ def _prepare_text_file_discard_to_batch(
     file_metadata = metadata.get("files", {}).get(file_path)
 
     try:
-        update = ownership_stack.enter_context(
-            acquire_batch_ownership_update_for_selection(
-                batch_name=batch_name,
-                file_path=file_path,
-                file_metadata=file_metadata,
-                selected_lines=discard_input.all_lines_to_batch,
+        with read_git_object_buffer_or_empty(
+            f"{discard_input.comparison_base}:{file_path}"
+        ) as reference_source_lines:
+            update = ownership_stack.enter_context(
+                acquire_batch_ownership_update_for_selection(
+                    batch_name=batch_name,
+                    file_path=file_path,
+                    file_metadata=file_metadata,
+                    selected_lines=discard_input.all_lines_to_batch,
+                    reference_source_lines=reference_source_lines,
+                    batch_baseline_commit=metadata.get("baseline"),
+                )
             )
-        )
     except ValueError as e:
         exit_with_error(
             _(
@@ -219,10 +227,11 @@ def _collect_text_file_discard_inputs(
     repo_root = get_git_repository_root_path()
     inputs_by_file: dict[str, _TextFileDiscardInput] = {}
     files_with_text_patches: set[str] = set()
+    comparison_base = session_comparison_base()
 
     with acquire_unified_diff(
         stream_live_git_diff(
-            base=session_comparison_base(),
+            base=comparison_base,
             context_lines=get_context_lines(),
             paths=files,
         )
@@ -255,11 +264,15 @@ def _collect_text_file_discard_inputs(
                 patch.lines,
                 annotator=annotate_with_batch_source,
             )
+            _insertion_references.record_baseline_references_for_additions(
+                hunk_lines,
+            )
             discard_input = inputs_by_file.get(file_path)
             if discard_input is None:
                 discard_input = _TextFileDiscardInput(
                     file_path=file_path,
                     file_mode=detect_file_mode_from_root(repo_root, file_path),
+                    comparison_base=comparison_base,
                     all_lines_to_batch=[],
                     patches_to_discard=[],
                 )

--- a/src/git_stage_batch/commands/file_scope/include_file_to_batch.py
+++ b/src/git_stage_batch/commands/file_scope/include_file_to_batch.py
@@ -6,9 +6,11 @@ from contextlib import ExitStack
 import sys
 
 from ...batch.source.annotation import annotate_with_batch_source
+from ...batch.ownership import insertion_references as _insertion_references
 from ...batch.state.lifecycle import create_batch
 from ...batch.ownership_update import acquire_batch_ownership_update_for_selection
 from ...batch.state.query import read_batch_metadata
+from ...batch.state.validation import get_validated_baseline_commit
 from ...batch.text_file_storage import add_file_to_batch
 from ...batch.state.batch_names import batch_exists
 from ...core.diff_parser import acquire_unified_diff, build_line_changes_from_patch_lines
@@ -26,6 +28,7 @@ from ...data.session import snapshot_file_if_untracked
 from ...exceptions import exit_with_error
 from ...i18n import _
 from ...utils.paths import get_context_lines
+from ...utils.repository_buffers import read_git_object_buffer_or_empty
 from ..selection import whole_file_batch_staging as _whole_file_batch_staging
 from ..selection.action_completion import finish_selected_change_action
 
@@ -100,6 +103,9 @@ def include_file_to_batch(
                 patch.lines,
                 annotator=annotate_with_batch_source,
             )
+            _insertion_references.record_baseline_references_for_additions(
+                hunk_lines,
+            )
             all_lines_to_batch.extend(hunk_lines.lines)
 
     if not all_lines_to_batch:
@@ -139,8 +145,14 @@ def include_file_to_batch(
 
     metadata = read_batch_metadata(batch_name)
     file_metadata = metadata.get("files", {}).get(file_path)
+    baseline_commit = get_validated_baseline_commit(batch_name)
 
     with ExitStack() as ownership_stack:
+        reference_source_lines = ownership_stack.enter_context(
+            read_git_object_buffer_or_empty(
+                f"{comparison_base}:{file_path}"
+            )
+        )
         try:
             update = ownership_stack.enter_context(
                 acquire_batch_ownership_update_for_selection(
@@ -148,6 +160,8 @@ def include_file_to_batch(
                     file_path=file_path,
                     file_metadata=file_metadata,
                     selected_lines=all_lines_to_batch,
+                    reference_source_lines=reference_source_lines,
+                    batch_baseline_commit=baseline_commit,
                 )
             )
         except ValueError as error:

--- a/src/git_stage_batch/commands/selection/batch_line_updates.py
+++ b/src/git_stage_batch/commands/selection/batch_line_updates.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from collections.abc import Callable, Sequence
 from contextlib import ExitStack
 
+from ...batch.ownership.replacement_line_runs import (
+    stream_replacement_line_runs_from_lines,
+)
 from ...batch.state.lifecycle import create_batch
 from ...batch.ownership_update import acquire_batch_ownership_update_for_selection
 from ...batch.state.query import read_batch_metadata
@@ -18,7 +21,10 @@ from ...data.selected_change.snapshots import (
 )
 from ...exceptions import exit_with_error
 from ...i18n import _
-from ...utils.repository_buffers import read_git_object_buffer_or_empty
+from ...utils.repository_buffers import (
+    load_working_tree_file_as_buffer,
+    read_git_object_buffer_or_empty,
+)
 
 
 def add_selected_lines_to_batch(
@@ -28,7 +34,6 @@ def add_selected_lines_to_batch(
     selected_lines: Sequence,
     stale_source_action: str,
     hunk_lines: Sequence | None = None,
-    replacement_line_runs=None,
     snapshot_untracked: bool = False,
     before_add: Callable[[], None] | None = None,
 ) -> None:
@@ -40,21 +45,49 @@ def add_selected_lines_to_batch(
     metadata = read_batch_metadata(batch_name)
     file_metadata = metadata.get("files", {}).get(file_path)
     baseline_commit = get_validated_baseline_commit(batch_name)
-    replacement_origin_source_buffer = (
-        read_git_object_buffer_or_empty(f"HEAD:{file_path}")
-        if hunk_lines is not None and replacement_line_runs
-        else None
+    has_replacement_rows = (
+        hunk_lines is not None
+        and any(getattr(line, "kind", None) == "+" for line in hunk_lines)
+        and any(getattr(line, "kind", None) == "-" for line in hunk_lines)
     )
 
     with ExitStack() as ownership_stack:
         replacement_origin_source_lines = (
-            ownership_stack.enter_context(replacement_origin_source_buffer)
-            if replacement_origin_source_buffer is not None
+            ownership_stack.enter_context(
+                read_git_object_buffer_or_empty(f"HEAD:{file_path}")
+            )
+            if has_replacement_rows
+            else None
+        )
+        working_source_lines = (
+            ownership_stack.enter_context(
+                load_working_tree_file_as_buffer(file_path)
+            )
+            if has_replacement_rows
             else None
         )
         try:
             reference_source_lines = ownership_stack.enter_context(
                 load_selected_file_comparison_base_buffer(file_path)
+            )
+            replacement_line_runs = (
+                stream_replacement_line_runs_from_lines(
+                    old_file_lines=reference_source_lines,
+                    new_file_lines=working_source_lines,
+                )
+                if working_source_lines is not None
+                else None
+            )
+            replacement_origin_line_runs = (
+                stream_replacement_line_runs_from_lines(
+                    old_file_lines=replacement_origin_source_lines,
+                    new_file_lines=working_source_lines,
+                )
+                if (
+                    replacement_origin_source_lines is not None
+                    and working_source_lines is not None
+                )
+                else None
             )
             update = ownership_stack.enter_context(
                 acquire_batch_ownership_update_for_selection(
@@ -64,6 +97,9 @@ def add_selected_lines_to_batch(
                     selected_lines=selected_lines,
                     hunk_lines=hunk_lines,
                     replacement_line_runs=replacement_line_runs,
+                    replacement_origin_line_runs=(
+                        replacement_origin_line_runs
+                    ),
                     reference_source_lines=reference_source_lines,
                     batch_baseline_commit=baseline_commit,
                     replacement_origin_source_lines=(

--- a/src/git_stage_batch/commands/selection/discard_line_batching.py
+++ b/src/git_stage_batch/commands/selection/discard_line_batching.py
@@ -117,17 +117,12 @@ def discard_file_lines_to_batch(
     _insertion_references.record_baseline_references_for_additions(
         line_changes,
     )
-    replacement_line_runs = (
-        _discard_line_replacement.derive_live_replacement_line_runs(file_path)
-    )
-
     _batch_line_updates.add_selected_lines_to_batch(
         batch_name=batch_name,
         file_path=file_path,
         selected_lines=selection.selected_lines,
         stale_source_action=_("Cannot discard lines to batch"),
         hunk_lines=line_changes.lines,
-        replacement_line_runs=replacement_line_runs,
         snapshot_untracked=True,
     )
 
@@ -196,19 +191,12 @@ def discard_selected_lines_to_batch(
     _insertion_references.record_baseline_references_for_additions(
         line_changes,
     )
-    replacement_line_runs = (
-        _discard_line_replacement.derive_live_replacement_line_runs(
-            line_changes.path
-        )
-    )
-
     _batch_line_updates.add_selected_lines_to_batch(
         batch_name=batch_name,
         file_path=line_changes.path,
         selected_lines=selection.selected_lines,
         stale_source_action=_("Cannot discard lines to batch"),
         hunk_lines=line_changes.lines,
-        replacement_line_runs=replacement_line_runs,
         snapshot_untracked=True,
         before_add=lambda: log_journal(
             "discard_lines_to_batch_before_add",

--- a/src/git_stage_batch/commands/selection/discard_line_replacement.py
+++ b/src/git_stage_batch/commands/selection/discard_line_replacement.py
@@ -19,10 +19,6 @@ from ...batch.merge.baseline_reference_translation import (
     translate_ownership_baseline_references,
 )
 from ...batch.state.query import read_batch_metadata
-from ...batch.ownership.replacement_line_runs import (
-    ReplacementLineRun,
-    derive_replacement_line_runs_from_lines,
-)
 from ...batch.selection import require_line_selection_in_view
 from ...batch.source.advancement import (
     advance_source_lines_preserving_existing_presence,
@@ -70,18 +66,6 @@ class DiscardLineReplacementSelection:
     rewritten_line_changes: object
     rewritten_selected_lines: list
     rewritten_working_lines: Sequence[bytes]
-
-
-def derive_live_replacement_line_runs(file_path: str) -> list[ReplacementLineRun]:
-    """Derive file-level replacement runs for the current live file state."""
-    with (
-        read_git_object_buffer_or_empty(f"HEAD:{file_path}") as baseline_lines,
-        load_working_tree_file_as_buffer(file_path) as working_lines,
-    ):
-        return derive_replacement_line_runs_from_lines(
-            old_file_lines=baseline_lines,
-            new_file_lines=working_lines,
-        )
 
 
 @contextmanager

--- a/src/git_stage_batch/commands/selection/include_line_batching.py
+++ b/src/git_stage_batch/commands/selection/include_line_batching.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import sys
 
 from ...batch.source.annotation import annotate_with_batch_source
+from ...batch.ownership import insertion_references as _insertion_references
 from ...data.line_state import load_line_changes_from_state
 from ...data.selected_change.loading import require_selected_hunk
 from ...exceptions import exit_with_error
@@ -12,7 +13,6 @@ from ...i18n import _
 from . import batch_line_selection as _batch_line_selection
 from . import batch_line_updates as _batch_line_updates
 from . import include_file_selection as _include_file_selection
-from . import include_line_selection as _include_line_selection
 from .action_completion import finish_selected_change_action
 from .selected_hunk_refresh import recalculate_selected_hunk_for_command
 
@@ -28,9 +28,7 @@ def include_file_lines_to_batch(
     """Include specific lines from a file to batch."""
     cached_lines = _include_file_selection.load_explicit_file_selection(file_path)
     line_changes = annotate_with_batch_source(file_path, cached_lines)
-    _include_line_selection.record_baseline_references_for_additions(
-        line_changes
-    )
+    _insertion_references.record_baseline_references_for_additions(line_changes)
 
     selection = _batch_line_selection.select_lines_for_batch_action(
         line_changes,
@@ -80,9 +78,7 @@ def include_selected_lines_to_batch(
     require_selected_hunk()
 
     line_changes = load_line_changes_from_state()
-    _include_line_selection.record_baseline_references_for_additions(
-        line_changes
-    )
+    _insertion_references.record_baseline_references_for_additions(line_changes)
     selection = _batch_line_selection.select_lines_for_batch_action(
         line_changes,
         line_id_specification,

--- a/src/git_stage_batch/commands/selection/include_line_selection.py
+++ b/src/git_stage_batch/commands/selection/include_line_selection.py
@@ -46,11 +46,6 @@ from ...utils.paths import get_session_batch_sources_file_path
 from . import replacement_selection
 
 
-record_baseline_references_for_additions = (
-    _insertion_references.record_baseline_references_for_additions
-)
-
-
 class TransientIncludeFailureReason(Enum):
     """Why transient batch staging could not safely realize a line selection."""
 

--- a/src/git_stage_batch/commands/selection/selected_change_batch_discarding.py
+++ b/src/git_stage_batch/commands/selection/selected_change_batch_discarding.py
@@ -8,6 +8,7 @@ import os
 import sys
 
 from ...batch.source.annotation import annotate_with_batch_source
+from ...batch.ownership import insertion_references as _insertion_references
 from ...batch.state.lifecycle import create_batch
 from ...batch.ownership_update import acquire_batch_ownership_update_for_selection
 from ...batch.state.query import read_batch_metadata
@@ -31,6 +32,9 @@ from ...data.file_modes import detect_file_mode
 from ...data.hunk_tracking import fetch_next_change
 from ...data.live_diff import stream_live_git_diff
 from ...data.progress import record_hunk_discarded
+from ...data.selected_change.snapshots import (
+    load_selected_file_comparison_base_buffer,
+)
 from ...data.session import snapshot_file_if_untracked
 from ...exceptions import NoMoreHunks, exit_with_error
 from ...i18n import _, ngettext
@@ -131,6 +135,9 @@ def _discard_text_hunk_to_batch(
         selected_patch_lines,
         annotator=annotate_with_batch_source,
     )
+    _insertion_references.record_baseline_references_for_additions(
+        line_changes,
+    )
     file_path = line_changes.path
 
     blocklist_path = get_block_list_file_path()
@@ -169,6 +176,9 @@ def _discard_text_hunk_to_batch(
                         patch.lines,
                         annotator=annotate_with_batch_source,
                     )
+                    _insertion_references.record_baseline_references_for_additions(
+                        hunk_lines,
+                    )
                     all_lines_to_batch.extend(hunk_lines.lines)
                     patches_to_discard.append((
                         patch_stack.enter_context(LineBuffer.from_chunks(patch.lines)),
@@ -182,6 +192,9 @@ def _discard_text_hunk_to_batch(
         file_metadata = metadata.get("files", {}).get(file_path)
 
         with ExitStack() as ownership_stack:
+            reference_source_lines = ownership_stack.enter_context(
+                load_selected_file_comparison_base_buffer(file_path)
+            )
             try:
                 update = ownership_stack.enter_context(
                     acquire_batch_ownership_update_for_selection(
@@ -189,6 +202,8 @@ def _discard_text_hunk_to_batch(
                         file_path=file_path,
                         file_metadata=file_metadata,
                         selected_lines=all_lines_to_batch,
+                        reference_source_lines=reference_source_lines,
+                        batch_baseline_commit=metadata.get("baseline"),
                     )
                 )
             except ValueError as e:

--- a/src/git_stage_batch/commands/selection/selected_change_batch_staging.py
+++ b/src/git_stage_batch/commands/selection/selected_change_batch_staging.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import sys
 
 from ...batch.source.annotation import annotate_with_batch_source
+from ...batch.ownership import insertion_references as _insertion_references
 from ...batch.state.lifecycle import create_batch
 from ...batch.ownership_update import acquire_batch_ownership_update_for_selection
 from ...batch.state.query import read_batch_metadata
@@ -33,6 +34,7 @@ from ...exceptions import exit_with_error
 from ...i18n import _
 from ...utils.file_io import append_lines_to_file, read_text_file_line_set
 from ...utils.paths import get_block_list_file_path, get_context_lines
+from ...utils.repository_buffers import read_git_object_buffer_or_empty
 from . import whole_file_batch_staging as _whole_file_batch_staging
 from .action_completion import finish_selected_change_action
 
@@ -110,6 +112,9 @@ def include_selected_change_to_batch(
                 patch.lines,
                 annotator=annotate_with_batch_source,
             )
+            _insertion_references.record_baseline_references_for_additions(
+                selected_line_changes,
+            )
             selected_hash = patch_hash
             break
 
@@ -124,12 +129,19 @@ def include_selected_change_to_batch(
     file_metadata = metadata.get("files", {}).get(file_path)
 
     try:
-        with acquire_batch_ownership_update_for_selection(
-            batch_name=batch_name,
-            file_path=file_path,
-            file_metadata=file_metadata,
-            selected_lines=all_lines_to_batch,
-        ) as update:
+        with (
+            read_git_object_buffer_or_empty(
+                f":{file_path}"
+            ) as reference_source_lines,
+            acquire_batch_ownership_update_for_selection(
+                batch_name=batch_name,
+                file_path=file_path,
+                file_metadata=file_metadata,
+                selected_lines=all_lines_to_batch,
+                reference_source_lines=reference_source_lines,
+                batch_baseline_commit=metadata.get("baseline"),
+            ) as update,
+        ):
             add_file_to_batch(
                 batch_name,
                 file_path,

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -10462,6 +10462,36 @@ def test_batch_absence_content_owns_public_builders():
     assert violations == []
 
 
+def test_batch_insertion_references_own_addition_metadata():
+    """Insertion ownership metadata should not be owned by an include command."""
+    insertion_references = __import__(
+        "git_stage_batch.batch.ownership.insertion_references",
+        fromlist=["insertion_references"],
+    )
+    include_selection = __import__(
+        "git_stage_batch.commands.selection.include_line_selection",
+        fromlist=["include_line_selection"],
+    )
+    public_name = "record_baseline_references_for_additions"
+    consumer_paths = {
+        SRC_ROOT / "commands" / "selection" / "discard_line_batching.py",
+        SRC_ROOT / "commands" / "selection" / "include_line_batching.py",
+        SRC_ROOT / "commands" / "selection" / "include_line_selection.py",
+    }
+
+    assert public_name in vars(insertion_references)
+    assert public_name not in vars(include_selection)
+
+    for path in consumer_paths:
+        imported_modules = {
+            alias.name
+            for imported_module, node in _import_from_nodes(path)
+            if imported_module == "git_stage_batch.batch.ownership"
+            for alias in node.names
+        }
+        assert "insertion_references" in imported_modules
+
+
 def test_batch_replacement_line_runs_own_public_derivation():
     """Replacement run derivation should live outside ownership metadata."""
     replacement_line_runs = __import__(
@@ -10475,10 +10505,12 @@ def test_batch_replacement_line_runs_own_public_derivation():
     public_names = {
         "ReplacementLineRun",
         "derive_replacement_line_runs_from_lines",
+        "stream_replacement_line_runs_from_lines",
     }
     private_names = {
         "_ReplacementLineRun",
         "_derive_replacement_line_runs_from_lines",
+        "_stream_replacement_line_runs_from_lines",
     }
     expected_imports = {
         SRC_ROOT / "batch" / "ownership/hunk_translation.py": {
@@ -10488,16 +10520,15 @@ def test_batch_replacement_line_runs_own_public_derivation():
         SRC_ROOT / "batch" / "ownership_update.py": {
             "ReplacementLineRun",
         },
-        SRC_ROOT / "commands" / "selection" / "discard_line_replacement.py": {
-            "ReplacementLineRun",
-            "derive_replacement_line_runs_from_lines",
-        },
         SRC_ROOT / "commands" / "selection" / "replacement_selection.py": (
             {
                 "ReplacementLineRun",
                 "derive_replacement_line_runs_from_lines",
             }
         ),
+        SRC_ROOT / "commands" / "selection" / "batch_line_updates.py": {
+            "stream_replacement_line_runs_from_lines",
+        },
     }
     violations = []
 
@@ -17718,6 +17749,7 @@ def test_include_line_batching_stays_in_command_helper():
         "batch_line_selection",
         "batch_line_updates",
         "include_file_selection",
+        "insertion_references",
         "load_line_changes_from_state",
         "recalculate_selected_hunk_for_command",
         "require_selected_hunk",
@@ -17752,10 +17784,6 @@ def test_include_line_batching_stays_in_command_helper():
     assert not include_imports_helper
     assert action_imports_helper
     assert helper_imports <= helper_imported_names
-    assert {
-        "include_line_selection",
-        "insertion_references",
-    } & helper_imported_names
 
 
 def test_discard_line_selection_stays_in_command_helper():
@@ -17975,7 +18003,6 @@ def test_discard_line_replacement_stays_in_command_helper():
         "DiscardLineReplacementSelection",
         "add_discard_line_replacement_to_batch",
         "build_discard_line_replacement_target_buffer",
-        "derive_live_replacement_line_runs",
         "prepare_discard_line_replacement_selection",
     }
     line_batching_names = {
@@ -18003,7 +18030,6 @@ def test_discard_line_replacement_stays_in_command_helper():
         "create_batch",
         "create_batch_source_commit",
         "detect_file_mode",
-        "derive_replacement_line_runs_from_lines",
         "read_git_object_buffer_or_none",
         "read_git_object_buffer_or_empty",
         "load_line_changes_from_state",

--- a/tests/batch/merge/test_baseline_reference_translation.py
+++ b/tests/batch/merge/test_baseline_reference_translation.py
@@ -1,5 +1,7 @@
 """Tests for translating selection references onto batch baselines."""
 
+import pytest
+
 from git_stage_batch.batch.merge.baseline_reference_translation import (
     translate_ownership_baseline_references,
 )
@@ -285,3 +287,49 @@ def test_does_not_project_plain_deletion_onto_different_content():
 
     assert deletion.baseline_reference is None
     assert list(deletion.content_lines) == [b"old\n"]
+
+
+def test_rejects_replacement_missing_from_target_baseline():
+    """Projection must fail closed when the parent span no longer exists."""
+    source = [b"head\n", b"old\n", b"tail\n"]
+    target = [b"head\n", b"tail\n"]
+    reference = BaselineReference(
+        after_line=1,
+        after_content=b"head",
+        before_line=3,
+        before_content=b"tail",
+        has_before_line=True,
+    )
+    deletion = AbsenceClaim(
+        anchor_line=1,
+        content_lines=[b"old\n"],
+        baseline_reference=reference,
+    )
+    ownership = BatchOwnership.from_presence_lines(
+        ["2"],
+        [deletion],
+        replacement_units=[
+            ReplacementUnit(
+                presence_lines=["2"],
+                deletion_indices=[0],
+                origin=ReplacementUnitOrigin(
+                    old_start=2,
+                    old_end=2,
+                    new_start=2,
+                    new_end=2,
+                    baseline_reference=reference,
+                ),
+            )
+        ],
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="replacement origin could not be projected",
+    ):
+        translate_ownership_baseline_references(
+            ownership,
+            source,
+            target,
+            replacement_origin_source_lines=source,
+        )

--- a/tests/batch/ownership/test_translation.py
+++ b/tests/batch/ownership/test_translation.py
@@ -65,6 +65,40 @@ def test_presence_line_set_returns_line_ranges():
     assert ownership.resolve().presence_line_set == selection
 
 
+def test_translate_lines_uses_context_without_claiming_it():
+    """Unchanged hunk rows provide boundaries without becoming ownership."""
+    lines = [
+        LineEntry(
+            id=None,
+            kind=" ",
+            old_line_number=1,
+            new_line_number=1,
+            text_bytes=b"before",
+            source_line=1,
+        ),
+        LineEntry(
+            id=1,
+            kind="+",
+            old_line_number=None,
+            new_line_number=2,
+            text_bytes=b"inserted",
+            source_line=2,
+        ),
+        LineEntry(
+            id=None,
+            kind=" ",
+            old_line_number=2,
+            new_line_number=3,
+            text_bytes=b"after",
+            source_line=3,
+        ),
+    ]
+
+    ownership = translate_lines_to_batch_ownership(lines)
+
+    assert ownership.presence_line_set() == {2}
+
+
 def test_translate_lines_builds_selected_ranges_without_line_sets(monkeypatch):
     """Selected display lines should translate through range builders."""
     def fail_from_lines(cls, lines):

--- a/tests/batch/test_ownership_update.py
+++ b/tests/batch/test_ownership_update.py
@@ -51,12 +51,12 @@ def test_prepare_batch_ownership_update_first_time_stale_blank_context():
         file_path="test.py",
         current_batch_source_commit=None,
         existing_ownership=None,
-        selected_lines=lines
+        selected_lines=lines,
     )
 
     assert result.batch_source_commit is None
     assert result.ownership_before is None
-    assert result.ownership_after.presence_claims[0].source_lines == ["1-2"]
+    assert result.ownership_after.presence_claims[0].source_lines == ["2"]
 
 
 def test_prepare_batch_ownership_update_first_time_deletion_anchor():
@@ -73,7 +73,9 @@ def test_prepare_batch_ownership_update_first_time_deletion_anchor():
         file_path="test.py",
         current_batch_source_commit=None,
         existing_ownership=None,
-        selected_lines=lines
+        selected_lines=lines,
+        reference_source_lines=[b"anchor\n", b"old line\n"],
+        reference_target_lines=[b"anchor\n", b"old line\n"],
     )
 
     assert result.batch_source_commit is None

--- a/tests/batch/test_ownership_update.py
+++ b/tests/batch/test_ownership_update.py
@@ -7,6 +7,9 @@ import inspect
 import git_stage_batch.batch.ownership_update as ownership_update_module
 import pytest
 from git_stage_batch.batch.ownership.model import BatchOwnership
+from git_stage_batch.batch.ownership.replacement_line_runs import (
+    ReplacementLineRun,
+)
 from git_stage_batch.batch.ownership_update import (
     PreparedBatchUpdate,
     acquire_batch_ownership_update_for_selection,
@@ -107,6 +110,51 @@ def test_prepare_batch_update_rejects_unprojected_deletion_reference():
             current_batch_source_commit=None,
             existing_ownership=None,
             selected_lines=lines,
+        )
+
+
+def test_prepare_batch_update_rejects_unprojected_replacement_origin():
+    """Replacement references require the live-HEAD coordinate source."""
+    hunk_lines = [
+        LineEntry(
+            id=1,
+            kind="-",
+            old_line_number=1,
+            new_line_number=None,
+            text_bytes=b"old",
+            source_line=None,
+        ),
+        LineEntry(
+            id=2,
+            kind="+",
+            old_line_number=None,
+            new_line_number=1,
+            text_bytes=b"new",
+            source_line=1,
+        ),
+    ]
+
+    with pytest.raises(
+        ValueError,
+        match="replacement baseline references require live HEAD lines",
+    ):
+        prepare_batch_ownership_update_for_selection(
+            batch_name="test-batch",
+            file_path="test.py",
+            current_batch_source_commit=None,
+            existing_ownership=None,
+            selected_lines=hunk_lines,
+            hunk_lines=hunk_lines,
+            replacement_line_runs=[
+                ReplacementLineRun(
+                    old_start=1,
+                    old_end=1,
+                    new_start=1,
+                    new_end=1,
+                ),
+            ],
+            reference_source_lines=[b"old\n"],
+            reference_target_lines=[b"old\n"],
         )
 
 

--- a/tests/batch/test_ownership_update.py
+++ b/tests/batch/test_ownership_update.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import inspect
 
 import git_stage_batch.batch.ownership_update as ownership_update_module
+import pytest
 from git_stage_batch.batch.ownership.model import BatchOwnership
 from git_stage_batch.batch.ownership_update import (
     PreparedBatchUpdate,
@@ -81,6 +82,32 @@ def test_prepare_batch_ownership_update_first_time_deletion_anchor():
     assert result.batch_source_commit is None
     assert result.ownership_before is None
     assert result.ownership_after.deletions[0].anchor_line == 1
+
+
+def test_prepare_batch_update_rejects_unprojected_deletion_reference():
+    """Baseline-relative deletion metadata must be projected before merging."""
+    lines = [
+        LineEntry(
+            id=1,
+            kind="-",
+            old_line_number=2,
+            new_line_number=None,
+            text_bytes=b"old line",
+            source_line=1,
+        ),
+    ]
+
+    with pytest.raises(
+        ValueError,
+        match="selection baseline references require",
+    ):
+        prepare_batch_ownership_update_for_selection(
+            batch_name="test-batch",
+            file_path="test.py",
+            current_batch_source_commit=None,
+            existing_ownership=None,
+            selected_lines=lines,
+        )
 
 
 def test_prepare_batch_ownership_update_first_time():

--- a/tests/commands/selection/test_batch_line_updates.py
+++ b/tests/commands/selection/test_batch_line_updates.py
@@ -1,5 +1,7 @@
 """Tests for selected-line batch update command boundaries."""
 
+from types import SimpleNamespace
+
 import pytest
 
 import git_stage_batch.commands.selection.batch_line_updates as batch_line_updates
@@ -60,8 +62,10 @@ def test_invalid_comparison_snapshot_becomes_command_error(monkeypatch):
             file_path="module.py",
             selected_lines=[],
             stale_source_action="Cannot include lines to batch",
-            hunk_lines=[object()],
-            replacement_line_runs=[object()],
+            hunk_lines=[
+                SimpleNamespace(kind="-"),
+                SimpleNamespace(kind="+"),
+            ],
         )
 
     assert error.value.exit_code == 1

--- a/tests/commands/test_file_scoped_operations.py
+++ b/tests/commands/test_file_scoped_operations.py
@@ -1248,9 +1248,9 @@ class TestBatchSourceWithFile:
         command_start()
         command_discard_to_batch("batch", file="simple.txt")
 
-        # Batch display shows additions: [#1] line1, [#2] line2, [#3] line3, [#4] line4
-        # Apply only line 3 (not line 4)
-        command_apply_from_batch("batch", line_ids="3", file="simple.txt")
+        # Batch display numbers only the two owned additions.
+        # Apply line3 (the first addition), but not line4.
+        command_apply_from_batch("batch", line_ids="1", file="simple.txt")
 
         content = (multi_file_repo / "simple.txt").read_text()
         # Should have line3
@@ -1581,10 +1581,9 @@ class TestFileAndLineIDCombinations:
         command_discard_to_batch("multi", file="alpha.txt")
         command_discard_to_batch("multi", file="beta.txt")
 
-        # Beta batch has: [#1] beta1, [#2] beta2 (deletion), [#3] beta2-modified, [#4] beta3, [#5] beta4-new
-        # Deletions are shown in batch display (as suppression constraints)
-        # Apply only line 5 from beta.txt (beta4-new)
-        command_apply_from_batch("multi", line_ids="5", file="beta.txt")
+        # Beta batch numbers the replacement pair and trailing addition.
+        # Apply only line 3 from beta.txt (beta4-new).
+        command_apply_from_batch("multi", line_ids="3", file="beta.txt")
 
         alpha_content = (multi_file_repo / "alpha.txt").read_text()
         beta_content = (multi_file_repo / "beta.txt").read_text()

--- a/tests/functional/test_batch_projection_command_paths.py
+++ b/tests/functional/test_batch_projection_command_paths.py
@@ -89,3 +89,21 @@ def test_bulk_discard_projects_onto_older_batch_baseline(functional_repo):
 
     assert result.returncode == 0, result.stderr
     assert _batch_file_content(functional_repo) == _expected_replacement(original)
+
+
+def test_selected_discard_projects_cached_comparison_onto_batch(functional_repo):
+    """Selected discard must use the comparison snapshot that built its hunk."""
+    _file_path, original = _prepare_replacement_against_older_batch(
+        functional_repo
+    )
+
+    result = git_stage_batch(
+        "discard",
+        "--to",
+        "saved",
+        "--no-auto-advance",
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert _batch_file_content(functional_repo) == _expected_replacement(original)

--- a/tests/functional/test_batch_projection_command_paths.py
+++ b/tests/functional/test_batch_projection_command_paths.py
@@ -107,3 +107,21 @@ def test_selected_discard_projects_cached_comparison_onto_batch(functional_repo)
 
     assert result.returncode == 0, result.stderr
     assert _batch_file_content(functional_repo) == _expected_replacement(original)
+
+
+def test_selected_include_projects_index_onto_older_batch(functional_repo):
+    """Selected include must translate index coordinates to the batch baseline."""
+    _file_path, original = _prepare_replacement_against_older_batch(
+        functional_repo
+    )
+
+    result = git_stage_batch(
+        "include",
+        "--to",
+        "saved",
+        "--no-auto-advance",
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert _batch_file_content(functional_repo) == _expected_replacement(original)

--- a/tests/functional/test_batch_projection_command_paths.py
+++ b/tests/functional/test_batch_projection_command_paths.py
@@ -2,6 +2,8 @@
 
 import subprocess
 
+import pytest
+
 from .conftest import git_stage_batch
 
 
@@ -51,12 +53,12 @@ def _prepare_replacement_against_older_batch(functional_repo):
     return file_path, original
 
 
-def _batch_file_content(functional_repo):
+def _batch_file_content(functional_repo, file_path="sections.txt"):
     return subprocess.run(
         [
             "git",
             "show",
-            "refs/git-stage-batch/batches/saved:sections.txt",
+            f"refs/git-stage-batch/batches/saved:{file_path}",
         ],
         check=True,
         cwd=functional_repo,
@@ -69,6 +71,97 @@ def _expected_replacement(original):
     return original.replace(
         "section2\nx\nold\n",
         "section2\nx\nNEW\n",
+    )
+
+
+def _prepare_insertion_against_older_batch(functional_repo):
+    file_path = functional_repo / "insertions.txt"
+    original = "top\n\ntop\n\nbottom\n"
+    file_path.write_text(original)
+    subprocess.run(
+        ["git", "add", "insertions.txt"],
+        check=True,
+        cwd=functional_repo,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "Add repeated insertion boundaries"],
+        check=True,
+        cwd=functional_repo,
+        capture_output=True,
+    )
+    git_stage_batch("new", "saved")
+
+    head_content = "prefix-a\nprefix-b\n" + original
+    file_path.write_text(head_content)
+    subprocess.run(
+        ["git", "add", "insertions.txt"],
+        check=True,
+        cwd=functional_repo,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "Add later prefix"],
+        check=True,
+        cwd=functional_repo,
+        capture_output=True,
+    )
+    file_path.write_text(
+        "prefix-a\n"
+        "prefix-b\n"
+        "top\n"
+        "\n"
+        "first\n"
+        "second\n"
+        "\n"
+        "top\n"
+        "\n"
+        "bottom\n"
+    )
+    git_stage_batch("start", "--no-auto-advance")
+    return original
+
+
+def _insertion_command_arguments(route):
+    if route == "bulk-discard":
+        return ("discard", "--to", "saved", "--files", "insertions.txt")
+    if route == "file-discard":
+        return ("discard", "--to", "saved", "--file", "insertions.txt")
+    if route == "selected-discard":
+        return ("discard", "--to", "saved")
+    if route == "selected-include":
+        return ("include", "--to", "saved")
+    return ("include", "--to", "saved", "--file", "insertions.txt")
+
+
+@pytest.mark.parametrize(
+    "route",
+    [
+        "bulk-discard",
+        "file-discard",
+        "selected-discard",
+        "selected-include",
+        "file-include",
+    ],
+)
+def test_insertions_project_without_claiming_newer_context(
+    functional_repo,
+    route,
+):
+    """Whole-change saves must project only changed lines onto old batches."""
+    original = _prepare_insertion_against_older_batch(functional_repo)
+
+    result = git_stage_batch(
+        *_insertion_command_arguments(route),
+        "--no-auto-advance",
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert _batch_file_content(functional_repo, "insertions.txt") == original.replace(
+        "\ntop\n",
+        "\nfirst\nsecond\n\ntop\n",
+        1,
     )
 
 
@@ -119,6 +212,26 @@ def test_selected_include_projects_index_onto_older_batch(functional_repo):
         "include",
         "--to",
         "saved",
+        "--no-auto-advance",
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert _batch_file_content(functional_repo) == _expected_replacement(original)
+
+
+def test_explicit_include_projects_comparison_onto_older_batch(functional_repo):
+    """Explicit file include must bind its rendered comparison to the batch."""
+    _file_path, original = _prepare_replacement_against_older_batch(
+        functional_repo
+    )
+
+    result = git_stage_batch(
+        "include",
+        "--to",
+        "saved",
+        "--file",
+        "sections.txt",
         "--no-auto-advance",
         check=False,
     )

--- a/tests/functional/test_batch_projection_command_paths.py
+++ b/tests/functional/test_batch_projection_command_paths.py
@@ -1,0 +1,91 @@
+"""Projection coverage for batch capture command paths."""
+
+import subprocess
+
+from .conftest import git_stage_batch
+
+
+def _prepare_replacement_against_older_batch(functional_repo):
+    file_path = functional_repo / "sections.txt"
+    original = (
+        "section1\n"
+        "x\n"
+        "old\n"
+        "y\n"
+        "section2\n"
+        "x\n"
+        "old\n"
+        "y\n"
+        "end\n"
+    )
+    file_path.write_text(original)
+    subprocess.run(
+        ["git", "add", "sections.txt"],
+        check=True,
+        cwd=functional_repo,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "Add repeated sections"],
+        check=True,
+        cwd=functional_repo,
+        capture_output=True,
+    )
+    git_stage_batch("new", "saved")
+
+    file_path.write_text("section2\nx\nold\ny\nend\n")
+    subprocess.run(
+        ["git", "add", "sections.txt"],
+        check=True,
+        cwd=functional_repo,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "Remove first section"],
+        check=True,
+        cwd=functional_repo,
+        capture_output=True,
+    )
+    file_path.write_text("section2\nx\nNEW\ny\nend\n")
+    git_stage_batch("start", "--no-auto-advance")
+    return file_path, original
+
+
+def _batch_file_content(functional_repo):
+    return subprocess.run(
+        [
+            "git",
+            "show",
+            "refs/git-stage-batch/batches/saved:sections.txt",
+        ],
+        check=True,
+        cwd=functional_repo,
+        capture_output=True,
+        text=True,
+    ).stdout
+
+
+def _expected_replacement(original):
+    return original.replace(
+        "section2\nx\nold\n",
+        "section2\nx\nNEW\n",
+    )
+
+
+def test_bulk_discard_projects_onto_older_batch_baseline(functional_repo):
+    """Bulk discard must project collected live coordinates before storage."""
+    _file_path, original = _prepare_replacement_against_older_batch(
+        functional_repo
+    )
+
+    result = git_stage_batch(
+        "discard",
+        "--to",
+        "saved",
+        "--files",
+        "sections.txt",
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert _batch_file_content(functional_repo) == _expected_replacement(original)

--- a/tests/functional/test_discard_file_behavior.py
+++ b/tests/functional/test_discard_file_behavior.py
@@ -10,6 +10,67 @@ from .conftest import git_stage_batch
 class TestDiscardFile:
     """Tests for discard --file removing files and preserving batch content."""
 
+    def test_discard_file_saves_leading_deletion_past_older_prefix(
+        self,
+        functional_repo,
+    ):
+        """Whole-file deletion projection follows content past an old prefix."""
+        file_path = functional_repo / "sections.txt"
+        file_path.write_text("prefix\nold\ntail\n")
+        subprocess.run(
+            ["git", "add", "sections.txt"],
+            check=True,
+            cwd=functional_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add prefixed section"],
+            check=True,
+            cwd=functional_repo,
+            capture_output=True,
+        )
+        git_stage_batch("new", "saved")
+
+        file_path.write_text("old\ntail\n")
+        subprocess.run(
+            ["git", "add", "sections.txt"],
+            check=True,
+            cwd=functional_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Remove prefix"],
+            check=True,
+            cwd=functional_repo,
+            capture_output=True,
+        )
+        file_path.write_text("tail\n")
+
+        git_stage_batch("start", "--no-auto-advance")
+        result = git_stage_batch(
+            "discard",
+            "--to",
+            "saved",
+            "--file",
+            "sections.txt",
+            "--no-auto-advance",
+            check=False,
+        )
+
+        assert result.returncode == 0, result.stderr
+        stored_content = subprocess.run(
+            [
+                "git",
+                "show",
+                "refs/git-stage-batch/batches/saved:sections.txt",
+            ],
+            check=True,
+            cwd=functional_repo,
+            capture_output=True,
+            text=True,
+        ).stdout
+        assert stored_content == "prefix\ntail\n"
+
     def test_discard_file_projects_replacement_onto_older_batch_baseline(
         self,
         functional_repo,

--- a/tests/functional/test_discard_file_behavior.py
+++ b/tests/functional/test_discard_file_behavior.py
@@ -10,7 +10,7 @@ from .conftest import git_stage_batch
 class TestDiscardFile:
     """Tests for discard --file removing files and preserving batch content."""
 
-    def test_discard_file_saves_leading_deletion_past_older_prefix(
+    def test_discard_file_projects_leading_deletion_past_older_prefix(
         self,
         functional_repo,
     ):
@@ -70,6 +70,17 @@ class TestDiscardFile:
             text=True,
         ).stdout
         assert stored_content == "prefix\ntail\n"
+
+        file_path.write_text("prefix\nold\ntail\n")
+        git_stage_batch(
+            "apply",
+            "--from",
+            "saved",
+            "--file",
+            "sections.txt",
+        )
+
+        assert file_path.read_text() == "prefix\ntail\n"
 
     def test_discard_file_projects_replacement_onto_older_batch_baseline(
         self,

--- a/tests/functional/test_discard_file_behavior.py
+++ b/tests/functional/test_discard_file_behavior.py
@@ -10,6 +10,82 @@ from .conftest import git_stage_batch
 class TestDiscardFile:
     """Tests for discard --file removing files and preserving batch content."""
 
+    def test_discard_file_projects_replacement_onto_older_batch_baseline(
+        self,
+        functional_repo,
+    ):
+        """Whole-file saves must not reuse live-HEAD deletion coordinates."""
+        file_path = functional_repo / "sections.txt"
+        original = (
+            "section1\n"
+            "x\n"
+            "old\n"
+            "y\n"
+            "section2\n"
+            "x\n"
+            "old\n"
+            "y\n"
+            "end\n"
+        )
+        file_path.write_text(original)
+        subprocess.run(
+            ["git", "add", "sections.txt"],
+            check=True,
+            cwd=functional_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add repeated sections"],
+            check=True,
+            cwd=functional_repo,
+            capture_output=True,
+        )
+        git_stage_batch("new", "saved")
+
+        live_baseline = "section2\nx\nold\ny\nend\n"
+        file_path.write_text(live_baseline)
+        subprocess.run(
+            ["git", "add", "sections.txt"],
+            check=True,
+            cwd=functional_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Remove first section"],
+            check=True,
+            cwd=functional_repo,
+            capture_output=True,
+        )
+        file_path.write_text("section2\nx\nNEW\ny\nend\n")
+
+        git_stage_batch("start", "--no-auto-advance")
+        result = git_stage_batch(
+            "discard",
+            "--to",
+            "saved",
+            "--file",
+            "sections.txt",
+            "--no-auto-advance",
+            check=False,
+        )
+
+        assert result.returncode == 0, result.stderr
+        stored_content = subprocess.run(
+            [
+                "git",
+                "show",
+                "refs/git-stage-batch/batches/saved:sections.txt",
+            ],
+            check=True,
+            cwd=functional_repo,
+            capture_output=True,
+            text=True,
+        ).stdout
+        assert stored_content == original.replace(
+            "section2\nx\nold\n",
+            "section2\nx\nNEW\n",
+        )
+
     def test_discard_file_batch_round_trips_reordered_block(self, functional_repo):
         """A saved whole-file rewrite must not duplicate a moved block."""
         file_path = functional_repo / "realize.py"

--- a/tests/functional/test_include_line_transient_staging.py
+++ b/tests/functional/test_include_line_transient_staging.py
@@ -55,6 +55,37 @@ def _batch_content(repo, batch_name: str, path: str) -> str:
     return result.stdout
 
 
+def _prepare_staged_replacement(repo) -> None:
+    _commit_file(
+        repo,
+        "file.txt",
+        "head\n"
+        "orig-one\n"
+        "orig-two\n"
+        "tail\n",
+    )
+    (repo / "file.txt").write_text(
+        "staged-prefix\n"
+        "head\n"
+        "staged-one\n"
+        "staged-two\n"
+        "tail\n"
+    )
+    subprocess.run(
+        ["git", "add", "file.txt"],
+        check=True,
+        cwd=repo,
+        capture_output=True,
+    )
+    (repo / "file.txt").write_text(
+        "staged-prefix\n"
+        "head\n"
+        "work-one\n"
+        "work-two\n"
+        "tail\n"
+    )
+
+
 def _prepare_ambiguous_middle_insertion(repo) -> None:
     _commit_file(
         repo,
@@ -295,6 +326,30 @@ def test_discard_translates_deletion_position_from_staged_index(functional_repo)
 
     assert result.returncode == 0, result.stderr
     assert _batch_content(functional_repo, "saved", "file.txt") == "a\na\nb\n"
+
+
+def test_discard_to_batch_projects_partial_staged_replacement(functional_repo):
+    """Discarded replacements suppress HEAD content rather than index content."""
+    _prepare_staged_replacement(functional_repo)
+
+    git_stage_batch("start", "--no-auto-advance")
+    result = git_stage_batch(
+        "discard",
+        "--to",
+        "saved",
+        "--line",
+        "1,3",
+        "--no-auto-advance",
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert _batch_content(functional_repo, "saved", "file.txt") == (
+        "head\n"
+        "work-one\n"
+        "orig-two\n"
+        "tail\n"
+    )
 
 
 def test_discard_translates_replacement_origin_for_older_batch(functional_repo):

--- a/tests/functional/test_include_line_transient_staging.py
+++ b/tests/functional/test_include_line_transient_staging.py
@@ -328,6 +328,30 @@ def test_discard_translates_deletion_position_from_staged_index(functional_repo)
     assert _batch_content(functional_repo, "saved", "file.txt") == "a\na\nb\n"
 
 
+def test_include_to_batch_projects_partial_staged_replacement(functional_repo):
+    """Replacement removal bytes come from the persistent batch baseline."""
+    _prepare_staged_replacement(functional_repo)
+
+    git_stage_batch("start", "--no-auto-advance")
+    result = git_stage_batch(
+        "include",
+        "--to",
+        "saved",
+        "--line",
+        "1,3",
+        "--no-auto-advance",
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert _batch_content(functional_repo, "saved", "file.txt") == (
+        "head\n"
+        "work-one\n"
+        "orig-two\n"
+        "tail\n"
+    )
+
+
 def test_discard_to_batch_projects_partial_staged_replacement(functional_repo):
     """Discarded replacements suppress HEAD content rather than index content."""
     _prepare_staged_replacement(functional_repo)

--- a/tests/functional/test_stale_batch_source_advancement.py
+++ b/tests/functional/test_stale_batch_source_advancement.py
@@ -58,7 +58,7 @@ def test_stale_source_advancement_on_discard(functional_repo):
     first_batch_source = metadata["files"]["test.py"]["batch_source_commit"]
 
     # Verify the batch captured the modification
-    assert _presence_source_lines(metadata["files"]["test.py"]) == ["1-3"]
+    assert _presence_source_lines(metadata["files"]["test.py"]) == ["2"]
 
     # Now add ENTIRELY NEW code that doesn't exist in the batch source
     # The batch source has "line 1\nmodified line 2\nline 3\n"
@@ -77,9 +77,10 @@ def test_stale_source_advancement_on_discard(functional_repo):
     # Batch source should have changed
     assert second_batch_source != first_batch_source
 
-    # Verify ownership was preserved and extended
-    # Should now claim all 5 lines
-    assert "1-5" in ",".join(_presence_source_lines(metadata["files"]["test.py"]))
+    # Verify ownership was preserved and extended without claiming context.
+    assert ",".join(
+        _presence_source_lines(metadata["files"]["test.py"])
+    ) == "2,4-5"
 
 
 def test_again_include_to_new_batch_does_not_reuse_stale_session_source(functional_repo):
@@ -112,6 +113,48 @@ def test_again_include_to_new_batch_does_not_reuse_stale_session_source(function
     assert 'return "layer3"' not in source_content
     assert 'return "bridge"' in realized_content
     assert 'return "layer3"' not in realized_content
+
+
+def test_again_discard_to_new_batch_uses_current_file_coordinates(functional_repo):
+    """A first discard after again must not claim removed session-start lines."""
+    test_file = functional_repo / "layers.txt"
+    baseline = "header\nsection one\nsection two\nfooter\n"
+    session_content = (
+        "header\n"
+        "removed before discard\n"
+        "section one\n"
+        "section two\n"
+        "footer\n"
+        "saved by discard\n"
+    )
+    current_content = baseline + "saved by discard\n"
+
+    test_file.write_text(baseline)
+    subprocess.run(["git", "add", "layers.txt"], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "Add layered file"],
+        check=True,
+        capture_output=True,
+    )
+
+    test_file.write_text(session_content)
+    command_start(quiet=True)
+
+    test_file.write_text(current_content)
+    command_again(quiet=True)
+    command_discard_to_batch(
+        batch_name="current-layer",
+        file="layers.txt",
+        quiet=True,
+        advance=False,
+    )
+
+    assert test_file.read_text() == baseline
+
+    batch_commit = get_batch_commit_sha("current-layer")
+    assert batch_commit is not None
+    realized_content = _show_file(batch_commit, "layers.txt")
+    assert realized_content == current_content
 
 
 def test_replacement_to_new_batch_uses_its_rewritten_source(functional_repo):
@@ -342,7 +385,7 @@ def test_stale_discard_preserves_previously_discarded_claimed_lines(functional_r
 
     assert "owned earlier\n" in source
     assert "new later\n" in source
-    assert ",".join(_presence_source_lines(file_metadata)) == "1-3"
+    assert ",".join(_presence_source_lines(file_metadata)) == "1,3"
 
 
 def test_existing_ownership_preserved_through_advancement(functional_repo):


### PR DESCRIPTION
Replacement anchors now retain rewritten-source and saved-baseline
coordinates before and after later batch updates.

File and selected-change commands still prepare ownership from several
comparison sources. Without one projection contract, unchanged context can
become owned and referenced coordinates can reach persistence without the
buffers that define them.

This commit series binds each text-save route to its exact comparison
snapshot, derives replacement and insertion metadata in the ownership
layer, keeps context structural, and rejects incomplete projection inputs.

Text-save commands now project changed ownership from exact comparison
sources, leave context structural, and fail closed on incomplete inputs.