### PR TITLE
batch: Keep replacement planning ranges mapped

### DIFF
--- a/src/git_stage_batch/batch/merge/baseline_edits.py
+++ b/src/git_stage_batch/batch/merge/baseline_edits.py
@@ -26,6 +26,7 @@ from .baseline_replacement_choices import (
 from .baseline_replacement_ranges import (
     collect_replacement_source_ranges as _collect_replacement_source_ranges,
     replacement_source_range_capacity as _replacement_source_range_capacity,
+    selected_replacement_source_ranges as _selected_replacement_source_ranges,
 )
 from ..line_matching.sequence_equality import (
     line_sequences_equal as _line_sequences_match,
@@ -1381,16 +1382,34 @@ def has_missing_origin_replacement_claims(
     presence_line_set: LineSelection,
     source_lines: Sequence[bytes],
     mapping: LineMapping,
+    *,
+    spool_dir: str | Path | None = None,
 ) -> bool:
     """Return whether parent-tracked replacement lines would need placement."""
     selected_presence = coerce_line_ranges(presence_line_set)
-    for unit in getattr(ownership, "replacement_units", []):
-        if getattr(unit, "origin", None) is None:
-            continue
-        claimed_selection = LineRanges.from_specs(unit.presence_lines)
-        for claimed_line in selected_presence.intersection(claimed_selection):
-            if claimed_line < 1 or claimed_line > len(source_lines):
+    with MatcherWorkspace(spool_dir=spool_dir) as workspace:
+        for unit in getattr(ownership, "replacement_units", []):
+            if getattr(unit, "origin", None) is None:
                 continue
-            if mapping.get_target_line_from_source_line(claimed_line) is None:
+            claimed_ranges = _collect_replacement_source_ranges(
+                workspace,
+                unit.presence_lines,
+            )
+            if claimed_ranges is None:
                 return True
+            try:
+                for claimed_start, claimed_end in _selected_replacement_source_ranges(
+                    claimed_ranges,
+                    selected_presence,
+                ):
+                    for claimed_line in range(claimed_start, claimed_end + 1):
+                        if claimed_line > len(source_lines):
+                            continue
+                        if (
+                            mapping.get_target_line_from_source_line(claimed_line)
+                            is None
+                        ):
+                            return True
+            finally:
+                workspace.close_resource(claimed_ranges)
     return False

--- a/src/git_stage_batch/batch/merge/baseline_edits.py
+++ b/src/git_stage_batch/batch/merge/baseline_edits.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable, Iterator, Sequence
 from contextlib import contextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from ...core.line_selection import LineRanges, LineSelection, coerce_line_ranges
 from ...core.mapped_storage import MappedRecordVector, sort_mapped_records
@@ -22,6 +22,10 @@ from .baseline_reference_positions import (
 )
 from .baseline_replacement_choices import (
     replacement_origin_choices_for_unit as _replacement_origin_choices_for_unit,
+)
+from .baseline_replacement_ranges import (
+    collect_replacement_source_ranges as _collect_replacement_source_ranges,
+    replacement_source_range_capacity as _replacement_source_range_capacity,
 )
 from ..line_matching.sequence_equality import (
     line_sequences_equal as _line_sequences_match,
@@ -40,7 +44,10 @@ if TYPE_CHECKING:
     from ..ownership.model import BatchOwnership
     from ..ownership.absence_claims import AbsenceClaim
     from ..ownership.references import BaselineReference
-    from ..ownership.replacement_units import ReplacementUnitOrigin
+    from ..ownership.replacement_units import (
+        ReplacementUnit,
+        ReplacementUnitOrigin,
+    )
 
 
 _BaselineRemovalEdit = tuple[int, int]
@@ -619,7 +626,7 @@ def _live_coordinate_edits_are_safe(
 
 
 def _replacement_origin_absence_bounds(
-    origin: Any,
+    origin: ReplacementUnitOrigin | None,
     working_lines: Sequence[bytes],
 ) -> tuple[int, int] | None:
     """Return the target bounds of an original replacement parent, if provable."""
@@ -641,7 +648,7 @@ def _replacement_origin_absence_bounds(
 
 def _replacement_edit_with_origin_guard(
     claim: AbsenceClaim,
-    origin: Any,
+    origin: ReplacementUnitOrigin | None,
     working_lines: Sequence[bytes],
 ) -> _BaselineRemovalEdit | None:
     """Return a removal edit only if it fits inside the original parent unit."""
@@ -665,8 +672,8 @@ def _replacement_edit_with_origin_guard(
 
 def _replacement_edit_from_parent_offset(
     claim: AbsenceClaim,
-    origin: Any,
-    claimed_lines: LineRanges,
+    origin: ReplacementUnitOrigin | None,
+    claimed_ranges: Sequence[tuple[int, ...]],
     working_lines: Sequence[bytes],
 ) -> _BaselineRemovalEdit | None:
     """Place an equal-size split replacement by offset inside its parent."""
@@ -689,7 +696,6 @@ def _replacement_edit_from_parent_offset(
     if old_line_count != new_line_count:
         return None
 
-    claimed_ranges = claimed_lines.ranges()
     if len(claimed_ranges) != 1:
         return None
 
@@ -738,8 +744,8 @@ def _replacement_edit_from_parent_offset(
 def _replacement_edit_from_origin_resolution(
     claim: AbsenceClaim,
     unit_index: int,
-    unit: Any,
-    claimed_lines: LineRanges,
+    unit: ReplacementUnit,
+    claimed_ranges: Sequence[tuple[int, ...]],
     working_lines: Sequence[bytes],
     resolution: _MergeResolution | None,
     *,
@@ -753,7 +759,7 @@ def _replacement_edit_from_origin_resolution(
         claim,
         unit_index,
         unit,
-        claimed_lines,
+        ((source_start, source_end) for source_start, source_end in claimed_ranges),
         working_lines,
         max_results=max_results,
     )
@@ -775,8 +781,8 @@ def _replacement_edit_from_origin_resolution(
 def _replacement_baseline_edit(
     claim: AbsenceClaim,
     unit_index: int,
-    unit: Any,
-    claimed_lines: LineRanges,
+    unit: ReplacementUnit,
+    claimed_ranges: Sequence[tuple[int, ...]],
     working_lines: Sequence[bytes],
     resolution: _MergeResolution | None,
     *,
@@ -794,7 +800,7 @@ def _replacement_baseline_edit(
     offset_edit = _replacement_edit_from_parent_offset(
         claim,
         origin,
-        claimed_lines,
+        claimed_ranges,
         working_lines,
     )
     if offset_edit is not None:
@@ -804,7 +810,7 @@ def _replacement_baseline_edit(
         claim,
         unit_index,
         unit,
-        claimed_lines,
+        claimed_ranges,
         working_lines,
         resolution,
         max_results=max_resolution_choices,
@@ -812,15 +818,6 @@ def _replacement_baseline_edit(
     if reviewed_edit is None:
         return None
     return reviewed_edit, True
-
-
-def _selection_fits_source(
-    source_selection: LineRanges,
-    source_line_count: int,
-) -> bool:
-    """Return whether every selected source line has available content."""
-    ranges = source_selection.ranges()
-    return not ranges or ranges[-1][1] <= source_line_count
 
 
 def _positioned_source_lines_match(
@@ -843,73 +840,122 @@ def _positioned_source_lines_match(
     return True
 
 
-def _replacement_source_range_capacity(replacement_units: Sequence[Any]) -> int:
-    """Return mapped-record capacity for replacement source ranges."""
-    return sum(
-        line_spec.count(",") + 1
-        for unit in replacement_units
-        for line_spec in unit.presence_lines
-    )
-
-
 def _plan_replacement_unit_edits(
+    workspace: MatcherWorkspace,
     plan: _BaselineEditPlan,
     source_line_count: int,
     working_lines: Sequence[bytes],
-    replacement_units: Sequence[Any],
+    replacement_units: Sequence[ReplacementUnit],
     deletion_claims: Sequence[AbsenceClaim],
     deletion_edit_bounds: MappedRecordVector,
+    replacement_source_ranges: MappedRecordVector,
     resolution: _MergeResolution | None,
     *,
     max_resolution_choices: int,
-) -> LineRanges | None:
-    """Plan coupled replacement units and return their claimed source lines."""
-    unit_claimed_lines = LineRanges.empty()
-
+) -> bool:
+    """Plan coupled replacement units and record their claimed source ranges."""
     for unit_index, unit in enumerate(replacement_units):
-        claimed_selection = LineRanges.from_specs(unit.presence_lines)
+        claimed_ranges = _collect_replacement_source_ranges(
+            workspace,
+            unit.presence_lines,
+        )
         if (
-            not claimed_selection
-            or not _selection_fits_source(
-                claimed_selection,
-                source_line_count,
-            )
+            claimed_ranges is None
+            or not claimed_ranges
+            or claimed_ranges[-1][1] > source_line_count
             or len(unit.deletion_indices) != 1
         ):
-            return None
+            return False
 
         deletion_index = unit.deletion_indices[0]
-        if deletion_index < 0 or deletion_index >= len(deletion_claims):
-            return None
-
+        if (
+            deletion_index < 0
+            or deletion_index >= len(deletion_claims)
+        ):
+            return False
         replacement_edit = _replacement_baseline_edit(
             deletion_claims[deletion_index],
             unit_index,
             unit,
-            claimed_selection,
+            claimed_ranges,
             working_lines,
             resolution,
             max_resolution_choices=max_resolution_choices,
         )
         if replacement_edit is None:
-            return None
+            return False
 
         removal_edit, coordinate_was_reviewed = replacement_edit
         start, end = removal_edit
         plan.add_source_ranges(
             start,
             end,
-            claimed_selection.ranges(),
+            ((source_start, source_end) for source_start, source_end in claimed_ranges),
         )
+        for source_start, source_end in claimed_ranges:
+            replacement_source_ranges.append((source_start, source_end))
         deletion_edit_bounds[deletion_index] = (
             1,
             start,
             end,
             coordinate_was_reviewed,
         )
-        unit_claimed_lines = unit_claimed_lines.union(claimed_selection)
+        workspace.close_resource(claimed_ranges)
 
-    return unit_claimed_lines
+    return True
+
+
+def _replacement_source_ranges_fit_presence(
+    presence_lines: LineRanges,
+    replacement_source_ranges: MappedRecordVector,
+) -> bool:
+    """Sort replacement ranges and require disjoint presence coverage."""
+    sort_mapped_records(replacement_source_ranges)
+    presence_ranges = presence_lines.ranges()
+    presence_range_index = 0
+    previous_replacement_end = 0
+
+    for source_start, source_end in replacement_source_ranges:
+        if source_start < 1 or source_end < source_start:
+            return False
+        if source_start <= previous_replacement_end:
+            return False
+        while (
+            presence_range_index < len(presence_ranges)
+            and presence_ranges[presence_range_index][1] < source_start
+        ):
+            presence_range_index += 1
+        if presence_range_index >= len(presence_ranges):
+            return False
+        presence_start, presence_end = presence_ranges[presence_range_index]
+        if presence_start > source_start or source_end > presence_end:
+            return False
+        previous_replacement_end = source_end
+
+    return True
+
+
+def _presence_lines_without_replacements(
+    presence_lines: LineRanges,
+    replacement_source_ranges: Sequence[tuple[int, ...]],
+) -> Iterator[int]:
+    """Yield claimed source lines not carried by replacement units."""
+    replacement_range_index = 0
+    for presence_start, presence_end in presence_lines.ranges():
+        remaining_start = presence_start
+        while (
+            replacement_range_index < len(replacement_source_ranges)
+            and replacement_source_ranges[replacement_range_index][0] <= presence_end
+        ):
+            replacement_start, replacement_end = replacement_source_ranges[
+                replacement_range_index
+            ]
+            for claimed_line in range(remaining_start, replacement_start):
+                yield claimed_line
+            remaining_start = replacement_end + 1
+            replacement_range_index += 1
+        for claimed_line in range(remaining_start, presence_end + 1):
+            yield claimed_line
 
 
 def _plan_independent_removal_edits(
@@ -944,21 +990,25 @@ def _collect_presence_position_records(
     source_line_count: int,
     working_lines: Sequence[bytes],
     ownership: BatchOwnership,
-    remaining_claimed_lines: LineRanges,
+    presence_lines: LineRanges,
+    replacement_source_ranges: Sequence[tuple[int, ...]],
 ) -> tuple[MappedRecordVector, MappedRecordVector, bool] | None:
     """Partition presence lines into positioned and mapping-backed records."""
     positioned_lines = workspace.record_vector(
-        len(remaining_claimed_lines),
+        len(presence_lines),
         "QQ",
     )
     unmapped_lines = workspace.record_vector(
-        len(remaining_claimed_lines),
+        len(presence_lines),
         "Q",
     )
     positioned_lines_are_ordered = True
     previous_position: int | None = None
 
-    for claimed_line in remaining_claimed_lines:
+    for claimed_line in _presence_lines_without_replacements(
+        presence_lines,
+        replacement_source_ranges,
+    ):
         if claimed_line > source_line_count:
             return None
         position = _find_baseline_insertion_position(
@@ -1057,7 +1107,8 @@ def _plan_presence_insertions(
     source_lines: Sequence[bytes],
     working_lines: Sequence[bytes],
     ownership: BatchOwnership,
-    remaining_claimed_lines: LineRanges,
+    presence_lines: LineRanges,
+    replacement_source_ranges: Sequence[tuple[int, ...]],
     *,
     trust_baseline_coordinates: bool,
     spool_dir: str | Path | None,
@@ -1068,7 +1119,8 @@ def _plan_presence_insertions(
         len(source_lines),
         working_lines,
         ownership,
-        remaining_claimed_lines,
+        presence_lines,
+        replacement_source_ranges,
     )
     if position_records is None:
         return None
@@ -1245,6 +1297,10 @@ def _build_baseline_edit_plan(
     """Build and validate one storage-backed exact-coordinate edit plan."""
     replacement_units = getattr(ownership, "replacement_units", [])
     presence_lines = coerce_line_ranges(presence_line_set)
+    replacement_source_range_capacity = sum(
+        _replacement_source_range_capacity(unit.presence_lines)
+        for unit in replacement_units
+    )
     plan = _BaselineEditPlan(
         workspace,
         edit_capacity=(
@@ -1253,21 +1309,30 @@ def _build_baseline_edit_plan(
             + len(presence_lines)
         ),
         source_range_capacity=(
-            _replacement_source_range_capacity(replacement_units)
-            + len(presence_lines)
+            replacement_source_range_capacity + len(presence_lines)
         ),
     )
-    unit_claimed_lines = _plan_replacement_unit_edits(
+    replacement_source_ranges = workspace.record_vector(
+        replacement_source_range_capacity,
+        "QQ",
+    )
+    if not _plan_replacement_unit_edits(
+        workspace,
         plan,
         len(source_lines),
         working_lines,
         replacement_units,
         deletion_claims,
         deletion_edit_bounds,
+        replacement_source_ranges,
         resolution,
         max_resolution_choices=max_resolution_choices,
-    )
-    if unit_claimed_lines is None:
+    ):
+        return None
+    if not _replacement_source_ranges_fit_presence(
+        presence_lines,
+        replacement_source_ranges,
+    ):
         return None
     if not _plan_independent_removal_edits(
         plan,
@@ -1277,22 +1342,21 @@ def _build_baseline_edit_plan(
     ):
         return None
 
-    remaining_claimed_lines = presence_lines.difference(unit_claimed_lines)
     positioned_insertion_lines = _plan_presence_insertions(
         plan,
         workspace,
         source_lines,
         working_lines,
         ownership,
-        remaining_claimed_lines,
+        presence_lines,
+        replacement_source_ranges,
         trust_baseline_coordinates=trust_baseline_coordinates,
         spool_dir=spool_dir,
     )
     if positioned_insertion_lines is None:
         return None
 
-    if unit_claimed_lines.union(remaining_claimed_lines) != presence_lines:
-        return None
+    workspace.close_resource(replacement_source_ranges)
     if (
         not trust_baseline_coordinates
         and not _live_coordinate_edits_are_safe(

--- a/src/git_stage_batch/batch/merge/baseline_replacement_choices.py
+++ b/src/git_stage_batch/batch/merge/baseline_replacement_choices.py
@@ -2,17 +2,21 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 import hashlib
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
-from ...core.line_selection import LineSelection, coerce_line_ranges
 from ...core.text_lines import normalize_line_sequence_endings
 from ..line_matching.sequence_equality import line_slice_equals as _line_slice_matches
 
 if TYPE_CHECKING:
+    from ...core.line_selection import LineSelection
     from ..ownership.absence_claims import AbsenceClaim
+    from ..ownership.replacement_units import (
+        ReplacementUnit,
+        ReplacementUnitOrigin,
+    )
 
 
 @dataclass(frozen=True)
@@ -28,13 +32,16 @@ class ReplacementOriginChoice:
 def replacement_origin_choices_for_unit(
     claim: AbsenceClaim,
     unit_index: int,
-    unit: Any,
-    claimed_lines: LineSelection,
+    unit: ReplacementUnit,
+    claimed_ranges: LineSelection | Iterable[tuple[int, int]],
     working_lines: Sequence[bytes],
     *,
     max_results: int | None = None,
 ) -> tuple[str | None, tuple[ReplacementOriginChoice, ...]]:
-    """Return explicit target placements for an origin-tracked replacement."""
+    """Return explicit target placements for an origin-tracked replacement.
+
+    Range-record inputs must be normalized and ordered like ``LineSelection.ranges()``.
+    """
     origin = getattr(unit, "origin", None)
     if origin is None or not claim.content_lines:
         return None, ()
@@ -77,26 +84,57 @@ def replacement_origin_choices_for_unit(
         unit_index,
         deletion_indices[0],
         origin,
-        claimed_lines,
+        _replacement_range_records(claimed_ranges),
         forbidden_sequence,
     )
     return key, tuple(choices)
 
 
+def _replacement_range_records(
+    claimed_ranges: LineSelection | Iterable[tuple[int, int]],
+) -> Iterable[tuple[int, int]]:
+    """Return range records without materializing a streamed input."""
+    ranges = getattr(claimed_ranges, "ranges", None)
+    if ranges is not None:
+        return ranges()
+    return claimed_ranges
+
+
 def _replacement_origin_ambiguity_key(
     unit_index: int,
     deletion_index: int,
-    origin: Any,
-    claimed_lines: LineSelection,
+    origin: ReplacementUnitOrigin,
+    claimed_ranges: Iterable[tuple[int, int]],
     forbidden_sequence: Sequence[bytes],
 ) -> str:
-    claimed = coerce_line_ranges(claimed_lines).to_line_spec()
+    claimed = _range_sequence_identity(claimed_ranges)
     digest = _sequence_digest(forbidden_sequence)
     return (
         f"replacement-origin:{unit_index}:delete:{deletion_index}:"
         f"claimed:{claimed}:old:{origin.old_start}-{origin.old_end}:"
         f"new:{origin.new_start}-{origin.new_end}:{digest}"
     )
+
+
+def _range_sequence_identity(
+    ranges: Iterable[tuple[int, int]],
+) -> str:
+    hasher = hashlib.sha256()
+    first_line: int | None = None
+    last_line: int | None = None
+    range_count = 0
+    for start, end in ranges:
+        if first_line is None:
+            first_line = start
+        last_line = end
+        range_count += 1
+        hasher.update(str(start).encode("ascii"))
+        hasher.update(b":")
+        hasher.update(str(end).encode("ascii"))
+        hasher.update(b";")
+
+    span = "empty" if first_line is None else f"{first_line}-{last_line}"
+    return f"{span}:{range_count}:{hasher.hexdigest()[:12]}"
 
 
 def _sequence_digest(lines: Sequence[bytes]) -> str:

--- a/src/git_stage_batch/batch/merge/baseline_replacement_ranges.py
+++ b/src/git_stage_batch/batch/merge/baseline_replacement_ranges.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
 
-from ...core.line_selection import scan_line_range_specs
+from ...core.line_selection import LineRanges, scan_line_range_specs
 from ...core.mapped_storage import MappedRecordVector, sort_mapped_records
 from ..line_matching.match_workspace import MatcherWorkspace
 
@@ -39,6 +39,30 @@ def replacement_source_range_capacity(
 ) -> int:
     """Return an upper bound for records parsed from range specifications."""
     return sum(range_spec.count(",") + 1 for range_spec in range_specs)
+
+
+def selected_replacement_source_ranges(
+    source_ranges: Sequence[tuple[int, ...]],
+    selected_lines: LineRanges,
+) -> Iterator[tuple[int, int]]:
+    """Yield intersections between normalized source ranges and a selection."""
+    selected_ranges = selected_lines.ranges()
+    source_range_index = 0
+    selected_range_index = 0
+    while source_range_index < len(source_ranges) and selected_range_index < len(
+        selected_ranges
+    ):
+        source_start, source_end = source_ranges[source_range_index]
+        selected_start, selected_end = selected_ranges[selected_range_index]
+        start = max(source_start, selected_start)
+        end = min(source_end, selected_end)
+        if start <= end:
+            yield start, end
+
+        if source_end < selected_end:
+            source_range_index += 1
+        else:
+            selected_range_index += 1
 
 
 def _compact_source_ranges(source_ranges: MappedRecordVector) -> None:

--- a/src/git_stage_batch/batch/merge/baseline_replacement_ranges.py
+++ b/src/git_stage_batch/batch/merge/baseline_replacement_ranges.py
@@ -1,0 +1,11 @@
+"""Storage-backed source ranges for baseline replacement units."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+def replacement_source_range_capacity(
+    range_specs: Sequence[str],
+) -> int:
+    """Return an upper bound for records parsed from range specifications."""
+    return sum(range_spec.count(",") + 1 for range_spec in range_specs)

--- a/src/git_stage_batch/batch/merge/baseline_replacement_ranges.py
+++ b/src/git_stage_batch/batch/merge/baseline_replacement_ranges.py
@@ -11,7 +11,7 @@ from ..line_matching.match_workspace import MatcherWorkspace
 
 def collect_replacement_source_ranges(
     workspace: MatcherWorkspace,
-    range_specs: Sequence[str],
+    range_specs: Sequence[str | int],
 ) -> MappedRecordVector | None:
     """Parse and normalize one replacement selection in mapped storage."""
     source_ranges = workspace.record_vector(
@@ -35,10 +35,13 @@ def collect_replacement_source_ranges(
 
 
 def replacement_source_range_capacity(
-    range_specs: Sequence[str],
+    range_specs: Sequence[str | int],
 ) -> int:
     """Return an upper bound for records parsed from range specifications."""
-    return sum(range_spec.count(",") + 1 for range_spec in range_specs)
+    return sum(
+        range_spec.count(",") + 1 if isinstance(range_spec, str) else 1
+        for range_spec in range_specs
+    )
 
 
 def selected_replacement_source_ranges(

--- a/src/git_stage_batch/batch/merge/baseline_replacement_ranges.py
+++ b/src/git_stage_batch/batch/merge/baseline_replacement_ranges.py
@@ -4,8 +4,54 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
+from ...core.line_selection import scan_line_range_specs
+from ...core.mapped_storage import MappedRecordVector, sort_mapped_records
+from ..line_matching.match_workspace import MatcherWorkspace
+
+
+def collect_replacement_source_ranges(
+    workspace: MatcherWorkspace,
+    range_specs: Sequence[str],
+) -> MappedRecordVector | None:
+    """Parse and normalize one replacement selection in mapped storage."""
+    source_ranges = workspace.record_vector(
+        replacement_source_range_capacity(range_specs),
+        "QQ",
+    )
+    try:
+        for source_start, source_end in scan_line_range_specs(range_specs):
+            if source_end > 0xFFFF_FFFF_FFFF_FFFF:
+                workspace.close_resource(source_ranges)
+                return None
+            source_ranges.append((source_start, source_end))
+    except (TypeError, ValueError, OverflowError):
+        workspace.close_resource(source_ranges)
+        return None
+
+    if len(source_ranges) > 1:
+        sort_mapped_records(source_ranges)
+        _compact_source_ranges(source_ranges)
+    return source_ranges
+
+
 def replacement_source_range_capacity(
     range_specs: Sequence[str],
 ) -> int:
     """Return an upper bound for records parsed from range specifications."""
     return sum(range_spec.count(",") + 1 for range_spec in range_specs)
+
+
+def _compact_source_ranges(source_ranges: MappedRecordVector) -> None:
+    retained_count = 0
+    for source_start, source_end in source_ranges:
+        if retained_count:
+            previous_start, previous_end = source_ranges[retained_count - 1]
+            if source_start <= previous_end + 1:
+                source_ranges[retained_count - 1] = (
+                    previous_start,
+                    max(previous_end, source_end),
+                )
+                continue
+        source_ranges[retained_count] = (source_start, source_end)
+        retained_count += 1
+    source_ranges.truncate(retained_count)

--- a/src/git_stage_batch/batch/merge/merge.py
+++ b/src/git_stage_batch/batch/merge/merge.py
@@ -191,6 +191,7 @@ def _merge_batch_acquired_line_chunks(
             presence_line_set,
             source_lines,
             mapping,
+            spool_dir=spool_dir,
         ):
             raise _MergeError(
                 _(

--- a/src/git_stage_batch/batch/ownership/replacement_units.py
+++ b/src/git_stage_batch/batch/ownership/replacement_units.py
@@ -73,7 +73,7 @@ class ReplacementUnit:
     canonical deletion constraint is stored only once in metadata.
     """
 
-    presence_lines: list[str]
+    presence_lines: list[str | int]
     deletion_indices: list[int]
     origin: ReplacementUnitOrigin | None = field(default=None, compare=False)
 

--- a/tests/batch/merge/test_baseline_edits.py
+++ b/tests/batch/merge/test_baseline_edits.py
@@ -315,6 +315,59 @@ def test_baseline_replacement_payload_stays_lazy(
     assert source_lines.read_count == line_count
 
 
+def test_fragmented_replacement_planning_avoids_heap_selections(
+    monkeypatch,
+) -> None:
+    """Fragmented replacement ranges should stay in mapped planning storage."""
+    selected_ranges = tuple((line, line) for line in range(1, 2000, 2))
+    range_spec = ",".join(str(start) for start, _end in selected_ranges)
+    selected_lines = LineRanges.from_ranges(selected_ranges)
+    source_lines = _CountingLines(1999)
+    working_lines = [b"old value\n"]
+    replacement_reference = _boundary_reference(
+        after_line=None,
+        before_line=None,
+    )
+    deletion_claims = [
+        AbsenceClaim(
+            anchor_line=None,
+            content_lines=[b"old value\n"],
+            baseline_reference=replacement_reference,
+        ),
+    ]
+    ownership = BatchOwnership.from_presence_lines(
+        [range_spec],
+        deletion_claims,
+        replacement_units=[
+            ReplacementUnit(
+                presence_lines=[range_spec],
+                deletion_indices=[0],
+            ),
+        ],
+    )
+
+    def fail_heap_selection(*_args, **_kwargs):
+        raise AssertionError("baseline planning rebuilt a heap selection")
+
+    monkeypatch.setattr(LineRanges, "from_specs", fail_heap_selection)
+    monkeypatch.setattr(LineRanges, "union", fail_heap_selection)
+    monkeypatch.setattr(LineRanges, "difference", fail_heap_selection)
+
+    result = baseline_edits.try_apply_baseline_replacement_units(
+        source_lines,
+        working_lines,
+        ownership,
+        selected_lines,
+        deletion_claims,
+        trust_baseline_coordinates=True,
+    )
+
+    assert result is not None
+    assert source_lines.read_count == 0
+    assert sum(1 for _line in result) == 1000
+    assert source_lines.read_count == 1000
+
+
 def test_baseline_insertion_planning_does_not_flatten_references(
     monkeypatch,
 ) -> None:

--- a/tests/batch/merge/test_baseline_edits.py
+++ b/tests/batch/merge/test_baseline_edits.py
@@ -255,6 +255,44 @@ def test_baseline_edit_planning_rejects_incomplete_replacement_unit() -> None:
     assert result is None
 
 
+def test_baseline_edit_planning_accepts_integer_source_range_metadata() -> None:
+    """Replacement range metadata should retain its documented integer form."""
+    source_lines = [b"new value\n"]
+    working_lines = [b"old value\n"]
+    deletion_claims = [
+        AbsenceClaim(
+            anchor_line=None,
+            content_lines=[b"old value\n"],
+            baseline_reference=_boundary_reference(
+                after_line=None,
+                before_line=None,
+            ),
+        ),
+    ]
+    ownership = BatchOwnership.from_presence_lines(
+        ["1"],
+        deletion_claims,
+        replacement_units=[
+            ReplacementUnit(
+                presence_lines=[1],
+                deletion_indices=[0],
+            ),
+        ],
+    )
+
+    result = baseline_edits.try_apply_baseline_replacement_units(
+        source_lines,
+        working_lines,
+        ownership,
+        LineRanges.from_ranges(((1, 1),)),
+        deletion_claims,
+        trust_baseline_coordinates=True,
+    )
+
+    assert result is not None
+    assert list(result) == source_lines
+
+
 def test_baseline_replacement_payload_stays_lazy(
     monkeypatch,
 ) -> None:

--- a/tests/batch/merge/test_baseline_replacement_choices.py
+++ b/tests/batch/merge/test_baseline_replacement_choices.py
@@ -1,5 +1,7 @@
 """Focused tests for replacement-origin placement choices."""
 
+import re
+
 from git_stage_batch.batch.merge import baseline_replacement_choices
 from git_stage_batch.batch.ownership.absence_claims import AbsenceClaim
 from git_stage_batch.batch.ownership.replacement_units import (
@@ -33,10 +35,15 @@ def test_replacement_origin_choices_normalize_content_without_a_list(
         _position,
         expected,
     ) -> bool:
-        assert not isinstance(expected, list)
-        assert expected[0] == b"old value\n"
+        assert expected is normalized_content
         return True
 
+    normalized_content = (b"old value\n",)
+    monkeypatch.setattr(
+        baseline_replacement_choices,
+        "normalize_line_sequence_endings",
+        lambda _lines: normalized_content,
+    )
     monkeypatch.setattr(
         baseline_replacement_choices,
         "_line_slice_matches",
@@ -81,5 +88,93 @@ def test_replacement_origin_key_keeps_claimed_ranges_compact() -> None:
     )
 
     assert key is not None
-    assert "claimed:1-1000:" in key
+    assert re.fullmatch(
+        r"replacement-origin:0:delete:0:"
+        r"claimed:1-1000:1:[0-9a-f]{12}:"
+        r"old:1-1:new:1-1000:[0-9a-f]{12}",
+        key,
+    )
+    assert len(choices) == 1
+
+
+def test_replacement_origin_key_hashes_fragmented_ranges() -> None:
+    """Replacement review keys should stay fixed-size for fragmented claims."""
+    claim = AbsenceClaim(
+        anchor_line=None,
+        content_lines=[b"old value\n"],
+    )
+    unit = ReplacementUnit(
+        presence_lines=["1"],
+        deletion_indices=[0],
+        origin=ReplacementUnitOrigin(
+            old_start=1,
+            old_end=1,
+            new_start=1,
+            new_end=1999,
+        ),
+    )
+
+    def fragmented_ranges():
+        return ((line, line) for line in range(1, 2000, 2))
+
+    key, choices = baseline_replacement_choices.replacement_origin_choices_for_unit(
+        claim,
+        0,
+        unit,
+        fragmented_ranges(),
+        [b"old value\n"],
+        max_results=2,
+    )
+    canonical_key, _canonical_choices = (
+        baseline_replacement_choices.replacement_origin_choices_for_unit(
+            claim,
+            0,
+            unit,
+            LineRanges.from_ranges(fragmented_ranges()),
+            [b"old value\n"],
+            max_results=2,
+        )
+    )
+
+    assert key is not None
+    assert canonical_key == key
+    assert re.fullmatch(
+        r"replacement-origin:0:delete:0:"
+        r"claimed:1-1999:1000:[0-9a-f]{12}:"
+        r"old:1-1:new:1-1999:[0-9a-f]{12}",
+        key,
+    )
+    assert len(key) < 150
+    assert len(choices) == 1
+
+
+def test_replacement_origin_key_accepts_unbounded_line_ids() -> None:
+    """Replacement review keys should preserve the line-selection domain."""
+    line = 2**64
+    claim = AbsenceClaim(
+        anchor_line=None,
+        content_lines=[b"old value\n"],
+    )
+    unit = ReplacementUnit(
+        presence_lines=[str(line)],
+        deletion_indices=[0],
+        origin=ReplacementUnitOrigin(
+            old_start=1,
+            old_end=1,
+            new_start=line,
+            new_end=line,
+        ),
+    )
+
+    key, choices = baseline_replacement_choices.replacement_origin_choices_for_unit(
+        claim,
+        0,
+        unit,
+        LineRanges.from_ranges(((line, line),)),
+        [b"old value\n"],
+        max_results=2,
+    )
+
+    assert key is not None
+    assert f"claimed:{line}-{line}:1:" in key
     assert len(choices) == 1

--- a/tests/batch/merge/test_baseline_replacement_ranges.py
+++ b/tests/batch/merge/test_baseline_replacement_ranges.py
@@ -4,7 +4,9 @@ from git_stage_batch.batch.line_matching.match_workspace import MatcherWorkspace
 from git_stage_batch.batch.merge.baseline_replacement_ranges import (
     collect_replacement_source_ranges,
     replacement_source_range_capacity,
+    selected_replacement_source_ranges,
 )
+from git_stage_batch.core.line_selection import LineRanges
 
 
 def test_replacement_source_range_capacity_counts_string_records() -> None:
@@ -22,3 +24,39 @@ def test_replacement_source_ranges_normalize_in_mapped_storage() -> None:
 
         assert source_ranges is not None
         assert tuple(source_ranges) == ((1, 4), (6, 9))
+
+
+def test_selected_replacement_source_ranges_stream_intersections() -> None:
+    """Selected source intersections should stay range-backed."""
+    class FragmentedSourceRanges:
+        def __init__(self, count: int) -> None:
+            self.count = count
+            self.maximum_read_index = 0
+
+        def __len__(self) -> int:
+            return self.count
+
+        def __getitem__(self, index: int) -> tuple[int, int]:
+            if index < 0 or index >= self.count:
+                raise IndexError(index)
+            if index > self.maximum_read_index:
+                raise AssertionError("intersections were collected before yielding")
+            source_line = 2 * index + 1
+            return source_line, source_line
+
+    source_ranges = FragmentedSourceRanges(1000)
+    selected_lines = LineRanges.from_ranges(((1, 1999),))
+    intersections = selected_replacement_source_ranges(
+        source_ranges,
+        selected_lines,
+    )
+
+    assert next(intersections) == (1, 1)
+    source_ranges.maximum_read_index = len(source_ranges) - 1
+    last_intersection = None
+    remaining_count = 0
+    for last_intersection in intersections:
+        remaining_count += 1
+
+    assert remaining_count == 999
+    assert last_intersection == (1999, 1999)

--- a/tests/batch/merge/test_baseline_replacement_ranges.py
+++ b/tests/batch/merge/test_baseline_replacement_ranges.py
@@ -1,6 +1,8 @@
 """Tests for storage-backed baseline replacement source ranges."""
 
+from git_stage_batch.batch.line_matching.match_workspace import MatcherWorkspace
 from git_stage_batch.batch.merge.baseline_replacement_ranges import (
+    collect_replacement_source_ranges,
     replacement_source_range_capacity,
 )
 
@@ -8,3 +10,15 @@ from git_stage_batch.batch.merge.baseline_replacement_ranges import (
 def test_replacement_source_range_capacity_counts_string_records() -> None:
     """Mapped range allocation should cover every string record."""
     assert replacement_source_range_capacity(["7-9,1-3", "6", "2-4"]) == 4
+
+
+def test_replacement_source_ranges_normalize_in_mapped_storage() -> None:
+    """Unordered and overlapping metadata should retain LineRanges semantics."""
+    with MatcherWorkspace() as workspace:
+        source_ranges = collect_replacement_source_ranges(
+            workspace,
+            ["7-9,1-3", "6", "2-4"],
+        )
+
+        assert source_ranges is not None
+        assert tuple(source_ranges) == ((1, 4), (6, 9))

--- a/tests/batch/merge/test_baseline_replacement_ranges.py
+++ b/tests/batch/merge/test_baseline_replacement_ranges.py
@@ -1,0 +1,10 @@
+"""Tests for storage-backed baseline replacement source ranges."""
+
+from git_stage_batch.batch.merge.baseline_replacement_ranges import (
+    replacement_source_range_capacity,
+)
+
+
+def test_replacement_source_range_capacity_counts_string_records() -> None:
+    """Mapped range allocation should cover every string record."""
+    assert replacement_source_range_capacity(["7-9,1-3", "6", "2-4"]) == 4


### PR DESCRIPTION
Baseline replacement planning carries saved source ranges through
placement, review-key construction, and required-content validation.

Highly fragmented selections can expand review identities and intermediate
Python collections before file-backed planning storage can process them,
and missing-origin preflight can recreate the same heap growth.

This pull request adds fixed-size framed range identities and a mapped
provider that counts, normalizes, intersects, and streams replacement
records, then adopts it in planning and missing-origin discovery.

Validation covers compact identities, bounded allocation, mapped
normalization, pull-based intersections, integer metadata, and fragmented
planning sentinels; all 178 focused tests and the complete Ruff check pass.
