### PR TITLE
project: Test current Python releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
       fail-fast: false
 
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Thank you for your interest in contributing!
 This project uses [uv](https://docs.astral.sh/uv/) for development workflow and [Meson](https://mesonbuild.com/) as the build backend.
 
 **Requirements:**
-- Python 3.10+
+- Python 3.10 through 3.14
 - uv (for development)
 - meson and ninja-build (install via your system package manager)
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ pip install git-stage-batch
 
 ## Requirements
 
-- Python 3.10 through 3.13
+- Python 3.10 or newer; CI covers current releases through Python 3.14
 - Git 2.29 or newer
 - A POSIX operating system; Linux is the currently tested platform. Native Windows is not supported.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -70,7 +70,8 @@ This runs the tool without permanently installing it.
 
 ## Requirements
 
-- **Python 3.10 through 3.13**
+- **Python 3.10 or newer.** CI covers current releases through Python 3.14;
+  newer releases are allowed before they enter the tested matrix.
 - **Git 2.29 or newer** available on `PATH`
 - **POSIX operating system.** Linux is tested in CI; native Windows is not
   supported because repository locking, signals, symlinks, and terminal process

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Version Control :: Git",
 ]
 

--- a/tests/architecture/test_support_contract.py
+++ b/tests/architecture/test_support_contract.py
@@ -1,0 +1,21 @@
+"""Keep public compatibility metadata aligned with continuous integration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read_project_file(path: str) -> str:
+    return (PROJECT_ROOT / path).read_text()
+
+
+def test_python_metadata_matches_tested_interpreters():
+    """Package metadata should stay open while CI covers current releases."""
+    pyproject = _read_project_file("pyproject.toml")
+    workflow = _read_project_file(".github/workflows/ci.yml")
+
+    assert 'requires-python = ">=3.10"' in pyproject
+    assert 'python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]' in workflow


### PR DESCRIPTION
The package accepts Python 3.10 and newer while continuous integration
currently exercises releases only through Python 3.13.

Python 3.14 is now a current interpreter. Leaving it outside the test matrix
makes the public compatibility information stale, while adding an upper bound
would unnecessarily prevent users from trying later Python releases.

This change adds Python 3.14 to the Linux test matrix and package classifiers,
keeps `requires-python` open-ended at `>=3.10`, clarifies the documented
difference between tested and forward-compatible releases, and adds an
architecture check that keeps metadata aligned with CI.

Verified with the focused architecture test on Python 3.10 and Python 3.14,
Ruff, and workflow YAML parsing.
