### PR TITLE
assets: Refine commit messages in one pass

### DIFF
--- a/assets/claude-agents/commit-message-drafter.md
+++ b/assets/claude-agents/commit-message-drafter.md
@@ -32,6 +32,8 @@ Expect the caller to provide:
 - for historical mode, the target commit's full SHA and series position
 - whether this is a single commit or part of a series
 - the current commit's one-clause purpose
+- for a series, its overall goal, the selected state at this position, and the
+  immediately preceding and following index entries
 - whether this is the final commit in the series
 - whether this is the penultimate commit in the series, when known
 - any repository-specific commit rules already discovered
@@ -61,13 +63,17 @@ Prefer the smallest number of commands that gives a confident answer.
 For historical mode, leave the index and worktree out of the analysis:
 
 1. `git --no-optional-locks show --stat --patch --find-renames TARGET_SHA`
-2. `git --no-optional-locks show TARGET_SHA^:<path>` for representative
-   parent-state paths
-3. `git --no-optional-locks log --reverse --format='%H%n%B%n---'
-   BASE_SHA..SERIES_HEAD` for the cumulative narrative and adjacent
-   fourth-paragraph transitions
+2. the caller's series goal, selected-state summary, and adjacent index entries
+   for cumulative narrative and fourth-paragraph transitions
+3. `git --no-optional-locks show TARGET_SHA^:<path>` only when representative
+   parent-state content is needed to verify that summary
 4. representative path history, repository guidance, and the commit hook as
    needed
+
+Do not reread the complete raw series when the caller supplied an indexed
+summary. Inspect an adjacent commit directly only when its supplied transition
+is ambiguous. Fall back to a range-wide log only when essential series context
+is missing and cannot be recovered from the target and its neighbors.
 
 If historical mode lacks an exact target SHA, report the missing input instead
 of falling back to `git diff --cached`.

--- a/assets/claude-skills/refine-commit-messages/SKILL.md
+++ b/assets/claude-skills/refine-commit-messages/SKILL.md
@@ -52,9 +52,27 @@ checkpoint to resume.
 Before either mode, read repository guidance, representative recent messages,
 and the commit-message hook. Repository-specific rules override the bundled
 fallback rules. Use `Agent(commit-message-drafter)` in its historical-commit
-mode when installed. Give it the target SHA, parent state, patch, complete
-ordered series, position, and discovered rules; never ask it to inspect the
-clean staged index for an already-committed patch.
+mode when installed.
+
+Build one compact series index before drafting. Record the base, source head,
+and overall goal once. For each position, record its SHA, subject, narrative
+role, one plain-language sentence describing the patch outcome, and only the
+prior capabilities needed to understand that change. Do not copy the whole
+prefix of earlier entries into each new entry. Inspect each patch once in
+order and update the index with that commit's state change.
+
+For an individual draft, provide the target SHA, relevant parent state, patch,
+overall goal, target index entry, adjacent entries, and discovered rules. Do
+not resend the full index or reread the complete raw series for every commit,
+and never ask the drafter to inspect the clean staged index for an
+already-committed patch.
+
+Persist the index as `series-index.json`, bound to the canonical base and
+source head. In audit mode, keep it under the external audit temporary
+directory. In default mode, write it under
+`$REFINE_MESSAGES_STATE_DIR` after `start`. Reuse a matching index after
+context compaction or `resume`; never repeat the range-wide semantic read just
+to reconstruct lost working context.
 
 ## Audit mode
 
@@ -72,10 +90,10 @@ REFINE_MESSAGES_HELPER=.claude/skills/refine-commit-messages/scripts/refine-comm
 BASE_SHA=$(python3 "$REFINE_MESSAGES_HELPER" check-range --audit-only --base "$BASE_SHA")
 AUDIT_TMP=$(mktemp -d)
 python3 "$REFINE_MESSAGES_HELPER" inspect --base "$BASE_SHA" > "$AUDIT_TMP/scan.json"
-git --no-optional-locks log --reverse --format='%H%n%B%n---' "$BASE_SHA"..HEAD
 ```
 
-Inspect every patch as well as every message:
+`scan.json` contains every message and its mechanical signals. Inspect the
+patches once:
 
 ```bash
 git --no-optional-locks log --reverse --stat --patch --find-renames "$BASE_SHA"..HEAD
@@ -128,8 +146,9 @@ python3 "$REFINE_MESSAGES_HELPER" status --json
 
 Do not read or reuse artifacts from an older run before `start`.
 If the range contains signed commits, ensure the configured signing mechanism
-can re-sign replacements. `verify-head` rejects a rewrite that strips or adds
-signature presence.
+can re-sign them. The one-pass callbacks explicitly re-sign originally signed
+positions and keep originally unsigned positions unsigned; a signing failure
+stops the rebase.
 
 ## Resume
 
@@ -146,11 +165,35 @@ RECOVERY_REF=$(python3 "$REFINE_MESSAGES_HELPER" recovery-ref)
 git --no-optional-locks show-ref --verify "$RECOVERY_REF"
 ```
 
-If a rebase is active, inspect `git status`, its todo/done files, and the last
-checkpoint event. Continue only when they identify the same message edit and
-series position. Aborting that rebase is safe; never abort and then call
-`start`. Outside a rebase, `check-resume` requires the exact original tree
-sequence and author metadata to remain intact.
+Use the checkpoint phase reported by `status`. For the current `applying`
+phase, inspect `git status`, the rebase todo/done files, and the last checkpoint
+event. Continue only when they identify the same rewrite plan and series
+position. After resolving a transient hook failure or other understood stop,
+run:
+
+```bash
+git --no-optional-locks -c commit.gpgSign=false rebase --continue
+python3 "$REFINE_MESSAGES_HELPER" finalize-apply --base "$BASE_SHA"
+```
+
+If no rebase is active while the phase is `applying`, compare `HEAD` with the
+checkpoint's `rewrite_source_head`. An equal value means the rebase never
+started or was aborted; fix the cause and rerun `apply-audit`. A different
+value means the rebase changed history, so run only `finalize-apply` and let it
+verify the result. Aborting the rebase is safe; never abort and then call
+`start`. If a message itself fails the commit hook, abort the controlled
+rebase, correct that proposal in `audit.json`, and rerun `apply-audit` from the
+existing checkpoint. Outside a rebase,
+`check-resume` requires the exact original tree sequence and author metadata
+to remain intact.
+
+A checkpoint in the older `rewriting` phase predates the one-pass workflow. If
+its rebase is active, abort that rebase to return to the saved pre-step state,
+then run `apply-audit`, which validates the existing audit; do not call
+`start`.
+If no rebase is active, first run `verify` and `scan`, update the audit's
+position-bound SHAs and mechanical signals, and recheck only the message that
+already landed and its neighbors before using `apply-audit`.
 
 ## Audit and rewrite
 
@@ -160,7 +203,8 @@ Generate the current mechanical scan:
 python3 "$REFINE_MESSAGES_HELPER" scan --base "$BASE_SHA"
 ```
 
-Inspect every commit's body and patch. Write
+Use the series index to inspect every commit's body and patch exactly once.
+Write
 `$REFINE_MESSAGES_STATE_DIR/audit.json` with this shape:
 
 ```json
@@ -171,7 +215,7 @@ Inspect every commit's body and patch. Write
   "head": "FULL_CURRENT_HEAD_SHA",
   "conventions": {
     "sources": ["CONTRIBUTING.md", "fallback message guidelines"],
-    "summary": "Concrete paragraph, prefix, tense, and wrapping rules applied"
+    "summary": "Concrete structure, plain-language, term, and wrapping rules"
   },
   "commits": [
     {
@@ -201,49 +245,49 @@ mechanically signaled message because of an explicit repository override, add:
 ]
 ```
 
-Cover every commit exactly once in order. Validate the working audit:
+For a `REWORD`, write `patch_fidelity` and `series_transition` about the
+proposed replacement; the helper carries those findings into the final audit.
+Cover every commit exactly once in order.
+
+If every verdict is `KEEP`, proceed directly to the completion gate. Otherwise
+apply every replacement in one controlled rebase:
 
 ```bash
-python3 "$REFINE_MESSAGES_HELPER" validate-audit --allow-reword --base "$BASE_SHA"
+python3 "$REFINE_MESSAGES_HELPER" apply-audit --base "$BASE_SHA"
 ```
 
-Reword the earliest `REWORD` only. Save its proposed message under the state
-directory, then let the helper create a controlled stop at that exact commit:
-
-```bash
-POSITION=PUT_ONE_BASED_POSITION_HERE
-TARGET_SHA=PUT_CURRENT_FULL_SHA_HERE
-MESSAGE_FILE="$REFINE_MESSAGES_STATE_DIR/message-$POSITION.txt"
-python3 "$REFINE_MESSAGES_HELPER" begin-reword --base "$BASE_SHA" --position "$POSITION" --target "$TARGET_SHA"
-git --no-optional-locks show --stat --patch --find-renames HEAD
-git commit --amend -F "$MESSAGE_FILE"
-python3 "$REFINE_MESSAGES_HELPER" verify-head --position "$POSITION"
-git rebase --continue
-python3 "$REFINE_MESSAGES_HELPER" verify --base "$BASE_SHA"
-```
+`apply-audit` validates `scan.json` and the complete audit before creating a
+rebase. Do not run a separate validation pass first.
 
 Do not stage, edit, reset, split, squash, reorder, or drop content. If a hook
 changes the index or tree, stop and restore from the recovery ref. If a patch
 does not match one coherent message, report that `refine-history` is needed
 instead of changing its boundary here.
 
-`begin-reword` uses a portable sequence editor and command-scoped Git settings
-that disable abbreviated todo commands, autosquash, update-refs, rebase-merges,
-and autostash. Do not replace it with an ad hoc interactive-rebase recipe.
+`apply-audit` freezes the validated audit by series position and adds one
+constant-size verification callback after every pick in a portable rebase
+todo. Each callback restores that position's expected message and signature
+presence while verifying its tree and author. The callbacks run from a frozen
+copy inside the worktree's Git directory, so historical checkouts cannot
+replace the helper. The rebase disables abbreviated todo commands, autosquash,
+update-refs, rebase-merges, and autostash. Afterward, the helper performs one
+linear whole-series check, regenerates `scan.json`, and converts the audit to
+current all-`KEEP` entries.
 
-After each reword, regenerate `scan.json` and rebuild the complete audit from
-the beginning because all descendant SHAs changed. Continue until every entry
-is `KEEP`. Vary fourth-paragraph phrasing while preserving the required series
-position: future work for earlier commits, the singular final commit for the
-penultimate commit, and a conclusion for the final commit.
+Do not rebuild the complete audit merely because rewritten ancestors changed
+descendant SHAs. Reinspect only a message that differs from the validated
+plan, its adjacent transitions, or evidence affected by a changed repository
+rule. If boundaries, order, or patches changed, stop rather than trying to
+repair the audit. Ordinary successful application needs one initial semantic
+audit. Later checks are linear mechanical verification and never repeat
+semantic drafting once per reworded commit.
 
 ## Completion gate
 
-Validate the final all-`KEEP` audit, then complete:
+Reconfirm publication safety, then let the helper validate the final
+all-`KEEP` audit and complete:
 
 ```bash
-python3 "$REFINE_MESSAGES_HELPER" validate-audit --base "$BASE_SHA"
-python3 "$REFINE_MESSAGES_HELPER" verify --base "$BASE_SHA"
 git --no-optional-locks status --short
 git --no-optional-locks branch -a --contains HEAD
 git --no-optional-locks remote -v

--- a/assets/claude-skills/refine-commit-messages/scripts/refine-commit-messages-checkpoint.py
+++ b/assets/claude-skills/refine-commit-messages/scripts/refine-commit-messages-checkpoint.py
@@ -96,6 +96,7 @@ CHECKPOINT_PATH = STATE_DIR / "checkpoint.json"
 PRE_COMMITS_PATH = STATE_DIR / "pre-commits.json"
 SCAN_PATH = STATE_DIR / "scan.json"
 AUDIT_PATH = STATE_DIR / "audit.json"
+REWRITE_PLAN_PATH = STATE_DIR / "rewrite-plan.json"
 
 
 def now() -> str:
@@ -214,6 +215,48 @@ def git_dir() -> Path:
     return Path(git_output("rev-parse", "--absolute-git-dir"))
 
 
+def rewrite_helper_snapshot_path() -> Path:
+    """Return the Git-private path for the active rebase helper copy."""
+    return (
+        git_dir()
+        / "git-stage-batch"
+        / "refine-commit-messages"
+        / "rewrite-helper.py"
+    )
+
+
+def snapshot_rewrite_helper() -> Path:
+    """Freeze this helper outside the tree that the rebase will check out."""
+    target = rewrite_helper_snapshot_path()
+    for directory in (target.parent.parent, target.parent):
+        if directory.is_symlink() or (
+            directory.exists() and not directory.is_dir()
+        ):
+            raise SystemExit(
+                f"refusing to use unsafe rewrite-helper directory: {directory}"
+            )
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.is_symlink() or (target.exists() and not target.is_file()):
+        raise SystemExit(f"refusing to replace unsafe rewrite helper: {target}")
+
+    temporary_name: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "wb",
+            dir=target.parent,
+            prefix=f".{target.name}.",
+            delete=False,
+        ) as temporary:
+            temporary_name = temporary.name
+            temporary.write(Path(__file__).resolve(strict=True).read_bytes())
+        os.chmod(temporary_name, 0o600)
+        os.replace(temporary_name, target)
+    finally:
+        if temporary_name is not None:
+            Path(temporary_name).unlink(missing_ok=True)
+    return target.resolve(strict=True)
+
+
 def current_branch_ref() -> str | None:
     """Return the current symbolic branch ref."""
     result = git_run("symbolic-ref", "-q", "HEAD", check=False)
@@ -231,6 +274,39 @@ def active_rebase() -> tuple[bool, str | None]:
             return True, None
         return True, head_name.read_text(encoding="utf-8").strip() or None
     return False, None
+
+
+def latest_rebase_pick() -> str | None:
+    """Return the most recent original commit named in the active rebase log."""
+    for directory_name in ("rebase-merge", "rebase-apply"):
+        done_path = git_dir() / directory_name / "done"
+        if not done_path.is_file() or done_path.is_symlink():
+            continue
+        with done_path.open("rb") as done_file:
+            remaining = done_path.stat().st_size
+            partial = b""
+            while remaining:
+                block_size = min(8192, remaining)
+                remaining -= block_size
+                done_file.seek(remaining)
+                lines = (done_file.read(block_size) + partial).split(b"\n")
+                partial = lines[0]
+                for raw_line in reversed(lines[1:]):
+                    stripped = raw_line.lstrip()
+                    if stripped.startswith(b"pick "):
+                        commit = stripped.split(maxsplit=2)[1].decode(
+                            "ascii",
+                            errors="strict",
+                        )
+                        return canonical_base(commit)
+            stripped = partial.lstrip()
+            if stripped.startswith(b"pick "):
+                commit = stripped.split(maxsplit=2)[1].decode(
+                    "ascii",
+                    errors="strict",
+                )
+                return canonical_base(commit)
+    return None
 
 
 def reject_non_rebase_operations() -> None:
@@ -286,17 +362,16 @@ def remote_refs_containing(commit: str) -> list[str]:
 
 
 def reject_shared_commits(commits: list[str]) -> None:
-    """Reject rewriting any commit visible through a remote-tracking ref."""
-    shared = []
-    for commit in commits:
-        refs = remote_refs_containing(commit)
-        if refs:
-            shared.append((commit, refs))
-    if not shared:
+    """Reject one oldest-first linear chain visible through a remote ref."""
+    if not commits:
         return
-    details = "\n".join(f"  {commit}: {', '.join(refs)}" for commit, refs in shared)
+    oldest = commits[0]
+    refs = remote_refs_containing(oldest)
+    if not refs:
+        return
     raise SystemExit(
-        "refusing to rewrite commits contained in remote-tracking refs:\n" + details
+        "refusing to rewrite a commit range contained in remote-tracking refs:\n"
+        f"  {oldest}: {', '.join(refs)}"
     )
 
 
@@ -543,6 +618,8 @@ def original_document(base: str, recovery_ref: str) -> dict[str, Any]:
 def compare_invariants(
     originals: list[dict[str, Any]],
     current: list[dict[str, Any]],
+    *,
+    include_signature: bool = True,
 ) -> list[str]:
     """Compare a current range to its message-only invariants."""
     errors: list[str] = []
@@ -552,7 +629,8 @@ def compare_invariants(
         ]
     for original, candidate in zip(originals, current, strict=True):
         position = original["position"]
-        for field in ("tree", "author", "signed"):
+        fields = ("tree", "author", "signed") if include_signature else ("tree", "author")
+        for field in fields:
             if candidate.get(field) != original.get(field):
                 errors.append(
                     f"position {position}: {field} changed during message refinement"
@@ -634,7 +712,9 @@ def validate_checkpoint(
         )
     original_shas = [record["sha"] for record in originals if "sha" in record]
     current_shas = range_commits(base, allow_empty=True)
-    reject_shared_commits(list(dict.fromkeys([*original_shas, *current_shas])))
+    reject_shared_commits(original_shas)
+    if current_shas != original_shas:
+        reject_shared_commits(current_shas)
     if require_current and not rebase_active:
         current = records_for(base)
         errors.extend(compare_invariants(originals, current))
@@ -832,6 +912,198 @@ def validate_audit_document(
         raise SystemExit("refine-commit-messages audit failed:\n" + "\n".join(errors))
 
 
+def build_rewrite_plan(
+    audit: dict[str, Any],
+    scan: dict[str, Any],
+) -> dict[str, Any]:
+    """Freeze one validated audit as a position-indexed rewrite plan."""
+    reword_positions = [
+        position
+        for position, entry in enumerate(audit["commits"], start=1)
+        if entry["verdict"] == "REWORD"
+    ]
+    return {
+        "schema": 1,
+        "base": scan["base"],
+        "source_head": scan["head"],
+        "scan": scan,
+        "audit": audit,
+        "reword_positions": reword_positions,
+    }
+
+
+def load_rewrite_plan() -> dict[str, Any]:
+    """Load and validate the frozen audit used by the one-pass rewrite."""
+    plan = load_json(REWRITE_PLAN_PATH)
+    scan = plan.get("scan")
+    audit = plan.get("audit")
+    positions = plan.get("reword_positions")
+    if (
+        plan.get("schema") != 1
+        or not isinstance(scan, dict)
+        or not isinstance(audit, dict)
+        or not isinstance(positions, list)
+        or not all(isinstance(position, int) for position in positions)
+    ):
+        raise SystemExit("invalid refine-commit-messages rewrite plan")
+    if (
+        plan.get("base") != scan.get("base")
+        or plan.get("source_head") != scan.get("head")
+        or scan.get("mode") != "refine"
+    ):
+        raise SystemExit("rewrite plan does not match its source scan")
+    validate_audit_document(
+        audit,
+        scan,
+        allow_reword=True,
+        expected_mode="refine",
+    )
+    expected_positions = [
+        position
+        for position, entry in enumerate(audit["commits"], start=1)
+        if entry["verdict"] == "REWORD"
+    ]
+    if positions != expected_positions or not positions:
+        raise SystemExit("rewrite plan must contain every REWORD position in order")
+    return plan
+
+
+def validate_rewrite_plan_binding(
+    plan: dict[str, Any],
+    checkpoint: dict[str, Any],
+    checkpoint_base: str,
+) -> None:
+    """Require the frozen plan to match the active checkpoint attempt."""
+    if (
+        plan["base"] != checkpoint_base
+        or checkpoint.get("rewrite_source_head") != plan["source_head"]
+        or checkpoint.get("rewrite_positions") != plan["reword_positions"]
+    ):
+        raise SystemExit("rewrite plan does not match the active checkpoint attempt")
+
+
+def require_rewrite_helper(checkpoint: dict[str, Any]) -> None:
+    """Require an internal rebase callback to use the frozen helper copy."""
+    configured = checkpoint.get("rewrite_helper")
+    try:
+        expected = rewrite_helper_snapshot_path().resolve(strict=True)
+        current = Path(__file__).resolve(strict=True)
+    except OSError as error:
+        raise SystemExit(
+            "cannot resolve the checkpoint rewrite-helper snapshot"
+        ) from error
+    if configured != str(expected) or current != expected:
+        raise SystemExit(
+            "rewrite callback is not running from the checkpoint helper snapshot"
+        )
+
+
+def rewrite_entry_path(position: int) -> Path:
+    """Return the state path for one constant-size rewrite entry."""
+    return STATE_DIR / f"rewrite-entry-{position}.json"
+
+
+def write_rewrite_entries(plan: dict[str, Any]) -> None:
+    """Write one independently verifiable record for each rebase position."""
+    for position, (source, audit_entry) in enumerate(
+        zip(
+            plan["scan"]["commits"],
+            plan["audit"]["commits"],
+            strict=True,
+        ),
+        start=1,
+    ):
+        reword = audit_entry["verdict"] == "REWORD"
+        write_json(
+            rewrite_entry_path(position),
+            {
+                "schema": 1,
+                "base": plan["base"],
+                "source_head": plan["source_head"],
+                "position": position,
+                "source_sha": source["sha"],
+                "tree": source["tree"],
+                "author": source["author"],
+                "signed": source["signed"],
+                "reword": reword,
+                "source_message": source["message"],
+                "expected_message": (
+                    audit_entry["proposed_message"].rstrip("\n")
+                    if reword
+                    else source["message"]
+                ),
+            },
+        )
+
+
+def load_rewrite_entry(position: int) -> dict[str, Any]:
+    """Load one frozen position record without rereading the complete plan."""
+    entry = load_json(rewrite_entry_path(position))
+    required_strings = (
+        "base",
+        "source_head",
+        "source_sha",
+        "tree",
+        "author",
+        "expected_message",
+    )
+    if (
+        entry.get("schema") != 1
+        or entry.get("position") != position
+        or not all(nonempty_string(entry.get(field)) for field in required_strings)
+        or not isinstance(entry.get("source_message"), str)
+        or not isinstance(entry.get("signed"), bool)
+        or not isinstance(entry.get("reword"), bool)
+    ):
+        raise SystemExit(f"invalid rewrite entry for position {position}")
+    return entry
+
+
+def finalized_audit(
+    plan: dict[str, Any],
+    scan: dict[str, Any],
+) -> dict[str, Any]:
+    """Translate a successfully applied rewrite plan into an all-KEEP audit."""
+    source_audit = plan["audit"]
+    entries: list[dict[str, Any]] = []
+    for source_entry, current in zip(
+        source_audit["commits"],
+        scan["commits"],
+        strict=True,
+    ):
+        reworded = source_entry["verdict"] == "REWORD"
+        entry: dict[str, Any] = {
+            "sha": current["sha"],
+            "subject": current["subject"],
+            "signals": current["signals"],
+            "verdict": "KEEP",
+            "reason": (
+                "The replacement now matches the audited patch and series position."
+                if reworded
+                else source_entry["reason"]
+            ),
+            "patch_fidelity": source_entry["patch_fidelity"],
+        }
+        if "series_transition" in source_entry:
+            entry["series_transition"] = source_entry["series_transition"]
+        false_positives = source_entry.get(
+            "proposed_signal_false_positives"
+            if reworded
+            else "signal_false_positives"
+        )
+        if false_positives:
+            entry["signal_false_positives"] = false_positives
+        entries.append(entry)
+    return {
+        "schema": 1,
+        "mode": "refine",
+        "base": scan["base"],
+        "head": scan["head"],
+        "conventions": source_audit["conventions"],
+        "commits": entries,
+    }
+
+
 def cmd_state_dir(_: argparse.Namespace) -> None:
     """Print the state directory."""
     print(STATE_DIR)
@@ -996,9 +1268,8 @@ def cmd_validate_audit(args: argparse.Namespace) -> None:
     print(f"audit valid for {scan['commit_count']} commits")
 
 
-def cmd_edit_first(args: argparse.Namespace) -> None:
-    """Turn the first actionable rebase todo command from pick into edit."""
-    supplied_path = args.todo_file
+def checked_todo_path(supplied_path: Path) -> Path:
+    """Resolve a rebase todo only inside the current worktree's Git directory."""
     if supplied_path.is_symlink():
         raise SystemExit(f"refusing to edit a symlinked rebase todo: {supplied_path}")
     try:
@@ -1018,23 +1289,11 @@ def cmd_edit_first(args: argparse.Namespace) -> None:
         or todo_path not in expected_paths
     ):
         raise SystemExit(f"refusing to edit an unsafe rebase todo: {todo_path}")
+    return todo_path
 
-    lines = todo_path.read_text(encoding="utf-8").splitlines(keepends=True)
-    for index, line in enumerate(lines):
-        stripped = line.lstrip()
-        if not stripped.strip() or stripped.startswith("#"):
-            continue
-        if not stripped.startswith("pick "):
-            command = stripped.split(maxsplit=1)[0]
-            raise SystemExit(
-                f"expected the first rebase command to be 'pick', found {command!r}"
-            )
-        indentation = line[: len(line) - len(stripped)]
-        lines[index] = indentation + "edit " + stripped.removeprefix("pick ")
-        break
-    else:
-        raise SystemExit("rebase todo has no actionable command")
 
+def replace_todo(todo_path: Path, lines: list[str]) -> None:
+    """Atomically replace one validated rebase todo."""
     mode = todo_path.stat().st_mode & 0o777
     temporary_name: str | None = None
     try:
@@ -1052,6 +1311,81 @@ def cmd_edit_first(args: argparse.Namespace) -> None:
     finally:
         if temporary_name is not None:
             Path(temporary_name).unlink(missing_ok=True)
+
+
+def cmd_edit_first(args: argparse.Namespace) -> None:
+    """Turn the first actionable rebase todo command from pick into edit."""
+    todo_path = checked_todo_path(args.todo_file)
+    lines = todo_path.read_text(encoding="utf-8").splitlines(keepends=True)
+    for index, line in enumerate(lines):
+        stripped = line.lstrip()
+        if not stripped.strip() or stripped.startswith("#"):
+            continue
+        if not stripped.startswith("pick "):
+            command = stripped.split(maxsplit=1)[0]
+            raise SystemExit(
+                f"expected the first rebase command to be 'pick', found {command!r}"
+            )
+        indentation = line[: len(line) - len(stripped)]
+        lines[index] = indentation + "edit " + stripped.removeprefix("pick ")
+        break
+    else:
+        raise SystemExit("rebase todo has no actionable command")
+    replace_todo(todo_path, lines)
+
+
+def cmd_prepare_todo(args: argparse.Namespace) -> None:
+    """Attach one invariant-normalizing callback to every rebase position."""
+    data, checkpoint_base, rebase_active, _ = validate_checkpoint(
+        require_current=False
+    )
+    if data.get("phase") != "applying" or not rebase_active:
+        raise SystemExit("rewrite-plan sequence editor requires the applying phase")
+    require_rewrite_helper(data)
+    plan = load_rewrite_plan()
+    validate_rewrite_plan_binding(plan, data, checkpoint_base)
+    todo_path = checked_todo_path(args.todo_file)
+    source_commits = plan["scan"]["commits"]
+    output: list[str] = []
+    position = 0
+    for line in todo_path.read_text(encoding="utf-8").splitlines(keepends=True):
+        stripped = line.lstrip()
+        if not stripped.strip() or stripped.startswith("#"):
+            output.append(line)
+            continue
+        parts = stripped.split(maxsplit=2)
+        command = parts[0]
+        if command != "pick" or len(parts) < 2:
+            raise SystemExit(
+                "rewrite-plan rebase expected only pick commands, "
+                f"found {command!r}"
+            )
+        position += 1
+        if position > len(source_commits):
+            raise SystemExit("rewrite-plan rebase contains unexpected commits")
+        commit = canonical_base(parts[1])
+        expected = source_commits[position - 1]["sha"]
+        if commit != expected:
+            raise SystemExit(
+                f"rewrite-plan position {position} is {commit}, expected {expected}"
+            )
+        output.append(line)
+        command_line = shlex.join(
+            [
+                sys.executable,
+                str(Path(__file__).resolve()),
+                "apply-message",
+                "--position",
+                str(position),
+            ]
+        )
+        output.append(f"exec {command_line}\n")
+    if position != len(source_commits):
+        raise SystemExit(
+            "rewrite-plan rebase commit count changed: "
+            f"expected {len(source_commits)}, found {position}"
+        )
+    replace_todo(todo_path, output)
 
 
 def cmd_begin_reword(args: argparse.Namespace) -> None:
@@ -1151,6 +1485,285 @@ def cmd_begin_reword(args: argparse.Namespace) -> None:
     print(f"stopped at position {args.position} for message-only amendment")
 
 
+def cmd_apply_message(args: argparse.Namespace) -> None:
+    """Restore one frozen position's expected message and signature state."""
+    data = load_checkpoint()
+    reject_non_rebase_operations()
+    rebase_active, rebase_branch = active_rebase()
+    branch_ref = data.get("branch_ref")
+    checkpoint_base = data.get("base")
+    original_count = data.get("original_count")
+    rewrite_source_head = data.get("rewrite_source_head")
+    rewrite_positions = data.get("rewrite_positions")
+    if (
+        data.get("schema") != 1
+        or data.get("phase") != "applying"
+        or not rebase_active
+        or not nonempty_string(branch_ref)
+        or rebase_branch != branch_ref
+        or not nonempty_string(checkpoint_base)
+        or not isinstance(original_count, int)
+        or not nonempty_string(rewrite_source_head)
+        or not isinstance(rewrite_positions, list)
+        or not all(isinstance(position, int) for position in rewrite_positions)
+        or not 1 <= args.position <= original_count
+    ):
+        raise SystemExit("apply-message requires the active rewrite-plan rebase")
+    require_rewrite_helper(data)
+    assert isinstance(checkpoint_base, str)
+    assert isinstance(rewrite_source_head, str)
+    entry = load_rewrite_entry(args.position)
+    if (
+        entry["base"] != checkpoint_base
+        or entry["source_head"] != rewrite_source_head
+        or entry["reword"] != (args.position in rewrite_positions)
+    ):
+        raise SystemExit("rewrite entry does not match the active checkpoint attempt")
+    if latest_rebase_pick() != entry["source_sha"]:
+        raise SystemExit(
+            f"apply-message position {args.position} does not match "
+            "the active rebase command"
+        )
+    expected_message = entry["expected_message"]
+    current = commit_record("HEAD", args.position, original_count)
+    errors = compare_invariants(
+        [entry],
+        [{**current, "position": args.position}],
+        include_signature=False,
+    )
+    if errors:
+        raise SystemExit(
+            "rewrite callback changed commit content:\n" + "\n".join(errors)
+        )
+
+    if current["message"] not in {
+        entry["source_message"],
+        expected_message,
+    }:
+        raise SystemExit(
+            f"position {args.position} matches neither its source nor "
+            "its expected message"
+        )
+
+    amended = (
+        current["message"] != expected_message
+        or current["signed"] != entry["signed"]
+    )
+    if amended:
+        signing_option = "--gpg-sign" if entry["signed"] else "--no-gpg-sign"
+        result = subprocess.run(
+            [
+                "git",
+                "--no-optional-locks",
+                "commit",
+                "--amend",
+                "--allow-empty",
+                signing_option,
+                "-F",
+                "-",
+            ],
+            text=True,
+            input=expected_message + "\n",
+            check=False,
+        )
+        if result.returncode:
+            raise SystemExit(
+                f"message or signature amendment failed at position "
+                f"{args.position}; inspect the Git and hook output before resuming"
+            )
+        amended = True
+
+    revised = commit_record("HEAD", args.position, original_count)
+    errors = compare_invariants(
+        [entry],
+        [{**revised, "position": args.position}],
+    )
+    if revised["message"] != expected_message:
+        errors.append(f"position {args.position}: expected message was not applied")
+    if errors:
+        raise SystemExit(
+            "message/signature amendment verification failed:\n"
+            + "\n".join(errors)
+        )
+    action = "verified" if not amended else "normalized"
+    print(f"{action} message and signature at position {args.position}")
+
+
+def finalize_rewrite_plan(base: str) -> None:
+    """Verify one completed rebase and refresh the audit without rereading patches."""
+    data, checkpoint_base, rebase_active, originals = validate_checkpoint(
+        require_current=True
+    )
+    if base != checkpoint_base:
+        raise SystemExit("rewrite plan base does not match the checkpoint")
+    if rebase_active:
+        raise SystemExit("cannot finalize the rewrite plan during a rebase")
+    if data.get("phase") not in {"applying", "rewritten"}:
+        raise SystemExit("no applied rewrite plan is ready to finalize")
+    require_clean_worktree()
+    plan = load_rewrite_plan()
+    validate_rewrite_plan_binding(plan, data, checkpoint_base)
+
+    scan = scan_document(base, mode="refine")
+    errors = compare_invariants(originals, scan["commits"])
+    if len(scan["commits"]) == len(plan["scan"]["commits"]):
+        for position, (source, audit_entry, current) in enumerate(
+            zip(
+                plan["scan"]["commits"],
+                plan["audit"]["commits"],
+                scan["commits"],
+                strict=True,
+            ),
+            start=1,
+        ):
+            expected_message = (
+                audit_entry["proposed_message"].rstrip("\n")
+                if audit_entry["verdict"] == "REWORD"
+                else source["message"]
+            )
+            if current["message"] != expected_message:
+                errors.append(
+                    f"position {position}: current message does not match "
+                    "the validated rewrite plan"
+                )
+    if errors:
+        raise SystemExit(
+            "one-pass message rewrite verification failed:\n" + "\n".join(errors)
+        )
+
+    audit = finalized_audit(plan, scan)
+    validate_audit_document(
+        audit,
+        scan,
+        allow_reword=False,
+        expected_mode="refine",
+    )
+    write_json(SCAN_PATH, scan)
+    write_json(AUDIT_PATH, audit)
+    if data.get("phase") != "rewritten":
+        data["phase"] = "rewritten"
+        data.setdefault("events", []).append(
+            {
+                "at": now(),
+                "event": "finalize-apply",
+                "head": scan["head"],
+                "reword_positions": plan["reword_positions"],
+            }
+        )
+        save_checkpoint(data)
+    print(
+        "one-pass rewrite verified for "
+        f"{len(scan['commits'])} commits and "
+        f"{len(plan['reword_positions'])} replacement messages"
+    )
+
+
+def cmd_apply_audit(args: argparse.Namespace) -> None:
+    """Apply every validated REWORD in one controlled interactive rebase."""
+    data, checkpoint_base, rebase_active, _ = validate_checkpoint(
+        require_current=True
+    )
+    if data.get("phase") == "complete":
+        raise SystemExit(
+            "refine-commit-messages is already complete; start a fresh run "
+            "before applying another audit"
+        )
+    base = canonical_base(args.base)
+    if base != checkpoint_base:
+        raise SystemExit("rewrite base does not match the checkpoint")
+    if rebase_active:
+        raise SystemExit("a checkpoint rebase is already active")
+    require_clean_worktree()
+    scan = scan_document(base, mode="refine")
+    if load_json(SCAN_PATH) != scan:
+        raise SystemExit("scan.json is stale; run scan again")
+    audit = load_json(AUDIT_PATH)
+    validate_audit_document(
+        audit,
+        scan,
+        allow_reword=True,
+        expected_mode="refine",
+    )
+    plan = build_rewrite_plan(audit, scan)
+    if not plan["reword_positions"]:
+        raise SystemExit("audit has no REWORD entries; proceed to completion")
+    write_json(REWRITE_PLAN_PATH, plan)
+    write_rewrite_entries(plan)
+    rewrite_helper = snapshot_rewrite_helper()
+
+    data["phase"] = "applying"
+    data["rewrite_helper"] = str(rewrite_helper)
+    data["rewrite_source_head"] = plan["source_head"]
+    data["rewrite_positions"] = plan["reword_positions"]
+    data.setdefault("events", []).append(
+        {
+            "at": now(),
+            "event": "apply-audit",
+            "source_head": scan["head"],
+            "reword_positions": plan["reword_positions"],
+        }
+    )
+    save_checkpoint(data)
+
+    environment = os.environ.copy()
+    environment["GIT_SEQUENCE_EDITOR"] = shlex.join(
+        [
+            sys.executable,
+            str(rewrite_helper),
+            "prepare-todo",
+        ]
+    )
+    result = subprocess.run(
+        [
+            "git",
+            "--no-optional-locks",
+            "-c",
+            "rebase.abbreviateCommands=false",
+            "-c",
+            "rebase.autoSquash=false",
+            "-c",
+            "rebase.updateRefs=false",
+            "-c",
+            "rebase.rebaseMerges=false",
+            "-c",
+            "rebase.autoStash=false",
+            "-c",
+            "rebase.rescheduleFailedExec=true",
+            "-c",
+            "commit.gpgSign=false",
+            "rebase",
+            "--keep-empty",
+            "-i",
+            base,
+        ],
+        text=True,
+        env=environment,
+        check=False,
+    )
+    if result.returncode:
+        active_after, _ = active_rebase()
+        if not active_after and git_output("rev-parse", "HEAD") == scan["head"]:
+            raise SystemExit(
+                "one-pass message rewrite did not start; inspect the rebase "
+                "error, then rerun apply-audit from the existing checkpoint"
+            )
+        if not active_after:
+            raise SystemExit(
+                "one-pass message rewrite ended after HEAD changed; run "
+                "finalize-apply to verify the result or use the recovery ref"
+            )
+        raise SystemExit(
+            "one-pass message rewrite stopped; inspect the active rebase, "
+            "then continue it and run finalize-apply"
+        )
+    finalize_rewrite_plan(base)
+
+
+def cmd_finalize_apply(args: argparse.Namespace) -> None:
+    """Finalize an applied rewrite plan after an interrupted caller resumes it."""
+    finalize_rewrite_plan(canonical_base(args.base))
+
+
 def load_external_json(path: Path) -> dict[str, Any]:
     """Load a caller-selected audit-only JSON file."""
     if path.is_symlink() or not path.is_file():
@@ -1223,7 +1836,7 @@ def cmd_complete(args: argparse.Namespace) -> None:
         allow_reword=False,
         expected_mode="refine",
     )
-    current = records_for(base)
+    current = scan["commits"]
     errors = compare_invariants(originals, current)
     if errors:
         raise SystemExit("message-only completion failed:\n" + "\n".join(errors))
@@ -1298,11 +1911,27 @@ def build_parser() -> argparse.ArgumentParser:
     edit_first.add_argument("todo_file", type=Path)
     edit_first.set_defaults(func=cmd_edit_first)
 
+    prepare_todo = commands.add_parser("prepare-todo")
+    prepare_todo.add_argument("todo_file", type=Path)
+    prepare_todo.set_defaults(func=cmd_prepare_todo)
+
     begin_reword = commands.add_parser("begin-reword")
     begin_reword.add_argument("--base", required=True)
     begin_reword.add_argument("--position", required=True, type=int)
     begin_reword.add_argument("--target", required=True)
     begin_reword.set_defaults(func=cmd_begin_reword)
+
+    apply_message = commands.add_parser("apply-message")
+    apply_message.add_argument("--position", required=True, type=int)
+    apply_message.set_defaults(func=cmd_apply_message)
+
+    apply_audit = commands.add_parser("apply-audit")
+    apply_audit.add_argument("--base", required=True)
+    apply_audit.set_defaults(func=cmd_apply_audit)
+
+    finalize_apply = commands.add_parser("finalize-apply")
+    finalize_apply.add_argument("--base", required=True)
+    finalize_apply.set_defaults(func=cmd_finalize_apply)
 
     verify_head = commands.add_parser("verify-head")
     verify_head.add_argument("--position", required=True, type=int)

--- a/assets/codex-skills/internal/commit-message-drafter.md
+++ b/assets/codex-skills/internal/commit-message-drafter.md
@@ -29,6 +29,8 @@ Expect the caller to provide:
 - for historical mode, the target commit's full SHA and series position
 - whether this is a single commit or part of a series
 - the current commit's one-clause purpose
+- for a series, its overall goal, the selected state at this position, and the
+  immediately preceding and following index entries
 - whether this is the final commit in the series
 - whether this is the penultimate commit in the series, when known
 - any repository-specific commit rules already discovered
@@ -57,11 +59,17 @@ Prefer the smallest number of commands that gives a confident answer.
 For historical mode, leave the index and worktree out of the analysis:
 
 1. `git show --stat --patch --find-renames TARGET_SHA` for the exact patch
-2. `git show TARGET_SHA^:<path>` for representative parent-state paths
-3. `git log --reverse --format='%H%n%B%n---' BASE_SHA..SERIES_HEAD` for the
-   cumulative narrative and adjacent fourth-paragraph transitions
+2. the caller's series goal, selected-state summary, and adjacent index entries
+   for cumulative narrative and fourth-paragraph transitions
+3. `git show TARGET_SHA^:<path>` only when representative parent-state content
+   is needed to verify that summary
 4. representative path history, repository guidance, and the commit hook as
    needed
+
+Do not reread the complete raw series when the caller supplied an indexed
+summary. Inspect an adjacent commit directly only when its supplied transition
+is ambiguous. Fall back to a range-wide log only when essential series context
+is missing and cannot be recovered from the target and its neighbors.
 
 If historical mode lacks an exact target SHA, report the missing input instead
 of falling back to `git diff --cached`.

--- a/assets/codex-skills/refine-commit-messages/SKILL.md
+++ b/assets/codex-skills/refine-commit-messages/SKILL.md
@@ -35,9 +35,27 @@ checkpoint to resume.
 Before either mode, read repository guidance, representative recent messages,
 and the commit-message hook. Repository-specific rules override the bundled
 fallback rules. Use `.agents/internal/commit-message-drafter.md` in its
-historical-commit mode when installed. Give it the target SHA, parent state,
-patch, complete ordered series, position, and discovered rules; never ask it
-to inspect the clean staged index for an already-committed patch.
+historical-commit mode when installed.
+
+Build one compact series index before drafting. Record the base, source head,
+and overall goal once. For each position, record its SHA, subject, narrative
+role, one plain-language sentence describing the patch outcome, and only the
+prior capabilities needed to understand that change. Do not copy the whole
+prefix of earlier entries into each new entry. Inspect each patch once in
+order and update the index with that commit's state change.
+
+For an individual draft, provide the target SHA, relevant parent state, patch,
+overall goal, target index entry, adjacent entries, and discovered rules. Do
+not resend the full index or reread the complete raw series for every commit,
+and never ask the drafter to inspect the clean staged index for an
+already-committed patch.
+
+Persist the index as `series-index.json`, bound to the canonical base and
+source head. In audit mode, keep it under the external audit temporary
+directory. In default mode, write it under
+`$REFINE_MESSAGES_STATE_DIR` after `start`. Reuse a matching index after
+context compaction or `resume`; never repeat the range-wide semantic read just
+to reconstruct lost working context.
 
 ## Audit mode
 
@@ -55,10 +73,10 @@ REFINE_MESSAGES_HELPER=.agents/skills/refine-commit-messages/scripts/refine-comm
 BASE_SHA=$(python3 "$REFINE_MESSAGES_HELPER" check-range --audit-only --base "$BASE_SHA")
 AUDIT_TMP=$(mktemp -d)
 python3 "$REFINE_MESSAGES_HELPER" inspect --base "$BASE_SHA" > "$AUDIT_TMP/scan.json"
-git --no-optional-locks log --reverse --format='%H%n%B%n---' "$BASE_SHA"..HEAD
 ```
 
-Inspect every patch as well as every message:
+`scan.json` contains every message and its mechanical signals. Inspect the
+patches once:
 
 ```bash
 git --no-optional-locks log --reverse --stat --patch --find-renames "$BASE_SHA"..HEAD
@@ -111,8 +129,9 @@ python3 "$REFINE_MESSAGES_HELPER" status --json
 
 Do not read or reuse artifacts from an older run before `start`.
 If the range contains signed commits, ensure the configured signing mechanism
-can re-sign replacements. `verify-head` rejects a rewrite that strips or adds
-signature presence.
+can re-sign them. The one-pass callbacks explicitly re-sign originally signed
+positions and keep originally unsigned positions unsigned; a signing failure
+stops the rebase.
 
 ## Resume
 
@@ -129,11 +148,35 @@ RECOVERY_REF=$(python3 "$REFINE_MESSAGES_HELPER" recovery-ref)
 git --no-optional-locks show-ref --verify "$RECOVERY_REF"
 ```
 
-If a rebase is active, inspect `git status`, its todo/done files, and the last
-checkpoint event. Continue only when they identify the same message edit and
-series position. Aborting that rebase is safe; never abort and then call
-`start`. Outside a rebase, `check-resume` requires the exact original tree
-sequence and author metadata to remain intact.
+Use the checkpoint phase reported by `status`. For the current `applying`
+phase, inspect `git status`, the rebase todo/done files, and the last checkpoint
+event. Continue only when they identify the same rewrite plan and series
+position. After resolving a transient hook failure or other understood stop,
+run:
+
+```bash
+git --no-optional-locks -c commit.gpgSign=false rebase --continue
+python3 "$REFINE_MESSAGES_HELPER" finalize-apply --base "$BASE_SHA"
+```
+
+If no rebase is active while the phase is `applying`, compare `HEAD` with the
+checkpoint's `rewrite_source_head`. An equal value means the rebase never
+started or was aborted; fix the cause and rerun `apply-audit`. A different
+value means the rebase changed history, so run only `finalize-apply` and let it
+verify the result. Aborting the rebase is safe; never abort and then call
+`start`. If a message itself fails the commit hook, abort the controlled
+rebase, correct that proposal in `audit.json`, and rerun `apply-audit` from the
+existing checkpoint. Outside a rebase,
+`check-resume` requires the exact original tree sequence and author metadata
+to remain intact.
+
+A checkpoint in the older `rewriting` phase predates the one-pass workflow. If
+its rebase is active, abort that rebase to return to the saved pre-step state,
+then run `apply-audit`, which validates the existing audit; do not call
+`start`.
+If no rebase is active, first run `verify` and `scan`, update the audit's
+position-bound SHAs and mechanical signals, and recheck only the message that
+already landed and its neighbors before using `apply-audit`.
 
 ## Audit and rewrite
 
@@ -143,7 +186,8 @@ Generate the current mechanical scan:
 python3 "$REFINE_MESSAGES_HELPER" scan --base "$BASE_SHA"
 ```
 
-Inspect every commit's body and patch. Write
+Use the series index to inspect every commit's body and patch exactly once.
+Write
 `$REFINE_MESSAGES_STATE_DIR/audit.json` with this shape:
 
 ```json
@@ -154,7 +198,7 @@ Inspect every commit's body and patch. Write
   "head": "FULL_CURRENT_HEAD_SHA",
   "conventions": {
     "sources": ["CONTRIBUTING.md", "fallback message guidelines"],
-    "summary": "Concrete paragraph, prefix, tense, and wrapping rules applied"
+    "summary": "Concrete structure, plain-language, term, and wrapping rules"
   },
   "commits": [
     {
@@ -184,49 +228,49 @@ mechanically signaled message because of an explicit repository override, add:
 ]
 ```
 
-Cover every commit exactly once in order. Validate the working audit:
+For a `REWORD`, write `patch_fidelity` and `series_transition` about the
+proposed replacement; the helper carries those findings into the final audit.
+Cover every commit exactly once in order.
+
+If every verdict is `KEEP`, proceed directly to the completion gate. Otherwise
+apply every replacement in one controlled rebase:
 
 ```bash
-python3 "$REFINE_MESSAGES_HELPER" validate-audit --allow-reword --base "$BASE_SHA"
+python3 "$REFINE_MESSAGES_HELPER" apply-audit --base "$BASE_SHA"
 ```
 
-Reword the earliest `REWORD` only. Save its proposed message under the state
-directory, then let the helper create a controlled stop at that exact commit:
-
-```bash
-POSITION=PUT_ONE_BASED_POSITION_HERE
-TARGET_SHA=PUT_CURRENT_FULL_SHA_HERE
-MESSAGE_FILE="$REFINE_MESSAGES_STATE_DIR/message-$POSITION.txt"
-python3 "$REFINE_MESSAGES_HELPER" begin-reword --base "$BASE_SHA" --position "$POSITION" --target "$TARGET_SHA"
-git --no-optional-locks show --stat --patch --find-renames HEAD
-git commit --amend -F "$MESSAGE_FILE"
-python3 "$REFINE_MESSAGES_HELPER" verify-head --position "$POSITION"
-git rebase --continue
-python3 "$REFINE_MESSAGES_HELPER" verify --base "$BASE_SHA"
-```
+`apply-audit` validates `scan.json` and the complete audit before creating a
+rebase. Do not run a separate validation pass first.
 
 Do not stage, edit, reset, split, squash, reorder, or drop content. If a hook
 changes the index or tree, stop and restore from the recovery ref. If a patch
 does not match one coherent message, report that `refine-history` is needed
 instead of changing its boundary here.
 
-`begin-reword` uses a portable sequence editor and command-scoped Git settings
-that disable abbreviated todo commands, autosquash, update-refs, rebase-merges,
-and autostash. Do not replace it with an ad hoc interactive-rebase recipe.
+`apply-audit` freezes the validated audit by series position and adds one
+constant-size verification callback after every pick in a portable rebase
+todo. Each callback restores that position's expected message and signature
+presence while verifying its tree and author. The callbacks run from a frozen
+copy inside the worktree's Git directory, so historical checkouts cannot
+replace the helper. The rebase disables abbreviated todo commands, autosquash,
+update-refs, rebase-merges, and autostash. Afterward, the helper performs one
+linear whole-series check, regenerates `scan.json`, and converts the audit to
+current all-`KEEP` entries.
 
-After each reword, regenerate `scan.json` and rebuild the complete audit from
-the beginning because all descendant SHAs changed. Continue until every entry
-is `KEEP`. Vary fourth-paragraph phrasing while preserving the required series
-position: future work for earlier commits, the singular final commit for the
-penultimate commit, and a conclusion for the final commit.
+Do not rebuild the complete audit merely because rewritten ancestors changed
+descendant SHAs. Reinspect only a message that differs from the validated
+plan, its adjacent transitions, or evidence affected by a changed repository
+rule. If boundaries, order, or patches changed, stop rather than trying to
+repair the audit. Ordinary successful application needs one initial semantic
+audit. Later checks are linear mechanical verification and never repeat
+semantic drafting once per reworded commit.
 
 ## Completion gate
 
-Validate the final all-`KEEP` audit, then complete:
+Reconfirm publication safety, then let the helper validate the final
+all-`KEEP` audit and complete:
 
 ```bash
-python3 "$REFINE_MESSAGES_HELPER" validate-audit --base "$BASE_SHA"
-python3 "$REFINE_MESSAGES_HELPER" verify --base "$BASE_SHA"
 git --no-optional-locks status --short
 git --no-optional-locks branch -a --contains HEAD
 git --no-optional-locks remote -v

--- a/assets/codex-skills/refine-commit-messages/scripts/refine-commit-messages-checkpoint.py
+++ b/assets/codex-skills/refine-commit-messages/scripts/refine-commit-messages-checkpoint.py
@@ -96,6 +96,7 @@ CHECKPOINT_PATH = STATE_DIR / "checkpoint.json"
 PRE_COMMITS_PATH = STATE_DIR / "pre-commits.json"
 SCAN_PATH = STATE_DIR / "scan.json"
 AUDIT_PATH = STATE_DIR / "audit.json"
+REWRITE_PLAN_PATH = STATE_DIR / "rewrite-plan.json"
 
 
 def now() -> str:
@@ -214,6 +215,48 @@ def git_dir() -> Path:
     return Path(git_output("rev-parse", "--absolute-git-dir"))
 
 
+def rewrite_helper_snapshot_path() -> Path:
+    """Return the Git-private path for the active rebase helper copy."""
+    return (
+        git_dir()
+        / "git-stage-batch"
+        / "refine-commit-messages"
+        / "rewrite-helper.py"
+    )
+
+
+def snapshot_rewrite_helper() -> Path:
+    """Freeze this helper outside the tree that the rebase will check out."""
+    target = rewrite_helper_snapshot_path()
+    for directory in (target.parent.parent, target.parent):
+        if directory.is_symlink() or (
+            directory.exists() and not directory.is_dir()
+        ):
+            raise SystemExit(
+                f"refusing to use unsafe rewrite-helper directory: {directory}"
+            )
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.is_symlink() or (target.exists() and not target.is_file()):
+        raise SystemExit(f"refusing to replace unsafe rewrite helper: {target}")
+
+    temporary_name: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "wb",
+            dir=target.parent,
+            prefix=f".{target.name}.",
+            delete=False,
+        ) as temporary:
+            temporary_name = temporary.name
+            temporary.write(Path(__file__).resolve(strict=True).read_bytes())
+        os.chmod(temporary_name, 0o600)
+        os.replace(temporary_name, target)
+    finally:
+        if temporary_name is not None:
+            Path(temporary_name).unlink(missing_ok=True)
+    return target.resolve(strict=True)
+
+
 def current_branch_ref() -> str | None:
     """Return the current symbolic branch ref."""
     result = git_run("symbolic-ref", "-q", "HEAD", check=False)
@@ -231,6 +274,39 @@ def active_rebase() -> tuple[bool, str | None]:
             return True, None
         return True, head_name.read_text(encoding="utf-8").strip() or None
     return False, None
+
+
+def latest_rebase_pick() -> str | None:
+    """Return the most recent original commit named in the active rebase log."""
+    for directory_name in ("rebase-merge", "rebase-apply"):
+        done_path = git_dir() / directory_name / "done"
+        if not done_path.is_file() or done_path.is_symlink():
+            continue
+        with done_path.open("rb") as done_file:
+            remaining = done_path.stat().st_size
+            partial = b""
+            while remaining:
+                block_size = min(8192, remaining)
+                remaining -= block_size
+                done_file.seek(remaining)
+                lines = (done_file.read(block_size) + partial).split(b"\n")
+                partial = lines[0]
+                for raw_line in reversed(lines[1:]):
+                    stripped = raw_line.lstrip()
+                    if stripped.startswith(b"pick "):
+                        commit = stripped.split(maxsplit=2)[1].decode(
+                            "ascii",
+                            errors="strict",
+                        )
+                        return canonical_base(commit)
+            stripped = partial.lstrip()
+            if stripped.startswith(b"pick "):
+                commit = stripped.split(maxsplit=2)[1].decode(
+                    "ascii",
+                    errors="strict",
+                )
+                return canonical_base(commit)
+    return None
 
 
 def reject_non_rebase_operations() -> None:
@@ -286,17 +362,16 @@ def remote_refs_containing(commit: str) -> list[str]:
 
 
 def reject_shared_commits(commits: list[str]) -> None:
-    """Reject rewriting any commit visible through a remote-tracking ref."""
-    shared = []
-    for commit in commits:
-        refs = remote_refs_containing(commit)
-        if refs:
-            shared.append((commit, refs))
-    if not shared:
+    """Reject one oldest-first linear chain visible through a remote ref."""
+    if not commits:
         return
-    details = "\n".join(f"  {commit}: {', '.join(refs)}" for commit, refs in shared)
+    oldest = commits[0]
+    refs = remote_refs_containing(oldest)
+    if not refs:
+        return
     raise SystemExit(
-        "refusing to rewrite commits contained in remote-tracking refs:\n" + details
+        "refusing to rewrite a commit range contained in remote-tracking refs:\n"
+        f"  {oldest}: {', '.join(refs)}"
     )
 
 
@@ -543,6 +618,8 @@ def original_document(base: str, recovery_ref: str) -> dict[str, Any]:
 def compare_invariants(
     originals: list[dict[str, Any]],
     current: list[dict[str, Any]],
+    *,
+    include_signature: bool = True,
 ) -> list[str]:
     """Compare a current range to its message-only invariants."""
     errors: list[str] = []
@@ -552,7 +629,8 @@ def compare_invariants(
         ]
     for original, candidate in zip(originals, current, strict=True):
         position = original["position"]
-        for field in ("tree", "author", "signed"):
+        fields = ("tree", "author", "signed") if include_signature else ("tree", "author")
+        for field in fields:
             if candidate.get(field) != original.get(field):
                 errors.append(
                     f"position {position}: {field} changed during message refinement"
@@ -634,7 +712,9 @@ def validate_checkpoint(
         )
     original_shas = [record["sha"] for record in originals if "sha" in record]
     current_shas = range_commits(base, allow_empty=True)
-    reject_shared_commits(list(dict.fromkeys([*original_shas, *current_shas])))
+    reject_shared_commits(original_shas)
+    if current_shas != original_shas:
+        reject_shared_commits(current_shas)
     if require_current and not rebase_active:
         current = records_for(base)
         errors.extend(compare_invariants(originals, current))
@@ -832,6 +912,198 @@ def validate_audit_document(
         raise SystemExit("refine-commit-messages audit failed:\n" + "\n".join(errors))
 
 
+def build_rewrite_plan(
+    audit: dict[str, Any],
+    scan: dict[str, Any],
+) -> dict[str, Any]:
+    """Freeze one validated audit as a position-indexed rewrite plan."""
+    reword_positions = [
+        position
+        for position, entry in enumerate(audit["commits"], start=1)
+        if entry["verdict"] == "REWORD"
+    ]
+    return {
+        "schema": 1,
+        "base": scan["base"],
+        "source_head": scan["head"],
+        "scan": scan,
+        "audit": audit,
+        "reword_positions": reword_positions,
+    }
+
+
+def load_rewrite_plan() -> dict[str, Any]:
+    """Load and validate the frozen audit used by the one-pass rewrite."""
+    plan = load_json(REWRITE_PLAN_PATH)
+    scan = plan.get("scan")
+    audit = plan.get("audit")
+    positions = plan.get("reword_positions")
+    if (
+        plan.get("schema") != 1
+        or not isinstance(scan, dict)
+        or not isinstance(audit, dict)
+        or not isinstance(positions, list)
+        or not all(isinstance(position, int) for position in positions)
+    ):
+        raise SystemExit("invalid refine-commit-messages rewrite plan")
+    if (
+        plan.get("base") != scan.get("base")
+        or plan.get("source_head") != scan.get("head")
+        or scan.get("mode") != "refine"
+    ):
+        raise SystemExit("rewrite plan does not match its source scan")
+    validate_audit_document(
+        audit,
+        scan,
+        allow_reword=True,
+        expected_mode="refine",
+    )
+    expected_positions = [
+        position
+        for position, entry in enumerate(audit["commits"], start=1)
+        if entry["verdict"] == "REWORD"
+    ]
+    if positions != expected_positions or not positions:
+        raise SystemExit("rewrite plan must contain every REWORD position in order")
+    return plan
+
+
+def validate_rewrite_plan_binding(
+    plan: dict[str, Any],
+    checkpoint: dict[str, Any],
+    checkpoint_base: str,
+) -> None:
+    """Require the frozen plan to match the active checkpoint attempt."""
+    if (
+        plan["base"] != checkpoint_base
+        or checkpoint.get("rewrite_source_head") != plan["source_head"]
+        or checkpoint.get("rewrite_positions") != plan["reword_positions"]
+    ):
+        raise SystemExit("rewrite plan does not match the active checkpoint attempt")
+
+
+def require_rewrite_helper(checkpoint: dict[str, Any]) -> None:
+    """Require an internal rebase callback to use the frozen helper copy."""
+    configured = checkpoint.get("rewrite_helper")
+    try:
+        expected = rewrite_helper_snapshot_path().resolve(strict=True)
+        current = Path(__file__).resolve(strict=True)
+    except OSError as error:
+        raise SystemExit(
+            "cannot resolve the checkpoint rewrite-helper snapshot"
+        ) from error
+    if configured != str(expected) or current != expected:
+        raise SystemExit(
+            "rewrite callback is not running from the checkpoint helper snapshot"
+        )
+
+
+def rewrite_entry_path(position: int) -> Path:
+    """Return the state path for one constant-size rewrite entry."""
+    return STATE_DIR / f"rewrite-entry-{position}.json"
+
+
+def write_rewrite_entries(plan: dict[str, Any]) -> None:
+    """Write one independently verifiable record for each rebase position."""
+    for position, (source, audit_entry) in enumerate(
+        zip(
+            plan["scan"]["commits"],
+            plan["audit"]["commits"],
+            strict=True,
+        ),
+        start=1,
+    ):
+        reword = audit_entry["verdict"] == "REWORD"
+        write_json(
+            rewrite_entry_path(position),
+            {
+                "schema": 1,
+                "base": plan["base"],
+                "source_head": plan["source_head"],
+                "position": position,
+                "source_sha": source["sha"],
+                "tree": source["tree"],
+                "author": source["author"],
+                "signed": source["signed"],
+                "reword": reword,
+                "source_message": source["message"],
+                "expected_message": (
+                    audit_entry["proposed_message"].rstrip("\n")
+                    if reword
+                    else source["message"]
+                ),
+            },
+        )
+
+
+def load_rewrite_entry(position: int) -> dict[str, Any]:
+    """Load one frozen position record without rereading the complete plan."""
+    entry = load_json(rewrite_entry_path(position))
+    required_strings = (
+        "base",
+        "source_head",
+        "source_sha",
+        "tree",
+        "author",
+        "expected_message",
+    )
+    if (
+        entry.get("schema") != 1
+        or entry.get("position") != position
+        or not all(nonempty_string(entry.get(field)) for field in required_strings)
+        or not isinstance(entry.get("source_message"), str)
+        or not isinstance(entry.get("signed"), bool)
+        or not isinstance(entry.get("reword"), bool)
+    ):
+        raise SystemExit(f"invalid rewrite entry for position {position}")
+    return entry
+
+
+def finalized_audit(
+    plan: dict[str, Any],
+    scan: dict[str, Any],
+) -> dict[str, Any]:
+    """Translate a successfully applied rewrite plan into an all-KEEP audit."""
+    source_audit = plan["audit"]
+    entries: list[dict[str, Any]] = []
+    for source_entry, current in zip(
+        source_audit["commits"],
+        scan["commits"],
+        strict=True,
+    ):
+        reworded = source_entry["verdict"] == "REWORD"
+        entry: dict[str, Any] = {
+            "sha": current["sha"],
+            "subject": current["subject"],
+            "signals": current["signals"],
+            "verdict": "KEEP",
+            "reason": (
+                "The replacement now matches the audited patch and series position."
+                if reworded
+                else source_entry["reason"]
+            ),
+            "patch_fidelity": source_entry["patch_fidelity"],
+        }
+        if "series_transition" in source_entry:
+            entry["series_transition"] = source_entry["series_transition"]
+        false_positives = source_entry.get(
+            "proposed_signal_false_positives"
+            if reworded
+            else "signal_false_positives"
+        )
+        if false_positives:
+            entry["signal_false_positives"] = false_positives
+        entries.append(entry)
+    return {
+        "schema": 1,
+        "mode": "refine",
+        "base": scan["base"],
+        "head": scan["head"],
+        "conventions": source_audit["conventions"],
+        "commits": entries,
+    }
+
+
 def cmd_state_dir(_: argparse.Namespace) -> None:
     """Print the state directory."""
     print(STATE_DIR)
@@ -996,9 +1268,8 @@ def cmd_validate_audit(args: argparse.Namespace) -> None:
     print(f"audit valid for {scan['commit_count']} commits")
 
 
-def cmd_edit_first(args: argparse.Namespace) -> None:
-    """Turn the first actionable rebase todo command from pick into edit."""
-    supplied_path = args.todo_file
+def checked_todo_path(supplied_path: Path) -> Path:
+    """Resolve a rebase todo only inside the current worktree's Git directory."""
     if supplied_path.is_symlink():
         raise SystemExit(f"refusing to edit a symlinked rebase todo: {supplied_path}")
     try:
@@ -1018,23 +1289,11 @@ def cmd_edit_first(args: argparse.Namespace) -> None:
         or todo_path not in expected_paths
     ):
         raise SystemExit(f"refusing to edit an unsafe rebase todo: {todo_path}")
+    return todo_path
 
-    lines = todo_path.read_text(encoding="utf-8").splitlines(keepends=True)
-    for index, line in enumerate(lines):
-        stripped = line.lstrip()
-        if not stripped.strip() or stripped.startswith("#"):
-            continue
-        if not stripped.startswith("pick "):
-            command = stripped.split(maxsplit=1)[0]
-            raise SystemExit(
-                f"expected the first rebase command to be 'pick', found {command!r}"
-            )
-        indentation = line[: len(line) - len(stripped)]
-        lines[index] = indentation + "edit " + stripped.removeprefix("pick ")
-        break
-    else:
-        raise SystemExit("rebase todo has no actionable command")
 
+def replace_todo(todo_path: Path, lines: list[str]) -> None:
+    """Atomically replace one validated rebase todo."""
     mode = todo_path.stat().st_mode & 0o777
     temporary_name: str | None = None
     try:
@@ -1052,6 +1311,81 @@ def cmd_edit_first(args: argparse.Namespace) -> None:
     finally:
         if temporary_name is not None:
             Path(temporary_name).unlink(missing_ok=True)
+
+
+def cmd_edit_first(args: argparse.Namespace) -> None:
+    """Turn the first actionable rebase todo command from pick into edit."""
+    todo_path = checked_todo_path(args.todo_file)
+    lines = todo_path.read_text(encoding="utf-8").splitlines(keepends=True)
+    for index, line in enumerate(lines):
+        stripped = line.lstrip()
+        if not stripped.strip() or stripped.startswith("#"):
+            continue
+        if not stripped.startswith("pick "):
+            command = stripped.split(maxsplit=1)[0]
+            raise SystemExit(
+                f"expected the first rebase command to be 'pick', found {command!r}"
+            )
+        indentation = line[: len(line) - len(stripped)]
+        lines[index] = indentation + "edit " + stripped.removeprefix("pick ")
+        break
+    else:
+        raise SystemExit("rebase todo has no actionable command")
+    replace_todo(todo_path, lines)
+
+
+def cmd_prepare_todo(args: argparse.Namespace) -> None:
+    """Attach one invariant-normalizing callback to every rebase position."""
+    data, checkpoint_base, rebase_active, _ = validate_checkpoint(
+        require_current=False
+    )
+    if data.get("phase") != "applying" or not rebase_active:
+        raise SystemExit("rewrite-plan sequence editor requires the applying phase")
+    require_rewrite_helper(data)
+    plan = load_rewrite_plan()
+    validate_rewrite_plan_binding(plan, data, checkpoint_base)
+    todo_path = checked_todo_path(args.todo_file)
+    source_commits = plan["scan"]["commits"]
+    output: list[str] = []
+    position = 0
+    for line in todo_path.read_text(encoding="utf-8").splitlines(keepends=True):
+        stripped = line.lstrip()
+        if not stripped.strip() or stripped.startswith("#"):
+            output.append(line)
+            continue
+        parts = stripped.split(maxsplit=2)
+        command = parts[0]
+        if command != "pick" or len(parts) < 2:
+            raise SystemExit(
+                "rewrite-plan rebase expected only pick commands, "
+                f"found {command!r}"
+            )
+        position += 1
+        if position > len(source_commits):
+            raise SystemExit("rewrite-plan rebase contains unexpected commits")
+        commit = canonical_base(parts[1])
+        expected = source_commits[position - 1]["sha"]
+        if commit != expected:
+            raise SystemExit(
+                f"rewrite-plan position {position} is {commit}, expected {expected}"
+            )
+        output.append(line)
+        command_line = shlex.join(
+            [
+                sys.executable,
+                str(Path(__file__).resolve()),
+                "apply-message",
+                "--position",
+                str(position),
+            ]
+        )
+        output.append(f"exec {command_line}\n")
+    if position != len(source_commits):
+        raise SystemExit(
+            "rewrite-plan rebase commit count changed: "
+            f"expected {len(source_commits)}, found {position}"
+        )
+    replace_todo(todo_path, output)
 
 
 def cmd_begin_reword(args: argparse.Namespace) -> None:
@@ -1151,6 +1485,285 @@ def cmd_begin_reword(args: argparse.Namespace) -> None:
     print(f"stopped at position {args.position} for message-only amendment")
 
 
+def cmd_apply_message(args: argparse.Namespace) -> None:
+    """Restore one frozen position's expected message and signature state."""
+    data = load_checkpoint()
+    reject_non_rebase_operations()
+    rebase_active, rebase_branch = active_rebase()
+    branch_ref = data.get("branch_ref")
+    checkpoint_base = data.get("base")
+    original_count = data.get("original_count")
+    rewrite_source_head = data.get("rewrite_source_head")
+    rewrite_positions = data.get("rewrite_positions")
+    if (
+        data.get("schema") != 1
+        or data.get("phase") != "applying"
+        or not rebase_active
+        or not nonempty_string(branch_ref)
+        or rebase_branch != branch_ref
+        or not nonempty_string(checkpoint_base)
+        or not isinstance(original_count, int)
+        or not nonempty_string(rewrite_source_head)
+        or not isinstance(rewrite_positions, list)
+        or not all(isinstance(position, int) for position in rewrite_positions)
+        or not 1 <= args.position <= original_count
+    ):
+        raise SystemExit("apply-message requires the active rewrite-plan rebase")
+    require_rewrite_helper(data)
+    assert isinstance(checkpoint_base, str)
+    assert isinstance(rewrite_source_head, str)
+    entry = load_rewrite_entry(args.position)
+    if (
+        entry["base"] != checkpoint_base
+        or entry["source_head"] != rewrite_source_head
+        or entry["reword"] != (args.position in rewrite_positions)
+    ):
+        raise SystemExit("rewrite entry does not match the active checkpoint attempt")
+    if latest_rebase_pick() != entry["source_sha"]:
+        raise SystemExit(
+            f"apply-message position {args.position} does not match "
+            "the active rebase command"
+        )
+    expected_message = entry["expected_message"]
+    current = commit_record("HEAD", args.position, original_count)
+    errors = compare_invariants(
+        [entry],
+        [{**current, "position": args.position}],
+        include_signature=False,
+    )
+    if errors:
+        raise SystemExit(
+            "rewrite callback changed commit content:\n" + "\n".join(errors)
+        )
+
+    if current["message"] not in {
+        entry["source_message"],
+        expected_message,
+    }:
+        raise SystemExit(
+            f"position {args.position} matches neither its source nor "
+            "its expected message"
+        )
+
+    amended = (
+        current["message"] != expected_message
+        or current["signed"] != entry["signed"]
+    )
+    if amended:
+        signing_option = "--gpg-sign" if entry["signed"] else "--no-gpg-sign"
+        result = subprocess.run(
+            [
+                "git",
+                "--no-optional-locks",
+                "commit",
+                "--amend",
+                "--allow-empty",
+                signing_option,
+                "-F",
+                "-",
+            ],
+            text=True,
+            input=expected_message + "\n",
+            check=False,
+        )
+        if result.returncode:
+            raise SystemExit(
+                f"message or signature amendment failed at position "
+                f"{args.position}; inspect the Git and hook output before resuming"
+            )
+        amended = True
+
+    revised = commit_record("HEAD", args.position, original_count)
+    errors = compare_invariants(
+        [entry],
+        [{**revised, "position": args.position}],
+    )
+    if revised["message"] != expected_message:
+        errors.append(f"position {args.position}: expected message was not applied")
+    if errors:
+        raise SystemExit(
+            "message/signature amendment verification failed:\n"
+            + "\n".join(errors)
+        )
+    action = "verified" if not amended else "normalized"
+    print(f"{action} message and signature at position {args.position}")
+
+
+def finalize_rewrite_plan(base: str) -> None:
+    """Verify one completed rebase and refresh the audit without rereading patches."""
+    data, checkpoint_base, rebase_active, originals = validate_checkpoint(
+        require_current=True
+    )
+    if base != checkpoint_base:
+        raise SystemExit("rewrite plan base does not match the checkpoint")
+    if rebase_active:
+        raise SystemExit("cannot finalize the rewrite plan during a rebase")
+    if data.get("phase") not in {"applying", "rewritten"}:
+        raise SystemExit("no applied rewrite plan is ready to finalize")
+    require_clean_worktree()
+    plan = load_rewrite_plan()
+    validate_rewrite_plan_binding(plan, data, checkpoint_base)
+
+    scan = scan_document(base, mode="refine")
+    errors = compare_invariants(originals, scan["commits"])
+    if len(scan["commits"]) == len(plan["scan"]["commits"]):
+        for position, (source, audit_entry, current) in enumerate(
+            zip(
+                plan["scan"]["commits"],
+                plan["audit"]["commits"],
+                scan["commits"],
+                strict=True,
+            ),
+            start=1,
+        ):
+            expected_message = (
+                audit_entry["proposed_message"].rstrip("\n")
+                if audit_entry["verdict"] == "REWORD"
+                else source["message"]
+            )
+            if current["message"] != expected_message:
+                errors.append(
+                    f"position {position}: current message does not match "
+                    "the validated rewrite plan"
+                )
+    if errors:
+        raise SystemExit(
+            "one-pass message rewrite verification failed:\n" + "\n".join(errors)
+        )
+
+    audit = finalized_audit(plan, scan)
+    validate_audit_document(
+        audit,
+        scan,
+        allow_reword=False,
+        expected_mode="refine",
+    )
+    write_json(SCAN_PATH, scan)
+    write_json(AUDIT_PATH, audit)
+    if data.get("phase") != "rewritten":
+        data["phase"] = "rewritten"
+        data.setdefault("events", []).append(
+            {
+                "at": now(),
+                "event": "finalize-apply",
+                "head": scan["head"],
+                "reword_positions": plan["reword_positions"],
+            }
+        )
+        save_checkpoint(data)
+    print(
+        "one-pass rewrite verified for "
+        f"{len(scan['commits'])} commits and "
+        f"{len(plan['reword_positions'])} replacement messages"
+    )
+
+
+def cmd_apply_audit(args: argparse.Namespace) -> None:
+    """Apply every validated REWORD in one controlled interactive rebase."""
+    data, checkpoint_base, rebase_active, _ = validate_checkpoint(
+        require_current=True
+    )
+    if data.get("phase") == "complete":
+        raise SystemExit(
+            "refine-commit-messages is already complete; start a fresh run "
+            "before applying another audit"
+        )
+    base = canonical_base(args.base)
+    if base != checkpoint_base:
+        raise SystemExit("rewrite base does not match the checkpoint")
+    if rebase_active:
+        raise SystemExit("a checkpoint rebase is already active")
+    require_clean_worktree()
+    scan = scan_document(base, mode="refine")
+    if load_json(SCAN_PATH) != scan:
+        raise SystemExit("scan.json is stale; run scan again")
+    audit = load_json(AUDIT_PATH)
+    validate_audit_document(
+        audit,
+        scan,
+        allow_reword=True,
+        expected_mode="refine",
+    )
+    plan = build_rewrite_plan(audit, scan)
+    if not plan["reword_positions"]:
+        raise SystemExit("audit has no REWORD entries; proceed to completion")
+    write_json(REWRITE_PLAN_PATH, plan)
+    write_rewrite_entries(plan)
+    rewrite_helper = snapshot_rewrite_helper()
+
+    data["phase"] = "applying"
+    data["rewrite_helper"] = str(rewrite_helper)
+    data["rewrite_source_head"] = plan["source_head"]
+    data["rewrite_positions"] = plan["reword_positions"]
+    data.setdefault("events", []).append(
+        {
+            "at": now(),
+            "event": "apply-audit",
+            "source_head": scan["head"],
+            "reword_positions": plan["reword_positions"],
+        }
+    )
+    save_checkpoint(data)
+
+    environment = os.environ.copy()
+    environment["GIT_SEQUENCE_EDITOR"] = shlex.join(
+        [
+            sys.executable,
+            str(rewrite_helper),
+            "prepare-todo",
+        ]
+    )
+    result = subprocess.run(
+        [
+            "git",
+            "--no-optional-locks",
+            "-c",
+            "rebase.abbreviateCommands=false",
+            "-c",
+            "rebase.autoSquash=false",
+            "-c",
+            "rebase.updateRefs=false",
+            "-c",
+            "rebase.rebaseMerges=false",
+            "-c",
+            "rebase.autoStash=false",
+            "-c",
+            "rebase.rescheduleFailedExec=true",
+            "-c",
+            "commit.gpgSign=false",
+            "rebase",
+            "--keep-empty",
+            "-i",
+            base,
+        ],
+        text=True,
+        env=environment,
+        check=False,
+    )
+    if result.returncode:
+        active_after, _ = active_rebase()
+        if not active_after and git_output("rev-parse", "HEAD") == scan["head"]:
+            raise SystemExit(
+                "one-pass message rewrite did not start; inspect the rebase "
+                "error, then rerun apply-audit from the existing checkpoint"
+            )
+        if not active_after:
+            raise SystemExit(
+                "one-pass message rewrite ended after HEAD changed; run "
+                "finalize-apply to verify the result or use the recovery ref"
+            )
+        raise SystemExit(
+            "one-pass message rewrite stopped; inspect the active rebase, "
+            "then continue it and run finalize-apply"
+        )
+    finalize_rewrite_plan(base)
+
+
+def cmd_finalize_apply(args: argparse.Namespace) -> None:
+    """Finalize an applied rewrite plan after an interrupted caller resumes it."""
+    finalize_rewrite_plan(canonical_base(args.base))
+
+
 def load_external_json(path: Path) -> dict[str, Any]:
     """Load a caller-selected audit-only JSON file."""
     if path.is_symlink() or not path.is_file():
@@ -1223,7 +1836,7 @@ def cmd_complete(args: argparse.Namespace) -> None:
         allow_reword=False,
         expected_mode="refine",
     )
-    current = records_for(base)
+    current = scan["commits"]
     errors = compare_invariants(originals, current)
     if errors:
         raise SystemExit("message-only completion failed:\n" + "\n".join(errors))
@@ -1298,11 +1911,27 @@ def build_parser() -> argparse.ArgumentParser:
     edit_first.add_argument("todo_file", type=Path)
     edit_first.set_defaults(func=cmd_edit_first)
 
+    prepare_todo = commands.add_parser("prepare-todo")
+    prepare_todo.add_argument("todo_file", type=Path)
+    prepare_todo.set_defaults(func=cmd_prepare_todo)
+
     begin_reword = commands.add_parser("begin-reword")
     begin_reword.add_argument("--base", required=True)
     begin_reword.add_argument("--position", required=True, type=int)
     begin_reword.add_argument("--target", required=True)
     begin_reword.set_defaults(func=cmd_begin_reword)
+
+    apply_message = commands.add_parser("apply-message")
+    apply_message.add_argument("--position", required=True, type=int)
+    apply_message.set_defaults(func=cmd_apply_message)
+
+    apply_audit = commands.add_parser("apply-audit")
+    apply_audit.add_argument("--base", required=True)
+    apply_audit.set_defaults(func=cmd_apply_audit)
+
+    finalize_apply = commands.add_parser("finalize-apply")
+    finalize_apply.add_argument("--base", required=True)
+    finalize_apply.set_defaults(func=cmd_finalize_apply)
 
     verify_head = commands.add_parser("verify-head")
     verify_head.add_argument("--position", required=True, type=int)

--- a/tests/assets/test_refine_commit_messages_checkpoint.py
+++ b/tests/assets/test_refine_commit_messages_checkpoint.py
@@ -65,8 +65,18 @@ def _helper(
     check: bool = True,
 ) -> subprocess.CompletedProcess[str]:
     """Run the bundled message-refinement helper."""
+    return _helper_at(repo, CODEX_HELPER, *args, check=check)
+
+
+def _helper_at(
+    repo: Path,
+    helper: Path,
+    *args: str,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    """Run one installed copy of the message-refinement helper."""
     result = subprocess.run(
-        [sys.executable, str(CODEX_HELPER), *args],
+        [sys.executable, str(helper), *args],
         cwd=repo,
         text=True,
         capture_output=True,
@@ -111,6 +121,89 @@ def _final_message() -> str:
     )
 
 
+def _start_single_reword(
+    repo: Path,
+    base: str,
+    replacement: str,
+    *,
+    helper: Path = CODEX_HELPER,
+) -> Path:
+    """Start a one-commit checkpoint with one validated replacement."""
+    return _start_reword_plan(
+        repo,
+        base,
+        {1: replacement},
+        helper=helper,
+    )
+
+
+def _start_reword_plan(
+    repo: Path,
+    base: str,
+    replacements: dict[int, str],
+    *,
+    helper: Path = CODEX_HELPER,
+) -> Path:
+    """Start a checkpoint with validated replacements by series position."""
+    _helper_at(repo, helper, "start", "--base", base)
+    _helper_at(repo, helper, "scan", "--base", base)
+    state_dir = repo / ".git-stage-batch" / "refine-commit-messages"
+    scan = json.loads((state_dir / "scan.json").read_text(encoding="utf-8"))
+    entries = []
+    for position, entry in enumerate(scan["commits"], start=1):
+        reword = position in replacements
+        audit_entry = {
+            "sha": entry["sha"],
+            "subject": entry["subject"],
+            "signals": entry["signals"],
+            "verdict": "REWORD" if reword else "KEEP",
+            "reason": "The message is checked against its patch and position.",
+            "patch_fidelity": "The proposal describes the complete test patch.",
+        }
+        if len(scan["commits"]) > 1:
+            audit_entry["series_transition"] = (
+                "The message matches its position in the test series."
+            )
+        if reword:
+            audit_entry["proposed_message"] = replacements[position]
+        entries.append(audit_entry)
+    audit = {
+        "schema": 1,
+        "mode": "refine",
+        "base": scan["base"],
+        "head": scan["head"],
+        "conventions": {
+            "sources": ["fallback message guidelines"],
+            "summary": "Position-aware body paragraphs for the test series.",
+        },
+        "commits": entries,
+    }
+    (state_dir / "audit.json").write_text(json.dumps(audit), encoding="utf-8")
+    return state_dir
+
+
+def _enable_fake_signing(repo: Path) -> None:
+    """Configure a deterministic signer that emits a syntactically valid block."""
+    git_dir = Path(
+        _git(repo, "rev-parse", "--absolute-git-dir").stdout.strip()
+    )
+    signer = git_dir / "fake-gpg"
+    signer.write_text(
+        "#!/bin/sh\n"
+        "cat >/dev/null\n"
+        "printf '%s\\n' "
+        "'[GNUPG:] SIG_CREATED D 1 10 00 0 0 0 0 0' >&2\n"
+        "printf '%s\\n' "
+        "'-----BEGIN PGP SIGNATURE-----' "
+        "'dGVzdC1zaWduYXR1cmU=' "
+        "'-----END PGP SIGNATURE-----'\n",
+        encoding="utf-8",
+    )
+    signer.chmod(0o755)
+    _git(repo, "config", "gpg.program", str(signer))
+    _git(repo, "config", "user.signingkey", "test-key")
+
+
 @pytest.fixture
 def git_repo(tmp_path: Path) -> Path:
     """Create a repository with one base commit."""
@@ -143,6 +236,25 @@ def test_public_audit_mode_uses_a_positional_keyword() -> None:
     )
 
 
+def test_skill_applies_one_indexed_audit_in_a_single_rebase() -> None:
+    """Message refinement should not restart a whole-series audit per reword."""
+    codex_skill = CODEX_SKILL.read_text(encoding="utf-8")
+    claude_skill = CLAUDE_SKILL.read_text(encoding="utf-8")
+
+    for skill in (codex_skill, claude_skill):
+        prose = " ".join(skill.split())
+        assert "apply-audit --base" in skill
+        assert "one initial semantic audit" in prose
+        assert "never repeat semantic drafting once per reworded commit" in prose
+        assert "Do not resend the full index" in prose
+        assert "Do not copy the whole prefix of earlier entries" in prose
+        assert "Persist the index as `series-index.json`" in prose
+        assert "--format='%H%n%B%n---'" not in skill
+        assert "validate-audit --allow-reword" not in skill
+        assert "Do not run a separate validation pass first" in prose
+        assert "rebuild the complete audit from the beginning" not in skill
+
+
 def test_message_guidance_requires_low_context_prose() -> None:
     """Drafters should explain repository terms instead of inventing shorthand."""
     for path in (CODEX_GUIDELINES, CLAUDE_GUIDELINES):
@@ -155,6 +267,7 @@ def test_message_guidance_requires_low_context_prose() -> None:
 
     for path in (CODEX_DRAFTER, CLAUDE_DRAFTER):
         drafter = " ".join(path.read_text(encoding="utf-8").split())
+        assert "Do not reread the complete raw series" in drafter
         assert "Write for a reader who has never seen the repository" in drafter
 
 
@@ -496,6 +609,427 @@ def test_begin_reword_neutralizes_history_changing_rebase_config(
     assert len(subjects) == 3
     assert subjects[1].startswith("fixup!")
     assert _git(git_repo, "rev-parse", "side-draft").stdout.strip() == second
+
+
+def test_apply_audit_migrates_an_active_legacy_reword_checkpoint(
+    git_repo: Path,
+) -> None:
+    """Aborting an older per-commit stop should preserve its audit and recovery."""
+    base = _git(git_repo, "rev-parse", "HEAD").stdout.strip()
+    source = _commit(git_repo, "Bad message\n")
+    replacement = _message(
+        "core: Expose message inspection",
+        "The project provides a stable message representation.",
+        "Reviewers cannot inspect that representation as a report.",
+        "This commit exposes inspection through a report command.",
+    )
+    state_dir = _start_single_reword(git_repo, base, replacement)
+    checkpoint_before = json.loads(
+        (state_dir / "checkpoint.json").read_text(encoding="utf-8")
+    )
+    _helper(
+        git_repo,
+        "begin-reword",
+        "--base",
+        base,
+        "--position",
+        "1",
+        "--target",
+        source,
+    )
+
+    _git(git_repo, "rebase", "--abort")
+    _helper(git_repo, "validate-audit", "--allow-reword", "--base", base)
+    _helper(git_repo, "apply-audit", "--base", base)
+
+    checkpoint_after = json.loads(
+        (state_dir / "checkpoint.json").read_text(encoding="utf-8")
+    )
+    assert checkpoint_after["recovery_ref"] == checkpoint_before["recovery_ref"]
+    assert [event["event"] for event in checkpoint_after["events"]].count("start") == 1
+    assert (
+        _git(git_repo, "log", "-1", "--format=%B").stdout.rstrip("\n")
+        == replacement.rstrip("\n")
+    )
+    _helper(git_repo, "complete", "--base", base)
+
+
+def test_apply_audit_rewords_the_series_in_one_validated_pass(
+    git_repo: Path,
+) -> None:
+    """One rewrite plan should replace every REWORD without repeated audits."""
+    base = _git(git_repo, "rev-parse", "HEAD").stdout.strip()
+    (git_repo / "opening.txt").write_text("opening\n", encoding="utf-8")
+    _git(git_repo, "add", "opening.txt")
+    _commit(git_repo, "Bad opening message\n")
+    middle_message = _message(
+        "core: classify message requests",
+        "The project provides an interface for message processing.",
+        "Callers still cannot classify requests before executing them.",
+        "This commit continues the workflow by classifying each request.",
+        "The final commit will connect the classified requests.",
+    )
+    (git_repo / "middle.txt").write_text("middle\n", encoding="utf-8")
+    _git(git_repo, "add", "middle.txt")
+    middle = _commit(git_repo, middle_message)
+    (git_repo / "final.txt").write_text("final\n", encoding="utf-8")
+    _git(git_repo, "add", "final.txt")
+    _commit(git_repo, "Bad final message\n")
+    _git(git_repo, "branch", "side-draft", middle)
+    _git(git_repo, "config", "rebase.autoSquash", "true")
+    _git(git_repo, "config", "rebase.updateRefs", "true")
+    _helper(git_repo, "start", "--base", base)
+    _helper(git_repo, "scan", "--base", base)
+
+    state_dir = git_repo / ".git-stage-batch" / "refine-commit-messages"
+    scan = json.loads((state_dir / "scan.json").read_text(encoding="utf-8"))
+    replacements = {1: _opening_message(), 3: _final_message()}
+    audit_entries = []
+    for position, entry in enumerate(scan["commits"], start=1):
+        audit_entry = {
+            "sha": entry["sha"],
+            "subject": entry["subject"],
+            "signals": entry["signals"],
+            "verdict": "REWORD" if position in replacements else "KEEP",
+            "reason": "The message is checked against its exact patch and position.",
+            "patch_fidelity": "The message describes the complete test patch.",
+            "series_transition": "The message matches its role in this three-step series.",
+        }
+        if position in replacements:
+            audit_entry["proposed_message"] = replacements[position]
+        audit_entries.append(audit_entry)
+    audit = {
+        "schema": 1,
+        "mode": "refine",
+        "base": scan["base"],
+        "head": scan["head"],
+        "conventions": {
+            "sources": ["fallback message guidelines"],
+            "summary": "Four body paragraphs with position-aware transitions.",
+        },
+        "commits": audit_entries,
+    }
+    (state_dir / "audit.json").write_text(json.dumps(audit), encoding="utf-8")
+    pre_trees = [entry["tree"] for entry in scan["commits"]]
+    pre_authors = [entry["author"] for entry in scan["commits"]]
+
+    _helper(git_repo, "validate-audit", "--allow-reword", "--base", base)
+    result = _helper(git_repo, "apply-audit", "--base", base)
+
+    current = json.loads((state_dir / "scan.json").read_text(encoding="utf-8"))
+    final_audit = json.loads((state_dir / "audit.json").read_text(encoding="utf-8"))
+    checkpoint = json.loads(
+        (state_dir / "checkpoint.json").read_text(encoding="utf-8")
+    )
+    messages = _git(
+        git_repo,
+        "log",
+        "--reverse",
+        "--format=%B%x00",
+        f"{base}..HEAD",
+    ).stdout.rstrip("\x00\n").split("\x00\n")
+
+    assert "2 replacement messages" in result.stdout
+    assert [message.rstrip("\n") for message in messages] == [
+        _opening_message().rstrip("\n"),
+        middle_message.rstrip("\n"),
+        _final_message().rstrip("\n"),
+    ]
+    assert [entry["tree"] for entry in current["commits"]] == pre_trees
+    assert len(set(pre_trees)) == 3
+    assert [entry["author"] for entry in current["commits"]] == pre_authors
+    assert [entry["verdict"] for entry in final_audit["commits"]] == [
+        "KEEP",
+        "KEEP",
+        "KEEP",
+    ]
+    assert all("proposed_message" not in entry for entry in final_audit["commits"])
+    assert checkpoint["phase"] == "rewritten"
+    assert checkpoint["rewrite_source_head"] == scan["head"]
+    assert checkpoint["rewrite_positions"] == [1, 3]
+    assert Path(checkpoint["rewrite_helper"]).is_file()
+    assert [event["event"] for event in checkpoint["events"]].count(
+        "apply-audit"
+    ) == 1
+    assert (state_dir / "rewrite-entry-1.json").is_file()
+    assert (state_dir / "rewrite-entry-2.json").is_file()
+    assert (state_dir / "rewrite-entry-3.json").is_file()
+    assert _git(git_repo, "rev-parse", "side-draft").stdout.strip() == middle
+    _helper(git_repo, "complete", "--base", base)
+
+
+def test_apply_audit_preserves_mixed_signature_presence(
+    git_repo: Path,
+) -> None:
+    """Each replayed position should restore its own signed or unsigned state."""
+    base = _git(git_repo, "rev-parse", "HEAD").stdout.strip()
+    _enable_fake_signing(git_repo)
+    _git(
+        git_repo,
+        "commit",
+        "--allow-empty",
+        "-q",
+        "--gpg-sign",
+        "-F",
+        "-",
+        input_text=_opening_message(),
+    )
+    _commit(git_repo, "Bad unsigned message\n")
+    state_dir = _start_reword_plan(
+        git_repo,
+        base,
+        {2: _final_message()},
+    )
+    initial_scan = json.loads(
+        (state_dir / "scan.json").read_text(encoding="utf-8")
+    )
+    assert [entry["signed"] for entry in initial_scan["commits"]] == [True, False]
+    _git(git_repo, "config", "commit.gpgSign", "true")
+
+    _helper(git_repo, "apply-audit", "--base", base)
+
+    final_scan = json.loads(
+        (state_dir / "scan.json").read_text(encoding="utf-8")
+    )
+    assert [entry["signed"] for entry in final_scan["commits"]] == [True, False]
+    assert [entry["message"] for entry in final_scan["commits"]] == [
+        _opening_message().rstrip("\n"),
+        _final_message().rstrip("\n"),
+    ]
+    _helper(git_repo, "complete", "--base", base)
+
+
+def test_apply_audit_uses_a_helper_outside_the_rewritten_tree(
+    git_repo: Path,
+) -> None:
+    """Historical checkouts must not replace internal rebase callback code."""
+    base = _git(git_repo, "rev-parse", "HEAD").stdout.strip()
+    installed_helper = (
+        git_repo
+        / ".agents"
+        / "skills"
+        / "refine-commit-messages"
+        / "scripts"
+        / "refine-commit-messages-checkpoint.py"
+    )
+    installed_helper.parent.mkdir(parents=True)
+    installed_helper.write_text(
+        "raise SystemExit('historical helper executed')\n",
+        encoding="utf-8",
+    )
+    _git(git_repo, "add", str(installed_helper.relative_to(git_repo)))
+    _commit(git_repo, "Bad historical-helper message\n")
+    installed_helper.write_bytes(CODEX_HELPER.read_bytes())
+    _git(git_repo, "add", str(installed_helper.relative_to(git_repo)))
+    current_message = _final_message()
+    _commit(git_repo, current_message)
+    replacement = _opening_message()
+    state_dir = _start_reword_plan(
+        git_repo,
+        base,
+        {1: replacement},
+        helper=installed_helper,
+    )
+
+    _helper_at(git_repo, installed_helper, "apply-audit", "--base", base)
+
+    checkpoint = json.loads(
+        (state_dir / "checkpoint.json").read_text(encoding="utf-8")
+    )
+    git_dir = Path(
+        _git(git_repo, "rev-parse", "--absolute-git-dir").stdout.strip()
+    )
+    rewrite_helper = Path(checkpoint["rewrite_helper"])
+    assert rewrite_helper.is_file()
+    assert rewrite_helper.is_relative_to(git_dir)
+    assert rewrite_helper != installed_helper
+    final_scan = json.loads(
+        (state_dir / "scan.json").read_text(encoding="utf-8")
+    )
+    assert [entry["message"] for entry in final_scan["commits"]] == [
+        replacement.rstrip("\n"),
+        current_message.rstrip("\n"),
+    ]
+    _helper_at(git_repo, installed_helper, "complete", "--base", base)
+
+
+def test_apply_audit_handles_a_source_subject_larger_than_one_read_block(
+    git_repo: Path,
+) -> None:
+    """Finding the active pick should not depend on a bounded log-file tail."""
+    base = _git(git_repo, "rev-parse", "HEAD").stdout.strip()
+    _commit(git_repo, "x" * 9000 + "\n")
+    replacement = _message(
+        "core: Expose message inspection",
+        "The project provides a stable message representation.",
+        "Reviewers cannot inspect that representation as a report.",
+        "This commit exposes inspection through a report command.",
+    )
+    _start_single_reword(git_repo, base, replacement)
+
+    _helper(git_repo, "apply-audit", "--base", base)
+
+    assert (
+        _git(git_repo, "log", "-1", "--format=%B").stdout.rstrip("\n")
+        == replacement.rstrip("\n")
+    )
+    _helper(git_repo, "complete", "--base", base)
+
+
+def test_apply_audit_can_retry_when_a_pre_rebase_hook_blocks_start(
+    git_repo: Path,
+) -> None:
+    """A failed rebase preflight should remain retryable from the checkpoint."""
+    base = _git(git_repo, "rev-parse", "HEAD").stdout.strip()
+    source_head = _commit(git_repo, "Bad message\n")
+    replacement = _message(
+        "core: Expose message inspection",
+        "The project provides a stable message representation.",
+        "Reviewers cannot inspect that representation as a report.",
+        "This commit exposes inspection through a report command.",
+    )
+    _start_single_reword(git_repo, base, replacement)
+    git_dir = Path(
+        _git(git_repo, "rev-parse", "--absolute-git-dir").stdout.strip()
+    )
+    hook = git_dir / "hooks" / "pre-rebase"
+    hook.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+    hook.chmod(0o755)
+
+    stopped = _helper(git_repo, "apply-audit", "--base", base, check=False)
+
+    assert stopped.returncode != 0
+    assert "one-pass message rewrite did not start" in stopped.stderr
+    assert not (git_dir / "rebase-merge").exists()
+    assert _git(git_repo, "rev-parse", "HEAD").stdout.strip() == source_head
+    hook.unlink()
+
+    _helper(git_repo, "apply-audit", "--base", base)
+
+    assert (
+        _git(git_repo, "log", "-1", "--format=%B").stdout.rstrip("\n")
+        == replacement.rstrip("\n")
+    )
+    _helper(git_repo, "complete", "--base", base)
+
+
+def test_apply_message_rejects_an_entry_from_another_rewrite_attempt(
+    git_repo: Path,
+) -> None:
+    """Each per-position callback record must stay bound to its checkpoint."""
+    base = _git(git_repo, "rev-parse", "HEAD").stdout.strip()
+    _commit(git_repo, "Bad message\n")
+    replacement = _message(
+        "core: Expose message inspection",
+        "The project provides a stable message representation.",
+        "Reviewers cannot inspect that representation as a report.",
+        "This commit exposes inspection through a report command.",
+    )
+    state_dir = _start_single_reword(git_repo, base, replacement)
+    git_dir = Path(
+        _git(git_repo, "rev-parse", "--absolute-git-dir").stdout.strip()
+    )
+    marker = git_dir / "fail-commit-message-once"
+    marker.write_text("fail\n", encoding="utf-8")
+    hook = git_dir / "hooks" / "commit-msg"
+    hook.write_text(
+        "#!/bin/sh\n"
+        'git_dir=$(git rev-parse --absolute-git-dir)\n'
+        'if test -f "$git_dir/fail-commit-message-once"; then\n'
+        '  rm "$git_dir/fail-commit-message-once"\n'
+        "  exit 1\n"
+        "fi\n",
+        encoding="utf-8",
+    )
+    hook.chmod(0o755)
+    stopped = _helper(git_repo, "apply-audit", "--base", base, check=False)
+    assert stopped.returncode != 0
+
+    entry_path = state_dir / "rewrite-entry-1.json"
+    entry = json.loads(entry_path.read_text(encoding="utf-8"))
+    entry["source_head"] = "0" * 40
+    entry_path.write_text(json.dumps(entry), encoding="utf-8")
+
+    continued = _git(git_repo, "rebase", "--continue", check=False)
+
+    assert continued.returncode != 0
+    assert (
+        "rewrite entry does not match the active checkpoint attempt"
+        in continued.stderr
+    )
+    _git(git_repo, "rebase", "--abort")
+
+
+def test_apply_audit_resumes_after_a_transient_hook_failure(
+    git_repo: Path,
+) -> None:
+    """A rescheduled amendment should finish from the frozen position record."""
+    base = _git(git_repo, "rev-parse", "HEAD").stdout.strip()
+    _commit(git_repo, "Bad message\n")
+    _helper(git_repo, "start", "--base", base)
+    _helper(git_repo, "scan", "--base", base)
+    state_dir = git_repo / ".git-stage-batch" / "refine-commit-messages"
+    scan = json.loads((state_dir / "scan.json").read_text(encoding="utf-8"))
+    entry = scan["commits"][0]
+    replacement = _message(
+        "core: expose message inspection",
+        "The project provides a stable message representation.",
+        "Reviewers cannot inspect that representation as a report.",
+        "This commit exposes inspection through a report command.",
+    )
+    audit = {
+        "schema": 1,
+        "mode": "refine",
+        "base": scan["base"],
+        "head": scan["head"],
+        "conventions": {
+            "sources": ["fallback message guidelines"],
+            "summary": "Three body paragraphs for a standalone commit.",
+        },
+        "commits": [
+            {
+                "sha": entry["sha"],
+                "subject": entry["subject"],
+                "signals": entry["signals"],
+                "verdict": "REWORD",
+                "reason": "The existing message lacks the required narrative.",
+                "patch_fidelity": "The proposal describes the complete test patch.",
+                "proposed_message": replacement,
+            }
+        ],
+    }
+    (state_dir / "audit.json").write_text(json.dumps(audit), encoding="utf-8")
+
+    git_dir = Path(
+        _git(git_repo, "rev-parse", "--absolute-git-dir").stdout.strip()
+    )
+    marker = git_dir / "fail-commit-message-once"
+    marker.write_text("fail\n", encoding="utf-8")
+    hook = git_dir / "hooks" / "commit-msg"
+    hook.write_text(
+        "#!/bin/sh\n"
+        'git_dir=$(git rev-parse --absolute-git-dir)\n'
+        'if test -f "$git_dir/fail-commit-message-once"; then\n'
+        '  rm "$git_dir/fail-commit-message-once"\n'
+        "  exit 1\n"
+        "fi\n",
+        encoding="utf-8",
+    )
+    hook.chmod(0o755)
+
+    stopped = _helper(git_repo, "apply-audit", "--base", base, check=False)
+
+    assert stopped.returncode != 0
+    assert "one-pass message rewrite stopped" in stopped.stderr
+    assert (git_dir / "rebase-merge").is_dir()
+    _git(git_repo, "rebase", "--continue")
+    finalized = _helper(git_repo, "finalize-apply", "--base", base)
+    assert "1 replacement messages" in finalized.stdout
+    assert (
+        _git(git_repo, "log", "-1", "--format=%B").stdout.rstrip("\n")
+        == replacement.rstrip("\n")
+    )
+    _helper(git_repo, "complete", "--base", base)
 
 
 def test_checkpoint_rejects_changes_to_out_of_scope_local_branches(


### PR DESCRIPTION
The commit-message refinement workflow audits existing histories and
checkpoints one message edit at a time. Its Codex and Claude drafters read the
complete commit range to reconstruct each target's series context.

Each replacement changes every later commit identifier and invalidates the
prior audit. The workflow therefore repeats semantic review and complete-range
reads, making the work grow with both the series length and number of edited
messages.

This PR records one compact series index, validates every proposal together,
applies all replacements in one controlled rebase, and performs linear
invariant checks afterward. Both bundled platforms share the behavior, and
tests cover signatures, frozen helpers, legacy checkpoints, long subjects,
and interrupted retries.

Message refinement now needs one semantic audit for an ordinary successful
run. The full final-tree suite previously passed with 3,485 tests and 12 skips;
the post-rebase 26-test focus, targeted Ruff checks, and package build also
pass.
