### PR TITLE
cli: Route commands through typed dispatch

### DIFF
--- a/scripts/check_type_hygiene.py
+++ b/scripts/check_type_hygiene.py
@@ -23,6 +23,10 @@ ALLOWED_EXPLICIT_ANY = frozenset({
     "GitHelpArgumentParser.__init__::param:kwargs",
     "src/git_stage_batch/cli/git_help.py::"
     "GitHelpArgumentParser.print_help::cast",
+    "src/git_stage_batch/cli/subcommand_parser.py::"
+    "Subparsers.add_parser::param:kwargs",
+    "src/git_stage_batch/cli/subcommand_parser.py::"
+    "add_subcommand_parser::param:kwargs",
 })
 
 

--- a/scripts/check_type_hygiene.py
+++ b/scripts/check_type_hygiene.py
@@ -17,6 +17,12 @@ SOURCE_ROOT = REPOSITORY_ROOT / "src" / "git_stage_batch"
 # third-party APIs, or provide generic JSON/pickle transport. Keeping the
 # allowlist symbol-specific prevents a whole module from becoming an Any sink.
 ALLOWED_EXPLICIT_ANY = frozenset({
+    "src/git_stage_batch/cli/git_help.py::"
+    "GitHelpArgumentParser.__init__::param:args",
+    "src/git_stage_batch/cli/git_help.py::"
+    "GitHelpArgumentParser.__init__::param:kwargs",
+    "src/git_stage_batch/cli/git_help.py::"
+    "GitHelpArgumentParser.print_help::cast",
 })
 
 

--- a/src/git_stage_batch/cli/batch_subcommands.py
+++ b/src/git_stage_batch/cli/batch_subcommands.py
@@ -12,10 +12,10 @@ from ..i18n import _
 from .apply_dispatch import dispatch_apply_command
 from .file_arguments import add_file_argument
 from .reset_dispatch import dispatch_reset_command
-from .subcommand_parser import add_subcommand_parser
+from .subcommand_parser import Subparsers, add_subcommand_parser
 
 
-def add_new_subcommand(subparsers) -> None:
+def add_new_subcommand(subparsers: Subparsers) -> None:
     """Register the new subcommand."""
     parser_new = add_subcommand_parser(
         subparsers,

--- a/src/git_stage_batch/cli/completion.py
+++ b/src/git_stage_batch/cli/completion.py
@@ -9,6 +9,7 @@ from pathlib import PurePosixPath
 from ..batch.state.query import list_batch_files
 from ..exceptions import CommandError
 from ..utils.file_patterns import list_changed_files
+from .subcommand_parser import Subparsers
 
 
 _WILDMATCH_META = frozenset({"*", "?", "["})
@@ -113,7 +114,7 @@ def command_complete_files(current_token: str, *, from_batch: str | None = None)
         print(candidate)
 
 
-def add_completion_subcommand(subparsers) -> None:
+def add_completion_subcommand(subparsers: Subparsers) -> None:
     """Register the hidden file-completion subcommand."""
     parser_complete_files = subparsers.add_parser(
         "__complete-files",

--- a/src/git_stage_batch/cli/file_blocking_subcommands.py
+++ b/src/git_stage_batch/cli/file_blocking_subcommands.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 from ..commands.block_file import command_block_file
 from ..commands.unblock_file import command_unblock_file
 from ..i18n import _
-from .subcommand_parser import add_subcommand_parser
+from .subcommand_parser import Subparsers, add_subcommand_parser
 
 
-def add_block_file_subcommand(subparsers) -> None:
+def add_block_file_subcommand(subparsers: Subparsers) -> None:
     """Register the block-file subcommand."""
     parser_block_file = add_subcommand_parser(
         subparsers,

--- a/src/git_stage_batch/cli/file_blocking_subcommands.py
+++ b/src/git_stage_batch/cli/file_blocking_subcommands.py
@@ -36,7 +36,7 @@ def add_block_file_subcommand(subparsers: Subparsers) -> None:
     )
 
 
-def add_unblock_file_subcommand(subparsers) -> None:
+def add_unblock_file_subcommand(subparsers: Subparsers) -> None:
     """Register the unblock-file subcommand."""
     parser_unblock_file = add_subcommand_parser(
         subparsers,

--- a/src/git_stage_batch/cli/git_help.py
+++ b/src/git_stage_batch/cli/git_help.py
@@ -5,12 +5,17 @@ from __future__ import annotations
 import argparse
 import os
 import tempfile
-from contextlib import nullcontext
+from contextlib import AbstractContextManager, nullcontext
 from importlib import resources
 from pathlib import Path
+from types import TracebackType
+from typing import TYPE_CHECKING, Any, Callable, cast
 
 from ..utils.command import run_command
 from ..utils.git_command import run_git_command
+
+if TYPE_CHECKING:
+    from importlib.abc import Traversable
 
 
 class GitHelpArgumentParser(argparse.ArgumentParser):
@@ -18,14 +23,14 @@ class GitHelpArgumentParser(argparse.ArgumentParser):
 
     def __init__(
         self,
-        *args,
+        *args: Any,
         help_topic: str | None = None,
-        **kwargs,
-    ):
+        **kwargs: Any,
+    ) -> None:
         self._git_help_topic = help_topic
         super().__init__(*args, **kwargs)
 
-    def print_help(self, file=None):
+    def print_help(self, file: object | None = None) -> None:
         """Try to use git help, fall back to argparse help."""
         if (
             self._git_help_topic is not None
@@ -34,7 +39,7 @@ class GitHelpArgumentParser(argparse.ArgumentParser):
             return
 
         # Fall back to standard argparse help
-        super().print_help(file)
+        super().print_help(cast(Any, file))
 
 
 def _resolve_default_manpath() -> str | None:
@@ -84,23 +89,29 @@ def _try_git_help_with_environment(
     return result.returncode == 0
 
 
-def _with_real_manpath_root(manpage_path: Path):
+def _with_real_manpath_root(manpage_path: Path) -> AbstractContextManager[Path]:
     """Yield a manpath root that contains the requested man page."""
     if manpage_path.parent.name == "man1":
         return nullcontext(manpage_path.parent.parent)
 
     class _TemporaryManRoot:
-        def __enter__(self):
-            self._temp_dir = tempfile.TemporaryDirectory(prefix="git-stage-batch-help-")
+        def __enter__(self) -> Path:
+            self._temp_dir = tempfile.TemporaryDirectory[str](
+                prefix="git-stage-batch-help-"
+            )
             temp_root = Path(self._temp_dir.name)
             temp_manpage = temp_root / "man1" / manpage_path.name
             temp_manpage.parent.mkdir(parents=True, exist_ok=True)
             temp_manpage.write_bytes(manpage_path.read_bytes())
             return temp_root
 
-        def __exit__(self, exc_type, exc, tb):
+        def __exit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc: BaseException | None,
+            tb: TracebackType | None,
+        ) -> None:
             self._temp_dir.cleanup()
-            return False
 
     return _TemporaryManRoot()
 
@@ -118,7 +129,12 @@ def _git_help_name_for_help_topic(help_topic: str) -> str:
 def _show_git_stage_batch_help(help_topic: str = "stage-batch") -> bool:
     """Show git-stage-batch help from packaged or system man pages."""
     try:
-        packaged_manpage = resources.files("git_stage_batch").joinpath(
+        packaged_manpage = resources.files("git_stage_batch")
+        join_resource_path = cast(
+            "Callable[..., Traversable]",
+            packaged_manpage.joinpath,
+        )
+        packaged_manpage = join_resource_path(
             "assets",
             "man",
             "man1",

--- a/src/git_stage_batch/cli/journal_subcommands.py
+++ b/src/git_stage_batch/cli/journal_subcommands.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 from ..commands.journal import command_journal
 from ..i18n import _
-from .subcommand_parser import add_subcommand_parser
+from .subcommand_parser import Subparsers, add_subcommand_parser
 
 
-def add_journal_subcommand(subparsers) -> None:
+def add_journal_subcommand(subparsers: Subparsers) -> None:
     """Register the diagnostic journal management command."""
     parser = add_subcommand_parser(
         subparsers,

--- a/src/git_stage_batch/cli/session_subcommands.py
+++ b/src/git_stage_batch/cli/session_subcommands.py
@@ -74,7 +74,7 @@ def add_stop_subcommand(subparsers: Subparsers) -> None:
     parser_stop.set_defaults(func=lambda _: command_stop())
 
 
-def add_undo_subcommand(subparsers) -> None:
+def add_undo_subcommand(subparsers: Subparsers) -> None:
     """Register the undo subcommand."""
     parser_undo = add_subcommand_parser(
         subparsers,

--- a/src/git_stage_batch/cli/session_subcommands.py
+++ b/src/git_stage_batch/cli/session_subcommands.py
@@ -64,7 +64,7 @@ def add_again_subcommand(subparsers: Subparsers) -> None:
     )
 
 
-def add_stop_subcommand(subparsers) -> None:
+def add_stop_subcommand(subparsers: Subparsers) -> None:
     """Register the stop subcommand."""
     parser_stop = add_subcommand_parser(
         subparsers,

--- a/src/git_stage_batch/cli/session_subcommands.py
+++ b/src/git_stage_batch/cli/session_subcommands.py
@@ -50,7 +50,7 @@ def add_start_subcommand(subparsers) -> None:
     )
 
 
-def add_again_subcommand(subparsers) -> None:
+def add_again_subcommand(subparsers: Subparsers) -> None:
     """Register the again subcommand."""
     parser_again = add_subcommand_parser(
         subparsers,

--- a/src/git_stage_batch/cli/session_subcommands.py
+++ b/src/git_stage_batch/cli/session_subcommands.py
@@ -90,7 +90,7 @@ def add_undo_subcommand(subparsers) -> None:
     parser_undo.set_defaults(func=lambda args: command_undo(force=args.force))
 
 
-def add_redo_subcommand(subparsers) -> None:
+def add_redo_subcommand(subparsers: Subparsers) -> None:
     """Register the redo subcommand."""
     parser_redo = add_subcommand_parser(
         subparsers,

--- a/src/git_stage_batch/cli/session_subcommands.py
+++ b/src/git_stage_batch/cli/session_subcommands.py
@@ -13,10 +13,10 @@ from ..commands.undo import command_undo
 from ..i18n import _
 from ..output.status_prompt import DEFAULT_PROMPT_FORMAT
 from .auto_advance_options import add_auto_advance_arguments
-from .subcommand_parser import add_subcommand_parser
+from .subcommand_parser import Subparsers, add_subcommand_parser
 
 
-def add_check_unstaged_subcommand(subparsers) -> None:
+def add_check_unstaged_subcommand(subparsers: Subparsers) -> None:
     """Register the check-unstaged subcommand."""
     parser_check_unstaged = add_subcommand_parser(
         subparsers,

--- a/src/git_stage_batch/cli/session_subcommands.py
+++ b/src/git_stage_batch/cli/session_subcommands.py
@@ -116,7 +116,7 @@ def add_abort_subcommand(subparsers) -> None:
     parser_abort.set_defaults(func=lambda _: command_abort())
 
 
-def add_status_subcommand(subparsers) -> None:
+def add_status_subcommand(subparsers: Subparsers) -> None:
     """Register the status subcommand."""
     parser_status = add_subcommand_parser(
         subparsers,

--- a/src/git_stage_batch/cli/session_subcommands.py
+++ b/src/git_stage_batch/cli/session_subcommands.py
@@ -106,7 +106,7 @@ def add_redo_subcommand(subparsers) -> None:
     parser_redo.set_defaults(func=lambda args: command_redo(force=args.force))
 
 
-def add_abort_subcommand(subparsers) -> None:
+def add_abort_subcommand(subparsers: Subparsers) -> None:
     """Register the abort subcommand."""
     parser_abort = add_subcommand_parser(
         subparsers,

--- a/src/git_stage_batch/cli/session_subcommands.py
+++ b/src/git_stage_batch/cli/session_subcommands.py
@@ -26,7 +26,7 @@ def add_check_unstaged_subcommand(subparsers: Subparsers) -> None:
     parser_check_unstaged.set_defaults(func=lambda _: command_check_unstaged())
 
 
-def add_start_subcommand(subparsers) -> None:
+def add_start_subcommand(subparsers: Subparsers) -> None:
     """Register the start subcommand."""
     parser_start = add_subcommand_parser(
         subparsers,

--- a/src/git_stage_batch/cli/subcommand_parser.py
+++ b/src/git_stage_batch/cli/subcommand_parser.py
@@ -2,18 +2,35 @@
 
 from __future__ import annotations
 
+import argparse
+from typing import Any, Protocol, cast
+
 from .git_help import GitHelpArgumentParser
 
 
+class Subparsers(Protocol):
+    """Argument-parser operation needed by subcommand registrars."""
+
+    def add_parser(
+        self,
+        name: str,
+        **kwargs: Any,
+    ) -> argparse.ArgumentParser:
+        """Add and return one subcommand parser."""
+
+
 def add_subcommand_parser(
-    subparsers,
+    subparsers: Subparsers,
     command_name: str,
-    **kwargs,
+    **kwargs: Any,
 ) -> GitHelpArgumentParser:
     """Add a subcommand parser wired to its git help topic."""
     help_topic = kwargs.pop("help_topic", f"stage-batch-{command_name}")
-    return subparsers.add_parser(
-        command_name,
-        help_topic=help_topic,
-        **kwargs,
+    return cast(
+        GitHelpArgumentParser,
+        subparsers.add_parser(
+            command_name,
+            help_topic=help_topic,
+            **kwargs,
+        ),
     )

--- a/src/git_stage_batch/cli/subcommand_registry.py
+++ b/src/git_stage_batch/cli/subcommand_registry.py
@@ -37,9 +37,10 @@ from .session_subcommands import (
     add_undo_subcommand,
 )
 from .tui_subcommands import add_interactive_subcommand
+from .subcommand_parser import Subparsers
 
 
-def add_cli_subcommands(subparsers) -> None:
+def add_cli_subcommands(subparsers: Subparsers) -> None:
     """Register all public and hidden CLI subcommands in display order."""
     add_check_unstaged_subcommand(subparsers)
     add_start_subcommand(subparsers)

--- a/src/git_stage_batch/commands/new.py
+++ b/src/git_stage_batch/commands/new.py
@@ -10,10 +10,10 @@ from ..i18n import _
 from ..utils.git_repository import require_git_repository
 
 
-def command_new_batch(batch_name: str, note: str = "") -> None:
+def command_new_batch(batch_name: str, note: str | None = None) -> None:
     """Create a new batch."""
     require_git_repository()
     batch_name = require_plain_batch_name(batch_name, "new")
     with undo_checkpoint(f"new {batch_name}", worktree_paths=[]):
-        create_batch(batch_name, note)
+        create_batch(batch_name, note or "")
     print(_("✓ Created batch '{name}'").format(name=batch_name), file=sys.stderr)

--- a/src/git_stage_batch/data/progress.py
+++ b/src/git_stage_batch/data/progress.py
@@ -12,6 +12,7 @@ from ..core.models import (
     RenameChange,
     TextFileDeletionChange,
 )
+from .status_types import ChangeSummary
 from ..utils.file_io import (
     append_lines_to_file,
     count_nonblank_text_file_lines,
@@ -61,7 +62,7 @@ def record_hunk_skipped(line_changes: LineLevelChange, hunk_hash: str) -> None:
             first_changed_line = entry.old_line_number or entry.new_line_number
             break
 
-    metadata = {
+    metadata: ChangeSummary = {
         "hash": hunk_hash,
         "file": line_changes.path,
         "line": first_changed_line or 0,
@@ -73,7 +74,7 @@ def record_hunk_skipped(line_changes: LineLevelChange, hunk_hash: str) -> None:
 def record_binary_hunk_skipped(binary_change: BinaryFileChange, hunk_hash: str) -> None:
     """Record that a binary change was skipped with file-level metadata."""
     file_path = binary_change.path()
-    metadata = {
+    metadata: ChangeSummary = {
         "hash": hunk_hash,
         "file": file_path,
         "line": None,
@@ -100,7 +101,7 @@ def record_mode_change_skipped(mode_change: FileModeChange, hunk_hash: str) -> N
 
 def record_gitlink_hunk_skipped(gitlink_change: GitlinkChange, hunk_hash: str) -> None:
     """Record that a gitlink change was skipped with file-level metadata."""
-    metadata = {
+    metadata: ChangeSummary = {
         "hash": hunk_hash,
         "file": gitlink_change.path(),
         "line": None,
@@ -115,7 +116,7 @@ def record_gitlink_hunk_skipped(gitlink_change: GitlinkChange, hunk_hash: str) -
 
 def record_rename_hunk_skipped(rename_change: RenameChange, hunk_hash: str) -> None:
     """Record that a rename change was skipped with file-level metadata."""
-    metadata = {
+    metadata: ChangeSummary = {
         "hash": hunk_hash,
         "file": rename_change.new_path,
         "line": None,
@@ -132,7 +133,7 @@ def record_text_deletion_hunk_skipped(
     hunk_hash: str,
 ) -> None:
     """Record that a whole-text-file deletion was skipped with file-level metadata."""
-    metadata = {
+    metadata: ChangeSummary = {
         "hash": hunk_hash,
         "file": deletion_change.path(),
         "line": None,
@@ -143,7 +144,7 @@ def record_text_deletion_hunk_skipped(
     _append_skipped_hunk_metadata(metadata)
 
 
-def _append_skipped_hunk_metadata(metadata: dict) -> None:
+def _append_skipped_hunk_metadata(metadata: ChangeSummary) -> None:
     jsonl_path = get_skipped_hunks_jsonl_file_path()
     append_lines_to_file(jsonl_path, [json.dumps(metadata)])
 

--- a/src/git_stage_batch/data/status_summary.py
+++ b/src/git_stage_batch/data/status_summary.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from typing import cast
 
 from .batch_selected_changes import (
     load_current_selected_batch_binary_file,
@@ -31,6 +32,11 @@ from .selected_change.store import (
     read_selected_change_kind,
 )
 from .session import get_iteration_count
+from .status_types import (
+    ChangeSummary,
+    FileReviewSummary,
+    StatusSummary,
+)
 from ..utils.file_io import count_nonblank_text_file_lines, stream_text_file_lines
 from ..utils.paths import (
     get_discarded_hunks_file_path,
@@ -41,7 +47,7 @@ from ..utils.paths import (
 )
 
 
-def read_status_summary() -> dict:
+def read_status_summary() -> StatusSummary:
     """Read the complete machine-readable status summary for an active session."""
     iteration = get_iteration_count()
 
@@ -74,8 +80,8 @@ def read_status_summary() -> dict:
     }
 
 
-def _read_skipped_hunks() -> list[dict]:
-    skipped_hunks = []
+def _read_skipped_hunks() -> list[ChangeSummary]:
+    skipped_hunks: list[ChangeSummary] = []
     jsonl_path = get_skipped_hunks_jsonl_file_path()
     if not jsonl_path.exists():
         return skipped_hunks
@@ -84,7 +90,9 @@ def _read_skipped_hunks() -> list[dict]:
         if not line.strip():
             continue
         try:
-            skipped_hunks.append(json.loads(line))
+            parsed = json.loads(line)
+            if isinstance(parsed, dict):
+                skipped_hunks.append(cast(ChangeSummary, parsed))
         except json.JSONDecodeError:
             pass
 
@@ -151,7 +159,7 @@ def _read_live_review_display_ids(file_path: str) -> list[int] | None:
     })
 
 
-def _read_selected_change_summary() -> tuple[bool, dict | None]:
+def _read_selected_change_summary() -> tuple[bool, ChangeSummary | None]:
     """Return whether a non-stale selected change exists and its status summary."""
     selected_kind = read_selected_change_kind()
     if selected_kind == SelectedChangeKind.RENAME:
@@ -248,12 +256,16 @@ def _read_selected_change_summary() -> tuple[bool, dict | None]:
             if selected_kind is not None
             else SelectedChangeKind.HUNK.value
         )
+        ids: list[int]
         if selected_kind == SelectedChangeKind.BATCH_FILE:
             ids = _read_batch_review_display_ids(line_changes.path)
         elif selected_kind == SelectedChangeKind.FILE:
-            ids = _read_live_review_display_ids(line_changes.path)
-            if ids is None:
-                ids = line_changes.changed_line_ids()
+            live_ids = _read_live_review_display_ids(line_changes.path)
+            ids = (
+                line_changes.changed_line_ids()
+                if live_ids is None
+                else live_ids
+            )
         else:
             ids = line_changes.changed_line_ids()
         return True, {
@@ -266,7 +278,7 @@ def _read_selected_change_summary() -> tuple[bool, dict | None]:
         return False, None
 
 
-def _read_file_review_summary() -> dict | None:
+def _read_file_review_summary() -> FileReviewSummary | None:
     review_state = read_last_file_review_state(clear_invalid=False)
     if review_state is None:
         return None

--- a/src/git_stage_batch/data/status_types.py
+++ b/src/git_stage_batch/data/status_types.py
@@ -1,0 +1,64 @@
+"""Typed schemas for machine-readable session status."""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+
+class ChangeSummary(TypedDict, total=False):
+    """One selected or skipped change in a status response."""
+
+    hash: str
+    kind: str
+    file: str
+    line: int | None
+    ids: list[int]
+    type: str
+    change_type: str
+    old_path: str
+    new_path: str
+    old_mode: str
+    new_mode: str
+    old_oid: str | None
+    new_oid: str | None
+
+
+class FileReviewSummary(TypedDict):
+    """Last file-review state included in status."""
+
+    source: str
+    batch_name: str | None
+    file: str
+    page_spec: str
+    shown_pages: list[int]
+    page_count: int
+    entire_file_shown: bool
+    fresh: bool
+
+
+class SessionSummary(TypedDict):
+    """Active session state included in status."""
+
+    active: bool
+    iteration: int
+    status: str
+    in_progress: bool
+
+
+class ProgressSummary(TypedDict):
+    """Per-iteration progress counters."""
+
+    included: int
+    skipped: int
+    discarded: int
+    remaining: int
+
+
+class StatusSummary(TypedDict):
+    """Complete machine-readable status response."""
+
+    session: SessionSummary
+    selected_change: ChangeSummary | None
+    file_review: FileReviewSummary | None
+    progress: ProgressSummary
+    skipped_hunks: list[ChangeSummary]

--- a/src/git_stage_batch/output/status.py
+++ b/src/git_stage_batch/output/status.py
@@ -4,10 +4,15 @@ from __future__ import annotations
 
 from ..data.progress import format_id_range
 from ..data.selected_change.store import SelectedChangeKind
+from ..data.status_types import (
+    ChangeSummary,
+    FileReviewSummary,
+    StatusSummary,
+)
 from ..i18n import _
 
 
-def print_status_summary(summary: dict) -> None:
+def print_status_summary(summary: StatusSummary) -> None:
     """Print a human-readable status summary."""
     iteration = summary["session"]["iteration"]
     status_value = summary["session"]["status"]
@@ -56,7 +61,7 @@ def _selected_kind_label(selected_kind: str | None) -> str:
     return labels.get(selected_kind or SelectedChangeKind.HUNK.value, _("Current selection:"))
 
 
-def _print_selected_change(selected_summary: dict) -> None:
+def _print_selected_change(selected_summary: ChangeSummary) -> None:
     ids_str = format_id_range(selected_summary["ids"])
     print(_selected_kind_label(selected_summary.get("kind")))
     if selected_summary.get("line") is None:
@@ -75,7 +80,7 @@ def _print_selected_change(selected_summary: dict) -> None:
     print()
 
 
-def _print_file_review(file_review_summary: dict) -> None:
+def _print_file_review(file_review_summary: FileReviewSummary) -> None:
     print(_("Last file review:"))
     source = file_review_summary["source"]
     if file_review_summary["batch_name"]:
@@ -94,7 +99,7 @@ def _print_file_review(file_review_summary: dict) -> None:
     print()
 
 
-def _print_skipped_hunk(hunk: dict) -> None:
+def _print_skipped_hunk(hunk: ChangeSummary) -> None:
     ids_str = format_id_range(hunk.get("ids", []))
     if hunk.get("line") is None:
         print(_("  {file}").format(file=hunk["file"]))

--- a/src/git_stage_batch/output/status_prompt.py
+++ b/src/git_stage_batch/output/status_prompt.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 from string import Formatter
+from typing import TypedDict
 
 from ..data.progress import format_id_range
+from ..data.status_types import StatusSummary
 from ..exceptions import CommandError
 from ..i18n import _
 
@@ -38,6 +40,32 @@ _PROMPT_FIELDS = frozenset(
 _LIGHT_PROMPT_FIELDS = frozenset({"active"})
 
 
+class _PromptValues(TypedDict, total=False):
+    """Values exposed to status prompt format strings."""
+
+    active: bool
+    change_type: str
+    discarded: int
+    file_review_batch: str
+    file_review_fresh: bool | str
+    file_review_source: str
+    included: int
+    in_progress: bool
+    iteration: int
+    processed: int
+    progress_label: str
+    progress_status: str
+    remaining: int
+    selected_file: str
+    selected_ids: str
+    selected_kind: str
+    selected_line: int | str
+    skipped: int
+    status: str
+    status_label: str
+    total: int
+
+
 def prompt_needs_status_summary(prompt_format: str) -> bool:
     """Return whether rendering a prompt format requires session state."""
     return bool(_prompt_field_names(prompt_format) - _LIGHT_PROMPT_FIELDS)
@@ -68,15 +96,17 @@ def _prompt_field_names(prompt_format: str) -> set[str]:
     return fields
 
 
-def _prompt_values(summary: dict | None = None) -> dict:
+def _prompt_values(
+    summary: StatusSummary | None = None,
+) -> _PromptValues:
     """Return values available to `status --for-prompt` format strings."""
     if summary is None:
         return {"active": True}
 
     session = summary["session"]
     progress = summary["progress"]
-    selected = summary["selected_change"] or {}
-    file_review = summary["file_review"] or {}
+    selected = summary["selected_change"]
+    file_review = summary["file_review"]
     progress_status = session["status"]
     progress_label = _("in progress") if progress_status == "in_progress" else _("complete")
     processed = progress["included"] + progress["skipped"] + progress["discarded"]
@@ -85,11 +115,27 @@ def _prompt_values(summary: dict | None = None) -> dict:
 
     return {
         "active": session["active"],
-        "change_type": selected.get("change_type") or "",
+        "change_type": (
+            selected.get("change_type") or ""
+            if selected is not None
+            else ""
+        ),
         "discarded": progress["discarded"],
-        "file_review_batch": file_review.get("batch_name") or "",
-        "file_review_fresh": file_review.get("fresh", ""),
-        "file_review_source": file_review.get("source") or "",
+        "file_review_batch": (
+            file_review.get("batch_name") or ""
+            if file_review is not None
+            else ""
+        ),
+        "file_review_fresh": (
+            file_review.get("fresh", "")
+            if file_review is not None
+            else ""
+        ),
+        "file_review_source": (
+            file_review.get("source") or ""
+            if file_review is not None
+            else ""
+        ),
         "included": progress["included"],
         "in_progress": session["in_progress"],
         "iteration": session["iteration"],
@@ -97,10 +143,26 @@ def _prompt_values(summary: dict | None = None) -> dict:
         "progress_label": progress_label,
         "progress_status": progress_status,
         "remaining": progress["remaining"],
-        "selected_file": selected.get("file") or "",
-        "selected_ids": format_id_range(selected.get("ids") or []),
-        "selected_kind": selected.get("kind") or "",
-        "selected_line": selected.get("line") or "",
+        "selected_file": (
+            selected.get("file") or ""
+            if selected is not None
+            else ""
+        ),
+        "selected_ids": format_id_range(
+            selected.get("ids") or []
+            if selected is not None
+            else []
+        ),
+        "selected_kind": (
+            selected.get("kind") or ""
+            if selected is not None
+            else ""
+        ),
+        "selected_line": (
+            selected.get("line") or ""
+            if selected is not None
+            else ""
+        ),
         "skipped": progress["skipped"],
         "status": status,
         "status_label": status,
@@ -108,7 +170,10 @@ def _prompt_values(summary: dict | None = None) -> dict:
     }
 
 
-def render_prompt_status(prompt_format: str, summary: dict | None = None) -> str:
+def render_prompt_status(
+    prompt_format: str,
+    summary: StatusSummary | None = None,
+) -> str:
     """Render a prompt status segment for an active session."""
     fields = _prompt_field_names(prompt_format)
     values = _prompt_values(summary if fields - _LIGHT_PROMPT_FIELDS else None)


### PR DESCRIPTION
Selection and runtime services now expose concrete contracts to their
callers.

The command-line parser and individual command routes still erase those
contracts through broad callback and option values.

This PR types Git-help integration, parser callbacks, status responses,
command dispatch, and saved-change session creation. The Git-help import
remains runtime-safe on Python 3.14.

CLI requests now reach command services through typed dispatch. The full
test suite, static checks, package build, and historical compile/import
gate pass.
