### PR TITLE
utils: Remove unused repository utility interfaces

### DIFF
--- a/src/git_stage_batch/data/undo/worktree.py
+++ b/src/git_stage_batch/data/undo/worktree.py
@@ -10,7 +10,6 @@ from pathlib import Path
 
 from ...core.buffer import LineBuffer
 from ...utils.git_command import run_git_command
-from ...utils.git_index import GitIndexEntryUpdate
 from ...utils.git_repository import (
     get_git_repository_root_path,
     is_git_repository_root_path,
@@ -273,20 +272,6 @@ def create_blob_from_worktree_path(path: Path, *, mode: str) -> str:
     if mode == "120000":
         return create_git_blob([os.readlink(os.fsencode(path))])
     return _create_blob_from_path(path)
-
-
-def index_update_from_path(
-    *,
-    index_path: str,
-    source_path: Path,
-    mode: str,
-) -> GitIndexEntryUpdate:
-    """Return an index update for a worktree path."""
-    return GitIndexEntryUpdate(
-        file_path=index_path,
-        mode=mode,
-        blob_sha=create_blob_from_worktree_path(source_path, mode=mode),
-    )
 
 
 def file_mode_for_path(path: Path) -> str:

--- a/src/git_stage_batch/exceptions.py
+++ b/src/git_stage_batch/exceptions.py
@@ -19,10 +19,6 @@ class RepositoryReadError(Exception):
     """Base class for failures while reading repository state."""
 
 
-class RepositoryObjectMissing(RepositoryReadError):
-    """Raised when a requested Git object or path is absent."""
-
-
 class RepositoryPathMissing(RepositoryReadError):
     """Raised when a requested working-tree path is absent."""
 

--- a/src/git_stage_batch/utils/file_job_workspace.py
+++ b/src/git_stage_batch/utils/file_job_workspace.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable
 from contextlib import AbstractContextManager
 from dataclasses import fields, is_dataclass
 from enum import Enum
@@ -112,50 +112,11 @@ class FileJobWorkspace(AbstractContextManager["FileJobWorkspace"]):
             spool_dir=spool_dir,
         )
 
-    def write_json(
-        self,
-        ordinal: int,
-        name: str,
-        value: Any,
-    ) -> Path:
-        """Write small JSON metadata to a unique private artifact."""
-        path = self.artifact_path(ordinal, name)
-        with path.open("x", encoding="utf-8") as output:
-            json.dump(value, output, ensure_ascii=True, separators=(",", ":"))
-            output.write("\n")
-        return path
-
     def read_json(self, path: str | Path) -> Any:
         """Read small JSON metadata from a workspace artifact."""
         artifact_path = self._require_regular_workspace_file(path)
         with artifact_path.open(encoding="utf-8") as source:
             return json.load(source)
-
-    def write_jsonl(
-        self,
-        ordinal: int,
-        name: str,
-        values: Iterable[Any],
-    ) -> Path:
-        """Stream JSON records to a unique private JSONL artifact."""
-        path = self.artifact_path(ordinal, name)
-        with path.open("x", encoding="utf-8") as output:
-            for value in values:
-                json.dump(
-                    value,
-                    output,
-                    ensure_ascii=True,
-                    separators=(",", ":"),
-                )
-                output.write("\n")
-        return path
-
-    def stream_jsonl(self, path: str | Path) -> Iterator[Any]:
-        """Yield JSON records from a workspace artifact."""
-        artifact_path = self._require_regular_workspace_file(path)
-        with artifact_path.open(encoding="utf-8") as source:
-            for line in source:
-                yield json.loads(line)
 
     def write_pickle(
         self,

--- a/src/git_stage_batch/utils/git_worktree.py
+++ b/src/git_stage_batch/utils/git_worktree.py
@@ -32,21 +32,6 @@ def git_apply_to_worktree(
     )
 
 
-def git_checkout_paths(
-    treeish: str,
-    paths: Sequence[str],
-    *,
-    check: bool = True,
-) -> subprocess.CompletedProcess[str]:
-    """Check out paths from a treeish into the index and working tree."""
-    return run_git_command(
-        ["checkout", treeish, "--", *paths],
-        check=check,
-        requires_index_lock=True,
-        literal_pathspecs=True,
-    )
-
-
 def git_checkout_index_paths(
     paths: Sequence[str],
     *,

--- a/src/git_stage_batch/utils/journal.py
+++ b/src/git_stage_batch/utils/journal.py
@@ -554,12 +554,4 @@ def purge_journal(*, all_repositories: bool = False) -> int:
     return removed
 
 
-def _reset_journal_state_for_tests() -> None:
-    """Discard process-global writers after environment changes in tests."""
-    global _WRITERS, _REPOSITORY_IDS
-    with _WRITERS_LOCK:
-        _WRITERS = {}
-        _REPOSITORY_IDS = {}
-
-
 atexit.register(flush_journal)

--- a/src/git_stage_batch/utils/repository_buffers.py
+++ b/src/git_stage_batch/utils/repository_buffers.py
@@ -23,7 +23,6 @@ from ..utils.git_object_io import (
 from ..exceptions import (
     GitOperationFailed,
     RepositoryDataInvalid,
-    RepositoryObjectMissing,
     RepositoryPathInaccessible,
     RepositoryPathMissing,
 )
@@ -211,21 +210,6 @@ def read_git_object_buffer_or_none(
         raise GitOperationFailed(
             f"Could not read Git object {revision_path!r}"
         ) from error
-
-
-def read_git_object_buffer(
-    revision_path: str,
-    *,
-    spool_dir: str | Path | None = None,
-) -> LineBuffer:
-    """Load a Git blob or raise a typed missing/failure exception."""
-    buffer = read_git_object_buffer_or_none(
-        revision_path,
-        spool_dir=spool_dir,
-    )
-    if buffer is None:
-        raise RepositoryObjectMissing(revision_path)
-    return buffer
 
 
 def read_git_object_buffer_or_empty(

--- a/tests/commands/test_journal.py
+++ b/tests/commands/test_journal.py
@@ -9,8 +9,8 @@ import pytest
 
 from git_stage_batch.commands.journal import command_journal
 from git_stage_batch.exceptions import CommandError
-from git_stage_batch.utils import journal
 from git_stage_batch.utils.journal import JOURNAL_LEVEL_ENV, JOURNAL_PATH_ENV, flush_journal, log_journal
+from tests.journal_helpers import reset_journal_state
 
 
 @pytest.fixture
@@ -19,9 +19,9 @@ def temp_git_repo(tmp_path, monkeypatch):
     subprocess.run(["git", "init"], check=True, capture_output=True)
     monkeypatch.setenv(JOURNAL_PATH_ENV, str(tmp_path / "state" / "journal.jsonl"))
     monkeypatch.setenv(JOURNAL_LEVEL_ENV, "metadata-only")
-    journal._reset_journal_state_for_tests()
+    reset_journal_state()
     yield tmp_path
-    journal._reset_journal_state_for_tests()
+    reset_journal_state()
 
 
 def test_journal_command_reports_json_summary(temp_git_repo, capsys):

--- a/tests/journal_helpers.py
+++ b/tests/journal_helpers.py
@@ -1,0 +1,12 @@
+"""Test-only controls for process-global journal state."""
+
+from __future__ import annotations
+
+from git_stage_batch.utils import journal
+
+
+def reset_journal_state() -> None:
+    """Discard cached writers after a test changes journal environment."""
+    with journal._WRITERS_LOCK:
+        journal._WRITERS = {}
+        journal._REPOSITORY_IDS = {}

--- a/tests/utils/test_file_job_workspace.py
+++ b/tests/utils/test_file_job_workspace.py
@@ -156,7 +156,8 @@ def test_workspace_metadata_reads_reject_external_symlink_alias(tmp_path):
 def test_workspace_metadata_reads_reject_internal_symlink_alias(tmp_path):
     """Even in-workspace aliases should not substitute worker output."""
     with FileJobWorkspace(parent_directory=tmp_path) as workspace:
-        artifact = workspace.write_json(0, "input.json", {"content": True})
+        artifact = workspace.artifact_path(0, "input.json")
+        artifact.write_text('{"content":true}\n', encoding="utf-8")
         output = workspace.output_path(0, "result.json")
         output.symlink_to(artifact)
 
@@ -164,51 +165,18 @@ def test_workspace_metadata_reads_reject_internal_symlink_alias(tmp_path):
             workspace.read_json(output)
 
 
-def test_workspace_supports_private_metadata_formats(tmp_path):
-    """JSON, JSONL, and pickle metadata should round trip inside the workspace."""
+def test_workspace_supports_private_pickle_metadata(tmp_path):
+    """Pickle metadata should round trip inside the workspace."""
     with FileJobWorkspace(parent_directory=tmp_path) as workspace:
-        json_path = workspace.write_json(1, "metadata.json", {"name": "one"})
-        jsonl_path = workspace.write_jsonl(
-            1,
-            "records.jsonl",
-            ({"ordinal": ordinal} for ordinal in range(3)),
-        )
         pickle_path = workspace.write_pickle(
             1,
             "metadata.pickle",
             {"paths": (Path("one"), Path("two"))},
         )
 
-        assert workspace.read_json(json_path) == {"name": "one"}
-        assert list(workspace.stream_jsonl(jsonl_path)) == [
-            {"ordinal": 0},
-            {"ordinal": 1},
-            {"ordinal": 2},
-        ]
         assert workspace.read_pickle(pickle_path) == {
             "paths": (Path("one"), Path("two"))
         }
-
-
-def test_workspace_json_formats_preserve_surrogateescaped_paths(tmp_path):
-    """Private JSON metadata should support arbitrary Git path bytes."""
-    file_path = "invalid-\udcff.txt"
-    with FileJobWorkspace(parent_directory=tmp_path) as workspace:
-        json_path = workspace.write_json(
-            1,
-            "metadata.json",
-            {"file_path": file_path},
-        )
-        jsonl_path = workspace.write_jsonl(
-            1,
-            "records.jsonl",
-            ({"file_path": file_path},),
-        )
-
-        assert workspace.read_json(json_path) == {"file_path": file_path}
-        assert list(workspace.stream_jsonl(jsonl_path)) == [
-            {"file_path": file_path}
-        ]
 
 
 def test_workspace_pickle_rejects_content_and_resource_graphs(tmp_path):
@@ -365,7 +333,10 @@ def test_workspace_cleanup_runs_after_keyboard_interrupt(tmp_path):
     with pytest.raises(KeyboardInterrupt):
         with FileJobWorkspace(parent_directory=tmp_path) as workspace:
             root = workspace.root
-            workspace.write_json(0, "metadata.json", {"ready": True})
+            workspace.artifact_path(0, "metadata.json").write_text(
+                '{"ready":true}\n',
+                encoding="utf-8",
+            )
             raise KeyboardInterrupt
 
     assert not root.exists()

--- a/tests/utils/test_journal.py
+++ b/tests/utils/test_journal.py
@@ -27,6 +27,7 @@ from git_stage_batch.utils.journal import (
     purge_journal,
     summarize_journal,
 )
+from tests.journal_helpers import reset_journal_state
 
 
 @pytest.fixture
@@ -40,9 +41,9 @@ def temp_git_repo(tmp_path, monkeypatch):
     subprocess.run(["git", "add", "README.md"], check=True)
     subprocess.run(["git", "commit", "-m", "initial"], check=True, capture_output=True)
     monkeypatch.setenv(JOURNAL_PATH_ENV, str(tmp_path / "private" / "journal.jsonl"))
-    journal._reset_journal_state_for_tests()
+    reset_journal_state()
     yield tmp_path
-    journal._reset_journal_state_for_tests()
+    reset_journal_state()
 
 
 def _entries(path: Path) -> list[dict]:


### PR DESCRIPTION
Repository and workspace utilities provide object reads, managed worktrees,
secure artifacts, and diagnostic journal recording for commands and workers.

Several neighboring wrappers and reset controls have no production caller.
Their only consumers are fixtures or tests for transport formats that runtime
code does not use.

This pull request moves journal reset behavior into the test tree and removes
the unused repository and workspace interfaces. Ruff, strict typing,
type-hygiene, dead-code validation, and the full test suite pass.

Repository and workspace utilities now expose only operations used by
production code.

CI note: the Python 3.10 type-hygiene job found a stale allowlist entry for the metadata parser removed in this series. The logically connected cleanup landed in #366; every other check passed.