### PR TITLE
ci: Restore the supported-version and bounded-heap gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
   minimum-git:
     runs-on: ubuntu-latest
     env:
-      GIT_VERSION: "2.31.0"
+      GIT_VERSION: "2.39.0"
 
     steps:
       - uses: actions/checkout@v4

--- a/tests/architecture/test_support_contract.py
+++ b/tests/architecture/test_support_contract.py
@@ -25,7 +25,7 @@ def test_ci_exercises_minimum_git():
     """CI should cover the minimum supported Git release."""
     workflow = _read_project_file(".github/workflows/ci.yml")
 
-    assert 'GIT_VERSION: "2.31.0"' in workflow
+    assert 'GIT_VERSION: "2.39.0"' in workflow
     assert 'repository: git/git' in workflow
     assert 'run: test "$(git version)" = "git version ${GIT_VERSION}"' in workflow
 

--- a/tests/batch/line_matching/test_comparison.py
+++ b/tests/batch/line_matching/test_comparison.py
@@ -16,7 +16,8 @@ from git_stage_batch.batch.line_matching.comparison import (
 from git_stage_batch.batch.line_matching.match import match_lines
 
 
-_LINE_SCALE_HEAP_LIMIT = 256 * 1024
+_LINE_SCALE_TEST_COUNTS = (1024, 8192)
+_LINE_SCALE_HEAP_GROWTH_LIMIT = 32 * 1024
 
 
 def test_derive_semantic_change_runs_accepts_non_list_sequences(line_sequence):
@@ -125,23 +126,27 @@ def test_trusted_matching_fast_path_matches_bidirectional_reference():
 
 def test_large_unmapped_disjoint_gaps_avoid_line_scale_python_heap():
     """Large reciprocal checks should index gaps in mapped storage."""
-    line_count = 8192
-    midpoint = line_count // 2
-    source = [f"old-{index}\n".encode() for index in range(line_count)]
-    target = [f"new-{index}\n".encode() for index in range(line_count)]
-    source.insert(midpoint, b"shared anchor\n")
-    target.insert(midpoint, b"shared anchor\n")
+    heap_peaks = []
+    for line_count in _LINE_SCALE_TEST_COUNTS:
+        midpoint = line_count // 2
+        source = [f"old-{index}\n".encode() for index in range(line_count)]
+        target = [f"new-{index}\n".encode() for index in range(line_count)]
+        source.insert(midpoint, b"shared anchor\n")
+        target.insert(midpoint, b"shared anchor\n")
 
-    gc.collect()
-    tracemalloc.start()
-    try:
-        runs = derive_semantic_change_runs(source, target)
-        _current_heap, peak_heap = tracemalloc.get_traced_memory()
-    finally:
-        tracemalloc.stop()
+        gc.collect()
+        tracemalloc.start()
+        try:
+            runs = derive_semantic_change_runs(source, target)
+            _current_heap, peak_heap = tracemalloc.get_traced_memory()
+        finally:
+            tracemalloc.stop()
 
-    assert len(runs) == 2
-    assert peak_heap < _LINE_SCALE_HEAP_LIMIT
+        assert len(runs) == 2
+        heap_peaks.append(peak_heap)
+
+    small_peak, large_peak = heap_peaks
+    assert large_peak < small_peak + _LINE_SCALE_HEAP_GROWTH_LIMIT
 
 
 def test_stream_semantic_change_runs_closes_matching_pairs(monkeypatch):

--- a/tests/batch/line_matching/test_match_workspace.py
+++ b/tests/batch/line_matching/test_match_workspace.py
@@ -14,7 +14,8 @@ from git_stage_batch.batch.line_matching.match_workspace import MatcherWorkspace
 from git_stage_batch.core.mapped_storage import MAPPED_STORAGE_OFFLOAD_SIZE_THRESHOLD
 
 
-_LINE_SCALE_HEAP_LIMIT = 256 * 1024
+_LINE_SCALE_TEST_COUNTS = (1024, 8192)
+_LINE_SCALE_HEAP_GROWTH_LIMIT = 32 * 1024
 
 
 def test_matcher_workspace_tracks_and_closes_resources():
@@ -104,40 +105,44 @@ def test_match_lines_closes_first_mapping_if_second_allocation_fails(
 @pytest.mark.parametrize("target_stride", [1, 9])
 def test_lis_target_ranking_does_not_use_line_scale_python_heap(target_stride):
     """LIS target ranks should stay in mapped storage for large alignments."""
-    line_count = 8192
-    target_end = line_count * target_stride
+    heap_peaks = []
+    for line_count in _LINE_SCALE_TEST_COUNTS:
+        target_end = line_count * target_stride
 
-    with MatcherWorkspace() as workspace:
-        pairs = workspace.record_vector(line_count, "QQ")
-        for source_index in range(line_count):
-            pairs.append(
-                (
-                    source_index,
-                    (line_count - source_index - 1) * target_stride,
+        with MatcherWorkspace() as workspace:
+            pairs = workspace.record_vector(line_count, "QQ")
+            for source_index in range(line_count):
+                pairs.append(
+                    (
+                        source_index,
+                        (line_count - source_index - 1) * target_stride,
+                    )
                 )
-            )
 
-        gc.collect()
-        tracemalloc.start()
-        try:
-            anchors = match_module._longest_increasing_subsequence_records(
-                pairs,
-                0,
-                target_end,
-                workspace,
-            )
-            _current_heap, peak_heap = tracemalloc.get_traced_memory()
-        finally:
-            tracemalloc.stop()
+            gc.collect()
+            tracemalloc.start()
+            try:
+                anchors = match_module._longest_increasing_subsequence_records(
+                    pairs,
+                    0,
+                    target_end,
+                    workspace,
+                )
+                _current_heap, peak_heap = tracemalloc.get_traced_memory()
+            finally:
+                tracemalloc.stop()
 
-        try:
-            assert tuple(anchors) == (
-                (0, (line_count - 1) * target_stride),
-            )
-        finally:
-            workspace.close_resource(anchors)
+            try:
+                assert tuple(anchors) == (
+                    (0, (line_count - 1) * target_stride),
+                )
+            finally:
+                workspace.close_resource(anchors)
 
-    assert peak_heap < _LINE_SCALE_HEAP_LIMIT
+        heap_peaks.append(peak_heap)
+
+    small_peak, large_peak = heap_peaks
+    assert large_peak < small_peak + _LINE_SCALE_HEAP_GROWTH_LIMIT
 
 
 def test_dense_lis_target_ranking_does_not_sort_candidates(monkeypatch):

--- a/tests/batch/source/test_advancement.py
+++ b/tests/batch/source/test_advancement.py
@@ -35,7 +35,8 @@ from git_stage_batch.core.models import LineEntry
 from git_stage_batch.core.buffer import LineBuffer
 
 
-_LINE_SCALE_HEAP_LIMIT = 256 * 1024
+_LINE_SCALE_TEST_COUNTS = (1024, 8192)
+_LINE_SCALE_HEAP_GROWTH_LIMIT = 32 * 1024
 
 
 class _IterationGuardedLineSelection:
@@ -188,38 +189,42 @@ def test_batch_source_lineage_expands_complete_owned_replacements():
 
 def test_fragmented_source_lineage_translation_avoids_line_scale_python_heap():
     """Fragmented provenance should coalesce before entering heap storage."""
-    line_count = 8192
-    selection = LineRanges.from_ranges(((1, line_count),))
+    heap_peaks = []
+    for line_count in _LINE_SCALE_TEST_COUNTS:
+        selection = LineRanges.from_ranges(((1, line_count),))
 
-    with BatchSourceLineage() as lineage:
-        for source_line in range(1, line_count + 1):
-            new_start = source_line * 2 - 1
-            lineage.append_source_run(
-                LineageRun(
-                    old_start=source_line,
-                    old_end=source_line,
-                    new_start=new_start,
+        with BatchSourceLineage() as lineage:
+            for source_line in range(1, line_count + 1):
+                new_start = source_line * 2 - 1
+                lineage.append_source_run(
+                    LineageRun(
+                        old_start=source_line,
+                        old_end=source_line,
+                        new_start=new_start,
+                    )
                 )
-            )
-            lineage.append_source_expansion(
-                SourceSelectionExpansion(
-                    source_start=source_line,
-                    source_end=source_line,
-                    new_start=new_start,
-                    new_end=new_start + 1,
+                lineage.append_source_expansion(
+                    SourceSelectionExpansion(
+                        source_start=source_line,
+                        source_end=source_line,
+                        new_start=new_start,
+                        new_end=new_start + 1,
+                    )
                 )
-            )
 
-        gc.collect()
-        tracemalloc.start()
-        try:
-            translated = lineage.translate_source_selection(selection)
-            _current_heap, peak_heap = tracemalloc.get_traced_memory()
-        finally:
-            tracemalloc.stop()
+            gc.collect()
+            tracemalloc.start()
+            try:
+                translated = lineage.translate_source_selection(selection)
+                _current_heap, peak_heap = tracemalloc.get_traced_memory()
+            finally:
+                tracemalloc.stop()
 
-    assert translated.ranges() == ((1, line_count * 2),)
-    assert peak_heap < _LINE_SCALE_HEAP_LIMIT
+        assert translated.ranges() == ((1, line_count * 2),)
+        heap_peaks.append(peak_heap)
+
+    small_peak, large_peak = heap_peaks
+    assert large_peak < small_peak + _LINE_SCALE_HEAP_GROWTH_LIMIT
 
 
 def test_batch_source_lineage_finds_unmapped_source_ranges():
@@ -622,34 +627,40 @@ def test_advance_source_tracks_contiguous_lineage_as_runs():
 
 def test_advance_source_avoids_line_scale_python_heap():
     """Required source coordinates should remain range- and storage-backed."""
-    line_count = 8192
-    source_content = b"".join(
-        f"line-{line_index:08d}\n".encode()
-        for line_index in range(line_count)
-    )
-    ownership = BatchOwnership.from_presence_lines([f"1-{line_count}"], [])
+    heap_peaks = []
+    for line_count in _LINE_SCALE_TEST_COUNTS:
+        source_content = b"".join(
+            f"line-{line_index:08d}\n".encode()
+            for line_index in range(line_count)
+        )
+        ownership = BatchOwnership.from_presence_lines([f"1-{line_count}"], [])
 
-    with (
-        LineBuffer.from_bytes(source_content) as old_lines,
-        LineBuffer.from_bytes(source_content) as working_lines,
-    ):
-        assert len(old_lines) == line_count
-        assert len(working_lines) == line_count
-        gc.collect()
-        tracemalloc.start()
-        try:
-            with advance_source_lines_preserving_existing_presence(
-                old_lines,
-                working_lines,
-                ownership,
-            ) as source_with_provenance:
-                result_byte_count = source_with_provenance.source_buffer.byte_count
-            _current_heap, peak_heap = tracemalloc.get_traced_memory()
-        finally:
-            tracemalloc.stop()
+        with (
+            LineBuffer.from_bytes(source_content) as old_lines,
+            LineBuffer.from_bytes(source_content) as working_lines,
+        ):
+            assert len(old_lines) == line_count
+            assert len(working_lines) == line_count
+            gc.collect()
+            tracemalloc.start()
+            try:
+                with advance_source_lines_preserving_existing_presence(
+                    old_lines,
+                    working_lines,
+                    ownership,
+                ) as source_with_provenance:
+                    result_byte_count = (
+                        source_with_provenance.source_buffer.byte_count
+                    )
+                _current_heap, peak_heap = tracemalloc.get_traced_memory()
+            finally:
+                tracemalloc.stop()
 
-    assert result_byte_count == len(source_content)
-    assert peak_heap < _LINE_SCALE_HEAP_LIMIT
+        assert result_byte_count == len(source_content)
+        heap_peaks.append(peak_heap)
+
+    small_peak, large_peak = heap_peaks
+    assert large_peak < small_peak + _LINE_SCALE_HEAP_GROWTH_LIMIT
 
 
 def test_advance_source_context_closes_lineage():


### PR DESCRIPTION
The repository's current implementation uses `git apply --cached --3way`, which
Git 2.31 rejects. Raise the minimum-Git CI lane and its architecture contract to
2.39 so pull requests exercise the supported command combination.

The line-matching and source-advancement regression tests also currently enforce
bounded Python heap use with an absolute 256 KiB peak limit at 8,192 lines.
CPython 3.14 has higher constant tracemalloc bookkeeping overhead: the affected
paths remain flat as inputs grow, but their constant peaks exceed that limit.

Measure each path at 1,024 and 8,192 lines and require the larger input to add
less than 32 KiB of peak Python heap. This continues to reject per-line Python
containers while making the invariant independent of interpreter constant
overhead.

This PR deliberately carries only the CI and support-contract portion of the
Git 2.39 policy so it can land independently and restore a green gate. The
runtime, development, and documentation requirements remain in the follow-up
policy PR.

Validation includes the complete Python 3.10 suite, all lint and static-analysis
checks, the matching benchmark, the affected modules under Python 3.14, and
focused bounded-heap runs under both Python 3.10 and 3.14.
