### PR TITLE
session: Count every review pass

### DIFF
--- a/src/git_stage_batch/commands/session/iteration.py
+++ b/src/git_stage_batch/commands/session/iteration.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from ...data.file_tracking import auto_add_untracked_files
 from ...data.hunk_tracking import fetch_next_change
-from ...data.session import clear_iteration_state
+from ...data.session import clear_iteration_state, increment_iteration_count
 from ...exceptions import NoMoreHunks
 from ...i18n import _
 from ..selection.selected_change_display import show_selected_change
@@ -13,6 +13,7 @@ from ..selection.selected_change_display import show_selected_change
 def restart_iteration_pass(*, quiet: bool = False) -> None:
     """Clear iteration state and select the first available change."""
     clear_iteration_state()
+    increment_iteration_count()
     auto_add_untracked_files(show_progress=not quiet)
 
     try:

--- a/tests/commands/test_again.py
+++ b/tests/commands/test_again.py
@@ -7,6 +7,7 @@ from git_stage_batch.commands.include import command_include
 from git_stage_batch.commands.show import command_show, command_show_file_list
 from git_stage_batch.data.file_review.state import read_last_file_review_state
 from git_stage_batch.data.hunk_tracking import fetch_next_change
+from git_stage_batch.data.session import get_iteration_count
 from git_stage_batch.data.selected_change.store import (
     SelectedChangeKind,
     read_selected_change_kind,
@@ -59,6 +60,18 @@ def temp_git_repo(tmp_path, monkeypatch):
 
 class TestCommandAgain:
     """Tests for again command."""
+    def test_again_advances_session_iteration(self, temp_git_repo):
+        """Again should report each fresh pass as the next iteration."""
+        (temp_git_repo / "README.md").write_text("# Test\nmodified\n")
+
+        command_start(quiet=True)
+        assert get_iteration_count() == 1
+
+        command_again(quiet=True)
+        assert get_iteration_count() == 2
+
+        command_again(quiet=True)
+        assert get_iteration_count() == 3
 
     def test_again_clears_iteration_state(self, temp_git_repo):
         """Test that again clears iteration-specific state but preserves permanent state."""

--- a/tests/commands/test_start.py
+++ b/tests/commands/test_start.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import pytest
 
 from git_stage_batch.commands.start import command_start
+from git_stage_batch.data.session import get_iteration_count
 from git_stage_batch.data.session_marker import session_is_active
 from git_stage_batch.exceptions import CommandError
 from git_stage_batch.utils.file_io import read_text_file_contents
@@ -61,6 +62,7 @@ class TestCommandStart:
 
         state_dir = get_state_directory_path()
         assert state_dir.exists()
+        assert get_iteration_count() == 2
 
     def test_start_initializes_abort_state(self, temp_git_repo):
         """Test that start initializes abort state files."""


### PR DESCRIPTION
A review session stores an iteration count and clears per-pass state before
the `start` and `again` commands select the next change.

Restarting a review pass leaves the stored count unchanged, so status and
prompt integrations cannot distinguish consecutive passes through skipped
changes.

This pull request increments the count whenever a pass starts and adds
command-level assertions for initial and repeated restarts. The refreshed
suite passes with 3,484 tests and 12 skips.

The persisted count now identifies every review pass entered through `start`
or `again`.
