### PR TITLE
project: Detect unreachable production definitions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,11 @@ jobs:
         run: uv run pytest -n auto
 
       - name: Run Ruff
-        run: uv run ruff check src tests
+        run: uv run ruff check src tests scripts
+
+      - name: Check for dead code
+        if: matrix.python-version == '3.10'
+        run: uv run python scripts/check_dead_code.py
 
       - name: Check type hygiene
         if: matrix.python-version == '3.10'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,8 @@ uv sync
 uv run pytest -n auto
 
 # Run lint and strict type checks
-uv run ruff check src tests
+uv run ruff check src tests scripts
+uv run python scripts/check_dead_code.py
 uv run python scripts/check_type_hygiene.py
 uv run mypy
 ```
@@ -45,6 +46,10 @@ other structured containers concrete rather than falling back to bare
 `dict`, `list`, or `tuple` annotations. The type-hygiene check also prevents
 explicit `Any` from spreading beyond the small set of reviewed serialization,
 reflection, and third-party API boundaries.
+
+The dead-code check analyzes the production package without treating tests as
+callers. It rejects stale exceptions when an indirectly used schema field or
+protocol method no longer needs one.
 
 ## Find the Code for a Change
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
     "ninja>=1.11.0",
     "pytest-xdist>=3.8.0",
     "ruff==0.12.2",
+    "vulture==2.16",
 ]
 docs = [
     "mkdocs-material>=9.7.4",

--- a/scripts/check_dead_code.py
+++ b/scripts/check_dead_code.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+"""Reject unreviewed Vulture findings and stale finding exceptions."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+import sys
+
+from vulture import Vulture
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+SCAN_PATHS = (
+    REPOSITORY_ROOT / "src" / "git_stage_batch",
+)
+MINIMUM_CONFIDENCE = 60
+
+
+@dataclass(frozen=True)
+class FindingIdentity:
+    """Stable identity for one kind of Vulture finding."""
+
+    path: str
+    kind: str
+    name: str
+
+
+@dataclass(frozen=True)
+class AllowedFinding:
+    """One reviewed indirect use that Vulture cannot follow."""
+
+    identity: FindingIdentity
+    expected_count: int
+    reason: str
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One Vulture finding with its source location and diagnostic."""
+
+    identity: FindingIdentity
+    line: int
+    message: str
+    confidence: int
+
+
+def _allowed(
+    path: str,
+    kind: str,
+    name: str,
+    reason: str,
+    *,
+    expected_count: int = 1,
+) -> AllowedFinding:
+    return AllowedFinding(
+        FindingIdentity(path, kind, name),
+        expected_count,
+        reason,
+    )
+
+
+# Vulture is intentionally conservative and cannot follow some uses that do
+# not spell an attribute or function name in ordinary Python code. Keep each
+# exception tied to one path, finding kind, and name. The expected occurrence
+# count makes a second, genuinely unused definition fail instead of inheriting
+# an existing exception.
+ALLOWED_FINDINGS = (
+    # Persisted and dynamically indexed mapping keys.
+    _allowed(
+        "src/git_stage_batch/batch/operation_candidate_state.py",
+        "variable",
+        "algorithm_version",
+        "TypedDict key read from decoded JSON by string name.",
+    ),
+    _allowed(
+        "src/git_stage_batch/batch/ownership/metadata_types.py",
+        "variable",
+        "original_unit",
+        "TypedDict key read from persisted metadata by string name.",
+    ),
+    _allowed(
+        "src/git_stage_batch/batch/ownership/units.py",
+        "variable",
+        "next_index",
+        "TypedDict key read by string name.",
+        expected_count=2,
+    ),
+    _allowed(
+        "src/git_stage_batch/batch/state/metadata_types.py",
+        "variable",
+        "added_lines",
+        "TypedDict key read from persisted metadata by string name.",
+    ),
+    _allowed(
+        "src/git_stage_batch/batch/state/metadata_types.py",
+        "variable",
+        "deleted_lines",
+        "TypedDict key read from persisted metadata by string name.",
+    ),
+    _allowed(
+        "src/git_stage_batch/commands/batch_source/text_plan_jobs.py",
+        "variable",
+        "replacement_display_text",
+        "TypedDict key read from a worker manifest by string name.",
+    ),
+    _allowed(
+        "src/git_stage_batch/commands/batch_source/text_plan_jobs.py",
+        "variable",
+        "replacement_exact",
+        "TypedDict key read from a worker manifest by string name.",
+    ),
+    _allowed(
+        "src/git_stage_batch/commands/validate.py",
+        "variable",
+        "migration_required",
+        "TypedDict key read from a validation report by string name.",
+    ),
+    _allowed(
+        "src/git_stage_batch/commands/validate.py",
+        "variable",
+        "residue",
+        "TypedDict key read from a validation report by string name.",
+    ),
+    _allowed(
+        "src/git_stage_batch/data/line_state.py",
+        "variable",
+        "old_lineno",
+        "TypedDict key read from persisted line state by string name.",
+    ),
+    _allowed(
+        "src/git_stage_batch/data/line_state.py",
+        "variable",
+        "new_lineno",
+        "TypedDict key read from persisted line state by string name.",
+    ),
+    _allowed(
+        "src/git_stage_batch/data/line_state.py",
+        "variable",
+        "text_bytes_b64",
+        "TypedDict key read from persisted line state by string name.",
+    ),
+    _allowed(
+        "src/git_stage_batch/data/live_change_jobs.py",
+        "variable",
+        "patch_artifact_path",
+        "TypedDict key read from a worker manifest by string name.",
+    ),
+    _allowed(
+        "src/git_stage_batch/data/recovery_types.py",
+        "variable",
+        "head",
+        "TypedDict key validated through a field-name collection.",
+    ),
+    _allowed(
+        "src/git_stage_batch/data/recovery_types.py",
+        "variable",
+        "storage_mode",
+        "TypedDict key read from persisted recovery state by string name.",
+    ),
+    _allowed(
+        "src/git_stage_batch/data/recovery_types.py",
+        "variable",
+        "tracked_session_paths",
+        "TypedDict key read from persisted recovery state by string name.",
+    ),
+    _allowed(
+        "src/git_stage_batch/data/recovery_types.py",
+        "variable",
+        "tracked_batches_paths",
+        "TypedDict key read from persisted recovery state by string name.",
+    ),
+    _allowed(
+        "src/git_stage_batch/data/recovery_types.py",
+        "variable",
+        "session_files",
+        "TypedDict key read from persisted recovery state by string name.",
+    ),
+    _allowed(
+        "src/git_stage_batch/data/recovery_types.py",
+        "variable",
+        "batches_files",
+        "TypedDict key read from persisted recovery state by string name.",
+    ),
+    _allowed(
+        "src/git_stage_batch/data/recovery_types.py",
+        "variable",
+        "repository_files",
+        "TypedDict key read from persisted recovery state by string name.",
+    ),
+    _allowed(
+        "src/git_stage_batch/data/status_types.py",
+        "variable",
+        "active",
+        "TypedDict key read from a status response by string name.",
+    ),
+    _allowed(
+        "src/git_stage_batch/data/status_types.py",
+        "variable",
+        "in_progress",
+        "TypedDict key read from a status response by string name.",
+    ),
+    _allowed(
+        "src/git_stage_batch/data/status_types.py",
+        "variable",
+        "skipped",
+        "TypedDict key read from a status response by string name.",
+    ),
+    _allowed(
+        "src/git_stage_batch/data/status_types.py",
+        "variable",
+        "discarded",
+        "TypedDict key read from a status response by string name.",
+    ),
+    _allowed(
+        "src/git_stage_batch/output/status_prompt.py",
+        "variable",
+        "skipped",
+        "TypedDict key consumed through str.format_map.",
+    ),
+    _allowed(
+        "src/git_stage_batch/output/status_prompt.py",
+        "variable",
+        "active",
+        "TypedDict key consumed through str.format_map.",
+    ),
+    _allowed(
+        "src/git_stage_batch/output/status_prompt.py",
+        "variable",
+        "discarded",
+        "TypedDict key consumed through str.format_map.",
+    ),
+    _allowed(
+        "src/git_stage_batch/output/status_prompt.py",
+        "variable",
+        "file_review_batch",
+        "TypedDict key consumed through str.format_map.",
+    ),
+    _allowed(
+        "src/git_stage_batch/output/status_prompt.py",
+        "variable",
+        "file_review_fresh",
+        "TypedDict key consumed through str.format_map.",
+    ),
+    _allowed(
+        "src/git_stage_batch/output/status_prompt.py",
+        "variable",
+        "file_review_source",
+        "TypedDict key consumed through str.format_map.",
+    ),
+    _allowed(
+        "src/git_stage_batch/output/status_prompt.py",
+        "variable",
+        "in_progress",
+        "TypedDict key consumed through str.format_map.",
+    ),
+    _allowed(
+        "src/git_stage_batch/utils/journal.py",
+        "variable",
+        "oldest_timestamp",
+        "TypedDict key returned through the journal's public summary mapping.",
+    ),
+    _allowed(
+        "src/git_stage_batch/utils/journal.py",
+        "variable",
+        "newest_timestamp",
+        "TypedDict key returned through the journal's public summary mapping.",
+    ),
+    # Dataclass fields used through whole-record behavior or serialization.
+    _allowed(
+        "src/git_stage_batch/batch/ownership/merging.py",
+        "variable",
+        "content_digest",
+        "Field contributes to dataclass equality and hashing used by a dictionary.",
+    ),
+    _allowed(
+        "src/git_stage_batch/data/file_review/records.py",
+        "variable",
+        "change_index",
+        "Field is persisted through dataclasses.asdict.",
+    ),
+    _allowed(
+        "src/git_stage_batch/data/live_change_jobs.py",
+        "variable",
+        "mtime_ns",
+        "Field contributes to whole-dataclass equality.",
+    ),
+    _allowed(
+        "src/git_stage_batch/data/live_change_jobs.py",
+        "variable",
+        "ctime_ns",
+        "Field contributes to whole-dataclass equality.",
+    ),
+    _allowed(
+        "src/git_stage_batch/data/live_change_jobs.py",
+        "variable",
+        "device",
+        "Field contributes to whole-dataclass equality.",
+    ),
+    _allowed(
+        "src/git_stage_batch/data/live_change_jobs.py",
+        "variable",
+        "inode",
+        "Field contributes to whole-dataclass equality.",
+    ),
+    # Protocol surface used indirectly by the standard library.
+    _allowed(
+        "src/git_stage_batch/cli/pager.py",
+        "method",
+        "writable",
+        "Method implements the TextIO-compatible stream protocol.",
+    ),
+)
+
+
+def _allowed_findings_by_identity() -> dict[FindingIdentity, AllowedFinding]:
+    allowed = {finding.identity: finding for finding in ALLOWED_FINDINGS}
+    if len(allowed) != len(ALLOWED_FINDINGS):
+        raise RuntimeError("dead-code allowlist contains duplicate identities")
+    return allowed
+
+
+def _relative_path(filename: str) -> str:
+    path = Path(filename)
+    if not path.is_absolute():
+        path = REPOSITORY_ROOT / path
+    return path.resolve().relative_to(REPOSITORY_ROOT).as_posix()
+
+
+def find_unused_code() -> list[Finding]:
+    """Return Vulture findings from production code alone."""
+    checker = Vulture()
+    checker.scavenge([str(path) for path in SCAN_PATHS])
+    return [
+        Finding(
+            identity=FindingIdentity(
+                path=_relative_path(item.filename),
+                kind=item.typ,
+                name=item.name,
+            ),
+            line=item.first_lineno,
+            message=item.message,
+            confidence=item.confidence,
+        )
+        for item in checker.get_unused_code(
+            min_confidence=MINIMUM_CONFIDENCE,
+            sort_by_size=True,
+        )
+    ]
+
+
+def main() -> int:
+    findings = find_unused_code()
+    allowed = _allowed_findings_by_identity()
+    counts = Counter(finding.identity for finding in findings)
+    unexpected = [
+        finding for finding in findings if finding.identity not in allowed
+    ]
+    count_mismatches = [
+        (finding, counts.get(identity, 0))
+        for identity, finding in allowed.items()
+        if counts.get(identity, 0) != finding.expected_count
+    ]
+
+    if not unexpected and not count_mismatches:
+        print(
+            "Dead-code check passed: "
+            f"{len(findings)} indirect uses have reviewed exceptions."
+        )
+        return 0
+
+    for finding in unexpected:
+        print(
+            f"{finding.identity.path}:{finding.line}: {finding.message} "
+            f"({finding.confidence}% confidence)",
+            file=sys.stderr,
+        )
+    for allowed_finding, actual_count in count_mismatches:
+        identity = allowed_finding.identity
+        print(
+            f"{identity.path}: stale or changed dead-code exception for "
+            f"{identity.kind} {identity.name!r}: expected "
+            f"{allowed_finding.expected_count}, found {actual_count}; "
+            f"{allowed_finding.reason}",
+            file=sys.stderr,
+        )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_type_hygiene.py
+++ b/scripts/check_type_hygiene.py
@@ -58,8 +58,6 @@ ALLOWED_EXPLICIT_ANY = frozenset({
     "src/git_stage_batch/batch/state/metadata_schema.py::"
     "_optional_string::param:data",
     "src/git_stage_batch/batch/state/metadata_schema.py::"
-    "_required_object_id::param:data",
-    "src/git_stage_batch/batch/state/metadata_schema.py::"
     "_optional_object_id::param:data",
     "src/git_stage_batch/batch/state/metadata_schema.py::"
     "_validate_object_id::param:value",
@@ -80,13 +78,7 @@ ALLOWED_EXPLICIT_ANY = frozenset({
     "src/git_stage_batch/utils/file_job_transport.py::"
     "_assert_transport_dataclass_shape::cast",
     "src/git_stage_batch/utils/file_job_workspace.py::"
-    "FileJobWorkspace.write_json::param:value",
-    "src/git_stage_batch/utils/file_job_workspace.py::"
     "FileJobWorkspace.read_json::return",
-    "src/git_stage_batch/utils/file_job_workspace.py::"
-    "FileJobWorkspace.write_jsonl::param:values",
-    "src/git_stage_batch/utils/file_job_workspace.py::"
-    "FileJobWorkspace.stream_jsonl::return",
     "src/git_stage_batch/utils/file_job_workspace.py::"
     "FileJobWorkspace.write_pickle::param:value",
     "src/git_stage_batch/utils/file_job_workspace.py::"

--- a/src/git_stage_batch/cli/git_help.py
+++ b/src/git_stage_batch/cli/git_help.py
@@ -109,7 +109,7 @@ def _with_real_manpath_root(manpage_path: Path) -> AbstractContextManager[Path]:
             self,
             exc_type: type[BaseException] | None,
             exc: BaseException | None,
-            tb: TracebackType | None,
+            _traceback: TracebackType | None,
         ) -> None:
             self._temp_dir.cleanup()
 

--- a/tests/batch/merge/test_merge.py
+++ b/tests/batch/merge/test_merge.py
@@ -285,8 +285,8 @@ def test_candidate_enumeration_propagates_atomic_unit_errors(monkeypatch):
     """Candidate discovery must not reinterpret atomic selection failures."""
 
     def refuse_atomic_selection(*_args, **_kwargs):
+        yield from ()
         raise AtomicUnitError("select the complete replacement")
-        yield
 
     monkeypatch.setattr(
         merge_module,

--- a/tests/cli/test_git_help.py
+++ b/tests/cli/test_git_help.py
@@ -84,7 +84,7 @@ def test_show_git_stage_batch_help_uses_packaged_page_first(monkeypatch, tmp_pat
         def __enter__(self):
             return self.path
 
-        def __exit__(self, exc_type, exc, tb):
+        def __exit__(self, exc_type, exc, _traceback):
             return False
 
     monkeypatch.setattr(git_help.resources, "as_file", lambda path: _AsFile(path))
@@ -124,7 +124,7 @@ def test_show_git_stage_batch_help_uses_packaged_command_page(monkeypatch, tmp_p
         def __enter__(self):
             return self.path
 
-        def __exit__(self, exc_type, exc, tb):
+        def __exit__(self, exc_type, exc, _traceback):
             return False
 
     monkeypatch.setattr(git_help.resources, "as_file", lambda path: _AsFile(path))
@@ -168,7 +168,7 @@ def test_show_git_stage_batch_help_materializes_editable_manpage(
         def __enter__(self):
             return self.path
 
-        def __exit__(self, exc_type, exc, tb):
+        def __exit__(self, exc_type, exc, _traceback):
             return False
 
     monkeypatch.setattr(git_help.resources, "as_file", lambda path: _AsFile(path))

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -219,12 +219,12 @@ def test_main_handles_git_failure_before_dispatch_without_traceback(capsys):
 
     @contextmanager
     def failing_lock():
+        yield from ()
         raise subprocess.CalledProcessError(
             128,
             ["git", "rev-parse", "--absolute-git-dir"],
             stderr="fatal: not a git repository\n",
         )
-        yield
 
     args = Namespace(working_directory=None)
 

--- a/tests/commands/batch_source/test_candidate_planning.py
+++ b/tests/commands/batch_source/test_candidate_planning.py
@@ -21,7 +21,7 @@ class _Context(AbstractContextManager):
     def __enter__(self) -> object:
         return self.value
 
-    def __exit__(self, exc_type, exc_value, traceback) -> None:
+    def __exit__(self, exc_type, _exc_value, traceback) -> None:
         self.closed = True
         return None
 
@@ -35,7 +35,7 @@ class _ReplacementView(AbstractContextManager):
     def __enter__(self) -> _ReplacementView:
         return self
 
-    def __exit__(self, exc_type, exc_value, traceback) -> None:
+    def __exit__(self, exc_type, _exc_value, traceback) -> None:
         self.source_buffer.close()
         self.closed = True
         return None

--- a/tests/commands/batch_source/test_replacement_previews.py
+++ b/tests/commands/batch_source/test_replacement_previews.py
@@ -19,7 +19,7 @@ class _OwnershipContext(AbstractContextManager):
     def __enter__(self) -> object:
         return self.ownership
 
-    def __exit__(self, exc_type, exc_value, traceback) -> None:
+    def __exit__(self, exc_type, _exc_value, traceback) -> None:
         return None
 
 
@@ -31,7 +31,7 @@ class _ReplacementView(AbstractContextManager):
     def __enter__(self) -> "_ReplacementView":
         return self
 
-    def __exit__(self, exc_type, exc_value, traceback) -> None:
+    def __exit__(self, exc_type, _exc_value, traceback) -> None:
         self.source_buffer.close()
         return None
 

--- a/tests/commands/batch_source/test_text_plan_builders.py
+++ b/tests/commands/batch_source/test_text_plan_builders.py
@@ -28,7 +28,7 @@ class _OwnershipContext(AbstractContextManager):
     def __enter__(self) -> _Ownership:
         return self.ownership
 
-    def __exit__(self, exc_type, exc_value, traceback) -> None:
+    def __exit__(self, exc_type, _exc_value, traceback) -> None:
         return None
 
 
@@ -41,7 +41,7 @@ class _ReplacementView(AbstractContextManager):
     def __enter__(self):
         return self
 
-    def __exit__(self, exc_type, exc_value, traceback) -> None:
+    def __exit__(self, exc_type, _exc_value, traceback) -> None:
         self.close()
 
     def close(self) -> None:


### PR DESCRIPTION
The production package now contains only interfaces with runtime callers or
known indirect use through Python protocols and data schemas.

Linting and strict typing do not distinguish unreachable production
definitions from methods and fields that Python reaches indirectly. Tests can
also hide dead production code by remaining its only callers.

This pull request adds a production-only Vulture check with exact,
self-pruning exceptions, runs it in continuous integration, and documents the
local command. It also marks protocol-only arguments explicitly and removes
stale type-hygiene exceptions. Ruff, strict typing, type-hygiene, dead-code
validation, and the full test suite pass.

Local validation and continuous integration now reject unreachable production
definitions without treating tests as production callers.
