### PR TITLE
ownership: Preserve presence reference sides

### DIFF
--- a/src/git_stage_batch/batch/ownership/merging.py
+++ b/src/git_stage_batch/batch/ownership/merging.py
@@ -122,10 +122,16 @@ def merge_batch_ownership(existing: BatchOwnership, new: BatchOwnership) -> Batc
     existing_claimed = existing.presence_line_set()
     new_claimed = new.presence_line_set()
     combined_claimed = existing_claimed.union(new_claimed)
-    combined_presence_references = {
-        **existing.presence_baseline_references(),
-        **new.presence_baseline_references(),
-    }
+    combined_presence_references = existing.presence_baseline_references()
+    for source_line, new_reference in (
+        new.presence_baseline_references().items()
+    ):
+        merged_reference = _merge_baseline_references(
+            combined_presence_references.get(source_line),
+            new_reference,
+        )
+        if merged_reference is not None:
+            combined_presence_references[source_line] = merged_reference
 
     combined_deletions: list[AbsenceClaim] = []
     deletion_index_by_signature: dict[_AbsenceSignature, int] = {}

--- a/tests/batch/source/test_advancement.py
+++ b/tests/batch/source/test_advancement.py
@@ -288,6 +288,42 @@ def test_merge_deduplicated_deletions_keeps_stronger_baseline_reference():
     ]
 
 
+def test_merge_presence_claims_keeps_strongest_baseline_reference_sides():
+    """Overlapping presence claims should retain both useful boundaries."""
+    existing_reference = BaselineReference(
+        after_line=7,
+        after_content=b"after\n",
+        before_line=None,
+        has_before_line=False,
+    )
+    new_reference = BaselineReference(
+        after_line=None,
+        after_content=None,
+        has_after_line=False,
+        before_line=11,
+        before_content=b"before\n",
+        has_before_line=True,
+    )
+    existing = BatchOwnership.from_presence_lines(
+        ["1"],
+        baseline_references={1: existing_reference},
+    )
+    new = BatchOwnership.from_presence_lines(
+        ["1"],
+        baseline_references={1: new_reference},
+    )
+
+    merged = merge_batch_ownership(existing, new)
+
+    assert merged.presence_baseline_reference(1) == BaselineReference(
+        after_line=7,
+        after_content=b"after\n",
+        before_line=11,
+        before_content=b"before\n",
+        has_before_line=True,
+    )
+
+
 def test_merge_ignores_boolean_replacement_unit_deletion_indices():
     """JSON booleans should not be accepted as deletion indexes."""
     new = BatchOwnership.from_presence_lines(


### PR DESCRIPTION
Saved-change ownership merges repeated presence claims and combines deletion
claims with references to nearby unchanged lines.

Repeated presence claims can carry complementary before and after references.
Overwriting the earlier claim discards an anchor that coordinate-based merge
planning can still use, even though the claimed line set remains unchanged.

This pull request merges each overlapping presence reference one side at a
time, retaining the strongest available before and after anchors. A focused
regression test covers complementary references. The 3,485-test suite, Ruff,
dead-code validation, type-hygiene validation, strict mypy, benchmark smoke,
wheel and source-distribution build/install smoke, and SHA-256 repository
tests pass locally.

Repeated presence claims now preserve every useful coordinate reference for
saved-change merge planning.
