### PR TITLE
batch: Bound replacement candidate previews

### DIFF
--- a/src/git_stage_batch/batch/merge/baseline_replacement_choices.py
+++ b/src/git_stage_batch/batch/merge/baseline_replacement_choices.py
@@ -36,12 +36,15 @@ def replacement_origin_choices_for_unit(
     claimed_ranges: LineSelection | Iterable[tuple[int, int]],
     working_lines: Sequence[bytes],
     *,
-    max_results: int | None = None,
+    max_results: int,
 ) -> tuple[str | None, tuple[ReplacementOriginChoice, ...]]:
     """Return explicit target placements for an origin-tracked replacement.
 
     Range-record inputs must be normalized and ordered like ``LineSelection.ranges()``.
     """
+    if type(max_results) is not int or max_results < 1:
+        raise ValueError("max_results must be positive")
+
     origin = getattr(unit, "origin", None)
     if origin is None or not claim.content_lines:
         return None, ()
@@ -70,7 +73,7 @@ def replacement_origin_choices_for_unit(
                 ),
             )
         )
-        if max_results is not None and len(choices) >= max_results:
+        if len(choices) >= max_results:
             break
 
     if not choices:

--- a/src/git_stage_batch/batch/merge/merge.py
+++ b/src/git_stage_batch/batch/merge/merge.py
@@ -260,6 +260,13 @@ def enumerate_merge_batch_candidates_from_line_sequences(
     verifies that the ordinary merge refuses, then enumerates supported
     ambiguity choices one at a time.
     """
+    if (
+        type(max_candidates) is not int
+        or max_candidates < 1
+        or max_candidates > _MERGE_CANDIDATE_CAP
+    ):
+        raise ValueError(f"max_candidates must be between 1 and {_MERGE_CANDIDATE_CAP}")
+
     normalized_source_lines = normalize_line_sequence_endings(source_lines)
     normalized_working_lines = normalize_line_sequence_endings(working_lines)
     with (

--- a/tests/batch/merge/test_baseline_replacement_choices.py
+++ b/tests/batch/merge/test_baseline_replacement_choices.py
@@ -56,6 +56,7 @@ def test_replacement_origin_choices_normalize_content_without_a_list(
         unit,
         LineRanges.from_ranges(((1, 1),)),
         [b"old value\n"],
+        max_results=2,
     )
 
     assert key is not None
@@ -85,6 +86,7 @@ def test_replacement_origin_key_keeps_claimed_ranges_compact() -> None:
         unit,
         LineRanges.from_ranges(((1, 1000),)),
         [b"old value\n"],
+        max_results=2,
     )
 
     assert key is not None

--- a/tests/batch/merge/test_baseline_replacement_choices.py
+++ b/tests/batch/merge/test_baseline_replacement_choices.py
@@ -2,6 +2,8 @@
 
 import re
 
+import pytest
+
 from git_stage_batch.batch.merge import baseline_replacement_choices
 from git_stage_batch.batch.ownership.absence_claims import AbsenceClaim
 from git_stage_batch.batch.ownership.replacement_units import (
@@ -9,6 +11,22 @@ from git_stage_batch.batch.ownership.replacement_units import (
     ReplacementUnitOrigin,
 )
 from git_stage_batch.core.line_selection import LineRanges
+
+
+@pytest.mark.parametrize("max_results", [-1, 0, True, 1.0, None])
+def test_replacement_origin_choices_require_positive_integer_limit(
+    max_results,
+) -> None:
+    """Replacement review should reject invalid collection bounds."""
+    with pytest.raises(ValueError, match="max_results must be positive"):
+        baseline_replacement_choices.replacement_origin_choices_for_unit(
+            AbsenceClaim(anchor_line=None, content_lines=[]),
+            0,
+            object(),
+            LineRanges.empty(),
+            [],
+            max_results=max_results,
+        )
 
 
 def test_replacement_origin_choices_normalize_content_without_a_list(

--- a/tests/batch/merge/test_merge.py
+++ b/tests/batch/merge/test_merge.py
@@ -1964,6 +1964,25 @@ footer
                 max_candidates=3,
             )
 
+    @pytest.mark.parametrize("max_candidates", [0, 51, True, 1.0, None])
+    def test_candidate_enumeration_rejects_unsupported_caps(
+        self,
+        max_candidates,
+    ):
+        """Public candidate limits must fit the merge application safety cap."""
+        ownership = BatchOwnership.from_presence_lines(["1"], [])
+
+        with pytest.raises(
+            ValueError,
+            match="max_candidates must be between 1 and 50",
+        ):
+            enumerate_merge_batch_candidates_from_line_sequences(
+                [b"claimed\n"],
+                ownership,
+                [],
+                max_candidates=max_candidates,
+            )
+
     def test_multiple_contextual_ambiguities_remain_a_hard_refusal(self):
         """Independent ambiguous runs should not form a candidate product."""
         source = b"""header


### PR DESCRIPTION
Replacement-origin searches accept a result limit, while the public
candidate operation exposes a configurable preview cap.

Optional or loosely typed bounds can leave lower searches unbounded and let
Boolean, floating, nonpositive, or oversized values reach candidate work
with inconsistent meaning.

This pull request makes lower search bounds mandatory positive integers
and enforces a plain-integer public preview policy from one through fifty
before candidate enumeration begins.

Validation covers invalid provider limits and sentinel-backed early
rejection at the public boundary; all 133 focused tests and the complete
Ruff check pass.
