### PR TITLE
cli: Keep empty line selections on line-action paths

### DIFF
--- a/src/git_stage_batch/cli/discard_dispatch.py
+++ b/src/git_stage_batch/cli/discard_dispatch.py
@@ -140,7 +140,7 @@ def dispatch_discard_command(args: argparse.Namespace) -> None:
                 undo_operation=f"discard --to {shlex.quote(args.to_batch)}",
                 worktree_paths=resolved_live_scope.files,
             )
-    elif args.line_ids:
+    elif args.line_ids is not None:
         resolved_live_scope = resolve_live_file_scope(
             args.file,
             args.file_patterns,

--- a/src/git_stage_batch/cli/discard_dispatch.py
+++ b/src/git_stage_batch/cli/discard_dispatch.py
@@ -29,7 +29,11 @@ from .replacement_input import require_replacement_text
 def _dispatch_discard_replacement(args: argparse.Namespace) -> None:
     if args.as_text is not None and args.as_stdin:
         raise CommandError(_("Cannot use `--as` and `--as-stdin` together."))
-    if args.to_batch and args.line_ids and not args.from_batch:
+    if (
+        args.to_batch
+        and args.line_ids is not None
+        and not args.from_batch
+    ):
         resolved_live_scope = resolve_live_file_scope(
             args.file,
             args.file_patterns,

--- a/src/git_stage_batch/cli/include_dispatch.py
+++ b/src/git_stage_batch/cli/include_dispatch.py
@@ -159,7 +159,7 @@ def dispatch_include_command(args: argparse.Namespace) -> None:
             line_ids=args.line_ids,
             undo_operation=f"include --to {shlex.quote(args.to_batch)}",
         )
-    elif args.line_ids:
+    elif args.line_ids is not None:
         resolved_live_scope = resolve_live_file_scope(
             args.file,
             args.file_patterns,

--- a/src/git_stage_batch/cli/include_dispatch.py
+++ b/src/git_stage_batch/cli/include_dispatch.py
@@ -28,7 +28,7 @@ from .replacement_input import require_replacement_text
 def _dispatch_include_replacement(args: argparse.Namespace) -> None:
     if args.as_text is not None and args.as_stdin:
         raise CommandError(_("Cannot use `--as` and `--as-stdin` together."))
-    if args.line_ids and args.from_batch and not args.to_batch:
+    if args.line_ids is not None and args.from_batch and not args.to_batch:
         if args.no_edge_overlap:
             raise CommandError(
                 _(

--- a/src/git_stage_batch/cli/include_dispatch.py
+++ b/src/git_stage_batch/cli/include_dispatch.py
@@ -55,7 +55,7 @@ def _dispatch_include_replacement(args: argparse.Namespace) -> None:
             replacement_text=replacement_text,
         )
         return
-    if args.line_ids and not args.from_batch and not args.to_batch:
+    if args.line_ids is not None and not args.from_batch and not args.to_batch:
         resolved_live_scope = resolve_live_file_scope(
             args.file,
             args.file_patterns,

--- a/src/git_stage_batch/cli/skip_dispatch.py
+++ b/src/git_stage_batch/cli/skip_dispatch.py
@@ -19,7 +19,7 @@ def dispatch_skip_command(args: argparse.Namespace) -> None:
         selected_action=FileReviewAction.SKIP,
         line_ids=args.line_ids,
     )
-    if args.line_ids:
+    if args.line_ids is not None:
         resolved_file = resolved_file_scope.require_single_line_file(
             _("Cannot use --lines with multiple files.")
         )

--- a/tests/cli/test_argument_parser.py
+++ b/tests/cli/test_argument_parser.py
@@ -920,6 +920,46 @@ def test_parse_command_line_include_with_file_and_line_dispatches_file_scope(mon
     )
 
 
+def _assert_empty_line_selection_stays_a_line_action(
+    monkeypatch,
+    command_name,
+    dispatch_module,
+    line_command_name,
+    file_command_name,
+):
+    """An empty --line value must not fall through to a whole-file action."""
+    line_command = Mock()
+    file_command = Mock(
+        side_effect=AssertionError("whole-file command should not run"),
+    )
+    monkeypatch.setattr(dispatch_module, line_command_name, line_command)
+    monkeypatch.setattr(dispatch_module, file_command_name, file_command)
+    _mock_live_file_candidates(monkeypatch, ["path.txt"])
+
+    args = parse_command_line(
+        [command_name, "--file", "path.txt", "--line", ""],
+        quiet=True,
+    )
+
+    assert args is not None
+    args.func(args)
+    line_command.assert_called_once_with(
+        "",
+        file="path.txt",
+        auto_advance=None,
+    )
+    file_command.assert_not_called()
+
+
+def test_parse_command_line_include_empty_line_stays_a_line_action(monkeypatch):
+    _assert_empty_line_selection_stays_a_line_action(
+        monkeypatch,
+        "include",
+        include_dispatch,
+        "command_include_line",
+        "command_include_file",
+    )
+
 @pytest.mark.parametrize(
     "file_arguments",
     [

--- a/tests/cli/test_argument_parser.py
+++ b/tests/cli/test_argument_parser.py
@@ -960,6 +960,16 @@ def test_parse_command_line_include_empty_line_stays_a_line_action(monkeypatch):
         "command_include_file",
     )
 
+
+def test_parse_command_line_discard_empty_line_stays_a_line_action(monkeypatch):
+    _assert_empty_line_selection_stays_a_line_action(
+        monkeypatch,
+        "discard",
+        discard_dispatch,
+        "command_discard_line",
+        "command_discard_file",
+    )
+
 @pytest.mark.parametrize(
     "file_arguments",
     [

--- a/tests/cli/test_argument_parser.py
+++ b/tests/cli/test_argument_parser.py
@@ -970,6 +970,17 @@ def test_parse_command_line_discard_empty_line_stays_a_line_action(monkeypatch):
         "command_discard_file",
     )
 
+
+def test_parse_command_line_skip_empty_line_stays_a_line_action(monkeypatch):
+    _assert_empty_line_selection_stays_a_line_action(
+        monkeypatch,
+        "skip",
+        skip_dispatch,
+        "command_skip_line",
+        "command_skip_file",
+    )
+
+
 @pytest.mark.parametrize(
     "file_arguments",
     [


### PR DESCRIPTION
All affected line-command dispatchers now retain selected-file markers until
their command-level review checks run.

Several dispatch branches still distinguish line actions from whole-file
actions by testing the parsed line value for truthiness. An explicitly present
but empty line selection is therefore routed as a whole-file action or rejected
as an invalid replacement request.

This pull request switches direct and replacement dispatch for include,
discard, and skip to test whether a line value is present, including the empty
string. Focused callback tests assert that every empty selection reaches only
the line implementation and never the whole-file path. The 3,557-test suite
with 12 skips, Ruff, dead-code validation, type-hygiene validation, strict
mypy, benchmark smoke, the SHA-256 repository workflow, and wheel and
source-distribution build and install smokes pass locally.

Explicitly empty line selections now remain on line-action paths throughout
the affected include, discard, and skip workflows.
