### PR TITLE
cli: Combine selected and explicit --file paths

### DIFF
--- a/src/git_stage_batch/cli/apply_dispatch.py
+++ b/src/git_stage_batch/cli/apply_dispatch.py
@@ -7,6 +7,7 @@ import shlex
 
 from ..commands.apply_from import command_apply_from_batch
 from ..commands.file_scope.multi_file_actions import run_for_each_resolved_file
+from ..data.file_review.records import FileReviewAction
 from .file_scope import resolve_batch_file_scope
 
 
@@ -16,6 +17,8 @@ def dispatch_apply_command(args: argparse.Namespace) -> None:
         args.from_batch,
         args.file,
         args.file_patterns,
+        selected_action=FileReviewAction.APPLY_FROM_BATCH,
+        command_name="apply",
     )
     line_ids = args.line_ids if hasattr(args, "line_ids") else None
     run_for_each_resolved_file(

--- a/src/git_stage_batch/cli/discard_dispatch.py
+++ b/src/git_stage_batch/cli/discard_dispatch.py
@@ -19,6 +19,7 @@ from ..commands.file_scope.multi_file_actions import (
     discard_to_batch_each_resolved_file,
     run_for_each_resolved_file,
 )
+from ..data.file_review.records import FileReviewAction
 from ..exceptions import CommandError
 from ..i18n import _
 from .file_scope import resolve_batch_file_scope, resolve_live_file_scope
@@ -29,7 +30,11 @@ def _dispatch_discard_replacement(args: argparse.Namespace) -> None:
     if args.as_text is not None and args.as_stdin:
         raise CommandError(_("Cannot use `--as` and `--as-stdin` together."))
     if args.to_batch and args.line_ids and not args.from_batch:
-        resolved_live_scope = resolve_live_file_scope(args.file, args.file_patterns)
+        resolved_live_scope = resolve_live_file_scope(
+            args.file,
+            args.file_patterns,
+            selected_action=FileReviewAction.DISCARD_TO_BATCH,
+        )
         resolved_file = resolved_live_scope.require_single_file(
             _("Cannot use --lines with multiple files.")
         )
@@ -48,7 +53,11 @@ def _dispatch_discard_replacement(args: argparse.Namespace) -> None:
         and args.from_batch is None
         and args.line_ids is None
     ):
-        resolved_live_scope = resolve_live_file_scope(args.file, args.file_patterns)
+        resolved_live_scope = resolve_live_file_scope(
+            args.file,
+            args.file_patterns,
+            selected_action=FileReviewAction.DISCARD,
+        )
         if resolved_live_scope.is_implicit:
             raise CommandError(
                 _(
@@ -89,6 +98,8 @@ def dispatch_discard_command(args: argparse.Namespace) -> None:
             args.from_batch,
             args.file,
             args.file_patterns,
+            selected_action=FileReviewAction.DISCARD_FROM_BATCH,
+            command_name="discard",
         )
         run_for_each_resolved_file(
             resolved_batch_scope,
@@ -102,7 +113,11 @@ def dispatch_discard_command(args: argparse.Namespace) -> None:
             worktree_paths=resolved_batch_scope.files,
         )
     elif args.to_batch:
-        resolved_live_scope = resolve_live_file_scope(args.file, args.file_patterns)
+        resolved_live_scope = resolve_live_file_scope(
+            args.file,
+            args.file_patterns,
+            selected_action=FileReviewAction.DISCARD_TO_BATCH,
+        )
         if resolved_live_scope.is_multiple and args.line_ids is None:
             discard_to_batch_each_resolved_file(
                 args.to_batch,
@@ -123,7 +138,11 @@ def dispatch_discard_command(args: argparse.Namespace) -> None:
                 worktree_paths=resolved_live_scope.files,
             )
     elif args.line_ids:
-        resolved_live_scope = resolve_live_file_scope(args.file, args.file_patterns)
+        resolved_live_scope = resolve_live_file_scope(
+            args.file,
+            args.file_patterns,
+            selected_action=FileReviewAction.DISCARD,
+        )
         resolved_file = resolved_live_scope.require_single_file(
             _("Cannot use --lines with multiple files.")
         )
@@ -133,7 +152,11 @@ def dispatch_discard_command(args: argparse.Namespace) -> None:
             auto_advance=args.auto_advance,
         )
     else:
-        resolved_live_scope = resolve_live_file_scope(args.file, args.file_patterns)
+        resolved_live_scope = resolve_live_file_scope(
+            args.file,
+            args.file_patterns,
+            selected_action=FileReviewAction.DISCARD,
+        )
         if not resolved_live_scope.is_implicit:
             if resolved_live_scope.is_multiple:
                 discard_each_resolved_file(

--- a/src/git_stage_batch/cli/file_arguments.py
+++ b/src/git_stage_batch/cli/file_arguments.py
@@ -50,14 +50,14 @@ def normalize_parsed_file_arguments(args: argparse.Namespace) -> None:
         return
 
     file_groups = args.file
-    if file_groups and not file_groups[-1]:
+    if all(not group for group in file_groups):
         args.file = ""
         return
 
     file_values = [
         value
         for group in file_groups
-        for value in group
+        for value in (group or [""])
     ]
 
     if len(file_values) == 1:

--- a/src/git_stage_batch/cli/file_scope.py
+++ b/src/git_stage_batch/cli/file_scope.py
@@ -7,9 +7,21 @@ from dataclasses import dataclass
 from enum import Enum
 
 from ..batch.state.query import read_batch_metadata
+from ..batch.state.metadata_types import BatchFileMetadataDict
 from ..batch.source.selector import batch_name_for_source_lookup
 from ..batch.state.batch_names import batch_exists
+from ..data.batch_file_scope import (
+    resolve_batch_file_scope as resolve_stored_batch_file_scope,
+    resolve_current_batch_atomic_file_scope,
+)
 from ..data.file_tracking import list_untracked_files
+from ..data.file_review.action_refusals import (
+    refuse_ambiguous_bare_action_after_partial_file_review,
+    refuse_live_action_for_batch_selection,
+)
+from ..data.file_review.action_scope import resolve_batch_source_action_scope
+from ..data.file_review.records import FileReviewAction
+from ..data.selected_change.paths import get_selected_change_file_path
 from ..exceptions import CommandError
 from ..i18n import _
 from ..utils.file_patterns import (
@@ -76,9 +88,13 @@ def _resolve_file_patterns(
     file_patterns: list[str] | None,
 ) -> list[str] | None:
     """Return combined pattern arguments, preserving pathless --file."""
-    if file_arg == "":
+    if file_arg == "" or (
+        isinstance(file_arg, list)
+        and "" in file_arg
+    ):
         if file_patterns is not None:
             raise CommandError(_("Cannot use --file together with --files."))
+    if file_arg == "":
         return None
 
     patterns: list[str] = []
@@ -114,10 +130,11 @@ def _resolve_file_argument_patterns(
     candidates: Sequence[str],
     file_arg: FileArgument,
     file_patterns: list[str] | None,
+    *,
+    selected_file: str | None = None,
 ) -> tuple[list[str], list[str]]:
     """Resolve --file/--files values against candidates with exact --file fallback."""
     file_values = _file_arg_values(file_arg)
-    display_patterns = [*file_values, *(file_patterns or [])]
     candidate_by_path = {
         _normalize_file_argument_path(candidate): candidate
         for candidate in candidates
@@ -125,13 +142,29 @@ def _resolve_file_argument_patterns(
 
     exact_files: list[str] = []
     pattern_values: list[str] = []
-    for value in file_values:
+    display_patterns: list[str] = []
+    for raw_value in file_values:
+        value = raw_value
+        if value == "":
+            if selected_file is None:
+                raise CommandError(
+                    _("No selected hunk. Run 'show' first or specify file path.")
+                )
+            value = selected_file
+            if _normalize_file_argument_path(value) not in candidate_by_path:
+                raise CommandError(
+                    _("Selected file is not available in this file scope: {file}").format(
+                        file=value,
+                    )
+                )
+        display_patterns.append(value)
         exact_file = candidate_by_path.get(_normalize_file_argument_path(value))
         if exact_file is not None:
             exact_files.append(exact_file)
         else:
             pattern_values.append(value)
 
+    display_patterns.extend(file_patterns or [])
     pattern_values.extend(file_patterns or [])
     resolved_patterns = (
         resolve_gitignore_style_patterns(candidates, pattern_values)
@@ -142,11 +175,64 @@ def _resolve_file_argument_patterns(
     return resolved_files, display_patterns
 
 
+def _has_pathless_file_marker(file_arg: FileArgument) -> bool:
+    """Return whether a multi-value file argument requests the selected file."""
+    return isinstance(file_arg, list) and "" in file_arg
+
+
+def _resolve_live_selected_file(
+    action: FileReviewAction | None,
+) -> str | None:
+    """Resolve a selected live file without bypassing pathless-action guards."""
+    if action is not None:
+        refuse_live_action_for_batch_selection(action)
+        refuse_ambiguous_bare_action_after_partial_file_review(action)
+    return get_selected_change_file_path()
+
+
+def _resolve_batch_selected_file(
+    batch_name: str,
+    all_files: dict[str, BatchFileMetadataDict],
+    action: FileReviewAction | None,
+    command_name: str | None,
+) -> str | None:
+    """Resolve a selected batch file through the existing pathless guards."""
+    selected_file: str | None = ""
+    if action is not None:
+        if command_name is None:
+            raise ValueError(
+                "command_name is required for a mutating batch file scope"
+            )
+        scope_resolution = resolve_batch_source_action_scope(
+            action,
+            command_name=command_name,
+            batch_name=batch_name,
+            line_ids=None,
+            file="",
+            patterns=None,
+        )
+        selected_file = scope_resolution.file
+    selected_file = resolve_current_batch_atomic_file_scope(
+        batch_name,
+        all_files,
+        selected_file,
+        None,
+        None,
+    )
+    resolved_files = resolve_stored_batch_file_scope(
+        batch_name,
+        all_files,
+        selected_file,
+    )
+    return next(iter(resolved_files), None)
+
+
 def resolve_live_file_scope(
     file_arg: FileArgument,
     file_patterns: list[str] | None,
     *,
     include_staged: bool = False,
+    selected_action: FileReviewAction | None = None,
 ) -> FileScope:
     """Resolve single-file or pattern-based live file scope."""
     resolved_patterns = _resolve_file_patterns(file_arg, file_patterns)
@@ -157,10 +243,16 @@ def resolve_live_file_scope(
     if include_staged:
         candidate_files.extend(list_staged_files())
     candidate_files = list(dict.fromkeys(candidate_files))
+    selected_file = (
+        _resolve_live_selected_file(selected_action)
+        if _has_pathless_file_marker(file_arg)
+        else None
+    )
     resolved_files, display_patterns = _resolve_file_argument_patterns(
         candidate_files,
         file_arg,
         file_patterns,
+        selected_file=selected_file,
     )
     if not resolved_files:
         raise CommandError(
@@ -175,6 +267,9 @@ def resolve_batch_file_scope(
     batch_name: str,
     file_arg: FileArgument,
     file_patterns: list[str] | None,
+    *,
+    selected_action: FileReviewAction | None = None,
+    command_name: str | None = None,
 ) -> FileScope:
     """Resolve single-file or pattern-based batch file scope."""
     lookup_batch_name = batch_name_for_source_lookup(batch_name)
@@ -185,10 +280,22 @@ def resolve_batch_file_scope(
         raise CommandError(_("Batch '{name}' does not exist").format(name=lookup_batch_name))
 
     metadata = read_batch_metadata(lookup_batch_name)
+    all_files = metadata.get("files", {})
+    selected_file = (
+        _resolve_batch_selected_file(
+            lookup_batch_name,
+            all_files,
+            selected_action,
+            command_name,
+        )
+        if _has_pathless_file_marker(file_arg)
+        else None
+    )
     resolved_files, display_patterns = _resolve_file_argument_patterns(
-        list(metadata.get("files", {}).keys()),
+        list(all_files.keys()),
         file_arg,
         file_patterns,
+        selected_file=selected_file,
     )
     if not resolved_files:
         raise CommandError(

--- a/src/git_stage_batch/cli/include_dispatch.py
+++ b/src/git_stage_batch/cli/include_dispatch.py
@@ -18,6 +18,7 @@ from ..commands.include import (
     command_include_to_batch,
 )
 from ..commands.include_from import command_include_from_batch
+from ..data.file_review.records import FileReviewAction
 from ..exceptions import CommandError
 from ..i18n import _
 from .file_scope import resolve_batch_file_scope, resolve_live_file_scope
@@ -39,6 +40,8 @@ def _dispatch_include_replacement(args: argparse.Namespace) -> None:
             args.from_batch,
             args.file,
             args.file_patterns,
+            selected_action=FileReviewAction.INCLUDE_FROM_BATCH,
+            command_name="include",
         )
         resolved_file = resolved_batch_scope.require_single_file(
             _("Cannot use --lines with multiple files.")
@@ -52,7 +55,11 @@ def _dispatch_include_replacement(args: argparse.Namespace) -> None:
         )
         return
     if args.line_ids and not args.from_batch and not args.to_batch:
-        resolved_live_scope = resolve_live_file_scope(args.file, args.file_patterns)
+        resolved_live_scope = resolve_live_file_scope(
+            args.file,
+            args.file_patterns,
+            selected_action=FileReviewAction.INCLUDE,
+        )
         resolved_file = resolved_live_scope.require_single_file(
             _("Cannot use --lines with multiple files.")
         )
@@ -74,6 +81,7 @@ def _dispatch_include_replacement(args: argparse.Namespace) -> None:
             args.file,
             args.file_patterns,
             include_staged=True,
+            selected_action=FileReviewAction.INCLUDE,
         )
         if resolved_live_scope.is_implicit:
             raise CommandError(
@@ -116,6 +124,8 @@ def dispatch_include_command(args: argparse.Namespace) -> None:
             args.from_batch,
             args.file,
             args.file_patterns,
+            selected_action=FileReviewAction.INCLUDE_FROM_BATCH,
+            command_name="include",
         )
         run_for_each_resolved_file(
             resolved_batch_scope,
@@ -129,7 +139,11 @@ def dispatch_include_command(args: argparse.Namespace) -> None:
             worktree_paths=resolved_batch_scope.files,
         )
     elif args.to_batch:
-        resolved_live_scope = resolve_live_file_scope(args.file, args.file_patterns)
+        resolved_live_scope = resolve_live_file_scope(
+            args.file,
+            args.file_patterns,
+            selected_action=FileReviewAction.INCLUDE_TO_BATCH,
+        )
         run_for_each_resolved_file(
             resolved_live_scope,
             lambda file: command_include_to_batch(
@@ -142,7 +156,11 @@ def dispatch_include_command(args: argparse.Namespace) -> None:
             undo_operation=f"include --to {shlex.quote(args.to_batch)}",
         )
     elif args.line_ids:
-        resolved_live_scope = resolve_live_file_scope(args.file, args.file_patterns)
+        resolved_live_scope = resolve_live_file_scope(
+            args.file,
+            args.file_patterns,
+            selected_action=FileReviewAction.INCLUDE,
+        )
         resolved_file = resolved_live_scope.require_single_file(
             _("Cannot use --lines with multiple files.")
         )
@@ -152,7 +170,11 @@ def dispatch_include_command(args: argparse.Namespace) -> None:
             auto_advance=args.auto_advance,
         )
     else:
-        resolved_live_scope = resolve_live_file_scope(args.file, args.file_patterns)
+        resolved_live_scope = resolve_live_file_scope(
+            args.file,
+            args.file_patterns,
+            selected_action=FileReviewAction.INCLUDE,
+        )
         if resolved_live_scope.is_multiple:
             include_each_resolved_file(
                 list(resolved_live_scope.files),

--- a/src/git_stage_batch/cli/reset_dispatch.py
+++ b/src/git_stage_batch/cli/reset_dispatch.py
@@ -7,6 +7,7 @@ import shlex
 
 from ..commands.file_scope.multi_file_actions import run_for_each_resolved_file
 from ..commands.reset import command_reset_from_batch
+from ..data.file_review.records import FileReviewAction
 from .file_scope import resolve_batch_file_scope
 
 
@@ -16,6 +17,8 @@ def dispatch_reset_command(args: argparse.Namespace) -> None:
         args.from_batch,
         args.file,
         args.file_patterns,
+        selected_action=FileReviewAction.RESET_FROM_BATCH,
+        command_name="reset",
     )
     command_parts = ["reset", "--from", shlex.quote(args.from_batch)]
     if args.to_batch is not None:

--- a/src/git_stage_batch/cli/skip_dispatch.py
+++ b/src/git_stage_batch/cli/skip_dispatch.py
@@ -6,13 +6,18 @@ import argparse
 
 from ..commands.file_scope.multi_file_actions import skip_each_resolved_file
 from ..commands.skip import command_skip, command_skip_file, command_skip_line
+from ..data.file_review.records import FileReviewAction
 from ..i18n import _
 from .file_scope import resolve_live_file_scope
 
 
 def dispatch_skip_command(args: argparse.Namespace) -> None:
     """Dispatch parsed skip arguments."""
-    resolved_file_scope = resolve_live_file_scope(args.file, args.file_patterns)
+    resolved_file_scope = resolve_live_file_scope(
+        args.file,
+        args.file_patterns,
+        selected_action=FileReviewAction.SKIP,
+    )
     if args.line_ids:
         resolved_file = resolved_file_scope.require_single_file(
             _("Cannot use --lines with multiple files.")

--- a/tests/cli/test_argument_parser.py
+++ b/tests/cli/test_argument_parser.py
@@ -858,6 +858,93 @@ def test_parse_command_line_include_with_files_dispatches_per_file(monkeypatch):
     )
 
 
+def test_parse_command_line_include_combines_explicit_and_selected_files(monkeypatch):
+    """A pathless repeated --file should add the selected file."""
+    mock_command = Mock()
+    monkeypatch.setattr(
+        include_dispatch,
+        "include_each_resolved_file",
+        mock_command,
+    )
+    _mock_live_file_candidates(monkeypatch, ["a.py", "selected.py"])
+    monkeypatch.setattr(
+        file_scope,
+        "get_selected_change_file_path",
+        lambda: "selected.py",
+    )
+
+    args = parse_command_line(
+        ["include", "--file", "a.py", "--file"],
+        quiet=True,
+    )
+
+    assert args is not None
+    args.func(args)
+    mock_command.assert_called_once_with(
+        ["a.py", "selected.py"],
+        auto_advance=None,
+    )
+
+
+def test_parse_command_line_include_preserves_pathless_action_refusal(monkeypatch):
+    mock_command = Mock()
+    monkeypatch.setattr(
+        include_dispatch,
+        "include_each_resolved_file",
+        mock_command,
+    )
+    _mock_live_file_candidates(monkeypatch, ["a.py", "selected.py"])
+    monkeypatch.setattr(
+        file_scope,
+        "get_selected_change_file_path",
+        lambda: "selected.py",
+    )
+
+    def refuse_batch_selection(action):
+        raise CommandError("selected file came from a batch")
+
+    monkeypatch.setattr(
+        file_scope,
+        "refuse_live_action_for_batch_selection",
+        refuse_batch_selection,
+    )
+
+    args = parse_command_line(
+        ["include", "--file", "a.py", "--file"],
+        quiet=True,
+    )
+
+    assert args is not None
+    with pytest.raises(CommandError, match="came from a batch"):
+        args.func(args)
+    mock_command.assert_not_called()
+
+
+def test_parse_command_line_include_from_refuses_foreign_selected_batch(monkeypatch):
+    mock_command = Mock()
+    monkeypatch.setattr(
+        include_dispatch,
+        "command_include_from_batch",
+        mock_command,
+    )
+    _mock_batch_files(monkeypatch, ["a.py", "selected.py"])
+    monkeypatch.setattr(
+        stored_batch_file_scope,
+        "selected_batch_change_matches_batch",
+        lambda batch_name: False,
+    )
+
+    args = parse_command_line(
+        ["include", "--from", "batch", "--file", "a.py", "--file"],
+        quiet=True,
+    )
+
+    assert args is not None
+    with pytest.raises(CommandError, match="came from a different batch"):
+        args.func(args)
+    mock_command.assert_not_called()
+
+
 def test_parse_command_line_include_rejects_files_without_patterns():
     """--files should still require at least one pattern."""
     assert parse_command_line(["include", "--files"], quiet=True) is None
@@ -1087,18 +1174,18 @@ def test_parse_command_line_skip_with_file_path():
     assert callable(args.func)
 
 
-def test_parse_command_line_skip_repeated_file_uses_argument_bearing_value():
-    """Repeated --file should not make an earlier pathless use conflict."""
+def test_parse_command_line_skip_repeated_file_keeps_selected_marker_first():
+    """An earlier pathless --file should contribute the selected file."""
     args = parse_command_line(["skip", "--file", "--file", "src/debug.py"], quiet=True)
     assert args is not None
-    assert args.file == "src/debug.py"
+    assert args.file == ["", "src/debug.py"]
 
 
-def test_parse_command_line_skip_repeated_file_keeps_final_pathless_value():
-    """A final pathless --file should keep selected-file behavior."""
+def test_parse_command_line_skip_repeated_file_keeps_selected_marker_last():
+    """A final pathless --file should add the selected file to explicit paths."""
     args = parse_command_line(["skip", "--file", "src/debug.py", "--file"], quiet=True)
     assert args is not None
-    assert args.file == ""
+    assert args.file == ["src/debug.py", ""]
 
 
 def test_parse_command_line_skip_with_line():

--- a/tests/cli/test_argument_parser.py
+++ b/tests/cli/test_argument_parser.py
@@ -19,6 +19,8 @@ from git_stage_batch.cli import (
     skip_dispatch,
 )
 from git_stage_batch.cli.argument_parser import parse_command_line
+from git_stage_batch.data import batch_file_scope as stored_batch_file_scope
+from git_stage_batch.data.file_review.records import FileReviewAction
 from git_stage_batch.exceptions import CommandError
 
 
@@ -80,6 +82,55 @@ def test_resolve_live_file_scope_resolves_file_argument_as_pattern(monkeypatch):
     assert scope.optional_file() == "src/parser.py"
 
 
+def test_resolve_live_file_scope_combines_explicit_and_selected_files(monkeypatch):
+    _mock_live_file_candidates(monkeypatch, ["src/parser.py", "notes.txt"])
+    monkeypatch.setattr(
+        file_scope,
+        "get_selected_change_file_path",
+        lambda: "notes.txt",
+    )
+
+    scope = file_scope.resolve_live_file_scope(["src/parser.py", ""], None)
+
+    assert scope.kind is file_scope.FileScopeKind.PATTERN
+    assert scope.files == ("src/parser.py", "notes.txt")
+
+
+def test_resolve_live_file_scope_runs_pathless_action_guards(monkeypatch):
+    _mock_live_file_candidates(monkeypatch, ["src/parser.py", "notes.txt"])
+    live_source_guard = Mock()
+    partial_review_guard = Mock()
+    monkeypatch.setattr(
+        file_scope,
+        "refuse_live_action_for_batch_selection",
+        live_source_guard,
+    )
+    monkeypatch.setattr(
+        file_scope,
+        "refuse_ambiguous_bare_action_after_partial_file_review",
+        partial_review_guard,
+    )
+    monkeypatch.setattr(
+        file_scope,
+        "get_selected_change_file_path",
+        lambda: "notes.txt",
+    )
+
+    file_scope.resolve_live_file_scope(
+        ["src/parser.py", ""],
+        None,
+        selected_action=FileReviewAction.INCLUDE,
+    )
+
+    live_source_guard.assert_called_once_with(FileReviewAction.INCLUDE)
+    partial_review_guard.assert_called_once_with(FileReviewAction.INCLUDE)
+
+
+def test_resolve_live_file_scope_rejects_mixed_pathless_file_and_files(monkeypatch):
+    with pytest.raises(CommandError, match="Cannot use --file together with --files"):
+        file_scope.resolve_live_file_scope(["src/parser.py", ""], ["*.txt"])
+
+
 def test_resolve_live_file_scope_keeps_single_pattern_scope_kind(monkeypatch):
     monkeypatch.setattr(file_scope, "list_changed_files", lambda: ["src/parser.py", "notes.txt"])
     monkeypatch.setattr(file_scope, "list_untracked_files", lambda: [])
@@ -125,6 +176,69 @@ def test_resolve_batch_file_scope_resolves_file_argument_as_pattern(monkeypatch)
     assert scope.kind is file_scope.FileScopeKind.PATTERN
     assert scope.files == ("src/parser.py",)
     assert scope.optional_file() == "src/parser.py"
+
+
+def test_resolve_batch_file_scope_combines_explicit_and_selected_files(monkeypatch):
+    _mock_batch_files(monkeypatch, ["src/parser.py", "notes.txt"])
+    monkeypatch.setattr(
+        stored_batch_file_scope,
+        "get_selected_change_file_path",
+        lambda: "notes.txt",
+    )
+
+    scope = file_scope.resolve_batch_file_scope(
+        "batch",
+        ["src/parser.py", ""],
+        None,
+    )
+
+    assert scope.kind is file_scope.FileScopeKind.PATTERN
+    assert scope.files == ("src/parser.py", "notes.txt")
+
+
+def test_resolve_batch_file_scope_refuses_foreign_batch_selection(monkeypatch):
+    _mock_batch_files(monkeypatch, ["src/parser.py", "notes.txt"])
+    monkeypatch.setattr(
+        stored_batch_file_scope,
+        "selected_batch_change_matches_batch",
+        lambda batch_name: False,
+    )
+
+    with pytest.raises(CommandError, match="came from a different batch"):
+        file_scope.resolve_batch_file_scope(
+            "batch",
+            ["src/parser.py", ""],
+            None,
+            selected_action=FileReviewAction.INCLUDE_FROM_BATCH,
+            command_name="include",
+        )
+
+
+def test_resolve_batch_file_scope_revalidates_atomic_selection(monkeypatch):
+    _mock_batch_files(monkeypatch, ["src/parser.py", "notes.txt"])
+    monkeypatch.setattr(
+        file_scope,
+        "resolve_batch_source_action_scope",
+        lambda *args, **kwargs: Mock(file=""),
+    )
+
+    def refuse_stale_selection(*args, **kwargs):
+        raise CommandError("selected batch binary no longer matches")
+
+    monkeypatch.setattr(
+        file_scope,
+        "resolve_current_batch_atomic_file_scope",
+        refuse_stale_selection,
+    )
+
+    with pytest.raises(CommandError, match="no longer matches"):
+        file_scope.resolve_batch_file_scope(
+            "batch",
+            ["src/parser.py", ""],
+            None,
+            selected_action=FileReviewAction.INCLUDE_FROM_BATCH,
+            command_name="include",
+        )
 
 
 def test_resolve_batch_file_scope_keeps_pattern_scope_kind(monkeypatch):

--- a/tests/cli/test_file_arguments.py
+++ b/tests/cli/test_file_arguments.py
@@ -24,8 +24,16 @@ def test_normalize_parsed_file_arguments_preserves_absent_file_patterns():
     assert args.file_patterns is None
 
 
-def test_normalize_parsed_file_arguments_marks_pathless_file_argument():
+def test_normalize_parsed_file_arguments_preserves_pathless_and_explicit_groups():
     args = argparse.Namespace(file=[["src/parser.py"], []], file_patterns=None)
+
+    normalize_parsed_file_arguments(args)
+
+    assert args.file == ["src/parser.py", ""]
+
+
+def test_normalize_parsed_file_arguments_collapses_only_pathless_groups():
+    args = argparse.Namespace(file=[[], []], file_patterns=None)
 
     normalize_parsed_file_arguments(args)
 


### PR DESCRIPTION
File-scoped commands accept repeated `--file` groups and let a pathless
group refer to the currently selected file.

When an explicit path and a pathless group are combined, argument
normalization currently discards one of them. A request such as
`--file a --file` therefore cannot target both `a` and the selected file.

This pull request preserves each pathless group as a selected-file marker
and resolves it through the live-review and saved-batch safeguards introduced
in #372. It then carries the combined scope through the exact multi-file
dispatch behavior fixed in #373. Parser and command tests cover ordering,
live and saved-batch selection, stale or unavailable selections, action
guards, and conflicts with `--files` patterns. The 3,530-test suite with 12
skips, Ruff, dead-code validation, type-hygiene validation, strict mypy,
benchmark smoke, and wheel and source-distribution build/install smoke pass
locally.

Repeated `--file` arguments can now combine explicit paths with the selected
file without bypassing selection provenance or action safeguards.
