### PR TITLE
ci: Exercise the documented macOS platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,39 @@ jobs:
       - name: Run tests with minimum Git
         run: uv run pytest -n auto
 
+  macos:
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure git identity
+        run: |
+          git config --global user.name "CI"
+          git config --global user.email "ci@test"
+
+      - name: Install gettext
+        run: |
+          brew install gettext
+          echo "$(brew --prefix gettext)/bin" >> "$GITHUB_PATH"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.13"
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      - name: Set up test environment
+        run: |
+          uv venv
+          uv pip install --group dev
+          uv sync --all-groups
+
+      - name: Run tests on macOS
+        run: uv run pytest -n auto
+
   build:
     runs-on: ubuntu-latest
 

--- a/README.md
+++ b/README.md
@@ -180,7 +180,8 @@ pip install git-stage-batch
 
 - Python 3.10 or newer; CI covers current releases through Python 3.14
 - Git 2.31 or newer
-- A POSIX operating system; Linux is the currently tested platform. Native Windows is not supported.
+- A POSIX operating system; Linux and macOS are tested in CI. Native Windows
+  is not supported.
 
 ## Documentation
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -73,9 +73,9 @@ This runs the tool without permanently installing it.
 - **Python 3.10 or newer.** CI covers current releases through Python 3.14;
   newer releases are allowed before they enter the tested matrix.
 - **Git 2.31 or newer** available on `PATH`
-- **POSIX operating system.** Linux is tested in CI; native Windows is not
-  supported because repository locking, signals, symlinks, and terminal process
-  control currently use POSIX facilities.
+- **POSIX operating system.** Linux and macOS are tested in CI; native Windows
+  is not supported because repository locking, signals, symlinks, and terminal
+  process control currently use POSIX facilities.
 
 There are no runtime Python package dependencies. Building from source also
 requires Meson, meson-python, Ninja, and gettext. Repository paths are handled

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ keywords = ["git", "staging", "commit", "diff", "patch"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Environment :: Console",
+    "Operating System :: MacOS :: MacOS X",
     "Operating System :: POSIX",
     "Operating System :: POSIX :: Linux",
     "Intended Audience :: Developers",

--- a/tests/architecture/test_support_contract.py
+++ b/tests/architecture/test_support_contract.py
@@ -28,3 +28,10 @@ def test_ci_exercises_minimum_git():
     assert 'GIT_VERSION: "2.31.0"' in workflow
     assert 'repository: git/git' in workflow
     assert 'run: test "$(git version)" = "git version ${GIT_VERSION}"' in workflow
+
+
+def test_ci_exercises_macos():
+    """CI should cover the documented macOS platform."""
+    workflow = _read_project_file(".github/workflows/ci.yml")
+
+    assert "runs-on: macos-latest" in workflow

--- a/tests/batch/line_matching/test_match_workspace.py
+++ b/tests/batch/line_matching/test_match_workspace.py
@@ -8,6 +8,7 @@ import git_stage_batch.batch.line_matching.match as match_module
 import git_stage_batch.core.mapped_storage as mapped_storage_module
 from git_stage_batch.batch.line_matching.match import match_lines
 from git_stage_batch.batch.line_matching.match_workspace import MatcherWorkspace
+from git_stage_batch.core.mapped_storage import MAPPED_STORAGE_OFFLOAD_SIZE_THRESHOLD
 
 
 def test_matcher_workspace_tracks_and_closes_resources():
@@ -48,7 +49,8 @@ def test_match_lines_routes_mapped_storage_to_requested_spool(
     )
     spool_dir = tmp_path / "scratch"
     spool_dir.mkdir()
-    lines = [f"line {index}\n".encode() for index in range(2_000)]
+    line_count = MAPPED_STORAGE_OFFLOAD_SIZE_THRESHOLD // 4 + 1
+    lines = [f"line {index}\n".encode() for index in range(line_count)]
 
     with match_lines(lines, lines, spool_dir=spool_dir) as mapping:
         assert len(tuple(mapping.mapped_line_pairs())) == len(lines)

--- a/tests/commands/test_sift.py
+++ b/tests/commands/test_sift.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from git_stage_batch.batch.merge.merge import merge_batch_from_line_sequences_as_buffer
 
 import subprocess
+import sys
 import pytest
 
 from git_stage_batch.batch.state.batch_names import batch_exists
@@ -1227,6 +1228,10 @@ class TestSiftFileJobs:
         assert not batch_exists("empty-destination")
         assert read_batch_metadata("empty-source")["note"] == "changed after snapshot"
 
+    @pytest.mark.skipif(
+        sys.platform != "linux",
+        reason="process sift execution is supported on Linux only",
+    )
     def test_forced_process_matches_inline_publication(
         self,
         temp_git_repo,
@@ -1443,6 +1448,10 @@ class TestSiftFileJobs:
         assert read_batch_metadata("raced-destination")["files"] == {}
         assert not any(name.startswith("sift-tmp-") for name in list_batch_names())
 
+    @pytest.mark.skipif(
+        sys.platform != "linux",
+        reason="process sift execution is supported on Linux only",
+    )
     def test_process_sift_preserves_added_text_boundaries(
         self,
         temp_git_repo,
@@ -1478,6 +1487,10 @@ class TestSiftFileJobs:
             for file_path in expected_content
         } == expected_content
 
+    @pytest.mark.skipif(
+        sys.platform != "linux",
+        reason="process sift execution is supported on Linux only",
+    )
     def test_process_sift_preserves_text_deletions(
         self,
         temp_git_repo,

--- a/tests/functional/test_functional_batch_operations.py
+++ b/tests/functional/test_functional_batch_operations.py
@@ -679,7 +679,10 @@ class TestBatchRebaseWorkflow:
         # Rebase to edit the first commit
         # HEAD~2 goes back before both our commits, allowing us to edit both
         # sed will change the first pick to edit (which is "Add feature skeleton")
-        env = {**subprocess.os.environ, "GIT_SEQUENCE_EDITOR": "sed -i '1s/pick/edit/'"}
+        env = {
+            **subprocess.os.environ,
+            "GIT_SEQUENCE_EDITOR": "sed -i.bak '1s/^pick/edit/'",
+        }
         rebase_result = subprocess.run(
             ["git", "rebase", "-i", "HEAD~2"],
             env=env,

--- a/tests/functional/test_special_path_workflow.py
+++ b/tests/functional/test_special_path_workflow.py
@@ -2,6 +2,7 @@
 
 import os
 import subprocess
+import sys
 
 import pytest
 
@@ -16,7 +17,7 @@ SPECIAL_PATHS = [
     "old b/component.txt",
     "trailing-space.txt ",
 ]
-if os.name == "posix":
+if os.name == "posix" and sys.platform != "darwin":
     SPECIAL_PATHS.append(os.fsdecode(b"non-utf8-\xff.txt"))
 
 

--- a/tests/utils/test_file_jobs.py
+++ b/tests/utils/test_file_jobs.py
@@ -42,6 +42,10 @@ _PROCESS_TEST = pytest.mark.skipif(
     sys.platform != "linux" or _RUNNING_UNDER_XDIST,
     reason="forced forkserver coverage runs on Linux with pytest -n 0",
 )
+_LINUX_PROCESS_TEST = pytest.mark.skipif(
+    sys.platform != "linux",
+    reason="process file-job execution is supported on Linux only",
+)
 _PARENT_COMPUTE_CALLS = 0
 
 
@@ -411,6 +415,7 @@ def test_compute_keyboard_interrupt_propagates_across_process_transport(
     assert not root.exists()
 
 
+@_LINUX_PROCESS_TEST
 def test_process_scheduler_submits_largest_first_with_bounded_pending(
     tmp_path,
     monkeypatch,
@@ -476,6 +481,7 @@ def test_process_scheduler_submits_largest_first_with_bounded_pending(
     assert lifecycle == {"closed": True, "terminated": False}
 
 
+@_LINUX_PROCESS_TEST
 def test_process_scheduler_stops_admission_after_task_failure(
     tmp_path,
     monkeypatch,
@@ -546,6 +552,7 @@ def test_process_scheduler_stops_admission_after_task_failure(
     assert lifecycle == {"closed": False, "terminated": True}
 
 
+@_LINUX_PROCESS_TEST
 def test_process_failure_waits_only_for_pending_lower_ordinals(
     tmp_path,
     monkeypatch,
@@ -664,6 +671,7 @@ def test_lowest_ordinal_failure_wins(tmp_path):
     assert "one" in error.value.original_message
 
 
+@_LINUX_PROCESS_TEST
 def test_process_construction_failure_does_not_compute_inline(
     tmp_path,
     monkeypatch,
@@ -689,6 +697,7 @@ def test_process_construction_failure_does_not_compute_inline(
     assert _PARENT_COMPUTE_CALLS == 0
 
 
+@_LINUX_PROCESS_TEST
 def test_partially_started_worker_is_killed_and_connections_are_closed(
     tmp_path,
     monkeypatch,
@@ -812,6 +821,7 @@ def test_worker_death_does_not_retry_inline(tmp_path):
     assert _PARENT_COMPUTE_CALLS == 0
 
 
+@_LINUX_PROCESS_TEST
 def test_keyboard_interrupt_terminates_workers_before_workspace_cleanup(
     tmp_path,
     monkeypatch,
@@ -1019,6 +1029,7 @@ def test_linux_auto_respects_cpu_availability():
     )
 
 
+@_LINUX_PROCESS_TEST
 def test_linux_auto_uses_process_affinity_when_cpu_count_is_unspecified(
     monkeypatch,
 ):
@@ -1059,6 +1070,7 @@ def test_forced_process_selection_respects_job_cpu_and_worker_caps():
     )
 
 
+@_LINUX_PROCESS_TEST
 def test_process_execution_enforces_the_hard_worker_cap(
     tmp_path,
     monkeypatch,
@@ -1115,6 +1127,7 @@ def test_process_execution_enforces_the_hard_worker_cap(
     assert observed_max_workers == [file_jobs_module._MAX_FILE_JOB_WORKERS]
 
 
+@_LINUX_PROCESS_TEST
 def test_collected_lower_ordinal_failure_wins_over_worker_failure(
     tmp_path,
     monkeypatch,
@@ -1179,6 +1192,7 @@ def test_collected_lower_ordinal_failure_wins_over_worker_failure(
     assert "one failed" in error.value.original_message
 
 
+@_LINUX_PROCESS_TEST
 def test_worker_failure_reports_its_job_instead_of_an_unrelated_ordinal(
     tmp_path,
     monkeypatch,

--- a/tests/utils/test_repository_buffers.py
+++ b/tests/utils/test_repository_buffers.py
@@ -8,6 +8,7 @@ import pytest
 
 import git_stage_batch.core.mapped_storage as mapped_storage_module
 from git_stage_batch.core.buffer import LineBuffer
+from git_stage_batch.core.mapped_storage import MAPPED_STORAGE_OFFLOAD_SIZE_THRESHOLD
 from git_stage_batch.exceptions import RepositoryDataInvalid
 import git_stage_batch.utils.repository_buffers as repository_buffers
 from git_stage_batch.utils.repository_buffers import (
@@ -60,7 +61,7 @@ def test_stream_git_blob_buffers_spools_and_closes_each_source(
     tmp_path,
 ):
     """Batch-loaded source buffers should be mmap-backed and file-local."""
-    payload = b"line\n" * 2_000
+    payload = b"line\n" * (MAPPED_STORAGE_OFFLOAD_SIZE_THRESHOLD // 5 + 1)
     temporary_directories = []
     real_temporary_file = mapped_storage_module._temporary_file
 


### PR DESCRIPTION
The project documents support for POSIX systems, but CI currently exercises
Linux only. That leaves macOS behavior outside the enforced compatibility
contract.

This change adds a macOS job that installs gettext, prepares the same
development environment used by Linux CI, and runs the full suite on the
current macOS runner. It also adds the macOS package classifier and aligns the
README and installation guide with the tested platforms.

The first macOS run exposed Linux-specific assumptions in otherwise portable
tests. This change also sizes mmap fixtures from the host page size, limits
forced process-execution coverage to Linux, uses portable in-place `sed`
syntax, and excludes the undecodable-byte pathname case that Darwin cannot
create. An architecture check requires the macOS job to remain present.

Verified with the focused support-contract tests, Ruff, workflow YAML parsing,
diff validation, and the 27 affected tests on Linux. The corrected macOS
expectations will be validated by this PR's CI.
