### PR TITLE
editor: Narrow borrowed-line source dependencies

### DIFF
--- a/src/git_stage_batch/editor/line_editor.py
+++ b/src/git_stage_batch/editor/line_editor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Iterator, Sequence
 from dataclasses import dataclass
-from typing import overload
+from typing import cast, overload
 
 from ..core.buffer import LineBuffer
 from ..core.text_lines import normalize_line_ending
@@ -646,7 +646,7 @@ class LineEditor(Sequence[_LineLike]):
         active_sources: set[LineEditor] = set()
         for owner in self._pieces.active_owners():
             if owner is not None and owner is not self:
-                active_sources.add(owner)
+                active_sources.add(cast(LineEditor, owner))
 
         for source in active_sources:
             self._borrow_editor(source)

--- a/src/git_stage_batch/editor/piece_table.py
+++ b/src/git_stage_batch/editor/piece_table.py
@@ -5,14 +5,17 @@ from __future__ import annotations
 from array import array
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, SupportsBytes
-
-if TYPE_CHECKING:
-    from .line_editor import LineEditor
+from typing import Protocol, SupportsBytes
 
 
 BytesLike = bytes | bytearray | memoryview
 LineLike = BytesLike | SupportsBytes
+
+
+class LineOwner(Protocol):
+    """Owner contract retained alongside borrowed line storage."""
+
+    def _require_open(self) -> None: ...
 
 
 @dataclass(slots=True)
@@ -20,7 +23,7 @@ class LineSource:
     """One source sequence referenced by the piece table."""
 
     lines: Sequence[LineLike]
-    owner: LineEditor | None = None
+    owner: LineOwner | None = None
 
 
 @dataclass(slots=True)
@@ -30,7 +33,7 @@ class LineRange:
     lines: Sequence[LineLike]
     start: int
     end: int
-    owner: LineEditor | None
+    owner: LineOwner | None
 
 
 SOURCE_RUN = 0
@@ -41,7 +44,7 @@ _UNKNOWN_END = (1 << 64) - 1
 class LinePieceTable:
     """Compact run table for editor line content."""
 
-    def __init__(self, source: Sequence[LineLike], owner: LineEditor) -> None:
+    def __init__(self, source: Sequence[LineLike], owner: LineOwner) -> None:
         self._sources: list[LineSource] = []
         self._source_lookup: dict[tuple[int, int], int] = {}
         self._run_kinds = bytearray()
@@ -58,7 +61,7 @@ class LinePieceTable:
     def run(
         self,
         index: int,
-    ) -> tuple[int, Sequence[LineLike], int, int | None, LineEditor | None]:
+    ) -> tuple[int, Sequence[LineLike], int, int | None, LineOwner | None]:
         source = self._sources[self._run_source_ids[index]]
         end = self._run_ends[index]
         return (
@@ -77,7 +80,7 @@ class LinePieceTable:
         lines: Sequence[LineLike],
         start: int,
         end: int,
-        owner: LineEditor | None,
+        owner: LineOwner | None,
     ) -> None:
         source_id = self._source_id(lines, owner)
         self._append_run(_INDEXED_RUN, source_id, start, end)
@@ -211,7 +214,7 @@ class LinePieceTable:
         self._run_starts = replacement_starts
         self._run_ends = replacement_ends
 
-    def active_owners(self) -> Iterator[LineEditor]:
+    def active_owners(self) -> Iterator[LineOwner]:
         for source_id in self._run_source_ids:
             owner = self._sources[source_id].owner
             if owner is not None:
@@ -220,7 +223,7 @@ class LinePieceTable:
     def _source_id(
         self,
         lines: Sequence[LineLike],
-        owner: LineEditor | None,
+        owner: LineOwner | None,
     ) -> int:
         key = (id(lines), id(owner))
         source_id = self._source_lookup.get(key)


### PR DESCRIPTION
The line editor assembles changed files by borrowing line ranges from other
editors and keeping those source editors alive until assembly finishes.

The low-level structure that stores those ranges names the complete
LineEditor class even though it only retains and releases borrowed data.
That makes line storage depend on the full editing implementation and makes
runtime import cycles more likely.

This PR defines the small interface that borrowed-line sources must provide
and adapts LineEditor to implement it.

Borrowed ranges can now retain their sources without making low-level line
storage import the complete editor implementation.
