### PR TITLE
state: Preserve validated metadata in Git-backed batch state

### DIFF
--- a/src/git_stage_batch/batch/binary_file_storage.py
+++ b/src/git_stage_batch/batch/binary_file_storage.py
@@ -74,7 +74,7 @@ def add_binary_file_to_batch(
             "mode": file_mode,
         }
 
-        write_file_backed_batch_metadata(batch_name, metadata)
+        metadata_model = write_file_backed_batch_metadata(batch_name, metadata)
 
         source_buffers = (
             {file_path: current_binary_buffer}
@@ -87,12 +87,14 @@ def add_binary_file_to_batch(
                 file_path,
                 blob_sha,
                 file_mode,
+                metadata=metadata_model,
                 source_buffers=source_buffers,
             )
         else:
             _content_commits.remove_file_from_batch_commit(
                 batch_name,
                 file_path,
+                metadata=metadata_model,
                 source_buffers=source_buffers,
             )
     finally:

--- a/src/git_stage_batch/batch/file_entry_storage.py
+++ b/src/git_stage_batch/batch/file_entry_storage.py
@@ -18,8 +18,12 @@ def remove_file_from_batch(batch_name: str, file_path: str) -> None:
     """Remove a file from batch metadata and batch commit tree."""
     metadata = read_batch_metadata(batch_name)
     metadata.get("files", {}).pop(file_path, None)
-    write_file_backed_batch_metadata(batch_name, metadata)
-    _content_commits.remove_file_from_batch_commit(batch_name, file_path)
+    metadata_model = write_file_backed_batch_metadata(batch_name, metadata)
+    _content_commits.remove_file_from_batch_commit(
+        batch_name,
+        file_path,
+        metadata=metadata_model,
+    )
 
 
 def copy_file_from_batch_to_batch(
@@ -38,22 +42,42 @@ def copy_file_from_batch_to_batch(
         dest_metadata["files"] = {}
     dest_metadata["files"][file_path] = deepcopy(file_meta)
 
-    write_file_backed_batch_metadata(dest_batch, dest_metadata)
+    metadata_model = write_file_backed_batch_metadata(
+        dest_batch,
+        dest_metadata,
+    )
 
     source_commit = get_batch_commit_sha(source_batch)
     if not source_commit:
-        _content_commits.remove_file_from_batch_commit(dest_batch, file_path)
+        _content_commits.remove_file_from_batch_commit(
+            dest_batch,
+            file_path,
+            metadata=metadata_model,
+        )
         return
 
     if file_meta.get("file_type") == "gitlink":
         if file_meta.get("change_type") == "deleted":
-            _content_commits.remove_file_from_batch_commit(dest_batch, file_path)
+            _content_commits.remove_file_from_batch_commit(
+                dest_batch,
+                file_path,
+                metadata=metadata_model,
+            )
             return
         oid = file_meta.get("new_oid")
         if not oid:
-            _content_commits.remove_file_from_batch_commit(dest_batch, file_path)
+            _content_commits.remove_file_from_batch_commit(
+                dest_batch,
+                file_path,
+                metadata=metadata_model,
+            )
             return
-        _content_commits.update_batch_gitlink_commit(dest_batch, file_path, oid)
+        _content_commits.update_batch_gitlink_commit(
+            dest_batch,
+            file_path,
+            oid,
+            metadata=metadata_model,
+        )
         return
 
     source_buffer = read_git_object_buffer_or_none(f"{source_commit}:{file_path}")
@@ -66,9 +90,14 @@ def copy_file_from_batch_to_batch(
             file_path,
             blob_sha,
             file_mode,
+            metadata=metadata_model,
         )
     else:
-        _content_commits.remove_file_from_batch_commit(dest_batch, file_path)
+        _content_commits.remove_file_from_batch_commit(
+            dest_batch,
+            file_path,
+            metadata=metadata_model,
+        )
 
 
 def read_file_from_batch(batch_name: str, file_path: str) -> Optional[str]:

--- a/src/git_stage_batch/batch/file_mode_storage.py
+++ b/src/git_stage_batch/batch/file_mode_storage.py
@@ -39,11 +39,12 @@ def add_file_mode_to_batch(batch_name: str, change: FileModeChange) -> None:
             "presence_claims": [],
             "deletions": [],
         }
-        write_file_backed_batch_metadata(batch_name, metadata)
+        metadata_model = write_file_backed_batch_metadata(batch_name, metadata)
         _content_commits.update_batch_commit(
             batch_name,
             file_path,
             blob_sha,
             change.new_mode,
+            metadata=metadata_model,
             source_buffers={file_path: buffer},
         )

--- a/src/git_stage_batch/batch/gitlink_storage.py
+++ b/src/git_stage_batch/batch/gitlink_storage.py
@@ -33,10 +33,14 @@ def add_gitlink_to_batch(
         "new_oid": gitlink_change.new_oid,
     }
 
-    write_file_backed_batch_metadata(batch_name, metadata)
+    metadata_model = write_file_backed_batch_metadata(batch_name, metadata)
 
     if gitlink_change.is_deleted_file():
-        _content_commits.remove_file_from_batch_commit(batch_name, file_path)
+        _content_commits.remove_file_from_batch_commit(
+            batch_name,
+            file_path,
+            metadata=metadata_model,
+        )
         return
 
     if gitlink_change.new_oid is None:
@@ -48,4 +52,5 @@ def add_gitlink_to_batch(
         batch_name,
         file_path,
         gitlink_change.new_oid,
+        metadata=metadata_model,
     )

--- a/src/git_stage_batch/batch/state/content_commits.py
+++ b/src/git_stage_batch/batch/state/content_commits.py
@@ -12,6 +12,7 @@ from ...utils.git_index import (
     temp_git_index,
 )
 from ...utils.git_object_io import get_git_object_type
+from .metadata_schema import BatchMetadata
 from .query import get_batch_baseline_commit, get_batch_commit_sha
 from .references import read_file_backed_batch_metadata, sync_batch_state_refs
 
@@ -37,6 +38,7 @@ def remove_file_from_batch_commit(
     batch_name: str,
     file_path: str,
     *,
+    metadata: BatchMetadata,
     source_buffers: dict[str, LineBuffer] | None = None,
 ) -> None:
     """Remove a file from a batch content commit tree."""
@@ -58,6 +60,7 @@ def remove_file_from_batch_commit(
 
     sync_batch_state_refs(
         batch_name,
+        metadata,
         content_commit=commit_sha,
         source_buffers=source_buffers,
     )
@@ -69,6 +72,7 @@ def update_batch_commit(
     blob_sha: str,
     file_mode: str,
     *,
+    metadata: BatchMetadata,
     source_buffers: dict[str, LineBuffer] | None = None,
 ) -> None:
     """Update a file entry in a batch content commit tree."""
@@ -93,6 +97,7 @@ def update_batch_commit(
 
     sync_batch_state_refs(
         batch_name,
+        metadata,
         content_commit=commit_sha,
         source_buffers=source_buffers,
     )
@@ -102,6 +107,8 @@ def update_batch_gitlink_commit(
     batch_name: str,
     file_path: str,
     oid: str,
+    *,
+    metadata: BatchMetadata,
 ) -> None:
     """Update a submodule pointer entry in a batch content commit tree."""
     with temp_git_index() as env:
@@ -118,4 +125,4 @@ def update_batch_gitlink_commit(
         message=f"Batch: {batch_name}",
     )
 
-    sync_batch_state_refs(batch_name, content_commit=commit_sha)
+    sync_batch_state_refs(batch_name, metadata, content_commit=commit_sha)

--- a/src/git_stage_batch/batch/state/lifecycle.py
+++ b/src/git_stage_batch/batch/state/lifecycle.py
@@ -43,7 +43,7 @@ def create_batch(name: str, note: str = "", baseline_commit: str | None = None) 
         "baseline": baseline_commit,
         "files": {}
     }
-    write_file_backed_batch_metadata(name, metadata)
+    metadata_model = write_file_backed_batch_metadata(name, metadata)
 
     tree_result = run_git_command(["rev-parse", f"{baseline_commit}^{{tree}}"], requires_index_lock=False)
     tree_sha = tree_result.stdout.strip()
@@ -51,7 +51,7 @@ def create_batch(name: str, note: str = "", baseline_commit: str | None = None) 
     commit_sha = git_commit_tree(tree_sha, parents=parents, message=f"Batch: {name}")
 
     from .references import sync_batch_state_refs
-    sync_batch_state_refs(name, content_commit=commit_sha)
+    sync_batch_state_refs(name, metadata_model, content_commit=commit_sha)
 
 
 def delete_batch(name: str) -> None:
@@ -81,7 +81,7 @@ def update_batch_note(name: str, note: str) -> None:
 
     # Update note
     metadata["note"] = note
-    write_file_backed_batch_metadata(name, metadata)
+    metadata_model = write_file_backed_batch_metadata(name, metadata)
 
     from .references import sync_batch_state_refs
-    sync_batch_state_refs(name)
+    sync_batch_state_refs(name, metadata_model)

--- a/src/git_stage_batch/batch/state/metadata_schema.py
+++ b/src/git_stage_batch/batch/state/metadata_schema.py
@@ -6,12 +6,12 @@ import hashlib
 import json
 import re
 import uuid
-from collections.abc import Mapping
-from dataclasses import dataclass
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, replace
 from datetime import datetime
 from enum import Enum
 from types import MappingProxyType
-from typing import Any, TypeAlias
+from typing import Any, TypeAlias, cast
 
 from ...exceptions import BatchMetadataError
 from ...utils.git_repository import object_id_hex_length
@@ -79,6 +79,27 @@ class BatchFileMetadata:
     def to_dict(self) -> dict[str, Any]:
         return _thaw_mapping(self.values)
 
+    @property
+    def batch_source_commit(self) -> str | None:
+        """Return the validated source commit, when this entry has one."""
+        return cast(str | None, self.values.get("batch_source_commit"))
+
+    @property
+    def mode(self) -> str:
+        """Return the validated Git mode used for stored source content."""
+        mode = self.values.get("mode")
+        return mode if isinstance(mode, str) else "100644"
+
+    def with_source_path(self) -> BatchFileMetadata:
+        """Return this entry with its canonical state-tree source path."""
+        return replace(
+            self,
+            values=MappingProxyType({
+                **self.values,
+                "source_path": f"sources/{self.path}",
+            }),
+        )
+
 
 @dataclass(frozen=True)
 class BatchMetadata:
@@ -116,6 +137,41 @@ class BatchMetadata:
             "content_commit": self.content_commit,
             "files": {entry.path: entry.to_dict() for entry in self.files},
         }
+
+    def for_publication(
+        self,
+        *,
+        content_ref: str,
+        content_commit: str,
+        source_paths: Iterable[str],
+    ) -> BatchMetadata:
+        """Derive a new canonical state-ref model from validated metadata."""
+        if not content_ref:
+            _invalid(self.batch, "'content_ref' must be a non-empty string")
+        _validate_object_id(content_commit, self.batch, "content_commit")
+
+        source_path_set = frozenset(source_paths)
+        file_paths = {entry.path for entry in self.files}
+        unknown_source_paths = source_path_set - file_paths
+        if unknown_source_paths:
+            _invalid(
+                self.batch,
+                "source snapshots reference unknown file(s): "
+                f"{_field_list(unknown_source_paths)}",
+            )
+
+        return replace(
+            self,
+            revision=new_batch_metadata_revision(),
+            files=tuple(
+                entry.with_source_path()
+                if entry.path in source_path_set else
+                entry
+                for entry in self.files
+            ),
+            content_ref=content_ref,
+            content_commit=content_commit,
+        )
 
 
 def new_batch_metadata_revision() -> str:

--- a/src/git_stage_batch/batch/state/references.py
+++ b/src/git_stage_batch/batch/state/references.py
@@ -18,7 +18,6 @@ from .metadata_schema import (
     BatchMetadata,
     decode_batch_metadata,
     encode_batch_metadata,
-    metadata_from_application_dict,
 )
 from .batch_names import validate_batch_name
 from ...exceptions import BatchMetadataError
@@ -208,23 +207,23 @@ def get_authoritative_batch_commit_sha(batch_name: str) -> str | None:
 
 def sync_batch_state_refs(
     batch_name: str,
+    metadata: BatchMetadata,
     *,
     content_commit: str | None = None,
     source_buffers: dict[str, LineBuffer] | None = None,
 ) -> None:
-    """Publish batch metadata and source snapshots into authoritative Git refs."""
+    """Publish validated metadata and source snapshots into authoritative refs."""
     validate_batch_name(batch_name)
+    if metadata.batch != batch_name:
+        raise ValueError(
+            f"Cannot publish metadata for batch '{metadata.batch}' as '{batch_name}'"
+        )
 
     existing_content_commit = get_authoritative_batch_commit_sha(batch_name)
     content_commit = content_commit or existing_content_commit or _legacy_batch_commit_sha(batch_name)
     if not content_commit:
         delete_batch_state_refs(batch_name)
         return
-
-    file_backed_model = read_file_backed_batch_metadata_model(batch_name)
-    if file_backed_model is None:
-        raise ValueError(f"Batch '{batch_name}' has no file-backed metadata to publish")
-    metadata = file_backed_model.to_application_dict()
 
     existing_state_ref = run_git_command(
         ["rev-parse", "--verify", get_batch_state_ref_name(batch_name)],
@@ -242,25 +241,23 @@ def sync_batch_state_refs(
             requires_index_lock=False,
         )
         existing_state_model = _decode_state_metadata(existing_state.stdout, batch_name)
-        if file_backed_model.revision != existing_state_model.revision:
+        if metadata.revision != existing_state_model.revision:
             remove_file_backed_batch_metadata(batch_name)
             raise BatchMetadataError(
                 f"Batch '{batch_name}' changed after its metadata was read. "
                 "Retry the operation against the latest batch state."
             )
 
-    state_files = {}
-
     source_buffers = source_buffers or {}
     buffer_updates: list[_StateBufferUpdate] = []
     managed_buffers: list[LineBuffer] = []
+    published_source_paths: set[str] = set()
 
     try:
         with temp_git_index() as env:
-            for file_path, file_meta in metadata.get("files", {}).items():
-                state_file_meta = dict(file_meta)
-
-                source_commit = file_meta.get("batch_source_commit")
+            for file_metadata in metadata.files:
+                file_path = file_metadata.path
+                source_commit = file_metadata.batch_source_commit
                 if source_commit:
                     source_buffer = source_buffers.get(file_path)
                     if source_buffer is None:
@@ -276,19 +273,15 @@ def sync_batch_state_refs(
                             _StateBufferUpdate(
                                 path=source_path,
                                 data=source_buffer,
-                                mode=file_meta.get("mode", "100644"),
+                                mode=file_metadata.mode,
                             )
                         )
-                        state_file_meta["source_path"] = source_path
+                        published_source_paths.add(file_path)
 
-                state_files[file_path] = state_file_meta
-
-            state_model = metadata_from_application_dict(
-                batch_name,
-                {**metadata, "files": state_files},
+            state_model = metadata.for_publication(
                 content_ref=get_batch_content_ref_name(batch_name),
                 content_commit=content_commit,
-                new_revision=True,
+                source_paths=published_source_paths,
             )
             state_json = encode_batch_metadata(state_model).encode("utf-8")
             buffer_updates.append(_StateBufferUpdate(path="batch.json", data=state_json))

--- a/src/git_stage_batch/batch/text_file_storage.py
+++ b/src/git_stage_batch/batch/text_file_storage.py
@@ -245,7 +245,10 @@ def add_files_to_batch(batch_name: str, updates: list[BatchFileUpdate]) -> None:
                 )
             git_update_index_entries(index_updates, env=env)
 
-            write_file_backed_batch_metadata(batch_name, metadata)
+            metadata_model = write_file_backed_batch_metadata(
+                batch_name,
+                metadata,
+            )
             if batch_sources_changed:
                 save_session_batch_sources(batch_sources)
 
@@ -260,6 +263,7 @@ def add_files_to_batch(batch_name: str, updates: list[BatchFileUpdate]) -> None:
         from .state.references import sync_batch_state_refs
         sync_batch_state_refs(
             batch_name,
+            metadata_model,
             content_commit=commit_sha,
             source_buffers=batch_source_buffers,
         )

--- a/src/git_stage_batch/commands/batch_source/reset_claims.py
+++ b/src/git_stage_batch/commands/batch_source/reset_claims.py
@@ -252,8 +252,8 @@ def reset_all_claims_from_batch(batch_name: str) -> None:
     """Remove all claims from a batch."""
     metadata = read_batch_metadata(batch_name)
     metadata["files"] = {}
-    write_file_backed_batch_metadata(batch_name, metadata)
-    sync_batch_state_refs(batch_name)
+    metadata_model = write_file_backed_batch_metadata(batch_name, metadata)
+    sync_batch_state_refs(batch_name, metadata_model)
 
 
 def _ensure_destination_batch(

--- a/src/git_stage_batch/commands/batch_transform/sift_persistence.py
+++ b/src/git_stage_batch/commands/batch_transform/sift_persistence.py
@@ -124,13 +124,14 @@ def add_sifted_text_file_to_batch(
         file_metadata["change_type"] = text_change_type.value
     metadata["files"][file_path] = file_metadata
 
-    write_file_backed_batch_metadata(batch_name, metadata)
+    metadata_model = write_file_backed_batch_metadata(batch_name, metadata)
 
     source_buffers = {file_path: target_buffer}
     if text_change_type == TextFileChangeType.DELETED:
         remove_file_from_batch_commit(
             batch_name,
             file_path,
+            metadata=metadata_model,
             source_buffers=source_buffers,
         )
     else:
@@ -139,6 +140,7 @@ def add_sifted_text_file_to_batch(
             file_path,
             target_blob_sha,
             file_mode,
+            metadata=metadata_model,
             source_buffers=source_buffers,
         )
 
@@ -247,10 +249,14 @@ def publish_sifted_files(
         )
         if replace_existing and source_metadata.get("created_at"):
             temp_metadata["created_at"] = source_metadata["created_at"]
-        write_file_backed_batch_metadata(destination_batch, temp_metadata)
+        metadata_model = write_file_backed_batch_metadata(
+            destination_batch,
+            temp_metadata,
+        )
         destination_metadata_written = True
         sync_batch_state_refs(
             destination_batch,
+            metadata_model,
             content_commit=commit_sha,
             source_buffers=_source_buffers_from_sift_results(retained_files),
         )

--- a/src/git_stage_batch/data/batch_refs.py
+++ b/src/git_stage_batch/data/batch_refs.py
@@ -124,5 +124,12 @@ def restore_batch_refs() -> None:
             )
             remove_file_backed_batch_metadata(batch_name)
         else:
-            write_file_backed_batch_metadata(batch_name, full_metadata)
-            sync_batch_state_refs(batch_name, content_commit=commit_sha)
+            metadata_model = write_file_backed_batch_metadata(
+                batch_name,
+                full_metadata,
+            )
+            sync_batch_state_refs(
+                batch_name,
+                metadata_model,
+                content_commit=commit_sha,
+            )

--- a/tests/architecture/test_seam_rules.py
+++ b/tests/architecture/test_seam_rules.py
@@ -120,6 +120,24 @@ def test_atomic_buffer_publication_stays_out_of_core():
     }
 
 
+def test_batch_state_publication_consumes_validated_metadata():
+    """State publication accepts the schema model without thawing it first."""
+    publication_symbols = {"sync_batch_state_refs"}
+    assert modules_defining(publication_symbols) == {
+        "git_stage_batch.batch.state.references": publication_symbols,
+    }
+
+    schema_imports = {
+        name
+        for edge in internal_import_edges()
+        if edge.source == "git_stage_batch.batch.state.references"
+        and edge.target == "git_stage_batch.batch.state.metadata_schema"
+        for name in edge.names
+    }
+    assert "BatchMetadata" in schema_imports
+    assert "metadata_from_application_dict" not in schema_imports
+
+
 def test_undo_checkpoint_orchestration_delegates_state_policy():
     """Stack orchestration must not absorb snapshot or restore policy."""
     snapshot_symbols = {

--- a/tests/batch/state/test_metadata_schema.py
+++ b/tests/batch/state/test_metadata_schema.py
@@ -64,6 +64,25 @@ def test_v1_round_trip_is_deterministic_and_immutable():
         model.files[0].values["mode"] = "100755"  # type: ignore[index]
 
 
+def test_publication_derives_a_new_immutable_model():
+    model = decode_batch_metadata(_v1_metadata(), expected_batch="feature")
+
+    published = model.for_publication(
+        content_ref="refs/git-stage-batch/batches/feature",
+        content_commit=_oid("d"),
+        source_paths={"src/example.py"},
+    )
+
+    assert published.revision != model.revision
+    assert published.content_commit == _oid("d")
+    assert published.files[0].batch_source_commit == _oid("c")
+    assert published.files[0].mode == "100644"
+    assert published.files[0].values["source_path"] == "sources/src/example.py"
+    assert "source_path" not in model.files[0].values
+    with pytest.raises(TypeError):
+        published.files[0].values["source_path"] = "other"  # type: ignore[index]
+
+
 def test_unversioned_state_metadata_migrates_deterministically():
     legacy = {
         "batch": "feature",

--- a/tests/batch/state/test_references.py
+++ b/tests/batch/state/test_references.py
@@ -114,6 +114,33 @@ def test_state_ref_contains_batch_json_and_source_snapshot(temp_git_repo):
     assert source_content == "line1\nline2\nline3\n"
 
 
+def test_state_publication_consumes_validated_metadata_model(
+    temp_git_repo,
+    monkeypatch,
+):
+    """Publication should not thaw validated metadata back into application dicts."""
+    create_batch("test-batch", "Before")
+    metadata = read_batch_metadata("test-batch")
+    metadata["note"] = "After"
+    metadata_model = write_file_backed_batch_metadata("test-batch", metadata)
+
+    def fail_to_application_dict(_metadata):
+        raise AssertionError("publication must consume the validated model")
+
+    monkeypatch.setattr(
+        type(metadata_model),
+        "to_application_dict",
+        fail_to_application_dict,
+    )
+
+    sync_batch_state_refs("test-batch", metadata_model)
+
+    batch_json = json.loads(
+        _git_show(f"{get_batch_state_ref_name('test-batch')}:batch.json")
+    )
+    assert batch_json["note"] == "After"
+
+
 def test_stale_metadata_writer_cannot_replace_newer_state(temp_git_repo):
     create_batch("test-batch", "Original")
     stale_metadata = read_batch_metadata("test-batch")
@@ -121,10 +148,13 @@ def test_stale_metadata_writer_cannot_replace_newer_state(temp_git_repo):
     current_state = _git_rev_parse(get_batch_state_ref_name("test-batch"))
 
     stale_metadata["note"] = "Stale"
-    write_file_backed_batch_metadata("test-batch", stale_metadata)
+    stale_model = write_file_backed_batch_metadata(
+        "test-batch",
+        stale_metadata,
+    )
 
     with pytest.raises(BatchMetadataError, match="changed after its metadata was read"):
-        sync_batch_state_refs("test-batch")
+        sync_batch_state_refs("test-batch", stale_model)
 
     assert _git_rev_parse(get_batch_state_ref_name("test-batch")) == current_state
     assert read_batch_metadata("test-batch")["note"] == "Current"


### PR DESCRIPTION
Saved batch JSON is validated into an immutable BatchMetadata value before
batch writers update file-backed and Git-backed state.

The Git-backed state updater reloads the metadata file as a mutable
dictionary and validates it again. That round trip discards the checked
value already held by each writer and permits unchecked conversion inside
the update path.

This PR adds immutable derivation of Git-backed metadata and passes
validated BatchMetadata values directly from every batch writer into
reference updates.

Schema, state, and architecture tests now cover immutable derivation, stale
writers, direct validated handoff, and the absence of mutable conversion.
