### PR TITLE
cli: Declare runtime policy with each command

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -100,18 +100,47 @@ Every explicit non-interactive command follows this sequence:
    normalizes file arguments.
 3. [`cli/root_parser.py`](src/git_stage_batch/cli/root_parser.py) creates the
    root parser and asks `add_cli_subcommands()` to register commands.
-4. One parser registration function stores a callable in `args.func` with
-   `set_defaults(func=...)`.
-5. `dispatch_cli_mode()` in [`runtime.py`](src/git_stage_batch/runtime.py)
+4. One parser registration function attaches a
+   [`CommandPolicy`](src/git_stage_batch/cli/command_policy.py) and stores a
+   callable in `args.func` with `set_defaults(func=...)`.
+5. `main()` applies the declared repository, locking, pager, and
+   session-ownership policies.
+6. `dispatch_cli_mode()` in [`runtime.py`](src/git_stage_batch/runtime.py)
    sends non-interactive work to `execute_non_interactive_args()`.
-6. [`cli/execution.py`](src/git_stage_batch/cli/execution.py) calls
+7. [`cli/execution.py`](src/git_stage_batch/cli/execution.py) calls
    `args.func(args)`.
-7. That callable invokes a function under `commands/`, either directly or
+8. That callable invokes a function under `commands/`, either directly or
    through a dispatch module under `cli/` when several option combinations
    share one command name.
 
 The parser chooses *which* operation the user requested. The function under
 `commands/` owns *how* that operation behaves.
+
+### Command runtime policy
+
+Every call to `add_subcommand_parser()` declares five independent policy
+dimensions beside the command registration:
+
+- **Session ownership** says whether the command may run while an active
+  session belongs to another worktree. It does not claim that a command is
+  literally read-only.
+- **Locking** says whether `main()` acquires the repository session lock,
+  leaves locking to interactive mode, or bypasses the lock for shell-prompt
+  status.
+- **Repository requirement** says whether the invocation requires a Git
+  repository. Prompt status is deliberately allowed outside one.
+- **Pager eligibility** says whether human-readable terminal output may use
+  Git's configured pager. Porcelain and prompt output still bypass paging.
+- **State changes** describe the most persistent state the command may change:
+  none; scratch selection, review, cache, or iteration state; or durable
+  repository, batch, session-lifecycle, asset, or journal state.
+
+These dimensions remain independent. For example, `show` may refresh
+worktree-local selection and cache files while still being allowed when
+another worktree owns the active session. The journal command may purge
+durable diagnostic files without changing session-owned repository state.
+Architecture tests require every registered parser, including hidden commands
+and aliases, to carry a complete policy.
 
 ### Example: `status`
 
@@ -231,7 +260,8 @@ Follow these steps:
 2. Register the command in the matching file under `src/git_stage_batch/cli/`.
    Current groups include session commands, selected-change commands,
    file-blocking commands, fixup commands, asset commands, and named-batch
-   commands.
+   commands. Declare its session-ownership, locking, repository, pager, and
+   state-change policies in the same `add_subcommand_parser()` call.
 3. Add that registration function to
    `cli/subcommand_registry.py`. A new option on an existing command does not
    need another registry entry.

--- a/src/git_stage_batch/cli/asset_subcommands.py
+++ b/src/git_stage_batch/cli/asset_subcommands.py
@@ -4,6 +4,14 @@ from __future__ import annotations
 
 from ..commands.install_assets import command_install_assets
 from ..i18n import _
+from .command_policy import (
+    CommandPolicy,
+    LockingPolicy,
+    PagerPolicy,
+    RepositoryPolicy,
+    SessionOwnershipPolicy,
+    StateChangePolicy,
+)
 from .subcommand_parser import Subparsers, add_subcommand_parser
 
 
@@ -12,6 +20,13 @@ def add_install_assets_subcommand(subparsers: Subparsers) -> None:
     parser_install_assets = add_subcommand_parser(
         subparsers,
         "install-assets",
+        policy=CommandPolicy(
+            session_ownership=SessionOwnershipPolicy.REQUIRE_AVAILABLE,
+            locking=LockingPolicy.SESSION,
+            repository=RepositoryPolicy.REQUIRED,
+            pager=PagerPolicy.NEVER,
+            state_changes=StateChangePolicy.DURABLE,
+        ),
         help=_("Install bundled assistant assets into the repository"),
     )
     parser_install_assets.add_argument(

--- a/src/git_stage_batch/cli/batch_subcommands.py
+++ b/src/git_stage_batch/cli/batch_subcommands.py
@@ -10,6 +10,14 @@ from ..commands.new import command_new_batch
 from ..commands.sift import command_sift_batch
 from ..i18n import _
 from .apply_dispatch import dispatch_apply_command
+from .command_policy import (
+    CommandPolicy,
+    LockingPolicy,
+    PagerPolicy,
+    RepositoryPolicy,
+    SessionOwnershipPolicy,
+    StateChangePolicy,
+)
 from .file_arguments import add_file_argument
 from .reset_dispatch import dispatch_reset_command
 from .subcommand_parser import Subparsers, add_subcommand_parser
@@ -20,6 +28,13 @@ def add_new_subcommand(subparsers: Subparsers) -> None:
     parser_new = add_subcommand_parser(
         subparsers,
         "new",
+        policy=CommandPolicy(
+            session_ownership=SessionOwnershipPolicy.REQUIRE_AVAILABLE,
+            locking=LockingPolicy.SESSION,
+            repository=RepositoryPolicy.REQUIRED,
+            pager=PagerPolicy.NEVER,
+            state_changes=StateChangePolicy.DURABLE,
+        ),
         help=_("Create a new batch"),
     )
     parser_new.add_argument(
@@ -42,6 +57,13 @@ def add_list_subcommand(subparsers: Subparsers) -> None:
     parser_list = add_subcommand_parser(
         subparsers,
         "list",
+        policy=CommandPolicy(
+            session_ownership=SessionOwnershipPolicy.ALLOW_FOREIGN,
+            locking=LockingPolicy.SESSION,
+            repository=RepositoryPolicy.REQUIRED,
+            pager=PagerPolicy.ELIGIBLE,
+            state_changes=StateChangePolicy.NONE,
+        ),
         help=_("List all batches"),
     )
     parser_list.set_defaults(func=lambda _: command_list_batches())
@@ -52,6 +74,13 @@ def add_validate_subcommand(subparsers: Subparsers) -> None:
     parser_validate = add_subcommand_parser(
         subparsers,
         "validate",
+        policy=CommandPolicy(
+            session_ownership=SessionOwnershipPolicy.ALLOW_FOREIGN,
+            locking=LockingPolicy.SESSION,
+            repository=RepositoryPolicy.REQUIRED,
+            pager=PagerPolicy.NEVER,
+            state_changes=StateChangePolicy.NONE,
+        ),
         help=_("Validate persisted batch metadata"),
     )
     parser_validate.add_argument(
@@ -69,6 +98,13 @@ def add_drop_subcommand(subparsers: Subparsers) -> None:
     parser_drop = add_subcommand_parser(
         subparsers,
         "drop",
+        policy=CommandPolicy(
+            session_ownership=SessionOwnershipPolicy.REQUIRE_AVAILABLE,
+            locking=LockingPolicy.SESSION,
+            repository=RepositoryPolicy.REQUIRED,
+            pager=PagerPolicy.NEVER,
+            state_changes=StateChangePolicy.DURABLE,
+        ),
         help=_("Delete a batch"),
     )
     parser_drop.add_argument(
@@ -83,6 +119,13 @@ def add_annotate_subcommand(subparsers: Subparsers) -> None:
     parser_annotate = add_subcommand_parser(
         subparsers,
         "annotate",
+        policy=CommandPolicy(
+            session_ownership=SessionOwnershipPolicy.REQUIRE_AVAILABLE,
+            locking=LockingPolicy.SESSION,
+            repository=RepositoryPolicy.REQUIRED,
+            pager=PagerPolicy.NEVER,
+            state_changes=StateChangePolicy.DURABLE,
+        ),
         help=_("Add or update batch description"),
     )
     parser_annotate.add_argument(
@@ -103,6 +146,13 @@ def add_sift_subcommand(subparsers: Subparsers) -> None:
     parser_sift = add_subcommand_parser(
         subparsers,
         "sift",
+        policy=CommandPolicy(
+            session_ownership=SessionOwnershipPolicy.REQUIRE_AVAILABLE,
+            locking=LockingPolicy.SESSION,
+            repository=RepositoryPolicy.REQUIRED,
+            pager=PagerPolicy.NEVER,
+            state_changes=StateChangePolicy.DURABLE,
+        ),
         help=_("Remove already-present portions from a batch"),
     )
     parser_sift.add_argument(
@@ -129,6 +179,13 @@ def add_apply_subcommand(subparsers: Subparsers) -> None:
     parser_apply = add_subcommand_parser(
         subparsers,
         "apply",
+        policy=CommandPolicy(
+            session_ownership=SessionOwnershipPolicy.REQUIRE_AVAILABLE,
+            locking=LockingPolicy.SESSION,
+            repository=RepositoryPolicy.REQUIRED,
+            pager=PagerPolicy.NEVER,
+            state_changes=StateChangePolicy.DURABLE,
+        ),
         help=_("Apply batch changes to working tree"),
     )
     parser_apply.add_argument(
@@ -161,6 +218,13 @@ def add_reset_subcommand(subparsers: Subparsers) -> None:
     parser_reset = add_subcommand_parser(
         subparsers,
         "reset",
+        policy=CommandPolicy(
+            session_ownership=SessionOwnershipPolicy.REQUIRE_AVAILABLE,
+            locking=LockingPolicy.SESSION,
+            repository=RepositoryPolicy.REQUIRED,
+            pager=PagerPolicy.NEVER,
+            state_changes=StateChangePolicy.DURABLE,
+        ),
         help=_("Remove claims from batch"),
     )
     parser_reset.add_argument(

--- a/src/git_stage_batch/cli/command_policy.py
+++ b/src/git_stage_batch/cli/command_policy.py
@@ -1,0 +1,119 @@
+"""Declarative runtime policy for registered CLI commands."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from enum import Enum
+
+
+class SessionOwnershipPolicy(Enum):
+    """Whether a command may run while another worktree owns the session."""
+
+    REQUIRE_AVAILABLE = "require-available"
+    ALLOW_FOREIGN = "allow-foreign"
+
+
+class LockingPolicy(Enum):
+    """How the top-level CLI acquires the repository session lock."""
+
+    SESSION = "session"
+    NONE = "none"
+    SESSION_EXCEPT_PROMPT = "session-except-prompt"
+
+
+class RepositoryPolicy(Enum):
+    """Whether a command requires a Git repository."""
+
+    REQUIRED = "required"
+    OPTIONAL = "optional"
+    OPTIONAL_FOR_PROMPT = "optional-for-prompt"
+
+
+class PagerPolicy(Enum):
+    """Whether human-readable output may use the configured pager."""
+
+    ELIGIBLE = "eligible"
+    NEVER = "never"
+
+
+class StateChangePolicy(Enum):
+    """The most persistent application or repository state a command may change."""
+
+    NONE = "none"
+    SCRATCH = "scratch"
+    DURABLE = "durable"
+
+
+@dataclass(frozen=True)
+class CommandPolicy:
+    """Complete runtime contract attached to one registered CLI command."""
+
+    session_ownership: SessionOwnershipPolicy
+    locking: LockingPolicy
+    repository: RepositoryPolicy
+    pager: PagerPolicy
+    state_changes: StateChangePolicy
+
+
+CONSERVATIVE_COMMAND_POLICY = CommandPolicy(
+    session_ownership=SessionOwnershipPolicy.REQUIRE_AVAILABLE,
+    locking=LockingPolicy.SESSION,
+    repository=RepositoryPolicy.REQUIRED,
+    pager=PagerPolicy.NEVER,
+    state_changes=StateChangePolicy.DURABLE,
+)
+
+IMPLICIT_SHOW_POLICY = CommandPolicy(
+    session_ownership=SessionOwnershipPolicy.REQUIRE_AVAILABLE,
+    locking=LockingPolicy.SESSION,
+    repository=RepositoryPolicy.REQUIRED,
+    pager=PagerPolicy.ELIGIBLE,
+    state_changes=StateChangePolicy.SCRATCH,
+)
+
+INTERACTIVE_POLICY = CommandPolicy(
+    session_ownership=SessionOwnershipPolicy.REQUIRE_AVAILABLE,
+    locking=LockingPolicy.NONE,
+    repository=RepositoryPolicy.REQUIRED,
+    pager=PagerPolicy.NEVER,
+    state_changes=StateChangePolicy.DURABLE,
+)
+
+
+def policy_for_args(args: argparse.Namespace) -> CommandPolicy:
+    """Return declared policy, failing closed for synthetic or unknown arguments."""
+    if (
+        getattr(args, "interactive_flag", False)
+        or getattr(args, "interactive_command", False)
+    ):
+        return INTERACTIVE_POLICY
+
+    policy = getattr(args, "command_policy", None)
+    if isinstance(policy, CommandPolicy):
+        return policy
+    return CONSERVATIVE_COMMAND_POLICY
+
+
+def policy_requires_repository(
+    policy: CommandPolicy,
+    args: argparse.Namespace,
+) -> bool:
+    """Return whether the selected invocation requires a Git repository."""
+    if policy.repository is RepositoryPolicy.REQUIRED:
+        return True
+    if policy.repository is RepositoryPolicy.OPTIONAL:
+        return False
+    return getattr(args, "prompt_format", None) is None
+
+
+def policy_uses_session_lock(
+    policy: CommandPolicy,
+    args: argparse.Namespace,
+) -> bool:
+    """Return whether the selected invocation uses the repository session lock."""
+    if policy.locking is LockingPolicy.SESSION:
+        return True
+    if policy.locking is LockingPolicy.NONE:
+        return False
+    return getattr(args, "prompt_format", None) is None

--- a/src/git_stage_batch/cli/completion.py
+++ b/src/git_stage_batch/cli/completion.py
@@ -9,7 +9,15 @@ from pathlib import PurePosixPath
 from ..batch.state.query import list_batch_files
 from ..exceptions import CommandError
 from ..utils.file_patterns import list_changed_files
-from .subcommand_parser import Subparsers
+from .command_policy import (
+    CommandPolicy,
+    LockingPolicy,
+    PagerPolicy,
+    RepositoryPolicy,
+    SessionOwnershipPolicy,
+    StateChangePolicy,
+)
+from .subcommand_parser import Subparsers, add_subcommand_parser
 
 
 _WILDMATCH_META = frozenset({"*", "?", "["})
@@ -116,8 +124,17 @@ def command_complete_files(current_token: str, *, from_batch: str | None = None)
 
 def add_completion_subcommand(subparsers: Subparsers) -> None:
     """Register the hidden file-completion subcommand."""
-    parser_complete_files = subparsers.add_parser(
+    parser_complete_files = add_subcommand_parser(
+        subparsers,
         "__complete-files",
+        policy=CommandPolicy(
+            session_ownership=SessionOwnershipPolicy.REQUIRE_AVAILABLE,
+            locking=LockingPolicy.SESSION,
+            repository=RepositoryPolicy.REQUIRED,
+            pager=PagerPolicy.ELIGIBLE,
+            state_changes=StateChangePolicy.NONE,
+        ),
+        help_topic="stage-batch",
         help=argparse.SUPPRESS,
     )
     parser_complete_files.add_argument(

--- a/src/git_stage_batch/cli/file_blocking_subcommands.py
+++ b/src/git_stage_batch/cli/file_blocking_subcommands.py
@@ -5,6 +5,14 @@ from __future__ import annotations
 from ..commands.block_file import command_block_file
 from ..commands.unblock_file import command_unblock_file
 from ..i18n import _
+from .command_policy import (
+    CommandPolicy,
+    LockingPolicy,
+    PagerPolicy,
+    RepositoryPolicy,
+    SessionOwnershipPolicy,
+    StateChangePolicy,
+)
 from .subcommand_parser import Subparsers, add_subcommand_parser
 
 
@@ -13,6 +21,13 @@ def add_block_file_subcommand(subparsers: Subparsers) -> None:
     parser_block_file = add_subcommand_parser(
         subparsers,
         "block-file",
+        policy=CommandPolicy(
+            session_ownership=SessionOwnershipPolicy.REQUIRE_AVAILABLE,
+            locking=LockingPolicy.SESSION,
+            repository=RepositoryPolicy.REQUIRED,
+            pager=PagerPolicy.ELIGIBLE,
+            state_changes=StateChangePolicy.DURABLE,
+        ),
         aliases=["bf"],
         help=_("Permanently exclude a file (adds to .gitignore)"),
     )
@@ -41,6 +56,13 @@ def add_unblock_file_subcommand(subparsers: Subparsers) -> None:
     parser_unblock_file = add_subcommand_parser(
         subparsers,
         "unblock-file",
+        policy=CommandPolicy(
+            session_ownership=SessionOwnershipPolicy.REQUIRE_AVAILABLE,
+            locking=LockingPolicy.SESSION,
+            repository=RepositoryPolicy.REQUIRED,
+            pager=PagerPolicy.ELIGIBLE,
+            state_changes=StateChangePolicy.DURABLE,
+        ),
         aliases=["ubf"],
         help=_("Remove a file from the blocked list"),
     )

--- a/src/git_stage_batch/cli/fixup_subcommands.py
+++ b/src/git_stage_batch/cli/fixup_subcommands.py
@@ -9,6 +9,14 @@ from ..commands.suggest_fixup import (
     command_suggest_fixup_line,
 )
 from ..i18n import _
+from .command_policy import (
+    CommandPolicy,
+    LockingPolicy,
+    PagerPolicy,
+    RepositoryPolicy,
+    SessionOwnershipPolicy,
+    StateChangePolicy,
+)
 from .subcommand_parser import Subparsers, add_subcommand_parser
 
 
@@ -36,6 +44,13 @@ def add_suggest_fixup_subcommand(subparsers: Subparsers) -> None:
     parser_suggest_fixup = add_subcommand_parser(
         subparsers,
         "suggest-fixup",
+        policy=CommandPolicy(
+            session_ownership=SessionOwnershipPolicy.REQUIRE_AVAILABLE,
+            locking=LockingPolicy.SESSION,
+            repository=RepositoryPolicy.REQUIRED,
+            pager=PagerPolicy.NEVER,
+            state_changes=StateChangePolicy.SCRATCH,
+        ),
         aliases=["x"],
         help=_("Suggest which commit the selected hunk should be fixed up to"),
     )

--- a/src/git_stage_batch/cli/journal_subcommands.py
+++ b/src/git_stage_batch/cli/journal_subcommands.py
@@ -4,6 +4,14 @@ from __future__ import annotations
 
 from ..commands.journal import command_journal
 from ..i18n import _
+from .command_policy import (
+    CommandPolicy,
+    LockingPolicy,
+    PagerPolicy,
+    RepositoryPolicy,
+    SessionOwnershipPolicy,
+    StateChangePolicy,
+)
 from .subcommand_parser import Subparsers, add_subcommand_parser
 
 
@@ -12,6 +20,13 @@ def add_journal_subcommand(subparsers: Subparsers) -> None:
     parser = add_subcommand_parser(
         subparsers,
         "journal",
+        policy=CommandPolicy(
+            session_ownership=SessionOwnershipPolicy.ALLOW_FOREIGN,
+            locking=LockingPolicy.SESSION,
+            repository=RepositoryPolicy.REQUIRED,
+            pager=PagerPolicy.NEVER,
+            state_changes=StateChangePolicy.DURABLE,
+        ),
         help=_("Inspect or purge diagnostic journal data"),
     )
     action = parser.add_mutually_exclusive_group()

--- a/src/git_stage_batch/cli/main.py
+++ b/src/git_stage_batch/cli/main.py
@@ -5,28 +5,22 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
-import argparse
 from contextlib import AbstractContextManager, nullcontext
 
+from ..data.session_ownership import require_no_foreign_session_owner
 from ..exceptions import CommandError
 from ..i18n import _
 from ..runtime import dispatch_cli_mode
-from ..data.session_ownership import require_no_foreign_session_owner
 from ..utils.journal import flush_journal
+from ..utils.git_repository import require_git_repository
 from .argument_parser import parse_command_line
-from .pager import pager_output, should_page_output
-
-
-_READ_ONLY_COMMANDS = frozenset(
-    {
-        "check-unstaged",
-        "journal",
-        "list",
-        "show",
-        "status",
-        "validate",
-    }
+from .command_policy import (
+    SessionOwnershipPolicy,
+    policy_for_args,
+    policy_requires_repository,
+    policy_uses_session_lock,
 )
+from .pager import pager_output, should_page_output
 
 
 def acquire_session_lock() -> AbstractContextManager[None]:
@@ -34,15 +28,6 @@ def acquire_session_lock() -> AbstractContextManager[None]:
     from ..utils.session_lock import acquire_session_lock as acquire_lock
 
     return acquire_lock()
-
-
-def _command_may_mutate(args: argparse.Namespace) -> bool:
-    """Return whether dispatch may change worktree-local or shared state."""
-    if getattr(args, "interactive_flag", False):
-        return True
-    if getattr(args, "interactive_command", False):
-        return True
-    return getattr(args, "command", None) not in _READ_ONLY_COMMANDS
 
 
 def _configure_terminal_streams() -> None:
@@ -70,22 +55,25 @@ def main() -> None:
         if args is not None:
             if args.working_directory is not None:
                 os.chdir(args.working_directory)
-            skip_session_lock = getattr(args, "prompt_format", None) is not None
-            interactive = bool(
-                getattr(args, "interactive_flag", False)
-                or getattr(args, "interactive_command", False)
-            )
+            policy = policy_for_args(args)
+            if policy_requires_repository(policy, args):
+                require_git_repository()
             pager_context = (
-                pager_output() if should_page_output(args) else nullcontext()
+                pager_output()
+                if should_page_output(args)
+                else nullcontext()
             )
             lock_context = (
-                nullcontext()
-                if skip_session_lock or interactive
-                else acquire_session_lock()
+                acquire_session_lock()
+                if policy_uses_session_lock(policy, args)
+                else nullcontext()
             )
             with pager_context:
                 with lock_context:
-                    if not skip_session_lock and _command_may_mutate(args):
+                    if (
+                        policy.session_ownership
+                        is SessionOwnershipPolicy.REQUIRE_AVAILABLE
+                    ):
                         require_no_foreign_session_owner()
                     dispatch_cli_mode(args)
         else:

--- a/src/git_stage_batch/cli/pager.py
+++ b/src/git_stage_batch/cli/pager.py
@@ -11,34 +11,23 @@ from typing import Iterator, TextIO, cast
 
 from ..utils.command import start_command
 from ..utils.git_command import run_git_command
+from .command_policy import CommandPolicy, PagerPolicy, policy_for_args
 
 
-_PAGEABLE_COMMANDS = {
-    None,
-    "again",
-    "block-file",
-    "discard",
-    "include",
-    "list",
-    "show",
-    "skip",
-    "start",
-    "status",
-    "unblock-file",
-    "__complete-files",
-}
-
-
-def should_page_output(args: argparse.Namespace) -> bool:
+def should_page_output(
+    args: argparse.Namespace,
+    *,
+    policy: CommandPolicy | None = None,
+) -> bool:
     """Return whether the selected CLI command should write through a pager."""
+    selected_policy = policy if policy is not None else policy_for_args(args)
+    if selected_policy.pager is PagerPolicy.NEVER:
+        return False
+
     if not sys.stdout.isatty():
         return False
 
     if getattr(args, "interactive_flag", False):
-        return False
-
-    command = getattr(args, "command", None)
-    if command == "interactive":
         return False
 
     if getattr(args, "porcelain", False):
@@ -47,7 +36,7 @@ def should_page_output(args: argparse.Namespace) -> bool:
     if getattr(args, "prompt_format", None) is not None:
         return False
 
-    return command in _PAGEABLE_COMMANDS
+    return True
 
 
 def _resolve_git_pager() -> str | None:

--- a/src/git_stage_batch/cli/root_parser.py
+++ b/src/git_stage_batch/cli/root_parser.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from .. import __version__
 from ..i18n import _
+from .command_policy import IMPLICIT_SHOW_POLICY
 from .git_help import GitHelpArgumentParser
 from .subcommand_registry import add_cli_subcommands
 
@@ -16,6 +17,7 @@ def build_root_parser() -> GitHelpArgumentParser:
         help_topic="stage-batch",
         exit_on_error=False,
     )
+    parser.set_defaults(command_policy=IMPLICIT_SHOW_POLICY)
     parser.add_argument(
         "--version",
         action="version",

--- a/src/git_stage_batch/cli/selection_subcommands.py
+++ b/src/git_stage_batch/cli/selection_subcommands.py
@@ -6,6 +6,14 @@ import argparse
 
 from ..i18n import _
 from .auto_advance_options import add_auto_advance_arguments
+from .command_policy import (
+    CommandPolicy,
+    LockingPolicy,
+    PagerPolicy,
+    RepositoryPolicy,
+    SessionOwnershipPolicy,
+    StateChangePolicy,
+)
 from .discard_dispatch import dispatch_discard_command
 from .file_arguments import add_file_argument
 from .include_dispatch import dispatch_include_command
@@ -19,6 +27,13 @@ def add_show_subcommand(subparsers: Subparsers) -> None:
     parser_show = add_subcommand_parser(
         subparsers,
         "show",
+        policy=CommandPolicy(
+            session_ownership=SessionOwnershipPolicy.ALLOW_FOREIGN,
+            locking=LockingPolicy.SESSION,
+            repository=RepositoryPolicy.REQUIRED,
+            pager=PagerPolicy.ELIGIBLE,
+            state_changes=StateChangePolicy.SCRATCH,
+        ),
         help=_("Show the selected hunk"),
     )
     parser_show.add_argument(
@@ -90,6 +105,13 @@ def add_include_subcommand(subparsers: Subparsers) -> None:
     parser_include = add_subcommand_parser(
         subparsers,
         "include",
+        policy=CommandPolicy(
+            session_ownership=SessionOwnershipPolicy.REQUIRE_AVAILABLE,
+            locking=LockingPolicy.SESSION,
+            repository=RepositoryPolicy.REQUIRED,
+            pager=PagerPolicy.ELIGIBLE,
+            state_changes=StateChangePolicy.DURABLE,
+        ),
         aliases=["i"],
         help=_("Stage the selected hunk"),
     )
@@ -163,6 +185,13 @@ def add_skip_subcommand(subparsers: Subparsers) -> None:
     parser_skip = add_subcommand_parser(
         subparsers,
         "skip",
+        policy=CommandPolicy(
+            session_ownership=SessionOwnershipPolicy.REQUIRE_AVAILABLE,
+            locking=LockingPolicy.SESSION,
+            repository=RepositoryPolicy.REQUIRED,
+            pager=PagerPolicy.ELIGIBLE,
+            state_changes=StateChangePolicy.SCRATCH,
+        ),
         aliases=["s"],
         help=_("Skip the selected hunk without staging"),
     )
@@ -190,6 +219,13 @@ def add_discard_subcommand(subparsers: Subparsers) -> None:
     parser_discard = add_subcommand_parser(
         subparsers,
         "discard",
+        policy=CommandPolicy(
+            session_ownership=SessionOwnershipPolicy.REQUIRE_AVAILABLE,
+            locking=LockingPolicy.SESSION,
+            repository=RepositoryPolicy.REQUIRED,
+            pager=PagerPolicy.ELIGIBLE,
+            state_changes=StateChangePolicy.DURABLE,
+        ),
         aliases=["d"],
         help=_("Remove the selected hunk from working tree"),
     )

--- a/src/git_stage_batch/cli/session_subcommands.py
+++ b/src/git_stage_batch/cli/session_subcommands.py
@@ -13,6 +13,14 @@ from ..commands.undo import command_undo
 from ..i18n import _
 from ..output.status_prompt import DEFAULT_PROMPT_FORMAT
 from .auto_advance_options import add_auto_advance_arguments
+from .command_policy import (
+    CommandPolicy,
+    LockingPolicy,
+    PagerPolicy,
+    RepositoryPolicy,
+    SessionOwnershipPolicy,
+    StateChangePolicy,
+)
 from .subcommand_parser import Subparsers, add_subcommand_parser
 
 
@@ -21,6 +29,13 @@ def add_check_unstaged_subcommand(subparsers: Subparsers) -> None:
     parser_check_unstaged = add_subcommand_parser(
         subparsers,
         "check-unstaged",
+        policy=CommandPolicy(
+            session_ownership=SessionOwnershipPolicy.ALLOW_FOREIGN,
+            locking=LockingPolicy.SESSION,
+            repository=RepositoryPolicy.REQUIRED,
+            pager=PagerPolicy.NEVER,
+            state_changes=StateChangePolicy.NONE,
+        ),
         help=_("Check whether the index fits an unstaged-only workflow"),
     )
     parser_check_unstaged.set_defaults(func=lambda _: command_check_unstaged())
@@ -31,6 +46,13 @@ def add_start_subcommand(subparsers: Subparsers) -> None:
     parser_start = add_subcommand_parser(
         subparsers,
         "start",
+        policy=CommandPolicy(
+            session_ownership=SessionOwnershipPolicy.REQUIRE_AVAILABLE,
+            locking=LockingPolicy.SESSION,
+            repository=RepositoryPolicy.REQUIRED,
+            pager=PagerPolicy.ELIGIBLE,
+            state_changes=StateChangePolicy.DURABLE,
+        ),
         help=_("Start a new batch staging session"),
     )
     parser_start.add_argument(
@@ -55,6 +77,13 @@ def add_again_subcommand(subparsers: Subparsers) -> None:
     parser_again = add_subcommand_parser(
         subparsers,
         "again",
+        policy=CommandPolicy(
+            session_ownership=SessionOwnershipPolicy.REQUIRE_AVAILABLE,
+            locking=LockingPolicy.SESSION,
+            repository=RepositoryPolicy.REQUIRED,
+            pager=PagerPolicy.ELIGIBLE,
+            state_changes=StateChangePolicy.DURABLE,
+        ),
         aliases=["a"],
         help=_("Clear state and start a fresh pass"),
     )
@@ -69,6 +98,13 @@ def add_stop_subcommand(subparsers: Subparsers) -> None:
     parser_stop = add_subcommand_parser(
         subparsers,
         "stop",
+        policy=CommandPolicy(
+            session_ownership=SessionOwnershipPolicy.REQUIRE_AVAILABLE,
+            locking=LockingPolicy.SESSION,
+            repository=RepositoryPolicy.REQUIRED,
+            pager=PagerPolicy.NEVER,
+            state_changes=StateChangePolicy.DURABLE,
+        ),
         help=_("Stop the selected session and clear state"),
     )
     parser_stop.set_defaults(func=lambda _: command_stop())
@@ -79,6 +115,13 @@ def add_undo_subcommand(subparsers: Subparsers) -> None:
     parser_undo = add_subcommand_parser(
         subparsers,
         "undo",
+        policy=CommandPolicy(
+            session_ownership=SessionOwnershipPolicy.REQUIRE_AVAILABLE,
+            locking=LockingPolicy.SESSION,
+            repository=RepositoryPolicy.REQUIRED,
+            pager=PagerPolicy.NEVER,
+            state_changes=StateChangePolicy.DURABLE,
+        ),
         aliases=["u", "back"],
         help=_("Undo the most recent undoable session operation"),
     )
@@ -95,6 +138,13 @@ def add_redo_subcommand(subparsers: Subparsers) -> None:
     parser_redo = add_subcommand_parser(
         subparsers,
         "redo",
+        policy=CommandPolicy(
+            session_ownership=SessionOwnershipPolicy.REQUIRE_AVAILABLE,
+            locking=LockingPolicy.SESSION,
+            repository=RepositoryPolicy.REQUIRED,
+            pager=PagerPolicy.NEVER,
+            state_changes=StateChangePolicy.DURABLE,
+        ),
         aliases=["forward"],
         help=_("Redo the most recently undone session operation"),
     )
@@ -111,6 +161,13 @@ def add_abort_subcommand(subparsers: Subparsers) -> None:
     parser_abort = add_subcommand_parser(
         subparsers,
         "abort",
+        policy=CommandPolicy(
+            session_ownership=SessionOwnershipPolicy.REQUIRE_AVAILABLE,
+            locking=LockingPolicy.SESSION,
+            repository=RepositoryPolicy.REQUIRED,
+            pager=PagerPolicy.NEVER,
+            state_changes=StateChangePolicy.DURABLE,
+        ),
         help=_("Restore repository to pre-session state"),
     )
     parser_abort.set_defaults(func=lambda _: command_abort())
@@ -121,6 +178,13 @@ def add_status_subcommand(subparsers: Subparsers) -> None:
     parser_status = add_subcommand_parser(
         subparsers,
         "status",
+        policy=CommandPolicy(
+            session_ownership=SessionOwnershipPolicy.ALLOW_FOREIGN,
+            locking=LockingPolicy.SESSION_EXCEPT_PROMPT,
+            repository=RepositoryPolicy.OPTIONAL_FOR_PROMPT,
+            pager=PagerPolicy.ELIGIBLE,
+            state_changes=StateChangePolicy.NONE,
+        ),
         aliases=["st"],
         help=_("Show selected session status"),
     )

--- a/src/git_stage_batch/cli/subcommand_parser.py
+++ b/src/git_stage_batch/cli/subcommand_parser.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 from typing import Any, Protocol, cast
 
+from .command_policy import CommandPolicy
 from .git_help import GitHelpArgumentParser
 
 
@@ -22,11 +23,13 @@ class Subparsers(Protocol):
 def add_subcommand_parser(
     subparsers: Subparsers,
     command_name: str,
+    *,
+    policy: CommandPolicy,
     **kwargs: Any,
 ) -> GitHelpArgumentParser:
     """Add a subcommand parser wired to its git help topic."""
     help_topic = kwargs.pop("help_topic", f"stage-batch-{command_name}")
-    return cast(
+    parser = cast(
         GitHelpArgumentParser,
         subparsers.add_parser(
             command_name,
@@ -34,3 +37,5 @@ def add_subcommand_parser(
             **kwargs,
         ),
     )
+    parser.set_defaults(command_policy=policy)
+    return parser

--- a/src/git_stage_batch/cli/tui_subcommands.py
+++ b/src/git_stage_batch/cli/tui_subcommands.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from ..i18n import _
+from .command_policy import INTERACTIVE_POLICY
 from .subcommand_parser import Subparsers, add_subcommand_parser
 
 
@@ -11,6 +12,7 @@ def add_interactive_subcommand(subparsers: Subparsers) -> None:
     parser_interactive = add_subcommand_parser(
         subparsers,
         "interactive",
+        policy=INTERACTIVE_POLICY,
         help=_("Start interactive hunk-by-hunk mode"),
     )
     parser_interactive.set_defaults(interactive_command=True)

--- a/tests/architecture/test_command_policies.py
+++ b/tests/architecture/test_command_policies.py
@@ -1,0 +1,76 @@
+"""Architecture rules for declarative CLI command policy."""
+
+from __future__ import annotations
+
+import argparse
+
+from git_stage_batch.cli.command_policy import (
+    CommandPolicy,
+    LockingPolicy,
+    PagerPolicy,
+    RepositoryPolicy,
+    SessionOwnershipPolicy,
+    StateChangePolicy,
+)
+from git_stage_batch.cli.root_parser import build_root_parser
+
+
+def _registered_subcommand_parsers(
+) -> list[tuple[tuple[str, ...], argparse.ArgumentParser]]:
+    root_parser = build_root_parser()
+    subcommands = next(
+        action
+        for action in root_parser._actions
+        if isinstance(action, argparse._SubParsersAction)
+    )
+    names_by_parser: dict[int, list[str]] = {}
+    parsers_by_id: dict[int, argparse.ArgumentParser] = {}
+    for name, parser in subcommands.choices.items():
+        parser_id = id(parser)
+        names_by_parser.setdefault(parser_id, []).append(name)
+        parsers_by_id[parser_id] = parser
+    return [
+        (tuple(names_by_parser[parser_id]), parsers_by_id[parser_id])
+        for parser_id in names_by_parser
+    ]
+
+
+def test_every_registered_command_declares_complete_policy():
+    """Every parser registration must carry all runtime policy dimensions."""
+    for names, parser in _registered_subcommand_parsers():
+        assert "command_policy" in parser._defaults, names
+        policy = parser._defaults["command_policy"]
+        assert isinstance(policy, CommandPolicy), names
+        assert isinstance(policy.session_ownership, SessionOwnershipPolicy), names
+        assert isinstance(policy.locking, LockingPolicy), names
+        assert isinstance(policy.repository, RepositoryPolicy), names
+        assert isinstance(policy.pager, PagerPolicy), names
+        assert isinstance(policy.state_changes, StateChangePolicy), names
+
+
+def test_show_declares_scratch_changes_and_foreign_owner_access():
+    """Show may cache selections without claiming literal read-only behavior."""
+    parser_by_name = {
+        name: parser
+        for names, parser in _registered_subcommand_parsers()
+        for name in names
+    }
+
+    policy = parser_by_name["show"]._defaults["command_policy"]
+
+    assert policy.state_changes is StateChangePolicy.SCRATCH
+    assert policy.session_ownership is SessionOwnershipPolicy.ALLOW_FOREIGN
+
+
+def test_state_changes_do_not_imply_session_ownership_policy():
+    """Journal purge is durable but independent of active session ownership."""
+    parser_by_name = {
+        name: parser
+        for names, parser in _registered_subcommand_parsers()
+        for name in names
+    }
+
+    policy = parser_by_name["journal"]._defaults["command_policy"]
+
+    assert policy.state_changes is StateChangePolicy.DURABLE
+    assert policy.session_ownership is SessionOwnershipPolicy.ALLOW_FOREIGN

--- a/tests/cli/test_command_policy.py
+++ b/tests/cli/test_command_policy.py
@@ -1,0 +1,66 @@
+"""Tests for command-policy selection and invocation refinements."""
+
+from __future__ import annotations
+
+import argparse
+
+from git_stage_batch.cli.argument_parser import parse_command_line
+from git_stage_batch.cli.command_policy import (
+    CONSERVATIVE_COMMAND_POLICY,
+    INTERACTIVE_POLICY,
+    LockingPolicy,
+    RepositoryPolicy,
+    SessionOwnershipPolicy,
+    policy_for_args,
+    policy_requires_repository,
+    policy_uses_session_lock,
+)
+
+
+def _parse(*arguments: str) -> argparse.Namespace:
+    args = parse_command_line(list(arguments), quiet=True)
+    assert args is not None
+    return args
+
+
+def test_registered_alias_uses_canonical_policy():
+    canonical = _parse("again")
+    alias = _parse("a")
+
+    assert alias.command_policy == canonical.command_policy
+
+
+def test_unknown_synthetic_arguments_fail_closed():
+    args = argparse.Namespace(command="future-command")
+
+    policy = policy_for_args(args)
+
+    assert policy is CONSERVATIVE_COMMAND_POLICY
+    assert policy.session_ownership is SessionOwnershipPolicy.REQUIRE_AVAILABLE
+    assert policy.locking is LockingPolicy.SESSION
+    assert policy.repository is RepositoryPolicy.REQUIRED
+
+
+def test_interactive_flag_overrides_implicit_show_policy():
+    args = _parse()
+    args.interactive_flag = True
+
+    assert policy_for_args(args) is INTERACTIVE_POLICY
+
+
+def test_status_prompt_refines_repository_and_lock_policy():
+    args = _parse("status", "--for-prompt")
+    policy = policy_for_args(args)
+
+    assert policy.repository is RepositoryPolicy.OPTIONAL_FOR_PROMPT
+    assert policy.locking is LockingPolicy.SESSION_EXCEPT_PROMPT
+    assert policy_requires_repository(policy, args) is False
+    assert policy_uses_session_lock(policy, args) is False
+
+
+def test_regular_status_uses_repository_and_session_lock():
+    args = _parse("status")
+    policy = policy_for_args(args)
+
+    assert policy_requires_repository(policy, args) is True
+    assert policy_uses_session_lock(policy, args) is True

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -14,6 +14,12 @@ from git_stage_batch.utils.file_jobs import FileJobError
 main_module = import_module("git_stage_batch.cli.main")
 
 
+def _parse_args(*arguments: str) -> Namespace:
+    args = main_module.parse_command_line(list(arguments), quiet=True)
+    assert args is not None
+    return args
+
+
 def test_main_callable():
     """Test that main is callable."""
     assert main_module.main is not None
@@ -108,9 +114,9 @@ def test_main_rejects_mutation_owned_by_another_worktree(capsys):
     dispatch.assert_not_called()
 
 
-def test_main_allows_read_only_command_with_foreign_owner():
-    """Read-only repository inspection does not require session ownership."""
-    args = Namespace(working_directory=None, command="status")
+def test_main_allows_foreign_compatible_command_with_foreign_owner():
+    """A command's declared ownership policy controls the foreign-owner guard."""
+    args = _parse_args("status")
 
     with patch.object(sys, "argv", ["git-stage-batch", "status"]):
         with patch.object(main_module, "parse_command_line", return_value=args):
@@ -133,22 +139,29 @@ def test_main_skips_session_lock_for_prompt_status():
     def fake_dispatch(args):
         events.append(("dispatch", args.prompt_format))
 
-    args = Namespace(working_directory=None, prompt_format="STAGING")
+    args = _parse_args("status", "--for-prompt")
 
     with patch.object(sys, "argv", ["git-stage-batch", "status", "--for-prompt"]):
         with patch.object(main_module, "parse_command_line", return_value=args):
             with patch.object(main_module, "should_page_output", return_value=False):
                 with patch.object(
                     main_module,
-                    "acquire_session_lock",
-                    side_effect=AssertionError("prompt status must not lock"),
+                    "require_git_repository",
+                    side_effect=AssertionError(
+                        "prompt status must remain available outside repositories"
+                    ),
                 ):
                     with patch.object(
                         main_module,
-                        "dispatch_cli_mode",
-                        side_effect=fake_dispatch,
+                        "acquire_session_lock",
+                        side_effect=AssertionError("prompt status must not lock"),
                     ):
-                        main_module.main()
+                        with patch.object(
+                            main_module,
+                            "dispatch_cli_mode",
+                            side_effect=fake_dispatch,
+                        ):
+                            main_module.main()
 
     assert events == [("dispatch", "STAGING")]
 
@@ -160,10 +173,7 @@ def test_main_skips_session_lock_for_rich_prompt_status():
     def fake_dispatch(args):
         events.append(("dispatch", args.prompt_format))
 
-    args = Namespace(
-        working_directory=None,
-        prompt_format="{processed}/{total}",
-    )
+    args = _parse_args("status", "--for-prompt", "{processed}/{total}")
 
     with patch.object(sys, "argv", ["git-stage-batch", "status", "--for-prompt"]):
         with patch.object(main_module, "parse_command_line", return_value=args):

--- a/tests/cli/test_pager.py
+++ b/tests/cli/test_pager.py
@@ -7,6 +7,7 @@ from contextlib import contextmanager
 from importlib import import_module
 
 from git_stage_batch.cli import pager as pager_module
+from git_stage_batch.cli.argument_parser import parse_command_line
 from git_stage_batch.cli.pager import should_page_output
 
 main_module = import_module("git_stage_batch.cli.main")
@@ -20,6 +21,11 @@ def _make_args(**overrides) -> argparse.Namespace:
         "working_directory": None,
     }
     defaults.update(overrides)
+    command = defaults["command"]
+    if "command_policy" not in defaults and isinstance(command, str):
+        parsed_args = parse_command_line([command], quiet=True)
+        if parsed_args is not None:
+            defaults["command_policy"] = parsed_args.command_policy
     return argparse.Namespace(**defaults)
 
 
@@ -35,6 +41,15 @@ def test_should_page_include_when_stdout_is_tty(monkeypatch):
     monkeypatch.setattr("sys.stdout.isatty", lambda: True)
 
     assert should_page_output(_make_args(command="include")) is True
+
+
+def test_should_page_from_declared_policy_instead_of_command_name(monkeypatch):
+    """Pager eligibility should travel with registration metadata."""
+    args = _make_args(command="show")
+    args.command = "renamed-show"
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+
+    assert should_page_output(args) is True
 
 
 def test_should_not_page_porcelain_output(monkeypatch):


### PR DESCRIPTION
The command-line interface registers operations through parser functions,
while top-level dispatch coordinates session locking, foreign-worktree
ownership checks, and terminal paging.

Those runtime decisions are maintained in separate command-name lists and
special cases. Adding or renaming a command can therefore leave registration
and enforcement out of sync, and the existing read-only label obscures
commands such as `show` that may update scratch selection or cache state.

This PR attaches repository, locking, session-ownership, pager, and
state-change policy directly to every command registration. Dispatch and
paging consume those declarations, unknown argument namespaces fail closed,
and architecture tests require complete policy for public, aliased, and hidden
commands. The architecture guide documents each dimension and the command
registration checklist. The full suite passes with 3,508 tests and 12 skips;
Ruff, type hygiene, strict mypy, and package builds also pass.

Command registration is now authoritative for runtime policy, so extending the
CLI no longer requires synchronizing distant command-name lists.
