### PR TITLE
tui: Delegate ignore-file changes from browser navigation

### DIFF
--- a/src/git_stage_batch/tui/file_review/block_actions.py
+++ b/src/git_stage_batch/tui/file_review/block_actions.py
@@ -7,13 +7,15 @@ import sys
 from ...exceptions import CommandError
 from ...i18n import _
 from .session import FileReviewSessionState
-from ..prompts import confirm_destructive_operation
+from ..prompts import (
+    confirm_destructive_operation,
+    unlocked_input,
+    wrap_prompt_for_readline,
+)
 
 
 def apply_block_action(state: FileReviewSessionState, action: str) -> None:
     """Run a block or unblock action for the reviewed file."""
-    from .file_browser import prompt_block_local_only
-
     if action == "B":
         if not confirm_destructive_operation(
             "block",
@@ -35,6 +37,28 @@ def apply_block_action(state: FileReviewSessionState, action: str) -> None:
         unblock_review_file(state.file_path)
     except CommandError as e:
         print(e.message, file=sys.stderr)
+
+
+def prompt_block_local_only() -> bool | None:
+    """Prompt for the block-file destination."""
+    try:
+        choice = unlocked_input(
+            wrap_prompt_for_readline(
+                _("Block target [g]itignore, [l]ocal exclude, or q: ")
+            )
+        ).strip().lower()
+    except (KeyboardInterrupt, EOFError):
+        return None
+
+    if choice in {"q", "quit", "cancel"}:
+        return None
+    if choice in {"l", "local", "local exclude"}:
+        return True
+    if choice in {"", "g", "gitignore"}:
+        return False
+
+    print(_("Invalid block target."), file=sys.stderr)
+    return None
 
 
 def block_review_file(file_path: str, *, local_only: bool) -> None:

--- a/src/git_stage_batch/tui/file_review/file_browser.py
+++ b/src/git_stage_batch/tui/file_review/file_browser.py
@@ -10,8 +10,8 @@ from ...data.file_tracking import list_untracked_files
 from ...exceptions import CommandError
 from ...i18n import _
 from ...utils.file_patterns import list_changed_files, resolve_gitignore_style_patterns
+from . import block_actions
 from .batch_actions import apply_batch_file_action
-from .block_actions import block_review_file
 from .live_actions import apply_live_file_action
 from .session import FileReviewSessionState
 from ..flow import FlowState, LocationRole
@@ -112,28 +112,6 @@ def choose_review_file(
         print(_("Invalid file selection."), file=sys.stderr)
 
 
-def prompt_block_local_only() -> bool | None:
-    """Prompt for the block-file destination."""
-    try:
-        choice = unlocked_input(
-            wrap_prompt_for_readline(
-                _("Block target [g]itignore, [l]ocal exclude, or q: ")
-            )
-        ).strip().lower()
-    except (KeyboardInterrupt, EOFError):
-        return None
-
-    if choice in {"q", "quit", "cancel"}:
-        return None
-    if choice in {"l", "local", "local exclude"}:
-        return True
-    if choice in {"", "g", "gitignore"}:
-        return False
-
-    print(_("Invalid block target."), file=sys.stderr)
-    return None
-
-
 def _mark_file_choice(
     choice: str,
     entries: list[ReviewFileEntry],
@@ -204,14 +182,14 @@ def _apply_marked_file_action(
             _("This will add the marked files to ignore state."),
         ):
             return
-        local_only = prompt_block_local_only()
+        local_only = block_actions.prompt_block_local_only()
         if local_only is None:
             return
 
     for path in sorted(marked_paths):
         try:
             if action == "B":
-                block_review_file(path, local_only=local_only)
+                block_actions.block_review_file(path, local_only=local_only)
                 continue
 
             state = FileReviewSessionState(flow_state=flow_state, file_path=path)

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -8100,7 +8100,6 @@ def test_tui_file_review_file_browser_owns_file_selection():
         "ReviewFileEntry",
         "choose_review_file",
         "list_review_file_entries",
-        "prompt_block_local_only",
     }
     moved_names = {
         "ReviewFileEntry",
@@ -8236,6 +8235,11 @@ def test_tui_file_review_block_actions_own_block_commands():
         imported_module
         for imported_module, _node in _import_from_nodes(file_browser_path)
     }
+    file_browser_imports_block_actions = any(
+        imported_module == "git_stage_batch.tui.file_review"
+        and any(alias.name == "block_actions" for alias in node.names)
+        for imported_module, node in _import_from_nodes(file_browser_path)
+    )
     block_action_imports = {
         imported_module
         for imported_module, _node in _import_from_nodes(block_actions_path)
@@ -8252,19 +8256,26 @@ def test_tui_file_review_block_actions_own_block_commands():
     assert {
         "apply_block_action",
         "block_review_file",
+        "prompt_block_local_only",
         "unblock_review_file",
     } <= vars(block_actions).keys()
+    assert "prompt_block_local_only" not in vars(
+        __import__(
+            "git_stage_batch.tui.file_review.file_browser",
+            fromlist=["file_browser"],
+        )
+    )
     assert "_apply_block_action" not in browser_function_names
     assert all(snippet not in browser_text for snippet in old_browser_snippets)
     assert "git_stage_batch.tui.file_review.block_actions" in browser_imports
-    assert "git_stage_batch.tui.file_review.block_actions" in file_browser_imports
+    assert file_browser_imports_block_actions
     assert "git_stage_batch.commands.block_file" not in browser_imports
     assert "git_stage_batch.commands.unblock_file" not in browser_imports
     assert "git_stage_batch.commands.block_file" not in file_browser_imports
     assert "git_stage_batch.commands.unblock_file" not in file_browser_imports
     assert "git_stage_batch.commands.block_file" in block_action_imports
     assert "git_stage_batch.commands.unblock_file" in block_action_imports
-    assert "git_stage_batch.tui.file_review.file_browser" in block_action_imports
+    assert "git_stage_batch.tui.file_review.file_browser" not in block_action_imports
     assert "git_stage_batch.tui.prompts" in block_action_imports
 
 

--- a/tests/tui/test_file_review.py
+++ b/tests/tui/test_file_review.py
@@ -894,7 +894,7 @@ class TestHandleFileBrowser:
                 return_value=True,
             ):
                 with patch(
-                    "git_stage_batch.tui.file_review.file_browser.prompt_block_local_only",
+                    "git_stage_batch.tui.file_review.block_actions.prompt_block_local_only",
                     return_value=True,
                 ):
                     with patch(


### PR DESCRIPTION
The terminal file browser selects files for actions and also chooses where
a block action stores each ignore entry.

Choosing between the repository-local exclude file and a tracked ignore
file belongs to the block action, which already owns the corresponding
single-file workflow. Browser navigation should only supply marked files.

This PR moves the destination prompt and repository change into the
block-action module and makes the browser delegate every marked block
request.

Interaction and architecture tests now require that delegation without
allowing block actions to depend on browser navigation.
