### PR TITLE
merge: Separate replacement validation from edit assembly

### DIFF
--- a/src/git_stage_batch/batch/merge/baseline_edits.py
+++ b/src/git_stage_batch/batch/merge/baseline_edits.py
@@ -27,14 +27,11 @@ from .baseline_replacement_edits import (
     replacement_source_ranges_fit_presence as _replacement_source_ranges_fit_presence,
 )
 from .baseline_replacement_ranges import (
-    collect_replacement_source_ranges as _collect_replacement_source_ranges,
     replacement_source_range_capacity as _replacement_source_range_capacity,
-    selected_replacement_source_ranges as _selected_replacement_source_ranges,
 )
 from ..line_matching.sequence_equality import (
     line_sequences_equal as _line_sequences_match,
 )
-from ..line_matching.line_mapping import LineMapping
 from ..line_matching.match_workspace import MatcherWorkspace
 from .candidates import MergeResolution as _MergeResolution
 
@@ -270,41 +267,3 @@ def _build_baseline_edit_plan(
     if not plan.sort_and_validate():
         return None
     return plan
-
-
-def has_missing_origin_replacement_claims(
-    ownership: BatchOwnership,
-    presence_line_set: LineSelection,
-    source_lines: Sequence[bytes],
-    mapping: LineMapping,
-    *,
-    spool_dir: str | Path | None = None,
-) -> bool:
-    """Return whether parent-tracked replacement lines would need placement."""
-    selected_presence = coerce_line_ranges(presence_line_set)
-    with MatcherWorkspace(spool_dir=spool_dir) as workspace:
-        for unit in getattr(ownership, "replacement_units", []):
-            if getattr(unit, "origin", None) is None:
-                continue
-            claimed_ranges = _collect_replacement_source_ranges(
-                workspace,
-                unit.presence_lines,
-            )
-            if claimed_ranges is None:
-                return True
-            try:
-                for claimed_start, claimed_end in _selected_replacement_source_ranges(
-                    claimed_ranges,
-                    selected_presence,
-                ):
-                    for claimed_line in range(claimed_start, claimed_end + 1):
-                        if claimed_line > len(source_lines):
-                            continue
-                        if (
-                            mapping.get_target_line_from_source_line(claimed_line)
-                            is None
-                        ):
-                            return True
-            finally:
-                workspace.close_resource(claimed_ranges)
-    return False

--- a/src/git_stage_batch/batch/merge/merge.py
+++ b/src/git_stage_batch/batch/merge/merge.py
@@ -22,6 +22,7 @@ from .coordinate_strategy import (
 )
 from .validation import (
     check_structural_validity as _check_merge_structural_validity,
+    has_missing_origin_replacement_claims as _has_missing_origin_replacement_claims,
 )
 from ..line_matching.line_mapping import LineMapping
 from ..line_matching.match import match_lines
@@ -174,7 +175,7 @@ def _build_structural_realized_entries(
                 )
                 mapping = owned_mapping
 
-        if _baseline_edits.has_missing_origin_replacement_claims(
+        if _has_missing_origin_replacement_claims(
             ownership,
             presence_line_set,
             source_lines,

--- a/src/git_stage_batch/batch/merge/validation.py
+++ b/src/git_stage_batch/batch/merge/validation.py
@@ -3,12 +3,18 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
+from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
-from ...core.line_selection import LineSelection
+from ...core.line_selection import LineSelection, coerce_line_ranges
 from ...exceptions import MergeError as _MergeError
 from ...i18n import _
 from ..line_matching.line_mapping import LineMapping
+from ..line_matching.match_workspace import MatcherWorkspace
+from .baseline_replacement_ranges import (
+    collect_replacement_source_ranges as _collect_replacement_source_ranges,
+    selected_replacement_source_ranges as _selected_replacement_source_ranges,
+)
 from .presence_context import (
     contextual_presence_placements as _contextual_presence_placements,
 )
@@ -18,6 +24,45 @@ from .presence_missing_claims import (
 
 if TYPE_CHECKING:
     from ..ownership.absence_claims import AbsenceClaim
+    from ..ownership.model import BatchOwnership
+
+
+def has_missing_origin_replacement_claims(
+    ownership: BatchOwnership,
+    presence_line_set: LineSelection,
+    source_lines: Sequence[bytes],
+    mapping: LineMapping,
+    *,
+    spool_dir: str | Path | None = None,
+) -> bool:
+    """Return whether parent-tracked replacement lines would need placement."""
+    selected_presence = coerce_line_ranges(presence_line_set)
+    with MatcherWorkspace(spool_dir=spool_dir) as workspace:
+        for unit in getattr(ownership, "replacement_units", []):
+            if getattr(unit, "origin", None) is None:
+                continue
+            claimed_ranges = _collect_replacement_source_ranges(
+                workspace,
+                unit.presence_lines,
+            )
+            if claimed_ranges is None:
+                return True
+            try:
+                for claimed_start, claimed_end in _selected_replacement_source_ranges(
+                    claimed_ranges,
+                    selected_presence,
+                ):
+                    for claimed_line in range(claimed_start, claimed_end + 1):
+                        if claimed_line > len(source_lines):
+                            continue
+                        if (
+                            mapping.get_target_line_from_source_line(claimed_line)
+                            is None
+                        ):
+                            return True
+            finally:
+                workspace.close_resource(claimed_ranges)
+    return False
 
 
 def check_structural_validity(


### PR DESCRIPTION
Replacement, insertion, and removal decisions live in separate modules. The
merge path also aligns unchanged lines from the saved source file with lines
in the current target file.

Content alignment needs to detect selected replacement source lines that
found no target match. That check still belongs to complete edit assembly,
which gives validation code no direct interface and permits duplicate answers
about whether alignment is valid.

This PR adds the replacement-line check to content validation, makes the
active merge path use it, and removes the copy from edit assembly. The
merge-focused tests, Ruff, type hygiene, strict mypy, and package build pass.

Replacement-line alignment validation now has one owner outside complete
edit assembly.
