### PR TITLE
show: Preserve resolved batch file lists

### DIFF
--- a/src/git_stage_batch/cli/show_dispatch.py
+++ b/src/git_stage_batch/cli/show_dispatch.py
@@ -18,6 +18,7 @@ from .replacement_input import resolve_replacement_text
 
 
 class _ShowFromOptions(TypedDict, total=False):
+    file_paths: list[str]
     patterns: list[str] | None
     selectable: bool
     page: str | None
@@ -90,7 +91,7 @@ def _dispatch_show_from_batch(
             raise CommandError(_("Cannot use --lines with multiple files."))
         if replacement_requested:
             raise CommandError(_("`show --as` requires exactly one resolved file."))
-        options["patterns"] = args.file_patterns
+        options["file_paths"] = list(resolved_file_scope.files)
         command_show_from_batch(args.from_batch, args.line_ids, **options)
     else:
         command_show_from_batch(

--- a/src/git_stage_batch/commands/show_from.py
+++ b/src/git_stage_batch/commands/show_from.py
@@ -9,6 +9,7 @@ from .batch_source import candidate_preview_action as _candidate_preview_action
 from .batch_source import file_display_action as _file_display_action
 from .batch_source import file_list_action as _file_list_action
 from .batch_source import replacement_previews as _replacement_previews
+from ..batch.state.metadata_types import BatchFileMetadataDict
 from ..batch.state.validation import read_validated_batch_metadata
 from ..core.replacement import ReplacementPayload
 from ..batch.selection import require_single_file_context_for_line_selection
@@ -28,11 +29,26 @@ def _batch_source_args(batch_name: str) -> str:
     return f" --from {shlex.quote(batch_name)}"
 
 
+def _resolve_exact_file_paths(
+    batch_name: str,
+    all_files: dict[str, BatchFileMetadataDict],
+    file_paths: list[str],
+) -> dict[str, BatchFileMetadataDict]:
+    """Resolve exact paths through the command's normal missing-file checks."""
+    resolved: dict[str, BatchFileMetadataDict] = {}
+    for file_path in file_paths:
+        resolved.update(
+            resolve_batch_file_scope(batch_name, all_files, file_path)
+        )
+    return resolved
+
+
 def command_show_from_batch(
     batch_name: str,
     line_ids: Optional[str] = None,
     file: Optional[str] = None,
     patterns: Optional[list[str]] = None,
+    file_paths: list[str] | None = None,
     selectable: bool = True,
     page: str | None = None,
     porcelain: bool = False,
@@ -46,6 +62,7 @@ def command_show_from_batch(
         file: Optional file path to show from batch.
               If None, shows all files in batch.
         patterns: Optional gitignore-style file patterns to filter batch files.
+        file_paths: Optional exact file paths already resolved by CLI dispatch.
         selectable: If True, cache the displayed file for later line operations.
         page: Optional file-review page selection.
     """
@@ -69,7 +86,11 @@ def command_show_from_batch(
     all_files = metadata.get("files", {})
 
     # Resolve file scope (for consistent --file handling across commands)
-    files = resolve_batch_file_scope(batch_name, all_files, file, patterns)
+    files = (
+        _resolve_exact_file_paths(batch_name, all_files, file_paths)
+        if file_paths is not None
+        else resolve_batch_file_scope(batch_name, all_files, file, patterns)
+    )
 
     # Parse line selection and enforce single-file context
     selected_ids = require_single_file_context_for_line_selection(

--- a/tests/cli/test_argument_parser.py
+++ b/tests/cli/test_argument_parser.py
@@ -392,6 +392,34 @@ def test_show_from_no_advance_peeks_without_selecting(monkeypatch):
     )
 
 
+def test_show_from_repeated_explicit_files_passes_exact_resolved_scope(monkeypatch):
+    mock_command = Mock()
+    monkeypatch.setattr(show_dispatch, "command_show_from_batch", mock_command)
+    _mock_batch_files(monkeypatch, ["a.py", "selected.py", "other.py"])
+
+    args = parse_command_line(
+        [
+            "show",
+            "--from",
+            "batch",
+            "--file",
+            "a.py",
+            "--file",
+            "selected.py",
+        ],
+        quiet=True,
+    )
+
+    assert args is not None
+    args.func(args)
+    mock_command.assert_called_once_with(
+        "batch",
+        None,
+        page=None,
+        file_paths=["a.py", "selected.py"],
+    )
+
+
 def test_show_page_accepts_single_file_pattern_match(monkeypatch):
     mock_command = Mock()
     monkeypatch.setattr(show_dispatch, "command_show", mock_command)

--- a/tests/commands/test_show_from.py
+++ b/tests/commands/test_show_from.py
@@ -70,6 +70,31 @@ class TestCommandShowFromBatch:
         assert "content" in captured.out
         assert "[#1]" in captured.out  # Check for line ID annotation
 
+    def test_show_from_exact_file_paths_filters_batch_list(self, temp_git_repo, capsys):
+        """Resolved file paths should not expand back to the full batch."""
+        for file_name in ("first.txt", "second.txt", "omitted.txt"):
+            (temp_git_repo / file_name).write_text(f"{file_name}\n")
+
+        command_start()
+        for file_name in ("first.txt", "second.txt", "omitted.txt"):
+            command_include_to_batch(
+                "test-batch",
+                file=file_name,
+                quiet=True,
+            )
+        capsys.readouterr()
+
+        command_show_from_batch(
+            "test-batch",
+            file_paths=["first.txt", "second.txt"],
+            selectable=False,
+        )
+
+        captured = capsys.readouterr()
+        assert "first.txt" in captured.out
+        assert "second.txt" in captured.out
+        assert "omitted.txt" not in captured.out
+
     def test_show_from_empty_added_text_file_is_visible(self, temp_git_repo, capsys):
         """Empty text lifecycle entries should not look like missing batch changes."""
         (temp_git_repo / "empty.txt").write_bytes(b"")


### PR DESCRIPTION
The `show` command resolves `--file` and `--files` arguments against
saved-batch metadata before choosing a single-file view or a multi-file list.

When users provide multiple `--file` values, multi-file dispatch can discard
the resolved paths when no `--files` patterns exist. Saved-batch display then
expands the request to every file in the batch.

This pull request passes exact resolved paths into saved-batch display and
validates each path through the normal missing-file checks. Dispatch and
command tests prove that repeated explicit paths are preserved and an
unrequested third batch file is omitted. The 3,520-test suite with 12 skips,
Ruff, dead-code validation, type-hygiene validation, strict mypy, benchmark
smoke, and wheel and source-distribution build/install smoke pass locally.

Multi-file saved-batch display now preserves the requested file list through
rendered output.
