### PR TITLE
journal: Record terminal transaction outcomes

### DIFF
--- a/src/git_stage_batch/commands/apply_from.py
+++ b/src/git_stage_batch/commands/apply_from.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import sys
+from dataclasses import dataclass
 from typing import Optional
+from uuid import uuid4
 
 from .batch_source import action_context as _action_context
 from .batch_source import action_selection as _action_selection
@@ -12,6 +14,19 @@ from .batch_source import candidate_execution as _candidate_execution
 from ..data.file_review.records import FileReviewAction
 from ..i18n import _
 from ..utils.git_repository import require_git_repository
+from ..utils.journal import log_journal
+
+
+@dataclass(slots=True)
+class _ApplyJournalState:
+    """Last observable apply phase for a terminal journal event."""
+
+    stage: str = "repository"
+    rollback: str = "not-started"
+
+    def update(self, stage: str, rollback: str) -> None:
+        self.stage = stage
+        self.rollback = rollback
 
 
 def command_apply_from_batch(
@@ -29,46 +44,89 @@ def command_apply_from_batch(
               If None, applies all files in batch.
         patterns: Optional gitignore-style file patterns to filter batch files.
     """
-    require_git_repository()
     raw_selector = batch_name
-    context = _action_context.resolve_batch_source_action_context(
-        raw_selector,
-        operation="apply",
-        review_action=FileReviewAction.APPLY_FROM_BATCH,
-        command_name="apply",
+    resolved_batch_name: str | None = None
+    operation_id = uuid4().hex
+    journal_state = _ApplyJournalState()
+    log_journal(
+        "apply_from_batch_start",
+        operation_id=operation_id,
+        batch_name=raw_selector,
+        batch_selector=raw_selector,
         line_ids=line_ids,
-        file=file,
-        patterns=patterns,
+        requested_file_path=file,
+        pattern_count=len(patterns or ()),
     )
-    selector = context.selector
-    batch_name = context.batch_name
-
-    selection = _action_selection.resolve_apply_action_selection(
-        context,
-        line_ids=line_ids,
-        patterns=patterns,
-    )
-    file = selection.file
-    files = selection.files
-    selected_ids = selection.selected_ids
-    selection_ids_to_apply = selection.selection_ids
-    if selector.candidate_ordinal is not None:
-        _candidate_execution.execute_apply_candidate(
-            batch_name=batch_name,
-            raw_selector=raw_selector,
-            ordinal=selector.candidate_ordinal,
-            files=files,
-            selected_ids=selected_ids,
-            selection_ids_to_apply=selection_ids_to_apply,
+    try:
+        require_git_repository()
+        journal_state.update("context", "not-started")
+        context = _action_context.resolve_batch_source_action_context(
+            raw_selector,
+            operation="apply",
+            review_action=FileReviewAction.APPLY_FROM_BATCH,
+            command_name="apply",
+            line_ids=line_ids,
+            file=file,
+            patterns=patterns,
         )
-        return
+        selector = context.selector
+        batch_name = context.batch_name
+        resolved_batch_name = batch_name
 
-    _apply_action.execute_apply_action(
+        journal_state.update("selection", "not-started")
+        selection = _action_selection.resolve_apply_action_selection(
+            context,
+            line_ids=line_ids,
+            patterns=patterns,
+        )
+        file = selection.file
+        files = selection.files
+        selected_ids = selection.selected_ids
+        selection_ids_to_apply = selection.selection_ids
+        if selector.candidate_ordinal is not None:
+            _candidate_execution.execute_apply_candidate(
+                batch_name=batch_name,
+                raw_selector=raw_selector,
+                ordinal=selector.candidate_ordinal,
+                files=files,
+                selected_ids=selected_ids,
+                selection_ids_to_apply=selection_ids_to_apply,
+                journal_progress=journal_state.update,
+            )
+        else:
+            _apply_action.execute_apply_action(
+                batch_name=batch_name,
+                context=context,
+                selection=selection,
+                journal_progress=journal_state.update,
+            )
+    except BaseException as error:
+        log_journal(
+            "apply_from_batch_failed",
+            operation_id=operation_id,
+            batch_name=raw_selector,
+            batch_selector=raw_selector,
+            resolved_batch_name=resolved_batch_name,
+            stage=journal_state.stage,
+            rollback=journal_state.rollback,
+            error_type=type(error).__name__,
+        )
+        raise
+
+    journal_state.update("complete", journal_state.rollback)
+    log_journal(
+        "apply_from_batch_success",
+        operation_id=operation_id,
         batch_name=batch_name,
-        context=context,
-        selection=selection,
+        batch_selector=raw_selector,
+        resolved_batch_name=batch_name,
+        files=list(files),
+        stage=journal_state.stage,
+        rollback=journal_state.rollback,
     )
 
+    if selector.candidate_ordinal is not None:
+        return
     if line_ids:
         print(_("✓ Applied selected lines from batch '{name}' to working tree").format(name=batch_name), file=sys.stderr)
     elif file is not None:

--- a/src/git_stage_batch/commands/batch_source/apply_action.py
+++ b/src/git_stage_batch/commands/batch_source/apply_action.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 import sys
+from typing import Callable
 
 from . import action_completion as _action_completion
 from . import action_context as _action_context
@@ -33,7 +34,7 @@ from ...data.file_target_identity import (
     capture_worktree_identities,
     capture_worktree_identity,
 )
-from ...data.undo.checkpoints import undo_checkpoint
+from ...data.undo.checkpoints import UndoCheckpointStatus, undo_checkpoint
 from ...exceptions import (
     AtomicUnitError,
     CommandError,
@@ -102,14 +103,17 @@ def execute_apply_action(
     batch_name: str,
     context: _action_context.BatchSourceActionContext,
     selection: _action_selection.BatchSourceActionSelection,
+    journal_progress: Callable[[str, str], None] | None = None,
 ) -> None:
     """Apply selected batch-source changes to the working tree."""
+    report_progress = journal_progress or (lambda _stage, _rollback: None)
     files = selection.files
     selected_ids = selection.selected_ids
     selection_ids_to_apply = selection.selection_ids
     rendered = selection.rendered
     operation_parts = list(selection.operation_parts)
     repository_root = get_git_repository_root_path()
+    report_progress("planning", "not-started")
     with FileJobWorkspace() as workspace:
         (
             apply_plans,
@@ -128,12 +132,20 @@ def execute_apply_action(
             _require_unchanged_worktree_targets(
                 expected_worktree_identities,
             )
+            publication_started = False
+            checkpoint_status: UndoCheckpointStatus | None = None
+            report_progress("checkpoint", "not-started")
             try:
                 with undo_checkpoint(
                     " ".join(operation_parts),
                     worktree_paths=list(files),
                     rollback_on_error=True,
-                ):
+                ) as checkpoint_status:
+                    publication_started = True
+                    report_progress(
+                        "publication",
+                        checkpoint_status.rollback,
+                    )
                     for plan in apply_plans:
                         snapshot_file_if_untracked(plan.file_path)
                         if isinstance(plan, _action_plans.ApplyTextFileActionPlan):
@@ -168,17 +180,33 @@ def execute_apply_action(
                             raise TypeError("unsupported apply action plan")
                     for file_path, file_meta in mode_actions:
                         _file_mode_actions.apply_new_file_mode(file_path, file_meta)
-            except CommandError:
-                raise
-            except Exception as error:
+            except BaseException as error:
+                if publication_started:
+                    report_progress(
+                        "publication",
+                        (
+                            checkpoint_status.rollback
+                            if checkpoint_status is not None
+                            else "unavailable"
+                        ),
+                    )
+                if isinstance(error, CommandError):
+                    raise
+                if not isinstance(error, Exception):
+                    raise
                 _worktree_refusals.refuse_incompatible_worktree_action(
                     batch_name=batch_name,
                     file_paths=files,
                     error=error,
                 )
+            else:
+                assert checkpoint_status is not None
+                report_progress("publication", checkpoint_status.rollback)
         finally:
             _action_plans.close_action_plans(apply_plans)
 
+    assert checkpoint_status is not None
+    report_progress("completion", checkpoint_status.rollback)
     _action_completion.finish_batch_source_action_review(context, files)
 
 

--- a/src/git_stage_batch/commands/batch_source/candidate_execution.py
+++ b/src/git_stage_batch/commands/batch_source/candidate_execution.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sys
+from typing import Callable
 
 from . import candidate_materialization as _candidate_materialization
 from . import text_file_actions as _text_file_actions
@@ -10,7 +11,7 @@ from ...batch.operation_candidate_state import clear_candidate_preview_state_for
 from ...batch.state.metadata_types import BatchFileMetadataDict
 from ...core.replacement import ReplacementPayload
 from ...data.session import snapshot_file_if_untracked
-from ...data.undo.checkpoints import undo_checkpoint
+from ...data.undo.checkpoints import UndoCheckpointStatus, undo_checkpoint
 from ...i18n import _
 
 
@@ -22,8 +23,11 @@ def execute_apply_candidate(
     files: dict[str, BatchFileMetadataDict],
     selected_ids: set[int] | None,
     selection_ids_to_apply: set[int] | None,
+    journal_progress: Callable[[str, str], None] | None = None,
 ) -> None:
     """Recompute and apply one previewed apply candidate."""
+    report_progress = journal_progress or (lambda _stage, _rollback: None)
+    report_progress("materialization", "not-started")
     materialized = _candidate_materialization.materialize_apply_candidate(
         batch_name=batch_name,
         raw_selector=raw_selector,
@@ -46,14 +50,38 @@ def execute_apply_candidate(
         )
         print(f"  {file_path}: {_('Working tree')}", file=sys.stderr)
         operation_parts = ["apply", "--from", raw_selector, "--file", file_path]
-        with undo_checkpoint(" ".join(operation_parts), worktree_paths=[file_path]):
-            snapshot_file_if_untracked(file_path)
-            _text_file_actions.write_text_file_to_worktree(
-                file_path,
-                target.after_buffer,
-                materialized.file_mode,
-                target.change_type,
-            )
+        report_progress("checkpoint", "not-started")
+        checkpoint_status: UndoCheckpointStatus | None = None
+        publication_started = False
+        try:
+            with undo_checkpoint(
+                " ".join(operation_parts),
+                worktree_paths=[file_path],
+                rollback_on_error=True,
+            ) as checkpoint_status:
+                publication_started = True
+                report_progress("publication", checkpoint_status.rollback)
+                snapshot_file_if_untracked(file_path)
+                _text_file_actions.write_text_file_to_worktree(
+                    file_path,
+                    target.after_buffer,
+                    materialized.file_mode,
+                    target.change_type,
+                )
+        except BaseException:
+            if publication_started:
+                report_progress(
+                    "publication",
+                    (
+                        checkpoint_status.rollback
+                        if checkpoint_status is not None
+                        else "unavailable"
+                    ),
+                )
+            raise
+        assert checkpoint_status is not None
+        report_progress("publication", checkpoint_status.rollback)
+        report_progress("completion", checkpoint_status.rollback)
         clear_candidate_preview_state_for_file(
             batch_name=batch_name,
             file_path=file_path,

--- a/src/git_stage_batch/commands/file_scope/discard_file.py
+++ b/src/git_stage_batch/commands/file_scope/discard_file.py
@@ -117,7 +117,7 @@ def discard_file_changes(
     else:
         target_file = file
 
-    checkpoint: AbstractContextManager[None]
+    checkpoint: AbstractContextManager[object]
     patch_context: AbstractContextManager[Iterator[UnifiedDiffItem]]
     if _prepared_changes is None:
         auto_add_untracked_files([target_file])

--- a/src/git_stage_batch/commands/file_scope/discard_to_batch.py
+++ b/src/git_stage_batch/commands/file_scope/discard_to_batch.py
@@ -412,36 +412,49 @@ def discard_files_to_batch(
 
         for file_path in files:
             log_journal(
-                "discard_file_to_batch_start",
+                "discard_files_to_batch_file_start",
                 batch_name=batch_name,
                 file_path=file_path,
                 quiet=quiet,
             )
-            discard_input = collected_discards.inputs_by_file.get(file_path)
-            if (
-                discard_input is None
-                and file_path in collected_discards.files_with_text_patches
-            ):
-                continue
+            outcome = "failed"
+            try:
+                discard_input = collected_discards.inputs_by_file.get(file_path)
+                if (
+                    discard_input is None
+                    and file_path in collected_discards.files_with_text_patches
+                ):
+                    outcome = "skipped"
+                    continue
 
-            if discard_input is None or not session.prepare_text_file(discard_input):
-                session.flush()
-                discarded_hunks = discard_file_to_batch(
-                    batch_name,
-                    file_path,
-                    quiet=True,
-                    advance=False,
-                    auto_advance=auto_advance,
+                if (
+                    discard_input is None
+                    or not session.prepare_text_file(discard_input)
+                ):
+                    session.flush()
+                    discarded_hunks = discard_file_to_batch(
+                        batch_name,
+                        file_path,
+                        quiet=True,
+                        advance=False,
+                        auto_advance=auto_advance,
+                    )
+                    if session.record_single_file_discard(
+                        file_path,
+                        discarded_hunks,
+                    ):
+                        blocked_hashes = read_text_file_line_set(blocklist_path)
+                    outcome = "fallback"
+                    continue
+
+                outcome = "prepared"
+            finally:
+                log_journal(
+                    "discard_files_to_batch_file_end",
+                    batch_name=batch_name,
+                    file_path=file_path,
+                    outcome=outcome,
                 )
-                if session.record_single_file_discard(file_path, discarded_hunks):
-                    blocked_hashes = read_text_file_line_set(blocklist_path)
-                continue
-
-            log_journal(
-                "discard_file_to_batch_end",
-                batch_name=batch_name,
-                file_path=file_path,
-            )
 
         session.flush()
     finally:

--- a/src/git_stage_batch/commands/file_scope/include_file.py
+++ b/src/git_stage_batch/commands/file_scope/include_file.py
@@ -91,7 +91,7 @@ def include_file_changes(
     else:
         target_file = file
 
-    checkpoint: AbstractContextManager[None]
+    checkpoint: AbstractContextManager[object]
     patch_context: AbstractContextManager[Iterator[UnifiedDiffItem]]
     rollback_context: AbstractContextManager[None]
     if _prepared_changes is None:

--- a/src/git_stage_batch/commands/file_scope/multi_file_actions.py
+++ b/src/git_stage_batch/commands/file_scope/multi_file_actions.py
@@ -75,7 +75,7 @@ def _multi_file_undo_checkpoint(
     files: Sequence[str],
     *,
     worktree_paths: Sequence[str] | None = None,
-) -> AbstractContextManager[None]:
+) -> AbstractContextManager[object]:
     """Create one undo checkpoint for a resolved multi-file command."""
     paths = list(worktree_paths) if worktree_paths is not None else list(files)
     return undo_checkpoint(

--- a/src/git_stage_batch/commands/file_scope/skip_file.py
+++ b/src/git_stage_batch/commands/file_scope/skip_file.py
@@ -66,7 +66,7 @@ def skip_file_changes(
     else:
         target_file = file
 
-    checkpoint: AbstractContextManager[None]
+    checkpoint: AbstractContextManager[object]
     patch_context: AbstractContextManager[Iterator[UnifiedDiffItem]]
     if _prepared_changes is None:
         auto_add_untracked_files([target_file])

--- a/src/git_stage_batch/commands/selection/discard_line_batching.py
+++ b/src/git_stage_batch/commands/selection/discard_line_batching.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import os
 import sys
+from dataclasses import dataclass
+from uuid import uuid4
 
 from ...batch.source.annotation import annotate_with_batch_source
 from ...batch.ownership import insertion_references as _insertion_references
@@ -26,6 +28,76 @@ from . import discard_line_publication as _discard_line_publication
 from . import discard_line_replacement as _discard_line_replacement
 from .action_completion import finish_selected_change_action
 from .selected_hunk_refresh import recalculate_selected_hunk_for_command
+
+
+@dataclass(slots=True)
+class _DiscardLinesJournalState:
+    """Last observable discard phase for a terminal journal event."""
+
+    operation_id: str
+    stage: str = "selection"
+    rollback: str = "not-started"
+    file_path: str | None = None
+
+
+def _begin_discard_lines_journal(
+    batch_name: str,
+    line_id_specification: str,
+    *,
+    quiet: bool,
+) -> _DiscardLinesJournalState:
+    """Start one correlated selected-line discard journal operation."""
+    state = _DiscardLinesJournalState(operation_id=uuid4().hex)
+    log_journal(
+        "discard_lines_to_batch_start",
+        operation_id=state.operation_id,
+        batch_name=batch_name,
+        line_ids=line_id_specification,
+        quiet=quiet,
+    )
+    return state
+
+
+def _log_discard_lines_failure(
+    state: _DiscardLinesJournalState,
+    batch_name: str,
+    line_id_specification: str,
+    error: BaseException,
+    *,
+    rollback: str | None = None,
+) -> None:
+    """Record one terminal selected-line discard failure."""
+    if rollback is not None:
+        state.rollback = rollback
+    log_journal(
+        "discard_lines_to_batch_failed",
+        operation_id=state.operation_id,
+        batch_name=batch_name,
+        line_ids=line_id_specification,
+        file_path=state.file_path,
+        stage=state.stage,
+        rollback=state.rollback,
+        error_type=type(error).__name__,
+    )
+
+
+def _log_discard_lines_success(
+    state: _DiscardLinesJournalState,
+    batch_name: str,
+    line_id_specification: str,
+    *,
+    rollback: str = "not-needed",
+) -> None:
+    """Record one terminal selected-line discard success."""
+    log_journal(
+        "discard_lines_to_batch_success",
+        operation_id=state.operation_id,
+        batch_name=batch_name,
+        line_ids=line_id_specification,
+        file_path=state.file_path,
+        stage="complete",
+        rollback=rollback,
+    )
 
 
 def discard_lines_as_to_batch(
@@ -164,95 +236,127 @@ def discard_selected_lines_to_batch(
     *,
     quiet: bool = False,
     auto_advance: bool | None = None,
+    journal_state: _DiscardLinesJournalState | None = None,
 ) -> int:
     """Save specific selected lines to batch and discard them."""
-    log_journal(
-        "discard_lines_to_batch_start",
-        batch_name=batch_name,
-        line_ids=line_id_specification,
-        quiet=quiet,
-    )
+    owns_terminal_journal = journal_state is None
+    if journal_state is None:
+        journal_state = _begin_discard_lines_journal(
+            batch_name,
+            line_id_specification,
+            quiet=quiet,
+        )
+    try:
+        require_selected_hunk()
 
-    require_selected_hunk()
-
-    line_changes = require_line_changes_from_state()
-    selection = _batch_line_selection.select_lines_for_batch_action(
-        line_changes,
-        line_id_specification,
-    )
-
-    if not selection.selected_lines:
-        exit_with_error(
-            _("No matching lines found for selection: {ids}").format(
-                ids=line_id_specification,
-            )
+        line_changes = require_line_changes_from_state()
+        journal_state.file_path = line_changes.path
+        selection = _batch_line_selection.select_lines_for_batch_action(
+            line_changes,
+            line_id_specification,
         )
 
-    _insertion_references.record_baseline_references_for_additions(
-        line_changes,
-    )
-    _batch_line_updates.add_selected_lines_to_batch(
-        batch_name=batch_name,
-        file_path=line_changes.path,
-        selected_lines=selection.selected_lines,
-        stale_source_action=_("Cannot discard lines to batch"),
-        hunk_lines=line_changes.lines,
-        snapshot_untracked=True,
-        before_add=lambda: log_journal(
-            "discard_lines_to_batch_before_add",
+        if not selection.selected_lines:
+            exit_with_error(
+                _("No matching lines found for selection: {ids}").format(
+                    ids=line_id_specification,
+                )
+            )
+
+        _insertion_references.record_baseline_references_for_additions(
+            line_changes,
+        )
+
+        def before_add() -> None:
+            journal_state.stage = "batch-publication"
+            journal_state.rollback = "unavailable"
+            log_journal(
+                "discard_lines_to_batch_before_add",
+                operation_id=journal_state.operation_id,
+                batch_name=batch_name,
+                file_path=line_changes.path,
+            )
+
+        _batch_line_updates.add_selected_lines_to_batch(
             batch_name=batch_name,
             file_path=line_changes.path,
-        ),
-    )
+            selected_lines=selection.selected_lines,
+            stale_source_action=_("Cannot discard lines to batch"),
+            hunk_lines=line_changes.lines,
+            snapshot_untracked=True,
+            before_add=before_add,
+        )
 
-    log_journal(
-        "discard_lines_to_batch_after_add",
-        batch_name=batch_name,
-        file_path=line_changes.path,
-    )
+        log_journal(
+            "discard_lines_to_batch_after_add",
+            operation_id=journal_state.operation_id,
+            batch_name=batch_name,
+            file_path=line_changes.path,
+        )
 
-    working_file_path = get_git_repository_root_path() / line_changes.path
-    if not os.path.lexists(working_file_path):
-        exit_with_error(
-            _("File not found in working tree: {file}").format(
-                file=line_changes.path,
+        journal_state.stage = "worktree-publication"
+        working_file_path = get_git_repository_root_path() / line_changes.path
+        if not os.path.lexists(working_file_path):
+            exit_with_error(
+                _("File not found in working tree: {file}").format(
+                    file=line_changes.path,
+                )
             )
+
+        with load_working_tree_file_as_buffer(line_changes.path) as working_lines:
+            target_working_buffer = build_target_working_tree_buffer_from_lines(
+                line_changes,
+                selection.requested_ids,
+                working_lines,
+            )
+
+        log_journal(
+            "discard_lines_to_batch_before_write",
+            operation_id=journal_state.operation_id,
+            file_path=str(working_file_path),
+        )
+        with target_working_buffer:
+            _discard_line_publication.publish_worktree_line_discard(
+                line_changes.path,
+                working_file_path,
+                target_working_buffer,
+            )
+        log_journal(
+            "discard_lines_to_batch_after_write",
+            operation_id=journal_state.operation_id,
+            file_path=str(working_file_path),
         )
 
-    with load_working_tree_file_as_buffer(line_changes.path) as working_lines:
-        target_working_buffer = build_target_working_tree_buffer_from_lines(
-            line_changes,
-            selection.requested_ids,
-            working_lines,
-        )
+        if not quiet:
+            print(
+                _(
+                    "✓ Discarded line(s) to batch '{name}': {lines}"
+                ).format(
+                    name=batch_name,
+                    lines=line_id_specification,
+                ),
+                file=sys.stderr,
+            )
 
-    log_journal("discard_lines_to_batch_before_write", file_path=str(working_file_path))
-    with target_working_buffer:
-        _discard_line_publication.publish_worktree_line_discard(
+        journal_state.stage = "completion"
+        recalculate_selected_hunk_for_command(
             line_changes.path,
-            working_file_path,
-            target_working_buffer,
+            auto_advance=auto_advance,
         )
-    log_journal("discard_lines_to_batch_after_write", file_path=str(working_file_path))
+    except BaseException as error:
+        if owns_terminal_journal:
+            _log_discard_lines_failure(
+                journal_state,
+                batch_name,
+                line_id_specification,
+                error,
+            )
+        raise
 
-    if not quiet:
-        print(
-            _("✓ Discarded line(s) to batch '{name}': {lines}").format(
-                name=batch_name,
-                lines=line_id_specification,
-            ),
-            file=sys.stderr,
+    if owns_terminal_journal:
+        _log_discard_lines_success(
+            journal_state,
+            batch_name,
+            line_id_specification,
         )
-
-    recalculate_selected_hunk_for_command(
-        line_changes.path,
-        auto_advance=auto_advance,
-    )
-
-    log_journal(
-        "discard_lines_to_batch_success",
-        batch_name=batch_name,
-        line_ids=line_id_specification,
-        file_path=line_changes.path,
-    )
     return 1

--- a/src/git_stage_batch/commands/selection/discard_to_batch_action.py
+++ b/src/git_stage_batch/commands/selection/discard_to_batch_action.py
@@ -10,7 +10,7 @@ from ...data.selected_change.store import (
     SelectedChangeKind,
     read_selected_change_kind,
 )
-from ...data.undo.checkpoints import undo_checkpoint
+from ...data.undo.checkpoints import UndoCheckpointStatus, undo_checkpoint
 from ...batch.state.batch_names import validate_batch_name
 from ...exceptions import exit_with_error
 from ...i18n import _
@@ -45,87 +45,147 @@ def execute_discard_to_batch_action(
 
     selected_change = load_selected_change() if file is None else None
     worktree_paths = checkpoint_paths_for_file_scope(file, selected_change)
-    with undo_checkpoint(
-        " ".join(operation_parts),
-        worktree_paths=worktree_paths,
-        rollback_on_error=True,
-    ):
-        if (
-            file is None
-            and line_ids is None
-            and read_selected_change_kind() == SelectedChangeKind.MODE
-        ):
-            selected_change = load_selected_change()
-            if isinstance(selected_change, FileModeChange):
-                return _whole_file_batch_discarding.discard_mode_to_batch(
-                    batch_name,
-                    selected_change,
-                    quiet=quiet,
-                    auto_advance=auto_advance,
-                )
+    line_journal = (
+        _discard_line_batching._begin_discard_lines_journal(
+            batch_name,
+            line_ids,
+            quiet=quiet,
+        )
+        if file is None and line_ids is not None
+        else None
+    )
+    checkpoint_status: UndoCheckpointStatus | None = None
+    try:
+        with undo_checkpoint(
+            " ".join(operation_parts),
+            worktree_paths=worktree_paths,
+            rollback_on_error=True,
+        ) as checkpoint_status:
+            if line_journal is not None:
+                line_journal.rollback = checkpoint_status.rollback
 
-        if (
-            file is None
-            and line_ids is None
-            and read_selected_change_kind() == SelectedChangeKind.RENAME
-        ):
-            selected_change = load_selected_change()
-            if isinstance(selected_change, RenameChange):
-                exit_with_error(
-                    _(
-                        "Cannot discard rename '{old} -> {new}' to a batch yet. "
-                        "Discard, skip, or stage the rename first."
-                    ).format(
-                        old=selected_change.old_path,
-                        new=selected_change.new_path,
-                    )
-                )
-
-        if (
-            file is None
-            and line_ids is None
-            and read_selected_change_kind() == SelectedChangeKind.GITLINK
-        ):
-            exit_with_error(
-                _("Discarding submodule pointer changes to a batch is not supported yet.")
-            )
-
-        if (
-            file is None
-            and line_ids is None
-            and read_selected_change_kind() == SelectedChangeKind.BINARY
-        ):
-            selected_change = load_selected_change()
-            if isinstance(selected_change, BinaryFileChange):
-                saved_hunks = _whole_file_batch_discarding.discard_binary_to_batch(
-                    batch_name,
-                    selected_change,
-                    quiet=quiet,
-                    auto_advance=auto_advance,
-                )
-            else:
-                saved_hunks = (
-                    _selected_change_batch_discarding.discard_selected_change_to_batch(
-                        batch_name,
-                        file_only=False,
-                        quiet=quiet,
-                        auto_advance=auto_advance,
-                    )
-                )
-        elif (
-            file is None
-            and line_ids is None
-            and read_selected_change_kind() == SelectedChangeKind.DELETION
-        ):
-            selected_change = load_selected_change()
-            if isinstance(selected_change, TextFileDeletionChange):
-                saved_hunks = (
-                    _whole_file_batch_discarding.discard_text_deletion_to_batch(
+            if (
+                file is None
+                and line_ids is None
+                and read_selected_change_kind() == SelectedChangeKind.MODE
+            ):
+                selected_change = load_selected_change()
+                if isinstance(selected_change, FileModeChange):
+                    return _whole_file_batch_discarding.discard_mode_to_batch(
                         batch_name,
                         selected_change,
                         quiet=quiet,
                         auto_advance=auto_advance,
                     )
+
+            if (
+                file is None
+                and line_ids is None
+                and read_selected_change_kind() == SelectedChangeKind.RENAME
+            ):
+                selected_change = load_selected_change()
+                if isinstance(selected_change, RenameChange):
+                    exit_with_error(
+                        _(
+                            "Cannot discard rename '{old} -> {new}' to a batch yet. "
+                            "Discard, skip, or stage the rename first."
+                        ).format(
+                            old=selected_change.old_path,
+                            new=selected_change.new_path,
+                        )
+                    )
+
+            if (
+                file is None
+                and line_ids is None
+                and read_selected_change_kind() == SelectedChangeKind.GITLINK
+            ):
+                exit_with_error(
+                    _(
+                        "Discarding submodule pointer changes to a batch is not "
+                        "supported yet."
+                    )
+                )
+
+            if (
+                file is None
+                and line_ids is None
+                and read_selected_change_kind() == SelectedChangeKind.BINARY
+            ):
+                selected_change = load_selected_change()
+                if isinstance(selected_change, BinaryFileChange):
+                    saved_hunks = (
+                        _whole_file_batch_discarding.discard_binary_to_batch(
+                            batch_name,
+                            selected_change,
+                            quiet=quiet,
+                            auto_advance=auto_advance,
+                        )
+                    )
+                else:
+                    saved_hunks = (
+                        _selected_change_batch_discarding.discard_selected_change_to_batch(
+                            batch_name,
+                            file_only=False,
+                            quiet=quiet,
+                            auto_advance=auto_advance,
+                        )
+                    )
+            elif (
+                file is None
+                and line_ids is None
+                and read_selected_change_kind() == SelectedChangeKind.DELETION
+            ):
+                selected_change = load_selected_change()
+                if isinstance(selected_change, TextFileDeletionChange):
+                    saved_hunks = (
+                        _whole_file_batch_discarding.discard_text_deletion_to_batch(
+                            batch_name,
+                            selected_change,
+                            quiet=quiet,
+                            auto_advance=auto_advance,
+                        )
+                    )
+                else:
+                    saved_hunks = (
+                        _selected_change_batch_discarding.discard_selected_change_to_batch(
+                            batch_name,
+                            file_only=False,
+                            quiet=quiet,
+                            auto_advance=auto_advance,
+                        )
+                    )
+            elif file is not None:
+                target_file = require_file_scope_target_path(file)
+                if line_ids is None:
+                    saved_hunks = (
+                        _file_scope_discard_file_to_batch.discard_file_to_batch(
+                            batch_name,
+                            target_file,
+                            quiet=quiet,
+                            advance=advance,
+                            auto_advance=auto_advance,
+                        )
+                    )
+                else:
+                    saved_hunks = (
+                        _discard_line_batching.discard_file_lines_to_batch(
+                            batch_name,
+                            target_file,
+                            line_ids,
+                            quiet=quiet,
+                            auto_advance=auto_advance,
+                        )
+                    )
+            elif line_ids is not None:
+                saved_hunks = (
+                    _discard_line_batching.discard_selected_lines_to_batch(
+                        batch_name,
+                        line_ids,
+                        quiet=quiet,
+                        auto_advance=auto_advance,
+                        journal_state=line_journal,
+                    )
                 )
             else:
                 saved_hunks = (
@@ -136,41 +196,32 @@ def execute_discard_to_batch_action(
                         auto_advance=auto_advance,
                     )
                 )
-        elif file is not None:
-            target_file = require_file_scope_target_path(file)
-            if line_ids is None:
-                saved_hunks = _file_scope_discard_file_to_batch.discard_file_to_batch(
-                    batch_name,
-                    target_file,
-                    quiet=quiet,
-                    advance=advance,
-                    auto_advance=auto_advance,
-                )
-            else:
-                saved_hunks = _discard_line_batching.discard_file_lines_to_batch(
-                    batch_name,
-                    target_file,
-                    line_ids,
-                    quiet=quiet,
-                    auto_advance=auto_advance,
-                )
-        elif line_ids is not None:
-            saved_hunks = _discard_line_batching.discard_selected_lines_to_batch(
+
+        if original_file_scope in (None, "") and line_ids is not None:
+            finish_review_scoped_line_action(review_state)
+    except BaseException as error:
+        if line_journal is not None:
+            assert line_ids is not None
+            _discard_line_batching._log_discard_lines_failure(
+                line_journal,
                 batch_name,
                 line_ids,
-                quiet=quiet,
-                auto_advance=auto_advance,
+                error,
+                rollback=(
+                    checkpoint_status.rollback
+                    if checkpoint_status is not None
+                    else "not-started"
+                ),
             )
-        else:
-            saved_hunks = (
-                _selected_change_batch_discarding.discard_selected_change_to_batch(
-                    batch_name,
-                    file_only=False,
-                    quiet=quiet,
-                    auto_advance=auto_advance,
-                )
-            )
+        raise
 
-    if original_file_scope in (None, "") and line_ids is not None:
-        finish_review_scoped_line_action(review_state)
+    if line_journal is not None:
+        assert checkpoint_status is not None
+        assert line_ids is not None
+        _discard_line_batching._log_discard_lines_success(
+            line_journal,
+            batch_name,
+            line_ids,
+            rollback=checkpoint_status.rollback,
+        )
     return saved_hunks

--- a/src/git_stage_batch/data/undo/checkpoints.py
+++ b/src/git_stage_batch/data/undo/checkpoints.py
@@ -6,6 +6,7 @@ import json
 import shutil
 import tempfile
 from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterator, Literal
 
@@ -52,6 +53,26 @@ _PENDING_CHECKPOINT: str | None = None
 _PENDING_CHECKPOINT_REPOSITORY: Path | None = None
 _PENDING_CHECKPOINT_ROLLBACK_ON_ERROR: bool | None = None
 _PENDING_CHECKPOINT_ROLLBACK_CAUSE: BaseException | None = None
+
+
+@dataclass(slots=True)
+class UndoCheckpointStatus:
+    """Observable rollback state for one checkpoint context.
+
+    A delegated rollback belongs to an enclosing transactional checkpoint;
+    the nested context cannot report that enclosing rollback's final outcome.
+    """
+
+    rollback: Literal[
+        "unavailable",
+        "not-requested",
+        "pending",
+        "delegated",
+        "completed",
+        "failed",
+        "not-needed",
+        "not-attempted",
+    ] = "not-requested"
 
 
 def _clear_pending_checkpoint() -> None:
@@ -232,7 +253,7 @@ def undo_checkpoint(
     index_paths: list[str] | None = None,
     repository_paths: list[str] | None = None,
     rollback_on_error: bool = False,
-) -> Iterator[None]:
+) -> Iterator[UndoCheckpointStatus]:
     """Bracket an undoable operation with before and after snapshots.
 
     When rollback_on_error is true, restore the before-image and discard the
@@ -241,6 +262,7 @@ def undo_checkpoint(
     """
     global _PENDING_CHECKPOINT_ROLLBACK_ON_ERROR
     global _PENDING_CHECKPOINT_ROLLBACK_CAUSE
+    status = UndoCheckpointStatus()
 
     if _PENDING_CHECKPOINT is not None:
         current_repository = get_git_directory_path()
@@ -257,8 +279,13 @@ def undo_checkpoint(
                 repository_paths=repository_paths,
                 rollback_on_error=rollback_on_error,
             )
+            if rollback_on_error:
+                # The enclosing transaction owns the shared before-image and
+                # will decide whether rollback succeeds.  Do not report this
+                # nested operation as independently pending or completed.
+                status.rollback = "delegated"
             try:
-                yield
+                yield status
             except BaseException as nested_error:
                 if rollback_on_error:
                     _PENDING_CHECKPOINT_ROLLBACK_CAUSE = nested_error
@@ -282,8 +309,12 @@ def undo_checkpoint(
     )
     if checkpoint is not None:
         _PENDING_CHECKPOINT_ROLLBACK_ON_ERROR = rollback_on_error
+        if rollback_on_error:
+            status.rollback = "pending"
+    elif rollback_on_error:
+        status.rollback = "unavailable"
     try:
-        yield
+        yield status
     except BaseException as operation_error:
         if checkpoint is not None and rollback_on_error:
             try:
@@ -291,7 +322,10 @@ def undo_checkpoint(
                     checkpoint,
                     previous_redo=previous_redo,
                 )
-            except Exception as rollback_error:
+            except BaseException as rollback_error:
+                status.rollback = "failed"
+                if not isinstance(rollback_error, Exception):
+                    raise
                 raise CommandError(
                     _(
                         "Operation failed and its automatic rollback also failed. "
@@ -303,6 +337,7 @@ def undo_checkpoint(
                         rollback_error=rollback_error,
                     )
                 ) from operation_error
+            status.rollback = "completed"
         elif checkpoint is not None:
             finalize_pending_checkpoint()
         raise
@@ -315,7 +350,10 @@ def undo_checkpoint(
                         checkpoint,
                         previous_redo=previous_redo,
                     )
-                except Exception as rollback_error:
+                except BaseException as rollback_error:
+                    status.rollback = "failed"
+                    if not isinstance(rollback_error, Exception):
+                        raise
                     raise CommandError(
                         _(
                             "Operation failed and its automatic rollback also failed. "
@@ -327,13 +365,20 @@ def undo_checkpoint(
                             rollback_error=rollback_error,
                         )
                     ) from pending_nested_error
+                status.rollback = "completed"
                 raise CommandError(
                     _(
                         "A nested transactional operation failed, so the "
                         "enclosing operation was rolled back: {error}"
                     ).format(error=pending_nested_error)
                 ) from pending_nested_error
-            finalize_pending_checkpoint()
+            try:
+                finalize_pending_checkpoint()
+            except BaseException:
+                status.rollback = "not-attempted"
+                raise
+            if rollback_on_error:
+                status.rollback = "not-needed"
 
 
 def _rollback_failed_checkpoint(

--- a/tests/commands/test_apply_from.py
+++ b/tests/commands/test_apply_from.py
@@ -14,6 +14,7 @@ import subprocess
 import pytest
 
 import git_stage_batch.commands.batch_source.apply_action as apply_action
+import git_stage_batch.commands.apply_from as apply_from_command
 from git_stage_batch.batch.state.lifecycle import create_batch
 from git_stage_batch.commands.apply_from import command_apply_from_batch
 from git_stage_batch.commands.redo import command_redo
@@ -120,10 +121,20 @@ class TestCommandApplyFromBatch:
         assert "line 2" in content
         assert "line 3" in content
 
+    @pytest.mark.parametrize(
+        ("failure_type", "expected_type"),
+        [
+            (OSError, CommandError),
+            (KeyboardInterrupt, KeyboardInterrupt),
+        ],
+        ids=("write-error", "cancellation"),
+    )
     def test_multi_file_write_failure_rolls_back_earlier_applies(
         self,
         temp_git_repo,
         monkeypatch,
+        failure_type,
+        expected_type,
     ):
         """A failed later file should roll back every worktree write."""
         for name in ("a.txt", "b.txt"):
@@ -150,13 +161,14 @@ class TestCommandApplyFromBatch:
             (temp_git_repo / name).write_text(f"{name} base\n")
 
         original_write = apply_action._text_file_actions.write_text_file_to_worktree
+        journal_events = []
         calls = 0
 
         def fail_second_write(*args, **kwargs):
             nonlocal calls
             calls += 1
             if calls == 2:
-                raise OSError("injected write failure")
+                raise failure_type("injected write failure")
             return original_write(*args, **kwargs)
 
         monkeypatch.setattr(
@@ -164,12 +176,20 @@ class TestCommandApplyFromBatch:
             "write_text_file_to_worktree",
             fail_second_write,
         )
+        monkeypatch.setattr(
+            apply_from_command,
+            "log_journal",
+            lambda operation, **fields: journal_events.append((operation, fields)),
+        )
 
-        with pytest.raises(CommandError, match="injected write failure"):
+        with pytest.raises(expected_type, match="injected write failure"):
             command_apply_from_batch("test-batch")
 
         assert (temp_git_repo / "a.txt").read_text() == "a.txt base\n"
         assert (temp_git_repo / "b.txt").read_text() == "b.txt base\n"
+        assert journal_events[-1][0] == "apply_from_batch_failed"
+        assert journal_events[-1][1]["stage"] == "publication"
+        assert journal_events[-1][1]["rollback"] == "completed"
 
     def test_apply_from_batch_does_not_stage(self, temp_git_repo):
         """Test that apply does not stage changes to index."""

--- a/tests/commands/test_journal.py
+++ b/tests/commands/test_journal.py
@@ -4,12 +4,16 @@ from __future__ import annotations
 
 import json
 import subprocess
+from contextlib import contextmanager
 from types import SimpleNamespace
 
 import pytest
 
 from git_stage_batch.commands.journal import command_journal
 import git_stage_batch.commands.apply_from as apply_from
+from git_stage_batch.commands.selection import discard_line_batching
+from git_stage_batch.commands.selection import discard_to_batch_action
+from git_stage_batch.data.undo.checkpoints import UndoCheckpointStatus
 from git_stage_batch.exceptions import CommandError
 from git_stage_batch.utils.journal import JOURNAL_LEVEL_ENV, JOURNAL_PATH_ENV, flush_journal, log_journal
 from tests.journal_helpers import reset_journal_state
@@ -180,3 +184,104 @@ def test_apply_failure_logs_stage_and_rollback_outcome(monkeypatch):
     assert events[1][1]["stage"] == "publication"
     assert events[1][1]["rollback"] == "completed"
     assert events[1][1]["error_type"] == "CommandError"
+
+
+def test_discard_line_failure_has_terminal_journal_event(
+    temp_git_repo,
+    monkeypatch,
+):
+    """A failed line discard must not leave an unmatched start event."""
+    monkeypatch.setattr(
+        discard_line_batching,
+        "require_selected_hunk",
+        lambda: (_ for _ in ()).throw(RuntimeError("selection failed")),
+    )
+
+    with pytest.raises(RuntimeError, match="selection failed"):
+        discard_line_batching.discard_selected_lines_to_batch(
+            "saved",
+            "1",
+            quiet=True,
+        )
+
+    flush_journal()
+    journal_path = temp_git_repo / "state" / "journal.jsonl"
+    entries = [json.loads(line) for line in journal_path.read_text().splitlines()]
+    operations = [entry["operation"] for entry in entries]
+
+    assert operations == [
+        "discard_lines_to_batch_start",
+        "discard_lines_to_batch_failed",
+    ]
+    assert entries[-1]["fields"]["stage"] == "selection"
+    assert entries[-1]["fields"]["rollback"] == "not-started"
+
+
+def test_discard_line_terminal_event_waits_for_transaction_rollback(
+    monkeypatch,
+):
+    """Command-level failure logging must observe the completed rollback."""
+    events = []
+
+    @contextmanager
+    def transactional_checkpoint(*_args, **_kwargs):
+        status = UndoCheckpointStatus(rollback="pending")
+        try:
+            yield status
+        except BaseException:
+            status.rollback = "completed"
+            raise
+
+    def fail_discard(*_args, journal_state, **_kwargs):
+        journal_state.stage = "worktree-publication"
+        raise OSError("injected write failure")
+
+    monkeypatch.setattr(
+        discard_to_batch_action,
+        "validate_batch_name",
+        lambda _name: None,
+    )
+    monkeypatch.setattr(
+        discard_to_batch_action,
+        "load_selected_change",
+        lambda: SimpleNamespace(),
+    )
+    monkeypatch.setattr(
+        discard_to_batch_action,
+        "checkpoint_paths_for_file_scope",
+        lambda *_args: [],
+    )
+    monkeypatch.setattr(
+        discard_to_batch_action,
+        "undo_checkpoint",
+        transactional_checkpoint,
+    )
+    monkeypatch.setattr(
+        discard_line_batching,
+        "discard_selected_lines_to_batch",
+        fail_discard,
+    )
+    monkeypatch.setattr(
+        discard_line_batching,
+        "log_journal",
+        lambda operation, **fields: events.append((operation, fields)),
+    )
+
+    with pytest.raises(OSError, match="injected write failure"):
+        discard_to_batch_action.execute_discard_to_batch_action(
+            batch_name="saved",
+            line_ids="1",
+            file=None,
+            original_file_scope=None,
+            review_state=None,
+            quiet=True,
+            advance=True,
+            auto_advance=None,
+        )
+
+    assert [operation for operation, _fields in events] == [
+        "discard_lines_to_batch_start",
+        "discard_lines_to_batch_failed",
+    ]
+    assert events[1][1]["stage"] == "worktree-publication"
+    assert events[1][1]["rollback"] == "completed"

--- a/tests/commands/test_journal.py
+++ b/tests/commands/test_journal.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import json
 import subprocess
+from types import SimpleNamespace
 
 import pytest
 
 from git_stage_batch.commands.journal import command_journal
+import git_stage_batch.commands.apply_from as apply_from
 from git_stage_batch.exceptions import CommandError
 from git_stage_batch.utils.journal import JOURNAL_LEVEL_ENV, JOURNAL_PATH_ENV, flush_journal, log_journal
 from tests.journal_helpers import reset_journal_state
@@ -53,3 +55,128 @@ def test_journal_command_purges_data(temp_git_repo, capsys):
 def test_all_requires_purge(temp_git_repo):
     with pytest.raises(CommandError, match="--all"):
         command_journal(all_repositories=True)
+
+
+def test_apply_success_has_correlated_terminal_journal_event(monkeypatch):
+    """Apply start and success events must share an operation identifier."""
+    events = []
+    context = SimpleNamespace(
+        selector=SimpleNamespace(candidate_ordinal=None),
+        batch_name="resolved",
+    )
+    selection = SimpleNamespace(
+        file=None,
+        files={"file.txt": {}},
+        selected_ids=None,
+        selection_ids=None,
+    )
+    monkeypatch.setattr(apply_from, "require_git_repository", lambda: None)
+    monkeypatch.setattr(
+        apply_from._action_context,
+        "resolve_batch_source_action_context",
+        lambda *_args, **_kwargs: context,
+    )
+    monkeypatch.setattr(
+        apply_from._action_selection,
+        "resolve_apply_action_selection",
+        lambda *_args, **_kwargs: selection,
+    )
+
+    def apply_action(*, journal_progress, **_kwargs):
+        journal_progress("completion", "delegated")
+
+    monkeypatch.setattr(apply_from._apply_action, "execute_apply_action", apply_action)
+    monkeypatch.setattr(
+        apply_from,
+        "log_journal",
+        lambda operation, **fields: events.append((operation, fields)),
+    )
+
+    apply_from.command_apply_from_batch("saved")
+
+    assert [operation for operation, _fields in events] == [
+        "apply_from_batch_start",
+        "apply_from_batch_success",
+    ]
+    assert events[0][1]["operation_id"] == events[1][1]["operation_id"]
+    assert events[0][1]["batch_selector"] == "saved"
+    assert events[1][1]["batch_selector"] == "saved"
+    assert events[1][1]["resolved_batch_name"] == "resolved"
+    assert events[1][1]["stage"] == "complete"
+    assert events[1][1]["rollback"] == "delegated"
+
+
+def test_apply_start_redacts_requested_file_path(temp_git_repo, monkeypatch):
+    """Metadata-only apply diagnostics must not retain a requested path."""
+    requested_path = "secret/customer.txt"
+    monkeypatch.setattr(
+        apply_from,
+        "require_git_repository",
+        lambda: (_ for _ in ()).throw(CommandError("stop after start")),
+    )
+
+    with pytest.raises(CommandError, match="stop after start"):
+        apply_from.command_apply_from_batch(
+            "saved",
+            file=requested_path,
+        )
+
+    flush_journal()
+    journal_path = temp_git_repo / "state" / "journal.jsonl"
+    serialized = journal_path.read_text()
+    entries = [json.loads(line) for line in serialized.splitlines()]
+
+    requested_file = entries[0]["fields"]["requested_file_path"]
+    assert requested_file["path_id"]
+    assert requested_path not in serialized
+
+
+def test_apply_failure_logs_stage_and_rollback_outcome(monkeypatch):
+    """Apply failures must report where they stopped and whether rollback ran."""
+    events = []
+    context = SimpleNamespace(
+        selector=SimpleNamespace(candidate_ordinal=None),
+        batch_name="resolved",
+    )
+    selection = SimpleNamespace(
+        file=None,
+        files={"file.txt": {}},
+        selected_ids=None,
+        selection_ids=None,
+    )
+    monkeypatch.setattr(apply_from, "require_git_repository", lambda: None)
+    monkeypatch.setattr(
+        apply_from._action_context,
+        "resolve_batch_source_action_context",
+        lambda *_args, **_kwargs: context,
+    )
+    monkeypatch.setattr(
+        apply_from._action_selection,
+        "resolve_apply_action_selection",
+        lambda *_args, **_kwargs: selection,
+    )
+
+    def fail_apply(*, journal_progress, **_kwargs):
+        journal_progress("publication", "completed")
+        raise CommandError("injected failure")
+
+    monkeypatch.setattr(apply_from._apply_action, "execute_apply_action", fail_apply)
+    monkeypatch.setattr(
+        apply_from,
+        "log_journal",
+        lambda operation, **fields: events.append((operation, fields)),
+    )
+
+    with pytest.raises(CommandError, match="injected failure"):
+        apply_from.command_apply_from_batch("saved")
+
+    assert [operation for operation, _fields in events] == [
+        "apply_from_batch_start",
+        "apply_from_batch_failed",
+    ]
+    assert events[0][1]["operation_id"] == events[1][1]["operation_id"]
+    assert events[1][1]["batch_selector"] == "saved"
+    assert events[1][1]["resolved_batch_name"] == "resolved"
+    assert events[1][1]["stage"] == "publication"
+    assert events[1][1]["rollback"] == "completed"
+    assert events[1][1]["error_type"] == "CommandError"

--- a/tests/commands/test_journal.py
+++ b/tests/commands/test_journal.py
@@ -11,6 +11,7 @@ import pytest
 
 from git_stage_batch.commands.journal import command_journal
 import git_stage_batch.commands.apply_from as apply_from
+from git_stage_batch.commands.file_scope import discard_to_batch
 from git_stage_batch.commands.selection import discard_line_batching
 from git_stage_batch.commands.selection import discard_to_batch_action
 from git_stage_batch.data.undo.checkpoints import UndoCheckpointStatus
@@ -285,3 +286,50 @@ def test_discard_line_terminal_event_waits_for_transaction_rollback(
     ]
     assert events[1][1]["stage"] == "worktree-publication"
     assert events[1][1]["rollback"] == "completed"
+
+
+def test_multi_file_discard_distinguishes_collection_and_single_file_events(
+    temp_git_repo,
+    monkeypatch,
+):
+    """Nested whole-file discards need distinct reconstructable event names."""
+    operations = []
+    monkeypatch.setattr(discard_to_batch, "require_git_repository", lambda: None)
+    monkeypatch.setattr(discard_to_batch, "ensure_state_directory_exists", lambda: None)
+    monkeypatch.setattr(discard_to_batch, "auto_add_untracked_files", lambda _files: None)
+    monkeypatch.setattr(discard_to_batch, "batch_exists", lambda _name: True)
+    monkeypatch.setattr(discard_to_batch, "read_batch_metadata", lambda _name: {})
+    monkeypatch.setattr(discard_to_batch, "read_text_file_line_set", lambda _path: set())
+    monkeypatch.setattr(
+        discard_to_batch,
+        "_collect_text_file_discard_inputs",
+        lambda *_args, **_kwargs: discard_to_batch._CollectedTextFileDiscards(
+            inputs_by_file={},
+            files_with_text_patches=set(),
+        ),
+    )
+    monkeypatch.setattr(
+        discard_to_batch,
+        "log_journal",
+        lambda operation, **_fields: operations.append(operation),
+    )
+
+    def discard_one(*_args, **_kwargs):
+        operations.append("discard_file_to_batch_start")
+        operations.append("discard_file_to_batch_end")
+        return 0
+
+    monkeypatch.setattr(discard_to_batch, "discard_file_to_batch", discard_one)
+
+    discard_to_batch.discard_files_to_batch(
+        "saved",
+        ["fallback.dat"],
+        advance=False,
+    )
+
+    assert operations == [
+        "discard_files_to_batch_file_start",
+        "discard_file_to_batch_start",
+        "discard_file_to_batch_end",
+        "discard_files_to_batch_file_end",
+    ]

--- a/tests/commands/test_undo.py
+++ b/tests/commands/test_undo.py
@@ -319,12 +319,13 @@ def test_atomic_failed_operation_rolls_back_before_propagating(temp_git_repo):
     get_session_directory_path().mkdir(parents=True, exist_ok=True)
     previous_checkpoint = current_undo_commit()
 
+    status = None
     with pytest.raises(RuntimeError, match="operation failed"):
         with undo_checkpoint(
             "change target",
             worktree_paths=["target.txt"],
             rollback_on_error=True,
-        ):
+        ) as status:
             target.write_text("partial mutation\n")
             subprocess.run(
                 ["git", "add", "target.txt"],
@@ -337,6 +338,41 @@ def test_atomic_failed_operation_rolls_back_before_propagating(temp_git_repo):
     assert target.read_text() == "before\n"
     assert _show_index_path(temp_git_repo, "target.txt") == b"before\n"
     assert current_undo_commit() == previous_checkpoint
+    assert status is not None
+    assert status.rollback == "completed"
+
+
+def test_transaction_status_preserves_unavailable_without_active_session(
+    temp_git_repo,
+):
+    """A missing checkpoint store must not be reported as an unused rollback."""
+    with undo_checkpoint(
+        "change target",
+        worktree_paths=["target.txt"],
+        rollback_on_error=True,
+    ) as status:
+        pass
+
+    assert status.rollback == "unavailable"
+
+    with undo_checkpoint("ordinary change", worktree_paths=[]) as ordinary_status:
+        pass
+
+    assert ordinary_status.rollback == "not-requested"
+
+
+def test_nontransactional_checkpoint_status_remains_not_requested(
+    temp_git_repo,
+):
+    """Successful ordinary and nested checkpoints must not imply rollback."""
+    get_session_directory_path().mkdir(parents=True, exist_ok=True)
+
+    with undo_checkpoint("outer", worktree_paths=[]) as outer_status:
+        with undo_checkpoint("inner", worktree_paths=[]) as inner_status:
+            pass
+
+    assert inner_status.rollback == "not-requested"
+    assert outer_status.rollback == "not-requested"
 
 
 @pytest.mark.parametrize(
@@ -400,13 +436,16 @@ def test_nested_transaction_uses_compatible_outer_checkpoint(temp_git_repo):
         "outer",
         worktree_paths=["target.txt"],
         rollback_on_error=True,
-    ):
+    ) as outer_status:
         with undo_checkpoint(
             "inner",
             worktree_paths=["target.txt"],
             rollback_on_error=True,
-        ):
+        ) as inner_status:
             target.write_text("after\n")
+
+    assert inner_status.rollback == "delegated"
+    assert outer_status.rollback == "not-needed"
 
     undo_last_checkpoint()
 
@@ -419,6 +458,7 @@ def test_caught_nested_transaction_error_rolls_back_outer_checkpoint(temp_git_re
     get_session_directory_path().mkdir(parents=True, exist_ok=True)
     previous_checkpoint = current_undo_commit()
 
+    inner_status = None
     with pytest.raises(CommandError, match="enclosing operation was rolled back"):
         with undo_checkpoint(
             "outer",
@@ -431,7 +471,7 @@ def test_caught_nested_transaction_error_rolls_back_outer_checkpoint(temp_git_re
                     "inner",
                     worktree_paths=["target.txt"],
                     rollback_on_error=True,
-                ):
+                ) as inner_status:
                     target.write_text("inner mutation\n")
                     raise RuntimeError("inner failed")
             except RuntimeError:
@@ -439,6 +479,8 @@ def test_caught_nested_transaction_error_rolls_back_outer_checkpoint(temp_git_re
 
     assert target.read_text() == "before\n"
     assert current_undo_commit() == previous_checkpoint
+    assert inner_status is not None
+    assert inner_status.rollback == "delegated"
 
 
 def test_failed_checkpoint_finalization_requires_force(temp_git_repo, monkeypatch):


### PR DESCRIPTION
Apply, discard, and undo operations already emit journal records, but callers
cannot consistently correlate an operation with its terminal outcome.

Failures can therefore leave incomplete-looking records, nested rollback state
can remain pending, and metadata-only journaling can retain a requested path
under a field name that bypasses path redaction.

This series records terminal success and failure events for apply and selected-
line discard operations, makes per-file discard outcomes explicit, finalizes
undo status defensively, and names requested paths so journal sanitization
redacts them. Regression coverage checks correlation, rollback timing,
multi-file outcomes, compatibility fields, and metadata-only path privacy.

Journal consumers now receive a complete, privacy-preserving account of every
transaction outcome.
