### PR TITLE
typing: Type sift and workflow metadata

### DIFF
--- a/src/git_stage_batch/batch/atomic_file_changes.py
+++ b/src/git_stage_batch/batch/atomic_file_changes.py
@@ -2,14 +2,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
-
+from .state.metadata_types import BatchFileMetadataDict
 from ..core.models import BinaryFileChange, GitlinkChange
 
 
 def binary_change_from_batch_file_metadata(
     file_path: str,
-    file_meta: Mapping[str, object],
+    file_meta: BatchFileMetadataDict,
 ) -> BinaryFileChange | None:
     """Return an atomic binary batch change, if the entry is binary."""
     if file_meta.get("file_type") != "binary":
@@ -26,7 +25,7 @@ def binary_change_from_batch_file_metadata(
 
 def gitlink_change_from_batch_file_metadata(
     file_path: str,
-    file_meta: Mapping[str, object],
+    file_meta: BatchFileMetadataDict,
 ) -> GitlinkChange | None:
     """Return an atomic submodule pointer batch change, if the entry is one."""
     if file_meta.get("file_type") != "gitlink":

--- a/src/git_stage_batch/batch/attribution_projection.py
+++ b/src/git_stage_batch/batch/attribution_projection.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
 
 from . import attribution_fingerprints as _attribution_fingerprints
 from .attribution import (
@@ -11,7 +10,7 @@ from .attribution import (
     FileAttribution,
 )
 from .attribution_units import AttributionUnitKind
-from ..core.models import LineLevelChange
+from ..core.models import LineEntry, LineLevelChange
 
 
 @dataclass(frozen=True)
@@ -34,7 +33,7 @@ class _CollectedAddedRun:
 
 
 def _collect_deleted_run(
-    lines: list,
+    lines: list[LineEntry],
     start_idx: int,
 ) -> _CollectedDeletedRun:
     end_idx = start_idx
@@ -52,7 +51,7 @@ def _collect_deleted_run(
 
 
 def _collect_added_run(
-    lines: list,
+    lines: list[LineEntry],
     start_idx: int,
 ) -> _CollectedAddedRun:
     end_idx = start_idx
@@ -83,7 +82,7 @@ def _collect_added_run(
 
 def project_attribution_to_diff(
     attribution: FileAttribution,
-    line_changes,
+    line_changes: LineLevelChange,
 ) -> dict[int, AttributedUnit]:
     """Project file attribution onto diff fragments."""
     display_to_unit: dict[int, AttributedUnit] = {}
@@ -194,7 +193,7 @@ def project_attribution_to_diff(
 def _anchor_consistent_with_diff_position(
     unit_anchor: int | None,
     deletion_start_idx: int,
-    lines: list,
+    lines: list[LineEntry],
 ) -> bool:
     """Sanity-check a unit-defined anchor against available diff context."""
     preceding_working_line = None
@@ -211,12 +210,12 @@ def _anchor_consistent_with_diff_position(
 
 
 def filter_owned_diff_fragments(
-    line_changes,
+    line_changes: LineLevelChange,
     attribution: FileAttribution,
-) -> tuple[bool, Any]:
+) -> tuple[bool, LineLevelChange | None]:
     """Filter displayed diff fragments that correspond to owned units."""
     display_to_unit = project_attribution_to_diff(attribution, line_changes)
-    filtered_lines = []
+    filtered_lines: list[LineEntry] = []
 
     for idx, line_entry in enumerate(line_changes.lines):
         attr_unit = display_to_unit.get(idx)

--- a/src/git_stage_batch/batch/binary_file_content.py
+++ b/src/git_stage_batch/batch/binary_file_content.py
@@ -2,17 +2,16 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
-
 from ..core.buffer import LineBuffer
 from ..utils.repository_buffers import read_git_object_buffer_or_none
+from .state.metadata_types import BatchFileMetadataDict
 from .state.query import get_batch_commit_sha
 
 
 def read_binary_file_from_batch(
     batch_name: str,
     file_path: str,
-    file_meta: Mapping[str, object],
+    file_meta: BatchFileMetadataDict,
     *,
     missing_content_message: str | None = None,
 ) -> LineBuffer | None:

--- a/src/git_stage_batch/batch/state/metadata_schema.py
+++ b/src/git_stage_batch/batch/state/metadata_schema.py
@@ -18,6 +18,7 @@ from ...utils.git_repository import object_id_hex_length
 from .metadata_types import (
     BatchFileMetadataDict,
     BatchMetadataDict,
+    BatchStorageMetadataDict,
 )
 
 
@@ -128,7 +129,7 @@ class BatchMetadata:
             "files": {entry.path: entry.to_dict() for entry in self.files},
         }
 
-    def to_storage_dict(self) -> dict[str, Any]:
+    def to_storage_dict(self) -> BatchStorageMetadataDict:
         """Return the canonical current-version storage representation."""
         return {
             "schema_version": CURRENT_BATCH_METADATA_SCHEMA_VERSION,

--- a/src/git_stage_batch/batch/state/metadata_types.py
+++ b/src/git_stage_batch/batch/state/metadata_types.py
@@ -43,6 +43,18 @@ class BatchMetadataDict(TypedDict, total=False):
     files: dict[str, BatchFileMetadataDict]
 
 
+class BatchStorageMetadataDict(TypedDict):
+    """Canonical current-schema mapping persisted as ``batch.json``."""
+
+    schema_version: int
+    revision: str
+    batch: str
+    note: str
+    created_at: str
+    baseline: str | None
+    content_ref: str | None
+    content_commit: str | None
+    files: dict[str, BatchFileMetadataDict]
 
 
 def add_ownership_metadata(

--- a/src/git_stage_batch/cli/batch_subcommands.py
+++ b/src/git_stage_batch/cli/batch_subcommands.py
@@ -98,7 +98,7 @@ def add_annotate_subcommand(subparsers) -> None:
     )
 
 
-def add_sift_subcommand(subparsers) -> None:
+def add_sift_subcommand(subparsers: Subparsers) -> None:
     """Register the sift subcommand."""
     parser_sift = add_subcommand_parser(
         subparsers,

--- a/src/git_stage_batch/cli/selection_subcommands.py
+++ b/src/git_stage_batch/cli/selection_subcommands.py
@@ -11,10 +11,10 @@ from .file_arguments import add_file_argument
 from .include_dispatch import dispatch_include_command
 from .show_dispatch import dispatch_show_command
 from .skip_dispatch import dispatch_skip_command
-from .subcommand_parser import add_subcommand_parser
+from .subcommand_parser import Subparsers, add_subcommand_parser
 
 
-def add_show_subcommand(subparsers) -> None:
+def add_show_subcommand(subparsers: Subparsers) -> None:
     """Register the show subcommand."""
     parser_show = add_subcommand_parser(
         subparsers,

--- a/src/git_stage_batch/cli/show_dispatch.py
+++ b/src/git_stage_batch/cli/show_dispatch.py
@@ -3,22 +3,38 @@
 from __future__ import annotations
 
 import argparse
+from typing import TypedDict
 
 from ..batch.state.query import read_batch_metadata
 from ..batch.source.selector import batch_name_for_source_lookup
 from ..batch.state.batch_names import batch_exists
 from ..commands.show import command_show, command_show_file_list
 from ..commands.show_from import command_show_from_batch
+from ..core.replacement import ReplacementPayload
 from ..exceptions import CommandError
 from ..i18n import _
-from .file_scope import resolve_batch_file_scope, resolve_live_file_scope
+from .file_scope import FileScope, resolve_batch_file_scope, resolve_live_file_scope
 from .replacement_input import resolve_replacement_text
+
+
+class _ShowFromOptions(TypedDict, total=False):
+    patterns: list[str] | None
+    selectable: bool
+    page: str | None
+    porcelain: bool
+    replacement_text: str | ReplacementPayload | None
+
+
+class _ShowLiveOptions(TypedDict, total=False):
+    page: str | None
+    porcelain: bool
+    selectable: bool
 
 
 def _validate_show_page_request(
     args: argparse.Namespace,
     *,
-    resolved_file_scope,
+    resolved_file_scope: FileScope,
 ) -> None:
     lookup_batch = (
         batch_name_for_source_lookup(args.from_batch)
@@ -54,7 +70,7 @@ def _validate_show_page_request(
 def _dispatch_show_from_batch(
     args: argparse.Namespace,
     *,
-    resolved_file_scope,
+    resolved_file_scope: FileScope,
     replacement_requested: bool,
 ) -> None:
     replacement_text = (
@@ -62,37 +78,33 @@ def _dispatch_show_from_batch(
         if replacement_requested
         else None
     )
-    show_kwargs = {"page": args.page}
+    options: _ShowFromOptions = {"page": args.page}
     if args.porcelain:
-        show_kwargs["porcelain"] = args.porcelain
+        options["porcelain"] = True
     if not args.advance:
-        show_kwargs["selectable"] = False
-    if replacement_text is not None:
-        show_kwargs["replacement_text"] = replacement_text
+        options["selectable"] = False
+    if replacement_requested:
+        options["replacement_text"] = replacement_text
     if resolved_file_scope.is_multiple:
         if args.line_ids:
             raise CommandError(_("Cannot use --lines with multiple files."))
         if replacement_requested:
             raise CommandError(_("`show --as` requires exactly one resolved file."))
-        command_show_from_batch(
-            args.from_batch,
-            args.line_ids,
-            patterns=args.file_patterns,
-            **show_kwargs,
-        )
+        options["patterns"] = args.file_patterns
+        command_show_from_batch(args.from_batch, args.line_ids, **options)
     else:
         command_show_from_batch(
             args.from_batch,
             args.line_ids,
             resolved_file_scope.optional_file(),
-            **show_kwargs,
+            **options,
         )
 
 
 def _dispatch_show_live(
     args: argparse.Namespace,
     *,
-    resolved_file_scope,
+    resolved_file_scope: FileScope,
 ) -> None:
     if args.line_ids or not resolved_file_scope.is_implicit:
         if resolved_file_scope.is_multiple and args.porcelain:
@@ -100,30 +112,30 @@ def _dispatch_show_live(
         if resolved_file_scope.is_multiple:
             if args.line_ids:
                 raise CommandError(_("Cannot use --lines with multiple files."))
-            show_list_kwargs = {}
-            if not args.advance:
-                show_list_kwargs["selectable"] = False
-            command_show_file_list(
-                list(resolved_file_scope.files),
-                **show_list_kwargs,
-            )
+            if args.advance:
+                command_show_file_list(list(resolved_file_scope.files))
+            else:
+                command_show_file_list(
+                    list(resolved_file_scope.files),
+                    selectable=False,
+                )
         else:
-            show_kwargs = {
-                "file": resolved_file_scope.optional_file(),
+            options: _ShowLiveOptions = {
                 "page": args.page,
                 "porcelain": args.porcelain,
             }
             if not args.advance:
-                show_kwargs["selectable"] = False
+                options["selectable"] = False
             command_show(
-                **show_kwargs,
+                file=resolved_file_scope.optional_file(),
+                **options,
             )
         return
 
-    show_kwargs = {"porcelain": args.porcelain}
-    if not args.advance:
-        show_kwargs["selectable"] = False
-    command_show(**show_kwargs)
+    if args.advance:
+        command_show(porcelain=args.porcelain)
+    else:
+        command_show(porcelain=args.porcelain, selectable=False)
 
 
 def dispatch_show_command(args: argparse.Namespace) -> None:

--- a/src/git_stage_batch/commands/batch_transform/sift_jobs.py
+++ b/src/git_stage_batch/commands/batch_transform/sift_jobs.py
@@ -6,11 +6,12 @@ from dataclasses import dataclass
 import json
 from pathlib import Path
 import pickle
-from typing import Literal
+from typing import Literal, TypedDict, cast
 
 from . import sift_results as _sift_results
 from ...batch.ownership.absence_claims import AbsenceClaim
 from ...batch.ownership.model import BatchOwnership
+from ...batch.state.metadata_types import BatchFileMetadataDict
 from ...core.buffer import LineBuffer
 from ...data.file_target_identity import WorktreeIdentity
 from ...exceptions import MergeError
@@ -21,6 +22,20 @@ from ...utils.file_job_workspace import FileJobWorkspace
 SiftTextJobOutcome = Literal["retained", "removed", "merge_error"]
 _MANIFEST_VERSION = 1
 _MAX_ERROR_MESSAGE_CHARACTERS = 4 * 1024
+
+
+class SiftTextJobInput(TypedDict):
+    """Private pickle payload captured for one sift worker."""
+
+    baseline_object_id: str | None
+    batch_source_object_id: str | None
+    file_meta: BatchFileMetadataDict
+    working_tree_artifact_path: str
+
+
+class _SiftDeletionRecord(TypedDict):
+    anchor_line: int | None
+    content_path: str
 
 
 @dataclass(frozen=True, slots=True)
@@ -53,9 +68,10 @@ def compute_sifted_text_file_job(
     job: SiftTextFileJob,
 ) -> SiftTextFileJobResult:
     """Compute and stream one text sift result into private artifacts."""
-    input_metadata = _read_pickle(job.input_artifact_path)
-    if type(input_metadata) is not dict:
+    input_value = _read_pickle(job.input_artifact_path)
+    if type(input_value) is not dict:
         raise TypeError("sift text input must be a dictionary")
+    input_metadata = cast(SiftTextJobInput, input_value)
 
     try:
         result = _sift_results.compute_sifted_text_file(
@@ -160,7 +176,7 @@ def load_sifted_text_file_result(
             spool_dir=job.scratch_directory,
         )
         opened_buffers.append(target_buffer)
-        deletions = []
+        deletions: list[AbsenceClaim] = []
         for deletion_record in deletion_records:
             content_buffer = workspace.read_buffer(
                 deletion_record["content_path"],
@@ -243,7 +259,7 @@ def _require_supported_ownership(ownership: BatchOwnership) -> None:
 def _validate_manifest(
     value: object,
     job: SiftTextFileJob,
-) -> tuple[list[str], list[dict[str, object]], str]:
+) -> tuple[list[str], list[_SiftDeletionRecord], str]:
     if type(value) is not dict:
         raise TypeError("sift text manifest must be a dictionary")
     if set(value) != {
@@ -273,7 +289,7 @@ def _validate_manifest(
     deletion_values = value.get("deletions")
     if not isinstance(deletion_values, list):
         raise TypeError("sift text manifest has invalid deletions")
-    deletion_records: list[dict[str, object]] = []
+    deletion_records: list[_SiftDeletionRecord] = []
     deletion_directory = Path(job.deletion_output_directory)
     for index, deletion_value in enumerate(deletion_values):
         if type(deletion_value) is not dict:
@@ -300,9 +316,14 @@ def _validate_manifest(
                 "content_path": str(expected_path),
             }
         )
-    return presence_lines, deletion_records, change_type
+    return (
+        cast(list[str], presence_lines),
+        deletion_records,
+        cast(str, change_type),
+    )
 
 
-def _read_pickle(path: str | Path):
+def _read_pickle(path: str | Path) -> object:
     with Path(path).open("rb") as source:
-        return pickle.load(source)
+        value: object = pickle.load(source)
+        return value

--- a/src/git_stage_batch/commands/batch_transform/sift_persistence.py
+++ b/src/git_stage_batch/commands/batch_transform/sift_persistence.py
@@ -5,6 +5,11 @@ from __future__ import annotations
 import uuid
 
 from ...batch.state.lifecycle import create_batch
+from ...batch.state.metadata_types import (
+    BatchFileMetadataDict,
+    BatchMetadataDict,
+    add_ownership_metadata,
+)
 from ...batch.state.compatibility_metadata import write_file_backed_batch_metadata
 from ...batch.ownership.model import BatchOwnership
 from ...batch.state.query import get_batch_baseline_commit, read_batch_metadata
@@ -37,7 +42,7 @@ from ...utils.git_object_io import create_git_blob
 from .sift_results import SiftedBinaryFileResult, SiftedFileResult, SiftedModeFileResult
 
 
-RetainedSiftedFile = tuple[str, dict, SiftedFileResult]
+RetainedSiftedFile = tuple[str, BatchFileMetadataDict, SiftedFileResult]
 
 
 def create_synthetic_batch_source_commit(
@@ -115,11 +120,11 @@ def add_sifted_text_file_to_batch(
         metadata["files"] = {}
 
     text_change_type = normalized_text_change_type(change_type)
-    file_metadata = {
+    file_metadata: BatchFileMetadataDict = {
         "batch_source_commit": batch_source_commit,
-        **ownership.to_metadata_dict(),
         "mode": file_mode,
     }
+    add_ownership_metadata(file_metadata, ownership.to_metadata_dict())
     if text_change_type != TextFileChangeType.MODIFIED:
         file_metadata["change_type"] = text_change_type.value
     metadata["files"][file_path] = file_metadata
@@ -148,7 +153,7 @@ def add_sifted_text_file_to_batch(
 def add_sifted_file_to_batch(
     batch_name: str,
     file_path: str,
-    file_meta: dict,
+    file_meta: BatchFileMetadataDict,
     result: SiftedFileResult,
 ) -> None:
     """Persist any retained sifted file result into a batch."""
@@ -180,7 +185,7 @@ def add_sifted_file_to_batch(
 def replace_batch_with_sifted_files(
     batch_name: str,
     retained_files: list[RetainedSiftedFile],
-    source_metadata: dict,
+    source_metadata: BatchMetadataDict,
 ) -> None:
     """Replace a batch atomically with retained sifted file results."""
     publish_sifted_files(
@@ -196,7 +201,7 @@ def publish_sifted_files(
     *,
     destination_batch: str,
     retained_files: list[RetainedSiftedFile],
-    source_metadata: dict,
+    source_metadata: BatchMetadataDict,
     destination_note: str,
     replace_existing: bool,
 ) -> None:

--- a/src/git_stage_batch/commands/batch_transform/sift_results.py
+++ b/src/git_stage_batch/commands/batch_transform/sift_results.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional
+from typing import Optional, TypedDict
 
 from ...batch.line_matching.comparison import (
     SemanticChangeKind,
@@ -35,6 +35,18 @@ from ...utils.repository_buffers import read_git_object_buffer_or_empty
 from ...utils.repository_buffers import load_git_blob_as_buffer
 from ...exceptions import MergeError
 from ...core.text_lines import normalize_line_sequence_endings
+
+
+class _SpoolDirOptions(TypedDict, total=False):
+    """Typed optional arguments for spool-aware helpers."""
+
+    spool_dir: str | Path
+
+
+def _spool_dir_options(spool_dir: str | Path | None) -> _SpoolDirOptions:
+    if spool_dir is None:
+        return {}
+    return {"spool_dir": spool_dir}
 
 
 @dataclass
@@ -173,7 +185,7 @@ def compute_sifted_binary_file(
 
 def compute_sifted_text_file(
     file_path: str,
-    file_meta: dict,
+    file_meta: BatchFileMetadataDict,
     *,
     baseline_object_id: str | None,
     batch_source_object_id: str | None,
@@ -318,7 +330,7 @@ def build_ownership_from_working_and_target_lines(
     semantic_runs = derive_semantic_change_runs(
         source_lines=working_lines,
         target_lines=target_lines,
-        **({} if spool_dir is None else {"spool_dir": spool_dir}),
+        **_spool_dir_options(spool_dir),
     )
 
     claimed_ranges: list[tuple[int, int]] = []

--- a/src/git_stage_batch/commands/file_scope/discard_file.py
+++ b/src/git_stage_batch/commands/file_scope/discard_file.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
-from contextlib import nullcontext
+from collections.abc import Iterator, Sequence
+from contextlib import AbstractContextManager, nullcontext
 import shlex
 import sys
 
@@ -116,6 +116,8 @@ def discard_file_changes(
     else:
         target_file = file
 
+    checkpoint: AbstractContextManager[None]
+    patch_context: AbstractContextManager[Iterator[UnifiedDiffItem]]
     if _prepared_changes is None:
         auto_add_untracked_files([target_file])
         checkpoint_paths = checkpoint_paths_for_live_file(target_file)

--- a/src/git_stage_batch/commands/file_scope/discard_to_batch.py
+++ b/src/git_stage_batch/commands/file_scope/discard_to_batch.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
 from contextlib import ExitStack
 from dataclasses import dataclass
 import os
 
 from ...batch.source.annotation import annotate_with_batch_source
 from ...batch.ownership import insertion_references as _insertion_references
+from ...batch.ownership.model import BatchOwnership
+from ...batch.state.metadata_types import BatchMetadataDict
 from ...batch.state.lifecycle import create_batch
 from ...batch.ownership_update import acquire_batch_ownership_update_for_selection
 from ...batch.state.query import read_batch_metadata
@@ -17,7 +19,14 @@ from ...batch.state.batch_names import batch_exists
 from ...core.buffer import LineBuffer
 from ...core.diff_parser import acquire_unified_diff, build_line_changes_from_patch_lines
 from ...core.hashing import compute_stable_hunk_hash_from_lines
-from ...core.models import BinaryFileChange, FileModeChange, GitlinkChange, RenameChange, TextFileDeletionChange
+from ...core.models import (
+    BinaryFileChange,
+    FileModeChange,
+    GitlinkChange,
+    LineEntry,
+    RenameChange,
+    TextFileDeletionChange,
+)
 from ...data.file_modes import detect_file_mode_from_root
 from ...data.file_tracking import auto_add_untracked_files
 from ...data.live_diff import stream_live_git_diff
@@ -61,7 +70,7 @@ class _TextFileDiscardInput:
     file_path: str
     file_mode: str
     comparison_base: str
-    all_lines_to_batch: list
+    all_lines_to_batch: list[LineEntry]
     patches_to_discard: list[_PreparedPatchDiscard]
 
 
@@ -79,7 +88,7 @@ class _PreparedTextFileDiscardToBatch:
 
     file_path: str
     file_mode: str
-    ownership: object
+    ownership: BatchOwnership
     batch_source_commit: str | None
     patches_to_discard: list[_PreparedPatchDiscard]
 
@@ -95,7 +104,7 @@ class DiscardFilesToBatchResult:
 class _DiscardFilesToBatchSession:
     """Mutable publication state for one multi-file discard-to-batch action."""
 
-    def __init__(self, batch_name: str, metadata: dict) -> None:
+    def __init__(self, batch_name: str, metadata: BatchMetadataDict) -> None:
         self._batch_name = batch_name
         self._metadata = metadata
         self._ownership_stack = ExitStack()
@@ -168,7 +177,7 @@ def _prepare_text_file_discard_to_batch(
     batch_name: str,
     discard_input: _TextFileDiscardInput,
     *,
-    metadata: dict,
+    metadata: BatchMetadataDict,
     ownership_stack: ExitStack,
 ) -> _PreparedTextFileDiscardToBatch | None:
     """Prepare one normal text file discard without publishing batch state."""
@@ -299,7 +308,7 @@ def _run_reverse_apply_for_prepared_discards(
     *,
     check_only: bool = False,
 ) -> None:
-    def patch_chunks():
+    def patch_chunks() -> Iterator[bytes]:
         for prepared in prepared_discards:
             for patch in prepared.patches_to_discard:
                 yield from patch.patch_lines

--- a/src/git_stage_batch/commands/file_scope/include_file.py
+++ b/src/git_stage_batch/commands/file_scope/include_file.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from contextlib import contextmanager, nullcontext
+from contextlib import AbstractContextManager, contextmanager, nullcontext
 import sys
 from typing import Iterator
 
@@ -91,6 +91,9 @@ def include_file_changes(
     else:
         target_file = file
 
+    checkpoint: AbstractContextManager[None]
+    patch_context: AbstractContextManager[Iterator[UnifiedDiffItem]]
+    rollback_context: AbstractContextManager[None]
     if _prepared_changes is None:
         auto_add_untracked_files([target_file])
         checkpoint_paths = checkpoint_paths_for_live_file(target_file)

--- a/src/git_stage_batch/commands/file_scope/include_file_to_batch.py
+++ b/src/git_stage_batch/commands/file_scope/include_file_to_batch.py
@@ -14,7 +14,10 @@ from ...batch.state.validation import get_validated_baseline_commit
 from ...batch.text_file_storage import add_file_to_batch
 from ...batch.state.batch_names import batch_exists
 from ...core.diff_parser import acquire_unified_diff, build_line_changes_from_patch_lines
-from ...core.models import FileModeChange, RenameChange, TextFileDeletionChange
+from ...core.models import (
+    FileModeChange,
+    SingleHunkPatch,
+)
 from ...data.file_change_display import (
     render_binary_file_change,
     render_gitlink_change,
@@ -97,7 +100,7 @@ def include_file_to_batch(
             if isinstance(patch, FileModeChange):
                 mode_change = patch
                 continue
-            if isinstance(patch, (RenameChange, TextFileDeletionChange)):
+            if not isinstance(patch, SingleHunkPatch):
                 continue
             hunk_lines = build_line_changes_from_patch_lines(
                 patch.lines,

--- a/src/git_stage_batch/commands/selection/batch_line_selection.py
+++ b/src/git_stage_batch/commands/selection/batch_line_selection.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 
 from ...batch.selection import require_line_selection_in_view
 from ...core.line_selection import parse_line_selection
+from ...core.models import LineEntry, LineLevelChange
 
 
 @dataclass(frozen=True)
@@ -13,11 +14,11 @@ class BatchLineSelection:
     """Line IDs and matching changed lines selected for a batch action."""
 
     requested_ids: set[int]
-    selected_lines: list
+    selected_lines: list[LineEntry]
 
 
 def select_lines_for_batch_action(
-    line_changes,
+    line_changes: LineLevelChange,
     line_id_specification: str,
 ) -> BatchLineSelection:
     """Validate line IDs against a view and return matching changed lines."""

--- a/src/git_stage_batch/commands/selection/batch_line_updates.py
+++ b/src/git_stage_batch/commands/selection/batch_line_updates.py
@@ -21,6 +21,7 @@ from ...data.selected_change.snapshots import (
 )
 from ...exceptions import exit_with_error
 from ...i18n import _
+from ...core.models import LineEntry
 from ...utils.repository_buffers import (
     load_working_tree_file_as_buffer,
     read_git_object_buffer_or_empty,
@@ -31,9 +32,9 @@ def add_selected_lines_to_batch(
     *,
     batch_name: str,
     file_path: str,
-    selected_lines: Sequence,
+    selected_lines: Sequence[LineEntry],
     stale_source_action: str,
-    hunk_lines: Sequence | None = None,
+    hunk_lines: Sequence[LineEntry] | None = None,
     snapshot_untracked: bool = False,
     before_add: Callable[[], None] | None = None,
 ) -> None:
@@ -94,7 +95,7 @@ def add_selected_lines_to_batch(
                     batch_name=batch_name,
                     file_path=file_path,
                     file_metadata=file_metadata,
-                    selected_lines=selected_lines,
+                    selected_lines=list(selected_lines),
                     hunk_lines=hunk_lines,
                     replacement_line_runs=replacement_line_runs,
                     replacement_origin_line_runs=(

--- a/src/git_stage_batch/commands/selection/consumed_selection_recording.py
+++ b/src/git_stage_batch/commands/selection/consumed_selection_recording.py
@@ -11,6 +11,11 @@ from ...batch.ownership.translation import (
     detect_stale_batch_source_for_selection,
     translate_lines_to_batch_ownership,
 )
+from ...batch.state.metadata_types import (
+    BatchFileMetadataDict,
+    ReplacementMaskMetadata,
+    add_ownership_metadata,
+)
 from ...batch.source.advancement import advance_batch_source_for_file_with_provenance
 from ...batch.source.selected_line_refresh import (
     refresh_selected_lines_against_new_source,
@@ -29,9 +34,9 @@ def record_consumed_selection(
     file_path: str,
     *,
     source_buffer: LineBuffer,
-    selected_lines: list,
+    selected_lines: list[LineEntry],
     coordinate_lines: Sequence[LineEntry] | None = None,
-    replacement_mask: dict[str, list[str]] | None = None,
+    replacement_mask: ReplacementMaskMetadata | None = None,
 ) -> None:
     """Persist consumed selection ownership for masking across `again`."""
     existing_file_metadata = read_consumed_file_metadata(file_path)
@@ -41,10 +46,10 @@ def record_consumed_selection(
         batch_source_commit: str,
         ownership: BatchOwnership,
     ) -> None:
-        file_metadata = {
+        file_metadata: BatchFileMetadataDict = {
             "batch_source_commit": batch_source_commit,
-            **ownership.to_metadata_dict(),
         }
+        add_ownership_metadata(file_metadata, ownership.to_metadata_dict())
         existing_replacement_masks = (
             existing_file_metadata.get("replacement_masks", [])
             if existing_file_metadata else

--- a/src/git_stage_batch/commands/selection/discard_line_replacement.py
+++ b/src/git_stage_batch/commands/selection/discard_line_replacement.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator, Sequence
+from collections.abc import Iterator
 from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
 import os
@@ -19,6 +19,7 @@ from ...batch.merge.baseline_reference_translation import (
     translate_ownership_baseline_references,
 )
 from ...batch.state.query import read_batch_metadata
+from ...batch.state.metadata_types import BatchFileMetadataDict
 from ...batch.selection import require_line_selection_in_view
 from ...batch.source.advancement import (
     advance_source_lines_preserving_existing_presence,
@@ -30,7 +31,9 @@ from ...batch.text_file_storage import add_file_to_batch
 from ...batch.state.batch_names import batch_exists
 from ...core.buffer import LineBuffer, buffer_ends_with_lf
 from ...core.line_selection import parse_line_selection
+from ...core.models import LineEntry, LineLevelChange
 from ...core.replacement import ReplacementPayload, coerce_replacement_payload
+from ...batch.ownership.model import BatchOwnership
 from ...batch.source.cache import (
     load_session_batch_sources,
     save_session_batch_sources,
@@ -59,13 +62,13 @@ from . import replacement_selection
 class DiscardLineReplacementSelection:
     """Prepared replacement selection for discard-to-batch."""
 
-    line_changes: object
+    line_changes: LineLevelChange
     file_path: str
     working_file_path: Path
-    selected_lines: list
-    rewritten_line_changes: object
-    rewritten_selected_lines: list
-    rewritten_working_lines: Sequence[bytes]
+    selected_lines: list[LineEntry]
+    rewritten_line_changes: LineLevelChange
+    rewritten_selected_lines: list[LineEntry]
+    rewritten_working_lines: LineBuffer
 
 
 @contextmanager
@@ -77,6 +80,8 @@ def prepare_discard_line_replacement_selection(
 ) -> Iterator[DiscardLineReplacementSelection]:
     """Prepare rewritten line selection state for discard-to-batch."""
     line_changes = load_line_changes_from_state()
+    if line_changes is None:
+        exit_with_error(_("No selected hunk. Run 'start' first."))
     requested_ids = set(parse_line_selection(line_id_specification))
     require_line_selection_in_view(
         line_changes,
@@ -173,6 +178,7 @@ def add_discard_line_replacement_to_batch(
     file_metadata = metadata.get("files", {}).get(selection.file_path)
 
     with ExitStack() as ownership_stack:
+        batch_source_commit: str | None
         try:
             if file_metadata is None:
                 batch_source_commit = create_batch_source_commit(
@@ -239,10 +245,10 @@ def add_discard_line_replacement_to_batch(
 def _merge_replacement_with_batch(
     selection: DiscardLineReplacementSelection,
     *,
-    file_metadata: dict,
-    batch_baseline_commit: object,
+    file_metadata: BatchFileMetadataDict,
+    batch_baseline_commit: str | None,
     ownership_stack: ExitStack,
-):
+) -> tuple[BatchOwnership, str]:
     if not isinstance(batch_baseline_commit, str) or not batch_baseline_commit:
         raise ValueError("replacement update requires a batch baseline commit")
 
@@ -309,9 +315,9 @@ def _record_session_batch_source(file_path: str, batch_source_commit: str) -> No
 
 
 def _select_rewritten_replacement_lines(
-    original_selected_lines: list,
-    rewritten_line_changes,
-) -> list:
+    original_selected_lines: list[LineEntry],
+    rewritten_line_changes: LineLevelChange,
+) -> list[LineEntry]:
     """Find the rewritten changed span that overlaps the original selection."""
     original_old_lines = {
         line.old_line_number

--- a/src/git_stage_batch/commands/selection/discard_line_replacement_action.py
+++ b/src/git_stage_batch/commands/selection/discard_line_replacement_action.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from ...core.replacement import ReplacementPayload, coerce_replacement_payload
 from ...data.file_review.action_scope import finish_review_scoped_line_action
+from ...data.file_review.records import FileReviewState
 from ...data.selected_change.loading import require_selected_hunk
 from ...data.selected_change.paths import get_selected_change_file_path
 from ...data.selected_change.store import (
@@ -22,7 +23,7 @@ def discard_live_line_replacement_to_batch(
     replacement_text: str | ReplacementPayload,
     file: str | None = None,
     *,
-    review_state,
+    review_state: FileReviewState | None,
     no_edge_overlap: bool = False,
     quiet: bool = False,
     auto_advance: bool | None = None,

--- a/src/git_stage_batch/commands/selection/include_line_action.py
+++ b/src/git_stage_batch/commands/selection/include_line_action.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from contextlib import ExitStack
 import sys
 
@@ -9,6 +10,7 @@ from ...batch.selection import require_line_selection_in_view
 from ...core.buffer import LineBuffer, buffer_matches
 from ...core.line_selection import parse_line_selection
 from ...data.file_review.action_scope import finish_review_scoped_line_action
+from ...data.file_review.records import FileReviewState
 from ...data.selected_change.paths import get_selected_change_file_path
 from ...data.line_id_files import read_line_ids_file, write_line_ids_file
 from ...utils.repository_buffers import (
@@ -35,7 +37,9 @@ from . import replacement_selection
 from .selected_hunk_refresh import refresh_selected_hunk_after_line_action
 
 
-def _selection_uses_only_bare_cr_line_breaks(*line_sequences) -> bool:
+def _selection_uses_only_bare_cr_line_breaks(
+    *line_sequences: Sequence[bytes],
+) -> bool:
     """Return whether nonempty line breaks use bare CR and never LF."""
     saw_bare_carriage_return = False
     for lines in line_sequences:
@@ -52,7 +56,7 @@ def include_live_line_selection(
     line_id_specification: str,
     file: str | None = None,
     *,
-    review_state,
+    review_state: FileReviewState | None,
     auto_advance: bool | None = None,
     quiet: bool = False,
     operation: str | None = None,

--- a/src/git_stage_batch/commands/selection/include_line_selection.py
+++ b/src/git_stage_batch/commands/selection/include_line_selection.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from contextlib import ExitStack
 from dataclasses import dataclass, replace
 from enum import Enum
 import sys
 import uuid
 
+from ...batch.ownership.model import BatchOwnership
 from ...batch.ownership.hunk_translation import (
     translate_hunk_selection_to_batch_ownership,
 )
@@ -23,10 +25,11 @@ from ...core.buffer import LineBuffer, buffer_matches
 from ...batch.source.snapshots import create_batch_source_commit
 from ...batch.source.line_coordinates import translate_display_source_coordinates
 from ...batch.realized_file_content import build_realized_buffer_from_lines
+from ...core.models import LineEntry, LineLevelChange
 from ...data.selected_change.file_hunk_cache import cache_unstaged_file_as_single_hunk
 from ...data.file_modes import detect_file_mode
 from ...data.file_tracking import auto_add_untracked_files
-from ...data.line_state import load_line_changes_from_state
+from ...data.line_state import require_line_changes_from_state
 from ...utils.repository_buffers import (
     read_git_object_buffer_or_none,
     load_working_tree_file_as_buffer,
@@ -35,6 +38,7 @@ from ...data.selected_change.loading import require_selected_hunk
 from ...data.selected_change.paths import get_selected_change_file_path
 from ...data.selected_change.store import (
     SelectedChangeKind,
+    SelectedChangeStateSnapshot,
     read_selected_change_kind,
     snapshot_selected_change_state,
 )
@@ -86,9 +90,9 @@ class TransientIncludeResult:
 class IncludeLineSelectionContext:
     """Resolved selected-line view for a live include action."""
 
-    line_changes: object
+    line_changes: LineLevelChange
     preserve_selected_state: bool = False
-    saved_selected_state: object | None = None
+    saved_selected_state: SelectedChangeStateSnapshot | None = None
     reset_processed_include_ids: bool = False
 
 
@@ -134,14 +138,14 @@ def selected_file_view_is_fresh_for(target_file: str) -> bool:
 
 def load_include_line_selection_context(
     file: str | None,
-    selected_state_stack,
+    selected_state_stack: ExitStack,
 ) -> IncludeLineSelectionContext:
     """Resolve the selected line view for include --line."""
     if file is None:
         require_selected_hunk()
         return IncludeLineSelectionContext(
             line_changes=annotate_line_changes_with_working_tree_source(
-                load_line_changes_from_state()
+                require_line_changes_from_state()
             )
         )
 
@@ -161,7 +165,7 @@ def load_include_line_selection_context(
     saved_selected_state = None
 
     if reuse_selected_file_view:
-        line_changes = load_line_changes_from_state()
+        line_changes = require_line_changes_from_state()
     else:
         if file != "" and not selected_file_view_targets_file:
             preserve_selected_state = True
@@ -169,9 +173,10 @@ def load_include_line_selection_context(
                 snapshot_selected_change_state()
             )
 
-        line_changes = cache_unstaged_file_as_single_hunk(target_file)
-        if line_changes is None:
+        cached_line_changes = cache_unstaged_file_as_single_hunk(target_file)
+        if cached_line_changes is None:
             exit_with_error(_("No changes in file '{file}'.").format(file=target_file))
+        line_changes = cached_line_changes
 
     return IncludeLineSelectionContext(
         line_changes=annotate_line_changes_with_working_tree_source(line_changes),
@@ -187,12 +192,11 @@ def line_sequence_ends_with_lf(lines: Sequence[bytes]) -> bool:
     return line_count > 0 and lines[line_count - 1].endswith(b"\n")
 
 
-def annotate_line_changes_with_working_tree_source(line_changes):
+def annotate_line_changes_with_working_tree_source(
+    line_changes: LineLevelChange,
+) -> LineLevelChange:
     """Attach working-tree source line positions to line changes."""
-    if line_changes is None:
-        return None
-
-    new_lines = []
+    new_lines: list[LineEntry] = []
     for line, source_line in translate_display_source_coordinates(
         line_changes.lines,
         lambda line_number: line_number,
@@ -205,7 +209,7 @@ def annotate_line_changes_with_working_tree_source(line_changes):
 def build_transient_index_buffer(
     *,
     source_lines: Sequence[bytes],
-    ownership,
+    ownership: BatchOwnership,
     current_index_lines: Sequence[bytes],
     hunk_base_lines: Sequence[bytes],
 ) -> LineBuffer:
@@ -232,7 +236,7 @@ def build_transient_index_buffer(
 
 def try_build_index_content_via_transient_batch(
     *,
-    line_changes,
+    line_changes: LineLevelChange,
     selected_display_ids: set[int],
     current_index_lines: Sequence[bytes],
     hunk_base_lines: Sequence[bytes],
@@ -259,11 +263,12 @@ def try_build_index_content_via_transient_batch(
                     TransientIncludeFailureReason.WORKING_TREE_WOULD_CHANGE,
                     detail="working tree changed after new-file snapshot",
                 )
+        selected_source_lines: list[bytes] = []
+        for line in selected_lines:
+            assert line.source_line is not None
+            selected_source_lines.append(hunk_source_lines[line.source_line - 1])
         return TransientIncludeResult.success(
-            LineBuffer.from_chunks(
-                hunk_source_lines[line.source_line - 1]
-                for line in selected_lines
-            )
+            LineBuffer.from_chunks(selected_source_lines)
         )
 
     batch_name = f"include-line-{uuid.uuid4().hex}"
@@ -326,14 +331,14 @@ def try_build_index_content_via_transient_batch(
                     TransientIncludeFailureReason.MISSING_BATCH_METADATA
                 )
 
-            batch_source_commit = file_metadata.get("batch_source_commit")
-            if not batch_source_commit:
+            stored_batch_source_commit = file_metadata.get("batch_source_commit")
+            if not stored_batch_source_commit:
                 return TransientIncludeResult.failure(
                     TransientIncludeFailureReason.MISSING_BATCH_METADATA
                 )
 
             source_buffer = read_git_object_buffer_or_none(
-                f"{batch_source_commit}:{line_changes.path}"
+                f"{stored_batch_source_commit}:{line_changes.path}"
             )
             if source_buffer is None:
                 return TransientIncludeResult.failure(

--- a/src/git_stage_batch/commands/selection/next_change_display.py
+++ b/src/git_stage_batch/commands/selection/next_change_display.py
@@ -9,6 +9,7 @@ from ...core.models import (
     FileModeChange,
     GitlinkChange,
     RenameChange,
+    SingleHunkPatch,
     TextFileDeletionChange,
 )
 from ...data.file_review.state import clear_last_file_review_state
@@ -52,6 +53,7 @@ def _cache_candidate(candidate: EligibleLiveChange) -> None:
     elif isinstance(change, BinaryFileChange):
         cache_binary_file_change(change)
     else:
+        assert isinstance(candidate.raw_patch, SingleHunkPatch)
         cache_hunk_change(
             candidate.raw_patch.lines,
             candidate.stable_hash,

--- a/src/git_stage_batch/commands/selection/replacement_selection.py
+++ b/src/git_stage_batch/commands/selection/replacement_selection.py
@@ -10,6 +10,7 @@ from ...batch.ownership.replacement_line_runs import (
     derive_replacement_line_runs_from_lines,
 )
 from ...exceptions import exit_with_error
+from ...core.models import LineEntry, LineLevelChange
 from ...i18n import _
 
 
@@ -36,13 +37,13 @@ def require_contiguous_display_selection(selected_ids: set[int]) -> None:
 
 
 def build_leading_replacement_addition_selection_error(
-    line_changes,
+    line_changes: LineLevelChange,
     selected_ids: set[int],
 ) -> str | None:
     """Reject include selections that split an inserted replacement prefix."""
-    changed_run: list = []
+    changed_run: list[LineEntry] = []
 
-    def check_run(run: list) -> str | None:
+    def check_run(run: list[LineEntry]) -> str | None:
         if not run:
             return None
         deletion_ids = tuple(
@@ -104,7 +105,7 @@ def build_leading_replacement_addition_selection_error(
 
 
 def build_partial_structural_run_selection_error(
-    line_changes,
+    line_changes: LineLevelChange,
     selected_ids: set[int],
     *,
     hunk_base_lines: Sequence[bytes],
@@ -142,7 +143,10 @@ def build_partial_structural_run_selection_error(
     )
 
 
-def expand_replacement_selection_ids(line_changes, requested_ids: set[int]) -> set[int]:
+def expand_replacement_selection_ids(
+    line_changes: LineLevelChange,
+    requested_ids: set[int],
+) -> set[int]:
     """Expand a selection to the smallest adjacent mixed replacement run."""
     selected_indices = [
         index

--- a/src/git_stage_batch/commands/selection/selected_change_batch_discarding.py
+++ b/src/git_stage_batch/commands/selection/selected_change_batch_discarding.py
@@ -26,6 +26,7 @@ from ...core.models import (
     BinaryFileChange,
     GitlinkChange,
     RenameChange,
+    SingleHunkPatch,
     TextFileDeletionChange,
 )
 from ...data.file_modes import detect_file_mode
@@ -153,15 +154,11 @@ def _discard_text_hunk_to_batch(
                 stream_live_git_diff(context_lines=get_context_lines())
             ) as patches:
                 for patch in patches:
-                    if isinstance(patch, RenameChange):
-                        continue
-
-                    if isinstance(patch, TextFileDeletionChange):
-                        continue
-
                     if isinstance(patch, GitlinkChange):
                         exit_with_error(_("Discarding submodule pointer changes to a batch is not supported yet."))
                     if isinstance(patch, BinaryFileChange):
+                        continue
+                    if not isinstance(patch, SingleHunkPatch):
                         continue
 
                     if patch.new_path != file_path:

--- a/src/git_stage_batch/commands/selection/selected_change_batch_staging.py
+++ b/src/git_stage_batch/commands/selection/selected_change_batch_staging.py
@@ -25,6 +25,7 @@ from ...core.models import (
     BinaryFileChange,
     GitlinkChange,
     RenameChange,
+    SingleHunkPatch,
     TextFileDeletionChange,
 )
 from ...data.file_modes import detect_file_mode
@@ -103,6 +104,8 @@ def include_selected_change_to_batch(
                     return
                 continue
 
+            if not isinstance(patch, SingleHunkPatch):
+                continue
             patch_hash = compute_stable_hunk_hash_from_lines(patch.lines)
             if patch_hash in blocked_hashes:
                 continue

--- a/src/git_stage_batch/commands/selection/selected_change_discarding.py
+++ b/src/git_stage_batch/commands/selection/selected_change_discarding.py
@@ -6,6 +6,7 @@ import os
 import sys
 
 from ...batch.submodule_pointer import discard_submodule_pointer_from_batch
+from ...batch.state.metadata_types import BatchFileMetadataDict
 from ...core.buffer import LineBuffer
 from ...core.diff_parser import build_line_changes_from_patch_lines, patch_is_new_file
 from ...core.models import (
@@ -18,6 +19,7 @@ from ...core.models import (
 from ...data.hunk_tracking import fetch_next_change
 from ...data.progress import record_hunk_discarded
 from ...data.selected_change.loading import load_selected_change
+from ...data.selected_change.loading import SelectedChange
 from ...data.selected_change.paths import worktree_paths_for_selected_change
 from ...data.session import (
     path_is_intent_to_add,
@@ -73,7 +75,7 @@ def discard_selected_change(
 
 
 def _discard_loaded_selected_change(
-    item,
+    item: SelectedChange,
     *,
     quiet: bool,
     auto_advance: bool | None,
@@ -300,7 +302,7 @@ def discard_gitlink_change(gitlink_change: GitlinkChange) -> None:
     file_path = gitlink_change.path()
     if gitlink_change.is_new_file():
         snapshot_file_if_untracked(file_path, intent_to_add=True)
-    file_meta = {
+    file_meta: BatchFileMetadataDict = {
         "file_type": "gitlink",
         "change_type": gitlink_change.change_type,
         "old_oid": gitlink_change.old_oid,

--- a/src/git_stage_batch/commands/selection/selected_change_staging.py
+++ b/src/git_stage_batch/commands/selection/selected_change_staging.py
@@ -17,7 +17,7 @@ from ...core.models import (
 from ...data.hunk_tracking import fetch_next_change
 from ...data.index_entries import read_index_entry
 from ...data.progress import record_hunk_included
-from ...data.selected_change.loading import load_selected_change
+from ...data.selected_change.loading import SelectedChange, load_selected_change
 from ...data.selected_change.paths import worktree_paths_for_selected_change
 from ...data.undo.checkpoints import undo_checkpoint
 from ...exceptions import NoMoreHunks, exit_with_error
@@ -58,15 +58,16 @@ def include_selected_change(
         "include",
         worktree_paths=worktree_paths_for_selected_change(item),
     ):
-        return _include_loaded_selected_change(
+        _include_loaded_selected_change(
             item,
             quiet=quiet,
             auto_advance=auto_advance,
         )
+        return None
 
 
 def _include_loaded_selected_change(
-    item,
+    item: SelectedChange,
     *,
     quiet: bool,
     auto_advance: bool | None,
@@ -214,7 +215,9 @@ def stage_file_mode_change(item: FileModeChange) -> None:
         exit_with_error(_("Failed to stage executable mode change."))
 
 
-def stage_gitlink_change(gitlink_change: GitlinkChange) -> subprocess.CompletedProcess:
+def stage_gitlink_change(
+    gitlink_change: GitlinkChange,
+) -> subprocess.CompletedProcess[str]:
     """Stage a submodule pointer change in the index."""
     file_path = gitlink_change.path()
     if gitlink_change.is_deleted_file():

--- a/src/git_stage_batch/commands/show_from.py
+++ b/src/git_stage_batch/commands/show_from.py
@@ -96,6 +96,7 @@ def command_show_from_batch(
             exit_with_error(_("`show --from --as` requires `--line`."))
         if len(files) != 1:
             exit_with_error(_("`show --from --as` requires exactly one file."))
+        assert selected_ids is not None
         file_path = list(files.keys())[0]
         _replacement_previews.print_batch_source_replacement_preview(
             batch_name=batch_name,

--- a/src/git_stage_batch/commands/sift.py
+++ b/src/git_stage_batch/commands/sift.py
@@ -26,6 +26,7 @@ import sys
 
 from ..exceptions import MergeError
 from ..batch.state.validation import read_validated_batch_metadata
+from ..batch.state.metadata_types import BatchFileMetadataDict, BatchMetadataDict
 from ..batch.state.reference_names import (
     format_batch_content_ref_name,
     format_batch_state_ref_name,
@@ -60,7 +61,7 @@ from ..utils.git_object_io import list_git_tree_blobs, resolve_git_objects
 
 @dataclass(frozen=True, slots=True)
 class _SourceBatchSnapshot:
-    metadata: dict
+    metadata: BatchMetadataDict
     ref_identities: tuple[tuple[str, str | None], ...]
 
 
@@ -68,7 +69,7 @@ class _SourceBatchSnapshot:
 class _TextSiftInput:
     ordinal: int
     file_path: str
-    file_meta: dict
+    file_meta: BatchFileMetadataDict
     worktree_identity: WorktreeIdentity
     worktree_artifact_path: Path
     scratch_directory: Path
@@ -241,7 +242,7 @@ def _print_sift_summary(
 
 def _build_sifted_files(
     *,
-    source_metadata: dict,
+    source_metadata: BatchMetadataDict,
     repository_root: Path,
     workspace: FileJobWorkspace,
 ) -> tuple[
@@ -280,7 +281,7 @@ def _build_sifted_files(
 
 def _capture_sift_inputs(
     *,
-    source_files: dict[str, dict],
+    source_files: dict[str, BatchFileMetadataDict],
     repository_root: Path,
     workspace: FileJobWorkspace,
 ) -> _SiftInputCapture:
@@ -331,7 +332,7 @@ def _capture_sift_inputs(
 
 def _build_sift_text_jobs(
     *,
-    source_metadata: dict,
+    source_metadata: BatchMetadataDict,
     capture: _SiftInputCapture,
     workspace: FileJobWorkspace,
 ) -> list[OrderedFileJob[_sift_jobs.SiftTextFileJob]]:
@@ -355,17 +356,18 @@ def _build_sift_text_jobs(
         source_object_id = source_blob_by_input.get(
             (text_input.ordinal, text_input.file_path)
         )
+        input_metadata: _sift_jobs.SiftTextJobInput = {
+            "baseline_object_id": baseline_object_id,
+            "batch_source_object_id": source_object_id,
+            "file_meta": text_input.file_meta,
+            "working_tree_artifact_path": str(
+                text_input.worktree_artifact_path
+            ),
+        }
         input_artifact = workspace.write_pickle(
             text_input.ordinal,
             "sift-input.pickle",
-            {
-                "baseline_object_id": baseline_object_id,
-                "batch_source_object_id": source_object_id,
-                "file_meta": text_input.file_meta,
-                "working_tree_artifact_path": str(
-                    text_input.worktree_artifact_path
-                ),
-            },
+            input_metadata,
         )
         target_output_path = workspace.output_path(
             text_input.ordinal,
@@ -417,8 +419,8 @@ def _run_sift_text_jobs(
         result_label="sift text",
         run_jobs=run_file_jobs,
     )
-    job_by_ordinal = {}
-    result_by_ordinal = {}
+    job_by_ordinal: dict[int, _sift_jobs.SiftTextFileJob] = {}
+    result_by_ordinal: dict[int, _sift_jobs.SiftTextFileJobResult] = {}
     for ordered_job, result in paired_results:
         job_by_ordinal[ordered_job.ordinal] = ordered_job.payload
         result_by_ordinal[result.ordinal] = result
@@ -427,7 +429,7 @@ def _run_sift_text_jobs(
 
 def _reduce_sift_results(
     *,
-    source_files: dict[str, dict],
+    source_files: dict[str, BatchFileMetadataDict],
     capture: _SiftInputCapture,
     execution: _SiftTextExecution,
     repository_root: Path,
@@ -437,6 +439,7 @@ def _reduce_sift_results(
     retained_files: list[_sift_persistence.RetainedSiftedFile] = []
     try:
         for ordinal, (file_path, file_meta) in enumerate(source_files.items()):
+            sifted_result: _sift_results.SiftedFileResult | None
             if file_meta.get("file_type") == "mode":
                 sifted_result = _sift_results.compute_sifted_mode_file(
                     file_path,
@@ -642,7 +645,7 @@ def _handle_empty_source_batch(
     source_batch: str,
     dest_batch: str,
     *,
-    source_metadata: dict,
+    source_metadata: BatchMetadataDict,
 ) -> None:
     """Handle the case where the source batch is empty."""
     if source_batch == dest_batch:

--- a/src/git_stage_batch/data/batch_file_scope.py
+++ b/src/git_stage_batch/data/batch_file_scope.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Optional
 
+from ..batch.state.metadata_types import BatchFileMetadataDict
 from ..exceptions import CommandError
 from ..i18n import _
 from ..utils.file_patterns import resolve_gitignore_style_patterns
@@ -21,10 +22,10 @@ from .selected_change.file_changes import load_selected_mode_change, read_select
 
 def resolve_batch_file_scope(
     batch_name: str,
-    all_files: dict[str, dict],
+    all_files: dict[str, BatchFileMetadataDict],
     file: Optional[str] = None,
     patterns: Optional[list[str]] = None,
-) -> dict[str, dict]:
+) -> dict[str, BatchFileMetadataDict]:
     """Resolve which files from a batch to operate on.
 
     Args:
@@ -73,7 +74,7 @@ def resolve_batch_file_scope(
 
 def resolve_current_batch_atomic_file_scope(
     batch_name: str,
-    all_files: dict[str, dict],
+    all_files: dict[str, BatchFileMetadataDict],
     file: Optional[str] = None,
     patterns: Optional[list[str]] = None,
     line_ids: Optional[str] = None,
@@ -117,7 +118,7 @@ def resolve_current_batch_atomic_file_scope(
 
 def _get_batch_file_for_line_operation(
     batch_name: str,
-    all_files: dict[str, dict],
+    all_files: dict[str, BatchFileMetadataDict],
     file: str | None,
 ) -> str:
     """Determine which file in batch to operate on."""

--- a/src/git_stage_batch/data/batch_refs.py
+++ b/src/git_stage_batch/data/batch_refs.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import json
 import shutil
-from typing import Any
+from typing import TypeAlias, TypedDict, cast
 
+from ..batch.state.metadata_types import BatchMetadataDict
 from ..batch.state.reference_names import BATCH_CONTENT_REF_PREFIX, LEGACY_BATCH_REF_PREFIX
 from ..batch.state.query import read_batch_metadata
 from ..batch.state.compatibility_metadata import write_file_backed_batch_metadata
@@ -20,6 +21,17 @@ from ..utils.file_io import read_text_file_contents, write_text_file_contents
 from ..utils.git_command import run_git_command
 from ..utils.git_refs import update_git_refs
 from ..utils.paths import get_batch_directory_path, get_batch_refs_snapshot_file_path
+
+
+class BatchRefSnapshotEntry(TypedDict):
+    """One batch's refs plus validated application metadata."""
+
+    commit_sha: str
+    state_commit_sha: str | None
+    metadata: BatchMetadataDict
+
+
+BatchRefSnapshot: TypeAlias = dict[str, BatchRefSnapshotEntry]
 
 
 def _list_batch_content_refs() -> dict[str, str]:
@@ -56,7 +68,7 @@ def _get_batch_state_ref_commit(batch_name: str) -> str | None:
     return result.stdout.strip()
 
 
-def snapshot_batch_refs() -> dict[str, dict[str, Any]]:
+def snapshot_batch_refs() -> BatchRefSnapshot:
     """Save selected state of all batch refs to snapshot file for abort support.
 
     Stores a single JSON object mapping batch names to their state:
@@ -64,18 +76,40 @@ def snapshot_batch_refs() -> dict[str, dict[str, Any]]:
 
     This includes complete metadata so dropped batches can be fully restored.
     """
-    snapshot_data = {}
+    snapshot_data: BatchRefSnapshot = {}
     for batch_name, commit_sha in _list_batch_content_refs().items():
         full_metadata = read_batch_metadata(batch_name)
 
         snapshot_data[batch_name] = {
             "commit_sha": commit_sha,
             "state_commit_sha": _get_batch_state_ref_commit(batch_name),
-            "metadata": full_metadata
+            "metadata": full_metadata,
         }
 
     write_text_file_contents(get_batch_refs_snapshot_file_path(), json.dumps(snapshot_data, indent=2))
     return snapshot_data
+
+
+def _decode_batch_ref_snapshot(payload: str) -> BatchRefSnapshot | None:
+    """Return a structurally valid snapshot mapping, or ignore stale garbage."""
+    value: object = json.loads(payload)
+    if not isinstance(value, dict):
+        return None
+    for batch_name, entry in value.items():
+        if not isinstance(batch_name, str) or not isinstance(entry, dict):
+            return None
+        commit_sha = entry.get("commit_sha")
+        state_commit_sha = entry.get("state_commit_sha")
+        metadata = entry.get("metadata")
+        if not isinstance(commit_sha, str):
+            return None
+        if state_commit_sha is not None and not isinstance(state_commit_sha, str):
+            return None
+        if not isinstance(metadata, dict) or not all(
+            isinstance(key, str) for key in metadata
+        ):
+            return None
+    return cast(BatchRefSnapshot, value)
 
 
 def restore_batch_refs() -> None:
@@ -92,8 +126,12 @@ def restore_batch_refs() -> None:
 
     # Load snapshot
     try:
-        snapshot_data: dict[str, Any] = json.loads(read_text_file_contents(snapshot_path))
-    except (json.JSONDecodeError, KeyError):
+        snapshot_data = _decode_batch_ref_snapshot(
+            read_text_file_contents(snapshot_path)
+        )
+    except json.JSONDecodeError:
+        return
+    if snapshot_data is None:
         return
 
     # Get selected batch refs
@@ -112,7 +150,7 @@ def restore_batch_refs() -> None:
     for batch_name, batch_state in snapshot_data.items():
         commit_sha = batch_state["commit_sha"]
         state_commit_sha = batch_state.get("state_commit_sha")
-        full_metadata = batch_state.get("metadata", {})
+        full_metadata = batch_state["metadata"]
 
         if state_commit_sha:
             update_git_refs(

--- a/src/git_stage_batch/data/batch_selected_changes.py
+++ b/src/git_stage_batch/data/batch_selected_changes.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping
 from hashlib import sha256
 
 from ..batch.state.query import get_batch_commit_sha, read_batch_metadata
+from ..batch.state.metadata_types import BatchFileMetadataDict
 from ..core.models import BinaryFileChange
 from ..exceptions import CommandError
 from ..i18n import _
@@ -30,7 +31,7 @@ from .selected_change.clear_reasons import (
 def compute_batch_binary_fingerprint(
     batch_name: str,
     file_path: str,
-    file_meta: Mapping[str, object],
+    file_meta: BatchFileMetadataDict,
 ) -> str:
     """Return a stable identity for the current binary content stored in a batch."""
     batch_blob = None
@@ -80,7 +81,7 @@ def selected_batch_binary_batch_name() -> str | None:
 
 def selected_batch_binary_file_for_batch(
     batch_name: str,
-    all_files: Mapping[str, dict],
+    all_files: Mapping[str, BatchFileMetadataDict],
 ) -> str | None:
     """Return the selected batch-binary file if it still exists in batch metadata."""
     if not selected_batch_binary_matches_batch(batch_name):
@@ -143,7 +144,7 @@ def load_current_selected_batch_binary_file(
 
 def require_current_selected_batch_binary_file_for_batch(
     batch_name: str,
-    all_files: Mapping[str, dict],
+    all_files: Mapping[str, BatchFileMetadataDict],
 ) -> str | None:
     """Return selected batch-binary file for this batch, or refuse if it went stale."""
     if not selected_batch_binary_matches_batch(batch_name):
@@ -174,7 +175,7 @@ def require_current_selected_batch_binary_file_for_batch(
 
 def compute_batch_gitlink_fingerprint(
     file_path: str,
-    file_meta: Mapping[str, object],
+    file_meta: BatchFileMetadataDict,
 ) -> str:
     """Return a stable identity for the current stored submodule pointer."""
     payload = {
@@ -201,7 +202,7 @@ def selected_batch_gitlink_matches_batch(batch_name: str) -> bool:
 
 def selected_batch_gitlink_file_for_batch(
     batch_name: str,
-    all_files: Mapping[str, dict],
+    all_files: Mapping[str, BatchFileMetadataDict],
 ) -> str | None:
     """Return the selected batch submodule pointer if it is still current."""
     if not selected_batch_gitlink_matches_batch(batch_name):
@@ -239,7 +240,7 @@ def selected_batch_gitlink_file_for_batch(
 
 def require_current_selected_batch_gitlink_file_for_batch(
     batch_name: str,
-    all_files: Mapping[str, dict],
+    all_files: Mapping[str, BatchFileMetadataDict],
 ) -> str | None:
     """Return selected batch submodule pointer, or refuse if it went stale."""
     if not selected_batch_gitlink_matches_batch(batch_name):

--- a/src/git_stage_batch/data/change_freshness.py
+++ b/src/git_stage_batch/data/change_freshness.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from ..batch.state.query import list_batch_names, read_batch_metadata_for_batches
+from ..batch.state.metadata_types import BatchMetadataDict
 from ..core.models import (
     BinaryFileChange,
     FileModeChange,
@@ -101,7 +102,7 @@ def text_deletion_change_is_stale(
 def text_deletion_change_is_batched(
     deletion_change: TextFileDeletionChange,
     *,
-    batch_metadata_by_name: dict[str, dict] | None = None,
+    batch_metadata_by_name: dict[str, BatchMetadataDict] | None = None,
 ) -> bool:
     """Return whether a whole-text-file deletion is already represented in a batch."""
     return empty_text_lifecycle_change_is_batched(
@@ -113,7 +114,7 @@ def text_deletion_change_is_batched(
 def empty_text_lifecycle_change_is_batched(
     file_path: str,
     *,
-    batch_metadata_by_name: dict[str, dict] | None = None,
+    batch_metadata_by_name: dict[str, BatchMetadataDict] | None = None,
 ) -> bool:
     """Return whether the current empty text lifecycle diff is already batched."""
     change_type = detect_empty_text_lifecycle_change(file_path)

--- a/src/git_stage_batch/data/consumed_replacement_masks.py
+++ b/src/git_stage_batch/data/consumed_replacement_masks.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from ..core.models import LineEntry, LineLevelChange
+from ..batch.state.metadata_types import BatchFileMetadataDict
 from .consumed_selections import read_consumed_file_metadata
 
 
@@ -20,7 +21,7 @@ def filter_consumed_replacement_masks(
 def filter_consumed_replacement_masks_with_metadata(
     line_changes: LineLevelChange,
     *,
-    file_metadata: dict | None,
+    file_metadata: BatchFileMetadataDict | None,
 ) -> LineLevelChange | None:
     """Hide replacement runs using caller-supplied consumed metadata."""
     replacement_masks = (

--- a/src/git_stage_batch/data/consumed_selections.py
+++ b/src/git_stage_batch/data/consumed_selections.py
@@ -3,15 +3,16 @@
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import cast
 
+from ..batch.state.metadata_types import BatchFileMetadataDict, BatchMetadataDict
 from ..exceptions import CommandError
 from ..i18n import _
 from ..utils.file_io import read_text_file_contents, write_text_file_contents
 from ..utils.paths import get_session_consumed_selections_file_path
 
 
-def load_consumed_selections_metadata() -> dict[str, Any]:
+def load_consumed_selections_metadata() -> BatchMetadataDict:
     """Load hidden consumed-selection metadata."""
     path = get_session_consumed_selections_file_path()
     if not path.exists():
@@ -43,10 +44,12 @@ def load_consumed_selections_metadata() -> dict[str, Any]:
                     "{path}. Abort the session to recover safely."
                 ).format(file=file_path, path=path)
             )
-    return {"files": files}
+    return {"files": cast(dict[str, BatchFileMetadataDict], files)}
 
 
-def read_consumed_file_metadata(file_path: str) -> dict[str, Any] | None:
+def read_consumed_file_metadata(
+    file_path: str,
+) -> BatchFileMetadataDict | None:
     """Return hidden consumed-selection metadata for one file."""
     metadata = load_consumed_selections_metadata()
     file_metadata = metadata.get("files", {}).get(file_path)
@@ -55,7 +58,7 @@ def read_consumed_file_metadata(file_path: str) -> dict[str, Any] | None:
 
 def write_consumed_file_metadata(
     file_path: str,
-    file_metadata: dict[str, Any],
+    file_metadata: BatchFileMetadataDict,
 ) -> None:
     """Persist hidden consumed-selection metadata for one file."""
     metadata = load_consumed_selections_metadata()

--- a/src/git_stage_batch/data/file_hunk_display.py
+++ b/src/git_stage_batch/data/file_hunk_display.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
+from collections.abc import Generator, Iterable
 import os
 import subprocess
 import tempfile
 from typing import Optional
 
 from ..core.diff_parser import (
+    UnifiedDiffItem,
     acquire_unified_diff,
     build_line_changes_from_patch_lines,
 )
@@ -167,17 +168,17 @@ def _stream_no_index_diff_lines(
 
 def build_combined_file_line_changes(
     file_path: str,
-    patches,
-) -> Optional[LineLevelChange]:
+    patches: Iterable[UnifiedDiffItem],
+) -> LineLevelChange | None:
     """Combine file diff hunks into one file-scoped LineLevelChange."""
-    all_line_entries = []
+    all_line_entries: list[LineEntry] = []
     line_id_counter = 1
-    min_old_start = None
-    max_old_end = None
-    min_new_start = None
-    max_new_end = None
-    previous_old_end = None
-    previous_new_end = None
+    min_old_start: int | None = None
+    max_old_end: int | None = None
+    min_new_start: int | None = None
+    max_new_end: int | None = None
+    previous_old_end: int | None = None
+    previous_new_end: int | None = None
 
     for single_hunk in patches:
         if isinstance(
@@ -251,6 +252,10 @@ def build_combined_file_line_changes(
     if not all_line_entries:
         return None
 
+    assert min_old_start is not None
+    assert max_old_end is not None
+    assert min_new_start is not None
+    assert max_new_end is not None
     combined_header = HunkHeader(
         old_start=min_old_start,
         old_len=max_old_end - min_old_start,

--- a/src/git_stage_batch/data/file_review/batch_selection.py
+++ b/src/git_stage_batch/data/file_review/batch_selection.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 from ...batch.file_display import render_batch_file_display
 from ...batch.selection import require_single_file_context_for_line_selection_ranges
+from ...batch.state.metadata_types import BatchFileMetadataDict
 from ...batch.submodule_pointer import (
     is_batch_submodule_pointer,
     refuse_batch_submodule_pointer_lines,
@@ -131,7 +132,7 @@ def translate_batch_file_gutter_ids_to_selection_ids(
 
 def translate_reset_batch_file_gutter_ids_to_selection_ranges(
     batch_name: str,
-    all_files: dict[str, dict],
+    all_files: dict[str, BatchFileMetadataDict],
     file: str | None,
     patterns: list[str] | None,
     line_id_specification: str,

--- a/src/git_stage_batch/data/file_review/fingerprints.py
+++ b/src/git_stage_batch/data/file_review/fingerprints.py
@@ -5,10 +5,8 @@ from __future__ import annotations
 import json
 from hashlib import sha256
 from pathlib import Path
-from typing import Any
-
 from ...core.buffer import LineBuffer
-from ...core.models import ReviewActionGroup
+from ...core.models import LineLevelChange, ReviewActionGroup
 from ...utils.paths import (
     get_index_snapshot_file_path,
     get_working_tree_snapshot_file_path,
@@ -20,7 +18,7 @@ from ..line_state import (
 from ..selected_change.store import SelectedChangeKind
 
 
-def _json_hash(payload: Any) -> str:
+def _json_hash(payload: object) -> str:
     data = json.dumps(
         payload,
         sort_keys=True,
@@ -50,12 +48,12 @@ def fingerprint_selected_file_view(
     gutter_to_selection_id: dict[int, int] | None = None,
     actionable_selection_groups: tuple[tuple[int, ...], ...] | None = None,
     review_action_groups: tuple[ReviewActionGroup, ...] | None = None,
-    line_changes=None,
+    line_changes: LineLevelChange | None = None,
 ) -> str:
     """Fingerprint the selected file view and its current line ID space."""
     if line_changes is None:
         line_changes = load_line_changes_from_state()
-    snapshots = {}
+    snapshots: dict[str, str | None] = {}
     for name, path in (
         ("index", get_index_snapshot_file_path()),
         ("working_tree", get_working_tree_snapshot_file_path()),
@@ -89,7 +87,7 @@ def fingerprint_selected_file_view(
 
 def compute_current_file_review_diff_fingerprint(
     file_path: str,
-    line_changes=None,
+    line_changes: LineLevelChange | None = None,
 ) -> str:
     """Fingerprint the cached selected file diff for freshness checks."""
     if line_changes is None:

--- a/src/git_stage_batch/data/file_review/selection_validation.py
+++ b/src/git_stage_batch/data/file_review/selection_validation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from dataclasses import dataclass
+from typing import Protocol
 
 from ...core.line_selection import LineRanges, LineSelection, coerce_line_ranges
 from ...exceptions import CommandError
@@ -19,6 +20,18 @@ def _format_line_ranges(selection: LineRanges) -> str:
 class _ReviewValidationGroup:
     display_ids: LineRanges
     is_splittable: bool
+
+
+class ReviewSelectionForValidation(Protocol):
+    """Selection fields needed by review-scoped validation."""
+
+    @property
+    def display_ids(self) -> tuple[int, ...]:
+        """Return the IDs displayed for this selection."""
+
+    @property
+    def is_splittable(self) -> bool:
+        """Return whether partial selection is valid."""
 
 
 def shown_review_selections_for_action(
@@ -42,7 +55,7 @@ def shown_review_selections_for_action(
 
 def validate_review_scoped_line_selection(
     requested_ids: LineSelection | Iterable[int],
-    valid_selections: Iterable[_records.FileReviewSelectionState],
+    valid_selections: Iterable[ReviewSelectionForValidation],
 ) -> None:
     """Validate a union of complete actionable review selections."""
     requested_ranges = coerce_line_ranges(requested_ids)

--- a/src/git_stage_batch/data/file_tracking.py
+++ b/src/git_stage_batch/data/file_tracking.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import subprocess
 import sys
 from collections.abc import Iterable
 
@@ -84,7 +85,9 @@ def auto_add_untracked_files(
     recorded_paths = read_file_paths_file(auto_added_path)
     recorded_set = set(recorded_paths)
 
-    def apply_transition(candidate_paths: list[str]):
+    def apply_transition(
+        candidate_paths: list[str],
+    ) -> tuple[subprocess.CompletedProcess[str], list[str]]:
         new_paths = [path for path in candidate_paths if path not in recorded_set]
         manifest_existed = auto_added_path.exists()
         if new_paths:

--- a/src/git_stage_batch/data/hunk_tracking.py
+++ b/src/git_stage_batch/data/hunk_tracking.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 from typing import Union
 
 from ..batch.state.query import list_batch_names, read_batch_metadata_for_batches
+from ..batch.state.metadata_types import BatchMetadataDict
 from ..core.models import (
     BinaryFileChange,
     FileModeChange,
     GitlinkChange,
     LineLevelChange,
     RenameChange,
+    SingleHunkPatch,
     TextFileDeletionChange,
 )
 from ..exceptions import NoMoreHunks
@@ -28,18 +30,23 @@ class _BatchMetadataSnapshot:
     """Lazy batch metadata snapshot for one hunk navigation scan."""
 
     def __init__(self) -> None:
-        self._metadata_by_name: dict[str, dict] | None = None
-        self._metadata_by_path: dict[str, dict[str, dict]] | None = None
+        self._metadata_by_name: dict[str, BatchMetadataDict] | None = None
+        self._metadata_by_path: (
+            dict[str, dict[str, BatchMetadataDict]] | None
+        ) = None
 
-    def metadata_by_name(self) -> dict[str, dict]:
+    def metadata_by_name(self) -> dict[str, BatchMetadataDict]:
         if self._metadata_by_name is None:
             self._metadata_by_name = read_batch_metadata_for_batches(list_batch_names())
         return self._metadata_by_name
 
-    def metadata_for_path(self, file_path: str) -> dict[str, dict]:
+    def metadata_for_path(
+        self,
+        file_path: str,
+    ) -> dict[str, BatchMetadataDict]:
         """Return only batches with metadata for one canonical path."""
         if self._metadata_by_path is None:
-            metadata_by_path: dict[str, dict[str, dict]] = {}
+            metadata_by_path: dict[str, dict[str, BatchMetadataDict]] = {}
             for batch_name, metadata in self.metadata_by_name().items():
                 for path in metadata.get("files", {}):
                     metadata_by_path.setdefault(path, {})[batch_name] = metadata
@@ -78,6 +85,7 @@ def fetch_next_change() -> Union[
             elif isinstance(item, BinaryFileChange):
                 _selected_file_changes.cache_binary_file_change(item)
             else:
+                assert isinstance(candidate.raw_patch, SingleHunkPatch)
                 _selected_store.cache_hunk_change(
                     candidate.raw_patch.lines,
                     candidate.stable_hash,

--- a/src/git_stage_batch/data/live_change_candidates.py
+++ b/src/git_stage_batch/data/live_change_candidates.py
@@ -4,11 +4,17 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
+from types import TracebackType
 from typing import Iterator
 
 from ..batch.state.query import list_batch_names, read_batch_metadata_for_batches
+from ..batch.state.metadata_types import BatchMetadataDict
 from ..batch.source.annotation import annotate_with_batch_source
-from ..core.diff_parser import acquire_unified_diff, build_line_changes_from_patch_lines
+from ..core.diff_parser import (
+    UnifiedDiffItem,
+    acquire_unified_diff,
+    build_line_changes_from_patch_lines,
+)
 from ..core.buffer import LineBuffer
 from ..core.hashing import (
     compute_binary_file_hash,
@@ -67,7 +73,7 @@ class EligibleLiveChange:
 
     change: LiveChange
     stable_hash: str
-    raw_patch: object
+    raw_patch: UnifiedDiffItem
 
     def close(self) -> None:
         """Close raw patch storage owned by this prepared candidate."""
@@ -80,7 +86,12 @@ class EligibleLiveChange:
     def __enter__(self) -> EligibleLiveChange:
         return self
 
-    def __exit__(self, exc_type, exc, traceback) -> None:
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
         self.close()
 
 
@@ -90,14 +101,16 @@ class LiveChangeScanContext:
     def __init__(
         self,
         *,
-        batch_metadata_by_name: dict[str, dict] | None = None,
+        batch_metadata_by_name: dict[str, BatchMetadataDict] | None = None,
     ) -> None:
         self.blocked_paths = read_file_paths_file(get_blocked_files_file_path())
         self.blocked_hashes = read_text_file_line_set(get_block_list_file_path())
         self._metadata_by_name = batch_metadata_by_name
-        self._metadata_by_path: dict[str, dict[str, dict]] | None = None
+        self._metadata_by_path: (
+            dict[str, dict[str, BatchMetadataDict]] | None
+        ) = None
 
-    def metadata_by_name(self) -> dict[str, dict]:
+    def metadata_by_name(self) -> dict[str, BatchMetadataDict]:
         """Return the complete batch metadata snapshot for this scan."""
         if self._metadata_by_name is None:
             self._metadata_by_name = read_batch_metadata_for_batches(
@@ -105,7 +118,10 @@ class LiveChangeScanContext:
             )
         return self._metadata_by_name
 
-    def metadata_for_path(self, file_path: str) -> dict[str, dict]:
+    def metadata_for_path(
+        self,
+        file_path: str,
+    ) -> dict[str, BatchMetadataDict]:
         if self._metadata_by_path is None:
             self._metadata_by_path = {}
             for batch_name, metadata in self.metadata_by_name().items():
@@ -114,17 +130,17 @@ class LiveChangeScanContext:
         return self._metadata_by_path.get(file_path, {})
 
 
-def live_change_paths(item: object) -> tuple[str, ...]:
+def live_change_paths(item: UnifiedDiffItem) -> tuple[str, ...]:
     """Return every repository path covered by one parsed live change."""
     if isinstance(item, RenameChange):
         return item.old_path, item.new_path
     if isinstance(item, SingleHunkPatch) and item.old_path != item.new_path:
         return item.old_path, item.new_path
-    return (item.path(),)  # type: ignore[attr-defined]
+    return (item.path(),)
 
 
 def blocked_live_change_reason(
-    item: object,
+    item: UnifiedDiffItem,
     stable_hash: str,
     context: LiveChangeScanContext,
 ) -> SkipReason | None:
@@ -189,7 +205,7 @@ def prepare_atomic_live_change(
 
 
 def prepare_live_change(
-    item: object,
+    item: UnifiedDiffItem,
     context: LiveChangeScanContext,
 ) -> tuple[EligibleLiveChange | None, SkipReason | None]:
     """Apply the common blocked/batched policy to one parsed diff item."""

--- a/src/git_stage_batch/data/live_change_jobs.py
+++ b/src/git_stage_batch/data/live_change_jobs.py
@@ -7,7 +7,7 @@ from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
 import json
 from pathlib import Path
-from typing import Any, TextIO
+from typing import TextIO, TypedDict, cast
 
 from ..batch.attribution import (
     AttributionMetrics,
@@ -19,6 +19,7 @@ from ..batch.source.annotation import (
 )
 from ..batch.source.cache import load_session_batch_sources
 from ..batch.state.query import list_batch_names, read_batch_metadata_for_batches
+from ..batch.state.metadata_types import BatchFileMetadataDict, BatchMetadataDict
 from ..batch.state.reference_names import format_batch_state_ref_name
 from ..core.buffer import LineBuffer
 from ..core.diff_parser import (
@@ -127,6 +128,29 @@ class LiveChangeCountPlan:
     jobs: tuple[OrderedFileJob[LiveTextFileJob], ...]
     atomic_count: int
     repository_root: Path
+
+
+class _LiveInputManifest(TypedDict):
+    """Artifact manifest consumed by one live text-file worker."""
+
+    file_path: str
+    baseline_path: str
+    head_commit: str | None
+    batch_source_commit: str | None
+    batch_metadata_by_name: dict[str, BatchMetadataDict]
+    consumed_file_metadata: BatchFileMetadataDict | None
+    batch_state_commit_by_name: dict[str, str]
+    scratch_directory: str
+
+
+class _LiveHunkRecord(TypedDict):
+    """One patch artifact row in a live text-file job."""
+
+    ordinal: int
+    old_path: str
+    new_path: str
+    stable_hash: str
+    patch_artifact_path: str
 
 
 def capture_worktree_stat_identity(
@@ -415,8 +439,8 @@ class _LiveTextFileGroup:
         repository_root: Path,
         head_commit: str | None,
         batch_source_commit: str | None,
-        batch_metadata_by_name: dict[str, dict],
-        consumed_file_metadata: dict | None,
+        batch_metadata_by_name: dict[str, BatchMetadataDict],
+        consumed_file_metadata: BatchFileMetadataDict | None,
         batch_state_commit_by_name: dict[str, str],
     ) -> None:
         self.workspace = workspace
@@ -471,7 +495,7 @@ class _LiveTextFileGroup:
             item.lines,
         )
         self._patch_artifact_bytes += patch_path.stat().st_size
-        record = {
+        record: _LiveHunkRecord = {
             "ordinal": ordinal,
             "old_path": item.old_path,
             "new_path": item.new_path,
@@ -555,9 +579,9 @@ def _batch_state_commit_snapshot(
 
 
 def _file_batch_metadata(
-    batch_metadata_by_name: Mapping[str, dict],
+    batch_metadata_by_name: Mapping[str, BatchMetadataDict],
     file_path: str,
-) -> dict[str, dict]:
+) -> dict[str, BatchMetadataDict]:
     return {
         batch_name: {
             "files": {
@@ -569,7 +593,7 @@ def _file_batch_metadata(
 
 
 def _acquire_baseline_lines(
-    input_manifest: Mapping[str, Any],
+    input_manifest: _LiveInputManifest,
     *,
     spool_dir: Path,
 ) -> tuple[LineBuffer, bool]:
@@ -608,7 +632,7 @@ def _captured_empty_lifecycle_is_batched(
     file_path: str,
     *,
     change_type: TextFileChangeType | None,
-    batch_metadata_by_name: Mapping[str, dict],
+    batch_metadata_by_name: Mapping[str, BatchMetadataDict],
 ) -> bool:
     if change_type is None:
         return False
@@ -625,7 +649,7 @@ def _write_json_artifact(
     workspace: FileJobWorkspace,
     ordinal: int,
     name: str,
-    value: Any,
+    value: object,
 ) -> Path:
     path = workspace.artifact_path(ordinal, name)
     with path.open("x", encoding="utf-8") as output:
@@ -639,15 +663,114 @@ def _write_json_artifact(
     return path
 
 
-def _read_json_manifest(path: str) -> dict[str, Any]:
+def _required_manifest_string(
+    values: dict[str, object],
+    key: str,
+) -> str:
+    value = values.get(key)
+    if not isinstance(value, str):
+        raise ValueError(f"live-change manifest field {key!r} must be a string")
+    return value
+
+
+def _optional_manifest_string(
+    values: dict[str, object],
+    key: str,
+) -> str | None:
+    value = values.get(key)
+    if value is not None and not isinstance(value, str):
+        raise ValueError(
+            f"live-change manifest field {key!r} must be a string or null"
+        )
+    return value
+
+
+def _read_json_manifest(path: str) -> _LiveInputManifest:
     with Path(path).open(encoding="utf-8") as source:
-        return json.load(source)
+        value: object = json.load(source)
+    if not isinstance(value, dict) or not all(
+        isinstance(key, str) for key in value
+    ):
+        raise ValueError("live-change manifest must be a JSON object")
+    values = cast(dict[str, object], value)
+    batch_metadata = values.get("batch_metadata_by_name")
+    if not isinstance(batch_metadata, dict) or not all(
+        isinstance(key, str) and isinstance(metadata, dict)
+        for key, metadata in batch_metadata.items()
+    ):
+        raise ValueError(
+            "live-change manifest field 'batch_metadata_by_name' "
+            "must be an object of metadata objects"
+        )
+    consumed_metadata = values.get("consumed_file_metadata")
+    if consumed_metadata is not None and not isinstance(
+        consumed_metadata,
+        dict,
+    ):
+        raise ValueError(
+            "live-change manifest field 'consumed_file_metadata' "
+            "must be an object or null"
+        )
+    state_commits = values.get("batch_state_commit_by_name")
+    if not isinstance(state_commits, dict) or not all(
+        isinstance(key, str) and isinstance(commit, str)
+        for key, commit in state_commits.items()
+    ):
+        raise ValueError(
+            "live-change manifest field 'batch_state_commit_by_name' "
+            "must map names to object IDs"
+        )
+    return {
+        "file_path": _required_manifest_string(values, "file_path"),
+        "baseline_path": _required_manifest_string(values, "baseline_path"),
+        "head_commit": _optional_manifest_string(values, "head_commit"),
+        "batch_source_commit": _optional_manifest_string(
+            values,
+            "batch_source_commit",
+        ),
+        "batch_metadata_by_name": cast(
+            dict[str, BatchMetadataDict],
+            batch_metadata,
+        ),
+        "consumed_file_metadata": cast(
+            BatchFileMetadataDict | None,
+            consumed_metadata,
+        ),
+        "batch_state_commit_by_name": cast(dict[str, str], state_commits),
+        "scratch_directory": _required_manifest_string(
+            values,
+            "scratch_directory",
+        ),
+    }
 
 
-def _stream_hunk_manifest(path: str) -> Iterator[dict[str, Any]]:
+def _stream_hunk_manifest(path: str) -> Iterator[_LiveHunkRecord]:
     with Path(path).open(encoding="utf-8") as source:
         for line in source:
-            yield json.loads(line)
+            value: object = json.loads(line)
+            if not isinstance(value, dict) or not all(
+                isinstance(key, str) for key in value
+            ):
+                raise ValueError("hunk manifest entry must be a JSON object")
+            values = cast(dict[str, object], value)
+            ordinal = values.get("ordinal")
+            if type(ordinal) is not int:
+                raise ValueError(
+                    "hunk manifest field 'ordinal' must be an integer"
+                )
+            yield {
+                "ordinal": ordinal,
+                "old_path": _required_manifest_string(values, "old_path"),
+                "new_path": _required_manifest_string(values, "new_path"),
+                "stable_hash": _required_manifest_string(
+                    values,
+                    "stable_hash",
+                ),
+                "patch_artifact_path": _required_manifest_string(
+                    values,
+                    "patch_artifact_path",
+                ),
+            }
 
 
 def _stale_result(

--- a/src/git_stage_batch/data/selected_change/batch_file_cache.py
+++ b/src/git_stage_batch/data/selected_change/batch_file_cache.py
@@ -6,6 +6,7 @@ import json
 from typing import Optional
 
 from ...batch.state.query import read_batch_metadata
+from ...batch.state.metadata_types import BatchMetadataDict
 from ...core.hashing import compute_stable_hunk_hash_from_lines
 from ...core.models import RenderedBatchDisplay
 from ...exceptions import CommandError
@@ -37,7 +38,7 @@ def _patch_path_token(path: str) -> bytes:
 def cache_batch_as_single_hunk(
     batch_name: str,
     file_path: str | None = None,
-    metadata: dict | None = None,
+    metadata: BatchMetadataDict | None = None,
 ) -> Optional[RenderedBatchDisplay]:
     """Load one batch file and cache it as the selected hunk."""
     if metadata is None:

--- a/src/git_stage_batch/data/selected_change/hunk_filtering.py
+++ b/src/git_stage_batch/data/selected_change/hunk_filtering.py
@@ -12,6 +12,7 @@ from ...batch.attribution import (
 )
 from ...batch.attribution_projection import filter_owned_diff_fragments
 from ...batch.state.query import list_batch_names, read_batch_metadata_for_batches
+from ...batch.state.metadata_types import BatchFileMetadataDict, BatchMetadataDict
 from ...core.models import LineLevelChange
 from ...utils.file_io import write_text_file_contents
 from ...utils.journal import log_journal
@@ -24,7 +25,7 @@ from ..consumed_selections import read_consumed_file_metadata
 
 def apply_line_level_batch_filter_to_cached_hunk(
     *,
-    batch_metadata_by_name: dict[str, dict] | None = None,
+    batch_metadata_by_name: dict[str, BatchMetadataDict] | None = None,
 ) -> bool:
     """Filter cached hunk using file-centric ownership attribution.
 
@@ -64,7 +65,7 @@ def apply_line_level_batch_filter_to_cached_hunk(
 def filter_line_level_change_for_batches(
     line_changes: LineLevelChange,
     *,
-    batch_metadata_by_name: dict[str, dict] | None = None,
+    batch_metadata_by_name: dict[str, BatchMetadataDict] | None = None,
 ) -> LineLevelChange | None:
     """Return the unowned portion of a live line change, or ``None``."""
     file_path = line_changes.path
@@ -103,8 +104,8 @@ def filter_line_level_change_with_attribution(
     line_changes: LineLevelChange,
     *,
     attribution: FileAttribution,
-    batch_metadata_by_name: dict[str, dict],
-    consumed_file_metadata: dict | None,
+    batch_metadata_by_name: dict[str, BatchMetadataDict],
+    consumed_file_metadata: BatchFileMetadataDict | None,
     captured_empty_lifecycle_is_batched: bool | None = None,
 ) -> LineLevelChange | None:
     """Filter one hunk from caller-supplied attribution and metadata.
@@ -136,7 +137,7 @@ def filter_line_level_change_with_attribution(
 def _empty_lifecycle_change_is_batched(
     line_changes: LineLevelChange,
     *,
-    batch_metadata_by_name: dict[str, dict],
+    batch_metadata_by_name: dict[str, BatchMetadataDict],
 ) -> bool:
     return not line_changes.lines and (
         _change_freshness.empty_text_lifecycle_change_is_batched(
@@ -150,7 +151,7 @@ def _filter_line_level_change_with_prepared_resources(
     line_changes: LineLevelChange,
     *,
     attribution: FileAttribution,
-    consumed_file_metadata: dict | None,
+    consumed_file_metadata: BatchFileMetadataDict | None,
 ) -> LineLevelChange | None:
     """Project attribution and replacement masks without repository I/O."""
 
@@ -160,6 +161,7 @@ def _filter_line_level_change_with_prepared_resources(
     )
     if should_skip:
         return None
+    assert filtered_line_changes is not None
 
     return _consumed_replacement_masks.filter_consumed_replacement_masks_with_metadata(
         filtered_line_changes,
@@ -169,14 +171,13 @@ def _filter_line_level_change_with_prepared_resources(
 
 def consumed_batch_metadata(
     file_path: str,
-    consumed_file_metadata: dict | None,
-) -> dict[str, dict] | None:
+    consumed_file_metadata: BatchFileMetadataDict | None,
+) -> dict[str, BatchMetadataDict] | None:
     if consumed_file_metadata is None:
         return None
-    return {
-        "__consumed__": {
-            "files": {
-                file_path: consumed_file_metadata,
-            },
+    consumed_metadata: BatchMetadataDict = {
+        "files": {
+            file_path: consumed_file_metadata,
         },
     }
+    return {"__consumed__": consumed_metadata}

--- a/src/git_stage_batch/data/selected_change/store.py
+++ b/src/git_stage_batch/data/selected_change/store.py
@@ -9,6 +9,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
+from types import TracebackType
 
 from ...core.diff_parser import build_line_changes_from_patch_lines
 from ...core.models import (
@@ -64,7 +65,7 @@ class SelectedChangeStateSnapshot:
     """Temporary file copy of selected change state."""
 
     paths: dict[str, Path | None]
-    temporary_directory: tempfile.TemporaryDirectory
+    temporary_directory: tempfile.TemporaryDirectory[str]
 
     def close(self) -> None:
         self.temporary_directory.cleanup()
@@ -72,7 +73,12 @@ class SelectedChangeStateSnapshot:
     def __enter__(self) -> SelectedChangeStateSnapshot:
         return self
 
-    def __exit__(self, exc_type, exc, traceback) -> None:
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
         self.close()
 
 
@@ -111,7 +117,7 @@ def load_line_changes_from_patch_path(patch_path: Path) -> LineLevelChange:
         return build_line_changes_from_patch_lines(patch_lines)
 
 
-def _selected_change_state_paths():
+def _selected_change_state_paths() -> dict[str, Path]:
     """Return files that make up the cached selected change state."""
     return {
         "patch": get_selected_hunk_patch_file_path(),
@@ -134,7 +140,7 @@ def _selected_change_state_paths():
 
 def snapshot_selected_change_state() -> SelectedChangeStateSnapshot:
     """Capture the current selected change cache."""
-    temporary_directory = tempfile.TemporaryDirectory()
+    temporary_directory = tempfile.TemporaryDirectory[str]()
     snapshot_root = Path(temporary_directory.name)
     snapshot_paths: dict[str, Path | None] = {}
 

--- a/src/git_stage_batch/data/start_time_changes.py
+++ b/src/git_stage_batch/data/start_time_changes.py
@@ -280,7 +280,12 @@ def read_staged_renames() -> list[StagedRename]:
         new_path = item.get("new_path")
         new_mode = item.get("new_mode")
         new_blob = item.get("new_blob")
-        if not all(isinstance(value, str) for value in (old_path, new_path, new_mode, new_blob)):
+        if (
+            not isinstance(old_path, str)
+            or not isinstance(new_path, str)
+            or not isinstance(new_mode, str)
+            or not isinstance(new_blob, str)
+        ):
             continue
         renames.append(
             StagedRename(
@@ -313,7 +318,11 @@ def read_staged_deletions() -> list[StagedDeletion]:
         file_path = item.get("path")
         old_mode = item.get("old_mode")
         old_blob = item.get("old_blob")
-        if not all(isinstance(value, str) for value in (file_path, old_mode, old_blob)):
+        if (
+            not isinstance(file_path, str)
+            or not isinstance(old_mode, str)
+            or not isinstance(old_blob, str)
+        ):
             continue
         deletions.append(
             StagedDeletion(


### PR DESCRIPTION
Saved-change actions and previews now share concrete application metadata.

Sift persistence, display dispatch, file and line workflows, live-change
transport, attribution, and atomic file decoding still widen those records.

This PR carries typed metadata through sift and display commands and the
workflow data they consume.

Sift, display, and file workflows now preserve concrete metadata across
process and storage boundaries. The full test suite, static checks, package
build, and historical compile/import gate pass.
