### PR TITLE
build: Install-test both distribution formats

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,14 +205,26 @@ jobs:
       - name: Install other dependencies
         run: uv sync --all-groups
 
-      - name: Build wheel
+      - name: Build distributions
         run: uv build
 
       - name: Verify wheel installs
         run: |
-          uv venv /tmp/test-install
-          uv pip install --python /tmp/test-install/bin/python dist/*.whl
-          /tmp/test-install/bin/git-stage-batch --help
+          uv venv "$RUNNER_TEMP/wheel-install"
+          uv pip install \
+            --no-config \
+            --python "$RUNNER_TEMP/wheel-install/bin/python" \
+            dist/*.whl
+          "$RUNNER_TEMP/wheel-install/bin/git-stage-batch" --help
+
+      - name: Verify source distribution installs
+        run: |
+          uv venv "$RUNNER_TEMP/sdist-install"
+          uv pip install \
+            --no-config \
+            --python "$RUNNER_TEMP/sdist-install/bin/python" \
+            dist/*.tar.gz
+          "$RUNNER_TEMP/sdist-install/bin/git-stage-batch" --help
 
   sha256-repository:
     runs-on: ubuntu-latest

--- a/tests/architecture/test_support_contract.py
+++ b/tests/architecture/test_support_contract.py
@@ -35,3 +35,11 @@ def test_ci_exercises_macos():
     workflow = _read_project_file(".github/workflows/ci.yml")
 
     assert "runs-on: macos-latest" in workflow
+
+
+def test_ci_install_checks_both_distribution_formats():
+    """Built wheels and source distributions should each be installed."""
+    workflow = _read_project_file(".github/workflows/ci.yml")
+
+    assert "dist/*.whl" in workflow
+    assert "dist/*.tar.gz" in workflow


### PR DESCRIPTION
The build job creates both a wheel and a source distribution, but currently
installs and smoke-tests only the wheel. A broken source archive could
therefore reach publication despite a green build.

This change installs the wheel and source archive into separate clean virtual
environments, with configuration discovery disabled, and invokes the packaged
command from each environment. An architecture check requires both artifact
patterns to remain covered.

Verified by building the current wheel and source distribution locally,
installing each into an independent environment, running both command entry
points, and passing the focused architecture tests, Ruff, workflow validation,
and diff checks.
