### PR TITLE
assets: Add Claude unpublished-commit publication

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,13 +76,13 @@ claude "/commit-unstaged-changes"
 
 Omit `--filter` when installing Claude skills if you also want the larger
 `/decompose-and-commit-unstaged-changes` workflow and the standalone
-`/refine-history BASE_SHA` and `/refine-commit-messages BASE_SHA` workflows.
-The latter rewrites noncompliant messages by default while preserving every
-patch and boundary; use `audit BASE_SHA` for a report without history changes.
-Selecting `refine-history` installs its message-refinement dependency, and
-selecting decomposition installs both. Mutating refinement accepts only a
-clean, linear, unpublished range; use the corresponding `resume` form to
-continue an interrupted run.
+`/refine-history BASE_SHA`, `/refine-commit-messages BASE_SHA`, and
+`/publish-unpushed-commits` workflows. Publication creates ready-for-review
+GitHub pull requests or GitLab merge requests by default, supports explicit
+`draft` and `audit` modes, handles forks and provider-native stacks, and never
+merges. Selecting publication or decomposition installs both refinement
+dependencies. Mutating refinement and publication accept only a clean, linear,
+unpublished range and provide a `resume` form for interruption.
 
 ## Example Workflow
 

--- a/assets/claude-skills/publish-unpushed-commits/SKILL.md
+++ b/assets/claude-skills/publish-unpushed-commits/SKILL.md
@@ -1,0 +1,570 @@
+---
+name: publish-unpushed-commits
+description: Turn a clean local range of unpublished commits into reviewable GitHub pull requests or GitLab merge requests, choosing provider-native stacks when suitable and ordinary review requests for singletons, unavailable stack support, and forks
+user-invocable: true
+disable-model-invocation: true
+argument-hint: "[ready|draft|audit|resume]"
+when_to_use: "Use when the user asks Claude Code to publish, submit, open review requests for, or resume publishing local unpublished commits. Publish ready for review by default; use explicit draft mode for drafts and audit mode for a non-publishing plan. Never merge or change unrelated collaboration state."
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - LS
+  - Edit
+  - Write
+  - Agent(commit-message-drafter)
+  - Bash(git *)
+  - Bash(gh api *)
+  - Bash(gh auth status *)
+  - Bash(gh pr list *)
+  - Bash(gh pr view *)
+  - Bash(gh repo view)
+  - Bash(gh repo view *)
+  - Bash(glab api *)
+  - Bash(glab auth status *)
+  - Bash(glab config get *)
+  - Bash(glab repo view)
+  - Bash(glab repo view *)
+  - Bash(git-stage-batch *)
+  - Bash(pipx run git-stage-batch *)
+  - Bash(python3 *)
+  - Bash(mkdir *)
+  - Bash(mktemp *)
+  - Bash(test *)
+---
+
+# Publish Unpushed Commits
+
+Publish a curated local commit range as the smallest natural set of pull
+requests or merge requests. Preserve useful commit and review boundaries,
+choose the remote topology from provider capabilities, and stop after verified
+publication.
+
+Read the matching `references/github-publication.md` or
+`references/gitlab-publication.md` before any push or review-request creation.
+Use `scripts/publish-checkpoint.py` for every mutating run so partial
+multi-branch publication can be resumed without conversation memory.
+
+## Usage and authority
+
+Invocation arguments: `$ARGUMENTS`
+
+```text
+/publish-unpushed-commits
+/publish-unpushed-commits ready
+/publish-unpushed-commits draft
+/publish-unpushed-commits audit
+/publish-unpushed-commits resume
+```
+
+Treat an invocation without a mode as `ready`. Ready mode creates review
+requests as ready from the outset; do not create drafts and promote them as a
+staging mechanism. Draft status is opt-in and applies to every new review
+request in the run. Resume preserves the recorded requested status and accepts
+no new status. Audit performs remote queries and produces the complete grouping,
+topology, validation, branch, title, and body plan without rewriting history,
+pushing branches, creating review requests, or writing a checkpoint.
+
+A mutating invocation authorizes rebasing and refining only the demonstrably
+unpublished range, creating private recovery and planning refs, pushing new
+run-owned branches, creating its review requests with frozen prose, and
+creating eligible native GitHub stack relationships. It does not authorize
+merging, enabling auto-merge, requesting reviews, changing labels or
+milestones, bypassing repository rules, editing any existing review request,
+or making product changes solely to obtain passing continuous integration.
+
+## Preserve these invariants
+
+- Require a clean index and worktree, a named local branch, a nonempty linear
+  range, no Git operation in progress, working authentication for the selected
+  GitHub or GitLab host, and no active `git-stage-batch` session. Saved batches
+  do not block publication.
+- Read the repository instructions, contribution guide, review-request
+  template, commit hook, workflows, and representative accepted reviews before
+  changing history or drafting prose.
+- Select one publication remote: use the explicitly supplied remote when
+  present and `origin` otherwise. Fetch and inspect only that remote. Do not
+  enumerate, fetch, inspect, or query other configured Git remotes merely
+  because they exist. Before any rewrite, query advertised tags from the
+  selected remote and from each resolved target or head repository that it
+  does not represent. Reject a range commit that is a lightweight-tag target,
+  the peeled target of an annotated tag, reachable from the selected remote's
+  remote-tracking refs, or associated with an existing review request unless
+  resuming the exact recorded run. Do not classify an unadvertised local tag as
+  publication.
+- Resolve the provider, host URL, target repository, head repository, push
+  remote, target trunk, and fetched trunk commit independently. Never assume
+  `origin` is both the fork and its upstream.
+- For GitLab, pin every API call to the authenticated hostname and resolve both
+  repository paths to numeric project IDs before starting recovery state. Do
+  not store credentials. Reject self-managed installations served below a
+  relative URL path.
+- For GitHub, resolve and checkpoint the immutable numeric IDs of both
+  repositories as well as their canonical owner/name paths. Re-read both
+  identities before every push or remote review-request mutation so a rename,
+  transfer, deletion, or path reuse fails closed.
+- Create a recovery ref before the first publication-owned rewrite. Use only
+  unique run-owned branch names and explicit force-with-lease expectations.
+  Bind the sole configured push URL to an API-observed clone URL for the head
+  repository, checkpoint credential-safe digests, and reject an unverifiable,
+  remapped, or ambiguous remote on resume. Never force-push the trunk, adopt an
+  existing remote branch on a fresh run, or push an unrecorded branch.
+- Preserve the aggregate intended change. Reorder groups only when patches and
+  prerequisites prove independence. Preserve authors and compare rewritten
+  series with recovery refs using `git --no-optional-locks range-diff`.
+- Keep every review-request snapshot reviewable and runnable to the degree
+  required by the repository. A higher review request must not be the only
+  place that repairs an unintentionally broken lower snapshot.
+- Draft every exact title and body template before publication. A higher layer
+  contains exactly one frozen placeholder for its preceding review request;
+  render that URL before creation. Ready mode creates ready review requests
+  with that final prose, avoiding both later body edits and a draft-to-ready
+  notification cycle.
+- Use native GitHub stacks only for eligible dependent multi-pull-request
+  groups in one repository. GitLab recognizes eligible same-project branch
+  chains as stacked merge requests. Use ordinary review requests for
+  singletons, unavailable stack support, and forks.
+- Treat every push and remote mutation as non-atomic. Record and inspect partial
+  results before retrying. Never delete remote recovery evidence automatically.
+
+Stop on ambiguous range ownership, provider or authentication failure, changed
+remote branches, existing review requests not owned by the checkpoint, unsafe
+history rewrites, conflicts that disprove the grouping, missing local validation,
+partial publication whose exact result cannot be established, or any need for
+new product work. Report the recovery ref and run directory.
+
+## Git command concurrency
+
+Prefix every read-only Git command with `git --no-optional-locks`, including
+commands run while executing either refinement contract in process. This
+applies to repository inspection such as `status`, `diff`, `log`, `show`,
+`branch`, `remote`, `rev-parse`, `for-each-ref`, `ls-remote`, `range-diff`, and
+`apply --check`. It prevents optional index-stat refreshes from contending for
+`.git/index.lock` when independent reads run concurrently.
+
+The publication and refinement checkpoint helpers already apply this option to
+their Git subprocesses. Do not infer that it makes mutations safe to overlap:
+run fetches, history rewrites, branch or ref updates, commits, and pushes
+serially in their documented order.
+
+## Progress discipline
+
+Use the compact audit table as the progress record for sections 1 and 2. Once
+section 3 starts the checkpoint, run `python3 "$PUBLISH_HELPER" status --json`
+at the end of every numbered section and before continuing after compaction or
+interruption. The expected phases after sections 3 through 6 are respectively
+`started` with a normalized result, `planned`, `validated`, and `published`.
+Resolve any mismatch before continuing; do not create a parallel progress file
+or rely on a conversational checklist instead of the checkpoint.
+
+## 1. Resolve repositories and freeze the range
+
+Move to the repository root and inspect local state. Before first use, read
+`git-stage-batch --help`. For GitHub, read `gh api --help`, `gh repo view
+--help`, `gh pr list --help`, and `gh pr view --help`. For GitLab, read `glab
+api --help`, `glab repo view --help`, and `glab config get --help`, plus `glab
+auth status --help` when using its optional diagnostics.
+
+For a fresh run, use an explicitly supplied target repository, push remote,
+trunk, or base when present. Otherwise:
+
+1. Use an explicitly supplied push remote when present; otherwise require and
+   use `origin`. Do not infer a different remote from branch configuration.
+2. Identify its host and provider. Use `gh repo view` for GitHub and
+   `glab repo view` for GitLab. If both or neither CLI recognizes a self-hosted
+   remote, require an explicit provider instead of guessing.
+3. When the head repository is a fork, default the target repository to its
+   provider-reported parent. Otherwise target the head repository.
+4. Resolve the target repository's default branch as the trunk.
+5. Fetch only the selected publication remote. If it does not represent the
+   target repository, fetch the target trunk by URL into a uniquely named
+   private ref without adding or changing Git configuration. Ignore every
+   other configured remote.
+
+For GitLab, derive the hostname from the root host URL and use a host-pinned
+`glab api --hostname HOST user` query as the authoritative authentication
+check. `glab auth status` is optional diagnostics because an environment-only
+token need not appear as stored login state. Authentication comes from
+`glab`'s credential store or its documented token environment variables;
+never inspect or persist the token itself. Resolve and verify the numeric
+target and head project IDs, their canonical project URLs, and the configured
+API host before starting recovery state. Read
+`references/gitlab-publication.md` for the exact preflight.
+
+For GitHub, likewise derive the exact root hostname, pass it to every `gh api`
+call with `--hostname`, and use fully qualified `[HOST/]OWNER/REPO` arguments
+for other `gh` commands. Use `gh api --hostname HOST user` as the authentication
+check and verify the target and head repository identities before recovery state.
+Authentication may come from the exact host's `gh` credential store or its
+documented token environment variables; never inspect or persist the token.
+Record each repository's positive numeric API `id`, canonical `full_name`,
+canonical URL, and provider-returned HTTPS and SSH clone URLs. Require the
+configured push URL to match one of the head repository's observed clone URLs;
+fail closed on SSH aliases or other forms that cannot be matched exactly.
+Read `references/github-publication.md` for the exact preflight.
+
+Record `HEAD`, provider, host URL, the target trunk commit, their merge base,
+the current branch, the selected remote URL, repository owners, and every
+commit in merge-base-to-`HEAD` order. Reject a detached head, merge commits in
+the range, an empty range, dirty state, or any range commit found through the
+selected remote's tracking refs or the provider's review-request queries.
+
+Before invoking either refinement skill, build a tag-query source set covering
+the selected publication remote plus the resolved target and head repositories.
+Use the selected remote name when it represents that repository and a
+provider-reported clone URL otherwise; deduplicate sources by canonical
+provider repository identity. Never enumerate other configured Git remotes or
+their remote-tracking refs. Run this command for every source and require every
+query to succeed:
+
+```bash
+git --no-optional-locks ls-remote --tags SOURCE
+```
+
+Do not add `--refs`, because that would omit the `^{}` records that peel
+annotated tags.
+Compare the complete range with both direct tag object identifiers and peeled
+identifiers; any matching commit has already been published. Perform this
+query again if the range boundary changes before checkpoint start.
+
+When installed, run `git-stage-batch status`; block only an active session.
+`git-stage-batch list` may report durable saved batches without blocking this
+workflow because publication does not reinterpret them.
+
+## 2. Audit outcomes and dependencies
+
+Inspect each commit and patch once. Build one compact table with original
+position, commit identifier, plain-language outcome, prerequisite, proposed
+group, proposed review request, and boundary reason. Reuse the table for
+history, branch, title, body, and completion work.
+
+Choose boundaries by outcome:
+
+- Keep one cohesive independently landable outcome in one review request.
+- Put a prerequisite below its consumers in one dependent group.
+- Put unrelated independently landable work in separate groups rooted at the
+  target trunk; adjacency does not create a dependency.
+- Keep behavior with the tests, fixtures, documentation, generated output, and
+  exact checker policy needed to review that behavior.
+- Keep groundwork separate when it is independently understandable and its
+  adopter will be a later review request in the same publication group.
+- Do not split by directory, file type, commit count, or equal size.
+- Do not manufacture multiple review requests for a cohesive singleton.
+
+Do not change commit boundaries solely to achieve a preferred review-request
+count. If one commit mixes outcomes that must publish independently, invoke
+`/refine-history BASE_SHA` before starting the publication checkpoint. Rebuild
+the compact audit after that rewrite. If a safe split is not justified, keep
+the commit in one review request.
+
+When this workflow says to invoke an installed refinement skill, use the
+runtime's nested skill mechanism when it is available. If the runtime cannot
+recursively invoke a user-only skill, locate and read that skill's complete
+`SKILL.md`, then execute its contract in-process with the explicit base and
+mode. Apply the same fallback recursively when `refine-history` hands work to
+`refine-commit-messages`. Do not replace either contract with an abridged copy
+or ask the user to restart the publication workflow.
+
+Both refinement dependencies are installed with this skill, and the
+publisher's tool surface covers their contracts. The full-contract fallback
+preserves their checkpoints and validation without duplicating a weaker
+refinement procedure here.
+
+In audit mode, complete the remaining planning and validation analysis without
+executing its mutations, then report the proposed topology and stop.
+
+## 3. Start recovery state and normalize history
+
+After fetching and any required boundary refinement, start the checkpoint. The
+explicit base is the frozen merge base; the target base is the fetched target
+trunk commit:
+
+```bash
+PUBLISH_HELPER="${CLAUDE_SKILL_DIR}/scripts/publish-checkpoint.py"
+PROVIDER_ID_ARGS=()
+if [[ "$PROVIDER" == github ]]; then
+  PROVIDER_ID_ARGS=(
+    --target-repository-id "$TARGET_REPOSITORY_ID"
+    --head-repository-id "$HEAD_REPOSITORY_ID"
+  )
+else
+  PROVIDER_ID_ARGS=(
+    --target-project-id "$TARGET_PROJECT_ID"
+    --head-project-id "$HEAD_PROJECT_ID"
+  )
+fi
+python3 "$PUBLISH_HELPER" start \
+  --base "$FORK_POINT" \
+  --target-base "$TARGET_BASE_SHA" \
+  --provider "$PROVIDER" \
+  --host-url "$HOST_URL" \
+  --target-repository "$TARGET_REPOSITORY" \
+  --head-repository "$HEAD_REPOSITORY" \
+  "${PROVIDER_ID_ARGS[@]}" \
+  --remote "$PUSH_REMOTE" \
+  --head-push-url "$HEAD_HTTPS_CLONE_URL" \
+  --head-push-url "$HEAD_SSH_CLONE_URL" \
+  --trunk "$TRUNK_BRANCH" \
+  --status "$REQUESTED_STATUS"
+RUN_DIR=$(python3 "$PUBLISH_HELPER" run-dir)
+```
+
+The helper rejects remotely reachable history, creates a recovery ref, and
+preserves prior completed runs. It requires exactly one push URL for the named
+remote and proves that URL matches an API-observed head-repository clone URL.
+It records only credential-safe SHA-256 destination identities. Recognized
+credential rotation therefore does not invalidate a resume, but an account,
+host, port, path, or non-credential query remap does. Do not manually replace
+its active pointer or checkpoint.
+
+Create a unique private planning branch at the recorded source head. Rebase it
+onto the exact fetched target base before grouping. Resolve only conflicts whose
+result is established by the existing patches and tests; otherwise stop. Check
+the rewrite with `git --no-optional-locks range-diff` and compare the aggregate
+diff semantically.
+
+Create one cumulative branch at each proposed review-request tip. Each
+dependent group starts at the target base, and each higher branch contains the
+preceding branch. Independent groups each start at the target base. Use an
+integration branch to compose independent group tips in intended landing order;
+require its tree to represent the normalized aggregate result.
+
+Refine messages bottom-up within each review request by invoking
+`/refine-commit-messages DIRECT_PARENT_TIP`. Cascade changed identifiers into
+descendant branches, then recheck all anchors and the integration result. Treat
+each review request as its own message series: a final commit concludes its
+review request, while a real dependency names the preceding pull request or
+merge request in the stack or series in plain long-form prose. Do not use
+compressed labels such as "preceding stack layer."
+
+After every rewrite and branch tip stabilizes, freeze the integration result:
+
+```bash
+python3 "$PUBLISH_HELPER" record-normalized --tip "$INTEGRATION_TIP"
+```
+
+## 4. Choose publication topology and draft prose
+
+Read the selected provider reference now. For GitHub, probe stack support before
+any push and select `github-stack` only for an eligible same-repository group of
+two to one hundred dependent pull requests. For GitLab, select `gitlab-stack`
+only for an eligible same-project group of two to ten dependent merge requests;
+GitLab recognizes the direct-base chain without a separate stack mutation.
+Select `ordinary` for every other group. Unavailable native support, a
+singleton, an oversized group, or a fork is a supported ordinary path.
+Authentication, provider mismatch, or transient API failure is ambiguous and
+must stop instead of silently changing topology.
+
+For a provider-native stack, plan the bottom review request against the trunk
+and each higher review request against the branch immediately below it. For
+ordinary publication, including same-repository fallbacks and cross-fork
+groups, plan every cumulative review request against the target trunk and
+explain the temporary overlapping diff in its body. This distinction prevents
+an oversized GitLab group from being inferred as a native stack despite its
+`ordinary` plan.
+
+Derive each title and body from that review request's direct-base diff. Follow
+the repository template and recent accepted style. Apply the repository's
+complete commit-message guidance at review-request scope rather than copying
+commit bodies. Write for a drive-by reviewer who does not know the local group
+names.
+
+Every body must explain the selected state, concrete limitation or motivation,
+the review request's outcome, validation, and any prerequisite. Name a
+dependency as `the preceding pull request in the stack` or `the preceding merge
+request in the stack` for a provider stack, and use `the preceding pull request
+in the series` or `the preceding merge request in the series` for ordinary
+publication. The bottom body contains no relationship placeholder. Every
+higher body contains exactly one literal `{{PRECEDING_REVIEW_URL}}` where the
+preceding review request's canonical URL belongs. A directed link to the
+preceding review request is sufficient; do not promise a successor or plan a
+post-creation edit. Store exact body templates under the active run directory
+before recording the plan.
+
+Write `plan-input.json` with this shape and record it:
+
+```json
+{
+  "schema": 1,
+  "base": "FULL_TARGET_BASE_SHA",
+  "integration_tip": "FULL_INTEGRATION_TIP_SHA",
+  "groups": [
+    {
+      "id": "cohesive-group",
+      "transport": "ordinary",
+      "layers": [
+        {
+          "id": "reviewable-outcome",
+          "branch": "publish/reviewable-outcome-RUN_ID",
+          "base_branch": "main",
+          "tip": "FULL_LAYER_TIP_SHA",
+          "title": "Exact review-request title",
+          "body_file": "bodies/reviewable-outcome.md"
+        }
+      ]
+    }
+  ]
+}
+```
+
+```bash
+python3 "$PUBLISH_HELPER" record-plan --file "$RUN_DIR/plan-input.json"
+```
+
+The helper is authoritative for mechanical plan validity. It rejects an empty
+or net-zero normalized result, an empty incremental layer, a net-zero group, a
+target-trunk publication branch, an invalid body placeholder layout, a provider
+stack outside its size bounds, and any set of group outcomes that does not
+compose cleanly and exactly to the frozen integration tree. This summary
+explains the aggregate-coverage gate; it is not a replacement for semantic
+patch review.
+
+## 5. Validate every planned snapshot
+
+Validate each layer tip against its direct base before pushing:
+
+1. Re-read its commit messages, exact diff, title, and body.
+2. Run the repository's complete local continuous integration gate at that tip.
+3. Confirm that no higher layer is required to repair an unintended failure.
+4. Re-fetch the target trunk. If it moved, rebuild from the checkpoint's
+   recovery state and rerun every affected check. Before recording the rebuilt
+   plan, replace the pre-validation target and aggregate result explicitly:
+
+   ```bash
+   python3 "$PUBLISH_HELPER" refresh-normalized \
+     --target-base "$NEW_TARGET_BASE_SHA" \
+     --tip "$NEW_INTEGRATION_TIP_SHA"
+   ```
+
+   Rewrite any body whose direct-base diff changed, then record the complete
+   replacement plan. The helper returns the run to `started` and does not
+   permit this transition after validation freezes.
+5. Query remote branches and all review-request states again. Require every
+   branch to be absent on a fresh run. On resume, require exact checkpoint
+   ownership.
+6. Verify the integration tree and aggregate diff against the normalized result.
+
+Record successful completion of the entire local gate:
+
+```bash
+python3 "$PUBLISH_HELPER" advance --phase validated
+```
+
+Do not publish a subset whose planned lower or higher snapshots failed. If
+passing requires new product work, stop and ask for that separate authority.
+
+## 6. Publish and verify
+
+Advance immediately before the first push:
+
+```bash
+python3 "$PUBLISH_HELPER" advance --phase publishing
+```
+
+Follow the selected provider reference. Push every run-owned branch with an
+explicit lease, running `prepare-push` before each remote side effect and
+`confirm-push` after fetching its exact result. Create ordinary or stack-member
+review requests bottom-to-top with their exact final prose and requested
+status. Before creating a higher layer, record the preceding layer so the
+helper can render its frozen URL placeholder into an immutable body file.
+GitLab uses helper-generated JSON with host-pinned `glab api` calls, not
+`glab mr create` or `glab mr update`. After creating every member of a native
+GitHub stack, use `github-stack-request` and the direct GitHub stack-creation
+REST endpoint to create or adopt exactly the planned stack. A GitLab stack
+needs no separate mutation; verify its direct target-branch chain.
+
+Immediately after each creation call, query the target repository, verify the
+new review request's initial identity, exact head and base objects, title,
+body, open state, and requested draft state, then checkpoint the immutable
+provider-assigned number and URL before creating the next layer or a GitHub
+stack relationship:
+
+```bash
+python3 "$PUBLISH_HELPER" record-created-review \
+  --layer "$LAYER_ID" \
+  --number "$REVIEW_NUMBER" \
+  --url "$REVIEW_URL" \
+  --head "$VERIFIED_HEAD_SHA" \
+  --base "$VERIFIED_BASE_BRANCH" \
+  --base-head "$VERIFIED_BASE_HEAD_SHA" \
+  --status "$REQUESTED_STATUS"
+```
+
+The checkpoint binds every later operation to that observed review request.
+Never accept a caller-supplied review number as a mutation target. Do not edit a
+created title or body: providers do not offer a portable conditional update for
+that prose, so any mismatch or collaborator drift must stop the run rather than
+be overwritten. After creating or adopting a native GitHub stack, verify its
+server-side stack object rather than relying on command output or local
+metadata. For GitLab, verify the merge-request chain through the host-pinned
+API.
+
+After all creation and stack operations, query every review request again and
+verify its open state, head repository, head owner, branch, exact commit,
+direct base, title, rendered body, requested draft state, and unchanged
+provider-assigned identity. Normalize only a terminal newline when a provider
+CLI does not preserve it. Preserve reviewers, labels, assignees, milestones,
+and collaborator edits. Record only that final verified response:
+
+```bash
+python3 "$PUBLISH_HELPER" record-review \
+  --layer "$LAYER_ID" \
+  --number "$REVIEW_NUMBER" \
+  --url "$REVIEW_URL" \
+  --head "$VERIFIED_HEAD_SHA" \
+  --base "$VERIFIED_BASE_BRANCH" \
+  --base-head "$VERIFIED_BASE_HEAD_SHA" \
+  --status "$REQUESTED_STATUS"
+```
+
+For a native GitHub stack member, append `--stack-number "$STACK_NUMBER"`. Omit
+that argument for GitLab and ordinary review requests. Once every planned
+review request is recorded, finish the checkpoint:
+
+```bash
+python3 "$PUBLISH_HELPER" finish
+```
+
+Query checks once for the report. An absent suite is not success. Wait and
+monitor only when the user explicitly requested it; publication itself does not
+include merging or check-waiting.
+
+## Resume without duplication
+
+For literal `resume`, locate the installed helper and run:
+
+```bash
+PUBLISH_HELPER="${CLAUDE_SKILL_DIR}/scripts/publish-checkpoint.py"
+python3 "$PUBLISH_HELPER" status --json
+RUN_DIR=$(python3 "$PUBLISH_HELPER" run-dir)
+```
+
+Do not start a new run. Strictly inspect the checkpoint, plan, recovery ref,
+local branches, fetched remote branches, all target-repository review requests,
+created review identities, rendered body files, and any provider stack object.
+Trust verified provider state over conversational memory, but never absorb
+unrecorded remote state merely because names resemble the plan.
+
+Continue from the first incomplete phase. A branch or review request created by
+the run but not yet recorded is partial publication evidence: verify it against
+the plan and record it rather than recreating it. For a prepared push, compare
+the remote with both the expected old object and planned tip. Materialize a
+higher layer's body only after its preceding review is recorded, then verify the
+exact rendered prose before creation. For a GitHub stack, reclassify the exact
+server state as create, adopt, or conflict before mutation. Stop on any third
+push state, changed heads, bases, readiness, prose, closed unmerged review
+requests, unknown stack members, or collaborator edits requiring a policy
+choice.
+
+## Completion
+
+Complete only when the helper reports `published` and every planned review
+request is open, points to its verified commit and base, contains the exact
+audited prose and relationship links, has the requested ready or draft state,
+and has the verified provider stack relationship when applicable. Do not merge.
+
+Report the provider and host; grouping and dependency rationale; selected
+transport for each group; every branch, review request number, URL, title, base,
+head, and readiness; local validation and currently registered remote checks;
+relationship prose; recovery ref; run directory; planning and anchor branches;
+and any partial or manual follow-up state.

--- a/assets/claude-skills/publish-unpushed-commits/references/github-publication.md
+++ b/assets/claude-skills/publish-unpushed-commits/references/github-publication.md
@@ -1,0 +1,382 @@
+# GitHub Publication Methods
+
+Use this reference after the publication plan and exact pull request prose are
+complete. Installed command help wins when a flag or behavior differs from this
+reference.
+
+- [Pin the host and authentication](#pin-the-host-and-authentication)
+- [Choose the transport](#choose-the-transport)
+- [Push run-owned branches](#push-run-owned-branches)
+- [Create exact pull requests](#create-exact-pull-requests)
+- [Create or adopt a native stack](#create-or-adopt-a-native-stack)
+- [Describe ordinary relationships](#describe-ordinary-relationships)
+- [Verify ordinary pull requests](#verify-ordinary-pull-requests)
+
+## Pin the host and authentication
+
+Derive the hostname, including an explicit port, from the validated root host
+URL. Pass it explicitly to every `gh api` call. For `gh repo` and `gh pr`
+queries, pass a fully qualified `[HOST/]OWNER/REPO` argument instead of relying
+on shell-wide host state:
+
+```bash
+GITHUB_HOST=$(python3 -c \
+  'import sys, urllib.parse; print(urllib.parse.urlsplit(sys.argv[1]).netloc)' \
+  "$HOST_URL")
+gh api --hostname "$GITHUB_HOST" user
+```
+
+The successful `user` query is the authentication gate. `gh` uses the stored
+credential for that host, or its documented `GH_TOKEN`, `GITHUB_TOKEN`,
+`GH_ENTERPRISE_TOKEN`, or `GITHUB_ENTERPRISE_TOKEN` environment variables as
+appropriate. Never print or checkpoint a token. Verify the target and head
+repositories' canonical host and owner/name through host-pinned API responses
+before starting recovery state. Record each response's positive numeric `id`,
+exact `full_name`, canonical `html_url`, `clone_url`, and `ssh_url`. Pass the
+numeric IDs and both head clone URLs to `publish-checkpoint.py start`; the
+helper rejects a push remote that does not match an observed head-repository
+URL.
+
+Repeat those canonical target and head repository queries immediately before
+every branch push, pull-request creation, stack creation, and resume.
+Require both numeric IDs as well as the paths and URLs to remain unchanged.
+Stop if a repository was transferred, renamed, deleted, recreated at the same
+path, or resolved through a different host; do not silently update the
+checkpoint identity.
+
+## Choose the transport
+
+Use a native GitHub stack only when all of these conditions hold:
+
+- the group has at least two dependent pull requests;
+- the group has no more than one hundred pull requests;
+- every head branch and the trunk branch live in the target repository;
+- `gh api --hostname "$GITHUB_HOST"
+  "repos/$TARGET_REPOSITORY/stacks"` confirms that Stacked Pull
+  Requests are available.
+
+Use ordinary pull requests for a singleton, when Stacked Pull Requests are
+unavailable, or when the head branches live in a fork. Never turn unrelated
+work into a dependency merely to obtain a stack.
+
+Create the relationship through GitHub's stack-creation REST endpoint after
+the exact pull requests exist. It accepts their numbers in bottom-to-top order
+as one server-side request and rejects a chain that is no longer eligible. Do
+not substitute `gh stack init`, `submit`, or `link`: those commands can own
+local branches, push, create pull requests, correct bases, or add to an
+existing stack, duplicating or exceeding this skill's checkpoint authority.
+
+## Push run-owned branches
+
+Resolve the expected old object for every remote branch immediately before
+pushing. Require the branch to be absent on a fresh run; the helper rejects a
+first preparation that supplies an existing object. On resume, require the old
+object to equal the checkpoint's already prepared lease or confirmed object.
+First revalidate the head repository's numeric identity and require the
+configured push URL to still match its checkpointed, credential-safe digest;
+the helper enforces the URL checks when preparing the push. Checkpoint the
+lease before the remote side effect:
+
+```bash
+python3 "$PUBLISH_HELPER" prepare-push \
+  --layer "$LAYER_ID" \
+  --expected-old "$EXPECTED_OLD_OR_ABSENT"
+```
+
+Then obtain the complete Git argument vector from the checkpoint and execute it
+without caller-supplied remote, branch, source, or lease fields:
+
+```bash
+PUSH_TARGET=$(python3 "$PUBLISH_HELPER" push-target --layer "$LAYER_ID")
+python3 -c '
+import json, subprocess, sys, urllib.parse
+target = json.load(sys.stdin)
+host_url = target["host_url"]
+host = urllib.parse.urlsplit(host_url).netloc
+for path_key, id_key in (
+    ("target_repository", "target_repository_id"),
+    ("head_repository", "head_repository_id"),
+):
+    path = target[path_key]
+    observed = json.loads(subprocess.check_output(
+        ["gh", "api", "--hostname", host, f"repos/{path}"],
+        text=True,
+    ))
+    if (
+        observed.get("id") != target[id_key]
+        or observed.get("full_name") != path
+        or observed.get("html_url", "").rstrip("/") != f"{host_url}/{path}"
+    ):
+        raise SystemExit(f"GitHub repository identity changed: {path}")
+subprocess.run(["git", *target["arguments"]], check=True)
+' <<<"$PUSH_TARGET"
+```
+
+For a new branch, pass `absent` to `prepare-push`; the generated Git lease uses
+an empty expected object. Pushes are not atomic across branches. Fetch the
+remote branch after every successful command, require its object to equal the
+planned layer tip, then record that observation:
+
+```bash
+python3 "$PUBLISH_HELPER" confirm-push \
+  --layer "$LAYER_ID" \
+  --remote-head "$FETCHED_REMOTE_SHA"
+```
+
+After any failure, fetch and inspect every planned branch and pull request
+before retrying. If a prepared push has no confirmation, a remote branch still
+at the recorded expected old object can be retried with the same lease; a
+remote branch already at the planned tip can be confirmed without another
+push. Any third object is a collision and must stop publication.
+
+## Create exact pull requests
+
+Create pull requests with their final audited title and body. Ready-for-review
+publication is the default and sends `draft: false`. Explicit draft mode sends
+`draft: true` from the frozen plan.
+
+Generate an exact REST endpoint and JSON payload from the checkpoint. Re-query
+both immutable repository identities in the same executor immediately before
+the mutation, then send the helper-owned payload without caller-supplied
+repository, head, base, title, body, or draft fields:
+
+```bash
+REQUEST=$(python3 "$PUBLISH_HELPER" github-request --layer "$LAYER_ID")
+python3 -c '
+import json, subprocess, sys, urllib.parse
+request = json.load(sys.stdin)
+host_url = request["host_url"]
+host = urllib.parse.urlsplit(host_url).netloc
+for path_key, id_key in (
+    ("target_repository", "target_repository_id"),
+    ("head_repository", "head_repository_id"),
+):
+    path = request[path_key]
+    observed = json.loads(subprocess.check_output(
+        ["gh", "api", "--hostname", host, f"repos/{path}"],
+        text=True,
+    ))
+    expected_url = f"{host_url}/{path}"
+    if (
+        observed.get("id") != request[id_key]
+        or observed.get("full_name") != path
+        or observed.get("html_url", "").rstrip("/") != expected_url
+    ):
+        raise SystemExit(f"GitHub repository identity changed: {path}")
+def branch_commit(path, branch):
+    encoded = urllib.parse.quote(branch, safe="")
+    reference = json.loads(subprocess.check_output(
+        ["gh", "api", "--hostname", host, f"repos/{path}/git/ref/heads/{encoded}"],
+        text=True,
+    ))
+    if reference.get("object", {}).get("type") != "commit":
+        raise SystemExit(f"GitHub branch no longer names a commit: {path}:{branch}")
+    return reference["object"]["sha"]
+if branch_commit(request["head_repository"], request["head_branch"]) != request["head_commit"]:
+    raise SystemExit("GitHub pull request head branch changed before creation")
+if branch_commit(request["target_repository"], request["base_branch"]) != request["base_head"]:
+    raise SystemExit("GitHub pull request base branch changed before creation")
+subprocess.run(
+    [
+        "gh", "api", "--hostname", host, "--method", "POST",
+        request["endpoint"], "--input", request["payload_file"],
+    ],
+    check=True,
+)
+' <<<"$REQUEST"
+```
+
+Create each group from bottom to top. A dependent layer's frozen body template
+contains exactly one `{{PRECEDING_REVIEW_URL}}` placeholder. After the preceding
+pull request has been created, verified, and recorded, `github-request`
+replaces that placeholder with its checkpointed canonical URL and writes the
+rendered body into immutable recovery state before producing the POST payload.
+The bottom pull request needs no successor link, so no pull request body is
+edited after creation and collaborator prose cannot be overwritten.
+
+For same-repository publication, the helper uses the plain checkpointed branch
+name. Native-stack members use a chained base: the bottom pull request targets
+the trunk and each higher pull request targets the branch immediately below
+it. Every ordinary cumulative pull request targets the trunk, including a
+same-repository fallback when native stacks are unavailable or exceed their
+size bound. For a fork, the helper additionally uses the owner-qualified head
+`HEAD_OWNER:BRANCH` and includes the exact `head_repo` name required to
+disambiguate organization-owned sibling repositories. This direct REST path
+avoids the GitHub CLI's user-owned-fork restriction on `gh pr create --head`.
+
+Higher ordinary pull requests temporarily include their prerequisites in their
+diffs. Their descriptions must name the preceding pull request in the series,
+state that it must merge first, and explain that GitHub will recalculate the
+diff against the trunk afterward. Put this relationship in prose written for a
+new reader; do not rely only on a local group label.
+
+Parse the created pull request's number and canonical URL from the creation
+response. Query that exact number through `gh api --hostname "$GITHUB_HOST"
+"repos/$TARGET_REPOSITORY/pulls/$PR_NUMBER"`, verify its initial title, body,
+head repository, branch, head object, direct base branch and object, open state,
+and requested draft state, then run `record-created-review` as shown in the main
+skill. Do this before native-stack creation. On resume, search by
+the exact checkpointed head repository and branch and adopt only a unique
+response that passes the same verification.
+
+## Create or adopt a native stack
+
+After creating and verifying every same-repository pull request, query every
+exact pull request again. Reverify all ordinary fields and write the fresh
+stack membership into a helper input ordered from bottom to top:
+
+```json
+{
+  "schema": 1,
+  "pull_requests": [
+    {"number": 41, "stack": null},
+    {"number": 42, "stack": null}
+  ]
+}
+```
+
+When membership exists, replace `null` with an object containing the positive
+stack `number`, member `position`, and total `size` from the REST pull-request
+resource. Generate the exact stack-creation request or adoption decision from
+that file. The helper refuses incomplete, foreign, oversized, differently
+ordered, or already finally recorded groups:
+
+```bash
+STACK_REQUEST=$(python3 "$PUBLISH_HELPER" github-stack-request \
+  --group "$GROUP_ID" \
+  --observations "$STACK_OBSERVATIONS_FILE")
+python3 -c '
+import hashlib, json, pathlib, subprocess, sys, urllib.parse
+target = json.load(sys.stdin)
+host_url = target["host_url"]
+host = urllib.parse.urlsplit(host_url).netloc
+path = target["target_repository"]
+observed = json.loads(subprocess.check_output(
+    ["gh", "api", "--hostname", host, f"repos/{path}"],
+    text=True,
+))
+if (
+    observed.get("id") != target["target_repository_id"]
+    or observed.get("full_name") != path
+    or observed.get("html_url", "").rstrip("/") != f"{host_url}/{path}"
+):
+    raise SystemExit(f"GitHub repository identity changed: {path}")
+for expected in target["pull_requests"]:
+    number = expected["number"]
+    pull = json.loads(subprocess.check_output(
+        [
+            "gh", "api", "--hostname", host,
+            f"repos/{path}/pulls/{number}",
+        ],
+        text=True,
+    ))
+    expected_body = pathlib.Path(expected["body_path"]).read_text(encoding="utf-8")
+    body_digest = hashlib.sha256(expected_body.encode("utf-8")).hexdigest()
+    actual_stack = pull.get("stack")
+    expected_stack = expected["stack"]
+    if expected_stack is None:
+        stack_matches = actual_stack is None
+    else:
+        stack_matches = actual_stack is not None and all(
+            actual_stack.get(key) == expected_stack[key]
+            for key in ("number", "position", "size")
+        )
+    if (
+        body_digest != expected["body_sha256"]
+        or pull.get("number") != expected["number"]
+        or pull.get("html_url", "").rstrip("/") != expected["url"]
+        or pull.get("state") != "open"
+        or pull.get("draft") != (expected["status"] == "draft")
+        or pull.get("title") != expected["title"]
+        or pull.get("body") != expected_body
+        or pull.get("head", {}).get("repo", {}).get("id") != target["head_repository_id"]
+        or pull.get("head", {}).get("ref") != expected["branch"]
+        or pull.get("head", {}).get("sha") != expected["head"]
+        or pull.get("base", {}).get("repo", {}).get("id") != target["target_repository_id"]
+        or pull.get("base", {}).get("ref") != expected["base"]
+        or pull.get("base", {}).get("sha") != expected["base_head"]
+        or not stack_matches
+    ):
+        raise SystemExit(
+            f"GitHub pull request changed before stack creation: {number}"
+        )
+if target["action"] == "adopt":
+    raise SystemExit(0)
+subprocess.run(
+    [
+        "gh", "api", "--hostname", host, "--method", "POST",
+        target["endpoint"], "--input", target["payload_file"],
+    ],
+    check=True,
+)
+' <<<"$STACK_REQUEST"
+```
+
+If every pull request is unstacked, the decision is `create` and the helper
+writes the exact bottom-to-top number list accepted by GitHub's stack-creation
+REST endpoint. The executor rechecks each complete pull request and membership
+immediately before that single mutation. The server validates the whole chain;
+if a pull request became ineligible or joined another stack, creation fails
+instead of additively extending that stack. If all pull requests already
+occupy exactly one stack in the planned order and with no extra members, the
+decision is `adopt` and no mutation runs. Any partial or foreign membership
+stops.
+
+Verify each stacked pull request through the repository API. Require the same
+non-null stack number, expected stack size and position, recorded head commit,
+direct base branch, title, body, and readiness:
+
+```bash
+gh api --hostname "$GITHUB_HOST" \
+  "repos/$TARGET_REPOSITORY/pulls/$PR_NUMBER"
+gh api --hostname "$GITHUB_HOST" \
+  "repos/$TARGET_REPOSITORY/stacks/$STACK_NUMBER"
+```
+
+If stack creation fails after pull requests were created, retain and report the
+ordinary pull requests and checkpoint. Do not delete them, silently retry as a
+different topology, or claim native stack publication.
+
+## Describe ordinary relationships
+
+Every higher pull request in an ordinary dependent series includes a final
+section whose frozen predecessor placeholder is rendered during bottom-to-top
+creation:
+
+```markdown
+## Pull request series
+
+This pull request depends on {{PRECEDING_REVIEW_URL}}, the preceding pull
+request in the series, and must merge after it.
+```
+
+For any ordinary cumulative series, add:
+
+```markdown
+Until {{PRECEDING_REVIEW_URL}} merges, this pull request's diff also contains
+that prerequisite.
+GitHub will recalculate the diff against the target branch after the
+prerequisite lands.
+```
+
+The helper accepts that token exactly once in every higher layer and forbids it
+in a bottom layer. It replaces only the token, using the canonical URL already
+recorded for the preceding pull request. Verify the rendered body in the
+creation payload and remote response. Never edit a published body to add a
+successor link; directed predecessor links completely describe the dependency
+without risking collaborator-authored prose.
+
+## Verify ordinary pull requests
+
+For every pull request, require the API response to match the checkpoint's
+target repository, head repository and owner, branch, commit, direct base,
+title, body, open state, and requested draft state. Resolve the direct base
+branch through the target repository API immediately before and after creation;
+both observations must equal the plan's target-base commit or, for a native
+stack, the preceding layer tip. Pass that exact object to `record-review
+--base-head`. For an ordinary series, require every base to be the target trunk
+and every higher body to identify its real prerequisite.
+
+Do not wait for continuous integration unless the user explicitly asks. Query
+the registered checks once for the completion report. Treat an empty result as
+"not registered," not as success.

--- a/assets/claude-skills/publish-unpushed-commits/references/gitlab-publication.md
+++ b/assets/claude-skills/publish-unpushed-commits/references/gitlab-publication.md
@@ -1,0 +1,368 @@
+# GitLab Publication Methods
+
+Use this reference after the publication plan and exact merge-request prose are
+complete. Installed `glab` help and the selected GitLab host's API responses win
+when behavior differs from this reference.
+
+- [Pin the host, authentication, and projects](#pin-the-host-authentication-and-projects)
+- [Choose the transport](#choose-the-transport)
+- [Push run-owned branches](#push-run-owned-branches)
+- [Create exact merge requests](#create-exact-merge-requests)
+- [Describe and verify relationships](#describe-and-verify-relationships)
+- [Verify merge requests](#verify-merge-requests)
+
+## Pin the host, authentication, and projects
+
+This workflow supports GitLab.com and self-managed GitLab installations whose
+public URL is rooted at the host, with an optional port. Reject installations
+served below a relative URL such as `https://example.com/gitlab`; `glab` cannot
+reliably pin those API paths without host configuration outside this skill's
+authority.
+
+Derive the API hostname, including an explicit port, and protocol from the
+validated root URL. Reject a per-host or environment `api_host` or
+`api_protocol` override that differs from that destination; otherwise
+`--hostname` can select credentials for one host while sending the API request
+to another. Every GitLab CLI query and mutation must name the validated
+hostname:
+
+```bash
+GITLAB_HOST=$(python3 -c \
+  'import sys, urllib.parse; print(urllib.parse.urlsplit(sys.argv[1]).netloc)' \
+  "$HOST_URL")
+GITLAB_SCHEME=$(python3 -c \
+  'import sys, urllib.parse; print(urllib.parse.urlsplit(sys.argv[1]).scheme)' \
+  "$HOST_URL")
+if ! CONFIGURED_API_HOST=$(glab config get api_host --host "$GITLAB_HOST"); then
+  echo "Cannot read GitLab api_host configuration" >&2
+  exit 1
+fi
+if ! CONFIGURED_API_PROTOCOL=$(glab config get api_protocol --host "$GITLAB_HOST"); then
+  echo "Cannot read GitLab api_protocol configuration" >&2
+  exit 1
+fi
+if [[ -n "$CONFIGURED_API_HOST" && "$CONFIGURED_API_HOST" != "$GITLAB_HOST" ]]; then
+  echo "GitLab api_host does not match the selected host" >&2
+  exit 1
+fi
+if [[ -n "$CONFIGURED_API_PROTOCOL" && "$CONFIGURED_API_PROTOCOL" != "$GITLAB_SCHEME" ]]; then
+  echo "GitLab api_protocol does not match the selected scheme" >&2
+  exit 1
+fi
+glab api --hostname "$GITLAB_HOST" user
+```
+
+The successful `user` query is the authoritative authentication check. `glab`
+selects the credential registered for that exact host, while `GITLAB_TOKEN`,
+`GITLAB_ACCESS_TOKEN`, or `OAUTH_TOKEN` can supply an environment-only token
+and take precedence over stored credentials. `glab auth status --hostname
+"$GITLAB_HOST"` is optional diagnostics, not a required gate, because an
+environment-only token need not be represented as stored login state. Never
+print a token, copy it into the checkpoint, or pass it on a command line. Stop
+before pushing if the authenticated API preflight fails.
+
+Resolve both project paths through the same host before starting the checkpoint.
+URL-encode nested namespaces, require each response's `path_with_namespace` to
+equal the intended path, and record its positive numeric `id`:
+
+```bash
+ENCODED_TARGET=$(python3 -c \
+  'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' \
+  "$TARGET_REPOSITORY")
+ENCODED_HEAD=$(python3 -c \
+  'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' \
+  "$HEAD_REPOSITORY")
+glab api --hostname "$GITLAB_HOST" "projects/$ENCODED_TARGET"
+glab api --hostname "$GITLAB_HOST" "projects/$ENCODED_HEAD"
+```
+
+For each response, require the positive numeric `id`, exact
+`path_with_namespace`, and canonical `web_url` to equal respectively the
+observed ID, intended repository path, and
+`$HOST_URL/$INTENDED_REPOSITORY_PATH`. Require its `http_url_to_repo` to use
+the same scheme, host, port, and repository path. Record the head project's
+exact `http_url_to_repo` and `ssh_url_to_repo` values and pass both as
+`--head-push-url` arguments at checkpoint start. This lets the helper bind
+either ordinary HTTP or exact SSH push configuration while failing closed on
+aliases it cannot prove. It also detects an `api_host` redirect, wrong-host
+response, or stale namespace before recovery state is created.
+
+Pass those IDs as `--target-project-id` and `--head-project-id` to
+`publish-checkpoint.py start`. Numeric IDs bind later API requests to the
+observed projects and let fork publication avoid changing Git remotes; they do
+not make a namespace rename transparent. If either project's canonical path or
+URL changes during a run, stop instead of updating the checkpoint identity.
+Re-read both numeric project objects and both GitLab API configuration fields
+immediately before every branch push, merge-request creation, and resume.
+Require the same path, canonical URL, clone host, API hostname, and API
+protocol. This makes the stop-on-rename and stop-on-reroute rules pre-mutation
+checks rather than only completion-time diagnostics.
+
+## Choose the transport
+
+GitLab recognizes a stack from ordinary merge-request target branches. Select
+`gitlab-stack` only when all of these conditions hold:
+
+- the group has two to ten dependent merge requests;
+- every source branch and the trunk live in the target project;
+- the selected host's `version` API reports GitLab 19.1 or newer; and
+- the bottom merge request targets the trunk while each higher merge request
+  targets the source branch immediately below it.
+
+Use `ordinary` for a singleton, an older GitLab host, a group larger than the
+native stack limit, or a cross-fork publication. In an ordinary dependent
+series, target every cumulative merge request at the trunk. Do not retain a
+same-project source-to-source chain while labeling it ordinary: GitLab can
+infer that chain as a native stack and reject an oversized group only after
+remote creation has begun.
+
+Do not use `glab stack create`, `save`, `amend`, or `sync`. That experimental
+workflow owns commit creation, local branches, pushing, and merge-request prose,
+which duplicates this skill's refinement and checkpoint ownership. GitLab's
+server recognizes the planned target-branch chain without separate stack
+metadata or a linking mutation.
+
+## Push run-owned branches
+
+Resolve the expected old object for every remote branch immediately before
+pushing. Require a new branch on a fresh run. On resume, compare the remote
+object with the checkpointed lease. First require the configured push URL to
+still match the checkpoint's credential-safe digest; the helper enforces this
+when preparing the push. Record the lease before the remote side effect:
+
+```bash
+python3 "$PUBLISH_HELPER" prepare-push \
+  --layer "$LAYER_ID" \
+  --expected-old "$EXPECTED_OLD_OR_ABSENT"
+```
+
+Obtain the complete Git argument vector from the checkpoint. In the same
+executor, reject an API configuration reroute and re-read the numeric head
+project before executing Git without caller-supplied remote, branch, source,
+or lease fields:
+
+```bash
+PUSH_TARGET=$(python3 "$PUBLISH_HELPER" push-target --layer "$LAYER_ID")
+python3 -c '
+import json, subprocess, sys, urllib.parse
+target = json.load(sys.stdin)
+host_url = target["host_url"]
+parsed_host = urllib.parse.urlsplit(host_url)
+host = parsed_host.netloc
+for key, expected in (("api_host", host), ("api_protocol", parsed_host.scheme)):
+    configured = subprocess.check_output(
+        ["glab", "config", "get", key, "--host", host],
+        text=True,
+    ).strip()
+    if configured and configured != expected:
+        raise SystemExit(f"GitLab {key} changed: {configured}")
+for path_key, id_key in (
+    ("target_repository", "target_project_id"),
+    ("head_repository", "head_project_id"),
+):
+    path = target[path_key]
+    project_id = target[id_key]
+    observed = json.loads(subprocess.check_output(
+        ["glab", "api", "--hostname", host, f"projects/{project_id}"],
+        text=True,
+    ))
+    clone = urllib.parse.urlsplit(observed.get("http_url_to_repo", ""))
+    if (
+        observed.get("id") != project_id
+        or observed.get("path_with_namespace") != path
+        or observed.get("web_url", "").rstrip("/") != f"{host_url}/{path}"
+        or clone.scheme != parsed_host.scheme
+        or clone.netloc != host
+        or clone.path.removesuffix(".git").rstrip("/") != f"/{path}"
+    ):
+        raise SystemExit(f"GitLab project identity changed: {path}")
+subprocess.run(["git", *target["arguments"]], check=True)
+' <<<"$PUSH_TARGET"
+```
+
+For a new branch, pass `absent` to `prepare-push`; the generated Git lease uses
+an empty expected object. Fetch or query the source project after every push,
+require the branch to equal the planned tip, and confirm it:
+
+```bash
+python3 "$PUBLISH_HELPER" confirm-push \
+  --layer "$LAYER_ID" \
+  --remote-head "$FETCHED_REMOTE_SHA"
+```
+
+Pushes are not atomic across branches. On resume, a prepared branch still at
+its expected old object can be retried with the same lease; one at the planned
+tip can be confirmed without another push. Any third object is a collision and
+must stop publication.
+
+## Create exact merge requests
+
+Do not use `glab mr create` or `glab mr update`. Depending on local remotes,
+those commands can add Git configuration while resolving a fork, and their
+draft option rewrites the title. Generate an exact JSON API request instead:
+
+```bash
+REQUEST=$(python3 "$PUBLISH_HELPER" gitlab-request --layer "$LAYER_ID")
+python3 -c '
+import json, subprocess, sys, urllib.parse
+request = json.load(sys.stdin)
+host_url = request["host_url"]
+parsed_host = urllib.parse.urlsplit(host_url)
+host = parsed_host.netloc
+for key, expected in (("api_host", host), ("api_protocol", parsed_host.scheme)):
+    configured = subprocess.check_output(
+        ["glab", "config", "get", key, "--host", host],
+        text=True,
+    ).strip()
+    if configured and configured != expected:
+        raise SystemExit(f"GitLab {key} changed: {configured}")
+for path_key, id_key in (
+    ("target_repository", "target_project_id"),
+    ("head_repository", "head_project_id"),
+):
+    path = request[path_key]
+    project_id = request[id_key]
+    observed = json.loads(subprocess.check_output(
+        ["glab", "api", "--hostname", host, f"projects/{project_id}"],
+        text=True,
+    ))
+    clone = urllib.parse.urlsplit(observed.get("http_url_to_repo", ""))
+    if (
+        observed.get("id") != project_id
+        or observed.get("path_with_namespace") != path
+        or observed.get("web_url", "").rstrip("/") != f"{host_url}/{path}"
+        or clone.scheme != parsed_host.scheme
+        or clone.netloc != host
+        or clone.path.removesuffix(".git").rstrip("/") != f"/{path}"
+    ):
+        raise SystemExit(f"GitLab project identity changed: {path}")
+def branch_commit(project_id, branch):
+    encoded = urllib.parse.quote(branch, safe="")
+    observed = json.loads(subprocess.check_output(
+        [
+            "glab", "api", "--hostname", host,
+            f"projects/{project_id}/repository/branches/{encoded}",
+        ],
+        text=True,
+    ))
+    return observed.get("commit", {}).get("id")
+if branch_commit(request["head_project_id"], request["head_branch"]) != request["head_commit"]:
+    raise SystemExit("GitLab merge request source branch changed before creation")
+if branch_commit(request["target_project_id"], request["base_branch"]) != request["base_head"]:
+    raise SystemExit("GitLab merge request target branch changed before creation")
+subprocess.run(
+    [
+        "glab",
+        "api",
+        "--hostname",
+        host,
+        "--method",
+        "POST",
+        request["endpoint"],
+        "--input",
+        request["payload_file"],
+    ],
+    check=True,
+)
+' <<<"$REQUEST"
+```
+
+Create each group from bottom to top. A dependent layer's frozen description
+template contains exactly one `{{PRECEDING_REVIEW_URL}}` placeholder. After the
+preceding merge request has been created, verified, and recorded,
+`gitlab-request` replaces that placeholder with its checkpointed canonical URL
+and writes the rendered description into immutable recovery state before
+producing the POST payload. The bottom merge request needs no successor link,
+so no published description is edited and collaborator prose cannot be
+overwritten.
+
+The helper creates the request through the numeric source-project endpoint and
+includes the numeric target project ID. It preserves the description's exact
+UTF-8 text and terminal newline. Ready titles are used verbatim. In explicit
+draft mode, the final planned title begins with exactly `Draft: `; that title is
+also sent verbatim, so the API marks the merge request draft without a second
+prefix.
+
+GitLab descriptions can execute quick actions. The helper rejects a line that
+looks like one rather than silently changing labels, reviewers, assignees,
+milestones, readiness, merge state, or other collaboration state. If repository
+template prose intentionally requires a quick action, the helper deliberately
+offers no bypass. Remove or escape it, or stop and perform a separately
+authorized manual collaboration-state mutation outside this workflow.
+
+Immediately before creation, query the source branch through the numeric head
+project and the direct base branch through the numeric target project. Require
+their objects to equal the planned layer tip and base head. Query both again
+after creation; a changed base or source makes the result ambiguous and must
+stop the run.
+
+Parse the new merge request's positive `iid` and canonical `web_url`, then
+query that exact IID from the numeric target project. Verify its initial title,
+description, source and target project IDs, source and target branches, head
+and base objects, opened state, and requested draft state. Run
+`record-created-review` as shown in the main skill before creating the next
+layer. On resume, search the target project by the exact numeric source project
+and branch, and adopt only a unique response that passes the same verification.
+
+## Describe and verify relationships
+
+For an eligible same-project stack, create the bottom merge request against the
+trunk and each higher merge request against the source branch immediately below
+it. GitLab detects the stack from that chain. Verify the ordered source and
+target branches through the host-pinned API after every member exists.
+
+Every higher merge request also explains its dependency in prose:
+
+```markdown
+## Merge request stack
+
+This merge request depends on {{PRECEDING_REVIEW_URL}}, the preceding merge
+request in the stack, and must merge after it.
+```
+
+For an ordinary cumulative series, every merge request targets the trunk. Use
+ordinary relationship prose and add:
+
+```markdown
+Until {{PRECEDING_REVIEW_URL}} merges, this merge request's diff also contains
+that prerequisite. GitLab will recalculate the diff against the target branch
+after the prerequisite lands.
+```
+
+Do not add GitLab merge-request dependencies as an implicit substitute. They
+are a separate licensed merge gate and broader collaboration-state mutation.
+Use them only when the user or repository policy explicitly requires them.
+
+The helper accepts the predecessor token exactly once in every higher layer
+and forbids it in a bottom layer. It replaces only that token with the
+checkpointed canonical URL. Verify the rendered description in the creation
+payload and remote response. Never edit a published description to add a
+successor link; directed predecessor links completely describe the dependency
+without risking collaborator-authored prose.
+
+## Verify merge requests
+
+Read every merge request from the numeric target project on the selected host:
+
+```bash
+glab api \
+  --hostname "$GITLAB_HOST" \
+  "projects/$TARGET_PROJECT_ID/merge_requests/$MR_NUMBER"
+```
+
+Require `target_project_id`, `source_project_id`, source branch, exact `sha`,
+target branch, title, description, `opened` state, `draft` value, and `web_url`
+to match the checkpoint and plan. Query the direct target branch once more and
+require its object to equal the pre-creation observation and the plan's expected
+base head. Pass that exact object to `record-review --base-head`.
+
+For a stack, require the complete source-to-target branch chain and the
+documented two-to-ten member bound. For an ordinary series, require every
+target branch to be the trunk and every higher description to identify its real
+prerequisite. On resume, search the target project for the exact source project
+and branch before creating anything; adopt only a unique response that verifies
+against the plan.
+
+Do not wait for pipelines unless the user explicitly asks. Query the merge
+request's registered pipelines once for the completion report. Treat an empty
+result as "not registered," not as success.

--- a/assets/claude-skills/publish-unpushed-commits/scripts/publish-checkpoint.py
+++ b/assets/claude-skills/publish-unpushed-commits/scripts/publish-checkpoint.py
@@ -1,0 +1,2119 @@
+#!/usr/bin/env python3
+"""Checkpoint publication of an unpublished commit range."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import os
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+from urllib.parse import unquote_plus, urlsplit
+
+
+SCHEMA = 1
+RUN_ID = re.compile(r"^[0-9]{8}T[0-9]{6}Z(?:-[1-9][0-9]*)?$")
+IDENTIFIER = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]*$")
+PROJECT_PATH = re.compile(r"^[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)+$")
+HOST_URL = re.compile(
+    r"^https?://[A-Za-z0-9](?:[A-Za-z0-9.-]*[A-Za-z0-9])?"
+    r"(?::[1-9][0-9]{0,4})?$"
+)
+OBJECT_ID = re.compile(r"^(?:[0-9a-f]{40}|[0-9a-f]{64})$")
+QUICK_ACTION = re.compile(r"(?im)^[ \t]*/[a-z][a-z0-9_-]*(?:[ \t]|$)")
+GITLAB_DRAFT_TITLE = re.compile(
+    r"(?i)^(?:(?:draft|wip)(?:\s*:|\s+)|\[(?:draft|wip)\]|\((?:draft|wip)\))"
+)
+PHASES = ("started", "planned", "validated", "publishing", "published")
+PUBLICATION_STATUSES = ("ready", "draft")
+PROVIDERS = ("github", "gitlab")
+TRANSPORTS = ("github-stack", "gitlab-stack", "ordinary")
+PRECEDING_REVIEW_URL = "{{PRECEDING_REVIEW_URL}}"
+
+
+def git_run(*args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    """Run Git without optional locks."""
+    return subprocess.run(
+        ["git", "--no-optional-locks", *args],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=check,
+    )
+
+
+def git_output(*args: str) -> str:
+    """Return stripped Git output."""
+    return git_run(*args).stdout.strip()
+
+
+def git_dir() -> Path:
+    """Return this worktree's absolute Git directory."""
+    try:
+        return Path(git_output("rev-parse", "--absolute-git-dir"))
+    except subprocess.CalledProcessError as error:
+        raise SystemExit(
+            "publish-unpushed-commits requires a Git repository"
+        ) from error
+
+
+STATE_ROOT = git_dir() / "git-stage-batch" / "publish-unpushed-commits"
+RUNS_DIR = STATE_ROOT / "runs"
+ACTIVE_PATH = STATE_ROOT / "active.json"
+
+
+def now() -> str:
+    """Return an ISO-formatted UTC timestamp."""
+    return dt.datetime.now(dt.timezone.utc).isoformat()
+
+
+def reject_unsafe_path(path: Path) -> None:
+    """Reject an existing symlink anywhere below the worktree Git directory."""
+    current = path
+    stop = git_dir().parent
+    while current != stop:
+        if current.is_symlink():
+            raise SystemExit(
+                f"refusing to use symlinked publication state path: {current}"
+            )
+        if current == current.parent:
+            break
+        current = current.parent
+
+
+def atomic_write(path: Path, content: str) -> None:
+    """Atomically replace one private state file."""
+    reject_unsafe_path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_name: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            delete=False,
+        ) as temporary:
+            temporary_name = temporary.name
+            temporary.write(content)
+            temporary.flush()
+            os.fsync(temporary.fileno())
+        os.replace(temporary_name, path)
+    finally:
+        if temporary_name is not None:
+            Path(temporary_name).unlink(missing_ok=True)
+
+
+def write_json(path: Path, value: dict[str, Any]) -> None:
+    """Atomically write one JSON object."""
+    atomic_write(path, json.dumps(value, indent=2, sort_keys=True) + "\n")
+
+
+def load_json(path: Path, *, required: bool = True) -> dict[str, Any]:
+    """Strictly load one JSON object."""
+    reject_unsafe_path(path)
+    if path.exists() and not path.is_file():
+        raise SystemExit(f"publication state path is not a regular file: {path}")
+    if not path.is_file():
+        if required:
+            raise SystemExit(f"required publication state file is missing: {path}")
+        return {}
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise SystemExit(
+            f"cannot read publication state from {path}: {error}"
+        ) from error
+    if not isinstance(value, dict):
+        raise SystemExit(f"expected a JSON object in publication state file: {path}")
+    return value
+
+
+def require_string(
+    value: object,
+    field: str,
+    *,
+    pattern: re.Pattern[str] | None = None,
+) -> str:
+    """Return one required nonempty string."""
+    if not isinstance(value, str) or not value.strip():
+        raise SystemExit(f"publication state field {field!r} must be a nonempty string")
+    if pattern is not None and pattern.fullmatch(value) is None:
+        raise SystemExit(f"publication state field {field!r} has an invalid value")
+    return value
+
+
+def require_integer(value: object, field: str) -> int:
+    """Return one required positive integer."""
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise SystemExit(
+            f"publication state field {field!r} must be a positive integer"
+        )
+    return value
+
+
+def require_git_branch(value: object, field: str) -> str:
+    """Return one nonempty syntactically valid Git branch name."""
+    branch = require_string(value, field)
+    result = git_run("check-ref-format", "--branch", branch, check=False)
+    if result.returncode or result.stdout.strip() != branch:
+        raise SystemExit(f"publication state field {field!r} is not a Git branch")
+    return branch
+
+
+def require_git_remote_name(value: object, field: str) -> str:
+    """Return one name suitable for a Git remote-tracking ref namespace."""
+    remote = require_string(value, field)
+    result = git_run(
+        "check-ref-format", f"refs/remotes/{remote}/publication", check=False
+    )
+    if result.returncode:
+        raise SystemExit(f"publication state field {field!r} is not a Git remote name")
+    return remote
+
+
+def canonical_review_url(
+    provider: str,
+    host_url: str,
+    target_repository: str,
+    number: int,
+) -> str:
+    """Return one provider review URL from validated checkpoint identity."""
+    if provider == "github":
+        review_path = f"{target_repository}/pull/{number}"
+    else:
+        review_path = f"{target_repository}/-/merge_requests/{number}"
+    return f"{host_url}/{review_path}"
+
+
+def require_string_list(value: object, field: str) -> list[str]:
+    """Return one required list of nonempty strings."""
+    if not isinstance(value, list) or not value:
+        raise SystemExit(f"publication state field {field!r} must be a nonempty array")
+    return [
+        require_string(item, f"{field}[{position}]")
+        for position, item in enumerate(value)
+    ]
+
+
+def file_digest(path: Path) -> str:
+    """Return the SHA-256 digest of one required nonempty regular file."""
+    reject_unsafe_path(path)
+    if not path.is_file() or path.is_symlink():
+        raise SystemExit(f"required publication body file is missing: {path}")
+    try:
+        content = path.read_bytes()
+    except OSError as error:
+        raise SystemExit(
+            f"cannot read publication body file {path}: {error}"
+        ) from error
+    if not content.strip():
+        raise SystemExit(f"publication body file is empty or blank: {path}")
+    return hashlib.sha256(content).hexdigest()
+
+
+def read_body(path: Path) -> str:
+    """Return one required nonblank UTF-8 review-request body."""
+    file_digest(path)
+    try:
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as error:
+        raise SystemExit(
+            f"cannot read publication body file {path}: {error}"
+        ) from error
+
+
+def reject_gitlab_quick_actions(body: str, layer_id: str) -> None:
+    """Reject prose that GitLab could reinterpret as collaboration mutations."""
+    match = QUICK_ACTION.search(body)
+    if match is not None:
+        action = match.group(0).strip().split(maxsplit=1)[0]
+        raise SystemExit(
+            f"GitLab body for layer {layer_id} contains possible quick action "
+            f"{action!r}; remove it or obtain explicit authority"
+        )
+
+
+def canonical_commit(revision: str) -> str:
+    """Resolve one revision to a full commit identifier."""
+    try:
+        return git_output("rev-parse", "--verify", f"{revision}^{{commit}}")
+    except subprocess.CalledProcessError as error:
+        raise SystemExit(f"invalid commit revision: {revision!r}") from error
+
+
+def range_commits(base: str, tip: str) -> list[str]:
+    """Return a nonempty linear range in oldest-first order."""
+    if git_run("merge-base", "--is-ancestor", base, tip, check=False).returncode:
+        raise SystemExit(f"base {base} is not an ancestor of {tip}")
+    commits = git_output("rev-list", "--reverse", f"{base}..{tip}").splitlines()
+    if not commits:
+        raise SystemExit("publish-unpushed-commits range is empty")
+    merges = git_output("rev-list", "--merges", f"{base}..{tip}").splitlines()
+    if merges:
+        raise SystemExit(
+            "publish-unpushed-commits supports only linear ranges; merge commits found: "
+            + ", ".join(merges)
+        )
+    return commits
+
+
+def reject_remote_containment(commits: list[str], remote: str) -> None:
+    """Reject a range contained by the selected publication remote."""
+    refs = git_output(
+        "for-each-ref",
+        "--format=%(refname)",
+        "--contains",
+        commits[0],
+        f"refs/remotes/{remote}",
+    ).splitlines()
+    if refs:
+        raise SystemExit(
+            "refusing to publish a range already contained in the selected "
+            "remote's tracking refs: " + ", ".join(refs)
+        )
+
+
+def require_clean_repository() -> None:
+    """Reject pending work and in-progress Git operations."""
+    status = git_run("status", "--porcelain=v1", "--untracked-files=normal").stdout
+    if status:
+        raise SystemExit("publish-unpushed-commits requires a clean working tree")
+    repository_git_dir = git_dir()
+    for marker in (
+        "MERGE_HEAD",
+        "CHERRY_PICK_HEAD",
+        "REVERT_HEAD",
+        "rebase-merge",
+        "rebase-apply",
+    ):
+        if (repository_git_dir / marker).exists():
+            raise SystemExit(f"refusing to publish during Git operation: {marker}")
+
+
+def configured_push_url(remote: str) -> str:
+    """Return the only configured push URL for one named remote."""
+    result = git_run("remote", "get-url", "--push", "--all", remote, check=False)
+    urls = [line for line in result.stdout.splitlines() if line]
+    if result.returncode or len(urls) != 1:
+        raise SystemExit(
+            f"publication push remote {remote!r} must have exactly one push URL"
+        )
+    return urls[0]
+
+
+def canonical_push_destination(url: str) -> str:
+    """Remove credentials and non-routing URL data from one push destination."""
+    if "://" in url:
+        try:
+            parsed = urlsplit(url)
+            hostname = parsed.hostname
+            port = parsed.port
+        except ValueError as error:
+            raise SystemExit("publication push remote has an invalid URL") from error
+        if hostname is None:
+            raise SystemExit("publication push remote URL has no hostname")
+        scheme = parsed.scheme.lower()
+        if scheme in ("http", "https"):
+            username = ""
+            query_parts = []
+            for component in parsed.query.split("&"):
+                key = unquote_plus(component.split("=", maxsplit=1)[0]).lower()
+                if key not in ("access_token", "oauth_token", "private_token"):
+                    query_parts.append(component)
+            query = "&".join(query_parts)
+        elif scheme == "ssh":
+            username = parsed.username or ""
+            query = parsed.query
+        else:
+            raise SystemExit("publication push remote uses an unsupported URL scheme")
+        return json.dumps(
+            [scheme, username, hostname.lower(), port, parsed.path, query],
+            separators=(",", ":"),
+        )
+
+    scp_like = re.fullmatch(
+        r"(?:(?P<user>[^/@:\s]+)@)?(?P<host>[^/:\s]+):(?P<path>.+)",
+        url,
+    )
+    if scp_like is not None:
+        return json.dumps(
+            [
+                "scp",
+                scp_like.group("user") or "",
+                scp_like.group("host").lower(),
+                None,
+                scp_like.group("path"),
+                "",
+            ],
+            separators=(",", ":"),
+        )
+    raise SystemExit("publication push remote uses an unverifiable URL form")
+
+
+def push_url_digest(remote: str) -> str:
+    """Return a credential-safe identity for a named remote's push URL."""
+    destination = canonical_push_destination(configured_push_url(remote))
+    return hashlib.sha256(destination.encode("utf-8")).hexdigest()
+
+
+def validate_push_remote(checkpoint: dict[str, Any]) -> None:
+    """Reject a push remote whose configured destination changed during a run."""
+    if push_url_digest(checkpoint["remote"]) != checkpoint["push_url_sha256"]:
+        raise SystemExit("publication push remote URL changed after checkpoint start")
+
+
+def active_run_id(*, required: bool = True) -> str | None:
+    """Return the validated active run identifier."""
+    active = load_json(ACTIVE_PATH, required=required)
+    if not active:
+        return None
+    if active.get("schema") != SCHEMA:
+        raise SystemExit("unsupported active publication state schema")
+    return require_string(active.get("run_id"), "run_id", pattern=RUN_ID)
+
+
+def run_dir(run_id: str) -> Path:
+    """Return a validated run directory."""
+    require_string(run_id, "run_id", pattern=RUN_ID)
+    return RUNS_DIR / run_id
+
+
+def checkpoint_path(run_id: str) -> Path:
+    """Return one run's checkpoint path."""
+    return run_dir(run_id) / "checkpoint.json"
+
+
+def plan_path(run_id: str) -> Path:
+    """Return one run's plan path."""
+    return run_dir(run_id) / "plan.json"
+
+
+def require_mapping(value: object, field: str) -> dict[str, Any]:
+    """Return one required JSON object."""
+    if not isinstance(value, dict):
+        raise SystemExit(f"publication state field {field!r} must be an object")
+    return value
+
+
+def validate_body_reference(
+    run_id: str,
+    body_file: object,
+    body_sha256: object,
+    field: str,
+) -> tuple[str, str]:
+    """Validate one run-relative immutable body reference."""
+    relative = require_string(body_file, f"{field}.file")
+    parts = Path(relative).parts
+    if (
+        Path(relative).is_absolute()
+        or ".." in parts
+        or len(parts) < 2
+        or parts[0] != "bodies"
+    ):
+        raise SystemExit(f"unsafe publication body path in {field}")
+    digest = require_string(
+        body_sha256,
+        f"{field}.sha256",
+        pattern=OBJECT_ID,
+    )
+    if file_digest(run_dir(run_id) / relative) != digest:
+        raise SystemExit(f"publication body digest changed in {field}")
+    return relative, digest
+
+
+def validate_checkpoint(value: dict[str, Any]) -> dict[str, Any]:
+    """Validate and return one checkpoint document."""
+    if value.get("schema") != SCHEMA:
+        raise SystemExit("unsupported publication checkpoint schema")
+    run_id = require_string(value.get("run_id"), "run_id", pattern=RUN_ID)
+    require_string(value.get("base"), "base", pattern=OBJECT_ID)
+    require_string(value.get("target_base"), "target_base", pattern=OBJECT_ID)
+    source_head = require_string(
+        value.get("source_head"), "source_head", pattern=OBJECT_ID
+    )
+    require_string(value.get("source_tree"), "source_tree", pattern=OBJECT_ID)
+    require_git_branch(value.get("original_branch"), "original_branch")
+    provider = value.get("provider")
+    if provider not in PROVIDERS:
+        raise SystemExit("invalid publication provider")
+    require_string(value.get("host_url"), "host_url", pattern=HOST_URL)
+    target_repository = require_string(
+        value.get("target_repository"), "target_repository", pattern=PROJECT_PATH
+    )
+    head_repository = require_string(
+        value.get("head_repository"), "head_repository", pattern=PROJECT_PATH
+    )
+    if provider == "github":
+        if target_repository.count("/") != 1 or head_repository.count("/") != 1:
+            raise SystemExit("GitHub repositories must use owner/name paths")
+        if "target_project_id" in value or "head_project_id" in value:
+            raise SystemExit("GitHub checkpoints cannot contain GitLab project IDs")
+        target_repository_id = require_integer(
+            value.get("target_repository_id"), "target_repository_id"
+        )
+        head_repository_id = require_integer(
+            value.get("head_repository_id"), "head_repository_id"
+        )
+        if (target_repository == head_repository) != (
+            target_repository_id == head_repository_id
+        ):
+            raise SystemExit("GitHub repository paths and numeric IDs disagree")
+    else:
+        if "target_repository_id" in value or "head_repository_id" in value:
+            raise SystemExit("GitLab checkpoints cannot contain GitHub repository IDs")
+        target_project_id = require_integer(
+            value.get("target_project_id"), "target_project_id"
+        )
+        head_project_id = require_integer(
+            value.get("head_project_id"), "head_project_id"
+        )
+        if (target_repository == head_repository) != (
+            target_project_id == head_project_id
+        ):
+            raise SystemExit("GitLab project paths and numeric IDs disagree")
+    require_git_remote_name(value.get("remote"), "remote")
+    require_string(
+        value.get("push_url_sha256"),
+        "push_url_sha256",
+        pattern=OBJECT_ID,
+    )
+    head_push_url_sha256s = require_string_list(
+        value.get("head_push_url_sha256s"), "head_push_url_sha256s"
+    )
+    if len(head_push_url_sha256s) != len(set(head_push_url_sha256s)):
+        raise SystemExit("checkpointed head repository push URLs must be unique")
+    for position, digest in enumerate(head_push_url_sha256s):
+        require_string(
+            digest,
+            f"head_push_url_sha256s[{position}]",
+            pattern=OBJECT_ID,
+        )
+    if value["push_url_sha256"] not in head_push_url_sha256s:
+        raise SystemExit("publication push remote is not bound to the head repository")
+    require_git_branch(value.get("trunk"), "trunk")
+    if value.get("requested_status") not in PUBLICATION_STATUSES:
+        raise SystemExit("invalid requested publication status")
+    if value.get("phase") not in PHASES:
+        raise SystemExit("invalid publication phase")
+    normalized_fields = ("normalized_tip", "normalized_tree")
+    normalized_present = [field in value for field in normalized_fields]
+    if any(normalized_present) and not all(normalized_present):
+        raise SystemExit("publication checkpoint has incomplete normalized state")
+    for field in normalized_fields:
+        if field in value:
+            require_string(value.get(field), field, pattern=OBJECT_ID)
+    if value.get("phase") != "started" and not all(normalized_present):
+        raise SystemExit("publication checkpoint phase requires normalized state")
+    recovery_ref = require_string(value.get("recovery_ref"), "recovery_ref")
+    expected_recovery_ref = (
+        f"refs/git-stage-batch/publish-unpushed-commits/{run_id}/original"
+    )
+    if recovery_ref != expected_recovery_ref:
+        raise SystemExit("invalid publication recovery ref")
+    commits = require_string_list(value.get("commits"), "commits")
+    if len(commits) != len(set(commits)):
+        raise SystemExit("publication checkpoint commits must be unique")
+    for position, commit in enumerate(commits):
+        require_string(commit, f"commits[{position}]", pattern=OBJECT_ID)
+    if commits[-1] != source_head:
+        raise SystemExit("publication checkpoint source head must end its commit range")
+    require_string(value.get("created_at"), "created_at")
+    require_string(value.get("updated_at"), "updated_at")
+    remote_branches = require_mapping(value.get("remote_branches"), "remote_branches")
+    for layer_id, remote_branch in remote_branches.items():
+        require_string(layer_id, "remote_branches key", pattern=IDENTIFIER)
+        record = require_mapping(
+            remote_branch,
+            f"remote_branches.{layer_id}",
+        )
+        if record.get("layer") != layer_id:
+            raise SystemExit(
+                f"remote branch record key does not match layer {layer_id}"
+            )
+        require_git_branch(record.get("branch"), f"remote_branches.{layer_id}.branch")
+        require_string(
+            record.get("planned_head"),
+            f"remote_branches.{layer_id}.planned_head",
+            pattern=OBJECT_ID,
+        )
+        expected_old = record.get("expected_old")
+        if expected_old is not None:
+            require_string(
+                expected_old,
+                f"remote_branches.{layer_id}.expected_old",
+                pattern=OBJECT_ID,
+            )
+        require_string(
+            record.get("prepared_at"),
+            f"remote_branches.{layer_id}.prepared_at",
+        )
+        confirmed_head = record.get("confirmed_head")
+        confirmed_at = record.get("confirmed_at")
+        if (confirmed_head is None) != (confirmed_at is None):
+            raise SystemExit(
+                f"remote branch record for {layer_id} has incomplete confirmation"
+            )
+        if confirmed_head is not None:
+            require_string(
+                confirmed_head,
+                f"remote_branches.{layer_id}.confirmed_head",
+                pattern=OBJECT_ID,
+            )
+            require_string(
+                confirmed_at,
+                f"remote_branches.{layer_id}.confirmed_at",
+            )
+            if confirmed_head != record["planned_head"]:
+                raise SystemExit(
+                    f"remote branch record for {layer_id} confirms the wrong head"
+                )
+
+    created_reviews = require_mapping(value.get("created_reviews"), "created_reviews")
+    created_numbers: set[int] = set()
+    created_urls: set[str] = set()
+    for layer_id, created_review in created_reviews.items():
+        require_string(layer_id, "created_reviews key", pattern=IDENTIFIER)
+        record = require_mapping(
+            created_review,
+            f"created_reviews.{layer_id}",
+        )
+        for field in ("group", "layer"):
+            require_string(
+                record.get(field),
+                f"created_reviews.{layer_id}.{field}",
+                pattern=IDENTIFIER,
+            )
+        for field in ("branch", "base"):
+            require_git_branch(record.get(field), f"created_reviews.{layer_id}.{field}")
+        if record.get("layer") != layer_id:
+            raise SystemExit(
+                f"created review record key does not match layer {layer_id}"
+            )
+        for field in ("head", "base_head"):
+            require_string(
+                record.get(field),
+                f"created_reviews.{layer_id}.{field}",
+                pattern=OBJECT_ID,
+            )
+        number = require_integer(
+            record.get("number"), f"created_reviews.{layer_id}.number"
+        )
+        url = require_string(record.get("url"), f"created_reviews.{layer_id}.url")
+        expected_url = canonical_review_url(
+            value["provider"],
+            value["host_url"],
+            value["target_repository"],
+            number,
+        )
+        if url != expected_url:
+            raise SystemExit(
+                f"created review URL does not match its checkpoint identity: {layer_id}"
+            )
+        if number in created_numbers or url in created_urls:
+            raise SystemExit("created reviews must use unique review requests")
+        created_numbers.add(number)
+        created_urls.add(url)
+        if record.get("status") != value["requested_status"]:
+            raise SystemExit(
+                f"created review for {layer_id} has the wrong requested status"
+            )
+        validate_body_reference(
+            run_id,
+            record.get("body_file"),
+            record.get("body_sha256"),
+            f"created_reviews.{layer_id}.body",
+        )
+        require_string(
+            record.get("observed_at"),
+            f"created_reviews.{layer_id}.observed_at",
+        )
+
+    publications = require_mapping(value.get("publications"), "publications")
+    phase = value["phase"]
+    if phase not in ("publishing", "published") and (
+        remote_branches or created_reviews or publications
+    ):
+        raise SystemExit("remote publication state exists before publishing")
+    publication_numbers: set[int] = set()
+    publication_urls: set[str] = set()
+    for layer_id, publication in publications.items():
+        require_string(layer_id, "publications key", pattern=IDENTIFIER)
+        if not isinstance(publication, dict):
+            raise SystemExit(f"publication record for {layer_id} must be an object")
+        for field in ("group", "layer"):
+            require_string(
+                publication.get(field),
+                f"publications.{layer_id}.{field}",
+                pattern=IDENTIFIER,
+            )
+        for field in ("branch", "base"):
+            require_git_branch(
+                publication.get(field), f"publications.{layer_id}.{field}"
+            )
+        if publication["layer"] != layer_id:
+            raise SystemExit(f"publication record key does not match layer {layer_id}")
+        require_string(
+            publication.get("head"),
+            f"publications.{layer_id}.head",
+            pattern=OBJECT_ID,
+        )
+        require_string(
+            publication.get("base_head"),
+            f"publications.{layer_id}.base_head",
+            pattern=OBJECT_ID,
+        )
+        number = require_integer(
+            publication.get("number"), f"publications.{layer_id}.number"
+        )
+        url = require_string(publication.get("url"), f"publications.{layer_id}.url")
+        expected_url = canonical_review_url(
+            value["provider"],
+            value["host_url"],
+            value["target_repository"],
+            number,
+        )
+        if url != expected_url:
+            raise SystemExit(
+                f"publication URL does not match its checkpoint identity: {layer_id}"
+            )
+        if number in publication_numbers or url in publication_urls:
+            raise SystemExit("publication records must use unique review requests")
+        publication_numbers.add(number)
+        publication_urls.add(url)
+        if publication.get("status") != value["requested_status"]:
+            raise SystemExit(
+                f"publication record for {layer_id} has the wrong requested status"
+            )
+        stack_number = publication.get("stack_number")
+        if stack_number is not None:
+            require_integer(stack_number, f"publications.{layer_id}.stack_number")
+        require_string(
+            publication.get("verified_at"),
+            f"publications.{layer_id}.verified_at",
+        )
+    return value
+
+
+def load_checkpoint() -> dict[str, Any]:
+    """Load the active checkpoint."""
+    run_id = active_run_id()
+    assert run_id is not None
+    checkpoint = validate_checkpoint(load_json(checkpoint_path(run_id)))
+    if checkpoint["run_id"] != run_id:
+        raise SystemExit("active publication run does not match its checkpoint")
+    return checkpoint
+
+
+def save_checkpoint(checkpoint: dict[str, Any]) -> None:
+    """Validate and save the active checkpoint."""
+    checkpoint["updated_at"] = now()
+    validate_checkpoint(checkpoint)
+    write_json(checkpoint_path(checkpoint["run_id"]), checkpoint)
+
+
+def new_run_id() -> str:
+    """Return a collision-safe timestamp run identifier."""
+    stem = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    candidate = stem
+    suffix = 2
+    while run_dir(candidate).exists():
+        candidate = f"{stem}-{suffix}"
+        suffix += 1
+    return candidate
+
+
+def command_start(args: argparse.Namespace) -> None:
+    """Start one publication run and create its recovery ref."""
+    previous_id = active_run_id(required=False)
+    if previous_id is not None:
+        previous = validate_checkpoint(load_json(checkpoint_path(previous_id)))
+        if previous["phase"] != "published":
+            raise SystemExit(
+                "an unfinished publication run already exists; use resume instead"
+            )
+
+    branch = git_output("branch", "--show-current")
+    if not branch:
+        raise SystemExit("publish-unpushed-commits requires a named local branch")
+    require_git_branch(branch, "original_branch")
+    require_string(args.host_url, "host_url", pattern=HOST_URL)
+    require_string(
+        args.target_repository,
+        "target_repository",
+        pattern=PROJECT_PATH,
+    )
+    require_string(args.head_repository, "head_repository", pattern=PROJECT_PATH)
+    if args.provider == "github":
+        if (
+            args.target_repository.count("/") != 1
+            or args.head_repository.count("/") != 1
+        ):
+            raise SystemExit("GitHub repositories must use owner/name paths")
+        if args.target_project_id is not None or args.head_project_id is not None:
+            raise SystemExit("GitHub publication does not accept GitLab project IDs")
+        require_integer(args.target_repository_id, "target_repository_id")
+        require_integer(args.head_repository_id, "head_repository_id")
+        if (args.target_repository == args.head_repository) != (
+            args.target_repository_id == args.head_repository_id
+        ):
+            raise SystemExit("GitHub repository paths and numeric IDs disagree")
+    else:
+        if args.target_repository_id is not None or args.head_repository_id is not None:
+            raise SystemExit("GitLab publication does not accept GitHub repository IDs")
+        require_integer(args.target_project_id, "target_project_id")
+        require_integer(args.head_project_id, "head_project_id")
+    require_git_remote_name(args.remote, "remote")
+    require_git_branch(args.trunk, "trunk")
+    if not args.head_push_url:
+        raise SystemExit("record at least one API-observed head repository push URL")
+    configured_destination = canonical_push_destination(
+        configured_push_url(args.remote)
+    )
+    observed_destinations = {
+        canonical_push_destination(require_string(url, "head_push_url"))
+        for url in args.head_push_url
+    }
+    if configured_destination not in observed_destinations:
+        raise SystemExit(
+            "publication push remote does not match the API-observed head repository"
+        )
+    head_push_url_sha256s = sorted(
+        hashlib.sha256(destination.encode("utf-8")).hexdigest()
+        for destination in observed_destinations
+    )
+    require_clean_repository()
+    base = canonical_commit(args.base)
+    target_base = canonical_commit(args.target_base)
+    if git_run(
+        "merge-base", "--is-ancestor", base, target_base, check=False
+    ).returncode:
+        raise SystemExit("target base must descend from the publication range base")
+    source_head = canonical_commit("HEAD")
+    commits = range_commits(base, source_head)
+    reject_remote_containment(commits, args.remote)
+    run_id = new_run_id()
+    recovery_ref = f"refs/git-stage-batch/publish-unpushed-commits/{run_id}/original"
+    checkpoint = {
+        "schema": SCHEMA,
+        "run_id": run_id,
+        "phase": "started",
+        "requested_status": args.status,
+        "base": base,
+        "target_base": target_base,
+        "source_head": source_head,
+        "source_tree": git_output("show", "-s", "--format=%T", source_head),
+        "original_branch": branch,
+        "provider": args.provider,
+        "host_url": args.host_url,
+        "target_repository": args.target_repository,
+        "head_repository": args.head_repository,
+        "remote": args.remote,
+        "push_url_sha256": push_url_digest(args.remote),
+        "head_push_url_sha256s": head_push_url_sha256s,
+        "trunk": args.trunk,
+        "recovery_ref": recovery_ref,
+        "commits": commits,
+        "remote_branches": {},
+        "created_reviews": {},
+        "publications": {},
+        "created_at": now(),
+        "updated_at": now(),
+    }
+    if args.provider == "gitlab":
+        checkpoint["target_project_id"] = args.target_project_id
+        checkpoint["head_project_id"] = args.head_project_id
+    else:
+        checkpoint["target_repository_id"] = args.target_repository_id
+        checkpoint["head_repository_id"] = args.head_repository_id
+    validate_checkpoint(checkpoint)
+    result = git_run("update-ref", recovery_ref, source_head, "", check=False)
+    if result.returncode:
+        raise SystemExit(
+            f"cannot create publication recovery ref: {result.stderr.strip()}"
+        )
+    run_dir(run_id).mkdir(parents=True, exist_ok=False)
+    save_checkpoint(checkpoint)
+    write_json(ACTIVE_PATH, {"schema": SCHEMA, "run_id": run_id})
+    print(json.dumps(checkpoint, indent=2, sort_keys=True))
+
+
+def require_list(value: object, field: str) -> list[Any]:
+    """Return one required publication-data list."""
+    if not isinstance(value, list):
+        raise SystemExit(f"publication data field {field!r} must be an array")
+    return value
+
+
+def command_record_normalized(args: argparse.Namespace) -> None:
+    """Freeze the rebased or otherwise normalized aggregate result."""
+    checkpoint = load_checkpoint()
+    if checkpoint["phase"] != "started":
+        raise SystemExit("the normalized publication result is already frozen")
+    tip = canonical_commit(args.tip)
+    range_commits(checkpoint["target_base"], tip)
+    target_tree = git_output("show", "-s", "--format=%T", checkpoint["target_base"])
+    tip_tree = git_output("show", "-s", "--format=%T", tip)
+    if tip_tree == target_tree:
+        raise SystemExit("normalized publication result has no aggregate tree change")
+    checkpoint["normalized_tip"] = tip
+    checkpoint["normalized_tree"] = tip_tree
+    save_checkpoint(checkpoint)
+    print(json.dumps(checkpoint, indent=2, sort_keys=True))
+
+
+def command_refresh_normalized(args: argparse.Namespace) -> None:
+    """Replace a pre-validation result after the target trunk advances."""
+    checkpoint = load_checkpoint()
+    if checkpoint["phase"] not in ("started", "planned"):
+        raise SystemExit(
+            "the normalized publication result is frozen after validation begins"
+        )
+    if "normalized_tip" not in checkpoint:
+        raise SystemExit("record the initial normalized publication result first")
+    target_base = canonical_commit(args.target_base)
+    if git_run(
+        "merge-base",
+        "--is-ancestor",
+        checkpoint["target_base"],
+        target_base,
+        check=False,
+    ).returncode:
+        raise SystemExit("the target base did not advance by fast-forward")
+    tip = canonical_commit(args.tip)
+    range_commits(target_base, tip)
+    target_tree = git_output("show", "-s", "--format=%T", target_base)
+    tip_tree = git_output("show", "-s", "--format=%T", tip)
+    if tip_tree == target_tree:
+        raise SystemExit("normalized publication result has no aggregate tree change")
+    checkpoint["target_base"] = target_base
+    checkpoint["normalized_tip"] = tip
+    checkpoint["normalized_tree"] = tip_tree
+    checkpoint["phase"] = "started"
+    save_checkpoint(checkpoint)
+    print(json.dumps(checkpoint, indent=2, sort_keys=True))
+
+
+def validate_composed_plan_tree(
+    checkpoint: dict[str, Any],
+    integration_tip: str,
+    groups: list[dict[str, Any]],
+) -> None:
+    """Require the independent group outcomes to compose to the frozen tree."""
+    with tempfile.TemporaryDirectory(prefix="git-stage-batch-publish-index-") as temp:
+        environment = {**os.environ, "GIT_INDEX_FILE": str(Path(temp) / "index")}
+        read_tree = subprocess.run(
+            [
+                "git",
+                "--no-optional-locks",
+                "read-tree",
+                checkpoint["target_base"],
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=environment,
+            check=False,
+        )
+        if read_tree.returncode:
+            raise SystemExit(
+                "cannot initialize publication aggregate validation: "
+                + read_tree.stderr.decode(errors="replace").strip()
+            )
+
+        for group in groups:
+            group_tip = group["layers"][-1]["tip"]
+            patch = subprocess.run(
+                [
+                    "git",
+                    "--no-optional-locks",
+                    "diff",
+                    "--binary",
+                    "--full-index",
+                    "--no-ext-diff",
+                    "--no-renames",
+                    "--no-textconv",
+                    checkpoint["target_base"],
+                    group_tip,
+                    "--",
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+            if patch.returncode:
+                raise SystemExit(
+                    f"cannot read aggregate changes for publication group "
+                    f"{group['id']}: " + patch.stderr.decode(errors="replace").strip()
+                )
+            apply = subprocess.run(
+                [
+                    "git",
+                    "--no-optional-locks",
+                    "apply",
+                    "--cached",
+                    "--3way",
+                    "--whitespace=nowarn",
+                    "-",
+                ],
+                input=patch.stdout,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=environment,
+                check=False,
+            )
+            if apply.returncode:
+                raise SystemExit(
+                    f"publication group {group['id']} does not compose cleanly "
+                    "with the preceding groups: "
+                    + apply.stderr.decode(errors="replace").strip()
+                )
+
+        comparison = subprocess.run(
+            [
+                "git",
+                "--no-optional-locks",
+                "diff-index",
+                "--cached",
+                "--quiet",
+                integration_tip,
+                "--",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=environment,
+            check=False,
+        )
+        if comparison.returncode == 1:
+            raise SystemExit(
+                "publication groups do not compose the normalized aggregate tree"
+            )
+        if comparison.returncode:
+            raise SystemExit(
+                "cannot compare the publication aggregate with its normalized tree: "
+                + comparison.stderr.decode(errors="replace").strip()
+            )
+
+
+def validate_plan(
+    value: dict[str, Any],
+    checkpoint: dict[str, Any],
+    *,
+    check_branches: bool = True,
+    require_body_hash: bool = False,
+) -> dict[str, Any]:
+    """Validate one complete publication plan."""
+    if value.get("schema") != SCHEMA:
+        raise SystemExit("unsupported publication plan schema")
+    if "normalized_tree" not in checkpoint:
+        raise SystemExit("record the normalized publication result before its plan")
+    if value.get("base") != checkpoint["target_base"]:
+        raise SystemExit("publication plan base does not match the checkpoint")
+    integration_tip = canonical_commit(
+        require_string(value.get("integration_tip"), "integration_tip")
+    )
+    if integration_tip != checkpoint["normalized_tip"]:
+        raise SystemExit("publication plan integration tip is not the normalized tip")
+    integration_tree = git_output("show", "-s", "--format=%T", integration_tip)
+    if integration_tree != checkpoint["normalized_tree"]:
+        raise SystemExit(
+            "publication plan does not preserve the normalized aggregate tree"
+        )
+
+    groups = require_list(value.get("groups"), "groups")
+    if not groups:
+        raise SystemExit("publication plan must contain at least one group")
+    group_ids: set[str] = set()
+    layer_ids: set[str] = set()
+    branches: set[str] = set()
+    normalized_groups: list[dict[str, Any]] = []
+    target_tree = git_output("show", "-s", "--format=%T", checkpoint["target_base"])
+    for group_position, raw_group in enumerate(groups, start=1):
+        if not isinstance(raw_group, dict):
+            raise SystemExit("every publication group must be an object")
+        group_id = require_string(raw_group.get("id"), "group.id", pattern=IDENTIFIER)
+        if group_id in group_ids:
+            raise SystemExit(f"duplicate publication group identifier: {group_id}")
+        group_ids.add(group_id)
+        transport = raw_group.get("transport")
+        if transport not in TRANSPORTS:
+            raise SystemExit(f"invalid publication transport for group {group_id}")
+        layers = require_list(raw_group.get("layers"), "group.layers")
+        if not layers:
+            raise SystemExit(f"publication group {group_id} has no layers")
+        stack_provider = {
+            "github-stack": "github",
+            "gitlab-stack": "gitlab",
+        }.get(transport)
+        if stack_provider is not None and checkpoint["provider"] != stack_provider:
+            raise SystemExit(
+                f"publication transport {transport} does not match provider "
+                f"{checkpoint['provider']}"
+            )
+        if stack_provider is not None and len(layers) < 2:
+            raise SystemExit("a provider stack must contain at least two layers")
+        if transport == "github-stack" and len(layers) > 100:
+            raise SystemExit(
+                "a GitHub stack cannot contain more than one hundred layers"
+            )
+        if transport == "gitlab-stack" and len(layers) > 10:
+            raise SystemExit("a GitLab stack cannot contain more than ten layers")
+        if (
+            stack_provider is not None
+            and checkpoint["head_repository"] != checkpoint["target_repository"]
+        ):
+            raise SystemExit("a provider stack cannot cross a repository fork")
+        previous_tip = checkpoint["target_base"]
+        previous_branch = checkpoint["trunk"]
+        normalized_layers: list[dict[str, Any]] = []
+        for layer_position, raw_layer in enumerate(layers, start=1):
+            if not isinstance(raw_layer, dict):
+                raise SystemExit("every publication layer must be an object")
+            layer_id = require_string(
+                raw_layer.get("id"), "layer.id", pattern=IDENTIFIER
+            )
+            branch = require_git_branch(raw_layer.get("branch"), "layer.branch")
+            if branch == checkpoint["trunk"]:
+                raise SystemExit(
+                    "a publication layer cannot use the target trunk branch"
+                )
+            base_branch = require_git_branch(
+                raw_layer.get("base_branch"), "layer.base_branch"
+            )
+            title = require_string(raw_layer.get("title"), "layer.title")
+            if "\n" in title or "\r" in title:
+                raise SystemExit(f"review-request title must be one line: {layer_id}")
+            if checkpoint["provider"] == "gitlab":
+                if checkpoint["requested_status"] == "draft" and not title.startswith(
+                    "Draft: "
+                ):
+                    raise SystemExit(
+                        f"GitLab draft title must begin with 'Draft: ': {layer_id}"
+                    )
+                if (
+                    checkpoint["requested_status"] == "ready"
+                    and GITLAB_DRAFT_TITLE.match(title) is not None
+                ):
+                    raise SystemExit(
+                        f"GitLab ready title cannot use a draft prefix: {layer_id}"
+                    )
+            body_file = require_string(raw_layer.get("body_file"), "layer.body_file")
+            tip = canonical_commit(require_string(raw_layer.get("tip"), "layer.tip"))
+            if layer_id in layer_ids:
+                raise SystemExit(f"duplicate publication layer identifier: {layer_id}")
+            if branch in branches:
+                raise SystemExit(f"duplicate publication branch: {branch}")
+            layer_ids.add(layer_id)
+            branches.add(branch)
+            if check_branches:
+                branch_tip = git_run(
+                    "show-ref",
+                    "--verify",
+                    "--hash",
+                    f"refs/heads/{branch}",
+                    check=False,
+                )
+                if branch_tip.returncode or branch_tip.stdout.strip() != tip:
+                    raise SystemExit(
+                        f"publication branch does not match planned tip: {branch}"
+                    )
+            if git_run(
+                "merge-base", "--is-ancestor", previous_tip, tip, check=False
+            ).returncode:
+                raise SystemExit(
+                    f"publication group {group_id} is not cumulative at layer {layer_id}"
+                )
+            range_commits(previous_tip, tip)
+            previous_tree = git_output("show", "-s", "--format=%T", previous_tip)
+            tip_tree = git_output("show", "-s", "--format=%T", tip)
+            if tip_tree == previous_tree:
+                raise SystemExit(
+                    f"publication layer {layer_id} has no incremental tree change"
+                )
+            body_path = run_dir(checkpoint["run_id"]) / body_file
+            body_parts = Path(body_file).parts
+            if (
+                Path(body_file).is_absolute()
+                or ".." in body_parts
+                or len(body_parts) < 2
+                or body_parts[0] != "bodies"
+            ):
+                raise SystemExit(f"unsafe body file path for layer {layer_id}")
+            body = read_body(body_path)
+            body_sha256 = hashlib.sha256(body.encode("utf-8")).hexdigest()
+            placeholder_count = body.count(PRECEDING_REVIEW_URL)
+            if layer_position == 1 and placeholder_count:
+                raise SystemExit(
+                    f"bottom publication layer cannot name a preceding review: "
+                    f"{layer_id}"
+                )
+            if layer_position > 1 and placeholder_count != 1:
+                raise SystemExit(
+                    f"dependent publication layer must contain exactly one "
+                    f"{PRECEDING_REVIEW_URL} placeholder: {layer_id}"
+                )
+            if checkpoint["provider"] == "gitlab":
+                reject_gitlab_quick_actions(body, layer_id)
+            recorded_body_sha256 = raw_layer.get("body_sha256")
+            if recorded_body_sha256 is None:
+                if require_body_hash:
+                    raise SystemExit(f"publication layer {layer_id} lacks a body hash")
+            else:
+                require_string(
+                    recorded_body_sha256,
+                    "layer.body_sha256",
+                    pattern=OBJECT_ID,
+                )
+                if recorded_body_sha256 != body_sha256:
+                    raise SystemExit(
+                        f"audited review-request body changed for layer {layer_id}"
+                    )
+            if layer_position == 1 or transport == "ordinary":
+                expected_base = checkpoint["trunk"]
+            else:
+                expected_base = previous_branch
+            if base_branch != expected_base:
+                raise SystemExit(
+                    f"publication layer {layer_id} must target {expected_base}"
+                )
+            normalized_layers.append(
+                {
+                    "id": layer_id,
+                    "position": layer_position,
+                    "branch": branch,
+                    "base_branch": base_branch,
+                    "tip": tip,
+                    "title": title,
+                    "body_file": body_file,
+                    "body_sha256": body_sha256,
+                }
+            )
+            previous_tip = tip
+            previous_branch = branch
+        group_tree = git_output("show", "-s", "--format=%T", previous_tip)
+        if group_tree == target_tree:
+            raise SystemExit(
+                f"publication group {group_id} has no aggregate tree change"
+            )
+        normalized_groups.append(
+            {
+                "id": group_id,
+                "position": group_position,
+                "transport": transport,
+                "layers": normalized_layers,
+            }
+        )
+    validate_composed_plan_tree(checkpoint, integration_tip, normalized_groups)
+    return {
+        "schema": SCHEMA,
+        "base": checkpoint["target_base"],
+        "integration_tip": integration_tip,
+        "groups": normalized_groups,
+    }
+
+
+def command_record_plan(args: argparse.Namespace) -> None:
+    """Validate and record the branch and review-request plan."""
+    checkpoint = load_checkpoint()
+    if checkpoint["phase"] not in ("started", "planned"):
+        raise SystemExit("the publication plan is frozen after validation begins")
+    source = Path(args.file)
+    plan = validate_plan(load_json(source), checkpoint)
+    write_json(plan_path(checkpoint["run_id"]), plan)
+    checkpoint["phase"] = "planned"
+    save_checkpoint(checkpoint)
+    print(json.dumps(plan, indent=2, sort_keys=True))
+
+
+def load_plan(
+    checkpoint: dict[str, Any], *, check_branches: bool = True
+) -> dict[str, Any]:
+    """Load and revalidate the active plan."""
+    plan = load_json(plan_path(checkpoint["run_id"]))
+    return validate_plan(
+        plan,
+        checkpoint,
+        check_branches=check_branches,
+        require_body_hash=True,
+    )
+
+
+def find_layer(
+    plan: dict[str, Any], layer_id: str
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Return the group and layer for one unique identifier."""
+    for group in plan["groups"]:
+        for layer in group["layers"]:
+            if layer["id"] == layer_id:
+                return group, layer
+    raise SystemExit(f"unknown publication layer: {layer_id}")
+
+
+def find_group(plan: dict[str, Any], group_id: str) -> dict[str, Any]:
+    """Return one unique publication group."""
+    for group in plan["groups"]:
+        if group["id"] == group_id:
+            return group
+    raise SystemExit(f"unknown publication group: {group_id}")
+
+
+def expected_base_head(
+    checkpoint: dict[str, Any],
+    plan: dict[str, Any],
+    layer: dict[str, Any],
+) -> str:
+    """Return the immutable commit expected at one layer's direct base."""
+    if layer["base_branch"] == checkpoint["trunk"]:
+        return checkpoint["target_base"]
+    for group in plan["groups"]:
+        for candidate in group["layers"]:
+            if candidate["branch"] == layer["base_branch"]:
+                return candidate["tip"]
+    raise SystemExit(f"cannot resolve planned base head for layer {layer['id']}")
+
+
+def rendered_body(
+    checkpoint: dict[str, Any],
+    group: dict[str, Any],
+    layer: dict[str, Any],
+) -> tuple[str, str, str]:
+    """Return the immutable body rendered with its preceding review URL."""
+    body = read_body(run_dir(checkpoint["run_id"]) / layer["body_file"])
+    if layer["position"] == 1:
+        return layer["body_file"], layer["body_sha256"], body
+    preceding_layer = group["layers"][layer["position"] - 2]
+    preceding_review = checkpoint["created_reviews"].get(preceding_layer["id"])
+    if preceding_review is None:
+        raise SystemExit(
+            f"create and record the preceding review before layer {layer['id']}"
+        )
+    rendered = body.replace(PRECEDING_REVIEW_URL, preceding_review["url"])
+    digest = hashlib.sha256(rendered.encode("utf-8")).hexdigest()
+    relative = f"bodies/rendered/{digest}.md"
+    return relative, digest, rendered
+
+
+def materialize_rendered_body(
+    checkpoint: dict[str, Any],
+    group: dict[str, Any],
+    layer: dict[str, Any],
+) -> tuple[str, str, str]:
+    """Write and return one deterministic rendered review body."""
+    relative, digest, body = rendered_body(checkpoint, group, layer)
+    if relative != layer["body_file"]:
+        atomic_write(run_dir(checkpoint["run_id"]) / relative, body)
+    return relative, digest, body
+
+
+def validate_progress_against_plan(
+    checkpoint: dict[str, Any], plan: dict[str, Any]
+) -> None:
+    """Cross-check remote mutation state against the immutable plan."""
+    planned_layers = {
+        layer["id"]: (group, layer)
+        for group in plan["groups"]
+        for layer in group["layers"]
+    }
+    for layer_id, remote_branch in checkpoint["remote_branches"].items():
+        if layer_id not in planned_layers:
+            raise SystemExit(f"remote branch state names unknown layer {layer_id}")
+        _group, layer = planned_layers[layer_id]
+        if remote_branch["branch"] != layer["branch"]:
+            raise SystemExit(f"remote branch state changed branch for layer {layer_id}")
+        if remote_branch["planned_head"] != layer["tip"]:
+            raise SystemExit(f"remote branch state changed head for layer {layer_id}")
+
+    for layer_id, created_review in checkpoint["created_reviews"].items():
+        if layer_id not in planned_layers:
+            raise SystemExit(f"created review state names unknown layer {layer_id}")
+        group, layer = planned_layers[layer_id]
+        expected_fields = {
+            "group": group["id"],
+            "layer": layer_id,
+            "branch": layer["branch"],
+            "base": layer["base_branch"],
+            "base_head": expected_base_head(checkpoint, plan, layer),
+            "head": layer["tip"],
+            "status": checkpoint["requested_status"],
+        }
+        if any(
+            created_review.get(field) != expected
+            for field, expected in expected_fields.items()
+        ):
+            raise SystemExit(f"created review state changed for layer {layer_id}")
+        expected_body_file, expected_body_sha256, _body = rendered_body(
+            checkpoint,
+            group,
+            layer,
+        )
+        if (
+            created_review.get("body_file") != expected_body_file
+            or created_review.get("body_sha256") != expected_body_sha256
+        ):
+            raise SystemExit(f"created review body changed for layer {layer_id}")
+        remote_branch = checkpoint["remote_branches"].get(layer_id)
+        if remote_branch is None or remote_branch.get("confirmed_head") != layer["tip"]:
+            raise SystemExit(
+                f"created review lacks a confirmed remote branch for {layer_id}"
+            )
+
+    for layer_id, publication in checkpoint["publications"].items():
+        if layer_id not in planned_layers:
+            raise SystemExit(f"publication record names unknown layer {layer_id}")
+        group, layer = planned_layers[layer_id]
+        if publication["group"] != group["id"]:
+            raise SystemExit(f"publication record changed group for layer {layer_id}")
+        if publication["branch"] != layer["branch"]:
+            raise SystemExit(f"publication record changed branch for layer {layer_id}")
+        if publication["base"] != layer["base_branch"]:
+            raise SystemExit(f"publication record changed base for layer {layer_id}")
+        if publication["head"] != layer["tip"]:
+            raise SystemExit(f"publication record changed head for layer {layer_id}")
+        if publication["base_head"] != expected_base_head(checkpoint, plan, layer):
+            raise SystemExit(
+                f"publication record changed base head for layer {layer_id}"
+            )
+        created_review = checkpoint["created_reviews"].get(layer_id)
+        if created_review is None:
+            raise SystemExit(
+                f"publication record lacks created review state for {layer_id}"
+            )
+        for field in (
+            "group",
+            "layer",
+            "branch",
+            "base",
+            "base_head",
+            "head",
+            "number",
+            "url",
+            "status",
+        ):
+            if publication.get(field) != created_review.get(field):
+                raise SystemExit(
+                    f"publication record changed created identity for {layer_id}"
+                )
+        remote_branch = checkpoint["remote_branches"].get(layer_id)
+        if remote_branch is None or remote_branch.get("confirmed_head") != layer["tip"]:
+            raise SystemExit(
+                f"publication record lacks a confirmed remote branch for {layer_id}"
+            )
+
+    stack_groups: dict[int, str] = {}
+    for publication in checkpoint["publications"].values():
+        stack_number = publication["stack_number"]
+        if stack_number is None:
+            continue
+        group_id = publication["group"]
+        existing_group = stack_groups.setdefault(stack_number, group_id)
+        if existing_group != group_id:
+            raise SystemExit(
+                f"GitHub stack {stack_number} is assigned to multiple publication "
+                "groups"
+            )
+
+
+def require_publishing() -> tuple[dict[str, Any], dict[str, Any]]:
+    """Return strictly validated publishing checkpoint and plan state."""
+    checkpoint = load_checkpoint()
+    if checkpoint["phase"] != "publishing":
+        raise SystemExit("remote publication actions require the publishing phase")
+    validate_push_remote(checkpoint)
+    plan = load_plan(checkpoint)
+    validate_progress_against_plan(checkpoint, plan)
+    return checkpoint, plan
+
+
+def command_prepare_push(args: argparse.Namespace) -> None:
+    """Checkpoint the exact lease before pushing one planned branch."""
+    checkpoint, plan = require_publishing()
+    _group, layer = find_layer(plan, args.layer)
+    if args.layer in checkpoint["publications"]:
+        raise SystemExit("cannot prepare a push after recording its review request")
+    expected_old: str | None
+    if args.expected_old == "absent":
+        expected_old = None
+    else:
+        expected_old = require_string(
+            args.expected_old,
+            "expected_old",
+            pattern=OBJECT_ID,
+        )
+    proposed = {
+        "layer": args.layer,
+        "branch": layer["branch"],
+        "expected_old": expected_old,
+        "planned_head": layer["tip"],
+        "prepared_at": now(),
+        "confirmed_head": None,
+        "confirmed_at": None,
+    }
+    existing = checkpoint["remote_branches"].get(args.layer)
+    if existing is None and expected_old is not None:
+        raise SystemExit("a fresh publication branch must be absent on the remote")
+    if existing is not None:
+        comparable = dict(existing)
+        comparable["prepared_at"] = proposed["prepared_at"]
+        comparable["confirmed_head"] = None
+        comparable["confirmed_at"] = None
+        if comparable != proposed:
+            raise SystemExit(f"push lease changed for layer {args.layer}")
+        print(json.dumps(existing, indent=2, sort_keys=True))
+        return
+    checkpoint["remote_branches"][args.layer] = proposed
+    save_checkpoint(checkpoint)
+    print(json.dumps(proposed, indent=2, sort_keys=True))
+
+
+def command_push_target(args: argparse.Namespace) -> None:
+    """Return checkpoint-bound Git arguments for one prepared branch push."""
+    checkpoint, plan = require_publishing()
+    _group, layer = find_layer(plan, args.layer)
+    remote_branch = checkpoint["remote_branches"].get(args.layer)
+    if remote_branch is None:
+        raise SystemExit(f"prepare the push lease for layer {args.layer} first")
+    if remote_branch.get("confirmed_head") is not None:
+        raise SystemExit(f"the push for layer {args.layer} is already confirmed")
+    branch_ref = f"refs/heads/{layer['branch']}"
+    expected_old = remote_branch["expected_old"] or ""
+    arguments = [
+        "-c",
+        "push.pushOption=",
+        "push",
+        "--no-follow-tags",
+        "--recurse-submodules=no",
+        f"--force-with-lease={branch_ref}:{expected_old}",
+        checkpoint["remote"],
+        f"{layer['tip']}:{branch_ref}",
+    ]
+    output = {
+        "arguments": arguments,
+        "branch": layer["branch"],
+        "expected_old": remote_branch["expected_old"],
+        "head_repository": checkpoint["head_repository"],
+        "host_url": checkpoint["host_url"],
+        "layer": args.layer,
+        "planned_head": layer["tip"],
+        "provider": checkpoint["provider"],
+        "remote": checkpoint["remote"],
+        "target_repository": checkpoint["target_repository"],
+    }
+    if checkpoint["provider"] == "github":
+        output["head_repository_id"] = checkpoint["head_repository_id"]
+        output["target_repository_id"] = checkpoint["target_repository_id"]
+    else:
+        output["head_project_id"] = checkpoint["head_project_id"]
+        output["target_project_id"] = checkpoint["target_project_id"]
+    print(json.dumps(output, indent=2, sort_keys=True))
+
+
+def command_confirm_push(args: argparse.Namespace) -> None:
+    """Record a fetched remote branch at its exact planned commit."""
+    checkpoint, plan = require_publishing()
+    _group, layer = find_layer(plan, args.layer)
+    remote_branch = checkpoint["remote_branches"].get(args.layer)
+    if remote_branch is None:
+        raise SystemExit(f"prepare the push lease before confirming layer {args.layer}")
+    remote_head = require_string(
+        args.remote_head,
+        "remote_head",
+        pattern=OBJECT_ID,
+    )
+    if remote_head != layer["tip"]:
+        raise SystemExit("fetched remote branch does not match its planned head")
+    confirmed = remote_branch.get("confirmed_head")
+    if confirmed is not None and confirmed != remote_head:
+        raise SystemExit(f"confirmed remote branch changed for layer {args.layer}")
+    remote_branch["confirmed_head"] = remote_head
+    if remote_branch.get("confirmed_at") is None:
+        remote_branch["confirmed_at"] = now()
+    save_checkpoint(checkpoint)
+    print(json.dumps(remote_branch, indent=2, sort_keys=True))
+
+
+def request_payload_path(run_id: str, layer_id: str, operation: str) -> Path:
+    """Return one collision-resistant helper-owned API request path."""
+    stem = hashlib.sha256(layer_id.encode("utf-8")).hexdigest()
+    return run_dir(run_id) / "requests" / f"{stem}-{operation}.json"
+
+
+def command_gitlab_request(args: argparse.Namespace) -> None:
+    """Generate an exact host-pinned GitLab merge-request creation payload."""
+    checkpoint, plan = require_publishing()
+    if checkpoint["provider"] != "gitlab":
+        raise SystemExit("GitLab request payloads require a GitLab publication")
+    group, layer = find_layer(plan, args.layer)
+    if args.layer in checkpoint["created_reviews"]:
+        raise SystemExit("this merge request is already recorded as created")
+    if args.layer in checkpoint["publications"]:
+        raise SystemExit("this merge request is already finally recorded")
+    remote_branch = checkpoint["remote_branches"].get(args.layer)
+    if remote_branch is None or remote_branch.get("confirmed_head") != layer["tip"]:
+        raise SystemExit("confirm the remote source branch before creating its request")
+    body_file, body_sha256, body = materialize_rendered_body(
+        checkpoint,
+        group,
+        layer,
+    )
+    payload = {
+        "source_branch": layer["branch"],
+        "target_branch": layer["base_branch"],
+        "title": layer["title"],
+        "description": body,
+        "target_project_id": checkpoint["target_project_id"],
+    }
+    payload_file = request_payload_path(checkpoint["run_id"], args.layer, "create")
+    write_json(payload_file, payload)
+    output = {
+        "base_branch": layer["base_branch"],
+        "base_head": expected_base_head(checkpoint, plan, layer),
+        "body_file": body_file,
+        "body_sha256": body_sha256,
+        "endpoint": (f"projects/{checkpoint['head_project_id']}/merge_requests"),
+        "head_branch": layer["branch"],
+        "head_commit": layer["tip"],
+        "head_project_id": checkpoint["head_project_id"],
+        "head_repository": checkpoint["head_repository"],
+        "host_url": checkpoint["host_url"],
+        "payload_file": str(payload_file),
+        "target_project_id": checkpoint["target_project_id"],
+        "target_repository": checkpoint["target_repository"],
+    }
+    print(json.dumps(output, indent=2, sort_keys=True))
+
+
+def command_github_request(args: argparse.Namespace) -> None:
+    """Generate one checkpoint-bound GitHub pull-request creation payload."""
+    checkpoint, plan = require_publishing()
+    if checkpoint["provider"] != "github":
+        raise SystemExit("GitHub request targets require a GitHub publication")
+    group, layer = find_layer(plan, args.layer)
+    if args.layer in checkpoint["created_reviews"]:
+        raise SystemExit("this pull request is already recorded as created")
+    if args.layer in checkpoint["publications"]:
+        raise SystemExit("this pull request is already finally recorded")
+    remote_branch = checkpoint["remote_branches"].get(args.layer)
+    if remote_branch is None or remote_branch.get("confirmed_head") != layer["tip"]:
+        raise SystemExit("confirm the remote source branch before creating its request")
+    if checkpoint["head_repository"] == checkpoint["target_repository"]:
+        head = layer["branch"]
+    else:
+        head_owner = checkpoint["head_repository"].split("/", maxsplit=1)[0]
+        head = f"{head_owner}:{layer['branch']}"
+    body_file, body_sha256, body = materialize_rendered_body(
+        checkpoint,
+        group,
+        layer,
+    )
+    payload = {
+        "title": layer["title"],
+        "head": head,
+        "base": layer["base_branch"],
+        "body": body,
+        "draft": checkpoint["requested_status"] == "draft",
+    }
+    if checkpoint["head_repository"] != checkpoint["target_repository"]:
+        payload["head_repo"] = checkpoint["head_repository"].split("/", maxsplit=1)[1]
+    payload_file = request_payload_path(
+        checkpoint["run_id"], args.layer, "github-create"
+    )
+    write_json(payload_file, payload)
+    output = {
+        "base_branch": layer["base_branch"],
+        "base_head": expected_base_head(checkpoint, plan, layer),
+        "body_file": body_file,
+        "body_sha256": body_sha256,
+        "endpoint": f"repos/{checkpoint['target_repository']}/pulls",
+        "head_branch": layer["branch"],
+        "head_commit": layer["tip"],
+        "head_repository": checkpoint["head_repository"],
+        "head_repository_id": checkpoint["head_repository_id"],
+        "host_url": checkpoint["host_url"],
+        "layer": args.layer,
+        "payload_file": str(payload_file),
+        "target_repository": checkpoint["target_repository"],
+        "target_repository_id": checkpoint["target_repository_id"],
+    }
+    print(json.dumps(output, indent=2, sort_keys=True))
+
+
+def command_github_stack_request(args: argparse.Namespace) -> None:
+    """Return an exact GitHub stack-creation or adoption request."""
+    checkpoint, plan = require_publishing()
+    if checkpoint["provider"] != "github":
+        raise SystemExit("GitHub stack targets require a GitHub publication")
+    group = find_group(plan, args.group)
+    if group["transport"] != "github-stack" or len(group["layers"]) < 2:
+        raise SystemExit("GitHub stack creation requires a native stack group")
+    layer_ids = [layer["id"] for layer in group["layers"]]
+    if any(layer_id in checkpoint["publications"] for layer_id in layer_ids):
+        raise SystemExit("cannot recreate a group after final review verification")
+    missing = [
+        layer_id
+        for layer_id in layer_ids
+        if layer_id not in checkpoint["created_reviews"]
+    ]
+    if missing:
+        raise SystemExit(
+            "record every created review before creating the stack: "
+            + ", ".join(missing)
+        )
+    reviews = [checkpoint["created_reviews"][layer_id] for layer_id in layer_ids]
+    observations = load_json(Path(args.observations))
+    if observations.get("schema") != SCHEMA:
+        raise SystemExit("unsupported GitHub stack-membership observation schema")
+    pull_requests = require_list(observations.get("pull_requests"), "pull_requests")
+    if len(pull_requests) != len(layer_ids):
+        raise SystemExit("GitHub stack observations do not cover the planned group")
+    memberships: list[dict[str, int] | None] = []
+    for position, (raw_observation, layer_id) in enumerate(
+        zip(pull_requests, layer_ids, strict=True),
+        start=1,
+    ):
+        observation = require_mapping(
+            raw_observation,
+            f"pull_requests[{position - 1}]",
+        )
+        expected_number = checkpoint["created_reviews"][layer_id]["number"]
+        number = require_integer(
+            observation.get("number"),
+            f"pull_requests[{position - 1}].number",
+        )
+        if number != expected_number:
+            raise SystemExit("GitHub stack observations changed pull request order")
+        raw_stack = observation.get("stack")
+        if raw_stack is None:
+            memberships.append(None)
+            continue
+        stack = require_mapping(raw_stack, f"pull_requests[{position - 1}].stack")
+        membership = {
+            "number": require_integer(
+                stack.get("number"),
+                f"pull_requests[{position - 1}].stack.number",
+            ),
+            "position": require_integer(
+                stack.get("position"),
+                f"pull_requests[{position - 1}].stack.position",
+            ),
+            "size": require_integer(
+                stack.get("size"),
+                f"pull_requests[{position - 1}].stack.size",
+            ),
+        }
+        memberships.append(membership)
+
+    if all(membership is None for membership in memberships):
+        action = "create"
+        stack_number: int | None = None
+    elif any(membership is None for membership in memberships):
+        raise SystemExit("planned pull requests have partial GitHub stack membership")
+    else:
+        stacked = [membership for membership in memberships if membership is not None]
+        stack_numbers = {membership["number"] for membership in stacked}
+        sizes = {membership["size"] for membership in stacked}
+        positions = [membership["position"] for membership in stacked]
+        if (
+            len(stack_numbers) != 1
+            or sizes != {len(layer_ids)}
+            or positions != list(range(1, len(layer_ids) + 1))
+        ):
+            raise SystemExit(
+                "planned pull requests belong to a foreign or differently ordered "
+                "GitHub stack"
+            )
+        action = "adopt"
+        stack_number = next(iter(stack_numbers))
+    output = {
+        "action": action,
+        "group": group["id"],
+        "head_repository": checkpoint["head_repository"],
+        "head_repository_id": checkpoint["head_repository_id"],
+        "host_url": checkpoint["host_url"],
+        "pull_requests": [
+            {
+                "base": review["base"],
+                "base_head": review["base_head"],
+                "body_file": review["body_file"],
+                "body_path": str(run_dir(checkpoint["run_id"]) / review["body_file"]),
+                "body_sha256": review["body_sha256"],
+                "branch": review["branch"],
+                "head": review["head"],
+                "number": review["number"],
+                "stack": memberships[position],
+                "status": review["status"],
+                "title": group["layers"][position]["title"],
+                "url": review["url"],
+            }
+            for position, review in enumerate(reviews)
+        ],
+        "target_repository": checkpoint["target_repository"],
+        "target_repository_id": checkpoint["target_repository_id"],
+    }
+    if action == "create":
+        payload_file = request_payload_path(
+            checkpoint["run_id"],
+            group["id"],
+            "github-stack-create",
+        )
+        write_json(
+            payload_file,
+            {"pull_requests": [review["number"] for review in reviews]},
+        )
+        output["endpoint"] = f"repos/{checkpoint['target_repository']}/stacks"
+        output["payload_file"] = str(payload_file)
+    if stack_number is not None:
+        output["stack_number"] = stack_number
+    print(json.dumps(output, indent=2, sort_keys=True))
+
+
+def command_advance(args: argparse.Namespace) -> None:
+    """Advance through a non-remote publication phase."""
+    checkpoint = load_checkpoint()
+    transitions = {
+        "planned": "validated",
+        "validated": "publishing",
+    }
+    expected = transitions.get(checkpoint["phase"])
+    if expected != args.phase:
+        raise SystemExit(
+            f"cannot advance publication from {checkpoint['phase']} to {args.phase}"
+        )
+    load_plan(checkpoint)
+    checkpoint["phase"] = args.phase
+    save_checkpoint(checkpoint)
+    print(json.dumps(checkpoint, indent=2, sort_keys=True))
+
+
+def verified_review_identity(
+    args: argparse.Namespace,
+    checkpoint: dict[str, Any],
+    plan: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    """Validate provider observations and return one planned review identity."""
+    group, layer = find_layer(plan, args.layer)
+    remote_branch = checkpoint["remote_branches"].get(args.layer)
+    if remote_branch is None or remote_branch.get("confirmed_head") != layer["tip"]:
+        raise SystemExit("recording a review requires its confirmed remote branch")
+    head = canonical_commit(args.head)
+    if head != layer["tip"]:
+        raise SystemExit("published review head does not match its planned tip")
+    if args.base != layer["base_branch"]:
+        raise SystemExit("published review base does not match its plan")
+    if args.status != checkpoint["requested_status"]:
+        raise SystemExit("published review status does not match the requested status")
+    base_head = canonical_commit(args.base_head)
+    if base_head != expected_base_head(checkpoint, plan, layer):
+        raise SystemExit("published review base head does not match its planned commit")
+    number = require_integer(args.number, "number")
+    url = require_string(args.url, "url")
+    expected_url = canonical_review_url(
+        checkpoint["provider"],
+        checkpoint["host_url"],
+        checkpoint["target_repository"],
+        number,
+    )
+    if url.rstrip("/") != expected_url:
+        raise SystemExit("published review URL does not match the target repository")
+    identity = {
+        "group": group["id"],
+        "layer": args.layer,
+        "branch": layer["branch"],
+        "base": args.base,
+        "base_head": base_head,
+        "head": head,
+        "number": number,
+        "url": expected_url,
+        "status": args.status,
+    }
+    return group, layer, identity
+
+
+def reject_duplicate_review_identity(
+    records: dict[str, Any],
+    layer_id: str,
+    identity: dict[str, Any],
+) -> None:
+    """Reject one number or URL already bound to a different layer."""
+    for existing_layer, existing_record in records.items():
+        if existing_layer == layer_id:
+            continue
+        if existing_record["number"] == identity["number"]:
+            raise SystemExit(
+                f"review request {identity['number']} is already assigned to another layer"
+            )
+        if existing_record["url"] == identity["url"]:
+            raise SystemExit("review URL is already assigned to another layer")
+
+
+def command_record_created_review(args: argparse.Namespace) -> None:
+    """Checkpoint one verified review identity immediately after creation."""
+    checkpoint, plan = require_publishing()
+    if args.layer in checkpoint["publications"]:
+        raise SystemExit("this review request is already finally recorded")
+    group, layer, identity = verified_review_identity(args, checkpoint, plan)
+    created_reviews = checkpoint["created_reviews"]
+    reject_duplicate_review_identity(created_reviews, args.layer, identity)
+    existing = created_reviews.get(args.layer)
+    if existing is not None:
+        if any(existing.get(field) != expected for field, expected in identity.items()):
+            raise SystemExit(f"created review identity changed for layer {args.layer}")
+        print(json.dumps(existing, indent=2, sort_keys=True))
+        return
+    body_file, body_sha256, _body = materialize_rendered_body(
+        checkpoint,
+        group,
+        layer,
+    )
+    created_review = {
+        **identity,
+        "body_file": body_file,
+        "body_sha256": body_sha256,
+        "observed_at": now(),
+    }
+    created_reviews[args.layer] = created_review
+    save_checkpoint(checkpoint)
+    print(json.dumps(created_review, indent=2, sort_keys=True))
+
+
+def command_record_review(args: argparse.Namespace) -> None:
+    """Record one final verified remote pull or merge request."""
+    checkpoint, plan = require_publishing()
+    group, _layer, identity = verified_review_identity(args, checkpoint, plan)
+    created_review = checkpoint["created_reviews"].get(args.layer)
+    if created_review is None:
+        raise SystemExit("record the created review identity before final verification")
+    for field, expected in identity.items():
+        if created_review.get(field) != expected:
+            raise SystemExit(f"final review identity changed for layer {args.layer}")
+    if group["transport"] == "github-stack" and len(group["layers"]) > 1:
+        stack_number: int | None = require_integer(args.stack_number, "stack_number")
+    else:
+        if args.stack_number is not None:
+            raise SystemExit("this publication transport cannot record a stack number")
+        stack_number = None
+    publications = checkpoint["publications"]
+    if stack_number is not None:
+        for existing_publication in publications.values():
+            if (
+                existing_publication["stack_number"] == stack_number
+                and existing_publication["group"] != group["id"]
+            ):
+                raise SystemExit(
+                    f"GitHub stack {stack_number} is already assigned to another "
+                    "publication group"
+                )
+    reject_duplicate_review_identity(publications, args.layer, identity)
+    existing = publications.get(args.layer)
+    if existing is not None:
+        expected_existing = {**identity, "stack_number": stack_number}
+        if any(
+            existing.get(field) != expected
+            for field, expected in expected_existing.items()
+        ):
+            raise SystemExit(f"publication record changed for layer {args.layer}")
+        print(json.dumps(existing, indent=2, sort_keys=True))
+        return
+    publication = {
+        **identity,
+        "stack_number": stack_number,
+        "verified_at": now(),
+    }
+    publications[args.layer] = publication
+    save_checkpoint(checkpoint)
+    print(json.dumps(publication, indent=2, sort_keys=True))
+
+
+def command_finish(_args: argparse.Namespace) -> None:
+    """Mark a fully recorded publication run complete."""
+    checkpoint = load_checkpoint()
+    if checkpoint["phase"] != "publishing":
+        raise SystemExit("publication can finish only from the publishing phase")
+    plan = load_plan(checkpoint)
+    validate_progress_against_plan(checkpoint, plan)
+    expected_layers = {
+        layer["id"] for group in plan["groups"] for layer in group["layers"]
+    }
+    if set(checkpoint["created_reviews"]) != expected_layers:
+        missing = sorted(expected_layers - set(checkpoint["created_reviews"]))
+        raise SystemExit("created review records are incomplete: " + ", ".join(missing))
+    if set(checkpoint["publications"]) != expected_layers:
+        missing = sorted(expected_layers - set(checkpoint["publications"]))
+        raise SystemExit("publication records are incomplete: " + ", ".join(missing))
+    for group in plan["groups"]:
+        if group["transport"] != "github-stack" or len(group["layers"]) < 2:
+            continue
+        stack_numbers = {
+            checkpoint["publications"][layer["id"]]["stack_number"]
+            for layer in group["layers"]
+        }
+        if len(stack_numbers) != 1:
+            raise SystemExit(
+                f"GitHub stack group {group['id']} has inconsistent stack numbers"
+            )
+    checkpoint["phase"] = "published"
+    save_checkpoint(checkpoint)
+    print(json.dumps(checkpoint, indent=2, sort_keys=True))
+
+
+def validate_resume_state(checkpoint: dict[str, Any]) -> dict[str, Any]:
+    """Validate local recovery and planned branches before resuming."""
+    recovery = git_run(
+        "show-ref", "--verify", "--hash", checkpoint["recovery_ref"], check=False
+    )
+    if recovery.returncode or recovery.stdout.strip() != checkpoint["source_head"]:
+        raise SystemExit("publication recovery ref is missing or changed")
+    canonical_commit(checkpoint["target_base"])
+    commits = range_commits(checkpoint["base"], checkpoint["recovery_ref"])
+    if commits != checkpoint["commits"]:
+        raise SystemExit("publication recovery range does not match its checkpoint")
+    if checkpoint["phase"] != "published":
+        validate_push_remote(checkpoint)
+    if checkpoint["phase"] != "started":
+        plan = load_plan(
+            checkpoint,
+            check_branches=checkpoint["phase"] != "published",
+        )
+        validate_progress_against_plan(checkpoint, plan)
+    return checkpoint
+
+
+def command_status(args: argparse.Namespace) -> None:
+    """Print the active state after strict validation."""
+    checkpoint = validate_resume_state(load_checkpoint())
+    if args.json:
+        print(json.dumps(checkpoint, indent=2, sort_keys=True))
+        return
+    print(f"run: {checkpoint['run_id']}")
+    print(f"phase: {checkpoint['phase']}")
+    print(f"requested status: {checkpoint['requested_status']}")
+    print(f"recovery ref: {checkpoint['recovery_ref']}")
+
+
+def command_state_dir(_args: argparse.Namespace) -> None:
+    """Print the private state root."""
+    print(STATE_ROOT)
+
+
+def command_run_dir(_args: argparse.Namespace) -> None:
+    """Print the active run directory."""
+    run_id = active_run_id()
+    assert run_id is not None
+    print(run_dir(run_id))
+
+
+def parser() -> argparse.ArgumentParser:
+    """Build the command-line parser."""
+    root = argparse.ArgumentParser(description=__doc__)
+    commands = root.add_subparsers(dest="command", required=True)
+
+    state_dir_parser = commands.add_parser("state-dir")
+    state_dir_parser.set_defaults(func=command_state_dir)
+
+    run_dir_parser = commands.add_parser("run-dir")
+    run_dir_parser.set_defaults(func=command_run_dir)
+
+    start = commands.add_parser("start")
+    start.add_argument("--base", required=True)
+    start.add_argument("--target-base", required=True)
+    start.add_argument("--provider", choices=PROVIDERS, required=True)
+    start.add_argument("--host-url", required=True)
+    start.add_argument("--target-repository", required=True)
+    start.add_argument("--head-repository", required=True)
+    start.add_argument("--target-repository-id", type=int)
+    start.add_argument("--head-repository-id", type=int)
+    start.add_argument("--target-project-id", type=int)
+    start.add_argument("--head-project-id", type=int)
+    start.add_argument("--remote", required=True)
+    start.add_argument("--head-push-url", action="append")
+    start.add_argument("--trunk", required=True)
+    start.add_argument("--status", choices=PUBLICATION_STATUSES, required=True)
+    start.set_defaults(func=command_start)
+
+    record_normalized = commands.add_parser("record-normalized")
+    record_normalized.add_argument("--tip", required=True)
+    record_normalized.set_defaults(func=command_record_normalized)
+
+    refresh_normalized = commands.add_parser("refresh-normalized")
+    refresh_normalized.add_argument("--target-base", required=True)
+    refresh_normalized.add_argument("--tip", required=True)
+    refresh_normalized.set_defaults(func=command_refresh_normalized)
+
+    record_plan = commands.add_parser("record-plan")
+    record_plan.add_argument("--file", required=True)
+    record_plan.set_defaults(func=command_record_plan)
+
+    advance = commands.add_parser("advance")
+    advance.add_argument("--phase", choices=("validated", "publishing"), required=True)
+    advance.set_defaults(func=command_advance)
+
+    prepare_push = commands.add_parser("prepare-push")
+    prepare_push.add_argument("--layer", required=True)
+    prepare_push.add_argument("--expected-old", required=True)
+    prepare_push.set_defaults(func=command_prepare_push)
+
+    push_target = commands.add_parser("push-target")
+    push_target.add_argument("--layer", required=True)
+    push_target.set_defaults(func=command_push_target)
+
+    confirm_push = commands.add_parser("confirm-push")
+    confirm_push.add_argument("--layer", required=True)
+    confirm_push.add_argument("--remote-head", required=True)
+    confirm_push.set_defaults(func=command_confirm_push)
+
+    gitlab_request = commands.add_parser("gitlab-request")
+    gitlab_request.add_argument("--layer", required=True)
+    gitlab_request.set_defaults(func=command_gitlab_request)
+
+    github_request = commands.add_parser("github-request")
+    github_request.add_argument("--layer", required=True)
+    github_request.set_defaults(func=command_github_request)
+
+    github_stack_request = commands.add_parser("github-stack-request")
+    github_stack_request.add_argument("--group", required=True)
+    github_stack_request.add_argument("--observations", required=True)
+    github_stack_request.set_defaults(func=command_github_stack_request)
+
+    record_created_review = commands.add_parser("record-created-review")
+    record_created_review.add_argument("--layer", required=True)
+    record_created_review.add_argument("--number", type=int, required=True)
+    record_created_review.add_argument("--url", required=True)
+    record_created_review.add_argument("--head", required=True)
+    record_created_review.add_argument("--base", required=True)
+    record_created_review.add_argument("--base-head", required=True)
+    record_created_review.add_argument(
+        "--status", choices=PUBLICATION_STATUSES, required=True
+    )
+    record_created_review.set_defaults(func=command_record_created_review)
+
+    record_review = commands.add_parser("record-review")
+    record_review.add_argument("--layer", required=True)
+    record_review.add_argument("--number", type=int, required=True)
+    record_review.add_argument("--url", required=True)
+    record_review.add_argument("--head", required=True)
+    record_review.add_argument("--base", required=True)
+    record_review.add_argument("--base-head", required=True)
+    record_review.add_argument("--status", choices=PUBLICATION_STATUSES, required=True)
+    record_review.add_argument("--stack-number", type=int)
+    record_review.set_defaults(func=command_record_review)
+
+    finish = commands.add_parser("finish")
+    finish.set_defaults(func=command_finish)
+
+    status = commands.add_parser("status")
+    status.add_argument("--json", action="store_true")
+    status.set_defaults(func=command_status)
+    return root
+
+
+def main() -> None:
+    """Run the selected helper command."""
+    args = parser().parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/assets/claude-skills/refine-commit-messages/SKILL.md
+++ b/assets/claude-skills/refine-commit-messages/SKILL.md
@@ -166,10 +166,10 @@ git --no-optional-locks show-ref --verify "$RECOVERY_REF"
 ```
 
 Use the checkpoint phase reported by `status`. For the current `applying`
-phase, inspect `git status`, the rebase todo/done files, and the last checkpoint
-event. Continue only when they identify the same rewrite plan and series
-position. After resolving a transient hook failure or other understood stop,
-run:
+phase, inspect `git --no-optional-locks status`, the rebase todo/done files, and
+the last checkpoint event. Continue only when they identify the same rewrite
+plan and series position. After resolving a transient hook failure or other
+understood stop, run:
 
 ```bash
 git --no-optional-locks -c commit.gpgSign=false rebase --continue

--- a/assets/claude-skills/refine-history/SKILL.md
+++ b/assets/claude-skills/refine-history/SKILL.md
@@ -137,11 +137,11 @@ git --no-optional-locks show-ref --verify "$RECOVERY_REF"
 `check-resume` requires the checkpoint, recovery ref, original range,
 `pre-tree.txt`, `pre-count.txt`, and `pre-series.txt` to agree and rechecks
 local remote-tracking containment. It does not refresh remotes or determine
-branch policy. If a rebase is active, inspect `git status`, the rebase todo/done
-files, the last checkpoint event, and the relevant rewrite procedure. Continue
-only when they identify the same interrupted refinement step. It is also safe
-to use `git rebase --abort` to return to that step's pre-rebase state; never
-abort and then call `start`.
+branch policy. If a rebase is active, inspect `git --no-optional-locks status`,
+the rebase todo/done files, the last checkpoint event, and the relevant rewrite
+procedure. Continue only when they identify the same interrupted refinement
+step. It is also safe to use `git rebase --abort` to return to that step's
+pre-rebase state; never abort and then call `start`.
 
 If no Git operation is active, require a clean tree and no batch/session before
 starting another rewrite. When an active batch or dirty tree cannot be tied

--- a/assets/claude-skills/refine-history/references/rewrite-procedures.md
+++ b/assets/claude-skills/refine-history/references/rewrite-procedures.md
@@ -84,12 +84,12 @@ For one target:
 
 ```bash
 TARGET_SHA=PUT_COMMIT_THAT_SHOULD_HAVE_CONTAINED_THE_HUNK
-TARGET_SHORT=$(git rev-parse --short=7 "$TARGET_SHA")
-REPAIR_SHORT=$(git rev-parse --short=7 "$REPAIR_SHA")
+TARGET_SHORT=$(git --no-optional-locks rev-parse --short=7 "$TARGET_SHA")
+REPAIR_SHORT=$(git --no-optional-locks rev-parse --short=7 "$REPAIR_SHA")
 git --no-optional-locks show --format= --binary "$REPAIR_SHA" > "$REFINE_HISTORY_STATE_DIR/repair-$REPAIR_SHORT.patch"
 python3 "$REFINE_HISTORY_HELPER" mark --phase rewriting --note "integrate $REPAIR_SHA into $TARGET_SHA"
 GIT_SEQUENCE_EDITOR="sed -i -E -e 's/^pick (${TARGET_SHORT}[0-9a-f]*) /edit \\1 /' -e 's/^pick (${REPAIR_SHORT}[0-9a-f]*) /drop \\1 /'" git rebase -i "$BASE_SHA"
-git apply --check "$REFINE_HISTORY_STATE_DIR/repair-$REPAIR_SHORT.patch"
+git --no-optional-locks apply --check "$REFINE_HISTORY_STATE_DIR/repair-$REPAIR_SHORT.patch"
 git apply "$REFINE_HISTORY_STATE_DIR/repair-$REPAIR_SHORT.patch"
 git-stage-batch start
 git-stage-batch show
@@ -103,9 +103,10 @@ test -z "$(git --no-optional-locks status --short)"
 git rebase --continue
 ```
 
-If `git apply --check` fails, reconstruct the same one-target hunks manually
-and verify the working diff against the saved patch. Never suppress the apply
-failure. Restart the complete audit when the rebase finishes.
+If `git --no-optional-locks apply --check` fails, reconstruct the same
+one-target hunks manually and verify the working diff against the saved patch.
+Never suppress the apply failure. Restart the complete audit when the rebase
+finishes.
 
 ## Repair a failing committed snapshot
 

--- a/docs/ai-assistants.md
+++ b/docs/ai-assistants.md
@@ -42,6 +42,9 @@ The bundled Claude skills currently include:
 - `commit-unstaged-changes` for splitting unstaged work into one or more commits
 - `decompose-and-commit-unstaged-changes` for peeling larger unstaged work into
   concern batches and rebuilding a fine-grained commit series
+- `publish-unpushed-commits` for turning a clean unpublished commit range into
+  ready-for-review GitHub pull requests or GitLab merge requests, including
+  provider-native same-repository stacks and cross-fork publication
 - `refine-commit-messages` for auditing and rewording messages in an existing
   series without changing any patch or commit boundary
 - `refine-history` for splitting, rewording, and integrating commits in an
@@ -50,7 +53,8 @@ The bundled Claude skills currently include:
 The regular commit skills stage the current working tree into new commits.
 The decomposition skill hands its rebuilt series to `refine-history` for the
 final boundary rewrite, and `refine-history` delegates its final prose pass to
-`refine-commit-messages`. You can also invoke either skill directly:
+`refine-commit-messages`. You can invoke the refinement and publication
+workflows directly:
 
 ```bash
 claude "/refine-commit-messages BASE_SHA"
@@ -58,6 +62,10 @@ claude "/refine-commit-messages audit BASE_SHA"
 claude "/refine-commit-messages resume"
 claude "/refine-history BASE_SHA"
 claude "/refine-history resume"
+claude "/publish-unpushed-commits"
+claude "/publish-unpushed-commits draft"
+claude "/publish-unpushed-commits audit"
+claude "/publish-unpushed-commits resume"
 ```
 
 The default forms of both refinement skills require a clean, non-empty, linear
@@ -68,12 +76,39 @@ unchanged. Its `audit BASE_SHA` form may inspect shared history because it does
 not update refs or commits. The `resume` forms continue each skill's checkpoint
 on its original branch.
 
-Selecting the decomposition skill installs both refinement dependencies, and
-selecting `refine-history` installs `refine-commit-messages`:
+Publication is ready for review by default. The explicit `draft` form keeps all
+new review requests in draft status, `audit` plans without publishing, and
+`resume` continues the strict publication checkpoint. The skill uses GitHub's
+native stack relationship or GitLab's recognized target-branch chain for
+eligible dependent branches in one repository. It uses ordinary review
+requests for a singleton, when native stacks are unavailable, and when head
+branches live in a fork. It stops after verified publication and never merges.
+
+For eligible groups, the skill probes GitHub's Stacked Pull Requests REST API
+and creates the relationship directly after the pull requests exist. It falls
+back to ordinary pull requests when that API is unavailable; no GitHub CLI
+extension is required. See GitHub's
+[Stacked Pull Requests API documentation](https://docs.github.com/en/pull-requests/reference/stacked-pull-requests-rest-and-graphql-apis)
+for repository availability and endpoint details.
+
+GitLab recognizes same-project stacked merge requests from their target-branch
+chain on GitLab 19.1 and newer. Publication creates and verifies that chain with
+host-pinned `glab api` calls rather than adopting `glab stack`, whose
+experimental workflow also owns commit and branch construction. GitLab
+publication requires an authenticated `glab` CLI for the selected root-hosted
+GitLab URL and records numeric source and target project identities. See the
+[GitLab stacked merge request documentation](https://docs.gitlab.com/user/project/merge_requests/reviews/stacked_merge_requests/)
+for the server-side relationship and limits.
+
+Selecting the decomposition or publication skill installs both refinement
+dependencies, and selecting `refine-history` installs
+`refine-commit-messages`:
 
 ```bash
 git-stage-batch install-assets claude-skills \
   --filter decompose-and-commit-unstaged-changes
+git-stage-batch install-assets claude-skills \
+  --filter publish-unpushed-commits
 ```
 
 Create or update `CLAUDE.md` in your repository root:

--- a/docs/index.md
+++ b/docs/index.md
@@ -240,13 +240,14 @@ Then ask Claude Code to split and commit the current unstaged work:
 
 Omit `--filter` when installing Claude skills if you also want the larger
 `/decompose-and-commit-unstaged-changes` workflow and the standalone
-`/refine-history BASE_SHA` and `/refine-commit-messages BASE_SHA` workflows.
-Message refinement rewrites by default; its explicit `audit BASE_SHA` mode
-only reports findings and proposed replacements. Selecting `refine-history`
-installs its message-refinement dependency, and selecting decomposition
-installs both. Mutating refinement accepts only a clean, linear, unpublished
-range. See the [AI assistant guide](ai-assistants.md) for resume behavior,
-Codex setup, and fuller assistant configuration.
+`/refine-history BASE_SHA`, `/refine-commit-messages BASE_SHA`, and
+`/publish-unpushed-commits` workflows. Publication creates ready-for-review
+GitHub pull requests or GitLab merge requests by default, supports explicit
+`draft` and `audit` modes, handles forks and provider-native stacks, and never
+merges. Selecting publication or decomposition installs both refinement
+dependencies. Mutating workflows accept only clean, linear, unpublished ranges
+and provide a `resume` form. See the
+[AI assistant guide](ai-assistants.md) for Codex setup and fuller behavior.
 
 ## Example Workflow
 

--- a/src/git_stage_batch/data/asset_catalog.py
+++ b/src/git_stage_batch/data/asset_catalog.py
@@ -69,6 +69,33 @@ ASSET_GROUPS: dict[str, AssetGroup] = {
         ),
         entry_companion_assets=(
             (
+                "publish-unpushed-commits",
+                (
+                    CompanionAsset(
+                        source_segments=(
+                            "assets",
+                            "claude-skills",
+                            "refine-history",
+                        ),
+                        target_segments=(".claude", "skills", "refine-history"),
+                        display_name="Claude skill",
+                    ),
+                    CompanionAsset(
+                        source_segments=(
+                            "assets",
+                            "claude-skills",
+                            "refine-commit-messages",
+                        ),
+                        target_segments=(
+                            ".claude",
+                            "skills",
+                            "refine-commit-messages",
+                        ),
+                        display_name="Claude skill",
+                    ),
+                ),
+            ),
+            (
                 "decompose-and-commit-unstaged-changes",
                 (
                     CompanionAsset(

--- a/tests/commands/test_install_assets.py
+++ b/tests/commands/test_install_assets.py
@@ -81,6 +81,13 @@ class TestCommandInstallAssets:
         claude_refine = (
             temp_git_repo / ".claude" / "skills" / "refine-history" / "SKILL.md"
         )
+        claude_publish = (
+            temp_git_repo
+            / ".claude"
+            / "skills"
+            / "publish-unpushed-commits"
+            / "SKILL.md"
+        )
         codex_internal_drafter = (
             temp_git_repo / ".agents" / "internal" / "commit-message-drafter.md"
         )
@@ -115,6 +122,7 @@ class TestCommandInstallAssets:
         assert claude_decompose.exists()
         assert claude_messages.exists()
         assert claude_refine.exists()
+        assert claude_publish.exists()
         assert codex_internal_drafter.exists()
         assert codex_unstaged.exists()
         assert codex_staged.exists()
@@ -131,8 +139,8 @@ class TestCommandInstallAssets:
         ) in captured.err
         assert (
             "Installed Claude skills: commit-staged-changes, commit-unstaged-changes, "
-            "decompose-and-commit-unstaged-changes, refine-commit-messages, "
-            "refine-history"
+            "decompose-and-commit-unstaged-changes, publish-unpushed-commits, "
+            "refine-commit-messages, refine-history"
         ) in captured.err
         assert (
             "Installed Codex skills: commit-staged-changes, commit-unstaged-changes, "
@@ -199,6 +207,13 @@ class TestCommandInstallAssets:
         refine_skill = (
             temp_git_repo / ".claude" / "skills" / "refine-history" / "SKILL.md"
         )
+        publish_skill = (
+            temp_git_repo
+            / ".claude"
+            / "skills"
+            / "publish-unpushed-commits"
+            / "SKILL.md"
+        )
         decompose_agent = (
             temp_git_repo / ".claude" / "agents" / "decompose-batch-peeler.md"
         )
@@ -208,6 +223,7 @@ class TestCommandInstallAssets:
         assert decompose_skill.exists()
         assert message_skill.exists()
         assert refine_skill.exists()
+        assert publish_skill.exists()
         assert decompose_agent.exists()
         assert "name: commit-staged-changes" in staged_skill.read_text(encoding="utf-8")
         assert "name: commit-unstaged-changes" in unstaged_skill.read_text(
@@ -221,8 +237,8 @@ class TestCommandInstallAssets:
         captured = capsys.readouterr()
         assert (
             "Installed Claude skills: commit-staged-changes, commit-unstaged-changes, "
-            "decompose-and-commit-unstaged-changes, refine-commit-messages, "
-            "refine-history"
+            "decompose-and-commit-unstaged-changes, publish-unpushed-commits, "
+            "refine-commit-messages, refine-history"
         ) in captured.err
 
     def test_install_single_skill(self, temp_git_repo):

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -149,6 +149,22 @@ class TestWheelContents:
             for f in files
         ), "Missing bundled refine-commit-messages Claude skill asset"
 
+    def test_wheel_contains_claude_publish_skill_asset(self, build_wheel):
+        """Test that the wheel contains the Claude publication helper."""
+        with zipfile.ZipFile(build_wheel, "r") as whl:
+            files = whl.namelist()
+
+        assert any(
+            "git_stage_batch/assets/claude-skills/publish-unpushed-commits/"
+            "scripts/publish-checkpoint.py" in f
+            for f in files
+        ), "Missing bundled publish-unpushed-commits Claude skill asset"
+        assert any(
+            "git_stage_batch/assets/claude-skills/publish-unpushed-commits/"
+            "references/gitlab-publication.md" in f
+            for f in files
+        ), "Missing bundled GitLab publication reference"
+
     def test_wheel_contains_claude_agent_asset(self, build_wheel):
         """Test that wheel contains the bundled Claude agent asset."""
         with zipfile.ZipFile(build_wheel, "r") as whl:


### PR DESCRIPTION
The project bundles Claude workflows for committing staged and unstaged
changes and refining unpublished history. Its asset installer carries the
supporting agents and refinement dependencies with each selected workflow.

Claude users cannot turn an unpublished commit range into GitHub pull
requests or GitLab merge requests while preserving recovery state,
explicit dependency relationships, and provider-specific repository
identity checks.

This pull request adds a ready-by-default publication skill with optional
draft, audit, and resume modes. It supports native GitHub stacks, GitLab
branch chains, ordinary fork publication, checkpointed recovery, and a
single selected Git remote that defaults to `origin`. It also installs the
required refinement skills and documents the workflow. A clean
lower-snapshot environment passes 3,563 tests with 12 skips, Ruff,
dead-code policy, type-hygiene policy, and strict mypy.

Claude users can now publish reviewable commit groups without granting the
workflow authority to merge them.
