### PR TITLE
batch: Reconcile stale sources semantically

### DIFF
--- a/src/git_stage_batch/batch/line_matching/lineage.py
+++ b/src/git_stage_batch/batch/line_matching/lineage.py
@@ -8,7 +8,11 @@ from pathlib import Path
 from types import TracebackType
 
 from ...core.line_selection import LineRanges, LineSelection, coerce_line_ranges
-from ...core.mapped_storage import ChunkedMappedRecordVector
+from ...core.mapped_storage import (
+    ChunkedMappedRecordVector,
+    MappedRecordVector,
+    sort_mapped_records,
+)
 
 
 _LINEAGE_RECORD_FORMAT = "QQQ"
@@ -16,6 +20,12 @@ _LINEAGE_CHUNK_CAPACITY = 8192
 _LINEAGE_OLD_START = 0
 _LINEAGE_OLD_END = 1
 _LINEAGE_NEW_START = 2
+_EXPANSION_RECORD_FORMAT = "QQQQ"
+_EXPANSION_SOURCE_START = 0
+_EXPANSION_SOURCE_END = 1
+_EXPANSION_NEW_START = 2
+_EXPANSION_NEW_END = 3
+_TRANSLATED_RANGE_RECORD_FORMAT = "QQ"
 
 
 @dataclass(frozen=True, slots=True)
@@ -46,6 +56,33 @@ class LineageRun:
             raise ValueError("range is outside lineage run")
         new_start = self.new_start + (old_start - self.old_start)
         return new_start, new_start + (old_end - old_start)
+
+
+@dataclass(frozen=True, slots=True)
+class SourceSelectionExpansion:
+    """A fully owned source range expanded to a longer refreshed range."""
+
+    source_start: int
+    source_end: int
+    new_start: int
+    new_end: int
+
+    def __post_init__(self) -> None:
+        if (
+            self.source_start <= 0
+            or self.source_end <= 0
+            or self.new_start <= 0
+            or self.new_end <= 0
+        ):
+            raise ValueError("source expansion coordinates must be positive")
+        if self.source_start > self.source_end:
+            raise ValueError("source expansion start must be <= end")
+        if self.new_start > self.new_end:
+            raise ValueError("source expansion destination start must be <= end")
+        source_count = self.source_end - self.source_start + 1
+        new_count = self.new_end - self.new_start + 1
+        if new_count <= source_count:
+            raise ValueError("source expansion destination must be longer")
 
 
 def _lineage_run_from_record(record: tuple[int, ...]) -> LineageRun:
@@ -156,15 +193,14 @@ class _LineageRunTable:
             return None
         return run.translate(old_line)
 
-    def translate_selection(
+    def append_translated_ranges(
         self,
-        selection: LineSelection | Iterable[int],
-    ) -> LineRanges:
-        self._require_open()
-        translated_ranges: list[tuple[int, int]] = []
+        selection: LineRanges,
+        destination: MappedRecordVector,
+    ) -> None:
+        """Append translated intersections without retaining Python records."""
         run_index = 0
-
-        for selected_start, selected_end in coerce_line_ranges(selection).ranges():
+        for selected_start, selected_end in selection.ranges():
             while (
                 run_index < len(self)
                 and self._run_at_index(run_index).old_end < selected_start
@@ -176,16 +212,13 @@ class _LineageRunTable:
                 run = self._run_at_index(scan_index)
                 if run.old_start > selected_end:
                     break
-
                 old_start = max(selected_start, run.old_start)
                 old_end = min(selected_end, run.old_end)
                 if old_start <= old_end:
-                    translated_ranges.append(run.translate_range(old_start, old_end))
+                    destination.append(run.translate_range(old_start, old_end))
                 if run.old_end >= selected_end:
                     break
                 scan_index += 1
-
-        return LineRanges.from_ranges(translated_ranges)
 
     def first_unmapped_line(
         self,
@@ -263,6 +296,108 @@ class _LineageRunTable:
             raise ValueError("lineage run table is closed")
 
 
+def _source_expansion_from_record(
+    record: tuple[int, ...],
+) -> SourceSelectionExpansion:
+    return SourceSelectionExpansion(
+        source_start=record[_EXPANSION_SOURCE_START],
+        source_end=record[_EXPANSION_SOURCE_END],
+        new_start=record[_EXPANSION_NEW_START],
+        new_end=record[_EXPANSION_NEW_END],
+    )
+
+
+class _SourceExpansionTable:
+    """Ordered mapped expansions used only for whole-selection translation."""
+
+    def __init__(
+        self,
+        expansions: Iterable[SourceSelectionExpansion] = (),
+        *,
+        spool_dir: str | Path | None = None,
+    ) -> None:
+        self._expansions = ChunkedMappedRecordVector(
+            record_format=_EXPANSION_RECORD_FORMAT,
+            chunk_capacity=_LINEAGE_CHUNK_CAPACITY,
+            spool_dir=spool_dir,
+        )
+        self._last_source_end = 0
+        self._closed = False
+        for expansion in expansions:
+            self.append(expansion)
+
+    @property
+    def byte_count(self) -> int:
+        return 0 if self._closed else self._expansions.byte_count
+
+    def __bool__(self) -> bool:
+        self._require_open()
+        return bool(self._expansions)
+
+    def __len__(self) -> int:
+        self._require_open()
+        return len(self._expansions)
+
+    def append(self, expansion: SourceSelectionExpansion) -> None:
+        self._require_open()
+        if expansion.source_start <= self._last_source_end:
+            raise ValueError("source expansions must not overlap")
+        self._expansions.append((
+            expansion.source_start,
+            expansion.source_end,
+            expansion.new_start,
+            expansion.new_end,
+        ))
+        self._last_source_end = expansion.source_end
+
+    def runs(self) -> Iterator[SourceSelectionExpansion]:
+        self._require_open()
+        for record in self._expansions:
+            yield _source_expansion_from_record(record)
+
+    def translated_ranges(
+        self,
+        selection: LineRanges,
+    ) -> Iterator[tuple[int, int]]:
+        """Yield destinations only when the complete source range is selected."""
+        selected_ranges = selection.ranges()
+        selected_index = 0
+        for record in self._expansions:
+            expansion = _source_expansion_from_record(record)
+            while (
+                selected_index < len(selected_ranges)
+                and selected_ranges[selected_index][1] < expansion.source_start
+            ):
+                selected_index += 1
+            if selected_index >= len(selected_ranges):
+                return
+            selected_start, selected_end = selected_ranges[selected_index]
+            if (
+                selected_start <= expansion.source_start
+                and selected_end >= expansion.source_end
+            ):
+                yield expansion.new_start, expansion.new_end
+
+    def append_translated_ranges(
+        self,
+        selection: LineRanges,
+        destination: MappedRecordVector,
+    ) -> None:
+        """Append whole-selection expansion destinations."""
+        for new_start, new_end in self.translated_ranges(selection):
+            destination.append((new_start, new_end))
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._expansions.close()
+        self._closed = True
+
+    def _require_open(self) -> None:
+        if self._closed:
+            raise ValueError("source expansion table is closed")
+
+
 class BatchSourceLineage:
     """Lineage from old source and working lines to refreshed source lines."""
 
@@ -270,24 +405,46 @@ class BatchSourceLineage:
         self,
         source_runs: Iterable[LineageRun] = (),
         working_runs: Iterable[LineageRun] = (),
+        source_expansions: Iterable[SourceSelectionExpansion] = (),
         *,
         spool_dir: str | Path | None = None,
     ) -> None:
-        self._source_runs = _LineageRunTable(
+        source_run_table = _LineageRunTable(
             source_runs,
             spool_dir=spool_dir,
         )
-        self._working_runs = _LineageRunTable(
-            working_runs,
-            spool_dir=spool_dir,
-        )
+        try:
+            working_run_table = _LineageRunTable(
+                working_runs,
+                spool_dir=spool_dir,
+            )
+            try:
+                source_expansion_table = _SourceExpansionTable(
+                    source_expansions,
+                    spool_dir=spool_dir,
+                )
+            except BaseException:
+                working_run_table.close()
+                raise
+        except BaseException:
+            source_run_table.close()
+            raise
+
+        self._source_runs = source_run_table
+        self._working_runs = working_run_table
+        self._source_expansions = source_expansion_table
+        self._spool_dir = spool_dir
         self._closed = False
 
     @property
     def byte_count(self) -> int:
         if self._closed:
             return 0
-        return self._source_runs.byte_count + self._working_runs.byte_count
+        return (
+            self._source_runs.byte_count
+            + self._working_runs.byte_count
+            + self._source_expansions.byte_count
+        )
 
     @property
     def closed(self) -> bool:
@@ -301,6 +458,10 @@ class BatchSourceLineage:
         self._require_open()
         return self._working_runs.runs()
 
+    def source_expansions(self) -> Iterator[SourceSelectionExpansion]:
+        self._require_open()
+        return self._source_expansions.runs()
+
     def append_source_run(self, run: LineageRun) -> None:
         self._require_open()
         self._source_runs.append(run)
@@ -308,6 +469,13 @@ class BatchSourceLineage:
     def append_working_run(self, run: LineageRun) -> None:
         self._require_open()
         self._working_runs.append(run)
+
+    def append_source_expansion(
+        self,
+        expansion: SourceSelectionExpansion,
+    ) -> None:
+        self._require_open()
+        self._source_expansions.append(expansion)
 
     def translate_source_line(self, line_number: int) -> int | None:
         self._require_open()
@@ -318,7 +486,42 @@ class BatchSourceLineage:
         selection: LineSelection | Iterable[int],
     ) -> LineRanges:
         self._require_open()
-        return self._source_runs.translate_selection(selection)
+        source_selection = coerce_line_ranges(selection)
+        source_ranges = MappedRecordVector(
+            len(self._source_runs) + len(source_selection.ranges()),
+            _TRANSLATED_RANGE_RECORD_FORMAT,
+            spool_dir=self._spool_dir,
+        )
+        try:
+            self._source_runs.append_translated_ranges(
+                source_selection,
+                source_ranges,
+            )
+            if len(source_ranges) > 1:
+                sort_mapped_records(source_ranges)
+
+            expansion_ranges = MappedRecordVector(
+                len(self._source_expansions),
+                _TRANSLATED_RANGE_RECORD_FORMAT,
+                spool_dir=self._spool_dir,
+            )
+            try:
+                self._source_expansions.append_translated_ranges(
+                    source_selection,
+                    expansion_ranges,
+                )
+                if len(expansion_ranges) > 1:
+                    sort_mapped_records(expansion_ranges)
+                return LineRanges.from_ranges(
+                    _merged_compact_translated_ranges(
+                        source_ranges,
+                        expansion_ranges,
+                    )
+                )
+            finally:
+                expansion_ranges.close()
+        finally:
+            source_ranges.close()
 
     def first_unmapped_source_line(
         self,
@@ -334,9 +537,14 @@ class BatchSourceLineage:
     def close(self) -> None:
         if self._closed:
             return
-        self._source_runs.close()
-        self._working_runs.close()
-        self._closed = True
+        try:
+            self._source_runs.close()
+        finally:
+            try:
+                self._working_runs.close()
+            finally:
+                self._source_expansions.close()
+                self._closed = True
 
     def __enter__(self) -> BatchSourceLineage:
         self._require_open()
@@ -359,3 +567,45 @@ class BatchSourceLineage:
     def _require_open(self) -> None:
         if self._closed:
             raise ValueError("batch source lineage is closed")
+
+
+def _merged_compact_translated_ranges(
+    source_ranges: MappedRecordVector,
+    expansion_ranges: MappedRecordVector,
+) -> Iterator[tuple[int, int]]:
+    """Merge and coalesce two ordered mapped range streams."""
+    source_index = 0
+    expansion_index = 0
+    current_start: int | None = None
+    current_end: int | None = None
+
+    while (
+        source_index < len(source_ranges)
+        or expansion_index < len(expansion_ranges)
+    ):
+        if (
+            expansion_index >= len(expansion_ranges)
+            or (
+                source_index < len(source_ranges)
+                and source_ranges[source_index]
+                <= expansion_ranges[expansion_index]
+            )
+        ):
+            start, end = source_ranges[source_index]
+            source_index += 1
+        else:
+            start, end = expansion_ranges[expansion_index]
+            expansion_index += 1
+
+        if current_start is None or current_end is None:
+            current_start = start
+            current_end = end
+        elif start <= current_end + 1:
+            current_end = max(current_end, end)
+        else:
+            yield current_start, current_end
+            current_start = start
+            current_end = end
+
+    if current_start is not None and current_end is not None:
+        yield current_start, current_end

--- a/src/git_stage_batch/batch/source/advancement.py
+++ b/src/git_stage_batch/batch/source/advancement.py
@@ -3,22 +3,49 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
 from types import TracebackType
 
 from ...core.buffer import LineBuffer
+from ...core.line_selection import LineRanges, coerce_line_ranges
+from ...core.mapped_storage import MappedRecordVector, sort_mapped_records
 from .snapshots import create_batch_source_commit
 from ...utils.repository_buffers import (
     read_git_object_buffer_or_none,
     load_working_tree_file_as_buffer,
 )
 from ...utils.git_repository import get_git_repository_root_path
-from ..line_matching.lineage import BatchSourceLineage, LineageRun
-from ..merge.presence_constraints import apply_presence_constraints
-from ..realization.entry_storage import realized_entry_content_chunks
+from ..line_matching.comparison import (
+    SemanticChangeKind,
+    SemanticChangeRun,
+    stream_semantic_change_runs,
+)
+from ..line_matching.lineage import (
+    BatchSourceLineage,
+    LineageRun,
+    SourceSelectionExpansion,
+)
+from ..line_matching.match_workspace import MatcherWorkspace
+from ..line_matching.sequence_equality import line_slice_equals
+from ..merge.baseline_replacement_ranges import collect_replacement_source_ranges
 from ..ownership.model import BatchOwnership
 from ..ownership.remapping import remap_batch_ownership_with_lineage
+
+
+_SOURCE_RANGE_RECORD_FORMAT = "QQ"
+
+
+class BatchSourceAdvanceError(ValueError):
+    """Expected refusal while reconciling a stale batch source."""
+
+
+@dataclass(frozen=True, slots=True)
+class _SavedReplacementTargetSpan:
+    """Unique live span suppressed by an authoritative replacement unit."""
+
+    start: int
+    end: int
 
 
 @dataclass
@@ -30,8 +57,10 @@ class SourceContentWithLineProvenance:
 
     def close(self) -> None:
         """Release the synthesized buffer and line lineage."""
-        self.source_buffer.close()
-        self.lineage.close()
+        try:
+            self.source_buffer.close()
+        finally:
+            self.lineage.close()
 
     def __enter__(self) -> SourceContentWithLineProvenance:
         return self
@@ -56,8 +85,10 @@ class BatchSourceAdvanceResult:
 
     def close(self) -> None:
         """Release the refreshed source buffer and line lineage."""
-        self.source_buffer.close()
-        self.lineage.close()
+        try:
+            self.source_buffer.close()
+        finally:
+            self.lineage.close()
 
     def __enter__(self) -> BatchSourceAdvanceResult:
         return self
@@ -76,48 +107,397 @@ def advance_source_lines_preserving_existing_presence(
     working_lines: Sequence[bytes],
     ownership: BatchOwnership,
 ) -> SourceContentWithLineProvenance:
-    """Build source content with provenance from line sequences."""
-    presence_lines = ownership.presence_line_set()
+    """Reconcile source content with the worktree and retain owned provenance.
 
-    entries = apply_presence_constraints(
-        old_lines,
-        working_lines,
-        presence_lines,
-    )
-
+    Owned source lines in a changed semantic run are advanced to the live
+    variant when the complete source side is owned.  Partial ownership remains
+    conservative: required old lines are retained beside the live variant so
+    unrelated ownership is never silently absorbed.  Source-only runs that
+    contain required lines are retained whole because their unowned lines may
+    be shared structural boundaries.  An explicit saved replacement remains
+    authoritative when the live run is the baseline variant it suppresses.
+    """
+    presence_lines = coerce_line_ranges(ownership.presence_line_set())
     lineage = BatchSourceLineage()
     try:
-        for run in entries.provenance_runs():
-            line_count = run.dest_end - run.dest_start
-            new_start = run.dest_start + 1
-            if run.source_start != 0:
-                lineage.append_source_run(
-                    LineageRun(
-                        old_start=run.source_start,
-                        old_end=run.source_start + line_count - 1,
-                        new_start=new_start,
-                    )
-                )
-            if run.target_start != 0:
-                lineage.append_working_run(
-                    LineageRun(
-                        old_start=run.target_start,
-                        old_end=run.target_start + line_count - 1,
-                        new_start=new_start,
-                    )
-                )
-
         return SourceContentWithLineProvenance(
             source_buffer=LineBuffer.from_chunks(
-                realized_entry_content_chunks(entries)
+                _advanced_source_chunks(
+                    old_lines,
+                    working_lines,
+                    presence_lines,
+                    ownership,
+                    lineage,
+                )
             ),
             lineage=lineage,
         )
-    except Exception:
+    except BaseException:
         lineage.close()
         raise
+
+
+def _required_source_ranges(
+    workspace: MatcherWorkspace,
+    ownership: BatchOwnership,
+    presence_lines: LineRanges,
+) -> MappedRecordVector:
+    """Return storage-backed ranges whose old-source lineage is required."""
+    required = workspace.record_vector(
+        len(presence_lines.ranges()) + len(ownership.deletions),
+        _SOURCE_RANGE_RECORD_FORMAT,
+    )
+    for source_start, source_end in presence_lines.ranges():
+        required.append((source_start, source_end))
+    for deletion in ownership.deletions:
+        if deletion.anchor_line is not None:
+            required.append((deletion.anchor_line, deletion.anchor_line))
+
+    if len(required) > 1:
+        sort_mapped_records(required)
+        _compact_source_ranges(required)
+    return required
+
+
+def _compact_source_ranges(source_ranges: MappedRecordVector) -> None:
+    """Coalesce ordered overlapping or adjacent mapped source ranges."""
+    retained_count = 0
+    for source_start, source_end in source_ranges:
+        if retained_count:
+            previous_start, previous_end = source_ranges[retained_count - 1]
+            if source_start <= previous_end + 1:
+                source_ranges[retained_count - 1] = (
+                    previous_start,
+                    max(previous_end, source_end),
+                )
+                continue
+        source_ranges[retained_count] = (source_start, source_end)
+        retained_count += 1
+    source_ranges.truncate(retained_count)
+
+
+def _required_ranges_in(
+    required_ranges: Sequence[tuple[int, ...]],
+    source_start: int,
+    source_end: int,
+) -> Iterator[tuple[int, int]]:
+    """Yield required-range intersections with one source interval."""
+    low = 0
+    high = len(required_ranges)
+    while low < high:
+        middle = (low + high) // 2
+        if required_ranges[middle][1] < source_start:
+            low = middle + 1
+        else:
+            high = middle
+
+    for range_index in range(low, len(required_ranges)):
+        required_start, required_end = required_ranges[range_index]
+        if required_start > source_end:
+            return
+        yield max(required_start, source_start), min(required_end, source_end)
+
+
+def _line_chunks(
+    lines: Sequence[bytes],
+    start: int,
+    end: int,
+) -> Iterator[bytes]:
+    """Yield one-based inclusive line ranges without materializing a slice."""
+    for line_number in range(start, end + 1):
+        yield bytes(lines[line_number - 1])
+
+
+def _advanced_source_chunks(
+    old_lines: Sequence[bytes],
+    working_lines: Sequence[bytes],
+    presence_lines: LineRanges,
+    ownership: BatchOwnership,
+    lineage: BatchSourceLineage,
+) -> Iterator[bytes]:
+    """Yield reconciled source chunks while recording source and live lineage."""
+    source_cursor = 1
+    working_cursor = 1
+    new_cursor = 1
+    workspace = MatcherWorkspace()
+    semantic_runs: Iterator[SemanticChangeRun] | None = None
+
+    def emit_unchanged(line_count: int) -> Iterator[bytes]:
+        nonlocal source_cursor, working_cursor, new_cursor
+        if line_count <= 0:
+            return
+        source_end = source_cursor + line_count - 1
+        working_end = working_cursor + line_count - 1
+        lineage.append_source_run(LineageRun(
+            old_start=source_cursor,
+            old_end=source_end,
+            new_start=new_cursor,
+        ))
+        lineage.append_working_run(LineageRun(
+            old_start=working_cursor,
+            old_end=working_end,
+            new_start=new_cursor,
+        ))
+        new_cursor += line_count
+        yield from _line_chunks(working_lines, working_cursor, working_end)
+        source_cursor = source_end + 1
+        working_cursor = working_end + 1
+
+    def emit_source(start: int, end: int) -> Iterator[bytes]:
+        nonlocal new_cursor
+        lineage.append_source_run(LineageRun(
+            old_start=start,
+            old_end=end,
+            new_start=new_cursor,
+        ))
+        new_cursor += end - start + 1
+        yield from _line_chunks(old_lines, start, end)
+
+    def emit_working(
+        start: int,
+        end: int,
+        *,
+        source_start: int | None = None,
+        source_end: int | None = None,
+    ) -> Iterator[bytes]:
+        nonlocal new_cursor
+        if source_start is not None and source_end is not None:
+            lineage.append_source_run(LineageRun(
+                old_start=source_start,
+                old_end=source_end,
+                new_start=new_cursor,
+            ))
+            source_count = source_end - source_start + 1
+            working_count = end - start + 1
+            if working_count > source_count:
+                lineage.append_source_expansion(SourceSelectionExpansion(
+                    source_start=source_start,
+                    source_end=source_end,
+                    new_start=new_cursor,
+                    new_end=new_cursor + working_count - 1,
+                ))
+        lineage.append_working_run(LineageRun(
+            old_start=start,
+            old_end=end,
+            new_start=new_cursor,
+        ))
+        new_cursor += end - start + 1
+        yield from _line_chunks(working_lines, start, end)
+
+    try:
+        required_source_ranges = _required_source_ranges(
+            workspace,
+            ownership,
+            presence_lines,
+        )
+        semantic_runs = stream_semantic_change_runs(old_lines, working_lines)
+        for run in semantic_runs:
+            unchanged_count = _unchanged_line_count_before_run(
+                run,
+                source_cursor=source_cursor,
+                working_cursor=working_cursor,
+            )
+            yield from emit_unchanged(unchanged_count)
+
+            if run.kind is SemanticChangeKind.PRESENCE:
+                assert run.target_start is not None
+                assert run.target_end is not None
+                yield from emit_working(run.target_start, run.target_end)
+                working_cursor = run.target_end + 1
+                continue
+
+            assert run.source_start is not None
+            assert run.source_end is not None
+            if run.kind is SemanticChangeKind.DELETION:
+                if next(_required_ranges_in(
+                    required_source_ranges,
+                    run.source_start,
+                    run.source_end,
+                ), None) is not None:
+                    yield from emit_source(run.source_start, run.source_end)
+                source_cursor = run.source_end + 1
+                continue
+
+            assert run.kind is SemanticChangeKind.REPLACEMENT
+            assert run.target_start is not None
+            assert run.target_end is not None
+            source_count = run.source_end - run.source_start + 1
+            target_count = run.target_end - run.target_start + 1
+            fully_owned = (
+                presence_lines.count(run.source_start, run.source_end)
+                == source_count
+            )
+
+            saved_replacement_span = _saved_replacement_target_span(
+                run,
+                working_lines,
+                ownership,
+                workspace,
+            )
+            if saved_replacement_span is not None:
+                if run.target_start < saved_replacement_span.start:
+                    yield from emit_working(
+                        run.target_start,
+                        saved_replacement_span.start - 1,
+                    )
+                yield from emit_source(run.source_start, run.source_end)
+                if saved_replacement_span.end < run.target_end:
+                    yield from emit_working(
+                        saved_replacement_span.end + 1,
+                        run.target_end,
+                    )
+            elif fully_owned:
+                if source_count > target_count:
+                    raise BatchSourceAdvanceError(
+                        "Cannot advance a fully owned source replacement that "
+                        "contracts multiple owned lines: source lineage would "
+                        "not be unique."
+                    )
+                yield from emit_working(
+                    run.target_start,
+                    run.target_end,
+                    source_start=run.source_start,
+                    source_end=run.source_end,
+                )
+            else:
+                for required_start, required_end in (
+                    _required_ranges_in(
+                        required_source_ranges,
+                        run.source_start,
+                        run.source_end,
+                    )
+                ):
+                    yield from emit_source(required_start, required_end)
+                yield from emit_working(run.target_start, run.target_end)
+
+            source_cursor = run.source_end + 1
+            working_cursor = run.target_end + 1
+
+        source_remaining = len(old_lines) - source_cursor + 1
+        working_remaining = len(working_lines) - working_cursor + 1
+        if source_remaining != working_remaining:
+            raise ValueError("Semantic source comparison left unequal trailing spans")
+        yield from emit_unchanged(source_remaining)
     finally:
-        entries.close()
+        try:
+            if semantic_runs is not None:
+                close = getattr(semantic_runs, "close", None)
+                if close is not None:
+                    close()
+        finally:
+            workspace.close()
+
+
+def _unchanged_line_count_before_run(
+    run: SemanticChangeRun,
+    *,
+    source_cursor: int,
+    working_cursor: int,
+) -> int:
+    """Return the matched span immediately preceding one semantic run."""
+    if run.source_start is not None:
+        source_count = run.source_start - source_cursor
+    else:
+        source_count = None
+    if run.target_start is not None:
+        working_count = run.target_start - working_cursor
+    else:
+        working_count = None
+
+    if source_count is not None and working_count is not None:
+        if source_count != working_count:
+            raise ValueError("Semantic source comparison produced unequal matched spans")
+        return source_count
+    if source_count is not None:
+        return source_count
+    if working_count is not None:
+        return working_count
+    raise ValueError("Semantic change run has no source or target range")
+
+
+def _saved_replacement_target_span(
+    run: SemanticChangeRun,
+    working_lines: Sequence[bytes],
+    ownership: BatchOwnership,
+    workspace: MatcherWorkspace,
+) -> _SavedReplacementTargetSpan | None:
+    """Return the unique live subrange suppressed by a saved replacement.
+
+    A semantic matcher may group the suppressed baseline variant with adjacent
+    live-only edits.  Locate the exact suppressed subrange so those neighboring
+    edits remain in place while the authoritative saved replacement is kept.
+    Refuse ambiguous baseline occurrences.  If no suppressed baseline text is
+    present, the fully owned live run is a newer replacement revision and the
+    ordinary advancement path may adopt it.
+    """
+    assert run.source_start is not None
+    assert run.source_end is not None
+    assert run.target_start is not None
+    assert run.target_end is not None
+    source_count = run.source_end - run.source_start + 1
+    matched_span: _SavedReplacementTargetSpan | None = None
+
+    for unit in ownership.replacement_units:
+        replacement_ranges = collect_replacement_source_ranges(
+            workspace,
+            unit.presence_lines,
+        )
+        if replacement_ranges is None:
+            continue
+        try:
+            covered_source_count = sum(
+                min(source_end, run.source_end)
+                - max(source_start, run.source_start)
+                + 1
+                for source_start, source_end in replacement_ranges
+                if (
+                    source_start <= run.source_end
+                    and source_end >= run.source_start
+                )
+            )
+        finally:
+            workspace.close_resource(replacement_ranges)
+        if covered_source_count != source_count:
+            continue
+
+        for deletion_index in unit.deletion_indices:
+            if (
+                type(deletion_index) is not int
+                or deletion_index < 0
+                or deletion_index >= len(ownership.deletions)
+            ):
+                continue
+            suppressed_variant = ownership.deletions[
+                deletion_index
+            ].content_lines
+            variant_count = len(suppressed_variant)
+            if variant_count == 0:
+                continue
+            first_target_index = run.target_start - 1
+            final_target_index = run.target_end - variant_count
+            for target_index in range(
+                first_target_index,
+                final_target_index + 1,
+            ):
+                if not line_slice_equals(
+                    working_lines,
+                    target_index,
+                    suppressed_variant,
+                ):
+                    continue
+                candidate_span = _SavedReplacementTargetSpan(
+                    start=target_index + 1,
+                    end=target_index + variant_count,
+                )
+                if matched_span is None:
+                    matched_span = candidate_span
+                elif matched_span != candidate_span:
+                    raise BatchSourceAdvanceError(
+                        "Cannot advance an authoritative replacement with "
+                        "multiple matching live baseline spans."
+                    )
+
+    return matched_span
 
 
 def advance_batch_source_for_file_with_provenance(
@@ -171,7 +551,7 @@ def advance_batch_source_for_file_with_provenance(
             source_buffer=source_with_provenance.source_buffer,
             lineage=source_with_provenance.lineage,
         )
-    except Exception:
+    except BaseException:
         if source_with_provenance is not None:
             source_with_provenance.close()
         raise

--- a/src/git_stage_batch/commands/selection/consumed_selection_recording.py
+++ b/src/git_stage_batch/commands/selection/consumed_selection_recording.py
@@ -16,7 +16,10 @@ from ...batch.state.metadata_types import (
     ReplacementMaskMetadata,
     add_ownership_metadata,
 )
-from ...batch.source.advancement import advance_batch_source_for_file_with_provenance
+from ...batch.source.advancement import (
+    BatchSourceAdvanceError,
+    advance_batch_source_for_file_with_provenance,
+)
 from ...batch.source.selected_line_refresh import (
     refresh_selected_lines_against_new_source,
     refresh_selected_lines_against_source_lines,
@@ -28,6 +31,8 @@ from ...data.consumed_selections import (
     read_consumed_file_metadata,
     write_consumed_file_metadata,
 )
+from ...exceptions import CommandError
+from ...i18n import _
 
 
 def record_consumed_selection(
@@ -69,21 +74,31 @@ def record_consumed_selection(
         ) as existing_ownership:
             batch_source_commit = existing_file_metadata["batch_source_commit"]
             if detect_stale_batch_source_for_selection(selected_lines):
-                with advance_batch_source_for_file_with_provenance(
-                    batch_name="consumed-selections",
-                    file_path=file_path,
-                    old_batch_source_commit=batch_source_commit,
-                    existing_ownership=existing_ownership,
-                ) as advance_result:
-                    batch_source_commit = advance_result.batch_source_commit
-                    existing_ownership = advance_result.ownership
-                    selected_lines = refresh_selected_lines_against_source_lines(
-                        selected_lines,
-                        source_lines=advance_result.source_buffer,
-                        working_lines=(),
-                        lineage=advance_result.lineage,
-                        coordinate_lines=coordinate_lines,
-                    )
+                try:
+                    with advance_batch_source_for_file_with_provenance(
+                        batch_name="consumed-selections",
+                        file_path=file_path,
+                        old_batch_source_commit=batch_source_commit,
+                        existing_ownership=existing_ownership,
+                    ) as advance_result:
+                        batch_source_commit = advance_result.batch_source_commit
+                        existing_ownership = advance_result.ownership
+                        selected_lines = refresh_selected_lines_against_source_lines(
+                            selected_lines,
+                            source_lines=advance_result.source_buffer,
+                            working_lines=(),
+                            lineage=advance_result.lineage,
+                            coordinate_lines=coordinate_lines,
+                        )
+                except BatchSourceAdvanceError as error:
+                    raise CommandError(
+                        _(
+                            "Cannot record the included replacement because "
+                            "its saved source cannot be advanced.\n"
+                            "File: {file}\n"
+                            "Error: {error}"
+                        ).format(file=file_path, error=error)
+                    ) from error
             new_ownership = translate_lines_to_batch_ownership(selected_lines)
             persist_selection(
                 batch_source_commit=batch_source_commit,

--- a/tests/batch/source/test_advancement.py
+++ b/tests/batch/source/test_advancement.py
@@ -21,6 +21,7 @@ from git_stage_batch.batch.ownership.translation import (
 from git_stage_batch.batch.ownership.references import BaselineReference
 from git_stage_batch.batch.ownership.replacement_units import ReplacementUnit
 from git_stage_batch.batch.source.advancement import (
+    BatchSourceAdvanceError,
     advance_batch_source_for_file_with_provenance,
     advance_source_lines_preserving_existing_presence,
 )
@@ -504,6 +505,100 @@ def test_advance_source_tracks_working_line_provenance_for_ambiguous_duplicates(
         )
 
 
+def test_advance_source_does_not_duplicate_changed_method_signature():
+    """Refreshing a fully owned file should not concatenate method versions."""
+    old_source = (
+        b"class Prompt {\n"
+        b"    show({message, type}) {\n"
+        b"        return message ?? type;\n"
+        b"    }\n"
+        b"}\n"
+    )
+    working_tree = (
+        b"class Prompt {\n"
+        b"    show(serviceName, message, type) {\n"
+        b"        return message ?? type;\n"
+        b"    }\n"
+        b"}\n"
+    )
+    ownership = BatchOwnership.from_presence_lines(["1-5"], [])
+
+    with _advance_source_from_content(
+        old_source_buffer=old_source,
+        working_buffer=working_tree,
+        ownership=ownership,
+    ) as source_with_provenance:
+        assert source_with_provenance.source_buffer.to_bytes() == working_tree
+
+
+def test_advance_source_does_not_nest_superseded_guard():
+    """Refreshing an extended guard should not retain its old first line."""
+    old_source = (
+        b"function stop(serviceName) {\n"
+        b"    if (serviceName !== selectedService)\n"
+        b"        return;\n"
+        b"}\n"
+    )
+    working_tree = (
+        b"function stop(serviceName) {\n"
+        b"    if (serviceName !== selectedService &&\n"
+        b"        serviceName !== fingerprintService)\n"
+        b"        return;\n"
+        b"}\n"
+    )
+    ownership = BatchOwnership.from_presence_lines(["1-4"], [])
+
+    with _advance_source_from_content(
+        old_source_buffer=old_source,
+        working_buffer=working_tree,
+        ownership=ownership,
+    ) as source_with_provenance:
+        assert source_with_provenance.source_buffer.to_bytes() == working_tree
+        remapped = remap_batch_ownership_with_lineage(
+            ownership,
+            source_with_provenance.lineage,
+        )
+
+    assert remapped.presence_line_set().ranges() == ((1, 5),)
+
+
+def test_advance_source_does_not_duplicate_changed_return_statement():
+    """Refreshing an extended return should keep one executable statement."""
+    old_source = (
+        b"function canStart(serviceName) {\n"
+        b"    return serviceName === selectedService;\n"
+        b"}\n"
+    )
+    working_tree = (
+        b"function canStart(serviceName) {\n"
+        b"    return serviceName === selectedService ||\n"
+        b"        serviceName === fingerprintService;\n"
+        b"}\n"
+    )
+    ownership = BatchOwnership.from_presence_lines(["1-3"], [])
+
+    with _advance_source_from_content(
+        old_source_buffer=old_source,
+        working_buffer=working_tree,
+        ownership=ownership,
+    ) as source_with_provenance:
+        assert source_with_provenance.source_buffer.to_bytes() == working_tree
+        remapped = remap_batch_ownership_with_lineage(
+            ownership,
+            source_with_provenance.lineage,
+        )
+        assert tuple(source_with_provenance.lineage.source_expansions()) == (
+            SourceSelectionExpansion(
+                source_start=2,
+                source_end=2,
+                new_start=2,
+                new_end=3,
+            ),
+        )
+
+    assert remapped.presence_line_set().ranges() == ((1, 4),)
+
+
 def test_advance_source_tracks_contiguous_lineage_as_runs():
     """Large contiguous source refreshes should keep one source-line run."""
     source_lines = b"".join(
@@ -525,6 +620,38 @@ def test_advance_source_tracks_contiguous_lineage_as_runs():
         )
 
 
+def test_advance_source_avoids_line_scale_python_heap():
+    """Required source coordinates should remain range- and storage-backed."""
+    line_count = 8192
+    source_content = b"".join(
+        f"line-{line_index:08d}\n".encode()
+        for line_index in range(line_count)
+    )
+    ownership = BatchOwnership.from_presence_lines([f"1-{line_count}"], [])
+
+    with (
+        LineBuffer.from_bytes(source_content) as old_lines,
+        LineBuffer.from_bytes(source_content) as working_lines,
+    ):
+        assert len(old_lines) == line_count
+        assert len(working_lines) == line_count
+        gc.collect()
+        tracemalloc.start()
+        try:
+            with advance_source_lines_preserving_existing_presence(
+                old_lines,
+                working_lines,
+                ownership,
+            ) as source_with_provenance:
+                result_byte_count = source_with_provenance.source_buffer.byte_count
+            _current_heap, peak_heap = tracemalloc.get_traced_memory()
+        finally:
+            tracemalloc.stop()
+
+    assert result_byte_count == len(source_content)
+    assert peak_heap < _LINE_SCALE_HEAP_LIMIT
+
+
 def test_advance_source_context_closes_lineage():
     """Source advancement context should release lineage resources."""
     ownership = BatchOwnership.from_presence_lines(["1"], [])
@@ -540,6 +667,133 @@ def test_advance_source_context_closes_lineage():
     assert lineage.closed is True
     with pytest.raises(ValueError, match="batch source lineage is closed"):
         lineage.translate_source_line(1)
+
+
+def test_advance_source_preserves_shared_method_boundary_for_partial_ownership():
+    """Refreshing an owned method body must retain its shared closing brace."""
+    old_source = (
+        b"class S {\n"
+        b"    static {\n"
+        b"        register();\n"
+        b"    }\n"
+        b"\n"
+        b"    static enabled() {\n"
+        b"        return true;\n"
+        b"    }\n"
+        b"\n"
+        b"    constructor() {\n"
+        b"    }\n"
+        b"}\n"
+    )
+    working_tree = (
+        b"class S {\n"
+        b"    static {\n"
+        b"        register();\n"
+        b"    }\n"
+        b"\n"
+        b"    constructor() {\n"
+        b"    }\n"
+        b"}\n"
+    )
+    ownership = BatchOwnership.from_presence_lines(["2-7"], [])
+
+    with _advance_source_from_content(
+        old_source_buffer=old_source,
+        working_buffer=working_tree,
+        ownership=ownership,
+    ) as source_with_provenance:
+        assert source_with_provenance.source_buffer.to_bytes() == old_source
+
+
+@pytest.mark.parametrize(
+    ("working_tree", "expected_source", "expected_presence", "working_extra"),
+    [
+        (
+            b"head\nold\nextra\ntail\n",
+            b"head\nnew\nextra\ntail\n",
+            ((2, 2),),
+            (3, 3),
+        ),
+        (
+            b"head\nextra\nold\ntail\n",
+            b"head\nextra\nnew\ntail\n",
+            ((3, 3),),
+            (2, 2),
+        ),
+    ],
+)
+def test_advance_source_replaces_suppressed_span_without_losing_live_neighbors(
+    working_tree,
+    expected_source,
+    expected_presence,
+    working_extra,
+):
+    """Saved replacements stay authoritative inside a larger semantic run."""
+    ownership = BatchOwnership.from_presence_lines(
+        ["2"],
+        [AbsenceClaim(anchor_line=1, content_lines=[b"old\n"])],
+        replacement_units=[
+            ReplacementUnit(presence_lines=["2"], deletion_indices=[0]),
+        ],
+    )
+
+    with _advance_source_from_content(
+        old_source_buffer=b"head\nnew\ntail\n",
+        working_buffer=working_tree,
+        ownership=ownership,
+    ) as source_with_provenance:
+        remapped = remap_batch_ownership_with_lineage(
+            ownership,
+            source_with_provenance.lineage,
+        )
+
+        assert source_with_provenance.source_buffer.to_bytes() == expected_source
+        assert source_with_provenance.lineage.translate_working_line(
+            working_extra[0]
+        ) == working_extra[1]
+
+    assert remapped.presence_line_set().ranges() == expected_presence
+    assert remapped.replacement_units[0].presence_lines == [
+        str(expected_presence[0][0])
+    ]
+
+
+def test_advance_source_refuses_ambiguous_saved_replacement_baseline_spans():
+    """Repeated live baseline variants must not replace saved ownership."""
+    ownership = BatchOwnership.from_presence_lines(
+        ["2"],
+        [AbsenceClaim(anchor_line=1, content_lines=[b"old\n"])],
+        replacement_units=[
+            ReplacementUnit(presence_lines=["2"], deletion_indices=[0]),
+        ],
+    )
+
+    with pytest.raises(
+        BatchSourceAdvanceError,
+        match="multiple matching live baseline",
+    ):
+        with _advance_source_from_content(
+            old_source_buffer=b"head\nnew\ntail\n",
+            working_buffer=b"head\nold\nold\ntail\n",
+            ownership=ownership,
+        ):
+            pass
+
+
+def test_advance_source_refuses_owned_replacement_contraction() -> None:
+    """A contracted owned range cannot retain unique source-line lineage."""
+    ownership = BatchOwnership.from_presence_lines(["2-3"])
+
+    with pytest.raises(
+        BatchSourceAdvanceError,
+        match="contracts multiple owned lines",
+    ):
+        with _advance_source_from_content(
+            old_source_buffer=b"head\none\ntwo\ntail\n",
+            working_buffer=b"head\ncombined\ntail\n",
+            ownership=ownership,
+        ):
+            pass
 
 
 def test_advance_source_lines_accepts_non_list_line_sequences(line_sequence):

--- a/tests/batch/source/test_advancement.py
+++ b/tests/batch/source/test_advancement.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import gc
+import tracemalloc
+
 import pytest
 
 from git_stage_batch.batch.source import advancement as advancement_module
@@ -21,10 +24,17 @@ from git_stage_batch.batch.source.advancement import (
     advance_batch_source_for_file_with_provenance,
     advance_source_lines_preserving_existing_presence,
 )
-from git_stage_batch.batch.line_matching.lineage import BatchSourceLineage, LineageRun
+from git_stage_batch.batch.line_matching.lineage import (
+    BatchSourceLineage,
+    LineageRun,
+    SourceSelectionExpansion,
+)
 from git_stage_batch.core.line_selection import LineRanges
 from git_stage_batch.core.models import LineEntry
 from git_stage_batch.core.buffer import LineBuffer
+
+
+_LINE_SCALE_HEAP_LIMIT = 256 * 1024
 
 
 class _IterationGuardedLineSelection:
@@ -152,6 +162,63 @@ def test_batch_source_lineage_translates_ranges():
             LineRanges.from_ranges([(2, 8)])
         ).ranges() == ((11, 13), (20, 20))
         assert lineage.translate_working_line(21) == 31
+
+
+def test_batch_source_lineage_expands_complete_owned_replacements():
+    """Whole source selections should inherit every expanded destination line."""
+    with BatchSourceLineage(
+        source_runs=[LineageRun(old_start=1, old_end=3, new_start=1)],
+        source_expansions=[
+            SourceSelectionExpansion(
+                source_start=2,
+                source_end=2,
+                new_start=2,
+                new_end=3,
+            ),
+        ],
+    ) as lineage:
+        assert lineage.translate_source_selection(
+            LineRanges.from_ranges(((2, 2),))
+        ).ranges() == ((2, 3),)
+        assert lineage.translate_source_selection(
+            LineRanges.from_ranges(((1, 1),))
+        ).ranges() == ((1, 1),)
+
+
+def test_fragmented_source_lineage_translation_avoids_line_scale_python_heap():
+    """Fragmented provenance should coalesce before entering heap storage."""
+    line_count = 8192
+    selection = LineRanges.from_ranges(((1, line_count),))
+
+    with BatchSourceLineage() as lineage:
+        for source_line in range(1, line_count + 1):
+            new_start = source_line * 2 - 1
+            lineage.append_source_run(
+                LineageRun(
+                    old_start=source_line,
+                    old_end=source_line,
+                    new_start=new_start,
+                )
+            )
+            lineage.append_source_expansion(
+                SourceSelectionExpansion(
+                    source_start=source_line,
+                    source_end=source_line,
+                    new_start=new_start,
+                    new_end=new_start + 1,
+                )
+            )
+
+        gc.collect()
+        tracemalloc.start()
+        try:
+            translated = lineage.translate_source_selection(selection)
+            _current_heap, peak_heap = tracemalloc.get_traced_memory()
+        finally:
+            tracemalloc.stop()
+
+    assert translated.ranges() == ((1, line_count * 2),)
+    assert peak_heap < _LINE_SCALE_HEAP_LIMIT
 
 
 def test_batch_source_lineage_finds_unmapped_source_ranges():

--- a/tests/commands/selection/test_consumed_selection_recording.py
+++ b/tests/commands/selection/test_consumed_selection_recording.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 import subprocess
 
 import pytest
@@ -9,6 +10,9 @@ import pytest
 from git_stage_batch.commands.selection.consumed_selection_recording import (
     record_consumed_selection,
 )
+from git_stage_batch.commands.selection import consumed_selection_recording
+from git_stage_batch.batch.ownership.model import BatchOwnership
+from git_stage_batch.batch.source.advancement import BatchSourceAdvanceError
 from git_stage_batch.commands.start import command_start
 from git_stage_batch.core.models import LineEntry
 from git_stage_batch.data.consumed_selections import (
@@ -163,6 +167,47 @@ def test_corrupt_consumed_file_entry_fails_closed(temp_git_repo):
 
     with pytest.raises(CommandError, match="invalid entry for tracked.txt"):
         load_consumed_selections_metadata()
+
+
+def test_expected_source_advance_refusal_is_a_command_error(monkeypatch):
+    """Consumed-selection advancement refusals should not escape as internals."""
+
+    @contextmanager
+    def acquired_ownership(_metadata):
+        yield BatchOwnership([], [])
+
+    monkeypatch.setattr(
+        consumed_selection_recording,
+        "read_consumed_file_metadata",
+        lambda _file_path: {"batch_source_commit": "old-source"},
+    )
+    monkeypatch.setattr(
+        consumed_selection_recording,
+        "acquire_ownership_for_metadata_dict",
+        acquired_ownership,
+    )
+    monkeypatch.setattr(
+        consumed_selection_recording,
+        "detect_stale_batch_source_for_selection",
+        lambda _selected_lines: True,
+    )
+    monkeypatch.setattr(
+        consumed_selection_recording,
+        "advance_batch_source_for_file_with_provenance",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            BatchSourceAdvanceError("ambiguous replacement")
+        ),
+    )
+
+    with (
+        LineBuffer.from_bytes(b"content\n") as source_buffer,
+        pytest.raises(CommandError, match="saved source cannot be advanced"),
+    ):
+        record_consumed_selection(
+            "file.txt",
+            source_buffer=source_buffer,
+            selected_lines=[],
+        )
 
 
 def test_record_consumed_selection_accepts_buffer(temp_git_repo):

--- a/tests/functional/test_functional_batch_operations.py
+++ b/tests/functional/test_functional_batch_operations.py
@@ -597,6 +597,44 @@ class TestComplexBatchWorkflows:
             if result.returncode == 0:
                 assert result.stdout
 
+    def test_split_new_file_reconstructs_exact_content(self, functional_repo):
+        """Applying batches split from a new file must reproduce it exactly."""
+        test_file = functional_repo / "new-service.js"
+        expected = (
+            "class Service {\n"
+            "    start() {\n"
+            "        return oldValue ||\n"
+            "            newValue;\n"
+            "    }\n"
+            "}\n"
+        )
+        test_file.write_text(expected)
+
+        git_stage_batch("new", "new-file-structure")
+        git_stage_batch("new", "new-file-behavior")
+        git_stage_batch("start")
+
+        git_stage_batch(
+            "discard",
+            "--to",
+            "new-file-structure",
+            "--line",
+            "1,2,5,6",
+        )
+        git_stage_batch(
+            "discard",
+            "--to",
+            "new-file-behavior",
+            "--file",
+        )
+
+        assert not test_file.exists()
+
+        git_stage_batch("apply", "--from", "new-file-structure")
+        git_stage_batch("apply", "--from", "new-file-behavior")
+
+        assert test_file.read_text() == expected
+
     def test_batch_accumulation_workflow(self, repo_with_changes):
         """Test accumulating changes to a batch over multiple sessions."""
         git_stage_batch("new", "accumulated")


### PR DESCRIPTION
Stale-source refresh currently maps saved line ownership back onto the latest
source before applying line-scoped batch operations.

When signatures, guards, or replacement regions change together, coordinate
lineage alone can concatenate unrelated text, lose a neighboring edit, or
silently choose among semantically ambiguous candidates.

This series records source-expansion lineage in mapped storage, reconciles
semantic change runs, treats authoritative replacements explicitly, and turns
unresolvable ambiguity into a command error. Focused regressions cover changed
signatures, guards, adjacent edits, replacements, and refusal cases.

Stale-source operations now preserve the intended semantic change or fail
clearly instead of manufacturing a plausible but incorrect result.
