### PR TITLE
batch: Refuse unsafe merge placements

### DIFF
--- a/src/git_stage_batch/batch/merge/candidate_enumeration.py
+++ b/src/git_stage_batch/batch/merge/candidate_enumeration.py
@@ -351,7 +351,7 @@ def _presence_candidate_set(
                 trusted_source_lines={
                     deletion.anchor_line
                     for deletion in deletion_claims
-                    if deletion.anchor_line is not None
+                    if deletion.anchor_line is not None and deletion.content_lines
                 },
                 distinctive_context_lines=distinctive_context_lines,
                 spool_dir=spool_dir,

--- a/src/git_stage_batch/batch/merge/candidate_enumeration.py
+++ b/src/git_stage_batch/batch/merge/candidate_enumeration.py
@@ -332,6 +332,7 @@ def _presence_candidate_set(
         ownership,
         presence_line_set,
         deletion_claims,
+        target_lines=working_lines,
         spool_dir=spool_dir,
     )
     presence_mapping = match_lines(
@@ -435,6 +436,7 @@ def _absence_candidate_set(
         ownership,
         presence_line_set,
         deletion_claims,
+        target_lines=working_lines,
         spool_dir=spool_dir,
     )
 

--- a/src/git_stage_batch/batch/merge/coordinate_strategy.py
+++ b/src/git_stage_batch/batch/merge/coordinate_strategy.py
@@ -11,6 +11,7 @@ from .baseline_replacement_ranges import (
     collect_replacement_source_ranges,
     replacement_source_range_capacity,
 )
+from .baseline_reference_positions import baseline_reference_insertion_position
 from ..line_matching.match_workspace import MatcherWorkspace
 from ...core.line_selection import LineRanges, LineSelection, coerce_line_ranges
 from ...core.mapped_storage import MappedRecordVector, sort_mapped_records
@@ -69,6 +70,7 @@ def presence_lines_requiring_distinctive_context(
     presence_line_set: LineSelection,
     deletion_claims: Sequence[AbsenceClaim],
     *,
+    target_lines: Sequence[bytes] | None = None,
     spool_dir: str | Path | None = None,
 ) -> LineRanges:
     """Return presence lines lacking coordinate or replacement anchoring."""
@@ -98,6 +100,13 @@ def presence_lines_requiring_distinctive_context(
                     type(claimed_line) is int
                     and claimed_line > 0
                     and reference.has_after_line
+                    and (
+                        target_lines is None
+                        or baseline_reference_insertion_position(
+                            reference,
+                            target_lines,
+                        ) is not None
+                    )
                 ):
                     covered_ranges.append((claimed_line, claimed_line))
 

--- a/src/git_stage_batch/batch/merge/merge.py
+++ b/src/git_stage_batch/batch/merge/merge.py
@@ -196,6 +196,7 @@ def _build_structural_realized_entries(
             ownership,
             presence_line_set,
             deletion_claims,
+            target_lines=working_lines,
             spool_dir=spool_dir,
         )
 

--- a/src/git_stage_batch/batch/merge/presence_constraints.py
+++ b/src/git_stage_batch/batch/merge/presence_constraints.py
@@ -367,7 +367,7 @@ def satisfy_constraints(
     trusted_source_lines = {
         deletion.anchor_line
         for deletion in deletion_claims
-        if deletion.anchor_line is not None
+        if deletion.anchor_line is not None and deletion.content_lines
     }
     realized_entries = apply_presence_constraints(
         source_lines,

--- a/src/git_stage_batch/batch/merge/validation.py
+++ b/src/git_stage_batch/batch/merge/validation.py
@@ -148,6 +148,7 @@ def check_structural_validity(
                 )
 
     has_unmapped_deletion_anchor = False
+    has_unmapped_claimed_deletion_anchor = False
     for deletion in deletions:
         if not deletion.content_lines:
             continue
@@ -161,6 +162,8 @@ def check_structural_validity(
 
             if not line_mapping.is_source_line_present(after_line):
                 has_unmapped_deletion_anchor = True
+                if after_line in claimed_lines:
+                    has_unmapped_claimed_deletion_anchor = True
                 has_context = False
                 for check_line in range(
                     max(1, after_line - 3),
@@ -180,9 +183,14 @@ def check_structural_validity(
                         )
                     )
 
-    # Let absence realization report its more precise missing-anchor error once
-    # nearby mapped context has allowed an unmapped deletion anchor through.
-    if has_unmapped_deletion_anchor:
+    # An unclaimed missing deletion anchor will remain absent after presence
+    # realization, so let absence handling report its precise anchor error.
+    # A claimed anchor can be reintroduced by that realization; validate its
+    # placement first so the deletion cannot mask a silent variant interleave.
+    if (
+        has_unmapped_deletion_anchor
+        and not has_unmapped_claimed_deletion_anchor
+    ):
         return None
 
     _missing_presence_lines, presence_placements = (
@@ -201,6 +209,12 @@ def check_structural_validity(
             spool_dir=spool_dir,
         )
     )
+    # Let absence realization report its more precise missing-anchor error once
+    # nearby mapped context has allowed an unmapped deletion anchor through.
+    # Presence placement still has to run first: an unrelated missing anchor
+    # must not disable ambiguity refusal for every claimed line in the file.
+    if has_unmapped_deletion_anchor:
+        return presence_placements
     _check_unbounded_trailing_context(
         line_mapping,
         claimed_lines,

--- a/src/git_stage_batch/batch/merge/validation.py
+++ b/src/git_stage_batch/batch/merge/validation.py
@@ -149,6 +149,8 @@ def check_structural_validity(
 
     has_unmapped_deletion_anchor = False
     for deletion in deletions:
+        if not deletion.content_lines:
+            continue
         after_line = deletion.anchor_line
 
         if after_line is not None:
@@ -192,7 +194,7 @@ def check_structural_validity(
             trusted_source_lines={
                 deletion.anchor_line
                 for deletion in deletions
-                if deletion.anchor_line is not None
+                if deletion.anchor_line is not None and deletion.content_lines
             },
             require_distinctive_context=require_distinctive_presence_context,
             distinctive_context_lines=distinctive_presence_context_lines,

--- a/src/git_stage_batch/batch/source/advancement.py
+++ b/src/git_stage_batch/batch/source/advancement.py
@@ -40,14 +40,6 @@ class BatchSourceAdvanceError(ValueError):
     """Expected refusal while reconciling a stale batch source."""
 
 
-@dataclass(frozen=True, slots=True)
-class _SavedReplacementTargetSpan:
-    """Unique live span suppressed by an authoritative replacement unit."""
-
-    start: int
-    end: int
-
-
 @dataclass
 class SourceContentWithLineProvenance:
     """Synthesized source buffer with line provenance from its inputs."""
@@ -328,47 +320,56 @@ def _advanced_source_chunks(
                 == source_count
             )
 
-            saved_replacement_span = _saved_replacement_target_span(
+            saved_replacement_spans = _saved_replacement_target_spans(
                 run,
                 working_lines,
                 ownership,
                 workspace,
             )
-            if saved_replacement_span is not None:
-                if run.target_start < saved_replacement_span.start:
+            try:
+                if saved_replacement_spans:
+                    target_cursor = run.target_start
+                    source_emitted = False
+                    for span_start, span_end in saved_replacement_spans:
+                        if target_cursor < span_start:
+                            yield from emit_working(
+                                target_cursor,
+                                span_start - 1,
+                            )
+                        if not source_emitted:
+                            yield from emit_source(run.source_start, run.source_end)
+                            source_emitted = True
+                        target_cursor = span_end + 1
+                    if target_cursor <= run.target_end:
+                        yield from emit_working(
+                            target_cursor,
+                            run.target_end,
+                        )
+                elif fully_owned:
+                    if source_count > target_count:
+                        raise BatchSourceAdvanceError(
+                            "Cannot advance a fully owned source replacement that "
+                            "contracts multiple owned lines: source lineage would "
+                            "not be unique."
+                        )
                     yield from emit_working(
                         run.target_start,
-                        saved_replacement_span.start - 1,
-                    )
-                yield from emit_source(run.source_start, run.source_end)
-                if saved_replacement_span.end < run.target_end:
-                    yield from emit_working(
-                        saved_replacement_span.end + 1,
                         run.target_end,
+                        source_start=run.source_start,
+                        source_end=run.source_end,
                     )
-            elif fully_owned:
-                if source_count > target_count:
-                    raise BatchSourceAdvanceError(
-                        "Cannot advance a fully owned source replacement that "
-                        "contracts multiple owned lines: source lineage would "
-                        "not be unique."
-                    )
-                yield from emit_working(
-                    run.target_start,
-                    run.target_end,
-                    source_start=run.source_start,
-                    source_end=run.source_end,
-                )
-            else:
-                for required_start, required_end in (
-                    _required_ranges_in(
-                        required_source_ranges,
-                        run.source_start,
-                        run.source_end,
-                    )
-                ):
-                    yield from emit_source(required_start, required_end)
-                yield from emit_working(run.target_start, run.target_end)
+                else:
+                    for required_start, required_end in (
+                        _required_ranges_in(
+                            required_source_ranges,
+                            run.source_start,
+                            run.source_end,
+                        )
+                    ):
+                        yield from emit_source(required_start, required_end)
+                    yield from emit_working(run.target_start, run.target_end)
+            finally:
+                workspace.close_resource(saved_replacement_spans)
 
             source_cursor = run.source_end + 1
             working_cursor = run.target_end + 1
@@ -415,13 +416,13 @@ def _unchanged_line_count_before_run(
     raise ValueError("Semantic change run has no source or target range")
 
 
-def _saved_replacement_target_span(
+def _saved_replacement_target_spans(
     run: SemanticChangeRun,
     working_lines: Sequence[bytes],
     ownership: BatchOwnership,
     workspace: MatcherWorkspace,
-) -> _SavedReplacementTargetSpan | None:
-    """Return the unique live subrange suppressed by a saved replacement.
+) -> MappedRecordVector:
+    """Return unique live subranges suppressed by a saved replacement.
 
     A semantic matcher may group the suppressed baseline variant with adjacent
     live-only edits.  Locate the exact suppressed subrange so those neighboring
@@ -435,7 +436,7 @@ def _saved_replacement_target_span(
     assert run.target_start is not None
     assert run.target_end is not None
     source_count = run.source_end - run.source_start + 1
-    matched_span: _SavedReplacementTargetSpan | None = None
+    matched_unit_spans: MappedRecordVector | None = None
 
     for unit in ownership.replacement_units:
         replacement_ranges = collect_replacement_source_ranges(
@@ -460,44 +461,86 @@ def _saved_replacement_target_span(
         if covered_source_count != source_count:
             continue
 
-        for deletion_index in unit.deletion_indices:
-            if (
-                type(deletion_index) is not int
-                or deletion_index < 0
-                or deletion_index >= len(ownership.deletions)
-            ):
-                continue
-            suppressed_variant = ownership.deletions[
-                deletion_index
-            ].content_lines
-            variant_count = len(suppressed_variant)
-            if variant_count == 0:
-                continue
-            first_target_index = run.target_start - 1
-            final_target_index = run.target_end - variant_count
-            for target_index in range(
-                first_target_index,
-                final_target_index + 1,
-            ):
-                if not line_slice_equals(
-                    working_lines,
-                    target_index,
-                    suppressed_variant,
+        unit_spans = workspace.record_vector(
+            len(unit.deletion_indices),
+            _SOURCE_RANGE_RECORD_FORMAT,
+        )
+        try:
+            for deletion_index in unit.deletion_indices:
+                if (
+                    type(deletion_index) is not int
+                    or deletion_index < 0
+                    or deletion_index >= len(ownership.deletions)
                 ):
                     continue
-                candidate_span = _SavedReplacementTargetSpan(
-                    start=target_index + 1,
-                    end=target_index + variant_count,
-                )
-                if matched_span is None:
-                    matched_span = candidate_span
-                elif matched_span != candidate_span:
-                    raise BatchSourceAdvanceError(
-                        "Cannot advance an authoritative replacement with "
-                        "multiple matching live baseline spans."
-                    )
+                suppressed_variant = ownership.deletions[
+                    deletion_index
+                ].content_lines
+                variant_count = len(suppressed_variant)
+                if variant_count == 0:
+                    continue
+                first_target_index = run.target_start - 1
+                final_target_index = run.target_end - variant_count
+                matched_start: int | None = None
+                for target_index in range(
+                    first_target_index,
+                    final_target_index + 1,
+                ):
+                    if not line_slice_equals(
+                        working_lines,
+                        target_index,
+                        suppressed_variant,
+                    ):
+                        continue
+                    if matched_start is not None:
+                        raise BatchSourceAdvanceError(
+                            "Cannot advance an authoritative replacement with "
+                            "multiple matching live baseline spans."
+                        )
+                    matched_start = target_index + 1
+                if matched_start is not None:
+                    unit_spans.append((
+                        matched_start,
+                        matched_start + variant_count - 1,
+                    ))
 
-    return matched_span
+            if len(unit_spans) > 1:
+                sort_mapped_records(unit_spans)
+                previous_end = unit_spans[0][1]
+                for span_index in range(1, len(unit_spans)):
+                    span_start, span_end = unit_spans[span_index]
+                    if span_start <= previous_end:
+                        raise BatchSourceAdvanceError(
+                            "Cannot advance an authoritative replacement with "
+                            "overlapping live baseline spans."
+                        )
+                    previous_end = span_end
+            if not unit_spans:
+                continue
+            if matched_unit_spans is None:
+                matched_unit_spans = workspace.record_vector(
+                    len(unit_spans),
+                    _SOURCE_RANGE_RECORD_FORMAT,
+                )
+                for span in unit_spans:
+                    matched_unit_spans.append(span)
+            elif (
+                len(matched_unit_spans) != len(unit_spans)
+                or any(
+                    matched_unit_spans[index] != unit_spans[index]
+                    for index in range(len(unit_spans))
+                )
+            ):
+                raise BatchSourceAdvanceError(
+                    "Cannot advance an authoritative replacement with "
+                    "multiple matching live baseline spans."
+                )
+        finally:
+            workspace.close_resource(unit_spans)
+
+    if matched_unit_spans is None:
+        return workspace.record_vector(0, _SOURCE_RANGE_RECORD_FORMAT)
+    return matched_unit_spans
 
 
 def advance_batch_source_for_file_with_provenance(

--- a/tests/batch/merge/test_coordinate_strategy.py
+++ b/tests/batch/merge/test_coordinate_strategy.py
@@ -119,6 +119,28 @@ def test_only_unanchored_presence_requires_distinctive_context() -> None:
     assert strict_lines.ranges() == ((2, 2),)
 
 
+def test_stale_presence_reference_does_not_cover_distinctive_context() -> None:
+    """Recorded coordinates only anchor presence while their payloads resolve."""
+    reference = BaselineReference(
+        after_line=1,
+        after_content=b"stale-head",
+        before_line=3,
+        before_content=b"tail",
+        has_before_line=True,
+    )
+    ownership = BatchOwnership.from_presence_lines(
+        ["2"],
+        baseline_references={2: reference},
+    )
+
+    strict_lines = presence_lines_requiring_distinctive_context(
+        ownership,
+        ownership.presence_line_set(),
+        ownership.deletions,
+        target_lines=[b"head\n", b"live variant\n", b"tail\n"],
+    )
+
+    assert strict_lines.ranges() == ((2, 2),)
 def test_coordinate_coverage_avoids_line_scale_python_heap() -> None:
     """Per-line coordinate coverage should stay in mapped storage."""
     line_count = 8192

--- a/tests/batch/merge/test_coordinate_strategy.py
+++ b/tests/batch/merge/test_coordinate_strategy.py
@@ -141,14 +141,22 @@ def test_stale_presence_reference_does_not_cover_distinctive_context() -> None:
     )
 
     assert strict_lines.ranges() == ((2, 2),)
+
+
 def test_coordinate_coverage_avoids_line_scale_python_heap() -> None:
     """Per-line coordinate coverage should stay in mapped storage."""
     line_count = 8192
-    reference = BaselineReference(after_line=None)
+    target_lines = [b"anchor\n"] * line_count
     ownership = BatchOwnership.from_presence_lines(
         [f"1-{line_count}"],
         baseline_references={
-            line_number: reference
+            line_number: BaselineReference(
+                after_line=line_number - 1 if line_number > 1 else None,
+                after_content=b"anchor" if line_number > 1 else None,
+                before_line=line_number,
+                before_content=b"anchor",
+                has_before_line=True,
+            )
             for line_number in range(1, line_count + 1)
         },
     )
@@ -161,6 +169,7 @@ def test_coordinate_coverage_avoids_line_scale_python_heap() -> None:
             ownership,
             selection,
             ownership.deletions,
+            target_lines=target_lines,
         ))
         _current_heap, peak_heap = tracemalloc.get_traced_memory()
     finally:

--- a/tests/batch/merge/test_merge.py
+++ b/tests/batch/merge/test_merge.py
@@ -1500,6 +1500,20 @@ class TestMergeBatch:
 
         with pytest.raises(MergeError):
             merge_batch(source, ownership, working)
+
+    def test_empty_absence_is_not_trusted_during_constraint_realization(self):
+        """Direct realization must apply the same empty-anchor filtering."""
+        selected = LineRanges.from_specs(["2"])
+
+        with pytest.raises(MergeError):
+            satisfy_constraints(
+                [b"head\n", b"saved variant\n", b"tail\n"],
+                [b"head\n", b"live variant\n", b"tail\n"],
+                selected,
+                [AbsenceClaim(anchor_line=2, content_lines=[])],
+                require_distinctive_context=True,
+                distinctive_context_lines=selected,
+            )
     def test_baseline_referenced_noncontiguous_presence_is_noop_when_source_matches(self):
         """Already-satisfied additions may be interleaved with unclaimed source lines."""
         source = b"line1\nline2\nline3\nline4\n"

--- a/tests/batch/merge/test_merge.py
+++ b/tests/batch/merge/test_merge.py
@@ -1488,6 +1488,18 @@ class TestMergeBatch:
 
         with pytest.raises(MergeError):
             merge_batch(source, ownership, working)
+
+    def test_empty_absence_does_not_silence_presence_ambiguity(self):
+        """A no-op deletion must not become an unmapped trusted anchor."""
+        source = b"head\nsaved variant\ntail\n"
+        working = b"head\nlive variant\ntail\n"
+        ownership = BatchOwnership.from_presence_lines(
+            ["2"],
+            [AbsenceClaim(anchor_line=2, content_lines=[])],
+        )
+
+        with pytest.raises(MergeError):
+            merge_batch(source, ownership, working)
     def test_baseline_referenced_noncontiguous_presence_is_noop_when_source_matches(self):
         """Already-satisfied additions may be interleaved with unclaimed source lines."""
         source = b"line1\nline2\nline3\nline4\n"

--- a/tests/batch/merge/test_merge.py
+++ b/tests/batch/merge/test_merge.py
@@ -1469,6 +1469,25 @@ class TestMergeBatch:
 
         assert result == source
 
+    def test_stale_baseline_reference_does_not_silence_presence_ambiguity(self):
+        """An unresolved coordinate cannot permit a silent variant interleave."""
+        source = b"head\nsaved variant\ntail\n"
+        working = b"head\nlive variant\ntail\n"
+        ownership = BatchOwnership.from_presence_lines(
+            ["2"],
+            baseline_references={
+                2: BaselineReference(
+                    after_line=1,
+                    after_content=b"stale-head",
+                    before_line=3,
+                    before_content=b"tail",
+                    has_before_line=True,
+                )
+            },
+        )
+
+        with pytest.raises(MergeError):
+            merge_batch(source, ownership, working)
     def test_baseline_referenced_noncontiguous_presence_is_noop_when_source_matches(self):
         """Already-satisfied additions may be interleaved with unclaimed source lines."""
         source = b"line1\nline2\nline3\nline4\n"

--- a/tests/batch/merge/test_merge.py
+++ b/tests/batch/merge/test_merge.py
@@ -1501,6 +1501,18 @@ class TestMergeBatch:
         with pytest.raises(MergeError):
             merge_batch(source, ownership, working)
 
+    def test_unmapped_unrelated_absence_does_not_silence_presence_ambiguity(self):
+        """A missing deletion anchor must not bypass presence placement checks."""
+        source = b"head\nsaved variant\ntail\n"
+        working = b"head\nlive variant\ntail\n"
+        ownership = BatchOwnership.from_presence_lines(
+            ["2"],
+            [AbsenceClaim(anchor_line=2, content_lines=[b"unrelated\n"])],
+        )
+
+        with pytest.raises(MergeError):
+            merge_batch(source, ownership, working)
+
     def test_empty_absence_is_not_trusted_during_constraint_realization(self):
         """Direct realization must apply the same empty-anchor filtering."""
         selected = LineRanges.from_specs(["2"])
@@ -1514,6 +1526,7 @@ class TestMergeBatch:
                 require_distinctive_context=True,
                 distinctive_context_lines=selected,
             )
+
     def test_baseline_referenced_noncontiguous_presence_is_noop_when_source_matches(self):
         """Already-satisfied additions may be interleaved with unclaimed source lines."""
         source = b"line1\nline2\nline3\nline4\n"

--- a/tests/batch/source/test_advancement.py
+++ b/tests/batch/source/test_advancement.py
@@ -769,6 +769,41 @@ def test_advance_source_replaces_suppressed_span_without_losing_live_neighbors(
     ]
 
 
+@pytest.mark.parametrize(
+    ("working_tree", "expected_source"),
+    [
+        (
+            b"head\nold-a\nold-b\ntail\n",
+            b"head\nnew\ntail\n",
+        ),
+        (
+            b"head\nold-a\nlive extra\nold-b\ntail\n",
+            b"head\nnew\nlive extra\ntail\n",
+        ),
+    ],
+)
+def test_advance_source_replaces_all_suppressed_spans_for_one_unit(
+    working_tree,
+    expected_source,
+):
+    """A replacement unit may own several distinct deletion-side runs."""
+    ownership = BatchOwnership.from_presence_lines(
+        ["2"],
+        [
+            AbsenceClaim(anchor_line=1, content_lines=[b"old-a\n"]),
+            AbsenceClaim(anchor_line=1, content_lines=[b"old-b\n"]),
+        ],
+        replacement_units=[
+            ReplacementUnit(presence_lines=["2"], deletion_indices=[0, 1]),
+        ],
+    )
+
+    with _advance_source_from_content(
+        old_source_buffer=b"head\nnew\ntail\n",
+        working_buffer=working_tree,
+        ownership=ownership,
+    ) as source_with_provenance:
+        assert source_with_provenance.source_buffer.to_bytes() == expected_source
 def test_advance_source_refuses_ambiguous_saved_replacement_baseline_spans():
     """Repeated live baseline variants must not replace saved ownership."""
     ownership = BatchOwnership.from_presence_lines(

--- a/tests/batch/source/test_advancement.py
+++ b/tests/batch/source/test_advancement.py
@@ -826,6 +826,29 @@ def test_advance_source_refuses_ambiguous_saved_replacement_baseline_spans():
             pass
 
 
+def test_advance_source_refuses_two_deletions_claiming_same_live_span():
+    """Distinct deletion claims cannot both consume one baseline occurrence."""
+    ownership = BatchOwnership.from_presence_lines(
+        ["2"],
+        [
+            AbsenceClaim(anchor_line=1, content_lines=[b"old\n"]),
+            AbsenceClaim(anchor_line=1, content_lines=[b"old\n"]),
+        ],
+        replacement_units=[
+            ReplacementUnit(presence_lines=["2"], deletion_indices=[0, 1]),
+        ],
+    )
+
+    with pytest.raises(
+        BatchSourceAdvanceError,
+        match="overlapping live baseline spans",
+    ):
+        with _advance_source_from_content(
+            old_source_buffer=b"head\nnew\ntail\n",
+            working_buffer=b"head\nold\ntail\n",
+            ownership=ownership,
+        ):
+            pass
 def test_advance_source_refuses_owned_replacement_contraction() -> None:
     """A contracted owned range cannot retain unique source-line lineage."""
     ownership = BatchOwnership.from_presence_lines(["2-3"])

--- a/tests/batch/source/test_advancement.py
+++ b/tests/batch/source/test_advancement.py
@@ -25,6 +25,11 @@ from git_stage_batch.batch.source.advancement import (
     advance_batch_source_for_file_with_provenance,
     advance_source_lines_preserving_existing_presence,
 )
+from git_stage_batch.batch.line_matching.comparison import (
+    SemanticChangeKind,
+    SemanticChangeRun,
+)
+from git_stage_batch.batch.line_matching.match_workspace import MatcherWorkspace
 from git_stage_batch.batch.line_matching.lineage import (
     BatchSourceLineage,
     LineageRun,
@@ -804,6 +809,8 @@ def test_advance_source_replaces_all_suppressed_spans_for_one_unit(
         ownership=ownership,
     ) as source_with_provenance:
         assert source_with_provenance.source_buffer.to_bytes() == expected_source
+
+
 def test_advance_source_refuses_ambiguous_saved_replacement_baseline_spans():
     """Repeated live baseline variants must not replace saved ownership."""
     ownership = BatchOwnership.from_presence_lines(
@@ -849,6 +856,53 @@ def test_advance_source_refuses_two_deletions_claiming_same_live_span():
             ownership=ownership,
         ):
             pass
+
+
+def test_ambiguous_replacement_span_scan_avoids_line_scale_python_heap():
+    """Repeated baseline matches should be refused with bounded scan state."""
+    ownership = BatchOwnership.from_presence_lines(
+        ["1"],
+        [AbsenceClaim(anchor_line=None, content_lines=[b"old\n"])],
+        replacement_units=[
+            ReplacementUnit(presence_lines=["1"], deletion_indices=[0]),
+        ],
+    )
+    heap_peaks = []
+    for line_count in _LINE_SCALE_TEST_COUNTS:
+        working_lines = [b"old\n"] * line_count
+        run = SemanticChangeRun(
+            SemanticChangeKind.REPLACEMENT,
+            source_start=1,
+            source_end=1,
+            target_start=1,
+            target_end=line_count,
+        )
+
+        gc.collect()
+        tracemalloc.start()
+        try:
+            with (
+                MatcherWorkspace() as workspace,
+                pytest.raises(
+                    BatchSourceAdvanceError,
+                    match="multiple matching live baseline",
+                ),
+            ):
+                advancement_module._saved_replacement_target_spans(
+                    run,
+                    working_lines,
+                    ownership,
+                    workspace,
+                )
+            _current_heap, peak_heap = tracemalloc.get_traced_memory()
+        finally:
+            tracemalloc.stop()
+        heap_peaks.append(peak_heap)
+
+    small_peak, large_peak = heap_peaks
+    assert large_peak < small_peak + _LINE_SCALE_HEAP_GROWTH_LIMIT
+
+
 def test_advance_source_refuses_owned_replacement_contraction() -> None:
     """A contracted owned range cannot retain unique source-line lineage."""
     ownership = BatchOwnership.from_presence_lines(["2-3"])


### PR DESCRIPTION
Saved batch ownership uses baseline references, absence claims, and replacement
spans to place content against a changing live target.

Stale references and empty or deferred deletion anchors can suppress the
distinctive-context checks that should refuse competing placements. Source
advancement can also collapse several suppressed replacement spans into one
match or retain Python state proportional to ambiguous input size.

Validate references against live content in merge and preview paths, treat
empty deletions as no-op anchors, check presence placement before deferred
absence errors, and preserve every distinct nonoverlapping replacement span.
The regressions cover refusal behavior, span overlap, and bounded heap growth.

Validation includes the complete parallel test suite, Ruff, dead-code analysis,
type-hygiene analysis, strict mypy checks, and diff validation.
