### PR TITLE
state: Make session path getters side-effect free

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -327,9 +327,19 @@ implementation until its caller is removed:
 Each kind of persisted session record has one data module that reads and writes
 it. Use this sequence when adding or changing a record:
 
-1. Add the path in [`utils/paths.py`](src/git_stage_batch/utils/paths.py).
+Path construction under
+[`utils/paths.py`](src/git_stage_batch/utils/paths.py) is side-effect free.
+Calling a `get_*_path()` function must not create repository state. Generic
+file writers create their parent immediately before writing; code that writes
+directories directly uses the matching `ensure_*_directory_exists()` helper at
+that write boundary. Readers never ensure directories merely to inspect a
+path.
+
+1. Add the pure path in
+   [`utils/paths.py`](src/git_stage_batch/utils/paths.py).
 2. Add serialization and validation in the module under `data/` that owns the
-   record.
+   record. Add an explicit directory ensure only when the storage operation
+   cannot use the generic file writer.
 3. Decide when the record is created, refreshed, and cleared. Selected-change
    files are enumerated by
    [`data/selected_change/store.py`](src/git_stage_batch/data/selected_change/store.py)

--- a/src/git_stage_batch/batch/file_display.py
+++ b/src/git_stage_batch/batch/file_display.py
@@ -16,10 +16,10 @@ from ..core.line_selection import LineRanges
 from ..core.models import (
     RenderedBatchDisplay,
 )
+from ..utils.context_lines import get_context_lines
 from ..utils.repository_buffers import (
     read_git_object_buffer_or_none,
 )
-from ..utils.paths import get_context_lines
 
 
 def render_batch_file_display(

--- a/src/git_stage_batch/commands/batch_source/replacement_previews.py
+++ b/src/git_stage_batch/commands/batch_source/replacement_previews.py
@@ -11,6 +11,7 @@ from ...batch.state.metadata_types import BatchFileMetadataDict
 from ...batch.submodule_pointer import is_batch_submodule_pointer
 from ...core.replacement import ReplacementPayload, coerce_replacement_payload
 from ...core.models import RenderedBatchDisplay
+from ...utils.context_lines import get_context_lines
 from ...data.file_review.batch_selection import (
     translate_batch_file_gutter_ids_to_selection_ids,
 )
@@ -19,7 +20,6 @@ from ...utils.repository_buffers import read_git_object_buffer_or_none
 from ...exceptions import exit_with_error
 from ...i18n import _
 from ...output.candidate_preview_diff import render_candidate_buffer_diff
-from ...utils.paths import get_context_lines
 
 
 SelectionTranslator = Callable[

--- a/src/git_stage_batch/commands/file_scope/discard_file.py
+++ b/src/git_stage_batch/commands/file_scope/discard_file.py
@@ -23,6 +23,7 @@ from ...core.models import (
     RenameChange,
     TextFileDeletionChange,
 )
+from ...utils.context_lines import get_context_lines
 from ...data.file_tracking import auto_add_untracked_files
 from ...data.index_entries import read_index_entry
 from ...data.live_diff import stream_live_git_diff
@@ -37,7 +38,7 @@ from ...utils.git_command import run_git_command
 from ...utils.git_index import git_update_index
 from ...utils.git_repository import get_git_repository_root_path
 from ...utils.git_worktree import git_checkout_index_paths
-from ...utils.paths import get_block_list_file_path, get_context_lines
+from ...utils.paths import get_block_list_file_path
 from ..selection.action_completion import finish_selected_change_action
 from .target_path import checkpoint_paths_for_live_file
 from ..selection.selected_change_discarding import (

--- a/src/git_stage_batch/commands/file_scope/discard_file_to_batch.py
+++ b/src/git_stage_batch/commands/file_scope/discard_file_to_batch.py
@@ -20,6 +20,7 @@ from ...core.diff_parser import acquire_unified_diff, build_line_changes_from_pa
 from ...core.hashing import compute_stable_hunk_hash_from_lines
 from ...core.models import BinaryFileChange, FileModeChange, GitlinkChange, RenameChange, TextFileDeletionChange
 from ...core.text_lifecycle import TextFileChangeType
+from ...utils.context_lines import get_context_lines
 from ...data.file_change_display import (
     render_binary_file_change,
     render_gitlink_change,
@@ -40,7 +41,7 @@ from ...utils.git_worktree import (
 )
 from ...utils.git_repository import get_git_repository_root_path
 from ...utils.journal import log_journal
-from ...utils.paths import get_block_list_file_path, get_context_lines
+from ...utils.paths import get_block_list_file_path
 from ...utils.repository_buffers import read_git_object_buffer_or_empty
 from ...utils.session_start_point import session_comparison_base
 from ..selection.action_completion import finish_selected_change_action

--- a/src/git_stage_batch/commands/file_scope/discard_to_batch.py
+++ b/src/git_stage_batch/commands/file_scope/discard_to_batch.py
@@ -27,6 +27,7 @@ from ...core.models import (
     RenameChange,
     TextFileDeletionChange,
 )
+from ...utils.context_lines import get_context_lines
 from ...data.file_modes import detect_file_mode_from_root
 from ...data.file_tracking import auto_add_untracked_files
 from ...data.live_diff import stream_live_git_diff
@@ -46,7 +47,6 @@ from ...utils.journal import log_journal
 from ...utils.paths import (
     ensure_state_directory_exists,
     get_block_list_file_path,
-    get_context_lines,
 )
 from ...utils.repository_buffers import read_git_object_buffer_or_empty
 from ...utils.session_start_point import session_comparison_base

--- a/src/git_stage_batch/commands/file_scope/file_list_action.py
+++ b/src/git_stage_batch/commands/file_scope/file_list_action.py
@@ -14,6 +14,7 @@ from ...core.models import (
     SingleHunkPatch,
     TextFileDeletionChange,
 )
+from ...utils.context_lines import get_context_lines
 from ...data.binary_identity import attach_live_binary_fingerprint
 from ...data.change_freshness import text_deletion_change_is_batched
 from ...data.file_hunk_display import build_combined_file_line_changes
@@ -35,7 +36,6 @@ from ...output.file_review_list import (
     print_file_review_list,
 )
 from ...utils.session_start_point import session_comparison_base
-from ...utils.paths import get_context_lines
 
 
 def show_live_file_list(files: list[str], *, selectable: bool = True) -> None:

--- a/src/git_stage_batch/commands/file_scope/include_file_to_batch.py
+++ b/src/git_stage_batch/commands/file_scope/include_file_to_batch.py
@@ -18,6 +18,7 @@ from ...core.models import (
     FileModeChange,
     SingleHunkPatch,
 )
+from ...utils.context_lines import get_context_lines
 from ...data.file_change_display import (
     render_binary_file_change,
     render_gitlink_change,
@@ -30,7 +31,6 @@ from ...utils.session_start_point import session_comparison_base
 from ...data.session import snapshot_file_if_untracked
 from ...exceptions import exit_with_error
 from ...i18n import _
-from ...utils.paths import get_context_lines
 from ...utils.repository_buffers import read_git_object_buffer_or_empty
 from ..selection import whole_file_batch_staging as _whole_file_batch_staging
 from ..selection.action_completion import finish_selected_change_action

--- a/src/git_stage_batch/commands/file_scope/multi_file_actions.py
+++ b/src/git_stage_batch/commands/file_scope/multi_file_actions.py
@@ -10,6 +10,7 @@ import sys
 from typing import Protocol
 
 from ...data.file_tracking import auto_add_untracked_files
+from ...utils.context_lines import get_context_lines
 from ...data.file_target_identity import (
     IndexIdentity,
     WorktreeIdentity,
@@ -30,7 +31,6 @@ from ...exceptions import CommandError
 from ...i18n import _, ngettext
 from ...utils.git_repository import require_git_repository
 from ...utils.paths import ensure_state_directory_exists
-from ...utils.paths import get_context_lines
 from . import discard_file as _discard_file
 from .discard_to_batch import discard_files_to_batch
 from . import include_file as _include_file

--- a/src/git_stage_batch/commands/file_scope/skip_file.py
+++ b/src/git_stage_batch/commands/file_scope/skip_file.py
@@ -26,6 +26,7 @@ from ...core.models import (
     RenameChange,
     TextFileDeletionChange,
 )
+from ...utils.context_lines import get_context_lines
 from ...data.file_tracking import auto_add_untracked_files
 from ...data.live_diff import stream_live_git_diff
 from ...data.progress import (
@@ -40,7 +41,7 @@ from ...data.selected_change.paths import get_selected_change_file_path
 from ...data.undo.checkpoints import undo_checkpoint
 from ...i18n import _, ngettext
 from ...utils.file_io import append_lines_to_file, read_text_file_line_set
-from ...utils.paths import get_block_list_file_path, get_context_lines
+from ...utils.paths import get_block_list_file_path
 from ..selection.action_completion import finish_selected_change_action
 
 

--- a/src/git_stage_batch/commands/selection/selected_change_batch_discarding.py
+++ b/src/git_stage_batch/commands/selection/selected_change_batch_discarding.py
@@ -29,6 +29,7 @@ from ...core.models import (
     SingleHunkPatch,
     TextFileDeletionChange,
 )
+from ...utils.context_lines import get_context_lines
 from ...data.file_modes import detect_file_mode
 from ...data.hunk_tracking import fetch_next_change
 from ...data.live_diff import stream_live_git_diff
@@ -52,7 +53,6 @@ from ...utils.git_repository import get_git_repository_root_path
 from ...utils.journal import log_journal
 from ...utils.paths import (
     get_block_list_file_path,
-    get_context_lines,
     get_selected_hunk_hash_file_path,
     get_selected_hunk_patch_file_path,
 )

--- a/src/git_stage_batch/commands/selection/selected_change_batch_staging.py
+++ b/src/git_stage_batch/commands/selection/selected_change_batch_staging.py
@@ -28,13 +28,14 @@ from ...core.models import (
     SingleHunkPatch,
     TextFileDeletionChange,
 )
+from ...utils.context_lines import get_context_lines
 from ...data.file_modes import detect_file_mode
 from ...data.live_diff import stream_live_git_diff
 from ...data.progress import record_hunk_skipped
 from ...exceptions import exit_with_error
 from ...i18n import _
 from ...utils.file_io import append_lines_to_file, read_text_file_line_set
-from ...utils.paths import get_block_list_file_path, get_context_lines
+from ...utils.paths import get_block_list_file_path
 from ...utils.repository_buffers import read_git_object_buffer_or_empty
 from . import whole_file_batch_staging as _whole_file_batch_staging
 from .action_completion import finish_selected_change_action

--- a/src/git_stage_batch/data/file_hunk_display.py
+++ b/src/git_stage_batch/data/file_hunk_display.py
@@ -28,8 +28,8 @@ from ..utils.repository_buffers import read_git_object_buffer_or_none
 from ..i18n import ngettext
 from ..utils.git_command import stream_git_command
 from ..git_paths import encode_path, quote_path_token
-from ..utils.paths import get_context_lines
 from ..core.text_lines import bytes_to_lines
+from ..utils.context_lines import get_context_lines
 from .file_tracking import auto_add_untracked_files
 from .live_diff import stream_live_git_diff
 from ..utils.session_start_point import session_comparison_base

--- a/src/git_stage_batch/data/live_change_candidates.py
+++ b/src/git_stage_batch/data/live_change_candidates.py
@@ -41,8 +41,8 @@ from ..utils.file_io import (
 from ..utils.paths import (
     get_block_list_file_path,
     get_blocked_files_file_path,
-    get_context_lines,
 )
+from ..utils.context_lines import get_context_lines
 from .change_freshness import text_deletion_change_is_batched
 from .binary_identity import attach_live_binary_fingerprint
 from .live_diff import stream_live_git_diff

--- a/src/git_stage_batch/data/live_change_jobs.py
+++ b/src/git_stage_batch/data/live_change_jobs.py
@@ -33,12 +33,12 @@ from ..utils.file_job_workspace import FileJobWorkspace
 from ..utils.file_jobs import OrderedFileJob
 from ..utils.git_object_io import resolve_git_objects
 from ..utils.git_repository import get_git_repository_root_path
-from ..utils.paths import get_context_lines
 from ..utils.repository_buffers import (
     load_working_tree_file_as_buffer,
     read_git_object_buffer_or_none,
 )
 from ..utils.session_start_point import current_head_commit
+from ..utils.context_lines import get_context_lines
 from .consumed_selections import load_consumed_selections_metadata
 from .live_change_candidates import (
     LiveChangeScanContext,

--- a/src/git_stage_batch/data/selected_change/hunk_recalculation.py
+++ b/src/git_stage_batch/data/selected_change/hunk_recalculation.py
@@ -27,11 +27,11 @@ from ...core.models import (
 from ...utils.file_io import read_text_file_line_set
 from ...utils.paths import (
     get_block_list_file_path,
-    get_context_lines,
     get_processed_include_ids_file_path,
     get_processed_skip_ids_file_path,
 )
 from ..auto_advance import resolve_auto_advance
+from ...utils.context_lines import get_context_lines
 from ..line_id_files import write_line_ids_file
 from .. import change_freshness as _change_freshness
 from .. import line_state as _line_state

--- a/src/git_stage_batch/data/selected_change/store.py
+++ b/src/git_stage_batch/data/selected_change/store.py
@@ -203,8 +203,11 @@ def write_selected_change_kind(kind: SelectedChangeKind) -> None:
 def invalidate_selected_change_cache() -> None:
     """Durably hide the old cache before replacing its component files."""
     kind_path = get_selected_change_kind_file_path()
+    selected_directory = kind_path.parent
+    if not selected_directory.exists():
+        return
     kind_path.unlink(missing_ok=True)
-    fsync_directory(kind_path.parent)
+    fsync_directory(selected_directory)
 
 
 def read_selected_change_kind() -> SelectedChangeKind | None:

--- a/src/git_stage_batch/data/session.py
+++ b/src/git_stage_batch/data/session.py
@@ -30,6 +30,7 @@ from ..utils.git_repository import get_git_repository_root_path
 from ..utils.journal import journal_enabled, log_journal
 from .index_entries import IndexEntry, read_index_entries
 from ..utils.paths import (
+    ensure_abort_snapshots_directory_exists,
     get_abort_head_file_path,
     get_abort_snapshot_list_file_path,
     get_abort_snapshots_directory_path,
@@ -338,6 +339,7 @@ def _snapshot_worktree_paths_for_unborn_abort(file_paths: list[str]) -> None:
         source = repo_root / file_path
         if not os.path.lexists(source) or (source.is_dir() and not source.is_symlink()):
             continue
+        ensure_abort_snapshots_directory_exists()
         target = snapshot_dir / file_path
         target.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(source, target, follow_symlinks=False)
@@ -399,6 +401,7 @@ def snapshot_file_if_untracked(
     # Save a complete before-image for files and standalone repositories.
     snapshot_dir = get_abort_snapshots_directory_path()
     snapshot_path = snapshot_dir / file_path
+    ensure_abort_snapshots_directory_exists()
     snapshot_path.parent.mkdir(parents=True, exist_ok=True)
     if full_path.is_dir() and not full_path.is_symlink():
         shutil.copytree(full_path, snapshot_path, symlinks=True)
@@ -453,6 +456,7 @@ def snapshot_files_if_untracked(file_paths: list[str]) -> None:
         if not os.path.lexists(full_path):
             continue
         snapshot_path = snapshot_dir / file_path
+        ensure_abort_snapshots_directory_exists()
         snapshot_path.parent.mkdir(parents=True, exist_ok=True)
         if full_path.is_dir() and not full_path.is_symlink():
             shutil.copytree(full_path, snapshot_path, symlinks=True)

--- a/src/git_stage_batch/output/candidate_preview.py
+++ b/src/git_stage_batch/output/candidate_preview.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 from ..batch.operation_candidate_types import OperationCandidatePreview
+from ..utils.context_lines import get_context_lines
 from ..i18n import _
-from ..utils.paths import get_context_lines
 from . import candidate_preview_snippets
 from . import candidate_preview_summary
 from .candidate_preview_commands import (

--- a/src/git_stage_batch/utils/context_lines.py
+++ b/src/git_stage_batch/utils/context_lines.py
@@ -1,0 +1,18 @@
+"""Read the persisted unified-diff context setting."""
+
+from __future__ import annotations
+
+from .file_io import read_text_file_contents
+from .paths import get_context_lines_file_path
+
+
+def get_context_lines() -> int:
+    """Return the stored context-line count, defaulting to three."""
+    context_file = get_context_lines_file_path()
+    if not context_file.exists():
+        return 3
+
+    try:
+        return int(read_text_file_contents(context_file).strip())
+    except ValueError:
+        return 3

--- a/src/git_stage_batch/utils/paths.py
+++ b/src/git_stage_batch/utils/paths.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from .file_io import read_text_file_contents
 from .git_repository import get_git_common_directory_path, get_git_directory_path
 
 
@@ -370,21 +369,6 @@ def get_context_lines_file_path() -> Path:
         Path to context lines file
     """
     return get_config_state_directory_path() / "context-lines.txt"
-
-
-def get_context_lines() -> int:
-    """Get stored context lines value, defaulting to 3.
-
-    Returns:
-        Number of context lines to use in diffs
-    """
-    context_file = get_context_lines_file_path()
-    if context_file.exists():
-        try:
-            return int(read_text_file_contents(context_file).strip())
-        except ValueError:
-            return 3
-    return 3
 
 
 def get_suggest_fixup_state_file_path() -> Path:

--- a/src/git_stage_batch/utils/paths.py
+++ b/src/git_stage_batch/utils/paths.py
@@ -47,37 +47,52 @@ def ensure_state_directory_exists() -> None:
 
 def get_session_directory_path() -> Path:
     """Get the directory containing active session scratch state."""
-    path = get_state_directory_path() / "session"
-    path.mkdir(parents=True, exist_ok=True)
-    return path
+    return get_state_directory_path() / "session"
+
+
+def ensure_session_directory_exists() -> None:
+    """Create the active session scratch directory if it does not exist."""
+    get_session_directory_path().mkdir(parents=True, exist_ok=True)
 
 
 def get_selected_state_directory_path() -> Path:
     """Get the directory containing the selected change cache."""
-    path = get_session_directory_path() / "selected"
-    path.mkdir(parents=True, exist_ok=True)
-    return path
+    return get_session_directory_path() / "selected"
+
+
+def ensure_selected_state_directory_exists() -> None:
+    """Create the selected change cache directory if it does not exist."""
+    get_selected_state_directory_path().mkdir(parents=True, exist_ok=True)
 
 
 def get_progress_state_directory_path() -> Path:
     """Get the directory containing hunk progress state."""
-    path = get_session_directory_path() / "progress"
-    path.mkdir(parents=True, exist_ok=True)
-    return path
+    return get_session_directory_path() / "progress"
+
+
+def ensure_progress_state_directory_exists() -> None:
+    """Create the hunk progress directory if it does not exist."""
+    get_progress_state_directory_path().mkdir(parents=True, exist_ok=True)
 
 
 def get_processed_state_directory_path() -> Path:
     """Get the directory containing processed line-id state."""
-    path = get_session_directory_path() / "processed"
-    path.mkdir(parents=True, exist_ok=True)
-    return path
+    return get_session_directory_path() / "processed"
+
+
+def ensure_processed_state_directory_exists() -> None:
+    """Create the processed line-id directory if it does not exist."""
+    get_processed_state_directory_path().mkdir(parents=True, exist_ok=True)
 
 
 def get_config_state_directory_path() -> Path:
     """Get the directory containing session configuration state."""
-    path = get_session_directory_path() / "config"
-    path.mkdir(parents=True, exist_ok=True)
-    return path
+    return get_session_directory_path() / "config"
+
+
+def ensure_config_state_directory_exists() -> None:
+    """Create the session configuration directory if it does not exist."""
+    get_config_state_directory_path().mkdir(parents=True, exist_ok=True)
 
 
 def get_auto_advance_config_file_path() -> Path:
@@ -87,23 +102,32 @@ def get_auto_advance_config_file_path() -> Path:
 
 def get_abort_state_directory_path() -> Path:
     """Get the directory containing abort/recovery state."""
-    path = get_session_directory_path() / "abort"
-    path.mkdir(parents=True, exist_ok=True)
-    return path
+    return get_session_directory_path() / "abort"
+
+
+def ensure_abort_state_directory_exists() -> None:
+    """Create the abort recovery directory if it does not exist."""
+    get_abort_state_directory_path().mkdir(parents=True, exist_ok=True)
 
 
 def get_fixup_state_directory_path() -> Path:
     """Get the directory containing suggest-fixup state."""
-    path = get_session_directory_path() / "fixup"
-    path.mkdir(parents=True, exist_ok=True)
-    return path
+    return get_session_directory_path() / "fixup"
+
+
+def ensure_fixup_state_directory_exists() -> None:
+    """Create the suggest-fixup state directory if it does not exist."""
+    get_fixup_state_directory_path().mkdir(parents=True, exist_ok=True)
 
 
 def get_candidate_state_directory_path() -> Path:
     """Get the directory containing batch candidate iteration state."""
-    path = get_session_directory_path() / "candidates"
-    path.mkdir(parents=True, exist_ok=True)
-    return path
+    return get_session_directory_path() / "candidates"
+
+
+def ensure_candidate_state_directory_exists() -> None:
+    """Create the batch candidate state directory if it does not exist."""
+    get_candidate_state_directory_path().mkdir(parents=True, exist_ok=True)
 
 
 def get_batch_candidate_state_file_path() -> Path:
@@ -269,6 +293,11 @@ def get_abort_snapshots_directory_path() -> Path:
         Path to snapshots directory
     """
     return get_abort_state_directory_path() / "untracked"
+
+
+def ensure_abort_snapshots_directory_exists() -> None:
+    """Create the untracked-file recovery directory if it does not exist."""
+    get_abort_snapshots_directory_path().mkdir(parents=True, exist_ok=True)
 
 
 def get_abort_snapshot_list_file_path() -> Path:

--- a/tests/commands/test_again.py
+++ b/tests/commands/test_again.py
@@ -23,6 +23,7 @@ from git_stage_batch.commands.start import command_start
 from git_stage_batch.batch.state.lifecycle import create_batch
 from git_stage_batch.utils.file_io import read_text_file_contents, write_text_file_contents
 from git_stage_batch.utils.paths import (
+    ensure_progress_state_directory_exists,
     get_abort_head_file_path,
     get_abort_snapshot_list_file_path,
     get_abort_snapshots_directory_path,
@@ -68,6 +69,7 @@ class TestCommandAgain:
         state_dir = get_state_directory_path()
 
         # Create iteration-specific files
+        ensure_progress_state_directory_exists()
         blocklist = get_block_list_file_path()
         blocklist.write_text("test")
 
@@ -328,6 +330,7 @@ class TestCommandAgain:
 
         # Create iteration-specific file to verify it was cleared
         state_dir = get_state_directory_path()
+        ensure_progress_state_directory_exists()
         blocklist = get_block_list_file_path()
         blocklist.write_text("test")
 

--- a/tests/commands/test_show.py
+++ b/tests/commands/test_show.py
@@ -3,7 +3,8 @@
 from git_stage_batch.core.hashing import compute_stable_hunk_hash_from_lines
 from tests.diff_parser_helpers import collect_unified_diff
 from git_stage_batch.utils.git_command import stream_git_command
-from git_stage_batch.utils.paths import get_block_list_file_path, get_context_lines
+from git_stage_batch.utils.context_lines import get_context_lines
+from git_stage_batch.utils.paths import get_block_list_file_path
 from git_stage_batch.data.session import initialize_abort_state
 from git_stage_batch.utils.paths import ensure_state_directory_exists
 from git_stage_batch.utils.paths import (
@@ -154,6 +155,7 @@ class TestCommandShow:
         first_patch_hash = compute_stable_hunk_hash_from_lines(patches[0].lines)
 
         blocklist_path = get_block_list_file_path()
+        blocklist_path.parent.mkdir(parents=True, exist_ok=True)
         blocklist_path.write_text(f"{first_patch_hash}\n")
 
         command_show()
@@ -181,6 +183,7 @@ class TestCommandShow:
         patch_hash = compute_stable_hunk_hash_from_lines(patches[0].lines)
 
         blocklist_path = get_block_list_file_path()
+        blocklist_path.parent.mkdir(parents=True, exist_ok=True)
         blocklist_path.write_text(f"{patch_hash}\n")
 
         command_show()
@@ -310,6 +313,7 @@ class TestCommandShow:
         patch_hash = compute_stable_hunk_hash_from_lines(patches[0].lines)
 
         blocklist_path = get_block_list_file_path()
+        blocklist_path.parent.mkdir(parents=True, exist_ok=True)
         blocklist_path.write_text(f"{patch_hash}\n")
 
         # Should exit with code 1

--- a/tests/commands/test_status.py
+++ b/tests/commands/test_status.py
@@ -11,7 +11,11 @@ from git_stage_batch.commands.show_from import command_show_from_batch
 from git_stage_batch.data.selected_change.store import SelectedChangeKind, read_selected_change_kind
 from git_stage_batch.data.session import initialize_abort_state
 from git_stage_batch.utils.paths import get_iteration_count_file_path
-from git_stage_batch.utils.paths import ensure_state_directory_exists, get_state_directory_path
+from git_stage_batch.utils.paths import (
+    ensure_config_state_directory_exists,
+    ensure_state_directory_exists,
+    get_state_directory_path,
+)
 
 import json
 import subprocess
@@ -194,6 +198,7 @@ class TestCommandStatus:
         # Set iteration count to 2 to test iteration display
         ensure_state_directory_exists()
         initialize_abort_state()
+        ensure_config_state_directory_exists()
         get_iteration_count_file_path().write_text("2")
 
         # Cache selected hunk with show

--- a/tests/data/test_hunk_tracking.py
+++ b/tests/data/test_hunk_tracking.py
@@ -21,6 +21,8 @@ from git_stage_batch.data.hunk_tracking import (
 )
 from git_stage_batch.utils.file_io import append_lines_to_file
 from git_stage_batch.utils.paths import (
+    ensure_processed_state_directory_exists,
+    ensure_selected_state_directory_exists,
     ensure_state_directory_exists,
     get_block_list_file_path,
     get_selected_hunk_hash_file_path,
@@ -48,6 +50,8 @@ def temp_git_repo(tmp_path, monkeypatch):
     subprocess.run(["git", "commit", "-m", "Initial commit"], check=True, cwd=repo, capture_output=True)
 
     ensure_state_directory_exists()
+    ensure_selected_state_directory_exists()
+    ensure_processed_state_directory_exists()
 
     return repo
 

--- a/tests/data/test_line_state.py
+++ b/tests/data/test_line_state.py
@@ -15,6 +15,8 @@ from git_stage_batch.data.line_state import (
 from git_stage_batch.exceptions import CommandError
 from git_stage_batch.utils.file_io import write_text_file_contents
 from git_stage_batch.utils.paths import (
+    ensure_processed_state_directory_exists,
+    ensure_selected_state_directory_exists,
     ensure_state_directory_exists,
     get_selected_hunk_patch_file_path,
     get_line_changes_json_file_path,
@@ -41,6 +43,8 @@ def temp_git_repo(tmp_path, monkeypatch):
 
     # Ensure state directory exists
     ensure_state_directory_exists()
+    ensure_selected_state_directory_exists()
+    ensure_processed_state_directory_exists()
 
     return repo
 

--- a/tests/data/test_selected_change_lifecycle.py
+++ b/tests/data/test_selected_change_lifecycle.py
@@ -9,6 +9,8 @@ from git_stage_batch.data.selected_change.lifecycle import (
     clear_selected_change_state_files,
 )
 from git_stage_batch.utils.paths import (
+    ensure_processed_state_directory_exists,
+    ensure_selected_state_directory_exists,
     ensure_state_directory_exists,
     get_index_snapshot_file_path,
     get_line_changes_json_file_path,
@@ -60,6 +62,8 @@ class TestClearSelectedChangeStateFiles:
 
     def test_clears_per_selection_state_files(self, temp_git_repo):
         """Selected-change cleanup should leave global batch state intact."""
+        ensure_selected_state_directory_exists()
+        ensure_processed_state_directory_exists()
         get_selected_hunk_patch_file_path().write_text("patch")
         get_selected_hunk_hash_file_path().write_text("hash")
         get_line_changes_json_file_path().write_text("{}")

--- a/tests/data/test_selected_hunk_recalculation.py
+++ b/tests/data/test_selected_hunk_recalculation.py
@@ -15,6 +15,7 @@ from git_stage_batch.data.selected_change.hunk_recalculation import (
 from git_stage_batch.data.session import initialize_abort_state
 from git_stage_batch.utils.file_io import append_lines_to_file
 from git_stage_batch.utils.paths import (
+    ensure_processed_state_directory_exists,
     ensure_state_directory_exists,
     get_block_list_file_path,
     get_processed_include_ids_file_path,
@@ -124,6 +125,7 @@ class TestRecalculateCurrentHunkForFile:
 
         # Cache hunk and add some processed IDs
         fetch_next_change()
+        ensure_processed_state_directory_exists()
         get_processed_include_ids_file_path().write_text("1\n2\n")
 
         # Recalculate

--- a/tests/utils/test_context_lines.py
+++ b/tests/utils/test_context_lines.py
@@ -1,0 +1,44 @@
+"""Tests for persisted unified-diff context configuration."""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from git_stage_batch.utils.context_lines import get_context_lines
+from git_stage_batch.utils.paths import get_context_lines_file_path
+
+
+@pytest.fixture
+def temp_git_repo(tmp_path, monkeypatch):
+    """Create a temporary Git repository."""
+    repo = tmp_path / "test_repo"
+    repo.mkdir()
+    subprocess.run(["git", "init"], check=True, cwd=repo, capture_output=True)
+    monkeypatch.chdir(repo)
+    return repo
+
+
+def test_get_context_lines_default_does_not_create_state(temp_git_repo):
+    """Reading an absent setting should leave repository state untouched."""
+    assert get_context_lines() == 3
+    assert not (temp_git_repo / ".git" / "git-stage-batch").exists()
+
+
+def test_get_context_lines_reads_file(temp_git_repo):
+    """A stored integer should override the default."""
+    context_file = get_context_lines_file_path()
+    context_file.parent.mkdir(parents=True)
+    context_file.write_text("5\n")
+
+    assert get_context_lines() == 5
+
+
+def test_get_context_lines_invalid_content(temp_git_repo):
+    """Malformed stored content should use the default."""
+    context_file = get_context_lines_file_path()
+    context_file.parent.mkdir(parents=True)
+    context_file.write_text("not-a-number\n")
+
+    assert get_context_lines() == 3

--- a/tests/utils/test_paths.py
+++ b/tests/utils/test_paths.py
@@ -27,14 +27,15 @@ from git_stage_batch.utils.paths import get_processed_batch_ids_file_path
 from git_stage_batch.utils.paths import get_batched_hunks_file_path
 from git_stage_batch.utils.paths import get_start_batch_refs_file_path
 
+import inspect
 import subprocess
 from pathlib import Path
 
 import pytest
 
+from git_stage_batch.utils import paths as path_utils
 from git_stage_batch.utils.paths import (
     ensure_state_directory_exists,
-    get_context_lines,
     get_context_lines_file_path,
     get_state_directory_path,
 )
@@ -57,6 +58,97 @@ def temp_git_repo(tmp_path, monkeypatch):
     subprocess.run(["git", "commit", "-m", "Initial commit"], check=True, cwd=repo, capture_output=True)
 
     return repo
+
+
+_PATH_GETTERS = [
+    (name, getter)
+    for name, getter in vars(path_utils).items()
+    if (
+        inspect.isfunction(getter)
+        and getter.__module__ == path_utils.__name__
+        and name.startswith("get_")
+        and name.endswith("_path")
+    )
+]
+
+
+@pytest.mark.parametrize(
+    ("name", "getter"),
+    _PATH_GETTERS,
+    ids=[name for name, _getter in _PATH_GETTERS],
+)
+def test_path_getters_do_not_create_state(temp_git_repo, name, getter):
+    """Constructing any state path must not create repository directories."""
+    required_parameters = [
+        parameter
+        for parameter in inspect.signature(getter).parameters.values()
+        if parameter.default is inspect.Parameter.empty
+    ]
+    arguments = ["example-batch"] if required_parameters else []
+
+    result = getter(*arguments)
+
+    assert isinstance(result, Path), name
+    assert not (temp_git_repo / ".git" / "git-stage-batch").exists(), name
+
+
+@pytest.mark.parametrize(
+    ("ensure_directory", "get_directory"),
+    [
+        (
+            path_utils.ensure_state_directory_exists,
+            path_utils.get_state_directory_path,
+        ),
+        (
+            path_utils.ensure_session_directory_exists,
+            path_utils.get_session_directory_path,
+        ),
+        (
+            path_utils.ensure_selected_state_directory_exists,
+            path_utils.get_selected_state_directory_path,
+        ),
+        (
+            path_utils.ensure_progress_state_directory_exists,
+            path_utils.get_progress_state_directory_path,
+        ),
+        (
+            path_utils.ensure_processed_state_directory_exists,
+            path_utils.get_processed_state_directory_path,
+        ),
+        (
+            path_utils.ensure_config_state_directory_exists,
+            path_utils.get_config_state_directory_path,
+        ),
+        (
+            path_utils.ensure_abort_state_directory_exists,
+            path_utils.get_abort_state_directory_path,
+        ),
+        (
+            path_utils.ensure_abort_snapshots_directory_exists,
+            path_utils.get_abort_snapshots_directory_path,
+        ),
+        (
+            path_utils.ensure_fixup_state_directory_exists,
+            path_utils.get_fixup_state_directory_path,
+        ),
+        (
+            path_utils.ensure_candidate_state_directory_exists,
+            path_utils.get_candidate_state_directory_path,
+        ),
+    ],
+)
+def test_explicit_directory_ensure_creates_requested_path(
+    temp_git_repo,
+    ensure_directory,
+    get_directory,
+):
+    """Explicit ensure helpers should create their selected directory."""
+    expected_directory = get_directory()
+    assert not expected_directory.exists()
+
+    ensure_directory()
+
+    assert expected_directory.is_dir()
 
 
 class TestGetStateDirectoryPath:
@@ -191,29 +283,6 @@ class TestLineLevelOperationPaths:
         lock_path = get_session_lock_file_path()
         state_dir = get_state_directory_path()
         assert lock_path == state_dir / "session.lock"
-
-
-class TestGetContextLines:
-    """Tests for get_context_lines function."""
-
-    def test_get_context_lines_default(self, temp_git_repo):
-        """Test that get_context_lines returns 3 when file doesn't exist."""
-        ensure_state_directory_exists()
-        assert get_context_lines() == 3
-
-    def test_get_context_lines_reads_file(self, temp_git_repo):
-        """Test that get_context_lines reads value from file."""
-        ensure_state_directory_exists()
-        context_file = get_context_lines_file_path()
-        context_file.write_text("5\n")
-        assert get_context_lines() == 5
-
-    def test_get_context_lines_invalid_content(self, temp_git_repo):
-        """Test that get_context_lines returns 3 for invalid content."""
-        ensure_state_directory_exists()
-        context_file = get_context_lines_file_path()
-        context_file.write_text("not-a-number\n")
-        assert get_context_lines() == 3
 
 
 class TestGetContextLinesFilePath:


### PR DESCRIPTION
The state path utility constructs repository paths, reads the saved
unified-diff context setting, and lets several nested directory getters
prepare storage as a side effect.

Repository inspection can therefore create session state merely by asking
where a record would live. Direct recovery snapshot copies also depend on
that hidden setup, which obscures the distinction between reading state and
crossing a filesystem write boundary.

This PR moves context setting reads to a dedicated utility, makes every state
path getter side-effect free, and adds explicit directory initialization for
direct snapshot copies. Missing selected-change cache storage is left alone,
tests dynamically check every getter and explicit ensure helper, and the
architecture guide defines the storage contract. The full suite passes with
3,578 tests and 12 skips; the post-refinement 271-test focus, Ruff, type
hygiene, strict mypy, and a clean-tree package build also pass.

Path lookup is now auditable as a pure operation, while directory creation is
owned by explicit write boundaries.
