### PR TITLE
ci: Make Codeberg mirror failures nonblocking

### DIFF
--- a/.github/workflows/mirror-codeberg.yml
+++ b/.github/workflows/mirror-codeberg.yml
@@ -19,8 +19,38 @@ jobs:
           fetch-depth: 0
 
       - name: Push to Codeberg
+        env:
+          CODEBERG_TOKEN: ${{ secrets.CODEBERG_TOKEN }}
+          GIT_TERMINAL_PROMPT: "0"
+        shell: bash
         run: |
-          git remote add codeberg https://halfline:${{ secrets.CODEBERG_TOKEN }}@codeberg.org/halfline/git-stage-batch.git
-          git fetch --prune origin '+refs/heads/*:refs/mirror/heads/*' '+refs/tags/*:refs/tags/*'
-          git push codeberg --force --prune 'refs/mirror/heads/*:refs/heads/*'
-          git push codeberg --tags --force
+          set -uo pipefail
+
+          git remote add codeberg "https://halfline:${CODEBERG_TOKEN}@codeberg.org/halfline/git-stage-batch.git"
+
+          max_attempts=5
+          for (( attempt=1; attempt<=max_attempts; attempt+=1 )); do
+            echo "::group::Codeberg mirror attempt ${attempt} of ${max_attempts}"
+
+            if git fetch --force --prune origin \
+                '+refs/heads/*:refs/mirror/heads/*' \
+                '+refs/tags/*:refs/mirror/tags/*' &&
+              git push codeberg --force --prune \
+                'refs/mirror/heads/*:refs/heads/*' \
+                'refs/mirror/tags/*:refs/tags/*'
+            then
+              echo "::endgroup::"
+              echo "Codeberg mirror synchronized."
+              exit 0
+            fi
+
+            echo "::endgroup::"
+            if (( attempt < max_attempts )); then
+              delay_seconds=$((10 * 2 ** (attempt - 1)))
+              echo "Codeberg mirror attempt ${attempt} failed; retrying in ${delay_seconds} seconds."
+              sleep "${delay_seconds}"
+            fi
+          done
+
+          echo "::error title=Codeberg mirror failed::Codeberg mirror failed after ${max_attempts} attempts."
+          exit 1

--- a/.github/workflows/mirror-codeberg.yml
+++ b/.github/workflows/mirror-codeberg.yml
@@ -6,6 +6,10 @@ on:
     tags: ["**"]
   delete:
 
+concurrency:
+  group: codeberg-mirror
+  cancel-in-progress: false
+
 jobs:
   mirror:
     runs-on: ubuntu-latest

--- a/.github/workflows/mirror-codeberg.yml
+++ b/.github/workflows/mirror-codeberg.yml
@@ -52,5 +52,10 @@ jobs:
             fi
           done
 
-          echo "::error title=Codeberg mirror failed::Codeberg mirror failed after ${max_attempts} attempts."
-          exit 1
+          echo "::warning title=Codeberg mirror delayed::Codeberg mirror failed after ${max_attempts} attempts. GitHub remains the source of truth; a later mirror run can reconcile the complete ref set."
+          {
+            echo "### Codeberg mirror delayed"
+            echo
+            echo "The mirror failed after ${max_attempts} attempts. GitHub remains the source of truth, and a later run can reconcile the complete branch and tag set."
+          } >> "${GITHUB_STEP_SUMMARY}"
+          exit 0


### PR DESCRIPTION
The Codeberg mirror workflow copies every GitHub branch and tag after push and delete events.

Closely spaced events can race while updating remote refs, and Codeberg also intermittently returns HTTP 504 responses or disconnects. Either condition currently leaves an otherwise valid GitHub update with a failed mirror check.

This PR serializes mirror jobs, fetches the complete GitHub ref set before each of five attempts, and force-prunes both branch and tag namespaces in one push. Exponential backoff absorbs transient failures, while an exhausted retry sequence emits a warning and returns success.

GitHub remains the source of truth, and later events can reconcile the Codeberg mirror without allowing a prolonged secondary-host outage to block GitHub work.
