### PR TITLE
tests: Reject cycles across runtime modules

### DIFF
--- a/tests/architecture/import_boundary_helpers.py
+++ b/tests/architecture/import_boundary_helpers.py
@@ -132,6 +132,46 @@ def internal_module_import_edges(
     return tuple(edges)
 
 
+def find_dependency_cycle(
+    edges: tuple[ImportEdge, ...],
+) -> tuple[str, ...] | None:
+    """Return one deterministic dependency cycle, including its repeated root."""
+    adjacency: dict[str, set[str]] = {}
+    for edge in edges:
+        adjacency.setdefault(edge.source, set()).add(edge.target)
+        adjacency.setdefault(edge.target, set())
+
+    state: dict[str, int] = {}
+    stack: list[str] = []
+    stack_indexes: dict[str, int] = {}
+
+    def visit(module: str) -> tuple[str, ...] | None:
+        state[module] = 1
+        stack_indexes[module] = len(stack)
+        stack.append(module)
+
+        for dependency in sorted(adjacency[module]):
+            dependency_state = state.get(dependency, 0)
+            if dependency_state == 0:
+                cycle = visit(dependency)
+                if cycle is not None:
+                    return cycle
+            elif dependency_state == 1:
+                return tuple((*stack[stack_indexes[dependency] :], dependency))
+
+        stack.pop()
+        stack_indexes.pop(module)
+        state[module] = 2
+        return None
+
+    for module in sorted(adjacency):
+        if state.get(module, 0) == 0:
+            cycle = visit(module)
+            if cycle is not None:
+                return cycle
+    return None
+
+
 def forbidden_import_violations(
     rules: tuple[ForbiddenImportRule, ...],
 ) -> list[str]:

--- a/tests/architecture/test_seam_rules.py
+++ b/tests/architecture/test_seam_rules.py
@@ -4,11 +4,18 @@ from __future__ import annotations
 
 from .import_boundary_helpers import (
     ForbiddenImportRule,
+    find_dependency_cycle,
     forbidden_import_violations,
     internal_import_edges,
     internal_module_import_edges,
     modules_defining,
 )
+
+
+def test_internal_runtime_module_graph_is_acyclic():
+    """Concrete runtime module dependencies must form a directed acyclic graph."""
+    cycle = find_dependency_cycle(internal_module_import_edges())
+    assert cycle is None, " -> ".join(cycle or ())
 
 
 def test_live_change_policy_has_one_owner():


### PR DESCRIPTION
Runtime modules now follow explicit local dependency rules for filesystem
writes, session checks, undo behavior, review data, batch metadata, and
saved-batch previews.

Individually permitted imports can still form a loop across several
modules. Such a loop makes initialization order significant and lets
callers depend back on the modules they use.

This PR builds the graph of concrete runtime imports and adds deterministic
cycle detection to the architecture suite.

The suite now enforces both each local dependency rule and the global
requirement that runtime imports flow in one acyclic direction.
