### PR TITLE
version: Expose the generated package interface

### DIFF
--- a/src/git_stage_batch/_version.pyi
+++ b/src/git_stage_batch/_version.pyi
@@ -1,0 +1,3 @@
+"""Type declaration for the build-generated version module."""
+
+__version__: str


### PR DESCRIPTION
The package version is generated during builds and exposed to runtime
consumers.

Static analysis has no declaration for the generated module, so typed
consumers cannot resolve its public names.

This PR adds the generated version stub while leaving runtime version
generation unchanged.

The package version now has a stable typed interface. The full test suite,
static checks, package build, and historical compile/import gate pass.
