### PR TITLE
abort: Reject invalid batch recovery snapshots

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -27,6 +27,16 @@ that an undo, redo, or abort operation promises to restore. Checkpoint stack
 refs describe undo and redo order; anchor refs provide reachability. Those are
 separate responsibilities.
 
+The worktree-local `session/abort/batch-refs.json` file is required recovery
+state once `session/abort/head.txt` publishes the active session. Its
+`schema_version` identifies the snapshot format, and its `batches` object
+contains each batch's content ref, optional state ref, and validated metadata.
+Abort loads this snapshot once and validates its complete structure and
+referenced objects before changing HEAD, the index, the worktree, or batch
+refs. Missing, empty, malformed, or unsupported snapshot state leaves the
+session marker and repository-wide ownership record intact for repair and
+retry.
+
 Gitlink entries name commits in a submodule's separate object database. They
 cannot be rooted by refs in the superproject; their availability remains the
 responsibility of the nested repository.

--- a/src/git_stage_batch/commands/abort.py
+++ b/src/git_stage_batch/commands/abort.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import sys
-import json
 
-from ..data.batch_refs import restore_batch_refs
+from ..data.batch_refs import (
+    batch_ref_snapshot_recovery_objects,
+    load_batch_refs_snapshot,
+    restore_batch_refs,
+)
 from ..data.session import clear_session_state
 from ..data.session_ownership import (
     release_session_ownership,
@@ -88,23 +92,28 @@ def command_abort(*, quiet: bool = False) -> None:
         if abort_stash_path.exists()
         else None
     )
-    recovery_objects = [start_point.head_commit, start_point.index_tree, abort_stash]
-    batch_snapshot_path = get_abort_state_directory_path() / "batch-refs.json"
-    try:
-        batch_snapshot = json.loads(read_text_file_contents(batch_snapshot_path))
-    except json.JSONDecodeError:
-        batch_snapshot = {}
-    for batch_state in batch_snapshot.values():
-        recovery_objects.extend(
-            [batch_state.get("commit_sha"), batch_state.get("state_commit_sha")]
-        )
+    batch_snapshot = load_batch_refs_snapshot()
+    recovery_objects: list[str | None] = [
+        start_point.head_commit,
+        start_point.index_tree,
+        abort_stash,
+        *batch_ref_snapshot_recovery_objects(batch_snapshot),
+    ]
     try:
         recovery_anchors = json.loads(
             read_text_file_contents(get_abort_recovery_anchors_file_path())
         )
     except json.JSONDecodeError:
         recovery_anchors = None
-    validate_recovery_objects(recovery_objects, anchors=recovery_anchors)
+    try:
+        validate_recovery_objects(recovery_objects, anchors=recovery_anchors)
+    except CommandError as error:
+        raise CommandError(
+            _(
+                "{error}\nThe session remains active; repair the recovery state "
+                "and run 'git-stage-batch abort' again."
+            ).format(error=error.message)
+        ) from error
 
     # Reset auto-added files first
     if not start_point.is_unborn and get_auto_added_files_file_path().exists():
@@ -199,7 +208,7 @@ def command_abort(*, quiet: bool = False) -> None:
 
     # Restore batch refs to their original state
     # This recreates both git refs and metadata files from the snapshot
-    restore_batch_refs()
+    restore_batch_refs(batch_snapshot)
 
     # Clear all session state (preserves batches and batch-sources)
     # Do this AFTER restore_batch_refs so snapshot file is available

--- a/src/git_stage_batch/data/batch_refs.py
+++ b/src/git_stage_batch/data/batch_refs.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import json
 import shutil
-from typing import TypeAlias, TypedDict, cast
+from typing import NoReturn, TypedDict, cast
 
+from ..batch.state.batch_names import validate_batch_name
+from ..batch.state.metadata_schema import metadata_from_application_dict
 from ..batch.state.metadata_types import BatchMetadataDict
 from ..batch.state.reference_names import BATCH_CONTENT_REF_PREFIX, LEGACY_BATCH_REF_PREFIX
 from ..batch.state.query import read_batch_metadata
@@ -17,10 +19,19 @@ from ..batch.state.references import (
     remove_file_backed_batch_metadata,
     sync_batch_state_refs,
 )
-from ..utils.file_io import read_text_file_contents, write_text_file_contents
+from ..exceptions import BatchMetadataError, CommandError
+from ..i18n import _
+from ..utils.file_io import (
+    read_required_text_file_contents,
+    write_text_file_contents,
+)
 from ..utils.git_command import run_git_command
 from ..utils.git_refs import update_git_refs
+from ..utils.git_repository import object_id_hex_length
 from ..utils.paths import get_batch_directory_path, get_batch_refs_snapshot_file_path
+
+
+BATCH_REF_SNAPSHOT_SCHEMA_VERSION = 1
 
 
 class BatchRefSnapshotEntry(TypedDict):
@@ -31,7 +42,17 @@ class BatchRefSnapshotEntry(TypedDict):
     metadata: BatchMetadataDict
 
 
-BatchRefSnapshot: TypeAlias = dict[str, BatchRefSnapshotEntry]
+class BatchRefSnapshot(TypedDict):
+    """Versioned abort snapshot of every batch reference."""
+
+    schema_version: int
+    batches: dict[str, BatchRefSnapshotEntry]
+
+
+_SNAPSHOT_KEYS = frozenset({"schema_version", "batches"})
+_ENTRY_KEYS = frozenset({"commit_sha", "state_commit_sha", "metadata"})
+_REQUIRED_METADATA_KEYS = frozenset({"note", "created_at", "baseline", "files"})
+_OPTIONAL_METADATA_KEYS = frozenset({"revision"})
 
 
 def _list_batch_content_refs() -> dict[str, str]:
@@ -71,48 +92,254 @@ def _get_batch_state_ref_commit(batch_name: str) -> str | None:
 def snapshot_batch_refs() -> BatchRefSnapshot:
     """Save selected state of all batch refs to snapshot file for abort support.
 
-    Stores a single JSON object mapping batch names to their state:
-    {"batch-name": {"commit_sha": "...", "metadata": {...}}}
+    Stores a versioned JSON object containing a mapping from batch names to
+    their refs and metadata.
 
     This includes complete metadata so dropped batches can be fully restored.
     """
-    snapshot_data: BatchRefSnapshot = {}
+    snapshot_data: BatchRefSnapshot = {
+        "schema_version": BATCH_REF_SNAPSHOT_SCHEMA_VERSION,
+        "batches": {},
+    }
     for batch_name, commit_sha in _list_batch_content_refs().items():
         full_metadata = read_batch_metadata(batch_name)
 
-        snapshot_data[batch_name] = {
+        snapshot_data["batches"][batch_name] = {
             "commit_sha": commit_sha,
             "state_commit_sha": _get_batch_state_ref_commit(batch_name),
             "metadata": full_metadata,
         }
 
-    write_text_file_contents(get_batch_refs_snapshot_file_path(), json.dumps(snapshot_data, indent=2))
+    write_text_file_contents(
+        get_batch_refs_snapshot_file_path(),
+        json.dumps(snapshot_data, indent=2, sort_keys=True) + "\n",
+    )
     return snapshot_data
 
 
-def _decode_batch_ref_snapshot(payload: str) -> BatchRefSnapshot | None:
-    """Return a structurally valid snapshot mapping, or ignore stale garbage."""
-    value: object = json.loads(payload)
+def _invalid_snapshot(detail: str, *, cause: BaseException | None = None) -> NoReturn:
+    snapshot_path = get_batch_refs_snapshot_file_path()
+    error = CommandError(
+        _(
+            "The batch-reference recovery snapshot is {detail}: {path}. "
+            "The session remains active; repair the snapshot and run "
+            "'git-stage-batch abort' again."
+        ).format(detail=detail, path=snapshot_path)
+    )
+    if cause is None:
+        raise error
+    raise error from cause
+
+
+def _validate_snapshot_object_id(
+    value: object,
+    *,
+    batch_name: str,
+    field: str,
+) -> str:
+    object_id_length = object_id_hex_length()
+    if not isinstance(value, str) or len(value) != object_id_length:
+        _invalid_snapshot(
+            _("invalid: batch {batch!r} field {field!r} must be a full object ID").format(
+                batch=batch_name,
+                field=field,
+            )
+        )
+    try:
+        int(value, 16)
+    except ValueError as error:
+        _invalid_snapshot(
+            _("invalid: batch {batch!r} field {field!r} is not hexadecimal").format(
+                batch=batch_name,
+                field=field,
+            ),
+            cause=error,
+        )
+    return value
+
+
+def _decode_batch_ref_snapshot(payload: str) -> BatchRefSnapshot:
+    """Decode and deeply validate one versioned batch-reference snapshot."""
+    try:
+        value: object = json.loads(payload)
+    except json.JSONDecodeError as error:
+        _invalid_snapshot(_("malformed JSON"), cause=error)
+
     if not isinstance(value, dict):
-        return None
-    for batch_name, entry in value.items():
-        if not isinstance(batch_name, str) or not isinstance(entry, dict):
-            return None
-        commit_sha = entry.get("commit_sha")
-        state_commit_sha = entry.get("state_commit_sha")
-        metadata = entry.get("metadata")
-        if not isinstance(commit_sha, str):
-            return None
-        if state_commit_sha is not None and not isinstance(state_commit_sha, str):
-            return None
-        if not isinstance(metadata, dict) or not all(
-            isinstance(key, str) for key in metadata
+        _invalid_snapshot(_("invalid: the top level must be an object"))
+
+    snapshot_keys = set(value)
+    if snapshot_keys != _SNAPSHOT_KEYS:
+        missing = sorted(_SNAPSHOT_KEYS - snapshot_keys)
+        unknown = sorted(snapshot_keys - _SNAPSHOT_KEYS)
+        details = []
+        if missing:
+            details.append(_("missing field(s) {fields}").format(fields=missing))
+        if unknown:
+            details.append(_("unknown field(s) {fields}").format(fields=unknown))
+        _invalid_snapshot(_("invalid: {details}").format(details=", ".join(details)))
+
+    schema_version = value["schema_version"]
+    if type(schema_version) is not int:
+        _invalid_snapshot(_("invalid: 'schema_version' must be an integer"))
+    if schema_version != BATCH_REF_SNAPSHOT_SCHEMA_VERSION:
+        _invalid_snapshot(
+            _(
+                "invalid: unsupported schema version {actual}; expected {expected}"
+            ).format(
+                actual=schema_version,
+                expected=BATCH_REF_SNAPSHOT_SCHEMA_VERSION,
+            )
+        )
+
+    raw_batches = value["batches"]
+    if not isinstance(raw_batches, dict):
+        _invalid_snapshot(_("invalid: 'batches' must be an object"))
+
+    batches: dict[str, BatchRefSnapshotEntry] = {}
+    for raw_batch_name, raw_entry in raw_batches.items():
+        if not isinstance(raw_batch_name, str):
+            _invalid_snapshot(_("invalid: every batch name must be a string"))
+        try:
+            validate_batch_name(raw_batch_name)
+        except CommandError as error:
+            _invalid_snapshot(
+                _("invalid: batch name {batch!r} is not valid ({error})").format(
+                    batch=raw_batch_name,
+                    error=error.message,
+                ),
+                cause=error,
+            )
+
+        if not isinstance(raw_entry, dict):
+            _invalid_snapshot(
+                _("invalid: entry for batch {batch!r} must be an object").format(
+                    batch=raw_batch_name
+                )
+            )
+        entry_keys = set(raw_entry)
+        if entry_keys != _ENTRY_KEYS:
+            _invalid_snapshot(
+                _(
+                    "invalid: entry for batch {batch!r} must contain exactly {fields}"
+                ).format(batch=raw_batch_name, fields=sorted(_ENTRY_KEYS))
+            )
+
+        commit_sha = _validate_snapshot_object_id(
+            raw_entry["commit_sha"],
+            batch_name=raw_batch_name,
+            field="commit_sha",
+        )
+        raw_state_commit_sha = raw_entry["state_commit_sha"]
+        state_commit_sha = (
+            None
+            if raw_state_commit_sha is None
+            else _validate_snapshot_object_id(
+                raw_state_commit_sha,
+                batch_name=raw_batch_name,
+                field="state_commit_sha",
+            )
+        )
+
+        raw_metadata = raw_entry["metadata"]
+        if not isinstance(raw_metadata, dict):
+            _invalid_snapshot(
+                _("invalid: metadata for batch {batch!r} must be an object").format(
+                    batch=raw_batch_name
+                )
+            )
+        metadata_keys = set(raw_metadata)
+        missing_metadata_keys = _REQUIRED_METADATA_KEYS - metadata_keys
+        unknown_metadata_keys = metadata_keys - (
+            _REQUIRED_METADATA_KEYS | _OPTIONAL_METADATA_KEYS
+        )
+        if missing_metadata_keys or unknown_metadata_keys:
+            field_errors = []
+            if missing_metadata_keys:
+                field_errors.append(
+                    _("missing {fields}").format(
+                        fields=sorted(missing_metadata_keys)
+                    )
+                )
+            if unknown_metadata_keys:
+                field_errors.append(
+                    _("unknown {fields}").format(
+                        fields=sorted(unknown_metadata_keys)
+                    )
+                )
+            _invalid_snapshot(
+                _(
+                    "invalid: metadata for batch {batch!r} has an invalid field set "
+                    "({details})"
+                ).format(
+                    batch=raw_batch_name,
+                    details=", ".join(field_errors),
+                )
+            )
+        if "revision" in raw_metadata and not isinstance(
+            raw_metadata["revision"], str
         ):
-            return None
-    return cast(BatchRefSnapshot, value)
+            _invalid_snapshot(
+                _(
+                    "invalid: metadata for batch {batch!r} field 'revision' "
+                    "must be a string"
+                ).format(batch=raw_batch_name)
+            )
+        metadata = cast(BatchMetadataDict, raw_metadata)
+        try:
+            metadata_from_application_dict(raw_batch_name, metadata)
+        except BatchMetadataError as error:
+            _invalid_snapshot(
+                _(
+                    "invalid: metadata for batch {batch!r} is malformed ({error})"
+                ).format(
+                    batch=raw_batch_name,
+                    error=error,
+                ),
+                cause=error,
+            )
+
+        batches[raw_batch_name] = {
+            "commit_sha": commit_sha,
+            "state_commit_sha": state_commit_sha,
+            "metadata": metadata,
+        }
+
+    return {
+        "schema_version": BATCH_REF_SNAPSHOT_SCHEMA_VERSION,
+        "batches": batches,
+    }
 
 
-def restore_batch_refs() -> None:
+def load_batch_refs_snapshot() -> BatchRefSnapshot:
+    """Load required abort recovery state without conflating absence and emptiness."""
+    snapshot_path = get_batch_refs_snapshot_file_path()
+    try:
+        payload = read_required_text_file_contents(snapshot_path)
+    except FileNotFoundError as error:
+        _invalid_snapshot(_("missing"), cause=error)
+    except OSError as error:
+        _invalid_snapshot(_("unreadable"), cause=error)
+    if not payload.strip():
+        _invalid_snapshot(_("empty"))
+    return _decode_batch_ref_snapshot(payload)
+
+
+def batch_ref_snapshot_recovery_objects(
+    snapshot: BatchRefSnapshot,
+) -> list[str | None]:
+    """Return every Git object directly referenced by a batch snapshot."""
+    return [
+        object_name
+        for batch_state in snapshot["batches"].values()
+        for object_name in (
+            batch_state["commit_sha"],
+            batch_state["state_commit_sha"],
+        )
+    ]
+
+
+def restore_batch_refs(snapshot: BatchRefSnapshot) -> None:
     """Restore batch refs from snapshot, reverting all batch changes made during session.
 
     Compares snapshot with selected refs:
@@ -120,19 +347,7 @@ def restore_batch_refs() -> None:
     - Batches in snapshot but not selected: restore (recreate ref + metadata)
     - Batches in both with different SHAs: revert (update ref to snapshot SHA)
     """
-    snapshot_path = get_batch_refs_snapshot_file_path()
-    if not snapshot_path.exists():
-        return
-
-    # Load snapshot
-    try:
-        snapshot_data = _decode_batch_ref_snapshot(
-            read_text_file_contents(snapshot_path)
-        )
-    except json.JSONDecodeError:
-        return
-    if snapshot_data is None:
-        return
+    snapshot_data = snapshot["batches"]
 
     # Get selected batch refs
     selected_batches = _list_batch_content_refs()
@@ -149,7 +364,7 @@ def restore_batch_refs() -> None:
     # Restore/revert batches from snapshot
     for batch_name, batch_state in snapshot_data.items():
         commit_sha = batch_state["commit_sha"]
-        state_commit_sha = batch_state.get("state_commit_sha")
+        state_commit_sha = batch_state["state_commit_sha"]
         full_metadata = batch_state["metadata"]
 
         if state_commit_sha:

--- a/src/git_stage_batch/data/session.py
+++ b/src/git_stage_batch/data/session.py
@@ -6,7 +6,7 @@ import json
 import os
 import shutil
 
-from .batch_refs import snapshot_batch_refs
+from .batch_refs import batch_ref_snapshot_recovery_objects, snapshot_batch_refs
 from .recovery_anchors import anchor_recovery_objects
 from ..utils.session_start_point import (
     resolve_session_start_point,
@@ -312,11 +312,12 @@ def _initialize_abort_state() -> None:
         log_journal("session_stash_created", stash_hash=stash_hash)
 
     batch_snapshot = snapshot_batch_refs()
-    recovery_objects = [start_point.head_commit, stash_hash, start_point.index_tree]
-    for batch_state in batch_snapshot.values():
-        recovery_objects.extend(
-            [batch_state.get("commit_sha"), batch_state.get("state_commit_sha")]
-        )
+    recovery_objects: list[str | None] = [
+        start_point.head_commit,
+        stash_hash,
+        start_point.index_tree,
+        *batch_ref_snapshot_recovery_objects(batch_snapshot),
+    ]
     recovery_anchors = anchor_recovery_objects(recovery_objects)
     write_text_file_contents(
         get_abort_recovery_anchors_file_path(),

--- a/src/git_stage_batch/utils/file_io.py
+++ b/src/git_stage_batch/utils/file_io.py
@@ -31,8 +31,18 @@ PROJECT_FILE_MODE = 0o644
 _PATH_LIST_MAGIC = b"\0git-stage-batch-path-list-v1\0"
 
 
+def read_required_text_file_contents(path: Path) -> str:
+    """Read a required file's text contents with UTF-8 encoding.
+
+    Unlike :func:`read_text_file_contents`, absence is not treated as empty
+    content. Callers that require durable state can therefore distinguish a
+    missing file from a present, zero-length file.
+    """
+    return path.read_text(encoding="utf-8", errors="surrogateescape")
+
+
 def read_text_file_contents(path: Path) -> str:
-    """Read a file's text contents with UTF-8 encoding.
+    """Read an optional file's text contents with UTF-8 encoding.
 
     Args:
         path: Path to the file to read
@@ -40,11 +50,10 @@ def read_text_file_contents(path: Path) -> str:
     Returns:
         File contents as string, or empty string if file doesn't exist
     """
-    return (
-        path.read_text(encoding="utf-8", errors="surrogateescape")
-        if path.exists()
-        else ""
-    )
+    try:
+        return read_required_text_file_contents(path)
+    except FileNotFoundError:
+        return ""
 
 
 def write_text_file_contents(

--- a/tests/data/test_batch_refs.py
+++ b/tests/data/test_batch_refs.py
@@ -7,9 +7,15 @@ import subprocess
 
 import pytest
 
-from git_stage_batch.data.batch_refs import restore_batch_refs, snapshot_batch_refs
+from git_stage_batch.data.batch_refs import (
+    BATCH_REF_SNAPSHOT_SCHEMA_VERSION,
+    load_batch_refs_snapshot,
+    restore_batch_refs,
+    snapshot_batch_refs,
+)
 from git_stage_batch.batch.state.lifecycle import create_batch, update_batch_note
 from git_stage_batch.batch.state.references import get_batch_content_ref_name
+from git_stage_batch.exceptions import CommandError
 from git_stage_batch.utils.file_io import read_text_file_contents
 from git_stage_batch.utils.git_command import run_git_command
 from git_stage_batch.utils.paths import (
@@ -48,7 +54,11 @@ class TestSnapshotBatchRefs:
         assert snapshot_path.exists()
 
         snapshot_data = json.loads(read_text_file_contents(snapshot_path))
-        assert snapshot_data == {}
+        assert snapshot_data == {
+            "schema_version": BATCH_REF_SNAPSHOT_SCHEMA_VERSION,
+            "batches": {},
+        }
+        assert load_batch_refs_snapshot() == snapshot_data
 
     def test_snapshot_with_batches(self, temp_git_repo):
         """Test snapshotting existing batches."""
@@ -72,25 +82,49 @@ class TestSnapshotBatchRefs:
         snapshot_path = get_batch_refs_snapshot_file_path()
         snapshot_data = json.loads(read_text_file_contents(snapshot_path))
 
-        assert batch_name in snapshot_data
-        assert snapshot_data[batch_name]["commit_sha"] == commit_sha
+        assert snapshot_data["schema_version"] == BATCH_REF_SNAPSHOT_SCHEMA_VERSION
+        assert batch_name in snapshot_data["batches"]
+        assert snapshot_data["batches"][batch_name]["commit_sha"] == commit_sha
         # Metadata is now nested under "metadata" key
-        assert snapshot_data[batch_name]["metadata"]["note"] == "Test note"
-        assert snapshot_data[batch_name]["metadata"]["created_at"] == "2026-03-13T12:00:00Z"
+        assert snapshot_data["batches"][batch_name]["metadata"]["note"] == "Test note"
+        assert (
+            snapshot_data["batches"][batch_name]["metadata"]["created_at"]
+            == "2026-03-13T12:00:00Z"
+        )
 
 
 class TestRestoreBatchRefs:
     """Tests for restore_batch_refs function."""
 
-    def test_restore_with_no_snapshot(self, temp_git_repo):
-        """Test restoring when no snapshot exists."""
-        # Should not error
-        restore_batch_refs()
+    def test_load_requires_snapshot(self, temp_git_repo):
+        """Required recovery state must not treat absence as an empty snapshot."""
+        with pytest.raises(CommandError, match="recovery snapshot is missing"):
+            load_batch_refs_snapshot()
+
+    @pytest.mark.parametrize(
+        "snapshot",
+        [
+            {"schema_version": True, "batches": {}},
+            {"schema_version": BATCH_REF_SNAPSHOT_SCHEMA_VERSION + 1, "batches": {}},
+            {
+                "schema_version": BATCH_REF_SNAPSHOT_SCHEMA_VERSION,
+                "batches": [],
+            },
+        ],
+    )
+    def test_load_rejects_invalid_snapshot_schema(self, temp_git_repo, snapshot):
+        write_text_file_contents(
+            get_batch_refs_snapshot_file_path(),
+            json.dumps(snapshot),
+        )
+
+        with pytest.raises(CommandError, match="recovery snapshot is invalid"):
+            load_batch_refs_snapshot()
 
     def test_restore_drops_new_batches(self, temp_git_repo):
         """Test that batches created after snapshot are dropped."""
         # Create empty snapshot
-        snapshot_batch_refs()
+        snapshot = snapshot_batch_refs()
 
         # Create a new batch
         batch_name = "new-batch"
@@ -102,8 +136,10 @@ class TestRestoreBatchRefs:
         result = run_git_command(["show-ref", f"refs/batches/{batch_name}"], check=False)
         assert result.returncode == 0
 
-        # Restore
-        restore_batch_refs()
+        # Restoration consumes the preflighted object instead of rereading
+        # recovery state that can change after preflight.
+        get_batch_refs_snapshot_file_path().unlink()
+        restore_batch_refs(snapshot)
 
         # Verify batch was dropped
         result = run_git_command(["show-ref", f"refs/batches/{batch_name}"], check=False)
@@ -123,7 +159,7 @@ class TestRestoreBatchRefs:
         write_text_file_contents(metadata_path, json.dumps(metadata))
 
         # Snapshot
-        snapshot_batch_refs()
+        snapshot = snapshot_batch_refs()
 
         # Delete the batch
         run_git_command(["update-ref", "-d", f"refs/batches/{batch_name}"])
@@ -133,7 +169,7 @@ class TestRestoreBatchRefs:
         assert result.returncode != 0
 
         # Restore
-        restore_batch_refs()
+        restore_batch_refs(snapshot)
 
         # Verify batch was restored into authoritative storage
         result = run_git_command(["show-ref", get_batch_content_ref_name(batch_name)], check=False)
@@ -152,7 +188,7 @@ class TestRestoreBatchRefs:
         run_git_command(["update-ref", f"refs/batches/{batch_name}", original_sha])
 
         # Snapshot
-        snapshot_batch_refs()
+        snapshot = snapshot_batch_refs()
 
         # Make another commit
         (temp_git_repo / "newfile.txt").write_text("content\n")
@@ -169,7 +205,7 @@ class TestRestoreBatchRefs:
         assert result.stdout.strip() == new_sha
 
         # Restore
-        restore_batch_refs()
+        restore_batch_refs(snapshot)
 
         # Verify batch was reverted to original commit in authoritative storage
         result = run_git_command(["rev-parse", get_batch_content_ref_name(batch_name)])
@@ -188,13 +224,13 @@ class TestRestoreBatchRefs:
             ["rev-parse", f"refs/git-stage-batch/state/{batch_name}"]
         ).stdout.strip()
 
-        snapshot_batch_refs()
+        snapshot = snapshot_batch_refs()
         update_batch_note(batch_name, "after")
         assert run_git_command(
             ["rev-parse", f"refs/git-stage-batch/state/{batch_name}"]
         ).stdout.strip() != original_state_sha
 
-        restore_batch_refs()
+        restore_batch_refs(snapshot)
 
         restored_content_sha = run_git_command(
             ["rev-parse", f"refs/git-stage-batch/batches/{batch_name}"]

--- a/tests/functional/test_abort_restoration.py
+++ b/tests/functional/test_abort_restoration.py
@@ -1,11 +1,44 @@
 """Tests for abort restoration behavior."""
 
+import json
 import os
 import subprocess
 
 import pytest
 
 from .conftest import git_stage_batch
+
+
+def _damage_batch_ref_snapshot(snapshot_path, original_payload, damage):
+    if damage == "missing":
+        snapshot_path.unlink()
+        return
+    if damage == "empty":
+        snapshot_path.write_text("", encoding="utf-8")
+        return
+    if damage == "malformed-json":
+        snapshot_path.write_text("{", encoding="utf-8")
+        return
+    if damage == "top-level-array":
+        snapshot_path.write_text("[]\n", encoding="utf-8")
+        return
+
+    snapshot = json.loads(original_payload)
+    if damage == "batches-array":
+        snapshot["batches"] = []
+    elif damage == "missing-schema-version":
+        del snapshot["schema_version"]
+    else:
+        entry = snapshot["batches"]["before-session"]
+        if damage == "entry-array":
+            snapshot["batches"]["before-session"] = []
+        elif damage == "metadata-files-array":
+            entry["metadata"]["files"] = []
+        elif damage == "missing-object":
+            entry["commit_sha"] = "0" * len(entry["commit_sha"])
+        else:
+            raise AssertionError(f"unknown damage mode: {damage}")
+    snapshot_path.write_text(json.dumps(snapshot) + "\n", encoding="utf-8")
 
 
 @pytest.fixture
@@ -293,6 +326,130 @@ def test_abort_stash_conflict_keeps_session_for_retry(functional_repo):
     ).stdout.split(b"\0")
     assert b" M README.md" in status
     assert b"A  new.txt" in status
+
+
+@pytest.mark.parametrize(
+    "damage",
+    [
+        "missing",
+        "empty",
+        "malformed-json",
+        "top-level-array",
+        "batches-array",
+        "missing-schema-version",
+        "entry-array",
+        "metadata-files-array",
+        "missing-object",
+    ],
+)
+def test_abort_batch_snapshot_preflight_is_strict_and_retryable(
+    functional_repo,
+    damage,
+):
+    """Damaged required batch state must fail before mutation and allow retry."""
+    readme_path = functional_repo / "README.md"
+    session_start_bytes = b"# dirty before session\n"
+    readme_path.write_bytes(session_start_bytes)
+    git_stage_batch("new", "before-session")
+    git_stage_batch("start")
+
+    git_dir = functional_repo / ".git"
+    snapshot_path = (
+        git_dir / "git-stage-batch" / "session" / "abort" / "batch-refs.json"
+    )
+    marker_path = git_dir / "git-stage-batch" / "session" / "abort" / "head.txt"
+    owner_path = git_dir / "git-stage-batch" / "active-session.json"
+    original_snapshot = snapshot_path.read_text(encoding="utf-8")
+
+    git_stage_batch("drop", "before-session")
+    git_stage_batch("new", "during-session")
+    during_session_bytes = b"# changed during session\n"
+    readme_path.write_bytes(during_session_bytes)
+
+    head_before_abort = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    index_before_abort = subprocess.run(
+        ["git", "write-tree"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    marker_before_abort = marker_path.read_bytes()
+    owner_before_abort = owner_path.read_bytes()
+
+    _damage_batch_ref_snapshot(snapshot_path, original_snapshot, damage)
+    failed_abort = git_stage_batch("abort", check=False)
+
+    assert failed_abort.returncode != 0
+    assert "session remains active" in failed_abort.stderr.lower()
+    assert "Session aborted" not in failed_abort.stderr
+    assert "All changes reverted" not in failed_abort.stderr
+    assert marker_path.read_bytes() == marker_before_abort
+    assert owner_path.read_bytes() == owner_before_abort
+    assert readme_path.read_bytes() == during_session_bytes
+    assert subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip() == head_before_abort
+    assert subprocess.run(
+        ["git", "write-tree"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip() == index_before_abort
+    assert subprocess.run(
+        [
+            "git",
+            "show-ref",
+            "--verify",
+            "--quiet",
+            "refs/git-stage-batch/batches/before-session",
+        ],
+        check=False,
+    ).returncode != 0
+    assert subprocess.run(
+        [
+            "git",
+            "show-ref",
+            "--verify",
+            "--quiet",
+            "refs/git-stage-batch/batches/during-session",
+        ],
+        check=False,
+    ).returncode == 0
+
+    snapshot_path.write_text(original_snapshot, encoding="utf-8")
+    git_stage_batch("abort")
+
+    assert readme_path.read_bytes() == session_start_bytes
+    assert subprocess.run(
+        [
+            "git",
+            "show-ref",
+            "--verify",
+            "--quiet",
+            "refs/git-stage-batch/batches/before-session",
+        ],
+        check=False,
+    ).returncode == 0
+    assert subprocess.run(
+        [
+            "git",
+            "show-ref",
+            "--verify",
+            "--quiet",
+            "refs/git-stage-batch/batches/during-session",
+        ],
+        check=False,
+    ).returncode != 0
+    assert not marker_path.exists()
+    assert not owner_path.exists()
 
 
 @pytest.mark.parametrize("link_target", ["README.md", "missing-target"])

--- a/tests/utils/test_file_io.py
+++ b/tests/utils/test_file_io.py
@@ -18,6 +18,7 @@ from git_stage_batch.utils.file_io import (
     AtomicWriteModePolicy,
     PROJECT_FILE_MODE,
     append_lines_to_file,
+    read_required_text_file_contents,
     read_text_file_contents,
     write_file_bytes,
     write_text_file_contents,
@@ -61,6 +62,20 @@ class TestReadTextFileContents:
         content = read_text_file_contents(test_file)
 
         assert content == "Line 1\nLine 2\nLine 3\n"
+
+
+class TestReadRequiredTextFileContents:
+    """Tests for read_required_text_file_contents function."""
+
+    def test_read_empty_file(self, tmp_path):
+        test_file = tmp_path / "empty.txt"
+        test_file.write_text("", encoding="utf-8")
+
+        assert read_required_text_file_contents(test_file) == ""
+
+    def test_missing_file_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            read_required_text_file_contents(tmp_path / "missing.txt")
 
 
 class TestWriteTextFileContents:


### PR DESCRIPTION
Session startup saves batch references and the Git objects needed for abort
before publishing the marker that makes a session active.

If that required batch snapshot is missing or damaged, abort currently treats
it as an empty mapping. HEAD, the index, and the worktree may be restored while
batch changes remain, after which the command clears the recovery state and
reports success.

This PR separates required and optional text reads, gives the batch snapshot a
versioned schema, validates every nested field and referenced object once
before mutation, and passes the checked value into restoration. Fault-injection
tests cover nine damaged states, prove that failure preserves repository and
session state, and retry after repairing the snapshot. The full suite passes
with 3,499 tests and 12 skips; Ruff, type-hygiene, and strict mypy checks also
pass.

Abort now refuses to report complete restoration without valid batch recovery
data and retains the active session for repair and retry.
