### PR TITLE
core: Scan line range specifications incrementally

### DIFF
--- a/src/git_stage_batch/core/line_selection.py
+++ b/src/git_stage_batch/core/line_selection.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from bisect import bisect_right
 from dataclasses import dataclass, field
+from itertools import chain
 from typing import Iterable, Iterator, Protocol
 
 
@@ -153,10 +154,21 @@ class LineRanges:
 
     @classmethod
     def from_specs(cls, line_ranges: Iterable[str | int]) -> LineRanges:
-        specs = [str(line) for line in line_ranges]
-        if not specs:
+        remaining_specs = iter(line_ranges)
+        try:
+            first_spec = next(remaining_specs)
+        except StopIteration:
             return cls.empty()
-        return parse_line_selection_ranges(",".join(specs))
+
+        if isinstance(first_spec, str) and not first_spec.strip():
+            try:
+                second_spec = next(remaining_specs)
+            except StopIteration as error:
+                raise ValueError("Selection string cannot be empty") from error
+            specs = chain((first_spec, second_spec), remaining_specs)
+        else:
+            specs = chain((first_spec,), remaining_specs)
+        return cls.from_ranges(scan_line_range_specs(specs))
 
     def __contains__(self, line_number: object) -> bool:
         if type(line_number) is not int:

--- a/src/git_stage_batch/core/line_selection.py
+++ b/src/git_stage_batch/core/line_selection.py
@@ -88,6 +88,43 @@ def coerce_line_ranges(selection: LineSelection | Iterable[int]) -> LineRanges:
     return LineRanges.from_lines(selection)
 
 
+def scan_line_range_specs(
+    line_ranges: Iterable[str | int],
+) -> Iterator[tuple[int, int]]:
+    """Yield raw inclusive ranges from line specifications without collecting."""
+    for line_range in line_ranges:
+        specification = str(line_range)
+        item_start = 0
+        while item_start <= len(specification):
+            separator = specification.find(",", item_start)
+            item_stop = len(specification) if separator < 0 else separator
+            item = specification[item_start:item_stop].strip()
+            if item:
+                range_separator = item.find("-", 1)
+                if range_separator < 0:
+                    try:
+                        start = end = int(item)
+                    except ValueError as error:
+                        raise ValueError(f"Invalid line ID: {item}") from error
+                    if start <= 0:
+                        raise ValueError(f"Line ID must be positive: {item}")
+                else:
+                    try:
+                        start = int(item[:range_separator].strip())
+                        end = int(item[range_separator + 1 :].strip())
+                    except ValueError as error:
+                        raise ValueError(f"Invalid range: {item}") from error
+                    if start <= 0 or end <= 0:
+                        raise ValueError(f"Line IDs must be positive: {item}")
+                if start > end:
+                    raise ValueError(f"Range start must be <= end: {item}")
+                yield start, end
+
+            if separator < 0:
+                break
+            item_start = separator + 1
+
+
 @dataclass(frozen=True, slots=True)
 class LineRanges:
     """Immutable 1-based line selection stored as normalized inclusive ranges."""

--- a/src/git_stage_batch/core/line_selection.py
+++ b/src/git_stage_batch/core/line_selection.py
@@ -382,46 +382,7 @@ def parse_line_selection_ranges(selection: str) -> LineRanges:
     """Parse a line selection string into normalized line ranges."""
     if not selection or not selection.strip():
         raise ValueError("Selection string cannot be empty")
-
-    ranges: list[tuple[int, int]] = []
-    parts = selection.split(",")
-
-    for part in parts:
-        part = part.strip()
-        if not part:
-            continue
-
-        range_separator_pos = part.find("-", 1)
-        if range_separator_pos != -1:
-            start_str = part[:range_separator_pos]
-            end_str = part[range_separator_pos + 1:]
-
-            try:
-                start = int(start_str.strip())
-                end = int(end_str.strip())
-            except ValueError as e:
-                raise ValueError(f"Invalid range: {part}") from e
-
-            if start <= 0 or end <= 0:
-                raise ValueError(f"Line IDs must be positive: {part}")
-
-            if start > end:
-                raise ValueError(f"Range start must be <= end: {part}")
-
-            ranges.append((start, end))
-            continue
-
-        try:
-            line_id = int(part)
-        except ValueError as e:
-            raise ValueError(f"Invalid line ID: {part}") from e
-
-        if line_id <= 0:
-            raise ValueError(f"Line ID must be positive: {part}")
-
-        ranges.append((line_id, line_id))
-
-    return LineRanges.from_ranges(ranges)
+    return LineRanges.from_ranges(scan_line_range_specs((selection,)))
 
 
 def format_line_ids(line_ids: list[str | int]) -> str:

--- a/tests/core/test_line_selection.py
+++ b/tests/core/test_line_selection.py
@@ -8,6 +8,7 @@ from git_stage_batch.core.line_selection import (
     format_line_ids,
     parse_line_selection,
     parse_line_selection_ranges,
+    scan_line_range_specs,
 )
 
 
@@ -197,6 +198,28 @@ class TestLineRanges:
         assert len(selection) == 1000001
         assert 999999 in selection
         assert 1000001 not in selection
+
+    def test_scans_range_specs_without_reading_ahead(self):
+        def specifications():
+            yield "1-3,5"
+            raise AssertionError("range scanning read the next specification")
+
+        ranges = scan_line_range_specs(specifications())
+
+        assert next(ranges) == (1, 3)
+        assert next(ranges) == (5, 5)
+        with pytest.raises(
+            AssertionError,
+            match="range scanning read the next specification",
+        ):
+            next(ranges)
+
+    def test_scans_raw_ranges_without_normalizing_them(self):
+        assert tuple(scan_line_range_specs(["5-7,1", 3])) == (
+            (5, 7),
+            (1, 1),
+            (3, 3),
+        )
 
     def test_count_intersection_and_difference_use_ranges(self):
         selection = parse_line_selection_ranges("1-10,20-30")

--- a/tests/core/test_line_selection.py
+++ b/tests/core/test_line_selection.py
@@ -221,6 +221,51 @@ class TestLineRanges:
             (3, 3),
         )
 
+    def test_from_specs_preserves_single_blank_rejection(self):
+        with pytest.raises(ValueError, match="Selection string cannot be empty"):
+            LineRanges.from_specs([" "])
+
+        assert LineRanges.from_specs([]) == LineRanges.empty()
+        assert LineRanges.from_specs(["", ""]) == LineRanges.empty()
+
+    @pytest.mark.parametrize(
+        ("specification", "message"),
+        [
+            ("0", "Line ID must be positive: 0"),
+            ("0-2", "Line IDs must be positive: 0-2"),
+            ("2-1", "Range start must be <= end: 2-1"),
+        ],
+    )
+    def test_from_specs_preserves_validation_messages(
+        self,
+        specification,
+        message,
+    ):
+        with pytest.raises(ValueError, match=message):
+            LineRanges.from_specs([specification])
+
+    def test_from_specs_streams_into_range_scanner(self, monkeypatch):
+        scanned_specs = []
+
+        def scan_specs(specs):
+            assert not isinstance(specs, (list, tuple))
+            for specification in specs:
+                scanned_specs.append(specification)
+                line = int(specification)
+                yield line, line
+
+        monkeypatch.setattr(
+            "git_stage_batch.core.line_selection.scan_line_range_specs",
+            scan_specs,
+        )
+
+        selection = LineRanges.from_specs(
+            specification for specification in ("3", "1")
+        )
+
+        assert scanned_specs == ["3", "1"]
+        assert selection.ranges() == ((1, 1), (3, 3))
+
     def test_count_intersection_and_difference_use_ranges(self):
         selection = parse_line_selection_ranges("1-10,20-30")
 

--- a/tests/core/test_line_selection.py
+++ b/tests/core/test_line_selection.py
@@ -191,7 +191,22 @@ class TestLineRanges:
 
         assert selection.ranges() == ((1, 3),)
 
-    def test_parse_selection_ranges_does_not_expand_ranges(self):
+    def test_parse_selection_ranges_does_not_expand_ranges(
+        self,
+        monkeypatch,
+    ):
+        original_from_ranges = LineRanges.from_ranges
+
+        def require_range_stream(cls, ranges):
+            assert not isinstance(ranges, (list, tuple))
+            return original_from_ranges(ranges)
+
+        monkeypatch.setattr(
+            LineRanges,
+            "from_ranges",
+            classmethod(require_range_stream),
+        )
+
         selection = parse_line_selection_ranges("1-1000000,1000002")
 
         assert selection.ranges() == ((1, 1000000), (1000002, 1000002))


### PR DESCRIPTION
LineRanges constructs normalized selections from individual or
comma-delimited line-range specifications.

Both construction paths collect intermediate specifications or parsed
records, so Python heap use grows with fragmented saved ownership before
normalization can compact it.

This pull request introduces a pull-based scanner, routes LineRanges and
the legacy single-string parser through it, and preserves the established
input contracts and validation messages.

Validation covers incremental delivery, constructor delegation, empty and
invalid inputs, and a guarded fragmented specification; all 44 focused
tests and the complete Ruff check pass.
