### PR TITLE
cli: Preserve selected markers across line command dispatch

### DIFF
--- a/src/git_stage_batch/cli/apply_dispatch.py
+++ b/src/git_stage_batch/cli/apply_dispatch.py
@@ -13,14 +13,15 @@ from .file_scope import resolve_batch_file_scope
 
 def dispatch_apply_command(args: argparse.Namespace) -> None:
     """Dispatch parsed apply arguments."""
+    line_ids = args.line_ids if hasattr(args, "line_ids") else None
     resolved_file_scope = resolve_batch_file_scope(
         args.from_batch,
         args.file,
         args.file_patterns,
         selected_action=FileReviewAction.APPLY_FROM_BATCH,
         command_name="apply",
+        line_ids=line_ids,
     )
-    line_ids = args.line_ids if hasattr(args, "line_ids") else None
     run_for_each_resolved_file(
         resolved_file_scope,
         lambda file: command_apply_from_batch(

--- a/src/git_stage_batch/cli/discard_dispatch.py
+++ b/src/git_stage_batch/cli/discard_dispatch.py
@@ -119,6 +119,7 @@ def dispatch_discard_command(args: argparse.Namespace) -> None:
             args.file,
             args.file_patterns,
             selected_action=FileReviewAction.DISCARD_TO_BATCH,
+            line_ids=args.line_ids,
         )
         if resolved_live_scope.is_multiple and args.line_ids is None:
             discard_to_batch_each_resolved_file(

--- a/src/git_stage_batch/cli/discard_dispatch.py
+++ b/src/git_stage_batch/cli/discard_dispatch.py
@@ -101,6 +101,7 @@ def dispatch_discard_command(args: argparse.Namespace) -> None:
             args.file_patterns,
             selected_action=FileReviewAction.DISCARD_FROM_BATCH,
             command_name="discard",
+            line_ids=args.line_ids,
         )
         run_for_each_resolved_file(
             resolved_batch_scope,

--- a/src/git_stage_batch/cli/discard_dispatch.py
+++ b/src/git_stage_batch/cli/discard_dispatch.py
@@ -34,8 +34,9 @@ def _dispatch_discard_replacement(args: argparse.Namespace) -> None:
             args.file,
             args.file_patterns,
             selected_action=FileReviewAction.DISCARD_TO_BATCH,
+            line_ids=args.line_ids,
         )
-        resolved_file = resolved_live_scope.require_single_file(
+        resolved_file = resolved_live_scope.require_single_line_file(
             _("Cannot use --lines with multiple files.")
         )
         replacement_text = require_replacement_text(args)

--- a/src/git_stage_batch/cli/discard_dispatch.py
+++ b/src/git_stage_batch/cli/discard_dispatch.py
@@ -145,8 +145,9 @@ def dispatch_discard_command(args: argparse.Namespace) -> None:
             args.file,
             args.file_patterns,
             selected_action=FileReviewAction.DISCARD,
+            line_ids=args.line_ids,
         )
-        resolved_file = resolved_live_scope.require_single_file(
+        resolved_file = resolved_live_scope.require_single_line_file(
             _("Cannot use --lines with multiple files.")
         )
         command_discard_line(

--- a/src/git_stage_batch/cli/file_scope.py
+++ b/src/git_stage_batch/cli/file_scope.py
@@ -88,12 +88,6 @@ class FileScope:
             raise ValueError("file scope does not have a concrete path")
         return self.files[0]
 
-    def require_single_file(self, error_message: str) -> str | None:
-        """Return an optional single file path, or raise for a multi-file scope."""
-        if self.is_multiple:
-            raise CommandError(error_message)
-        return self.optional_file()
-
     def optional_line_file(self) -> str | None:
         """Return a single line-action file while preserving a selected marker."""
         if self.is_multiple:

--- a/src/git_stage_batch/cli/include_dispatch.py
+++ b/src/git_stage_batch/cli/include_dispatch.py
@@ -59,8 +59,9 @@ def _dispatch_include_replacement(args: argparse.Namespace) -> None:
             args.file,
             args.file_patterns,
             selected_action=FileReviewAction.INCLUDE,
+            line_ids=args.line_ids,
         )
-        resolved_file = resolved_live_scope.require_single_file(
+        resolved_file = resolved_live_scope.require_single_line_file(
             _("Cannot use --lines with multiple files.")
         )
         replacement_text = require_replacement_text(args)

--- a/src/git_stage_batch/cli/include_dispatch.py
+++ b/src/git_stage_batch/cli/include_dispatch.py
@@ -42,8 +42,9 @@ def _dispatch_include_replacement(args: argparse.Namespace) -> None:
             args.file_patterns,
             selected_action=FileReviewAction.INCLUDE_FROM_BATCH,
             command_name="include",
+            line_ids=args.line_ids,
         )
-        resolved_file = resolved_batch_scope.require_single_file(
+        resolved_file = resolved_batch_scope.require_single_line_file(
             _("Cannot use --lines with multiple files.")
         )
         replacement_text = require_replacement_text(args)

--- a/src/git_stage_batch/cli/include_dispatch.py
+++ b/src/git_stage_batch/cli/include_dispatch.py
@@ -127,6 +127,7 @@ def dispatch_include_command(args: argparse.Namespace) -> None:
             args.file_patterns,
             selected_action=FileReviewAction.INCLUDE_FROM_BATCH,
             command_name="include",
+            line_ids=args.line_ids,
         )
         run_for_each_resolved_file(
             resolved_batch_scope,

--- a/src/git_stage_batch/cli/include_dispatch.py
+++ b/src/git_stage_batch/cli/include_dispatch.py
@@ -144,6 +144,7 @@ def dispatch_include_command(args: argparse.Namespace) -> None:
             args.file,
             args.file_patterns,
             selected_action=FileReviewAction.INCLUDE_TO_BATCH,
+            line_ids=args.line_ids,
         )
         run_for_each_resolved_file(
             resolved_live_scope,

--- a/src/git_stage_batch/cli/reset_dispatch.py
+++ b/src/git_stage_batch/cli/reset_dispatch.py
@@ -19,6 +19,7 @@ def dispatch_reset_command(args: argparse.Namespace) -> None:
         args.file_patterns,
         selected_action=FileReviewAction.RESET_FROM_BATCH,
         command_name="reset",
+        line_ids=args.line_ids,
     )
     command_parts = ["reset", "--from", shlex.quote(args.from_batch)]
     if args.to_batch is not None:

--- a/src/git_stage_batch/cli/skip_dispatch.py
+++ b/src/git_stage_batch/cli/skip_dispatch.py
@@ -17,9 +17,10 @@ def dispatch_skip_command(args: argparse.Namespace) -> None:
         args.file,
         args.file_patterns,
         selected_action=FileReviewAction.SKIP,
+        line_ids=args.line_ids,
     )
     if args.line_ids:
-        resolved_file = resolved_file_scope.require_single_file(
+        resolved_file = resolved_file_scope.require_single_line_file(
             _("Cannot use --lines with multiple files.")
         )
         command_skip_line(

--- a/tests/cli/test_argument_parser.py
+++ b/tests/cli/test_argument_parser.py
@@ -994,6 +994,45 @@ def test_parse_command_line_include_to_line_preserves_selected_marker(monkeypatc
         auto_advance=None,
     )
 
+
+def test_parse_command_line_include_from_line_preserves_selected_marker(monkeypatch):
+    """A selected batch marker should remain pathless through shared line dispatch."""
+    mock_command = Mock()
+    monkeypatch.setattr(
+        include_dispatch,
+        "command_include_from_batch",
+        mock_command,
+    )
+    _mock_batch_files(monkeypatch, ["selected.py"])
+    monkeypatch.setattr(
+        file_scope,
+        "get_selected_change_file_path",
+        lambda: "selected.py",
+    )
+
+    args = parse_command_line(
+        [
+            "include",
+            "--from",
+            "cleanup",
+            "--line",
+            "2-3",
+            "--file",
+            "selected.py",
+            "--file",
+        ],
+        quiet=True,
+    )
+
+    assert args is not None
+    args.func(args)
+    mock_command.assert_called_once_with(
+        "cleanup",
+        "2-3",
+        "",
+    )
+
+
 def test_parse_command_line_include_with_files_dispatches_per_file(monkeypatch):
     """Include should dispatch once per file resolved from --files."""
     mock_command = Mock()

--- a/tests/cli/test_argument_parser.py
+++ b/tests/cli/test_argument_parser.py
@@ -924,6 +924,7 @@ def test_parse_command_line_include_with_file_and_line_dispatches_file_scope(mon
     "file_arguments",
     [
         ["--file", "selected.py", "--file"],
+        ["--file", "--file", "selected.py"],
     ],
 )
 def test_parse_command_line_include_line_preserves_selected_marker(

--- a/tests/cli/test_argument_parser.py
+++ b/tests/cli/test_argument_parser.py
@@ -959,6 +959,41 @@ def test_parse_command_line_include_line_preserves_selected_marker(
         auto_advance=None,
     )
 
+
+def test_parse_command_line_include_to_line_preserves_selected_marker(monkeypatch):
+    """A selected marker should remain pathless through shared line dispatch."""
+    mock_command = Mock()
+    monkeypatch.setattr(include_dispatch, "command_include_to_batch", mock_command)
+    _mock_live_file_candidates(monkeypatch, ["selected.py"])
+    monkeypatch.setattr(
+        file_scope,
+        "get_selected_change_file_path",
+        lambda: "selected.py",
+    )
+
+    args = parse_command_line(
+        [
+            "include",
+            "--to",
+            "later",
+            "--line",
+            "2-3",
+            "--file",
+            "selected.py",
+            "--file",
+        ],
+        quiet=True,
+    )
+
+    assert args is not None
+    args.func(args)
+    mock_command.assert_called_once_with(
+        "later",
+        "2-3",
+        "",
+        auto_advance=None,
+    )
+
 def test_parse_command_line_include_with_files_dispatches_per_file(monkeypatch):
     """Include should dispatch once per file resolved from --files."""
     mock_command = Mock()

--- a/tests/cli/test_argument_parser.py
+++ b/tests/cli/test_argument_parser.py
@@ -920,6 +920,44 @@ def test_parse_command_line_include_with_file_and_line_dispatches_file_scope(mon
     )
 
 
+@pytest.mark.parametrize(
+    "file_arguments",
+    [
+        ["--file", "selected.py", "--file"],
+    ],
+)
+def test_parse_command_line_include_line_preserves_selected_marker(
+    monkeypatch,
+    file_arguments,
+):
+    """A deduplicated selected-file marker should stay pathless for line actions."""
+    mock_command = Mock()
+    monkeypatch.setattr(include_dispatch, "command_include_line", mock_command)
+    _mock_live_file_candidates(monkeypatch, ["selected.py"])
+    monkeypatch.setattr(
+        file_scope,
+        "get_selected_change_file_path",
+        lambda: "selected.py",
+    )
+    monkeypatch.setattr(
+        file_scope,
+        "refuse_ambiguous_bare_action_after_partial_file_review",
+        Mock(side_effect=AssertionError("whole-file guard should not run")),
+    )
+
+    args = parse_command_line(
+        ["include", "--line", "2-3", *file_arguments],
+        quiet=True,
+    )
+
+    assert args is not None
+    args.func(args)
+    mock_command.assert_called_once_with(
+        "2-3",
+        file="",
+        auto_advance=None,
+    )
+
 def test_parse_command_line_include_with_files_dispatches_per_file(monkeypatch):
     """Include should dispatch once per file resolved from --files."""
     mock_command = Mock()

--- a/tests/commands/test_file_review.py
+++ b/tests/commands/test_file_review.py
@@ -1088,6 +1088,40 @@ def test_repeated_file_marker_include_to_line_uses_partial_review_scope(
 
     metadata = read_batch_metadata("later")
     assert set(metadata.get("files", {})) == {"file.txt"}
+
+
+def test_repeated_file_marker_include_from_line_uses_partial_review_scope(
+    paged_batch_repo,
+    monkeypatch,
+    capsys,
+):
+    _force_one_change_per_page(monkeypatch)
+    command_show_from_batch("cleanup", file="file.txt", page="1")
+    capsys.readouterr()
+    state = read_last_file_review_state()
+    assert state is not None
+    line_spec = format_line_ids(list(state.selections[0].display_ids))
+    args = parse_command_line(
+        [
+            "include",
+            "--from",
+            "cleanup",
+            "--line",
+            line_spec,
+            "--file",
+            "file.txt",
+            "--file",
+        ],
+        quiet=True,
+    )
+    assert args is not None
+
+    args.func(args)
+
+    captured = capsys.readouterr()
+    assert "Staged selected lines from batch 'cleanup'" in captured.err
+    assert read_last_file_review_state() is not None
+
 def test_pathless_include_line_as_keeps_partial_review_guard_for_bare_action(
     paged_file_repo,
     monkeypatch,

--- a/tests/commands/test_file_review.py
+++ b/tests/commands/test_file_review.py
@@ -1024,6 +1024,39 @@ def test_repeated_file_marker_line_action_preserves_file_list_refusal(
     with pytest.raises(CommandError, match="last command only showed files"):
         args.func(args)
 
+
+def test_repeated_file_marker_line_action_preserves_stale_review_refusal(
+    paged_file_repo,
+    monkeypatch,
+    capsys,
+):
+    _force_one_change_per_page(monkeypatch)
+    command_show(file="file.txt", page="1")
+    capsys.readouterr()
+    state = read_last_file_review_state()
+    assert state is not None
+    line_spec = format_line_ids(list(state.selections[0].display_ids))
+    subprocess.run(
+        ["git", "restore", "file.txt"],
+        check=True,
+        capture_output=True,
+    )
+    args = parse_command_line(
+        [
+            "include",
+            "--line",
+            line_spec,
+            "--file",
+            "file.txt",
+            "--file",
+        ],
+        quiet=True,
+    )
+    assert args is not None
+
+    with pytest.raises(CommandError, match="no longer matches"):
+        args.func(args)
+
 def test_pathless_include_line_as_keeps_partial_review_guard_for_bare_action(
     paged_file_repo,
     monkeypatch,

--- a/tests/commands/test_file_review.py
+++ b/tests/commands/test_file_review.py
@@ -1057,6 +1057,37 @@ def test_repeated_file_marker_line_action_preserves_stale_review_refusal(
     with pytest.raises(CommandError, match="no longer matches"):
         args.func(args)
 
+
+def test_repeated_file_marker_include_to_line_uses_partial_review_scope(
+    paged_file_repo,
+    monkeypatch,
+    capsys,
+):
+    _force_one_change_per_page(monkeypatch)
+    command_show(file="file.txt", page="1")
+    capsys.readouterr()
+    state = read_last_file_review_state()
+    assert state is not None
+    line_spec = format_line_ids(list(state.selections[0].display_ids))
+    args = parse_command_line(
+        [
+            "include",
+            "--to",
+            "later",
+            "--line",
+            line_spec,
+            "--file",
+            "file.txt",
+            "--file",
+        ],
+        quiet=True,
+    )
+    assert args is not None
+
+    args.func(args)
+
+    metadata = read_batch_metadata("later")
+    assert set(metadata.get("files", {})) == {"file.txt"}
 def test_pathless_include_line_as_keeps_partial_review_guard_for_bare_action(
     paged_file_repo,
     monkeypatch,

--- a/tests/commands/test_file_review.py
+++ b/tests/commands/test_file_review.py
@@ -1122,6 +1122,40 @@ def test_repeated_file_marker_include_from_line_uses_partial_review_scope(
     assert "Staged selected lines from batch 'cleanup'" in captured.err
     assert read_last_file_review_state() is not None
 
+
+def test_repeated_file_marker_batch_line_action_preserves_review_source_refusal(
+    paged_batch_repo,
+    monkeypatch,
+    capsys,
+):
+    _force_one_change_per_page(monkeypatch)
+    command_apply_from_batch("cleanup", file="file.txt")
+    command_include_to_batch("other-batch", file="file.txt", quiet=True)
+    capsys.readouterr()
+    command_show_from_batch("cleanup", file="file.txt", page="1")
+    capsys.readouterr()
+    state = read_last_file_review_state()
+    assert state is not None
+    line_spec = format_line_ids(list(state.selections[0].display_ids))
+    args = parse_command_line(
+        [
+            "include",
+            "--from",
+            "other-batch",
+            "--line",
+            line_spec,
+            "--file",
+            "file.txt",
+            "--file",
+        ],
+        quiet=True,
+    )
+    assert args is not None
+
+    with pytest.raises(CommandError, match="no longer matches"):
+        args.func(args)
+
+
 def test_pathless_include_line_as_keeps_partial_review_guard_for_bare_action(
     paged_file_repo,
     monkeypatch,

--- a/tests/commands/test_file_review.py
+++ b/tests/commands/test_file_review.py
@@ -971,6 +971,35 @@ def test_repeated_file_marker_include_line_uses_partial_review_scope(
     captured = capsys.readouterr()
     assert f"Included line(s): {line_spec}" in captured.err
     assert read_last_file_review_state() is not None
+
+
+def test_repeated_file_marker_include_line_rejects_unshown_change(
+    paged_file_repo,
+    monkeypatch,
+    capsys,
+):
+    _force_one_change_per_page(monkeypatch)
+    command_show(file="file.txt", page="1")
+    capsys.readouterr()
+    state = read_last_file_review_state()
+    assert state is not None
+    unshown_spec = format_line_ids(list(state.selections[1].display_ids))
+    args = parse_command_line(
+        [
+            "include",
+            "--line",
+            unshown_spec,
+            "--file",
+            "file.txt",
+            "--file",
+        ],
+        quiet=True,
+    )
+    assert args is not None
+
+    with pytest.raises(CommandError, match="not valid from the current file review"):
+        args.func(args)
+
 def test_pathless_include_line_as_keeps_partial_review_guard_for_bare_action(
     paged_file_repo,
     monkeypatch,

--- a/tests/commands/test_file_review.py
+++ b/tests/commands/test_file_review.py
@@ -13,6 +13,7 @@ from git_stage_batch.batch.ownership.absence_claims import AbsenceClaim
 from git_stage_batch.batch.ownership.replacement_units import ReplacementUnit
 from git_stage_batch.batch.state.query import read_batch_metadata
 from git_stage_batch.batch.text_file_storage import add_file_to_batch
+from git_stage_batch.cli.argument_parser import parse_command_line
 from git_stage_batch.commands.apply_from import command_apply_from_batch
 from git_stage_batch.commands.discard_from import command_discard_from_batch
 from git_stage_batch.commands.discard import command_discard, command_discard_file, command_discard_file_as, command_discard_line, command_discard_line_as_to_batch, command_discard_to_batch
@@ -940,6 +941,35 @@ def test_pathless_include_line_accepts_complete_shown_change_and_keeps_partial_r
     assert read_last_file_review_state() is not None
 
 
+@pytest.mark.parametrize(
+    "file_arguments",
+    [
+        ["--file", "file.txt", "--file"],
+    ],
+)
+def test_repeated_file_marker_include_line_uses_partial_review_scope(
+    paged_file_repo,
+    monkeypatch,
+    capsys,
+    file_arguments,
+):
+    _force_one_change_per_page(monkeypatch)
+    command_show(file="file.txt", page="1")
+    capsys.readouterr()
+    state = read_last_file_review_state()
+    assert state is not None
+    line_spec = format_line_ids(list(state.selections[0].display_ids))
+    args = parse_command_line(
+        ["include", "--line", line_spec, *file_arguments],
+        quiet=True,
+    )
+    assert args is not None
+
+    args.func(args)
+
+    captured = capsys.readouterr()
+    assert f"Included line(s): {line_spec}" in captured.err
+    assert read_last_file_review_state() is not None
 def test_pathless_include_line_as_keeps_partial_review_guard_for_bare_action(
     paged_file_repo,
     monkeypatch,

--- a/tests/commands/test_file_review.py
+++ b/tests/commands/test_file_review.py
@@ -945,6 +945,7 @@ def test_pathless_include_line_accepts_complete_shown_change_and_keeps_partial_r
     "file_arguments",
     [
         ["--file", "file.txt", "--file"],
+        ["--file", "--file", "file.txt"],
     ],
 )
 def test_repeated_file_marker_include_line_uses_partial_review_scope(

--- a/tests/commands/test_file_review.py
+++ b/tests/commands/test_file_review.py
@@ -1000,6 +1000,30 @@ def test_repeated_file_marker_include_line_rejects_unshown_change(
     with pytest.raises(CommandError, match="not valid from the current file review"):
         args.func(args)
 
+
+def test_repeated_file_marker_line_action_preserves_file_list_refusal(
+    paged_file_repo,
+    capsys,
+):
+    _add_second_changed_file(paged_file_repo)
+    command_show_file_list(["file.txt", "other.txt"])
+    capsys.readouterr()
+    args = parse_command_line(
+        [
+            "include",
+            "--line",
+            "1",
+            "--file",
+            "file.txt",
+            "--file",
+        ],
+        quiet=True,
+    )
+    assert args is not None
+
+    with pytest.raises(CommandError, match="last command only showed files"):
+        args.func(args)
+
 def test_pathless_include_line_as_keeps_partial_review_guard_for_bare_action(
     paged_file_repo,
     monkeypatch,


### PR DESCRIPTION
The preceding stack layer lets live and saved-batch scope resolution keep a
pathless `--file` marker alongside its concrete candidate path. Ordinary live
include uses that line-specific contract when it dispatches a selected-line
action.

The remaining line workflows still discard marker provenance before their
command-level review checks. Users combining an explicit path with the
selected-file marker can therefore bypass shown-page, complete-change,
stale-review, or saved-batch source validation depending on the command path.

This pull request carries line intent and marker provenance through the
remaining include replacement and saved-batch paths, apply, reset, discard,
and skip. Command tests cover both marker orders, selected-file dispatch,
unshown lines, incomplete file lists, stale reviews, and foreign saved-batch
sources. The 3,554-test suite with 12 skips, Ruff, dead-code validation,
type-hygiene validation, strict mypy, benchmark smoke, the SHA-256 repository
workflow, and wheel and source-distribution build and install smokes pass
locally.

Include, apply, reset, discard, and skip now keep repeated selected-file
markers under command-level line validation in every affected workflow.
