### PR TITLE
tests: Consolidate scripted interactive subprocesses

### DIFF
--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -6,6 +6,19 @@ from pathlib import Path
 import pytest
 
 
+PROJECT_ROOT = Path(__file__).parents[2]
+
+
+def _git_stage_batch_command(*args):
+    """Build a command that runs git-stage-batch from the working tree."""
+    venv_gsb = PROJECT_ROOT / ".venv" / "bin" / "git-stage-batch"
+
+    if venv_gsb.exists():
+        return [str(venv_gsb), *args]
+
+    return ["uv", "run", "--", "git-stage-batch", *args]
+
+
 @pytest.fixture
 def functional_repo(tmp_path, monkeypatch):
     """Create a realistic git repository for functional testing.

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -111,20 +111,8 @@ def git_stage_batch(*args, input_text=None, check=True):
         subprocess.CompletedProcess
     """
 
-    # Find the project root (where pyproject.toml is)
-    test_dir = Path(__file__).parent
-    project_root = test_dir.parent.parent
-    venv_gsb = project_root / ".venv" / "bin" / "git-stage-batch"
-
-    # Use the venv git-stage-batch directly to ensure we get the in-tree version
-    if venv_gsb.exists():
-        cmd = [str(venv_gsb)] + list(args)
-    else:
-        # Fallback to uv run if venv not found
-        cmd = ["uv", "run", "--", "git-stage-batch"] + list(args)
-
     result = subprocess.run(
-        cmd,
+        _git_stage_batch_command(*args),
         input=input_text,
         text=True,
         encoding="utf-8",

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -1,5 +1,6 @@
 """Shared fixtures for functional tests."""
 
+import shlex
 import subprocess
 from pathlib import Path
 
@@ -48,11 +49,15 @@ def run_interactive(
             check=False,
         )
     except subprocess.TimeoutExpired as error:
-        output = (
-            _decode_timeout_output(error.output)
-            + _decode_timeout_output(error.stderr)
+        stdout = _decode_timeout_output(error.stdout)
+        stderr = _decode_timeout_output(error.stderr)
+        pytest.fail(
+            f"Interactive command timed out after {timeout} seconds\n"
+            f"Command: {shlex.join(command)}\n"
+            f"Scripted input: {inputs!r}\n"
+            f"STDOUT:\n{stdout or '<empty>'}\n"
+            f"STDERR:\n{stderr or '<empty>'}"
         )
-        pytest.fail(f"Interactive mode timed out\n{output}")
 
 
 @pytest.fixture

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -7,6 +7,7 @@ import pytest
 
 
 PROJECT_ROOT = Path(__file__).parents[2]
+INTERACTIVE_TIMEOUT = 15
 
 
 def _git_stage_batch_command(*args):
@@ -17,6 +18,41 @@ def _git_stage_batch_command(*args):
         return [str(venv_gsb), *args]
 
     return ["uv", "run", "--", "git-stage-batch", *args]
+
+
+def _decode_timeout_output(value):
+    """Return captured timeout output as displayable text."""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value or ""
+
+
+def run_interactive(
+    *inputs,
+    cli_args=("-i",),
+    timeout=INTERACTIVE_TIMEOUT,
+):
+    """Run an interactive command with scripted input and a CI-safe hang guard."""
+    command = _git_stage_batch_command(*cli_args)
+    input_text = "\n".join(inputs) + "\n"
+
+    try:
+        return subprocess.run(
+            command,
+            input=input_text,
+            text=True,
+            encoding="utf-8",
+            errors="surrogateescape",
+            capture_output=True,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as error:
+        output = (
+            _decode_timeout_output(error.output)
+            + _decode_timeout_output(error.stderr)
+        )
+        pytest.fail(f"Interactive mode timed out\n{output}")
 
 
 @pytest.fixture

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -7,7 +7,7 @@ import pytest
 
 
 PROJECT_ROOT = Path(__file__).parents[2]
-INTERACTIVE_TIMEOUT = 15
+INTERACTIVE_TIMEOUT = 60
 
 
 def _git_stage_batch_command(*args):

--- a/tests/functional/test_abort_again_display.py
+++ b/tests/functional/test_abort_again_display.py
@@ -1,39 +1,14 @@
 """Comprehensive tests for abort, again, and display correctness."""
 
-from pathlib import Path
-import pytest
-
 import subprocess
 
-from .conftest import git_stage_batch, get_staged_files, get_unstaged_diff, get_git_status
-
-
-def run_interactive(*inputs, timeout=5):
-    """Run interactive mode with simulated input."""
-
-    test_dir = Path(__file__).parent
-    project_root = test_dir.parent.parent
-    venv_gsb = project_root / ".venv" / "bin" / "git-stage-batch"
-
-    if venv_gsb.exists():
-        cmd = [str(venv_gsb), "-i"]
-    else:
-        cmd = ["uv", "run", "--", "git-stage-batch", "-i"]
-
-    input_text = "\n".join(inputs) + "\n"
-
-    try:
-        result = subprocess.run(
-            cmd,
-            input=input_text,
-            text=True,
-            capture_output=True,
-            timeout=timeout,
-            check=False
-        )
-        return result
-    except subprocess.TimeoutExpired:
-        pytest.fail("Interactive mode timed out")
+from .conftest import (
+    get_git_status,
+    get_staged_files,
+    get_unstaged_diff,
+    git_stage_batch,
+    run_interactive,
+)
 
 
 class TestAbortThorough:

--- a/tests/functional/test_functional_interactive.py
+++ b/tests/functional/test_functional_interactive.py
@@ -4,59 +4,12 @@ from pathlib import Path
 
 import subprocess
 
-import pytest
-
-from .conftest import git_stage_batch, get_staged_files
-
-
-INTERACTIVE_TIMEOUT = 15
-
-
-def decode_timeout_output(value):
-    if isinstance(value, bytes):
-        return value.decode(errors="replace")
-    return value or ""
-
-
-def run_interactive(*inputs, timeout=INTERACTIVE_TIMEOUT):
-    """Run interactive mode with simulated input.
-
-    Args:
-        *inputs: Input strings to send to interactive mode
-        timeout: Timeout in seconds
-
-    Returns:
-        subprocess.CompletedProcess
-    """
-
-    # Find the venv git-stage-batch to ensure we use in-tree version
-    test_dir = Path(__file__).parent
-    project_root = test_dir.parent.parent
-    venv_gsb = project_root / ".venv" / "bin" / "git-stage-batch"
-
-    if venv_gsb.exists():
-        cmd = [str(venv_gsb), "-i"]
-    else:
-        cmd = ["uv", "run", "--", "git-stage-batch", "-i"]
-
-    input_text = "\n".join(inputs) + "\n"
-
-    try:
-        result = subprocess.run(
-            cmd,
-            input=input_text,
-            text=True,
-            capture_output=True,
-            timeout=timeout,
-            check=False
-        )
-        return result
-    except subprocess.TimeoutExpired as error:
-        output = (
-            decode_timeout_output(error.output)
-            + decode_timeout_output(error.stderr)
-        )
-        pytest.fail(f"Interactive mode timed out\n{output}")
+from .conftest import (
+    INTERACTIVE_TIMEOUT,
+    git_stage_batch,
+    get_staged_files,
+    run_interactive,
+)
 
 
 class TestInteractiveMode:

--- a/tests/functional/test_functional_interactive.py
+++ b/tests/functional/test_functional_interactive.py
@@ -4,12 +4,7 @@ from pathlib import Path
 
 import subprocess
 
-from .conftest import (
-    INTERACTIVE_TIMEOUT,
-    git_stage_batch,
-    get_staged_files,
-    run_interactive,
-)
+from .conftest import git_stage_batch, get_staged_files, run_interactive
 
 
 class TestInteractiveMode:
@@ -29,24 +24,7 @@ class TestInteractiveMode:
 
     def test_interactive_command_alias(self, repo_with_changes):
         """Test starting with 'interactive' command."""
-
-        test_dir = Path(__file__).parent
-        project_root = test_dir.parent.parent
-        venv_gsb = project_root / ".venv" / "bin" / "git-stage-batch"
-
-        if venv_gsb.exists():
-            cmd = [str(venv_gsb), "interactive"]
-        else:
-            cmd = ["uv", "run", "--", "git-stage-batch", "interactive"]
-
-        result = subprocess.run(
-            cmd,
-            input="q\n",
-            text=True,
-            capture_output=True,
-            timeout=INTERACTIVE_TIMEOUT,
-            check=False
-        )
+        result = run_interactive("q", cli_args=("interactive",))
         assert result.returncode == 0
 
     def test_interactive_with_no_changes(self, functional_repo):


### PR DESCRIPTION
Functional tests launch the in-tree command through several helper implementations. Scripted terminal sessions cover the `-i` flag, the `interactive` command, and the abort, again, and display workflows.

Those modules duplicate executable selection, use different five- and fifteen-second deadlines, and provide different amounts of timeout context. A healthy workflow can therefore fail when a hosted runner is under load, and the resulting report may not identify which command or input sequence was active.

This PR adds one functional command builder and one scripted interactive runner, then moves every affected workflow onto them. The shared runner uses a sixty-second hang guard and reports the command, scripted input, stdout, and stderr separately when that guard expires.

The interactive suite now applies one executable-resolution rule, one hang deadline, and one diagnostic format. The 131 affected functional tests pass on the rebased branch.
