### PR TITLE
state: Validate iteration counts before session restart

### DIFF
--- a/src/git_stage_batch/commands/again.py
+++ b/src/git_stage_batch/commands/again.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from ..data.auto_advance import write_auto_advance_default
-from ..data.session import require_session_started
+from ..data.session import get_iteration_count, require_session_started
 from ..utils.git_repository import require_git_repository
 from ..utils.paths import ensure_state_directory_exists
 from .session.iteration import restart_iteration_pass
@@ -21,7 +21,12 @@ def command_again(*, quiet: bool = False, auto_advance: bool | None = None) -> N
     require_session_started()
     ensure_state_directory_exists()
 
+    current_iteration = get_iteration_count()
+
     if auto_advance is not None:
         write_auto_advance_default(auto_advance)
 
-    restart_iteration_pass(quiet=quiet)
+    restart_iteration_pass(
+        current_iteration=current_iteration,
+        quiet=quiet,
+    )

--- a/src/git_stage_batch/commands/session/iteration.py
+++ b/src/git_stage_batch/commands/session/iteration.py
@@ -10,10 +10,14 @@ from ...i18n import _
 from ..selection.selected_change_display import show_selected_change
 
 
-def restart_iteration_pass(*, quiet: bool = False) -> None:
+def restart_iteration_pass(
+    *,
+    current_iteration: int,
+    quiet: bool = False,
+) -> None:
     """Clear iteration state and select the first available change."""
     clear_iteration_state()
-    increment_iteration_count()
+    increment_iteration_count(current_iteration)
     auto_add_untracked_files(show_progress=not quiet)
 
     try:

--- a/src/git_stage_batch/commands/start.py
+++ b/src/git_stage_batch/commands/start.py
@@ -8,7 +8,11 @@ from ..data.auto_advance import DEFAULT_AUTO_ADVANCE, write_auto_advance_default
 from ..data.hunk_tracking import fetch_next_change
 from ..data.selected_change.lifecycle import clear_selected_change_state_files
 from ..data.file_tracking import auto_add_untracked_files
-from ..data.session import clear_session_state, initialize_abort_state
+from ..data.session import (
+    clear_session_state,
+    get_iteration_count,
+    initialize_abort_state,
+)
 from ..data.session_marker import session_is_active
 from ..data.session_ownership import (
     claim_session_ownership,
@@ -46,10 +50,14 @@ def command_start(
 
     # If session already exists, run again logic instead
     if session_is_active():
+        current_iteration = get_iteration_count()
         claim_session_ownership()
         if auto_advance is not None:
             write_auto_advance_default(auto_advance)
-        restart_iteration_pass(quiet=quiet)
+        restart_iteration_pass(
+            current_iteration=current_iteration,
+            quiet=quiet,
+        )
         return
 
     # Batch reviews may be shown outside an active session. A new session must

--- a/src/git_stage_batch/data/session.py
+++ b/src/git_stage_batch/data/session.py
@@ -467,15 +467,32 @@ def get_iteration_count() -> int:
     count_path = get_iteration_count_file_path()
     if not count_path.exists():
         return 1
-    return int(read_text_file_contents(count_path).strip())
+    try:
+        count = int(read_text_file_contents(count_path).strip())
+    except ValueError as error:
+        raise CommandError(
+            _("Session iteration count is invalid: {path}").format(
+                path=count_path,
+            )
+        ) from error
+    if count < 1:
+        raise CommandError(
+            _("Session iteration count is invalid: {path}").format(
+                path=count_path,
+            )
+        )
+    return count
 
 
-def increment_iteration_count() -> None:
+def increment_iteration_count(current_count: int | None = None) -> None:
     """Increment the iteration counter.
 
     Called when the user runs 'again' to restart from the beginning.
+
+    Args:
+        current_count: A count validated before iteration state was cleared.
     """
-    selected = get_iteration_count()
+    selected = get_iteration_count() if current_count is None else current_count
     write_text_file_contents(get_iteration_count_file_path(), str(selected + 1))
 
 

--- a/tests/commands/test_again.py
+++ b/tests/commands/test_again.py
@@ -13,7 +13,7 @@ from git_stage_batch.data.selected_change.store import (
     read_selected_change_kind,
 )
 from git_stage_batch.data.selected_change.paths import get_selected_change_file_path
-from git_stage_batch.exceptions import NoMoreHunks
+from git_stage_batch.exceptions import CommandError, NoMoreHunks
 
 import subprocess
 
@@ -28,8 +28,10 @@ from git_stage_batch.utils.paths import (
     get_abort_snapshot_list_file_path,
     get_abort_snapshots_directory_path,
     get_abort_stash_file_path,
+    get_auto_advance_config_file_path,
     get_block_list_file_path,
     get_batches_directory_path,
+    get_iteration_count_file_path,
     get_selected_change_clear_reason_file_path,
     get_session_batch_sources_file_path,
     get_state_directory_path,
@@ -69,6 +71,34 @@ class TestCommandAgain:
 
         command_again(quiet=True)
         assert get_iteration_count() == 3
+
+    def test_again_reports_corrupt_iteration_count(self, temp_git_repo):
+        """Again should reject a corrupt counter before changing session state."""
+        (temp_git_repo / "README.md").write_text("# Test\nmodified\n")
+        command_start(quiet=True)
+        progress_sentinel = (
+            get_state_directory_path()
+            / "session"
+            / "progress"
+            / "sentinel"
+        )
+        progress_sentinel.parent.mkdir(parents=True, exist_ok=True)
+        progress_sentinel.write_text("keep\n", encoding="utf-8")
+        auto_advance_path = get_auto_advance_config_file_path()
+        original_auto_advance = auto_advance_path.read_bytes()
+        write_text_file_contents(
+            get_iteration_count_file_path(),
+            "not-an-integer",
+        )
+
+        with pytest.raises(
+            CommandError,
+            match="Session iteration count is invalid",
+        ):
+            command_again(quiet=True, auto_advance=False)
+
+        assert progress_sentinel.read_text(encoding="utf-8") == "keep\n"
+        assert auto_advance_path.read_bytes() == original_auto_advance
 
     def test_again_clears_iteration_state(self, temp_git_repo):
         """Test that again clears iteration-specific state but preserves permanent state."""

--- a/tests/commands/test_start.py
+++ b/tests/commands/test_start.py
@@ -9,10 +9,15 @@ from git_stage_batch.commands.start import command_start
 from git_stage_batch.data.session import get_iteration_count
 from git_stage_batch.data.session_marker import session_is_active
 from git_stage_batch.exceptions import CommandError
-from git_stage_batch.utils.file_io import read_text_file_contents
+from git_stage_batch.utils.file_io import (
+    read_text_file_contents,
+    write_text_file_contents,
+)
 from git_stage_batch.utils.paths import (
     get_abort_head_file_path,
     get_abort_stash_file_path,
+    get_auto_advance_config_file_path,
+    get_iteration_count_file_path,
     get_state_directory_path,
 )
 
@@ -63,6 +68,37 @@ class TestCommandStart:
         state_dir = get_state_directory_path()
         assert state_dir.exists()
         assert get_iteration_count() == 2
+
+    def test_active_start_rejects_corrupt_iteration_before_changes(
+        self,
+        temp_git_repo,
+    ):
+        """An active start should validate its counter before restarting."""
+        (temp_git_repo / "README.md").write_text("# Test\nmodified\n")
+        command_start(quiet=True)
+        progress_sentinel = (
+            get_state_directory_path()
+            / "session"
+            / "progress"
+            / "sentinel"
+        )
+        progress_sentinel.parent.mkdir(parents=True, exist_ok=True)
+        progress_sentinel.write_text("keep\n", encoding="utf-8")
+        auto_advance_path = get_auto_advance_config_file_path()
+        original_auto_advance = auto_advance_path.read_bytes()
+        write_text_file_contents(
+            get_iteration_count_file_path(),
+            "not-an-integer",
+        )
+
+        with pytest.raises(
+            CommandError,
+            match="Session iteration count is invalid",
+        ):
+            command_start(quiet=True, auto_advance=False)
+
+        assert progress_sentinel.read_text(encoding="utf-8") == "keep\n"
+        assert auto_advance_path.read_bytes() == original_auto_advance
 
     def test_start_initializes_abort_state(self, temp_git_repo):
         """Test that start initializes abort state files."""

--- a/tests/commands/test_status.py
+++ b/tests/commands/test_status.py
@@ -219,6 +219,21 @@ class TestCommandStatus:
         assert "Discarded:" in captured.out
         assert "Remaining:" in captured.out
 
+    def test_status_reports_corrupt_iteration_count(self, temp_git_repo):
+        """Corrupt session state should produce a normal command error."""
+        (temp_git_repo / "README.md").write_text("# Test\nmodified\n")
+        command_start(quiet=True)
+        write_text_file_contents(
+            get_iteration_count_file_path(),
+            "not-an-integer",
+        )
+
+        with pytest.raises(
+            CommandError,
+            match="Session iteration count is invalid",
+        ):
+            command_status()
+
     def test_status_porcelain_no_session(self, temp_git_repo, capsys):
         """Test status --porcelain when no session is active."""
         command_status(porcelain=True)


### PR DESCRIPTION
Session status and restart commands share a persisted, one-based iteration
counter.

A malformed or nonpositive value can expose an internal conversion error.
Restart paths can also clear progress before discovering the corrupt value,
turning a reporting problem into lost recovery state.

This pull request validates the shared counter through a command-level
repository-state error and passes the parsed value through restart before
clearing iteration progress. Regression tests cover status, `again`, and an
active `start`, including preservation of settings and recovery files after
failed preflight. The 3,490-test suite, Ruff, dead-code validation,
type-hygiene validation, strict mypy, benchmark smoke, wheel and
source-distribution build/install smoke, and SHA-256 repository tests pass
locally.

Session status and restart commands now reject corrupt iteration state before
any restart mutation.
