### PR TITLE
matcher: Bound large-file matching state

### DIFF
--- a/src/git_stage_batch/batch/line_matching/comparison.py
+++ b/src/git_stage_batch/batch/line_matching/comparison.py
@@ -13,8 +13,14 @@ from enum import Enum, auto
 from itertools import chain
 from pathlib import Path
 
+from .line_mapping import IntVector, LineMapping
 from .match import match_lines
+from .match_workspace import MatcherWorkspace
+from .occurrence_index import LinePayloadOccurrenceIndex
 from ...core.models import LineLevelChange
+
+
+_SMALL_UNMAPPED_LINE_COUNT = 64
 
 
 class SemanticChangeKind(Enum):
@@ -90,24 +96,161 @@ def _trusted_matched_pairs(
     spool_dir: str | Path | None = None,
 ) -> Iterator[tuple[int, int]]:
     """Yield bidirectionally trusted source/target line pairs."""
-    with (
-        match_lines(
-            source_lines=source_lines,
-            target_lines=target_lines,
-            spool_dir=spool_dir,
-        ) as alignment,
-        match_lines(
+    with match_lines(
+        source_lines=source_lines,
+        target_lines=target_lines,
+        spool_dir=spool_dir,
+    ) as alignment:
+        if (
+            not alignment.may_have_unmapped_equal_lines
+            or not _unmapped_lines_share_content(
+                alignment,
+                source_lines=source_lines,
+                target_lines=target_lines,
+                spool_dir=spool_dir,
+            )
+        ):
+            yield from alignment.mapped_line_pairs()
+            return
+
+        with match_lines(
             source_lines=target_lines,
             target_lines=source_lines,
             spool_dir=spool_dir,
-        ) as reverse_alignment,
-    ):
-        for source_line, target_line in alignment.mapped_line_pairs():
-            reverse_source_line = reverse_alignment.get_target_line_from_source_line(
-                target_line
+        ) as reverse_alignment:
+            for source_line, target_line in alignment.mapped_line_pairs():
+                reverse_source_line = (
+                    reverse_alignment.get_target_line_from_source_line(
+                        target_line
+                    )
+                )
+                if reverse_source_line == source_line:
+                    yield source_line, target_line
+
+
+def _unmapped_lines_share_content(
+    alignment: LineMapping,
+    *,
+    source_lines: Sequence[bytes],
+    target_lines: Sequence[bytes],
+    spool_dir: str | Path | None,
+) -> bool:
+    """Return whether the two unmapped sides contain an equal line.
+
+    A direction-dependent alternative alignment necessarily leaves equal
+    content unmapped on both sides of the forward alignment.  When no such
+    content exists, every forward pair is already reciprocal and the reverse
+    matcher cannot reject one.
+    """
+    source_unmapped_count, bounded_source_indexes = (
+        _bounded_unmapped_indexes(alignment.source_to_target)
+    )
+    target_unmapped_count, bounded_target_indexes = (
+        _bounded_unmapped_indexes(alignment.target_to_source)
+    )
+    smaller_count = min(source_unmapped_count, target_unmapped_count)
+    if smaller_count == 0:
+        return False
+
+    if smaller_count <= _SMALL_UNMAPPED_LINE_COUNT:
+        return _small_unmapped_lines_share_content(
+            alignment,
+            source_lines=source_lines,
+            target_lines=target_lines,
+            source_unmapped_count=source_unmapped_count,
+            target_unmapped_count=target_unmapped_count,
+            bounded_source_indexes=bounded_source_indexes,
+            bounded_target_indexes=bounded_target_indexes,
+        )
+
+    with MatcherWorkspace(spool_dir=spool_dir) as workspace:
+        if source_unmapped_count <= target_unmapped_count:
+            occurrence_index = LinePayloadOccurrenceIndex(
+                workspace,
+                source_lines,
+                normalize_payloads=False,
+                target_indexes=_unmapped_indexes(alignment.source_to_target),
             )
-            if reverse_source_line == source_line:
-                yield source_line, target_line
+            return any(
+                occurrence_index.occurrence_count(target_lines[target_index])
+                for target_index in _unmapped_indexes(
+                    alignment.target_to_source
+                )
+            )
+
+        occurrence_index = LinePayloadOccurrenceIndex(
+            workspace,
+            target_lines,
+            normalize_payloads=False,
+            target_indexes=_unmapped_indexes(alignment.target_to_source),
+        )
+        return any(
+            occurrence_index.occurrence_count(source_lines[source_index])
+            for source_index in _unmapped_indexes(alignment.source_to_target)
+        )
+
+
+def _small_unmapped_lines_share_content(
+    alignment: LineMapping,
+    *,
+    source_lines: Sequence[bytes],
+    target_lines: Sequence[bytes],
+    source_unmapped_count: int,
+    target_unmapped_count: int,
+    bounded_source_indexes: Sequence[int],
+    bounded_target_indexes: Sequence[int],
+) -> bool:
+    """Check a bounded number of unmapped lines without an index."""
+    if source_unmapped_count <= target_unmapped_count:
+        smaller_lines = [
+            source_lines[source_index]
+            for source_index in bounded_source_indexes
+        ]
+        target_indexes: Iterable[int] = bounded_target_indexes
+        if target_unmapped_count > _SMALL_UNMAPPED_LINE_COUNT:
+            target_indexes = _unmapped_indexes(alignment.target_to_source)
+        return any(
+            any(
+                target_lines[target_index] == source_line
+                for source_line in smaller_lines
+            )
+            for target_index in target_indexes
+        )
+
+    smaller_lines = [
+        target_lines[target_index]
+        for target_index in bounded_target_indexes
+    ]
+    source_indexes: Iterable[int] = bounded_source_indexes
+    if source_unmapped_count > _SMALL_UNMAPPED_LINE_COUNT:
+        source_indexes = _unmapped_indexes(alignment.source_to_target)
+    return any(
+        any(
+            source_lines[source_index] == target_line
+            for target_line in smaller_lines
+        )
+        for source_index in source_indexes
+    )
+
+
+def _bounded_unmapped_indexes(mapping: IntVector) -> tuple[int, list[int]]:
+    """Count zero entries and retain at most a fixed number of indexes."""
+    count = 0
+    indexes: list[int] = []
+    for index in range(len(mapping)):
+        if mapping[index] != 0:
+            continue
+        count += 1
+        if len(indexes) < _SMALL_UNMAPPED_LINE_COUNT:
+            indexes.append(index)
+    return count, indexes
+
+
+def _unmapped_indexes(mapping: IntVector) -> Iterator[int]:
+    """Yield zero-based indexes absent from a line-mapping vector."""
+    for index in range(len(mapping)):
+        if mapping[index] == 0:
+            yield index
 
 
 def derive_semantic_change_runs(

--- a/src/git_stage_batch/batch/line_matching/line_mapping.py
+++ b/src/git_stage_batch/batch/line_matching/line_mapping.py
@@ -24,6 +24,7 @@ class LineMapping:
 
     source_to_target: IntVector
     target_to_source: IntVector
+    may_have_unmapped_equal_lines: bool = field(default=True, repr=False)
     _closed: bool = field(default=False, init=False, repr=False)
 
     def __enter__(self) -> LineMapping:

--- a/src/git_stage_batch/batch/line_matching/match.py
+++ b/src/git_stage_batch/batch/line_matching/match.py
@@ -74,7 +74,13 @@ class _LineOccurrenceTable:
             source_length,
             _OCCURRENCE_RECORD_FORMAT,
         )
+        self._has_common_lines = False
         self._closed = False
+
+    @property
+    def has_common_lines(self) -> bool:
+        """Return whether target scanning found source-equal content."""
+        return self._has_common_lines
 
     def scan_source(self, start: int, end: int) -> None:
         """Record source-side occurrence counts."""
@@ -119,6 +125,7 @@ class _LineOccurrenceTable:
             if record_index is None:
                 continue
 
+            self._has_common_lines = True
             record = self._records[record_index]
             target_count = record[_OCCURRENCE_TARGET_COUNT]
             if target_count == 0:
@@ -482,7 +489,7 @@ def _align_segment(
     source_to_target: _IntVector,
     target_to_source: _IntVector,
     workspace: MatcherWorkspace,
-) -> None:
+) -> bool:
     """Conservatively align one source/target segment.
 
     Strategy:
@@ -526,7 +533,7 @@ def _align_segment(
     )
 
     if source_start >= source_end or target_start >= target_end:
-        return
+        return False
 
     occurrence_table = _LineOccurrenceTable(
         workspace,
@@ -542,6 +549,7 @@ def _align_segment(
             source_start,
             source_end,
         )
+        has_common_lines = occurrence_table.has_common_lines
     finally:
         occurrence_table.close()
 
@@ -557,7 +565,7 @@ def _align_segment(
 
     if not anchors:
         workspace.close_resource(anchors)
-        return
+        return has_common_lines
 
     previous_source = source_start
     previous_target = target_start
@@ -595,6 +603,7 @@ def _align_segment(
         )
     finally:
         workspace.close_resource(anchors)
+    return has_common_lines
 
 
 def _validated_anchor_pairs(
@@ -657,15 +666,16 @@ def _align_segments_around_anchors(
     source_to_target: _IntVector,
     target_to_source: _IntVector,
     workspace: MatcherWorkspace,
-) -> None:
+) -> bool:
     """Align independent segments separated by trusted equal-line anchors."""
     source_start = 0
     target_start = 0
+    may_have_unmapped_equal_lines = False
 
     for source_line, target_line in anchor_pairs:
         source_index = source_line - 1
         target_index = target_line - 1
-        _align_segment(
+        may_have_unmapped_equal_lines |= _align_segment(
             source_lines,
             target_lines,
             source_start,
@@ -681,7 +691,7 @@ def _align_segments_around_anchors(
         source_start = source_index + 1
         target_start = target_index + 1
 
-    _align_segment(
+    may_have_unmapped_equal_lines |= _align_segment(
         source_lines,
         target_lines,
         source_start,
@@ -692,6 +702,7 @@ def _align_segments_around_anchors(
         target_to_source,
         workspace,
     )
+    return may_have_unmapped_equal_lines
 
 
 def match_acquirable_lines(
@@ -754,7 +765,7 @@ def match_acquirable_lines(
                 anchor_pairs,
                 workspace,
             )
-            _align_segments_around_anchors(
+            may_have_unmapped_equal_lines = _align_segments_around_anchors(
                 acquired_source_lines,
                 acquired_target_lines,
                 (
@@ -768,7 +779,8 @@ def match_acquirable_lines(
 
         return _LineMapping(
             source_to_target=source_to_target,
-            target_to_source=target_to_source
+            target_to_source=target_to_source,
+            may_have_unmapped_equal_lines=may_have_unmapped_equal_lines,
         )
     except BaseException:
         if source_to_target is not None:

--- a/src/git_stage_batch/batch/line_matching/match.py
+++ b/src/git_stage_batch/batch/line_matching/match.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from bisect import bisect_left
 from collections.abc import Hashable, Iterable, Sequence
 from pathlib import Path
 from typing import TypeVar
@@ -21,6 +20,8 @@ LineContent = TypeVar("LineContent", bound=Hashable)
 _MAX_UINT32 = (1 << 32) - 1
 _MAX_UINT64 = (1 << 64) - 1
 _LINE_PAIR_RECORD_FORMAT = "QQ"
+_LINE_INDEX_RECORD_FORMAT = "Q"
+_DIRECT_TARGET_RANK_SPAN_FACTOR = 8
 _OCCURRENCE_RECORD_FORMAT = "QQQQQQ"
 _OCCURRENCE_HASH = 0
 _OCCURRENCE_SOURCE_INDEX = 1
@@ -234,12 +235,19 @@ def _longest_increasing_subsequence_records(
     if pair_count == 0 or target_end <= target_start:
         return workspace.record_vector(0, _LINE_PAIR_RECORD_FORMAT)
 
-    target_indices = sorted({
-        pairs[pair_index][1]
-        for pair_index in range(pair_count)
-    })
-    best_lengths = workspace.int_vector(len(target_indices) + 1, width=8, fill=0)
-    best_indexes = workspace.int_vector(len(target_indices) + 1, width=8, fill=0)
+    target_indices = None
+    target_span = target_end - target_start
+    use_direct_target_ranks = (
+        target_span <= pair_count * _DIRECT_TARGET_RANK_SPAN_FACTOR
+    )
+    if use_direct_target_ranks:
+        target_rank_count = target_span
+    else:
+        target_indices = _sorted_unique_target_indices(pairs, workspace)
+        target_rank_count = len(target_indices)
+
+    best_lengths = workspace.int_vector(target_rank_count + 1, width=8, fill=0)
+    best_indexes = workspace.int_vector(target_rank_count + 1, width=8, fill=0)
     predecessors = workspace.int_vector(pair_count, width=8, fill=0)
     result_indexes = None
 
@@ -249,7 +257,15 @@ def _longest_increasing_subsequence_records(
 
         for pair_index in range(pair_count):
             _, target_index = pairs[pair_index]
-            target_rank = bisect_left(target_indices, target_index) + 1
+            if use_direct_target_ranks:
+                target_rank = target_index - target_start + 1
+                if target_rank < 1 or target_rank > target_span:
+                    raise ValueError(
+                        "LIS candidate target index is outside its segment"
+                    )
+            else:
+                assert target_indices is not None
+                target_rank = _mapped_target_rank(target_indices, target_index) + 1
             predecessor_length, predecessor_index_number = (
                 _query_best_record_by_target_rank(
                     best_lengths,
@@ -298,6 +314,50 @@ def _longest_increasing_subsequence_records(
         workspace.close_resource(predecessors)
         workspace.close_resource(best_indexes)
         workspace.close_resource(best_lengths)
+        if target_indices is not None:
+            workspace.close_resource(target_indices)
+
+
+def _sorted_unique_target_indices(
+    pairs: MappedRecordVector,
+    workspace: MatcherWorkspace,
+) -> MappedRecordVector:
+    """Return storage-backed sorted target coordinates from candidate pairs."""
+    target_indices = workspace.record_vector(
+        len(pairs),
+        _LINE_INDEX_RECORD_FORMAT,
+    )
+    for pair_index in range(len(pairs)):
+        target_indices.append((pairs[pair_index][1],))
+    sort_mapped_records(target_indices)
+
+    unique_count = 0
+    previous_target_index: int | None = None
+    for read_index in range(len(target_indices)):
+        target_index = target_indices[read_index][0]
+        if target_index == previous_target_index:
+            continue
+        target_indices[unique_count] = (target_index,)
+        unique_count += 1
+        previous_target_index = target_index
+    target_indices.truncate(unique_count)
+    return target_indices
+
+
+def _mapped_target_rank(
+    target_indices: MappedRecordVector,
+    target_index: int,
+) -> int:
+    """Return the zero-based insertion rank in mapped sorted coordinates."""
+    low = 0
+    high = len(target_indices)
+    while low < high:
+        middle = (low + high) // 2
+        if target_indices[middle][0] < target_index:
+            low = middle + 1
+        else:
+            high = middle
+    return low
 
 
 def _query_best_record_by_target_rank(

--- a/src/git_stage_batch/batch/line_matching/occurrence_index.py
+++ b/src/git_stage_batch/batch/line_matching/occurrence_index.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator, Sequence
+from collections.abc import Iterable, Iterator, Sequence
 
 from ...core.text_lines import normalize_line_endings
 from .match_workspace import MatcherWorkspace
@@ -29,14 +29,18 @@ def normalized_line_payload(content: bytes) -> bytes:
 
 
 class LinePayloadOccurrenceIndex:
-    """Index target positions by normalized line payload using mapped storage."""
+    """Index target positions by line payload using mapped storage."""
 
     def __init__(
         self,
         workspace: MatcherWorkspace,
         target_lines: Sequence[bytes],
+        *,
+        normalize_payloads: bool = True,
+        target_indexes: Iterable[int] | None = None,
     ) -> None:
         self._target_lines = target_lines
+        self._normalize_payloads = normalize_payloads
         self._bucket_count = _bucket_capacity(len(target_lines))
         self._buckets = workspace.int_vector(
             self._bucket_count,
@@ -51,11 +55,11 @@ class LinePayloadOccurrenceIndex:
             len(target_lines),
             _POSITION_RECORD_FORMAT,
         )
-        self._build()
+        self._build(target_indexes)
 
     def occurrence_count(self, content: bytes) -> int:
-        """Return the number of target lines with this normalized payload."""
-        payload = normalized_line_payload(content)
+        """Return the number of target lines with this configured payload."""
+        payload = self._payload(content)
         record_index = self._find_content_record(
             payload,
             _payload_hash(payload),
@@ -65,8 +69,8 @@ class LinePayloadOccurrenceIndex:
         return self._contents[record_index][_CONTENT_COUNT]
 
     def matching_line_indexes(self, content: bytes) -> Iterator[int]:
-        """Yield zero-based target indexes having this normalized payload."""
-        payload = normalized_line_payload(content)
+        """Yield zero-based target indexes having this configured payload."""
+        payload = self._payload(content)
         record_index = self._find_content_record(
             payload,
             _payload_hash(payload),
@@ -82,9 +86,16 @@ class LinePayloadOccurrenceIndex:
             yield position[_POSITION_TARGET_INDEX]
             position_number = position[_POSITION_NEXT]
 
-    def _build(self) -> None:
-        for target_index in range(len(self._target_lines)):
-            payload = normalized_line_payload(self._target_lines[target_index])
+    def _build(self, target_indexes: Iterable[int] | None) -> None:
+        indexes = (
+            range(len(self._target_lines))
+            if target_indexes is None
+            else target_indexes
+        )
+        for target_index in indexes:
+            if target_index < 0 or target_index >= len(self._target_lines):
+                raise ValueError("target line index is out of range")
+            payload = self._payload(self._target_lines[target_index])
             payload_hash = _payload_hash(payload)
             content_record_index = self._find_content_record(
                 payload,
@@ -129,7 +140,7 @@ class LinePayloadOccurrenceIndex:
             record = self._contents[record_index]
             if (
                 record[_CONTENT_HASH] == payload_hash
-                and normalized_line_payload(
+                and self._payload(
                     self._target_lines[
                         record[_CONTENT_REPRESENTATIVE_INDEX]
                     ]
@@ -143,6 +154,11 @@ class LinePayloadOccurrenceIndex:
 
     def _bucket_index(self, payload_hash: int) -> int:
         return payload_hash & (self._bucket_count - 1)
+
+    def _payload(self, content: bytes) -> bytes:
+        if self._normalize_payloads:
+            return normalized_line_payload(content)
+        return bytes(content)
 
 
 def _bucket_capacity(line_count: int) -> int:

--- a/src/git_stage_batch/core/mapped_storage.py
+++ b/src/git_stage_batch/core/mapped_storage.py
@@ -478,6 +478,18 @@ class MappedRecordVector(Sequence[tuple[int, ...]]):
 def sort_mapped_records(records: MappedRecordVector) -> None:
     """Sort fixed-width records in place without materializing a Python list."""
     record_count = len(records)
+    if record_count < 2:
+        return
+
+    previous = records[0]
+    for record_index in range(1, record_count):
+        current = records[record_index]
+        if previous > current:
+            break
+        previous = current
+    else:
+        return
+
     for start in range(record_count // 2 - 1, -1, -1):
         _sift_mapped_record(records, start, record_count)
     for end in range(record_count - 1, 0, -1):

--- a/tests/batch/line_matching/test_comparison.py
+++ b/tests/batch/line_matching/test_comparison.py
@@ -1,5 +1,9 @@
 """Tests for batch comparison helpers."""
 
+import gc
+from itertools import product
+import tracemalloc
+
 import pytest
 
 import git_stage_batch.batch.line_matching.comparison as comparison_module
@@ -9,6 +13,10 @@ from git_stage_batch.batch.line_matching.comparison import (
     derive_semantic_change_runs,
     stream_semantic_change_runs,
 )
+from git_stage_batch.batch.line_matching.match import match_lines
+
+
+_LINE_SCALE_HEAP_LIMIT = 256 * 1024
 
 
 def test_derive_semantic_change_runs_accepts_non_list_sequences(line_sequence):
@@ -23,6 +31,117 @@ def test_derive_semantic_change_runs_accepts_non_list_sequences(line_sequence):
     assert (runs[0].source_start, runs[0].source_end) == (2, 2)
     assert (runs[0].target_start, runs[0].target_end) == (2, 2)
     assert runs[0].target_anchor == 1
+
+
+def test_trusted_matching_skips_reciprocal_pass_for_disjoint_gaps(monkeypatch):
+    """A forward alignment is final when its gaps share no equal content."""
+    calls = 0
+    real_match_lines = comparison_module.match_lines
+
+    def count_match(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return real_match_lines(*args, **kwargs)
+
+    monkeypatch.setattr(comparison_module, "match_lines", count_match)
+
+    runs = derive_semantic_change_runs(
+        [b"head\n", b"old\n", b"tail\n"],
+        [b"head\n", b"new\n", b"tail\n"],
+    )
+
+    assert calls == 1
+    assert runs == [
+        SemanticChangeRun(
+            kind=SemanticChangeKind.REPLACEMENT,
+            source_start=2,
+            source_end=2,
+            target_start=2,
+            target_end=2,
+            target_anchor=1,
+        )
+    ]
+
+
+def test_trusted_matching_keeps_reciprocal_pass_for_crossed_lines(monkeypatch):
+    """Direction-dependent crossed matches must still be rejected."""
+    calls = 0
+    real_match_lines = comparison_module.match_lines
+
+    def count_match(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return real_match_lines(*args, **kwargs)
+
+    monkeypatch.setattr(comparison_module, "match_lines", count_match)
+
+    runs = derive_semantic_change_runs(
+        [b"first\n", b"second\n"],
+        [b"second\n", b"first\n"],
+    )
+
+    assert calls == 2
+    assert runs == [
+        SemanticChangeRun(
+            kind=SemanticChangeKind.REPLACEMENT,
+            source_start=1,
+            source_end=2,
+            target_start=1,
+            target_end=2,
+        )
+    ]
+
+
+def test_trusted_matching_fast_path_matches_bidirectional_reference():
+    """Fast-path trust must equal an explicit reciprocal intersection."""
+    alphabet = (b"a\n", b"b\n")
+    sequences = [
+        values
+        for length in range(4)
+        for values in product(alphabet, repeat=length)
+    ]
+
+    for source in sequences:
+        for target in sequences:
+            with (
+                match_lines(source, target) as forward,
+                match_lines(target, source) as reverse,
+            ):
+                reverse_pairs = {
+                    (source_line, target_line)
+                    for target_line, source_line in reverse.mapped_line_pairs()
+                }
+                expected = tuple(
+                    pair
+                    for pair in forward.mapped_line_pairs()
+                    if pair in reverse_pairs
+                )
+
+            assert tuple(comparison_module._trusted_matched_pairs(
+                source,
+                target,
+            )) == expected
+
+
+def test_large_unmapped_disjoint_gaps_avoid_line_scale_python_heap():
+    """Large reciprocal checks should index gaps in mapped storage."""
+    line_count = 8192
+    midpoint = line_count // 2
+    source = [f"old-{index}\n".encode() for index in range(line_count)]
+    target = [f"new-{index}\n".encode() for index in range(line_count)]
+    source.insert(midpoint, b"shared anchor\n")
+    target.insert(midpoint, b"shared anchor\n")
+
+    gc.collect()
+    tracemalloc.start()
+    try:
+        runs = derive_semantic_change_runs(source, target)
+        _current_heap, peak_heap = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+
+    assert len(runs) == 2
+    assert peak_heap < _LINE_SCALE_HEAP_LIMIT
 
 
 def test_stream_semantic_change_runs_closes_matching_pairs(monkeypatch):

--- a/tests/batch/line_matching/test_match_workspace.py
+++ b/tests/batch/line_matching/test_match_workspace.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import gc
+import tracemalloc
+
 import pytest
 
 import git_stage_batch.batch.line_matching.match as match_module
@@ -9,6 +12,9 @@ import git_stage_batch.core.mapped_storage as mapped_storage_module
 from git_stage_batch.batch.line_matching.match import match_lines
 from git_stage_batch.batch.line_matching.match_workspace import MatcherWorkspace
 from git_stage_batch.core.mapped_storage import MAPPED_STORAGE_OFFLOAD_SIZE_THRESHOLD
+
+
+_LINE_SCALE_HEAP_LIMIT = 256 * 1024
 
 
 def test_matcher_workspace_tracks_and_closes_resources():
@@ -93,3 +99,68 @@ def test_match_lines_closes_first_mapping_if_second_allocation_fails(
         match_lines([b"line\n"], [b"line\n"])
 
     assert source_mapping.closed is True
+
+
+@pytest.mark.parametrize("target_stride", [1, 9])
+def test_lis_target_ranking_does_not_use_line_scale_python_heap(target_stride):
+    """LIS target ranks should stay in mapped storage for large alignments."""
+    line_count = 8192
+    target_end = line_count * target_stride
+
+    with MatcherWorkspace() as workspace:
+        pairs = workspace.record_vector(line_count, "QQ")
+        for source_index in range(line_count):
+            pairs.append(
+                (
+                    source_index,
+                    (line_count - source_index - 1) * target_stride,
+                )
+            )
+
+        gc.collect()
+        tracemalloc.start()
+        try:
+            anchors = match_module._longest_increasing_subsequence_records(
+                pairs,
+                0,
+                target_end,
+                workspace,
+            )
+            _current_heap, peak_heap = tracemalloc.get_traced_memory()
+        finally:
+            tracemalloc.stop()
+
+        try:
+            assert tuple(anchors) == (
+                (0, (line_count - 1) * target_stride),
+            )
+        finally:
+            workspace.close_resource(anchors)
+
+    assert peak_heap < _LINE_SCALE_HEAP_LIMIT
+
+
+def test_dense_lis_target_ranking_does_not_sort_candidates(monkeypatch):
+    """Dense target coordinates should use the direct mapped rank index."""
+    line_count = 128
+
+    def reject_sort(_records):
+        raise AssertionError("dense target ranks should not be sorted")
+
+    monkeypatch.setattr(match_module, "sort_mapped_records", reject_sort)
+
+    with MatcherWorkspace() as workspace:
+        pairs = workspace.record_vector(line_count, "QQ")
+        for source_index in range(line_count):
+            pairs.append((source_index, line_count - source_index - 1))
+
+        anchors = match_module._longest_increasing_subsequence_records(
+            pairs,
+            0,
+            line_count,
+            workspace,
+        )
+        try:
+            assert tuple(anchors) == ((0, line_count - 1),)
+        finally:
+            workspace.close_resource(anchors)

--- a/tests/batch/merge/test_baseline_anchor_matching.py
+++ b/tests/batch/merge/test_baseline_anchor_matching.py
@@ -417,6 +417,40 @@ def test_live_target_rejects_repeated_replacement_parent_boundary():
     assert is_unique is False
 
 
+def test_occurrence_index_can_preserve_exact_line_identity():
+    """Distinctive context should retain line terminators in identity checks."""
+    lines = [b"same\n", b"same"]
+
+    with MatcherWorkspace() as workspace:
+        normalized_index = LinePayloadOccurrenceIndex(workspace, lines)
+        exact_index = LinePayloadOccurrenceIndex(
+            workspace,
+            lines,
+            normalize_payloads=False,
+        )
+
+        assert normalized_index.occurrence_count(b"same\n") == 2
+        assert exact_index.occurrence_count(b"same\n") == 1
+        assert exact_index.occurrence_count(b"same") == 1
+
+
+def test_occurrence_index_can_filter_target_indexes():
+    """Filtered indexes should retain only requested target positions."""
+    lines = [b"keep\n", b"skip\n", b"keep\n", b"other\n"]
+
+    with MatcherWorkspace() as workspace:
+        occurrence_index = LinePayloadOccurrenceIndex(
+            workspace,
+            lines,
+            normalize_payloads=False,
+            target_indexes=(0, 3),
+        )
+
+        assert occurrence_index.occurrence_count(b"keep\n") == 1
+        assert occurrence_index.occurrence_count(b"skip\n") == 0
+        assert tuple(occurrence_index.matching_line_indexes(b"other\n")) == (3,)
+
+
 def test_live_target_checks_indexed_boundary_candidates(monkeypatch):
     """Many unique claims must not rescan every target boundary."""
     target = [f"line-{index}\n".encode() for index in range(1002)]

--- a/tests/core/test_mapped_storage.py
+++ b/tests/core/test_mapped_storage.py
@@ -219,6 +219,35 @@ def test_mapped_record_vector_can_start_presized():
         assert list(records) == [(10, 20), (30, 40)]
 
 
+def test_sort_mapped_records_returns_early_for_ordered_records(monkeypatch):
+    """Already ordered mapped records should need only a linear scan."""
+    with MappedRecordVector(3, "QQ") as records:
+        records.append((1, 2))
+        records.append((1, 3))
+        records.append((2, 1))
+        monkeypatch.setattr(
+            mapped_storage_module,
+            "_sift_mapped_record",
+            lambda *_args: pytest.fail("ordered records must not build a heap"),
+        )
+
+        mapped_storage_module.sort_mapped_records(records)
+
+        assert list(records) == [(1, 2), (1, 3), (2, 1)]
+
+
+def test_sort_mapped_records_still_orders_unsorted_records():
+    """The ordered fast path must retain bounded in-place sorting fallback."""
+    with MappedRecordVector(3, "QQ") as records:
+        records.append((2, 1))
+        records.append((1, 3))
+        records.append((1, 2))
+
+        mapped_storage_module.sort_mapped_records(records)
+
+        assert list(records) == [(1, 2), (1, 3), (2, 1)]
+
+
 def test_chunked_mapped_record_vector_grows_from_small_chunks():
     """Chunked vectors should avoid allocating the full chunk up front."""
     records = ChunkedMappedRecordVector(


### PR DESCRIPTION
Large-file line matching already uses mapped storage for alignment records, but
several ranking and reciprocal-comparison paths still scale Python heap usage or
repeat a full reverse match.

That leaves the matcher vulnerable to input-size-dependent heap growth and
avoidable work on large files, precisely where mapped storage is intended to
keep resource use predictable.

This series adds an ordered fast path for mapped-record sorting, stores dense
and sparse LIS ranks outside the Python heap, bounds exact occurrence tracking,
and skips reciprocal matching only when the two sides are provably disjoint.
Exhaustive and targeted regressions cover ordering, duplicate lines, ambiguous
gaps, and reciprocal-match behavior.

The result keeps line-scale matcher state bounded while preserving conservative
matching semantics and current throughput.
