### PR TITLE
tests: Remove redundant interactive again smoke test

### DIFF
--- a/tests/functional/test_abort_again_display.py
+++ b/tests/functional/test_abort_again_display.py
@@ -271,11 +271,6 @@ class TestAgainInteractive:
         result = run_interactive("s", "again", "q")
         assert result.returncode in [0, 1]
 
-    def test_interactive_again_after_operations(self, repo_with_changes):
-        """Test again after operations in interactive mode."""
-        result = run_interactive("i", "s", "s", "again", "q")
-        assert result.returncode in [0, 1]
-
     def test_interactive_again_with_batch(self, repo_with_changes):
         """Test again with batch operations in interactive mode."""
         git_stage_batch("new", "again-interactive")


### PR DESCRIPTION
The functional suite exercises the `again` command through direct repository-state checks and interactive coverage of both its keyboard action and full command name.

An additional subprocess test repeats the same action sequence but accepts either success or failure and inspects neither output nor repository state. It therefore cannot distinguish a regression from expected behavior, while still adding another timing-sensitive interactive process.

This PR removes that smoke test. The remaining coverage continues to require observable state changes or successful completion, so it protects the behavior instead of merely launching it.

Interactive `again` coverage is now smaller and more meaningful, with no loss of an asserted behavior.
