### PR TITLE
batch: Validate unresolved replacement discovery

### DIFF
--- a/src/git_stage_batch/batch/merge/candidate_enumeration.py
+++ b/src/git_stage_batch/batch/merge/candidate_enumeration.py
@@ -94,6 +94,10 @@ def _find_unresolved_replacement_origin(
                 )
 
             deletion_index = unit.deletion_indices[0]
+            if type(deletion_index) is not int:
+                raise _MergeError(
+                    _("Batch was created from a different version of the file")
+                )
             if deletion_index < 0 or deletion_index >= len(deletion_claims):
                 raise _MergeError(
                     _("Batch was created from a different version of the file")

--- a/src/git_stage_batch/batch/merge/candidate_enumeration.py
+++ b/src/git_stage_batch/batch/merge/candidate_enumeration.py
@@ -61,8 +61,8 @@ def _find_unresolved_replacement_origin(
     *,
     max_candidates: int,
     spool_dir: str | Path | None,
-) -> list[_UnresolvedReplacementOrigin]:
-    """Return unresolved split replacements that need explicit placement."""
+) -> _UnresolvedReplacementOrigin | None:
+    """Return the only unresolved split replacement, if there is one."""
     owned_mapping = match_lines(
         source_lines,
         working_lines,
@@ -70,7 +70,7 @@ def _find_unresolved_replacement_origin(
     )
     try:
         selected_presence = coerce_line_ranges(presence_line_set)
-        unresolved: list[_UnresolvedReplacementOrigin] = []
+        unresolved = None
         for unit_index, unit in enumerate(
             getattr(ownership, "replacement_units", [])
         ):
@@ -109,15 +109,18 @@ def _find_unresolved_replacement_origin(
             if key is None:
                 continue
             claimed_ranges = claimed_lines.ranges()
-            unresolved.append(
-                _UnresolvedReplacementOrigin(
-                    source_start=claimed_ranges[0][0],
-                    source_end=claimed_ranges[-1][1],
-                    deletion_index=deletion_index,
-                    ambiguity_key=key,
-                    choices=choices,
-                )
+            candidate = _UnresolvedReplacementOrigin(
+                source_start=claimed_ranges[0][0],
+                source_end=claimed_ranges[-1][1],
+                deletion_index=deletion_index,
+                ambiguity_key=key,
+                choices=choices,
             )
+            if unresolved is not None:
+                raise _MergeError(
+                    _("Multiple split replacement placements need review")
+                )
+            unresolved = candidate
         return unresolved
     finally:
         owned_mapping.close()
@@ -144,17 +147,14 @@ def _replacement_origin_candidate_set(
         max_candidates=max_candidates,
         spool_dir=spool_dir,
     )
-    if not unresolved:
+    if unresolved is None:
         return _MergeCandidateSet(())
-    if len(unresolved) > 1:
-        raise _MergeError(_("Multiple split replacement placements need review"))
 
-    unresolved_origin = unresolved[0]
-    source_start = unresolved_origin.source_start
-    source_end = unresolved_origin.source_end
-    deletion_index = unresolved_origin.deletion_index
-    key = unresolved_origin.ambiguity_key
-    choices = unresolved_origin.choices
+    source_start = unresolved.source_start
+    source_end = unresolved.source_end
+    deletion_index = unresolved.deletion_index
+    key = unresolved.ambiguity_key
+    choices = unresolved.choices
     if len(choices) > max_candidates:
         raise _MergeError(_("Too many merge candidates to preview safely"))
 

--- a/src/git_stage_batch/batch/merge/candidate_enumeration.py
+++ b/src/git_stage_batch/batch/merge/candidate_enumeration.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -40,18 +41,28 @@ if TYPE_CHECKING:
 _MergeResolutionValidator = Callable[[_MergeResolution], bool]
 
 
-def _replacement_origin_candidate_set(
+@dataclass(frozen=True, slots=True)
+class _UnresolvedReplacementOrigin:
+    """One replacement origin that still needs an explicit placement."""
+
+    source_start: int
+    source_end: int
+    deletion_index: int
+    ambiguity_key: str
+    choices: tuple[_BaselineReplacementOriginChoice, ...]
+
+
+def _find_unresolved_replacement_origin(
     source_lines: Sequence[bytes],
     ownership: "BatchOwnership",
     working_lines: Sequence[bytes],
     presence_line_set: LineSelection,
     deletion_claims: list["AbsenceClaim"],
     *,
-    resolution_is_valid: _MergeResolutionValidator,
     max_candidates: int,
     spool_dir: str | Path | None,
-) -> _MergeCandidateSet:
-    """Enumerate reviewed placements for one unresolved split replacement."""
+) -> list[_UnresolvedReplacementOrigin]:
+    """Return unresolved split replacements that need explicit placement."""
     owned_mapping = match_lines(
         source_lines,
         working_lines,
@@ -59,15 +70,10 @@ def _replacement_origin_candidate_set(
     )
     try:
         selected_presence = coerce_line_ranges(presence_line_set)
-        unresolved: list[
-            tuple[
-                LineRanges,
-                int,
-                str,
-                tuple[_BaselineReplacementOriginChoice, ...],
-            ]
-        ] = []
-        for unit_index, unit in enumerate(getattr(ownership, "replacement_units", [])):
+        unresolved: list[_UnresolvedReplacementOrigin] = []
+        for unit_index, unit in enumerate(
+            getattr(ownership, "replacement_units", [])
+        ):
             if getattr(unit, "origin", None) is None:
                 continue
 
@@ -102,16 +108,53 @@ def _replacement_origin_candidate_set(
             )
             if key is None:
                 continue
-            unresolved.append((claimed_lines, deletion_index, key, choices))
+            claimed_ranges = claimed_lines.ranges()
+            unresolved.append(
+                _UnresolvedReplacementOrigin(
+                    source_start=claimed_ranges[0][0],
+                    source_end=claimed_ranges[-1][1],
+                    deletion_index=deletion_index,
+                    ambiguity_key=key,
+                    choices=choices,
+                )
+            )
+        return unresolved
     finally:
         owned_mapping.close()
 
+
+def _replacement_origin_candidate_set(
+    source_lines: Sequence[bytes],
+    ownership: "BatchOwnership",
+    working_lines: Sequence[bytes],
+    presence_line_set: LineSelection,
+    deletion_claims: list["AbsenceClaim"],
+    *,
+    resolution_is_valid: _MergeResolutionValidator,
+    max_candidates: int,
+    spool_dir: str | Path | None,
+) -> _MergeCandidateSet:
+    """Enumerate reviewed placements for one unresolved split replacement."""
+    unresolved = _find_unresolved_replacement_origin(
+        source_lines,
+        ownership,
+        working_lines,
+        presence_line_set,
+        deletion_claims,
+        max_candidates=max_candidates,
+        spool_dir=spool_dir,
+    )
     if not unresolved:
         return _MergeCandidateSet(())
     if len(unresolved) > 1:
         raise _MergeError(_("Multiple split replacement placements need review"))
 
-    claimed_lines, deletion_index, key, choices = unresolved[0]
+    unresolved_origin = unresolved[0]
+    source_start = unresolved_origin.source_start
+    source_end = unresolved_origin.source_end
+    deletion_index = unresolved_origin.deletion_index
+    key = unresolved_origin.ambiguity_key
+    choices = unresolved_origin.choices
     if len(choices) > max_candidates:
         raise _MergeError(_("Too many merge candidates to preview safely"))
 
@@ -127,9 +170,6 @@ def _replacement_origin_candidate_set(
     count = len(valid_choices)
     claim = deletion_claims[deletion_index]
     line_count = len(claim.content_lines)
-    claimed_ranges = claimed_lines.ranges()
-    source_start = claimed_ranges[0][0]
-    source_end = claimed_ranges[-1][1]
     ambiguity_target_line_range = (
         min(choice.position + 1 for choice in valid_choices),
         max(choice.position + line_count for choice in valid_choices),

--- a/tests/batch/merge/test_candidate_enumeration.py
+++ b/tests/batch/merge/test_candidate_enumeration.py
@@ -1,0 +1,57 @@
+"""Focused tests for merge candidate discovery."""
+
+import pytest
+
+from git_stage_batch.batch.merge import candidate_enumeration
+from git_stage_batch.batch.ownership.absence_claims import AbsenceClaim
+from git_stage_batch.batch.ownership.model import BatchOwnership
+from git_stage_batch.batch.ownership.replacement_units import (
+    ReplacementUnit,
+    ReplacementUnitOrigin,
+)
+from git_stage_batch.exceptions import MergeError
+
+
+class _UnreadableReplacementUnit:
+    @property
+    def origin(self):
+        raise AssertionError("candidate discovery read a third unresolved unit")
+
+
+def test_replacement_origin_discovery_stops_after_second_unresolved_unit() -> None:
+    """A second unresolved replacement should fail before reading later units."""
+    source_lines = [b"new one\n", b"new two\n"]
+    working_lines = [b"old one\n", b"old two\n"]
+    deletion_claims = [
+        AbsenceClaim(anchor_line=None, content_lines=[b"old one\n"]),
+        AbsenceClaim(anchor_line=None, content_lines=[b"old two\n"]),
+    ]
+    ownership = BatchOwnership.from_presence_lines(
+        ["1-2"],
+        deletion_claims,
+        replacement_units=[
+            ReplacementUnit(
+                presence_lines=["1"],
+                deletion_indices=[0],
+                origin=ReplacementUnitOrigin(1, 1, 1, 1),
+            ),
+            ReplacementUnit(
+                presence_lines=["2"],
+                deletion_indices=[1],
+                origin=ReplacementUnitOrigin(2, 2, 2, 2),
+            ),
+        ],
+    )
+    ownership.replacement_units.append(_UnreadableReplacementUnit())
+
+    with pytest.raises(
+        MergeError,
+        match="Multiple split replacement placements need review",
+    ):
+        candidate_enumeration.enumerate_merge_batch_candidates_for_lines(
+            source_lines,
+            ownership,
+            working_lines,
+            resolution_is_valid=lambda _resolution: True,
+            max_candidates=10,
+        )

--- a/tests/batch/merge/test_candidate_enumeration.py
+++ b/tests/batch/merge/test_candidate_enumeration.py
@@ -18,6 +18,39 @@ class _UnreadableReplacementUnit:
         raise AssertionError("candidate discovery read a third unresolved unit")
 
 
+@pytest.mark.parametrize("deletion_index", [False, 0.0])
+def test_replacement_origin_discovery_rejects_noninteger_deletion_index(
+    deletion_index,
+) -> None:
+    """Replacement review should reject noninteger deletion aliases."""
+    source_lines = [b"new value\n"]
+    working_lines = [b"old value\n"]
+    deletion_claims = [
+        AbsenceClaim(anchor_line=None, content_lines=[b"old value\n"]),
+    ]
+    ownership = BatchOwnership.from_presence_lines(
+        ["1"],
+        deletion_claims,
+        replacement_units=[
+            ReplacementUnit(
+                presence_lines=["1"],
+                deletion_indices=[deletion_index],
+                origin=ReplacementUnitOrigin(1, 1, 1, 1),
+            ),
+        ],
+    )
+
+    with pytest.raises(
+        MergeError,
+        match="Batch was created from a different version of the file",
+    ):
+        candidate_enumeration.enumerate_merge_batch_candidates_for_lines(
+            source_lines,
+            ownership,
+            working_lines,
+            resolution_is_valid=lambda _resolution: True,
+            max_candidates=10,
+        )
 def test_replacement_origin_discovery_stops_after_second_unresolved_unit() -> None:
     """A second unresolved replacement should fail before reading later units."""
     source_lines = [b"new one\n", b"new two\n"]


### PR DESCRIPTION
Candidate enumeration gathers placement details for saved replacements
whose original target locations remain unresolved.

The review flow supports only one unresolved replacement, but discovery can
retain extra descriptors, read later metadata before refusing, and accept
deletion-index aliases.

This pull request represents one unresolved origin explicitly, refuses as
soon as a second appears, and requires each retained deletion index to have
the exact int type before claim lookup.

Validation proves early refusal with guarded metadata and rejects Boolean
and floating deletion indexes; all 118 focused tests and the complete Ruff
check pass.
