### PR TITLE
typing: Enforce strict package checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,10 @@ jobs:
         if: matrix.python-version == '3.10'
         run: uv run python scripts/check_type_hygiene.py
 
+      - name: Run strict type checks
+        if: matrix.python-version == '3.10'
+        run: uv run mypy
+
   build:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,10 @@ jobs:
       - name: Run Ruff
         run: uv run ruff check src tests
 
+      - name: Check type hygiene
+        if: matrix.python-version == '3.10'
+        run: uv run python scripts/check_type_hygiene.py
+
   build:
     runs-on: ubuntu-latest
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,11 +27,16 @@ uv sync
 
 # Run tests
 uv run pytest -n auto
+uv run python scripts/check_type_hygiene.py
 ```
 
 Use the xdist form (`-n auto`) for full-suite runs. The suite is large enough
 that serial `uv run pytest` is mainly useful for focused debugging or when
 reproducing ordering-sensitive failures.
+
+`dict`, `list`, or `tuple` annotations. The type-hygiene check also prevents
+explicit `Any` from spreading beyond the small set of reviewed serialization,
+reflection, and third-party API boundaries.
 
 ## Find the Code for a Change
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,13 +27,20 @@ uv sync
 
 # Run tests
 uv run pytest -n auto
+
+# Run lint and strict type checks
+uv run ruff check src tests
 uv run python scripts/check_type_hygiene.py
+uv run mypy
 ```
 
 Use the xdist form (`-n auto`) for full-suite runs. The suite is large enough
 that serial `uv run pytest` is mainly useful for focused debugging or when
 reproducing ordering-sensitive failures.
 
+The type checker targets the oldest supported Python version and checks the
+entire `git_stage_batch` package in strict mode. Keep persisted mappings and
+other structured containers concrete rather than falling back to bare
 `dict`, `list`, or `tuple` annotations. The type-hygiene check also prevents
 explicit `Any` from spreading beyond the small set of reviewed serialization,
 reflection, and third-party API boundaries.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,12 @@ preview = true
 [tool.pytest.ini_options]
 addopts = ["--import-mode=importlib", "-n", "auto"]
 
+[tool.mypy]
+python_version = "3.10"
+files = ["src/git_stage_batch"]
+strict = true
+show_error_codes = true
+
 [tool.uv.extra-build-dependencies]
 git-stage-batch = [
     "meson-python>=0.17.0",

--- a/scripts/check_type_hygiene.py
+++ b/scripts/check_type_hygiene.py
@@ -296,6 +296,11 @@ def main() -> int:
             f"dynamic boundary ({use.identity}; {use.annotation})",
             file=sys.stderr,
         )
+    for identity in stale:
+        print(
+            f"stale explicit-Any allowlist entry: {identity}",
+            file=sys.stderr,
+        )
     return 1
 
 

--- a/scripts/check_type_hygiene.py
+++ b/scripts/check_type_hygiene.py
@@ -75,6 +75,22 @@ ALLOWED_EXPLICIT_ANY = frozenset({
     "Subparsers.add_parser::param:kwargs",
     "src/git_stage_batch/cli/subcommand_parser.py::"
     "add_subcommand_parser::param:kwargs",
+    "src/git_stage_batch/utils/file_job_transport.py::"
+    "_assert_transport_value::cast",
+    "src/git_stage_batch/utils/file_job_transport.py::"
+    "_assert_transport_dataclass_shape::cast",
+    "src/git_stage_batch/utils/file_job_workspace.py::"
+    "FileJobWorkspace.write_json::param:value",
+    "src/git_stage_batch/utils/file_job_workspace.py::"
+    "FileJobWorkspace.read_json::return",
+    "src/git_stage_batch/utils/file_job_workspace.py::"
+    "FileJobWorkspace.write_jsonl::param:values",
+    "src/git_stage_batch/utils/file_job_workspace.py::"
+    "FileJobWorkspace.stream_jsonl::return",
+    "src/git_stage_batch/utils/file_job_workspace.py::"
+    "FileJobWorkspace.write_pickle::param:value",
+    "src/git_stage_batch/utils/file_job_workspace.py::"
+    "FileJobWorkspace.read_pickle::return",
 })
 
 

--- a/src/git_stage_batch/utils/file_job_transport.py
+++ b/src/git_stage_batch/utils/file_job_transport.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator, Sequence
+from collections.abc import Iterable
 from dataclasses import dataclass, fields, is_dataclass
 from enum import Enum
 import importlib
+from typing import Any, cast
 from pathlib import (
     Path,
     PosixPath,
@@ -78,7 +79,7 @@ def _assert_transport_value(
             label=label,
             state=state,
             depth=depth,
-            values=(value.value,),
+            values=((f"{label}[0]", value.value),),
         )
         return
     # Exact scalar and collection types are intentional. State-bearing
@@ -112,7 +113,10 @@ def _assert_transport_value(
             label=label,
             state=state,
             depth=depth,
-            values=value,
+            values=(
+                (f"{label}[{index}]", item)
+                for index, item in enumerate(value)
+            ),
         )
         return
     if isinstance(value, tuple):
@@ -126,9 +130,9 @@ def _assert_transport_value(
             state=state,
             depth=depth,
             values=(
-                (field.name, getattr(value, field.name)) for field in fields(value)
+                (f"{label}.{field.name}", getattr(value, field.name))
+                for field in fields(cast(Any, value))
             ),
-            named_values=True,
         )
         return
     raise TypeError(
@@ -171,7 +175,7 @@ def _assert_transport_dataclass_shape(value: object, *, label: str) -> None:
     if parameters is None or not parameters.frozen or hasattr(value, "__dict__"):
         raise TypeError(f"{label} must use a frozen slots dataclass")
 
-    field_names = {field.name for field in fields(value)}
+    field_names = {field.name for field in fields(cast(Any, value))}
     for value_class in value_type.__mro__:
         if value_class is object:
             continue
@@ -241,19 +245,14 @@ def _recurse_transport_values(
     label: str,
     state: _TransportValidationState,
     depth: int,
-    values: Sequence[object] | Iterator[tuple[str, object]],
-    named_values: bool = False,
+    values: Iterable[tuple[str, object]],
 ) -> None:
     value_id = id(owner)
     if value_id in state.active_ids:
         raise TypeError(f"{label} contains a recursive value")
     state.active_ids.add(value_id)
     try:
-        for index, value in enumerate(values):
-            value_label = f"{label}[{index}]"
-            if named_values:
-                value_name, value = value
-                value_label = f"{label}.{value_name}"
+        for value_label, value in values:
             _assert_transport_value(
                 value,
                 label=value_label,

--- a/src/git_stage_batch/utils/file_job_workspace.py
+++ b/src/git_stage_batch/utils/file_job_workspace.py
@@ -18,7 +18,8 @@ from pathlib import (
 import pickle
 import stat
 import tempfile
-from typing import Any
+from types import TracebackType
+from typing import Any, cast
 
 from ..core.buffer import BufferInput, LineBuffer
 from .buffer_io import write_buffer_to_path
@@ -190,7 +191,12 @@ class FileJobWorkspace(AbstractContextManager["FileJobWorkspace"]):
         self._require_open()
         return self
 
-    def __exit__(self, exc_type, exc, traceback) -> None:
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
         self.close()
 
     def _allocate_path(
@@ -294,7 +300,7 @@ def _assert_pickle_metadata_value(
             value,
             label=label,
             active_ids=active_ids,
-            values=value,
+            values=cast(Iterable[object], value),
         )
         return
     if isinstance(value, (dict, list, tuple, set, frozenset)):


### PR DESCRIPTION
Interactive review completes the package-wide conversion to concrete
internal contracts.

File-job transport and stale Any exceptions must still be validated before
strict checking can become a required project gate.

This PR validates transport identities, rejects stale policy entries, runs
the reviewed Any policy in CI, and enables strict mypy checking for the
package.

The package now passes strict mypy over 461 source files with the reviewed
37-slot dynamic policy enforced in CI. The full test suite, static checks,
package build, and historical compile/import gate pass.
