### PR TITLE
scripts: Add advisory dead-code reporting

### DIFF
--- a/scripts/check_dead_code.py
+++ b/scripts/check_dead_code.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
-"""Reject unreviewed Vulture findings and stale finding exceptions."""
+"""Report unreviewed Vulture findings and stale finding exceptions."""
 
 from __future__ import annotations
 
+import argparse
 from collections import Counter
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 import sys
@@ -350,7 +352,58 @@ def find_unused_code() -> list[Finding]:
     ]
 
 
-def main() -> int:
+def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--advisory",
+        action="store_true",
+        help=(
+            "emit GitHub warning annotations and succeed when dead-code "
+            "policy findings are present"
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def _workflow_command_data(value: str) -> str:
+    """Escape message data used in a GitHub workflow command."""
+    return (
+        value.replace("%", "%25")
+        .replace("\r", "%0D")
+        .replace("\n", "%0A")
+    )
+
+
+def _workflow_command_property(value: str) -> str:
+    """Escape a property used in a GitHub workflow command."""
+    return (
+        _workflow_command_data(value)
+        .replace(":", "%3A")
+        .replace(",", "%2C")
+    )
+
+
+def _emit_warning(
+    *,
+    path: str,
+    line: int | None,
+    title: str,
+    message: str,
+) -> None:
+    properties = [
+        f"file={_workflow_command_property(path)}",
+        f"title={_workflow_command_property(title)}",
+    ]
+    if line is not None:
+        properties.append(f"line={line}")
+    print(
+        f"::warning {','.join(properties)}::"
+        f"{_workflow_command_data(message)}"
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
     findings = find_unused_code()
     allowed = _allowed_findings_by_identity()
     counts = Counter(finding.identity for finding in findings)
@@ -371,21 +424,38 @@ def main() -> int:
         return 0
 
     for finding in unexpected:
+        message = f"{finding.message} ({finding.confidence}% confidence)"
         print(
-            f"{finding.identity.path}:{finding.line}: {finding.message} "
-            f"({finding.confidence}% confidence)",
+            f"{finding.identity.path}:{finding.line}: {message}",
             file=sys.stderr,
         )
+        if args.advisory:
+            _emit_warning(
+                path=finding.identity.path,
+                line=finding.line,
+                title="Dead code in intermediate stack layer",
+                message=message,
+            )
     for allowed_finding, actual_count in count_mismatches:
         identity = allowed_finding.identity
-        print(
-            f"{identity.path}: stale or changed dead-code exception for "
+        message = (
+            "stale or changed dead-code exception for "
             f"{identity.kind} {identity.name!r}: expected "
             f"{allowed_finding.expected_count}, found {actual_count}; "
-            f"{allowed_finding.reason}",
+            f"{allowed_finding.reason}"
+        )
+        print(
+            f"{identity.path}: {message}",
             file=sys.stderr,
         )
-    return 1
+        if args.advisory:
+            _emit_warning(
+                path=identity.path,
+                line=None,
+                title="Dead-code exception in intermediate stack layer",
+                message=message,
+            )
+    return 0 if args.advisory else 1
 
 
 if __name__ == "__main__":

--- a/tests/architecture/test_dead_code_check.py
+++ b/tests/architecture/test_dead_code_check.py
@@ -1,0 +1,89 @@
+"""Tests for the maintained dead-code policy check."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+
+import pytest
+
+
+SCRIPT_PATH = Path(__file__).parents[2] / "scripts" / "check_dead_code.py"
+SPEC = importlib.util.spec_from_file_location("check_dead_code", SCRIPT_PATH)
+assert SPEC is not None
+assert SPEC.loader is not None
+check_dead_code = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = check_dead_code
+SPEC.loader.exec_module(check_dead_code)
+
+
+@pytest.fixture
+def unexpected_finding(monkeypatch):
+    finding = check_dead_code.Finding(
+        identity=check_dead_code.FindingIdentity(
+            path="src/git_stage_batch/example.py",
+            kind="function",
+            name="unused_helper",
+        ),
+        line=42,
+        message="unused function 'unused_helper'",
+        confidence=100,
+    )
+    monkeypatch.setattr(check_dead_code, "ALLOWED_FINDINGS", ())
+    monkeypatch.setattr(check_dead_code, "find_unused_code", lambda: [finding])
+    return finding
+
+
+def test_strict_mode_rejects_unexpected_finding(unexpected_finding, capsys):
+    assert check_dead_code.main([]) == 1
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "src/git_stage_batch/example.py:42" in captured.err
+    assert "::warning" not in captured.err
+
+
+def test_advisory_mode_warns_without_failing(unexpected_finding, capsys):
+    assert check_dead_code.main(["--advisory"]) == 0
+
+    captured = capsys.readouterr()
+    assert "src/git_stage_batch/example.py:42" in captured.err
+    assert captured.out == (
+        "::warning file=src/git_stage_batch/example.py,"
+        "title=Dead code in intermediate stack layer,line=42::"
+        "unused function 'unused_helper' (100%25 confidence)\n"
+    )
+
+
+def test_advisory_mode_warns_for_stale_exception(monkeypatch, capsys):
+    allowed = check_dead_code._allowed(
+        "src/git_stage_batch/example.py",
+        "function",
+        "indirect_helper",
+        "Called by generated code.",
+    )
+    monkeypatch.setattr(check_dead_code, "ALLOWED_FINDINGS", (allowed,))
+    monkeypatch.setattr(check_dead_code, "find_unused_code", lambda: [])
+
+    assert check_dead_code.main(["--advisory"]) == 0
+
+    captured = capsys.readouterr()
+    assert "stale or changed dead-code exception" in captured.err
+    assert "::warning file=src/git_stage_batch/example.py" in captured.out
+    assert "title=Dead-code exception in intermediate stack layer" in captured.out
+
+
+def test_warning_escapes_properties_separately_from_message_data(capsys):
+    check_dead_code._emit_warning(
+        path="src/git_stage_batch/example,one.py",
+        line=7,
+        title="Dead code: advisory",
+        message="100% confidence: unused, for now\nreview the stack",
+    )
+
+    assert capsys.readouterr().out == (
+        "::warning file=src/git_stage_batch/example%2Cone.py,"
+        "title=Dead code%3A advisory,line=7::"
+        "100%25 confidence: unused, for now%0Areview the stack\n"
+    )


### PR DESCRIPTION
The dead-code checker rejects every unreviewed Vulture finding and stale
exception with a nonzero exit status. It has no reporting mode that can
keep those findings visible without returning failure.

An incomplete pull request stack can intentionally contain definitions
that a later pull request adopts. Strict-only reporting therefore forces
reviewers to combine groundwork with its adopter or accept a failing pull
request even when the complete stack is free of dead code.

This pull request adds an advisory checker mode that emits escaped GitHub
warning annotations and succeeds for policy findings while leaving
failures in the scanner fatal. Focused tests cover unexpected findings,
stale exceptions, strict and advisory exit statuses, and the separate
escaping rules for workflow-command properties and message data. The
3,561-test suite with 12 skips, Ruff, strict dead-code validation,
type-hygiene validation, strict mypy, benchmark smoke, the SHA-256
repository workflow, and wheel and source-distribution build and install
smokes pass locally.

Dead-code policy findings can now remain visible in a non-fatal review
without weakening the strict enforcement contract.
