### PR TITLE
merge: Separate insertion decisions from edit assembly

### DIFF
--- a/BATCHES.md
+++ b/BATCHES.md
@@ -353,9 +353,12 @@ exact-coordinate responsibilities:
 - [`batch/merge/baseline_replacement_edits.py`](src/git_stage_batch/batch/merge/baseline_replacement_edits.py)
   plans replacement edits at verified baseline positions and records which
   source ranges supply their new content.
+- [`batch/merge/baseline_presence_edits.py`](src/git_stage_batch/batch/merge/baseline_presence_edits.py)
+  plans insertions for required source lines at recorded baseline positions
+  and checks that structurally matched lines survive other planned edits.
 - [`batch/merge/baseline_edits.py`](src/git_stage_batch/batch/merge/baseline_edits.py)
-  coordinates exact-coordinate replacement, removal, and insertion planning
-  and opens the resulting edit stream.
+  coordinates the separate replacement, removal, and insertion plans and opens
+  the resulting edit stream.
 - [`batch/merge/absence_constraints.py`](src/git_stage_batch/batch/merge/absence_constraints.py)
   resolves which matching baseline bytes an absence claim may suppress.
 - [`batch/merge/presence_constraints.py`](src/git_stage_batch/batch/merge/presence_constraints.py)

--- a/src/git_stage_batch/batch/merge/baseline_edits.py
+++ b/src/git_stage_batch/batch/merge/baseline_edits.py
@@ -6,8 +6,8 @@ from collections.abc import Iterator, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from ...core.line_selection import LineRanges, LineSelection, coerce_line_ranges
-from ...core.mapped_storage import MappedRecordVector, sort_mapped_records
+from ...core.line_selection import LineSelection, coerce_line_ranges
+from ...core.mapped_storage import MappedRecordVector
 from ...core.text_lines import normalize_line_sequence_endings
 from .baseline_anchor_matching import (
     baseline_removal_edit as _baseline_removal_edit,
@@ -17,8 +17,8 @@ from .baseline_edit_plan import (
     BaselineEditPlan as _BaselineEditPlan,
     BaselineEditStream as _BaselineEditStream,
 )
-from .baseline_reference_positions import (
-    baseline_reference_insertion_position as _find_baseline_insertion_position,
+from .baseline_presence_edits import (
+    plan_presence_insertions as _plan_presence_insertions,
 )
 from .baseline_replacement_edits import (
     plan_replacement_unit_edits as _plan_replacement_unit_edits,
@@ -34,7 +34,6 @@ from ..line_matching.sequence_equality import (
     line_slice_equals as _line_slice_matches,
 )
 from ..line_matching.line_mapping import LineMapping
-from ..line_matching.match import match_lines as _match_lines
 from ..line_matching.match_workspace import MatcherWorkspace
 from .candidates import MergeResolution as _MergeResolution
 
@@ -51,49 +50,6 @@ def _selection_outside_bounds(lines: LineSelection, max_line: int) -> bool:
         if line < 1 or line > max_line:
             return True
     return False
-
-
-def _positioned_source_lines_match(
-    source_lines: Sequence[bytes],
-    working_lines: Sequence[bytes],
-    position: int,
-    positioned_lines: Sequence[tuple[int, ...]],
-    start_index: int,
-    stop_index: int,
-) -> bool:
-    """Return whether one positioned source-line group already exists."""
-    line_count = stop_index - start_index
-    if position < 0 or position + line_count > len(working_lines):
-        return False
-
-    for offset, record_index in enumerate(range(start_index, stop_index)):
-        _record_position, source_line = positioned_lines[record_index]
-        if working_lines[position + offset] != source_lines[source_line - 1]:
-            return False
-    return True
-
-
-def _presence_lines_without_replacements(
-    presence_lines: LineRanges,
-    replacement_source_ranges: Sequence[tuple[int, ...]],
-) -> Iterator[int]:
-    """Yield claimed source lines not carried by replacement units."""
-    replacement_range_index = 0
-    for presence_start, presence_end in presence_lines.ranges():
-        remaining_start = presence_start
-        while (
-            replacement_range_index < len(replacement_source_ranges)
-            and replacement_source_ranges[replacement_range_index][0] <= presence_end
-        ):
-            replacement_start, replacement_end = replacement_source_ranges[
-                replacement_range_index
-            ]
-            for claimed_line in range(remaining_start, replacement_start):
-                yield claimed_line
-            remaining_start = replacement_end + 1
-            replacement_range_index += 1
-        for claimed_line in range(remaining_start, presence_end + 1):
-            yield claimed_line
 
 
 def _plan_independent_removal_edits(
@@ -121,223 +77,6 @@ def _plan_independent_removal_edits(
         )
 
     return True
-
-
-def _collect_presence_position_records(
-    workspace: MatcherWorkspace,
-    source_line_count: int,
-    working_lines: Sequence[bytes],
-    ownership: BatchOwnership,
-    presence_lines: LineRanges,
-    replacement_source_ranges: Sequence[tuple[int, ...]],
-) -> tuple[MappedRecordVector, MappedRecordVector, bool] | None:
-    """Partition presence lines into positioned and mapping-backed records."""
-    positioned_lines = workspace.record_vector(
-        len(presence_lines),
-        "QQ",
-    )
-    unmapped_lines = workspace.record_vector(
-        len(presence_lines),
-        "Q",
-    )
-    positioned_lines_are_ordered = True
-    previous_position: int | None = None
-
-    for claimed_line in _presence_lines_without_replacements(
-        presence_lines,
-        replacement_source_ranges,
-    ):
-        if claimed_line > source_line_count:
-            return None
-        position = _find_baseline_insertion_position(
-            ownership.presence_baseline_reference(claimed_line),
-            working_lines,
-        )
-        if position is None:
-            unmapped_lines.append((claimed_line,))
-        else:
-            if (
-                previous_position is not None
-                and position < previous_position
-            ):
-                positioned_lines_are_ordered = False
-            positioned_lines.append((position, claimed_line))
-            previous_position = position
-
-    return positioned_lines, unmapped_lines, positioned_lines_are_ordered
-
-
-def _mapping_preserves_unpositioned_presence(
-    plan: _BaselineEditPlan,
-    source_lines: Sequence[bytes],
-    working_lines: Sequence[bytes],
-    unmapped_lines: MappedRecordVector,
-    *,
-    spool_dir: str | Path | None,
-) -> bool:
-    """Return whether mapped unpositioned lines survive planned removals."""
-    if not unmapped_lines:
-        return True
-
-    if not plan.sort_target_spans_and_validate():
-        return False
-
-    target_lines_are_ordered = True
-    previous_target_line: int | None = None
-    with _match_lines(
-        source_lines,
-        working_lines,
-        spool_dir=spool_dir,
-    ) as mapping:
-        for record_index in range(len(unmapped_lines)):
-            claimed_line = unmapped_lines[record_index][0]
-            target_line = mapping.get_target_line_from_source_line(claimed_line)
-            if target_line is None:
-                return False
-            target_index = target_line - 1
-            if previous_target_line is not None and target_index < previous_target_line:
-                target_lines_are_ordered = False
-            unmapped_lines[record_index] = (target_index,)
-            previous_target_line = target_index
-
-    if not target_lines_are_ordered:
-        sort_mapped_records(unmapped_lines)
-    return not plan.removes_any_target_lines(unmapped_lines)
-
-
-def _add_positioned_presence_insertions(
-    plan: _BaselineEditPlan,
-    source_lines: Sequence[bytes],
-    working_lines: Sequence[bytes],
-    positioned_lines: MappedRecordVector,
-    target_spans: Sequence[tuple[int, ...]],
-    *,
-    positioned_lines_are_ordered: bool,
-    trust_baseline_coordinates: bool,
-) -> bool:
-    """Append required insertion groups and retain only their source records."""
-    if not positioned_lines_are_ordered:
-        sort_mapped_records(positioned_lines)
-
-    group_start = 0
-    retained_line_count = 0
-    target_span_index = 0
-    while group_start < len(positioned_lines):
-        position = positioned_lines[group_start][0]
-        group_stop = group_start + 1
-        while (
-            group_stop < len(positioned_lines)
-            and positioned_lines[group_stop][0] == position
-        ):
-            group_stop += 1
-
-        while (
-            target_span_index < len(target_spans)
-            and target_spans[target_span_index][1] <= position
-        ):
-            target_span_index += 1
-
-        group_matches = (
-            not trust_baseline_coordinates
-            and _positioned_source_lines_match(
-                source_lines,
-                working_lines,
-                position,
-                positioned_lines,
-                group_start,
-                group_stop,
-            )
-        )
-
-        retain_group = not group_matches
-        if group_matches:
-            group_end = position + group_stop - group_start
-            removed_line_count = 0
-            scan_index = target_span_index
-            while (
-                scan_index < len(target_spans)
-                and target_spans[scan_index][0] < group_end
-            ):
-                span_start, span_end = target_spans[scan_index]
-                removed_line_count += max(
-                    0,
-                    min(group_end, span_end) - max(position, span_start),
-                )
-                if span_end >= group_end:
-                    break
-                scan_index += 1
-
-            if 0 < removed_line_count < group_end - position:
-                return False
-            retain_group = removed_line_count == group_end - position
-
-        if retain_group:
-            plan.add_positioned_source_lines(
-                position,
-                positioned_lines,
-                group_start,
-                group_stop,
-            )
-            for record_index in range(group_start, group_stop):
-                positioned_lines[retained_line_count] = positioned_lines[record_index]
-                retained_line_count += 1
-        group_start = group_stop
-    positioned_lines.truncate(retained_line_count)
-    return True
-
-
-def _plan_presence_insertions(
-    plan: _BaselineEditPlan,
-    workspace: MatcherWorkspace,
-    source_lines: Sequence[bytes],
-    working_lines: Sequence[bytes],
-    ownership: BatchOwnership,
-    presence_lines: LineRanges,
-    replacement_source_ranges: Sequence[tuple[int, ...]],
-    *,
-    trust_baseline_coordinates: bool,
-    spool_dir: str | Path | None,
-) -> MappedRecordVector | None:
-    """Plan explicit insertions and validate presence resolved by matching."""
-    position_records = _collect_presence_position_records(
-        workspace,
-        len(source_lines),
-        working_lines,
-        ownership,
-        presence_lines,
-        replacement_source_ranges,
-    )
-    if position_records is None:
-        return None
-    positioned_lines, unmapped_lines, positioned_lines_are_ordered = (
-        position_records
-    )
-
-    if not _mapping_preserves_unpositioned_presence(
-        plan,
-        source_lines,
-        working_lines,
-        unmapped_lines,
-        spool_dir=spool_dir,
-    ):
-        return None
-
-    workspace.close_resource(unmapped_lines)
-    target_spans = plan.sorted_target_spans()
-    if target_spans is None:
-        return None
-    if not _add_positioned_presence_insertions(
-        plan,
-        source_lines,
-        working_lines,
-        positioned_lines,
-        target_spans,
-        positioned_lines_are_ordered=positioned_lines_are_ordered,
-        trust_baseline_coordinates=trust_baseline_coordinates,
-    ):
-        return None
-
-    return positioned_lines
 
 
 def _has_complete_baseline_references(

--- a/src/git_stage_batch/batch/merge/baseline_presence_edits.py
+++ b/src/git_stage_batch/batch/merge/baseline_presence_edits.py
@@ -1,0 +1,279 @@
+"""Presence edits for baseline-coordinate merge planning."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Sequence
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from ...core.line_selection import LineRanges
+from ...core.mapped_storage import MappedRecordVector, sort_mapped_records
+from .baseline_edit_plan import BaselineEditPlan
+from .baseline_reference_positions import (
+    baseline_reference_insertion_position as _find_baseline_insertion_position,
+)
+from ..line_matching.match import match_lines as _match_lines
+from ..line_matching.match_workspace import MatcherWorkspace
+
+if TYPE_CHECKING:
+    from ..ownership.model import BatchOwnership
+
+
+def _positioned_source_lines_match(
+    source_lines: Sequence[bytes],
+    working_lines: Sequence[bytes],
+    position: int,
+    positioned_lines: Sequence[tuple[int, ...]],
+    start_index: int,
+    stop_index: int,
+) -> bool:
+    """Return whether one positioned source-line group already exists."""
+    line_count = stop_index - start_index
+    if position < 0 or position + line_count > len(working_lines):
+        return False
+
+    for offset, record_index in enumerate(range(start_index, stop_index)):
+        _record_position, source_line = positioned_lines[record_index]
+        if working_lines[position + offset] != source_lines[source_line - 1]:
+            return False
+    return True
+
+
+def _presence_lines_without_replacements(
+    presence_lines: LineRanges,
+    replacement_source_ranges: Sequence[tuple[int, ...]],
+) -> Iterator[int]:
+    """Yield claimed source lines not carried by replacement units."""
+    replacement_range_index = 0
+    for presence_start, presence_end in presence_lines.ranges():
+        remaining_start = presence_start
+        while (
+            replacement_range_index < len(replacement_source_ranges)
+            and replacement_source_ranges[replacement_range_index][0] <= presence_end
+        ):
+            replacement_start, replacement_end = replacement_source_ranges[
+                replacement_range_index
+            ]
+            for claimed_line in range(remaining_start, replacement_start):
+                yield claimed_line
+            remaining_start = replacement_end + 1
+            replacement_range_index += 1
+        for claimed_line in range(remaining_start, presence_end + 1):
+            yield claimed_line
+
+
+def _collect_presence_position_records(
+    workspace: MatcherWorkspace,
+    source_line_count: int,
+    working_lines: Sequence[bytes],
+    ownership: BatchOwnership,
+    presence_lines: LineRanges,
+    replacement_source_ranges: Sequence[tuple[int, ...]],
+) -> tuple[MappedRecordVector, MappedRecordVector, bool] | None:
+    """Partition presence lines into positioned and mapping-backed records."""
+    positioned_lines = workspace.record_vector(
+        len(presence_lines),
+        "QQ",
+    )
+    unmapped_lines = workspace.record_vector(
+        len(presence_lines),
+        "Q",
+    )
+    positioned_lines_are_ordered = True
+    previous_position: int | None = None
+
+    for claimed_line in _presence_lines_without_replacements(
+        presence_lines,
+        replacement_source_ranges,
+    ):
+        if claimed_line > source_line_count:
+            return None
+        position = _find_baseline_insertion_position(
+            ownership.presence_baseline_reference(claimed_line),
+            working_lines,
+        )
+        if position is None:
+            unmapped_lines.append((claimed_line,))
+        else:
+            if (
+                previous_position is not None
+                and position < previous_position
+            ):
+                positioned_lines_are_ordered = False
+            positioned_lines.append((position, claimed_line))
+            previous_position = position
+
+    return positioned_lines, unmapped_lines, positioned_lines_are_ordered
+
+
+def _mapping_preserves_unpositioned_presence(
+    plan: BaselineEditPlan,
+    source_lines: Sequence[bytes],
+    working_lines: Sequence[bytes],
+    unmapped_lines: MappedRecordVector,
+    *,
+    spool_dir: str | Path | None,
+) -> bool:
+    """Return whether mapped unpositioned lines survive planned removals."""
+    if not unmapped_lines:
+        return True
+
+    if not plan.sort_target_spans_and_validate():
+        return False
+
+    target_lines_are_ordered = True
+    previous_target_line: int | None = None
+    with _match_lines(
+        source_lines,
+        working_lines,
+        spool_dir=spool_dir,
+    ) as mapping:
+        for record_index in range(len(unmapped_lines)):
+            claimed_line = unmapped_lines[record_index][0]
+            target_line = mapping.get_target_line_from_source_line(claimed_line)
+            if target_line is None:
+                return False
+            target_index = target_line - 1
+            if previous_target_line is not None and target_index < previous_target_line:
+                target_lines_are_ordered = False
+            unmapped_lines[record_index] = (target_index,)
+            previous_target_line = target_index
+
+    if not target_lines_are_ordered:
+        sort_mapped_records(unmapped_lines)
+    return not plan.removes_any_target_lines(unmapped_lines)
+
+
+def _add_positioned_presence_insertions(
+    plan: BaselineEditPlan,
+    source_lines: Sequence[bytes],
+    working_lines: Sequence[bytes],
+    positioned_lines: MappedRecordVector,
+    target_spans: Sequence[tuple[int, ...]],
+    *,
+    positioned_lines_are_ordered: bool,
+    trust_baseline_coordinates: bool,
+) -> bool:
+    """Append required insertion groups and retain only their source records."""
+    if not positioned_lines_are_ordered:
+        sort_mapped_records(positioned_lines)
+
+    group_start = 0
+    retained_line_count = 0
+    target_span_index = 0
+    while group_start < len(positioned_lines):
+        position = positioned_lines[group_start][0]
+        group_stop = group_start + 1
+        while (
+            group_stop < len(positioned_lines)
+            and positioned_lines[group_stop][0] == position
+        ):
+            group_stop += 1
+
+        while (
+            target_span_index < len(target_spans)
+            and target_spans[target_span_index][1] <= position
+        ):
+            target_span_index += 1
+
+        group_matches = (
+            not trust_baseline_coordinates
+            and _positioned_source_lines_match(
+                source_lines,
+                working_lines,
+                position,
+                positioned_lines,
+                group_start,
+                group_stop,
+            )
+        )
+
+        retain_group = not group_matches
+        if group_matches:
+            group_end = position + group_stop - group_start
+            removed_line_count = 0
+            scan_index = target_span_index
+            while (
+                scan_index < len(target_spans)
+                and target_spans[scan_index][0] < group_end
+            ):
+                span_start, span_end = target_spans[scan_index]
+                removed_line_count += max(
+                    0,
+                    min(group_end, span_end) - max(position, span_start),
+                )
+                if span_end >= group_end:
+                    break
+                scan_index += 1
+
+            if 0 < removed_line_count < group_end - position:
+                return False
+            retain_group = removed_line_count == group_end - position
+
+        if retain_group:
+            plan.add_positioned_source_lines(
+                position,
+                positioned_lines,
+                group_start,
+                group_stop,
+            )
+            for record_index in range(group_start, group_stop):
+                positioned_lines[retained_line_count] = positioned_lines[record_index]
+                retained_line_count += 1
+        group_start = group_stop
+    positioned_lines.truncate(retained_line_count)
+    return True
+
+
+def plan_presence_insertions(
+    plan: BaselineEditPlan,
+    workspace: MatcherWorkspace,
+    source_lines: Sequence[bytes],
+    working_lines: Sequence[bytes],
+    ownership: BatchOwnership,
+    presence_lines: LineRanges,
+    replacement_source_ranges: Sequence[tuple[int, ...]],
+    *,
+    trust_baseline_coordinates: bool,
+    spool_dir: str | Path | None,
+) -> MappedRecordVector | None:
+    """Plan explicit insertions and validate presence resolved by matching."""
+    position_records = _collect_presence_position_records(
+        workspace,
+        len(source_lines),
+        working_lines,
+        ownership,
+        presence_lines,
+        replacement_source_ranges,
+    )
+    if position_records is None:
+        return None
+    positioned_lines, unmapped_lines, positioned_lines_are_ordered = (
+        position_records
+    )
+
+    if not _mapping_preserves_unpositioned_presence(
+        plan,
+        source_lines,
+        working_lines,
+        unmapped_lines,
+        spool_dir=spool_dir,
+    ):
+        return None
+
+    workspace.close_resource(unmapped_lines)
+    target_spans = plan.sorted_target_spans()
+    if target_spans is None:
+        return None
+    if not _add_positioned_presence_insertions(
+        plan,
+        source_lines,
+        working_lines,
+        positioned_lines,
+        target_spans,
+        positioned_lines_are_ordered=positioned_lines_are_ordered,
+        trust_baseline_coordinates=trust_baseline_coordinates,
+    ):
+        return None
+
+    return positioned_lines

--- a/tests/batch/merge/test_merge.py
+++ b/tests/batch/merge/test_merge.py
@@ -5,7 +5,6 @@ import tracemalloc
 
 import pytest
 
-import git_stage_batch.batch.merge.baseline_edits as baseline_edits_module
 import git_stage_batch.batch.merge.baseline_presence_edits as baseline_presence_edits_module
 import git_stage_batch.batch.merge.candidate_enumeration as candidate_enumeration_module
 import git_stage_batch.batch.merge.merge as merge_module
@@ -502,19 +501,14 @@ def test_baseline_fallback_routes_matching_storage_to_invocation_spool(
     spool_dir = tmp_path / "scratch"
     spool_dir.mkdir()
     observed_spools = []
-    matching_module = (
-        baseline_edits_module
-        if hasattr(baseline_edits_module, "_match_lines")
-        else baseline_presence_edits_module
-    )
-    original_match_lines = matching_module._match_lines
+    original_match_lines = baseline_presence_edits_module._match_lines
 
     def record_match(*args, **kwargs):
         observed_spools.append(kwargs.get("spool_dir"))
         return original_match_lines(*args, **kwargs)
 
     monkeypatch.setattr(
-        matching_module,
+        baseline_presence_edits_module,
         "_match_lines",
         record_match,
     )

--- a/tests/batch/merge/test_merge.py
+++ b/tests/batch/merge/test_merge.py
@@ -6,6 +6,7 @@ import tracemalloc
 import pytest
 
 import git_stage_batch.batch.merge.baseline_edits as baseline_edits_module
+import git_stage_batch.batch.merge.baseline_presence_edits as baseline_presence_edits_module
 import git_stage_batch.batch.merge.candidate_enumeration as candidate_enumeration_module
 import git_stage_batch.batch.merge.merge as merge_module
 import git_stage_batch.batch.realization.provenance as provenance_module
@@ -501,14 +502,19 @@ def test_baseline_fallback_routes_matching_storage_to_invocation_spool(
     spool_dir = tmp_path / "scratch"
     spool_dir.mkdir()
     observed_spools = []
-    original_match_lines = baseline_edits_module._match_lines
+    matching_module = (
+        baseline_edits_module
+        if hasattr(baseline_edits_module, "_match_lines")
+        else baseline_presence_edits_module
+    )
+    original_match_lines = matching_module._match_lines
 
     def record_match(*args, **kwargs):
         observed_spools.append(kwargs.get("spool_dir"))
         return original_match_lines(*args, **kwargs)
 
     monkeypatch.setattr(
-        baseline_edits_module,
+        matching_module,
         "_match_lines",
         record_match,
     )


### PR DESCRIPTION
Replacement placement is separate from the module that combines all edits at
file positions recorded when changes were saved. That assembly module still
decides whether each saved source line survives other edits, is already
present, or must be inserted.

Those insertion decisions belong together, but moving their matching code
across source and test commits can leave an intermediate test importing the
wrong module. The repository also requires commits that touch tests to remain
separate from source changes.

This PR adds an insertion-decision module, uses a temporary tests-only lookup
while production adopts it, removes that lookup afterward, deletes the copied
source implementation, and documents which module owns each responsibility.
The merge-focused tests, Ruff, type hygiene, strict mypy, and package build
pass.

Insertion decisions now have one documented owner, and every source and
tests-only commit remains independently runnable.
