### PR TITLE
batch: Refuse foreign pathless file selections

### DIFF
--- a/src/git_stage_batch/data/batch_file_scope.py
+++ b/src/git_stage_batch/data/batch_file_scope.py
@@ -11,13 +11,40 @@ from ..utils.file_patterns import resolve_gitignore_style_patterns
 from .batch_selected_changes import (
     require_current_selected_batch_binary_file_for_batch,
     require_current_selected_batch_gitlink_file_for_batch,
+    selected_batch_binary_matches_batch,
+    selected_batch_gitlink_matches_batch,
 )
+from .file_review.records import ReviewSource
+from .file_review.state import read_last_file_review_state
 from .selected_change.paths import get_selected_change_file_path
 from .selected_change.store import (
     SelectedChangeKind,
     read_selected_change_kind,
 )
 from .selected_change.file_changes import load_selected_mode_change, read_selected_mode_data
+
+
+def selected_batch_change_matches_batch(batch_name: str) -> bool:
+    """Return whether a selected batch change came from the requested batch."""
+    selected_kind = read_selected_change_kind()
+    if selected_kind == SelectedChangeKind.BATCH_FILE:
+        review_state = read_last_file_review_state()
+        return (
+            review_state is not None
+            and review_state.source == ReviewSource.BATCH
+            and review_state.batch_name == batch_name
+        )
+    if selected_kind == SelectedChangeKind.BATCH_BINARY:
+        return selected_batch_binary_matches_batch(batch_name)
+    if selected_kind == SelectedChangeKind.BATCH_GITLINK:
+        return selected_batch_gitlink_matches_batch(batch_name)
+    if selected_kind == SelectedChangeKind.BATCH_MODE:
+        mode_data = read_selected_mode_data()
+        return (
+            mode_data is not None
+            and mode_data.get("batch_name") == batch_name
+        )
+    return True
 
 
 def resolve_batch_file_scope(
@@ -45,6 +72,14 @@ def resolve_batch_file_scope(
     """
     if file is not None:
         if file == "":
+            if not selected_batch_change_matches_batch(batch_name):
+                raise CommandError(
+                    _(
+                        "The selected file came from a different batch.\n"
+                        "Show a file from batch '{name}' before using a "
+                        "pathless --file."
+                    ).format(name=batch_name)
+                )
             file_to_use = get_selected_change_file_path()
             if file_to_use is None:
                 raise CommandError(

--- a/tests/commands/test_file_review.py
+++ b/tests/commands/test_file_review.py
@@ -2132,6 +2132,22 @@ def test_pathless_include_from_other_batch_after_full_batch_review_refuses(paged
         command_include_from_batch("other-batch", line_ids=line_spec)
 
 
+def test_pathless_file_include_from_other_batch_after_review_refuses(
+    paged_batch_repo,
+    monkeypatch,
+    capsys,
+):
+    _force_one_change_per_page(monkeypatch)
+    command_apply_from_batch("cleanup", file="file.txt")
+    command_include_to_batch("other-batch", file="file.txt", quiet=True)
+    capsys.readouterr()
+    command_show_from_batch("cleanup", file="file.txt", page="all")
+    capsys.readouterr()
+
+    with pytest.raises(CommandError, match="came from a different batch"):
+        command_include_from_batch("other-batch", file="")
+
+
 def test_show_from_batch_file_defaults_to_page_review_and_persists_state(paged_batch_repo, monkeypatch, capsys):
     _force_one_change_per_page(monkeypatch)
 

--- a/tests/data/test_batch_file_scope.py
+++ b/tests/data/test_batch_file_scope.py
@@ -1,0 +1,96 @@
+"""Tests for session-aware batch file scope resolution."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from git_stage_batch.data import batch_file_scope
+from git_stage_batch.data.file_review.records import ReviewSource
+from git_stage_batch.data.selected_change.store import SelectedChangeKind
+from git_stage_batch.exceptions import CommandError
+
+
+def test_selected_batch_file_matches_its_review_source(monkeypatch):
+    monkeypatch.setattr(
+        batch_file_scope,
+        "read_selected_change_kind",
+        lambda: SelectedChangeKind.BATCH_FILE,
+    )
+    monkeypatch.setattr(
+        batch_file_scope,
+        "read_last_file_review_state",
+        lambda: Mock(source=ReviewSource.BATCH, batch_name="selected"),
+    )
+
+    assert batch_file_scope.selected_batch_change_matches_batch("selected")
+    assert not batch_file_scope.selected_batch_change_matches_batch("other")
+
+
+def test_selected_batch_mode_matches_its_persisted_source(monkeypatch):
+    monkeypatch.setattr(
+        batch_file_scope,
+        "read_selected_change_kind",
+        lambda: SelectedChangeKind.BATCH_MODE,
+    )
+    monkeypatch.setattr(
+        batch_file_scope,
+        "read_selected_mode_data",
+        lambda: {"batch_name": "selected"},
+    )
+
+    assert batch_file_scope.selected_batch_change_matches_batch("selected")
+    assert not batch_file_scope.selected_batch_change_matches_batch("other")
+
+
+def test_live_selection_is_available_as_a_batch_path(monkeypatch):
+    monkeypatch.setattr(
+        batch_file_scope,
+        "read_selected_change_kind",
+        lambda: SelectedChangeKind.HUNK,
+    )
+
+    assert batch_file_scope.selected_batch_change_matches_batch("batch")
+
+
+def test_pathless_batch_scope_refuses_selection_from_other_batch(monkeypatch):
+    selected_path = Mock(return_value="selected.txt")
+    monkeypatch.setattr(
+        batch_file_scope,
+        "selected_batch_change_matches_batch",
+        lambda batch_name: False,
+    )
+    monkeypatch.setattr(
+        batch_file_scope,
+        "get_selected_change_file_path",
+        selected_path,
+    )
+
+    with pytest.raises(CommandError, match="came from a different batch"):
+        batch_file_scope.resolve_batch_file_scope(
+            "requested",
+            {"selected.txt": {}},
+            file="",
+        )
+
+    selected_path.assert_not_called()
+
+
+def test_pathless_batch_scope_uses_matching_selected_path(monkeypatch):
+    monkeypatch.setattr(
+        batch_file_scope,
+        "selected_batch_change_matches_batch",
+        lambda batch_name: True,
+    )
+    monkeypatch.setattr(
+        batch_file_scope,
+        "get_selected_change_file_path",
+        lambda: "selected.txt",
+    )
+
+    resolved = batch_file_scope.resolve_batch_file_scope(
+        "requested",
+        {"selected.txt": {}, "other.txt": {}},
+        file="",
+    )
+
+    assert list(resolved) == ["selected.txt"]


### PR DESCRIPTION
Saved-batch commands let a pathless `--file` reuse the path from the
currently selected change.

Users can review a file from one batch and then target another batch with
`--file` but no path. If both batches contain that path, the command can act
on content the user did not review.

This pull request checks the selected change's source batch for text, binary,
submodule, and mode selections before resolving a pathless saved-batch scope.
It adds resolver coverage for matching and foreign sources and command
coverage that refuses an include after a different batch was reviewed. The
3,518-test suite with 12 skips, Ruff, dead-code validation, type-hygiene
validation, strict mypy, benchmark smoke, and wheel and source-distribution
build/install smoke pass locally.

Pathless saved-batch actions now fail before dispatch when the selected path
belongs to another batch.
