### PR TITLE
cli: Preserve selected markers through line-scope resolution

### DIFF
--- a/src/git_stage_batch/cli/file_scope.py
+++ b/src/git_stage_batch/cli/file_scope.py
@@ -84,6 +84,8 @@ class FileScope:
             return None
         if self.is_multiple:
             raise ValueError("multiple file scope cannot be represented by one path")
+        if not self.files:
+            raise ValueError("file scope does not have a concrete path")
         return self.files[0]
 
     def require_single_file(self, error_message: str) -> str | None:
@@ -156,8 +158,15 @@ def _resolve_file_argument_patterns(
     file_patterns: list[str] | None,
     *,
     selected_file: str | None = None,
+    defer_selected_marker_validation: bool = False,
 ) -> tuple[list[str], list[str]]:
-    """Resolve --file/--files values against candidates with exact --file fallback."""
+    """Resolve file arguments while optionally deferring marker validation.
+
+    Line actions must pass a selected-file marker to their command-level
+    review validator even when its cached path is absent or unavailable.
+    Known marker paths are still retained here for duplicate and multi-file
+    detection.
+    """
     file_values = _file_arg_values(file_arg)
     candidate_by_path = {
         _normalize_file_argument_path(candidate): candidate
@@ -169,13 +178,23 @@ def _resolve_file_argument_patterns(
     display_patterns: list[str] = []
     for raw_value in file_values:
         value = raw_value
-        if value == "":
+        is_selected_marker = value == ""
+        if is_selected_marker:
             if selected_file is None:
+                if defer_selected_marker_validation:
+                    continue
                 raise CommandError(
                     _("No selected hunk. Run 'show' first or specify file path.")
                 )
             value = selected_file
-            if _normalize_file_argument_path(value) not in candidate_by_path:
+            selected_candidate = candidate_by_path.get(
+                _normalize_file_argument_path(value)
+            )
+            if selected_candidate is None:
+                if defer_selected_marker_validation:
+                    exact_files.append(value)
+                    display_patterns.append(value)
+                    continue
                 raise CommandError(
                     _("Selected file is not available in this file scope: {file}").format(
                         file=value,
@@ -206,9 +225,10 @@ def _has_pathless_file_marker(file_arg: FileArgument) -> bool:
 
 def _resolve_live_selected_file(
     action: FileReviewAction | None,
+    line_ids: str | None,
 ) -> str | None:
-    """Resolve a selected live file without bypassing pathless-action guards."""
-    if action is not None:
+    """Resolve a selected live file with guards appropriate to the action scope."""
+    if action is not None and line_ids is None:
         refuse_live_action_for_batch_selection(action)
         refuse_ambiguous_bare_action_after_partial_file_review(action)
     return get_selected_change_file_path()
@@ -257,19 +277,25 @@ def resolve_live_file_scope(
     *,
     include_staged: bool = False,
     selected_action: FileReviewAction | None = None,
+    line_ids: str | None = None,
 ) -> FileScope:
     """Resolve single-file or pattern-based live file scope."""
     resolved_patterns = _resolve_file_patterns(file_arg, file_patterns)
     if resolved_patterns is None:
         return FileScope.implicit() if file_arg is None else FileScope.explicit("")
 
+    includes_selected_file_marker = _has_pathless_file_marker(file_arg)
+    defer_selected_marker_validation = (
+        includes_selected_file_marker
+        and line_ids is not None
+    )
     candidate_files = [*list_changed_files(), *list_untracked_files()]
     if include_staged:
         candidate_files.extend(list_staged_files())
     candidate_files = list(dict.fromkeys(candidate_files))
     selected_file = (
-        _resolve_live_selected_file(selected_action)
-        if _has_pathless_file_marker(file_arg)
+        _resolve_live_selected_file(selected_action, line_ids)
+        if includes_selected_file_marker
         else None
     )
     resolved_files, display_patterns = _resolve_file_argument_patterns(
@@ -277,14 +303,18 @@ def resolve_live_file_scope(
         file_arg,
         file_patterns,
         selected_file=selected_file,
+        defer_selected_marker_validation=defer_selected_marker_validation,
     )
-    if not resolved_files:
+    if not resolved_files and not defer_selected_marker_validation:
         raise CommandError(
             _("No changed files matched: {patterns}").format(
                 patterns=", ".join(display_patterns),
             )
         )
-    return FileScope.pattern(resolved_files)
+    return FileScope.pattern(
+        resolved_files,
+        includes_selected_file_marker=includes_selected_file_marker,
+    )
 
 
 def resolve_batch_file_scope(

--- a/src/git_stage_batch/cli/file_scope.py
+++ b/src/git_stage_batch/cli/file_scope.py
@@ -239,8 +239,12 @@ def _resolve_batch_selected_file(
     all_files: dict[str, BatchFileMetadataDict],
     action: FileReviewAction | None,
     command_name: str | None,
+    line_ids: str | None,
 ) -> str | None:
-    """Resolve a selected batch file through the existing pathless guards."""
+    """Resolve a selected batch file with guards appropriate to the action scope."""
+    if line_ids is not None:
+        return get_selected_change_file_path()
+
     selected_file: str | None = ""
     if action is not None:
         if command_name is None:
@@ -261,7 +265,7 @@ def _resolve_batch_selected_file(
         all_files,
         selected_file,
         None,
-        None,
+        line_ids,
     )
     resolved_files = resolve_stored_batch_file_scope(
         batch_name,
@@ -324,6 +328,7 @@ def resolve_batch_file_scope(
     *,
     selected_action: FileReviewAction | None = None,
     command_name: str | None = None,
+    line_ids: str | None = None,
 ) -> FileScope:
     """Resolve single-file or pattern-based batch file scope."""
     lookup_batch_name = batch_name_for_source_lookup(batch_name)
@@ -333,6 +338,11 @@ def resolve_batch_file_scope(
     if not batch_exists(lookup_batch_name):
         raise CommandError(_("Batch '{name}' does not exist").format(name=lookup_batch_name))
 
+    includes_selected_file_marker = _has_pathless_file_marker(file_arg)
+    defer_selected_marker_validation = (
+        includes_selected_file_marker
+        and line_ids is not None
+    )
     metadata = read_batch_metadata(lookup_batch_name)
     all_files = metadata.get("files", {})
     selected_file = (
@@ -341,8 +351,9 @@ def resolve_batch_file_scope(
             all_files,
             selected_action,
             command_name,
+            line_ids,
         )
-        if _has_pathless_file_marker(file_arg)
+        if includes_selected_file_marker
         else None
     )
     resolved_files, display_patterns = _resolve_file_argument_patterns(
@@ -350,12 +361,16 @@ def resolve_batch_file_scope(
         file_arg,
         file_patterns,
         selected_file=selected_file,
+        defer_selected_marker_validation=defer_selected_marker_validation,
     )
-    if not resolved_files:
+    if not resolved_files and not defer_selected_marker_validation:
         raise CommandError(
             _("No files in batch '{name}' matched: {patterns}").format(
                 name=lookup_batch_name,
                 patterns=", ".join(display_patterns),
             )
         )
-    return FileScope.pattern(resolved_files)
+    return FileScope.pattern(
+        resolved_files,
+        includes_selected_file_marker=includes_selected_file_marker,
+    )

--- a/src/git_stage_batch/cli/file_scope.py
+++ b/src/git_stage_batch/cli/file_scope.py
@@ -43,10 +43,11 @@ class FileScopeKind(str, Enum):
 
 @dataclass(frozen=True)
 class FileScope:
-    """Resolved command file scope with explicit origin and concrete files."""
+    """Resolved command file scope with known paths and marker provenance."""
 
     kind: FileScopeKind
     files: tuple[str, ...] = ()
+    includes_selected_file_marker: bool = False
 
     @classmethod
     def implicit(cls) -> "FileScope":
@@ -57,8 +58,17 @@ class FileScope:
         return cls(FileScopeKind.EXPLICIT, (file_path,))
 
     @classmethod
-    def pattern(cls, files: list[str]) -> "FileScope":
-        return cls(FileScopeKind.PATTERN, tuple(files))
+    def pattern(
+        cls,
+        files: list[str],
+        *,
+        includes_selected_file_marker: bool = False,
+    ) -> "FileScope":
+        return cls(
+            FileScopeKind.PATTERN,
+            tuple(files),
+            includes_selected_file_marker=includes_selected_file_marker,
+        )
 
     @property
     def is_implicit(self) -> bool:
@@ -81,6 +91,20 @@ class FileScope:
         if self.is_multiple:
             raise CommandError(error_message)
         return self.optional_file()
+
+    def optional_line_file(self) -> str | None:
+        """Return a single line-action file while preserving a selected marker."""
+        if self.is_multiple:
+            raise ValueError("multiple file scope cannot be represented by one path")
+        if self.includes_selected_file_marker:
+            return ""
+        return self.optional_file()
+
+    def require_single_line_file(self, error_message: str) -> str | None:
+        """Return a line-action file, or raise for a multi-file scope."""
+        if self.is_multiple:
+            raise CommandError(error_message)
+        return self.optional_line_file()
 
 
 def _resolve_file_patterns(

--- a/src/git_stage_batch/cli/include_dispatch.py
+++ b/src/git_stage_batch/cli/include_dispatch.py
@@ -160,8 +160,9 @@ def dispatch_include_command(args: argparse.Namespace) -> None:
             args.file,
             args.file_patterns,
             selected_action=FileReviewAction.INCLUDE,
+            line_ids=args.line_ids,
         )
-        resolved_file = resolved_live_scope.require_single_file(
+        resolved_file = resolved_live_scope.require_single_line_file(
             _("Cannot use --lines with multiple files.")
         )
         command_include_line(

--- a/src/git_stage_batch/commands/file_scope/multi_file_actions.py
+++ b/src/git_stage_batch/commands/file_scope/multi_file_actions.py
@@ -53,6 +53,9 @@ class ResolvedFileScope(Protocol):
     def optional_file(self) -> str | None:
         """Return the optional single-file path for command callbacks."""
 
+    def optional_line_file(self) -> str | None:
+        """Return the single-file path while preserving selected-marker scope."""
+
 
 @dataclass(frozen=True, slots=True)
 class _LiveActionTargetSnapshot:
@@ -107,7 +110,11 @@ def run_for_each_resolved_file(
             for file_path in file_scope.files:
                 callback(file_path)
         return
-    callback(file_scope.optional_file())
+    callback(
+        file_scope.optional_line_file()
+        if line_ids is not None
+        else file_scope.optional_file()
+    )
 
 
 def discard_each_resolved_file(

--- a/tests/cli/test_argument_parser.py
+++ b/tests/cli/test_argument_parser.py
@@ -147,6 +147,38 @@ def test_resolve_live_file_scope_runs_pathless_action_guards(monkeypatch):
     partial_review_guard.assert_called_once_with(FileReviewAction.INCLUDE)
 
 
+def test_resolve_live_line_file_scope_defers_pathless_action_guards(monkeypatch):
+    _mock_live_file_candidates(monkeypatch, ["selected.py"])
+    live_source_guard = Mock()
+    partial_review_guard = Mock()
+    monkeypatch.setattr(
+        file_scope,
+        "refuse_live_action_for_batch_selection",
+        live_source_guard,
+    )
+    monkeypatch.setattr(
+        file_scope,
+        "refuse_ambiguous_bare_action_after_partial_file_review",
+        partial_review_guard,
+    )
+    monkeypatch.setattr(
+        file_scope,
+        "get_selected_change_file_path",
+        lambda: "selected.py",
+    )
+
+    scope = file_scope.resolve_live_file_scope(
+        ["", "selected.py"],
+        None,
+        selected_action=FileReviewAction.INCLUDE,
+        line_ids="1",
+    )
+
+    assert scope.optional_line_file() == ""
+    live_source_guard.assert_not_called()
+    partial_review_guard.assert_not_called()
+
+
 def test_resolve_live_file_scope_rejects_mixed_pathless_file_and_files(monkeypatch):
     with pytest.raises(CommandError, match="Cannot use --file together with --files"):
         file_scope.resolve_live_file_scope(["src/parser.py", ""], ["*.txt"])

--- a/tests/cli/test_argument_parser.py
+++ b/tests/cli/test_argument_parser.py
@@ -247,6 +247,7 @@ def test_resolve_batch_file_scope_combines_explicit_and_selected_files(monkeypat
 
     assert scope.kind is file_scope.FileScopeKind.PATTERN
     assert scope.files == ("src/parser.py", "notes.txt")
+    assert scope.includes_selected_file_marker is True
 
 
 def test_resolve_batch_file_scope_refuses_foreign_batch_selection(monkeypatch):

--- a/tests/cli/test_argument_parser.py
+++ b/tests/cli/test_argument_parser.py
@@ -97,6 +97,26 @@ def test_resolve_live_file_scope_combines_explicit_and_selected_files(monkeypatc
     assert scope.includes_selected_file_marker is True
 
 
+def test_resolve_live_line_file_scope_preserves_selected_marker(monkeypatch):
+    _mock_live_file_candidates(monkeypatch, ["selected.py"])
+    monkeypatch.setattr(
+        file_scope,
+        "get_selected_change_file_path",
+        lambda: "selected.py",
+    )
+
+    scope = file_scope.resolve_live_file_scope(
+        ["selected.py", ""],
+        None,
+        selected_action=FileReviewAction.INCLUDE,
+        line_ids="1",
+    )
+
+    assert scope.files == ("selected.py",)
+    assert scope.optional_file() == "selected.py"
+    assert scope.optional_line_file() == ""
+
+
 def test_resolve_live_file_scope_runs_pathless_action_guards(monkeypatch):
     _mock_live_file_candidates(monkeypatch, ["src/parser.py", "notes.txt"])
     live_source_guard = Mock()

--- a/tests/cli/test_argument_parser.py
+++ b/tests/cli/test_argument_parser.py
@@ -94,6 +94,7 @@ def test_resolve_live_file_scope_combines_explicit_and_selected_files(monkeypatc
 
     assert scope.kind is file_scope.FileScopeKind.PATTERN
     assert scope.files == ("src/parser.py", "notes.txt")
+    assert scope.includes_selected_file_marker is True
 
 
 def test_resolve_live_file_scope_runs_pathless_action_guards(monkeypatch):

--- a/tests/cli/test_argument_parser.py
+++ b/tests/cli/test_argument_parser.py
@@ -252,6 +252,12 @@ def test_resolve_batch_file_scope_combines_explicit_and_selected_files(monkeypat
 
 def test_resolve_batch_line_file_scope_preserves_selected_marker(monkeypatch):
     _mock_batch_files(monkeypatch, ["selected.py"])
+    whole_file_scope_guard = Mock()
+    monkeypatch.setattr(
+        file_scope,
+        "resolve_batch_source_action_scope",
+        whole_file_scope_guard,
+    )
     monkeypatch.setattr(
         file_scope,
         "get_selected_change_file_path",
@@ -270,6 +276,7 @@ def test_resolve_batch_line_file_scope_preserves_selected_marker(monkeypatch):
     assert scope.files == ("selected.py",)
     assert scope.optional_file() == "selected.py"
     assert scope.optional_line_file() == ""
+    whole_file_scope_guard.assert_not_called()
 
 
 def test_resolve_batch_file_scope_refuses_foreign_batch_selection(monkeypatch):

--- a/tests/cli/test_argument_parser.py
+++ b/tests/cli/test_argument_parser.py
@@ -250,6 +250,28 @@ def test_resolve_batch_file_scope_combines_explicit_and_selected_files(monkeypat
     assert scope.includes_selected_file_marker is True
 
 
+def test_resolve_batch_line_file_scope_preserves_selected_marker(monkeypatch):
+    _mock_batch_files(monkeypatch, ["selected.py"])
+    monkeypatch.setattr(
+        file_scope,
+        "get_selected_change_file_path",
+        lambda: "selected.py",
+    )
+
+    scope = file_scope.resolve_batch_file_scope(
+        "batch",
+        ["selected.py", ""],
+        None,
+        selected_action=FileReviewAction.INCLUDE_FROM_BATCH,
+        command_name="include",
+        line_ids="1",
+    )
+
+    assert scope.files == ("selected.py",)
+    assert scope.optional_file() == "selected.py"
+    assert scope.optional_line_file() == ""
+
+
 def test_resolve_batch_file_scope_refuses_foreign_batch_selection(monkeypatch):
     _mock_batch_files(monkeypatch, ["src/parser.py", "notes.txt"])
     monkeypatch.setattr(

--- a/tests/commands/test_file_scope_actions.py
+++ b/tests/commands/test_file_scope_actions.py
@@ -6,9 +6,10 @@ from git_stage_batch.exceptions import CommandError
 
 
 class _FileScope:
-    def __init__(self, files=(), optional_file=None):
+    def __init__(self, files=(), optional_file=None, optional_line_file=None):
         self.files = tuple(files)
         self._optional_file = optional_file
+        self._optional_line_file = optional_line_file
 
     @property
     def is_multiple(self):
@@ -16,6 +17,9 @@ class _FileScope:
 
     def optional_file(self):
         return self._optional_file
+
+    def optional_line_file(self):
+        return self._optional_line_file
 
 
 class _Checkpoint:
@@ -245,6 +249,24 @@ def test_run_for_each_resolved_file_dispatches_optional_file(monkeypatch):
 
     assert checkpoint_calls == []
     assert callback_calls == ["alpha.txt"]
+
+
+def test_run_for_each_resolved_file_dispatches_pathless_line_file(monkeypatch):
+    checkpoint_calls = _capture_undo_checkpoints(monkeypatch)
+    callback_calls = []
+
+    multi_file_actions.run_for_each_resolved_file(
+        _FileScope(
+            optional_file="selected.txt",
+            optional_line_file="",
+        ),
+        callback_calls.append,
+        line_ids="1",
+        undo_operation="include --from scratch",
+    )
+
+    assert checkpoint_calls == []
+    assert callback_calls == [""]
 
 
 def test_run_for_each_resolved_file_rejects_line_ids_for_multiple_files():


### PR DESCRIPTION
File-scoped commands can combine explicit paths with a pathless `--file`
group that refers to the currently selected file. Shared live and saved-batch
resolution turns those arguments into concrete candidate paths before command
dispatch.

Line actions need the pathless marker to retain its review origin until
line-level validation runs. Eagerly replacing it with the cached path can run
whole-file guards on a line request or let an explicit companion path bypass
shown-page, stale-review, and saved-batch source checks.

This pull request records selected-marker provenance in resolved file scopes,
adds line-specific single-file access, and defers live and saved-batch
whole-file guards whenever line input is present. Ordinary live include adopts
the contract as its first command caller. Parser, resolver, and command tests
cover both repeated-argument orders, concrete multiplicity, marker forwarding,
and isolation from whole-file guards. The 3,542-test suite with 12 skips, Ruff,
dead-code validation, type-hygiene validation, strict mypy, benchmark smoke,
the SHA-256 repository workflow, and wheel and source-distribution build and
install smokes pass locally.

Shared line-scope resolution and ordinary live include now preserve the
selected-file marker until command-level review validation can use it.
