### PR TITLE
batch: Preserve required content across removals

### DIFF
--- a/src/git_stage_batch/batch/merge/baseline_edit_plan.py
+++ b/src/git_stage_batch/batch/merge/baseline_edit_plan.py
@@ -78,23 +78,47 @@ class BaselineEditPlan:
         if pending_start is not None and pending_end is not None:
             self._add_payload_range(position, pending_start, pending_end)
 
-    def removes_target_line(self, target_index: int) -> bool:
-        """Return whether a planned non-insertion edit covers a target line."""
-        return any(
-            start <= target_index < end
-            for start, end in self._target_spans
-        )
+    def removes_any_target_lines(
+        self,
+        sorted_target_lines: Sequence[tuple[int, ...]],
+    ) -> bool:
+        """Return whether sorted target indexes intersect a target span."""
+        target_span_index = 0
+        for (target_line,) in sorted_target_lines:
+            while (
+                target_span_index < len(self._target_spans)
+                and self._target_spans[target_span_index][1] <= target_line
+            ):
+                target_span_index += 1
+            if target_span_index >= len(self._target_spans):
+                return False
+            start, end = self._target_spans[target_span_index]
+            if start <= target_line < end:
+                return True
+        return False
 
-    def sort_and_validate(self) -> bool:
-        """Sort plan records and reject overlapping target or source spans."""
+    def sorted_target_spans(
+        self,
+    ) -> Sequence[tuple[int, ...]] | None:
+        """Return sorted target spans, or None when they overlap."""
+        if not self.sort_target_spans_and_validate():
+            return None
+        return self._target_spans
+
+    def sort_target_spans_and_validate(self) -> bool:
+        """Sort target spans and reject overlaps or empty reversals."""
         if not self._target_spans_are_ordered:
             sort_mapped_records(self._target_spans)
             self._target_spans_are_ordered = True
+        return self._target_spans_are_valid()
+
+    def sort_and_validate(self) -> bool:
+        """Sort plan records and reject overlapping target or source spans."""
         if not self._payload_ranges_are_ordered:
             sort_mapped_records(self._payload_ranges)
             self._payload_ranges_are_ordered = True
         return (
-            self._target_spans_are_valid()
+            self.sorted_target_spans() is not None
             and self._payload_ranges_are_valid()
             and self._payload_positions_avoid_target_interiors()
         )

--- a/src/git_stage_batch/batch/merge/baseline_edits.py
+++ b/src/git_stage_batch/batch/merge/baseline_edits.py
@@ -1077,6 +1077,7 @@ def _add_positioned_presence_insertions(
     source_lines: Sequence[bytes],
     working_lines: Sequence[bytes],
     positioned_lines: MappedRecordVector,
+    target_spans: Sequence[tuple[int, ...]],
     *,
     positioned_lines_are_ordered: bool,
     trust_baseline_coordinates: bool,
@@ -1087,6 +1088,7 @@ def _add_positioned_presence_insertions(
 
     group_start = 0
     retained_line_count = 0
+    target_span_index = 0
     while group_start < len(positioned_lines):
         position = positioned_lines[group_start][0]
         group_stop = group_start + 1
@@ -1095,6 +1097,12 @@ def _add_positioned_presence_insertions(
             and positioned_lines[group_stop][0] == position
         ):
             group_stop += 1
+
+        while (
+            target_span_index < len(target_spans)
+            and target_spans[target_span_index][1] <= position
+        ):
+            target_span_index += 1
 
         group_matches = (
             not trust_baseline_coordinates
@@ -1108,7 +1116,27 @@ def _add_positioned_presence_insertions(
             )
         )
 
-        if not group_matches:
+        retain_group = not group_matches
+        if group_matches:
+            group_end = position + group_stop - group_start
+            removed_line_count = 0
+            scan_index = target_span_index
+            while (
+                scan_index < len(target_spans)
+                and target_spans[scan_index][0] < group_end
+            ):
+                span_start, span_end = target_spans[scan_index]
+                removed_line_count += max(
+                    0,
+                    min(group_end, span_end) - max(position, span_start),
+                )
+                if span_end >= group_end:
+                    break
+                scan_index += 1
+
+            retain_group = removed_line_count == group_end - position
+
+        if retain_group:
             plan.add_positioned_source_lines(
                 position,
                 positioned_lines,
@@ -1159,11 +1187,15 @@ def _plan_presence_insertions(
         return None
 
     workspace.close_resource(unmapped_lines)
+    target_spans = plan.sorted_target_spans()
+    if target_spans is None:
+        return None
     _add_positioned_presence_insertions(
         plan,
         source_lines,
         working_lines,
         positioned_lines,
+        target_spans,
         positioned_lines_are_ordered=positioned_lines_are_ordered,
         trust_baseline_coordinates=trust_baseline_coordinates,
     )

--- a/src/git_stage_batch/batch/merge/baseline_edits.py
+++ b/src/git_stage_batch/batch/merge/baseline_edits.py
@@ -1081,7 +1081,7 @@ def _add_positioned_presence_insertions(
     *,
     positioned_lines_are_ordered: bool,
     trust_baseline_coordinates: bool,
-) -> None:
+) -> bool:
     """Append required insertion groups and retain only their source records."""
     if not positioned_lines_are_ordered:
         sort_mapped_records(positioned_lines)
@@ -1134,6 +1134,8 @@ def _add_positioned_presence_insertions(
                     break
                 scan_index += 1
 
+            if 0 < removed_line_count < group_end - position:
+                return False
             retain_group = removed_line_count == group_end - position
 
         if retain_group:
@@ -1148,6 +1150,7 @@ def _add_positioned_presence_insertions(
                 retained_line_count += 1
         group_start = group_stop
     positioned_lines.truncate(retained_line_count)
+    return True
 
 
 def _plan_presence_insertions(
@@ -1190,7 +1193,7 @@ def _plan_presence_insertions(
     target_spans = plan.sorted_target_spans()
     if target_spans is None:
         return None
-    _add_positioned_presence_insertions(
+    if not _add_positioned_presence_insertions(
         plan,
         source_lines,
         working_lines,
@@ -1198,7 +1201,8 @@ def _plan_presence_insertions(
         target_spans,
         positioned_lines_are_ordered=positioned_lines_are_ordered,
         trust_baseline_coordinates=trust_baseline_coordinates,
-    )
+    ):
+        return None
 
     return positioned_lines
 

--- a/src/git_stage_batch/batch/merge/baseline_edits.py
+++ b/src/git_stage_batch/batch/merge/baseline_edits.py
@@ -1081,11 +1081,12 @@ def _add_positioned_presence_insertions(
     positioned_lines_are_ordered: bool,
     trust_baseline_coordinates: bool,
 ) -> None:
-    """Group positioned presence lines and append required insertions."""
+    """Append required insertion groups and retain only their source records."""
     if not positioned_lines_are_ordered:
         sort_mapped_records(positioned_lines)
 
     group_start = 0
+    retained_line_count = 0
     while group_start < len(positioned_lines):
         position = positioned_lines[group_start][0]
         group_stop = group_start + 1
@@ -1095,9 +1096,9 @@ def _add_positioned_presence_insertions(
         ):
             group_stop += 1
 
-        if (
-            trust_baseline_coordinates
-            or not _positioned_source_lines_match(
+        group_matches = (
+            not trust_baseline_coordinates
+            and _positioned_source_lines_match(
                 source_lines,
                 working_lines,
                 position,
@@ -1105,14 +1106,20 @@ def _add_positioned_presence_insertions(
                 group_start,
                 group_stop,
             )
-        ):
+        )
+
+        if not group_matches:
             plan.add_positioned_source_lines(
                 position,
                 positioned_lines,
                 group_start,
                 group_stop,
             )
+            for record_index in range(group_start, group_stop):
+                positioned_lines[retained_line_count] = positioned_lines[record_index]
+                retained_line_count += 1
         group_start = group_stop
+    positioned_lines.truncate(retained_line_count)
 
 
 def _plan_presence_insertions(

--- a/src/git_stage_batch/batch/merge/baseline_edits.py
+++ b/src/git_stage_batch/batch/merge/baseline_edits.py
@@ -1038,7 +1038,7 @@ def _mapping_preserves_unpositioned_presence(
     plan: _BaselineEditPlan,
     source_lines: Sequence[bytes],
     working_lines: Sequence[bytes],
-    unmapped_lines: Sequence[tuple[int, ...]],
+    unmapped_lines: MappedRecordVector,
     *,
     spool_dir: str | Path | None,
 ) -> bool:
@@ -1046,21 +1046,30 @@ def _mapping_preserves_unpositioned_presence(
     if not unmapped_lines:
         return True
 
+    if not plan.sort_target_spans_and_validate():
+        return False
+
+    target_lines_are_ordered = True
+    previous_target_line: int | None = None
     with _match_lines(
         source_lines,
         working_lines,
         spool_dir=spool_dir,
     ) as mapping:
-        for claimed_line, in unmapped_lines:
-            target_line = mapping.get_target_line_from_source_line(
-                claimed_line
-            )
-            if (
-                target_line is None
-                or plan.removes_target_line(target_line - 1)
-            ):
+        for record_index in range(len(unmapped_lines)):
+            claimed_line = unmapped_lines[record_index][0]
+            target_line = mapping.get_target_line_from_source_line(claimed_line)
+            if target_line is None:
                 return False
-    return True
+            target_index = target_line - 1
+            if previous_target_line is not None and target_index < previous_target_line:
+                target_lines_are_ordered = False
+            unmapped_lines[record_index] = (target_index,)
+            previous_target_line = target_index
+
+    if not target_lines_are_ordered:
+        sort_mapped_records(unmapped_lines)
+    return not plan.removes_any_target_lines(unmapped_lines)
 
 
 def _add_positioned_presence_insertions(

--- a/tests/batch/merge/test_baseline_edits.py
+++ b/tests/batch/merge/test_baseline_edits.py
@@ -405,6 +405,54 @@ def test_baseline_edit_planning_rejects_duplicate_deletion_binding() -> None:
     assert result is None
 
 
+def test_live_planning_ignores_already_present_insertion_groups() -> None:
+    """A skipped no-op group should not need an ambiguous insertion boundary."""
+    same = b"same\n"
+    source_lines = [same, same, same, b"new\n"]
+    working_lines = [same, same, same, b"old\n"]
+    noop_reference = _boundary_reference(
+        after_line=1,
+        after_content=b"same",
+        before_line=2,
+        before_content=b"same",
+    )
+    replacement_reference = _boundary_reference(
+        after_line=3,
+        after_content=b"same",
+        before_line=None,
+    )
+    claim = AbsenceClaim(
+        anchor_line=3,
+        content_lines=[b"old\n"],
+        baseline_reference=replacement_reference,
+    )
+    ownership = BatchOwnership.from_presence_lines(
+        ["2", "4"],
+        [claim],
+        baseline_references={
+            2: noop_reference,
+            4: replacement_reference,
+        },
+        replacement_units=[
+            ReplacementUnit(
+                presence_lines=["4"],
+                deletion_indices=[0],
+            ),
+        ],
+    )
+
+    result = baseline_edits.try_apply_baseline_replacement_units(
+        source_lines,
+        working_lines,
+        ownership,
+        LineRanges.from_ranges(((2, 2), (4, 4))),
+        [claim],
+    )
+
+    assert result is not None
+    assert list(result) == source_lines
+
+
 def test_baseline_replacement_payload_stays_lazy(
     monkeypatch,
 ) -> None:

--- a/tests/batch/merge/test_baseline_edits.py
+++ b/tests/batch/merge/test_baseline_edits.py
@@ -453,6 +453,48 @@ def test_live_planning_ignores_already_present_insertion_groups() -> None:
     assert list(result) == source_lines
 
 
+def test_live_planning_reinserts_payload_removed_by_replacement() -> None:
+    """Matching insertion bytes should survive a planned target removal."""
+    source_lines = [b"new\n", b"old\n"]
+    working_lines = [b"old\n"]
+    replacement_reference = _boundary_reference(
+        after_line=None,
+        before_line=None,
+    )
+    insertion_reference = _boundary_reference(
+        after_line=None,
+        before_line=1,
+        before_content=b"old",
+    )
+    claim = AbsenceClaim(
+        anchor_line=None,
+        content_lines=[b"old\n"],
+        baseline_reference=replacement_reference,
+    )
+    ownership = BatchOwnership.from_presence_lines(
+        ["1-2"],
+        [claim],
+        baseline_references={2: insertion_reference},
+        replacement_units=[
+            ReplacementUnit(
+                presence_lines=["1"],
+                deletion_indices=[0],
+            ),
+        ],
+    )
+
+    result = baseline_edits.try_apply_baseline_replacement_units(
+        source_lines,
+        working_lines,
+        ownership,
+        LineRanges.from_ranges(((1, 2),)),
+        [claim],
+    )
+
+    assert result is not None
+    assert list(result) == source_lines
+
+
 def test_baseline_replacement_payload_stays_lazy(
     monkeypatch,
 ) -> None:

--- a/tests/batch/merge/test_baseline_edits.py
+++ b/tests/batch/merge/test_baseline_edits.py
@@ -495,6 +495,51 @@ def test_live_planning_reinserts_payload_removed_by_replacement() -> None:
     assert list(result) == source_lines
 
 
+def test_live_planning_rejects_partially_removed_matching_payload() -> None:
+    """A partly removed no-op group should fail instead of duplicating content."""
+    source_lines = [b"new\n", b"old\n", b"tail\n"]
+    working_lines = [b"old\n", b"tail\n"]
+    replacement_reference = _boundary_reference(
+        after_line=None,
+        before_line=2,
+        before_content=b"tail",
+    )
+    insertion_reference = _boundary_reference(
+        after_line=None,
+        before_line=1,
+        before_content=b"old",
+    )
+    claim = AbsenceClaim(
+        anchor_line=None,
+        content_lines=[b"old\n"],
+        baseline_reference=replacement_reference,
+    )
+    ownership = BatchOwnership.from_presence_lines(
+        ["1-3"],
+        [claim],
+        baseline_references={
+            2: insertion_reference,
+            3: insertion_reference,
+        },
+        replacement_units=[
+            ReplacementUnit(
+                presence_lines=["1"],
+                deletion_indices=[0],
+            ),
+        ],
+    )
+
+    result = baseline_edits.try_apply_baseline_replacement_units(
+        source_lines,
+        working_lines,
+        ownership,
+        LineRanges.from_ranges(((1, 3),)),
+        [claim],
+    )
+
+    assert result is None
+
+
 def test_baseline_replacement_payload_stays_lazy(
     monkeypatch,
 ) -> None:


### PR DESCRIPTION
Baseline plans keep required source content in insertion groups and compare
those groups with the current target and planned removal spans.

A satisfied group can be refused by unnecessary boundary validation,
removed after being treated as a no-op, or partially overlapped and then
duplicated by whole-group reinsertion.

This pull request scans ordered removals linearly, elides untouched
satisfied groups, restores groups that removals fully consume, and refuses
every nonzero partial overlap.

Validation covers repeated boundaries, full replacement and reinsertion,
and partial-removal refusal; all 18 focused tests and the complete Ruff
check pass.
