### PR TITLE
include: Use reviewed index positions for repeated boundaries

### DIFF
--- a/src/git_stage_batch/batch/realized_file_content.py
+++ b/src/git_stage_batch/batch/realized_file_content.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 
 from ..core.buffer import LineBuffer
 from ..editor.line_endings import (
-    detect_line_ending,
+    choose_line_ending,
     restore_line_endings_in_chunks,
 )
 from ..core.text_lines import normalize_line_sequence_endings
@@ -27,9 +27,15 @@ def build_realized_buffer_from_lines(
     batch_source_lines: Sequence[bytes],
     ownership: "BatchOwnership",
     *,
+    preferred_line_ending_lines: Sequence[bytes] | None = None,
     spool_dir: str | Path | None = None,
 ) -> LineBuffer:
-    """Build realized batch content as a line buffer."""
+    """Build realized content, optionally preferring a target's line endings."""
+    line_ending_sources = (
+        (batch_source_lines,)
+        if preferred_line_ending_lines is None
+        else (preferred_line_ending_lines, batch_source_lines)
+    )
     return LineBuffer.from_chunks(
         restore_line_endings_in_chunks(
             _stream_realized_content_chunks_from_lines(
@@ -38,7 +44,7 @@ def build_realized_buffer_from_lines(
                 ownership,
                 spool_dir=spool_dir,
             ),
-            detect_line_ending(batch_source_lines),
+            choose_line_ending(*line_ending_sources),
         ),
         spool_dir=spool_dir,
     )

--- a/src/git_stage_batch/commands/selection/include_line_selection.py
+++ b/src/git_stage_batch/commands/selection/include_line_selection.py
@@ -22,6 +22,7 @@ from ...batch.state.batch_names import batch_exists
 from ...core.buffer import LineBuffer, buffer_matches
 from ...batch.source.snapshots import create_batch_source_commit
 from ...batch.source.line_coordinates import translate_display_source_coordinates
+from ...batch.realized_file_content import build_realized_buffer_from_lines
 from ...data.selected_change.file_hunk_cache import cache_unstaged_file_as_single_hunk
 from ...data.file_modes import detect_file_mode
 from ...data.file_tracking import auto_add_untracked_files
@@ -201,6 +202,34 @@ def annotate_line_changes_with_working_tree_source(line_changes):
     return replace(line_changes, lines=new_lines)
 
 
+def build_transient_index_buffer(
+    *,
+    source_lines: Sequence[bytes],
+    ownership,
+    current_index_lines: Sequence[bytes],
+    hunk_base_lines: Sequence[bytes],
+) -> LineBuffer:
+    """Merge structurally, then use unchanged reviewed index coordinates."""
+    try:
+        return merge_batch_from_line_sequences_as_buffer(
+            source_lines,
+            ownership,
+            current_index_lines,
+        )
+    except MergeError:
+        # The ownership references use the reviewed index snapshot's
+        # coordinates. They are a safe fallback only while the live index
+        # still matches that exact baseline.
+        if not buffer_matches(current_index_lines, hunk_base_lines):
+            raise
+        return build_realized_buffer_from_lines(
+            current_index_lines,
+            source_lines,
+            ownership,
+            preferred_line_ending_lines=current_index_lines,
+        )
+
+
 def try_build_index_content_via_transient_batch(
     *,
     line_changes,
@@ -316,10 +345,11 @@ def try_build_index_content_via_transient_batch(
                 source_buffer as source_lines,
             ):
                 try:
-                    target_index_buffer = merge_batch_from_line_sequences_as_buffer(
-                        source_lines,
-                        ownership,
-                        current_index_lines,
+                    target_index_buffer = build_transient_index_buffer(
+                        source_lines=source_lines,
+                        ownership=ownership,
+                        current_index_lines=current_index_lines,
+                        hunk_base_lines=hunk_base_lines,
                     )
                 except MergeError as error:
                     return TransientIncludeResult.failure(

--- a/tests/batch/test_storage_duplication.py
+++ b/tests/batch/test_storage_duplication.py
@@ -379,6 +379,22 @@ def test_build_realized_buffer_from_lines_returns_buffer():
         assert result.byte_count == len(b"A\r\nNEW\r\nB\r\n")
 
 
+def test_build_realized_buffer_can_prefer_base_line_endings():
+    """A target merge can retain LF when its batch source uses CRLF."""
+    base_content = b"A\nB\n"
+    batch_source_content = b"A\r\nNEW\r\nB\r\n"
+    ownership = BatchOwnership.from_presence_lines(["2"], [])
+    base_lines = base_content.splitlines(keepends=True)
+
+    with build_realized_buffer_from_lines(
+        base_lines,
+        batch_source_content.splitlines(keepends=True),
+        ownership,
+        preferred_line_ending_lines=base_lines,
+    ) as result:
+        assert result.to_bytes() == b"A\nNEW\nB\n"
+
+
 def test_build_realized_content_equal_block_with_unclaimed_insert():
     """Test that unclaimed inserts don't appear, and equal blocks work correctly."""
     # Base: A, B, C

--- a/tests/commands/test_include.py
+++ b/tests/commands/test_include.py
@@ -60,6 +60,88 @@ def _show_index_file(repo, file_name: str) -> str:
     ).stdout
 
 
+def test_transient_index_buffer_prefers_structural_merge(monkeypatch):
+    """Ordinary index merges should not use the coordinate fallback."""
+    structural_result = object()
+    monkeypatch.setattr(
+        include_line_selection,
+        "merge_batch_from_line_sequences_as_buffer",
+        lambda *_args: structural_result,
+    )
+    monkeypatch.setattr(
+        include_line_selection,
+        "build_realized_buffer_from_lines",
+        lambda *_args, **_kwargs: pytest.fail("coordinate fallback was used"),
+    )
+
+    result = include_line_selection.build_transient_index_buffer(
+        source_lines=[b"base\n", b"selected\n"],
+        ownership=object(),
+        current_index_lines=[b"base\n"],
+        hunk_base_lines=[b"base\n"],
+    )
+
+    assert result is structural_result
+
+
+def test_transient_index_buffer_uses_reviewed_coordinates_for_unchanged_index(
+    monkeypatch,
+):
+    """An unchanged reviewed index can resolve an ambiguous structural merge."""
+    coordinate_result = object()
+
+    def refuse_structural_merge(*_args):
+        raise MergeError("repeated boundary")
+
+    monkeypatch.setattr(
+        include_line_selection,
+        "merge_batch_from_line_sequences_as_buffer",
+        refuse_structural_merge,
+    )
+    monkeypatch.setattr(
+        include_line_selection,
+        "build_realized_buffer_from_lines",
+        lambda *_args, **_kwargs: coordinate_result,
+    )
+
+    result = include_line_selection.build_transient_index_buffer(
+        source_lines=[b"base\n", b"selected\n"],
+        ownership=object(),
+        current_index_lines=[b"base\n"],
+        hunk_base_lines=[b"base\n"],
+    )
+
+    assert result is coordinate_result
+
+
+def test_transient_index_buffer_rejects_coordinates_after_index_change(
+    monkeypatch,
+):
+    """A changed index must retain the ambiguity-safe merge refusal."""
+
+    def refuse_structural_merge(*_args):
+        raise MergeError("repeated boundary")
+
+    monkeypatch.setattr(
+        include_line_selection,
+        "merge_batch_from_line_sequences_as_buffer",
+        refuse_structural_merge,
+    )
+    monkeypatch.setattr(
+        include_line_selection,
+        "build_realized_buffer_from_lines",
+        lambda *_args, **_kwargs: pytest.fail("stale coordinates were trusted"),
+    )
+
+    with pytest.raises(MergeError, match="repeated boundary"):
+        include_line_selection.build_transient_index_buffer(
+            source_lines=[b"base\n", b"selected\n"],
+            ownership=object(),
+            current_index_lines=[b"changed\n"],
+            hunk_base_lines=[b"base\n"],
+        )
+
+
 @pytest.fixture
 def temp_git_repo(tmp_path, monkeypatch):
     """Create a temporary git repository for testing."""

--- a/tests/functional/test_include_line_transient_staging.py
+++ b/tests/functional/test_include_line_transient_staging.py
@@ -254,6 +254,48 @@ def test_repeated_anchor_fallback_uses_reviewed_occurrence(functional_repo):
     assert (functional_repo / "file.txt").read_text() == changed
 
 
+@pytest.mark.parametrize(
+    ("second_line_spec", "staged_addition"),
+    [
+        pytest.param("2", "selected\nunselected\n", id="later-text-line"),
+        pytest.param("3", "selected\n\n", id="later-blank-line"),
+    ],
+)
+def test_consecutive_line_includes_before_repeated_anchor(
+    functional_repo,
+    second_line_spec,
+    staged_addition,
+):
+    """A prior include can anchor another line from the same reviewed group."""
+    changed, expected_prefix, expected_suffix = (
+        _prepare_repeated_anchor_insertion(functional_repo)
+    )
+
+    git_stage_batch("start", "--no-auto-advance")
+    git_stage_batch("show", "--file", "file.txt", "--page", "all")
+    first_result = git_stage_batch(
+        "include",
+        "--line",
+        "1",
+        "--no-auto-advance",
+        check=False,
+    )
+    second_result = git_stage_batch(
+        "include",
+        "--line",
+        second_line_spec,
+        "--no-auto-advance",
+        check=False,
+    )
+
+    assert first_result.returncode == 0, first_result.stderr
+    assert second_result.returncode == 0, second_result.stderr
+    assert _index_content(functional_repo, "file.txt") == (
+        expected_prefix + staged_addition + expected_suffix
+    )
+    assert (functional_repo / "file.txt").read_text() == changed
+
+
 def test_discard_to_batch_after_consecutive_line_includes(functional_repo):
     _prepare_ambiguous_middle_insertion(functional_repo)
 

--- a/tests/functional/test_include_line_transient_staging.py
+++ b/tests/functional/test_include_line_transient_staging.py
@@ -2,6 +2,8 @@
 
 import subprocess
 
+import pytest
+
 from .conftest import git_stage_batch
 
 
@@ -115,6 +117,24 @@ def _prepare_ambiguous_middle_insertion(repo) -> None:
     git_stage_batch("show", "--file", "file.txt", "--page", "all")
 
 
+def _prepare_repeated_anchor_insertion(repo) -> tuple[str, str, str]:
+    prefix = "import pytest\n\n\n"
+    suffix = (
+        "@pytest.fixture\n"
+        "def first_fixture():\n"
+        "    return None\n"
+        "\n"
+        "\n"
+        "@pytest.fixture\n"
+        "def second_fixture():\n"
+        "    return None\n"
+    )
+    changed = prefix + "selected\nunselected\n\n\n" + suffix
+    _commit_file(repo, "file.txt", prefix + suffix)
+    (repo / "file.txt").write_text(changed)
+    return changed, prefix, suffix
+
+
 def test_include_line_transient_staging_first_replace_row(functional_repo):
     _commit_file(functional_repo, "file.txt", "a\nb\n")
     (functional_repo / "file.txt").write_text("A\nB\n")
@@ -163,6 +183,36 @@ def test_include_line_transient_staging_pure_addition(functional_repo):
     git_stage_batch("include", "--line", "1")
 
     assert _index_content(functional_repo, "file.txt") == "base\nfoo\n"
+
+
+@pytest.mark.parametrize(
+    ("line_spec", "staged_addition"),
+    [
+        pytest.param("1", "selected\n", id="first-line"),
+        pytest.param("2", "unselected\n", id="later-line"),
+        pytest.param("1-2", "selected\nunselected\n", id="multiple-lines"),
+        pytest.param("3", "\n", id="blank-line"),
+    ],
+)
+def test_include_line_transient_staging_before_repeated_anchor(
+    functional_repo,
+    line_spec,
+    staged_addition,
+):
+    """A fresh file review can stage an insertion before a repeated anchor."""
+    changed, expected_prefix, expected_suffix = (
+        _prepare_repeated_anchor_insertion(functional_repo)
+    )
+
+    git_stage_batch("start")
+    git_stage_batch("show", "--file", "file.txt", "--page", "all")
+    result = git_stage_batch("include", "--line", line_spec, check=False)
+
+    assert result.returncode == 0, result.stderr
+    assert _index_content(functional_repo, "file.txt") == (
+        expected_prefix + staged_addition + expected_suffix
+    )
+    assert (functional_repo / "file.txt").read_text() == changed
 
 
 def test_discard_to_batch_after_consecutive_line_includes(functional_repo):

--- a/tests/functional/test_include_line_transient_staging.py
+++ b/tests/functional/test_include_line_transient_staging.py
@@ -325,6 +325,32 @@ def test_repeated_anchor_fallback_preserves_unrelated_staged_content(
     assert file_path.read_text() == staged_prefix + changed
 
 
+def test_repeated_anchor_fallback_preserves_index_line_endings(functional_repo):
+    """Exact reviewed coordinates retain the index's normalized line endings."""
+    changed, expected_prefix, expected_suffix = (
+        _prepare_repeated_anchor_insertion(functional_repo)
+    )
+    subprocess.run(
+        ["git", "config", "core.autocrlf", "true"],
+        check=True,
+        cwd=functional_repo,
+        capture_output=True,
+    )
+    file_path = functional_repo / "file.txt"
+    changed_crlf = changed.replace("\n", "\r\n").encode()
+    file_path.write_bytes(changed_crlf)
+
+    git_stage_batch("start")
+    git_stage_batch("show", "--file", "file.txt", "--page", "all")
+    result = git_stage_batch("include", "--line", "1", check=False)
+
+    assert result.returncode == 0, result.stderr
+    assert _index_bytes(functional_repo, "file.txt") == (
+        expected_prefix + "selected\n" + expected_suffix
+    ).encode()
+    assert file_path.read_bytes() == changed_crlf
+
+
 def test_discard_to_batch_after_consecutive_line_includes(functional_repo):
     _prepare_ambiguous_middle_insertion(functional_repo)
 

--- a/tests/functional/test_include_line_transient_staging.py
+++ b/tests/functional/test_include_line_transient_staging.py
@@ -215,6 +215,45 @@ def test_include_line_transient_staging_before_repeated_anchor(
     assert (functional_repo / "file.txt").read_text() == changed
 
 
+def test_repeated_anchor_fallback_uses_reviewed_occurrence(functional_repo):
+    """Recorded coordinates distinguish the later repeated boundary."""
+    prefix = "import pytest\n\n\n"
+    first_fixture = (
+        "@pytest.fixture\n"
+        "def first_fixture():\n"
+        "    return None\n"
+        "\n"
+        "\n"
+    )
+    second_fixture = (
+        "@pytest.fixture\n"
+        "def second_fixture():\n"
+        "    return None\n"
+    )
+    changed = (
+        prefix
+        + first_fixture
+        + "selected\nunselected\n\n\n"
+        + second_fixture
+    )
+    _commit_file(
+        functional_repo,
+        "file.txt",
+        prefix + first_fixture + second_fixture,
+    )
+    (functional_repo / "file.txt").write_text(changed)
+
+    git_stage_batch("start")
+    git_stage_batch("show", "--file", "file.txt", "--page", "all")
+    result = git_stage_batch("include", "--line", "1", check=False)
+
+    assert result.returncode == 0, result.stderr
+    assert _index_content(functional_repo, "file.txt") == (
+        prefix + first_fixture + "selected\n" + second_fixture
+    )
+    assert (functional_repo / "file.txt").read_text() == changed
+
+
 def test_discard_to_batch_after_consecutive_line_includes(functional_repo):
     _prepare_ambiguous_middle_insertion(functional_repo)
 

--- a/tests/functional/test_include_line_transient_staging.py
+++ b/tests/functional/test_include_line_transient_staging.py
@@ -296,6 +296,35 @@ def test_consecutive_line_includes_before_repeated_anchor(
     assert (functional_repo / "file.txt").read_text() == changed
 
 
+def test_repeated_anchor_fallback_preserves_unrelated_staged_content(
+    functional_repo,
+):
+    """Exact reviewed coordinates retain content staged before the session."""
+    changed, expected_prefix, expected_suffix = (
+        _prepare_repeated_anchor_insertion(functional_repo)
+    )
+    staged_prefix = "staged before review\n"
+    file_path = functional_repo / "file.txt"
+    file_path.write_text(staged_prefix + expected_prefix + expected_suffix)
+    subprocess.run(
+        ["git", "add", "file.txt"],
+        check=True,
+        cwd=functional_repo,
+        capture_output=True,
+    )
+    file_path.write_text(staged_prefix + changed)
+
+    git_stage_batch("start")
+    git_stage_batch("show", "--file", "file.txt", "--page", "all")
+    result = git_stage_batch("include", "--line", "2", check=False)
+
+    assert result.returncode == 0, result.stderr
+    assert _index_content(functional_repo, "file.txt") == (
+        staged_prefix + expected_prefix + "selected\n" + expected_suffix
+    )
+    assert file_path.read_text() == staged_prefix + changed
+
+
 def test_discard_to_batch_after_consecutive_line_includes(functional_repo):
     _prepare_ambiguous_middle_insertion(functional_repo)
 


### PR DESCRIPTION
Line-level inclusion normally places selected text by structurally merging it into the current index and worktree. That approach avoids trusting coordinates after either copy of the file has changed.

When the same insertion boundary appears more than once, structural matching cannot identify which occurrence the user reviewed even if the index is still byte-for-byte identical to its reviewed snapshot. Reconstructing the index from the wrong source can also discard pre-staged content or turn normalized LF content into a whole-file CRLF rewrite.

This PR continues to prefer structural merging, but falls back to the recorded reviewed index position when structural placement is ambiguous and the live index has not changed. Coordinate-based realization now retains the target index line endings, while worktree updates continue to require structural agreement. Direct and repository-level tests cover first and later repeated boundaries, consecutive selections, pre-staged content, and automatic line-ending conversion.

Selected lines can now be staged at repeated boundaries without choosing the wrong occurrence, discarding existing staged bytes, modifying unselected worktree content, or rewriting index line endings. All 97 affected tests pass on the rebased branch.
