### PR TITLE
typing: Carry application metadata through previews

### DIFF
--- a/src/git_stage_batch/batch/attribution.py
+++ b/src/git_stage_batch/batch/attribution.py
@@ -28,6 +28,7 @@ from .attribution_units import (
     make_attribution_unit_id as _make_attribution_unit_id,
 )
 from .state.query import list_batch_names, read_batch_metadata_for_batches
+from .state.metadata_types import BatchFileMetadataDict, BatchMetadataDict
 from .state.reference_names import format_batch_state_ref_name
 from ..core.line_selection import parse_line_selection
 from ..utils.repository_buffers import (
@@ -73,7 +74,7 @@ class BatchAttributionContext:
     """Reusable source alignment for one batch/file attribution pass."""
 
     batch_name: str
-    file_metadata: dict
+    file_metadata: BatchFileMetadataDict
     batch_source_lines: Sequence[bytes]
     alignment: _LineMapping
     deletion_fingerprints: dict[
@@ -87,7 +88,7 @@ class BatchAttributionContext:
 @dataclass(frozen=True)
 class _BatchSourceRequest:
     batch_name: str
-    file_metadata: dict
+    file_metadata: BatchFileMetadataDict
     primary_refspec: str
     fallback_refspec: str
 
@@ -97,12 +98,14 @@ class _ResolvedBatchSourceRequest:
     """One batch claim grouped by its canonical source blob identity."""
 
     batch_name: str
-    file_metadata: dict
+    file_metadata: BatchFileMetadataDict
     source_object_id: str | None
     presence_source_lines: tuple[int, ...]
 
 
-def _parse_presence_source_lines(file_metadata: dict) -> list[int]:
+def _parse_presence_source_lines(
+    file_metadata: BatchFileMetadataDict,
+) -> list[int]:
     presence_lines: list[int] = []
     for claim in file_metadata.get("presence_claims", []):
         source_lines = claim.get("source_lines", [])
@@ -118,7 +121,7 @@ def _parse_presence_source_lines(file_metadata: dict) -> list[int]:
     return presence_lines
 
 
-def _has_presence_source_lines(file_metadata: dict) -> bool:
+def _has_presence_source_lines(file_metadata: BatchFileMetadataDict) -> bool:
     return bool(
         file_metadata.get("presence_claims") or file_metadata.get("claimed_lines")
     )
@@ -127,8 +130,8 @@ def _has_presence_source_lines(file_metadata: dict) -> bool:
 def build_file_attribution(
     file_path: str,
     *,
-    batch_metadata_by_name: dict[str, dict] | None = None,
-    supplemental_batch_metadata: dict[str, dict] | None = None,
+    batch_metadata_by_name: dict[str, BatchMetadataDict] | None = None,
+    supplemental_batch_metadata: dict[str, BatchMetadataDict] | None = None,
     spool_dir: str | Path | None = None,
     metrics: AttributionMetrics | None = None,
 ) -> FileAttribution:
@@ -159,14 +162,14 @@ def build_file_attribution_from_lines(
     *,
     baseline_lines: Sequence[bytes],
     working_tree_lines: Sequence[bytes],
-    batch_metadata_by_name: dict[str, dict] | None = None,
-    supplemental_batch_metadata: dict[str, dict] | None = None,
+    batch_metadata_by_name: dict[str, BatchMetadataDict] | None = None,
+    supplemental_batch_metadata: dict[str, BatchMetadataDict] | None = None,
     batch_state_commit_by_name: Mapping[str, str] | None = None,
     spool_dir: str | Path | None = None,
     metrics: AttributionMetrics | None = None,
 ) -> FileAttribution:
     """Build file attribution from caller-owned indexed line sequences."""
-    all_batch_metadata = {}
+    all_batch_metadata: dict[str, BatchMetadataDict] = {}
     if batch_metadata_by_name is None:
         batch_metadata_by_name = read_batch_metadata_for_batches(list_batch_names())
     if metrics is not None:
@@ -175,7 +178,7 @@ def build_file_attribution_from_lines(
     # Only entries retained from the primary metadata map may resolve
     # source_path through state-backed storage. Supplemental entries, including
     # __consumed__ and any same-name override, use batch_source_commit.
-    state_backed_batch_names = set()
+    state_backed_batch_names: set[str] = set()
     for batch_name, metadata in batch_metadata_by_name.items():
         if file_path in metadata.get("files", {}):
             all_batch_metadata[batch_name] = metadata
@@ -200,7 +203,10 @@ def build_file_attribution_from_lines(
         _enumerate_units_from_file_comparison(comparison, all_units_map)
 
     baseline_unit_ids = tuple(all_units_map)
-    owners_by_unit_id = {unit_id: set() for unit_id in baseline_unit_ids}
+    owners_by_unit_id: dict[str, set[str]] = {
+        unit_id: set()
+        for unit_id in baseline_unit_ids
+    }
     _attribute_batches(
         file_path,
         all_batch_metadata,
@@ -229,7 +235,7 @@ def build_file_attribution_from_lines(
 
 def _attribute_batches(
     file_path: str,
-    all_batch_metadata: dict,
+    all_batch_metadata: dict[str, BatchMetadataDict],
     *,
     state_backed_batch_names: frozenset[str],
     batch_state_commit_by_name: Mapping[str, str] | None,
@@ -428,7 +434,7 @@ def _attribute_source_group(
 
 def _batch_source_requests(
     file_path: str,
-    all_batch_metadata: dict,
+    all_batch_metadata: dict[str, BatchMetadataDict],
     *,
     state_backed_batch_names: frozenset[str],
     batch_state_commit_by_name: Mapping[str, str] | None = None,

--- a/src/git_stage_batch/batch/attribution_units.py
+++ b/src/git_stage_batch/batch/attribution_units.py
@@ -6,6 +6,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
+from types import TracebackType
 
 from . import attribution_fingerprints as _attribution_fingerprints
 from .line_matching.line_mapping import LineMapping
@@ -57,7 +58,12 @@ class FileComparison:
     def __enter__(self) -> FileComparison:
         return self
 
-    def __exit__(self, exc_type, exc, traceback) -> None:
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
         self.close()
 
 
@@ -83,7 +89,9 @@ def make_attribution_unit_id(
             return fingerprint.sha1[:8]
         if content is None or not content:
             return "none"
-        return _attribution_fingerprints.fingerprint_bytes(content).sha1[:8]
+        content_fingerprint = _attribution_fingerprints.fingerprint_bytes(content)
+        assert content_fingerprint is not None
+        return content_fingerprint.sha1[:8]
 
     if kind == AttributionUnitKind.PRESENCE_ONLY:
         line_str = str(claimed_line) if claimed_line is not None else "missing"

--- a/src/git_stage_batch/batch/file_display.py
+++ b/src/git_stage_batch/batch/file_display.py
@@ -10,6 +10,7 @@ from . import file_display_model as _file_display_model
 from . import file_mergeability as _file_mergeability
 from .ownership.model import BatchOwnership
 from .ownership.metadata_loading import acquire_ownership_for_metadata_dict
+from .state.metadata_types import BatchFileMetadataDict, BatchMetadataDict
 from .state.query import read_batch_metadata
 from ..core.line_selection import LineRanges
 from ..core.models import (
@@ -24,7 +25,7 @@ from ..utils.paths import get_context_lines
 def render_batch_file_display(
     batch_name: str,
     file_path: str,
-    metadata: dict | None = None,
+    metadata: BatchMetadataDict | None = None,
     *,
     probe_mergeability: bool = True,
 ) -> Optional['RenderedBatchDisplay']:
@@ -79,7 +80,7 @@ def _render_batch_file_display_from_ownership(
     *,
     batch_source_commit: str,
     file_path: str,
-    file_meta: dict,
+    file_meta: BatchFileMetadataDict,
     ownership: BatchOwnership,
     probe_mergeability: bool,
 ) -> Optional['RenderedBatchDisplay']:
@@ -104,7 +105,7 @@ def _render_batch_file_display_from_ownership(
 def build_batch_file_display_from_inputs(
     *,
     file_path: str,
-    file_meta: dict,
+    file_meta: BatchFileMetadataDict,
     ownership: BatchOwnership,
     batch_source_lines: Sequence[bytes],
     probe_mergeability: bool,

--- a/src/git_stage_batch/batch/file_display_model.py
+++ b/src/git_stage_batch/batch/file_display_model.py
@@ -14,6 +14,8 @@ from ..core.models import (
     ReviewActionGroup,
 )
 from .ownership.unit_types import OwnershipUnit
+from .ownership.display_lines import OwnershipDisplayLine
+from .state.metadata_types import BatchFileMetadataDict
 
 
 _BATCH_MERGE_REVIEW_ACTIONS = (
@@ -27,8 +29,8 @@ _BATCH_RESET_REVIEW_ACTION = "reset-from-batch"
 def build_rendered_batch_display_model(
     *,
     file_path: str,
-    file_meta: dict,
-    display_lines: list[dict],
+    file_meta: BatchFileMetadataDict,
+    display_lines: list[OwnershipDisplayLine],
     mergeable_id_ranges: LineRanges,
     units: Sequence[OwnershipUnit],
 ) -> Optional[RenderedBatchDisplay]:

--- a/src/git_stage_batch/batch/file_mergeability.py
+++ b/src/git_stage_batch/batch/file_mergeability.py
@@ -12,6 +12,7 @@ from ..utils.repository_buffers import load_working_tree_file_as_buffer
 from .merge import merge as batch_merge
 from .line_matching.match import match_lines
 from .ownership.model import BatchOwnership
+from .ownership.display_lines import OwnershipDisplayLine
 from .ownership.unit_rebuild import rebuild_ownership_from_units
 from .ownership.unit_types import OwnershipUnit
 from .ownership.unit_validation import validate_ownership_units
@@ -30,7 +31,7 @@ def probe_batch_file_mergeability(
     *,
     file_path: str,
     ownership: BatchOwnership,
-    display_lines: list[dict],
+    display_lines: list[OwnershipDisplayLine],
     batch_source_lines: Sequence[bytes],
 ) -> BatchFileMergeability:
     """Return mergeable display IDs and ownership units for batch display lines."""

--- a/src/git_stage_batch/batch/operation_candidate_fingerprints.py
+++ b/src/git_stage_batch/batch/operation_candidate_fingerprints.py
@@ -6,11 +6,13 @@ import hashlib
 import json
 from typing import TYPE_CHECKING, TypedDict
 
-from ..core.buffer import buffer_byte_chunks
+from ..core.buffer import BufferInput, buffer_byte_chunks
 from .ownership.absence_claims import AbsenceClaim
 from .ownership.claims import PresenceClaim
+from .ownership.model import BatchOwnership
 from .ownership.references import BaselineReference
 from .ownership.replacement_units import ReplacementUnit
+from .state.metadata_types import BatchFileMetadataDict
 
 if TYPE_CHECKING:
     from ..core.buffer import LineBuffer
@@ -76,14 +78,14 @@ def _hash_bytes(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
 
 
-def _buffer_fingerprint(buffer) -> str:
+def _buffer_fingerprint(buffer: BufferInput) -> str:
     digest = hashlib.sha256()
     for chunk in buffer_byte_chunks(buffer):
         digest.update(chunk)
     return digest.hexdigest()
 
 
-def _json_fingerprint(payload) -> str:
+def _json_fingerprint(payload: object) -> str:
     return hashlib.sha256(
         json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
     ).hexdigest()
@@ -174,7 +176,7 @@ def _replacement_unit_payload(
     }
 
 
-def _ownership_fingerprint(ownership) -> str:
+def _ownership_fingerprint(ownership: BatchOwnership) -> str:
     return _json_fingerprint({
         "presence_claims": [
             _presence_claim_payload(claim)
@@ -253,9 +255,9 @@ def batch_fingerprint(
     batch_name: str,
     file_path: str,
     source_buffer: LineBuffer,
-    ownership,
+    ownership: BatchOwnership,
     batch_source_commit: str,
-    file_meta: dict,
+    file_meta: BatchFileMetadataDict,
 ) -> str:
     return _json_fingerprint({
         "algorithm_version": ALGORITHM_VERSION,

--- a/src/git_stage_batch/batch/operation_candidates.py
+++ b/src/git_stage_batch/batch/operation_candidates.py
@@ -21,6 +21,7 @@ from .merge.candidates import (
     MergeCandidateSetOutcome,
 )
 from .ownership.model import BatchOwnership
+from .state.metadata_types import BatchFileMetadataDict
 from .operation_candidate_types import (
     CandidateEnumerationLimitError as _CandidateEnumerationLimitError,
     CandidateTarget as _CandidateTarget,
@@ -129,7 +130,7 @@ def build_apply_candidate_previews(
     ownership: BatchOwnership,
     worktree_lines: LineBuffer,
     batch_source_commit: str,
-    file_meta: dict[str, object],
+    file_meta: BatchFileMetadataDict,
     text_change_type: str | TextFileChangeType,
     worktree_file_mode: str | None,
     worktree_exists: bool,
@@ -240,7 +241,7 @@ def build_include_candidate_previews(
     index_lines: LineBuffer,
     worktree_lines: LineBuffer,
     batch_source_commit: str,
-    file_meta: dict[str, object],
+    file_meta: BatchFileMetadataDict,
     text_change_type: str | TextFileChangeType,
     index_file_mode: str | None,
     worktree_file_mode: str | None,

--- a/src/git_stage_batch/batch/ownership/display_lines.py
+++ b/src/git_stage_batch/batch/ownership/display_lines.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, Literal, TypeVar, TypedDict
 
 from ...i18n import ngettext
 
@@ -15,6 +15,17 @@ if TYPE_CHECKING:
 LineForDisplay = TypeVar("LineForDisplay", bytes, str)
 
 
+class OwnershipDisplayLine(TypedDict, total=False):
+    """One rendered ownership line and its selection coordinates."""
+
+    id: int | None
+    type: Literal["claimed", "context", "deletion", "gap"]
+    source_line: int
+    deletion_index: int
+    omitted_line_count: int
+    content: str
+
+
 def _decode_display_line(line: bytes) -> str:
     return line.decode("utf-8", errors="replace")
 
@@ -23,7 +34,7 @@ def build_display_lines_from_batch_source_lines(
     source_lines: Sequence[bytes],
     ownership: 'BatchOwnership',
     context_lines: int | None = None,
-) -> list[dict]:
+) -> list[OwnershipDisplayLine]:
     """Build display representation from indexed batch-source lines."""
     return _build_display_lines_from_batch_source_lines(
         source_lines,
@@ -39,13 +50,13 @@ def _build_display_lines_from_batch_source_lines(
     context_lines: int | None,
     *,
     source_line_to_text: Callable[[LineForDisplay], str],
-) -> list[dict]:
+) -> list[OwnershipDisplayLine]:
     """Build display representation from indexed batch-source lines."""
     if context_lines is None:
         context_lines = 0
     claimed_set = ownership.presence_line_set()
 
-    display_lines = []
+    display_lines: list[OwnershipDisplayLine] = []
     display_id = 1
 
     # Build map of absence claim positions

--- a/src/git_stage_batch/batch/ownership/line_entries.py
+++ b/src/git_stage_batch/batch/ownership/line_entries.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass, field
+from typing import overload
 
 from ...core.models import LineEntry
 from .claims import LineRangeBuilder
@@ -47,6 +48,14 @@ class LineEntryContentSequence(Sequence[bytes]):
 
     def __len__(self) -> int:
         return len(self._lines)
+
+    @overload
+    def __getitem__(self, index: int) -> bytes:
+        ...
+
+    @overload
+    def __getitem__(self, index: slice) -> Sequence[bytes]:
+        ...
 
     def __getitem__(self, index: int | slice) -> bytes | Sequence[bytes]:
         if isinstance(index, slice):

--- a/src/git_stage_batch/batch/ownership/metadata_loading.py
+++ b/src/git_stage_batch/batch/ownership/metadata_loading.py
@@ -21,11 +21,12 @@ from .metadata_blobs import (
     presence_claim_reference_blob_ids,
     replacement_origin_reference_blob_ids,
 )
+from .metadata_types import BatchOwnershipMetadata
 from .replacement_units import ReplacementUnit
 
 
 def acquire_ownership_for_metadata_dict(
-    data: dict,
+    data: BatchOwnershipMetadata,
     *,
     spool_dir: str | Path | None = None,
 ) -> AcquiredBatchOwnership[BatchOwnership]:
@@ -70,7 +71,7 @@ def acquire_ownership_for_metadata_dict(
 
 
 def ownership_from_metadata_dict(
-    data: dict,
+    data: BatchOwnershipMetadata,
     *,
     blob_contents: dict[str, bytes],
     deletion_blob_buffers: dict[str, LineBuffer] | None = None,

--- a/src/git_stage_batch/batch/ownership/units.py
+++ b/src/git_stage_batch/batch/ownership/units.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from typing import Literal, TypedDict, overload
 
 from ...core.line_selection import LineRanges, LineSelection
-from .display_lines import build_display_lines_from_batch_source_lines
+from .display_lines import (
+    OwnershipDisplayLine,
+    build_display_lines_from_batch_source_lines,
+)
 from .model import (
     BatchOwnership,
 )
@@ -18,12 +22,29 @@ from .unit_types import (
     OwnershipUnitKind as _UnitKind,
 )
 from .replacement_units import normalize_replacement_units
+from .references import BaselineReference
+
+
+class _ClaimedDisplayRun(TypedDict):
+    """Consecutive claimed lines in the ownership display."""
+
+    display_ids: list[int]
+    source_lines: list[int]
+    next_index: int
+
+
+class _DeletionDisplayRun(TypedDict):
+    """Consecutive deleted lines in the ownership display."""
+
+    display_ids: list[int]
+    deletion_indices: list[int]
+    next_index: int
 
 
 def _presence_references_for_lines(
     ownership: BatchOwnership,
     source_lines: LineSelection,
-) -> dict:
+) -> dict[int, BaselineReference]:
     """Return baseline references owned by one semantic unit."""
     return {
         line: reference
@@ -34,7 +55,7 @@ def _presence_references_for_lines(
 
 def build_ownership_units_from_display_lines(
     ownership: BatchOwnership,
-    display_lines: list[dict],
+    display_lines: list[OwnershipDisplayLine],
 ) -> list[_UnitRecord]:
     """Build semantic ownership units from already reconstructed display lines.
 
@@ -50,6 +71,7 @@ def build_ownership_units_from_display_lines(
         )
     )
     i = 0
+    claimed_run: _ClaimedDisplayRun
 
     while i < len(display_lines):
         line = display_lines[i]
@@ -83,14 +105,15 @@ def build_ownership_units_from_display_lines(
                 )
             ):
                 # Collect single claimed line (to preserve fine-grained reset)
-                claimed_display_id = display_lines[i]["id"]
+                claimed_display_id = _required_display_id(display_lines[i])
                 claimed_source_line = display_lines[i]["source_line"]
                 i += 1
 
                 # Replacement unit: deletion block adjacent to single claimed line
                 claimed_run = {
                     "display_ids": [claimed_display_id],
-                    "source_lines": [claimed_source_line]
+                    "source_lines": [claimed_source_line],
+                    "next_index": i,
                 }
                 units.append(_build_replacement_unit(
                     ownership=ownership,
@@ -106,7 +129,7 @@ def build_ownership_units_from_display_lines(
 
         elif line["type"] == "claimed":
             # Collect single claimed line (not a block, to preserve fine-grained reset)
-            claimed_display_id = line["id"]
+            claimed_display_id = _required_display_id(line)
             claimed_source_line = line["source_line"]
             i += 1
 
@@ -133,7 +156,8 @@ def build_ownership_units_from_display_lines(
                 # Replacement unit: claimed line adjacent to deletion block
                 claimed_run = {
                     "display_ids": [claimed_display_id],
-                    "source_lines": [claimed_source_line]
+                    "source_lines": [claimed_source_line],
+                    "next_index": i,
                 }
                 units.append(_build_replacement_unit(
                     ownership=ownership,
@@ -167,9 +191,17 @@ def _ownership_unit_display_order_key(unit: _UnitRecord) -> int:
     return unit.display_line_ids.first() or 10**12
 
 
+def _required_display_id(display_line: OwnershipDisplayLine) -> int:
+    """Return the selectable ID guaranteed for claimed/deletion lines."""
+    display_id = display_line.get("id")
+    if display_id is None:
+        raise ValueError("selectable ownership display line has no ID")
+    return display_id
+
+
 def _build_explicit_replacement_units_from_display_lines(
     ownership: BatchOwnership,
-    display_lines: list[dict],
+    display_lines: list[OwnershipDisplayLine],
 ) -> tuple[list[_UnitRecord], LineRanges, set[int]]:
     """Build units from persisted replacement metadata."""
     units: list[_UnitRecord] = []
@@ -237,7 +269,7 @@ def _build_explicit_replacement_units_from_display_lines(
 
 
 def _display_line_is_consumed(
-    display_line: dict,
+    display_line: OwnershipDisplayLine,
     consumed_claimed_lines: LineSelection,
     consumed_deletion_indices: set[int],
 ) -> bool:
@@ -249,13 +281,33 @@ def _display_line_is_consumed(
     return False
 
 
+@overload
 def _collect_display_run(
-    display_lines: list,
+    display_lines: list[OwnershipDisplayLine],
     start_index: int,
-    expected_type: str,
+    expected_type: Literal["claimed"],
     consumed_claimed_lines: LineSelection,
     consumed_deletion_indices: set[int],
-) -> dict:
+) -> _ClaimedDisplayRun: ...
+
+
+@overload
+def _collect_display_run(
+    display_lines: list[OwnershipDisplayLine],
+    start_index: int,
+    expected_type: Literal["deletion"],
+    consumed_claimed_lines: LineSelection,
+    consumed_deletion_indices: set[int],
+) -> _DeletionDisplayRun: ...
+
+
+def _collect_display_run(
+    display_lines: list[OwnershipDisplayLine],
+    start_index: int,
+    expected_type: Literal["claimed", "deletion"],
+    consumed_claimed_lines: LineSelection,
+    consumed_deletion_indices: set[int],
+) -> _ClaimedDisplayRun | _DeletionDisplayRun:
     """Collect a consecutive run of display lines of the same type.
 
     Args:
@@ -270,11 +322,29 @@ def _collect_display_run(
         - deletion_indices: List of deletion indices (for deletion) or None
         - next_index: Index of first line after the run
     """
-    display_ids = []
-    source_lines = [] if expected_type == "claimed" else None
-    deletion_indices = [] if expected_type == "deletion" else None
-
+    display_ids: list[int] = []
     i = start_index
+    if expected_type == "claimed":
+        source_lines: list[int] = []
+        while (
+            i < len(display_lines)
+            and display_lines[i]["type"] == expected_type
+            and not _display_line_is_consumed(
+                display_lines[i],
+                consumed_claimed_lines,
+                consumed_deletion_indices,
+            )
+        ):
+            display_ids.append(_required_display_id(display_lines[i]))
+            source_lines.append(display_lines[i]["source_line"])
+            i += 1
+        return {
+            "display_ids": display_ids,
+            "source_lines": source_lines,
+            "next_index": i,
+        }
+
+    deletion_indices: list[int] = []
     while (
         i < len(display_lines)
         and display_lines[i]["type"] == expected_type
@@ -284,27 +354,20 @@ def _collect_display_run(
             consumed_deletion_indices,
         )
     ):
-        display_ids.append(display_lines[i]["id"])
-
-        if expected_type == "claimed":
-            source_lines.append(display_lines[i]["source_line"])
-        elif expected_type == "deletion":
-            deletion_indices.append(display_lines[i]["deletion_index"])
-
+        display_ids.append(_required_display_id(display_lines[i]))
+        deletion_indices.append(display_lines[i]["deletion_index"])
         i += 1
-
     return {
         "display_ids": display_ids,
-        "source_lines": source_lines,
         "deletion_indices": deletion_indices,
-        "next_index": i
+        "next_index": i,
     }
 
 
 def _build_replacement_unit(
     ownership: BatchOwnership,
-    deletion_run: dict,
-    claimed_run: dict
+    deletion_run: _DeletionDisplayRun,
+    claimed_run: _ClaimedDisplayRun,
 ) -> _UnitRecord:
     """Build a REPLACEMENT unit from adjacent deletion and claimed runs.
 
@@ -340,7 +403,7 @@ def _build_replacement_unit(
 
 def _build_deletion_only_unit(
     ownership: BatchOwnership,
-    deletion_run: dict
+    deletion_run: _DeletionDisplayRun,
 ) -> _UnitRecord:
     """Build a DELETION_ONLY unit from a deletion run with no adjacent claimed lines.
 

--- a/src/git_stage_batch/batch/ownership_update.py
+++ b/src/git_stage_batch/batch/ownership_update.py
@@ -7,6 +7,7 @@ from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
 
 from ..core.models import LineEntry
+from .state.metadata_types import BatchFileMetadataDict
 from .ownership.hunk_translation import translate_hunk_selection_to_batch_ownership
 from .ownership.model import BatchOwnership
 from .ownership.metadata_loading import acquire_ownership_for_metadata_dict
@@ -63,7 +64,7 @@ def _merge_refreshed_selected_lines_into_hunk(
 
 
 def _translate_selection_to_batch_ownership(
-    selected_lines: list,
+    selected_lines: list[LineEntry],
     *,
     hunk_lines: Sequence[LineEntry] | None = None,
     replacement_line_runs: Iterable[ReplacementLineRun] | None = None,
@@ -138,7 +139,7 @@ def prepare_batch_ownership_update_for_selection(
     file_path: str,
     current_batch_source_commit: str | None,
     existing_ownership: BatchOwnership | None,
-    selected_lines: list,
+    selected_lines: list[LineEntry],
     *,
     hunk_lines: Sequence[LineEntry] | None = None,
     replacement_line_runs: Iterable[ReplacementLineRun] | None = None,
@@ -236,8 +237,8 @@ def acquire_batch_ownership_update_for_selection(
     *,
     batch_name: str,
     file_path: str,
-    file_metadata: dict | None,
-    selected_lines: list,
+    file_metadata: BatchFileMetadataDict | None,
+    selected_lines: list[LineEntry],
     initial_batch_source_commit: str | None = None,
     hunk_lines: Sequence[LineEntry] | None = None,
     replacement_line_runs: Iterable[ReplacementLineRun] | None = None,
@@ -252,6 +253,7 @@ def acquire_batch_ownership_update_for_selection(
     so callers should persist or detach it before leaving the context.
     """
     with ExitStack() as stack:
+        current_batch_source_commit: str | None
         if file_metadata is None:
             if initial_batch_source_commit is None:
                 current_batch_source_commit, prepared_selected_lines = (

--- a/src/git_stage_batch/batch/selection.py
+++ b/src/git_stage_batch/batch/selection.py
@@ -15,6 +15,7 @@ from .ownership.units import (
 from .ownership.unit_rebuild import rebuild_ownership_from_units
 from .ownership.unit_selection import select_ownership_units_by_display_ids
 from .ownership.unit_validation import validate_ownership_units
+from .state.metadata_types import BatchFileMetadataDict
 from ..core.line_selection import (
     LineRanges,
     LineSelection,
@@ -111,7 +112,7 @@ def require_line_selection_in_view(
 
 def require_single_file_context_for_line_selection(
     batch_name: str,
-    files: dict[str, dict],
+    files: dict[str, BatchFileMetadataDict],
     line_ids: Optional[str],
     operation_verb: str,
 ) -> Optional[set[int]]:
@@ -140,12 +141,13 @@ def require_single_file_context_for_line_selection(
     ):
         return None
 
+    assert line_ids is not None
     return set(parse_line_selection(line_ids))
 
 
 def require_single_file_context_for_line_selection_ranges(
     batch_name: str,
-    files: dict[str, dict],
+    files: dict[str, BatchFileMetadataDict],
     line_ids: Optional[str],
     operation_verb: str,
 ) -> Optional[LineRanges]:
@@ -158,12 +160,13 @@ def require_single_file_context_for_line_selection_ranges(
     ):
         return None
 
+    assert line_ids is not None
     return parse_line_selection_ranges(line_ids)
 
 
 def _line_selection_has_single_file_context(
     batch_name: str,
-    files: dict[str, dict],
+    files: dict[str, BatchFileMetadataDict],
     line_ids: Optional[str],
     operation_verb: str,
 ) -> bool:
@@ -186,7 +189,7 @@ def _line_selection_has_single_file_context(
 
 @contextmanager
 def acquire_batch_ownership_for_display_ids_from_lines(
-    file_meta: dict,
+    file_meta: BatchFileMetadataDict,
     batch_source_lines: Sequence[bytes],
     selected_ids: Optional[set[int]],
     *,

--- a/src/git_stage_batch/batch/state/metadata_schema.py
+++ b/src/git_stage_batch/batch/state/metadata_schema.py
@@ -15,6 +15,10 @@ from typing import Any, TypeAlias, cast
 
 from ...exceptions import BatchMetadataError
 from ...utils.git_repository import object_id_hex_length
+from .metadata_types import (
+    BatchFileMetadataDict,
+    BatchMetadataDict,
+)
 
 
 CURRENT_BATCH_METADATA_SCHEMA_VERSION = 1
@@ -76,8 +80,8 @@ class BatchFileMetadata:
     path: str
     values: Mapping[str, JsonValue]
 
-    def to_dict(self) -> dict[str, Any]:
-        return _thaw_mapping(self.values)
+    def to_dict(self) -> BatchFileMetadataDict:
+        return cast(BatchFileMetadataDict, _thaw_mapping(self.values))
 
     @property
     def batch_source_commit(self) -> str | None:
@@ -114,7 +118,7 @@ class BatchMetadata:
     content_ref: str | None = None
     content_commit: str | None = None
 
-    def to_application_dict(self) -> dict[str, Any]:
+    def to_application_dict(self) -> BatchMetadataDict:
         """Return the compatibility mapping used by current domain code."""
         return {
             "revision": self.revision,

--- a/src/git_stage_batch/batch/state/metadata_types.py
+++ b/src/git_stage_batch/batch/state/metadata_types.py
@@ -7,6 +7,11 @@ from typing import Literal, TypedDict
 from ..ownership.metadata_types import BatchOwnershipMetadata
 
 
+class ReplacementMaskMetadata(TypedDict, total=False):
+    """A consumed replacement signature stored for later filtering."""
+
+    deleted_lines: list[str]
+    added_lines: list[str]
 
 
 class BatchFileMetadataDict(BatchOwnershipMetadata, total=False):
@@ -18,9 +23,24 @@ class BatchFileMetadataDict(BatchOwnershipMetadata, total=False):
     mode: str
     old_mode: str
     new_mode: str
+    old_oid: str | None
+    new_oid: str | None
     source_path: str
+    replacement_masks: list[ReplacementMaskMetadata]
 
 
+class BatchMetadataDict(TypedDict, total=False):
+    """Validated application mapping for a complete batch."""
+
+    schema_version: int
+    revision: str | None
+    batch: str
+    note: str
+    created_at: str
+    baseline: str | None
+    content_ref: str | None
+    content_commit: str | None
+    files: dict[str, BatchFileMetadataDict]
 
 
 

--- a/src/git_stage_batch/batch/state/query.py
+++ b/src/git_stage_batch/batch/state/query.py
@@ -6,6 +6,7 @@ from collections.abc import Iterable, Mapping
 from typing import Optional
 
 from .reference_names import BATCH_CONTENT_REF_PREFIX, LEGACY_BATCH_REF_PREFIX
+from .metadata_types import BatchMetadataDict
 from .references import (
     get_authoritative_batch_commit_sha,
     get_legacy_batch_ref_name,
@@ -20,7 +21,7 @@ from ...utils.git_command import run_git_command
 from ...git_paths import decode_path, nul_records
 
 
-def read_batch_metadata(name: str) -> dict:
+def read_batch_metadata(name: str) -> BatchMetadataDict:
     """Read metadata for a batch.
 
     Returns metadata with structure:
@@ -53,7 +54,7 @@ def read_batch_metadata_for_batches(
     batch_names: Iterable[str],
     *,
     batch_state_commit_by_name: Mapping[str, str] | None = None,
-) -> dict[str, dict]:
+) -> dict[str, BatchMetadataDict]:
     """Read metadata for many batches with one bulk state lookup pass."""
     unique_batch_names = list(dict.fromkeys(batch_names))
     if not unique_batch_names:
@@ -75,7 +76,7 @@ def read_batch_metadata_for_batches(
     return metadata_by_name
 
 
-def _empty_batch_metadata() -> dict:
+def _empty_batch_metadata() -> BatchMetadataDict:
     return {
         "note": "",
         "created_at": "",
@@ -84,7 +85,9 @@ def _empty_batch_metadata() -> dict:
     }
 
 
-def _read_file_backed_batch_metadata_or_empty(name: str) -> dict:
+def _read_file_backed_batch_metadata_or_empty(
+    name: str,
+) -> BatchMetadataDict:
     model = read_file_backed_batch_metadata_model(name)
     if model is None:
         return _empty_batch_metadata()

--- a/src/git_stage_batch/batch/state/references.py
+++ b/src/git_stage_batch/batch/state/references.py
@@ -6,8 +6,6 @@ import shutil
 import subprocess
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
-from typing import Any
-
 from .reference_names import (
     format_batch_content_ref_name,
     format_batch_state_ref_name,
@@ -19,6 +17,7 @@ from .metadata_schema import (
     decode_batch_metadata,
     encode_batch_metadata,
 )
+from .metadata_types import BatchMetadataDict
 from .batch_names import validate_batch_name
 from ...exceptions import BatchMetadataError
 from ...core.buffer import LineBuffer
@@ -50,7 +49,7 @@ class _StateBufferUpdate:
     mode: str = "100644"
 
 
-def _buffer_chunks(buffer: _StateBufferData):
+def _buffer_chunks(buffer: _StateBufferData) -> Iterable[bytes]:
     if isinstance(buffer, LineBuffer):
         yield from buffer.byte_chunks()
     else:
@@ -103,7 +102,7 @@ def _legacy_batch_commit_sha(batch_name: str) -> str | None:
     return result.stdout.strip()
 
 
-def read_file_backed_batch_metadata(batch_name: str) -> dict:
+def read_file_backed_batch_metadata(batch_name: str) -> BatchMetadataDict:
     model = read_file_backed_batch_metadata_model(batch_name)
     if model is None:
         return {
@@ -119,7 +118,7 @@ def _decode_state_metadata(payload: str | bytes, batch_name: str) -> BatchMetada
     return decode_batch_metadata(payload, expected_batch=batch_name)
 
 
-def read_batch_state_metadata(batch_name: str) -> dict[str, Any] | None:
+def read_batch_state_metadata(batch_name: str) -> BatchMetadataDict | None:
     """Read normalized batch metadata from the authoritative state ref."""
     validate_batch_name(batch_name)
     result = run_git_command(
@@ -137,7 +136,7 @@ def read_batch_state_metadata_for_batches(
     batch_names: Iterable[str],
     *,
     state_commit_by_name: Mapping[str, str] | None = None,
-) -> dict[str, dict[str, Any]]:
+) -> dict[str, BatchMetadataDict]:
     """Read normalized state metadata for many validated batches.
 
     When canonical commits are supplied, missing mappings intentionally skip
@@ -162,7 +161,7 @@ def read_batch_state_metadata_for_batches(
         refspec_by_name[batch_name] = f"{state_source}:batch.json"
     blobs = read_git_blobs_as_bytes(refspec_by_name.values())
 
-    metadata_by_name: dict[str, dict[str, Any]] = {}
+    metadata_by_name: dict[str, BatchMetadataDict] = {}
     for batch_name, refspec in refspec_by_name.items():
         blob = blobs.get(refspec)
         if blob is None:

--- a/src/git_stage_batch/batch/state/validation.py
+++ b/src/git_stage_batch/batch/state/validation.py
@@ -6,14 +6,15 @@ metadata early and produce clear error messages.
 
 from __future__ import annotations
 
-from typing import Any
+from collections.abc import Mapping
 
 from .query import read_batch_metadata
+from .metadata_types import BatchMetadataDict
 from .references import get_batch_state_ref_name, get_legacy_batch_ref_name
 from ...exceptions import BatchMetadataError
 from ...i18n import _
 from ...utils.git_command import run_git_command
-from ...utils.git_object_io import resolve_git_objects
+from ...utils.git_object_io import GitObjectInfo, resolve_git_objects
 from ...utils.repository_buffers import git_object_name_is_batch_protocol_safe
 from ...utils.paths import (
     get_batch_metadata_file_path,
@@ -89,7 +90,10 @@ def validate_batch_metadata_file_exists(batch_name: str) -> None:
         pass
 
 
-def validate_batch_metadata_structure(metadata: dict[str, Any], batch_name: str) -> None:
+def validate_batch_metadata_structure(
+    metadata: BatchMetadataDict,
+    batch_name: str,
+) -> None:
     """Verify that batch metadata has required structure and fields.
 
     Args:
@@ -120,7 +124,7 @@ def validate_batch_metadata_structure(metadata: dict[str, Any], batch_name: str)
         )
 
     # Validate files structure if present
-    source_commits: list[tuple[str, object]] = []
+    source_commits: list[tuple[str, str]] = []
     if "files" in metadata:
         files = metadata["files"]
         if not isinstance(files, dict):
@@ -191,10 +195,11 @@ def validate_batch_metadata_structure(metadata: dict[str, Any], batch_name: str)
             )
 
 
-def _git_object_exists(object_name: object, object_info_by_name: dict) -> bool:
+def _git_object_exists(
+    object_name: str,
+    object_info_by_name: Mapping[str, GitObjectInfo],
+) -> bool:
     """Check unusual metadata names through argv, outside the batch protocol."""
-    if not isinstance(object_name, str):
-        return False
     if git_object_name_is_batch_protocol_safe(object_name):
         return object_name in object_info_by_name
     result = run_git_command(
@@ -205,7 +210,7 @@ def _git_object_exists(object_name: object, object_info_by_name: dict) -> bool:
     return result.returncode == 0
 
 
-def load_and_validate_batch_metadata(batch_name: str) -> dict[str, Any]:
+def load_and_validate_batch_metadata(batch_name: str) -> BatchMetadataDict:
     """Load batch metadata and validate its structure.
 
     This is the primary entry point for commands that need batch metadata.
@@ -313,7 +318,7 @@ def get_validated_baseline_commit(batch_name: str) -> str:
     return baseline
 
 
-def read_validated_batch_metadata(batch_name: str) -> dict[str, Any]:
+def read_validated_batch_metadata(batch_name: str) -> BatchMetadataDict:
     """Read and validate batch metadata (command entry point helper).
 
     This is a drop-in replacement for read_batch_metadata that adds validation.

--- a/src/git_stage_batch/batch/submodule_pointer.py
+++ b/src/git_stage_batch/batch/submodule_pointer.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import shutil
+from pathlib import Path
 
+from .state.metadata_types import BatchFileMetadataDict
 from ..exceptions import CommandError
 from ..i18n import _
 from ..utils.git_command import run_git_command
@@ -21,7 +23,7 @@ from ..utils.git_repository import (
 )
 
 
-def is_batch_submodule_pointer(file_meta: dict) -> bool:
+def is_batch_submodule_pointer(file_meta: BatchFileMetadataDict) -> bool:
     """Return whether batch metadata describes a submodule pointer."""
     return file_meta.get("file_type") == "gitlink"
 
@@ -37,7 +39,7 @@ def refuse_batch_submodule_pointer_lines(action: str) -> None:
 
 def _submodule_pointer_oid(
     file_path: str,
-    file_meta: dict,
+    file_meta: BatchFileMetadataDict,
     field: str,
     *,
     action: str,
@@ -53,7 +55,11 @@ def _submodule_pointer_oid(
     return oid
 
 
-def _change_type(file_path: str, file_meta: dict, action: str) -> str:
+def _change_type(
+    file_path: str,
+    file_meta: BatchFileMetadataDict,
+    action: str,
+) -> str:
     """Return the stored pointer change type, or raise a user error."""
     change_type = file_meta.get("change_type")
     if change_type not in {"added", "modified", "deleted"}:
@@ -65,11 +71,11 @@ def _change_type(file_path: str, file_meta: dict, action: str) -> str:
     return change_type
 
 
-def _submodule_worktree_path(file_path: str):
+def _submodule_worktree_path(file_path: str) -> Path:
     return get_git_repository_root_path() / file_path
 
 
-def _require_submodule_worktree(file_path: str, action: str):
+def _require_submodule_worktree(file_path: str, action: str) -> Path:
     """Return an independently rooted submodule worktree or fail closed."""
     full_path = _submodule_worktree_path(file_path)
     if not is_git_repository_root_path(full_path):
@@ -195,7 +201,10 @@ def _remove_submodule_pointer_from_index(file_path: str, action: str) -> None:
         )
 
 
-def apply_submodule_pointer_from_batch(file_path: str, file_meta: dict) -> None:
+def apply_submodule_pointer_from_batch(
+    file_path: str,
+    file_meta: BatchFileMetadataDict,
+) -> None:
     """Apply a stored submodule pointer to the worktree."""
     change_type = _change_type(file_path, file_meta, "Apply")
     if change_type == "deleted":
@@ -208,7 +217,10 @@ def apply_submodule_pointer_from_batch(file_path: str, file_meta: dict) -> None:
         _mark_submodule_pointer_intent_to_add(file_path, "apply")
 
 
-def stage_submodule_pointer_from_batch(file_path: str, file_meta: dict) -> None:
+def stage_submodule_pointer_from_batch(
+    file_path: str,
+    file_meta: BatchFileMetadataDict,
+) -> None:
     """Apply a stored submodule pointer to the worktree and index."""
     change_type = _change_type(file_path, file_meta, "Stage")
     if change_type == "deleted":
@@ -231,7 +243,10 @@ def stage_submodule_pointer_from_batch(file_path: str, file_meta: dict) -> None:
         )
 
 
-def discard_submodule_pointer_from_batch(file_path: str, file_meta: dict) -> None:
+def discard_submodule_pointer_from_batch(
+    file_path: str,
+    file_meta: BatchFileMetadataDict,
+) -> None:
     """Restore the baseline state for a stored submodule pointer."""
     change_type = _change_type(file_path, file_meta, "Discard")
     if change_type == "added":

--- a/src/git_stage_batch/commands/batch_source/action_context.py
+++ b/src/git_stage_batch/commands/batch_source/action_context.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from ...batch.state.metadata_types import (
+    BatchFileMetadataDict,
+    BatchMetadataDict,
+)
 from ...batch.state.validation import read_validated_batch_metadata
 from ...batch.source.selector import (
     BatchSourceSelector,
@@ -27,8 +31,8 @@ class BatchSourceActionContext:
     batch_name: str
     file: str | None
     scope_resolution: ActionScopeResolution
-    metadata: dict
-    all_files: dict
+    metadata: BatchMetadataDict
+    all_files: dict[str, BatchFileMetadataDict]
 
 
 def resolve_batch_source_action_context(

--- a/src/git_stage_batch/commands/batch_source/action_plans.py
+++ b/src/git_stage_batch/commands/batch_source/action_plans.py
@@ -6,13 +6,17 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Protocol
 
+from ...batch.state.metadata_types import BatchFileMetadataDict
 from ...core.buffer import LineBuffer
+from ...core.text_lifecycle import TextFileChangeType
 
 
 class BatchSourceActionPlan(Protocol):
     """Plan record that may hold resources until command execution."""
 
-    file_path: str
+    @property
+    def file_path(self) -> str:
+        ...
 
     def close(self) -> None:
         ...
@@ -25,7 +29,7 @@ class ApplyTextFileActionPlan:
     file_path: str
     buffer: LineBuffer | None
     file_mode: str | None
-    change_type: str
+    change_type: TextFileChangeType
 
     def close(self) -> None:
         if self.buffer is not None:
@@ -41,8 +45,8 @@ class IncludeTextFileActionPlan:
     working_buffer: LineBuffer | None
     index_file_mode: str | None
     working_file_mode: str | None
-    index_change_type: str
-    working_change_type: str
+    index_change_type: TextFileChangeType
+    working_change_type: TextFileChangeType
 
     def close(self) -> None:
         if self.index_buffer is not None:
@@ -61,7 +65,7 @@ class DiscardTextFileActionPlan:
     file_path: str
     buffer: LineBuffer | None
     file_mode: str | None
-    change_type: str
+    change_type: TextFileChangeType
 
     def close(self) -> None:
         if self.buffer is not None:
@@ -73,7 +77,7 @@ class BinaryFileActionPlan:
     """Deferred binary file action with optional stored batch content."""
 
     file_path: str
-    file_meta: dict
+    file_meta: BatchFileMetadataDict
     buffer: LineBuffer | None
 
     def close(self) -> None:
@@ -86,7 +90,7 @@ class SubmodulePointerActionPlan:
     """Deferred submodule pointer action."""
 
     file_path: str
-    file_meta: dict
+    file_meta: BatchFileMetadataDict
 
     def close(self) -> None:
         return None

--- a/src/git_stage_batch/commands/batch_source/action_selection.py
+++ b/src/git_stage_batch/commands/batch_source/action_selection.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 from ...batch.selection import (
     require_single_file_context_for_line_selection,
 )
+from ...batch.state.metadata_types import BatchFileMetadataDict
 from ...batch.submodule_pointer import (
     is_batch_submodule_pointer,
     refuse_batch_submodule_pointer_lines,
@@ -35,7 +36,7 @@ class BatchSourceActionSelection:
     """Resolved files, line IDs, and command text for an action command."""
 
     file: str | None
-    files: dict
+    files: dict[str, BatchFileMetadataDict]
     selected_ids: set[int] | None
     selection_ids: set[int] | None
     rendered: "RenderedBatchDisplay | None"
@@ -176,7 +177,11 @@ def _resolve_batch_source_action_files(
     line_ids: str | None,
     patterns: list[str] | None,
     command_name: str,
-) -> tuple[str | None, dict, set[int] | None]:
+) -> tuple[
+    str | None,
+    dict[str, BatchFileMetadataDict],
+    set[int] | None,
+]:
     file = resolve_current_batch_atomic_file_scope(
         context.batch_name,
         context.all_files,
@@ -200,7 +205,7 @@ def _resolve_batch_source_action_files(
 
 
 def _refuse_line_selection_for_atomic_files(
-    files: dict,
+    files: dict[str, BatchFileMetadataDict],
     selected_ids: set[int] | None,
     *,
     binary_message: str,
@@ -222,7 +227,7 @@ def _refuse_line_selection_for_atomic_files(
 
 def _translate_selected_ids(
     batch_name: str,
-    files: dict,
+    files: dict[str, BatchFileMetadataDict],
     selected_ids: set[int] | None,
     action: FileReviewAction,
 ) -> tuple[set[int] | None, "RenderedBatchDisplay | None"]:

--- a/src/git_stage_batch/commands/batch_source/apply_action.py
+++ b/src/git_stage_batch/commands/batch_source/apply_action.py
@@ -19,6 +19,9 @@ from . import text_file_actions as _text_file_actions
 from . import text_plan_jobs as _text_plan_jobs
 from . import worktree_refusals as _worktree_refusals
 from ...batch.operation_candidate_types import CandidatePreviewCount
+from ...batch.state.metadata_types import BatchFileMetadataDict
+from ...core.models import RenderedBatchDisplay
+from ...core.text_lifecycle import TextFileChangeType
 from ...batch.binary_file_content import read_binary_file_from_batch
 from ...batch.submodule_pointer import (
     apply_submodule_pointer_from_batch,
@@ -51,7 +54,7 @@ from ...utils.git_object_io import list_git_tree_blobs, resolve_git_objects
 class _ApplyTextInput:
     ordinal: int
     file_path: str
-    file_meta: dict
+    file_meta: BatchFileMetadataDict
     identity: WorktreeIdentity
     worktree_artifact: Path
     scratch_directory: Path
@@ -65,8 +68,8 @@ class _ApplyPlanCapture:
     plans_by_ordinal: dict[int, _action_plans.BatchSourceActionPlan]
     command_errors_by_ordinal: dict[int, CommandError]
     unexpected_errors_by_ordinal: dict[int, str]
-    mode_actions: list[tuple[str, dict]]
-    binary_metadata_by_ordinal: dict[int, dict]
+    mode_actions: list[tuple[str, BatchFileMetadataDict]]
+    binary_metadata_by_ordinal: dict[int, BatchFileMetadataDict]
     worktree_identities: dict[str, WorktreeIdentity]
 
 
@@ -153,11 +156,16 @@ def execute_apply_action(
                                 ),
                             )
                             _print_binary_worktree_result(plan.file_path, action)
-                        else:
+                        elif isinstance(
+                            plan,
+                            _action_plans.SubmodulePointerActionPlan,
+                        ):
                             apply_submodule_pointer_from_batch(
                                 plan.file_path,
                                 plan.file_meta,
                             )
+                        else:
+                            raise TypeError("unsupported apply action plan")
                     for file_path, file_meta in mode_actions:
                         _file_mode_actions.apply_new_file_mode(file_path, file_meta)
             except CommandError:
@@ -177,15 +185,15 @@ def execute_apply_action(
 def _build_apply_action_plans(
     *,
     batch_name: str,
-    files: dict[str, dict],
+    files: dict[str, BatchFileMetadataDict],
     selected_ids: set[int] | None,
     selection_ids_to_apply: set[int] | None,
-    rendered,
+    rendered: RenderedBatchDisplay | None,
     repository_root: Path,
     workspace: FileJobWorkspace,
 ) -> tuple[
     list[_action_plans.BatchSourceActionPlan],
-    list[tuple[str, dict]],
+    list[tuple[str, BatchFileMetadataDict]],
     dict[str, WorktreeIdentity],
 ]:
     capture = _capture_apply_plan_inputs(
@@ -221,7 +229,7 @@ def _build_apply_action_plans(
 
 def _capture_apply_plan_inputs(
     *,
-    files: dict[str, dict],
+    files: dict[str, BatchFileMetadataDict],
     selected_ids: set[int] | None,
     workspace: FileJobWorkspace,
 ) -> _ApplyPlanCapture:
@@ -229,8 +237,8 @@ def _capture_apply_plan_inputs(
     plans_by_ordinal: dict[int, _action_plans.BatchSourceActionPlan] = {}
     command_errors_by_ordinal: dict[int, CommandError] = {}
     unexpected_errors_by_ordinal: dict[int, str] = {}
-    mode_actions: list[tuple[str, dict]] = []
-    binary_metadata_by_ordinal: dict[int, dict] = {}
+    mode_actions: list[tuple[str, BatchFileMetadataDict]] = []
+    binary_metadata_by_ordinal: dict[int, BatchFileMetadataDict] = {}
     worktree_identities: dict[str, WorktreeIdentity] = {}
     text_inputs: list[_ApplyTextInput] = []
 
@@ -399,8 +407,8 @@ def _run_apply_text_jobs(
 def _reduce_apply_action_plans(
     *,
     batch_name: str,
-    files: dict[str, dict],
-    rendered,
+    files: dict[str, BatchFileMetadataDict],
+    rendered: RenderedBatchDisplay | None,
     capture: _ApplyPlanCapture,
     text_results_by_ordinal: dict[int, _text_plan_jobs.ApplyTextPlanJobResult],
     workspace: FileJobWorkspace,
@@ -472,19 +480,19 @@ def _reduce_apply_action_plans(
                 result.file_path,
                 buffer,
                 result.file_mode,
-                result.change_type,
+                TextFileChangeType(result.change_type),
             )
         elif result.outcome == "noop":
             continue
         elif result.outcome == "atomic_unit_error":
-            error = AtomicUnitError(
+            atomic_error = AtomicUnitError(
                 details["message"],
                 details.get("required_selection_ids"),
                 details.get("unit_kind"),
             )
             if rendered:
                 _atomic_unit_refusals.translate_atomic_unit_error_to_gutter_ids(
-                    error,
+                    atomic_error,
                     rendered,
                     "apply",
                     batch_name,
@@ -492,7 +500,7 @@ def _reduce_apply_action_plans(
             exit_with_error(
                 _("Failed to apply batch '{name}': {error}").format(
                     name=batch_name,
-                    error=str(error),
+                    error=str(atomic_error),
                 )
             )
         elif result.outcome == "command_error":

--- a/src/git_stage_batch/commands/batch_source/candidate_execution.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_execution.py
@@ -7,6 +7,7 @@ import sys
 from . import candidate_materialization as _candidate_materialization
 from . import text_file_actions as _text_file_actions
 from ...batch.operation_candidate_state import clear_candidate_preview_state_for_file
+from ...batch.state.metadata_types import BatchFileMetadataDict
 from ...core.replacement import ReplacementPayload
 from ...data.session import snapshot_file_if_untracked
 from ...data.undo.checkpoints import undo_checkpoint
@@ -18,7 +19,7 @@ def execute_apply_candidate(
     batch_name: str,
     raw_selector: str,
     ordinal: int,
-    files: dict,
+    files: dict[str, BatchFileMetadataDict],
     selected_ids: set[int] | None,
     selection_ids_to_apply: set[int] | None,
 ) -> None:
@@ -77,7 +78,7 @@ def execute_include_candidate(
     batch_name: str,
     raw_selector: str,
     ordinal: int,
-    files: dict,
+    files: dict[str, BatchFileMetadataDict],
     selected_ids: set[int] | None,
     selection_ids_to_include: set[int] | None,
     replacement_payload: ReplacementPayload | None,

--- a/src/git_stage_batch/commands/batch_source/candidate_inputs.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_inputs.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 import os
 from typing import Iterable
 
+from ...batch.state.metadata_types import BatchFileMetadataDict
 from ...batch.submodule_pointer import is_batch_submodule_pointer
 from ...core.text_lifecycle import (
     TextFileChangeType,
@@ -40,14 +41,14 @@ class CandidateIndexTarget:
     file_mode: str | None
 
 
-def is_text_candidate_entry(file_meta: dict) -> bool:
+def is_text_candidate_entry(file_meta: BatchFileMetadataDict) -> bool:
     """Return whether a batch file entry supports text candidate handling."""
     return file_meta.get("file_type") not in {"binary", "mode"} and not is_batch_submodule_pointer(file_meta)
 
 
 def candidate_batch_source_ref(
     file_path: str,
-    file_meta: dict,
+    file_meta: BatchFileMetadataDict,
 ) -> CandidateBatchSourceRef | None:
     """Return the batch source object reference, or None when metadata lacks one."""
     batch_source_commit = file_meta.get("batch_source_commit")
@@ -61,7 +62,7 @@ def candidate_batch_source_ref(
 
 def require_candidate_batch_source_ref(
     file_path: str,
-    file_meta: dict,
+    file_meta: BatchFileMetadataDict,
 ) -> CandidateBatchSourceRef:
     """Return the batch source object reference for validated candidate metadata."""
     batch_source_commit = file_meta["batch_source_commit"]
@@ -74,7 +75,7 @@ def require_candidate_batch_source_ref(
 def candidate_worktree_text_target(
     *,
     file_path: str,
-    file_meta: dict,
+    file_meta: BatchFileMetadataDict,
     selected_ids: Iterable[int] | None,
     captured_working_tree_exists: bool | None = None,
 ) -> CandidateWorktreeTarget:
@@ -97,7 +98,7 @@ def candidate_worktree_text_target(
 
 def candidate_index_text_target(
     *,
-    file_meta: dict,
+    file_meta: BatchFileMetadataDict,
     selected_ids: Iterable[int] | None,
     index_exists: bool,
 ) -> CandidateIndexTarget:
@@ -112,5 +113,5 @@ def candidate_index_text_target(
     )
 
 
-def _batch_file_mode(file_meta: dict) -> str:
+def _batch_file_mode(file_meta: BatchFileMetadataDict) -> str:
     return str(file_meta.get("mode", "100644"))

--- a/src/git_stage_batch/commands/batch_source/candidate_materialization.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_materialization.py
@@ -11,6 +11,7 @@ from ...batch.operation_candidate_types import (
     OperationCandidatePreview,
     TargetCandidatePreview,
 )
+from ...batch.state.metadata_types import BatchFileMetadataDict
 from ...core.buffer import LineBuffer
 from ...core.replacement import ReplacementPayload
 from ...utils.repository_buffers import (
@@ -65,7 +66,7 @@ def materialize_apply_candidate(
     batch_name: str,
     raw_selector: str,
     ordinal: int,
-    files: dict,
+    files: dict[str, BatchFileMetadataDict],
     selected_ids: set[int] | None,
     selection_ids_to_apply: set[int] | None,
 ) -> ApplyCandidateMaterialization:
@@ -144,7 +145,7 @@ def materialize_include_candidate(
     batch_name: str,
     raw_selector: str,
     ordinal: int,
-    files: dict,
+    files: dict[str, BatchFileMetadataDict],
     selected_ids: set[int] | None,
     selection_ids_to_include: set[int] | None,
     replacement_payload: ReplacementPayload | None,

--- a/src/git_stage_batch/commands/batch_source/candidate_planning.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_planning.py
@@ -13,6 +13,7 @@ from ...batch.operation_candidates import (
 )
 from ...batch.replacement import build_replacement_batch_view_from_lines
 from ...batch.selection import acquire_batch_ownership_for_display_ids_from_lines
+from ...batch.state.metadata_types import BatchFileMetadataDict
 from ...core.buffer import LineBuffer
 from ...core.replacement import ReplacementPayload
 
@@ -25,7 +26,7 @@ def plan_apply_candidate_previews(
     *,
     batch_name: str,
     file_path: str,
-    file_meta: dict,
+    file_meta: BatchFileMetadataDict,
     batch_source_lines: LineBuffer,
     batch_source_commit: str,
     worktree_lines: LineBuffer,
@@ -35,12 +36,11 @@ def plan_apply_candidate_previews(
     spool_dir: str | Path | None = None,
 ) -> tuple[OperationCandidatePreview, ...]:
     """Build apply previews from normalized source and target inputs."""
-    ownership_arguments = _spool_arguments(spool_dir)
     with acquire_batch_ownership_for_display_ids_from_lines(
         file_meta,
         batch_source_lines,
         selection_ids,
-        **ownership_arguments,
+        spool_dir=spool_dir,
     ) as ownership:
         return _build_apply_candidate_previews(
             batch_name=batch_name,
@@ -55,7 +55,7 @@ def plan_apply_candidate_previews(
             worktree_exists=worktree_target.exists,
             selected_ids=selected_ids,
             selection_ids=selection_ids,
-            **ownership_arguments,
+            spool_dir=spool_dir,
         )
 
 
@@ -63,7 +63,7 @@ def plan_include_candidate_previews(
     *,
     batch_name: str,
     file_path: str,
-    file_meta: dict,
+    file_meta: BatchFileMetadataDict,
     batch_source_lines: LineBuffer,
     batch_source_commit: str,
     index_lines: LineBuffer,
@@ -76,14 +76,13 @@ def plan_include_candidate_previews(
     spool_dir: str | Path | None = None,
 ) -> tuple[OperationCandidatePreview, ...]:
     """Build include previews from normalized source and target inputs."""
-    spool_arguments = _spool_arguments(spool_dir)
     with ExitStack() as stack:
         ownership = stack.enter_context(
             acquire_batch_ownership_for_display_ids_from_lines(
                 file_meta,
                 batch_source_lines,
                 selection_ids,
-                **spool_arguments,
+                spool_dir=spool_dir,
             )
         )
         source_for_candidates = batch_source_lines
@@ -94,7 +93,7 @@ def plan_include_candidate_previews(
                     batch_source_lines,
                     ownership,
                     replacement_payload,
-                    **spool_arguments,
+                    spool_dir=spool_dir,
                 )
             except ValueError as error:
                 raise CandidateReplacementError(str(error)) from error
@@ -119,11 +118,5 @@ def plan_include_candidate_previews(
             selected_ids=selected_ids,
             selection_ids=selection_ids,
             replacement_payload=replacement_payload,
-            **spool_arguments,
+            spool_dir=spool_dir,
         )
-
-
-def _spool_arguments(spool_dir: str | Path | None) -> dict[str, str | Path]:
-    if spool_dir is None:
-        return {}
-    return {"spool_dir": spool_dir}

--- a/src/git_stage_batch/commands/batch_source/candidate_preview_action.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_preview_action.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from ...batch.operation_candidate_state import save_candidate_preview_state
+from ...batch.source.selector import BatchSourceSelector
+from ...batch.state.metadata_types import BatchFileMetadataDict
 from ...core.replacement import ReplacementPayload
 from ...data.file_review.batch_selection import (
     translate_batch_file_gutter_ids_to_selection_ids,
@@ -19,9 +21,9 @@ from . import candidate_previews as _candidate_previews
 
 def show_batch_source_candidate_preview(
     *,
-    selector,
+    selector: BatchSourceSelector,
     batch_name: str,
-    files: dict,
+    files: dict[str, BatchFileMetadataDict],
     selected_ids: set[int] | None,
     replacement_text: str | ReplacementPayload | None,
     patterns: list[str] | None,
@@ -29,6 +31,9 @@ def show_batch_source_candidate_preview(
     note: str | None,
 ) -> None:
     """Render a candidate preview for a show-from batch source selector."""
+    operation = selector.candidate_operation
+    if operation is None:
+        raise ValueError("candidate preview requires an operation")
     if patterns is not None or len(files) != 1:
         exit_with_error(_("Candidate preview requires exactly one file."))
     file_path = list(files.keys())[0]
@@ -52,7 +57,7 @@ def show_batch_source_candidate_preview(
         exit_with_error(
             _("Batch '{batch}' has no {operation} candidates for {file}.").format(
                 batch=batch_name,
-                operation=selector.candidate_operation,
+                operation=operation,
                 file=file_path,
             )
         )
@@ -75,7 +80,7 @@ def show_batch_source_candidate_preview(
             previews,
             selector.candidate_ordinal,
             batch_name=batch_name,
-            operation=selector.candidate_operation,
+            operation=operation,
             file_path=file_path,
         )
         render_operation_candidate(

--- a/src/git_stage_batch/commands/batch_source/candidate_preview_builders.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_preview_builders.py
@@ -3,14 +3,15 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any
 
 from . import candidate_inputs as _candidate_inputs
 from . import candidate_planning as _candidate_planning
 from ..selection import replacement_selection
 from ...batch.operation_candidate_types import OperationCandidatePreview
 from ...batch.source.selector import BatchSourceSelector
+from ...batch.state.metadata_types import BatchFileMetadataDict
 from ...core.buffer import LineBuffer
+from ...core.models import RenderedBatchDisplay
 from ...core.replacement import ReplacementPayload, coerce_replacement_payload
 from ...data.file_review.batch_selection import (
     translate_batch_file_gutter_ids_to_selection_ids,
@@ -25,15 +26,15 @@ from ...i18n import _
 
 
 SelectionTranslator = Callable[
-    [str, str, set[int], FileReviewAction],
-    tuple[set[int], Any],
+    [str, str, set[int] | None, FileReviewAction | str],
+    tuple[set[int] | None, RenderedBatchDisplay | None],
 ]
 
 
 def build_batch_source_candidate_previews(
     *,
     selector: BatchSourceSelector,
-    files: dict,
+    files: dict[str, BatchFileMetadataDict],
     file_path: str,
     selected_ids: set[int] | None,
     replacement_text: str | ReplacementPayload | None,

--- a/src/git_stage_batch/commands/batch_source/candidate_preview_counts.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_preview_counts.py
@@ -12,6 +12,7 @@ from ...batch.operation_candidate_types import (
     CandidateEnumerationLimitError,
     CandidatePreviewCount,
 )
+from ...batch.state.metadata_types import BatchFileMetadataDict
 from ...core.buffer import LineBuffer
 from ...core.replacement import ReplacementPayload
 from ...data.file_target_identity import IndexIdentity
@@ -27,7 +28,7 @@ def count_apply_candidate_previews_for_file(
     *,
     batch_name: str,
     file_path: str,
-    file_meta: dict,
+    file_meta: BatchFileMetadataDict,
     selection_ids_to_apply: set[int] | None,
     batch_source_object_id: str | None = None,
     working_tree_artifact_path: str | Path | None = None,
@@ -112,7 +113,7 @@ def count_include_candidate_previews_for_file(
     *,
     batch_name: str,
     file_path: str,
-    file_meta: dict,
+    file_meta: BatchFileMetadataDict,
     selection_ids_to_include: set[int] | None,
     replacement_payload: ReplacementPayload | None,
     batch_source_object_id: str | None = None,

--- a/src/git_stage_batch/commands/batch_source/discard_action.py
+++ b/src/git_stage_batch/commands/batch_source/discard_action.py
@@ -29,7 +29,7 @@ from ...i18n import _
 
 def _print_binary_discard_result(
     file_path: str,
-    action: _binary_file_actions.BinaryWorktreeAction,
+    action: _binary_file_actions.BinaryWorktreeAction | None,
 ) -> None:
     """Print discard-from status for a binary working-tree action."""
     if action is _binary_file_actions.BinaryWorktreeAction.REPLACED:

--- a/src/git_stage_batch/commands/batch_source/file_display_action.py
+++ b/src/git_stage_batch/commands/batch_source/file_display_action.py
@@ -9,6 +9,10 @@ from ...batch.atomic_file_changes import (
     gitlink_change_from_batch_file_metadata,
 )
 from ...batch.file_display import render_batch_file_display
+from ...batch.state.metadata_types import (
+    BatchFileMetadataDict,
+    BatchMetadataDict,
+)
 from ...core.models import FileModeChange, LineLevelChange
 from ...data.selected_change.batch_file_cache import cache_rendered_batch_file_display
 from ...data.batch_selected_changes import (
@@ -17,6 +21,7 @@ from ...data.batch_selected_changes import (
 )
 from ...data.file_review.pages import normalize_page_spec
 from ...data.file_review.records import ReviewSource
+from ...data.file_review.model import FileReviewModel
 from ...data.file_review.state import (
     clear_last_file_review_state,
     write_last_file_review_state,
@@ -44,7 +49,10 @@ from ...output.patch import (
 )
 
 
-def _shown_pages_for_display_ids(review_model, display_ids: set[int]) -> tuple[int, ...]:
+def _shown_pages_for_display_ids(
+    review_model: FileReviewModel,
+    display_ids: set[int],
+) -> tuple[int, ...]:
     """Return review pages that contain the selected display IDs."""
     return tuple(
         sorted(
@@ -61,8 +69,8 @@ def show_batch_source_file_display(
     *,
     batch_name: str,
     file_path: str,
-    files: dict[str, dict],
-    metadata: dict,
+    files: dict[str, BatchFileMetadataDict],
+    metadata: BatchMetadataDict,
     selected_ids: set[int] | None,
     selectable: bool,
     page: str | None,
@@ -157,7 +165,7 @@ def show_batch_source_file_display(
         )
         return
 
-    review_model = None
+    review_model: FileReviewModel | None = None
     review_gutter_to_selection_id = (
         rendered.review_gutter_to_selection_id
         or rendered.gutter_to_selection_id
@@ -168,7 +176,7 @@ def show_batch_source_file_display(
     )
     review_action_groups = rendered.review_action_groups or None
 
-    def get_review_model():
+    def get_review_model() -> FileReviewModel:
         nonlocal review_model
         if review_model is None:
             review_model = build_file_review_model(

--- a/src/git_stage_batch/commands/batch_source/file_list_action.py
+++ b/src/git_stage_batch/commands/batch_source/file_list_action.py
@@ -17,6 +17,8 @@ from ...batch.ownership.metadata_blobs import (
     replacement_origin_reference_blob_ids,
 )
 from ...batch.ownership.metadata_loading import ownership_from_metadata_dict
+from ...batch.state.metadata_types import BatchFileMetadataDict
+from ...core.buffer import LineBuffer
 from ...core.models import FileModeChange
 from ...data.file_review.records import ReviewSource
 from ...data.selected_change.clear_reasons import (
@@ -26,6 +28,7 @@ from ...data.selected_change.lifecycle import clear_selected_change_state_files
 from ...exceptions import RepositoryDataInvalid
 from ...i18n import _
 from ...output.file_review_list import (
+    FileReviewListEntry,
     make_binary_file_review_list_entry,
     make_file_review_list_entry,
     make_gitlink_file_review_list_entry,
@@ -33,6 +36,7 @@ from ...output.file_review_list import (
     print_file_review_list,
 )
 from ...utils.git_object_io import resolve_git_objects
+from ...utils.git_object_io import GitObjectInfo
 from ...utils.repository_buffers import (
     acquire_git_blob_buffers,
     git_object_name_is_batch_protocol_safe,
@@ -43,12 +47,12 @@ from ...utils.repository_buffers import (
 def show_batch_source_file_list(
     *,
     batch_name: str,
-    files: dict[str, dict],
+    files: dict[str, BatchFileMetadataDict],
     selectable: bool,
     command_source_args: str,
 ) -> None:
     """Show a navigational list for multiple files from a batch."""
-    entries = []
+    entries: list[FileReviewListEntry] = []
     text_files = {
         file_path: file_meta
         for file_path, file_meta in files.items()
@@ -161,8 +165,8 @@ def show_batch_source_file_list(
 
 def _require_ownership_blobs(
     *,
-    text_files: dict[str, dict],
-    object_info_by_name: dict,
+    text_files: dict[str, BatchFileMetadataDict],
+    object_info_by_name: dict[str, GitObjectInfo],
 ) -> None:
     """Require every blob referenced by ownership metadata to be readable."""
     for file_path, file_meta in text_files.items():
@@ -190,11 +194,11 @@ def _require_ownership_blobs(
 
 def _append_batch_file_entries(
     *,
-    entries: list,
-    files: dict[str, dict],
-    source_buffer_by_path: dict,
+    entries: list[FileReviewListEntry],
+    files: dict[str, BatchFileMetadataDict],
+    source_buffer_by_path: dict[str, LineBuffer],
     reference_contents: dict[str, bytes],
-    deletion_buffers: dict,
+    deletion_buffers: dict[str, LineBuffer],
 ) -> None:
     """Append ordered batch entries from caller-owned bulk object inputs."""
     for file_path, file_meta in files.items():

--- a/src/git_stage_batch/commands/batch_source/include_action.py
+++ b/src/git_stage_batch/commands/batch_source/include_action.py
@@ -20,11 +20,14 @@ from . import text_plan_jobs as _text_plan_jobs
 from . import worktree_refusals as _worktree_refusals
 from ...batch.binary_file_content import read_binary_file_from_batch
 from ...batch.operation_candidate_types import CandidatePreviewCount
+from ...batch.state.metadata_types import BatchFileMetadataDict
 from ...batch.submodule_pointer import (
     is_batch_submodule_pointer,
     stage_submodule_pointer_from_batch,
 )
 from ...core.replacement import ReplacementPayload
+from ...core.models import RenderedBatchDisplay
+from ...core.text_lifecycle import TextFileChangeType
 from ...data.file_target_identity import (
     IndexIdentity,
     WorktreeIdentity,
@@ -50,7 +53,7 @@ from ...utils.git_repository import get_git_repository_root_path
 class _IncludeTextInput:
     ordinal: int
     file_path: str
-    file_meta: dict
+    file_meta: BatchFileMetadataDict
     index_identity: IndexIdentity
     worktree_identity: WorktreeIdentity
     worktree_artifact: Path
@@ -65,8 +68,8 @@ class _IncludePlanCapture:
     plans_by_ordinal: dict[int, _action_plans.BatchSourceActionPlan]
     command_errors_by_ordinal: dict[int, CommandError]
     unexpected_errors_by_ordinal: dict[int, str]
-    mode_actions: list[tuple[str, dict]]
-    binary_metadata_by_ordinal: dict[int, dict]
+    mode_actions: list[tuple[str, BatchFileMetadataDict]]
+    binary_metadata_by_ordinal: dict[int, BatchFileMetadataDict]
     index_identities: dict[str, IndexIdentity]
     worktree_identities: dict[str, WorktreeIdentity]
 
@@ -140,11 +143,16 @@ def execute_include_action(
                                 plan.file_meta,
                                 plan.buffer,
                             )
-                        else:
+                        elif isinstance(
+                            plan,
+                            _action_plans.SubmodulePointerActionPlan,
+                        ):
                             stage_submodule_pointer_from_batch(
                                 plan.file_path,
                                 plan.file_meta,
                             )
+                        else:
+                            raise TypeError("unsupported include action plan")
                     for file_path, file_meta in mode_actions:
                         _file_mode_actions.stage_file_mode(file_path, file_meta)
                         _file_mode_actions.apply_new_file_mode(
@@ -168,16 +176,16 @@ def execute_include_action(
 def _build_include_action_plans(
     *,
     batch_name: str,
-    files: dict[str, dict],
+    files: dict[str, BatchFileMetadataDict],
     selected_ids: set[int] | None,
     selection_ids_to_include: set[int] | None,
-    rendered,
+    rendered: RenderedBatchDisplay | None,
     replacement_payload: ReplacementPayload | None,
     repository_root: Path,
     workspace: FileJobWorkspace,
 ) -> tuple[
     list[_action_plans.BatchSourceActionPlan],
-    list[tuple[str, dict]],
+    list[tuple[str, BatchFileMetadataDict]],
     dict[str, IndexIdentity],
     dict[str, WorktreeIdentity],
 ]:
@@ -220,7 +228,7 @@ def _build_include_action_plans(
 
 def _capture_include_plan_inputs(
     *,
-    files: dict[str, dict],
+    files: dict[str, BatchFileMetadataDict],
     selected_ids: set[int] | None,
     workspace: FileJobWorkspace,
 ) -> _IncludePlanCapture:
@@ -234,8 +242,8 @@ def _capture_include_plan_inputs(
     plans_by_ordinal: dict[int, _action_plans.BatchSourceActionPlan] = {}
     command_errors_by_ordinal: dict[int, CommandError] = {}
     unexpected_errors_by_ordinal: dict[int, str] = {}
-    mode_actions: list[tuple[str, dict]] = []
-    binary_metadata_by_ordinal: dict[int, dict] = {}
+    mode_actions: list[tuple[str, BatchFileMetadataDict]] = []
+    binary_metadata_by_ordinal: dict[int, BatchFileMetadataDict] = {}
     text_inputs: list[_IncludeTextInput] = []
 
     for ordinal, (file_path, file_meta) in enumerate(files.items()):
@@ -402,9 +410,16 @@ def _build_include_text_jobs(
                 expected_index_identity=text_input.index_identity,
                 expected_worktree_identity=text_input.worktree_identity,
             )
-            source_info = object_info_by_id.get(source_object_id)
-            index_info = object_info_by_id.get(
-                text_input.index_identity.content_object_id
+            source_info = (
+                None
+                if source_object_id is None
+                else object_info_by_id.get(source_object_id)
+            )
+            index_object_id = text_input.index_identity.content_object_id
+            index_info = (
+                None
+                if index_object_id is None
+                else object_info_by_id.get(index_object_id)
             )
             jobs.append(
                 OrderedFileJob(
@@ -464,8 +479,8 @@ def _run_include_text_jobs(
 def _reduce_include_action_plans(
     *,
     batch_name: str,
-    files: dict[str, dict],
-    rendered,
+    files: dict[str, BatchFileMetadataDict],
+    rendered: RenderedBatchDisplay | None,
     capture: _IncludePlanCapture,
     text_results_by_ordinal: dict[int, _text_plan_jobs.IncludeTextPlanJobResult],
     workspace: FileJobWorkspace,
@@ -555,20 +570,20 @@ def _reduce_include_action_plans(
                 worktree_buffer,
                 result.index_file_mode,
                 result.worktree_file_mode,
-                result.index_change_type,
-                result.worktree_change_type,
+                TextFileChangeType(result.index_change_type),
+                TextFileChangeType(result.worktree_change_type),
             )
         elif result.outcome == "noop":
             continue
         elif result.outcome == "atomic_unit_error":
-            error = AtomicUnitError(
+            atomic_error = AtomicUnitError(
                 details["message"],
                 details.get("required_selection_ids"),
                 details.get("unit_kind"),
             )
             if rendered:
                 _atomic_unit_refusals.translate_atomic_unit_error_to_gutter_ids(
-                    error,
+                    atomic_error,
                     rendered,
                     "include from",
                     batch_name,
@@ -576,7 +591,7 @@ def _reduce_include_action_plans(
             exit_with_error(
                 _("Failed to include from batch '{name}': {error}").format(
                     name=batch_name,
-                    error=str(error),
+                    error=str(atomic_error),
                 )
             )
         elif result.outcome == "command_error":

--- a/src/git_stage_batch/commands/batch_source/replacement_previews.py
+++ b/src/git_stage_batch/commands/batch_source/replacement_previews.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any
 
 from ..selection import replacement_selection
 from ...batch.replacement import build_replacement_batch_view_from_lines
 from ...batch.selection import acquire_batch_ownership_for_display_ids_from_lines
+from ...batch.state.metadata_types import BatchFileMetadataDict
 from ...batch.submodule_pointer import is_batch_submodule_pointer
 from ...core.replacement import ReplacementPayload, coerce_replacement_payload
+from ...core.models import RenderedBatchDisplay
 from ...data.file_review.batch_selection import (
     translate_batch_file_gutter_ids_to_selection_ids,
 )
@@ -22,15 +23,15 @@ from ...utils.paths import get_context_lines
 
 
 SelectionTranslator = Callable[
-    [str, str, set[int], FileReviewAction],
-    tuple[set[int], Any],
+    [str, str, set[int] | None, FileReviewAction | str],
+    tuple[set[int] | None, RenderedBatchDisplay | None],
 ]
 
 
 def print_batch_source_replacement_preview(
     *,
     batch_name: str,
-    files: dict,
+    files: dict[str, BatchFileMetadataDict],
     file_path: str,
     selected_ids: set[int],
     replacement_text: str | ReplacementPayload,
@@ -62,6 +63,8 @@ def print_batch_source_replacement_preview(
             selected_ids,
             FileReviewAction.INCLUDE_FROM_BATCH,
         )
+        if selection_ids is None:
+            raise ValueError("selection translation omitted selected lines")
         with acquire_batch_ownership_for_display_ids_from_lines(
             file_meta,
             batch_source_lines,

--- a/src/git_stage_batch/commands/batch_source/reset_claims.py
+++ b/src/git_stage_batch/commands/batch_source/reset_claims.py
@@ -18,7 +18,12 @@ from ...batch.ownership.units import (
 from ...batch.ownership.unit_rebuild import rebuild_ownership_from_units
 from ...batch.ownership.unit_selection import filter_ownership_units_by_display_ids
 from ...batch.ownership.unit_validation import validate_ownership_units
+from ...batch.ownership.unit_types import OwnershipUnit
 from ...batch.state.query import read_batch_metadata
+from ...batch.state.metadata_types import (
+    BatchFileMetadataDict,
+    BatchMetadataDict,
+)
 from ...batch.selection import require_display_ids_available
 from ...batch.state.references import sync_batch_state_refs
 from ...batch.text_file_storage import (
@@ -217,7 +222,7 @@ def partition_line_ownership_units(
     *,
     batch_name: str,
     file_path: str,
-):
+) -> tuple[list[OwnershipUnit], list[OwnershipUnit]]:
     """Partition ownership units by selected display line IDs."""
     units = build_ownership_units_from_batch_source_lines(
         ownership,
@@ -259,7 +264,7 @@ def reset_all_claims_from_batch(batch_name: str) -> None:
 def _ensure_destination_batch(
     source_batch: str,
     dest_batch: str,
-    source_metadata: dict,
+    source_metadata: BatchMetadataDict,
 ) -> None:
     """Create destination batch from source baseline, or verify compatibility."""
     source_baseline = source_metadata.get("baseline")
@@ -288,7 +293,7 @@ def _ensure_destination_batch(
 def _add_ownership_to_destination(
     dest_batch: str,
     file_path: str,
-    source_file_meta: dict,
+    source_file_meta: BatchFileMetadataDict,
     ownership: BatchOwnership,
 ) -> None:
     """Add selected text ownership to destination, merging with compatible claims."""

--- a/src/git_stage_batch/commands/batch_source/reset_selection.py
+++ b/src/git_stage_batch/commands/batch_source/reset_selection.py
@@ -6,6 +6,7 @@ import shlex
 from dataclasses import dataclass
 
 from ...batch.state.query import read_batch_metadata
+from ...batch.state.metadata_types import BatchFileMetadataDict
 from ...batch.source.selector import require_plain_batch_name
 from ...batch.state.batch_names import batch_exists, validate_batch_name
 from ...core.line_selection import LineRanges
@@ -28,7 +29,7 @@ class ResetClaimSelection:
 
     batch_name: str
     file: str | None
-    all_files: dict
+    all_files: dict[str, BatchFileMetadataDict]
     effective_line_ids: LineRanges | None
     affected_files: set[str]
     operation_parts: tuple[str, ...]
@@ -45,7 +46,7 @@ def resolve_reset_claim_selection(
     """Resolve reset-from-batch scope without rejecting empty batches."""
     batch_name = require_plain_batch_name(batch_name, "reset")
     validate_batch_name(batch_name)
-    extra_action_parts = ()
+    extra_action_parts: tuple[str, ...] = ()
     if to_batch is not None:
         extra_action_parts = ("--to", shlex.quote(to_batch))
     scope_resolution = resolve_batch_source_action_scope(

--- a/src/git_stage_batch/commands/batch_source/text_plan_builders.py
+++ b/src/git_stage_batch/commands/batch_source/text_plan_builders.py
@@ -6,12 +6,14 @@ from contextlib import ExitStack
 from dataclasses import dataclass
 import os
 from pathlib import Path
+from typing import TypedDict
 
 from . import action_plans as _action_plans
 from ...batch.discard import discard_batch_from_line_sequences_as_buffer
 from ...batch.merge.merge import merge_batch_from_line_sequences_as_buffer
 from ...batch.replacement import build_replacement_batch_view_from_lines
 from ...batch.selection import acquire_batch_ownership_for_display_ids_from_lines
+from ...batch.state.metadata_types import BatchFileMetadataDict
 from ...core.buffer import LineBuffer
 from ...core.replacement import ReplacementPayload
 from ...core.text_lifecycle import (
@@ -29,6 +31,18 @@ from ...utils.repository_buffers import (
     load_working_tree_file_as_buffer,
 )
 from ...utils.git_repository import get_git_repository_root_path
+
+
+class _SpoolDirOptions(TypedDict, total=False):
+    """Typed optional arguments for spool-aware helpers."""
+
+    spool_dir: str | Path
+
+
+def _spool_dir_options(spool_dir: str | Path | None) -> _SpoolDirOptions:
+    if spool_dir is None:
+        return {}
+    return {"spool_dir": spool_dir}
 
 
 @dataclass(frozen=True)
@@ -66,7 +80,7 @@ def _close_include_merge_buffers(
 
 
 def apply_text_plan_requires_source(
-    file_meta: dict,
+    file_meta: BatchFileMetadataDict,
     selected_ids: set[int] | None,
 ) -> bool:
     """Return whether one apply text plan needs batch source content."""
@@ -78,7 +92,7 @@ def apply_text_plan_requires_source(
 
 
 def include_text_plan_requires_source(
-    file_meta: dict,
+    file_meta: BatchFileMetadataDict,
     selected_ids: set[int] | None,
 ) -> bool:
     """Return whether one include text plan needs batch source content."""
@@ -88,7 +102,7 @@ def include_text_plan_requires_source(
 def build_apply_text_file_action_plan(
     *,
     file_path: str,
-    file_meta: dict,
+    file_meta: BatchFileMetadataDict,
     selected_ids: set[int] | None,
     selection_ids_to_apply: set[int] | None,
     batch_source_object_id: str | None = None,
@@ -156,14 +170,12 @@ def build_apply_text_file_action_plan(
                 spool_dir=spool_dir,
             )
         working_lines = stack.enter_context(working_tree_buffer)
-        ownership_arguments = {}
-        if spool_dir is not None:
-            ownership_arguments["spool_dir"] = spool_dir
+        spool_options = _spool_dir_options(spool_dir)
         with acquire_batch_ownership_for_display_ids_from_lines(
             file_meta,
             batch_source_lines,
             selection_ids_to_apply,
-            **ownership_arguments,
+            **spool_options,
         ) as ownership:
             if ownership.is_empty():
                 if selected_ids is None and text_change_type == TextFileChangeType.ADDED:
@@ -174,14 +186,11 @@ def build_apply_text_file_action_plan(
                 else:
                     return ApplyTextPlanBuildResult()
             else:
-                merge_arguments = {}
-                if spool_dir is not None:
-                    merge_arguments["spool_dir"] = spool_dir
                 merged_buffer = merge_batch_from_line_sequences_as_buffer(
                     batch_source_lines,
                     ownership,
                     working_lines,
-                    **merge_arguments,
+                    **spool_options,
                 )
 
     try:
@@ -206,7 +215,7 @@ def build_apply_text_file_action_plan(
 def build_include_text_file_action_plan(
     *,
     file_path: str,
-    file_meta: dict,
+    file_meta: BatchFileMetadataDict,
     selected_ids: set[int] | None,
     selection_ids_to_include: set[int] | None,
     replacement_payload: ReplacementPayload | None,
@@ -305,14 +314,12 @@ def build_include_text_file_action_plan(
                     spool_dir=spool_dir,
                 )
             working_lines = resources.enter_context(working_buffer)
-            ownership_arguments = {}
-            if spool_dir is not None:
-                ownership_arguments["spool_dir"] = spool_dir
+            spool_options = _spool_dir_options(spool_dir)
             with acquire_batch_ownership_for_display_ids_from_lines(
                 file_meta,
                 batch_source_lines,
                 selection_ids_to_include,
-                **ownership_arguments,
+                **spool_options,
             ) as ownership:
                 if ownership.is_empty():
                     if (
@@ -334,34 +341,28 @@ def build_include_text_file_action_plan(
                         source_lines = batch_source_lines
                         merge_ownership = ownership
                         if replacement_payload is not None:
-                            replacement_arguments = {}
-                            if spool_dir is not None:
-                                replacement_arguments["spool_dir"] = spool_dir
                             replacement_view = stack.enter_context(
                                 build_replacement_batch_view_from_lines(
                                     batch_source_lines,
                                     ownership,
                                     replacement_payload,
-                                    **replacement_arguments,
+                                    **spool_options,
                                 )
                             )
                             source_lines = replacement_view.source_buffer
                             merge_ownership = replacement_view.ownership
-                        merge_arguments = {}
-                        if spool_dir is not None:
-                            merge_arguments["spool_dir"] = spool_dir
                         merged_index_buffer = merge_batch_from_line_sequences_as_buffer(
                             source_lines,
                             merge_ownership,
                             index_lines,
-                            **merge_arguments,
+                            **spool_options,
                         )
                         merged_working_buffer = (
                             merge_batch_from_line_sequences_as_buffer(
                                 source_lines,
                                 merge_ownership,
                                 working_lines,
-                                **merge_arguments,
+                                **spool_options,
                             )
                         )
 
@@ -395,7 +396,7 @@ def build_include_text_file_action_plan(
 def build_discard_text_file_action_plan(
     *,
     file_path: str,
-    file_meta: dict,
+    file_meta: BatchFileMetadataDict,
     baseline_commit: str,
     selected_ids: set[int] | None,
     selection_ids_to_discard: set[int] | None,

--- a/src/git_stage_batch/commands/batch_source/text_plan_jobs.py
+++ b/src/git_stage_batch/commands/batch_source/text_plan_jobs.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 import pickle
 from pathlib import Path
-from typing import Literal
 from typing import Literal, TypedDict, cast
 
 from . import candidate_preview_counts as _candidate_preview_counts
 from . import text_plan_builders as _text_plan_builders
+from ...batch.state.metadata_types import BatchFileMetadataDict
 from ...core.replacement import ReplacementPayload
 from ...core.buffer import LineBuffer
 from ...core.text_lifecycle import normalized_text_change_type
@@ -53,6 +53,26 @@ _TEXT_CHANGE_TYPES = frozenset({
     "modified",
     "deleted",
 })
+
+
+class _ApplyInputMetadata(TypedDict):
+    """Serialized inputs for one apply text-planning worker."""
+
+    batch_name: str
+    batch_source_object_id: str | None
+    file_meta: BatchFileMetadataDict
+    selected_ids: list[int] | None
+    selection_ids: list[int] | None
+    working_tree_artifact_path: str
+    scratch_directory: str
+
+
+class _IncludeInputMetadata(_ApplyInputMetadata):
+    """Serialized inputs for one include text-planning worker."""
+
+    replacement_artifact_path: str | None
+    replacement_display_text: str | None
+    replacement_exact: bool
 
 
 @dataclass(frozen=True, slots=True)
@@ -114,9 +134,10 @@ def compute_apply_text_plan_job(
     job: ApplyTextPlanJob,
 ) -> ApplyTextPlanJobResult:
     """Build one text apply plan from immutable artifact inputs."""
-    input_metadata = _read_pickle(job.input_artifact_path)
-    if type(input_metadata) is not dict:
+    raw_input_metadata = _read_pickle(job.input_artifact_path)
+    if type(raw_input_metadata) is not dict:
         raise TypeError("apply text-plan input must be a dictionary")
+    input_metadata = cast(_ApplyInputMetadata, raw_input_metadata)
     file_meta = input_metadata["file_meta"]
     selected_ids = _optional_int_set(input_metadata["selected_ids"])
     selection_ids = _optional_int_set(input_metadata["selection_ids"])
@@ -150,7 +171,7 @@ def compute_apply_text_plan_job(
 
         plan = build_result.plan
         try:
-            change_type = getattr(plan.change_type, "value", plan.change_type)
+            change_type = normalized_text_change_type(plan.change_type).value
             output_path = None
             if plan.buffer is not None and change_type != "deleted":
                 write_buffer_to_path(job.output_path, plan.buffer)
@@ -224,9 +245,10 @@ def compute_include_text_plan_job(
     job: IncludeTextPlanJob,
 ) -> IncludeTextPlanJobResult:
     """Build one text include plan from immutable artifact inputs."""
-    input_metadata = _read_pickle(job.input_artifact_path)
-    if type(input_metadata) is not dict:
+    raw_input_metadata = _read_pickle(job.input_artifact_path)
+    if type(raw_input_metadata) is not dict:
         raise TypeError("include text-plan input must be a dictionary")
+    input_metadata = cast(_IncludeInputMetadata, raw_input_metadata)
     file_meta = input_metadata["file_meta"]
     selected_ids = _optional_int_set(input_metadata["selected_ids"])
     selection_ids = _optional_int_set(input_metadata["selection_ids"])
@@ -262,16 +284,12 @@ def compute_include_text_plan_job(
 
         plan = build_result.plan
         try:
-            index_change_type = getattr(
+            index_change_type = normalized_text_change_type(
                 plan.index_change_type,
-                "value",
-                plan.index_change_type,
-            )
-            worktree_change_type = getattr(
+            ).value
+            worktree_change_type = normalized_text_change_type(
                 plan.working_change_type,
-                "value",
-                plan.working_change_type,
-            )
+            ).value
             index_output_path = _write_plan_output(
                 job.index_output_path,
                 plan.index_buffer,
@@ -365,7 +383,7 @@ def compute_include_text_plan_job(
 
 
 def apply_text_plan_requires_source(
-    file_meta: dict,
+    file_meta: BatchFileMetadataDict,
     selected_ids: set[int] | None,
 ) -> bool:
     """Return whether one apply text plan needs batch source content."""
@@ -376,7 +394,7 @@ def apply_text_plan_requires_source(
 
 
 def include_text_plan_requires_source(
-    file_meta: dict,
+    file_meta: BatchFileMetadataDict,
     selected_ids: set[int] | None,
 ) -> bool:
     """Return whether one include text plan needs batch source content."""
@@ -606,7 +624,7 @@ def _write_plan_output(
 
 
 def _replacement_payload_from_metadata(
-    input_metadata: dict,
+    input_metadata: _IncludeInputMetadata,
 ) -> ReplacementPayload | None:
     replacement_path = input_metadata["replacement_artifact_path"]
     if replacement_path is None:

--- a/src/git_stage_batch/exceptions.py
+++ b/src/git_stage_batch/exceptions.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Literal
+from typing import Literal, NoReturn
 
 
 class CommandError(Exception):
     """Raised when a command fails and needs to exit with an error code."""
 
-    def __init__(self, message: str, exit_code: int = 1):
+    def __init__(self, message: str, exit_code: int = 1) -> None:
         self.message = message
         self.exit_code = exit_code
         super().__init__(message)
@@ -40,7 +40,7 @@ class GitOperationFailed(RepositoryReadError):
     """Raised when Git fails while reading repository state."""
 
 
-def exit_with_error(message: str, exit_code: int = 1) -> None:
+def exit_with_error(message: str, exit_code: int = 1) -> NoReturn:
     """Raise a CommandError instead of exiting directly."""
     raise CommandError(message, exit_code)
 
@@ -141,7 +141,7 @@ class AtomicUnitError(MergeError):
         message: str,
         required_selection_ids: Iterable[int] | None = None,
         unit_kind: str | None = None,
-    ):
+    ) -> None:
         super().__init__(message)
         self.required_selection_ids = required_selection_ids
         self.unit_kind = unit_kind


### PR DESCRIPTION
Typed CLI dispatch can deliver concrete command requests to saved-change
services.

Application metadata, action plans, candidate materialization, previews,
execution, and reset claims still cross internal boundaries through broad
mappings.

This PR defines application records and carries them through planning,
preview rendering, action execution, and selection reset.

Saved-change previews and actions now retain typed metadata end to end. The
full test suite, static checks, package build, and historical
compile/import gate pass.
