### PR TITLE
batch-source: Share candidate preview construction

### DIFF
--- a/src/git_stage_batch/commands/batch_source/candidate_materialization.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_materialization.py
@@ -6,15 +6,13 @@ from contextlib import ExitStack
 from dataclasses import dataclass
 
 from . import candidate_inputs as _candidate_inputs
+from . import candidate_planning as _candidate_planning
 from . import candidate_previews as _candidate_previews
 from ...batch.operation_candidate_types import (
     OperationCandidatePreview,
     TargetCandidatePreview,
 )
-from ...batch.operation_candidates import (
-    build_apply_candidate_previews,
-    build_include_candidate_previews,
-)
+from ...batch.operation_candidates import build_include_candidate_previews
 from ...batch.replacement import build_replacement_batch_view_from_lines
 from ...batch.selection import acquire_batch_ownership_for_display_ids_from_lines
 from ...core.buffer import LineBuffer
@@ -104,46 +102,38 @@ def materialize_apply_candidate(
         batch_source_buffer as batch_source_lines,
         load_working_tree_file_as_buffer(file_path) as working_lines,
     ):
-        with acquire_batch_ownership_for_display_ids_from_lines(
-            file_meta,
-            batch_source_lines,
-            selection_ids_to_apply,
-        ) as ownership:
-            try:
-                previews = build_apply_candidate_previews(
-                    batch_name=batch_name,
-                    file_path=file_path,
-                    source_lines=batch_source_lines,
-                    ownership=ownership,
-                    worktree_lines=working_lines,
-                    batch_source_commit=batch_source_ref.commit,
-                    file_meta=file_meta,
-                    text_change_type=worktree_target.text_change_type,
-                    worktree_file_mode=worktree_target.file_mode,
-                    worktree_exists=worktree_target.exists,
-                    selected_ids=selected_ids,
-                    selection_ids=selection_ids_to_apply,
-                )
-            except MergeError as e:
-                exit_with_error(str(e))
+        try:
+            previews = _candidate_planning.plan_apply_candidate_previews(
+                batch_name=batch_name,
+                file_path=file_path,
+                file_meta=file_meta,
+                batch_source_lines=batch_source_lines,
+                batch_source_commit=batch_source_ref.commit,
+                worktree_lines=working_lines,
+                worktree_target=worktree_target,
+                selected_ids=selected_ids,
+                selection_ids=selection_ids_to_apply,
+            )
+        except MergeError as e:
+            exit_with_error(str(e))
 
-            try:
-                preview = _candidate_previews.require_candidate_preview_for_ordinal(
-                    previews,
-                    ordinal,
-                    batch_name=batch_name,
-                    operation="apply",
-                    file_path=file_path,
-                )
-                _candidate_previews.require_candidate_preview_state(
-                    preview,
-                    ordinal,
-                    selector=raw_selector,
-                    file_path=file_path,
-                )
-            except Exception:
-                _candidate_previews.close_candidate_previews(previews)
-                raise
+        try:
+            preview = _candidate_previews.require_candidate_preview_for_ordinal(
+                previews,
+                ordinal,
+                batch_name=batch_name,
+                operation="apply",
+                file_path=file_path,
+            )
+            _candidate_previews.require_candidate_preview_state(
+                preview,
+                ordinal,
+                selector=raw_selector,
+                file_path=file_path,
+            )
+        except Exception:
+            _candidate_previews.close_candidate_previews(previews)
+            raise
 
     return ApplyCandidateMaterialization(
         preview=preview,

--- a/src/git_stage_batch/commands/batch_source/candidate_materialization.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_materialization.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from contextlib import ExitStack
 from dataclasses import dataclass
 
 from . import candidate_inputs as _candidate_inputs
@@ -12,9 +11,6 @@ from ...batch.operation_candidate_types import (
     OperationCandidatePreview,
     TargetCandidatePreview,
 )
-from ...batch.operation_candidates import build_include_candidate_previews
-from ...batch.replacement import build_replacement_batch_view_from_lines
-from ...batch.selection import acquire_batch_ownership_for_display_ids_from_lines
 from ...core.buffer import LineBuffer
 from ...core.replacement import ReplacementPayload
 from ...utils.repository_buffers import (
@@ -192,65 +188,41 @@ def materialize_include_candidate(
         index_buffer as index_lines,
         load_working_tree_file_as_buffer(file_path) as working_lines,
     ):
-        with acquire_batch_ownership_for_display_ids_from_lines(
-            file_meta,
-            batch_source_lines,
-            selection_ids_to_include,
-        ) as ownership:
-            with ExitStack() as stack:
-                source_for_candidates = batch_source_lines
-                candidate_ownership = ownership
-                if replacement_payload is not None:
-                    try:
-                        replacement_view = build_replacement_batch_view_from_lines(
-                            batch_source_lines,
-                            ownership,
-                            replacement_payload,
-                        )
-                    except ValueError as e:
-                        exit_with_error(str(e))
-                    replacement_view = stack.enter_context(replacement_view)
-                    source_for_candidates = replacement_view.source_buffer
-                    candidate_ownership = replacement_view.ownership
-                try:
-                    previews = build_include_candidate_previews(
-                        batch_name=batch_name,
-                        file_path=file_path,
-                        source_lines=source_for_candidates,
-                        ownership=candidate_ownership,
-                        index_lines=index_lines,
-                        worktree_lines=working_lines,
-                        batch_source_commit=batch_source_ref.commit,
-                        file_meta=file_meta,
-                        text_change_type=worktree_target.text_change_type,
-                        index_file_mode=index_target.file_mode,
-                        worktree_file_mode=worktree_target.file_mode,
-                        index_exists=index_target.exists,
-                        worktree_exists=worktree_target.exists,
-                        selected_ids=selected_ids,
-                        selection_ids=selection_ids_to_include,
-                        replacement_payload=replacement_payload,
-                    )
-                except (MergeError, ValueError) as e:
-                    exit_with_error(str(e))
+        try:
+            previews = _candidate_planning.plan_include_candidate_previews(
+                batch_name=batch_name,
+                file_path=file_path,
+                file_meta=file_meta,
+                batch_source_lines=batch_source_lines,
+                batch_source_commit=batch_source_ref.commit,
+                index_lines=index_lines,
+                index_target=index_target,
+                worktree_lines=working_lines,
+                worktree_target=worktree_target,
+                selected_ids=selected_ids,
+                selection_ids=selection_ids_to_include,
+                replacement_payload=replacement_payload,
+            )
+        except (MergeError, ValueError) as e:
+            exit_with_error(str(e))
 
-            try:
-                preview = _candidate_previews.require_candidate_preview_for_ordinal(
-                    previews,
-                    ordinal,
-                    batch_name=batch_name,
-                    operation="include",
-                    file_path=file_path,
-                )
-                _candidate_previews.require_candidate_preview_state(
-                    preview,
-                    ordinal,
-                    selector=raw_selector,
-                    file_path=file_path,
-                )
-            except Exception:
-                _candidate_previews.close_candidate_previews(previews)
-                raise
+        try:
+            preview = _candidate_previews.require_candidate_preview_for_ordinal(
+                previews,
+                ordinal,
+                batch_name=batch_name,
+                operation="include",
+                file_path=file_path,
+            )
+            _candidate_previews.require_candidate_preview_state(
+                preview,
+                ordinal,
+                selector=raw_selector,
+                file_path=file_path,
+            )
+        except Exception:
+            _candidate_previews.close_candidate_previews(previews)
+            raise
 
     return IncludeCandidateMaterialization(
         preview=preview,

--- a/src/git_stage_batch/commands/batch_source/candidate_planning.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_planning.py
@@ -2,15 +2,23 @@
 
 from __future__ import annotations
 
+from contextlib import ExitStack
 from pathlib import Path
 
 from . import candidate_inputs as _candidate_inputs
 from ...batch.operation_candidate_types import OperationCandidatePreview
 from ...batch.operation_candidates import (
     build_apply_candidate_previews as _build_apply_candidate_previews,
+    build_include_candidate_previews as _build_include_candidate_previews,
 )
+from ...batch.replacement import build_replacement_batch_view_from_lines
 from ...batch.selection import acquire_batch_ownership_for_display_ids_from_lines
 from ...core.buffer import LineBuffer
+from ...core.replacement import ReplacementPayload
+
+
+class CandidateReplacementError(ValueError):
+    """Raised when replacement input cannot form a candidate source view."""
 
 
 def plan_apply_candidate_previews(
@@ -48,6 +56,70 @@ def plan_apply_candidate_previews(
             selected_ids=selected_ids,
             selection_ids=selection_ids,
             **ownership_arguments,
+        )
+
+
+def plan_include_candidate_previews(
+    *,
+    batch_name: str,
+    file_path: str,
+    file_meta: dict,
+    batch_source_lines: LineBuffer,
+    batch_source_commit: str,
+    index_lines: LineBuffer,
+    index_target: _candidate_inputs.CandidateIndexTarget,
+    worktree_lines: LineBuffer,
+    worktree_target: _candidate_inputs.CandidateWorktreeTarget,
+    selected_ids: set[int] | None,
+    selection_ids: set[int] | None,
+    replacement_payload: ReplacementPayload | None,
+    spool_dir: str | Path | None = None,
+) -> tuple[OperationCandidatePreview, ...]:
+    """Build include previews from normalized source and target inputs."""
+    spool_arguments = _spool_arguments(spool_dir)
+    with ExitStack() as stack:
+        ownership = stack.enter_context(
+            acquire_batch_ownership_for_display_ids_from_lines(
+                file_meta,
+                batch_source_lines,
+                selection_ids,
+                **spool_arguments,
+            )
+        )
+        source_for_candidates = batch_source_lines
+        candidate_ownership = ownership
+        if replacement_payload is not None:
+            try:
+                replacement_view = build_replacement_batch_view_from_lines(
+                    batch_source_lines,
+                    ownership,
+                    replacement_payload,
+                    **spool_arguments,
+                )
+            except ValueError as error:
+                raise CandidateReplacementError(str(error)) from error
+            replacement_view = stack.enter_context(replacement_view)
+            source_for_candidates = replacement_view.source_buffer
+            candidate_ownership = replacement_view.ownership
+
+        return _build_include_candidate_previews(
+            batch_name=batch_name,
+            file_path=file_path,
+            source_lines=source_for_candidates,
+            ownership=candidate_ownership,
+            index_lines=index_lines,
+            worktree_lines=worktree_lines,
+            batch_source_commit=batch_source_commit,
+            file_meta=file_meta,
+            text_change_type=worktree_target.text_change_type,
+            index_file_mode=index_target.file_mode,
+            worktree_file_mode=worktree_target.file_mode,
+            index_exists=index_target.exists,
+            worktree_exists=worktree_target.exists,
+            selected_ids=selected_ids,
+            selection_ids=selection_ids,
+            replacement_payload=replacement_payload,
+            **spool_arguments,
         )
 
 

--- a/src/git_stage_batch/commands/batch_source/candidate_planning.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_planning.py
@@ -1,0 +1,57 @@
+"""Shared operation-candidate planning for batch-source commands."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from . import candidate_inputs as _candidate_inputs
+from ...batch.operation_candidate_types import OperationCandidatePreview
+from ...batch.operation_candidates import (
+    build_apply_candidate_previews as _build_apply_candidate_previews,
+)
+from ...batch.selection import acquire_batch_ownership_for_display_ids_from_lines
+from ...core.buffer import LineBuffer
+
+
+def plan_apply_candidate_previews(
+    *,
+    batch_name: str,
+    file_path: str,
+    file_meta: dict,
+    batch_source_lines: LineBuffer,
+    batch_source_commit: str,
+    worktree_lines: LineBuffer,
+    worktree_target: _candidate_inputs.CandidateWorktreeTarget,
+    selected_ids: set[int] | None,
+    selection_ids: set[int] | None,
+    spool_dir: str | Path | None = None,
+) -> tuple[OperationCandidatePreview, ...]:
+    """Build apply previews from normalized source and target inputs."""
+    ownership_arguments = _spool_arguments(spool_dir)
+    with acquire_batch_ownership_for_display_ids_from_lines(
+        file_meta,
+        batch_source_lines,
+        selection_ids,
+        **ownership_arguments,
+    ) as ownership:
+        return _build_apply_candidate_previews(
+            batch_name=batch_name,
+            file_path=file_path,
+            source_lines=batch_source_lines,
+            ownership=ownership,
+            worktree_lines=worktree_lines,
+            batch_source_commit=batch_source_commit,
+            file_meta=file_meta,
+            text_change_type=worktree_target.text_change_type,
+            worktree_file_mode=worktree_target.file_mode,
+            worktree_exists=worktree_target.exists,
+            selected_ids=selected_ids,
+            selection_ids=selection_ids,
+            **ownership_arguments,
+        )
+
+
+def _spool_arguments(spool_dir: str | Path | None) -> dict[str, str | Path]:
+    if spool_dir is None:
+        return {}
+    return {"spool_dir": spool_dir}

--- a/src/git_stage_batch/commands/batch_source/candidate_preview_builders.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_preview_builders.py
@@ -3,16 +3,12 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from contextlib import ExitStack
 from typing import Any
 
 from . import candidate_inputs as _candidate_inputs
 from . import candidate_planning as _candidate_planning
 from ..selection import replacement_selection
 from ...batch.operation_candidate_types import OperationCandidatePreview
-from ...batch.operation_candidates import build_include_candidate_previews
-from ...batch.replacement import build_replacement_batch_view_from_lines
-from ...batch.selection import acquire_batch_ownership_for_display_ids_from_lines
 from ...batch.source.selector import BatchSourceSelector
 from ...core.buffer import LineBuffer
 from ...core.replacement import ReplacementPayload, coerce_replacement_payload
@@ -114,55 +110,33 @@ def build_batch_source_candidate_previews(
                     selection_ids=selection_ids_to_apply,
                 )
 
-        with acquire_batch_ownership_for_display_ids_from_lines(
-            file_meta,
-            batch_source_lines,
-            selection_ids_to_apply,
-        ) as ownership:
-            with ExitStack() as stack:
-                source_for_candidates = batch_source_lines
-                candidate_ownership = ownership
-                if replacement_payload is not None:
-                    try:
-                        replacement_view = build_replacement_batch_view_from_lines(
-                            batch_source_lines,
-                            ownership,
-                            replacement_payload,
-                        )
-                    except ValueError as e:
-                        exit_with_error(str(e))
-                    replacement_view = stack.enter_context(replacement_view)
-                    source_for_candidates = replacement_view.source_buffer
-                    candidate_ownership = replacement_view.ownership
-
-                index_buffer = read_git_object_buffer_or_none(f":{file_path}")
-                index_exists = index_buffer is not None
-                if index_buffer is None:
-                    index_buffer = LineBuffer.from_bytes(b"")
-                index_target = _candidate_inputs.candidate_index_text_target(
+        index_buffer = read_git_object_buffer_or_none(f":{file_path}")
+        index_exists = index_buffer is not None
+        if index_buffer is None:
+            index_buffer = LineBuffer.from_bytes(b"")
+        index_target = _candidate_inputs.candidate_index_text_target(
+            file_meta=file_meta,
+            selected_ids=selected_ids,
+            index_exists=index_exists,
+        )
+        with (
+            index_buffer as index_lines,
+            load_working_tree_file_as_buffer(file_path) as working_lines,
+        ):
+            try:
+                return _candidate_planning.plan_include_candidate_previews(
+                    batch_name=selector.batch_name,
+                    file_path=file_path,
                     file_meta=file_meta,
+                    batch_source_lines=batch_source_lines,
+                    batch_source_commit=batch_source_ref.commit,
+                    index_lines=index_lines,
+                    index_target=index_target,
+                    worktree_lines=working_lines,
+                    worktree_target=worktree_target,
                     selected_ids=selected_ids,
-                    index_exists=index_exists,
+                    selection_ids=selection_ids_to_apply,
+                    replacement_payload=replacement_payload,
                 )
-                with (
-                    index_buffer as index_lines,
-                    load_working_tree_file_as_buffer(file_path) as working_lines,
-                ):
-                    return build_include_candidate_previews(
-                        batch_name=selector.batch_name,
-                        file_path=file_path,
-                        source_lines=source_for_candidates,
-                        ownership=candidate_ownership,
-                        index_lines=index_lines,
-                        worktree_lines=working_lines,
-                        batch_source_commit=batch_source_ref.commit,
-                        file_meta=file_meta,
-                        text_change_type=worktree_target.text_change_type,
-                        index_file_mode=index_target.file_mode,
-                        worktree_file_mode=worktree_target.file_mode,
-                        index_exists=index_target.exists,
-                        worktree_exists=worktree_target.exists,
-                        selected_ids=selected_ids,
-                        selection_ids=selection_ids_to_apply,
-                        replacement_payload=replacement_payload,
-                    )
+            except _candidate_planning.CandidateReplacementError as e:
+                exit_with_error(str(e))

--- a/src/git_stage_batch/commands/batch_source/candidate_preview_builders.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_preview_builders.py
@@ -7,12 +7,10 @@ from contextlib import ExitStack
 from typing import Any
 
 from . import candidate_inputs as _candidate_inputs
+from . import candidate_planning as _candidate_planning
 from ..selection import replacement_selection
 from ...batch.operation_candidate_types import OperationCandidatePreview
-from ...batch.operation_candidates import (
-    build_apply_candidate_previews,
-    build_include_candidate_previews,
-)
+from ...batch.operation_candidates import build_include_candidate_previews
 from ...batch.replacement import build_replacement_batch_view_from_lines
 from ...batch.selection import acquire_batch_ownership_for_display_ids_from_lines
 from ...batch.source.selector import BatchSourceSelector
@@ -89,6 +87,33 @@ def build_batch_source_candidate_previews(
                 action,
             )
 
+        replacement_payload = None
+        if replacement_text is not None:
+            if operation == "apply":
+                exit_with_error(
+                    _("Replacement preview is not valid for apply candidates.")
+                )
+            if not selected_ids:
+                exit_with_error(_("`show --from --as` requires `--line`."))
+            replacement_selection.require_contiguous_display_selection(
+                selected_ids,
+            )
+            replacement_payload = coerce_replacement_payload(replacement_text)
+
+        if operation == "apply":
+            with load_working_tree_file_as_buffer(file_path) as working_lines:
+                return _candidate_planning.plan_apply_candidate_previews(
+                    batch_name=selector.batch_name,
+                    file_path=file_path,
+                    file_meta=file_meta,
+                    batch_source_lines=batch_source_lines,
+                    batch_source_commit=batch_source_ref.commit,
+                    worktree_lines=working_lines,
+                    worktree_target=worktree_target,
+                    selected_ids=selected_ids,
+                    selection_ids=selection_ids_to_apply,
+                )
+
         with acquire_batch_ownership_for_display_ids_from_lines(
             file_meta,
             batch_source_lines,
@@ -97,18 +122,7 @@ def build_batch_source_candidate_previews(
             with ExitStack() as stack:
                 source_for_candidates = batch_source_lines
                 candidate_ownership = ownership
-                replacement_payload = None
-                if replacement_text is not None:
-                    if operation == "apply":
-                        exit_with_error(
-                            _("Replacement preview is not valid for apply candidates.")
-                        )
-                    if not selected_ids:
-                        exit_with_error(_("`show --from --as` requires `--line`."))
-                    replacement_selection.require_contiguous_display_selection(
-                        selected_ids,
-                    )
-                    replacement_payload = coerce_replacement_payload(replacement_text)
+                if replacement_payload is not None:
                     try:
                         replacement_view = build_replacement_batch_view_from_lines(
                             batch_source_lines,
@@ -120,23 +134,6 @@ def build_batch_source_candidate_previews(
                     replacement_view = stack.enter_context(replacement_view)
                     source_for_candidates = replacement_view.source_buffer
                     candidate_ownership = replacement_view.ownership
-
-                if operation == "apply":
-                    with load_working_tree_file_as_buffer(file_path) as working_lines:
-                        return build_apply_candidate_previews(
-                            batch_name=selector.batch_name,
-                            file_path=file_path,
-                            source_lines=source_for_candidates,
-                            ownership=candidate_ownership,
-                            worktree_lines=working_lines,
-                            batch_source_commit=batch_source_ref.commit,
-                            file_meta=file_meta,
-                            text_change_type=worktree_target.text_change_type,
-                            worktree_file_mode=worktree_target.file_mode,
-                            worktree_exists=worktree_target.exists,
-                            selected_ids=selected_ids,
-                            selection_ids=selection_ids_to_apply,
-                        )
 
                 index_buffer = read_git_object_buffer_or_none(f":{file_path}")
                 index_exists = index_buffer is not None

--- a/src/git_stage_batch/commands/batch_source/candidate_preview_counts.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_preview_counts.py
@@ -12,9 +12,6 @@ from ...batch.operation_candidate_types import (
     CandidateEnumerationLimitError,
     CandidatePreviewCount,
 )
-from ...batch.operation_candidates import build_include_candidate_previews
-from ...batch.replacement import build_replacement_batch_view_from_lines
-from ...batch.selection import acquire_batch_ownership_for_display_ids_from_lines
 from ...core.buffer import LineBuffer
 from ...core.replacement import ReplacementPayload
 from ...data.file_target_identity import IndexIdentity
@@ -195,54 +192,20 @@ def count_include_candidate_previews_for_file(
                     spool_dir=spool_dir,
                 )
             working_lines = stack.enter_context(working_buffer)
-            ownership_arguments = {}
-            if spool_dir is not None:
-                ownership_arguments["spool_dir"] = spool_dir
-            ownership = stack.enter_context(
-                acquire_batch_ownership_for_display_ids_from_lines(
-                    file_meta,
-                    batch_source_lines,
-                    selection_ids_to_include,
-                    **ownership_arguments,
-                )
-            )
-            source_for_candidates = batch_source_lines
-            candidate_ownership = ownership
-            if replacement_payload is not None:
-                replacement_arguments = {}
-                if spool_dir is not None:
-                    replacement_arguments["spool_dir"] = spool_dir
-                replacement_view = stack.enter_context(
-                    build_replacement_batch_view_from_lines(
-                        batch_source_lines,
-                        ownership,
-                        replacement_payload,
-                        **replacement_arguments,
-                    )
-                )
-                source_for_candidates = replacement_view.source_buffer
-                candidate_ownership = replacement_view.ownership
-            preview_arguments = {}
-            if spool_dir is not None:
-                preview_arguments["spool_dir"] = spool_dir
-            previews = build_include_candidate_previews(
+            previews = _candidate_planning.plan_include_candidate_previews(
                 batch_name=batch_name,
                 file_path=file_path,
-                source_lines=source_for_candidates,
-                ownership=candidate_ownership,
-                index_lines=index_lines,
-                worktree_lines=working_lines,
-                batch_source_commit=batch_source_ref.commit,
                 file_meta=file_meta,
-                text_change_type=worktree_target.text_change_type,
-                index_file_mode=index_target.file_mode,
-                worktree_file_mode=worktree_target.file_mode,
-                index_exists=index_target.exists,
-                worktree_exists=worktree_target.exists,
+                batch_source_lines=batch_source_lines,
+                batch_source_commit=batch_source_ref.commit,
+                index_lines=index_lines,
+                index_target=index_target,
+                worktree_lines=working_lines,
+                worktree_target=worktree_target,
                 selected_ids=selection_ids_to_include,
                 selection_ids=selection_ids_to_include,
                 replacement_payload=replacement_payload,
-                **preview_arguments,
+                spool_dir=spool_dir,
             )
             try:
                 return CandidatePreviewCount(count=len(previews))

--- a/src/git_stage_batch/commands/batch_source/candidate_preview_counts.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_preview_counts.py
@@ -6,15 +6,13 @@ from contextlib import ExitStack
 from pathlib import Path
 
 from . import candidate_inputs as _candidate_inputs
+from . import candidate_planning as _candidate_planning
 from . import candidate_previews as _candidate_previews
 from ...batch.operation_candidate_types import (
     CandidateEnumerationLimitError,
     CandidatePreviewCount,
 )
-from ...batch.operation_candidates import (
-    build_apply_candidate_previews,
-    build_include_candidate_previews,
-)
+from ...batch.operation_candidates import build_include_candidate_previews
 from ...batch.replacement import build_replacement_batch_view_from_lines
 from ...batch.selection import acquire_batch_ownership_for_display_ids_from_lines
 from ...core.buffer import LineBuffer
@@ -89,34 +87,17 @@ def count_apply_candidate_previews_for_file(
                     spool_dir=spool_dir,
                 )
             working_lines = stack.enter_context(working_tree_buffer)
-            ownership_arguments = {}
-            if spool_dir is not None:
-                ownership_arguments["spool_dir"] = spool_dir
-            ownership = stack.enter_context(
-                acquire_batch_ownership_for_display_ids_from_lines(
-                    file_meta,
-                    batch_source_lines,
-                    selection_ids_to_apply,
-                    **ownership_arguments,
-                )
-            )
-            preview_arguments = {}
-            if spool_dir is not None:
-                preview_arguments["spool_dir"] = spool_dir
-            previews = build_apply_candidate_previews(
+            previews = _candidate_planning.plan_apply_candidate_previews(
                 batch_name=batch_name,
                 file_path=file_path,
-                source_lines=batch_source_lines,
-                ownership=ownership,
-                worktree_lines=working_lines,
-                batch_source_commit=batch_source_ref.commit,
                 file_meta=file_meta,
-                text_change_type=worktree_target.text_change_type,
-                worktree_file_mode=worktree_target.file_mode,
-                worktree_exists=worktree_target.exists,
+                batch_source_lines=batch_source_lines,
+                batch_source_commit=batch_source_ref.commit,
+                worktree_lines=working_lines,
+                worktree_target=worktree_target,
                 selected_ids=selection_ids_to_apply,
                 selection_ids=selection_ids_to_apply,
-                **preview_arguments,
+                spool_dir=spool_dir,
             )
             try:
                 return CandidatePreviewCount(count=len(previews))

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -13171,6 +13171,12 @@ def test_operation_candidate_types_own_preview_records():
         SRC_ROOT
         / "commands"
         / "batch_source"
+        / "candidate_planning.py": {
+            "OperationCandidatePreview",
+        },
+        SRC_ROOT
+        / "commands"
+        / "batch_source"
         / "candidate_preview_builders.py": {
             "OperationCandidatePreview",
         },
@@ -14651,6 +14657,7 @@ def test_batch_source_candidate_materialization_owns_reviewed_candidate_loading(
         for path in preview_free_paths
     }
     materialization_imports_candidate_previews = False
+    materialization_imports_candidate_planning = False
     materialization_builder_imports = set()
 
     for path in preview_free_paths:
@@ -14677,6 +14684,11 @@ def test_batch_source_candidate_materialization_owns_reviewed_candidate_loading(
             and "candidate_previews" in imported_names
         ):
             materialization_imports_candidate_previews = True
+        if (
+            imported_module == "git_stage_batch.commands.batch_source"
+            and "candidate_planning" in imported_names
+        ):
+            materialization_imports_candidate_planning = True
         if imported_module == "git_stage_batch.batch.operation_candidates":
             materialization_builder_imports |= imported_names & builder_names
 
@@ -14695,7 +14707,10 @@ def test_batch_source_candidate_materialization_owns_reviewed_candidate_loading(
         include_from_path: set(),
     }
     assert materialization_imports_candidate_previews
-    assert materialization_builder_imports == builder_names
+    assert materialization_imports_candidate_planning
+    assert materialization_builder_imports == {
+        "build_include_candidate_previews",
+    }
 
     for path in preview_free_paths:
         command_text = path.read_text()

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -14708,9 +14708,7 @@ def test_batch_source_candidate_materialization_owns_reviewed_candidate_loading(
     }
     assert materialization_imports_candidate_previews
     assert materialization_imports_candidate_planning
-    assert materialization_builder_imports == {
-        "build_include_candidate_previews",
-    }
+    assert materialization_builder_imports == set()
 
     for path in preview_free_paths:
         command_text = path.read_text()

--- a/tests/architecture/test_seam_rules.py
+++ b/tests/architecture/test_seam_rules.py
@@ -138,6 +138,30 @@ def test_batch_state_publication_consumes_validated_metadata():
     assert "metadata_from_application_dict" not in schema_imports
 
 
+def test_batch_source_candidate_planning_has_one_owner():
+    """Show, count, and execution paths share candidate construction policy."""
+    planning_symbols = {
+        "plan_apply_candidate_previews",
+    }
+    planning_module = (
+        "git_stage_batch.commands.batch_source.candidate_planning"
+    )
+    assert modules_defining(planning_symbols) == {
+        planning_module: planning_symbols,
+    }
+
+    consumers = {
+        edge.source
+        for edge in internal_module_import_edges()
+        if edge.target == planning_module
+    }
+    assert consumers == {
+        "git_stage_batch.commands.batch_source.candidate_materialization",
+        "git_stage_batch.commands.batch_source.candidate_preview_builders",
+        "git_stage_batch.commands.batch_source.candidate_preview_counts",
+    }
+
+
 def test_undo_checkpoint_orchestration_delegates_state_policy():
     """Stack orchestration must not absorb snapshot or restore policy."""
     snapshot_symbols = {

--- a/tests/architecture/test_seam_rules.py
+++ b/tests/architecture/test_seam_rules.py
@@ -142,6 +142,7 @@ def test_batch_source_candidate_planning_has_one_owner():
     """Show, count, and execution paths share candidate construction policy."""
     planning_symbols = {
         "plan_apply_candidate_previews",
+        "plan_include_candidate_previews",
     }
     planning_module = (
         "git_stage_batch.commands.batch_source.candidate_planning"
@@ -149,6 +150,16 @@ def test_batch_source_candidate_planning_has_one_owner():
     assert modules_defining(planning_symbols) == {
         planning_module: planning_symbols,
     }
+
+    rules = (
+        ForbiddenImportRule(
+            "git_stage_batch.commands.batch_source",
+            "git_stage_batch.batch.operation_candidates",
+            "batch-source callers must use shared candidate planning",
+            allowed_sources=frozenset({planning_module}),
+        ),
+    )
+    assert forbidden_import_violations(rules) == []
 
     consumers = {
         edge.source

--- a/tests/commands/batch_source/test_candidate_materialization.py
+++ b/tests/commands/batch_source/test_candidate_materialization.py
@@ -2,25 +2,12 @@
 
 from __future__ import annotations
 
-from contextlib import AbstractContextManager
-
 import pytest
 
 from git_stage_batch.core.buffer import LineBuffer
 from git_stage_batch.core.replacement import ReplacementPayload
 from git_stage_batch.exceptions import CommandError
 import git_stage_batch.commands.batch_source.candidate_materialization as materialization
-
-
-class _OwnershipContext(AbstractContextManager):
-    def __init__(self, ownership: object) -> None:
-        self.ownership = ownership
-
-    def __enter__(self) -> object:
-        return self.ownership
-
-    def __exit__(self, exc_type, exc_value, traceback) -> None:
-        return None
 
 
 class _Target:
@@ -43,21 +30,6 @@ class _Preview:
 
     def require_target(self, name: str) -> _Target:
         return next(target for target in self.targets if target.target == name)
-
-
-class _ReplacementView(AbstractContextManager):
-    def __init__(self, source_buffer: LineBuffer, ownership: object) -> None:
-        self.source_buffer = source_buffer
-        self.ownership = ownership
-        self.closed = False
-
-    def __enter__(self) -> _ReplacementView:
-        return self
-
-    def __exit__(self, exc_type, exc_value, traceback) -> None:
-        self.source_buffer.close()
-        self.closed = True
-        return None
 
 
 def _patch_apply_materialization_io(monkeypatch, tmp_path):
@@ -237,7 +209,6 @@ def test_materialize_apply_candidate_rejects_binary_entries():
 
 
 def _patch_include_materialization_io(monkeypatch, tmp_path):
-    ownership = object()
     batch_buffer = LineBuffer.from_bytes(b"batch\n")
     index_buffer = LineBuffer.from_bytes(b"index\n")
     worktree_buffer = LineBuffer.from_bytes(b"worktree\n")
@@ -265,12 +236,6 @@ def _patch_include_materialization_io(monkeypatch, tmp_path):
         "load_working_tree_file_as_buffer",
         lambda file_path: worktree_buffer,
     )
-    monkeypatch.setattr(
-        materialization,
-        "acquire_batch_ownership_for_display_ids_from_lines",
-        lambda file_meta, source_lines, selection_ids: _OwnershipContext(ownership),
-    )
-    return ownership
 
 
 def test_materialize_include_candidate_returns_reviewed_preview(
@@ -278,23 +243,17 @@ def test_materialize_include_candidate_returns_reviewed_preview(
     tmp_path,
 ):
     """Include materialization should return the reviewed preview and modes."""
-    ownership = _patch_include_materialization_io(monkeypatch, tmp_path)
+    _patch_include_materialization_io(monkeypatch, tmp_path)
     replacement_payload = ReplacementPayload.from_text("replacement\n")
-    replacement_ownership = object()
-    replacement_view = _ReplacementView(
-        LineBuffer.from_bytes(b"replacement\n"),
-        replacement_ownership,
-    )
     targets = (_Target("index"), _Target("worktree"))
     previews = (_Preview("first"), _Preview("second", targets))
     calls = {}
 
-    def build_replacement_batch_view_from_lines(source_lines, view_ownership, payload):
-        calls["replacement"] = (source_lines, view_ownership, payload)
-        return replacement_view
-
-    def build_include_candidate_previews(**kwargs):
-        calls["build"] = kwargs
+    def plan_include_candidate_previews(**kwargs):
+        calls["build"] = {
+            **kwargs,
+            "source_bytes": kwargs["batch_source_lines"].to_bytes(),
+        }
         return previews
 
     def require_preview(loaded_previews, ordinal, **kwargs):
@@ -305,14 +264,9 @@ def test_materialize_include_candidate_returns_reviewed_preview(
         calls["require_state"] = (preview, ordinal, kwargs)
 
     monkeypatch.setattr(
-        materialization,
-        "build_replacement_batch_view_from_lines",
-        build_replacement_batch_view_from_lines,
-    )
-    monkeypatch.setattr(
-        materialization,
-        "build_include_candidate_previews",
-        build_include_candidate_previews,
+        materialization._candidate_planning,
+        "plan_include_candidate_previews",
+        plan_include_candidate_previews,
     )
     monkeypatch.setattr(
         materialization._candidate_previews,
@@ -348,17 +302,14 @@ def test_materialize_include_candidate_returns_reviewed_preview(
     assert result.file_path == "notes.txt"
     assert result.index_file_mode is None
     assert result.worktree_file_mode is None
-    assert calls["replacement"][1] is ownership
-    assert calls["replacement"][2] is replacement_payload
     assert calls["build"]["batch_name"] == "cleanup"
     assert calls["build"]["file_path"] == "notes.txt"
-    assert calls["build"]["source_lines"] is replacement_view.source_buffer
-    assert calls["build"]["ownership"] is replacement_ownership
+    assert calls["build"]["source_bytes"] == b"batch\n"
     assert calls["build"]["selected_ids"] == {3}
     assert calls["build"]["selection_ids"] == {9}
     assert calls["build"]["replacement_payload"] is replacement_payload
-    assert calls["build"]["index_exists"]
-    assert calls["build"]["worktree_exists"]
+    assert calls["build"]["index_target"].exists
+    assert calls["build"]["worktree_target"].exists
     assert calls["require_preview"] == (
         previews,
         2,
@@ -376,8 +327,6 @@ def test_materialize_include_candidate_returns_reviewed_preview(
             "file_path": "notes.txt",
         },
     )
-    assert replacement_view.closed
-
     result.close()
 
     assert [preview.closed for preview in previews] == [True, True]
@@ -395,8 +344,8 @@ def test_materialize_include_candidate_closes_previews_on_state_failure(
     )
 
     monkeypatch.setattr(
-        materialization,
-        "build_include_candidate_previews",
+        materialization._candidate_planning,
+        "plan_include_candidate_previews",
         lambda **kwargs: previews,
     )
     monkeypatch.setattr(

--- a/tests/commands/batch_source/test_candidate_materialization.py
+++ b/tests/commands/batch_source/test_candidate_materialization.py
@@ -61,7 +61,6 @@ class _ReplacementView(AbstractContextManager):
 
 
 def _patch_apply_materialization_io(monkeypatch, tmp_path):
-    ownership = object()
     batch_buffer = LineBuffer.from_bytes(b"batch\n")
     worktree_buffer = LineBuffer.from_bytes(b"worktree\n")
     (tmp_path / "notes.txt").write_bytes(b"worktree\n")
@@ -81,22 +80,19 @@ def _patch_apply_materialization_io(monkeypatch, tmp_path):
         "load_working_tree_file_as_buffer",
         lambda file_path: worktree_buffer,
     )
-    monkeypatch.setattr(
-        materialization,
-        "acquire_batch_ownership_for_display_ids_from_lines",
-        lambda file_meta, source_lines, selection_ids: _OwnershipContext(ownership),
-    )
-    return ownership
 
 
 def test_materialize_apply_candidate_returns_reviewed_preview(monkeypatch, tmp_path):
     """Apply materialization should return the reviewed preview and mode."""
-    ownership = _patch_apply_materialization_io(monkeypatch, tmp_path)
+    _patch_apply_materialization_io(monkeypatch, tmp_path)
     previews = (_Preview("first"), _Preview("second"))
     calls = {}
 
-    def build_apply_candidate_previews(**kwargs):
-        calls["build"] = kwargs
+    def plan_apply_candidate_previews(**kwargs):
+        calls["build"] = {
+            **kwargs,
+            "source_bytes": kwargs["batch_source_lines"].to_bytes(),
+        }
         return previews
 
     def require_preview(loaded_previews, ordinal, **kwargs):
@@ -107,9 +103,9 @@ def test_materialize_apply_candidate_returns_reviewed_preview(monkeypatch, tmp_p
         calls["require_state"] = (preview, ordinal, kwargs)
 
     monkeypatch.setattr(
-        materialization,
-        "build_apply_candidate_previews",
-        build_apply_candidate_previews,
+        materialization._candidate_planning,
+        "plan_apply_candidate_previews",
+        plan_apply_candidate_previews,
     )
     monkeypatch.setattr(
         materialization._candidate_previews,
@@ -144,10 +140,10 @@ def test_materialize_apply_candidate_returns_reviewed_preview(monkeypatch, tmp_p
     assert result.file_mode is None
     assert calls["build"]["batch_name"] == "cleanup"
     assert calls["build"]["file_path"] == "notes.txt"
-    assert calls["build"]["ownership"] is ownership
+    assert calls["build"]["source_bytes"] == b"batch\n"
     assert calls["build"]["selected_ids"] == {3}
     assert calls["build"]["selection_ids"] == {9}
-    assert calls["build"]["worktree_exists"]
+    assert calls["build"]["worktree_target"].exists
     assert calls["require_preview"] == (
         previews,
         2,
@@ -180,8 +176,8 @@ def test_materialize_apply_candidate_closes_previews_on_state_failure(
     previews = (_Preview("first"), _Preview("second"))
 
     monkeypatch.setattr(
-        materialization,
-        "build_apply_candidate_previews",
+        materialization._candidate_planning,
+        "plan_apply_candidate_previews",
         lambda **kwargs: previews,
     )
     monkeypatch.setattr(

--- a/tests/commands/batch_source/test_candidate_planning.py
+++ b/tests/commands/batch_source/test_candidate_planning.py
@@ -1,0 +1,81 @@
+"""Tests for shared batch-source candidate planning."""
+
+from __future__ import annotations
+
+from contextlib import AbstractContextManager
+
+from git_stage_batch.commands.batch_source import candidate_inputs
+from git_stage_batch.commands.batch_source import candidate_planning as planning
+from git_stage_batch.core.buffer import LineBuffer
+from git_stage_batch.core.text_lifecycle import TextFileChangeType
+
+
+class _Context(AbstractContextManager):
+    def __init__(self, value: object) -> None:
+        self.value = value
+        self.closed = False
+
+    def __enter__(self) -> object:
+        return self.value
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        self.closed = True
+        return None
+
+
+def _worktree_target() -> candidate_inputs.CandidateWorktreeTarget:
+    return candidate_inputs.CandidateWorktreeTarget(
+        exists=True,
+        file_mode="100755",
+        text_change_type=TextFileChangeType.MODIFIED,
+    )
+
+
+def test_apply_planning_owns_ownership_and_builder_arguments(monkeypatch):
+    ownership = object()
+    ownership_context = _Context(ownership)
+    source = LineBuffer.from_bytes(b"source\n")
+    worktree = LineBuffer.from_bytes(b"worktree\n")
+    calls = {}
+
+    monkeypatch.setattr(
+        planning,
+        "acquire_batch_ownership_for_display_ids_from_lines",
+        lambda *args, **kwargs: ownership_context,
+    )
+
+    def build_apply_candidate_previews(**kwargs):
+        calls["build"] = kwargs
+        return ("preview",)
+
+    monkeypatch.setattr(
+        planning,
+        "_build_apply_candidate_previews",
+        build_apply_candidate_previews,
+    )
+
+    try:
+        previews = planning.plan_apply_candidate_previews(
+            batch_name="cleanup",
+            file_path="notes.txt",
+            file_meta={"mode": "100755"},
+            batch_source_lines=source,
+            batch_source_commit="commit",
+            worktree_lines=worktree,
+            worktree_target=_worktree_target(),
+            selected_ids={3},
+            selection_ids={9},
+        )
+    finally:
+        source.close()
+        worktree.close()
+
+    assert previews == ("preview",)
+    assert calls["build"]["source_lines"] is source
+    assert calls["build"]["ownership"] is ownership
+    assert calls["build"]["worktree_lines"] is worktree
+    assert calls["build"]["selected_ids"] == {3}
+    assert calls["build"]["selection_ids"] == {9}
+    assert calls["build"]["worktree_file_mode"] == "100755"
+    assert calls["build"]["worktree_exists"]
+    assert ownership_context.closed

--- a/tests/commands/batch_source/test_candidate_planning.py
+++ b/tests/commands/batch_source/test_candidate_planning.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 from contextlib import AbstractContextManager
 
+import pytest
+
 from git_stage_batch.commands.batch_source import candidate_inputs
 from git_stage_batch.commands.batch_source import candidate_planning as planning
 from git_stage_batch.core.buffer import LineBuffer
+from git_stage_batch.core.replacement import ReplacementPayload
 from git_stage_batch.core.text_lifecycle import TextFileChangeType
 
 
@@ -19,6 +22,21 @@ class _Context(AbstractContextManager):
         return self.value
 
     def __exit__(self, exc_type, exc_value, traceback) -> None:
+        self.closed = True
+        return None
+
+
+class _ReplacementView(AbstractContextManager):
+    def __init__(self, source_buffer: LineBuffer, ownership: object) -> None:
+        self.source_buffer = source_buffer
+        self.ownership = ownership
+        self.closed = False
+
+    def __enter__(self) -> _ReplacementView:
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        self.source_buffer.close()
         self.closed = True
         return None
 
@@ -78,4 +96,143 @@ def test_apply_planning_owns_ownership_and_builder_arguments(monkeypatch):
     assert calls["build"]["selection_ids"] == {9}
     assert calls["build"]["worktree_file_mode"] == "100755"
     assert calls["build"]["worktree_exists"]
+    assert ownership_context.closed
+
+
+def test_include_planning_owns_replacement_view_and_builder_arguments(
+    monkeypatch,
+    tmp_path,
+):
+    ownership = object()
+    replacement_ownership = object()
+    ownership_context = _Context(ownership)
+    source = LineBuffer.from_bytes(b"source\n")
+    index = LineBuffer.from_bytes(b"index\n")
+    worktree = LineBuffer.from_bytes(b"worktree\n")
+    replacement_view = _ReplacementView(
+        LineBuffer.from_bytes(b"replacement\n"),
+        replacement_ownership,
+    )
+    payload = ReplacementPayload.from_text("new\n")
+    calls = {}
+
+    monkeypatch.setattr(
+        planning,
+        "acquire_batch_ownership_for_display_ids_from_lines",
+        lambda *args, **kwargs: ownership_context,
+    )
+
+    def build_replacement(source_lines, view_ownership, replacement, **kwargs):
+        calls["replacement"] = (
+            source_lines,
+            view_ownership,
+            replacement,
+            kwargs,
+        )
+        return replacement_view
+
+    def build_include_candidate_previews(**kwargs):
+        calls["build"] = {
+            **kwargs,
+            "source_bytes": kwargs["source_lines"].to_bytes(),
+        }
+        return ("preview",)
+
+    monkeypatch.setattr(
+        planning,
+        "build_replacement_batch_view_from_lines",
+        build_replacement,
+    )
+    monkeypatch.setattr(
+        planning,
+        "_build_include_candidate_previews",
+        build_include_candidate_previews,
+    )
+
+    try:
+        previews = planning.plan_include_candidate_previews(
+            batch_name="cleanup",
+            file_path="notes.txt",
+            file_meta={"mode": "100755"},
+            batch_source_lines=source,
+            batch_source_commit="commit",
+            index_lines=index,
+            index_target=candidate_inputs.CandidateIndexTarget(
+                exists=False,
+                file_mode=None,
+            ),
+            worktree_lines=worktree,
+            worktree_target=_worktree_target(),
+            selected_ids={3},
+            selection_ids={9},
+            replacement_payload=payload,
+            spool_dir=tmp_path,
+        )
+    finally:
+        source.close()
+        index.close()
+        worktree.close()
+
+    assert previews == ("preview",)
+    assert calls["replacement"] == (
+        source,
+        ownership,
+        payload,
+        {"spool_dir": tmp_path},
+    )
+    assert calls["build"]["source_bytes"] == b"replacement\n"
+    assert calls["build"]["ownership"] is replacement_ownership
+    assert calls["build"]["index_lines"] is index
+    assert calls["build"]["worktree_lines"] is worktree
+    assert calls["build"]["index_exists"] is False
+    assert calls["build"]["worktree_exists"] is True
+    assert calls["build"]["spool_dir"] == tmp_path
+    assert ownership_context.closed
+    assert replacement_view.closed
+
+
+def test_include_planning_identifies_replacement_failures(monkeypatch):
+    source = LineBuffer.from_bytes(b"source\n")
+    index = LineBuffer.from_bytes(b"index\n")
+    worktree = LineBuffer.from_bytes(b"worktree\n")
+    ownership_context = _Context(object())
+
+    monkeypatch.setattr(
+        planning,
+        "acquire_batch_ownership_for_display_ids_from_lines",
+        lambda *args, **kwargs: ownership_context,
+    )
+    monkeypatch.setattr(
+        planning,
+        "build_replacement_batch_view_from_lines",
+        lambda *args, **kwargs: (_ for _ in ()).throw(ValueError("bad replacement")),
+    )
+
+    try:
+        with pytest.raises(
+            planning.CandidateReplacementError,
+            match="bad replacement",
+        ):
+            planning.plan_include_candidate_previews(
+                batch_name="cleanup",
+                file_path="notes.txt",
+                file_meta={},
+                batch_source_lines=source,
+                batch_source_commit="commit",
+                index_lines=index,
+                index_target=candidate_inputs.CandidateIndexTarget(
+                    exists=True,
+                    file_mode="100644",
+                ),
+                worktree_lines=worktree,
+                worktree_target=_worktree_target(),
+                selected_ids=None,
+                selection_ids=None,
+                replacement_payload=ReplacementPayload.from_text("new\n"),
+            )
+    finally:
+        source.close()
+        index.close()
+        worktree.close()
+
     assert ownership_context.closed

--- a/tests/commands/batch_source/test_candidate_preview_builders.py
+++ b/tests/commands/batch_source/test_candidate_preview_builders.py
@@ -72,21 +72,24 @@ def test_build_batch_source_candidate_previews_builds_apply_candidates(
     tmp_path,
 ):
     """Apply candidate construction should pass translated selection IDs."""
-    ownership = _patch_common_candidate_builder_io(monkeypatch, tmp_path)
+    _patch_common_candidate_builder_io(monkeypatch, tmp_path)
     calls = {}
 
     def translate_selection_ids(batch_name, file_path, selected_ids, action):
         calls["translation"] = (batch_name, file_path, selected_ids, action)
         return {10}, None
 
-    def build_apply_candidate_previews(**kwargs):
-        calls["build"] = kwargs
+    def plan_apply_candidate_previews(**kwargs):
+        calls["build"] = {
+            **kwargs,
+            "source_bytes": kwargs["batch_source_lines"].to_bytes(),
+        }
         return ("apply-preview",)
 
     monkeypatch.setattr(
-        builders,
-        "build_apply_candidate_previews",
-        build_apply_candidate_previews,
+        builders._candidate_planning,
+        "plan_apply_candidate_previews",
+        plan_apply_candidate_previews,
     )
 
     previews = builders.build_batch_source_candidate_previews(
@@ -113,10 +116,10 @@ def test_build_batch_source_candidate_previews_builds_apply_candidates(
     )
     assert calls["build"]["batch_name"] == "cleanup"
     assert calls["build"]["file_path"] == "notes.txt"
-    assert calls["build"]["ownership"] is ownership
+    assert calls["build"]["source_bytes"] == b"batch\n"
     assert calls["build"]["selected_ids"] == {1}
     assert calls["build"]["selection_ids"] == {10}
-    assert calls["build"]["worktree_exists"]
+    assert calls["build"]["worktree_target"].exists
 
 
 def test_build_batch_source_candidate_previews_builds_include_replacement(

--- a/tests/commands/batch_source/test_candidate_preview_builders.py
+++ b/tests/commands/batch_source/test_candidate_preview_builders.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from contextlib import AbstractContextManager
-
 import pytest
 
 from git_stage_batch.batch.source.selector import BatchSourceSelector
@@ -13,29 +11,7 @@ import git_stage_batch.commands.batch_source.candidate_preview_builders as build
 from git_stage_batch.exceptions import CommandError
 
 
-class _OwnershipContext(AbstractContextManager):
-    def __init__(self, ownership: object) -> None:
-        self.ownership = ownership
-
-    def __enter__(self) -> object:
-        return self.ownership
-
-    def __exit__(self, exc_type, exc_value, traceback) -> None:
-        return None
-
-
-class _ReplacementView(AbstractContextManager):
-    def __init__(self, source_buffer: LineBuffer, ownership: object) -> None:
-        self.source_buffer = source_buffer
-        self.ownership = ownership
-
-    def __exit__(self, exc_type, exc_value, traceback) -> None:
-        self.source_buffer.close()
-        return None
-
-
 def _patch_common_candidate_builder_io(monkeypatch, tmp_path):
-    ownership = object()
     batch_buffer = LineBuffer.from_bytes(b"batch\n")
     worktree_buffer = LineBuffer.from_bytes(b"worktree\n")
     index_buffer = LineBuffer.from_bytes(b"index\n")
@@ -59,12 +35,6 @@ def _patch_common_candidate_builder_io(monkeypatch, tmp_path):
         "load_working_tree_file_as_buffer",
         lambda file_path: worktree_buffer,
     )
-    monkeypatch.setattr(
-        builders,
-        "acquire_batch_ownership_for_display_ids_from_lines",
-        lambda file_meta, source_lines, selection_ids: _OwnershipContext(ownership),
-    )
-    return ownership
 
 
 def test_build_batch_source_candidate_previews_builds_apply_candidates(
@@ -127,7 +97,6 @@ def test_build_batch_source_candidate_previews_builds_include_replacement(
     tmp_path,
 ):
     """Include candidate construction should pass replacement preview state."""
-    replacement_ownership = object()
     _patch_common_candidate_builder_io(monkeypatch, tmp_path)
     calls = {}
 
@@ -135,31 +104,19 @@ def test_build_batch_source_candidate_previews_builds_include_replacement(
         calls["translation"] = (batch_name, file_path, selected_ids, action)
         return {20}, None
 
-    def build_replacement_batch_view_from_lines(source_lines, ownership, payload):
-        calls["replacement_payload"] = payload
-        return _ReplacementView(
-            LineBuffer.from_bytes(b"replacement\n"),
-            replacement_ownership,
-        )
-
-    def build_include_candidate_previews(**kwargs):
+    def plan_include_candidate_previews(**kwargs):
         calls["build"] = kwargs
         return ("include-preview",)
 
-    monkeypatch.setattr(
-        builders,
-        "build_replacement_batch_view_from_lines",
-        build_replacement_batch_view_from_lines,
-    )
     monkeypatch.setattr(
         builders.replacement_selection,
         "require_contiguous_display_selection",
         lambda selected_ids: calls.setdefault("contiguous", selected_ids),
     )
     monkeypatch.setattr(
-        builders,
-        "build_include_candidate_previews",
-        build_include_candidate_previews,
+        builders._candidate_planning,
+        "plan_include_candidate_previews",
+        plan_include_candidate_previews,
     )
 
     previews = builders.build_batch_source_candidate_previews(
@@ -185,11 +142,10 @@ def test_build_batch_source_candidate_previews_builds_include_replacement(
         FileReviewAction.INCLUDE_FROM_BATCH,
     )
     assert calls["contiguous"] == {1}
-    assert calls["build"]["ownership"] is replacement_ownership
-    assert calls["build"]["replacement_payload"] is calls["replacement_payload"]
+    assert calls["build"]["replacement_payload"].as_text() == "new\n"
     assert calls["build"]["selection_ids"] == {20}
-    assert calls["build"]["index_exists"]
-    assert calls["build"]["worktree_exists"]
+    assert calls["build"]["index_target"].exists
+    assert calls["build"]["worktree_target"].exists
 
 
 def test_build_batch_source_candidate_previews_rejects_apply_replacement(

--- a/tests/commands/batch_source/test_candidate_preview_counts.py
+++ b/tests/commands/batch_source/test_candidate_preview_counts.py
@@ -114,18 +114,21 @@ def test_count_apply_candidate_previews_for_file_counts_previews(
     tmp_path,
 ):
     """Apply candidate counting should return closed preview counts."""
-    ownership = _patch_apply_candidate_count_io(monkeypatch, tmp_path)
+    _patch_apply_candidate_count_io(monkeypatch, tmp_path)
     previews = (_Preview(), _Preview())
     calls = {}
 
-    def build_apply_candidate_previews(**kwargs):
-        calls["build"] = kwargs
+    def plan_apply_candidate_previews(**kwargs):
+        calls["build"] = {
+            **kwargs,
+            "source_bytes": kwargs["batch_source_lines"].to_bytes(),
+        }
         return previews
 
     monkeypatch.setattr(
-        counts,
-        "build_apply_candidate_previews",
-        build_apply_candidate_previews,
+        counts._candidate_planning,
+        "plan_apply_candidate_previews",
+        plan_apply_candidate_previews,
     )
 
     result = counts.count_apply_candidate_previews_for_file(
@@ -142,10 +145,10 @@ def test_count_apply_candidate_previews_for_file_counts_previews(
     assert result == CandidatePreviewCount(count=2)
     assert calls["build"]["batch_name"] == "cleanup"
     assert calls["build"]["file_path"] == "notes.txt"
-    assert calls["build"]["ownership"] is ownership
+    assert calls["build"]["source_bytes"] == b"batch\n"
     assert calls["build"]["selected_ids"] == {7}
     assert calls["build"]["selection_ids"] == {7}
-    assert calls["build"]["worktree_exists"]
+    assert calls["build"]["worktree_target"].exists
     assert [preview.closed for preview in previews] == [True, True]
 
 
@@ -179,13 +182,13 @@ def test_count_apply_candidate_previews_for_file_reports_limit(
     """Apply candidate counting should preserve enumeration limit messages."""
     _patch_apply_candidate_count_io(monkeypatch, tmp_path)
 
-    def build_apply_candidate_previews(**kwargs):
+    def plan_apply_candidate_previews(**kwargs):
         raise CandidateEnumerationLimitError("too many")
 
     monkeypatch.setattr(
-        counts,
-        "build_apply_candidate_previews",
-        build_apply_candidate_previews,
+        counts._candidate_planning,
+        "plan_apply_candidate_previews",
+        plan_apply_candidate_previews,
     )
 
     result = counts.count_apply_candidate_previews_for_file(

--- a/tests/commands/batch_source/test_candidate_preview_counts.py
+++ b/tests/commands/batch_source/test_candidate_preview_counts.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from contextlib import AbstractContextManager
-
 import pytest
 
 from git_stage_batch.batch.operation_candidate_types import (
@@ -15,17 +13,6 @@ from git_stage_batch.core.replacement import ReplacementPayload
 import git_stage_batch.commands.batch_source.candidate_preview_counts as counts
 
 
-class _OwnershipContext(AbstractContextManager):
-    def __init__(self, ownership: object) -> None:
-        self.ownership = ownership
-
-    def __enter__(self) -> object:
-        return self.ownership
-
-    def __exit__(self, exc_type, exc_value, traceback) -> None:
-        return None
-
-
 class _Preview:
     def __init__(self) -> None:
         self.closed = False
@@ -33,22 +20,7 @@ class _Preview:
     def close(self) -> None:
         self.closed = True
 
-
-class _ReplacementView(AbstractContextManager):
-    def __init__(self, source_buffer: LineBuffer, ownership: object) -> None:
-        self.source_buffer = source_buffer
-        self.ownership = ownership
-
-    def __enter__(self) -> "_ReplacementView":
-        return self
-
-    def __exit__(self, exc_type, exc_value, traceback) -> None:
-        self.source_buffer.close()
-        return None
-
-
 def _patch_apply_candidate_count_io(monkeypatch, tmp_path):
-    ownership = object()
     batch_buffer = LineBuffer.from_bytes(b"batch\n")
     worktree_buffer = LineBuffer.from_bytes(b"worktree\n")
     (tmp_path / "notes.txt").write_bytes(b"worktree\n")
@@ -68,16 +40,9 @@ def _patch_apply_candidate_count_io(monkeypatch, tmp_path):
         "load_working_tree_file_as_buffer",
         lambda file_path: worktree_buffer,
     )
-    monkeypatch.setattr(
-        counts,
-        "acquire_batch_ownership_for_display_ids_from_lines",
-        lambda file_meta, source_lines, selection_ids: _OwnershipContext(ownership),
-    )
-    return ownership
 
 
 def _patch_include_candidate_count_io(monkeypatch, tmp_path):
-    ownership = object()
     batch_buffer = LineBuffer.from_bytes(b"batch\n")
     index_buffer = LineBuffer.from_bytes(b"index\n")
     worktree_buffer = LineBuffer.from_bytes(b"worktree\n")
@@ -101,12 +66,6 @@ def _patch_include_candidate_count_io(monkeypatch, tmp_path):
         "load_working_tree_file_as_buffer",
         lambda file_path: worktree_buffer,
     )
-    monkeypatch.setattr(
-        counts,
-        "acquire_batch_ownership_for_display_ids_from_lines",
-        lambda file_meta, source_lines, selection_ids: _OwnershipContext(ownership),
-    )
-    return ownership
 
 
 def test_count_apply_candidate_previews_for_file_counts_previews(
@@ -269,35 +228,22 @@ def test_count_include_candidate_previews_for_file_counts_replacements(
     tmp_path,
 ):
     """Include candidate counting should count replacement previews."""
-    base_ownership = _patch_include_candidate_count_io(monkeypatch, tmp_path)
-    replacement_ownership = object()
+    _patch_include_candidate_count_io(monkeypatch, tmp_path)
     payload = ReplacementPayload.from_text("new\n")
     previews = (_Preview(),)
     calls = {}
 
-    def build_replacement_view(source_lines, ownership, replacement_payload):
-        calls["replacement"] = (source_lines.to_bytes(), ownership, replacement_payload)
-        return _ReplacementView(
-            LineBuffer.from_bytes(b"replacement\n"),
-            replacement_ownership,
-        )
-
-    def build_include_candidate_previews(**kwargs):
+    def plan_include_candidate_previews(**kwargs):
         calls["build"] = {
             **kwargs,
-            "source_bytes": kwargs["source_lines"].to_bytes(),
+            "source_bytes": kwargs["batch_source_lines"].to_bytes(),
         }
         return previews
 
     monkeypatch.setattr(
-        counts,
-        "build_replacement_batch_view_from_lines",
-        build_replacement_view,
-    )
-    monkeypatch.setattr(
-        counts,
-        "build_include_candidate_previews",
-        build_include_candidate_previews,
+        counts._candidate_planning,
+        "plan_include_candidate_previews",
+        plan_include_candidate_previews,
     )
 
     result = counts.count_include_candidate_previews_for_file(
@@ -313,16 +259,14 @@ def test_count_include_candidate_previews_for_file_counts_replacements(
     )
 
     assert result == CandidatePreviewCount(count=1)
-    assert calls["replacement"] == (b"batch\n", base_ownership, payload)
     assert calls["build"]["batch_name"] == "cleanup"
     assert calls["build"]["file_path"] == "notes.txt"
-    assert calls["build"]["source_bytes"] == b"replacement\n"
-    assert calls["build"]["ownership"] is replacement_ownership
+    assert calls["build"]["source_bytes"] == b"batch\n"
     assert calls["build"]["selected_ids"] == {9}
     assert calls["build"]["selection_ids"] == {9}
     assert calls["build"]["replacement_payload"] is payload
-    assert calls["build"]["index_exists"]
-    assert calls["build"]["worktree_exists"]
+    assert calls["build"]["index_target"].exists
+    assert calls["build"]["worktree_target"].exists
     assert previews[0].closed
 
 
@@ -333,13 +277,13 @@ def test_count_include_candidate_previews_for_file_reports_limit(
     """Include candidate counting should preserve enumeration limit messages."""
     _patch_include_candidate_count_io(monkeypatch, tmp_path)
 
-    def build_include_candidate_previews(**kwargs):
+    def plan_include_candidate_previews(**kwargs):
         raise CandidateEnumerationLimitError("too many")
 
     monkeypatch.setattr(
-        counts,
-        "build_include_candidate_previews",
-        build_include_candidate_previews,
+        counts._candidate_planning,
+        "plan_include_candidate_previews",
+        plan_include_candidate_previews,
     )
 
     result = counts.count_include_candidate_previews_for_file(

--- a/tests/commands/test_candidate_previews.py
+++ b/tests/commands/test_candidate_previews.py
@@ -640,8 +640,8 @@ def test_include_from_reports_candidate_limit(temp_git_repo, monkeypatch):
         )
 
     monkeypatch.setattr(
-        candidate_preview_counts,
-        "build_include_candidate_previews",
+        candidate_preview_counts._candidate_planning,
+        "plan_include_candidate_previews",
         fail_count,
     )
 

--- a/tests/commands/test_candidate_previews.py
+++ b/tests/commands/test_candidate_previews.py
@@ -443,8 +443,8 @@ def test_apply_from_reports_candidate_enumeration_error(
         raise RuntimeError("metadata drift")
 
     monkeypatch.setattr(
-        candidate_preview_counts,
-        "build_apply_candidate_previews",
+        candidate_preview_counts._candidate_planning,
+        "plan_apply_candidate_previews",
         fail_count,
     )
 


### PR DESCRIPTION
Displaying, counting, and executing saved-batch matches construct apply and
include previews through separate copies of the same preparation flow.

Those copies can supply different merge arguments or release selected-line
and replacement data before preview construction finishes.

This PR introduces shared apply and include preview helpers, routes all
three callers through them, and keeps borrowed data alive until each result
has been built.

Behavior and architecture tests now cover shared construction, replacement
cleanup, and the callers permitted to use each helper.
