### PR TITLE
ci: Exercise the minimum supported Git release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,67 @@ jobs:
         if: matrix.python-version == '3.10'
         run: uv run mypy
 
+  minimum-git:
+    runs-on: ubuntu-latest
+    env:
+      GIT_VERSION: "2.31.0"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check out minimum supported Git
+        uses: actions/checkout@v4
+        with:
+          repository: git/git
+          ref: v${{ env.GIT_VERSION }}
+          path: git-source
+          persist-credentials: false
+
+      - name: Install Git build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            autoconf \
+            build-essential \
+            gettext \
+            libcurl4-openssl-dev \
+            libexpat1-dev \
+            zlib1g-dev
+
+      - name: Build minimum supported Git
+        run: |
+          make -C git-source configure
+          cd git-source
+          ./configure --prefix="$RUNNER_TEMP/git-${GIT_VERSION}"
+          make -j2 all NO_GETTEXT=YesPlease NO_TCLTK=YesPlease
+          make install NO_GETTEXT=YesPlease NO_TCLTK=YesPlease
+          echo "$RUNNER_TEMP/git-${GIT_VERSION}/bin" >> "$GITHUB_PATH"
+
+      - name: Verify minimum Git version
+        run: test "$(git version)" = "git version ${GIT_VERSION}"
+
+      - name: Configure git identity
+        run: |
+          git config --global user.name "CI"
+          git config --global user.email "ci@test"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.10"
+
+      - name: Set up Python
+        run: uv python install 3.10
+
+      - name: Set up test environment
+        run: |
+          uv venv
+          uv pip install --group dev
+          uv sync --all-groups
+
+      - name: Run tests with minimum Git
+        run: uv run pytest -n auto
+
   build:
     runs-on: ubuntu-latest
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@ This project uses [uv](https://docs.astral.sh/uv/) for development workflow and 
 
 **Requirements:**
 - Python 3.10 through 3.14
+- Git 2.31 or newer
 - uv (for development)
 - meson and ninja-build (install via your system package manager)
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ pip install git-stage-batch
 ## Requirements
 
 - Python 3.10 or newer; CI covers current releases through Python 3.14
-- Git 2.29 or newer
+- Git 2.31 or newer
 - A POSIX operating system; Linux is the currently tested platform. Native Windows is not supported.
 
 ## Documentation

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -72,7 +72,7 @@ This runs the tool without permanently installing it.
 
 - **Python 3.10 or newer.** CI covers current releases through Python 3.14;
   newer releases are allowed before they enter the tested matrix.
-- **Git 2.29 or newer** available on `PATH`
+- **Git 2.31 or newer** available on `PATH`
 - **POSIX operating system.** Linux is tested in CI; native Windows is not
   supported because repository locking, signals, symlinks, and terminal process
   control currently use POSIX facilities.

--- a/tests/architecture/test_support_contract.py
+++ b/tests/architecture/test_support_contract.py
@@ -19,3 +19,12 @@ def test_python_metadata_matches_tested_interpreters():
 
     assert 'requires-python = ">=3.10"' in pyproject
     assert 'python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]' in workflow
+
+
+def test_ci_exercises_minimum_git():
+    """CI should cover the minimum supported Git release."""
+    workflow = _read_project_file(".github/workflows/ci.yml")
+
+    assert 'GIT_VERSION: "2.31.0"' in workflow
+    assert 'repository: git/git' in workflow
+    assert 'run: test "$(git version)" = "git version ${GIT_VERSION}"' in workflow

--- a/tests/assets/test_refine_commit_messages_checkpoint.py
+++ b/tests/assets/test_refine_commit_messages_checkpoint.py
@@ -191,7 +191,7 @@ def _enable_fake_signing(repo: Path) -> None:
     signer.write_text(
         "#!/bin/sh\n"
         "cat >/dev/null\n"
-        "printf '%s\\n' "
+        "printf '\\n%s\\n' "
         "'[GNUPG:] SIG_CREATED D 1 10 00 0 0 0 0 0' >&2\n"
         "printf '%s\\n' "
         "'-----BEGIN PGP SIGNATURE-----' "


### PR DESCRIPTION
Continuous integration tests every current Python release, while the project
also promises compatibility with older Git releases.

Repository path discovery uses `git rev-parse --path-format=absolute`, which
was introduced in Git 2.31. The documented Git 2.29 floor therefore promises
compatibility that the implementation cannot provide, while Linux runners use
a much newer release and leave the actual lower boundary untested.

This change raises the documented minimum to Git 2.31 and adds a dedicated job
that checks out the official Git 2.31.0 tag, builds and installs it, verifies
the exact binary selected on `PATH`, and runs the full suite with that version.
It also makes the deterministic signer fixture use status framing accepted by
Git 2.31. An architecture check locks the minimum-version job to the public
support contract.

Verified with the focused architecture tests, Ruff, workflow YAML parsing,
a clean Ubuntu 24.04 build of Git 2.31.0, and a targeted signing check using
that binary.
