### PR TITLE
source: Handle dangling links across saved-source workflows

### DIFF
--- a/src/git_stage_batch/batch/source/advancement.py
+++ b/src/git_stage_batch/batch/source/advancement.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from collections.abc import Sequence
 from dataclasses import dataclass
 from types import TracebackType
@@ -128,7 +129,7 @@ def advance_batch_source_for_file_with_provenance(
     """Advance batch source and expose provenance for re-annotation."""
     repo_root = get_git_repository_root_path()
     working_file_path = repo_root / file_path
-    if not working_file_path.exists():
+    if not os.path.lexists(working_file_path):
         raise ValueError(
             f"Cannot advance batch source for {file_path}: "
             f"file does not exist in working tree"

--- a/src/git_stage_batch/batch/source/annotation.py
+++ b/src/git_stage_batch/batch/source/annotation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from pathlib import Path
@@ -160,7 +161,7 @@ def annotate_with_batch_source(
     """
     repo_root = get_git_repository_root_path()
     file_full_path = repo_root / path_value
-    if not file_full_path.exists():
+    if not os.path.lexists(file_full_path):
         return _fill_source_from_working_tree(line_changes)
 
     with load_working_tree_file_as_buffer(path_value) as working_lines:

--- a/tests/batch/source/test_advancement.py
+++ b/tests/batch/source/test_advancement.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from git_stage_batch.batch.source import advancement as advancement_module
 from git_stage_batch.batch.ownership.absence_claims import AbsenceClaim
 from git_stage_batch.batch.ownership.model import (
     BatchOwnership,
@@ -17,6 +18,7 @@ from git_stage_batch.batch.ownership.translation import (
 from git_stage_batch.batch.ownership.references import BaselineReference
 from git_stage_batch.batch.ownership.replacement_units import ReplacementUnit
 from git_stage_batch.batch.source.advancement import (
+    advance_batch_source_for_file_with_provenance,
     advance_source_lines_preserving_existing_presence,
 )
 from git_stage_batch.batch.line_matching.lineage import BatchSourceLineage, LineageRun
@@ -322,6 +324,51 @@ def test_merge_presence_claims_keeps_strongest_baseline_reference_sides():
         before_content=b"before\n",
         has_before_line=True,
     )
+
+
+def test_advance_batch_source_reads_dangling_symlink(
+    monkeypatch,
+    tmp_path,
+):
+    """A dangling symlink remains a readable Git worktree object."""
+    (tmp_path / "link").symlink_to("missing-new-target")
+    loaded_paths: list[str] = []
+    monkeypatch.setattr(
+        advancement_module,
+        "get_git_repository_root_path",
+        lambda: tmp_path,
+    )
+    monkeypatch.setattr(
+        advancement_module,
+        "read_git_object_buffer_or_none",
+        lambda _revision: LineBuffer.from_bytes(b"missing-old-target"),
+    )
+
+    def load_working_tree_file(path: str) -> LineBuffer:
+        loaded_paths.append(path)
+        return LineBuffer.from_bytes(b"missing-new-target")
+
+    monkeypatch.setattr(
+        advancement_module,
+        "load_working_tree_file_as_buffer",
+        load_working_tree_file,
+    )
+    monkeypatch.setattr(
+        advancement_module,
+        "create_batch_source_commit",
+        lambda _path, *, file_buffer_override: "new-source",
+    )
+
+    with advance_batch_source_for_file_with_provenance(
+        "batch",
+        "link",
+        "old-source",
+        BatchOwnership.from_presence_lines([]),
+    ) as result:
+        assert result.batch_source_commit == "new-source"
+        assert result.source_buffer.to_bytes() == b"missing-new-target"
+
+    assert loaded_paths == ["link"]
 
 
 def test_merge_ignores_boolean_replacement_unit_deletion_indices():

--- a/tests/batch/source/test_annotation.py
+++ b/tests/batch/source/test_annotation.py
@@ -336,6 +336,80 @@ def test_annotate_with_batch_source_loads_indexed_buffers(monkeypatch, tmp_path)
     assert [line.source_line for line in annotated.lines] == [1, None, 2]
 
 
+def test_annotate_with_batch_source_maps_dangling_symlink(
+    monkeypatch,
+    tmp_path,
+):
+    """A dangling symlink should be mapped against its existing batch source."""
+    line_changes = LineLevelChange(
+        path="link",
+        header=HunkHeader(old_start=1, old_len=2, new_start=1, new_len=3),
+        lines=[
+            LineEntry(
+                id=None,
+                kind=" ",
+                old_line_number=1,
+                new_line_number=1,
+                text_bytes=b"line 1\n",
+            ),
+            LineEntry(
+                id=1,
+                kind="+",
+                old_line_number=None,
+                new_line_number=2,
+                text_bytes=b"inserted\n",
+            ),
+            LineEntry(
+                id=None,
+                kind=" ",
+                old_line_number=2,
+                new_line_number=3,
+                text_bytes=b"line 2\n",
+            ),
+        ],
+    )
+    (tmp_path / "link").symlink_to("missing-target")
+    loaded_paths: list[str] = []
+
+    monkeypatch.setattr(
+        source_annotation_module,
+        "get_git_repository_root_path",
+        lambda: tmp_path,
+    )
+    monkeypatch.setattr(
+        source_annotation_module,
+        "get_batch_source_for_file",
+        lambda _path: "source-commit",
+    )
+    monkeypatch.setattr(
+        source_annotation_module,
+        "read_git_object_buffer_or_none",
+        lambda _revision, **_kwargs: LineBuffer.from_chunks(
+            [b"line 1\n", b"line 2\n"]
+        ),
+    )
+
+    def load_working_tree_file(path: str) -> LineBuffer:
+        loaded_paths.append(path)
+        return LineBuffer.from_chunks(
+            [b"line 1\n", b"inserted\n", b"line 2\n"]
+        )
+
+    monkeypatch.setattr(
+        source_annotation_module,
+        "load_working_tree_file_as_buffer",
+        load_working_tree_file,
+    )
+
+    annotated = source_annotation_module.annotate_with_batch_source(
+        "link",
+        line_changes,
+    )
+
+    assert loaded_paths == ["link"]
+    assert [line.source_line for line in annotated.lines] == [1, None, 2]
+
+
 def test_acquired_mapping_annotates_multiple_hunks_with_one_match(monkeypatch):
     """One file-scoped mapping should be reusable across several hunks."""
     line_changes = LineLevelChange(


### PR DESCRIPTION
Saved-source advancement and annotation read working-tree objects through a
loader that preserves symbolic-link contents without following their targets.

A dangling symbolic link is a valid directory entry, but target-following
existence checks reject it before advancement reaches that loader and make
annotation treat it as a new file. That can lose the saved-source coordinates
needed for later ownership translation.

This pull request checks directory-entry existence without following symbolic
links in both paths. Regression tests prove that advancement refreshes a
dangling link and annotation maps inserted link content against its existing
saved source. The 3,487-test suite, Ruff, dead-code validation, type-hygiene
validation, strict mypy, benchmark smoke, wheel and source-distribution
build/install smoke, and SHA-256 repository tests pass locally.

Saved-source processing now preserves dangling symbolic-link content without
treating the absent target as a missing working-tree file.
