### PR TITLE
assets: Make workflow checkpoint recovery fail closed

### DIFF
--- a/assets/claude-skills/decompose-and-commit-unstaged-changes/SKILL.md
+++ b/assets/claude-skills/decompose-and-commit-unstaged-changes/SKILL.md
@@ -107,21 +107,8 @@ directory as stale output from another attempt. Phase 1 must not read them as
 input. Remove any old candidate and narrative files before analysis; the
 final plan is overwritten only after the candidate passes Gate 1:
 
-```bash
-python - <<'PY'
-import subprocess
-from pathlib import Path
-state_dir = Path(subprocess.check_output(
-    ["python", ".claude/skills/decompose-and-commit-unstaged-changes/scripts/decompose-checkpoint.py", "state-dir"],
-    text=True,
-).strip())
-state_dir.mkdir(parents=True, exist_ok=True)
-(state_dir / "decompose-plan.candidate.json").unlink(missing_ok=True)
-(state_dir / "decompose-plan.json").unlink(missing_ok=True)
-(state_dir / "decompose-narrative.md").unlink(missing_ok=True)
-(state_dir / "decompose-refinement.md").unlink(missing_ok=True)
-PY
-```
+The fresh `start` command below performs that scoped cleanup. Do not remove
+the workflow state directory or sibling recovery state directly.
 
 For a fresh full or `deconstruct` run, record the new checkpoint immediately
 after recording the base commit:

--- a/assets/claude-skills/decompose-and-commit-unstaged-changes/SKILL.md
+++ b/assets/claude-skills/decompose-and-commit-unstaged-changes/SKILL.md
@@ -173,6 +173,8 @@ Then choose the resume point:
 Do not treat a candidate plan plus narrative as sufficient progress by
 itself. Candidate artifacts are resumable only through Gate 1. A failed Gate 1
 means the prior analysis was not a checkpoint; it was a rejected draft.
+Artifacts without a valid decompose checkpoint have no trusted base and must
+route to a fresh run.
 
 After every successful gate or phase transition, run:
 
@@ -309,8 +311,8 @@ python .claude/skills/decompose-and-commit-unstaged-changes/scripts/decompose-ch
 ```
 
 For a `deconstruct` run, use `--mode deconstruct`. For a `resume` run that
-reruns Phase 1, use `--mode resume` and keep the original checkpoint `base`
-if one exists.
+reruns Phase 1, use `--mode resume`. The helper preserves the original
+checkpoint `base` and refuses an explicit base that does not match it.
 
 Spawn `Agent(decompose-analyzer)` with this prompt:
 

--- a/assets/claude-skills/decompose-and-commit-unstaged-changes/scripts/decompose-checkpoint.py
+++ b/assets/claude-skills/decompose-and-commit-unstaged-changes/scripts/decompose-checkpoint.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 
 import argparse
 import datetime as _dt
+import errno
 import hashlib
 import json
 import os
 import shutil
 import subprocess
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -64,6 +66,25 @@ def file_digest(path: Path) -> str | None:
         for chunk in iter(lambda: handle.read(1024 * 1024), b""):
             h.update(chunk)
     return h.hexdigest()
+
+
+def fsync_directory(path: Path) -> None:
+    """Durably publish directory-entry changes where the platform permits."""
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as error:
+        if os.name == "nt" or error.errno in (errno.EINVAL, errno.ENOTSUP):
+            return
+        raise
+    try:
+        try:
+            os.fsync(descriptor)
+        except OSError as error:
+            if error.errno not in (errno.EBADF, errno.EINVAL, errno.ENOTSUP):
+                raise
+    finally:
+        os.close(descriptor)
 
 
 def load_checkpoint() -> dict[str, Any]:
@@ -152,12 +173,25 @@ def infer_resume_target(state: dict[str, Any]) -> str:
 def save_checkpoint(data: dict[str, Any]) -> None:
     STATE_DIR.mkdir(parents=True, exist_ok=True)
     data["updated_at"] = now()
-    CHECKPOINT_PATH.touch(exist_ok=True)
     data["artifacts"] = artifact_state(data)
-    CHECKPOINT_PATH.write_text(
-        json.dumps(data, indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
+    data["artifacts"]["checkpoint_exists"] = True
+    payload = json.dumps(data, indent=2, sort_keys=True) + "\n"
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=STATE_DIR,
+        prefix=f".{CHECKPOINT_PATH.name}.",
+        suffix=".tmp",
     )
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_path, CHECKPOINT_PATH)
+        fsync_directory(STATE_DIR)
+    except BaseException:
+        temporary_path.unlink(missing_ok=True)
+        raise
 
 
 def clear_state_dir_for_fresh_start() -> list[str]:

--- a/assets/claude-skills/decompose-and-commit-unstaged-changes/scripts/decompose-checkpoint.py
+++ b/assets/claude-skills/decompose-and-commit-unstaged-changes/scripts/decompose-checkpoint.py
@@ -37,6 +37,18 @@ PLAN_PATH = STATE_DIR / "decompose-plan.json"
 CANDIDATE_PATH = STATE_DIR / "decompose-plan.candidate.json"
 NARRATIVE_PATH = STATE_DIR / "decompose-narrative.md"
 PRESERVE_ON_FRESH_START = {".gitignore"}
+CHECKPOINT_MODES = {"full", "deconstruct", "reconstruct", "resume"}
+CHECKPOINT_PHASES = {
+    "started",
+    "phase1-running",
+    "phase1-candidate",
+    "phase1-complete",
+    "phase2-running",
+    "phase2-complete",
+    "phase3-running",
+    "refine-history-running",
+    "phase3-complete",
+}
 
 
 def now() -> str:
@@ -58,6 +70,11 @@ def current_head() -> str:
     return git_output("rev-parse", "HEAD")
 
 
+def resolve_commit(revision: str) -> str:
+    """Resolve one revision to its full commit object name."""
+    return git_output("rev-parse", "--verify", f"{revision}^{{commit}}")
+
+
 def file_digest(path: Path) -> str | None:
     if not path.exists() or not path.is_file():
         return None
@@ -66,6 +83,12 @@ def file_digest(path: Path) -> str | None:
         for chunk in iter(lambda: handle.read(1024 * 1024), b""):
             h.update(chunk)
     return h.hexdigest()
+
+
+def require_safe_state_dir() -> None:
+    """Refuse to read or mutate workflow state through a directory symlink."""
+    if STATE_DIR.is_symlink():
+        raise SystemExit(f"refusing to use symlinked state path: {STATE_DIR}")
 
 
 def fsync_directory(path: Path) -> None:
@@ -88,13 +111,96 @@ def fsync_directory(path: Path) -> None:
 
 
 def load_checkpoint() -> dict[str, Any]:
-    if not CHECKPOINT_PATH.exists():
+    require_safe_state_dir()
+    if not os.path.lexists(CHECKPOINT_PATH):
         return {}
+    if CHECKPOINT_PATH.is_symlink():
+        return {"checkpoint_error": "checkpoint path is a symlink"}
     try:
         data = json.loads(CHECKPOINT_PATH.read_text(encoding="utf-8"))
-    except json.JSONDecodeError:
-        return {"checkpoint_error": "invalid json"}
-    return data if isinstance(data, dict) else {}
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        return {"checkpoint_error": str(error)}
+    if not isinstance(data, dict):
+        return {"checkpoint_error": "checkpoint must be a JSON object"}
+    return data
+
+
+def _nonempty_string(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def checkpoint_validation_error(data: dict[str, Any]) -> str | None:
+    """Return why checkpoint state is unsafe to update, if applicable."""
+    parse_error = data.get("checkpoint_error")
+    if parse_error:
+        return str(parse_error)
+    if type(data.get("schema")) is not int or data["schema"] != 1:
+        return "unsupported or missing schema"
+    base = data.get("base")
+    if not _nonempty_string(base):
+        return "missing base"
+    assert isinstance(base, str)
+    resolved_base = resolve_commit(base)
+    if not resolved_base:
+        return "base does not name a commit"
+    if resolved_base != base:
+        return "base is not a full commit object name"
+    if data.get("mode") not in CHECKPOINT_MODES:
+        return "invalid mode"
+    if data.get("phase") not in CHECKPOINT_PHASES:
+        return "invalid phase"
+
+    events = data.get("events")
+    if not isinstance(events, list):
+        return "events must be a list"
+    for index, event in enumerate(events):
+        if not isinstance(event, dict):
+            return f"event {index} must be an object"
+        if not _nonempty_string(event.get("at")):
+            return f"event {index} has no valid timestamp"
+        if not _nonempty_string(event.get("event")):
+            return f"event {index} has no valid kind"
+
+    completed_batches = data.get("completed_batches")
+    if not isinstance(completed_batches, list):
+        return "completed batches must be a list"
+    for index, batch_name in enumerate(completed_batches):
+        if not _nonempty_string(batch_name):
+            return f"completed batch {index} must be a nonempty string"
+
+    commits = data.get("commits")
+    if not isinstance(commits, list):
+        return "commits must be a list"
+    for index, commit in enumerate(commits):
+        if not isinstance(commit, dict):
+            return f"commit {index} must be an object"
+        commit_sha = commit.get("sha")
+        if not _nonempty_string(commit_sha):
+            return f"commit {index} has no valid object name"
+        assert isinstance(commit_sha, str)
+        if resolve_commit(commit_sha) != commit_sha:
+            return f"commit {index} does not name a full commit object"
+        if not isinstance(commit.get("subject"), str):
+            return f"commit {index} has no valid subject"
+
+    if "current_batch" in data and not _nonempty_string(
+        data["current_batch"]
+    ):
+        return "current batch must be a nonempty string"
+    return None
+
+
+def require_checkpoint() -> dict[str, Any]:
+    """Load checkpoint state that is safe to update or resume."""
+    if not os.path.lexists(CHECKPOINT_PATH):
+        raise SystemExit("no decompose checkpoint; run start first")
+    data = load_checkpoint()
+    validation_error = checkpoint_validation_error(data)
+    if validation_error is not None:
+        raise SystemExit(
+            f"invalid decompose checkpoint: {validation_error}"
+        )
+    return data
 
 
 def list_batch_refs() -> list[str]:
@@ -144,9 +250,13 @@ def artifact_state(data: dict[str, Any]) -> dict[str, Any]:
 
 
 def infer_resume_target(state: dict[str, Any]) -> str:
+    if not state["checkpoint_exists"]:
+        return "fresh"
     phase = state["phase"]
     if phase == "phase3-complete":
         return "complete"
+    if phase == "phase1-running":
+        return "phase1"
     if phase in {"phase3-running", "refine-history-running"}:
         if state["batch_count"]:
             return "phase3-after-gate2"
@@ -171,6 +281,7 @@ def infer_resume_target(state: dict[str, Any]) -> str:
 
 
 def save_checkpoint(data: dict[str, Any]) -> None:
+    require_safe_state_dir()
     STATE_DIR.mkdir(parents=True, exist_ok=True)
     data["updated_at"] = now()
     data["artifacts"] = artifact_state(data)
@@ -210,8 +321,39 @@ def clear_state_dir_for_fresh_start() -> list[str]:
 
 
 def cmd_start(args: argparse.Namespace) -> None:
-    removed = [] if args.mode == "resume" else clear_state_dir_for_fresh_start()
-    base = args.base or current_head()
+    if args.mode == "resume":
+        data = require_checkpoint()
+        base = data["base"]
+        if (
+            args.base is not None
+            and resolve_commit(args.base) != base
+        ):
+            raise SystemExit(
+                "resume base does not match the decompose checkpoint"
+            )
+        previous_phase = data.get("phase")
+        data["phase"] = "phase1-running"
+        data["events"].append(
+            {
+                "at": now(),
+                "event": "start",
+                "mode": "resume",
+                "base": base,
+                "previous_phase": previous_phase,
+                "cleared_state_files": [],
+            }
+        )
+        save_checkpoint(data)
+        print(str(CHECKPOINT_PATH))
+        return
+
+    base_revision = args.base or "HEAD"
+    base = resolve_commit(base_revision)
+    if not base:
+        raise SystemExit(
+            f"invalid decompose base revision: {base_revision}"
+        )
+    removed = clear_state_dir_for_fresh_start()
     data: dict[str, Any] = {
         "schema": 1,
         "created_at": now(),

--- a/assets/claude-skills/decompose-and-commit-unstaged-changes/scripts/decompose-checkpoint.py
+++ b/assets/claude-skills/decompose-and-commit-unstaged-changes/scripts/decompose-checkpoint.py
@@ -36,7 +36,14 @@ CHECKPOINT_PATH = STATE_DIR / "decompose-checkpoint.json"
 PLAN_PATH = STATE_DIR / "decompose-plan.json"
 CANDIDATE_PATH = STATE_DIR / "decompose-plan.candidate.json"
 NARRATIVE_PATH = STATE_DIR / "decompose-narrative.md"
-PRESERVE_ON_FRESH_START = {".gitignore"}
+REFINEMENT_PATH = STATE_DIR / "decompose-refinement.md"
+DECOMPOSE_STATE_PATHS = (
+    CHECKPOINT_PATH,
+    PLAN_PATH,
+    CANDIDATE_PATH,
+    NARRATIVE_PATH,
+    REFINEMENT_PATH,
+)
 CHECKPOINT_MODES = {"full", "deconstruct", "reconstruct", "resume"}
 CHECKPOINT_PHASES = {
     "started",
@@ -306,17 +313,26 @@ def save_checkpoint(data: dict[str, Any]) -> None:
 
 
 def clear_state_dir_for_fresh_start() -> list[str]:
+    require_safe_state_dir()
     if not STATE_DIR.exists():
         return []
     removed: list[str] = []
-    for path in STATE_DIR.iterdir():
-        if path.name in PRESERVE_ON_FRESH_START:
-            continue
+    paths = [
+        path
+        for path in DECOMPOSE_STATE_PATHS
+        if path.exists() or path.is_symlink()
+    ]
+    paths.extend(
+        path
+        for path in STATE_DIR.glob(f".{CHECKPOINT_PATH.name}.*.tmp")
+        if path.is_file() or path.is_symlink()
+    )
+    for path in paths:
         removed.append(path.name)
-        if path.is_dir():
-            shutil.rmtree(path)
-        else:
+        if path.is_symlink() or not path.is_dir():
             path.unlink()
+        else:
+            shutil.rmtree(path)
     return sorted(removed)
 
 
@@ -439,12 +455,17 @@ def cmd_status(args: argparse.Namespace) -> None:
             print(f"  {batch}")
 
 
+def cmd_state_dir(_args: argparse.Namespace) -> None:
+    require_safe_state_dir()
+    print(STATE_DIR)
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
     sub = parser.add_subparsers(dest="command", required=True)
 
     state_dir = sub.add_parser("state-dir")
-    state_dir.set_defaults(func=lambda args: print(STATE_DIR))
+    state_dir.set_defaults(func=cmd_state_dir)
 
     start = sub.add_parser("start")
     start.add_argument(

--- a/assets/claude-skills/decompose-and-commit-unstaged-changes/scripts/decompose-checkpoint.py
+++ b/assets/claude-skills/decompose-and-commit-unstaged-changes/scripts/decompose-checkpoint.py
@@ -394,17 +394,7 @@ def cmd_start(args: argparse.Namespace) -> None:
 
 
 def cmd_mark(args: argparse.Namespace) -> None:
-    data = load_checkpoint()
-    if not data:
-        data = {
-            "schema": 1,
-            "created_at": now(),
-            "mode": "unknown",
-            "base": current_head(),
-            "events": [],
-            "completed_batches": [],
-            "commits": [],
-        }
+    data = require_checkpoint()
     if args.phase:
         data["phase"] = args.phase
     if args.current_batch:
@@ -415,9 +405,11 @@ def cmd_mark(args: argparse.Namespace) -> None:
     if args.completed_batch and data.get("current_batch") == args.completed_batch:
         data.pop("current_batch", None)
     if args.commit:
-        commit = args.commit
-        if commit == "HEAD":
-            commit = current_head()
+        commit = resolve_commit(args.commit)
+        if not commit:
+            raise SystemExit(
+                f"invalid decompose commit revision: {args.commit}"
+            )
         subject = git_output("log", "-1", "--format=%s", commit)
         commits = data.setdefault("commits", [])
         if not any(item.get("sha") == commit for item in commits if isinstance(item, dict)):
@@ -434,6 +426,12 @@ def cmd_mark(args: argparse.Namespace) -> None:
 
 def cmd_status(args: argparse.Namespace) -> None:
     data = load_checkpoint()
+    if os.path.lexists(CHECKPOINT_PATH):
+        validation_error = checkpoint_validation_error(data)
+        if validation_error is not None:
+            raise SystemExit(
+                f"invalid decompose checkpoint: {validation_error}"
+            )
     state = artifact_state(data)
     state["resume_target"] = infer_resume_target(state)
     state["events"] = data.get("events", [])[-10:]
@@ -477,7 +475,10 @@ def build_parser() -> argparse.ArgumentParser:
     start.set_defaults(func=cmd_start)
 
     mark = sub.add_parser("mark")
-    mark.add_argument("--phase")
+    mark.add_argument(
+        "--phase",
+        choices=sorted(CHECKPOINT_PHASES - {"started"}),
+    )
     mark.add_argument("--current-batch")
     mark.add_argument("--completed-batch")
     mark.add_argument("--commit")

--- a/assets/codex-skills/decompose-and-commit-unstaged-changes/SKILL.md
+++ b/assets/codex-skills/decompose-and-commit-unstaged-changes/SKILL.md
@@ -102,21 +102,8 @@ directory as stale output from another attempt. Phase 1 must not read them as
 input. Remove any old candidate and narrative files before analysis; the
 final plan is overwritten only after the candidate passes Gate 1:
 
-```bash
-python - <<'PY'
-import subprocess
-from pathlib import Path
-state_dir = Path(subprocess.check_output(
-    ["python", ".agents/skills/decompose-and-commit-unstaged-changes/scripts/decompose-checkpoint.py", "state-dir"],
-    text=True,
-).strip())
-state_dir.mkdir(parents=True, exist_ok=True)
-(state_dir / "decompose-plan.candidate.json").unlink(missing_ok=True)
-(state_dir / "decompose-plan.json").unlink(missing_ok=True)
-(state_dir / "decompose-narrative.md").unlink(missing_ok=True)
-(state_dir / "decompose-refinement.md").unlink(missing_ok=True)
-PY
-```
+The fresh `start` command below performs that scoped cleanup. Do not remove
+the workflow state directory or sibling recovery state directly.
 
 For a fresh full or `deconstruct` run, record the new checkpoint immediately
 after recording the base commit:

--- a/assets/codex-skills/decompose-and-commit-unstaged-changes/SKILL.md
+++ b/assets/codex-skills/decompose-and-commit-unstaged-changes/SKILL.md
@@ -168,6 +168,8 @@ Then choose the resume point:
 Do not treat a candidate plan plus narrative as sufficient progress by
 itself. Candidate artifacts are resumable only through Gate 1. A failed Gate 1
 means the prior analysis was not a checkpoint; it was a rejected draft.
+Artifacts without a valid decompose checkpoint have no trusted base and must
+route to a fresh run.
 
 After every successful gate or phase transition, run:
 
@@ -304,8 +306,8 @@ python .agents/skills/decompose-and-commit-unstaged-changes/scripts/decompose-ch
 ```
 
 For a `deconstruct` run, use `--mode deconstruct`. For a `resume` run that
-reruns Phase 1, use `--mode resume` and keep the original checkpoint `base`
-if one exists.
+reruns Phase 1, use `--mode resume`. The helper preserves the original
+checkpoint `base` and refuses an explicit base that does not match it.
 
 Use `references/decompose-analyzer.md` as the Phase 1 worker brief. If a
 fresh-context subagent is available, spawn it with this prompt; otherwise

--- a/assets/codex-skills/decompose-and-commit-unstaged-changes/scripts/decompose-checkpoint.py
+++ b/assets/codex-skills/decompose-and-commit-unstaged-changes/scripts/decompose-checkpoint.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 
 import argparse
 import datetime as _dt
+import errno
 import hashlib
 import json
 import os
 import shutil
 import subprocess
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -64,6 +66,25 @@ def file_digest(path: Path) -> str | None:
         for chunk in iter(lambda: handle.read(1024 * 1024), b""):
             h.update(chunk)
     return h.hexdigest()
+
+
+def fsync_directory(path: Path) -> None:
+    """Durably publish directory-entry changes where the platform permits."""
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as error:
+        if os.name == "nt" or error.errno in (errno.EINVAL, errno.ENOTSUP):
+            return
+        raise
+    try:
+        try:
+            os.fsync(descriptor)
+        except OSError as error:
+            if error.errno not in (errno.EBADF, errno.EINVAL, errno.ENOTSUP):
+                raise
+    finally:
+        os.close(descriptor)
 
 
 def load_checkpoint() -> dict[str, Any]:
@@ -152,12 +173,25 @@ def infer_resume_target(state: dict[str, Any]) -> str:
 def save_checkpoint(data: dict[str, Any]) -> None:
     STATE_DIR.mkdir(parents=True, exist_ok=True)
     data["updated_at"] = now()
-    CHECKPOINT_PATH.touch(exist_ok=True)
     data["artifacts"] = artifact_state(data)
-    CHECKPOINT_PATH.write_text(
-        json.dumps(data, indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
+    data["artifacts"]["checkpoint_exists"] = True
+    payload = json.dumps(data, indent=2, sort_keys=True) + "\n"
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=STATE_DIR,
+        prefix=f".{CHECKPOINT_PATH.name}.",
+        suffix=".tmp",
     )
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_path, CHECKPOINT_PATH)
+        fsync_directory(STATE_DIR)
+    except BaseException:
+        temporary_path.unlink(missing_ok=True)
+        raise
 
 
 def clear_state_dir_for_fresh_start() -> list[str]:

--- a/assets/codex-skills/decompose-and-commit-unstaged-changes/scripts/decompose-checkpoint.py
+++ b/assets/codex-skills/decompose-and-commit-unstaged-changes/scripts/decompose-checkpoint.py
@@ -37,6 +37,18 @@ PLAN_PATH = STATE_DIR / "decompose-plan.json"
 CANDIDATE_PATH = STATE_DIR / "decompose-plan.candidate.json"
 NARRATIVE_PATH = STATE_DIR / "decompose-narrative.md"
 PRESERVE_ON_FRESH_START = {".gitignore"}
+CHECKPOINT_MODES = {"full", "deconstruct", "reconstruct", "resume"}
+CHECKPOINT_PHASES = {
+    "started",
+    "phase1-running",
+    "phase1-candidate",
+    "phase1-complete",
+    "phase2-running",
+    "phase2-complete",
+    "phase3-running",
+    "refine-history-running",
+    "phase3-complete",
+}
 
 
 def now() -> str:
@@ -58,6 +70,11 @@ def current_head() -> str:
     return git_output("rev-parse", "HEAD")
 
 
+def resolve_commit(revision: str) -> str:
+    """Resolve one revision to its full commit object name."""
+    return git_output("rev-parse", "--verify", f"{revision}^{{commit}}")
+
+
 def file_digest(path: Path) -> str | None:
     if not path.exists() or not path.is_file():
         return None
@@ -66,6 +83,12 @@ def file_digest(path: Path) -> str | None:
         for chunk in iter(lambda: handle.read(1024 * 1024), b""):
             h.update(chunk)
     return h.hexdigest()
+
+
+def require_safe_state_dir() -> None:
+    """Refuse to read or mutate workflow state through a directory symlink."""
+    if STATE_DIR.is_symlink():
+        raise SystemExit(f"refusing to use symlinked state path: {STATE_DIR}")
 
 
 def fsync_directory(path: Path) -> None:
@@ -88,13 +111,96 @@ def fsync_directory(path: Path) -> None:
 
 
 def load_checkpoint() -> dict[str, Any]:
-    if not CHECKPOINT_PATH.exists():
+    require_safe_state_dir()
+    if not os.path.lexists(CHECKPOINT_PATH):
         return {}
+    if CHECKPOINT_PATH.is_symlink():
+        return {"checkpoint_error": "checkpoint path is a symlink"}
     try:
         data = json.loads(CHECKPOINT_PATH.read_text(encoding="utf-8"))
-    except json.JSONDecodeError:
-        return {"checkpoint_error": "invalid json"}
-    return data if isinstance(data, dict) else {}
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        return {"checkpoint_error": str(error)}
+    if not isinstance(data, dict):
+        return {"checkpoint_error": "checkpoint must be a JSON object"}
+    return data
+
+
+def _nonempty_string(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def checkpoint_validation_error(data: dict[str, Any]) -> str | None:
+    """Return why checkpoint state is unsafe to update, if applicable."""
+    parse_error = data.get("checkpoint_error")
+    if parse_error:
+        return str(parse_error)
+    if type(data.get("schema")) is not int or data["schema"] != 1:
+        return "unsupported or missing schema"
+    base = data.get("base")
+    if not _nonempty_string(base):
+        return "missing base"
+    assert isinstance(base, str)
+    resolved_base = resolve_commit(base)
+    if not resolved_base:
+        return "base does not name a commit"
+    if resolved_base != base:
+        return "base is not a full commit object name"
+    if data.get("mode") not in CHECKPOINT_MODES:
+        return "invalid mode"
+    if data.get("phase") not in CHECKPOINT_PHASES:
+        return "invalid phase"
+
+    events = data.get("events")
+    if not isinstance(events, list):
+        return "events must be a list"
+    for index, event in enumerate(events):
+        if not isinstance(event, dict):
+            return f"event {index} must be an object"
+        if not _nonempty_string(event.get("at")):
+            return f"event {index} has no valid timestamp"
+        if not _nonempty_string(event.get("event")):
+            return f"event {index} has no valid kind"
+
+    completed_batches = data.get("completed_batches")
+    if not isinstance(completed_batches, list):
+        return "completed batches must be a list"
+    for index, batch_name in enumerate(completed_batches):
+        if not _nonempty_string(batch_name):
+            return f"completed batch {index} must be a nonempty string"
+
+    commits = data.get("commits")
+    if not isinstance(commits, list):
+        return "commits must be a list"
+    for index, commit in enumerate(commits):
+        if not isinstance(commit, dict):
+            return f"commit {index} must be an object"
+        commit_sha = commit.get("sha")
+        if not _nonempty_string(commit_sha):
+            return f"commit {index} has no valid object name"
+        assert isinstance(commit_sha, str)
+        if resolve_commit(commit_sha) != commit_sha:
+            return f"commit {index} does not name a full commit object"
+        if not isinstance(commit.get("subject"), str):
+            return f"commit {index} has no valid subject"
+
+    if "current_batch" in data and not _nonempty_string(
+        data["current_batch"]
+    ):
+        return "current batch must be a nonempty string"
+    return None
+
+
+def require_checkpoint() -> dict[str, Any]:
+    """Load checkpoint state that is safe to update or resume."""
+    if not os.path.lexists(CHECKPOINT_PATH):
+        raise SystemExit("no decompose checkpoint; run start first")
+    data = load_checkpoint()
+    validation_error = checkpoint_validation_error(data)
+    if validation_error is not None:
+        raise SystemExit(
+            f"invalid decompose checkpoint: {validation_error}"
+        )
+    return data
 
 
 def list_batch_refs() -> list[str]:
@@ -144,9 +250,13 @@ def artifact_state(data: dict[str, Any]) -> dict[str, Any]:
 
 
 def infer_resume_target(state: dict[str, Any]) -> str:
+    if not state["checkpoint_exists"]:
+        return "fresh"
     phase = state["phase"]
     if phase == "phase3-complete":
         return "complete"
+    if phase == "phase1-running":
+        return "phase1"
     if phase in {"phase3-running", "refine-history-running"}:
         if state["batch_count"]:
             return "phase3-after-gate2"
@@ -171,6 +281,7 @@ def infer_resume_target(state: dict[str, Any]) -> str:
 
 
 def save_checkpoint(data: dict[str, Any]) -> None:
+    require_safe_state_dir()
     STATE_DIR.mkdir(parents=True, exist_ok=True)
     data["updated_at"] = now()
     data["artifacts"] = artifact_state(data)
@@ -210,8 +321,39 @@ def clear_state_dir_for_fresh_start() -> list[str]:
 
 
 def cmd_start(args: argparse.Namespace) -> None:
-    removed = [] if args.mode == "resume" else clear_state_dir_for_fresh_start()
-    base = args.base or current_head()
+    if args.mode == "resume":
+        data = require_checkpoint()
+        base = data["base"]
+        if (
+            args.base is not None
+            and resolve_commit(args.base) != base
+        ):
+            raise SystemExit(
+                "resume base does not match the decompose checkpoint"
+            )
+        previous_phase = data.get("phase")
+        data["phase"] = "phase1-running"
+        data["events"].append(
+            {
+                "at": now(),
+                "event": "start",
+                "mode": "resume",
+                "base": base,
+                "previous_phase": previous_phase,
+                "cleared_state_files": [],
+            }
+        )
+        save_checkpoint(data)
+        print(str(CHECKPOINT_PATH))
+        return
+
+    base_revision = args.base or "HEAD"
+    base = resolve_commit(base_revision)
+    if not base:
+        raise SystemExit(
+            f"invalid decompose base revision: {base_revision}"
+        )
+    removed = clear_state_dir_for_fresh_start()
     data: dict[str, Any] = {
         "schema": 1,
         "created_at": now(),

--- a/assets/codex-skills/decompose-and-commit-unstaged-changes/scripts/decompose-checkpoint.py
+++ b/assets/codex-skills/decompose-and-commit-unstaged-changes/scripts/decompose-checkpoint.py
@@ -36,7 +36,14 @@ CHECKPOINT_PATH = STATE_DIR / "decompose-checkpoint.json"
 PLAN_PATH = STATE_DIR / "decompose-plan.json"
 CANDIDATE_PATH = STATE_DIR / "decompose-plan.candidate.json"
 NARRATIVE_PATH = STATE_DIR / "decompose-narrative.md"
-PRESERVE_ON_FRESH_START = {".gitignore"}
+REFINEMENT_PATH = STATE_DIR / "decompose-refinement.md"
+DECOMPOSE_STATE_PATHS = (
+    CHECKPOINT_PATH,
+    PLAN_PATH,
+    CANDIDATE_PATH,
+    NARRATIVE_PATH,
+    REFINEMENT_PATH,
+)
 CHECKPOINT_MODES = {"full", "deconstruct", "reconstruct", "resume"}
 CHECKPOINT_PHASES = {
     "started",
@@ -306,17 +313,26 @@ def save_checkpoint(data: dict[str, Any]) -> None:
 
 
 def clear_state_dir_for_fresh_start() -> list[str]:
+    require_safe_state_dir()
     if not STATE_DIR.exists():
         return []
     removed: list[str] = []
-    for path in STATE_DIR.iterdir():
-        if path.name in PRESERVE_ON_FRESH_START:
-            continue
+    paths = [
+        path
+        for path in DECOMPOSE_STATE_PATHS
+        if path.exists() or path.is_symlink()
+    ]
+    paths.extend(
+        path
+        for path in STATE_DIR.glob(f".{CHECKPOINT_PATH.name}.*.tmp")
+        if path.is_file() or path.is_symlink()
+    )
+    for path in paths:
         removed.append(path.name)
-        if path.is_dir():
-            shutil.rmtree(path)
-        else:
+        if path.is_symlink() or not path.is_dir():
             path.unlink()
+        else:
+            shutil.rmtree(path)
     return sorted(removed)
 
 
@@ -439,12 +455,17 @@ def cmd_status(args: argparse.Namespace) -> None:
             print(f"  {batch}")
 
 
+def cmd_state_dir(_args: argparse.Namespace) -> None:
+    require_safe_state_dir()
+    print(STATE_DIR)
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
     sub = parser.add_subparsers(dest="command", required=True)
 
     state_dir = sub.add_parser("state-dir")
-    state_dir.set_defaults(func=lambda args: print(STATE_DIR))
+    state_dir.set_defaults(func=cmd_state_dir)
 
     start = sub.add_parser("start")
     start.add_argument(

--- a/assets/codex-skills/decompose-and-commit-unstaged-changes/scripts/decompose-checkpoint.py
+++ b/assets/codex-skills/decompose-and-commit-unstaged-changes/scripts/decompose-checkpoint.py
@@ -394,17 +394,7 @@ def cmd_start(args: argparse.Namespace) -> None:
 
 
 def cmd_mark(args: argparse.Namespace) -> None:
-    data = load_checkpoint()
-    if not data:
-        data = {
-            "schema": 1,
-            "created_at": now(),
-            "mode": "unknown",
-            "base": current_head(),
-            "events": [],
-            "completed_batches": [],
-            "commits": [],
-        }
+    data = require_checkpoint()
     if args.phase:
         data["phase"] = args.phase
     if args.current_batch:
@@ -415,9 +405,11 @@ def cmd_mark(args: argparse.Namespace) -> None:
     if args.completed_batch and data.get("current_batch") == args.completed_batch:
         data.pop("current_batch", None)
     if args.commit:
-        commit = args.commit
-        if commit == "HEAD":
-            commit = current_head()
+        commit = resolve_commit(args.commit)
+        if not commit:
+            raise SystemExit(
+                f"invalid decompose commit revision: {args.commit}"
+            )
         subject = git_output("log", "-1", "--format=%s", commit)
         commits = data.setdefault("commits", [])
         if not any(item.get("sha") == commit for item in commits if isinstance(item, dict)):
@@ -434,6 +426,12 @@ def cmd_mark(args: argparse.Namespace) -> None:
 
 def cmd_status(args: argparse.Namespace) -> None:
     data = load_checkpoint()
+    if os.path.lexists(CHECKPOINT_PATH):
+        validation_error = checkpoint_validation_error(data)
+        if validation_error is not None:
+            raise SystemExit(
+                f"invalid decompose checkpoint: {validation_error}"
+            )
     state = artifact_state(data)
     state["resume_target"] = infer_resume_target(state)
     state["events"] = data.get("events", [])[-10:]
@@ -477,7 +475,10 @@ def build_parser() -> argparse.ArgumentParser:
     start.set_defaults(func=cmd_start)
 
     mark = sub.add_parser("mark")
-    mark.add_argument("--phase")
+    mark.add_argument(
+        "--phase",
+        choices=sorted(CHECKPOINT_PHASES - {"started"}),
+    )
     mark.add_argument("--current-batch")
     mark.add_argument("--completed-batch")
     mark.add_argument("--commit")

--- a/tests/assets/test_decompose_checkpoint.py
+++ b/tests/assets/test_decompose_checkpoint.py
@@ -130,7 +130,7 @@ def test_resume_start_preserves_checkpoint_progress_and_base(
         ("current_batch", ""),
     ],
 )
-def test_resume_rejects_invalid_checkpoint_structure(
+def test_resume_and_status_reject_invalid_checkpoint_structure(
     git_repo: Path,
     field: str,
     value: object,
@@ -155,9 +155,12 @@ def test_resume_rejects_invalid_checkpoint_structure(
         "resume",
         check=False,
     )
+    status = _helper(git_repo, "status", "--json", check=False)
 
     assert resume.returncode != 0
+    assert status.returncode != 0
     assert "invalid decompose checkpoint" in resume.stderr
+    assert "invalid decompose checkpoint" in status.stderr
     assert checkpoint_path.read_bytes() == saved
 
 
@@ -186,6 +189,31 @@ def test_fresh_start_validates_base_before_clearing_state(
     assert "invalid decompose base revision" in result.stderr
     assert checkpoint_path.read_bytes() == saved_checkpoint
     assert plan_path.read_text(encoding="utf-8") == "{}\n"
+
+
+def test_mark_validates_commit_before_replacing_checkpoint(
+    git_repo: Path,
+) -> None:
+    """A mark must not record a revision that does not identify a commit."""
+    _helper(git_repo, "start", "--mode", "full", "--base", "HEAD")
+    checkpoint_path = (
+        git_repo / ".git-stage-batch" / "decompose-checkpoint.json"
+    )
+    saved = checkpoint_path.read_bytes()
+
+    result = _helper(
+        git_repo,
+        "mark",
+        "--phase",
+        "phase3-running",
+        "--commit",
+        "missing-commit",
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "invalid decompose commit revision" in result.stderr
+    assert checkpoint_path.read_bytes() == saved
 
 
 def test_start_refuses_symlinked_state_directory(
@@ -264,6 +292,63 @@ def test_fresh_start_clears_only_decompose_state(git_repo: Path) -> None:
     assert not (state_dir / "decompose-narrative.md").exists()
     assert not (state_dir / "decompose-refinement.md").exists()
     assert not list(state_dir.glob(".decompose-checkpoint.json.*.tmp"))
+
+
+@pytest.mark.parametrize("contents", [None, "", "{broken", "[]"])
+def test_mark_requires_valid_existing_checkpoint(
+    git_repo: Path,
+    contents: str | None,
+) -> None:
+    """Mark must not invent recovery state when its checkpoint is unavailable."""
+    checkpoint_path = (
+        git_repo / ".git-stage-batch" / "decompose-checkpoint.json"
+    )
+    if contents is not None:
+        checkpoint_path.parent.mkdir()
+        checkpoint_path.write_text(contents, encoding="utf-8")
+
+    result = _helper(
+        git_repo,
+        "mark",
+        "--phase",
+        "phase1-candidate",
+        check=False,
+    )
+    status = _helper(git_repo, "status", "--json", check=False)
+
+    assert result.returncode != 0
+    if contents is None:
+        assert "no decompose checkpoint" in result.stderr
+        assert not checkpoint_path.exists()
+        assert status.returncode == 0
+    else:
+        assert "invalid decompose checkpoint" in result.stderr
+        assert status.returncode != 0
+        assert "invalid decompose checkpoint" in status.stderr
+        assert checkpoint_path.read_text(encoding="utf-8") == contents
+
+
+def test_status_does_not_resume_orphaned_artifacts(git_repo: Path) -> None:
+    """Artifacts without a checkpoint cannot establish a recovery base."""
+    state_dir = git_repo / ".git-stage-batch"
+    state_dir.mkdir()
+    (state_dir / "decompose-plan.candidate.json").write_text(
+        "{}\n",
+        encoding="utf-8",
+    )
+    (state_dir / "decompose-narrative.md").write_text(
+        "Draft\n",
+        encoding="utf-8",
+    )
+
+    status = json.loads(
+        _helper(git_repo, "status", "--json").stdout
+    )
+
+    assert status["checkpoint_exists"] is False
+    assert status["candidate_exists"] is True
+    assert status["narrative_exists"] is True
+    assert status["resume_target"] == "fresh"
 
 
 def test_failed_atomic_replace_preserves_checkpoint(

--- a/tests/assets/test_decompose_checkpoint.py
+++ b/tests/assets/test_decompose_checkpoint.py
@@ -1,0 +1,83 @@
+"""Tests for the bundled decompose workflow checkpoint helper."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+CODEX_HELPER = (
+    PROJECT_ROOT
+    / "assets"
+    / "codex-skills"
+    / "decompose-and-commit-unstaged-changes"
+    / "scripts"
+    / "decompose-checkpoint.py"
+)
+
+
+def _git(repo: Path, *args: str) -> str:
+    """Run Git and return stripped stdout."""
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        check=True,
+    ).stdout.strip()
+
+
+@pytest.fixture
+def git_repo(tmp_path: Path) -> Path:
+    """Create a repository with a base commit and a later draft."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.name", "Test User")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "commit", "--allow-empty", "-m", "Base")
+    return repo
+
+
+def test_failed_atomic_replace_preserves_checkpoint(
+    git_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed checkpoint replacement must leave prior recovery data intact."""
+    state_dir = git_repo / ".git-stage-batch"
+    monkeypatch.setenv("DECOMPOSE_STATE_DIR", str(state_dir))
+    monkeypatch.chdir(git_repo)
+    spec = importlib.util.spec_from_file_location(
+        "decompose_checkpoint_for_test",
+        CODEX_HELPER,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    first = {
+        "schema": 1,
+        "base": _git(git_repo, "rev-parse", "HEAD"),
+        "phase": "started",
+        "events": [],
+        "completed_batches": [],
+        "commits": [],
+    }
+    module.save_checkpoint(first)
+    checkpoint_path = state_dir / "decompose-checkpoint.json"
+    saved = checkpoint_path.read_bytes()
+
+    def fail_replace(_source: Path, _destination: Path) -> None:
+        raise OSError("injected replacement failure")
+
+    monkeypatch.setattr(module.os, "replace", fail_replace)
+    changed = {**first, "phase": "phase1-running"}
+
+    with pytest.raises(OSError, match="injected replacement failure"):
+        module.save_checkpoint(changed)
+
+    assert checkpoint_path.read_bytes() == saved
+    assert not list(state_dir.glob(".decompose-checkpoint.json.*.tmp"))

--- a/tests/assets/test_decompose_checkpoint.py
+++ b/tests/assets/test_decompose_checkpoint.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -31,6 +33,24 @@ def _git(repo: Path, *args: str) -> str:
     ).stdout.strip()
 
 
+def _helper(
+    repo: Path,
+    *args: str,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    """Run the Codex checkpoint helper in a test repository."""
+    result = subprocess.run(
+        [sys.executable, str(CODEX_HELPER), *args],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if check:
+        result.check_returncode()
+    return result
+
+
 @pytest.fixture
 def git_repo(tmp_path: Path) -> Path:
     """Create a repository with a base commit and a later draft."""
@@ -41,6 +61,131 @@ def git_repo(tmp_path: Path) -> Path:
     _git(repo, "config", "user.email", "test@example.com")
     _git(repo, "commit", "--allow-empty", "-m", "Base")
     return repo
+
+
+def test_resume_start_preserves_checkpoint_progress_and_base(
+    git_repo: Path,
+) -> None:
+    """Restarting Phase 1 must retain recovery data and the canonical base."""
+    base = _git(git_repo, "rev-parse", "HEAD")
+    _git(git_repo, "commit", "--allow-empty", "-m", "Draft")
+    _helper(git_repo, "start", "--mode", "full", "--base", base)
+    _helper(
+        git_repo,
+        "mark",
+        "--phase",
+        "phase3-running",
+        "--completed-batch",
+        "decompose-one",
+        "--commit",
+        "HEAD",
+    )
+    checkpoint_path = (
+        git_repo / ".git-stage-batch" / "decompose-checkpoint.json"
+    )
+    before = json.loads(checkpoint_path.read_text(encoding="utf-8"))
+
+    _helper(git_repo, "start", "--mode", "resume")
+
+    after = json.loads(checkpoint_path.read_text(encoding="utf-8"))
+    assert after["base"] == base
+    assert after["mode"] == before["mode"] == "full"
+    assert after["phase"] == "phase1-running"
+    assert after["completed_batches"] == before["completed_batches"]
+    assert after["commits"] == before["commits"]
+    assert after["events"][:-1] == before["events"]
+    assert after["events"][-1]["previous_phase"] == "phase3-running"
+    status = json.loads(
+        _helper(git_repo, "status", "--json").stdout
+    )
+    assert status["resume_target"] == "phase1"
+
+    saved = checkpoint_path.read_bytes()
+    mismatch = _helper(
+        git_repo,
+        "start",
+        "--mode",
+        "resume",
+        "--base",
+        "HEAD",
+        check=False,
+    )
+    assert mismatch.returncode != 0
+    assert "resume base does not match" in mismatch.stderr
+    assert checkpoint_path.read_bytes() == saved
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("schema", True),
+        ("base", "HEAD"),
+        ("mode", 1),
+        ("phase", None),
+        ("phase", "unknown"),
+        ("events", [None]),
+        ("completed_batches", [1]),
+        ("commits", ["not-an-object"]),
+        ("commits", [{"sha": "missing-commit", "subject": ""}]),
+        ("current_batch", ""),
+    ],
+)
+def test_resume_rejects_invalid_checkpoint_structure(
+    git_repo: Path,
+    field: str,
+    value: object,
+) -> None:
+    """Recovery commands must not bless malformed nested checkpoint state."""
+    _helper(git_repo, "start", "--mode", "full", "--base", "HEAD")
+    checkpoint_path = (
+        git_repo / ".git-stage-batch" / "decompose-checkpoint.json"
+    )
+    checkpoint = json.loads(checkpoint_path.read_text(encoding="utf-8"))
+    checkpoint[field] = value
+    checkpoint_path.write_text(
+        json.dumps(checkpoint),
+        encoding="utf-8",
+    )
+    saved = checkpoint_path.read_bytes()
+
+    resume = _helper(
+        git_repo,
+        "start",
+        "--mode",
+        "resume",
+        check=False,
+    )
+
+    assert resume.returncode != 0
+    assert "invalid decompose checkpoint" in resume.stderr
+    assert checkpoint_path.read_bytes() == saved
+
+
+def test_fresh_start_validates_base_before_clearing_state(
+    git_repo: Path,
+) -> None:
+    """An invalid base must not erase an existing recovery checkpoint."""
+    _helper(git_repo, "start", "--mode", "full", "--base", "HEAD")
+    state_dir = git_repo / ".git-stage-batch"
+    checkpoint_path = state_dir / "decompose-checkpoint.json"
+    plan_path = state_dir / "decompose-plan.json"
+    plan_path.write_text("{}\n", encoding="utf-8")
+    saved_checkpoint = checkpoint_path.read_bytes()
+
+    result = _helper(
+        git_repo,
+        "start",
+        "--mode",
+        "full",
+        "--base",
+        "missing-base",
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "invalid decompose base revision" in result.stderr
+    assert checkpoint_path.read_bytes() == saved_checkpoint
+    assert plan_path.read_text(encoding="utf-8") == "{}\n"
 
 
 def test_failed_atomic_replace_preserves_checkpoint(

--- a/tests/assets/test_decompose_checkpoint.py
+++ b/tests/assets/test_decompose_checkpoint.py
@@ -20,6 +20,14 @@ CODEX_HELPER = (
     / "scripts"
     / "decompose-checkpoint.py"
 )
+CLAUDE_HELPER = (
+    PROJECT_ROOT
+    / "assets"
+    / "claude-skills"
+    / "decompose-and-commit-unstaged-changes"
+    / "scripts"
+    / "decompose-checkpoint.py"
+)
 
 
 def _git(repo: Path, *args: str) -> str:
@@ -61,6 +69,11 @@ def git_repo(tmp_path: Path) -> Path:
     _git(repo, "config", "user.email", "test@example.com")
     _git(repo, "commit", "--allow-empty", "-m", "Base")
     return repo
+
+
+def test_codex_and_claude_decompose_helpers_match() -> None:
+    """Assistant variants should enforce identical checkpoint behavior."""
+    assert CODEX_HELPER.read_bytes() == CLAUDE_HELPER.read_bytes()
 
 
 def test_resume_start_preserves_checkpoint_progress_and_base(

--- a/tests/assets/test_decompose_checkpoint.py
+++ b/tests/assets/test_decompose_checkpoint.py
@@ -188,6 +188,84 @@ def test_fresh_start_validates_base_before_clearing_state(
     assert plan_path.read_text(encoding="utf-8") == "{}\n"
 
 
+def test_start_refuses_symlinked_state_directory(
+    git_repo: Path,
+    tmp_path: Path,
+) -> None:
+    """Fresh cleanup must not follow a workflow-state directory symlink."""
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    sentinel = outside / "keep.txt"
+    sentinel.write_text("keep\n", encoding="utf-8")
+    (git_repo / ".git-stage-batch").symlink_to(
+        outside,
+        target_is_directory=True,
+    )
+
+    state_dir_result = _helper(
+        git_repo,
+        "state-dir",
+        check=False,
+    )
+    result = _helper(
+        git_repo,
+        "start",
+        "--mode",
+        "full",
+        "--base",
+        "HEAD",
+        check=False,
+    )
+
+    assert state_dir_result.returncode != 0
+    assert result.returncode != 0
+    assert (
+        "refusing to use symlinked state path"
+        in state_dir_result.stderr
+    )
+    assert "refusing to use symlinked state path" in result.stderr
+    assert sentinel.read_text(encoding="utf-8") == "keep\n"
+
+
+def test_fresh_start_clears_only_decompose_state(git_repo: Path) -> None:
+    """Fresh decompose state must not delete sibling workflow recovery."""
+    state_dir = git_repo / ".git-stage-batch"
+    refine_history = state_dir / "refine-history"
+    refine_messages = state_dir / "refine-commit-messages"
+    refine_history.mkdir(parents=True)
+    refine_messages.mkdir()
+    (refine_history / "checkpoint.json").write_text(
+        "{}\n",
+        encoding="utf-8",
+    )
+    (refine_messages / "checkpoint.json").write_text(
+        "{}\n",
+        encoding="utf-8",
+    )
+    unrelated = state_dir / "keep.txt"
+    unrelated.write_text("keep\n", encoding="utf-8")
+    for name in (
+        "decompose-plan.json",
+        "decompose-plan.candidate.json",
+        "decompose-narrative.md",
+        "decompose-refinement.md",
+        ".decompose-checkpoint.json.abandoned.tmp",
+    ):
+        (state_dir / name).write_text("stale\n", encoding="utf-8")
+
+    _helper(git_repo, "start", "--mode", "full", "--base", "HEAD")
+
+    assert refine_history.is_dir()
+    assert refine_messages.is_dir()
+    assert unrelated.read_text(encoding="utf-8") == "keep\n"
+    assert (state_dir / "decompose-checkpoint.json").is_file()
+    assert not (state_dir / "decompose-plan.json").exists()
+    assert not (state_dir / "decompose-plan.candidate.json").exists()
+    assert not (state_dir / "decompose-narrative.md").exists()
+    assert not (state_dir / "decompose-refinement.md").exists()
+    assert not list(state_dir.glob(".decompose-checkpoint.json.*.tmp"))
+
+
 def test_failed_atomic_replace_preserves_checkpoint(
     git_repo: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
The bundled Codex and Claude decomposition workflows persist JSON checkpoints
so an interrupted commit decomposition can resume.

Direct writes can truncate the only recovery record, while weak resume, mark,
status, and fresh-start validation can trust malformed or orphaned state.
Fresh starts can also follow a symlinked state directory or delete sibling
workflow recovery records.

This pull request publishes checkpoints through flushed temporary files and
atomic replacement, validates every nested field and referenced Git object
before recovery or mutation, preserves the checkpoint base during resume, and
removes only workflow-owned artifacts from a checked state path. It applies
the contract to both distributed helpers and adds an architecture test that
keeps their implementations identical. The 3,512-test suite, Ruff, dead-code
validation, type-hygiene validation, strict mypy, benchmark smoke, wheel and
source-distribution build/install smoke, and SHA-256 repository tests pass
locally.

Both distributed workflow helpers now preserve trustworthy checkpoint state
or fail before mutation.
