### PR TITLE
merge: Refuse ambiguous unanchored placement

### DIFF
--- a/src/git_stage_batch/batch/merge/baseline_edits.py
+++ b/src/git_stage_batch/batch/merge/baseline_edits.py
@@ -36,6 +36,7 @@ from ..line_matching.match_workspace import MatcherWorkspace
 from .candidates import MergeResolution as _MergeResolution
 
 if TYPE_CHECKING:
+    from ..line_matching.line_mapping import LineMapping
     from ..ownership.model import BatchOwnership
     from ..ownership.absence_claims import AbsenceClaim
 
@@ -76,6 +77,7 @@ def try_apply_baseline_coordinate_edits(
     resolution: _MergeResolution | None = None,
     max_resolution_choices: int = _DEFAULT_RESOLUTION_CHOICE_LIMIT,
     trust_baseline_coordinates: bool = False,
+    source_to_working_mapping: LineMapping | None = None,
     spool_dir: str | Path | None = None,
 ) -> Iterator[bytes] | None:
     """Return content edited at recorded baseline coordinates, if safe.
@@ -125,6 +127,7 @@ def try_apply_baseline_coordinate_edits(
             resolution=resolution,
             max_resolution_choices=max_resolution_choices,
             trust_baseline_coordinates=trust_baseline_coordinates,
+            source_to_working_mapping=source_to_working_mapping,
             spool_dir=spool_dir,
         )
         if plan is None:
@@ -159,6 +162,7 @@ def _build_baseline_edit_plan(
     resolution: _MergeResolution | None,
     max_resolution_choices: int,
     trust_baseline_coordinates: bool,
+    source_to_working_mapping: LineMapping | None,
     spool_dir: str | Path | None,
 ) -> _BaselineEditPlan | None:
     """Build and validate one storage-backed exact-coordinate edit plan."""
@@ -218,6 +222,7 @@ def _build_baseline_edit_plan(
         presence_lines,
         replacement_source_ranges,
         trust_baseline_coordinates=trust_baseline_coordinates,
+        source_to_working_mapping=source_to_working_mapping,
         spool_dir=spool_dir,
     )
     if positioned_insertion_lines is None:

--- a/src/git_stage_batch/batch/merge/baseline_presence_edits.py
+++ b/src/git_stage_batch/batch/merge/baseline_presence_edits.py
@@ -12,6 +12,7 @@ from .baseline_edit_plan import BaselineEditPlan
 from .baseline_reference_positions import (
     baseline_reference_insertion_position as _find_baseline_insertion_position,
 )
+from ..line_matching.line_mapping import LineMapping
 from ..line_matching.match import match_lines as _match_lines
 from ..line_matching.match_workspace import MatcherWorkspace
 
@@ -112,6 +113,7 @@ def _mapping_preserves_unpositioned_presence(
     working_lines: Sequence[bytes],
     unmapped_lines: MappedRecordVector,
     *,
+    source_to_working_mapping: LineMapping | None,
     spool_dir: str | Path | None,
 ) -> bool:
     """Return whether mapped unpositioned lines survive planned removals."""
@@ -123,11 +125,16 @@ def _mapping_preserves_unpositioned_presence(
 
     target_lines_are_ordered = True
     previous_target_line: int | None = None
-    with _match_lines(
-        source_lines,
-        working_lines,
-        spool_dir=spool_dir,
-    ) as mapping:
+    owned_mapping = None
+    mapping = source_to_working_mapping
+    if mapping is None:
+        owned_mapping = _match_lines(
+            source_lines,
+            working_lines,
+            spool_dir=spool_dir,
+        )
+        mapping = owned_mapping
+    try:
         for record_index in range(len(unmapped_lines)):
             claimed_line = unmapped_lines[record_index][0]
             target_line = mapping.get_target_line_from_source_line(claimed_line)
@@ -138,6 +145,9 @@ def _mapping_preserves_unpositioned_presence(
                 target_lines_are_ordered = False
             unmapped_lines[record_index] = (target_index,)
             previous_target_line = target_index
+    finally:
+        if owned_mapping is not None:
+            owned_mapping.close()
 
     if not target_lines_are_ordered:
         sort_mapped_records(unmapped_lines)
@@ -235,6 +245,7 @@ def plan_presence_insertions(
     replacement_source_ranges: Sequence[tuple[int, ...]],
     *,
     trust_baseline_coordinates: bool,
+    source_to_working_mapping: LineMapping | None,
     spool_dir: str | Path | None,
 ) -> MappedRecordVector | None:
     """Plan explicit insertions and validate presence resolved by matching."""
@@ -257,6 +268,7 @@ def plan_presence_insertions(
         source_lines,
         working_lines,
         unmapped_lines,
+        source_to_working_mapping=source_to_working_mapping,
         spool_dir=spool_dir,
     ):
         return None

--- a/src/git_stage_batch/batch/merge/candidate_enumeration.py
+++ b/src/git_stage_batch/batch/merge/candidate_enumeration.py
@@ -32,6 +32,7 @@ from .candidates import (
 from .coordinate_strategy import (
     AMBIGUITY_KEY as _COORDINATE_STRATEGY_AMBIGUITY_KEY,
     CoordinateStrategyChoice as _CoordinateStrategyChoice,
+    presence_lines_requiring_distinctive_context as _distinctive_context_lines,
 )
 from .validation import (
     check_structural_validity as _check_merge_structural_validity,
@@ -318,6 +319,7 @@ def _replacement_origin_candidate_set(
 
 def _presence_candidate_set(
     source_lines: Sequence[bytes],
+    ownership: "BatchOwnership",
     working_lines: Sequence[bytes],
     presence_line_set: LineSelection,
     deletion_claims: list["AbsenceClaim"],
@@ -326,6 +328,12 @@ def _presence_candidate_set(
     max_candidates: int,
     spool_dir: str | Path | None,
 ) -> _MergeCandidateSet:
+    distinctive_context_lines = _distinctive_context_lines(
+        ownership,
+        presence_line_set,
+        deletion_claims,
+        spool_dir=spool_dir,
+    )
     presence_mapping = match_lines(
         source_lines,
         working_lines,
@@ -344,6 +352,8 @@ def _presence_candidate_set(
                     for deletion in deletion_claims
                     if deletion.anchor_line is not None
                 },
+                distinctive_context_lines=distinctive_context_lines,
+                spool_dir=spool_dir,
             )
         )
     finally:
@@ -421,24 +431,35 @@ def _absence_candidate_set(
     if len([claim for claim in deletion_claims if claim.content_lines]) != 1:
         raise _MergeError(_("Batch was created from a different version of the file"))
 
+    distinctive_context_lines = _distinctive_context_lines(
+        ownership,
+        presence_line_set,
+        deletion_claims,
+        spool_dir=spool_dir,
+    )
+
     owned_mapping = match_lines(
         source_lines,
         working_lines,
         spool_dir=spool_dir,
     )
     try:
-        _check_merge_structural_validity(
+        contextual_placements = _check_merge_structural_validity(
             owned_mapping,
             presence_line_set,
             deletion_claims,
             source_lines,
             working_lines,
+            distinctive_presence_context_lines=distinctive_context_lines,
+            spool_dir=spool_dir,
         )
         realized_entries = _presence_constraints.apply_presence_constraints(
             source_lines,
             working_lines,
             presence_line_set,
             source_to_working_mapping=owned_mapping,
+            distinctive_context_lines=distinctive_context_lines,
+            contextual_placements=contextual_placements,
             spool_dir=spool_dir,
         )
     finally:
@@ -563,6 +584,7 @@ def enumerate_merge_batch_candidates_for_lines(
 
     presence_candidates = _presence_candidate_set(
         source_lines,
+        ownership,
         working_lines,
         presence_line_set,
         deletion_claims,

--- a/src/git_stage_batch/batch/merge/coordinate_strategy.py
+++ b/src/git_stage_batch/batch/merge/coordinate_strategy.py
@@ -4,16 +4,25 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from enum import Enum
+from pathlib import Path
 from typing import TYPE_CHECKING
 
-from ...core.line_selection import LineSelection
+from .baseline_replacement_ranges import (
+    collect_replacement_source_ranges,
+    replacement_source_range_capacity,
+)
+from ..line_matching.match_workspace import MatcherWorkspace
+from ...core.line_selection import LineRanges, LineSelection, coerce_line_ranges
+from ...core.mapped_storage import MappedRecordVector, sort_mapped_records
 
 if TYPE_CHECKING:
     from ..ownership.absence_claims import AbsenceClaim
     from ..ownership.model import BatchOwnership
+    from ..ownership.replacement_units import ReplacementUnit
 
 
 AMBIGUITY_KEY = "baseline-coordinate-vs-structural"
+_SOURCE_RANGE_RECORD_FORMAT = "QQ"
 
 
 class CoordinateStrategyChoice(Enum):
@@ -53,3 +62,125 @@ def has_recorded_baseline_coordinates(
         if origin_reference is not None and origin_reference.has_after_line:
             return True
     return False
+
+
+def presence_lines_requiring_distinctive_context(
+    ownership: BatchOwnership,
+    presence_line_set: LineSelection,
+    deletion_claims: Sequence[AbsenceClaim],
+    *,
+    spool_dir: str | Path | None = None,
+) -> LineRanges:
+    """Return presence lines lacking coordinate or replacement anchoring."""
+    source_selection = coerce_line_ranges(presence_line_set)
+    if not source_selection:
+        return LineRanges.empty()
+
+    coverage_capacity = sum(
+        len(claim.baseline_references)
+        for claim in ownership.presence_claims
+    ) + len(deletion_claims) + sum(
+        replacement_source_range_capacity(unit.presence_lines)
+        for unit in ownership.replacement_units
+        if _unit_has_nonempty_deletion(unit, deletion_claims)
+    )
+    if coverage_capacity == 0:
+        return source_selection
+
+    with MatcherWorkspace(spool_dir=spool_dir) as workspace:
+        covered_ranges = workspace.record_vector(
+            coverage_capacity,
+            _SOURCE_RANGE_RECORD_FORMAT,
+        )
+        for claim in ownership.presence_claims:
+            for claimed_line, reference in claim.baseline_references.items():
+                if (
+                    type(claimed_line) is int
+                    and claimed_line > 0
+                    and reference.has_after_line
+                ):
+                    covered_ranges.append((claimed_line, claimed_line))
+
+        _append_legacy_replacement_coverage(
+            covered_ranges,
+            presence_line_set,
+            deletion_claims,
+        )
+
+        for unit in ownership.replacement_units:
+            if not _unit_has_nonempty_deletion(unit, deletion_claims):
+                continue
+            unit_ranges = collect_replacement_source_ranges(
+                workspace,
+                unit.presence_lines,
+            )
+            if unit_ranges is None:
+                continue
+            try:
+                for source_start, source_end in unit_ranges:
+                    covered_ranges.append((source_start, source_end))
+            finally:
+                workspace.close_resource(unit_ranges)
+
+        if len(covered_ranges) > 1:
+            sort_mapped_records(covered_ranges)
+            _compact_source_ranges(covered_ranges)
+        covered_selection = LineRanges.from_ranges(
+            (start, end) for start, end in covered_ranges
+        )
+        return source_selection.difference(covered_selection)
+
+
+def _append_legacy_replacement_coverage(
+    covered_ranges: MappedRecordVector,
+    presence_line_set: LineSelection,
+    deletion_claims: Sequence[AbsenceClaim],
+) -> None:
+    """Cover legacy replacements coupled by their immediate source anchor."""
+    selected_ranges = presence_line_set.ranges()
+    for deletion in deletion_claims:
+        if not deletion.content_lines:
+            continue
+        anchor_line = deletion.anchor_line
+        if anchor_line is None:
+            replacement_start = 1
+        elif type(anchor_line) is int and anchor_line >= 0:
+            replacement_start = anchor_line + 1
+        else:
+            continue
+        for selected_start, selected_end in selected_ranges:
+            if selected_start <= replacement_start <= selected_end:
+                covered_ranges.append((replacement_start, selected_end))
+                break
+            if selected_start > replacement_start:
+                break
+
+
+def _unit_has_nonempty_deletion(
+    unit: ReplacementUnit,
+    deletion_claims: Sequence[AbsenceClaim],
+) -> bool:
+    """Return whether a replacement unit has a usable deletion side."""
+    return any(
+        type(deletion_index) is int
+        and 0 <= deletion_index < len(deletion_claims)
+        and bool(deletion_claims[deletion_index].content_lines)
+        for deletion_index in unit.deletion_indices
+    )
+
+
+def _compact_source_ranges(source_ranges: MappedRecordVector) -> None:
+    """Coalesce ordered coverage ranges without rebuilding them on the heap."""
+    retained_count = 0
+    for source_start, source_end in source_ranges:
+        if retained_count:
+            previous_start, previous_end = source_ranges[retained_count - 1]
+            if source_start <= previous_end + 1:
+                source_ranges[retained_count - 1] = (
+                    previous_start,
+                    max(previous_end, source_end),
+                )
+                continue
+        source_ranges[retained_count] = (source_start, source_end)
+        retained_count += 1
+    source_ranges.truncate(retained_count)

--- a/src/git_stage_batch/batch/merge/merge.py
+++ b/src/git_stage_batch/batch/merge/merge.py
@@ -20,6 +20,7 @@ from .coordinate_strategy import (
     AMBIGUITY_KEY as _COORDINATE_STRATEGY_AMBIGUITY_KEY,
     CoordinateStrategyChoice as _CoordinateStrategyChoice,
     has_recorded_baseline_coordinates as _has_recorded_baseline_coordinates,
+    presence_lines_requiring_distinctive_context as _distinctive_context_lines,
 )
 from .validation import (
     check_structural_validity as _check_merge_structural_validity,
@@ -159,6 +160,7 @@ def _build_structural_realized_entries(
 ) -> "RealizedEntries":
     """Build the structural candidate while owning any derived mapping."""
     owned_mapping: LineMapping | None = None
+    contextual_placements = None
     mapping = source_to_working_mapping
     try:
         with _baseline_anchor_matching.acquire_deletion_anchor_pairs_for_target(
@@ -190,13 +192,24 @@ def _build_structural_realized_entries(
                 )
             )
 
+        distinctive_presence_context_lines = _distinctive_context_lines(
+            ownership,
+            presence_line_set,
+            deletion_claims,
+            spool_dir=spool_dir,
+        )
+
         try:
-            _check_merge_structural_validity(
+            contextual_placements = _check_merge_structural_validity(
                 mapping,
                 presence_line_set,
                 deletion_claims,
                 source_lines,
                 working_lines,
+                distinctive_presence_context_lines=(
+                    distinctive_presence_context_lines
+                ),
+                spool_dir=spool_dir,
             )
         except _MergeError:
             if resolution is None:
@@ -209,6 +222,8 @@ def _build_structural_realized_entries(
             deletion_claims,
             source_to_working_mapping=mapping,
             resolution=resolution,
+            distinctive_context_lines=distinctive_presence_context_lines,
+            contextual_placements=contextual_placements,
             spool_dir=spool_dir,
         )
     finally:
@@ -390,35 +405,28 @@ def _merge_batch_acquired_line_chunks(
             _close_candidate(selected_coordinate_candidate)
         return
 
-    if strategy_choice is None:
-        fallback_chunks = _baseline_edits.try_apply_baseline_coordinate_edits(
-            source_lines,
-            working_lines,
-            ownership,
-            presence_line_set,
-            deletion_claims,
-            resolution=effective_resolution,
-            max_resolution_choices=_MERGE_CANDIDATE_CAP + 1,
-            spool_dir=spool_dir,
-        )
-        if fallback_chunks is not None:
-            try:
-                yield from fallback_chunks
-            finally:
-                _close_candidate(fallback_chunks)
-            return
-
-    coordinate_candidate = None
+    owned_shared_mapping = None
+    shared_mapping = source_to_working_mapping
     if (
-        resolution is None
-        and _has_recorded_baseline_coordinates(
+        strategy_choice is None
+        and shared_mapping is None
+        and presence_line_set
+        and not _has_recorded_baseline_coordinates(
             ownership,
             presence_line_set,
             deletion_claims,
         )
     ):
-        coordinate_candidate = (
-            _baseline_edits.try_apply_baseline_coordinate_edits(
+        owned_shared_mapping = match_lines(
+            source_lines,
+            working_lines,
+            spool_dir=spool_dir,
+        )
+        shared_mapping = owned_shared_mapping
+
+    try:
+        if strategy_choice is None:
+            fallback_chunks = _baseline_edits.try_apply_baseline_coordinate_edits(
                 source_lines,
                 working_lines,
                 ownership,
@@ -426,34 +434,68 @@ def _merge_batch_acquired_line_chunks(
                 deletion_claims,
                 resolution=effective_resolution,
                 max_resolution_choices=_MERGE_CANDIDATE_CAP + 1,
-                trust_baseline_coordinates=True,
+                source_to_working_mapping=shared_mapping,
                 spool_dir=spool_dir,
             )
-        )
-    try:
-        realized_entries = _build_structural_realized_entries(
-            source_lines,
-            ownership,
-            working_lines,
-            presence_line_set,
-            deletion_claims,
-            source_to_working_mapping=source_to_working_mapping,
-            resolution=effective_resolution,
-            spool_dir=spool_dir,
-        )
-        try:
-            structural_chunks = _realized_entry_content_chunks(realized_entries)
-            if coordinate_candidate is None:
-                yield from structural_chunks
-            else:
-                yield from _yield_identical_candidate_chunks(
-                    coordinate_candidate,
-                    structural_chunks,
+            if fallback_chunks is not None:
+                try:
+                    yield from fallback_chunks
+                finally:
+                    _close_candidate(fallback_chunks)
+                return
+
+        coordinate_candidate = None
+        if (
+            resolution is None
+            and _has_recorded_baseline_coordinates(
+                ownership,
+                presence_line_set,
+                deletion_claims,
+            )
+        ):
+            coordinate_candidate = (
+                _baseline_edits.try_apply_baseline_coordinate_edits(
+                    source_lines,
+                    working_lines,
+                    ownership,
+                    presence_line_set,
+                    deletion_claims,
+                    resolution=effective_resolution,
+                    max_resolution_choices=_MERGE_CANDIDATE_CAP + 1,
+                    trust_baseline_coordinates=True,
+                    source_to_working_mapping=shared_mapping,
+                    spool_dir=spool_dir,
                 )
+            )
+        try:
+            realized_entries = _build_structural_realized_entries(
+                source_lines,
+                ownership,
+                working_lines,
+                presence_line_set,
+                deletion_claims,
+                source_to_working_mapping=shared_mapping,
+                resolution=effective_resolution,
+                spool_dir=spool_dir,
+            )
+            try:
+                structural_chunks = _realized_entry_content_chunks(
+                    realized_entries
+                )
+                if coordinate_candidate is None:
+                    yield from structural_chunks
+                else:
+                    yield from _yield_identical_candidate_chunks(
+                        coordinate_candidate,
+                        structural_chunks,
+                    )
+            finally:
+                realized_entries.close()
         finally:
-            realized_entries.close()
+            _close_candidate(coordinate_candidate)
     finally:
-        _close_candidate(coordinate_candidate)
+        if owned_shared_mapping is not None:
+            owned_shared_mapping.close()
 
 
 def enumerate_merge_batch_candidates_from_line_sequences(

--- a/src/git_stage_batch/batch/merge/presence_constraints.py
+++ b/src/git_stage_batch/batch/merge/presence_constraints.py
@@ -47,6 +47,9 @@ def apply_presence_constraints(
     source_to_working_mapping: LineMapping | None = None,
     resolution: _MergeResolution | None = None,
     trusted_source_lines: Collection[int] = (),
+    require_distinctive_context: bool = False,
+    distinctive_context_lines: LineSelection | None = None,
+    contextual_placements: Sequence[_PresenceRunPlacement] | None = None,
     spool_dir: str | Path | None = None,
 ) -> RealizedEntries:
     """Apply presence constraints: ensure all claimed lines exist in result.
@@ -81,6 +84,9 @@ def apply_presence_constraints(
             mapping,
             resolution=resolution,
             trusted_source_lines=trusted_source_lines,
+            require_distinctive_context=require_distinctive_context,
+            distinctive_context_lines=distinctive_context_lines,
+            contextual_placements=contextual_placements,
             spool_dir=spool_dir,
         )
     finally:
@@ -96,6 +102,9 @@ def _apply_presence_constraints_with_mapping(
     *,
     resolution: _MergeResolution | None = None,
     trusted_source_lines: Collection[int] = (),
+    require_distinctive_context: bool = False,
+    distinctive_context_lines: LineSelection | None = None,
+    contextual_placements: Sequence[_PresenceRunPlacement] | None = None,
     spool_dir: str | Path | None = None,
 ) -> RealizedEntries:
     """Apply presence constraints using an existing source-to-working mapping."""
@@ -139,6 +148,9 @@ def _apply_presence_constraints_with_mapping(
                 mapping,
                 max_results=_PRESENCE_CANDIDATE_CAP + 1,
                 trusted_source_lines=trusted_source_lines,
+                require_distinctive_context=require_distinctive_context,
+                distinctive_context_lines=distinctive_context_lines,
+                spool_dir=spool_dir,
             )
         )
         if presence_key is not None and presence_key in resolution.decisions:
@@ -176,13 +188,23 @@ def _apply_presence_constraints_with_mapping(
         mapping.is_source_line_present(source_line)
         for source_line in trusted_source_lines
     ):
-        missing_claimed, placements = _contextual_presence_placements(
-            source_lines,
-            working_lines,
-            presence_line_set,
-            mapping,
-            trusted_source_lines=trusted_source_lines,
-        )
+        placements: Sequence[_PresenceRunPlacement]
+        if contextual_placements is None:
+            missing_claimed, computed_placements = (
+                _contextual_presence_placements(
+                    source_lines,
+                    working_lines,
+                    presence_line_set,
+                    mapping,
+                    trusted_source_lines=trusted_source_lines,
+                    require_distinctive_context=require_distinctive_context,
+                    distinctive_context_lines=distinctive_context_lines,
+                    spool_dir=spool_dir,
+                )
+            )
+            placements = computed_placements
+        else:
+            placements = contextual_placements
         if placements:
             return _realize_contextual_placements(
                 source_lines,
@@ -336,6 +358,9 @@ def satisfy_constraints(
     strict: bool = True,
     source_to_working_mapping: LineMapping | None = None,
     resolution: _MergeResolution | None = None,
+    require_distinctive_context: bool = False,
+    distinctive_context_lines: LineSelection | None = None,
+    contextual_placements: Sequence[_PresenceRunPlacement] | None = None,
     spool_dir: str | Path | None = None,
 ) -> RealizedEntries:
     """Apply presence and absence constraints until claimed lines survive."""
@@ -351,6 +376,9 @@ def satisfy_constraints(
         source_to_working_mapping=source_to_working_mapping,
         resolution=resolution,
         trusted_source_lines=trusted_source_lines,
+        require_distinctive_context=require_distinctive_context,
+        distinctive_context_lines=distinctive_context_lines,
+        contextual_placements=contextual_placements,
         spool_dir=spool_dir,
     )
 
@@ -377,6 +405,8 @@ def satisfy_constraints(
                 presence_line_set,
                 resolution=resolution,
                 trusted_source_lines=trusted_source_lines,
+                require_distinctive_context=require_distinctive_context,
+                distinctive_context_lines=distinctive_context_lines,
                 spool_dir=spool_dir,
             )
         finally:

--- a/src/git_stage_batch/batch/merge/presence_context.py
+++ b/src/git_stage_batch/batch/merge/presence_context.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
-from collections import Counter
 from collections.abc import Collection, Sequence
 from dataclasses import dataclass
+from pathlib import Path
 
 from ..line_matching.line_mapping import LineMapping
+from ..line_matching.match_workspace import MatcherWorkspace
+from ..line_matching.occurrence_index import LinePayloadOccurrenceIndex
 from .presence_missing_claims import mapped_missing_source_lines
 from ...core.line_selection import LineRanges, LineSelection
 from ...exceptions import MergeError
@@ -14,6 +16,7 @@ from ...i18n import _
 
 
 _CONTEXTUAL_LEADING_GAP = 3
+_DIRECT_DISTINCTIVE_CONTEXT_CHECK_LIMIT = 8
 
 
 @dataclass(frozen=True)
@@ -50,59 +53,192 @@ class _PresenceRunAnalysis:
     gap_index: int | None
 
 
-def _distinctive_mapped_source_lines(
-    source_lines: Sequence[bytes],
-    target_lines: Sequence[bytes],
-    mapping: LineMapping,
-    trusted_source_lines: Collection[int],
-) -> list[tuple[int, int]]:
-    """Return mapped pairs whose line identity is safe as a boundary.
+class _DistinctiveContextResolver:
+    """Find nearby globally distinctive mappings with bounded heap state."""
 
-    A raw alignment can map repeated punctuation through an equal prefix or
-    suffix.  Such a mapping is useful for preserving content, but it does not
-    identify which structural occurrence owns an insertion boundary.  A line
-    is therefore a contextual boundary only when it is unique in both file
-    versions, or when another constraint explicitly anchors that source line.
-    """
-    source_counts = Counter(source_lines)
-    target_counts = Counter(target_lines)
-    trusted = set(trusted_source_lines)
-    pairs: list[tuple[int, int]] = []
+    def __init__(
+        self,
+        source_lines: Sequence[bytes],
+        target_lines: Sequence[bytes],
+        mapping: LineMapping,
+        trusted_source_lines: Collection[int],
+        *,
+        spool_dir: str | Path | None,
+    ) -> None:
+        self._source_lines = source_lines
+        self._target_lines = target_lines
+        self._mapping = mapping
+        self._trusted_source_lines = trusted_source_lines
+        self._spool_dir = spool_dir
+        self._direct_check_count = 0
+        self._direct_results: dict[int, bool] = {}
+        self._workspace: MatcherWorkspace | None = None
+        self._source_occurrences: LinePayloadOccurrenceIndex | None = None
+        self._target_occurrences: LinePayloadOccurrenceIndex | None = None
 
-    for source_line, target_line in mapping.mapped_line_pairs():
-        content = source_lines[source_line - 1]
-        if (
-            source_line in trusted
-            or (
-                source_counts[content] == 1
-                and target_counts[content] == 1
+    def close(self) -> None:
+        """Release lazily allocated occurrence indexes."""
+        if self._workspace is not None:
+            self._workspace.close()
+            self._workspace = None
+            self._source_occurrences = None
+            self._target_occurrences = None
+
+    def nearest_before(self, run_start: int) -> tuple[int, int] | None:
+        """Return the nearest distinctive mapped line before a source run."""
+        for source_line in range(run_start - 1, 0, -1):
+            target_line = self._mapping.get_target_line_from_source_line(
+                source_line
             )
+            if target_line is not None and self._is_distinctive(source_line):
+                return source_line, target_line
+        return None
+
+    def nearest_after(self, run_end: int) -> tuple[int, int] | None:
+        """Return the nearest distinctive mapped line after a source run."""
+        for source_line in range(
+            run_end + 1,
+            len(self._source_lines) + 1,
         ):
-            pairs.append((source_line, target_line))
+            target_line = self._mapping.get_target_line_from_source_line(
+                source_line
+            )
+            if target_line is not None and self._is_distinctive(source_line):
+                return source_line, target_line
+        return None
 
-    return pairs
+    def nearest_around(
+        self,
+        run_start: int,
+        run_end: int,
+    ) -> tuple[tuple[int, int] | None, tuple[int, int] | None]:
+        """Return nearest distinctive mappings around a source run."""
+        before = _nearest_mapped_before(self._mapping, run_start)
+        after = _nearest_mapped_after(
+            self._mapping,
+            run_end,
+            len(self._source_lines),
+        )
+        candidates = tuple(
+            pair[0]
+            for pair in (before, after)
+            if pair is not None
+        )
+        distinctive = self._distinctive_results(candidates)
+
+        if before is not None and not distinctive[0]:
+            before = self.nearest_before(run_start)
+        if after is not None and not distinctive[-1]:
+            after = self.nearest_after(run_end)
+        return before, after
+
+    def _is_distinctive(self, source_line: int) -> bool:
+        return self._distinctive_results((source_line,))[0]
+
+    def _distinctive_results(
+        self,
+        source_lines: Sequence[int],
+    ) -> tuple[bool, ...]:
+        results: list[bool | None] = []
+        unchecked_lines: list[int] = []
+        for source_line in source_lines:
+            if source_line in self._trusted_source_lines:
+                results.append(True)
+            elif source_line in self._direct_results:
+                results.append(self._direct_results[source_line])
+            else:
+                results.append(None)
+                unchecked_lines.append(source_line)
+
+        if not unchecked_lines:
+            return tuple(result is True for result in results)
+
+        if (
+            self._source_occurrences is None
+            and self._direct_check_count + len(unchecked_lines)
+            <= _DIRECT_DISTINCTIVE_CONTEXT_CHECK_LIMIT
+        ):
+            contents = [
+                self._source_lines[source_line - 1]
+                for source_line in unchecked_lines
+            ]
+            source_counts = _line_occurrence_counts(
+                self._source_lines,
+                contents,
+            )
+            target_counts = _line_occurrence_counts(
+                self._target_lines,
+                contents,
+            )
+            for source_line, source_count, target_count in zip(
+                unchecked_lines,
+                source_counts,
+                target_counts,
+                strict=True,
+            ):
+                self._direct_results[source_line] = (
+                    source_count == 1 and target_count == 1
+                )
+            self._direct_check_count += len(unchecked_lines)
+        else:
+            if self._source_occurrences is None:
+                self._build_occurrence_indexes()
+            assert self._source_occurrences is not None
+            assert self._target_occurrences is not None
+            for result_index, (source_line, result) in enumerate(
+                zip(source_lines, results, strict=True)
+            ):
+                if result is not None:
+                    continue
+                content = self._source_lines[source_line - 1]
+                results[result_index] = (
+                    self._source_occurrences.occurrence_count(content) == 1
+                    and self._target_occurrences.occurrence_count(content) == 1
+                )
+
+        for result_index, (source_line, result) in enumerate(
+            zip(source_lines, results, strict=True)
+        ):
+            if result is None:
+                results[result_index] = self._direct_results[source_line]
+        return tuple(result is True for result in results)
+
+    def _build_occurrence_indexes(self) -> None:
+        self._workspace = MatcherWorkspace(spool_dir=self._spool_dir)
+        try:
+            self._source_occurrences = LinePayloadOccurrenceIndex(
+                self._workspace,
+                self._source_lines,
+                normalize_payloads=False,
+            )
+            self._target_occurrences = LinePayloadOccurrenceIndex(
+                self._workspace,
+                self._target_lines,
+                normalize_payloads=False,
+            )
+        except BaseException:
+            self.close()
+            raise
 
 
-def _nearest_context_before(
-    pairs: Sequence[tuple[int, int]],
-    run_start: int,
-) -> tuple[int, int] | None:
-    nearest = None
-    for source_line, target_line in pairs:
-        if source_line >= run_start:
-            break
-        nearest = (source_line, target_line)
-    return nearest
-
-
-def _nearest_context_after(
-    pairs: Sequence[tuple[int, int]],
-    run_end: int,
-) -> tuple[int, int] | None:
-    for source_line, target_line in pairs:
-        if source_line > run_end:
-            return source_line, target_line
-    return None
+def _line_occurrence_counts(
+    lines: Sequence[bytes],
+    contents: Sequence[bytes],
+) -> tuple[int, ...]:
+    """Count a bounded set of exact lines, capping each count at two."""
+    counts = [0] * len(contents)
+    content_hashes = tuple(hash(content) for content in contents)
+    for line_index in range(len(lines)):
+        line = lines[line_index]
+        line_hash = hash(line)
+        for content_index, content in enumerate(contents):
+            if (
+                counts[content_index] < 2
+                and line_hash == content_hashes[content_index]
+                and line == content
+            ):
+                counts[content_index] += 1
+    return tuple(counts)
 
 
 def _nearest_mapped_before(
@@ -203,55 +339,80 @@ def _analyze_presence_runs(
     source_selection: LineSelection,
     mapping: LineMapping,
     trusted_source_lines: Collection[int],
+    *,
+    require_distinctive_context: bool = False,
+    distinctive_context_lines: LineSelection | None = None,
+    spool_dir: str | Path | None = None,
 ) -> tuple[LineRanges, tuple[_PresenceRunAnalysis, ...]]:
     missing = mapped_missing_source_lines(
         source_selection,
         len(source_lines),
         mapping,
     )
-    distinctive_pairs = None
+    distinctive_context: _DistinctiveContextResolver | None = None
     analyses: list[_PresenceRunAnalysis] = []
 
-    for run_start, run_end in missing.ranges():
-        gap_index: int | None
-        mapped_before = _nearest_mapped_before(mapping, run_start)
-        mapped_after = _nearest_mapped_after(mapping, run_end, len(source_lines))
-        leading_gap = (
-            run_start - mapped_before[0] - 1
-            if mapped_before is not None
-            else 0
-        )
-
-        if leading_gap < _CONTEXTUAL_LEADING_GAP:
-            before = mapped_before
-            after = mapped_after
-            gap_index = before[1] if before is not None else 0
-        else:
-            if distinctive_pairs is None:
-                distinctive_pairs = _distinctive_mapped_source_lines(
-                    source_lines,
-                    target_lines,
-                    mapping,
-                    trusted_source_lines,
+    try:
+        for run_start, run_end in missing.ranges():
+            gap_index: int | None
+            mapped_before = _nearest_mapped_before(mapping, run_start)
+            mapped_after = _nearest_mapped_after(
+                mapping,
+                run_end,
+                len(source_lines),
+            )
+            leading_gap = (
+                run_start - mapped_before[0] - 1
+                if mapped_before is not None
+                else 0
+            )
+            run_requires_distinctive_context = (
+                require_distinctive_context
+                or (
+                    distinctive_context_lines is not None
+                    and distinctive_context_lines.count(run_start, run_end) > 0
                 )
-            before = _nearest_context_before(distinctive_pairs, run_start)
-            after = _nearest_context_after(distinctive_pairs, run_end)
-            gap_index = _choose_insertion_gap(
-                run_start=run_start,
-                run_end=run_end,
-                source_line_count=len(source_lines),
-                target_line_count=len(target_lines),
-                before=before,
-                after=after,
             )
 
-        analyses.append(_PresenceRunAnalysis(
-            run_start=run_start,
-            run_end=run_end,
-            before=before,
-            after=after,
-            gap_index=gap_index,
-        ))
+            if (
+                not run_requires_distinctive_context
+                and leading_gap < _CONTEXTUAL_LEADING_GAP
+            ):
+                before = mapped_before
+                after = mapped_after
+                gap_index = before[1] if before is not None else 0
+            else:
+                if distinctive_context is None:
+                    distinctive_context = _DistinctiveContextResolver(
+                        source_lines,
+                        target_lines,
+                        mapping,
+                        trusted_source_lines,
+                        spool_dir=spool_dir,
+                    )
+                before, after = distinctive_context.nearest_around(
+                    run_start,
+                    run_end,
+                )
+                gap_index = _choose_insertion_gap(
+                    run_start=run_start,
+                    run_end=run_end,
+                    source_line_count=len(source_lines),
+                    target_line_count=len(target_lines),
+                    before=before,
+                    after=after,
+                )
+
+            analyses.append(_PresenceRunAnalysis(
+                run_start=run_start,
+                run_end=run_end,
+                before=before,
+                after=after,
+                gap_index=gap_index,
+            ))
+    finally:
+        if distinctive_context is not None:
+            distinctive_context.close()
 
     return missing, tuple(analyses)
 
@@ -263,6 +424,9 @@ def contextual_presence_ambiguities(
     mapping: LineMapping,
     *,
     trusted_source_lines: Collection[int] = (),
+    require_distinctive_context: bool = False,
+    distinctive_context_lines: LineSelection | None = None,
+    spool_dir: str | Path | None = None,
 ) -> tuple[ContextualPresenceAmbiguity, ...]:
     """Return bounded placement ambiguities for suspicious missing runs."""
     _, analyses = _analyze_presence_runs(
@@ -271,6 +435,9 @@ def contextual_presence_ambiguities(
         source_selection,
         mapping,
         trusted_source_lines,
+        require_distinctive_context=require_distinctive_context,
+        distinctive_context_lines=distinctive_context_lines,
+        spool_dir=spool_dir,
     )
     ambiguities: list[ContextualPresenceAmbiguity] = []
 
@@ -295,6 +462,9 @@ def contextual_presence_placements(
     mapping: LineMapping,
     *,
     trusted_source_lines: Collection[int] = (),
+    require_distinctive_context: bool = False,
+    distinctive_context_lines: LineSelection | None = None,
+    spool_dir: str | Path | None = None,
 ) -> tuple[LineRanges, tuple[PresenceRunPlacement, ...]]:
     """Return missing claims and their context-supported insertion gaps.
 
@@ -311,6 +481,9 @@ def contextual_presence_placements(
         source_selection,
         mapping,
         trusted_source_lines,
+        require_distinctive_context=require_distinctive_context,
+        distinctive_context_lines=distinctive_context_lines,
+        spool_dir=spool_dir,
     )
     if not missing:
         return missing, ()

--- a/src/git_stage_batch/batch/merge/presence_placement_choices.py
+++ b/src/git_stage_batch/batch/merge/presence_placement_choices.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 from collections.abc import Collection, Sequence
 from dataclasses import dataclass
 import hashlib
+from pathlib import Path
 
 from ...core.line_selection import LineSelection
 from ..line_matching.line_mapping import LineMapping
+from ..line_matching.line_range_view import LineRangeView
 from ..line_matching.sequence_equality import line_slice_equals as _line_slice_matches
 from ..line_matching.sequence_search import iter_exact_context_gaps
 from .presence_context import (
@@ -36,13 +38,16 @@ def presence_choices_for_missing_claimed_run(
     *,
     max_results: int,
     trusted_source_lines: Collection[int] = (),
+    require_distinctive_context: bool = False,
+    distinctive_context_lines: LineSelection | None = None,
+    spool_dir: str | Path | None = None,
 ) -> tuple[str | None, tuple["PresenceChoice", ...]]:
     missing_claimed = _mapped_missing_source_lines(
         presence_line_set,
         len(source_lines),
         mapping,
     )
-    ranges = list(missing_claimed.ranges())
+    ranges = missing_claimed.ranges()
     if len(ranges) != 1:
         return None, ()
 
@@ -67,6 +72,9 @@ def presence_choices_for_missing_claimed_run(
         run_end=run_end,
         max_results=max_results,
         trusted_source_lines=trusted_source_lines,
+        require_distinctive_context=require_distinctive_context,
+        distinctive_context_lines=distinctive_context_lines,
+        spool_dir=spool_dir,
     )
 
 
@@ -93,7 +101,7 @@ def _adjacent_context_choices(
 
     left_context = (bytes(source_lines[before_source_line - 1]),)
     right_context = (bytes(source_lines[after_source_line - 1]),)
-    claimed_run = source_lines[run_start - 1:run_end]
+    claimed_run = LineRangeView(source_lines, run_start - 1, run_end)
     key = presence_ambiguity_key(
         run_start,
         run_end,
@@ -135,6 +143,9 @@ def _contextual_choices(
     run_end: int,
     max_results: int,
     trusted_source_lines: Collection[int],
+    require_distinctive_context: bool,
+    distinctive_context_lines: LineSelection | None,
+    spool_dir: str | Path | None,
 ) -> tuple[str | None, tuple[PresenceChoice, ...]]:
     """Return reviewed gaps bounded by distinctive contextual anchors."""
     ambiguities = _contextual_presence_ambiguities(
@@ -143,6 +154,9 @@ def _contextual_choices(
         presence_line_set,
         mapping,
         trusted_source_lines=trusted_source_lines,
+        require_distinctive_context=require_distinctive_context,
+        distinctive_context_lines=distinctive_context_lines,
+        spool_dir=spool_dir,
     )
     if len(ambiguities) != 1:
         return None, ()
@@ -151,7 +165,7 @@ def _contextual_choices(
     if ambiguity.run_start != run_start or ambiguity.run_end != run_end:
         return None, ()
 
-    claimed_run = source_lines[run_start - 1:run_end]
+    claimed_run = LineRangeView(source_lines, run_start - 1, run_end)
     before_source_line = ambiguity.before_source_line or 0
     after_source_line = ambiguity.after_source_line or len(source_lines) + 1
     key = presence_ambiguity_key(

--- a/src/git_stage_batch/batch/merge/validation.py
+++ b/src/git_stage_batch/batch/merge/validation.py
@@ -16,6 +16,7 @@ from .baseline_replacement_ranges import (
     selected_replacement_source_ranges as _selected_replacement_source_ranges,
 )
 from .presence_context import (
+    PresenceRunPlacement,
     contextual_presence_placements as _contextual_presence_placements,
 )
 from .presence_missing_claims import (
@@ -71,7 +72,11 @@ def check_structural_validity(
     deletions: list[AbsenceClaim],
     source_lines: Sequence[bytes],
     target_lines: Sequence[bytes],
-) -> None:
+    *,
+    require_distinctive_presence_context: bool = False,
+    distinctive_presence_context_lines: LineSelection | None = None,
+    spool_dir: str | Path | None = None,
+) -> tuple[PresenceRunPlacement, ...] | None:
     """Validate that batch can be safely applied given structural alignment.
 
     Checks:
@@ -101,7 +106,7 @@ def check_structural_validity(
     )
 
     if len(target_lines) == 0:
-        return
+        return None
 
     if present_count == 0 and len(target_lines) > 0:
         if claimed_lines:
@@ -176,18 +181,23 @@ def check_structural_validity(
     # Let absence realization report its more precise missing-anchor error once
     # nearby mapped context has allowed an unmapped deletion anchor through.
     if has_unmapped_deletion_anchor:
-        return
+        return None
 
-    _contextual_presence_placements(
-        source_lines,
-        target_lines,
-        claimed_lines,
-        line_mapping,
-        trusted_source_lines={
-            deletion.anchor_line
-            for deletion in deletions
-            if deletion.anchor_line is not None
-        },
+    _missing_presence_lines, presence_placements = (
+        _contextual_presence_placements(
+            source_lines,
+            target_lines,
+            claimed_lines,
+            line_mapping,
+            trusted_source_lines={
+                deletion.anchor_line
+                for deletion in deletions
+                if deletion.anchor_line is not None
+            },
+            require_distinctive_context=require_distinctive_presence_context,
+            distinctive_context_lines=distinctive_presence_context_lines,
+            spool_dir=spool_dir,
+        )
     )
     _check_unbounded_trailing_context(
         line_mapping,
@@ -196,6 +206,7 @@ def check_structural_validity(
         source_lines,
         target_lines,
     )
+    return presence_placements
 
 
 def _check_unbounded_trailing_context(

--- a/tests/batch/merge/test_coordinate_strategy.py
+++ b/tests/batch/merge/test_coordinate_strategy.py
@@ -1,11 +1,20 @@
 """Tests for coordinate-versus-structural merge strategy decisions."""
 
+import gc
+import tracemalloc
+
 from git_stage_batch.batch.merge.coordinate_strategy import (
     has_recorded_baseline_coordinates,
+    presence_lines_requiring_distinctive_context,
 )
+from git_stage_batch.batch.ownership.absence_claims import AbsenceClaim
 from git_stage_batch.batch.ownership.model import BatchOwnership
 from git_stage_batch.batch.ownership.references import BaselineReference
+from git_stage_batch.batch.ownership.replacement_units import ReplacementUnit
 from git_stage_batch.core.line_selection import LineRanges
+
+
+_LINE_SCALE_HEAP_LIMIT = 256 * 1024
 
 
 class _IterationGuardedSelection(LineRanges):
@@ -38,3 +47,102 @@ def test_coordinate_detection_scans_references_not_selected_lines() -> None:
         _IterationGuardedSelection.from_ranges(((line_count, line_count),)),
         [],
     )
+
+
+def test_unrelated_deletion_does_not_anchor_presence_context() -> None:
+    """An independent absence claim cannot make an insertion structurally safe."""
+    deletion = AbsenceClaim(anchor_line=3, content_lines=[b"unwanted\n"])
+    ownership = BatchOwnership.from_presence_lines(["2"], [deletion])
+
+    assert presence_lines_requiring_distinctive_context(
+        ownership,
+        ownership.presence_line_set(),
+        ownership.deletions,
+    )
+
+
+def test_replacement_unit_covers_its_presence_context() -> None:
+    """A valid deletion-coupled replacement retains its structural anchoring."""
+    deletion = AbsenceClaim(anchor_line=1, content_lines=[b"old\n"])
+    ownership = BatchOwnership.from_presence_lines(
+        ["2"],
+        [deletion],
+        replacement_units=[
+            ReplacementUnit(presence_lines=["2"], deletion_indices=[0]),
+        ],
+    )
+
+    assert not presence_lines_requiring_distinctive_context(
+        ownership,
+        ownership.presence_line_set(),
+        ownership.deletions,
+    )
+
+
+def test_legacy_adjacent_deletion_covers_replacement_presence_context() -> None:
+    """Legacy replacement metadata retains adjacency-based coupling."""
+    deletion = AbsenceClaim(anchor_line=1, content_lines=[b"old\n"])
+    ownership = BatchOwnership.from_presence_lines(["2-3"], [deletion])
+
+    assert not presence_lines_requiring_distinctive_context(
+        ownership,
+        ownership.presence_line_set(),
+        ownership.deletions,
+    )
+
+
+def test_legacy_replacement_covers_tail_of_spanning_presence_range() -> None:
+    """Adjacent legacy coverage starts inside a normalized presence range."""
+    deletion = AbsenceClaim(anchor_line=1, content_lines=[b"old\n"])
+    ownership = BatchOwnership.from_presence_lines(["1-3"], [deletion])
+
+    strict_lines = presence_lines_requiring_distinctive_context(
+        ownership,
+        ownership.presence_line_set(),
+        ownership.deletions,
+    )
+
+    assert strict_lines.ranges() == ((1, 1),)
+
+
+def test_only_unanchored_presence_requires_distinctive_context() -> None:
+    """Replacement adjacency must not exempt an independent presence run."""
+    deletion = AbsenceClaim(anchor_line=3, content_lines=[b"old\n"])
+    ownership = BatchOwnership.from_presence_lines(["2", "4"], [deletion])
+
+    strict_lines = presence_lines_requiring_distinctive_context(
+        ownership,
+        ownership.presence_line_set(),
+        ownership.deletions,
+    )
+
+    assert strict_lines.ranges() == ((2, 2),)
+
+
+def test_coordinate_coverage_avoids_line_scale_python_heap() -> None:
+    """Per-line coordinate coverage should stay in mapped storage."""
+    line_count = 8192
+    reference = BaselineReference(after_line=None)
+    ownership = BatchOwnership.from_presence_lines(
+        [f"1-{line_count}"],
+        baseline_references={
+            line_number: reference
+            for line_number in range(1, line_count + 1)
+        },
+    )
+    selection = ownership.presence_line_set()
+
+    gc.collect()
+    tracemalloc.start()
+    try:
+        requires_context = bool(presence_lines_requiring_distinctive_context(
+            ownership,
+            selection,
+            ownership.deletions,
+        ))
+        _current_heap, peak_heap = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+
+    assert requires_context is False
+    assert peak_heap < _LINE_SCALE_HEAP_LIMIT

--- a/tests/batch/merge/test_duplication.py
+++ b/tests/batch/merge/test_duplication.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import pytest
+
 
 from git_stage_batch.batch.ownership.absence_claims import AbsenceClaim
 
 from git_stage_batch.batch.ownership.model import BatchOwnership
 from git_stage_batch.batch.merge.merge import merge_batch_from_line_sequences_as_buffer
 from git_stage_batch.core.buffer import LineBuffer
+from git_stage_batch.exceptions import MergeError
 
 
 def merge_batch(
@@ -96,6 +99,135 @@ def test_merge_batch_claimed_line_missing_from_working_tree():
 
     # Should insert X
     assert result == b"A\nX\nB\n", f"Expected X to be inserted, got: {repr(result)}"
+
+
+def test_merge_refuses_overlapping_return_statement_variants_without_baseline_anchor():
+    """An unanchored saved return must not be inserted beside its replacement."""
+    batch_source_content = (
+        b"function f() {\n"
+        b"    return oldValue ||\n"
+        b"        newValue;\n"
+        b"}\n"
+    )
+    ownership = BatchOwnership.from_presence_lines(["2-3"], [])
+    working_content = b"function f() {\n    return oldValue;\n}\n"
+
+    with pytest.raises(MergeError):
+        merge_batch(batch_source_content, ownership, working_content)
+
+
+def test_merge_refuses_overlapping_method_variants_without_baseline_anchor():
+    """A saved method must not be nested inside a different method signature."""
+    batch_source_content = (
+        b"class X {\n"
+        b"    method({newArg}) {\n"
+        b"        act();\n"
+        b"    }\n"
+        b"}\n"
+    )
+    ownership = BatchOwnership.from_presence_lines(["2-4"], [])
+    working_content = (
+        b"class X {\n"
+        b"    method(oldArg) {\n"
+        b"        act();\n"
+        b"    }\n"
+        b"}\n"
+    )
+
+    with pytest.raises(MergeError):
+        merge_batch(batch_source_content, ownership, working_content)
+
+
+def test_merge_refuses_method_placement_at_unterminated_repeated_brace_boundary():
+    """A method must not be placed inside an unmatched preceding method."""
+    batch_source_content = (
+        b"class Dialog {\n"
+        b"    constructor() {\n"
+        b"        initialize();\n"
+        b"    }\n"
+        b"\n"
+        b"    inserted() {\n"
+        b"        added();\n"
+        b"    }\n"
+        b"\n"
+        b"    last() {\n"
+        b"        finish();\n"
+        b"    }\n"
+        b"}\n"
+    )
+    ownership = BatchOwnership.from_presence_lines(["6-8"], [])
+    working_content = (
+        b"class Dialog {\n"
+        b"    constructor() {\n"
+        b"        initialize();\n"
+        b"\n"
+        b"    last() {\n"
+        b"        finish();\n"
+        b"    }\n"
+        b"}\n"
+    )
+
+    with pytest.raises(MergeError):
+        merge_batch(batch_source_content, ownership, working_content)
+
+
+def test_merge_refuses_object_member_placement_after_competing_delimiter():
+    """A saved object member must not be appended beyond an extra object close."""
+    batch_source_content = (
+        b"const handlers = {\n"
+        b"    [Role.PASSWORD]: {\n"
+        b"        action: passwordAction,\n"
+        b"    },\n"
+        b"    [Role.WEB_LOGIN]: {\n"
+        b"        action: webLoginAction,\n"
+        b"    },\n"
+        b"};\n"
+    )
+    ownership = BatchOwnership.from_presence_lines(["5-7"], [])
+    working_content = (
+        b"const handlers = {\n"
+        b"    [Role.PASSWORD]: {\n"
+        b"        action: passwordAction,\n"
+        b"    },\n"
+        b"    },\n"
+        b"};\n"
+    )
+
+    with pytest.raises(MergeError):
+        merge_batch(batch_source_content, ownership, working_content)
+
+
+def test_merge_refuses_competing_callback_and_direct_call_variants():
+    """Apply must not preserve both side-effecting variants of the same call."""
+    batch_source_content = (
+        b"function answer() {\n"
+        b"    completePendingCallback(() => {\n"
+        b"        verifier.answerQuery(service, answer);\n"
+        b"    });\n"
+        b"}\n"
+    )
+    ownership = BatchOwnership.from_presence_lines(["2-4"], [])
+    working_content = (
+        b"function answer() {\n"
+        b"    verifier.answerQuery(service, answer);\n"
+        b"}\n"
+    )
+
+    with pytest.raises(MergeError):
+        merge_batch(batch_source_content, ownership, working_content)
+
+
+def test_unrelated_deletion_does_not_allow_competing_presence_variants():
+    """An independent deletion must not disable strict insertion context."""
+    batch_source_content = b"head\nsaved variant\ntail\nanchor\n"
+    ownership = BatchOwnership.from_presence_lines(
+        ["2"],
+        [AbsenceClaim(anchor_line=4, content_lines=[b"unwanted\n"])],
+    )
+    working_content = b"head\nlive variant\ntail\nanchor\n"
+
+    with pytest.raises(MergeError):
+        merge_batch(batch_source_content, ownership, working_content)
 
 
 def test_merge_batch_with_deletion_suppresses_content():

--- a/tests/batch/merge/test_merge.py
+++ b/tests/batch/merge/test_merge.py
@@ -1,5 +1,6 @@
 """Tests for structural batch merge algorithm."""
 
+import gc
 from itertools import repeat
 import tracemalloc
 
@@ -36,12 +37,16 @@ from git_stage_batch.batch.merge.merge import (
     merge_batch_from_line_sequences_as_buffer,
 )
 from git_stage_batch.batch.merge.presence_constraints import satisfy_constraints
+from git_stage_batch.batch.merge.presence_context import (
+    contextual_presence_placements,
+)
 from git_stage_batch.batch.realization.entries import RealizedEntry
 from git_stage_batch.batch.realization.entry_storage import (
     RealizedEntries,
     realized_entry_content_chunks,
 )
 from git_stage_batch.core.buffer import LineBuffer
+from git_stage_batch.core.line_selection import LineRanges
 from git_stage_batch.exceptions import AtomicUnitError, MergeError
 from git_stage_batch.batch.ownership.absence_claims import AbsenceClaim
 from git_stage_batch.batch.ownership.model import (
@@ -53,6 +58,9 @@ from git_stage_batch.batch.ownership.replacement_units import (
     ReplacementUnitOrigin,
 )
 from git_stage_batch.core.text_lines import normalize_line_sequence_endings
+
+
+_LINE_SCALE_HEAP_LIMIT = 256 * 1024
 
 
 class _IndexGuardedLineBuffer(LineBuffer):
@@ -153,6 +161,47 @@ def test_candidate_comparison_does_not_copy_large_chunk_remainders():
 
     assert yielded_count == 512
     assert peak_heap < 64 * 1024
+
+
+def test_distinctive_presence_context_avoids_line_scale_python_heap():
+    """Strict contextual indexing should retain records in mapped storage."""
+    line_count = 8192
+    changed_index = line_count // 2
+    source_content = b"".join(
+        f"line-{line_index:08d}\n".encode()
+        for line_index in range(line_count)
+    )
+    target_content = b"".join(
+        (
+            b"target-only\n"
+            if line_index == changed_index
+            else f"line-{line_index:08d}\n".encode()
+        )
+        for line_index in range(line_count)
+    )
+    selected = LineRanges.from_ranges(((changed_index + 1, changed_index + 1),))
+
+    with (
+        LineBuffer.from_bytes(source_content) as source_lines,
+        LineBuffer.from_bytes(target_content) as target_lines,
+        match_lines(source_lines, target_lines) as mapping,
+    ):
+        gc.collect()
+        tracemalloc.start()
+        try:
+            with pytest.raises(MergeError):
+                contextual_presence_placements(
+                    source_lines,
+                    target_lines,
+                    selected,
+                    mapping,
+                    require_distinctive_context=True,
+                )
+            _current_heap, peak_heap = tracemalloc.get_traced_memory()
+        finally:
+            tracemalloc.stop()
+
+    assert peak_heap < _LINE_SCALE_HEAP_LIMIT
 
 
 @pytest.mark.parametrize("candidates_match", [True, False])
@@ -353,6 +402,32 @@ def test_large_merge_without_coordinates_plans_baseline_once(monkeypatch):
         assert len(merged) == len(source)
 
     assert planning_modes == [False]
+
+
+def test_unanchored_presence_reuses_fallback_line_mapping(monkeypatch):
+    """Baseline probing and structural placement should share one mapping."""
+    source = [f"line {index}\n".encode() for index in range(1000)]
+    missing_index = len(source) // 2
+    target = source[:missing_index] + source[missing_index + 1:]
+    ownership = BatchOwnership.from_presence_lines([str(missing_index + 1)], [])
+    mapping_calls = 0
+    real_match_lines = merge_module.match_lines
+
+    def count_mapping(*args, **kwargs):
+        nonlocal mapping_calls
+        mapping_calls += 1
+        return real_match_lines(*args, **kwargs)
+
+    monkeypatch.setattr(merge_module, "match_lines", count_mapping)
+
+    with merge_batch_from_line_sequences_as_buffer(
+        source,
+        ownership,
+        target,
+    ) as merged:
+        assert merged.to_bytes() == b"".join(source)
+
+    assert mapping_calls == 1
 
 
 def test_coordinate_candidate_discovery_reuses_initial_comparison(monkeypatch):


### PR DESCRIPTION
Batch merge currently combines saved ownership coordinates, replacement
metadata, and contextual placement when applying a batch to a changed file.

When a saved line has no surviving anchor and its text appears around repeated
syntax, ordinary context can place it at the wrong occurrence instead of
recognizing that the placement is ambiguous.

This builds on the bounded occurrence index introduced by
https://github.com/halfline/git-stage-batch/pull/388.

This series classifies unanchored presence candidates and resolves them only
when source and target context is distinctive. Validated placements are reused,
while anchored and legacy fallback paths retain their existing behavior.
Regression and performance coverage exercises repeated blocks, ambiguous
contexts, and large candidate sets.

The merge now refuses unsafe unanchored placement without penalizing the common
anchored path.
