### PR TITLE
state: Isolate active-session checks from session updates

### DIFF
--- a/src/git_stage_batch/cli/execution.py
+++ b/src/git_stage_batch/cli/execution.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import argparse
 
 from ..commands.show import command_show
-from ..data.session import session_is_active
+from ..data.session_marker import session_is_active
 from ..exceptions import exit_with_error
 from ..i18n import _
 

--- a/src/git_stage_batch/commands/block_file.py
+++ b/src/git_stage_batch/commands/block_file.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import sys
 from contextlib import nullcontext
 
-from ..data.session import path_is_intent_to_add, session_is_active
+from ..data.session import path_is_intent_to_add
+from ..data.session_marker import session_is_active
 from ..data.undo_checkpoints import undo_checkpoint
 from ..data.ignore_files import (
     add_file_to_local_exclude,

--- a/src/git_stage_batch/commands/start.py
+++ b/src/git_stage_batch/commands/start.py
@@ -8,7 +8,8 @@ from ..data.auto_advance import DEFAULT_AUTO_ADVANCE, write_auto_advance_default
 from ..data.hunk_tracking import fetch_next_change
 from ..data.selected_change.lifecycle import clear_selected_change_state_files
 from ..data.file_tracking import auto_add_untracked_files
-from ..data.session import clear_session_state, initialize_abort_state, session_is_active
+from ..data.session import clear_session_state, initialize_abort_state
+from ..data.session_marker import session_is_active
 from ..data.session_ownership import (
     claim_session_ownership,
     require_no_foreign_session_owner,

--- a/src/git_stage_batch/commands/status.py
+++ b/src/git_stage_batch/commands/status.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import subprocess
 import sys
 
-from ..data.session import session_is_active
+from ..data.session_marker import session_is_active
 from ..data.status_summary import read_status_summary as _read_status_summary
 from ..exceptions import CommandError
 from ..i18n import _

--- a/src/git_stage_batch/commands/stop.py
+++ b/src/git_stage_batch/commands/stop.py
@@ -9,7 +9,8 @@ from ..data.start_time_changes import (
     restore_unstaged_start_time_deletions,
     restore_unstaged_start_time_renames,
 )
-from ..data.session import clear_session_state, session_is_active
+from ..data.session import clear_session_state
+from ..data.session_marker import session_is_active
 from ..data.session_ownership import (
     release_session_ownership,
     require_current_session_owner,

--- a/src/git_stage_batch/commands/unblock_file.py
+++ b/src/git_stage_batch/commands/unblock_file.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import sys
 from contextlib import nullcontext
 
-from ..data.session import session_is_active
+from ..data.session_marker import session_is_active
 from ..data.undo_checkpoints import undo_checkpoint
 from ..data.ignore_files import (
     add_pattern_to_gitignore,

--- a/src/git_stage_batch/data/session.py
+++ b/src/git_stage_batch/data/session.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import os
-from pathlib import Path
 import shutil
 
 from .batch_refs import snapshot_batch_refs
@@ -74,21 +73,6 @@ def _journal_index_entries(
         }
         for file_path in file_paths
     ]
-
-
-def active_session_marker_path(git_dir: Path | None = None) -> Path:
-    """Return the active-session marker path without creating state directories."""
-    state_dir = (
-        git_dir / "git-stage-batch"
-        if git_dir is not None
-        else get_state_directory_path()
-    )
-    return state_dir / "session" / "abort" / "head.txt"
-
-
-def session_is_active(git_dir: Path | None = None) -> bool:
-    """Return whether a batch staging session marker exists."""
-    return active_session_marker_path(git_dir).exists()
 
 
 def _diff_index_name_status(*, intent_to_add_visible: bool) -> dict[str, str]:

--- a/src/git_stage_batch/data/session_marker.py
+++ b/src/git_stage_batch/data/session_marker.py
@@ -1,0 +1,22 @@
+"""Read-only access to the worktree-local active-session marker."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..utils.paths import get_state_directory_path
+
+
+def active_session_marker_path(git_dir: Path | None = None) -> Path:
+    """Return the active-session marker path without creating state directories."""
+    state_dir = (
+        git_dir / "git-stage-batch"
+        if git_dir is not None
+        else get_state_directory_path()
+    )
+    return state_dir / "session" / "abort" / "head.txt"
+
+
+def session_is_active(git_dir: Path | None = None) -> bool:
+    """Return whether a batch staging session marker exists."""
+    return active_session_marker_path(git_dir).exists()

--- a/src/git_stage_batch/data/session_ownership.py
+++ b/src/git_stage_batch/data/session_ownership.py
@@ -15,7 +15,7 @@ from ..utils.paths import (
     get_active_session_owner_file_path,
     get_common_state_directory_path,
 )
-from .session import active_session_marker_path, session_is_active
+from .session_marker import active_session_marker_path, session_is_active
 
 
 @dataclass(frozen=True)

--- a/src/git_stage_batch/tui/session_startup.py
+++ b/src/git_stage_batch/tui/session_startup.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import sys
 
-from ..data.session import session_is_active
+from ..data.session_marker import session_is_active
 from ..utils.session_start_point import load_session_start_point
 from ..exceptions import CommandError
 from ..i18n import _

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -4727,8 +4727,8 @@ def test_status_summary_uses_batch_selected_binary_validation():
     assert "selected_batch_binary_file_for_batch" not in status_summary_text
 
 
-def test_active_session_query_stays_in_session_data():
-    """Callers should ask session data whether a session is active."""
+def test_active_session_query_stays_in_session_marker_data():
+    """Callers should use the read-only active-session marker seam."""
     caller_paths = (
         SRC_ROOT / "cli" / "execution.py",
         SRC_ROOT / "commands" / "block_file.py",
@@ -4737,16 +4737,16 @@ def test_active_session_query_stays_in_session_data():
         SRC_ROOT / "commands" / "unblock_file.py",
         SRC_ROOT / "tui" / "session_startup.py",
     )
-    session = __import__(
-        "git_stage_batch.data.session",
-        fromlist=["session"],
+    session_marker = __import__(
+        "git_stage_batch.data.session_marker",
+        fromlist=["session_marker"],
     )
     public_names = {
         "active_session_marker_path",
         "session_is_active",
     }
 
-    assert public_names <= vars(session).keys()
+    assert public_names <= vars(session_marker).keys()
 
     for caller_path in caller_paths:
         caller_tree = ast.parse(caller_path.read_text(), filename=str(caller_path))
@@ -4755,18 +4755,18 @@ def test_active_session_query_stays_in_session_data():
             for node in ast.walk(caller_tree)
             if isinstance(node, ast.ClassDef | ast.FunctionDef)
         }
-        caller_imported_session_names = set()
+        caller_imported_marker_names = set()
         caller_imported_path_names = set()
 
         for imported_module, node in _import_from_nodes(caller_path):
             imported_names = {alias.name for alias in node.names}
-            if imported_module == "git_stage_batch.data.session":
-                caller_imported_session_names |= imported_names
+            if imported_module == "git_stage_batch.data.session_marker":
+                caller_imported_marker_names |= imported_names
             if imported_module == "git_stage_batch.utils.paths":
                 caller_imported_path_names |= imported_names
 
         assert "_session_marker_path" not in caller_names
-        assert "session_is_active" in caller_imported_session_names
+        assert "session_is_active" in caller_imported_marker_names
         assert "get_abort_head_file_path" not in caller_imported_path_names
         assert "get_state_directory_path" not in caller_imported_path_names
         assert "session/abort/head.txt" not in caller_path.read_text()
@@ -6891,7 +6891,7 @@ def test_tui_session_startup_owns_interactive_startup():
     }
     startup_imports = {
         "git_stage_batch.commands.start",
-        "git_stage_batch.data.session",
+        "git_stage_batch.data.session_marker",
         "git_stage_batch.utils.file_io",
         "git_stage_batch.utils.git_command",
         "git_stage_batch.utils.paths",

--- a/tests/commands/test_start.py
+++ b/tests/commands/test_start.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 import pytest
 
 from git_stage_batch.commands.start import command_start
-from git_stage_batch.data.session import session_is_active
+from git_stage_batch.data.session_marker import session_is_active
 from git_stage_batch.exceptions import CommandError
 from git_stage_batch.utils.file_io import read_text_file_contents
 from git_stage_batch.utils.paths import (

--- a/tests/data/test_session.py
+++ b/tests/data/test_session.py
@@ -1,6 +1,6 @@
-"""Tests for session state helpers."""
+"""Tests for active-session marker helpers."""
 
-from git_stage_batch.data.session import (
+from git_stage_batch.data.session_marker import (
     active_session_marker_path,
     session_is_active,
 )

--- a/tests/data/test_session_ownership.py
+++ b/tests/data/test_session_ownership.py
@@ -11,7 +11,7 @@ import pytest
 from git_stage_batch.commands.abort import command_abort
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.commands.stop import command_stop
-from git_stage_batch.data.session import session_is_active
+from git_stage_batch.data.session_marker import session_is_active
 from git_stage_batch.data.session_ownership import require_no_foreign_session_owner
 from git_stage_batch.exceptions import CommandError
 from git_stage_batch.utils.paths import get_active_session_owner_file_path


### PR DESCRIPTION
Commands, the command-line entry point, session ownership tracking, and the
terminal interface import the full session module to ask whether a session
is active.

Those callers only need a read-only marker-file check. Importing the larger
module also exposes session creation, removal, snapshots, and repository
updates to code that does not need them.

This PR moves the active-session marker path and query into
data.session_marker, updates every read-only caller, and adds architecture
checks for the new import direction.

Read-only callers can now check session activity without importing code
that changes session state.
