### PR TITLE
project: Close command and metadata edge cases

### DIFF
--- a/src/git_stage_batch/batch/merge/absence_constraints.py
+++ b/src/git_stage_batch/batch/merge/absence_constraints.py
@@ -207,7 +207,7 @@ def absence_choices_for_claim(
         before_line = (
             None
             if position + len(forbidden_sequence) >= len(entries)
-            else position + 1
+            else position + len(forbidden_sequence) + 1
         )
         choices.append(
             AbsenceChoice(

--- a/src/git_stage_batch/batch/state/metadata_schema.py
+++ b/src/git_stage_batch/batch/state/metadata_schema.py
@@ -614,12 +614,13 @@ def _validate_hex_object_id(
 ) -> None:
     if not isinstance(value, str) or len(value) not in lengths:
         _invalid(batch_name, f"'{field}' must be a hexadecimal object ID")
-    try:
-        int(value, 16)
-    except ValueError as error:
+    if any(
+        character not in "0123456789abcdefABCDEF"
+        for character in value
+    ):
         raise BatchMetadataError(
             f"Batch '{batch_name}' metadata field '{field}' is not hexadecimal"
-        ) from error
+        )
 
 
 def _field_list(fields: set[str] | frozenset[str]) -> str:

--- a/src/git_stage_batch/cli/pager.py
+++ b/src/git_stage_batch/cli/pager.py
@@ -90,6 +90,10 @@ class _PagerStdout:
     def writable(self) -> bool:
         return True
 
+    @property
+    def closed(self) -> bool:
+        return self._stream.closed
+
     def close(self) -> None:
         if self._stream.closed:
             return

--- a/src/git_stage_batch/cli/quick_actions.py
+++ b/src/git_stage_batch/cli/quick_actions.py
@@ -15,11 +15,24 @@ QUICK_ACTIONS = {
 
 
 def expand_quick_actions(args: list[str]) -> list[str]:
-    """Expand shortcut arguments into their long command forms."""
-    expanded = []
-    for arg in args:
-        if arg in QUICK_ACTIONS:
-            expanded.extend(QUICK_ACTIONS[arg])
-        else:
-            expanded.append(arg)
-    return expanded
+    """Expand a shortcut only when it occupies the subcommand position."""
+    command_index = 0
+    while command_index < len(args):
+        argument = args[command_index]
+        if argument == "-C":
+            command_index += 2
+            continue
+        if argument.startswith("-C") and argument != "-C":
+            command_index += 1
+            continue
+        if argument == "-i":
+            command_index += 1
+            continue
+        break
+
+    if command_index >= len(args):
+        return list(args)
+    expansion = QUICK_ACTIONS.get(args[command_index])
+    if expansion is None:
+        return list(args)
+    return [*args[:command_index], *expansion, *args[command_index + 1:]]

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -70,10 +70,14 @@ def command_include(
         skipped_ids = read_line_ids_file(get_processed_skip_ids_file_path())
         line_changes = load_line_changes_from_state()
         if skipped_ids and line_changes is not None:
-            remaining_ids = line_changes.changed_line_ids()
-            if remaining_ids:
+            remaining_selection = ",".join(
+                str(line.id)
+                for line in line_changes.lines
+                if line.id is not None and line.id not in skipped_ids
+            )
+            if remaining_selection:
                 _include_line_action.include_live_line_selection(
-                    ",".join(str(line_id) for line_id in remaining_ids),
+                    remaining_selection,
                     review_state=None,
                     auto_advance=auto_advance,
                     quiet=quiet,

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -84,6 +84,7 @@ def command_include(
                     operation="include",
                 )
                 return
+            return
 
     _selected_change_staging.include_selected_change(
         quiet=quiet,

--- a/src/git_stage_batch/commands/include.py
+++ b/src/git_stage_batch/commands/include.py
@@ -63,7 +63,7 @@ def command_include(
     refuse_bare_action_after_auto_advance_disabled("include")
 
     if read_selected_change_kind() == SelectedChangeKind.FILE:
-        command_include_file("", auto_advance=auto_advance)
+        command_include_file("", quiet=quiet, auto_advance=auto_advance)
         return
 
     if read_selected_change_kind() == SelectedChangeKind.HUNK:

--- a/src/git_stage_batch/commands/skip.py
+++ b/src/git_stage_batch/commands/skip.py
@@ -49,7 +49,7 @@ def command_skip(
     refuse_bare_action_after_auto_advance_disabled("skip")
 
     if read_selected_change_kind() == SelectedChangeKind.FILE:
-        command_skip_file("", auto_advance=auto_advance)
+        command_skip_file("", quiet=quiet, auto_advance=auto_advance)
         return
 
     _selected_change_skipping.skip_selected_change(

--- a/src/git_stage_batch/data/batch_refs.py
+++ b/src/git_stage_batch/data/batch_refs.py
@@ -145,15 +145,15 @@ def _validate_snapshot_object_id(
                 field=field,
             )
         )
-    try:
-        int(value, 16)
-    except ValueError as error:
+    if any(
+        character not in "0123456789abcdefABCDEF"
+        for character in value
+    ):
         _invalid_snapshot(
             _("invalid: batch {batch!r} field {field!r} is not hexadecimal").format(
                 batch=batch_name,
                 field=field,
             ),
-            cause=error,
         )
     return value
 

--- a/src/git_stage_batch/staging/content_buffers.py
+++ b/src/git_stage_batch/staging/content_buffers.py
@@ -482,6 +482,13 @@ def _target_working_tree_line_contents(
 ) -> Iterator[bytes]:
     working_pointer = line_changes.header.new_prefix_line_count()
 
+    def working_line_matches(line_entry: LineEntry) -> bool:
+        return (
+            working_pointer < working_line_count
+            and _line_payload_at(working_lines, working_pointer)
+            == _line_entry_payload(line_entry)
+        )
+
     def copy_unchanged_lines_before(new_line_number: int | None) -> Iterator[bytes]:
         nonlocal working_pointer
         if new_line_number is None:
@@ -522,21 +529,27 @@ def _target_working_tree_line_contents(
 
         if line_entry.kind == " ":
             yield from copy_unchanged_lines_before(line_entry.new_line_number)
-            if working_pointer < working_line_count:
-                yield _working_tree_line_content_at(working_lines, working_pointer)
-                working_pointer += 1
+            if not working_line_matches(line_entry):
+                raise ValueError(
+                    "Working tree content no longer matches the selected line view"
+                )
+            yield _working_tree_line_content_at(working_lines, working_pointer)
+            working_pointer += 1
         elif line_entry.kind == "-":
             if line_entry.id in discard_ids:
                 yield from copy_remaining_lines_before_deletion(index)
                 yield _line_entry_content(line_entry)
         elif line_entry.kind == "+":
             yield from copy_unchanged_lines_before(line_entry.new_line_number)
-            if working_pointer < working_line_count:
-                if line_entry.id in discard_ids:
-                    working_pointer += 1
-                else:
-                    yield _working_tree_line_content_at(working_lines, working_pointer)
-                    working_pointer += 1
+            if not working_line_matches(line_entry):
+                raise ValueError(
+                    "Working tree content no longer matches the selected line view"
+                )
+            if line_entry.id in discard_ids:
+                working_pointer += 1
+            else:
+                yield _working_tree_line_content_at(working_lines, working_pointer)
+                working_pointer += 1
 
     while 0 <= working_pointer < working_line_count:
         yield _working_tree_line_content_at(working_lines, working_pointer)

--- a/src/git_stage_batch/utils/git_command.py
+++ b/src/git_stage_batch/utils/git_command.py
@@ -177,8 +177,9 @@ def stream_git_diff(
         "--no-textconv",
         "--src-prefix=a/",
         "--dst-prefix=b/",
-        "--no-color",
     ]
+    if no_color:
+        arguments.append("--no-color")
     if ignore_submodules is not None:
         config_arguments.extend(["-c", f"diff.ignoreSubmodules={ignore_submodules}"])
         arguments.append(f"--ignore-submodules={ignore_submodules}")

--- a/tests/batch/merge/test_absence_constraints.py
+++ b/tests/batch/merge/test_absence_constraints.py
@@ -1,0 +1,25 @@
+"""Tests for absence-constraint candidate metadata."""
+
+from git_stage_batch.batch.merge.absence_constraints import (
+    absence_choices_for_claim,
+)
+from git_stage_batch.batch.realization.entries import RealizedEntry
+
+
+def test_absence_choice_reports_line_after_complete_removed_sequence():
+    """Candidate bounds should surround the whole multi-line removal."""
+    entries = [
+        RealizedEntry(b"head\n", 1),
+        RealizedEntry(b"old-a\n", None),
+        RealizedEntry(b"old-b\n", None),
+        RealizedEntry(b"tail\n", 2),
+    ]
+
+    choices = absence_choices_for_claim(
+        entries,
+        1,
+        [b"old-a\n", b"old-b\n"],
+    )
+
+    assert choices[0].target_after_line == 1
+    assert choices[0].target_before_line == 4

--- a/tests/batch/state/test_metadata_schema.py
+++ b/tests/batch/state/test_metadata_schema.py
@@ -64,6 +64,15 @@ def test_v1_round_trip_is_deterministic_and_immutable():
         model.files[0].values["mode"] = "100755"  # type: ignore[index]
 
 
+def test_object_id_rejects_signed_hexadecimal_text():
+    """A sign character is not part of a full Git object ID."""
+    metadata = _v1_metadata()
+    metadata["baseline"] = "-" + "0" * 39
+
+    with pytest.raises(BatchMetadataError, match="not hexadecimal"):
+        decode_batch_metadata(metadata, expected_batch="feature")
+
+
 def test_publication_derives_a_new_immutable_model():
     model = decode_batch_metadata(_v1_metadata(), expected_batch="feature")
 

--- a/tests/cli/test_pager.py
+++ b/tests/cli/test_pager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import io
 from contextlib import contextmanager
 from importlib import import_module
 
@@ -105,6 +106,16 @@ def test_build_pager_environment_preserves_user_overrides(monkeypatch):
 
     assert env["LESS"] == "SX"
     assert env["LV"] == "-abc"
+
+
+def test_pager_stdout_exposes_underlying_closed_state():
+    """The pager proxy should satisfy callers that inspect TextIO.closed."""
+    stream = io.StringIO()
+    proxy = pager_module._PagerStdout(stream, stream)
+
+    assert proxy.closed is False
+    proxy.close()
+    assert proxy.closed is True
 
 
 def test_pager_output_starts_pager_with_git_compatible_environment(monkeypatch):

--- a/tests/cli/test_quick_actions.py
+++ b/tests/cli/test_quick_actions.py
@@ -37,3 +37,21 @@ def test_expand_quick_actions_expands_tokens_in_place():
         "--line",
         "1-3",
     ]
+
+
+def test_expand_quick_actions_preserves_shortcut_shaped_command_arguments():
+    """Batch names and other values must not be interpreted as commands."""
+    assert expand_quick_actions(["include", "--to", "if"]) == [
+        "include",
+        "--to",
+        "if",
+    ]
+
+
+def test_expand_quick_actions_supports_attached_working_directory_option():
+    assert expand_quick_actions(["-Crepo", "dl", "2"]) == [
+        "-Crepo",
+        "discard",
+        "--line",
+        "2",
+    ]

--- a/tests/commands/test_include.py
+++ b/tests/commands/test_include.py
@@ -209,7 +209,7 @@ class TestCommandInclude:
         assert _show_index_file(temp_git_repo, "new.txt") == "include me\n"
         assert new_file.read_text() == "skip me\ninclude me\n"
 
-    def test_include_stages_contentful_file_deletion(self, temp_git_repo):
+    def test_include_stages_contentful_file_deletion(self, temp_git_repo, capsys):
         """Bare include should stage a deletion rather than an empty blob."""
         deleted = temp_git_repo / "deleted.txt"
         deleted.write_text("content\n")
@@ -228,7 +228,12 @@ class TestCommandInclude:
         deleted.unlink()
 
         command_start(quiet=True)
+        capsys.readouterr()
         command_include(quiet=True, auto_advance=False)
+
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert captured.err == ""
 
         assert subprocess.run(
             ["git", "status", "--short", "--", "deleted.txt"],

--- a/tests/commands/test_include.py
+++ b/tests/commands/test_include.py
@@ -28,6 +28,7 @@ from git_stage_batch.data.hunk_tracking import (
 )
 from git_stage_batch.data.selected_change.loading import load_selected_change
 from git_stage_batch.data.line_state import load_line_changes_from_state
+from git_stage_batch.data.selected_change.store import write_line_changes_state
 from git_stage_batch.data.selected_change.clear_reasons import (
     selected_change_was_cleared_by_auto_advance_disabled,
 )
@@ -203,7 +204,12 @@ class TestCommandInclude:
         new_file.write_text("skip me\ninclude me\n")
 
         command_start(quiet=True)
+        unmasked_line_changes = load_line_changes_from_state()
+        assert unmasked_line_changes is not None
         command_skip_line("1", auto_advance=False)
+        # A refreshed view can still expose the original ID while the durable
+        # skip record remains authoritative.
+        write_line_changes_state(unmasked_line_changes)
         command_include(quiet=True, auto_advance=False)
 
         assert _show_index_file(temp_git_repo, "new.txt") == "include me\n"

--- a/tests/commands/test_include.py
+++ b/tests/commands/test_include.py
@@ -28,12 +28,16 @@ from git_stage_batch.data.hunk_tracking import (
 )
 from git_stage_batch.data.selected_change.loading import load_selected_change
 from git_stage_batch.data.line_state import load_line_changes_from_state
+from git_stage_batch.data.line_id_files import write_line_ids_file
 from git_stage_batch.data.selected_change.store import write_line_changes_state
 from git_stage_batch.data.selected_change.clear_reasons import (
     selected_change_was_cleared_by_auto_advance_disabled,
 )
 from git_stage_batch.exceptions import CommandError, MergeError, NoMoreHunks
-from git_stage_batch.utils.paths import get_state_directory_path
+from git_stage_batch.utils.paths import (
+    get_processed_skip_ids_file_path,
+    get_state_directory_path,
+)
 from git_stage_batch.commands.again import command_again
 from tests.batch.ownership.metadata_helpers import (
     reject_materialized_ownership_metadata as _reject_materialized_ownership_metadata,
@@ -214,6 +218,32 @@ class TestCommandInclude:
 
         assert _show_index_file(temp_git_repo, "new.txt") == "include me\n"
         assert new_file.read_text() == "skip me\ninclude me\n"
+
+    def test_bare_include_does_not_stage_when_all_lines_are_skipped(
+        self,
+        temp_git_repo,
+    ):
+        """Bare include should be a no-op when skips cover the whole hunk."""
+        new_file = temp_git_repo / "new.txt"
+        new_file.write_text("skip one\nskip two\n")
+
+        command_start(quiet=True)
+        line_changes = load_line_changes_from_state()
+        assert line_changes is not None
+        write_line_ids_file(
+            get_processed_skip_ids_file_path(),
+            line_changes.changed_line_ids(),
+        )
+        command_include(quiet=True, auto_advance=False)
+
+        assert subprocess.run(
+            ["git", "diff", "--cached", "--", "new.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+            text=True,
+        ).stdout == ""
+        assert new_file.read_text() == "skip one\nskip two\n"
 
     def test_include_stages_contentful_file_deletion(self, temp_git_repo, capsys):
         """Bare include should stage a deletion rather than an empty blob."""

--- a/tests/commands/test_skip.py
+++ b/tests/commands/test_skip.py
@@ -147,6 +147,36 @@ class TestCommandSkip:
         with pytest.raises(CommandError, match="automatic advancement is disabled"):
             command_skip(quiet=True)
 
+    def test_quiet_skip_forwards_to_atomic_file_scope(
+        self,
+        temp_git_repo,
+        capsys,
+    ):
+        """Bare quiet skip should suppress output for a file-level selection."""
+        deleted = temp_git_repo / "deleted.txt"
+        deleted.write_text("content\n")
+        subprocess.run(
+            ["git", "add", "deleted.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add deleted file"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+        deleted.unlink()
+
+        command_start(quiet=True)
+        capsys.readouterr()
+        command_skip(quiet=True, auto_advance=False)
+
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert captured.err == ""
+
 
 class TestCommandSkipLine:
     """Tests for skip --line command."""

--- a/tests/data/test_batch_refs.py
+++ b/tests/data/test_batch_refs.py
@@ -121,6 +121,18 @@ class TestRestoreBatchRefs:
         with pytest.raises(CommandError, match="recovery snapshot is invalid"):
             load_batch_refs_snapshot()
 
+    def test_load_rejects_signed_object_id(self, temp_git_repo):
+        """Recovery refs require hexadecimal digits, not Python int syntax."""
+        create_batch("test-batch", "Test note")
+        snapshot_batch_refs()
+        snapshot_path = get_batch_refs_snapshot_file_path()
+        snapshot = json.loads(read_text_file_contents(snapshot_path))
+        snapshot["batches"]["test-batch"]["commit_sha"] = "-" + "0" * 39
+        write_text_file_contents(snapshot_path, json.dumps(snapshot))
+
+        with pytest.raises(CommandError, match="is not hexadecimal"):
+            load_batch_refs_snapshot()
+
     def test_restore_drops_new_batches(self, temp_git_repo):
         """Test that batches created after snapshot are dropped."""
         # Create empty snapshot

--- a/tests/staging/test_content_buffers.py
+++ b/tests/staging/test_content_buffers.py
@@ -1407,3 +1407,23 @@ class TestBuildTargetWorkingTreeContent:
         result = _build_target_working_tree_content_text(line_changes, {1}, working_text)
 
         assert result.endswith("\n")
+    def test_discard_selected_lines_refuses_drifted_worktree_content(self):
+        """Classic worktree discard must fail instead of consuming stale rows."""
+        line_changes = LineLevelChange(
+            path="test.txt",
+            header=HunkHeader(1, 3, 1, 3),
+            lines=[
+                LineEntry(None, " ", 1, 1, text_bytes=b"keep"),
+                LineEntry(1, "-", 2, None, text_bytes=b"old"),
+                LineEntry(2, "+", None, 2, text_bytes=b"new"),
+                LineEntry(None, " ", 3, 3, text_bytes=b"tail"),
+            ],
+        )
+
+        with LineBuffer.from_bytes(b"keep\ndrifted\ntail\n") as working_lines:
+            with pytest.raises(ValueError, match="no longer matches"):
+                _build_target_working_tree_content_bytes(
+                    line_changes,
+                    {1, 2},
+                    working_lines,
+                )

--- a/tests/utils/test_git_command.py
+++ b/tests/utils/test_git_command.py
@@ -385,6 +385,22 @@ class TestStreamGitDiff:
         assert lines
         assert not any(b"\x1b[" in line for line in lines)
 
+    def test_stream_git_diff_allows_color_when_requested(self, temp_git_repo):
+        """The no_color option should not silently override an explicit False."""
+        run_git_command(["config", "color.ui", "always"])
+        test_file = temp_git_repo / "color.txt"
+        test_file.write_text("color line\n")
+        subprocess.run(
+            ["git", "add", "color.txt"],
+            check=True,
+            cwd=temp_git_repo,
+            capture_output=True,
+        )
+
+        lines = list(stream_git_diff(cached=True, no_color=False))
+
+        assert any(b"\x1b[" in line for line in lines)
+
     def test_stream_git_diff_overrides_format_changing_configuration(
         self,
         temp_git_repo,


### PR DESCRIPTION
Several command and metadata boundaries accept state that is valid in the
common path but ambiguous or incompatible at their edges.

Those gaps can report the wrong deletion boundary, break logging through the
pager proxy, expand quick actions inside ordinary arguments, ignore diff color
requests, print during quiet file actions, re-include skipped lines, accept
signed object identifiers, or discard through a stale line view.

Close each boundary at its owning interface and add focused regression tests
for the externally observable behavior. The changes remain independent in the
implementation while sharing one review outcome: malformed or stale edge state
is rejected, and command options retain their documented meaning.

Validation includes the complete parallel test suite, Ruff, dead-code analysis,
type-hygiene analysis, strict mypy checks, and diff validation.
