### PR TITLE
merge: Separate merge-method selection from saved-position edits

### DIFF
--- a/BATCHES.md
+++ b/BATCHES.md
@@ -347,6 +347,9 @@ line and every absence claim:
 owns structural validation. The merge helpers separate these structural and
 exact-coordinate responsibilities:
 
+- [`batch/merge/coordinate_strategy.py`](src/git_stage_batch/batch/merge/coordinate_strategy.py)
+  detects whether a merge has recorded positions and defines the reviewed
+  choice between using those positions and structural content matching.
 - [`batch/merge/baseline_anchor_matching.py`](src/git_stage_batch/batch/merge/baseline_anchor_matching.py)
   proves recorded boundaries identify the intended live-target positions and
   supplies safe deletion anchors to structural matching.

--- a/src/git_stage_batch/batch/merge/baseline_edits.py
+++ b/src/git_stage_batch/batch/merge/baseline_edits.py
@@ -66,38 +66,6 @@ def _has_complete_baseline_references(
     return bool(presence_line_set or deletion_claims)
 
 
-def has_recorded_baseline_coordinates(
-    ownership: BatchOwnership,
-    presence_line_set: LineSelection,
-    deletion_claims: Sequence[AbsenceClaim],
-) -> bool:
-    """Return whether selected edit metadata includes a recorded coordinate."""
-    for presence_claim in ownership.presence_claims:
-        for claimed_line, presence_reference in (
-            presence_claim.baseline_references.items()
-        ):
-            if (
-                claimed_line in presence_line_set
-                and presence_reference.has_after_line
-            ):
-                return True
-    for deletion_claim in deletion_claims:
-        deletion_reference = deletion_claim.baseline_reference
-        if (
-            deletion_reference is not None
-            and deletion_reference.has_after_line
-        ):
-            return True
-    for unit in ownership.replacement_units:
-        origin = unit.origin
-        if origin is None:
-            continue
-        origin_reference = origin.baseline_reference
-        if origin_reference is not None and origin_reference.has_after_line:
-            return True
-    return False
-
-
 def try_apply_baseline_replacement_units(
     source_lines: Sequence[bytes],
     working_lines: Sequence[bytes],

--- a/src/git_stage_batch/batch/merge/baseline_edits.py
+++ b/src/git_stage_batch/batch/merge/baseline_edits.py
@@ -66,7 +66,7 @@ def _has_complete_baseline_references(
     return bool(presence_line_set or deletion_claims)
 
 
-def try_apply_baseline_replacement_units(
+def try_apply_baseline_coordinate_edits(
     source_lines: Sequence[bytes],
     working_lines: Sequence[bytes],
     ownership: BatchOwnership,
@@ -139,6 +139,32 @@ def try_apply_baseline_replacement_units(
     except BaseException:
         workspace.close()
         raise
+
+
+def try_apply_baseline_replacement_units(
+    source_lines: Sequence[bytes],
+    working_lines: Sequence[bytes],
+    ownership: BatchOwnership,
+    presence_line_set: LineSelection,
+    deletion_claims: list[AbsenceClaim],
+    *,
+    resolution: _MergeResolution | None = None,
+    max_resolution_choices: int = _DEFAULT_RESOLUTION_CHOICE_LIMIT,
+    trust_baseline_coordinates: bool = False,
+    spool_dir: str | Path | None = None,
+) -> Iterator[bytes] | None:
+    """Call the saved-position edit function under its former name."""
+    return try_apply_baseline_coordinate_edits(
+        source_lines,
+        working_lines,
+        ownership,
+        presence_line_set,
+        deletion_claims,
+        resolution=resolution,
+        max_resolution_choices=max_resolution_choices,
+        trust_baseline_coordinates=trust_baseline_coordinates,
+        spool_dir=spool_dir,
+    )
 
 
 def _build_baseline_edit_plan(

--- a/src/git_stage_batch/batch/merge/baseline_edits.py
+++ b/src/git_stage_batch/batch/merge/baseline_edits.py
@@ -1,4 +1,4 @@
-"""Baseline-coordinate edit fallback for batch merge."""
+"""Coordinate-based edit planning and streaming for batch merge."""
 
 from __future__ import annotations
 
@@ -78,13 +78,19 @@ def try_apply_baseline_coordinate_edits(
     trust_baseline_coordinates: bool = False,
     spool_dir: str | Path | None = None,
 ) -> Iterator[bytes] | None:
-    """Apply baseline-coordinate edits when structural source anchors fail.
+    """Return content edited at recorded baseline coordinates, if safe.
 
-    This is a conservative fallback for same-source round trips where the batch
-    source is the post-change file and the target is still the pre-change
-    baseline/index. In that shape, source anchors can legitimately be absent
-    even though the old baseline bytes still exist at an exact recorded
-    coordinate.
+    Combine replacement, removal, and insertion plans at positions saved from
+    the batch baseline. By default, keep required source lines that are already
+    present and reject coordinates whose saved boundary identifies more than
+    one live-target location. Setting ``trust_baseline_coordinates`` makes the
+    recorded positions authoritative. It skips live-target uniqueness and
+    already-present insertion checks while retaining boundary, removal-content,
+    and plan-consistency checks.
+
+    Return ``None`` if any selected edit cannot be planned safely. A plan that
+    changes content returns a lazy stream that owns its planning workspace until
+    the stream is exhausted or closed.
     """
     if _selection_outside_bounds(presence_line_set, len(source_lines)):
         return None

--- a/src/git_stage_batch/batch/merge/baseline_edits.py
+++ b/src/git_stage_batch/batch/merge/baseline_edits.py
@@ -141,32 +141,6 @@ def try_apply_baseline_coordinate_edits(
         raise
 
 
-def try_apply_baseline_replacement_units(
-    source_lines: Sequence[bytes],
-    working_lines: Sequence[bytes],
-    ownership: BatchOwnership,
-    presence_line_set: LineSelection,
-    deletion_claims: list[AbsenceClaim],
-    *,
-    resolution: _MergeResolution | None = None,
-    max_resolution_choices: int = _DEFAULT_RESOLUTION_CHOICE_LIMIT,
-    trust_baseline_coordinates: bool = False,
-    spool_dir: str | Path | None = None,
-) -> Iterator[bytes] | None:
-    """Call the saved-position edit function under its former name."""
-    return try_apply_baseline_coordinate_edits(
-        source_lines,
-        working_lines,
-        ownership,
-        presence_line_set,
-        deletion_claims,
-        resolution=resolution,
-        max_resolution_choices=max_resolution_choices,
-        trust_baseline_coordinates=trust_baseline_coordinates,
-        spool_dir=spool_dir,
-    )
-
-
 def _build_baseline_edit_plan(
     workspace: MatcherWorkspace,
     source_lines: Sequence[bytes],

--- a/src/git_stage_batch/batch/merge/coordinate_strategy.py
+++ b/src/git_stage_batch/batch/merge/coordinate_strategy.py
@@ -1,4 +1,4 @@
-"""Resolution values for coordinate-versus-structural merge ambiguity."""
+"""Recorded-coordinate availability and merge-strategy choices."""
 
 from __future__ import annotations
 

--- a/src/git_stage_batch/batch/merge/coordinate_strategy.py
+++ b/src/git_stage_batch/batch/merge/coordinate_strategy.py
@@ -1,6 +1,16 @@
 """Resolution values for coordinate-versus-structural merge ambiguity."""
 
+from __future__ import annotations
+
+from collections.abc import Sequence
 from enum import Enum
+from typing import TYPE_CHECKING
+
+from ...core.line_selection import LineSelection
+
+if TYPE_CHECKING:
+    from ..ownership.absence_claims import AbsenceClaim
+    from ..ownership.model import BatchOwnership
 
 
 AMBIGUITY_KEY = "baseline-coordinate-vs-structural"
@@ -11,3 +21,35 @@ class CoordinateStrategyChoice(Enum):
 
     STRUCTURAL = 1
     RECORDED_COORDINATES = 2
+
+
+def has_recorded_baseline_coordinates(
+    ownership: BatchOwnership,
+    presence_line_set: LineSelection,
+    deletion_claims: Sequence[AbsenceClaim],
+) -> bool:
+    """Return whether selected edit metadata includes a recorded coordinate."""
+    for presence_claim in ownership.presence_claims:
+        for claimed_line, presence_reference in (
+            presence_claim.baseline_references.items()
+        ):
+            if (
+                claimed_line in presence_line_set
+                and presence_reference.has_after_line
+            ):
+                return True
+    for deletion_claim in deletion_claims:
+        deletion_reference = deletion_claim.baseline_reference
+        if (
+            deletion_reference is not None
+            and deletion_reference.has_after_line
+        ):
+            return True
+    for unit in ownership.replacement_units:
+        origin = unit.origin
+        if origin is None:
+            continue
+        origin_reference = origin.baseline_reference
+        if origin_reference is not None and origin_reference.has_after_line:
+            return True
+    return False

--- a/src/git_stage_batch/batch/merge/merge.py
+++ b/src/git_stage_batch/batch/merge/merge.py
@@ -370,7 +370,7 @@ def _merge_batch_acquired_line_chunks(
         ):
             raise _MergeError(_("Selected merge resolution is no longer valid"))
         selected_coordinate_candidate = (
-            _baseline_edits.try_apply_baseline_replacement_units(
+            _baseline_edits.try_apply_baseline_coordinate_edits(
                 source_lines,
                 working_lines,
                 ownership,
@@ -391,7 +391,7 @@ def _merge_batch_acquired_line_chunks(
         return
 
     if strategy_choice is None:
-        fallback_chunks = _baseline_edits.try_apply_baseline_replacement_units(
+        fallback_chunks = _baseline_edits.try_apply_baseline_coordinate_edits(
             source_lines,
             working_lines,
             ownership,
@@ -418,7 +418,7 @@ def _merge_batch_acquired_line_chunks(
         )
     ):
         coordinate_candidate = (
-            _baseline_edits.try_apply_baseline_replacement_units(
+            _baseline_edits.try_apply_baseline_coordinate_edits(
                 source_lines,
                 working_lines,
                 ownership,

--- a/src/git_stage_batch/batch/merge/merge.py
+++ b/src/git_stage_batch/batch/merge/merge.py
@@ -19,6 +19,7 @@ from .candidates import (
 from .coordinate_strategy import (
     AMBIGUITY_KEY as _COORDINATE_STRATEGY_AMBIGUITY_KEY,
     CoordinateStrategyChoice as _CoordinateStrategyChoice,
+    has_recorded_baseline_coordinates as _has_recorded_baseline_coordinates,
 )
 from .validation import (
     check_structural_validity as _check_merge_structural_validity,
@@ -362,7 +363,7 @@ def _merge_batch_acquired_line_chunks(
     )
 
     if strategy_choice == _CoordinateStrategyChoice.RECORDED_COORDINATES:
-        if not _baseline_edits.has_recorded_baseline_coordinates(
+        if not _has_recorded_baseline_coordinates(
             ownership,
             presence_line_set,
             deletion_claims,
@@ -410,7 +411,7 @@ def _merge_batch_acquired_line_chunks(
     coordinate_candidate = None
     if (
         resolution is None
-        and _baseline_edits.has_recorded_baseline_coordinates(
+        and _has_recorded_baseline_coordinates(
             ownership,
             presence_line_set,
             deletion_claims,

--- a/src/git_stage_batch/batch/realized_file_content.py
+++ b/src/git_stage_batch/batch/realized_file_content.py
@@ -63,7 +63,7 @@ def _stream_realized_content_chunks_from_lines(
     presence_line_set = resolved.presence_line_set
     deletion_claims = resolved.deletion_claims
 
-    baseline_chunks = _baseline_edits.try_apply_baseline_replacement_units(
+    baseline_chunks = _baseline_edits.try_apply_baseline_coordinate_edits(
         batch_source_lines,
         base_lines,
         ownership,
@@ -102,7 +102,7 @@ def _stream_realized_content_chunks_from_lines(
                 spool_dir=spool_dir,
             )
     except _MergeError:
-        baseline_chunks = _baseline_edits.try_apply_baseline_replacement_units(
+        baseline_chunks = _baseline_edits.try_apply_baseline_coordinate_edits(
             batch_source_lines,
             base_lines,
             ownership,

--- a/tests/batch/merge/test_baseline_edits.py
+++ b/tests/batch/merge/test_baseline_edits.py
@@ -51,15 +51,6 @@ class _InterruptingLines(Sequence[bytes]):
         raise KeyboardInterrupt
 
 
-class _IterationGuardedSelection(LineRanges):
-    """Selection whose individual lines must not be expanded."""
-
-    __slots__ = ()
-
-    def __iter__(self):
-        raise AssertionError("selected line ranges must not be expanded")
-
-
 def _boundary_reference(
     *,
     after_line: int | None,
@@ -135,25 +126,6 @@ def test_baseline_edit_planning_composes_all_edit_kinds() -> None:
 
     assert result is not None
     assert list(result) == [b"new value\n", b"inserted\n", b"tail\n"]
-
-
-def test_coordinate_detection_scans_references_not_selected_lines() -> None:
-    """Coordinate detection must scale with edits, not selected line count."""
-    line_count = 1_000_000
-    reference = _boundary_reference(
-        after_line=None,
-        before_line=None,
-    )
-    ownership = BatchOwnership.from_presence_lines(
-        [f"1-{line_count}"],
-        baseline_references={line_count: reference},
-    )
-
-    assert baseline_edits.has_recorded_baseline_coordinates(
-        ownership,
-        _IterationGuardedSelection.from_ranges(((line_count, line_count),)),
-        [],
-    )
 
 
 def test_trusted_plan_composes_partial_replacement_and_repeated_insertion() -> None:

--- a/tests/batch/merge/test_baseline_edits.py
+++ b/tests/batch/merge/test_baseline_edits.py
@@ -116,7 +116,7 @@ def test_baseline_edit_planning_composes_all_edit_kinds() -> None:
         ],
     )
 
-    result = baseline_edits.try_apply_baseline_replacement_units(
+    result = baseline_edits.try_apply_baseline_coordinate_edits(
         source_lines,
         working_lines,
         ownership,
@@ -208,7 +208,7 @@ def test_trusted_plan_composes_partial_replacement_and_repeated_insertion() -> N
         ],
     )
 
-    result = baseline_edits.try_apply_baseline_replacement_units(
+    result = baseline_edits.try_apply_baseline_coordinate_edits(
         source_lines,
         working_lines,
         ownership,
@@ -270,7 +270,7 @@ def test_same_boundary_replacement_payloads_follow_source_order() -> None:
     )
 
     for trust_baseline_coordinates in (False, True):
-        result = baseline_edits.try_apply_baseline_replacement_units(
+        result = baseline_edits.try_apply_baseline_coordinate_edits(
             source_lines,
             working_lines,
             ownership,
@@ -319,7 +319,7 @@ def test_same_boundary_noncontiguous_payloads_follow_source_order() -> None:
         ],
     )
 
-    result = baseline_edits.try_apply_baseline_replacement_units(
+    result = baseline_edits.try_apply_baseline_coordinate_edits(
         source_lines,
         working_lines,
         ownership,
@@ -356,7 +356,7 @@ def test_baseline_edit_planning_rejects_incomplete_replacement_unit() -> None:
         ],
     )
 
-    result = baseline_edits.try_apply_baseline_replacement_units(
+    result = baseline_edits.try_apply_baseline_coordinate_edits(
         source_lines,
         working_lines,
         ownership,
@@ -396,7 +396,7 @@ def test_baseline_edit_planning_rejects_noninteger_deletion_index(
         ],
     )
 
-    result = baseline_edits.try_apply_baseline_replacement_units(
+    result = baseline_edits.try_apply_baseline_coordinate_edits(
         source_lines,
         working_lines,
         ownership,
@@ -433,7 +433,7 @@ def test_baseline_edit_planning_accepts_integer_source_range_metadata() -> None:
         ],
     )
 
-    result = baseline_edits.try_apply_baseline_replacement_units(
+    result = baseline_edits.try_apply_baseline_coordinate_edits(
         source_lines,
         working_lines,
         ownership,
@@ -499,7 +499,7 @@ def test_baseline_edit_planning_rejects_duplicate_deletion_binding() -> None:
         (1, 0),
         (2, 2),
     ]
-    result = baseline_edits.try_apply_baseline_replacement_units(
+    result = baseline_edits.try_apply_baseline_coordinate_edits(
         source_lines,
         working_lines,
         ownership,
@@ -547,7 +547,7 @@ def test_live_planning_ignores_already_present_insertion_groups() -> None:
         ],
     )
 
-    result = baseline_edits.try_apply_baseline_replacement_units(
+    result = baseline_edits.try_apply_baseline_coordinate_edits(
         source_lines,
         working_lines,
         ownership,
@@ -589,7 +589,7 @@ def test_live_planning_reinserts_payload_removed_by_replacement() -> None:
         ],
     )
 
-    result = baseline_edits.try_apply_baseline_replacement_units(
+    result = baseline_edits.try_apply_baseline_coordinate_edits(
         source_lines,
         working_lines,
         ownership,
@@ -635,7 +635,7 @@ def test_live_planning_rejects_partially_removed_matching_payload() -> None:
         ],
     )
 
-    result = baseline_edits.try_apply_baseline_replacement_units(
+    result = baseline_edits.try_apply_baseline_coordinate_edits(
         source_lines,
         working_lines,
         ownership,
@@ -691,7 +691,7 @@ def test_baseline_replacement_payload_stays_lazy(
         raising=False,
     )
 
-    result = baseline_edits.try_apply_baseline_replacement_units(
+    result = baseline_edits.try_apply_baseline_coordinate_edits(
         source_lines,
         working_lines,
         ownership,
@@ -744,7 +744,7 @@ def test_fragmented_replacement_planning_avoids_heap_selections(
     monkeypatch.setattr(LineRanges, "union", fail_heap_selection)
     monkeypatch.setattr(LineRanges, "difference", fail_heap_selection)
 
-    result = baseline_edits.try_apply_baseline_replacement_units(
+    result = baseline_edits.try_apply_baseline_coordinate_edits(
         source_lines,
         working_lines,
         ownership,
@@ -785,7 +785,7 @@ def test_baseline_insertion_planning_does_not_flatten_references(
         fail_flatten,
     )
 
-    result = baseline_edits.try_apply_baseline_replacement_units(
+    result = baseline_edits.try_apply_baseline_coordinate_edits(
         source_lines,
         [],
         ownership,
@@ -821,7 +821,7 @@ def test_baseline_insertion_planning_sorts_target_positions() -> None:
         },
     )
 
-    result = baseline_edits.try_apply_baseline_replacement_units(
+    result = baseline_edits.try_apply_baseline_coordinate_edits(
         source_lines,
         working_lines,
         ownership,
@@ -885,7 +885,7 @@ def test_baseline_edit_stream_closes_planning_workspace(
         TrackingWorkspace,
     )
 
-    result = baseline_edits.try_apply_baseline_replacement_units(
+    result = baseline_edits.try_apply_baseline_coordinate_edits(
         source_lines,
         working_lines,
         ownership,
@@ -949,7 +949,7 @@ def test_baseline_edit_planning_closes_workspace_on_base_exception(
     )
 
     with pytest.raises(KeyboardInterrupt):
-        baseline_edits.try_apply_baseline_replacement_units(
+        baseline_edits.try_apply_baseline_coordinate_edits(
             source_lines,
             working_lines,
             ownership,
@@ -1009,7 +1009,7 @@ def test_baseline_edit_stream_closes_workspace_on_base_exception(
         TrackingWorkspace,
     )
 
-    result = baseline_edits.try_apply_baseline_replacement_units(
+    result = baseline_edits.try_apply_baseline_coordinate_edits(
         source_lines,
         working_lines,
         ownership,

--- a/tests/batch/merge/test_coordinate_strategy.py
+++ b/tests/batch/merge/test_coordinate_strategy.py
@@ -1,0 +1,40 @@
+"""Tests for coordinate-versus-structural merge strategy decisions."""
+
+from git_stage_batch.batch.merge.coordinate_strategy import (
+    has_recorded_baseline_coordinates,
+)
+from git_stage_batch.batch.ownership.model import BatchOwnership
+from git_stage_batch.batch.ownership.references import BaselineReference
+from git_stage_batch.core.line_selection import LineRanges
+
+
+class _IterationGuardedSelection(LineRanges):
+    """Selection whose individual lines must not be expanded."""
+
+    __slots__ = ()
+
+    def __iter__(self):
+        raise AssertionError("selected line ranges must not be expanded")
+
+
+def test_coordinate_detection_scans_references_not_selected_lines() -> None:
+    """Coordinate detection must scale with edits, not selected line count."""
+    line_count = 1_000_000
+    reference = BaselineReference(
+        after_line=None,
+        after_content=None,
+        has_after_line=True,
+        before_line=None,
+        before_content=None,
+        has_before_line=True,
+    )
+    ownership = BatchOwnership.from_presence_lines(
+        [f"1-{line_count}"],
+        baseline_references={line_count: reference},
+    )
+
+    assert has_recorded_baseline_coordinates(
+        ownership,
+        _IterationGuardedSelection.from_ranges(((line_count, line_count),)),
+        [],
+    )

--- a/tests/batch/merge/test_merge.py
+++ b/tests/batch/merge/test_merge.py
@@ -14,7 +14,7 @@ from git_stage_batch.batch.merge.baseline_correspondence import (
     build_baseline_correspondence,
 )
 from git_stage_batch.batch.merge.baseline_edits import (
-    try_apply_baseline_replacement_units,
+    try_apply_baseline_coordinate_edits,
 )
 from git_stage_batch.batch.discard_reversal import reverse_presence_constraints
 from git_stage_batch.batch.discard import (
@@ -188,7 +188,7 @@ def test_coordinate_candidate_is_closed_after_comparison(
 
     monkeypatch.setattr(
         merge_module._baseline_edits,
-        "try_apply_baseline_replacement_units",
+        "try_apply_baseline_coordinate_edits",
         plan_candidate,
     )
 
@@ -237,7 +237,7 @@ def test_coordinate_candidate_is_closed_when_structural_planning_refuses(
 
     monkeypatch.setattr(
         merge_module._baseline_edits,
-        "try_apply_baseline_replacement_units",
+        "try_apply_baseline_coordinate_edits",
         lambda *_args, **kwargs: (
             coordinate_candidate
             if kwargs.get("trust_baseline_coordinates", False)
@@ -330,7 +330,7 @@ def test_large_merge_without_coordinates_plans_baseline_once(monkeypatch):
     )
     planning_modes = []
     original_plan = (
-        merge_module._baseline_edits.try_apply_baseline_replacement_units
+        merge_module._baseline_edits.try_apply_baseline_coordinate_edits
     )
 
     def count_plan(*args, **kwargs):
@@ -341,7 +341,7 @@ def test_large_merge_without_coordinates_plans_baseline_once(monkeypatch):
 
     monkeypatch.setattr(
         merge_module._baseline_edits,
-        "try_apply_baseline_replacement_units",
+        "try_apply_baseline_coordinate_edits",
         count_plan,
     )
 
@@ -394,7 +394,7 @@ def test_coordinate_candidate_discovery_reuses_initial_comparison(monkeypatch):
     )
     planning_modes = []
     original_plan = (
-        merge_module._baseline_edits.try_apply_baseline_replacement_units
+        merge_module._baseline_edits.try_apply_baseline_coordinate_edits
     )
 
     def count_plan(*args, **kwargs):
@@ -405,7 +405,7 @@ def test_coordinate_candidate_discovery_reuses_initial_comparison(monkeypatch):
 
     monkeypatch.setattr(
         merge_module._baseline_edits,
-        "try_apply_baseline_replacement_units",
+        "try_apply_baseline_coordinate_edits",
         count_plan,
     )
 
@@ -516,7 +516,7 @@ def test_baseline_fallback_routes_matching_storage_to_invocation_spool(
     working_lines = [b"prefix\n", b"two\n"]
     ownership = BatchOwnership.from_presence_lines(["2"], [])
 
-    fallback_chunks = try_apply_baseline_replacement_units(
+    fallback_chunks = try_apply_baseline_coordinate_edits(
         source_lines,
         working_lines,
         ownership,
@@ -1491,7 +1491,7 @@ class TestMergeBatch:
                 for line in (2, 4)
             },
         )
-        fallback_chunks = try_apply_baseline_replacement_units(
+        fallback_chunks = try_apply_baseline_coordinate_edits(
             source_lines,
             working_lines,
             ownership,

--- a/tests/batch/test_operation_candidates.py
+++ b/tests/batch/test_operation_candidates.py
@@ -140,7 +140,7 @@ def test_coordinate_candidate_planning_runs_each_baseline_strategy_once(
     )
     planning_modes = []
     original_plan = (
-        merge_module._baseline_edits.try_apply_baseline_replacement_units
+        merge_module._baseline_edits.try_apply_baseline_coordinate_edits
     )
 
     def count_plan(*args, **kwargs):
@@ -151,7 +151,7 @@ def test_coordinate_candidate_planning_runs_each_baseline_strategy_once(
 
     monkeypatch.setattr(
         merge_module._baseline_edits,
-        "try_apply_baseline_replacement_units",
+        "try_apply_baseline_coordinate_edits",
         count_plan,
     )
 


### PR DESCRIPTION
A merge can locate saved changes by aligning unchanged content or by using
file positions recorded when the changes were saved. Merge-method selection
still asks edit assembly whether the selected changes carry recorded
positions, and the assembly function's name mentions only replacements even
though it combines replacements, removals, and insertions.

The misplaced query obscures which code chooses a merge method. The
replacement-only function name also makes its complete behavior difficult to
identify, while source and tests must adopt a new name in separate commits.

This PR moves saved-position detection beside merge-method selection without
expanding large selected ranges, migrates tests before deleting the old query,
renames complete edit assembly through a temporary forwarding function, and
documents both responsibilities. The merge-focused tests, Ruff, type hygiene,
strict mypy, and package build pass.

Merge-method selection now owns saved-position detection and the choice
between recorded positions and content alignment. Complete edit assembly has
an accurate name and documentation for all three edit types.
