### PR TITLE
project: Require Git 2.39

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ This project uses [uv](https://docs.astral.sh/uv/) for development workflow and 
 
 **Requirements:**
 - Python 3.10 through 3.14
-- Git 2.31 or newer
+- Git 2.39 or newer
 - uv (for development)
 - meson and ninja-build (install via your system package manager)
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ pip install git-stage-batch
 ## Requirements
 
 - Python 3.10 or newer; CI covers current releases through Python 3.14
-- Git 2.31 or newer
+- Git 2.39 or newer
 - A POSIX operating system; Linux and macOS are tested in CI. Native Windows
   is not supported.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -72,7 +72,7 @@ This runs the tool without permanently installing it.
 
 - **Python 3.10 or newer.** CI covers current releases through Python 3.14;
   newer releases are allowed before they enter the tested matrix.
-- **Git 2.31 or newer** available on `PATH`
+- **Git 2.39 or newer** available on `PATH`
 - **POSIX operating system.** Linux and macOS are tested in CI; native Windows
   is not supported because repository locking, signals, symlinks, and terminal
   process control currently use POSIX facilities.


### PR DESCRIPTION
The CI lane and architecture contract now enforce Git 2.39, because Git 2.31
rejects the index-only three-way patch application used by current publication
planning.

Complete that support-policy change in the user-facing requirements. Require
Git 2.39 at runtime, use it for contributor environments, and align the README
and installation guide with the tested support floor.

The prerequisite gate repair landed independently in #394. After rebasing onto
that merge, this PR contains only the runtime, development, and documentation
requirements.

Validation on the rebased head includes the complete local lint, dead-code,
type-hygiene, strict type, test, benchmark, SHA-256 repository, build, wheel
installation, and source-distribution installation gates. The full suite passes
with 3660 tests and 12 skips.
