### PR TITLE
project: Require self-contained commit prose

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,8 @@ We follow strict commit message conventions to maintain a clear and understandab
 - **Wrap body paragraphs at 75 characters.**
 - **Be humble and forward thinking.** Avoid words like "comprehensive" or "crucial", and avoid a tone that could sound like bragging or seem short-sighted.
 - **Do not invent concise self-describing labels for internal ideas and use them casually,** expecting the reader to implicitly know what they should mean. Explain things in a way that reduces cognitive load on the reader.
+- **Define codebase-specific or ambiguous terms at first use in every message.** A reader should not need another commit in the series to learn what a term or identifier means.
+- **Prefer a complete plain-language sentence over compressed shorthand.** Spell out the behavior hidden by noun piles, abstract verbs, or compounds such as `X-backed` and `X-aware` when their meaning is not obvious.
 
 ### Format
 
@@ -205,6 +207,8 @@ Before finalizing a commit message, check:
 - If this is an incremental step, does it clearly say so?
 - If this is the penultimate commit in a series, does the fourth paragraph name what the upcoming final commit will do?
 - If this is an earlier non-final commit in a series, does the fourth paragraph name what subsequent commits will do?
+- Can a newcomer understand the state, limitation, and change without decoding coined shorthand?
+- Are codebase-specific or ambiguous terms defined in this message rather than only in another commit?
 - Do body paragraphs wrap at 75 characters?
 
 ### Example: Single Commit

--- a/assets/claude-agents/commit-message-drafter.md
+++ b/assets/claude-agents/commit-message-drafter.md
@@ -83,6 +83,12 @@ one fails.
 - Respect the caller's stated split. Do not broaden the story to absorb work
   outside the selected staged or historical patch.
 - The summary line must describe one change only.
+- Write for a reader who has never seen the repository. Prefer a complete
+  plain-language sentence over a coined label, compressed noun phrase, or
+  abstract verb that hides what the program does.
+- Define codebase-specific or ambiguous terms at first use in every message.
+  Introduce an identifier by its role when its name does not explain itself,
+  even if an earlier commit already introduced it.
 - The body must match repository paragraph-count and tense rules when given.
 - The first paragraph describes the selected current state, not the patch.
 - Do not consider uncommitted changes or untracked files as part of the
@@ -113,6 +119,7 @@ Return exactly these sections:
    - whether the summary is single-purpose
    - expected paragraph count
    - series positioning
+   - whether local terms and identifiers are defined in this message
    - any repository rule you applied
 
 3. `UNCERTAINTY`

--- a/assets/claude-skills/refine-commit-messages/SKILL.md
+++ b/assets/claude-skills/refine-commit-messages/SKILL.md
@@ -27,7 +27,10 @@ noncompliant commits. Preserve the commit count, order, tree at every series
 position, author identity/date, signature presence, and final tree.
 
 Read `references/message-guidelines.md` before auditing. Treat the patches as
-evidence for the prose, never as editable material.
+evidence for the prose, never as editable material. Within each message,
+reject unexplained local terms, coined shorthand, and compressed labels that
+make a newcomer decode the prose when a plain sentence could state the
+behavior directly.
 
 ## Usage
 

--- a/assets/claude-skills/refine-commit-messages/references/message-guidelines.md
+++ b/assets/claude-skills/refine-commit-messages/references/message-guidelines.md
@@ -17,6 +17,51 @@ documentation section, and build hook must be either the named outcome or
 necessary support for it. A patch with several independent outcomes belongs
 in `refine-history`; do not disguise it with a broader message.
 
+## Low-context prose
+
+Assume the reader understands ordinary software development and Git, but has
+never seen this repository. The message should let that reader identify the
+selected state, the concrete limitation, and the effect of the patch without
+first decoding local vocabulary.
+
+- Make each message independently understandable. Do not require the reader to
+  open an earlier commit to recover a definition or remember a local term.
+- Prefer a short, complete sentence over a coined label or compressed noun
+  phrase. Do not turn a relationship into phrases such as `metadata bridge`,
+  `ownership path`, `state seam`, or `typing surface` when plain prose can say
+  what data moves, who uses it, and why.
+- Do not invent a one- or two-word name for an idea solely to shorten the
+  message. A memorable label is not automatically a clear explanation.
+- Use an established project term only when it is the clearest name for the
+  concept. Define a codebase-specific or ambiguous term at first use in every
+  message with a brief appositive or plain-language clause.
+- Introduce a code identifier by its role when the name alone is not
+  self-explanatory: `SelectionResult, the object that carries the chosen
+  hunks`, rather than treating `SelectionResult` as prior knowledge. Repeat
+  that brief role in a later message when the identifier appears there again.
+- Expand uncommon abbreviations on first use. Common terms such as Git, CLI,
+  API, and JSON need no definition unless the repository gives them a special
+  meaning.
+- Spell out the relationship hidden by compounds such as `X-backed`,
+  `X-aware`, `X-driven`, or `X-shaped` when more than one interpretation is
+  plausible.
+- Replace abstract verbs such as `thread`, `surface`, `normalize`, `harden`,
+  or `plumb` with the concrete behavior when the abstraction would force the
+  reader to inspect the patch.
+- Give pronouns clear antecedents. Do not make a reader search earlier
+  paragraphs to learn what `it`, `that path`, or `the state` means.
+
+For example, `state: Harden ownership recovery` leaves both the failure and
+the role of ownership unclear. `state: Restore saved line selections after
+reopening a session` states the behavior directly. Likewise, replace `The
+typed path lacks a metadata bridge` with a sentence such as `Saved selections
+do not carry the file name and object identifier needed to find their source
+files again`.
+
+Apply a read-once test: a newcomer should be able to paraphrase what existed,
+what was missing, and what this commit changes. If the paraphrase depends on
+guessing a local term, define the term or rewrite the sentence.
+
 ## Message shape
 
 Use a concise, single-outcome subject with the repository's normal lowercase

--- a/assets/codex-skills/internal/commit-message-drafter.md
+++ b/assets/codex-skills/internal/commit-message-drafter.md
@@ -71,6 +71,12 @@ of falling back to `git diff --cached`.
 - Respect the caller's stated split. Do not broaden the story to absorb work
   outside the selected staged or historical patch.
 - The summary line must describe one change only.
+- Write for a reader who has never seen the repository. Prefer a complete
+  plain-language sentence over a coined label, compressed noun phrase, or
+  abstract verb that hides what the program does.
+- Define codebase-specific or ambiguous terms at first use in every message.
+  Introduce an identifier by its role when its name does not explain itself,
+  even if an earlier commit already introduced it.
 - The body must match repository paragraph-count and tense rules when given.
 - The first paragraph describes the selected current state, not the patch.
 - Do not consider uncommitted changes or untracked files as part of the
@@ -98,6 +104,7 @@ Return exactly these sections:
    - whether the summary is single-purpose
    - expected paragraph count
    - series positioning
+   - whether local terms and identifiers are defined in this message
    - any repository rule you applied
 
 3. `UNCERTAINTY`

--- a/assets/codex-skills/refine-commit-messages/SKILL.md
+++ b/assets/codex-skills/refine-commit-messages/SKILL.md
@@ -10,7 +10,10 @@ noncompliant commits. Preserve the commit count, order, tree at every series
 position, author identity/date, signature presence, and final tree.
 
 Read `references/message-guidelines.md` before auditing. Treat the patches as
-evidence for the prose, never as editable material.
+evidence for the prose, never as editable material. Within each message,
+reject unexplained local terms, coined shorthand, and compressed labels that
+make a newcomer decode the prose when a plain sentence could state the
+behavior directly.
 
 ## Usage
 

--- a/assets/codex-skills/refine-commit-messages/references/message-guidelines.md
+++ b/assets/codex-skills/refine-commit-messages/references/message-guidelines.md
@@ -17,6 +17,51 @@ documentation section, and build hook must be either the named outcome or
 necessary support for it. A patch with several independent outcomes belongs
 in `refine-history`; do not disguise it with a broader message.
 
+## Low-context prose
+
+Assume the reader understands ordinary software development and Git, but has
+never seen this repository. The message should let that reader identify the
+selected state, the concrete limitation, and the effect of the patch without
+first decoding local vocabulary.
+
+- Make each message independently understandable. Do not require the reader to
+  open an earlier commit to recover a definition or remember a local term.
+- Prefer a short, complete sentence over a coined label or compressed noun
+  phrase. Do not turn a relationship into phrases such as `metadata bridge`,
+  `ownership path`, `state seam`, or `typing surface` when plain prose can say
+  what data moves, who uses it, and why.
+- Do not invent a one- or two-word name for an idea solely to shorten the
+  message. A memorable label is not automatically a clear explanation.
+- Use an established project term only when it is the clearest name for the
+  concept. Define a codebase-specific or ambiguous term at first use in every
+  message with a brief appositive or plain-language clause.
+- Introduce a code identifier by its role when the name alone is not
+  self-explanatory: `SelectionResult, the object that carries the chosen
+  hunks`, rather than treating `SelectionResult` as prior knowledge. Repeat
+  that brief role in a later message when the identifier appears there again.
+- Expand uncommon abbreviations on first use. Common terms such as Git, CLI,
+  API, and JSON need no definition unless the repository gives them a special
+  meaning.
+- Spell out the relationship hidden by compounds such as `X-backed`,
+  `X-aware`, `X-driven`, or `X-shaped` when more than one interpretation is
+  plausible.
+- Replace abstract verbs such as `thread`, `surface`, `normalize`, `harden`,
+  or `plumb` with the concrete behavior when the abstraction would force the
+  reader to inspect the patch.
+- Give pronouns clear antecedents. Do not make a reader search earlier
+  paragraphs to learn what `it`, `that path`, or `the state` means.
+
+For example, `state: Harden ownership recovery` leaves both the failure and
+the role of ownership unclear. `state: Restore saved line selections after
+reopening a session` states the behavior directly. Likewise, replace `The
+typed path lacks a metadata bridge` with a sentence such as `Saved selections
+do not carry the file name and object identifier needed to find their source
+files again`.
+
+Apply a read-once test: a newcomer should be able to paraphrase what existed,
+what was missing, and what this commit changes. If the paraphrase depends on
+guessing a local term, define the term or rewrite the sentence.
+
 ## Message shape
 
 Use a concise, single-outcome subject with the repository's normal lowercase

--- a/tests/assets/test_refine_commit_messages_checkpoint.py
+++ b/tests/assets/test_refine_commit_messages_checkpoint.py
@@ -29,6 +29,14 @@ CLAUDE_HELPER = (
 )
 CODEX_SKILL = CODEX_HELPER.parents[1] / "SKILL.md"
 CLAUDE_SKILL = CLAUDE_HELPER.parents[1] / "SKILL.md"
+CODEX_GUIDELINES = CODEX_HELPER.parents[1] / "references" / "message-guidelines.md"
+CLAUDE_GUIDELINES = CLAUDE_HELPER.parents[1] / "references" / "message-guidelines.md"
+CODEX_DRAFTER = (
+    PROJECT_ROOT / "assets" / "codex-skills" / "internal" / "commit-message-drafter.md"
+)
+CLAUDE_DRAFTER = (
+    PROJECT_ROOT / "assets" / "claude-agents" / "commit-message-drafter.md"
+)
 
 
 def _git(
@@ -133,6 +141,21 @@ def test_public_audit_mode_uses_a_positional_keyword() -> None:
     assert (
         'argument-hint: "<base-sha> | audit <base-sha> | resume"' in claude_skill
     )
+
+
+def test_message_guidance_requires_low_context_prose() -> None:
+    """Drafters should explain repository terms instead of inventing shorthand."""
+    for path in (CODEX_GUIDELINES, CLAUDE_GUIDELINES):
+        guidance = path.read_text(encoding="utf-8")
+        assert "## Low-context prose" in guidance
+        assert "Do not invent a one- or two-word name" in guidance
+        assert "Define a codebase-specific or ambiguous term at first use" in guidance
+        assert "Make each message independently understandable" in guidance
+        assert "Apply a read-once test" in guidance
+
+    for path in (CODEX_DRAFTER, CLAUDE_DRAFTER):
+        drafter = " ".join(path.read_text(encoding="utf-8").split())
+        assert "Write for a reader who has never seen the repository" in drafter
 
 
 def test_start_freezes_base_and_binds_resume_to_the_branch(git_repo: Path) -> None:


### PR DESCRIPTION
The project asks commit authors and bundled message drafters to write for
readers with limited context. The refinement assets also define subject, body,
and series-transition structure.

Those instructions do not require each message to define local terms or
replace compressed shorthand with concrete behavior. Drive-by reviewers may
therefore need to infer repository vocabulary before understanding a change.

This PR adds explicit low-context prose rules to the contribution guide and
the Codex and Claude drafting paths. It requires definitions at first use,
bans invented shorthand, adds read-once checks, and tests both bundled
platforms.

Every bundled message-writing path now shares a tested requirement that each
commit message stand on its own. The full test suite, Ruff, type-hygiene check,
strict mypy, and package build pass.
