### PR TITLE
utils: Separate Buffer storage from filesystem writes

### DIFF
--- a/src/git_stage_batch/commands/batch_source/binary_file_actions.py
+++ b/src/git_stage_batch/commands/batch_source/binary_file_actions.py
@@ -5,11 +5,9 @@ from __future__ import annotations
 from enum import Enum
 import os
 
-from ...core.buffer import (
-    LineBuffer,
-    write_buffer_to_working_tree_path,
-)
+from ...core.buffer import LineBuffer
 from ...data.file_modes import detect_file_mode_in_commit
+from ...utils.buffer_io import write_buffer_to_working_tree_path
 from ...utils.repository_buffers import read_git_object_buffer_or_none
 from ...utils.git_index import git_update_index
 from ...utils.git_repository import get_git_repository_root_path

--- a/src/git_stage_batch/commands/batch_source/text_file_actions.py
+++ b/src/git_stage_batch/commands/batch_source/text_file_actions.py
@@ -4,12 +4,10 @@ from __future__ import annotations
 
 import os
 
-from ...core.buffer import (
-    LineBuffer,
-    write_buffer_to_working_tree_path,
-)
+from ...core.buffer import LineBuffer
 from ...core.text_lifecycle import TextFileChangeType, normalized_text_change_type
 from ...staging.index_update import update_index_with_blob_buffer
+from ...utils.buffer_io import write_buffer_to_working_tree_path
 from ...utils.git_index import git_update_index
 from ...utils.git_repository import get_git_repository_root_path
 from ...utils.git_object_io import create_git_blob

--- a/src/git_stage_batch/commands/batch_source/text_plan_jobs.py
+++ b/src/git_stage_batch/commands/batch_source/text_plan_jobs.py
@@ -9,10 +9,10 @@ from typing import Literal
 
 from . import candidate_preview_counts as _candidate_preview_counts
 from . import text_plan_builders as _text_plan_builders
-from ...core.buffer import write_buffer_to_path
 from ...core.replacement import ReplacementPayload
 from ...data.file_target_identity import IndexIdentity, WorktreeIdentity
 from ...exceptions import AtomicUnitError, CommandError, MergeError
+from ...utils.buffer_io import write_buffer_to_path
 
 
 ApplyTextPlanOutcome = Literal[

--- a/src/git_stage_batch/commands/batch_transform/sift_jobs.py
+++ b/src/git_stage_batch/commands/batch_transform/sift_jobs.py
@@ -11,9 +11,10 @@ from typing import Literal
 from . import sift_results as _sift_results
 from ...batch.ownership.absence_claims import AbsenceClaim
 from ...batch.ownership.model import BatchOwnership
-from ...core.buffer import LineBuffer, write_buffer_to_path
+from ...core.buffer import LineBuffer
 from ...data.file_target_identity import WorktreeIdentity
 from ...exceptions import MergeError
+from ...utils.buffer_io import write_buffer_to_path
 from ...utils.file_job_workspace import FileJobWorkspace
 
 

--- a/src/git_stage_batch/commands/file_scope/discard_file_replacement.py
+++ b/src/git_stage_batch/commands/file_scope/discard_file_replacement.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from contextlib import ExitStack
 import sys
 
-from ...core.buffer import LineBuffer, write_buffer_to_working_tree_path
+from ...core.buffer import LineBuffer
 from ...core.replacement import ReplacementPayload, coerce_replacement_payload
 from ...data.file_review.state import clear_last_file_review_state_if_file_matches
 from ...data.selected_change.paths import get_selected_change_file_path
@@ -17,6 +17,7 @@ from ...data.session import snapshot_file_if_untracked
 from ...data.undo_checkpoints import undo_checkpoint
 from ...exceptions import exit_with_error
 from ...i18n import _
+from ...utils.buffer_io import write_buffer_to_working_tree_path
 from ...utils.git_repository import get_git_repository_root_path
 from ..selection import discard_file_selection as _discard_file_selection
 from ..selection.selected_hunk_refresh import recalculate_selected_hunk_for_command

--- a/src/git_stage_batch/commands/selection/discard_line_publication.py
+++ b/src/git_stage_batch/commands/selection/discard_line_publication.py
@@ -7,10 +7,10 @@ from pathlib import Path
 from ...core.buffer import (
     BufferInput,
     buffer_matches,
-    write_buffer_to_working_tree_path,
 )
 from ...data.file_modes import detect_file_mode
 from ...data.index_entries import read_index_entry
+from ...utils.buffer_io import write_buffer_to_working_tree_path
 from ...utils.repository_buffers import read_git_object_buffer_or_none
 
 

--- a/src/git_stage_batch/core/buffer.py
+++ b/src/git_stage_batch/core/buffer.py
@@ -5,12 +5,8 @@ from __future__ import annotations
 from collections.abc import Iterable, Sequence
 from contextlib import nullcontext
 import mmap
-import os
 from pathlib import Path
-import stat
-import tempfile
 from typing import Any, BinaryIO, Generic, Iterator, TypeVar, overload
-import uuid
 
 from .mapped_storage import (
     ChunkedMappedRecordVector,
@@ -736,113 +732,3 @@ def buffer_preview(buffer: BufferInput, size: int = 200) -> bytes:
         if len(preview) >= size:
             break
     return bytes(preview)
-
-
-def write_buffer_to_path(path: str | Path, buffer: BufferInput) -> None:
-    """Write buffer bytes to a path, creating parent directories as needed."""
-    file_path = Path(path)
-    file_path.parent.mkdir(parents=True, exist_ok=True)
-    if file_path.is_symlink():
-        target = b"".join(buffer_byte_chunks(buffer))
-        _replace_with_symlink_atomically(file_path, target)
-        return
-
-    _write_regular_file_atomically(file_path, buffer)
-
-
-def write_buffer_to_working_tree_path(
-    path: str | Path,
-    buffer: BufferInput,
-    *,
-    mode: str | None = None,
-) -> None:
-    """Write buffer bytes as a Git working-tree path with the given mode."""
-    file_path = Path(path)
-    file_path.parent.mkdir(parents=True, exist_ok=True)
-
-    if mode == "120000":
-        target = b"".join(buffer_byte_chunks(buffer))
-        _replace_with_symlink_atomically(file_path, target)
-        return
-
-    requested_mode = None
-    if mode == "100755":
-        requested_mode = 0o755
-    elif mode == "100644":
-        requested_mode = 0o644
-    _write_regular_file_atomically(file_path, buffer, mode=requested_mode)
-
-
-def _write_regular_file_atomically(
-    file_path: Path,
-    buffer: BufferInput,
-    *,
-    mode: int | None = None,
-) -> None:
-    """Stream a regular file through a same-directory atomic replacement."""
-    try:
-        metadata = file_path.lstat()
-    except FileNotFoundError:
-        metadata = None
-    if metadata is not None and not stat.S_ISREG(metadata.st_mode):
-        metadata = None
-    replacement_mode = (
-        mode
-        if mode is not None
-        else stat.S_IMODE(metadata.st_mode) if metadata is not None else 0o644
-    )
-    file_descriptor, temporary_name = tempfile.mkstemp(
-        dir=file_path.parent,
-        prefix=".git-stage-batch-",
-        suffix=".tmp",
-    )
-    temporary_path = Path(temporary_name)
-    try:
-        with os.fdopen(file_descriptor, "wb") as file_handle:
-            for chunk in buffer_byte_chunks(buffer):
-                file_handle.write(chunk)
-            file_handle.flush()
-            if metadata is not None and hasattr(os, "fchown"):
-                try:
-                    os.fchown(file_handle.fileno(), metadata.st_uid, metadata.st_gid)
-                except PermissionError:
-                    replacement_mode &= 0o700
-            os.fchmod(file_handle.fileno(), replacement_mode)
-            os.fsync(file_handle.fileno())
-        os.replace(temporary_path, file_path)
-        _fsync_directory(file_path.parent)
-    finally:
-        temporary_path.unlink(missing_ok=True)
-
-
-def _replace_with_symlink_atomically(file_path: Path, target: bytes) -> None:
-    """Publish a symlink through a same-directory atomic replacement."""
-    temporary_path = None
-    for _attempt in range(100):
-        candidate = file_path.parent / f".git-stage-batch-{uuid.uuid4().hex}.tmp"
-        try:
-            os.symlink(target, os.fsencode(candidate))
-        except FileExistsError:
-            continue
-        temporary_path = candidate
-        break
-
-    if temporary_path is None:
-        raise FileExistsError(f"Unable to create temporary symlink for {file_path}")
-
-    try:
-        os.replace(temporary_path, file_path)
-        _fsync_directory(file_path.parent)
-    finally:
-        temporary_path.unlink(missing_ok=True)
-
-
-def _fsync_directory(directory: Path) -> None:
-    directory_descriptor = os.open(
-        directory,
-        os.O_RDONLY | getattr(os, "O_DIRECTORY", 0),
-    )
-    try:
-        os.fsync(directory_descriptor)
-    finally:
-        os.close(directory_descriptor)

--- a/src/git_stage_batch/data/selected_change/snapshots.py
+++ b/src/git_stage_batch/data/selected_change/snapshots.py
@@ -10,8 +10,8 @@ from ...core.buffer import (
     buffer_matches,
     buffer_byte_count,
     buffer_preview,
-    write_buffer_to_path,
 )
+from ...utils.buffer_io import write_buffer_to_path
 from ...utils.repository_buffers import (
     read_git_object_buffer_or_none,
     read_working_tree_object,

--- a/src/git_stage_batch/data/selected_change/store.py
+++ b/src/git_stage_batch/data/selected_change/store.py
@@ -14,12 +14,10 @@ from ...core.diff_parser import build_line_changes_from_patch_lines
 from ...core.models import (
     LineLevelChange,
 )
-from ...core.buffer import (
-    LineBuffer,
-    write_buffer_to_path,
-)
+from ...core.buffer import LineBuffer
+from ...utils.atomic_write import fsync_directory
+from ...utils.buffer_io import write_buffer_to_path
 from ...utils.file_io import (
-    fsync_directory,
     read_text_file_contents,
     write_file_bytes,
     write_text_file_contents,

--- a/src/git_stage_batch/data/undo_restore.py
+++ b/src/git_stage_batch/data/undo_restore.py
@@ -10,7 +10,7 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
-from ..core.buffer import write_buffer_to_working_tree_path
+from ..utils.buffer_io import write_buffer_to_working_tree_path
 from ..utils.repository_buffers import load_git_blob_as_buffer
 from .undo_refs import list_restorable_refs
 from ..exceptions import CommandError

--- a/src/git_stage_batch/utils/atomic_write.py
+++ b/src/git_stage_batch/utils/atomic_write.py
@@ -1,0 +1,102 @@
+"""Low-level durable atomic publication helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+import errno
+import os
+from pathlib import Path
+import tempfile
+import uuid
+
+
+_TEMPORARY_FILE_PREFIX = ".git-stage-batch-"
+
+
+def write_chunks_atomically(
+    path: Path,
+    chunks: Iterable[bytes],
+    *,
+    mode: int,
+    existing_metadata: os.stat_result | None = None,
+) -> None:
+    """Publish streamed bytes through a same-directory regular file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    file_descriptor, temporary_name = tempfile.mkstemp(
+        dir=path.parent,
+        prefix=_TEMPORARY_FILE_PREFIX,
+        suffix=".tmp",
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(file_descriptor, "wb") as file_handle:
+            for chunk in chunks:
+                file_handle.write(chunk)
+            file_handle.flush()
+            if not _preserve_ownership(file_handle.fileno(), existing_metadata):
+                mode &= 0o700
+            os.fchmod(file_handle.fileno(), mode)
+            os.fsync(file_handle.fileno())
+        os.replace(temporary_path, path)
+        fsync_directory(path.parent)
+    finally:
+        temporary_path.unlink(missing_ok=True)
+
+
+def replace_symlink_atomically(path: Path, target: bytes) -> None:
+    """Publish a symlink through a same-directory atomic replacement."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path = None
+    for _attempt in range(100):
+        candidate = path.parent / (
+            f"{_TEMPORARY_FILE_PREFIX}{uuid.uuid4().hex}.tmp"
+        )
+        try:
+            os.symlink(target, os.fsencode(candidate))
+        except FileExistsError:
+            continue
+        temporary_path = candidate
+        break
+
+    if temporary_path is None:
+        raise FileExistsError(f"Unable to create temporary symlink for {path}")
+
+    try:
+        os.replace(temporary_path, path)
+        fsync_directory(path.parent)
+    finally:
+        temporary_path.unlink(missing_ok=True)
+
+
+def fsync_directory(path: Path) -> None:
+    """Durably publish directory-entry changes where the platform permits."""
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+    try:
+        directory_descriptor = os.open(path, flags)
+    except OSError as error:
+        if os.name == "nt" or error.errno in (errno.EINVAL, errno.ENOTSUP):
+            return
+        raise
+    try:
+        try:
+            os.fsync(directory_descriptor)
+        except OSError as error:
+            if error.errno not in (errno.EBADF, errno.EINVAL, errno.ENOTSUP):
+                raise
+    finally:
+        os.close(directory_descriptor)
+
+
+def _preserve_ownership(
+    file_descriptor: int,
+    metadata: os.stat_result | None,
+) -> bool:
+    if metadata is None or not hasattr(os, "fchown"):
+        return True
+    try:
+        os.fchown(file_descriptor, metadata.st_uid, metadata.st_gid)
+    except PermissionError:
+        # An unprivileged owner often cannot restore a non-default group. The
+        # caller will remove group/other access before publishing the file.
+        return False
+    return True

--- a/src/git_stage_batch/utils/buffer_io.py
+++ b/src/git_stage_batch/utils/buffer_io.py
@@ -1,0 +1,67 @@
+"""Atomic filesystem publication for core byte buffers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import stat
+
+from ..core.buffer import BufferInput, buffer_byte_chunks
+from .atomic_write import replace_symlink_atomically, write_chunks_atomically
+
+
+def write_buffer_to_path(path: str | Path, buffer: BufferInput) -> None:
+    """Write buffer bytes to a path, creating parent directories as needed."""
+    file_path = Path(path)
+    if file_path.is_symlink():
+        target = b"".join(buffer_byte_chunks(buffer))
+        replace_symlink_atomically(file_path, target)
+        return
+
+    _write_regular_file_atomically(file_path, buffer)
+
+
+def write_buffer_to_working_tree_path(
+    path: str | Path,
+    buffer: BufferInput,
+    *,
+    mode: str | None = None,
+) -> None:
+    """Write buffer bytes as a Git working-tree path with the given mode."""
+    file_path = Path(path)
+    if mode == "120000":
+        target = b"".join(buffer_byte_chunks(buffer))
+        replace_symlink_atomically(file_path, target)
+        return
+
+    requested_mode = None
+    if mode == "100755":
+        requested_mode = 0o755
+    elif mode == "100644":
+        requested_mode = 0o644
+    _write_regular_file_atomically(file_path, buffer, mode=requested_mode)
+
+
+def _write_regular_file_atomically(
+    file_path: Path,
+    buffer: BufferInput,
+    *,
+    mode: int | None = None,
+) -> None:
+    """Stream a regular file through a same-directory atomic replacement."""
+    try:
+        metadata = file_path.lstat()
+    except FileNotFoundError:
+        metadata = None
+    if metadata is not None and not stat.S_ISREG(metadata.st_mode):
+        metadata = None
+    replacement_mode = (
+        mode
+        if mode is not None
+        else stat.S_IMODE(metadata.st_mode) if metadata is not None else 0o644
+    )
+    write_chunks_atomically(
+        file_path,
+        buffer_byte_chunks(buffer),
+        mode=replacement_mode,
+        existing_metadata=metadata,
+    )

--- a/src/git_stage_batch/utils/file_io.py
+++ b/src/git_stage_batch/utils/file_io.py
@@ -2,15 +2,17 @@
 
 from __future__ import annotations
 
-import errno
 import os
 import stat
-import tempfile
 from collections.abc import Collection
 from enum import Enum
 from pathlib import Path
 from typing import Iterable
 
+from .atomic_write import (
+    fsync_directory as _fsync_directory,
+    write_chunks_atomically,
+)
 from ..exceptions import CommandError
 from ..git_paths import decode_path, encode_path, nul_records
 from ..i18n import _
@@ -145,40 +147,6 @@ def _replacement_mode(
     raise ValueError(f"unsupported atomic write mode policy: {mode_policy!r}")
 
 
-def _preserve_ownership(
-    file_descriptor: int,
-    metadata: os.stat_result | None,
-) -> bool:
-    if metadata is None or not hasattr(os, "fchown"):
-        return True
-    try:
-        os.fchown(file_descriptor, metadata.st_uid, metadata.st_gid)
-    except PermissionError:
-        # An unprivileged owner often cannot restore a non-default group. The
-        # caller will remove group/other access before publishing the file.
-        return False
-    return True
-
-
-def fsync_directory(path: Path) -> None:
-    """Durably publish directory-entry changes where the platform permits."""
-    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
-    try:
-        directory_descriptor = os.open(path, flags)
-    except OSError as error:
-        if os.name == "nt" or error.errno in (errno.EINVAL, errno.ENOTSUP):
-            return
-        raise
-    try:
-        try:
-            os.fsync(directory_descriptor)
-        except OSError as error:
-            if error.errno not in (errno.EBADF, errno.EINVAL, errno.ENOTSUP):
-                raise
-    finally:
-        os.close(directory_descriptor)
-
-
 def _write_file_contents_atomically(
     path: Path,
     data: bytes,
@@ -187,28 +155,14 @@ def _write_file_contents_atomically(
     mode: int | None,
 ) -> None:
     """Replace one state file without exposing partial contents."""
-    path.parent.mkdir(parents=True, exist_ok=True)
     metadata = _existing_file_metadata(path)
     replacement_mode = _replacement_mode(metadata, mode_policy, mode)
-    file_descriptor, temporary_name = tempfile.mkstemp(
-        dir=path.parent,
-        prefix=f".{path.name}.",
-        suffix=".tmp",
+    write_chunks_atomically(
+        path,
+        (data,),
+        mode=replacement_mode,
+        existing_metadata=metadata,
     )
-    temporary_path = Path(temporary_name)
-    try:
-        with os.fdopen(file_descriptor, "wb") as file_handle:
-            file_handle.write(data)
-            file_handle.flush()
-            ownership_preserved = _preserve_ownership(file_handle.fileno(), metadata)
-            if not ownership_preserved:
-                replacement_mode &= 0o700
-            os.fchmod(file_handle.fileno(), replacement_mode)
-            os.fsync(file_handle.fileno())
-        os.replace(temporary_path, path)
-        fsync_directory(path.parent)
-    finally:
-        temporary_path.unlink(missing_ok=True)
 
 
 def path_is_empty(path: Path) -> bool:
@@ -246,7 +200,7 @@ def append_lines_to_file(path: Path, lines: Iterable[str]) -> None:
             file_handle.write(str(line).rstrip() + "\n")
         file_handle.flush()
         os.fsync(file_handle.fileno())
-    fsync_directory(path.parent)
+    _fsync_directory(path.parent)
 
 
 def read_file_paths_file(path: Path) -> list[str]:

--- a/src/git_stage_batch/utils/file_job_workspace.py
+++ b/src/git_stage_batch/utils/file_job_workspace.py
@@ -20,7 +20,8 @@ import stat
 import tempfile
 from typing import Any
 
-from ..core.buffer import BufferInput, LineBuffer, write_buffer_to_path
+from ..core.buffer import BufferInput, LineBuffer
+from .buffer_io import write_buffer_to_path
 
 
 _STANDARD_PATH_TYPES = frozenset({

--- a/tests/architecture/test_seam_rules.py
+++ b/tests/architecture/test_seam_rules.py
@@ -80,7 +80,15 @@ def test_repository_readers_stay_below_policy_layers():
 
 
 def test_atomic_buffer_publication_stays_out_of_core():
-    """Atomic filesystem publication belongs to utils."""
+    """Core buffers describe bytes; filesystem publication belongs to utils."""
+    publication_symbols = {
+        "write_buffer_to_path",
+        "write_buffer_to_working_tree_path",
+    }
+    assert modules_defining(publication_symbols) == {
+        "git_stage_batch.utils.buffer_io": publication_symbols,
+    }
+
     atomic_symbols = {
         "fsync_directory",
         "replace_symlink_atomically",

--- a/tests/architecture/test_seam_rules.py
+++ b/tests/architecture/test_seam_rules.py
@@ -79,6 +79,18 @@ def test_repository_readers_stay_below_policy_layers():
     assert forbidden_import_violations(rules) == []
 
 
+def test_atomic_buffer_publication_stays_out_of_core():
+    """Atomic filesystem publication belongs to utils."""
+    atomic_symbols = {
+        "fsync_directory",
+        "replace_symlink_atomically",
+        "write_chunks_atomically",
+    }
+    assert modules_defining(atomic_symbols) == {
+        "git_stage_batch.utils.atomic_write": atomic_symbols,
+    }
+
+
 def test_tui_shell_boundary_does_not_own_repository_locking():
     """Arbitrary shell children run outside repository action locks."""
     rules = (

--- a/tests/core/test_buffer.py
+++ b/tests/core/test_buffer.py
@@ -10,6 +10,7 @@ from collections.abc import Sequence
 import pytest
 
 from git_stage_batch.core import buffer as buffer_module
+from git_stage_batch.utils import atomic_write as atomic_write_module
 from git_stage_batch.core.buffer import (
     LineBuffer,
     buffer_byte_chunks,
@@ -18,6 +19,8 @@ from git_stage_batch.core.buffer import (
     buffer_has_data,
     buffer_matches,
     buffer_preview,
+)
+from git_stage_batch.utils.buffer_io import (
     write_buffer_to_path,
     write_buffer_to_working_tree_path,
 )
@@ -264,7 +267,7 @@ def test_symlink_write_keeps_old_entry_until_atomic_replace(tmp_path, monkeypatc
         assert os.readlink(output_path) == "old-target"
         original_replace(source, destination)
 
-    monkeypatch.setattr(buffer_module.os, "replace", inspect_replace)
+    monkeypatch.setattr(atomic_write_module.os, "replace", inspect_replace)
 
     write_buffer_to_path(output_path, b"new-target")
 
@@ -280,7 +283,7 @@ def test_failed_symlink_publication_preserves_old_entry(tmp_path, monkeypatch):
     def fail_replace(*args):
         raise OSError("simulated publication failure")
 
-    monkeypatch.setattr(buffer_module.os, "replace", fail_replace)
+    monkeypatch.setattr(atomic_write_module.os, "replace", fail_replace)
 
     with pytest.raises(OSError, match="simulated publication failure"):
         write_buffer_to_path(output_path, b"new-target")
@@ -332,7 +335,7 @@ def test_atomic_regular_write_tightens_mode_when_ownership_cannot_be_preserved(
     monkeypatch,
 ):
     """A differently owned replacement must not retain group or other access."""
-    if not hasattr(buffer_module.os, "fchown"):
+    if not hasattr(atomic_write_module.os, "fchown"):
         pytest.skip("fchown is not available")
 
     output_path = tmp_path / "path"
@@ -342,7 +345,7 @@ def test_atomic_regular_write_tightens_mode_when_ownership_cannot_be_preserved(
     def fail_fchown(*_args):
         raise PermissionError("ownership cannot be preserved")
 
-    monkeypatch.setattr(buffer_module.os, "fchown", fail_fchown)
+    monkeypatch.setattr(atomic_write_module.os, "fchown", fail_fchown)
 
     write_buffer_to_path(output_path, b"new")
 

--- a/tests/utils/test_file_io.py
+++ b/tests/utils/test_file_io.py
@@ -6,6 +6,7 @@ import stat
 
 import pytest
 
+import git_stage_batch.utils.atomic_write as atomic_write
 import git_stage_batch.utils.file_io as file_io
 from git_stage_batch.exceptions import CommandError
 from git_stage_batch.utils.file_io import read_file_paths_file
@@ -120,7 +121,7 @@ class TestWriteTextFileContents:
             file_io.write_text_file_contents(test_file, "New content")
 
         assert test_file.read_text(encoding="utf-8") == "Old content"
-        assert list(tmp_path.glob(".test.txt.*.tmp")) == []
+        assert list(tmp_path.glob(".git-stage-batch-*.tmp")) == []
 
     @pytest.mark.parametrize("mode", [0o600, 0o644, 0o660, 0o755])
     def test_project_write_preserves_existing_mode(self, tmp_path, mode):
@@ -213,7 +214,7 @@ class TestWriteTextFileContents:
             write_text_file_contents(test_file, "new")
 
         assert test_file.read_text(encoding="utf-8") == "old"
-        assert list(tmp_path.glob(".test.txt.*.tmp")) == []
+        assert list(tmp_path.glob(".git-stage-batch-*.tmp")) == []
 
     def test_unwritable_directory_failure_preserves_existing_contents(
         self,
@@ -226,7 +227,7 @@ class TestWriteTextFileContents:
         def refuse_temp_file(**_kwargs):
             raise PermissionError("directory is read-only")
 
-        monkeypatch.setattr(file_io.tempfile, "mkstemp", refuse_temp_file)
+        monkeypatch.setattr(atomic_write.tempfile, "mkstemp", refuse_temp_file)
 
         with pytest.raises(PermissionError, match="read-only"):
             write_text_file_contents(test_file, "new")


### PR DESCRIPTION
Filesystem output keeps temporary-file creation, durable replacement,
symlink handling, directory syncing, and Buffer path writes in broadly used
modules.

Callers that only need crash-safe replacement must import unrelated file
handling, while the widely imported Buffer type carries operating-system
path responsibilities alongside byte storage.

This PR gathers regular-file and symlink replacement in one low-level
utility and moves regular-file and working-tree Buffer output into a
filesystem adapter.

Buffer remains responsible for bytes, while filesystem utilities own the
shared replacement sequence and path writes.
