### PR TITLE
jobs: Run file jobs on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,12 @@ jobs:
       - name: Run tests on macOS
         run: uv run pytest -n auto
 
+      - name: Smoke test process file jobs on macOS
+        run: >-
+          uv run pytest -n 0
+          tests/utils/test_file_jobs.py::test_inline_and_forced_process_runs_return_identical_ordered_results
+          tests/utils/test_file_jobs.py::test_process_worker_does_not_inherit_the_parent_session_lock
+
   build:
     runs-on: ubuntu-latest
 

--- a/src/git_stage_batch/utils/file_job_process.py
+++ b/src/git_stage_batch/utils/file_job_process.py
@@ -10,7 +10,10 @@ from typing import TYPE_CHECKING, Generic, Protocol, TypeVar, cast
 
 if TYPE_CHECKING:
     from multiprocessing.connection import Connection
-    from multiprocessing.context import ForkServerContext, ForkServerProcess
+    from multiprocessing.context import ForkServerContext, SpawnContext
+    from multiprocessing.process import BaseProcess
+
+    _ProcessContext = ForkServerContext | SpawnContext
 
 
 JobT = TypeVar("JobT")
@@ -48,7 +51,7 @@ class _FileJobSupervisorError(Exception):
 
 
 class _ProcessFileJobSupervisor(Generic[JobT, ResultT]):
-    """Small forkserver supervisor with explicit public worker termination."""
+    """Small process supervisor with explicit public worker termination."""
 
     def __init__(
         self,
@@ -57,9 +60,9 @@ class _ProcessFileJobSupervisor(Generic[JobT, ResultT]):
         max_workers: int,
         repository_root: Path,
         worker_target: Callable[..., None],
-        context_factory: Callable[[], ForkServerContext],
+        context_factory: Callable[[], _ProcessContext],
     ) -> None:
-        self._workers: list[ForkServerProcess] = []
+        self._workers: list[BaseProcess] = []
         self._connections: list[Connection] = []
         self._pending_ordinals: list[list[int]] = []
         self._closed = False
@@ -212,7 +215,7 @@ class _ProcessFileJobSupervisor(Generic[JobT, ResultT]):
 
     def _start_worker(
         self,
-        context: ForkServerContext,
+        context: _ProcessContext,
         worker_target: Callable[..., None],
         compute: Callable[[JobT], ResultT],
         repository_root: Path,
@@ -220,7 +223,7 @@ class _ProcessFileJobSupervisor(Generic[JobT, ResultT]):
     ) -> None:
         parent_connection: Connection | None = None
         child_connection: Connection | None = None
-        process: ForkServerProcess | None = None
+        process: BaseProcess | None = None
         try:
             parent_connection, child_connection = context.Pipe(duplex=True)
             process = context.Process(
@@ -251,7 +254,7 @@ class _ProcessFileJobSupervisor(Generic[JobT, ResultT]):
 
     def _stop_partially_started_worker(
         self,
-        process: ForkServerProcess | None,
+        process: BaseProcess | None,
     ) -> None:
         if process is None:
             return

--- a/src/git_stage_batch/utils/file_jobs.py
+++ b/src/git_stage_batch/utils/file_jobs.py
@@ -1,4 +1,4 @@
-"""Ordered inline and forkserver execution for compact file-scoped jobs."""
+"""Ordered inline and process execution for compact file-scoped jobs."""
 
 from __future__ import annotations
 
@@ -31,7 +31,8 @@ from .file_job_transport import (
 
 if TYPE_CHECKING:
     from multiprocessing.connection import Connection
-    from multiprocessing.context import ForkServerContext
+
+    from .file_job_process import _ProcessContext
 
 
 JobT = TypeVar("JobT")
@@ -39,6 +40,7 @@ ResultT = TypeVar("ResultT")
 _MAX_FILE_JOB_WORKERS = 4
 _AUTO_PROCESS_MINIMUM_ESTIMATED_BYTES = 256 * 1024
 _MAX_ERROR_MESSAGE_CHARACTERS = 4 * 1024
+_PROCESS_FILE_JOB_PLATFORMS = frozenset(("darwin", "linux"))
 
 
 @dataclass(frozen=True, slots=True)
@@ -103,14 +105,14 @@ def select_file_job_execution(
     platform: str,
     cpu_count: int | None,
 ) -> FileJobExecution:
-    """Select inline or bounded Linux process execution."""
+    """Select inline or bounded supported-platform process execution."""
     job_count = len(jobs)
     requested_value = "auto" if requested_jobs is None else requested_jobs
     if requested_value == "":
         raise _invalid_jobs_value()
 
     if requested_value == "auto":
-        if platform != "linux":
+        if platform not in _PROCESS_FILE_JOB_PLATFORMS:
             return FileJobExecution(
                 "inline",
                 1,
@@ -130,9 +132,10 @@ def select_file_job_execution(
                 "automatic process execution requires at least 2 CPUs",
             )
         total_estimated_bytes = sum(job.estimated_bytes for job in jobs)
-        # A 2026-07-16 whole-prompt benchmark measured a 20 percent gain near
-        # 242 KiB and larger gains above it. Use a round 256 KiB heuristic to
-        # amortize process startup without implying a precise crossover.
+        # A 2026-07-16 Linux whole-prompt benchmark measured a 20 percent gain
+        # near 242 KiB and larger gains above it. A spawn proxy crossed over
+        # below the same point. Use a conservative shared 256 KiB threshold
+        # until native platform measurements justify separate values.
         if total_estimated_bytes < _AUTO_PROCESS_MINIMUM_ESTIMATED_BYTES:
             return FileJobExecution(
                 "inline",
@@ -164,8 +167,10 @@ def select_file_job_execution(
     if requested_count == 1:
         reason = "GIT_STAGE_BATCH_JOBS requests inline execution"
         return FileJobExecution("inline", 1, reason)
-    if platform != "linux":
-        raise CommandError("GIT_STAGE_BATCH_JOBS greater than 1 requires Linux.")
+    if platform not in _PROCESS_FILE_JOB_PLATFORMS:
+        raise CommandError(
+            "GIT_STAGE_BATCH_JOBS greater than 1 requires Linux or macOS."
+        )
     if job_count == 0:
         return FileJobExecution("inline", 1, "no eligible file jobs")
 
@@ -196,8 +201,11 @@ def run_file_jobs(
         raise ValueError(f"unsupported file-job transport: {execution.transport}")
     if type(execution.max_workers) is not int or execution.max_workers <= 0:
         raise ValueError("file-job execution requires a positive worker count")
-    if execution.transport == "process" and sys.platform != "linux":
-        raise ValueError("process file-job execution requires Linux")
+    if (
+        execution.transport == "process"
+        and sys.platform not in _PROCESS_FILE_JOB_PLATFORMS
+    ):
+        raise ValueError("process file-job execution requires Linux or macOS")
     if not ordered_jobs:
         return []
     repository_root = repository_root.resolve()
@@ -434,10 +442,14 @@ def _file_job_worker(
             pass
 
 
-def _get_process_context() -> ForkServerContext:
+def _get_process_context() -> _ProcessContext:
     import multiprocessing
 
-    return multiprocessing.get_context("forkserver")
+    if sys.platform == "darwin":
+        return multiprocessing.get_context("spawn")
+    if sys.platform == "linux":
+        return multiprocessing.get_context("forkserver")
+    raise RuntimeError(f"process file jobs are unavailable on {sys.platform}")
 
 
 def _initialize_file_job_worker(repository_root: Path) -> None:

--- a/tests/commands/test_apply_from.py
+++ b/tests/commands/test_apply_from.py
@@ -26,8 +26,8 @@ from tests.buffer_helpers import uses_mapped_storage
 
 _RUNNING_UNDER_XDIST = "PYTEST_XDIST_WORKER" in os.environ
 _PROCESS_TEST = pytest.mark.skipif(
-    sys.platform != "linux" or _RUNNING_UNDER_XDIST,
-    reason="forced forkserver coverage runs on Linux with pytest -n 0",
+    sys.platform not in {"darwin", "linux"} or _RUNNING_UNDER_XDIST,
+    reason="forced process coverage runs on Linux and macOS with pytest -n 0",
 )
 
 

--- a/tests/commands/test_include_from.py
+++ b/tests/commands/test_include_from.py
@@ -35,8 +35,8 @@ from tests.buffer_helpers import uses_mapped_storage
 
 _RUNNING_UNDER_XDIST = "PYTEST_XDIST_WORKER" in os.environ
 _PROCESS_TEST = pytest.mark.skipif(
-    sys.platform != "linux" or _RUNNING_UNDER_XDIST,
-    reason="forced forkserver coverage runs on Linux with pytest -n 0",
+    sys.platform not in {"darwin", "linux"} or _RUNNING_UNDER_XDIST,
+    reason="forced process coverage runs on Linux and macOS with pytest -n 0",
 )
 
 

--- a/tests/commands/test_sift.py
+++ b/tests/commands/test_sift.py
@@ -1,5 +1,6 @@
 """Tests for sift command."""
 
+import os
 from pathlib import Path
 
 from git_stage_batch.batch.merge.merge import merge_batch_from_line_sequences_as_buffer
@@ -38,6 +39,14 @@ from git_stage_batch.utils.file_job_workspace import FileJobWorkspace
 from tests.batch.ownership.metadata_helpers import (
     acquire_ownership_for_metadata,
     reject_materialized_ownership_metadata as _reject_materialized_ownership_metadata,
+)
+
+
+_RUNNING_UNDER_XDIST = "PYTEST_XDIST_WORKER" in os.environ
+_PROCESS_SIFT_TEST = pytest.mark.skipif(
+    sys.platform not in {"darwin", "linux"}
+    or (sys.platform == "darwin" and _RUNNING_UNDER_XDIST),
+    reason="macOS process sift coverage requires pytest -n 0",
 )
 
 
@@ -1228,10 +1237,7 @@ class TestSiftFileJobs:
         assert not batch_exists("empty-destination")
         assert read_batch_metadata("empty-source")["note"] == "changed after snapshot"
 
-    @pytest.mark.skipif(
-        sys.platform != "linux",
-        reason="process sift execution is supported on Linux only",
-    )
+    @_PROCESS_SIFT_TEST
     def test_forced_process_matches_inline_publication(
         self,
         temp_git_repo,
@@ -1448,10 +1454,7 @@ class TestSiftFileJobs:
         assert read_batch_metadata("raced-destination")["files"] == {}
         assert not any(name.startswith("sift-tmp-") for name in list_batch_names())
 
-    @pytest.mark.skipif(
-        sys.platform != "linux",
-        reason="process sift execution is supported on Linux only",
-    )
+    @_PROCESS_SIFT_TEST
     def test_process_sift_preserves_added_text_boundaries(
         self,
         temp_git_repo,
@@ -1487,10 +1490,7 @@ class TestSiftFileJobs:
             for file_path in expected_content
         } == expected_content
 
-    @pytest.mark.skipif(
-        sys.platform != "linux",
-        reason="process sift execution is supported on Linux only",
-    )
+    @_PROCESS_SIFT_TEST
     def test_process_sift_preserves_text_deletions(
         self,
         temp_git_repo,

--- a/tests/data/test_live_change_jobs.py
+++ b/tests/data/test_live_change_jobs.py
@@ -56,8 +56,8 @@ _REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 if str(_REPOSITORY_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPOSITORY_ROOT))
 _PROCESS_TEST = pytest.mark.skipif(
-    sys.platform != "linux" or _RUNNING_UNDER_XDIST,
-    reason="forced forkserver coverage runs on Linux with pytest -n 0",
+    sys.platform not in {"darwin", "linux"} or _RUNNING_UNDER_XDIST,
+    reason="forced process coverage runs on Linux and macOS with pytest -n 0",
 )
 
 

--- a/tests/functional/test_functional_status.py
+++ b/tests/functional/test_functional_status.py
@@ -16,8 +16,8 @@ from .conftest import git_stage_batch
 
 _RUNNING_UNDER_XDIST = "PYTEST_XDIST_WORKER" in os.environ
 _PROCESS_TEST = pytest.mark.skipif(
-    sys.platform != "linux" or _RUNNING_UNDER_XDIST,
-    reason="forced forkserver coverage runs on Linux with pytest -n 0",
+    sys.platform not in {"darwin", "linux"} or _RUNNING_UNDER_XDIST,
+    reason="forced process coverage runs on Linux and macOS with pytest -n 0",
 )
 
 

--- a/tests/utils/test_file_jobs.py
+++ b/tests/utils/test_file_jobs.py
@@ -1,4 +1,4 @@
-"""Tests for ordered inline and forkserver file-job execution."""
+"""Tests for ordered inline and process file-job execution."""
 
 from __future__ import annotations
 
@@ -38,13 +38,18 @@ _RUNNING_UNDER_XDIST = "PYTEST_XDIST_WORKER" in os.environ
 _REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 if str(_REPOSITORY_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPOSITORY_ROOT))
+_SUPPORTED_PROCESS_PLATFORMS = frozenset(("darwin", "linux"))
 _PROCESS_TEST = pytest.mark.skipif(
-    sys.platform != "linux" or _RUNNING_UNDER_XDIST,
-    reason="forced forkserver coverage runs on Linux with pytest -n 0",
+    sys.platform not in _SUPPORTED_PROCESS_PLATFORMS or _RUNNING_UNDER_XDIST,
+    reason="forced process coverage runs on Linux and macOS with pytest -n 0",
 )
-_LINUX_PROCESS_TEST = pytest.mark.skipif(
+_SUPPORTED_PROCESS_TEST = pytest.mark.skipif(
+    sys.platform not in _SUPPORTED_PROCESS_PLATFORMS,
+    reason="process file-job execution is supported on Linux and macOS",
+)
+_LINUX_TEST = pytest.mark.skipif(
     sys.platform != "linux",
-    reason="process file-job execution is supported on Linux only",
+    reason="CPU affinity coverage requires Linux",
 )
 _PARENT_COMPUTE_CALLS = 0
 
@@ -375,7 +380,7 @@ def test_validated_runner_rejects_an_unexpected_result_count(
 
 
 @_PROCESS_TEST
-def test_forkserver_worker_does_not_inherit_the_parent_session_lock(
+def test_process_worker_does_not_inherit_the_parent_session_lock(
     tmp_path,
     monkeypatch,
 ):
@@ -421,7 +426,7 @@ def test_compute_keyboard_interrupt_propagates_across_process_transport(
     assert not root.exists()
 
 
-@_LINUX_PROCESS_TEST
+@_SUPPORTED_PROCESS_TEST
 def test_process_scheduler_submits_largest_first_with_bounded_pending(
     tmp_path,
     monkeypatch,
@@ -487,7 +492,7 @@ def test_process_scheduler_submits_largest_first_with_bounded_pending(
     assert lifecycle == {"closed": True, "terminated": False}
 
 
-@_LINUX_PROCESS_TEST
+@_SUPPORTED_PROCESS_TEST
 def test_process_scheduler_stops_admission_after_task_failure(
     tmp_path,
     monkeypatch,
@@ -558,7 +563,7 @@ def test_process_scheduler_stops_admission_after_task_failure(
     assert lifecycle == {"closed": False, "terminated": True}
 
 
-@_LINUX_PROCESS_TEST
+@_SUPPORTED_PROCESS_TEST
 def test_process_failure_waits_only_for_pending_lower_ordinals(
     tmp_path,
     monkeypatch,
@@ -677,7 +682,7 @@ def test_lowest_ordinal_failure_wins(tmp_path):
     assert "one" in error.value.original_message
 
 
-@_LINUX_PROCESS_TEST
+@_SUPPORTED_PROCESS_TEST
 def test_process_construction_failure_does_not_compute_inline(
     tmp_path,
     monkeypatch,
@@ -689,10 +694,10 @@ def test_process_construction_failure_does_not_compute_inline(
     monkeypatch.setattr(
         file_jobs_module,
         "_get_process_context",
-        lambda *_args: (_ for _ in ()).throw(OSError("cannot start forkserver")),
+        lambda *_args: (_ for _ in ()).throw(OSError("cannot start process context")),
     )
 
-    with pytest.raises(FileJobError, match="cannot start forkserver"):
+    with pytest.raises(FileJobError, match="cannot start process context"):
         run_file_jobs(
             [OrderedFileJob(0, "file.txt", 1, 7)],
             _record_parent_call,
@@ -703,7 +708,7 @@ def test_process_construction_failure_does_not_compute_inline(
     assert _PARENT_COMPUTE_CALLS == 0
 
 
-@_LINUX_PROCESS_TEST
+@_SUPPORTED_PROCESS_TEST
 def test_partially_started_worker_is_killed_and_connections_are_closed(
     tmp_path,
     monkeypatch,
@@ -827,7 +832,7 @@ def test_worker_death_does_not_retry_inline(tmp_path):
     assert _PARENT_COMPUTE_CALLS == 0
 
 
-@_LINUX_PROCESS_TEST
+@_SUPPORTED_PROCESS_TEST
 def test_keyboard_interrupt_terminates_workers_before_workspace_cleanup(
     tmp_path,
     monkeypatch,
@@ -895,12 +900,12 @@ def test_invalid_requested_job_values_raise_deterministic_error(requested_jobs):
 
 
 @pytest.mark.parametrize("requested_jobs", (None, "auto", "1"))
-def test_non_linux_inline_selection_never_creates_context(
+def test_unsupported_platform_inline_selection_never_creates_context(
     tmp_path,
     monkeypatch,
     requested_jobs,
 ):
-    """Darwin auto and inline controls must not touch multiprocessing."""
+    """Unsupported-platform auto and inline controls must remain inline."""
     monkeypatch.setattr(
         file_jobs_module,
         "_get_process_context",
@@ -912,7 +917,7 @@ def test_non_linux_inline_selection_never_creates_context(
     execution = select_file_job_execution(
         jobs,
         requested_jobs=requested_jobs,
-        platform="darwin",
+        platform="win32",
         cpu_count=8,
     )
 
@@ -925,35 +930,38 @@ def test_non_linux_inline_selection_never_creates_context(
     ) == [5]
 
 
-def test_non_linux_forced_process_selection_fails_before_execution():
-    """Darwin must reject a forced process count instead of falling back."""
+def test_unsupported_platform_forced_process_selection_fails_before_execution():
+    """An unsupported platform must reject forced processes before execution."""
     with pytest.raises(
         CommandError,
-        match="requires Linux",
+        match="requires Linux or macOS",
     ):
         select_file_job_execution(
             [OrderedFileJob(0, "file.txt", 1, None)],
             requested_jobs="2",
-            platform="darwin",
+            platform="win32",
             cpu_count=8,
         )
 
 
-def test_non_linux_forced_process_selection_fails_without_jobs():
-    """A forced non-Linux process request should fail even with no work."""
+def test_unsupported_platform_forced_process_selection_fails_without_jobs():
+    """A forced unsupported process request should fail even with no work."""
     with pytest.raises(
         CommandError,
-        match="requires Linux",
+        match="requires Linux or macOS",
     ):
         select_file_job_execution(
             [],
             requested_jobs="2",
-            platform="darwin",
+            platform="win32",
             cpu_count=8,
         )
 
 
-def test_linux_auto_keeps_work_just_below_the_round_heuristic_inline():
+@pytest.mark.parametrize("platform", ("darwin", "linux"))
+def test_supported_platform_auto_keeps_work_below_the_heuristic_inline(
+    platform,
+):
     """Automatic execution should avoid process startup below 256 KiB."""
     jobs = [
         OrderedFileJob(0, "a.txt", 128 * 1024 - 1, None),
@@ -963,7 +971,7 @@ def test_linux_auto_keeps_work_just_below_the_round_heuristic_inline():
     execution = select_file_job_execution(
         jobs,
         requested_jobs="auto",
-        platform="linux",
+        platform=platform,
         cpu_count=8,
     )
 
@@ -972,7 +980,10 @@ def test_linux_auto_keeps_work_just_below_the_round_heuristic_inline():
     assert "below the" in execution.reason
 
 
-def test_linux_auto_selects_processes_at_the_round_heuristic():
+@pytest.mark.parametrize("platform", ("darwin", "linux"))
+def test_supported_platform_auto_selects_processes_at_the_heuristic(
+    platform,
+):
     """The 256 KiB heuristic should be inclusive."""
     jobs = [
         OrderedFileJob(0, "a.txt", 128 * 1024, None),
@@ -982,7 +993,7 @@ def test_linux_auto_selects_processes_at_the_round_heuristic():
     execution = select_file_job_execution(
         jobs,
         requested_jobs="auto",
-        platform="linux",
+        platform=platform,
         cpu_count=8,
     )
 
@@ -991,7 +1002,10 @@ def test_linux_auto_selects_processes_at_the_round_heuristic():
     assert "262144 estimated bytes" in execution.reason
 
 
-def test_linux_auto_selects_bounded_processes_above_the_heuristic():
+@pytest.mark.parametrize("platform", ("darwin", "linux"))
+def test_supported_platform_auto_selects_bounded_processes_above_the_heuristic(
+    platform,
+):
     """Automatic execution should admit measured multi-file CPU wins."""
     jobs = [
         OrderedFileJob(ordinal, f"{ordinal}.txt", 125_000, None) for ordinal in range(5)
@@ -1000,7 +1014,7 @@ def test_linux_auto_selects_bounded_processes_above_the_heuristic():
     execution = select_file_job_execution(
         jobs,
         requested_jobs=None,
-        platform="linux",
+        platform=platform,
         cpu_count=8,
     )
 
@@ -1009,7 +1023,8 @@ def test_linux_auto_selects_bounded_processes_above_the_heuristic():
     assert "625000 estimated bytes" in execution.reason
 
 
-def test_linux_auto_respects_cpu_availability():
+@pytest.mark.parametrize("platform", ("darwin", "linux"))
+def test_supported_platform_auto_respects_cpu_availability(platform):
     """Automatic worker selection should not exceed available CPUs."""
     jobs = [
         OrderedFileJob(ordinal, f"{ordinal}.txt", 250_000, None) for ordinal in range(2)
@@ -1019,7 +1034,7 @@ def test_linux_auto_respects_cpu_availability():
         select_file_job_execution(
             jobs,
             requested_jobs="auto",
-            platform="linux",
+            platform=platform,
             cpu_count=1,
         ).transport
         == "inline"
@@ -1028,14 +1043,14 @@ def test_linux_auto_respects_cpu_availability():
         select_file_job_execution(
             jobs,
             requested_jobs="auto",
-            platform="linux",
+            platform=platform,
             cpu_count=2,
         ).max_workers
         == 2
     )
 
 
-@_LINUX_PROCESS_TEST
+@_LINUX_TEST
 def test_linux_auto_uses_process_affinity_when_cpu_count_is_unspecified(
     monkeypatch,
 ):
@@ -1060,14 +1075,37 @@ def test_linux_auto_uses_process_affinity_when_cpu_count_is_unspecified(
     assert execution.max_workers == 2
 
 
-def test_forced_process_selection_respects_job_cpu_and_worker_caps():
+def test_macos_auto_uses_cpu_count_when_affinity_is_unavailable(
+    monkeypatch,
+):
+    """Darwin should use the portable CPU count fallback."""
+    jobs = [
+        OrderedFileJob(ordinal, f"{ordinal}.txt", 125_000, None)
+        for ordinal in range(4)
+    ]
+    monkeypatch.delattr(file_jobs_module.os, "sched_getaffinity", raising=False)
+    monkeypatch.setattr(file_jobs_module.os, "cpu_count", lambda: 3)
+
+    execution = select_file_job_execution(
+        jobs,
+        requested_jobs="auto",
+        platform="darwin",
+        cpu_count=None,
+    )
+
+    assert execution.transport == "process"
+    assert execution.max_workers == 3
+
+
+@pytest.mark.parametrize("platform", ("darwin", "linux"))
+def test_forced_process_selection_respects_job_cpu_and_worker_caps(platform):
     """Forced worker counts should remain bounded by every execution limit."""
     jobs = [OrderedFileJob(ordinal, f"{ordinal}.txt", 1, None) for ordinal in range(10)]
 
     assert select_file_job_execution(
         jobs,
         requested_jobs="9",
-        platform="linux",
+        platform=platform,
         cpu_count=3,
     ) == FileJobExecution(
         "process",
@@ -1076,7 +1114,34 @@ def test_forced_process_selection_respects_job_cpu_and_worker_caps():
     )
 
 
-@_LINUX_PROCESS_TEST
+@pytest.mark.parametrize(
+    ("platform", "expected_start_method"),
+    (("darwin", "spawn"), ("linux", "forkserver")),
+)
+def test_process_context_uses_platform_start_method(
+    monkeypatch,
+    platform,
+    expected_start_method,
+):
+    """Each supported platform should use its safe explicit start method."""
+    import multiprocessing
+
+    context = object()
+    observed_start_methods = []
+    monkeypatch.setattr(file_jobs_module.sys, "platform", platform)
+    monkeypatch.setattr(
+        multiprocessing,
+        "get_context",
+        lambda start_method: (
+            observed_start_methods.append(start_method) or context
+        ),
+    )
+
+    assert file_jobs_module._get_process_context() is context
+    assert observed_start_methods == [expected_start_method]
+
+
+@_SUPPORTED_PROCESS_TEST
 def test_process_execution_enforces_the_hard_worker_cap(
     tmp_path,
     monkeypatch,
@@ -1133,7 +1198,7 @@ def test_process_execution_enforces_the_hard_worker_cap(
     assert observed_max_workers == [file_jobs_module._MAX_FILE_JOB_WORKERS]
 
 
-@_LINUX_PROCESS_TEST
+@_SUPPORTED_PROCESS_TEST
 def test_collected_lower_ordinal_failure_wins_over_worker_failure(
     tmp_path,
     monkeypatch,
@@ -1198,7 +1263,7 @@ def test_collected_lower_ordinal_failure_wins_over_worker_failure(
     assert "one failed" in error.value.original_message
 
 
-@_LINUX_PROCESS_TEST
+@_SUPPORTED_PROCESS_TEST
 def test_worker_failure_reports_its_job_instead_of_an_unrelated_ordinal(
     tmp_path,
     monkeypatch,
@@ -1402,7 +1467,7 @@ def test_main_module_compute_function_is_rejected_before_execution(
     tmp_path,
     monkeypatch,
 ):
-    """Forkserver callables cannot depend on the launching main module."""
+    """Process callables cannot depend on the launching main module."""
     monkeypatch.setattr(_identity, "__module__", "__main__")
 
     with pytest.raises(TypeError, match="top-level importable"):
@@ -1415,7 +1480,7 @@ def test_main_module_compute_function_is_rejected_before_execution(
 
 
 def test_non_importable_transport_dataclass_is_rejected():
-    """IPC dataclass types must be reconstructable in a forkserver child."""
+    """IPC dataclass types must be reconstructable in a process child."""
 
     @dataclass(frozen=True)
     class LocalPayload:
@@ -1446,14 +1511,14 @@ def test_invalid_transport_is_rejected_even_without_jobs(tmp_path):
         )
 
 
-def test_process_transport_is_rejected_outside_linux(
+def test_process_transport_is_rejected_outside_supported_platforms(
     tmp_path,
     monkeypatch,
 ):
     """A manually constructed execution policy cannot bypass platform scope."""
-    monkeypatch.setattr(file_jobs_module.sys, "platform", "darwin")
+    monkeypatch.setattr(file_jobs_module.sys, "platform", "win32")
 
-    with pytest.raises(ValueError, match="requires Linux"):
+    with pytest.raises(ValueError, match="requires Linux or macOS"):
         run_file_jobs(
             [],
             _identity,

--- a/tests/utils/test_file_jobs.py
+++ b/tests/utils/test_file_jobs.py
@@ -154,10 +154,16 @@ def _current_directory(_value: int) -> str:
 
 
 def _has_open_descriptor_for_path(path: Path) -> bool:
-    expected_path = path.resolve()
-    for descriptor_path in Path("/proc/self/fd").iterdir():
+    expected_stat = path.stat()
+    for descriptor_name in os.listdir("/dev/fd"):
+        if not descriptor_name.isdigit():
+            continue
         try:
-            if descriptor_path.resolve() == expected_path:
+            descriptor_stat = os.fstat(int(descriptor_name))
+            if (
+                descriptor_stat.st_dev == expected_stat.st_dev
+                and descriptor_stat.st_ino == expected_stat.st_ino
+            ):
                 return True
         except OSError:
             continue


### PR DESCRIPTION
File jobs, which perform work independently for each selected file, run
inline on supported POSIX systems and use bounded fork-server workers on
Linux. The worker supervisor preserves result ordering, failure priority,
and explicit cleanup.

macOS users cannot select process execution for CPU-heavy file work, so
automatic and explicitly requested job counts leave that work serial. The
macOS CI job also runs the full suite inside pytest-xdist workers, which
force file jobs inline and leave the native process path untested.

This pull request enables file-job processes on macOS by selecting the
multiprocessing spawn context while retaining the existing worker cap and
256 KiB automatic-execution threshold. It generalizes the supervisor for
both process contexts, makes the test for inherited repository lock
descriptors portable, covers apply, include, sift, status, and live-change
behavior with spawned workers, and adds a serial native macOS CI smoke test.
The full local suite passes with 3,538 tests and 12 skips, along with lint,
typing, dead-code, type-hygiene, benchmark-smoke, and wheel and source
distribution installation checks.

macOS now has bounded file-job process execution with command-level parity
coverage and native CI validation of the platform-specific behavior.
