### PR TITLE
cli: Remove the unused command state-change policy

### DIFF
--- a/src/git_stage_batch/cli/asset_subcommands.py
+++ b/src/git_stage_batch/cli/asset_subcommands.py
@@ -10,7 +10,6 @@ from .command_policy import (
     PagerPolicy,
     RepositoryPolicy,
     SessionOwnershipPolicy,
-    StateChangePolicy,
 )
 from .subcommand_parser import Subparsers, add_subcommand_parser
 
@@ -25,7 +24,6 @@ def add_install_assets_subcommand(subparsers: Subparsers) -> None:
             locking=LockingPolicy.SESSION,
             repository=RepositoryPolicy.REQUIRED,
             pager=PagerPolicy.NEVER,
-            state_changes=StateChangePolicy.DURABLE,
         ),
         help=_("Install bundled assistant assets into the repository"),
     )

--- a/src/git_stage_batch/cli/batch_subcommands.py
+++ b/src/git_stage_batch/cli/batch_subcommands.py
@@ -16,7 +16,6 @@ from .command_policy import (
     PagerPolicy,
     RepositoryPolicy,
     SessionOwnershipPolicy,
-    StateChangePolicy,
 )
 from .file_arguments import add_file_argument
 from .reset_dispatch import dispatch_reset_command
@@ -33,7 +32,6 @@ def add_new_subcommand(subparsers: Subparsers) -> None:
             locking=LockingPolicy.SESSION,
             repository=RepositoryPolicy.REQUIRED,
             pager=PagerPolicy.NEVER,
-            state_changes=StateChangePolicy.DURABLE,
         ),
         help=_("Create a new batch"),
     )
@@ -62,7 +60,6 @@ def add_list_subcommand(subparsers: Subparsers) -> None:
             locking=LockingPolicy.SESSION,
             repository=RepositoryPolicy.REQUIRED,
             pager=PagerPolicy.ELIGIBLE,
-            state_changes=StateChangePolicy.NONE,
         ),
         help=_("List all batches"),
     )
@@ -79,7 +76,6 @@ def add_validate_subcommand(subparsers: Subparsers) -> None:
             locking=LockingPolicy.SESSION,
             repository=RepositoryPolicy.REQUIRED,
             pager=PagerPolicy.NEVER,
-            state_changes=StateChangePolicy.NONE,
         ),
         help=_("Validate persisted batch metadata"),
     )
@@ -103,7 +99,6 @@ def add_drop_subcommand(subparsers: Subparsers) -> None:
             locking=LockingPolicy.SESSION,
             repository=RepositoryPolicy.REQUIRED,
             pager=PagerPolicy.NEVER,
-            state_changes=StateChangePolicy.DURABLE,
         ),
         help=_("Delete a batch"),
     )
@@ -124,7 +119,6 @@ def add_annotate_subcommand(subparsers: Subparsers) -> None:
             locking=LockingPolicy.SESSION,
             repository=RepositoryPolicy.REQUIRED,
             pager=PagerPolicy.NEVER,
-            state_changes=StateChangePolicy.DURABLE,
         ),
         help=_("Add or update batch description"),
     )
@@ -151,7 +145,6 @@ def add_sift_subcommand(subparsers: Subparsers) -> None:
             locking=LockingPolicy.SESSION,
             repository=RepositoryPolicy.REQUIRED,
             pager=PagerPolicy.NEVER,
-            state_changes=StateChangePolicy.DURABLE,
         ),
         help=_("Remove already-present portions from a batch"),
     )
@@ -184,7 +177,6 @@ def add_apply_subcommand(subparsers: Subparsers) -> None:
             locking=LockingPolicy.SESSION,
             repository=RepositoryPolicy.REQUIRED,
             pager=PagerPolicy.NEVER,
-            state_changes=StateChangePolicy.DURABLE,
         ),
         help=_("Apply batch changes to working tree"),
     )
@@ -223,7 +215,6 @@ def add_reset_subcommand(subparsers: Subparsers) -> None:
             locking=LockingPolicy.SESSION,
             repository=RepositoryPolicy.REQUIRED,
             pager=PagerPolicy.NEVER,
-            state_changes=StateChangePolicy.DURABLE,
         ),
         help=_("Remove claims from batch"),
     )

--- a/src/git_stage_batch/cli/command_policy.py
+++ b/src/git_stage_batch/cli/command_policy.py
@@ -37,14 +37,6 @@ class PagerPolicy(Enum):
     NEVER = "never"
 
 
-class StateChangePolicy(Enum):
-    """The most persistent application or repository state a command may change."""
-
-    NONE = "none"
-    SCRATCH = "scratch"
-    DURABLE = "durable"
-
-
 @dataclass(frozen=True)
 class CommandPolicy:
     """Complete runtime contract attached to one registered CLI command."""
@@ -53,7 +45,6 @@ class CommandPolicy:
     locking: LockingPolicy
     repository: RepositoryPolicy
     pager: PagerPolicy
-    state_changes: StateChangePolicy
 
 
 CONSERVATIVE_COMMAND_POLICY = CommandPolicy(
@@ -61,7 +52,6 @@ CONSERVATIVE_COMMAND_POLICY = CommandPolicy(
     locking=LockingPolicy.SESSION,
     repository=RepositoryPolicy.REQUIRED,
     pager=PagerPolicy.NEVER,
-    state_changes=StateChangePolicy.DURABLE,
 )
 
 IMPLICIT_SHOW_POLICY = CommandPolicy(
@@ -69,7 +59,6 @@ IMPLICIT_SHOW_POLICY = CommandPolicy(
     locking=LockingPolicy.SESSION,
     repository=RepositoryPolicy.REQUIRED,
     pager=PagerPolicy.ELIGIBLE,
-    state_changes=StateChangePolicy.SCRATCH,
 )
 
 INTERACTIVE_POLICY = CommandPolicy(
@@ -77,7 +66,6 @@ INTERACTIVE_POLICY = CommandPolicy(
     locking=LockingPolicy.NONE,
     repository=RepositoryPolicy.REQUIRED,
     pager=PagerPolicy.NEVER,
-    state_changes=StateChangePolicy.DURABLE,
 )
 
 

--- a/src/git_stage_batch/cli/completion.py
+++ b/src/git_stage_batch/cli/completion.py
@@ -15,7 +15,6 @@ from .command_policy import (
     PagerPolicy,
     RepositoryPolicy,
     SessionOwnershipPolicy,
-    StateChangePolicy,
 )
 from .subcommand_parser import Subparsers, add_subcommand_parser
 
@@ -132,7 +131,6 @@ def add_completion_subcommand(subparsers: Subparsers) -> None:
             locking=LockingPolicy.SESSION,
             repository=RepositoryPolicy.REQUIRED,
             pager=PagerPolicy.ELIGIBLE,
-            state_changes=StateChangePolicy.NONE,
         ),
         help_topic="stage-batch",
         help=argparse.SUPPRESS,

--- a/src/git_stage_batch/cli/file_blocking_subcommands.py
+++ b/src/git_stage_batch/cli/file_blocking_subcommands.py
@@ -11,7 +11,6 @@ from .command_policy import (
     PagerPolicy,
     RepositoryPolicy,
     SessionOwnershipPolicy,
-    StateChangePolicy,
 )
 from .subcommand_parser import Subparsers, add_subcommand_parser
 
@@ -26,7 +25,6 @@ def add_block_file_subcommand(subparsers: Subparsers) -> None:
             locking=LockingPolicy.SESSION,
             repository=RepositoryPolicy.REQUIRED,
             pager=PagerPolicy.ELIGIBLE,
-            state_changes=StateChangePolicy.DURABLE,
         ),
         aliases=["bf"],
         help=_("Permanently exclude a file (adds to .gitignore)"),
@@ -61,7 +59,6 @@ def add_unblock_file_subcommand(subparsers: Subparsers) -> None:
             locking=LockingPolicy.SESSION,
             repository=RepositoryPolicy.REQUIRED,
             pager=PagerPolicy.ELIGIBLE,
-            state_changes=StateChangePolicy.DURABLE,
         ),
         aliases=["ubf"],
         help=_("Remove a file from the blocked list"),

--- a/src/git_stage_batch/cli/fixup_subcommands.py
+++ b/src/git_stage_batch/cli/fixup_subcommands.py
@@ -15,7 +15,6 @@ from .command_policy import (
     PagerPolicy,
     RepositoryPolicy,
     SessionOwnershipPolicy,
-    StateChangePolicy,
 )
 from .subcommand_parser import Subparsers, add_subcommand_parser
 
@@ -49,7 +48,6 @@ def add_suggest_fixup_subcommand(subparsers: Subparsers) -> None:
             locking=LockingPolicy.SESSION,
             repository=RepositoryPolicy.REQUIRED,
             pager=PagerPolicy.NEVER,
-            state_changes=StateChangePolicy.SCRATCH,
         ),
         aliases=["x"],
         help=_("Suggest which commit the selected hunk should be fixed up to"),

--- a/src/git_stage_batch/cli/journal_subcommands.py
+++ b/src/git_stage_batch/cli/journal_subcommands.py
@@ -10,7 +10,6 @@ from .command_policy import (
     PagerPolicy,
     RepositoryPolicy,
     SessionOwnershipPolicy,
-    StateChangePolicy,
 )
 from .subcommand_parser import Subparsers, add_subcommand_parser
 
@@ -25,7 +24,6 @@ def add_journal_subcommand(subparsers: Subparsers) -> None:
             locking=LockingPolicy.SESSION,
             repository=RepositoryPolicy.REQUIRED,
             pager=PagerPolicy.NEVER,
-            state_changes=StateChangePolicy.DURABLE,
         ),
         help=_("Inspect or purge diagnostic journal data"),
     )

--- a/src/git_stage_batch/cli/selection_subcommands.py
+++ b/src/git_stage_batch/cli/selection_subcommands.py
@@ -12,7 +12,6 @@ from .command_policy import (
     PagerPolicy,
     RepositoryPolicy,
     SessionOwnershipPolicy,
-    StateChangePolicy,
 )
 from .discard_dispatch import dispatch_discard_command
 from .file_arguments import add_file_argument
@@ -32,7 +31,6 @@ def add_show_subcommand(subparsers: Subparsers) -> None:
             locking=LockingPolicy.SESSION,
             repository=RepositoryPolicy.REQUIRED,
             pager=PagerPolicy.ELIGIBLE,
-            state_changes=StateChangePolicy.SCRATCH,
         ),
         help=_("Show the selected hunk"),
     )
@@ -110,7 +108,6 @@ def add_include_subcommand(subparsers: Subparsers) -> None:
             locking=LockingPolicy.SESSION,
             repository=RepositoryPolicy.REQUIRED,
             pager=PagerPolicy.ELIGIBLE,
-            state_changes=StateChangePolicy.DURABLE,
         ),
         aliases=["i"],
         help=_("Stage the selected hunk"),
@@ -190,7 +187,6 @@ def add_skip_subcommand(subparsers: Subparsers) -> None:
             locking=LockingPolicy.SESSION,
             repository=RepositoryPolicy.REQUIRED,
             pager=PagerPolicy.ELIGIBLE,
-            state_changes=StateChangePolicy.SCRATCH,
         ),
         aliases=["s"],
         help=_("Skip the selected hunk without staging"),
@@ -224,7 +220,6 @@ def add_discard_subcommand(subparsers: Subparsers) -> None:
             locking=LockingPolicy.SESSION,
             repository=RepositoryPolicy.REQUIRED,
             pager=PagerPolicy.ELIGIBLE,
-            state_changes=StateChangePolicy.DURABLE,
         ),
         aliases=["d"],
         help=_("Remove the selected hunk from working tree"),

--- a/src/git_stage_batch/cli/session_subcommands.py
+++ b/src/git_stage_batch/cli/session_subcommands.py
@@ -19,7 +19,6 @@ from .command_policy import (
     PagerPolicy,
     RepositoryPolicy,
     SessionOwnershipPolicy,
-    StateChangePolicy,
 )
 from .subcommand_parser import Subparsers, add_subcommand_parser
 
@@ -34,7 +33,6 @@ def add_check_unstaged_subcommand(subparsers: Subparsers) -> None:
             locking=LockingPolicy.SESSION,
             repository=RepositoryPolicy.REQUIRED,
             pager=PagerPolicy.NEVER,
-            state_changes=StateChangePolicy.NONE,
         ),
         help=_("Check whether the index fits an unstaged-only workflow"),
     )
@@ -51,7 +49,6 @@ def add_start_subcommand(subparsers: Subparsers) -> None:
             locking=LockingPolicy.SESSION,
             repository=RepositoryPolicy.REQUIRED,
             pager=PagerPolicy.ELIGIBLE,
-            state_changes=StateChangePolicy.DURABLE,
         ),
         help=_("Start a new batch staging session"),
     )
@@ -82,7 +79,6 @@ def add_again_subcommand(subparsers: Subparsers) -> None:
             locking=LockingPolicy.SESSION,
             repository=RepositoryPolicy.REQUIRED,
             pager=PagerPolicy.ELIGIBLE,
-            state_changes=StateChangePolicy.DURABLE,
         ),
         aliases=["a"],
         help=_("Clear state and start a fresh pass"),
@@ -103,7 +99,6 @@ def add_stop_subcommand(subparsers: Subparsers) -> None:
             locking=LockingPolicy.SESSION,
             repository=RepositoryPolicy.REQUIRED,
             pager=PagerPolicy.NEVER,
-            state_changes=StateChangePolicy.DURABLE,
         ),
         help=_("Stop the selected session and clear state"),
     )
@@ -120,7 +115,6 @@ def add_undo_subcommand(subparsers: Subparsers) -> None:
             locking=LockingPolicy.SESSION,
             repository=RepositoryPolicy.REQUIRED,
             pager=PagerPolicy.NEVER,
-            state_changes=StateChangePolicy.DURABLE,
         ),
         aliases=["u", "back"],
         help=_("Undo the most recent undoable session operation"),
@@ -143,7 +137,6 @@ def add_redo_subcommand(subparsers: Subparsers) -> None:
             locking=LockingPolicy.SESSION,
             repository=RepositoryPolicy.REQUIRED,
             pager=PagerPolicy.NEVER,
-            state_changes=StateChangePolicy.DURABLE,
         ),
         aliases=["forward"],
         help=_("Redo the most recently undone session operation"),
@@ -166,7 +159,6 @@ def add_abort_subcommand(subparsers: Subparsers) -> None:
             locking=LockingPolicy.SESSION,
             repository=RepositoryPolicy.REQUIRED,
             pager=PagerPolicy.NEVER,
-            state_changes=StateChangePolicy.DURABLE,
         ),
         help=_("Restore repository to pre-session state"),
     )
@@ -183,7 +175,6 @@ def add_status_subcommand(subparsers: Subparsers) -> None:
             locking=LockingPolicy.SESSION_EXCEPT_PROMPT,
             repository=RepositoryPolicy.OPTIONAL_FOR_PROMPT,
             pager=PagerPolicy.ELIGIBLE,
-            state_changes=StateChangePolicy.NONE,
         ),
         aliases=["st"],
         help=_("Show selected session status"),

--- a/tests/architecture/test_command_policies.py
+++ b/tests/architecture/test_command_policies.py
@@ -10,7 +10,6 @@ from git_stage_batch.cli.command_policy import (
     PagerPolicy,
     RepositoryPolicy,
     SessionOwnershipPolicy,
-    StateChangePolicy,
 )
 from git_stage_batch.cli.root_parser import build_root_parser
 
@@ -45,11 +44,10 @@ def test_every_registered_command_declares_complete_policy():
         assert isinstance(policy.locking, LockingPolicy), names
         assert isinstance(policy.repository, RepositoryPolicy), names
         assert isinstance(policy.pager, PagerPolicy), names
-        assert isinstance(policy.state_changes, StateChangePolicy), names
 
 
-def test_show_declares_scratch_changes_and_foreign_owner_access():
-    """Show may cache selections without claiming literal read-only behavior."""
+def test_show_declares_foreign_owner_access():
+    """Show may inspect another worktree's active session."""
     parser_by_name = {
         name: parser
         for names, parser in _registered_subcommand_parsers()
@@ -58,19 +56,4 @@ def test_show_declares_scratch_changes_and_foreign_owner_access():
 
     policy = parser_by_name["show"]._defaults["command_policy"]
 
-    assert policy.state_changes is StateChangePolicy.SCRATCH
-    assert policy.session_ownership is SessionOwnershipPolicy.ALLOW_FOREIGN
-
-
-def test_state_changes_do_not_imply_session_ownership_policy():
-    """Journal purge is durable but independent of active session ownership."""
-    parser_by_name = {
-        name: parser
-        for names, parser in _registered_subcommand_parsers()
-        for name in names
-    }
-
-    policy = parser_by_name["journal"]._defaults["command_policy"]
-
-    assert policy.state_changes is StateChangePolicy.DURABLE
     assert policy.session_ownership is SessionOwnershipPolicy.ALLOW_FOREIGN


### PR DESCRIPTION
Command registrations declare repository requirements, session ownership, and
pager behavior that dispatch enforces.

They also carry a state-change classification that dispatch never reads. The
field can drift from command behavior without changing locking, validation, or
execution.

This pull request stops requiring the unenforced classification in
architecture tests and removes it from every command registration. Ruff,
strict typing, type-hygiene, dead-code validation, and the full test suite
pass.

Command policy records now contain only fields that dispatch enforces.

CI note: the Python 3.10 type-hygiene job found stale allowlist entries for definitions removed earlier in this series. The logically connected cleanup landed in #366; every other check passed.