### PR TITLE
selection: Stage complete replacement regions

### DIFF
--- a/src/git_stage_batch/commands/selection/replacement_selection.py
+++ b/src/git_stage_batch/commands/selection/replacement_selection.py
@@ -31,8 +31,7 @@ def require_contiguous_display_selection(selected_ids: set[int]) -> None:
     if not selected_ids:
         return
 
-    selected_range = list(range(min(selected_ids), max(selected_ids) + 1))
-    if sorted(selected_ids) != selected_range:
+    if len(selected_ids) != max(selected_ids) - min(selected_ids) + 1:
         exit_with_error(_("Replacement selection must be one contiguous line range."))
 
 
@@ -115,9 +114,7 @@ def build_partial_structural_run_selection_error(
     if len(selected_ids) <= 1:
         return None
 
-    sorted_ids = sorted(selected_ids)
-    expected_ids = list(range(sorted_ids[0], sorted_ids[-1] + 1))
-    if sorted_ids != expected_ids:
+    if len(selected_ids) != max(selected_ids) - min(selected_ids) + 1:
         return None
 
     run_sets = derive_display_id_run_sets_from_lines(

--- a/src/git_stage_batch/commands/selection/replacement_selection.py
+++ b/src/git_stage_batch/commands/selection/replacement_selection.py
@@ -144,50 +144,68 @@ def expand_replacement_selection_ids(
     line_changes: LineLevelChange,
     requested_ids: set[int],
 ) -> set[int]:
-    """Expand a selection to the smallest adjacent mixed replacement run."""
-    selected_indices = [
-        index
-        for index, line in enumerate(line_changes.lines)
-        if line.id in requested_ids
-    ]
-    if not selected_indices:
-        return requested_ids
+    """Expand selected rows to every adjacent mixed replacement core."""
+    expanded_ids: set[int] | None = None
+    line_index = 0
+    while line_index < len(line_changes.lines):
+        if line_changes.lines[line_index].kind not in ("+", "-"):
+            line_index += 1
+            continue
 
-    run_start = min(selected_indices)
-    run_end = max(selected_indices)
-
-    run_entries = line_changes.lines[run_start:run_end + 1]
-    run_kinds = {line.kind for line in run_entries if line.kind in ("+", "-")}
-
-    if run_kinds != {"+", "-"}:
-        selected_kind = next(iter(run_kinds), None)
-        opposite_kind = "-" if selected_kind == "+" else "+"
-
-        left_index = run_start - 1
-        while left_index >= 0 and line_changes.lines[left_index].kind == selected_kind:
-            left_index -= 1
-        if left_index >= 0 and line_changes.lines[left_index].kind == opposite_kind:
-            run_start = left_index
-
-        right_index = run_end + 1
+        run_start = line_index
+        first_addition: int | None = None
+        first_requested_index: int | None = None
+        malformed_run = False
         while (
-            right_index < len(line_changes.lines)
-            and line_changes.lines[right_index].kind == selected_kind
+            line_index < len(line_changes.lines)
+            and line_changes.lines[line_index].kind in ("+", "-")
         ):
-            right_index += 1
+            line = line_changes.lines[line_index]
+            if line.id in requested_ids and first_requested_index is None:
+                first_requested_index = line_index
+            if line.kind == "+":
+                if first_addition is None:
+                    first_addition = line_index
+            elif first_addition is not None:
+                malformed_run = True
+            line_index += 1
+        run_stop = line_index
+
         if (
-            right_index < len(line_changes.lines)
-            and line_changes.lines[right_index].kind == opposite_kind
+            malformed_run
+            or first_addition is None
+            or first_addition == run_start
         ):
-            run_end = right_index
+            continue
 
-        run_entries = line_changes.lines[run_start:run_end + 1]
-        run_kinds = {line.kind for line in run_entries if line.kind in ("+", "-")}
-        if run_kinds != {"+", "-"}:
-            return requested_ids
+        deletion_count = first_addition - run_start
+        addition_count = run_stop - first_addition
+        replacement_stop = first_addition + min(
+            deletion_count,
+            addition_count,
+        )
+        if (
+            first_requested_index is None
+            or first_requested_index >= replacement_stop
+        ):
+            continue
 
-    return {
-        line.id
-        for line in run_entries
-        if line.id is not None
-    }
+        if any(
+            line_changes.lines[run_index].id is None
+            for run_index in range(run_start, replacement_stop)
+        ):
+            exit_with_error(
+                _(
+                    "Cannot replace a partial replacement run because another "
+                    "changed line in the run is unavailable."
+                )
+            )
+
+        if expanded_ids is None:
+            expanded_ids = set(requested_ids)
+        for run_index in range(run_start, replacement_stop):
+            line_id = line_changes.lines[run_index].id
+            if line_id is not None:
+                expanded_ids.add(line_id)
+
+    return requested_ids if expanded_ids is None else expanded_ids

--- a/src/git_stage_batch/staging/content_buffers.py
+++ b/src/git_stage_batch/staging/content_buffers.py
@@ -173,6 +173,55 @@ def _replacement_selection_span_indices(
     replace_ids: set[int],
 ) -> tuple[int, int]:
     """Return the display span for one contiguous run of changed rows."""
+    line_index = 0
+    while line_index < len(line_changes.lines):
+        if line_changes.lines[line_index].kind not in ("+", "-"):
+            line_index += 1
+            continue
+
+        run_start = line_index
+        first_addition: int | None = None
+        first_selected_index: int | None = None
+        malformed_run = False
+        while (
+            line_index < len(line_changes.lines)
+            and line_changes.lines[line_index].kind in ("+", "-")
+        ):
+            line = line_changes.lines[line_index]
+            if line.id in replace_ids and first_selected_index is None:
+                first_selected_index = line_index
+            if line.kind == "+":
+                if first_addition is None:
+                    first_addition = line_index
+            elif first_addition is not None:
+                malformed_run = True
+            line_index += 1
+
+        if (
+            malformed_run
+            or first_addition is None
+            or first_addition == run_start
+        ):
+            continue
+        replacement_stop = first_addition + min(
+            first_addition - run_start,
+            line_index - first_addition,
+        )
+        if (
+            first_selected_index is None
+            or first_selected_index >= replacement_stop
+        ):
+            continue
+        if any(
+            line_changes.lines[run_index].id is None
+            or line_changes.lines[run_index].id not in replace_ids
+            for run_index in range(run_start, replacement_stop)
+        ):
+            raise ValueError(
+                "Replacement selection must include one complete replacement "
+                "run; another changed line is unavailable or unselected"
+            )
+
     selected_count = 0
     span_start_index: int | None = None
     span_end_index: int | None = None

--- a/src/git_stage_batch/staging/content_buffers.py
+++ b/src/git_stage_batch/staging/content_buffers.py
@@ -168,6 +168,45 @@ def _is_synthetic_gap_line(line_entry: LineEntry) -> bool:
     )
 
 
+def _replacement_selection_span_indices(
+    line_changes: LineLevelChange,
+    replace_ids: set[int],
+) -> tuple[int, int]:
+    """Return the display span for one contiguous run of changed rows."""
+    selected_count = 0
+    span_start_index: int | None = None
+    span_end_index: int | None = None
+    selection_started = False
+    selection_ended = False
+    selection_is_discontiguous = False
+
+    for display_index, line in enumerate(line_changes.lines):
+        if line.kind not in ("+", "-"):
+            continue
+
+        if line.id is not None and line.id in replace_ids:
+            if selection_ended:
+                selection_is_discontiguous = True
+            if span_start_index is None:
+                span_start_index = display_index
+            span_end_index = display_index
+            selection_started = True
+            selected_count += 1
+        elif selection_started:
+            selection_ended = True
+
+    if selected_count != len(replace_ids):
+        raise ValueError(
+            "Replacement selection contains line IDs outside the current hunk"
+        )
+    if selection_is_discontiguous:
+        raise ValueError("Replacement selection must be one contiguous line range")
+
+    assert span_start_index is not None
+    assert span_end_index is not None
+    return span_start_index, span_end_index
+
+
 def _old_index_for_new_anchor(
     line_changes: LineLevelChange,
     new_anchor: int,
@@ -360,23 +399,11 @@ def _build_target_index_buffer_with_replaced_lines(
             has_trailing_newline=base_has_trailing_newline,
         )
 
-    changed_ids = sorted(line_changes.changed_line_ids())
-    selected_ids = sorted(replace_ids)
-    if any(line_id not in changed_ids for line_id in selected_ids):
-        raise ValueError("Replacement selection contains line IDs outside the current hunk")
-
-    expected_range = list(range(selected_ids[0], selected_ids[-1] + 1))
-    if selected_ids != expected_range:
-        raise ValueError("Replacement selection must be one contiguous line range")
-
     base_line_count = len(base_lines)
-    selected_indices = [
-        index
-        for index, line in enumerate(line_changes.lines)
-        if line.id in replace_ids
-    ]
-    span_start_index = min(selected_indices)
-    span_end_index = max(selected_indices)
+    span_start_index, span_end_index = _replacement_selection_span_indices(
+        line_changes,
+        replace_ids,
+    )
 
     def find_next_old_line_number(start_index: int) -> int | None:
         for line_entry in line_changes.lines[start_index:]:
@@ -632,23 +659,11 @@ def _build_target_working_tree_buffer_with_replaced_lines(
             has_trailing_newline=working_has_trailing_newline,
         )
 
-    changed_ids = sorted(line_changes.changed_line_ids())
-    selected_ids = sorted(replace_ids)
-    if any(line_id not in changed_ids for line_id in selected_ids):
-        raise ValueError("Replacement selection contains line IDs outside the current hunk")
-
-    expected_range = list(range(selected_ids[0], selected_ids[-1] + 1))
-    if selected_ids != expected_range:
-        raise ValueError("Replacement selection must be one contiguous line range")
-
     working_line_count = len(working_lines)
-    selected_indices = [
-        index
-        for index, line in enumerate(line_changes.lines)
-        if line.id in replace_ids
-    ]
-    span_start_index = min(selected_indices)
-    span_end_index = max(selected_indices)
+    span_start_index, span_end_index = _replacement_selection_span_indices(
+        line_changes,
+        replace_ids,
+    )
 
     def find_next_new_line_number(start_index: int) -> int | None:
         for line_entry in line_changes.lines[start_index:]:

--- a/tests/commands/test_replacement_selection.py
+++ b/tests/commands/test_replacement_selection.py
@@ -3,8 +3,10 @@
 import pytest
 
 from git_stage_batch.commands.selection.replacement_selection import (
+    expand_replacement_selection_ids,
     require_contiguous_display_selection,
 )
+from git_stage_batch.core.models import HunkHeader, LineEntry, LineLevelChange
 from git_stage_batch.exceptions import CommandError
 
 
@@ -21,3 +23,28 @@ def test_contiguous_display_selection_rejects_gapped_ids():
     assert "Replacement selection must be one contiguous line range." in (
         exc_info.value.message
     )
+
+
+@pytest.mark.parametrize(
+    "requested_ids",
+    [{3}, {3, 4}, {1, 2}],
+)
+def test_replacement_selection_expands_both_complete_sides(requested_ids):
+    """Selecting either side of a replacement includes the full mixed run."""
+    line_changes = LineLevelChange(
+        path="test.txt",
+        header=HunkHeader(1, 2, 1, 2),
+        lines=[
+            LineEntry(1, "-", 1, None, text_bytes=b"old-a"),
+            LineEntry(2, "-", 2, None, text_bytes=b"old-b"),
+            LineEntry(3, "+", None, 1, text_bytes=b"new-a"),
+            LineEntry(4, "+", None, 2, text_bytes=b"new-b"),
+        ],
+    )
+
+    assert expand_replacement_selection_ids(line_changes, requested_ids) == {
+        1,
+        2,
+        3,
+        4,
+    }

--- a/tests/commands/test_replacement_selection.py
+++ b/tests/commands/test_replacement_selection.py
@@ -79,3 +79,29 @@ def test_replacement_selection_refuses_unavailable_opposite_side():
 
     with pytest.raises(CommandError, match="changed line in the run is unavailable"):
         expand_replacement_selection_ids(line_changes, {2})
+
+
+def test_replacement_selection_expands_each_selected_disjoint_run():
+    """File-scoped selections may cross context and still expand each replacement."""
+    line_changes = LineLevelChange(
+        path="test.txt",
+        header=HunkHeader(1, 4, 1, 4),
+        lines=[
+            LineEntry(1, "-", 1, None, text_bytes=b"old-a"),
+            LineEntry(2, "+", None, 1, text_bytes=b"new-a"),
+            LineEntry(None, " ", 2, 2, text_bytes=b"context"),
+            LineEntry(3, "-", 3, None, text_bytes=b"old-b"),
+            LineEntry(4, "-", 4, None, text_bytes=b"old-c"),
+            LineEntry(5, "+", None, 3, text_bytes=b"new-b"),
+            LineEntry(6, "+", None, 4, text_bytes=b"new-c"),
+        ],
+    )
+
+    assert expand_replacement_selection_ids(line_changes, {2, 5}) == {
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+    }

--- a/tests/commands/test_replacement_selection.py
+++ b/tests/commands/test_replacement_selection.py
@@ -48,3 +48,19 @@ def test_replacement_selection_expands_both_complete_sides(requested_ids):
         3,
         4,
     }
+
+
+def test_replacement_selection_leaves_surplus_additions_outside_core():
+    """An insertion following a one-for-one replacement remains independently selectable."""
+    line_changes = LineLevelChange(
+        path="test.txt",
+        header=HunkHeader(1, 1, 1, 2),
+        lines=[
+            LineEntry(1, "-", 1, None, text_bytes=b"old"),
+            LineEntry(2, "+", None, 1, text_bytes=b"new"),
+            LineEntry(3, "+", None, 2, text_bytes=b"extra"),
+        ],
+    )
+
+    assert expand_replacement_selection_ids(line_changes, {2}) == {1, 2}
+    assert expand_replacement_selection_ids(line_changes, {3}) == {3}

--- a/tests/commands/test_replacement_selection.py
+++ b/tests/commands/test_replacement_selection.py
@@ -64,3 +64,18 @@ def test_replacement_selection_leaves_surplus_additions_outside_core():
 
     assert expand_replacement_selection_ids(line_changes, {2}) == {1, 2}
     assert expand_replacement_selection_ids(line_changes, {3}) == {3}
+
+
+def test_replacement_selection_refuses_unavailable_opposite_side():
+    """A skipped row cannot be silently omitted from a selected replacement."""
+    line_changes = LineLevelChange(
+        path="test.txt",
+        header=HunkHeader(1, 1, 1, 1),
+        lines=[
+            LineEntry(None, "-", 1, None, text_bytes=b"skipped-old"),
+            LineEntry(2, "+", None, 1, text_bytes=b"selected-new"),
+        ],
+    )
+
+    with pytest.raises(CommandError, match="changed line in the run is unavailable"):
+        expand_replacement_selection_ids(line_changes, {2})

--- a/tests/staging/test_content_buffers.py
+++ b/tests/staging/test_content_buffers.py
@@ -695,6 +695,23 @@ class TestBuildTargetIndexContent:
                 {1, 5},
             )
 
+    def test_replace_selection_requires_unavailable_replacement_core_row(self):
+        """Low-level callers cannot replace only one selectable side of a run."""
+        line_changes = LineLevelChange(
+            path="test.txt",
+            header=HunkHeader(1, 1, 1, 1),
+            lines=[
+                LineEntry(None, "-", 1, None, text_bytes=b"skipped-old"),
+                LineEntry(2, "+", None, 1, text_bytes=b"selected-new"),
+            ],
+        )
+
+        with pytest.raises(ValueError, match="one complete replacement run"):
+            content_buffers_module._replacement_selection_span_indices(
+                line_changes,
+                {2},
+            )
+
     def test_replace_selection_validation_avoids_line_scale_python_heap(self):
         """Position validation must scan changed rows without materializing them."""
         heap_peaks = []

--- a/tests/staging/test_content_buffers.py
+++ b/tests/staging/test_content_buffers.py
@@ -677,6 +677,24 @@ class TestBuildTargetIndexContent:
 
         assert result == b"replacement\n"
 
+    def test_replace_selection_cannot_cross_changed_row_without_id(self):
+        """A skipped changed row must remain a replacement-selection boundary."""
+        line_changes = LineLevelChange(
+            path="test.txt",
+            header=HunkHeader(1, 1, 1, 2),
+            lines=[
+                LineEntry(1, "-", 1, None, text_bytes=b"old"),
+                LineEntry(None, "+", None, 1, text_bytes=b"skipped"),
+                LineEntry(5, "+", None, 2, text_bytes=b"selected"),
+            ],
+        )
+
+        with pytest.raises(ValueError, match="one complete replacement run"):
+            content_buffers_module._replacement_selection_span_indices(
+                line_changes,
+                {1, 5},
+            )
+
     def test_replace_selection_validation_avoids_line_scale_python_heap(self):
         """Position validation must scan changed rows without materializing them."""
         heap_peaks = []

--- a/tests/staging/test_content_buffers.py
+++ b/tests/staging/test_content_buffers.py
@@ -650,6 +650,29 @@ class TestBuildTargetIndexContent:
 
         assert result == b"keep\nstaged value\n"
 
+    def test_replace_selection_uses_display_positions_after_id_remapping(self):
+        """Preserved ID holes must not make adjacent replacement rows invalid."""
+        line_changes = LineLevelChange(
+            path="test.txt",
+            header=HunkHeader(1, 1, 1, 2),
+            lines=[
+                LineEntry(1, "-", 1, None, text_bytes=b"old"),
+                LineEntry(4, "+", None, 1, text_bytes=b"new-a"),
+                LineEntry(5, "+", None, 2, text_bytes=b"new-b"),
+            ],
+        )
+
+        with LineBuffer.from_bytes(b"old\n") as base_lines:
+            result = _build_target_index_replacement_bytes(
+                line_changes,
+                {1, 4, 5},
+                "replacement",
+                base_lines,
+                base_has_trailing_newline=True,
+            )
+
+        assert result == b"replacement\n"
+
     def test_replace_selection_honors_old_line_numbers_after_gap_markers(self):
         """File-scoped replacement staging should stay anchored after omitted regions."""
         header = HunkHeader(2, 12, 2, 12)

--- a/tests/staging/test_content_buffers.py
+++ b/tests/staging/test_content_buffers.py
@@ -1,7 +1,11 @@
 """Tests for line-level staging content buffers."""
 
+import gc
+import tracemalloc
+
 import pytest
 
+from git_stage_batch.staging import content_buffers as content_buffers_module
 from git_stage_batch.core.models import LineLevelChange, HunkHeader, LineEntry
 from git_stage_batch.core.buffer import LineBuffer
 from git_stage_batch.core.replacement import ReplacementPayload
@@ -672,6 +676,45 @@ class TestBuildTargetIndexContent:
             )
 
         assert result == b"replacement\n"
+
+    def test_replace_selection_validation_avoids_line_scale_python_heap(self):
+        """Position validation must scan changed rows without materializing them."""
+        heap_peaks = []
+        for line_count in (1024, 8192):
+            line_changes = LineLevelChange(
+                path="test.txt",
+                header=HunkHeader(1, 0, 1, line_count),
+                lines=[
+                    LineEntry(
+                        line_id,
+                        "+",
+                        None,
+                        line_id,
+                        text_bytes=b"changed",
+                    )
+                    for line_id in range(1, line_count + 1)
+                ],
+            )
+            replace_ids = set(range(1, line_count + 1))
+
+            gc.collect()
+            tracemalloc.start()
+            try:
+                span = (
+                    content_buffers_module._replacement_selection_span_indices(
+                        line_changes,
+                        replace_ids,
+                    )
+                )
+                _current_heap, peak_heap = tracemalloc.get_traced_memory()
+            finally:
+                tracemalloc.stop()
+
+            assert span == (0, line_count - 1)
+            heap_peaks.append(peak_heap)
+
+        small_peak, large_peak = heap_peaks
+        assert large_peak < small_peak + 16 * 1024
 
     def test_replace_selection_honors_old_line_numbers_after_gap_markers(self):
         """File-scoped replacement staging should stay anchored after omitted regions."""


### PR DESCRIPTION
Line-scoped replacement actions pair removed and added rows from mixed change
regions before staging or discarding replacement text.

Remapped line identifiers are not guaranteed to remain numerically contiguous,
and selecting one side of a multi-line replacement can leave available partner
rows behind. Numeric range materialization also makes Python heap use grow with
the selected line count.

Validate contiguity by display position, require complete replacement cores,
and expand every selected mixed region across both available sides. Regression
coverage exercises remapped identifiers, skipped and unavailable rows,
boundaries, disjoint replacements, and bounded heap growth.

Validation includes the complete parallel test suite, Ruff, dead-code analysis,
type-hygiene analysis, strict mypy checks, and diff validation.
