### PR TITLE
batch: Bound include candidate expansion

### DIFF
--- a/src/git_stage_batch/batch/operation_candidates.py
+++ b/src/git_stage_batch/batch/operation_candidates.py
@@ -280,8 +280,8 @@ def build_include_candidate_previews(
     if index_candidates == (None,) and worktree_candidates == (None,):
         return ()
 
-    products = list(product(index_candidates, worktree_candidates))
-    if len(products) > _MAX_OPERATION_CANDIDATES:
+    product_count = len(index_candidates) * len(worktree_candidates)
+    if product_count > _MAX_OPERATION_CANDIDATES:
         raise _CandidateEnumerationLimitError(
             "too many include candidates to preview safely"
         )
@@ -301,13 +301,16 @@ def build_include_candidate_previews(
         selection_ids=selection_ids,
         replacement_payload=replacement_payload,
     )
-    count = len(products)
+    count = product_count
     previews: list[_OperationCandidatePreview] = []
     try:
         for ordinal, (
             index_candidate,
             worktree_candidate,
-        ) in enumerate(products, start=1):
+        ) in enumerate(
+            product(index_candidates, worktree_candidates),
+            start=1,
+        ):
             index_preview = _materialize_target_candidate(
                 target="index",
                 file_path=file_path,

--- a/tests/batch/test_operation_candidates.py
+++ b/tests/batch/test_operation_candidates.py
@@ -6,6 +6,7 @@ import pytest
 
 from git_stage_batch.batch import operation_candidates
 from git_stage_batch.batch.operation_candidate_types import (
+    CandidateEnumerationLimitError,
     OperationCandidatePreview,
     TargetCandidatePreview,
 )
@@ -72,6 +73,52 @@ def test_operation_candidate_preview_rejects_missing_target():
         preview.close()
 
     assert exc_info.value.args == ("index",)
+
+
+def test_include_candidate_limit_precedes_product_materialization(
+    monkeypatch,
+):
+    """Over-limit target choices should fail before building their product."""
+    target_candidates = iter(
+        (
+            tuple(object() for _index in range(8)),
+            tuple(object() for _index in range(8)),
+        )
+    )
+    monkeypatch.setattr(
+        operation_candidates,
+        "_merge_candidates_or_unambiguous",
+        lambda *_args, **_kwargs: next(target_candidates),
+    )
+    monkeypatch.setattr(
+        operation_candidates,
+        "product",
+        lambda *_args: (_ for _ in ()).throw(
+            AssertionError("candidate product was materialized")
+        ),
+    )
+
+    with pytest.raises(
+        CandidateEnumerationLimitError,
+        match="too many include candidates",
+    ):
+        operation_candidates.build_include_candidate_previews(
+            batch_name="batch",
+            file_path="notes.txt",
+            source_lines=object(),
+            ownership=object(),
+            index_lines=object(),
+            worktree_lines=object(),
+            batch_source_commit="commit",
+            file_meta={},
+            text_change_type="modified",
+            index_file_mode=None,
+            worktree_file_mode=None,
+            index_exists=True,
+            worktree_exists=True,
+            selected_ids=None,
+            selection_ids=None,
+        )
 
 
 def test_target_candidate_materialization_clones_before_buffer(monkeypatch):


### PR DESCRIPTION
Include candidate planning combines index and worktree choices into a
Cartesian product before generating previews.

Large conflicting choice sets currently materialize that full product before
the existing safety limit runs, so the limit does not bound initial memory
use.

This pull request calculates the combined count before expansion, rejects
oversized sets immediately, and iterates accepted products lazily. A focused
regression test ensures product iteration cannot begin before the check.

Validation: `tests/batch/test_operation_candidates.py` passes with 6 tests.