### PR TITLE
tui: Preserve types through interactive review

### DIFF
--- a/src/git_stage_batch/cli/tui_subcommands.py
+++ b/src/git_stage_batch/cli/tui_subcommands.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 from ..i18n import _
-from .subcommand_parser import add_subcommand_parser
+from .subcommand_parser import Subparsers, add_subcommand_parser
 
 
-def add_interactive_subcommand(subparsers) -> None:
+def add_interactive_subcommand(subparsers: Subparsers) -> None:
     """Register the interactive subcommand."""
     parser_interactive = add_subcommand_parser(
         subparsers,

--- a/src/git_stage_batch/tui/action_prompt_menu.py
+++ b/src/git_stage_batch/tui/action_prompt_menu.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 import shutil
+from collections.abc import Sequence
 
 from ..i18n import _
 from ..output.colors import Colors, format_hotkey
@@ -19,7 +20,7 @@ def _visible_len(text: str) -> int:
 
 def format_menu_section_lines(
     label: str,
-    options: list[tuple[str, str, str]],
+    options: Sequence[tuple[str, str, str]],
     use_color: bool,
 ) -> list[str]:
     """Format one menu section, wrapping options across continuation lines."""

--- a/src/git_stage_batch/tui/current_change.py
+++ b/src/git_stage_batch/tui/current_change.py
@@ -24,7 +24,9 @@ class CurrentChange:
 def load_current_change(flow_state: FlowState) -> CurrentChange | None:
     """Load the change currently selected by the interactive source."""
     if flow_state.source.role is LocationRole.BATCH:
-        rendered = cache_batch_as_single_hunk(flow_state.source.batch_name)
+        rendered = cache_batch_as_single_hunk(
+            flow_state.source.require_batch_name()
+        )
         if rendered is None:
             return None
         return CurrentChange(

--- a/src/git_stage_batch/tui/file_review/batch_actions.py
+++ b/src/git_stage_batch/tui/file_review/batch_actions.py
@@ -23,7 +23,7 @@ def apply_batch_line_action(
         from ...commands.include_from import command_include_from_batch
 
         command_include_from_batch(
-            state.flow_state.source.batch_name,
+            state.flow_state.source.require_batch_name(),
             line_ids=line_ids,
             file=state.file_path,
         )
@@ -32,7 +32,7 @@ def apply_batch_line_action(
     from ...commands.discard_from import command_discard_from_batch
 
     command_discard_from_batch(
-        state.flow_state.source.batch_name,
+        state.flow_state.source.require_batch_name(),
         line_ids=line_ids,
         file=state.file_path,
     )

--- a/src/git_stage_batch/tui/file_review/batch_actions.py
+++ b/src/git_stage_batch/tui/file_review/batch_actions.py
@@ -71,7 +71,7 @@ def apply_batch_file_action(
         from ...commands.include_from import command_include_from_batch
 
         command_include_from_batch(
-            state.flow_state.source.batch_name,
+            state.flow_state.source.require_batch_name(),
             file=state.file_path,
         )
         return
@@ -79,7 +79,7 @@ def apply_batch_file_action(
     from ...commands.discard_from import command_discard_from_batch
 
     command_discard_from_batch(
-        state.flow_state.source.batch_name,
+        state.flow_state.source.require_batch_name(),
         file=state.file_path,
     )
 

--- a/src/git_stage_batch/tui/file_review/batch_actions.py
+++ b/src/git_stage_batch/tui/file_review/batch_actions.py
@@ -51,7 +51,7 @@ def apply_batch_replacement_action(
     from ...commands.include_from import command_include_from_batch
 
     command_include_from_batch(
-        state.flow_state.source.batch_name,
+        state.flow_state.source.require_batch_name(),
         line_ids=line_ids,
         file=state.file_path,
         replacement_text=replacement_text,

--- a/src/git_stage_batch/tui/file_review/candidates.py
+++ b/src/git_stage_batch/tui/file_review/candidates.py
@@ -24,7 +24,7 @@ def browse_candidates(state: FileReviewSessionState) -> None:
     if operation is None:
         return
 
-    batch_name = state.flow_state.source.batch_name
+    batch_name = state.flow_state.source.require_batch_name()
     selector = f"{batch_name}:{operation}"
 
     try:

--- a/src/git_stage_batch/tui/file_review/display.py
+++ b/src/git_stage_batch/tui/file_review/display.py
@@ -26,7 +26,7 @@ def render_file_review(
             from ...commands.show_from import command_show_from_batch
 
             command_show_from_batch(
-                flow_state.source.batch_name,
+                flow_state.source.require_batch_name(),
                 file=file_path,
                 page=page_spec,
                 selectable=True,

--- a/src/git_stage_batch/tui/file_review/file_browser.py
+++ b/src/git_stage_batch/tui/file_review/file_browser.py
@@ -31,7 +31,7 @@ def list_review_file_entries(
 ) -> list[ReviewFileEntry]:
     """Return reviewable files for the current interactive source."""
     if flow_state.source.role is LocationRole.BATCH:
-        batch_name = flow_state.source.batch_name
+        batch_name = flow_state.source.require_batch_name()
         metadata = read_batch_metadata(batch_name)
         candidates = list(metadata.get("files", {}).keys())
     else:
@@ -189,6 +189,7 @@ def _apply_marked_file_action(
     for path in sorted(marked_paths):
         try:
             if action == "B":
+                assert local_only is not None
                 block_actions.block_review_file(path, local_only=local_only)
                 continue
 

--- a/src/git_stage_batch/tui/file_review/live_actions.py
+++ b/src/git_stage_batch/tui/file_review/live_actions.py
@@ -92,7 +92,7 @@ def apply_live_file_action(
             from ...commands.include import command_include_to_batch
 
             command_include_to_batch(
-                state.flow_state.target.batch_name,
+                state.flow_state.target.require_batch_name(),
                 file=state.file_path,
                 quiet=True,
                 auto_advance=False,
@@ -124,7 +124,7 @@ def apply_live_file_action(
         from ...commands.discard import command_discard_to_batch
 
         command_discard_to_batch(
-            state.flow_state.target.batch_name,
+            state.flow_state.target.require_batch_name(),
             file=state.file_path,
             quiet=True,
             advance=False,

--- a/src/git_stage_batch/tui/file_review/live_actions.py
+++ b/src/git_stage_batch/tui/file_review/live_actions.py
@@ -17,7 +17,7 @@ def apply_live_line_action(
             from ...commands.include import command_include_to_batch
 
             command_include_to_batch(
-                state.flow_state.target.batch_name,
+                state.flow_state.target.require_batch_name(),
                 line_ids=line_ids,
                 file=state.file_path,
                 quiet=True,
@@ -40,7 +40,7 @@ def apply_live_line_action(
         from ...commands.discard import command_discard_to_batch
 
         command_discard_to_batch(
-            state.flow_state.target.batch_name,
+            state.flow_state.target.require_batch_name(),
             line_ids=line_ids,
             file=state.file_path,
             quiet=True,

--- a/src/git_stage_batch/tui/file_review/live_actions.py
+++ b/src/git_stage_batch/tui/file_review/live_actions.py
@@ -63,7 +63,7 @@ def apply_live_replacement_action(
         from ...commands.discard import command_discard_line_as_to_batch
 
         command_discard_line_as_to_batch(
-            state.flow_state.target.batch_name,
+            state.flow_state.target.require_batch_name(),
             line_ids,
             replacement_text,
             file=state.file_path,

--- a/src/git_stage_batch/tui/file_selection_menu.py
+++ b/src/git_stage_batch/tui/file_selection_menu.py
@@ -120,7 +120,7 @@ def _handle_file_discard(flow_state: FlowState, filename: str) -> None:
                 command_discard_file(file="", auto_advance=True)
         elif flow_state.target.role is LocationRole.BATCH:
             command_discard_to_batch(
-                flow_state.target.batch_name,
+                flow_state.target.require_batch_name(),
                 file="",
                 quiet=True,
                 auto_advance=True,
@@ -131,6 +131,9 @@ def _handle_file_discard(flow_state: FlowState, filename: str) -> None:
         if flow_state.target.role is not LocationRole.STAGING_AREA:
             print(_("Batch-to-batch transfers not yet supported."), file=sys.stderr)
             return
-        command_discard_from_batch(flow_state.source.batch_name, file="")
+        command_discard_from_batch(
+            flow_state.source.require_batch_name(),
+            file="",
+        )
     else:
         raise ValueError(f"Unknown source role: {flow_state.source.role}")

--- a/src/git_stage_batch/tui/file_selection_menu.py
+++ b/src/git_stage_batch/tui/file_selection_menu.py
@@ -82,7 +82,7 @@ def _handle_file_include(flow_state: FlowState) -> None:
             command_include_file(file="", auto_advance=True)
         elif flow_state.target.role is LocationRole.BATCH:
             command_include_to_batch(
-                flow_state.target.batch_name,
+                flow_state.target.require_batch_name(),
                 file="",
                 quiet=True,
                 auto_advance=True,
@@ -93,7 +93,10 @@ def _handle_file_include(flow_state: FlowState) -> None:
         if flow_state.target.role is not LocationRole.STAGING_AREA:
             print(_("Batch-to-batch transfers not yet supported."), file=sys.stderr)
             return
-        command_include_from_batch(flow_state.source.batch_name, file="")
+        command_include_from_batch(
+            flow_state.source.require_batch_name(),
+            file="",
+        )
     else:
         raise ValueError(f"Unknown source role: {flow_state.source.role}")
 

--- a/src/git_stage_batch/tui/flow.py
+++ b/src/git_stage_batch/tui/flow.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
+from typing import ClassVar
 
 from ..i18n import _
 
@@ -32,6 +33,12 @@ class FlowLocation:
         """Create a batch location."""
         return cls(LocationRole.BATCH, batch_name)
 
+    def require_batch_name(self) -> str:
+        """Return the batch name for a batch location."""
+        if self.role is not LocationRole.BATCH or self.batch_name is None:
+            raise ValueError("flow location is not a batch")
+        return self.batch_name
+
     def get_display_label(self) -> str:
         """Get display label for this location."""
         if self.role is LocationRole.WORKING_TREE:
@@ -44,8 +51,8 @@ class FlowLocation:
         return self.batch_name
 
     # Constants for common locations
-    WORKING_TREE = None  # type: ignore  # Will be set after class definition
-    STAGING_AREA = None  # type: ignore
+    WORKING_TREE: ClassVar[FlowLocation]
+    STAGING_AREA: ClassVar[FlowLocation]
 
 
 # Set constants after class is fully defined

--- a/src/git_stage_batch/tui/flow_menu.py
+++ b/src/git_stage_batch/tui/flow_menu.py
@@ -19,7 +19,7 @@ def handle_from_menu(flow_state: FlowState) -> None:
     print(_("Pull changes from:"))
     print()
 
-    options = []
+    options: list[tuple[str, FlowLocation]] = []
     selected_marker = _(" (selected)")
 
     is_selected = flow_state.source.role is LocationRole.WORKING_TREE
@@ -78,7 +78,7 @@ def handle_to_menu(flow_state: FlowState) -> None:
     print(_("Push changes to:"))
     print()
 
-    options = []
+    options: list[tuple[str, FlowLocation | None]] = []
     selected_marker = _(" (selected)")
 
     is_selected = flow_state.target.role is LocationRole.STAGING_AREA
@@ -134,7 +134,9 @@ def handle_to_menu(flow_state: FlowState) -> None:
             command_new_batch(batch_name=batch_id, note=note if note else None)
             flow_state.target = FlowLocation.for_batch(batch_id)
         elif 0 <= idx < len(options) - 1:
-            flow_state.target = options[idx][1]
+            selected_location = options[idx][1]
+            assert selected_location is not None
+            flow_state.target = selected_location
 
         if (
             flow_state.target.role is LocationRole.BATCH

--- a/src/git_stage_batch/tui/hunk_actions.py
+++ b/src/git_stage_batch/tui/hunk_actions.py
@@ -65,7 +65,7 @@ def handle_hunk_discard(flow_state: FlowState) -> None:
                 command_discard(quiet=True, auto_advance=True)
         elif flow_state.target.role is LocationRole.BATCH:
             command_discard_to_batch(
-                flow_state.target.batch_name,
+                flow_state.target.require_batch_name(),
                 quiet=True,
                 auto_advance=True,
             )
@@ -78,6 +78,6 @@ def handle_hunk_discard(flow_state: FlowState) -> None:
                 file=sys.stderr,
             )
             raise BypassRefresh()
-        command_discard_from_batch(flow_state.source.batch_name)
+        command_discard_from_batch(flow_state.source.require_batch_name())
     else:
         raise ValueError(f"Unknown source role: {flow_state.source.role}")

--- a/src/git_stage_batch/tui/hunk_actions.py
+++ b/src/git_stage_batch/tui/hunk_actions.py
@@ -22,7 +22,7 @@ def handle_hunk_include(flow_state: FlowState) -> None:
             command_include(quiet=True, auto_advance=True)
         elif flow_state.target.role is LocationRole.BATCH:
             command_include_to_batch(
-                flow_state.target.batch_name,
+                flow_state.target.require_batch_name(),
                 quiet=True,
                 auto_advance=True,
             )
@@ -35,7 +35,7 @@ def handle_hunk_include(flow_state: FlowState) -> None:
                 file=sys.stderr,
             )
             raise BypassRefresh()
-        command_include_from_batch(flow_state.source.batch_name)
+        command_include_from_batch(flow_state.source.require_batch_name())
     else:
         raise ValueError(f"Unknown source role: {flow_state.source.role}")
 

--- a/src/git_stage_batch/tui/line_selection_menu.py
+++ b/src/git_stage_batch/tui/line_selection_menu.py
@@ -106,7 +106,7 @@ def _handle_line_include(flow_state: FlowState, line_ids: str) -> None:
             command_include_line(line_ids, auto_advance=True)
         elif flow_state.target.role is LocationRole.BATCH:
             command_include_to_batch(
-                flow_state.target.batch_name,
+                flow_state.target.require_batch_name(),
                 line_ids=line_ids,
                 quiet=True,
                 auto_advance=True,
@@ -117,7 +117,10 @@ def _handle_line_include(flow_state: FlowState, line_ids: str) -> None:
         if flow_state.target.role is not LocationRole.STAGING_AREA:
             print(_("Batch-to-batch transfers not yet supported."), file=sys.stderr)
             return
-        command_include_from_batch(flow_state.source.batch_name, line_ids=line_ids)
+        command_include_from_batch(
+            flow_state.source.require_batch_name(),
+            line_ids=line_ids,
+        )
     else:
         raise ValueError(f"Unknown source role: {flow_state.source.role}")
 

--- a/src/git_stage_batch/tui/line_selection_menu.py
+++ b/src/git_stage_batch/tui/line_selection_menu.py
@@ -144,7 +144,7 @@ def _handle_line_discard(flow_state: FlowState, line_ids: str) -> None:
                 command_discard_line(line_ids, auto_advance=True)
         elif flow_state.target.role is LocationRole.BATCH:
             command_discard_to_batch(
-                flow_state.target.batch_name,
+                flow_state.target.require_batch_name(),
                 line_ids=line_ids,
                 quiet=True,
                 auto_advance=True,
@@ -155,6 +155,9 @@ def _handle_line_discard(flow_state: FlowState, line_ids: str) -> None:
         if flow_state.target.role is not LocationRole.STAGING_AREA:
             print(_("Batch-to-batch transfers not yet supported."), file=sys.stderr)
             return
-        command_discard_from_batch(flow_state.source.batch_name, line_ids=line_ids)
+        command_discard_from_batch(
+            flow_state.source.require_batch_name(),
+            line_ids=line_ids,
+        )
     else:
         raise ValueError(f"Unknown source role: {flow_state.source.role}")

--- a/src/git_stage_batch/tui/prompts.py
+++ b/src/git_stage_batch/tui/prompts.py
@@ -99,21 +99,7 @@ def prompt_action(use_color: bool = True, show_question: bool = True, has_hunk: 
         # Grouped secondary menu sections
         print()
 
-        rendered_sections = []
-
-        def append_section(
-                rendered_sections,
-                label,
-                options,
-                use_color,
-        ):
-                rendered_sections.extend(
-                        action_prompt_menu.format_menu_section_lines(
-                                label,
-                                options,
-                                use_color,
-                        )
-                )
+        rendered_sections: list[str] = []
 
         section_specs = [
                 (pgettext("menu section label", "Other scope"), option_groups.scope),
@@ -122,17 +108,18 @@ def prompt_action(use_color: bool = True, show_question: bool = True, has_hunk: 
         ]
 
         for label, options in section_specs:
-                if options:
-                        append_section(
-                                rendered_sections,
-                                label,
-                                options,
-                                use_color,
-                        )
+            if options:
+                rendered_sections.extend(
+                    action_prompt_menu.format_menu_section_lines(
+                        label,
+                        options,
+                        use_color,
+                    )
+                )
 
         if rendered_sections:
-                for rendered_section in rendered_sections:
-                        print(rendered_section)
+            for rendered_section in rendered_sections:
+                print(rendered_section)
 
         print()
     try:


### PR DESCRIPTION
Command and saved-change state now provide typed inputs to interactive
callers.

File, hunk, line, live-change, and replacement review actions still lose
those types while routing prompts and candidate choices.

This PR carries concrete contracts through the interactive flow and every
review action or display boundary.

Interactive review now preserves typed state from candidate browsing
through the selected action. The full test suite, static checks, package
build, and historical compile/import gate pass.
