### PR TITLE
batch: Normalize replacement review content lazily

### DIFF
--- a/src/git_stage_batch/batch/merge/baseline_replacement_choices.py
+++ b/src/git_stage_batch/batch/merge/baseline_replacement_choices.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 import hashlib
 from typing import TYPE_CHECKING, Any
 
-from ...core.text_lines import normalize_line_endings
+from ...core.text_lines import normalize_line_sequence_endings
 from ..line_matching.sequence_equality import line_slice_equals as _line_slice_matches
 
 if TYPE_CHECKING:
@@ -38,10 +38,9 @@ def replacement_origin_choices_for_unit(
     if origin is None or not claim.content_lines:
         return None, ()
 
-    forbidden_sequence = [
-        normalize_line_endings(line)
-        for line in claim.content_lines
-    ]
+    forbidden_sequence = normalize_line_sequence_endings(
+        claim.content_lines
+    )
     if not forbidden_sequence:
         return None, ()
     if len(forbidden_sequence) > len(working_lines):

--- a/tests/batch/merge/test_baseline_replacement_choices.py
+++ b/tests/batch/merge/test_baseline_replacement_choices.py
@@ -1,0 +1,55 @@
+"""Focused tests for replacement-origin placement choices."""
+
+from git_stage_batch.batch.merge import baseline_replacement_choices
+from git_stage_batch.batch.ownership.absence_claims import AbsenceClaim
+from git_stage_batch.batch.ownership.replacement_units import (
+    ReplacementUnit,
+    ReplacementUnitOrigin,
+)
+from git_stage_batch.core.line_selection import LineRanges
+
+
+def test_replacement_origin_choices_normalize_content_without_a_list(
+    monkeypatch,
+) -> None:
+    """Replacement review should expose a normalized sequence view."""
+    claim = AbsenceClaim(
+        anchor_line=None,
+        content_lines=[b"old value\r\n"],
+    )
+    unit = ReplacementUnit(
+        presence_lines=["1"],
+        deletion_indices=[0],
+        origin=ReplacementUnitOrigin(
+            old_start=1,
+            old_end=1,
+            new_start=1,
+            new_end=1,
+        ),
+    )
+
+    def match_normalized_view(
+        _working_lines,
+        _position,
+        expected,
+    ) -> bool:
+        assert not isinstance(expected, list)
+        assert expected[0] == b"old value\n"
+        return True
+
+    monkeypatch.setattr(
+        baseline_replacement_choices,
+        "_line_slice_matches",
+        match_normalized_view,
+    )
+
+    key, choices = baseline_replacement_choices.replacement_origin_choices_for_unit(
+        claim,
+        0,
+        unit,
+        LineRanges.from_ranges(((1, 1),)),
+        [b"old value\n"],
+    )
+
+    assert key is not None
+    assert len(choices) == 1


### PR DESCRIPTION
Replacement-origin review currently normalizes every recorded deletion line into a Python list before candidate matching and key hashing.

Large replacements retain a second per-line collection even though matching only needs indexed access to normalized content.

This PR reuses the core normalized sequence view so lines are normalized on access. A focused test rejects list-backed matching input while preserving CRLF normalization.

Validation: the focused replacement-choice and ambiguous-placement tests pass, and the complete stacked tip passes 3,715 tests with 12 skips.