### PR TITLE
release: Publish packages with trusted credentials

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,60 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y gettext
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.10"
+
+      - name: Set up Python
+        run: uv python install 3.10
+
+      - name: Set up build environment
+        run: |
+          uv venv
+          uv pip install --group dev
+          uv sync --all-groups
+
+      - name: Build package distributions
+        run: uv build
+
+      - name: Upload package distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/git-stage-batch
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download package distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,38 @@
+# Releasing
+
+Publishing a GitHub release triggers
+[`release.yml`](https://github.com/halfline/git-stage-batch/blob/main/.github/workflows/release.yml).
+The workflow builds the wheel and source distribution in a job without
+publishing credentials, transfers those files as a workflow artifact, and
+gives only the final PyPI job permission to request an OpenID Connect token.
+
+## One-time Trusted Publisher setup
+
+Configure the existing `git-stage-batch` project under
+[PyPI's **Publishing** settings](https://docs.pypi.org/trusted-publishers/adding-a-publisher/)
+with this GitHub publisher:
+
+- **Owner:** `halfline`
+- **Repository:** `git-stage-batch`
+- **Workflow name:** `release.yml`
+- **Environment name:** `pypi`
+
+Create a matching `pypi` environment in the GitHub repository. Add required
+reviewers to that environment when releases should require approval after the
+distribution build completes.
+
+The workflow intentionally has no PyPI password or API-token secret. Its
+publish job receives only `id-token: write`, downloads the distributions
+created by the unprivileged build job, and publishes them with
+[PyPA's official Trusted Publishing action](https://docs.pypi.org/trusted-publishers/using-a-publisher/).
+
+## Publish a release
+
+1. Confirm that CI passes on the release commit.
+2. Create and push the version tag.
+3. Publish the corresponding GitHub release.
+4. Approve the `pypi` environment deployment when protection rules require it.
+5. Verify that both the wheel and source distribution appear on PyPI.
+
+The GitHub release event selects the tagged commit, so do not publish a draft
+release until its tag points to the intended source.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,7 @@ nav:
   - Home: index.md
   - Getting Started:
     - Installation: installation.md
+    - Releasing: releasing.md
   - Reference:
     - Commands: commands.md
     - Interactive Mode: interactive.md

--- a/tests/architecture/test_support_contract.py
+++ b/tests/architecture/test_support_contract.py
@@ -43,3 +43,13 @@ def test_ci_install_checks_both_distribution_formats():
 
     assert "dist/*.whl" in workflow
     assert "dist/*.tar.gz" in workflow
+
+
+def test_release_uses_trusted_publishing():
+    """The PyPI job should use OIDC without a stored publishing token."""
+    workflow = _read_project_file(".github/workflows/release.yml")
+
+    assert "id-token: write" in workflow
+    assert "pypa/gh-action-pypi-publish@release/v1" in workflow
+    assert "secrets." not in workflow
+    assert "password:" not in workflow


### PR DESCRIPTION
Package artifacts are now built and install-tested in CI, but publication is
not yet represented by a repository workflow using PyPI Trusted Publishing.
That leaves the release credential boundary outside the versioned project
contract.

This series adds a release-only workflow triggered by published GitHub
releases. An unprivileged job builds and uploads both distribution formats;
only the dependent `pypi` environment job receives `id-token: write`, downloads
those artifacts, and invokes PyPA's official publishing action. No stored PyPI
secret is referenced.

The follow-up commit documents the one-time PyPI publisher registration, the
matching GitHub environment, optional reviewer protection, and the operator
release procedure. A separate `release.yml` is intentional: PyPI binds the
trusted identity to the exact workflow filename, and normal CI does not need
OIDC permission.

Verified with the focused support-contract tests, Ruff, action/workflow
validation, a strict documentation build, and diff checks. The external PyPI
publisher and GitHub environment still require the documented one-time
repository-owner setup before the first release.
