### PR TITLE
batch: Remove unused source-refresh interfaces

### DIFF
--- a/src/git_stage_batch/batch/line_matching/comparison.py
+++ b/src/git_stage_batch/batch/line_matching/comparison.py
@@ -53,14 +53,6 @@ class SemanticChangeRun:
         _validate_range_pair(self.source_start, self.source_end, "source")
         _validate_range_pair(self.target_start, self.target_end, "target")
 
-    def source_line_numbers(self) -> range:
-        """Return source line numbers in this run without materializing them."""
-        return _line_range(self.source_start, self.source_end)
-
-    def target_line_numbers(self) -> range:
-        """Return target line numbers in this run without materializing them."""
-        return _line_range(self.target_start, self.target_end)
-
     def has_source_line(self, line_number: int | None) -> bool:
         if (
             line_number is None
@@ -78,12 +70,6 @@ class SemanticChangeRun:
         ):
             return False
         return self.target_start <= line_number <= self.target_end
-
-
-def _line_range(start: int | None, end: int | None) -> range:
-    if start is None or end is None:
-        return range(0)
-    return range(start, end + 1)
 
 
 def _validate_range_pair(
@@ -229,21 +215,6 @@ def derive_display_id_run_sets_from_lines(
     semantic_runs = derive_semantic_change_runs(
         source_lines,
         target_lines,
-    )
-    return _display_id_run_sets_from_semantic_runs(line_changes, semantic_runs)
-
-
-def derive_replacement_display_id_run_sets_from_lines(
-    line_changes: LineLevelChange,
-    *,
-    source_lines: Sequence[bytes],
-    target_lines: Sequence[bytes],
-) -> list[set[int]]:
-    """Map replacement runs from byte-line sequences onto display IDs."""
-    semantic_runs = (
-        run
-        for run in derive_semantic_change_runs(source_lines, target_lines)
-        if run.kind == SemanticChangeKind.REPLACEMENT
     )
     return _display_id_run_sets_from_semantic_runs(line_changes, semantic_runs)
 

--- a/src/git_stage_batch/batch/line_matching/line_mapping.py
+++ b/src/git_stage_batch/batch/line_matching/line_mapping.py
@@ -25,11 +25,9 @@ class LineMapping:
     source_to_target: IntVector
     target_to_source: IntVector
     _closed: bool = field(default=False, init=False, repr=False)
-    _close_on_exit: bool = field(default=True, init=False, repr=False)
 
     def __enter__(self) -> LineMapping:
         self._require_open()
-        self._close_on_exit = True
         return self
 
     def __exit__(
@@ -38,14 +36,7 @@ class LineMapping:
         exc: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
-        if self._close_on_exit:
-            self.close()
-
-    def detach(self) -> LineMapping:
-        """Transfer ownership out of the current context manager."""
-        self._require_open()
-        self._close_on_exit = False
-        return self
+        self.close()
 
     def close(self) -> None:
         """Close owned vector storage."""

--- a/src/git_stage_batch/batch/line_matching/lineage.py
+++ b/src/git_stage_batch/batch/line_matching/lineage.py
@@ -283,16 +283,6 @@ class BatchSourceLineage:
         )
         self._closed = False
 
-    @classmethod
-    def from_runs(
-        cls,
-        *,
-        source_runs: Iterable[LineageRun] = (),
-        working_runs: Iterable[LineageRun] = (),
-        spool_dir: str | Path | None = None,
-    ) -> BatchSourceLineage:
-        return cls(source_runs, working_runs, spool_dir=spool_dir)
-
     @property
     def byte_count(self) -> int:
         if self._closed:
@@ -340,13 +330,6 @@ class BatchSourceLineage:
     def translate_working_line(self, line_number: int) -> int | None:
         self._require_open()
         return self._working_runs.translate_line(line_number)
-
-    def translate_working_selection(
-        self,
-        selection: LineSelection | Iterable[int],
-    ) -> LineRanges:
-        self._require_open()
-        return self._working_runs.translate_selection(selection)
 
     def close(self) -> None:
         if self._closed:

--- a/src/git_stage_batch/batch/line_matching/sequence_search.py
+++ b/src/git_stage_batch/batch/line_matching/sequence_search.py
@@ -17,38 +17,6 @@ class TargetGap:
     target_before_line: int | None
 
 
-def iter_exact_sequence_occurrences(
-    lines: Sequence[bytes],
-    sequence: Sequence[bytes],
-    *,
-    start: int = 0,
-    end: int | None = None,
-    max_results: int | None = None,
-) -> Iterator[int]:
-    """Yield exact sequence start offsets in ascending order."""
-    if end is None:
-        end = len(lines)
-    start = max(start, 0)
-    end = min(end, len(lines))
-    if not sequence:
-        return
-    if start > end:
-        return
-
-    result_count = 0
-    sequence_length = len(sequence)
-    last_start = end - sequence_length
-    for index in range(start, last_start + 1):
-        if all(
-            lines[index + offset] == sequence[offset]
-            for offset in range(sequence_length)
-        ):
-            yield index
-            result_count += 1
-            if max_results is not None and result_count >= max_results:
-                return
-
-
 def iter_exact_context_gaps(
     target_lines: Sequence[bytes],
     *,

--- a/src/git_stage_batch/batch/merge/candidate_enumeration.py
+++ b/src/git_stage_batch/batch/merge/candidate_enumeration.py
@@ -95,7 +95,6 @@ def _coordinate_strategy_candidate_set(
                     _MergeResolutionDecision(
                         ambiguity_key=_COORDINATE_STRATEGY_AMBIGUITY_KEY,
                         choice_index=choice_index.value,
-                        choice_label=summary,
                     ),
                 ),
                 summary=summary,
@@ -301,7 +300,6 @@ def _replacement_origin_candidate_set(
                     _MergeResolutionDecision(
                         ambiguity_key=key,
                         choice_index=choice.choice_index,
-                        choice_label=summary,
                     ),
                 ),
                 summary=summary,
@@ -391,7 +389,6 @@ def _presence_candidate_set(
                     _MergeResolutionDecision(
                         ambiguity_key=presence_key,
                         choice_index=choice.choice_index,
-                        choice_label=summary,
                     ),
                 ),
                 summary=summary,
@@ -508,7 +505,6 @@ def _absence_candidate_set(
                         _MergeResolutionDecision(
                             ambiguity_key=ambiguity_key,
                             choice_index=choice.choice_index,
-                            choice_label=summary,
                         ),
                     ),
                     summary=summary,

--- a/src/git_stage_batch/batch/merge/candidates.py
+++ b/src/git_stage_batch/batch/merge/candidates.py
@@ -13,7 +13,6 @@ class MergeResolutionDecision:
 
     ambiguity_key: str
     choice_index: int
-    choice_label: str
 
 
 @dataclass(frozen=True)

--- a/src/git_stage_batch/batch/ownership/remapping.py
+++ b/src/git_stage_batch/batch/ownership/remapping.py
@@ -2,12 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Sequence
-
 from ...core.line_selection import LineSelection
 from ..line_matching.lineage import BatchSourceLineage
-from ..line_matching.line_mapping import LineMapping
-from ..line_matching.match import match_lines
 from .model import BatchOwnership
 from .absence_claims import AbsenceClaim
 from .claims import (
@@ -16,38 +12,6 @@ from .claims import (
     presence_claims_from_source_lines,
 )
 from .replacement_units import ReplacementUnit, normalize_replacement_units
-
-
-def _remap_replacement_units(
-    replacement_units: list[ReplacementUnit],
-    *,
-    map_claimed_line: Callable[[int], int | None],
-    deletion_count: int,
-) -> list[ReplacementUnit]:
-    """Remap explicit replacement-unit presence lines into a new source space."""
-    remapped_units: list[ReplacementUnit] = []
-
-    for unit in replacement_units:
-        new_presence_lines: set[int] = set()
-        for old_line_num in parse_ownership_line_ranges(unit.presence_lines):
-            new_line_num = map_claimed_line(old_line_num)
-            if new_line_num is None:
-                raise ValueError(
-                    f"Cannot remap replacement unit presence line {old_line_num} "
-                    f"from old source to new source: no unique mapping found."
-                )
-            new_presence_lines.add(new_line_num)
-
-        remapped_units.append(ReplacementUnit(
-            presence_lines=format_ownership_line_set(new_presence_lines),
-            deletion_indices=unit.deletion_indices,
-            origin=unit.origin,
-        ))
-
-    return normalize_replacement_units(
-        remapped_units,
-        deletion_count=deletion_count,
-    )
 
 
 def _first_unmapped_line(
@@ -86,84 +50,6 @@ def _remap_replacement_units_with_lineage(
     return normalize_replacement_units(
         remapped_units,
         deletion_count=deletion_count,
-    )
-
-
-def remap_batch_ownership_to_new_source_lines(
-    ownership: BatchOwnership,
-    old_source_lines: Sequence[bytes],
-    new_source_lines: Sequence[bytes],
-) -> BatchOwnership:
-    """Remap batch ownership between old and new source line sequences."""
-    with match_lines(old_source_lines, new_source_lines) as mapping:
-        return _remap_batch_ownership_with_mapping(ownership, mapping)
-
-
-def _remap_batch_ownership_with_mapping(
-    ownership: BatchOwnership,
-    mapping: LineMapping,
-) -> BatchOwnership:
-    """Remap batch ownership using an existing old-to-new source mapping."""
-    # Remap presence lines
-    old_presence = ownership.presence_line_set()
-    new_presence = set()
-
-    for old_line_num in old_presence:
-        new_line_num = mapping.get_target_line_from_source_line(old_line_num)
-        if new_line_num is None:
-            # Line cannot be mapped - fail loudly
-            raise ValueError(
-                f"Cannot remap presence line {old_line_num} from old source to new source: "
-                f"no unique mapping found. This indicates the old line was removed or "
-                f"significantly changed in the new source."
-            )
-        new_presence.add(new_line_num)
-
-    # Remap deletion anchors
-    new_deletions = []
-    for deletion in ownership.deletions:
-        if deletion.anchor_line is None:
-            # Start-of-file anchor remains None
-            new_deletions.append(AbsenceClaim(
-                anchor_line=None,
-                content_lines=deletion.content_lines,
-                baseline_reference=deletion.baseline_reference,
-            ))
-        else:
-            # Remap anchor line
-            new_anchor = mapping.get_target_line_from_source_line(deletion.anchor_line)
-            if new_anchor is None:
-                # Anchor cannot be mapped - fail loudly
-                raise ValueError(
-                    f"Cannot remap deletion anchor line {deletion.anchor_line} from old source "
-                    f"to new source: no unique mapping found. This indicates the anchor line "
-                    f"was removed or significantly changed in the new source."
-                )
-            new_deletions.append(AbsenceClaim(
-                anchor_line=new_anchor,
-                content_lines=deletion.content_lines,
-                baseline_reference=deletion.baseline_reference,
-            ))
-
-    new_replacement_units = _remap_replacement_units(
-        ownership.replacement_units,
-        map_claimed_line=mapping.get_target_line_from_source_line,
-        deletion_count=len(new_deletions),
-    )
-
-    new_presence_baseline_references = {}
-    for old_line_num, reference in ownership.presence_baseline_references().items():
-        new_line_num = mapping.get_target_line_from_source_line(old_line_num)
-        if new_line_num is not None:
-            new_presence_baseline_references[new_line_num] = reference
-
-    return BatchOwnership(
-        presence_claims=presence_claims_from_source_lines(
-            new_presence,
-            new_presence_baseline_references,
-        ),
-        deletions=new_deletions,
-        replacement_units=new_replacement_units,
     )
 
 

--- a/src/git_stage_batch/batch/ownership/unit_types.py
+++ b/src/git_stage_batch/batch/ownership/unit_types.py
@@ -37,7 +37,6 @@ class OwnershipUnit:
         deletion_claims: Absence claims that are part of this unit
         display_line_ids: Display line IDs that map to this unit (from reconstructed display)
         is_atomic: If True, partial removal is not allowed
-        atomic_reason: Explanation for why unit is atomic (for debugging/errors)
         preserves_replacement_unit: True when this unit came from persisted replacement metadata
         replacement_origin: Original parent replacement context, when known
     """
@@ -47,6 +46,5 @@ class OwnershipUnit:
     display_line_ids: LineRanges
     baseline_references: dict[int, BaselineReference] = field(default_factory=dict)
     is_atomic: bool = False
-    atomic_reason: str | None = None
     preserves_replacement_unit: bool = False
     replacement_origin: ReplacementUnitOrigin | None = None

--- a/src/git_stage_batch/batch/ownership/units.py
+++ b/src/git_stage_batch/batch/ownership/units.py
@@ -177,7 +177,6 @@ def build_ownership_units_from_display_lines(
                         LineRanges.from_lines([claimed_source_line]),
                     ),
                     is_atomic=False,
-                    atomic_reason=None
                 ))
         else:
             # Unknown type - skip
@@ -258,7 +257,6 @@ def _build_explicit_replacement_units_from_display_lines(
                 claimed_source_lines,
             ),
             is_atomic=True,
-            atomic_reason="explicit_replacement",
             preserves_replacement_unit=True,
             replacement_origin=replacement_unit.origin,
         ))
@@ -397,7 +395,6 @@ def _build_replacement_unit(
             claimed_source_lines,
         ),
         is_atomic=True,
-        atomic_reason="display_adjacency"
     )
 
 
@@ -425,7 +422,6 @@ def _build_deletion_only_unit(
         deletion_claims=deletion_claims,
         display_line_ids=LineRanges.from_lines(deletion_run["display_ids"]),
         is_atomic=True,
-        atomic_reason="deletion_only"
     )
 
 

--- a/src/git_stage_batch/batch/ownership_update.py
+++ b/src/git_stage_batch/batch/ownership_update.py
@@ -35,9 +35,6 @@ class PreparedBatchUpdate:
     batch_source_commit: str | None
     """The batch source commit to use for this file."""
 
-    ownership_before: BatchOwnership | None
-    """Ownership before applying this update, possibly remapped to new source."""
-
     ownership_after: BatchOwnership
     """Ownership after merging new selection with existing ownership."""
 
@@ -134,40 +131,6 @@ def _ownership_has_replacement_origin_references(
     return False
 
 
-def prepare_batch_ownership_update_for_selection(
-    batch_name: str,
-    file_path: str,
-    current_batch_source_commit: str | None,
-    existing_ownership: BatchOwnership | None,
-    selected_lines: list[LineEntry],
-    *,
-    hunk_lines: Sequence[LineEntry] | None = None,
-    replacement_line_runs: Iterable[ReplacementLineRun] | None = None,
-    replacement_origin_line_runs: Iterable[ReplacementLineRun] | None = None,
-    reference_source_lines: Sequence[bytes] | None = None,
-    reference_target_lines: Sequence[bytes] | None = None,
-    replacement_origin_source_lines: Sequence[bytes] | None = None,
-) -> PreparedBatchUpdate:
-    """Prepare complete ownership update after stale-source handling."""
-    refreshed = ensure_batch_source_current_for_selection(
-        batch_name=batch_name,
-        file_path=file_path,
-        current_batch_source_commit=current_batch_source_commit,
-        existing_ownership=existing_ownership,
-        selected_lines=selected_lines,
-        coordinate_lines=hunk_lines,
-    )
-    return _prepare_batch_ownership_update_from_refreshed_selection(
-        refreshed,
-        hunk_lines=hunk_lines,
-        replacement_line_runs=replacement_line_runs,
-        replacement_origin_line_runs=replacement_origin_line_runs,
-        reference_source_lines=reference_source_lines,
-        reference_target_lines=reference_target_lines,
-        replacement_origin_source_lines=replacement_origin_source_lines,
-    )
-
-
 def _prepare_batch_ownership_update_from_refreshed_selection(
     refreshed: RefreshedBatchSelection,
     *,
@@ -227,7 +190,6 @@ def _prepare_batch_ownership_update_from_refreshed_selection(
 
     return PreparedBatchUpdate(
         batch_source_commit=refreshed.batch_source_commit,
-        ownership_before=refreshed.ownership,
         ownership_after=merged_ownership
     )
 

--- a/src/git_stage_batch/batch/realization/entry_storage.py
+++ b/src/git_stage_batch/batch/realization/entry_storage.py
@@ -207,16 +207,6 @@ class RealizedEntries(Sequence[_RealizedEntry]):
         start, stop = self._validated_range(start, stop)
         yield from self._provenance.runs(start, stop)
 
-    @property
-    def provenance_run_count(self) -> int:
-        self._require_open()
-        return len(self._provenance)
-
-    @property
-    def flushed_provenance_run_count(self) -> int:
-        self._require_open()
-        return self._provenance.flushed_run_count
-
     def content_at(self, index: int) -> LineLike:
         self._require_open()
         return self._editor[self._normalize_index(index)]

--- a/src/git_stage_batch/batch/realization/provenance.py
+++ b/src/git_stage_batch/batch/realization/provenance.py
@@ -129,11 +129,6 @@ class ProvenanceRunTable:
         return self._closed
 
     @property
-    def flushed_run_count(self) -> int:
-        self._require_open()
-        return len(self._runs)
-
-    @property
     def pending_run_count(self) -> int:
         self._require_open()
         return 1 if self._pending_run is not None else 0

--- a/src/git_stage_batch/batch/source/annotation.py
+++ b/src/git_stage_batch/batch/source/annotation.py
@@ -187,19 +187,3 @@ def annotate_with_batch_source_working_lines(
         spool_dir=spool_dir,
     ) as mapping:
         return annotate_with_batch_source_mapping(line_changes, mapping)
-
-
-def annotate_with_batch_source_lines(
-    line_changes: LineLevelChange,
-    *,
-    batch_source_lines: Sequence[bytes],
-    working_lines: Sequence[bytes],
-    spool_dir: str | Path | None = None,
-) -> LineLevelChange:
-    """Annotate LineLevelChange from indexed batch-source and working lines."""
-    with match_lines(
-        batch_source_lines,
-        working_lines,
-        spool_dir=spool_dir,
-    ) as mapping:
-        return annotate_with_batch_source_mapping(line_changes, mapping)

--- a/src/git_stage_batch/exceptions.py
+++ b/src/git_stage_batch/exceptions.py
@@ -3,8 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-from dataclasses import dataclass
-from typing import Literal, NoReturn
+from typing import NoReturn
 
 
 class CommandError(Exception):
@@ -61,50 +60,6 @@ class MergeError(Exception):
     """Raised when batch merge fails due to structural ambiguity."""
 
     pass
-
-
-@dataclass(frozen=True)
-class MergeAmbiguityChoice:
-    """One concrete merge ambiguity choice."""
-
-    choice_index: int
-    target_after_line: int | None
-    target_before_line: int | None
-    explanation: str
-
-
-@dataclass(frozen=True)
-class MergeAmbiguity:
-    """An enumerable merge ambiguity."""
-
-    key: str
-    kind: Literal[
-        "missing_claimed_run_placement",
-        "ambiguous_absence_boundary",
-        "replacement_region_placement",
-    ]
-    source_line_range: tuple[int, int] | None
-    choices: tuple[MergeAmbiguityChoice, ...]
-
-
-@dataclass(frozen=True)
-class MergeAmbiguitySet:
-    """A collection of merge ambiguities for one target."""
-
-    file_path: str | None
-    source_line_count: int
-    target_line_count: int
-    ambiguities: tuple[MergeAmbiguity, ...]
-
-
-class MergeAmbiguityError(MergeError):
-    """Raised when a merge refusal has enumerable candidate choices."""
-
-    def __init__(self, ambiguity: MergeAmbiguitySet):
-        self.ambiguity = ambiguity
-        super().__init__("Merge has enumerable ambiguity")
-
-
 class MissingAnchorError(MergeError):
     """Raised when an anchor line is not present in realized content.
 

--- a/tests/batch/line_matching/test_comparison.py
+++ b/tests/batch/line_matching/test_comparison.py
@@ -6,11 +6,9 @@ import git_stage_batch.batch.line_matching.comparison as comparison_module
 from git_stage_batch.batch.line_matching.comparison import (
     SemanticChangeKind,
     SemanticChangeRun,
-    derive_replacement_display_id_run_sets_from_lines,
     derive_semantic_change_runs,
     stream_semantic_change_runs,
 )
-from git_stage_batch.core.models import HunkHeader, LineEntry, LineLevelChange
 
 
 def test_derive_semantic_change_runs_accepts_non_list_sequences(line_sequence):
@@ -82,8 +80,6 @@ def test_derive_semantic_change_runs_uses_range_records():
     ]
     assert not hasattr(runs[0], "source_run")
     assert not hasattr(runs[0], "target_run")
-    assert runs[0].source_line_numbers() == range(2, 4)
-    assert runs[0].target_line_numbers() == range(2, 4)
 
 
 def test_semantic_change_run_rejects_invalid_ranges():
@@ -150,66 +146,3 @@ def test_derive_semantic_change_runs_uses_ranges_for_one_sided_changes():
             target_end=3,
         )
     ]
-
-
-def test_replacement_display_id_run_sets_accepts_non_list_sequences(line_sequence):
-    """Replacement display grouping accepts indexed byte-line sequences."""
-    line_changes = LineLevelChange(
-        path="module.py",
-        header=HunkHeader(old_start=1, old_len=2, new_start=1, new_len=4),
-        lines=[
-            LineEntry(
-                id=None,
-                kind=" ",
-                old_line_number=1,
-                new_line_number=1,
-                text_bytes=b"keep\n",
-                text="keep\n",
-            ),
-            LineEntry(
-                id=1,
-                kind="-",
-                old_line_number=2,
-                new_line_number=None,
-                text_bytes=b"old value\n",
-                text="old value\n",
-            ),
-            LineEntry(
-                id=2,
-                kind="+",
-                old_line_number=None,
-                new_line_number=2,
-                text_bytes=b"new value 1\n",
-                text="new value 1\n",
-            ),
-            LineEntry(
-                id=3,
-                kind="+",
-                old_line_number=None,
-                new_line_number=3,
-                text_bytes=b"new value 2\n",
-                text="new value 2\n",
-            ),
-            LineEntry(
-                id=4,
-                kind="+",
-                old_line_number=None,
-                new_line_number=4,
-                text_bytes=b"new value 3\n",
-                text="new value 3\n",
-            ),
-        ],
-    )
-
-    run_sets = derive_replacement_display_id_run_sets_from_lines(
-        line_changes,
-        source_lines=line_sequence([b"keep\n", b"old value\n"]),
-        target_lines=line_sequence([
-            b"keep\n",
-            b"new value 1\n",
-            b"new value 2\n",
-            b"new value 3\n",
-        ]),
-    )
-
-    assert run_sets == [{1, 2, 3, 4}]

--- a/tests/batch/merge/test_merge.py
+++ b/tests/batch/merge/test_merge.py
@@ -596,18 +596,6 @@ class TestMatchLines:
         with pytest.raises(ValueError, match="line mapping is closed"):
             mapping.get_target_line_from_source_line(1)
 
-    def test_line_mapping_detach_transfers_context_ownership(self):
-        """Detached mappings remain usable until their new owner closes them."""
-        with match_lines([b"a\n"], [b"a\n"]) as mapping:
-            detached = mapping.detach()
-
-        assert detached.get_target_line_from_source_line(1) == 1
-        detached.close()
-        detached.close()
-
-        with pytest.raises(ValueError, match="line mapping is closed"):
-            detached.detach()
-
     def test_line_mapping_exposes_mapped_line_pairs(self):
         """Mapped pair iteration exposes source-order correspondence."""
         with match_lines(

--- a/tests/batch/merge/test_merge.py
+++ b/tests/batch/merge/test_merge.py
@@ -939,12 +939,10 @@ class TestMergeLineSequences:
         entries = RealizedEntries()
         entries.append_line_from(lines, 0, source_line=1, target_line=1)
 
-        assert entries.flushed_provenance_run_count == 0
         assert entries.source_line_at(0) == 1
 
         entries.append_line_from(lines, 1, source_line=2, target_line=2)
 
-        assert entries.flushed_provenance_run_count == 0
         runs = list(entries.provenance_runs())
         assert len(runs) == 1
         assert (runs[0].dest_start, runs[0].dest_end) == (0, 2)
@@ -1154,7 +1152,7 @@ class TestMergeLineSequences:
             entries = _build_realized_entries_for_discard(lines, lines, mapping)
 
         assert len(entries) == 1000
-        assert entries.provenance_run_count == 1
+        assert len(entries._provenance) == 1
         assert entries.source_line_at(999) == 1000
         entries.close()
 
@@ -1165,7 +1163,7 @@ class TestMergeLineSequences:
         entries = satisfy_constraints(lines, lines, set(), [])
 
         assert len(entries) == 1000
-        assert entries.provenance_run_count == 1
+        assert len(entries._provenance) == 1
         assert entries.target_line_at(999) == 1000
         entries.close()
 

--- a/tests/batch/ownership/test_units.py
+++ b/tests/batch/ownership/test_units.py
@@ -168,7 +168,6 @@ def test_deletion_followed_by_claimed_becomes_replacement():
     assert len(units) == 1
     assert units[0].kind == OwnershipUnitKind.REPLACEMENT
     assert units[0].is_atomic is True
-    assert units[0].atomic_reason == "display_adjacency"
     assert len(units[0].deletion_claims) == 1
     assert units[0].claimed_source_lines == {1}
 
@@ -246,7 +245,6 @@ def test_claimed_followed_by_deletion_becomes_replacement():
     assert len(units) == 1
     assert units[0].kind == OwnershipUnitKind.REPLACEMENT
     assert units[0].is_atomic is True
-    assert units[0].atomic_reason == "display_adjacency"
 
 
 def test_deletion_without_adjacent_claimed_is_deletion_only():
@@ -278,7 +276,6 @@ def test_deletion_without_adjacent_claimed_is_deletion_only():
     assert len(units) == 1
     assert units[0].kind == OwnershipUnitKind.DELETION_ONLY
     assert units[0].is_atomic is True
-    assert units[0].atomic_reason == "deletion_only"
     assert len(units[0].deletion_claims) == 1
     assert units[0].claimed_source_lines == set()
 
@@ -306,7 +303,6 @@ def test_claimed_without_adjacent_deletion_is_presence_only():
     assert len(units) == 1
     assert units[0].kind == OwnershipUnitKind.PRESENCE_ONLY
     assert units[0].is_atomic is False
-    assert units[0].atomic_reason is None
     assert type(units[0].claimed_source_lines) is LineRanges
     assert type(units[0].display_line_ids) is LineRanges
     assert units[0].claimed_source_lines == {2}
@@ -541,7 +537,6 @@ def test_explicit_replacement_unit_overrides_display_adjacency():
 
     assert len(units) == 1
     assert units[0].kind == OwnershipUnitKind.REPLACEMENT
-    assert units[0].atomic_reason == "explicit_replacement"
     assert units[0].preserves_replacement_unit is True
     assert units[0].claimed_source_lines == {1}
     assert units[0].deletion_claims == ownership.deletions

--- a/tests/batch/source/test_advancement.py
+++ b/tests/batch/source/test_advancement.py
@@ -9,10 +9,7 @@ from git_stage_batch.batch.ownership.model import (
     BatchOwnership,
 )
 from git_stage_batch.batch.ownership.merging import merge_batch_ownership
-from git_stage_batch.batch.ownership.remapping import (
-    remap_batch_ownership_to_new_source_lines,
-    remap_batch_ownership_with_lineage,
-)
+from git_stage_batch.batch.ownership.remapping import remap_batch_ownership_with_lineage
 from git_stage_batch.batch.ownership.translation import (
     detect_stale_batch_source_for_selection,
     translate_lines_to_batch_ownership,
@@ -58,23 +55,6 @@ class _PresenceLineGuardedOwnership(BatchOwnership):
 
     def presence_line_set(self) -> _IterationGuardedLineSelection:
         return self._selection
-
-
-def _remap_ownership_from_content(
-    *,
-    ownership: BatchOwnership,
-    old_source_content: bytes,
-    new_source_content: bytes,
-) -> BatchOwnership:
-    with (
-        LineBuffer.from_bytes(old_source_content) as old_source_lines,
-        LineBuffer.from_bytes(new_source_content) as new_source_lines,
-    ):
-        return remap_batch_ownership_to_new_source_lines(
-            ownership=ownership,
-            old_source_lines=old_source_lines,
-            new_source_lines=new_source_lines,
-        )
 
 
 def _advance_source_from_content(
@@ -148,213 +128,9 @@ def test_translate_fails_loudly_with_none_source_line():
         translate_lines_to_batch_ownership(stale_lines)
 
 
-def test_remap_claimed_lines_to_new_source():
-    """Test remapping of claimed lines from old source to new source."""
-    # Old source has 3 lines
-    old_source = b"line one\nline two\nline three\n"
-
-    # New source has 4 lines (added a line at the beginning)
-    new_source = b"new first line\nline one\nline two\nline three\n"
-
-    # Original ownership claims lines 1-2 in old source
-    old_ownership = BatchOwnership.from_presence_lines(["1-2"], [])
-
-    # Remap to new source
-    new_ownership = _remap_ownership_from_content(
-        ownership=old_ownership,
-        old_source_content=old_source,
-        new_source_content=new_source
-    )
-
-    # Lines 1-2 in old source should map to lines 2-3 in new source
-    assert new_ownership.presence_claims[0].source_lines == ["2-3"]
-    assert new_ownership.deletions == []
-
-
-def test_remap_claimed_lines_accepts_non_list_line_sequences(line_sequence):
-    """Ownership remapping accepts indexed byte-line sequences."""
-    old_lines = line_sequence([b"line one\n", b"line two\n", b"line three\n"])
-    new_lines = line_sequence([
-        b"new first line\n",
-        b"line one\n",
-        b"line two\n",
-        b"line three\n",
-    ])
-    old_ownership = BatchOwnership.from_presence_lines(["1-2"], [])
-
-    new_ownership = remap_batch_ownership_to_new_source_lines(
-        ownership=old_ownership,
-        old_source_lines=old_lines,
-        new_source_lines=new_lines,
-    )
-
-    assert new_ownership.presence_claims[0].source_lines == ["2-3"]
-    assert new_ownership.deletions == []
-
-
-def test_remap_deletion_anchors_to_new_source():
-    """Test remapping of absence claim anchors from old source to new source."""
-    old_source = b"line one\nline two\nline three\n"
-    new_source = b"new first line\nline one\nline two\nline three\n"
-
-    # Original ownership has deletion anchored at line 2
-    old_ownership = BatchOwnership.from_presence_lines(
-        [],
-        [
-            AbsenceClaim(anchor_line=2, content_lines=[b"deleted line\n"])
-        ]
-    )
-
-    # Remap to new source
-    new_ownership = _remap_ownership_from_content(
-        ownership=old_ownership,
-        old_source_content=old_source,
-        new_source_content=new_source
-    )
-
-    # Anchor at line 2 in old source should map to line 3 in new source
-    assert len(new_ownership.deletions) == 1
-    assert new_ownership.deletions[0].anchor_line == 3
-    assert list(new_ownership.deletions[0].content_lines) == [b"deleted line\n"]
-
-
-def test_remap_start_of_file_deletion_anchor():
-    """Test that start-of-file deletion anchors (None) remain None after remapping."""
-    old_source = b"line one\nline two\n"
-    new_source = b"new first line\nline one\nline two\n"
-
-    old_ownership = BatchOwnership.from_presence_lines(
-        [],
-        [
-            AbsenceClaim(anchor_line=None, content_lines=[b"deleted at start\n"])
-        ]
-    )
-
-    new_ownership = _remap_ownership_from_content(
-        ownership=old_ownership,
-        old_source_content=old_source,
-        new_source_content=new_source
-    )
-
-    # Start-of-file anchor should remain None
-    assert len(new_ownership.deletions) == 1
-    assert new_ownership.deletions[0].anchor_line is None
-
-
-def test_remap_fails_when_line_removed_in_new_source():
-    """Test that remapping fails loudly when claimed line is removed in new source."""
-    old_source = b"line one\nline two\nline three\n"
-    # New source removed line two
-    new_source = b"line one\nline three\n"
-
-    # Claim line 2 in old source
-    old_ownership = BatchOwnership.from_presence_lines(["2"], [])
-
-    # Should fail because line 2 cannot be uniquely mapped
-    with pytest.raises(ValueError, match="Cannot remap presence line"):
-        _remap_ownership_from_content(
-            ownership=old_ownership,
-            old_source_content=old_source,
-            new_source_content=new_source
-        )
-
-
-def test_remap_fails_when_anchor_removed_in_new_source():
-    """Test that remapping fails loudly when deletion anchor is removed in new source."""
-    old_source = b"line one\nline two\nline three\n"
-    new_source = b"line one\nline three\n"
-
-    # Anchor deletion at line 2
-    old_ownership = BatchOwnership.from_presence_lines(
-        [],
-        [
-            AbsenceClaim(anchor_line=2, content_lines=[b"deleted\n"])
-        ]
-    )
-
-    # Should fail because anchor line 2 cannot be uniquely mapped
-    with pytest.raises(ValueError, match="Cannot remap deletion anchor"):
-        _remap_ownership_from_content(
-            ownership=old_ownership,
-            old_source_content=old_source,
-            new_source_content=new_source
-        )
-
-
-def test_remap_preserves_multiple_claimed_line_ranges():
-    """Test that remapping preserves multiple claimed line ranges correctly."""
-    old_source = b"a\nb\nc\nd\ne\nf\n"
-    # Add two lines at the beginning
-    new_source = b"x\ny\na\nb\nc\nd\ne\nf\n"
-
-    # Claim lines 1-2 and 5-6 in old source
-    old_ownership = BatchOwnership.from_presence_lines(["1-2", "5-6"], [])
-
-    new_ownership = _remap_ownership_from_content(
-        ownership=old_ownership,
-        old_source_content=old_source,
-        new_source_content=new_source
-    )
-
-    # Lines 1-2 → 3-4, lines 5-6 → 7-8
-    assert new_ownership.presence_claims[0].source_lines == ["3-4,7-8"]
-
-
-def test_remap_preserves_deletion_content():
-    """Test that deletion content is preserved during remapping."""
-    old_source = b"line one\nline two\n"
-    new_source = b"prefix\nline one\nline two\n"
-
-    absence_content = [b"deleted line 1\n", b"deleted line 2\n"]
-
-    old_ownership = BatchOwnership.from_presence_lines(
-        [],
-        [
-            AbsenceClaim(anchor_line=1, content_lines=absence_content)
-        ]
-    )
-
-    new_ownership = _remap_ownership_from_content(
-        ownership=old_ownership,
-        old_source_content=old_source,
-        new_source_content=new_source
-    )
-
-    # Content should be preserved exactly
-    assert list(new_ownership.deletions[0].content_lines) == absence_content
-
-
-def test_remap_preserves_explicit_replacement_units():
-    """Replacement metadata should follow claimed-line source remapping."""
-    old_source = b"new value\nanchor\n"
-    new_source = b"prefix\nnew value\nanchor\n"
-
-    old_ownership = BatchOwnership.from_presence_lines(
-        ["1"],
-        [
-            AbsenceClaim(anchor_line=2, content_lines=[b"old value\n"]),
-        ],
-        replacement_units=[
-            ReplacementUnit(presence_lines=["1"], deletion_indices=[0]),
-        ],
-    )
-
-    new_ownership = _remap_ownership_from_content(
-        ownership=old_ownership,
-        old_source_content=old_source,
-        new_source_content=new_source,
-    )
-
-    assert new_ownership.presence_claims[0].source_lines == ["2"]
-    assert new_ownership.deletions[0].anchor_line == 3
-    assert new_ownership.replacement_units == [
-        ReplacementUnit(presence_lines=["2"], deletion_indices=[0]),
-    ]
-
-
 def test_batch_source_lineage_translates_ranges():
     """Batch source lineage should translate selections without per-line storage."""
-    with BatchSourceLineage.from_runs(
+    with BatchSourceLineage(
         source_runs=[
             LineageRun(old_start=1, old_end=2, new_start=10),
             LineageRun(old_start=3, old_end=4, new_start=12),
@@ -374,14 +150,11 @@ def test_batch_source_lineage_translates_ranges():
             LineRanges.from_ranges([(2, 8)])
         ).ranges() == ((11, 13), (20, 20))
         assert lineage.translate_working_line(21) == 31
-        assert lineage.translate_working_selection(
-            LineRanges.from_ranges([(20, 21)])
-        ).ranges() == ((30, 31),)
 
 
 def test_batch_source_lineage_finds_unmapped_source_ranges():
     """Unmapped-source lookup should scan runs without expanding selections."""
-    with BatchSourceLineage.from_runs(
+    with BatchSourceLineage(
         source_runs=[
             LineageRun(old_start=1, old_end=20, new_start=100),
             LineageRun(old_start=30, old_end=40, new_start=200),
@@ -415,7 +188,7 @@ def test_batch_source_lineage_rejects_overlapping_appends():
 
 def test_batch_source_lineage_closes_mapped_storage():
     """Batch source lineage should close mapped run storage."""
-    lineage = BatchSourceLineage.from_runs(
+    lineage = BatchSourceLineage(
         source_runs=[
             LineageRun(old_start=1, old_end=1000, new_start=1),
             LineageRun(old_start=2000, old_end=2000, new_start=5000),
@@ -437,7 +210,7 @@ def test_source_lineage_remaps_guarded_presence_ranges():
     ownership = _PresenceLineGuardedOwnership(
         _IterationGuardedLineSelection(((1, 1000), (2000, 2001)))
     )
-    with BatchSourceLineage.from_runs(
+    with BatchSourceLineage(
         source_runs=[
             LineageRun(old_start=1, old_end=1000, new_start=10),
             LineageRun(old_start=2000, old_end=2001, new_start=5000),

--- a/tests/batch/source/test_annotation.py
+++ b/tests/batch/source/test_annotation.py
@@ -6,9 +6,9 @@ from git_stage_batch.batch.source import annotation as source_annotation_module
 from git_stage_batch.batch.source.annotation import (
     acquire_batch_source_mapping,
     annotate_with_batch_source_mapping,
-    annotate_with_batch_source_lines,
     annotate_with_batch_source_working_lines,
 )
+from git_stage_batch.batch.line_matching.match import match_lines
 from git_stage_batch.core.buffer import LineBuffer
 from git_stage_batch.core.models import HunkHeader, LineEntry, LineLevelChange
 
@@ -87,6 +87,16 @@ def _gapped_deletion_changes() -> LineLevelChange:
     )
 
 
+def _annotate_with_batch_source_lines(
+    line_changes: LineLevelChange,
+    *,
+    batch_source_lines,
+    working_lines,
+) -> LineLevelChange:
+    with match_lines(batch_source_lines, working_lines) as mapping:
+        return annotate_with_batch_source_mapping(line_changes, mapping)
+
+
 def test_annotation_keeps_consecutive_leading_deletions_before_line_one():
     """All rows in one leading deletion run share its file-start anchor."""
     annotated = annotate_with_batch_source_mapping(
@@ -99,7 +109,7 @@ def test_annotation_keeps_consecutive_leading_deletions_before_line_one():
 
 def test_mapped_annotation_keeps_leading_deletion_run_anchor():
     """Mapped annotation does not project later leading deletions after line one."""
-    annotated = annotate_with_batch_source_lines(
+    annotated = _annotate_with_batch_source_lines(
         _leading_deletion_changes(),
         batch_source_lines=[b"remaining\n"],
         working_lines=[b"remaining\n"],
@@ -121,7 +131,7 @@ def test_annotation_translates_deletion_anchor_after_synthetic_gap():
     ]
 
     first_source = annotate_with_batch_source_mapping(changes, None)
-    mapped_source = annotate_with_batch_source_lines(
+    mapped_source = _annotate_with_batch_source_lines(
         changes,
         batch_source_lines=working_lines,
         working_lines=working_lines,
@@ -171,7 +181,7 @@ def test_annotate_with_batch_source_lines_accepts_non_list_byte_sequences(
         ],
     )
 
-    annotated = annotate_with_batch_source_lines(
+    annotated = _annotate_with_batch_source_lines(
         line_changes,
         batch_source_lines=line_sequence([b"line 1\n", b"line 2\n"]),
         working_lines=line_sequence([

--- a/tests/batch/source/test_refresh.py
+++ b/tests/batch/source/test_refresh.py
@@ -218,7 +218,7 @@ def test_refresh_deletion_anchor_uses_source_lineage_without_prior_context():
         text_bytes=b"delete me",
         source_line=1,
     )
-    with BatchSourceLineage.from_runs(
+    with BatchSourceLineage(
         source_runs=[LineageRun(old_start=1, old_end=1, new_start=2)],
         working_runs=[LineageRun(old_start=2, old_end=2, new_start=3)],
     ) as lineage:

--- a/tests/batch/test_ownership_update.py
+++ b/tests/batch/test_ownership_update.py
@@ -5,15 +5,10 @@ from __future__ import annotations
 import inspect
 
 import git_stage_batch.batch.ownership_update as ownership_update_module
-import pytest
 from git_stage_batch.batch.ownership.model import BatchOwnership
-from git_stage_batch.batch.ownership.replacement_line_runs import (
-    ReplacementLineRun,
-)
 from git_stage_batch.batch.ownership_update import (
     PreparedBatchUpdate,
     acquire_batch_ownership_update_for_selection,
-    prepare_batch_ownership_update_for_selection,
 )
 from git_stage_batch.commands.selection import (
     selected_change_batch_discarding,
@@ -28,189 +23,11 @@ def test_prepared_batch_update_dataclass():
 
     update = PreparedBatchUpdate(
         batch_source_commit="def456",
-        ownership_before=None,
         ownership_after=ownership
     )
 
     assert update.batch_source_commit == "def456"
-    assert update.ownership_before is None
     assert update.ownership_after == ownership
-
-
-def test_prepare_batch_ownership_update_first_time_stale_blank_context():
-    """First-time stale selections re-annotate blank context before translation."""
-    lines = [
-        LineEntry(
-            id=None, kind=' ', old_line_number=1, new_line_number=1,
-            text_bytes=b"", text="", source_line=None
-        ),
-        LineEntry(
-            id=1, kind='+', old_line_number=None, new_line_number=2,
-            text_bytes=b"new line", text="new line", source_line=None
-        ),
-    ]
-
-    result = prepare_batch_ownership_update_for_selection(
-        batch_name="test-batch",
-        file_path="test.py",
-        current_batch_source_commit=None,
-        existing_ownership=None,
-        selected_lines=lines,
-    )
-
-    assert result.batch_source_commit is None
-    assert result.ownership_before is None
-    assert result.ownership_after.presence_claims[0].source_lines == ["2"]
-
-
-def test_prepare_batch_ownership_update_first_time_deletion_anchor():
-    """First-time deletion-only selections keep their source anchor."""
-    lines = [
-        LineEntry(
-            id=1, kind='-', old_line_number=2, new_line_number=None,
-            text_bytes=b"old line", text="old line", source_line=None
-        ),
-    ]
-
-    result = prepare_batch_ownership_update_for_selection(
-        batch_name="test-batch",
-        file_path="test.py",
-        current_batch_source_commit=None,
-        existing_ownership=None,
-        selected_lines=lines,
-        reference_source_lines=[b"anchor\n", b"old line\n"],
-        reference_target_lines=[b"anchor\n", b"old line\n"],
-    )
-
-    assert result.batch_source_commit is None
-    assert result.ownership_before is None
-    assert result.ownership_after.deletions[0].anchor_line == 1
-
-
-def test_prepare_batch_update_rejects_unprojected_deletion_reference():
-    """Baseline-relative deletion metadata must be projected before merging."""
-    lines = [
-        LineEntry(
-            id=1,
-            kind="-",
-            old_line_number=2,
-            new_line_number=None,
-            text_bytes=b"old line",
-            source_line=1,
-        ),
-    ]
-
-    with pytest.raises(
-        ValueError,
-        match="selection baseline references require",
-    ):
-        prepare_batch_ownership_update_for_selection(
-            batch_name="test-batch",
-            file_path="test.py",
-            current_batch_source_commit=None,
-            existing_ownership=None,
-            selected_lines=lines,
-        )
-
-
-def test_prepare_batch_update_rejects_unprojected_replacement_origin():
-    """Replacement references require the live-HEAD coordinate source."""
-    hunk_lines = [
-        LineEntry(
-            id=1,
-            kind="-",
-            old_line_number=1,
-            new_line_number=None,
-            text_bytes=b"old",
-            source_line=None,
-        ),
-        LineEntry(
-            id=2,
-            kind="+",
-            old_line_number=None,
-            new_line_number=1,
-            text_bytes=b"new",
-            source_line=1,
-        ),
-    ]
-
-    with pytest.raises(
-        ValueError,
-        match="replacement baseline references require live HEAD lines",
-    ):
-        prepare_batch_ownership_update_for_selection(
-            batch_name="test-batch",
-            file_path="test.py",
-            current_batch_source_commit=None,
-            existing_ownership=None,
-            selected_lines=hunk_lines,
-            hunk_lines=hunk_lines,
-            replacement_line_runs=[
-                ReplacementLineRun(
-                    old_start=1,
-                    old_end=1,
-                    new_start=1,
-                    new_end=1,
-                ),
-            ],
-            reference_source_lines=[b"old\n"],
-            reference_target_lines=[b"old\n"],
-        )
-
-
-def test_prepare_batch_ownership_update_first_time():
-    """Test prepare_batch_ownership_update_for_selection for first-time add."""
-    lines = [
-        LineEntry(
-            id=1, kind='+', old_line_number=None, new_line_number=1,
-            text_bytes=b"line1\n", text="line1\n", source_line=1
-        ),
-        LineEntry(
-            id=2, kind='+', old_line_number=None, new_line_number=2,
-            text_bytes=b"line2\n", text="line2\n", source_line=2
-        ),
-    ]
-
-    result = prepare_batch_ownership_update_for_selection(
-        batch_name="test-batch",
-        file_path="test.py",
-        current_batch_source_commit=None,
-        existing_ownership=None,
-        selected_lines=lines
-    )
-
-    assert result.batch_source_commit is None
-    assert result.ownership_before is None
-    assert result.ownership_after is not None
-    assert result.ownership_after.presence_claims[0].source_lines == ["1-2"]
-
-
-def test_prepare_batch_ownership_update_with_existing():
-    """Test prepare_batch_ownership_update_for_selection with existing ownership."""
-    existing = BatchOwnership.from_presence_lines(["1-2"], [])
-
-    lines = [
-        LineEntry(
-            id=3, kind='+', old_line_number=None, new_line_number=3,
-            text_bytes=b"line3\n", text="line3\n", source_line=3
-        ),
-        LineEntry(
-            id=4, kind='+', old_line_number=None, new_line_number=4,
-            text_bytes=b"line4\n", text="line4\n", source_line=4
-        ),
-    ]
-
-    result = prepare_batch_ownership_update_for_selection(
-        batch_name="test-batch",
-        file_path="test.py",
-        current_batch_source_commit="source123",
-        existing_ownership=existing,
-        selected_lines=lines
-    )
-
-    assert result.ownership_before == existing
-    assert result.ownership_after is not None
-    assert "1-4" in ",".join(result.ownership_after.presence_claims[0].source_lines)
 
 
 def test_acquire_batch_ownership_update_uses_metadata_acquisition(monkeypatch):
@@ -259,7 +76,6 @@ def test_acquire_batch_ownership_update_uses_metadata_acquisition(monkeypatch):
         assert entered is True
         assert exited is False
         assert result.batch_source_commit == "source123"
-        assert result.ownership_before is existing
         assert result.ownership_after.presence_line_set() == {1, 2}
 
     assert exited is True
@@ -280,5 +96,3 @@ def test_both_commands_use_same_helper_interface():
     ) in discard_source
     assert "acquire_batch_ownership_update_for_selection(" in include_source
     assert "acquire_batch_ownership_update_for_selection(" in discard_source
-    assert "prepare_batch_ownership_update_for_selection(" not in include_source
-    assert "prepare_batch_ownership_update_for_selection(" not in discard_source


### PR DESCRIPTION
Source refresh maps old line numbers to new ones and carries saved line claims
through those mappings when a file changes.

The implementation also provides alternate constructors, detached mappings,
raw-sequence remapping, and diagnostic records that no live source-refresh
path consumes.

This pull request updates tests to use the runtime mapping and ownership
operations directly, then removes the alternate interfaces. Ruff, strict
typing, type-hygiene, dead-code validation, and the full test suite pass.

Source refresh now uses only line-matching and saved-line ownership operations
with runtime callers.
