### PR TITLE
batch: Expose reviewed coordinate merge choices

### DIFF
--- a/src/git_stage_batch/batch/operation_candidates.py
+++ b/src/git_stage_batch/batch/operation_candidates.py
@@ -7,15 +7,20 @@ from pathlib import Path
 
 from ..core.buffer import LineBuffer
 from ..core.replacement import ReplacementPayload
-from ..core.text_lifecycle import selected_text_target_change_type
-from ..exceptions import AtomicUnitError, MergeError
+from ..core.text_lifecycle import (
+    TextFileChangeType,
+    selected_text_target_change_type,
+)
+from ..exceptions import MergeError
 from .merge.merge import (
     enumerate_merge_batch_candidates_from_line_sequences,
     merge_batch_from_line_sequences_as_buffer,
 )
 from .merge.candidates import (
     MergeCandidate,
+    MergeCandidateSetOutcome,
 )
+from .ownership.model import BatchOwnership
 from .operation_candidate_types import (
     CandidateEnumerationLimitError as _CandidateEnumerationLimitError,
     CandidateTarget as _CandidateTarget,
@@ -34,39 +39,25 @@ from .operation_candidate_fingerprints import (
 
 def _merge_candidates_or_unambiguous(
     source_lines: LineBuffer,
-    ownership,
+    ownership: BatchOwnership,
     target_lines: LineBuffer,
     *,
     spool_dir: str | Path | None = None,
-) -> tuple[MergeCandidate | None, ...]:
-    merge_arguments = {}
-    if spool_dir is not None:
-        merge_arguments["spool_dir"] = spool_dir
-    try:
-        with merge_batch_from_line_sequences_as_buffer(
-            source_lines,
-            ownership,
-            target_lines,
-            **merge_arguments,
-        ) as _buffer:
-            pass
-        return (None,)
-    except AtomicUnitError:
-        raise
-    except MergeError:
-        pass
-
-    candidate_arguments = {"max_candidates": _MAX_OPERATION_CANDIDATES}
-    if spool_dir is not None:
-        candidate_arguments["spool_dir"] = spool_dir
+) -> tuple[MergeCandidate, ...] | None:
     candidate_set = enumerate_merge_batch_candidates_from_line_sequences(
         source_lines,
         ownership,
         target_lines,
-        **candidate_arguments,
+        max_candidates=_MAX_OPERATION_CANDIDATES,
+        spool_dir=spool_dir,
     )
-    if candidate_set.candidates:
+    if candidate_set.outcome is MergeCandidateSetOutcome.REVIEW_REQUIRED:
         return candidate_set.candidates
+    if (
+        candidate_set.outcome
+        is MergeCandidateSetOutcome.ORDINARY_MERGE_SUCCEEDED
+    ):
+        return None
     raise MergeError("Batch was created from a different version of the file")
 
 
@@ -75,11 +66,11 @@ def _materialize_target_candidate(
     target: _CandidateTarget,
     file_path: str,
     source_lines: LineBuffer,
-    ownership,
+    ownership: BatchOwnership,
     before_lines: LineBuffer,
     candidate: MergeCandidate | None,
     file_mode: str | None,
-    text_change_type,
+    text_change_type: str | TextFileChangeType,
     destination_exists: bool,
     selected_ids: set[int] | None,
     spool_dir: str | Path | None = None,
@@ -89,17 +80,13 @@ def _materialize_target_candidate(
         if spool_dir is None
         else before_lines.clone(spool_dir=spool_dir)
     )
-    merge_arguments = {
-        "resolution": None if candidate is None else candidate.resolution,
-    }
-    if spool_dir is not None:
-        merge_arguments["spool_dir"] = spool_dir
     try:
         after = merge_batch_from_line_sequences_as_buffer(
             source_lines,
             ownership,
             before_lines,
-            **merge_arguments,
+            resolution=None if candidate is None else candidate.resolution,
+            spool_dir=spool_dir,
         )
     except BaseException:
         before_copy.close()
@@ -139,11 +126,11 @@ def build_apply_candidate_previews(
     batch_name: str,
     file_path: str,
     source_lines: LineBuffer,
-    ownership,
+    ownership: BatchOwnership,
     worktree_lines: LineBuffer,
     batch_source_commit: str,
-    file_meta: dict,
-    text_change_type,
+    file_meta: dict[str, object],
+    text_change_type: str | TextFileChangeType,
     worktree_file_mode: str | None,
     worktree_exists: bool,
     selected_ids: set[int] | None,
@@ -157,7 +144,7 @@ def build_apply_candidate_previews(
         worktree_lines,
         spool_dir=spool_dir,
     )
-    if merge_candidates == (None,):
+    if merge_candidates is None:
         return ()
 
     batch_fingerprint = _fingerprint_batch(
@@ -249,12 +236,12 @@ def build_include_candidate_previews(
     batch_name: str,
     file_path: str,
     source_lines: LineBuffer,
-    ownership,
+    ownership: BatchOwnership,
     index_lines: LineBuffer,
     worktree_lines: LineBuffer,
     batch_source_commit: str,
-    file_meta: dict,
-    text_change_type,
+    file_meta: dict[str, object],
+    text_change_type: str | TextFileChangeType,
     index_file_mode: str | None,
     worktree_file_mode: str | None,
     index_exists: bool,
@@ -277,10 +264,16 @@ def build_include_candidate_previews(
         worktree_lines,
         spool_dir=spool_dir,
     )
-    if index_candidates == (None,) and worktree_candidates == (None,):
+    if index_candidates is None and worktree_candidates is None:
         return ()
 
-    product_count = len(index_candidates) * len(worktree_candidates)
+    index_choices = (
+        (None,) if index_candidates is None else index_candidates
+    )
+    worktree_choices = (
+        (None,) if worktree_candidates is None else worktree_candidates
+    )
+    product_count = len(index_choices) * len(worktree_choices)
     if product_count > _MAX_OPERATION_CANDIDATES:
         raise _CandidateEnumerationLimitError(
             "too many include candidates to preview safely"
@@ -308,7 +301,7 @@ def build_include_candidate_previews(
             index_candidate,
             worktree_candidate,
         ) in enumerate(
-            product(index_candidates, worktree_candidates),
+            product(index_choices, worktree_choices),
             start=1,
         ):
             index_preview = _materialize_target_candidate(

--- a/tests/batch/test_operation_candidates.py
+++ b/tests/batch/test_operation_candidates.py
@@ -5,12 +5,17 @@ from __future__ import annotations
 import pytest
 
 from git_stage_batch.batch import operation_candidates
+import git_stage_batch.batch.merge.merge as merge_module
+from git_stage_batch.batch.merge.candidates import MergeCandidateSet
+from git_stage_batch.batch.ownership.model import BatchOwnership
+from git_stage_batch.batch.ownership.references import BaselineReference
 from git_stage_batch.batch.operation_candidate_types import (
     CandidateEnumerationLimitError,
     OperationCandidatePreview,
     TargetCandidatePreview,
 )
 from git_stage_batch.core.buffer import LineBuffer
+from git_stage_batch.exceptions import MergeError
 
 
 def _target(name: str) -> TargetCandidatePreview:
@@ -73,6 +78,96 @@ def test_operation_candidate_preview_rejects_missing_target():
         preview.close()
 
     assert exc_info.value.args == ("index",)
+
+
+def test_operation_planning_preserves_an_unenumerable_refusal(monkeypatch):
+    """An empty candidate set is not success unless the ordinary merge worked."""
+    monkeypatch.setattr(
+        operation_candidates,
+        "enumerate_merge_batch_candidates_from_line_sequences",
+        lambda *_args, **_kwargs: MergeCandidateSet.refused(),
+    )
+
+    with pytest.raises(
+        MergeError,
+        match="Batch was created from a different version of the file",
+    ):
+        operation_candidates._merge_candidates_or_unambiguous(
+            object(),
+            object(),
+            object(),
+        )
+
+
+def test_operation_planning_recognizes_an_unambiguous_merge(monkeypatch):
+    """A successful ordinary merge should not produce candidate previews."""
+    monkeypatch.setattr(
+        operation_candidates,
+        "enumerate_merge_batch_candidates_from_line_sequences",
+        lambda *_args, **_kwargs: MergeCandidateSet.ordinary_merge(),
+    )
+
+    assert operation_candidates._merge_candidates_or_unambiguous(
+        object(),
+        object(),
+        object(),
+    ) is None
+
+
+def test_coordinate_candidate_planning_runs_each_baseline_strategy_once(
+    monkeypatch,
+):
+    """Operation planning must reuse candidate discovery's initial merge."""
+    source = LineBuffer.from_bytes(
+        b"P\nANCHOR\nNEXT\nMIDDLE\nANCHOR\nNEW\nNEXT\nTAIL\n"
+    )
+    target = LineBuffer.from_bytes(
+        b"P\nANCHOR\nNEXT\nFILL\nANCHOR\nNEXT\nMIDDLE\n"
+        b"ANCHOR\nNEXT\nTAIL\n"
+    )
+    ownership = BatchOwnership.from_presence_lines(
+        ["6"],
+        [],
+        baseline_references={
+            6: BaselineReference(
+                after_line=5,
+                after_content=b"ANCHOR\n",
+                before_line=6,
+                before_content=b"NEXT\n",
+                has_before_line=True,
+            )
+        },
+    )
+    planning_modes = []
+    original_plan = (
+        merge_module._baseline_edits.try_apply_baseline_replacement_units
+    )
+
+    def count_plan(*args, **kwargs):
+        planning_modes.append(
+            kwargs.get("trust_baseline_coordinates", False)
+        )
+        return original_plan(*args, **kwargs)
+
+    monkeypatch.setattr(
+        merge_module._baseline_edits,
+        "try_apply_baseline_replacement_units",
+        count_plan,
+    )
+
+    try:
+        candidates = operation_candidates._merge_candidates_or_unambiguous(
+            source,
+            ownership,
+            target,
+        )
+    finally:
+        source.close()
+        target.close()
+
+    assert candidates is not None
+    assert len(candidates) == 2
+    assert planning_modes == [False, True]
 
 
 def test_include_candidate_limit_precedes_product_materialization(

--- a/tests/commands/test_candidate_previews.py
+++ b/tests/commands/test_candidate_previews.py
@@ -213,6 +213,59 @@ def _create_contextual_presence_batch(repo):
     (repo / "file.txt").write_text("header\ntarget one\ntarget two\nfooter\n")
 
 
+def _create_coordinate_strategy_batch(repo):
+    source = (
+        "P\n"
+        "ANCHOR\n"
+        "NEXT\n"
+        "MIDDLE\n"
+        "ANCHOR\n"
+        "NEW\n"
+        "NEXT\n"
+        "TAIL\n"
+    )
+    (repo / "file.txt").write_text(source)
+    subprocess.run(["git", "add", "file.txt"], check=True, cwd=repo, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "Add coordinate source file"],
+        check=True,
+        cwd=repo,
+        capture_output=True,
+    )
+    initialize_abort_state()
+    create_batch("coordinate-choice")
+    add_file_to_batch(
+        "coordinate-choice",
+        "file.txt",
+        BatchOwnership.from_presence_lines(
+            ["6"],
+            [],
+            baseline_references={
+                6: BaselineReference(
+                    after_line=5,
+                    after_content=b"ANCHOR\n",
+                    before_line=6,
+                    before_content=b"NEXT\n",
+                    has_before_line=True,
+                )
+            },
+        ),
+        "100644",
+    )
+    (repo / "file.txt").write_text(
+        "P\n"
+        "ANCHOR\n"
+        "NEXT\n"
+        "FILL\n"
+        "ANCHOR\n"
+        "NEXT\n"
+        "MIDDLE\n"
+        "ANCHOR\n"
+        "NEXT\n"
+        "TAIL\n"
+    )
+
+
 def _candidate_state_has_file(batch_name, file_path):
     state_path = get_batch_candidate_state_file_path()
     if not state_path.exists():
@@ -245,6 +298,48 @@ def test_contextual_presence_candidates_can_be_previewed_and_applied(
     assert (temp_git_repo / "file.txt").read_text() == (
         "header\ntarget one\nclaimed\ntarget two\nfooter\n"
     )
+
+
+def test_coordinate_strategy_candidates_can_be_reviewed_and_applied(
+    temp_git_repo,
+    capsys,
+):
+    """Conflicting valid strategies should use the reviewed candidate flow."""
+    _create_coordinate_strategy_batch(temp_git_repo)
+
+    with pytest.raises(CommandError) as exc_info:
+        command_apply_from_batch("coordinate-choice", file="file.txt")
+
+    assert "file.txt has 2 apply candidates" in exc_info.value.message
+    command_show_from_batch("coordinate-choice:apply", file="file.txt")
+
+    overview = capsys.readouterr()
+    assert "apply candidates  ·  2 choices" in overview.out
+    assert "Candidate 1/2" in overview.out
+    assert "Candidate 2/2" in overview.out
+    assert _candidate_state_has_file("coordinate-choice", "file.txt")
+
+    command_apply_from_batch(
+        "coordinate-choice:apply:1",
+        file="file.txt",
+    )
+
+    captured = capsys.readouterr()
+    assert "Applied candidate 1 of 2" in captured.err
+    assert (temp_git_repo / "file.txt").read_text() == (
+        "P\n"
+        "ANCHOR\n"
+        "NEXT\n"
+        "FILL\n"
+        "ANCHOR\n"
+        "NEXT\n"
+        "MIDDLE\n"
+        "ANCHOR\n"
+        "NEW\n"
+        "NEXT\n"
+        "TAIL\n"
+    )
+    assert not _candidate_state_has_file("coordinate-choice", "file.txt")
 
 
 def test_show_candidate_set_lists_context_and_commands(temp_git_repo, capsys):

--- a/tests/functional/repeated_boundary_fixture.py
+++ b/tests/functional/repeated_boundary_fixture.py
@@ -1,0 +1,150 @@
+"""Fixed content captured from the repeated-boundary staging regression."""
+
+
+_ORIGINAL = """                        source_segments=("assets", "claude-agents", "decompose-rebuilder.md"),
+                        target_segments=(".claude", "agents", "decompose-rebuilder.md"),
+                        display_name="Claude agent",
+                    ),
+                    CompanionAsset(
+                        source_segments=("assets", "claude-skills", "refine-history"),
+                        target_segments=(".claude", "skills", "refine-history"),
+                        display_name="Claude skill",
+                    ),
+                    CompanionAsset(
+                        source_segments=(
+                            "assets",
+                            "claude-skills",
+                            "refine-commit-messages",
+                        ),
+                        target_segments=(
+                            ".claude",
+                            "skills",
+                            "refine-commit-messages",
+                        ),
+                        display_name="Claude skill",
+                    ),
+                ),
+            ),
+            (
+                "refine-history",
+                (
+                    CompanionAsset(
+                        source_segments=(
+                            "assets",
+                            "claude-skills",
+                            "refine-commit-messages",
+                        ),
+                        target_segments=(
+                            ".claude",
+                            "skills",
+                            "refine-commit-messages",
+                        ),
+                        display_name="Claude skill",
+                    ),
+                ),
+            ),
+        ),
+    ),
+    "codex-skills": AssetGroup(
+        source_segments=("assets", "codex-skills"),
+        target_segments=(".agents", "skills"),
+        display_name_singular="Codex skill",
+        display_name_plural="Codex skills",
+        required_entry="SKILL.md",
+        companion_assets=(
+            CompanionAsset(
+                source_segments=(
+                    "assets",
+                    "codex-skills",
+                    "internal",
+                    "commit-message-drafter.md",
+                ),
+                target_segments=(".agents", "internal", "commit-message-drafter.md"),
+                display_name="Codex internal asset",
+            ),
+            CompanionAsset(
+                source_segments=("assets", "codex-skills", "config", "config.toml"),
+                target_segments=(".codex", "config.toml"),
+                display_name="Codex config",
+            ),
+        ),
+    ),
+}
+"""
+
+_EXPANDED_SOURCE_SEGMENTS = """                        source_segments=(
+                            "assets",
+                            "claude-agents",
+                            "decompose-rebuilder.md",
+                        ),"""
+
+_INSERTION = """        entry_companion_assets=(
+            (
+                "decompose-and-commit-unstaged-changes",
+                (
+                    CompanionAsset(
+                        source_segments=("assets", "codex-skills", "refine-history"),
+                        target_segments=(".agents", "skills", "refine-history"),
+                        display_name="Codex skill",
+                    ),
+                    CompanionAsset(
+                        source_segments=(
+                            "assets",
+                            "codex-skills",
+                            "refine-commit-messages",
+                        ),
+                        target_segments=(
+                            ".agents",
+                            "skills",
+                            "refine-commit-messages",
+                        ),
+                        display_name="Codex skill",
+                    ),
+                ),
+            ),
+            (
+                "refine-history",
+                (
+                    CompanionAsset(
+                        source_segments=(
+                            "assets",
+                            "codex-skills",
+                            "refine-commit-messages",
+                        ),
+                        target_segments=(
+                            ".agents",
+                            "skills",
+                            "refine-commit-messages",
+                        ),
+                        display_name="Codex skill",
+                    ),
+                ),
+            ),
+        ),
+"""
+
+
+def captured_repeated_boundary_insertion() -> tuple[str, str, str]:
+    """Return original, changed, and coordinate-correct expected content."""
+    compact_source_segments = (
+        '                        source_segments=("assets", "claude-agents", '
+        '"decompose-rebuilder.md"),'
+    )
+    final_boundary = "    ),\n}\n"
+    assert _ORIGINAL.count(compact_source_segments) == 1
+    assert _ORIGINAL.count(final_boundary) == 1
+    changed = _ORIGINAL.replace(
+        compact_source_segments,
+        _EXPANDED_SOURCE_SEGMENTS,
+        1,
+    ).replace(
+        final_boundary,
+        _INSERTION + final_boundary,
+        1,
+    )
+    expected = _ORIGINAL.replace(
+        final_boundary,
+        _INSERTION + final_boundary,
+        1,
+    )
+    return _ORIGINAL, changed, expected

--- a/tests/functional/test_include_line_transient_staging.py
+++ b/tests/functional/test_include_line_transient_staging.py
@@ -5,6 +5,7 @@ import subprocess
 import pytest
 
 from .conftest import git_stage_batch
+from .repeated_boundary_fixture import captured_repeated_boundary_insertion
 
 
 def _commit_file(repo, path: str, content: str) -> None:
@@ -185,6 +186,29 @@ def test_include_line_transient_staging_pure_addition(functional_repo):
     assert _index_content(functional_repo, "file.txt") == "base\nfoo\n"
 
 
+def _repeated_boundary_insertion_contents() -> tuple[str, str, str]:
+    """Return the captured repeated-boundary insertion regression contents."""
+    return captured_repeated_boundary_insertion()
+
+
+def test_include_complete_repeated_boundary_insertion(functional_repo):
+    """A full repeated-boundary insertion must retain selected closing lines."""
+    original, changed, expected = _repeated_boundary_insertion_contents()
+    _commit_file(functional_repo, "file.txt", original)
+    (functional_repo / "file.txt").write_text(changed)
+
+    git_stage_batch("start", "--no-auto-advance")
+    git_stage_batch("show", "--file", "file.txt", "--page", "all")
+    result = git_stage_batch(
+        "include",
+        "--line",
+        "7-49",
+        "--no-auto-advance",
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert _index_content(functional_repo, "file.txt") == expected
 @pytest.mark.parametrize(
     ("line_spec", "staged_addition"),
     [

--- a/tests/functional/test_include_line_transient_staging.py
+++ b/tests/functional/test_include_line_transient_staging.py
@@ -209,6 +209,75 @@ def test_include_complete_repeated_boundary_insertion(functional_repo):
 
     assert result.returncode == 0, result.stderr
     assert _index_content(functional_repo, "file.txt") == expected
+
+
+def test_ambiguous_saved_insertion_uses_reviewed_candidate(functional_repo):
+    """A saved insertion must require review before choosing its boundary."""
+    original, changed, expected = _repeated_boundary_insertion_contents()
+    _commit_file(functional_repo, "file.txt", original)
+    (functional_repo / "file.txt").write_text(changed)
+
+    git_stage_batch("start", "--no-auto-advance")
+    git_stage_batch("show", "--file", "file.txt", "--page", "all")
+    include_result = git_stage_batch(
+        "include",
+        "--to",
+        "saved",
+        "--line",
+        "7-49",
+        "--no-auto-advance",
+        check=False,
+    )
+    (functional_repo / "file.txt").write_text(original)
+    apply_result = git_stage_batch(
+        "apply",
+        "--from",
+        "saved",
+        "--file",
+        "file.txt",
+        check=False,
+    )
+
+    assert include_result.returncode == 0, include_result.stderr
+    assert apply_result.returncode != 0
+    assert "file.txt has 2 apply candidates" in apply_result.stderr
+    assert (functional_repo / "file.txt").read_text() == original
+
+    overview_result = git_stage_batch(
+        "show",
+        "--from",
+        "saved:apply",
+        "--file",
+        "file.txt",
+        check=False,
+    )
+    preview_result = git_stage_batch(
+        "show",
+        "--from",
+        "saved:apply:2",
+        "--file",
+        "file.txt",
+        check=False,
+    )
+    reviewed_apply_result = git_stage_batch(
+        "apply",
+        "--from",
+        "saved:apply:2",
+        "--file",
+        "file.txt",
+        check=False,
+    )
+
+    assert overview_result.returncode == 0, overview_result.stderr
+    assert "apply candidates  ·  2 choices" in overview_result.stdout
+    assert "Candidate 1/2" in overview_result.stdout
+    assert "Candidate 2/2" in overview_result.stdout
+    assert preview_result.returncode == 0, preview_result.stderr
+    assert "apply candidate 2/2" in preview_result.stdout
+    assert reviewed_apply_result.returncode == 0, reviewed_apply_result.stderr
+    assert (functional_repo / "file.txt").read_text() == expected
+
+
 @pytest.mark.parametrize(
     ("line_spec", "staged_addition"),
     [


### PR DESCRIPTION
Merge discovery now reports conflicting structural and coordinate results as
explicit strategy candidates instead of silently selecting one.

Apply and include planning still probe ordinary merges separately, so users
cannot yet review those candidates through the command workflow that consumes
saved batches.

This pull request makes operation planning reuse discovery outcomes, exposes
the choices through apply/include previews, and exercises explicit selection
with the captured repeated-boundary regression fixture. The operation tests
also ensure each baseline strategy is planned only once.

The connected stack now detects conflicting strategies, presents both safe
results for review, and applies only the candidate chosen by the user.
Validation: 239 focused tests and Ruff pass; the final tree matches the
original unpublished series exactly.