### PR TITLE
batch: Review conflicting merge strategies

### DIFF
--- a/src/git_stage_batch/batch/merge/candidate_enumeration.py
+++ b/src/git_stage_batch/batch/merge/candidate_enumeration.py
@@ -29,6 +29,10 @@ from .candidates import (
     MergeResolution as _MergeResolution,
     MergeResolutionDecision as _MergeResolutionDecision,
 )
+from .coordinate_strategy import (
+    AMBIGUITY_KEY as _COORDINATE_STRATEGY_AMBIGUITY_KEY,
+    CoordinateStrategyChoice as _CoordinateStrategyChoice,
+)
 from .validation import (
     check_structural_validity as _check_merge_structural_validity,
 )
@@ -57,6 +61,58 @@ class _UnresolvedReplacementOrigin:
     choices: tuple[_BaselineReplacementOriginChoice, ...]
 
 
+def _coordinate_strategy_candidate_set(
+    *,
+    strategies_differ: bool,
+    max_candidates: int,
+) -> _MergeCandidateSet:
+    """Offer both merge strategies when their valid results disagree."""
+    if not strategies_differ:
+        return _MergeCandidateSet.refused()
+    if max_candidates < 2:
+        raise _MergeError(_("Too many merge candidates to preview safely"))
+
+    explanation = _(
+        "recorded baseline coordinates and structural content matching "
+        "produce different results"
+    )
+    choices = (
+        (
+            _CoordinateStrategyChoice.STRUCTURAL,
+            _("use structural content matching"),
+        ),
+        (
+            _CoordinateStrategyChoice.RECORDED_COORDINATES,
+            _("use recorded baseline coordinates"),
+        ),
+    )
+    return _MergeCandidateSet.review_required(
+        tuple(
+            _MergeCandidate(
+                ordinal=ordinal,
+                count=len(choices),
+                decisions=(
+                    _MergeResolutionDecision(
+                        ambiguity_key=_COORDINATE_STRATEGY_AMBIGUITY_KEY,
+                        choice_index=choice_index.value,
+                        choice_label=summary,
+                    ),
+                ),
+                summary=summary,
+                source_line_range=None,
+                target_after_line=None,
+                target_before_line=None,
+                explanation=explanation,
+                ambiguity_target_line_range=None,
+            )
+            for ordinal, (choice_index, summary) in enumerate(
+                choices,
+                start=1,
+            )
+        )
+    )
+
+
 def _find_unresolved_replacement_origin(
     source_lines: Sequence[bytes],
     ownership: "BatchOwnership",
@@ -78,10 +134,8 @@ def _find_unresolved_replacement_origin(
         try:
             selected_presence = coerce_line_ranges(presence_line_set)
             unresolved = None
-            for unit_index, unit in enumerate(
-                getattr(ownership, "replacement_units", [])
-            ):
-                if getattr(unit, "origin", None) is None:
+            for unit_index, unit in enumerate(ownership.replacement_units):
+                if unit.origin is None:
                     continue
 
                 claimed_ranges = _collect_replacement_source_ranges(
@@ -196,7 +250,7 @@ def _replacement_origin_candidate_set(
         spool_dir=spool_dir,
     )
     if unresolved is None:
-        return _MergeCandidateSet(())
+        return _MergeCandidateSet.refused()
 
     source_start = unresolved.source_start
     source_end = unresolved.source_end
@@ -213,7 +267,7 @@ def _replacement_origin_candidate_set(
             valid_choices.append(choice)
 
     if not valid_choices:
-        return _MergeCandidateSet(())
+        return _MergeCandidateSet.refused()
 
     count = len(valid_choices)
     claim = deletion_claims[deletion_index]
@@ -261,7 +315,7 @@ def _replacement_origin_candidate_set(
                 ambiguity_target_line_range=ambiguity_target_line_range,
             )
         )
-    return _MergeCandidateSet(tuple(candidates))
+    return _MergeCandidateSet.review_required(tuple(candidates))
 
 
 def _presence_candidate_set(
@@ -300,7 +354,7 @@ def _presence_candidate_set(
     if presence_key is not None and len(presence_choices) > max_candidates:
         raise _MergeError(_("Too many merge candidates to preview safely"))
     if presence_key is None or len(presence_choices) <= 1:
-        return _MergeCandidateSet(())
+        return _MergeCandidateSet.refused()
 
     valid_choices: list[_presence_placement_choices.PresenceChoice] = []
     for choice in presence_choices:
@@ -309,7 +363,7 @@ def _presence_candidate_set(
             valid_choices.append(choice)
 
     if len(valid_choices) <= 1:
-        return _MergeCandidateSet(())
+        return _MergeCandidateSet.refused()
 
     count = len(valid_choices)
     ambiguity_target_line_range = (
@@ -350,7 +404,7 @@ def _presence_candidate_set(
                 ambiguity_target_line_range=ambiguity_target_line_range,
             )
         )
-    return _MergeCandidateSet(tuple(candidates))
+    return _MergeCandidateSet.review_required(tuple(candidates))
 
 
 def _absence_candidate_set(
@@ -365,7 +419,7 @@ def _absence_candidate_set(
     spool_dir: str | Path | None,
 ) -> _MergeCandidateSet:
     if not deletion_claims:
-        return _MergeCandidateSet(())
+        return _MergeCandidateSet.refused()
 
     if len([claim for claim in deletion_claims if claim.content_lines]) != 1:
         raise _MergeError(_("Batch was created from a different version of the file"))
@@ -383,16 +437,12 @@ def _absence_candidate_set(
             source_lines,
             working_lines,
         )
-        presence_arguments = {
-            "source_to_working_mapping": owned_mapping,
-        }
-        if spool_dir is not None:
-            presence_arguments["spool_dir"] = spool_dir
         realized_entries = _presence_constraints.apply_presence_constraints(
             source_lines,
             working_lines,
             presence_line_set,
-            **presence_arguments,
+            source_to_working_mapping=owned_mapping,
+            spool_dir=spool_dir,
         )
     finally:
         owned_mapping.close()
@@ -422,7 +472,7 @@ def _absence_candidate_set(
         if len(choices) > max_candidates:
             raise _MergeError(_("Too many merge candidates to preview safely"))
         if len(choices) <= 1:
-            return _MergeCandidateSet(())
+            return _MergeCandidateSet.refused()
 
         valid_choices: list[_MergeAbsenceChoice] = []
         for choice in choices:
@@ -431,7 +481,7 @@ def _absence_candidate_set(
                 valid_choices.append(choice)
 
         if len(valid_choices) <= 1:
-            return _MergeCandidateSet(())
+            return _MergeCandidateSet.refused()
 
         count = len(valid_choices)
         ambiguity_target_line_range = (
@@ -475,7 +525,7 @@ def _absence_candidate_set(
                     ambiguity_target_line_range=ambiguity_target_line_range,
                 )
             )
-        return _MergeCandidateSet(tuple(candidates))
+        return _MergeCandidateSet.review_required(tuple(candidates))
     finally:
         realized_entries.close()
 
@@ -487,9 +537,17 @@ def enumerate_merge_batch_candidates_for_lines(
     *,
     resolution_is_valid: _MergeResolutionValidator,
     max_candidates: int,
+    coordinate_strategies_differ: bool = False,
     spool_dir: str | Path | None = None,
 ) -> _MergeCandidateSet:
     """Enumerate merge candidates for acquired normalized line sequences."""
+    coordinate_strategy_candidates = _coordinate_strategy_candidate_set(
+        strategies_differ=coordinate_strategies_differ,
+        max_candidates=max_candidates,
+    )
+    if coordinate_strategy_candidates.candidates:
+        return coordinate_strategy_candidates
+
     resolved = ownership.resolve()
     presence_line_set = resolved.presence_line_set
     deletion_claims = resolved.deletion_claims

--- a/src/git_stage_batch/batch/merge/merge.py
+++ b/src/git_stage_batch/batch/merge/merge.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Iterator, Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 from . import baseline_edits as _baseline_edits
 from . import presence_constraints as _presence_constraints
@@ -14,6 +14,10 @@ from .candidate_enumeration import (
 from .candidates import (
     MergeCandidateSet as _MergeCandidateSet,
     MergeResolution as _MergeResolution,
+)
+from .coordinate_strategy import (
+    AMBIGUITY_KEY as _COORDINATE_STRATEGY_AMBIGUITY_KEY,
+    CoordinateStrategyChoice as _CoordinateStrategyChoice,
 )
 from .validation import (
     check_structural_validity as _check_merge_structural_validity,
@@ -29,25 +33,214 @@ from ...editor.line_endings import (
     restore_line_endings_in_chunks,
 )
 from ...editor.line_export import ensure_line_chunk_boundaries
+from ...editor.piece_table import LineLike
 from ...exceptions import (
+    AtomicUnitError as _AtomicUnitError,
     MergeError as _MergeError,
 )
 from ...i18n import _
 from ...core.text_lines import (
     AcquirableLineSequence,
+    as_acquirable_line_sequence,
     normalize_line_sequence_endings,
 )
 
 if TYPE_CHECKING:
+    from ...core.line_selection import LineSelection
+    from ..ownership.absence_claims import AbsenceClaim
     from ..ownership.model import BatchOwnership
+    from ..realization.entry_storage import RealizedEntries
 
 
 _MERGE_CANDIDATE_CAP = 50
 
 
-def _byte_chunks(chunks: Iterable[Any]) -> Iterator[bytes]:
-    for chunk in chunks:
-        yield bytes(chunk)
+class _CoordinateStrategyAmbiguity(_MergeError):
+    """Recorded coordinates and structural matching produced different bytes."""
+
+
+@runtime_checkable
+class _Closeable(Protocol):
+    """Resource that supports explicit cleanup."""
+
+    def close(self) -> None: ...
+
+
+def _close_candidate(candidate: Iterator[bytes] | None) -> None:
+    """Close a lazy merge candidate when it owns planning resources."""
+    if isinstance(candidate, _Closeable):
+        candidate.close()
+
+
+def _coordinate_ambiguity_error() -> _CoordinateStrategyAmbiguity:
+    return _CoordinateStrategyAmbiguity(
+        _(
+            "Cannot safely choose between recorded baseline coordinates "
+            "and structural content matching"
+        )
+    )
+
+
+def _yield_identical_candidate_chunks(
+    coordinate_chunks: Iterable[LineLike],
+    structural_chunks: Iterable[LineLike],
+) -> Iterator[bytes]:
+    """Yield structurally chunked bytes when both candidate streams match."""
+    coordinate_iterator = iter(coordinate_chunks)
+    structural_iterator = iter(structural_chunks)
+    coordinate_chunk = b""
+    structural_chunk = b""
+    coordinate_offset = 0
+    structural_offset = 0
+    coordinate_done = False
+    structural_done = False
+
+    while True:
+        while (
+            coordinate_offset == len(coordinate_chunk)
+            and not coordinate_done
+        ):
+            try:
+                coordinate_chunk = bytes(next(coordinate_iterator))
+                coordinate_offset = 0
+            except StopIteration:
+                coordinate_done = True
+        while (
+            structural_offset == len(structural_chunk)
+            and not structural_done
+        ):
+            try:
+                structural_chunk = bytes(next(structural_iterator))
+                structural_offset = 0
+            except StopIteration:
+                structural_done = True
+
+        if coordinate_done or structural_done:
+            if coordinate_done and structural_done:
+                return
+            raise _coordinate_ambiguity_error()
+
+        compare_size = min(
+            len(coordinate_chunk) - coordinate_offset,
+            len(structural_chunk) - structural_offset,
+        )
+        coordinate_view = memoryview(coordinate_chunk)[
+            coordinate_offset:coordinate_offset + compare_size
+        ]
+        structural_view = memoryview(structural_chunk)[
+            structural_offset:structural_offset + compare_size
+        ]
+        try:
+            if coordinate_view != structural_view:
+                raise _coordinate_ambiguity_error()
+        finally:
+            coordinate_view.release()
+            structural_view.release()
+
+        coordinate_offset += compare_size
+        structural_offset += compare_size
+        if structural_offset == len(structural_chunk):
+            yield structural_chunk
+
+
+def _build_structural_realized_entries(
+    source_lines: Sequence[bytes],
+    ownership: "BatchOwnership",
+    working_lines: Sequence[bytes],
+    presence_line_set: "LineSelection",
+    deletion_claims: list["AbsenceClaim"],
+    *,
+    source_to_working_mapping: LineMapping | None,
+    resolution: _MergeResolution | None,
+    spool_dir: str | Path | None,
+) -> "RealizedEntries":
+    """Build the structural candidate while owning any derived mapping."""
+    owned_mapping: LineMapping | None = None
+    mapping = source_to_working_mapping
+    try:
+        with _baseline_edits.acquire_deletion_anchor_pairs_for_target(
+            source_lines,
+            working_lines,
+            deletion_claims,
+            spool_dir=spool_dir,
+        ) as deletion_anchor_pairs:
+            if mapping is None or deletion_anchor_pairs:
+                owned_mapping = match_lines(
+                    source_lines,
+                    working_lines,
+                    anchor_pairs=deletion_anchor_pairs,
+                    spool_dir=spool_dir,
+                )
+                mapping = owned_mapping
+
+        if _baseline_edits.has_missing_origin_replacement_claims(
+            ownership,
+            presence_line_set,
+            source_lines,
+            mapping,
+            spool_dir=spool_dir,
+        ):
+            raise _MergeError(
+                _(
+                    "Cannot reliably place split replacement: original replacement "
+                    "boundary is not present"
+                )
+            )
+
+        try:
+            _check_merge_structural_validity(
+                mapping,
+                presence_line_set,
+                deletion_claims,
+                source_lines,
+                working_lines,
+            )
+        except _MergeError:
+            if resolution is None:
+                raise
+
+        return _presence_constraints.satisfy_constraints(
+            source_lines,
+            working_lines,
+            presence_line_set,
+            deletion_claims,
+            source_to_working_mapping=mapping,
+            resolution=resolution,
+            spool_dir=spool_dir,
+        )
+    finally:
+        if owned_mapping is not None:
+            owned_mapping.close()
+
+
+def _strategy_choice_and_effective_resolution(
+    resolution: _MergeResolution | None,
+) -> tuple[_CoordinateStrategyChoice | None, _MergeResolution | None]:
+    """Separate the coordinate-strategy decision from structural decisions."""
+    if (
+        resolution is None
+        or _COORDINATE_STRATEGY_AMBIGUITY_KEY not in resolution.decisions
+    ):
+        return None, resolution
+
+    raw_choice = resolution.decisions[_COORDINATE_STRATEGY_AMBIGUITY_KEY]
+    if type(raw_choice) is not int:
+        raise _MergeError(_("Selected merge resolution is no longer valid"))
+    try:
+        choice = _CoordinateStrategyChoice(raw_choice)
+    except ValueError:
+        raise _MergeError(
+            _("Selected merge resolution is no longer valid")
+        ) from None
+    remaining_decisions = {
+        key: value
+        for key, value in resolution.decisions.items()
+        if key != _COORDINATE_STRATEGY_AMBIGUITY_KEY
+    }
+    effective_resolution = (
+        _MergeResolution(remaining_decisions) if remaining_decisions else None
+    )
+    return choice, effective_resolution
 
 
 def _merge_result_line_ending_from_lines(
@@ -72,8 +265,12 @@ def merge_batch_from_line_sequences_as_buffer(
         working_lines,
         source_lines,
     )
-    normalized_source_lines = normalize_line_sequence_endings(source_lines)
-    normalized_working_lines = normalize_line_sequence_endings(working_lines)
+    normalized_source_lines = as_acquirable_line_sequence(
+        normalize_line_sequence_endings(source_lines)
+    )
+    normalized_working_lines = as_acquirable_line_sequence(
+        normalize_line_sequence_endings(working_lines)
+    )
     return LineBuffer.from_chunks(
         restore_line_endings_in_chunks(
             ensure_line_chunk_boundaries(
@@ -101,8 +298,12 @@ def can_merge_batch_from_line_sequences(
     resolution: _MergeResolution | None = None,
 ) -> bool:
     """Return whether a normalized line merge can be applied."""
-    normalized_source_lines = normalize_line_sequence_endings(source_lines)
-    normalized_working_lines = normalize_line_sequence_endings(working_lines)
+    normalized_source_lines = as_acquirable_line_sequence(
+        normalize_line_sequence_endings(source_lines)
+    )
+    normalized_working_lines = as_acquirable_line_sequence(
+        normalize_line_sequence_endings(working_lines)
+    )
     try:
         for _chunk in _merge_batch_line_chunks(
             normalized_source_lines,
@@ -118,9 +319,9 @@ def can_merge_batch_from_line_sequences(
 
 
 def _merge_batch_line_chunks(
-    source_lines: AcquirableLineSequence[Any],
+    source_lines: AcquirableLineSequence[bytes],
     ownership: "BatchOwnership",
-    working_lines: AcquirableLineSequence[Any],
+    working_lines: AcquirableLineSequence[bytes],
     *,
     source_to_working_mapping: LineMapping | None = None,
     resolution: _MergeResolution | None = None,
@@ -154,96 +355,102 @@ def _merge_batch_acquired_line_chunks(
     resolved = ownership.resolve()
     presence_line_set = resolved.presence_line_set
     deletion_claims = resolved.deletion_claims
-
-    fallback_chunks = _baseline_edits.try_apply_baseline_replacement_units(
-        source_lines,
-        working_lines,
-        ownership,
-        presence_line_set,
-        deletion_claims,
-        resolution=resolution,
-        max_resolution_choices=_MERGE_CANDIDATE_CAP + 1,
-        spool_dir=spool_dir,
+    strategy_choice, effective_resolution = (
+        _strategy_choice_and_effective_resolution(resolution)
     )
-    if fallback_chunks is not None:
-        yield from _byte_chunks(fallback_chunks)
-        return
 
-    owned_mapping: LineMapping | None = None
-    mapping = source_to_working_mapping
-    with _baseline_edits.acquire_deletion_anchor_pairs_for_target(
-        source_lines,
-        working_lines,
-        deletion_claims,
-        spool_dir=spool_dir,
-    ) as deletion_anchor_pairs:
-        if mapping is None or deletion_anchor_pairs:
-            owned_mapping = match_lines(
-                source_lines,
-                working_lines,
-                anchor_pairs=deletion_anchor_pairs,
-                spool_dir=spool_dir,
-            )
-            mapping = owned_mapping
-    try:
-        if _baseline_edits.has_missing_origin_replacement_claims(
+    if strategy_choice == _CoordinateStrategyChoice.RECORDED_COORDINATES:
+        if not _baseline_edits.has_recorded_baseline_coordinates(
             ownership,
             presence_line_set,
-            source_lines,
-            mapping,
-            spool_dir=spool_dir,
-        ):
-            raise _MergeError(
-                _(
-                    "Cannot reliably place split replacement: original replacement "
-                    "boundary is not present"
-                )
-            )
-
-        try:
-            _check_merge_structural_validity(
-                mapping, presence_line_set, deletion_claims, source_lines, working_lines
-            )
-        except _MergeError:
-            if resolution is None:
-                raise
-
-        constraint_arguments = {
-            "source_to_working_mapping": mapping,
-            "resolution": resolution,
-        }
-        if spool_dir is not None:
-            constraint_arguments["spool_dir"] = spool_dir
-        realized_entries = _presence_constraints.satisfy_constraints(
-            source_lines,
-            working_lines,
-            presence_line_set,
             deletion_claims,
-            **constraint_arguments,
+        ):
+            raise _MergeError(_("Selected merge resolution is no longer valid"))
+        selected_coordinate_candidate = (
+            _baseline_edits.try_apply_baseline_replacement_units(
+                source_lines,
+                working_lines,
+                ownership,
+                presence_line_set,
+                deletion_claims,
+                resolution=effective_resolution,
+                max_resolution_choices=_MERGE_CANDIDATE_CAP + 1,
+                trust_baseline_coordinates=True,
+                spool_dir=spool_dir,
+            )
         )
-    except _MergeError:
+        if selected_coordinate_candidate is None:
+            raise _MergeError(_("Selected merge resolution is no longer valid"))
+        try:
+            yield from selected_coordinate_candidate
+        finally:
+            _close_candidate(selected_coordinate_candidate)
+        return
+
+    if strategy_choice is None:
         fallback_chunks = _baseline_edits.try_apply_baseline_replacement_units(
             source_lines,
             working_lines,
             ownership,
             presence_line_set,
             deletion_claims,
-            resolution=resolution,
+            resolution=effective_resolution,
             max_resolution_choices=_MERGE_CANDIDATE_CAP + 1,
             spool_dir=spool_dir,
         )
         if fallback_chunks is not None:
-            yield from _byte_chunks(fallback_chunks)
+            try:
+                yield from fallback_chunks
+            finally:
+                _close_candidate(fallback_chunks)
             return
-        raise
-    finally:
-        if owned_mapping is not None:
-            owned_mapping.close()
 
+    coordinate_candidate = None
+    if (
+        resolution is None
+        and _baseline_edits.has_recorded_baseline_coordinates(
+            ownership,
+            presence_line_set,
+            deletion_claims,
+        )
+    ):
+        coordinate_candidate = (
+            _baseline_edits.try_apply_baseline_replacement_units(
+                source_lines,
+                working_lines,
+                ownership,
+                presence_line_set,
+                deletion_claims,
+                resolution=effective_resolution,
+                max_resolution_choices=_MERGE_CANDIDATE_CAP + 1,
+                trust_baseline_coordinates=True,
+                spool_dir=spool_dir,
+            )
+        )
     try:
-        yield from _realized_entry_content_chunks(realized_entries)
+        realized_entries = _build_structural_realized_entries(
+            source_lines,
+            ownership,
+            working_lines,
+            presence_line_set,
+            deletion_claims,
+            source_to_working_mapping=source_to_working_mapping,
+            resolution=effective_resolution,
+            spool_dir=spool_dir,
+        )
+        try:
+            structural_chunks = _realized_entry_content_chunks(realized_entries)
+            if coordinate_candidate is None:
+                yield from structural_chunks
+            else:
+                yield from _yield_identical_candidate_chunks(
+                    coordinate_candidate,
+                    structural_chunks,
+                )
+        finally:
+            realized_entries.close()
     finally:
-        realized_entries.close()
+        _close_candidate(coordinate_candidate)
 
 
 def enumerate_merge_batch_candidates_from_line_sequences(
@@ -267,12 +474,17 @@ def enumerate_merge_batch_candidates_from_line_sequences(
     ):
         raise ValueError(f"max_candidates must be between 1 and {_MERGE_CANDIDATE_CAP}")
 
-    normalized_source_lines = normalize_line_sequence_endings(source_lines)
-    normalized_working_lines = normalize_line_sequence_endings(working_lines)
+    normalized_source_lines = as_acquirable_line_sequence(
+        normalize_line_sequence_endings(source_lines)
+    )
+    normalized_working_lines = as_acquirable_line_sequence(
+        normalize_line_sequence_endings(working_lines)
+    )
     with (
         normalized_source_lines.acquire_lines() as acquired_source_lines,
         normalized_working_lines.acquire_lines() as acquired_working_lines,
     ):
+        coordinate_strategy_ambiguous = False
         try:
             for _chunk in _merge_batch_acquired_line_chunks(
                 acquired_source_lines,
@@ -281,9 +493,14 @@ def enumerate_merge_batch_candidates_from_line_sequences(
                 spool_dir=spool_dir,
             ):
                 pass
-            return _MergeCandidateSet(())
-        except _MergeError:
-            pass
+            return _MergeCandidateSet.ordinary_merge()
+        except _AtomicUnitError:
+            raise
+        except _MergeError as error:
+            coordinate_strategy_ambiguous = isinstance(
+                error,
+                _CoordinateStrategyAmbiguity,
+            )
 
         def resolution_is_valid(candidate_resolution: _MergeResolution) -> bool:
             try:
@@ -305,5 +522,6 @@ def enumerate_merge_batch_candidates_from_line_sequences(
             acquired_working_lines,
             resolution_is_valid=resolution_is_valid,
             max_candidates=max_candidates,
+            coordinate_strategies_differ=coordinate_strategy_ambiguous,
             spool_dir=spool_dir,
         )

--- a/tests/batch/merge/test_baseline_anchor_matching.py
+++ b/tests/batch/merge/test_baseline_anchor_matching.py
@@ -20,6 +20,7 @@ from git_stage_batch.batch.ownership.absence_claims import AbsenceClaim
 from git_stage_batch.batch.ownership.model import BatchOwnership
 from git_stage_batch.batch.ownership.references import BaselineReference
 from git_stage_batch.batch.ownership.replacement_units import ReplacementUnitOrigin
+from git_stage_batch.exceptions import MergeError
 
 
 def _deletion_anchor_pairs(*args, **kwargs):
@@ -124,7 +125,7 @@ def test_live_target_rejects_repeated_verified_deletion_boundary():
 
 @pytest.mark.parametrize("supply_mapping", [False, True])
 def test_live_merge_does_not_apply_ambiguous_baseline_coordinate(supply_mapping):
-    """Structural placement must outrank a stale repeated baseline coordinate."""
+    """A stale deletion coordinate must conflict with structural placement."""
     source = [
         b"P\n",
         b"ANCHOR\n",
@@ -167,35 +168,21 @@ def test_live_merge_does_not_apply_ambiguous_baseline_coordinate(supply_mapping)
         else nullcontext(None)
     )
 
-    with (
-        mapping_context as mapping,
-        merge_batch_from_line_sequences_as_buffer(
-            source,
-            BatchOwnership([], [claim]),
-            target,
-            source_to_working_mapping=mapping,
-        ) as merged,
-    ):
-        result = list(merged)
-
-    assert result == [
-        b"P\n",
-        b"ANCHOR\n",
-        b"OLD\n",
-        b"NEXT\n",
-        b"FILL\n",
-        b"ANCHOR\n",
-        b"OLD\n",
-        b"NEXT\n",
-        b"MIDDLE\n",
-        b"ANCHOR\n",
-        b"NEXT\n",
-        b"TAIL\n",
-    ]
+    with mapping_context as mapping:
+        with pytest.raises(
+            MergeError,
+            match="recorded baseline coordinates and structural content matching",
+        ):
+            merge_batch_from_line_sequences_as_buffer(
+                source,
+                BatchOwnership([], [claim]),
+                target,
+                source_to_working_mapping=mapping,
+            )
 
 
 def test_live_merge_does_not_insert_at_ambiguous_baseline_coordinate():
-    """A stale repeated insertion boundary must defer to structural placement."""
+    """A stale insertion coordinate must conflict with structural placement."""
     source = [
         b"P\n",
         b"ANCHOR\n",
@@ -232,6 +219,55 @@ def test_live_merge_does_not_insert_at_ambiguous_baseline_coordinate():
         },
     )
 
+    with pytest.raises(
+        MergeError,
+        match="recorded baseline coordinates and structural content matching",
+    ):
+        merge_batch_from_line_sequences_as_buffer(
+            source,
+            ownership,
+            target,
+        )
+
+
+def test_live_merge_accepts_identical_coordinate_and_structural_candidates():
+    """Matching candidates should not make a repeated boundary ambiguous."""
+    source = [
+        b"P\n",
+        b"ANCHOR\n",
+        b"NEXT\n",
+        b"MIDDLE\n",
+        b"ANCHOR\n",
+        b"NEW\n",
+        b"NEXT\n",
+        b"TAIL\n",
+    ]
+    target = [
+        b"P\n",
+        b"ANCHOR\n",
+        b"NEXT\n",
+        b"FILL\n",
+        b"ANCHOR\n",
+        b"NEXT\n",
+        b"MIDDLE\n",
+        b"ANCHOR\n",
+        b"NEXT\n",
+        b"TAIL\n",
+    ]
+    ownership = BatchOwnership.from_presence_lines(
+        ["6"],
+        [],
+        baseline_references={
+            6: BaselineReference(
+                after_line=8,
+                after_content=b"ANCHOR\n",
+                before_line=9,
+                before_content=b"NEXT\n",
+                has_before_line=True,
+            ),
+        },
+    )
+
     with merge_batch_from_line_sequences_as_buffer(
         source,
         ownership,
@@ -252,6 +288,56 @@ def test_live_merge_does_not_insert_at_ambiguous_baseline_coordinate():
         b"NEXT\n",
         b"TAIL\n",
     ]
+
+
+def test_repeated_boundary_candidates_match_with_pre_staged_prefix():
+    """A pre-staged prefix must not stale exact reviewed coordinates."""
+    source = [
+        b"staged\n",
+        b"P\n",
+        b"ANCHOR\n",
+        b"NEXT\n",
+        b"MIDDLE\n",
+        b"ANCHOR\n",
+        b"NEW\n",
+        b"NEXT\n",
+        b"TAIL\n",
+    ]
+    target = [
+        b"staged\n",
+        b"P\n",
+        b"ANCHOR\n",
+        b"NEXT\n",
+        b"FILL\n",
+        b"ANCHOR\n",
+        b"NEXT\n",
+        b"MIDDLE\n",
+        b"ANCHOR\n",
+        b"NEXT\n",
+        b"TAIL\n",
+    ]
+    ownership = BatchOwnership.from_presence_lines(
+        ["7"],
+        [],
+        baseline_references={
+            7: BaselineReference(
+                after_line=9,
+                after_content=b"ANCHOR\n",
+                before_line=10,
+                before_content=b"NEXT\n",
+                has_before_line=True,
+            ),
+        },
+    )
+
+    with merge_batch_from_line_sequences_as_buffer(
+        source,
+        ownership,
+        target,
+    ) as merged:
+        result = list(merged)
+
+    assert result == target[:9] + [b"NEW\n"] + target[9:]
 
 
 def test_live_target_accepts_one_unique_composite_deletion_boundary():

--- a/tests/batch/merge/test_baseline_edits.py
+++ b/tests/batch/merge/test_baseline_edits.py
@@ -156,6 +156,112 @@ def test_coordinate_detection_scans_references_not_selected_lines() -> None:
     )
 
 
+def test_trusted_plan_composes_partial_replacement_and_repeated_insertion() -> None:
+    """Partial replacements and additions retain pre-staged target content."""
+    source_lines = [
+        line.encode()
+        for line in (
+            "head\n",
+            "NEW-A\n",
+            "NEW-B\n",
+            "section\n",
+            "marker\n",
+            "ADDED\n",
+            "end\n",
+            "section\n",
+            "marker\n",
+            "end\n",
+            "tail\n",
+        )
+    ]
+    working_lines = [
+        line.encode()
+        for line in (
+            "staged\n",
+            "head\n",
+            "old-a\n",
+            "old-b\n",
+            "section\n",
+            "marker\n",
+            "end\n",
+            "section\n",
+            "marker\n",
+            "end\n",
+            "tail\n",
+        )
+    ]
+    replacement_reference = _boundary_reference(
+        after_line=2,
+        after_content=b"head\n",
+        before_line=4,
+        before_content=b"old-b\n",
+    )
+    insertion_reference = _boundary_reference(
+        after_line=6,
+        after_content=b"marker\n",
+        before_line=7,
+        before_content=b"end\n",
+    )
+    deletion_claims = [
+        AbsenceClaim(
+            anchor_line=1,
+            content_lines=[b"old-a\n"],
+            baseline_reference=replacement_reference,
+        )
+    ]
+    ownership = BatchOwnership.from_presence_lines(
+        ["2", "6"],
+        deletion_claims,
+        baseline_references={
+            2: replacement_reference,
+            6: insertion_reference,
+        },
+        replacement_units=[
+            ReplacementUnit(
+                presence_lines=["2"],
+                deletion_indices=[0],
+                origin=ReplacementUnitOrigin(
+                    old_start=2,
+                    old_end=3,
+                    new_start=2,
+                    new_end=3,
+                    baseline_reference=_boundary_reference(
+                        after_line=2,
+                        after_content=b"head\n",
+                        before_line=5,
+                        before_content=b"section\n",
+                    ),
+                ),
+            )
+        ],
+    )
+
+    result = baseline_edits.try_apply_baseline_replacement_units(
+        source_lines,
+        working_lines,
+        ownership,
+        LineRanges.from_ranges(((2, 2), (6, 6))),
+        deletion_claims,
+        trust_baseline_coordinates=True,
+    )
+
+    assert result is not None
+    assert list(result) == [
+        b"staged\n",
+        b"head\n",
+        b"NEW-A\n",
+        b"old-b\n",
+        b"section\n",
+        b"marker\n",
+        b"ADDED\n",
+        b"end\n",
+        b"section\n",
+        b"marker\n",
+        b"end\n",
+        b"tail\n",
+    ]
+
+
 def test_same_boundary_replacement_payloads_follow_source_order() -> None:
     """Replacement and insertion payloads at one boundary should retain order."""
     source_lines = [b"new one\n", b"new two\n"]

--- a/tests/batch/merge/test_merge.py
+++ b/tests/batch/merge/test_merge.py
@@ -1,8 +1,12 @@
 """Tests for structural batch merge algorithm."""
 
+from itertools import repeat
+import tracemalloc
+
 import pytest
 
 import git_stage_batch.batch.merge.baseline_edits as baseline_edits_module
+import git_stage_batch.batch.merge.candidate_enumeration as candidate_enumeration_module
 import git_stage_batch.batch.merge.merge as merge_module
 import git_stage_batch.batch.realization.provenance as provenance_module
 from git_stage_batch.batch.merge.baseline_correspondence import (
@@ -19,6 +23,11 @@ from git_stage_batch.batch.discard import (
     discard_batch_from_line_sequences_as_buffer,
 )
 from git_stage_batch.batch.line_matching.match import match_lines
+from git_stage_batch.batch.merge.candidates import (
+    MergeCandidateSetOutcome,
+    MergeResolution,
+)
+from git_stage_batch.batch.merge.coordinate_strategy import AMBIGUITY_KEY
 from git_stage_batch.batch.merge.validation import check_structural_validity
 from git_stage_batch.batch.merge.merge import (
     _merge_batch_line_chunks,
@@ -33,7 +42,7 @@ from git_stage_batch.batch.realization.entry_storage import (
     realized_entry_content_chunks,
 )
 from git_stage_batch.core.buffer import LineBuffer
-from git_stage_batch.exceptions import MergeError
+from git_stage_batch.exceptions import AtomicUnitError, MergeError
 from git_stage_batch.batch.ownership.absence_claims import AbsenceClaim
 from git_stage_batch.batch.ownership.model import (
     BatchOwnership,
@@ -90,6 +99,352 @@ class _GuardedLine:
 
     def endswith(self, suffix):
         raise AssertionError("line endings should not be materialized")
+
+
+class _CloseTrackingIterator:
+    """Chunk iterator that records explicit cleanup."""
+
+    def __init__(self, chunks):
+        self._chunks = iter(chunks)
+        self.closed = False
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        return next(self._chunks)
+
+    def close(self):
+        self.closed = True
+
+
+def test_candidate_comparison_preserves_structural_chunk_boundaries():
+    """Stream comparison must not fragment the selected structural output."""
+    structural_chunks = [b"alpha\n", b"beta\n", b"gamma\n"]
+    coordinate_chunks = [b"", b"alpha\nbe", b"ta\ngamma", b"\n", b""]
+
+    result = list(
+        merge_module._yield_identical_candidate_chunks(
+            coordinate_chunks,
+            structural_chunks,
+        )
+    )
+
+    assert result == structural_chunks
+
+
+def test_candidate_comparison_does_not_copy_large_chunk_remainders():
+    """Uneven candidate chunks must use constant-size comparison state."""
+    structural_chunk = b"x" * 1024
+    coordinate_chunk = structural_chunk * 512
+
+    tracemalloc.start()
+    try:
+        yielded_count = sum(
+            1
+            for _chunk in merge_module._yield_identical_candidate_chunks(
+                (coordinate_chunk,),
+                repeat(structural_chunk, 512),
+            )
+        )
+        _current_heap, peak_heap = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+
+    assert yielded_count == 512
+    assert peak_heap < 64 * 1024
+
+
+@pytest.mark.parametrize("candidates_match", [True, False])
+def test_coordinate_candidate_is_closed_after_comparison(
+    monkeypatch,
+    candidates_match,
+):
+    """Compared coordinate streams must close on acceptance and ambiguity."""
+    source = [b"a\n", b"new\n", b"b\n"]
+    target = [b"a\n", b"b\n"]
+    ownership = BatchOwnership.from_presence_lines(
+        ["2"],
+        [],
+        baseline_references={
+            2: BaselineReference(
+                after_line=1,
+                after_content=b"a\n",
+                before_line=2,
+                before_content=b"b\n",
+                has_before_line=True,
+            )
+        },
+    )
+    coordinate_candidate = _CloseTrackingIterator(
+        source if candidates_match else [b"a\n", b"b\n", b"new\n"]
+    )
+    planning_modes = []
+
+    def plan_candidate(*_args, **kwargs):
+        trust_coordinates = kwargs.get("trust_baseline_coordinates", False)
+        planning_modes.append(trust_coordinates)
+        return coordinate_candidate if trust_coordinates else None
+
+    monkeypatch.setattr(
+        merge_module._baseline_edits,
+        "try_apply_baseline_replacement_units",
+        plan_candidate,
+    )
+
+    if candidates_match:
+        with merge_batch_from_line_sequences_as_buffer(
+            source,
+            ownership,
+            target,
+        ) as merged:
+            assert list(merged) == source
+    else:
+        with pytest.raises(
+            MergeError,
+            match="recorded baseline coordinates and structural content matching",
+        ):
+            merge_batch_from_line_sequences_as_buffer(
+                source,
+                ownership,
+                target,
+            )
+
+    assert planning_modes == [False, True]
+    assert coordinate_candidate.closed
+
+
+def test_coordinate_candidate_is_closed_when_structural_planning_refuses(
+    monkeypatch,
+):
+    """A coordinate stream must close when no structural candidate exists."""
+    source = [b"a\n", b"new\n", b"b\n"]
+    target = [b"a\n", b"b\n"]
+    ownership = BatchOwnership.from_presence_lines(
+        ["2"],
+        [],
+        baseline_references={
+            2: BaselineReference(
+                after_line=1,
+                after_content=b"a\n",
+                before_line=2,
+                before_content=b"b\n",
+                has_before_line=True,
+            )
+        },
+    )
+    coordinate_candidate = _CloseTrackingIterator(source)
+
+    monkeypatch.setattr(
+        merge_module._baseline_edits,
+        "try_apply_baseline_replacement_units",
+        lambda *_args, **kwargs: (
+            coordinate_candidate
+            if kwargs.get("trust_baseline_coordinates", False)
+            else None
+        ),
+    )
+
+    def refuse_structural_candidate(*_args, **_kwargs):
+        raise MergeError("structural candidate is invalid")
+
+    monkeypatch.setattr(
+        merge_module,
+        "_build_structural_realized_entries",
+        refuse_structural_candidate,
+    )
+
+    with pytest.raises(MergeError, match="structural candidate is invalid"):
+        merge_batch_from_line_sequences_as_buffer(
+            source,
+            ownership,
+            target,
+        )
+
+    assert coordinate_candidate.closed
+
+
+@pytest.mark.parametrize("choice", [0, 3, True, "1", None])
+def test_coordinate_strategy_rejects_invalid_resolution_values(choice):
+    """Only serialized values of the strategy enum are valid choices."""
+    resolution = MergeResolution({AMBIGUITY_KEY: choice})
+
+    with pytest.raises(
+        MergeError,
+        match="Selected merge resolution is no longer valid",
+    ):
+        merge_batch_from_line_sequences_as_buffer(
+            [b"same\n"],
+            BatchOwnership([], []),
+            [b"same\n"],
+            resolution=resolution,
+        )
+
+
+def test_candidate_enumeration_propagates_atomic_unit_errors(monkeypatch):
+    """Candidate discovery must not reinterpret atomic selection failures."""
+
+    def refuse_atomic_selection(*_args, **_kwargs):
+        raise AtomicUnitError("select the complete replacement")
+        yield
+
+    monkeypatch.setattr(
+        merge_module,
+        "_merge_batch_acquired_line_chunks",
+        refuse_atomic_selection,
+    )
+
+    with pytest.raises(
+        AtomicUnitError,
+        match="select the complete replacement",
+    ):
+        enumerate_merge_batch_candidates_from_line_sequences(
+            [b"source\n"],
+            BatchOwnership([], []),
+            [b"target\n"],
+        )
+
+
+def test_candidate_enumeration_marks_an_ordinary_merge_as_unambiguous():
+    """An empty candidate set must distinguish success from hard refusal."""
+    candidate_set = enumerate_merge_batch_candidates_from_line_sequences(
+        [b"same\n"],
+        BatchOwnership([], []),
+        [b"same\n"],
+    )
+
+    assert candidate_set.candidates == ()
+    assert (
+        candidate_set.outcome
+        is MergeCandidateSetOutcome.ORDINARY_MERGE_SUCCEEDED
+    )
+
+
+def test_large_merge_without_coordinates_plans_baseline_once(monkeypatch):
+    """Large legacy batches should not repeat an inapplicable baseline plan."""
+    source = [f"line {index}\n".encode() for index in range(10_000)]
+    target = [b"remove me\n", *source]
+    ownership = BatchOwnership(
+        [],
+        [AbsenceClaim(anchor_line=None, content_lines=[b"remove me\n"])],
+    )
+    planning_modes = []
+    original_plan = (
+        merge_module._baseline_edits.try_apply_baseline_replacement_units
+    )
+
+    def count_plan(*args, **kwargs):
+        planning_modes.append(
+            kwargs.get("trust_baseline_coordinates", False)
+        )
+        return original_plan(*args, **kwargs)
+
+    monkeypatch.setattr(
+        merge_module._baseline_edits,
+        "try_apply_baseline_replacement_units",
+        count_plan,
+    )
+
+    with merge_batch_from_line_sequences_as_buffer(
+        source,
+        ownership,
+        target,
+    ) as merged:
+        assert len(merged) == len(source)
+
+    assert planning_modes == [False]
+
+
+def test_coordinate_candidate_discovery_reuses_initial_comparison(monkeypatch):
+    """Candidate discovery must not repeat both baseline planning passes."""
+    source = [
+        b"P\n",
+        b"ANCHOR\n",
+        b"NEXT\n",
+        b"MIDDLE\n",
+        b"ANCHOR\n",
+        b"NEW\n",
+        b"NEXT\n",
+        b"TAIL\n",
+    ]
+    target = [
+        b"P\n",
+        b"ANCHOR\n",
+        b"NEXT\n",
+        b"FILL\n",
+        b"ANCHOR\n",
+        b"NEXT\n",
+        b"MIDDLE\n",
+        b"ANCHOR\n",
+        b"NEXT\n",
+        b"TAIL\n",
+    ]
+    ownership = BatchOwnership.from_presence_lines(
+        ["6"],
+        [],
+        baseline_references={
+            6: BaselineReference(
+                after_line=5,
+                after_content=b"ANCHOR\n",
+                before_line=6,
+                before_content=b"NEXT\n",
+                has_before_line=True,
+            )
+        },
+    )
+    planning_modes = []
+    original_plan = (
+        merge_module._baseline_edits.try_apply_baseline_replacement_units
+    )
+
+    def count_plan(*args, **kwargs):
+        planning_modes.append(
+            kwargs.get("trust_baseline_coordinates", False)
+        )
+        return original_plan(*args, **kwargs)
+
+    monkeypatch.setattr(
+        merge_module._baseline_edits,
+        "try_apply_baseline_replacement_units",
+        count_plan,
+    )
+
+    def fail_duplicate_matching(*_args, **_kwargs):
+        raise AssertionError("coordinate candidate discovery repeated line matching")
+
+    monkeypatch.setattr(
+        candidate_enumeration_module,
+        "match_lines",
+        fail_duplicate_matching,
+    )
+
+    candidate_set = enumerate_merge_batch_candidates_from_line_sequences(
+        source,
+        ownership,
+        target,
+    )
+
+    assert len(candidate_set.candidates) == 2
+    assert planning_modes == [False, True]
+
+    planning_modes.clear()
+    with merge_batch_from_line_sequences_as_buffer(
+        source,
+        ownership,
+        target,
+        resolution=candidate_set.candidates[0].resolution,
+    ) as _structural_result:
+        pass
+    assert planning_modes == []
+
+    with merge_batch_from_line_sequences_as_buffer(
+        source,
+        ownership,
+        target,
+        resolution=candidate_set.candidates[1].resolution,
+    ) as _coordinate_result:
+        pass
+    assert planning_modes == [True]
 
 
 def test_merge_routes_mapping_and_output_storage_to_invocation_spool(
@@ -2020,6 +2375,7 @@ footer
         )
 
         assert candidate_set.candidates == ()
+        assert candidate_set.outcome is MergeCandidateSetOutcome.REFUSED
 
     def test_replacement_review_does_not_waive_insertion_ambiguity(self):
         """Reviewing one replacement cannot authorize an unrelated insertion."""


### PR DESCRIPTION
Merge discovery now distinguishes refusals, ordinary success, and reviewed
choices, and ownership metadata identifies batches with recorded baseline
coordinates.

Repeated boundaries can let structural matching and recorded coordinates
produce different valid files. Silently choosing either strategy can move
saved content to the wrong occurrence.

This pull request compares both merge results through bounded streams, keeps
identical output unambiguous, and emits explicit strategy candidates when
the bytes differ. Merge-level tests cover coordinate translation, cleanup,
error paths, and single-pass planning.

This is the second connected layer; the remaining operation PR will expose
these reviewed choices through apply/include previews and functional staging.
Validation: 165 focused tests and Ruff pass.