### PR TITLE
ci: Warn on dead code in intermediate pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,9 +77,26 @@ jobs:
       - name: Run Ruff
         run: uv run ruff check src tests scripts
 
+      # A stack layer may provide groundwork used only by a later layer. Keep
+      # the cumulative top (and every standalone tree) strict while making
+      # incomplete intermediate-layer findings visible without blocking them.
       - name: Check for dead code
-        if: matrix.python-version == '3.10'
+        if: >-
+          matrix.python-version == '3.10' &&
+          (
+            github.event_name != 'pull_request' ||
+            github.event.pull_request.stack == null ||
+            github.event.pull_request.stack.position == github.event.pull_request.stack.size
+          )
         run: uv run python scripts/check_dead_code.py
+
+      - name: Check for dead code (advisory)
+        if: >-
+          matrix.python-version == '3.10' &&
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.stack != null &&
+          github.event.pull_request.stack.position < github.event.pull_request.stack.size
+        run: uv run python scripts/check_dead_code.py --advisory
 
       - name: Check type hygiene
         if: matrix.python-version == '3.10'

--- a/tests/architecture/test_support_contract.py
+++ b/tests/architecture/test_support_contract.py
@@ -45,6 +45,26 @@ def test_ci_install_checks_both_distribution_formats():
     assert "dist/*.tar.gz" in workflow
 
 
+def test_ci_enforces_dead_code_for_complete_pull_request_stacks():
+    """Intermediate pull requests in a stack should warn.
+
+    Complete trees should retain strict dead-code enforcement.
+    """
+    workflow = _read_project_file(".github/workflows/ci.yml")
+
+    assert "github.event.pull_request.stack == null" in workflow
+    assert (
+        "github.event.pull_request.stack.position == "
+        "github.event.pull_request.stack.size"
+    ) in workflow
+    assert "Check for dead code (advisory)" in workflow
+    assert "scripts/check_dead_code.py --advisory" in workflow
+    assert (
+        "github.event.pull_request.stack.position < "
+        "github.event.pull_request.stack.size"
+    ) in workflow
+
+
 def test_release_uses_trusted_publishing():
     """The PyPI job should use OIDC without a stored publishing token."""
     workflow = _read_project_file(".github/workflows/release.yml")


### PR DESCRIPTION
The preceding pull request in the stack adds a tested advisory mode to the
dead-code checker. The continuous integration workflow still invokes only
the strict mode for every push and pull request.

A pull request that introduces groundwork can contain temporarily unused
definitions when a later pull request in the same stack adopts them.
Failing that intermediate review prevents the groundwork from remaining an
independent pull request even when the cumulative top is free of dead code.

This pull request selects advisory reporting for pull requests below the
top of a stack by using GitHub's pull request stack position and size.
Standalone pull requests, the top pull request in each stack, and pushes to
the main branch remain strict. An architecture test protects each workflow
predicate and the advisory invocation. The 3,562-test suite with 12 skips,
Ruff, strict dead-code validation, type-hygiene validation, strict mypy,
benchmark smoke, the SHA-256 repository workflow, and wheel and
source-distribution build and install smokes pass locally.

Intermediate pull requests can now report temporary dead code without
blocking the stack, while complete review trees retain strict enforcement.
