### PR TITLE
batch: Bound baseline edit planning heap use

### DIFF
--- a/src/git_stage_batch/batch/merge/baseline_edit_plan.py
+++ b/src/git_stage_batch/batch/merge/baseline_edit_plan.py
@@ -1,0 +1,206 @@
+"""Storage-backed execution plans for baseline-coordinate edits."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Sequence
+
+from ...core.line_selection import LineRanges
+from ...core.mapped_storage import sort_mapped_records
+from ..line_matching.match_workspace import MatcherWorkspace
+
+
+class BaselineEditPlan:
+    """Target edits with source payloads retained as mapped line ranges."""
+
+    def __init__(
+        self,
+        workspace: MatcherWorkspace,
+        *,
+        edit_capacity: int,
+        source_range_capacity: int,
+    ) -> None:
+        self._edits = workspace.record_vector(
+            edit_capacity,
+            "QQQQQ",
+        )
+        self._source_ranges = workspace.record_vector(
+            source_range_capacity,
+            "QQ",
+        )
+        self._next_ordinal = 0
+        self._edits_are_ordered = True
+        self._previous_sort_key: tuple[int, int] | None = None
+
+    def __bool__(self) -> bool:
+        return bool(self._edits)
+
+    def add_removal(self, start: int, end: int) -> None:
+        """Append one target removal without replacement source lines."""
+        self._append_edit(start, end, len(self._source_ranges))
+
+    def add_source_selection(
+        self,
+        start: int,
+        end: int,
+        source_selection: LineRanges,
+    ) -> None:
+        """Append one edit whose payload is a range-backed source selection."""
+        source_range_start = len(self._source_ranges)
+        for source_start, source_end in source_selection.ranges():
+            self._source_ranges.append((source_start, source_end))
+        self._append_edit(start, end, source_range_start)
+
+    def add_positioned_source_lines(
+        self,
+        position: int,
+        positioned_lines: Sequence[tuple[int, ...]],
+        start_index: int,
+        stop_index: int,
+    ) -> None:
+        """Append one insertion from sorted position/source-line records."""
+        source_range_start = len(self._source_ranges)
+        pending_start: int | None = None
+        pending_end: int | None = None
+
+        for record_index in range(start_index, stop_index):
+            record_position, source_line = positioned_lines[record_index]
+            if record_position != position:
+                raise ValueError("insertion group contains multiple positions")
+            if pending_start is None or pending_end is None:
+                pending_start = source_line
+                pending_end = source_line
+                continue
+            if source_line == pending_end + 1:
+                pending_end = source_line
+                continue
+            self._source_ranges.append((pending_start, pending_end))
+            pending_start = source_line
+            pending_end = source_line
+
+        if pending_start is not None and pending_end is not None:
+            self._source_ranges.append((pending_start, pending_end))
+        self._append_edit(position, position, source_range_start)
+
+    def removes_target_line(self, target_index: int) -> bool:
+        """Return whether a planned non-insertion edit covers a target line."""
+        return any(
+            start <= target_index < end
+            for (
+                start,
+                end,
+                _ordinal,
+                _source_range_start,
+                _source_range_stop,
+            ) in self._edits
+        )
+
+    def sort_and_validate(self) -> bool:
+        """Sort edits by target position and reject overlapping target spans."""
+        if not self._edits_are_ordered:
+            sort_mapped_records(self._edits)
+        previous_end = 0
+        for (
+            start,
+            end,
+            _ordinal,
+            _source_range_start,
+            _source_range_stop,
+        ) in self._edits:
+            if start < previous_end:
+                return False
+            previous_end = max(previous_end, end)
+        return True
+
+    def stream_lines(
+        self,
+        source_lines: Sequence[bytes],
+        working_lines: Sequence[bytes],
+    ) -> Iterator[bytes]:
+        """Yield working lines with the validated edit plan applied."""
+        position = 0
+        for (
+            start,
+            end,
+            _ordinal,
+            source_range_start,
+            source_range_stop,
+        ) in self._edits:
+            for working_index in range(position, start):
+                yield working_lines[working_index]
+            for source_range_index in range(
+                source_range_start,
+                source_range_stop,
+            ):
+                source_start, source_end = self._source_ranges[source_range_index]
+                for source_line in range(source_start, source_end + 1):
+                    yield source_lines[source_line - 1]
+            position = end
+
+        for working_index in range(position, len(working_lines)):
+            yield working_lines[working_index]
+
+    def _append_edit(
+        self,
+        start: int,
+        end: int,
+        source_range_start: int,
+    ) -> None:
+        source_range_stop = len(self._source_ranges)
+        sort_key = (start, end)
+        if self._previous_sort_key is not None and sort_key < self._previous_sort_key:
+            self._edits_are_ordered = False
+        self._edits.append(
+            (
+                start,
+                end,
+                self._next_ordinal,
+                source_range_start,
+                source_range_stop,
+            )
+        )
+        self._previous_sort_key = sort_key
+        self._next_ordinal += 1
+
+
+class BaselineEditStream(Iterator[bytes]):
+    """Own mapped edit-plan storage until output ends or closes."""
+
+    def __init__(
+        self,
+        plan: BaselineEditPlan,
+        source_lines: Sequence[bytes],
+        working_lines: Sequence[bytes],
+        workspace: MatcherWorkspace,
+    ) -> None:
+        self._lines = plan.stream_lines(source_lines, working_lines)
+        self._workspace: MatcherWorkspace | None = workspace
+
+    def __iter__(self) -> BaselineEditStream:
+        return self
+
+    def __next__(self) -> bytes:
+        try:
+            return next(self._lines)
+        except StopIteration:
+            self.close()
+            raise
+        except Exception:
+            self.close()
+            raise
+
+    def close(self) -> None:
+        """Release the output generator and its mapped planning storage."""
+        workspace = self._workspace
+        if workspace is None:
+            return
+        self._workspace = None
+        try:
+            self._lines.close()
+        finally:
+            workspace.close()
+
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except Exception:
+            pass

--- a/src/git_stage_batch/batch/merge/baseline_edits.py
+++ b/src/git_stage_batch/batch/merge/baseline_edits.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator, Mapping, Sequence
+from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -12,6 +12,10 @@ from ...core.mapped_storage import MappedRecordVector, sort_mapped_records
 from ...exceptions import MergeError as _MergeError
 from ...i18n import _
 from ...core.text_lines import normalize_line_sequence_endings
+from .baseline_edit_plan import (
+    BaselineEditPlan as _BaselineEditPlan,
+    BaselineEditStream as _BaselineEditStream,
+)
 from .baseline_reference_positions import (
     baseline_reference_absence_position as _find_baseline_absence_position,
     baseline_reference_insertion_position as _find_baseline_insertion_position,
@@ -37,7 +41,7 @@ if TYPE_CHECKING:
     from ..ownership.absence_claims import AbsenceClaim
 
 
-_BaselineLineEdit = tuple[int, int, list[bytes]]
+_BaselineRemovalEdit = tuple[int, int]
 _DEFAULT_RESOLUTION_CHOICE_LIMIT = 51
 
 
@@ -152,7 +156,7 @@ def _removal_boundary_is_fixed_to_file_edge(claim: AbsenceClaim) -> bool:
 def _baseline_removal_edit(
     claim: AbsenceClaim,
     working_lines: Sequence[bytes],
-) -> _BaselineLineEdit | None:
+) -> _BaselineRemovalEdit | None:
     if not claim.content_lines:
         return None
 
@@ -166,7 +170,7 @@ def _baseline_removal_edit(
         return None
     if not _line_slice_matches(working_lines, position, forbidden_sequence):
         return None
-    return position, position + len(forbidden_sequence), []
+    return position, position + len(forbidden_sequence)
 
 
 def _removal_boundary_identity_matches_at(
@@ -498,13 +502,12 @@ def _live_coordinate_edits_are_safe(
     working_lines: Sequence[bytes],
     deletion_claims: Sequence[AbsenceClaim],
     deletion_edit_bounds: Sequence[tuple[int, ...]],
-    insertion_groups: Mapping[int, Sequence[int]] | None,
-    claimed_line_references: Mapping[int, Any],
+    positioned_insertion_lines: Sequence[tuple[int, ...]] | None,
     *,
     spool_dir: str | Path | None,
 ) -> bool:
     """Return whether every coordinate edit has one live target boundary."""
-    if not deletion_claims and not insertion_groups:
+    if not deletion_claims and not positioned_insertion_lines:
         return True
 
     with MatcherWorkspace(spool_dir=spool_dir) as workspace:
@@ -609,17 +612,18 @@ def _live_coordinate_edits_are_safe(
                 return False
             replacement_reference_index = next_replacement_reference
 
-        if insertion_groups is not None:
-            for position, claimed_lines in insertion_groups.items():
-                for claimed_line in claimed_lines:
-                    reference = claimed_line_references.get(claimed_line)
-                    if not _live_insertion_boundary_is_unique(
-                        reference,
-                        working_lines,
-                        position,
-                        occurrence_index,
-                    ):
-                        return False
+        if positioned_insertion_lines is not None:
+            for position, claimed_line in positioned_insertion_lines:
+                reference = ownership.presence_baseline_reference(
+                    claimed_line
+                )
+                if not _live_insertion_boundary_is_unique(
+                    reference,
+                    working_lines,
+                    position,
+                    occurrence_index,
+                ):
+                    return False
 
     return True
 
@@ -649,7 +653,7 @@ def _replacement_edit_with_origin_guard(
     claim: AbsenceClaim,
     origin: Any,
     working_lines: Sequence[bytes],
-) -> _BaselineLineEdit | None:
+) -> _BaselineRemovalEdit | None:
     """Return a removal edit only if it fits inside the original parent unit."""
     removal_edit = _baseline_removal_edit(claim, working_lines)
     if removal_edit is None:
@@ -662,19 +666,19 @@ def _replacement_edit_with_origin_guard(
     if parent_bounds is None:
         return None
 
-    start, end, replacement_lines = removal_edit
+    start, end = removal_edit
     parent_start, parent_end = parent_bounds
     if start < parent_start or end > parent_end:
         return None
-    return start, end, replacement_lines
+    return start, end
 
 
 def _replacement_edit_from_parent_offset(
     claim: AbsenceClaim,
     origin: Any,
-    claimed_lines: Sequence[int],
+    claimed_lines: LineRanges,
     working_lines: Sequence[bytes],
-) -> _BaselineLineEdit | None:
+) -> _BaselineRemovalEdit | None:
     """Place an equal-size split replacement by offset inside its parent."""
     if origin is None or not claim.content_lines:
         return None
@@ -695,18 +699,15 @@ def _replacement_edit_from_parent_offset(
     if old_line_count != new_line_count:
         return None
 
-    if not claimed_lines:
+    claimed_ranges = claimed_lines.ranges()
+    if len(claimed_ranges) != 1:
         return None
 
-    first_claimed_line = claimed_lines[0]
-    if any(
-        claimed_line != first_claimed_line + offset
-        for offset, claimed_line in enumerate(claimed_lines)
-    ):
-        return None
+    first_claimed_line, last_claimed_line = claimed_ranges[0]
+    claimed_line_count = last_claimed_line - first_claimed_line + 1
 
     forbidden_sequence = normalize_line_sequence_endings(claim.content_lines)
-    if len(forbidden_sequence) != len(claimed_lines):
+    if len(forbidden_sequence) != claimed_line_count:
         return None
 
     parent_bounds = _replacement_origin_absence_bounds(origin, working_lines)
@@ -730,7 +731,7 @@ def _replacement_edit_from_parent_offset(
 
     if (
         relative_offset < 0
-        or relative_offset + len(claimed_lines) > new_line_count
+        or relative_offset + claimed_line_count > new_line_count
     ):
         return None
 
@@ -741,19 +742,19 @@ def _replacement_edit_from_parent_offset(
         return None
     if not _line_slice_matches(working_lines, start, forbidden_sequence):
         return None
-    return start, end, []
+    return start, end
 
 
 def _replacement_edit_from_origin_resolution(
     claim: AbsenceClaim,
     unit_index: int,
     unit: Any,
-    claimed_lines: Sequence[int],
+    claimed_lines: LineRanges,
     working_lines: Sequence[bytes],
     resolution: _MergeResolution | None,
     *,
     max_results: int,
-) -> _BaselineLineEdit | None:
+) -> _BaselineRemovalEdit | None:
     """Return a replacement edit from a reviewed origin-placement choice."""
     if resolution is None:
         return None
@@ -776,7 +777,6 @@ def _replacement_edit_from_origin_resolution(
             return (
                 choice.position,
                 choice.position + len(forbidden_sequence),
-                [],
             )
 
     raise _MergeError(_("Selected merge resolution is no longer valid"))
@@ -786,12 +786,12 @@ def _replacement_baseline_edit(
     claim: AbsenceClaim,
     unit_index: int,
     unit: Any,
-    claimed_lines: Sequence[int],
+    claimed_lines: LineRanges,
     working_lines: Sequence[bytes],
     resolution: _MergeResolution | None,
     *,
     max_resolution_choices: int,
-) -> tuple[_BaselineLineEdit, bool] | None:
+) -> tuple[_BaselineRemovalEdit, bool] | None:
     origin = getattr(unit, "origin", None)
     guarded_edit = _replacement_edit_with_origin_guard(
         claim,
@@ -824,33 +824,288 @@ def _replacement_baseline_edit(
     return reviewed_edit, True
 
 
-def _apply_non_overlapping_baseline_edits(
+def _selection_fits_source(
+    source_selection: LineRanges,
+    source_line_count: int,
+) -> bool:
+    """Return whether every selected source line has available content."""
+    ranges = source_selection.ranges()
+    return not ranges or ranges[-1][1] <= source_line_count
+
+
+def _positioned_source_lines_match(
+    source_lines: Sequence[bytes],
     working_lines: Sequence[bytes],
-    edits: list[_BaselineLineEdit],
-) -> Iterator[bytes] | None:
-    sorted_edits = sorted(edits, key=lambda edit: (edit[0], edit[1]))
-    previous_end = 0
-    for start, end, _replacement_lines in sorted_edits:
-        if start < previous_end:
+    position: int,
+    positioned_lines: Sequence[tuple[int, ...]],
+    start_index: int,
+    stop_index: int,
+) -> bool:
+    """Return whether one positioned source-line group already exists."""
+    line_count = stop_index - start_index
+    if position < 0 or position + line_count > len(working_lines):
+        return False
+
+    for offset, record_index in enumerate(range(start_index, stop_index)):
+        _record_position, source_line = positioned_lines[record_index]
+        if working_lines[position + offset] != source_lines[source_line - 1]:
+            return False
+    return True
+
+
+def _replacement_source_range_capacity(replacement_units: Sequence[Any]) -> int:
+    """Return mapped-record capacity for replacement source ranges."""
+    return sum(
+        line_spec.count(",") + 1
+        for unit in replacement_units
+        for line_spec in unit.presence_lines
+    )
+
+
+def _plan_replacement_unit_edits(
+    plan: _BaselineEditPlan,
+    source_line_count: int,
+    working_lines: Sequence[bytes],
+    replacement_units: Sequence[Any],
+    deletion_claims: Sequence[AbsenceClaim],
+    deletion_edit_bounds: MappedRecordVector,
+    resolution: _MergeResolution | None,
+    *,
+    max_resolution_choices: int,
+) -> LineRanges | None:
+    """Plan coupled replacement units and return their claimed source lines."""
+    unit_claimed_lines = LineRanges.empty()
+
+    for unit_index, unit in enumerate(replacement_units):
+        claimed_selection = LineRanges.from_specs(unit.presence_lines)
+        if (
+            not claimed_selection
+            or not _selection_fits_source(
+                claimed_selection,
+                source_line_count,
+            )
+            or len(unit.deletion_indices) != 1
+        ):
             return None
-        previous_end = max(previous_end, end)
 
-    return _iter_lines_with_baseline_edits(working_lines, sorted_edits)
+        deletion_index = unit.deletion_indices[0]
+        if deletion_index < 0 or deletion_index >= len(deletion_claims):
+            return None
+
+        replacement_edit = _replacement_baseline_edit(
+            deletion_claims[deletion_index],
+            unit_index,
+            unit,
+            claimed_selection,
+            working_lines,
+            resolution,
+            max_resolution_choices=max_resolution_choices,
+        )
+        if replacement_edit is None:
+            return None
+
+        removal_edit, coordinate_was_reviewed = replacement_edit
+        start, end = removal_edit
+        plan.add_source_selection(
+            start,
+            end,
+            claimed_selection,
+        )
+        deletion_edit_bounds[deletion_index] = (
+            1,
+            start,
+            end,
+            coordinate_was_reviewed,
+        )
+        unit_claimed_lines = unit_claimed_lines.union(claimed_selection)
+
+    return unit_claimed_lines
 
 
-def _iter_lines_with_baseline_edits(
+def _plan_independent_removal_edits(
+    plan: _BaselineEditPlan,
     working_lines: Sequence[bytes],
-    sorted_edits: Sequence[_BaselineLineEdit],
-) -> Iterator[bytes]:
-    position = 0
-    for start, end, replacement_lines in sorted_edits:
-        for index in range(position, start):
-            yield working_lines[index]
-        yield from replacement_lines
-        position = end
+    deletion_claims: Sequence[AbsenceClaim],
+    deletion_edit_bounds: MappedRecordVector,
+) -> bool:
+    """Plan removals not already coupled to replacement units."""
+    for deletion_index, claim in enumerate(deletion_claims):
+        if deletion_edit_bounds[deletion_index][0]:
+            continue
 
-    for index in range(position, len(working_lines)):
-        yield working_lines[index]
+        removal_edit = _baseline_removal_edit(claim, working_lines)
+        if removal_edit is None:
+            return False
+
+        start, end = removal_edit
+        plan.add_removal(start, end)
+        deletion_edit_bounds[deletion_index] = (
+            1,
+            start,
+            end,
+            0,
+        )
+
+    return True
+
+
+def _collect_presence_position_records(
+    workspace: MatcherWorkspace,
+    source_line_count: int,
+    working_lines: Sequence[bytes],
+    ownership: BatchOwnership,
+    remaining_claimed_lines: LineRanges,
+) -> tuple[MappedRecordVector, MappedRecordVector, bool] | None:
+    """Partition presence lines into positioned and mapping-backed records."""
+    positioned_lines = workspace.record_vector(
+        len(remaining_claimed_lines),
+        "QQ",
+    )
+    unmapped_lines = workspace.record_vector(
+        len(remaining_claimed_lines),
+        "Q",
+    )
+    positioned_lines_are_ordered = True
+    previous_position: int | None = None
+
+    for claimed_line in remaining_claimed_lines:
+        if claimed_line > source_line_count:
+            return None
+        position = _find_baseline_insertion_position(
+            ownership.presence_baseline_reference(claimed_line),
+            working_lines,
+        )
+        if position is None:
+            unmapped_lines.append((claimed_line,))
+        else:
+            if (
+                previous_position is not None
+                and position < previous_position
+            ):
+                positioned_lines_are_ordered = False
+            positioned_lines.append((position, claimed_line))
+            previous_position = position
+
+    return positioned_lines, unmapped_lines, positioned_lines_are_ordered
+
+
+def _mapping_preserves_unpositioned_presence(
+    plan: _BaselineEditPlan,
+    source_lines: Sequence[bytes],
+    working_lines: Sequence[bytes],
+    unmapped_lines: Sequence[tuple[int, ...]],
+    *,
+    spool_dir: str | Path | None,
+) -> bool:
+    """Return whether mapped unpositioned lines survive planned removals."""
+    if not unmapped_lines:
+        return True
+
+    with _match_lines(
+        source_lines,
+        working_lines,
+        spool_dir=spool_dir,
+    ) as mapping:
+        for claimed_line, in unmapped_lines:
+            target_line = mapping.get_target_line_from_source_line(
+                claimed_line
+            )
+            if (
+                target_line is None
+                or plan.removes_target_line(target_line - 1)
+            ):
+                return False
+    return True
+
+
+def _add_positioned_presence_insertions(
+    plan: _BaselineEditPlan,
+    source_lines: Sequence[bytes],
+    working_lines: Sequence[bytes],
+    positioned_lines: MappedRecordVector,
+    *,
+    positioned_lines_are_ordered: bool,
+    trust_baseline_coordinates: bool,
+) -> None:
+    """Group positioned presence lines and append required insertions."""
+    if not positioned_lines_are_ordered:
+        sort_mapped_records(positioned_lines)
+
+    group_start = 0
+    while group_start < len(positioned_lines):
+        position = positioned_lines[group_start][0]
+        group_stop = group_start + 1
+        while (
+            group_stop < len(positioned_lines)
+            and positioned_lines[group_stop][0] == position
+        ):
+            group_stop += 1
+
+        if (
+            trust_baseline_coordinates
+            or not _positioned_source_lines_match(
+                source_lines,
+                working_lines,
+                position,
+                positioned_lines,
+                group_start,
+                group_stop,
+            )
+        ):
+            plan.add_positioned_source_lines(
+                position,
+                positioned_lines,
+                group_start,
+                group_stop,
+            )
+        group_start = group_stop
+
+
+def _plan_presence_insertions(
+    plan: _BaselineEditPlan,
+    workspace: MatcherWorkspace,
+    source_lines: Sequence[bytes],
+    working_lines: Sequence[bytes],
+    ownership: BatchOwnership,
+    remaining_claimed_lines: LineRanges,
+    *,
+    trust_baseline_coordinates: bool,
+    spool_dir: str | Path | None,
+) -> MappedRecordVector | None:
+    """Plan explicit insertions and validate presence resolved by matching."""
+    position_records = _collect_presence_position_records(
+        workspace,
+        len(source_lines),
+        working_lines,
+        ownership,
+        remaining_claimed_lines,
+    )
+    if position_records is None:
+        return None
+    positioned_lines, unmapped_lines, positioned_lines_are_ordered = (
+        position_records
+    )
+
+    if not _mapping_preserves_unpositioned_presence(
+        plan,
+        source_lines,
+        working_lines,
+        unmapped_lines,
+        spool_dir=spool_dir,
+    ):
+        return None
+
+    workspace.close_resource(unmapped_lines)
+    _add_positioned_presence_insertions(
+        plan,
+        source_lines,
+        working_lines,
+        positioned_lines,
+        positioned_lines_are_ordered=positioned_lines_are_ordered,
+        trust_baseline_coordinates=trust_baseline_coordinates,
+    )
+
+    return positioned_lines
 
 
 def _has_complete_baseline_references(
@@ -858,9 +1113,8 @@ def _has_complete_baseline_references(
     presence_line_set: LineSelection,
     deletion_claims: list[AbsenceClaim],
 ) -> bool:
-    claimed_line_references = ownership.presence_baseline_references()
     for claimed_line in presence_line_set:
-        reference = claimed_line_references.get(claimed_line)
+        reference = ownership.presence_baseline_reference(claimed_line)
         if reference is None or not getattr(reference, "has_after_line", False):
             return False
     for claim in deletion_claims:
@@ -944,13 +1198,15 @@ def try_apply_baseline_replacement_units(
     ):
         return iter(working_lines)
 
-    with MappedRecordVector(
-        len(deletion_claims),
-        "QQQQ",
-        length=len(deletion_claims),
-        spool_dir=spool_dir,
-    ) as deletion_edit_bounds:
-        return _try_apply_baseline_replacement_units(
+    workspace = MatcherWorkspace(spool_dir=spool_dir)
+    try:
+        deletion_edit_bounds = workspace.record_vector(
+            len(deletion_claims),
+            "QQQQ",
+            length=len(deletion_claims),
+        )
+        plan = _build_baseline_edit_plan(
+            workspace,
             source_lines,
             working_lines,
             ownership,
@@ -962,9 +1218,28 @@ def try_apply_baseline_replacement_units(
             trust_baseline_coordinates=trust_baseline_coordinates,
             spool_dir=spool_dir,
         )
+        if plan is None:
+            workspace.close()
+            return None
+
+        workspace.close_resource(deletion_edit_bounds)
+        if not plan:
+            workspace.close()
+            return iter(working_lines)
+
+        return _BaselineEditStream(
+            plan,
+            source_lines,
+            working_lines,
+            workspace,
+        )
+    except Exception:
+        workspace.close()
+        raise
 
 
-def _try_apply_baseline_replacement_units(
+def _build_baseline_edit_plan(
+    workspace: MatcherWorkspace,
     source_lines: Sequence[bytes],
     working_lines: Sequence[bytes],
     ownership: BatchOwnership,
@@ -976,127 +1251,55 @@ def _try_apply_baseline_replacement_units(
     max_resolution_choices: int,
     trust_baseline_coordinates: bool,
     spool_dir: str | Path | None,
-) -> Iterator[bytes] | None:
-    """Build and validate exact-coordinate fallback edits."""
+) -> _BaselineEditPlan | None:
+    """Build and validate one storage-backed exact-coordinate edit plan."""
     replacement_units = getattr(ownership, "replacement_units", [])
-    edits: list[_BaselineLineEdit] = []
-    unit_claimed_lines = LineRanges.empty()
-    unit_deletion_indices: set[int] = set()
-
-    for unit_index, unit in enumerate(replacement_units):
-        claimed_selection = LineRanges.from_specs(unit.presence_lines)
-        claimed_lines = list(claimed_selection)
-        if not claimed_lines or len(unit.deletion_indices) != 1:
-            return None
-
-        deletion_index = unit.deletion_indices[0]
-        if deletion_index < 0 or deletion_index >= len(deletion_claims):
-            return None
-        replacement_lines: list[bytes] = []
-        for claimed_line in claimed_lines:
-            if claimed_line < 1 or claimed_line > len(source_lines):
-                return None
-            replacement_lines.append(source_lines[claimed_line - 1])
-
-        replacement_edit = _replacement_baseline_edit(
-            deletion_claims[deletion_index],
-            unit_index,
-            unit,
-            claimed_lines,
-            working_lines,
-            resolution,
-            max_resolution_choices=max_resolution_choices,
-        )
-        if replacement_edit is None:
-            return None
-        removal_edit, coordinate_was_reviewed = replacement_edit
-        start, end, _removed_lines = removal_edit
-        edits.append((start, end, replacement_lines))
-        deletion_edit_bounds[deletion_index] = (
-            1,
-            start,
-            end,
-            coordinate_was_reviewed,
-        )
-        unit_claimed_lines = unit_claimed_lines.union(claimed_selection)
-        unit_deletion_indices.add(deletion_index)
-
-    for deletion_index, claim in enumerate(deletion_claims):
-        if deletion_index in unit_deletion_indices:
-            continue
-        removal_edit = _baseline_removal_edit(claim, working_lines)
-        if removal_edit is None:
-            return None
-        edits.append(removal_edit)
-        deletion_edit_bounds[deletion_index] = (
-            1,
-            removal_edit[0],
-            removal_edit[1],
-            0,
-        )
-
     presence_lines = coerce_line_ranges(presence_line_set)
+    plan = _BaselineEditPlan(
+        workspace,
+        edit_capacity=(
+            len(replacement_units)
+            + len(deletion_claims)
+            + len(presence_lines)
+        ),
+        source_range_capacity=(
+            _replacement_source_range_capacity(replacement_units)
+            + len(presence_lines)
+        ),
+    )
+    unit_claimed_lines = _plan_replacement_unit_edits(
+        plan,
+        len(source_lines),
+        working_lines,
+        replacement_units,
+        deletion_claims,
+        deletion_edit_bounds,
+        resolution,
+        max_resolution_choices=max_resolution_choices,
+    )
+    if unit_claimed_lines is None:
+        return None
+    if not _plan_independent_removal_edits(
+        plan,
+        working_lines,
+        deletion_claims,
+        deletion_edit_bounds,
+    ):
+        return None
+
     remaining_claimed_lines = presence_lines.difference(unit_claimed_lines)
-    claimed_line_references = ownership.presence_baseline_references()
-    grouped_insertions: dict[int, list[int]] | None = None
-    if remaining_claimed_lines:
-        grouped_insertions = {}
-        has_mapped_claimed_lines = False
-        for claimed_line in sorted(remaining_claimed_lines):
-            if claimed_line < 1 or claimed_line > len(source_lines):
-                return None
-            reference = claimed_line_references.get(claimed_line)
-            position = _find_baseline_insertion_position(
-                reference,
-                working_lines,
-            )
-            if position is None:
-                has_mapped_claimed_lines = True
-                continue
-            grouped_insertions.setdefault(position, []).append(claimed_line)
-
-        if has_mapped_claimed_lines:
-            with _match_lines(
-                source_lines,
-                working_lines,
-                spool_dir=spool_dir,
-            ) as mapping:
-                for claimed_line in remaining_claimed_lines:
-                    reference = claimed_line_references.get(claimed_line)
-                    if _find_baseline_insertion_position(
-                        reference,
-                        working_lines,
-                    ) is not None:
-                        continue
-                    target_line = mapping.get_target_line_from_source_line(
-                        claimed_line
-                    )
-                    if target_line is None or any(
-                        start <= target_line - 1 < end
-                        for start, end, _replacement_lines in edits
-                    ):
-                        return None
-
-        for position, claimed_lines in grouped_insertions.items():
-            insertion_lines = [
-                source_lines[claimed_line - 1] for claimed_line in claimed_lines
-            ]
-            if (
-                not trust_baseline_coordinates
-                and _line_slice_matches(
-                    working_lines,
-                    position,
-                    insertion_lines,
-                )
-            ):
-                continue
-            edits.append(
-                (
-                    position,
-                    position,
-                    insertion_lines,
-                )
-            )
+    positioned_insertion_lines = _plan_presence_insertions(
+        plan,
+        workspace,
+        source_lines,
+        working_lines,
+        ownership,
+        remaining_claimed_lines,
+        trust_baseline_coordinates=trust_baseline_coordinates,
+        spool_dir=spool_dir,
+    )
+    if positioned_insertion_lines is None:
+        return None
 
     if unit_claimed_lines.union(remaining_claimed_lines) != presence_lines:
         return None
@@ -1107,14 +1310,16 @@ def _try_apply_baseline_replacement_units(
             working_lines,
             deletion_claims,
             deletion_edit_bounds,
-            grouped_insertions,
-            claimed_line_references,
+            positioned_insertion_lines,
             spool_dir=spool_dir,
         )
     ):
         return None
 
-    return _apply_non_overlapping_baseline_edits(working_lines, edits)
+    workspace.close_resource(positioned_insertion_lines)
+    if not plan.sort_and_validate():
+        return None
+    return plan
 
 
 def has_missing_origin_replacement_claims(

--- a/src/git_stage_batch/batch/merge/baseline_replacement_choices.py
+++ b/src/git_stage_batch/batch/merge/baseline_replacement_choices.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 import hashlib
 from typing import TYPE_CHECKING, Any
 
+from ...core.line_selection import LineSelection, coerce_line_ranges
 from ...core.text_lines import normalize_line_sequence_endings
 from ..line_matching.sequence_equality import line_slice_equals as _line_slice_matches
 
@@ -28,7 +29,7 @@ def replacement_origin_choices_for_unit(
     claim: AbsenceClaim,
     unit_index: int,
     unit: Any,
-    claimed_lines: Sequence[int],
+    claimed_lines: LineSelection,
     working_lines: Sequence[bytes],
     *,
     max_results: int | None = None,
@@ -86,10 +87,10 @@ def _replacement_origin_ambiguity_key(
     unit_index: int,
     deletion_index: int,
     origin: Any,
-    claimed_lines: Sequence[int],
+    claimed_lines: LineSelection,
     forbidden_sequence: Sequence[bytes],
 ) -> str:
-    claimed = ",".join(str(line) for line in claimed_lines)
+    claimed = coerce_line_ranges(claimed_lines).to_line_spec()
     digest = _sequence_digest(forbidden_sequence)
     return (
         f"replacement-origin:{unit_index}:delete:{deletion_index}:"

--- a/src/git_stage_batch/batch/merge/candidate_enumeration.py
+++ b/src/git_stage_batch/batch/merge/candidate_enumeration.py
@@ -60,14 +60,19 @@ def _replacement_origin_candidate_set(
     try:
         selected_presence = coerce_line_ranges(presence_line_set)
         unresolved: list[
-            tuple[list[int], int, str, tuple[_BaselineReplacementOriginChoice, ...]]
+            tuple[
+                LineRanges,
+                int,
+                str,
+                tuple[_BaselineReplacementOriginChoice, ...],
+            ]
         ] = []
         for unit_index, unit in enumerate(getattr(ownership, "replacement_units", [])):
             if getattr(unit, "origin", None) is None:
                 continue
 
             claimed_selection = LineRanges.from_specs(unit.presence_lines)
-            claimed_lines = list(selected_presence.intersection(claimed_selection))
+            claimed_lines = selected_presence.intersection(claimed_selection)
             if not claimed_lines:
                 continue
             if all(
@@ -122,8 +127,9 @@ def _replacement_origin_candidate_set(
     count = len(valid_choices)
     claim = deletion_claims[deletion_index]
     line_count = len(claim.content_lines)
-    source_start = min(claimed_lines)
-    source_end = max(claimed_lines)
+    claimed_ranges = claimed_lines.ranges()
+    source_start = claimed_ranges[0][0]
+    source_end = claimed_ranges[-1][1]
     ambiguity_target_line_range = (
         min(choice.position + 1 for choice in valid_choices),
         max(choice.position + line_count for choice in valid_choices),

--- a/src/git_stage_batch/batch/ownership/model.py
+++ b/src/git_stage_batch/batch/ownership/model.py
@@ -75,6 +75,16 @@ class BatchOwnership:
             references.update(claim.baseline_references)
         return references
 
+    def presence_baseline_reference(
+        self,
+        source_line: int,
+    ) -> _BaselineReference | None:
+        """Return the effective baseline reference for one source line."""
+        for claim in reversed(self.presence_claims):
+            if source_line in claim.baseline_references:
+                return claim.baseline_references[source_line]
+        return None
+
     def to_metadata_dict(self) -> dict:
         """Convert to metadata dictionary format for storage."""
         data = {

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -12626,6 +12626,55 @@ def test_batch_merge_candidate_enumeration_owns_preview_building():
     assert violations == []
 
 
+def test_batch_baseline_edit_plan_owns_mapped_execution_storage():
+    """Baseline edit records and stream lifetime should stay below policy."""
+    baseline_edit_plan = __import__(
+        "git_stage_batch.batch.merge.baseline_edit_plan",
+        fromlist=["baseline_edit_plan"],
+    )
+    baseline_edits = __import__(
+        "git_stage_batch.batch.merge.baseline_edits",
+        fromlist=["baseline_edits"],
+    )
+    plan_path = SRC_ROOT / "batch" / "merge/baseline_edit_plan.py"
+    fallback_path = SRC_ROOT / "batch" / "merge/baseline_edits.py"
+    public_names = {
+        "BaselineEditPlan",
+        "BaselineEditStream",
+    }
+    expected_imports = {
+        fallback_path: public_names,
+    }
+    violations = []
+
+    assert public_names <= vars(baseline_edit_plan).keys()
+    assert public_names.isdisjoint(vars(baseline_edits))
+
+    for path in SRC_ROOT.rglob("*.py"):
+        if path == plan_path:
+            continue
+
+        imported_public_names = set()
+        for imported_module, node in _import_from_nodes(path):
+            if imported_module != (
+                "git_stage_batch.batch.merge.baseline_edit_plan"
+            ):
+                continue
+            imported_public_names.update(
+                alias.name for alias in node.names
+                if alias.name in public_names
+            )
+
+        if path in expected_imports:
+            assert expected_imports[path] <= imported_public_names
+        elif imported_public_names:
+            relative_path = path.relative_to(REPO_ROOT)
+            names = ", ".join(sorted(imported_public_names))
+            violations.append(f"{relative_path} imports {names}")
+
+    assert violations == []
+
+
 def test_batch_baseline_edits_own_replacement_fallback():
     """Baseline-coordinate merge fallback should live outside merge."""
     baseline_edits = __import__(

--- a/tests/batch/merge/test_baseline_edits.py
+++ b/tests/batch/merge/test_baseline_edits.py
@@ -1,0 +1,348 @@
+"""Focused tests for baseline-coordinate edit planning."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from git_stage_batch.batch.merge import baseline_edits
+from git_stage_batch.batch.ownership.absence_claims import AbsenceClaim
+from git_stage_batch.batch.ownership.model import BatchOwnership
+from git_stage_batch.batch.ownership.references import BaselineReference
+from git_stage_batch.batch.ownership.replacement_units import ReplacementUnit
+from git_stage_batch.core.line_selection import LineRanges
+
+
+class _CountingLines(Sequence[bytes]):
+    def __init__(self, line_count: int) -> None:
+        self.line_count = line_count
+        self.read_count = 0
+
+    def __len__(self) -> int:
+        return self.line_count
+
+    def __getitem__(self, index: int | slice) -> bytes | Sequence[bytes]:
+        if isinstance(index, slice):
+            raise AssertionError("source lines must not be sliced")
+        if index < 0:
+            index += self.line_count
+        if index < 0 or index >= self.line_count:
+            raise IndexError(index)
+        self.read_count += 1
+        return b"new value\n"
+
+
+def _boundary_reference(
+    *,
+    after_line: int | None,
+    after_content: bytes | None = None,
+    before_line: int | None,
+    before_content: bytes | None = None,
+) -> BaselineReference:
+    return BaselineReference(
+        after_line=after_line,
+        after_content=after_content,
+        has_after_line=True,
+        before_line=before_line,
+        before_content=before_content,
+        has_before_line=True,
+    )
+
+
+def test_baseline_edit_planning_composes_all_edit_kinds() -> None:
+    """Replacement, removal, and insertion plans should compose in order."""
+    source_lines = [b"new value\n", b"inserted\n"]
+    working_lines = [b"old value\n", b"remove me\n", b"tail\n"]
+    replacement_reference = _boundary_reference(
+        after_line=None,
+        before_line=2,
+        before_content=b"remove me",
+    )
+    removal_reference = _boundary_reference(
+        after_line=1,
+        after_content=b"old value",
+        before_line=3,
+        before_content=b"tail",
+    )
+    insertion_reference = _boundary_reference(
+        after_line=2,
+        after_content=b"remove me",
+        before_line=3,
+        before_content=b"tail",
+    )
+    deletion_claims = [
+        AbsenceClaim(
+            anchor_line=None,
+            content_lines=[b"old value\n"],
+            baseline_reference=replacement_reference,
+        ),
+        AbsenceClaim(
+            anchor_line=1,
+            content_lines=[b"remove me\n"],
+            baseline_reference=removal_reference,
+        ),
+    ]
+    ownership = BatchOwnership.from_presence_lines(
+        ["1-2"],
+        deletion_claims,
+        baseline_references={
+            1: replacement_reference,
+            2: insertion_reference,
+        },
+        replacement_units=[
+            ReplacementUnit(
+                presence_lines=["1"],
+                deletion_indices=[0],
+            ),
+        ],
+    )
+
+    result = baseline_edits.try_apply_baseline_replacement_units(
+        source_lines,
+        working_lines,
+        ownership,
+        LineRanges.from_ranges(((1, 2),)),
+        deletion_claims,
+    )
+
+    assert result is not None
+    assert list(result) == [b"new value\n", b"inserted\n", b"tail\n"]
+
+
+def test_baseline_edit_planning_rejects_incomplete_replacement_unit() -> None:
+    """Replacement metadata without one removal must fail closed."""
+    source_lines = [b"new value\n"]
+    working_lines = [b"old value\n"]
+    deletion_claims = [
+        AbsenceClaim(
+            anchor_line=None,
+            content_lines=[b"old value\n"],
+            baseline_reference=_boundary_reference(
+                after_line=None,
+                before_line=None,
+            ),
+        ),
+    ]
+    ownership = BatchOwnership.from_presence_lines(
+        ["1"],
+        deletion_claims,
+        replacement_units=[
+            ReplacementUnit(
+                presence_lines=["1"],
+                deletion_indices=[],
+            ),
+        ],
+    )
+
+    result = baseline_edits.try_apply_baseline_replacement_units(
+        source_lines,
+        working_lines,
+        ownership,
+        LineRanges.from_ranges(((1, 1),)),
+        deletion_claims,
+        trust_baseline_coordinates=True,
+    )
+
+    assert result is None
+
+
+def test_baseline_replacement_payload_stays_lazy(
+    monkeypatch,
+) -> None:
+    """Planning should retain source ranges instead of collecting their lines."""
+
+    def fail_collection(*_args, **_kwargs):
+        raise AssertionError("baseline plans must use storage-backed ranges")
+
+    line_count = 1000
+    source_lines = _CountingLines(line_count)
+    working_lines = [b"old value\n"]
+    replacement_reference = _boundary_reference(
+        after_line=None,
+        before_line=None,
+    )
+    deletion_claims = [
+        AbsenceClaim(
+            anchor_line=None,
+            content_lines=[b"old value\n"],
+            baseline_reference=replacement_reference,
+        ),
+    ]
+    ownership = BatchOwnership.from_presence_lines(
+        [f"1-{line_count}"],
+        deletion_claims,
+        replacement_units=[
+            ReplacementUnit(
+                presence_lines=[f"1-{line_count}"],
+                deletion_indices=[0],
+            ),
+        ],
+    )
+    monkeypatch.setattr(
+        baseline_edits,
+        "list",
+        fail_collection,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        baseline_edits,
+        "sorted",
+        fail_collection,
+        raising=False,
+    )
+
+    result = baseline_edits.try_apply_baseline_replacement_units(
+        source_lines,
+        working_lines,
+        ownership,
+        LineRanges.from_ranges(((1, line_count),)),
+        deletion_claims,
+        trust_baseline_coordinates=True,
+    )
+
+    assert result is not None
+    assert source_lines.read_count == 0
+    assert sum(1 for line in result if line == b"new value\n") == line_count
+    assert source_lines.read_count == line_count
+
+
+def test_baseline_insertion_planning_does_not_flatten_references(
+    monkeypatch,
+) -> None:
+    """Insertion planning should query ownership without copying its reference map."""
+    line_count = 1000
+    source_lines = _CountingLines(line_count)
+    reference = _boundary_reference(
+        after_line=None,
+        before_line=None,
+    )
+    ownership = BatchOwnership.from_presence_lines(
+        [f"1-{line_count}"],
+        baseline_references={
+            source_line: reference for source_line in range(1, line_count + 1)
+        },
+    )
+
+    def fail_flatten():
+        raise AssertionError("baseline references must not be flattened")
+
+    monkeypatch.setattr(
+        ownership,
+        "presence_baseline_references",
+        fail_flatten,
+    )
+
+    result = baseline_edits.try_apply_baseline_replacement_units(
+        source_lines,
+        [],
+        ownership,
+        LineRanges.from_ranges(((1, line_count),)),
+        [],
+        trust_baseline_coordinates=True,
+    )
+
+    assert result is not None
+    assert source_lines.read_count == 0
+    assert sum(1 for line in result if line == b"new value\n") == line_count
+    assert source_lines.read_count == line_count
+
+
+def test_baseline_insertion_planning_sorts_target_positions() -> None:
+    """Source-order claims should still apply in target-coordinate order."""
+    source_lines = [b"after first\n", b"before first\n"]
+    working_lines = [b"first\n", b"second\n"]
+    ownership = BatchOwnership.from_presence_lines(
+        ["1-2"],
+        baseline_references={
+            1: _boundary_reference(
+                after_line=1,
+                after_content=b"first",
+                before_line=2,
+                before_content=b"second",
+            ),
+            2: _boundary_reference(
+                after_line=None,
+                before_line=1,
+                before_content=b"first",
+            ),
+        },
+    )
+
+    result = baseline_edits.try_apply_baseline_replacement_units(
+        source_lines,
+        working_lines,
+        ownership,
+        LineRanges.from_ranges(((1, 2),)),
+        [],
+        trust_baseline_coordinates=True,
+    )
+
+    assert result is not None
+    assert list(result) == [
+        b"before first\n",
+        b"first\n",
+        b"after first\n",
+        b"second\n",
+    ]
+
+
+def test_baseline_edit_stream_closes_planning_workspace(
+    monkeypatch,
+) -> None:
+    """Stopping edit output early should release mapped planning storage."""
+    workspaces = []
+    original_workspace = baseline_edits.MatcherWorkspace
+
+    class TrackingWorkspace(original_workspace):
+        def __init__(self, *args, **kwargs) -> None:
+            super().__init__(*args, **kwargs)
+            self.was_closed = False
+            workspaces.append(self)
+
+        def close(self) -> None:
+            self.was_closed = True
+            super().close()
+
+    source_lines = [b"first\n", b"second\n"]
+    working_lines = [b"old\n"]
+    replacement_reference = _boundary_reference(
+        after_line=None,
+        before_line=None,
+    )
+    deletion_claims = [
+        AbsenceClaim(
+            anchor_line=None,
+            content_lines=[b"old\n"],
+            baseline_reference=replacement_reference,
+        ),
+    ]
+    ownership = BatchOwnership.from_presence_lines(
+        ["1-2"],
+        deletion_claims,
+        replacement_units=[
+            ReplacementUnit(
+                presence_lines=["1-2"],
+                deletion_indices=[0],
+            ),
+        ],
+    )
+    monkeypatch.setattr(
+        baseline_edits,
+        "MatcherWorkspace",
+        TrackingWorkspace,
+    )
+
+    result = baseline_edits.try_apply_baseline_replacement_units(
+        source_lines,
+        working_lines,
+        ownership,
+        LineRanges.from_ranges(((1, 2),)),
+        deletion_claims,
+        trust_baseline_coordinates=True,
+    )
+
+    assert result is not None
+    assert len(workspaces) == 1
+    assert workspaces[0].was_closed is False
+    assert next(result) == b"first\n"
+    result.close()
+    assert workspaces[0].was_closed is True

--- a/tests/batch/merge/test_baseline_replacement_choices.py
+++ b/tests/batch/merge/test_baseline_replacement_choices.py
@@ -53,3 +53,33 @@ def test_replacement_origin_choices_normalize_content_without_a_list(
 
     assert key is not None
     assert len(choices) == 1
+
+
+def test_replacement_origin_key_keeps_claimed_ranges_compact() -> None:
+    """Replacement review keys should describe ranges without listing lines."""
+    claim = AbsenceClaim(
+        anchor_line=None,
+        content_lines=[b"old value\n"],
+    )
+    unit = ReplacementUnit(
+        presence_lines=["1-1000"],
+        deletion_indices=[0],
+        origin=ReplacementUnitOrigin(
+            old_start=1,
+            old_end=1,
+            new_start=1,
+            new_end=1000,
+        ),
+    )
+
+    key, choices = baseline_replacement_choices.replacement_origin_choices_for_unit(
+        claim,
+        0,
+        unit,
+        LineRanges.from_ranges(((1, 1000),)),
+        [b"old value\n"],
+    )
+
+    assert key is not None
+    assert "claimed:1-1000:" in key
+    assert len(choices) == 1

--- a/tests/batch/ownership/test_ownership_model.py
+++ b/tests/batch/ownership/test_ownership_model.py
@@ -1,0 +1,27 @@
+"""Focused tests for batch ownership model queries."""
+
+from git_stage_batch.batch.ownership.claims import PresenceClaim
+from git_stage_batch.batch.ownership.model import BatchOwnership
+from git_stage_batch.batch.ownership.references import BaselineReference
+
+
+def test_presence_baseline_reference_uses_last_claim() -> None:
+    """Single-reference lookup should preserve flattened-map precedence."""
+    first_reference = BaselineReference(after_line=1)
+    last_reference = BaselineReference(after_line=2)
+    ownership = BatchOwnership(
+        presence_claims=[
+            PresenceClaim(
+                source_lines=["1"],
+                baseline_references={1: first_reference},
+            ),
+            PresenceClaim(
+                source_lines=["1"],
+                baseline_references={1: last_reference},
+            ),
+        ],
+        deletions=[],
+    )
+
+    assert ownership.presence_baseline_reference(1) is last_reference
+    assert ownership.presence_baseline_reference(2) is None


### PR DESCRIPTION
Baseline-coordinate fallback reconstructs batches against recorded positions when structural source anchors are unavailable. Replacement review then exposes ambiguous placements through candidate keys.

The fallback retains edits, payload groups, and flattened ownership references in Python collections, while review expands claimed selections into per-line lists and keys. Large selections can therefore grow the interpreter heap in proportion to their line count.

The branch adds point reference lookup in the ownership model, keeps planning records in MatcherWorkspace-backed vectors owned by the merge layer, streams payloads while that workspace is alive, and carries existing LineRanges through candidate discovery and review keys. The implementation preserves later-claim precedence without introducing a duplicate range type or new iter_-prefixed functions.

Validation includes a 2,000-case differential comparison with the former planner, focused ordering, lifetime, architecture, and compact-key tests, and the complete suite with 3,715 passes and 12 skips. Subprocess heap measurements plateau near 50 KiB from 10,000 through 100,000 lines for both replacement and insertion cases.