### PR TITLE
batch: Distinguish coordinate-aware merge outcomes

### DIFF
--- a/src/git_stage_batch/batch/merge/baseline_edits.py
+++ b/src/git_stage_batch/batch/merge/baseline_edits.py
@@ -1214,13 +1214,45 @@ def _has_complete_baseline_references(
 ) -> bool:
     for claimed_line in presence_line_set:
         reference = ownership.presence_baseline_reference(claimed_line)
-        if reference is None or not getattr(reference, "has_after_line", False):
+        if reference is None or not reference.has_after_line:
             return False
     for claim in deletion_claims:
         reference = claim.baseline_reference
-        if reference is None or not getattr(reference, "has_after_line", False):
+        if reference is None or not reference.has_after_line:
             return False
     return bool(presence_line_set or deletion_claims)
+
+
+def has_recorded_baseline_coordinates(
+    ownership: BatchOwnership,
+    presence_line_set: LineSelection,
+    deletion_claims: Sequence[AbsenceClaim],
+) -> bool:
+    """Return whether selected edit metadata includes a recorded coordinate."""
+    for presence_claim in ownership.presence_claims:
+        for claimed_line, presence_reference in (
+            presence_claim.baseline_references.items()
+        ):
+            if (
+                claimed_line in presence_line_set
+                and presence_reference.has_after_line
+            ):
+                return True
+    for deletion_claim in deletion_claims:
+        deletion_reference = deletion_claim.baseline_reference
+        if (
+            deletion_reference is not None
+            and deletion_reference.has_after_line
+        ):
+            return True
+    for unit in ownership.replacement_units:
+        origin = unit.origin
+        if origin is None:
+            continue
+        origin_reference = origin.baseline_reference
+        if origin_reference is not None and origin_reference.has_after_line:
+            return True
+    return False
 
 
 def _all_deletions_are_already_absent(

--- a/src/git_stage_batch/batch/merge/candidates.py
+++ b/src/git_stage_batch/batch/merge/candidates.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
+from enum import Enum
 
 
 @dataclass(frozen=True)
@@ -43,8 +44,45 @@ class MergeCandidate:
         )
 
 
+class MergeCandidateSetOutcome(Enum):
+    """Outcome represented by one merge-candidate discovery result."""
+
+    REFUSED = "refused"
+    ORDINARY_MERGE_SUCCEEDED = "ordinary-merge-succeeded"
+    REVIEW_REQUIRED = "review-required"
+
+
 @dataclass(frozen=True)
 class MergeCandidateSet:
-    """Merge candidates for one target."""
+    """Validated merge-candidate discovery result for one target."""
 
     candidates: tuple[MergeCandidate, ...]
+    outcome: MergeCandidateSetOutcome = MergeCandidateSetOutcome.REFUSED
+
+    def __post_init__(self) -> None:
+        review_required = (
+            self.outcome is MergeCandidateSetOutcome.REVIEW_REQUIRED
+        )
+        if bool(self.candidates) != review_required:
+            raise ValueError(
+                "review-required results must contain candidates and "
+                "other results must not"
+            )
+
+    @classmethod
+    def refused(cls) -> MergeCandidateSet:
+        """Return a hard refusal with no enumerable review choices."""
+        return cls((), MergeCandidateSetOutcome.REFUSED)
+
+    @classmethod
+    def ordinary_merge(cls) -> MergeCandidateSet:
+        """Return an ordinary merge that needs no candidate review."""
+        return cls((), MergeCandidateSetOutcome.ORDINARY_MERGE_SUCCEEDED)
+
+    @classmethod
+    def review_required(
+        cls,
+        candidates: tuple[MergeCandidate, ...],
+    ) -> MergeCandidateSet:
+        """Return a nonempty set of reviewed merge choices."""
+        return cls(candidates, MergeCandidateSetOutcome.REVIEW_REQUIRED)

--- a/src/git_stage_batch/batch/merge/coordinate_strategy.py
+++ b/src/git_stage_batch/batch/merge/coordinate_strategy.py
@@ -1,0 +1,13 @@
+"""Resolution values for coordinate-versus-structural merge ambiguity."""
+
+from enum import Enum
+
+
+AMBIGUITY_KEY = "baseline-coordinate-vs-structural"
+
+
+class CoordinateStrategyChoice(Enum):
+    """A reviewed choice between two valid merge strategies."""
+
+    STRUCTURAL = 1
+    RECORDED_COORDINATES = 2

--- a/tests/batch/merge/test_baseline_edits.py
+++ b/tests/batch/merge/test_baseline_edits.py
@@ -51,6 +51,15 @@ class _InterruptingLines(Sequence[bytes]):
         raise KeyboardInterrupt
 
 
+class _IterationGuardedSelection(LineRanges):
+    """Selection whose individual lines must not be expanded."""
+
+    __slots__ = ()
+
+    def __iter__(self):
+        raise AssertionError("selected line ranges must not be expanded")
+
+
 def _boundary_reference(
     *,
     after_line: int | None,
@@ -126,6 +135,25 @@ def test_baseline_edit_planning_composes_all_edit_kinds() -> None:
 
     assert result is not None
     assert list(result) == [b"new value\n", b"inserted\n", b"tail\n"]
+
+
+def test_coordinate_detection_scans_references_not_selected_lines() -> None:
+    """Coordinate detection must scale with edits, not selected line count."""
+    line_count = 1_000_000
+    reference = _boundary_reference(
+        after_line=None,
+        before_line=None,
+    )
+    ownership = BatchOwnership.from_presence_lines(
+        [f"1-{line_count}"],
+        baseline_references={line_count: reference},
+    )
+
+    assert baseline_edits.has_recorded_baseline_coordinates(
+        ownership,
+        _IterationGuardedSelection.from_ranges(((line_count, line_count),)),
+        [],
+    )
 
 
 def test_same_boundary_replacement_payloads_follow_source_order() -> None:

--- a/tests/batch/merge/test_candidates.py
+++ b/tests/batch/merge/test_candidates.py
@@ -1,0 +1,72 @@
+"""Tests for merge candidate result value objects."""
+
+import pytest
+
+from git_stage_batch.batch.merge.candidates import (
+    MergeCandidate,
+    MergeCandidateSet,
+    MergeCandidateSetOutcome,
+)
+from git_stage_batch.batch.merge.coordinate_strategy import (
+    CoordinateStrategyChoice,
+)
+
+
+def _candidate() -> MergeCandidate:
+    return MergeCandidate(
+        ordinal=1,
+        count=1,
+        decisions=(),
+        summary="review this merge",
+        source_line_range=None,
+        target_after_line=None,
+        target_before_line=None,
+        explanation="candidate result",
+    )
+
+
+@pytest.mark.parametrize(
+    "outcome",
+    [
+        MergeCandidateSetOutcome.REFUSED,
+        MergeCandidateSetOutcome.ORDINARY_MERGE_SUCCEEDED,
+    ],
+)
+def test_nonreview_outcomes_reject_candidates(outcome):
+    """No-review outcomes must not carry contradictory candidates."""
+    with pytest.raises(ValueError, match="review-required"):
+        MergeCandidateSet((_candidate(),), outcome)
+
+
+def test_review_outcome_requires_candidates():
+    """A review-required result must include at least one concrete choice."""
+    with pytest.raises(ValueError, match="review-required"):
+        MergeCandidateSet((), MergeCandidateSetOutcome.REVIEW_REQUIRED)
+
+
+def test_candidate_result_factories_construct_valid_outcomes():
+    """Named constructors should expose the complete result state."""
+    candidate = _candidate()
+
+    refused = MergeCandidateSet.refused()
+    ordinary = MergeCandidateSet.ordinary_merge()
+    review = MergeCandidateSet.review_required((candidate,))
+
+    assert refused == MergeCandidateSet(
+        (),
+        MergeCandidateSetOutcome.REFUSED,
+    )
+    assert ordinary == MergeCandidateSet(
+        (),
+        MergeCandidateSetOutcome.ORDINARY_MERGE_SUCCEEDED,
+    )
+    assert review == MergeCandidateSet(
+        (candidate,),
+        MergeCandidateSetOutcome.REVIEW_REQUIRED,
+    )
+
+
+def test_coordinate_strategy_is_not_implicitly_an_integer():
+    """Strategy decisions should serialize explicitly through their values."""
+    assert not isinstance(CoordinateStrategyChoice.STRUCTURAL, int)
+    assert CoordinateStrategyChoice.STRUCTURAL.value == 1


### PR DESCRIPTION
Merge candidate discovery currently represents every no-choice result with
an empty collection, and saved ownership metadata can contain recorded
baseline coordinates without a cheap way to identify them.

Operation planning cannot distinguish an ordinary merge from a refusal, and
merge discovery cannot decide when coordinate-guided planning is available
without risking range expansion proportional to file size.

This pull request gives candidate sets validated refusal, ordinary-success,
and review-required outcomes. It also detects recorded coordinates directly
from ownership metadata and protects that lookup with range-backed tests.

This groundwork is the first connected layer for explicit review when
structural matching and recorded coordinates produce different safe merges.
Validation: 24 focused tests pass.