### PR TITLE
batch: Index live baseline boundary uniqueness

### DIFF
--- a/src/git_stage_batch/batch/merge/baseline_edits.py
+++ b/src/git_stage_batch/batch/merge/baseline_edits.py
@@ -39,6 +39,7 @@ from .candidates import MergeResolution as _MergeResolution
 if TYPE_CHECKING:
     from ..ownership.model import BatchOwnership
     from ..ownership.absence_claims import AbsenceClaim
+    from ..ownership.references import BaselineReference
 
 
 _BaselineRemovalEdit = tuple[int, int]
@@ -307,7 +308,7 @@ def _live_removal_boundary_is_unique(
 
 
 def _insertion_boundary_identity_matches_at(
-    reference: Any,
+    reference: BaselineReference | None,
     target_lines: Sequence[bytes],
     position: int,
 ) -> bool:
@@ -345,7 +346,7 @@ def _insertion_boundary_identity_matches_at(
 
 
 def _live_insertion_boundary_is_unique(
-    reference: Any,
+    reference: BaselineReference | None,
     target_lines: Sequence[bytes],
     expected_position: int,
     occurrence_index: LinePayloadOccurrenceIndex,
@@ -366,47 +367,30 @@ def _live_insertion_boundary_is_unique(
     ):
         return True
 
-    rarest_content: bytes | None = None
-    rarest_boundary_delta = 0
-    rarest_count = len(target_lines) + 1
-
-    def consider(content: bytes | None, boundary_delta: int) -> None:
-        nonlocal rarest_content
-        nonlocal rarest_boundary_delta
-        nonlocal rarest_count
-        if content is None:
-            return
-        count = occurrence_index.occurrence_count(content)
-        if count < rarest_count:
-            rarest_content = content
-            rarest_boundary_delta = boundary_delta
-            rarest_count = count
-
-    if after_line is not None:
-        consider(getattr(reference, "after_content", None), 1)
-    if getattr(reference, "has_before_line", False) and before_line is not None:
-        consider(getattr(reference, "before_content", None), 0)
-
-    if rarest_content is None or rarest_count == 0:
-        return False
-    if rarest_count == 1:
-        return True
-
-    for line_index in occurrence_index.matching_line_indexes(rarest_content):
-        position = line_index + rarest_boundary_delta
-        if (
-            position < 0
-            or position > len(target_lines)
-            or position == expected_position
-        ):
-            continue
-        if _insertion_boundary_identity_matches_at(
+    return _boundary_identity_occurs_once(
+        occurrence_index,
+        expected_position,
+        len(target_lines),
+        after_content=(
+            getattr(reference, "after_content", None)
+            if after_line is not None
+            else None
+        ),
+        span_contents=(),
+        before_content=(
+            getattr(reference, "before_content", None)
+            if (
+                getattr(reference, "has_before_line", False) and before_line is not None
+            )
+            else None
+        ),
+        before_delta=0,
+        identity_matches_at=lambda position: _insertion_boundary_identity_matches_at(
             reference,
             target_lines,
             position,
-        ):
-            return False
-    return True
+        ),
+    )
 
 
 def _replacement_origin_boundary_identity_matches_at(

--- a/src/git_stage_batch/batch/merge/baseline_edits.py
+++ b/src/git_stage_batch/batch/merge/baseline_edits.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator, Sequence
+from collections.abc import Callable, Iterator, Sequence
 from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -210,6 +210,57 @@ def _removal_boundary_identity_matches_at(
     )
 
 
+def _boundary_identity_occurs_once(
+    occurrence_index: LinePayloadOccurrenceIndex,
+    expected_position: int,
+    last_position: int,
+    *,
+    after_content: bytes | None,
+    span_contents: Sequence[bytes],
+    before_content: bytes | None,
+    before_delta: int,
+    identity_matches_at: Callable[[int], bool],
+) -> bool:
+    """Return whether indexed boundary content identifies one full identity."""
+    rarest_content: bytes | None = None
+    rarest_boundary_delta = 0
+    rarest_count: int | None = None
+
+    def consider(content: bytes | None, boundary_delta: int) -> None:
+        nonlocal rarest_content
+        nonlocal rarest_boundary_delta
+        nonlocal rarest_count
+        if content is None:
+            return
+        count = occurrence_index.occurrence_count(content)
+        if rarest_count is None or count < rarest_count:
+            rarest_content = content
+            rarest_boundary_delta = boundary_delta
+            rarest_count = count
+
+    consider(after_content, 1)
+    for offset, content in enumerate(span_contents):
+        consider(content, -offset)
+    consider(before_content, before_delta)
+
+    if rarest_content is None or rarest_count is None or rarest_count == 0:
+        return False
+    if rarest_count == 1:
+        return True
+
+    for line_index in occurrence_index.matching_line_indexes(rarest_content):
+        position = line_index + rarest_boundary_delta
+        if (
+            position < 0
+            or position > last_position
+            or position == expected_position
+        ):
+            continue
+        if identity_matches_at(position):
+            return False
+    return True
+
+
 def _live_removal_boundary_is_unique(
     claim: AbsenceClaim,
     target_lines: Sequence[bytes],
@@ -232,51 +283,27 @@ def _live_removal_boundary_is_unique(
 
     reference = claim.baseline_reference
     assert reference is not None
-    rarest_content: bytes | None = None
-    rarest_boundary_delta = 0
-    rarest_count = len(target_lines) + 1
-
-    def consider(content: bytes | None, boundary_delta: int) -> None:
-        nonlocal rarest_content
-        nonlocal rarest_boundary_delta
-        nonlocal rarest_count
-        if content is None:
-            return
-        count = occurrence_index.occurrence_count(content)
-        if count < rarest_count:
-            rarest_content = content
-            rarest_boundary_delta = boundary_delta
-            rarest_count = count
-
-    if reference.after_line is not None:
-        consider(reference.after_content, 1)
-    for offset in range(len(forbidden_sequence)):
-        consider(forbidden_sequence[offset], -offset)
-    if reference.has_before_line and reference.before_line is not None:
-        consider(reference.before_content, -len(forbidden_sequence))
-
-    if rarest_content is None or rarest_count == 0:
-        return False
-    if rarest_count == 1:
-        return True
-
-    last_position = len(target_lines) - len(forbidden_sequence)
-    for line_index in occurrence_index.matching_line_indexes(rarest_content):
-        position = line_index + rarest_boundary_delta
-        if (
-            position < 0
-            or position > last_position
-            or position == expected_position
-        ):
-            continue
-        if _removal_boundary_identity_matches_at(
+    return _boundary_identity_occurs_once(
+        occurrence_index,
+        expected_position,
+        len(target_lines) - len(forbidden_sequence),
+        after_content=(
+            reference.after_content if reference.after_line is not None else None
+        ),
+        span_contents=forbidden_sequence,
+        before_content=(
+            reference.before_content
+            if reference.has_before_line and reference.before_line is not None
+            else None
+        ),
+        before_delta=-len(forbidden_sequence),
+        identity_matches_at=lambda position: _removal_boundary_identity_matches_at(
             claim,
             target_lines,
             position,
             forbidden_sequence,
-        ):
-            return False
-    return True
+        ),
+    )
 
 
 def _insertion_boundary_identity_matches_at(

--- a/src/git_stage_batch/batch/merge/baseline_edits.py
+++ b/src/git_stage_batch/batch/merge/baseline_edits.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
     from ..ownership.model import BatchOwnership
     from ..ownership.absence_claims import AbsenceClaim
     from ..ownership.references import BaselineReference
+    from ..ownership.replacement_units import ReplacementUnitOrigin
 
 
 _BaselineRemovalEdit = tuple[int, int]
@@ -394,7 +395,7 @@ def _live_insertion_boundary_is_unique(
 
 
 def _replacement_origin_boundary_identity_matches_at(
-    origin: Any,
+    origin: ReplacementUnitOrigin | None,
     target_lines: Sequence[bytes],
     position: int,
 ) -> bool:
@@ -442,13 +443,13 @@ def _replacement_origin_boundary_identity_matches_at(
 
 
 def _live_replacement_origin_boundary_is_unique(
-    origin: Any,
+    origin: ReplacementUnitOrigin | None,
     target_lines: Sequence[bytes],
     expected_position: int,
     occurrence_index: LinePayloadOccurrenceIndex,
 ) -> bool:
     """Require a replacement parent to identify one live target span."""
-    if not _replacement_origin_boundary_identity_matches_at(
+    if origin is None or not _replacement_origin_boundary_identity_matches_at(
         origin,
         target_lines,
         expected_position,
@@ -464,48 +465,26 @@ def _live_replacement_origin_boundary_is_unique(
     ):
         return True
 
-    rarest_content: bytes | None = None
-    rarest_boundary_delta = 0
-    rarest_count = len(target_lines) + 1
-
-    def consider(content: bytes | None, boundary_delta: int) -> None:
-        nonlocal rarest_content
-        nonlocal rarest_boundary_delta
-        nonlocal rarest_count
-        if content is None:
-            return
-        count = occurrence_index.occurrence_count(content)
-        if count < rarest_count:
-            rarest_content = content
-            rarest_boundary_delta = boundary_delta
-            rarest_count = count
-
-    if after_line is not None:
-        consider(reference.after_content, 1)
-    if reference.has_before_line and before_line is not None:
-        consider(reference.before_content, -origin.old_line_count)
-
-    if rarest_content is None or rarest_count == 0:
-        return False
-    if rarest_count == 1:
-        return True
-
-    last_position = len(target_lines) - origin.old_line_count
-    for line_index in occurrence_index.matching_line_indexes(rarest_content):
-        position = line_index + rarest_boundary_delta
-        if (
-            position < 0
-            or position > last_position
-            or position == expected_position
-        ):
-            continue
-        if _replacement_origin_boundary_identity_matches_at(
-            origin,
-            target_lines,
-            position,
-        ):
-            return False
-    return True
+    return _boundary_identity_occurs_once(
+        occurrence_index,
+        expected_position,
+        len(target_lines) - origin.old_line_count,
+        after_content=(reference.after_content if after_line is not None else None),
+        span_contents=(),
+        before_content=(
+            reference.before_content
+            if reference.has_before_line and before_line is not None
+            else None
+        ),
+        before_delta=-origin.old_line_count,
+        identity_matches_at=lambda position: (
+            _replacement_origin_boundary_identity_matches_at(
+                origin,
+                target_lines,
+                position,
+            )
+        ),
+    )
 
 
 def _live_coordinate_edits_are_safe(

--- a/tests/batch/merge/test_baseline_anchor_matching.py
+++ b/tests/batch/merge/test_baseline_anchor_matching.py
@@ -8,6 +8,10 @@ import git_stage_batch.batch.merge.baseline_edits as baseline_edits
 from git_stage_batch.batch.merge.baseline_edits import (
     acquire_deletion_anchor_pairs_for_target,
 )
+from git_stage_batch.batch.line_matching.match_workspace import MatcherWorkspace
+from git_stage_batch.batch.line_matching.occurrence_index import (
+    LinePayloadOccurrenceIndex,
+)
 from git_stage_batch.batch.line_matching.match import match_lines
 from git_stage_batch.batch.merge.merge import (
     merge_batch_from_line_sequences_as_buffer,
@@ -15,6 +19,7 @@ from git_stage_batch.batch.merge.merge import (
 from git_stage_batch.batch.ownership.absence_claims import AbsenceClaim
 from git_stage_batch.batch.ownership.model import BatchOwnership
 from git_stage_batch.batch.ownership.references import BaselineReference
+from git_stage_batch.batch.ownership.replacement_units import ReplacementUnitOrigin
 
 
 def _deletion_anchor_pairs(*args, **kwargs):
@@ -283,6 +288,45 @@ def test_live_target_accepts_one_unique_composite_deletion_boundary():
     )
 
     assert _deletion_anchor_pairs(source, target, [claim]) == ((1, 1),)
+
+
+def test_live_target_rejects_repeated_replacement_parent_boundary():
+    """A repeated parent identity must not validate a replacement coordinate."""
+    target = [
+        b"head\n",
+        b"old one\n",
+        b"old two\n",
+        b"tail\n",
+        b"gap\n",
+        b"head\n",
+        b"old one\n",
+        b"old two\n",
+        b"tail\n",
+    ]
+    origin = ReplacementUnitOrigin(
+        old_start=2,
+        old_end=3,
+        new_start=2,
+        new_end=3,
+        baseline_reference=BaselineReference(
+            after_line=1,
+            after_content=b"head\n",
+            before_line=4,
+            before_content=b"tail\n",
+            has_before_line=True,
+        ),
+    )
+
+    with MatcherWorkspace() as workspace:
+        occurrence_index = LinePayloadOccurrenceIndex(workspace, target)
+        is_unique = baseline_edits._live_replacement_origin_boundary_is_unique(
+            origin,
+            target,
+            1,
+            occurrence_index,
+        )
+
+    assert is_unique is False
 
 
 def test_live_target_checks_indexed_boundary_candidates(monkeypatch):


### PR DESCRIPTION
Live baseline edits validate saved removals, insertions, and replacement
parents by locating a unique normalized boundary in the current target.

The three paths maintain separate matchers and target scans, which duplicate
work, can drift apart, and can accept an ambiguous repeated replacement
parent.

This pull request builds one normalized target-occurrence index and routes
removal, insertion, and replacement-parent uniqueness through the same
lookup.

Validation covers repeated replacement parents alongside existing baseline
composition and anchor matching; all 19 focused tests and the complete Ruff
check pass.
